### PR TITLE
fix(main): accept v2 greatest-hits shape (nodes[].node_id) in load-greatest-hits (t/2003)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/sourceHandlers.test.ts
+++ b/taxonomy-editor/src/main/__tests__/sourceHandlers.test.ts
@@ -78,4 +78,27 @@ describe('load-greatest-hits IPC handler (t/1998)', () => {
     writeGreatestHits('{ not valid json');
     expect(invoke('load-greatest-hits')).toBeNull();
   });
+
+  // v2 forward-compat (t/2003 / DebateTool #241): the file bumped from flat `node_ids` to
+  // `nodes: [{ node_id, ... }]`. The handler extracts the ID list from either shape.
+  it('reads the v2 shape (nodes[].node_id) and returns { node_ids }', () => {
+    writeGreatestHits(JSON.stringify({
+      version: 2,
+      nodes: [
+        { pov: 'acc', bdi_category: 'beliefs', node_id: 'acc-beliefs-085', debate_count: 107, crux_link_count: 2 },
+        { pov: 'acc', bdi_category: 'beliefs', node_id: 'acc-beliefs-032', debate_count: 85, crux_link_count: 21 },
+      ],
+    }));
+    expect(invoke('load-greatest-hits')).toEqual({ node_ids: ['acc-beliefs-085', 'acc-beliefs-032'] });
+  });
+
+  it('drops v2 entries missing node_id (never surfaces undefined)', () => {
+    writeGreatestHits(JSON.stringify({ version: 2, nodes: [{ node_id: 'x' }, { debate_count: 5 }] }));
+    expect(invoke('load-greatest-hits')).toEqual({ node_ids: ['x'] });
+  });
+
+  it('prefers flat node_ids when a file carries both (v1 precedence)', () => {
+    writeGreatestHits(JSON.stringify({ version: 1, node_ids: ['v1-a'], nodes: [{ node_id: 'v2-b' }] }));
+    expect(invoke('load-greatest-hits')).toEqual({ node_ids: ['v1-a'] });
+  });
 });

--- a/taxonomy-editor/src/main/ipc/sourceHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/sourceHandlers.ts
@@ -104,8 +104,19 @@ export function registerSourceHandlers(): void {
     try {
       const filePath = path.join(getDataRootPath(), 'calibration', 'greatest-hits.json');
       if (!fs.existsSync(filePath)) return null;
-      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { node_ids?: string[] };
-      return { node_ids: data.node_ids ?? [] };
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as {
+        node_ids?: string[];
+        nodes?: { node_id?: string }[];
+      };
+      // Accept v1 (flat `node_ids`) and v2 (`nodes[].node_id`, t/2003 / DebateTool #241) — pull
+      // the ID list from whichever shape the file carries so exclusion survives the data-repo
+      // regen timing. A v2 file read as v1-only would silently return [] → exclusion no-ops,
+      // exactly the silent-degrade trap TL flagged (t/1998#2). Malformed v2 entries (no
+      // node_id) are dropped, never surfaced as undefined.
+      const nodeIds = data.node_ids
+        ?? data.nodes?.map((n) => n.node_id).filter((id): id is string => typeof id === 'string')
+        ?? [];
+      return { node_ids: nodeIds };
     } catch { /* telemetry — silent by design; missing/malformed → null, renderer degrades */ return null; }
   });
 


### PR DESCRIPTION
Forward-compat fix for the `load-greatest-hits` IPC handler (shipped in t/1998, `af8d1504`).

DebateTool's **t/2003** (#241) bumps `calibration/greatest-hits.json` to **v2**: flat `node_ids: string[]` → `nodes: [{ node_id, ... }]`. The v1-only handler reads `data.node_ids` directly, so a v2 file silently returns `{ node_ids: [] }` → greatest-hits exclusion no-ops on desktop (the silent-degrade trap, TL t/1998#2). t/2003#2 flagged this IPC read plus ServerAPI's identical REST read for a v1+v2 fix.

### Change
`data.node_ids ?? data.nodes?.map(n => n.node_id).filter(isString) ?? []` — extracts the ID list from either shape, keeps the `{ node_ids }` output (Taxonomy Editor's bridge contract), and drops malformed v2 entries (no `node_id`). Accepting both shapes means this code needn't land atomically with the data-repo v2 file.

### Tests
+3 cases (v2 `nodes[].node_id` extraction; malformed-entry drop; v1 precedence when both present). **7/7** `sourceHandlers` tests pass; `tsc -p tsconfig.main.json` + eslint clean.

Self-cert: `/trivial-change` (forward-compat read tweak to an existing handler, single scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
