### PR TITLE
fix(server): type BACKEND_DISPLAY as Record<ApiKeyBackend> so omissions fail to compile (t/1959)

### DIFF
--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -54,9 +54,13 @@ function callerIdentity(): { principalName: string; idp: string } {
 }
 
 // t/896: user-facing provider names for the missing_api_key fast-fail message.
-const BACKEND_DISPLAY: Record<string, string> = {
+// t/1959: keyed off the ApiKeyBackend union (AIBackend re-export) so omitting a
+// backend is a COMPILE error, not a runtime fall-through to the raw backend id.
+// Labels mirror ai-models.json (the single source of truth for provider names).
+const BACKEND_DISPLAY: Record<AIBackend, string> = {
   gemini: 'Gemini', claude: 'Claude (Anthropic)', groq: 'Groq',
   openai: 'OpenAI', deepseek: 'DeepSeek', tavily: 'Tavily', ollama: 'Ollama',
+  azure: 'Azure OpenAI', zai: 'Z.AI (GLM)', moonshot: 'Moonshot (Kimi)',
 };
 
 export function registerAiRoutes(r: Router, _ctx: ServerCtx): void {


### PR DESCRIPTION
## t/1959 — smallest member of the stale-backend-list family

`BACKEND_DISPLAY` (the `missing_api_key` fast-fail's provider-name map in `routes/ai.ts`) was `Record<string, string>`, so a backend absent from the map silently fell through to the raw backend id in the user-facing error. It was missing `zai`, `moonshot`, and `azure`.

### Fix
Key it off the `ApiKeyBackend` union (via the already-imported `AIBackend` re-export) → **omitting a backend is now a compile error**, not a runtime fall-through. The type change surfaced the three gaps; added their real provider names mirrored from `ai-models.json` (the documented single source of truth): `Azure OpenAI`, `Z.AI (GLM)`, `Moonshot (Kimi)` — no placeholders.

Same drift class as the array-form fix t/1956; siblings t/1957 / t/1958.

### Verification
`tsc -p tsconfig.server.json` green; `accessControl.test.ts` (the `missingApiKey` consumer) 47/47. Low severity — cosmetic error-message improvement plus a type guard that prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)