### PR TITLE
feat(debate): greatest-hits hard exclusion + t/1981 pre-filter leak fix (t/1438)

### DIFF
--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -64,7 +64,7 @@ interface CLIConfig {
   utilityModels?: { summary?: string; scope?: string; moderator?: string; crux?: string };
   exploreFirst?: boolean;
   exploreModel?: string;
-  enableCorpusCoverage?: boolean;
+  excludeGreatestHits?: boolean;
 }
 
 interface GoldenFixtureConfig extends CLIConfig {
@@ -393,7 +393,7 @@ async function main(): Promise<void> {
     salienceBeacon: config.salienceBeacon,
     stageModels: config.stageModels,
     utilityModels: config.utilityModels,
-    enableCorpusCoverage: config.enableCorpusCoverage,
+    excludeGreatestHits: config.excludeGreatestHits,
   };
 
   // Prepare output paths early so the snapshot callback can write partial files

--- a/lib/debate/corpusCoverage.test.ts
+++ b/lib/debate/corpusCoverage.test.ts
@@ -2,7 +2,13 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { computeCorpusCoverage, saveCoverageMap, loadCoverageMap } from './corpusCoverage.js';
+import {
+  computeCorpusCoverage,
+  saveCoverageMap,
+  loadCoverageMap,
+  generateGreatestHitsFile,
+  loadGreatestHitsFile,
+} from './corpusCoverage.js';
 
 // ── Mock fns (module-level, survive across describes) ─────
 
@@ -236,5 +242,124 @@ describe('saveCoverageMap / loadCoverageMap', () => {
     });
 
     expect(loadCoverageMap('/data')).toBeNull();
+  });
+});
+
+describe('generateGreatestHitsFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws ActionableError when coverage map is missing', () => {
+    setupMocks({ existsSync: () => false });
+    expect(() => generateGreatestHitsFile('/data')).toThrow(/corpus-coverage.json not found/);
+  });
+
+  it('throws ActionableError (no-clobber) when greatest-hits.json already exists', () => {
+    const coverageMap = {
+      version: 1 as const,
+      last_updated: '2026-07-01T00:00:00Z',
+      debate_count_threshold: 20,
+      node_stats: {
+        'acc-beliefs-001': { debate_count: 25, crux_link_count: 0, retread_flag: true },
+      },
+    };
+    setupMocks({
+      existsSync: (p) => true,
+      readFileSync: () => JSON.stringify(coverageMap),
+    });
+    expect(() => generateGreatestHitsFile('/data')).toThrow(/already exists/);
+  });
+
+  it('with force:true, writes over existing greatest-hits.json', () => {
+    const coverageMap = {
+      version: 1 as const,
+      last_updated: '2026-07-01T00:00:00Z',
+      debate_count_threshold: 20,
+      node_stats: {
+        'acc-beliefs-001': { debate_count: 25, crux_link_count: 0, retread_flag: true },
+        'saf-desires-002': { debate_count: 3, crux_link_count: 0, retread_flag: false },
+      },
+    };
+    let written = '';
+    setupMocks({
+      existsSync: () => true,
+      readFileSync: () => JSON.stringify(coverageMap),
+      writeFileSync: (_p, content) => { written = content; },
+    });
+    generateGreatestHitsFile('/data', { force: true });
+    const parsed = JSON.parse(written);
+    expect(parsed.version).toBe(1);
+    expect(parsed.node_ids).toContain('acc-beliefs-001');
+    expect(parsed.node_ids).not.toContain('saf-desires-002');
+  });
+});
+
+describe('loadGreatestHitsFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when greatest-hits.json does not exist', () => {
+    setupMocks({ existsSync: () => false });
+    expect(loadGreatestHitsFile('/data')).toBeNull();
+  });
+
+  it('throws ActionableError on JSON parse failure', () => {
+    setupMocks({
+      existsSync: () => true,
+      readFileSync: () => 'not valid json {{{',
+    });
+    expect(() => loadGreatestHitsFile('/data')).toThrow(/Failed to parse greatest-hits.json/);
+  });
+
+  it('throws ActionableError on shape failure (wrong version)', () => {
+    setupMocks({
+      existsSync: () => true,
+      readFileSync: () => JSON.stringify({ version: 2, node_ids: ['acc-beliefs-001'] }),
+    });
+    expect(() => loadGreatestHitsFile('/data')).toThrow(/unexpected shape/);
+  });
+
+  it('throws ActionableError when node_ids contains non-strings', () => {
+    setupMocks({
+      existsSync: () => true,
+      readFileSync: () => JSON.stringify({ version: 1, node_ids: [123, 'acc-beliefs-001'] }),
+    });
+    expect(() => loadGreatestHitsFile('/data')).toThrow(/unexpected shape/);
+  });
+
+  it('happy path — returns Set of IDs from file', () => {
+    setupMocks({
+      existsSync: () => true,
+      readFileSync: () => JSON.stringify({
+        version: 1,
+        generated_at: '2026-07-01T00:00:00Z',
+        node_count: 2,
+        debate_count_threshold: 20,
+        node_ids: ['acc-beliefs-001', 'saf-desires-002'],
+      }),
+    });
+    const result = loadGreatestHitsFile('/data');
+    expect(result).not.toBeNull();
+    expect(result!.has('acc-beliefs-001')).toBe(true);
+    expect(result!.has('saf-desires-002')).toBe(true);
+  });
+
+  it('unknown node IDs are excluded from the Set when knownNodeIds provided', () => {
+    setupMocks({
+      existsSync: () => true,
+      readFileSync: () => JSON.stringify({
+        version: 1,
+        generated_at: '2026-07-01T00:00:00Z',
+        node_count: 2,
+        debate_count_threshold: 20,
+        node_ids: ['acc-beliefs-001', 'stale-node-xyz'],
+      }),
+    });
+    const known = new Set(['acc-beliefs-001']);
+    const result = loadGreatestHitsFile('/data', known);
+    expect(result!.has('acc-beliefs-001')).toBe(true);
+    expect(result!.has('stale-node-xyz')).toBe(false);
   });
 });

--- a/lib/debate/corpusCoverage.ts
+++ b/lib/debate/corpusCoverage.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { ActionableError } from './errors.js';
 import { loadCruxLinksFromAggregated } from './cruxLinkage.js';
+import { getGlobalRecorder } from '../flight-recorder/index.js';
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -137,6 +138,148 @@ export function loadCoverageMap(dataRoot: string): CorpusCoverageMap | null {
   } catch {
     return null;
   }
+}
+
+// ── Greatest-hits exclusion file ──────────────────────────
+
+export interface GreatestHitsFile {
+  version: 1;
+  generated_at: string;
+  node_count: number;
+  debate_count_threshold: number;
+  node_ids: string[];
+}
+
+const GREATEST_HITS_FILE = 'greatest-hits.json';
+
+export function greatestHitsPath(dataRoot: string): string {
+  return path.join(dataRoot, 'calibration', GREATEST_HITS_FILE);
+}
+
+/**
+ * Generate calibration/greatest-hits.json from the corpus coverage map.
+ * No-clobber by default: if the file already exists, throws ActionableError
+ * to protect hand-curation (pass { force: true } to overwrite).
+ * Node IDs are sorted by debate_count descending so the most overused appear first.
+ *
+ * CL binding condition self-cert: (1) flag-On + missing file → ActionableError at
+ * loadGreatestHitsFile call site; (2) this writer validates coverage map exists.
+ */
+export function generateGreatestHitsFile(
+  dataRoot: string,
+  options: { force?: boolean } = {},
+): void {
+  const coverageMap = loadCoverageMap(dataRoot);
+  if (!coverageMap) {
+    throw new ActionableError({
+      goal: 'Generate greatest-hits exclusion file from corpus coverage map',
+      problem: `corpus-coverage.json not found — cannot identify retread nodes`,
+      location: 'generateGreatestHitsFile',
+      nextSteps: [
+        'Run computeCorpusCoverage() and saveCoverageMap() first',
+        `Expected coverage map at: ${coveragePath(dataRoot)}`,
+      ],
+    });
+  }
+
+  const outPath = greatestHitsPath(dataRoot);
+  if (!options.force && fs.existsSync(outPath)) {
+    throw new ActionableError({
+      goal: 'Generate greatest-hits exclusion file',
+      problem: `greatest-hits.json already exists at ${outPath} — will not overwrite a hand-editable file without explicit force`,
+      location: 'generateGreatestHitsFile',
+      nextSteps: [
+        'Pass { force: true } to overwrite (discards any hand edits)',
+        `Or delete the file manually: ${outPath}`,
+        'Or keep the existing file if it reflects your curation',
+      ],
+    });
+  }
+
+  const retreads = Object.entries(coverageMap.node_stats)
+    .filter(([, stats]) => stats.retread_flag)
+    .sort((a, b) => b[1].debate_count - a[1].debate_count)
+    .map(([nodeId]) => nodeId);
+
+  const file: GreatestHitsFile = {
+    version: 1,
+    generated_at: new Date().toISOString(),
+    node_count: retreads.length,
+    debate_count_threshold: coverageMap.debate_count_threshold,
+    node_ids: retreads,
+  };
+
+  const dir = path.join(dataRoot, 'calibration');
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(outPath, JSON.stringify(file, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Load calibration/greatest-hits.json and return a Set of node IDs to exclude.
+ * Returns null when the file does not exist (caller must enforce flag-On + missing → error).
+ * Parse/shape failures throw ActionableError.
+ * Unknown node IDs (not in knownNodeIds) are warned to the flight recorder and skipped.
+ */
+export function loadGreatestHitsFile(
+  dataRoot: string,
+  knownNodeIds?: Set<string>,
+): Set<string> | null {
+  const p = greatestHitsPath(dataRoot);
+  if (!fs.existsSync(p)) return null;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(fs.readFileSync(p, 'utf-8'));
+  } catch (err) {
+    throw new ActionableError({
+      goal: 'Load greatest-hits exclusion file',
+      problem: `Failed to parse greatest-hits.json at ${p}: ${err instanceof Error ? err.message : err}`,
+      location: 'loadGreatestHitsFile',
+      nextSteps: [
+        'Validate the JSON with a linter',
+        `Re-generate via generateGreatestHitsFile({ force: true })`,
+      ],
+    });
+  }
+
+  if (
+    typeof raw !== 'object' || raw === null ||
+    (raw as Record<string, unknown>).version !== 1 ||
+    !Array.isArray((raw as Record<string, unknown>).node_ids) ||
+    !(raw as { node_ids: unknown[] }).node_ids.every((id) => typeof id === 'string')
+  ) {
+    throw new ActionableError({
+      goal: 'Load greatest-hits exclusion file',
+      problem: `greatest-hits.json at ${p} has unexpected shape — expected { version: 1, node_ids: string[] }`,
+      location: 'loadGreatestHitsFile',
+      nextSteps: [
+        'Check the file has not been corrupted',
+        `Re-generate via generateGreatestHitsFile({ force: true })`,
+      ],
+    });
+  }
+
+  const nodeIds = (raw as GreatestHitsFile).node_ids;
+  const exclusionSet = new Set<string>();
+  const unknownIds: string[] = [];
+
+  for (const id of nodeIds) {
+    if (knownNodeIds && !knownNodeIds.has(id)) {
+      unknownIds.push(id);
+    } else {
+      exclusionSet.add(id);
+    }
+  }
+
+  if (unknownIds.length > 0) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'debate-engine', level: 'warn',
+      message: `greatest-hits.json: ${unknownIds.length} unknown node IDs ignored`,
+      data: { unknown_ids: unknownIds.slice(0, 20), total_unknown: unknownIds.length },
+    });
+  }
+
+  return exclusionSet;
 }
 
 // ── Helpers ────────────────────────────────────────────────────

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -986,6 +986,7 @@ export class DebateEngine {
       },
       model_tier: this.config.modelTier,
       protocol_id: this.config.protocolId ?? 'structured',
+      ...(this.config.excludeGreatestHits ? { exclude_greatest_hits: true } : {}),
       diagnostics: {
         enabled: true,
         entries: {},

--- a/lib/debate/debateEngine/internals.ts
+++ b/lib/debate/debateEngine/internals.ts
@@ -88,8 +88,8 @@ export interface DebateConfig {
   enableInsularityIntervention?: boolean;
   /** Enable stagnation-gated diversity-injection round (t/1280). Off by default — experiment flag. */
   enableDiversityRound?: boolean;
-  /** Enable corpus-coverage anti-recurrence: downweight retread nodes, boost underexplored tail (t/1438). */
-  enableCorpusCoverage?: boolean;
+  /** Exclude greatest-hits (retread) nodes from debate node selection (t/1438). Requires calibration/greatest-hits.json. */
+  excludeGreatestHits?: boolean;
   /** Inject comp-linguist per-POV, per-BDI situation register-statements at setup (t/1450 experiment). Off by default. */
   enableSituationStatements?: boolean;
   /** Enable over-generate/select/rewrite pipeline: N=3 drafts, dedup, greedy top-K, rewrite, coherence gate (t/1581). */

--- a/lib/debate/debateEngine/taxonomyContext.ts
+++ b/lib/debate/debateEngine/taxonomyContext.ts
@@ -10,7 +10,8 @@ import { type TaxonomyContext, formatTaxonomyContext, computeInjectionManifest }
 import { resolveRepoRoot, resolveDataRoot, loadSituationStatements } from '../taxonomyLoader.js';
 import { scoreNodeRelevance, scoreNodesLexical, scoreNodesViaAN, selectRelevantNodes, selectRelevantSituationNodes, buildRelevanceQuery, computePolicymakerRelevanceBoost, type RelevanceOptions, type ANClaimEmbedding, type ScoredPovNode, filterByTopicConstraints } from '../taxonomyRelevance.js';
 import { formatRecentTranscript } from '../helpers.js';
-import { loadCoverageMap } from '../corpusCoverage.js';
+import { loadGreatestHitsFile } from '../corpusCoverage.js';
+import { ActionableError } from '../errors.js';
 import { filterByExclusionAbsolute, SCOPE_BOUNDARY_THRESHOLD } from '../exclusionGuard.js';
 import { getGlobalRecorder } from '../../flight-recorder/index.js';
 
@@ -262,30 +263,38 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
     };
   }
 
-  // Load corpus coverage map when enabled (t/1438)
-  if (engine.config.enableCorpusCoverage) {
-    try {
-      const __dir = path.dirname(fileURLToPath(import.meta.url));
-      const repoRoot = resolveRepoRoot(__dir);
-      const dataRoot = resolveDataRoot(repoRoot);
-      const coverageMap = loadCoverageMap(dataRoot);
-      if (coverageMap) {
-        relevanceOpts.corpusCoverage = { nodeStats: coverageMap.node_stats };
-      }
-    } catch (err) {
-      getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: 'Corpus coverage map load failed — proceeding without', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+  // Load greatest-hits exclusion set when enabled (t/1438).
+  // Flag-On + missing file = ActionableError (CL binding condition #1 self-cert).
+  if (engine.config.excludeGreatestHits) {
+    const __dir = path.dirname(fileURLToPath(import.meta.url));
+    const repoRoot = resolveRepoRoot(__dir);
+    const dataRoot = resolveDataRoot(repoRoot);
+    const knownNodeIds = new Set(ctx.povNodes.map(n => n.id));
+    const exclusionSet = loadGreatestHitsFile(dataRoot, knownNodeIds);
+    if (!exclusionSet) {
+      throw new ActionableError({
+        goal: 'Apply greatest-hits node exclusion for debate setup',
+        problem: 'excludeGreatestHits is enabled but calibration/greatest-hits.json is missing',
+        location: 'getRelevantTaxonomyContext',
+        nextSteps: [
+          'Generate the file: call generateGreatestHitsFile(dataRoot) from corpusCoverage.ts',
+          `Expected at: ${path.join(dataRoot, 'calibration', 'greatest-hits.json')}`,
+          'Or set excludeGreatestHits: false in the debate config to disable',
+        ],
+      });
     }
+    relevanceOpts.greatestHitsExclude = exclusionSet;
   }
 
   const scoredPovRaw = selectRelevantNodes(ctx.povNodes, scores, relevanceOpts);
 
-  // Log corpus coverage adjustments (t/1438)
-  const ccResult = (scoredPovRaw as ScoredPovNode[] & { _corpusCoverage?: { downweightedCount: number; boostedCount: number; downweightedNodeIds: string[]; boostedNodeIds: string[] } })._corpusCoverage;
-  if (ccResult && (ccResult.downweightedCount > 0 || ccResult.boostedCount > 0)) {
+  // Log greatest-hits exclusion (t/1438)
+  const ghResult = (scoredPovRaw as ScoredPovNode[] & { _greatestHits?: { excludedCount: number; excludedNodeIds: string[] } })._greatestHits;
+  if (ghResult && ghResult.excludedCount > 0) {
     getGlobalRecorder()?.record({
       type: 'turn.taxonomy_inject', component: 'debate-engine', level: 'info',
-      message: `Corpus coverage: ${ccResult.downweightedCount} retreads downweighted, ${ccResult.boostedCount} nodes boosted`,
-      data: ccResult,
+      message: `Greatest-hits exclusion: ${ghResult.excludedCount} nodes pre-filtered`,
+      data: ghResult,
     });
   }
 

--- a/lib/debate/taxonomyRelevance.test.ts
+++ b/lib/debate/taxonomyRelevance.test.ts
@@ -917,168 +917,123 @@ describe('selectRelevantNodes — POV diversity floor', () => {
   });
 });
 
-// ── Corpus coverage in selectRelevantNodes (t/1278) ──────────
+// ── Greatest-hits hard exclusion in selectRelevantNodes (t/1438) ──────────
 
-describe('selectRelevantNodes — corpus coverage', () => {
-  it('downweights retread nodes below threshold', () => {
+describe('selectRelevantNodes — greatestHitsExclude', () => {
+  it('pre-filters excluded nodes — they never appear in result', () => {
     const nodes = [
       makeNode('acc-beliefs-001', 'Beliefs'),
       makeNode('acc-beliefs-002', 'Beliefs'),
-      makeNode('acc-beliefs-003', 'Beliefs'),
-      makeNode('acc-beliefs-004', 'Beliefs'),
     ];
-
     const scores = new Map([
-      ['acc-beliefs-001', 0.60],  // retread — will become 0.36 (below 0.48)
-      ['acc-beliefs-002', 0.55],  // not retread
-      ['acc-beliefs-003', 0.50],  // not retread
-      ['acc-beliefs-004', 0.49],  // not retread
+      ['acc-beliefs-001', 0.8],
+      ['acc-beliefs-002', 0.8],
     ]);
-
     const result = selectRelevantNodes(nodes, scores, {
-      embeddingThreshold: 0.48,
+      threshold: 0.5,
       minPerCategory: 0,
       minPerPov: 0,
-      corpusCoverage: {
-        nodeStats: {
-          'acc-beliefs-001': { debate_count: 25, crux_link_count: 0, retread_flag: true },
-        },
-        retreadMultiplier: 0.6,
-      },
+      greatestHitsExclude: new Set(['acc-beliefs-001']),
     });
-
-    const ids = result.map(r => r.node.id);
-    // acc-beliefs-001 had score 0.60 * 0.6 = 0.36, now below threshold
+    const ids = result.map(s => s.node.id);
     expect(ids).not.toContain('acc-beliefs-001');
     expect(ids).toContain('acc-beliefs-002');
-    expect(ids).toContain('acc-beliefs-003');
   });
 
-  it('never downweights fault-line nodes (crux_link_count >= 2)', () => {
+  it('excluded node cannot re-enter via minPerCategory refill (t/1981)', () => {
+    // Only one Beliefs node exists, and it is excluded.
+    // minPerCategory=3 would normally force it back in — the pre-filter must block that.
+    const nodes = [makeNode('acc-beliefs-001', 'Beliefs')];
+    const scores = new Map([['acc-beliefs-001', 0.9]]);
+    const result = selectRelevantNodes(nodes, scores, {
+      threshold: 0.5,
+      minPerCategory: 3,
+      minPerPov: 0,
+      greatestHitsExclude: new Set(['acc-beliefs-001']),
+    });
+    expect(result.map(s => s.node.id)).not.toContain('acc-beliefs-001');
+  });
+
+  it('excluded node cannot re-enter via POV diversity floor (t/1981)', () => {
+    // Node is the only acc-* node; minPerPov=2 would normally pull it in.
+    const nodes = [makeNode('acc-beliefs-001', 'Beliefs')];
+    const scores = new Map([['acc-beliefs-001', 0.9]]);
+    const result = selectRelevantNodes(nodes, scores, {
+      threshold: 0.5,
+      minPerCategory: 0,
+      minPerPov: 2,
+      greatestHitsExclude: new Set(['acc-beliefs-001']),
+    });
+    expect(result.map(s => s.node.id)).not.toContain('acc-beliefs-001');
+  });
+
+  it('attaches _greatestHits diagnostics', () => {
     const nodes = [
       makeNode('acc-beliefs-001', 'Beliefs'),
       makeNode('acc-beliefs-002', 'Beliefs'),
-      makeNode('acc-beliefs-003', 'Beliefs'),
     ];
-
     const scores = new Map([
-      ['acc-beliefs-001', 0.55],  // fault-line — retread_flag is false
-      ['acc-beliefs-002', 0.50],
-      ['acc-beliefs-003', 0.49],
+      ['acc-beliefs-001', 0.8],
+      ['acc-beliefs-002', 0.8],
     ]);
-
     const result = selectRelevantNodes(nodes, scores, {
-      embeddingThreshold: 0.48,
+      threshold: 0.5,
       minPerCategory: 0,
       minPerPov: 0,
-      corpusCoverage: {
-        nodeStats: {
-          'acc-beliefs-001': { debate_count: 30, crux_link_count: 3, retread_flag: false },
-        },
-      },
+      greatestHitsExclude: new Set(['acc-beliefs-001']),
     });
-
-    const ids = result.map(r => r.node.id);
-    // Fault-line: retread_flag is false, so no downweight applied
-    expect(ids).toContain('acc-beliefs-001');
-    const node001 = result.find(r => r.node.id === 'acc-beliefs-001');
-    expect(node001!.score).toBe(0.55);
+    const diag = (result as ScoredPovNode[] & { _greatestHits?: import('./taxonomyRelevance.js').GreatestHitsExcludeResult })._greatestHits;
+    expect(diag).toBeDefined();
+    expect(diag!.excludedNodeIds).toContain('acc-beliefs-001');
+    expect(diag!.excludedCount).toBe(1);
   });
 
-  it('boosts low-coverage nodes above relevance floor', () => {
-    const nodes = [
-      makeNode('acc-beliefs-001', 'Beliefs'),
-      makeNode('acc-beliefs-002', 'Beliefs'),
-      makeNode('acc-beliefs-003', 'Beliefs'),
-      makeNode('acc-beliefs-004', 'Beliefs'),
-    ];
-
-    // Node 004 is just below threshold but low-coverage — boost should push above
-    const scores = new Map([
-      ['acc-beliefs-001', 0.55],
-      ['acc-beliefs-002', 0.50],
-      ['acc-beliefs-003', 0.49],
-      ['acc-beliefs-004', 0.46],  // below 0.48 but above floor (0.48*0.5=0.24)
-    ]);
-
+  it('IDs not in povNodes are silently ignored — no diagnostic entry', () => {
+    const nodes = [makeNode('acc-beliefs-002', 'Beliefs')];
+    const scores = new Map([['acc-beliefs-002', 0.8]]);
     const result = selectRelevantNodes(nodes, scores, {
-      embeddingThreshold: 0.48,
+      threshold: 0.5,
       minPerCategory: 0,
       minPerPov: 0,
-      corpusCoverage: {
-        nodeStats: {
-          'acc-beliefs-004': { debate_count: 1, crux_link_count: 0, retread_flag: false },
-        },
-        coverageBoost: 0.04,
-        lowCoverageThreshold: 5,
-      },
+      greatestHitsExclude: new Set(['nonexistent-node-999']),
     });
+    const diag = (result as ScoredPovNode[] & { _greatestHits?: import('./taxonomyRelevance.js').GreatestHitsExcludeResult })._greatestHits;
+    expect(diag).toBeUndefined();
+    expect(result.map(s => s.node.id)).toContain('acc-beliefs-002');
+  });
+});
 
-    const ids = result.map(r => r.node.id);
-    // 0.46 + 0.04 = 0.50 — above threshold
-    expect(ids).toContain('acc-beliefs-004');
+// ── wellTested hardExclude re-entry prevention (t/1981) ──────────
+
+describe('selectRelevantNodes — wellTested hardExclude re-entry (t/1981)', () => {
+  it('hard-excluded well_tested node cannot re-enter via minPerCategory refill', () => {
+    const node = {
+      ...makeNode('acc-beliefs-001', 'Beliefs'),
+      graph_attributes: { debate_tested: { tier: 'well_tested', last_tested: new Date().toISOString(), record: [], revisions: [], sort_key: 0, engagements: 1, challenges: 0, held: 0, weakened: 0, description_hash: 'test' } },
+    } as unknown as import('./taxonomyTypes.js').PovNode;
+    const scores = new Map([['acc-beliefs-001', 0.9]]);
+    const result = selectRelevantNodes([node], scores, {
+      threshold: 0.5,
+      minPerCategory: 3,
+      minPerPov: 0,
+      wellTested: { excludeWellTested: true },
+    });
+    expect(result.map(s => s.node.id)).not.toContain('acc-beliefs-001');
   });
 
-  it('caps coverage boost promotions', () => {
-    // Create many low-coverage nodes
-    const nodes = Array.from({ length: 12 }, (_, i) =>
-      makeNode(`acc-beliefs-${String(i).padStart(3, '0')}`, 'Beliefs'));
-
-    const scores = new Map(
-      nodes.map((n, i) => [n.id, i < 3 ? 0.55 : 0.46] as [string, number]),
-    );
-
-    const nodeStats: Record<string, { debate_count: number; crux_link_count: number; retread_flag: boolean }> = {};
-    for (let i = 3; i < 12; i++) {
-      nodeStats[`acc-beliefs-${String(i).padStart(3, '0')}`] = { debate_count: 1, crux_link_count: 0, retread_flag: false };
-    }
-
-    const result = selectRelevantNodes(nodes, scores, {
-      embeddingThreshold: 0.48,
+  it('hard-excluded well_tested node cannot re-enter via POV diversity floor', () => {
+    const node = {
+      ...makeNode('acc-beliefs-001', 'Beliefs'),
+      graph_attributes: { debate_tested: { tier: 'well_tested', last_tested: new Date().toISOString(), record: [], revisions: [], sort_key: 0, engagements: 1, challenges: 0, held: 0, weakened: 0, description_hash: 'test' } },
+    } as unknown as import('./taxonomyTypes.js').PovNode;
+    const scores = new Map([['acc-beliefs-001', 0.9]]);
+    const result = selectRelevantNodes([node], scores, {
+      threshold: 0.5,
       minPerCategory: 0,
-      minPerPov: 0,
-      corpusCoverage: {
-        nodeStats,
-        coverageBoost: 0.04,
-        maxCoveragePromotions: 3,
-      },
+      minPerPov: 2,
+      wellTested: { excludeWellTested: true },
     });
-
-    const diagnostics = (result as ScoredPovNode[] & { _corpusCoverage?: import('./taxonomyRelevance.js').CorpusCoverageResult })._corpusCoverage;
-    expect(diagnostics).toBeDefined();
-    // Only 3 promoted despite 9 candidates
-    expect(diagnostics!.boostedCount).toBe(3);
-  });
-
-  it('attaches _corpusCoverage diagnostics', () => {
-    const nodes = [
-      makeNode('acc-beliefs-001', 'Beliefs'),
-      makeNode('acc-beliefs-002', 'Beliefs'),
-      makeNode('acc-beliefs-003', 'Beliefs'),
-    ];
-
-    const scores = new Map([
-      ['acc-beliefs-001', 0.60],
-      ['acc-beliefs-002', 0.55],
-      ['acc-beliefs-003', 0.30],  // low-coverage candidate above floor
-    ]);
-
-    const result = selectRelevantNodes(nodes, scores, {
-      embeddingThreshold: 0.48,
-      minPerCategory: 0,
-      minPerPov: 0,
-      corpusCoverage: {
-        nodeStats: {
-          'acc-beliefs-001': { debate_count: 25, crux_link_count: 0, retread_flag: true },
-          'acc-beliefs-003': { debate_count: 2, crux_link_count: 0, retread_flag: false },
-        },
-      },
-    });
-
-    const diagnostics = (result as ScoredPovNode[] & { _corpusCoverage?: import('./taxonomyRelevance.js').CorpusCoverageResult })._corpusCoverage;
-    expect(diagnostics).toBeDefined();
-    expect(diagnostics!.downweightedNodeIds).toContain('acc-beliefs-001');
-    expect(diagnostics!.boostedNodeIds).toContain('acc-beliefs-003');
+    expect(result.map(s => s.node.id)).not.toContain('acc-beliefs-001');
   });
 });
 

--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -47,23 +47,10 @@ export interface RelevanceOptions {
   minPerPov?: number;
   /** Branch-aware situation selection — boosts nodes in topic-relevant root categories. */
   situationBranchBoost?: SituationBranchBoostConfig;
-  /** Corpus coverage stats — downweights retread nodes and boosts low-coverage nodes (t/1278). */
-  corpusCoverage?: CorpusCoverageConfig;
+  /** Greatest-hits exclusion set — pre-filters retread nodes before scoring (t/1438). */
+  greatestHitsExclude?: Set<string>;
   /** Well-tested exclusion lever — downweights or excludes well_tested nodes (Phase 3, t/1587). */
   wellTested?: WellTestedConfig;
-}
-
-export interface CorpusCoverageConfig {
-  /** Node coverage stats from computeCorpusCoverage(). */
-  nodeStats: Record<string, { debate_count: number; crux_link_count: number; retread_flag: boolean }>;
-  /** Score multiplier for retread nodes (default 0.6). */
-  retreadMultiplier?: number;
-  /** Boost for low-coverage nodes above relevance floor (default 0.04). */
-  coverageBoost?: number;
-  /** debate_count below which a node is considered low-coverage (default 5). */
-  lowCoverageThreshold?: number;
-  /** Max low-coverage promotions to apply (default 8). */
-  maxCoveragePromotions?: number;
 }
 
 export interface SituationBranchBoostConfig {
@@ -113,11 +100,9 @@ export interface LineageBoostResult {
   promotedCount: number;
 }
 
-export interface CorpusCoverageResult {
-  downweightedNodeIds: string[];
-  boostedNodeIds: string[];
-  downweightedCount: number;
-  boostedCount: number;
+export interface GreatestHitsExcludeResult {
+  excludedNodeIds: string[];
+  excludedCount: number;
 }
 
 export interface WellTestedConfig {
@@ -249,55 +234,10 @@ export function selectRelevantNodes(
     _lineageBoostResult = { boostedNodeIds: boostedIds, promotedNodeIds: promotedIds, promotedCount: promotedIds.length };
   }
 
-  // Apply corpus coverage adjustments (t/1278)
-  let _corpusCoverageResult: CorpusCoverageResult | undefined;
-  if (opts.corpusCoverage) {
-    const cc = opts.corpusCoverage;
-    const retreadMult = cc.retreadMultiplier ?? 0.6;
-    const covBoost = cc.coverageBoost ?? 0.04;
-    const lowThresh = cc.lowCoverageThreshold ?? 5;
-    const maxPromos = cc.maxCoveragePromotions ?? 8;
-    const relevanceFloor = threshold * 0.5;
-
-    const downweightedIds: string[] = [];
-    const boostCandidates: { id: string; score: number }[] = [];
-
-    for (const node of povNodes) {
-      const stats = cc.nodeStats[node.id];
-      if (!stats) continue;
-
-      const current = effectiveScores.get(node.id) ?? 0;
-
-      // Downweight retreads (high debate_count, low crux links) — never touch fault-lines
-      if (stats.retread_flag) {
-        effectiveScores.set(node.id, current * retreadMult);
-        downweightedIds.push(node.id);
-      }
-
-      // Coverage-seeking boost for underexplored nodes above relevance floor
-      if (stats.debate_count < lowThresh && current >= relevanceFloor && !stats.retread_flag) {
-        boostCandidates.push({ id: node.id, score: current });
-      }
-    }
-
-    // Apply coverage boost, capped
-    boostCandidates.sort((a, b) => b.score - a.score);
-    const boostedIds: string[] = [];
-    for (let i = 0; i < Math.min(maxPromos, boostCandidates.length); i++) {
-      const { id } = boostCandidates[i];
-      effectiveScores.set(id, (effectiveScores.get(id) ?? 0) + covBoost);
-      boostedIds.push(id);
-    }
-
-    if (downweightedIds.length > 0 || boostedIds.length > 0) {
-      _corpusCoverageResult = {
-        downweightedNodeIds: downweightedIds,
-        boostedNodeIds: boostedIds,
-        downweightedCount: downweightedIds.length,
-        boostedCount: boostedIds.length,
-      };
-    }
-  }
+  // Pre-filter set: well-tested hard-excludes (t/1981 leak fix) + greatest-hits (t/1438).
+  // Building as a pre-filter ensures excluded nodes can't re-enter via minPerCategory refill
+  // or POV-diversity floor (the former score=0 approach had both leak paths).
+  const preExcludeSet = new Set<string>();
 
   // Apply well-tested exclusion lever (Phase 3, t/1587)
   let _wellTestedResult: WellTestedExclusionResult | undefined;
@@ -326,7 +266,7 @@ export function selectRelevantNodes(
 
       const current = effectiveScores.get(node.id) ?? 0;
       if (hardExclude) {
-        effectiveScores.set(node.id, 0);
+        preExcludeSet.add(node.id);
         excludedIds.push(node.id);
       } else {
         effectiveScores.set(node.id, current * mult);
@@ -345,14 +285,21 @@ export function selectRelevantNodes(
     }
   }
 
-  // Remove hardExcluded nodes from the candidate pool before grouping — score-0
-  // is insufficient because minPerCategory refill and POV-diversity floor pick by
-  // top-score regardless of threshold, so score-0 nodes can re-enter (t/1981).
-  const hardExcludedIds: Set<string> = _wellTestedResult?.excludedNodeIds?.length
-    ? new Set(_wellTestedResult.excludedNodeIds)
-    : new Set();
-  const candidateNodes = hardExcludedIds.size > 0
-    ? povNodes.filter(n => !hardExcludedIds.has(n.id))
+  // Apply greatest-hits exclusion (t/1438) — adds to preExcludeSet before grouping.
+  let _greatestHitsResult: GreatestHitsExcludeResult | undefined;
+  if (opts.greatestHitsExclude && opts.greatestHitsExclude.size > 0) {
+    const excludedNodeIds = povNodes
+      .filter(n => opts.greatestHitsExclude!.has(n.id))
+      .map(n => n.id);
+    for (const id of excludedNodeIds) preExcludeSet.add(id);
+    if (excludedNodeIds.length > 0) {
+      _greatestHitsResult = { excludedNodeIds, excludedCount: excludedNodeIds.length };
+    }
+  }
+
+  // Filter before grouping — excluded nodes cannot re-enter via minPerCategory or POV floor.
+  const activePovNodes = preExcludeSet.size > 0
+    ? povNodes.filter(n => !preExcludeSet.has(n.id))
     : povNodes;
 
   // Group by category
@@ -362,7 +309,7 @@ export function selectRelevantNodes(
     'Intentions': [],
   };
 
-  for (const node of candidateNodes) {
+  for (const node of activePovNodes) {
     const cat = node.category || 'Intentions';
     const score = effectiveScores.get(node.id) || 0;
     (groups[cat] ?? groups['Intentions']).push({ node, score });
@@ -394,7 +341,7 @@ export function selectRelevantNodes(
       const count = povCounts[pov];
       if (count >= minPov) continue;
       const deficit = minPov - count;
-      const candidates = candidateNodes
+      const candidates = activePovNodes
         .filter(n => n.id.startsWith(prefix) && !selectedIds.has(n.id))
         .map(n => ({ node: n, score: effectiveScores.get(n.id) || 0 }))
         .sort((a, b) => b.score - a.score);
@@ -437,8 +384,8 @@ export function selectRelevantNodes(
   if (_povDiversityResult) {
     (sliced as ScoredPovNode[] & { _povDiversity?: PovDiversityResult })._povDiversity = _povDiversityResult;
   }
-  if (_corpusCoverageResult) {
-    (sliced as ScoredPovNode[] & { _corpusCoverage?: CorpusCoverageResult })._corpusCoverage = _corpusCoverageResult;
+  if (_greatestHitsResult) {
+    (sliced as ScoredPovNode[] & { _greatestHits?: GreatestHitsExcludeResult })._greatestHits = _greatestHitsResult;
   }
   if (_wellTestedResult) {
     (sliced as ScoredPovNode[] & { _wellTested?: WellTestedExclusionResult })._wellTested = _wellTestedResult;

--- a/lib/debate/types/session.ts
+++ b/lib/debate/types/session.ts
@@ -320,6 +320,8 @@ export interface DebateSession {
   model_tier?: ModelTier;
   /** Debate protocol format. Absent in older debates (defaults to 'structured'). */
   protocol_id?: string;
+  /** Exclude greatest-hits (retread) nodes from selection for this debate (t/1438). Absent ⇒ false. */
+  exclude_greatest_hits?: boolean;
   /** Legacy config object from older saved debates. */
   config?: Record<string, unknown>;
   /** AI temperature for this debate (0.0-1.0). Absent uses system default. */


### PR DESCRIPTION
## Summary

- Replaces `enableCorpusCoverage` soft downweight with hard array-level pre-filter using `calibration/greatest-hits.json`
- `loadGreatestHitsFile`: parse/shape failures -> `ActionableError`; unknown node IDs -> flight-recorder warn + skip (CL binding conditions, t/1438#17)
- Converts `wellTested` `hardExclude` from `score=0` to `preExcludeSet` (t/1981) -- eliminates re-entry via `minPerCategory` refill and POV diversity floor
- Typed `exclude_greatest_hits` field on `DebateSession` (snake_case; TE + DebateUI contract, t/1980#2)
- Removes `CorpusCoverageConfig`/`CorpusCoverageResult`; replaces with `GreatestHitsExcludeResult`
- Verify gate: 2737/2751 pass; remaining 3 failures are pre-existing `qbafBridge.test.ts` (tsx not in worktree)

## Test plan

- [ ] `npx vitest run taxonomyRelevance.test.ts` -- new `greatestHitsExclude` describe (5 tests) + wellTested re-entry (2 tests) all pass
- [ ] `npx vitest run corpusCoverage.test.ts` -- `generateGreatestHitsFile` + `loadGreatestHitsFile` tests (7 tests) pass
- [ ] CI ci-gate green before self-merge

Closes t/1438