### PR TITLE
chore(deps): bump fast-uri 3.1.2->3.1.4 + hono in / (security, supersedes #118) (t/2002)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -996,9 +996,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
chore(deps): bump fast-uri 3.1.2->3.1.4 + hono 4.12.26->4.12.32 in / (security) (t/2002)

Lands the fast-uri high-severity security fix (GHSA-v2hh-gcrm-f6hx,
GHSA-4c8g-83qw-93j6) + hono, from the stranded Dependabot PR #118. #118 was ~178h
old under the retired npm_and_yarn grouping and would neither rebase nor recreate,
so applying the lockfile bump fresh. Both are transitive (root package-lock.json
only; no package.json change). Dependabot Wave-1 fast-uri highs are t/2002's scope
per t/2001#1 (routed to the PR-backlog ticket to avoid a double-bump). One moderate
alert remains (t/2001 Wave-3 mediums) — not chased here. #118 closed as superseded.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
