### PR TITLE
ci: skip redundant plain test-run for taxonomy-editor (~3.5min/run) (t/1988)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,12 @@ jobs:
         run: npx tsc --noEmit -p tsconfig.main.json
 
       - name: Test
+        # Skip for taxonomy-editor: its "Test with coverage" step below already
+        # runs the full vitest suite (and enforces coverage thresholds), so the
+        # plain run was pure duplication (~3.5 min wasted per CI run, t/1988).
+        # Mutually exclusive with that step: taxonomy-editor → coverage-only;
+        # the other apps → plain run only (they have no coverage step).
+        if: matrix.app != 'taxonomy-editor'
         working-directory: ${{ matrix.app }}
         run: npm test --if-present
 


### PR DESCRIPTION
ci: skip redundant plain test-run for taxonomy-editor (~3.5min/run) (t/1988)

The taxonomy-editor test-electron leg ran its full vitest suite TWICE per CI
run: the `Test` step (`npm test` -> `vitest run`, ~3m35s) then `Test with
coverage` (`vitest run --coverage`, ~4m8s) — the same suite, plain then
instrumented. Profiling (job 90857490457) showed coverage instrumentation adds
only ~33s; the duplicate run was the cost.

Gate the plain `Test` step on `matrix.app != 'taxonomy-editor'` so the two steps
are mutually exclusive: taxonomy-editor runs coverage-only (still full suite +
threshold enforcement), other apps run the plain step (no coverage step). Cuts
the leg ~10m51s -> ~7m15s (~33%), zero signal loss — no test dropped, no
threshold changed.

Self-cert: /trivial-change (signal-preserving CI de-dup, single-step conditional).

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
