### PR TITLE
fix(security): summary-viewer sanitizer removal + flightRecorderInit FP doc (t/2024 A+C)

### DIFF
--- a/summary-viewer/src/htmlSafetyInvariant.test.ts
+++ b/summary-viewer/src/htmlSafetyInvariant.test.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Guards the security invariant behind t/2024 Fix A (CodeQL js/incomplete-multi-
+// character-sanitization + js/bad-tag-filter): generateContent no longer HTML-sanitizes
+// AI text — the regex sanitizer was bypassable AND redundant, so it was removed
+// (TL-approved p/56#192). Safety instead relies on the renderer displaying AI text ONLY
+// via react-markdown, which does not execute raw HTML unless the `rehype-raw` plugin is
+// enabled. This test goes red if anyone reintroduces a raw-HTML sink in the renderer,
+// which would reopen the XSS surface the removed sanitizer nominally (but ineffectively)
+// covered.
+
+const rendererDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'renderer');
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...collectSourceFiles(full));
+    else if (/\.(ts|tsx)$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+describe('summary-viewer HTML-safety invariant (t/2024 Fix A)', () => {
+  const files = collectSourceFiles(rendererDir);
+
+  it('has renderer source files to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('never uses dangerouslySetInnerHTML in the renderer', () => {
+    const offenders = files
+      .filter((f) => fs.readFileSync(f, 'utf-8').includes('dangerouslySetInnerHTML'))
+      .map((f) => path.relative(rendererDir, f));
+    expect(offenders).toEqual([]);
+  });
+
+  it('never enables rehype-raw (which would make react-markdown execute raw HTML)', () => {
+    const offenders = files
+      .filter((f) => /rehype-raw/.test(fs.readFileSync(f, 'utf-8')))
+      .map((f) => path.relative(rendererDir, f));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/summary-viewer/src/main/generateContent.ts
+++ b/summary-viewer/src/main/generateContent.ts
@@ -6,12 +6,14 @@ import { PROJECT_ROOT } from './fileIO';
 import { ActionableError } from '../../../lib/debate/errors';
 import { callByUsage } from '../../../lib/ai-client/usageRegistry.js';
 
-function sanitizeAiText(text: string): string {
-  return text
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '')
-    .replace(/<script\b[^>]*\/?>/gi, '')
-    .replace(/\bon\w+\s*=\s*["'][^"']*["']/gi, '');
-}
+// SECURITY INVARIANT (t/2024, CodeQL js/incomplete-multi-character-sanitization +
+// js/bad-tag-filter): AI-generated text is NOT HTML-sanitized here. It is rendered
+// exclusively via react-markdown (DocumentPane etc.), which does not execute embedded
+// raw HTML unless the `rehype-raw` plugin is added. A regex-based sanitizer was both
+// bypassable (CodeQL) and redundant, so it was removed (TL-approved p/56#192). The
+// safety guarantee therefore depends on the renderer NOT introducing a raw-HTML sink:
+// do NOT add `rehype-raw` or `dangerouslySetInnerHTML` to summary-viewer's renderer.
+// Enforced by htmlSafetyInvariant.test.ts.
 
 export async function generateContent(
   systemPrompt: string,
@@ -47,5 +49,5 @@ export async function generateContent(
     },
   );
 
-  return sanitizeAiText(result.text);
+  return result.text;
 }

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -497,6 +497,11 @@ export function initFlightRecorder(): FlightRecorder {
       if (elapsed > 60_000) {
         clearAuthTracking();
       } else {
+        // NOTE (t/2024, CodeQL js/user-controlled-bypass #5314 — dismissed as false
+        // positive, TL-approved p/56#192): this cookie read is DIAGNOSTIC ONLY. It
+        // populates the `has_session_cookie` telemetry field below and gates NO security
+        // decision — the auth-loop branch keys on redirectCount/elapsed, never on this
+        // value. Do not treat `hasSession` as an authorization signal.
         const hasSession = document.cookie.includes('AppServiceAuthSession');
         recorder.record({
           type: 'auth.callback_landing',


### PR DESCRIPTION
## Summary
SEC Wave-2 (epic t/2001, ticket t/2024) — the remaining 5 of 7 CodeQL highs. Both TL-approved (p/56#192).

- **A — #4005/#4010/#4011/#4012** (`summary-viewer/src/main/generateContent.ts`): the `sanitizeAiText` regex was a bypassable HTML sanitizer (CodeQL) **and** redundant — AI text renders exclusively via **react-markdown**, which does not execute raw HTML without `rehype-raw` (absent, verified). Removed the regex; documented the invariant; added `htmlSafetyInvariant.test.ts` — a node-env guard that fails red if the renderer ever introduces `dangerouslySetInnerHTML` or `rehype-raw`.
- **C — #5314 `js/user-controlled-bypass`** (`taxonomy-editor/src/renderer/lib/flightRecorderInit.ts`): genuine **false positive** — the cookie read is diagnostic-only (populates the `has_session_cookie` telemetry field; gates no security decision — the auth-loop branch keys on `redirectCount`/`elapsed`). Co-located a NOTE; the alert is **dismissed as "false positive"** per the epic policy (t/2001#5), no analyzer-gaming code change.

## Verification
- summary-viewer: `tsc -p tsconfig.main.json` clean, `eslint src/` clean, `vitest run` **14/14** (incl. the 3 new guard assertions).
- C is comment-only in taxonomy-editor (no behavior change).
- CodeQL alert-clearing confirmed on the post-merge re-scan (A×4); C cleared via dismissal.

Companion PR #252 covers fixes B + D. Triage: t/2024#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)