### PR TITLE
feat(debate): persist excludeGreatestHits toggle through createDebate (t/1980)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore.test.ts
@@ -555,6 +555,35 @@ describe('createDebate', () => {
     await useDebateStore.getState().createDebate('Topic', ['accelerationist'], false);
     expect(mockApi.listDebateSessionsMeta).toHaveBeenCalled();
   });
+
+  // ── excludeGreatestHits option → persisted config (t/1980) ──
+  // Store is the single writer for app-created debates; the option maps to the
+  // snake_case persisted field the renderer scoring + CLI engine both read.
+  it('persists exclude_greatest_hits=true when the option is set', async () => {
+    await useDebateStore.getState().createDebate(
+      'Topic', ['accelerationist'], false, 'topic', '', '', undefined, undefined,
+      undefined, undefined, { excludeGreatestHits: true },
+    );
+    const saved = mockApi.saveDebateSession.mock.calls[0][0] as Record<string, unknown>;
+    expect(saved.exclude_greatest_hits).toBe(true);
+    expect(useDebateStore.getState().activeDebate!.exclude_greatest_hits).toBe(true);
+  });
+
+  it('defaults exclude_greatest_hits to false when the option is omitted', async () => {
+    await useDebateStore.getState().createDebate('Topic', ['accelerationist'], false);
+    const saved = mockApi.saveDebateSession.mock.calls[0][0] as Record<string, unknown>;
+    expect(saved.exclude_greatest_hits).toBe(false);
+    expect(useDebateStore.getState().activeDebate!.exclude_greatest_hits).toBe(false);
+  });
+
+  it('persists exclude_greatest_hits=false when the option is explicitly false', async () => {
+    await useDebateStore.getState().createDebate(
+      'Topic', ['accelerationist'], false, 'topic', '', '', undefined, undefined,
+      undefined, undefined, { excludeGreatestHits: false },
+    );
+    const saved = mockApi.saveDebateSession.mock.calls[0][0] as Record<string, unknown>;
+    expect(saved.exclude_greatest_hits).toBe(false);
+  });
 });
 
 describe('loadDebate', () => {
@@ -596,6 +625,26 @@ describe('loadDebate', () => {
     await useDebateStore.getState().loadDebate('session-1');
 
     expect(useDebateStore.getState().debateModel).toBe('gemini-2.0-pro');
+  });
+
+  // ── exclude_greatest_hits round-trips on load (t/1980) ──
+  it('carries exclude_greatest_hits back on load', async () => {
+    const session = makeSession({ exclude_greatest_hits: true });
+    mockApi.loadDebateSession.mockResolvedValueOnce(session);
+
+    await useDebateStore.getState().loadDebate('session-1');
+
+    expect(useDebateStore.getState().activeDebate!.exclude_greatest_hits).toBe(true);
+  });
+
+  it('treats a pre-feature debate with no exclude_greatest_hits as false (absent ⇒ false)', async () => {
+    const session = makeSession(); // no exclude_greatest_hits field (lazy migration)
+    mockApi.loadDebateSession.mockResolvedValueOnce(session);
+
+    await useDebateStore.getState().loadDebate('session-1');
+
+    // Absent on the raw session; readers coalesce `?? false`.
+    expect(useDebateStore.getState().activeDebate!.exclude_greatest_hits ?? false).toBe(false);
   });
 
   it('restores audience from session', async () => {

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -44,7 +44,7 @@ export interface SessionSlice {
   debateLoading: boolean;
 
   loadSessions: () => Promise<void>;
-  createDebate: (topic: string, povers: SpeakerId[], userIsPover: boolean, sourceType?: DebateSourceType, sourceRef?: string, sourceContent?: string, debateModel?: string, protocolId?: string, debateTemperature?: number, debateAudience?: DebateAudience, options?: { title?: string; evaluatorModel?: string; pacing?: string; useAdaptiveStaging?: boolean; phaseBoundsOverride?: { maxConfrontationRounds?: number; maxArgumentationRounds?: number; maxConcludingRounds?: number }; speakerModels?: Record<string, string>; modelTier?: 'basic' | 'advanced'; stepMode?: boolean; stageModels?: { brief?: string; plan?: string; cite?: string }; background?: string }) => Promise<string>;
+  createDebate: (topic: string, povers: SpeakerId[], userIsPover: boolean, sourceType?: DebateSourceType, sourceRef?: string, sourceContent?: string, debateModel?: string, protocolId?: string, debateTemperature?: number, debateAudience?: DebateAudience, options?: { title?: string; evaluatorModel?: string; pacing?: string; useAdaptiveStaging?: boolean; phaseBoundsOverride?: { maxConfrontationRounds?: number; maxArgumentationRounds?: number; maxConcludingRounds?: number }; speakerModels?: Record<string, string>; modelTier?: 'basic' | 'advanced'; stepMode?: boolean; stageModels?: { brief?: string; plan?: string; cite?: string }; background?: string; excludeGreatestHits?: boolean }) => Promise<string>;
   createSituationDebate: (ccNodeId: string) => Promise<string>;
   createConflictDebate: (claimId: string) => Promise<string>;
   loadDebate: (id: string) => Promise<void>;
@@ -372,6 +372,12 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
       stage_models: options?.stageModels ? { ...options.stageModels } as Record<string, string> : undefined,
       model_tier: options?.modelTier || undefined,
       protocol_id: protocolId || 'structured',
+      // Greatest-hits exclusion toggle (t/1980, parent t/1979; engine rescope t/1438).
+      // Store is the single writer for app-created debates (which orchestrate via
+      // useDebateStore + in-renderer taxonomyRelevance, never the lib DebateEngine —
+      // t/1779); the CLI engine writes it for CLI-created sessions. Persisted here so
+      // it round-trips via save/load; absent on old debates ⇒ readers coalesce to false.
+      exclude_greatest_hits: options?.excludeGreatestHits ?? false,
       debate_temperature: debateTemperature ?? undefined,
       adaptive_staging: options?.useAdaptiveStaging
         ? { enabled: true, pacing: (options.pacing as 'tight' | 'moderate' | 'thorough') ?? 'moderate', phase_bounds_override: options.phaseBoundsOverride, step_mode: options.stepMode || undefined }


### PR DESCRIPTION
## Summary
Store/config carrier for the greatest-hits exclusion toggle (t/1980; parent t/1979; engine rescope t/1438).

- Adds `excludeGreatestHits?: boolean` to `createDebate(...)` options and writes it onto the created session as `exclude_greatest_hits` (snake_case) — the field DebateTool typed on the lib `DebateSession` via t/1438 (`06cb960e`).
- **Single writer = store** for app-created debates (they orchestrate via `useDebateStore` + in-renderer `taxonomyRelevance`, never the lib `DebateEngine` — t/1779); the CLI engine writes it for CLI-created sessions.
- Persisted so it round-trips via save/load; **absent ⇒ false** for pre-feature debates (lazy migration — readers coalesce `?? false`).

Unblocks **DebateUI t/1979** (Setup toggle + overview On/Off), which read/write this same persisted field.

## Scope note
This slice is the option → config → persist **carrier** only. The renderer scoring **read** (deriving the `RelevanceOptions.greatestHitsExclude` node-ID `Set` from the boolean via the greatest-hits data file) is a separate slice — it needs a bridge round-trip (`loadGreatestHitsFile` is node/filesystem-only) and depends on engine-side derivation not yet present in lib. Tracked as a sibling under t/1979.

## Tests
- `createDebate`: option→config for `true`, explicit `false`, and omitted (defaults false).
- `loadDebate`: round-trip carry + absent⇒false.

## Verification
- `tsc` main + renderer: clean
- `eslint src/ --max-warnings=4256`: 650 warnings (unchanged; under ceiling)
- scoped vitest `useDebateStore.test.ts`: 95 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)