### PR TITLE
fix(scripts): normalize Get-DataRoot via GetFullPath to remove embedded '..' (t/2007)

### DIFF
--- a/scripts/AITriad/Private/Resolve-DataPath.ps1
+++ b/scripts/AITriad/Private/Resolve-DataPath.ps1
@@ -150,11 +150,14 @@ function Get-DataRoot {
 
     $Root = $script:DataConfig.data_root
     if ([System.IO.Path]::IsPathRooted($Root)) {
-        return $Root
+        return [System.IO.Path]::GetFullPath($Root)
     }
-    # Resolve relative to where .aitriad.json was found, then Get-CodeRoot fallback
+    # Resolve relative to where .aitriad.json was found, then Get-CodeRoot fallback.
+    # Normalize via GetFullPath so the returned path has no embedded '..' segments —
+    # from a sibling worktree the raw Join yields '<wt>\..\ai-triad-data', which is
+    # fine for file I/O but breaks path-string comparisons (mirrors Get-SourcesDir; t/2007).
     if ($script:DataConfigDir) { $Anchor = $script:DataConfigDir } else { $Anchor = Get-CodeRoot }
-    return Join-Path $Anchor $Root
+    return [System.IO.Path]::GetFullPath((Join-Path $Anchor $Root))
 }
 
 function Get-TaxonomyDir {


### PR DESCRIPTION
`Get-DataRoot` joined a relative `data_root` to its anchor without normalizing, so from a sibling worktree it returned `<wt>\..\ai-triad-data` — fine for file I/O but breaks path-string comparisons keyed on the data root. `Get-SourcesDir` already normalizes the analogous `sources_root` via `[System.IO.Path]::GetFullPath()`; this mirrors it for both return paths.

Pre-existing quirk (the shared root produced the same shape), surfaced by the retire-shared-checkout review (t/1926#12) where N per-role worktrees multiply distinct anchor dirs. Self-certified under /trivial-change (TL-authorized, p/24#175).

## Verify
- `Invoke-Pester ./tests/` → **956 passed, 0 failed**, 12 skipped
- `Test-ModuleManifest ./scripts/AITriad/AITriad.psd1` → OK (AITriad 0.8.6)
- Empirical: `Get-DataRoot` → `C:\Users\jsnov\repos\ai-triad-data` (no `..`), path exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)