### PR TITLE
refactor(server-community): reduce eslint complexity in analytics + community (t/1923)

### DIFF
--- a/taxonomy-editor/src/server/community/analytics.ts
+++ b/taxonomy-editor/src/server/community/analytics.ts
@@ -190,6 +190,66 @@ async function readEvents(from: string, to: string): Promise<AnalyticsEvent[]> {
   return events;
 }
 
+// ── Aggregation accumulators ──
+
+type DailyEntry = { events: number; users: Set<string>; sessions: Set<string> };
+type UserEntry = { lastActive: string; sessions: Set<string>; events: number; categories: Record<string, number> };
+type SessionEntry = { first: number; last: number };
+
+/** t/892: sum AI usage/cost from an `ai.call` event's detail (additive, one pass). */
+function accumulateAiCost(aiCost: AiCostSummary, evt: AnalyticsEvent): void {
+  if (evt.event_type !== 'ai.call') return;
+  const d = evt.detail || {};
+  const tokensIn = Number(d.tokens_in) || 0;
+  const tokensOut = Number(d.tokens_out) || 0;
+  const costUsd = Number(d.estimated_cost_usd) || 0;
+  const model = typeof d.model === 'string' && d.model ? d.model : 'unknown';
+  aiCost.calls++; aiCost.tokensIn += tokensIn; aiCost.tokensOut += tokensOut; aiCost.costUsd += costUsd;
+  let m = aiCost.byModel[model];
+  if (!m) { m = { calls: 0, tokensIn: 0, tokensOut: 0, costUsd: 0 }; aiCost.byModel[model] = m; }
+  m.calls++; m.tokensIn += tokensIn; m.tokensOut += tokensOut; m.costUsd += costUsd;
+}
+
+/** Roll one event into the per-day totals (events + distinct users/sessions). */
+function accumulateDaily(dailyMap: Map<string, DailyEntry>, evt: AnalyticsEvent): void {
+  const date = evt.timestamp.slice(0, 10);
+  let daily = dailyMap.get(date);
+  if (!daily) { daily = { events: 0, users: new Set(), sessions: new Set() }; dailyMap.set(date, daily); }
+  daily.events++;
+  daily.users.add(evt.user);
+  daily.sessions.add(evt.session_id);
+}
+
+/** Roll one event into the per-user summary (last-active, sessions, categories). */
+function accumulateUser(userMap: Map<string, UserEntry>, evt: AnalyticsEvent): void {
+  let u = userMap.get(evt.user);
+  if (!u) { u = { lastActive: evt.timestamp, sessions: new Set(), events: 0, categories: {} }; userMap.set(evt.user, u); }
+  if (evt.timestamp > u.lastActive) u.lastActive = evt.timestamp;
+  u.sessions.add(evt.session_id);
+  u.events++;
+  u.categories[evt.category] = (u.categories[evt.category] || 0) + 1;
+}
+
+/** Track first/last event timestamps for one session (for duration averaging). */
+function accumulateSession(sessionTimes: Map<string, SessionEntry>, evt: AnalyticsEvent): void {
+  const ts = new Date(evt.timestamp).getTime();
+  let sess = sessionTimes.get(evt.session_id);
+  if (!sess) { sess = { first: ts, last: ts }; sessionTimes.set(evt.session_id, sess); }
+  if (ts < sess.first) sess.first = ts;
+  if (ts > sess.last) sess.last = ts;
+}
+
+/** Mean session duration in ms across sessions with a positive span (0 if none). */
+function meanSessionDurationMs(sessionTimes: Map<string, SessionEntry>): number {
+  let totalDuration = 0;
+  let sessionCount = 0;
+  for (const sess of sessionTimes.values()) {
+    const dur = sess.last - sess.first;
+    if (dur > 0) { totalDuration += dur; sessionCount++; }
+  }
+  return sessionCount > 0 ? Math.round(totalDuration / sessionCount) : 0;
+}
+
 /** Query aggregated analytics for a date range. */
 export async function queryAggregated(from: string, to: string): Promise<QueryResult> {
   const events = await readEvents(from, to);
@@ -199,9 +259,9 @@ export async function queryAggregated(from: string, to: string): Promise<QueryRe
   const featureUsage: Record<string, number> = {};
   const eventTypes: Record<string, number> = {};
   const aiCost: AiCostSummary = { calls: 0, tokensIn: 0, tokensOut: 0, costUsd: 0, byModel: {} };
-  const dailyMap = new Map<string, { events: number; users: Set<string>; sessions: Set<string> }>();
-  const userMap = new Map<string, { lastActive: string; sessions: Set<string>; events: number; categories: Record<string, number> }>();
-  const sessionTimes = new Map<string, { first: number; last: number }>();
+  const dailyMap = new Map<string, DailyEntry>();
+  const userMap = new Map<string, UserEntry>();
+  const sessionTimes = new Map<string, SessionEntry>();
 
   for (const evt of events) {
     userSet.add(evt.user);
@@ -210,47 +270,13 @@ export async function queryAggregated(from: string, to: string): Promise<QueryRe
     featureUsage[evt.category] = (featureUsage[evt.category] || 0) + 1;
     eventTypes[evt.event_type] = (eventTypes[evt.event_type] || 0) + 1;
 
-    // t/892: sum AI usage/cost from ai.call detail (one pass, additive).
-    if (evt.event_type === 'ai.call') {
-      const d = evt.detail || {};
-      const tokensIn = Number(d.tokens_in) || 0;
-      const tokensOut = Number(d.tokens_out) || 0;
-      const costUsd = Number(d.estimated_cost_usd) || 0;
-      const model = typeof d.model === 'string' && d.model ? d.model : 'unknown';
-      aiCost.calls++; aiCost.tokensIn += tokensIn; aiCost.tokensOut += tokensOut; aiCost.costUsd += costUsd;
-      let m = aiCost.byModel[model];
-      if (!m) { m = { calls: 0, tokensIn: 0, tokensOut: 0, costUsd: 0 }; aiCost.byModel[model] = m; }
-      m.calls++; m.tokensIn += tokensIn; m.tokensOut += tokensOut; m.costUsd += costUsd;
-    }
-
-    const date = evt.timestamp.slice(0, 10);
-    let daily = dailyMap.get(date);
-    if (!daily) { daily = { events: 0, users: new Set(), sessions: new Set() }; dailyMap.set(date, daily); }
-    daily.events++;
-    daily.users.add(evt.user);
-    daily.sessions.add(evt.session_id);
-
-    let u = userMap.get(evt.user);
-    if (!u) { u = { lastActive: evt.timestamp, sessions: new Set(), events: 0, categories: {} }; userMap.set(evt.user, u); }
-    if (evt.timestamp > u.lastActive) u.lastActive = evt.timestamp;
-    u.sessions.add(evt.session_id);
-    u.events++;
-    u.categories[evt.category] = (u.categories[evt.category] || 0) + 1;
-
-    const ts = new Date(evt.timestamp).getTime();
-    let sess = sessionTimes.get(evt.session_id);
-    if (!sess) { sess = { first: ts, last: ts }; sessionTimes.set(evt.session_id, sess); }
-    if (ts < sess.first) sess.first = ts;
-    if (ts > sess.last) sess.last = ts;
+    accumulateAiCost(aiCost, evt);
+    accumulateDaily(dailyMap, evt);
+    accumulateUser(userMap, evt);
+    accumulateSession(sessionTimes, evt);
   }
 
-  let totalDuration = 0;
-  let sessionCount = 0;
-  for (const sess of sessionTimes.values()) {
-    const dur = sess.last - sess.first;
-    if (dur > 0) { totalDuration += dur; sessionCount++; }
-  }
-  const avgSessionDurationMs = sessionCount > 0 ? Math.round(totalDuration / sessionCount) : 0;
+  const avgSessionDurationMs = meanSessionDurationMs(sessionTimes);
 
   const daily: DailySummary[] = Array.from(dailyMap.entries())
     .sort(([a], [b]) => a.localeCompare(b))

--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -4,6 +4,7 @@
 import crypto from 'crypto';
 import { resolveDataPath } from '../config.js';
 import { getUserContentBackend, assertSafeId } from '../storage/fileIO.js';
+import type { StorageBackend } from '../storage/storageBackend.js';
 import { sanitizeUserText } from '../security/contentSanitizer.js';
 import { getStorageUserId, isAnonymousUser } from '../security/userContext.js';
 import { log } from '../logger.js';
@@ -417,6 +418,58 @@ export async function copyFromCommunity(type: 'chats' | 'debates', communityId: 
   return { newId: copy.id as string };
 }
 
+/** Parse a community item's stored JSON, tolerating a malformed file — a removal
+ *  must still succeed, so an unparseable body is recorded and treated as empty. */
+function parseRemovalItem(raw: string): Record<string, unknown> {
+  try { return JSON.parse(raw) as Record<string, unknown>; }
+  catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'community', level: 'warn',
+      message: 'Removing community item with unparseable JSON',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    return {};
+  }
+}
+
+/** Build the audit record captured before a community item is hard-deleted (t/748). */
+function buildRemovalAudit(
+  id: string,
+  type: 'chats' | 'debates',
+  item: Record<string, unknown>,
+  removedBy: string,
+  reason?: string,
+): Record<string, unknown> {
+  const meta = (item.community_metadata && typeof item.community_metadata === 'object')
+    ? item.community_metadata as Record<string, unknown> : {};
+  const topic = item.topic as { final?: string; original?: string } | string | undefined;
+  return {
+    id,
+    type: type === 'chats' ? 'chat' : 'debate',
+    title: (item.title as string)
+      || (typeof topic === 'object' ? (topic.final || topic.original) : topic)
+      || 'Untitled',
+    submitted_by: (meta.submitted_by_display as string) ?? null,
+    removed_by: removedBy,
+    removed_at: new Date().toISOString(),
+    reason: reason ?? null,
+  };
+}
+
+/** Drop the cached listing index so a removed item disappears immediately;
+ *  best-effort (the count-staleness check self-heals it on the next list). */
+async function invalidateListingIndex(backend: StorageBackend, dir: string): Promise<void> {
+  try {
+    await backend.deleteFile(path.join(dir, COMMUNITY_INDEX_FILE));
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'community', level: 'warn',
+      message: 'Failed to clear community listing index after removal (self-heals on next list)',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+  }
+}
+
 /**
  * Admin hard-delete of a published community item (t/748). Captures an audit
  * record (community/_removals/rem-{uuid}.json), removes the published file, and
@@ -440,50 +493,20 @@ export async function removeCommunityItem(
 
   // Capture metadata for the audit record before deleting. Tolerate a malformed
   // file — removal must still succeed.
-  let item: Record<string, unknown> = {};
-  try { item = JSON.parse(raw) as Record<string, unknown>; }
-  catch (err) {
-    getGlobalRecorder()?.record({
-      type: 'system.error', component: 'community', level: 'warn',
-      message: 'Removing community item with unparseable JSON',
-      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-    });
-  }
-  const meta = (item.community_metadata && typeof item.community_metadata === 'object')
-    ? item.community_metadata as Record<string, unknown> : {};
-  const topic = item.topic as { final?: string; original?: string } | string | undefined;
+  const item = parseRemovalItem(raw);
   const removedBy = getStorageUserId();
 
   // Hard delete the published file, then write the audit record (so the trail
   // reflects a completed removal), then invalidate the cached listing index.
   await backend.deleteFile(filePath);
 
-  const audit = {
-    id,
-    type: type === 'chats' ? 'chat' : 'debate',
-    title: (item.title as string)
-      || (typeof topic === 'object' ? (topic.final || topic.original) : topic)
-      || 'Untitled',
-    submitted_by: (meta.submitted_by_display as string) ?? null,
-    removed_by: removedBy,
-    removed_at: new Date().toISOString(),
-    reason: reason ?? null,
-  };
   await backend.writeFile(
     path.join(removalsDir(), `rem-${crypto.randomUUID()}.json`),
-    JSON.stringify(audit, null, 2),
+    JSON.stringify(buildRemovalAudit(id, type, item, removedBy, reason), null, 2),
   );
 
   // Invalidate the listing index so the removed item drops out immediately.
-  try {
-    await backend.deleteFile(path.join(dir, COMMUNITY_INDEX_FILE));
-  } catch (err) {
-    getGlobalRecorder()?.record({
-      type: 'system.error', component: 'community', level: 'warn',
-      message: 'Failed to clear community listing index after removal (self-heals on next list)',
-      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-    });
-  }
+  await invalidateListingIndex(backend, dir);
 
   log.server.info({ id, type, removedBy }, 'Community item removed');
 }


### PR DESCRIPTION
Server Community slice of t/1910 (src/server fan-out of the t/1848 complexity debt epic).

## What
ADR-007 behavior-preserving decomposition of two over-threshold functions:

- **`queryAggregated`** (cx 23 → ~4): extracted per-event accumulators `accumulateAiCost` / `accumulateDaily` / `accumulateUser` / `accumulateSession` + `meanSessionDurationMs`; named the Daily/User/Session map-entry types. Loop bodies moved verbatim.
- **`removeCommunityItem`** (cx 19 → ~4): extracted `parseRemovalItem` (tolerant parse), `buildRemovalAudit` (title/meta resolution), `invalidateListingIndex`.

## Behavior preservation
Call ordering, early-returns, and flight-recorder-in-catch all preserved; no ActionableError paths touched. Residual helpers are independently testable.

## Verify (worktree off origin/main)
- tsc main + server: 0 / 0
- eslint: 0 warnings on both files (complexity resolved)
- depcruise: 0 violations (1304 modules)
- vitest: 23/23 (analytics, community, communityRemoval, communityFaults, communityListingIndex)

Shared `--max-warnings` ceiling **not** ratcheted (epic-level per t/1848).

Closes t/1923.