### PR TITLE
fix(security): harden contentSanitizer against control-char-obfuscated schemes/tags (t/2027)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/contentSanitizer.test.ts
+++ b/taxonomy-editor/src/server/__tests__/contentSanitizer.test.ts
@@ -70,3 +70,36 @@ describe('sanitizeUserText — multi-pass bypass resistance (t/2023)', () => {
     expect(sanitizeUserText('a < b > c, and 1<2')).toBe('a < b > c, and 1<2');
   });
 });
+
+// t/2027: control chars that a browser later elides (TAB/CR/LF/NUL, etc.) split a
+// dangerous keyword past a contiguous-literal match. The folded CTRL class must
+// neutralize these — WITHOUT treating a plain space (which browsers do NOT strip
+// mid-scheme) as obfuscation.
+describe('sanitizeUserText — control-char obfuscation hardening (t/2027)', () => {
+  it('neutralizes control-char-split dangerous schemes', () => {
+    expect(sanitizeUserText('java\tscript:alert(1)')).toBe('blocked:alert(1)');
+    expect(sanitizeUserText('java\nscript:alert(1)')).toBe('blocked:alert(1)');
+    expect(sanitizeUserText('java\r\nscript:alert(1)')).toBe('blocked:alert(1)');
+    expect(sanitizeUserText('javascript\0:alert(1)')).toBe('blocked:alert(1)');
+    expect(sanitizeUserText('vb\tscript:msgbox')).toBe('blocked:msgbox');
+    // control char immediately before the colon
+    expect(sanitizeUserText('[x](javascript\t:alert(1))')).toBe('[x](blocked:alert(1))');
+  });
+
+  it('neutralizes control-char-split executable tags', () => {
+    expect(sanitizeUserText('a <scr\0ipt>alert(1)</scr\0ipt> b')).toBe('a alert(1) b');
+    expect(sanitizeUserText('<if\trame src=evil></if\trame>x')).toBe('x');
+  });
+
+  it('neutralizes obfuscated data:text/html', () => {
+    expect(sanitizeUserText('data\0:text/html,<b>')).toBe('data:blocked,<b>');
+    expect(sanitizeUserText('data:te\txt/html,x')).toBe('data:blocked,x');
+  });
+
+  it('does NOT treat a plain space as obfuscation (no false positives)', () => {
+    // U+0020 is not stripped mid-scheme by browsers, so "java script" prose that
+    // can never become a live javascript: URI must survive untouched.
+    expect(sanitizeUserText('the java script tutorial')).toBe('the java script tutorial');
+    expect(sanitizeUserText('read the vb script docs')).toBe('read the vb script docs');
+  });
+});

--- a/taxonomy-editor/src/server/security/contentSanitizer.ts
+++ b/taxonomy-editor/src/server/security/contentSanitizer.ts
@@ -16,9 +16,26 @@
  * comparison operators, or fenced code content structure.
  */
 
-const EXECUTABLE_TAGS = /<\/?(?:script|iframe|object|embed|style)\b[^>]*>/gi;
-const DANGEROUS_SCHEME = /\b(?:javascript|vbscript):/gi;
-const DATA_HTML = /\bdata:text\/html/gi;
+// t/2027 — control-char obfuscation hardening. Attackers split a dangerous
+// keyword with control characters the browser later elides (`java\tscript:`,
+// `javascript\0:`, `<scr\0ipt>`), slipping past a contiguous-literal match. An
+// optional CTRL class folded between every keyword letter neutralizes these;
+// because the whole obfuscated span is replaced, embedded control chars are
+// removed only inside the dangerous match — legit whitespace/newlines elsewhere
+// (markdown, code fences) are untouched. Set = C0 controls + DEL, NOT space:
+// 0x20 isn't stripped mid-scheme by browsers, so folding it would false-positive
+// on legit prose ("the java script docs"). TAB/CR/LF/NUL are the real live
+// vectors; the rest of C0+DEL is conservative, fail-safe over-inclusion. The
+// tag-name fold is likewise conservative (a spec tokenizer ends the tag name at
+// TAB/LF/FF/space rather than eliding it) — over-inclusive removal, still safe.
+const CTRL = '[\\x00-\\x1F\\x7F]*';
+const gap = (word: string): string => word.split('').join(CTRL);
+const EXECUTABLE_TAGS = new RegExp(
+  `</?(?:${['script', 'iframe', 'object', 'embed', 'style'].map(gap).join('|')})\\b[^>]*>`,
+  'gi',
+);
+const DANGEROUS_SCHEME = new RegExp(`\\b(?:${gap('javascript')}|${gap('vbscript')})${CTRL}:`, 'gi');
+const DATA_HTML = new RegExp(`\\b${gap('data')}${CTRL}:${CTRL}${gap('text')}${CTRL}/${CTRL}${gap('html')}`, 'gi');
 
 /**
  * Neutralize executable tags + dangerous URL schemes in a single string.
@@ -42,8 +59,11 @@ const DATA_HTML = /\bdata:text\/html/gi;
  * would let the loop return a possibly-unsanitized string, which is the very
  * defect this query flags).
  *
- * The three regexes are linear-time (single bounded `[^>]*`, fixed alternations,
- * literals) — no nested/overlapping unbounded quantifiers, so no ReDoS.
+ * Per-match linear: the folded `[\x00-\x1F\x7F]*` classes sit between distinct
+ * literals (no `X*X*` adjacency, no nested/overlapping unbounded quantifiers), so
+ * the control-char fold adds no ReDoS. (The tag `[^>]*` tail's O(n) per-position
+ * worst-case scan against pathological no-`>` input is tracked separately in
+ * t/2029 — pre-existing, unrelated to the fold.)
  */
 export function sanitizeUserText(s: string): string {
   let out = s;


### PR DESCRIPTION
## What

Hardens `contentSanitizer.ts` against **control-char-obfuscated** dangerous schemes/tags (t/2027). Folds an optional control-char class `[\x00-\x1F\x7F]` between every keyword letter of the scheme/tag/data matchers, so browser-elided splits are neutralized:

- `java\tscript:` / `java\nscript:` / `javascript\0:` → `blocked:`
- `<scr\0ipt>` / `<if\trame>` → stripped
- `data\0:text/html` → `data:blocked`

The set **excludes space (0x20)** — browsers don't strip it mid-scheme, so folding it would false-positive on legit prose ("the java script docs"). Because the whole obfuscated span is replaced, control chars are removed **only inside the dangerous match**; the existing **t/2023 fixed-point loop** and its termination invariant are preserved unchanged.

## Scope discipline

The security-reviewer pass **verified the fold is ReDoS-free, terminating, and CodeQL-safe**. It also surfaced two **pre-existing** findings (confirmed identical on the un-folded original — not introduced here), tracked **separately** rather than coupled to this ready hardening (per TL):

- **t/2029** (HIGH) — `[^>]*` O(n²) event-loop DoS. Fast-follow, TL-steered toward an input-size cap.
- **t/2030** (MED) — HTML-entity bypass (`javascript&colon;`) + `data:image/svg+xml` coverage.

## Tests

Adds a t/2027 `describe` block to the existing `contentSanitizer.test.ts` (control-char splits, obfuscated tags/data, plain-space false-positive guard). Co-location confirmed with ServerAPI (the test file's owner). **Scoped vitest 13/13, `tsc -p tsconfig.main.json`, and eslint all green.**

## Reviews

- Design + land approved by TL (t/2027#1, t/2027#4).
- Cross-scope test-file placement OK'd by ServerAPI (p/135#18).

Closes t/2027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
