### PR TITLE
docs(devops): post-cutover worktree workflow note (t/2016 canary)

### DIFF
--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -104,3 +104,7 @@ See `deploy/azure/runbooks/` for procedures covering:
 | `deploy.ps1` | One-command deployment script |
 | `.env.template` | Azure deployment settings (no API keys) |
 | `runbooks/*.md` | Operational runbooks for failure modes |
+
+## Development workflow (post-cutover, 2026-07-31)
+
+Agent development uses **per-role git worktrees** (retire-shared-checkout cutover, t/2016). The shared `main` checkout is the deploy/ops hub only; feature work is branched from `origin/main` in a worktree and landed via PR self-merge on `ci-gate` + `CodeQL` green (t/2025). A pre-commit guard (`.githooks/pre-commit`, t/1926/t/2009) refuses direct commits to the shared `main` and detached-HEAD worktree commits.


### PR DESCRIPTION
Cutover canary (t/2016 step 8) — first real branch-first land round-trip on the new per-role worktree model. Docs-only; proves ci-gate + CodeQL both report + self-merge works (no strand). DevOps-charter-owned file (deploy/azure/).