### PR TITLE
[DO NOT MERGE] SKIP-proof t/1989 — non-requirements PR, expect python-embed-smoke skipped + ci-gate green

### DIFF
--- a/operations/devops/.skip-proof-t1989.txt
+++ b/operations/devops/.skip-proof-t1989.txt
@@ -1,0 +1,1 @@
+SKIP-proof throwaway for t/1989 — verifies python-embed-smoke SKIPS on a non-requirements PR and ci-gate stays GREEN. Closed unmerged.


### PR DESCRIPTION
Throwaway (t/1989 Quality condition): touches only operations/devops/.skip-proof-t1989.txt (matches no path-filter) → python-embed-smoke must SKIP and ci-gate stay GREEN, byte-identical to how the other conditional jobs resolve. Closed unmerged once captured.