### PR TITLE
ci: revert merge_group trigger — merge queue is org-only, unavailable here (t/1968)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,6 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-  # merge_group: fires when a PR is added to the GitHub merge queue (t/1968). The
-  # queue tests each PR against the PROJECTED merged state — restores strict=true's
-  # "tested against current main" guarantee without the up-to-date rebase livelock.
-  # No job edits needed: `changes` (if: event==pull_request) SKIPS on merge_group,
-  # so every code job's `github.event_name != 'pull_request'` guard runs the FULL
-  # suite unfiltered, and `ci-gate` (the queue's required check) aggregates them.
-  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
ci: revert merge_group trigger — merge queue is org-only, unavailable here (t/1968)

Reverts #175. GitHub merge queue is not available on this repo (user-owned;
merge queue requires organization ownership), so the merge_group trigger can
never fire — dead config that implies an unavailable capability. Removing it
per TL (t/1968#9). strict=false + single ci-gate is the accepted steady state;
re-add this trigger only if the repo moves to a GitHub org.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Technical Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
