### PR TITLE
fix(server): warn when vBackends drops an unknown backend (t/1995)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
+++ b/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
@@ -6,7 +6,7 @@
  * so getConfig()/forceReload() exercise the ENOENT → defaults fail-safe.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -15,6 +15,7 @@ import {
   getConfigState, writeConfig, diffFromDefaults, getClientConfig,
   type RuntimeConfig,
 } from '../runtimeConfig.js';
+import { log } from '../logger.js';
 
 const defaults = (): RuntimeConfig => getDefaults();
 
@@ -144,6 +145,20 @@ describe('validateAndMerge — allowedBackends', () => {
     );
     expect(config.tiers.platform.allowedBackends).toEqual(['gemini', 'groq']);
     expect(errors.some(e => e.includes('dropped') && e.includes('platform'))).toBe(true);
+  });
+
+  it('t/1995: emits a runtime warn naming the dropped backend', () => {
+    const warnSpy = vi.spyOn(log.server, 'warn').mockImplementation(() => {});
+    try {
+      validateAndMerge({ tiers: { platform: { allowedBackends: ['gemini', 'bogus', 'groq'] } } }, defaults());
+      const call = warnSpy.mock.calls.find(c => typeof c[1] === 'string' && c[1].includes('vBackends'));
+      expect(call).toBeDefined();
+      expect(String(call?.[1])).toContain("'bogus'");
+      expect(String(call?.[1])).toContain('platform');
+      expect((call?.[0] as { dropped?: unknown }).dropped).toEqual(['bogus']);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('falls back to default when no known backends remain', () => {

--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -266,7 +266,16 @@ function vBackends(val: unknown, def: string[], field: string, errors: string[])
     return [...def];
   }
   if (filtered.length !== val.length) {
+    const dropped = val.filter(b => !(typeof b === 'string' && (KNOWN_BACKENDS as readonly string[]).includes(b)));
     errors.push(`${field}: dropped ${val.length - filtered.length} unknown/invalid backend(s)`);
+    // t/1995: a silently-dropped backend (e.g. a newly-added one still missing from
+    // KNOWN_BACKENDS) previously surfaced only as a UI "(not on your tier)" with no
+    // server-side evidence. Emit a runtime warn naming the dropped backend(s) so it's a
+    // one-line log read, not a config-diff hunt. (errors[] above is aggregated post-load.)
+    log.server.warn(
+      { component: 'runtime-config', field, dropped, allowed: [...KNOWN_BACKENDS] },
+      `vBackends: dropped unknown backend(s) ${dropped.map(d => `'${String(d)}'`).join(', ')} from ${field} — add to KNOWN_BACKENDS to register`,
+    );
   }
   return filtered;
 }


### PR DESCRIPTION
`vBackends()` silently dropped unknown `allowedBackends` entries — recorded only in the aggregated `errors[]` (surfaced post-load as a count) with no runtime log, so a misconfigured/newly-added backend failed invisibly (symptom: UI "(not on your tier)" with no server evidence).

**Fix:** emit a structured `log.server.warn` naming the dropped backend(s) + tier field, with an "add to KNOWN_BACKENDS" remediation hint. The `errors[]` push is unchanged.

**Test:** runtimeConfig.test.ts asserts the warn fires naming 'bogus' + the 'platform' field and carries `dropped=['bogus']` (31/31). tsc(server) rc=0, eslint 0. Self-cert /trivial-change.