### PR TITLE
fix(server): accept greatest-hits.json v2 shape in /api/greatest-hits (t/2003)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/greatestHitsRoute.test.ts
+++ b/taxonomy-editor/src/server/__tests__/greatestHitsRoute.test.ts
@@ -46,6 +46,27 @@ describe('loadGreatestHitsNodeIds (t/1998)', () => {
     expect(JSON.parse(JSON.stringify(result))).toEqual({ node_ids: ['acc-bel-001', 'saf-des-002'] });
   });
 
+  it('t/2003: reads the v2 shape (nodes[].node_id) into { node_ids }', () => {
+    writeGreatestHits(JSON.stringify({
+      version: 2,
+      nodes: [
+        { node_id: 'acc-beliefs-085', pov: 'accelerationist', bdi_category: 'beliefs', debate_count: 107, crux_link_count: 2 },
+        { node_id: 'acc-beliefs-032', pov: 'accelerationist', bdi_category: 'beliefs', debate_count: 85, crux_link_count: 21 },
+      ],
+    }));
+    expect(loadGreatestHitsNodeIds()).toEqual({ node_ids: ['acc-beliefs-085', 'acc-beliefs-032'] });
+  });
+
+  it('t/2003: v1 node_ids take precedence when both shapes are present', () => {
+    writeGreatestHits(JSON.stringify({ version: 2, node_ids: ['v1-id'], nodes: [{ node_id: 'v2-id' }] }));
+    expect(loadGreatestHitsNodeIds()).toEqual({ node_ids: ['v1-id'] });
+  });
+
+  it('t/2003: v2 filters entries with a non-string or missing node_id', () => {
+    writeGreatestHits(JSON.stringify({ version: 2, nodes: [{ node_id: 'ok' }, { node_id: 42 }, {}] }));
+    expect(loadGreatestHitsNodeIds()).toEqual({ node_ids: ['ok'] });
+  });
+
   it('returns null on malformed JSON (graceful no-op)', () => {
     writeGreatestHits('{ not valid json');
     expect(loadGreatestHitsNodeIds()).toBeNull();

--- a/taxonomy-editor/src/server/routes/sources.ts
+++ b/taxonomy-editor/src/server/routes/sources.ts
@@ -107,22 +107,34 @@ function loadDocTitles(): DocMetaMap | null {
 }
 
 /**
- * t/1998: read `calibration/greatest-hits.json` and return just its `node_ids` for
- * the renderer's greatest-hits exclusion. Returns null when the file is absent or
- * unreadable (graceful no-op — the renderer treats null as "no exclusion available";
- * see the loud-degrade design in t/1998#2). Mirrors loadDocTitles (fs read, null on
- * absence). Deliberately does NOT use corpusCoverage.loadGreatestHitsFile(): that
- * returns a Set (JSON.stringify(new Set()) → {}) and throws on a missing file — this
- * endpoint returns the raw `{ node_ids }` array or null instead.
+ * t/1998: read `calibration/greatest-hits.json` and return its node IDs as
+ * `{ node_ids }` for the renderer's greatest-hits exclusion. Returns null when the
+ * file is absent or unreadable (graceful no-op — the renderer treats null as "no
+ * exclusion available"; see the loud-degrade design in t/1998#2). Mirrors
+ * loadDocTitles (fs read, null on absence). Deliberately does NOT use
+ * corpusCoverage.loadGreatestHitsFile(): that returns a Set (JSON.stringify(new
+ * Set()) → {}) and throws on a missing file.
+ *
+ * t/2003: accepts BOTH file shapes so it survives the DebateTool v2 data regen on
+ * either side of it — v1 = flat `node_ids: string[]`; v2 = `nodes: [{ node_id, pov,
+ * bdi_category, ... }]`. Without this, v2 leaves `node_ids` undefined → `{ node_ids:
+ * [] }` → exclusion silently no-ops. The response contract (`{ node_ids: string[] }`)
+ * is unchanged — the renderer builds the Set + filters vs. live nodes.
  */
 export function loadGreatestHitsNodeIds(): { node_ids: string[] } | null {
   try {
     const p = greatestHitsPath(getDataRoot());
     if (!fs.existsSync(p)) return null;
-    const parsed = JSON.parse(fs.readFileSync(p, 'utf-8')) as { node_ids?: unknown };
-    const node_ids = Array.isArray(parsed.node_ids)
-      ? parsed.node_ids.filter((id): id is string => typeof id === 'string')
-      : [];
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf-8')) as {
+      node_ids?: unknown;
+      nodes?: Array<{ node_id?: unknown }>;
+    };
+    const raw: unknown[] = Array.isArray(parsed.node_ids)
+      ? parsed.node_ids
+      : Array.isArray(parsed.nodes)
+        ? parsed.nodes.map(n => n?.node_id)
+        : [];
+    const node_ids = raw.filter((id): id is string => typeof id === 'string');
     return { node_ids };
   } catch { /* telemetry — silent by design: absent/malformed → null (graceful no-op) */ return null; }
 }


### PR DESCRIPTION
DebateTool bumped `calibration/greatest-hits.json` to v2 (t/2003, `02568ee9`): flat `node_ids: string[]` → `nodes: [{ node_id, pov, bdi_category, ... }]`. `loadGreatestHitsNodeIds` read `parsed.node_ids` directly → undefined on v2 → `{ node_ids: [] }` → exclusion **silently no-ops** (the same silent-failure genus as t/1995/t/1997).

Now derives from `nodes[].node_id` when `node_ids` is absent, so the endpoint survives the data regen on either side of it. Confirmed the v2 field name (`nodes[].node_id`) against DebateTool PR #241 (t/2003#1). Response `{ node_ids: string[] }` unchanged — renderer contract intact.

Tests: v2 `nodes[].node_id` read, v1 precedence when both present, v2 non-string/missing node_id filtered. tsc(server) rc=0, eslint 0, 8/8. Self-cert /trivial-change.