### PR TITLE
feat(ai-client): export exhaustive ALL_API_KEY_BACKENDS (t/1956)

### DIFF
--- a/lib/ai-client/allApiKeyBackends.test.ts
+++ b/lib/ai-client/allApiKeyBackends.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { ALL_API_KEY_BACKENDS } from './types.js';
+
+// The compile-time guarantee (Record<ApiKeyBackend, true> forces every union
+// member) is the real protection — see t/1956. These runtime assertions guard
+// against an accidental map/keys mismatch and document the expected membership.
+describe('ALL_API_KEY_BACKENDS', () => {
+  it('contains every API-key backend, including the previously-omitted zai and moonshot', () => {
+    expect([...ALL_API_KEY_BACKENDS].sort()).toEqual(
+      [
+        'azure',
+        'claude',
+        'deepseek',
+        'gemini',
+        'groq',
+        'moonshot',
+        'ollama',
+        'openai',
+        'tavily',
+        'zai',
+      ].sort(),
+    );
+  });
+
+  it('has no duplicates', () => {
+    expect(new Set(ALL_API_KEY_BACKENDS).size).toBe(ALL_API_KEY_BACKENDS.length);
+  });
+});

--- a/lib/ai-client/index.ts
+++ b/lib/ai-client/index.ts
@@ -3,6 +3,7 @@
 
 export type { GenerateOptions, ProviderResult, TokenUsage, RateLimitType, RateLimitHeaders, RetryProgress, BackendId, ApiKeyBackend, FetchFn, ToolDefinition, ToolCall, ToolResult, ModelCapabilities } from './types.js';
 export type { ModelEntry, ModelRegistry, ModelPricing } from './registry.js';
+export { ALL_API_KEY_BACKENDS } from './types.js';
 export { resolveBackend, resolveModel, buildModelIdMap, getApiModelId, getDefaultTimeout, getModelCapabilities, filterByCapabilities, estimateCost } from './registry.js';
 export { withTimeout, withRetry, retryableFetch, parseRateLimitType, parseRateLimitHeaders, CLI_RETRY_CONFIG, SERVER_RETRY_CONFIG } from './retry.js';
 export type { RetryConfig } from './retry.js';

--- a/lib/ai-client/types.ts
+++ b/lib/ai-client/types.ts
@@ -70,6 +70,28 @@ export type BackendId = 'gemini' | 'claude' | 'groq' | 'openai' | 'azure' | 'oll
 /** Superset of BackendId that includes non-generation backends needing API key management (e.g. tavily for search). */
 export type ApiKeyBackend = BackendId | 'tavily';
 
+/**
+ * Exhaustive map of every API-key backend. `Record<ApiKeyBackend, true>` forces
+ * every union member to be present, so adding a backend to `BackendId`/`ApiKeyBackend`
+ * without adding it here is a COMPILE ERROR — not a silent omission. This is the
+ * source of truth; do not hand-maintain parallel backend arrays (t/1956).
+ */
+const ALL_API_KEY_BACKENDS_MAP: Record<ApiKeyBackend, true> = {
+  gemini: true,
+  claude: true,
+  groq: true,
+  openai: true,
+  azure: true,
+  ollama: true,
+  deepseek: true,
+  zai: true,
+  moonshot: true,
+  tavily: true,
+};
+
+/** Canonical, exhaustive list of all API-key backends. Derived from {@link ALL_API_KEY_BACKENDS_MAP}. */
+export const ALL_API_KEY_BACKENDS = Object.keys(ALL_API_KEY_BACKENDS_MAP) as ApiKeyBackend[];
+
 export interface ModelCapabilities {
   supportsTools: boolean;
   supportsVision: boolean;


### PR DESCRIPTION
Derives a canonical API-key backend list from `Record<ApiKeyBackend, true>` so omitting a backend from the union-without-the-list is a **compile error** (was a silent gap — every hand-maintained `ALL_BACKENDS` copy is missing zai + moonshot). Export only; consumer adoption is t/1957/1958/1959.

- `lib/ai-client/types.ts`: `ALL_API_KEY_BACKENDS_MAP` + `ALL_API_KEY_BACKENDS`
- `lib/ai-client/index.ts`: re-export the value
- `allApiKeyBackends.test.ts`: exhaustive-membership + no-dupes
- Proven: removing a member fails `tsc` with TS2741 (t/1956#1)

Local verify: my change green; the only red is flaky `lib/debate/` tests + the Azurite-emulator azure test (both out of scope, non-deterministic on rerun).

Ticket: t/1956