### PR TITLE
refactor(diag): decompose B4 complexity — 8 heaviest remaining diagnostics files (t/1909)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.tsx
@@ -74,15 +74,20 @@ function buildTaxonomySection(label: string, nodes: TaxNode[]): string {
   return lines.join('\n');
 }
 
-function buildDebateSnapshot(debate: DebateSession, taxonomies?: Map<string, TaxNode[]>): string {
+type ConvergenceSignal = NonNullable<DebateSession['convergence_signals']>[number];
+
+function snapshotHeaderLines(debate: DebateSession): string[] {
   const lines: string[] = [];
   lines.push(`# Debate: ${debate.topic}`);
   const povers = debate.active_povers ?? [];
   lines.push(`Debaters: ${povers.map(p => POVER_INFO[p as keyof typeof POVER_INFO]?.label ?? p).join(', ')}`);
   lines.push(`Transcript entries: ${debate.transcript.length}`);
   lines.push(`Argument network: ${debate.argument_network?.nodes.length ?? 0} nodes, ${debate.argument_network?.edges.length ?? 0} edges`);
+  return lines;
+}
 
-  lines.push('\n## Transcript Summary');
+function transcriptSummaryLines(debate: DebateSession): string[] {
+  const lines: string[] = ['\n## Transcript Summary'];
   for (const e of debate.transcript) {
     const speaker = POVER_INFO[e.speaker as keyof typeof POVER_INFO]?.label ?? e.speaker;
     const meta = e.metadata as Record<string, unknown> | undefined;
@@ -91,7 +96,11 @@ function buildDebateSnapshot(debate: DebateSession, taxonomies?: Map<string, Tax
     lines.push(`\n### ${e.id} — ${speaker} (${e.type})${moves}`);
     lines.push(preview);
   }
+  return lines;
+}
 
+function argNetworkLines(debate: DebateSession): string[] {
+  const lines: string[] = [];
   if (debate.argument_network && debate.argument_network.nodes.length > 0) {
     lines.push('\n## Argument Network Nodes');
     for (const n of debate.argument_network.nodes) {
@@ -107,7 +116,11 @@ function buildDebateSnapshot(debate: DebateSession, taxonomies?: Map<string, Tax
       lines.push(`- ${e.source} → ${e.target}: ${label}`);
     }
   }
+  return lines;
+}
 
+function commitmentLines(debate: DebateSession): string[] {
+  const lines: string[] = [];
   if (debate.commitments && Object.keys(debate.commitments).length > 0) {
     lines.push('\n## Commitments');
     for (const [speaker, store] of Object.entries(debate.commitments)) {
@@ -118,25 +131,46 @@ function buildDebateSnapshot(debate: DebateSession, taxonomies?: Map<string, Tax
       if (store.challenged.length) lines.push(`Challenged (${store.challenged.length}): ${store.challenged.slice(0, 5).join('; ')}${store.challenged.length > 5 ? '...' : ''}`);
     }
   }
+  return lines;
+}
 
+function formatConvergenceSnapshotLine(label: string, sig: ConvergenceSignal): string {
+  return `${label}: collab=${((sig.move_polarity?.ratio ?? 0) * 100).toFixed(0)}%, dialectical engagement=${((sig.dialectical_engagement?.ratio ?? 0) * 100).toFixed(0)}%, argument redundancy=${((sig.argument_redundancy?.max_self_overlap ?? 0) * 100).toFixed(0)}%, concession=${sig.concession_opportunity?.outcome ?? 'none'}, drift=${((sig.position_drift?.drift ?? 0) * 100).toFixed(0)}%`;
+}
+
+function convergenceSnapshotLines(debate: DebateSession): string[] {
+  const lines: string[] = [];
   if (debate.convergence_signals && debate.convergence_signals.length > 0) {
     lines.push('\n## Convergence Signals (latest per speaker)');
-    const bySpeaker = new Map<string, typeof debate.convergence_signals[0]>();
+    const bySpeaker = new Map<string, ConvergenceSignal>();
     for (const s of debate.convergence_signals) bySpeaker.set(s.speaker, s);
     for (const [speaker, sig] of bySpeaker) {
       const label = POVER_INFO[speaker as keyof typeof POVER_INFO]?.label ?? speaker;
-      lines.push(`${label}: collab=${((sig.move_polarity?.ratio ?? 0) * 100).toFixed(0)}%, dialectical engagement=${((sig.dialectical_engagement?.ratio ?? 0) * 100).toFixed(0)}%, argument redundancy=${((sig.argument_redundancy?.max_self_overlap ?? 0) * 100).toFixed(0)}%, concession=${sig.concession_opportunity?.outcome ?? 'none'}, drift=${((sig.position_drift?.drift ?? 0) * 100).toFixed(0)}%`);
+      lines.push(formatConvergenceSnapshotLine(label, sig));
     }
   }
+  return lines;
+}
 
-  if (taxonomies) {
-    const povLabels: Record<string, string> = Object.fromEntries(Object.entries(POV_META).map(([k, v]) => [k, v.label]));
-    for (const [pov, nodes] of taxonomies) {
-      lines.push(buildTaxonomySection(povLabels[pov] ?? pov, nodes));
-    }
+function taxonomyLines(taxonomies?: Map<string, TaxNode[]>): string[] {
+  if (!taxonomies) return [];
+  const lines: string[] = [];
+  const povLabels: Record<string, string> = Object.fromEntries(Object.entries(POV_META).map(([k, v]) => [k, v.label]));
+  for (const [pov, nodes] of taxonomies) {
+    lines.push(buildTaxonomySection(povLabels[pov] ?? pov, nodes));
   }
+  return lines;
+}
 
-  return lines.join('\n');
+function buildDebateSnapshot(debate: DebateSession, taxonomies?: Map<string, TaxNode[]>): string {
+  return [
+    ...snapshotHeaderLines(debate),
+    ...transcriptSummaryLines(debate),
+    ...argNetworkLines(debate),
+    ...commitmentLines(debate),
+    ...convergenceSnapshotLines(debate),
+    ...taxonomyLines(taxonomies),
+  ].join('\n');
 }
 
 function buildSystemPrompt(debate: DebateSession, taxonomies?: Map<string, TaxNode[]>): string {
@@ -376,6 +410,17 @@ function buildSuggestText(debate: DebateSession, selectedEntry: string | null): 
   return suggestions.join('\n');
 }
 
+function formatConvergenceStatusBlock(label: string, sig: ConvergenceSignal): string[] {
+  return [
+    `\n**${label}:**`,
+    `- Collaborative moves: ${((sig.move_polarity?.ratio ?? 0) * 100).toFixed(0)}%`,
+    `- Dialectical engagement: ${((sig.dialectical_engagement?.ratio ?? 0) * 100).toFixed(0)}%`,
+    `- Argument redundancy: ${((sig.argument_redundancy?.max_self_overlap ?? 0) * 100).toFixed(0)}%`,
+    `- Concession: ${sig.concession_opportunity?.outcome ?? 'none'}`,
+    `- Position drift: ${((sig.position_drift?.drift ?? 0) * 100).toFixed(0)}%`,
+  ];
+}
+
 const SLASH_COMMANDS: Record<string, { description: string; handler: (debate: DebateSession, selectedEntry?: string | null) => string }> = {
   '/help': {
     description: 'Show available commands',
@@ -424,22 +469,21 @@ const SLASH_COMMANDS: Record<string, { description: string; handler: (debate: De
     handler: (debate) => {
       const signals = debate.convergence_signals;
       if (!signals || signals.length === 0) return 'No convergence signals recorded yet.';
-      const bySpeaker = new Map<string, typeof signals[0]>();
+      const bySpeaker = new Map<string, ConvergenceSignal>();
       for (const s of signals) bySpeaker.set(s.speaker, s);
       const lines = ['**Convergence Status:**'];
       for (const [speaker, sig] of bySpeaker) {
         const label = POVER_INFO[speaker as keyof typeof POVER_INFO]?.label ?? speaker;
-        lines.push(`\n**${label}:**`);
-        lines.push(`- Collaborative moves: ${((sig.move_polarity?.ratio ?? 0) * 100).toFixed(0)}%`);
-        lines.push(`- Dialectical engagement: ${((sig.dialectical_engagement?.ratio ?? 0) * 100).toFixed(0)}%`);
-        lines.push(`- Argument redundancy: ${((sig.argument_redundancy?.max_self_overlap ?? 0) * 100).toFixed(0)}%`);
-        lines.push(`- Concession: ${sig.concession_opportunity?.outcome ?? 'none'}`);
-        lines.push(`- Position drift: ${((sig.position_drift?.drift ?? 0) * 100).toFixed(0)}%`);
+        lines.push(...formatConvergenceStatusBlock(label, sig));
       }
       return lines.join('\n');
     },
   },
 };
+
+function countSourceEdges(net: DebateSession['argument_network'], id: string, type: 'attacks' | 'supports') {
+  return net?.edges.filter(e => e.source === id && e.type === type) ?? [];
+}
 
 function handleCompareCommand(debate: DebateSession, args: string): string | null {
   const match = args.match(/\/compare\s+(\S+)\s+(\S+)/i);
@@ -451,10 +495,10 @@ function handleCompareCommand(debate: DebateSession, args: string): string | nul
   const s1 = POVER_INFO[e1.speaker as keyof typeof POVER_INFO]?.label ?? e1.speaker;
   const s2 = POVER_INFO[e2.speaker as keyof typeof POVER_INFO]?.label ?? e2.speaker;
   const net = debate.argument_network;
-  const e1Attacks = net?.edges.filter(e => e.source === e1.id && e.type === 'attacks') ?? [];
-  const e2Attacks = net?.edges.filter(e => e.source === e2.id && e.type === 'attacks') ?? [];
-  const e1Supports = net?.edges.filter(e => e.source === e1.id && e.type === 'supports') ?? [];
-  const e2Supports = net?.edges.filter(e => e.source === e2.id && e.type === 'supports') ?? [];
+  const e1Attacks = countSourceEdges(net, e1.id, 'attacks');
+  const e2Attacks = countSourceEdges(net, e2.id, 'attacks');
+  const e1Supports = countSourceEdges(net, e1.id, 'supports');
+  const e2Supports = countSourceEdges(net, e2.id, 'supports');
   return [
     `**Comparing ${e1.id} vs ${e2.id}:**`,
     '',
@@ -469,6 +513,350 @@ function handleCompareCommand(debate: DebateSession, args: string): string | nul
     `**${e1.id}** preview: ${e1.content.slice(0, 120)}...`,
     `**${e2.id}** preview: ${e2.content.slice(0, 120)}...`,
   ].join('\n');
+}
+
+function pickBackend(model: string): string {
+  return model.startsWith('claude') ? 'claude'
+    : model.startsWith('groq') ? 'groq'
+    : model.startsWith('openai') ? 'openai'
+    : 'gemini';
+}
+
+async function ensureApiKey(backend: string): Promise<void> {
+  const hasKey = await api.hasApiKey(backend);
+  if (!hasKey) {
+    const names: Record<string, string> = { gemini: 'Gemini', claude: 'Claude', groq: 'Groq', openai: 'OpenAI' };
+    throw new Error(`No ${names[backend] ?? backend} API key configured. Open Settings to add one.`);
+  }
+}
+
+function buildApiMessages(compacted: ChatMessage[], contextNote: string): { role: 'user' | 'model'; content: string }[] {
+  const apiMessages: { role: 'user' | 'model'; content: string }[] = [];
+  for (const m of compacted) {
+    if (m.role === 'system') {
+      apiMessages.push({ role: 'user', content: `[System update]: ${m.content}` });
+      apiMessages.push({ role: 'model', content: 'Noted, I\'ll incorporate this updated state.' });
+    } else if (m.role === 'user') {
+      apiMessages.push({ role: 'user', content: m.content });
+    } else {
+      apiMessages.push({ role: 'model', content: m.content });
+    }
+  }
+
+  const lastIdx = apiMessages.length - 1;
+  if (lastIdx >= 0 && apiMessages[lastIdx].role === 'user') {
+    apiMessages[lastIdx] = {
+      ...apiMessages[lastIdx],
+      content: apiMessages[lastIdx].content + '\n' + contextNote,
+    };
+  }
+  return apiMessages;
+}
+
+function runCleanups(cleanups: (() => void)[]): void {
+  for (const cleanup of cleanups) {
+    try { cleanup(); } catch (cleanupErr) { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-chat', level: 'warn', message: 'Effect cleanup failed', error: { name: (cleanupErr as Error).name ?? 'Error', message: String(cleanupErr), stack: (cleanupErr as Error).stack } }); }
+  }
+}
+
+function historyPrev(promptHistory: React.MutableRefObject<string[]>, historyIdx: React.MutableRefObject<number>): string {
+  const newIdx = historyIdx.current === -1
+    ? promptHistory.current.length - 1
+    : Math.max(0, historyIdx.current - 1);
+  historyIdx.current = newIdx;
+  return promptHistory.current[newIdx];
+}
+
+function historyNext(promptHistory: React.MutableRefObject<string[]>, historyIdx: React.MutableRefObject<number>): string {
+  const newIdx = historyIdx.current + 1;
+  if (newIdx >= promptHistory.current.length) {
+    historyIdx.current = -1;
+    return '';
+  }
+  historyIdx.current = newIdx;
+  return promptHistory.current[newIdx];
+}
+
+function completeSlashCommand(input: string): string | null {
+  const partial = input.toLowerCase();
+  const allCmds = [...Object.keys(SLASH_COMMANDS), '/clear', '/compare', '/?'];
+  const match = allCmds.find(c => c.startsWith(partial) && c !== partial);
+  if (!match) return null;
+  return match === '/compare' ? '/compare ' : match;
+}
+
+function CollapsedToggleButton({ onOpen }: { onOpen: () => void }) {
+  return (
+    <button
+      onClick={onOpen}
+      title="Open Debate Chat (Ctrl+Shift+D)"
+      style={{
+        position: 'fixed', right: 12, bottom: 12, zIndex: 1000,
+        width: 44, height: 44, borderRadius: '50%',
+        background: 'var(--warning)', border: 'none', cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
+        fontSize: '1.2rem', color: '#000',
+      }}
+    >
+      ?
+    </button>
+  );
+}
+
+function ChatHeader({ model, hasMessages, onClear, onClose }: {
+  model: string;
+  hasMessages: boolean;
+  onClear: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px',
+      borderBottom: '1px solid var(--border)', background: 'var(--bg-secondary)',
+    }}>
+      <span style={{ fontSize: '0.85rem', fontWeight: 700, color: 'var(--warning)' }}>
+        Debate Chat
+      </span>
+      <span style={{
+        fontSize: 'var(--text-2xs)', color: 'var(--text-muted)',
+        padding: '1px 6px', borderRadius: 4,
+        background: 'rgba(255,255,255,0.06)', border: '1px solid var(--border)',
+        flex: 1,
+      }}>
+        {model}
+      </span>
+      {hasMessages && (
+        <button
+          onClick={onClear}
+          title="Clear chat (Ctrl+L)"
+          style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '0.7rem' }}
+        >Clear</button>
+      )}
+      <button
+        onClick={onClose}
+        title="Close chat (Esc)"
+        style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '0.85rem', lineHeight: 1 }}
+      >&times;</button>
+    </div>
+  );
+}
+
+function ChatEmptyState({ isWeb }: { isWeb: boolean }) {
+  return isWeb ? (
+    <div style={{ color: 'var(--text-muted)', fontSize: '0.75rem', padding: '24px 12px', textAlign: 'center' }}>
+      Debate Chat is available in the desktop app.
+      <br /><br />
+      <span style={{ fontSize: 'var(--text-2xs)' }}>
+        AI-powered chat requires direct API access which is not supported in the web viewer.
+      </span>
+    </div>
+  ) : (
+    <div style={{ color: 'var(--text-muted)', fontSize: '0.75rem', padding: '12px 0', textAlign: 'center' }}>
+      Ask questions about the debate.
+      <br /><br />
+      <span style={{ fontSize: 'var(--text-2xs)' }}>
+        Try: "Show me the brief for S21"
+        <br />"Which debater conceded the most?"
+        <br />"What's the strongest attack chain?"
+        <br /><br />
+        Type / or HELP for commands | /suggest for question ideas
+      </span>
+    </div>
+  );
+}
+
+function MessageBubble({ msg, onNavigate }: { msg: ChatMessage; onNavigate: (cmd: NavigateCommand) => void }) {
+  return (
+    <div
+      style={{
+        alignSelf: msg.role === 'user' ? 'flex-end' : 'flex-start',
+        maxWidth: '90%',
+        padding: '6px 10px',
+        borderRadius: 8,
+        fontSize: '0.75rem',
+        lineHeight: 1.4,
+        background: msg.role === 'user' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'var(--bg-tertiary, rgba(255,255,255,0.05))',
+        color: 'var(--text-primary, var(--border-color))',
+        border: msg.role === 'user' ? '1px solid color-mix(in srgb, var(--warning) 30%, transparent)' : '1px solid var(--border)',
+        userSelect: 'text',
+        cursor: 'text',
+      }}
+    >
+      {msg.role === 'assistant' ? (
+        <div className="diag-chat-markdown">
+          <Markdown remarkPlugins={[remarkGfm, remarkColorizePov]}>{msg.content}</Markdown>
+        </div>
+      ) : (
+        <div style={{ whiteSpace: 'pre-wrap' }}>{msg.content}</div>
+      )}
+      {msg.navigation && (
+        <div style={{
+          marginTop: 4, paddingTop: 4, borderTop: '1px solid var(--border)',
+          fontSize: 'var(--text-2xs)', color: 'var(--warning)', cursor: 'pointer',
+        }}
+          onClick={() => msg.navigation && onNavigate(msg.navigation)}
+        >
+          Navigated to {msg.navigation.entry ?? 'overview'}{msg.navigation.tab ? ` → ${msg.navigation.tab}` : ''}{msg.navigation.overviewTab ? ` → ${msg.navigation.overviewTab}` : ''}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StreamingBubble({ streamingText }: { streamingText: string }) {
+  return (
+    <div style={{
+      alignSelf: 'flex-start', maxWidth: '90%',
+      padding: '6px 10px', borderRadius: 8,
+      fontSize: '0.75rem', lineHeight: 1.4,
+      background: 'var(--bg-tertiary, rgba(255,255,255,0.05))',
+      color: 'var(--text-primary, var(--border-color))',
+      border: '1px solid var(--border)',
+      userSelect: 'text', cursor: 'text',
+    }}>
+      <div className="diag-chat-markdown">
+        <Markdown remarkPlugins={[remarkGfm, remarkColorizePov]}>{streamingText}</Markdown>
+      </div>
+    </div>
+  );
+}
+
+function ThinkingIndicator({ activity }: { activity: string | null }) {
+  return (
+    <div style={{
+      alignSelf: 'flex-start', padding: '6px 10px', borderRadius: 8,
+      fontSize: '0.7rem', color: 'var(--text-muted)', fontStyle: 'italic',
+    }}>
+      {activity || 'Thinking...'}
+    </div>
+  );
+}
+
+function SuggestionsBar({ suggestions, onSuggestionClick }: { suggestions: string[]; onSuggestionClick: (s: string) => void }) {
+  if (!suggestions.length) return null;
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, padding: '4px 0' }}>
+      {suggestions.map((s, i) => (
+        <button
+          key={i}
+          onClick={() => onSuggestionClick(s)}
+          style={{
+            padding: '3px 8px', borderRadius: 12,
+            fontSize: 'var(--text-2xs)', cursor: 'pointer',
+            background: 'color-mix(in srgb, var(--warning) 8%, transparent)',
+            color: 'var(--warning)',
+            border: '1px solid color-mix(in srgb, var(--warning) 20%, transparent)',
+            transition: 'background 0.15s',
+          }}
+          onMouseEnter={e => (e.currentTarget.style.background = 'color-mix(in srgb, var(--warning) 18%, transparent)')}
+          onMouseLeave={e => (e.currentTarget.style.background = 'color-mix(in srgb, var(--warning) 8%, transparent)')}
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ChatScrollArea({
+  isWeb, messages, generating, streamingText, activity, suggestions, onNavigate, onSuggestionClick, messagesEndRef,
+}: {
+  isWeb: boolean;
+  messages: ChatMessage[];
+  generating: boolean;
+  streamingText: string;
+  activity: string | null;
+  suggestions: string[];
+  onNavigate: (cmd: NavigateCommand) => void;
+  onSuggestionClick: (s: string) => void;
+  messagesEndRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <div style={{
+      flex: 1, overflowY: 'auto', padding: '8px 12px',
+      display: 'flex', flexDirection: 'column', gap: 8,
+    }}>
+      {messages.length === 0 && !generating && (
+        <ChatEmptyState isWeb={isWeb} />
+      )}
+      {messages.filter(m => m.role !== 'system').map(msg => (
+        <MessageBubble key={msg.id} msg={msg} onNavigate={onNavigate} />
+      ))}
+      {generating && streamingText && (
+        <StreamingBubble streamingText={streamingText} />
+      )}
+      {generating && !streamingText && (
+        <ThinkingIndicator activity={activity} />
+      )}
+      {!generating && (
+        <SuggestionsBar suggestions={suggestions} onSuggestionClick={onSuggestionClick} />
+      )}
+      <div ref={messagesEndRef} />
+    </div>
+  );
+}
+
+function ChatInputBar({
+  isWeb, debate, generating, input, canSend, contextTokens, inputRef, onInputChange, onKeyDown, onSend,
+}: {
+  isWeb: boolean;
+  debate: DebateSession | null;
+  generating: boolean;
+  input: string;
+  canSend: boolean;
+  contextTokens: number;
+  inputRef: React.RefObject<HTMLTextAreaElement | null>;
+  onInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onSend: () => void;
+}) {
+  return (
+    <div style={{
+      padding: '8px 12px', borderTop: '1px solid var(--border)',
+      background: 'var(--bg-secondary)',
+    }}>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <textarea
+          ref={inputRef}
+          value={input}
+          onChange={onInputChange}
+          onKeyDown={onKeyDown}
+          placeholder={isWeb ? 'Chat available in desktop app' : debate ? 'Ask about the debate... (/ for commands)' : 'Waiting for debate data...'}
+          disabled={isWeb || !debate || generating}
+          rows={2}
+          style={{
+            flex: 1, resize: 'none',
+            padding: '6px 8px', borderRadius: 6,
+            fontSize: '0.75rem',
+            background: 'var(--bg-primary)',
+            color: 'var(--text-primary)',
+            border: '1px solid var(--border)',
+            outline: 'none',
+            fontFamily: 'inherit',
+          }}
+        />
+        <button
+          onClick={onSend}
+          disabled={isWeb || !input.trim() || !debate || generating}
+          style={{
+            padding: '0 12px', borderRadius: 6,
+            background: canSend ? 'var(--warning)' : 'var(--bg-tertiary)',
+            color: canSend ? '#000' : 'var(--text-muted)',
+            border: 'none', cursor: canSend ? 'pointer' : 'not-allowed',
+            fontWeight: 600, fontSize: '0.75rem',
+          }}
+        >Send</button>
+      </div>
+      <div style={{
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 4,
+      }}>
+        <span>~{contextTokens.toLocaleString()} tokens in context</span>
+        <span>Enter send | Ctrl+L clear</span>
+      </div>
+    </div>
+  );
 }
 
 export function DiagnosticsChatSidebar({ debate, selectedEntry, currentTab, onNavigate, embedded, onClose }: Props) {
@@ -640,15 +1028,8 @@ export function DiagnosticsChatSidebar({ debate, selectedEntry, currentTab, onNa
     const cleanups: (() => void)[] = [];
     try {
       const model = getModel();
-      const backend = model.startsWith('claude') ? 'claude'
-        : model.startsWith('groq') ? 'groq'
-        : model.startsWith('openai') ? 'openai'
-        : 'gemini';
-      const hasKey = await api.hasApiKey(backend);
-      if (!hasKey) {
-        const names: Record<string, string> = { gemini: 'Gemini', claude: 'Claude', groq: 'Groq', openai: 'OpenAI' };
-        throw new Error(`No ${names[backend] ?? backend} API key configured. Open Settings to add one.`);
-      }
+      const backend = pickBackend(model);
+      await ensureApiKey(backend);
 
       setActivity(`Calling ${model}...`);
 
@@ -664,25 +1045,7 @@ export function DiagnosticsChatSidebar({ debate, selectedEntry, currentTab, onNa
         setMessages(compacted);
       }
 
-      const apiMessages: { role: 'user' | 'model'; content: string }[] = [];
-      for (const m of compacted) {
-        if (m.role === 'system') {
-          apiMessages.push({ role: 'user', content: `[System update]: ${m.content}` });
-          apiMessages.push({ role: 'model', content: 'Noted, I\'ll incorporate this updated state.' });
-        } else if (m.role === 'user') {
-          apiMessages.push({ role: 'user', content: m.content });
-        } else {
-          apiMessages.push({ role: 'model', content: m.content });
-        }
-      }
-
-      const lastIdx = apiMessages.length - 1;
-      if (lastIdx >= 0 && apiMessages[lastIdx].role === 'user') {
-        apiMessages[lastIdx] = {
-          ...apiMessages[lastIdx],
-          content: apiMessages[lastIdx].content + '\n' + contextNote,
-        };
-      }
+      const apiMessages = buildApiMessages(compacted, contextNote);
 
       // Register chunk listener for progressive streaming (best-effort)
       const unsubChunk = api.onChatStreamChunk((chunk) => {
@@ -729,15 +1092,14 @@ export function DiagnosticsChatSidebar({ debate, selectedEntry, currentTab, onNa
         timestamp: new Date().toISOString(),
       }]);
     } finally {
-      for (const cleanup of cleanups) {
-        try { cleanup(); } catch (cleanupErr) { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-chat', level: 'warn', message: 'Effect cleanup failed', error: { name: (cleanupErr as Error).name ?? 'Error', message: String(cleanupErr), stack: (cleanupErr as Error).stack } }); }
-      }
+      runCleanups(cleanups);
       setGenerating(false);
       setActivity(null);
     }
   }, [input, debate, generating, messages, selectedEntry, currentTab, onNavigate, taxonomies, handleSlashCommand]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    const textarea = e.target as HTMLTextAreaElement;
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (input.trim()) {
@@ -747,34 +1109,19 @@ export function DiagnosticsChatSidebar({ debate, selectedEntry, currentTab, onNa
       }
       void sendMessage();
     } else if (e.key === 'ArrowUp' && promptHistory.current.length > 0) {
-      const textarea = e.target as HTMLTextAreaElement;
       if (textarea.selectionStart === 0 && textarea.selectionEnd === 0) {
         e.preventDefault();
-        const newIdx = historyIdx.current === -1
-          ? promptHistory.current.length - 1
-          : Math.max(0, historyIdx.current - 1);
-        historyIdx.current = newIdx;
-        setInput(promptHistory.current[newIdx]);
+        setInput(historyPrev(promptHistory, historyIdx));
       }
     } else if (e.key === 'ArrowDown' && historyIdx.current >= 0) {
-      const textarea = e.target as HTMLTextAreaElement;
       if (textarea.selectionStart === textarea.value.length) {
         e.preventDefault();
-        const newIdx = historyIdx.current + 1;
-        if (newIdx >= promptHistory.current.length) {
-          historyIdx.current = -1;
-          setInput('');
-        } else {
-          historyIdx.current = newIdx;
-          setInput(promptHistory.current[newIdx]);
-        }
+        setInput(historyNext(promptHistory, historyIdx));
       }
     } else if (e.key === 'Tab' && input.startsWith('/')) {
       e.preventDefault();
-      const partial = input.toLowerCase();
-      const allCmds = [...Object.keys(SLASH_COMMANDS), '/clear', '/compare', '/?'];
-      const match = allCmds.find(c => c.startsWith(partial) && c !== partial);
-      if (match) setInput(match === '/compare' ? '/compare ' : match);
+      const match = completeSlashCommand(input);
+      if (match) setInput(match);
     }
   };
 
@@ -848,6 +1195,12 @@ export function DiagnosticsChatSidebar({ debate, selectedEntry, currentTab, onNa
   }, [width]);
 
   const lastAssistantMsg = [...messages].reverse().find(m => m.role === 'assistant');
+  const suggestions = lastAssistantMsg?.suggestions?.length
+    ? lastAssistantMsg.suggestions
+    : localSuggestions;
+  const canSend = !isWeb && !!input.trim() && !!debate && !generating;
+  const handleClear = () => { setMessages([]); lastSeenEntryCount.current = 0; };
+  const handleHeaderClose = () => { if (embedded && onClose) onClose(); else setOpen(false); };
 
   const chatContent = (
     <div className="diag-chat-sidebar" style={{
@@ -855,218 +1208,46 @@ export function DiagnosticsChatSidebar({ debate, selectedEntry, currentTab, onNa
       background: 'var(--bg-primary, var(--bg-secondary))',
     }}>
       {/* Header */}
-      <div style={{
-        display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px',
-        borderBottom: '1px solid var(--border)', background: 'var(--bg-secondary)',
-      }}>
-        <span style={{ fontSize: '0.85rem', fontWeight: 700, color: 'var(--warning)' }}>
-          Debate Chat
-        </span>
-        <span style={{
-          fontSize: 'var(--text-2xs)', color: 'var(--text-muted)',
-          padding: '1px 6px', borderRadius: 4,
-          background: 'rgba(255,255,255,0.06)', border: '1px solid var(--border)',
-          flex: 1,
-        }}>
-          {getModel()}
-        </span>
-        {messages.length > 0 && (
-          <button
-            onClick={() => { setMessages([]); lastSeenEntryCount.current = 0; }}
-            title="Clear chat (Ctrl+L)"
-            style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '0.7rem' }}
-          >Clear</button>
-        )}
-        <button
-          onClick={() => { if (embedded && onClose) onClose(); else setOpen(false); }}
-          title="Close chat (Esc)"
-          style={{ background: 'none', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '0.85rem', lineHeight: 1 }}
-        >&times;</button>
-      </div>
+      <ChatHeader
+        model={getModel()}
+        hasMessages={messages.length > 0}
+        onClear={handleClear}
+        onClose={handleHeaderClose}
+      />
 
       {/* Messages */}
-      <div style={{
-        flex: 1, overflowY: 'auto', padding: '8px 12px',
-        display: 'flex', flexDirection: 'column', gap: 8,
-      }}>
-        {messages.length === 0 && !generating && (
-          isWeb ? (
-            <div style={{ color: 'var(--text-muted)', fontSize: '0.75rem', padding: '24px 12px', textAlign: 'center' }}>
-              Debate Chat is available in the desktop app.
-              <br /><br />
-              <span style={{ fontSize: 'var(--text-2xs)' }}>
-                AI-powered chat requires direct API access which is not supported in the web viewer.
-              </span>
-            </div>
-          ) : (
-            <div style={{ color: 'var(--text-muted)', fontSize: '0.75rem', padding: '12px 0', textAlign: 'center' }}>
-              Ask questions about the debate.
-              <br /><br />
-              <span style={{ fontSize: 'var(--text-2xs)' }}>
-                Try: "Show me the brief for S21"
-                <br />"Which debater conceded the most?"
-                <br />"What's the strongest attack chain?"
-                <br /><br />
-                Type / or HELP for commands | /suggest for question ideas
-              </span>
-            </div>
-          )
-        )}
-        {messages.filter(m => m.role !== 'system').map(msg => (
-          <div
-            key={msg.id}
-            style={{
-              alignSelf: msg.role === 'user' ? 'flex-end' : 'flex-start',
-              maxWidth: '90%',
-              padding: '6px 10px',
-              borderRadius: 8,
-              fontSize: '0.75rem',
-              lineHeight: 1.4,
-              background: msg.role === 'user' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'var(--bg-tertiary, rgba(255,255,255,0.05))',
-              color: 'var(--text-primary, var(--border-color))',
-              border: msg.role === 'user' ? '1px solid color-mix(in srgb, var(--warning) 30%, transparent)' : '1px solid var(--border)',
-              userSelect: 'text',
-              cursor: 'text',
-            }}
-          >
-            {msg.role === 'assistant' ? (
-              <div className="diag-chat-markdown">
-                <Markdown remarkPlugins={[remarkGfm, remarkColorizePov]}>{msg.content}</Markdown>
-              </div>
-            ) : (
-              <div style={{ whiteSpace: 'pre-wrap' }}>{msg.content}</div>
-            )}
-            {msg.navigation && (
-              <div style={{
-                marginTop: 4, paddingTop: 4, borderTop: '1px solid var(--border)',
-                fontSize: 'var(--text-2xs)', color: 'var(--warning)', cursor: 'pointer',
-              }}
-                onClick={() => msg.navigation && onNavigate(msg.navigation)}
-              >
-                Navigated to {msg.navigation.entry ?? 'overview'}{msg.navigation.tab ? ` → ${msg.navigation.tab}` : ''}{msg.navigation.overviewTab ? ` → ${msg.navigation.overviewTab}` : ''}
-              </div>
-            )}
-          </div>
-        ))}
-        {generating && streamingText && (
-          <div style={{
-            alignSelf: 'flex-start', maxWidth: '90%',
-            padding: '6px 10px', borderRadius: 8,
-            fontSize: '0.75rem', lineHeight: 1.4,
-            background: 'var(--bg-tertiary, rgba(255,255,255,0.05))',
-            color: 'var(--text-primary, var(--border-color))',
-            border: '1px solid var(--border)',
-            userSelect: 'text', cursor: 'text',
-          }}>
-            <div className="diag-chat-markdown">
-              <Markdown remarkPlugins={[remarkGfm, remarkColorizePov]}>{streamingText}</Markdown>
-            </div>
-          </div>
-        )}
-        {generating && !streamingText && (
-          <div style={{
-            alignSelf: 'flex-start', padding: '6px 10px', borderRadius: 8,
-            fontSize: '0.7rem', color: 'var(--text-muted)', fontStyle: 'italic',
-          }}>
-            {activity || 'Thinking...'}
-          </div>
-        )}
-        {!generating && (() => {
-          const suggestions = lastAssistantMsg?.suggestions?.length
-            ? lastAssistantMsg.suggestions
-            : localSuggestions;
-          if (!suggestions.length) return null;
-          return (
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, padding: '4px 0' }}>
-              {suggestions.map((s, i) => (
-                <button
-                  key={i}
-                  onClick={() => handleSuggestionClick(s)}
-                  style={{
-                    padding: '3px 8px', borderRadius: 12,
-                    fontSize: 'var(--text-2xs)', cursor: 'pointer',
-                    background: 'color-mix(in srgb, var(--warning) 8%, transparent)',
-                    color: 'var(--warning)',
-                    border: '1px solid color-mix(in srgb, var(--warning) 20%, transparent)',
-                    transition: 'background 0.15s',
-                  }}
-                  onMouseEnter={e => (e.currentTarget.style.background = 'color-mix(in srgb, var(--warning) 18%, transparent)')}
-                  onMouseLeave={e => (e.currentTarget.style.background = 'color-mix(in srgb, var(--warning) 8%, transparent)')}
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
-          );
-        })()}
-        <div ref={messagesEndRef} />
-      </div>
+      <ChatScrollArea
+        isWeb={isWeb}
+        messages={messages}
+        generating={generating}
+        streamingText={streamingText}
+        activity={activity}
+        suggestions={suggestions}
+        onNavigate={onNavigate}
+        onSuggestionClick={handleSuggestionClick}
+        messagesEndRef={messagesEndRef}
+      />
 
       {/* Input */}
-      <div style={{
-        padding: '8px 12px', borderTop: '1px solid var(--border)',
-        background: 'var(--bg-secondary)',
-      }}>
-        <div style={{ display: 'flex', gap: 6 }}>
-          <textarea
-            ref={inputRef}
-            value={input}
-            onChange={e => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={isWeb ? 'Chat available in desktop app' : debate ? 'Ask about the debate... (/ for commands)' : 'Waiting for debate data...'}
-            disabled={isWeb || !debate || generating}
-            rows={2}
-            style={{
-              flex: 1, resize: 'none',
-              padding: '6px 8px', borderRadius: 6,
-              fontSize: '0.75rem',
-              background: 'var(--bg-primary)',
-              color: 'var(--text-primary)',
-              border: '1px solid var(--border)',
-              outline: 'none',
-              fontFamily: 'inherit',
-            }}
-          />
-          <button
-            onClick={() => void sendMessage()}
-            disabled={isWeb || !input.trim() || !debate || generating}
-            style={{
-              padding: '0 12px', borderRadius: 6,
-              background: !isWeb && input.trim() && debate && !generating ? 'var(--warning)' : 'var(--bg-tertiary)',
-              color: !isWeb && input.trim() && debate && !generating ? '#000' : 'var(--text-muted)',
-              border: 'none', cursor: !isWeb && input.trim() && debate && !generating ? 'pointer' : 'not-allowed',
-              fontWeight: 600, fontSize: '0.75rem',
-            }}
-          >Send</button>
-        </div>
-        <div style={{
-          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-          fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 4,
-        }}>
-          <span>~{contextTokens.toLocaleString()} tokens in context</span>
-          <span>Enter send | Ctrl+L clear</span>
-        </div>
-      </div>
+      <ChatInputBar
+        isWeb={isWeb}
+        debate={debate}
+        generating={generating}
+        input={input}
+        canSend={canSend}
+        contextTokens={contextTokens}
+        inputRef={inputRef}
+        onInputChange={e => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onSend={() => void sendMessage()}
+      />
     </div>
   );
 
   if (!open) {
     if (embedded) return null;
     return (
-      <button
-        onClick={() => setOpen(true)}
-        title="Open Debate Chat (Ctrl+Shift+D)"
-        style={{
-          position: 'fixed', right: 12, bottom: 12, zIndex: 1000,
-          width: 44, height: 44, borderRadius: '50%',
-          background: 'var(--warning)', border: 'none', cursor: 'pointer',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          boxShadow: '0 2px 8px rgba(0,0,0,0.3)',
-          fontSize: '1.2rem', color: '#000',
-        }}
-      >
-        ?
-      </button>
+      <CollapsedToggleButton onOpen={() => setOpen(true)} />
     );
   }
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/OverviewView.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/OverviewView.tsx
@@ -20,6 +20,14 @@ import { useDescriptionMode, DescriptionToggle } from '../../shared/DescriptionT
 import { useTaxonomyStore } from '../../../hooks/useTaxonomyStore';
 import { generatePlainPreview } from '../../../utils/regeneratePlainDescription';
 
+type DebateState = ReturnType<typeof useDebateStore.getState>;
+type ActiveDebate = NonNullable<DebateState['activeDebate']>;
+type ModeratorState = NonNullable<ActiveDebate['moderator_state']>;
+type Diagnostics = NonNullable<ActiveDebate['diagnostics']>;
+type DiagEntries = Diagnostics['entries'];
+type ExclusionViolation = { claim_id: string; claim_text: string; node_id: string; similarity_main: number; similarity_exclusion: number };
+type ScopeDriftWarning = { debater: string; node_id: string; similarity: number; draft_excerpt: string };
+
 const AIF_TOOLTIPS = {
   'I-node': 'I-node (Information node) — a claim, proposition, or data point. These are the passive content of arguments: what is being asserted.',
   'CA': 'CA-node (Conflict Application) — an attack relationship. Three types: rebut (contradicts conclusion), undercut (denies the inference), undermine (attacks premise credibility). Each attack is classified by argumentation scheme (e.g., ARGUMENT_FROM_EVIDENCE, ARGUMENT_FROM_ANALOGY) with critical questions that identify how to evaluate it.',
@@ -365,6 +373,637 @@ function PanelArgumentNetwork({ an }: { an: { nodes: ArgumentNetworkNode[]; edge
   );
 }
 
+function TopicScopeSection({ scope }: { scope: TopicScope | undefined }) {
+  if (!scope) return null;
+  return <TopicScopePanel scope={scope} />;
+}
+
+function StrengthTimelineSection({ timeline, an }: { timeline: ActiveDebate['qbaf_timeline']; an: ActiveDebate['argument_network'] }) {
+  if (!timeline || timeline.length === 0 || !an) return null;
+  return <StrengthTimeline timeline={timeline} nodes={an.nodes} />;
+}
+
+function DocumentCoverageWrapper({ coverageMap, strengthWeighted, debateGenerating, askQuestion }: {
+  coverageMap: CoverageMap | null;
+  strengthWeighted: StrengthWeightedCoverage | null;
+  debateGenerating: DebateState['debateGenerating'];
+  askQuestion: DebateState['askQuestion'];
+}) {
+  if (!coverageMap) return null;
+  return (
+    <DocumentCoverageSection coverageMap={coverageMap} strengthWeighted={strengthWeighted} onSteerToClaim={debateGenerating ? undefined : (claimText) => {
+      void askQuestion(`What is your perspective on the claim that ${claimText}?`);
+    }} />
+  );
+}
+
+function PanelArgumentNetworkSection({ an }: { an: ActiveDebate['argument_network'] }) {
+  if (!an || an.nodes.length === 0) return null;
+  return <PanelArgumentNetwork an={an} />;
+}
+
+function WhatIfWrapper({ an }: { an: ActiveDebate['argument_network'] }) {
+  if (!an || an.nodes.length === 0) return null;
+  return <WhatIfSection nodes={an.nodes} edges={an.edges} />;
+}
+
+function CommitmentStoresSection({ commitments }: { commitments: ActiveDebate['commitments'] }) {
+  if (!commitments || Object.keys(commitments).length === 0) return null;
+  return (
+    <CollapsibleSection title="Commitment Stores" defaultOpen>
+      {Object.entries(commitments).map(([poverId, store]) => (
+        <div key={poverId} className="diag-commit-store">
+          <strong>{speakerLabel(poverId as SpeakerId)}</strong>
+          <div className="diag-commit-counts">
+            Asserted: {store.asserted.length} | Conceded: {store.conceded.length} | Challenged: {store.challenged.length}
+          </div>
+          {store.conceded.length > 0 && (
+            <div className="diag-commit-list">
+              <span className="diag-muted">Conceded:</span>
+              {store.conceded.map((c, i) => <div key={i} className="diag-commit-item">• {c}</div>)}
+            </div>
+          )}
+        </div>
+      ))}
+    </CollapsibleSection>
+  );
+}
+
+function ModeratorBudget({ ms }: { ms: ModeratorState }) {
+  return (
+    <>
+      {/* Budget gauge */}
+      <div className="diag-kv">
+        <span className="diag-k">Budget:</span>
+        <span className="diag-v">{ms.budget_remaining}/{ms.budget_total} remaining</span>
+      </div>
+      <div className="ovw-gauge-track">
+        {/* eslint-disable-next-line local/no-inline-style -- data-driven width/background */}
+        <div className="ovw-gauge-fill" style={{
+          width: `${ms.budget_total > 0 ? ((ms.budget_total - ms.budget_remaining) / ms.budget_total * 100) : 0}%`,
+          background: ms.budget_remaining <= 1 ? 'var(--danger)' : ms.budget_remaining <= 2 ? 'var(--warning)' : 'var(--success)',
+        }} />
+      </div>
+    </>
+  );
+}
+
+function ModeratorHealth({ ms }: { ms: ModeratorState }) {
+  const latestHealth = ms.health_history.length > 0 ? ms.health_history[ms.health_history.length - 1] : null;
+  if (!latestHealth) return null;
+  return (
+    <>
+      <div className="diag-kv">
+        <span className="diag-k">Health:</span>
+        {/* eslint-disable-next-line local/no-inline-style -- data-driven health color */}
+        <span className="diag-v" style={{ color: latestHealth.value >= 0.7 ? 'var(--success)' : latestHealth.value >= 0.4 ? 'var(--warning)' : 'var(--danger)' }}>
+          {(latestHealth.value ?? 0).toFixed(2)}
+        </span>
+        {ms.consecutive_decline > 0 && <span className="diag-badge ovw-badge-danger-ml4">{ms.consecutive_decline} decline{ms.consecutive_decline > 1 ? 's' : ''}</span>}
+        {ms.consecutive_rise >= 2 && <span className="diag-badge ovw-badge-success-ml4">{ms.consecutive_rise} rises</span>}
+      </div>
+      <div className="ovw-health-grid">
+        {(['engagement', 'novelty', 'responsiveness', 'coverage', 'balance'] as const).map(comp => (
+          <div key={comp} className="ovw-center">
+            <div className="diag-k ovw-2xs">{comp.slice(0, 3).toUpperCase()}</div>
+            {/* eslint-disable-next-line local/no-inline-style -- data-driven component color */}
+            <div className="ovw-fw600" style={{ color: latestHealth.components[comp] >= 0.5 ? 'var(--success)' : latestHealth.components[comp] >= 0.25 ? 'var(--warning)' : 'var(--danger)' }}>
+              {(latestHealth.components[comp] ?? 0).toFixed(2)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+function ModeratorBurden({ ms }: { ms: ModeratorState }) {
+  if (Object.keys(ms.burden_per_debater).length === 0) return null;
+  const maxBurden = Math.max(...Object.values(ms.burden_per_debater), 0.01);
+  return (
+    <div className="ovw-mb6">
+      <span className="diag-k ovw-2xs">Burden (avg {(ms.avg_burden ?? 0).toFixed(2)}):</span>
+      {Object.entries(ms.burden_per_debater).map(([debater, burden]) => (
+        <div key={debater} className="ovw-burden-row">
+          <span className="ovw-burden-label">{speakerLabel(debater as SpeakerId)}</span>
+          <div className="ovw-burden-track">
+            {/* eslint-disable-next-line local/no-inline-style -- data-driven width/background */}
+            <div className="ovw-gauge-fill" style={{ width: `${(burden / maxBurden * 100)}%`, background: burden > ms.avg_burden * 1.5 ? 'var(--danger)' : 'var(--color-saf)' }} />
+          </div>
+          <span className="ovw-burden-val">{(burden ?? 0).toFixed(2)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ModeratorCooldown({ ms }: { ms: ModeratorState }) {
+  return (
+    <div className="ovw-cooldown-row">
+      <span><span className="diag-k">Cooldown:</span> {ms.rounds_since_last_intervention >= ms.required_gap ? <span className="ovw-success">ready</span> : <span className="ovw-warning">{ms.required_gap - ms.rounds_since_last_intervention}r left</span>}</span>
+      <span><span className="diag-k">Gap:</span> {ms.required_gap}</span>
+      {ms.cooldown_blocked_count > 0 && <span><span className="diag-k">Blocked:</span> {ms.cooldown_blocked_count}x</span>}
+    </div>
+  );
+}
+
+function ModeratorInterventions({ ms }: { ms: ModeratorState }) {
+  if (ms.intervention_history.length === 0) return null;
+  const familyColors: Record<string, string> = {
+    procedural: 'var(--color-saf)', elicitation: 'var(--warning)', repair: 'var(--danger)',
+    reconciliation: 'var(--success)', reflection: 'var(--text-secondary)', synthesis: 'var(--text-secondary)',
+  };
+  return (
+    <div className="ovw-mt4">
+      <span className="diag-k ovw-2xs">Interventions:</span>
+      {ms.intervention_history.map((h, i) => (
+        <div key={i} className="ovw-intervention-row">
+          <span className="diag-muted ovw-w24">R{h.round}</span>
+          {/* eslint-disable-next-line local/no-inline-style -- data-driven family color */}
+          <span className="diag-badge ovw-2xs" style={{ background: `${familyColors[h.family] ?? 'var(--text-muted)'}30`, color: familyColors[h.family] ?? 'var(--text-muted)' }}>{h.move}</span>
+          <span className="ovw-2xs">{'→'} {speakerLabel(h.target as SpeakerId)}</span>
+          <span className="diag-muted ovw-2xs">({(h.burden ?? 0).toFixed(1)})</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ActiveModeratorSection({ moderatorState }: { moderatorState: ActiveDebate['moderator_state'] }) {
+  if (!moderatorState) return null;
+  const ms = moderatorState;
+  return (
+    <CollapsibleSection title={`Active Moderator — ${ms.interventions_fired} interventions, budget ${ms.budget_remaining}/${ms.budget_total}`} defaultOpen>
+      <ModeratorBudget ms={ms} />
+      <ModeratorHealth ms={ms} />
+      <ModeratorBurden ms={ms} />
+      <ModeratorCooldown ms={ms} />
+      <ModeratorInterventions ms={ms} />
+    </CollapsibleSection>
+  );
+}
+
+function ModeratorDeliberationsSection({ transcript }: { transcript: ActiveDebate['transcript'] }) {
+  const modEntries = transcript
+    .filter(e => (e.metadata as Record<string, unknown>)?.moderator_trace)
+    .map(e => ({
+      id: e.id,
+      trace: (e.metadata as Record<string, unknown>).moderator_trace as {
+        selected: string; focus_point: string; addressing?: string;
+        agreement_detected?: boolean; recent_scheme?: string | null;
+        convergence_score?: number | null; convergence_triggered?: boolean;
+        intervention_recommended?: boolean; intervention_move?: string | null; intervention_validated?: boolean;
+        health_score?: number; budget_remaining?: number;
+        argument_network_snapshot?: { total_claims: number; total_edges: number; unaddressed_claims: number } | null;
+      },
+    }));
+  if (modEntries.length === 0) return null;
+
+  const selectionCounts: Record<string, number> = {};
+  let convergenceValues: number[] = [];
+  modEntries.forEach(({ trace }) => {
+    selectionCounts[trace.selected] = (selectionCounts[trace.selected] || 0) + 1;
+    if (trace.convergence_score != null) convergenceValues.push(trace.convergence_score);
+  });
+  const latestTrace = modEntries[modEntries.length - 1].trace;
+  const avgConvergence = convergenceValues.length > 0
+    ? convergenceValues.reduce((a, b) => a + b, 0) / convergenceValues.length
+    : null;
+
+  return (
+    <CollapsibleSection title={`Moderator Deliberations — ${modEntries.length} rounds`} defaultOpen>
+      <div className="diag-kv">
+        <span className="diag-k">Speaker selection:</span>
+        <div className="diag-badges">
+          {Object.entries(selectionCounts).sort((a, b) => b[1] - a[1]).map(([s, c]) => (
+            <span key={s} className="diag-badge diag-badge-move">{speakerLabel(s as SpeakerId)} ({c})</span>
+          ))}
+        </div>
+      </div>
+      {avgConvergence != null && (
+        <div className="diag-kv">
+          <span className="diag-k">Avg convergence:</span>
+          <span className="diag-v">{(avgConvergence * 100).toFixed(0)}%</span>
+          {latestTrace.convergence_triggered && <span className="diag-badge ovw-badge-success-ml4">triggered</span>}
+        </div>
+      )}
+      {latestTrace.focus_point && (
+        <div className="diag-kv">
+          <span className="diag-k">Current focus:</span>
+          <span className="diag-v">{latestTrace.focus_point}</span>
+        </div>
+      )}
+      {latestTrace.argument_network_snapshot && (
+        <div className="diag-kv">
+          <span className="diag-k">AN snapshot:</span>
+          <span className="diag-v">
+            {latestTrace.argument_network_snapshot.total_claims} claims, {latestTrace.argument_network_snapshot.total_edges} edges, {latestTrace.argument_network_snapshot.unaddressed_claims} unaddressed
+          </span>
+        </div>
+      )}
+      <div className="ovw-mt6-2xs">
+        {modEntries.slice(-5).reverse().map(({ id, trace }) => (
+          <div key={id} className="diag-mod-round ovw-mod-round-row">
+            <span className="diag-badge diag-badge-move ovw-2xs-minw50">{speakerLabel(trace.selected as SpeakerId)}</span>
+            <span className="diag-muted ovw-flex1">{trace.focus_point}</span>
+            {/* eslint-disable-next-line local/no-inline-style -- data-driven validated color */}
+            {trace.intervention_move && <span className="diag-badge ovw-2xs" style={{ background: trace.intervention_validated ? 'color-mix(in srgb, var(--text-secondary) 20%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)', color: trace.intervention_validated ? 'var(--text-secondary)' : 'var(--danger)' }}>{trace.intervention_move}{trace.intervention_validated ? '' : ' (suppressed)'}</span>}
+            {trace.health_score != null && <span className="diag-muted ovw-2xs">H:{trace.health_score.toFixed(2)}</span>}
+            {trace.recent_scheme && <span className="diag-badge ovw-badge-secondary">{trace.recent_scheme}</span>}
+            {trace.convergence_score != null && <span className="diag-muted">{(trace.convergence_score * 100).toFixed(0)}%</span>}
+          </div>
+        ))}
+      </div>
+    </CollapsibleSection>
+  );
+}
+
+function DriftDetectionSection({ transcript }: { transcript: ActiveDebate['transcript'] }) {
+  const driftEntries = transcript
+    .filter(e => {
+      const trace = (e.metadata as Record<string, unknown>)?.moderator_trace as Record<string, unknown> | undefined;
+      return trace?.drift_detected === true;
+    })
+    .map(e => {
+      const trace = (e.metadata as Record<string, unknown>).moderator_trace as Record<string, unknown>;
+      const round = trace.debate_phase ? undefined : (e.metadata as Record<string, unknown>)?.round as number | undefined;
+      return {
+        id: e.id,
+        round,
+        reasoning: trace.drift_reasoning as string | null,
+        intervention_move: trace.intervention_move as string | null,
+        intervention_validated: trace.intervention_validated as boolean | undefined,
+        selected: trace.selected as string | undefined,
+      };
+    });
+  if (driftEntries.length === 0) return null;
+  const redirected = driftEntries.filter(d => d.intervention_validated && d.intervention_move && ['REDIRECT', 'CHALLENGE', 'CLARIFY', 'CHECK'].includes(d.intervention_move));
+  return (
+    <CollapsibleSection title={`Drift Detection — ${driftEntries.length} detected, ${redirected.length} intervened`}>
+      {driftEntries.map(d => (
+        <div key={d.id} className="ovw-mb6-2xs">
+          <div className="ovw-flex-baseline">
+            {d.round != null && <span className="diag-muted">R{d.round}</span>}
+            {d.selected && <span>{speakerLabel(d.selected as SpeakerId)}</span>}
+            {/* eslint-disable-next-line local/no-inline-style -- data-driven validated color */}
+            <span className="diag-badge ovw-2xs" style={{
+              background: d.intervention_validated ? 'color-mix(in srgb, var(--danger) 15%, transparent)' : 'color-mix(in srgb, var(--warning) 15%, transparent)',
+              color: d.intervention_validated ? 'var(--danger)' : 'var(--warning)',
+            }}>
+              {d.intervention_validated && d.intervention_move ? d.intervention_move : 'drift noted'}
+            </span>
+          </div>
+          {d.reasoning && (
+            <div className="ovw-drift-reason">{d.reasoning}</div>
+          )}
+        </div>
+      ))}
+    </CollapsibleSection>
+  );
+}
+
+function UnansweredClaimsSection({ ledger }: { ledger: ActiveDebate['unanswered_claims_ledger'] }) {
+  if (!ledger || ledger.length === 0) return null;
+  return (
+    <CollapsibleSection title={`Unanswered Claims — ${ledger.filter(c => !c.addressed_round).length} open`}>
+      {ledger.map(claim => (
+        <div key={claim.claim_id} className={`diag-ledger-entry ${claim.addressed_round ? 'diag-ledger-addressed' : ''}`}>
+          <div className="ovw-flex-baseline">
+            <span className="diag-an-id">{claim.claim_id}</span>
+            <span className="diag-an-speaker">({speakerLabel(claim.speaker as SpeakerId)})</span>
+            {/* eslint-disable-next-line local/no-inline-style -- data-driven addressed color */}
+            <span className="diag-badge ovw-2xs" style={{ background: claim.addressed_round ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)', color: claim.addressed_round ? 'var(--success)' : 'var(--danger)' }}>
+              {claim.addressed_round ? `addressed R${claim.addressed_round}` : `since R${claim.first_unanswered_round}`}
+            </span>
+          </div>
+          <div className="ovw-pl8-2xs">{claim.claim_text}</div>
+        </div>
+      ))}
+    </CollapsibleSection>
+  );
+}
+
+function MissingArgumentsSection({ missing }: { missing: ActiveDebate['missing_arguments'] }) {
+  if (!missing || missing.length === 0) return null;
+  return (
+    <CollapsibleSection title={`Missing Arguments — ${missing.length} identified`}>
+      {missing.map((arg, i) => (
+        <div key={i} className="diag-missing-arg">
+          <div className="ovw-flex-baseline">
+            <span className="diag-badge diag-badge-move ovw-2xs">{arg.side}</span>
+            <span className="diag-badge ovw-badge-secondary">{arg.bdi_layer}</span>
+          </div>
+          <div className="ovw-arg-text">{arg.argument}</div>
+          <div className="ovw-2xs-muted-italic">{arg.why_strong}</div>
+        </div>
+      ))}
+    </CollapsibleSection>
+  );
+}
+
+function PositionDriftSection({ positionDrift }: { positionDrift: ActiveDebate['position_drift'] }) {
+  if (!positionDrift || positionDrift.length === 0) return null;
+  const drift = positionDrift;
+  const speakers = [...new Set(drift.map(d => d.speaker))];
+  return (
+    <CollapsibleSection title={`Position Drift — ${drift.length} snapshots`}>
+      {speakers.map(speaker => {
+        const speakerDrift = drift.filter(d => d.speaker === speaker);
+        const latest = speakerDrift[speakerDrift.length - 1];
+        const first = speakerDrift[0];
+        const selfDelta = (latest.self_similarity ?? 0) - (first.self_similarity ?? 0);
+        return (
+          <div key={speaker} className="diag-drift-speaker">
+            <div className="ovw-flex-baseline">
+              <strong>{speakerLabel(speaker as SpeakerId)}</strong>
+              <span className="diag-muted">self-sim: {(latest.self_similarity ?? 0).toFixed(3)}</span>
+              <span className={`diag-badge ${selfDelta < -0.05 ? 'diag-drift-warning' : ''} ovw-2xs`}>
+                {selfDelta > 0 ? '+' : ''}{selfDelta.toFixed(3)}
+              </span>
+            </div>
+            <div className="ovw-opp-sims">
+              {Object.entries(latest.opponent_similarities).map(([opp, sim]) => (
+                <span key={opp}>→ {speakerLabel(opp as SpeakerId)}: {(sim ?? 0).toFixed(3)}</span>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </CollapsibleSection>
+  );
+}
+
+function aggregateExclusionGuard(entries: DiagEntries) {
+  let claimsChecked = 0;
+  let claimViolations: ExclusionViolation[] = [];
+  let draftsChecked = 0;
+  let driftWarnings: ScopeDriftWarning[] = [];
+  let hasAnyData = false;
+
+  for (const entry of Object.values(entries)) {
+    const extTrace = entry.extraction_trace;
+    if (extTrace) {
+      hasAnyData = true;
+      if (extTrace.exclusion_guard) {
+        claimsChecked += extTrace.exclusion_guard.checked;
+        if (extTrace.exclusion_guard.violations?.length) claimViolations = claimViolations.concat(extTrace.exclusion_guard.violations);
+      }
+      if (extTrace.exclusion_violations?.length) {
+        claimViolations = claimViolations.concat(extTrace.exclusion_violations);
+      }
+    }
+
+    if (entry.scope_drift_check) {
+      hasAnyData = true;
+      draftsChecked += entry.scope_drift_check.refs_checked;
+      if (entry.scope_drift_check.warnings?.length) driftWarnings = driftWarnings.concat(entry.scope_drift_check.warnings);
+    }
+    if (entry.scope_drift_warnings?.length) {
+      hasAnyData = true;
+      driftWarnings = driftWarnings.concat(entry.scope_drift_warnings);
+    }
+  }
+
+  return { claimsChecked, claimViolations, draftsChecked, driftWarnings, hasAnyData };
+}
+
+function ExclusionGuardDetail({ claimsChecked, claimViolations, draftsChecked, driftWarnings }: {
+  claimsChecked: number;
+  claimViolations: ExclusionViolation[];
+  draftsChecked: number;
+  driftWarnings: ScopeDriftWarning[];
+}) {
+  return (
+    <div className="ovw-sm">
+      <div className="ovw-summary-row">
+        {/* eslint-disable-next-line local/no-inline-style -- data-driven violation color */}
+        <span className="ovw-summary-chip" style={{
+          background: claimViolations.length > 0 ? 'color-mix(in srgb, var(--danger) 10%, transparent)' : 'color-mix(in srgb, var(--success) 8%, transparent)',
+          color: claimViolations.length > 0 ? 'var(--danger)' : 'var(--success)',
+        }}>
+          {claimsChecked} claims checked, {claimViolations.length} violation{claimViolations.length !== 1 ? 's' : ''}
+        </span>
+        {/* eslint-disable-next-line local/no-inline-style -- data-driven warning color */}
+        <span className="ovw-summary-chip" style={{
+          background: driftWarnings.length > 0 ? 'color-mix(in srgb, var(--warning) 10%, transparent)' : 'color-mix(in srgb, var(--success) 8%, transparent)',
+          color: driftWarnings.length > 0 ? 'var(--warning)' : 'var(--success)',
+        }}>
+          {draftsChecked} drafts checked, {driftWarnings.length} drift warning{driftWarnings.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+      {claimViolations.length > 0 && (
+        <div className="ovw-mb6">
+          <div className="diag-k ovw-viol-header">Exclusion Violations ({claimViolations.length})</div>
+          {claimViolations.slice(0, 10).map((v, i) => (
+            <div key={i} className="ovw-viol-row">
+              <span className="ovw-fw600-danger">{v.claim_id}</span>
+              <span className="ovw-muted-color">→</span>
+              <span>{v.node_id}</span>
+              <span className="diag-muted ovw-2xs">
+                (main: {v.similarity_main.toFixed(2)}, excl: {v.similarity_exclusion.toFixed(2)})
+              </span>
+            </div>
+          ))}
+          {claimViolations.length > 10 && (
+            <div className="diag-muted ovw-2xs-ml8">…and {claimViolations.length - 10} more</div>
+          )}
+        </div>
+      )}
+      {driftWarnings.length > 0 && (
+        <div>
+          <div className="diag-k ovw-drift-header">Scope Drift Warnings ({driftWarnings.length})</div>
+          {driftWarnings.slice(0, 10).map((w, i) => (
+            <div key={i} className="ovw-viol-row">
+              <span className="ovw-fw600-warning">{w.debater}</span>
+              <span className="ovw-muted-color">→</span>
+              <span>{w.node_id}</span>
+              <span className="diag-muted ovw-2xs">
+                (sim: {w.similarity.toFixed(2)})
+              </span>
+            </div>
+          ))}
+          {driftWarnings.length > 10 && (
+            <div className="diag-muted ovw-2xs-ml8">…and {driftWarnings.length - 10} more</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExclusionGuardSection({ entries }: { entries: DiagEntries | undefined }) {
+  if (!entries || Object.keys(entries).length === 0) return null;
+
+  const { claimsChecked, claimViolations, draftsChecked, driftWarnings, hasAnyData } = aggregateExclusionGuard(entries);
+
+  if (!hasAnyData) {
+    return (
+      <CollapsibleSection title="Exclusion Guard">
+        <div className="ovw-empty-note">
+          Exclusion guard data not available for this debate
+        </div>
+      </CollapsibleSection>
+    );
+  }
+
+  const allClear = claimViolations.length === 0 && driftWarnings.length === 0;
+
+  return (
+    <CollapsibleSection title={`Exclusion Guard${!allClear ? ` — ${claimViolations.length + driftWarnings.length} issues` : ''}`}>
+      {allClear ? (
+        <div className="ovw-all-clear">
+          All statements within scope — no exclusion violations or drift warnings
+        </div>
+      ) : (
+        <ExclusionGuardDetail claimsChecked={claimsChecked} claimViolations={claimViolations} draftsChecked={draftsChecked} driftWarnings={driftWarnings} />
+      )}
+      <div className="diag-muted ovw-2xs-mt6">
+        {claimsChecked} claims checked, {claimViolations.length} violation{claimViolations.length !== 1 ? 's' : ''} | {draftsChecked} drafts checked, {driftWarnings.length} drift warning{driftWarnings.length !== 1 ? 's' : ''}
+      </div>
+    </CollapsibleSection>
+  );
+}
+
+function TaxonomySuggestionsSection({ suggestions }: { suggestions: NonNullable<ActiveDebate['taxonomy_suggestions']> }) {
+  const [descMode, setDescMode] = useDescriptionMode();
+  const taxState = useTaxonomyStore(useShallow(s => ({
+    accelerationist: s.accelerationist, safetyist: s.safetyist, skeptic: s.skeptic, situations: s.situations,
+  })));
+
+  const [plainPreviews, setPlainPreviews] = useState<Record<string, string | null>>({});
+  const [previewLoading, setPreviewLoading] = useState<Record<string, boolean>>({});
+  const inflightRef = useRef<Set<string>>(new Set());
+
+  const lookupPlainDescription = useCallback((nodeId: string, pov: string): string | null => {
+    const povKey = pov as keyof typeof taxState;
+    const file = taxState[povKey];
+    if (!file?.nodes) return null;
+    const node = (file.nodes as any[]).find((n: any) => n.id === nodeId);
+    return node?.plain_description ?? null;
+  }, [taxState]);
+
+  useEffect(() => {
+    if (descMode !== 'plain' || !suggestions?.length) return;
+    for (let i = 0; i < suggestions.length; i++) {
+      const sug = suggestions[i];
+      const key = `after-${sug.node_id}-${i}`;
+      if (inflightRef.current.has(key) || plainPreviews[key] !== undefined) continue;
+      inflightRef.current.add(key);
+      setPreviewLoading(prev => ({ ...prev, [key]: true }));
+      void generatePlainPreview(sug.proposed_description ?? '').then(text => {
+        setPlainPreviews(prev => ({ ...prev, [key]: text }));
+        setPreviewLoading(prev => ({ ...prev, [key]: false }));
+      });
+    }
+  }, [descMode, suggestions, plainPreviews]);
+
+  return (
+    <CollapsibleSection title={`Taxonomy Suggestions — ${suggestions.length} revisions`} defaultOpen>
+      <div className="ovw-toolbar-mb6">
+        <DescriptionToggle mode={descMode} onToggle={setDescMode} hasPlainDescription />
+      </div>
+      {suggestions.map((sug, i) => {
+        const afterKey = `after-${sug.node_id}-${i}`;
+        let beforeText = sug.current_description;
+        let afterText = sug.proposed_description;
+        let beforeGenerating = false;
+        let afterGenerating = false;
+
+        if (descMode === 'plain') {
+          const storedPlain = lookupPlainDescription(sug.node_id, sug.node_pov);
+          if (storedPlain) {
+            beforeText = storedPlain;
+          } else if (sug.current_description) {
+            beforeGenerating = true;
+          }
+
+          if (plainPreviews[afterKey] !== undefined) {
+            afterText = plainPreviews[afterKey] ?? sug.proposed_description;
+          } else {
+            afterGenerating = true;
+          }
+        }
+
+        return (
+        <div key={i} className="diag-taxo-suggestion">
+          <div className="ovw-suggestion-head">
+            <span className="diag-an-id">{sug.node_id}</span>
+            <strong className="ovw-07rem">{sug.node_label}</strong>
+            <span className="diag-badge diag-badge-move ovw-2xs">{sug.node_pov}</span>
+            <span className={`diag-badge diag-suggestion-${sug.suggestion_type} ovw-2xs`}>{sug.suggestion_type}</span>
+          </div>
+          {beforeText && (
+            <div className="diag-taxo-before">
+              <span className="diag-k">Before:</span>
+              <div className={`diag-taxo-desc${beforeGenerating ? ' plain-description-generating' : ''}`}>{beforeText}</div>
+            </div>
+          )}
+          <div className="diag-taxo-after">
+            <span className="diag-k">After:</span>
+            <div className={`diag-taxo-desc diag-taxo-desc-proposed${afterGenerating ? ' plain-description-generating' : ''}`}>{afterText}</div>
+          </div>
+          <div className="ovw-rationale">
+            {sug.rationale}
+          </div>
+          {sug.evidence_claim_ids && sug.evidence_claim_ids.length > 0 && (
+            <div className="ovw-evidence-list">
+              Evidence: {sug.evidence_claim_ids.join(', ')}
+            </div>
+          )}
+        </div>
+        );
+      })}
+    </CollapsibleSection>
+  );
+}
+
+function SessionStatisticsSection({ diag, transcript }: { diag: ActiveDebate['diagnostics']; transcript: ActiveDebate['transcript'] }) {
+  if (!diag) return null;
+  return (
+    <CollapsibleSection title="Session Statistics" defaultOpen>
+      <div className="diag-kv"><span className="diag-k">Statements:</span> <span className="diag-v">{transcript.filter(e => e.type === 'statement' || e.type === 'opening').length} ({transcript.length} total entries)</span></div>
+      <div className="diag-kv"><span className="diag-k">AI calls:</span> <span className="diag-v">{diag.overview.total_ai_calls}</span></div>
+      <div className="diag-kv"><span className="diag-k">Total response time:</span> <span className="diag-v">{((diag.overview.total_response_time_ms ?? 0) / 1000).toFixed(1)}s</span></div>
+      <div className="diag-kv"><span className="diag-k">Claims accepted:</span> <span className="diag-v">{diag.overview.claims_accepted}</span></div>
+      <div className="diag-kv"><span className="diag-k">Claims rejected:</span> <span className="diag-v">{diag.overview.claims_rejected}</span></div>
+      {(diag.overview.total_input_tokens != null || diag.overview.total_output_tokens != null) && (
+        <div className="diag-kv">
+          <span className="diag-k">Total tokens:</span>
+          <span className="diag-v">
+            {diag.overview.total_input_tokens != null ? diag.overview.total_input_tokens.toLocaleString() : '—'} in
+            {' / '}
+            {diag.overview.total_output_tokens != null ? diag.overview.total_output_tokens.toLocaleString() : '—'} out
+            {diag.overview.total_input_tokens != null && diag.overview.total_output_tokens != null && (
+              <> ({(diag.overview.total_input_tokens + diag.overview.total_output_tokens).toLocaleString()} total)</>
+            )}
+          </span>
+        </div>
+      )}
+      {Object.keys(diag.overview.move_type_counts).length > 0 && (
+        <div className="ovw-mt6">
+          <span className="diag-k">Move types:</span>
+          <div className="diag-badges">
+            {Object.entries(diag.overview.move_type_counts).sort((a, b) => b[1] - a[1]).map(([m, c]) => (
+              <span key={m} className="diag-badge diag-badge-move">{m} ({c})</span>
+            ))}
+          </div>
+        </div>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+function EmptyStateSection({ an, commitments, diag }: {
+  an: ActiveDebate['argument_network'];
+  commitments: ActiveDebate['commitments'];
+  diag: ActiveDebate['diagnostics'];
+}) {
+  if (an?.nodes.length || commitments || diag) return null;
+  return (
+    <div className="diag-empty">No diagnostic data available. Enable diagnostics and run a debate to see the argument network, commitments, and statistics.</div>
+  );
+}
+
 export function OverviewView() {
   const { activeDebate, askQuestion, debateGenerating } = useDebateStore(
     useShallow(s => ({ activeDebate: s.activeDebate, askQuestion: s.askQuestion, debateGenerating: s.debateGenerating }))
@@ -413,539 +1052,50 @@ export function OverviewView() {
 
   const topicScope = activeDebate.topic?.scope as TopicScope | undefined;
 
-  const [descMode, setDescMode] = useDescriptionMode();
-  const taxState = useTaxonomyStore(useShallow(s => ({
-    accelerationist: s.accelerationist, safetyist: s.safetyist, skeptic: s.skeptic, situations: s.situations,
-  })));
-
-  const [plainPreviews, setPlainPreviews] = useState<Record<string, string | null>>({});
-  const [previewLoading, setPreviewLoading] = useState<Record<string, boolean>>({});
-  const inflightRef = useRef<Set<string>>(new Set());
-
-  const lookupPlainDescription = useCallback((nodeId: string, pov: string): string | null => {
-    const povKey = pov as keyof typeof taxState;
-    const file = taxState[povKey];
-    if (!file?.nodes) return null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const node = (file.nodes as any[]).find((n: any) => n.id === nodeId);
-    return node?.plain_description ?? null;
-  }, [taxState]);
-
-  const suggestions = activeDebate.taxonomy_suggestions;
-  useEffect(() => {
-    if (descMode !== 'plain' || !suggestions?.length) return;
-    for (let i = 0; i < suggestions.length; i++) {
-      const sug = suggestions[i];
-      const key = `after-${sug.node_id}-${i}`;
-      if (inflightRef.current.has(key) || plainPreviews[key] !== undefined) continue;
-      inflightRef.current.add(key);
-      setPreviewLoading(prev => ({ ...prev, [key]: true }));
-      void generatePlainPreview(sug.proposed_description ?? '').then(text => {
-        setPlainPreviews(prev => ({ ...prev, [key]: text }));
-        setPreviewLoading(prev => ({ ...prev, [key]: false }));
-      });
-    }
-  }, [descMode, suggestions, plainPreviews]);
-
   return (
     <div className="diag-overview">
       {/* Topic Scope (10.2) */}
-      {topicScope && <TopicScopePanel scope={topicScope} />}
+      <TopicScopeSection scope={topicScope} />
 
       {/* Strength Timeline (D-Q5) */}
-      {timeline && timeline.length > 0 && an && (
-        <StrengthTimeline timeline={timeline} nodes={an.nodes} />
-      )}
+      <StrengthTimelineSection timeline={timeline} an={an} />
 
       {/* Document Coverage (CT-3/CT-4) — click-to-steer injects a question about uncovered claims */}
-      {coverageMap && <DocumentCoverageSection coverageMap={coverageMap} strengthWeighted={strengthWeighted} onSteerToClaim={debateGenerating ? undefined : (claimText) => {
-        void askQuestion(`What is your perspective on the claim that ${claimText}?`);
-      }} />}
+      <DocumentCoverageWrapper coverageMap={coverageMap} strengthWeighted={strengthWeighted} debateGenerating={debateGenerating} askQuestion={askQuestion} />
 
       {/* Argument Network */}
-      {an && an.nodes.length > 0 && <PanelArgumentNetwork an={an} />}
+      <PanelArgumentNetworkSection an={an} />
 
       {/* What-If Mode (D-Q6) */}
-      {an && an.nodes.length > 0 && (
-        <WhatIfSection nodes={an.nodes} edges={an.edges} />
-      )}
+      <WhatIfWrapper an={an} />
 
       {/* Commitment Stores */}
-      {commitments && Object.keys(commitments).length > 0 && (
-        <CollapsibleSection title="Commitment Stores" defaultOpen>
-          {Object.entries(commitments).map(([poverId, store]) => (
-            <div key={poverId} className="diag-commit-store">
-              <strong>{speakerLabel(poverId as SpeakerId)}</strong>
-              <div className="diag-commit-counts">
-                Asserted: {store.asserted.length} | Conceded: {store.conceded.length} | Challenged: {store.challenged.length}
-              </div>
-              {store.conceded.length > 0 && (
-                <div className="diag-commit-list">
-                  <span className="diag-muted">Conceded:</span>
-                  {store.conceded.map((c, i) => <div key={i} className="diag-commit-item">• {c}</div>)}
-                </div>
-              )}
-            </div>
-          ))}
-        </CollapsibleSection>
-      )}
+      <CommitmentStoresSection commitments={commitments} />
 
       {/* Active Moderator State */}
-      {activeDebate.moderator_state && (() => {
-        const ms = activeDebate.moderator_state;
-        const latestHealth = ms.health_history.length > 0 ? ms.health_history[ms.health_history.length - 1] : null;
-        const familyColors: Record<string, string> = {
-          procedural: 'var(--color-saf)', elicitation: 'var(--warning)', repair: 'var(--danger)',
-          reconciliation: 'var(--success)', reflection: 'var(--text-secondary)', synthesis: 'var(--text-secondary)',
-        };
-        const maxBurden = Math.max(...Object.values(ms.burden_per_debater), 0.01);
-
-        return (
-          <CollapsibleSection title={`Active Moderator — ${ms.interventions_fired} interventions, budget ${ms.budget_remaining}/${ms.budget_total}`} defaultOpen>
-            {/* Budget gauge */}
-            <div className="diag-kv">
-              <span className="diag-k">Budget:</span>
-              <span className="diag-v">{ms.budget_remaining}/{ms.budget_total} remaining</span>
-            </div>
-            <div className="ovw-gauge-track">
-              {/* eslint-disable-next-line local/no-inline-style -- data-driven width/background */}
-              <div className="ovw-gauge-fill" style={{
-                width: `${ms.budget_total > 0 ? ((ms.budget_total - ms.budget_remaining) / ms.budget_total * 100) : 0}%`,
-                background: ms.budget_remaining <= 1 ? 'var(--danger)' : ms.budget_remaining <= 2 ? 'var(--warning)' : 'var(--success)',
-              }} />
-            </div>
-
-            {/* Health score */}
-            {latestHealth && (
-              <>
-                <div className="diag-kv">
-                  <span className="diag-k">Health:</span>
-                  {/* eslint-disable-next-line local/no-inline-style -- data-driven health color */}
-                  <span className="diag-v" style={{ color: latestHealth.value >= 0.7 ? 'var(--success)' : latestHealth.value >= 0.4 ? 'var(--warning)' : 'var(--danger)' }}>
-                    {(latestHealth.value ?? 0).toFixed(2)}
-                  </span>
-                  {ms.consecutive_decline > 0 && <span className="diag-badge ovw-badge-danger-ml4">{ms.consecutive_decline} decline{ms.consecutive_decline > 1 ? 's' : ''}</span>}
-                  {ms.consecutive_rise >= 2 && <span className="diag-badge ovw-badge-success-ml4">{ms.consecutive_rise} rises</span>}
-                </div>
-                <div className="ovw-health-grid">
-                  {(['engagement', 'novelty', 'responsiveness', 'coverage', 'balance'] as const).map(comp => (
-                    <div key={comp} className="ovw-center">
-                      <div className="diag-k ovw-2xs">{comp.slice(0, 3).toUpperCase()}</div>
-                      {/* eslint-disable-next-line local/no-inline-style -- data-driven component color */}
-                      <div className="ovw-fw600" style={{ color: latestHealth.components[comp] >= 0.5 ? 'var(--success)' : latestHealth.components[comp] >= 0.25 ? 'var(--warning)' : 'var(--danger)' }}>
-                        {(latestHealth.components[comp] ?? 0).toFixed(2)}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </>
-            )}
-
-            {/* Burden distribution */}
-            {Object.keys(ms.burden_per_debater).length > 0 && (
-              <div className="ovw-mb6">
-                <span className="diag-k ovw-2xs">Burden (avg {(ms.avg_burden ?? 0).toFixed(2)}):</span>
-                {Object.entries(ms.burden_per_debater).map(([debater, burden]) => (
-                  <div key={debater} className="ovw-burden-row">
-                    <span className="ovw-burden-label">{speakerLabel(debater as SpeakerId)}</span>
-                    <div className="ovw-burden-track">
-                      {/* eslint-disable-next-line local/no-inline-style -- data-driven width/background */}
-                      <div className="ovw-gauge-fill" style={{ width: `${(burden / maxBurden * 100)}%`, background: burden > ms.avg_burden * 1.5 ? 'var(--danger)' : 'var(--color-saf)' }} />
-                    </div>
-                    <span className="ovw-burden-val">{(burden ?? 0).toFixed(2)}</span>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Cooldown & state */}
-            <div className="ovw-cooldown-row">
-              <span><span className="diag-k">Cooldown:</span> {ms.rounds_since_last_intervention >= ms.required_gap ? <span className="ovw-success">ready</span> : <span className="ovw-warning">{ms.required_gap - ms.rounds_since_last_intervention}r left</span>}</span>
-              <span><span className="diag-k">Gap:</span> {ms.required_gap}</span>
-              {ms.cooldown_blocked_count > 0 && <span><span className="diag-k">Blocked:</span> {ms.cooldown_blocked_count}x</span>}
-            </div>
-
-            {/* Intervention history */}
-            {ms.intervention_history.length > 0 && (
-              <div className="ovw-mt4">
-                <span className="diag-k ovw-2xs">Interventions:</span>
-                {ms.intervention_history.map((h, i) => (
-                  <div key={i} className="ovw-intervention-row">
-                    <span className="diag-muted ovw-w24">R{h.round}</span>
-                    {/* eslint-disable-next-line local/no-inline-style -- data-driven family color */}
-                    <span className="diag-badge ovw-2xs" style={{ background: `${familyColors[h.family] ?? 'var(--text-muted)'}30`, color: familyColors[h.family] ?? 'var(--text-muted)' }}>{h.move}</span>
-                    <span className="ovw-2xs">{'→'} {speakerLabel(h.target as SpeakerId)}</span>
-                    <span className="diag-muted ovw-2xs">({(h.burden ?? 0).toFixed(1)})</span>
-                  </div>
-                ))}
-              </div>
-            )}
-          </CollapsibleSection>
-        );
-      })()}
+      <ActiveModeratorSection moderatorState={activeDebate.moderator_state} />
 
       {/* Moderator Deliberations — aggregate moderator_trace from system entries */}
-      {(() => {
-        const modEntries = activeDebate.transcript
-          .filter(e => (e.metadata as Record<string, unknown>)?.moderator_trace)
-          .map(e => ({
-            id: e.id,
-            trace: (e.metadata as Record<string, unknown>).moderator_trace as {
-              selected: string; focus_point: string; addressing?: string;
-              agreement_detected?: boolean; recent_scheme?: string | null;
-              convergence_score?: number | null; convergence_triggered?: boolean;
-              intervention_recommended?: boolean; intervention_move?: string | null; intervention_validated?: boolean;
-              health_score?: number; budget_remaining?: number;
-              argument_network_snapshot?: { total_claims: number; total_edges: number; unaddressed_claims: number } | null;
-            },
-          }));
-        if (modEntries.length === 0) return null;
-
-        const selectionCounts: Record<string, number> = {};
-        let convergenceValues: number[] = [];
-        modEntries.forEach(({ trace }) => {
-          selectionCounts[trace.selected] = (selectionCounts[trace.selected] || 0) + 1;
-          if (trace.convergence_score != null) convergenceValues.push(trace.convergence_score);
-        });
-        const latestTrace = modEntries[modEntries.length - 1].trace;
-        const avgConvergence = convergenceValues.length > 0
-          ? convergenceValues.reduce((a, b) => a + b, 0) / convergenceValues.length
-          : null;
-
-        return (
-          <CollapsibleSection title={`Moderator Deliberations — ${modEntries.length} rounds`} defaultOpen>
-            <div className="diag-kv">
-              <span className="diag-k">Speaker selection:</span>
-              <div className="diag-badges">
-                {Object.entries(selectionCounts).sort((a, b) => b[1] - a[1]).map(([s, c]) => (
-                  <span key={s} className="diag-badge diag-badge-move">{speakerLabel(s as SpeakerId)} ({c})</span>
-                ))}
-              </div>
-            </div>
-            {avgConvergence != null && (
-              <div className="diag-kv">
-                <span className="diag-k">Avg convergence:</span>
-                <span className="diag-v">{(avgConvergence * 100).toFixed(0)}%</span>
-                {latestTrace.convergence_triggered && <span className="diag-badge ovw-badge-success-ml4">triggered</span>}
-              </div>
-            )}
-            {latestTrace.focus_point && (
-              <div className="diag-kv">
-                <span className="diag-k">Current focus:</span>
-                <span className="diag-v">{latestTrace.focus_point}</span>
-              </div>
-            )}
-            {latestTrace.argument_network_snapshot && (
-              <div className="diag-kv">
-                <span className="diag-k">AN snapshot:</span>
-                <span className="diag-v">
-                  {latestTrace.argument_network_snapshot.total_claims} claims, {latestTrace.argument_network_snapshot.total_edges} edges, {latestTrace.argument_network_snapshot.unaddressed_claims} unaddressed
-                </span>
-              </div>
-            )}
-            <div className="ovw-mt6-2xs">
-              {modEntries.slice(-5).reverse().map(({ id, trace }) => (
-                <div key={id} className="diag-mod-round ovw-mod-round-row">
-                  <span className="diag-badge diag-badge-move ovw-2xs-minw50">{speakerLabel(trace.selected as SpeakerId)}</span>
-                  <span className="diag-muted ovw-flex1">{trace.focus_point}</span>
-                  {/* eslint-disable-next-line local/no-inline-style -- data-driven validated color */}
-                  {trace.intervention_move && <span className="diag-badge ovw-2xs" style={{ background: trace.intervention_validated ? 'color-mix(in srgb, var(--text-secondary) 20%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)', color: trace.intervention_validated ? 'var(--text-secondary)' : 'var(--danger)' }}>{trace.intervention_move}{trace.intervention_validated ? '' : ' (suppressed)'}</span>}
-                  {trace.health_score != null && <span className="diag-muted ovw-2xs">H:{trace.health_score.toFixed(2)}</span>}
-                  {trace.recent_scheme && <span className="diag-badge ovw-badge-secondary">{trace.recent_scheme}</span>}
-                  {trace.convergence_score != null && <span className="diag-muted">{(trace.convergence_score * 100).toFixed(0)}%</span>}
-                </div>
-              ))}
-            </div>
-          </CollapsibleSection>
-        );
-      })()}
+      <ModeratorDeliberationsSection transcript={activeDebate.transcript} />
 
       {/* Drift Detection Trace (10.6) — moderator drift patterns */}
-      {(() => {
-        const driftEntries = activeDebate.transcript
-          .filter(e => {
-            const trace = (e.metadata as Record<string, unknown>)?.moderator_trace as Record<string, unknown> | undefined;
-            return trace?.drift_detected === true;
-          })
-          .map(e => {
-            const trace = (e.metadata as Record<string, unknown>).moderator_trace as Record<string, unknown>;
-            const round = trace.debate_phase ? undefined : (e.metadata as Record<string, unknown>)?.round as number | undefined;
-            return {
-              id: e.id,
-              round,
-              reasoning: trace.drift_reasoning as string | null,
-              intervention_move: trace.intervention_move as string | null,
-              intervention_validated: trace.intervention_validated as boolean | undefined,
-              selected: trace.selected as string | undefined,
-            };
-          });
-        if (driftEntries.length === 0) return null;
-        const redirected = driftEntries.filter(d => d.intervention_validated && d.intervention_move && ['REDIRECT', 'CHALLENGE', 'CLARIFY', 'CHECK'].includes(d.intervention_move));
-        return (
-          <CollapsibleSection title={`Drift Detection — ${driftEntries.length} detected, ${redirected.length} intervened`}>
-            {driftEntries.map(d => (
-              <div key={d.id} className="ovw-mb6-2xs">
-                <div className="ovw-flex-baseline">
-                  {d.round != null && <span className="diag-muted">R{d.round}</span>}
-                  {d.selected && <span>{speakerLabel(d.selected as SpeakerId)}</span>}
-                  {/* eslint-disable-next-line local/no-inline-style -- data-driven validated color */}
-                  <span className="diag-badge ovw-2xs" style={{
-                    background: d.intervention_validated ? 'color-mix(in srgb, var(--danger) 15%, transparent)' : 'color-mix(in srgb, var(--warning) 15%, transparent)',
-                    color: d.intervention_validated ? 'var(--danger)' : 'var(--warning)',
-                  }}>
-                    {d.intervention_validated && d.intervention_move ? d.intervention_move : 'drift noted'}
-                  </span>
-                </div>
-                {d.reasoning && (
-                  <div className="ovw-drift-reason">{d.reasoning}</div>
-                )}
-              </div>
-            ))}
-          </CollapsibleSection>
-        );
-      })()}
+      <DriftDetectionSection transcript={activeDebate.transcript} />
 
       {/* Unanswered Claims Ledger */}
-      {activeDebate.unanswered_claims_ledger && activeDebate.unanswered_claims_ledger.length > 0 && (
-        <CollapsibleSection title={`Unanswered Claims — ${activeDebate.unanswered_claims_ledger.filter(c => !c.addressed_round).length} open`}>
-          {activeDebate.unanswered_claims_ledger.map(claim => (
-            <div key={claim.claim_id} className={`diag-ledger-entry ${claim.addressed_round ? 'diag-ledger-addressed' : ''}`}>
-              <div className="ovw-flex-baseline">
-                <span className="diag-an-id">{claim.claim_id}</span>
-                <span className="diag-an-speaker">({speakerLabel(claim.speaker as SpeakerId)})</span>
-                {/* eslint-disable-next-line local/no-inline-style -- data-driven addressed color */}
-                <span className="diag-badge ovw-2xs" style={{ background: claim.addressed_round ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--danger) 15%, transparent)', color: claim.addressed_round ? 'var(--success)' : 'var(--danger)' }}>
-                  {claim.addressed_round ? `addressed R${claim.addressed_round}` : `since R${claim.first_unanswered_round}`}
-                </span>
-              </div>
-              <div className="ovw-pl8-2xs">{claim.claim_text}</div>
-            </div>
-          ))}
-        </CollapsibleSection>
-      )}
+      <UnansweredClaimsSection ledger={activeDebate.unanswered_claims_ledger} />
 
       {/* Missing Arguments */}
-      {activeDebate.missing_arguments && activeDebate.missing_arguments.length > 0 && (
-        <CollapsibleSection title={`Missing Arguments — ${activeDebate.missing_arguments.length} identified`}>
-          {activeDebate.missing_arguments.map((arg, i) => (
-            <div key={i} className="diag-missing-arg">
-              <div className="ovw-flex-baseline">
-                <span className="diag-badge diag-badge-move ovw-2xs">{arg.side}</span>
-                <span className="diag-badge ovw-badge-secondary">{arg.bdi_layer}</span>
-              </div>
-              <div className="ovw-arg-text">{arg.argument}</div>
-              <div className="ovw-2xs-muted-italic">{arg.why_strong}</div>
-            </div>
-          ))}
-        </CollapsibleSection>
-      )}
+      <MissingArgumentsSection missing={activeDebate.missing_arguments} />
 
       {/* Position Drift (Sycophancy Guard) */}
-      {activeDebate.position_drift && activeDebate.position_drift.length > 0 && (() => {
-        const drift = activeDebate.position_drift!;
-        const speakers = [...new Set(drift.map(d => d.speaker))];
-        return (
-          <CollapsibleSection title={`Position Drift — ${drift.length} snapshots`}>
-            {speakers.map(speaker => {
-              const speakerDrift = drift.filter(d => d.speaker === speaker);
-              const latest = speakerDrift[speakerDrift.length - 1];
-              const first = speakerDrift[0];
-              const selfDelta = (latest.self_similarity ?? 0) - (first.self_similarity ?? 0);
-              return (
-                <div key={speaker} className="diag-drift-speaker">
-                  <div className="ovw-flex-baseline">
-                    <strong>{speakerLabel(speaker as SpeakerId)}</strong>
-                    <span className="diag-muted">self-sim: {(latest.self_similarity ?? 0).toFixed(3)}</span>
-                    <span className={`diag-badge ${selfDelta < -0.05 ? 'diag-drift-warning' : ''} ovw-2xs`}>
-                      {selfDelta > 0 ? '+' : ''}{selfDelta.toFixed(3)}
-                    </span>
-                  </div>
-                  <div className="ovw-opp-sims">
-                    {Object.entries(latest.opponent_similarities).map(([opp, sim]) => (
-                      <span key={opp}>→ {speakerLabel(opp as SpeakerId)}: {(sim ?? 0).toFixed(3)}</span>
-                    ))}
-                  </div>
-                </div>
-              );
-            })}
-          </CollapsibleSection>
-        );
-      })()}
+      <PositionDriftSection positionDrift={activeDebate.position_drift} />
 
       {/* Exclusion Guard Summary */}
-      {(() => {
-        const entries = diag?.entries;
-        if (!entries || Object.keys(entries).length === 0) return null;
-
-        let claimsChecked = 0;
-        let claimViolations: { claim_id: string; claim_text: string; node_id: string; similarity_main: number; similarity_exclusion: number }[] = [];
-        let draftsChecked = 0;
-        let driftWarnings: { debater: string; node_id: string; similarity: number; draft_excerpt: string }[] = [];
-        let hasAnyData = false;
-
-        for (const entry of Object.values(entries)) {
-          const extTrace = entry.extraction_trace;
-          if (extTrace) {
-            hasAnyData = true;
-            if (extTrace.exclusion_guard) {
-              claimsChecked += extTrace.exclusion_guard.checked;
-              if (extTrace.exclusion_guard.violations?.length) claimViolations = claimViolations.concat(extTrace.exclusion_guard.violations);
-            }
-            if (extTrace.exclusion_violations?.length) {
-              claimViolations = claimViolations.concat(extTrace.exclusion_violations);
-            }
-          }
-
-          if (entry.scope_drift_check) {
-            hasAnyData = true;
-            draftsChecked += entry.scope_drift_check.refs_checked;
-            if (entry.scope_drift_check.warnings?.length) driftWarnings = driftWarnings.concat(entry.scope_drift_check.warnings);
-          }
-          if (entry.scope_drift_warnings?.length) {
-            hasAnyData = true;
-            driftWarnings = driftWarnings.concat(entry.scope_drift_warnings);
-          }
-        }
-
-        if (!hasAnyData) {
-          return (
-            <CollapsibleSection title="Exclusion Guard">
-              <div className="ovw-empty-note">
-                Exclusion guard data not available for this debate
-              </div>
-            </CollapsibleSection>
-          );
-        }
-
-        const allClear = claimViolations.length === 0 && driftWarnings.length === 0;
-
-        return (
-          <CollapsibleSection title={`Exclusion Guard${!allClear ? ` — ${claimViolations.length + driftWarnings.length} issues` : ''}`}>
-            {allClear ? (
-              <div className="ovw-all-clear">
-                All statements within scope — no exclusion violations or drift warnings
-              </div>
-            ) : (
-              <div className="ovw-sm">
-                <div className="ovw-summary-row">
-                  {/* eslint-disable-next-line local/no-inline-style -- data-driven violation color */}
-                  <span className="ovw-summary-chip" style={{
-                    background: claimViolations.length > 0 ? 'color-mix(in srgb, var(--danger) 10%, transparent)' : 'color-mix(in srgb, var(--success) 8%, transparent)',
-                    color: claimViolations.length > 0 ? 'var(--danger)' : 'var(--success)',
-                  }}>
-                    {claimsChecked} claims checked, {claimViolations.length} violation{claimViolations.length !== 1 ? 's' : ''}
-                  </span>
-                  {/* eslint-disable-next-line local/no-inline-style -- data-driven warning color */}
-                  <span className="ovw-summary-chip" style={{
-                    background: driftWarnings.length > 0 ? 'color-mix(in srgb, var(--warning) 10%, transparent)' : 'color-mix(in srgb, var(--success) 8%, transparent)',
-                    color: driftWarnings.length > 0 ? 'var(--warning)' : 'var(--success)',
-                  }}>
-                    {draftsChecked} drafts checked, {driftWarnings.length} drift warning{driftWarnings.length !== 1 ? 's' : ''}
-                  </span>
-                </div>
-                {claimViolations.length > 0 && (
-                  <div className="ovw-mb6">
-                    <div className="diag-k ovw-viol-header">Exclusion Violations ({claimViolations.length})</div>
-                    {claimViolations.slice(0, 10).map((v, i) => (
-                      <div key={i} className="ovw-viol-row">
-                        <span className="ovw-fw600-danger">{v.claim_id}</span>
-                        <span className="ovw-muted-color">→</span>
-                        <span>{v.node_id}</span>
-                        <span className="diag-muted ovw-2xs">
-                          (main: {v.similarity_main.toFixed(2)}, excl: {v.similarity_exclusion.toFixed(2)})
-                        </span>
-                      </div>
-                    ))}
-                    {claimViolations.length > 10 && (
-                      <div className="diag-muted ovw-2xs-ml8">…and {claimViolations.length - 10} more</div>
-                    )}
-                  </div>
-                )}
-                {driftWarnings.length > 0 && (
-                  <div>
-                    <div className="diag-k ovw-drift-header">Scope Drift Warnings ({driftWarnings.length})</div>
-                    {driftWarnings.slice(0, 10).map((w, i) => (
-                      <div key={i} className="ovw-viol-row">
-                        <span className="ovw-fw600-warning">{w.debater}</span>
-                        <span className="ovw-muted-color">→</span>
-                        <span>{w.node_id}</span>
-                        <span className="diag-muted ovw-2xs">
-                          (sim: {w.similarity.toFixed(2)})
-                        </span>
-                      </div>
-                    ))}
-                    {driftWarnings.length > 10 && (
-                      <div className="diag-muted ovw-2xs-ml8">…and {driftWarnings.length - 10} more</div>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-            <div className="diag-muted ovw-2xs-mt6">
-              {claimsChecked} claims checked, {claimViolations.length} violation{claimViolations.length !== 1 ? 's' : ''} | {draftsChecked} drafts checked, {driftWarnings.length} drift warning{driftWarnings.length !== 1 ? 's' : ''}
-            </div>
-          </CollapsibleSection>
-        );
-      })()}
+      <ExclusionGuardSection entries={diag?.entries} />
 
       {/* Taxonomy Suggestions */}
       {activeDebate.taxonomy_suggestions && activeDebate.taxonomy_suggestions.length > 0 && (
-        <CollapsibleSection title={`Taxonomy Suggestions — ${activeDebate.taxonomy_suggestions.length} revisions`} defaultOpen>
-          <div className="ovw-toolbar-mb6">
-            <DescriptionToggle mode={descMode} onToggle={setDescMode} hasPlainDescription />
-          </div>
-          {activeDebate.taxonomy_suggestions.map((sug, i) => {
-            const afterKey = `after-${sug.node_id}-${i}`;
-            let beforeText = sug.current_description;
-            let afterText = sug.proposed_description;
-            let beforeGenerating = false;
-            let afterGenerating = false;
-
-            if (descMode === 'plain') {
-              const storedPlain = lookupPlainDescription(sug.node_id, sug.node_pov);
-              if (storedPlain) {
-                beforeText = storedPlain;
-              } else if (sug.current_description) {
-                beforeGenerating = true;
-              }
-
-              if (plainPreviews[afterKey] !== undefined) {
-                afterText = plainPreviews[afterKey] ?? sug.proposed_description;
-              } else {
-                afterGenerating = true;
-              }
-            }
-
-            return (
-            <div key={i} className="diag-taxo-suggestion">
-              <div className="ovw-suggestion-head">
-                <span className="diag-an-id">{sug.node_id}</span>
-                <strong className="ovw-07rem">{sug.node_label}</strong>
-                <span className="diag-badge diag-badge-move ovw-2xs">{sug.node_pov}</span>
-                <span className={`diag-badge diag-suggestion-${sug.suggestion_type} ovw-2xs`}>{sug.suggestion_type}</span>
-              </div>
-              {beforeText && (
-                <div className="diag-taxo-before">
-                  <span className="diag-k">Before:</span>
-                  <div className={`diag-taxo-desc${beforeGenerating ? ' plain-description-generating' : ''}`}>{beforeText}</div>
-                </div>
-              )}
-              <div className="diag-taxo-after">
-                <span className="diag-k">After:</span>
-                <div className={`diag-taxo-desc diag-taxo-desc-proposed${afterGenerating ? ' plain-description-generating' : ''}`}>{afterText}</div>
-              </div>
-              <div className="ovw-rationale">
-                {sug.rationale}
-              </div>
-              {sug.evidence_claim_ids && sug.evidence_claim_ids.length > 0 && (
-                <div className="ovw-evidence-list">
-                  Evidence: {sug.evidence_claim_ids.join(', ')}
-                </div>
-              )}
-            </div>
-            );
-          })}
-        </CollapsibleSection>
+        <TaxonomySuggestionsSection suggestions={activeDebate.taxonomy_suggestions} />
       )}
 
       {/* Fact-Check Verification */}
@@ -955,42 +1105,9 @@ export function OverviewView() {
       />
 
       {/* Overview Stats */}
-      {diag && (
-        <CollapsibleSection title="Session Statistics" defaultOpen>
-          <div className="diag-kv"><span className="diag-k">Statements:</span> <span className="diag-v">{activeDebate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length} ({activeDebate.transcript.length} total entries)</span></div>
-          <div className="diag-kv"><span className="diag-k">AI calls:</span> <span className="diag-v">{diag.overview.total_ai_calls}</span></div>
-          <div className="diag-kv"><span className="diag-k">Total response time:</span> <span className="diag-v">{((diag.overview.total_response_time_ms ?? 0) / 1000).toFixed(1)}s</span></div>
-          <div className="diag-kv"><span className="diag-k">Claims accepted:</span> <span className="diag-v">{diag.overview.claims_accepted}</span></div>
-          <div className="diag-kv"><span className="diag-k">Claims rejected:</span> <span className="diag-v">{diag.overview.claims_rejected}</span></div>
-          {(diag.overview.total_input_tokens != null || diag.overview.total_output_tokens != null) && (
-            <div className="diag-kv">
-              <span className="diag-k">Total tokens:</span>
-              <span className="diag-v">
-                {diag.overview.total_input_tokens != null ? diag.overview.total_input_tokens.toLocaleString() : '—'} in
-                {' / '}
-                {diag.overview.total_output_tokens != null ? diag.overview.total_output_tokens.toLocaleString() : '—'} out
-                {diag.overview.total_input_tokens != null && diag.overview.total_output_tokens != null && (
-                  <> ({(diag.overview.total_input_tokens + diag.overview.total_output_tokens).toLocaleString()} total)</>
-                )}
-              </span>
-            </div>
-          )}
-          {Object.keys(diag.overview.move_type_counts).length > 0 && (
-            <div className="ovw-mt6">
-              <span className="diag-k">Move types:</span>
-              <div className="diag-badges">
-                {Object.entries(diag.overview.move_type_counts).sort((a, b) => b[1] - a[1]).map(([m, c]) => (
-                  <span key={m} className="diag-badge diag-badge-move">{m} ({c})</span>
-                ))}
-              </div>
-            </div>
-          )}
-        </CollapsibleSection>
-      )}
+      <SessionStatisticsSection diag={diag} transcript={activeDebate.transcript} />
 
-      {!an?.nodes.length && !commitments && !diag && (
-        <div className="diag-empty">No diagnostic data available. Enable diagnostics and run a debate to see the argument network, commitments, and statistics.</div>
-      )}
+      <EmptyStateSection an={an} commitments={commitments} diag={diag} />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.parts.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.parts.tsx
@@ -36,6 +36,55 @@ interface PartProps {
   m: EntryDetailRouterModel;
 }
 
+type IntMeta = EntryDetailRouterProps['entry']['intervention_metadata'];
+type TopicAlignment = NonNullable<NonNullable<EntryDetailRouterProps['diag']>['topic_alignment']>;
+
+// Pure branch selection for the scope badge — extracted from EntryHeader's
+// topic-alignment IIFE (ADR-007) so both the component and this chain stay ≤15.
+function scopeBadgeState(
+  ta: TopicAlignment,
+  modRedirect: unknown,
+  modDrift: boolean,
+  hasDemotedRef: boolean,
+  intMeta: IntMeta,
+): { state: 'green' | 'amber' | 'red'; label: string; tip: string } {
+  let state: 'green' | 'amber' | 'red';
+  let label: string;
+  let tip: string;
+  if (!ta.topic_aligned || modRedirect) {
+    state = 'red'; label = modRedirect ? 'drift redirect' : 'off-scope'; tip = modRedirect ? `Moderator ${intMeta!.move} for drift` : 'Topic alignment failed after all retries';
+  } else if (ta.repaired) {
+    state = 'amber'; label = 'repaired'; tip = 'Off-scope draft repaired on retry';
+  } else if (modDrift || hasDemotedRef) {
+    state = 'amber'; label = 'drift noted'; tip = modDrift ? 'Moderator flagged drift concern' : 'References demoted taxonomy node';
+  } else {
+    state = 'green'; label = 'on-scope'; tip = 'All topic alignment checks passed';
+  }
+  return { state, label, tip };
+}
+
+// Scope/topic-alignment badge — extracted verbatim from EntryHeader's IIFE.
+function TopicAlignmentBadge({ entry, diag, meta }: Pick<EntryDetailRouterProps, 'entry' | 'diag' | 'meta'>) {
+  if (!diag?.topic_alignment) return null;
+  const ta = diag.topic_alignment;
+  const sft = (meta?.injection_manifest as Record<string, unknown> | undefined)?.scope_filter_trace as
+    { demoted?: { nodeId: string }[] } | undefined;
+  const demotedIds = new Set((sft?.demoted ?? []).map(d => d.nodeId));
+  const hasDemotedRef = (entry.taxonomy_refs ?? []).some(r => demotedIds.has(r.node_id));
+  const modTrace = meta?.moderator_trace as Record<string, unknown> | undefined;
+  const modDrift = modTrace?.drift_detected === true;
+  const intMeta = entry.intervention_metadata;
+  const modRedirect = modDrift && intMeta && ['REDIRECT', 'CHALLENGE'].includes(intMeta.move);
+  const { state, label, tip } = scopeBadgeState(ta, modRedirect, modDrift, hasDemotedRef, intMeta);
+  const colors = { green: 'var(--success)', amber: 'var(--warning, var(--warning))', red: 'var(--danger)' };
+  const bgs = { green: 'color-mix(in srgb, var(--success) 15%, transparent)', amber: 'color-mix(in srgb, var(--warning, var(--warning)) 15%, transparent)', red: 'color-mix(in srgb, var(--danger) 15%, transparent)' };
+  return (
+    <span title={tip} className="edr-scope-badge" style={{
+      background: bgs[state], color: colors[state],
+    }}>{label}</span>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Entry header (statement badge, speaker, scope/repair badges, nav)
 // ---------------------------------------------------------------------------
@@ -72,36 +121,7 @@ export function EntryHeader({ p, m }: PartProps) {
         className="edr-copy-id-btn"
         title={`Copy turn_id for flight recorder correlation: ${entry.id}`}
       >{entry.id.slice(0, 8)}</button>
-      {diag?.topic_alignment && (() => {
-        const ta = diag.topic_alignment;
-        const sft = (meta?.injection_manifest as Record<string, unknown> | undefined)?.scope_filter_trace as
-          { demoted?: { nodeId: string }[] } | undefined;
-        const demotedIds = new Set((sft?.demoted ?? []).map(d => d.nodeId));
-        const hasDemotedRef = (entry.taxonomy_refs ?? []).some(r => demotedIds.has(r.node_id));
-        const modTrace = meta?.moderator_trace as Record<string, unknown> | undefined;
-        const modDrift = modTrace?.drift_detected === true;
-        const intMeta = entry.intervention_metadata;
-        const modRedirect = modDrift && intMeta && ['REDIRECT', 'CHALLENGE'].includes(intMeta.move);
-        let state: 'green' | 'amber' | 'red';
-        let label: string;
-        let tip: string;
-        if (!ta.topic_aligned || modRedirect) {
-          state = 'red'; label = modRedirect ? 'drift redirect' : 'off-scope'; tip = modRedirect ? `Moderator ${intMeta!.move} for drift` : 'Topic alignment failed after all retries';
-        } else if (ta.repaired) {
-          state = 'amber'; label = 'repaired'; tip = 'Off-scope draft repaired on retry';
-        } else if (modDrift || hasDemotedRef) {
-          state = 'amber'; label = 'drift noted'; tip = modDrift ? 'Moderator flagged drift concern' : 'References demoted taxonomy node';
-        } else {
-          state = 'green'; label = 'on-scope'; tip = 'All topic alignment checks passed';
-        }
-        const colors = { green: 'var(--success)', amber: 'var(--warning, var(--warning))', red: 'var(--danger)' };
-        const bgs = { green: 'color-mix(in srgb, var(--success) 15%, transparent)', amber: 'color-mix(in srgb, var(--warning, var(--warning)) 15%, transparent)', red: 'color-mix(in srgb, var(--danger) 15%, transparent)' };
-        return (
-          <span title={tip} className="edr-scope-badge" style={{
-            background: bgs[state], color: colors[state],
-          }}>{label}</span>
-        );
-      })()}
+      {diag?.topic_alignment && <TopicAlignmentBadge entry={entry} diag={diag} meta={meta} />}
       {diag?.entailment_repairs && diag.entailment_repairs.some(r => r.verdict !== 'entailed') && (() => {
         const repaired = diag.entailment_repairs!.filter(r => r.verdict !== 'entailed');
         return (
@@ -310,27 +330,22 @@ export function EntryTabBar({ p, m }: PartProps) {
 // Tab content router (per-activeTab pane)
 // ---------------------------------------------------------------------------
 
-export function EntryTabContent({ p, m }: PartProps) {
+// Tab panes are split into three cohesive groups (ADR-007) so each rendering
+// function stays ≤15 complexity. Only one branch renders at a time; the fragments
+// carry no wrapper DOM, so grouping is behavior-preserving.
+function EntryTabPanesPrimary({ p, m }: PartProps) {
   const {
     entry, entryIdx, diag, meta, debate, an, turnValTrail, perTurnUtilities,
     taxNodeMap, policyMap, allEdges, nodeWeights, nodeLabels,
-    selectedTaxRefId, setSelectedTaxRefId, selectedPolicyId, setSelectedPolicyId,
-    setOverviewTab, setTextCopyMenu, tabContentRef, searchQuery,
+    selectedTaxRefId, setSelectedTaxRefId, setOverviewTab,
   } = p;
   const {
-    activeTab, tabs, taxRefCount, precedingIntervention, interventionResponseField,
+    activeTab, taxRefCount, precedingIntervention, interventionResponseField,
     suppressedIntervention, entryErrors, modTrace, briefStage, briefAttempts,
-    planStage, planAttempts, draftStage, lookaheadDiag, citeStage, citeAttempts,
   } = m;
 
   return (
-    <div ref={tabContentRef} tabIndex={0} onContextMenu={(e) => {
-      const sel = window.getSelection()?.toString();
-      if (sel && sel.trim().length > 0) {
-        e.preventDefault();
-        setTextCopyMenu({ x: e.clientX, y: e.clientY, text: sel });
-      }
-    }} className="edr-tab-content" style={activeTab === 'tax-refs' ? { padding: '8px 10px' } : { padding: 0 }}>
+    <>
       {/* ══════════════ TAX-REFS TAB ══════════════ */}
       {activeTab === 'tax-refs' && (
         <TaxRefsTab
@@ -393,7 +408,22 @@ export function EntryTabContent({ p, m }: PartProps) {
           setSelectedTaxRefId={setSelectedTaxRefId}
         />
       )}
+    </>
+  );
+}
 
+function EntryTabPanesSecondary({ p, m }: PartProps) {
+  const {
+    entry, diag, meta, debate, an, turnValTrail,
+    taxNodeMap, policyMap, allEdges, nodeWeights,
+    selectedTaxRefId, setSelectedTaxRefId, selectedPolicyId, setSelectedPolicyId,
+  } = p;
+  const {
+    activeTab, planStage, planAttempts, draftStage, lookaheadDiag, citeStage, citeAttempts, briefStage,
+  } = m;
+
+  return (
+    <>
       {/* ══════════════ PLAN TAB ══════════════ */}
       {activeTab === 'plan' && planStage && (
         <PlanTab
@@ -450,7 +480,16 @@ export function EntryTabContent({ p, m }: PartProps) {
           setSelectedPolicyId={setSelectedPolicyId}
         />
       )}
+    </>
+  );
+}
 
+function EntryTabPanesTertiary({ p, m }: PartProps) {
+  const { entry, entryIdx, diag, meta, debate, an, nodeWeights, searchQuery } = p;
+  const { activeTab, tabs } = m;
+
+  return (
+    <>
       {/* ══════════════ CLAIMS TAB (delegated) ══════════════ */}
       {activeTab === 'claims' && (
         <div className="edr-tab-pane">
@@ -515,7 +554,25 @@ export function EntryTabContent({ p, m }: PartProps) {
           />
         </div>
       )}
+    </>
+  );
+}
 
+export function EntryTabContent({ p, m }: PartProps) {
+  const { setTextCopyMenu, tabContentRef } = p;
+  const { activeTab } = m;
+
+  return (
+    <div ref={tabContentRef} tabIndex={0} onContextMenu={(e) => {
+      const sel = window.getSelection()?.toString();
+      if (sel && sel.trim().length > 0) {
+        e.preventDefault();
+        setTextCopyMenu({ x: e.clientX, y: e.clientY, text: sel });
+      }
+    }} className="edr-tab-content" style={activeTab === 'tax-refs' ? { padding: '8px 10px' } : { padding: 0 }}>
+      <EntryTabPanesPrimary p={p} m={m} />
+      <EntryTabPanesSecondary p={p} m={m} />
+      <EntryTabPanesTertiary p={p} m={m} />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/OverviewTabRouter.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/OverviewTabRouter.tsx
@@ -28,6 +28,920 @@ import { CommitmentsPanel } from './shared';
 
 declare const __COMPONENT_VERSIONS__: Record<string, string>;
 
+type TranscriptEntry = DebateSession['transcript'][number];
+
+type ModeratorTrace = {
+  selected?: string; focus_point?: string; selection_reason?: string;
+  convergence_score?: number | null; convergence_triggered?: boolean;
+  intervention_recommended?: boolean; intervention_move?: string | null;
+  intervention_validated?: boolean; health_score?: number;
+};
+
+const TOPIC_SCOPE_RISK_COLORS: Record<TopicScopeRiskLevel, string> = {
+  low: 'var(--success)', medium: 'var(--warning)', high: 'var(--danger)', catastrophic: 'var(--danger)', unspecified: 'var(--text-muted)',
+};
+
+// ---------------------------------------------------------------------------
+// Topic Scope (10.2)
+// ---------------------------------------------------------------------------
+
+function TopicScopeBadges({ scope }: { scope: TopicScope }) {
+  return (
+    <div className="ovr-badge-row">
+      {scope.domain && <span className="ovr-chip">{scope.domain}</span>}
+      {scope.product_type && <span className="ovr-chip">{scope.product_type}</span>}
+      {scope.time_horizon && <span className="ovr-chip">{scope.time_horizon}</span>}
+      <span
+        className="ovr-chip-bold"
+        // eslint-disable-next-line local/no-inline-style -- risk-level-driven background/color
+        style={{ background: `color-mix(in srgb, ${TOPIC_SCOPE_RISK_COLORS[scope.risk_level]} 20%, transparent)`, color: TOPIC_SCOPE_RISK_COLORS[scope.risk_level] }}
+      >
+        risk: {scope.risk_level}
+      </span>
+      <span
+        className="ovr-chip-base"
+        // eslint-disable-next-line local/no-inline-style -- constraint-confidence-driven background/color
+        style={{ background: scope.constraint_confidence === 'explicit' ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--warning) 15%, transparent)', color: scope.constraint_confidence === 'explicit' ? 'var(--success)' : 'var(--warning)' }}
+      >
+        {scope.constraint_confidence}
+      </span>
+    </div>
+  );
+}
+
+function TopicScopeSection({ debate, effectiveOverviewTab }: { debate: DebateSession; effectiveOverviewTab: OverviewTab }) {
+  if (effectiveOverviewTab !== 'topic-scope' || !debate.topic?.scope) return null;
+  const scope = debate.topic.scope as TopicScope;
+  return (
+    <div className="ovr-topic-scope">
+      <h4 className="ovr-h4">Topic Scope</h4>
+      <div className="ovr-mb-8">
+        <span className="ovr-scope-prop">{scope.core_proposition}</span>
+      </div>
+      <TopicScopeBadges scope={scope} />
+
+      {scope.relevant_disciplines.length > 0 && (
+        <div className="ovr-mb-10">
+          <div className="ovr-label">Relevant Disciplines</div>
+          <div className="ovr-tag-row">
+            {scope.relevant_disciplines.map(d => (
+              <span key={d} className="ovr-tag-warning">{d}</span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {scope.key_tensions.length > 0 && (
+        <div className="ovr-mb-10">
+          <div className="ovr-label">Key Tensions</div>
+          <ol className="ovr-ol">
+            {scope.key_tensions.map((t, i) => <li key={i} className="ovr-mb-2">{t}</li>)}
+          </ol>
+        </div>
+      )}
+
+      {scope.off_scope_topics.length > 0 && (
+        <div className="ovr-mb-10">
+          <div className="ovr-label-danger">Off-Scope Topics</div>
+          <div className="ovr-tag-row">
+            {scope.off_scope_topics.map(t => (
+              <span key={t} className="ovr-tag-danger">{t}</span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {scope.drift_signatures.length > 0 && (
+        <div className="ovr-mb-10">
+          <div className="ovr-label-warning">Drift Signatures</div>
+          <ul className="ovr-ul">
+            {scope.drift_signatures.map((d, i) => <li key={i} className="ovr-li-warning">{d}</li>)}
+          </ul>
+        </div>
+      )}
+
+      {scope.example_ceiling && (
+        <div className="ovr-mb-10">
+          <div className="ovr-label-tight">Example Ceiling</div>
+          <div className="ovr-example-ceiling">{scope.example_ceiling}</div>
+        </div>
+      )}
+
+      {scope.explicit_qualifiers.length > 0 && (
+        <div className="ovr-mb-10">
+          <div className="ovr-label">Qualifiers</div>
+          <div className="ovr-tag-row">
+            {scope.explicit_qualifiers.map(q => (
+              <span key={q} className="ovr-tag-neutral">{q}</span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {scope.excluded_scenarios.length > 0 && (
+        <div className="ovr-mb-10">
+          <div className="ovr-label">Excluded Scenarios</div>
+          <ul className="ovr-ul">
+            {scope.excluded_scenarios.map((s, i) => <li key={i} className="ovr-mb-2">{s}</li>)}
+          </ul>
+        </div>
+      )}
+
+      {scope.on_scope_evidence.length > 0 && (
+        <div className="ovr-mb-10">
+          <div className="ovr-label">On-Scope Evidence</div>
+          <ul className="ovr-ul">
+            {scope.on_scope_evidence.map((e, i) => <li key={i} className="ovr-mb-2">{e}</li>)}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Lineage Frame
+// ---------------------------------------------------------------------------
+
+function computeLineageBoostStats(transcript: DebateSession['transcript']) {
+  // Check if any transcript entry had lineage boost data
+  const boostActive = transcript.some(e => {
+    const manifest = (e.metadata as Record<string, unknown>)?.injection_manifest as { lineage_boost?: unknown } | undefined;
+    return !!manifest?.lineage_boost;
+  });
+  // Aggregate per-turn boost stats from injection manifests
+  let totalBoosted = 0;
+  let totalPromoted = 0;
+  let turnsWithBoost = 0;
+  for (const e of transcript) {
+    const manifest = (e.metadata as Record<string, unknown>)?.injection_manifest as {
+      lineage_boost?: { boosted?: number; promoted?: number };
+    } | undefined;
+    if (manifest?.lineage_boost) {
+      turnsWithBoost++;
+      totalBoosted += manifest.lineage_boost.boosted ?? 0;
+      totalPromoted += manifest.lineage_boost.promoted ?? 0;
+    }
+  }
+  return { boostActive, totalBoosted, totalPromoted, turnsWithBoost };
+}
+
+function aggregateLineageNodes(transcript: DebateSession['transcript']) {
+  const allPromoted = new Set<string>();
+  const allInjected = new Set<string>();
+  const allReferenced = new Set<string>();
+  for (const e of transcript) {
+    if (e.type !== 'opening' && e.type !== 'statement') continue;
+    const manifest = (e.metadata as Record<string, unknown>)?.injection_manifest as {
+      lineage_boost?: { boostedNodeIds?: string[]; promotedNodeIds?: string[] };
+      povNodeIds?: string[];
+    } | undefined;
+    if (!manifest) continue;
+    for (const id of (e.taxonomy_refs ?? []).map((r: { node_id: string }) => r.node_id)) allReferenced.add(id);
+    for (const id of manifest.povNodeIds ?? []) allInjected.add(id);
+    const lb = manifest.lineage_boost;
+    if (lb) {
+      for (const id of lb.promotedNodeIds ?? []) allPromoted.add(id);
+    }
+  }
+  return { allPromoted, allInjected, allReferenced };
+}
+
+function lineageVerdict(promotedRate: number) {
+  const verdict = promotedRate > 0.15 ? 'high_impact' : promotedRate > 0.05 ? 'moderate_impact' : 'low_impact';
+  const verdictLabel = verdict === 'high_impact' ? 'High impact' : verdict === 'moderate_impact' ? 'Moderate impact' : 'Low impact';
+  const verdictColor = verdict === 'high_impact' ? 'var(--success)' : verdict === 'moderate_impact' ? 'var(--warning)' : 'var(--danger)';
+  return { verdictLabel, verdictColor };
+}
+
+// Lineage Effectiveness — promoted vs. cited
+function LineageEffectivenessSection({ debate, boostActive }: { debate: DebateSession; boostActive: boolean }) {
+  if (!boostActive) return null;
+  const { allPromoted, allInjected, allReferenced } = aggregateLineageNodes(debate.transcript);
+  if (allPromoted.size === 0) return null;
+  const promotedCitedIds = [...allPromoted].filter(id => allReferenced.has(id));
+  const promotedCited = promotedCitedIds.length;
+  const promotedRate = promotedCited / allPromoted.size;
+  const baselineRate = allInjected.size > 0 ? allReferenced.size / allInjected.size : 0;
+  const ratio = baselineRate > 0 ? promotedRate / baselineRate : 0;
+  const { verdictLabel, verdictColor } = lineageVerdict(promotedRate);
+  const promotedCitedSet = new Set(promotedCitedIds);
+  return (
+    <div className="ovr-effectiveness">
+      <div className="ovr-effectiveness-title">Lineage Effectiveness</div>
+      <div>
+        Lineage boost promoted <strong>{allPromoted.size}</strong> node{allPromoted.size !== 1 ? 's' : ''};{' '}
+        <strong className="ovr-success-text">{promotedCited}</strong> cited ({(promotedRate * 100).toFixed(0)}%)
+        {' vs. '}<strong>{(baselineRate * 100).toFixed(0)}%</strong> baseline
+      </div>
+      <div className="ovr-muted-mt-2">
+        {promotedRate > baselineRate
+          ? `Promoted nodes cited ${ratio.toFixed(1)}× more than baseline — boost is helping`
+          : promotedRate === baselineRate
+            ? 'Promoted node citation rate matches baseline'
+            : 'Promoted nodes cited less than baseline — boost had limited effect'}
+      </div>
+      <div
+        className="ovr-verdict"
+        // eslint-disable-next-line local/no-inline-style -- verdict-driven color
+        style={{ color: verdictColor }}
+      >
+        Lineage boost: {verdictLabel}
+      </div>
+      {allPromoted.size <= 30 && (
+        <div className="ovr-promoted-list">
+          {[...allPromoted].map(id => (
+            <span
+              key={id}
+              className="ovr-promoted-chip"
+              // eslint-disable-next-line local/no-inline-style -- citation-state-driven background/color/border
+              style={{
+                background: promotedCitedSet.has(id) ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--text-muted) 15%, transparent)',
+                color: promotedCitedSet.has(id) ? 'var(--success)' : 'var(--text-muted)',
+                border: `1px solid ${promotedCitedSet.has(id) ? 'color-mix(in srgb, var(--success) 30%, transparent)' : 'color-mix(in srgb, var(--text-muted) 20%, transparent)'}`,
+              }}
+              title={promotedCitedSet.has(id) ? 'Cited by debaters' : 'Not cited'}
+            >
+              {id}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Vocabulary Disambiguation Aggregate (t/212)
+function computeVocabularyData(transcript: DebateSession['transcript']) {
+  const allResolved: { colloquial: string; canonical: string; confidence: string; speaker: string }[] = [];
+  const allAmbiguous: { colloquial: string; speaker: string }[] = [];
+  for (const e of transcript) {
+    if (e.speaker === 'system' || e.speaker === 'moderator' || e.speaker === 'user') continue;
+    const meta = e.metadata as Record<string, unknown> | undefined;
+    const res = meta?.vocabulary_resolutions as { colloquial: string; canonical: string; confidence: string }[] | undefined;
+    const amb = meta?.vocabulary_ambiguities as { colloquial: string }[] | undefined;
+    if (res) for (const r of res) allResolved.push({ ...r, speaker: speakerLabel(e.speaker) });
+    if (amb) for (const a of amb) allAmbiguous.push({ colloquial: a.colloquial, speaker: speakerLabel(e.speaker) });
+  }
+  // Group by colloquial term -> canonical form(s) with speakers
+  const grouped = new Map<string, { canonical: string; confidence: string; speakers: Set<string>; count: number }>();
+  for (const r of allResolved) {
+    const key = `${r.colloquial}→${r.canonical}`;
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.speakers.add(r.speaker);
+      existing.count++;
+    } else {
+      grouped.set(key, { canonical: r.canonical, confidence: r.confidence, speakers: new Set([r.speaker]), count: 1 });
+    }
+  }
+  return { allResolved, allAmbiguous, grouped };
+}
+
+function VocabularyDisambiguationSection({ debate }: { debate: DebateSession }) {
+  const { allResolved, allAmbiguous, grouped } = computeVocabularyData(debate.transcript);
+  if (allResolved.length === 0 && allAmbiguous.length === 0) return null;
+  return (
+    <div className="ovr-mt-20">
+      <h4 className="ovr-h4">Vocabulary Disambiguation</h4>
+      <p className="ovr-intro-8">
+        Colloquial terms resolved to canonical forms based on speaker POV.
+        {allResolved.length > 0 && <> <strong>{allResolved.length}</strong> resolved across {grouped.size} unique mappings.</>}
+        {allAmbiguous.length > 0 && <> <span className="ovr-warning-text"><strong>{allAmbiguous.length}</strong> ambiguous.</span></>}
+      </p>
+      {grouped.size > 0 && (
+        <table className="ovr-vocab-table">
+          <thead>
+            <tr className="ovr-vocab-head-row">
+              <th className="ovr-th-left">Colloquial</th>
+              <th className="ovr-th-left">Canonical Form</th>
+              <th className="ovr-th-center">Conf.</th>
+              <th className="ovr-th-left">Speakers</th>
+              <th className="ovr-th-center">Hits</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[...grouped.entries()].sort((a, b) => b[1].count - a[1].count).map(([key, v]) => {
+              const colloquial = key.split('→')[0];
+              return (
+                <tr key={key} className="ovr-vocab-row">
+                  <td className="ovr-td">
+                    <span className="vocab-term ovr-vocab-term">{colloquial}</span>
+                  </td>
+                  <td className="ovr-td-secondary">{v.canonical}</td>
+                  <td
+                    className="ovr-td-conf"
+                    // eslint-disable-next-line local/no-inline-style -- confidence-driven color
+                    style={{ color: v.confidence === 'high' ? 'var(--success)' : v.confidence === 'low' ? 'var(--danger)' : 'var(--warning)' }}
+                  >{v.confidence}</td>
+                  <td className="ovr-td-muted">{[...v.speakers].join(', ')}</td>
+                  <td className="ovr-td-center">{v.count}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+      {allAmbiguous.length > 0 && (
+        <div className="ovr-ambiguous">
+          <div className="ovr-ambiguous-title">Ambiguous terms (needs review):</div>
+          {[...new Set(allAmbiguous.map(a => a.colloquial))].map((term, i) => {
+            const speakers = [...new Set(allAmbiguous.filter(a => a.colloquial === term).map(a => a.speaker))];
+            return (
+              <div key={i} className="ovr-ambiguous-item">
+                &ldquo;{term}&rdquo; <span className="ovr-muted">&mdash; {speakers.join(', ')}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LineageSection({ debate, effectiveOverviewTab }: { debate: DebateSession; effectiveOverviewTab: OverviewTab }) {
+  if (effectiveOverviewTab !== 'lineage') return null;
+  const frame = debate.topic.critique?.lineage_frame;
+  if (!frame || frame.length === 0) return <div className="ovr-empty">No lineage data for this debate.</div>;
+  const maxPct = Math.max(...frame.map(f => f.percentage));
+  const { boostActive, totalBoosted, totalPromoted, turnsWithBoost } = computeLineageBoostStats(debate.transcript);
+  return (
+    <div className="ovr-panel">
+      <h4 className="ovr-h4">Intellectual Lineage Frame</h4>
+      <p className="ovr-intro">
+        Dominant intellectual traditions detected from activated taxonomy nodes. These traditions shape which nodes receive relevance boosts during context injection.
+      </p>
+      <div className="ovr-lineage-list">
+        {frame.map(f => (
+          <div key={f.cluster_id}>
+            <div className="ovr-lineage-row">
+              <span className="ovr-lineage-label">{f.label}</span>
+              <div className="ovr-lineage-track">
+                <div
+                  className="ovr-lineage-bar"
+                  // eslint-disable-next-line local/no-inline-style -- data-driven bar width
+                  style={{ width: `${maxPct > 0 ? (f.percentage / maxPct) * 100 : 0}%` }}
+                />
+              </div>
+              <span className="ovr-lineage-pct">
+                {(f.percentage * 100).toFixed(0)}%
+              </span>
+            </div>
+            {f.traditions && f.traditions.length > 0 && (
+              <div className="ovr-lineage-traditions">
+                {f.traditions.join(', ')}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="ovr-boost-row">
+        <div
+          className="ovr-boost-stat-base"
+          // eslint-disable-next-line local/no-inline-style -- boostActive-driven background/color
+          style={{
+            background: boostActive ? 'color-mix(in srgb, var(--success) 12%, transparent)' : 'color-mix(in srgb, var(--danger) 8%, transparent)',
+            color: boostActive ? 'var(--success)' : 'var(--text-muted)',
+          }}
+        >
+          Lineage Boost: {boostActive ? 'Active' : 'Inactive'}
+        </div>
+        {boostActive && turnsWithBoost > 0 && (
+          <>
+            <div className="ovr-boost-stat">
+              Turns with boost: {turnsWithBoost}
+            </div>
+            <div className="ovr-boost-stat">
+              Nodes boosted: {totalBoosted} · Promoted: {totalPromoted}
+            </div>
+          </>
+        )}
+      </div>
+      <LineageEffectivenessSection debate={debate} boostActive={boostActive} />
+      <VocabularyDisambiguationSection debate={debate} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Argument Network / Commitments / POV Progression / Prompt Diff wrappers
+// ---------------------------------------------------------------------------
+
+interface ArgumentNetworkSectionProps {
+  debate: DebateSession;
+  an: { nodes: ArgumentNetworkNode[]; edges: ArgumentNetworkEdge[] } | undefined;
+  effectiveOverviewTab: OverviewTab;
+  anFilterMode: 'all' | 'unattributed' | 'novel' | 'anchored';
+  anFilterNodeId: string;
+  setAnFilterMode: (mode: 'all' | 'unattributed' | 'novel' | 'anchored') => void;
+  setAnFilterNodeId: (id: string) => void;
+  focusedNodeId: string | null;
+  handleUpdateSubScore: (nodeId: string, key: string, value: number) => void;
+  setOverviewTab: (tab: OverviewTab) => void;
+  setSelectedEntry: (id: string | null) => void;
+  setLocalOverride: (v: boolean) => void;
+  nodeLabels: Map<string, string>;
+}
+
+function ArgumentNetworkSection({
+  debate, an, effectiveOverviewTab, anFilterMode, anFilterNodeId, setAnFilterMode,
+  setAnFilterNodeId, focusedNodeId, handleUpdateSubScore, setOverviewTab, setSelectedEntry,
+  setLocalOverride, nodeLabels,
+}: ArgumentNetworkSectionProps) {
+  if (effectiveOverviewTab !== 'argument-network' || !an || an.nodes.length === 0) return null;
+  return (
+    <ArgumentNetworkTab
+      debate={debate}
+      an={an}
+      anFilterMode={anFilterMode}
+      anFilterNodeId={anFilterNodeId}
+      setAnFilterMode={setAnFilterMode}
+      setAnFilterNodeId={setAnFilterNodeId}
+      focusedNodeId={focusedNodeId}
+      handleUpdateSubScore={handleUpdateSubScore}
+      setOverviewTab={setOverviewTab}
+      setSelectedEntry={setSelectedEntry}
+      setLocalOverride={setLocalOverride}
+      nodeLabels={nodeLabels}
+    />
+  );
+}
+
+interface CommitmentsSectionProps {
+  effectiveOverviewTab: OverviewTab;
+  commitments: Record<string, CommitmentStore> | undefined;
+  an: { nodes: ArgumentNetworkNode[]; edges: ArgumentNetworkEdge[] } | undefined;
+  setOverviewTab: (tab: OverviewTab) => void;
+  setFocusedNodeId: (id: string | null) => void;
+}
+
+function CommitmentsSection({ effectiveOverviewTab, commitments, an, setOverviewTab, setFocusedNodeId }: CommitmentsSectionProps) {
+  if (effectiveOverviewTab !== 'commitments' || !commitments || Object.keys(commitments).length === 0) return null;
+  return (
+    <CommitmentsPanel
+      commitments={commitments}
+      nodes={an?.nodes ?? []}
+      edges={an?.edges ?? []}
+      onGoToNode={(nodeId) => { setOverviewTab('argument-network'); setFocusedNodeId(nodeId); }}
+    />
+  );
+}
+
+function PromptDiffSection({ debate, effectiveOverviewTab, selectedEntry }: { debate: DebateSession; effectiveOverviewTab: OverviewTab; selectedEntry: string | null }) {
+  if (effectiveOverviewTab !== 'prompt-diff') return null;
+  return (
+    <div className="ovr-prompt-diff">
+      <PromptDiffContent
+        debate={debate}
+        focusedEntryId={selectedEntry ?? debate.transcript[0]?.id ?? ''}
+        embedded
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Flight Recorder Context — live snapshot of app state
+// ---------------------------------------------------------------------------
+
+type FrRow = [string, string | number | null | undefined];
+type FrSection = { title: string; rows: FrRow[] };
+type FrEApi = { processVersions?: Record<string, string | undefined>; osRelease?: string; osPlatform?: string; osArch?: string } | undefined;
+type FrMem = { usedJSHeapSize: number; totalJSHeapSize: number } | undefined;
+type FrTaxState = ReturnType<typeof useTaxonomyStore.getState>;
+
+function frNodeCount(file: { nodes?: readonly unknown[] } | null | undefined): number {
+  return file?.nodes?.length ?? 0;
+}
+
+function buildAppSection(eApi: FrEApi): FrSection {
+  return {
+    title: 'App',
+    rows: [
+      ['Platform', eApi?.osPlatform ?? navigator.platform],
+      ['Arch', eApi?.osArch ?? 'unknown'],
+      ['OS Version', eApi?.osRelease ?? 'N/A'],
+      ['VITE_TARGET', import.meta.env.VITE_TARGET ?? 'electron'],
+      ['Mode', import.meta.env.DEV ? 'dev' : 'prod'],
+    ],
+  };
+}
+
+function buildSbomSection(pv: Record<string, string | undefined> | undefined): FrSection {
+  return {
+    title: 'SBOM',
+    rows: [
+      ['Node', pv?.node ?? 'N/A'],
+      ['Electron', pv?.electron ?? 'N/A'],
+      ['Chrome', pv?.chrome ?? 'N/A'],
+      ['V8', pv?.v8 ?? 'N/A'],
+      ['React', typeof __COMPONENT_VERSIONS__ !== 'undefined' ? __COMPONENT_VERSIONS__.react : 'N/A'],
+      ['Zustand', typeof __COMPONENT_VERSIONS__ !== 'undefined' ? __COMPONENT_VERSIONS__.zustand : 'N/A'],
+    ],
+  };
+}
+
+function buildWindowsSection(taxState: FrTaxState): FrSection {
+  return {
+    title: 'Windows',
+    rows: [
+      ['Active Tab', taxState.activeTab],
+      ['Toolbar Panel', taxState.toolbarPanel ?? '(none)'],
+      ['Selected Node', taxState.selectedNodeId ?? '(none)'],
+    ],
+  };
+}
+
+function buildDebateSection(debate: DebateSession): FrSection {
+  return {
+    title: 'Debate',
+    rows: [
+      ['ID', debate.id.slice(0, 8) + '...'],
+      ['Phase', debate.phase],
+      ['Adaptive Phase', debate.adaptive_staging?.phase_state?.current_phase ?? '(none)'],
+      ['Transcript', debate.transcript?.length ?? 0],
+      ['AN Nodes', debate.argument_network?.nodes?.length ?? 0],
+      ['Convergence Signals', debate.convergence_signals?.length ?? 0],
+      ['Protocol', debate.protocol_id ?? '(default)'],
+    ],
+  };
+}
+
+function buildTaxonomySection(taxState: FrTaxState): FrSection {
+  return {
+    title: 'Taxonomy',
+    rows: [
+      ['Accelerationist nodes', frNodeCount(taxState.accelerationist)],
+      ['Safetyist nodes', frNodeCount(taxState.safetyist)],
+      ['Skeptic nodes', frNodeCount(taxState.skeptic)],
+      ['Situations nodes', frNodeCount(taxState.situations)],
+      ['Edges', taxState.edgesFile?.edges?.length ?? 0],
+      ['Dirty files', taxState.dirty?.size ?? 0],
+      ['Save error', taxState.saveError ?? '(none)'],
+    ],
+  };
+}
+
+function buildAiSection(taxState: FrTaxState): FrSection {
+  return {
+    title: 'AI',
+    rows: [
+      ['Backend', taxState.aiBackend],
+      ['Model', taxState.geminiModel],
+    ],
+  };
+}
+
+function buildPerformanceSection(mem: FrMem): FrSection {
+  return {
+    title: 'Performance',
+    rows: [
+      ['Uptime', `${Math.round(performance.now() / 1000)}s`],
+      ['Heap used', mem ? `${Math.round(mem.usedJSHeapSize / 1048576)} MB` : 'N/A'],
+      ['Heap total', mem ? `${Math.round(mem.totalJSHeapSize / 1048576)} MB` : 'N/A'],
+    ],
+  };
+}
+
+function isFrValueEmpty(v: string | number | null | undefined): boolean {
+  if (v === null || v === undefined) return true;
+  const s = String(v);
+  return s === '' || s === '0' || s === '(none)' || s === 'N/A';
+}
+
+function FrContextSection({ debate, effectiveOverviewTab }: { debate: DebateSession; effectiveOverviewTab: OverviewTab }) {
+  if (effectiveOverviewTab !== 'fr-context') return null;
+  const taxState = useTaxonomyStore.getState();
+  const mem = (performance as unknown as { memory?: { usedJSHeapSize: number; totalJSHeapSize: number } }).memory;
+  const eApi = (window as unknown as { electronAPI?: { processVersions?: Record<string, string | undefined>; osRelease?: string; osPlatform?: string; osArch?: string } }).electronAPI;
+  const pv = eApi?.processVersions;
+  const sections: FrSection[] = [
+    buildAppSection(eApi),
+    buildSbomSection(pv),
+    buildWindowsSection(taxState),
+    buildDebateSection(debate),
+    buildTaxonomySection(taxState),
+    buildAiSection(taxState),
+    buildPerformanceSection(mem),
+  ];
+  return (
+    <div className="ovr-fr-context">
+      <div className="ovr-fr-header">
+        <span className="ovr-fr-title">Flight Recorder Context Snapshot</span>
+        <button
+          onClick={() => { void triggerManualDump(); }}
+          className="ovr-dump-btn"
+        >Dump Now</button>
+      </div>
+      <div className="ovr-fr-grid">
+        {sections.map(s => (
+          <div key={s.title} className="ovr-fr-card">
+            <div className="ovr-fr-card-title">{s.title}</div>
+            {s.rows.map(([label, value]) => {
+              const empty = isFrValueEmpty(value);
+              return (
+                <div key={label} className="ovr-fr-row">
+                  <span className="ovr-fr-label">{label}</span>
+                  <span
+                    className="ovr-fr-value"
+                    // eslint-disable-next-line local/no-inline-style -- empty-state-driven color
+                    style={{ color: empty ? 'var(--text-muted)' : 'var(--text-primary)' }}
+                  >{String(value ?? '')}</span>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Transcript list for selection
+// ---------------------------------------------------------------------------
+
+function deriveTranscriptRowMeta(e: TranscriptEntry, debate: DebateSession) {
+  const eMeta = e.metadata as Record<string, unknown> | undefined;
+  const modT = eMeta?.moderator_trace as ModeratorTrace | undefined;
+  const eDiag = debate.diagnostics?.entries[e.id];
+  const hasStages = eDiag?.stage_diagnostics && eDiag.stage_diagnostics.length > 0;
+  const pipelineError = e.type === 'statement' && hasStages && !eDiag?.extracted_claims && !(eDiag as Record<string, unknown>)?.extraction_trace;
+  return { modT, hasStages, pipelineError };
+}
+
+function ModeratorTraceRow({ modT }: { modT: ModeratorTrace }) {
+  return (
+    <div className="ovr-mod-row">
+      <span className="ovr-mod-tag">MOD</span>
+      {modT.focus_point && <span className="ovr-mod-focus" title={modT.focus_point}>{modT.focus_point}</span>}
+      {modT.selection_reason && modT.selection_reason !== 'moderator_ai_selection' && (
+        <span className="ovr-mod-reason">{modT.selection_reason === 'turn_alternation_override' ? 'override' : modT.selection_reason}</span>
+      )}
+      {modT.intervention_move && (
+        <span
+          className="ovr-mod-tag-base"
+          // eslint-disable-next-line local/no-inline-style -- validation-driven background/color
+          style={{ background: modT.intervention_validated ? 'var(--bg-hover)' : 'color-mix(in srgb, var(--danger) 15%, transparent)', color: modT.intervention_validated ? 'var(--text-secondary)' : 'var(--danger)' }}
+        >{modT.intervention_move}{modT.intervention_validated ? '' : ' (suppressed)'}</span>
+      )}
+      {modT.convergence_score != null && <span className="ovr-mod-metric">conv:{(modT.convergence_score * 100).toFixed(0)}%</span>}
+      {modT.health_score != null && <span className="ovr-mod-metric">H:{modT.health_score.toFixed(2)}</span>}
+    </div>
+  );
+}
+
+interface TranscriptRowProps {
+  e: TranscriptEntry;
+  i: number;
+  debate: DebateSession;
+  selectedEntry: string | null;
+  setSelectedEntry: (id: string | null) => void;
+  setLocalOverride: (v: boolean) => void;
+}
+
+function TranscriptRow({ e, i, debate, selectedEntry, setSelectedEntry, setLocalOverride }: TranscriptRowProps) {
+  const stmtId = `S${i + 1}`;
+  const { modT, hasStages, pipelineError } = deriveTranscriptRowMeta(e, debate);
+  return (
+    <div
+      onClick={() => { setSelectedEntry(e.id); setLocalOverride(true); }}
+      className="ovr-transcript-entry"
+      // eslint-disable-next-line local/no-inline-style -- selection-driven background/border
+      style={{ background: selectedEntry === e.id ? 'color-mix(in srgb, var(--color-acc) 8%, transparent)' : 'var(--bg-primary)', borderLeft: selectedEntry === e.id ? '3px solid var(--color-acc)' : '3px solid transparent' }}
+    >
+      <div className="ovr-stmt-head">
+        <span
+          title={pipelineError ? `Statement ${stmtId} — pipeline error` : `Statement ${stmtId}`}
+          className="ovr-stmt-badge"
+          // eslint-disable-next-line local/no-inline-style -- pipeline-error-driven background/color
+          style={{
+            background: pipelineError ? 'color-mix(in srgb, var(--danger) 15%, transparent)' : 'color-mix(in srgb, var(--color-acc) 12%, transparent)',
+            color: pipelineError ? 'var(--danger)' : 'var(--color-acc)',
+          }}
+        >{pipelineError && <span className="ovr-mr-3">●</span>}{stmtId}</span>
+        <span className="ovr-stmt-content">
+          <strong>{speakerLabel(e.speaker)}</strong> [{e.type}] <Highlight text={e.content.slice(0, 80)} />...
+        </span>
+        {hasStages && <span title="4-stage pipeline" className="ovr-pipeline-badge">B/P/D/C</span>}
+      </div>
+      {modT && <ModeratorTraceRow modT={modT} />}
+    </div>
+  );
+}
+
+interface TranscriptSectionProps {
+  debate: DebateSession;
+  effectiveOverviewTab: OverviewTab;
+  transcriptSpeakerFilter: string | null;
+  setTranscriptSpeakerFilter: (filter: string | null) => void;
+  selectedEntry: string | null;
+  setSelectedEntry: (id: string | null) => void;
+  setLocalOverride: (v: boolean) => void;
+}
+
+function TranscriptSection({
+  debate, effectiveOverviewTab, transcriptSpeakerFilter, setTranscriptSpeakerFilter,
+  selectedEntry, setSelectedEntry, setLocalOverride,
+}: TranscriptSectionProps) {
+  if (effectiveOverviewTab !== 'transcript') return null;
+  const speakers = Array.from(new Set(debate.transcript.map(e => e.speaker)));
+  const filteredTranscript = transcriptSpeakerFilter
+    ? debate.transcript.map((e, i) => ({ e, i })).filter(({ e }) => e.speaker === transcriptSpeakerFilter)
+    : debate.transcript.map((e, i) => ({ e, i }));
+  return (
+    <div className="ovr-transcript">
+      <div className="ovr-transcript-filters">
+        <button
+          onClick={() => setTranscriptSpeakerFilter(null)}
+          className="ovr-filter-btn"
+          // eslint-disable-next-line local/no-inline-style -- active-filter-driven background/color
+          style={{
+            background: !transcriptSpeakerFilter ? 'var(--warning)' : 'transparent',
+            color: !transcriptSpeakerFilter ? 'var(--text-primary)' : 'var(--text-secondary)',
+          }}
+        >All ({debate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length} stmts / {debate.transcript.length})</button>
+        {speakers.map(s => {
+          const count = debate.transcript.filter(e => e.speaker === s).length;
+          const active = transcriptSpeakerFilter === s;
+          return (
+            <button
+              key={s}
+              onClick={() => setTranscriptSpeakerFilter(active ? null : s)}
+              className="ovr-filter-btn"
+              // eslint-disable-next-line local/no-inline-style -- active-filter-driven background/color
+              style={{
+                background: active ? 'var(--warning)' : 'transparent',
+                color: active ? 'var(--text-primary)' : 'var(--text-secondary)',
+              }}
+            >{speakerLabel(s)} ({count})</button>
+          );
+        })}
+      </div>
+      <div className="ovr-transcript-list">
+      {filteredTranscript.map(({ e, i }) => (
+        <TranscriptRow
+          key={e.id}
+          e={e}
+          i={i}
+          debate={debate}
+          selectedEntry={selectedEntry}
+          setSelectedEntry={setSelectedEntry}
+          setLocalOverride={setLocalOverride}
+        />
+      ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exclusion Guard Overview — aggregate across all entries
+// ---------------------------------------------------------------------------
+
+type ExclusionEntries = NonNullable<DebateSession['diagnostics']>['entries'];
+
+function computeExclusionAggregate(entries: ExclusionEntries) {
+  let claimsChecked = 0;
+  let claimViolations: { claim_id: string; claim_text: string; node_id: string; similarity_main: number; similarity_exclusion: number }[] = [];
+  let draftsChecked = 0;
+  let driftWarnings: { debater: string; node_id: string; similarity: number; draft_excerpt: string }[] = [];
+  let hasAnyData = false;
+
+  for (const entry of Object.values(entries)) {
+    const extTrace = entry.extraction_trace;
+    if (extTrace) {
+      hasAnyData = true;
+      if (extTrace.exclusion_guard) {
+        claimsChecked += extTrace.exclusion_guard.checked;
+        if (extTrace.exclusion_guard.violations?.length) claimViolations = claimViolations.concat(extTrace.exclusion_guard.violations);
+      }
+      if (extTrace.exclusion_violations?.length) {
+        claimViolations = claimViolations.concat(extTrace.exclusion_violations);
+      }
+    }
+    if (entry.scope_drift_check) {
+      hasAnyData = true;
+      draftsChecked += entry.scope_drift_check.refs_checked;
+      if (entry.scope_drift_check.warnings?.length) driftWarnings = driftWarnings.concat(entry.scope_drift_check.warnings);
+    }
+    if (entry.scope_drift_warnings?.length) {
+      hasAnyData = true;
+      driftWarnings = driftWarnings.concat(entry.scope_drift_warnings);
+    }
+  }
+
+  const allClear = claimViolations.length === 0 && driftWarnings.length === 0;
+  return { claimsChecked, claimViolations, draftsChecked, driftWarnings, hasAnyData, allClear };
+}
+
+function ExclusionOverviewSection({ debate, effectiveOverviewTab }: { debate: DebateSession; effectiveOverviewTab: OverviewTab }) {
+  if (effectiveOverviewTab !== 'exclusion-overview') return null;
+  const entries = debate.diagnostics?.entries;
+  if (!entries || Object.keys(entries).length === 0) {
+    return (
+      <div className="ovr-p-16">
+        <h4 className="ovr-h4-8">Exclusion Guard</h4>
+        <div className="ovr-italic-muted">
+          No diagnostics data available for this debate.
+        </div>
+      </div>
+    );
+  }
+
+  const { claimsChecked, claimViolations, draftsChecked, driftWarnings, hasAnyData, allClear } = computeExclusionAggregate(entries);
+
+  return (
+    <div className="ovr-panel">
+      <h4 className="ovr-h4-10">Exclusion Guard Summary</h4>
+
+      {!hasAnyData ? (
+        <div className="ovr-italic-muted">
+          Exclusion guard data not available — no extraction traces found in this debate.
+        </div>
+      ) : (
+        <>
+          {/* Aggregate badges */}
+          <div className="ovr-badge-row">
+            <span
+              className="ovr-guard-badge"
+              // eslint-disable-next-line local/no-inline-style -- violation-count-driven background/color
+              style={{
+                background: claimViolations.length > 0 ? 'color-mix(in srgb, var(--danger) 10%, transparent)' : 'color-mix(in srgb, var(--success) 8%, transparent)',
+                color: claimViolations.length > 0 ? 'var(--danger)' : 'var(--success)',
+              }}
+            >
+              {claimsChecked} claims checked — {claimViolations.length} violation{claimViolations.length !== 1 ? 's' : ''}
+            </span>
+            <span
+              className="ovr-guard-badge"
+              // eslint-disable-next-line local/no-inline-style -- warning-count-driven background/color
+              style={{
+                background: driftWarnings.length > 0 ? 'color-mix(in srgb, var(--warning) 10%, transparent)' : 'color-mix(in srgb, var(--success) 8%, transparent)',
+                color: driftWarnings.length > 0 ? 'var(--warning)' : 'var(--success)',
+              }}
+            >
+              {draftsChecked} refs checked — {driftWarnings.length} drift warning{driftWarnings.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+
+          {allClear ? (
+            <div className="ovr-clear-banner">
+              All statements within scope — no exclusion violations or drift warnings
+            </div>
+          ) : (
+            <>
+              {claimViolations.length > 0 && (
+                <div className="ovr-mb-12">
+                  <div className="ovr-section-title-danger">
+                    Exclusion Violations ({claimViolations.length})
+                  </div>
+                  {claimViolations.map((v, i) => (
+                    <div key={i} className="ovr-violation-card">
+                      <div className="ovr-violation-head">
+                        <span className="ovr-danger-bold">{v.claim_id}</span>
+                        <span className="ovr-muted">→</span>
+                        <span className="ovr-bold">{v.node_id}</span>
+                      </div>
+                      <div className="ovr-violation-claim">{v.claim_text}</div>
+                      <div className="ovr-violation-sims">
+                        <span>main: <strong>{v.similarity_main.toFixed(3)}</strong></span>
+                        <span>exclusion: <strong>{v.similarity_exclusion.toFixed(3)}</strong></span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {driftWarnings.length > 0 && (
+                <div>
+                  <div className="ovr-section-title-warning">
+                    Scope Drift Warnings ({driftWarnings.length})
+                  </div>
+                  {driftWarnings.map((w, i) => (
+                    <div key={i} className="ovr-drift-card">
+                      <div className="ovr-violation-head">
+                        <span className="ovr-warning-bold">{w.debater}</span>
+                        <span className="ovr-muted">→</span>
+                        <span className="ovr-bold">{w.node_id}</span>
+                        <span className="ovr-drift-sim">
+                          {w.similarity.toFixed(3)}
+                        </span>
+                      </div>
+                      <div className="ovr-drift-excerpt">
+                        {w.draft_excerpt.length > 200 ? w.draft_excerpt.slice(0, 200) + '…' : w.draft_excerpt}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 interface OverviewTabRouterProps {
   debate: DebateSession;
   an: { nodes: ArgumentNetworkNode[]; edges: ArgumentNetworkEdge[] } | undefined;
@@ -79,115 +993,7 @@ export function OverviewTabRouter({
       {<>
 
       {/* Topic Scope (10.2) */}
-      {effectiveOverviewTab === 'topic-scope' && debate.topic?.scope && (() => {
-        const scope = debate.topic.scope as TopicScope;
-        const RISK_COLORS: Record<TopicScopeRiskLevel, string> = {
-          low: 'var(--success)', medium: 'var(--warning)', high: 'var(--danger)', catastrophic: 'var(--danger)', unspecified: 'var(--text-muted)',
-        };
-        return (
-          <div className="ovr-topic-scope">
-            <h4 className="ovr-h4">Topic Scope</h4>
-            <div className="ovr-mb-8">
-              <span className="ovr-scope-prop">{scope.core_proposition}</span>
-            </div>
-            <div className="ovr-badge-row">
-              {scope.domain && <span className="ovr-chip">{scope.domain}</span>}
-              {scope.product_type && <span className="ovr-chip">{scope.product_type}</span>}
-              {scope.time_horizon && <span className="ovr-chip">{scope.time_horizon}</span>}
-              <span
-                className="ovr-chip-bold"
-                // eslint-disable-next-line local/no-inline-style -- risk-level-driven background/color
-                style={{ background: `color-mix(in srgb, ${RISK_COLORS[scope.risk_level]} 20%, transparent)`, color: RISK_COLORS[scope.risk_level] }}
-              >
-                risk: {scope.risk_level}
-              </span>
-              <span
-                className="ovr-chip-base"
-                // eslint-disable-next-line local/no-inline-style -- constraint-confidence-driven background/color
-                style={{ background: scope.constraint_confidence === 'explicit' ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--warning) 15%, transparent)', color: scope.constraint_confidence === 'explicit' ? 'var(--success)' : 'var(--warning)' }}
-              >
-                {scope.constraint_confidence}
-              </span>
-            </div>
-
-            {scope.relevant_disciplines.length > 0 && (
-              <div className="ovr-mb-10">
-                <div className="ovr-label">Relevant Disciplines</div>
-                <div className="ovr-tag-row">
-                  {scope.relevant_disciplines.map(d => (
-                    <span key={d} className="ovr-tag-warning">{d}</span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {scope.key_tensions.length > 0 && (
-              <div className="ovr-mb-10">
-                <div className="ovr-label">Key Tensions</div>
-                <ol className="ovr-ol">
-                  {scope.key_tensions.map((t, i) => <li key={i} className="ovr-mb-2">{t}</li>)}
-                </ol>
-              </div>
-            )}
-
-            {scope.off_scope_topics.length > 0 && (
-              <div className="ovr-mb-10">
-                <div className="ovr-label-danger">Off-Scope Topics</div>
-                <div className="ovr-tag-row">
-                  {scope.off_scope_topics.map(t => (
-                    <span key={t} className="ovr-tag-danger">{t}</span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {scope.drift_signatures.length > 0 && (
-              <div className="ovr-mb-10">
-                <div className="ovr-label-warning">Drift Signatures</div>
-                <ul className="ovr-ul">
-                  {scope.drift_signatures.map((d, i) => <li key={i} className="ovr-li-warning">{d}</li>)}
-                </ul>
-              </div>
-            )}
-
-            {scope.example_ceiling && (
-              <div className="ovr-mb-10">
-                <div className="ovr-label-tight">Example Ceiling</div>
-                <div className="ovr-example-ceiling">{scope.example_ceiling}</div>
-              </div>
-            )}
-
-            {scope.explicit_qualifiers.length > 0 && (
-              <div className="ovr-mb-10">
-                <div className="ovr-label">Qualifiers</div>
-                <div className="ovr-tag-row">
-                  {scope.explicit_qualifiers.map(q => (
-                    <span key={q} className="ovr-tag-neutral">{q}</span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {scope.excluded_scenarios.length > 0 && (
-              <div className="ovr-mb-10">
-                <div className="ovr-label">Excluded Scenarios</div>
-                <ul className="ovr-ul">
-                  {scope.excluded_scenarios.map((s, i) => <li key={i} className="ovr-mb-2">{s}</li>)}
-                </ul>
-              </div>
-            )}
-
-            {scope.on_scope_evidence.length > 0 && (
-              <div className="ovr-mb-10">
-                <div className="ovr-label">On-Scope Evidence</div>
-                <ul className="ovr-ul">
-                  {scope.on_scope_evidence.map((e, i) => <li key={i} className="ovr-mb-2">{e}</li>)}
-                </ul>
-              </div>
-            )}
-          </div>
-        );
-      })()}
+      <TopicScopeSection debate={debate} effectiveOverviewTab={effectiveOverviewTab} />
 
       {/* Extraction Timeline — diagnoses AN-plateau failures */}
       {effectiveOverviewTab === 'extraction' && (
@@ -210,239 +1016,7 @@ export function OverviewTabRouter({
       )}
 
       {/* Lineage Frame — intellectual tradition distribution from topic critique */}
-      {effectiveOverviewTab === 'lineage' && (() => {
-        const frame = debate.topic.critique?.lineage_frame;
-        if (!frame || frame.length === 0) return <div className="ovr-empty">No lineage data for this debate.</div>;
-        const maxPct = Math.max(...frame.map(f => f.percentage));
-        // Check if any transcript entry had lineage boost data
-        const boostActive = debate.transcript.some(e => {
-          const manifest = (e.metadata as Record<string, unknown>)?.injection_manifest as { lineage_boost?: unknown } | undefined;
-          return !!manifest?.lineage_boost;
-        });
-        // Aggregate per-turn boost stats from injection manifests
-        let totalBoosted = 0;
-        let totalPromoted = 0;
-        let turnsWithBoost = 0;
-        for (const e of debate.transcript) {
-          const manifest = (e.metadata as Record<string, unknown>)?.injection_manifest as {
-            lineage_boost?: { boosted?: number; promoted?: number };
-          } | undefined;
-          if (manifest?.lineage_boost) {
-            turnsWithBoost++;
-            totalBoosted += manifest.lineage_boost.boosted ?? 0;
-            totalPromoted += manifest.lineage_boost.promoted ?? 0;
-          }
-        }
-        return (
-          <div className="ovr-panel">
-            <h4 className="ovr-h4">Intellectual Lineage Frame</h4>
-            <p className="ovr-intro">
-              Dominant intellectual traditions detected from activated taxonomy nodes. These traditions shape which nodes receive relevance boosts during context injection.
-            </p>
-            <div className="ovr-lineage-list">
-              {frame.map(f => (
-                <div key={f.cluster_id}>
-                  <div className="ovr-lineage-row">
-                    <span className="ovr-lineage-label">{f.label}</span>
-                    <div className="ovr-lineage-track">
-                      <div
-                        className="ovr-lineage-bar"
-                        // eslint-disable-next-line local/no-inline-style -- data-driven bar width
-                        style={{ width: `${maxPct > 0 ? (f.percentage / maxPct) * 100 : 0}%` }}
-                      />
-                    </div>
-                    <span className="ovr-lineage-pct">
-                      {(f.percentage * 100).toFixed(0)}%
-                    </span>
-                  </div>
-                  {f.traditions && f.traditions.length > 0 && (
-                    <div className="ovr-lineage-traditions">
-                      {f.traditions.join(', ')}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-            <div className="ovr-boost-row">
-              <div
-                className="ovr-boost-stat-base"
-                // eslint-disable-next-line local/no-inline-style -- boostActive-driven background/color
-                style={{
-                  background: boostActive ? 'color-mix(in srgb, var(--success) 12%, transparent)' : 'color-mix(in srgb, var(--danger) 8%, transparent)',
-                  color: boostActive ? 'var(--success)' : 'var(--text-muted)',
-                }}
-              >
-                Lineage Boost: {boostActive ? 'Active' : 'Inactive'}
-              </div>
-              {boostActive && turnsWithBoost > 0 && (
-                <>
-                  <div className="ovr-boost-stat">
-                    Turns with boost: {turnsWithBoost}
-                  </div>
-                  <div className="ovr-boost-stat">
-                    Nodes boosted: {totalBoosted} · Promoted: {totalPromoted}
-                  </div>
-                </>
-              )}
-            </div>
-            {/* Lineage Effectiveness — promoted vs. cited */}
-            {boostActive && (() => {
-              const allPromoted = new Set<string>();
-              const allInjected = new Set<string>();
-              const allReferenced = new Set<string>();
-              for (const e of debate.transcript) {
-                if (e.type !== 'opening' && e.type !== 'statement') continue;
-                const manifest = (e.metadata as Record<string, unknown>)?.injection_manifest as {
-                  lineage_boost?: { boostedNodeIds?: string[]; promotedNodeIds?: string[] };
-                  povNodeIds?: string[];
-                } | undefined;
-                if (!manifest) continue;
-                for (const id of (e.taxonomy_refs ?? []).map((r: { node_id: string }) => r.node_id)) allReferenced.add(id);
-                for (const id of manifest.povNodeIds ?? []) allInjected.add(id);
-                const lb = manifest.lineage_boost;
-                if (lb) {
-                  for (const id of lb.promotedNodeIds ?? []) allPromoted.add(id);
-                }
-              }
-              if (allPromoted.size === 0) return null;
-              const promotedCitedIds = [...allPromoted].filter(id => allReferenced.has(id));
-              const promotedCited = promotedCitedIds.length;
-              const promotedRate = promotedCited / allPromoted.size;
-              const baselineRate = allInjected.size > 0 ? allReferenced.size / allInjected.size : 0;
-              const ratio = baselineRate > 0 ? promotedRate / baselineRate : 0;
-              const verdict = promotedRate > 0.15 ? 'high_impact' : promotedRate > 0.05 ? 'moderate_impact' : 'low_impact';
-              const verdictLabel = verdict === 'high_impact' ? 'High impact' : verdict === 'moderate_impact' ? 'Moderate impact' : 'Low impact';
-              const verdictColor = verdict === 'high_impact' ? 'var(--success)' : verdict === 'moderate_impact' ? 'var(--warning)' : 'var(--danger)';
-              const promotedCitedSet = new Set(promotedCitedIds);
-              return (
-                <div className="ovr-effectiveness">
-                  <div className="ovr-effectiveness-title">Lineage Effectiveness</div>
-                  <div>
-                    Lineage boost promoted <strong>{allPromoted.size}</strong> node{allPromoted.size !== 1 ? 's' : ''};{' '}
-                    <strong className="ovr-success-text">{promotedCited}</strong> cited ({(promotedRate * 100).toFixed(0)}%)
-                    {' vs. '}<strong>{(baselineRate * 100).toFixed(0)}%</strong> baseline
-                  </div>
-                  <div className="ovr-muted-mt-2">
-                    {promotedRate > baselineRate
-                      ? `Promoted nodes cited ${ratio.toFixed(1)}× more than baseline — boost is helping`
-                      : promotedRate === baselineRate
-                        ? 'Promoted node citation rate matches baseline'
-                        : 'Promoted nodes cited less than baseline — boost had limited effect'}
-                  </div>
-                  <div
-                    className="ovr-verdict"
-                    // eslint-disable-next-line local/no-inline-style -- verdict-driven color
-                    style={{ color: verdictColor }}
-                  >
-                    Lineage boost: {verdictLabel}
-                  </div>
-                  {allPromoted.size <= 30 && (
-                    <div className="ovr-promoted-list">
-                      {[...allPromoted].map(id => (
-                        <span
-                          key={id}
-                          className="ovr-promoted-chip"
-                          // eslint-disable-next-line local/no-inline-style -- citation-state-driven background/color/border
-                          style={{
-                            background: promotedCitedSet.has(id) ? 'color-mix(in srgb, var(--success) 15%, transparent)' : 'color-mix(in srgb, var(--text-muted) 15%, transparent)',
-                            color: promotedCitedSet.has(id) ? 'var(--success)' : 'var(--text-muted)',
-                            border: `1px solid ${promotedCitedSet.has(id) ? 'color-mix(in srgb, var(--success) 30%, transparent)' : 'color-mix(in srgb, var(--text-muted) 20%, transparent)'}`,
-                          }}
-                          title={promotedCitedSet.has(id) ? 'Cited by debaters' : 'Not cited'}
-                        >
-                          {id}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              );
-            })()}
-            {/* Vocabulary Disambiguation Aggregate (t/212) */}
-            {(() => {
-              const allResolved: { colloquial: string; canonical: string; confidence: string; speaker: string }[] = [];
-              const allAmbiguous: { colloquial: string; speaker: string }[] = [];
-              for (const e of debate.transcript) {
-                if (e.speaker === 'system' || e.speaker === 'moderator' || e.speaker === 'user') continue;
-                const meta = e.metadata as Record<string, unknown> | undefined;
-                const res = meta?.vocabulary_resolutions as { colloquial: string; canonical: string; confidence: string }[] | undefined;
-                const amb = meta?.vocabulary_ambiguities as { colloquial: string }[] | undefined;
-                if (res) for (const r of res) allResolved.push({ ...r, speaker: speakerLabel(e.speaker) });
-                if (amb) for (const a of amb) allAmbiguous.push({ colloquial: a.colloquial, speaker: speakerLabel(e.speaker) });
-              }
-              if (allResolved.length === 0 && allAmbiguous.length === 0) return null;
-              // Group by colloquial term -> canonical form(s) with speakers
-              const grouped = new Map<string, { canonical: string; confidence: string; speakers: Set<string>; count: number }>();
-              for (const r of allResolved) {
-                const key = `${r.colloquial}→${r.canonical}`;
-                const existing = grouped.get(key);
-                if (existing) {
-                  existing.speakers.add(r.speaker);
-                  existing.count++;
-                } else {
-                  grouped.set(key, { canonical: r.canonical, confidence: r.confidence, speakers: new Set([r.speaker]), count: 1 });
-                }
-              }
-              return (
-                <div className="ovr-mt-20">
-                  <h4 className="ovr-h4">Vocabulary Disambiguation</h4>
-                  <p className="ovr-intro-8">
-                    Colloquial terms resolved to canonical forms based on speaker POV.
-                    {allResolved.length > 0 && <> <strong>{allResolved.length}</strong> resolved across {grouped.size} unique mappings.</>}
-                    {allAmbiguous.length > 0 && <> <span className="ovr-warning-text"><strong>{allAmbiguous.length}</strong> ambiguous.</span></>}
-                  </p>
-                  {grouped.size > 0 && (
-                    <table className="ovr-vocab-table">
-                      <thead>
-                        <tr className="ovr-vocab-head-row">
-                          <th className="ovr-th-left">Colloquial</th>
-                          <th className="ovr-th-left">Canonical Form</th>
-                          <th className="ovr-th-center">Conf.</th>
-                          <th className="ovr-th-left">Speakers</th>
-                          <th className="ovr-th-center">Hits</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {[...grouped.entries()].sort((a, b) => b[1].count - a[1].count).map(([key, v]) => {
-                          const colloquial = key.split('→')[0];
-                          return (
-                            <tr key={key} className="ovr-vocab-row">
-                              <td className="ovr-td">
-                                <span className="vocab-term ovr-vocab-term">{colloquial}</span>
-                              </td>
-                              <td className="ovr-td-secondary">{v.canonical}</td>
-                              <td
-                                className="ovr-td-conf"
-                                // eslint-disable-next-line local/no-inline-style -- confidence-driven color
-                                style={{ color: v.confidence === 'high' ? 'var(--success)' : v.confidence === 'low' ? 'var(--danger)' : 'var(--warning)' }}
-                              >{v.confidence}</td>
-                              <td className="ovr-td-muted">{[...v.speakers].join(', ')}</td>
-                              <td className="ovr-td-center">{v.count}</td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  )}
-                  {allAmbiguous.length > 0 && (
-                    <div className="ovr-ambiguous">
-                      <div className="ovr-ambiguous-title">Ambiguous terms (needs review):</div>
-                      {[...new Set(allAmbiguous.map(a => a.colloquial))].map((term, i) => {
-                        const speakers = [...new Set(allAmbiguous.filter(a => a.colloquial === term).map(a => a.speaker))];
-                        return (
-                          <div key={i} className="ovr-ambiguous-item">
-                            &ldquo;{term}&rdquo; <span className="ovr-muted">&mdash; {speakers.join(', ')}</span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-              );
-            })()}
-          </div>
-        );
-      })()}
+      <LineageSection debate={debate} effectiveOverviewTab={effectiveOverviewTab} />
 
       {/* Adaptive Staging — signal telemetry, phase transitions, GC events */}
       {effectiveOverviewTab === 'adaptive' && (
@@ -455,32 +1029,30 @@ export function OverviewTabRouter({
       )}
 
       {/* Argument Network with inline Moderator Deliberations */}
-      {effectiveOverviewTab === 'argument-network' && an && an.nodes.length > 0 && (
-        <ArgumentNetworkTab
-          debate={debate}
-          an={an}
-          anFilterMode={anFilterMode}
-          anFilterNodeId={anFilterNodeId}
-          setAnFilterMode={setAnFilterMode}
-          setAnFilterNodeId={setAnFilterNodeId}
-          focusedNodeId={focusedNodeId}
-          handleUpdateSubScore={handleUpdateSubScore}
-          setOverviewTab={setOverviewTab}
-          setSelectedEntry={setSelectedEntry}
-          setLocalOverride={setLocalOverride}
-          nodeLabels={nodeLabels}
-        />
-      )}
+      <ArgumentNetworkSection
+        debate={debate}
+        an={an}
+        effectiveOverviewTab={effectiveOverviewTab}
+        anFilterMode={anFilterMode}
+        anFilterNodeId={anFilterNodeId}
+        setAnFilterMode={setAnFilterMode}
+        setAnFilterNodeId={setAnFilterNodeId}
+        focusedNodeId={focusedNodeId}
+        handleUpdateSubScore={handleUpdateSubScore}
+        setOverviewTab={setOverviewTab}
+        setSelectedEntry={setSelectedEntry}
+        setLocalOverride={setLocalOverride}
+        nodeLabels={nodeLabels}
+      />
 
       {/* Commitments */}
-      {effectiveOverviewTab === 'commitments' && commitments && Object.keys(commitments).length > 0 && (
-        <CommitmentsPanel
-          commitments={commitments}
-          nodes={an?.nodes ?? []}
-          edges={an?.edges ?? []}
-          onGoToNode={(nodeId) => { setOverviewTab('argument-network'); setFocusedNodeId(nodeId); }}
-        />
-      )}
+      <CommitmentsSection
+        effectiveOverviewTab={effectiveOverviewTab}
+        commitments={commitments}
+        an={an}
+        setOverviewTab={setOverviewTab}
+        setFocusedNodeId={setFocusedNodeId}
+      />
 
       {/* POV Progression — inline view (replaces separate popout) */}
       {effectiveOverviewTab === 'pov-progression' && (
@@ -490,227 +1062,22 @@ export function OverviewTabRouter({
       )}
 
       {/* Flight Recorder Context — live snapshot of app state */}
-      {effectiveOverviewTab === 'fr-context' && (() => {
-        const taxState = useTaxonomyStore.getState();
-        const mem = (performance as unknown as { memory?: { usedJSHeapSize: number; totalJSHeapSize: number } }).memory;
-        const eApi = (window as unknown as { electronAPI?: { processVersions?: Record<string, string | undefined>; osRelease?: string; osPlatform?: string; osArch?: string } }).electronAPI;
-        const pv = eApi?.processVersions;
-        const sections: { title: string; rows: [string, string | number | null | undefined][] }[] = [
-          {
-            title: 'App',
-            rows: [
-              ['Platform', eApi?.osPlatform ?? navigator.platform],
-              ['Arch', eApi?.osArch ?? 'unknown'],
-              ['OS Version', eApi?.osRelease ?? 'N/A'],
-              ['VITE_TARGET', import.meta.env.VITE_TARGET ?? 'electron'],
-              ['Mode', import.meta.env.DEV ? 'dev' : 'prod'],
-            ],
-          },
-          {
-            title: 'SBOM',
-            rows: [
-              ['Node', pv?.node ?? 'N/A'],
-              ['Electron', pv?.electron ?? 'N/A'],
-              ['Chrome', pv?.chrome ?? 'N/A'],
-              ['V8', pv?.v8 ?? 'N/A'],
-              ['React', typeof __COMPONENT_VERSIONS__ !== 'undefined' ? __COMPONENT_VERSIONS__.react : 'N/A'],
-              ['Zustand', typeof __COMPONENT_VERSIONS__ !== 'undefined' ? __COMPONENT_VERSIONS__.zustand : 'N/A'],
-            ],
-          },
-          {
-            title: 'Windows',
-            rows: [
-              ['Active Tab', taxState.activeTab],
-              ['Toolbar Panel', taxState.toolbarPanel ?? '(none)'],
-              ['Selected Node', taxState.selectedNodeId ?? '(none)'],
-            ],
-          },
-          {
-            title: 'Debate',
-            rows: [
-              ['ID', debate.id.slice(0, 8) + '...'],
-              ['Phase', debate.phase],
-              ['Adaptive Phase', debate.adaptive_staging?.phase_state?.current_phase ?? '(none)'],
-              ['Transcript', debate.transcript?.length ?? 0],
-              ['AN Nodes', debate.argument_network?.nodes?.length ?? 0],
-              ['Convergence Signals', debate.convergence_signals?.length ?? 0],
-              ['Protocol', debate.protocol_id ?? '(default)'],
-            ],
-          },
-          {
-            title: 'Taxonomy',
-            rows: [
-              ['Accelerationist nodes', taxState.accelerationist?.nodes?.length ?? 0],
-              ['Safetyist nodes', taxState.safetyist?.nodes?.length ?? 0],
-              ['Skeptic nodes', taxState.skeptic?.nodes?.length ?? 0],
-              ['Situations nodes', taxState.situations?.nodes?.length ?? 0],
-              ['Edges', taxState.edgesFile?.edges?.length ?? 0],
-              ['Dirty files', taxState.dirty?.size ?? 0],
-              ['Save error', taxState.saveError ?? '(none)'],
-            ],
-          },
-          {
-            title: 'AI',
-            rows: [
-              ['Backend', taxState.aiBackend],
-              ['Model', taxState.geminiModel],
-            ],
-          },
-          {
-            title: 'Performance',
-            rows: [
-              ['Uptime', `${Math.round(performance.now() / 1000)}s`],
-              ['Heap used', mem ? `${Math.round(mem.usedJSHeapSize / 1048576)} MB` : 'N/A'],
-              ['Heap total', mem ? `${Math.round(mem.totalJSHeapSize / 1048576)} MB` : 'N/A'],
-            ],
-          },
-        ];
-        const isEmptyValue = (v: string | number | null | undefined): boolean => {
-          if (v === null || v === undefined) return true;
-          const s = String(v);
-          return s === '' || s === '0' || s === '(none)' || s === 'N/A';
-        };
-        return (
-          <div className="ovr-fr-context">
-            <div className="ovr-fr-header">
-              <span className="ovr-fr-title">Flight Recorder Context Snapshot</span>
-              <button
-                onClick={() => { void triggerManualDump(); }}
-                className="ovr-dump-btn"
-              >Dump Now</button>
-            </div>
-            <div className="ovr-fr-grid">
-              {sections.map(s => (
-                <div key={s.title} className="ovr-fr-card">
-                  <div className="ovr-fr-card-title">{s.title}</div>
-                  {s.rows.map(([label, value]) => {
-                    const empty = isEmptyValue(value);
-                    return (
-                      <div key={label} className="ovr-fr-row">
-                        <span className="ovr-fr-label">{label}</span>
-                        <span
-                          className="ovr-fr-value"
-                          // eslint-disable-next-line local/no-inline-style -- empty-state-driven color
-                          style={{ color: empty ? 'var(--text-muted)' : 'var(--text-primary)' }}
-                        >{String(value ?? '')}</span>
-                      </div>
-                    );
-                  })}
-                </div>
-              ))}
-            </div>
-          </div>
-        );
-      })()}
+      <FrContextSection debate={debate} effectiveOverviewTab={effectiveOverviewTab} />
 
       {/* Transcript list for selection */}
-      {effectiveOverviewTab === 'transcript' && (() => {
-        const speakers = Array.from(new Set(debate.transcript.map(e => e.speaker)));
-        const filteredTranscript = transcriptSpeakerFilter
-          ? debate.transcript.map((e, i) => ({ e, i })).filter(({ e }) => e.speaker === transcriptSpeakerFilter)
-          : debate.transcript.map((e, i) => ({ e, i }));
-        return (
-        <div className="ovr-transcript">
-          <div className="ovr-transcript-filters">
-            <button
-              onClick={() => setTranscriptSpeakerFilter(null)}
-              className="ovr-filter-btn"
-              // eslint-disable-next-line local/no-inline-style -- active-filter-driven background/color
-              style={{
-                background: !transcriptSpeakerFilter ? 'var(--warning)' : 'transparent',
-                color: !transcriptSpeakerFilter ? 'var(--text-primary)' : 'var(--text-secondary)',
-              }}
-            >All ({debate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length} stmts / {debate.transcript.length})</button>
-            {speakers.map(s => {
-              const count = debate.transcript.filter(e => e.speaker === s).length;
-              const active = transcriptSpeakerFilter === s;
-              return (
-                <button
-                  key={s}
-                  onClick={() => setTranscriptSpeakerFilter(active ? null : s)}
-                  className="ovr-filter-btn"
-                  // eslint-disable-next-line local/no-inline-style -- active-filter-driven background/color
-                  style={{
-                    background: active ? 'var(--warning)' : 'transparent',
-                    color: active ? 'var(--text-primary)' : 'var(--text-secondary)',
-                  }}
-                >{speakerLabel(s)} ({count})</button>
-              );
-            })}
-          </div>
-          <div className="ovr-transcript-list">
-          {filteredTranscript.map(({ e, i }) => {
-          const stmtId = `S${i + 1}`;
-          const eMeta = e.metadata as Record<string, unknown> | undefined;
-          const modT = eMeta?.moderator_trace as {
-            selected?: string; focus_point?: string; selection_reason?: string;
-            convergence_score?: number | null; convergence_triggered?: boolean;
-            intervention_recommended?: boolean; intervention_move?: string | null;
-            intervention_validated?: boolean; health_score?: number;
-          } | undefined;
-          const eDiag = debate.diagnostics?.entries[e.id];
-          const hasStages = eDiag?.stage_diagnostics && eDiag.stage_diagnostics.length > 0;
-          const pipelineError = e.type === 'statement' && hasStages && !eDiag?.extracted_claims && !(eDiag as Record<string, unknown>)?.extraction_trace;
-          return (
-            <div
-              key={e.id}
-              onClick={() => { setSelectedEntry(e.id); setLocalOverride(true); }}
-              className="ovr-transcript-entry"
-              // eslint-disable-next-line local/no-inline-style -- selection-driven background/border
-              style={{ background: selectedEntry === e.id ? 'color-mix(in srgb, var(--color-acc) 8%, transparent)' : 'var(--bg-primary)', borderLeft: selectedEntry === e.id ? '3px solid var(--color-acc)' : '3px solid transparent' }}
-            >
-              <div className="ovr-stmt-head">
-                <span
-                  title={pipelineError ? `Statement ${stmtId} — pipeline error` : `Statement ${stmtId}`}
-                  className="ovr-stmt-badge"
-                  // eslint-disable-next-line local/no-inline-style -- pipeline-error-driven background/color
-                  style={{
-                    background: pipelineError ? 'color-mix(in srgb, var(--danger) 15%, transparent)' : 'color-mix(in srgb, var(--color-acc) 12%, transparent)',
-                    color: pipelineError ? 'var(--danger)' : 'var(--color-acc)',
-                  }}
-                >{pipelineError && <span className="ovr-mr-3">●</span>}{stmtId}</span>
-                <span className="ovr-stmt-content">
-                  <strong>{speakerLabel(e.speaker)}</strong> [{e.type}] <Highlight text={e.content.slice(0, 80)} />...
-                </span>
-                {hasStages && <span title="4-stage pipeline" className="ovr-pipeline-badge">B/P/D/C</span>}
-              </div>
-              {modT && (
-                <div className="ovr-mod-row">
-                  <span className="ovr-mod-tag">MOD</span>
-                  {modT.focus_point && <span className="ovr-mod-focus" title={modT.focus_point}>{modT.focus_point}</span>}
-                  {modT.selection_reason && modT.selection_reason !== 'moderator_ai_selection' && (
-                    <span className="ovr-mod-reason">{modT.selection_reason === 'turn_alternation_override' ? 'override' : modT.selection_reason}</span>
-                  )}
-                  {modT.intervention_move && (
-                    <span
-                      className="ovr-mod-tag-base"
-                      // eslint-disable-next-line local/no-inline-style -- validation-driven background/color
-                      style={{ background: modT.intervention_validated ? 'var(--bg-hover)' : 'color-mix(in srgb, var(--danger) 15%, transparent)', color: modT.intervention_validated ? 'var(--text-secondary)' : 'var(--danger)' }}
-                    >{modT.intervention_move}{modT.intervention_validated ? '' : ' (suppressed)'}</span>
-                  )}
-                  {modT.convergence_score != null && <span className="ovr-mod-metric">conv:{(modT.convergence_score * 100).toFixed(0)}%</span>}
-                  {modT.health_score != null && <span className="ovr-mod-metric">H:{modT.health_score.toFixed(2)}</span>}
-                </div>
-              )}
-            </div>
-          );
-        })}
-        </div>
-        </div>
-        );
-      })()}
+      <TranscriptSection
+        debate={debate}
+        effectiveOverviewTab={effectiveOverviewTab}
+        transcriptSpeakerFilter={transcriptSpeakerFilter}
+        setTranscriptSpeakerFilter={setTranscriptSpeakerFilter}
+        selectedEntry={selectedEntry}
+        setSelectedEntry={setSelectedEntry}
+        setLocalOverride={setLocalOverride}
+      />
       </>}
 
       {/* Prompt Diff — rendered outside the selectedEntry guard so it works from transcript inline buttons too */}
-      {effectiveOverviewTab === 'prompt-diff' && (
-        <div className="ovr-prompt-diff">
-          <PromptDiffContent
-            debate={debate}
-            focusedEntryId={selectedEntry ?? debate.transcript[0]?.id ?? ''}
-            embedded
-          />
-        </div>
-      )}
+      <PromptDiffSection debate={debate} effectiveOverviewTab={effectiveOverviewTab} selectedEntry={selectedEntry} />
 
       {/* Agent Utility — per-speaker composite with sparkline curves */}
       {effectiveOverviewTab === 'utility' && (
@@ -732,140 +1099,7 @@ export function OverviewTabRouter({
       )}
 
       {/* Exclusion Guard Overview — aggregate across all entries */}
-      {effectiveOverviewTab === 'exclusion-overview' && (() => {
-        const entries = debate.diagnostics?.entries;
-        if (!entries || Object.keys(entries).length === 0) {
-          return (
-            <div className="ovr-p-16">
-              <h4 className="ovr-h4-8">Exclusion Guard</h4>
-              <div className="ovr-italic-muted">
-                No diagnostics data available for this debate.
-              </div>
-            </div>
-          );
-        }
-
-        let claimsChecked = 0;
-        let claimViolations: { claim_id: string; claim_text: string; node_id: string; similarity_main: number; similarity_exclusion: number }[] = [];
-        let draftsChecked = 0;
-        let driftWarnings: { debater: string; node_id: string; similarity: number; draft_excerpt: string }[] = [];
-        let hasAnyData = false;
-
-        for (const entry of Object.values(entries)) {
-          const extTrace = entry.extraction_trace;
-          if (extTrace) {
-            hasAnyData = true;
-            if (extTrace.exclusion_guard) {
-              claimsChecked += extTrace.exclusion_guard.checked;
-              if (extTrace.exclusion_guard.violations?.length) claimViolations = claimViolations.concat(extTrace.exclusion_guard.violations);
-            }
-            if (extTrace.exclusion_violations?.length) {
-              claimViolations = claimViolations.concat(extTrace.exclusion_violations);
-            }
-          }
-          if (entry.scope_drift_check) {
-            hasAnyData = true;
-            draftsChecked += entry.scope_drift_check.refs_checked;
-            if (entry.scope_drift_check.warnings?.length) driftWarnings = driftWarnings.concat(entry.scope_drift_check.warnings);
-          }
-          if (entry.scope_drift_warnings?.length) {
-            hasAnyData = true;
-            driftWarnings = driftWarnings.concat(entry.scope_drift_warnings);
-          }
-        }
-
-        const allClear = claimViolations.length === 0 && driftWarnings.length === 0;
-
-        return (
-          <div className="ovr-panel">
-            <h4 className="ovr-h4-10">Exclusion Guard Summary</h4>
-
-            {!hasAnyData ? (
-              <div className="ovr-italic-muted">
-                Exclusion guard data not available — no extraction traces found in this debate.
-              </div>
-            ) : (
-              <>
-                {/* Aggregate badges */}
-                <div className="ovr-badge-row">
-                  <span
-                    className="ovr-guard-badge"
-                    // eslint-disable-next-line local/no-inline-style -- violation-count-driven background/color
-                    style={{
-                      background: claimViolations.length > 0 ? 'color-mix(in srgb, var(--danger) 10%, transparent)' : 'color-mix(in srgb, var(--success) 8%, transparent)',
-                      color: claimViolations.length > 0 ? 'var(--danger)' : 'var(--success)',
-                    }}
-                  >
-                    {claimsChecked} claims checked — {claimViolations.length} violation{claimViolations.length !== 1 ? 's' : ''}
-                  </span>
-                  <span
-                    className="ovr-guard-badge"
-                    // eslint-disable-next-line local/no-inline-style -- warning-count-driven background/color
-                    style={{
-                      background: driftWarnings.length > 0 ? 'color-mix(in srgb, var(--warning) 10%, transparent)' : 'color-mix(in srgb, var(--success) 8%, transparent)',
-                      color: driftWarnings.length > 0 ? 'var(--warning)' : 'var(--success)',
-                    }}
-                  >
-                    {draftsChecked} refs checked — {driftWarnings.length} drift warning{driftWarnings.length !== 1 ? 's' : ''}
-                  </span>
-                </div>
-
-                {allClear ? (
-                  <div className="ovr-clear-banner">
-                    All statements within scope — no exclusion violations or drift warnings
-                  </div>
-                ) : (
-                  <>
-                    {claimViolations.length > 0 && (
-                      <div className="ovr-mb-12">
-                        <div className="ovr-section-title-danger">
-                          Exclusion Violations ({claimViolations.length})
-                        </div>
-                        {claimViolations.map((v, i) => (
-                          <div key={i} className="ovr-violation-card">
-                            <div className="ovr-violation-head">
-                              <span className="ovr-danger-bold">{v.claim_id}</span>
-                              <span className="ovr-muted">→</span>
-                              <span className="ovr-bold">{v.node_id}</span>
-                            </div>
-                            <div className="ovr-violation-claim">{v.claim_text}</div>
-                            <div className="ovr-violation-sims">
-                              <span>main: <strong>{v.similarity_main.toFixed(3)}</strong></span>
-                              <span>exclusion: <strong>{v.similarity_exclusion.toFixed(3)}</strong></span>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                    {driftWarnings.length > 0 && (
-                      <div>
-                        <div className="ovr-section-title-warning">
-                          Scope Drift Warnings ({driftWarnings.length})
-                        </div>
-                        {driftWarnings.map((w, i) => (
-                          <div key={i} className="ovr-drift-card">
-                            <div className="ovr-violation-head">
-                              <span className="ovr-warning-bold">{w.debater}</span>
-                              <span className="ovr-muted">→</span>
-                              <span className="ovr-bold">{w.node_id}</span>
-                              <span className="ovr-drift-sim">
-                                {w.similarity.toFixed(3)}
-                              </span>
-                            </div>
-                            <div className="ovr-drift-excerpt">
-                              {w.draft_excerpt.length > 200 ? w.draft_excerpt.slice(0, 200) + '…' : w.draft_excerpt}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </>
-                )}
-              </>
-            )}
-          </div>
-        );
-      })()}
+      <ExclusionOverviewSection debate={debate} effectiveOverviewTab={effectiveOverviewTab} />
     </>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/EvidenceTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/EvidenceTab.tsx
@@ -41,6 +41,455 @@ interface ArgumentNetwork {
   edges: ArgumentNetworkEdge[];
 }
 
+type EvidenceStageDiag = NonNullable<EntryDiagnostics['stage_diagnostics']>[number];
+
+// -- 1. Evidence Summary --
+function buildSummaryCards(evidenceWP: EvidenceWP | undefined): { label: string; value: string }[] {
+  return [
+    { label: 'Facts', value: String(evidenceWP?.facts?.length ?? 0) },
+    { label: 'Key Points', value: String(evidenceWP?.keyPoints?.length ?? 0) },
+    { label: 'Nodes Covered', value: String(evidenceWP?.nodesCovered?.length ?? 0) },
+    { label: 'Total Candidates', value: String(evidenceWP?.totalCandidates ?? 0) },
+    ...((evidenceWP as Record<string, unknown>)?.evidence_utilization ? [{
+      label: 'Citation Rate',
+      value: `${((evidenceWP as Record<string, unknown>).evidence_utilization as { utilization_rate: number }).utilization_rate}%`,
+    }] : []),
+  ];
+}
+
+function SummaryMetaRow({ evidenceStage, evidenceWP }: {
+  evidenceStage: EvidenceStageDiag;
+  evidenceWP: EvidenceWP | undefined;
+}) {
+  return (
+    <div className="evid-meta-row">
+      <span>{evidenceStage.model}</span>
+      <span>{(evidenceStage.response_time_ms / 1000).toFixed(1)}s</span>
+      {evidenceWP?.nodesCovered && <span>Nodes covered: {evidenceWP.nodesCovered.join(', ')}</span>}
+      {evidenceWP?.totalCandidates != null && <span>({evidenceWP.totalCandidates} candidates screened)</span>}
+    </div>
+  );
+}
+
+function EvidenceSummarySection({ evidenceStage, evidenceWP }: {
+  evidenceStage: EvidenceStageDiag | undefined;
+  evidenceWP: EvidenceWP | undefined;
+}) {
+  if (!evidenceStage) return null;
+  return (
+    <details open>
+      <summary className="evid-summary">Source Evidence Retrieved</summary>
+      <SummaryMetaRow evidenceStage={evidenceStage} evidenceWP={evidenceWP} />
+      {evidenceStage.parse_error && (
+        <div className="evid-parse-error">
+          <strong>Parse error:</strong> {evidenceStage.parse_error}
+        </div>
+      )}
+      <div className="evid-cards-row">
+        {buildSummaryCards(evidenceWP).map(card => (
+          <div key={card.label} className="evid-card">
+            <div className="evid-card-label">{card.label}</div>
+            <div className="evid-card-value">{card.value}</div>
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+// -- 2. Source Facts --
+function SourceFactsSection({ evidenceWP }: { evidenceWP: EvidenceWP | undefined }) {
+  if (!evidenceWP?.facts || evidenceWP.facts.length === 0) return null;
+  return (
+    <details open className="evid-details-mt">
+      <summary className="evid-summary">
+        Source Facts ({evidenceWP.facts.length})
+      </summary>
+      {evidenceWP.facts.map((fact, fi) => {
+        const specColor = fact.specificity === 'precise' ? 'var(--success)' : fact.specificity === 'qualified' ? 'var(--warning)' : 'var(--text-muted)';
+        return (
+          <div key={fi} className="evid-fact">
+            <div className="evid-row-center-gap6">
+              {/* eslint-disable-next-line local/no-inline-style -- dynamic specColor swatch */}
+              <span style={{
+                fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
+                color: specColor, background: `${specColor}18`,
+              }}>{fact.specificity?.toUpperCase() ?? 'FACT'}</span>
+              <a
+                href={`https://scholar.google.com/scholar?q=${encodeURIComponent(fact.doc_id.replace(/-/g, ' ').replace(/\d{4}$/, ''))}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="evid-doc-link"
+                title={`Search for: ${fact.doc_id}`}
+              >
+                {fact.doc_id}
+              </a>
+              {fact.temporal_bound && (
+                <span className="evid-temporal">{fact.temporal_bound}</span>
+              )}
+            </div>
+            <div className="evid-claim">{fact.claim}</div>
+            {fact.linked_taxonomy_nodes?.length > 0 && (
+              <div className="evid-linked-nodes">
+                {fact.linked_taxonomy_nodes.join(', ')}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </details>
+  );
+}
+
+// -- 3. Key Points --
+function KeyPointsSection({ evidenceWP }: { evidenceWP: EvidenceWP | undefined }) {
+  if (!evidenceWP?.keyPoints || evidenceWP.keyPoints.length === 0) return null;
+  return (
+    <details open className="evid-details-mt">
+      <summary className="evid-summary">
+        Key Points ({evidenceWP.keyPoints.length})
+      </summary>
+      {evidenceWP.keyPoints.map((kp, ki) => {
+        const stanceColor = kp.stance === 'support' || kp.stance === 'agree' ? 'var(--success)'
+          : kp.stance === 'oppose' || kp.stance === 'disagree' ? 'var(--danger)' : 'var(--warning)';
+        return (
+          // eslint-disable-next-line local/no-inline-style -- dynamic stanceColor border
+          <div key={ki} style={{
+            marginBottom: 6, padding: '6px 8px', borderRadius: 4,
+            borderLeft: `3px solid ${stanceColor}`, background: 'var(--bg-subtle)',
+          }}>
+            <div className="evid-row-center-gap6">
+              {/* eslint-disable-next-line local/no-inline-style -- dynamic stanceColor swatch */}
+              <span style={{
+                fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
+                color: stanceColor, background: `${stanceColor}18`,
+              }}>{kp.stance?.toUpperCase() ?? 'POINT'}</span>
+              <span className="evid-muted-2xs">{kp.pov}</span>
+              <a
+                href={`https://scholar.google.com/scholar?q=${encodeURIComponent(kp.doc_id.replace(/-/g, ' ').replace(/\d{4}$/, ''))}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="evid-doc-link"
+                title={`Search for: ${kp.doc_id}`}
+              >
+                {kp.doc_id}
+              </a>
+            </div>
+            <div className="evid-claim">{kp.point}</div>
+            {kp.verbatim && (
+              <div className="evid-verbatim">
+                &ldquo;{kp.verbatim}&rdquo;
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </details>
+  );
+}
+
+// -- 4. Raw Evidence Block --
+function RawEvidenceSection({ evidenceStage }: { evidenceStage: EvidenceStageDiag | undefined }) {
+  if (!evidenceStage) return null;
+  return (
+    <details className="evid-details-mt">
+      <summary className="evid-summary-muted">
+        Raw Evidence Block <CopyButton text={evidenceStage.raw_response} />
+      </summary>
+      <pre className="evid-raw-pre">{evidenceStage.raw_response}</pre>
+    </details>
+  );
+}
+
+// -- 5. Cited Evidence (what the debater actually referenced) --
+function CitedEvidenceSection({ evidenceWP }: { evidenceWP: EvidenceWP | undefined }) {
+  const eu = (evidenceWP as Record<string, unknown>)?.evidence_utilization as {
+    total_docs?: number; cited_docs?: Array<{ doc_id: string; title?: string; match_type: string }>; utilization_rate?: number;
+  } | undefined;
+  if (!eu?.cited_docs || eu.total_docs === 0) return null;
+  const matchColors: Record<string, string> = { exact_id: 'var(--success)', slug: 'var(--text-secondary)', title_exact: 'var(--text-secondary)', title_partial: 'var(--warning)', markdown_link: 'var(--success)' };
+  return (
+    <details open className="evid-details-mt">
+      <summary className="evid-summary">
+        Cited Evidence ({eu.cited_docs.length}/{eu.total_docs} sources, {eu.utilization_rate}%)
+      </summary>
+      {eu.cited_docs.length === 0 ? (
+        <div className="evid-empty-cite">
+          Debater did not cite any source documents from the evidence brief.
+        </div>
+      ) : (
+        eu.cited_docs.map((cd, i) => (
+          // eslint-disable-next-line local/no-inline-style -- dynamic matchColors border
+          <div key={i} style={{ marginBottom: 4, padding: '4px 8px', borderRadius: 4, borderLeft: `3px solid ${matchColors[cd.match_type] ?? 'var(--text-muted)'}`, background: 'var(--bg-subtle)', fontSize: 'var(--text-2xs)' }}>
+            <span className="evid-bold600">{cd.title ?? cd.doc_id}</span>
+            {/* eslint-disable-next-line local/no-inline-style -- dynamic matchColors chip */}
+            <span style={{ fontSize: 'var(--text-2xs)', marginLeft: 6, padding: '0 4px', borderRadius: 3, color: matchColors[cd.match_type] ?? 'var(--text-muted)', background: `color-mix(in srgb, ${matchColors[cd.match_type] ?? 'var(--text-muted)'} 10%, transparent)` }}>
+              {cd.match_type.replace('_', ' ')}
+            </span>
+          </div>
+        ))
+      )}
+    </details>
+  );
+}
+
+// -- 6. Citation Pipeline (full chain per source) --
+function CitationPipelineSection({ evidenceWP }: { evidenceWP: EvidenceWP | undefined }) {
+  const pipeline = (evidenceWP as Record<string, unknown>)?.citation_pipeline as Array<{
+    doc_id: string; resolved_title: string; resolved_url: string | null;
+    url_type: string; provenance_label: string | null;
+    cited: boolean; match_type: string | null; linkified: boolean;
+  }> | undefined;
+  if (!pipeline || pipeline.length === 0) return null;
+  const urlTypeColors: Record<string, string> = {
+    doi: 'var(--success)', arxiv: 'var(--success)', ssrn: 'var(--success)', direct: 'var(--text-secondary)',
+    scholar_fallback: 'var(--warning)', google_fallback: 'var(--warning)', none: 'var(--danger)',
+  };
+  return (
+    <details className="evid-details-mt">
+      <summary className="evid-summary">
+        Citation Pipeline ({pipeline.filter(p => p.cited).length}/{pipeline.length} cited, {pipeline.filter(p => p.linkified).length} linkified)
+      </summary>
+      <table className="evid-table">
+        <thead>
+          <tr className="evid-thead-row">
+            <th className="evid-th-left">Source</th>
+            <th className="evid-th-left">Title</th>
+            <th className="evid-th-center">URL Type</th>
+            <th className="evid-th-center">Cited</th>
+            <th className="evid-th-center">Match</th>
+            <th className="evid-th-center">Linked</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pipeline.map((p, pi) => (
+            // eslint-disable-next-line local/no-inline-style -- dynamic cited-row highlight
+            <tr key={pi} style={{
+              borderBottom: '1px solid var(--border)',
+              background: p.cited ? 'color-mix(in srgb, var(--success) 5%, transparent)' : 'transparent',
+            }}>
+              <td className="evid-td-source">
+                {p.resolved_url ? (
+                  <a href={p.resolved_url} target="_blank" rel="noopener noreferrer"
+                    className="evid-cite-link" title={p.doc_id}>
+                    {p.doc_id.length > 25 ? p.doc_id.slice(0, 22) + '…' : p.doc_id}
+                  </a>
+                ) : (
+                  <span title={p.doc_id}>{p.doc_id.length > 25 ? p.doc_id.slice(0, 22) + '…' : p.doc_id}</span>
+                )}
+              </td>
+              <td className="evid-td-title"
+                title={p.resolved_title}>
+                {p.resolved_title !== p.doc_id ? p.resolved_title.slice(0, 35) : '—'}
+              </td>
+              <td className="evid-td-center">
+                {/* eslint-disable-next-line local/no-inline-style -- dynamic urlTypeColors chip */}
+                <span style={{
+                  fontSize: 'var(--text-2xs)', padding: '0 4px', borderRadius: 3, fontWeight: 600,
+                  color: urlTypeColors[p.url_type] ?? 'var(--text-muted)',
+                  background: `color-mix(in srgb, ${urlTypeColors[p.url_type] ?? 'var(--text-muted)'} 10%, transparent)`,
+                }}>{p.url_type}</span>
+              </td>
+              <td className="evid-td-center">
+                {p.cited ? '✓' : '—'}
+              </td>
+              <td className="evid-td-center">
+                {p.match_type ? (
+                  <span className="evid-muted-2xs">
+                    {p.match_type.replace('_', ' ')}
+                  </span>
+                ) : '—'}
+              </td>
+              <td className="evid-td-center">
+                {p.linkified ? '🔗' : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {pipeline.some(p => p.provenance_label) && (
+        <div className="evid-provenance">
+          Provenance: {pipeline.filter(p => p.provenance_label).map(p => `${p.doc_id} → ${p.provenance_label}`).join(', ')}
+        </div>
+      )}
+    </details>
+  );
+}
+
+// -- 7. Ungrounded Claims (from model knowledge, not corpus) --
+function UngroundedClaimsSection({ evidenceWP }: { evidenceWP: EvidenceWP | undefined }) {
+  const uc = (evidenceWP as Record<string, unknown>)?.ungrounded_claims as
+    Array<{ claim: string; reason: string }> | undefined;
+  if (!uc || uc.length === 0) return null;
+  return (
+    <details className="evid-details-mt">
+      <summary className="evid-summary-secondary">
+        Ungrounded Claims ({uc.length})
+      </summary>
+      <div className="evid-ungrounded-note">
+        These factual assertions appear in the statement but don&apos;t match any source in the evidence block or corpus. They likely come from the model&apos;s training data.
+      </div>
+      {uc.map((c, ci) => (
+        <div key={ci} className="evid-ungrounded-item">
+          <div>{c.claim}</div>
+          <div className="evid-linked-nodes">{c.reason}</div>
+        </div>
+      ))}
+    </details>
+  );
+}
+
+// -- Extraction Funnel (post-turn) --
+function ExtractionFunnelSection({ extTrace }: { extTrace: ExtractionTrace | undefined }) {
+  if (!extTrace || extTrace.candidates_proposed <= 0) return null;
+  const max = extTrace.candidates_proposed;
+  const bars: [string, number, string][] = [
+    ['Candidates', extTrace.candidates_proposed, 'var(--text-secondary)'],
+    ['Accepted', extTrace.candidates_accepted, 'var(--success)'],
+    ['Rejected', extTrace.candidates_rejected, 'var(--danger)'],
+  ];
+  return (
+    <details open className="evid-details-mt">
+      <summary className="evid-summary">Extraction Funnel</summary>
+      <div className="evid-funnel-wrap">
+        {bars.map(([label, count, color]) => (
+          <div key={label} className="evid-funnel-row">
+            <span className="evid-funnel-label">{label}</span>
+            <div className="evid-funnel-track">
+              {/* eslint-disable-next-line local/no-inline-style -- dynamic bar width/color */}
+              <div style={{
+                width: `${max > 0 ? Math.round(count / max * 100) : 0}%`,
+                height: '100%', borderRadius: 3, background: color,
+                minWidth: count > 0 ? 4 : 0,
+              }} />
+            </div>
+            <span className="evid-funnel-count">{count}</span>
+            <span className="evid-muted-2xs">
+              {max > 0 ? `${Math.round(count / max * 100)}%` : ''}
+            </span>
+          </div>
+        ))}
+        {extTrace.rejection_reasons && Object.keys(extTrace.rejection_reasons).length > 0 && (
+          <div className="evid-reasons-row">
+            {Object.entries(extTrace.rejection_reasons).map(([reason, count]) => (
+              <span key={reason} className="evid-reason-chip">{reason} ({count})</span>
+            ))}
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function ANDeltaEdgeNodeText({ sourceNode, targetNode }: {
+  sourceNode: ArgumentNetworkNode | undefined;
+  targetNode: ArgumentNetworkNode | undefined;
+}) {
+  if (!sourceNode && !targetNode) return null;
+  return (
+    <div className="evid-edge-text">
+      {sourceNode && <span title={sourceNode.attribution_text_genus || undefined}>{sourceNode.text.length > 60 ? sourceNode.text.slice(0, 60) + '…' : sourceNode.text}</span>}
+      {sourceNode && targetNode && <span> → </span>}
+      {targetNode && <span title={targetNode.attribution_text_genus || undefined}>{targetNode.text.length > 60 ? targetNode.text.slice(0, 60) + '…' : targetNode.text}</span>}
+    </div>
+  );
+}
+
+function ANDeltaEdgeRow({ edge, an, sColors }: {
+  edge: ArgumentNetworkEdge;
+  an: ArgumentNetwork | undefined;
+  sColors: Record<string, string>;
+}) {
+  const sourceNode = an?.nodes.find(n => n.id === edge.source);
+  const targetNode = an?.nodes.find(n => n.id === edge.target);
+  const edgeColor = edge.type === 'attacks' ? 'var(--danger)' : 'var(--success)';
+  const edgeLabel = edge.type === 'attacks'
+    ? (edge.attack_type ? `attacks (${edge.attack_type})` : 'attacks')
+    : 'supports';
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic edgeColor border
+    <div style={{ margin: '3px 0', paddingLeft: 10, borderLeft: `2px solid ${edgeColor}` }}>
+      <div className="evid-edge-header">
+        <span className="evid-edge-node">{edge.source}</span>
+        {/* eslint-disable-next-line local/no-inline-style -- dynamic edgeColor label */}
+        <span style={{ color: edgeColor, fontWeight: 600 }}>{edgeLabel}</span>
+        <span className="evid-edge-node">{edge.target}</span>
+        {edge.strength && (
+          // eslint-disable-next-line local/no-inline-style -- dynamic sColors strength chip
+          <span style={{ padding: '0 3px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, background: `color-mix(in srgb, ${sColors[edge.strength] ?? 'var(--text-muted)'} 10%, transparent)`, color: sColors[edge.strength] ?? 'var(--text-muted)' }}>
+            {edge.strength}
+          </span>
+        )}
+        {edge.argumentation_scheme && (
+          <span className="evid-scheme-chip">
+            {edge.argumentation_scheme}
+          </span>
+        )}
+      </div>
+      <ANDeltaEdgeNodeText sourceNode={sourceNode} targetNode={targetNode} />
+      {edge.warrant && (
+        <details className="evid-mt2">
+          <summary className="evid-summary-muted">Warrant</summary>
+          <div className="evid-warrant">
+            {edge.warrant}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+// -- AN Delta (post-turn) --
+function ANDeltaSection({ extTrace, an }: {
+  extTrace: ExtractionTrace | undefined;
+  an: ArgumentNetwork | undefined;
+}) {
+  if (!extTrace) return null;
+  const addedEdges = an?.edges.filter(e =>
+    extTrace.an_nodes_added_ids.includes(e.source) || extTrace.an_nodes_added_ids.includes(e.target)
+  ) ?? [];
+  const attackEdges = addedEdges.filter(e => e.type === 'attacks').length;
+  const supportEdges = addedEdges.length - attackEdges;
+  const sColors: Record<string, string> = { decisive: 'var(--success)', substantial: 'var(--text-secondary)', tangential: 'var(--text-muted)' };
+  return (
+    <details open className="evid-details-mt">
+      <summary className="evid-summary">AN Delta</summary>
+      <div className="evid-delta-cards">
+        <div className="evid-delta-card">
+          <div className="evid-muted-2xs">Nodes Added</div>
+          <div className="evid-mono700">{extTrace.an_nodes_added_ids.length}</div>
+          {extTrace.an_nodes_added_ids.length > 0 && (
+            <div className="evid-nodes-added">
+              {extTrace.an_nodes_added_ids.join(', ')}
+            </div>
+          )}
+        </div>
+        <div className="evid-delta-card">
+          <div className="evid-muted-2xs">Edges Added</div>
+          <div className="evid-mono700">{addedEdges.length}</div>
+          <div className="evid-edges-sub">
+            <span className="evid-success">{supportEdges} support</span>{' / '}
+            <span className="evid-danger">{attackEdges} attack</span>
+          </div>
+        </div>
+        <div className="evid-delta-card">
+          <div className="evid-muted-2xs">Network Size</div>
+          <div className="evid-mono700">
+            {extTrace.an_node_count_before} → {extTrace.an_node_count_after}
+          </div>
+        </div>
+      </div>
+      {addedEdges.length > 0 && (
+        <div className="evid-edges-list">
+          {addedEdges.map((edge, ei) => (
+            <ANDeltaEdgeRow key={ei} edge={edge} an={an} sColors={sColors} />
+          ))}
+        </div>
+      )}
+    </details>
+  );
+}
+
 export interface EvidenceTabProps {
   entry: { id: string; type: string; content?: unknown; metadata?: unknown; taxonomy_refs?: unknown[]; policy_refs?: unknown[]; speaker: string };
   diag: EntryDiagnostics | undefined;
@@ -62,399 +511,15 @@ export function EvidenceTab({ entry, diag, an, searchQuery }: EvidenceTabProps) 
             : 'No evidence data available for this turn.'}
         </div>
       ) : (<>
-        {/* -- 1. Evidence Summary -- */}
-        {evidenceStage && (
-          <details open>
-            <summary className="evid-summary">Source Evidence Retrieved</summary>
-            <div className="evid-meta-row">
-              <span>{evidenceStage.model}</span>
-              <span>{(evidenceStage.response_time_ms / 1000).toFixed(1)}s</span>
-              {evidenceWP?.nodesCovered && <span>Nodes covered: {evidenceWP.nodesCovered.join(', ')}</span>}
-              {evidenceWP?.totalCandidates != null && <span>({evidenceWP.totalCandidates} candidates screened)</span>}
-            </div>
-            {evidenceStage.parse_error && (
-              <div className="evid-parse-error">
-                <strong>Parse error:</strong> {evidenceStage.parse_error}
-              </div>
-            )}
-            <div className="evid-cards-row">
-              {[
-                { label: 'Facts', value: String(evidenceWP?.facts?.length ?? 0) },
-                { label: 'Key Points', value: String(evidenceWP?.keyPoints?.length ?? 0) },
-                { label: 'Nodes Covered', value: String(evidenceWP?.nodesCovered?.length ?? 0) },
-                { label: 'Total Candidates', value: String(evidenceWP?.totalCandidates ?? 0) },
-                ...((evidenceWP as Record<string, unknown>)?.evidence_utilization ? [{
-                  label: 'Citation Rate',
-                  value: `${((evidenceWP as Record<string, unknown>).evidence_utilization as { utilization_rate: number }).utilization_rate}%`,
-                }] : []),
-              ].map(card => (
-                <div key={card.label} className="evid-card">
-                  <div className="evid-card-label">{card.label}</div>
-                  <div className="evid-card-value">{card.value}</div>
-                </div>
-              ))}
-            </div>
-          </details>
-        )}
-        {/* -- 2. Source Facts -- */}
-        {evidenceWP?.facts && evidenceWP.facts.length > 0 && (
-          <details open className="evid-details-mt">
-            <summary className="evid-summary">
-              Source Facts ({evidenceWP.facts.length})
-            </summary>
-            {evidenceWP.facts.map((fact, fi) => {
-              const specColor = fact.specificity === 'precise' ? 'var(--success)' : fact.specificity === 'qualified' ? 'var(--warning)' : 'var(--text-muted)';
-              return (
-                <div key={fi} className="evid-fact">
-                  <div className="evid-row-center-gap6">
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic specColor swatch */}
-                    <span style={{
-                      fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
-                      color: specColor, background: `${specColor}18`,
-                    }}>{fact.specificity?.toUpperCase() ?? 'FACT'}</span>
-                    <a
-                      href={`https://scholar.google.com/scholar?q=${encodeURIComponent(fact.doc_id.replace(/-/g, ' ').replace(/\d{4}$/, ''))}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="evid-doc-link"
-                      title={`Search for: ${fact.doc_id}`}
-                    >
-                      {fact.doc_id}
-                    </a>
-                    {fact.temporal_bound && (
-                      <span className="evid-temporal">{fact.temporal_bound}</span>
-                    )}
-                  </div>
-                  <div className="evid-claim">{fact.claim}</div>
-                  {fact.linked_taxonomy_nodes?.length > 0 && (
-                    <div className="evid-linked-nodes">
-                      {fact.linked_taxonomy_nodes.join(', ')}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </details>
-        )}
-        {/* -- 3. Key Points -- */}
-        {evidenceWP?.keyPoints && evidenceWP.keyPoints.length > 0 && (
-          <details open className="evid-details-mt">
-            <summary className="evid-summary">
-              Key Points ({evidenceWP.keyPoints.length})
-            </summary>
-            {evidenceWP.keyPoints.map((kp, ki) => {
-              const stanceColor = kp.stance === 'support' || kp.stance === 'agree' ? 'var(--success)'
-                : kp.stance === 'oppose' || kp.stance === 'disagree' ? 'var(--danger)' : 'var(--warning)';
-              return (
-                // eslint-disable-next-line local/no-inline-style -- dynamic stanceColor border
-                <div key={ki} style={{
-                  marginBottom: 6, padding: '6px 8px', borderRadius: 4,
-                  borderLeft: `3px solid ${stanceColor}`, background: 'var(--bg-subtle)',
-                }}>
-                  <div className="evid-row-center-gap6">
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic stanceColor swatch */}
-                    <span style={{
-                      fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
-                      color: stanceColor, background: `${stanceColor}18`,
-                    }}>{kp.stance?.toUpperCase() ?? 'POINT'}</span>
-                    <span className="evid-muted-2xs">{kp.pov}</span>
-                    <a
-                      href={`https://scholar.google.com/scholar?q=${encodeURIComponent(kp.doc_id.replace(/-/g, ' ').replace(/\d{4}$/, ''))}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="evid-doc-link"
-                      title={`Search for: ${kp.doc_id}`}
-                    >
-                      {kp.doc_id}
-                    </a>
-                  </div>
-                  <div className="evid-claim">{kp.point}</div>
-                  {kp.verbatim && (
-                    <div className="evid-verbatim">
-                      &ldquo;{kp.verbatim}&rdquo;
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </details>
-        )}
-        {/* -- 4. Raw Evidence Block -- */}
-        {evidenceStage && (
-          <details className="evid-details-mt">
-            <summary className="evid-summary-muted">
-              Raw Evidence Block <CopyButton text={evidenceStage.raw_response} />
-            </summary>
-            <pre className="evid-raw-pre">{evidenceStage.raw_response}</pre>
-          </details>
-        )}
-        {/* -- 5. Cited Evidence (what the debater actually referenced) -- */}
-        {(() => {
-          const eu = (evidenceWP as Record<string, unknown>)?.evidence_utilization as {
-            total_docs?: number; cited_docs?: Array<{ doc_id: string; title?: string; match_type: string }>; utilization_rate?: number;
-          } | undefined;
-          if (!eu?.cited_docs || eu.total_docs === 0) return null;
-          const matchColors: Record<string, string> = { exact_id: 'var(--success)', slug: 'var(--text-secondary)', title_exact: 'var(--text-secondary)', title_partial: 'var(--warning)', markdown_link: 'var(--success)' };
-          return (
-            <details open className="evid-details-mt">
-              <summary className="evid-summary">
-                Cited Evidence ({eu.cited_docs.length}/{eu.total_docs} sources, {eu.utilization_rate}%)
-              </summary>
-              {eu.cited_docs.length === 0 ? (
-                <div className="evid-empty-cite">
-                  Debater did not cite any source documents from the evidence brief.
-                </div>
-              ) : (
-                eu.cited_docs.map((cd, i) => (
-                  // eslint-disable-next-line local/no-inline-style -- dynamic matchColors border
-                  <div key={i} style={{ marginBottom: 4, padding: '4px 8px', borderRadius: 4, borderLeft: `3px solid ${matchColors[cd.match_type] ?? 'var(--text-muted)'}`, background: 'var(--bg-subtle)', fontSize: 'var(--text-2xs)' }}>
-                    <span className="evid-bold600">{cd.title ?? cd.doc_id}</span>
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic matchColors chip */}
-                    <span style={{ fontSize: 'var(--text-2xs)', marginLeft: 6, padding: '0 4px', borderRadius: 3, color: matchColors[cd.match_type] ?? 'var(--text-muted)', background: `color-mix(in srgb, ${matchColors[cd.match_type] ?? 'var(--text-muted)'} 10%, transparent)` }}>
-                      {cd.match_type.replace('_', ' ')}
-                    </span>
-                  </div>
-                ))
-              )}
-            </details>
-          );
-        })()}
-        {/* -- 6. Citation Pipeline (full chain per source) -- */}
-        {(() => {
-          const pipeline = (evidenceWP as Record<string, unknown>)?.citation_pipeline as Array<{
-            doc_id: string; resolved_title: string; resolved_url: string | null;
-            url_type: string; provenance_label: string | null;
-            cited: boolean; match_type: string | null; linkified: boolean;
-          }> | undefined;
-          if (!pipeline || pipeline.length === 0) return null;
-          const urlTypeColors: Record<string, string> = {
-            doi: 'var(--success)', arxiv: 'var(--success)', ssrn: 'var(--success)', direct: 'var(--text-secondary)',
-            scholar_fallback: 'var(--warning)', google_fallback: 'var(--warning)', none: 'var(--danger)',
-          };
-          return (
-            <details className="evid-details-mt">
-              <summary className="evid-summary">
-                Citation Pipeline ({pipeline.filter(p => p.cited).length}/{pipeline.length} cited, {pipeline.filter(p => p.linkified).length} linkified)
-              </summary>
-              <table className="evid-table">
-                <thead>
-                  <tr className="evid-thead-row">
-                    <th className="evid-th-left">Source</th>
-                    <th className="evid-th-left">Title</th>
-                    <th className="evid-th-center">URL Type</th>
-                    <th className="evid-th-center">Cited</th>
-                    <th className="evid-th-center">Match</th>
-                    <th className="evid-th-center">Linked</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {pipeline.map((p, pi) => (
-                    // eslint-disable-next-line local/no-inline-style -- dynamic cited-row highlight
-                    <tr key={pi} style={{
-                      borderBottom: '1px solid var(--border)',
-                      background: p.cited ? 'color-mix(in srgb, var(--success) 5%, transparent)' : 'transparent',
-                    }}>
-                      <td className="evid-td-source">
-                        {p.resolved_url ? (
-                          <a href={p.resolved_url} target="_blank" rel="noopener noreferrer"
-                            className="evid-cite-link" title={p.doc_id}>
-                            {p.doc_id.length > 25 ? p.doc_id.slice(0, 22) + '…' : p.doc_id}
-                          </a>
-                        ) : (
-                          <span title={p.doc_id}>{p.doc_id.length > 25 ? p.doc_id.slice(0, 22) + '…' : p.doc_id}</span>
-                        )}
-                      </td>
-                      <td className="evid-td-title"
-                        title={p.resolved_title}>
-                        {p.resolved_title !== p.doc_id ? p.resolved_title.slice(0, 35) : '—'}
-                      </td>
-                      <td className="evid-td-center">
-                        {/* eslint-disable-next-line local/no-inline-style -- dynamic urlTypeColors chip */}
-                        <span style={{
-                          fontSize: 'var(--text-2xs)', padding: '0 4px', borderRadius: 3, fontWeight: 600,
-                          color: urlTypeColors[p.url_type] ?? 'var(--text-muted)',
-                          background: `color-mix(in srgb, ${urlTypeColors[p.url_type] ?? 'var(--text-muted)'} 10%, transparent)`,
-                        }}>{p.url_type}</span>
-                      </td>
-                      <td className="evid-td-center">
-                        {p.cited ? '✓' : '—'}
-                      </td>
-                      <td className="evid-td-center">
-                        {p.match_type ? (
-                          <span className="evid-muted-2xs">
-                            {p.match_type.replace('_', ' ')}
-                          </span>
-                        ) : '—'}
-                      </td>
-                      <td className="evid-td-center">
-                        {p.linkified ? '🔗' : '—'}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {pipeline.some(p => p.provenance_label) && (
-                <div className="evid-provenance">
-                  Provenance: {pipeline.filter(p => p.provenance_label).map(p => `${p.doc_id} → ${p.provenance_label}`).join(', ')}
-                </div>
-              )}
-            </details>
-          );
-        })()}
-        {/* -- 7. Ungrounded Claims (from model knowledge, not corpus) -- */}
-        {(() => {
-          const uc = (evidenceWP as Record<string, unknown>)?.ungrounded_claims as
-            Array<{ claim: string; reason: string }> | undefined;
-          if (!uc || uc.length === 0) return null;
-          return (
-            <details className="evid-details-mt">
-              <summary className="evid-summary-secondary">
-                Ungrounded Claims ({uc.length})
-              </summary>
-              <div className="evid-ungrounded-note">
-                These factual assertions appear in the statement but don&apos;t match any source in the evidence block or corpus. They likely come from the model&apos;s training data.
-              </div>
-              {uc.map((c, ci) => (
-                <div key={ci} className="evid-ungrounded-item">
-                  <div>{c.claim}</div>
-                  <div className="evid-linked-nodes">{c.reason}</div>
-                </div>
-              ))}
-            </details>
-          );
-        })()}
-        {/* -- Extraction Funnel (post-turn) -- */}
-        {extTrace && extTrace.candidates_proposed > 0 && (
-          <details open className="evid-details-mt">
-            <summary className="evid-summary">Extraction Funnel</summary>
-            {(() => {
-              const max = extTrace.candidates_proposed;
-              const bars: [string, number, string][] = [
-                ['Candidates', extTrace.candidates_proposed, 'var(--text-secondary)'],
-                ['Accepted', extTrace.candidates_accepted, 'var(--success)'],
-                ['Rejected', extTrace.candidates_rejected, 'var(--danger)'],
-              ];
-              return (
-                <div className="evid-funnel-wrap">
-                  {bars.map(([label, count, color]) => (
-                    <div key={label} className="evid-funnel-row">
-                      <span className="evid-funnel-label">{label}</span>
-                      <div className="evid-funnel-track">
-                        {/* eslint-disable-next-line local/no-inline-style -- dynamic bar width/color */}
-                        <div style={{
-                          width: `${max > 0 ? Math.round(count / max * 100) : 0}%`,
-                          height: '100%', borderRadius: 3, background: color,
-                          minWidth: count > 0 ? 4 : 0,
-                        }} />
-                      </div>
-                      <span className="evid-funnel-count">{count}</span>
-                      <span className="evid-muted-2xs">
-                        {max > 0 ? `${Math.round(count / max * 100)}%` : ''}
-                      </span>
-                    </div>
-                  ))}
-                  {extTrace.rejection_reasons && Object.keys(extTrace.rejection_reasons).length > 0 && (
-                    <div className="evid-reasons-row">
-                      {Object.entries(extTrace.rejection_reasons).map(([reason, count]) => (
-                        <span key={reason} className="evid-reason-chip">{reason} ({count})</span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              );
-            })()}
-          </details>
-        )}
-        {/* -- AN Delta (post-turn) -- */}
-        {extTrace && (
-          <details open className="evid-details-mt">
-            <summary className="evid-summary">AN Delta</summary>
-            {(() => {
-              const addedEdges = an?.edges.filter(e =>
-                extTrace.an_nodes_added_ids.includes(e.source) || extTrace.an_nodes_added_ids.includes(e.target)
-              ) ?? [];
-              const attackEdges = addedEdges.filter(e => e.type === 'attacks').length;
-              const supportEdges = addedEdges.length - attackEdges;
-              const sColors: Record<string, string> = { decisive: 'var(--success)', substantial: 'var(--text-secondary)', tangential: 'var(--text-muted)' };
-              return (<>
-                <div className="evid-delta-cards">
-                  <div className="evid-delta-card">
-                    <div className="evid-muted-2xs">Nodes Added</div>
-                    <div className="evid-mono700">{extTrace.an_nodes_added_ids.length}</div>
-                    {extTrace.an_nodes_added_ids.length > 0 && (
-                      <div className="evid-nodes-added">
-                        {extTrace.an_nodes_added_ids.join(', ')}
-                      </div>
-                    )}
-                  </div>
-                  <div className="evid-delta-card">
-                    <div className="evid-muted-2xs">Edges Added</div>
-                    <div className="evid-mono700">{addedEdges.length}</div>
-                    <div className="evid-edges-sub">
-                      <span className="evid-success">{supportEdges} support</span>{' / '}
-                      <span className="evid-danger">{attackEdges} attack</span>
-                    </div>
-                  </div>
-                  <div className="evid-delta-card">
-                    <div className="evid-muted-2xs">Network Size</div>
-                    <div className="evid-mono700">
-                      {extTrace.an_node_count_before} → {extTrace.an_node_count_after}
-                    </div>
-                  </div>
-                </div>
-                {addedEdges.length > 0 && (
-                  <div className="evid-edges-list">
-                    {addedEdges.map((edge, ei) => {
-                      const sourceNode = an?.nodes.find(n => n.id === edge.source);
-                      const targetNode = an?.nodes.find(n => n.id === edge.target);
-                      const edgeColor = edge.type === 'attacks' ? 'var(--danger)' : 'var(--success)';
-                      const edgeLabel = edge.type === 'attacks'
-                        ? (edge.attack_type ? `attacks (${edge.attack_type})` : 'attacks')
-                        : 'supports';
-                      return (
-                        // eslint-disable-next-line local/no-inline-style -- dynamic edgeColor border
-                        <div key={ei} style={{ margin: '3px 0', paddingLeft: 10, borderLeft: `2px solid ${edgeColor}` }}>
-                          <div className="evid-edge-header">
-                            <span className="evid-edge-node">{edge.source}</span>
-                            {/* eslint-disable-next-line local/no-inline-style -- dynamic edgeColor label */}
-                            <span style={{ color: edgeColor, fontWeight: 600 }}>{edgeLabel}</span>
-                            <span className="evid-edge-node">{edge.target}</span>
-                            {edge.strength && (
-                              // eslint-disable-next-line local/no-inline-style -- dynamic sColors strength chip
-                              <span style={{ padding: '0 3px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, background: `color-mix(in srgb, ${sColors[edge.strength] ?? 'var(--text-muted)'} 10%, transparent)`, color: sColors[edge.strength] ?? 'var(--text-muted)' }}>
-                                {edge.strength}
-                              </span>
-                            )}
-                            {edge.argumentation_scheme && (
-                              <span className="evid-scheme-chip">
-                                {edge.argumentation_scheme}
-                              </span>
-                            )}
-                          </div>
-                          {(sourceNode || targetNode) && (
-                            <div className="evid-edge-text">
-                              {sourceNode && <span title={sourceNode.attribution_text_genus || undefined}>{sourceNode.text.length > 60 ? sourceNode.text.slice(0, 60) + '…' : sourceNode.text}</span>}
-                              {sourceNode && targetNode && <span> → </span>}
-                              {targetNode && <span title={targetNode.attribution_text_genus || undefined}>{targetNode.text.length > 60 ? targetNode.text.slice(0, 60) + '…' : targetNode.text}</span>}
-                            </div>
-                          )}
-                          {edge.warrant && (
-                            <details className="evid-mt2">
-                              <summary className="evid-summary-muted">Warrant</summary>
-                              <div className="evid-warrant">
-                                {edge.warrant}
-                              </div>
-                            </details>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </>);
-            })()}
-          </details>
-        )}
+        <EvidenceSummarySection evidenceStage={evidenceStage} evidenceWP={evidenceWP} />
+        <SourceFactsSection evidenceWP={evidenceWP} />
+        <KeyPointsSection evidenceWP={evidenceWP} />
+        <RawEvidenceSection evidenceStage={evidenceStage} />
+        <CitedEvidenceSection evidenceWP={evidenceWP} />
+        <CitationPipelineSection evidenceWP={evidenceWP} />
+        <UngroundedClaimsSection evidenceWP={evidenceWP} />
+        <ExtractionFunnelSection extTrace={extTrace} />
+        <ANDeltaSection extTrace={extTrace} an={an} />
       </>)}
     </div>
   );

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
@@ -115,6 +115,350 @@ function deriveStrength(edge: { strength?: string; weight?: number }): string {
   return 'tangential';
 }
 
+function truncateText(t: string, n: number): string {
+  return t.length > n ? t.slice(0, n) + '…' : t;
+}
+
+/** Strongest attacker of a node by contribution (source strength × weight × attack-type multiplier). */
+function strongestAttacker(attacks: ArgumentNetworkEdge[], strengthMap: Map<string, number> | undefined, allNodes: ArgumentNetworkNode[]): { text: string; contribution: number } | null {
+  let strongestAtk: { text: string; contribution: number } | null = null;
+  for (const a of attacks) {
+    const src = strengthMap?.get(a.source);
+    if (src == null) continue;
+    const w = a.weight ?? 0.5;
+    const mult = ATTACK_TYPE_WEIGHTS[a.attack_type ?? 'rebut'] ?? 1.0;
+    const contrib = src * w * mult;
+    if (!strongestAtk || contrib > strongestAtk.contribution) {
+      const srcNode = allNodes.find(n => n.id === a.source);
+      strongestAtk = { text: srcNode ? truncateText(srcNode.text, 60) : a.source, contribution: contrib };
+    }
+  }
+  return strongestAtk;
+}
+
+/** Strongest supporter of a node by contribution (source strength × weight). */
+function strongestSupporter(supports: ArgumentNetworkEdge[], strengthMap: Map<string, number> | undefined, allNodes: ArgumentNetworkNode[]): { text: string; contribution: number } | null {
+  let strongestSup: { text: string; contribution: number } | null = null;
+  for (const s of supports) {
+    const src = strengthMap?.get(s.source);
+    if (src == null) continue;
+    const w = s.weight ?? 0.5;
+    const contrib = src * w;
+    if (!strongestSup || contrib > strongestSup.contribution) {
+      const srcNode = allNodes.find(n => n.id === s.source);
+      strongestSup = { text: srcNode ? truncateText(srcNode.text, 60) : s.source, contribution: contrib };
+    }
+  }
+  return strongestSup;
+}
+
+/** Col 1: Argument-network node id + originating statement id. */
+function IdStatementCell({ node, statementId, searchQuery, onGotoEntry }: {
+  node: ArgumentNetworkNode;
+  statementId?: string;
+  searchQuery?: string;
+  onGotoEntry?: (entryId: string) => void;
+}) {
+  return (
+    <span className="inr-flex-center-g2">
+      <strong title={`Argument Network node ${node.id.replace('AN-', '')}${statementId ? `, extracted from debate statement ${statementId}` : ''}`} className="inr-accent"><Highlight text={node.id} query={searchQuery} /></strong>
+      {statementId && (
+        <span
+          title={`Claim extracted from debate turn ${statementId} by ${speakerLabel(node.speaker)}${onGotoEntry ? ' — click to go to statement' : ''}`}
+          onClick={onGotoEntry && node.source_entry_id ? (e) => { e.stopPropagation(); onGotoEntry(node.source_entry_id); } : undefined}
+          // eslint-disable-next-line local/no-inline-style -- clickability-driven cursor/textDecoration
+          style={{
+            cursor: onGotoEntry && node.source_entry_id ? 'pointer' : 'default',
+            textDecoration: onGotoEntry && node.source_entry_id ? 'underline' : 'none',
+          }}
+        >{statementId}</span>
+      )}
+    </span>
+  );
+}
+
+/** Col 2: Speaker label with descriptive tooltip. */
+function SpeakerCell({ node }: { node: ArgumentNetworkNode }) {
+  const label = speakerLabel(node.speaker);
+  const desc: Record<string, string> = {
+    Accelerationist: 'Accelerationist — advocates rapid AI development',
+    Safetyist: 'Safetyist — prioritizes AI safety and alignment',
+    Skeptic: 'Skeptic — questions assumptions from all sides',
+    Moderator: 'Moderator — neutral facilitator',
+  };
+  return <span title={desc[label] ?? label}>{label}</span>;
+}
+
+/** Col 3: BDI category badge. */
+function BdiCategoryCell({ node }: { node: ArgumentNetworkNode }) {
+  if (!node.bdi_category) return null;
+  const bdiLabel = node.bdi_category === 'belief' ? 'Belief' : node.bdi_category === 'desire' ? 'Desire' : 'Intention';
+  return <span title={`${bdiLabel} (confidence: ${node.bdi_confidence?.toFixed(2) ?? '?'})`}>{bdiLabel}</span>;
+}
+
+/** Col 4: Taxonomy attribution badge (attributed ref or unattributed reason). */
+function TaxonomyAttributionCell({ node, nodeLabels }: { node: ArgumentNetworkNode; nodeLabels?: Map<string, string> }) {
+  const attr = node.claim_taxonomy_attribution;
+  if (!attr) return null;
+  if (attr.unattributed_reason) {
+    const reasonLabel = attr.unattributed_reason === 'novel_argument' ? 'novel' : 'no embedding';
+    return (
+      <span
+        title={`Unattributed: ${attr.unattributed_reason === 'novel_argument' ? 'claim is a novel argument not closely matching any taxonomy Belief node (best similarity < 0.35)' : 'missing embedding — cannot compute similarity'}`}
+        className="inr-attr-badge"
+      ><span className="inr-attr-dot-danger">●</span>{reasonLabel}</span>
+    );
+  }
+  const conf = attr.attribution_confidence;
+  const confColor = conf >= 0.7 ? 'var(--success)' : conf >= 0.5 ? 'var(--text-muted)' : 'var(--warning)';
+  const secCount = attr.secondary_refs?.length ?? 0;
+  const primaryLabel = nodeLabels?.get(attr.primary_ref);
+  const primaryTitle = primaryLabel ? `${primaryLabel} (${attr.primary_ref})` : attr.primary_ref;
+  return (
+    <span
+      title={`Attributed to ${primaryTitle} (confidence: ${conf.toFixed(2)})${secCount > 0 ? `\n${secCount} secondary ref${secCount !== 1 ? 's' : ''}: ${attr.secondary_refs!.map(s => { const l = nodeLabels?.get(s.node_id); return `${l ? `${l} (${s.node_id})` : s.node_id} (${s.similarity.toFixed(2)})`; }).join(', ')}` : ''}`}
+      className="inr-attr-badge"
+    >
+      {/* eslint-disable-next-line local/no-inline-style -- confidence-driven dot color */}
+      <span style={{ color: confColor, fontSize: '0.9rem', marginRight: 3 }}>●</span>{attr.primary_ref} {conf.toFixed(2)}</span>
+  );
+}
+
+/** Col 5: Strength score badge (computed vs base). */
+function StrengthBadgeCell({ node, computedStrength }: { node: ArgumentNetworkNode; computedStrength?: number }) {
+  const base = node.base_strength ?? 0.5;
+  const computed = computedStrength ?? node.computed_strength ?? base;
+  const delta = computed - base;
+  return (
+    <ScoreBadge
+      value={computed}
+      label="strength"
+      tooltip={`Strength: ${computed.toFixed(2)} (base: ${base.toFixed(2)}, delta: ${delta >= 0 ? '+' : ''}${delta.toFixed(2)})`}
+    />
+  );
+}
+
+/** Col 6: Attack/support edge count. */
+function EdgeCountCell({ attacks, supports, hasChildren }: { attacks: ArgumentNetworkEdge[]; supports: ArgumentNetworkEdge[]; hasChildren: boolean }) {
+  return (
+    <span className="inr-edgecount" title={hasChildren ? `${attacks.length + supports.length} attack/support relationship${attacks.length + supports.length !== 1 ? 's' : ''} connected to this claim` : undefined}>
+      {hasChildren ? `${attacks.length + supports.length} edge${attacks.length + supports.length !== 1 ? 's' : ''}` : ''}
+    </span>
+  );
+}
+
+/** NL strength explanation (B2) — rendered only when expanded with at least one edge. */
+function StrengthExplanation({ node, attacks, supports, allNodes, strengthMap, computedStrength, expanded }: {
+  node: ArgumentNetworkNode;
+  attacks: ArgumentNetworkEdge[];
+  supports: ArgumentNetworkEdge[];
+  allNodes: ArgumentNetworkNode[];
+  strengthMap?: Map<string, number>;
+  computedStrength?: number;
+  expanded: boolean;
+}) {
+  if (!expanded) return null;
+  if (!(attacks.length > 0 || supports.length > 0)) return null;
+  const base = node.base_strength ?? 0.5;
+  const computed = computedStrength ?? node.computed_strength ?? base;
+  const band = computed >= 0.8 ? 'accepted' : computed >= 0.5 ? 'moderate' : computed >= 0.3 ? 'weak' : 'rejected';
+  const strongestAtk = strongestAttacker(attacks, strengthMap, allNodes);
+  const strongestSup = strongestSupporter(supports, strengthMap, allNodes);
+  // Build explanation
+  let explanation = `${band} (${computed.toFixed(2)})`;
+  if (strongestSup && strongestAtk) {
+    explanation += ` because "${strongestSup.text}" (+${strongestSup.contribution.toFixed(2)}) even though "${strongestAtk.text}" (−${strongestAtk.contribution.toFixed(2)})`;
+  } else if (strongestSup) {
+    explanation += ` because "${strongestSup.text}" (+${strongestSup.contribution.toFixed(2)})`;
+  } else if (strongestAtk) {
+    explanation += ` despite "${strongestAtk.text}" (−${strongestAtk.contribution.toFixed(2)})`;
+  }
+  return (
+    <div className="inr-explanation">
+      {explanation}
+    </div>
+  );
+}
+
+/** Strength-band pill for an edge. */
+function StrengthBandBadge({ edge }: { edge: { strength?: string; weight?: number } }) {
+  const s = deriveStrength(edge);
+  const st = STRENGTH_STYLES[s] ?? STRENGTH_STYLES.substantial;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- strength-band-driven background/color
+    <span style={{ padding: '1px 5px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, background: st.bg, color: st.color }}>{st.label}</span>
+  );
+}
+
+/** Attack contribution figure with breakdown tooltip. */
+function AttackContribution({ contribution, srcStr, edgeWeight, hasWeight, atkMult, attackType }: {
+  contribution?: number;
+  srcStr?: number;
+  edgeWeight: number;
+  hasWeight: boolean;
+  atkMult: number;
+  attackType?: string;
+}) {
+  if (contribution == null) return <span />;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- weight-presence-driven opacity
+    <span title={`Attack contribution = (source strength (${(srcStr ?? 0).toFixed(2)}) × edge weight (${edgeWeight.toFixed(1)}${hasWeight ? '' : ' — default, no AI weight'})) × attack type multiplier (${attackType}: ${atkMult.toFixed(1)}).\nRebut=1.0, Undercut=1.1 (denies inference), Undermine=1.2 (attacks premise).`} style={{ color: 'var(--danger)', cursor: 'default', opacity: hasWeight ? 1 : 0.5 }}>
+      −{contribution.toFixed(2)} <span className="inr-text-muted">({(srcStr ?? 0).toFixed(2)}×{edgeWeight.toFixed(1)}{hasWeight ? '' : '?'}×{atkMult.toFixed(1)})</span>
+    </span>
+  );
+}
+
+/** Support contribution figure with breakdown tooltip. */
+function SupportContribution({ contributionS, srcStrS, edgeWeightS, hasWeightS }: {
+  contributionS?: number;
+  srcStrS?: number;
+  edgeWeightS: number;
+  hasWeightS: boolean;
+}) {
+  if (contributionS == null) return <span />;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- weight-presence-driven opacity
+    <span title={`Support contribution = source strength (${(srcStrS ?? 0).toFixed(2)}) × edge weight (${edgeWeightS.toFixed(1)}${hasWeightS ? '' : ' — default, no AI weight'}). No type multiplier for supports — all support relationships are weighted equally.`} style={{ color: 'var(--success)', cursor: 'default', opacity: hasWeightS ? 1 : 0.5 }}>
+      +{contributionS.toFixed(2)} <span className="inr-text-muted">({(srcStrS ?? 0).toFixed(2)}×{edgeWeightS.toFixed(1)}{hasWeightS ? '' : '?'})</span>
+    </span>
+  );
+}
+
+/** Inline "go to statement" button for an edge source, or an empty placeholder. */
+function EdgeGotoButton({ onGotoEntry, sourceNode, stmtIdByEntry, className }: {
+  onGotoEntry?: (entryId: string) => void;
+  sourceNode?: ArgumentNetworkNode;
+  stmtIdByEntry?: Map<string, string>;
+  className: string;
+}) {
+  if (!(onGotoEntry && sourceNode?.source_entry_id)) return <span />;
+  return (
+    <button
+      onClick={(ev) => { ev.stopPropagation(); onGotoEntry(sourceNode.source_entry_id); }}
+      title={`Go to ${stmtIdByEntry?.get(sourceNode.source_entry_id) || sourceNode.source_entry_id}`}
+      className={className}
+    >{stmtIdByEntry?.get(sourceNode.source_entry_id) || 'goto'}</button>
+  );
+}
+
+/** Expanded debater block for an edge source (speaker, goto, source text). */
+function DebaterBlock({ expanded, sourceNode, onGotoEntry, stmtIdByEntry, searchQuery, gotoClassName }: {
+  expanded: boolean;
+  sourceNode?: ArgumentNetworkNode;
+  onGotoEntry?: (entryId: string) => void;
+  stmtIdByEntry?: Map<string, string>;
+  searchQuery?: string;
+  gotoClassName: string;
+}) {
+  if (!(expanded && sourceNode)) return null;
+  return (
+    <div className="inr-debater-block">
+      <span className="inr-text-muted">Debater:</span> <strong>{speakerLabel(sourceNode.speaker)}</strong>
+      {onGotoEntry && sourceNode.source_entry_id && (
+        <button
+          onClick={() => onGotoEntry(sourceNode.source_entry_id)}
+          title={`Go to ${stmtIdByEntry?.get(sourceNode.source_entry_id) || sourceNode.source_entry_id}`}
+          className={gotoClassName}
+        >{stmtIdByEntry?.get(sourceNode.source_entry_id) || 'goto'}</button>
+      )}
+      <div className="inr-mt2"><Highlight text={sourceNode.text} query={searchQuery} /></div>
+    </div>
+  );
+}
+
+/** A single attack edge row. */
+function AttackEdgeRow({ a, allNodes, strengthMap, onGotoEntry, stmtIdByEntry, expanded, searchQuery }: {
+  a: ArgumentNetworkEdge;
+  allNodes: ArgumentNetworkNode[];
+  strengthMap?: Map<string, number>;
+  onGotoEntry?: (entryId: string) => void;
+  stmtIdByEntry?: Map<string, string>;
+  expanded: boolean;
+  searchQuery?: string;
+}) {
+  const sourceNode = allNodes.find(n => n.id === a.source);
+  const srcStr = strengthMap?.get(a.source);
+  const atkMult = ATTACK_TYPE_WEIGHTS[a.attack_type ?? 'rebut'] ?? 1.0;
+  const hasWeight = a.weight != null;
+  const edgeWeight = a.weight ?? 0.5;
+  const contribution = srcStr != null ? srcStr * edgeWeight * atkMult : undefined;
+  return (
+    <div className="inr-atk-edge">
+      <div className="diag-edge-row inr-edge-grid">
+        <span className="inr-ca-node">CA-node</span>
+        <span>← {a.source}</span>
+        <strong>{a.attack_type}</strong>
+        <StrengthBandBadge edge={a} />
+        <span className="inr-text-muted">{a.scheme ? `via ${a.scheme}` : ''}</span>
+        <AttackContribution contribution={contribution} srcStr={srcStr} edgeWeight={edgeWeight} hasWeight={hasWeight} atkMult={atkMult} attackType={a.attack_type} />
+        <EdgeGotoButton onGotoEntry={onGotoEntry} sourceNode={sourceNode} stmtIdByEntry={stmtIdByEntry} className="inr-goto-btn-danger" />
+      </div>
+      {a.warrant && <div className="inr-warrant">Warrant: <Highlight text={a.warrant} query={searchQuery} /></div>}
+      <DebaterBlock expanded={expanded} sourceNode={sourceNode} onGotoEntry={onGotoEntry} stmtIdByEntry={stmtIdByEntry} searchQuery={searchQuery} gotoClassName="inr-goto-btn-acc" />
+    </div>
+  );
+}
+
+/** A single support edge row. */
+function SupportEdgeRow({ s, allNodes, strengthMap, onGotoEntry, stmtIdByEntry, expanded, searchQuery }: {
+  s: ArgumentNetworkEdge;
+  allNodes: ArgumentNetworkNode[];
+  strengthMap?: Map<string, number>;
+  onGotoEntry?: (entryId: string) => void;
+  stmtIdByEntry?: Map<string, string>;
+  expanded: boolean;
+  searchQuery?: string;
+}) {
+  const sourceNode = allNodes.find(n => n.id === s.source);
+  const srcStrS = strengthMap?.get(s.source);
+  const hasWeightS = s.weight != null;
+  const edgeWeightS = s.weight ?? 0.5;
+  const contributionS = srcStrS != null ? srcStrS * edgeWeightS : undefined;
+  return (
+    <div className="inr-sup-edge">
+      <div className="diag-edge-row inr-edge-grid">
+        <span className="inr-ra-node">RA-node</span>
+        <span>← {s.source}</span>
+        <strong>supports</strong>
+        <StrengthBandBadge edge={s} />
+        <span className="inr-text-muted">{s.scheme ? `via ${s.scheme}` : ''}</span>
+        <SupportContribution contributionS={contributionS} srcStrS={srcStrS} edgeWeightS={edgeWeightS} hasWeightS={hasWeightS} />
+        <EdgeGotoButton onGotoEntry={onGotoEntry} sourceNode={sourceNode} stmtIdByEntry={stmtIdByEntry} className="inr-goto-btn-success" />
+      </div>
+      {s.warrant && <div className="inr-warrant">Warrant: {s.warrant}</div>}
+      <DebaterBlock expanded={expanded} sourceNode={sourceNode} onGotoEntry={onGotoEntry} stmtIdByEntry={stmtIdByEntry} searchQuery={searchQuery} gotoClassName="inr-goto-btn-success-ml" />
+    </div>
+  );
+}
+
+/** Leave-one-out QBAF attribution list. */
+function LooAttribution({ attribution }: { attribution: ReturnType<typeof explainNodeStrength> | null }) {
+  if (!attribution || attribution.attributions.length === 0) return null;
+  return (
+    <div className="inr-loo-container">
+      <div className="inr-loo-heading">QBAF Attribution (leave-one-out)</div>
+      <div className="inr-loo-summary">{attribution.summary}</div>
+      {attribution.attributions.slice(0, 6).map((a, i) => (
+        <div key={i} className="inr-loo-row">
+          {/* eslint-disable-next-line local/no-inline-style -- influence-sign-driven color */}
+          <span style={{ color: a.influence >= 0 ? 'var(--success)' : 'var(--danger)', textAlign: 'right' }}>
+            {a.influence >= 0 ? '+' : ''}{a.influence.toFixed(3)}
+          </span>
+          {/* eslint-disable-next-line local/no-inline-style -- edge-type-driven color */}
+          <span style={{ color: a.edgeType === 'attacks' ? 'var(--danger)' : 'var(--success)' }}>
+            {a.edgeType}{a.attackType ? ` (${a.attackType})` : ''}
+          </span>
+          <span className="inr-text-muted">from {a.sourceId}</span>
+          <span className="inr-text-muted-italic">{a.scheme ? `via ${a.scheme}` : ''}</span>
+        </div>
+      ))}
+      {attribution.attributions.length > 6 && (
+        <div className="inr-loo-more">...and {attribution.attributions.length - 6} more</div>
+      )}
+    </div>
+  );
+}
+
 /** Expandable I-node row — collapsed by default showing ID, speaker, strength. Expand reveals claim text, edges, sub-scores. */
 export function INodeRow({ node, attacks, supports, allNodes, allEdges, isSource, computedStrength, statementId, strengthMap, onGotoEntry, stmtIdByEntry, focused, onUpdateSubScore, searchQuery, nodeLabels, defaultExpanded = false }: {
   node: ArgumentNetworkNode;
@@ -167,259 +511,40 @@ export function INodeRow({ node, attacks, supports, allNodes, allEdges, isSource
         </button>
         <div className="diag-claim-row inr-claim-grid">
           {/* Col 1: AN ID + Statement ID */}
-          <span className="inr-flex-center-g2">
-            <strong title={`Argument Network node ${node.id.replace('AN-', '')}${statementId ? `, extracted from debate statement ${statementId}` : ''}`} className="inr-accent"><Highlight text={node.id} query={searchQuery} /></strong>
-            {statementId && (
-              <span
-                title={`Claim extracted from debate turn ${statementId} by ${speakerLabel(node.speaker)}${onGotoEntry ? ' — click to go to statement' : ''}`}
-                onClick={onGotoEntry && node.source_entry_id ? (e) => { e.stopPropagation(); onGotoEntry(node.source_entry_id); } : undefined}
-                // eslint-disable-next-line local/no-inline-style -- clickability-driven cursor/textDecoration
-                style={{
-                  cursor: onGotoEntry && node.source_entry_id ? 'pointer' : 'default',
-                  textDecoration: onGotoEntry && node.source_entry_id ? 'underline' : 'none',
-                }}
-              >{statementId}</span>
-            )}
-          </span>
+          <IdStatementCell node={node} statementId={statementId} searchQuery={searchQuery} onGotoEntry={onGotoEntry} />
           {/* Col 2: Speaker */}
-          {(() => {
-            const label = speakerLabel(node.speaker);
-            const desc: Record<string, string> = {
-              Accelerationist: 'Accelerationist — advocates rapid AI development',
-              Safetyist: 'Safetyist — prioritizes AI safety and alignment',
-              Skeptic: 'Skeptic — questions assumptions from all sides',
-              Moderator: 'Moderator — neutral facilitator',
-            };
-            return <span title={desc[label] ?? label}>{label}</span>;
-          })()}
+          <SpeakerCell node={node} />
           {/* Col 3: BDI category + status */}
           <span>
-            {node.bdi_category && (() => {
-              const bdiLabel = node.bdi_category === 'belief' ? 'Belief' : node.bdi_category === 'desire' ? 'Desire' : 'Intention';
-              return <span title={`${bdiLabel} (confidence: ${node.bdi_confidence?.toFixed(2) ?? '?'})`}>{bdiLabel}</span>;
-            })()}
+            <BdiCategoryCell node={node} />
           </span>
           {/* Col 4: Taxonomy attribution badge */}
           <span>
-            {node.claim_taxonomy_attribution && (() => {
-              const attr = node.claim_taxonomy_attribution;
-              if (attr.unattributed_reason) {
-                const reasonLabel = attr.unattributed_reason === 'novel_argument' ? 'novel' : 'no embedding';
-                return (
-                  <span
-                    title={`Unattributed: ${attr.unattributed_reason === 'novel_argument' ? 'claim is a novel argument not closely matching any taxonomy Belief node (best similarity < 0.35)' : 'missing embedding — cannot compute similarity'}`}
-                    className="inr-attr-badge"
-                  ><span className="inr-attr-dot-danger">●</span>{reasonLabel}</span>
-                );
-              }
-              const conf = attr.attribution_confidence;
-              const confColor = conf >= 0.7 ? 'var(--success)' : conf >= 0.5 ? 'var(--text-muted)' : 'var(--warning)';
-              const secCount = attr.secondary_refs?.length ?? 0;
-              const primaryLabel = nodeLabels?.get(attr.primary_ref);
-              const primaryTitle = primaryLabel ? `${primaryLabel} (${attr.primary_ref})` : attr.primary_ref;
-              return (
-                <span
-                  title={`Attributed to ${primaryTitle} (confidence: ${conf.toFixed(2)})${secCount > 0 ? `\n${secCount} secondary ref${secCount !== 1 ? 's' : ''}: ${attr.secondary_refs!.map(s => { const l = nodeLabels?.get(s.node_id); return `${l ? `${l} (${s.node_id})` : s.node_id} (${s.similarity.toFixed(2)})`; }).join(', ')}` : ''}`}
-                  className="inr-attr-badge"
-                >
-                  {/* eslint-disable-next-line local/no-inline-style -- confidence-driven dot color */}
-                  <span style={{ color: confColor, fontSize: '0.9rem', marginRight: 3 }}>●</span>{attr.primary_ref} {conf.toFixed(2)}</span>
-              );
-            })()}
+            <TaxonomyAttributionCell node={node} nodeLabels={nodeLabels} />
           </span>
           {/* Col 5: Strength badge */}
-          {(() => {
-            const base = node.base_strength ?? 0.5;
-            const computed = computedStrength ?? node.computed_strength ?? base;
-            const delta = computed - base;
-            return (
-              <ScoreBadge
-                value={computed}
-                label="strength"
-                tooltip={`Strength: ${computed.toFixed(2)} (base: ${base.toFixed(2)}, delta: ${delta >= 0 ? '+' : ''}${delta.toFixed(2)})`}
-              />
-            );
-          })()}
+          <StrengthBadgeCell node={node} computedStrength={computedStrength} />
           {/* Col 6: Edge count */}
-          <span className="inr-edgecount" title={hasChildren ? `${attacks.length + supports.length} attack/support relationship${attacks.length + supports.length !== 1 ? 's' : ''} connected to this claim` : undefined}>
-            {hasChildren ? `${attacks.length + supports.length} edge${attacks.length + supports.length !== 1 ? 's' : ''}` : ''}
-          </span>
+          <EdgeCountCell attacks={attacks} supports={supports} hasChildren={hasChildren} />
         </div>
       </div>
       <div className="inr-claim-text"><Highlight text={node.text} query={searchQuery} /></div>
       {expanded && node.attribution_text_genus && <div className="claim-attribution-text inr-pl18"><span className="claim-attribution-label">Attribution:</span>{node.attribution_text_genus}</div>}
       {/* NL strength explanation (B2) */}
-      {expanded && (attacks.length > 0 || supports.length > 0) && (() => {
-        const base = node.base_strength ?? 0.5;
-        const computed = computedStrength ?? node.computed_strength ?? base;
-        const band = computed >= 0.8 ? 'accepted' : computed >= 0.5 ? 'moderate' : computed >= 0.3 ? 'weak' : 'rejected';
-        const truncate = (t: string, n: number) => t.length > n ? t.slice(0, n) + '…' : t;
-        // Find strongest attacker by contribution
-        let strongestAtk: { text: string; contribution: number } | null = null;
-        for (const a of attacks) {
-          const src = strengthMap?.get(a.source);
-          if (src == null) continue;
-          const w = a.weight ?? 0.5;
-          const mult = ATTACK_TYPE_WEIGHTS[a.attack_type ?? 'rebut'] ?? 1.0;
-          const contrib = src * w * mult;
-          if (!strongestAtk || contrib > strongestAtk.contribution) {
-            const srcNode = allNodes.find(n => n.id === a.source);
-            strongestAtk = { text: srcNode ? truncate(srcNode.text, 60) : a.source, contribution: contrib };
-          }
-        }
-        // Find strongest supporter by contribution
-        let strongestSup: { text: string; contribution: number } | null = null;
-        for (const s of supports) {
-          const src = strengthMap?.get(s.source);
-          if (src == null) continue;
-          const w = s.weight ?? 0.5;
-          const contrib = src * w;
-          if (!strongestSup || contrib > strongestSup.contribution) {
-            const srcNode = allNodes.find(n => n.id === s.source);
-            strongestSup = { text: srcNode ? truncate(srcNode.text, 60) : s.source, contribution: contrib };
-          }
-        }
-        // Build explanation
-        let explanation = `${band} (${computed.toFixed(2)})`;
-        if (strongestSup && strongestAtk) {
-          explanation += ` because "${strongestSup.text}" (+${strongestSup.contribution.toFixed(2)}) even though "${strongestAtk.text}" (−${strongestAtk.contribution.toFixed(2)})`;
-        } else if (strongestSup) {
-          explanation += ` because "${strongestSup.text}" (+${strongestSup.contribution.toFixed(2)})`;
-        } else if (strongestAtk) {
-          explanation += ` despite "${strongestAtk.text}" (−${strongestAtk.contribution.toFixed(2)})`;
-        }
-        return (
-          <div className="inr-explanation">
-            {explanation}
-          </div>
-        );
-      })()}
+      <StrengthExplanation node={node} attacks={attacks} supports={supports} allNodes={allNodes} strengthMap={strengthMap} computedStrength={computedStrength} expanded={expanded} />
       {expanded && node.bdi_sub_scores && <SubScoreRow node={node} onUpdateSubScore={onUpdateSubScore} />}
 
       {/* Edges — shown when expanded */}
       {hasChildren && expanded && (
         <div className="inr-edges-container">
-          {attacks.map(a => {
-            const sourceNode = allNodes.find(n => n.id === a.source);
-            const srcStr = strengthMap?.get(a.source);
-            const atkMult = ATTACK_TYPE_WEIGHTS[a.attack_type ?? 'rebut'] ?? 1.0;
-            const hasWeight = a.weight != null;
-            const edgeWeight = a.weight ?? 0.5;
-            const contribution = srcStr != null ? srcStr * edgeWeight * atkMult : undefined;
-            return (
-              <div key={a.id} className="inr-atk-edge">
-                <div className="diag-edge-row inr-edge-grid">
-                  <span className="inr-ca-node">CA-node</span>
-                  <span>← {a.source}</span>
-                  <strong>{a.attack_type}</strong>
-                  {(() => { const s = deriveStrength(a); const st = STRENGTH_STYLES[s] ?? STRENGTH_STYLES.substantial; return (
-                    // eslint-disable-next-line local/no-inline-style -- strength-band-driven background/color
-                    <span style={{ padding: '1px 5px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, background: st.bg, color: st.color }}>{st.label}</span>
-                  ); })()}
-                  <span className="inr-text-muted">{a.scheme ? `via ${a.scheme}` : ''}</span>
-                  {contribution != null ? (
-                    // eslint-disable-next-line local/no-inline-style -- weight-presence-driven opacity
-                    <span title={`Attack contribution = (source strength (${(srcStr ?? 0).toFixed(2)}) × edge weight (${edgeWeight.toFixed(1)}${hasWeight ? '' : ' — default, no AI weight'})) × attack type multiplier (${a.attack_type}: ${atkMult.toFixed(1)}).\nRebut=1.0, Undercut=1.1 (denies inference), Undermine=1.2 (attacks premise).`} style={{ color: 'var(--danger)', cursor: 'default', opacity: hasWeight ? 1 : 0.5 }}>
-                      −{contribution.toFixed(2)} <span className="inr-text-muted">({(srcStr ?? 0).toFixed(2)}×{edgeWeight.toFixed(1)}{hasWeight ? '' : '?'}×{atkMult.toFixed(1)})</span>
-                    </span>
-                  ) : <span />}
-                  {onGotoEntry && sourceNode?.source_entry_id ? (
-                    <button
-                      onClick={(ev) => { ev.stopPropagation(); onGotoEntry(sourceNode.source_entry_id); }}
-                      title={`Go to ${stmtIdByEntry?.get(sourceNode.source_entry_id) || sourceNode.source_entry_id}`}
-                      className="inr-goto-btn-danger"
-                    >{stmtIdByEntry?.get(sourceNode.source_entry_id) || 'goto'}</button>
-                  ) : <span />}
-                </div>
-                {a.warrant && <div className="inr-warrant">Warrant: <Highlight text={a.warrant} query={searchQuery} /></div>}
-                {expanded && sourceNode && (
-                  <div className="inr-debater-block">
-                    <span className="inr-text-muted">Debater:</span> <strong>{speakerLabel(sourceNode.speaker)}</strong>
-                    {onGotoEntry && sourceNode.source_entry_id && (
-                      <button
-                        onClick={() => onGotoEntry(sourceNode.source_entry_id)}
-                        title={`Go to ${stmtIdByEntry?.get(sourceNode.source_entry_id) || sourceNode.source_entry_id}`}
-                        className="inr-goto-btn-acc"
-                      >{stmtIdByEntry?.get(sourceNode.source_entry_id) || 'goto'}</button>
-                    )}
-                    <div className="inr-mt2"><Highlight text={sourceNode.text} query={searchQuery} /></div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-          {supports.map(s => {
-            const sourceNode = allNodes.find(n => n.id === s.source);
-            const srcStrS = strengthMap?.get(s.source);
-            const hasWeightS = s.weight != null;
-            const edgeWeightS = s.weight ?? 0.5;
-            const contributionS = srcStrS != null ? srcStrS * edgeWeightS : undefined;
-            return (
-              <div key={s.id} className="inr-sup-edge">
-                <div className="diag-edge-row inr-edge-grid">
-                  <span className="inr-ra-node">RA-node</span>
-                  <span>← {s.source}</span>
-                  <strong>supports</strong>
-                  {(() => { const str = deriveStrength(s); const st = STRENGTH_STYLES[str] ?? STRENGTH_STYLES.substantial; return (
-                    // eslint-disable-next-line local/no-inline-style -- strength-band-driven background/color
-                    <span style={{ padding: '1px 5px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600, background: st.bg, color: st.color }}>{st.label}</span>
-                  ); })()}
-                  <span className="inr-text-muted">{s.scheme ? `via ${s.scheme}` : ''}</span>
-                  {contributionS != null ? (
-                    // eslint-disable-next-line local/no-inline-style -- weight-presence-driven opacity
-                    <span title={`Support contribution = source strength (${(srcStrS ?? 0).toFixed(2)}) × edge weight (${edgeWeightS.toFixed(1)}${hasWeightS ? '' : ' — default, no AI weight'}). No type multiplier for supports — all support relationships are weighted equally.`} style={{ color: 'var(--success)', cursor: 'default', opacity: hasWeightS ? 1 : 0.5 }}>
-                      +{contributionS.toFixed(2)} <span className="inr-text-muted">({(srcStrS ?? 0).toFixed(2)}×{edgeWeightS.toFixed(1)}{hasWeightS ? '' : '?'})</span>
-                    </span>
-                  ) : <span />}
-                  {onGotoEntry && sourceNode?.source_entry_id ? (
-                    <button
-                      onClick={(ev) => { ev.stopPropagation(); onGotoEntry(sourceNode.source_entry_id); }}
-                      title={`Go to ${stmtIdByEntry?.get(sourceNode.source_entry_id) || sourceNode.source_entry_id}`}
-                      className="inr-goto-btn-success"
-                    >{stmtIdByEntry?.get(sourceNode.source_entry_id) || 'goto'}</button>
-                  ) : <span />}
-                </div>
-                {s.warrant && <div className="inr-warrant">Warrant: {s.warrant}</div>}
-                {expanded && sourceNode && (
-                  <div className="inr-debater-block">
-                    <span className="inr-text-muted">Debater:</span> <strong>{speakerLabel(sourceNode.speaker)}</strong>
-                    {onGotoEntry && sourceNode.source_entry_id && (
-                      <button
-                        onClick={() => onGotoEntry(sourceNode.source_entry_id)}
-                        title={`Go to ${stmtIdByEntry?.get(sourceNode.source_entry_id) || sourceNode.source_entry_id}`}
-                        className="inr-goto-btn-success-ml"
-                      >{stmtIdByEntry?.get(sourceNode.source_entry_id) || 'goto'}</button>
-                    )}
-                    <div className="inr-mt2"><Highlight text={sourceNode.text} query={searchQuery} /></div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
+          {attacks.map(a => (
+            <AttackEdgeRow key={a.id} a={a} allNodes={allNodes} strengthMap={strengthMap} onGotoEntry={onGotoEntry} stmtIdByEntry={stmtIdByEntry} expanded={expanded} searchQuery={searchQuery} />
+          ))}
+          {supports.map(s => (
+            <SupportEdgeRow key={s.id} s={s} allNodes={allNodes} strengthMap={strengthMap} onGotoEntry={onGotoEntry} stmtIdByEntry={stmtIdByEntry} expanded={expanded} searchQuery={searchQuery} />
+          ))}
           {/* Leave-one-out QBAF attribution */}
-          {attribution && attribution.attributions.length > 0 && (
-            <div className="inr-loo-container">
-              <div className="inr-loo-heading">QBAF Attribution (leave-one-out)</div>
-              <div className="inr-loo-summary">{attribution.summary}</div>
-              {attribution.attributions.slice(0, 6).map((a, i) => (
-                <div key={i} className="inr-loo-row">
-                  {/* eslint-disable-next-line local/no-inline-style -- influence-sign-driven color */}
-                  <span style={{ color: a.influence >= 0 ? 'var(--success)' : 'var(--danger)', textAlign: 'right' }}>
-                    {a.influence >= 0 ? '+' : ''}{a.influence.toFixed(3)}
-                  </span>
-                  {/* eslint-disable-next-line local/no-inline-style -- edge-type-driven color */}
-                  <span style={{ color: a.edgeType === 'attacks' ? 'var(--danger)' : 'var(--success)' }}>
-                    {a.edgeType}{a.attackType ? ` (${a.attackType})` : ''}
-                  </span>
-                  <span className="inr-text-muted">from {a.sourceId}</span>
-                  <span className="inr-text-muted-italic">{a.scheme ? `via ${a.scheme}` : ''}</span>
-                </div>
-              ))}
-              {attribution.attributions.length > 6 && (
-                <div className="inr-loo-more">...and {attribution.attributions.length - 6} more</div>
-              )}
-            </div>
-          )}
+          <LooAttribution attribution={attribution} />
         </div>
       )}
     </div>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ModeratorTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ModeratorTab.tsx
@@ -7,259 +7,341 @@ import type { ModeratorTraceData } from '../types';
 import { TensionsListDetail } from './TensionsListDetail';
 import { DebateExchangeRich } from './DebateExchangeRich';
 
+type PromptSection = { title: string; content: string };
+type Candidate = NonNullable<ModeratorTraceData['candidates']>[number];
+
+const sectionStyle: React.CSSProperties = { marginBottom: 12, padding: '8px 10px', borderRadius: 6, background: 'var(--bg-secondary)', border: '1px solid var(--border)' };
+const headingStyle: React.CSSProperties = { fontWeight: 700, fontSize: 'var(--text-2xs)', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--color-acc)', marginBottom: 6 };
+
+const HEALTH_COMPONENT_TOOLTIPS: Record<string, string> = {
+  engagement: 'Engagement (weight: 0.25, SLI floor: 0.25)\n\nMeasures how substantively debaters engage with each other\'s claims.\nComputed as the average dialectical_engagement.ratio from the last 3 convergence signals.\ndialectical_engagement.ratio = fraction of prior claims that were directly addressed.\n\nLow engagement means debaters are talking past each other — triggers elicitation interventions (PIN, PROBE, CHALLENGE).',
+  novelty: 'Novelty (weight: 0.25, SLI floor: 0.25)\n\nMeasures whether debaters are introducing new ideas vs. recycling old arguments.\nComputed as: 1 − avg(argument_redundancy.avg_self_overlap) over the last 3 signals.\navg_self_overlap compares each statement to the speaker\'s own prior statements via cosine similarity.\n\nLow novelty means the debate is going in circles — triggers elicitation interventions.',
+  responsiveness: 'Responsiveness (weight: 0.20, SLI floor: 0.15)\n\nMeasures whether debaters take concession opportunities when warranted.\nComputed from convergence signals: of turns where a concession opportunity existed, what fraction were "taken" vs. "missed"?\nIf no concession opportunities arose, defaults to 1.0 (no penalty).\n\nLow responsiveness means debaters are ignoring valid challenges — triggers elicitation interventions.',
+  coverage: 'Coverage (weight: 0.15, SLI floor: 0.20)\n\nMeasures what fraction of relevant taxonomy nodes have been cited in the debate.\nComputed as: min(cited_node_count / relevant_node_count, 1.0).\nIf no relevant nodes exist, defaults to 1.0.\n\nLow coverage means the debate is ignoring important perspectives from the taxonomy — triggers procedural interventions (REDIRECT, BALANCE, SEQUENCE).',
+  balance: 'Balance (weight: 0.15, SLI floor: 0.30)\n\nMeasures whether all debaters are getting roughly equal speaking time.\nComputed as: 1 − (max_turns − min_turns) / total_turns.\n1.0 = perfectly balanced; 0.0 = one debater completely dominated.\n\nLow balance means one debater is being sidelined — triggers procedural interventions (BALANCE, REDIRECT).',
+};
+
+function parsePromptSections(selectionPrompt: string | undefined): PromptSection[] {
+  if (!selectionPrompt) return [];
+  const sections: PromptSection[] = [];
+  const text = selectionPrompt;
+
+  const headingRe = /(?:^|\n)(?:={3,}\s*(.+?)\s*={3,}|##\s*(.+?))\s*\n/g;
+  let lastIdx = 0;
+  let lastTitle = 'System Prompt';
+  let match;
+  while ((match = headingRe.exec(text)) !== null) {
+    const preceding = text.slice(lastIdx, match.index).trim();
+    if (preceding) sections.push({ title: lastTitle, content: preceding });
+    lastTitle = (match[1] || match[2]).replace(/\s*\(.*?\)\s*$/, '');
+    lastIdx = match.index + match[0].length;
+  }
+  const remaining = text.slice(lastIdx).trim();
+  if (remaining) sections.push({ title: lastTitle, content: remaining });
+  return sections;
+}
+
+function DecisionSection({ trace }: { trace: ModeratorTraceData }) {
+  return (
+    <div style={sectionStyle}>
+      <div style={headingStyle}>Decision</div>
+      <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', fontSize: '0.75rem', alignItems: 'center' }}>
+        {trace.selected && (
+          <div><strong>Selected:</strong> <span style={{ color: 'var(--color-acc)', fontWeight: 700 }}>{trace.selected}</span></div>
+        )}
+        {trace.selection_reason && (
+          <span style={{ padding: '1px 6px', borderRadius: 3, background: 'color-mix(in srgb, var(--color-acc) 15%, transparent)', color: 'var(--color-acc)', fontSize: 'var(--text-2xs)', fontWeight: 600 }}>
+            {trace.selection_reason.replace(/_/g, ' ')}
+          </span>
+        )}
+        {trace.excluded_last_speaker && (
+          <div style={{ color: 'var(--text-muted)', fontSize: '0.7rem' }}>excluded: {trace.excluded_last_speaker}</div>
+        )}
+      </div>
+      {trace.focus_point && (
+        <div style={{ marginTop: 6, fontSize: '0.75rem' }}>
+          <strong>Focus:</strong> {trace.focus_point}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CandidateCard({ c, selected }: { c: Candidate; selected: ModeratorTraceData['selected'] }) {
+  return (
+    <div style={{
+      padding: '6px 10px', borderRadius: 6, fontSize: '0.72rem',
+      background: c.debater === selected ? 'color-mix(in srgb, var(--color-acc) 12%, transparent)' : 'transparent',
+      border: `1px solid ${c.debater === selected ? 'var(--color-acc)' : 'var(--border)'}`,
+      fontWeight: c.debater === selected ? 700 : 400,
+    }}>
+      <div>#{c.rank} {c.debater}</div>
+      <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 2 }}>
+        {c.claim_count != null && <span>{c.claim_count} claim{c.claim_count !== 1 ? 's' : ''} in AN</span>}
+        {c.computed_strength != null && (
+          <span
+            title="QBAF post-propagation acceptability: average computed strength across this debater's claims after attack/support edges are applied. Higher = arguments are holding up well under challenge."
+            style={{ marginLeft: 6, cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
+          >
+            QBAF: {c.computed_strength.toFixed(3)} ({c.scored_count ?? '?'} scored)
+          </span>
+        )}
+        {c.computed_strength == null && (c.claim_count ?? 0) > 0 && (
+          <span
+            title="QBAF strength propagation has not run yet. Strengths will appear after the debate engine computes post-propagation acceptability scores."
+            style={{ marginLeft: 6, fontStyle: 'italic', cursor: 'default' }}
+          >
+            (no QBAF scores yet)
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CandidatesSection({ trace }: { trace: ModeratorTraceData }) {
+  if (!(trace.candidates && trace.candidates.length > 0)) return null;
+  return (
+    <div style={sectionStyle}>
+      <div style={headingStyle}>Candidate Ranking</div>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        {trace.candidates.map((c, i) => (
+          <CandidateCard key={i} c={c} selected={trace.selected} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DebateStateSection({ trace }: { trace: ModeratorTraceData }) {
+  if (!(trace.convergence_score != null || trace.commitment_snapshot)) return null;
+  return (
+    <div style={sectionStyle}>
+      <div style={headingStyle}>Debate State</div>
+      {trace.convergence_score != null && (
+        <div style={{ fontSize: '0.72rem', marginBottom: 4 }}>
+          <strong
+            title={'Convergence measures how much the debaters are moving toward agreement on the current issue.\n\nThree weighted signals:\n• Cross-speaker support ratio (40%): Of all cross-speaker edges in the argument network, what fraction are supports vs. attacks? More support edges = higher convergence.\n• Concession rate (35%): How many claims on this issue have been conceded? More concessions = debaters yielding ground.\n• Stance alignment (25%): How many speaker pairs have at least one mutual support edge? Measures breadth of agreement across all participants.\n\nScore range: 0% (pure opposition) → 50% (baseline/unknown) → 100% (full agreement).\nWhen convergence exceeds the threshold, the moderator may suggest exploring a new topic.'}
+            style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
+          >Convergence:</strong> {(trace.convergence_score * 100).toFixed(0)}%
+          {trace.convergence_triggered && <span style={{ color: 'var(--success)', marginLeft: 6, fontWeight: 700 }}>TRIGGERED</span>}
+        </div>
+      )}
+      {trace.commitment_snapshot && (
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', fontSize: '0.7rem' }}>
+          {Object.entries(trace.commitment_snapshot).map(([name, c]) => (
+            <div key={name} style={{ padding: '4px 8px', borderRadius: 4, background: 'var(--bg-primary)', border: '1px solid var(--border)' }}>
+              <div style={{ fontWeight: 600, marginBottom: 2 }}>{name}</div>
+              <div style={{ display: 'flex', gap: 8, fontSize: 'var(--text-2xs)', color: 'var(--text-muted)' }}>
+                <span>{c.asserted} asserted</span>
+                <span>{c.conceded} conceded</span>
+                <span>{c.challenged} challenged</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ModeratorMetricsRow({ trace }: { trace: ModeratorTraceData }) {
+  return (
+    <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', fontSize: '0.72rem', marginBottom: 6 }}>
+      {trace.health_score != null && (
+        <div>
+          <strong
+            title={'Composite debate health score (0.0–1.0). Weighted average of 5 components:\n• Engagement \xD70.25 — are debaters substantively engaging with each other\'s claims?\n• Novelty \xD70.25 — are debaters introducing new ideas rather than recycling?\n• Responsiveness \xD70.20 — are debaters taking concession opportunities when warranted?\n• Coverage \xD70.15 — what fraction of relevant taxonomy nodes have been cited?\n• Balance \xD70.15 — are all debaters getting roughly equal speaking time?\n\nComputed over a sliding window of the last 3 convergence signals.\nGreen (≥0.70): healthy debate. Amber (0.40–0.69): degrading. Red (<0.40): intervention likely needed.\nWhen a component drops below its SLI floor for 2+ consecutive turns, the moderator auto-triggers an intervention.'}
+            style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
+          >Health:</strong>{' '}
+          <span style={{ color: trace.health_score >= 0.7 ? 'var(--success)' : trace.health_score >= 0.4 ? 'var(--warning)' : 'var(--danger)', fontWeight: 700 }}>
+            {trace.health_score.toFixed(2)}
+          </span>
+        </div>
+      )}
+      {trace.budget_remaining != null && trace.budget_total != null && (
+        <div>
+          <strong
+            title={'Intervention budget — how many moderator interventions remain.\n\nBudget = ceil(argumentation_rounds / 2.5). For a 20-round debate with ~17 argumentation rounds, budget ≈ 7.\nEach intervention (except COMMIT) consumes 1 budget unit.\nWhen budget reaches 0, no further interventions can fire (except off-budget COMMIT moves in concluding phase).\nThis prevents the moderator from over-intervening and dominating the debate.'}
+            style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
+          >Budget:</strong> {trace.budget_remaining}/{trace.budget_total}
+        </div>
+      )}
+      {trace.cooldown_rounds_left != null && (
+        <div>
+          <strong
+            title={'Cooldown — minimum rounds that must pass before the next intervention.\n\nAfter an intervention fires, the moderator enforces a 1-round gap before acting again.\nExempt from cooldown: Reconciliation (ACKNOWLEDGE, REVOICE), Elicitation (PIN, PROBE, CHALLENGE), and COMMIT.\n\n"ready" = cooldown expired, moderator can intervene if triggered.\n"N round(s)" = must wait N more rounds before the next intervention.'}
+            style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
+          >Cooldown:</strong> {trace.cooldown_rounds_left > 0 ? `${trace.cooldown_rounds_left} round(s)` : 'ready'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HealthComponentChip({ k, v }: { k: string; v: unknown }) {
+  return (
+    <span title={HEALTH_COMPONENT_TOOLTIPS[k] || k} style={{ padding: '1px 5px', borderRadius: 3, background: 'var(--bg-primary)', border: '1px solid var(--border)', cursor: 'default' }}>
+      {k}: {((v as number) ?? 0).toFixed(2)}
+    </span>
+  );
+}
+
+function HealthComponentsRow({ trace }: { trace: ModeratorTraceData }) {
+  if (!trace.health_components) return null;
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', fontSize: 'var(--text-2xs)', marginBottom: 6 }}>
+      {Object.entries(trace.health_components).map(([k, v]) => (
+        <HealthComponentChip key={k} k={k} v={v} />
+      ))}
+    </div>
+  );
+}
+
+function BurdenRow({ trace }: { trace: ModeratorTraceData }) {
+  if (!(trace.burden_per_debater && Object.keys(trace.burden_per_debater).length > 0)) return null;
+  return (
+    <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginBottom: 6 }}>
+      <strong
+        title={'Burden — cumulative intervention load per debater.\n\nEach intervention adds a burden weight based on its family:\n• Elicitation (PIN, PROBE, CHALLENGE): 1.0 — most disruptive\n• Synthesis (COMPRESS, COMMIT): 0.8\n• Repair (CLARIFY, CHECK, SUMMARIZE): 0.75\n• Reflection (META-REFLECT): 0.6\n• Procedural (REDIRECT, BALANCE, SEQUENCE): 0.5\n• Reconciliation (ACKNOWLEDGE, REVOICE): 0.25 — least disruptive\n\nBurden cap: if a debater\'s burden exceeds 1.5\xD7 the average burden, high-burden moves (weight > 0.5) against that debater are suppressed.\nThis prevents the moderator from repeatedly targeting the same debater.'}
+        style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
+      >Burden:</strong>{' '}
+      {Object.entries(trace.burden_per_debater).map(([d, b]) => `${d}: ${((b as number) ?? 0).toFixed(2)}`).join(', ')}
+    </div>
+  );
+}
+
+function InterventionSuppressionReason({ trace }: { trace: ModeratorTraceData }) {
+  if (!(trace.intervention_suppressed_reason && !trace.intervention_validated)) return null;
+  return (
+    <div style={{ fontSize: '0.7rem', color: 'var(--warning)', marginTop: 3 }}>
+      <strong>Reason:</strong>{' '}
+      <span
+        title={SUPPRESSION_REASON_TOOLTIPS[trace.intervention_suppressed_reason] ?? ''}
+        style={{ cursor: 'default', borderBottom: '1px dotted var(--warning)' }}
+      >
+        {trace.intervention_suppressed_reason.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
+      </span>
+      {trace.intervention_suppression_explanation && (
+        <span> &mdash; {trace.intervention_suppression_explanation}</span>
+      )}
+    </div>
+  );
+}
+
+function TriggerEvidenceRow({ trace }: { trace: ModeratorTraceData }) {
+  if (!trace.trigger_evidence) return null;
+  return (
+    <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 2 }}>
+      <span
+        title="Signal name — the moderator AI's label for the debate behavior that triggered this intervention recommendation. Common signals include: evasion (debater dodging a question), term_ambiguity (key term used with conflicting meanings), stagnation_crux (debate stuck on a crux point), unsupported_claim (assertion without evidence), scope_creep (discussion drifting from source material), contradiction (debater contradicting a prior position)."
+        style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
+      >Signal:</span> {String((trace.trigger_evidence as Record<string, unknown>).signal_name ?? 'unknown')}
+      {!!(trace.trigger_evidence as Record<string, unknown>).observed_behavior && (
+        <span> &mdash; {String((trace.trigger_evidence as Record<string, unknown>).observed_behavior)}</span>
+      )}
+    </div>
+  );
+}
+
+function InterventionBox({ trace }: { trace: ModeratorTraceData }) {
+  if (!trace.intervention_recommended) return null;
+  return (
+    <div style={{ marginTop: 4, padding: '6px 8px', borderRadius: 4, background: trace.intervention_validated ? 'color-mix(in srgb, var(--text-secondary) 10%, transparent)' : 'color-mix(in srgb, var(--danger) 8%, transparent)', border: `1px solid ${trace.intervention_validated ? 'var(--text-secondary)' : 'var(--danger)'}` }}>
+      <div style={{ fontSize: '0.72rem', fontWeight: 700, color: trace.intervention_validated ? 'var(--text-secondary)' : 'var(--danger)' }}>
+        {trace.intervention_validated ? 'Intervention Fired' : 'Intervention Suppressed'}
+        {trace.intervention_move && `: ${trace.intervention_move}`}
+        {trace.intervention_target && ` → ${trace.intervention_target}`}
+      </div>
+      <InterventionSuppressionReason trace={trace} />
+      {trace.trigger_reasoning && (
+        <div style={{ fontSize: 'var(--text-2xs)', marginTop: 4 }}>
+          <strong>Trigger:</strong> {trace.trigger_reasoning}
+        </div>
+      )}
+      <TriggerEvidenceRow trace={trace} />
+    </div>
+  );
+}
+
+function ActiveModeratorSection({ trace }: { trace: ModeratorTraceData }) {
+  if (!(trace.health_score != null || trace.intervention_recommended || trace.budget_remaining != null)) return null;
+  return (
+    <div style={sectionStyle}>
+      <div style={headingStyle}>Active Moderator</div>
+      <ModeratorMetricsRow trace={trace} />
+      <HealthComponentsRow trace={trace} />
+      <BurdenRow trace={trace} />
+      <InterventionBox trace={trace} />
+    </div>
+  );
+}
+
+function PromptSectionDetails({ s, i }: { s: PromptSection; i: number }) {
+  const isTensions = /KNOWN TENSIONS/i.test(s.title);
+  const isExchange = /RECENT DEBATE EXCHANGE/i.test(s.title);
+  return (
+    <details style={{ marginBottom: 4 }} open={i < 2}>
+      <summary style={{ cursor: 'pointer', fontWeight: 600, fontSize: '0.72rem', color: 'var(--text-primary)', padding: '3px 0' }}>
+        {s.title}
+        <span style={{ marginLeft: 6, fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', fontWeight: 400 }}>
+          {s.content.length > 500 ? `${(s.content.length / 1024).toFixed(1)}KB` : `${s.content.length} chars`}
+        </span>
+      </summary>
+      {isTensions ? <TensionsListDetail content={s.content} />
+        : isExchange ? <DebateExchangeRich content={s.content} />
+        : <pre style={{ fontSize: 'var(--text-2xs)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 300, overflow: 'auto', margin: '4px 0 8px', padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border)' }}>{s.content}</pre>
+      }
+    </details>
+  );
+}
+
+function PromptSectionsSection({ sections }: { sections: PromptSection[] }) {
+  if (!(sections.length > 0)) return null;
+  return (
+    <div style={sectionStyle}>
+      <div style={headingStyle}>Context Sent to Moderator</div>
+      {sections.map((s, i) => (
+        <PromptSectionDetails key={i} s={s} i={i} />
+      ))}
+    </div>
+  );
+}
+
+function ResponseSection({ trace }: { trace: ModeratorTraceData }) {
+  if (!trace.selection_response) return null;
+  return (
+    <div style={sectionStyle}>
+      <div style={headingStyle}>Moderator Response</div>
+      <pre style={{ fontSize: '0.7rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 200, overflow: 'auto', margin: 0, padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border)' }}>
+        {trace.selection_response}
+      </pre>
+    </div>
+  );
+}
+
 export function ModeratorTab({ trace }: { trace: ModeratorTraceData }) {
-  const sectionStyle: React.CSSProperties = { marginBottom: 12, padding: '8px 10px', borderRadius: 6, background: 'var(--bg-secondary)', border: '1px solid var(--border)' };
-  const headingStyle: React.CSSProperties = { fontWeight: 700, fontSize: 'var(--text-2xs)', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--color-acc)', marginBottom: 6 };
-
-  const promptSections = useMemo(() => {
-    if (!trace.selection_prompt) return [];
-    const sections: { title: string; content: string }[] = [];
-    const text = trace.selection_prompt;
-
-    const headingRe = /(?:^|\n)(?:={3,}\s*(.+?)\s*={3,}|##\s*(.+?))\s*\n/g;
-    let lastIdx = 0;
-    let lastTitle = 'System Prompt';
-    let match;
-    while ((match = headingRe.exec(text)) !== null) {
-      const preceding = text.slice(lastIdx, match.index).trim();
-      if (preceding) sections.push({ title: lastTitle, content: preceding });
-      lastTitle = (match[1] || match[2]).replace(/\s*\(.*?\)\s*$/, '');
-      lastIdx = match.index + match[0].length;
-    }
-    const remaining = text.slice(lastIdx).trim();
-    if (remaining) sections.push({ title: lastTitle, content: remaining });
-    return sections;
-  }, [trace.selection_prompt]);
+  const promptSections = useMemo(() => parsePromptSections(trace.selection_prompt), [trace.selection_prompt]);
 
   return (
     <>
       {/* Decision summary */}
-      <div style={sectionStyle}>
-        <div style={headingStyle}>Decision</div>
-        <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', fontSize: '0.75rem', alignItems: 'center' }}>
-          {trace.selected && (
-            <div><strong>Selected:</strong> <span style={{ color: 'var(--color-acc)', fontWeight: 700 }}>{trace.selected}</span></div>
-          )}
-          {trace.selection_reason && (
-            <span style={{ padding: '1px 6px', borderRadius: 3, background: 'color-mix(in srgb, var(--color-acc) 15%, transparent)', color: 'var(--color-acc)', fontSize: 'var(--text-2xs)', fontWeight: 600 }}>
-              {trace.selection_reason.replace(/_/g, ' ')}
-            </span>
-          )}
-          {trace.excluded_last_speaker && (
-            <div style={{ color: 'var(--text-muted)', fontSize: '0.7rem' }}>excluded: {trace.excluded_last_speaker}</div>
-          )}
-        </div>
-        {trace.focus_point && (
-          <div style={{ marginTop: 6, fontSize: '0.75rem' }}>
-            <strong>Focus:</strong> {trace.focus_point}
-          </div>
-        )}
-      </div>
+      <DecisionSection trace={trace} />
 
       {/* Candidates */}
-      {trace.candidates && trace.candidates.length > 0 && (
-        <div style={sectionStyle}>
-          <div style={headingStyle}>Candidate Ranking</div>
-          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
-            {trace.candidates.map((c, i) => (
-              <div key={i} style={{
-                padding: '6px 10px', borderRadius: 6, fontSize: '0.72rem',
-                background: c.debater === trace.selected ? 'color-mix(in srgb, var(--color-acc) 12%, transparent)' : 'transparent',
-                border: `1px solid ${c.debater === trace.selected ? 'var(--color-acc)' : 'var(--border)'}`,
-                fontWeight: c.debater === trace.selected ? 700 : 400,
-              }}>
-                <div>#{c.rank} {c.debater}</div>
-                <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 2 }}>
-                  {c.claim_count != null && <span>{c.claim_count} claim{c.claim_count !== 1 ? 's' : ''} in AN</span>}
-                  {c.computed_strength != null && (
-                    <span
-                      title="QBAF post-propagation acceptability: average computed strength across this debater's claims after attack/support edges are applied. Higher = arguments are holding up well under challenge."
-                      style={{ marginLeft: 6, cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
-                    >
-                      QBAF: {c.computed_strength.toFixed(3)} ({c.scored_count ?? '?'} scored)
-                    </span>
-                  )}
-                  {c.computed_strength == null && (c.claim_count ?? 0) > 0 && (
-                    <span
-                      title="QBAF strength propagation has not run yet. Strengths will appear after the debate engine computes post-propagation acceptability scores."
-                      style={{ marginLeft: 6, fontStyle: 'italic', cursor: 'default' }}
-                    >
-                      (no QBAF scores yet)
-                    </span>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      <CandidatesSection trace={trace} />
 
       {/* Convergence + Commitments */}
-      {(trace.convergence_score != null || trace.commitment_snapshot) && (
-        <div style={sectionStyle}>
-          <div style={headingStyle}>Debate State</div>
-          {trace.convergence_score != null && (
-            <div style={{ fontSize: '0.72rem', marginBottom: 4 }}>
-              <strong
-                title={'Convergence measures how much the debaters are moving toward agreement on the current issue.\n\nThree weighted signals:\n• Cross-speaker support ratio (40%): Of all cross-speaker edges in the argument network, what fraction are supports vs. attacks? More support edges = higher convergence.\n• Concession rate (35%): How many claims on this issue have been conceded? More concessions = debaters yielding ground.\n• Stance alignment (25%): How many speaker pairs have at least one mutual support edge? Measures breadth of agreement across all participants.\n\nScore range: 0% (pure opposition) → 50% (baseline/unknown) → 100% (full agreement).\nWhen convergence exceeds the threshold, the moderator may suggest exploring a new topic.'}
-                style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
-              >Convergence:</strong> {(trace.convergence_score * 100).toFixed(0)}%
-              {trace.convergence_triggered && <span style={{ color: 'var(--success)', marginLeft: 6, fontWeight: 700 }}>TRIGGERED</span>}
-            </div>
-          )}
-          {trace.commitment_snapshot && (
-            <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', fontSize: '0.7rem' }}>
-              {Object.entries(trace.commitment_snapshot).map(([name, c]) => (
-                <div key={name} style={{ padding: '4px 8px', borderRadius: 4, background: 'var(--bg-primary)', border: '1px solid var(--border)' }}>
-                  <div style={{ fontWeight: 600, marginBottom: 2 }}>{name}</div>
-                  <div style={{ display: 'flex', gap: 8, fontSize: 'var(--text-2xs)', color: 'var(--text-muted)' }}>
-                    <span>{c.asserted} asserted</span>
-                    <span>{c.conceded} conceded</span>
-                    <span>{c.challenged} challenged</span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
+      <DebateStateSection trace={trace} />
 
       {/* Active Moderator State */}
-      {(trace.health_score != null || trace.intervention_recommended || trace.budget_remaining != null) && (
-        <div style={sectionStyle}>
-          <div style={headingStyle}>Active Moderator</div>
-          <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap', fontSize: '0.72rem', marginBottom: 6 }}>
-            {trace.health_score != null && (
-              <div>
-                <strong
-                  title={'Composite debate health score (0.0–1.0). Weighted average of 5 components:\n• Engagement \xD70.25 — are debaters substantively engaging with each other\'s claims?\n• Novelty \xD70.25 — are debaters introducing new ideas rather than recycling?\n• Responsiveness \xD70.20 — are debaters taking concession opportunities when warranted?\n• Coverage \xD70.15 — what fraction of relevant taxonomy nodes have been cited?\n• Balance \xD70.15 — are all debaters getting roughly equal speaking time?\n\nComputed over a sliding window of the last 3 convergence signals.\nGreen (≥0.70): healthy debate. Amber (0.40–0.69): degrading. Red (<0.40): intervention likely needed.\nWhen a component drops below its SLI floor for 2+ consecutive turns, the moderator auto-triggers an intervention.'}
-                  style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
-                >Health:</strong>{' '}
-                <span style={{ color: trace.health_score >= 0.7 ? 'var(--success)' : trace.health_score >= 0.4 ? 'var(--warning)' : 'var(--danger)', fontWeight: 700 }}>
-                  {trace.health_score.toFixed(2)}
-                </span>
-              </div>
-            )}
-            {trace.budget_remaining != null && trace.budget_total != null && (
-              <div>
-                <strong
-                  title={'Intervention budget — how many moderator interventions remain.\n\nBudget = ceil(argumentation_rounds / 2.5). For a 20-round debate with ~17 argumentation rounds, budget ≈ 7.\nEach intervention (except COMMIT) consumes 1 budget unit.\nWhen budget reaches 0, no further interventions can fire (except off-budget COMMIT moves in concluding phase).\nThis prevents the moderator from over-intervening and dominating the debate.'}
-                  style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
-                >Budget:</strong> {trace.budget_remaining}/{trace.budget_total}
-              </div>
-            )}
-            {trace.cooldown_rounds_left != null && (
-              <div>
-                <strong
-                  title={'Cooldown — minimum rounds that must pass before the next intervention.\n\nAfter an intervention fires, the moderator enforces a 1-round gap before acting again.\nExempt from cooldown: Reconciliation (ACKNOWLEDGE, REVOICE), Elicitation (PIN, PROBE, CHALLENGE), and COMMIT.\n\n"ready" = cooldown expired, moderator can intervene if triggered.\n"N round(s)" = must wait N more rounds before the next intervention.'}
-                  style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
-                >Cooldown:</strong> {trace.cooldown_rounds_left > 0 ? `${trace.cooldown_rounds_left} round(s)` : 'ready'}
-              </div>
-            )}
-          </div>
-          {trace.health_components && (
-            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', fontSize: 'var(--text-2xs)', marginBottom: 6 }}>
-              {Object.entries(trace.health_components).map(([k, v]) => {
-                const tooltips: Record<string, string> = {
-                  engagement: 'Engagement (weight: 0.25, SLI floor: 0.25)\n\nMeasures how substantively debaters engage with each other\'s claims.\nComputed as the average dialectical_engagement.ratio from the last 3 convergence signals.\ndialectical_engagement.ratio = fraction of prior claims that were directly addressed.\n\nLow engagement means debaters are talking past each other — triggers elicitation interventions (PIN, PROBE, CHALLENGE).',
-                  novelty: 'Novelty (weight: 0.25, SLI floor: 0.25)\n\nMeasures whether debaters are introducing new ideas vs. recycling old arguments.\nComputed as: 1 − avg(argument_redundancy.avg_self_overlap) over the last 3 signals.\navg_self_overlap compares each statement to the speaker\'s own prior statements via cosine similarity.\n\nLow novelty means the debate is going in circles — triggers elicitation interventions.',
-                  responsiveness: 'Responsiveness (weight: 0.20, SLI floor: 0.15)\n\nMeasures whether debaters take concession opportunities when warranted.\nComputed from convergence signals: of turns where a concession opportunity existed, what fraction were "taken" vs. "missed"?\nIf no concession opportunities arose, defaults to 1.0 (no penalty).\n\nLow responsiveness means debaters are ignoring valid challenges — triggers elicitation interventions.',
-                  coverage: 'Coverage (weight: 0.15, SLI floor: 0.20)\n\nMeasures what fraction of relevant taxonomy nodes have been cited in the debate.\nComputed as: min(cited_node_count / relevant_node_count, 1.0).\nIf no relevant nodes exist, defaults to 1.0.\n\nLow coverage means the debate is ignoring important perspectives from the taxonomy — triggers procedural interventions (REDIRECT, BALANCE, SEQUENCE).',
-                  balance: 'Balance (weight: 0.15, SLI floor: 0.30)\n\nMeasures whether all debaters are getting roughly equal speaking time.\nComputed as: 1 − (max_turns − min_turns) / total_turns.\n1.0 = perfectly balanced; 0.0 = one debater completely dominated.\n\nLow balance means one debater is being sidelined — triggers procedural interventions (BALANCE, REDIRECT).',
-                };
-                return (
-                  <span key={k} title={tooltips[k] || k} style={{ padding: '1px 5px', borderRadius: 3, background: 'var(--bg-primary)', border: '1px solid var(--border)', cursor: 'default' }}>
-                    {k}: {((v as number) ?? 0).toFixed(2)}
-                  </span>
-                );
-              })}
-            </div>
-          )}
-          {trace.burden_per_debater && Object.keys(trace.burden_per_debater).length > 0 && (
-            <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginBottom: 6 }}>
-              <strong
-                title={'Burden — cumulative intervention load per debater.\n\nEach intervention adds a burden weight based on its family:\n• Elicitation (PIN, PROBE, CHALLENGE): 1.0 — most disruptive\n• Synthesis (COMPRESS, COMMIT): 0.8\n• Repair (CLARIFY, CHECK, SUMMARIZE): 0.75\n• Reflection (META-REFLECT): 0.6\n• Procedural (REDIRECT, BALANCE, SEQUENCE): 0.5\n• Reconciliation (ACKNOWLEDGE, REVOICE): 0.25 — least disruptive\n\nBurden cap: if a debater\'s burden exceeds 1.5\xD7 the average burden, high-burden moves (weight > 0.5) against that debater are suppressed.\nThis prevents the moderator from repeatedly targeting the same debater.'}
-                style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
-              >Burden:</strong>{' '}
-              {Object.entries(trace.burden_per_debater).map(([d, b]) => `${d}: ${((b as number) ?? 0).toFixed(2)}`).join(', ')}
-            </div>
-          )}
-          {trace.intervention_recommended && (
-            <div style={{ marginTop: 4, padding: '6px 8px', borderRadius: 4, background: trace.intervention_validated ? 'color-mix(in srgb, var(--text-secondary) 10%, transparent)' : 'color-mix(in srgb, var(--danger) 8%, transparent)', border: `1px solid ${trace.intervention_validated ? 'var(--text-secondary)' : 'var(--danger)'}` }}>
-              <div style={{ fontSize: '0.72rem', fontWeight: 700, color: trace.intervention_validated ? 'var(--text-secondary)' : 'var(--danger)' }}>
-                {trace.intervention_validated ? 'Intervention Fired' : 'Intervention Suppressed'}
-                {trace.intervention_move && `: ${trace.intervention_move}`}
-                {trace.intervention_target && ` → ${trace.intervention_target}`}
-              </div>
-              {trace.intervention_suppressed_reason && !trace.intervention_validated && (
-                <div style={{ fontSize: '0.7rem', color: 'var(--warning)', marginTop: 3 }}>
-                  <strong>Reason:</strong>{' '}
-                  <span
-                    title={SUPPRESSION_REASON_TOOLTIPS[trace.intervention_suppressed_reason] ?? ''}
-                    style={{ cursor: 'default', borderBottom: '1px dotted var(--warning)' }}
-                  >
-                    {trace.intervention_suppressed_reason.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
-                  </span>
-                  {trace.intervention_suppression_explanation && (
-                    <span> &mdash; {trace.intervention_suppression_explanation}</span>
-                  )}
-                </div>
-              )}
-              {trace.trigger_reasoning && (
-                <div style={{ fontSize: 'var(--text-2xs)', marginTop: 4 }}>
-                  <strong>Trigger:</strong> {trace.trigger_reasoning}
-                </div>
-              )}
-              {trace.trigger_evidence && (
-                <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 2 }}>
-                  <span
-                    title="Signal name — the moderator AI's label for the debate behavior that triggered this intervention recommendation. Common signals include: evasion (debater dodging a question), term_ambiguity (key term used with conflicting meanings), stagnation_crux (debate stuck on a crux point), unsupported_claim (assertion without evidence), scope_creep (discussion drifting from source material), contradiction (debater contradicting a prior position)."
-                    style={{ cursor: 'default', borderBottom: '1px dotted var(--text-muted)' }}
-                  >Signal:</span> {String((trace.trigger_evidence as Record<string, unknown>).signal_name ?? 'unknown')}
-                  {!!(trace.trigger_evidence as Record<string, unknown>).observed_behavior && (
-                    <span> &mdash; {String((trace.trigger_evidence as Record<string, unknown>).observed_behavior)}</span>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+      <ActiveModeratorSection trace={trace} />
 
       {/* Selection prompt sections */}
-      {promptSections.length > 0 && (
-        <div style={sectionStyle}>
-          <div style={headingStyle}>Context Sent to Moderator</div>
-          {promptSections.map((s, i) => {
-            const isTensions = /KNOWN TENSIONS/i.test(s.title);
-            const isExchange = /RECENT DEBATE EXCHANGE/i.test(s.title);
-            return (
-              <details key={i} style={{ marginBottom: 4 }} open={i < 2}>
-                <summary style={{ cursor: 'pointer', fontWeight: 600, fontSize: '0.72rem', color: 'var(--text-primary)', padding: '3px 0' }}>
-                  {s.title}
-                  <span style={{ marginLeft: 6, fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', fontWeight: 400 }}>
-                    {s.content.length > 500 ? `${(s.content.length / 1024).toFixed(1)}KB` : `${s.content.length} chars`}
-                  </span>
-                </summary>
-                {isTensions ? <TensionsListDetail content={s.content} />
-                  : isExchange ? <DebateExchangeRich content={s.content} />
-                  : <pre style={{ fontSize: 'var(--text-2xs)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 300, overflow: 'auto', margin: '4px 0 8px', padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border)' }}>{s.content}</pre>
-                }
-              </details>
-            );
-          })}
-        </div>
-      )}
+      <PromptSectionsSection sections={promptSections} />
 
       {/* Raw AI response */}
-      {trace.selection_response && (
-        <div style={sectionStyle}>
-          <div style={headingStyle}>Moderator Response</div>
-          <pre style={{ fontSize: '0.7rem', whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 200, overflow: 'auto', margin: 0, padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border)' }}>
-            {trace.selection_response}
-          </pre>
-        </div>
-      )}
+      <ResponseSection trace={trace} />
     </>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/useDiagnosticsState.ts
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/useDiagnosticsState.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback, type RefObject } from 'react';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import type { DebateSession, EntryDiagnostics, ArgumentNetworkNode, CommitmentStore, TurnValidationTrail } from '../../../types/debate';
@@ -27,6 +27,335 @@ function countMatchesInValue(value: unknown, term: string): number {
     return n;
   }
   return 0;
+}
+
+type TranscriptEntry = DebateSession['transcript'][number];
+type ArgumentNetwork = NonNullable<DebateSession['argument_network']>;
+
+// --- Taxonomy data loading (extracted from loadTaxonomyData for complexity) ---
+async function loadTaxNodesData(
+  signal: { cancelled: boolean },
+): Promise<{ nodeMap: Map<string, Record<string, unknown>>; labels: Map<string, string> } | null> {
+  try {
+    const files = await Promise.all([
+      api.loadTaxonomyFile('accelerationist').catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-window', level: 'warn', message: 'Failed to load accelerationist taxonomy', error: { name: (err as Error).name ?? 'Error', message: String(err) } }); return null; }),
+      api.loadTaxonomyFile('safetyist').catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-window', level: 'warn', message: 'Failed to load safetyist taxonomy', error: { name: (err as Error).name ?? 'Error', message: String(err) } }); return null; }),
+      api.loadTaxonomyFile('skeptic').catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-window', level: 'warn', message: 'Failed to load skeptic taxonomy', error: { name: (err as Error).name ?? 'Error', message: String(err) } }); return null; }),
+      api.loadTaxonomyFile('situations').catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-window', level: 'warn', message: 'Failed to load situations taxonomy', error: { name: (err as Error).name ?? 'Error', message: String(err) } }); return null; }),
+    ]);
+    if (signal.cancelled) return null;
+    const m = new Map<string, Record<string, unknown>>();
+    for (const f of files) {
+      const nodes = (f as { nodes?: Record<string, unknown>[] } | null)?.nodes;
+      if (!Array.isArray(nodes)) continue;
+      for (const n of nodes) {
+        const id = (n as { id?: string }).id;
+        if (typeof id === 'string') m.set(id, n);
+      }
+    }
+    const labels = new Map<string, string>();
+    for (const [id, n] of m) {
+      const label = (n as { label?: string }).label;
+      if (typeof label === 'string') labels.set(id, label);
+    }
+    return { nodeMap: m, labels };
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'diagnostics-window', level: 'warn',
+      message: 'Failed to load taxonomy files for node lookup',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    return null;
+  }
+}
+
+async function loadPolicyData(
+  signal: { cancelled: boolean },
+): Promise<Map<string, { id: string; action: string; source_povs: string[]; member_count: number }> | null> {
+  try {
+    const registryRaw = await api.loadPolicyRegistry() as { policies?: { id: string; action: string; source_povs: string[]; member_count: number }[] } | null;
+    const policies = registryRaw?.policies;
+    if (!signal.cancelled && Array.isArray(policies)) {
+      const pm = new Map<string, { id: string; action: string; source_povs: string[]; member_count: number }>();
+      for (const p of policies) pm.set(p.id, p);
+      return pm;
+    }
+    return null;
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'diagnostics-window', level: 'warn',
+      message: 'Failed to load policy registry',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    return null;
+  }
+}
+
+async function loadEdgesData(signal: { cancelled: boolean }): Promise<TaxRefEdge[] | null> {
+  try {
+    const raw = await api.loadEdges() as { edges?: TaxRefEdge[] } | null;
+    if (signal.cancelled) return null;
+    if (raw && Array.isArray(raw.edges)) return raw.edges;
+    return null;
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'diagnostics-window', level: 'warn',
+      message: 'Failed to load edges data',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    return null;
+  }
+}
+
+// --- Deep-link application (extracted from the deep-link effect for complexity) ---
+interface DeepLinkSetters {
+  setDebate: (d: DebateSession | null) => void;
+  setDeepLinkError: (s: string | null) => void;
+  setSelectedEntry: (s: string | null) => void;
+  setLocalOverride: (b: boolean) => void;
+  setOverviewTab: (t: OverviewTab) => void;
+  setEntryTab: (t: EntryTab) => void;
+}
+
+function applyDeepLinkEntry(session: DebateSession, entryParam: string | null, setters: DeepLinkSetters): void {
+  if (entryParam == null) return;
+  const idx = parseInt(entryParam, 10);
+  if (!isNaN(idx) && idx >= 0 && idx < session.transcript.length) {
+    setters.setSelectedEntry(session.transcript[idx].id);
+    setters.setLocalOverride(true);
+    setters.setOverviewTab('transcript');
+  } else {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'diagnostics-deep-link', level: 'warn',
+      message: `Deep-link entry index out of range: ${entryParam} (transcript has ${session.transcript.length} entries)`,
+    });
+  }
+}
+
+function applyDeepLinkTab(params: URLSearchParams, setEntryTab: (t: EntryTab) => void): void {
+  const tabParam = params.get('tab');
+  if (!tabParam) return;
+  const VALID_ENTRY_TABS: string[] = ['tax-refs', 'details', 'claims', 'evidence', 'citations', 'brief', 'plan', 'draft', 'lookahead', 'cite', 'moderator', 'exclusion', 'affect'];
+  if (VALID_ENTRY_TABS.includes(tabParam)) {
+    setEntryTab(tabParam as EntryTab);
+  }
+}
+
+function applyDeepLinkOverview(params: URLSearchParams, entryParam: string | null, setOverviewTab: (t: OverviewTab) => void): void {
+  const overviewParam = params.get('overviewTab');
+  if (overviewParam && !entryParam) {
+    const VALID_OVERVIEW_TABS: string[] = ['topic-scope', 'extraction', 'argument-network', 'commitments', 'transcript', 'convergence', 'reflections', 'gaps', 'grounding', 'lineage', 'adaptive', 'pov-progression', 'fr-context', 'prompt-diff', 'utility', 'exclusion-overview', 'emotional-register'];
+    if (VALID_OVERVIEW_TABS.includes(overviewParam)) {
+      setOverviewTab(overviewParam as OverviewTab);
+    }
+  }
+}
+
+async function applyDeepLink(
+  debateId: string,
+  params: URLSearchParams,
+  getCancelled: () => boolean,
+  setters: DeepLinkSetters,
+): Promise<void> {
+  const { setDebate, setDeepLinkError } = setters;
+  try {
+    const raw = await api.loadDebateSession(debateId);
+    if (getCancelled()) return;
+    if (!raw) {
+      setDebate(null);
+      setDeepLinkError(`Debate not found: ${debateId}`);
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'diagnostics-deep-link', level: 'warn',
+        message: `Deep-link debate not found: ${debateId}`,
+      });
+      return;
+    }
+    const session = raw as DebateSession;
+    setDebate(session);
+
+    const entryParam = params.get('entry');
+    applyDeepLinkEntry(session, entryParam, setters);
+    applyDeepLinkTab(params, setters.setEntryTab);
+    applyDeepLinkOverview(params, entryParam, setters.setOverviewTab);
+  } catch (err) {
+    if (getCancelled()) return;
+    setDeepLinkError(`Failed to load debate: ${String(err)}`);
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'diagnostics-deep-link', level: 'error',
+      message: `Failed to load deep-linked debate: ${debateId}`,
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+  }
+}
+
+// --- Search match counting (extracted from matchCount for complexity) ---
+function countAnMatches(an: ArgumentNetwork, sq: string): number {
+  let count = 0;
+  for (const n of an.nodes) count += countMatches(n.id, sq) + countMatches(n.text, sq) + countMatches(n.speaker, sq);
+  for (const e of an.edges) count += countMatches(e.source, sq) + countMatches(e.warrant || '', sq) + countMatches(e.scheme || '', sq);
+  return count;
+}
+
+function countDiagMatches(diag: EntryDiagnostics, sq: string): number {
+  let count = 0;
+  count += countMatches(diag.prompt || '', sq);
+  count += countMatches(diag.raw_response || '', sq);
+  count += countMatches(diag.taxonomy_context || '', sq);
+  count += countMatches(diag.commitment_context || '', sq);
+  if (diag.extracted_claims) {
+    for (const c of diag.extracted_claims.accepted) count += countMatches(c.text, sq);
+    for (const c of diag.extracted_claims.rejected) count += countMatches(c.text, sq);
+  }
+  const stages = (diag as unknown as Record<string, unknown>).stage_diagnostics as { work_product?: Record<string, unknown> }[] | undefined;
+  if (stages) {
+    for (const stage of stages) {
+      if (!stage.work_product) continue;
+      count += countMatchesInValue(stage.work_product, sq);
+    }
+  }
+  return count;
+}
+
+function computeMatchCount(
+  sq: string,
+  debate: DebateSession | null,
+  an: DebateSession['argument_network'],
+  diag: EntryDiagnostics | undefined,
+): number {
+  if (!sq || !debate) return 0;
+  let count = 0;
+  if (an) count += countAnMatches(an, sq);
+  for (const e of debate.transcript) count += countMatches(e.content, sq);
+  if (diag) count += countDiagMatches(diag, sq);
+  return count;
+}
+
+// --- Keyboard navigation (extracted from the keydown effect for complexity) ---
+interface KeydownCtx {
+  searchInputRef: RefObject<HTMLInputElement | null>;
+  entry: TranscriptEntry | null;
+  entryTab: EntryTab;
+  overviewTab: OverviewTab;
+  effectiveOverviewTab: OverviewTab;
+  debate: DebateSession | null;
+  an: DebateSession['argument_network'];
+  commitments: DebateSession['commitments'];
+  focusedNodeId: string | null;
+  setEntryTab: (t: EntryTab) => void;
+  setOverviewTab: (t: OverviewTab) => void;
+  setSelectedEntry: (id: string | null) => void;
+  setLocalOverride: (b: boolean) => void;
+  setFocusedNodeId: (id: string | null) => void;
+}
+
+function hasGaps(debate: DebateSession): boolean {
+  return !!(debate.taxonomy_gap_analysis || (debate.gap_injections && debate.gap_injections.length > 0) || (debate.cross_cutting_proposals && debate.cross_cutting_proposals.length > 0));
+}
+
+function isOverviewTabVisible(
+  id: OverviewTab,
+  debate: DebateSession,
+  an: DebateSession['argument_network'],
+  commitments: DebateSession['commitments'],
+): boolean {
+  if (id === 'topic-scope') return !!debate.topic?.scope;
+  if (id === 'argument-network' || id === 'utility') return !!(an && an.nodes.length > 0);
+  if (id === 'commitments') return !!(commitments && Object.keys(commitments).length > 0);
+  if (id === 'convergence') return !!(debate.convergence_signals && debate.convergence_signals.length > 0);
+  if (id === 'reflections') return debate.transcript.some(e => e.type === 'reflection');
+  if (id === 'gaps') return hasGaps(debate);
+  if (id === 'grounding') return debate.transcript.some(e => e.taxonomy_refs && e.taxonomy_refs.length > 0);
+  return true;
+}
+
+function handleTabNav(dir: number, ctx: KeydownCtx): void {
+  const { entry, entryTab, debate, an, commitments, setEntryTab, overviewTab, setOverviewTab } = ctx;
+  if (entry) {
+    const ENTRY_TABS: EntryTab[] = ['moderator', 'details', 'brief', 'plan', 'evidence', 'citations', 'draft', 'lookahead', 'cite', 'claims', 'exclusion', 'affect', 'tax-refs'];
+    const idx = ENTRY_TABS.indexOf(entryTab);
+    const next = idx + dir;
+    if (next >= 0 && next < ENTRY_TABS.length) setEntryTab(ENTRY_TABS[next]);
+  } else if (debate) {
+    const OVERVIEW_TABS: OverviewTab[] = ['topic-scope', 'argument-network', 'commitments', 'transcript', 'extraction', 'convergence', 'reflections', 'gaps', 'grounding', 'lineage', 'adaptive', 'pov-progression', 'fr-context', 'prompt-diff', 'utility', 'exclusion-overview', 'emotional-register'];
+    const visible = OVERVIEW_TABS.filter(id => isOverviewTabVisible(id, debate, an, commitments));
+    const idx = visible.indexOf(overviewTab);
+    const next = idx + dir;
+    if (next >= 0 && next < visible.length) setOverviewTab(visible[next]);
+  }
+}
+
+function focusAnNode(dir: number, an: ArgumentNetwork, focusedNodeId: string | null, setFocusedNodeId: (id: string | null) => void): void {
+  const nodeIds = an.nodes.map(n => n.id);
+  const curIdx = focusedNodeId ? nodeIds.indexOf(focusedNodeId) : -1;
+  if (curIdx < 0) {
+    setFocusedNodeId(nodeIds[dir === 1 ? 0 : nodeIds.length - 1]);
+  } else {
+    const nextIdx = curIdx + dir;
+    if (nextIdx >= 0 && nextIdx < nodeIds.length) setFocusedNodeId(nodeIds[nextIdx]);
+  }
+}
+
+function handleEntryNav(dir: number, ctx: KeydownCtx): void {
+  const { entry, effectiveOverviewTab, an, focusedNodeId, setFocusedNodeId, debate, setSelectedEntry, setLocalOverride } = ctx;
+  if (!debate) return;
+  if (!entry && effectiveOverviewTab === 'argument-network' && an && an.nodes.length > 0) {
+    focusAnNode(dir, an, focusedNodeId, setFocusedNodeId);
+    return;
+  }
+
+  if (!entry) {
+    if (dir === 1 && debate.transcript.length > 0) {
+      setSelectedEntry(debate.transcript[0].id);
+      setLocalOverride(true);
+    }
+    return;
+  }
+  const curIdx = debate.transcript.findIndex(t => t.id === entry.id);
+  const nextIdx = curIdx + dir;
+  if (nextIdx >= 0 && nextIdx < debate.transcript.length) {
+    setSelectedEntry(debate.transcript[nextIdx].id);
+    setLocalOverride(true);
+  }
+}
+
+function isSearchFocusKey(e: KeyboardEvent): boolean {
+  return (e.ctrlKey || e.metaKey) && e.key === 'f';
+}
+
+function isTypingTarget(e: KeyboardEvent): boolean {
+  const tag = (e.target as HTMLElement)?.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+function isTabNavKey(e: KeyboardEvent): boolean {
+  return e.key === 'ArrowLeft' || e.key === 'ArrowRight';
+}
+
+function isEntryNavKey(e: KeyboardEvent): boolean {
+  return e.key === 'ArrowUp' || e.key === 'ArrowDown' ||
+    e.key === 'p' || e.key === 'P' || e.key === 'n' || e.key === 'N';
+}
+
+function handleDiagnosticsKeydown(e: KeyboardEvent, ctx: KeydownCtx): void {
+  if (isSearchFocusKey(e)) {
+    e.preventDefault();
+    ctx.searchInputRef.current?.focus();
+    ctx.searchInputRef.current?.select();
+    return;
+  }
+  if (isTypingTarget(e)) return;
+
+  if (isTabNavKey(e)) {
+    e.preventDefault();
+    handleTabNav(e.key === 'ArrowRight' ? 1 : -1, ctx);
+    return;
+  }
+
+  if (isEntryNavKey(e)) {
+    if (!ctx.debate) return;
+    e.preventDefault();
+    handleEntryNav((e.key === 'ArrowDown' || e.key === 'n' || e.key === 'N') ? 1 : -1, ctx);
+  }
 }
 
 export function useDiagnosticsState(initialData?: Record<string, unknown>) {
@@ -106,63 +435,13 @@ export function useDiagnosticsState(initialData?: Record<string, unknown>) {
 
   // Load taxonomy, policy registry, and edges for node lookup
   const loadTaxonomyData = useCallback(async (signal: { cancelled: boolean }) => {
-    try {
-      const files = await Promise.all([
-        api.loadTaxonomyFile('accelerationist').catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-window', level: 'warn', message: 'Failed to load accelerationist taxonomy', error: { name: (err as Error).name ?? 'Error', message: String(err) } }); return null; }),
-        api.loadTaxonomyFile('safetyist').catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-window', level: 'warn', message: 'Failed to load safetyist taxonomy', error: { name: (err as Error).name ?? 'Error', message: String(err) } }); return null; }),
-        api.loadTaxonomyFile('skeptic').catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-window', level: 'warn', message: 'Failed to load skeptic taxonomy', error: { name: (err as Error).name ?? 'Error', message: String(err) } }); return null; }),
-        api.loadTaxonomyFile('situations').catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'diagnostics-window', level: 'warn', message: 'Failed to load situations taxonomy', error: { name: (err as Error).name ?? 'Error', message: String(err) } }); return null; }),
-      ]);
-      if (signal.cancelled) return;
-      const m = new Map<string, Record<string, unknown>>();
-      for (const f of files) {
-        const nodes = (f as { nodes?: Record<string, unknown>[] } | null)?.nodes;
-        if (!Array.isArray(nodes)) continue;
-        for (const n of nodes) {
-          const id = (n as { id?: string }).id;
-          if (typeof id === 'string') m.set(id, n);
-        }
-      }
-      setTaxNodeMap(m);
-      const labels = new Map<string, string>();
-      for (const [id, n] of m) {
-        const label = (n as { label?: string }).label;
-        if (typeof label === 'string') labels.set(id, label);
-      }
-      setNodeLabels(labels);
-    } catch (err) {
-      getGlobalRecorder()?.record({
-        type: 'system.error', component: 'diagnostics-window', level: 'warn',
-        message: 'Failed to load taxonomy files for node lookup',
-        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-      });
-    }
-    try {
-      const registryRaw = await api.loadPolicyRegistry() as { policies?: { id: string; action: string; source_povs: string[]; member_count: number }[] } | null;
-      const policies = registryRaw?.policies;
-      if (!signal.cancelled && Array.isArray(policies)) {
-        const pm = new Map<string, { id: string; action: string; source_povs: string[]; member_count: number }>();
-        for (const p of policies) pm.set(p.id, p);
-        setPolicyMap(pm);
-      }
-    } catch (err) {
-      getGlobalRecorder()?.record({
-        type: 'system.error', component: 'diagnostics-window', level: 'warn',
-        message: 'Failed to load policy registry',
-        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-      });
-    }
-    try {
-      const raw = await api.loadEdges() as { edges?: TaxRefEdge[] } | null;
-      if (signal.cancelled) return;
-      if (raw && Array.isArray(raw.edges)) setAllEdges(raw.edges);
-    } catch (err) {
-      getGlobalRecorder()?.record({
-        type: 'system.error', component: 'diagnostics-window', level: 'warn',
-        message: 'Failed to load edges data',
-        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-      });
-    }
+    const tax = await loadTaxNodesData(signal);
+    if (signal.cancelled) return;
+    if (tax) { setTaxNodeMap(tax.nodeMap); setNodeLabels(tax.labels); }
+    const pm = await loadPolicyData(signal);
+    if (pm) setPolicyMap(pm);
+    const edges = await loadEdgesData(signal);
+    if (edges) setAllEdges(edges);
   }, []);
 
   // Initial load — no ref guard; the cancellation signal handles StrictMode double-invocation
@@ -214,62 +493,9 @@ export function useDiagnosticsState(initialData?: Record<string, unknown>) {
     const debateId = params.get('debateId');
     if (!debateId) return;
     let cancelled = false;
-    void (async () => {
-      try {
-        const raw = await api.loadDebateSession(debateId);
-        if (cancelled) return;
-        if (!raw) {
-          setDebate(null);
-          setDeepLinkError(`Debate not found: ${debateId}`);
-          getGlobalRecorder()?.record({
-            type: 'system.error', component: 'diagnostics-deep-link', level: 'warn',
-            message: `Deep-link debate not found: ${debateId}`,
-          });
-          return;
-        }
-        const session = raw as DebateSession;
-        setDebate(session);
-
-        const entryParam = params.get('entry');
-        if (entryParam != null) {
-          const idx = parseInt(entryParam, 10);
-          if (!isNaN(idx) && idx >= 0 && idx < session.transcript.length) {
-            setSelectedEntry(session.transcript[idx].id);
-            setLocalOverride(true);
-            setOverviewTab('transcript');
-          } else {
-            getGlobalRecorder()?.record({
-              type: 'system.error', component: 'diagnostics-deep-link', level: 'warn',
-              message: `Deep-link entry index out of range: ${entryParam} (transcript has ${session.transcript.length} entries)`,
-            });
-          }
-        }
-
-        const tabParam = params.get('tab');
-        if (tabParam) {
-          const VALID_ENTRY_TABS: string[] = ['tax-refs', 'details', 'claims', 'evidence', 'citations', 'brief', 'plan', 'draft', 'lookahead', 'cite', 'moderator', 'exclusion', 'affect'];
-          if (VALID_ENTRY_TABS.includes(tabParam)) {
-            setEntryTab(tabParam as EntryTab);
-          }
-        }
-
-        const overviewParam = params.get('overviewTab');
-        if (overviewParam && !entryParam) {
-          const VALID_OVERVIEW_TABS: string[] = ['topic-scope', 'extraction', 'argument-network', 'commitments', 'transcript', 'convergence', 'reflections', 'gaps', 'grounding', 'lineage', 'adaptive', 'pov-progression', 'fr-context', 'prompt-diff', 'utility', 'exclusion-overview', 'emotional-register'];
-          if (VALID_OVERVIEW_TABS.includes(overviewParam)) {
-            setOverviewTab(overviewParam as OverviewTab);
-          }
-        }
-      } catch (err) {
-        if (cancelled) return;
-        setDeepLinkError(`Failed to load debate: ${String(err)}`);
-        getGlobalRecorder()?.record({
-          type: 'system.error', component: 'diagnostics-deep-link', level: 'error',
-          message: `Failed to load deep-linked debate: ${debateId}`,
-          error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-        });
-      }
-    })();
+    void applyDeepLink(debateId, params, () => cancelled, {
+      setDebate, setDeepLinkError, setSelectedEntry, setLocalOverride, setOverviewTab, setEntryTab,
+    });
     return () => { cancelled = true; };
   }, []);
 
@@ -416,106 +642,15 @@ export function useDiagnosticsState(initialData?: Record<string, unknown>) {
 
   const sq = searchQuery.trim();
 
-  const matchCount = useMemo(() => {
-    if (!sq || !debate) return 0;
-    let count = 0;
-    if (an) {
-      for (const n of an.nodes) count += countMatches(n.id, sq) + countMatches(n.text, sq) + countMatches(n.speaker, sq);
-      for (const e of an.edges) count += countMatches(e.source, sq) + countMatches(e.warrant || '', sq) + countMatches(e.scheme || '', sq);
-    }
-    for (const e of debate.transcript) count += countMatches(e.content, sq);
-    if (diag) {
-      count += countMatches(diag.prompt || '', sq);
-      count += countMatches(diag.raw_response || '', sq);
-      count += countMatches(diag.taxonomy_context || '', sq);
-      count += countMatches(diag.commitment_context || '', sq);
-      if (diag.extracted_claims) {
-        for (const c of diag.extracted_claims.accepted) count += countMatches(c.text, sq);
-        for (const c of diag.extracted_claims.rejected) count += countMatches(c.text, sq);
-      }
-      const stages = (diag as unknown as Record<string, unknown>).stage_diagnostics as { work_product?: Record<string, unknown> }[] | undefined;
-      if (stages) {
-        for (const stage of stages) {
-          if (!stage.work_product) continue;
-          count += countMatchesInValue(stage.work_product, sq);
-        }
-      }
-    }
-    return count;
-  }, [sq, debate, an, diag]);
+  const matchCount = useMemo(() => computeMatchCount(sq, debate, an, diag), [sq, debate, an, diag]);
 
   // Keyboard navigation
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
-        e.preventDefault();
-        searchInputRef.current?.focus();
-        searchInputRef.current?.select();
-        return;
-      }
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        e.preventDefault();
-        const dir = e.key === 'ArrowRight' ? 1 : -1;
-        if (entry) {
-          const ENTRY_TABS: EntryTab[] = ['moderator', 'details', 'brief', 'plan', 'evidence', 'citations', 'draft', 'lookahead', 'cite', 'claims', 'exclusion', 'affect', 'tax-refs'];
-          const idx = ENTRY_TABS.indexOf(entryTab);
-          const next = idx + dir;
-          if (next >= 0 && next < ENTRY_TABS.length) setEntryTab(ENTRY_TABS[next]);
-        } else if (debate) {
-          const OVERVIEW_TABS: OverviewTab[] = ['topic-scope', 'argument-network', 'commitments', 'transcript', 'extraction', 'convergence', 'reflections', 'gaps', 'grounding', 'lineage', 'adaptive', 'pov-progression', 'fr-context', 'prompt-diff', 'utility', 'exclusion-overview', 'emotional-register'];
-          const visible = OVERVIEW_TABS.filter(id => {
-            if (id === 'topic-scope') return !!debate.topic?.scope;
-            if (id === 'argument-network' || id === 'utility') return !!(an && an.nodes.length > 0);
-            if (id === 'commitments') return !!(commitments && Object.keys(commitments).length > 0);
-            if (id === 'convergence') return !!(debate.convergence_signals && debate.convergence_signals.length > 0);
-            if (id === 'reflections') return debate.transcript.some(e => e.type === 'reflection');
-            if (id === 'gaps') return !!(debate.taxonomy_gap_analysis || (debate.gap_injections && debate.gap_injections.length > 0) || (debate.cross_cutting_proposals && debate.cross_cutting_proposals.length > 0));
-            if (id === 'grounding') return debate.transcript.some(e => e.taxonomy_refs && e.taxonomy_refs.length > 0);
-            return true;
-          });
-          const idx = visible.indexOf(overviewTab);
-          const next = idx + dir;
-          if (next >= 0 && next < visible.length) setOverviewTab(visible[next]);
-        }
-        return;
-      }
-
-      if (e.key === 'ArrowUp' || e.key === 'ArrowDown' ||
-          e.key === 'p' || e.key === 'P' || e.key === 'n' || e.key === 'N') {
-        if (!debate) return;
-        e.preventDefault();
-        const dir = (e.key === 'ArrowDown' || e.key === 'n' || e.key === 'N') ? 1 : -1;
-
-        if (!entry && effectiveOverviewTab === 'argument-network' && an && an.nodes.length > 0) {
-          const nodeIds = an.nodes.map(n => n.id);
-          const curIdx = focusedNodeId ? nodeIds.indexOf(focusedNodeId) : -1;
-          if (curIdx < 0) {
-            setFocusedNodeId(nodeIds[dir === 1 ? 0 : nodeIds.length - 1]);
-          } else {
-            const nextIdx = curIdx + dir;
-            if (nextIdx >= 0 && nextIdx < nodeIds.length) setFocusedNodeId(nodeIds[nextIdx]);
-          }
-          return;
-        }
-
-        if (!entry) {
-          if (dir === 1 && debate.transcript.length > 0) {
-            setSelectedEntry(debate.transcript[0].id);
-            setLocalOverride(true);
-          }
-          return;
-        }
-        const curIdx = debate.transcript.findIndex(t => t.id === entry.id);
-        const nextIdx = curIdx + dir;
-        if (nextIdx >= 0 && nextIdx < debate.transcript.length) {
-          setSelectedEntry(debate.transcript[nextIdx].id);
-          setLocalOverride(true);
-        }
-      }
-    };
+    const handler = (e: KeyboardEvent) => handleDiagnosticsKeydown(e, {
+      searchInputRef, entry, entryTab, overviewTab, effectiveOverviewTab,
+      debate, an, commitments, focusedNodeId,
+      setEntryTab, setOverviewTab, setSelectedEntry, setLocalOverride, setFocusedNodeId,
+    });
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [debate, entry, entryTab, overviewTab, effectiveOverviewTab, an, commitments, focusedNodeId]);


### PR DESCRIPTION
Batch B4 of t/1909 (parent t/1848 debt-reduction). Behavior-preserving ADR-007 line-slice decomposition of the 8 heaviest remaining over-threshold files in debate-diagnostics:

| file | worst before → after |
|---|---|
| OverviewTabRouter.tsx | 53 → ≤15 |
| DiagnosticsChatSidebar.tsx | 52 → ≤15 |
| OverviewView.tsx | 44 → ≤15 |
| useDiagnosticsState.ts | 43 → ≤15 |
| ModeratorTab.tsx | 42 → ≤15 |
| EvidenceTab.tsx | 37 → ≤15 |
| INodeRow.tsx | 34 → ≤15 |
| EntryDetailRouter.parts.tsx | 28 → ≤15 |

Verbatim body moves into module-level helpers / props-only sub-components; hooks kept unconditional; ADR-003 recorder catch-sites preserved. Removed one now-redundant no-explicit-any disable orphaned by the split.

**Verify (worktree off origin/main):** renderer tsc 0 errors, eslint 0 errors, **0 residual complexity on all 8 files**, depcruise clean (no violations), vite build clean, **464 colocated tests pass**. 0 inline-style regression (85 pre-existing dynamics unchanged). Shared `--max-warnings` gate NOT ratcheted.

Scope after B4: 49 → ~20 complexity warnings (B5 tail remains). Recovered + verified after a session-sleep interruption of the subagent run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)