### PR TITLE
feat(analysis): wire mention-render kit into FactsPanel (t/1906)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/FactsPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/FactsPanel.test.tsx
@@ -4,20 +4,35 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
+// setSelectedRef spy — the mention-render kit routes ref-link clicks through
+// useDebateStore.getState().setSelectedRef (t/1906). Hoisted so the vi.mock factory can close over it.
+const { setSelectedRef } = vi.hoisted(() => ({ setSelectedRef: vi.fn() }));
+
 vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }));
+vi.mock('../../hooks/useDebateStore', () => ({
+  useDebateStore: Object.assign(() => undefined, { getState: () => ({ setSelectedRef }) }),
+}));
 vi.mock('@bridge', () => ({
   api: {
     loadSourceEvidenceIndex: () => Promise.resolve({
       'node-facts': { facts: [{ claim: 'GDP rose 3% in 2024', label: 'Economic growth', doc_id: 'doc-42', specificity: 'precise', temporal_bound: '2024' }] },
       'node-empty': { facts: [] },
+      'node-mention': { facts: [{ claim: 'Anthropic released a model', label: 'Model release', doc_id: 'doc-7', specificity: 'precise', temporal_bound: null }] },
     }),
+    // Mention-render kit dependency (t/1901 bridge). Returns a stored mention for the
+    // mention node; empty (plain text) for everything else.
+    getContainerMentions: (containerId: string) => Promise.resolve(
+      containerId === 'sei:node-mention'
+        ? { containerId, mentions: [{ entity_ref: 'org-anthropic', quote: 'Anthropic', offset: 0, discovered_by: 'extraction' }] }
+        : { containerId, mentions: [] },
+    ),
   },
 }));
 
 const { FactsPanel } = await import('./FactsPanel');
 
-describe('FactsPanel (t/1025)', () => {
-  afterEach(() => { vi.restoreAllMocks(); });
+describe('FactsPanel (t/1025, t/1906)', () => {
+  afterEach(() => { vi.restoreAllMocks(); setSelectedRef.mockClear(); });
 
   it('shows an empty state for a node with no linked evidence', async () => {
     render(<FactsPanel nodeId="node-empty" />);
@@ -34,5 +49,18 @@ describe('FactsPanel (t/1025)', () => {
     // Doc id only appears in the expanded detail.
     expect(screen.getByText(/doc-42/)).toBeInTheDocument();
     expect(onSelectFact).toHaveBeenCalledWith(expect.objectContaining({ label: 'Economic growth' }));
+  });
+
+  it('renders a stored entity mention as a .ref-link and routes the click (t/1906)', async () => {
+    render(<FactsPanel nodeId="node-mention" />);
+    // Once mentions load, "Anthropic" in the claim renders as a ref-link button
+    // (kind conveyed via aria-label), not plain text.
+    const link = await screen.findByRole('button', { name: /Organization: Anthropic/ });
+    expect(link).toHaveClass('ref-link');
+
+    // Clicking routes to the shared DetailPane via setSelectedRef with the parsed ref,
+    // and does not toggle the card (stopPropagation).
+    fireEvent.click(link);
+    expect(setSelectedRef).toHaveBeenCalledWith({ kind: 'organization', id: 'org-anthropic' });
   });
 });

--- a/taxonomy-editor/src/renderer/components/analysis/FactsPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/FactsPanel.test.tsx
@@ -4,14 +4,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
-// setSelectedRef spy — the mention-render kit routes ref-link clicks through
-// useDebateStore.getState().setSelectedRef (t/1906). Hoisted so the vi.mock factory can close over it.
-const { setSelectedRef } = vi.hoisted(() => ({ setSelectedRef: vi.fn() }));
-
 vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }));
-vi.mock('../../hooks/useDebateStore', () => ({
-  useDebateStore: Object.assign(() => undefined, { getState: () => ({ setSelectedRef }) }),
-}));
 vi.mock('@bridge', () => ({
   api: {
     loadSourceEvidenceIndex: () => Promise.resolve({
@@ -32,7 +25,7 @@ vi.mock('@bridge', () => ({
 const { FactsPanel } = await import('./FactsPanel');
 
 describe('FactsPanel (t/1025, t/1906)', () => {
-  afterEach(() => { vi.restoreAllMocks(); setSelectedRef.mockClear(); });
+  afterEach(() => { vi.restoreAllMocks(); });
 
   it('shows an empty state for a node with no linked evidence', async () => {
     render(<FactsPanel nodeId="node-empty" />);
@@ -51,8 +44,9 @@ describe('FactsPanel (t/1025, t/1906)', () => {
     expect(onSelectFact).toHaveBeenCalledWith(expect.objectContaining({ label: 'Economic growth' }));
   });
 
-  it('renders a stored entity mention as a .ref-link and routes the click (t/1906)', async () => {
-    render(<FactsPanel nodeId="node-mention" />);
+  it('linkifies a stored mention and routes via the wired onSelectRef (t/1906)', async () => {
+    const onSelectRef = vi.fn();
+    render(<FactsPanel nodeId="node-mention" onSelectRef={onSelectRef} />);
     // Links render only in the EXPANDED claim (the muted collapsed preview stays plain
     // text for WCAG AA — see FactsPanel §9 note). Expand the card first.
     await waitFor(() => expect(screen.getByText('Model release')).toBeInTheDocument());
@@ -60,10 +54,17 @@ describe('FactsPanel (t/1025, t/1906)', () => {
     // "Anthropic" in the expanded claim renders as a ref-link button (kind via aria-label).
     const link = await screen.findByRole('button', { name: /Organization: Anthropic/ });
     expect(link).toHaveClass('ref-link');
-
-    // Clicking routes to the shared DetailPane via setSelectedRef with the parsed ref,
-    // and does not toggle the card (stopPropagation).
+    // Clicking routes through the injected handler with the parsed ref (not a dead link).
     fireEvent.click(link);
-    expect(setSelectedRef).toHaveBeenCalledWith({ kind: 'organization', id: 'org-anthropic' });
+    expect(onSelectRef).toHaveBeenCalledWith({ kind: 'organization', id: 'org-anthropic' });
+  });
+
+  it('renders mentions as PLAIN text when no onSelectRef is wired (t/1977 — no dead links)', async () => {
+    render(<FactsPanel nodeId="node-mention" />); // no co-mounted pane → no handler
+    await waitFor(() => expect(screen.getByText('Model release')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Model release'));
+    // The claim text is present, but "Anthropic" is NOT a link (would be a dead click).
+    expect(screen.getByText(/Anthropic released a model/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Organization: Anthropic/ })).toBeNull();
   });
 });

--- a/taxonomy-editor/src/renderer/components/analysis/FactsPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/FactsPanel.test.tsx
@@ -53,8 +53,11 @@ describe('FactsPanel (t/1025, t/1906)', () => {
 
   it('renders a stored entity mention as a .ref-link and routes the click (t/1906)', async () => {
     render(<FactsPanel nodeId="node-mention" />);
-    // Once mentions load, "Anthropic" in the claim renders as a ref-link button
-    // (kind conveyed via aria-label), not plain text.
+    // Links render only in the EXPANDED claim (the muted collapsed preview stays plain
+    // text for WCAG AA — see FactsPanel §9 note). Expand the card first.
+    await waitFor(() => expect(screen.getByText('Model release')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Model release'));
+    // "Anthropic" in the expanded claim renders as a ref-link button (kind via aria-label).
     const link = await screen.findByRole('button', { name: /Organization: Anthropic/ });
     expect(link).toHaveClass('ref-link');
 

--- a/taxonomy-editor/src/renderer/components/analysis/FactsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/FactsPanel.tsx
@@ -4,8 +4,9 @@
 import { useState, useEffect, useMemo } from 'react';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import type { EntityRef } from '@lib/entities/types';
 import { reconstructSeiContainer } from '../shared/mentionText';
-import { useMentionRenderer } from '../shared/MentionField';
+import { useContainerMentions, MentionField } from '../shared/MentionField';
 import './FactsPanel.css';
 
 export interface SourceFact {
@@ -65,9 +66,14 @@ const SPECIFICITY_COLORS: Record<string, { bg: string; fg: string }> = {
   unknown: { bg: 'rgba(148,163,184,0.12)', fg: '#64748b' },
 };
 
-export function FactsPanel({ nodeId, onSelectFact }: {
+export function FactsPanel({ nodeId, onSelectFact, onSelectRef }: {
   nodeId: string;
   onSelectFact?: (fact: SourceFact | null) => void;
+  /** Ref-select handler injected by a co-mounted DetailPane. Mentions linkify ONLY when
+   *  this is wired — otherwise claims render as plain text (t/1977: never a dead link
+   *  where no pane receives the click). The taxonomy-view DetailPane host (blocks t/1906)
+   *  supplies it; until then FactsPanel renders plain. */
+  onSelectRef?: (ref: EntityRef) => void;
 }) {
   const [facts, setFacts] = useState<SourceFact[] | null>(null);
   const [loading, setLoading] = useState(true);
@@ -86,20 +92,31 @@ export function FactsPanel({ nodeId, onSelectFact }: {
     return () => { cancelled = true; };
   }, [nodeId]);
 
-  // Mention-render kit (t/1906): the sei:<nodeId> container reconstructs the fact
-  // claims (single-LF join) so stored entity-name mentions render as .ref-link
-  // buttons in the reading flow. Hook is called unconditionally (before the early
-  // returns); claims are plain text, so no HighlightedTextarea caveat.
-  // Links render only in the EXPANDED claim (var(--text-primary), passes WCAG AA in
-  // all 4 themes). The collapsed preview stays plain text: it uses var(--text-muted)
-  // and .ref-link inherits color (var(--accent) is undefined app-wide), which would
-  // fail AA at the preview's small muted size (§9 sign-off, t/1906).
+  // Mention-render kit (t/1906): reconstruct the sei:<nodeId> container from the fact
+  // claims (single-LF join) so stored entity-name mentions can render as .ref-link
+  // buttons. Two gates:
+  //   1. Co-mount (t/1977): linkify ONLY when `onSelectRef` is wired — a link must have a
+  //      DetailPane to receive its click, else render plain text (never a dead link). The
+  //      taxonomy-view host that supplies onSelectRef blocks t/1906; until then → plain.
+  //   2. WCAG AA (§9): links render only in the EXPANDED claim (var(--text-primary),
+  //      passes AA in all 4 themes). The collapsed preview stays plain — it uses
+  //      var(--text-muted) and .ref-link inherits color (var(--accent) is undefined
+  //      app-wide), which fails AA at the preview's small muted size.
+  // Hooks stay unconditional (above the early returns); claims are plain text (no
+  // HighlightedTextarea caveat).
   const containerId = `sei:${nodeId}`;
   const container = useMemo(
     () => reconstructSeiContainer((facts ?? []).map(f => f.claim)),
     [facts],
   );
-  const renderField = useMentionRenderer(containerId, container);
+  const mentions = useContainerMentions(onSelectRef ? containerId : null);
+  const renderClaim = (index: number, claim: string) => {
+    if (!onSelectRef) return claim; // no co-mounted pane → plain text (t/1977)
+    const field = container.fields.find(f => f.name === `fact-${index}`);
+    return field
+      ? <MentionField field={field} mentions={mentions} onSelectRef={onSelectRef} />
+      : claim;
+  };
 
   if (loading) {
     return <div className="facts-message">Loading facts...</div>;
@@ -151,7 +168,7 @@ export function FactsPanel({ nodeId, onSelectFact }: {
             </div>
             {isExpanded && (
               <div className="facts-expanded">
-                <div className="facts-claim-full">{renderField(`fact-${i}`, f.claim)}</div>
+                <div className="facts-claim-full">{renderClaim(i, f.claim)}</div>
                 <div className="facts-meta">
                   <span title="Source document"><strong>Doc:</strong> {f.doc_id}</span>
                   {f.temporal_bound && (

--- a/taxonomy-editor/src/renderer/components/analysis/FactsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/FactsPanel.tsx
@@ -90,6 +90,10 @@ export function FactsPanel({ nodeId, onSelectFact }: {
   // claims (single-LF join) so stored entity-name mentions render as .ref-link
   // buttons in the reading flow. Hook is called unconditionally (before the early
   // returns); claims are plain text, so no HighlightedTextarea caveat.
+  // Links render only in the EXPANDED claim (var(--text-primary), passes WCAG AA in
+  // all 4 themes). The collapsed preview stays plain text: it uses var(--text-muted)
+  // and .ref-link inherits color (var(--accent) is undefined app-wide), which would
+  // fail AA at the preview's small muted size (§9 sign-off, t/1906).
   const containerId = `sei:${nodeId}`;
   const container = useMemo(
     () => reconstructSeiContainer((facts ?? []).map(f => f.claim)),
@@ -133,7 +137,7 @@ export function FactsPanel({ nodeId, onSelectFact }: {
                 <div className="facts-label">{f.label}</div>
                 {!isExpanded && (
                   <div className="facts-claim-preview">
-                    {renderField(`fact-${i}`, f.claim)}
+                    {f.claim}
                   </div>
                 )}
               </div>

--- a/taxonomy-editor/src/renderer/components/analysis/FactsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/FactsPanel.tsx
@@ -1,9 +1,11 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { reconstructSeiContainer } from '../shared/mentionText';
+import { useMentionRenderer } from '../shared/MentionField';
 import './FactsPanel.css';
 
 export interface SourceFact {
@@ -84,6 +86,17 @@ export function FactsPanel({ nodeId, onSelectFact }: {
     return () => { cancelled = true; };
   }, [nodeId]);
 
+  // Mention-render kit (t/1906): the sei:<nodeId> container reconstructs the fact
+  // claims (single-LF join) so stored entity-name mentions render as .ref-link
+  // buttons in the reading flow. Hook is called unconditionally (before the early
+  // returns); claims are plain text, so no HighlightedTextarea caveat.
+  const containerId = `sei:${nodeId}`;
+  const container = useMemo(
+    () => reconstructSeiContainer((facts ?? []).map(f => f.claim)),
+    [facts],
+  );
+  const renderField = useMentionRenderer(containerId, container);
+
   if (loading) {
     return <div className="facts-message">Loading facts...</div>;
   }
@@ -120,7 +133,7 @@ export function FactsPanel({ nodeId, onSelectFact }: {
                 <div className="facts-label">{f.label}</div>
                 {!isExpanded && (
                   <div className="facts-claim-preview">
-                    {f.claim}
+                    {renderField(`fact-${i}`, f.claim)}
                   </div>
                 )}
               </div>
@@ -134,7 +147,7 @@ export function FactsPanel({ nodeId, onSelectFact }: {
             </div>
             {isExpanded && (
               <div className="facts-expanded">
-                <div className="facts-claim-full">{f.claim}</div>
+                <div className="facts-claim-full">{renderField(`fact-${i}`, f.claim)}</div>
                 <div className="facts-meta">
                   <span title="Source document"><strong>Doc:</strong> {f.doc_id}</span>
                   {f.temporal_bound && (


### PR DESCRIPTION
Wires the Phase-2 mention-render kit into FactsPanel so stored entity-name mentions render as `.ref-link`s in the fact reading flow (t/1906, epic t/1890).

## What
- `sei:<nodeId>` container reconstructed from fact claims (`reconstructSeiContainer`); each claim rendered via the kit (`useContainerMentions` + `MentionField`).
- **Co-mount invariant (t/1977):** mentions linkify ONLY when an `onSelectRef` handler is wired (a DetailPane is co-mounted to receive the click); otherwise plain text — never a dead link. The taxonomy-view DetailPane host (separate Taxonomy Editor ticket, blocks t/1906) will supply `onSelectRef`, lighting mentions up automatically. No visual change today (renders plain).
- **WCAG AA (§9):** links render only in the expanded claim (`--text-primary`, AA-pass in all 4 themes: 12.3–15.0). The muted collapsed preview stays plain (`.ref-link` inherits color since `var(--accent)` is undefined app-wide → would fail AA at the preview's small muted size).
- Consumes stored mention records only (no client-side NER); the kit's quote-match guard drops stale/ambiguous → plain text; reuses the single `.ref-link` treatment.

## Verify
renderer-tsc 0/0 · eslint 0 · depcruise clean · vite build ✓ · colocated vitest 4/4 (incl. wired-link routing + unwired-plain-text cases). §9 four-theme visual + keyboard pass done against a live Electron build (t/1906#4).

t/1906 stays In Review, blocked on the taxonomy-view DetailPane host; closes when clicks open a real EntityDetail + Design re-verifies §9.