### PR TITLE
fix(security): cap aggregate sanitize work with a walk-scoped budget (t/2031)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/communityFaults.test.ts
+++ b/taxonomy-editor/src/server/__tests__/communityFaults.test.ts
@@ -60,7 +60,13 @@ vi.mock('../security/userContext.js', () => ({
   getStorageUserId: () => currentUser,
   isAnonymousUser: () => false,
 }));
-vi.mock('../security/contentSanitizer.js', () => ({ sanitizeUserText: (s: unknown) => s }));
+vi.mock('../security/contentSanitizer.js', () => ({
+  sanitizeUserText: (s: unknown) => s,
+  // t/2031: community.ts now wraps its sanitize walk in withSanitizeBudget; the
+  // mock must expose it. Faithful stub — just runs the fn (the real one seeds an
+  // ALS budget, irrelevant to these GitHub-API fault assertions).
+  withSanitizeBudget: <T>(fn: () => T): T => fn(),
+}));
 vi.mock('../config.js', () => ({ resolveDataPath: (p: string) => p }));
 vi.mock('../runtimeConfig.js', () => ({
   getConfig: () => ({ community: { maxPendingPerUser: 20, globalPendingCap: 500 } }),

--- a/taxonomy-editor/src/server/__tests__/contentSanitizer.test.ts
+++ b/taxonomy-editor/src/server/__tests__/contentSanitizer.test.ts
@@ -4,8 +4,12 @@
  * t/856 — conservative server-side content sanitization (XSS defense-in-depth).
  */
 
+import { performance } from 'perf_hooks';
 import { describe, it, expect, vi } from 'vitest';
-import { sanitizeUserText, sanitizeDeep, MAX_SANITIZE_INPUT } from '../security/contentSanitizer.js';
+import {
+  sanitizeUserText, sanitizeDeep, MAX_SANITIZE_INPUT,
+  withSanitizeBudget, SANITIZE_WALL_BUDGET_MS,
+} from '../security/contentSanitizer.js';
 import { log } from '../logger.js';
 
 describe('sanitizeUserText (t/856)', () => {
@@ -314,5 +318,106 @@ describe('sanitizeUserText — entity/numeric-ref canonicalization (t/2030)', ()
     const started = performance.now();
     sanitizeUserText('data:' + 'a'.repeat(20000)); // type run with no closing `/subtype`
     expect(performance.now() - started).toBeLessThan(500);
+  });
+});
+
+// t/2031: sanitizeUserText is per-call capped (t/2029), but a walk over MANY fields
+// (community.ts stripSensitiveKeys / sanitizeDeep) had no field-count cap → a crafted
+// multi-field body could block the event loop for minutes. A walk-scoped wall-time
+// budget (withSanitizeBudget) bounds the TOTAL work; past the deadline, remaining
+// fields drop to '' (fail-safe). Design t/2031#1, TL sign-off e/53#2, re-entrancy
+// condition e/53#2 (Q1), Server Community wrap sign-off e/53#3.
+describe('sanitize aggregate wall-time budget (t/2031)', () => {
+  // Pathological field: `<script`-repeat with NO `>`, sized JUST UNDER the 32 KiB cap
+  // (so it does NOT also trip the t/2029 truncation warn). The tag regex can't match
+  // (needs a literal `>`), so it sanitizes to a NON-EMPTY kept prefix at ~70 ms/field
+  // — non-empty is what distinguishes a PROCESSED field from one DROPPED to '' by the
+  // budget. 4600 × 7 = 32 200 chars < MAX_SANITIZE_INPUT (32 768).
+  const pathologicalField = (): string => '<script'.repeat(4600);
+
+  it('bounds total time for a many-pathological-field payload (AC: bounded, cap engages)', () => {
+    // 200 fields × ~70 ms ≈ ~14 s UNCAPPED; the 2 s wall budget caps it. Budget is
+    // wall-time, so the bound holds regardless of CI speed (slower CI just processes
+    // fewer fields before the deadline).
+    const payload: Record<string, string> = {};
+    for (let i = 0; i < 200; i++) payload[`f${i}`] = pathologicalField();
+    const warn = vi.spyOn(log.security, 'warn').mockImplementation((() => undefined) as never);
+    try {
+      const started = performance.now();
+      const out = sanitizeDeep(payload) as Record<string, string>;
+      const elapsed = performance.now() - started;
+      expect(elapsed).toBeLessThan(4000); // ≪ the ~14 s uncapped cost
+      const values = Object.values(out);
+      expect(values.some((v) => v === '')).toBe(true);   // cap engaged → tail fields dropped
+      expect(values.some((v) => v !== '')).toBe(true);   // early fields still processed
+      // Budget exhaustion logs exactly ONCE per walk (filter by message so an
+      // unrelated warn source could never mask a regression here).
+      const budgetWarns = warn.mock.calls.filter((c) => String(c[1]).includes('budget exhausted'));
+      expect(budgetWarns).toHaveLength(1);
+    } finally { warn.mockRestore(); }
+  });
+
+  it('does NOT truncate a large legit multi-field payload (AC: no regression)', () => {
+    // 400 legit fields, ~2 KB each (~800 KB aggregate). Legit text sanitizes in ~ms,
+    // so the walk never approaches the 2 s budget → every field is preserved verbatim.
+    const payload: Record<string, string> = {};
+    for (let i = 0; i < 400; i++) payload[`f${i}`] = `Legit comment #${i}: a < b && c > d, see [ref](https://x.test). `.repeat(30);
+    const warn = vi.spyOn(log.security, 'warn').mockImplementation((() => undefined) as never);
+    try {
+      const out = sanitizeDeep(payload) as Record<string, string>;
+      for (const [k, v] of Object.entries(payload)) expect(out[k]).toBe(v); // byte-for-byte
+      expect(warn).not.toHaveBeenCalled(); // budget never fired
+    } finally { warn.mockRestore(); }
+  });
+
+  it('re-entrancy: an outer wrap (community-style) composes with sanitizeDeep\'s self-wrap — ONE shared budget', () => {
+    // Server Community's coverage claim (e/53#3) rests on this: community.ts wraps
+    // stripSensitiveKeys, and any nested sanitizeDeep must NOT reseed a fresh budget.
+    // Drive the clock deterministically to prove the nested walk sees the OUTER,
+    // already-exhausted deadline (if it reseeded, its fresh deadline would be in the
+    // future and the fields would survive).
+    let t = 1000;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => t);
+    const warn = vi.spyOn(log.security, 'warn').mockImplementation((() => undefined) as never);
+    try {
+      withSanitizeBudget(() => {
+        // outer budget seeded at t=1000 → deadline = 1000 + SANITIZE_WALL_BUDGET_MS
+        expect(sanitizeUserText('hi javascript:x')).toBe('hi blocked:x'); // within budget
+        t = 1000 + SANITIZE_WALL_BUDGET_MS + 1; // jump PAST the outer deadline
+        // nested sanitizeDeep self-wraps; re-entrant guard → shares the outer (spent)
+        // budget → drops to '' rather than reseeding a fresh 2 s window.
+        expect(sanitizeDeep({ a: 'hello', b: { c: 'world' } })).toEqual({ a: '', b: { c: '' } });
+      });
+    } finally { nowSpy.mockRestore(); warn.mockRestore(); }
+  });
+
+  it('applies no budget OUTSIDE a withSanitizeBudget walk (bare callers unchanged)', () => {
+    // sanitizeUserText called with no active walk never drops, even if the clock has
+    // advanced far — the cap only exists within a walk (single-field callers like
+    // admin.ts are unaffected).
+    let t = 0;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => t);
+    try {
+      t = 10 * SANITIZE_WALL_BUDGET_MS; // way past any budget, but none is active
+      expect(sanitizeUserText('plain text with javascript:x')).toBe('plain text with blocked:x');
+    } finally { nowSpy.mockRestore(); }
+  });
+
+  it('withSanitizeBudget returns the fn result and is re-entrant (nested call does not reseed)', () => {
+    expect(withSanitizeBudget(() => 42)).toBe(42);
+    let t = 0;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => t);
+    try {
+      const seededDeadlines: number[] = [];
+      withSanitizeBudget(() => {
+        // Nested withSanitizeBudget must run inline under the SAME budget (no reseed):
+        // advancing the clock past the OUTER deadline drops fields even for work
+        // started via a nested wrap.
+        t = SANITIZE_WALL_BUDGET_MS + 1;
+        const inner = withSanitizeBudget(() => sanitizeUserText('x'));
+        seededDeadlines.push(inner.length);
+      });
+      expect(seededDeadlines).toEqual([0]); // dropped to '' → nested shared the spent budget
+    } finally { nowSpy.mockRestore(); }
   });
 });

--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -5,7 +5,7 @@ import crypto from 'crypto';
 import { resolveDataPath } from '../config.js';
 import { getUserContentBackend, assertSafeId } from '../storage/fileIO.js';
 import type { StorageBackend } from '../storage/storageBackend.js';
-import { sanitizeUserText } from '../security/contentSanitizer.js';
+import { sanitizeUserText, withSanitizeBudget } from '../security/contentSanitizer.js';
 import { getStorageUserId, isAnonymousUser } from '../security/userContext.js';
 import { log } from '../logger.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
@@ -330,7 +330,14 @@ function stripOriginalId(meta: unknown): unknown {
 }
 
 function sanitizeForCommunity(data: unknown, submittedBy: string): unknown {
-  const d = stripSensitiveKeys(JSON.parse(JSON.stringify(data))) as Record<string, unknown>;
+  // t/2031: bound the ENTIRE recursive strip/sanitize walk under one wall-time
+  // budget so a many-field crafted submission can't amplify per-field sanitize cost
+  // into a multi-minute event-loop block (Server Community sign-off e/53#3; the
+  // budget is re-entrant-safe, so any nested sanitizeDeep composes rather than
+  // reseeding). Behavior-preserving: legit submissions finish in ~ms, far under budget.
+  const d = withSanitizeBudget(
+    () => stripSensitiveKeys(JSON.parse(JSON.stringify(data))),
+  ) as Record<string, unknown>;
   d.community_metadata = {
     submitted_by_display: submittedBy,
     submitted_at: new Date().toISOString(),

--- a/taxonomy-editor/src/server/security/contentSanitizer.ts
+++ b/taxonomy-editor/src/server/security/contentSanitizer.ts
@@ -24,10 +24,62 @@
  * sanitizeUserText). Design: t/2030#1, TL sign-off e/52#2.
  */
 
+import { AsyncLocalStorage } from 'async_hooks';
+import { performance } from 'perf_hooks';
 import { decodeNamedCharacterReference } from 'decode-named-character-reference';
 import { decodeNumericCharacterReference } from 'micromark-util-decode-numeric-character-reference';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { log } from '../logger.js';
+
+// t/2031 — aggregate sanitize-work budget (multi-field DoS amplification).
+// sanitizeUserText is per-CALL capped (t/2029, ~150 ms worst at 32 KiB), but a walk
+// that sanitizes many fields — community.ts `stripSensitiveKeys`, `sanitizeDeep` —
+// had no cap on field COUNT: ~1,600 crafted 32 KiB fields ≈ ~240 s of synchronous
+// event-loop block in one request. `withEndpointTimeout` can't preempt it (a
+// setTimeout only fires once the CPU-bound loop yields).
+//
+// Fix: a WALK-SCOPED wall-time budget. `withSanitizeBudget(fn)` seeds a deadline in
+// AsyncLocalStorage for the (synchronous) walk; once past it, `sanitizeUserText`
+// drops remaining fields to '' — fail-safe: never stores unsanitized content —
+// bounding total STRING-SANITIZE work (the O(n²)-prone part this targets) to
+// ~SANITIZE_WALL_BUDGET_MS regardless of field count/size. (The budget is checked at
+// string-leaf entry, so pure-structural object/array traversal with no string leaves
+// is not clipped by it — but that is O(field-count), already bounded by the request
+// body-size limit to low-single-digit seconds, not the O(n²) blow-up this addresses.)
+//
+// TIME, not bytes (TL e/53#2): legit content is cheap (~1 ms even at 32 KiB — the
+// O(n²) fold cost only fires on crafted `<script`-repeat / deep-entity fields), so a
+// byte cap tight enough to bound the attack would truncate legit large submissions;
+// a wall-time budget can't be reached by legit content yet bounds any crafted
+// distribution. ACCEPTED PROPERTY (TL e/53#2): output is therefore timing-dependent —
+// the identical submission could truncate under extreme concurrent load. Acceptable
+// because it is always FAIL-SAFE (truncated → '' → nothing unsanitized stored) and,
+// since legit content finishes in ~ms, only ever bites crafted payloads in practice.
+//
+// 2000 ms sits far below every applicable request timeout — the community promote
+// path (the live caller) has no `withEndpointTimeout`; the server sets no
+// `requestTimeout` (Node default ~300 s); other endpoints' `withEndpointTimeout` is
+// 35–50 s — so the budget always truncates BEFORE any endpoint timeout fires (TL
+// condition, e/53#2).
+export const SANITIZE_WALL_BUDGET_MS = 2000;
+
+interface SanitizeBudget { deadline: number; loggedTruncation: boolean; }
+const budgetAls = new AsyncLocalStorage<SanitizeBudget>();
+
+/**
+ * Run `fn` under a walk-scoped sanitize wall-time budget shared by every
+ * `sanitizeUserText` call inside it. Returns `fn`'s result (walks are synchronous).
+ *
+ * RE-ENTRANT-SAFE (TL Q1, load-bearing, e/53#2): if a budget is already active, run
+ * under the EXISTING one — never seed a fresh deadline. This is what lets
+ * `sanitizeDeep`'s self-wrap compose inside an outer caller wrap (community.ts's
+ * `withSanitizeBudget(() => stripSensitiveKeys(...))`) without resetting the
+ * aggregate cap mid-walk — which would reopen the DoS.
+ */
+export function withSanitizeBudget<T>(fn: () => T): T {
+  if (budgetAls.getStore()) return fn(); // already budgeted — compose, don't reseed
+  return budgetAls.run({ deadline: performance.now() + SANITIZE_WALL_BUDGET_MS, loggedTruncation: false }, fn);
+}
 
 // t/2029 — input-size cap (DoS backstop). The tag `[^>]*` tail scans O(n) per
 // starting position, so pathological input (`<script` repeated with no closing
@@ -220,6 +272,24 @@ function neutralize(s: string): string {
  * matches from the shadow back into the original. Design: t/2030#1, TL e/52#2.
  */
 export function sanitizeUserText(s: string): string {
+  // t/2031 aggregate budget: once the walk-scoped wall-time budget is spent, drop
+  // remaining fields to '' (fail-safe — never store unsanitized content). Checked at
+  // field ENTRY, so the field that overran runs to completion and only SUBSEQUENT
+  // fields are dropped (total overrun ≤ budget + one field's worst ~150 ms). No-op
+  // outside a withSanitizeBudget walk (single-field callers, tests) → unchanged.
+  const budget = budgetAls.getStore();
+  if (budget && performance.now() > budget.deadline) {
+    if (!budget.loggedTruncation) {
+      budget.loggedTruncation = true; // once per walk — no content (secrets rule)
+      try {
+        log.security.warn(
+          { budgetMs: SANITIZE_WALL_BUDGET_MS },
+          'sanitizeUserText: walk sanitize budget exhausted — remaining fields dropped',
+        );
+      } catch { /* telemetry — silent by design: logging must never break sanitization */ }
+    }
+    return '';
+  }
   let base = s;
   // t/2029 DoS backstop: truncate oversized input BEFORE the O(n²)-prone loops
   // (and before entity decode, so decode is length-bounded too).
@@ -239,13 +309,25 @@ export function sanitizeUserText(s: string): string {
   return cleaned === decoded ? base : cleaned;
 }
 
-/** Recursively sanitize every string in a JSON-like value (arrays/objects). */
+/**
+ * Recursively sanitize every string in a JSON-like value (arrays/objects).
+ *
+ * t/2031: the whole walk runs under ONE shared sanitize budget via the self-wrap
+ * below, so a deeply-nested / many-field value can't amplify per-field cost without
+ * bound. The re-entrant guard in withSanitizeBudget means a caller that already
+ * established a budget (community.ts's stripSensitiveKeys wrap) keeps its budget
+ * across a nested sanitizeDeep — the two compose instead of reseeding.
+ */
 export function sanitizeDeep<T>(value: T): T {
+  return withSanitizeBudget(() => sanitizeDeepInner(value));
+}
+
+function sanitizeDeepInner<T>(value: T): T {
   if (typeof value === 'string') return sanitizeUserText(value) as unknown as T;
-  if (Array.isArray(value)) return value.map(sanitizeDeep) as unknown as T;
+  if (Array.isArray(value)) return value.map(sanitizeDeepInner) as unknown as T;
   if (value && typeof value === 'object') {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = sanitizeDeep(v);
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = sanitizeDeepInner(v);
     return out as unknown as T;
   }
   return value;


### PR DESCRIPTION
## Summary
Closes the multi-field **DoS amplification** in the content sanitizer (t/2031, follow-up to t/2029). `sanitizeUserText` is per-call capped, but a walk over many fields (`community.ts::stripSensitiveKeys`, `sanitizeDeep`) had no field-count cap → ~1,600 crafted 32 KiB fields ≈ ~240 s event-loop block in one request. `withEndpointTimeout` can't preempt a synchronous CPU loop. Auth-surface/DoS; **TL design sign-off e/53#2**, **Server Community wrap sign-off e/53#3**, **atomic-PR directive e/53#4**.

## Approach (all 4 TL decisions + 2 conditions)
- **Walk-scoped wall-time budget** via a `contentSanitizer`-local `AsyncLocalStorage` + `withSanitizeBudget(fn)`. `sanitizeUserText` checks the deadline at field entry; past it, remaining fields drop to `''` (fail-safe — never stores unsanitized) and log once per walk (no content).
- **Re-entrant-safe** (TL Q1, load-bearing): `if (als.getStore()) return fn()` — `sanitizeDeep`'s self-wrap composes inside community's wrap without reseeding. Exercised by a deterministic-clock nesting test (Server Community's coverage claim).
- **TIME budget (2 s)**, not bytes (TL Q2): legit content is ~ms even at 32 KiB, so a byte cap tight enough to bound the attack would truncate legit large submissions; time is distribution-proof. Accepted property (timing-dependent, always fail-safe) documented at the constant. Validated 2 s < every applicable request timeout (community path: none / Node ~300 s; others 35–50 s).
- **community.ts:333** wraps its one top-level `stripSensitiveKeys` call (Server Community's scope, under their sign-off; atomic per TL e/53#4 so main is never wired-but-uncapped).

## Verification
- **40** sanitizer tests: bounded-time many-pathological-field (AC), large-legit-multi-field **no-truncation** (AC), re-entrancy composition, no-budget passthrough for bare callers, once-per-walk log. **5** community tests green (wrap is behavior-preserving).
- Deterministic gates: `tsc` server+main, eslint, dependency-cruiser, `vite build` — all green.
- **Adversarial security-reviewer pass:** budget mechanism sound — no escape, fail-safe ordering, re-entrancy composes, `admin.ts` single-field caller unaffected, secrets-rule OK.

## Out-of-scope finding filed
The reviewer surfaced a **pre-existing, unrelated** stored-XSS/secret-leak: `stripSensitiveKeys`'s array branch returns bare string elements verbatim (`{tags:['<script>…']}` published unsanitized). Not touched here → filed **t/2032** (HIGH, Server Community) + ElectronMain sibling (`communityReviewIO.ts`).

## Notes
- No new npm deps (`async_hooks`/`perf_hooks` are Node builtins).
- CodeQL is a required check now (t/2025) — will confirm the `CodeQL` results check-run green on the final head before merge.
- @Server Community: the `community.ts:333` hunk is yours — tagging for your scope-owner ✓ before I route to TL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)