### PR TITLE
style(chat): remove duplicated .ref-link rules from ChatWorkspace.css (t/1967)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.css
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.css
@@ -182,26 +182,3 @@
   width: 100%;
   border-left: 1px solid var(--border-color);
 }
-
-/* ── Inline ID-ref links (t/1777) ─────────────────────── */
-/* `ref-link` is the shared marker class emitted by remarkLinkifyRefs (REF_LINK_CLASS);
-   values mirror the debate surface's .ref-link (StatementCard.css) so both read alike. */
-.ref-link {
-  appearance: none;
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  color: var(--accent);
-  cursor: pointer;
-  text-decoration: underline;
-  text-decoration-style: dotted;
-  text-underline-offset: 2px;
-}
-
-.ref-link:hover,
-.ref-link:focus-visible {
-  text-decoration-style: solid;
-  color: var(--accent-strong, var(--accent));
-}


### PR DESCRIPTION
Follow-through on t/1907 / t/1967. Deletes the per-surface `.ref-link` copy from `ChatWorkspace.css` now that t/1965 (`aed52d48`) landed the single shared home `components/shared/refLinkifyPlugin.css`.

- Removes the `.ref-link` + `.ref-link:hover/:focus-visible` blocks and the "values mirror StatementCard.css" comment that documented the duplication.
- **No CSS import added** — `ChatWorkspace.tsx` already imports `refLinkifyPlugin.ts`, so the shared CSS loads transitively (design assumption in t/1907#1 held).

**Verification (deterministic, mirrors t/1965's no-browser proof):** `.ref-link` is gone from `ChatWorkspace.css`; `vite build` still emits the byte-identical `.ref-link` rules in `DetailPane-*.css` via the shared `refLinkifyPlugin.css` graph, which the chat surface loads through its DetailPane + `refLinkifyPlugin.ts` imports. Dotted-underline / accent / solid-on-hover rendering unchanged. Full gate runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)