### PR TITLE
feat(lib/entities): shared entity-resolution helpers (t/1974)

### DIFF
--- a/lib/entities/entityResolve.test.ts
+++ b/lib/entities/entityResolve.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { coerceStringArray, normalizeEntity, resolveMergedInto } from './entityResolve.js';
+import { ActionableError } from '../debate/errors.js';
+import type { Entity } from './types.js';
+
+// Minimal valid Entity; override any field per-test. The polymorphic-shape tests
+// deliberately cast malformed real-world values (null / bare string) into the
+// string[]-typed fields — that is exactly the on-disk drift coerceStringArray guards.
+function mkEntity(id: string, over: Partial<Entity> = {}): Entity {
+  return {
+    id,
+    name: id,
+    aliases: [],
+    entity_type: 'artifact',
+    dolce_category: 'non-agentive-functional-artifact',
+    description: `A thing named ${id}.`,
+    status: 'approved',
+    created_at: '2026-01-01T00:00:00Z',
+    last_modified: '2026-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+/** Build a sync lookup over a set of entities, mirroring the registry.get seam. */
+function lookupFrom(...entities: Entity[]): (id: string) => Entity | null {
+  const map = new Map(entities.map((e) => [e.id, e]));
+  return (id: string) => map.get(id) ?? null;
+}
+
+describe('coerceStringArray', () => {
+  it('returns arrays unchanged (same reference)', () => {
+    const arr = ['a', 'b'];
+    expect(coerceStringArray(arr)).toBe(arr);
+    expect(coerceStringArray([])).toEqual([]);
+  });
+
+  it('maps null / undefined to an empty array', () => {
+    expect(coerceStringArray(null)).toEqual([]);
+    expect(coerceStringArray(undefined)).toEqual([]);
+  });
+
+  it('wraps a bare string as a single element (not an array of characters)', () => {
+    expect(coerceStringArray('GDPR')).toEqual(['GDPR']);
+    // guards the concrete bug: field[0] on a bare string is its first CHARACTER
+    expect(coerceStringArray('GDPR')[0]).toBe('GDPR');
+  });
+});
+
+describe('normalizeEntity', () => {
+  it('coerces both polymorphic fields and preserves every other field', () => {
+    const e = mkEntity('ent-1', {
+      name: 'OpenAI',
+      aliases: null as unknown as string[], // real data: 32 entities have null aliases
+      source_refs: 'doc-7' as unknown as string[], // real data: bare-string source_refs
+      confidence: 0.9,
+    });
+    const n = normalizeEntity(e);
+    expect(n.aliases).toEqual([]);
+    expect(n.source_refs).toEqual(['doc-7']);
+    // untouched fields survive
+    expect(n.name).toBe('OpenAI');
+    expect(n.confidence).toBe(0.9);
+    expect(n.id).toBe('ent-1');
+    expect(n.entity_type).toBe('artifact');
+  });
+
+  it('leaves already-valid arrays intact', () => {
+    const e = mkEntity('ent-2', { aliases: ['OAI', 'OpenAI Inc'], source_refs: ['doc-1'] });
+    const n = normalizeEntity(e);
+    expect(n.aliases).toEqual(['OAI', 'OpenAI Inc']);
+    expect(n.source_refs).toEqual(['doc-1']);
+  });
+
+  it('does not mutate the input record', () => {
+    const e = mkEntity('ent-3', { aliases: null as unknown as string[] });
+    normalizeEntity(e);
+    expect(e.aliases).toBeNull();
+  });
+});
+
+describe('resolveMergedInto', () => {
+  it('returns the record with no redirectedFrom when there is no tombstone', () => {
+    const a = mkEntity('ent-a');
+    const res = resolveMergedInto('ent-a', lookupFrom(a), { maxDepth: 5 });
+    expect(res).toEqual({ record: a, redirectedFrom: undefined });
+  });
+
+  it('follows a single hop and reports the original id as redirectedFrom', () => {
+    const a = mkEntity('ent-a', { merged_into: 'ent-b' });
+    const b = mkEntity('ent-b');
+    const res = resolveMergedInto('ent-a', lookupFrom(a, b), { maxDepth: 5 });
+    expect(res).toEqual({ record: b, redirectedFrom: 'ent-a' });
+  });
+
+  it('follows a multi-hop chain to the terminal record', () => {
+    const a = mkEntity('ent-a', { merged_into: 'ent-b' });
+    const b = mkEntity('ent-b', { merged_into: 'ent-c' });
+    const c = mkEntity('ent-c');
+    const res = resolveMergedInto('ent-a', lookupFrom(a, b, c), { maxDepth: 5 });
+    expect(res?.record.id).toBe('ent-c');
+    expect(res?.redirectedFrom).toBe('ent-a'); // the ORIGINAL id, not the last hop
+  });
+
+  it('returns null when the start id is absent', () => {
+    expect(resolveMergedInto('ent-missing', lookupFrom(), { maxDepth: 5 })).toBeNull();
+  });
+
+  it('returns null when a hop points at a missing id', () => {
+    const a = mkEntity('ent-a', { merged_into: 'ent-gone' });
+    expect(resolveMergedInto('ent-a', lookupFrom(a), { maxDepth: 5 })).toBeNull();
+  });
+
+  it('throws ActionableError on a two-node cycle (A→B→A)', () => {
+    const a = mkEntity('ent-a', { merged_into: 'ent-b' });
+    const b = mkEntity('ent-b', { merged_into: 'ent-a' });
+    expect(() => resolveMergedInto('ent-a', lookupFrom(a, b), { maxDepth: 10 }))
+      .toThrow(ActionableError);
+    expect(() => resolveMergedInto('ent-a', lookupFrom(a, b), { maxDepth: 10 }))
+      .toThrow(/cycle/i);
+  });
+
+  it('throws ActionableError on a self-cycle (A→A)', () => {
+    const a = mkEntity('ent-a', { merged_into: 'ent-a' });
+    expect(() => resolveMergedInto('ent-a', lookupFrom(a), { maxDepth: 10 }))
+      .toThrow(/cycle/i);
+  });
+
+  it('throws ActionableError when the chain exceeds maxDepth', () => {
+    const a = mkEntity('ent-a', { merged_into: 'ent-b' });
+    const b = mkEntity('ent-b', { merged_into: 'ent-c' });
+    const c = mkEntity('ent-c'); // terminal, but too far for maxDepth:1
+    expect(() => resolveMergedInto('ent-a', lookupFrom(a, b, c), { maxDepth: 1 }))
+      .toThrow(/depth cap/i);
+  });
+
+  it('resolves a chain that ends exactly at the depth cap', () => {
+    // maxDepth:2 permits processing A, B, C (3 nodes) — the 2-hop chain terminates in time.
+    const a = mkEntity('ent-a', { merged_into: 'ent-b' });
+    const b = mkEntity('ent-b', { merged_into: 'ent-c' });
+    const c = mkEntity('ent-c');
+    const res = resolveMergedInto('ent-a', lookupFrom(a, b, c), { maxDepth: 2 });
+    expect(res?.record.id).toBe('ent-c');
+  });
+});

--- a/lib/entities/entityResolve.ts
+++ b/lib/entities/entityResolve.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Cross-transport entity-resolution helpers (t/1974). Factored out of
+// server/routes/entity.ts so the server route, the desktop IPC handler
+// (main/ipc/entityHandlers.ts), and the renderer share ONE copy of the
+// merge-tombstone follow + polymorphic-field coercion instead of hand-synced
+// mirrors (TL flag t/1898#12; ServerAPI p/78#24). Pure — depends only on
+// ActionableError and the Entity type, with no transport coupling. The DI seam
+// (resolveMergedInto takes an injected sync `lookup`) lets both the async server
+// registry and the sync desktop file read reuse the same resolver.
+
+import { ActionableError } from '../debate/errors.js';
+import type { Entity } from './types.js';
+
+/**
+ * Coerce a polymorphic string-array field to a real `string[]` at the read boundary.
+ * entities.json stores `aliases` and `source_refs` in THREE shapes (t/1964 / Design
+ * field audit t/1882#7): array | null | bare string — e.g. aliases `["OAI"]` | `null` |
+ * `"GDPR"`, source_refs `["doc-1"]` | `"doc-1"`. A null crashes `.some`/`.length`; a bare
+ * string crashes `.map`/`.join` and renders its first character on `[0]`. Normalize here
+ * so no downstream consumer (server route, desktop IPC, renderer) ever sees either.
+ * array→as-is · null/undefined→[] · string→single-element.
+ */
+export function coerceStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? (v as string[]) : v == null ? [] : [v as string];
+}
+
+/**
+ * Normalize an Entity's polymorphic string-array fields (`aliases`, `source_refs`) at
+ * the read boundary. The genus audit (t/1964#3, Design t/1882#7) bounds the coercion set
+ * to exactly these two fields — every other UI-rendered field is single-shape.
+ */
+export function normalizeEntity(e: Entity): Entity {
+  return { ...e, aliases: coerceStringArray(e.aliases), source_refs: coerceStringArray(e.source_refs) };
+}
+
+export interface MergedIntoResult {
+  /** The terminal (non-tombstone) record the chain resolves to. */
+  record: Entity;
+  /** The originally-requested id, set only when ≥1 merge pointer was followed. */
+  redirectedFrom?: string;
+}
+
+/**
+ * Follow an Entity's single canonical `merged_into` tombstone pointer (Section 7)
+ * to the terminal record, recording the original id as `redirectedFrom` once any
+ * hop is taken. Returns null if any id in the chain is absent. Throws
+ * {@link ActionableError} on a cycle or when the chain exceeds `maxDepth` — both
+ * indicate corrupt merge data, not a deep-but-valid graph. Organizations have NO
+ * merged_into, so this is entity-only.
+ */
+export function resolveMergedInto(
+  id: string,
+  lookup: (id: string) => Entity | null | undefined,
+  opts: { maxDepth: number },
+): MergedIntoResult | null {
+  const seen = new Set<string>();
+  let currentId = id;
+  let redirectedFrom: string | undefined;
+
+  for (let depth = 0; depth <= opts.maxDepth; depth++) {
+    if (seen.has(currentId)) {
+      throw new ActionableError({
+        goal: 'Resolve a merged entity to its canonical record',
+        problem: `merged_into chain forms a cycle at "${currentId}" (started from "${id}")`,
+        location: 'lib/entities/entityResolve.ts → resolveMergedInto',
+        nextSteps: [
+          'Inspect entities.json for a merged_into loop (A→B→A) starting at this id',
+          'Break the cycle so exactly one record in the chain has no merged_into',
+        ],
+      });
+    }
+    seen.add(currentId);
+
+    const rec = lookup(currentId);
+    if (!rec) return null; // a hop points at a missing id → unresolved
+    if (!rec.merged_into) return { record: rec, redirectedFrom };
+
+    redirectedFrom = redirectedFrom ?? id; // first hop: remember where we started
+    currentId = rec.merged_into;
+  }
+
+  throw new ActionableError({
+    goal: 'Resolve a merged entity to its canonical record',
+    problem: `merged_into chain from "${id}" exceeded the depth cap (${opts.maxDepth})`,
+    location: 'lib/entities/entityResolve.ts → resolveMergedInto',
+    nextSteps: [
+      'Verify the merge graph is a short chain, not a deep or unbounded one',
+      `If a legitimately long chain exists, raise MAX_MERGE_DEPTH (currently ${opts.maxDepth})`,
+    ],
+  });
+}


### PR DESCRIPTION
Shared-module deliverable for **t/1974** (TL self-cert approved, t/1974#2). Factors the pure merge-follow + polymorphic-field coercion out of `server/routes/entity.ts` into `lib/entities/entityResolve.ts` so the server route, desktop IPC handler, and renderer share ONE copy instead of hand-synced mirrors (TL flag t/1898#12; ServerAPI p/78#24).

## Contents
- `lib/entities/entityResolve.ts` — `resolveMergedInto` (+ `MergedIntoResult`), `normalizeEntity`, `coerceStringArray`. Byte-identical to the server logic; only the `ActionableError` `location` strings become transport-neutral. `resolveMergedInto` keeps its injected sync `lookup` seam, so async (server registry) and sync (desktop file read) callers reuse it unchanged.
- `lib/entities/entityResolve.test.ts` — 15 cases: cycle / self-cycle / depth-cap throw, absent-hop & absent-start → null, no-tombstone / single-hop / multi-hop redirect, depth-cap boundary, plus `coerceStringArray`/`normalizeEntity` shape coverage (array/null/undefined/bare-string, field preservation, no input mutation).

## Verification
vitest **15/15**; module type-checks clean (the only tsc output is pre-existing node-globals noise in unrelated files + a standalone vitest-resolution artifact — zero errors reference `entityResolve.ts`). Picked up by `npm run verify` via the `lib/entities/**/*.test.ts` vitest include.

## Scope note
Shared module **only**. Consumer switches are t/1974's adoption step, owned by others: ServerAPI + ElectronMain drop their copies; the renderer `coerceStringArray` folds in (diffed — semantically equivalent, TL t/1974#2). Not sequenced ahead of #161 per TL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)