### PR TITLE
refactor(server): decompose mergeDumps/buildIndexes/summarizeErrors under complexity threshold (t/1910 batch 1)

### DIFF
--- a/taxonomy-editor/src/server/errorAggregation.ts
+++ b/taxonomy-editor/src/server/errorAggregation.ts
@@ -56,53 +56,60 @@ function startOfUtcDay(ms: number): number {
   return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
 }
 
+const DAY_MS = 86_400_000;
+
+interface ErrorGroup { name: string; message: string; count: number; lastSeen: string; users: Set<string> }
+interface ErrorAccum { today: number; last7d: number; last30d: number; groups: Map<string, ErrorGroup>; byDayMap: Map<string, number> }
+
+/**
+ * Fold one error entry into the running accumulator: window counters, the
+ * name::normalized-message group, and the trailing-30-day byDay bucket. Entries
+ * with an unparseable timestamp are skipped (mirrors the original `continue`).
+ */
+function accumulateErrorEntry(acc: ErrorAccum, e: ErrorEntry, now: number, todayStart: number): void {
+  const ts = Date.parse(String(e.timestamp));
+  if (Number.isNaN(ts)) return;
+
+  if (ts >= todayStart) acc.today++;
+  if (now - ts <= 7 * DAY_MS) acc.last7d++;
+  const within30 = now - ts <= 30 * DAY_MS;
+  if (within30) acc.last30d++;
+
+  const name = String(e.error?.name ?? 'Error');
+  const message = normalizeMessage(String(e.error?.message ?? ''));
+  const groupKey = `${name}::${message}`;
+  let g = acc.groups.get(groupKey);
+  if (!g) { g = { name, message, count: 0, lastSeen: String(e.timestamp), users: new Set() }; acc.groups.set(groupKey, g); }
+  g.count++;
+  if (String(e.timestamp) > g.lastSeen) g.lastSeen = String(e.timestamp);
+  if (e.userId) g.users.add(String(e.userId));
+
+  if (within30) {
+    const date = new Date(ts).toISOString().slice(0, 10);
+    acc.byDayMap.set(date, (acc.byDayMap.get(date) ?? 0) + 1);
+  }
+}
+
 /**
  * Aggregate error entries into the admin summary. Pure (takes `now`) so it's
  * deterministic under test. `today` is calendar-day (UTC midnight); last7d/30d
  * are rolling windows; byDay covers the trailing 30 days.
  */
 export function summarizeErrors(entries: ErrorEntry[], now: number = Date.now()): ErrorSummary {
-  const DAY = 86_400_000;
   const todayStart = startOfUtcDay(now);
-  let today = 0, last7d = 0, last30d = 0;
+  const acc: ErrorAccum = { today: 0, last7d: 0, last30d: 0, groups: new Map(), byDayMap: new Map() };
 
-  interface Group { name: string; message: string; count: number; lastSeen: string; users: Set<string> }
-  const groups = new Map<string, Group>();
-  const byDayMap = new Map<string, number>();
+  for (const e of entries) accumulateErrorEntry(acc, e, now, todayStart);
 
-  for (const e of entries) {
-    const ts = Date.parse(String(e.timestamp));
-    if (Number.isNaN(ts)) continue;
-
-    if (ts >= todayStart) today++;
-    if (now - ts <= 7 * DAY) last7d++;
-    const within30 = now - ts <= 30 * DAY;
-    if (within30) last30d++;
-
-    const name = String(e.error?.name ?? 'Error');
-    const message = normalizeMessage(String(e.error?.message ?? ''));
-    const groupKey = `${name}::${message}`;
-    let g = groups.get(groupKey);
-    if (!g) { g = { name, message, count: 0, lastSeen: String(e.timestamp), users: new Set() }; groups.set(groupKey, g); }
-    g.count++;
-    if (String(e.timestamp) > g.lastSeen) g.lastSeen = String(e.timestamp);
-    if (e.userId) g.users.add(String(e.userId));
-
-    if (within30) {
-      const date = new Date(ts).toISOString().slice(0, 10);
-      byDayMap.set(date, (byDayMap.get(date) ?? 0) + 1);
-    }
-  }
-
-  const topErrors: TopError[] = [...groups.entries()]
+  const topErrors: TopError[] = [...acc.groups.entries()]
     .map(([groupKey, g]) => ({ groupKey, name: g.name, message: g.message, count: g.count, lastSeen: g.lastSeen, affectedUsers: g.users.size }))
     .sort((a, b) => b.count - a.count || b.lastSeen.localeCompare(a.lastSeen));
 
-  const byDay = [...byDayMap.entries()]
+  const byDay = [...acc.byDayMap.entries()]
     .map(([date, count]) => ({ date, count }))
     .sort((a, b) => a.date.localeCompare(b.date));
 
-  return { total: entries.length, today, last7d, last30d, topErrors, byDay };
+  return { total: entries.length, today: acc.today, last7d: acc.last7d, last30d: acc.last30d, topErrors, byDay };
 }
 
 // ── 30s summary cache (proxyTiers.ts pattern) ──────────────────────────────

--- a/taxonomy-editor/src/server/flightRecorderDumps.ts
+++ b/taxonomy-editor/src/server/flightRecorderDumps.ts
@@ -224,13 +224,8 @@ function parseDumpNdjson(ndjson: string): ParsedDump {
  * Events are sorted by `_wall` timestamp and tagged with `_source` and `_merged_seq`.
  * Mirrors the `Merge-FlightRecorderDumps` PowerShell cmdlet.
  */
-export function mergeDumps(clientNdjson: string | null, serverNdjson: string | null): string {
-  const client = clientNdjson ? parseDumpNdjson(clientNdjson) : null;
-  const server = serverNdjson ? parseDumpNdjson(serverNdjson) : null;
-
-  const lines: string[] = [];
-
-  // Merged header
+/** Merged header line: overall metadata + per-source timestamps/capacity. */
+function buildMergedHeaderLine(client: ParsedDump | null, server: ParsedDump | null): string {
   const mergedHeader: Record<string, unknown> = {
     _type: 'header',
     merged: true,
@@ -247,9 +242,12 @@ export function mergeDumps(clientNdjson: string | null, serverNdjson: string | n
     mergedHeader[`${src}_retained`] = h.retained;
     mergedHeader[`${src}_lost`] = h.lost;
   }
-  lines.push(JSON.stringify(mergedHeader));
+  return JSON.stringify(mergedHeader);
+}
 
-  // Merged dictionary — deduplicate by category:value
+/** Merged dictionary lines — deduplicate by category:value, re-handle sequentially. */
+function buildMergedDictionaryLines(client: ParsedDump | null, server: ParsedDump | null): string[] {
+  const lines: string[] = [];
   const seen = new Set<string>();
   let handle = 0;
   for (const [src, dump] of [['client', client], ['server', server]] as const) {
@@ -261,8 +259,11 @@ export function mergeDumps(clientNdjson: string | null, serverNdjson: string | n
       lines.push(JSON.stringify({ ...entry, handle: handle++, source: src }));
     }
   }
+  return lines;
+}
 
-  // Merged context — union fields, track provenance
+/** Merged context line — union fields across sources, track per-source provenance. */
+function buildMergedContextLine(client: ParsedDump | null, server: ParsedDump | null): string {
   const mergedCtx: Record<string, unknown> = { _type: 'context' };
   const clientFields: string[] = [];
   const serverFields: string[] = [];
@@ -276,9 +277,11 @@ export function mergeDumps(clientNdjson: string | null, serverNdjson: string | n
   }
   mergedCtx._client_fields = clientFields;
   mergedCtx._server_fields = serverFields;
-  lines.push(JSON.stringify(mergedCtx));
+  return JSON.stringify(mergedCtx);
+}
 
-  // Interleave events by _wall timestamp
+/** Interleave events from both sources by _wall timestamp, stamping _merged_seq. */
+function buildInterleavedEventLines(client: ParsedDump | null, server: ParsedDump | null): string[] {
   const allEvents: Record<string, unknown>[] = [];
   if (client) for (const e of client.events) allEvents.push({ ...e, _source: 'client' });
   if (server) for (const e of server.events) allEvents.push({ ...e, _source: 'server' });
@@ -287,14 +290,34 @@ export function mergeDumps(clientNdjson: string | null, serverNdjson: string | n
     const wb = typeof b._wall === 'string' ? b._wall : '';
     return wa < wb ? -1 : wa > wb ? 1 : 0;
   });
+  const lines: string[] = [];
   for (let i = 0; i < allEvents.length; i++) {
     allEvents[i]._merged_seq = i;
     lines.push(JSON.stringify(allEvents[i]));
   }
+  return lines;
+}
 
-  // Triggers from both sources
+/** Trigger lines from both sources, tagged with provenance. */
+function buildTriggerLines(client: ParsedDump | null, server: ParsedDump | null): string[] {
+  const lines: string[] = [];
   if (client) for (const t of client.triggers) lines.push(JSON.stringify({ ...t, _source: 'client' }));
   if (server) for (const t of server.triggers) lines.push(JSON.stringify({ ...t, _source: 'server' }));
+  return lines;
+}
+
+export function mergeDumps(clientNdjson: string | null, serverNdjson: string | null): string {
+  const client = clientNdjson ? parseDumpNdjson(clientNdjson) : null;
+  const server = serverNdjson ? parseDumpNdjson(serverNdjson) : null;
+
+  // Section order is the dump contract: header → dictionary → context → events → triggers.
+  const lines: string[] = [
+    buildMergedHeaderLine(client, server),
+    ...buildMergedDictionaryLines(client, server),
+    buildMergedContextLine(client, server),
+    ...buildInterleavedEventLines(client, server),
+    ...buildTriggerLines(client, server),
+  ];
 
   return lines.join('\n') + '\n';
 }

--- a/taxonomy-editor/src/server/organizations.ts
+++ b/taxonomy-editor/src/server/organizations.ts
@@ -35,29 +35,35 @@ function emptyIndexes(): OrgIndexes {
   return { all: [], byId: new Map(), byTopic: new Map(), byPolicy: new Map(), edgesByOrg: new Map() };
 }
 
+/** Index one org into byId + the topic/policy reverse maps. */
+function indexOrg(idx: OrgIndexes, org: Organization): void {
+  if (typeof org?.id === 'string') idx.byId.set(org.id, org);
+  for (const t of org.topic_engagement ?? []) {
+    if (!t?.topic_ref) continue;
+    (idx.byTopic.get(t.topic_ref) ?? idx.byTopic.set(t.topic_ref, []).get(t.topic_ref)!).push(org);
+  }
+  for (const p of org.policy_engagement ?? []) {
+    if (!p?.policy_ref) continue;
+    (idx.byPolicy.get(p.policy_ref) ?? idx.byPolicy.set(p.policy_ref, []).get(p.policy_ref)!).push(org);
+  }
+}
+
+/** Index one edge under its source, and (for org-to-org edges) under its target too. */
+function indexEdge(idx: OrgIndexes, e: OrganizationEdge): void {
+  if (!e || typeof e.source !== 'string') return;
+  (idx.edgesByOrg.get(e.source) ?? idx.edgesByOrg.set(e.source, []).get(e.source)!).push(e);
+  // Org-to-org edges (ALLIED_WITH/COMPETES_WITH/FUNDS) are indexed under the target too,
+  // so an org sees incoming relationships, not just the ones it's the source of.
+  if (typeof e.target === 'string' && e.target.startsWith('org-') && e.target !== e.source) {
+    (idx.edgesByOrg.get(e.target) ?? idx.edgesByOrg.set(e.target, []).get(e.target)!).push(e);
+  }
+}
+
 function buildIndexes(orgs: Organization[], edges: OrganizationEdge[]): OrgIndexes {
   const idx = emptyIndexes();
   idx.all = orgs;
-  for (const org of orgs) {
-    if (typeof org?.id === 'string') idx.byId.set(org.id, org);
-    for (const t of org.topic_engagement ?? []) {
-      if (!t?.topic_ref) continue;
-      (idx.byTopic.get(t.topic_ref) ?? idx.byTopic.set(t.topic_ref, []).get(t.topic_ref)!).push(org);
-    }
-    for (const p of org.policy_engagement ?? []) {
-      if (!p?.policy_ref) continue;
-      (idx.byPolicy.get(p.policy_ref) ?? idx.byPolicy.set(p.policy_ref, []).get(p.policy_ref)!).push(org);
-    }
-  }
-  for (const e of edges) {
-    if (!e || typeof e.source !== 'string') continue;
-    (idx.edgesByOrg.get(e.source) ?? idx.edgesByOrg.set(e.source, []).get(e.source)!).push(e);
-    // Org-to-org edges (ALLIED_WITH/COMPETES_WITH/FUNDS) are indexed under the target too,
-    // so an org sees incoming relationships, not just the ones it's the source of.
-    if (typeof e.target === 'string' && e.target.startsWith('org-') && e.target !== e.source) {
-      (idx.edgesByOrg.get(e.target) ?? idx.edgesByOrg.set(e.target, []).get(e.target)!).push(e);
-    }
-  }
+  for (const org of orgs) indexOrg(idx, org);
+  for (const e of edges) indexEdge(idx, e);
   return idx;
 }
 


### PR DESCRIPTION
## t/1910 core-layer slice — batch 1 (non-auth data processors)

ADR-007 verbatim decomposition, behavior-preserving (section/loop bodies moved verbatim into named module-level helpers; call order + early-return control flow unchanged):

| function | before | after | helpers |
|---|---:|---:|---|
| `flightRecorderDumps.mergeDumps` | 32 | ~3 | 5 section builders (header/dictionary/context/events/triggers) |
| `organizations.buildIndexes` | 22 | ~3 | `indexOrg` + `indexEdge` |
| `errorAggregation.summarizeErrors` | 16 | ~3 | `accumulateErrorEntry` accumulator |

**Verify:** tsc (`tsconfig.server.json` + `tsconfig.main.json`) rc=0, eslint 0 warnings/0 errors on changed files, 40 covering tests green (flightRecorderDumps/organizations/errorAggregation).

Shared `--max-warnings` gate untouched (per parent t/1848 — epic-level budget).