### PR TITLE
fix(smoke): scope Test-GitHubHealth workflow-runs query to branch=main (t/1975)

### DIFF
--- a/scripts/AITriad/Public/Test-GitHubHealth.ps1
+++ b/scripts/AITriad/Public/Test-GitHubHealth.ps1
@@ -13,6 +13,10 @@ function Test-GitHubHealth {
         GitHub repo in owner/name format. Default: jpsnover/ai-triad-research.
     .PARAMETER TimeoutSec
         HTTP request timeout in seconds. Default: 10.
+    .PARAMETER Branch
+        Branch to scope the workflow-runs status check to. Default: main (the
+        deployed line) — so a red PR/branch run does not false-FAIL the CI-health
+        category in a prod smoke (t/1975).
     .EXAMPLE
         Test-GitHubHealth
     .EXAMPLE
@@ -29,7 +33,10 @@ function Test-GitHubHealth {
 
         [Parameter()]
         [ValidateRange(1, 120)]
-        [int]$TimeoutSec = 10
+        [int]$TimeoutSec = 10,
+
+        [Parameter()]
+        [string]$Branch = 'main'
     )
 
     Set-StrictMode -Version Latest
@@ -119,10 +126,15 @@ function Test-GitHubHealth {
     # ── Latest Workflow Runs ─────────────────────────────────────────────
     $KeyWorkflows = @('ci.yml', 'deploy-azure.yml', 'health-monitor.yml')
 
+    # t/1975 — scope the workflow-runs query to the deployed line (default: main)
+    # so a red PR/branch run doesn't false-FAIL the CI-health category in a prod
+    # smoke. GitHub filters by head_branch via the `branch` param; escape guards
+    # branch names containing '/'.
+    $BranchQ = [uri]::EscapeDataString($Branch)
     foreach ($Wf in $KeyWorkflows) {
         try {
             $RunsResp = Invoke-RestMethod `
-                -Uri "https://api.github.com/repos/$Repo/actions/workflows/$Wf/runs?per_page=1&status=completed" `
+                -Uri "https://api.github.com/repos/$Repo/actions/workflows/$Wf/runs?per_page=1&status=completed&branch=$BranchQ" `
                 -Headers $Headers -TimeoutSec $TimeoutSec -ErrorAction Stop
 
             if ($RunsResp.total_count -gt 0) {
@@ -131,7 +143,7 @@ function Test-GitHubHealth {
                 $RunDate = ([datetime]$Run.updated_at).ToString('yyyy-MM-dd HH:mm')
 
                 $Checks.Add([PSCustomObject]@{
-                    Check      = "Workflow: $Wf"
+                    Check      = "Workflow: $Wf @$Branch"
                     Pass       = $Conclusion -eq 'success'
                     ResponseMs = 0
                     Detail     = "conclusion=$Conclusion | $RunDate | #$($Run.run_number)"
@@ -139,7 +151,7 @@ function Test-GitHubHealth {
             }
             else {
                 $Checks.Add([PSCustomObject]@{
-                    Check      = "Workflow: $Wf"
+                    Check      = "Workflow: $Wf @$Branch"
                     Pass       = $true
                     ResponseMs = 0
                     Detail     = 'No completed runs found'
@@ -152,7 +164,7 @@ function Test-GitHubHealth {
                 $StatusCode = [int]$_.Exception.Response.StatusCode
             }
             $Checks.Add([PSCustomObject]@{
-                Check      = "Workflow: $Wf"
+                Check      = "Workflow: $Wf @$Branch"
                 Pass       = $false
                 ResponseMs = 0
                 Detail     = if ($StatusCode -eq 404) { 'Workflow not found' }

--- a/tests/Test-GitHubHealth.BranchScope.Tests.ps1
+++ b/tests/Test-GitHubHealth.BranchScope.Tests.ps1
@@ -1,0 +1,83 @@
+# Tag: health (t/1975)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Branch-scoping of Test-GitHubHealth's CI-workflow-status check (t/1975).
+.DESCRIPTION
+    The "Latest Workflow Runs" check queried ci.yml runs with NO branch filter, so
+    a red PR/branch run (normal during PR work) false-FAILed the GitHub health
+    category in a prod smoke (e/44#32). The fix scopes the workflow-runs query to
+    -Branch (default main), relying on the GitHub API's `branch` (head_branch)
+    filter to exclude PR runs. These tests mock Invoke-RestMethod (simulating that
+    server-side filter) to assert (a) the query carries branch=main, (b) a red
+    non-main run does not flip the check, and (c) the escape guard handles a
+    '/'-containing branch. Keyless, always runs.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-GitHubHealth branch scoping (t/1975)' -Tag 'health' {
+
+    It 'scopes the workflow-runs query to main and does not false-fail on a red non-main run' {
+        InModuleScope AITriad {
+            $script:WfUris = @()
+            Mock Invoke-RestMethod -MockWith {
+                if ($Uri -like '*githubstatus.com*') {
+                    return [PSCustomObject]@{ status = [PSCustomObject]@{ indicator = 'none'; description = 'All Systems Operational' } }
+                }
+                if ($Uri -like '*/actions/workflows/*') {
+                    $script:WfUris += $Uri
+                    # Simulate the GitHub API head_branch filter: only main runs come
+                    # back when branch=main; an UNSCOPED query would surface a red PR run.
+                    if ($Uri -like '*branch=main*') {
+                        return [PSCustomObject]@{ total_count = 1; workflow_runs = @([PSCustomObject]@{ conclusion = 'success'; updated_at = '2026-07-29T12:00:00Z'; run_number = 100 }) }
+                    }
+                    return [PSCustomObject]@{ total_count = 1; workflow_runs = @([PSCustomObject]@{ conclusion = 'failure'; updated_at = '2026-07-29T11:00:00Z'; run_number = 99 }) }
+                }
+                if ($Uri -like '*/rate_limit*') {
+                    return [PSCustomObject]@{ resources = [PSCustomObject]@{ core = [PSCustomObject]@{ remaining = 5000; limit = 5000; reset = 9999999999 } } }
+                }
+                return [PSCustomObject]@{ visibility = 'public'; default_branch = 'main' }  # repo endpoint
+            }
+
+            $result = Test-GitHubHealth 6>$null
+
+            @($script:WfUris).Count | Should -Be 3 -Because 'all three key workflows are queried'
+            foreach ($u in $script:WfUris) { $u | Should -Match 'branch=main' -Because 'the query must be scoped to the deployed line' }
+
+            $wfChecks = @($result.Checks | Where-Object { $_.Check -like 'Workflow:*' })
+            @($wfChecks).Count | Should -Be 3
+            @($wfChecks | Where-Object { -not $_.Pass }).Count | Should -Be 0 -Because 'branch=main returns only the green main run; the red non-main run is filtered out (the t/1975 fix)'
+            $wfChecks[0].Check | Should -Match '@main' -Because 'the scoping is visible in the check label'
+        }
+    }
+
+    It 'escapes a branch name containing "/" in the query (release/v2 -> release%2Fv2)' {
+        InModuleScope AITriad {
+            $script:WfUris2 = @()
+            Mock Invoke-RestMethod -MockWith {
+                if ($Uri -like '*githubstatus.com*') { return [PSCustomObject]@{ status = [PSCustomObject]@{ indicator = 'none'; description = 'ok' } } }
+                if ($Uri -like '*/actions/workflows/*') {
+                    $script:WfUris2 += $Uri
+                    return [PSCustomObject]@{ total_count = 0; workflow_runs = @() }
+                }
+                if ($Uri -like '*/rate_limit*') { return [PSCustomObject]@{ resources = [PSCustomObject]@{ core = [PSCustomObject]@{ remaining = 5000; limit = 5000; reset = 9999999999 } } } }
+                return [PSCustomObject]@{ visibility = 'public'; default_branch = 'main' }
+            }
+
+            $null = Test-GitHubHealth -Branch 'release/v2' 6>$null
+
+            foreach ($u in $script:WfUris2) {
+                $u | Should -Match 'branch=release%2Fv2' -Because 'EscapeDataString must encode the / so the query param is well-formed'
+                $u | Should -Not -Match 'branch=release/v2'
+            }
+        }
+    }
+}


### PR DESCRIPTION
`Test-GitHubHealth`'s "Latest Workflow Runs" check queried ci.yml runs with **no branch filter**, so a red `[DO NOT MERGE]` PR/branch run false-FAILed the GitHub health category in the gemini prod smoke (e/44#32) even though the deploy line was green.

## Fix
Add `-Branch` (default `main`) + append `&branch=$([uri]::EscapeDataString($Branch))` to the workflow-runs query. GitHub filters by head_branch → PR runs excluded → the prod-smoke CI-health signal reflects the deployed line. Label now shows `Workflow: <wf> @<branch>`. Edge case unchanged (0 runs → "No completed runs found" → Pass=true).

## Test
`tests/Test-GitHubHealth.BranchScope.Tests.ps1` (`-Tag health`, keyless): mocks `Invoke-RestMethod` (simulating the API head_branch filter) — asserts `branch=main` in the query, a red non-main run doesn't flip the check, and `/`-escaping (`release/v2`→`release%2Fv2`). **2/2**; `health` regression **244/0**; manifest OK.

Self-cert `/trivial-change` (optional param, safe default, no new public API). Diagnosis + fix spec by DevOps (t/1975#1); DevOps confirms diagnostic behavior post-land.

Closes t/1975.