### PR TITLE
refactor(diag): decompose B5 complexity — 13 tail files to ≤15 (t/1909, closes scope)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/WhatIfSection.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/WhatIfSection.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { useState, useMemo } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { useFlag } from '../../../hooks/useFeatureFlags';
 import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
@@ -87,67 +88,116 @@ export function WhatIfSection({ nodes, edges }: { nodes: ArgumentNetworkNode[]; 
 
       {active && (
         <div className="whatif-node-list">
-          {scoredNodes.map(n => {
-            const origBase = n.base_strength ?? 0.5;
-            const currentBase = overrides[n.id] ?? origBase;
-            const isOverridden = overrides[n.id] != null;
-            const origComputed = originalStrengths[n.id] ?? origBase;
-            const whatIfComputed = whatIfStrengths?.[n.id] ?? origComputed;
-            const delta = whatIfStrengths ? whatIfComputed - origComputed : 0;
-
-            return (
-              <div key={n.id} className={`whatif-node ${isOverridden ? 'whatif-node-modified' : ''}`}>
-                <div className="whatif-node-header">
-                  <span className="diag-an-id">{n.id}</span>
-                  <span className="diag-an-speaker">({speakerLabel(n.speaker)})</span>
-                  {isOverridden && (
-                    <button
-                      className="whatif-node-reset-btn"
-                      onClick={() => setOverrides(prev => { const next = { ...prev }; delete next[n.id]; return next; })}
-                      title="Reset this node"
-                    >
-                      x
-                    </button>
-                  )}
-                </div>
-                <div className="whatif-node-text">{n.text.slice(0, 100)}{n.text.length > 100 ? '...' : ''}</div>
-                <div className="whatif-slider-row">
-                  <span className="diag-k">Intrinsic:</span>
-                  <input
-                    type="range"
-                    min={0}
-                    max={1}
-                    step={0.05}
-                    value={currentBase}
-                    onChange={e => handleSliderChange(n.id, Number(e.target.value))}
-                    className="whatif-slider"
-                    title={`Intrinsic strength: ${currentBase.toFixed(2)} (original: ${origBase.toFixed(2)})`}
-                  />
-                  <span className="whatif-slider-value">{currentBase.toFixed(2)}</span>
-                  {isOverridden && (
-                    <span className="whatif-orig-value">(was {origBase.toFixed(2)})</span>
-                  )}
-                </div>
-                {whatIfStrengths && (
-                  <div className="whatif-result-row">
-                    <span className="diag-k">Dialectical:</span>
-                    <span className="diag-v">{origComputed.toFixed(2)}</span>
-                    <span className="diag-qbaf-arrow">{'→'}</span>
-                    <span className={`whatif-new-value ${Math.abs(delta) > 0.01 ? (delta > 0 ? 'whatif-up' : 'whatif-down') : ''}`}>
-                      {whatIfComputed.toFixed(2)}
-                    </span>
-                    {Math.abs(delta) > 0.01 && (
-                      <span className={`whatif-delta ${delta > 0 ? 'whatif-delta-up' : 'whatif-delta-down'}`}>
-                        {delta > 0 ? '↑' : '↓'} {delta > 0 ? '+' : ''}{delta.toFixed(2)}
-                      </span>
-                    )}
-                  </div>
-                )}
-              </div>
-            );
-          })}
+          {scoredNodes.map(n => (
+            <WhatIfNodeRow
+              key={n.id}
+              n={n}
+              overrides={overrides}
+              originalStrengths={originalStrengths}
+              whatIfStrengths={whatIfStrengths}
+              handleSliderChange={handleSliderChange}
+              setOverrides={setOverrides}
+            />
+          ))}
         </div>
       )}
     </CollapsibleSection>
+  );
+}
+
+/** Single node row within What-If Mode: intrinsic slider + dialectical result. */
+function WhatIfNodeRow({
+  n,
+  overrides,
+  originalStrengths,
+  whatIfStrengths,
+  handleSliderChange,
+  setOverrides,
+}: {
+  n: ArgumentNetworkNode;
+  overrides: Record<string, number>;
+  originalStrengths: Record<string, number>;
+  whatIfStrengths: Record<string, number> | null;
+  handleSliderChange: (nodeId: string, value: number) => void;
+  setOverrides: Dispatch<SetStateAction<Record<string, number>>>;
+}) {
+  const origBase = n.base_strength ?? 0.5;
+  const currentBase = overrides[n.id] ?? origBase;
+  const isOverridden = overrides[n.id] != null;
+  const origComputed = originalStrengths[n.id] ?? origBase;
+  const whatIfComputed = whatIfStrengths?.[n.id] ?? origComputed;
+  const delta = whatIfStrengths ? whatIfComputed - origComputed : 0;
+
+  return (
+    <div key={n.id} className={`whatif-node ${isOverridden ? 'whatif-node-modified' : ''}`}>
+      <div className="whatif-node-header">
+        <span className="diag-an-id">{n.id}</span>
+        <span className="diag-an-speaker">({speakerLabel(n.speaker)})</span>
+        {isOverridden && (
+          <button
+            className="whatif-node-reset-btn"
+            onClick={() => setOverrides(prev => { const next = { ...prev }; delete next[n.id]; return next; })}
+            title="Reset this node"
+          >
+            x
+          </button>
+        )}
+      </div>
+      <div className="whatif-node-text">{n.text.slice(0, 100)}{n.text.length > 100 ? '...' : ''}</div>
+      <div className="whatif-slider-row">
+        <span className="diag-k">Intrinsic:</span>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.05}
+          value={currentBase}
+          onChange={e => handleSliderChange(n.id, Number(e.target.value))}
+          className="whatif-slider"
+          title={`Intrinsic strength: ${currentBase.toFixed(2)} (original: ${origBase.toFixed(2)})`}
+        />
+        <span className="whatif-slider-value">{currentBase.toFixed(2)}</span>
+        {isOverridden && (
+          <span className="whatif-orig-value">(was {origBase.toFixed(2)})</span>
+        )}
+      </div>
+      <WhatIfResultRow
+        whatIfStrengths={whatIfStrengths}
+        origComputed={origComputed}
+        whatIfComputed={whatIfComputed}
+        delta={delta}
+      />
+    </div>
+  );
+}
+
+/** Dialectical strength before/after row; hidden until counterfactual strengths exist. */
+function WhatIfResultRow({
+  whatIfStrengths,
+  origComputed,
+  whatIfComputed,
+  delta,
+}: {
+  whatIfStrengths: Record<string, number> | null;
+  origComputed: number;
+  whatIfComputed: number;
+  delta: number;
+}) {
+  return (
+    whatIfStrengths && (
+      <div className="whatif-result-row">
+        <span className="diag-k">Dialectical:</span>
+        <span className="diag-v">{origComputed.toFixed(2)}</span>
+        <span className="diag-qbaf-arrow">{'→'}</span>
+        <span className={`whatif-new-value ${Math.abs(delta) > 0.01 ? (delta > 0 ? 'whatif-up' : 'whatif-down') : ''}`}>
+          {whatIfComputed.toFixed(2)}
+        </span>
+        {Math.abs(delta) > 0.01 && (
+          <span className={`whatif-delta ${delta > 0 ? 'whatif-delta-up' : 'whatif-delta-down'}`}>
+            {delta > 0 ? '↑' : '↓'} {delta > 0 ? '+' : ''}{delta.toFixed(2)}
+          </span>
+        )}
+      </div>
+    )
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
@@ -18,6 +18,8 @@ import { OverviewTabRouter } from './OverviewTabRouter';
 import { EntryDetailRouter } from './EntryDetailRouter';
 import { CopyLinkButton } from '../../shared/CopyLinkButton';
 import type { OverviewTab } from './types';
+import type { DebateSession } from '../../../types/debate';
+import type { RefObject } from 'react';
 import './DiagnosticsWindow.css';
 
 // ---------------------------------------------------------------------------
@@ -232,6 +234,98 @@ function HelpContent() {
 }
 
 // ---------------------------------------------------------------------------
+// Sidebar tab model + per-section builders (split to keep each ≤ complexity 15)
+// ---------------------------------------------------------------------------
+
+type SidebarTab = { id: OverviewTab; label: string; badge?: string; visible: boolean };
+type SidebarSection = { header: string; tabs: SidebarTab[] };
+
+function buildDebateSection(debate: DebateSession, hasAn: boolean, hasCommitments: boolean): SidebarSection {
+  return { header: 'DEBATE', tabs: [
+    { id: 'topic-scope', label: 'Topic Scope', visible: !!debate.topic?.scope },
+    { id: 'argument-network', label: 'Arg Net', visible: hasAn },
+    { id: 'commitments', label: 'Commitments', visible: hasCommitments },
+    { id: 'transcript', label: `Transcript (${debate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length} stmts / ${debate.transcript.length} total)`, visible: true },
+    { id: 'convergence', label: `Convergence (${debate.convergence_signals?.length ?? 0})`, visible: !!(debate.convergence_signals && debate.convergence_signals.length > 0) },
+    { id: 'gaps', label: 'Gaps', visible: !!(debate.taxonomy_gap_analysis || (debate.gap_injections && debate.gap_injections.length > 0) || (debate.cross_cutting_proposals && debate.cross_cutting_proposals.length > 0)) },
+    { id: 'pov-progression', label: 'Perspective Progression', visible: true },
+    { id: 'reflections', label: 'Post-Debate Reflections', visible: debate.transcript.some(e => e.type === 'reflection') },
+  ]};
+}
+
+function buildEvidenceSection(debate: DebateSession, plateau: boolean): SidebarSection {
+  return { header: 'EVIDENCE', tabs: [
+    { id: 'extraction', label: 'Extraction', badge: plateau ? '⚠' : undefined, visible: true },
+    { id: 'grounding', label: `Grounding (${debate.transcript.reduce((n, e) => n + (e.taxonomy_refs?.length ? 1 : 0), 0)})`, visible: debate.transcript.some(e => e.taxonomy_refs && e.taxonomy_refs.length > 0) },
+    { id: 'lineage', label: `Lineage (${debate.topic.critique?.lineage_frame?.length ?? 0})`, visible: !!(debate.topic.critique?.lineage_frame && debate.topic.critique.lineage_frame.length > 0) },
+  ]};
+}
+
+function buildEngineSection(debate: DebateSession, hasAn: boolean): SidebarSection {
+  return { header: 'ENGINE', tabs: [
+    { id: 'utility', label: 'Agent Utility', visible: hasAn },
+    { id: 'exclusion-overview', label: 'Exclusion Guard', visible: true },
+    { id: 'emotional-register', label: 'Emotional Register', visible: true },
+    { id: 'adaptive', label: 'Adaptive', visible: !!(debate as unknown as Record<string, unknown>).adaptive_staging_diagnostics },
+    { id: 'prompt-diff', label: 'Prompt Diff', visible: true },
+    { id: 'fr-context', label: 'Flight Recorder', visible: true },
+  ]};
+}
+
+// ---------------------------------------------------------------------------
+// DiagnosticsHeader — header bar (extracted to keep DiagnosticsWindow ≤ complexity 15)
+// ---------------------------------------------------------------------------
+
+function DiagnosticsHeader({
+  debate, showHelp, setShowHelp, searchQuery, setSearchQuery, matchCount, searchInputRef,
+}: {
+  debate: DebateSession | null;
+  showHelp: boolean;
+  setShowHelp: (v: boolean) => void;
+  searchQuery: string;
+  setSearchQuery: (q: string) => void;
+  matchCount: number;
+  searchInputRef?: RefObject<HTMLInputElement | null>;
+}) {
+  return (
+    <div className="diag-window-header">
+      <h2 className="diag-window-title">Debate Diagnostics</h2>
+      {debate && (
+        <>
+          <span className="diag-window-debate-title" title={debate.title}>
+            {debate.title}
+          </span>
+          <button
+            onClick={() => { void api.clipboardWriteText(debate.id); }}
+            className="diag-window-id-suffix"
+            title={`Copy full debate ID: ${debate.id}`}
+          >…{debate.id.slice(-6)} ⧉</button>
+          <span className="diag-window-ts" title={`Session start — matches flight recorder filename`}>
+            {new Date(debate.created_at).toISOString().replace(/\.\d{3}Z$/, 'Z')}
+          </span>
+        </>
+      )}
+      {debate && !showHelp && <SearchBar query={searchQuery} setQuery={setSearchQuery} matchCount={matchCount} inputRef={searchInputRef} />}
+      {(!debate || showHelp) && <div style={{ flex: 1 }} />}
+      <button
+        onClick={() => { void triggerManualDump(); }}
+        title="Dump flight recorder to disk (Ctrl+Alt+D)"
+        className="diag-dump-btn"
+      >
+        Dump Log
+      </button>
+      <button
+        onClick={() => setShowHelp(!showHelp)}
+        className="diag-help-btn"
+        style={{ background: showHelp ? 'var(--warning, var(--warning))' : 'none', color: showHelp ? '#000' : 'var(--warning, var(--warning))' }}
+      >
+        {showHelp ? 'Close Help' : 'Help'}
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // DiagnosticsWindow — thin shell
 // ---------------------------------------------------------------------------
 
@@ -271,40 +365,15 @@ export function DiagnosticsWindow({ initialData }: { initialData?: Record<string
     <div className="diag-window-content">
 
       {/* ── Header bar ── */}
-      <div className="diag-window-header">
-        <h2 className="diag-window-title">Debate Diagnostics</h2>
-        {debate && (
-          <>
-            <span className="diag-window-debate-title" title={debate.title}>
-              {debate.title}
-            </span>
-            <button
-              onClick={() => { void api.clipboardWriteText(debate.id); }}
-              className="diag-window-id-suffix"
-              title={`Copy full debate ID: ${debate.id}`}
-            >…{debate.id.slice(-6)} ⧉</button>
-            <span className="diag-window-ts" title={`Session start — matches flight recorder filename`}>
-              {new Date(debate.created_at).toISOString().replace(/\.\d{3}Z$/, 'Z')}
-            </span>
-          </>
-        )}
-        {debate && !showHelp && <SearchBar query={searchQuery} setQuery={setSearchQuery} matchCount={matchCount} inputRef={searchInputRef} />}
-        {(!debate || showHelp) && <div style={{ flex: 1 }} />}
-        <button
-          onClick={() => { void triggerManualDump(); }}
-          title="Dump flight recorder to disk (Ctrl+Alt+D)"
-          className="diag-dump-btn"
-        >
-          Dump Log
-        </button>
-        <button
-          onClick={() => setShowHelp(!showHelp)}
-          className="diag-help-btn"
-          style={{ background: showHelp ? 'var(--warning, var(--warning))' : 'none', color: showHelp ? '#000' : 'var(--warning, var(--warning))' }}
-        >
-          {showHelp ? 'Close Help' : 'Help'}
-        </button>
-      </div>
+      <DiagnosticsHeader
+        debate={debate}
+        showHelp={showHelp}
+        setShowHelp={setShowHelp}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        matchCount={matchCount}
+        searchInputRef={searchInputRef}
+      />
 
       {showHelp && <HelpContent />}
       {!debate && !showHelp && (
@@ -327,31 +396,10 @@ export function DiagnosticsWindow({ initialData }: { initialData?: Record<string
             const hasAn = !!(an && an.nodes.length > 0);
             const hasCommitments = !!(commitments && Object.keys(commitments).length > 0);
             const plateau = debate.extraction_summary?.plateau_detected === true;
-            type SidebarTab = { id: OverviewTab; label: string; badge?: string; visible: boolean };
-            const sections: { header: string; tabs: SidebarTab[] }[] = [
-              { header: 'DEBATE', tabs: [
-                { id: 'topic-scope', label: 'Topic Scope', visible: !!debate.topic?.scope },
-                { id: 'argument-network', label: 'Arg Net', visible: hasAn },
-                { id: 'commitments', label: 'Commitments', visible: hasCommitments },
-                { id: 'transcript', label: `Transcript (${debate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length} stmts / ${debate.transcript.length} total)`, visible: true },
-                { id: 'convergence', label: `Convergence (${debate.convergence_signals?.length ?? 0})`, visible: !!(debate.convergence_signals && debate.convergence_signals.length > 0) },
-                { id: 'gaps', label: 'Gaps', visible: !!(debate.taxonomy_gap_analysis || (debate.gap_injections && debate.gap_injections.length > 0) || (debate.cross_cutting_proposals && debate.cross_cutting_proposals.length > 0)) },
-                { id: 'pov-progression', label: 'Perspective Progression', visible: true },
-                { id: 'reflections', label: 'Post-Debate Reflections', visible: debate.transcript.some(e => e.type === 'reflection') },
-              ]},
-              { header: 'EVIDENCE', tabs: [
-                { id: 'extraction', label: 'Extraction', badge: plateau ? '⚠' : undefined, visible: true },
-                { id: 'grounding', label: `Grounding (${debate.transcript.reduce((n, e) => n + (e.taxonomy_refs?.length ? 1 : 0), 0)})`, visible: debate.transcript.some(e => e.taxonomy_refs && e.taxonomy_refs.length > 0) },
-                { id: 'lineage', label: `Lineage (${debate.topic.critique?.lineage_frame?.length ?? 0})`, visible: !!(debate.topic.critique?.lineage_frame && debate.topic.critique.lineage_frame.length > 0) },
-              ]},
-              { header: 'ENGINE', tabs: [
-                { id: 'utility', label: 'Agent Utility', visible: hasAn },
-                { id: 'exclusion-overview', label: 'Exclusion Guard', visible: true },
-                { id: 'emotional-register', label: 'Emotional Register', visible: true },
-                { id: 'adaptive', label: 'Adaptive', visible: !!(debate as unknown as Record<string, unknown>).adaptive_staging_diagnostics },
-                { id: 'prompt-diff', label: 'Prompt Diff', visible: true },
-                { id: 'fr-context', label: 'Flight Recorder', visible: true },
-              ]},
+            const sections: SidebarSection[] = [
+              buildDebateSection(debate, hasAn, hasCommitments),
+              buildEvidenceSection(debate, plateau),
+              buildEngineSection(debate, hasAn),
             ];
             return (
               <div className="diag-tab-sidebar">

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/AffectTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/AffectTab.tsx
@@ -36,6 +36,50 @@ const CATEGORY_LABELS: Record<AffectCategory, string> = {
   empathy: 'Empathy',
 };
 
+interface AppropriatenessPanelProps {
+  appropriateness: number | null;
+  profile: NonNullable<ReturnType<typeof computeAffectProfile>>;
+  phase: ReturnType<typeof getDebatePhase>;
+}
+
+function AppropriatenessPanel({ appropriateness, profile, phase }: AppropriatenessPanelProps) {
+  const approColor = appropriateness == null ? 'var(--text-muted)'
+    : appropriateness >= 0.7 ? 'var(--success)'
+    : appropriateness >= 0.4 ? 'var(--warning)'
+    : 'var(--danger)';
+
+  return (
+    <div style={{ padding: '10px 12px', borderRadius: 6, background: 'var(--bg-primary)', borderLeft: `3px solid ${approColor}` }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+        <span style={{ fontWeight: 600, fontSize: '0.72rem' }}>Phase Appropriateness</span>
+        <span style={{ fontSize: '0.85rem', fontWeight: 700, fontVariantNumeric: 'tabular-nums', color: approColor }}>
+          {appropriateness != null ? appropriateness.toFixed(3) : 'n/a'}
+        </span>
+        {appropriateness != null && appropriateness < 0.4 && profile.outrage > 0.5 && phase === 'concluding' && (
+          <span style={{
+            padding: '1px 6px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600,
+            background: 'rgba(220,38,38,0.15)', color: 'var(--danger)',
+          }}>concluding outrage warning</span>
+        )}
+      </div>
+      {appropriateness != null && (
+        <div style={{ height: 8, background: 'var(--bg-secondary, #222)', borderRadius: 4, overflow: 'hidden' }}>
+          <div style={{
+            width: `${appropriateness * 100}%`,
+            height: '100%',
+            background: approColor,
+            borderRadius: 4,
+            transition: 'width 0.3s ease',
+          }} />
+        </div>
+      )}
+      <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 4 }}>
+        1.0 = on-baseline, 0.0 = {'≥'}35% mean deviation from {phase}-phase expected profile.
+      </div>
+    </div>
+  );
+}
+
 export function AffectTab({ entry, debate, entryIdx }: AffectTabProps) {
   const content = typeof entry.content === 'string' ? entry.content : '';
 
@@ -58,11 +102,6 @@ export function AffectTab({ entry, debate, entryIdx }: AffectTabProps) {
       </div>
     );
   }
-
-  const approColor = appropriateness == null ? 'var(--text-muted)'
-    : appropriateness >= 0.7 ? 'var(--success)'
-    : appropriateness >= 0.4 ? 'var(--warning)'
-    : 'var(--danger)';
 
   return (
     <div style={{ padding: '8px 10px', flex: 1, minHeight: 200, overflowY: 'auto' }}>
@@ -153,34 +192,7 @@ export function AffectTab({ entry, debate, entryIdx }: AffectTabProps) {
       </div>
 
       {/* Appropriateness */}
-      <div style={{ padding: '10px 12px', borderRadius: 6, background: 'var(--bg-primary)', borderLeft: `3px solid ${approColor}` }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
-          <span style={{ fontWeight: 600, fontSize: '0.72rem' }}>Phase Appropriateness</span>
-          <span style={{ fontSize: '0.85rem', fontWeight: 700, fontVariantNumeric: 'tabular-nums', color: approColor }}>
-            {appropriateness != null ? appropriateness.toFixed(3) : 'n/a'}
-          </span>
-          {appropriateness != null && appropriateness < 0.4 && profile.outrage > 0.5 && phase === 'concluding' && (
-            <span style={{
-              padding: '1px 6px', borderRadius: 3, fontSize: 'var(--text-2xs)', fontWeight: 600,
-              background: 'rgba(220,38,38,0.15)', color: 'var(--danger)',
-            }}>concluding outrage warning</span>
-          )}
-        </div>
-        {appropriateness != null && (
-          <div style={{ height: 8, background: 'var(--bg-secondary, #222)', borderRadius: 4, overflow: 'hidden' }}>
-            <div style={{
-              width: `${appropriateness * 100}%`,
-              height: '100%',
-              background: approColor,
-              borderRadius: 4,
-              transition: 'width 0.3s ease',
-            }} />
-          </div>
-        )}
-        <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 4 }}>
-          1.0 = on-baseline, 0.0 = {'≥'}35% mean deviation from {phase}-phase expected profile.
-        </div>
-      </div>
+      <AppropriatenessPanel appropriateness={appropriateness} profile={profile} phase={phase} />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/BriefTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/BriefTab.tsx
@@ -9,6 +9,260 @@ import { classifyHintTarget, HINT_TARGET_STYLE, ArtifactBlock } from '../shared'
 import { TaxonomyRefDetail, type TaxRefNode, type TaxRefEdge } from '../../../taxonomy/TaxonomyRefDetail';
 import './BriefTab.css';
 
+// Shared turn-score color ramp (used in both the header and footer of the detailed validation box).
+function turnScoreColor(turnScore: number): string {
+  return turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)';
+}
+
+// --- Per-metric grounding badges (each guards its own null case) ---
+function ScoreBadge({ sc }: { sc: number | null | undefined }) {
+  if (sc == null) return null;
+  const scColor = sc >= 0.45 ? 'var(--success)' : sc >= 0.30 ? 'var(--warning)' : 'var(--danger)';
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic scColor
+    <span style={{ fontWeight: 600, color: scColor, marginLeft: 6 }}>{sc.toFixed(2)}</span>
+  );
+}
+
+function ConfBadge({ conf }: { conf: number | undefined }) {
+  if (conf == null) return null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic conf coloring
+    <span style={{ marginLeft: 4, fontWeight: 600, color: conf >= 0.70 ? 'var(--success)' : conf >= 0.50 ? 'var(--text-secondary)' : 'var(--warning)', background: conf < 0.50 ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : undefined, padding: conf < 0.50 ? '0 3px' : undefined, borderRadius: 2 }}>conf:{conf.toFixed(2)}</span>
+  );
+}
+
+function PrioBadge({ prio }: { prio: number | undefined }) {
+  if (prio == null) return null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic prio coloring
+    <span style={{ marginLeft: 4, fontWeight: 600, color: prio >= 4 ? 'var(--text-secondary)' : 'var(--text-muted)' }}>P{prio}/5</span>
+  );
+}
+
+function OperBadge({ oper }: { oper: number | undefined }) {
+  if (oper == null) return null;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic oper coloring
+    <span style={{ marginLeft: 4, fontWeight: 600, color: oper >= 4 ? 'var(--text-secondary)' : 'var(--text-muted)' }}>op:{oper}/5</span>
+  );
+}
+
+interface GroundingItemProps {
+  g: { node_id: string; why: string };
+  baseColor: string;
+  entry: DebateSession['transcript'][number];
+  nodeWeights: Map<string, { confidence?: number; priority?: number; operationality?: number; category?: string }>;
+  taxNodeMap: Map<string, Record<string, unknown>>;
+  selectedTaxRefId: string | null;
+  setSelectedTaxRefId: (id: string | null) => void;
+}
+
+// One POV grounding row — line 1: id + label + scores; line 2: justification/applicability.
+function GroundingItem({ g, baseColor, entry, nodeWeights, taxNodeMap, selectedTaxRefId, setSelectedTaxRefId }: GroundingItemProps) {
+  const ref = entry.taxonomy_refs?.find(r => r.node_id === g.node_id);
+  const sc = ref?.relevance_score;
+  const tw = nodeWeights.get(g.node_id);
+  const conf = (g as Record<string, unknown>).confidence as number | undefined ?? tw?.confidence;
+  const prio = (g as Record<string, unknown>).priority as number | undefined ?? tw?.priority;
+  const oper = (g as Record<string, unknown>).operationality as number | undefined ?? tw?.operationality;
+  const label = (taxNodeMap.get(g.node_id) as { label?: string } | undefined)?.label;
+  return (
+    // eslint-disable-next-line local/no-inline-style -- dynamic baseColor
+    <li style={{ fontSize: 'var(--text-2xs)', color: baseColor, marginBottom: 3 }}>
+      <div>
+        <button onClick={() => setSelectedTaxRefId(selectedTaxRefId === g.node_id ? null : g.node_id)} className="brief-taxref-btn">{g.node_id}</button>
+        {label && <span className="brief-grounding-label">{label}</span>}
+        <ScoreBadge sc={sc} />
+        <ConfBadge conf={conf} />
+        <PrioBadge prio={prio} />
+        <OperBadge oper={oper} />
+      </div>
+      {g.why && <div className="brief-grounding-why">{g.why}</div>}
+    </li>
+  );
+}
+
+// --- Document Claims to Engage table ---
+function DocumentClaimsSection({ workProduct, renderGrounding }: {
+  workProduct: Record<string, unknown>;
+  renderGrounding: (grounding: { node_id: string; why: string }[], baseColor: string) => React.ReactNode;
+}) {
+  const claims = workProduct.document_claims_to_engage as { d_id: string; claim: string; stance: string; why: string; grounding?: { node_id: string; why: string }[] }[] | undefined;
+  if (!(Array.isArray(claims) && claims.length > 0)) return null;
+  return (
+    <details open><summary className="brief-summary">Document Claims to Engage</summary>
+      <table className="brief-table">
+        <thead>
+          <tr className="brief-thead-row">
+            <th className="brief-th brief-th-w60">D-ID</th>
+            <th className="brief-th brief-th-w70">Stance</th>
+            <th className="brief-th">Claim &amp; Rationale</th>
+          </tr>
+        </thead>
+        <tbody>
+          {claims.map((dc, i) => {
+            const stanceColor = dc.stance === 'accept' ? 'var(--success)' : dc.stance === 'challenge' ? 'var(--danger)' : 'var(--warning)';
+            return (
+              <Fragment key={i}>
+                {/* eslint-disable-next-line local/no-inline-style -- dynamic borderBottom */}
+                <tr style={{ borderBottom: Array.isArray(dc.grounding) && dc.grounding.length > 0 ? 'none' : '1px solid var(--border)' }}>
+                  <td className="brief-td-did">{dc.d_id}</td>
+                  {/* eslint-disable-next-line local/no-inline-style -- dynamic stanceColor */}
+                  <td style={{ padding: '3px 6px', verticalAlign: 'top', fontWeight: 600, color: stanceColor, textTransform: 'uppercase', fontSize: 'var(--text-2xs)' }}>{dc.stance}</td>
+                  <td className="brief-td">
+                    <Highlight text={dc.claim} />
+                    <div className="brief-td-why"><Highlight text={dc.why} /></div>
+                  </td>
+                </tr>
+                {Array.isArray(dc.grounding) && dc.grounding.length > 0 && (
+                  <tr className="brief-tr-border">
+                    <td colSpan={3} className="brief-td-grounding">
+                      {renderGrounding(dc.grounding, 'var(--text-muted)')}
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </details>
+  );
+}
+
+// --- Validation score box (detailed process-reward breakdown when dims present) ---
+function DetailedValidationScore({ turnScore, dims, judgeUsed }: {
+  turnScore: number;
+  dims: TurnValidationTrail['final']['dimensions'];
+  judgeUsed: boolean;
+}) {
+  const stageA =
+    0.4 * (dims.schema.pass ? 1 : 0) +
+    0.3 * (dims.grounding.pass ? 1 : 0) +
+    0.2 * (dims.advancement.pass ? 1 : 0) +
+    0.1 * (dims.clarifies.pass ? 1 : 0);
+  const judgeQ = stageA > 0
+    ? Math.max(0, Math.min(1, (turnScore - 0.4 * stageA) / 0.6))
+    : 0.7;
+  const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
+  const dimColor = (pass: boolean) => pass ? 'var(--success)' : 'var(--danger)';
+  return (
+    <div className="brief-valbox">
+      <div className="brief-valbox-title">
+        Validation Score:{' '}
+        {/* eslint-disable-next-line local/no-inline-style -- mono spread + dynamic score color */}
+        <span style={{ ...mono, color: turnScoreColor(turnScore) }}>
+          {turnScore.toFixed(2)}
+        </span>
+      </div>
+      <div className="brief-valdims">
+        {/* eslint-disable-next-line local/no-inline-style -- dynamic dimColor + mono var */}
+        <span><span style={{ color: dimColor(dims.schema.pass) }}>{'●'}</span> schema {'×'}0.4 = <strong style={mono}>{(0.4 * (dims.schema.pass ? 1 : 0)).toFixed(2)}</strong></span>
+        {/* eslint-disable-next-line local/no-inline-style -- dynamic dimColor + mono var */}
+        <span><span style={{ color: dimColor(dims.grounding.pass) }}>{'●'}</span> grounding {'×'}0.3 = <strong style={mono}>{(0.3 * (dims.grounding.pass ? 1 : 0)).toFixed(2)}</strong></span>
+        {/* eslint-disable-next-line local/no-inline-style -- dynamic dimColor + mono var */}
+        <span><span style={{ color: dimColor(dims.advancement.pass) }}>{'●'}</span> advancement {'×'}0.2 = <strong style={mono}>{(0.2 * (dims.advancement.pass ? 1 : 0)).toFixed(2)}</strong></span>
+        {/* eslint-disable-next-line local/no-inline-style -- dynamic dimColor + mono var */}
+        <span><span style={{ color: dimColor(dims.clarifies.pass) }}>{'●'}</span> clarifies {'×'}0.1 = <strong style={mono}>{(0.1 * (dims.clarifies.pass ? 1 : 0)).toFixed(2)}</strong></span>
+      </div>
+      <div className="brief-valfooter">
+        {/* eslint-disable-next-line local/no-inline-style -- mono var */}
+        <span>Stage A: <strong style={mono}>{stageA.toFixed(2)}</strong> <span className="brief-muted">{'×'}0.4 = {(0.4 * stageA).toFixed(2)}</span></span>
+        {/* eslint-disable-next-line local/no-inline-style -- mono var */}
+        <span>Judge: <strong style={mono}>{judgeQ.toFixed(2)}</strong>{!judgeUsed && <span className="brief-muted"> (default)</span>} <span className="brief-muted">{'×'}0.6 = {(0.6 * judgeQ).toFixed(2)}</span></span>
+        {/* eslint-disable-next-line local/no-inline-style -- mono spread + dynamic score color */}
+        <span>Total: <strong style={{ ...mono, color: turnScoreColor(turnScore) }}>{turnScore.toFixed(2)}</strong></span>
+      </div>
+    </div>
+  );
+}
+
+function SimpleValidationScore({ valData }: { valData: { pass: boolean; hints: string[] } | undefined }) {
+  return (
+    <div className="brief-valscore">
+      Validation Score:{' '}
+      {valData ? (
+        // eslint-disable-next-line local/no-inline-style -- dynamic pass/fail color
+        <span style={{ color: valData.pass ? 'var(--success)' : 'var(--danger)' }}>
+          {valData.pass ? 'Pass' : 'Fail'}
+        </span>
+      ) : (
+        <span className="brief-muted">{'—'}</span>
+      )}
+    </div>
+  );
+}
+
+function ValidationScoreSection({ turnScore, dims, judgeUsed, valData }: {
+  turnScore: number | undefined;
+  dims: TurnValidationTrail['final']['dimensions'] | undefined;
+  judgeUsed: boolean;
+  valData: { pass: boolean; hints: string[] } | undefined;
+}) {
+  if (turnScore != null && dims) {
+    return <DetailedValidationScore turnScore={turnScore} dims={dims} judgeUsed={judgeUsed} />;
+  }
+  return <SimpleValidationScore valData={valData} />;
+}
+
+// --- Per-turn attempt sections ---
+function BriefAttemptsSection({ briefAttempts, turnValTrail }: {
+  briefAttempts: any[];
+  turnValTrail: TurnValidationTrail | undefined;
+}) {
+  if (!(briefAttempts.length > 0)) return null;
+  return (
+    <>
+      {briefAttempts.map((attempt, ai) => {
+        const isFinal = ai === briefAttempts.length - 1;
+        const valData = (attempt as Record<string, unknown>).stage_validation as { pass: boolean; hints: string[] } | undefined;
+        const hints = valData?.hints ?? [];
+        const turnScore = isFinal ? turnValTrail?.final.process_reward : undefined;
+        const dims = isFinal ? turnValTrail?.final.dimensions : undefined;
+        const judgeUsed = isFinal ? turnValTrail?.final.judge_used ?? false : false;
+        return (
+          <div key={ai}>
+            {/* Turn header */}
+            <div className="brief-turn-header">
+              <div className="brief-turn-rule" />
+              <span>Turn {ai + 1}</span>
+              <div className="brief-turn-rule" />
+            </div>
+            <ArtifactBlock label="Raw Prompt" text={attempt.prompt} />
+            <ArtifactBlock label="Raw Response" text={attempt.raw_response} />
+            {/* Validation Score */}
+            <ValidationScoreSection turnScore={turnScore} dims={dims} judgeUsed={judgeUsed} valData={valData} />
+            {/* Validation Feedback */}
+            {hints.length > 0 && (
+              <details open className="brief-feedback">
+                <summary className="brief-feedback-summary">Validation Feedback</summary>
+                <ul className="brief-feedback-list">
+                  {hints.map((h, hi) => {
+                    const target = classifyHintTarget(h);
+                    const ts = HINT_TARGET_STYLE[target];
+                    return (
+                      <li key={hi} className="brief-mb3">
+                        {/* eslint-disable-next-line local/no-inline-style -- dynamic hint-target color/bg */}
+                        <span style={{
+                          display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
+                          color: ts.color, background: ts.bg, padding: '1px 5px',
+                          borderRadius: 3, marginRight: 5, verticalAlign: 'middle',
+                        }}>{ts.label}</span>
+                        {humanizeSpeakerIds(h)}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </details>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
 export interface BriefTabProps {
   entry: DebateSession['transcript'][number];
   briefStage: any;
@@ -26,34 +280,18 @@ export function BriefTab(props: BriefTabProps) {
   // Shared renderer for POV grounding items — line 1: id + label + scores; line 2: justification/applicability.
   const renderGrounding = (grounding: { node_id: string; why: string }[], baseColor: string) => (
     <ul className="brief-grounding-list">
-      {grounding.map((g, gi) => {
-        const ref = entry.taxonomy_refs?.find(r => r.node_id === g.node_id);
-        const sc = ref?.relevance_score;
-        const scColor = sc == null ? 'var(--text-muted)' : sc >= 0.45 ? 'var(--success)' : sc >= 0.30 ? 'var(--warning)' : 'var(--danger)';
-        const tw = nodeWeights.get(g.node_id);
-        const conf = (g as Record<string, unknown>).confidence as number | undefined ?? tw?.confidence;
-        const prio = (g as Record<string, unknown>).priority as number | undefined ?? tw?.priority;
-        const oper = (g as Record<string, unknown>).operationality as number | undefined ?? tw?.operationality;
-        const label = (taxNodeMap.get(g.node_id) as { label?: string } | undefined)?.label;
-        return (
-          // eslint-disable-next-line local/no-inline-style -- dynamic baseColor
-          <li key={gi} style={{ fontSize: 'var(--text-2xs)', color: baseColor, marginBottom: 3 }}>
-            <div>
-              <button onClick={() => setSelectedTaxRefId(selectedTaxRefId === g.node_id ? null : g.node_id)} className="brief-taxref-btn">{g.node_id}</button>
-              {label && <span className="brief-grounding-label">{label}</span>}
-              {/* eslint-disable-next-line local/no-inline-style -- dynamic scColor */}
-              {sc != null && <span style={{ fontWeight: 600, color: scColor, marginLeft: 6 }}>{sc.toFixed(2)}</span>}
-              {/* eslint-disable-next-line local/no-inline-style -- dynamic conf coloring */}
-              {conf != null && <span style={{ marginLeft: 4, fontWeight: 600, color: conf >= 0.70 ? 'var(--success)' : conf >= 0.50 ? 'var(--text-secondary)' : 'var(--warning)', background: conf < 0.50 ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : undefined, padding: conf < 0.50 ? '0 3px' : undefined, borderRadius: 2 }}>conf:{conf.toFixed(2)}</span>}
-              {/* eslint-disable-next-line local/no-inline-style -- dynamic prio coloring */}
-              {prio != null && <span style={{ marginLeft: 4, fontWeight: 600, color: prio >= 4 ? 'var(--text-secondary)' : 'var(--text-muted)' }}>P{prio}/5</span>}
-              {/* eslint-disable-next-line local/no-inline-style -- dynamic oper coloring */}
-              {oper != null && <span style={{ marginLeft: 4, fontWeight: 600, color: oper >= 4 ? 'var(--text-secondary)' : 'var(--text-muted)' }}>op:{oper}/5</span>}
-            </div>
-            {g.why && <div className="brief-grounding-why">{g.why}</div>}
-          </li>
-        );
-      })}
+      {grounding.map((g, gi) => (
+        <GroundingItem
+          key={gi}
+          g={g}
+          baseColor={baseColor}
+          entry={entry}
+          nodeWeights={nodeWeights}
+          taxNodeMap={taxNodeMap}
+          selectedTaxRefId={selectedTaxRefId}
+          setSelectedTaxRefId={setSelectedTaxRefId}
+        />
+      ))}
     </ul>
   );
   return (
@@ -144,45 +382,7 @@ export function BriefTab(props: BriefTabProps) {
         </details>
       )}
       {/* Document Claims to Engage */}
-      {Array.isArray((briefStage.work_product as Record<string, unknown>).document_claims_to_engage) && ((briefStage.work_product as Record<string, unknown>).document_claims_to_engage as { d_id: string; claim: string; stance: string; why: string; grounding?: { node_id: string; why: string }[] }[]).length > 0 && (
-        <details open><summary className="brief-summary">Document Claims to Engage</summary>
-          <table className="brief-table">
-            <thead>
-              <tr className="brief-thead-row">
-                <th className="brief-th brief-th-w60">D-ID</th>
-                <th className="brief-th brief-th-w70">Stance</th>
-                <th className="brief-th">Claim &amp; Rationale</th>
-              </tr>
-            </thead>
-            <tbody>
-              {((briefStage.work_product as Record<string, unknown>).document_claims_to_engage as { d_id: string; claim: string; stance: string; why: string; grounding?: { node_id: string; why: string }[] }[]).map((dc, i) => {
-                const stanceColor = dc.stance === 'accept' ? 'var(--success)' : dc.stance === 'challenge' ? 'var(--danger)' : 'var(--warning)';
-                return (
-                  <Fragment key={i}>
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic borderBottom */}
-                    <tr style={{ borderBottom: Array.isArray(dc.grounding) && dc.grounding.length > 0 ? 'none' : '1px solid var(--border)' }}>
-                      <td className="brief-td-did">{dc.d_id}</td>
-                      {/* eslint-disable-next-line local/no-inline-style -- dynamic stanceColor */}
-                      <td style={{ padding: '3px 6px', verticalAlign: 'top', fontWeight: 600, color: stanceColor, textTransform: 'uppercase', fontSize: 'var(--text-2xs)' }}>{dc.stance}</td>
-                      <td className="brief-td">
-                        <Highlight text={dc.claim} />
-                        <div className="brief-td-why"><Highlight text={dc.why} /></div>
-                      </td>
-                    </tr>
-                    {Array.isArray(dc.grounding) && dc.grounding.length > 0 && (
-                      <tr className="brief-tr-border">
-                        <td colSpan={3} className="brief-td-grounding">
-                          {renderGrounding(dc.grounding, 'var(--text-muted)')}
-                        </td>
-                      </tr>
-                    )}
-                  </Fragment>
-                );
-              })}
-            </tbody>
-          </table>
-        </details>
-      )}
+      <DocumentClaimsSection workProduct={briefStage.work_product as Record<string, unknown>} renderGrounding={renderGrounding} />
       {/* Relevant Taxonomy Nodes (old schema fallback) */}
       {Array.isArray((briefStage.work_product as Record<string, unknown>).relevant_taxonomy_nodes) && !(() => {
         const wp = briefStage.work_product as Record<string, unknown>;
@@ -230,106 +430,7 @@ export function BriefTab(props: BriefTabProps) {
         </div>
       )}
       {/* -- Per-turn sections -- */}
-      {briefAttempts.length > 0 && briefAttempts.map((attempt, ai) => {
-        const isFinal = ai === briefAttempts.length - 1;
-        const valData = (attempt as Record<string, unknown>).stage_validation as { pass: boolean; hints: string[] } | undefined;
-        const hints = valData?.hints ?? [];
-        const turnScore = isFinal ? turnValTrail?.final.process_reward : undefined;
-        const dims = isFinal ? turnValTrail?.final.dimensions : undefined;
-        const judgeUsed = isFinal ? turnValTrail?.final.judge_used ?? false : false;
-        return (
-          <div key={ai}>
-            {/* Turn header */}
-            <div className="brief-turn-header">
-              <div className="brief-turn-rule" />
-              <span>Turn {ai + 1}</span>
-              <div className="brief-turn-rule" />
-            </div>
-            <ArtifactBlock label="Raw Prompt" text={attempt.prompt} />
-            <ArtifactBlock label="Raw Response" text={attempt.raw_response} />
-            {/* Validation Score */}
-            {(() => {
-              if (turnScore != null && dims) {
-                const stageA =
-                  0.4 * (dims.schema.pass ? 1 : 0) +
-                  0.3 * (dims.grounding.pass ? 1 : 0) +
-                  0.2 * (dims.advancement.pass ? 1 : 0) +
-                  0.1 * (dims.clarifies.pass ? 1 : 0);
-                const judgeQ = stageA > 0
-                  ? Math.max(0, Math.min(1, (turnScore - 0.4 * stageA) / 0.6))
-                  : 0.7;
-                const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
-                const dimColor = (pass: boolean) => pass ? 'var(--success)' : 'var(--danger)';
-                return (
-                  <div className="brief-valbox">
-                    <div className="brief-valbox-title">
-                      Validation Score:{' '}
-                      {/* eslint-disable-next-line local/no-inline-style -- mono spread + dynamic score color */}
-                      <span style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>
-                        {turnScore.toFixed(2)}
-                      </span>
-                    </div>
-                    <div className="brief-valdims">
-                      {/* eslint-disable-next-line local/no-inline-style -- dynamic dimColor + mono var */}
-                      <span><span style={{ color: dimColor(dims.schema.pass) }}>{'●'}</span> schema {'×'}0.4 = <strong style={mono}>{(0.4 * (dims.schema.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dynamic dimColor + mono var */}
-                      <span><span style={{ color: dimColor(dims.grounding.pass) }}>{'●'}</span> grounding {'×'}0.3 = <strong style={mono}>{(0.3 * (dims.grounding.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dynamic dimColor + mono var */}
-                      <span><span style={{ color: dimColor(dims.advancement.pass) }}>{'●'}</span> advancement {'×'}0.2 = <strong style={mono}>{(0.2 * (dims.advancement.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dynamic dimColor + mono var */}
-                      <span><span style={{ color: dimColor(dims.clarifies.pass) }}>{'●'}</span> clarifies {'×'}0.1 = <strong style={mono}>{(0.1 * (dims.clarifies.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                    </div>
-                    <div className="brief-valfooter">
-                      {/* eslint-disable-next-line local/no-inline-style -- mono var */}
-                      <span>Stage A: <strong style={mono}>{stageA.toFixed(2)}</strong> <span className="brief-muted">{'×'}0.4 = {(0.4 * stageA).toFixed(2)}</span></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- mono var */}
-                      <span>Judge: <strong style={mono}>{judgeQ.toFixed(2)}</strong>{!judgeUsed && <span className="brief-muted"> (default)</span>} <span className="brief-muted">{'×'}0.6 = {(0.6 * judgeQ).toFixed(2)}</span></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- mono spread + dynamic score color */}
-                      <span>Total: <strong style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>{turnScore.toFixed(2)}</strong></span>
-                    </div>
-                  </div>
-                );
-              }
-              return (
-                <div className="brief-valscore">
-                  Validation Score:{' '}
-                  {valData ? (
-                    // eslint-disable-next-line local/no-inline-style -- dynamic pass/fail color
-                    <span style={{ color: valData.pass ? 'var(--success)' : 'var(--danger)' }}>
-                      {valData.pass ? 'Pass' : 'Fail'}
-                    </span>
-                  ) : (
-                    <span className="brief-muted">{'—'}</span>
-                  )}
-                </div>
-              );
-            })()}
-            {/* Validation Feedback */}
-            {hints.length > 0 && (
-              <details open className="brief-feedback">
-                <summary className="brief-feedback-summary">Validation Feedback</summary>
-                <ul className="brief-feedback-list">
-                  {hints.map((h, hi) => {
-                    const target = classifyHintTarget(h);
-                    const ts = HINT_TARGET_STYLE[target];
-                    return (
-                      <li key={hi} className="brief-mb3">
-                        {/* eslint-disable-next-line local/no-inline-style -- dynamic hint-target color/bg */}
-                        <span style={{
-                          display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
-                          color: ts.color, background: ts.bg, padding: '1px 5px',
-                          borderRadius: 3, marginRight: 5, verticalAlign: 'middle',
-                        }}>{ts.label}</span>
-                        {humanizeSpeakerIds(h)}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </details>
-            )}
-          </div>
-        );
-      })}
+      <BriefAttemptsSection briefAttempts={briefAttempts} turnValTrail={turnValTrail} />
       {/* TaxonomyRefDetail */}
       {selectedTaxRefId && (() => {
         const node = taxNodeMap.get(selectedTaxRefId) as TaxRefNode | undefined;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CitationsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CitationsTab.tsx
@@ -50,6 +50,244 @@ export interface CitationsTabProps {
   searchQuery?: string;
 }
 
+// -- 1. Summary Cards --
+function SummaryCards({ citationResDiag }: { citationResDiag: CitationResolutionDiag }) {
+  return (
+    <div className="ctn-cards">
+      {[
+        {
+          label: 'Path',
+          value: citationResDiag.path === 'tool-calling' ? 'Tool-Call' : 'Bank+Scrub',
+          color: citationResDiag.path === 'tool-calling' ? 'var(--color-saf)' : 'var(--warning)',
+        },
+        { label: 'Bank', value: `${citationResDiag.bank_size} srcs`, color: undefined },
+        {
+          label: 'Matched',
+          value: `${citationResDiag.citations_matched}/${citationResDiag.citations_extracted}`,
+          color: citationResDiag.citations_matched === citationResDiag.citations_extracted
+            ? 'var(--success)'
+            : citationResDiag.citations_fabricated > citationResDiag.citations_extracted / 2
+              ? 'var(--danger)' : 'var(--warning)',
+        },
+        {
+          label: 'Fabricated',
+          value: citationResDiag.citations_fabricated === 0
+            ? '0 — clean'
+            : `${citationResDiag.citations_fabricated} ${citationResDiag.fabrications.filter(f => f.action === 'removed').length > 0 ? 'removed' : 'hedged'}`,
+          color: citationResDiag.citations_fabricated === 0 ? 'var(--success)' : 'var(--danger)',
+        },
+      ].map(card => (
+        <div key={card.label} className="ctn-card">
+          <div className="ctn-card-label">{card.label}</div>
+          {/* eslint-disable-next-line local/no-inline-style -- dynamic color (card.color) */}
+          <div style={{
+            fontSize: '0.82rem', fontWeight: 700, fontFamily: 'monospace',
+            color: card.color ?? 'inherit',
+          }}>{card.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// -- 2. Matched Citations --
+function MatchedCitations({ citationResDiag }: { citationResDiag: CitationResolutionDiag }) {
+  if (citationResDiag.matches.length === 0) return null;
+  return (
+    <details open className="ctn-details">
+      <summary className="ctn-summary">
+        Matched Citations ({citationResDiag.matches.length})
+      </summary>
+      {citationResDiag.matches
+        .slice().sort((a, b) => b.similarity - a.similarity)
+        .map((m, mi) => {
+          const matchTypeColors: Record<string, string> = { exact: 'var(--success)', fuzzy_title: 'var(--warning)', url: 'var(--color-saf)', arxiv_id: 'var(--text-secondary)' };
+          const mtColor = matchTypeColors[m.match_type] ?? 'var(--text-muted)';
+          return (
+            <div key={mi} className="ctn-match-card">
+              <div className="ctn-match-text">
+                &ldquo;{m.citation_text}&rdquo;
+              </div>
+              <div className="ctn-meta-row">
+                <span className="ctn-fw600">{m.doc_id}</span>
+                <span className="ctn-muted">— {m.similarity.toFixed(2)} similarity</span>
+                {/* eslint-disable-next-line local/no-inline-style -- dynamic color/background (mtColor) */}
+                <span style={{
+                  fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
+                  color: mtColor, background: `${mtColor}18`,
+                }}>{m.match_type.replace('_', ' ').toUpperCase()}</span>
+              </div>
+              {m.title && (
+                <div className="ctn-sub-muted">
+                  {m.title}
+                </div>
+              )}
+            </div>
+          );
+        })}
+    </details>
+  );
+}
+
+// -- 3. Fabricated Citations --
+function FabricatedCitations({ citationResDiag }: { citationResDiag: CitationResolutionDiag }) {
+  if (citationResDiag.fabrications.length === 0) return null;
+  return (
+    <details open className="ctn-details">
+      <summary className="ctn-summary">
+        Fabricated Citations ({citationResDiag.fabrications.length})
+      </summary>
+      {citationResDiag.fabrications.map((f, fi) => {
+        const patternColors: Record<string, string> = { arxiv: 'var(--text-secondary)', url: 'var(--color-saf)', title: 'var(--warning)', legislation: 'var(--text-secondary)' };
+        const patColor = patternColors[f.pattern] ?? 'var(--text-muted)';
+        return (
+          <div key={fi} className="ctn-fab-card">
+            <div className="ctn-fab-text">
+              &ldquo;{f.citation_text}&rdquo;
+            </div>
+            <div className="ctn-meta-row">
+              {/* eslint-disable-next-line local/no-inline-style -- dynamic color/background (patColor) */}
+              <span style={{
+                fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
+                color: patColor, background: `${patColor}18`,
+              }}>{f.pattern.toUpperCase()}</span>
+              <span>Not in citation bank</span>
+              {/* eslint-disable-next-line local/no-inline-style -- dynamic color/background (f.action) */}
+              <span style={{
+                fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
+                color: f.action === 'removed' ? 'var(--danger)' : 'var(--warning)',
+                background: f.action === 'removed' ? 'color-mix(in srgb, var(--danger) 10%, transparent)' : 'rgba(217,119,6,0.1)',
+              }}>{f.action}</span>
+            </div>
+            {f.replacement && (
+              <div className="ctn-replacement">
+                → {f.replacement}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </details>
+  );
+}
+
+// -- 4. Citation Bank --
+function CitationBank({ citationResDiag }: { citationResDiag: CitationResolutionDiag }) {
+  if (citationResDiag.bank_sources.length === 0) return null;
+  return (
+    <details className="ctn-details">
+      <summary className="ctn-summary">
+        Citation Bank ({citationResDiag.bank_sources.length} available sources)
+      </summary>
+      {citationResDiag.bank_sources.slice(0, 5).map((src, si) => (
+        <div key={si} className="ctn-bank-src">
+          • {src}
+        </div>
+      ))}
+      {citationResDiag.bank_sources.length > 5 && (
+        <details className="ctn-details-sm">
+          <summary className="ctn-summary-more">
+            {citationResDiag.bank_sources.length - 5} more…
+          </summary>
+          {citationResDiag.bank_sources.slice(5).map((src, si) => (
+            <div key={si} className="ctn-bank-src">
+              • {src}
+            </div>
+          ))}
+        </details>
+      )}
+    </details>
+  );
+}
+
+// -- 5. Tool Calls (Path B only) --
+function ToolCalls({ citationResDiag }: { citationResDiag: CitationResolutionDiag }) {
+  if (!citationResDiag.tool_calls || citationResDiag.tool_calls.length === 0) return null;
+  return (
+    <details open className="ctn-details">
+      <summary className="ctn-summary">
+        Tool Calls ({citationResDiag.tool_calls.length})
+      </summary>
+      {citationResDiag.tool_calls.map((tc, ti) => (
+        // eslint-disable-next-line local/no-inline-style -- dynamic borderLeft (tc.empty)
+        <div key={ti} style={{
+          marginBottom: 6, padding: '6px 8px', borderRadius: 4,
+          borderLeft: `3px solid ${tc.empty ? 'var(--warning)' : 'var(--text-secondary)'}`,
+          background: 'var(--bg-subtle)',
+        }}>
+          <div className="ctn-tc-header">
+            <span className="ctn-fw700">LOOKUP #{ti + 1}</span>
+            <span className="ctn-muted">{tc.time_ms}ms</span>
+            {tc.empty && (
+              <span className="ctn-empty-badge">⚠ EMPTY</span>
+            )}
+          </div>
+          <div className="ctn-tc-line">
+            <strong>Query:</strong> {tc.query}
+          </div>
+          {tc.source_type && (
+            <div className="ctn-tc-type">
+              Type: {tc.source_type}
+            </div>
+          )}
+          <div className="ctn-tc-results">
+            {tc.empty ? (
+              <span className="ctn-warn-text">Results: 0 — no verified sources found</span>
+            ) : (
+              <span>
+                Results: {tc.results_count}
+                {tc.top_result && (
+                  <> — top: <span className="ctn-saf">{tc.top_result.doc_id}</span> ({tc.top_result.relevance.toFixed(2)})</>
+                )}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </details>
+  );
+}
+
+// -- 6. Scrub Diff (Path A only) --
+function ScrubDiff({ citationResDiag }: { citationResDiag: CitationResolutionDiag }) {
+  if (!citationResDiag.scrub_diff) return null;
+  return (
+    <details open className="ctn-details">
+      <summary className="ctn-summary">
+        Scrub Diff
+      </summary>
+      <div className="ctn-scrub-summary">
+        {citationResDiag.scrub_diff.lines_removed} lines removed, {citationResDiag.scrub_diff.lines_modified} lines modified
+      </div>
+      <div className="ctn-scrub-stats">
+        <span>Original: {citationResDiag.scrub_diff.original_length} chars</span>
+        <span>Cleaned: {citationResDiag.scrub_diff.cleaned_length} chars</span>
+        <span>
+          Δ {citationResDiag.scrub_diff.original_length - citationResDiag.scrub_diff.cleaned_length} chars removed
+          ({((1 - citationResDiag.scrub_diff.cleaned_length / Math.max(1, citationResDiag.scrub_diff.original_length)) * 100).toFixed(1)}%)
+        </span>
+      </div>
+    </details>
+  );
+}
+
+// -- 7. Warnings --
+function Warnings({ citationResDiag }: { citationResDiag: CitationResolutionDiag }) {
+  if (citationResDiag.warnings.length === 0) return null;
+  return (
+    <details open className="ctn-details">
+      <summary className="ctn-summary">
+        Warnings ({citationResDiag.warnings.length})
+      </summary>
+      <ul className="ctn-warn-list">
+        {citationResDiag.warnings.map((w, wi) => (
+          <li key={wi} className="ctn-warn-item">{w}</li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
 export function CitationsTab({ diag, searchQuery }: CitationsTabProps) {
   const _draftForCitations = (diag?.stage_diagnostics?.filter(s => s.stage === 'draft') ?? []).slice(-1)[0];
   const citationResDiag = _draftForCitations?.citation_resolution as CitationResolutionDiag | undefined;
@@ -66,221 +304,13 @@ export function CitationsTab({ diag, searchQuery }: CitationsTabProps) {
 
   return (
     <div className="ctn-root">
-      {/* -- 1. Summary Cards -- */}
-      <div className="ctn-cards">
-        {[
-          {
-            label: 'Path',
-            value: citationResDiag.path === 'tool-calling' ? 'Tool-Call' : 'Bank+Scrub',
-            color: citationResDiag.path === 'tool-calling' ? 'var(--color-saf)' : 'var(--warning)',
-          },
-          { label: 'Bank', value: `${citationResDiag.bank_size} srcs`, color: undefined },
-          {
-            label: 'Matched',
-            value: `${citationResDiag.citations_matched}/${citationResDiag.citations_extracted}`,
-            color: citationResDiag.citations_matched === citationResDiag.citations_extracted
-              ? 'var(--success)'
-              : citationResDiag.citations_fabricated > citationResDiag.citations_extracted / 2
-                ? 'var(--danger)' : 'var(--warning)',
-          },
-          {
-            label: 'Fabricated',
-            value: citationResDiag.citations_fabricated === 0
-              ? '0 — clean'
-              : `${citationResDiag.citations_fabricated} ${citationResDiag.fabrications.filter(f => f.action === 'removed').length > 0 ? 'removed' : 'hedged'}`,
-            color: citationResDiag.citations_fabricated === 0 ? 'var(--success)' : 'var(--danger)',
-          },
-        ].map(card => (
-          <div key={card.label} className="ctn-card">
-            <div className="ctn-card-label">{card.label}</div>
-            {/* eslint-disable-next-line local/no-inline-style -- dynamic color (card.color) */}
-            <div style={{
-              fontSize: '0.82rem', fontWeight: 700, fontFamily: 'monospace',
-              color: card.color ?? 'inherit',
-            }}>{card.value}</div>
-          </div>
-        ))}
-      </div>
-
-      {/* -- 2. Matched Citations -- */}
-      {citationResDiag.matches.length > 0 && (
-        <details open className="ctn-details">
-          <summary className="ctn-summary">
-            Matched Citations ({citationResDiag.matches.length})
-          </summary>
-          {citationResDiag.matches
-            .slice().sort((a, b) => b.similarity - a.similarity)
-            .map((m, mi) => {
-              const matchTypeColors: Record<string, string> = { exact: 'var(--success)', fuzzy_title: 'var(--warning)', url: 'var(--color-saf)', arxiv_id: 'var(--text-secondary)' };
-              const mtColor = matchTypeColors[m.match_type] ?? 'var(--text-muted)';
-              return (
-                <div key={mi} className="ctn-match-card">
-                  <div className="ctn-match-text">
-                    &ldquo;{m.citation_text}&rdquo;
-                  </div>
-                  <div className="ctn-meta-row">
-                    <span className="ctn-fw600">{m.doc_id}</span>
-                    <span className="ctn-muted">— {m.similarity.toFixed(2)} similarity</span>
-                    {/* eslint-disable-next-line local/no-inline-style -- dynamic color/background (mtColor) */}
-                    <span style={{
-                      fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
-                      color: mtColor, background: `${mtColor}18`,
-                    }}>{m.match_type.replace('_', ' ').toUpperCase()}</span>
-                  </div>
-                  {m.title && (
-                    <div className="ctn-sub-muted">
-                      {m.title}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-        </details>
-      )}
-
-      {/* -- 3. Fabricated Citations -- */}
-      {citationResDiag.fabrications.length > 0 && (
-        <details open className="ctn-details">
-          <summary className="ctn-summary">
-            Fabricated Citations ({citationResDiag.fabrications.length})
-          </summary>
-          {citationResDiag.fabrications.map((f, fi) => {
-            const patternColors: Record<string, string> = { arxiv: 'var(--text-secondary)', url: 'var(--color-saf)', title: 'var(--warning)', legislation: 'var(--text-secondary)' };
-            const patColor = patternColors[f.pattern] ?? 'var(--text-muted)';
-            return (
-              <div key={fi} className="ctn-fab-card">
-                <div className="ctn-fab-text">
-                  &ldquo;{f.citation_text}&rdquo;
-                </div>
-                <div className="ctn-meta-row">
-                  {/* eslint-disable-next-line local/no-inline-style -- dynamic color/background (patColor) */}
-                  <span style={{
-                    fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
-                    color: patColor, background: `${patColor}18`,
-                  }}>{f.pattern.toUpperCase()}</span>
-                  <span>Not in citation bank</span>
-                  {/* eslint-disable-next-line local/no-inline-style -- dynamic color/background (f.action) */}
-                  <span style={{
-                    fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 5px', borderRadius: 3,
-                    color: f.action === 'removed' ? 'var(--danger)' : 'var(--warning)',
-                    background: f.action === 'removed' ? 'color-mix(in srgb, var(--danger) 10%, transparent)' : 'rgba(217,119,6,0.1)',
-                  }}>{f.action}</span>
-                </div>
-                {f.replacement && (
-                  <div className="ctn-replacement">
-                    → {f.replacement}
-                  </div>
-                )}
-              </div>
-            );
-          })}
-        </details>
-      )}
-
-      {/* -- 4. Citation Bank -- */}
-      {citationResDiag.bank_sources.length > 0 && (
-        <details className="ctn-details">
-          <summary className="ctn-summary">
-            Citation Bank ({citationResDiag.bank_sources.length} available sources)
-          </summary>
-          {citationResDiag.bank_sources.slice(0, 5).map((src, si) => (
-            <div key={si} className="ctn-bank-src">
-              • {src}
-            </div>
-          ))}
-          {citationResDiag.bank_sources.length > 5 && (
-            <details className="ctn-details-sm">
-              <summary className="ctn-summary-more">
-                {citationResDiag.bank_sources.length - 5} more…
-              </summary>
-              {citationResDiag.bank_sources.slice(5).map((src, si) => (
-                <div key={si} className="ctn-bank-src">
-                  • {src}
-                </div>
-              ))}
-            </details>
-          )}
-        </details>
-      )}
-
-      {/* -- 5. Tool Calls (Path B only) -- */}
-      {citationResDiag.tool_calls && citationResDiag.tool_calls.length > 0 && (
-        <details open className="ctn-details">
-          <summary className="ctn-summary">
-            Tool Calls ({citationResDiag.tool_calls.length})
-          </summary>
-          {citationResDiag.tool_calls.map((tc, ti) => (
-            // eslint-disable-next-line local/no-inline-style -- dynamic borderLeft (tc.empty)
-            <div key={ti} style={{
-              marginBottom: 6, padding: '6px 8px', borderRadius: 4,
-              borderLeft: `3px solid ${tc.empty ? 'var(--warning)' : 'var(--text-secondary)'}`,
-              background: 'var(--bg-subtle)',
-            }}>
-              <div className="ctn-tc-header">
-                <span className="ctn-fw700">LOOKUP #{ti + 1}</span>
-                <span className="ctn-muted">{tc.time_ms}ms</span>
-                {tc.empty && (
-                  <span className="ctn-empty-badge">⚠ EMPTY</span>
-                )}
-              </div>
-              <div className="ctn-tc-line">
-                <strong>Query:</strong> {tc.query}
-              </div>
-              {tc.source_type && (
-                <div className="ctn-tc-type">
-                  Type: {tc.source_type}
-                </div>
-              )}
-              <div className="ctn-tc-results">
-                {tc.empty ? (
-                  <span className="ctn-warn-text">Results: 0 — no verified sources found</span>
-                ) : (
-                  <span>
-                    Results: {tc.results_count}
-                    {tc.top_result && (
-                      <> — top: <span className="ctn-saf">{tc.top_result.doc_id}</span> ({tc.top_result.relevance.toFixed(2)})</>
-                    )}
-                  </span>
-                )}
-              </div>
-            </div>
-          ))}
-        </details>
-      )}
-
-      {/* -- 6. Scrub Diff (Path A only) -- */}
-      {citationResDiag.scrub_diff && (
-        <details open className="ctn-details">
-          <summary className="ctn-summary">
-            Scrub Diff
-          </summary>
-          <div className="ctn-scrub-summary">
-            {citationResDiag.scrub_diff.lines_removed} lines removed, {citationResDiag.scrub_diff.lines_modified} lines modified
-          </div>
-          <div className="ctn-scrub-stats">
-            <span>Original: {citationResDiag.scrub_diff.original_length} chars</span>
-            <span>Cleaned: {citationResDiag.scrub_diff.cleaned_length} chars</span>
-            <span>
-              Δ {citationResDiag.scrub_diff.original_length - citationResDiag.scrub_diff.cleaned_length} chars removed
-              ({((1 - citationResDiag.scrub_diff.cleaned_length / Math.max(1, citationResDiag.scrub_diff.original_length)) * 100).toFixed(1)}%)
-            </span>
-          </div>
-        </details>
-      )}
-
-      {/* -- 7. Warnings -- */}
-      {citationResDiag.warnings.length > 0 && (
-        <details open className="ctn-details">
-          <summary className="ctn-summary">
-            Warnings ({citationResDiag.warnings.length})
-          </summary>
-          <ul className="ctn-warn-list">
-            {citationResDiag.warnings.map((w, wi) => (
-              <li key={wi} className="ctn-warn-item">{w}</li>
-            ))}
-          </ul>
-        </details>
-      )}
+      <SummaryCards citationResDiag={citationResDiag} />
+      <MatchedCitations citationResDiag={citationResDiag} />
+      <FabricatedCitations citationResDiag={citationResDiag} />
+      <CitationBank citationResDiag={citationResDiag} />
+      <ToolCalls citationResDiag={citationResDiag} />
+      <ScrubDiff citationResDiag={citationResDiag} />
+      <Warnings citationResDiag={citationResDiag} />
 
       {/* -- 8. Status Bar -- */}
       <div className="ctn-status-bar">

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CiteTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CiteTab.tsx
@@ -25,79 +25,56 @@ export interface CiteTabProps {
   setSelectedPolicyId: (id: string | null) => void;
 }
 
-export function CiteTab(props: CiteTabProps) {
-  const { entry, debate, citeStage, citeAttempts, briefStage, turnValTrail, taxNodeMap, allEdges, policyMap, selectedTaxRefId, setSelectedTaxRefId, selectedPolicyId, setSelectedPolicyId } = props;
+interface CiteTaxRefsSectionProps {
+  citeStage: any;
+  entry: DebateSession['transcript'][number];
+  debate: DebateSession;
+  briefStage: any;
+  taxNodeMap: Map<string, Record<string, unknown>>;
+  allEdges: TaxRefEdge[];
+  selectedTaxRefId: string | null;
+  setSelectedTaxRefId: (id: string | null) => void;
+}
+
+function computeCiteTaxRefContext(
+  entry: DebateSession['transcript'][number],
+  debate: DebateSession,
+  briefStage: any,
+) {
+  const citeManifest = (entry.metadata as Record<string, unknown>)?.injection_manifest as {
+    lineage_boost?: { boostedNodeIds?: string[]; promotedNodeIds?: string[]; traditions?: string[] };
+  } | undefined;
+  const lb = citeManifest?.lineage_boost;
+  const boostedSet = new Set(lb?.boostedNodeIds ?? []);
+  const promotedSet = new Set(lb?.promotedNodeIds ?? []);
+  const boostTraditions = lb?.traditions
+    ?? debate.topic.critique?.lineage_frame?.flatMap((f: { traditions?: string[] }) => f.traditions ?? [])
+    ?? [];
+  const frameLabels = debate.topic.critique?.lineage_frame?.map((f: { label: string }) => f.label) ?? boostTraditions;
+  const briefNodes = new Set((() => {
+    const wp = briefStage?.work_product as Record<string, unknown> | undefined;
+    if (!wp) return [] as string[];
+    const fromGrounding = (arr: unknown): string[] => {
+      if (!Array.isArray(arr)) return [];
+      return (arr as { grounding?: { node_id: string }[] }[]).flatMap(x => Array.isArray(x.grounding) ? x.grounding.map(g => g.node_id) : []);
+    };
+    const nested = [
+      ...fromGrounding(wp.key_claims_to_address),
+      ...fromGrounding(wp.strongest_angles),
+      ...fromGrounding(wp.document_claims_to_engage),
+    ];
+    if (nested.length > 0) return nested;
+    return Array.isArray(wp.relevant_taxonomy_nodes)
+      ? (wp.relevant_taxonomy_nodes as { node_id: string }[]).map(n => n.node_id)
+      : [];
+  })());
+  return { boostedSet, promotedSet, boostTraditions, frameLabels, briefNodes };
+}
+
+function CiteTaxonomyRefsSection(props: CiteTaxRefsSectionProps) {
+  const { citeStage, entry, debate, briefStage, taxNodeMap, allEdges, selectedTaxRefId, setSelectedTaxRefId } = props;
+  const { boostedSet, promotedSet, boostTraditions, frameLabels, briefNodes } = computeCiteTaxRefContext(entry, debate, briefStage);
   return (
-    <div className="cit-root">
-      {/* -- Top section: header + content from final cite -- */}
-      <div className="cit-header">
-        <span className="cit-badge">CITE</span>
-        <span>{citeStage.model}</span>
-        <span>temp={citeStage.temperature}</span>
-        <span>{(citeStage.response_time_ms / 1000).toFixed(1)}s</span>
-        {typeof (citeStage.work_product as Record<string, unknown>).grounding_confidence === 'number' && (
-          // eslint-disable-next-line local/no-inline-style -- confidence-threshold-driven background
-          <span style={{ padding: '1px 6px', borderRadius: 3, background: (citeStage.work_product as Record<string, unknown>).grounding_confidence as number >= 0.7 ? 'color-mix(in srgb, var(--success) 20%, transparent)' : 'color-mix(in srgb, var(--warning) 20%, transparent)', fontSize: 'var(--text-2xs)' }}>
-            confidence: {((citeStage.work_product as Record<string, unknown>).grounding_confidence as number).toFixed(2)}
-          </span>
-        )}
-      </div>
-      {citeStage.parse_error && (
-        <div className="cit-parse-error">
-          <strong>Parse error:</strong> {citeStage.parse_error}
-        </div>
-      )}
-      {/* Moderator Directive (if present) */}
-      {(() => {
-        const wp = citeStage.work_product as Record<string, unknown>;
-        const drp = wp.directive_response_plan as string | undefined;
-        const dr = wp.directive_response as { directive: string; how_addressed: string } | undefined;
-        if (!drp && !dr) return null;
-        return (
-          <div className="cit-directive">
-            <div className="cit-directive-head">
-              <span className="cit-badge-2xs">MODERATOR DIRECTIVE</span>
-            </div>
-            {dr && (
-              <>
-                <div className="cit-mb4"><strong>Directive:</strong> <Highlight text={dr.directive} /></div>
-                <div><strong>How addressed:</strong> <Highlight text={dr.how_addressed} /></div>
-              </>
-            )}
-            {drp && !dr && <Highlight text={String(drp)} />}
-          </div>
-        );
-      })()}
-      {/* Taxonomy References */}
-      {Array.isArray((citeStage.work_product as Record<string, unknown>).taxonomy_refs) && (() => {
-        const citeManifest = (entry.metadata as Record<string, unknown>)?.injection_manifest as {
-          lineage_boost?: { boostedNodeIds?: string[]; promotedNodeIds?: string[]; traditions?: string[] };
-        } | undefined;
-        const lb = citeManifest?.lineage_boost;
-        const boostedSet = new Set(lb?.boostedNodeIds ?? []);
-        const promotedSet = new Set(lb?.promotedNodeIds ?? []);
-        const boostTraditions = lb?.traditions
-          ?? debate.topic.critique?.lineage_frame?.flatMap((f: { traditions?: string[] }) => f.traditions ?? [])
-          ?? [];
-        const frameLabels = debate.topic.critique?.lineage_frame?.map((f: { label: string }) => f.label) ?? boostTraditions;
-        const briefNodes = new Set((() => {
-          const wp = briefStage?.work_product as Record<string, unknown> | undefined;
-          if (!wp) return [] as string[];
-          const fromGrounding = (arr: unknown): string[] => {
-            if (!Array.isArray(arr)) return [];
-            return (arr as { grounding?: { node_id: string }[] }[]).flatMap(x => Array.isArray(x.grounding) ? x.grounding.map(g => g.node_id) : []);
-          };
-          const nested = [
-            ...fromGrounding(wp.key_claims_to_address),
-            ...fromGrounding(wp.strongest_angles),
-            ...fromGrounding(wp.document_claims_to_engage),
-          ];
-          if (nested.length > 0) return nested;
-          return Array.isArray(wp.relevant_taxonomy_nodes)
-            ? (wp.relevant_taxonomy_nodes as { node_id: string }[]).map(n => n.node_id)
-            : [];
-        })());
-        return (
         <details open><summary className="cit-summary">
           Taxonomy References
           {boostedSet.size > 0 && (
@@ -173,8 +150,134 @@ export function CiteTab(props: CiteTabProps) {
             );
           })()}
         </details>
+  );
+}
+
+interface CiteValScoreDetailProps {
+  turnScore: number;
+  dims: TurnValidationTrail['final']['dimensions'];
+  judgeUsed: boolean;
+}
+
+function computeCiteValidationBreakdown(turnScore: number, dims: TurnValidationTrail['final']['dimensions']) {
+  const stageA =
+    0.4 * (dims.schema.pass ? 1 : 0) +
+    0.3 * (dims.grounding.pass ? 1 : 0) +
+    0.2 * (dims.advancement.pass ? 1 : 0) +
+    0.1 * (dims.clarifies.pass ? 1 : 0);
+  const judgeQ = stageA > 0
+    ? Math.max(0, Math.min(1, (turnScore - 0.4 * stageA) / 0.6))
+    : 0.7;
+  return { stageA, judgeQ };
+}
+
+function CiteValidationScoreDetail(props: CiteValScoreDetailProps) {
+  const { turnScore, dims, judgeUsed } = props;
+  const { stageA, judgeQ } = computeCiteValidationBreakdown(turnScore, dims);
+  const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
+  const dimColor = (pass: boolean) => pass ? 'var(--success)' : 'var(--danger)';
+  return (
+                  <div className="cit-valscore-box">
+                    <div className="cit-valscore-title">
+                      Validation Score:{' '}
+                      {/* eslint-disable-next-line local/no-inline-style -- score-threshold-driven color */}
+                      <span style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>
+                        {turnScore.toFixed(2)}
+                      </span>
+                    </div>
+                    <div className="cit-dims-row">
+                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
+                      <span><span style={{ color: dimColor(dims.schema.pass) }}>{'●'}</span> schema {'×'}0.4 = <strong className="cit-mono">{(0.4 * (dims.schema.pass ? 1 : 0)).toFixed(2)}</strong></span>
+                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
+                      <span><span style={{ color: dimColor(dims.grounding.pass) }}>{'●'}</span> grounding {'×'}0.3 = <strong className="cit-mono">{(0.3 * (dims.grounding.pass ? 1 : 0)).toFixed(2)}</strong></span>
+                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
+                      <span><span style={{ color: dimColor(dims.advancement.pass) }}>{'●'}</span> advancement {'×'}0.2 = <strong className="cit-mono">{(0.2 * (dims.advancement.pass ? 1 : 0)).toFixed(2)}</strong></span>
+                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
+                      <span><span style={{ color: dimColor(dims.clarifies.pass) }}>{'●'}</span> clarifies {'×'}0.1 = <strong className="cit-mono">{(0.1 * (dims.clarifies.pass ? 1 : 0)).toFixed(2)}</strong></span>
+                    </div>
+                    <div className="cit-breakdown">
+                      <span>Stage A: <strong className="cit-mono">{stageA.toFixed(2)}</strong> <span className="cit-muted">{'×'}0.4 = {(0.4 * stageA).toFixed(2)}</span></span>
+                      <span>Judge: <strong className="cit-mono">{judgeQ.toFixed(2)}</strong>{!judgeUsed && <span className="cit-muted"> (default)</span>} <span className="cit-muted">{'×'}0.6 = {(0.6 * judgeQ).toFixed(2)}</span></span>
+                      {/* eslint-disable-next-line local/no-inline-style -- score-threshold-driven color */}
+                      <span>Total: <strong style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>{turnScore.toFixed(2)}</strong></span>
+                    </div>
+                  </div>
+  );
+}
+
+function CiteValidationScoreFallback(props: { valData: { pass: boolean; hints: string[] } | undefined }) {
+  const { valData } = props;
+  return (
+                <div className="cit-fallback-val">
+                  Validation Score:{' '}
+                  {valData ? (
+                    // eslint-disable-next-line local/no-inline-style -- pass-driven color
+                    <span style={{ color: valData.pass ? 'var(--success)' : 'var(--danger)' }}>
+                      {valData.pass ? 'Pass' : 'Fail'}
+                    </span>
+                  ) : (
+                    <span className="cit-muted">{'—'}</span>
+                  )}
+                </div>
+  );
+}
+
+export function CiteTab(props: CiteTabProps) {
+  const { entry, debate, citeStage, citeAttempts, briefStage, turnValTrail, taxNodeMap, allEdges, policyMap, selectedTaxRefId, setSelectedTaxRefId, selectedPolicyId, setSelectedPolicyId } = props;
+  return (
+    <div className="cit-root">
+      {/* -- Top section: header + content from final cite -- */}
+      <div className="cit-header">
+        <span className="cit-badge">CITE</span>
+        <span>{citeStage.model}</span>
+        <span>temp={citeStage.temperature}</span>
+        <span>{(citeStage.response_time_ms / 1000).toFixed(1)}s</span>
+        {typeof (citeStage.work_product as Record<string, unknown>).grounding_confidence === 'number' && (
+          // eslint-disable-next-line local/no-inline-style -- confidence-threshold-driven background
+          <span style={{ padding: '1px 6px', borderRadius: 3, background: (citeStage.work_product as Record<string, unknown>).grounding_confidence as number >= 0.7 ? 'color-mix(in srgb, var(--success) 20%, transparent)' : 'color-mix(in srgb, var(--warning) 20%, transparent)', fontSize: 'var(--text-2xs)' }}>
+            confidence: {((citeStage.work_product as Record<string, unknown>).grounding_confidence as number).toFixed(2)}
+          </span>
+        )}
+      </div>
+      {citeStage.parse_error && (
+        <div className="cit-parse-error">
+          <strong>Parse error:</strong> {citeStage.parse_error}
+        </div>
+      )}
+      {/* Moderator Directive (if present) */}
+      {(() => {
+        const wp = citeStage.work_product as Record<string, unknown>;
+        const drp = wp.directive_response_plan as string | undefined;
+        const dr = wp.directive_response as { directive: string; how_addressed: string } | undefined;
+        if (!drp && !dr) return null;
+        return (
+          <div className="cit-directive">
+            <div className="cit-directive-head">
+              <span className="cit-badge-2xs">MODERATOR DIRECTIVE</span>
+            </div>
+            {dr && (
+              <>
+                <div className="cit-mb4"><strong>Directive:</strong> <Highlight text={dr.directive} /></div>
+                <div><strong>How addressed:</strong> <Highlight text={dr.how_addressed} /></div>
+              </>
+            )}
+            {drp && !dr && <Highlight text={String(drp)} />}
+          </div>
         );
       })()}
+      {/* Taxonomy References */}
+      {Array.isArray((citeStage.work_product as Record<string, unknown>).taxonomy_refs) && (
+        <CiteTaxonomyRefsSection
+          citeStage={citeStage}
+          entry={entry}
+          debate={debate}
+          briefStage={briefStage}
+          taxNodeMap={taxNodeMap}
+          allEdges={allEdges}
+          selectedTaxRefId={selectedTaxRefId}
+          setSelectedTaxRefId={setSelectedTaxRefId}
+        />
+      )}
       {/* Move Annotations */}
       {Array.isArray((citeStage.work_product as Record<string, unknown>).move_annotations) && (
         <details open><summary className="cit-summary">Move Annotations</summary>
@@ -311,57 +414,9 @@ export function CiteTab(props: CiteTabProps) {
             {/* Validation Score */}
             {(() => {
               if (turnScore != null && dims) {
-                const stageA =
-                  0.4 * (dims.schema.pass ? 1 : 0) +
-                  0.3 * (dims.grounding.pass ? 1 : 0) +
-                  0.2 * (dims.advancement.pass ? 1 : 0) +
-                  0.1 * (dims.clarifies.pass ? 1 : 0);
-                const judgeQ = stageA > 0
-                  ? Math.max(0, Math.min(1, (turnScore - 0.4 * stageA) / 0.6))
-                  : 0.7;
-                const mono = { fontFamily: 'monospace', fontSize: 'var(--text-2xs)' } as const;
-                const dimColor = (pass: boolean) => pass ? 'var(--success)' : 'var(--danger)';
-                return (
-                  <div className="cit-valscore-box">
-                    <div className="cit-valscore-title">
-                      Validation Score:{' '}
-                      {/* eslint-disable-next-line local/no-inline-style -- score-threshold-driven color */}
-                      <span style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>
-                        {turnScore.toFixed(2)}
-                      </span>
-                    </div>
-                    <div className="cit-dims-row">
-                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                      <span><span style={{ color: dimColor(dims.schema.pass) }}>{'●'}</span> schema {'×'}0.4 = <strong className="cit-mono">{(0.4 * (dims.schema.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                      <span><span style={{ color: dimColor(dims.grounding.pass) }}>{'●'}</span> grounding {'×'}0.3 = <strong className="cit-mono">{(0.3 * (dims.grounding.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                      <span><span style={{ color: dimColor(dims.advancement.pass) }}>{'●'}</span> advancement {'×'}0.2 = <strong className="cit-mono">{(0.2 * (dims.advancement.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- dimension-pass-driven color */}
-                      <span><span style={{ color: dimColor(dims.clarifies.pass) }}>{'●'}</span> clarifies {'×'}0.1 = <strong className="cit-mono">{(0.1 * (dims.clarifies.pass ? 1 : 0)).toFixed(2)}</strong></span>
-                    </div>
-                    <div className="cit-breakdown">
-                      <span>Stage A: <strong className="cit-mono">{stageA.toFixed(2)}</strong> <span className="cit-muted">{'×'}0.4 = {(0.4 * stageA).toFixed(2)}</span></span>
-                      <span>Judge: <strong className="cit-mono">{judgeQ.toFixed(2)}</strong>{!judgeUsed && <span className="cit-muted"> (default)</span>} <span className="cit-muted">{'×'}0.6 = {(0.6 * judgeQ).toFixed(2)}</span></span>
-                      {/* eslint-disable-next-line local/no-inline-style -- score-threshold-driven color */}
-                      <span>Total: <strong style={{ ...mono, color: turnScore >= 0.7 ? 'var(--success)' : turnScore >= 0.5 ? 'var(--warning)' : 'var(--danger)' }}>{turnScore.toFixed(2)}</strong></span>
-                    </div>
-                  </div>
-                );
+                return <CiteValidationScoreDetail turnScore={turnScore} dims={dims} judgeUsed={judgeUsed} />;
               }
-              return (
-                <div className="cit-fallback-val">
-                  Validation Score:{' '}
-                  {valData ? (
-                    // eslint-disable-next-line local/no-inline-style -- pass-driven color
-                    <span style={{ color: valData.pass ? 'var(--success)' : 'var(--danger)' }}>
-                      {valData.pass ? 'Pass' : 'Fail'}
-                    </span>
-                  ) : (
-                    <span className="cit-muted">{'—'}</span>
-                  )}
-                </div>
-              );
+              return <CiteValidationScoreFallback valData={valData} />;
             })()}
             {/* Validation Feedback */}
             {hints.length > 0 && (

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ExclusionGuardTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ExclusionGuardTab.tsx
@@ -46,127 +46,143 @@ function similarityColor(value: number): string {
 }
 
 export function ExclusionGuardTab({ diag }: ExclusionGuardTabProps) {
-  // --- Claim Extraction Guard ---
+  return (
+    <div style={{ padding: '8px 10px', flex: 1, minHeight: 200, overflowY: 'auto' }}>
+      {/* Section 1: Claim Extraction Guard */}
+      <ClaimExtractionGuardSection diag={diag} />
+
+      {/* Section 2: Draft Scope Check */}
+      <DraftScopeCheckSection diag={diag} />
+
+      {/* Section 3: Taxonomy Context Injection (future — t/489) */}
+      <TaxonomyInjectionSection diag={diag} />
+
+      {/* Section 4: Situation Injection (future — t/490) */}
+      <SituationInjectionSection diag={diag} />
+    </div>
+  );
+}
+
+function ClaimExtractionGuardSection({ diag }: ExclusionGuardTabProps) {
   const extTrace = diag?.extraction_trace as Record<string, unknown> | undefined;
   const exclusionGuard = extTrace?.exclusion_guard as ExclusionGuardData | undefined;
   const legacyViolations = extTrace?.exclusion_violations as ExclusionViolation[] | undefined;
 
-  // --- Draft Scope Check ---
+  return (
+    <Section title="Claim Extraction Guard" defaultOpen>
+      {exclusionGuard ? (
+        <>
+          <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginBottom: 6 }}>
+            Checked <strong>{exclusionGuard.checked}</strong> claims against{' '}
+            <strong>{exclusionGuard.refs_with_exclusion_vector}</strong> exclusion vectors
+            (threshold: {exclusionGuard.threshold.toFixed(2)})
+          </div>
+          {exclusionGuard.violations.length > 0 ? (
+            exclusionGuard.violations.map((v, i) => (
+              <ViolationItem key={i} violation={v} />
+            ))
+          ) : (
+            <AllClearBanner message={`All ${exclusionGuard.checked} claims within scope — 0 exclusion violations`} />
+          )}
+        </>
+      ) : legacyViolations && legacyViolations.length > 0 ? (
+        legacyViolations.map((v, i) => (
+          <ViolationItem key={i} violation={v} />
+        ))
+      ) : extTrace ? (
+        <AllClearBanner message="All claims within scope — 0 exclusion violations" />
+      ) : (
+        <NoDataMessage message="No exclusion guard data — extraction trace not available" />
+      )}
+    </Section>
+  );
+}
+
+function DraftScopeCheckSection({ diag }: ExclusionGuardTabProps) {
   const scopeDriftCheck = (diag as Record<string, unknown> | undefined)?.scope_drift_check as ScopeDriftCheckData | undefined;
   const legacyWarnings = (diag as Record<string, unknown> | undefined)?.scope_drift_warnings as ScopeDriftWarning[] | undefined;
 
   return (
-    <div style={{ padding: '8px 10px', flex: 1, minHeight: 200, overflowY: 'auto' }}>
-      {/* Section 1: Claim Extraction Guard */}
-      <Section title="Claim Extraction Guard" defaultOpen>
-        {exclusionGuard ? (
-          <>
-            <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginBottom: 6 }}>
-              Checked <strong>{exclusionGuard.checked}</strong> claims against{' '}
-              <strong>{exclusionGuard.refs_with_exclusion_vector}</strong> exclusion vectors
-              (threshold: {exclusionGuard.threshold.toFixed(2)})
-            </div>
-            {exclusionGuard.violations.length > 0 ? (
-              exclusionGuard.violations.map((v, i) => (
-                <ViolationItem key={i} violation={v} />
-              ))
-            ) : (
-              <AllClearBanner message={`All ${exclusionGuard.checked} claims within scope — 0 exclusion violations`} />
-            )}
-          </>
-        ) : legacyViolations && legacyViolations.length > 0 ? (
-          legacyViolations.map((v, i) => (
-            <ViolationItem key={i} violation={v} />
-          ))
-        ) : extTrace ? (
-          <AllClearBanner message="All claims within scope — 0 exclusion violations" />
-        ) : (
-          <NoDataMessage message="No exclusion guard data — extraction trace not available" />
-        )}
-      </Section>
+    <Section title="Draft Scope Check" defaultOpen>
+      {scopeDriftCheck ? (
+        <>
+          <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginBottom: 6 }}>
+            Checked <strong>{scopeDriftCheck.refs_checked}</strong> refs,{' '}
+            <strong>{scopeDriftCheck.refs_with_exclusion_vector}</strong> with exclusion vectors
+            (threshold: {scopeDriftCheck.threshold.toFixed(2)})
+          </div>
+          {scopeDriftCheck.warnings.length > 0 ? (
+            scopeDriftCheck.warnings.map((w, i) => (
+              <WarningItem key={i} warning={w} />
+            ))
+          ) : (
+            <AllClearBanner message={`All ${scopeDriftCheck.refs_checked} refs within scope — 0 drift warnings`} />
+          )}
+        </>
+      ) : legacyWarnings && legacyWarnings.length > 0 ? (
+        legacyWarnings.map((w, i) => (
+          <WarningItem key={i} warning={w} />
+        ))
+      ) : diag ? (
+        <AllClearBanner message="No scope drift detected — 0 warnings" />
+      ) : (
+        <NoDataMessage message="No scope drift data — diagnostics not available for this entry" />
+      )}
+    </Section>
+  );
+}
 
-      {/* Section 2: Draft Scope Check */}
-      <Section title="Draft Scope Check" defaultOpen>
-        {scopeDriftCheck ? (
-          <>
-            <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginBottom: 6 }}>
-              Checked <strong>{scopeDriftCheck.refs_checked}</strong> refs,{' '}
-              <strong>{scopeDriftCheck.refs_with_exclusion_vector}</strong> with exclusion vectors
-              (threshold: {scopeDriftCheck.threshold.toFixed(2)})
-            </div>
-            {scopeDriftCheck.warnings.length > 0 ? (
-              scopeDriftCheck.warnings.map((w, i) => (
-                <WarningItem key={i} warning={w} />
-              ))
-            ) : (
-              <AllClearBanner message={`All ${scopeDriftCheck.refs_checked} refs within scope — 0 drift warnings`} />
-            )}
-          </>
-        ) : legacyWarnings && legacyWarnings.length > 0 ? (
-          legacyWarnings.map((w, i) => (
-            <WarningItem key={i} warning={w} />
-          ))
-        ) : diag ? (
-          <AllClearBanner message="No scope drift detected — 0 warnings" />
-        ) : (
-          <NoDataMessage message="No scope drift data — diagnostics not available for this entry" />
-        )}
-      </Section>
+function TaxonomyInjectionSection({ diag }: ExclusionGuardTabProps) {
+  if (!(diag as Record<string, unknown> | undefined)?.taxonomy_injection_trace) return null;
+  const tit = (diag as Record<string, unknown>).taxonomy_injection_trace as {
+    considered: number; demoted: number;
+    demoted_nodes?: { node_id: string; exclusion_similarity: number }[];
+  };
+  return (
+    <Section title={`Taxonomy Context Injection — ${tit.considered} considered, ${tit.demoted} demoted`} defaultOpen>
+      {tit.demoted > 0 && tit.demoted_nodes ? (
+        tit.demoted_nodes.map((n, i) => (
+          <div key={i} style={{
+            padding: '4px 8px', marginBottom: 3, borderRadius: 4, fontSize: '0.7rem',
+            borderLeft: '3px solid var(--warning)', background: 'color-mix(in srgb, var(--warning) 6%, transparent)',
+          }}>
+            <span style={{ fontWeight: 600 }}>{n.node_id}</span>
+            <span style={{ marginLeft: 8, fontFamily: 'monospace', color: similarityColor(n.exclusion_similarity) }}>
+              {n.exclusion_similarity.toFixed(3)}
+            </span>
+          </div>
+        ))
+      ) : (
+        <AllClearBanner message={`All ${tit.considered} nodes passed exclusion filter`} />
+      )}
+    </Section>
+  );
+}
 
-      {/* Section 3: Taxonomy Context Injection (future — t/489) */}
-      {(diag as Record<string, unknown> | undefined)?.taxonomy_injection_trace ? (() => {
-        const tit = (diag as Record<string, unknown>).taxonomy_injection_trace as {
-          considered: number; demoted: number;
-          demoted_nodes?: { node_id: string; exclusion_similarity: number }[];
-        };
-        return (
-          <Section title={`Taxonomy Context Injection — ${tit.considered} considered, ${tit.demoted} demoted`} defaultOpen>
-            {tit.demoted > 0 && tit.demoted_nodes ? (
-              tit.demoted_nodes.map((n, i) => (
-                <div key={i} style={{
-                  padding: '4px 8px', marginBottom: 3, borderRadius: 4, fontSize: '0.7rem',
-                  borderLeft: '3px solid var(--warning)', background: 'color-mix(in srgb, var(--warning) 6%, transparent)',
-                }}>
-                  <span style={{ fontWeight: 600 }}>{n.node_id}</span>
-                  <span style={{ marginLeft: 8, fontFamily: 'monospace', color: similarityColor(n.exclusion_similarity) }}>
-                    {n.exclusion_similarity.toFixed(3)}
-                  </span>
-                </div>
-              ))
-            ) : (
-              <AllClearBanner message={`All ${tit.considered} nodes passed exclusion filter`} />
-            )}
-          </Section>
-        );
-      })() : null}
-
-      {/* Section 4: Situation Injection (future — t/490) */}
-      {(diag as Record<string, unknown> | undefined)?.situation_injection_trace ? (() => {
-        const sit = (diag as Record<string, unknown>).situation_injection_trace as {
-          considered: number; excluded: number;
-          excluded_situations?: { situation_id: string; exclusion_similarity: number }[];
-        };
-        return (
-          <Section title={`Situation Injection — ${sit.considered} considered, ${sit.excluded} excluded`} defaultOpen>
-            {sit.excluded > 0 && sit.excluded_situations ? (
-              sit.excluded_situations.map((s, i) => (
-                <div key={i} style={{
-                  padding: '4px 8px', marginBottom: 3, borderRadius: 4, fontSize: '0.7rem',
-                  borderLeft: '3px solid var(--warning)', background: 'color-mix(in srgb, var(--warning) 6%, transparent)',
-                }}>
-                  <span style={{ fontWeight: 600 }}>{s.situation_id}</span>
-                  <span style={{ marginLeft: 8, fontFamily: 'monospace', color: similarityColor(s.exclusion_similarity) }}>
-                    {s.exclusion_similarity.toFixed(3)}
-                  </span>
-                </div>
-              ))
-            ) : (
-              <AllClearBanner message={`All ${sit.considered} situations passed exclusion filter`} />
-            )}
-          </Section>
-        );
-      })() : null}
-    </div>
+function SituationInjectionSection({ diag }: ExclusionGuardTabProps) {
+  if (!(diag as Record<string, unknown> | undefined)?.situation_injection_trace) return null;
+  const sit = (diag as Record<string, unknown>).situation_injection_trace as {
+    considered: number; excluded: number;
+    excluded_situations?: { situation_id: string; exclusion_similarity: number }[];
+  };
+  return (
+    <Section title={`Situation Injection — ${sit.considered} considered, ${sit.excluded} excluded`} defaultOpen>
+      {sit.excluded > 0 && sit.excluded_situations ? (
+        sit.excluded_situations.map((s, i) => (
+          <div key={i} style={{
+            padding: '4px 8px', marginBottom: 3, borderRadius: 4, fontSize: '0.7rem',
+            borderLeft: '3px solid var(--warning)', background: 'color-mix(in srgb, var(--warning) 6%, transparent)',
+          }}>
+            <span style={{ fontWeight: 600 }}>{s.situation_id}</span>
+            <span style={{ marginLeft: 8, fontFamily: 'monospace', color: similarityColor(s.exclusion_similarity) }}>
+              {s.exclusion_similarity.toFixed(3)}
+            </span>
+          </div>
+        ))
+      ) : (
+        <AllClearBanner message={`All ${sit.considered} situations passed exclusion filter`} />
+      )}
+    </Section>
   );
 }
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.tsx
@@ -9,6 +9,99 @@ export interface LookaheadTabProps {
   lookaheadDiag: any;
 }
 
+// --- Strategic Assessment helpers (extracted verbatim, one per utility dimension) ---
+function assessPosition(r: any, posDelta: number, weakClaims: number): string[] {
+  const assessments: string[] = [];
+  if (posDelta < -0.03 && r.utility_before.position_strength > 0.7) {
+    assessments.push(`Position dilution: speaker had strong position (${r.utility_before.position_strength.toFixed(2)}) but new claims drag the average down${weakClaims > 0 ? ` — ${weakClaims} weak claim${weakClaims !== 1 ? 's' : ''} (< 0.4 strength) pulling the mean` : ''}.`);
+  } else if (posDelta < -0.03) {
+    assessments.push(`Position weakened: new claims undermine the speaker's existing arguments.`);
+  } else if (posDelta > 0.03) {
+    assessments.push(`Position strengthened: new claims reinforce the speaker's stance (+${posDelta.toFixed(3)}).`);
+  }
+  return assessments;
+}
+
+function assessAttack(r: any, atkDelta: number): string[] {
+  const assessments: string[] = [];
+  if (atkDelta < 0.001 && r.utility_before.attack_effectiveness < 0.3) {
+    assessments.push(`No offensive impact: claims are defensive — they reinforce the speaker's position but don't target opponent weak points.`);
+  } else if (atkDelta < 0.001 && r.utility_before.attack_effectiveness >= 0.3) {
+    assessments.push(`Attack plateau: speaker already has good attack coverage (${r.utility_before.attack_effectiveness.toFixed(2)}) and these claims don't extend it.`);
+  } else if (atkDelta > 0.05) {
+    assessments.push(`Strong offensive move: attacks landed on opponent nodes (+${atkDelta.toFixed(3)} effectiveness).`);
+  }
+  return assessments;
+}
+
+function assessCrux(r: any, crxDelta: number): string[] {
+  const assessments: string[] = [];
+  if (crxDelta < 0.001 && r.utility_before.crux_engagement >= 0.9) {
+    assessments.push(`Cruxes fully addressed: all identified cruxes already engaged — new claims don't open new territory.`);
+  } else if (crxDelta < 0.001 && r.utility_before.crux_engagement < 0.5) {
+    assessments.push(`Crux avoidance: ${((1 - r.utility_before.crux_engagement) * 100).toFixed(0)}% of cruxes unaddressed and these claims don't engage them.`);
+  } else if (crxDelta > 0.05) {
+    assessments.push(`Crux engagement improved: speaker addressed previously unengaged disagreement points.`);
+  }
+  return assessments;
+}
+
+function assessPattern(r: any, posDelta: number, atkDelta: number): string[] {
+  const assessments: string[] = [];
+  if (!r.pass && posDelta < 0 && atkDelta < 0.001) {
+    assessments.push(`Pattern: padding — speaker is adding volume without advancing the debate. Retry hint would push toward targeted attacks on opponent weak points or unresolved cruxes.`);
+  } else if (!r.pass && r.utility_delta >= 0 && r.utility_delta < r.threshold) {
+    assessments.push(`Pattern: marginal — claims add slight value but below the threshold for meaningful contribution. More specific, falsifiable claims would score higher.`);
+  } else if (r.pass && r.utility_delta > 0.05) {
+    assessments.push(`Pattern: strong move — claims meaningfully advance the speaker's position.`);
+  }
+  return assessments;
+}
+
+function buildStrategicAssessments(r: any): string[] {
+  const posDelta = r.utility_after.position_strength - r.utility_before.position_strength;
+  const atkDelta = r.utility_after.attack_effectiveness - r.utility_before.attack_effectiveness;
+  const crxDelta = r.utility_after.crux_engagement - r.utility_before.crux_engagement;
+  const claims = r.tentative_claims;
+  const weakClaims = claims.filter((c: any) => c.strength < 0.4).length;
+  const strongClaims = claims.filter((c: any) => c.strength >= 0.7).length;
+
+  const assessments: string[] = [];
+  assessments.push(...assessPosition(r, posDelta, weakClaims));
+  assessments.push(...assessAttack(r, atkDelta));
+  assessments.push(...assessCrux(r, crxDelta));
+  assessments.push(...assessPattern(r, posDelta, atkDelta));
+  return assessments;
+}
+
+// --- Utility Breakdown row helpers (extracted verbatim) ---
+function utilityHint(k: string, b: number, d: number): string {
+  return k === 'position_strength'
+    ? (d < -0.03 ? 'diluting' : d > 0.03 ? 'reinforcing' : 'stable')
+    : k === 'attack_effectiveness'
+    ? (d < 0.001 ? (b < 0.3 ? 'no attacks' : 'plateau') : 'attacks landed')
+    : k === 'crux_engagement'
+    ? (d < 0.001 ? (b >= 0.9 ? 'fully engaged' : 'avoiding cruxes') : 'engaging')
+    : '';
+}
+
+function utilityHintColor(hint: string): string {
+  return hint === 'diluting' || hint === 'no attacks' || hint === 'avoiding cruxes' ? 'var(--danger)'
+    : hint === 'stable' || hint === 'plateau' || hint === 'fully engaged' ? 'var(--text-muted)'
+    : 'var(--success)';
+}
+
+// --- Tentative claim metadata derivation (extracted verbatim) ---
+function deriveClaimMeta(c: any, pca: any, firstPca: any): { marginalDelta: any; reason: any; claimColor: string; label: string } {
+  const classification = pca?.classification;
+  const marginalDelta = pca?.marginal_delta;
+  const reason = firstPca?.analysis[classification === 'STRONG' ? 'strongFoundations' : 'avoidClaims']
+    ?.find((a: any) => a.text === c.text)?.reason;
+  const claimColor = classification === 'STRONG' ? 'var(--success)' : classification === 'WEAK' ? 'var(--danger)' : (c.strength >= 0.7 ? 'var(--success)' : c.strength >= 0.4 ? 'var(--warning)' : 'var(--danger)');
+  const label = classification ?? (c.strength >= 0.7 ? 'STRONG' : c.strength >= 0.4 ? 'MODERATE' : 'WEAK');
+  return { marginalDelta, reason, claimColor, label };
+}
+
 export function LookaheadTab(props: LookaheadTabProps) {
   const { lookaheadDiag } = props;
   return (
@@ -59,42 +152,7 @@ export function LookaheadTab(props: LookaheadTabProps) {
       {/* Strategic Assessment */}
       {(() => {
         const r = lookaheadDiag.first_attempt;
-        const posDelta = r.utility_after.position_strength - r.utility_before.position_strength;
-        const atkDelta = r.utility_after.attack_effectiveness - r.utility_before.attack_effectiveness;
-        const crxDelta = r.utility_after.crux_engagement - r.utility_before.crux_engagement;
-        const claims = r.tentative_claims;
-        const weakClaims = claims.filter((c: any) => c.strength < 0.4).length;
-        const strongClaims = claims.filter((c: any) => c.strength >= 0.7).length;
-
-        const assessments: string[] = [];
-        if (posDelta < -0.03 && r.utility_before.position_strength > 0.7) {
-          assessments.push(`Position dilution: speaker had strong position (${r.utility_before.position_strength.toFixed(2)}) but new claims drag the average down${weakClaims > 0 ? ` — ${weakClaims} weak claim${weakClaims !== 1 ? 's' : ''} (< 0.4 strength) pulling the mean` : ''}.`);
-        } else if (posDelta < -0.03) {
-          assessments.push(`Position weakened: new claims undermine the speaker's existing arguments.`);
-        } else if (posDelta > 0.03) {
-          assessments.push(`Position strengthened: new claims reinforce the speaker's stance (+${posDelta.toFixed(3)}).`);
-        }
-        if (atkDelta < 0.001 && r.utility_before.attack_effectiveness < 0.3) {
-          assessments.push(`No offensive impact: claims are defensive — they reinforce the speaker's position but don't target opponent weak points.`);
-        } else if (atkDelta < 0.001 && r.utility_before.attack_effectiveness >= 0.3) {
-          assessments.push(`Attack plateau: speaker already has good attack coverage (${r.utility_before.attack_effectiveness.toFixed(2)}) and these claims don't extend it.`);
-        } else if (atkDelta > 0.05) {
-          assessments.push(`Strong offensive move: attacks landed on opponent nodes (+${atkDelta.toFixed(3)} effectiveness).`);
-        }
-        if (crxDelta < 0.001 && r.utility_before.crux_engagement >= 0.9) {
-          assessments.push(`Cruxes fully addressed: all identified cruxes already engaged — new claims don't open new territory.`);
-        } else if (crxDelta < 0.001 && r.utility_before.crux_engagement < 0.5) {
-          assessments.push(`Crux avoidance: ${((1 - r.utility_before.crux_engagement) * 100).toFixed(0)}% of cruxes unaddressed and these claims don't engage them.`);
-        } else if (crxDelta > 0.05) {
-          assessments.push(`Crux engagement improved: speaker addressed previously unengaged disagreement points.`);
-        }
-        if (!r.pass && posDelta < 0 && atkDelta < 0.001) {
-          assessments.push(`Pattern: padding — speaker is adding volume without advancing the debate. Retry hint would push toward targeted attacks on opponent weak points or unresolved cruxes.`);
-        } else if (!r.pass && r.utility_delta >= 0 && r.utility_delta < r.threshold) {
-          assessments.push(`Pattern: marginal — claims add slight value but below the threshold for meaningful contribution. More specific, falsifiable claims would score higher.`);
-        } else if (r.pass && r.utility_delta > 0.05) {
-          assessments.push(`Pattern: strong move — claims meaningfully advance the speaker's position.`);
-        }
+        const assessments = buildStrategicAssessments(r);
 
         if (assessments.length === 0) return null;
         return (
@@ -127,16 +185,8 @@ export function LookaheadTab(props: LookaheadTabProps) {
               const b = lookaheadDiag.first_attempt.utility_before[k];
               const a = lookaheadDiag.first_attempt.utility_after[k];
               const d = a - b;
-              const hint = k === 'position_strength'
-                ? (d < -0.03 ? 'diluting' : d > 0.03 ? 'reinforcing' : 'stable')
-                : k === 'attack_effectiveness'
-                ? (d < 0.001 ? (b < 0.3 ? 'no attacks' : 'plateau') : 'attacks landed')
-                : k === 'crux_engagement'
-                ? (d < 0.001 ? (b >= 0.9 ? 'fully engaged' : 'avoiding cruxes') : 'engaging')
-                : '';
-              const hintColor = hint === 'diluting' || hint === 'no attacks' || hint === 'avoiding cruxes' ? 'var(--danger)'
-                : hint === 'stable' || hint === 'plateau' || hint === 'fully engaged' ? 'var(--text-muted)'
-                : 'var(--success)';
+              const hint = utilityHint(k, b, d);
+              const hintColor = utilityHintColor(hint);
               return (
                 // eslint-disable-next-line local/no-inline-style -- dynamic fontWeight for composite row
                 <tr key={k} style={{ borderBottom: '1px solid var(--border)', fontWeight: k === 'composite' ? 700 : 400 }}>
@@ -171,12 +221,7 @@ export function LookaheadTab(props: LookaheadTabProps) {
           </summary>
             {claims.map((c: any, i: number) => {
               const pca = firstPca?.perClaim[i];
-              const classification = pca?.classification;
-              const marginalDelta = pca?.marginal_delta;
-              const reason = firstPca?.analysis[classification === 'STRONG' ? 'strongFoundations' : 'avoidClaims']
-                ?.find((a: any) => a.text === c.text)?.reason;
-              const claimColor = classification === 'STRONG' ? 'var(--success)' : classification === 'WEAK' ? 'var(--danger)' : (c.strength >= 0.7 ? 'var(--success)' : c.strength >= 0.4 ? 'var(--warning)' : 'var(--danger)');
-              const label = classification ?? (c.strength >= 0.7 ? 'STRONG' : c.strength >= 0.4 ? 'MODERATE' : 'WEAK');
+              const { marginalDelta, reason, claimColor, label } = deriveClaimMeta(c, pca, firstPca);
               return (
                 // eslint-disable-next-line local/no-inline-style -- dynamic claimColor border
                 <div key={i} style={{ margin: '4px 0', paddingLeft: 8, borderLeft: `2px solid ${claimColor}40`, fontSize: '0.7rem' }}>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/PlanTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/PlanTab.tsx
@@ -17,6 +17,61 @@ export interface PlanTabProps {
   setSelectedTaxRefId: (id: string | null) => void;
 }
 
+function PlanEmptyWarning({ planStage }: { planStage: any }) {
+  const show = !planStage.parse_error && planStage.work_product && Object.keys(planStage.work_product).length === 0;
+  if (!show) return null;
+  return (
+    <div className="plan-empty-warning">
+      No structured plan data — expand Raw Response below to inspect the model output.
+    </div>
+  );
+}
+
+type ArgStructItem = { point: string; evidence: string; taxonomy_anchor: string };
+
+function ArgumentStructureSection(props: {
+  items: unknown;
+  taxNodeMap: Map<string, Record<string, unknown>>;
+  selectedTaxRefId: string | null;
+  setSelectedTaxRefId: (id: string | null) => void;
+}) {
+  const { items, taxNodeMap, selectedTaxRefId, setSelectedTaxRefId } = props;
+  if (!(Array.isArray(items) && (items as ArgStructItem[]).length > 0)) return null;
+  return (
+    <details open><summary className="plan-section-summary">Argumentation Structure</summary>
+      {(items as ArgStructItem[]).map((s, i) => (
+        <div key={i} className="plan-arg">
+          <div className="plan-arg-point"><Highlight text={s.point} /></div>
+          {s.evidence && <div className="plan-detail-text"><Highlight text={s.evidence} /></div>}
+          {s.taxonomy_anchor && (
+            <div className="plan-mt3">
+              <span className="plan-muted-2xs">Anchor: </span>
+              <button
+                onClick={() => setSelectedTaxRefId(selectedTaxRefId === s.taxonomy_anchor ? null : s.taxonomy_anchor)}
+                className="plan-anchor-btn"
+              >{s.taxonomy_anchor}</button>
+              {(() => { const lbl = (taxNodeMap.get(s.taxonomy_anchor!) as TaxRefNode | undefined)?.label; return lbl ? <span className="plan-muted-2xs"> — {lbl}</span> : null; })()}
+            </div>
+          )}
+        </div>
+      ))}
+    </details>
+  );
+}
+
+function AnticipatedList({ items, title }: { items: unknown; title: string }) {
+  if (!(Array.isArray(items) && (items as string[]).length > 0)) return null;
+  return (
+    <details open><summary className="plan-section-summary">{title}</summary>
+      <ul className="plan-list">
+        {(items as string[]).map((r, i) => (
+          <li key={i}><Highlight text={r} /></li>
+        ))}
+      </ul>
+    </details>
+  );
+}
+
 export function PlanTab(props: PlanTabProps) {
   const { planStage, planAttempts, taxNodeMap, allEdges, selectedTaxRefId, setSelectedTaxRefId } = props;
   return (
@@ -35,11 +90,7 @@ export function PlanTab(props: PlanTabProps) {
         </div>
       )}
       {/* Empty work_product fallback */}
-      {!planStage.parse_error && planStage.work_product && Object.keys(planStage.work_product).length === 0 && (
-        <div className="plan-empty-warning">
-          No structured plan data — expand Raw Response below to inspect the model output.
-        </div>
-      )}
+      <PlanEmptyWarning planStage={planStage} />
       {/* Opponent Intelligence */}
       {(() => {
         const prompt = planStage.prompt ?? '';
@@ -138,26 +189,12 @@ export function PlanTab(props: PlanTabProps) {
         </details>
       )}
       {/* Argumentation Structure */}
-      {Array.isArray((planStage.work_product as Record<string, unknown>).argument_structure) && ((planStage.work_product as Record<string, unknown>).argument_structure as { point: string; evidence: string; taxonomy_anchor: string }[]).length > 0 && (
-        <details open><summary className="plan-section-summary">Argumentation Structure</summary>
-          {((planStage.work_product as Record<string, unknown>).argument_structure as { point: string; evidence: string; taxonomy_anchor: string }[]).map((s, i) => (
-            <div key={i} className="plan-arg">
-              <div className="plan-arg-point"><Highlight text={s.point} /></div>
-              {s.evidence && <div className="plan-detail-text"><Highlight text={s.evidence} /></div>}
-              {s.taxonomy_anchor && (
-                <div className="plan-mt3">
-                  <span className="plan-muted-2xs">Anchor: </span>
-                  <button
-                    onClick={() => setSelectedTaxRefId(selectedTaxRefId === s.taxonomy_anchor ? null : s.taxonomy_anchor)}
-                    className="plan-anchor-btn"
-                  >{s.taxonomy_anchor}</button>
-                  {(() => { const lbl = (taxNodeMap.get(s.taxonomy_anchor!) as TaxRefNode | undefined)?.label; return lbl ? <span className="plan-muted-2xs"> — {lbl}</span> : null; })()}
-                </div>
-              )}
-            </div>
-          ))}
-        </details>
-      )}
+      <ArgumentStructureSection
+        items={(planStage.work_product as Record<string, unknown>).argument_structure}
+        taxNodeMap={taxNodeMap}
+        selectedTaxRefId={selectedTaxRefId}
+        setSelectedTaxRefId={setSelectedTaxRefId}
+      />
       {/* Argument Sketch */}
       {!!(planStage.work_product as Record<string, unknown>).argument_sketch && (
         <details open><summary className="plan-section-summary">Argument Sketch</summary>
@@ -167,25 +204,9 @@ export function PlanTab(props: PlanTabProps) {
         </details>
       )}
       {/* Anticipated Responses */}
-      {Array.isArray((planStage.work_product as Record<string, unknown>).anticipated_responses) && ((planStage.work_product as Record<string, unknown>).anticipated_responses as string[]).length > 0 && (
-        <details open><summary className="plan-section-summary">Anticipated Responses</summary>
-          <ul className="plan-list">
-            {((planStage.work_product as Record<string, unknown>).anticipated_responses as string[]).map((r, i) => (
-              <li key={i}><Highlight text={r} /></li>
-            ))}
-          </ul>
-        </details>
-      )}
+      <AnticipatedList items={(planStage.work_product as Record<string, unknown>).anticipated_responses} title="Anticipated Responses" />
       {/* Anticipated Challenges */}
-      {Array.isArray((planStage.work_product as Record<string, unknown>).anticipated_challenges) && ((planStage.work_product as Record<string, unknown>).anticipated_challenges as string[]).length > 0 && (
-        <details open><summary className="plan-section-summary">Anticipated Challenges</summary>
-          <ul className="plan-list">
-            {((planStage.work_product as Record<string, unknown>).anticipated_challenges as string[]).map((r, i) => (
-              <li key={i}><Highlight text={r} /></li>
-            ))}
-          </ul>
-        </details>
-      )}
+      <AnticipatedList items={(planStage.work_product as Record<string, unknown>).anticipated_challenges} title="Anticipated Challenges" />
       {/* -- Per-attempt sections -- */}
       {planAttempts.length > 0 && planAttempts.map((attempt, ai) => {
         const isSingle = planAttempts.length === 1;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
@@ -355,67 +355,78 @@ function ArgNetMinimap({ nodes, edges }: { nodes: ArgumentNetworkNode[]; edges: 
   );
 }
 
-/** Inline sub-component: confidence impact trace from taxonomy store. */
-function ConfidenceImpactTrace({ debateId }: { debateId: string }) {
+interface ConfidenceImpact { nodeId: string; label: string; pov: string; entry: WeightHistoryEntry }
+
+/** Collect matching history entries from one history array into the shared impacts list. */
+function collectHistoryImpacts(
+  history: WeightHistoryEntry[] | undefined,
+  n: { id: string; label: string },
+  pov: string,
+  debateId: string,
+  impacts: ConfidenceImpact[],
+) {
+  if (!history) return;
+  for (const h of history) {
+    if (h.reason?.includes(debateId)) {
+      impacts.push({ nodeId: n.id, label: n.label, pov, entry: h });
+    }
+  }
+}
+
+/** Gather confidence/priority/operationality history impacts for a debate from the taxonomy store. */
+function collectConfidenceImpacts(debateId: string): ConfidenceImpact[] {
   const taxState = useTaxonomyStore.getState();
-  const impacts: { nodeId: string; label: string; pov: string; entry: WeightHistoryEntry }[] = [];
+  const impacts: ConfidenceImpact[] = [];
   for (const pov of ['accelerationist', 'safetyist', 'skeptic'] as const) {
     const file = taxState[pov];
     if (!file) continue;
     for (const n of file.nodes) {
-      if (n.confidence_history) {
-        for (const h of n.confidence_history) {
-          if (h.reason?.includes(debateId)) {
-            impacts.push({ nodeId: n.id, label: n.label, pov, entry: h });
-          }
-        }
-      }
-      if (n.priority_history) {
-        for (const h of n.priority_history) {
-          if (h.reason?.includes(debateId)) {
-            impacts.push({ nodeId: n.id, label: n.label, pov, entry: h });
-          }
-        }
-      }
-      if (n.operationality_history) {
-        for (const h of n.operationality_history) {
-          if (h.reason?.includes(debateId)) {
-            impacts.push({ nodeId: n.id, label: n.label, pov, entry: h });
-          }
-        }
-      }
+      collectHistoryImpacts(n.confidence_history, n, pov, debateId, impacts);
+      collectHistoryImpacts(n.priority_history, n, pov, debateId, impacts);
+      collectHistoryImpacts(n.operationality_history, n, pov, debateId, impacts);
     }
   }
+  return impacts;
+}
+
+/** Props-only sub-component: renders a single confidence-impact row. */
+function ConfidenceImpactRow({ imp }: { imp: ConfidenceImpact }) {
+  const deltaColor = imp.entry.delta > 0 ? 'var(--success)' : imp.entry.delta < 0 ? 'var(--danger)' : 'var(--text-muted)';
+  return (
+    <div className="ant-impact-row">
+      <code className="ant-impact-code">{imp.nodeId}</code>
+      <span className="ant-muted">{imp.label.length > 40 ? imp.label.slice(0, 40) + '…' : imp.label}</span>
+      <span className="ant-value">{imp.entry.value.toFixed(2)}</span>
+      {/* eslint-disable-next-line local/no-inline-style -- color is data-driven from delta sign */}
+      <span style={{ color: deltaColor, fontWeight: 600 }}>
+        {imp.entry.delta > 0 ? '+' : ''}{imp.entry.delta.toFixed(2)}
+      </span>
+      {imp.entry.attack_claim && (
+        <span className="ant-attack-claim" title={imp.entry.attack_claim}>
+          ← {imp.entry.attack_claim.length > 50 ? imp.entry.attack_claim.slice(0, 50) + '…' : imp.entry.attack_claim}
+        </span>
+      )}
+      {imp.entry.robustness != null && imp.entry.robustness >= 2 && (
+        <span className="ant-robust-chip">
+          {imp.entry.robustness}× confirmed
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Inline sub-component: confidence impact trace from taxonomy store. */
+function ConfidenceImpactTrace({ debateId }: { debateId: string }) {
+  const impacts = collectConfidenceImpacts(debateId);
   if (impacts.length === 0) return null;
   return (
     <div className="ant-impact">
       <div className="ant-impact-title">
         Confidence Impact ({impacts.length})
       </div>
-      {impacts.map((imp, i) => {
-        const deltaColor = imp.entry.delta > 0 ? 'var(--success)' : imp.entry.delta < 0 ? 'var(--danger)' : 'var(--text-muted)';
-        return (
-          <div key={i} className="ant-impact-row">
-            <code className="ant-impact-code">{imp.nodeId}</code>
-            <span className="ant-muted">{imp.label.length > 40 ? imp.label.slice(0, 40) + '…' : imp.label}</span>
-            <span className="ant-value">{imp.entry.value.toFixed(2)}</span>
-            {/* eslint-disable-next-line local/no-inline-style -- color is data-driven from delta sign */}
-            <span style={{ color: deltaColor, fontWeight: 600 }}>
-              {imp.entry.delta > 0 ? '+' : ''}{imp.entry.delta.toFixed(2)}
-            </span>
-            {imp.entry.attack_claim && (
-              <span className="ant-attack-claim" title={imp.entry.attack_claim}>
-                ← {imp.entry.attack_claim.length > 50 ? imp.entry.attack_claim.slice(0, 50) + '…' : imp.entry.attack_claim}
-              </span>
-            )}
-            {imp.entry.robustness != null && imp.entry.robustness >= 2 && (
-              <span className="ant-robust-chip">
-                {imp.entry.robustness}× confirmed
-              </span>
-            )}
-          </div>
-        );
-      })}
+      {impacts.map((imp, i) => (
+        <ConfidenceImpactRow key={i} imp={imp} />
+      ))}
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.tsx
@@ -16,6 +16,39 @@ function speakerLabel(speaker: string): string {
   return POVER_INFO[speaker as Exclude<SpeakerId, 'user'>]?.label || speaker;
 }
 
+// Mean strength of conceded claims (matched to AN nodes)
+function computeConcededMean(store: CommitmentStore, pov: string, nodes: ArgumentNetworkNode[]): number {
+  let concSum = 0, concCount = 0;
+  for (const text of store.conceded) {
+    const match = nodes.find(n => n.speaker === pov && (n.text === text || n.text.includes(text) || text.includes(n.text)));
+    if (match) { concSum += match.computed_strength ?? match.base_strength ?? 0.5; concCount++; }
+  }
+  return concCount > 0 ? concSum / concCount : 0.5;
+}
+
+// Mean strength of attack targets
+function computeAttackTargetMean(
+  pov: string,
+  nodesBySpeaker: Map<string, ArgumentNetworkNode[]>,
+  nodeMap: Map<string, ArgumentNetworkNode>,
+  edges: ArgumentNetworkEdge[],
+): number {
+  const speakerNodes = nodesBySpeaker.get(pov) ?? [];
+  const speakerNodeIds = new Set(speakerNodes.map(n => n.id));
+  const attackTargetIds = new Set<string>();
+  for (const e of edges) {
+    if (speakerNodeIds.has(e.source) && (e as { type?: string }).type === 'attacks') {
+      attackTargetIds.add(e.target);
+    }
+  }
+  let atkSum = 0, atkCount = 0;
+  for (const id of attackTargetIds) {
+    const n = nodeMap.get(id);
+    if (n) { atkSum += n.computed_strength ?? n.base_strength ?? 0.5; atkCount++; }
+  }
+  return atkCount > 0 ? atkSum / atkCount : 0.5;
+}
+
 export function CommitmentsPanel({ commitments, nodes, edges, onGoToNode }: {
   commitments: Record<string, CommitmentStore>;
   nodes: ArgumentNetworkNode[];
@@ -72,7 +105,7 @@ export function CommitmentsPanel({ commitments, nodes, edges, onGoToNode }: {
   // Compute concession asymmetry per speaker (mirrors calibrationLogger logic)
   const asymmetryByPov = useMemo(() => {
     const result: Record<string, number | null> = {};
-    const nodeMap = new Map(nodes.map(n => [n.id, n]));
+    const nodeMap = new Map<string, ArgumentNetworkNode>(nodes.map(n => [n.id, n]));
     const nodesBySpeaker = new Map<string, ArgumentNetworkNode[]>();
     for (const n of nodes) {
       if (!nodesBySpeaker.has(n.speaker)) nodesBySpeaker.set(n.speaker, []);
@@ -81,31 +114,8 @@ export function CommitmentsPanel({ commitments, nodes, edges, onGoToNode }: {
 
     for (const [pov, store] of Object.entries(commitments)) {
       if (store.conceded.length === 0) { result[pov] = null; continue; }
-
-      // Mean strength of conceded claims (matched to AN nodes)
-      let concSum = 0, concCount = 0;
-      for (const text of store.conceded) {
-        const match = nodes.find(n => n.speaker === pov && (n.text === text || n.text.includes(text) || text.includes(n.text)));
-        if (match) { concSum += match.computed_strength ?? match.base_strength ?? 0.5; concCount++; }
-      }
-      const concededMean = concCount > 0 ? concSum / concCount : 0.5;
-
-      // Mean strength of attack targets
-      const speakerNodes = nodesBySpeaker.get(pov) ?? [];
-      const speakerNodeIds = new Set(speakerNodes.map(n => n.id));
-      const attackTargetIds = new Set<string>();
-      for (const e of edges) {
-        if (speakerNodeIds.has(e.source) && (e as { type?: string }).type === 'attacks') {
-          attackTargetIds.add(e.target);
-        }
-      }
-      let atkSum = 0, atkCount = 0;
-      for (const id of attackTargetIds) {
-        const n = nodeMap.get(id);
-        if (n) { atkSum += n.computed_strength ?? n.base_strength ?? 0.5; atkCount++; }
-      }
-      const atkMean = atkCount > 0 ? atkSum / atkCount : 0.5;
-
+      const concededMean = computeConcededMean(store, pov, nodes);
+      const atkMean = computeAttackTargetMean(pov, nodesBySpeaker, nodeMap, edges);
       result[pov] = atkMean - concededMean;
     }
     return result;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/EdgesUsed.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/EdgesUsed.tsx
@@ -67,6 +67,44 @@ function EdgesUsedGroup({ edgeType, edges, selectedIdx, onSelect, nodeLabels }: 
   );
 }
 
+function EdgeDescriptions({ srcNode, tgtNode }: {
+  srcNode: TaxRefNode | undefined;
+  tgtNode: TaxRefNode | undefined;
+}) {
+  if (!(srcNode?.description || tgtNode?.description)) return null;
+  return (
+    <div style={{ display: 'flex', gap: 8, margin: '10px 0' }}>
+      {srcNode?.description && (
+        <div style={{ flex: 1, padding: '8px 10px', background: 'var(--bg-secondary)', borderRadius: 6, border: '1px solid var(--border)' }}>
+          <div style={{ fontSize: 'var(--text-2xs)', fontWeight: 700, textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 4, letterSpacing: '0.04em' }}>Source Description</div>
+          <div style={{ fontSize: '0.75rem', lineHeight: 1.5 }}>{srcNode.description as string}</div>
+        </div>
+      )}
+      {tgtNode?.description && (
+        <div style={{ flex: 1, padding: '8px 10px', background: 'var(--bg-secondary)', borderRadius: 6, border: '1px solid var(--border)' }}>
+          <div style={{ fontSize: 'var(--text-2xs)', fontWeight: 700, textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 4, letterSpacing: '0.04em' }}>Target Description</div>
+          <div style={{ fontSize: '0.75rem', lineHeight: 1.5 }}>{tgtNode.description as string}</div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EdgeStatus({ status }: { status: string }) {
+  return (
+    <>
+      {status && status !== 'approved' && (
+        <span className={`edge-detail-status-badge status-${status}`}>
+          {status === 'rejected' ? '✗ ' : '● '}{status}
+        </span>
+      )}
+      {status === 'approved' && (
+        <span style={{ color: 'var(--success)', fontWeight: 600, fontSize: '0.75rem' }}>{'✓'} Approved</span>
+      )}
+    </>
+  );
+}
+
 export function EdgesUsedDetail({ edge, taxNodeMap, nodeLabels }: {
   edge: TaxRefEdge;
   taxNodeMap: Map<string, Record<string, unknown>>;
@@ -102,22 +140,7 @@ export function EdgesUsedDetail({ edge, taxNodeMap, nodeLabels }: {
       </div>
 
       {/* Source & Target descriptions */}
-      {(srcNode?.description || tgtNode?.description) && (
-        <div style={{ display: 'flex', gap: 8, margin: '10px 0' }}>
-          {srcNode?.description && (
-            <div style={{ flex: 1, padding: '8px 10px', background: 'var(--bg-secondary)', borderRadius: 6, border: '1px solid var(--border)' }}>
-              <div style={{ fontSize: 'var(--text-2xs)', fontWeight: 700, textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 4, letterSpacing: '0.04em' }}>Source Description</div>
-              <div style={{ fontSize: '0.75rem', lineHeight: 1.5 }}>{srcNode.description as string}</div>
-            </div>
-          )}
-          {tgtNode?.description && (
-            <div style={{ flex: 1, padding: '8px 10px', background: 'var(--bg-secondary)', borderRadius: 6, border: '1px solid var(--border)' }}>
-              <div style={{ fontSize: 'var(--text-2xs)', fontWeight: 700, textTransform: 'uppercase', color: 'var(--text-muted)', marginBottom: 4, letterSpacing: '0.04em' }}>Target Description</div>
-              <div style={{ fontSize: '0.75rem', lineHeight: 1.5 }}>{tgtNode.description as string}</div>
-            </div>
-          )}
-        </div>
-      )}
+      <EdgeDescriptions srcNode={srcNode} tgtNode={tgtNode} />
 
       {/* Rationale */}
       {edge.rationale && (
@@ -134,14 +157,7 @@ export function EdgesUsedDetail({ edge, taxNodeMap, nodeLabels }: {
       </div>
 
       {/* Status */}
-      {edge.status && edge.status !== 'approved' && (
-        <span className={`edge-detail-status-badge status-${edge.status}`}>
-          {edge.status === 'rejected' ? '✗ ' : '● '}{edge.status}
-        </span>
-      )}
-      {edge.status === 'approved' && (
-        <span style={{ color: 'var(--success)', fontWeight: 600, fontSize: '0.75rem' }}>{'✓'} Approved</span>
-      )}
+      <EdgeStatus status={edge.status} />
 
       {/* Notes */}
       {edge.notes && (

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/TurnValidation.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/TurnValidation.tsx
@@ -27,6 +27,149 @@ export const HINT_TARGET_STYLE: Record<string, { label: string; color: string; b
   judge: { label: 'QUALITY', color: 'var(--text-secondary)', bg: 'var(--bg-hover)' },
 };
 
+function AttemptDimensions({ v }: { v: TurnAttempt['validation'] }) {
+  return (
+    v.dimensions && (
+      <ScoreBreakdown dims={{
+        schema: v.dimensions.schema ?? { pass: true, issues: [] },
+        grounding: v.dimensions.grounding ?? { pass: true, issues: [] },
+        advancement: v.dimensions.advancement ?? { pass: true, signals: [] },
+        clarifies: v.dimensions.clarifies ?? { pass: true, signals: [] },
+      } as TurnValidationDimensions} processReward={v.process_reward ?? 0} judgeUsed={v.judge_used} />
+    )
+  );
+}
+
+function AttemptCaveats({ v }: { v: TurnAttempt['validation'] }) {
+  return (
+    (v.repairHints?.length ?? 0) > 0 && (
+      <>
+        <div className="tv-section-label">Caveats</div>
+        <ul className="tv-hint-list">
+          {v.repairHints.map((h, i) => {
+            const target = classifyHintTarget(h);
+            const ts = HINT_TARGET_STYLE[target];
+            return (
+              <li key={i} className="tv-mb3">
+                {/* eslint-disable-next-line local/no-inline-style -- dynamic color/bg from HINT_TARGET_STYLE */}
+                <span style={{
+                  display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
+                  color: ts.color, background: ts.bg, padding: '1px 5px',
+                  borderRadius: 3, marginRight: 5, verticalAlign: 'middle',
+                }}>{ts.label}</span>
+                {humanizeSpeakerIds(h)}
+              </li>
+            );
+          })}
+        </ul>
+      </>
+    )
+  );
+}
+
+function AttemptClarifies({ v }: { v: TurnAttempt['validation'] }) {
+  return (
+    (v.clarifies_taxonomy?.length ?? 0) > 0 && (
+      <>
+        <div className="tv-section-label">Taxonomy clarification hints</div>
+        <ul className="tv-hint-list">
+          {v.clarifies_taxonomy.map((h, i) => (
+            <li key={i}>
+              <strong>{h.action}</strong>
+              {h.node_id ? ` ${h.node_id}` : h.label ? ` "${h.label}"` : ''}
+              {h.rationale ? ` — ${h.rationale}` : ''}
+            </li>
+          ))}
+        </ul>
+      </>
+    )
+  );
+}
+
+function AttemptHintEffectiveness({ a }: { a: TurnAttempt }) {
+  // Hint effectiveness tracking (retry attempts only)
+  return (
+    a.hint_effectiveness && a.hint_effectiveness.length > 0 && (
+      <>
+        <div className="tv-section-label-mt6">Hint Effectiveness</div>
+        <div className="tv-mt4">
+          {(() => {
+            const he = a.hint_effectiveness as Array<{
+              hint_text: string; category: string; source: string; specificity: string;
+              resolution: string; cited_fragment?: string; fragment_persists?: boolean;
+              pre_score: number; post_score?: number; score_delta?: number;
+            }>;
+            const fixed = he.filter(h => h.resolution === 'fixed').length;
+            const partial = he.filter(h => h.resolution === 'partially_fixed').length;
+            const ignored = he.filter(h => h.resolution === 'ignored').length;
+            const worse = he.filter(h => h.resolution === 'made_worse').length;
+            const resColors: Record<string, string> = {
+              fixed: 'var(--success)', partially_fixed: 'var(--warning)', ignored: 'var(--text-muted)', made_worse: 'var(--danger)', pending: 'var(--text-secondary)',
+            };
+            const specColors: Record<string, string> = {
+              concrete: 'var(--success)', structural: 'var(--text-secondary)', evaluative: 'var(--warning)',
+            };
+            return (
+              <>
+                <div className="tv-he-summary">
+                  <span className="tv-success-bold">Fixed: {fixed}</span>
+                  <span className="tv-warning-bold">Partial: {partial}</span>
+                  <span className="tv-muted-bold">Ignored: {ignored}</span>
+                  <span className="tv-danger-bold">Worse: {worse}</span>
+                  <span className="tv-muted">
+                    Score: {he[0]?.pre_score?.toFixed(2)} → {he[0]?.post_score?.toFixed(2)} ({(he[0]?.score_delta ?? 0) >= 0 ? '+' : ''}{he[0]?.score_delta?.toFixed(2)})
+                  </span>
+                </div>
+                {he.map((h, hi) => (
+                  // eslint-disable-next-line local/no-inline-style -- dynamic borderLeft color from resColors
+                  <div key={hi} style={{
+                    marginBottom: 4, padding: '4px 8px', borderRadius: 4, fontSize: 'var(--text-2xs)',
+                    borderLeft: `3px solid ${resColors[h.resolution] ?? 'var(--text-muted)'}`,
+                    background: 'var(--bg-subtle)',
+                  }}>
+                    <div className="tv-he-row-head">
+                      {/* eslint-disable-next-line local/no-inline-style -- dynamic color/bg from resColors */}
+                      <span style={{
+                        fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 4px', borderRadius: 3,
+                        color: resColors[h.resolution] ?? 'var(--text-muted)',
+                        background: `${resColors[h.resolution] ?? 'var(--text-muted)'}18`,
+                      }}>{h.resolution.toUpperCase().replace('_', ' ')}</span>
+                      {/* eslint-disable-next-line local/no-inline-style -- dynamic color/bg from specColors */}
+                      <span style={{
+                        fontSize: 'var(--text-2xs)', padding: '0 4px', borderRadius: 3,
+                        color: specColors[h.specificity] ?? 'var(--text-muted)',
+                        background: `${specColors[h.specificity] ?? 'var(--text-muted)'}18`,
+                      }}>{h.specificity}</span>
+                      <span className="tv-muted-2xs">{h.source.replace('_', ' ')}</span>
+                    </div>
+                    <div>{humanizeSpeakerIds(h.hint_text)}</div>
+                    {h.cited_fragment && (
+                      <div className="tv-muted-2xs-mt2">
+                        Fragment: &ldquo;{humanizeSpeakerIds(h.cited_fragment)}&rdquo; {h.fragment_persists ? '— still present' : '— removed'}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </>
+            );
+          })()}
+        </div>
+      </>
+    )
+  );
+}
+
+function AttemptPromptDelta({ a }: { a: TurnAttempt }) {
+  return (
+    a.prompt_delta && (
+      <>
+        <div className="tv-section-label">Repair prompt delta</div>
+        <pre className="tv-prompt-delta">{a.prompt_delta}</pre>
+      </>
+    )
+  );
+}
+
 export function TurnValidationAttemptRow({ a }: { a: TurnAttempt }) {
   const [open, setOpen] = useState(false);
   const v = a.validation;
@@ -45,124 +188,11 @@ export function TurnValidationAttemptRow({ a }: { a: TurnAttempt }) {
       </div>
       {open && (
         <div className="tv-attempt-body">
-          {v.dimensions && (
-            <ScoreBreakdown dims={{
-              schema: v.dimensions.schema ?? { pass: true, issues: [] },
-              grounding: v.dimensions.grounding ?? { pass: true, issues: [] },
-              advancement: v.dimensions.advancement ?? { pass: true, signals: [] },
-              clarifies: v.dimensions.clarifies ?? { pass: true, signals: [] },
-            } as TurnValidationDimensions} processReward={v.process_reward ?? 0} judgeUsed={v.judge_used} />
-          )}
-          {(v.repairHints?.length ?? 0) > 0 && (
-            <>
-              <div className="tv-section-label">Caveats</div>
-              <ul className="tv-hint-list">
-                {v.repairHints.map((h, i) => {
-                  const target = classifyHintTarget(h);
-                  const ts = HINT_TARGET_STYLE[target];
-                  return (
-                    <li key={i} className="tv-mb3">
-                      {/* eslint-disable-next-line local/no-inline-style -- dynamic color/bg from HINT_TARGET_STYLE */}
-                      <span style={{
-                        display: 'inline-block', fontSize: 'var(--text-2xs)', fontWeight: 700,
-                        color: ts.color, background: ts.bg, padding: '1px 5px',
-                        borderRadius: 3, marginRight: 5, verticalAlign: 'middle',
-                      }}>{ts.label}</span>
-                      {humanizeSpeakerIds(h)}
-                    </li>
-                  );
-                })}
-              </ul>
-            </>
-          )}
-          {(v.clarifies_taxonomy?.length ?? 0) > 0 && (
-            <>
-              <div className="tv-section-label">Taxonomy clarification hints</div>
-              <ul className="tv-hint-list">
-                {v.clarifies_taxonomy.map((h, i) => (
-                  <li key={i}>
-                    <strong>{h.action}</strong>
-                    {h.node_id ? ` ${h.node_id}` : h.label ? ` "${h.label}"` : ''}
-                    {h.rationale ? ` — ${h.rationale}` : ''}
-                  </li>
-                ))}
-              </ul>
-            </>
-          )}
-          {/* Hint effectiveness tracking (retry attempts only) */}
-          {a.hint_effectiveness && a.hint_effectiveness.length > 0 && (
-            <>
-              <div className="tv-section-label-mt6">Hint Effectiveness</div>
-              <div className="tv-mt4">
-                {(() => {
-                  const he = a.hint_effectiveness as Array<{
-                    hint_text: string; category: string; source: string; specificity: string;
-                    resolution: string; cited_fragment?: string; fragment_persists?: boolean;
-                    pre_score: number; post_score?: number; score_delta?: number;
-                  }>;
-                  const fixed = he.filter(h => h.resolution === 'fixed').length;
-                  const partial = he.filter(h => h.resolution === 'partially_fixed').length;
-                  const ignored = he.filter(h => h.resolution === 'ignored').length;
-                  const worse = he.filter(h => h.resolution === 'made_worse').length;
-                  const resColors: Record<string, string> = {
-                    fixed: 'var(--success)', partially_fixed: 'var(--warning)', ignored: 'var(--text-muted)', made_worse: 'var(--danger)', pending: 'var(--text-secondary)',
-                  };
-                  const specColors: Record<string, string> = {
-                    concrete: 'var(--success)', structural: 'var(--text-secondary)', evaluative: 'var(--warning)',
-                  };
-                  return (
-                    <>
-                      <div className="tv-he-summary">
-                        <span className="tv-success-bold">Fixed: {fixed}</span>
-                        <span className="tv-warning-bold">Partial: {partial}</span>
-                        <span className="tv-muted-bold">Ignored: {ignored}</span>
-                        <span className="tv-danger-bold">Worse: {worse}</span>
-                        <span className="tv-muted">
-                          Score: {he[0]?.pre_score?.toFixed(2)} → {he[0]?.post_score?.toFixed(2)} ({(he[0]?.score_delta ?? 0) >= 0 ? '+' : ''}{he[0]?.score_delta?.toFixed(2)})
-                        </span>
-                      </div>
-                      {he.map((h, hi) => (
-                        // eslint-disable-next-line local/no-inline-style -- dynamic borderLeft color from resColors
-                        <div key={hi} style={{
-                          marginBottom: 4, padding: '4px 8px', borderRadius: 4, fontSize: 'var(--text-2xs)',
-                          borderLeft: `3px solid ${resColors[h.resolution] ?? 'var(--text-muted)'}`,
-                          background: 'var(--bg-subtle)',
-                        }}>
-                          <div className="tv-he-row-head">
-                            {/* eslint-disable-next-line local/no-inline-style -- dynamic color/bg from resColors */}
-                            <span style={{
-                              fontSize: 'var(--text-2xs)', fontWeight: 700, padding: '0 4px', borderRadius: 3,
-                              color: resColors[h.resolution] ?? 'var(--text-muted)',
-                              background: `${resColors[h.resolution] ?? 'var(--text-muted)'}18`,
-                            }}>{h.resolution.toUpperCase().replace('_', ' ')}</span>
-                            {/* eslint-disable-next-line local/no-inline-style -- dynamic color/bg from specColors */}
-                            <span style={{
-                              fontSize: 'var(--text-2xs)', padding: '0 4px', borderRadius: 3,
-                              color: specColors[h.specificity] ?? 'var(--text-muted)',
-                              background: `${specColors[h.specificity] ?? 'var(--text-muted)'}18`,
-                            }}>{h.specificity}</span>
-                            <span className="tv-muted-2xs">{h.source.replace('_', ' ')}</span>
-                          </div>
-                          <div>{humanizeSpeakerIds(h.hint_text)}</div>
-                          {h.cited_fragment && (
-                            <div className="tv-muted-2xs-mt2">
-                              Fragment: &ldquo;{humanizeSpeakerIds(h.cited_fragment)}&rdquo; {h.fragment_persists ? '— still present' : '— removed'}
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                    </>
-                  );
-                })()}
-              </div>
-            </>
-          )}
-          {a.prompt_delta && (
-            <>
-              <div className="tv-section-label">Repair prompt delta</div>
-              <pre className="tv-prompt-delta">{a.prompt_delta}</pre>
-            </>
-          )}
+          <AttemptDimensions v={v} />
+          <AttemptCaveats v={v} />
+          <AttemptClarifies v={v} />
+          <AttemptHintEffectiveness a={a} />
+          <AttemptPromptDelta a={a} />
         </div>
       )}
     </div>


### PR DESCRIPTION
Batch B5 (final) of t/1909 (parent t/1848). Behavior-preserving ADR-007 line-slice decomposition of the 13 remaining over-threshold files (cyclomatic 16–26): LookaheadTab, BriefTab, TurnValidation, CitationsTab, CiteTab, ExclusionGuardTab, EdgesUsed, PlanTab, CommitmentsPanel, WhatIfSection, DiagnosticsWindow, ArgumentNetworkTab, AffectTab → every function ≤15.

Cohesive sub-steps (guards, per-branch handlers, repeated JSX blocks) extracted **verbatim** into module-level helpers / props-only sub-components in the same file; hooks kept unconditional; ADR-003 catch-sites preserved.

**Verify (worktree off origin/main):** renderer tsc 0 errors, eslint 0 errors, **scope-wide complexity 19 → 0**, depcruise clean, vite build clean, **464 colocated tests pass**, **0 inline-style regression** (372 pre-existing dynamics unchanged). Shared `--max-warnings` gate untouched.

**This closes t/1909** — the entire debate-diagnostics scope is now **0 complexity warnings** (was 78 across B1–B5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)