### PR TITLE
feat(taxonomy): one app-level DetailPane host for all main tabs (t/1987)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -37,6 +37,7 @@ import { useFeatureFlagStore, useFlag } from './hooks/useFeatureFlags';
 import { PrecacheToast } from './components/shared/PrecacheToast';
 import { usePrecache } from './hooks/usePrecache';
 import { DiagnosticsDrawer } from './components/shared/DiagnosticsDrawer';
+import { GlobalDetailPaneHost } from './components/shared/GlobalDetailPaneHost';
 
 // Lazy-loaded tab components — only fetched when their tab is selected
 const SituationsTab = lazy(() => import('./components/debate/SituationsTab').then(m => ({ default: m.SituationsTab })));
@@ -656,6 +657,11 @@ function MainApp() {
             {activeTab === 'organizations' && <OrganizationsTab />}
           </Suspense>
         </div>
+        {/* One app-level ref → DetailPane host for every main tab in this shell (t/1987).
+            A ref-link click in PovTab/Situations/Conflicts/Cruxes/Debate sets the global
+            selectedRef; this single right-rail pane resolves it. Standalone Chat / debate
+            popout / EntityBrowser keep their own panes (separate contexts). */}
+        <GlobalDetailPaneHost />
       </div>
       <SaveBar />
       <BottomNav onOpenMore={() => setHamburgerOpen(true)} />

--- a/taxonomy-editor/src/renderer/components/shared/GlobalDetailPaneHost.css
+++ b/taxonomy-editor/src/renderer/components/shared/GlobalDetailPaneHost.css
@@ -1,0 +1,11 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* App-level ref detail pane — right rail in the `.app-body` flex row, opened from a
+   FactsPanel / read-only mention ref-link in any main tab (t/1987). The shared
+   DetailPane provides its own inner chrome (border, header, resize); this only
+   constrains its footprint alongside the flex:1 `.tab-content`. */
+.app-detail-pane {
+  flex: 0 0 360px;
+  max-width: 40vw;
+  height: 100%;
+  overflow-y: auto;
+}

--- a/taxonomy-editor/src/renderer/components/shared/GlobalDetailPaneHost.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/GlobalDetailPaneHost.test.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/1987 — one app-level host for the shared ref → DetailPane contract. These tests
+// lock the store-fed mount: the pane renders iff the GLOBAL `selectedRef` is set, it
+// forwards that ref to the shared DetailPane, and its close control clears the
+// selection through `setSelectedRef`.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { EntityRef } from '@lib/entities/types';
+import { GlobalDetailPaneHost } from './GlobalDetailPaneHost';
+
+const mockDebateStore: Record<string, any> = {
+  selectedRef: null as EntityRef | null,
+  setSelectedRef: vi.fn((ref: EntityRef | null) => { mockDebateStore.selectedRef = ref; }),
+};
+vi.mock('../../hooks/useDebateStore', () => ({
+  useDebateStore: Object.assign(
+    (selector?: any) => (selector ? selector(mockDebateStore) : mockDebateStore),
+    { getState: () => mockDebateStore, setState: (p: Record<string, any>) => Object.assign(mockDebateStore, p) },
+  ),
+}));
+
+// Mock the shared pane to a marker: these tests assert the HOST wiring, not the
+// pane's internal ref-resolution (covered by DetailPane.test.tsx).
+vi.mock('./DetailPane', () => ({
+  DetailPane: ({ selectedRef, className, onClose }: { selectedRef: EntityRef; className?: string; onClose?: () => void }) => (
+    <div data-testid="detail-pane" data-classname={className}>
+      <span data-testid="pane-ref-id">{selectedRef.id}</span>
+      <button onClick={onClose}>close-pane</button>
+    </div>
+  ),
+}));
+
+const REF: EntityRef = { kind: 'node', id: 'acc-beliefs-001' };
+
+describe('GlobalDetailPaneHost (t/1987)', () => {
+  beforeEach(() => {
+    cleanup();
+    mockDebateStore.selectedRef = null;
+    mockDebateStore.setSelectedRef.mockClear();
+  });
+
+  it('renders nothing when no ref is selected', () => {
+    const { container } = render(<GlobalDetailPaneHost />);
+    expect(screen.queryByTestId('detail-pane')).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('mounts the shared DetailPane with the global selected ref', () => {
+    mockDebateStore.selectedRef = REF;
+    render(<GlobalDetailPaneHost />);
+    expect(screen.getByTestId('detail-pane')).toBeTruthy();
+    expect(screen.getByTestId('pane-ref-id').textContent).toBe('acc-beliefs-001');
+    // Uses the app-level sizing class, not a per-tab one.
+    expect(screen.getByTestId('detail-pane').getAttribute('data-classname')).toBe('app-detail-pane');
+  });
+
+  it('clears the selection through setSelectedRef when the pane is closed', () => {
+    mockDebateStore.selectedRef = REF;
+    render(<GlobalDetailPaneHost />);
+    fireEvent.click(screen.getByText('close-pane'));
+    expect(mockDebateStore.setSelectedRef).toHaveBeenCalledWith(null);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/GlobalDetailPaneHost.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/GlobalDetailPaneHost.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { DetailPane } from './DetailPane';
+import { useDebateStore } from '../../hooks/useDebateStore';
+import './GlobalDetailPaneHost.css';
+
+/**
+ * App-level host for the shared ref → DetailPane contract (t/1987, topology t/1987#2).
+ *
+ * Rendered once in `App.tsx` after the main tab content, inside the `.app-body` flex
+ * row. Reads the GLOBAL `selectedRef` from the debate store, so a FactsPanel or
+ * read-only mention ref-link click in ANY main tab that renders in the shared app
+ * shell — PovTab, Situations, Conflicts, Cruxes, Debate, … — opens this one pane.
+ * A single mount replaces what would otherwise be a per-tab host (the dead-click gap
+ * hit PovTab/t/1906, Cruxes, and DebateUI/t/1905 alike).
+ *
+ * Standalone contexts — the Chat tab, the popped-out debate window, and the
+ * EntityBrowser panel — keep their OWN co-mounted DetailPane; they render outside
+ * this shell (or in a separate window/store context), so this host does not cover
+ * them and must not double-mount over them.
+ *
+ * Store-fed today; stays compatible with t/1977's `onSelectRef` DI when it lands
+ * (TL p/56#176). A11y (focus capture + Escape) is inherited from the shared
+ * DetailPane (t/1925); Design re-verifies it live in this mount context before
+ * t/1905 / t/1906 close.
+ */
+export function GlobalDetailPaneHost() {
+  const selectedRef = useDebateStore((s) => s.selectedRef);
+  const setSelectedRef = useDebateStore((s) => s.setSelectedRef);
+
+  if (!selectedRef) return null;
+
+  return (
+    <DetailPane
+      className="app-detail-pane"
+      selectedRef={selectedRef}
+      onSelectRef={setSelectedRef}
+      onClose={() => setSelectedRef(null)}
+    />
+  );
+}

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -1131,6 +1131,11 @@ interface NodeDetailFactsTabProps {
 }
 
 function NodeDetailFactsTab({ node, selectedFact, setSelectedFact, sourceDoc, sourceDocLoading, factSplitPct, handleFactSplitMouseDown, factSplitRef }: NodeDetailFactsTabProps) {
+  // Co-mount WRITE side (t/1987 AC#2): supply the global ref setter so FactsPanel's
+  // stored-mention ref-links linkify and open the app-level DetailPane host. Without
+  // it FactsPanel gates to plain text per the t/1977 co-mount rule. The store setter
+  // is global, so this reads it directly rather than threading a prop from the parent.
+  const setSelectedRef = useDebateStore((s) => s.setSelectedRef);
   return (
     <div className="facts-split-container" ref={factSplitRef}>
       <div
@@ -1138,7 +1143,7 @@ function NodeDetailFactsTab({ node, selectedFact, setSelectedFact, sourceDoc, so
         /* eslint-disable-next-line local/no-inline-style -- height is a user-dragged split percentage, passed as a CSS custom property */
         style={sourceDoc?.available ? { '--nd-split-height': `${factSplitPct}%` } as React.CSSProperties : undefined}
       >
-        <FactsPanel nodeId={node.id} onSelectFact={setSelectedFact} />
+        <FactsPanel nodeId={node.id} onSelectFact={setSelectedFact} onSelectRef={setSelectedRef} />
       </div>
       {sourceDocLoading && (
         <div className="facts-doc-loading">


### PR DESCRIPTION
## What

Mount **one** app-level `GlobalDetailPaneHost` in `App.tsx` (after the tab content, inside the `.app-body` flex row) that reads the global `selectedRef` and renders the shared `DetailPane`. This is the missing co-mount host for the ref → DetailPane contract across the main app shell.

## Why

FactsPanel / read-only mention ref-links in the taxonomy view — and, per TL topology (t/1987#2), in Cruxes (t/1906) and the DebateUI surface (t/1905) — call `setSelectedRef` into a void: no pane was mounted in the shell, so those clicks were dead. All main tabs render in one shell and share the global store, so a single mount covers them all. Replaces the initially-scoped per-`PovTab` mount (avoids triple-mount / double-mount).

Standalone **Chat**, the popped-out **debate window**, and **EntityBrowser** keep their own co-mounted panes (separate store/window contexts) and are intentionally not covered here.

## Scope

- `src/renderer/components/shared/GlobalDetailPaneHost.tsx` — new host (store read + conditional shared pane)
- `src/renderer/components/shared/GlobalDetailPaneHost.css` — `.app-detail-pane` right-rail sizing (styles.css frozen → co-located)
- `src/renderer/components/shared/GlobalDetailPaneHost.test.tsx` — mount / ref-forward / close-clears coverage (3 tests)
- `src/renderer/App.tsx` — import + render `<GlobalDetailPaneHost />`

## Notes

- **Store-fed**, staying compatible with t/1977's `onSelectRef` DI when it lands (TL p/56#176).
- A11y (focus capture + Escape) is inherited from the shared `DetailPane` (t/1925); **Design re-verifies it live** in this mount context before t/1905 / t/1906 close.
- Unblocks **t/1905** and **t/1906**.

## Verify

- `GlobalDetailPaneHost.test.tsx` — 3/3 pass
- `tsc` / `eslint` clean on changed files (0 errors)
