### PR TITLE
refactor(diag): decompose entry-tabs complexity (t/1909 B3)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ClaimsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ClaimsTab.tsx
@@ -25,6 +25,17 @@ interface ExtractionTrace {
   an_nodes_added_ids: string[];
 }
 
+type ExtractedClaimsData = NonNullable<EntryDiagnostics['extracted_claims']>;
+type AcceptedClaim = ExtractedClaimsData['accepted'][number];
+type RejectedClaim = ExtractedClaimsData['rejected'][number];
+type EntailmentRepair = NonNullable<EntryDiagnostics['entailment_repairs']>[number];
+
+interface SharedBadges {
+  sharedBdiCategory: string | null;
+  sharedSpecificity: string | null;
+  sharedSteelmanOf: string | null;
+}
+
 export interface ClaimsTabProps {
   entry: { id: string; type: string; content?: unknown; metadata?: unknown; taxonomy_refs?: unknown[]; policy_refs?: unknown[]; speaker: string };
   diag: EntryDiagnostics | undefined;
@@ -33,6 +44,398 @@ export interface ClaimsTabProps {
   an: ArgumentNetwork | undefined;
   nodeWeights: Map<string, number>;
   searchQuery?: string;
+}
+
+// --- Extraction status (t/226) -------------------------------------------
+
+function computeExtractionStatus(diag: EntryDiagnostics | undefined, meta: Record<string, unknown> | undefined) {
+  const status = (diag as Record<string, unknown> | undefined)?.extraction_status as string | undefined;
+  const sketchCount = (meta?.my_claims as unknown[] | undefined)?.length ?? 0;
+  const acceptedCount = diag?.extracted_claims?.accepted?.length ?? 0;
+  const showReExtract = sketchCount > 0 && acceptedCount === 0 && status !== 'pending';
+  return { status, showReExtract };
+}
+
+// --- Extracted Claims: shared per-section header badges -------------------
+
+function computeSharedBadges(accepted: AcceptedClaim[], an: ArgumentNetwork | undefined): SharedBadges {
+  // Compute shared per-section metadata badges (§3 de-engineering: move repeated labels to section header)
+  const acceptedAnNodes = accepted.map(c => an?.nodes.find(n => n.id === c.id));
+  const uniqueBdiCategories = new Set(acceptedAnNodes.map(n => n?.bdi_category).filter(Boolean));
+  const uniqueSpecificities = new Set(acceptedAnNodes.map(n => n?.specificity).filter(Boolean));
+  const uniqueSteelmanOfs = new Set(acceptedAnNodes.map(n => n?.steelman_of).filter(Boolean));
+  // Only hoist to header when all rows share the exact same non-null value
+  const sharedBdiCategory = uniqueBdiCategories.size === 1 && accepted.length > 1
+    ? [...uniqueBdiCategories][0] as string : null;
+  const sharedSpecificity = uniqueSpecificities.size === 1 && accepted.length > 1
+    ? [...uniqueSpecificities][0] as string : null;
+  const sharedSteelmanOf = uniqueSteelmanOfs.size === 1 && accepted.length > 1
+    ? [...uniqueSteelmanOfs][0] as string : null;
+  return { sharedBdiCategory, sharedSpecificity, sharedSteelmanOf };
+}
+
+function buildSectionSuffix({ sharedBdiCategory, sharedSpecificity, sharedSteelmanOf }: SharedBadges): React.ReactNode {
+  const bdiHeaderBadge = sharedBdiCategory ? (
+    // eslint-disable-next-line local/no-inline-style -- background/color computed from sharedBdiCategory
+    <span style={{ padding: '0 4px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, marginLeft: 6,
+      background: sharedBdiCategory === 'belief' ? 'color-mix(in srgb, var(--color-saf) 15%, transparent)' : sharedBdiCategory === 'desire' ? 'color-mix(in srgb, var(--color-skp) 15%, transparent)' : 'color-mix(in srgb, var(--color-acc) 15%, transparent)',
+      color: sharedBdiCategory === 'belief' ? 'var(--color-saf)' : sharedBdiCategory === 'desire' ? 'var(--color-skp)' : 'var(--color-acc)' }}>
+      {sharedBdiCategory}
+    </span>
+  ) : null;
+  const specificityHeaderBadge = sharedSpecificity ? (
+    <span className="clm-hdr-specificity">
+      {sharedSpecificity}
+    </span>
+  ) : null;
+  const steelmanHeaderBadge = sharedSteelmanOf ? (
+    <span className="clm-hdr-steelman">
+      steelman of {POVER_INFO[sharedSteelmanOf as keyof typeof POVER_INFO]?.label ?? sharedSteelmanOf}
+    </span>
+  ) : null;
+
+  return (bdiHeaderBadge || specificityHeaderBadge || steelmanHeaderBadge) ? (
+    <span className="clm-section-suffix">
+      {bdiHeaderBadge}{specificityHeaderBadge}{steelmanHeaderBadge}
+    </span>
+  ) : null;
+}
+
+// --- Accepted claim: per-row derived metadata ----------------------------
+
+function computeEntailmentMeta(c: AcceptedClaim, diag: EntryDiagnostics) {
+  const repair = diag.entailment_repairs?.find(r => r.node_id === c.id);
+  const hasEntailmentData = (diag.entailment_repairs?.length ?? 0) > 0;
+  // §3: only show chip for non-pass verdicts (flag/fail); pass/entailed shows nothing
+  const entailmentVerdict: Verdict | null = repair
+    ? (repair.verdict === 'entailed' ? 'pass' : repair.verdict === 'partial' ? 'flag' : 'fail')
+    : null;
+  const showEntailmentChip = entailmentVerdict != null && entailmentVerdict !== 'pass';
+  const verdictColor = repair ? (repair.verdict === 'entailed' ? 'var(--success)' : repair.verdict === 'partial' ? 'var(--warning)' : 'var(--danger)') : null;
+  return { repair, hasEntailmentData, entailmentVerdict, showEntailmentChip, verdictColor };
+}
+
+function computeClaimRowMeta(c: AcceptedClaim, an: ArgumentNetwork | undefined, diag: EntryDiagnostics) {
+  const outEdges = an?.edges.filter(e => e.source === c.id) ?? [];
+  const edgeSummary = outEdges.map(edge => {
+    const label = edge.type === 'attacks'
+      ? (edge.attack_type ? `attacks(${edge.attack_type})` : 'attacks')
+      : 'supports';
+    return `${label} ${edge.target}`;
+  }).join(', ');
+  const anNode = an?.nodes.find(n => n.id === c.id);
+  const ec = anNode?.extraction_confidence;
+  const ecBand = ec != null ? (ec >= 1.0 ? 'near-verbatim' : ec >= 0.8 ? 'faithful compression' : ec >= 0.6 ? 'implicit premise' : 'minimum') : null;
+  return { outEdges, edgeSummary, anNode, ec, ecBand, ...computeEntailmentMeta(c, diag) };
+}
+
+type ClaimRowMeta = ReturnType<typeof computeClaimRowMeta>;
+
+// --- Accepted claim: leaf sub-components ----------------------------------
+
+function RowBdiBadge({ anNode, sharedBdiCategory }: { anNode: ArgumentNetworkNode | undefined; sharedBdiCategory: string | null }) {
+  // §3: per-row badge only when not hoisted to section header
+  if (!anNode?.bdi_category || sharedBdiCategory) return null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- background/color computed from anNode.bdi_category
+    <span style={{ padding: '0 4px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, marginRight: 3, background: anNode.bdi_category === 'belief' ? 'color-mix(in srgb, var(--color-saf) 15%, transparent)' : anNode.bdi_category === 'desire' ? 'color-mix(in srgb, var(--color-skp) 15%, transparent)' : 'color-mix(in srgb, var(--color-acc) 15%, transparent)', color: anNode.bdi_category === 'belief' ? 'var(--color-saf)' : anNode.bdi_category === 'desire' ? 'var(--color-skp)' : 'var(--color-acc)' }}>
+      {anNode.bdi_category}
+    </span>
+  );
+}
+
+function ClaimRowBadges({ anNode, sharedBdiCategory, sharedSpecificity, sharedSteelmanOf }: { anNode: ArgumentNetworkNode | undefined } & SharedBadges) {
+  return (
+    <>
+      <RowBdiBadge anNode={anNode} sharedBdiCategory={sharedBdiCategory} />
+      {anNode?.specificity && !sharedSpecificity && (
+        <span className="clm-row-specificity">
+          {anNode.specificity}
+        </span>
+      )}
+      {anNode?.steelman_of && !sharedSteelmanOf && (
+        <span className="clm-row-steelman">
+          steelman of {POVER_INFO[anNode.steelman_of as keyof typeof POVER_INFO]?.label ?? anNode.steelman_of}
+        </span>
+      )}
+    </>
+  );
+}
+
+function ClaimSummary({ c, meta, sharedBdiCategory, sharedSpecificity, sharedSteelmanOf }: { c: AcceptedClaim; meta: ClaimRowMeta } & SharedBadges) {
+  const { outEdges, edgeSummary, anNode, ec, ecBand, repair, hasEntailmentData, entailmentVerdict, showEntailmentChip } = meta;
+  return (
+    <summary className="clm-summary">
+      <span className="clm-c-success">✓ {c.id}</span> <span data-tooltip={`Word Overlap: ${c.overlap_pct}%\n\nMeasures grounding of claim in the debater's statement.\nFormula: shared words ≥4 chars / total claim words ≥4 chars × 100.\n\nThreshold: < 10-15% = rejected as not grounded.\n${c.overlap_pct}% = ${c.overlap_pct < 50 ? 'moderate' : 'strong'} lexical grounding.`} className="clm-overlap-pct">{c.overlap_pct}%</span>{' '}
+      {ec != null && (
+        <ScoreBadge
+          value={ec}
+          label="FIRE"
+          tooltip={`Extraction Confidence: ${ec.toFixed(2)}\nBand: ${ecBand}\n\nFIRE metric — how faithfully this claim was extracted from the speaker's statement.\n1.0 = near-verbatim (overlap ≥70%)\n0.8 = faithful compression (≥50%)\n0.6 = implicit premise (≥30%)\n0.5 = minimum (below 30%)`}
+        />
+      )}
+      {/* §3: chip only for non-pass entailment outcomes */}
+      {showEntailmentChip && repair && (
+        <VerdictChip
+          verdict={entailmentVerdict!}
+          label={`${repair.verdict === 'partial' ? '~' : '✗'} ${repair.verdict}`}
+          tooltip={`Entailment: ${repair.verdict}\n${repair.explanation}`}
+        />
+      )}
+      {!repair && hasEntailmentData && (
+        <span className="clm-not-sampled">not sampled</span>
+      )}
+      <ClaimRowBadges
+        anNode={anNode}
+        sharedBdiCategory={sharedBdiCategory}
+        sharedSpecificity={sharedSpecificity}
+        sharedSteelmanOf={sharedSteelmanOf}
+      />
+      <Highlight text={c.text} />
+      {anNode?.attribution_text_genus && <div className="claim-attribution-text"><span className="claim-attribution-label">Attribution:</span>{anNode.attribution_text_genus}</div>}
+      {outEdges.length > 0 && (
+        <span className="clm-edge-summary">
+          [{edgeSummary}]
+        </span>
+      )}
+    </summary>
+  );
+}
+
+function ClaimEdges({ outEdges, an }: { outEdges: ArgumentNetworkEdge[]; an: ArgumentNetwork | undefined }) {
+  const hasSupports = outEdges.some(e => e.type === 'supports');
+  const hasAttacks = outEdges.some(e => e.type === 'attacks');
+  const concedeAndPivot = hasSupports && hasAttacks;
+  const strengthColors = { decisive: 'var(--success)', substantial: 'var(--color-saf)', tangential: 'var(--text-muted)' } as Record<string, string>;
+  return (
+  <div className="clm-edges-wrap">
+    {concedeAndPivot && (
+      <div className="clm-concede-pivot">
+        Concede-and-pivot: supports + attacks edges from the same claim
+      </div>
+    )}
+    {outEdges.map((edge, ei) => {
+      const targetNode = an?.nodes.find(n => n.id === edge.target);
+      const edgeLabel = edge.type === 'attacks'
+        ? (edge.attack_type ? `attacks (${edge.attack_type})` : 'attacks')
+        : 'supports';
+      return (
+        // eslint-disable-next-line local/no-inline-style -- borderLeft computed from edge.type
+        <div key={ei} style={{ fontSize: 'var(--text-2xs)', margin: '3px 0', paddingLeft: 10, borderLeft: edge.type === 'attacks' ? '2px solid var(--danger)' : '2px solid var(--success)' }}>
+          <div className="clm-edge-head">
+            {/* eslint-disable-next-line local/no-inline-style -- color computed from edge.type */}
+            <span style={{ color: edge.type === 'attacks' ? 'var(--danger)' : 'var(--success)', fontWeight: 600 }}>{edgeLabel}</span>
+            {edge.strength && (
+              // eslint-disable-next-line local/no-inline-style -- color computed from strengthColors[edge.strength]
+              <span style={{ padding: '0 3px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, background: 'var(--bg-hover)', color: strengthColors[edge.strength] ?? 'var(--text-muted)' }}>
+                {edge.strength}
+              </span>
+            )}
+            {edge.argumentation_scheme && <span className="clm-scheme-badge">{edge.argumentation_scheme}</span>}
+          </div>
+          {targetNode && (
+            <div className="clm-target-node">
+              <span className="clm-fw600">{targetNode.id}</span> ({POVER_INFO[targetNode.speaker as keyof typeof POVER_INFO]?.label ?? targetNode.speaker}): {targetNode.text}
+            </div>
+          )}
+          {edge.warrant && (
+            <div className="clm-warrant">
+              {edge.warrant}
+            </div>
+          )}
+        </div>
+      );
+    })}
+  </div>
+  );
+}
+
+function ClaimRepairBlock({ repair, verdictColor }: { repair: EntailmentRepair | undefined; verdictColor: string | null }) {
+  if (!(repair && repair.verdict !== 'entailed' && repair.repaired_text)) return null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- background/border computed from repair.verdict
+    <div style={{ paddingLeft: 20, marginTop: 6, marginBottom: 4, padding: '6px 8px', borderRadius: 4, background: (repair.verdict as string) === 'entailed' ? 'color-mix(in srgb, var(--success) 8%, transparent)' : repair.verdict === 'partial' ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'color-mix(in srgb, var(--danger) 8%, transparent)', border: (repair.verdict as string) === 'entailed' ? '1px solid color-mix(in srgb, var(--success) 20%, transparent)' : repair.verdict === 'partial' ? '1px solid color-mix(in srgb, var(--warning) 20%, transparent)' : '1px solid color-mix(in srgb, var(--danger) 20%, transparent)' }}>
+      {/* eslint-disable-next-line local/no-inline-style -- color from computed verdictColor */}
+      <div style={{ fontSize: 'var(--text-2xs)', fontWeight: 700, color: verdictColor!, marginBottom: 4 }}>
+        Entailment Repair ({repair.verdict})
+      </div>
+      <div className="clm-repair-line">
+        <span className="clm-repair-orig">{repair.original_text}</span>
+      </div>
+      <div className="clm-repair-fixed">
+        {repair.repaired_text}
+      </div>
+      <div className="clm-repair-explain">
+        {repair.explanation}
+      </div>
+    </div>
+  );
+}
+
+function ClaimScores({ anNode }: { anNode: ArgumentNetworkNode | undefined }) {
+  if (!(anNode && (anNode.base_strength != null || anNode.bdi_sub_scores))) return null;
+  return (
+    <details className="clm-indent-block">
+      <summary className="clm-scores-summary">
+        Scores{anNode.base_strength != null ? ` — base: ${anNode.base_strength.toFixed(2)}` : ''}{anNode.computed_strength != null ? ` → computed: ${anNode.computed_strength.toFixed(2)}` : ''}{anNode.scoring_method ? ` (${anNode.scoring_method.replace(/_/g, ' ')})` : ''}
+      </summary>
+      <div className="clm-scores-body">
+        {anNode.base_strength != null && (
+          <div className="clm-scores-row">
+            <span><strong>Base:</strong> {anNode.base_strength.toFixed(2)}</span>
+            {anNode.computed_strength != null && <span><strong>Computed:</strong> {anNode.computed_strength.toFixed(2)}</span>}
+            {anNode.scoring_method && <span className="clm-muted">via {anNode.scoring_method.replace(/_/g, ' ')}</span>}
+          </div>
+        )}
+        {anNode.bdi_sub_scores && (
+          <div className="clm-subscores">
+            {Object.entries(anNode.bdi_sub_scores).filter(([, v]) => v != null).map(([k, v]) => {
+              const label = k.replace(/_/g, ' ');
+              const strVal = typeof v === 'number' ? (v >= 0.7 ? 'yes' : v >= 0.4 ? 'partial' : 'no') : String(v);
+              const color = strVal === 'yes' ? 'var(--success)' : strVal === 'partial' ? 'var(--warning)' : 'var(--danger)';
+              return (
+                // eslint-disable-next-line local/no-inline-style -- background/color computed from strVal
+                <span key={k} style={{ padding: '1px 4px', borderRadius: 3, fontSize: 'var(--text-2xs)', background: strVal === 'yes' ? 'color-mix(in srgb, var(--success) 15%, transparent)' : strVal === 'partial' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)', color }}>
+                  {label}: {strVal}
+                </span>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function ClaimEvidenceGraph({ anNode }: { anNode: ArgumentNetworkNode | undefined }) {
+  // Evidence graph inline (t/495)
+  const eg = anNode?.evidence_graph as { evidence_items: { id: string; source_doc_id: string; text: string; relation: 'support' | 'contradict'; similarity: number }[]; computed_strength: number; qbaf_iterations: number } | undefined;
+  if (!eg || eg.evidence_items.length === 0) return null;
+  const barPct = Math.round(eg.computed_strength * 100);
+  const barColor = eg.computed_strength >= 0.7 ? 'var(--success)' : eg.computed_strength >= 0.4 ? 'var(--warning)' : 'var(--danger)';
+  const supports = eg.evidence_items.filter(e => e.relation === 'support');
+  const contradicts = eg.evidence_items.filter(e => e.relation === 'contradict');
+  return (
+    <div className="clm-indent-block">
+      <div className="clm-evidence-header">
+        Evidence ({supports.length} support, {contradicts.length} contradict)
+      </div>
+      <div className="clm-evidence-bar-row">
+        <div className="clm-bar-track">
+          {/* eslint-disable-next-line local/no-inline-style -- width/background computed from barPct/barColor */}
+          <div style={{ width: `${barPct}%`, height: '100%', borderRadius: 3, background: barColor }} />
+        </div>
+        {/* eslint-disable-next-line local/no-inline-style -- color from computed barColor */}
+        <span style={{ fontSize: 'var(--text-2xs)', fontWeight: 700, color: barColor, minWidth: 36 }}>
+          {eg.computed_strength.toFixed(2)}
+        </span>
+        <span className="clm-2xs-muted">
+          {eg.qbaf_iterations} iter
+        </span>
+      </div>
+      {eg.evidence_items
+        .sort((a, b) => a.relation !== b.relation ? (a.relation === 'contradict' ? -1 : 1) : b.similarity - a.similarity)
+        .map(item => (
+        // eslint-disable-next-line local/no-inline-style -- borderLeft/background computed from item.relation
+        <div key={item.id} style={{
+          marginBottom: 3, padding: '3px 6px', borderRadius: 4, fontSize: 'var(--text-2xs)',
+          borderLeft: item.relation === 'support' ? '2px solid var(--success)' : '2px solid var(--danger)',
+          background: item.relation === 'support' ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
+        }}>
+          <div className="clm-evidence-item-head">
+            {/* eslint-disable-next-line local/no-inline-style -- background/color computed from item.relation */}
+            <span style={{
+              fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 4px', borderRadius: 3,
+              background: item.relation === 'support' ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)',
+              color: item.relation === 'support' ? 'var(--success)' : 'var(--danger)',
+            }}>
+              {item.relation === 'support' ? 'SUP' : 'CON'}
+            </span>
+            <span className="clm-muted">{(item.similarity * 100).toFixed(0)}%</span>
+            <span className="clm-evidence-src">
+              {item.source_doc_id}
+            </span>
+          </div>
+          <div className="clm-evidence-text">
+            {item.text.length > 120 ? item.text.slice(0, 120) + '…' : item.text}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function AcceptedClaimRow({ c, an, diag, sharedBdiCategory, sharedSpecificity, sharedSteelmanOf }: { c: AcceptedClaim; an: ArgumentNetwork | undefined; diag: EntryDiagnostics } & SharedBadges) {
+  const meta = computeClaimRowMeta(c, an, diag);
+  return (
+    <details open className="clm-claim-details">
+      <ClaimSummary
+        c={c}
+        meta={meta}
+        sharedBdiCategory={sharedBdiCategory}
+        sharedSpecificity={sharedSpecificity}
+        sharedSteelmanOf={sharedSteelmanOf}
+      />
+      {meta.outEdges.length > 0 && <ClaimEdges outEdges={meta.outEdges} an={an} />}
+      <ClaimRepairBlock repair={meta.repair} verdictColor={meta.verdictColor} />
+      <ClaimScores anNode={meta.anNode} />
+      <ClaimEvidenceGraph anNode={meta.anNode} />
+    </details>
+  );
+}
+
+function RejectedClaimRow({ c }: { c: RejectedClaim }) {
+  const isDup = c.reason === 'duplicate_claim';
+  const dupOf = isDup ? c.duplicate_of : undefined;
+  const dupText = isDup ? c.duplicate_of_text : undefined;
+  const rejectedNote = c.reason === 'low_overlap'
+    ? 'overlap too low (not grounded)'
+    : isDup
+      ? `duplicate of existing AN node${dupOf ? ` ${dupOf}` : ''}${dupText ? `: "${dupText}"` : ''}`
+      : c.reason;
+  return (
+    <div className="clm-m3">
+      <span className="clm-c-danger">✗</span> <span data-tooltip={`Word Overlap: ${c.overlap_pct}%\n\nMeasures grounding of claim in the debater's statement.\nFormula: shared words ≥4 chars / total claim words ≥4 chars × 100.\n\nRejected: ${rejectedNote}.`} className="clm-overlap-pct">{c.overlap_pct}%</span> <Highlight text={c.text} />
+      <div className="clm-reject-reason">
+        {c.reason}
+        {isDup && dupOf && (
+          <span className="clm-muted">
+            {' → duplicates '}
+            <span className="clm-fw600">{dupOf}</span>
+            {dupText && <span title={dupText}>{`: "${dupText.length > 80 ? dupText.slice(0, 80) + '…' : dupText}"`}</span>}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ExtractedClaimsSection({ diag, an }: { diag: EntryDiagnostics & { extracted_claims: ExtractedClaimsData }; an: ArgumentNetwork | undefined }) {
+  const { sharedBdiCategory, sharedSpecificity, sharedSteelmanOf } = computeSharedBadges(diag.extracted_claims.accepted, an);
+  const sectionSuffix = buildSectionSuffix({ sharedBdiCategory, sharedSpecificity, sharedSteelmanOf });
+  return (
+    <Section
+      title={`Extracted Claims (${diag.extracted_claims.accepted.length} accepted, ${diag.extracted_claims.rejected.length} rejected)`}
+      defaultOpen
+      titleSuffix={sectionSuffix}
+      copyText={[...diag.extracted_claims.accepted.map(c => { const anN = an?.nodes.find(n => n.id === c.id); return `✓ ${c.id} (${c.overlap_pct}%): ${c.text}${anN?.attribution_text_genus ? `\n  [Attribution: ${anN.attribution_text_genus}]` : ''}`; }), ...diag.extracted_claims.rejected.map(c => `✗ (${c.overlap_pct}%): ${c.text} — ${c.reason}`)].join('\n')}
+    >
+      {diag.extracted_claims.accepted.map((c, i) => (
+        <AcceptedClaimRow
+          key={i}
+          c={c}
+          an={an}
+          diag={diag}
+          sharedBdiCategory={sharedBdiCategory}
+          sharedSpecificity={sharedSpecificity}
+          sharedSteelmanOf={sharedSteelmanOf}
+        />
+      ))}
+      {diag.extracted_claims.rejected.map((c, i) => (
+        <RejectedClaimRow key={i} c={c} />
+      ))}
+    </Section>
+  );
 }
 
 export function ClaimsTab({ entry, diag, meta, debate, an, nodeWeights, searchQuery }: ClaimsTabProps) {
@@ -92,10 +495,7 @@ export function ClaimsTab({ entry, diag, meta, debate, an, nodeWeights, searchQu
 
       {/* Extraction status + re-extract button (t/226) */}
       {(() => {
-        const status = (diag as Record<string, unknown> | undefined)?.extraction_status as string | undefined;
-        const sketchCount = (meta?.my_claims as unknown[] | undefined)?.length ?? 0;
-        const acceptedCount = diag?.extracted_claims?.accepted?.length ?? 0;
-        const showReExtract = sketchCount > 0 && acceptedCount === 0 && status !== 'pending';
+        const { status, showReExtract } = computeExtractionStatus(diag, meta);
         if (!status && !showReExtract) return null;
         return (
           <div className="clm-ext-status">
@@ -118,302 +518,9 @@ export function ClaimsTab({ entry, diag, meta, debate, an, nodeWeights, searchQu
         );
       })()}
 
-      {diag?.extracted_claims && (() => {
-        // Compute shared per-section metadata badges (§3 de-engineering: move repeated labels to section header)
-        const acceptedAnNodes = diag.extracted_claims.accepted.map(c => an?.nodes.find(n => n.id === c.id));
-        const uniqueBdiCategories = new Set(acceptedAnNodes.map(n => n?.bdi_category).filter(Boolean));
-        const uniqueSpecificities = new Set(acceptedAnNodes.map(n => n?.specificity).filter(Boolean));
-        const uniqueSteelmanOfs = new Set(acceptedAnNodes.map(n => n?.steelman_of).filter(Boolean));
-        // Only hoist to header when all rows share the exact same non-null value
-        const sharedBdiCategory = uniqueBdiCategories.size === 1 && diag.extracted_claims.accepted.length > 1
-          ? [...uniqueBdiCategories][0] as string : null;
-        const sharedSpecificity = uniqueSpecificities.size === 1 && diag.extracted_claims.accepted.length > 1
-          ? [...uniqueSpecificities][0] as string : null;
-        const sharedSteelmanOf = uniqueSteelmanOfs.size === 1 && diag.extracted_claims.accepted.length > 1
-          ? [...uniqueSteelmanOfs][0] as string : null;
-
-        const bdiHeaderBadge = sharedBdiCategory ? (
-          // eslint-disable-next-line local/no-inline-style -- background/color computed from sharedBdiCategory
-          <span style={{ padding: '0 4px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, marginLeft: 6,
-            background: sharedBdiCategory === 'belief' ? 'color-mix(in srgb, var(--color-saf) 15%, transparent)' : sharedBdiCategory === 'desire' ? 'color-mix(in srgb, var(--color-skp) 15%, transparent)' : 'color-mix(in srgb, var(--color-acc) 15%, transparent)',
-            color: sharedBdiCategory === 'belief' ? 'var(--color-saf)' : sharedBdiCategory === 'desire' ? 'var(--color-skp)' : 'var(--color-acc)' }}>
-            {sharedBdiCategory}
-          </span>
-        ) : null;
-        const specificityHeaderBadge = sharedSpecificity ? (
-          <span className="clm-hdr-specificity">
-            {sharedSpecificity}
-          </span>
-        ) : null;
-        const steelmanHeaderBadge = sharedSteelmanOf ? (
-          <span className="clm-hdr-steelman">
-            steelman of {POVER_INFO[sharedSteelmanOf as keyof typeof POVER_INFO]?.label ?? sharedSteelmanOf}
-          </span>
-        ) : null;
-
-        const sectionSuffix = (bdiHeaderBadge || specificityHeaderBadge || steelmanHeaderBadge) ? (
-          <span className="clm-section-suffix">
-            {bdiHeaderBadge}{specificityHeaderBadge}{steelmanHeaderBadge}
-          </span>
-        ) : null;
-
-        return (
-        <Section
-          title={`Extracted Claims (${diag.extracted_claims.accepted.length} accepted, ${diag.extracted_claims.rejected.length} rejected)`}
-          defaultOpen
-          titleSuffix={sectionSuffix}
-          copyText={[...diag.extracted_claims.accepted.map(c => { const anN = an?.nodes.find(n => n.id === c.id); return `✓ ${c.id} (${c.overlap_pct}%): ${c.text}${anN?.attribution_text_genus ? `\n  [Attribution: ${anN.attribution_text_genus}]` : ''}`; }), ...diag.extracted_claims.rejected.map(c => `✗ (${c.overlap_pct}%): ${c.text} — ${c.reason}`)].join('\n')}
-        >
-          {diag.extracted_claims.accepted.map((c, i) => {
-            const outEdges = an?.edges.filter(e => e.source === c.id) ?? [];
-            const edgeSummary = outEdges.map(edge => {
-              const label = edge.type === 'attacks'
-                ? (edge.attack_type ? `attacks(${edge.attack_type})` : 'attacks')
-                : 'supports';
-              return `${label} ${edge.target}`;
-            }).join(', ');
-            const anNode = an?.nodes.find(n => n.id === c.id);
-            const ec = anNode?.extraction_confidence;
-            const ecBand = ec != null ? (ec >= 1.0 ? 'near-verbatim' : ec >= 0.8 ? 'faithful compression' : ec >= 0.6 ? 'implicit premise' : 'minimum') : null;
-            const repair = diag.entailment_repairs?.find(r => r.node_id === c.id);
-            const hasEntailmentData = (diag.entailment_repairs?.length ?? 0) > 0;
-            // §3: only show chip for non-pass verdicts (flag/fail); pass/entailed shows nothing
-            const entailmentVerdict: Verdict | null = repair
-              ? (repair.verdict === 'entailed' ? 'pass' : repair.verdict === 'partial' ? 'flag' : 'fail')
-              : null;
-            const showEntailmentChip = entailmentVerdict != null && entailmentVerdict !== 'pass';
-            const verdictColor = repair ? (repair.verdict === 'entailed' ? 'var(--success)' : repair.verdict === 'partial' ? 'var(--warning)' : 'var(--danger)') : null;
-            return (
-              <details key={i} open className="clm-claim-details">
-                <summary className="clm-summary">
-                  <span className="clm-c-success">✓ {c.id}</span> <span data-tooltip={`Word Overlap: ${c.overlap_pct}%\n\nMeasures grounding of claim in the debater's statement.\nFormula: shared words ≥4 chars / total claim words ≥4 chars × 100.\n\nThreshold: < 10-15% = rejected as not grounded.\n${c.overlap_pct}% = ${c.overlap_pct < 50 ? 'moderate' : 'strong'} lexical grounding.`} className="clm-overlap-pct">{c.overlap_pct}%</span>{' '}
-                  {ec != null && (
-                    <ScoreBadge
-                      value={ec}
-                      label="FIRE"
-                      tooltip={`Extraction Confidence: ${ec.toFixed(2)}\nBand: ${ecBand}\n\nFIRE metric — how faithfully this claim was extracted from the speaker's statement.\n1.0 = near-verbatim (overlap ≥70%)\n0.8 = faithful compression (≥50%)\n0.6 = implicit premise (≥30%)\n0.5 = minimum (below 30%)`}
-                    />
-                  )}
-                  {/* §3: chip only for non-pass entailment outcomes */}
-                  {showEntailmentChip && repair && (
-                    <VerdictChip
-                      verdict={entailmentVerdict!}
-                      label={`${repair.verdict === 'partial' ? '~' : '✗'} ${repair.verdict}`}
-                      tooltip={`Entailment: ${repair.verdict}\n${repair.explanation}`}
-                    />
-                  )}
-                  {!repair && hasEntailmentData && (
-                    <span className="clm-not-sampled">not sampled</span>
-                  )}
-                  {/* §3: per-row badge only when not hoisted to section header */}
-                  {anNode?.bdi_category && !sharedBdiCategory && (
-                    // eslint-disable-next-line local/no-inline-style -- background/color computed from anNode.bdi_category
-                    <span style={{ padding: '0 4px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, marginRight: 3, background: anNode.bdi_category === 'belief' ? 'color-mix(in srgb, var(--color-saf) 15%, transparent)' : anNode.bdi_category === 'desire' ? 'color-mix(in srgb, var(--color-skp) 15%, transparent)' : 'color-mix(in srgb, var(--color-acc) 15%, transparent)', color: anNode.bdi_category === 'belief' ? 'var(--color-saf)' : anNode.bdi_category === 'desire' ? 'var(--color-skp)' : 'var(--color-acc)' }}>
-                      {anNode.bdi_category}
-                    </span>
-                  )}
-                  {anNode?.specificity && !sharedSpecificity && (
-                    <span className="clm-row-specificity">
-                      {anNode.specificity}
-                    </span>
-                  )}
-                  {anNode?.steelman_of && !sharedSteelmanOf && (
-                    <span className="clm-row-steelman">
-                      steelman of {POVER_INFO[anNode.steelman_of as keyof typeof POVER_INFO]?.label ?? anNode.steelman_of}
-                    </span>
-                  )}
-                  <Highlight text={c.text} />
-                  {anNode?.attribution_text_genus && <div className="claim-attribution-text"><span className="claim-attribution-label">Attribution:</span>{anNode.attribution_text_genus}</div>}
-                  {outEdges.length > 0 && (
-                    <span className="clm-edge-summary">
-                      [{edgeSummary}]
-                    </span>
-                  )}
-                </summary>
-                {outEdges.length > 0 && (() => {
-                  const hasSupports = outEdges.some(e => e.type === 'supports');
-                  const hasAttacks = outEdges.some(e => e.type === 'attacks');
-                  const concedeAndPivot = hasSupports && hasAttacks;
-                  const strengthColors = { decisive: 'var(--success)', substantial: 'var(--color-saf)', tangential: 'var(--text-muted)' } as Record<string, string>;
-                  return (
-                  <div className="clm-edges-wrap">
-                    {concedeAndPivot && (
-                      <div className="clm-concede-pivot">
-                        Concede-and-pivot: supports + attacks edges from the same claim
-                      </div>
-                    )}
-                    {outEdges.map((edge, ei) => {
-                      const targetNode = an?.nodes.find(n => n.id === edge.target);
-                      const edgeLabel = edge.type === 'attacks'
-                        ? (edge.attack_type ? `attacks (${edge.attack_type})` : 'attacks')
-                        : 'supports';
-                      return (
-                        // eslint-disable-next-line local/no-inline-style -- borderLeft computed from edge.type
-                        <div key={ei} style={{ fontSize: 'var(--text-2xs)', margin: '3px 0', paddingLeft: 10, borderLeft: edge.type === 'attacks' ? '2px solid var(--danger)' : '2px solid var(--success)' }}>
-                          <div className="clm-edge-head">
-                            {/* eslint-disable-next-line local/no-inline-style -- color computed from edge.type */}
-                            <span style={{ color: edge.type === 'attacks' ? 'var(--danger)' : 'var(--success)', fontWeight: 600 }}>{edgeLabel}</span>
-                            {edge.strength && (
-                              // eslint-disable-next-line local/no-inline-style -- color computed from strengthColors[edge.strength]
-                              <span style={{ padding: '0 3px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, background: 'var(--bg-hover)', color: strengthColors[edge.strength] ?? 'var(--text-muted)' }}>
-                                {edge.strength}
-                              </span>
-                            )}
-                            {edge.argumentation_scheme && <span className="clm-scheme-badge">{edge.argumentation_scheme}</span>}
-                          </div>
-                          {targetNode && (
-                            <div className="clm-target-node">
-                              <span className="clm-fw600">{targetNode.id}</span> ({POVER_INFO[targetNode.speaker as keyof typeof POVER_INFO]?.label ?? targetNode.speaker}): {targetNode.text}
-                            </div>
-                          )}
-                          {edge.warrant && (
-                            <div className="clm-warrant">
-                              {edge.warrant}
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                  );
-                })()}
-                {repair && repair.verdict !== 'entailed' && repair.repaired_text && (
-                  // eslint-disable-next-line local/no-inline-style -- background/border computed from repair.verdict
-                  <div style={{ paddingLeft: 20, marginTop: 6, marginBottom: 4, padding: '6px 8px', borderRadius: 4, background: (repair.verdict as string) === 'entailed' ? 'color-mix(in srgb, var(--success) 8%, transparent)' : repair.verdict === 'partial' ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'color-mix(in srgb, var(--danger) 8%, transparent)', border: (repair.verdict as string) === 'entailed' ? '1px solid color-mix(in srgb, var(--success) 20%, transparent)' : repair.verdict === 'partial' ? '1px solid color-mix(in srgb, var(--warning) 20%, transparent)' : '1px solid color-mix(in srgb, var(--danger) 20%, transparent)' }}>
-                    {/* eslint-disable-next-line local/no-inline-style -- color from computed verdictColor */}
-                    <div style={{ fontSize: 'var(--text-2xs)', fontWeight: 700, color: verdictColor!, marginBottom: 4 }}>
-                      Entailment Repair ({repair.verdict})
-                    </div>
-                    <div className="clm-repair-line">
-                      <span className="clm-repair-orig">{repair.original_text}</span>
-                    </div>
-                    <div className="clm-repair-fixed">
-                      {repair.repaired_text}
-                    </div>
-                    <div className="clm-repair-explain">
-                      {repair.explanation}
-                    </div>
-                  </div>
-                )}
-                {anNode && (anNode.base_strength != null || anNode.bdi_sub_scores) && (
-                  <details className="clm-indent-block">
-                    <summary className="clm-scores-summary">
-                      Scores{anNode.base_strength != null ? ` — base: ${anNode.base_strength.toFixed(2)}` : ''}{anNode.computed_strength != null ? ` → computed: ${anNode.computed_strength.toFixed(2)}` : ''}{anNode.scoring_method ? ` (${anNode.scoring_method.replace(/_/g, ' ')})` : ''}
-                    </summary>
-                    <div className="clm-scores-body">
-                      {anNode.base_strength != null && (
-                        <div className="clm-scores-row">
-                          <span><strong>Base:</strong> {anNode.base_strength.toFixed(2)}</span>
-                          {anNode.computed_strength != null && <span><strong>Computed:</strong> {anNode.computed_strength.toFixed(2)}</span>}
-                          {anNode.scoring_method && <span className="clm-muted">via {anNode.scoring_method.replace(/_/g, ' ')}</span>}
-                        </div>
-                      )}
-                      {anNode.bdi_sub_scores && (
-                        <div className="clm-subscores">
-                          {Object.entries(anNode.bdi_sub_scores).filter(([, v]) => v != null).map(([k, v]) => {
-                            const label = k.replace(/_/g, ' ');
-                            const strVal = typeof v === 'number' ? (v >= 0.7 ? 'yes' : v >= 0.4 ? 'partial' : 'no') : String(v);
-                            const color = strVal === 'yes' ? 'var(--success)' : strVal === 'partial' ? 'var(--warning)' : 'var(--danger)';
-                            return (
-                              // eslint-disable-next-line local/no-inline-style -- background/color computed from strVal
-                              <span key={k} style={{ padding: '1px 4px', borderRadius: 3, fontSize: 'var(--text-2xs)', background: strVal === 'yes' ? 'color-mix(in srgb, var(--success) 15%, transparent)' : strVal === 'partial' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)', color }}>
-                                {label}: {strVal}
-                              </span>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  </details>
-                )}
-                {/* Evidence graph inline (t/495) */}
-                {(() => {
-                  const eg = anNode?.evidence_graph as { evidence_items: { id: string; source_doc_id: string; text: string; relation: 'support' | 'contradict'; similarity: number }[]; computed_strength: number; qbaf_iterations: number } | undefined;
-                  if (!eg || eg.evidence_items.length === 0) return null;
-                  const barPct = Math.round(eg.computed_strength * 100);
-                  const barColor = eg.computed_strength >= 0.7 ? 'var(--success)' : eg.computed_strength >= 0.4 ? 'var(--warning)' : 'var(--danger)';
-                  const supports = eg.evidence_items.filter(e => e.relation === 'support');
-                  const contradicts = eg.evidence_items.filter(e => e.relation === 'contradict');
-                  return (
-                    <div className="clm-indent-block">
-                      <div className="clm-evidence-header">
-                        Evidence ({supports.length} support, {contradicts.length} contradict)
-                      </div>
-                      <div className="clm-evidence-bar-row">
-                        <div className="clm-bar-track">
-                          {/* eslint-disable-next-line local/no-inline-style -- width/background computed from barPct/barColor */}
-                          <div style={{ width: `${barPct}%`, height: '100%', borderRadius: 3, background: barColor }} />
-                        </div>
-                        {/* eslint-disable-next-line local/no-inline-style -- color from computed barColor */}
-                        <span style={{ fontSize: 'var(--text-2xs)', fontWeight: 700, color: barColor, minWidth: 36 }}>
-                          {eg.computed_strength.toFixed(2)}
-                        </span>
-                        <span className="clm-2xs-muted">
-                          {eg.qbaf_iterations} iter
-                        </span>
-                      </div>
-                      {eg.evidence_items
-                        .sort((a, b) => a.relation !== b.relation ? (a.relation === 'contradict' ? -1 : 1) : b.similarity - a.similarity)
-                        .map(item => (
-                        // eslint-disable-next-line local/no-inline-style -- borderLeft/background computed from item.relation
-                        <div key={item.id} style={{
-                          marginBottom: 3, padding: '3px 6px', borderRadius: 4, fontSize: 'var(--text-2xs)',
-                          borderLeft: item.relation === 'support' ? '2px solid var(--success)' : '2px solid var(--danger)',
-                          background: item.relation === 'support' ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-                        }}>
-                          <div className="clm-evidence-item-head">
-                            {/* eslint-disable-next-line local/no-inline-style -- background/color computed from item.relation */}
-                            <span style={{
-                              fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 4px', borderRadius: 3,
-                              background: item.relation === 'support' ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)',
-                              color: item.relation === 'support' ? 'var(--success)' : 'var(--danger)',
-                            }}>
-                              {item.relation === 'support' ? 'SUP' : 'CON'}
-                            </span>
-                            <span className="clm-muted">{(item.similarity * 100).toFixed(0)}%</span>
-                            <span className="clm-evidence-src">
-                              {item.source_doc_id}
-                            </span>
-                          </div>
-                          <div className="clm-evidence-text">
-                            {item.text.length > 120 ? item.text.slice(0, 120) + '…' : item.text}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  );
-                })()}
-              </details>
-            );
-          })}
-          {diag.extracted_claims.rejected.map((c, i) => {
-            const isDup = c.reason === 'duplicate_claim';
-            const dupOf = isDup ? c.duplicate_of : undefined;
-            const dupText = isDup ? c.duplicate_of_text : undefined;
-            const rejectedNote = c.reason === 'low_overlap'
-              ? 'overlap too low (not grounded)'
-              : isDup
-                ? `duplicate of existing AN node${dupOf ? ` ${dupOf}` : ''}${dupText ? `: "${dupText}"` : ''}`
-                : c.reason;
-            return (
-              <div key={i} className="clm-m3">
-                <span className="clm-c-danger">✗</span> <span data-tooltip={`Word Overlap: ${c.overlap_pct}%\n\nMeasures grounding of claim in the debater's statement.\nFormula: shared words ≥4 chars / total claim words ≥4 chars × 100.\n\nRejected: ${rejectedNote}.`} className="clm-overlap-pct">{c.overlap_pct}%</span> <Highlight text={c.text} />
-                <div className="clm-reject-reason">
-                  {c.reason}
-                  {isDup && dupOf && (
-                    <span className="clm-muted">
-                      {' → duplicates '}
-                      <span className="clm-fw600">{dupOf}</span>
-                      {dupText && <span title={dupText}>{`: "${dupText.length > 80 ? dupText.slice(0, 80) + '…' : dupText}"`}</span>}
-                    </span>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </Section>
-        );
-      })()}
+      {diag?.extracted_claims && (
+        <ExtractedClaimsSection diag={diag as EntryDiagnostics & { extracted_claims: ExtractedClaimsData }} an={an} />
+      )}
 
       {/* Extraction Trace */}
       {extTrace && (

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/DetailsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/DetailsTab.tsx
@@ -52,6 +52,728 @@ export interface DetailsTabProps {
   entryErrors?: (FlightRecorderEvent & { error: { name: string; message: string; stack?: string } })[];
 }
 
+// ---------------------------------------------------------------------------
+// Pure helpers (behavior-preserving extractions of inline computations)
+// ---------------------------------------------------------------------------
+
+function pickReason(o: Record<string, unknown>): string {
+  return o.brief_reason as string ?? o.explanation as string ?? o.conclusion as string ?? '';
+}
+
+function formatPositionResponse(pos: string, reason: string, cond: string | undefined): string {
+  const posLabel = pos === 'agree' ? 'Agreed' : pos === 'disagree' ? 'Disagreed' : pos === 'conditional' ? 'Conditional' : pos;
+  return `${posLabel}${reason ? `: ${reason}` : ''}${cond && pos !== 'agree' ? ` (Condition: ${cond})` : ''}`;
+}
+
+function formatResponseSummary(
+  responseObj: Record<string, unknown> | null,
+  responseStr: string | null,
+): string | null {
+  if (responseStr) return responseStr;
+  if (!responseObj) return null;
+  if (responseObj.from_plan) return responseObj.how_addressed as string;
+  const pos = responseObj.position as string | undefined;
+  const reason = pickReason(responseObj);
+  const cond = responseObj.condition as string | undefined;
+  if (pos) return formatPositionResponse(pos, reason, cond);
+  const typ = responseObj.type as string | undefined;
+  if (typ) return `${typ}${reason ? `: ${reason}` : ''}`;
+  const term = responseObj.term as string | undefined;
+  if (term) return `"${term}": ${responseObj.definition ?? ''}${responseObj.example ? ` (e.g., ${responseObj.example})` : ''}`;
+  const ev = responseObj.evidence as string | undefined;
+  if (ev) return `Evidence: ${ev}`;
+  return JSON.stringify(responseObj);
+}
+
+function interventionCompliance(
+  hasResponse: boolean,
+  isFromPlan: boolean,
+  speakerIsTarget: boolean,
+): { color: string; icon: string } {
+  const color = hasResponse && !isFromPlan ? 'var(--success)'
+    : hasResponse && isFromPlan ? 'var(--warning)'
+    : !speakerIsTarget ? 'var(--text-secondary)'
+    : 'var(--danger)';
+  const icon = hasResponse && !isFromPlan ? '✓'
+    : hasResponse && isFromPlan ? '◐'
+    : !speakerIsTarget ? '→'
+    : '✗';
+  return { color, icon };
+}
+
+type InferredTarget = { id: string; type: 'supports' | 'attacks'; text?: string };
+
+function collectEdgeTargets(
+  turnEdges: ArgumentNetworkEdge[],
+  seen: Set<string>,
+  an: DetailsTabProps['an'],
+  out: InferredTarget[],
+): void {
+  for (const e of turnEdges) {
+    if (!seen.has(e.target)) {
+      seen.add(e.target);
+      const tNode = an?.nodes?.find(n => n.id === e.target);
+      out.push({ id: e.target, type: (e.type === 'revoice_of' ? 'supports' : e.type) as 'supports' | 'attacks', text: tNode?.text });
+    }
+  }
+}
+
+function collectClaimTargets(
+  allClaimTargetIds: string[],
+  seen: Set<string>,
+  an: DetailsTabProps['an'],
+  matchEdgeType: 'attacks' | 'supports' | null,
+  out: InferredTarget[],
+): void {
+  for (const tid of allClaimTargetIds) {
+    if (!seen.has(tid)) {
+      seen.add(tid);
+      const tNode = an?.nodes?.find(n => n.id === tid);
+      out.push({ id: tid, type: matchEdgeType ?? 'supports', text: tNode?.text });
+    }
+  }
+}
+
+function computeInferredTargets(
+  ann: MoveAnnotation | null,
+  an: DetailsTabProps['an'],
+  matchEdgeType: 'attacks' | 'supports' | null,
+  acceptedIds: Set<string>,
+  allClaimTargetIds: string[],
+): InferredTarget[] {
+  const inferredTargets: InferredTarget[] = [];
+  if (!ann?.target && an?.edges) {
+    const turnEdges = (an.edges ?? []).filter(e =>
+      acceptedIds.has(e.source) && (matchEdgeType ? e.type === matchEdgeType : true)
+    );
+    const seen = new Set<string>();
+    collectEdgeTargets(turnEdges, seen, an, inferredTargets);
+    if (inferredTargets.length === 0) {
+      collectClaimTargets(allClaimTargetIds, seen, an, matchEdgeType, inferredTargets);
+    }
+  }
+  return inferredTargets;
+}
+
+function utilityDeltaColor(delta: number | null): string {
+  return delta === null ? 'var(--text-muted)' : delta > 0.01 ? 'var(--success)' : delta < -0.01 ? 'var(--danger)' : 'var(--warning)';
+}
+
+function deriveResponse(interventionResponseField: DetailsTabProps['interventionResponseField']): {
+  hasResponse: boolean;
+  responseObj: Record<string, unknown> | null;
+  responseStr: string | null;
+  isFromPlan: boolean;
+} {
+  const hasResponse = !!interventionResponseField;
+  const responseObj = typeof interventionResponseField === 'object' ? interventionResponseField as Record<string, unknown> : null;
+  const responseStr = typeof interventionResponseField === 'string' ? interventionResponseField : null;
+  const isFromPlan = !!responseObj?.from_plan;
+  return { hasResponse, responseObj, responseStr, isFromPlan };
+}
+
+// ---------------------------------------------------------------------------
+// Props-only sub-components (guards moved inside; JSX moved verbatim)
+// ---------------------------------------------------------------------------
+
+function PipelineErrorBanner({ entry, diag }: {
+  entry: DetailsTabProps['entry'];
+  diag: DetailsTabProps['diag'];
+}): React.ReactNode {
+  if (entry.type !== 'statement') return null;
+  if (!diag) return null;
+  if (!((diag.stage_diagnostics?.length ?? 0) > 0)) return null;
+  if (diag.extracted_claims) return null;
+  if ((diag as Record<string, unknown>).extraction_trace) return null;
+  return (
+    <div className="det-pipeline-error">
+      <div className="det-pipeline-error-title">Pipeline Error</div>
+      <div className="det-body-15">
+        Pipeline stages completed ({diag.stage_diagnostics!.map(s => s.stage).join(' → ')}),
+        but post-pipeline processing failed. Claim extraction, evidence gathering, and argument
+        network updates were skipped for this turn. Check the flight recorder for error details.
+      </div>
+    </div>
+  );
+}
+
+function FlightRecorderErrorsSection({ entryErrors }: {
+  entryErrors: DetailsTabProps['entryErrors'];
+}): React.ReactNode {
+  if (!entryErrors || entryErrors.length === 0) return null;
+  return (
+    <Section title={`Flight Recorder Errors (${entryErrors.length})`} defaultOpen copyText={entryErrors.map(e => `${e.error.name}: ${e.error.message}${e.error.stack ? '\n' + e.error.stack : ''}`).join('\n\n')}>
+      {entryErrors.map((evt, i) => {
+        const data = evt.data as Record<string, unknown> | undefined;
+        return (
+          <div key={i} className="det-error-item">
+            <div className="det-error-head">
+              <span className="det-error-badge">{evt.error.name}</span>
+              {!!data?.speaker && (
+                <span className="det-muted-2xs">
+                  {String(data.speaker)}{data.round ? ` R${data.round}` : ''}
+                </span>
+              )}
+              <span className="det-error-time">
+                {new Date(evt._wall).toLocaleTimeString()}
+              </span>
+            </div>
+            <div className="det-error-msg">{evt.error.message}</div>
+            {evt.error.stack && (
+              <details className="det-mt4">
+                <summary className="det-stack-summary">Stack trace</summary>
+                <pre className="det-stack-pre">{evt.error.stack}</pre>
+              </details>
+            )}
+          </div>
+        );
+      })}
+    </Section>
+  );
+}
+
+function FmtDelta({ v, label, prevV }: {
+  v: number | null;
+  label: string;
+  prevV?: number;
+}): React.ReactNode {
+  if (v === null || v === undefined) return null;
+  const d = prevV !== undefined ? v - prevV : null;
+  const dStr = d !== null ? (d >= 0 ? `+${d.toFixed(3)}` : d.toFixed(3)) : '';
+  const dColor = d !== null ? (d > 0.01 ? 'var(--success)' : d < -0.01 ? 'var(--danger)' : 'var(--text-muted)') : 'var(--text-muted)';
+  return (
+    <span key={label} className="det-fmt-delta">
+      <span className="det-muted">{label}:</span>
+      <strong>{v.toFixed(3)}</strong>
+      {dStr && (
+        // eslint-disable-next-line local/no-inline-style -- dynamic dColor
+        <span style={{ fontSize: 'var(--text-2xs)', color: dColor }}>{dStr}</span>
+      )}
+    </span>
+  );
+}
+
+function PerTurnUtilityDelta({ perTurnUtilities, entry }: {
+  perTurnUtilities: DetailsTabProps['perTurnUtilities'];
+  entry: DetailsTabProps['entry'];
+}): React.ReactNode {
+  const turnSnap = perTurnUtilities?.find(s => s.entryId === entry.id);
+  if (!turnSnap) return null;
+  const snapIdx = perTurnUtilities.indexOf(turnSnap);
+  const prevSnap = snapIdx > 0 ? perTurnUtilities[snapIdx - 1] : null;
+  const curr = turnSnap.byAgent[entry.speaker];
+  const prev = prevSnap?.byAgent[entry.speaker];
+  if (!curr) return null;
+  const delta = prev ? curr.composite - prev.composite : null;
+  const deltaColor = utilityDeltaColor(delta);
+  const speakerColor: Record<string, string> = { accelerationist: 'var(--color-acc)', safetyist: 'var(--color-saf)', skeptic: 'var(--color-skp)' };
+  const color = speakerColor[entry.speaker] ?? 'var(--text-muted)';
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic speaker color background/border-left
+    <div style={{
+      marginBottom: 10, padding: '8px 10px', borderRadius: 5,
+      background: `${color}08`, borderLeft: `3px solid ${color}`,
+      fontSize: '0.72rem',
+    }}>
+      <div className="det-row-g8-mb4">
+        {/* eslint-disable-next-line local/no-inline-style -- dynamic speaker color */}
+        <span style={{ fontWeight: 700, fontSize: 'var(--text-2xs)', textTransform: 'uppercase', letterSpacing: '0.05em', color }}>Utility</span>
+        <span className="det-num-bold">{curr.composite.toFixed(3)}</span>
+        {delta !== null && (
+          // eslint-disable-next-line local/no-inline-style -- dynamic deltaColor
+          <span style={{ fontSize: '0.7rem', fontWeight: 600, color: deltaColor }}>
+            {delta >= 0 ? '+' : ''}{delta.toFixed(3)}
+          </span>
+        )}
+      </div>
+      <div className="det-flex-wrap-g14">
+        <FmtDelta v={curr.position_strength} label="pos" prevV={prev?.position_strength} />
+        <FmtDelta v={curr.attack_effectiveness} label="atk" prevV={prev?.attack_effectiveness} />
+        <FmtDelta v={curr.crux_engagement} label="crux" prevV={prev?.crux_engagement} />
+      </div>
+    </div>
+  );
+}
+
+function InterventionTargetBadge({ targetLabel, speakerIsTarget, entry }: {
+  targetLabel: string | null;
+  speakerIsTarget: boolean;
+  entry: DetailsTabProps['entry'];
+}): React.ReactNode {
+  if (!targetLabel) return null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic color/weight from speakerIsTarget
+    <span style={{ fontSize: 'var(--text-2xs)', color: !speakerIsTarget ? 'var(--text-secondary)' : 'var(--text-muted)', fontWeight: !speakerIsTarget ? 600 : 400 }}>
+      directed at {targetLabel}{!speakerIsTarget ? ` (not ${speakerLabel(entry.speaker)})` : ''}
+    </span>
+  );
+}
+
+function InterventionComplianceBox({
+  complianceColor, complianceIcon, hasResponse, isFromPlan, speakerIsTarget, targetLabel, entry, responseObj, responseStr,
+}: {
+  complianceColor: string;
+  complianceIcon: string;
+  hasResponse: boolean;
+  isFromPlan: boolean;
+  speakerIsTarget: boolean;
+  targetLabel: string | null;
+  entry: DetailsTabProps['entry'];
+  responseObj: Record<string, unknown> | null;
+  responseStr: string | null;
+}): React.ReactNode {
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic complianceColor background/border
+    <div style={{
+      display: 'flex', alignItems: 'flex-start', gap: 8,
+      padding: '6px 10px', borderRadius: 4,
+      background: `${complianceColor}12`,
+      border: `1px solid ${complianceColor}30`,
+    }}>
+      {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor background */}
+      <span style={{
+        width: 8, height: 8, borderRadius: '50%',
+        background: complianceColor,
+        flexShrink: 0, marginTop: 4,
+      }} />
+      <div>
+        {hasResponse && (
+          <>
+            {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor */}
+            <span style={{ fontWeight: 700, fontSize: '0.72rem', color: complianceColor }}>
+              {complianceIcon} {isFromPlan ? 'Addressed in plan' : 'Responded'}
+            </span>
+            {isFromPlan && (
+              <div className="det-muted-2xs-mt1">
+                Structured response field missing &mdash; showing plan intent
+              </div>
+            )}
+            <div className="det-primary-7-mt2">
+              {formatResponseSummary(responseObj, responseStr)}
+            </div>
+          </>
+        )}
+        {!hasResponse && !speakerIsTarget && (
+          <>
+            {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor */}
+            <span style={{ fontWeight: 700, fontSize: '0.72rem', color: complianceColor }}>
+              {complianceIcon} Not targeted
+            </span>
+            <div className="det-muted-2xs-mt2">
+              This directive was aimed at {targetLabel}, but {speakerLabel(entry.speaker)} was selected to speak. {speakerLabel(entry.speaker)} was not required to respond.
+            </div>
+          </>
+        )}
+        {!hasResponse && speakerIsTarget && (
+          <>
+            {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor */}
+            <span style={{ fontWeight: 700, fontSize: '0.72rem', color: complianceColor }}>
+              {complianceIcon} No response
+            </span>
+            <div className="det-muted-2xs-mt2">
+              The debater did not provide an explicit response to this directive.
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PrecedingInterventionSection({ precedingIntervention, entry, interventionResponseField }: {
+  precedingIntervention: DetailsTabProps['precedingIntervention'];
+  entry: DetailsTabProps['entry'];
+  interventionResponseField: DetailsTabProps['interventionResponseField'];
+}): React.ReactNode {
+  if (!precedingIntervention) return null;
+  const intMeta = precedingIntervention.intervention_metadata as {
+    family?: string; move?: string; force?: string; target_debater?: string;
+    trigger_reason?: string;
+  } | undefined;
+  const targetSpeakerId = intMeta?.target_debater;
+  const targetLabel = targetSpeakerId
+    ? (POVER_INFO[targetSpeakerId as Exclude<SpeakerId, 'user'>]?.label ?? targetSpeakerId)
+    : null;
+  const speakerIsTarget = targetLabel
+    ? targetLabel === speakerLabel(entry.speaker)
+    : true;
+  const moveLabel = intMeta?.move ?? 'directive';
+  const familyLabel = intMeta?.family ?? '';
+  const directiveText = typeof precedingIntervention.content === 'string'
+    ? precedingIntervention.content
+    : JSON.stringify(precedingIntervention.content);
+
+  const { hasResponse, responseObj, responseStr, isFromPlan } = deriveResponse(interventionResponseField);
+
+  const { color: complianceColor, icon: complianceIcon } = interventionCompliance(hasResponse, isFromPlan, speakerIsTarget);
+
+  return (
+    <div className="det-mod-directive">
+      <div className="det-row-g8-mb6">
+        <span className="det-mod-directive-title">
+          Moderator Directive
+        </span>
+        <span className="det-skp-badge">
+          {moveLabel}{familyLabel ? ` · ${familyLabel}` : ''}
+        </span>
+        <InterventionTargetBadge targetLabel={targetLabel} speakerIsTarget={speakerIsTarget} entry={entry} />
+      </div>
+      <div className="det-directive-text">
+        &ldquo;{directiveText}&rdquo;
+      </div>
+      <InterventionComplianceBox
+        complianceColor={complianceColor}
+        complianceIcon={complianceIcon}
+        hasResponse={hasResponse}
+        isFromPlan={isFromPlan}
+        speakerIsTarget={speakerIsTarget}
+        targetLabel={targetLabel}
+        entry={entry}
+        responseObj={responseObj}
+        responseStr={responseStr}
+      />
+    </div>
+  );
+}
+
+function SuppressedInterventionSection({ suppressedIntervention }: {
+  suppressedIntervention: DetailsTabProps['suppressedIntervention'];
+}): React.ReactNode {
+  if (!suppressedIntervention) return null;
+  return (
+    <div className="det-suppressed">
+      <div className="det-row-g6-mb6">
+        <span className="det-suppressed-title">
+          {'⚠'} Suppressed Intervention
+        </span>
+        {suppressedIntervention.intervention_move && (
+          <span className="det-warning-badge">
+            {suppressedIntervention.intervention_move}
+          </span>
+        )}
+      </div>
+      <div className="det-primary-7-mb4">
+        The moderator recommended a <strong>{suppressedIntervention.intervention_move ?? 'intervention'}</strong>
+        {suppressedIntervention.intervention_target && (
+          <> directed at <strong>{speakerLabel(suppressedIntervention.intervention_target)}</strong></>
+        )}
+        , but it was blocked by the engine.
+      </div>
+      <div className="det-suppressed-reason">
+        <strong className="det-warning">Reason: </strong>
+        {suppressedIntervention.intervention_suppressed_reason && (
+          <span
+            title={SUPPRESSION_REASON_TOOLTIPS[suppressedIntervention.intervention_suppressed_reason] ?? ''}
+            className="det-suppressed-reason-label"
+          >
+            {String(suppressedIntervention.intervention_suppressed_reason ?? '').replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase())}
+          </span>
+        )}
+        {suppressedIntervention.intervention_suppression_explanation
+          ? (suppressedIntervention.intervention_suppressed_reason ? ' — ' : '') + suppressedIntervention.intervention_suppression_explanation
+          : (!suppressedIntervention.intervention_suppressed_reason ? 'No reason recorded' : '')
+        }
+      </div>
+      {suppressedIntervention.trigger_reasoning && (
+        <div className="det-muted-2xs-mt4-italic">
+          {suppressedIntervention.trigger_reasoning}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MoveTargets({ ann, an, inferredTargets }: {
+  ann: MoveAnnotation | null;
+  an: DetailsTabProps['an'];
+  inferredTargets: InferredTarget[];
+}): React.ReactNode {
+  return (
+    <>
+      {ann?.target && (() => {
+        const targetNode = an?.nodes?.find(n => n.id === ann.target);
+        return (<>
+          <span className="det-ml6-muted-2xs">{'→'} {ann.target}</span>
+          {targetNode && <span className="det-ml4-muted-2xs-italic">"{targetNode.text.length > 100 ? targetNode.text.slice(0, 100) + '…' : targetNode.text}"</span>}
+        </>);
+      })()}
+      {!ann?.target && inferredTargets.length > 0 && (
+        <div className="det-inferred-targets">
+          <span className="det-muted-2xs">{'→'}</span>
+          {inferredTargets.map(t => (
+            // eslint-disable-next-line local/no-inline-style -- dynamic attack/support color
+            <span key={t.id} data-tooltip={t.text} style={{
+              padding: '1px 5px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, cursor: 'default',
+              background: `${t.type === 'attacks' ? 'var(--danger)' : 'var(--success)'}15`,
+              color: t.type === 'attacks' ? 'var(--danger)' : 'var(--success)',
+            }}>{t.id}</span>
+          ))}
+        </div>
+      )}
+      {!ann?.target && inferredTargets.length === 0 && (
+        <span className="det-ml6-muted-2xs-o6">no AN target</span>
+      )}
+    </>
+  );
+}
+
+function MoveItem({ m, index, an, acceptedIds, allClaimTargetIds }: {
+  m: string | MoveAnnotation;
+  index: number;
+  an: DetailsTabProps['an'];
+  acceptedIds: Set<string>;
+  allClaimTargetIds: string[];
+}): React.ReactNode {
+  const name = getMoveName(m);
+  const ann = typeof m === 'object' ? m as MoveAnnotation : null;
+  const edgeInfo = MOVE_EDGE_MAP[name.toUpperCase()] || MOVE_EDGE_MAP[name];
+  const cat = edgeInfo?.edgeType || 'neutral';
+  const catColor = cat === 'attack' ? 'var(--danger)' : cat === 'support' ? 'var(--success)' : '#888';
+  const matchEdgeType = cat === 'attack' ? 'attacks' : cat === 'support' ? 'supports' : null;
+  const inferredTargets = computeInferredTargets(ann, an, matchEdgeType, acceptedIds, allClaimTargetIds);
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic catColor border-left
+    <div key={index} style={{ margin: '4px 0', paddingLeft: 8, borderLeft: `2px solid ${catColor}44` }}>
+      <span className="det-saf-badge">{name}</span>
+      {/* eslint-disable-next-line local/no-inline-style -- dynamic catColor background/color */}
+      <span style={{ marginLeft: 6, padding: '1px 5px', borderRadius: 3, background: `${catColor}18`, color: catColor, fontSize: 'var(--text-2xs)', fontWeight: 600, textTransform: 'capitalize' }}>{cat}</span>
+      <MoveTargets ann={ann} an={an} inferredTargets={inferredTargets} />
+      {ann?.detail && <div className="det-primary-7-mt2">{ann.detail}</div>}
+    </div>
+  );
+}
+
+function DialecticalMovesSection({ meta, diag, an }: {
+  meta: DetailsTabProps['meta'];
+  diag: DetailsTabProps['diag'];
+  an: DetailsTabProps['an'];
+}): React.ReactNode {
+  if (!meta?.move_types) return null;
+  const acceptedIds = new Set(diag?.extracted_claims?.accepted.map(c => c.id) ?? []);
+  const claimTargets = (meta.my_claims as { claim: string; targets: string[] }[] | undefined) ?? [];
+  const allClaimTargetIds = [...new Set(claimTargets.flatMap(c => c.targets ?? []))];
+  return (
+    <Section title={`Dialectical Moves — ${(meta.move_types as (string | MoveAnnotation)[]).map(m => getMoveName(m)).join(', ')}`} defaultOpen copyText={`Moves: ${(meta.move_types as (string | MoveAnnotation)[]).map(m => getMoveName(m)).join(', ')}${meta.disagreement_type ? `\nType: ${meta.disagreement_type}` : ''}`}>
+      {(meta.move_types as (string | MoveAnnotation)[]).map((m, i) => (
+        <MoveItem key={i} m={m} index={i} an={an} acceptedIds={acceptedIds} allClaimTargetIds={allClaimTargetIds} />
+      ))}
+      {meta.disagreement_type ? <div className="det-mt4">Type: <strong>{String(meta.disagreement_type)}</strong></div> : null}
+    </Section>
+  );
+}
+
+function TurnValidationSummarySection({ turnValTrail }: {
+  turnValTrail: DetailsTabProps['turnValTrail'];
+}): React.ReactNode {
+  if (!turnValTrail) return null;
+  return (
+    <Section
+      title={`Turn Validation — ${turnValTrail.final.outcome} (score ${(turnValTrail.final.process_reward ?? 0).toFixed(2)}, ${turnValTrail.attempts.length} attempt${turnValTrail.attempts.length === 1 ? '' : 's'})`}
+      defaultOpen
+    >
+      {/* Inline turn validation summary (lightweight version) */}
+      <div className="det-fs-75">
+        <div className="det-row-g8-mb4">
+          {/* eslint-disable-next-line local/no-inline-style -- dynamic outcome-based background/color */}
+          <span style={{
+            padding: '2px 8px', borderRadius: 4, fontWeight: 700, fontSize: '0.7rem',
+            background: turnValTrail.final.outcome === 'pass' ? 'rgba(22,163,74,0.15)' : turnValTrail.final.outcome === 'accept_with_flag' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'rgba(220,38,38,0.15)',
+            color: turnValTrail.final.outcome === 'pass' ? 'var(--success)' : turnValTrail.final.outcome === 'accept_with_flag' ? 'var(--warning)' : 'var(--danger)',
+          }}>{turnValTrail.final.outcome}</span>
+          <span>score <strong>{(turnValTrail.final.process_reward ?? 0).toFixed(2)}</strong></span>
+          <span className="det-muted">{turnValTrail.attempts.length} attempt{turnValTrail.attempts.length === 1 ? '' : 's'}</span>
+        </div>
+        {turnValTrail.final.repairHints && turnValTrail.final.repairHints.length > 0 && (
+          <div className="det-mt4">
+            <strong>Caveats:</strong>
+            <ul className="det-caveats-list">
+              {turnValTrail.final.repairHints.map((h, i) => {
+                const target = classifyHintTarget(h);
+                const ts = HINT_TARGET_STYLE[target];
+                return (
+                  <li key={i} className="det-mb3">
+                    {/* eslint-disable-next-line local/no-inline-style -- dynamic hint-target color/bg */}
+                    <span style={{
+                      display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
+                      color: ts.color, background: ts.bg, padding: '1px 5px',
+                      borderRadius: 3, marginRight: 5, verticalAlign: 'middle',
+                    }}>{ts.label}</span>
+                    {humanizeSpeakerIds(h)}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+function CommitmentsInjectedSection({ diag }: {
+  diag: DetailsTabProps['diag'];
+}): React.ReactNode {
+  if (!diag?.commitment_context) return null;
+  return (
+    <Section title="Commitments Injected" defaultOpen copyText={diag.commitment_context}>
+      <ResizablePre tall text={diag.commitment_context} />
+    </Section>
+  );
+}
+
+function EdgesUsedSection({ diag, allEdges, taxNodeMap, nodeLabels }: {
+  diag: DetailsTabProps['diag'];
+  allEdges: DetailsTabProps['allEdges'];
+  taxNodeMap: DetailsTabProps['taxNodeMap'];
+  nodeLabels: DetailsTabProps['nodeLabels'];
+}): React.ReactNode {
+  if (!(!!(diag as Record<string, unknown>)?.edges_used && ((diag as Record<string, unknown>).edges_used as { source: string; target: string; type: string; confidence: number }[]).length > 0)) return null;
+  return (
+    <Section title={`Edges Used (${((diag as Record<string, unknown>).edges_used as unknown[]).length})`} defaultOpen copyText={((diag as Record<string, unknown>).edges_used as { source: string; target: string; type: string; confidence: number }[]).map(e => `${e.source} ${e.type} ${e.target} (${(e.confidence ?? 0).toFixed(2)})`).join('\n')}>
+      <EdgesUsedGrouped edges={(diag as Record<string, unknown>).edges_used as { source: string; target: string; type: string; confidence: number }[]} allEdges={allEdges} taxNodeMap={taxNodeMap} nodeLabels={nodeLabels} />
+    </Section>
+  );
+}
+
+function KeyAssumptionsSection({ meta }: {
+  meta: DetailsTabProps['meta'];
+}): React.ReactNode {
+  if (!meta?.key_assumptions) return null;
+  if ((meta.key_assumptions as { assumption: string; if_wrong: string }[]).length === 0) return null;
+  return (
+    <Section title={`Key Assumptions (${(meta.key_assumptions as unknown[]).length})`} defaultOpen copyText={(meta.key_assumptions as { assumption: string; if_wrong: string }[]).map(a => `Assumes: ${a.assumption}\nIf wrong: ${a.if_wrong}`).join('\n\n')}>
+      {(meta.key_assumptions as { assumption: string; if_wrong: string }[]).map((a, i) => (
+        <div key={i} className="det-assumption">
+          <div><strong>Assumes:</strong> {a.assumption}</div>
+          <div className="det-muted-7">If wrong: {a.if_wrong}</div>
+        </div>
+      ))}
+    </Section>
+  );
+}
+
+function PolicyRefsSection({ meta, entry, policyMap }: {
+  meta: DetailsTabProps['meta'];
+  entry: DetailsTabProps['entry'];
+  policyMap: DetailsTabProps['policyMap'];
+}): React.ReactNode {
+  const rawPolRefs = (meta?.policy_refs as (string | { policy_id: string; relevance?: string })[] | undefined) || entry.policy_refs || [];
+  const polIds = rawPolRefs.map(p => typeof p === 'string' ? p : p.policy_id);
+  if (polIds.length === 0) return null;
+  return (
+    <Section title={`Policy Refs (${polIds.length})`} defaultOpen copyText={polIds.join(', ')}>
+      <ul className="det-policy-list">
+        {polIds.map((p, i) => {
+          const pol = policyMap.get(p);
+          return (
+            <li key={i} className="det-policy-item">
+              <span className="det-policy-id">{p}</span>
+              {pol ? (
+                <span className="det-primary-72">
+                  {pol.action}
+                  <span className="det-ml6-muted-2xs">
+                    ({pol.source_povs.join(', ')}{pol.member_count > 0 ? ` · ${pol.member_count} members` : ''})
+                  </span>
+                </span>
+              ) : (
+                <span className="det-muted-72-italic">not in registry</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </Section>
+  );
+}
+
+function EdgeTensionsSection({ diag }: {
+  diag: DetailsTabProps['diag'];
+}): React.ReactNode {
+  if (!diag?.edge_tensions) return null;
+  return (
+    <Section title="Edge Tensions" defaultOpen copyText={diag.edge_tensions}>
+      <ResizablePre tall text={diag.edge_tensions} />
+    </Section>
+  );
+}
+
+function ArgumentNetworkContextSection({ diag }: {
+  diag: DetailsTabProps['diag'];
+}): React.ReactNode {
+  if (!diag?.argument_network_context) return null;
+  return (
+    <Section title="Argument Network Context" defaultOpen copyText={diag.argument_network_context}>
+      <ResizablePre tall text={diag.argument_network_context} />
+    </Section>
+  );
+}
+
+function ModelTimingSection({ diag }: {
+  diag: DetailsTabProps['diag'];
+}): React.ReactNode {
+  if (!diag?.model) return null;
+  return (
+    <Section title={`Model & Timing — ${diag.model} (${diag.response_time_ms ? (diag.response_time_ms / 1000).toFixed(1) + 's' : '?'})`} defaultOpen copyText={`Model: ${diag.model}\nResponse: ${diag.response_time_ms ? (diag.response_time_ms / 1000).toFixed(1) + 's' : '?'}`}>
+      <div>Model: {diag.model}</div>
+      {diag.response_time_ms && <div>Response: {(diag.response_time_ms / 1000).toFixed(1)}s</div>}
+    </Section>
+  );
+}
+
+function LineageFrameSection({ debate, entry }: {
+  debate: DetailsTabProps['debate'];
+  entry: DetailsTabProps['entry'];
+}): React.ReactNode {
+  const frame = debate.topic.critique?.lineage_frame;
+  if (!frame || frame.length === 0) return null;
+  const manifest = (entry.metadata as Record<string, unknown>)?.injection_manifest as {
+    lineage_boost?: { boostedNodeIds?: string[]; promotedNodeIds?: string[] };
+  } | undefined;
+  const lb = manifest?.lineage_boost;
+  const maxPct = Math.max(...frame.map((f: { percentage: number }) => f.percentage));
+  return (
+    <Section title={`Lineage Frame (${frame.length} categor${frame.length !== 1 ? 'ies' : 'y'})`} copyText={frame.map((f: { label?: string; cluster_id: string; percentage: number; traditions?: string[] }) => `${f.label ?? f.cluster_id}: ${f.percentage.toFixed(1)}%${f.traditions?.length ? ` (${f.traditions.join(', ')})` : ''}`).join('\n')}>
+      {frame.map((f: { cluster_id: string; label?: string; percentage: number; traditions?: string[] }, i: number) => (
+        <div key={i} className="det-mb6">
+          <div className="det-row-g6">
+            <div className="det-lineage-label">{f.label ?? f.cluster_id}</div>
+            <div className="det-lineage-bar">
+              {/* eslint-disable-next-line local/no-inline-style -- dynamic computed width */}
+              <div style={{ width: `${maxPct > 0 ? (f.percentage / maxPct) * 100 : 0}%`, height: '100%', borderRadius: 3, background: 'var(--warning)' }} />
+            </div>
+            <div className="det-lineage-pct">{f.percentage.toFixed(1)}%</div>
+          </div>
+          {f.traditions && f.traditions.length > 0 && (
+            <div className="det-lineage-traditions">
+              {f.traditions.join(', ')}
+            </div>
+          )}
+        </div>
+      ))}
+      <div className="det-mt4-muted-2xs">
+        Boost: {lb ? <span className="det-success">active</span> : <span>inactive</span>}
+        {lb && lb.promotedNodeIds && lb.promotedNodeIds.length > 0 && (
+          <> {'·'} {lb.promotedNodeIds.length} promoted</>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+function StatementSection({ entry }: {
+  entry: DetailsTabProps['entry'];
+}): React.ReactNode {
+  if (!entry.content) return null;
+  if (entry.type !== 'opening') return null;
+  return (
+    <Section title="Statement" defaultOpen copyText={entry.content}>
+      <div className="det-statement">
+        <Highlight text={entry.content} />
+      </div>
+    </Section>
+  );
+}
+
 /**
  * DetailsTab -- Overview/Details tab.
  * Shows per-turn utility delta, preceding intervention, suppressed intervention,
@@ -72,519 +794,37 @@ export function DetailsTab({ entry, entryIdx, diag, meta, debate, an, turnValTra
   return (
     <div className="det-root">
       {/* Pipeline error banner */}
-      {entry.type === 'statement' && diag && (diag.stage_diagnostics?.length ?? 0) > 0 && !diag.extracted_claims && !(diag as Record<string, unknown>).extraction_trace && (
-        <div className="det-pipeline-error">
-          <div className="det-pipeline-error-title">Pipeline Error</div>
-          <div className="det-body-15">
-            Pipeline stages completed ({diag.stage_diagnostics!.map(s => s.stage).join(' → ')}),
-            but post-pipeline processing failed. Claim extraction, evidence gathering, and argument
-            network updates were skipped for this turn. Check the flight recorder for error details.
-          </div>
-        </div>
-      )}
+      <PipelineErrorBanner entry={entry} diag={diag} />
       {/* Flight recorder errors for this entry */}
-      {entryErrors && entryErrors.length > 0 && (
-        <Section title={`Flight Recorder Errors (${entryErrors.length})`} defaultOpen copyText={entryErrors.map(e => `${e.error.name}: ${e.error.message}${e.error.stack ? '\n' + e.error.stack : ''}`).join('\n\n')}>
-          {entryErrors.map((evt, i) => {
-            const data = evt.data as Record<string, unknown> | undefined;
-            return (
-              <div key={i} className="det-error-item">
-                <div className="det-error-head">
-                  <span className="det-error-badge">{evt.error.name}</span>
-                  {!!data?.speaker && (
-                    <span className="det-muted-2xs">
-                      {String(data.speaker)}{data.round ? ` R${data.round}` : ''}
-                    </span>
-                  )}
-                  <span className="det-error-time">
-                    {new Date(evt._wall).toLocaleTimeString()}
-                  </span>
-                </div>
-                <div className="det-error-msg">{evt.error.message}</div>
-                {evt.error.stack && (
-                  <details className="det-mt4">
-                    <summary className="det-stack-summary">Stack trace</summary>
-                    <pre className="det-stack-pre">{evt.error.stack}</pre>
-                  </details>
-                )}
-              </div>
-            );
-          })}
-        </Section>
-      )}
+      <FlightRecorderErrorsSection entryErrors={entryErrors} />
       {/* Per-turn utility delta for this speaker */}
-      {((): React.ReactNode => {
-        const turnSnap = perTurnUtilities?.find(s => s.entryId === entry.id);
-        if (!turnSnap) return null;
-        const snapIdx = perTurnUtilities.indexOf(turnSnap);
-        const prevSnap = snapIdx > 0 ? perTurnUtilities[snapIdx - 1] : null;
-        const curr = turnSnap.byAgent[entry.speaker];
-        const prev = prevSnap?.byAgent[entry.speaker];
-        if (!curr) return null;
-        const delta = prev ? curr.composite - prev.composite : null;
-        const deltaColor = delta === null ? 'var(--text-muted)' : delta > 0.01 ? 'var(--success)' : delta < -0.01 ? 'var(--danger)' : 'var(--warning)';
-        const speakerColor: Record<string, string> = { accelerationist: 'var(--color-acc)', safetyist: 'var(--color-saf)', skeptic: 'var(--color-skp)' };
-        const color = speakerColor[entry.speaker] ?? 'var(--text-muted)';
-        const fmtDelta = (v: number | null, label: string, prevV?: number) => {
-          if (v === null || v === undefined) return null;
-          const d = prevV !== undefined ? v - prevV : null;
-          const dStr = d !== null ? (d >= 0 ? `+${d.toFixed(3)}` : d.toFixed(3)) : '';
-          const dColor = d !== null ? (d > 0.01 ? 'var(--success)' : d < -0.01 ? 'var(--danger)' : 'var(--text-muted)') : 'var(--text-muted)';
-          return (
-            <span key={label} className="det-fmt-delta">
-              <span className="det-muted">{label}:</span>
-              <strong>{v.toFixed(3)}</strong>
-              {dStr && (
-                // eslint-disable-next-line local/no-inline-style -- dynamic dColor
-                <span style={{ fontSize: 'var(--text-2xs)', color: dColor }}>{dStr}</span>
-              )}
-            </span>
-          );
-        };
-        return (
-          // eslint-disable-next-line local/no-inline-style -- dynamic speaker color background/border-left
-          <div style={{
-            marginBottom: 10, padding: '8px 10px', borderRadius: 5,
-            background: `${color}08`, borderLeft: `3px solid ${color}`,
-            fontSize: '0.72rem',
-          }}>
-            <div className="det-row-g8-mb4">
-              {/* eslint-disable-next-line local/no-inline-style -- dynamic speaker color */}
-              <span style={{ fontWeight: 700, fontSize: 'var(--text-2xs)', textTransform: 'uppercase', letterSpacing: '0.05em', color }}>Utility</span>
-              <span className="det-num-bold">{curr.composite.toFixed(3)}</span>
-              {delta !== null && (
-                // eslint-disable-next-line local/no-inline-style -- dynamic deltaColor
-                <span style={{ fontSize: '0.7rem', fontWeight: 600, color: deltaColor }}>
-                  {delta >= 0 ? '+' : ''}{delta.toFixed(3)}
-                </span>
-              )}
-            </div>
-            <div className="det-flex-wrap-g14">
-              {fmtDelta(curr.position_strength, 'pos', prev?.position_strength)}
-              {fmtDelta(curr.attack_effectiveness, 'atk', prev?.attack_effectiveness)}
-              {fmtDelta(curr.crux_engagement, 'crux', prev?.crux_engagement)}
-            </div>
-          </div>
-        );
-      })()}
-
+      <PerTurnUtilityDelta perTurnUtilities={perTurnUtilities} entry={entry} />
       {/* Preceding Intervention */}
-      {precedingIntervention && (() => {
-        const intMeta = precedingIntervention.intervention_metadata as {
-          family?: string; move?: string; force?: string; target_debater?: string;
-          trigger_reason?: string;
-        } | undefined;
-        const targetSpeakerId = intMeta?.target_debater;
-        const targetLabel = targetSpeakerId
-          ? (POVER_INFO[targetSpeakerId as Exclude<SpeakerId, 'user'>]?.label ?? targetSpeakerId)
-          : null;
-        const speakerIsTarget = targetLabel
-          ? targetLabel === speakerLabel(entry.speaker)
-          : true;
-        const moveLabel = intMeta?.move ?? 'directive';
-        const familyLabel = intMeta?.family ?? '';
-        const directiveText = typeof precedingIntervention.content === 'string'
-          ? precedingIntervention.content
-          : JSON.stringify(precedingIntervention.content);
-
-        const hasResponse = !!interventionResponseField;
-        const responseObj = typeof interventionResponseField === 'object' ? interventionResponseField as Record<string, unknown> : null;
-        const responseStr = typeof interventionResponseField === 'string' ? interventionResponseField : null;
-        const isFromPlan = !!responseObj?.from_plan;
-
-        const complianceColor = hasResponse && !isFromPlan ? 'var(--success)'
-          : hasResponse && isFromPlan ? 'var(--warning)'
-          : !speakerIsTarget ? 'var(--text-secondary)'
-          : 'var(--danger)';
-        const complianceIcon = hasResponse && !isFromPlan ? '✓'
-          : hasResponse && isFromPlan ? '◐'
-          : !speakerIsTarget ? '→'
-          : '✗';
-
-        const formatResponseSummary = () => {
-          if (responseStr) return responseStr;
-          if (!responseObj) return null;
-          if (responseObj.from_plan) return responseObj.how_addressed as string;
-          const pos = responseObj.position as string | undefined;
-          const reason = responseObj.brief_reason as string ?? responseObj.explanation as string ?? responseObj.conclusion as string ?? '';
-          const cond = responseObj.condition as string | undefined;
-          if (pos) {
-            const posLabel = pos === 'agree' ? 'Agreed' : pos === 'disagree' ? 'Disagreed' : pos === 'conditional' ? 'Conditional' : pos;
-            return `${posLabel}${reason ? `: ${reason}` : ''}${cond && pos !== 'agree' ? ` (Condition: ${cond})` : ''}`;
-          }
-          const typ = responseObj.type as string | undefined;
-          if (typ) return `${typ}${reason ? `: ${reason}` : ''}`;
-          const term = responseObj.term as string | undefined;
-          if (term) return `"${term}": ${responseObj.definition ?? ''}${responseObj.example ? ` (e.g., ${responseObj.example})` : ''}`;
-          const ev = responseObj.evidence as string | undefined;
-          if (ev) return `Evidence: ${ev}`;
-          return JSON.stringify(responseObj);
-        };
-
-        return (
-          <div className="det-mod-directive">
-            <div className="det-row-g8-mb6">
-              <span className="det-mod-directive-title">
-                Moderator Directive
-              </span>
-              <span className="det-skp-badge">
-                {moveLabel}{familyLabel ? ` · ${familyLabel}` : ''}
-              </span>
-              {targetLabel && (
-                // eslint-disable-next-line local/no-inline-style -- dynamic color/weight from speakerIsTarget
-                <span style={{ fontSize: 'var(--text-2xs)', color: !speakerIsTarget ? 'var(--text-secondary)' : 'var(--text-muted)', fontWeight: !speakerIsTarget ? 600 : 400 }}>
-                  directed at {targetLabel}{!speakerIsTarget ? ` (not ${speakerLabel(entry.speaker)})` : ''}
-                </span>
-              )}
-            </div>
-            <div className="det-directive-text">
-              &ldquo;{directiveText}&rdquo;
-            </div>
-            {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor background/border */}
-            <div style={{
-              display: 'flex', alignItems: 'flex-start', gap: 8,
-              padding: '6px 10px', borderRadius: 4,
-              background: `${complianceColor}12`,
-              border: `1px solid ${complianceColor}30`,
-            }}>
-              {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor background */}
-              <span style={{
-                width: 8, height: 8, borderRadius: '50%',
-                background: complianceColor,
-                flexShrink: 0, marginTop: 4,
-              }} />
-              <div>
-                {hasResponse && (
-                  <>
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor */}
-                    <span style={{ fontWeight: 700, fontSize: '0.72rem', color: complianceColor }}>
-                      {complianceIcon} {isFromPlan ? 'Addressed in plan' : 'Responded'}
-                    </span>
-                    {isFromPlan && (
-                      <div className="det-muted-2xs-mt1">
-                        Structured response field missing &mdash; showing plan intent
-                      </div>
-                    )}
-                    <div className="det-primary-7-mt2">
-                      {formatResponseSummary()}
-                    </div>
-                  </>
-                )}
-                {!hasResponse && !speakerIsTarget && (
-                  <>
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor */}
-                    <span style={{ fontWeight: 700, fontSize: '0.72rem', color: complianceColor }}>
-                      {complianceIcon} Not targeted
-                    </span>
-                    <div className="det-muted-2xs-mt2">
-                      This directive was aimed at {targetLabel}, but {speakerLabel(entry.speaker)} was selected to speak. {speakerLabel(entry.speaker)} was not required to respond.
-                    </div>
-                  </>
-                )}
-                {!hasResponse && speakerIsTarget && (
-                  <>
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic complianceColor */}
-                    <span style={{ fontWeight: 700, fontSize: '0.72rem', color: complianceColor }}>
-                      {complianceIcon} No response
-                    </span>
-                    <div className="det-muted-2xs-mt2">
-                      The debater did not provide an explicit response to this directive.
-                    </div>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
-        );
-      })()}
-
+      <PrecedingInterventionSection precedingIntervention={precedingIntervention} entry={entry} interventionResponseField={interventionResponseField} />
       {/* Suppressed Intervention */}
-      {suppressedIntervention ? (
-        <div className="det-suppressed">
-          <div className="det-row-g6-mb6">
-            <span className="det-suppressed-title">
-              {'⚠'} Suppressed Intervention
-            </span>
-            {suppressedIntervention.intervention_move && (
-              <span className="det-warning-badge">
-                {suppressedIntervention.intervention_move}
-              </span>
-            )}
-          </div>
-          <div className="det-primary-7-mb4">
-            The moderator recommended a <strong>{suppressedIntervention.intervention_move ?? 'intervention'}</strong>
-            {suppressedIntervention.intervention_target && (
-              <> directed at <strong>{speakerLabel(suppressedIntervention.intervention_target)}</strong></>
-            )}
-            , but it was blocked by the engine.
-          </div>
-          <div className="det-suppressed-reason">
-            <strong className="det-warning">Reason: </strong>
-            {suppressedIntervention.intervention_suppressed_reason && (
-              <span
-                title={SUPPRESSION_REASON_TOOLTIPS[suppressedIntervention.intervention_suppressed_reason] ?? ''}
-                className="det-suppressed-reason-label"
-              >
-                {String(suppressedIntervention.intervention_suppressed_reason ?? '').replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase())}
-              </span>
-            )}
-            {suppressedIntervention.intervention_suppression_explanation
-              ? (suppressedIntervention.intervention_suppressed_reason ? ' — ' : '') + suppressedIntervention.intervention_suppression_explanation
-              : (!suppressedIntervention.intervention_suppressed_reason ? 'No reason recorded' : '')
-            }
-          </div>
-          {suppressedIntervention.trigger_reasoning && (
-            <div className="det-muted-2xs-mt4-italic">
-              {suppressedIntervention.trigger_reasoning}
-            </div>
-          )}
-        </div>
-      ) : null}
-
+      <SuppressedInterventionSection suppressedIntervention={suppressedIntervention} />
       {/* Dialectical Moves */}
-      {!!meta?.move_types && (
-        <Section title={`Dialectical Moves — ${(meta.move_types as (string | MoveAnnotation)[]).map(m => getMoveName(m)).join(', ')}`} defaultOpen copyText={`Moves: ${(meta.move_types as (string | MoveAnnotation)[]).map(m => getMoveName(m)).join(', ')}${meta.disagreement_type ? `\nType: ${meta.disagreement_type}` : ''}`}>
-          {(() => {
-            const acceptedIds = new Set(diag?.extracted_claims?.accepted.map(c => c.id) ?? []);
-            const claimTargets = (meta.my_claims as { claim: string; targets: string[] }[] | undefined) ?? [];
-            const allClaimTargetIds = [...new Set(claimTargets.flatMap(c => c.targets ?? []))];
-            return (meta.move_types as (string | MoveAnnotation)[]).map((m, i) => {
-              const name = getMoveName(m);
-              const ann = typeof m === 'object' ? m as MoveAnnotation : null;
-              const edgeInfo = MOVE_EDGE_MAP[name.toUpperCase()] || MOVE_EDGE_MAP[name];
-              const cat = edgeInfo?.edgeType || 'neutral';
-              const catColor = cat === 'attack' ? 'var(--danger)' : cat === 'support' ? 'var(--success)' : '#888';
-              const matchEdgeType = cat === 'attack' ? 'attacks' : cat === 'support' ? 'supports' : null;
-              const inferredTargets: { id: string; type: 'supports' | 'attacks'; text?: string }[] = [];
-              if (!ann?.target && an?.edges) {
-                const turnEdges = (an.edges ?? []).filter(e =>
-                  acceptedIds.has(e.source) && (matchEdgeType ? e.type === matchEdgeType : true)
-                );
-                const seen = new Set<string>();
-                for (const e of turnEdges) {
-                  if (!seen.has(e.target)) {
-                    seen.add(e.target);
-                    const tNode = an?.nodes?.find(n => n.id === e.target);
-                    inferredTargets.push({ id: e.target, type: (e.type === 'revoice_of' ? 'supports' : e.type) as 'supports' | 'attacks', text: tNode?.text });
-                  }
-                }
-                if (inferredTargets.length === 0) {
-                  for (const tid of allClaimTargetIds) {
-                    if (!seen.has(tid)) {
-                      seen.add(tid);
-                      const tNode = an?.nodes?.find(n => n.id === tid);
-                      inferredTargets.push({ id: tid, type: matchEdgeType ?? 'supports', text: tNode?.text });
-                    }
-                  }
-                }
-              }
-              return (
-                // eslint-disable-next-line local/no-inline-style -- dynamic catColor border-left
-                <div key={i} style={{ margin: '4px 0', paddingLeft: 8, borderLeft: `2px solid ${catColor}44` }}>
-                  <span className="det-saf-badge">{name}</span>
-                  {/* eslint-disable-next-line local/no-inline-style -- dynamic catColor background/color */}
-                  <span style={{ marginLeft: 6, padding: '1px 5px', borderRadius: 3, background: `${catColor}18`, color: catColor, fontSize: 'var(--text-2xs)', fontWeight: 600, textTransform: 'capitalize' }}>{cat}</span>
-                  {ann?.target && (() => {
-                    const targetNode = an?.nodes?.find(n => n.id === ann.target);
-                    return (<>
-                      <span className="det-ml6-muted-2xs">{'→'} {ann.target}</span>
-                      {targetNode && <span className="det-ml4-muted-2xs-italic">"{targetNode.text.length > 100 ? targetNode.text.slice(0, 100) + '…' : targetNode.text}"</span>}
-                    </>);
-                  })()}
-                  {!ann?.target && inferredTargets.length > 0 && (
-                    <div className="det-inferred-targets">
-                      <span className="det-muted-2xs">{'→'}</span>
-                      {inferredTargets.map(t => (
-                        // eslint-disable-next-line local/no-inline-style -- dynamic attack/support color
-                        <span key={t.id} data-tooltip={t.text} style={{
-                          padding: '1px 5px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, cursor: 'default',
-                          background: `${t.type === 'attacks' ? 'var(--danger)' : 'var(--success)'}15`,
-                          color: t.type === 'attacks' ? 'var(--danger)' : 'var(--success)',
-                        }}>{t.id}</span>
-                      ))}
-                    </div>
-                  )}
-                  {!ann?.target && inferredTargets.length === 0 && (
-                    <span className="det-ml6-muted-2xs-o6">no AN target</span>
-                  )}
-                  {ann?.detail && <div className="det-primary-7-mt2">{ann.detail}</div>}
-                </div>
-              );
-            });
-          })()}
-          {meta.disagreement_type ? <div className="det-mt4">Type: <strong>{String(meta.disagreement_type)}</strong></div> : null}
-        </Section>
-      )}
-
+      <DialecticalMovesSection meta={meta} diag={diag} an={an} />
       {/* Turn Validation */}
-      {turnValTrail && (
-        <Section
-          title={`Turn Validation — ${turnValTrail.final.outcome} (score ${(turnValTrail.final.process_reward ?? 0).toFixed(2)}, ${turnValTrail.attempts.length} attempt${turnValTrail.attempts.length === 1 ? '' : 's'})`}
-          defaultOpen
-        >
-          {/* Inline turn validation summary (lightweight version) */}
-          <div className="det-fs-75">
-            <div className="det-row-g8-mb4">
-              {/* eslint-disable-next-line local/no-inline-style -- dynamic outcome-based background/color */}
-              <span style={{
-                padding: '2px 8px', borderRadius: 4, fontWeight: 700, fontSize: '0.7rem',
-                background: turnValTrail.final.outcome === 'pass' ? 'rgba(22,163,74,0.15)' : turnValTrail.final.outcome === 'accept_with_flag' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'rgba(220,38,38,0.15)',
-                color: turnValTrail.final.outcome === 'pass' ? 'var(--success)' : turnValTrail.final.outcome === 'accept_with_flag' ? 'var(--warning)' : 'var(--danger)',
-              }}>{turnValTrail.final.outcome}</span>
-              <span>score <strong>{(turnValTrail.final.process_reward ?? 0).toFixed(2)}</strong></span>
-              <span className="det-muted">{turnValTrail.attempts.length} attempt{turnValTrail.attempts.length === 1 ? '' : 's'}</span>
-            </div>
-            {turnValTrail.final.repairHints && turnValTrail.final.repairHints.length > 0 && (
-              <div className="det-mt4">
-                <strong>Caveats:</strong>
-                <ul className="det-caveats-list">
-                  {turnValTrail.final.repairHints.map((h, i) => {
-                    const target = classifyHintTarget(h);
-                    const ts = HINT_TARGET_STYLE[target];
-                    return (
-                      <li key={i} className="det-mb3">
-                        {/* eslint-disable-next-line local/no-inline-style -- dynamic hint-target color/bg */}
-                        <span style={{
-                          display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
-                          color: ts.color, background: ts.bg, padding: '1px 5px',
-                          borderRadius: 3, marginRight: 5, verticalAlign: 'middle',
-                        }}>{ts.label}</span>
-                        {humanizeSpeakerIds(h)}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            )}
-          </div>
-        </Section>
-      )}
-
+      <TurnValidationSummarySection turnValTrail={turnValTrail} />
       {/* Commitments Injected */}
-      {diag?.commitment_context && (
-        <Section title="Commitments Injected" defaultOpen copyText={diag.commitment_context}>
-          <ResizablePre tall text={diag.commitment_context} />
-        </Section>
-      )}
-
+      <CommitmentsInjectedSection diag={diag} />
       {/* Edges Used */}
-      {!!(diag as Record<string, unknown>)?.edges_used && ((diag as Record<string, unknown>).edges_used as { source: string; target: string; type: string; confidence: number }[]).length > 0 && (
-        <Section title={`Edges Used (${((diag as Record<string, unknown>).edges_used as unknown[]).length})`} defaultOpen copyText={((diag as Record<string, unknown>).edges_used as { source: string; target: string; type: string; confidence: number }[]).map(e => `${e.source} ${e.type} ${e.target} (${(e.confidence ?? 0).toFixed(2)})`).join('\n')}>
-          <EdgesUsedGrouped edges={(diag as Record<string, unknown>).edges_used as { source: string; target: string; type: string; confidence: number }[]} allEdges={allEdges} taxNodeMap={taxNodeMap} nodeLabels={nodeLabels} />
-        </Section>
-      )}
-
+      <EdgesUsedSection diag={diag} allEdges={allEdges} taxNodeMap={taxNodeMap} nodeLabels={nodeLabels} />
       {/* Key Assumptions */}
-      {!!meta?.key_assumptions && (meta.key_assumptions as { assumption: string; if_wrong: string }[]).length > 0 && (
-        <Section title={`Key Assumptions (${(meta.key_assumptions as unknown[]).length})`} defaultOpen copyText={(meta.key_assumptions as { assumption: string; if_wrong: string }[]).map(a => `Assumes: ${a.assumption}\nIf wrong: ${a.if_wrong}`).join('\n\n')}>
-          {(meta.key_assumptions as { assumption: string; if_wrong: string }[]).map((a, i) => (
-            <div key={i} className="det-assumption">
-              <div><strong>Assumes:</strong> {a.assumption}</div>
-              <div className="det-muted-7">If wrong: {a.if_wrong}</div>
-            </div>
-          ))}
-        </Section>
-      )}
-
+      <KeyAssumptionsSection meta={meta} />
       {/* Policy Refs */}
-      {(() => {
-        const rawPolRefs = (meta?.policy_refs as (string | { policy_id: string; relevance?: string })[] | undefined) || entry.policy_refs || [];
-        const polIds = rawPolRefs.map(p => typeof p === 'string' ? p : p.policy_id);
-        if (polIds.length === 0) return null;
-        return (
-        <Section title={`Policy Refs (${polIds.length})`} defaultOpen copyText={polIds.join(', ')}>
-          <ul className="det-policy-list">
-            {polIds.map((p, i) => {
-              const pol = policyMap.get(p);
-              return (
-                <li key={i} className="det-policy-item">
-                  <span className="det-policy-id">{p}</span>
-                  {pol ? (
-                    <span className="det-primary-72">
-                      {pol.action}
-                      <span className="det-ml6-muted-2xs">
-                        ({pol.source_povs.join(', ')}{pol.member_count > 0 ? ` · ${pol.member_count} members` : ''})
-                      </span>
-                    </span>
-                  ) : (
-                    <span className="det-muted-72-italic">not in registry</span>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        </Section>
-        );
-      })()}
-
+      <PolicyRefsSection meta={meta} entry={entry} policyMap={policyMap} />
       {/* Edge Tensions */}
-      {diag?.edge_tensions && (
-        <Section title="Edge Tensions" defaultOpen copyText={diag.edge_tensions}>
-          <ResizablePre tall text={diag.edge_tensions} />
-        </Section>
-      )}
-
+      <EdgeTensionsSection diag={diag} />
       {/* Argument Network Context */}
-      {diag?.argument_network_context && (
-        <Section title="Argument Network Context" defaultOpen copyText={diag.argument_network_context}>
-          <ResizablePre tall text={diag.argument_network_context} />
-        </Section>
-      )}
-
+      <ArgumentNetworkContextSection diag={diag} />
       {/* Model & Timing */}
-      {diag?.model && (
-        <Section title={`Model & Timing — ${diag.model} (${diag.response_time_ms ? (diag.response_time_ms / 1000).toFixed(1) + 's' : '?'})`} defaultOpen copyText={`Model: ${diag.model}\nResponse: ${diag.response_time_ms ? (diag.response_time_ms / 1000).toFixed(1) + 's' : '?'}`}>
-          <div>Model: {diag.model}</div>
-          {diag.response_time_ms && <div>Response: {(diag.response_time_ms / 1000).toFixed(1)}s</div>}
-        </Section>
-      )}
-
+      <ModelTimingSection diag={diag} />
       {/* Lineage Frame */}
-      {(() => {
-        const frame = debate.topic.critique?.lineage_frame;
-        if (!frame || frame.length === 0) return null;
-        const manifest = (entry.metadata as Record<string, unknown>)?.injection_manifest as {
-          lineage_boost?: { boostedNodeIds?: string[]; promotedNodeIds?: string[] };
-        } | undefined;
-        const lb = manifest?.lineage_boost;
-        const maxPct = Math.max(...frame.map((f: { percentage: number }) => f.percentage));
-        return (
-          <Section title={`Lineage Frame (${frame.length} categor${frame.length !== 1 ? 'ies' : 'y'})`} copyText={frame.map((f: { label?: string; cluster_id: string; percentage: number; traditions?: string[] }) => `${f.label ?? f.cluster_id}: ${f.percentage.toFixed(1)}%${f.traditions?.length ? ` (${f.traditions.join(', ')})` : ''}`).join('\n')}>
-            {frame.map((f: { cluster_id: string; label?: string; percentage: number; traditions?: string[] }, i: number) => (
-              <div key={i} className="det-mb6">
-                <div className="det-row-g6">
-                  <div className="det-lineage-label">{f.label ?? f.cluster_id}</div>
-                  <div className="det-lineage-bar">
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic computed width */}
-                    <div style={{ width: `${maxPct > 0 ? (f.percentage / maxPct) * 100 : 0}%`, height: '100%', borderRadius: 3, background: 'var(--warning)' }} />
-                  </div>
-                  <div className="det-lineage-pct">{f.percentage.toFixed(1)}%</div>
-                </div>
-                {f.traditions && f.traditions.length > 0 && (
-                  <div className="det-lineage-traditions">
-                    {f.traditions.join(', ')}
-                  </div>
-                )}
-              </div>
-            ))}
-            <div className="det-mt4-muted-2xs">
-              Boost: {lb ? <span className="det-success">active</span> : <span>inactive</span>}
-              {lb && lb.promotedNodeIds && lb.promotedNodeIds.length > 0 && (
-                <> {'·'} {lb.promotedNodeIds.length} promoted</>
-              )}
-            </div>
-          </Section>
-        );
-      })()}
-
+      <LineageFrameSection debate={debate} entry={entry} />
       {/* Statement (opening entries) */}
-      {entry.content && entry.type === 'opening' && (
-        <Section title="Statement" defaultOpen copyText={entry.content}>
-          <div className="det-statement">
-            <Highlight text={entry.content} />
-          </div>
-        </Section>
-      )}
+      <StatementSection entry={entry} />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/DraftTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/DraftTab.tsx
@@ -37,6 +37,63 @@ export interface DraftTabProps {
   allEdges: TaxRefEdge[];
 }
 
+// ── Derived types (never redefine debate types — pull from the shared lib) ──
+type StageDiag = NonNullable<EntryDiagnostics['stage_diagnostics']>[number];
+type DraftAttempt = StageDiag & {
+  orchestrationRun?: number;
+  stageRetryIndex?: number;
+  stageRetryCount?: number;
+};
+type OrchVal = TurnAttempt['validation'];
+type OrchDims = OrchVal['dimensions'];
+type StageValData = {
+  pass: boolean;
+  hints: string[];
+  details?: { rule: string; pass: boolean; value?: string; flagged_claims?: string[] }[];
+};
+type QualityGateShape = {
+  grounded: boolean; falsifiable: boolean; engages: boolean; topic_aligned: boolean; pass: boolean; weaknesses: string[];
+};
+type QGShape = {
+  pre_repair: QualityGateShape;
+  post_repair?: QualityGateShape;
+  repair_outcome?: 'fixed' | 'partial' | 'unchanged';
+};
+type TopicAttempt = { label: string; aligned: boolean; weaknesses: string[] };
+type TopicScopeUsed = NonNullable<EntryDiagnostics['topic_alignment']>['scope_used'];
+
+// ── Draft stage extraction ───────────────────────────────────────────────
+function computeDraftStages(
+  diag: EntryDiagnostics | undefined,
+  turnValTrail: TurnValidationTrail | undefined,
+) {
+  const stages = diag?.stage_diagnostics;
+  const draftAttempts = stages?.filter(s => s.stage === 'draft') ?? [];
+  const draftStage = draftAttempts.length > 0 ? draftAttempts[draftAttempts.length - 1] : undefined;
+  const postDraftStage = stages?.find(s => s.stage === 'postDraft');
+  const draftQualityStage = stages?.find(s => s.stage === 'draft_quality');
+
+  // Build all draft stages across ALL orchestration attempts
+  const orchAttempts = turnValTrail?.attempts ?? [];
+  const allDraftAttempts: DraftAttempt[] = orchAttempts.length > 0
+    ? orchAttempts.flatMap((a, runIdx) => {
+        const drafts = (a.stage_diagnostics ?? []).filter(s => s.stage === 'draft');
+        return drafts.map((s, di) => ({
+          ...s, orchestrationRun: runIdx, stageRetryIndex: di, stageRetryCount: drafts.length,
+        }));
+      })
+    : [];
+  const hasMultipleOrchRuns = orchAttempts.length > 1;
+  const effectiveDraftAttempts: DraftAttempt[] =
+    allDraftAttempts.length > 0
+      ? allDraftAttempts
+      : draftAttempts.map((s, i, arr) => ({
+          ...s, orchestrationRun: undefined, stageRetryIndex: i, stageRetryCount: arr.length,
+        }));
+
+  return { draftStage, postDraftStage, draftQualityStage, orchAttempts, hasMultipleOrchRuns, effectiveDraftAttempts };
+}
+
 export function DraftTab({
   entry,
   diag,
@@ -50,1099 +107,1204 @@ export function DraftTab({
   taxNodeMap,
   allEdges,
 }: DraftTabProps) {
-  const stages = diag?.stage_diagnostics;
-  const draftAttempts = stages?.filter(s => s.stage === 'draft') ?? [];
-  const draftStage = draftAttempts.length > 0 ? draftAttempts[draftAttempts.length - 1] : undefined;
-  const postDraftStage = stages?.find(s => s.stage === 'postDraft');
-  const draftQualityStage = stages?.find(s => s.stage === 'draft_quality');
-
-  // Build all draft stages across ALL orchestration attempts
-  type DraftAttemptEntry = typeof draftAttempts[number] & {
-    orchestrationRun: number;
-    stageRetryIndex: number;
-    stageRetryCount: number;
-  };
-  const orchAttempts = turnValTrail?.attempts ?? [];
-  const allDraftAttempts: DraftAttemptEntry[] = orchAttempts.length > 0
-    ? orchAttempts.flatMap((a, runIdx) => {
-        const drafts = (a.stage_diagnostics ?? []).filter(s => s.stage === 'draft');
-        return drafts.map((s, di) => ({
-          ...s, orchestrationRun: runIdx, stageRetryIndex: di, stageRetryCount: drafts.length,
-        }));
-      })
-    : [];
-  const hasMultipleOrchRuns = orchAttempts.length > 1;
-  const effectiveDraftAttempts: (typeof draftAttempts[number] & {
-    orchestrationRun?: number; stageRetryIndex?: number; stageRetryCount?: number;
-  })[] =
-    allDraftAttempts.length > 0
-      ? allDraftAttempts
-      : draftAttempts.map((s, i, arr) => ({
-          ...s, orchestrationRun: undefined, stageRetryIndex: i, stageRetryCount: arr.length,
-        }));
+  const { draftStage, postDraftStage, draftQualityStage, orchAttempts, hasMultipleOrchRuns, effectiveDraftAttempts } =
+    computeDraftStages(diag, turnValTrail);
 
   if (!draftStage && !entry.content) return null;
 
   return (
     <div className="draft-root">
       {/* -- Top section: header + content from final draft -- */}
-      {draftStage && (
-        <div className="draft-header-row">
-          <span className="draft-chip-success">DRAFT</span>
-          <span>{draftStage.model}</span>
-          <span>temp={draftStage.temperature}</span>
-          <span>{(draftStage.response_time_ms / 1000).toFixed(1)}s</span>
-        </div>
-      )}
-      {draftStage?.parse_error && (
-        <div className="draft-parse-error">
-          <strong>Parse error:</strong> {draftStage.parse_error}
-        </div>
-      )}
+      <DraftHeaderRow draftStage={draftStage} />
+      <DraftParseError draftStage={draftStage} />
       {/* Directive compliance (from final draft) */}
-      {(() => {
-        const sv = (draftStage as Record<string, unknown> | undefined)?.stage_validation as {
-          directive_compliance?: { compliant: boolean; repair_hint: string; directive_terms: string[]; matched_terms: number };
-        } | undefined;
-        const dc = sv?.directive_compliance;
-        if (!dc) return null;
-        return (
-          // eslint-disable-next-line local/no-inline-style -- compliance-driven border/background
-          <div style={{
-            margin: '6px 0', padding: '5px 8px', borderRadius: 4, fontSize: '0.7rem',
-            borderLeft: `3px solid ${dc.compliant ? 'var(--success)' : 'var(--danger)'}`,
-            background: dc.compliant ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-          }}>
-            {/* eslint-disable-next-line local/no-inline-style -- compliance-driven color */}
-            <div style={{ fontWeight: 600, color: dc.compliant ? 'var(--success)' : 'var(--danger)', marginBottom: 2 }}>
-              {dc.compliant ? '✓ Directive addressed' : '✗ Directive not addressed'}
-            </div>
-            {!dc.compliant && <div className="draft-text-secondary">{dc.repair_hint}</div>}
-            <div className="draft-terms-note">
-              {dc.matched_terms}/{dc.directive_terms.length} directive terms matched
-              {dc.directive_terms.length > 0 && (
-                <span className="draft-ml4">({dc.directive_terms.join(', ')})</span>
+      <DirectiveCompliance draftStage={draftStage} />
+      {/* Claim Sketches */}
+      <ClaimSketches draftStage={draftStage} />
+      {/* Key Assumptions */}
+      <KeyAssumptions draftStage={draftStage} />
+      {/* Disagreement type */}
+      <DisagreementType draftStage={draftStage} />
+      {/* Statement (from final draft) */}
+      <StatementSection draftStage={draftStage} />
+      {/* Fallback: non-pipeline statement (old debates without stage_diagnostics) */}
+      <FallbackStatementHeader draftStage={draftStage} diag={diag} />
+      <FallbackStatementBody draftStage={draftStage} entry={entry} />
+      {/* Micro-Fix stages (abstract_claims, intervention_compliance, directive_compliance) */}
+      <MicroFixStages diag={diag} />
+      {/* Post-Draft Fixups (t/296/t/311) */}
+      <PostDraftFixups postDraftStage={postDraftStage} />
+      {/* Vocabulary Disambiguation (t/212) */}
+      <VocabularyDisambiguation entry={entry} />
+      {/* Fact-check evidence detail -- shows web search evidence, queries, and citations */}
+      <FactCheckDetail entry={entry} />
+      {/* -- Per-turn sections (from all orchestration attempts) -- */}
+      <PerTurnSections
+        effectiveDraftAttempts={effectiveDraftAttempts}
+        turnValTrail={turnValTrail}
+        orchAttempts={orchAttempts}
+        hasMultipleOrchRuns={hasMultipleOrchRuns}
+      />
+      {/* -- Quality Pre-Check (draft_quality stage) -- */}
+      <QualityPreCheck draftQualityStage={draftQualityStage} diag={diag} />
+      {/* -- Topic Alignment Detail (per-attempt) -- */}
+      <TopicAlignmentDetail diag={diag} />
+    </div>
+  );
+}
+
+// ── Top-of-draft sections ────────────────────────────────────────────────
+
+function DraftHeaderRow({ draftStage }: { draftStage: StageDiag | undefined }) {
+  if (!draftStage) return null;
+  return (
+    <div className="draft-header-row">
+      <span className="draft-chip-success">DRAFT</span>
+      <span>{draftStage.model}</span>
+      <span>temp={draftStage.temperature}</span>
+      <span>{(draftStage.response_time_ms / 1000).toFixed(1)}s</span>
+    </div>
+  );
+}
+
+function DraftParseError({ draftStage }: { draftStage: StageDiag | undefined }) {
+  if (!draftStage || !draftStage.parse_error) return null;
+  return (
+    <div className="draft-parse-error">
+      <strong>Parse error:</strong> {draftStage.parse_error}
+    </div>
+  );
+}
+
+function DirectiveCompliance({ draftStage }: { draftStage: StageDiag | undefined }) {
+  const sv = (draftStage as Record<string, unknown> | undefined)?.stage_validation as {
+    directive_compliance?: { compliant: boolean; repair_hint: string; directive_terms: string[]; matched_terms: number };
+  } | undefined;
+  const dc = sv?.directive_compliance;
+  if (!dc) return null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- compliance-driven border/background
+    <div style={{
+      margin: '6px 0', padding: '5px 8px', borderRadius: 4, fontSize: '0.7rem',
+      borderLeft: `3px solid ${dc.compliant ? 'var(--success)' : 'var(--danger)'}`,
+      background: dc.compliant ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
+    }}>
+      {/* eslint-disable-next-line local/no-inline-style -- compliance-driven color */}
+      <div style={{ fontWeight: 600, color: dc.compliant ? 'var(--success)' : 'var(--danger)', marginBottom: 2 }}>
+        {dc.compliant ? '✓ Directive addressed' : '✗ Directive not addressed'}
+      </div>
+      {!dc.compliant && <div className="draft-text-secondary">{dc.repair_hint}</div>}
+      <div className="draft-terms-note">
+        {dc.matched_terms}/{dc.directive_terms.length} directive terms matched
+        {dc.directive_terms.length > 0 && (
+          <span className="draft-ml4">({dc.directive_terms.join(', ')})</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ClaimSketches({ draftStage }: { draftStage: StageDiag | undefined }) {
+  if (!draftStage || !Array.isArray((draftStage.work_product as Record<string, unknown>).claim_sketches)) return null;
+  return (
+    <details open><summary className="draft-summary">Claim Sketches</summary>
+      <ul className="draft-ul-72">
+        {((draftStage.work_product as Record<string, unknown>).claim_sketches as { claim: string; targets: string[] }[]).map((c, i) => (
+          <li key={i}>{c.claim}{c.targets?.length > 0 ? ` → ${c.targets.join(', ')}` : ''}</li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
+function KeyAssumptions({ draftStage }: { draftStage: StageDiag | undefined }): React.ReactNode {
+  if (!draftStage || !Array.isArray((draftStage.work_product as Record<string, unknown>).key_assumptions)) return null;
+  return (
+    <details open><summary className="draft-summary">Key Assumptions</summary>
+      {((draftStage.work_product as Record<string, unknown>).key_assumptions as { assumption: string; if_wrong: string }[]).map((a, i) => (
+        <div key={i} className="draft-assumption">
+          <div><strong>Assumption:</strong> {a.assumption}</div>
+          <div className="draft-text-muted"><strong>If wrong:</strong> {a.if_wrong}</div>
+        </div>
+      ))}
+    </details>
+  );
+}
+
+function DisagreementType({ draftStage }: { draftStage: StageDiag | undefined }) {
+  if (!draftStage || !(draftStage.work_product as Record<string, unknown>).disagreement_type) return null;
+  return (
+    <div className="draft-disagreement">
+      <strong>Disagreement type:</strong> <Highlight text={String((draftStage.work_product as Record<string, unknown>).disagreement_type)} />
+    </div>
+  );
+}
+
+function StatementSection({ draftStage }: { draftStage: StageDiag | undefined }) {
+  if (!draftStage || !(draftStage.work_product as Record<string, unknown>).statement) return null;
+  return (
+    <details open><summary className="draft-summary">Statement</summary>
+      <div className="draft-statement-body">
+        <Highlight text={String((draftStage.work_product as Record<string, unknown>).statement)} />
+      </div>
+    </details>
+  );
+}
+
+function FallbackStatementHeader({ draftStage, diag }: { draftStage: StageDiag | undefined; diag: EntryDiagnostics | undefined }) {
+  if (draftStage || !diag) return null;
+  return (
+    <div className="draft-header-row">
+      <span className="draft-chip-success">STATEMENT</span>
+      <span>{diag.model}</span>
+      {diag.response_time_ms && <span>{(diag.response_time_ms / 1000).toFixed(1)}s</span>}
+    </div>
+  );
+}
+
+function FallbackStatementBody({ draftStage, entry }: { draftStage: StageDiag | undefined; entry: DraftTabProps['entry'] }) {
+  if (draftStage || !entry.content) return null;
+  return (
+    <details open><summary className="draft-summary">Statement</summary>
+      <div className="draft-statement-body">
+        {typeof entry.content === 'string'
+          ? <Highlight text={entry.content} />
+          : <Highlight text={Array.isArray(entry.content)
+              ? (entry.content as unknown[]).map((item, i) => typeof item === 'string' ? item : (item as Record<string, unknown>)?.text ?? (item as Record<string, unknown>)?.content ?? JSON.stringify(item)).join('\n')
+              : JSON.stringify(entry.content, null, 2)} />}
+      </div>
+    </details>
+  );
+}
+
+// ── Micro-Fix cards (shared between final-draft + per-attempt sections) ────
+
+function MicroFixStages({ diag }: { diag: EntryDiagnostics | undefined }) {
+  const microFixStages = diag?.stage_diagnostics?.filter(s => s.stage === 'micro-fix') ?? [];
+  if (microFixStages.length === 0) return null;
+  return (
+    <>
+      {microFixStages.map((mf, mi) => (
+        <MicroFixCard key={mi} mf={mf} showPrompt={true} />
+      ))}
+    </>
+  );
+}
+
+function AttemptMicroFixes({ orchAttemptData }: { orchAttemptData: TurnAttempt | undefined }) {
+  const attemptMicroFixes = orchAttemptData?.stage_diagnostics?.filter(
+    (s: { stage: string }) => s.stage === 'micro-fix',
+  ) ?? [];
+  if (attemptMicroFixes.length === 0) return null;
+  return (
+    <>
+      {attemptMicroFixes.map((mf, mi) => (
+        <MicroFixCard key={`mf-${mi}`} mf={mf} showPrompt={false} />
+      ))}
+    </>
+  );
+}
+
+type MicroFixSource = { prompt?: string; response_time_ms?: number; work_product?: Record<string, unknown> };
+
+function MicroFixCard({ mf, showPrompt }: { mf: MicroFixSource; showPrompt: boolean }) {
+  const wp = mf.work_product as Record<string, unknown> | undefined;
+  const success = wp?.success as boolean | undefined;
+  const fixType = wp?.type as string | undefined;
+  const elapsed = mf.response_time_ms ?? 0;
+  const statusColor = success ? 'var(--success)' : 'var(--danger)';
+
+  // -- Intervention compliance --
+  if (fixType === 'intervention_compliance') {
+    return <MfInterventionCompliance wp={wp} success={success} statusColor={statusColor} elapsed={elapsed} />;
+  }
+  // -- Directive compliance --
+  if (fixType === 'directive_compliance') {
+    return <MfDirectiveCompliance mf={mf} wp={wp} success={success} statusColor={statusColor} elapsed={elapsed} showPrompt={showPrompt} />;
+  }
+  // -- Abstract claims (default) --
+  return <MfAbstractClaims mf={mf} wp={wp} success={success} statusColor={statusColor} elapsed={elapsed} showPrompt={showPrompt} />;
+}
+
+interface MfBranchProps {
+  wp: Record<string, unknown> | undefined;
+  success: boolean | undefined;
+  statusColor: string;
+  elapsed: number;
+}
+
+function interventionStatusText(
+  success: boolean | undefined,
+  rejected: string | undefined,
+  recheck: { compliant?: boolean; repair_hint?: string } | undefined,
+): string {
+  return success ? 'Applied' : rejected ? `Rejected (${rejected})` : recheck && !recheck.compliant ? 'Re-validation failed' : 'Failed';
+}
+
+function MfInterventionCompliance({ wp, success, statusColor, elapsed }: MfBranchProps) {
+  const w: Record<string, unknown> = wp ?? {};
+  const move = w.move as string | undefined;
+  const field = w.field as string | undefined;
+  const generated = w.generated_value as Record<string, unknown> | string | undefined;
+  const recheck = w.recheck_result as { compliant?: boolean; repair_hint?: string } | undefined;
+  const rejected = w.rejected_reason as string | undefined;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- success-driven border/background
+    <div style={{
+      margin: '6px 0', padding: '6px 8px',
+      background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
+      borderLeft: `3px solid ${statusColor}`,
+      borderRadius: 4, fontSize: 'var(--text-2xs)',
+    }}>
+      {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
+      <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
+        Micro-Fix: {move ?? 'Intervention'} Compliance ({elapsed}ms) — {interventionStatusText(success, rejected, recheck)}
+      </div>
+      {field && (
+        <div className="draft-field-note">
+          Field: <code className="draft-code-chip">{field}</code>
+          {!success && <span className="draft-ml6">Before: <em>missing</em></span>}
+        </div>
+      )}
+      {generated != null && (
+        <details open={success} className="draft-2xs">
+          {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
+          <summary style={{ cursor: 'pointer', color: statusColor }}>
+            {success ? 'After — Generated value' : 'Attempted value (rejected)'}
+          </summary>
+          <pre className="draft-mf-pre">
+            {typeof generated === 'string' ? generated : JSON.stringify(generated, null, 2)}
+          </pre>
+        </details>
+      )}
+      {recheck?.repair_hint && !recheck.compliant && (
+        <div className="draft-danger-note-mt4">
+          {recheck.repair_hint}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MfDirectiveCompliance({ mf, wp, success, statusColor, elapsed, showPrompt }: MfBranchProps & { mf: MicroFixSource; showPrompt: boolean }) {
+  const move = wp?.move as string | undefined;
+  const revisedPara = wp?.revised_first_paragraph as string | undefined;
+  const recheckCompliant = wp?.recheck_compliant as boolean | undefined;
+  const rejected = wp?.rejected_reason as string | undefined;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- success-driven border/background
+    <div style={{
+      margin: '6px 0', padding: '6px 8px',
+      background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
+      borderLeft: `3px solid ${statusColor}`,
+      borderRadius: 4, fontSize: 'var(--text-2xs)',
+    }}>
+      {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
+      <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
+        Micro-Fix: Directive Compliance — {move ?? '?'} ({elapsed}ms) — {success ? 'Applied' : rejected ? `Rejected (${rejected})` : recheckCompliant === false ? 'Re-validation failed' : 'Failed'}
+      </div>
+      {revisedPara && (
+        <details open={success} className="draft-2xs">
+          {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
+          <summary style={{ cursor: 'pointer', color: statusColor }}>
+            {success ? 'After — Revised first paragraph' : 'Attempted revision (rejected)'}
+          </summary>
+          <pre className="draft-mf-pre">{revisedPara}</pre>
+        </details>
+      )}
+      {showPrompt && mf.prompt && (
+        <details className="draft-2xs-mt4">
+          <summary className="draft-summary-muted">Micro-fix prompt</summary>
+          <pre className="draft-mf-pre">{mf.prompt}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function MfAbstractClaims({ mf, wp, success, statusColor, elapsed, showPrompt }: MfBranchProps & { mf: MicroFixSource; showPrompt: boolean }) {
+  const w: Record<string, unknown> = wp ?? {};
+  const diffPassed = w.diff_check_passed as boolean | undefined;
+  const changes = w.changes as Array<{ original?: string; revised?: string; fact_source?: string }> | undefined;
+  const rejected = w.rejected_reason as string | undefined;
+  const revisedStatement = w.revised_statement as string | undefined;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- success-driven border/background
+    <div style={{
+      margin: '6px 0', padding: '6px 8px',
+      background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
+      borderLeft: `3px solid ${statusColor}`,
+      borderRadius: 4, fontSize: 'var(--text-2xs)',
+    }}>
+      {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
+      <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
+        Micro-Fix: Abstract Claims ({elapsed}ms) — {success ? 'Applied' : diffPassed === false ? (rejected === 'hallucinated_changes' ? 'Rejected (hallucinated edits)' : 'Rejected (too many changes)') : 'Re-validation failed'}
+        {changes && <span className="draft-change-count">{changes.length} change{changes.length !== 1 ? 's' : ''}</span>}
+      </div>
+      {changes && changes.length > 0 && (
+        <div className="draft-2xs">
+          {changes.map((c, ci) => (
+            <div key={ci} className="draft-change-row">
+              <div className="draft-flex-baseline">
+                <span className="draft-before-label">BEFORE</span>
+                <div className="draft-before-text">
+                  {c.original ?? ''}
+                </div>
+              </div>
+              {c.revised && c.original !== c.revised && (
+                <div className="draft-flex-baseline-mt2">
+                  <span className="draft-after-label">AFTER</span>
+                  <div className="draft-after-text">
+                    {c.revised}
+                  </div>
+                </div>
+              )}
+              {c.fact_source && (
+                <div className="draft-source-note">
+                  source: {c.fact_source}
+                </div>
               )}
             </div>
+          ))}
+        </div>
+      )}
+      {revisedStatement && (
+        <details className="draft-2xs-mt4">
+          {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
+          <summary style={{ cursor: 'pointer', color: statusColor }}>
+            {success ? 'After — Full revised statement' : 'Attempted revision (rejected)'}
+          </summary>
+          <pre className="draft-mf-pre">{revisedStatement}</pre>
+        </details>
+      )}
+      {showPrompt && mf.prompt && (
+        <details className="draft-2xs-mt4">
+          <summary className="draft-summary-muted">Micro-fix prompt</summary>
+          <pre className="draft-mf-pre">{mf.prompt}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+// ── Post-Draft Fixups ────────────────────────────────────────────────────
+
+function PostDraftFixups({ postDraftStage }: { postDraftStage: StageDiag | undefined }) {
+  if (!postDraftStage) return null;
+  const wp = postDraftStage.work_product as Record<string, unknown> | undefined;
+  if (!wp) return null;
+  const autoSplit = wp.auto_split as boolean | undefined;
+  const splitParas = wp.auto_split_paragraphs as number | undefined;
+  const scrubbed = wp.citations_scrubbed as number | undefined;
+  const linked = wp.links_added as number | undefined;
+  const citWarn = wp.citation_warnings as number | undefined;
+  const ignored = wp.ignored_evidence_docs as number | undefined;
+  const hasAny = autoSplit || (scrubbed && scrubbed > 0) || (linked && linked > 0) || (citWarn && citWarn > 0);
+  if (!hasAny) return null;
+  return (
+    <div className="draft-postdraft-box">
+      <div className="draft-postdraft-title">Post-Draft Fixups ({postDraftStage.response_time_ms}ms)</div>
+      <div className="draft-col-gap4">
+        {autoSplit && <div className="draft-warning">&#9998; Auto-split → {splitParas} paragraphs</div>}
+        <ScrubbedCitations wp={wp} scrubbed={scrubbed} />
+        {linked != null && linked > 0 && <div className="draft-success">&#128279; Links added</div>}
+        <CitationWarnings wp={wp} citWarn={citWarn} />
+        <IgnoredEvidence wp={wp} ignored={ignored} />
+      </div>
+    </div>
+  );
+}
+
+function ScrubbedCitations({ wp, scrubbed }: { wp: Record<string, unknown>; scrubbed: number | undefined }) {
+  if (!(scrubbed != null && scrubbed > 0)) return null;
+  return (
+    <div>
+      <div className="draft-danger">&times; {scrubbed} citation(s) scrubbed</div>
+      {(() => {
+        const scrubbedList = wp.scrubbed_citations as string[] | undefined;
+        if (!scrubbedList || scrubbedList.length === 0) return null;
+        return (
+          <div className="draft-sublist-muted">
+            {scrubbedList.map((cit, ci) => (
+              <div key={ci} className="draft-strike-wrap">{cit}</div>
+            ))}
           </div>
         );
       })()}
-      {/* Claim Sketches */}
-      {draftStage && Array.isArray((draftStage.work_product as Record<string, unknown>).claim_sketches) && (
-        <details open><summary className="draft-summary">Claim Sketches</summary>
-          <ul className="draft-ul-72">
-            {((draftStage.work_product as Record<string, unknown>).claim_sketches as { claim: string; targets: string[] }[]).map((c, i) => (
-              <li key={i}>{c.claim}{c.targets?.length > 0 ? ` → ${c.targets.join(', ')}` : ''}</li>
+    </div>
+  );
+}
+
+function CitationWarnings({ wp, citWarn }: { wp: Record<string, unknown>; citWarn: number | undefined }) {
+  if (!(citWarn != null && citWarn > 0)) return null;
+  return (
+    <div>
+      <div className="draft-warning">&#9888; {citWarn} citation warning(s)</div>
+      {(() => {
+        const warnDetails = wp.citation_warning_details as string[] | undefined;
+        if (!warnDetails || warnDetails.length === 0) return null;
+        return (
+          <div className="draft-sublist-warning">
+            {warnDetails.map((w, wi) => (
+              <div key={wi} className="draft-wrap">{w}</div>
+            ))}
+          </div>
+        );
+      })()}
+    </div>
+  );
+}
+
+function IgnoredEvidence({ wp, ignored }: { wp: Record<string, unknown>; ignored: number | undefined }) {
+  if (!(ignored != null && ignored > 0)) return null;
+  return (
+    <div>
+      <div className="draft-text-muted">{ignored} evidence doc(s) not cited</div>
+      {(() => {
+        const titles = wp.ignored_evidence_titles as string[] | undefined;
+        if (!titles || titles.length === 0) return null;
+        return (
+          <div className="draft-sublist-muted-italic">
+            {titles.map((t, ti) => (
+              <div key={ti}>{t}</div>
+            ))}
+          </div>
+        );
+      })()}
+    </div>
+  );
+}
+
+// ── Vocabulary Disambiguation ────────────────────────────────────────────
+
+function VocabularyDisambiguation({ entry }: { entry: DraftTabProps['entry'] }) {
+  const entryMeta = entry.metadata as Record<string, unknown> | undefined;
+  const vocabRes = entryMeta?.vocabulary_resolutions as { colloquial: string; canonical: string; confidence: string; offset?: number }[] | undefined;
+  const vocabAmb = entryMeta?.vocabulary_ambiguities as { colloquial: string; offset?: number }[] | undefined;
+  if ((!vocabRes || vocabRes.length === 0) && (!vocabAmb || vocabAmb.length === 0)) return null;
+  return (
+    <details open>
+      <summary className="draft-summary">
+        Disambiguated Terms ({(vocabRes?.length ?? 0) + (vocabAmb?.length ?? 0)})
+        {vocabAmb && vocabAmb.length > 0 && (
+          <span className="draft-ambiguous-count">
+            {new Set(vocabAmb.map(a => a.colloquial)).size} ambiguous
+          </span>
+        )}
+      </summary>
+      <VocabResolutionsTable vocabRes={vocabRes} />
+      <VocabAmbiguities vocabAmb={vocabAmb} />
+    </details>
+  );
+}
+
+function VocabResolutionsTable({ vocabRes }: { vocabRes: { colloquial: string; canonical: string; confidence: string; offset?: number }[] | undefined }) {
+  if (!vocabRes || vocabRes.length === 0) return null;
+  // Dedup: same colloquial+canonical -> keep highest confidence
+  const confRank = { high: 3, medium: 2, low: 1 } as Record<string, number>;
+  const seen = new Map<string, typeof vocabRes[0]>();
+  for (const r of vocabRes) {
+    const key = `${r.colloquial}|${r.canonical}`;
+    const existing = seen.get(key);
+    if (!existing || (confRank[r.confidence] ?? 0) > (confRank[existing.confidence] ?? 0)) {
+      seen.set(key, r);
+    }
+  }
+  const deduped = [...seen.values()].sort((a, b) =>
+    a.colloquial.localeCompare(b.colloquial) || a.canonical.localeCompare(b.canonical)
+  );
+  return (
+    <table className="draft-vocab-table">
+      <thead>
+        <tr className="draft-tr-border">
+          <th className="draft-th-left">Term</th>
+          <th className="draft-th-left">Canonical</th>
+          <th className="draft-th-center">Conf</th>
+        </tr>
+      </thead>
+      <tbody>
+        {deduped.map((r, i) => (
+          <tr key={i} className="draft-tr-border-soft">
+            <td className="draft-td">{r.colloquial}</td>
+            <td className="draft-td-secondary">{r.canonical}</td>
+            {/* eslint-disable-next-line local/no-inline-style -- confidence-driven color */}
+            <td style={{
+              padding: '1px 4px', textAlign: 'center', fontWeight: 600,
+              color: r.confidence === 'high' ? 'var(--success)' : r.confidence === 'low' ? 'var(--danger)' : 'var(--warning)',
+            }}>{r.confidence}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function VocabAmbiguities({ vocabAmb }: { vocabAmb: { colloquial: string; offset?: number }[] | undefined }) {
+  if (!vocabAmb || vocabAmb.length === 0) return null;
+  const unique = [...new Set(vocabAmb.map(a => a.colloquial))].sort((a, b) => a.localeCompare(b));
+  return (
+    <div className="draft-ambiguous-box">
+      <div className="draft-ambiguous-title">Ambiguous terms:</div>
+      {unique.map((term, i) => (
+        <div key={i} className="draft-ml8">&ldquo;{term}&rdquo;</div>
+      ))}
+    </div>
+  );
+}
+
+// ── Fact-check evidence detail ───────────────────────────────────────────
+
+function FactCheckDetail({ entry }: { entry: DraftTabProps['entry'] }) {
+  if (entry.type !== 'fact-check') return null;
+  const fcMeta = (entry.metadata as Record<string, unknown>)?.fact_check as Record<string, unknown> | undefined;
+  if (!fcMeta) return null;
+  const verdict = fcMeta.verdict as string | undefined;
+  const explanation = fcMeta.explanation as string | undefined;
+  const checkedText = fcMeta.checked_text as string | undefined;
+  const webEvidence = fcMeta.web_search_evidence as string | undefined;
+  const webQueries = Array.isArray(fcMeta.web_search_queries) ? fcMeta.web_search_queries as string[] : [];
+  const webCitations = Array.isArray(fcMeta.web_search_citations) ? fcMeta.web_search_citations as Array<{ url?: string; title?: string; startIndex?: number; endIndex?: number }> : [];
+  const targetAnId = fcMeta.target_an_id as string | undefined;
+  const isAuto = !!targetAnId;
+  return (<>
+    <FactCheckVerdict verdict={verdict} explanation={explanation} checkedText={checkedText} targetAnId={targetAnId} isAuto={isAuto} />
+    {webQueries.length > 0 && (
+      <WebQueriesSection webQueries={webQueries} checkedText={checkedText} />
+    )}
+    {webEvidence && (
+      <details><summary className="draft-summary">Web Evidence</summary>
+        <pre className="draft-web-evidence">{webEvidence}</pre>
+      </details>
+    )}
+    {webCitations.length > 0 && (
+      <details open><summary className="draft-summary">Citations ({webCitations.length})</summary>
+        <div className="draft-2xs">
+          {webCitations.map((c, ci) => (
+            <div key={ci} className="draft-citation">
+              {c.title && <div className="draft-bold">{c.title}</div>}
+              {c.url && <div className="draft-url">{c.url}</div>}
+            </div>
+          ))}
+        </div>
+      </details>
+    )}
+  </>);
+}
+
+function FactCheckVerdict({ verdict, explanation, checkedText, targetAnId, isAuto }: {
+  verdict: string | undefined;
+  explanation: string | undefined;
+  checkedText: string | undefined;
+  targetAnId: string | undefined;
+  isAuto: boolean;
+}) {
+  return (
+    <details open><summary className="draft-summary">Verdict</summary>
+      <div className="draft-verdict-row">
+        {/* eslint-disable-next-line local/no-inline-style -- verdict-driven background */}
+        <span style={{
+          padding: '1px 8px', borderRadius: 4, fontWeight: 600, color: 'var(--text-primary)',
+          background: verdict === 'supported' ? 'var(--success)' : verdict === 'disputed' || verdict === 'false' ? 'var(--danger)' : 'var(--text-muted)',
+        }}>{verdict ?? 'unknown'}</span>
+        <span className="draft-text-muted">{isAuto ? 'auto-verified' : 'user-initiated'}</span>
+        {targetAnId && <span className="draft-text-muted">AN: {targetAnId}</span>}
+      </div>
+      {checkedText && (
+        <div className="draft-checked-text">
+          {checkedText}
+        </div>
+      )}
+      {explanation && (
+        <div className="draft-explanation">{explanation}</div>
+      )}
+    </details>
+  );
+}
+
+function WebQueriesSection({ webQueries, checkedText }: { webQueries: string[]; checkedText: string | undefined }) {
+  const isDomains = webQueries.every(q => /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(q.trim()));
+  const searchText = checkedText || '';
+  const allSameQuery = !isDomains;
+  return (
+    <details open><summary className="draft-summary">
+      {isDomains ? `Web Sources (${webQueries.length})` : `Search Queries (${webQueries.length})`}
+    </summary>
+      {isDomains && searchText && (
+        <div className="draft-query-note">
+          Query: &quot;{searchText.length > 100 ? searchText.slice(0, 97) + '...' : searchText}&quot;
+        </div>
+      )}
+      <ul className="draft-ul-none">
+        {webQueries.map((q, qi) => {
+          const trimmed = q.trim();
+          const looksLikeDomain = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(trimmed);
+          const searchUrl = looksLikeDomain
+            ? `https://www.google.com/search?q=${encodeURIComponent(searchText + ' site:' + trimmed)}`
+            : `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
+          return (
+            <li key={qi} className="draft-mb2">
+              <a
+                href={searchUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="draft-link"
+                title={looksLikeDomain ? `Search "${searchText}" on ${trimmed}` : `Search Google for "${trimmed}"`}
+              >
+                {trimmed}
+              </a>
+              {!allSameQuery && !looksLikeDomain && (
+                <span className="draft-query-tag">(query)</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </details>
+  );
+}
+
+// ── Per-turn draft attempt sections ──────────────────────────────────────
+
+function PerTurnSections({ effectiveDraftAttempts, turnValTrail, orchAttempts, hasMultipleOrchRuns }: {
+  effectiveDraftAttempts: DraftAttempt[];
+  turnValTrail: TurnValidationTrail | undefined;
+  orchAttempts: TurnAttempt[];
+  hasMultipleOrchRuns: boolean;
+}) {
+  if (effectiveDraftAttempts.length === 0) return null;
+  return (
+    <>
+      {effectiveDraftAttempts.map((attempt, ai) => {
+        const prevOrchRun = ai > 0 ? effectiveDraftAttempts[ai - 1].orchestrationRun : undefined;
+        return (
+          <DraftAttemptSection
+            key={ai}
+            attempt={attempt}
+            ai={ai}
+            total={effectiveDraftAttempts.length}
+            prevOrchRun={prevOrchRun}
+            turnValTrail={turnValTrail}
+            orchAttempts={orchAttempts}
+            hasMultipleOrchRuns={hasMultipleOrchRuns}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+function DraftAttemptSection({ attempt, ai, total, prevOrchRun, turnValTrail, orchAttempts, hasMultipleOrchRuns }: {
+  attempt: DraftAttempt;
+  ai: number;
+  total: number;
+  prevOrchRun: number | undefined;
+  turnValTrail: TurnValidationTrail | undefined;
+  orchAttempts: TurnAttempt[];
+  hasMultipleOrchRuns: boolean;
+}) {
+  const orchRun = attempt.orchestrationRun;
+  const retryIdx = attempt.stageRetryIndex ?? 0;
+  const retryCount = attempt.stageRetryCount ?? 1;
+  const isLastInRun = retryIdx === retryCount - 1;
+  const hasStageRetries = retryCount > 1;
+  const isFinal = ai === total - 1;
+  const valData = (attempt as Record<string, unknown>).stage_validation as StageValData | undefined;
+  const allHints = valData?.hints ?? [];
+  // Pull draft + judge hints from overall validation for the final attempt
+  const overallHints = isFinal
+    ? (turnValTrail?.final.repairHints ?? []).filter(h => classifyHintTarget(h) !== 'cite')
+    : [];
+  const combinedHints = [...allHints, ...overallHints];
+  const turnScore = isFinal ? turnValTrail?.final.process_reward : undefined;
+  const orchAttemptData = orchRun != null ? orchAttempts[orchRun] : undefined;
+
+  return (
+    <div>
+      {/* Orchestration run header + orchestration-level validation */}
+      <AttemptOrchHeader
+        orchRun={orchRun}
+        prevOrchRun={prevOrchRun}
+        hasMultipleOrchRuns={hasMultipleOrchRuns}
+        orchAttemptData={orchAttemptData}
+      />
+      {/* Draft attempt header */}
+      <DraftAttemptHeader
+        hasStageRetries={hasStageRetries}
+        hasMultipleOrchRuns={hasMultipleOrchRuns}
+        total={total}
+        retryIdx={retryIdx}
+        isLastInRun={isLastInRun}
+      />
+      <ArtifactBlock label="Raw Prompt" text={attempt.prompt} />
+      <ArtifactBlock label="Raw Response" text={attempt.raw_response} />
+      {/* Validation Score -- show the work */}
+      <ValidationScore
+        isFinal={isFinal}
+        turnValTrail={turnValTrail}
+        turnScore={turnScore}
+        valData={valData}
+      />
+      {/* Validation Feedback */}
+      <ValidationFeedback combinedHints={combinedHints} />
+      {/* Per-attempt Micro-Fix stages */}
+      <AttemptMicroFixes orchAttemptData={orchAttemptData} />
+    </div>
+  );
+}
+
+function AttemptOrchHeader({ orchRun, prevOrchRun, hasMultipleOrchRuns, orchAttemptData }: {
+  orchRun: number | undefined;
+  prevOrchRun: number | undefined;
+  hasMultipleOrchRuns: boolean;
+  orchAttemptData: TurnAttempt | undefined;
+}) {
+  const showOrchHeader = hasMultipleOrchRuns && orchRun !== prevOrchRun && orchRun != null;
+  if (!showOrchHeader) return null;
+  const orchOutcome = orchAttemptData?.validation?.outcome;
+  const orchAccepted = orchOutcome === 'pass' || orchOutcome === 'accept_with_flag';
+  return (
+    <>
+      {/* eslint-disable-next-line local/no-inline-style -- accepted-driven color */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8, margin: '14px 0 4px',
+        fontSize: 'var(--text-2xs)', fontWeight: 700, color: orchAccepted ? 'var(--success)' : 'var(--danger)',
+      }}>
+        {/* eslint-disable-next-line local/no-inline-style -- accepted-driven background */}
+        <div style={{ flex: 1, height: 2, background: orchAccepted ? 'color-mix(in srgb, var(--success) 30%, transparent)' : 'color-mix(in srgb, var(--danger) 30%, transparent)' }} />
+        <span>Orchestration Run {orchRun! + 1}{orchAccepted ? ' (accepted)' : ' (rejected by judge)'}</span>
+        {/* eslint-disable-next-line local/no-inline-style -- accepted-driven background */}
+        <div style={{ flex: 1, height: 2, background: orchAccepted ? 'color-mix(in srgb, var(--success) 30%, transparent)' : 'color-mix(in srgb, var(--danger) 30%, transparent)' }} />
+      </div>
+      {orchAttemptData?.validation && (
+        <OrchestrationValidation validation={orchAttemptData.validation} orchAccepted={orchAccepted} />
+      )}
+    </>
+  );
+}
+
+function OrchestrationValidation({ validation: ov, orchAccepted }: { validation: OrchVal; orchAccepted: boolean }) {
+  const dims = ov.dimensions;
+  const score = ov.process_reward;
+  const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
+  const orchHints = ov.repairHints ?? [];
+  return (
+    // eslint-disable-next-line local/no-inline-style -- accepted-driven background/border
+    <div style={{
+      margin: '4px 0 8px', borderRadius: 4, padding: '6px 8px', fontSize: '0.7rem',
+      background: orchAccepted ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
+      border: `1px solid ${orchAccepted ? 'color-mix(in srgb, var(--success) 20%, transparent)' : 'color-mix(in srgb, var(--danger) 20%, transparent)'}`,
+    }}>
+      <div className="draft-score-header">
+        <span>Orchestration Score:{' '}
+          {/* eslint-disable-next-line local/no-inline-style -- score-driven color */}
+          <span style={{ ...mono, color: score >= 0.7 ? 'var(--success)' : score >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>
+            {score.toFixed(2)}
+          </span>
+        </span>
+        {/* eslint-disable-next-line local/no-inline-style -- accepted-driven color/background */}
+        <span style={{
+          fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '1px 6px', borderRadius: 3,
+          color: orchAccepted ? 'var(--success)' : 'var(--danger)',
+          background: orchAccepted ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)',
+        }}>
+          {orchAccepted ? 'ACCEPTED' : 'REJECTED BY JUDGE'}
+        </span>
+      </div>
+      <ScoreMathRows dims={dims} score={score} judgeUsed={ov.judge_used} />
+      {orchHints.length > 0 && (
+        <div className="draft-caveats-box">
+          <div className="draft-caveats-title">Caveats</div>
+          <ul className="draft-hint-list">
+            {orchHints.map((h, hi) => {
+              const target = classifyHintTarget(h);
+              const ts = HINT_TARGET_STYLE[target];
+              return (
+                <li key={hi} className="draft-mb2">
+                  {/* eslint-disable-next-line local/no-inline-style -- hint-target-driven color/background */}
+                  <span style={{
+                    display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
+                    color: ts.color, background: ts.bg, padding: '1px 4px',
+                    borderRadius: 2, marginRight: 4, verticalAlign: 'middle',
+                  }}>{ts.label}</span>
+                  {humanizeSpeakerIds(h)}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Shared "dims row + Stage A / Judge / Total" breakdown (identical math in
+// orchestration-level + turn-level validation panels).
+function ScoreMathRows({ dims, score, judgeUsed }: { dims: OrchDims; score: number; judgeUsed: boolean }) {
+  const stageA =
+    0.4 * (dims.schema.pass ? 1 : 0) +
+    0.3 * (dims.grounding.pass ? 1 : 0) +
+    0.2 * (dims.advancement.pass ? 1 : 0) +
+    0.1 * (dims.clarifies.pass ? 1 : 0);
+  const judgeQ = stageA > 0
+    ? Math.max(0, Math.min(1, (score - 0.4 * stageA) / 0.6))
+    : 0.7;
+  const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
+  const dimColor = (pass: boolean) => pass ? 'var(--success)' : 'var(--danger)';
+  return (
+    <>
+      <div className="draft-dims-row">
+        {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
+        <span><span style={{ color: dimColor(dims.schema.pass) }}>●</span> schema ×0.4 = <strong className="draft-mono">{(0.4 * (dims.schema.pass ? 1 : 0)).toFixed(2)}</strong></span>
+        {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
+        <span><span style={{ color: dimColor(dims.grounding.pass) }}>●</span> grounding ×0.3 = <strong className="draft-mono">{(0.3 * (dims.grounding.pass ? 1 : 0)).toFixed(2)}</strong></span>
+        {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
+        <span><span style={{ color: dimColor(dims.advancement.pass) }}>●</span> advancement ×0.2 = <strong className="draft-mono">{(0.2 * (dims.advancement.pass ? 1 : 0)).toFixed(2)}</strong></span>
+        {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
+        <span><span style={{ color: dimColor(dims.clarifies.pass) }}>●</span> clarifies ×0.1 = <strong className="draft-mono">{(0.1 * (dims.clarifies.pass ? 1 : 0)).toFixed(2)}</strong></span>
+      </div>
+      <div className="draft-score-breakdown">
+        <span>Stage A: <strong className="draft-mono">{stageA.toFixed(2)}</strong> <span className="draft-text-muted">×0.4 = {(0.4 * stageA).toFixed(2)}</span></span>
+        <span>Judge: <strong className="draft-mono">{judgeQ.toFixed(2)}</strong>{!judgeUsed && <span className="draft-text-muted"> (default)</span>} <span className="draft-text-muted">×0.6 = {(0.6 * judgeQ).toFixed(2)}</span></span>
+        {/* eslint-disable-next-line local/no-inline-style -- score-driven color */}
+        <span>Total: <strong style={{ ...mono, color: score >= 0.7 ? 'var(--success)' : score >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>{score.toFixed(2)}</strong></span>
+      </div>
+    </>
+  );
+}
+
+function DraftAttemptHeader({ hasStageRetries, hasMultipleOrchRuns, total, retryIdx, isLastInRun }: {
+  hasStageRetries: boolean;
+  hasMultipleOrchRuns: boolean;
+  total: number;
+  retryIdx: number;
+  isLastInRun: boolean;
+}) {
+  if (!(hasStageRetries || hasMultipleOrchRuns || total > 1)) return null;
+  return (
+    <div className="draft-attempt-header">
+      <div className="draft-hr-line" />
+      <span>
+        Draft Attempt {retryIdx + 1}
+        {hasStageRetries && (
+          // eslint-disable-next-line local/no-inline-style -- last-in-run-driven color/background
+          <span style={{
+            marginLeft: 4, fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '1px 5px',
+            borderRadius: 3, verticalAlign: 'middle',
+            color: isLastInRun ? 'var(--success)' : 'var(--warning)',
+            background: isLastInRun ? 'color-mix(in srgb, var(--success) 12%, transparent)' : 'color-mix(in srgb, var(--warning) 12%, transparent)',
+          }}>
+            {isLastInRun ? 'final' : 'refined'}
+          </span>
+        )}
+      </span>
+      <div className="draft-hr-line" />
+    </div>
+  );
+}
+
+function ValidationScore({ isFinal, turnValTrail, turnScore, valData }: {
+  isFinal: boolean;
+  turnValTrail: TurnValidationTrail | undefined;
+  turnScore: number | undefined;
+  valData: StageValData | undefined;
+}) {
+  const dims = isFinal ? turnValTrail?.final.dimensions : undefined;
+  const judgeUsed = isFinal ? turnValTrail?.final.judge_used ?? false : false;
+  if (turnScore != null && dims) {
+    const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
+    return (
+      <div className="draft-valscore-box">
+        <div className="draft-valscore-title">
+          Validation Score:{' '}
+          {/* eslint-disable-next-line local/no-inline-style -- score-driven color */}
+          <span style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>
+            {turnScore.toFixed(2)}
+          </span>
+        </div>
+        <ScoreMathRows dims={dims} score={turnScore} judgeUsed={judgeUsed} />
+      </div>
+    );
+  }
+  // Fallback: no dimensions available
+  return <PerStageValidation valData={valData} />;
+}
+
+function PerStageValidation({ valData }: { valData: StageValData | undefined }) {
+  return (
+    <div className="draft-perstage-box">
+      <div className="draft-bold">
+        Per-stage Validation:{' '}
+        {valData ? (
+          // eslint-disable-next-line local/no-inline-style -- pass-driven color
+          <span style={{ color: valData.pass ? 'var(--success)' : 'var(--danger)' }}>
+            {valData.pass ? 'Pass' : 'Fail'}
+          </span>
+        ) : (
+          <span className="draft-text-muted">—</span>
+        )}
+      </div>
+      {valData?.details && valData.details.length > 0 && (
+        <div className="draft-details-list">
+          {valData.details.map((d, di) => (
+            <div key={di}>
+              <div className="draft-flex-center-gap6">
+                {/* eslint-disable-next-line local/no-inline-style -- pass-driven color */}
+                <span style={{ color: d.pass ? 'var(--success)' : 'var(--danger)', fontSize: '0.7rem' }}>{d.pass ? '✓' : '✗'}</span>
+                <span className="draft-text-primary">{d.rule}</span>
+                {d.value && <span className="draft-mono-muted">{d.value}</span>}
+              </div>
+              {d.flagged_claims && d.flagged_claims.length > 0 && (
+                <div className="draft-flagged-list">
+                  {d.flagged_claims.map((claim: string, ci: number) => (
+                    <div key={ci} className="draft-flagged-item">• {claim}</div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ValidationFeedback({ combinedHints }: { combinedHints: string[] }) {
+  if (combinedHints.length === 0) return null;
+  return (
+    <details open className="draft-feedback">
+      <summary className="draft-summary-plain">Validation Feedback</summary>
+      <ul className="draft-feedback-list">
+        {combinedHints.map((h, hi) => {
+          const target = classifyHintTarget(h);
+          const ts = HINT_TARGET_STYLE[target];
+          return (
+            <li key={hi} className="draft-mb3">
+              {/* eslint-disable-next-line local/no-inline-style -- hint-target-driven color/background */}
+              <span style={{
+                display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
+                color: ts.color, background: ts.bg, padding: '1px 5px',
+                borderRadius: 3, marginRight: 5, verticalAlign: 'middle',
+              }}>{ts.label}</span>
+              {humanizeSpeakerIds(h)}
+            </li>
+          );
+        })}
+      </ul>
+    </details>
+  );
+}
+
+// ── Quality Pre-Check ────────────────────────────────────────────────────
+
+function QualityPreCheck({ draftQualityStage, diag }: { draftQualityStage: StageDiag | undefined; diag: EntryDiagnostics | undefined }) {
+  if (!draftQualityStage) return null;
+  const wp = draftQualityStage.work_product as {
+    grounded?: boolean; falsifiable?: boolean; engages?: boolean; topic_aligned?: boolean; weaknesses?: string[];
+  };
+  const indicators: [string, boolean | undefined][] = [
+    ['Grounded', wp.grounded],
+    ['Falsifiable', wp.falsifiable],
+    ['Engages', wp.engages],
+    ['Topic Aligned', wp.topic_aligned],
+  ];
+  const allPass = indicators.every(([, v]) => v === true);
+  // §3: if all indicators pass, collapse to a single summary line
+  if (allPass && !draftQualityStage.parse_error) {
+    return (
+      <div className="draft-qcheck-pass">
+        <span className="draft-qcheck-icon">✓</span>
+        <span className="draft-qcheck-label">Quality Pre-Check — all pass</span>
+        <span className="draft-meta-muted">{draftQualityStage.model}</span>
+        <span className="draft-meta-muted">{(draftQualityStage.response_time_ms / 1000).toFixed(1)}s</span>
+      </div>
+    );
+  }
+  return (
+    <div className="draft-qcheck-warn">
+      <div className="draft-qcheck-head">
+        <span className="draft-qcheck-title">Quality Pre-Check</span>
+        <span className="draft-qcheck-badge">Draft Attempt 1</span>
+        {diag?.topic_alignment?.repaired && (
+          <span className="draft-qcheck-regen">triggered regen</span>
+        )}
+        <span className="draft-meta-muted">{draftQualityStage.model}</span>
+        <span className="draft-meta-muted">{(draftQualityStage.response_time_ms / 1000).toFixed(1)}s</span>
+      </div>
+      <div className="draft-indicators-row">
+        {indicators.map(([label, pass]) => (
+          <span key={label} className="draft-indicator">
+            {/* eslint-disable-next-line local/no-inline-style -- pass-driven color */}
+            <span style={{ color: pass ? 'var(--success)' : 'var(--danger)', fontWeight: 700 }}>{pass ? '✓' : '✗'}</span>
+            <span>{label}</span>
+          </span>
+        ))}
+      </div>
+      {wp.weaknesses && wp.weaknesses.length > 0 && (
+        <div className="draft-caveats-box">
+          <div className="draft-weakness-title">Weaknesses</div>
+          <ul className="draft-hint-list">
+            {wp.weaknesses.map((w, wi) => (
+              <li key={wi} className="draft-mb2">{humanizeSpeakerIds(w)}</li>
             ))}
           </ul>
-        </details>
-      )}
-      {/* Key Assumptions */}
-      {((): React.ReactNode => {
-        if (!draftStage || !Array.isArray((draftStage.work_product as Record<string, unknown>).key_assumptions)) return null;
-        return (
-          <details open><summary className="draft-summary">Key Assumptions</summary>
-            {((draftStage.work_product as Record<string, unknown>).key_assumptions as { assumption: string; if_wrong: string }[]).map((a, i) => (
-              <div key={i} className="draft-assumption">
-                <div><strong>Assumption:</strong> {a.assumption}</div>
-                <div className="draft-text-muted"><strong>If wrong:</strong> {a.if_wrong}</div>
-              </div>
-            ))}
-          </details>
-        );
-      })()}
-      {/* Disagreement type */}
-      {draftStage && !!(draftStage.work_product as Record<string, unknown>).disagreement_type && (
-        <div className="draft-disagreement">
-          <strong>Disagreement type:</strong> <Highlight text={String((draftStage.work_product as Record<string, unknown>).disagreement_type)} />
         </div>
       )}
-      {/* Statement (from final draft) */}
-      {draftStage && !!(draftStage.work_product as Record<string, unknown>).statement && (
-        <details open><summary className="draft-summary">Statement</summary>
-          <div className="draft-statement-body">
-            <Highlight text={String((draftStage.work_product as Record<string, unknown>).statement)} />
-          </div>
-        </details>
-      )}
-      {/* Fallback: non-pipeline statement (old debates without stage_diagnostics) */}
-      {!draftStage && diag && (
-        <div className="draft-header-row">
-          <span className="draft-chip-success">STATEMENT</span>
-          <span>{diag.model}</span>
-          {diag.response_time_ms && <span>{(diag.response_time_ms / 1000).toFixed(1)}s</span>}
+      {draftQualityStage.parse_error && (
+        <div className="draft-qcheck-parse-error">
+          <strong>Parse error:</strong> {draftQualityStage.parse_error}
         </div>
       )}
-      {!draftStage && !!entry.content && (
-        <details open><summary className="draft-summary">Statement</summary>
-          <div className="draft-statement-body">
-            {typeof entry.content === 'string'
-              ? <Highlight text={entry.content} />
-              : <Highlight text={Array.isArray(entry.content)
-                  ? (entry.content as unknown[]).map((item, i) => typeof item === 'string' ? item : (item as Record<string, unknown>)?.text ?? (item as Record<string, unknown>)?.content ?? JSON.stringify(item)).join('\n')
-                  : JSON.stringify(entry.content, null, 2)} />}
-          </div>
-        </details>
-      )}
-      {/* Micro-Fix stages (abstract_claims, intervention_compliance, directive_compliance) */}
-      {(() => {
-        const microFixStages = diag?.stage_diagnostics?.filter(s => s.stage === 'micro-fix') ?? [];
-        if (microFixStages.length === 0) return null;
-        return microFixStages.map((mf, mi) => {
-          const wp = mf.work_product as Record<string, unknown> | undefined;
-          const success = wp?.success as boolean | undefined;
-          const fixType = wp?.type as string | undefined;
-          const elapsed = mf.response_time_ms ?? 0;
-          const statusColor = success ? 'var(--success)' : 'var(--danger)';
-
-          // -- Intervention compliance --
-          if (fixType === 'intervention_compliance') {
-            const move = wp?.move as string | undefined;
-            const field = wp?.field as string | undefined;
-            const generated = wp?.generated_value as Record<string, unknown> | string | undefined;
-            const recheck = wp?.recheck_result as { compliant?: boolean; repair_hint?: string } | undefined;
-            const rejected = wp?.rejected_reason as string | undefined;
-            return (
-              // eslint-disable-next-line local/no-inline-style -- success-driven border/background
-              <div key={mi} style={{
-                margin: '6px 0', padding: '6px 8px',
-                background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-                borderLeft: `3px solid ${statusColor}`,
-                borderRadius: 4, fontSize: 'var(--text-2xs)',
-              }}>
-                {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
-                  Micro-Fix: {move ?? 'Intervention'} Compliance ({elapsed}ms) — {success ? 'Applied' : rejected ? `Rejected (${rejected})` : recheck && !recheck.compliant ? 'Re-validation failed' : 'Failed'}
-                </div>
-                {field && (
-                  <div className="draft-field-note">
-                    Field: <code className="draft-code-chip">{field}</code>
-                    {!success && <span className="draft-ml6">Before: <em>missing</em></span>}
-                  </div>
-                )}
-                {generated != null && (
-                  <details open={success} className="draft-2xs">
-                    {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                    <summary style={{ cursor: 'pointer', color: statusColor }}>
-                      {success ? 'After — Generated value' : 'Attempted value (rejected)'}
-                    </summary>
-                    <pre className="draft-mf-pre">
-                      {typeof generated === 'string' ? generated : JSON.stringify(generated, null, 2)}
-                    </pre>
-                  </details>
-                )}
-                {recheck?.repair_hint && !recheck.compliant && (
-                  <div className="draft-danger-note-mt4">
-                    {recheck.repair_hint}
-                  </div>
-                )}
-              </div>
-            );
-          }
-
-          // -- Directive compliance --
-          if (fixType === 'directive_compliance') {
-            const move = wp?.move as string | undefined;
-            const revisedPara = wp?.revised_first_paragraph as string | undefined;
-            const recheckCompliant = wp?.recheck_compliant as boolean | undefined;
-            const rejected = wp?.rejected_reason as string | undefined;
-            return (
-              // eslint-disable-next-line local/no-inline-style -- success-driven border/background
-              <div key={mi} style={{
-                margin: '6px 0', padding: '6px 8px',
-                background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-                borderLeft: `3px solid ${statusColor}`,
-                borderRadius: 4, fontSize: 'var(--text-2xs)',
-              }}>
-                {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
-                  Micro-Fix: Directive Compliance — {move ?? '?'} ({elapsed}ms) — {success ? 'Applied' : rejected ? `Rejected (${rejected})` : recheckCompliant === false ? 'Re-validation failed' : 'Failed'}
-                </div>
-                {revisedPara && (
-                  <details open={success} className="draft-2xs">
-                    {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                    <summary style={{ cursor: 'pointer', color: statusColor }}>
-                      {success ? 'After — Revised first paragraph' : 'Attempted revision (rejected)'}
-                    </summary>
-                    <pre className="draft-mf-pre">{revisedPara}</pre>
-                  </details>
-                )}
-                {mf.prompt && (
-                  <details className="draft-2xs-mt4">
-                    <summary className="draft-summary-muted">Micro-fix prompt</summary>
-                    <pre className="draft-mf-pre">{mf.prompt}</pre>
-                  </details>
-                )}
-              </div>
-            );
-          }
-
-          // -- Abstract claims (default) --
-          const diffPassed = wp?.diff_check_passed as boolean | undefined;
-          const changes = wp?.changes as Array<{ original?: string; revised?: string; fact_source?: string }> | undefined;
-          const rejected = wp?.rejected_reason as string | undefined;
-          const revisedStatement = wp?.revised_statement as string | undefined;
-          return (
-            // eslint-disable-next-line local/no-inline-style -- success-driven border/background
-            <div key={mi} style={{
-              margin: '6px 0', padding: '6px 8px',
-              background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-              borderLeft: `3px solid ${statusColor}`,
-              borderRadius: 4, fontSize: 'var(--text-2xs)',
-            }}>
-              {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-              <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
-                Micro-Fix: Abstract Claims ({elapsed}ms) — {success ? 'Applied' : diffPassed === false ? (rejected === 'hallucinated_changes' ? 'Rejected (hallucinated edits)' : 'Rejected (too many changes)') : 'Re-validation failed'}
-                {changes && <span className="draft-change-count">{changes.length} change{changes.length !== 1 ? 's' : ''}</span>}
-              </div>
-              {changes && changes.length > 0 && (
-                <div className="draft-2xs">
-                  {changes.map((c, ci) => (
-                    <div key={ci} className="draft-change-row">
-                      <div className="draft-flex-baseline">
-                        <span className="draft-before-label">BEFORE</span>
-                        <div className="draft-before-text">
-                          {c.original ?? ''}
-                        </div>
-                      </div>
-                      {c.revised && c.original !== c.revised && (
-                        <div className="draft-flex-baseline-mt2">
-                          <span className="draft-after-label">AFTER</span>
-                          <div className="draft-after-text">
-                            {c.revised}
-                          </div>
-                        </div>
-                      )}
-                      {c.fact_source && (
-                        <div className="draft-source-note">
-                          source: {c.fact_source}
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-              {revisedStatement && (
-                <details className="draft-2xs-mt4">
-                  {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                  <summary style={{ cursor: 'pointer', color: statusColor }}>
-                    {success ? 'After — Full revised statement' : 'Attempted revision (rejected)'}
-                  </summary>
-                  <pre className="draft-mf-pre">{revisedStatement}</pre>
-                </details>
-              )}
-              {mf.prompt && (
-                <details className="draft-2xs-mt4">
-                  <summary className="draft-summary-muted">Micro-fix prompt</summary>
-                  <pre className="draft-mf-pre">{mf.prompt}</pre>
-                </details>
-              )}
-            </div>
-          );
-        });
-      })()}
-      {/* Post-Draft Fixups (t/296/t/311) */}
-      {postDraftStage && (() => {
-        const wp = postDraftStage.work_product as Record<string, unknown> | undefined;
-        if (!wp) return null;
-        const autoSplit = wp.auto_split as boolean | undefined;
-        const splitParas = wp.auto_split_paragraphs as number | undefined;
-        const scrubbed = wp.citations_scrubbed as number | undefined;
-        const linked = wp.links_added as number | undefined;
-        const citWarn = wp.citation_warnings as number | undefined;
-        const ignored = wp.ignored_evidence_docs as number | undefined;
-        const hasAny = autoSplit || (scrubbed && scrubbed > 0) || (linked && linked > 0) || (citWarn && citWarn > 0);
-        if (!hasAny) return null;
-        return (
-          <div className="draft-postdraft-box">
-            <div className="draft-postdraft-title">Post-Draft Fixups ({postDraftStage.response_time_ms}ms)</div>
-            <div className="draft-col-gap4">
-              {autoSplit && <div className="draft-warning">&#9998; Auto-split → {splitParas} paragraphs</div>}
-              {scrubbed != null && scrubbed > 0 && (
-                <div>
-                  <div className="draft-danger">&times; {scrubbed} citation(s) scrubbed</div>
-                  {(() => {
-                    const scrubbedList = wp.scrubbed_citations as string[] | undefined;
-                    if (!scrubbedList || scrubbedList.length === 0) return null;
-                    return (
-                      <div className="draft-sublist-muted">
-                        {scrubbedList.map((cit, ci) => (
-                          <div key={ci} className="draft-strike-wrap">{cit}</div>
-                        ))}
-                      </div>
-                    );
-                  })()}
-                </div>
-              )}
-              {linked != null && linked > 0 && <div className="draft-success">&#128279; Links added</div>}
-              {citWarn != null && citWarn > 0 && (
-                <div>
-                  <div className="draft-warning">&#9888; {citWarn} citation warning(s)</div>
-                  {(() => {
-                    const warnDetails = wp.citation_warning_details as string[] | undefined;
-                    if (!warnDetails || warnDetails.length === 0) return null;
-                    return (
-                      <div className="draft-sublist-warning">
-                        {warnDetails.map((w, wi) => (
-                          <div key={wi} className="draft-wrap">{w}</div>
-                        ))}
-                      </div>
-                    );
-                  })()}
-                </div>
-              )}
-              {ignored != null && ignored > 0 && (
-                <div>
-                  <div className="draft-text-muted">{ignored} evidence doc(s) not cited</div>
-                  {(() => {
-                    const titles = wp.ignored_evidence_titles as string[] | undefined;
-                    if (!titles || titles.length === 0) return null;
-                    return (
-                      <div className="draft-sublist-muted-italic">
-                        {titles.map((t, ti) => (
-                          <div key={ti}>{t}</div>
-                        ))}
-                      </div>
-                    );
-                  })()}
-                </div>
-              )}
-            </div>
-          </div>
-        );
-      })()}
-      {/* Vocabulary Disambiguation (t/212) */}
-      {(() => {
-        const entryMeta = entry.metadata as Record<string, unknown> | undefined;
-        const vocabRes = entryMeta?.vocabulary_resolutions as { colloquial: string; canonical: string; confidence: string; offset?: number }[] | undefined;
-        const vocabAmb = entryMeta?.vocabulary_ambiguities as { colloquial: string; offset?: number }[] | undefined;
-        if ((!vocabRes || vocabRes.length === 0) && (!vocabAmb || vocabAmb.length === 0)) return null;
-        return (
-          <details open>
-            <summary className="draft-summary">
-              Disambiguated Terms ({(vocabRes?.length ?? 0) + (vocabAmb?.length ?? 0)})
-              {vocabAmb && vocabAmb.length > 0 && (
-                <span className="draft-ambiguous-count">
-                  {new Set(vocabAmb.map(a => a.colloquial)).size} ambiguous
-                </span>
-              )}
-            </summary>
-            {vocabRes && vocabRes.length > 0 && (() => {
-              // Dedup: same colloquial+canonical -> keep highest confidence
-              const confRank = { high: 3, medium: 2, low: 1 } as Record<string, number>;
-              const seen = new Map<string, typeof vocabRes[0]>();
-              for (const r of vocabRes) {
-                const key = `${r.colloquial}|${r.canonical}`;
-                const existing = seen.get(key);
-                if (!existing || (confRank[r.confidence] ?? 0) > (confRank[existing.confidence] ?? 0)) {
-                  seen.set(key, r);
-                }
-              }
-              const deduped = [...seen.values()].sort((a, b) =>
-                a.colloquial.localeCompare(b.colloquial) || a.canonical.localeCompare(b.canonical)
-              );
-              return (
-              <table className="draft-vocab-table">
-                <thead>
-                  <tr className="draft-tr-border">
-                    <th className="draft-th-left">Term</th>
-                    <th className="draft-th-left">Canonical</th>
-                    <th className="draft-th-center">Conf</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {deduped.map((r, i) => (
-                    <tr key={i} className="draft-tr-border-soft">
-                      <td className="draft-td">{r.colloquial}</td>
-                      <td className="draft-td-secondary">{r.canonical}</td>
-                      {/* eslint-disable-next-line local/no-inline-style -- confidence-driven color */}
-                      <td style={{
-                        padding: '1px 4px', textAlign: 'center', fontWeight: 600,
-                        color: r.confidence === 'high' ? 'var(--success)' : r.confidence === 'low' ? 'var(--danger)' : 'var(--warning)',
-                      }}>{r.confidence}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              );
-            })()}
-            {vocabAmb && vocabAmb.length > 0 && (() => {
-              const unique = [...new Set(vocabAmb.map(a => a.colloquial))].sort((a, b) => a.localeCompare(b));
-              return (
-              <div className="draft-ambiguous-box">
-                <div className="draft-ambiguous-title">Ambiguous terms:</div>
-                {unique.map((term, i) => (
-                  <div key={i} className="draft-ml8">&ldquo;{term}&rdquo;</div>
-                ))}
-              </div>
-              );
-            })()}
-          </details>
-        );
-      })()}
-      {/* Fact-check evidence detail -- shows web search evidence, queries, and citations */}
-      {entry.type === 'fact-check' && (() => {
-        const fcMeta = (entry.metadata as Record<string, unknown>)?.fact_check as Record<string, unknown> | undefined;
-        if (!fcMeta) return null;
-        const verdict = fcMeta.verdict as string | undefined;
-        const explanation = fcMeta.explanation as string | undefined;
-        const checkedText = fcMeta.checked_text as string | undefined;
-        const webEvidence = fcMeta.web_search_evidence as string | undefined;
-        const webQueries = Array.isArray(fcMeta.web_search_queries) ? fcMeta.web_search_queries as string[] : [];
-        const webCitations = Array.isArray(fcMeta.web_search_citations) ? fcMeta.web_search_citations as Array<{ url?: string; title?: string; startIndex?: number; endIndex?: number }> : [];
-        const targetAnId = fcMeta.target_an_id as string | undefined;
-        const isAuto = !!targetAnId;
-        return (<>
-          <details open><summary className="draft-summary">Verdict</summary>
-            <div className="draft-verdict-row">
-              {/* eslint-disable-next-line local/no-inline-style -- verdict-driven background */}
-              <span style={{
-                padding: '1px 8px', borderRadius: 4, fontWeight: 600, color: 'var(--text-primary)',
-                background: verdict === 'supported' ? 'var(--success)' : verdict === 'disputed' || verdict === 'false' ? 'var(--danger)' : 'var(--text-muted)',
-              }}>{verdict ?? 'unknown'}</span>
-              <span className="draft-text-muted">{isAuto ? 'auto-verified' : 'user-initiated'}</span>
-              {targetAnId && <span className="draft-text-muted">AN: {targetAnId}</span>}
-            </div>
-            {checkedText && (
-              <div className="draft-checked-text">
-                {checkedText}
-              </div>
-            )}
-            {explanation && (
-              <div className="draft-explanation">{explanation}</div>
-            )}
-          </details>
-          {webQueries.length > 0 && (() => {
-            const isDomains = webQueries.every(q => /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(q.trim()));
-            const searchText = checkedText || '';
-            const allSameQuery = !isDomains;
-            return (
-              <details open><summary className="draft-summary">
-                {isDomains ? `Web Sources (${webQueries.length})` : `Search Queries (${webQueries.length})`}
-              </summary>
-                {isDomains && searchText && (
-                  <div className="draft-query-note">
-                    Query: &quot;{searchText.length > 100 ? searchText.slice(0, 97) + '...' : searchText}&quot;
-                  </div>
-                )}
-                <ul className="draft-ul-none">
-                  {webQueries.map((q, qi) => {
-                    const trimmed = q.trim();
-                    const looksLikeDomain = /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(trimmed);
-                    const searchUrl = looksLikeDomain
-                      ? `https://www.google.com/search?q=${encodeURIComponent(searchText + ' site:' + trimmed)}`
-                      : `https://www.google.com/search?q=${encodeURIComponent(trimmed)}`;
-                    return (
-                      <li key={qi} className="draft-mb2">
-                        <a
-                          href={searchUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="draft-link"
-                          title={looksLikeDomain ? `Search "${searchText}" on ${trimmed}` : `Search Google for "${trimmed}"`}
-                        >
-                          {trimmed}
-                        </a>
-                        {!allSameQuery && !looksLikeDomain && (
-                          <span className="draft-query-tag">(query)</span>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </details>
-            );
-          })()}
-          {webEvidence && (
-            <details><summary className="draft-summary">Web Evidence</summary>
-              <pre className="draft-web-evidence">{webEvidence}</pre>
-            </details>
-          )}
-          {webCitations.length > 0 && (
-            <details open><summary className="draft-summary">Citations ({webCitations.length})</summary>
-              <div className="draft-2xs">
-                {webCitations.map((c, ci) => (
-                  <div key={ci} className="draft-citation">
-                    {c.title && <div className="draft-bold">{c.title}</div>}
-                    {c.url && <div className="draft-url">{c.url}</div>}
-                  </div>
-                ))}
-              </div>
-            </details>
-          )}
-        </>);
-      })()}
-      {/* -- Per-turn sections (from all orchestration attempts) -- */}
-      {effectiveDraftAttempts.length > 0 && (() => {
-        let prevOrchRun: number | undefined;
-        return effectiveDraftAttempts.map((attempt, ai) => {
-          const orchRun = (attempt as { orchestrationRun?: number }).orchestrationRun;
-          const retryIdx = (attempt as { stageRetryIndex?: number }).stageRetryIndex ?? 0;
-          const retryCount = (attempt as { stageRetryCount?: number }).stageRetryCount ?? 1;
-          const isLastInRun = retryIdx === retryCount - 1;
-          const hasStageRetries = retryCount > 1;
-          const isFinal = ai === effectiveDraftAttempts.length - 1;
-          const valData = (attempt as Record<string, unknown>).stage_validation as { pass: boolean; hints: string[]; details?: { rule: string; pass: boolean; value?: string; flagged_claims?: string[] }[] } | undefined;
-          const allHints = valData?.hints ?? [];
-          // Pull draft + judge hints from overall validation for the final attempt
-          const overallHints = isFinal
-            ? (turnValTrail?.final.repairHints ?? []).filter(h => classifyHintTarget(h) !== 'cite')
-            : [];
-          const combinedHints = [...allHints, ...overallHints];
-          const turnScore = isFinal ? turnValTrail?.final.process_reward : undefined;
-
-          // Orchestration run header
-          const showOrchHeader = hasMultipleOrchRuns && orchRun !== prevOrchRun && orchRun != null;
-          const orchAttemptData = orchRun != null ? orchAttempts[orchRun] : undefined;
-          const orchOutcome = orchAttemptData?.validation?.outcome;
-          const orchAccepted = orchOutcome === 'pass' || orchOutcome === 'accept_with_flag';
-          prevOrchRun = orchRun;
-
-          return (
-            <div key={ai}>
-              {/* Orchestration run header */}
-              {showOrchHeader && (
-                // eslint-disable-next-line local/no-inline-style -- accepted-driven color
-                <div style={{
-                  display: 'flex', alignItems: 'center', gap: 8, margin: '14px 0 4px',
-                  fontSize: 'var(--text-2xs)', fontWeight: 700, color: orchAccepted ? 'var(--success)' : 'var(--danger)',
-                }}>
-                  {/* eslint-disable-next-line local/no-inline-style -- accepted-driven background */}
-                  <div style={{ flex: 1, height: 2, background: orchAccepted ? 'color-mix(in srgb, var(--success) 30%, transparent)' : 'color-mix(in srgb, var(--danger) 30%, transparent)' }} />
-                  <span>Orchestration Run {orchRun! + 1}{orchAccepted ? ' (accepted)' : ' (rejected by judge)'}</span>
-                  {/* eslint-disable-next-line local/no-inline-style -- accepted-driven background */}
-                  <div style={{ flex: 1, height: 2, background: orchAccepted ? 'color-mix(in srgb, var(--success) 30%, transparent)' : 'color-mix(in srgb, var(--danger) 30%, transparent)' }} />
-                </div>
-              )}
-              {/* Orchestration-level validation */}
-              {showOrchHeader && orchAttemptData?.validation && (() => {
-                const ov = orchAttemptData.validation;
-                const dims = ov.dimensions;
-                const score = ov.process_reward;
-                const stageA =
-                  0.4 * (dims.schema.pass ? 1 : 0) +
-                  0.3 * (dims.grounding.pass ? 1 : 0) +
-                  0.2 * (dims.advancement.pass ? 1 : 0) +
-                  0.1 * (dims.clarifies.pass ? 1 : 0);
-                const judgeQ = stageA > 0
-                  ? Math.max(0, Math.min(1, (score - 0.4 * stageA) / 0.6))
-                  : 0.7;
-                const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
-                const dimColor = (pass: boolean) => pass ? 'var(--success)' : 'var(--danger)';
-                const orchHints = ov.repairHints ?? [];
-                return (
-                  // eslint-disable-next-line local/no-inline-style -- accepted-driven background/border
-                  <div style={{
-                    margin: '4px 0 8px', borderRadius: 4, padding: '6px 8px', fontSize: '0.7rem',
-                    background: orchAccepted ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-                    border: `1px solid ${orchAccepted ? 'color-mix(in srgb, var(--success) 20%, transparent)' : 'color-mix(in srgb, var(--danger) 20%, transparent)'}`,
-                  }}>
-                    <div className="draft-score-header">
-                      <span>Orchestration Score:{' '}
-                        {/* eslint-disable-next-line local/no-inline-style -- score-driven color */}
-                        <span style={{ ...mono, color: score >= 0.7 ? 'var(--success)' : score >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>
-                          {score.toFixed(2)}
-                        </span>
-                      </span>
-                      {/* eslint-disable-next-line local/no-inline-style -- accepted-driven color/background */}
-                      <span style={{
-                        fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '1px 6px', borderRadius: 3,
-                        color: orchAccepted ? 'var(--success)' : 'var(--danger)',
-                        background: orchAccepted ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)',
-                      }}>
-                        {orchAccepted ? 'ACCEPTED' : 'REJECTED BY JUDGE'}
-                      </span>
-                    </div>
-                    <div className="draft-dims-row">
-                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                      <span><span style={{ color: dimColor(dims.schema.pass) }}>●</span> schema ×0.4 = <strong className="draft-mono">{(0.4 * (dims.schema.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                      <span><span style={{ color: dimColor(dims.grounding.pass) }}>●</span> grounding ×0.3 = <strong className="draft-mono">{(0.3 * (dims.grounding.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                      <span><span style={{ color: dimColor(dims.advancement.pass) }}>●</span> advancement ×0.2 = <strong className="draft-mono">{(0.2 * (dims.advancement.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                      <span><span style={{ color: dimColor(dims.clarifies.pass) }}>●</span> clarifies ×0.1 = <strong className="draft-mono">{(0.1 * (dims.clarifies.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                    </div>
-                    <div className="draft-score-breakdown">
-                      <span>Stage A: <strong className="draft-mono">{stageA.toFixed(2)}</strong> <span className="draft-text-muted">×0.4 = {(0.4 * stageA).toFixed(2)}</span></span>
-                      <span>Judge: <strong className="draft-mono">{judgeQ.toFixed(2)}</strong>{!ov.judge_used && <span className="draft-text-muted"> (default)</span>} <span className="draft-text-muted">×0.6 = {(0.6 * judgeQ).toFixed(2)}</span></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- score-driven color */}
-                      <span>Total: <strong style={{ ...mono, color: score >= 0.7 ? 'var(--success)' : score >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>{score.toFixed(2)}</strong></span>
-                    </div>
-                    {orchHints.length > 0 && (
-                      <div className="draft-caveats-box">
-                        <div className="draft-caveats-title">Caveats</div>
-                        <ul className="draft-hint-list">
-                          {orchHints.map((h, hi) => {
-                            const target = classifyHintTarget(h);
-                            const ts = HINT_TARGET_STYLE[target];
-                            return (
-                              <li key={hi} className="draft-mb2">
-                                {/* eslint-disable-next-line local/no-inline-style -- hint-target-driven color/background */}
-                                <span style={{
-                                  display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
-                                  color: ts.color, background: ts.bg, padding: '1px 4px',
-                                  borderRadius: 2, marginRight: 4, verticalAlign: 'middle',
-                                }}>{ts.label}</span>
-                                {humanizeSpeakerIds(h)}
-                              </li>
-                            );
-                          })}
-                        </ul>
-                      </div>
-                    )}
-                  </div>
-                );
-              })()}
-              {/* Draft attempt header */}
-              {(hasStageRetries || hasMultipleOrchRuns || effectiveDraftAttempts.length > 1) && (
-                <div className="draft-attempt-header">
-                  <div className="draft-hr-line" />
-                  <span>
-                    Draft Attempt {retryIdx + 1}
-                    {hasStageRetries && (
-                      // eslint-disable-next-line local/no-inline-style -- last-in-run-driven color/background
-                      <span style={{
-                        marginLeft: 4, fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '1px 5px',
-                        borderRadius: 3, verticalAlign: 'middle',
-                        color: isLastInRun ? 'var(--success)' : 'var(--warning)',
-                        background: isLastInRun ? 'color-mix(in srgb, var(--success) 12%, transparent)' : 'color-mix(in srgb, var(--warning) 12%, transparent)',
-                      }}>
-                        {isLastInRun ? 'final' : 'refined'}
-                      </span>
-                    )}
-                  </span>
-                  <div className="draft-hr-line" />
-                </div>
-              )}
-              <ArtifactBlock label="Raw Prompt" text={attempt.prompt} />
-              <ArtifactBlock label="Raw Response" text={attempt.raw_response} />
-              {/* Validation Score -- show the work */}
-              {(() => {
-                const dims = isFinal ? turnValTrail?.final.dimensions : undefined;
-                const judgeUsed = isFinal ? turnValTrail?.final.judge_used ?? false : false;
-                if (turnScore != null && dims) {
-                  const stageA =
-                    0.4 * (dims.schema.pass ? 1 : 0) +
-                    0.3 * (dims.grounding.pass ? 1 : 0) +
-                    0.2 * (dims.advancement.pass ? 1 : 0) +
-                    0.1 * (dims.clarifies.pass ? 1 : 0);
-                  const judgeQ = stageA > 0
-                    ? Math.max(0, Math.min(1, (turnScore - 0.4 * stageA) / 0.6))
-                    : 0.7;
-                  const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
-                  const dimColor = (pass: boolean) => pass ? 'var(--success)' : 'var(--danger)';
-                  return (
-                    <div className="draft-valscore-box">
-                      <div className="draft-valscore-title">
-                        Validation Score:{' '}
-                        {/* eslint-disable-next-line local/no-inline-style -- score-driven color */}
-                        <span style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>
-                          {turnScore.toFixed(2)}
-                        </span>
-                      </div>
-                      <div className="draft-dims-row">
-                        {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                        <span><span style={{ color: dimColor(dims.schema.pass) }}>●</span> schema ×0.4 = <strong className="draft-mono">{(0.4 * (dims.schema.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                        {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                        <span><span style={{ color: dimColor(dims.grounding.pass) }}>●</span> grounding ×0.3 = <strong className="draft-mono">{(0.3 * (dims.grounding.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                        {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                        <span><span style={{ color: dimColor(dims.advancement.pass) }}>●</span> advancement ×0.2 = <strong className="draft-mono">{(0.2 * (dims.advancement.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                        {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                        <span><span style={{ color: dimColor(dims.clarifies.pass) }}>●</span> clarifies ×0.1 = <strong className="draft-mono">{(0.1 * (dims.clarifies.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      </div>
-                      <div className="draft-score-breakdown">
-                        <span>Stage A: <strong className="draft-mono">{stageA.toFixed(2)}</strong> <span className="draft-text-muted">×0.4 = {(0.4 * stageA).toFixed(2)}</span></span>
-                        <span>Judge: <strong className="draft-mono">{judgeQ.toFixed(2)}</strong>{!judgeUsed && <span className="draft-text-muted"> (default)</span>} <span className="draft-text-muted">×0.6 = {(0.6 * judgeQ).toFixed(2)}</span></span>
-                        {/* eslint-disable-next-line local/no-inline-style -- score-driven color */}
-                        <span>Total: <strong style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>{turnScore.toFixed(2)}</strong></span>
-                      </div>
-                    </div>
-                  );
-                }
-                // Fallback: no dimensions available
-                return (
-                  <div className="draft-perstage-box">
-                    <div className="draft-bold">
-                      Per-stage Validation:{' '}
-                      {valData ? (
-                        // eslint-disable-next-line local/no-inline-style -- pass-driven color
-                        <span style={{ color: valData.pass ? 'var(--success)' : 'var(--danger)' }}>
-                          {valData.pass ? 'Pass' : 'Fail'}
-                        </span>
-                      ) : (
-                        <span className="draft-text-muted">—</span>
-                      )}
-                    </div>
-                    {valData?.details && valData.details.length > 0 && (
-                      <div className="draft-details-list">
-                        {valData.details.map((d, di) => (
-                          <div key={di}>
-                            <div className="draft-flex-center-gap6">
-                              {/* eslint-disable-next-line local/no-inline-style -- pass-driven color */}
-                              <span style={{ color: d.pass ? 'var(--success)' : 'var(--danger)', fontSize: '0.7rem' }}>{d.pass ? '✓' : '✗'}</span>
-                              <span className="draft-text-primary">{d.rule}</span>
-                              {d.value && <span className="draft-mono-muted">{d.value}</span>}
-                            </div>
-                            {d.flagged_claims && d.flagged_claims.length > 0 && (
-                              <div className="draft-flagged-list">
-                                {d.flagged_claims.map((claim: string, ci: number) => (
-                                  <div key={ci} className="draft-flagged-item">• {claim}</div>
-                                ))}
-                              </div>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                );
-              })()}
-              {/* Validation Feedback */}
-              {combinedHints.length > 0 && (
-                <details open className="draft-feedback">
-                  <summary className="draft-summary-plain">Validation Feedback</summary>
-                  <ul className="draft-feedback-list">
-                    {combinedHints.map((h, hi) => {
-                      const target = classifyHintTarget(h);
-                      const ts = HINT_TARGET_STYLE[target];
-                      return (
-                        <li key={hi} className="draft-mb3">
-                          {/* eslint-disable-next-line local/no-inline-style -- hint-target-driven color/background */}
-                          <span style={{
-                            display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
-                            color: ts.color, background: ts.bg, padding: '1px 5px',
-                            borderRadius: 3, marginRight: 5, verticalAlign: 'middle',
-                          }}>{ts.label}</span>
-                          {humanizeSpeakerIds(h)}
-                        </li>
-                      );
-                    })}
-                  </ul>
-              </details>
-            )}
-              {/* Per-attempt Micro-Fix stages */}
-              {(() => {
-                const attemptMicroFixes = orchAttemptData?.stage_diagnostics?.filter(
-                  (s: { stage: string }) => s.stage === 'micro-fix',
-                ) ?? [];
-                if (attemptMicroFixes.length === 0) return null;
-                return attemptMicroFixes.map((mf: { stage: string; prompt?: string; raw_response?: string; response_time_ms?: number; work_product?: Record<string, unknown> }, mi: number) => {
-                  const wp = mf.work_product;
-                  const success = wp?.success as boolean | undefined;
-                  const fixType = wp?.type as string | undefined;
-                  const elapsed = mf.response_time_ms ?? 0;
-                  const statusColor = success ? 'var(--success)' : 'var(--danger)';
-
-                  if (fixType === 'intervention_compliance') {
-                    const move = wp?.move as string | undefined;
-                    const field = wp?.field as string | undefined;
-                    const generated = wp?.generated_value as Record<string, unknown> | string | undefined;
-                    const recheck = wp?.recheck_result as { compliant?: boolean; repair_hint?: string } | undefined;
-                    const rejected = wp?.rejected_reason as string | undefined;
-                    return (
-                      // eslint-disable-next-line local/no-inline-style -- success-driven border/background
-                      <div key={`mf-${mi}`} style={{
-                        margin: '6px 0', padding: '6px 8px',
-                        background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-                        borderLeft: `3px solid ${statusColor}`,
-                        borderRadius: 4, fontSize: 'var(--text-2xs)',
-                      }}>
-                        {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                        <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
-                          Micro-Fix: {move ?? 'Intervention'} Compliance ({elapsed}ms) — {success ? 'Applied' : rejected ? `Rejected (${rejected})` : recheck && !recheck.compliant ? 'Re-validation failed' : 'Failed'}
-                        </div>
-                        {field && (
-                          <div className="draft-field-note">
-                            Field: <code className="draft-code-chip">{field}</code>
-                            {!success && <span className="draft-ml6">Before: <em>missing</em></span>}
-                          </div>
-                        )}
-                        {generated != null && (
-                          <details open={success} className="draft-2xs">
-                            {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                            <summary style={{ cursor: 'pointer', color: statusColor }}>
-                              {success ? 'After — Generated value' : 'Attempted value (rejected)'}
-                            </summary>
-                            <pre className="draft-mf-pre">
-                              {typeof generated === 'string' ? generated : JSON.stringify(generated, null, 2)}
-                            </pre>
-                          </details>
-                        )}
-                        {recheck?.repair_hint && !recheck.compliant && (
-                          <div className="draft-danger-note-mt4">
-                            {recheck.repair_hint}
-                          </div>
-                        )}
-                      </div>
-                    );
-                  }
-
-                  if (fixType === 'directive_compliance') {
-                    const move = wp?.move as string | undefined;
-                    const revisedPara = wp?.revised_first_paragraph as string | undefined;
-                    const recheckCompliant = wp?.recheck_compliant as boolean | undefined;
-                    const rejected = wp?.rejected_reason as string | undefined;
-                    return (
-                      // eslint-disable-next-line local/no-inline-style -- success-driven border/background
-                      <div key={`mf-${mi}`} style={{
-                        margin: '6px 0', padding: '6px 8px',
-                        background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-                        borderLeft: `3px solid ${statusColor}`,
-                        borderRadius: 4, fontSize: 'var(--text-2xs)',
-                      }}>
-                        {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                        <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
-                          Micro-Fix: Directive Compliance — {move ?? '?'} ({elapsed}ms) — {success ? 'Applied' : rejected ? `Rejected (${rejected})` : recheckCompliant === false ? 'Re-validation failed' : 'Failed'}
-                        </div>
-                        {revisedPara && (
-                          <details open={success} className="draft-2xs">
-                            {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                            <summary style={{ cursor: 'pointer', color: statusColor }}>
-                              {success ? 'After — Revised first paragraph' : 'Attempted revision (rejected)'}
-                            </summary>
-                            <pre className="draft-mf-pre">{revisedPara}</pre>
-                          </details>
-                        )}
-                      </div>
-                    );
-                  }
-
-                  const changes = wp?.changes as Array<{ original?: string; revised?: string; fact_source?: string }> | undefined;
-                  const diffPassed = wp?.diff_check_passed as boolean | undefined;
-                  const rejected = wp?.rejected_reason as string | undefined;
-                  const revisedStatement = wp?.revised_statement as string | undefined;
-                  return (
-                    // eslint-disable-next-line local/no-inline-style -- success-driven border/background
-                    <div key={`mf-${mi}`} style={{
-                      margin: '6px 0', padding: '6px 8px',
-                      background: success ? 'color-mix(in srgb, var(--success) 6%, transparent)' : 'color-mix(in srgb, var(--danger) 6%, transparent)',
-                      borderLeft: `3px solid ${statusColor}`,
-                      borderRadius: 4, fontSize: 'var(--text-2xs)',
-                    }}>
-                      {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                      <div style={{ fontWeight: 600, color: statusColor, marginBottom: 4 }}>
-                        Micro-Fix: Abstract Claims ({elapsed}ms) — {success ? 'Applied' : diffPassed === false ? (rejected === 'hallucinated_changes' ? 'Rejected (hallucinated edits)' : 'Rejected (too many changes)') : 'Re-validation failed'}
-                        {changes && <span className="draft-change-count">{changes.length} change{changes.length !== 1 ? 's' : ''}</span>}
-                      </div>
-                      {changes && changes.length > 0 && (
-                        <div className="draft-2xs">
-                          {changes.map((c, ci) => (
-                            <div key={ci} className="draft-change-row">
-                              <div className="draft-flex-baseline">
-                                <span className="draft-before-label">BEFORE</span>
-                                <div className="draft-before-text">{c.original ?? ''}</div>
-                              </div>
-                              {c.revised && c.original !== c.revised && (
-                                <div className="draft-flex-baseline-mt2">
-                                  <span className="draft-after-label">AFTER</span>
-                                  <div className="draft-after-text">{c.revised}</div>
-                                </div>
-                              )}
-                              {c.fact_source && (
-                                <div className="draft-source-note">source: {c.fact_source}</div>
-                              )}
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                      {revisedStatement && (
-                        <details className="draft-2xs-mt4">
-                          {/* eslint-disable-next-line local/no-inline-style -- statusColor-driven */}
-                          <summary style={{ cursor: 'pointer', color: statusColor }}>
-                            {success ? 'After — Full revised statement' : 'Attempted revision (rejected)'}
-                          </summary>
-                          <pre className="draft-mf-pre">{revisedStatement}</pre>
-                        </details>
-                      )}
-                    </div>
-                  );
-                });
-              })()}
-          </div>
-        );
-      });
-    })()}
-    {/* -- Quality Pre-Check (draft_quality stage) -- */}
-    {draftQualityStage && (() => {
-      const wp = draftQualityStage.work_product as {
-        grounded?: boolean; falsifiable?: boolean; engages?: boolean; topic_aligned?: boolean; weaknesses?: string[];
-      };
-      const indicators: [string, boolean | undefined][] = [
-        ['Grounded', wp.grounded],
-        ['Falsifiable', wp.falsifiable],
-        ['Engages', wp.engages],
-        ['Topic Aligned', wp.topic_aligned],
-      ];
-      const allPass = indicators.every(([, v]) => v === true);
-      // §3: if all indicators pass, collapse to a single summary line
-      if (allPass && !draftQualityStage.parse_error) {
-        return (
-          <div className="draft-qcheck-pass">
-            <span className="draft-qcheck-icon">✓</span>
-            <span className="draft-qcheck-label">Quality Pre-Check — all pass</span>
-            <span className="draft-meta-muted">{draftQualityStage.model}</span>
-            <span className="draft-meta-muted">{(draftQualityStage.response_time_ms / 1000).toFixed(1)}s</span>
-          </div>
-        );
-      }
-      return (
-        <div className="draft-qcheck-warn">
-          <div className="draft-qcheck-head">
-            <span className="draft-qcheck-title">Quality Pre-Check</span>
-            <span className="draft-qcheck-badge">Draft Attempt 1</span>
-            {diag?.topic_alignment?.repaired && (
-              <span className="draft-qcheck-regen">triggered regen</span>
-            )}
-            <span className="draft-meta-muted">{draftQualityStage.model}</span>
-            <span className="draft-meta-muted">{(draftQualityStage.response_time_ms / 1000).toFixed(1)}s</span>
-          </div>
-          <div className="draft-indicators-row">
-            {indicators.map(([label, pass]) => (
-              <span key={label} className="draft-indicator">
-                {/* eslint-disable-next-line local/no-inline-style -- pass-driven color */}
-                <span style={{ color: pass ? 'var(--success)' : 'var(--danger)', fontWeight: 700 }}>{pass ? '✓' : '✗'}</span>
-                <span>{label}</span>
-              </span>
-            ))}
-          </div>
-          {wp.weaknesses && wp.weaknesses.length > 0 && (
-            <div className="draft-caveats-box">
-              <div className="draft-weakness-title">Weaknesses</div>
-              <ul className="draft-hint-list">
-                {wp.weaknesses.map((w, wi) => (
-                  <li key={wi} className="draft-mb2">{humanizeSpeakerIds(w)}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {draftQualityStage.parse_error && (
-            <div className="draft-qcheck-parse-error">
-              <strong>Parse error:</strong> {draftQualityStage.parse_error}
-            </div>
-          )}
-        </div>
-      );
-    })()}
-    {/* -- Topic Alignment Detail (per-attempt) -- */}
-    {diag?.topic_alignment && (() => {
-      const ta = diag.topic_alignment;
-      const qg = diag.quality_gate as {
-        pre_repair: { grounded: boolean; falsifiable: boolean; engages: boolean; topic_aligned: boolean; pass: boolean; weaknesses: string[] };
-        post_repair?: { grounded: boolean; falsifiable: boolean; engages: boolean; topic_aligned: boolean; pass: boolean; weaknesses: string[] };
-        repair_outcome?: 'fixed' | 'partial' | 'unchanged';
-      } | undefined;
-      const scope = ta.scope_used;
-      const attempts: { label: string; aligned: boolean; weaknesses: string[] }[] = [];
-      if (qg) {
-        attempts.push({ label: 'Draft 1', aligned: qg.pre_repair.topic_aligned, weaknesses: qg.pre_repair.weaknesses });
-        if (qg.post_repair) {
-          attempts.push({ label: 'Draft 2 (regen)', aligned: qg.post_repair.topic_aligned, weaknesses: qg.post_repair.weaknesses });
-        }
-      } else {
-        attempts.push({ label: 'Draft 1', aligned: ta.topic_aligned, weaknesses: [] });
-      }
-      const finalAligned = ta.topic_aligned;
-      return (
-        // eslint-disable-next-line local/no-inline-style -- aligned-driven background/border
-        <div style={{
-          margin: '10px 0 4px', borderRadius: 4, padding: '6px 8px', fontSize: '0.7rem',
-          background: finalAligned ? 'rgba(22,163,74,0.06)' : 'rgba(220,38,38,0.06)',
-          border: `1px solid ${finalAligned ? 'rgba(22,163,74,0.2)' : 'rgba(220,38,38,0.2)'}`,
-        }}>
-          <div className="draft-ta-title">Topic Alignment</div>
-          {attempts.map((att, ai) => {
-            const topicWeaknesses = att.weaknesses.filter(w =>
-              /\b(off.?scope|off.?topic|drift|outside.*scope|beyond.*scope|scope|domain|severity|magnitude|escalat|disproportionate|catastroph|existential|extinction|civiliz)\b/i.test(w)
-            );
-            const driftType = !att.aligned && scope && topicWeaknesses.length > 0
-              ? classifyOffScopeDrift(topicWeaknesses, scope)
-              : null;
-            const repairHint = driftType && scope ? offScopeRepairHint(driftType, scope) : null;
-            return (
-              // eslint-disable-next-line local/no-inline-style -- data-driven margin
-              <div key={ai} style={{ marginBottom: ai < attempts.length - 1 ? 8 : 0 }}>
-                <div className="draft-ta-row">
-                  <span className="draft-ta-label">{att.label}</span>
-                  {/* eslint-disable-next-line local/no-inline-style -- aligned-driven color/background */}
-                  <span style={{
-                    padding: '1px 6px', borderRadius: 3, fontWeight: 600, fontSize: 'var(--text-2xs)',
-                    background: att.aligned ? 'rgba(22,163,74,0.2)' : 'rgba(220,38,38,0.2)',
-                    color: att.aligned ? 'var(--success)' : 'var(--danger)',
-                  }}>{att.aligned ? 'ON-SCOPE' : 'OFF-SCOPE'}</span>
-                  {driftType && (
-                    <span className="draft-drift-badge">
-                      {driftType} drift
-                    </span>
-                  )}
-                  {ai === attempts.length - 1 && qg?.repair_outcome && (
-                    // eslint-disable-next-line local/no-inline-style -- repair-outcome-driven color/background
-                    <span style={{
-                      padding: '1px 5px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600,
-                      background: qg.repair_outcome === 'fixed' ? 'rgba(22,163,74,0.15)' : qg.repair_outcome === 'partial' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'rgba(220,38,38,0.1)',
-                      color: qg.repair_outcome === 'fixed' ? 'var(--success)' : qg.repair_outcome === 'partial' ? 'var(--warning)' : 'var(--danger)',
-                    }}>repair: {qg.repair_outcome}</span>
-                  )}
-                </div>
-                {!att.aligned && topicWeaknesses.length > 0 && (
-                  <div className="draft-offscope-box">
-                    <div className="draft-offscope-title">Why off-scope:</div>
-                    <ul className="draft-offscope-list">
-                      {topicWeaknesses.map((w, wi) => <li key={wi} className="draft-mb1">{humanizeSpeakerIds(w)}</li>)}
-                    </ul>
-                    {repairHint && (
-                      <div className="draft-repair-hint">
-                        <strong>Repair instruction:</strong> {repairHint}
-                      </div>
-                    )}
-                  </div>
-                )}
-                {!att.aligned && topicWeaknesses.length === 0 && att.weaknesses.length > 0 && (
-                  <div className="draft-offscope-box">
-                    <div className="draft-offscope-title">Why off-scope:</div>
-                    <ul className="draft-offscope-list">
-                      {att.weaknesses.map((w, wi) => <li key={wi} className="draft-mb1">{humanizeSpeakerIds(w)}</li>)}
-                    </ul>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-          {scope && (
-            <details className="draft-scope-details">
-              <summary className="draft-scope-summary">Scope Definition</summary>
-              <div className="draft-scope-body">
-                {scope.core_proposition && (
-                  <div className="draft-mb3"><strong>Core proposition:</strong> {scope.core_proposition}</div>
-                )}
-                {scope.domain && (
-                  <div className="draft-mb3"><strong>Domain:</strong> {scope.domain}</div>
-                )}
-                {scope.example_ceiling && (
-                  <div className="draft-mb3"><strong>Example ceiling:</strong> {scope.example_ceiling}</div>
-                )}
-                {scope.off_scope_topics && scope.off_scope_topics.length > 0 && (
-                  <div className="draft-mb3">
-                    <strong>Off-scope topics:</strong>
-                    <ul className="draft-scope-list">
-                      {scope.off_scope_topics.map((t: string, i: number) => <li key={i}>{t}</li>)}
-                    </ul>
-                  </div>
-                )}
-                {scope.drift_signatures && scope.drift_signatures.length > 0 && (
-                  <div>
-                    <strong>Drift signatures:</strong>
-                    <ul className="draft-scope-list">
-                      {scope.drift_signatures.map((s: string, i: number) => <li key={i}>{s}</li>)}
-                    </ul>
-                  </div>
-                )}
-              </div>
-            </details>
-          )}
-        </div>
-      );
-    })()}
     </div>
+  );
+}
+
+// ── Topic Alignment Detail ───────────────────────────────────────────────
+
+function TopicAlignmentDetail({ diag }: { diag: EntryDiagnostics | undefined }) {
+  if (!diag || !diag.topic_alignment) return null;
+  const ta = diag.topic_alignment;
+  const qg = diag.quality_gate as QGShape | undefined;
+  const scope = ta.scope_used;
+  const attempts: TopicAttempt[] = [];
+  if (qg) {
+    attempts.push({ label: 'Draft 1', aligned: qg.pre_repair.topic_aligned, weaknesses: qg.pre_repair.weaknesses });
+    if (qg.post_repair) {
+      attempts.push({ label: 'Draft 2 (regen)', aligned: qg.post_repair.topic_aligned, weaknesses: qg.post_repair.weaknesses });
+    }
+  } else {
+    attempts.push({ label: 'Draft 1', aligned: ta.topic_aligned, weaknesses: [] });
+  }
+  const finalAligned = ta.topic_aligned;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- aligned-driven background/border
+    <div style={{
+      margin: '10px 0 4px', borderRadius: 4, padding: '6px 8px', fontSize: '0.7rem',
+      background: finalAligned ? 'rgba(22,163,74,0.06)' : 'rgba(220,38,38,0.06)',
+      border: `1px solid ${finalAligned ? 'rgba(22,163,74,0.2)' : 'rgba(220,38,38,0.2)'}`,
+    }}>
+      <div className="draft-ta-title">Topic Alignment</div>
+      {attempts.map((att, ai) => (
+        <TopicAttemptRow key={ai} att={att} ai={ai} total={attempts.length} scope={scope} qg={qg} />
+      ))}
+      <ScopeDefinition scope={scope} />
+    </div>
+  );
+}
+
+function TopicAttemptRow({ att, ai, total, scope, qg }: {
+  att: TopicAttempt;
+  ai: number;
+  total: number;
+  scope: TopicScopeUsed;
+  qg: QGShape | undefined;
+}) {
+  const topicWeaknesses = att.weaknesses.filter(w =>
+    /\b(off.?scope|off.?topic|drift|outside.*scope|beyond.*scope|scope|domain|severity|magnitude|escalat|disproportionate|catastroph|existential|extinction|civiliz)\b/i.test(w)
+  );
+  const driftType = !att.aligned && scope && topicWeaknesses.length > 0
+    ? classifyOffScopeDrift(topicWeaknesses, scope)
+    : null;
+  const repairHint = driftType && scope ? offScopeRepairHint(driftType, scope) : null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- data-driven margin
+    <div style={{ marginBottom: ai < total - 1 ? 8 : 0 }}>
+      <div className="draft-ta-row">
+        <span className="draft-ta-label">{att.label}</span>
+        {/* eslint-disable-next-line local/no-inline-style -- aligned-driven color/background */}
+        <span style={{
+          padding: '1px 6px', borderRadius: 3, fontWeight: 600, fontSize: 'var(--text-2xs)',
+          background: att.aligned ? 'rgba(22,163,74,0.2)' : 'rgba(220,38,38,0.2)',
+          color: att.aligned ? 'var(--success)' : 'var(--danger)',
+        }}>{att.aligned ? 'ON-SCOPE' : 'OFF-SCOPE'}</span>
+        {driftType && (
+          <span className="draft-drift-badge">
+            {driftType} drift
+          </span>
+        )}
+        <RepairOutcomeBadge show={ai === total - 1} qg={qg} />
+      </div>
+      <TopicOffScope att={att} topicWeaknesses={topicWeaknesses} repairHint={repairHint} />
+    </div>
+  );
+}
+
+function RepairOutcomeBadge({ show, qg }: { show: boolean; qg: QGShape | undefined }) {
+  if (!show || !qg || !qg.repair_outcome) return null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- repair-outcome-driven color/background
+    <span style={{
+      padding: '1px 5px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600,
+      background: qg.repair_outcome === 'fixed' ? 'rgba(22,163,74,0.15)' : qg.repair_outcome === 'partial' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'rgba(220,38,38,0.1)',
+      color: qg.repair_outcome === 'fixed' ? 'var(--success)' : qg.repair_outcome === 'partial' ? 'var(--warning)' : 'var(--danger)',
+    }}>repair: {qg.repair_outcome}</span>
+  );
+}
+
+function TopicOffScope({ att, topicWeaknesses, repairHint }: {
+  att: TopicAttempt;
+  topicWeaknesses: string[];
+  repairHint: string | null;
+}) {
+  if (!att.aligned && topicWeaknesses.length > 0) {
+    return (
+      <div className="draft-offscope-box">
+        <div className="draft-offscope-title">Why off-scope:</div>
+        <ul className="draft-offscope-list">
+          {topicWeaknesses.map((w, wi) => <li key={wi} className="draft-mb1">{humanizeSpeakerIds(w)}</li>)}
+        </ul>
+        {repairHint && (
+          <div className="draft-repair-hint">
+            <strong>Repair instruction:</strong> {repairHint}
+          </div>
+        )}
+      </div>
+    );
+  }
+  if (!att.aligned && topicWeaknesses.length === 0 && att.weaknesses.length > 0) {
+    return (
+      <div className="draft-offscope-box">
+        <div className="draft-offscope-title">Why off-scope:</div>
+        <ul className="draft-offscope-list">
+          {att.weaknesses.map((w, wi) => <li key={wi} className="draft-mb1">{humanizeSpeakerIds(w)}</li>)}
+        </ul>
+      </div>
+    );
+  }
+  return null;
+}
+
+function ScopeDefinition({ scope }: { scope: TopicScopeUsed }) {
+  if (!scope) return null;
+  return (
+    <details className="draft-scope-details">
+      <summary className="draft-scope-summary">Scope Definition</summary>
+      <div className="draft-scope-body">
+        {scope.core_proposition && (
+          <div className="draft-mb3"><strong>Core proposition:</strong> {scope.core_proposition}</div>
+        )}
+        {scope.domain && (
+          <div className="draft-mb3"><strong>Domain:</strong> {scope.domain}</div>
+        )}
+        {scope.example_ceiling && (
+          <div className="draft-mb3"><strong>Example ceiling:</strong> {scope.example_ceiling}</div>
+        )}
+        {scope.off_scope_topics && scope.off_scope_topics.length > 0 && (
+          <div className="draft-mb3">
+            <strong>Off-scope topics:</strong>
+            <ul className="draft-scope-list">
+              {scope.off_scope_topics.map((t: string, i: number) => <li key={i}>{t}</li>)}
+            </ul>
+          </div>
+        )}
+        {scope.drift_signatures && scope.drift_signatures.length > 0 && (
+          <div>
+            <strong>Drift signatures:</strong>
+            <ul className="draft-scope-list">
+              {scope.drift_signatures.map((s: string, i: number) => <li key={i}>{s}</li>)}
+            </ul>
+          </div>
+        )}
+      </div>
+    </details>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/TaxRefsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/TaxRefsTab.tsx
@@ -20,6 +20,142 @@ export interface TaxRefsTabProps {
   setOverviewTab: (tab: OverviewTab) => void;
 }
 
+type TaxRef = NonNullable<DebateSession['transcript'][number]['taxonomy_refs']>[number];
+type RelevanceSource = { node_id: string; source: 'an' | 'topic'; an_score: number; topic_score: number; best_claim_id?: string; best_claim_text?: string; best_claim_sim?: number };
+type NodeWeight = { confidence?: number; priority?: number; operationality?: number; category?: string };
+
+function scoreColorFor(score: number | undefined): string {
+  return score == null ? 'var(--text-muted)'
+    : score >= 0.45 ? 'var(--success)'
+    : score >= 0.30 ? 'var(--warning)'
+    : 'var(--danger)';
+}
+
+function weightLabelFor(tw: NodeWeight | undefined): string | null {
+  return tw?.category === 'Beliefs' ? 'Confidence'
+    : tw?.category === 'Desires' ? 'Priority'
+    : tw?.category === 'Intentions' ? 'Operationality' : null;
+}
+
+function weightValueFor(tw: NodeWeight | undefined): number | undefined {
+  return tw?.category === 'Beliefs' ? tw.confidence
+    : tw?.category === 'Desires' ? tw.priority
+    : tw?.category === 'Intentions' ? tw.operationality : undefined;
+}
+
+function RelevanceWeightLine({ score, weightLabel, weightValue }: { score: number | undefined; weightLabel: string | null; weightValue: number | undefined }) {
+  if (!(score != null || weightValue != null)) return null;
+  return (
+    <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 2 }}>
+      ({score != null && <>Relevance {score.toFixed(2)}</>}
+      {score != null && weightLabel && weightValue != null && ' ; '}
+      {weightLabel && weightValue != null && <>{weightLabel} {weightLabel === 'Confidence' ? weightValue.toFixed(2) : `${weightValue}/5`}</>})
+    </div>
+  );
+}
+
+function TaxRefIdCell({ r, score, tw, isSelected, setSelectedTaxRefId }: { r: TaxRef; score: number | undefined; tw: NodeWeight | undefined; isSelected: boolean; setSelectedTaxRefId: (id: string | null) => void }) {
+  const weightLabel = weightLabelFor(tw);
+  const weightValue = weightValueFor(tw);
+  return (
+    <>
+      <button
+        onClick={() => setSelectedTaxRefId(isSelected ? null : r.node_id)}
+        style={{
+          background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+          color: 'var(--accent)', fontWeight: isSelected ? 700 : 600,
+          textDecoration: 'underline', fontFamily: 'inherit', fontSize: 'inherit', textAlign: 'left',
+        }}
+        title="Show Perspective details"
+      >{r.primary ? '★ ' : ''}{r.node_id}{(r as {label?: string}).label ? `: ${(r as {label?: string}).label}` : ''}</button>
+      <RelevanceWeightLine score={score} weightLabel={weightLabel} weightValue={weightValue} />
+    </>
+  );
+}
+
+function SourceCell({ src, isAN }: { src: RelevanceSource | undefined; isAN: boolean }) {
+  return (
+    <td style={{ padding: '4px 6px', verticalAlign: 'top' }}>
+      {src && (
+        <span style={{
+          display: 'inline-block',
+          padding: '1px 5px',
+          borderRadius: 3,
+          fontSize: 'var(--text-2xs)',
+          fontWeight: 700,
+          background: isAN ? 'color-mix(in srgb, var(--success) 20%, transparent)' : 'color-mix(in srgb, var(--warning) 20%, transparent)',
+          color: isAN ? 'var(--success)' : 'var(--warning)',
+        }}>{isAN ? (src.best_claim_id ?? 'AN') : 'TOPIC'}</span>
+      )}
+    </td>
+  );
+}
+
+function ScoringDetailRow({ src, isSelected, hasSourceData, setOverviewTab }: { src: RelevanceSource; isSelected: boolean; hasSourceData: boolean; setOverviewTab: (tab: OverviewTab) => void }) {
+  const isAN = src.source === 'an';
+  return (
+    <tr style={{ borderBottom: '1px solid var(--border)', background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent' }}>
+      <td colSpan={hasSourceData ? 4 : 3} style={{ padding: '0 6px 4px 20px' }}>
+        <details style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>
+          <summary style={{ cursor: 'pointer', userSelect: 'none' }}>Scoring detail</summary>
+          <div style={{ padding: '4px 0 2px 12px', lineHeight: 1.5 }}>
+            {isAN && src.best_claim_id && (
+              <div>
+                <strong>Best match:</strong>{' '}
+                <button onClick={() => setOverviewTab('argument-network')} style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--accent)', textDecoration: 'underline', fontFamily: 'inherit', fontSize: 'inherit' }}>{src.best_claim_id}</button>
+                {src.best_claim_text && <> &ldquo;{truncateLabel(src.best_claim_text, 60)}&rdquo;</>}
+                {src.best_claim_sim != null && <> (sim: {src.best_claim_sim.toFixed(2)})</>}
+              </div>
+            )}
+            <div><strong>AN score:</strong> {src.an_score.toFixed(3)}</div>
+            <div><strong>Topic floor:</strong> {(src.topic_score * 0.5).toFixed(3)} (raw: {src.topic_score.toFixed(3)} {'×'} 0.5)</div>
+            <div><strong>Winner:</strong> {isAN ? 'AN score used' : 'Topic floor used — no AN match above floor'}</div>
+          </div>
+        </details>
+      </td>
+    </tr>
+  );
+}
+
+function TaxRefRow({ r, hasSourceData, isSelected, src, tw, setSelectedTaxRefId, setOverviewTab }: {
+  r: TaxRef;
+  hasSourceData: boolean;
+  isSelected: boolean;
+  src: RelevanceSource | undefined;
+  tw: NodeWeight | undefined;
+  setSelectedTaxRefId: (id: string | null) => void;
+  setOverviewTab: (tab: OverviewTab) => void;
+}) {
+  const score = r.relevance_score;
+  const scoreColor = scoreColorFor(score);
+  const isAN = src?.source === 'an';
+  return (
+    <Fragment>
+      <tr
+        style={{
+          borderBottom: src ? 'none' : '1px solid var(--border)',
+          background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent',
+        }}
+      >
+        {hasSourceData && <SourceCell src={src} isAN={isAN} />}
+        <td style={{ padding: '4px 6px', verticalAlign: 'top' }}>
+          <TaxRefIdCell r={r} score={score} tw={tw} isSelected={isSelected} setSelectedTaxRefId={setSelectedTaxRefId} />
+        </td>
+        <td style={{ padding: '4px 6px', verticalAlign: 'top', textAlign: 'center', fontWeight: 600, color: scoreColor, fontFamily: 'monospace', fontSize: '0.75rem' }}>
+          {score != null ? score.toFixed(2) : '—'}
+        </td>
+        <td style={{ padding: '4px 6px', verticalAlign: 'top', whiteSpace: 'normal', wordBreak: 'break-word' }}>
+          {r.relevance}
+        </td>
+      </tr>
+      {/* Expandable scoring detail */}
+      {src && (
+        <ScoringDetailRow src={src} isSelected={isSelected} hasSourceData={hasSourceData} setOverviewTab={setOverviewTab} />
+      )}
+    </Fragment>
+  );
+}
+
 /**
  * TaxRefsTab -- Taxonomy References tab.
  * Renders the taxonomy ref table with AN coverage and TaxonomyRefDetail.
@@ -155,96 +291,18 @@ export function TaxRefsTab({ entry, meta, debate, taxRefCount, nodeWeights, taxN
           </tr>
         </thead>
         <tbody>
-          {[...entry.taxonomy_refs!].sort((a, b) => (b.relevance_score ?? 0) - (a.relevance_score ?? 0)).map((r, i) => {
-            const isSelected = selectedTaxRefId === r.node_id;
-            const score = r.relevance_score;
-            const scoreColor = score == null ? 'var(--text-muted)'
-              : score >= 0.45 ? 'var(--success)'
-              : score >= 0.30 ? 'var(--warning)'
-              : 'var(--danger)';
-            const src = sourceMap.get(r.node_id);
-            const isAN = src?.source === 'an';
-            const tw = nodeWeights.get(r.node_id);
-            const weightLabel = tw?.category === 'Beliefs' ? 'Confidence'
-              : tw?.category === 'Desires' ? 'Priority'
-              : tw?.category === 'Intentions' ? 'Operationality' : null;
-            const weightValue = tw?.category === 'Beliefs' ? tw.confidence
-              : tw?.category === 'Desires' ? tw.priority
-              : tw?.category === 'Intentions' ? tw.operationality : undefined;
-            return (
-              <Fragment key={i}>
-                <tr
-                  style={{
-                    borderBottom: src ? 'none' : '1px solid var(--border)',
-                    background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent',
-                  }}
-                >
-                  {hasSourceData && (
-                    <td style={{ padding: '4px 6px', verticalAlign: 'top' }}>
-                      {src && (
-                        <span style={{
-                          display: 'inline-block',
-                          padding: '1px 5px',
-                          borderRadius: 3,
-                          fontSize: 'var(--text-2xs)',
-                          fontWeight: 700,
-                          background: isAN ? 'color-mix(in srgb, var(--success) 20%, transparent)' : 'color-mix(in srgb, var(--warning) 20%, transparent)',
-                          color: isAN ? 'var(--success)' : 'var(--warning)',
-                        }}>{isAN ? (src.best_claim_id ?? 'AN') : 'TOPIC'}</span>
-                      )}
-                    </td>
-                  )}
-                  <td style={{ padding: '4px 6px', verticalAlign: 'top' }}>
-                    <button
-                      onClick={() => setSelectedTaxRefId(isSelected ? null : r.node_id)}
-                      style={{
-                        background: 'none', border: 'none', padding: 0, cursor: 'pointer',
-                        color: 'var(--accent)', fontWeight: isSelected ? 700 : 600,
-                        textDecoration: 'underline', fontFamily: 'inherit', fontSize: 'inherit', textAlign: 'left',
-                      }}
-                      title="Show Perspective details"
-                    >{r.primary ? '★ ' : ''}{r.node_id}{(r as {label?: string}).label ? `: ${(r as {label?: string}).label}` : ''}</button>
-                    {(score != null || weightValue != null) && (
-                      <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 2 }}>
-                        ({score != null && <>Relevance {score.toFixed(2)}</>}
-                        {score != null && weightLabel && weightValue != null && ' ; '}
-                        {weightLabel && weightValue != null && <>{weightLabel} {weightLabel === 'Confidence' ? weightValue.toFixed(2) : `${weightValue}/5`}</>})
-                      </div>
-                    )}
-                  </td>
-                  <td style={{ padding: '4px 6px', verticalAlign: 'top', textAlign: 'center', fontWeight: 600, color: scoreColor, fontFamily: 'monospace', fontSize: '0.75rem' }}>
-                    {score != null ? score.toFixed(2) : '—'}
-                  </td>
-                  <td style={{ padding: '4px 6px', verticalAlign: 'top', whiteSpace: 'normal', wordBreak: 'break-word' }}>
-                    {r.relevance}
-                  </td>
-                </tr>
-                {/* Expandable scoring detail */}
-                {src && (
-                  <tr style={{ borderBottom: '1px solid var(--border)', background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent' }}>
-                    <td colSpan={hasSourceData ? 4 : 3} style={{ padding: '0 6px 4px 20px' }}>
-                      <details style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>
-                        <summary style={{ cursor: 'pointer', userSelect: 'none' }}>Scoring detail</summary>
-                        <div style={{ padding: '4px 0 2px 12px', lineHeight: 1.5 }}>
-                          {isAN && src.best_claim_id && (
-                            <div>
-                              <strong>Best match:</strong>{' '}
-                              <button onClick={() => setOverviewTab('argument-network')} style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--accent)', textDecoration: 'underline', fontFamily: 'inherit', fontSize: 'inherit' }}>{src.best_claim_id}</button>
-                              {src.best_claim_text && <> &ldquo;{truncateLabel(src.best_claim_text, 60)}&rdquo;</>}
-                              {src.best_claim_sim != null && <> (sim: {src.best_claim_sim.toFixed(2)})</>}
-                            </div>
-                          )}
-                          <div><strong>AN score:</strong> {src.an_score.toFixed(3)}</div>
-                          <div><strong>Topic floor:</strong> {(src.topic_score * 0.5).toFixed(3)} (raw: {src.topic_score.toFixed(3)} {'×'} 0.5)</div>
-                          <div><strong>Winner:</strong> {isAN ? 'AN score used' : 'Topic floor used — no AN match above floor'}</div>
-                        </div>
-                      </details>
-                    </td>
-                  </tr>
-                )}
-              </Fragment>
-            );
-          })}
+          {[...entry.taxonomy_refs!].sort((a, b) => (b.relevance_score ?? 0) - (a.relevance_score ?? 0)).map((r, i) => (
+            <TaxRefRow
+              key={i}
+              r={r}
+              hasSourceData={hasSourceData}
+              isSelected={selectedTaxRefId === r.node_id}
+              src={sourceMap.get(r.node_id)}
+              tw={nodeWeights.get(r.node_id)}
+              setSelectedTaxRefId={setSelectedTaxRefId}
+              setOverviewTab={setOverviewTab}
+            />
+          ))}
         </tbody>
       </table>
       {selectedTaxRefId && (() => {


### PR DESCRIPTION
Batch B3 of t/1909 (parent t/1848). Behavior-preserving ADR-007 decomposition of the 4 heaviest `window/entry-tabs/` files — every function → ≤15:

- `ClaimsTab.tsx` (62/19/16), `DetailsTab.tsx` (56/37/36/20/16), `DraftTab.tsx` (53/51/35/32/28/24/22/18/17/16), `TaxRefsTab.tsx` (46)

Each section extracted into props-only sub-components (guards moved inside as exact-negation early returns) + pure helpers; JSX/`style={{…}}`/`no-inline-style` moved verbatim. DraftTab unified two near-duplicate micro-fix blocks via a `showPrompt` prop, preserving the original top-level-shows-prompt / per-attempt-hides-prompt asymmetry (verified against original).

Verified: 0 complexity warnings/file, renderer-tsc 0/0, colocated tests green (ClaimsTab 8, DetailsTab 45, DraftTab 5, EntryDetailRouter 9 — 85 scoped total), eslint 719/0 overall, depcruise clean, vite build OK. `--max-warnings` gate untouched.