### PR TITLE
feat(main): add load-greatest-hits IPC handler + preload exposure (t/1998)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/sourceHandlers.test.ts
+++ b/taxonomy-editor/src/main/__tests__/sourceHandlers.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * t/1998: the `load-greatest-hits` IPC handler is the desktop read for the greatest-hits
+ * exclusion list — it reads `calibration/greatest-hits.json` under the data root (the same
+ * static file the debate engine reads) and returns `{ node_ids }` or null. Drives the REAL
+ * handler by mocking `electron` (to capture the registered handler) and `../fileIO.js`
+ * (to point the data root at a per-test temp dir); the file read itself runs for real.
+ */
+
+const h = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  dataRoot: '',
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: (ch: string, fn: (...a: unknown[]) => unknown) => { h.handlers.set(ch, fn); } },
+}));
+
+// Only getDataRootPath is exercised by the load-greatest-hits test; the rest are stubbed so
+// the module's named imports resolve (they're called lazily inside handlers we don't drive).
+vi.mock('../fileIO.js', () => ({
+  getDataRootPath: () => h.dataRoot,
+  discoverSources: () => [],
+  loadSummary: () => null,
+  loadSnapshot: () => null,
+  resolveSourceDocument: () => null,
+  loadDataConfig: () => ({}),
+  PROJECT_ROOT: '/',
+}));
+
+// Imported AFTER the mocks so the handler binds the mocked deps.
+import { registerSourceHandlers } from '../ipc/sourceHandlers.js';
+
+function invoke(channel: string, ...args: unknown[]): unknown {
+  const fn = h.handlers.get(channel);
+  if (!fn) throw new Error(`${channel} not registered`);
+  return fn({}, ...args);
+}
+
+function writeGreatestHits(raw: string): void {
+  const dir = path.join(h.dataRoot, 'calibration');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'greatest-hits.json'), raw);
+}
+
+beforeEach(() => {
+  h.handlers.clear();
+  h.dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ghits-'));
+  registerSourceHandlers();
+});
+afterEach(() => {
+  fs.rmSync(h.dataRoot, { recursive: true, force: true });
+});
+
+describe('load-greatest-hits IPC handler (t/1998)', () => {
+  it('returns { node_ids } from calibration/greatest-hits.json', () => {
+    writeGreatestHits(JSON.stringify({ version: 1, node_ids: ['acc-beliefs-001', 'saf-desires-002'] }));
+    expect(invoke('load-greatest-hits')).toEqual({ node_ids: ['acc-beliefs-001', 'saf-desires-002'] });
+  });
+
+  it('returns { node_ids: [] } when the file omits node_ids', () => {
+    writeGreatestHits(JSON.stringify({ version: 1 }));
+    expect(invoke('load-greatest-hits')).toEqual({ node_ids: [] });
+  });
+
+  it('returns null when calibration/greatest-hits.json is absent', () => {
+    expect(invoke('load-greatest-hits')).toBeNull();
+  });
+
+  it('returns null when the file is malformed JSON (degrades, never throws)', () => {
+    writeGreatestHits('{ not valid json');
+    expect(invoke('load-greatest-hits')).toBeNull();
+  });
+});

--- a/taxonomy-editor/src/main/ipc/sourceHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/sourceHandlers.ts
@@ -93,6 +93,22 @@ export function registerSourceHandlers(): void {
   ipcMain.handle('load-source-evidence-index', () => loadEvidenceIndex());
   ipcMain.handle('load-doc-titles', () => loadDocTitles());
 
+  // greatest-hits exclusion list (t/1998) — reads the same static calibration file the debate
+  // engine reads (lib/debate/debateEngine/taxonomyContext.ts) so desktop and engine exclude
+  // the same nodes. Returns { node_ids } or null when the file is absent/unreadable; the
+  // renderer degrades gracefully rather than failing the debate (TL t/1998#2). Mirrors the
+  // load-doc-titles / load-source-evidence-index read pattern. Read per call (not cached):
+  // called once per debate build, and t/1999 may generate the file mid-session, so a cached
+  // null would go stale.
+  ipcMain.handle('load-greatest-hits', (): { node_ids: string[] } | null => {
+    try {
+      const filePath = path.join(getDataRootPath(), 'calibration', 'greatest-hits.json');
+      if (!fs.existsSync(filePath)) return null;
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { node_ids?: string[] };
+      return { node_ids: data.node_ids ?? [] };
+    } catch { /* telemetry — silent by design; missing/malformed → null, renderer degrades */ return null; }
+  });
+
   ipcMain.handle('get-source-evidence', async (_event, nodeIds: string[], pov: string) => {
     const emptyResult = { facts: [], keyPoints: [], formattedBlock: '', nodesCovered: [], totalCandidates: 0 };
     const index = loadEvidenceIndex();

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -384,6 +384,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('load-source-evidence-index'),
   loadDocTitles: (): Promise<Record<string, string> | null> =>
     ipcRenderer.invoke('load-doc-titles'),
+  loadGreatestHits: (): Promise<{ node_ids: string[] } | null> =>
+    ipcRenderer.invoke('load-greatest-hits'),
   getSourceEvidence: (nodeIds: string[], pov: string): Promise<unknown> =>
     ipcRenderer.invoke('get-source-evidence', nodeIds, pov),
   runEvidenceQbaf: (claimText: string, claimId: string, model?: string): Promise<unknown> =>


### PR DESCRIPTION
The **ElectronMain slice** of t/1998 (PM p/255#12) — the renderer can't read the filesystem, so the greatest-hits exclusion read needs a main-process IPC handler.

### Change
- `sourceHandlers.ts`: `load-greatest-hits` IPC handler — reads `calibration/greatest-hits.json` from the data root (the **same** static file the debate engine reads, so desktop and engine exclude the same nodes) and returns `{ node_ids }` or **null** when absent/unreadable. Mirrors the `load-doc-titles` / `load-source-evidence-index` read pattern.
- `preload.cts`: exposes `loadGreatestHits()`.

Degrades to null on a missing/malformed file (never throws) — the renderer's `buildRelevanceOptions` owns the *visible* graceful degrade (TL t/1998#2); the IPC layer just supplies data. Read per call (not cached) since t/1999 may generate the file mid-session.

**Scope:** only the IPC + preload half. Renderer bridge triplet → Taxonomy Editor (item #3); REST mirror → ServerAPI (item #1). Independent of the t/1999 file-generation gate — the handler is correct whether or not the file exists yet.

### Tests
`sourceHandlers.test.ts`: present → `{ node_ids }`, no `node_ids` field → `{ node_ids: [] }`, absent → null, malformed → null. **4/4 pass**; `tsc -p tsconfig.main.json` + eslint clean.

Self-cert: `/trivial-change` (mechanical mirror of an existing IPC read handler, single scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
