### PR TITLE
fix(runtimeConfig): add moonshot to KNOWN_BACKENDS

### DIFF
--- a/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
+++ b/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
@@ -25,8 +25,8 @@ describe('getDefaults (t/926)', () => {
     expect(d.resilience.throttleEnterFactor).toBe(2.0);
     expect(d.tiers.free.pinnedModel).toBe('gemini-flash-lite-latest');
     // t/1513: platform/byok expose every system backend; key-presence gates real availability.
-    expect(d.tiers.platform.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'ollama']);
-    expect(d.tiers.byok.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'ollama']);
+    expect(d.tiers.platform.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama']);
+    expect(d.tiers.byok.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama']);
     expect(d.tiers.anonymous.allowedBackends).toEqual(['gemini', 'claude', 'groq']); // intentionally limited (no user keys)
     expect(d.flightRecorder.maxTotalDumpSizeBytes).toBe(52_428_800);
     expect(d.server.gitFetchTimeoutMs).toBe(600_000);
@@ -154,7 +154,7 @@ describe('validateAndMerge — allowedBackends', () => {
 
   it('falls back to default on an empty array', () => {
     const { config, errors } = validateAndMerge({ tiers: { byok: { allowedBackends: [] } } }, defaults());
-    expect(config.tiers.byok.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'ollama']);
+    expect(config.tiers.byok.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama']);
     expect(errors.some(e => e.includes('non-empty array'))).toBe(true);
   });
 

--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -120,7 +120,7 @@ export interface RuntimeConfig {
 // Mirror of the backend ids in ai-models.json (t/1513). Used to validate admin
 // overrides of tier allowedBackends — must include every backend the system can
 // route to, or valid overrides get silently dropped by vBackends().
-export const KNOWN_BACKENDS = ['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'ollama'] as const;
+export const KNOWN_BACKENDS = ['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama'] as const;
 
 // Range bounds (spec §3.2).
 const DURATION_MAX = 86_400_000; // 24h


### PR DESCRIPTION
## Summary
- Adds `moonshot` to `KNOWN_BACKENDS` in `runtimeConfig.ts` — it was silently dropped by `vBackends()`, blocking Moonshot (Kimi) for all tiers
- Updates three hardcoded `allowedBackends` assertions in `runtimeConfig.test.ts` to match

## Root cause
`KNOWN_BACKENDS` is the allowlist for `vBackends()`. Any backend not in the array is silently stripped. `moonshot` was missing, so even `platform`/`byok` tier users saw "(not on your tier)" in the Settings AI Backend dropdown.

## Test plan
- [x] `npm run verify` green (374 passed, 0 failed) in worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)