### PR TITLE
ci(codeql): run CodeQL on every PR (drop PR path filter) so the differential check always reports (t/2025)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,9 @@
 # ─── CodeQL SAST ───
 # What:  Static application security testing for TypeScript/JavaScript using
 #        GitHub CodeQL with security-extended queries (OWASP Top 10 coverage).
-# Before: Triggers on push/PR to main for TS/JS files, plus weekly Monday scan.
-#         No manual setup needed.
+# Before: Triggers on TS/JS pushes to main, on EVERY pull_request to main (no
+#         path filter, so the differential check-run always reports — t/2025),
+#         plus weekly Monday scan. No manual setup needed.
 # After:  SARIF results appear in the GitHub Security tab. Review any new alerts
 #         and fix high-severity findings before merging.
 
@@ -17,12 +18,11 @@ on:
       - '**.js'
       - '**.jsx'
   pull_request:
+    # No path filter on PRs (t/2025): CodeQL must run on EVERY PR so the
+    # differential code-scanning check-run always reports. Once that check is a
+    # REQUIRED status context, a path-filtered PR that never triggered CodeQL
+    # would strand — the required check would sit pending forever (t/1962 genus).
     branches: [main]
-    paths:
-      - '**.ts'
-      - '**.tsx'
-      - '**.js'
-      - '**.jsx'
   schedule:
     # Weekly scan — catches new CVE patterns even without code changes
     - cron: '0 6 * * 1'


### PR DESCRIPTION
ci(codeql): run CodeQL on every PR (drop pull_request path filter) so the differential check always reports (t/2025)

Prereq for making the differential code-scanning check-run a REQUIRED status
context (fork (a), TL-approved p/28#143). With the PR path filter in place a PR
touching only non-TS files never triggers CodeQL, so a required check would sit
pending forever and strand the PR (t/1962 genus). Dropping the pull_request path
filter makes CodeQL run on every PR — always reporting — so the gate never
strands. Push filter kept (docs pushes don't change the alert set; saves runs);
weekly cron unchanged.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Technical Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
