### PR TITLE
refactor(storage): t/1921 Batch D — reduce listDirectory complexity 16->9

### DIFF
--- a/taxonomy-editor/src/server/storage/LAST_SESSION.md
+++ b/taxonomy-editor/src/server/storage/LAST_SESSION.md
@@ -1,6 +1,6 @@
 **Date:** 2026-07-29
 **Working on:** t/1921 — Reduce eslint complexity warnings in server/storage/ (ADR-007 helper extractions)
-**Status:** Batch A DONE (PR #135, `4f68d4ae`). Batch B DONE (PR #140, `68a229e5`). Batch C PR open (#147, `9a1e7e28`).
+**Status:** Batch A DONE (PR #135, `4f68d4ae`). Batch B DONE (PR #140, `68a229e5`). Batch C DONE (PR #147, `869e6a6d`). Batch D PR open (`b6ddc05a`).
 
 **Batch A landed:**
 - fileIO.ts: `findGraphAttributeMismatches` 17→7, `buildNodeSourceIndex` 26→2, `buildPolicySourceIndex` 27→4
@@ -9,13 +9,17 @@
 **Batch B landed:**
 - editMeta.ts: `stampNodeAuthorship` map callback 29→6 (`restoreUnchangedStamps`+`buildEditMeta`+`buildHistoryEntry`)
 
-**Batch C (PR #147, awaiting CI):**
-- githubRestClient.ts: `request` 45→13 (7 helpers: `recordAttempt`, `buildRequestHeaders`, `handleNotModified`, `parseAndLogResponse`, `extractApiMessage`, `handleNonOkStatus`, `handleNetworkError`)
+**Batch C landed (PR #147, `869e6a6d`):**
+- githubRestClient.ts: `request` 45→15 (7 helpers: `recordAttempt`, `buildRequestHeaders`, `handleNotModified`, `parseAndLogResponse`, `extractApiMessage`, `handleNonOkStatus`, `handleNetworkError`)
 - `NonOkOutcome` union type at module scope carries retry/return signal
+- `getGlobalRecorder()?.record()` kept in catch body (ESLint `require-flight-recorder-in-catch` rule)
+
+**Batch D (PR pending, `b6ddc05a`):**
+- githubAPIBackend.ts: `listDirectory` 16→9 (`fetchDirectoryFromAPI` helper, complexity 8)
 
 **Remaining:**
-- Batch D: githubAPIBackend.ts `listDirectory@16` (coordinate LOC impact with t/1688 exception)
+- Nothing — t/1921 complete after Batch D lands
 
-**Landing procedure (e/49/e/50):** PR-flow is CONVENTION not platform hard-block. Always land via feature branch → `gh pr create` → 6 checks → `gh pr merge --rebase --delete-branch`. From detached HEAD: push as `HEAD:refs/heads/<branch>` (fully-qualified).
+**Landing procedure (e/49/e/50):** PR-flow is CONVENTION not platform hard-block. Always land via feature branch → `gh pr create` → 6 checks → `gh pr merge --squash --delete-branch`. From detached HEAD: push as `HEAD:refs/heads/<branch>` (fully-qualified).
 
 **Prior sessions:** t/1941 edges serializer (`dcd54936`); t/1895 mention read path (`84cb675b`); t/1807 entity read path (`1d2d9111`); t/1688 fileIO+githubAPIBackend split (`c2ea5c7e`).

--- a/taxonomy-editor/src/server/storage/githubAPIBackend.ts
+++ b/taxonomy-editor/src/server/storage/githubAPIBackend.ts
@@ -523,16 +523,7 @@ export class GitHubAPIBackend implements StorageBackend {
         seen.add(rest.split('/')[0]);
       }
     } else if (!(this.rest.isTripped())) {
-      const creds = await this.getCredsCached();
-      if (creds) {
-        const ref = opts?.ref ?? this.getEffectiveRef();
-        const qRef = ref === 'main' ? '' : `?ref=${encodeURIComponent(ref)}`;
-        const resp = await this.rest.request(creds, 'GET',
-          `/repos/${creds.repo}/contents/${repoPath}${qRef}`);
-        if (resp.ok && Array.isArray(resp.data)) {
-          for (const e of resp.data as Array<{ name: string }>) seen.add(e.name);
-        }
-      }
+      await this.fetchDirectoryFromAPI(repoPath, opts, seen);
     }
 
     // Merge the session overlay so files written this session are visible and
@@ -542,6 +533,21 @@ export class GitHubAPIBackend implements StorageBackend {
     this.mergeOverlayIntoListing(prefix, seen);
 
     return [...seen];
+  }
+
+  private async fetchDirectoryFromAPI(
+    repoPath: string, opts: { ref?: string } | undefined, seen: Set<string>,
+  ): Promise<void> {
+    const creds = await this.getCredsCached();
+    if (creds) {
+      const ref = opts?.ref ?? this.getEffectiveRef();
+      const qRef = ref === 'main' ? '' : `?ref=${encodeURIComponent(ref)}`;
+      const resp = await this.rest.request(creds, 'GET',
+        `/repos/${creds.repo}/contents/${repoPath}${qRef}`);
+      if (resp.ok && Array.isArray(resp.data)) {
+        for (const e of resp.data as Array<{ name: string }>) seen.add(e.name);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- `githubAPIBackend.ts`: extract `fetchDirectoryFromAPI` private helper (complexity 8) from the `else if` branch in `listDirectory`, reducing `listDirectory` from complexity 16 → 9
- ADR-007 verbatim line-slice; only the signature and call site are hand-authored
- Final batch for t/1921 — all server/storage complexity warnings resolved

## Test plan
- [ ] `tsc --noEmit -p tsconfig.main.json` passes clean (verified locally)
- [ ] CI: quality-gates (ESLint complexity), test-electron, test-container

🤖 Generated with [Claude Code](https://claude.com/claude-code)