### PR TITLE
fix(server-ai): clear 4 CodeQL high findings in server/ai (t/2021)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/fsCache.test.ts
+++ b/taxonomy-editor/src/server/__tests__/fsCache.test.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment node
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { readFileWithMtime } from '../ai/fsCache.js';
+
+describe('fsCache.readFileWithMtime (t/2021 — TOCTOU-safe read)', () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fscache-test-'));
+    filePath = path.join(tmpDir, 'config.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns the file content and a matching mtime from one fd', () => {
+    fs.writeFileSync(filePath, '{"a":1}', 'utf-8');
+    const expectedMtime = fs.statSync(filePath).mtimeMs;
+
+    const { content, mtimeMs } = readFileWithMtime(filePath);
+    expect(content).toBe('{"a":1}');
+    // fstat on the same fd reports the same mtime as an independent stat.
+    expect(mtimeMs).toBe(expectedMtime);
+  });
+
+  it('throws ENOENT for a missing file (callers rely on this for cache-miss)', () => {
+    expect(() => readFileWithMtime(path.join(tmpDir, 'nope.json')))
+      .toThrowError(expect.objectContaining({ code: 'ENOENT' }));
+  });
+
+  it('does not leak a file descriptor across many reads', () => {
+    fs.writeFileSync(filePath, 'x', 'utf-8');
+    // If the fd were leaked each call, this loop would exhaust the fd table.
+    for (let i = 0; i < 300; i++) {
+      expect(readFileWithMtime(filePath).content).toBe('x');
+    }
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/fsCache.test.ts
+++ b/taxonomy-editor/src/server/__tests__/fsCache.test.ts
@@ -37,6 +37,21 @@ describe('fsCache.readFileWithMtime (t/2021 — TOCTOU-safe read)', () => {
       .toThrowError(expect.objectContaining({ code: 'ENOENT' }));
   });
 
+  it('skips the read on a cache hit but still reads on a stale mtime', () => {
+    fs.writeFileSync(filePath, '{"a":1}', 'utf-8');
+    const { mtimeMs } = readFileWithMtime(filePath);
+
+    // Same mtime → fast path: content is null so the caller reuses its cache.
+    const hit = readFileWithMtime(filePath, mtimeMs);
+    expect(hit.content).toBeNull();
+    expect(hit.mtimeMs).toBe(mtimeMs);
+
+    // A stale cached mtime → the read happens and returns the current content.
+    const miss = readFileWithMtime(filePath, mtimeMs - 1);
+    expect(miss.content).toBe('{"a":1}');
+    expect(miss.mtimeMs).toBe(mtimeMs);
+  });
+
   it('does not leak a file descriptor across many reads', () => {
     fs.writeFileSync(filePath, 'x', 'utf-8');
     // If the fd were leaked each call, this loop would exhaust the fd table.

--- a/taxonomy-editor/src/server/__tests__/providerBinding.test.ts
+++ b/taxonomy-editor/src/server/__tests__/providerBinding.test.ts
@@ -119,4 +119,44 @@ describe('providerBinding', () => {
     expect(result.ok).toBe(false);
     expect(result.boundTo).toBe('google');
   });
+
+  // ── t/2021 security regression: prototype-pollution / property-injection ──
+  // storageUserId is user-derived (normalized OAuth id). CodeQL flagged the
+  // dynamic write `bindings[storageUserId] = idp` (js/remote-property-injection).
+
+  it('rejects __proto__ as a storageUserId and writes no binding', () => {
+    const result = checkProviderBinding('__proto__', 'github');
+    expect(result).toEqual({ ok: false });
+    expect(fs.existsSync(path.join(adminDir, 'provider_bindings.json'))).toBe(false);
+  });
+
+  it('rejects constructor and prototype as storageUserIds', () => {
+    expect(checkProviderBinding('constructor', 'github')).toEqual({ ok: false });
+    expect(checkProviderBinding('prototype', 'github')).toEqual({ ok: false });
+  });
+
+  it('does not treat an Object.prototype member name as an existing binding', () => {
+    // With a normal-prototype map, bindings['toString'] resolved to
+    // Object.prototype.toString (truthy) and mis-flagged a first-time login as
+    // an idp mismatch. The null-prototype map makes a fresh id bind cleanly.
+    expect(checkProviderBinding('toString', 'github')).toEqual({ ok: true });
+
+    _resetBindingsCache();
+    expect(checkProviderBinding('toString', 'github')).toEqual({ ok: true });
+    expect(checkProviderBinding('toString', 'google')).toEqual({ ok: false, boundTo: 'github' });
+  });
+
+  it('drops a forbidden key from a pre-existing file without polluting Object.prototype', () => {
+    fs.writeFileSync(
+      path.join(adminDir, 'provider_bindings.json'),
+      '{"__proto__":"evil","alice":"github"}',
+      'utf-8',
+    );
+    _resetBindingsCache();
+
+    expect(checkProviderBinding('alice', 'github')).toEqual({ ok: true });
+    // The forbidden entry was dropped on load; Object.prototype is untouched.
+    expect(({} as Record<string, unknown>).evil).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(Object.prototype, 'evil')).toBe(false);
+  });
 });

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -20,6 +20,7 @@ import { getApiKey, getApiKeys, getProjectRoot, EMBED_SCRIPT, resolveDataPath, t
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { parseJsonRobust } from '../../../../lib/debate/helpers.js';
 import { extractProviderReason, deriveKeyErrorMessage } from './providerErrors.js';
+import { readFileWithMtime } from './fsCache.js';
 import { tavilySearch, buildSearchAugmentedPrompt } from '../../../../lib/search/tavily.js';
 import { resolveEmbeddings, type EmbeddingFallback } from '../../../../lib/embeddings/embeddingResolver.js';
 import type { EmbeddingsFile } from '../../../../lib/electron-shared/embeddingIO.js';
@@ -125,14 +126,13 @@ let _modelConfigMtime = 0;
 function loadModelConfig(): { modelMap: Record<string, string>; fallbackChains: Record<string, string[]>; defaults: Record<string, string> } {
   try {
     const configPath = path.join(getProjectRoot(), 'ai-models.json');
-    const stat = fs.statSync(configPath);
-    if (!_modelMapCache || stat.mtimeMs !== _modelConfigMtime) {
-      const raw = fs.readFileSync(configPath, 'utf-8');
+    const { content: raw, mtimeMs } = readFileWithMtime(configPath);
+    if (!_modelMapCache || mtimeMs !== _modelConfigMtime) {
       const registry = JSON.parse(raw) as { models: { id: string; apiModelId?: string }[]; fallbackChains?: Record<string, string[]>; defaults?: Record<string, string> };
       _modelMapCache = buildModelIdMap(registry as { models: { id: string; apiModelId: string; label: string; backend: string }[]; backends: [] });
       _fallbackChainCache = registry.fallbackChains ?? {};
       _defaultsCache = registry.defaults ?? {};
-      _modelConfigMtime = stat.mtimeMs;
+      _modelConfigMtime = mtimeMs;
       log.api.debug({ models: Object.keys(_modelMapCache!).length, chains: Object.keys(_fallbackChainCache!).length }, 'Reloaded model config');
     }
   } catch (err) {

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -126,8 +126,8 @@ let _modelConfigMtime = 0;
 function loadModelConfig(): { modelMap: Record<string, string>; fallbackChains: Record<string, string[]>; defaults: Record<string, string> } {
   try {
     const configPath = path.join(getProjectRoot(), 'ai-models.json');
-    const { content: raw, mtimeMs } = readFileWithMtime(configPath);
-    if (!_modelMapCache || mtimeMs !== _modelConfigMtime) {
+    const { content: raw, mtimeMs } = readFileWithMtime(configPath, _modelMapCache ? _modelConfigMtime : undefined);
+    if (raw !== null) {
       const registry = JSON.parse(raw) as { models: { id: string; apiModelId?: string }[]; fallbackChains?: Record<string, string[]>; defaults?: Record<string, string> };
       _modelMapCache = buildModelIdMap(registry as { models: { id: string; apiModelId: string; label: string; backend: string }[]; backends: [] });
       _fallbackChainCache = registry.fallbackChains ?? {};

--- a/taxonomy-editor/src/server/ai/fsCache.ts
+++ b/taxonomy-editor/src/server/ai/fsCache.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import fs from 'fs';
+
+/**
+ * TOCTOU-safe read of a config file's content + mtime.
+ *
+ * The mtime-cache loaders in this directory previously did `fs.statSync(p)`
+ * (check) followed by `fs.readFileSync(p)` (use) — two separate path
+ * resolutions, so a concurrent replace between them could return an mtime
+ * that doesn't match the bytes actually read (CodeQL js/file-system-race).
+ *
+ * Here the path is resolved exactly once (`openSync`); the mtime (`fstatSync`)
+ * and the content (`readFileSync`) are both taken from that single file
+ * descriptor, so they always describe the same underlying file — no race.
+ *
+ * Throws like `fs` does (e.g. ENOENT) so callers keep their existing
+ * try/catch for cache-miss and error semantics.
+ */
+export function readFileWithMtime(filePath: string): { content: string; mtimeMs: number } {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const mtimeMs = fs.fstatSync(fd).mtimeMs;
+    const content = fs.readFileSync(fd, 'utf-8');
+    return { content, mtimeMs };
+  } finally {
+    fs.closeSync(fd);
+  }
+}

--- a/taxonomy-editor/src/server/ai/fsCache.ts
+++ b/taxonomy-editor/src/server/ai/fsCache.ts
@@ -17,13 +17,23 @@ import fs from 'fs';
  *
  * Throws like `fs` does (e.g. ENOENT) so callers keep their existing
  * try/catch for cache-miss and error semantics.
+ *
+ * Pass `cachedMtimeMs` to preserve the mtime-cache fast path: the fstat and
+ * the read still happen on the same fd (no race), but the (larger) read is
+ * skipped when the file is unchanged, returning `content: null` so the caller
+ * reuses its already-parsed cache.
  */
-export function readFileWithMtime(filePath: string): { content: string; mtimeMs: number } {
+export function readFileWithMtime(
+  filePath: string,
+  cachedMtimeMs?: number,
+): { content: string | null; mtimeMs: number } {
   const fd = fs.openSync(filePath, 'r');
   try {
     const mtimeMs = fs.fstatSync(fd).mtimeMs;
-    const content = fs.readFileSync(fd, 'utf-8');
-    return { content, mtimeMs };
+    if (cachedMtimeMs !== undefined && mtimeMs === cachedMtimeMs) {
+      return { content: null, mtimeMs };
+    }
+    return { content: fs.readFileSync(fd, 'utf-8'), mtimeMs };
   } finally {
     fs.closeSync(fd);
   }

--- a/taxonomy-editor/src/server/ai/providerBinding.ts
+++ b/taxonomy-editor/src/server/ai/providerBinding.ts
@@ -50,8 +50,8 @@ function getBindingsPath(): string {
 function loadBindings(): ProviderBindings {
   const bindingsPath = getBindingsPath();
   try {
-    const { content, mtimeMs } = readFileWithMtime(bindingsPath);
-    if (_cache && mtimeMs === _cacheMtime) return _cache;
+    const { content, mtimeMs } = readFileWithMtime(bindingsPath, _cache ? _cacheMtime : undefined);
+    if (content === null) return _cache ?? emptyBindings();
     const parsed = JSON.parse(content) as Record<string, unknown>;
     // Rebuild into a null-prototype map, dropping any prototype-polluting or
     // non-string entries a hand-edited bindings file could contain.

--- a/taxonomy-editor/src/server/ai/providerBinding.ts
+++ b/taxonomy-editor/src/server/ai/providerBinding.ts
@@ -15,6 +15,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import { readFileWithMtime } from './fsCache.js';
 import { getDataRoot } from '../config.js';
 import { log } from '../logger.js';
 import { getConfig } from '../runtimeConfig.js';
@@ -22,6 +23,20 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 
 interface ProviderBindings {
   [storageUserId: string]: string;
+}
+
+// Property names that would reach Object.prototype if used as a dynamic map
+// key. A normalized storageUserId must never be one of these — using it as a
+// write target is a prototype-pollution vector (CodeQL js/remote-property-injection).
+const FORBIDDEN_KEYS = new Set<string>(['__proto__', 'constructor', 'prototype']);
+function isForbiddenKey(key: string): boolean {
+  return FORBIDDEN_KEYS.has(key);
+}
+
+// Bindings are held in a null-prototype object so a user-controlled key can
+// never resolve up the prototype chain on read, nor pollute it on write.
+function emptyBindings(): ProviderBindings {
+  return Object.create(null) as ProviderBindings;
 }
 
 let _cache: ProviderBindings | null = null;
@@ -35,11 +50,17 @@ function getBindingsPath(): string {
 function loadBindings(): ProviderBindings {
   const bindingsPath = getBindingsPath();
   try {
-    const stat = fs.statSync(bindingsPath);
-    if (_cache && stat.mtimeMs === _cacheMtime) return _cache;
-    const data = JSON.parse(fs.readFileSync(bindingsPath, 'utf-8')) as ProviderBindings;
-    _cache = data;
-    _cacheMtime = stat.mtimeMs;
+    const { content, mtimeMs } = readFileWithMtime(bindingsPath);
+    if (_cache && mtimeMs === _cacheMtime) return _cache;
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    // Rebuild into a null-prototype map, dropping any prototype-polluting or
+    // non-string entries a hand-edited bindings file could contain.
+    const clean = emptyBindings();
+    for (const [k, v] of Object.entries(parsed)) {
+      if (!isForbiddenKey(k) && typeof v === 'string') clean[k] = v;
+    }
+    _cache = clean;
+    _cacheMtime = mtimeMs;
     return _cache;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -51,7 +72,7 @@ function loadBindings(): ProviderBindings {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
     }
-    return {};
+    return emptyBindings();
   }
 }
 
@@ -71,7 +92,7 @@ function saveBindings(bindings: ProviderBindings): void {
     fs.mkdirSync(dir, { recursive: true });
   }
   fs.writeFileSync(bindingsPath, JSON.stringify(bindings, null, 2), 'utf-8');
-  _cache = { ...bindings };
+  _cache = Object.assign(emptyBindings(), bindings);
   _cacheMtime = 0;
   _lastLoadTime = Date.now();
 }
@@ -92,6 +113,18 @@ export interface BindingResult {
  */
 export function checkProviderBinding(storageUserId: string, idp: string): BindingResult {
   if (!storageUserId || storageUserId === '_local') return { ok: true };
+  // Defensive: a normalized storageUserId must never be a prototype-polluting
+  // key. Reject rather than let it reach the dynamic write below
+  // (CodeQL js/remote-property-injection). Also guards the read that follows.
+  if (isForbiddenKey(storageUserId)) {
+    log.server.warn({ storageUserId }, 'Provider binding: rejected reserved storageUserId key');
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'providerBinding', level: 'warn',
+      message: 'Rejected reserved storageUserId key',
+      data: { storageUserId },
+    });
+    return { ok: false };
+  }
 
   const bindings = getBindings();
   const bound = bindings[storageUserId];

--- a/taxonomy-editor/src/server/ai/proxyTiers.ts
+++ b/taxonomy-editor/src/server/ai/proxyTiers.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import fs from 'fs';
 import path from 'path';
+import { readFileWithMtime } from './fsCache.js';
 import { getDataRoot } from '../config.js';
 import { log } from '../logger.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
@@ -75,14 +75,14 @@ function loadTierConfig(): TierConfig {
   ];
   for (const p of candidates) {
     try {
-      const stat = fs.statSync(p);
-      if (_cache && stat.mtimeMs === _cacheMtime) return _cache;
-      const data = JSON.parse(fs.readFileSync(p, 'utf-8')) as Partial<TierConfig>;
+      const { content, mtimeMs } = readFileWithMtime(p);
+      if (_cache && mtimeMs === _cacheMtime) return _cache;
+      const data = JSON.parse(content) as Partial<TierConfig>;
       _cache = {
         defaults: { ...tierDefaults(), ...data.defaults },
         users: data.users ?? [],
       };
-      _cacheMtime = stat.mtimeMs;
+      _cacheMtime = mtimeMs;
       log.server.debug({ count: _cache.users.length, path: p }, 'Loaded tier entries');
       return _cache;
     } catch (err) {

--- a/taxonomy-editor/src/server/ai/proxyTiers.ts
+++ b/taxonomy-editor/src/server/ai/proxyTiers.ts
@@ -75,8 +75,8 @@ function loadTierConfig(): TierConfig {
   ];
   for (const p of candidates) {
     try {
-      const { content, mtimeMs } = readFileWithMtime(p);
-      if (_cache && mtimeMs === _cacheMtime) return _cache;
+      const { content, mtimeMs } = readFileWithMtime(p, _cache ? _cacheMtime : undefined);
+      if (content === null) return _cache ?? defaultTierConfig();
       const data = JSON.parse(content) as Partial<TierConfig>;
       _cache = {
         defaults: { ...tierDefaults(), ...data.defaults },


### PR DESCRIPTION
## t/2021 — clear 4 CodeQL high findings in `server/ai/` (SEC Wave-2, epic t/2001)

| # | Rule | Site | Fix |
|---|---|---|---|
| 5185 | `js/remote-property-injection` | providerBinding.ts:101 | forbidden-key guard + null-prototype map |
| 5175 | `js/file-system-race` | aiBackends.ts:130 | fd-based `readFileWithMtime` |
| 5174 | `js/file-system-race` | proxyTiers.ts:80 | fd-based `readFileWithMtime` |
| 5173 | `js/file-system-race` | providerBinding.ts:40 | fd-based `readFileWithMtime` |

### TOCTOU (3×)
The mtime-cache loaders did `fs.statSync(path)` (check) then `fs.readFileSync(path)` (use) — two path resolutions that can race a concurrent replace. New `fsCache.readFileWithMtime` resolves the path once (`openSync`) and takes mtime (`fstatSync(fd)`) + content (`readFileSync(fd)`) from the **same fd**, closing it in `finally`. An optional `cachedMtimeMs` preserves the original fast path (skip the read when unchanged) — added after security review flagged that `loadModelConfig` is on the unthrottled AI-request hot path.

### Property injection (input-handling)
`storageUserId` is a user-derived (normalized OAuth) id used as a map key in `bindings[storageUserId] = idp`. Fix: a denylist guard rejects `__proto__`/`constructor`/`prototype` (dominating both the read and the write), and the in-memory map is `Object.create(null)` so a user key can neither walk nor pollute the prototype chain. Also fixes a latent correctness bug — a `storageUserId` colliding with an `Object.prototype` member (e.g. `toString`) was previously mis-read as an existing binding.

### Tests
- `providerBinding.test.ts`: rejects reserved keys; no false "bound" for prototype-member ids; drops a forbidden key from a tampered file without polluting `Object.prototype`.
- `fsCache.test.ts`: content+mtime from one fd; ENOENT propagation; fast-path hit/stale; fd-leak smoke test.

### Security review
Ran a security-focused review (input-handling): both fixes assessed **sound / complete**, no residual injection or race, no error-swallowing (ADR-003 preserved), no secrets logged. Its one non-security finding (mtime fast-path regression) is incorporated in commit 2.

### Verify (worktree off origin/main)
tsc main+server clean · eslint 0 · scoped server suite **808/808**. CodeQL on this PR should mark #5185/#5175/#5174/#5173 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
