### PR TITLE
docs(server): extend auth-gate accepted-risk rationale to cover #5483 (t/2019)

### DIFF
--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -788,8 +788,9 @@ async function handleRequestInner(
   // here (e.g. /api/public/%2e%2e/admin) while resolving elsewhere at the router.
   const urlPath = normalizedRequestPath(req);
   // ACCEPTED RISK — CodeQL js/user-controlled-bypass on the urlPath-guarded auth
-  // branches below (alerts #4068/#5345/#4847/#4851, dismissed won't-fix; t/2019,
-  // t/2001#5, TL-approved p/87#164/#168): path-based auth inherently branches on a
+  // branches below AND on the top-level gate `if (!isPublicPath && !authDisabled)`
+  // (alerts #4068/#5345/#4847/#4851/#5483, dismissed won't-fix; t/2019,
+  // t/2001#5, TL-approved p/87#164/#168/#172): path-based auth inherently branches on a
   // user-controlled request path, so the query fires by design and cannot be removed
   // without removing path-based auth. The exploitable parser-differential IS closed —
   // this gate and the router both decide on ONE canonical normalized path


### PR DESCRIPTION
## t/2019 — co-located rationale, extended to #5483 (TL condition p/87#172)

Comment-only. The accepted-risk block at `server.ts:790` listed the 4 original dismissed `js/user-controlled-bypass` alerts; this extends it to also name **#5483** and the top-level gate `if (!isPublicPath && !authDisabled)`, so the co-located t/2001#5 rationale covers all 5.

**#5483 is not a new bug** — it's the same inherent accepted-risk pattern (path-based auth branches on a user-controlled normalized path), re-minted by CodeQL at a new taint node because the A fix routed `urlPath` through `normalizedRequestPath`. TL-confirmed (p/87#172); the gate + normalized parse are sound.

No code change. Verify: eslint 0 errors. Self-cert /trivial-change (comment-only, no behavioral change). Refs t/2019