### PR TITLE
[gate-verify] DOCS only (t/2025, do not merge)

### DIFF
--- a/codeql-gate-docs.md
+++ b/codeql-gate-docs.md
@@ -1,0 +1,5 @@
+# t/2025 CodeQL gate-verify — DOCS-ONLY case (throwaway, DO NOT MERGE, auto-deleted)
+
+This PR touches only Markdown. CodeQL's path filter (`**.ts/.tsx/.js/.jsx`) means the
+scan never triggers. Purpose: observe whether the evaluate-mode `code_scanning` rule
+strands a no-run PR (blocks, waiting for results forever) or passes/skips it.


### PR DESCRIPTION
Throwaway t/2025 CodeQL gate-verify — no-strand case (CodeQL should now RUN + pass on a docs-only PR). DO NOT MERGE.