### PR TITLE
fix(security): mkdtempSync for conflict-cluster temp files (CodeQL insecure-temp-file) [t/2001]

### DIFF
--- a/scripts/compute-conflict-clusters.mjs
+++ b/scripts/compute-conflict-clusters.mjs
@@ -56,10 +56,14 @@ function loadConflicts() {
 // ── Compute embeddings + clustering in Python ───────────────────
 
 function embedAndCluster(texts, ids, maxClusters) {
-  const tmpDir = os.tmpdir();
-  const inputFile = path.join(tmpDir, 'conflict-cluster-input.json');
-  const outputFile = path.join(tmpDir, 'conflict-cluster-output.json');
-  const scriptFile = path.join(tmpDir, 'conflict-cluster.py');
+  // Create a private, randomly-named temp dir (0700) rather than writing
+  // predictable filenames into the shared os.tmpdir() — the latter lets another
+  // local user pre-create/symlink these paths and hijack what Python executes
+  // (CodeQL js/insecure-temporary-file). mkdtempSync gives an unguessable dir.
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'conflict-cluster-'));
+  const inputFile = path.join(tmpDir, 'input.json');
+  const outputFile = path.join(tmpDir, 'output.json');
+  const scriptFile = path.join(tmpDir, 'cluster.py');
 
   fs.writeFileSync(inputFile, JSON.stringify({ texts, ids, max_clusters: maxClusters }));
   fs.writeFileSync(scriptFile, `
@@ -133,10 +137,8 @@ print("Done.")
 
   const result = JSON.parse(fs.readFileSync(outputFile, 'utf-8'));
 
-  // Cleanup
-  try { fs.unlinkSync(inputFile); } catch { /* ignore */ }
-  try { fs.unlinkSync(outputFile); } catch { /* ignore */ }
-  try { fs.unlinkSync(scriptFile); } catch { /* ignore */ }
+  // Cleanup — remove the private temp dir and everything in it.
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
 
   return result;
 }


### PR DESCRIPTION
## t/2001 Wave-3 residual — 2 CodeQL highs `js/insecure-temporary-file` (alerts 4044, 4045)

`scripts/compute-conflict-clusters.mjs` wrote predictable filenames into the shared `os.tmpdir()` — an input JSON, an output JSON, and an **executable `cluster.py`**. A local attacker can pre-create or symlink those paths and hijack the file Python runs. Real issue → **fix**, not dismiss.

### Change (10/-8, one file)
- `const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'conflict-cluster-'))` — a private, unguessable `0700` dir per run; the three files now live inside it.
- Cleanup replaced 3 `unlinkSync` calls with a single recursive `fs.rmSync(tmpDir, …)`.
- No behavior change to clustering output. `node --check` clean.

CodeQL is a non-required check, so I'll confirm alerts 4044/4045 flip to `fixed` on the **main** scan after merge (not a PR check) and report back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)