### PR TITLE
feat(debate): app-path greatest-hits exclusion — renderer scoring reads persisted flag (t/1998)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -63,6 +63,10 @@ export const api: AppAPI = {
   resolveSourceDocument: (docId) => window.electronAPI.resolveSourceDocument(docId),
   loadSourceEvidenceIndex: () => window.electronAPI.loadSourceEvidenceIndex(),
   loadDocTitles: () => window.electronAPI.loadDocTitles(),
+  // Optional-chaining fallback: the IPC handler (ElectronMain, t/1998) lands in parallel;
+  // until it's present window.electronAPI.loadGreatestHits is undefined → resolve null so
+  // the app degrades gracefully (no exclusion) rather than throwing.
+  loadGreatestHits: () => window.electronAPI.loadGreatestHits?.() ?? Promise.resolve(null),
   getSourceEvidence: (nodeIds, pov) => window.electronAPI.getSourceEvidence(nodeIds, pov),
   runEvidenceQbaf: (claimText, claimId, model) => window.electronAPI.runEvidenceQbaf(claimText, claimId, model),
 

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -210,6 +210,8 @@ export interface AppAPI {
   // --- Source evidence ---
   loadSourceEvidenceIndex: () => Promise<Record<string, unknown> | null>;
   loadDocTitles: () => Promise<Record<string, string> | null>;
+  /** Greatest-hits exclusion node IDs from calibration/greatest-hits.json (t/1998). Null when the file is absent. */
+  loadGreatestHits: () => Promise<{ node_ids: string[] } | null>;
   getSourceEvidence: (nodeIds: string[], pov: string) => Promise<{
     facts: unknown[]; keyPoints: unknown[]; formattedBlock: string;
     nodesCovered: string[]; totalCandidates: number;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -963,6 +963,7 @@ const rawApi: AppAPI = {
   // Source evidence
   loadSourceEvidenceIndex: () => get<Record<string, unknown> | null>('/api/source-evidence-index').catch(bridgeWarn('loadSourceEvidenceIndex failed', null)),
   loadDocTitles: () => get<Record<string, string> | null>('/api/doc-titles').catch(bridgeWarn('loadDocTitles failed', null)),
+  loadGreatestHits: () => get<{ node_ids: string[] } | null>('/api/greatest-hits').catch(bridgeWarn('loadGreatestHits failed', null)),
   getSourceEvidence: (nodeIds, pov) => post('/api/source-evidence', { nodeIds, pov }),
   runEvidenceQbaf: (claimText, claimId, model) => post<{ computed_strength: number; qbaf_iterations: number; evidence_items: Array<{ id: string; source_doc_id: string; text: string; relation: 'support' | 'contradict'; similarity: number }>; claim_id: string } | null>('/api/evidence-qbaf', { claimText, claimId, model }).catch(bridgeWarn('runEvidenceQbaf failed', null)),
 

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/__tests__/getGreatestHits.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/__tests__/getGreatestHits.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RelevanceOptions } from '../../../../utils/taxonomyRelevance';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────
+const mockLoadGreatestHits = vi.hoisted(() => vi.fn());
+const mockRecord = vi.hoisted(() => vi.fn());
+
+vi.mock('@bridge', () => ({ api: { loadGreatestHits: mockLoadGreatestHits } }));
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: mockRecord }),
+}));
+
+import { getGreatestHits, applyGreatestHitsExclusion, resetGreatestHitsCache } from '../getGreatestHits';
+
+beforeEach(() => {
+  resetGreatestHitsCache();
+  mockLoadGreatestHits.mockReset();
+  mockRecord.mockReset();
+});
+
+describe('getGreatestHits', () => {
+  it('returns node_ids when the bridge yields a list', async () => {
+    mockLoadGreatestHits.mockResolvedValue({ node_ids: ['acc-b-001', 'saf-d-004'] });
+    expect(await getGreatestHits()).toEqual(['acc-b-001', 'saf-d-004']);
+  });
+
+  it('caches the result — the bridge is called once across repeated reads', async () => {
+    mockLoadGreatestHits.mockResolvedValue({ node_ids: ['acc-b-001'] });
+    await getGreatestHits();
+    await getGreatestHits();
+    expect(mockLoadGreatestHits).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns undefined (and caches) when the file is absent (bridge returns null)', async () => {
+    mockLoadGreatestHits.mockResolvedValue(null);
+    expect(await getGreatestHits()).toBeUndefined();
+    await getGreatestHits();
+    expect(mockLoadGreatestHits).toHaveBeenCalledTimes(1); // null is cached, no retry
+  });
+
+  it('returns undefined and records a warning when the bridge throws', async () => {
+    mockLoadGreatestHits.mockRejectedValue(new Error('network down'));
+    expect(await getGreatestHits()).toBeUndefined();
+    expect(mockRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'system.error', level: 'warn' }),
+    );
+  });
+});
+
+describe('applyGreatestHitsExclusion', () => {
+  const opts = (): RelevanceOptions => ({ threshold: 0.45, minPerCategory: 3, maxTotal: 35 });
+
+  it('is a no-op when the flag is off/undefined', async () => {
+    const relevanceOpts = opts();
+    const outcome = await applyGreatestHitsExclusion(relevanceOpts, false);
+    expect(outcome).toEqual({ requested: false, applied: false, listSize: 0 });
+    expect(relevanceOpts.greatestHitsExclude).toBeUndefined();
+    expect(mockLoadGreatestHits).not.toHaveBeenCalled();
+  });
+
+  it('sets greatestHitsExclude and reports applied when the flag is on and a list loads', async () => {
+    mockLoadGreatestHits.mockResolvedValue({ node_ids: ['acc-b-001', 'saf-d-004', 'skp-i-002'] });
+    const relevanceOpts = opts();
+    const outcome = await applyGreatestHitsExclusion(relevanceOpts, true);
+    expect(outcome).toEqual({ requested: true, applied: true, listSize: 3 });
+    expect(relevanceOpts.greatestHitsExclude).toEqual(new Set(['acc-b-001', 'saf-d-004', 'skp-i-002']));
+    expect(mockRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'info', data: { exclusion_list_size: 3 } }),
+    );
+  });
+
+  it('degrades loudly (no exclusion, warn recorded) when on but the list is unavailable', async () => {
+    mockLoadGreatestHits.mockResolvedValue(null);
+    const relevanceOpts = opts();
+    const outcome = await applyGreatestHitsExclusion(relevanceOpts, true);
+    expect(outcome).toEqual({ requested: true, applied: false, listSize: 0 });
+    expect(relevanceOpts.greatestHitsExclude).toBeUndefined();
+    expect(mockRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'warn',
+        message: expect.stringContaining('exclusion list is unavailable'),
+        data: { reason: 'list_unavailable' },
+      }),
+    );
+  });
+
+  it('degrades loudly with reason=empty_list when the list loads but is empty', async () => {
+    mockLoadGreatestHits.mockResolvedValue({ node_ids: [] });
+    const relevanceOpts = opts();
+    const outcome = await applyGreatestHitsExclusion(relevanceOpts, true);
+    expect(outcome).toEqual({ requested: true, applied: false, listSize: 0 });
+    expect(relevanceOpts.greatestHitsExclude).toBeUndefined();
+    expect(mockRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'warn', data: { reason: 'empty_list' } }),
+    );
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/getGreatestHits.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/getGreatestHits.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Cached greatest-hits exclusion-list fetch + app-path exclusion application (t/1998).
+// STORE-FREE (mirrors shared/docTitles.ts) so any slice/shared module can import it
+// without a store load-order cycle — it imports only the bridge, the flight recorder,
+// and a type. The node-ID list comes from calibration/greatest-hits.json via the bridge
+// (Electron IPC `load-greatest-hits` + web `GET /api/greatest-hits`; the provider halves
+// land in parallel — ElectronMain / ServerAPI). Both bridge impls return null when the
+// file is absent, so getGreatestHits() resolves to undefined and callers degrade.
+//
+// This is the APP-run mirror of the CLI engine's exclusion at
+// lib/debate/debateEngine/taxonomyContext.ts:266. The engine HARD-THROWS when the flag
+// is On and the file is missing; the app path degrades LOUDLY instead (TL decision, PM
+// p/19#120) — a missing calibration file must never fail a GUI debate. applyGreatestHits-
+// Exclusion returns the outcome so the caller can surface a user-visible warning and the
+// overview can render "On — not applied".
+
+import { api } from '@bridge';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import type { RelevanceOptions } from '../../../utils/taxonomyRelevance';
+
+let _cached: { node_ids: string[] } | null | undefined;
+
+/**
+ * Load the greatest-hits exclusion node-ID list (cached for the session). Returns
+ * undefined when unavailable — file absent (bridge returns null), the provider endpoint
+ * isn't live yet, or a load error. Never throws.
+ */
+export async function getGreatestHits(): Promise<string[] | undefined> {
+  if (_cached !== undefined) return _cached?.node_ids;
+  try {
+    const result = await api.loadGreatestHits();
+    _cached = result;
+    return result?.node_ids;
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'debate-store',
+      level: 'warn',
+      message: 'Failed to load greatest-hits exclusion list',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    _cached = null;
+    return undefined;
+  }
+}
+
+/** Reset the module cache. Test isolation only. */
+export function resetGreatestHitsCache(): void {
+  _cached = undefined;
+}
+
+/** Outcome of an app-path greatest-hits exclusion attempt (drives the user warning + overview state). */
+export interface GreatestHitsOutcome {
+  /** The debate's exclude_greatest_hits flag was On. */
+  requested: boolean;
+  /** Exclusion was actually applied (list loaded and non-empty). */
+  applied: boolean;
+  /** Size of the exclusion list applied (0 when not applied). */
+  listSize: number;
+}
+
+/**
+ * Apply greatest-hits exclusion to relevance options for app-run debates (t/1998).
+ * When the flag is On and the list loads, sets `relevanceOpts.greatestHitsExclude` and
+ * records an info event. When On but the list is unavailable, LEAVES relevanceOpts
+ * untouched and records a warn event — the caller is responsible for the user-visible
+ * warning (this module stays store-free). Returns the outcome for that surfacing.
+ */
+export async function applyGreatestHitsExclusion(
+  relevanceOpts: RelevanceOptions,
+  excludeFlag: boolean | undefined,
+): Promise<GreatestHitsOutcome> {
+  if (!excludeFlag) return { requested: false, applied: false, listSize: 0 };
+
+  const ids = await getGreatestHits();
+  if (ids && ids.length > 0) {
+    relevanceOpts.greatestHitsExclude = new Set(ids);
+    getGlobalRecorder()?.record({
+      type: 'turn.taxonomy_inject',
+      component: 'debate-store',
+      level: 'info',
+      message: `Greatest-hits exclusion applied: ${ids.length}-node exclusion list loaded`,
+      data: { exclusion_list_size: ids.length },
+    });
+    return { requested: true, applied: true, listSize: ids.length };
+  }
+
+  // Loud degrade: requested but unavailable — do NOT throw (engine parity would fail the debate).
+  getGlobalRecorder()?.record({
+    type: 'turn.taxonomy_inject',
+    component: 'debate-store',
+    level: 'warn',
+    message: 'Greatest-hits exclusion is On but the exclusion list is unavailable — retread nodes NOT filtered',
+    data: { reason: ids ? 'empty_list' : 'list_unavailable' },
+  });
+  return { requested: true, applied: false, listSize: 0 };
+}

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -16,6 +16,7 @@ import { computeLineageDistribution, formatLineageContext } from '@lib/debate/to
 import { cosineSimilarity, scoreNodeRelevanceMeanTopN, selectRelevantNodes, selectRelevantSituationNodes, buildRelevanceQuery, scoreNodesViaAN } from '../../../utils/taxonomyRelevance';
 import type { ANClaimEmbedding, RelevanceOptions } from '../../../utils/taxonomyRelevance';
 import type { TaxonomyContext } from '../../../utils/taxonomyContext';
+import { applyGreatestHitsExclusion } from './getGreatestHits';
 import { getLineageMapping, getL2Categories, isLineageDataLoaded } from '../../../data/lineageCategories';
 import { api } from '@bridge';
 
@@ -404,6 +405,20 @@ function buildRelevanceOptions(threshold: number, debate: ReturnType<typeof useD
   return relevanceOpts;
 }
 
+/**
+ * Surface a user-visible debate warning when greatest-hits exclusion was requested but
+ * not applied (t/1998 loud-degrade). Store-touching companion to the store-free
+ * applyGreatestHitsExclusion; de-duped so a multi-turn debate raises it at most once.
+ */
+function surfaceGreatestHitsWarning(outcome: { requested: boolean; applied: boolean }): void {
+  if (!outcome.requested || outcome.applied) return;
+  const s = useDebateStore.getState();
+  const warning = 'Greatest-hits exclusion is On, but the exclusion list is unavailable — retread nodes were NOT filtered for this debate.';
+  if (s.debateWarnings.length < 50 && !s.debateWarnings.includes(warning)) {
+    useDebateStore.setState({ debateWarnings: [...s.debateWarnings, warning] });
+  }
+}
+
 /** Build the diagnostics injection manifest and log the lineage-boost promotion outcome. */
 function buildInjectionManifest(
   scoredPov: ReturnType<typeof selectRelevantNodes>,
@@ -518,6 +533,14 @@ export async function getRelevantTaxonomyContext(
     // Build relevance options with optional lineage boost
     const debate = useDebateStore.getState().activeDebate;
     const relevanceOpts = buildRelevanceOptions(threshold, debate, allPovNodes);
+
+    // Greatest-hits exclusion (t/1998) — app mirror of the CLI engine (debateEngine/
+    // taxonomyContext.ts:266). Degrades LOUDLY, not by throwing (TL decision, PM p/19#120):
+    // when the flag is On but the exclusion list is unavailable, exclusion is skipped and
+    // surfaceGreatestHitsWarning raises a user-visible note so the overview can show
+    // "On — not applied".
+    const ghOutcome = await applyGreatestHitsExclusion(relevanceOpts, debate?.exclude_greatest_hits);
+    surfaceGreatestHitsWarning(ghOutcome);
 
     const scoredPov = selectRelevantNodes(allPovNodes, scores, relevanceOpts);
     const scoredCC = selectRelevantSituationNodes(allCCNodes, scores, threshold, 3, 15);

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -48,6 +48,9 @@ export interface ElectronAPI {
   resolveSourceDocument: (docId: string) => Promise<{ available: boolean; type: 'pdf' | 'markdown' | null; content?: string; path?: string }>;
   loadSourceEvidenceIndex: () => Promise<Record<string, unknown> | null>;
   loadDocTitles: () => Promise<Record<string, string> | null>;
+  // IPC handler (`load-greatest-hits`) lands in parallel (ElectronMain, t/1998).
+  // Optional until then so electron-bridge's fallback (`?.() ?? null`) typechecks.
+  loadGreatestHits?: () => Promise<{ node_ids: string[] } | null>;
   getSourceEvidence: (nodeIds: string[], pov: string) => Promise<{
     facts: unknown[]; keyPoints: unknown[]; formattedBlock: string;
     nodesCovered: string[]; totalCandidates: number;


### PR DESCRIPTION
## Summary
Wires the **app-path read** for greatest-hits exclusion (t/1998; parent t/1979; store carrier t/1980; engine t/1438). App-run debates score nodes in-renderer via `taxonomyRelevance` and never invoke the lib `DebateEngine` (t/1779), so the persisted `exclude_greatest_hits` flag had no effect on the primary in-app path until now. Mirrors the CLI engine at `lib/debate/debateEngine/taxonomyContext.ts:266`.

## Changes (all Taxonomy Editor scope)
- **Bridge triplet** (`loadGreatestHits`): `AppAPI` (types.ts) + web (`GET /api/greatest-hits`) + electron (IPC delegate w/ optional-chaining fallback) + `electron.d.ts` type. Mirrors `loadDocTitles`.
- **`getGreatestHits.ts`** (store-free, mirrors `docTitles.ts`): cached fetch + `applyGreatestHitsExclusion` (sets `relevanceOpts.greatestHitsExclude`).
- **`taxonomyContext.ts`**: apply exclusion after `buildRelevanceOptions`; `surfaceGreatestHitsWarning` raises a user note when requested-but-unavailable.

## Degrade LOUDLY (TL decision, PM p/19#120)
Unlike the engine (which **throws** on flag-On + missing file), the app path **never fails a GUI debate**: exclusion is skipped, a `debateWarnings` note is raised, and a flight-recorder `warn` is logged. `getGreatestHits()` is exported as the shared availability source DebateUI reads for the overview "On — not applied" chip.

## Provider contract (ServerAPI REST + ElectronMain IPC, in parallel)
Return **`{ node_ids: string[] } | null`** — NOT a bare array, NOT a `Set` (Sets don't JSON-serialize). Until both land, the web 404 / absent IPC method resolve `null` → graceful no-op.

## Self-cert
`/add-bridge-method` (deviation: consumer is a store-free shared module like `docTitles.ts`, not a Zustand slice).

## Verification
- tsc main + renderer: clean
- `eslint src/ --max-warnings=4256`: 651 warnings, 0 errors (no new complexity warning — wiring extracted to `surfaceGreatestHitsWarning`)
- depcruise: no violations (no import cycle from the new module)
- vite build: clean
- vitest (scoped): 103 passed (8 new `getGreatestHits.test.ts` + 95 debate-store regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)