### PR TITLE
fix(debate): convert hardExclude to pre-score array filter (t/1981)

### DIFF
--- a/lib/debate/taxonomyRelevance.test.ts
+++ b/lib/debate/taxonomyRelevance.test.ts
@@ -1081,3 +1081,179 @@ describe('selectRelevantNodes — corpus coverage', () => {
     expect(diagnostics!.boostedNodeIds).toContain('acc-beliefs-003');
   });
 });
+
+// ── selectRelevantNodes — wellTested hardExclude re-entry regression (t/1981) ──
+
+describe('selectRelevantNodes — wellTested hardExclude', () => {
+  // Two distinct challenger camps so isReeligible() returns false when now=2026-07-30.
+  function makeWellTestedNode(id: string, category: Category): PovNode {
+    return {
+      id,
+      label: `Node ${id}`,
+      description: `Description for ${id}`,
+      category,
+      graph_attributes: {
+        debate_tested: {
+          tier: 'well_tested',
+          sort_key: 3.5,
+          engagements: 5,
+          challenges: 5,
+          held: 5,
+          weakened: 0,
+          revisions: [],
+          last_tested: '2026-07-29',
+          description_hash: 'abc',
+          record: [
+            {
+              debate_id: 'd1', date: '2026-07-10', pipeline_version: '1.0',
+              verdict: 'held',
+              strongest_attack_encountered: { claim_id: 'c1', strength: 0.8, scheme: 'ad_rem', challenger_camp: 'safetyist' },
+              claim_outcomes: { thrived: 1, survived: 0, died: 0 }, concession: null,
+            },
+            {
+              debate_id: 'd2', date: '2026-07-20', pipeline_version: '1.0',
+              verdict: 'held',
+              strongest_attack_encountered: { claim_id: 'c2', strength: 0.7, scheme: 'ad_rem', challenger_camp: 'skeptic' },
+              claim_outcomes: { thrived: 1, survived: 0, died: 0 }, concession: null,
+            },
+          ],
+        },
+      },
+    } as PovNode;
+  }
+
+  const NOW = new Date('2026-07-30');
+
+  it('excluded node does not re-enter via minPerCategory refill in a sparse category', () => {
+    // Beliefs has: wt-node (hardExcluded → score 0) + one below-threshold node.
+    // minPerCategory=2 triggers refill; buggy code would pick wt-node from sorted.
+    const nodes = [
+      makeWellTestedNode('acc-beliefs-wt', 'Beliefs'),
+      makeNode('acc-beliefs-001', 'Beliefs'),
+      makeNode('acc-desires-001', 'Desires'),
+      makeNode('acc-intentions-001', 'Intentions'),
+    ];
+    const scores = new Map([
+      ['acc-beliefs-wt', 0.70],
+      ['acc-beliefs-001', 0.40],  // below threshold — zero Beliefs nodes above threshold
+      ['acc-desires-001', 0.55],
+      ['acc-intentions-001', 0.55],
+    ]);
+
+    const result = selectRelevantNodes(nodes, scores, {
+      embeddingThreshold: 0.48,
+      minPerCategory: 2,
+      minPerPov: 0,
+      wellTested: { excludeWellTested: true, now: NOW },
+    });
+
+    const ids = result.map(r => r.node.id);
+    expect(ids).not.toContain('acc-beliefs-wt');
+    expect(ids).toContain('acc-beliefs-001');
+  });
+
+  it('excluded node does not re-enter via POV-diversity floor when POV is sparse', () => {
+    // saf has 1 above-threshold node + 1 excluded wt-node.
+    // minPerPov=2 triggers floor; buggy code would add wt-node to fill the deficit.
+    const nodes = [
+      makeNode('acc-beliefs-001', 'Beliefs'),
+      makeNode('acc-beliefs-002', 'Beliefs'),
+      makeNode('saf-beliefs-001', 'Beliefs'),
+      makeWellTestedNode('saf-beliefs-wt', 'Beliefs'),
+    ];
+    const scores = new Map([
+      ['acc-beliefs-001', 0.70],
+      ['acc-beliefs-002', 0.65],
+      ['saf-beliefs-001', 0.55],
+      ['saf-beliefs-wt', 0.80],  // high before hardExclude, 0 after
+    ]);
+
+    const result = selectRelevantNodes(nodes, scores, {
+      embeddingThreshold: 0.48,
+      minPerCategory: 0,
+      minPerPov: 2,
+      wellTested: { excludeWellTested: true, now: NOW },
+    });
+
+    const ids = result.map(r => r.node.id);
+    expect(ids).not.toContain('saf-beliefs-wt');
+    expect(ids).toContain('saf-beliefs-001');
+  });
+
+  it('downweight path (excludeWellTested: false) still allows refill re-entry', () => {
+    // Downweighted node stays in the candidate pool — only hardExclude removes it.
+    const nodes = [
+      makeWellTestedNode('acc-beliefs-wt', 'Beliefs'),
+      makeNode('acc-beliefs-001', 'Beliefs'),
+      makeNode('acc-desires-001', 'Desires'),
+      makeNode('acc-intentions-001', 'Intentions'),
+    ];
+    const scores = new Map([
+      ['acc-beliefs-wt', 0.80],  // 0.80 * 0.5 = 0.40 after downweight
+      ['acc-beliefs-001', 0.40],
+      ['acc-desires-001', 0.55],
+      ['acc-intentions-001', 0.55],
+    ]);
+
+    const result = selectRelevantNodes(nodes, scores, {
+      embeddingThreshold: 0.48,
+      minPerCategory: 2,
+      minPerPov: 0,
+      wellTested: { excludeWellTested: false, wellTestedMultiplier: 0.5, now: NOW },
+    });
+
+    // Still in pool at score 0.40 — refill picks it
+    expect(result.map(r => r.node.id)).toContain('acc-beliefs-wt');
+  });
+
+  it('re-eligible well-tested node is not excluded', () => {
+    // Only 1 challenger camp → isReeligible returns true → node stays in selection.
+    const reeligibleNode = {
+      id: 'acc-beliefs-reelig',
+      label: 'Reeligible node',
+      description: 'desc',
+      category: 'Beliefs' as Category,
+      graph_attributes: {
+        debate_tested: {
+          tier: 'well_tested',
+          sort_key: 3.5,
+          engagements: 5,
+          challenges: 5,
+          held: 5,
+          weakened: 0,
+          revisions: [],
+          last_tested: '2026-07-29',
+          description_hash: 'abc',
+          record: [
+            {
+              debate_id: 'd1', date: '2026-07-10', pipeline_version: '1.0',
+              verdict: 'held',
+              strongest_attack_encountered: { claim_id: 'c1', strength: 0.8, scheme: 'ad_rem', challenger_camp: 'safetyist' },
+              claim_outcomes: { thrived: 1, survived: 0, died: 0 }, concession: null,
+            },
+          ],
+        },
+      },
+    } as PovNode;
+
+    const nodes = [
+      reeligibleNode,
+      makeNode('acc-desires-001', 'Desires'),
+      makeNode('acc-intentions-001', 'Intentions'),
+    ];
+    const scores = new Map([
+      ['acc-beliefs-reelig', 0.60],
+      ['acc-desires-001', 0.55],
+      ['acc-intentions-001', 0.55],
+    ]);
+
+    const result = selectRelevantNodes(nodes, scores, {
+      embeddingThreshold: 0.48,
+      minPerCategory: 0,
+      minPerPov: 0,
+      wellTested: { excludeWellTested: true, now: NOW },
+    });
+
+    expect(result.map(r => r.node.id)).toContain('acc-beliefs-reelig');
+  });
+});

--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -345,6 +345,16 @@ export function selectRelevantNodes(
     }
   }
 
+  // Remove hardExcluded nodes from the candidate pool before grouping — score-0
+  // is insufficient because minPerCategory refill and POV-diversity floor pick by
+  // top-score regardless of threshold, so score-0 nodes can re-enter (t/1981).
+  const hardExcludedIds: Set<string> = _wellTestedResult?.excludedNodeIds?.length
+    ? new Set(_wellTestedResult.excludedNodeIds)
+    : new Set();
+  const candidateNodes = hardExcludedIds.size > 0
+    ? povNodes.filter(n => !hardExcludedIds.has(n.id))
+    : povNodes;
+
   // Group by category
   const groups: Record<string, ScoredPovNode[]> = {
     'Beliefs': [],
@@ -352,7 +362,7 @@ export function selectRelevantNodes(
     'Intentions': [],
   };
 
-  for (const node of povNodes) {
+  for (const node of candidateNodes) {
     const cat = node.category || 'Intentions';
     const score = effectiveScores.get(node.id) || 0;
     (groups[cat] ?? groups['Intentions']).push({ node, score });
@@ -384,7 +394,7 @@ export function selectRelevantNodes(
       const count = povCounts[pov];
       if (count >= minPov) continue;
       const deficit = minPov - count;
-      const candidates = povNodes
+      const candidates = candidateNodes
         .filter(n => n.id.startsWith(prefix) && !selectedIds.has(n.id))
         .map(n => ({ node: n, score: effectiveScores.get(n.id) || 0 }))
         .sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Summary

- hardExclude set excluded nodes' score to 0 but left them in the candidate array
- minPerCategory refill (sorted.slice(0, minPerCategory)) and POV-diversity floor both pick by top-score regardless of threshold, so score-0 excluded nodes could re-enter
- Fix: collect xcludedNodeIds after the well-tested block and filter them out of candidateNodes before grouping and before the diversity-floor candidate scan
- Downweight (mult) path unchanged — downweighted nodes remain eligible

## Test plan
- [ ] xcluded node does not re-enter via minPerCategory refill in a sparse category
- [ ] xcluded node does not re-enter via POV-diversity floor when POV is sparse
- [ ] downweight path (excludeWellTested: false) still allows refill re-entry
- [ ] e-eligible well-tested node is not excluded
- [ ] Full 54-test suite passes on committed worktree state

🤖 Generated with [Claude Code](https://claude.com/claude-code)