### PR TITLE
fix(server): normalize polymorphic entity aliases/source_refs at read boundary (t/1964)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/entity.test.ts
+++ b/taxonomy-editor/src/server/__tests__/entity.test.ts
@@ -144,6 +144,36 @@ describe('GET /api/entity/:ref (t/1786)', () => {
     expect(body).not.toHaveProperty('redirected_from');
   });
 
+  it('normalizes polymorphic aliases on the entity record: null → [], bare string → [string] (t/1964)', async () => {
+    // ent-034 "Claude" (the t/1898 mention target) has aliases: null; a bare-string alias
+    // ("GDPR") also occurs. The detail/mention flow reads .some/.length/[0] → must be arrays.
+    readEntityRegistryMock.mockResolvedValue(new Map([
+      ['ent-034', { id: 'ent-034', name: 'Claude', aliases: null } as unknown as Entity],
+      ['ent-071', { id: 'ent-071', name: 'GDPR', aliases: 'GDPR' } as unknown as Entity],
+    ]));
+    const nullCase = await invoke('ent-034');
+    expect(nullCase.status).toBe(200);
+    expect((nullCase.body as { record: Entity }).record.aliases).toEqual([]);
+    const stringCase = await invoke('ent-071');
+    expect(stringCase.status).toBe(200);
+    expect((stringCase.body as { record: Entity }).record.aliases).toEqual(['GDPR']);
+  });
+
+  it('normalizes polymorphic source_refs on the entity record: null → [], bare string → [string] (t/1964#3)', async () => {
+    // source_refs is array | bare string in the store; EntityDetail does `.length > 0 && .map`
+    // → a bare string passes .length then crashes on .map. Coerce at the read boundary.
+    readEntityRegistryMock.mockResolvedValue(new Map([
+      ['ent-040', { id: 'ent-040', name: 'IBM-HashiCorp', source_refs: 'doc-1' } as unknown as Entity],
+      ['ent-050', { id: 'ent-050', name: 'NoRefs', source_refs: null } as unknown as Entity],
+    ]));
+    const stringCase = await invoke('ent-040');
+    expect(stringCase.status).toBe(200);
+    expect((stringCase.body as { record: Entity }).record.source_refs).toEqual(['doc-1']);
+    const nullCase = await invoke('ent-050');
+    expect(nullCase.status).toBe(200);
+    expect((nullCase.body as { record: Entity }).record.source_refs).toEqual([]);
+  });
+
   it('follows a merged_into tombstone to the canonical Entity + stamps redirected_from', async () => {
     readEntityRegistryMock.mockResolvedValue(new Map([
       ['ent-001', { id: 'ent-001', merged_into: 'ent-002' } as unknown as Entity],
@@ -226,6 +256,21 @@ describe('GET /api/entities (t/1883)', () => {
       id: 'ent-001', name: 'OpenAI', aliases: ['OAI'], entity_type: 'institution',
       status: 'approved', confidence: 0.9, last_modified: '2026-02-02',
     });
+  });
+
+  it('coerces polymorphic aliases at the summary boundary: null → [], bare string → [string] (t/1964)', async () => {
+    // entities.json stores aliases as array | null | bare string. EntityBrowserPanel reads
+    // `e.aliases.some(...)`/`e.aliases[0]` off the SUMMARY row → null crashes, a bare string
+    // renders its first char. The list endpoint must hand back a real array either way.
+    readEntityRegistryMock.mockResolvedValue(new Map([
+      ['ent-034', { id: 'ent-034', name: 'Claude', aliases: null, entity_type: 'artifact', status: 'approved', last_modified: '2026-02-02' } as unknown as Entity],
+      ['ent-071', { id: 'ent-071', name: 'GDPR', aliases: 'GDPR', entity_type: 'legislation', status: 'approved', last_modified: '2026-02-02' } as unknown as Entity],
+    ]));
+    const { status, body } = await invokeList();
+    expect(status).toBe(200);
+    const rows = body as Record<string, unknown>[];
+    expect(rows.find(r => r.id === 'ent-034')!.aliases).toEqual([]);
+    expect(rows.find(r => r.id === 'ent-071')!.aliases).toEqual(['GDPR']);
   });
 
   it('returns [] when the entity store is absent (readEntityRegistry → null)', async () => {

--- a/taxonomy-editor/src/server/routes/entity.ts
+++ b/taxonomy-editor/src/server/routes/entity.ts
@@ -60,6 +60,28 @@ function policiesOf(data: unknown): Record<string, unknown>[] {
   return Array.isArray(arr) ? (arr as Record<string, unknown>[]) : [];
 }
 
+/**
+ * Coerce a polymorphic string-array field to a real `string[]` at the read boundary.
+ * entities.json stores `aliases` and `source_refs` in THREE shapes (t/1964, Design
+ * live audit): array | null | bare string — e.g. aliases `["OAI"]` | `null` | `"GDPR"`,
+ * source_refs `["doc-1"]` | `"doc-1"`. A null crashes `.some`/`.length`; a bare string
+ * crashes `.map`/`.join` and renders its first character on `[0]`. Normalize here so no
+ * downstream consumer (browser summary, detail pane, mention flow) ever sees either.
+ * array→as-is · null/undefined→[] · string→single-element.
+ */
+function coerceStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? (v as string[]) : v == null ? [] : [v as string];
+}
+
+/**
+ * Normalize an Entity's polymorphic string-array fields (`aliases`, `source_refs`) at
+ * the read boundary. The genus audit (t/1964#3, Design t/1882#7) bounds the coercion set
+ * to exactly these two fields — every other UI-rendered field is single-shape.
+ */
+function normalizeEntity(e: Entity): Entity {
+  return { ...e, aliases: coerceStringArray(e.aliases), source_refs: coerceStringArray(e.source_refs) };
+}
+
 /** Slugify a colloquial term into the `term:<slug>` wire form: lowercase,
  *  non-alphanumeric runs → single hyphen, trimmed. Deterministic and reversible
  *  enough that "labor displacement" ⇔ "labor-displacement". */
@@ -147,7 +169,9 @@ export function registerEntityRoutes(r: Router, _ctx: ServerCtx): void {
       const reg = await fileIO.readEntityRegistry();
       const rows: EntitySummary[] = reg
         ? [...reg.values()].map(e => ({
-            id: e.id, name: e.name, aliases: e.aliases,
+            // t/1964: aliases is polymorphic in the store (array | null | string) — coerce
+            // so EntityBrowserPanel's `e.aliases.some(...)` off the summary never crashes.
+            id: e.id, name: e.name, aliases: coerceStringArray(e.aliases),
             entity_type: e.entity_type, status: e.status,
             confidence: e.confidence, last_modified: e.last_modified,
           }))
@@ -225,11 +249,14 @@ export function registerEntityRoutes(r: Router, _ctx: ServerCtx): void {
           if (!registry) { json(res, notFound(ref)); return; }
           const resolved = resolveMergedInto(ref.id, id => registry.get(id) ?? null, { maxDepth: MAX_MERGE_DEPTH });
           if (!resolved) { json(res, notFound(ref)); return; }
+          // t/1964: normalize polymorphic aliases/source_refs before the detail/mention
+          // flow renders them — ent-034 "Claude" (the mention target) has aliases: null.
+          const record = normalizeEntity(resolved.record);
           json(
             res,
             resolved.redirectedFrom === undefined
-              ? { ref, kind: 'entity', record: resolved.record }
-              : { ref, redirected_from: resolved.redirectedFrom, kind: 'entity', record: resolved.record },
+              ? { ref, kind: 'entity', record }
+              : { ref, redirected_from: resolved.redirectedFrom, kind: 'entity', record },
           );
           return;
         }


### PR DESCRIPTION
## t/1964 — high-pri crash blocking Design's t/1898 pixel pass + entity epic tail

`entities.json` stores `aliases` and `source_refs` in three shapes each (array | null | bare string), but the `Entity` type declares `string[]`. A stored `null` crashes `.some`/`.length`; a bare string crashes `.map`/`.join`. **ent-034 "Claude" (aliases: null) is the `skp-beliefs-069` mention target**, so the mention→EntityDetail flow, the entity browser, and the detail pane all crash on it.

### Fix — normalize at the server read boundary (both read paths, per TL p/87#152)
- **`GET /api/entities`** summary mapping — coerces `aliases` (fixes `EntityBrowserPanel` reading `e.aliases.some(...)` off the summary row → the browser-open crash).
- **`GET /api/entity/:ref`** entity record — `normalizeEntity` coerces both `aliases` and `source_refs` before the detail/mention flow renders them.

`coerceStringArray`: array→as-is · null→[] · string→[x]. Genus audit (t/1964#3, Design t/1882#7) bounds the set to exactly `{aliases, source_refs}`.

### Tests
4 regression cases: null + bare-string for `aliases` (both endpoints) and `source_refs` (detail). Full file green (24/24), `tsc -p tsconfig.server.json` clean.

Renderer guards (Taxonomy Editor t/1882/t/1884) + writer hardening (PowerShell `EntitiesStore.ps1`) routed separately as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)