### PR TITLE
fix(main): delete/list/export/migrate ALL api-key backends incl. zai + moonshot (t/1957)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/apiKeyStore.test.ts
+++ b/taxonomy-editor/src/main/__tests__/apiKeyStore.test.ts
@@ -29,8 +29,9 @@ vi.mock('electron', () => ({
 // Imported after the mock is registered.
 import {
   removeApiKey, loadApiKeys, loadApiKey, storeApiKey, hasApiKey, migrateToSingleKey,
-  deleteApiKey, getMaskedKeys, getApiKeySummary, exportKeysForSharing, importKeysFromSharing,
+  deleteApiKey, deleteAllApiKeys, getMaskedKeys, getApiKeySummary, exportKeysForSharing, importKeysFromSharing,
 } from '../apiKeyStore.js';
+import type { ApiKeyBackend } from '../../../../lib/ai-client/types.js';
 import { setGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 
 beforeEach(() => {
@@ -167,5 +168,62 @@ describe('apiKeyStore single-key storage (t/1425)', () => {
       expect(loadApiKeys('claude')).toEqual(['solo']);
       expect(events).toHaveLength(0);
     });
+  });
+});
+
+describe('full-backend coverage (t/1957 — zai/moonshot were silently omitted)', () => {
+  // Exhaustive BY CONSTRUCTION: Record<ApiKeyBackend, string> fails to compile if a backend
+  // is added to the union but omitted here — so this regression can never silently skip a
+  // backend the way the old hand-maintained ALL_BACKENDS did (it dropped zai and moonshot,
+  // so deleteAllApiKeys left those keys on disk).
+  const FAKE_KEYS: Record<ApiKeyBackend, string> = {
+    gemini: 'k-gemini', claude: 'k-claude', groq: 'k-groq', openai: 'k-openai', azure: 'k-azure',
+    ollama: 'k-ollama', deepseek: 'k-deepseek', zai: 'k-zai', moonshot: 'k-moonshot', tavily: 'k-tavily',
+  };
+  const ALL = Object.keys(FAKE_KEYS) as ApiKeyBackend[];
+
+  it('AC: deleteAllApiKeys removes a key stored for EVERY backend — nothing left on disk', () => {
+    for (const backend of ALL) storeApiKey(FAKE_KEYS[backend], backend);
+    for (const backend of ALL) expect(hasApiKey(backend)).toBe(true); // precondition: all set
+
+    deleteAllApiKeys();
+
+    for (const backend of ALL) {
+      expect(hasApiKey(backend)).toBe(false);
+      expect(loadApiKeys(backend)).toEqual([]);
+    }
+    // No api-key*.enc file survives anywhere in the store dir.
+    const remaining = fs.readdirSync(tmpDir).filter((f) => f.startsWith('api-key') && f.endsWith('.enc'));
+    expect(remaining).toEqual([]);
+  });
+
+  it('regression: the specific zai + moonshot keys are deleted (were left behind pre-t/1957)', () => {
+    storeApiKey('zzz', 'zai');
+    storeApiKey('mmm', 'moonshot');
+    deleteAllApiKeys();
+    expect(hasApiKey('zai')).toBe(false);
+    expect(hasApiKey('moonshot')).toBe(false);
+  });
+
+  it('getApiKeySummary lists every backend, including zai and moonshot', () => {
+    const backends = getApiKeySummary().map((e) => e.backend);
+    for (const backend of ALL) expect(backends).toContain(backend);
+    expect(backends).toHaveLength(ALL.length);
+  });
+
+  it('exportKeysForSharing includes zai and moonshot keys', () => {
+    storeApiKey('zzz', 'zai');
+    storeApiKey('mmm', 'moonshot');
+    const payload = exportKeysForSharing('pw');
+    deleteAllApiKeys(); // wipe, then decrypt-via-import to inspect the payload contents
+    expect(importKeysFromSharing(payload, 'pw').sort()).toEqual(['moonshot', 'zai']);
+    expect(loadApiKeys('zai')).toEqual(['zzz']);
+    expect(loadApiKeys('moonshot')).toEqual(['mmm']);
+  });
+
+  it('migrateToSingleKey truncates a zai multi-key file (was skipped pre-t/1957)', () => {
+    writeMultiKeyFile('zai', ['z0', 'z1']);
+    expect(migrateToSingleKey()).toBe(1);
+    expect(loadApiKeys('zai')).toEqual(['z0']);
   });
 });

--- a/taxonomy-editor/src/main/apiKeyStore.ts
+++ b/taxonomy-editor/src/main/apiKeyStore.ts
@@ -7,15 +7,21 @@ import path from 'path';
 import crypto from 'crypto';
 import { app } from 'electron';
 import type { ApiKeyBackend } from '../../../lib/ai-client/types.js';
+import { ALL_API_KEY_BACKENDS } from '../../../lib/ai-client/types.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 
-// Single source of truth for backend ids (lib/ai-client, t/958). Prevents the local
-// drift that broke things when 'azure' was added to BackendId — this stays in sync
-// automatically. ALL_BACKENDS below is still maintained by hand, but every code path
-// typed as Backend follows BackendId without edits here.
+// Single source of truth for backend ids (lib/ai-client, t/958). Every code path typed
+// as Backend follows BackendId without edits here.
 type Backend = ApiKeyBackend;
 
-const ALL_BACKENDS: Backend[] = ['gemini', 'claude', 'groq', 'openai', 'azure', 'deepseek', 'tavily', 'ollama'];
+// The full set of backends that deleteAllApiKeys/getApiKeySummary/exportKeysForSharing/
+// migrateToSingleKey iterate. Derived from lib/ai-client's canonical, exhaustive
+// ALL_API_KEY_BACKENDS (t/1956). The local list this replaced silently dropped 'zai' and
+// 'moonshot' (t/1957), leaving those keys on disk after a "delete all", because a Backend[]
+// annotation accepts any *subset* of the union so the type gave no warning. The canonical
+// list is built from a Record<ApiKeyBackend, true>, so adding a backend to the union without
+// listing it is a compile error in lib/ai-client — this can't drift again.
+const ALL_BACKENDS: readonly Backend[] = ALL_API_KEY_BACKENDS;
 
 function keyFilePath(backend?: Backend): string {
   const suffix = backend && backend !== 'gemini' ? `-${backend}` : '';

--- a/taxonomy-editor/src/main/ipc/apiKeyHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/apiKeyHandlers.ts
@@ -9,12 +9,13 @@
 import { ipcMain } from 'electron';
 import { storeApiKey, hasApiKey, getApiKeySummary, exportKeysForSharing, importKeysFromSharing, deleteApiKey, deleteAllApiKeys, removeApiKey, getMaskedKeys, loadApiKeys } from '../apiKeyStore.js';
 import type { KeySharePayload } from '../apiKeyStore.js';
+import type { ApiKeyBackend } from '../../../../lib/ai-client/types.js';
 import { probeApiKey, isSupportedProbeBackend } from '../keyProbe.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 
 export function registerApiKeyHandlers(): void {
   ipcMain.handle('set-api-key', (_event, key: string, backend?: string) => {
-    storeApiKey(key, backend as 'gemini' | 'claude' | 'groq' | 'openai' | 'deepseek' | undefined);
+    storeApiKey(key, backend as ApiKeyBackend | undefined);
   });
 
   ipcMain.handle('validate-api-key', async (_event, key: string, backend: string): Promise<{ valid: boolean; error?: string }> => {
@@ -57,7 +58,7 @@ export function registerApiKeyHandlers(): void {
 
   ipcMain.handle('has-api-key', (_event, backend?: string) => {
     if (backend === 'ollama') return true;
-    return hasApiKey(backend as 'gemini' | 'claude' | 'groq' | 'openai' | 'deepseek' | undefined);
+    return hasApiKey(backend as ApiKeyBackend | undefined);
   });
 
   ipcMain.handle('get-api-key-summary', () => {


### PR DESCRIPTION
Fixes t/1957.

`apiKeyStore`'s hand-maintained `ALL_BACKENDS` was missing `zai` and `moonshot`, so **`deleteAllApiKeys()` left those two provider keys on disk** after telling the user every key was deleted (trust/privacy bug). `getApiKeySummary` / `exportKeysForSharing` / `migrateToSingleKey` skipped them too. A `Backend[]` annotation accepts any subset of the union, so TypeScript never warned.

### Fix
`ALL_BACKENDS` is now **derived from `lib/ai-client`'s canonical `ALL_API_KEY_BACKENDS`** (t/1956, landed `1f47aeca`). That list is built from a `Record<ApiKeyBackend, true>`, so adding a backend to the union without listing it is a compile error in `lib/ai-client` — the list is exhaustive by construction and can't drift again.

> t/1956 landed while this fix was in flight, so it adopts the shared export **directly** here rather than via the interim guarded list + follow-up ticket originally flagged on t/1957. **Deviation resolved — AC "list derived from `ALL_API_KEY_BACKENDS`" is fully met, no follow-up needed.**

Also widened the `apiKeyHandlers.ts` `set-api-key`/`has-api-key` casts from a stale 5-member literal to `ApiKeyBackend | undefined`.

### Tests
`Record<ApiKeyBackend, string>` (exhaustive in the test too): store a key for **every** backend → `deleteAllApiKeys()` → assert none remain and no `api-key*.enc` survives; plus zai/moonshot delete/export/migrate regressions and a summary-covers-all check. 14/14 `apiKeyStore` tests pass; `tsc -p tsconfig.main.json` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
