### PR TITLE
fix(server): normalize auth-gate request path — close user-controlled-bypass (t/2019 Cat A)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/normalizedRequestPath.test.ts
+++ b/taxonomy-editor/src/server/__tests__/normalizedRequestPath.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+//
+// t/2019 (js/user-controlled-bypass) — the auth gate and the router both parse the
+// request path with normalizedRequestPath (httpKit.ts), the ONE canonical parse.
+//
+// Before the fix the gate derived its path from raw `req.url.split('?')` while the
+// router used `new URL().pathname`. An encoded-traversal path
+// (/api/public/%2e%2e/admin) therefore read as a public /api/public/ prefix AT THE
+// GATE (auth-exempt) while resolving to /api/admin AT THE ROUTER — a real auth bypass.
+//
+// These tests pin: (1) the normalization behaviour (dot-segment resolution + query
+// strip, matching the router), (2) fail-secure on a malformed URL, and (3) the REAL
+// exploit is now denied at the composed gate decision
+// computeIsPublicPath(normalizedRequestPath(req)). The gate is inline in server.ts
+// (which boots the HTTP server on import, so it can't be imported), so we exercise the
+// exact composition the gate performs against the import-safe helper + allowlist.
+
+import { describe, it, expect } from 'vitest';
+import type { IncomingMessage } from 'http';
+import { normalizedRequestPath } from '../httpKit.js';
+import { computeIsPublicPath } from '../publicPaths.js';
+
+const req = (url: string | undefined): IncomingMessage => ({ url } as IncomingMessage);
+
+describe('normalizedRequestPath (t/2019 auth-gate path canonicalization)', () => {
+  describe('resolves dot-segments and strips the query — matching the router', () => {
+    it('encoded traversal (%2e%2e) resolves out of the /api/public/ prefix', () => {
+      expect(normalizedRequestPath(req('/api/public/%2e%2e/admin'))).toBe('/api/admin');
+    });
+
+    it('literal .. traversal resolves', () => {
+      expect(normalizedRequestPath(req('/api/public/../admin'))).toBe('/api/admin');
+    });
+
+    it('multi-hop encoded traversal resolves fully', () => {
+      expect(normalizedRequestPath(req('/api/public/%2e%2e/%2e%2e/admin'))).toBe('/admin');
+    });
+
+    it('traversal out of another public prefix (/.auth/) also resolves', () => {
+      expect(normalizedRequestPath(req('/.auth/%2e%2e/api/admin'))).toBe('/api/admin');
+    });
+
+    it('strips the query string so freeTier exact-path checks stay exact', () => {
+      expect(normalizedRequestPath(req('/api/ai/generate?model=x'))).toBe('/api/ai/generate');
+    });
+
+    it('leaves a legitimate path unchanged', () => {
+      expect(normalizedRequestPath(req('/share/pov/acc-beliefs-001'))).toBe('/share/pov/acc-beliefs-001');
+      expect(normalizedRequestPath(req('/api/models'))).toBe('/api/models');
+    });
+
+    it('is case-preserving (does not lowercase the path)', () => {
+      expect(normalizedRequestPath(req('/api/Public/x'))).toBe('/api/Public/x');
+    });
+  });
+
+  describe('fails secure on a malformed URL', () => {
+    it('an unparseable URL returns the non-public, unroutable sentinel (never throws)', () => {
+      const sentinel = normalizedRequestPath(req('//'));
+      expect(sentinel).toBe('/__malformed_url__');
+      // The sentinel is never in the public allowlist → the request is gated…
+      expect(computeIsPublicPath(sentinel)).toBe(false);
+      // …and matches no registered route (it starts with '/__', not '/api/…').
+      expect(sentinel.startsWith('/__')).toBe(true);
+    });
+
+    it('undefined req.url falls back to root, not a throw', () => {
+      expect(normalizedRequestPath(req(undefined))).toBe('/');
+    });
+  });
+
+  describe('the encoded-traversal auth bypass is closed at the gate (regression)', () => {
+    it('the RAW path would have been treated as public — the pre-fix vulnerability', () => {
+      // Documents exactly what the fix removes: the raw split-on-? path the old gate
+      // used reads as a /api/public/ prefix even though it resolves to /api/admin.
+      expect(computeIsPublicPath('/api/public/%2e%2e/admin')).toBe(true);
+    });
+
+    it('the NORMALIZED gate path is NOT public → the exploit request is gated', () => {
+      const gatePath = normalizedRequestPath(req('/api/public/%2e%2e/admin'));
+      expect(gatePath).toBe('/api/admin');
+      expect(computeIsPublicPath(gatePath)).toBe(false);
+    });
+
+    it('gate and router resolve the identical path for the exploit (no divergence)', () => {
+      // Both the auth gate and the router feed req through normalizedRequestPath, so
+      // the value they gate/route on is one and the same by construction.
+      const r = req('/api/public/%2e%2e/admin');
+      const gatePath = normalizedRequestPath(r);
+      const routerPath = normalizedRequestPath(r);
+      expect(gatePath).toBe(routerPath);
+      expect(routerPath).toBe('/api/admin');
+    });
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/normalizedRequestPath.test.ts
+++ b/taxonomy-editor/src/server/__tests__/normalizedRequestPath.test.ts
@@ -54,6 +54,34 @@ describe('normalizedRequestPath (t/2019 auth-gate path canonicalization)', () =>
     });
   });
 
+  // The encoding variants the TL called out (t/2019#5 condition 3) — each must resolve
+  // the SAME way at the gate and the router, so none reintroduces a parser differential.
+  describe('encoding-variant traversal (TL condition 3)', () => {
+    it('uppercase percent-encoding (%2E) resolves identically to lowercase → gated', () => {
+      const p = normalizedRequestPath(req('/api/public/%2E%2E/admin'));
+      expect(p).toBe('/api/admin');
+      expect(computeIsPublicPath(p)).toBe(false);
+    });
+
+    it('backslash traversal is normalized to forward-slash and resolves → gated', () => {
+      // new URL() converts '\' to '/' for special (http) schemes, so a backslash
+      // traversal escapes the public prefix at BOTH the gate and the router — the
+      // '\\' in this literal is a single backslash.
+      const p = normalizedRequestPath(req('/api/public/..\\admin'));
+      expect(p).toBe('/api/admin');
+      expect(computeIsPublicPath(p)).toBe(false);
+    });
+
+    it('double-encoding (%252e) does NOT over-resolve — stays literal, no differential', () => {
+      // %25 stays encoded (it is not '.'), so no dot-segment resolution happens: the
+      // path stays under /api/public/ at BOTH gate and router — consistent, no bypass.
+      // (The /api/public/ handler owns any further decoding within its own namespace.)
+      const p = normalizedRequestPath(req('/api/public/%252e%252e/admin'));
+      expect(p).toBe('/api/public/%252e%252e/admin');
+      expect(computeIsPublicPath(p)).toBe(true); // consistently public — reaches no /api/admin
+    });
+  });
+
   describe('fails secure on a malformed URL', () => {
     it('an unparseable URL returns the non-public, unroutable sentinel (never throws)', () => {
       const sentinel = normalizedRequestPath(req('//'));

--- a/taxonomy-editor/src/server/httpKit.ts
+++ b/taxonomy-editor/src/server/httpKit.ts
@@ -118,6 +118,29 @@ export function query(req: IncomingMessage, name: string): string | null {
   return url.searchParams.get(name);
 }
 
+/** t/2019 (js/user-controlled-bypass) — the ONE canonical request-path parse shared
+ *  by the auth gate and the router, so both make their allow/deny + routing decision
+ *  on the *identical* normalized pathname. The gate previously derived its path from
+ *  raw `req.url.split('?')` while the router used `new URL().pathname`: an
+ *  encoded-traversal path (e.g. `/api/public/%2e%2e/admin`) read as a public prefix at
+ *  the gate but resolved elsewhere (`/api/admin`) at the router — an auth bypass.
+ *  Routing both through this helper makes "gate and router agree" structural, not two
+ *  parses that happen to coincide. A malformed URL fails secure. */
+export function normalizedRequestPath(req: IncomingMessage): string {
+  try {
+    return new URL(req.url ?? '/', `http://localhost`).pathname;
+  } catch {
+    // Malformed URL (bad percent-encoding, protocol-relative '//'): fail secure to a
+    // sentinel that is never in the public allowlist and matches no route — the
+    // request is gated, then 404s, and the gate never throws mid-decision. Logged (not
+    // flight-recorder-recorded) so a hostile/garbled path is visible to ops without an
+    // attacker-controlled dump-amplification vector; the raw URL is withheld because a
+    // query string can carry a secret (no-secrets-in-logs rule).
+    log.server.warn({ component: 'httpKit' }, 'normalizedRequestPath: unparseable req.url — failing secure to gated sentinel');
+    return '/__malformed_url__';
+  }
+}
+
 /** Best-effort client IP: first X-Forwarded-For hop (behind the Azure ingress
  *  proxy), else the raw socket address. Used for per-IP rate-limit keys. */
 export function getClientIp(req: IncomingMessage): string {

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -42,7 +42,7 @@ import { getErrorSummaryCached, type ErrorEntry } from './errorAggregation.js';
 import { isCaseStatus } from './support/types.js';
 import * as organizations from './organizations.js';
 import { isPov } from './organizations.js';
-import { json, error, param, query, getClientIp, createRouter, withEndpointTimeout, type Handler } from './httpKit.js';
+import { json, error, param, query, getClientIp, createRouter, withEndpointTimeout, normalizedRequestPath, type Handler } from './httpKit.js';
 import { computeIsPublicPath } from './publicPaths.js';
 import { registerDebatesRoutes } from './routes/debates.js';
 import { registerSyncRoutes } from './routes/sync.js';
@@ -789,7 +789,11 @@ async function handleRequestInner(
   }
 
   // Auth gate — only enforced when authorized-users.json exists
-  const urlPath = req.url?.split('?')[0] || '';
+  // t/2019 (js/user-controlled-bypass): derive the gate path from the SAME normalized
+  // pathname the router matches on (normalizedRequestPath) — not raw
+  // req.url.split('?') — so an encoded-traversal path can't read as a public prefix
+  // here (e.g. /api/public/%2e%2e/admin) while resolving elsewhere at the router.
+  const urlPath = normalizedRequestPath(req);
   // /api/models is public: lets the pre-auth renderer populate the model
   // catalog from ai-models.json. Contains no secrets — just labels + ids.
   // /api/sync/webhook/github is public: GitHub POSTs unauthenticated; the
@@ -952,16 +956,19 @@ async function handleRequestInner(
   const userCtx = { principalName: effectivePrincipal, idp: effectiveIdp, branchName: sessionBranch, storageUserId, isAnonymous: isAnon, anonymousSessionId };
   await runWithUser(userCtx, async () => {
 
-    const url = new URL(req.url!, 'http://localhost');
-    const route = matchRoute(req.method!, url.pathname);
+    // t/2019: same canonical parse as the auth gate above (normalizedRequestPath) —
+    // gate and router decide on the identical normalized path by construction, not two
+    // parses that happen to agree. Named reqPath to not shadow the gate's urlPath.
+    const reqPath = normalizedRequestPath(req);
+    const route = matchRoute(req.method!, reqPath);
 
     // M7: per-IP rate limit on API write methods (100/min) — basic DoS/abuse guard.
-    if (route && (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH' || req.method === 'DELETE') && url.pathname.startsWith('/api/')) {
+    if (route && (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH' || req.method === 'DELETE') && reqPath.startsWith('/api/')) {
       const wr = rateLimiter.checkRate(`write:${getClientIp(req)}`, 100, 60_000);
       if (!wr.allowed) {
         const retryAfter = Math.max(1, Math.ceil((wr.retryAfterMs ?? 60_000) / 1000));
         // t/925: write-rate 429s were silent — log so abuse/DoS spikes are visible.
-        log.server.warn({ component: 'rate-limiter', type: 'write_per_minute', method: req.method, path: url.pathname, retryAfter }, 'API write rate-limited');
+        log.server.warn({ component: 'rate-limiter', type: 'write_per_minute', method: req.method, path: reqPath, retryAfter }, 'API write rate-limited');
         res.setHeader('Retry-After', String(retryAfter));
         json(res, { error: 'rate_limited', message: 'Too many requests', retryAfter }, 429);
         return;
@@ -972,11 +979,11 @@ async function handleRequestInner(
       (res as any).__routePath = route.routePath;
       // t/810: validate user-provided path params at the routing layer (primary
       // gate) before the handler runs. Handlers keep assertSafe* as defense-in-depth.
-      const badParam = invalidRouteParam(route.routePath, url.pathname);
+      const badParam = invalidRouteParam(route.routePath, reqPath);
       if (badParam) {
         getGlobalRecorder()?.record({
           type: 'system.error', component: 'server', level: 'warn',
-          message: `Blocked invalid path parameter '${badParam}': ${req.method} ${url.pathname}`,
+          message: `Blocked invalid path parameter '${badParam}': ${req.method} ${reqPath}`,
         });
         json(res, { error: `Invalid path parameter: ${badParam}`, requestId: getRequestId() }, 400);
         return;
@@ -992,7 +999,7 @@ async function handleRequestInner(
           message: `Unhandled error in ${route.routePath}`,
           error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
         });
-        log.server.error({ err, method: req.method, path: url.pathname, route: route.routePath }, 'Error handling request');
+        log.server.error({ err, method: req.method, path: reqPath, route: route.routePath }, 'Error handling request');
         const status = (err as { statusCode?: number }).statusCode ?? 500;
         // M4: full detail is recorded/logged above; clients get a generic message
         // for server errors in production (the error string can carry file paths).


### PR DESCRIPTION
## t/2019 Category A — auth-gate path normalization (TL pre-merge sign-off)

### The finding (real auth bypass, all 4 open `js/user-controlled-bypass` alerts)
The auth gate derived its path from **raw** `req.url.split('?')` while the router matched on **normalized** `new URL().pathname`. An encoded-traversal path — `/api/public/%2e%2e/admin` — reads as a public `/api/public/` prefix **at the gate** (auth-exempt) but resolves to `/api/admin` **at the router**. Gate says public, router serves admin = bypass.

### The fix (per your 3 conditions)
1. **One shared helper, both call it (structural).** New `normalizedRequestPath(req)` in `httpKit.ts`. The auth gate (`server.ts` ~L796) and the router (~L962) both derive their path from it, so they decide on the identical normalized pathname *by construction* — not two parses that happen to agree. All 6 router `url.pathname` sites now use the helper's `reqPath`.
2. **Fail-secure, tested.** A malformed URL (`//`, bad `%`-encoding) → sentinel `/__malformed_url__` that is never public and matches no route (gated → 404), logged (not FR-recorded, raw URL withheld — query strings can carry secrets) so probes stay visible without a dump/secret vector.
3. **Regression proving the real exploit closed.** `normalizedRequestPath.test.ts`: `/api/public/%2e%2e/admin` → `/api/admin`; the RAW path `computeIsPublicPath('/api/public/%2e%2e/admin') === true` (the pre-fix bug) vs the normalized gate path `=== false` (gated); plus `/.auth/%2e%2e/api/admin`, multi-hop, query-strip, case-preserve, and undefined-url variants.

### Scope note
The WS-upgrade path-match (`server.ts` L1165) and `serveStatic` (L458) already use `new URL().pathname` — no raw-vs-normalized gap there, left untouched to keep A reviewable in isolation. The `handleRequestInner` complexity decomposition (t/1910) is a **separate** Server-Auth-reviewed PR, not bundled here.

### Verify (all green, local)
tsc main + server (0) · eslint `--max-warnings=4256` (0 errors) · depcruise clean · 6 auth suites + new regression = 133 tests pass.

### Open question for you (per your p/87#162)
Target = **normalization clears** the CodeQL alerts. Whether that holds (the value still originates from `req.url`) is what your post-build ruling settles: if CodeQL still flags after this lands green on the branch, a justified dismissal (the normalized allowlist IS the control) is the fallback you rule on. **Do not auto-merge** — CodeQL isn't a required context (t/2025); I'll verify the check-run directly and hand it to you.

Refs t/2019