### PR TITLE
fix(main): use a single fd in read-research-file — clear CodeQL #5401 (t/2022)

### DIFF
--- a/taxonomy-editor/src/main/ipc/systemHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/systemHandlers.ts
@@ -116,10 +116,15 @@ export function registerSystemHandlers(): void {
 
   ipcMain.handle('read-research-file', (_event, relativePath: string) => {
     const filePath = resolveResearchPath(relativePath);
+    let fd: number | undefined;
     try {
-      // No existsSync guard (js/file-system-race, t/2022): stat/read directly and treat a
-      // missing file as null in the catch — avoids the check-then-use TOCTOU window.
-      const stat = fs.statSync(filePath);
+      // Open ONE descriptor and fstat+read through it (js/file-system-race, t/2022): statting a
+      // path then reading the same path is a TOCTOU; a single fd is race-free. Dropping the
+      // existsSync guard alone was insufficient — the residual statSync→readFileSync kept the
+      // alert open (#5401), so this mirrors the embeddings fd fix. A missing file (openSync
+      // ENOENT) is treated as null in the catch.
+      fd = fs.openSync(filePath, 'r');
+      const stat = fs.fstatSync(fd);
       if (stat.size > MAX_RESEARCH_FILE_SIZE) {
         throw new ActionableError({
           goal: 'Read research file',
@@ -128,7 +133,7 @@ export function registerSystemHandlers(): void {
           nextSteps: ['Use a smaller file or process it in chunks'],
         });
       }
-      const raw = fs.readFileSync(filePath, 'utf-8');
+      const raw = fs.readFileSync(fd, 'utf-8');
       return JSON.parse(raw);
     } catch (err) {
       if (err instanceof ActionableError) throw err;
@@ -142,6 +147,8 @@ export function registerSystemHandlers(): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       return null;
+    } finally {
+      if (fd !== undefined) fs.closeSync(fd);
     }
   });
 


### PR DESCRIPTION
The first t/2022 pass removed the existsSync guard in `read-research-file` but left the `statSync`→`readFileSync` on the same path — the identical stat-then-read TOCTOU the embeddings fix (#5400) eliminated with a file descriptor. CodeQL keys js/file-system-race to the readFileSync location, so **#5401 stayed open** after the post-merge main scan (the other 4 findings cleared). Applies the same fd approach: openSync → fstatSync (size check) → readFileSync(fd) → closeSync in finally. Missing file → openSync ENOENT → null (behavior unchanged); path-traversal guard still runs before the open. Existing systemHandlers tests pass unchanged; tsc-main + eslint clean. #5401 clears on the next main CodeQL scan.