### PR TITLE
feat(calibration): censoring analysis — condition convergence on decision point (t/1671)

### DIFF
--- a/lib/debate/calibrationLogger/extract-metrics.ts
+++ b/lib/debate/calibrationLogger/extract-metrics.ts
@@ -14,6 +14,7 @@
 
 import { getDebatePhase } from '../types.js';
 import type { DebateSession, ArgumentNetworkNode, TrackedCrux } from '../types.js';
+import type { CalibrationDataPoint } from './schema.js';
 import type { NeutralEvaluation } from '../neutralEvaluator.js';
 import { meanSentenceLength, lexicalDiversity, jargonDensity } from '../clarityMetrics.js';
 import { computeAffectIntensity, computeAffectProfile, computeAffectAppropriateness } from '../affectSignals.js';
@@ -676,5 +677,79 @@ export function computeCruxSemanticDivergence(
   return {
     cruxDivergenceRate: matched > 0 ? divergences / matched : null,
     cruxMatchStats,
+  };
+}
+
+// ── Censoring analysis (t/1671) ──────────────────────────────────────────────
+
+const CENSORED_REASONS: ReadonlySet<string> = new Set([
+  'max_iterations', 'situation_cap', 'api_ceiling',
+]);
+
+/** Result of computing a convergence metric conditioned on termination status (t/1671). */
+export interface CensoredConvergenceResult {
+  /** n_censored / (n_completed + n_censored) — unknown rows excluded from denominator. */
+  censoring_rate: number;
+  n_completed: number;
+  n_censored: number;
+  /** Legacy rows (termination_reason absent or 'unknown') excluded from both pools. */
+  n_unknown: number;
+  /** Headline: metric mean over natural-conclusion runs only. Null if no completed runs. */
+  metric_over_completed: number | null;
+  /** Informational: metric mean over completed + censored combined. Null if neither pool has values. */
+  metric_over_all: number | null;
+}
+
+/**
+ * Compute a convergence metric conditioned on termination status (t/1671).
+ *
+ * Censored  = termination_reason ∈ {max_iterations, situation_cap, api_ceiling}.
+ * Completed = termination_reason === 'natural_conclusion'.
+ * Unknown   = absent or 'unknown' — excluded from both pools; counted in n_unknown.
+ *
+ * selector may return number | null | boolean. Boolean is coerced (true→1, false→0).
+ */
+export function computeConvergenceWithCensoring(
+  entries: CalibrationDataPoint[],
+  selector: (entry: CalibrationDataPoint) => number | null | boolean,
+): CensoredConvergenceResult {
+  let nCompleted = 0;
+  let nCensored = 0;
+  let nUnknown = 0;
+  const completedValues: number[] = [];
+  const allValues: number[] = [];
+
+  for (const entry of entries) {
+    const reason = entry.termination_reason;
+    if (!reason || reason === 'unknown') {
+      nUnknown++;
+      continue;
+    }
+    const raw = selector(entry);
+    const val = typeof raw === 'boolean' ? (raw ? 1 : 0) : raw;
+    if (CENSORED_REASONS.has(reason)) {
+      nCensored++;
+      if (val !== null) allValues.push(val);
+    } else {
+      nCompleted++;
+      if (val !== null) {
+        completedValues.push(val);
+        allValues.push(val);
+      }
+    }
+  }
+
+  const denominator = nCompleted + nCensored;
+  return {
+    censoring_rate: denominator > 0 ? nCensored / denominator : 0,
+    n_completed: nCompleted,
+    n_censored: nCensored,
+    n_unknown: nUnknown,
+    metric_over_completed: completedValues.length > 0
+      ? completedValues.reduce((a, b) => a + b, 0) / completedValues.length
+      : null,
+    metric_over_all: allValues.length > 0
+      ? allValues.reduce((a, b) => a + b, 0) / allValues.length
+      : null,
   };
 }

--- a/lib/debate/calibrationLogger/extract.test.ts
+++ b/lib/debate/calibrationLogger/extract.test.ts
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import type { DebateSession } from '../types.js';
+import { extractCalibrationData } from './extract.js';
+import type { CalibrationDataPoint } from './schema.js';
+import { computeConvergenceWithCensoring } from './extract-metrics.js';
+
+// ── Minimal session factory ───────────────────────────────────────────────────
+
+function makeSession(overrides: Record<string, unknown> = {}): DebateSession {
+  return {
+    id: 'test-debate',
+    title: 'Test debate',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    phase: 'closed',
+    topic: { original: 'AI policy', refined: null, final: 'AI policy' },
+    source_type: 'topic',
+    source_ref: '',
+    source_content: '',
+    active_povers: ['accelerationist', 'safetyist', 'skeptic'],
+    user_is_pover: false,
+    transcript: [],
+    context_summaries: [],
+    debate_model: 'gemini-2.5-flash',
+    ...overrides,
+  } as unknown as DebateSession;
+}
+
+function sessionWithPhase(
+  exit_reason: string,
+  force_active: boolean,
+  transcriptEntries: { content: string }[] = [],
+): DebateSession {
+  return makeSession({
+    transcript: transcriptEntries,
+    adaptive_staging_diagnostics: {
+      enabled: true,
+      phases: [{ phase: 'synthesis', rounds: [1, 2, 3], exit_reason, force_active }],
+      signal_telemetry: [],
+      regressions: [],
+      total_predicate_evaluations: 3,
+      confidence_deferrals: 0,
+      vetoes_fired: 0,
+    },
+  });
+}
+
+// ── Golden-set: termination_reason derivation (t/1671#8) ─────────────────────
+//
+// All real exit_reason strings from phaseTransitions.ts mapped to expected classification.
+// Derived from force_active boolean stamped at source — not prose regex.
+
+describe('extractCalibrationData termination_reason golden set', () => {
+  it.each([
+    // force_active=true → cap-forced
+    ['Catastrophic health collapse (< 0.10)', true, 'situation_cap'],
+    ['Sustained health decline (< 0.20 for 3 rounds)', true, 'situation_cap'],
+    ['Network hard cap (500 >= 500)', true, 'situation_cap'],
+    ['Max total rounds (10 >= 10)', true, 'max_iterations'],
+    ['Max total rounds (15 >= 15)', true, 'max_iterations'],
+    ['Max thesis turns (limit reached)', true, 'situation_cap'],
+    ['Max exploration turns (limit reached)', true, 'situation_cap'],
+    ['API soft budget hit (80%)', true, 'situation_cap'],
+    ['Debate is dead (recycling > 0.8 AND fatigue > 0.8)', true, 'situation_cap'],
+    ['Max synthesis turns (limit reached)', true, 'situation_cap'],
+    ['Synthesis stall (2 rounds, delta < 0.05, recycling > 0.5)', true, 'situation_cap'],
+    // force_active=false → natural decision-point
+    ['Saturation score 0.75 >= threshold 0.70', false, 'natural_conclusion'],
+    ['Convergence 0.85 >= threshold 0.80', false, 'natural_conclusion'],
+  ] as [string, boolean, string][])(
+    'exit_reason=%s, force_active=%s → %s',
+    (exit_reason, force_active, expected) => {
+      const session = sessionWithPhase(exit_reason, force_active);
+      const dp = extractCalibrationData(session, 'local');
+      expect(dp.termination_reason).toBe(expected);
+    },
+  );
+
+  it('api_ceiling: transcript content overrides force_active', () => {
+    // force_active=true but transcript contains the api-ceiling marker
+    const session = sessionWithPhase(
+      'API hard ceiling hit (1000 >= 1000)',
+      true,
+      [{ content: 'API hard ceiling hit — debate terminated.' }],
+    );
+    const dp = extractCalibrationData(session, 'local');
+    expect(dp.termination_reason).toBe('api_ceiling');
+  });
+
+  it('unknown: no adaptive_staging_diagnostics → unknown', () => {
+    const dp = extractCalibrationData(makeSession(), 'local');
+    expect(dp.termination_reason).toBe('unknown');
+  });
+
+  it('unknown: phases[] present but force_active absent (legacy row) → unknown', () => {
+    const session = makeSession({
+      adaptive_staging_diagnostics: {
+        enabled: true,
+        // No force_active field — legacy shape
+        phases: [{ phase: 'synthesis', rounds: [1], exit_reason: 'Old reason format' }],
+        signal_telemetry: [],
+        regressions: [],
+        total_predicate_evaluations: 1,
+        confidence_deferrals: 0,
+        vetoes_fired: 0,
+      },
+    });
+    const dp = extractCalibrationData(session, 'local');
+    expect(dp.termination_reason).toBe('unknown');
+  });
+
+  // TL-required assertion (t/1671#9): prove that the LAST phases[] entry determines
+  // termination_reason, not an earlier cap-forced phase.
+  it('real converged debate: last phase entry force_active=false → natural_conclusion', () => {
+    const session = makeSession({
+      adaptive_staging_diagnostics: {
+        enabled: true,
+        phases: [
+          // Earlier phase ended via a cap — must NOT influence the result
+          { phase: 'exploration', rounds: [1, 2], exit_reason: 'Max exploration turns (limit reached)', force_active: true },
+          // Final phase ended naturally — this determines termination_reason
+          { phase: 'synthesis', rounds: [3, 4, 5], exit_reason: 'Convergence 0.85 >= threshold 0.80', force_active: false },
+        ],
+        signal_telemetry: [],
+        regressions: [],
+        total_predicate_evaluations: 5,
+        confidence_deferrals: 0,
+        vetoes_fired: 0,
+      },
+    });
+    const dp = extractCalibrationData(session, 'local');
+    expect(dp.termination_reason).toBe('natural_conclusion');
+  });
+});
+
+// ── computeConvergenceWithCensoring ──────────────────────────────────────────
+
+function makeEntry(
+  termination_reason: CalibrationDataPoint['termination_reason'],
+  value: number | null,
+): CalibrationDataPoint {
+  return { termination_reason, convergence_score_at_termination: value } as CalibrationDataPoint;
+}
+
+describe('computeConvergenceWithCensoring', () => {
+  it('all completed: rate=0, metric_over_completed = mean', () => {
+    const result = computeConvergenceWithCensoring(
+      [makeEntry('natural_conclusion', 0.8), makeEntry('natural_conclusion', 0.6)],
+      e => e.convergence_score_at_termination ?? null,
+    );
+    expect(result.censoring_rate).toBe(0);
+    expect(result.n_completed).toBe(2);
+    expect(result.n_censored).toBe(0);
+    expect(result.n_unknown).toBe(0);
+    expect(result.metric_over_completed).toBeCloseTo(0.7);
+    expect(result.metric_over_all).toBeCloseTo(0.7);
+  });
+
+  it('all censored: rate=1, metric_over_completed=null, metric_over_all has values', () => {
+    const result = computeConvergenceWithCensoring(
+      [makeEntry('max_iterations', 0.4), makeEntry('situation_cap', 0.3)],
+      e => e.convergence_score_at_termination ?? null,
+    );
+    expect(result.censoring_rate).toBe(1);
+    expect(result.n_completed).toBe(0);
+    expect(result.n_censored).toBe(2);
+    expect(result.metric_over_completed).toBeNull();
+    expect(result.metric_over_all).toBeCloseTo(0.35);
+  });
+
+  it('mixed: censoring_rate = n_censored / (n_completed + n_censored)', () => {
+    const result = computeConvergenceWithCensoring(
+      [
+        makeEntry('natural_conclusion', 0.9),
+        makeEntry('max_iterations', 0.5),
+        makeEntry('api_ceiling', 0.4),
+      ],
+      e => e.convergence_score_at_termination ?? null,
+    );
+    expect(result.censoring_rate).toBeCloseTo(2 / 3);
+    expect(result.n_completed).toBe(1);
+    expect(result.n_censored).toBe(2);
+    expect(result.metric_over_completed).toBeCloseTo(0.9);
+    expect(result.metric_over_all).toBeCloseTo((0.9 + 0.5 + 0.4) / 3);
+  });
+
+  it('all unknown: rate=0, all metrics null, n_unknown reported', () => {
+    const result = computeConvergenceWithCensoring(
+      [makeEntry('unknown', 0.5), makeEntry(undefined, 0.3)],
+      e => e.convergence_score_at_termination ?? null,
+    );
+    expect(result.censoring_rate).toBe(0);
+    expect(result.n_unknown).toBe(2);
+    expect(result.n_completed).toBe(0);
+    expect(result.n_censored).toBe(0);
+    expect(result.metric_over_completed).toBeNull();
+    expect(result.metric_over_all).toBeNull();
+  });
+
+  it('null metric values excluded from mean but rows still counted', () => {
+    const result = computeConvergenceWithCensoring(
+      [makeEntry('natural_conclusion', null), makeEntry('natural_conclusion', 0.8)],
+      e => e.convergence_score_at_termination ?? null,
+    );
+    expect(result.n_completed).toBe(2);
+    expect(result.metric_over_completed).toBeCloseTo(0.8);
+  });
+
+  it('boolean selector coerced to 0/1', () => {
+    const entries = [makeEntry('natural_conclusion', 0.8), makeEntry('natural_conclusion', 0.2)];
+    const result = computeConvergenceWithCensoring(
+      entries,
+      e => (e.convergence_score_at_termination ?? 0) > 0.5,
+    );
+    expect(result.metric_over_completed).toBeCloseTo(0.5);
+  });
+
+  it('empty input: zero rate, all nulls', () => {
+    const result = computeConvergenceWithCensoring([], () => null);
+    expect(result.censoring_rate).toBe(0);
+    expect(result.n_completed).toBe(0);
+    expect(result.n_censored).toBe(0);
+    expect(result.n_unknown).toBe(0);
+    expect(result.metric_over_completed).toBeNull();
+    expect(result.metric_over_all).toBeNull();
+  });
+
+  it('unknown rows excluded from denominator even when mixed with known rows', () => {
+    const result = computeConvergenceWithCensoring(
+      [
+        makeEntry('natural_conclusion', 0.9),
+        makeEntry('unknown', 0.5),  // should not affect rate
+        makeEntry('max_iterations', 0.4),
+      ],
+      e => e.convergence_score_at_termination ?? null,
+    );
+    // denominator = 1 completed + 1 censored = 2 (unknown excluded)
+    expect(result.censoring_rate).toBeCloseTo(1 / 2);
+    expect(result.n_unknown).toBe(1);
+  });
+});

--- a/lib/debate/calibrationLogger/extract.ts
+++ b/lib/debate/calibrationLogger/extract.ts
@@ -120,15 +120,32 @@ export function extractCalibrationData(
       composite?: { argumentative_saturation_score?: number; convergence_score?: number };
       signals?: Record<string, number>;
     }[];
+    phases?: { phase: string; rounds: number[]; exit_reason: string; force_active?: boolean }[];
   } | undefined;
   let argumentativeSaturationAtTransition: number | null = null;
+  let convergenceScoreAtTermination: number | null = null;
   let signalsAtTransition: Record<string, number> | null = null;
   if (asd?.signal_telemetry && asd.signal_telemetry.length > 0) {
     const telemetry = asd.signal_telemetry;
     // Find the last entry before phase changed (closest to transition)
     const last = telemetry[telemetry.length - 1];
     argumentativeSaturationAtTransition = last.composite?.argumentative_saturation_score ?? null;
+    convergenceScoreAtTermination = last.composite?.convergence_score ?? null;
     signalsAtTransition = last.signals ?? null;
+  }
+  // ── Termination reason (t/1671) ──
+  // Derived from structured force_active stamped in crossRespond.ts — not prose regex.
+  const hitApiCeiling = session.transcript.some((e: { content: string }) =>
+    typeof e.content === 'string' && e.content.includes('API hard ceiling hit'),
+  );
+  const lastAsdPhase = asd?.phases && asd.phases.length > 0 ? asd.phases[asd.phases.length - 1] : undefined;
+  let terminationReason: 'natural_conclusion' | 'max_iterations' | 'situation_cap' | 'api_ceiling' | 'unknown' = 'unknown';
+  if (hitApiCeiling) {
+    terminationReason = 'api_ceiling';
+  } else if (lastAsdPhase !== undefined && lastAsdPhase.force_active !== undefined) {
+    terminationReason = lastAsdPhase.force_active
+      ? (/Max total rounds/i.test(lastAsdPhase.exit_reason) ? 'max_iterations' : 'situation_cap')
+      : 'natural_conclusion';
   }
 
   // ── Round count ──
@@ -444,9 +461,9 @@ export function extractCalibrationData(
     claims_per_1k_words: claimsPer1k,
     kp_divisor: config.kpDivisor ?? 500,
 
-    hit_api_ceiling: session.transcript.some((e: { content: string }) =>
-      typeof e.content === 'string' && e.content.includes('API hard ceiling hit'),
-    ),
+    hit_api_ceiling: hitApiCeiling,
+    termination_reason: terminationReason,
+    convergence_score_at_termination: convergenceScoreAtTermination,
     total_api_calls: session.diagnostics?.overview?.total_ai_calls ?? 0,
     budget_hard_multiplier: config.budgetHardMultiplier ?? 15,
 

--- a/lib/debate/calibrationLogger/schema.ts
+++ b/lib/debate/calibrationLogger/schema.ts
@@ -64,7 +64,7 @@ export interface CalibrationDataPoint {
   evaluator_model_id?: string;
 
   // ── Parameter 1: Exploration exit threshold ──
-  /** Saturation score at the moment of exploration→synthesis transition (null if no transition) */
+  /** Saturation score from the last signal_telemetry entry at debate end (unconditional last-round value; null when no telemetry). Field name is historical — the extraction is not transition-gated. */
   argumentative_saturation_at_transition: number | null;
   /** The argumentation_exit threshold that was active */
   argumentation_exit_threshold: number;
@@ -421,4 +421,21 @@ export interface CalibrationDataPoint {
   // ── Over-generate/select/rewrite pipeline (t/1581) ──
   /** Whether a coherence gate miss occurred (rewrite failed to preserve ≥3/4 selected claims). */
   coherence_gate_miss?: boolean;
+
+  // ── Termination classification (t/1671) ──
+  /**
+   * How the debate ended, derived from phases[].force_active stamped in crossRespond.ts.
+   * 'natural_conclusion': force_active=false — convergence/saturation threshold reached naturally.
+   * 'max_iterations': force_active=true AND exit_reason matches /Max total rounds/i.
+   * 'situation_cap': force_active=true, any other forced cap (health, synthesis stall, etc.).
+   * 'api_ceiling': API hard ceiling hit (detected via transcript content; overrides force_active).
+   * 'unknown': legacy rows without force_active — excluded from censoring pools.
+   * Absent on pre-t/1671 rows; treated as 'unknown' by computeConvergenceWithCensoring.
+   */
+  termination_reason?: 'natural_conclusion' | 'max_iterations' | 'situation_cap' | 'api_ceiling' | 'unknown';
+  /**
+   * Last composite convergence_score from adaptive_staging_diagnostics.signal_telemetry.
+   * Same extraction point as argumentative_saturation_at_transition. Null when no telemetry.
+   */
+  convergence_score_at_termination?: number | null;
 }

--- a/lib/debate/debateEngine/phases/crossRespond.ts
+++ b/lib/debate/debateEngine/phases/crossRespond.ts
@@ -220,6 +220,7 @@ export async function runAdaptiveCrossRespond(engine: DebateEngineInternals): Pr
         phase: prevPhase,
         rounds: Array.from({ length: round - currentPhaseStartRound + 1 }, (_, i) => currentPhaseStartRound + i),
         exit_reason: result.reason,
+        force_active: result.force_active,
       });
       currentPhaseStartRound = round + 1;
       currentPhaseExitReason = result.reason;
@@ -265,6 +266,7 @@ export async function runAdaptiveCrossRespond(engine: DebateEngineInternals): Pr
         phase: state.current_phase,
         rounds: Array.from({ length: round - currentPhaseStartRound + 1 }, (_, i) => currentPhaseStartRound + i),
         exit_reason: result.reason,
+        force_active: result.force_active,
       });
 
       engine.addEntry({

--- a/lib/debate/types/phase.ts
+++ b/lib/debate/types/phase.ts
@@ -197,7 +197,7 @@ export interface SignalTelemetryRecord {
 
 export interface AdaptiveStagingDiagnostics {
   enabled: boolean;
-  phases: { phase: DebatePhase; rounds: number[]; exit_reason: string }[];
+  phases: { phase: DebatePhase; rounds: number[]; exit_reason: string; force_active: boolean }[];
   regressions: { from_round: number; crux_id: string; threshold_after: number }[];
   total_predicate_evaluations: number;
   confidence_deferrals: number;


### PR DESCRIPTION
## Summary

- `types/phase.ts` + `crossRespond.ts`: stamp `force_active: boolean` into `diag.phases[]` at both push sites (transition and terminate), providing structured classification signal at source
- `schema.ts`: add `termination_reason?` and `convergence_score_at_termination?` fields; fix `argumentative_saturation_at_transition` doc comment (was wrong — extraction is not transition-gated)
- `extract.ts`: derive `terminationReason` from `phases[].force_active` (not prose regex), extract `convergenceScoreAtTermination` from last telemetry entry, hoist `hitApiCeiling`
- `extract-metrics.ts`: add `CensoredConvergenceResult` interface + `computeConvergenceWithCensoring` — conditions any metric over runs that reached a natural decision point vs. cap-terminated runs
- `extract.test.ts` (new, 25 tests): golden-set for all real `phaseTransitions.ts` exit_reason strings, TL-required real-converged-debate fixture proving last-phases[]-entry ordering, full `computeConvergenceWithCensoring` coverage

## Design notes

Derivation uses `force_active` boolean stamped into `phases[]` in crossRespond.ts — not regex against `exit_reason` prose. TL blocker t/1671#7: natural convergence strings like "Convergence 0.85 >= threshold 0.80" matched no proposed regex, classifying completed runs as censored. The `force_active` signal cleanly separates cap-forced (true) from natural (false) endings at source.

Censoring predicate: termination_reason in {max_iterations, situation_cap, api_ceiling}. Legacy rows (no force_active field) -> unknown, excluded from both pools.

## Test plan

- [x] 25 new tests pass: `npx vitest run calibrationLogger/extract.test.ts`
- [x] Full suite: 2805 passed / 1 pre-existing local-only failure (cliPipeExit tsx cold-start, skipIf GITHUB_ACTIONS)
- [x] Type check: pre-existing baseline confirmed (lib/ tsc errors are pre-existing; CI only checks taxonomy-editor)

Closes t/1671

Generated with Claude Code