### PR TITLE
fix(flight-recorder): default dumpToFile out of the tree, not CWD (t/2014)

### DIFF
--- a/lib/flight-recorder/flightRecorder.test.ts
+++ b/lib/flight-recorder/flightRecorder.test.ts
@@ -646,6 +646,53 @@ describe('dumpToFile', () => {
     fs.rmdirSync(tmpDir);
   });
 
+  it('defaults out of the tree (not CWD) when no dumpDir is configured', () => {
+    // Regression: an empty dumpDir must not fall through to '.', which would
+    // drop dump files into whatever tree the process runs from (t/2014).
+    const savedRuntimeDir = process.env.AI_TRIAD_RUNTIME_DIR;
+    delete process.env.AI_TRIAD_RUNTIME_DIR; // exercise the temp-dir fallback
+    try {
+      const rec = new FlightRecorder({ capacity: 10 }); // DEFAULT_CONFIG.dumpDir === ''
+      rec.record(makeInput({ message: 'default-path-event' }));
+
+      const result = rec.dumpToFile();
+
+      expect(path.isAbsolute(result.path)).toBe(true);
+      expect(path.dirname(result.path)).not.toBe(process.cwd());
+      // Fallback uses mkdtempSync: a private, randomly-named dir under os.tmpdir().
+      expect(result.path.startsWith(os.tmpdir())).toBe(true);
+      expect(path.dirname(result.path)).toMatch(/flight-recorder-/);
+      expect(fs.existsSync(result.path)).toBe(true);
+
+      fs.unlinkSync(result.path);
+      fs.rmdirSync(path.dirname(result.path));
+    } finally {
+      if (savedRuntimeDir === undefined) delete process.env.AI_TRIAD_RUNTIME_DIR;
+      else process.env.AI_TRIAD_RUNTIME_DIR = savedRuntimeDir;
+    }
+  });
+
+  it('honors AI_TRIAD_RUNTIME_DIR for the default dump dir', () => {
+    const savedRuntimeDir = process.env.AI_TRIAD_RUNTIME_DIR;
+    const runtimeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fr-runtime-'));
+    process.env.AI_TRIAD_RUNTIME_DIR = runtimeDir;
+    try {
+      const rec = new FlightRecorder({ capacity: 10 });
+      rec.record(makeInput({ message: 'runtime-dir-event' }));
+
+      const result = rec.dumpToFile();
+
+      expect(path.dirname(result.path)).toBe(runtimeDir);
+      expect(fs.existsSync(result.path)).toBe(true);
+
+      fs.unlinkSync(result.path);
+    } finally {
+      if (savedRuntimeDir === undefined) delete process.env.AI_TRIAD_RUNTIME_DIR;
+      else process.env.AI_TRIAD_RUNTIME_DIR = savedRuntimeDir;
+      fs.rmdirSync(runtimeDir);
+    }
+  });
+
   it('returns empty timestamps when buffer is empty', () => {
     const outPath = path.join(os.tmpdir(), `fr-empty-${Date.now()}.jsonl`);
     const result = recorder.dumpToFile(outPath);

--- a/lib/flight-recorder/flightRecorder.ts
+++ b/lib/flight-recorder/flightRecorder.ts
@@ -3,6 +3,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as os from 'node:os';
 import * as net from 'node:net';
 import { Dictionary } from './dictionary.js';
 import { RingBuffer } from './ringBuffer.js';
@@ -146,7 +147,7 @@ export class FlightRecorder {
   dumpToFile(filePath?: string): DumpResult {
     const events = this.buffer.drain();
     const resolvedPath = filePath ?? path.join(
-      this.config.dumpDir || '.',
+      this.resolveDumpDir(),
       `dump-${process.pid}-${new Date().toISOString().replace(/[:.]/g, '-')}.jsonl`,
     );
 
@@ -168,6 +169,21 @@ export class FlightRecorder {
       debate_id: ctx.active_debate_id as string | undefined,
       size_bytes: Buffer.byteLength(ndjson, 'utf-8'),
     };
+  }
+
+  /**
+   * Resolve the directory for an auto-named dump. Precedence:
+   * configured dumpDir → AI_TRIAD_RUNTIME_DIR → a private temp dir.
+   * The `'.'`/CWD default is deliberately avoided so a bare dumpToFile()
+   * never drops artifacts into the tree it runs from (t/2014). The temp
+   * fallback uses mkdtempSync (mode 0700, random suffix) rather than a
+   * predictable os.tmpdir() path so the dump filename can't be
+   * pre-created or symlinked by another local user (js/insecure-temporary-file).
+   */
+  private resolveDumpDir(): string {
+    const configured = this.config.dumpDir || process.env.AI_TRIAD_RUNTIME_DIR;
+    if (configured) return configured;
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'flight-recorder-'));
   }
 
   // ── Summary (no I/O) ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
`FlightRecorder.dumpToFile()` with no explicit path and no configured `dumpDir` resolved its output to `this.config.dumpDir || '.'` — writing `dump-<pid>-<ts>.jsonl` into `process.cwd()`, i.e. the hub tree when run from the hub. This is the single genuine in-tree hub write surfaced by the t/2014 enumeration (t/2014#1, parent t/2008).

App callers (Electron/server) pass explicit external paths so it was latent, but any bare `dumpToFile()` — CLI `npm run debate`, tests, crash-dump, future callers — re-dirtied a "clean hub."

## Change
- Default now falls through to `AI_TRIAD_RUNTIME_DIR` then `os.tmpdir()`, never `'.'`. `DEFAULT_CONFIG.dumpDir` is `''`, so the `||` correctly routes the unconfigured case out of the tree.
- Adds a regression test asserting the bare default lands in the OS temp dir (absolute, exists), not CWD.

## Verification
- `tsc -p tsconfig.main.json` clean for flight-recorder
- flight-recorder vitest 66/66 green (keys unset, CI-faithful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)