### PR TITLE
refactor(server): decompose httpKit.error/featureFlags.setFlag under complexity threshold (t/1910 batch 2)

### DIFF
--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -249,12 +249,10 @@ export function listFlags(): FlagDef[] {
   return Object.values(getConfig().flags);
 }
 
-/** Create or update a flag (admin). Persists + appends audit. Returns the def. */
-export function setFlag(name: string, patch: Partial<FlagDef>, by = '_local'): FlagDef {
-  const config = { flags: { ...getConfig().flags } };
-  const before = config.flags[name] ?? null;
-  const now = new Date().toISOString();
-  const def: FlagDef = {
+/** Merge a patch over the existing flag def (or defaults), producing the new def.
+ *  Field precedence: patch → existing → default; timestamps/creator preserved. */
+function mergeFlagDef(name: string, patch: Partial<FlagDef>, before: FlagDef | null, now: string, by: string): FlagDef {
+  return {
     name,
     enabled: patch.enabled ?? before?.enabled ?? false,
     scope: patch.scope ?? before?.scope ?? 'global',
@@ -264,6 +262,14 @@ export function setFlag(name: string, patch: Partial<FlagDef>, by = '_local'): F
     created_by: before?.created_by ?? by,
     expires_at: patch.expires_at !== undefined ? patch.expires_at : before?.expires_at,
   };
+}
+
+/** Create or update a flag (admin). Persists + appends audit. Returns the def. */
+export function setFlag(name: string, patch: Partial<FlagDef>, by = '_local'): FlagDef {
+  const config = { flags: { ...getConfig().flags } };
+  const before = config.flags[name] ?? null;
+  const now = new Date().toISOString();
+  const def = mergeFlagDef(name, patch, before, now, by);
   config.flags[name] = def;
   persist(config);
   appendAudit({ timestamp: now, action: 'set', flag: name, by, before, after: def });

--- a/taxonomy-editor/src/server/httpKit.ts
+++ b/taxonomy-editor/src/server/httpKit.ts
@@ -26,6 +26,31 @@ export function json(res: ServerResponse, data: unknown, status = 200): void {
   res.end(JSON.stringify(data));
 }
 
+// t/1379: record 4xx client errors to the flight recorder (warn — expected
+// client errors, not server faults) so a client-side 4xx can be correlated with
+// server state by requestId. Server-side dump only; never leaked to the client.
+function recordClientError(res: ServerResponse, route: string, status: number, message: string): void {
+  getGlobalRecorder()?.record({
+    type: 'lifecycle', component: 'server', level: 'warn',
+    message: `${route}: ${status} client error`,
+    data: {
+      method: (res as unknown as { req?: { method?: string } }).req?.method,
+      path: route, status, requestId: getRequestId(), errorMessage: message,
+    },
+  });
+}
+
+// Prod 5xx: record the real detail server-side (withheld from the client body).
+function recordServerError(route: string, status: number, message: string, cause: unknown): void {
+  getGlobalRecorder()?.record({
+    type: 'system.error',
+    component: route,
+    level: 'error',
+    message: `${route}: server error (detail withheld from client)`,
+    error: { name: (cause as Error)?.name ?? 'Error', message, stack: (cause as Error)?.stack },
+  });
+}
+
 export function error(res: ServerResponse, message: string, status = 500, cause?: unknown): void {
   // M4: don't leak internal detail (file paths, stack) to clients on server
   // errors in production — record the real message server-side, return generic.
@@ -43,27 +68,11 @@ export function error(res: ServerResponse, message: string, status = 500, cause?
   if (status >= 500) {
     log.server.error({ component: route, status, err: cause }, `${route}: server error (${status}) — ${message}`);
   }
-  // t/1379: record 4xx client errors to the flight recorder (warn — expected
-  // client errors, not server faults) so a client-side 4xx can be correlated with
-  // server state by requestId. Server-side dump only; never leaked to the client.
   if (status >= 400 && status < 500) {
-    getGlobalRecorder()?.record({
-      type: 'lifecycle', component: 'server', level: 'warn',
-      message: `${route}: ${status} client error`,
-      data: {
-        method: (res as unknown as { req?: { method?: string } }).req?.method,
-        path: route, status, requestId: getRequestId(), errorMessage: message,
-      },
-    });
+    recordClientError(res, route, status, message);
   }
   if (status >= 500 && process.env.NODE_ENV === 'production') {
-    getGlobalRecorder()?.record({
-      type: 'system.error',
-      component: route,
-      level: 'error',
-      message: `${route}: server error (detail withheld from client)`,
-      error: { name: (cause as Error)?.name ?? 'Error', message, stack: (cause as Error)?.stack },
-    });
+    recordServerError(route, status, message, cause);
     json(res, { error: 'Internal server error', requestId: getRequestId() }, status);
     return;
   }


### PR DESCRIPTION
## t/1910 core-layer slice — batch 2 (non-auth)

ADR-007 verbatim decomposition, behavior-preserving:

| function | before | after | helpers |
|---|---:|---:|---|
| `httpKit.error` | 16 | ~8 | extract `recordClientError` + `recordServerError` side-effects; status-branch skeleton + idempotent-write guard unchanged |
| `featureFlags.setFlag` | 17 | ~2 | extract `mergeFlagDef` patch-merge literal; persist/audit unchanged |

**Verify:** tsc (`tsconfig.server.json`) rc=0, eslint 0 warnings/0 errors on changed files, 25 covering tests green (httpKit/featureFlags).

Shared `--max-warnings` gate untouched. Follows batch 1 (#143, merged 5b225335).