### PR TITLE
feat(taxonomy): wire entity mentions into NodeDetail description (t/1908)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/HighlightedField.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HighlightedField.test.tsx
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/1908 — HighlightedTextarea's read-only render composes search-highlight (`mark`) and
+// bold-keyword (`strong`) ranges, and now interleaves stored entity-mention `.ref-link`
+// buttons when `mentionSegments` is supplied. These tests guard both the new mention path
+// AND the unchanged no-mention path (a regression guard for every existing consumer).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { MentionSegment } from './mentionText';
+
+// HighlightedTextarea reads find state from the taxonomy store; RefLinkButton (pulled in
+// via HighlightedField -> MentionField) transitively imports the bridge/debate-store/
+// flight-recorder — mocked so the module graph resolves without real side effects.
+const taxStore = vi.hoisted(() => ({ current: { findQuery: '', findMode: 'raw', findCaseSensitive: false } }));
+vi.mock('../../hooks/useTaxonomyStore', () => ({ useTaxonomyStore: () => taxStore.current }));
+vi.mock('../../hooks/useDebateStore', () => ({ useDebateStore: { getState: () => ({ setSelectedRef: vi.fn() }) } }));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+vi.mock('@bridge', () => ({ api: { getContainerMentions: vi.fn() } }));
+
+import { HighlightedTextarea } from './HighlightedField';
+
+const orgRef = { kind: 'organization', id: 'org-001' } as const;
+
+beforeEach(() => {
+  taxStore.current = { findQuery: '', findMode: 'raw', findCaseSensitive: false };
+});
+
+describe('HighlightedTextarea — read-only mention interleaving (t/1908)', () => {
+  it('interleaves a .ref-link button with plain text and keeps bold keywords bold', () => {
+    const onSelectRef = vi.fn();
+    const segments: MentionSegment[] = [
+      { text: 'OpenAI', ref: orgRef },
+      { text: ' builds models.\nExcludes: hardware.' },
+    ];
+    const { container } = render(
+      <HighlightedTextarea
+        value={'OpenAI builds models.\nExcludes: hardware.'}
+        readOnly
+        mentionSegments={segments}
+        onSelectRef={onSelectRef}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Organization: OpenAI — open details' });
+    expect(btn).toHaveClass('ref-link');
+    // The bold keyword in the plain segment is still rendered <strong> (mention path preserves it).
+    expect(container.querySelector('strong')?.textContent).toBe('Excludes:');
+    // No search query -> no <mark>; full text is present.
+    expect(container.querySelector('mark')).toBeNull();
+    expect(container.textContent).toContain('OpenAI');
+    expect(container.textContent).toContain('builds models.');
+  });
+
+  it('routes a mention click to onSelectRef with the segment ref', async () => {
+    const onSelectRef = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <HighlightedTextarea
+        value="OpenAI builds AI"
+        readOnly
+        mentionSegments={[{ text: 'OpenAI', ref: orgRef }, { text: ' builds AI' }]}
+        onSelectRef={onSelectRef}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /OpenAI/ }));
+    expect(onSelectRef).toHaveBeenCalledWith(orgRef);
+  });
+
+  it('applies search-highlight marks inside a plain segment (search still works with mentions)', () => {
+    taxStore.current = { findQuery: 'builds', findMode: 'raw', findCaseSensitive: false };
+    const { container } = render(
+      <HighlightedTextarea
+        value="OpenAI builds AI"
+        readOnly
+        mentionSegments={[{ text: 'OpenAI' , ref: orgRef }, { text: ' builds AI' }]}
+        onSelectRef={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /OpenAI/ })).toBeInTheDocument();
+    expect(container.querySelector('mark')?.textContent).toBe('builds');
+  });
+});
+
+describe('HighlightedTextarea — unchanged paths (regression guard)', () => {
+  it('read-only without mentions renders search-highlight marks and no buttons', () => {
+    taxStore.current = { findQuery: 'builds', findMode: 'raw', findCaseSensitive: false };
+    const { container } = render(<HighlightedTextarea value="OpenAI builds AI" readOnly />);
+    expect(container.querySelector('mark')?.textContent).toBe('builds');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('edit mode ignores mentionSegments (renders a textarea, no ref-links)', () => {
+    const { container } = render(
+      <HighlightedTextarea
+        value="OpenAI builds AI"
+        onChange={() => {}}
+        mentionSegments={[{ text: 'OpenAI', ref: orgRef }, { text: ' builds AI' }]}
+        onSelectRef={vi.fn()}
+      />,
+    );
+    expect(container.querySelector('textarea')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/HighlightedField.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HighlightedField.tsx
@@ -2,8 +2,11 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { useRef, useCallback, useMemo, type ReactNode, type CSSProperties } from 'react';
+import type { EntityRef } from '@lib/entities/types';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { buildSearchRegex } from '../../utils/searchRegex';
+import { RefLinkButton } from './MentionField';
+import type { MentionSegment } from './mentionText';
 
 interface HighlightedInputProps {
   value: string;
@@ -22,6 +25,10 @@ interface HighlightedTextareaProps {
   style?: CSSProperties;
   /** Literal substrings to render bold in the backdrop overlay (e.g. "Encompasses:", "Excludes:"). */
   boldKeywords?: readonly string[];
+  /** Read-only only (t/1908): stored entity-mention render segments to interleave as `.ref-link` buttons. */
+  mentionSegments?: readonly MentionSegment[];
+  /** Click handler for a mention `.ref-link` (paired with `mentionSegments`). */
+  onSelectRef?: (ref: EntityRef) => void;
 }
 
 const DEFAULT_BOLD_KEYWORDS: readonly string[] = ['Encompasses:', 'Excludes:'];
@@ -116,63 +123,103 @@ export function HighlightedInput({ value, onChange, readOnly, disabled, type, st
   );
 }
 
-/** Build formatted ReactNode[] for read-only display: line break before keywords + bold. */
-function useFormattedParts(text: string, boldKeywords: readonly string[]): ReactNode[] {
+/**
+ * Format one span of plain text for read-only display: interleave search-highlight (`mark`)
+ * and bold-keyword (`strong`, preceded by a `<br>` for visual separation) ranges. Pure —
+ * `searchRegex` is reset per call so it can be reused across segments; `keyPrefix` keeps
+ * React keys unique when several spans are concatenated. Extracted verbatim from the old
+ * `useFormattedParts` body (t/1908) so the no-mention render is unchanged.
+ */
+function formatFieldParts(
+  text: string,
+  boldKeywords: readonly string[],
+  searchRegex: RegExp | null,
+  keyPrefix: string,
+): ReactNode[] {
+  type Range = { start: number; end: number; kind: 'mark' | 'bold' };
+  const ranges: Range[] = [];
+
+  if (searchRegex) {
+    searchRegex.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    let i = 0;
+    while ((m = searchRegex.exec(text)) !== null && i < 100) {
+      if (m[0].length > 0) ranges.push({ start: m.index, end: m.index + m[0].length, kind: 'mark' });
+      else searchRegex.lastIndex++;
+      i++;
+    }
+  }
+
+  for (const kw of boldKeywords) {
+    if (!kw) continue;
+    let from = 0;
+    while (from <= text.length) {
+      const idx = text.indexOf(kw, from);
+      if (idx < 0) break;
+      ranges.push({ start: idx, end: idx + kw.length, kind: 'bold' });
+      from = idx + kw.length;
+    }
+  }
+
+  ranges.sort((a, b) => a.start - b.start || (a.kind === b.kind ? 0 : a.kind === 'mark' ? -1 : 1));
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let key = 0;
+  for (const r of ranges) {
+    if (r.start < lastIndex) continue;
+    if (r.start > lastIndex) parts.push(text.slice(lastIndex, r.start));
+    const content = text.slice(r.start, r.end);
+    if (r.kind === 'mark') {
+      parts.push(<mark key={`${keyPrefix}m${key++}`}>{content}</mark>);
+    } else {
+      // Line break before the bold keyword for visual separation
+      parts.push(<br key={`${keyPrefix}br${key}`} />);
+      parts.push(<strong key={`${keyPrefix}s${key++}`}>{content}</strong>);
+    }
+    lastIndex = r.end;
+  }
+  if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+  return parts;
+}
+
+/**
+ * Build formatted ReactNode[] for read-only display: line break before keywords + bold.
+ * When `mentionSegments` is supplied (t/1908), the text is first split into stored
+ * entity-mention spans — `ref` segments render as shared `.ref-link` buttons and each plain
+ * span is formatted with `formatFieldParts` — so mentions interleave with search/bold
+ * ranges. With no mention segments the whole text is formatted directly (unchanged path for
+ * every existing consumer). A `ref` segment with no `onSelectRef` degrades to plain text.
+ */
+function useFormattedParts(
+  text: string,
+  boldKeywords: readonly string[],
+  mentionSegments?: readonly MentionSegment[],
+  onSelectRef?: (ref: EntityRef) => void,
+): ReactNode[] {
   const { findQuery, findMode, findCaseSensitive } = useTaxonomyStore();
 
   return useMemo(() => {
     const searchRegex = buildSearchRegex(findQuery, findMode, findCaseSensitive);
-    type Range = { start: number; end: number; kind: 'mark' | 'bold' };
-    const ranges: Range[] = [];
-
-    if (searchRegex) {
-      searchRegex.lastIndex = 0;
-      let m: RegExpExecArray | null;
-      let i = 0;
-      while ((m = searchRegex.exec(text)) !== null && i < 100) {
-        if (m[0].length > 0) ranges.push({ start: m.index, end: m.index + m[0].length, kind: 'mark' });
-        else searchRegex.lastIndex++;
-        i++;
-      }
+    if (mentionSegments && mentionSegments.length > 0) {
+      const parts: ReactNode[] = [];
+      mentionSegments.forEach((seg, i) => {
+        if (seg.ref && onSelectRef) {
+          const ref = seg.ref;
+          parts.push(<RefLinkButton key={`seg${i}`} text={seg.text} refKind={ref.kind} onSelect={() => onSelectRef(ref)} />);
+        } else {
+          parts.push(...formatFieldParts(seg.text, boldKeywords, searchRegex, `seg${i}-`));
+        }
+      });
+      return parts;
     }
-
-    for (const kw of boldKeywords) {
-      if (!kw) continue;
-      let from = 0;
-      while (from <= text.length) {
-        const idx = text.indexOf(kw, from);
-        if (idx < 0) break;
-        ranges.push({ start: idx, end: idx + kw.length, kind: 'bold' });
-        from = idx + kw.length;
-      }
-    }
-
-    ranges.sort((a, b) => a.start - b.start || (a.kind === b.kind ? 0 : a.kind === 'mark' ? -1 : 1));
-    const parts: ReactNode[] = [];
-    let lastIndex = 0;
-    let key = 0;
-    for (const r of ranges) {
-      if (r.start < lastIndex) continue;
-      if (r.start > lastIndex) parts.push(text.slice(lastIndex, r.start));
-      const content = text.slice(r.start, r.end);
-      if (r.kind === 'mark') {
-        parts.push(<mark key={key++}>{content}</mark>);
-      } else {
-        // Line break before the bold keyword for visual separation
-        parts.push(<br key={`br-${key}`} />);
-        parts.push(<strong key={key++}>{content}</strong>);
-      }
-      lastIndex = r.end;
-    }
-    if (lastIndex < text.length) parts.push(text.slice(lastIndex));
-    return parts;
-  }, [text, findQuery, findMode, findCaseSensitive, boldKeywords]);
+    return formatFieldParts(text, boldKeywords, searchRegex, '');
+  }, [text, findQuery, findMode, findCaseSensitive, boldKeywords, mentionSegments, onSelectRef]);
 }
 
-export function HighlightedTextarea({ value, onChange, readOnly, rows, style, boldKeywords = DEFAULT_BOLD_KEYWORDS }: HighlightedTextareaProps) {
+export function HighlightedTextarea({ value, onChange, readOnly, rows, style, boldKeywords = DEFAULT_BOLD_KEYWORDS, mentionSegments, onSelectRef }: HighlightedTextareaProps) {
   const backdropRef = useRef<HTMLDivElement>(null);
   const parts = useHighlightParts(value, boldKeywords);
-  const formattedParts = useFormattedParts(value, boldKeywords);
+  const formattedParts = useFormattedParts(value, boldKeywords, mentionSegments, onSelectRef);
   const hasHighlight = parts !== null;
 
   const handleChange = useCallback(

--- a/taxonomy-editor/src/renderer/components/shared/MentionField.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/MentionField.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ recor
 vi.mock('@bridge', () => ({ api: { getContainerMentions: vi.fn() } }));
 
 import { api } from '@bridge';
-import { MentionField, useContainerMentions, useMentionRenderer } from './MentionField';
+import { MentionField, RefLinkButton, useContainerMentionKit, useContainerMentions, useMentionRenderer } from './MentionField';
 import type { ContainerField, ReconstructedContainer } from './mentionText';
 
 const getMentions = api.getContainerMentions as unknown as ReturnType<typeof vi.fn>;
@@ -102,5 +102,47 @@ describe('useMentionRenderer', () => {
     }
     render(<Missing />);
     expect(screen.getByTestId('out')).toHaveTextContent('FALLBACK');
+  });
+});
+
+describe('RefLinkButton', () => {
+  it('renders a .ref-link button with kind metadata and routes clicks (stopping propagation)', async () => {
+    const onSelect = vi.fn();
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <div onClick={onRowClick}>
+        <RefLinkButton text="OpenAI" refKind="organization" onSelect={onSelect} />
+      </div>,
+    );
+    const btn = screen.getByRole('button', { name: 'Organization: OpenAI — open details' });
+    expect(btn).toHaveClass('ref-link');
+    expect(btn).toHaveAttribute('data-ref-kind', 'organization');
+    await user.click(btn);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onRowClick).not.toHaveBeenCalled(); // stopPropagation kept the click off the row
+  });
+});
+
+describe('useContainerMentionKit', () => {
+  const container: ReconstructedContainer = {
+    text: 'OpenAI builds AI',
+    fields: [{ name: 'description', text: 'OpenAI builds AI', start: 0 }],
+  };
+
+  it('segmentsFor returns linkable segments for a field once mentions load', async () => {
+    getMentions.mockResolvedValue({ text_sha256: 'x', extracted_at: 't', mentions: [mention] });
+    const { result } = renderHook(() => useContainerMentionKit('node:x', container));
+    await waitFor(() => expect(result.current.segmentsFor('description').some(s => s.ref)).toBe(true));
+    const segs = result.current.segmentsFor('description');
+    expect(segs[0]).toEqual({ text: 'OpenAI', ref: { kind: 'organization', id: 'org-001' } });
+    expect(segs[1]).toEqual({ text: ' builds AI' });
+  });
+
+  it('segmentsFor returns [] for an absent field, and renderField still linkifies', async () => {
+    getMentions.mockResolvedValue({ text_sha256: 'x', extracted_at: 't', mentions: [mention] });
+    const { result } = renderHook(() => useContainerMentionKit('node:x', container));
+    expect(result.current.segmentsFor('nope')).toEqual([]);
+    await waitFor(() => expect(result.current.segmentsFor('description').some(s => s.ref)).toBe(true));
   });
 });

--- a/taxonomy-editor/src/renderer/components/shared/MentionField.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/MentionField.tsx
@@ -13,7 +13,7 @@ import type { EntityRef } from '@lib/entities/types';
 import type { Mention } from '@lib/entities/mentionTypes';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useDebateStore } from '../../hooks/useDebateStore';
-import { buildFieldSegments, type ContainerField, type ReconstructedContainer } from './mentionText';
+import { buildFieldSegments, type ContainerField, type MentionSegment, type ReconstructedContainer } from './mentionText';
 import './refLinkifyPlugin.css'; // MentionField hard-codes `.ref-link` without going through the plugin; this is the ONLY thing styling NodeDetail's mention links once the global leak is removed (t/1907, TL2 p/287#3)
 
 /**
@@ -48,6 +48,30 @@ function kindLabel(kind: EntityRef['kind']): string {
 }
 
 /**
+ * The single `.ref-link` treatment for a stored mention span (no per-kind color; kind via
+ * `data-ref-kind` + aria-label). Shared by `MentionField` and by `HighlightedField`'s
+ * read-only formatted render (t/1908), so both reading surfaces render byte-identical links.
+ * `stopPropagation` keeps a click inside the link from bubbling to a row/card handler.
+ */
+export function RefLinkButton({ text, refKind, onSelect }: {
+  text: string;
+  refKind: EntityRef['kind'];
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="ref-link"
+      data-ref-kind={refKind}
+      aria-label={`${kindLabel(refKind)}: ${text} — open details`}
+      onClick={e => { e.stopPropagation(); onSelect(); }}
+    >
+      {text}
+    </button>
+  );
+}
+
+/**
  * Render one reconstructed field's text with its mentions linkified. Renders the field's
  * **NFC** text (`field.text`) so offsets stay valid; visually identical to the raw field
  * by canonical equivalence. A field with no mentions is a single plain text node.
@@ -61,40 +85,55 @@ export function MentionField({ field, mentions, onSelectRef }: {
   return (
     <>
       {segments.map((seg, i) => seg.ref
-        ? (
-          <button
-            key={i}
-            type="button"
-            className="ref-link"
-            data-ref-kind={seg.ref.kind}
-            aria-label={`${kindLabel(seg.ref.kind)}: ${seg.text} — open details`}
-            onClick={e => { e.stopPropagation(); onSelectRef(seg.ref!); }}
-          >
-            {seg.text}
-          </button>
-        )
+        ? <RefLinkButton key={i} text={seg.text} refKind={seg.ref.kind} onSelect={() => onSelectRef(seg.ref!)} />
         : <span key={i}>{seg.text}</span>)}
     </>
   );
 }
 
 /**
- * Ergonomic kit entry point for a reading surface: fetches the container's mentions and
- * returns a `renderField(fieldName, fallback)` that linkifies that reconstructed field
- * (or renders `fallback` when the field is absent). Clicks open the shared DetailPane via
- * the debate store's `setSelectedRef` — the same routing as inline ref-links. This is the
- * frozen kit API the per-owner surface integrations (SituationDetail, FactsPanel) reuse.
+ * Lower-level kit for a reading surface: one `useContainerMentions` fetch, exposing both a
+ * `renderField(fieldName, fallback)` (linkifies a reconstructed field, or `fallback` when
+ * absent) and a `segmentsFor(fieldName)` (the field's render segments — for callers that
+ * must interleave mentions with their own formatting, e.g. `HighlightedTextarea` composing
+ * search-highlight + bold ranges, t/1908). Clicks route through the shared `onSelectRef`
+ * (debate store `setSelectedRef` → DetailPane), the same routing as inline ref-links.
  */
-export function useMentionRenderer(
+export interface ContainerMentionKit {
+  mentions: Mention[];
+  onSelectRef: (ref: EntityRef) => void;
+  renderField: (fieldName: string, fallback: string) => ReactNode;
+  segmentsFor: (fieldName: string) => MentionSegment[];
+}
+
+export function useContainerMentionKit(
   containerId: string | null,
   container: ReconstructedContainer,
-): (fieldName: string, fallback: string) => ReactNode {
+): ContainerMentionKit {
   const mentions = useContainerMentions(containerId);
   const onSelectRef = useCallback((ref: EntityRef) => useDebateStore.getState().setSelectedRef(ref), []);
-  return useCallback((fieldName: string, fallback: string): ReactNode => {
+  const renderField = useCallback((fieldName: string, fallback: string): ReactNode => {
     const field = container.fields.find(f => f.name === fieldName);
     return field
       ? <MentionField field={field} mentions={mentions} onSelectRef={onSelectRef} />
       : fallback;
   }, [container, mentions, onSelectRef]);
+  const segmentsFor = useCallback((fieldName: string): MentionSegment[] => {
+    const field = container.fields.find(f => f.name === fieldName);
+    return field ? buildFieldSegments(field, mentions) : [];
+  }, [container, mentions]);
+  return { mentions, onSelectRef, renderField, segmentsFor };
+}
+
+/**
+ * Ergonomic kit entry point for a reading surface: returns a `renderField(fieldName,
+ * fallback)` that linkifies that reconstructed field. This is the frozen kit API the
+ * per-owner surface integrations (SituationDetail, FactsPanel) reuse — a thin wrapper over
+ * `useContainerMentionKit`.
+ */
+export function useMentionRenderer(
+  containerId: string | null,
+  container: ReconstructedContainer,
+): (fieldName: string, fallback: string) => ReactNode {
+  return useContainerMentionKit(containerId, container).renderField;
 }

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -28,8 +28,9 @@ import { NodeEditHistory } from './NodeEditHistory';
 import { nodeTypeFromId, nodePovFromId } from '@lib/debate/nodeIdUtils';
 import { POV_KEYS } from '@lib/debate/types';
 import { api } from '@bridge';
-import { useMentionRenderer } from '../shared/MentionField';
-import { reconstructNodeContainer } from '../shared/mentionText';
+import { useContainerMentionKit } from '../shared/MentionField';
+import { reconstructNodeContainer, type MentionSegment } from '../shared/mentionText';
+import type { EntityRef } from '@lib/entities/types';
 import { EditConflictBadge, type NodeConflict } from '../conflict/edit-conflicts';
 import { triggerPovNodeRegeneration } from '../../utils/regeneratePlainDescription';
 import { generateAphorism } from '../../utils/regenerateAphorism';
@@ -133,14 +134,22 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
   // Stored entity-name mentions for this node's reading-flow text (t/1898 §4.2). Fetched
   // only in the read-only (reading) context — the editable editor uses inputs, not link
   // spans. `reconstructNodeContainer` rebuilds the FULL container so every field's offset
-  // basis is correct even for fields we don't linkify here (label + plain_description
-  // land in E; the HighlightedTextarea `description` path is a tracked follow-up).
+  // basis is correct. `label` + `plain_description` linkify via `renderMentionField`; the
+  // `description` field (rendered through `HighlightedTextarea`) interleaves its mention
+  // segments with search/bold ranges via `descriptionMention` (t/1908).
   const mentionContainer = useMemo(
     () => reconstructNodeContainer(node),
     [node.label, node.description, node.plain_description],
   );
-  const renderMentionField = useMentionRenderer(readOnly ? `node:${node.id}` : null, mentionContainer);
+  const mentionKit = useContainerMentionKit(readOnly ? `node:${node.id}` : null, mentionContainer);
+  const renderMentionField = mentionKit.renderField;
   const labelContent: ReactNode = readOnly ? renderMentionField('label', node.label) : node.label;
+  // Only engage the segment path when there is a real link to render, so the common
+  // no-mention read-only description keeps its exact existing formatting.
+  const descSegments = readOnly ? mentionKit.segmentsFor('description') : [];
+  const descriptionMention: DescriptionMention | undefined = descSegments.some(s => s.ref)
+    ? { segments: descSegments, onSelectRef: mentionKit.onSelectRef }
+    : undefined;
 
   // Eagerly load facts index so count badge is available
   const [factCount, setFactCount] = useState(() => getFactCount(node.id));
@@ -435,6 +444,7 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
             showAttributeInfo={showAttributeInfo}
             hasGraphAttrs={hasGraphAttrs}
             renderMentionField={renderMentionField}
+            descriptionMention={descriptionMention}
           />
         )}
 
@@ -785,6 +795,12 @@ function BeliefsMetricsRow({ node, showDtDrilldown, setShowDtDrilldown }: Belief
 
 // ── Content tab: Description section (extracted from NodeDetail for complexity) ──
 
+/** Entity-mention render segments for the read-only `description` field + their click handler (t/1908). */
+interface DescriptionMention {
+  segments: readonly MentionSegment[];
+  onSelectRef: (ref: EntityRef) => void;
+}
+
 interface DescriptionSectionProps {
   pov: Pov;
   node: PovNode;
@@ -797,9 +813,11 @@ interface DescriptionSectionProps {
   updatePovNode: (pov: Pov, id: string, updates: Partial<PovNode>) => void;
   /** Renders a reconstructed container field's text with linkified entity mentions (t/1898); undefined = plain. */
   renderMentionField?: (fieldName: string, fallback: string) => ReactNode;
+  /** Mention segments for the formal `description` HighlightedTextarea (t/1908); undefined = no links. */
+  descriptionMention?: DescriptionMention;
 }
 
-function DescriptionSection({ pov, node, readOnly, err, descMode, setDescMode, maybeRegenAphorism, update, updatePovNode, renderMentionField }: DescriptionSectionProps) {
+function DescriptionSection({ pov, node, readOnly, err, descMode, setDescMode, maybeRegenAphorism, update, updatePovNode, renderMentionField, descriptionMention }: DescriptionSectionProps) {
   return (
     <div className={`form-group ${err('description') ? 'has-error' : ''}`}>
       <div className="description-header">
@@ -816,6 +834,8 @@ function DescriptionSection({ pov, node, readOnly, err, descMode, setDescMode, m
             onChange={(v) => update({ description: v })}
             rows={6}
             readOnly={readOnly}
+            mentionSegments={descriptionMention?.segments}
+            onSelectRef={descriptionMention?.onSelectRef}
           />
           {err('description') && <div className="error-text">{err('description')}</div>}
         </div>
@@ -1003,9 +1023,11 @@ interface NodeDetailContentTabProps {
   hasGraphAttrs: boolean;
   /** Renders a reconstructed container field's text with linkified entity mentions (t/1898). */
   renderMentionField?: (fieldName: string, fallback: string) => ReactNode;
+  /** Mention segments for the formal `description` HighlightedTextarea (t/1908). */
+  descriptionMention?: DescriptionMention;
 }
 
-function NodeDetailContentTab({ pov, node, readOnly, err, descMode, setDescMode, maybeRegenAphorism, update, updatePovNode, showDtDrilldown, setShowDtDrilldown, expandedLineage, setExpandedLineage, showAttributeInfo, hasGraphAttrs, renderMentionField }: NodeDetailContentTabProps) {
+function NodeDetailContentTab({ pov, node, readOnly, err, descMode, setDescMode, maybeRegenAphorism, update, updatePovNode, showDtDrilldown, setShowDtDrilldown, expandedLineage, setExpandedLineage, showAttributeInfo, hasGraphAttrs, renderMentionField, descriptionMention }: NodeDetailContentTabProps) {
   return (
     <>
       {node.category === 'Beliefs' && (
@@ -1027,6 +1049,7 @@ function NodeDetailContentTab({ pov, node, readOnly, err, descMode, setDescMode,
         update={update}
         updatePovNode={updatePovNode}
         renderMentionField={renderMentionField}
+        descriptionMention={descriptionMention}
       />
 
       {hasGraphAttrs && (


### PR DESCRIPTION
Follow-up from t/1898. The read-only `description` field renders through `HighlightedTextarea` → `useFormattedParts` (search-highlight + bold-keyword ranges) and did **not** linkify entity mentions — only `label`/`plain_description` did. This interleaves stored `.ref-link` mention spans into that read-only formatted render as a third range kind.

## Changes
- **`shared/MentionField.tsx`** — extract the `.ref-link` `<button>` into a shared **`RefLinkButton`** (single source of the ref-link treatment); add **`useContainerMentionKit`** exposing both `renderField` and `segmentsFor(fieldName)` from one `useContainerMentions` fetch. `useMentionRenderer` keeps its exact frozen signature (now a thin wrapper).
- **`shared/HighlightedField.tsx`** — extract the mark/bold range logic into a pure module-level `formatFieldParts`; `useFormattedParts` gains optional `mentionSegments`/`onSelectRef` (ref segments → `RefLinkButton`, plain segments formatted as before). `HighlightedTextarea` gains the two optional props, used **only** in the read-only branch. **No prop = byte-identical to before** for every existing consumer.
- **`taxonomy/NodeDetail.tsx`** — switch to `useContainerMentionKit`; thread the `description` field's mention segments to the formal `HighlightedTextarea`, engaging the segment path only when a real link exists (common no-mention path unchanged).

## Edge cases
Mentions index into NFC field text (offset basis `buildFieldSegments` guarantees; visually identical). `buildFieldSegments` drops drifted/unparseable/overlapping mentions. Bold keywords (`Encompasses:`/`Excludes:`) are never inside a mention, so `<br>`-before-bold is preserved per plain segment. Edit mode is a plain textarea (no mentions). No import cycle (MentionField does not import HighlightedField).

## Verify (worktree off origin/main `28ccc468`)
renderer-tsc 0/0 · eslint 0 errors (671 < 4256) · depcruise clean (1316 modules) · scoped vitest: shared suite 160/160 (incl. new `HighlightedField.test.tsx` + extended `MentionField.test.tsx`) + 83 across referencing suites · vite build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)