### PR TITLE
fix(server): close file-system-race TOCTOU in config loaders (t/2019 Cat C)

### DIFF
--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -123,15 +123,23 @@ function auditPath(): string { return path.join(getDataRoot(), 'admin', 'feature
 function loadConfig(): FlagsConfig {
   const p = flagsPath();
   try {
-    const stat = fs.statSync(p);
-    if (_cache && stat.mtimeMs === _cacheMtime) return _cache;
-    const data = JSON.parse(fs.readFileSync(p, 'utf-8')) as Partial<FlagsConfig>;
-    // Seed flags are the baseline — file overrides take precedence, but new
-    // seeds appear automatically without requiring a file rewrite.
-    _cache = { flags: { ...SEED_FLAGS, ...(data.flags ?? {}) } };
-    _cacheMtime = stat.mtimeMs;
-    log.server.debug({ path: p, count: Object.keys(_cache.flags).length }, 'Loaded feature flags');
-    return _cache;
+    // t/2019 (js/file-system-race): fstat + read the SAME fd, not the path twice —
+    // no swap/unlink can slip between the mtime check and the read. openSync throws
+    // ENOENT (no flags file) → the catch below degrades to the committed seed baseline.
+    const fd = fs.openSync(p, 'r');
+    try {
+      const stat = fs.fstatSync(fd);
+      if (_cache && stat.mtimeMs === _cacheMtime) return _cache;
+      const data = JSON.parse(fs.readFileSync(fd, 'utf-8')) as Partial<FlagsConfig>;
+      // Seed flags are the baseline — file overrides take precedence, but new
+      // seeds appear automatically without requiring a file rewrite.
+      _cache = { flags: { ...SEED_FLAGS, ...(data.flags ?? {}) } };
+      _cacheMtime = stat.mtimeMs;
+      log.server.debug({ path: p, count: Object.keys(_cache.flags).length }, 'Loaded feature flags');
+      return _cache;
+    } finally {
+      fs.closeSync(fd);
+    }
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== 'ENOENT') {

--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -448,21 +448,29 @@ function configPath(): string {
 function loadConfig(): RuntimeConfig {
   const p = configPath();
   try {
-    const stat = fs.statSync(p);
-    if (_cache && stat.mtimeMs === _cacheMtime) return _cache;
-    const raw = JSON.parse(fs.readFileSync(p, 'utf-8'));
-    const { config, errors } = validateAndMerge(raw, DEFAULTS);
-    if (errors.length > 0) {
-      log.server.warn({ component: 'runtime-config', path: p, errorCount: errors.length, errors: errors.slice(0, 20) }, 'Runtime config loaded with validation issues');
-      getGlobalRecorder()?.record({
-        type: 'system.error', component: 'runtime-config', level: 'warn',
-        message: `Runtime config loaded with ${errors.length} validation issue(s)`,
-        data: { errors: errors.slice(0, 20) },
-      });
+    // t/2019 (js/file-system-race): stat and read the SAME fd, not the path twice —
+    // fstat(fd)+read(fd) can't race a swap/unlink between a path stat and a path read.
+    // openSync throws ENOENT (no override file) → the catch below degrades to defaults.
+    const fd = fs.openSync(p, 'r');
+    try {
+      const stat = fs.fstatSync(fd);
+      if (_cache && stat.mtimeMs === _cacheMtime) return _cache;
+      const raw = JSON.parse(fs.readFileSync(fd, 'utf-8'));
+      const { config, errors } = validateAndMerge(raw, DEFAULTS);
+      if (errors.length > 0) {
+        log.server.warn({ component: 'runtime-config', path: p, errorCount: errors.length, errors: errors.slice(0, 20) }, 'Runtime config loaded with validation issues');
+        getGlobalRecorder()?.record({
+          type: 'system.error', component: 'runtime-config', level: 'warn',
+          message: `Runtime config loaded with ${errors.length} validation issue(s)`,
+          data: { errors: errors.slice(0, 20) },
+        });
+      }
+      _cache = config;
+      _cacheMtime = stat.mtimeMs;
+      return _cache;
+    } finally {
+      fs.closeSync(fd);
     }
-    _cache = config;
-    _cacheMtime = stat.mtimeMs;
-    return _cache;
   } catch (err) {
     // ENOENT is the common, expected case (no override file → defaults). Anything
     // else (malformed JSON, permissions) is surfaced before degrading to defaults.
@@ -533,10 +541,16 @@ export interface ConfigState {
 export function getConfigState(): ConfigState {
   const p = configPath();
   try {
-    const stat = fs.statSync(p);
-    const raw = JSON.parse(fs.readFileSync(p, 'utf-8'));
-    const { config, errors } = validateAndMerge(raw, DEFAULTS);
-    return { config, defaults: getDefaults(), errors, fileExists: true, lastModified: new Date(stat.mtimeMs).toISOString() };
+    // t/2019 (js/file-system-race): fstat + read one fd, not two path operations.
+    const fd = fs.openSync(p, 'r');
+    try {
+      const stat = fs.fstatSync(fd);
+      const raw = JSON.parse(fs.readFileSync(fd, 'utf-8'));
+      const { config, errors } = validateAndMerge(raw, DEFAULTS);
+      return { config, defaults: getDefaults(), errors, fileExists: true, lastModified: new Date(stat.mtimeMs).toISOString() };
+    } finally {
+      fs.closeSync(fd);
+    }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
       getGlobalRecorder()?.record({


### PR DESCRIPTION
## t/2019 Category C — file-system-race (TOCTOU) ×3

CodeQL `js/file-system-race` high alerts #4923 / #4924 / #5186. Three config loaders stat'd a path then read the **same path** — a time-of-check-to-time-of-use window where the file could be swapped or unlinked between the mtime check and the read.

| Site | Function |
|------|----------|
| `runtimeConfig.ts:453` | `loadConfig` (mtime-cache read) |
| `runtimeConfig.ts:537` | `getConfigState` (un-cached admin read) |
| `featureFlags.ts:128` | `loadConfig` (mtime-cache read) |

### Fix — canonical single-fd pattern
Each: `openSync(p,'r')` → `fstatSync(fd)` → `readFileSync(fd,'utf-8')` → `closeSync(fd)` in `finally`. The stat and the read now target one file descriptor, so no path-level swap/unlink can slip between them. `openSync` throws `ENOENT` on a missing file, caught by the **existing** catch that already degrades to defaults (runtimeConfig) / the committed seed baseline (featureFlags) — behaviour is unchanged for every real case (valid file, missing file, malformed JSON).

### Verify (local, all green)
tsc main + server (0) · eslint (0) · `runtimeConfig.test.ts` + `featureFlags.test.ts` = 47 tests pass (existing behavioral coverage: valid read, ENOENT→defaults, malformed JSON — the exact paths the fd change touches). A race-timing regression test would be inherently flaky; the alert-clearing is the proof, and the fd pattern reliably clears `js/file-system-race` (t/2022/t/2023 precedent).

Self-cert on CodeQL-green per TL p/87#166 (B + C need no sign-off). Refs t/2019