### PR TITLE
refactor(server): complexity decomposition batch — httpKit/featureFlags/sources/support/migrate (t/1910)

### DIFF
--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -249,12 +249,10 @@ export function listFlags(): FlagDef[] {
   return Object.values(getConfig().flags);
 }
 
-/** Create or update a flag (admin). Persists + appends audit. Returns the def. */
-export function setFlag(name: string, patch: Partial<FlagDef>, by = '_local'): FlagDef {
-  const config = { flags: { ...getConfig().flags } };
-  const before = config.flags[name] ?? null;
-  const now = new Date().toISOString();
-  const def: FlagDef = {
+/** Merge a patch over the existing flag def (or defaults), producing the new def.
+ *  Field precedence: patch → existing → default; timestamps/creator preserved. */
+function mergeFlagDef(name: string, patch: Partial<FlagDef>, before: FlagDef | null, now: string, by: string): FlagDef {
+  return {
     name,
     enabled: patch.enabled ?? before?.enabled ?? false,
     scope: patch.scope ?? before?.scope ?? 'global',
@@ -264,6 +262,14 @@ export function setFlag(name: string, patch: Partial<FlagDef>, by = '_local'): F
     created_by: before?.created_by ?? by,
     expires_at: patch.expires_at !== undefined ? patch.expires_at : before?.expires_at,
   };
+}
+
+/** Create or update a flag (admin). Persists + appends audit. Returns the def. */
+export function setFlag(name: string, patch: Partial<FlagDef>, by = '_local'): FlagDef {
+  const config = { flags: { ...getConfig().flags } };
+  const before = config.flags[name] ?? null;
+  const now = new Date().toISOString();
+  const def = mergeFlagDef(name, patch, before, now, by);
   config.flags[name] = def;
   persist(config);
   appendAudit({ timestamp: now, action: 'set', flag: name, by, before, after: def });

--- a/taxonomy-editor/src/server/httpKit.ts
+++ b/taxonomy-editor/src/server/httpKit.ts
@@ -26,6 +26,31 @@ export function json(res: ServerResponse, data: unknown, status = 200): void {
   res.end(JSON.stringify(data));
 }
 
+// t/1379: record 4xx client errors to the flight recorder (warn — expected
+// client errors, not server faults) so a client-side 4xx can be correlated with
+// server state by requestId. Server-side dump only; never leaked to the client.
+function recordClientError(res: ServerResponse, route: string, status: number, message: string): void {
+  getGlobalRecorder()?.record({
+    type: 'lifecycle', component: 'server', level: 'warn',
+    message: `${route}: ${status} client error`,
+    data: {
+      method: (res as unknown as { req?: { method?: string } }).req?.method,
+      path: route, status, requestId: getRequestId(), errorMessage: message,
+    },
+  });
+}
+
+// Prod 5xx: record the real detail server-side (withheld from the client body).
+function recordServerError(route: string, status: number, message: string, cause: unknown): void {
+  getGlobalRecorder()?.record({
+    type: 'system.error',
+    component: route,
+    level: 'error',
+    message: `${route}: server error (detail withheld from client)`,
+    error: { name: (cause as Error)?.name ?? 'Error', message, stack: (cause as Error)?.stack },
+  });
+}
+
 export function error(res: ServerResponse, message: string, status = 500, cause?: unknown): void {
   // M4: don't leak internal detail (file paths, stack) to clients on server
   // errors in production — record the real message server-side, return generic.
@@ -43,27 +68,11 @@ export function error(res: ServerResponse, message: string, status = 500, cause?
   if (status >= 500) {
     log.server.error({ component: route, status, err: cause }, `${route}: server error (${status}) — ${message}`);
   }
-  // t/1379: record 4xx client errors to the flight recorder (warn — expected
-  // client errors, not server faults) so a client-side 4xx can be correlated with
-  // server state by requestId. Server-side dump only; never leaked to the client.
   if (status >= 400 && status < 500) {
-    getGlobalRecorder()?.record({
-      type: 'lifecycle', component: 'server', level: 'warn',
-      message: `${route}: ${status} client error`,
-      data: {
-        method: (res as unknown as { req?: { method?: string } }).req?.method,
-        path: route, status, requestId: getRequestId(), errorMessage: message,
-      },
-    });
+    recordClientError(res, route, status, message);
   }
   if (status >= 500 && process.env.NODE_ENV === 'production') {
-    getGlobalRecorder()?.record({
-      type: 'system.error',
-      component: route,
-      level: 'error',
-      message: `${route}: server error (detail withheld from client)`,
-      error: { name: (cause as Error)?.name ?? 'Error', message, stack: (cause as Error)?.stack },
-    });
+    recordServerError(route, status, message, cause);
     json(res, { error: 'Internal server error', requestId: getRequestId() }, status);
     return;
   }

--- a/taxonomy-editor/src/server/routes/sources.ts
+++ b/taxonomy-editor/src/server/routes/sources.ts
@@ -53,39 +53,52 @@ function loadEvidenceIndex(): SourceEvidenceIndex | null {
 
 type DocMetaMap = import('../../../../lib/debate/evidenceFromSummaries.js').DocMetaMap;
 let _docTitles: DocMetaMap | null | undefined;
+
+/** Walk up from this module to find .aitriad.json and resolve its sources_root, or null. */
+function resolveSourcesRootFromConfig(): string | null {
+  let searchDir = path.resolve(__dirname, '..', '..', '..', '..');
+  let aitriadPath = '';
+  for (let i = 0; i < 5; i++) {
+    const candidate = path.join(searchDir, '.aitriad.json');
+    if (fs.existsSync(candidate)) { aitriadPath = candidate; break; }
+    searchDir = path.dirname(searchDir);
+  }
+  if (!aitriadPath) return null;
+  const aitriadConfig = JSON.parse(fs.readFileSync(aitriadPath, 'utf-8'));
+  const sourcesRoot = aitriadConfig.sources_root
+    ? path.resolve(path.dirname(aitriadPath), aitriadConfig.sources_root)
+    : null;
+  if (!sourcesRoot || !fs.existsSync(sourcesRoot)) return null;
+  return sourcesRoot;
+}
+
+/** Read per-source metadata.json titles/urls under sourcesRoot into a DocMetaMap. */
+function readDocMetaMap(sourcesRoot: string): DocMetaMap {
+  const metaMap: DocMetaMap = {};
+  for (const entry of fs.readdirSync(sourcesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const metaPath = path.join(sourcesRoot, entry.name, 'metadata.json');
+    if (!fs.existsSync(metaPath)) continue;
+    try {
+      const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+      if (meta.title) {
+        const docMeta: { title: string; resolved_url?: string; provenance_label?: string } = { title: meta.title };
+        if (meta.resolved_url) docMeta.resolved_url = meta.resolved_url;
+        if (meta.provenance?.length > 0 && meta.provenance[0].id) docMeta.provenance_label = meta.provenance[0].id;
+        if (!docMeta.resolved_url && meta.url) docMeta.resolved_url = meta.url;
+        metaMap[entry.name] = docMeta;
+      }
+    } catch { /* telemetry — silent by design;  skip */ }
+  }
+  return metaMap;
+}
+
 function loadDocTitles(): DocMetaMap | null {
   if (_docTitles !== undefined) return _docTitles;
   try {
-    // Resolve sources root from .aitriad.json (project root)
-    let searchDir = path.resolve(__dirname, '..', '..', '..', '..');
-    let aitriadPath = '';
-    for (let i = 0; i < 5; i++) {
-      const candidate = path.join(searchDir, '.aitriad.json');
-      if (fs.existsSync(candidate)) { aitriadPath = candidate; break; }
-      searchDir = path.dirname(searchDir);
-    }
-    if (!aitriadPath) { _docTitles = null; return null; }
-    const aitriadConfig = JSON.parse(fs.readFileSync(aitriadPath, 'utf-8'));
-    const sourcesRoot = aitriadConfig.sources_root
-      ? path.resolve(path.dirname(aitriadPath), aitriadConfig.sources_root)
-      : null;
-    if (!sourcesRoot || !fs.existsSync(sourcesRoot)) { _docTitles = null; return null; }
-    const metaMap: DocMetaMap = {};
-    for (const entry of fs.readdirSync(sourcesRoot, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      const metaPath = path.join(sourcesRoot, entry.name, 'metadata.json');
-      if (!fs.existsSync(metaPath)) continue;
-      try {
-        const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-        if (meta.title) {
-          const docMeta: { title: string; resolved_url?: string; provenance_label?: string } = { title: meta.title };
-          if (meta.resolved_url) docMeta.resolved_url = meta.resolved_url;
-          if (meta.provenance?.length > 0 && meta.provenance[0].id) docMeta.provenance_label = meta.provenance[0].id;
-          if (!docMeta.resolved_url && meta.url) docMeta.resolved_url = meta.url;
-          metaMap[entry.name] = docMeta;
-        }
-      } catch { /* telemetry — silent by design;  skip */ }
-    }
+    const sourcesRoot = resolveSourcesRootFromConfig();
+    if (!sourcesRoot) { _docTitles = null; return null; }
+    const metaMap = readDocMetaMap(sourcesRoot);
     _docTitles = Object.keys(metaMap).length > 0 ? metaMap : null;
     return _docTitles;
   } catch { /* telemetry — silent by design */ _docTitles = null; return null; }

--- a/taxonomy-editor/src/server/routes/support.ts
+++ b/taxonomy-editor/src/server/routes/support.ts
@@ -33,6 +33,34 @@ function callerIdentity(): { principalName: string; idp: string } {
   return callerTierIdentity(getCurrentUser());
 }
 
+type ParsedSupportCase =
+  | { ok: true; subject: string; description: string; systemInfo: { appVersion: string; browser: string; os: string; deploymentMode: 'web' | 'electron' }; priority: 'low' | 'medium' | 'high' }
+  | { ok: false; error: string; status: number };
+
+/** Clamp the client-supplied systemInfo to known, length-bounded fields. */
+function boundSystemInfo(raw: unknown): { appVersion: string; browser: string; os: string; deploymentMode: 'web' | 'electron' } {
+  const si = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {};
+  return {
+    appVersion: String(si.appVersion ?? 'unknown').slice(0, 100),
+    browser: String(si.browser ?? 'unknown').slice(0, 200),
+    os: String(si.os ?? 'unknown').slice(0, 100),
+    deploymentMode: (si.deploymentMode === 'electron' ? 'electron' : 'web') as 'web' | 'electron',
+  };
+}
+
+/** Validate + normalize the create-case body: trims/length-caps subject & description,
+ *  clamps priority, and bounds the systemInfo fields. Returns a typed error on invalid input. */
+function parseSupportCaseBody(body: unknown): ParsedSupportCase {
+  const b = (body ?? {}) as { subject?: unknown; description?: unknown; systemInfo?: unknown; priority?: unknown };
+  const subject = typeof b.subject === 'string' ? b.subject.trim() : '';
+  const description = typeof b.description === 'string' ? b.description.trim() : '';
+  if (!subject || subject.length > 200) return { ok: false, error: 'subject is required (≤200 chars)', status: 400 };
+  if (!description || description.length > 10_000) return { ok: false, error: 'description is required (≤10000 chars)', status: 400 };
+  const priority = (b.priority === 'low' || b.priority === 'high') ? b.priority : 'medium';
+  const systemInfo = boundSystemInfo(b.systemInfo);
+  return { ok: true, subject, description, systemInfo, priority };
+}
+
 export function registerSupportRoutes(r: Router, _ctx: ServerCtx): void {
   const { get, post } = r;
 
@@ -59,22 +87,13 @@ export function registerSupportRoutes(r: Router, _ctx: ServerCtx): void {
   post('/api/support/cases', async (_req, res, body) => {
     if (isAnonymousUser()) { error(res, 'Sign in to file a support case', 401); return; }
     try {
-      const b = (body ?? {}) as { subject?: unknown; description?: unknown; systemInfo?: unknown; priority?: unknown };
-      const subject = typeof b.subject === 'string' ? b.subject.trim() : '';
-      const description = typeof b.description === 'string' ? b.description.trim() : '';
-      if (!subject || subject.length > 200) { error(res, 'subject is required (≤200 chars)', 400); return; }
-      if (!description || description.length > 10_000) { error(res, 'description is required (≤10000 chars)', 400); return; }
-      const priority = (b.priority === 'low' || b.priority === 'high') ? b.priority : 'medium';
-      const si = (b.systemInfo && typeof b.systemInfo === 'object') ? b.systemInfo as Record<string, unknown> : {};
-      const systemInfo = {
-        appVersion: String(si.appVersion ?? 'unknown').slice(0, 100),
-        browser: String(si.browser ?? 'unknown').slice(0, 200),
-        os: String(si.os ?? 'unknown').slice(0, 100),
-        deploymentMode: (si.deploymentMode === 'electron' ? 'electron' : 'web') as 'web' | 'electron',
-      };
+      const parsed = parseSupportCaseBody(body);
+      if (!parsed.ok) { error(res, parsed.error, parsed.status); return; }
       const userId = getStorageUserId();
       const { principalName } = callerIdentity();
-      const c = await supportStore.createCase(userId, principalName || userId, { subject, description, systemInfo, priority });
+      const c = await supportStore.createCase(userId, principalName || userId, {
+        subject: parsed.subject, description: parsed.description, systemInfo: parsed.systemInfo, priority: parsed.priority,
+      });
       json(res, { id: c.id, case: c });
     } catch (err) { getGlobalRecorder()?.record({ type: 'system.error', component: 'support', level: 'error', message: 'support: create case failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); error(res, String(err), 500, err); }
   });

--- a/taxonomy-editor/src/server/scripts/migrateUserContentToBlob.ts
+++ b/taxonomy-editor/src/server/scripts/migrateUserContentToBlob.ts
@@ -82,6 +82,58 @@ export async function collectUserContentPaths(source: StorageBackend): Promise<s
  * each with a read-back SHA compare. Per-file failures are recorded and do not
  * abort the run. Returns a summary report.
  */
+/**
+ * Migrate one user-content file, folding the result (or a recorded failure) into
+ * `summary`. Never throws — per-file errors are captured so the run continues.
+ * Mirrors the original loop body (the `continue`s become early `return`s).
+ */
+async function migrateOneFile(
+  source: StorageBackend,
+  dest: StorageBackend,
+  p: string,
+  summary: MigrationSummary,
+  opts: { verify: boolean; dryRun: boolean; log: (m: string) => void },
+): Promise<void> {
+  const { verify, dryRun, log } = opts;
+  try {
+    const content = await source.readFile(p);
+    if (content === null) { summary.failures.push({ path: p, error: 'source returned null' }); return; }
+
+    // Dry run: confirm the source is readable + sized, but write nothing.
+    if (dryRun) {
+      summary.filesMigrated++; // would-migrate count
+      summary.bytesTransferred += Buffer.byteLength(content, 'utf-8');
+      return;
+    }
+
+    await dest.writeFile(p, content);
+    summary.filesMigrated++;
+    summary.bytesTransferred += Buffer.byteLength(content, 'utf-8');
+
+    if (verify) {
+      const readBack = await dest.readFile(p);
+      if (readBack === null || sha256(readBack) !== sha256(content)) {
+        summary.verifyFailures.push({ path: p, error: 'SHA mismatch or missing after write' });
+      } else {
+        summary.verified++;
+      }
+    }
+
+    if (summary.filesMigrated % 50 === 0) log(`  …${summary.filesMigrated} migrated`);
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'migration',
+      level: 'warn',
+      message: 'Failed to migrate user-content file — continuing',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    const error = (err as Error)?.message ?? String(err);
+    summary.failures.push({ path: p, error });
+    log(`  ! failed: ${p} — ${error}`);
+  }
+}
+
 export async function migrateUserContent(
   source: StorageBackend,
   dest: StorageBackend,
@@ -97,45 +149,7 @@ export async function migrateUserContent(
   const paths = await collectUserContentPaths(source);
   log(`${dryRun ? '[DRY RUN] ' : ''}Found ${paths.length} user-content files to migrate.`);
 
-  for (const p of paths) {
-    try {
-      const content = await source.readFile(p);
-      if (content === null) { summary.failures.push({ path: p, error: 'source returned null' }); continue; }
-
-      // Dry run: confirm the source is readable + sized, but write nothing.
-      if (dryRun) {
-        summary.filesMigrated++; // would-migrate count
-        summary.bytesTransferred += Buffer.byteLength(content, 'utf-8');
-        continue;
-      }
-
-      await dest.writeFile(p, content);
-      summary.filesMigrated++;
-      summary.bytesTransferred += Buffer.byteLength(content, 'utf-8');
-
-      if (verify) {
-        const readBack = await dest.readFile(p);
-        if (readBack === null || sha256(readBack) !== sha256(content)) {
-          summary.verifyFailures.push({ path: p, error: 'SHA mismatch or missing after write' });
-        } else {
-          summary.verified++;
-        }
-      }
-
-      if (summary.filesMigrated % 50 === 0) log(`  …${summary.filesMigrated} migrated`);
-    } catch (err) {
-      getGlobalRecorder()?.record({
-        type: 'system.error',
-        component: 'migration',
-        level: 'warn',
-        message: 'Failed to migrate user-content file — continuing',
-        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-      });
-      const error = (err as Error)?.message ?? String(err);
-      summary.failures.push({ path: p, error });
-      log(`  ! failed: ${p} — ${error}`);
-    }
-  }
+  for (const p of paths) await migrateOneFile(source, dest, p, summary, { verify, dryRun, log });
 
   log(
     `${dryRun ? '[DRY RUN] would migrate' : 'Migration complete:'} ${summary.filesMigrated} files, ` +


### PR DESCRIPTION
## t/1910 core-layer slice — batch 1 (3 commits, behavior-preserving ADR-007 decomposition)

Parent **t/1848** debt reduction. Decomposes over-threshold (cx > 15) functions in the ServerAPI core layer via verbatim block-extraction into named module-level helpers — control flow, early returns, `ActionableError` sites, and every `catch` error-recording site preserved exactly.

| commit | file | function(s) before → after |
|---|---|---|
| 4a243730 | `httpKit.ts` / `featureFlags.ts` | `error`@16, `setFlag`@17 → under threshold |
| 578b34c7 | `routes/sources.ts` / `scripts/migrateUserContentToBlob.ts` | `loadDocTitles`@21, `migrateUserContent`@19 → under threshold |
| 03e3f1aa | `routes/support.ts` | create-case handler `(anon)`@21 → under threshold |

### Verification (rebased on fresh origin/main; no file overlap with the 9 intervening commits)
- `tsc -p tsconfig.main.json` 0 errors, `tsc -p tsconfig.server.json` 0 errors
- `eslint` on all 5 touched files: **0 errors, 0 warnings** (complexity warnings on these functions eliminated)
- Full scoped server suite: **790/790 passed** (75 files)
- **`--max-warnings` gate NOT ratcheted** (per parent t/1848 epic guidance)

Remaining core-layer targets (server.ts `handleRequestInner`@83 etc.) follow in later batches; sub-role slices tracked in t/1921–t/1924.

🤖 Generated with [Claude Code](https://claude.com/claude-code)