### PR TITLE
ci: add merge_group trigger to enable the GitHub merge queue (t/1968)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # merge_group: fires when a PR is added to the GitHub merge queue (t/1968). The
+  # queue tests each PR against the PROJECTED merged state — restores strict=true's
+  # "tested against current main" guarantee without the up-to-date rebase livelock.
+  # No job edits needed: `changes` (if: event==pull_request) SKIPS on merge_group,
+  # so every code job's `github.event_name != 'pull_request'` guard runs the FULL
+  # suite unfiltered, and `ci-gate` (the queue's required check) aggregates them.
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
ci: add merge_group trigger to enable the GitHub merge queue (t/1968)

Enables the merge queue as the durable fix for the strict=true PR livelock
(t/1968). The queue tests each PR against the projected merged state, restoring
strict's "tested against current main" guarantee without the up-to-date rebase
treadmill that livelocked #139/#142.

Workflow-only change: `changes` skips on merge_group (its `if: event==pull_request`),
so every code job's `github.event_name != 'pull_request'` guard runs the full suite
unfiltered and `ci-gate` aggregates it as the queue's required check. Enabling
"Require merge queue" on main branch protection is the paired step (owner-gated).

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Technical Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
