### PR TITLE
ci(codeql): test/archive paths-ignore config + interim CodeQL self-merge discipline (t/2025)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+# CodeQL configuration (t/2025).
+#
+# paths-ignore: exclude test/archive from the SCAN — these are not production attack
+# surface, and CodeQL flags test-fixture patterns (insecure-temporary-file,
+# incomplete-url-sanitization, shell-injection-from-environment, ...) in
+# *.test.ts / __tests__ that are pure noise — the fleet was scattering per-line
+# `// codeql[...]` suppressions across every scope's tests. One place removes ~24+
+# alerts fleet-wide and stops the per-line scatter.
+#
+# IMPORTANT (differential-gate interaction, t/2025): this excludes paths from the
+# SCAN — it does NOT weaken the differential PR check on PRODUCTION paths. Excluded
+# paths simply produce no alerts; a NEW alert introduced in production code still
+# fails the `CodeQL Analysis` check once it is a required differential gate.
+name: "AI Triad Research CodeQL config"
+
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  - '**/*.test.ts'
+  - '**/*.test.tsx'
+  - '**/__tests__/**'
+  - '**/archive/**'
+  - '**/*_annotation_tool.html'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,8 +45,9 @@ jobs:
         uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4
         with:
           languages: javascript-typescript
-          # Security-extended covers OWASP Top 10 + additional patterns
-          queries: security-extended
+          # queries (security-extended) + the test/archive paths-ignore live in the
+          # config file so the scan scope is in one place (t/2025).
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38  # v4

--- a/docs/git-and-session-workflow.md
+++ b/docs/git-and-session-workflow.md
@@ -62,6 +62,8 @@ A ticket is **not Done** until all of the following are true:
 
 **Anti-pattern (from t/1221 audit):** Agent writes code → tests pass locally → marks ticket Done → never commits. The ticket looks shipped but the code exists only in one agent's working tree. If you cannot commit (e.g., blocked on a cross-scope dependency), mark the ticket as **blocked**, not Done.
 
+**CodeQL is a separate check — confirm it before self-merge (interim, t/2025):** `ci-gate` green + `gh pr checks` exit 0 does NOT mean CodeQL passed — `CodeQL Analysis` is a separate, currently-non-required check-run. Before self-merging, confirm the `CodeQL Analysis` check-run is green (not just `ci-gate`); for a **security-fix** PR, confirm the target alert is addressed AND the fix introduced no new high (a fix can add one and `gh pr checks --watch` still exits 0 — t/2023 #5460). This procedural stopgap is replaced by t/2025's structural required-differential CodeQL gate.
+
 ### Deviation Flagging Rule (owner-approved 2026-07-06)
 
 When an implementation deviates from a TL-approved design or an explicit review condition — different boundaries, substituted evidence, skipped verification named in an AC — state the deviation in your completion comment: "asked X, did Y, because Z." Unflagged deviations are treated as review failures even when the change is an improvement: a reviewer who must *detect* deviations pays more than the deviation saved. For contested or multi-deviation tickets, close with a deviation-ledger table (the t/1300#10 format).


### PR DESCRIPTION
ci(codeql): test/archive paths-ignore config + interim self-merge CodeQL-check discipline (t/2025)

Part of closing the CodeQL self-merge gap (t/2025): ci-gate green != CodeQL green, so
a PR can self-merge with CodeQL red/pending — it already bit (t/2023 #5460: a new high
in a security fix, gh pr checks --watch exited 0 because CodeQL isn't a required check).

- .github/codeql/codeql-config.yml (new): paths-ignore for test/archive
  (**/*.test.ts(x), **/__tests__/**, **/archive/**, **/*_annotation_tool.html) —
  removes ~24+ test-fixture alerts + stops the per-line codeql[...] suppression scatter
  across every scope's tests (t/2025#1). Excludes from the SCAN only — does NOT weaken
  the differential check on production paths.
- codeql.yml: reference the config file (queries moved into it).
- docs/git-and-session-workflow.md + the /land-from-worktree skill: interim discipline
  — confirm the CodeQL Analysis check-run before self-merge, not just ci-gate; for
  security fixes confirm no new high.

Durable structural fix (CodeQL as a REQUIRED differential check) is the next phase:
gate-verify 3 cases -> owner-gated branch-protection flip (ping TL first) + re-trigger
open PRs. NB flagged: the codeql.yml PR path-filter (**.ts/.tsx/.js/.jsx) means a
required CodeQL would strand non-TS PRs — a design point for the flip.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Technical Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
