### PR TITLE
fix(server-community): sanitize array-of-strings elements in stripSensitiveKeys (t/2032)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/community.test.ts
+++ b/taxonomy-editor/src/server/__tests__/community.test.ts
@@ -4,35 +4,13 @@
 // @vitest-environment node
 
 import { describe, it, expect } from 'vitest';
+// t/2032: import the REAL stripSensitiveKeys. The prior test defined an inline
+// replica, so its "handles arrays" case exercised the replica's logic — not the
+// production function — and could never have caught the array-branch bypass this
+// ticket fixes. Testing the real export also runs the real sanitizeUserText.
+import { stripSensitiveKeys } from '../community/community';
 
-// Import the module to access stripSensitiveKeys via sanitizeForCommunity
-// Since stripSensitiveKeys is not exported, we test it through the public interface
-// by dynamically importing the module internals
 describe('community sanitization', () => {
-  // We can't directly test the private function, so we'll test it by importing
-  // the module and using Function constructor to access the logic
-  // Instead, let's test the patterns directly
-
-  const SENSITIVE_KEYS = new Set([
-    'api_key', 'apiKey', 'api_keys', 'apiKeys',
-    'secret', 'token', 'password', 'credential', 'credentials',
-    'authorization', 'auth_token', 'access_token', 'refresh_token',
-    'private_key', 'privateKey',
-    'flight_recorder', 'debug', '_internal', 'diagnostics_state',
-  ]);
-
-  function stripSensitiveKeys(obj: unknown): unknown {
-    if (obj === null || typeof obj !== 'object') return obj;
-    if (Array.isArray(obj)) return obj.map(stripSensitiveKeys);
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-      if (SENSITIVE_KEYS.has(key)) continue;
-      if (typeof value === 'string' && /^(sk-|AIza|gsk_|key-|xai-|Bearer\s)/.test(value)) continue;
-      result[key] = stripSensitiveKeys(value);
-    }
-    return result;
-  }
-
   it('strips top-level sensitive keys', () => {
     const input = {
       id: 'test-123',
@@ -89,7 +67,7 @@ describe('community sanitization', () => {
     expect(result).not.toHaveProperty('groqKey');
   });
 
-  it('handles arrays correctly', () => {
+  it('handles arrays-of-objects correctly', () => {
     const input = {
       transcript: [
         { speaker: 'user', content: 'Hello', apiKey: 'leaked' },
@@ -103,6 +81,38 @@ describe('community sanitization', () => {
     expect(transcript[0].speaker).toBe('user');
     expect(transcript[1]).not.toHaveProperty('password');
     expect(transcript[1].speaker).toBe('bot');
+  });
+
+  // t/2032 — array-of-STRINGS elements must be sanitized, not passed verbatim.
+  // The prior array branch (`obj.map(stripSensitiveKeys)`) returned string
+  // elements unchanged: stored XSS + secret leak into public community storage.
+  it('sanitizes executable tags in array-of-strings elements', () => {
+    const input = { tags: ['<script>alert(1)</script>', 'ok'] };
+    const result = stripSensitiveKeys(input) as Record<string, unknown>;
+    const tags = result.tags as string[];
+    expect(tags).toHaveLength(2);
+    expect(tags[0]).not.toContain('<script'); // executable tag neutralized
+    expect(tags[1]).toBe('ok');               // legit element untouched
+  });
+
+  it('redacts secret-prefixed array-of-strings elements to empty string', () => {
+    const input = { keys: ['sk-LEAKED', 'AIzaLEAKED', 'gsk_LEAKED', 'normal'] };
+    const result = stripSensitiveKeys(input) as Record<string, unknown>;
+    const keys = result.keys as string[];
+    // Array shape preserved (positional), secret values gone (redacted to '').
+    expect(keys).toHaveLength(4);
+    expect(keys[0]).toBe('');
+    expect(keys[1]).toBe('');
+    expect(keys[2]).toBe('');
+    expect(keys[3]).toBe('normal');
+  });
+
+  it('sanitizes strings nested in arrays-within-arrays', () => {
+    const input = { nested: [['<iframe src=x>', 'sk-DEEP']] };
+    const result = stripSensitiveKeys(input) as Record<string, unknown>;
+    const inner = (result.nested as string[][])[0];
+    expect(inner[0]).not.toContain('<iframe');
+    expect(inner[1]).toBe(''); // secret redacted at any array depth
   });
 
   it('preserves null and primitive values', () => {

--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -304,14 +304,31 @@ const SENSITIVE_KEYS = new Set([
   'flight_recorder', 'debug', '_internal', 'diagnostics_state',
 ]);
 
-function stripSensitiveKeys(obj: unknown): unknown {
+// t/2032: single source of truth for the secret-prefix screen — used by BOTH the
+// object and array branches of stripSensitiveKeys. A single regex kills the drift
+// that let the array branch ship without a secret screen (two branches, one updated).
+const SECRET_PREFIX_RE = /^(sk-|AIza|gsk_|key-|xai-|Bearer\s)/;
+
+// Exported for direct regression testing (t/2032): the prior test used an inline
+// REPLICA of this logic, so its "handles arrays" case couldn't catch the real
+// function's array-branch bypass. Tests must exercise this function itself.
+export function stripSensitiveKeys(obj: unknown): unknown {
   if (obj === null || typeof obj !== 'object') return obj;
-  if (Array.isArray(obj)) return obj.map(stripSensitiveKeys);
+  if (Array.isArray(obj)) {
+    // t/2032: array string elements have no key to omit, so screen each in place —
+    // secret-prefix FIRST (redact to '' so a `sk-…` value can't leak, preserving
+    // array shape), else neutralize executable tags/schemes. Non-strings recurse.
+    return obj.map((v) => {
+      if (typeof v !== 'string') return stripSensitiveKeys(v);
+      if (SECRET_PREFIX_RE.test(v)) return '';
+      return sanitizeUserText(v);
+    });
+  }
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
     if (SENSITIVE_KEYS.has(key)) continue;
     if (typeof value === 'string') {
-      if (/^(sk-|AIza|gsk_|key-|xai-|Bearer\s)/.test(value)) continue;
+      if (SECRET_PREFIX_RE.test(value)) continue;
       result[key] = sanitizeUserText(value); // t/856: neutralize executable tags / schemes server-side
       continue;
     }


### PR DESCRIPTION
**HIGH — pre-existing stored-XSS + secret-leak** surfaced by the t/2031 security-reviewer pass. Auth-surface → TL pre-merge gate (t/2001#9).

## Bug
`stripSensitiveKeys` array branch was `obj.map(stripSensitiveKeys)`, which re-enters at the primitive guard (`typeof !== 'object' → return verbatim`). So a **string-array field** published to public community storage **unsanitized**, bypassing both `sanitizeUserText` and the secret-prefix strip:
- `{tags:['<script>alert(1)</script>']}` → live `<script>` published (stored XSS)
- `{keys:['sk-LEAKED']}` → secret-looking value published

Reachable via `sanitizeForCommunity` (admin promote path). Server-side defense-in-depth layer that's meant to hold on a renderer/CSP regression.

## Fix (governing spec t/2032#2, TL-approved Option A)
- Array string elements screened in place: **secret-prefix → redact to `''` FIRST** (preserves array shape), else `sanitizeUserText`. Non-strings recurse.
- Extracted **`SECRET_PREFIX_RE`** module const, used by **both** object and array branches — kills the two-branches-one-updated drift that hid this.

## Test root-cause also fixed
`community.test.ts` used an inline **replica** of `stripSensitiveKeys`, so its "handles arrays" case tested the replica — never the real function. Now imports the real (newly exported) function; adds regression cases for array XSS, secret-prefix redaction, and nested-array depth.

## Verify (worktree off origin/main)
- tsc main+server: 0 / 0
- eslint: 0
- depcruise: 0 violations
- vitest: 48 green (community + contentSanitizer)

## Notes
- Sibling **t/2033** (ElectronMain `communityReviewIO.ts`) implements the identical array-branch logic — linked `relates_to`.
- Cross-scope: `__tests__/community.test.ts` is ServerAPI's file — scope-owner ✓ requested from ServerAPI on that hunk.
- Traversal-dedup / shared-lib extraction is a fast-follow (t/2033 ruling), NOT gating this HIGH fix.

Closes t/2032.