### PR TITLE
feat(entities): -Status filter on Update-EntityMentionIndex (default approved) [t/1982]

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -45,7 +45,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Import-Entity` | Curation write: upsert 1-20 proposed/approved/deprecated entity records with a never-reused ent-NNN allocator; person records need a human description to approve (t/1804) |
 | `Invoke-EntityExtraction` | Phase 1 entity extraction from source_evidence_index.json facts; resolves against existing entities/orgs/taxonomy/dictionary/policy before minting only the unmatched remainder (t/1806) |
 | `Get-EntityReport` | Maintenance reports: near-duplicate entities, provenance orphans, dictionary-collision candidates, merge-chain defects (t/1806) |
-| `Update-EntityMentionIndex` | Phase 2-B batch re-index: rebuilds the derived `entity_mentions.json` by alias-first, deterministic matching of approved entities against curated container text (SEI facts + POV nodes); idempotent via per-container `text_sha256`, human mentions win, normalization mirrors the D1 parity contract (t/1894) |
+| `Update-EntityMentionIndex` | Phase 2-B batch re-index: rebuilds the derived `entity_mentions.json` by alias-first, deterministic matching of entities against curated container text (SEI facts + POV nodes). Indexes `-Status` entities only (default `approved`, per §5 / the D1 caller-filters-to-approved contract); widen to `-Status approved,proposed` for an explicit preview before curation. Populated statuses recorded in the envelope's `indexed_status`. Idempotent via per-container `text_sha256`, human mentions win, normalization mirrors the D1 parity contract (t/1894, t/1982) |
 
 ### Graph & Conflict Analysis
 | Cmdlet | Use when |

--- a/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
+++ b/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
@@ -9,12 +9,16 @@ function Update-EntityMentionIndex {
     .DESCRIPTION
         The retroactive re-index (§7): the durable rebuild path for entity_mentions.json,
         a DERIVED artifact (never a source of truth). Scans each curated container's exact
-        analyzed text for approved-entity aliases and writes one Mention per hit.
+        analyzed text for entity aliases and writes one Mention per hit. By default only
+        APPROVED entities are indexed (design of record §5; the D1 caller-filters-to-approved
+        contract) — widen with -Status to build a preview over proposed/deprecated records.
 
         Matching is ALIAS-FIRST and deterministic — an alias table (name + aliases) over the
-        approved entities in entities.json, matched case-insensitively with word boundaries
-        and flexible interior whitespace. No AI call, no embeddings; embedding tie-break is
-        D1 (Shared Lib), out of scope here.
+        in-scope entities in entities.json (default: status 'approved'), matched
+        case-insensitively with word boundaries and flexible interior whitespace. No AI call,
+        no embeddings; embedding tie-break is D1 (Shared Lib), out of scope here. The
+        populated statuses are recorded in the envelope's `indexed_status`, so a curated
+        index is distinguishable from a preview by inspecting the file.
 
         Container sources (the curated batch tier — facts + POV, design §5):
           - Source-Evidence-Index facts: container id `sei:<sei_key>`, text = the entry's
@@ -46,6 +50,12 @@ function Update-EntityMentionIndex {
         skip POV containers entirely. Absent files are skipped (non-fatal).
     .PARAMETER OutputPath
         Override entity_mentions.json output path. Defaults to Get-EntityMentionsFilePath.
+    .PARAMETER Status
+        Which entity statuses to index. Default @('approved') — the design-of-record §5
+        population and the D1 caller-filters-to-approved contract. Pass e.g.
+        -Status approved,proposed to build an explicit PREVIEW over un-curated candidates
+        (useful before any entity has been approved, so the Phase-2 render is not empty).
+        The populated set is recorded in the output envelope's `indexed_status`.
     .PARAMETER Force
         Rewrite the file even when the containers are unchanged (bumps last_modified).
         Without -Force an unchanged rebuild is a no-op that does not touch the file.
@@ -73,6 +83,10 @@ function Update-EntityMentionIndex {
         [Parameter()]
         [Alias('Path')]
         [string]$OutputPath,
+
+        [Parameter()]
+        [ValidateSet('proposed', 'approved', 'deprecated')]
+        [string[]]$Status = @('approved'),
 
         [Parameter()]
         [switch]$Force
@@ -119,13 +133,17 @@ function Update-EntityMentionIndex {
         return $true
     }
 
-    # --- Alias table over approved entities: normalized surface -> raw ent-* ref ------------
+    # --- Alias table over in-scope entities (default: status 'approved'): normalized surface -> raw ent-* ref ------------
     $Store = Get-EntitiesStore -Path $EntPath -InitIfMissing
     $Entities = if ($Store.PSObject.Properties['entities']) { @($Store.entities) } else { @() }
 
     $AliasEntries = [System.Collections.Generic.List[object]]::new()
     foreach ($e in $Entities) {
         if (-not $e.PSObject.Properties['id']) { continue }
+        # Status gate (§5 curation contract): index only the requested statuses; default is
+        # approved-only. A record without a `status` field is treated as un-indexable.
+        $eStatus = if ($e.PSObject.Properties['status']) { [string]$e.status } else { '' }
+        if ($eStatus -notin $Status) { continue }
         $ref = [string]$e.id
         $surfaces = [System.Collections.Generic.List[string]]::new()
         if ($e.PSObject.Properties['name'] -and $e.name) { $surfaces.Add([string]$e.name) }
@@ -325,6 +343,7 @@ function Update-EntityMentionIndex {
         ContainerCount = @($NewContainers.Keys).Count
         MentionCount   = $TotalMentions
         AliasCount     = @($AliasEntries).Count
+        IndexedStatus  = @($Status | Sort-Object -Unique)
         Unchanged      = $unchanged
         Written        = $false
     }
@@ -337,6 +356,7 @@ function Update-EntityMentionIndex {
     $file = [ordered]@{
         _schema_version = '1.0.0'
         _doc            = 'Derived artifact — rebuildable via Update-EntityMentionIndex (re-index, epic t/1890 design §7). Absence of a container means "no links yet", never an error.'
+        indexed_status  = @($Status | Sort-Object -Unique)
         last_modified   = $lastModified
         containers      = $NewContainers
     }

--- a/tests/Update-EntityMentionIndex.Tests.ps1
+++ b/tests/Update-EntityMentionIndex.Tests.ps1
@@ -29,8 +29,8 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             entity_count    = 2
             last_modified   = '2026-07-28'
             entities        = @(
-                [ordered]@{ id = 'ent-001'; name = 'Apollo Project'; aliases = @('Apollo Program'); entity_type = 'event' }
-                [ordered]@{ id = 'ent-002'; name = 'Apollo'; aliases = $null; entity_type = 'event' }
+                [ordered]@{ id = 'ent-001'; name = 'Apollo Project'; aliases = @('Apollo Program'); entity_type = 'event'; status = 'approved' }
+                [ordered]@{ id = 'ent-002'; name = 'Apollo'; aliases = $null; entity_type = 'event'; status = 'approved' }
             )
         }
         ($entities | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $script:entPath -Encoding utf8NoBOM
@@ -99,8 +99,8 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             $ents = [ordered]@{
                 _schema_version = '1.0.0'; _doc = 'test'; entity_count = 2; last_modified = '2026-07-28'
                 entities        = @(
-                    [ordered]@{ id = 'ent-010'; name = 'GPT-4o'; aliases = $null; entity_type = 'artifact' }
-                    [ordered]@{ id = 'ent-011'; name = 'o4-mini'; aliases = $null; entity_type = 'artifact' }
+                    [ordered]@{ id = 'ent-010'; name = 'GPT-4o'; aliases = $null; entity_type = 'artifact'; status = 'approved' }
+                    [ordered]@{ id = 'ent-011'; name = 'o4-mini'; aliases = $null; entity_type = 'artifact'; status = 'approved' }
                 )
             }
             ($ents | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $script:entPath -Encoding utf8NoBOM
@@ -251,6 +251,58 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             New-Sei -Path $script:seiPath -Map @{ 'n1' = @{ facts = @(@{ claim = 'Apollo Project.'; doc_id = 'd1' }) } }
             Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath -WhatIf | Out-Null
             Test-Path -LiteralPath $script:outPath | Should -BeFalse
+        }
+    }
+
+    Context 'Status filter (t/1982)' {
+        BeforeEach {
+            # One approved + one proposed entity, each with a distinct alias present in the text.
+            # Also a record with NO status field (must be treated as un-indexable).
+            $mixed = [ordered]@{
+                _schema_version = '1.0.0'; _doc = 'test'; entity_count = 3; last_modified = '2026-07-29'
+                entities        = @(
+                    [ordered]@{ id = 'ent-100'; name = 'Manhattan Project'; aliases = $null; entity_type = 'event'; status = 'approved' }
+                    [ordered]@{ id = 'ent-200'; name = 'Stargate'; aliases = $null; entity_type = 'event'; status = 'proposed' }
+                    [ordered]@{ id = 'ent-300'; name = 'Skunkworks'; aliases = $null; entity_type = 'event' }  # no status
+                )
+            }
+            ($mixed | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $script:entPath -Encoding utf8NoBOM
+            New-Sei -Path $script:seiPath -Map @{
+                'n1' = @{ facts = @(@{ claim = 'The Manhattan Project, Stargate, and Skunkworks all mattered.'; doc_id = 'd1' }) }
+            }
+        }
+
+        It 'Default indexes ONLY approved entities (proposed + status-less skipped)' {
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath
+            $r.IndexedStatus | Should -Be @('approved')
+
+            $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
+            $file.indexed_status | Should -Be @('approved')
+            $m = @($file.containers.'sei:n1'.mentions)
+            $m.Count | Should -Be 1
+            $m[0].entity_ref | Should -Be 'ent-100'
+        }
+
+        It '-Status proposed indexes ONLY the proposed entity' {
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath -Status proposed | Out-Null
+            $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
+            $file.indexed_status | Should -Be @('proposed')
+            $m = @($file.containers.'sei:n1'.mentions)
+            $m.Count | Should -Be 1
+            $m[0].entity_ref | Should -Be 'ent-200'
+        }
+
+        It '-Status approved,proposed (the explicit preview) indexes both, and records both in the envelope' {
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath -Status approved, proposed
+            ($r.IndexedStatus | Sort-Object) | Should -Be @('approved', 'proposed')
+
+            $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
+            # indexed_status is sorted-unique in the envelope.
+            @($file.indexed_status) | Should -Be @('approved', 'proposed')
+            $refs = @($file.containers.'sei:n1'.mentions.entity_ref | Sort-Object)
+            $refs | Should -Be @('ent-100', 'ent-200')
+            # The status-less ent-300 is still excluded even under the widened preview.
+            $refs | Should -Not -Contain 'ent-300'
         }
     }
 


### PR DESCRIPTION
## t/1982 — mention indexer had no status filter

`Update-EntityMentionIndex` applied no status gate, so `entity_mentions.json` indexed every entity regardless of curation state — contradicting its own help text, design-of-record §5, and D1's caller-filters-to-approved contract (t/1894 AC). With the live store all-`proposed`, it silently indexed 63 un-vetted candidates and 0 approved.

### Change
- **New `-Status` param** (ValidateSet `proposed`/`approved`/`deprecated`, default `@('approved')`). The alias-table loop skips records whose `status ∉ -Status`; a record with **no** `status` field is treated as un-indexable.
- **Envelope `indexed_status`** (sorted-unique) + returned-object `IndexedStatus` — a curated index is now distinguishable from a preview by inspecting the file.
- Default is `approved` (the honest §5 contract). Build an explicit preview with `-Status approved,proposed` before any entity is curated, so the Phase-2 render is not empty.
- Help `.DESCRIPTION` + `.PARAMETER Status`, the line comment, and `docs/cmdlet-reference.md` updated to match.

### Design decision
Agreed with TL2's approved-default (t/1982#1): permissive-default was considered and rejected (contradicts §5/contract; re-buries the curation gate; bakes the ent-049/076 duplicate coin-flip into a derived artifact). The one judgment call — regenerating the **live** index as an explicit `approved,proposed` preview to preserve today's render rather than emptying it — is flagged for TL2 in t/1982#1.

### Tests
+3 (default approved-only; `-Status proposed`; `approved,proposed` preview incl. status-less exclusion). Existing fixtures gained the schema-required `status` field they were missing. **Full suite 956/0**, manifest valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)