### PR TITLE
fix(githooks): refuse detached-HEAD worktree commits + branch-first landing (t/2009)

### DIFF
--- a/.githooks/ff-redetach.sh
+++ b/.githooks/ff-redetach.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# ─────────────────────────────────────────────────────────────────────────────
+# ff-redetach — safely re-sync a persistent per-role worktree onto origin/main (t/2009 §a).
+#
+# The retire-shared-checkout model (t/2008): each role works in a PERSISTENT worktree
+# sitting at detached origin/main + ephemeral per-task PR branches. Between tasks the
+# worktree must be re-synced to the latest origin/main — but NEVER by a hard reset or a
+# bare `git checkout --detach` that would silently DISCARD uncommitted or unlanded work
+# (the exact wipe-class this migration exists to kill, Sage #93 / t/1926).
+#
+# This helper is FAIL-SAFE (the opposite of the pre-commit hook's fail-open): on ANY
+# doubt it REFUSES and surfaces the refuse-when-dirty playbook, rather than discard.
+# It only re-detaches when the worktree is clean AND not ahead of origin/main.
+#
+# Usage (session start, from inside your worktree):  sh .githooks/ff-redetach.sh
+# ─────────────────────────────────────────────────────────────────────────────
+set -e
+
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "ff-redetach: not inside a git worktree" >&2; exit 2; }
+
+git fetch origin >&2 || { echo "ff-redetach: fetch failed — resolve network/auth and retry (nothing changed)" >&2; exit 2; }
+
+# Dirty tree (staged, unstaged, or untracked) → refuse; re-detaching would discard it.
+if [ -n "$(git status --porcelain)" ]; then
+  cat >&2 <<'MSG'
+
+  ✖ ff-redetach REFUSED: the worktree is DIRTY (uncommitted / untracked work).
+    Re-detaching would discard it. Land or stash first, then re-run:
+      git switch -c <type>/<slug>-t<ticket>   # name the branch → commit → land via PR
+      #  or:  git stash push -u -m "wip <ticket>"   (recover later: git stash pop)
+    (refuse-when-dirty playbook, ADR §3a — this helper never discards.)
+MSG
+  exit 1
+fi
+
+# Ahead of origin/main (local commits not yet on origin) → refuse; would orphan them.
+ahead=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo unknown)
+if [ "$ahead" != "0" ]; then
+  cat >&2 <<'MSG'
+
+  ✖ ff-redetach REFUSED: HEAD is AHEAD of origin/main (unlanded local commits).
+    Re-detaching would orphan them. Land them via a PR branch first:
+      git switch -c <type>/<slug>-t<ticket>   # if not already on a named branch
+      git push origin <branch>  →  gh pr create  →  self-merge on green
+    Then re-run ff-redetach.
+MSG
+  exit 1
+fi
+
+# Clean AND not ahead → safe to re-detach onto the freshly-fetched origin/main.
+git checkout --detach origin/main
+echo "ff-redetach: re-detached onto origin/main ($(git rev-parse --short HEAD))" >&2

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -10,9 +10,12 @@
 #
 # CARVE-OUTS (co-located here per the Gate Co-Location rule, t/1589 — NOT in a
 # ticket or external doc):
-#   • Linked worktrees are ALLOWED (git-dir != git-common-dir). The /land-from-worktree
-#     flow commits on a branch inside a worktree, so landing is never blocked.
-#   • Any branch other than `main` is ALLOWED.
+#   • Linked worktrees are ALLOWED on a NAMED branch (git-dir != git-common-dir).
+#     /land-from-worktree is branch-first (`git worktree add -b`), so landing
+#     commits sit on a named PR branch and are never blocked.
+#   • A commit on a DETACHED HEAD inside a worktree is REFUSED (t/2009): it would be
+#     an orphaned commit, lost on the next re-detach. Fix = create the branch first.
+#   • Any branch other than `main` (on the shared checkout) is ALLOWED.
 #   • Owner / emergency override: `git commit --no-verify` (git skips all hooks).
 #   • Fail-OPEN: if any git introspection errors, the hook ALLOWS the commit — a
 #     broken guard must never block legitimate work.
@@ -30,8 +33,28 @@ gd=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd) || exit 0
 cdir=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd) || exit 0
 [ -n "$gd" ] && [ -n "$cdir" ] || exit 0
 
-# Linked worktree → allow (this is where legitimate landing commits happen).
-[ "$gd" = "$cdir" ] || exit 0
+# Linked worktree: allow ONLY on a named branch. A commit on a DETACHED HEAD here
+# is orphaned-commit risk (lost on the next re-detach unless pushed); the
+# branch-first flow (`worktree add -b`) makes it a named branch from the start.
+if [ "$gd" != "$cdir" ]; then
+  git symbolic-ref -q HEAD >/dev/null 2>&1 && exit 0   # named branch → allow (landing)
+  cat >&2 <<'MSG'
+
+  ✖ BLOCKED: commit on a DETACHED HEAD inside a worktree (t/2009).
+    A detached-HEAD commit is orphaned — lost on the next re-detach unless pushed.
+
+  Create the worktree BRANCH-FIRST so commits land on a named PR branch:
+    git worktree add -b <type>/<slug>-t<ticket> ../wt-<ticket> origin/main
+    #  …commit on the named branch…  →  git push origin <branch>  →  gh pr create
+
+  Already detached with work to save? Name the branch in place, then commit:
+    git switch -c <type>/<slug>-t<ticket>
+
+  Owner / emergency override (bypasses this hook):
+    git commit --no-verify
+MSG
+  exit 1
+fi
 
 # Shared checkout: only the `main` branch is protected.
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
@@ -43,10 +66,10 @@ cat >&2 <<'MSG'
   ✖ BLOCKED: direct commit to the shared-tree `main` checkout (t/1926).
     This strands work local-only and diverges `main` from `origin`.
 
-  Land via /land-from-worktree instead:
-    git worktree add ../wt-<ticket> origin/main
-    #  …commit inside the worktree…
-    git push origin HEAD:<branch>   →   gh pr create   →   self-merge on green
+  Land via /land-from-worktree instead (branch-first):
+    git worktree add -b <type>/<slug>-t<ticket> ../wt-<ticket> origin/main
+    #  …commit on the named branch inside the worktree…
+    git push origin <branch>   →   gh pr create   →   self-merge on green
 
   Owner / emergency override (bypasses this hook):
     git commit --no-verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Orca config files (`.orca.yaml`, `AGENTS.md`, `.orca/` directory) live in a **se
 
 ### Shared-Checkout Commit Guard (git pre-commit hook)
 
-The fleet shares one `main` checkout, so a commit made **directly on its `main` branch** strands work local-only and diverges `main` from `origin` (t/1926). A committed pre-commit hook (`.githooks/pre-commit`) **refuses** such commits. Worktree commits, non-`main` branches, and `--no-verify` are allowed, so `/land-from-worktree` is never blocked. Git does not auto-run committed hooks — **enable once per checkout**:
+The fleet shares one `main` checkout, so a commit made **directly on its `main` branch** strands work local-only and diverges `main` from `origin` (t/1926). A committed pre-commit hook (`.githooks/pre-commit`) **refuses** such commits. It also **refuses a commit on a detached HEAD inside a worktree** (t/2009, orphaned-commit guard) — so `/land-from-worktree` is now **branch-first** (`git worktree add -b <branch> ...`). Worktree commits on a **named branch**, non-`main` branches, and `--no-verify` are allowed, so landing is never blocked. Git does not auto-run committed hooks — **enable once per checkout**:
 
 ```
 git config core.hooksPath .githooks

--- a/docs/git-and-session-workflow.md
+++ b/docs/git-and-session-workflow.md
@@ -29,9 +29,9 @@ Prevention: when your commit imports something from another scope, `git show HEA
 
 Multi-file or multi-commit changes land from an **isolated git worktree**, never the shared working tree. Three shared-tree failure patterns forced this (Sage #51 landing race, #54 dirty-tree false witness): on a shared tree, your uncommitted state is every other agent's environment. Follow `/land-from-worktree` (playbook skill). The core rules:
 
-1. `git fetch origin` immediately before creating the worktree; create it off `origin/main` (a stale base sees phantom breakage).
+1. `git fetch origin` immediately before creating the worktree; create it **branch-first** off `origin/main`: `git worktree add -b <type>/<slug>-t<ticket> ../wt-<ticket> origin/main` (a stale base sees phantom breakage). Branch-first because the pre-commit hook now **refuses a commit on a detached HEAD** inside a worktree (t/2009, orphaned-commit guard) — the named PR branch must exist before you commit, which also retires the old `push HEAD:refs/heads/<branch>` short-ref dance.
 2. `npm ci` inside the worktree for every package your verify touches — fresh worktrees have no node_modules; verify against stale deps red-herrings.
-3. Copy only your changed files in; `git add` by pathspec; **commit and push INSIDE the worktree** — the commit is born there. One SHA, nothing lingers on the shared ref. Never commit on the shared main and cherry-pick a copy.
+3. Copy only your changed files in; `git add` by pathspec; **commit on the worktree's named branch and push INSIDE the worktree** — `git push origin <branch>` (not `HEAD:refs/heads/<branch>`; the branch already exists from step 1). The commit is born there. One SHA, nothing lingers on the shared ref. Never commit on the shared main and cherry-pick a copy.
 4. Run the full verify gate inside the worktree before pushing (Definition of Done applies where the commit is born).
 5. Sync the shared tree afterward with file-scoped `git checkout origin/main -- <files>` — never a reset, which can drop other agents' work.
 6. Remove the worktree; confirm `git log origin/main..main` on the shared tree shows nothing of yours lingering.


### PR DESCRIPTION
fix(githooks): refuse detached-HEAD worktree commits + branch-first landing (t/2009)

Extends .githooks/pre-commit (t/1926): inside a worktree, a commit on a DETACHED
HEAD is now REFUSED (orphaned-commit guard) — allowed only on a named branch. Kills
the wipe-class the migration targets rather than relocating it (Sage's finding).

Co-ships the forced landing-flow change to BRANCH-FIRST (`git worktree add -b`),
since the old flow committed on a detached HEAD and would now be refused:
- .githooks/pre-commit: detached-in-worktree guard (`git symbolic-ref -q HEAD`),
  branch-first refuse message, updated carve-out header. Shared-main path unchanged.
- .githooks/ff-redetach.sh (t/2009 §a): fail-SAFE session-start re-sync — refuses
  when the worktree is dirty or ahead (surfaces the refuse-when-dirty playbook),
  re-detaches onto origin/main only when clean. Never discards.
- docs/git-and-session-workflow.md Worktree Landing + AGENTS.md hook note:
  branch-first flow (worktree add -b; push origin <branch>, not HEAD:refs/heads/).

Self-proving: this PR is landed via the new branch-first flow (worktree created with
`git worktree add -b`, committed on the named branch — the hook allowed it).

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Technical Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
