### PR TITLE
chore(poviewer,summary-viewer): ratchet flight-recorder rule warn->error (t/1976)

### DIFF
--- a/poviewer/eslint.config.mjs
+++ b/poviewer/eslint.config.mjs
@@ -5,8 +5,9 @@
 // Consumes the single canonical rule shared across all apps (lib/eslint-rules,
 // t/1929); no local fork. The typescript-eslint parser is wired so .ts/.tsx
 // files parse (the rule is purely syntactic — no type-aware projectService
-// needed). Rule is 'warn' here (advisory) pending a catch-block cleanup pass,
-// mirroring taxonomy-editor's warn→error-once-clean sequence.
+// needed). Rule is 'error' (ADR-003 hard gate): the mini-app catch tree is clean,
+// so this ratchets to full parity with taxonomy-editor's 'error' enforcement
+// (t/1976 warn→error, after t/1929 wired the rule to actually run here).
 
 import tseslint from 'typescript-eslint';
 import requireFlightRecorderInCatch from '../lib/eslint-rules/require-flight-recorder-in-catch.js';
@@ -25,7 +26,7 @@ export default tseslint.config(
     },
     plugins: { local: localPlugin },
     rules: {
-      'local/require-flight-recorder-in-catch': 'warn',
+      'local/require-flight-recorder-in-catch': 'error',
     },
   },
   {

--- a/summary-viewer/eslint.config.mjs
+++ b/summary-viewer/eslint.config.mjs
@@ -5,8 +5,9 @@
 // Consumes the single canonical rule shared across all apps (lib/eslint-rules,
 // t/1929); no local fork. The typescript-eslint parser is wired so .ts/.tsx
 // files parse (the rule is purely syntactic — no type-aware projectService
-// needed). Rule is 'warn' here (advisory) pending a catch-block cleanup pass,
-// mirroring taxonomy-editor's warn→error-once-clean sequence.
+// needed). Rule is 'error' (ADR-003 hard gate): the mini-app catch tree is clean,
+// so this ratchets to full parity with taxonomy-editor's 'error' enforcement
+// (t/1976 warn→error, after t/1929 wired the rule to actually run here).
 
 import tseslint from 'typescript-eslint';
 import requireFlightRecorderInCatch from '../lib/eslint-rules/require-flight-recorder-in-catch.js';
@@ -25,7 +26,7 @@ export default tseslint.config(
     },
     plugins: { local: localPlugin },
     rules: {
-      'local/require-flight-recorder-in-catch': 'warn',
+      'local/require-flight-recorder-in-catch': 'error',
     },
   },
   {


### PR DESCRIPTION
Completes **t/1976** — the tail follow-up to t/1929, requested by TL (p/30#99/#100): bring the two mini-apps to full ADR-003 parity with taxonomy-editor by ratcheting the shared `require-flight-recorder-in-catch` rule from `'warn'` to `'error'`.

## Why now
t/1929 wired the rule to actually run in poviewer + summary-viewer, but left it at `'warn'` pending a catch-cleanup pass. A rule stuck permanently at `'warn'` is a soft gate that gets ignored — taxonomy-editor enforces this at `'error'`.

## Catch-cleanup pass = no-op (verified)
Measured the current catch tree on origin: **0 violations, 0 total lint problems** in both apps — every existing catch already records (or is sanctioned). So no src changes were needed; this is a pure config flip. (Config-only; no mini-app `src/` edits, which stay in Taxonomy Editor's scope.)

## Change
`'warn'` → `'error'` in `poviewer/eslint.config.mjs` + `summary-viewer/eslint.config.mjs` (+ refreshed the now-stale header comment).

## Gate-verified
At `'error'`: clean tree lints **exit 0**; a throwaway `catch`-without-recorder now **hard-fails (1 error, exit 1)** instead of warning, in both apps. CI `test-electron` runs `npm run lint`, so ADR-003 violations in these apps now **fail CI**, not just warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)