### PR TITLE
refactor(storage): t/1921 Batch C — reduce GitHubRestClient.request complexity 45→13

### DIFF
--- a/taxonomy-editor/src/server/storage/LAST_SESSION.md
+++ b/taxonomy-editor/src/server/storage/LAST_SESSION.md
@@ -1,5 +1,21 @@
-**Date:** 2026-07-20
-**Working on:** t/1635 — version-aware read-merge-write for delta debate save (parent t/1470, HLD docs/hld-delta-debate-save.md)
-**Status:** DONE — landed via /land-from-worktree as dd9bb109 on origin/main. applyDebateDeltaToStorage(delta) + debateVersionConflict helper in fileIO.ts; 6-test suite in src/server/__tests__/applyDebateDeltaToStorage.test.ts (all pass). verify gate green on committed code. No design deviations.
-**Key context:** Test lives in src/server/__tests__/ (NOT storage/__tests__/) — MemoryBackend + fileIO.setTaxonomyBackend/setUserContentBackend + userContext.runWithUser, no vi.mock. 409 via Object.assign(new ActionableError,{statusCode,code:'version_conflict',currentVersion}); missing blob → currentVersion:null (client full-PUT self-heals); anon path mirrors into anonStore. applyDebateDelta imported from lib/debate (t/1634, DebateTool scope).
-**Next:** Ticket B done. Client half (delta-send + 409 full-PUT fallback) is renderer/Sync scope — not ours. No open Server Storage work.
+**Date:** 2026-07-29
+**Working on:** t/1921 — Reduce eslint complexity warnings in server/storage/ (ADR-007 helper extractions)
+**Status:** Batch A DONE (PR #135, `4f68d4ae`). Batch B DONE (PR #140, `68a229e5`). Batch C PR open (#147, `9a1e7e28`).
+
+**Batch A landed:**
+- fileIO.ts: `findGraphAttributeMismatches` 17→7, `buildNodeSourceIndex` 26→2, `buildPolicySourceIndex` 27→4
+- debateStore.ts: `applyDebateDeltaToStorage` 22→7
+
+**Batch B landed:**
+- editMeta.ts: `stampNodeAuthorship` map callback 29→6 (`restoreUnchangedStamps`+`buildEditMeta`+`buildHistoryEntry`)
+
+**Batch C (PR #147, awaiting CI):**
+- githubRestClient.ts: `request` 45→13 (7 helpers: `recordAttempt`, `buildRequestHeaders`, `handleNotModified`, `parseAndLogResponse`, `extractApiMessage`, `handleNonOkStatus`, `handleNetworkError`)
+- `NonOkOutcome` union type at module scope carries retry/return signal
+
+**Remaining:**
+- Batch D: githubAPIBackend.ts `listDirectory@16` (coordinate LOC impact with t/1688 exception)
+
+**Landing procedure (e/49/e/50):** PR-flow is CONVENTION not platform hard-block. Always land via feature branch → `gh pr create` → 6 checks → `gh pr merge --rebase --delete-branch`. From detached HEAD: push as `HEAD:refs/heads/<branch>` (fully-qualified).
+
+**Prior sessions:** t/1941 edges serializer (`dcd54936`); t/1895 mention read path (`84cb675b`); t/1807 entity read path (`1d2d9111`); t/1688 fileIO+githubAPIBackend split (`c2ea5c7e`).

--- a/taxonomy-editor/src/server/storage/githubRestClient.ts
+++ b/taxonomy-editor/src/server/storage/githubRestClient.ts
@@ -137,6 +137,13 @@ export class GitHubRestClient {
         if (outcome.delayMs) await this.sleep(outcome.delayMs);
 
       } catch (err: unknown) {
+        getGlobalRecorder()?.record({
+          type: 'system.error',
+          component: 'github-api',
+          level: 'error',
+          message: 'Operation failed',
+          error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+        });
         const networkResult = await this.handleNetworkError(
           err, startMs, method, pathAndQuery, attempt, callId, requestId,
         );
@@ -273,13 +280,6 @@ export class GitHubRestClient {
     err: unknown, startMs: number, method: string, pathAndQuery: string,
     attempt: number, callId: string | undefined, requestId: string,
   ): Promise<ApiResult | null> {
-    getGlobalRecorder()?.record({
-      type: 'system.error',
-      component: 'github-api',
-      level: 'error',
-      message: 'Operation failed',
-      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-    });
     const durationMs = Date.now() - startMs;
     this.deps.record({
       type: 'github.api.error',

--- a/taxonomy-editor/src/server/storage/githubRestClient.ts
+++ b/taxonomy-editor/src/server/storage/githubRestClient.ts
@@ -73,6 +73,10 @@ export function normalizeErrorForEvent(err: unknown): { name: string; message: s
   return { name: 'Error', message: String(err) };
 }
 
+type NonOkOutcome =
+  | { action: 'return'; result: ApiResult }
+  | { action: 'retry'; newCreds?: SyncCredentials; delayMs?: number };
+
 export class GitHubRestClient {
   // Rate limit tracking
   private rateLimit: RateLimitInfo = { remaining: 5000, limit: 5000, resetsAt: 0 };
@@ -99,34 +103,11 @@ export class GitHubRestClient {
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       const startMs = Date.now();
-
-      this.deps.record({
-        type: 'github.api.request',
-        component: 'github-api',
-        level: 'debug',
-        message: `${method} ${pathAndQuery}`,
-        call_id: callId,
-        request_id: requestId,
-        data: { method, endpoint: pathAndQuery, attempt },
-      });
+      this.recordAttempt(method, pathAndQuery, attempt, callId, requestId);
 
       try {
         const url = `${GITHUB_API}${pathAndQuery}`;
-        const headers: Record<string, string> = {
-          Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${creds.token}`,
-          'User-Agent': USER_AGENT,
-          'X-GitHub-Api-Version': API_VERSION,
-        };
-        if (body !== undefined) headers['Content-Type'] = 'application/json';
-        if (requestId) headers['X-Request-ID'] = requestId;
-
-        // Add ETag for conditional requests
-        const cachedEtag = this.deps.getEtag(pathAndQuery);
-        if (cachedEtag && method === 'GET') {
-          headers['If-None-Match'] = cachedEtag;
-        }
-
+        const headers = this.buildRequestHeaders(creds, method, pathAndQuery, body, requestId);
         const res = await fetch(url, {
           method,
           headers,
@@ -134,146 +115,189 @@ export class GitHubRestClient {
         });
 
         const durationMs = Date.now() - startMs;
-
-        // Track rate limits from response headers
         this.updateRateLimit(res.headers);
-
-        // ETag from response
         const responseEtag = res.headers.get('etag') ?? undefined;
 
-        // 304 Not Modified — return cached
         if (res.status === 304) {
-          this.deps.record({
-            type: 'github.api.response',
-            component: 'github-api',
-            level: 'debug',
-            duration_ms: durationMs,
-            call_id: callId,
-            request_id: requestId,
-            data: { status: 304, method, endpoint: pathAndQuery, cache_hit: true,
-                    rate_remaining: this.rateLimit.remaining },
-          });
-          this.onApiSuccess();
-          return { ok: true, status: 304, data: null, etag: responseEtag };
+          return this.handleNotModified(durationMs, method, pathAndQuery, callId, requestId, responseEtag);
         }
 
-        // Parse response body
-        const text = await res.text();
-        let data: unknown = null;
-        try { data = text ? JSON.parse(text) : null; } catch { /* telemetry — silent by design */ data = text; }
-
-        const is404Optional = !res.ok && res.status === 404 && apiOpts?.optional;
-        this.deps.record({
-          type: res.ok ? 'github.api.response' : (is404Optional ? 'github.api.miss' : 'github.api.error'),
-          component: 'github-api',
-          level: res.ok ? 'debug' : (is404Optional ? 'debug' : 'error'),
-          duration_ms: durationMs,
-          call_id: callId,
-          request_id: requestId,
-          data: {
-            status: res.status, method, endpoint: pathAndQuery,
-            rate_remaining: this.rateLimit.remaining,
-            ...(res.ok ? {} : { error: text?.slice(0, 500) }),
-          },
-        });
+        const { data, text } = await this.parseAndLogResponse(
+          res, method, pathAndQuery, durationMs, callId, requestId, !!apiOpts?.optional,
+        );
 
         if (res.ok) {
           this.onApiSuccess();
           return { ok: true, status: res.status, data, etag: responseEtag };
         }
 
-        // 404 — not found, don't retry
-        if (res.status === 404) {
-          return { ok: false, status: 404, data, error: 'Not found' };
-        }
-
-        // 401 — token expired, refresh once and retry
-        if (res.status === 401 && attempt === 0) {
-          const freshCreds = await this.deps.refreshCreds();
-          if (freshCreds) {
-            creds = freshCreds;
-            continue; // retry with fresh token
-          }
-        }
-
-        // 409 — conflict (SHA mismatch on write)
-        if (res.status === 409) {
-          return { ok: false, status: 409, data,
-            error: 'Conflict — file was modified concurrently' };
-        }
-
-        // 422 — validation error (branch exists, etc.)
-        if (res.status === 422) {
-          return { ok: false, status: 422, data,
-            error: (data && typeof data === 'object' && 'message' in data)
-              ? String((data as { message: unknown }).message) : 'Validation error' };
-        }
-
-        // 429 — rate limited
-        if (res.status === 429) {
-          this.deps.record({
-            type: 'github.api.rate_limit',
-            component: 'github-api',
-            level: 'warn',
-            message: 'Rate limited by GitHub API',
-            data: { remaining: this.rateLimit.remaining, resetsAt: this.rateLimit.resetsAt },
-          });
-
-          const retryAfter = res.headers.get('retry-after');
-          if (retryAfter && attempt < MAX_RETRIES) {
-            await this.sleep(parseInt(retryAfter, 10) * 1000);
-            continue;
-          }
-        }
-
-        // 5xx — retryable
-        if (res.status >= 500 && attempt < MAX_RETRIES) {
-          this.onApiFailure();
-          await this.sleep(this.backoffMs(attempt));
-          continue;
-        }
-
-        // Other 4xx — not retryable
-        const errorMsg = (data && typeof data === 'object' && 'message' in data)
-          ? String((data as { message: unknown }).message)
-          : text || `HTTP ${res.status}`;
-        this.onApiFailure();
-        return { ok: false, status: res.status, data, error: errorMsg };
+        const outcome = await this.handleNonOkStatus(res, data, text, attempt);
+        if (outcome.action === 'return') return outcome.result;
+        if (outcome.newCreds) creds = outcome.newCreds;
+        if (outcome.delayMs) await this.sleep(outcome.delayMs);
 
       } catch (err: unknown) {
-        getGlobalRecorder()?.record({
-          type: 'system.error',
-          component: 'github-api',
-          level: 'error',
-          message: 'Operation failed',
-          error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-        });
-        // Network error — retryable
-        const durationMs = Date.now() - startMs;
-        this.deps.record({
-          type: 'github.api.error',
-          component: 'github-api',
-          level: 'error',
-          duration_ms: durationMs,
-          call_id: callId,
-          request_id: requestId,
-          error: normalizeErrorForEvent(err),
-          data: { method, endpoint: pathAndQuery, attempt, network_error: true },
-        });
-
-        this.onApiFailure();
-        if (attempt < MAX_RETRIES) {
-          await this.sleep(this.backoffMs(attempt));
-          continue;
-        }
-
-        return { ok: false, status: 0, data: null,
-          error: `Network error: ${err instanceof Error ? err.message : String(err)}` };
+        const networkResult = await this.handleNetworkError(
+          err, startMs, method, pathAndQuery, attempt, callId, requestId,
+        );
+        if (networkResult !== null) return networkResult;
       }
     }
 
     // Should not reach here, but just in case
     return { ok: false, status: 0, data: null, error: 'Max retries exceeded' };
+  }
+
+  private recordAttempt(
+    method: string, pathAndQuery: string, attempt: number,
+    callId: string | undefined, requestId: string,
+  ): void {
+    this.deps.record({
+      type: 'github.api.request',
+      component: 'github-api',
+      level: 'debug',
+      message: `${method} ${pathAndQuery}`,
+      call_id: callId,
+      request_id: requestId,
+      data: { method, endpoint: pathAndQuery, attempt },
+    });
+  }
+
+  private buildRequestHeaders(
+    creds: SyncCredentials, method: string, pathAndQuery: string,
+    body: unknown, requestId: string,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${creds.token}`,
+      'User-Agent': USER_AGENT,
+      'X-GitHub-Api-Version': API_VERSION,
+    };
+    if (body !== undefined) headers['Content-Type'] = 'application/json';
+    if (requestId) headers['X-Request-ID'] = requestId;
+    const cachedEtag = this.deps.getEtag(pathAndQuery);
+    if (cachedEtag && method === 'GET') headers['If-None-Match'] = cachedEtag;
+    return headers;
+  }
+
+  private handleNotModified(
+    durationMs: number, method: string, pathAndQuery: string,
+    callId: string | undefined, requestId: string, responseEtag: string | undefined,
+  ): ApiResult {
+    this.deps.record({
+      type: 'github.api.response',
+      component: 'github-api',
+      level: 'debug',
+      duration_ms: durationMs,
+      call_id: callId,
+      request_id: requestId,
+      data: { status: 304, method, endpoint: pathAndQuery, cache_hit: true,
+              rate_remaining: this.rateLimit.remaining },
+    });
+    this.onApiSuccess();
+    return { ok: true, status: 304, data: null, etag: responseEtag };
+  }
+
+  private async parseAndLogResponse(
+    res: Response, method: string, pathAndQuery: string,
+    durationMs: number, callId: string | undefined, requestId: string, isOptional: boolean,
+  ): Promise<{ data: unknown; text: string }> {
+    const text = await res.text();
+    let data: unknown = null;
+    try { data = text ? JSON.parse(text) : null; } catch { /* telemetry — silent by design */ data = text; }
+
+    const is404Optional = !res.ok && res.status === 404 && isOptional;
+    this.deps.record({
+      type: res.ok ? 'github.api.response' : (is404Optional ? 'github.api.miss' : 'github.api.error'),
+      component: 'github-api',
+      level: res.ok ? 'debug' : (is404Optional ? 'debug' : 'error'),
+      duration_ms: durationMs,
+      call_id: callId,
+      request_id: requestId,
+      data: {
+        status: res.status, method, endpoint: pathAndQuery,
+        rate_remaining: this.rateLimit.remaining,
+        ...(res.ok ? {} : { error: text?.slice(0, 500) }),
+      },
+    });
+    return { data, text };
+  }
+
+  private extractApiMessage(data: unknown, fallback: string): string {
+    return (data && typeof data === 'object' && 'message' in data)
+      ? String((data as { message: unknown }).message)
+      : fallback;
+  }
+
+  private async handleNonOkStatus(
+    res: Response, data: unknown, text: string, attempt: number,
+  ): Promise<NonOkOutcome> {
+    if (res.status === 404) {
+      return { action: 'return', result: { ok: false, status: 404, data, error: 'Not found' } };
+    }
+    if (res.status === 401 && attempt === 0) {
+      const freshCreds = await this.deps.refreshCreds();
+      if (freshCreds) return { action: 'retry', newCreds: freshCreds };
+    }
+    if (res.status === 409) {
+      return { action: 'return', result: { ok: false, status: 409, data,
+        error: 'Conflict — file was modified concurrently' } };
+    }
+    if (res.status === 422) {
+      return { action: 'return', result: { ok: false, status: 422, data,
+        error: this.extractApiMessage(data, 'Validation error') } };
+    }
+    if (res.status === 429) {
+      this.deps.record({
+        type: 'github.api.rate_limit',
+        component: 'github-api',
+        level: 'warn',
+        message: 'Rate limited by GitHub API',
+        data: { remaining: this.rateLimit.remaining, resetsAt: this.rateLimit.resetsAt },
+      });
+      const retryAfter = res.headers.get('retry-after');
+      if (retryAfter && attempt < MAX_RETRIES) {
+        return { action: 'retry', delayMs: parseInt(retryAfter, 10) * 1000 };
+      }
+    }
+    if (res.status >= 500 && attempt < MAX_RETRIES) {
+      this.onApiFailure();
+      return { action: 'retry', delayMs: this.backoffMs(attempt) };
+    }
+    this.onApiFailure();
+    return { action: 'return', result: { ok: false, status: res.status, data,
+      error: this.extractApiMessage(data, text || `HTTP ${res.status}`) } };
+  }
+
+  private async handleNetworkError(
+    err: unknown, startMs: number, method: string, pathAndQuery: string,
+    attempt: number, callId: string | undefined, requestId: string,
+  ): Promise<ApiResult | null> {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'github-api',
+      level: 'error',
+      message: 'Operation failed',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    const durationMs = Date.now() - startMs;
+    this.deps.record({
+      type: 'github.api.error',
+      component: 'github-api',
+      level: 'error',
+      duration_ms: durationMs,
+      call_id: callId,
+      request_id: requestId,
+      error: normalizeErrorForEvent(err),
+      data: { method, endpoint: pathAndQuery, attempt, network_error: true },
+    });
+    this.onApiFailure();
+    if (attempt < MAX_RETRIES) {
+      await this.sleep(this.backoffMs(attempt));
+      return null; // signal retry
+    }
+    return { ok: false, status: 0, data: null,
+      error: `Network error: ${err instanceof Error ? err.message : String(err)}` };
   }
 
   private backoffMs(attempt: number): number {


### PR DESCRIPTION
## Summary

- `request` method: complexity 45→13 via 7 extracted private helpers
- Helpers: `recordAttempt`, `buildRequestHeaders`, `handleNotModified`, `parseAndLogResponse`, `extractApiMessage`, `handleNonOkStatus`, `handleNetworkError`
- All helpers land under complexity 15
- Verbatim line-slice bodies per ADR-007; only signatures + call sites hand-authored
- New module-level `NonOkOutcome` union type carries retry/return signal from `handleNonOkStatus`
- No behavior change

## Test plan

- [ ] `npx tsc --noEmit -p tsconfig.main.json` — clean ✓
- [ ] `npx tsc --noEmit` (renderer) — clean ✓
- [ ] CI: quality-gates (eslint complexity gate must not ratchet)
- [ ] CI: test-electron (taxonomy-editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)