### PR TITLE
fix(server): derive ALL_AI_BACKENDS from ENV_KEY_NAMES so delete-all covers every backend (t/1954)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/keyDeletion.test.ts
+++ b/taxonomy-editor/src/server/__tests__/keyDeletion.test.ts
@@ -53,4 +53,22 @@ describe('API key deletion', () => {
     expect(await store().get('gemini', U)).toBeNull();
     expect(await store().get('groq', U)).toBeNull();
   });
+
+  // Drift tripwire (t/1954): ALL_AI_BACKENDS was a hand-maintained literal that
+  // excluded these three BYOK backends, so delete-all silently left their keys
+  // behind. Deriving it from ENV_KEY_NAMES fixes that; this asserts the behavior
+  // so a future revert to a literal goes red.
+  it('deleteAllApiKeys clears the previously-drifted backends (moonshot, azure, zai)', async () => {
+    const u2 = 'carol';
+    const ctx2 = { principalName: u2, idp: 'github', storageUserId: u2, isAnonymous: false };
+    await store().set('moonshot', u2, 'k-moon');
+    await store().set('azure', u2, 'k-azure');
+    await store().set('zai', u2, 'k-zai');
+
+    await userContext.runWithUser(ctx2, () => deleteAllApiKeys());
+
+    expect(await store().get('moonshot', u2)).toBeNull();
+    expect(await store().get('azure', u2)).toBeNull();
+    expect(await store().get('zai', u2)).toBeNull();
+  });
 });

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -262,8 +262,12 @@ export async function deletePaidGeminiFallbackKey(): Promise<void> {
   await getKeyStore(getDataRoot).delete('gemini', PAID_FALLBACK_PARTITION);
 }
 
-/** All user-configurable AI backends — iterated by deleteAllApiKeys(). */
-const ALL_AI_BACKENDS: AIBackend[] = ['gemini', 'claude', 'groq', 'openai', 'tavily', 'ollama', 'deepseek'];
+/** All user-configurable AI backends — iterated by deleteAllApiKeys().
+ *  Derived from ENV_KEY_NAMES (the exhaustive Record<AIBackend, string> tsc
+ *  enforces) rather than hand-maintained, so a newly added backend can never be
+ *  silently missed by delete-all. A hardcoded literal had drifted — it excluded
+ *  azure/zai/moonshot, leaving their stored keys behind (t/1954). */
+const ALL_AI_BACKENDS = Object.keys(ENV_KEY_NAMES) as AIBackend[];
 
 export async function deleteApiKey(backend: AIBackend = 'gemini'): Promise<void> {
   await getKeyStore(getDataRoot).delete(backend, getCurrentUserId());


### PR DESCRIPTION
## t/1954 — delete-all silently missed moonshot/azure/zai

`config.ts` `ALL_AI_BACKENDS` was a hand-maintained literal (`['gemini','claude','groq','openai','tavily','ollama','deepseek']`) consumed by `deleteAllApiKeys`. It had drifted — excluding the **azure/zai/moonshot** BYOK backends — so "delete all API keys" left their stored keys behind. No gate covered it → silent.

**Fix (TL ruling p/87#146):** derive, don't hand-maintain:
`const ALL_AI_BACKENDS = Object.keys(ENV_KEY_NAMES) as AIBackend[];`
`ENV_KEY_NAMES` is the exhaustive `Record<AIBackend,string>` tsc already enforces, so the derivation auto-includes moonshot, back-fills azure/zai, and makes the next backend impossible to miss — converting silent drift into a compile-time guarantee.

**Test:** `keyDeletion.test.ts` gains a behavioral tripwire asserting `deleteAllApiKeys` clears moonshot/azure/zai (red against the old literal, green with the derivation).

Local gates green: `tsc -p tsconfig.server.json`, `tsc -p tsconfig.main.json`, `eslint` (changed files), scoped vitest 4/4.

Self-cert: /trivial-change (single-scope, TL-prescribed fix, no new interfaces).