### PR TITLE
ci: auto-merge Dependabot minor/patch bumps on green CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,33 @@
+# Auto-merges Dependabot MINOR and PATCH update PRs once CI passes, so routine
+# dependency bumps stop piling up (owner-requested, p/66). It arms GitHub's NATIVE
+# auto-merge, which only lands the PR when the required `ci-gate` check is green —
+# so a bump that breaks the build is never merged. MAJOR bumps are deliberately
+# excluded: they need human review (e.g. the TypeScript 7 decision, closed by owner).
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only Dependabot's own PRs — never touches human/agent PRs.
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Arm auto-merge for minor/patch bumps
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Owner-requested (p/66, option b): stop the Dependabot backlog regrowing. Arms GitHub native auto-merge for Dependabot **minor/patch** PRs once ci-gate is green — a bump that breaks the build never merges. **Major** bumps excluded (need human review, e.g. the TS-7 decision). Only acts on dependabot[bot] PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)