### PR TITLE
docs(flight-recorder): co-located FP rationale for CodeQL alert 4621 (t/2001)

### DIFF
--- a/lib/flight-recorder/flightRecorder.ts
+++ b/lib/flight-recorder/flightRecorder.ts
@@ -155,6 +155,13 @@ export class FlightRecorder {
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
     const { ndjson } = this.buildDump('explicit');
+    // CodeQL js/insecure-temporary-file (alert 4621) is a FALSE POSITIVE here.
+    // resolvedPath is either caller-supplied or lives INSIDE the mode-0700,
+    // random-suffix directory that resolveDumpDir() creates via mkdtempSync — a
+    // path an attacker can't predict, enter, or pre-create/symlink a target in.
+    // CodeQL flags the os.tmpdir()→writeFileSync flow without modelling
+    // mkdtempSync as the sanitizer it is (mitigation landed in t/2014). Dismissed
+    // false-positive on the main scan (t/2001 Wave-3, alert 4621).
     fs.writeFileSync(resolvedPath, ndjson, 'utf-8');
 
     const ctx = this.contextProvider();


### PR DESCRIPTION
**t/2001 Wave-3 residual** (TL p/30#109). Resolves the lone open CodeQL high `js/insecure-temporary-file` at `lib/flight-recorder/flightRecorder.ts:158` (alert 4621).

## Verdict: false positive
The alert's scanned commit (`3812f9e5`, 2026-06-07) **already contained** the mitigation. `resolveDumpDir()` creates the temp fallback via `fs.mkdtempSync(path.join(os.tmpdir(), 'flight-recorder-'))` — a **mode-0700, random-suffix private directory**. The dump file is written *inside* that dir (or into a caller/operator-supplied path). An attacker can't predict, enter, or pre-create/symlink a target in a 0700 mkdtemp dir, so there is no insecure-temp-file exposure. CodeQL flags the `os.tmpdir()`→`writeFileSync` taint flow without modelling `mkdtempSync` as the sanitizer it is (the mitigation landed in t/2014).

## Change
Comment-only: a co-located FP rationale at the `writeFileSync` site (per the t/2001#5 accepted-risk/FP convention). Alert 4621 is being **dismissed false-positive on the main scan** (not a PR check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)