### PR TITLE
fix(ai-models): reconcile fallbackChains to curated catalog (t/1784)

### DIFF
--- a/ai-models.json
+++ b/ai-models.json
@@ -733,17 +733,9 @@
       "gemini-3.5-flash-lite",
       "groq-llama-3.3-70b-versatile"
     ],
-    "gemini-3.5-flash": [
-      "gemini-3.6-flash",
-      "groq-llama-3.3-70b-versatile"
-    ],
     "gemini-3.1-pro-preview": [
       "gemini-3.1-pro-preview",
       "gemini-3.6-flash"
-    ],
-    "gemini-flash-lite-latest": [
-      "gemini-3.5-flash-lite",
-      "groq-llama-3.1-8b-instant"
     ],
     "claude-opus-4-8": [
       "claude-sonnet-4-6",
@@ -759,10 +751,6 @@
     ],
     "groq-llama-3.3-70b-versatile": [
       "groq-llama-3.1-8b-instant",
-      "gemini-3.6-flash"
-    ],
-    "groq-llama-4-scout-17b-16e": [
-      "groq-llama-3.3-70b-versatile",
       "gemini-3.6-flash"
     ],
     "groq-openai-gpt-oss-120b": [
@@ -789,16 +777,8 @@
       "gemini-3.5-flash-lite",
       "groq-llama-3.1-8b-instant"
     ],
-    "deepseek-chat": [
-      "groq-llama-3.3-70b-versatile",
-      "gemini-3.6-flash"
-    ],
-    "deepseek-reasoner": [
-      "deepseek-chat",
-      "gemini-3.1-pro-preview"
-    ],
     "deepseek-deepseek-v4-flash": [
-      "deepseek-chat",
+      "deepseek-deepseek-v4-pro",
       "gemini-3.6-flash"
     ],
     "zai-glm-5-2": [


### PR DESCRIPTION
Removes 5 dangling fallbackChains keys (gemini-3.5-flash, gemini-flash-lite-latest, groq-llama-4-scout-17b-16e, deepseek-chat, deepseek-reasoner) and realigns deepseek-deepseek-v4-flash's fallback from the uncurated deepseek-chat to its curated sibling deepseek-deepseek-v4-pro. Every fallbackChains key + value now resolves to a models[] entry. Dead failover config only — nothing in defaults/debateTiers selects these; validators were warn-only.

Verified: Test-AIModelsConfig Pass (t/1705); configInvariant + zaiFailover + registry TS suites green (t/1729).

Closes t/1784.