### PR TITLE
fix(taxonomy-editor): coerce polymorphic entity aliases + source_refs (array|null|string) (t/1884, t/1882)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.test.tsx
@@ -45,6 +45,20 @@ function options() {
 }
 
 describe('EntityBrowserPanel', () => {
+  it('does not crash when an entity has aliases:null (real-data defect, t/1884#3)', async () => {
+    // ~40% of real entities carry aliases:null despite the string[] type. Exercises the
+    // row [0] read AND the search .some() path — both must survive null.
+    listEntitiesMock.mockResolvedValue([
+      { id: 'ent-034', name: 'Claude', aliases: null as unknown as string[], entity_type: 'artifact', status: 'approved', confidence: 0.9, last_modified: '2026-02-01' },
+    ]);
+    const user = userEvent.setup();
+    render(<EntityBrowserPanel />);
+    expect(await screen.findByText('Claude')).toBeInTheDocument();
+    expect(options()).toHaveLength(1);
+    await user.type(screen.getByLabelText('Search entities'), 'anything'); // .some over null must not throw
+    expect(screen.getByText('No entities match')).toBeInTheDocument();
+  });
+
   it('lists all entities and shows the total count', async () => {
     render(<EntityBrowserPanel />);
     expect(await screen.findByText('OpenAI')).toBeInTheDocument();

--- a/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.test.tsx
@@ -45,18 +45,23 @@ function options() {
 }
 
 describe('EntityBrowserPanel', () => {
-  it('does not crash when an entity has aliases:null (real-data defect, t/1884#3)', async () => {
-    // ~40% of real entities carry aliases:null despite the string[] type. Exercises the
-    // row [0] read AND the search .some() path — both must survive null.
+  it('survives polymorphic aliases (array|null|string) and shows a bare-string alias in full (t/1884#4)', async () => {
+    // aliases is array(24)|null(32)|bare-string(22) in real data despite the string[] type.
+    // Exercises the row [0] read AND the search .some() path for null AND string.
     listEntitiesMock.mockResolvedValue([
       { id: 'ent-034', name: 'Claude', aliases: null as unknown as string[], entity_type: 'artifact', status: 'approved', confidence: 0.9, last_modified: '2026-02-01' },
+      { id: 'ent-071', name: 'GDPR', aliases: 'General Data Protection Regulation' as unknown as string[], entity_type: 'legislation', status: 'approved', confidence: 0.8, last_modified: '2026-02-01' },
     ]);
     const user = userEvent.setup();
     render(<EntityBrowserPanel />);
     expect(await screen.findByText('Claude')).toBeInTheDocument();
+    expect(options()).toHaveLength(2);
+    // a bare-string alias renders in FULL, not sliced to its first character ("also: G")
+    expect(screen.getByText('also: General Data Protection Regulation')).toBeInTheDocument();
+    // search over polymorphic aliases (the .some path) must not throw for null OR string
+    await user.type(screen.getByLabelText('Search entities'), 'protection');
+    expect(await screen.findByText('GDPR')).toBeInTheDocument();
     expect(options()).toHaveLength(1);
-    await user.type(screen.getByLabelText('Search entities'), 'anything'); // .some over null must not throw
-    expect(screen.getByText('No entities match')).toBeInTheDocument();
   });
 
   it('lists all entities and shows the total count', async () => {

--- a/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.tsx
@@ -13,6 +13,7 @@ import { api } from '@bridge';
 import type { EntitySummary, EntityRef, EntityType, Entity } from '@lib/entities/types';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { TypeBadge } from './DetailPrimitives';
+import { coerceStringArray } from './coerceStringArray';
 import { DetailPane } from './DetailPane';
 import { EmptyState } from './EmptyState';
 import './EntityBrowserPanel.css';
@@ -45,9 +46,9 @@ function matchesSearch(e: EntitySummary, q: string): boolean {
     e.name.toLowerCase().includes(q) ||
     e.id.toLowerCase().includes(q) ||
     e.entity_type.toLowerCase().includes(q) ||
-    // Defensive: real data has aliases:null on ~40% of entities despite the string[]
-    // type (t/1884#3); server normalization is the complementary fix.
-    (e.aliases ?? []).some(a => a.toLowerCase().includes(q))
+    // aliases is polymorphic in real data (array | string | null) despite the string[]
+    // type — coerce (t/1884#4); server normalization (t/1964) is the load-bearing fix.
+    coerceStringArray(e.aliases).some(a => a.toLowerCase().includes(q))
   );
 }
 
@@ -64,7 +65,7 @@ function compareEntities(a: EntitySummary, b: EntitySummary, sort: SortKey): num
 
 /** One entity row — role=option; compact name + type badge + status dot + muted alias line. */
 function EntityRow({ entity, selected, onSelect }: { entity: EntitySummary; selected: boolean; onSelect: () => void }) {
-  const alias = entity.aliases?.[0]; // aliases can be null in real data despite the string[] type (t/1884#3)
+  const alias = coerceStringArray(entity.aliases)[0]; // aliases is polymorphic (array|string|null) — coerce, so a bare string isn't sliced to its first char (t/1884#4)
   return (
     <li
       id={`ebp-opt-${entity.id}`}

--- a/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.tsx
@@ -45,7 +45,9 @@ function matchesSearch(e: EntitySummary, q: string): boolean {
     e.name.toLowerCase().includes(q) ||
     e.id.toLowerCase().includes(q) ||
     e.entity_type.toLowerCase().includes(q) ||
-    e.aliases.some(a => a.toLowerCase().includes(q))
+    // Defensive: real data has aliases:null on ~40% of entities despite the string[]
+    // type (t/1884#3); server normalization is the complementary fix.
+    (e.aliases ?? []).some(a => a.toLowerCase().includes(q))
   );
 }
 
@@ -62,7 +64,7 @@ function compareEntities(a: EntitySummary, b: EntitySummary, sort: SortKey): num
 
 /** One entity row — role=option; compact name + type badge + status dot + muted alias line. */
 function EntityRow({ entity, selected, onSelect }: { entity: EntitySummary; selected: boolean; onSelect: () => void }) {
-  const alias = entity.aliases[0];
+  const alias = entity.aliases?.[0]; // aliases can be null in real data despite the string[] type (t/1884#3)
   return (
     <li
       id={`ebp-opt-${entity.id}`}

--- a/taxonomy-editor/src/renderer/components/shared/EntityDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityDetail.test.tsx
@@ -34,11 +34,23 @@ const fullEntity: Entity = {
 };
 
 describe('EntityDetail', () => {
-  it('does not crash when aliases is null (real-data defect, t/1884#3)', () => {
-    // ent-034 "Claude" (the mention target) has aliases:null despite the string[] type.
-    render(<EntityDetail entity={{ ...fullEntity, aliases: null as unknown as string[] }} />);
+  it('survives polymorphic aliases + source_refs (array|null|string) — no throw (t/1882#7)', () => {
+    // ent-034 "Claude" has aliases:null; 11 entities have source_refs as a bare string —
+    // both despite the string[] type. `.length`/`.map`/`.join` must not throw.
+    render(<EntityDetail entity={{
+      ...fullEntity,
+      aliases: null as unknown as string[],
+      source_refs: 'eu-ai-act-analysis' as unknown as string[],
+    }} />);
     expect(screen.getByRole('heading', { name: 'OpenAI' })).toBeInTheDocument();
-    expect(screen.queryByText(/^also:/)).not.toBeInTheDocument(); // no alias row, no throw
+    expect(screen.queryByText(/^also:/)).not.toBeInTheDocument(); // null aliases → no row
+    // a bare-string source_refs → exactly one chip with the full doc id (not char-sliced)
+    expect(screen.getByText('doc: eu-ai-act-analysis')).toBeInTheDocument();
+  });
+
+  it('renders a bare-string alias in full, not sliced to a character (t/1884#4)', () => {
+    render(<EntityDetail entity={{ ...fullEntity, aliases: 'GDPR' as unknown as string[] }} />);
+    expect(screen.getByText('also: GDPR')).toBeInTheDocument();
   });
 
   it('renders the full field set', () => {

--- a/taxonomy-editor/src/renderer/components/shared/EntityDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityDetail.test.tsx
@@ -34,6 +34,13 @@ const fullEntity: Entity = {
 };
 
 describe('EntityDetail', () => {
+  it('does not crash when aliases is null (real-data defect, t/1884#3)', () => {
+    // ent-034 "Claude" (the mention target) has aliases:null despite the string[] type.
+    render(<EntityDetail entity={{ ...fullEntity, aliases: null as unknown as string[] }} />);
+    expect(screen.getByRole('heading', { name: 'OpenAI' })).toBeInTheDocument();
+    expect(screen.queryByText(/^also:/)).not.toBeInTheDocument(); // no alias row, no throw
+  });
+
   it('renders the full field set', () => {
     render(<EntityDetail entity={fullEntity} />);
     expect(screen.getByRole('heading', { name: 'OpenAI' })).toBeInTheDocument();

--- a/taxonomy-editor/src/renderer/components/shared/EntityDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityDetail.tsx
@@ -64,8 +64,8 @@ export function EntityDetail({ entity, redirectedFrom }: { entity: Entity; redir
           <TypeBadge type={entity_type} />
           <span className="ed-dolce-chip" title={dolce_category}>{humanizeDolce(dolce_category)}</span>
         </div>
-        {aliases.length > 0 && (
-          <div className="ed-aliases">also: {aliases.join(', ')}</div>
+        {(aliases ?? []).length > 0 && (
+          <div className="ed-aliases">also: {(aliases ?? []).join(', ')}</div>
         )}
         <div className="ed-status-row">
           <span className={`ed-status-pill ed-status-${status}`}>{STATUS_LABEL[status]}</span>

--- a/taxonomy-editor/src/renderer/components/shared/EntityDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityDetail.tsx
@@ -11,6 +11,7 @@
 
 import type { Entity } from '@lib/entities/types';
 import { TypeBadge, ExternalLinkRow } from './DetailPrimitives';
+import { coerceStringArray } from './coerceStringArray';
 import './EntityDetail.css';
 
 const STATUS_LABEL: Record<Entity['status'], string> = {
@@ -46,6 +47,10 @@ function EntityProvenanceFooter({ discovered_by, confidence }: Pick<Entity, 'dis
 
 export function EntityDetail({ entity, redirectedFrom }: { entity: Entity; redirectedFrom?: string }) {
   const { name, entity_type, dolce_category, aliases, status, description, external_refs, source_refs, discovered_by, confidence } = entity;
+  // aliases + source_refs are both polymorphic in real data (array|string|null) despite
+  // their string[] types — coerce before render (t/1882#7 / t/1884#4).
+  const aliasesArr = coerceStringArray(aliases);
+  const sourceRefsArr = coerceStringArray(source_refs);
 
   return (
     <div className="entity-detail">
@@ -64,8 +69,8 @@ export function EntityDetail({ entity, redirectedFrom }: { entity: Entity; redir
           <TypeBadge type={entity_type} />
           <span className="ed-dolce-chip" title={dolce_category}>{humanizeDolce(dolce_category)}</span>
         </div>
-        {(aliases ?? []).length > 0 && (
-          <div className="ed-aliases">also: {(aliases ?? []).join(', ')}</div>
+        {aliasesArr.length > 0 && (
+          <div className="ed-aliases">also: {aliasesArr.join(', ')}</div>
         )}
         <div className="ed-status-row">
           <span className={`ed-status-pill ed-status-${status}`}>{STATUS_LABEL[status]}</span>
@@ -90,11 +95,11 @@ export function EntityDetail({ entity, redirectedFrom }: { entity: Entity; redir
       {/* Appears in — source docs. Non-interactive labeled chips in P1a: no doc/source
           viewer target exists yet (spec open-Q3), so they are deliberately not clickable
           and not focusable — wiring is a clean follow-up when a target lands. */}
-      {source_refs && source_refs.length > 0 && (
+      {sourceRefsArr.length > 0 && (
         <div>
           <h3 className="ed-section-h3">Appears in</h3>
           <div className="ed-source-chips">
-            {source_refs.map((ref, i) => (
+            {sourceRefsArr.map((ref, i) => (
               <span key={i} className="ed-source-chip" title={ref}>doc: {ref}</span>
             ))}
           </div>

--- a/taxonomy-editor/src/renderer/components/shared/coerceStringArray.test.ts
+++ b/taxonomy-editor/src/renderer/components/shared/coerceStringArray.test.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { coerceStringArray } from './coerceStringArray';
+
+describe('coerceStringArray (polymorphic aliases/source_refs, t/1882#7 / t/1884#4)', () => {
+  it('returns an array unchanged', () => {
+    expect(coerceStringArray(['a', 'b'])).toEqual(['a', 'b']);
+  });
+  it('null / undefined → []', () => {
+    expect(coerceStringArray(null)).toEqual([]);
+    expect(coerceStringArray(undefined)).toEqual([]);
+  });
+  it('an empty array → []', () => {
+    expect(coerceStringArray([])).toEqual([]);
+  });
+  it('a bare string → single-element array (NOT split into characters)', () => {
+    expect(coerceStringArray('GDPR')).toEqual(['GDPR']);
+    expect(coerceStringArray('GDPR')[0]).toBe('GDPR'); // not "G"
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/coerceStringArray.ts
+++ b/taxonomy-editor/src/renderer/components/shared/coerceStringArray.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Coerce a polymorphic real-world entity field into a `string[]`.
+ *
+ * Two `Entity` fields typed `string[]` are polymorphic in the stored data (Design field
+ * audit, t/1882#7 / t/1884#4): `aliases` is array(24) | null(32) | bare-string(22, e.g.
+ * "GDPR"), and `source_refs` is array(67) | bare-string(11). A `?? []` guard only fixes
+ * null; a bare string still throws on `.some`/`.map`/`.join`, and `field[0]` on a string
+ * yields its first CHARACTER. This normalizes all shapes. (Design confirmed these two are
+ * the ONLY varying UI-rendered fields.) The load-bearing fix is server-side normalization
+ * at the endpoint (t/1964); this is renderer defense-in-depth — don't assume array.
+ */
+export function coerceStringArray(value: string[] | string | null | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  if (value == null) return [];
+  return [value]; // a bare string is one element, not an array of characters
+}


### PR DESCRIPTION
## Problem

Design found a production crash in the entity renderers (t/1884#3, t/1882#7): `aliases` and `source_refs` are typed `string[]`, but real data has them **polymorphic** — `array | null | bare-string`. The bare-string case is the sharp edge:
- `EntityBrowserPanel` — `.some()` on the search path and `aliases[0]` in the row both crash / mis-slice (a bare string `"GDPR"` rendered as `also: G`).
- `EntityDetail` — `source_refs.map()` and `aliases.join()` crash on a string.

A null-only guard (`?? []`) is insufficient — it doesn't cover the bare-string case.

## Fix

New shared helper `coerceStringArray(value)` → returns arrays unchanged, `[]` for null/undefined, and `[value]` for a bare string (so it isn't split into characters). Applied at every read site:
- `EntityBrowserPanel`: search `.some()` + row alias `[0]`
- `EntityDetail`: `aliases` (join) + `source_refs` (map)

Design confirmed the full audit: **only `aliases` + `source_refs`** vary. The load-bearing server-side normalization is tracked separately as t/1964 (ServerAPI).

## Tests

- `coerceStringArray.test.ts` — unit (array / null / undefined / empty / bare-string → not char-split)
- `EntityBrowserPanel.test.tsx` — polymorphic aliases: null + bare-string renders in full, search `.some` survives both
- `EntityDetail.test.tsx` — null aliases + bare-string `source_refs` (one chip, full id); bare-string alias in full

Tickets: t/1884#4, t/1882#7
