### PR TITLE
chore(security): triage 2 no-fix perl-modules criticals via justified .trivyignore (t/2006)

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -83,6 +83,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          trivyignores: '.trivyignore'
           skip-setup-trivy: true
 
       - name: Upload Trivy scan results

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -203,6 +203,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          trivyignores: '.trivyignore'
           skip-setup-trivy: true
 
       - name: Upload Trivy scan results

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,27 @@
+# Trivy vulnerability ignore file — AI Triad Research container images.
+# Scanned images: ghcr.io/jpsnover/ai-triad-base, ghcr.io/jpsnover/taxonomy-editor
+#
+# POLICY (t/2006): no silent suppression. Every entry MUST carry: the CVE, the
+# affected package, WHY it is ignored, and a concrete REVISIT trigger. Anything
+# with an available upstream fix must be patched (base rebuild), not ignored.
+# Last reviewed: 2026-07-30 (Docker).
+
+# ── perl-modules-5.36 (Debian bookworm) — NO UPSTREAM FIX AVAILABLE ─────────────
+# CVE-2026-13221  perl regex trie overflow (>65535 alternation branches)
+# CVE-2026-57433  Storable signed-integer overflow on crafted SX_HOOK deserialize
+#
+# Package:   perl-modules-5.36  (installed 5.36.0-7+deb12u3)
+# Fix state: Debian bookworm has published NO fixed version — Trivy reports an
+#            empty "Fixed Version" as of 2026-07-30. An `apt-get upgrade` base
+#            rebuild therefore cannot clear these (nothing to upgrade to).
+# Exposure:  perl is present only as a transitive dependency of git + pandoc in
+#            the base image. The Node/TS application does not invoke perl on
+#            untrusted input — there is no path that compiles an attacker-supplied
+#            regex or thaws an untrusted Storable blob. Exploitability in our
+#            context is negligible.
+# REVISIT:   drop each entry when Debian ships a fixed perl-modules-5.36
+#            (deb12u4+), OR when the node-26 / newer-Debian base lands
+#            (t/1990, ~2026-10-28) — whichever is first. Re-scan and remove any
+#            entry Trivy no longer reports.
+CVE-2026-13221
+CVE-2026-57433


### PR DESCRIPTION
## Summary
Remediates the Trivy **critical** surface for the container images (t/2006, Option A per PM p/302#4).

The critical surface is **2 CVEs**, both in `perl-modules-5.36` (`5.36.0-7+deb12u3`):
- **CVE-2026-13221** — perl regex trie overflow
- **CVE-2026-57433** — Storable signed-integer overflow

**Both have NO upstream fix** — Debian bookworm reports an empty Trivy `Fixed Version` as of 2026-07-30, so an `apt-get upgrade` base rebuild cannot clear them. Per the AC ("cleared **or** explicitly triaged with a justified, co-located `.trivyignore`"), these are handled by a justified ignore.

## Changes
- **`.trivyignore`** (new) — both CVEs with package, no-fix rationale, negligible-exposure note (perl is a transitive dep of git/pandoc; the Node/TS app never invokes perl on untrusted input), and a dated REVISIT trigger tied to t/1990 (~2026-10-28 node-26/newer-Debian base, or an earlier Debian perl fix).
- **base-image.yml / container.yml** — wire both Trivy scan steps to honor `.trivyignore` (`trivyignores: '.trivyignore'`).

## Proof
After merge I'll dispatch base-image.yml and confirm the fresh Trivy run reports **0 criticals** (both suppressed with justification), per the AC's "prove the count dropped."

No silent suppression — every entry justified and dated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)