### PR TITLE
fix(main): record flight-recorder retention-cleanup failures instead of silent-swallow (t/2026)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/flightRecorderDump.test.ts
+++ b/taxonomy-editor/src/main/__tests__/flightRecorderDump.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * t/2026: the `dump-flight-recorder` retention cleanup previously swallowed failures with a
+ * "telemetry — silent by design" comment, but it isn't telemetry — a failed prune (old dumps
+ * not reclaimed) is a real operational fact. It now records a warn-level event and still
+ * returns the dump path (cleanup failure must not fail the write). Drives the real handler by
+ * mocking `electron` (capture the handler; app.getPath → a temp dir) and forcing the retention
+ * `readdirSync` to throw.
+ */
+const H = vi.hoisted(() => {
+  const base = process.env.TEMP || process.env.TMPDIR || '/tmp';
+  return {
+    handlers: new Map<string, (...a: unknown[]) => unknown>(),
+    root: `${base}/frd-${process.pid}-${Date.now()}`,
+    events: [] as Record<string, unknown>[],
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (ch: string, fn: (...a: unknown[]) => unknown) => { H.handlers.set(ch, fn); },
+    on: () => {}, once: () => {}, removeListener: () => {},
+  },
+  app: { getPath: (name: string) => path.join(H.root, name) },
+  shell: { openPath: () => Promise.resolve('') },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+vi.mock('../fileIO.js', () => ({ PROJECT_ROOT: H.root }));
+
+import { registerFlightRecorderHandlers } from '../ipc/flightRecorderHandlers.js';
+import { setGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+
+function invoke(channel: string, ...args: unknown[]): unknown {
+  const fn = H.handlers.get(channel);
+  if (!fn) throw new Error(`${channel} not registered`);
+  return fn({}, ...args);
+}
+
+beforeEach(() => {
+  H.handlers.clear();
+  H.events.length = 0;
+  fs.rmSync(H.root, { recursive: true, force: true });
+  setGlobalRecorder({ record: (e: Record<string, unknown>) => { H.events.push(e); } } as never);
+  registerFlightRecorderHandlers();
+});
+afterEach(() => {
+  setGlobalRecorder(null as never);
+  fs.rmSync(H.root, { recursive: true, force: true });
+});
+
+describe('dump-flight-recorder retention-cleanup failure recording (t/2026)', () => {
+  it('records a warn event when retention cleanup throws, and still returns the dump path', () => {
+    // Force the retention pass to fail (readdirSync is the first fs call inside its try).
+    const spy = vi.spyOn(fs, 'readdirSync').mockImplementation(() => { throw new Error('readdir boom'); });
+    try {
+      const result = invoke('dump-flight-recorder', '{"t":"debate.turn"}\n') as { filePath: string; filename: string };
+
+      // The dump write succeeded despite the cleanup failure (best-effort, non-fatal).
+      expect(result.filename).toMatch(/^flight-recorder-.*\.jsonl$/);
+      expect(fs.existsSync(result.filePath)).toBe(true);
+
+      // …and the failure was recorded at warn level, not swallowed silently.
+      const rec = H.events.find(e => e.component === 'ipc-flight-recorder');
+      expect(rec).toBeDefined();
+      expect(rec?.level).toBe('warn');
+      expect(rec?.message).toContain('retention cleanup failed');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/taxonomy-editor/src/main/ipc/flightRecorderHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/flightRecorderHandlers.ts
@@ -86,7 +86,19 @@ export function registerFlightRecorderHandlers(): void {
         fs.unlinkSync(remaining[i].path);
         totalSize -= remaining[i].size;
       }
-    } catch { /* telemetry — silent by design;  retention cleanup is best-effort */ }
+    } catch (err) {
+      // Retention pruning is best-effort — its failure does NOT fail the dump write — but a
+      // failed prune is a real operational fact (old dumps not reclaimed, disk budget can creep),
+      // so record it at warn level rather than swallowing it silently (t/2026). This isn't
+      // telemetry, so it doesn't qualify for the silent-by-design exception.
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'ipc-flight-recorder',
+        level: 'warn',
+        message: 'Flight-recorder dump retention cleanup failed — old dumps may not be pruned',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+    }
 
     const filename = path.basename(filePath);
     console.log(`[flight-recorder] Dump written: ${filePath}`);


### PR DESCRIPTION
The `dump-flight-recorder` retention cleanup swallowed failures with a "telemetry — silent by design" comment, but it isn't telemetry — a failed prune (old dumps not reclaimed) is a real operational fact. Now records a warn-level flight-recorder event and still returns the dump path (cleanup failure stays non-fatal). Also makes the catch genuinely ADR-003-compliant (a real `record()`) rather than borrowing the silent-by-design phrase. Follow-up from the t/2022 security-reviewer note. Test: `flightRecorderDump.test.ts` forces the retention readdirSync to throw and asserts a warn record fires + the dump path is still returned. tsc-main + eslint clean. Self-cert /trivial-change.