### PR TITLE
refactor(server-ai): reduce eslint complexity in server/ai/ (t/1922)

### DIFF
--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -313,6 +313,38 @@ export function retryAfterMs(err: unknown): number {
   return 30_000;
 }
 
+// Normalize the caller-supplied key(s) to a filtered array, or undefined when the
+// caller passed nothing (→ fall back to the stored keys for each backend).
+function normalizeExplicitKeys(explicitApiKey: string | string[] | undefined): string[] | undefined {
+  if (explicitApiKey === undefined) return undefined;
+  return Array.isArray(explicitApiKey) ? explicitApiKey.filter(Boolean) : [explicitApiKey];
+}
+
+// Per-attempt generation options: explicit temperature > debate override > 0.7;
+// explicit timeout > backend default.
+function buildGenerateOptions(
+  options: { temperature?: number } | undefined,
+  timeoutMs: number | undefined,
+  currentModel: string,
+): GenerateOptions {
+  return {
+    temperature: options?.temperature ?? _debateTemperature ?? 0.7,
+    timeoutMs: timeoutMs ?? getDefaultTimeout(currentModel),
+  };
+}
+
+// No key for any model in the chain — throw a backend-named ActionableError.
+function throwNoApiKeyError(backend: string, modelsToTry: string[]): never {
+  const names: Record<string, string> = { gemini: 'Gemini', claude: 'Claude', groq: 'Groq', openai: 'OpenAI', tavily: 'Tavily', deepseek: 'DeepSeek', moonshot: 'Moonshot (Kimi)' };
+  const backendName = names[backend] ?? backend;
+  throw new ActionableError({
+    goal: `Generate text via ${backendName}`,
+    problem: `No API key configured for any model in the fallback chain: ${modelsToTry.join(' → ')}`,
+    location: 'aiBackends.generateText',
+    nextSteps: [`Set your ${backendName} API key in Settings`, 'Or switch to a backend that has a key configured'],
+  });
+}
+
 export async function generateText(
   prompt: string,
   model?: string,
@@ -322,9 +354,7 @@ export async function generateText(
   options?: { temperature?: number },
 ): Promise<GenerateResult> {
   const resolved = model || DEFAULT_MODEL;
-  const explicitKeys = explicitApiKey === undefined
-    ? undefined
-    : (Array.isArray(explicitApiKey) ? explicitApiKey.filter(Boolean) : [explicitApiKey]);
+  const explicitKeys = normalizeExplicitKeys(explicitApiKey);
   const modelsToTry = buildModelsToTry(resolved, explicitKeys !== undefined);
 
   let lastError: unknown;
@@ -341,21 +371,11 @@ export async function generateText(
         });
         continue;
       }
-      const names: Record<string, string> = { gemini: 'Gemini', claude: 'Claude', groq: 'Groq', openai: 'OpenAI', tavily: 'Tavily', deepseek: 'DeepSeek', moonshot: 'Moonshot (Kimi)' };
-      const backendName = names[backend] ?? backend;
-      throw new ActionableError({
-        goal: `Generate text via ${backendName}`,
-        problem: `No API key configured for any model in the fallback chain: ${modelsToTry.join(' → ')}`,
-        location: 'aiBackends.generateText',
-        nextSteps: [`Set your ${backendName} API key in Settings`, 'Or switch to a backend that has a key configured'],
-      });
+      throwNoApiKeyError(backend, modelsToTry);
     }
 
     const apiModel = getApiModelId(currentModel);
-    const opts: GenerateOptions = {
-      temperature: options?.temperature ?? _debateTemperature ?? 0.7,
-      timeoutMs: timeoutMs ?? getDefaultTimeout(currentModel),
-    };
+    const opts = buildGenerateOptions(options, timeoutMs, currentModel);
 
     const runWithRetry = (apiKey: string) => withRetry(
       () => callProvider(fetch, backend, prompt, apiModel, apiKey, opts),

--- a/taxonomy-editor/src/server/ai/providerErrors.ts
+++ b/taxonomy-editor/src/server/ai/providerErrors.ts
@@ -9,6 +9,27 @@
 // Keep this pure and dependency-free so both server layers can import it without
 // pulling in HTTP/route wiring.
 
+// Google details[].reason is the most specific code (e.g. SERVICE_DISABLED).
+// Returns the first non-empty string reason in the array, or undefined.
+function firstDetailReason(details: unknown): string | undefined {
+  if (!Array.isArray(details)) return undefined;
+  for (const d of details) {
+    const reason = (d as { reason?: unknown })?.reason;
+    if (typeof reason === 'string' && reason) return reason;
+  }
+  return undefined;
+}
+
+// First non-empty string-valued field among `keys`, in order — the Google
+// top-level status / OpenAI-compatible code/type fallback.
+function firstStringField(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'string' && v) return v;
+  }
+  return undefined;
+}
+
 // t/1620: pull the most specific machine-readable reason out of a provider error
 // body so a non-200 can be mapped to a real cause instead of a blanket "Invalid
 // API key". Handles both dialects the probed providers speak:
@@ -22,18 +43,34 @@ export function extractProviderReason(body: unknown): string | undefined {
   if (!err || typeof err !== 'object') return undefined;
   const e = err as { status?: unknown; code?: unknown; type?: unknown; details?: unknown };
   // Google: details[].reason is the most specific code (e.g. SERVICE_DISABLED).
-  if (Array.isArray(e.details)) {
-    for (const d of e.details) {
-      const reason = (d as { reason?: unknown })?.reason;
-      if (typeof reason === 'string' && reason) return reason;
-    }
-  }
+  const detailReason = firstDetailReason(e.details);
+  if (detailReason) return detailReason;
   // Google top-level status (PERMISSION_DENIED, RESOURCE_EXHAUSTED…) or the
   // OpenAI-compatible code/type field, whichever is present.
-  if (typeof e.status === 'string' && e.status) return e.status;
-  if (typeof e.code === 'string' && e.code) return e.code;
-  if (typeof e.type === 'string' && e.type) return e.type;
-  return undefined;
+  return firstStringField(e as Record<string, unknown>, ['status', 'code', 'type']);
+}
+
+// Reason/status predicates for deriveKeyErrorMessage — one per distinguished
+// case, conditions moved verbatim. `r` is the upper-cased reason string.
+// Quota / rate limit — the key itself is fine, just throttled.
+function isQuotaError(status: number, r: string): boolean {
+  return status === 429 || r.includes('RESOURCE_EXHAUSTED') || r.includes('RATE_LIMIT') || r.includes('QUOTA');
+}
+// Required API not enabled on the key's project (Google Generative Language API).
+function isApiDisabled(r: string): boolean {
+  return r.includes('SERVICE_DISABLED') || r.includes('API_NOT_ENABLED');
+}
+// Key restricted by referrer / IP / app restrictions — real key, wrong context.
+function isRestrictedKey(r: string): boolean {
+  return r.includes('HTTP_REFERRER') || r.includes('IP_ADDRESS') || r.includes('API_KEY_ANDROID') || r.includes('API_KEY_IOS');
+}
+// Permission denied — the key is real but lacks access to this API surface.
+function isPermissionDenied(status: number, r: string): boolean {
+  return status === 403 || r.includes('PERMISSION_DENIED') || r.includes('FORBIDDEN');
+}
+// Genuinely malformed / wrong key.
+function isInvalidKey(status: number, r: string): boolean {
+  return status === 400 || status === 401 || r.includes('API_KEY_INVALID') || r.includes('UNAUTHENTICATED') || r.includes('INVALID_API_KEY');
 }
 
 // t/1620: map (HTTP status, provider reason) to a specific, user-safe message.
@@ -43,26 +80,11 @@ export function extractProviderReason(body: unknown): string | undefined {
 // into "Invalid API key" and misled users holding a known-good-but-restricted key.
 export function deriveKeyErrorMessage(status: number, reason: string | undefined): string {
   const r = (reason ?? '').toUpperCase();
-  // Quota / rate limit — the key itself is fine, just throttled.
-  if (status === 429 || r.includes('RESOURCE_EXHAUSTED') || r.includes('RATE_LIMIT') || r.includes('QUOTA')) {
-    return 'Key is valid but the provider is rate-limiting or out of quota — retry shortly';
-  }
-  // Required API not enabled on the key's project (Google Generative Language API).
-  if (r.includes('SERVICE_DISABLED') || r.includes('API_NOT_ENABLED')) {
-    return 'Key is valid but the required API is not enabled for its project';
-  }
-  // Key restricted by referrer / IP / app restrictions — real key, wrong context.
-  if (r.includes('HTTP_REFERRER') || r.includes('IP_ADDRESS') || r.includes('API_KEY_ANDROID') || r.includes('API_KEY_IOS')) {
-    return 'Key is restricted (HTTP referrer / IP / app restrictions) and cannot be used here';
-  }
-  // Permission denied — the key is real but lacks access to this API surface.
-  if (status === 403 || r.includes('PERMISSION_DENIED') || r.includes('FORBIDDEN')) {
-    return 'Key is valid but not permitted to use this API (permission denied)';
-  }
-  // Genuinely malformed / wrong key.
-  if (status === 400 || status === 401 || r.includes('API_KEY_INVALID') || r.includes('UNAUTHENTICATED') || r.includes('INVALID_API_KEY')) {
-    return 'Invalid API key';
-  }
+  if (isQuotaError(status, r)) return 'Key is valid but the provider is rate-limiting or out of quota — retry shortly';
+  if (isApiDisabled(r)) return 'Key is valid but the required API is not enabled for its project';
+  if (isRestrictedKey(r)) return 'Key is restricted (HTTP referrer / IP / app restrictions) and cannot be used here';
+  if (isPermissionDenied(status, r)) return 'Key is valid but not permitted to use this API (permission denied)';
+  if (isInvalidKey(status, r)) return 'Invalid API key';
   // Unknown non-200 — status-aware fallback still beats a bald verdict.
   return `Provider rejected the key (HTTP ${status})`;
 }


### PR DESCRIPTION
## t/1922 — reduce eslint complexity warnings in `server/ai/` (Server AI Proxy slice of t/1910)

ADR-007 behavior-preserving decomposition of the three over-threshold functions in `src/server/ai/`. Conditions/order/early-returns moved **verbatim** — no behavior change.

| function | before | after |
|---|---:|---:|
| `deriveKeyErrorMessage` (providerErrors.ts) | 20 | ~7 |
| `extractProviderReason` (providerErrors.ts) | 16 | ~6 |
| `generateText` (aiBackends.ts) | 19 | ~12 |

**providerErrors.ts** — extracted `firstDetailReason` + `firstStringField` (extractProviderReason); five named predicates `isQuotaError`/`isApiDisabled`/`isRestrictedKey`/`isPermissionDenied`/`isInvalidKey` (deriveKeyErrorMessage), preserving the ordered if-chain.

**aiBackends.ts** — extracted `normalizeExplicitKeys`, `buildGenerateOptions`, `throwNoApiKeyError` from `generateText`. All three `getGlobalRecorder()?.record()` calls stay **inline**, including the in-`catch` `ai.fallback` record (preserves flight-recorder-in-catch, ADR-003).

### Guardrails honored
- Error-classification invariant untouched (`is429Error`/`isContextTooLongError` mutual exclusivity — not in the refactored functions).
- ActionableError + flight-recorder-in-catch preserved.
- `--max-warnings` ceiling **not** ratcheted.

### Verification (worktree off origin/main `82107ae4`)
- eslint `src/server/ai/`: 0 errors, **all 3 complexity warnings gone**
- tsc main ✓, tsc server ✓ (only pre-existing `extract.ts` diagnostic, unrelated)
- depcruise ✓ (0 violations)
- scoped server vitest **786/786** ✓ (one prior run had a flaky `blob unreachable` storage test; clean on re-run — my change has no async/network path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
