### PR TITLE
feat(ai-enrich): add deepseek backend branch for PS/TS stack parity (t/1938)

### DIFF
--- a/scripts/AIEnrich.psm1
+++ b/scripts/AIEnrich.psm1
@@ -18,7 +18,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 $script:ModelRegistry = @{}
 $script:FallbackChains = @{}
-$script:ContextWindows = @{ gemini = 1048576; claude = 200000; groq = 131072; openai = 131072; zai = 1000000; moonshot = 1000000 }
+$script:ContextWindows = @{ gemini = 1048576; claude = 200000; groq = 131072; openai = 131072; zai = 1000000; moonshot = 1000000; deepseek = 65536 }
 $script:LastApiKeySource = ''
 $script:AIApiLoggedThisSession = $false
 $script:AIApiLastModel = ''
@@ -178,6 +178,7 @@ function Resolve-AIApiKey {
         'azure'  = @('AZURE_OPENAI_API_KEY')
         'zai'    = @('ZAI_API_KEY')
         'moonshot' = @('MOONSHOT_API_KEY')
+        'deepseek' = @('DEEPSEEK_API_KEY')
     }
 
     $BackendEnvVars = $EnvVarMap[$Backend]
@@ -434,7 +435,8 @@ function Invoke-AIApi {
                 'ollama' { '(no env var — local, keyless)' }
                 'zai'    { 'ZAI_API_KEY' }
                 'moonshot' { 'MOONSHOT_API_KEY' }
-                default  { "(unknown backend '$Backend' — expected gemini/claude/groq/openai/azure/ollama/zai/moonshot)" }
+                'deepseek' { 'DEEPSEEK_API_KEY' }
+                default  { "(unknown backend '$Backend' — expected gemini/claude/groq/openai/azure/ollama/zai/moonshot/deepseek)" }
             }
             Write-Warning "No API key found for $Backend backend. Set $EnvHint or AI_API_KEY."
             return $null
@@ -659,6 +661,45 @@ function Invoke-AIApi {
             }
 
             $Body = $MoonshotBody | ConvertTo-Json -Depth 10
+        }
+
+        # t/1938 — DeepSeek exposes an OpenAI-compatible /v1/chat/completions endpoint
+        # at https://api.deepseek.com/. Bearer auth ($env:DEEPSEEK_API_KEY); request
+        # shape matches Groq/z.ai exactly. 64K-token context ($script:ContextWindows.deepseek).
+        'deepseek' {
+            $Uri = 'https://api.deepseek.com/v1/chat/completions'
+            $Headers = @{
+                'Authorization' = "Bearer $ResolvedKey"
+            }
+
+            $DeepSeekMessages = [System.Collections.Generic.List[object]]::new()
+            if ($SystemInstruction) {
+                $DeepSeekMessages.Add(@{ role = 'system'; content = $SystemInstruction })
+            }
+            $DeepSeekMessages.Add(@{ role = 'user'; content = $Prompt })
+
+            $DeepSeekBody = @{
+                model       = $ApiModelId
+                messages    = @($DeepSeekMessages)
+                temperature = $Temperature
+                max_tokens  = $MaxTokens
+            }
+            if ($JsonMode) {
+                if ($ResponseSchema) {
+                    $DeepSeekBody['response_format'] = @{
+                        type        = 'json_schema'
+                        json_schema = @{
+                            name   = 'response'
+                            schema = $ResponseSchema
+                            strict = $true
+                        }
+                    }
+                } else {
+                    $DeepSeekBody['response_format'] = @{ type = 'json_object' }
+                }
+            }
+
+            $Body = $DeepSeekBody | ConvertTo-Json -Depth 10
         }
 
         # t/1409 — Ollama exposes an OpenAI-compatible /v1/chat/completions endpoint
@@ -987,6 +1028,26 @@ function Invoke-AIApi {
             } catch {
                 $TopKeys = ($Response.PSObject.Properties.Name | Select-Object -First 5) -join ', '
                 Write-Warning "Moonshot: unexpected response shape (top-level keys: $TopKeys). Expected choices[].message.content"
+                return $null
+            }
+        }
+        # t/1938 — DeepSeek's /v1/chat/completions mirrors the Groq/OpenAI response shape.
+        'deepseek' {
+            try {
+                $Choice = $Response.choices[0]
+                $Text = $Choice.message.content
+                $Truncated = ($Choice.finish_reason -eq 'length')
+                $u = $Response.usage
+                if ($u) {
+                    $Usage = [PSCustomObject]@{
+                        InputTokens  = [int]($u.prompt_tokens)
+                        OutputTokens = [int]($u.completion_tokens)
+                        TotalTokens  = [int]($u.total_tokens)
+                    }
+                }
+            } catch {
+                $TopKeys = ($Response.PSObject.Properties.Name | Select-Object -First 5) -join ', '
+                Write-Warning "DeepSeek: unexpected response shape (top-level keys: $TopKeys). Expected choices[].message.content"
                 return $null
             }
         }

--- a/scripts/AITriad/Public/Test-AIApiKey.ps1
+++ b/scripts/AITriad/Public/Test-AIApiKey.ps1
@@ -63,7 +63,7 @@ function Test-AIApiKey {
     [OutputType([PSCustomObject])]
     param(
         [Parameter(Mandatory, ParameterSetName = 'One', Position = 0)]
-        [ValidateSet('gemini', 'claude', 'groq', 'openai', 'azure', 'ollama', 'zai', 'moonshot')]
+        [ValidateSet('gemini', 'claude', 'groq', 'openai', 'azure', 'ollama', 'zai', 'moonshot', 'deepseek')]
         [string]$Backend,
 
         [Parameter(ParameterSetName = 'One')]
@@ -176,6 +176,11 @@ function Test-AIApiKey {
                 $Uri = 'https://api.moonshot.ai/v1/models'
                 $Headers['Authorization'] = "Bearer $Key"
             }
+            # t/1938 — DeepSeek is OpenAI-compatible and exposes a GET /models list.
+            'deepseek' {
+                $Uri = 'https://api.deepseek.com/models'
+                $Headers['Authorization'] = "Bearer $Key"
+            }
         }
 
         # Probe the endpoint. Most backends are GET on /models; z.ai uses a POST
@@ -254,6 +259,8 @@ function Test-AIApiKey {
         # t/1437 — z.ai only if $env:ZAI_API_KEY is present (needs a real key).
         if ($env:ZAI_API_KEY) { $Backends += 'zai' }
         if ($env:MOONSHOT_API_KEY) { $Backends += 'moonshot' }
+        # t/1938 — DeepSeek only if $env:DEEPSEEK_API_KEY is present (needs a real key).
+        if ($env:DEEPSEEK_API_KEY) { $Backends += 'deepseek' }
         foreach ($B in $Backends) {
             _Probe-Backend -B $B -ExplicitKey '' -AzureEndpoint $env:AZURE_OPENAI_ENDPOINT -Timeout $TimeoutSec
         }

--- a/tests/Invoke-AIApi.DeepSeek.Tests.ps1
+++ b/tests/Invoke-AIApi.DeepSeek.Tests.ps1
@@ -1,0 +1,111 @@
+# Tag: enrichment (t/1938)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    DeepSeek dispatch regression tests (t/1938).
+.DESCRIPTION
+    PS/TS stack-parity cleanup: the TS stack supports the `deepseek` backend but
+    the PS adapter (AIEnrich.psm1) did not. These pure-PS assertions (parameter
+    surface, EnvVarMap wiring, context window, Resolve-AIApiKey resolution) always
+    run. Live round-trip tests self-skip with an ALARMING reason when
+    $env:DEEPSEEK_API_KEY isn't set — mirroring the t/1437 z.ai / t/1409 Ollama
+    pattern so a CI regression can't quietly pass-by-skip.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+    $EnrichPath = Join-Path $PSScriptRoot '..' 'scripts' 'AIEnrich.psm1'
+    Import-Module $EnrichPath -Force -WarningAction SilentlyContinue
+
+    $script:HasDeepSeekKey = -not [string]::IsNullOrWhiteSpace($env:DEEPSEEK_API_KEY)
+    $script:SkipReason     = 'DEEPSEEK_API_KEY not set — DEEPSEEK LIVE GUARD NOT RUN (CI regression? owner-provisioned key needed)'
+}
+
+Describe 'DeepSeek wiring — pure-PS shape checks (t/1938)' -Tag 'enrichment' {
+
+    It 'Test-AIApiKey ValidateSet includes deepseek' {
+        $cmd = Get-Command Test-AIApiKey -Module AITriad
+        $vs = $cmd.Parameters['Backend'].Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $vs.ValidValues | Should -Contain 'deepseek'
+    }
+
+    It 'AIEnrich ContextWindows registers deepseek at 65,536 tokens' {
+        InModuleScope AIEnrich {
+            $script:ContextWindows.ContainsKey('deepseek') | Should -Be $true
+            $script:ContextWindows['deepseek']            | Should -Be 65536
+        }
+    }
+
+    It 'Resolve-AIApiKey -Backend deepseek reads $env:DEEPSEEK_API_KEY (or falls back to $env:AI_API_KEY)' {
+        InModuleScope AIEnrich {
+            $saved = @{
+                DS = $env:DEEPSEEK_API_KEY
+                AI = $env:AI_API_KEY
+            }
+            try {
+                $env:DEEPSEEK_API_KEY = 'ds-test-key-marker-t1938'
+                $env:AI_API_KEY       = $null
+                $r = Resolve-AIApiKey -Backend 'deepseek'
+                $r | Should -Be 'ds-test-key-marker-t1938'
+                $script:LastApiKeySource | Should -Be '$env:DEEPSEEK_API_KEY'
+            } finally {
+                $env:DEEPSEEK_API_KEY = $saved.DS
+                $env:AI_API_KEY       = $saved.AI
+            }
+        }
+    }
+
+    It 'Resolve-AIApiKey -Backend deepseek returns $null when neither DEEPSEEK_API_KEY nor AI_API_KEY set' {
+        InModuleScope AIEnrich {
+            $saved = @{
+                DS = $env:DEEPSEEK_API_KEY
+                AI = $env:AI_API_KEY
+            }
+            try {
+                $env:DEEPSEEK_API_KEY = $null
+                $env:AI_API_KEY       = $null
+                $r = Resolve-AIApiKey -Backend 'deepseek'
+                $r | Should -BeNullOrEmpty
+            } finally {
+                $env:DEEPSEEK_API_KEY = $saved.DS
+                $env:AI_API_KEY       = $saved.AI
+            }
+        }
+    }
+}
+
+Describe 'DeepSeek live round-trip — requires DEEPSEEK_API_KEY (t/1938)' -Tag 'enrichment' {
+
+    It 'Test-AIApiKey -Backend deepseek returns Functional=$true when the key authenticates' {
+        if (-not $script:HasDeepSeekKey) {
+            Set-ItResult -Skipped -Because $script:SkipReason
+            return
+        }
+        $r = Test-AIApiKey -Backend deepseek -TimeoutSec 15
+        $r.Backend    | Should -Be 'deepseek'
+        $r.Functional | Should -Be $true
+        $r.StatusCode | Should -Be 200
+        $r.KeySource  | Should -Match 'DEEPSEEK_API_KEY|AI_API_KEY'
+    }
+
+    It 'Invoke-AIApi -Model deepseek-deepseek-v4-flash -Prompt returns non-empty Text + usage counters' {
+        if (-not $script:HasDeepSeekKey) {
+            Set-ItResult -Skipped -Because $script:SkipReason
+            return
+        }
+        $r = Invoke-AIApi -Model 'deepseek-deepseek-v4-flash' -Prompt 'Say hi in one short word.' -MaxTokens 200 -Temperature 0.1
+        $r                    | Should -Not -BeNullOrEmpty
+        $r.Backend            | Should -Be 'deepseek'
+        $r.Text               | Should -Not -BeNullOrEmpty
+        $r.Text.Trim().Length | Should -BeGreaterThan 0
+        $r.Usage              | Should -Not -BeNullOrEmpty
+        $r.Usage.InputTokens  | Should -BeGreaterThan 0
+        $r.Usage.OutputTokens | Should -BeGreaterThan 0
+        $r.Usage.TotalTokens  | Should -Be ($r.Usage.InputTokens + $r.Usage.OutputTokens)
+    }
+}


### PR DESCRIPTION
## Summary
PS/TS stack-parity cleanup (t/1938). The TS stack (`aiAdapter.ts` / `ai-client`) supports the `deepseek` backend but the PS adapter `scripts/AIEnrich.psm1` had no `deepseek` branch — so a backend selectable in TS was silently unavailable in PS.

Mirrors the landed z.ai pattern (t/1437):
- **`AIEnrich.psm1`** — OpenAI-compatible `deepseek` dispatch (`https://api.deepseek.com/v1/chat/completions`) + response extraction; Bearer auth via `DEEPSEEK_API_KEY`; `EnvVarMap` + `$EnvHint` entries; `ContextWindows` entry (65536, matching `ai-models.json`); help-text enum updated.
- **`Test-AIApiKey.ps1`** — `deepseek` added to the `Backend` ValidateSet, a GET `/models` probe branch, and the `-All` sweep gate (`DEEPSEEK_API_KEY` present).
- **`tests/Invoke-AIApi.DeepSeek.Tests.ps1`** — companion regression test mirroring `Invoke-AIApi.Zai.Tests.ps1`: pure-PS shape checks always run; live round-trip self-skips with an alarming reason when `DEEPSEEK_API_KEY` is unset.

## Verification
- `Invoke-Pester ./tests/` (keys unset, CI-faithful): **927 passed, 0 failed, 14 skipped**.
- `Test-ModuleManifest` on source manifest: clean (v0.8.6).
- `/review-ps` checklist satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)