### PR TITLE
refactor(server): extract handleRequestInner public-path allowlist to publicPaths.ts (t/1910)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/publicPaths.test.ts
+++ b/taxonomy-editor/src/server/__tests__/publicPaths.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+
+/**
+ * t/1910 — the auth-exempt allowlist extracted from handleRequestInner's isPublicPath
+ * OR-chain into publicPaths.ts. This table test pins the exact behavior (Server Auth
+ * guardrail, p/135#9): every one of the 22 terms resolves public, and near-miss paths
+ * do NOT — proving each term kept its exact-vs-prefix match-kind (an exact term must
+ * not behave like a prefix, which would widen the allowlist = auth bypass).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeIsPublicPath, PUBLIC_EXACT_PATHS, PUBLIC_PATH_PREFIXES } from '../publicPaths.js';
+
+describe('computeIsPublicPath — auth-exempt allowlist (t/1910)', () => {
+  it('has exactly 15 exact + 7 prefix terms (guards accidental add/drop)', () => {
+    expect(PUBLIC_EXACT_PATHS.size).toBe(15);
+    expect(PUBLIC_PATH_PREFIXES.length).toBe(7);
+  });
+
+  it('every exact-match path resolves public', () => {
+    for (const p of PUBLIC_EXACT_PATHS) expect(computeIsPublicPath(p)).toBe(true);
+  });
+
+  it('every prefix (and a path under it) resolves public', () => {
+    for (const prefix of PUBLIC_PATH_PREFIXES) {
+      expect(computeIsPublicPath(prefix)).toBe(true);          // the bare prefix
+      expect(computeIsPublicPath(`${prefix}sub/thing`)).toBe(true); // something under it
+    }
+  });
+
+  it('the full 22-path allowlist resolves public', () => {
+    const samples = [...PUBLIC_EXACT_PATHS, ...PUBLIC_PATH_PREFIXES.map(p => `${p}anything`)];
+    expect(samples.every(computeIsPublicPath)).toBe(true);
+    expect(samples.length).toBe(22);
+  });
+
+  // Near-miss NEGATIVES (Server Auth p/135#9): each proves an EXACT term did not become
+  // a prefix, and a PREFIX still needs its full boundary.
+  it.each([
+    '/api/models-x',      // NOT /api/models (exact term, not a prefix)
+    '/api/models/extra',  // NOT /api/models
+    '/health/x',          // NOT /health
+    '/sw.jsx',            // NOT /sw.js — the exact/prefix flip pair
+    '/api/publicX',       // NOT under /api/public/ (prefix needs the trailing slash)
+    '/shareX',            // NOT under /share/
+    '/workbox',           // NOT /workbox- (prefix needs the hyphen)
+    '/api/private/thing', // not auth-exempt at all
+    '/',                  // root is NOT public (goes through the auth gate)
+    '',                   // empty path
+  ])('near-miss %j is NOT public', (p) => {
+    expect(computeIsPublicPath(p)).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/publicShare.test.ts
+++ b/taxonomy-editor/src/server/__tests__/publicShare.test.ts
@@ -22,6 +22,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import type { IncomingMessage, ServerResponse } from 'http';
+import { computeIsPublicPath, PUBLIC_PATH_PREFIXES } from '../publicPaths.js';
 
 const { readTaxonomyFileMock, recordMock } = vi.hoisted(() => ({
   readTaxonomyFileMock: vi.fn(),
@@ -166,22 +167,17 @@ describe('GET /api/public/pov/:pov/node/:nodeId (t/1788)', () => {
 
   // ── (b) auth-bypass scope ──
   describe('auth-bypass scope (isPublicPath + route table)', () => {
-    // isPublicPath is inline in server.ts (which boots an HTTP server at import,
-    // so it is not import-safe). Anchor the assertion to the real source text —
-    // the same static-scan discipline extractRoutes uses — rather than a copy.
-    const serverSrc = fs.readFileSync(serverEntry, 'utf-8');
-    // Slice to the NEXT statement (not the first `;`) — the t/1788 exemption
-    // comment itself contains a semicolon, so a `;`-terminated slice would cut
-    // the block short before the clause it documents.
-    const blockStart = serverSrc.indexOf('const isPublicPath =');
-    const isPublicBlock = serverSrc.slice(blockStart, serverSrc.indexOf('const authDisabled', blockStart));
-
-    it('server.ts auth gate exempts the /api/public/ namespace', () => {
-      expect(isPublicBlock).toContain("urlPath.startsWith('/api/public/')");
+    // t/1910: isPublicPath moved from server.ts to the import-safe publicPaths.ts, so
+    // these assert the real predicate + registered prefix directly (stronger than the
+    // former source-text scan). The /api/public/ auth exemption is the t/1788 invariant.
+    it('the auth gate exempts the /api/public/ namespace', () => {
+      expect(PUBLIC_PATH_PREFIXES).toContain('/api/public/');
+      expect(computeIsPublicPath('/api/public/pov/acc-beliefs-001/node/acc-beliefs-001')).toBe(true);
     });
 
     it('the gated sibling /api/conflicts is NOT in the public exemption list', () => {
-      expect(isPublicBlock).not.toContain('/api/conflicts');
+      expect(computeIsPublicPath('/api/conflicts')).toBe(false);
+      expect(PUBLIC_PATH_PREFIXES).not.toContain('/api/conflicts');
     });
 
     it('predicate: /api/public/... is exempt, a gated path is not', () => {

--- a/taxonomy-editor/src/server/__tests__/shareShell.test.ts
+++ b/taxonomy-editor/src/server/__tests__/shareShell.test.ts
@@ -18,17 +18,12 @@ import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { computeIsPublicPath, PUBLIC_PATH_PREFIXES } from '../publicPaths.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const serverSrc = fs.readFileSync(path.join(here, '..', 'server.ts'), 'utf-8');
-
-// The isPublicPath allowlist block: from its declaration to the next statement.
-// Sliced to `const authDisabled` (not the first `;`) because the exemption
-// comments themselves contain semicolons.
-const isPublicBlock = serverSrc.slice(
-  serverSrc.indexOf('const isPublicPath ='),
-  serverSrc.indexOf('const authDisabled', serverSrc.indexOf('const isPublicPath =')),
-);
+// t/1910: isPublicPath moved to the import-safe publicPaths.ts (asserted behaviorally
+// below); serverSrc is still read for the serveStatic no-Set-Cookie invariant.
 
 // The serveStatic function body — the code path that delivers the SPA shell.
 const serveStaticBody = serverSrc.slice(
@@ -39,13 +34,14 @@ const serveStaticBody = serverSrc.slice(
 describe('/share/ public SPA-shell exemption (t/1789)', () => {
   // ── (a) auth-exempt + tightly scoped ──
   describe('isPublicPath exempts /share/ as a tight prefix', () => {
-    it('the /share/ clause is present in the auth-gate allowlist', () => {
-      expect(isPublicBlock).toContain("urlPath.startsWith('/share/')");
+    it('the /share/ prefix is present in the auth-gate allowlist', () => {
+      expect(PUBLIC_PATH_PREFIXES).toContain('/share/');
+      expect(computeIsPublicPath('/share/pov/acc-beliefs-001')).toBe(true);
     });
 
     it('a gated sibling (/api/taxonomy, /api/conflicts) is NOT exempted', () => {
-      expect(isPublicBlock).not.toContain('/api/taxonomy');
-      expect(isPublicBlock).not.toContain('/api/conflicts');
+      expect(computeIsPublicPath('/api/taxonomy')).toBe(false);
+      expect(computeIsPublicPath('/api/conflicts')).toBe(false);
     });
 
     it('predicate: /share/... is public, a gated app path is not', () => {

--- a/taxonomy-editor/src/server/publicPaths.ts
+++ b/taxonomy-editor/src/server/publicPaths.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Auth-exempt (public) request paths — extracted verbatim from handleRequestInner's
+ * `isPublicPath` OR-chain (t/1910) so the allowlist is testable in isolation (server.ts
+ * boots the HTTP server on import) and the match-kind split is explicit.
+ *
+ * MATCH-KIND IS LOAD-BEARING (Server Auth review, p/135#8): each term keeps EXACTLY the
+ * kind it had in the original chain — the 15 `urlPath === X` terms are exact matches
+ * (PUBLIC_EXACT_PATHS), the 7 `urlPath.startsWith(X)` terms are prefixes
+ * (PUBLIC_PATH_PREFIXES). Promoting an exact path to a prefix WIDENS the allowlist =
+ * auth bypass (the severe direction), so never move a term between the two lists.
+ * Watch the flip pair: `/sw.js` is EXACT, `/workbox-` is a PREFIX.
+ */
+
+/** Exact-match public paths (were `urlPath === X`). */
+export const PUBLIC_EXACT_PATHS: ReadonlySet<string> = new Set<string>([
+  '/health',
+  '/healthz',
+  '/status',
+  '/api/models',            // pre-auth model catalog from ai-models.json (labels/ids, no secrets)
+  '/api/data/available',
+  '/api/auth/me',
+  '/api/auth/logout',       // t/897: logout must work even for authed-but-unauthorized users
+  '/api/diagnostics/sw-state', // t/1128: pre-auth SW-state beacon from the login page
+  '/llms.txt',              // t/1143: public llms.txt discovery file
+  '/api/config/client',     // t/927: public client config subset (no secrets)
+  '/api/user/profile',
+  '/api/sync/webhook/github', // GitHub POSTs unauthenticated; handler does its own HMAC verify
+  '/api/community/submit',
+  '/manifest.webmanifest',
+  '/sw.js',                 // EXACT — contrast the '/workbox-' PREFIX below
+]);
+
+/** Prefix public paths (were `urlPath.startsWith(X)`). */
+export const PUBLIC_PATH_PREFIXES: readonly string[] = [
+  '/api/auth/fresh-login/', // t/1032: pre-auth fresh sign-in (clears stale cookies, then OAuth)
+  '/api/public/',           // t/1788: reserved auth-exempt namespace — Server Auth sign-off to extend
+  '/share/',                // t/1789: public POV-share SPA shell — Server Auth sign-off to extend
+  '/.auth/',
+  '/assets/',
+  '/workbox-',              // PREFIX — Workbox precache asset filenames
+  '/icons/',
+];
+
+/**
+ * True when `urlPath` is auth-exempt: an exact match in PUBLIC_EXACT_PATHS, or a prefix
+ * match against PUBLIC_PATH_PREFIXES. Order-independent (OR / any-match), so this is
+ * equivalent to the original `===`/`startsWith` OR-chain regardless of term order.
+ */
+export function computeIsPublicPath(urlPath: string): boolean {
+  return PUBLIC_EXACT_PATHS.has(urlPath) || PUBLIC_PATH_PREFIXES.some(p => urlPath.startsWith(p));
+}

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -43,6 +43,7 @@ import { isCaseStatus } from './support/types.js';
 import * as organizations from './organizations.js';
 import { isPov } from './organizations.js';
 import { json, error, param, query, getClientIp, createRouter, withEndpointTimeout, type Handler } from './httpKit.js';
+import { computeIsPublicPath } from './publicPaths.js';
 import { registerDebatesRoutes } from './routes/debates.js';
 import { registerSyncRoutes } from './routes/sync.js';
 import { registerAdminRoutes } from './routes/admin.js';
@@ -793,33 +794,10 @@ async function handleRequestInner(
   // catalog from ai-models.json. Contains no secrets — just labels + ids.
   // /api/sync/webhook/github is public: GitHub POSTs unauthenticated; the
   // handler does its own HMAC verification against GITHUB_WEBHOOK_SECRET.
-  const isPublicPath = urlPath === '/health'
-    || urlPath === '/healthz'
-    || urlPath === '/status'
-    || urlPath === '/api/models'
-    || urlPath === '/api/data/available'
-    || urlPath === '/api/auth/me'
-    || urlPath === '/api/auth/logout' // t/897: logout must work even for authed-but-unauthorized users
-    || urlPath.startsWith('/api/auth/fresh-login/') // t/1032: pre-auth fresh sign-in (clears stale cookies, then OAuth)
-    || urlPath === '/api/diagnostics/sw-state' // t/1128: pre-auth SW-state beacon from the login page
-    || urlPath === '/llms.txt' // t/1143: public llms.txt discovery file
-    || urlPath === '/api/config/client' // t/927: public client config subset (no secrets)
-    || urlPath === '/api/user/profile'
-    || urlPath === '/api/sync/webhook/github'
-    || urlPath === '/api/community/submit'
-    // t/1788: /api/public/* is a reserved auth-exempt namespace — public read-only POV node share; nothing else may be added under it without Server Auth sign-off.
-    || urlPath.startsWith('/api/public/')
-    // t/1789: /share/* serves the SPA shell to fully logged-out visitors (public
-    // POV share links). Static shell only (no /api/ dynamic surface); the public
-    // read data comes from /api/public/*. Reserved auth-exempt namespace — nothing
-    // added under it without Server Auth sign-off.
-    || urlPath.startsWith('/share/')
-    || urlPath.startsWith('/.auth/')
-    || urlPath.startsWith('/assets/')
-    || urlPath === '/manifest.webmanifest'
-    || urlPath === '/sw.js'
-    || urlPath.startsWith('/workbox-')
-    || urlPath.startsWith('/icons/');
+  // t/1910: the auth-exempt allowlist (15 exact + 7 prefix terms) moved verbatim to
+  // publicPaths.ts so it's testable in isolation; the exact-vs-prefix match-kind split
+  // is load-bearing and Server-Auth-reviewed (p/135#8) — do not add paths here.
+  const isPublicPath = computeIsPublicPath(urlPath);
   // AUTH_DISABLED='1' (default) = anonymous access, no login page.
   // AUTH_OPTIONAL='1' = show login page with anonymous option; sign-in
   //   unlocks platform-tier keys, anonymous users get lower limits + BYOK.


### PR DESCRIPTION
First slice of the `handleRequestInner@83` decomposition — the **Server-Auth-gated piece** (p/135#8–9). Moves the auth-exempt `isPublicPath` OR-chain into a new `publicPaths.ts` so it's testable in isolation. **handleRequestInner 83 → 62.**

## Match-kind is load-bearing — each term keeps EXACTLY its original kind

**15 exact (`urlPath === X`) → `PUBLIC_EXACT_PATHS` (Set):**
`/health` · `/healthz` · `/status` · `/api/models` · `/api/data/available` · `/api/auth/me` · `/api/auth/logout` · `/api/diagnostics/sw-state` · `/llms.txt` · `/api/config/client` · `/api/user/profile` · `/api/sync/webhook/github` · `/api/community/submit` · `/manifest.webmanifest` · `/sw.js`

**7 prefix (`urlPath.startsWith(X)`) → `PUBLIC_PATH_PREFIXES`:**
`/api/auth/fresh-login/` · `/api/public/` · `/share/` · `/.auth/` · `/assets/` · `/workbox-` · `/icons/`

No term moved between the lists (exact→prefix would widen the allowlist = bypass). **Flip pair: `/sw.js` EXACT vs `/workbox-` PREFIX.**

## Verification
- **Table test** `publicPaths.test.ts` (p/135#9): all 22 terms public + 10 near-miss NEGATIVES — `/sw.jsx`, `/api/publicX`, `/shareX`, `/workbox`, `/api/models-x`, `/health/x`, `/api/models/extra`, `/api/private/thing`, `/`, `''` all NOT public — + a 15+7 count guard.
- `accessControl` + `debateAnonAllowlist` suites green (auth-gate behavior unchanged). tsc(server) rc=0, eslint 0 err. Route registration unchanged (routeTable unaffected).

**@Server Auth — please diff each term's match-kind against the original chain (server.ts before this) for your final sign-off before merge.** Remaining slices (auth gate / anon guard / persona / route-dispatch @22) follow as a second PR.