### PR TITLE
feat: NLI misfit detection and confidence tuning

### DIFF
--- a/scripts/embed_taxonomy.py
+++ b/scripts/embed_taxonomy.py
@@ -38,7 +38,7 @@ NLI_MODEL_NAME = "cross-encoder/nli-deberta-v3-small"
 NLI_LABELS = ["entailment", "neutral", "contradiction"]
 # Minimum logit margin between the winning label and runner-up.
 # If the margin is below this, the classification is downgraded to "neutral".
-NLI_CONFIDENCE_MARGIN = 1.5
+NLI_CONFIDENCE_MARGIN = 1.0
 
 # Resolved at runtime via --taxonomy-dir or .aitriad.json
 TAXONOMY_DIR: Path = _DEFAULT_TAXONOMY_DIR

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -26,7 +26,9 @@ anthropic>=0.30
 # Git inspection
 gitpython>=3.1
 
-# Semantic embeddings for taxonomy search
+# Semantic embeddings (all-MiniLM-L6-v2) and NLI cross-encoder
+# (cross-encoder/nli-deberta-v3-small) for taxonomy search and
+# contradiction detection. Models download on first use (~180MB each).
 sentence-transformers>=2.7
 
 # Document conversion (PDF, DOCX, PPTX, XLSX, HTML, images → Markdown)

--- a/taxonomy-editor/src/main/fileIO.ts
+++ b/taxonomy-editor/src/main/fileIO.ts
@@ -295,3 +295,98 @@ export function buildNodeSourceIndex(): NodeSourceIndex {
 
   return index;
 }
+
+// ── Policy ↔ Source reverse index ─────────────────────────────────────────────
+
+export interface PolicySourceReference {
+  docId: string;
+  title: string;
+  dateIngested: string;
+  sourceTime: string;
+  stance: string;
+  nodeId: string;
+  pov: string;
+}
+
+export type PolicySourceIndex = Record<string, PolicySourceReference[]>;
+
+/**
+ * For each policy in policy_actions.json, find all nodes that reference it
+ * (by scanning policy_actions in POV files), then use the node-source index
+ * to find which sources reference those nodes.
+ * Returns policyId → list of source references.
+ */
+export function buildPolicySourceIndex(): PolicySourceIndex {
+  const result: PolicySourceIndex = {};
+
+  // 1. Load policy registry to get all policy IDs
+  const regRaw = readPolicyRegistry() as { policies?: { id: string }[] } | null;
+  if (!regRaw?.policies) return result;
+  for (const pol of regRaw.policies) {
+    result[pol.id] = [];
+  }
+
+  // 2. Build node → policy mapping by scanning all POV files
+  const nodeToPolicies = new Map<string, string[]>();
+  for (const pov of Object.keys(POV_FILE_MAP)) {
+    if (pov === 'cross-cutting') continue;
+    try {
+      const file = readTaxonomyFile(pov) as { nodes?: Array<{ id: string; graph_attributes?: { policy_actions?: { policy_id?: string }[] } }> };
+      if (!file?.nodes) continue;
+      for (const node of file.nodes) {
+        const actions = node.graph_attributes?.policy_actions;
+        if (!actions) continue;
+        for (const action of actions) {
+          if (!action.policy_id) continue;
+          if (!nodeToPolicies.has(node.id)) nodeToPolicies.set(node.id, []);
+          nodeToPolicies.get(node.id)!.push(action.policy_id);
+        }
+      }
+    } catch { /* skip unavailable POV files */ }
+  }
+
+  // 3. Build or reuse the node-source index
+  const nodeSourceIdx = buildNodeSourceIndex();
+
+  // 4. Pre-load source metadata for dateIngested / sourceTime
+  const metaCache: Record<string, { dateIngested: string; sourceTime: string }> = {};
+  if (fs.existsSync(SOURCES_DIR)) {
+    for (const entry of fs.readdirSync(SOURCES_DIR, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const metaPath = path.join(SOURCES_DIR, entry.name, 'metadata.json');
+      try {
+        if (fs.existsSync(metaPath)) {
+          const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+          metaCache[entry.name] = {
+            dateIngested: meta.date_ingested || meta.date_published || '',
+            sourceTime: meta.source_time || '',
+          };
+        }
+      } catch { /* skip */ }
+    }
+  }
+
+  // 5. For each node that has sources, map those sources to the node's policies
+  for (const [nodeId, policyIds] of nodeToPolicies) {
+    const sourceRefs = nodeSourceIdx[nodeId];
+    if (!sourceRefs) continue;
+
+    for (const polId of policyIds) {
+      if (!result[polId]) result[polId] = [];
+      for (const ref of sourceRefs) {
+        const meta = metaCache[ref.docId] || { dateIngested: ref.datePublished, sourceTime: '' };
+        result[polId].push({
+          docId: ref.docId,
+          title: ref.title,
+          dateIngested: meta.dateIngested,
+          sourceTime: meta.sourceTime,
+          stance: ref.stance,
+          nodeId,
+          pov: ref.pov,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/taxonomy-editor/src/main/ipcHandlers.ts
+++ b/taxonomy-editor/src/main/ipcHandlers.ts
@@ -17,6 +17,7 @@ import {
   getActiveTaxonomyDirName,
   setActiveTaxonomyDir,
   buildNodeSourceIndex,
+  buildPolicySourceIndex,
   readPolicyRegistry,
 } from './fileIO';
 import {
@@ -164,6 +165,10 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle('build-node-source-index', () => {
     return buildNodeSourceIndex();
+  });
+
+  ipcMain.handle('build-policy-source-index', () => {
+    return buildPolicySourceIndex();
   });
 
   ipcMain.handle('load-edges', () => {

--- a/taxonomy-editor/src/main/preload.ts
+++ b/taxonomy-editor/src/main/preload.ts
@@ -110,6 +110,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
   buildNodeSourceIndex: (): Promise<unknown> =>
     ipcRenderer.invoke('build-node-source-index'),
 
+  // Policy ↔ Source index
+  buildPolicySourceIndex: (): Promise<unknown> =>
+    ipcRenderer.invoke('build-policy-source-index'),
+
   // Edges
   loadEdges: (): Promise<unknown> =>
     ipcRenderer.invoke('load-edges'),

--- a/taxonomy-editor/src/renderer/components/ConflictDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/ConflictDetail.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import type { ConflictFile } from '../types/taxonomy';
 import { useTaxonomyStore } from '../hooks/useTaxonomyStore';
 import { DeleteConfirmDialog } from './DeleteConfirmDialog';
@@ -83,6 +83,35 @@ export function ConflictDetail({ conflict, readOnly, onPin, chipDepth = 0 }: Con
 
   const raw = conflict.linked_taxonomy_nodes;
   const linkedNodes = Array.isArray(raw) ? raw : raw ? [raw] : [];
+
+  // Derive related policies from linked taxonomy nodes
+  const { policyRegistry } = useTaxonomyStore();
+  const relatedPolicies = useMemo(() => {
+    if (linkedNodes.length === 0) return [];
+    const state = useTaxonomyStore.getState();
+    const policyIdSet = new Set<string>();
+
+    for (const povKey of ['accelerationist', 'safetyist', 'skeptic', 'crossCutting'] as const) {
+      const file = povKey === 'crossCutting' ? state.crossCutting : state[povKey];
+      if (!file?.nodes) continue;
+      for (const node of file.nodes) {
+        if (!linkedNodes.includes(node.id)) continue;
+        const ga = (node as { graph_attributes?: { policy_actions?: { policy_id?: string }[] } }).graph_attributes;
+        if (ga?.policy_actions) {
+          for (const action of ga.policy_actions) {
+            if (action.policy_id) policyIdSet.add(action.policy_id);
+          }
+        }
+      }
+    }
+
+    const policies: { id: string; action: string }[] = [];
+    for (const id of policyIdSet) {
+      const pol = policyRegistry?.find(p => p.id === id);
+      policies.push({ id, action: pol?.action ?? id });
+    }
+    return policies.sort((a, b) => a.id.localeCompare(b.id));
+  }, [linkedNodes, policyRegistry]);
 
   const addLinked = (id: string) => {
     if (id && !linkedNodes.includes(id)) {
@@ -192,6 +221,21 @@ export function ConflictDetail({ conflict, readOnly, onPin, chipDepth = 0 }: Con
             />
           )}
         </div>
+
+        {/* Related Policies (derived from linked nodes) */}
+        {relatedPolicies.length > 0 && (
+          <div className="form-group">
+            <label>Related Policies</label>
+            <div className="conflict-related-policies">
+              {relatedPolicies.map((pol) => (
+                <span key={pol.id} className="conflict-policy-badge" title={pol.action}>
+                  <span className="conflict-policy-badge-id">{pol.id}</span>
+                  <span className="conflict-policy-badge-action">{pol.action}</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Instances */}
         <div className="form-group">

--- a/taxonomy-editor/src/renderer/components/NodeTree.tsx
+++ b/taxonomy-editor/src/renderer/components/NodeTree.tsx
@@ -9,8 +9,6 @@ export type SortMode = 'id' | 'label' | 'similarity';
 export interface ClusterGroup {
   label: string;
   nodeIds: string[];
-  nliLabel?: 'entailment' | 'neutral' | 'contradiction' | null;
-  sides?: [string[], string[]] | null;
 }
 
 interface NodeTreeProps {
@@ -21,6 +19,7 @@ interface NodeTreeProps {
   similarScores?: Map<string, number> | null;
   clusters?: ClusterGroup[] | null;
   clusterLoading?: boolean;
+  misfits?: Set<string> | null;
 }
 
 const CATEGORY_ORDER: Category[] = ['Goals/Values', 'Methods/Arguments', 'Data/Facts'];
@@ -81,7 +80,7 @@ function saveCollapsed(collapsed: Set<string>) {
   localStorage.setItem(COLLAPSE_STORAGE_KEY, JSON.stringify([...collapsed]));
 }
 
-export function NodeTree({ nodes, selectedNodeId, onSelect, sortMode = 'id', similarScores, clusters, clusterLoading }: NodeTreeProps) {
+export function NodeTree({ nodes, selectedNodeId, onSelect, sortMode = 'id', similarScores, clusters, clusterLoading, misfits }: NodeTreeProps) {
   const [collapsed, setCollapsed] = useState<Set<string>>(() => loadCollapsed());
 
   const toggleGroup = useCallback((key: string) => {
@@ -116,44 +115,16 @@ export function NodeTree({ nodes, selectedNodeId, onSelect, sortMode = 'id', sim
               >
                 <span className={`category-toggle ${isCollapsed ? 'collapsed' : ''}`}>&#9660;</span>
                 {cluster.label} <span className="category-count">({clusterNodes.length})</span>
-                {cluster.nliLabel && (
-                  <span className={`nli-badge nli-${cluster.nliLabel}`}>
-                    {cluster.nliLabel === 'entailment' ? 'shared' : cluster.nliLabel === 'contradiction' ? 'contested' : 'unclear'}
-                  </span>
-                )}
               </div>
-              {!isCollapsed && (
-                cluster.nliLabel === 'contradiction' && cluster.sides ? (
-                  <>
-                    {cluster.sides[0].map(id => nodeMap.get(id)).filter(Boolean).map(node => (
-                      <NodeItem
-                        key={node!.id}
-                        node={node!}
-                        isSelected={selectedNodeId === node!.id}
-                        onSelect={onSelect}
-                      />
-                    ))}
-                    <div className="cluster-vs-separator">vs.</div>
-                    {cluster.sides[1].map(id => nodeMap.get(id)).filter(Boolean).map(node => (
-                      <NodeItem
-                        key={node!.id}
-                        node={node!}
-                        isSelected={selectedNodeId === node!.id}
-                        onSelect={onSelect}
-                      />
-                    ))}
-                  </>
-                ) : (
-                  clusterNodes.map((node) => (
-                    <NodeItem
-                      key={node.id}
-                      node={node}
-                      isSelected={selectedNodeId === node.id}
-                      onSelect={onSelect}
-                    />
-                  ))
-                )
-              )}
+              {!isCollapsed && clusterNodes.map((node) => (
+                <NodeItem
+                  key={node.id}
+                  node={node}
+                  isSelected={selectedNodeId === node.id}
+                  onSelect={onSelect}
+                  isMisfit={misfits?.has(node.id)}
+                />
+              ))}
             </div>
           );
         })}
@@ -278,13 +249,14 @@ const REL_LABELS: Record<string, string> = {
   specializes: 'specializes',
 };
 
-function NodeItem({ node, isSelected, onSelect, score, indent, relationship }: {
+function NodeItem({ node, isSelected, onSelect, score, indent, relationship, isMisfit }: {
   node: PovNode;
   isSelected: boolean;
   onSelect: (id: string) => void;
   score?: number;
   indent?: boolean;
   relationship?: string | null;
+  isMisfit?: boolean;
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -297,11 +269,14 @@ function NodeItem({ node, isSelected, onSelect, score, indent, relationship }: {
   return (
     <div
       ref={ref}
-      className={`node-item ${isSelected ? 'selected' : ''}${indent ? ' node-item-child' : ''}`}
+      className={`node-item ${isSelected ? 'selected' : ''}${indent ? ' node-item-child' : ''}${isMisfit ? ' node-item-misfit' : ''}`}
       data-cat={node.category}
       onClick={() => onSelect(node.id)}
     >
-      <div>{node.label || '(untitled)'}</div>
+      <div>
+        {node.label || '(untitled)'}
+        {isMisfit && <span className="misfit-badge" title="This node contradicts most of its cluster — it may belong in a different POV">misfit?</span>}
+      </div>
       <div className="node-item-id">
         {node.id}
         {relationship && <span className="node-item-rel">{REL_LABELS[relationship] || relationship}</span>}

--- a/taxonomy-editor/src/renderer/components/PolicyDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/PolicyDashboard.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useTaxonomyStore } from '../hooks/useTaxonomyStore';
+import { PolicySourcesPanel, getPolicySourceIndex } from './PolicySourcesPanel';
+import type { PolicySourceReference } from './PolicySourcesPanel';
 
 const POV_COLORS: Record<string, string> = {
   accelerationist: 'var(--color-acc)',
@@ -11,8 +13,16 @@ const POV_COLORS: Record<string, string> = {
   'cross-cutting': 'var(--color-cc)',
 };
 
+type PolicySourceIndex = Record<string, PolicySourceReference[]>;
+
 export function PolicyDashboard() {
   const { policyRegistry, edgesFile, setToolbarPanel } = useTaxonomyStore();
+  const [selectedPolicyId, setSelectedPolicyId] = useState<string | null>(null);
+  const [policySourceIndex, setPolicySourceIndex] = useState<PolicySourceIndex | null>(null);
+
+  useEffect(() => {
+    getPolicySourceIndex().then(setPolicySourceIndex);
+  }, []);
 
   const stats = useMemo(() => {
     const policies = policyRegistry ?? [];
@@ -89,6 +99,24 @@ export function PolicyDashboard() {
     return { totalCount, crossPovCount, top10, tagEntries, maxTag, contradictHotspots };
   }, [policyRegistry, edgesFile]);
 
+  // Timeline: sort policies by earliest dateIngested from their sources
+  const timeline = useMemo(() => {
+    if (!policyRegistry || !policySourceIndex) return [];
+    return policyRegistry
+      .map((pol) => {
+        const refs = policySourceIndex[pol.id] || [];
+        const dates = refs
+          .map((r) => r.dateIngested)
+          .filter((d) => d && d.length > 0)
+          .sort();
+        const firstDate = dates.length > 0 ? dates[0] : '';
+        const firstTitle = refs.length > 0 ? refs[0].title : '';
+        return { id: pol.id, action: pol.action, firstDate, firstTitle };
+      })
+      .filter((item) => item.firstDate.length > 0)
+      .sort((a, b) => a.firstDate.localeCompare(b.firstDate));
+  }, [policyRegistry, policySourceIndex]);
+
   if (!policyRegistry || policyRegistry.length === 0) {
     return (
       <div className="policy-dashboard">
@@ -122,12 +150,23 @@ export function PolicyDashboard() {
           </div>
         </div>
 
+        {/* Selected policy detail */}
+        {selectedPolicyId && (
+          <div className="policy-dashboard-section">
+            <div className="policy-dashboard-detail-header">
+              <h3 className="policy-dashboard-section-title">Sources for {selectedPolicyId}</h3>
+              <button className="btn btn-ghost btn-sm" onClick={() => setSelectedPolicyId(null)}>Back</button>
+            </div>
+            <PolicySourcesPanel policyId={selectedPolicyId} />
+          </div>
+        )}
+
         {/* Top 10 most-referenced */}
         <div className="policy-dashboard-section">
           <h3 className="policy-dashboard-section-title">Top 10 Most-Referenced Policies</h3>
           <div className="policy-dashboard-list">
             {stats.top10.map((p, i) => (
-              <div key={p.id} className="policy-dashboard-row">
+              <div key={p.id} className="policy-dashboard-row policy-dashboard-row-clickable" onClick={() => setSelectedPolicyId(p.id)}>
                 <span className="policy-dashboard-rank">{i + 1}.</span>
                 <span className="policy-dashboard-id">{p.id}</span>
                 <span className="policy-dashboard-action" title={p.action}>{p.action}</span>
@@ -173,6 +212,29 @@ export function PolicyDashboard() {
                   <span className="policy-dashboard-id">{h.id}</span>
                   <span className="policy-dashboard-action" title={h.action}>{h.action}</span>
                   <span className="policy-dashboard-count policy-dashboard-count-hot">{h.count}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Timeline */}
+        <div className="policy-dashboard-section">
+          <h3 className="policy-dashboard-section-title">Timeline</h3>
+          {timeline.length === 0 ? (
+            <div className="policy-dashboard-empty-section">No source dates available</div>
+          ) : (
+            <div className="policy-dashboard-timeline">
+              {timeline.map((item) => (
+                <div
+                  key={item.id}
+                  className="policy-timeline-row"
+                  onClick={() => setSelectedPolicyId(item.id)}
+                >
+                  <span className="policy-timeline-date">{item.firstDate}</span>
+                  <span className="policy-timeline-id">{item.id}</span>
+                  <span className="policy-timeline-action" title={item.action}>{item.action}</span>
+                  <span className="policy-timeline-source" title={item.firstTitle}>{item.firstTitle}</span>
                 </div>
               ))}
             </div>

--- a/taxonomy-editor/src/renderer/components/PolicySourcesPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/PolicySourcesPanel.tsx
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useState, useEffect, useMemo } from 'react';
+
+export interface PolicySourceReference {
+  docId: string;
+  title: string;
+  dateIngested: string;
+  sourceTime: string;
+  stance: string;
+  nodeId: string;
+  pov: string;
+}
+
+type PolicySourceIndex = Record<string, PolicySourceReference[]>;
+
+// Module-level cache -- built once, reused across renders
+let _policyIndexCache: PolicySourceIndex | null = null;
+let _policyIndexLoading = false;
+let _policyIndexListeners: Array<() => void> = [];
+
+async function getPolicySourceIndex(): Promise<PolicySourceIndex> {
+  if (_policyIndexCache) return _policyIndexCache;
+  if (_policyIndexLoading) {
+    return new Promise((resolve) => {
+      _policyIndexListeners.push(() => resolve(_policyIndexCache!));
+    });
+  }
+  _policyIndexLoading = true;
+  try {
+    _policyIndexCache = (await window.electronAPI.buildPolicySourceIndex()) as PolicySourceIndex;
+  } catch (err) {
+    console.error('[PolicySourcesPanel] Failed to build index:', err);
+    _policyIndexCache = {};
+  }
+  _policyIndexLoading = false;
+  for (const cb of _policyIndexListeners) cb();
+  _policyIndexListeners = [];
+  return _policyIndexCache;
+}
+
+/** Expose the cached index for other components (e.g. PolicyDashboard timeline) */
+export { getPolicySourceIndex };
+
+const STANCE_LABELS: Record<string, string> = {
+  strongly_aligned: 'Strongly Aligned',
+  aligned: 'Aligned',
+  neutral: 'Neutral',
+  qualifies: 'Qualifies',
+  disputes: 'Disputes',
+};
+
+const POV_LABELS: Record<string, string> = {
+  accelerationist: 'Acc',
+  safetyist: 'Saf',
+  skeptic: 'Skp',
+};
+
+interface PolicySourcesPanelProps {
+  policyId: string;
+}
+
+export function PolicySourcesPanel({ policyId }: PolicySourcesPanelProps) {
+  const [refs, setRefs] = useState<PolicySourceReference[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setExpanded(null);
+    getPolicySourceIndex().then((index) => {
+      setRefs(index[policyId] || []);
+      setLoading(false);
+    });
+  }, [policyId]);
+
+  // Group by docId
+  const grouped = useMemo(() => {
+    if (!refs) return [];
+    const byDoc: Record<string, PolicySourceReference[]> = {};
+    for (const r of refs) {
+      if (!byDoc[r.docId]) byDoc[r.docId] = [];
+      byDoc[r.docId].push(r);
+    }
+    return Object.entries(byDoc).sort((a, b) => b[1].length - a[1].length);
+  }, [refs]);
+
+  if (loading) {
+    return <div className="policy-sources-loading">Loading source references...</div>;
+  }
+
+  if (!refs || refs.length === 0) {
+    return <div className="policy-sources-empty">No sources reference this policy.</div>;
+  }
+
+  return (
+    <div className="policy-sources-panel">
+      <div className="policy-sources-summary">
+        {refs.length} reference{refs.length !== 1 ? 's' : ''} across {grouped.length} document{grouped.length !== 1 ? 's' : ''}
+      </div>
+
+      {grouped.map(([docId, docRefs]) => {
+        const first = docRefs[0];
+        const isExpanded = expanded === docId;
+
+        return (
+          <div key={docId} className="policy-sources-doc">
+            <button
+              className={`policy-sources-doc-header${isExpanded ? ' policy-sources-doc-expanded' : ''}`}
+              onClick={() => setExpanded(isExpanded ? null : docId)}
+            >
+              <span className="policy-sources-doc-title">{first.title}</span>
+              <span className="policy-sources-doc-meta">
+                <span className="policy-sources-doc-count">{docRefs.length}</span>
+                {first.dateIngested && (
+                  <span className="policy-sources-doc-date">{first.dateIngested}</span>
+                )}
+              </span>
+            </button>
+
+            {isExpanded && (
+              <div className="policy-sources-doc-body">
+                {docRefs.map((r, i) => (
+                  <div key={i} className="policy-sources-ref">
+                    <span className={`policy-sources-stance policy-sources-stance-${r.stance}`}>
+                      {STANCE_LABELS[r.stance] ?? r.stance}
+                    </span>
+                    <span className="policy-sources-pov">{POV_LABELS[r.pov] ?? r.pov}</span>
+                    <span className="policy-sources-node-id">{r.nodeId}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/PovTab.tsx
+++ b/taxonomy-editor/src/renderer/components/PovTab.tsx
@@ -79,6 +79,7 @@ export function PovTab({ pov }: PovTabProps) {
   }, [similarResults]);
 
   const clusterGroups = clusterView?.clusters ?? null;
+  const clusterMisfits = clusterView?.misfits ?? null;
 
   const orderedIds = useMemo(
     () => (file ? getOrderedNodeIds(file.nodes, sortMode, similarScoresMap, clusterGroups) : []),
@@ -353,6 +354,7 @@ export function PovTab({ pov }: PovTabProps) {
               similarScores={similarScoresMap}
               clusters={clusterGroups}
               clusterLoading={clusterLoading}
+              misfits={clusterMisfits}
             />
           </div>
         </div>

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.ts
@@ -531,66 +531,12 @@ export const useTaxonomyStore = create<TaxonomyState>((set, get) => ({
         }
       }
 
-      // NLI classification — all-pairs within each cluster, then bipartite partition for contested
-      try {
-        const { partitionBipartite } = await import('../utils/clustering');
-        const descMap = new Map(file.nodes.map(n => [n.id, n.description || n.label]));
-
-        // Build all pairs for clusters with 2+ nodes
-        const nliPairs: Array<{ text_a: string; text_b: string; clusterIdx: number; idA: string; idB: string }> = [];
-        for (let ci = 0; ci < multiClusters.length; ci++) {
-          const ids = multiClusters[ci].nodeIds;
-          if (ids.length < 2) continue;
-          for (let i = 0; i < ids.length; i++) {
-            for (let j = i + 1; j < ids.length; j++) {
-              nliPairs.push({
-                text_a: descMap.get(ids[i]) || ids[i],
-                text_b: descMap.get(ids[j]) || ids[j],
-                clusterIdx: ci,
-                idA: ids[i],
-                idB: ids[j],
-              });
-            }
-          }
-        }
-
-        if (nliPairs.length > 0) {
-          const { results } = await window.electronAPI.nliClassify(nliPairs);
-
-          // Tally labels and collect pair labels per cluster
-          const clusterCounts = new Map<number, Record<string, number>>();
-          const clusterPairLabels = new Map<number, Array<{ idA: string; idB: string; label: string }>>();
-
-          for (let k = 0; k < results.length; k++) {
-            const ci = nliPairs[k].clusterIdx;
-            if (!clusterCounts.has(ci)) clusterCounts.set(ci, { entailment: 0, neutral: 0, contradiction: 0 });
-            const counts = clusterCounts.get(ci)!;
-            counts[results[k].nli_label] = (counts[results[k].nli_label] || 0) + 1;
-
-            if (!clusterPairLabels.has(ci)) clusterPairLabels.set(ci, []);
-            clusterPairLabels.get(ci)!.push({
-              idA: nliPairs[k].idA,
-              idB: nliPairs[k].idB,
-              label: results[k].nli_label,
-            });
-          }
-
-          for (const [ci, counts] of clusterCounts) {
-            const dominant = Object.entries(counts).sort((a, b) => b[1] - a[1])[0];
-            const cluster = multiClusters[ci] as { nliLabel?: string; sides?: [string[], string[]] | null };
-            cluster.nliLabel = dominant[0];
-
-            // For contested clusters, try bipartite partition
-            if (dominant[0] === 'contradiction') {
-              const pairData = clusterPairLabels.get(ci) || [];
-              const sides = partitionBipartite(multiClusters[ci].nodeIds, pairData);
-              cluster.sides = sides;
-            }
-          }
-        }
-      } catch (nliErr) {
-        console.warn('[clusterView] NLI classification failed, continuing without labels:', nliErr);
-      }
+      // NLI classification is skipped for single-POV clustering (the editor
+      // always clusters within one POV tab). Within-POV nodes are inherently
+      // aligned in direction — NLI produces misleading contested/contradiction
+      // labels when comparing nodes that agree but address different topics.
+      // NLI is used in Find-CrossCuttingCandidates (PowerShell) where clusters
+      // span multiple POVs and opposition is meaningful.
 
       // Sort clusters by size descending
       multiClusters.sort((a, b) => b.nodeIds.length - a.nodeIds.length);

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.ts
@@ -305,7 +305,7 @@ interface TaxonomyState {
   analysisCritiqueOriginalNode: PovNode | null;
   runNodeCritique: (pov: Pov, node: PovNode) => Promise<void>;
 
-  clusterView: { clusters: { label: string; nodeIds: string[]; nliLabel?: 'entailment' | 'neutral' | 'contradiction' | null; sides?: [string[], string[]] | null }[] } | null;
+  clusterView: { clusters: { label: string; nodeIds: string[] }[]; misfits?: Set<string> } | null;
   clusterLoading: boolean;
   clusterError: string | null;
   runClusterView: (pov: Pov) => Promise<void>;
@@ -531,12 +531,67 @@ export const useTaxonomyStore = create<TaxonomyState>((set, get) => ({
         }
       }
 
-      // NLI classification is skipped for single-POV clustering (the editor
-      // always clusters within one POV tab). Within-POV nodes are inherently
-      // aligned in direction — NLI produces misleading contested/contradiction
-      // labels when comparing nodes that agree but address different topics.
-      // NLI is used in Find-CrossCuttingCandidates (PowerShell) where clusters
-      // span multiple POVs and opposition is meaningful.
+      // NLI misfit detection — flag nodes that contradict most of their
+      // cluster-mates, which may indicate wrong-POV placement.
+      const misfits = new Set<string>();
+      try {
+        const descMap = new Map(file.nodes.map(n => [n.id, n.description || n.label]));
+
+        // Build all pairs for clusters with 3+ nodes (2-node clusters can't have a misfit)
+        const nliPairs: Array<{ text_a: string; text_b: string; clusterIdx: number; idA: string; idB: string }> = [];
+        for (let ci = 0; ci < multiClusters.length; ci++) {
+          const ids = multiClusters[ci].nodeIds;
+          if (ids.length < 3) continue;
+          for (let i = 0; i < ids.length; i++) {
+            for (let j = i + 1; j < ids.length; j++) {
+              nliPairs.push({
+                text_a: descMap.get(ids[i]) || ids[i],
+                text_b: descMap.get(ids[j]) || ids[j],
+                clusterIdx: ci,
+                idA: ids[i],
+                idB: ids[j],
+              });
+            }
+          }
+        }
+
+        if (nliPairs.length > 0) {
+          const { results } = await window.electronAPI.nliClassify(nliPairs);
+
+          // Per-node contradiction counts within each cluster
+          // nodeId → { agrees: number, contradicts: number }
+          const nodeCounts = new Map<string, { agrees: number; contradicts: number }>();
+
+          for (let k = 0; k < results.length; k++) {
+            const { idA, idB } = nliPairs[k];
+            const label = results[k].nli_label;
+            for (const id of [idA, idB]) {
+              if (!nodeCounts.has(id)) nodeCounts.set(id, { agrees: 0, contradicts: 0 });
+            }
+            if (label === 'contradiction') {
+              nodeCounts.get(idA)!.contradicts++;
+              nodeCounts.get(idB)!.contradicts++;
+            } else {
+              nodeCounts.get(idA)!.agrees++;
+              nodeCounts.get(idB)!.agrees++;
+            }
+          }
+
+          // Flag nodes where contradictions outnumber agreements
+          for (const [nodeId, counts] of nodeCounts) {
+            if (counts.contradicts > counts.agrees) {
+              misfits.add(nodeId);
+            }
+          }
+
+          if (misfits.size > 0) {
+            console.log(`[clusterView] NLI flagged ${misfits.size} potential misfit nodes:`,
+              [...misfits].join(', '));
+          }
+        }
+      } catch (nliErr) {
+        console.warn('[clusterView] NLI misfit detection failed, continuing without:', nliErr);
+      }
 
       // Sort clusters by size descending
       multiClusters.sort((a, b) => b.nodeIds.length - a.nodeIds.length);
@@ -546,7 +601,7 @@ export const useTaxonomyStore = create<TaxonomyState>((set, get) => ({
         multiClusters.push({ label: 'Other', nodeIds: singletonIds });
       }
 
-      set({ clusterView: { clusters: multiClusters }, clusterLoading: false });
+      set({ clusterView: { clusters: multiClusters, misfits: misfits.size > 0 ? misfits : undefined }, clusterLoading: false });
     } catch (err) {
       set({ clusterLoading: false, clusterError: String(err) });
     }

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.ts
@@ -577,10 +577,23 @@ export const useTaxonomyStore = create<TaxonomyState>((set, get) => ({
             }
           }
 
-          // Flag nodes where contradictions outnumber agreements
+          // Flag nodes where contradictions outnumber agreements — but only
+          // if they're true outliers. If most nodes in the cluster have high
+          // contradiction ratios, the NLI signal is noise (same-POV nodes
+          // discussing different topics), not a real misfit.
+          const candidateMisfits: string[] = [];
           for (const [nodeId, counts] of nodeCounts) {
             if (counts.contradicts > counts.agrees) {
-              misfits.add(nodeId);
+              candidateMisfits.push(nodeId);
+            }
+          }
+          // Only flag if fewer than half the cluster's nodes are candidates
+          // — if most/all nodes are "misfits", none of them really are
+          for (let ci = 0; ci < multiClusters.length; ci++) {
+            const clusterIds = new Set(multiClusters[ci].nodeIds);
+            const clusterCandidates = candidateMisfits.filter(id => clusterIds.has(id));
+            if (clusterCandidates.length > 0 && clusterCandidates.length < clusterIds.size / 2) {
+              for (const id of clusterCandidates) misfits.add(id);
             }
           }
 

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -638,19 +638,19 @@ body {
   margin-left: 6px;
   vertical-align: middle;
 }
-.cluster-vs-separator {
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 0.75rem;
-  font-style: italic;
-  padding: 2px 0;
-  border-top: 1px dashed var(--border-color);
-  border-bottom: 1px dashed var(--border-color);
-  margin: 2px 16px;
+.node-item-misfit {
+  border-left: 3px solid #e6a855;
 }
-.nli-entailment { background: #2d5a2d; color: #a8e6a8; }  /* "shared" */
-.nli-neutral { background: #5a5a2d; color: #e6e6a8; }  /* "unclear" */
-.nli-contradiction { background: #5a2d2d; color: #e6a8a8; }  /* "contested" */
+.misfit-badge {
+  font-size: 0.6rem;
+  background: #5a4a2d;
+  color: #e6cf8a;
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-left: 6px;
+  vertical-align: middle;
+  cursor: help;
+}
 
 /* ─── Node list items ──────────────────────────────────── */
 

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -7560,3 +7560,241 @@ body {
   gap: 2px;
   margin-top: 4px;
 }
+
+/* ─── Policy Sources Panel ──────────────────────────── */
+.policy-sources-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.policy-sources-loading,
+.policy-sources-empty {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  padding: 8px 0;
+  font-style: italic;
+}
+
+.policy-sources-summary {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  padding: 4px 0 8px;
+}
+
+.policy-sources-doc {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.policy-sources-doc-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 6px 8px;
+  background: var(--bg-secondary);
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  transition: background 0.15s;
+}
+
+.policy-sources-doc-header:hover {
+  background: var(--bg-hover);
+}
+
+.policy-sources-doc-expanded {
+  border-bottom: 1px solid var(--border-color);
+}
+
+.policy-sources-doc-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+
+.policy-sources-doc-meta {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: 8px;
+}
+
+.policy-sources-doc-count {
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: var(--bg-panel);
+  border-radius: 8px;
+  padding: 1px 6px;
+  color: var(--text-secondary);
+}
+
+.policy-sources-doc-date {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-family: 'Cascadia Code', 'Fira Code', Consolas, monospace;
+}
+
+.policy-sources-doc-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 8px;
+}
+
+.policy-sources-ref {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.75rem;
+  padding: 2px 0;
+}
+
+.policy-sources-stance {
+  font-size: 0.68rem;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+}
+
+.policy-sources-stance-strongly_aligned,
+.policy-sources-stance-aligned {
+  color: var(--success);
+}
+
+.policy-sources-stance-disputes {
+  color: var(--danger);
+}
+
+.policy-sources-pov {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.policy-sources-node-id {
+  font-family: 'Cascadia Code', 'Fira Code', Consolas, monospace;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── Policy Dashboard: clickable rows ──────────────── */
+.policy-dashboard-row-clickable {
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.policy-dashboard-row-clickable:hover {
+  background: var(--bg-hover);
+}
+
+.policy-dashboard-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+/* ─── Policy Timeline ───────────────────────────────── */
+.policy-dashboard-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.policy-timeline-row {
+  display: grid;
+  grid-template-columns: 90px 70px 1fr 1fr;
+  gap: 8px;
+  align-items: center;
+  padding: 4px 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s;
+  border-radius: 3px;
+}
+
+.policy-timeline-row:hover {
+  background: var(--bg-hover);
+}
+
+.policy-timeline-date {
+  font-family: 'Cascadia Code', 'Fira Code', Consolas, monospace;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.policy-timeline-id {
+  font-family: 'Cascadia Code', 'Fira Code', Consolas, monospace;
+  font-size: 0.7rem;
+  color: var(--color-cc);
+  white-space: nowrap;
+}
+
+.policy-timeline-action {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.policy-timeline-source {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* ─── Conflict Related Policies ─────────────────────── */
+.conflict-related-policies {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.conflict-policy-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--color-cc);
+  background: transparent;
+  font-size: 0.75rem;
+  cursor: default;
+  max-width: 280px;
+  overflow: hidden;
+}
+
+.conflict-policy-badge-id {
+  font-family: 'Cascadia Code', 'Fira Code', Consolas, monospace;
+  font-size: 0.68rem;
+  color: var(--color-cc);
+  flex-shrink: 0;
+}
+
+.conflict-policy-badge-action {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -34,6 +34,7 @@ export interface ElectronAPI {
   isMaximized: () => Promise<boolean>;
   openExternal: (url: string) => Promise<void>;
   buildNodeSourceIndex: () => Promise<unknown>;
+  buildPolicySourceIndex: () => Promise<unknown>;
   loadEdges: () => Promise<unknown>;
   updateEdgeStatus: (index: number, status: string) => Promise<unknown>;
   bulkUpdateEdges: (indices: number[], status: string) => Promise<unknown>;


### PR DESCRIPTION
## Summary
- **NLI confidence margin lowered from 1.5 to 1.0** — fixes false neutrals on clear contradictions like "Fort Knox for AI Models" vs "AI for Everyone, Not Few"
- **Removed per-cluster NLI labeling from editor** — single-POV clustering produces misleading "contested" badges since same-POV nodes disagree on topic, not direction
- **Added per-node misfit detection** — runs all-pairs NLI within clusters (3+ nodes), flags individual nodes that contradict more cluster-mates than they agree with, but only when they're true outliers (fewer than half the cluster is flagged). Helps identify nodes placed in the wrong POV.
- **Misfit UI** — amber left border and "misfit?" badge with tooltip on flagged nodes in similarity sort view
- **requirements.txt** — added comment noting the NLI cross-encoder model (`cross-encoder/nli-deberta-v3-small`, ~180MB, downloads on first use)

## Test plan
- [ ] Launch taxonomy editor, switch any POV tab to similarity sort
- [ ] Verify no "CONTESTED" badges appear on cluster headers
- [ ] Verify clusters where all nodes agree show no misfit badges
- [ ] If a known wrong-POV node exists, verify it gets flagged as "misfit?"
- [ ] Run `Find-CrossCuttingCandidates -NoAI -TopN 6` — verify contested pairs show "vs." separator and shared/unclear/contested labels
- [ ] Run `python3 scripts/embed_taxonomy.py find-overlaps --top 5` — verify same-POV 1.0-similarity pairs labeled "duplicate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)