### PR TITLE
refactor(security): extract pure sanitizer core to lib/ with injectable onWarn (t/2035)

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -5,6 +5,10 @@
   "packages": {
     "": {
       "name": "@ai-triad/lib",
+      "dependencies": {
+        "decode-named-character-reference": "^1.3.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.2"
+      },
       "devDependencies": {
         "@types/node": "^26.1.2",
         "eslint": "^10.8.0",
@@ -953,6 +957,16 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -984,6 +998,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -1431,6 +1458,41 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "10.2.5",

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,6 +2,10 @@
   "name": "@ai-triad/lib",
   "private": true,
   "type": "module",
+  "dependencies": {
+    "decode-named-character-reference": "^1.3.0",
+    "micromark-util-decode-numeric-character-reference": "^2.0.2"
+  },
   "devDependencies": {
     "@types/node": "^26.1.2",
     "eslint": "^10.8.0",

--- a/lib/sanitize/contentSanitizerCore.test.ts
+++ b/lib/sanitize/contentSanitizerCore.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment node
+
+/**
+ * t/2035 — pure sanitizer core unit tests. These pin the CORE contract (decode +
+ * neutralize + per-string cap + injectable onWarn), independent of the server ALS
+ * budget / pino wrapper. The full behavior-preservation regression for the hardened
+ * server surface (t/2027/2029/2030/2031) lives in
+ * taxonomy-editor/src/server/__tests__/contentSanitizer.test.ts and must stay green.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { sanitizeText, MAX_SANITIZE_INPUT } from './contentSanitizerCore.js';
+import type { SanitizeWarning } from './contentSanitizerCore.js';
+
+describe('sanitizeText — core neutralization (t/856/t/2027)', () => {
+  it('strips executable tag blocks', () => {
+    expect(sanitizeText('hi <script>alert(1)</script> there')).toBe('hi alert(1) there');
+    expect(sanitizeText('<iframe src=evil></iframe>x')).toBe('x');
+  });
+
+  it('neutralizes dangerous URL schemes', () => {
+    expect(sanitizeText('[click](javascript:alert(1))')).toBe('[click](blocked:alert(1))');
+    expect(sanitizeText('vbscript:msgbox')).toBe('blocked:msgbox');
+  });
+
+  it('neutralizes control-char-split schemes/tags (t/2027)', () => {
+    expect(sanitizeText('java\tscript:alert(1)')).toBe('blocked:alert(1)');
+    expect(sanitizeText('a <scr\0ipt>x</scr\0ipt> b')).toBe('a x b');
+  });
+
+  it('leaves ordinary markdown / comparison operators intact', () => {
+    expect(sanitizeText('if (a < b && b > c) return;')).toBe('if (a < b && b > c) return;');
+    expect(sanitizeText('A normal [link](https://example.com).')).toBe('A normal [link](https://example.com).');
+  });
+
+  it('multi-pass: neutralizes a scheme reformed by tag removal (t/2023)', () => {
+    expect(sanitizeText('java<script></script>script:alert(1)')).toBe('blocked:alert(1)');
+    expect(sanitizeText('<scr<script>ipt>alert(1)')).toBe('alert(1)');
+  });
+});
+
+describe('sanitizeText — entity/numeric-ref canonicalization (t/2030)', () => {
+  it('neutralizes entity/numeric-encoded schemes', () => {
+    expect(sanitizeText('[x](javascript&colon;alert(1))')).toBe('[x](blocked:alert(1))');
+    expect(sanitizeText('&#106;avascript:alert(1)')).toBe('blocked:alert(1)');   // &#106; = j
+    expect(sanitizeText('&#x6a;avascript:alert(1)')).toBe('blocked:alert(1)');
+    expect(sanitizeText('[x](javascript&amp;colon;alert(1))')).toBe('[x](blocked:alert(1))'); // layered
+  });
+
+  it('broadens data: to the executable-markup media-type family (Finding B)', () => {
+    expect(sanitizeText('[x](data:image/svg+xml;base64,PHN2Zz4=)')).toBe('[x](data:blocked;base64,PHN2Zz4=)');
+    expect(sanitizeText('data:application/xhtml+xml,<html/>')).toBe('data:blocked,<html/>');
+    expect(sanitizeText('![img](data:image/png;base64,iVBORw0KG)')).toBe('![img](data:image/png;base64,iVBORw0KG)'); // legit untouched
+  });
+
+  it('returns clean input BYTE-FOR-BYTE (legit entities never mangled)', () => {
+    for (const s of ['Tom &amp; Jerry', 'compare a &lt; b &gt; c', '&copy; 2026', 'use `&lt;script&gt;` in docs']) {
+      expect(sanitizeText(s)).toBe(s);
+    }
+  });
+
+  it('does NOT decode/strip entity-encoded angle brackets (inert character data)', () => {
+    expect(sanitizeText('&lt;script&gt;alert(1)&lt;/script&gt;')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(sanitizeText('&#60;script&#62;x')).toBe('&#60;script&#62;x');
+  });
+});
+
+describe('sanitizeText — per-string cap + injectable onWarn (t/2029/t/2035)', () => {
+  it('truncates oversized input and fires onWarn with oversize-input (no content)', () => {
+    const seen: SanitizeWarning[] = [];
+    const out = sanitizeText('x'.repeat(MAX_SANITIZE_INPUT + 10), (w) => seen.push(w));
+    expect(out.length).toBeLessThanOrEqual(MAX_SANITIZE_INPUT);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ reason: 'oversize-input', originalLength: MAX_SANITIZE_INPUT + 10, cap: MAX_SANITIZE_INPUT });
+    // secrets rule: the warning carries only lengths, never the content.
+    expect(JSON.stringify(seen[0])).not.toContain('xxxxx');
+  });
+
+  it('does NOT fire onWarn for at-or-under-cap input', () => {
+    const warn = vi.fn();
+    sanitizeText('X'.repeat(MAX_SANITIZE_INPUT), warn);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('is pure: works with NO onWarn hook (no logger dependency)', () => {
+    // tag blocks are removed; content BETWEEN them is kept (narrow charter), so
+    // `<script>x</script>hi` → `xhi`. The point here is no-hook → no throw.
+    expect(sanitizeText('<script>x</script>hi')).toBe('xhi');
+    expect(sanitizeText('y'.repeat(MAX_SANITIZE_INPUT + 5)).length).toBeLessThanOrEqual(MAX_SANITIZE_INPUT);
+  });
+
+  it('a throwing onWarn never breaks sanitization', () => {
+    const boom = () => { throw new Error('logger down'); };
+    expect(sanitizeText('<script>x</script>ok'.padEnd(MAX_SANITIZE_INPUT + 50, 'z'), boom).length)
+      .toBeLessThanOrEqual(MAX_SANITIZE_INPUT);
+  });
+
+  it('bounds the pathological no-`>` payload (t/2029 DoS backstop travels with the core)', () => {
+    const started = performance.now();
+    const out = sanitizeText('<script'.repeat(50000)); // ~350 KB, no `>`
+    expect(performance.now() - started).toBeLessThan(2000);
+    expect(out.length).toBeLessThanOrEqual(MAX_SANITIZE_INPUT);
+  });
+});

--- a/lib/sanitize/contentSanitizerCore.ts
+++ b/lib/sanitize/contentSanitizerCore.ts
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * PURE, dependency-light content-sanitization core (t/2035, extracted from
+ * server/security/contentSanitizer.ts).
+ *
+ * This is the shared XSS defense-in-depth primitive: it neutralizes executable
+ * tag blocks (script/iframe/style/object/embed) and dangerous URL schemes
+ * (javascript:/vbscript:/data:*markup), matching against an entity-DECODED shadow
+ * so entity/numeric-char-ref obfuscation can't slip a live scheme past a literal
+ * matcher (t/2030). Deliberately NARROW — it does not strip ordinary HTML-like
+ * text, `<`/`>` comparison operators, or fenced code structure.
+ *
+ * WHY a separate lib/ core (t/2033#6, TL e/53#8): both the server community path
+ * AND the Electron main-process admin-promote path (`src/main/communityReviewIO`)
+ * publish to the SAME public community blob, so both need identical sanitization.
+ * The server module couples to pino (`../logger.js`) + the t/2031 ALS budget,
+ * neither of which is importable from `src/main` (tsconfig.main boundary). So the
+ * pure logic lives here — NO pino, NO AsyncLocalStorage budget — and each consumer
+ * wraps it: the server adds the ALS budget + pino; the desktop injects a
+ * flight-recorder `onWarn`. The aggregate ALS budget is a SERVER-ONLY concern (it
+ * defends a public HTTP surface against remote event-loop exhaustion); the desktop
+ * promote path is local-admin, self-recoverable, so it needs only this pure core.
+ *
+ * Observability is decoupled via an injectable `onWarn` hook rather than a logger
+ * import — that is precisely what makes this file importable from `src/main`.
+ */
+
+import { decodeNamedCharacterReference } from 'decode-named-character-reference';
+import { decodeNumericCharacterReference } from 'micromark-util-decode-numeric-character-reference';
+import { ActionableError } from '../debate/errors.js';
+
+// t/2029 — input-size cap (DoS backstop). The tag `[^>]*` tail scans O(n) per
+// starting position, so pathological input (`<script` repeated with no closing
+// `>`) costs O(n²) and can block the event loop (~1.6 s / 140 KB). Truncating the
+// INPUT bounds the cost to a fixed worst case while leaving `[^>]*` unbounded — no
+// per-tag length bound, hence no bypass. At CAP the worst case is the nested
+// tag-reforming "onion" (~4681 `<style>`-reforming layers) that drives the
+// fixed-point loop through ~O(layers²) passes: empirically ~120 ms (a single
+// no-`>` scan is ~70 ms) — always ≪ the pre-fix multi-second blow-up. 32 KiB is
+// 3.3× the largest existing caller field cap (feedback text ≤10 000 chars), so
+// legitimate single-field content never reaches it. Truncate-then-sanitize is
+// fail-safe: the sanitizer still runs on the kept prefix, so a tag split by the cut
+// is inert text. (Slice is by UTF-16 code unit; a surrogate pair split at the
+// boundary leaves a lone surrogate — still inert text, never a bypass.)
+export const MAX_SANITIZE_INPUT = 32 * 1024;
+
+/** Warning surfaced by the pure core so a host can log it without the core
+ *  importing a logger. Only `oversize-input` (the per-string MAX_SANITIZE_INPUT
+ *  truncation) originates here; the aggregate `budget-exhausted` warning is a
+ *  server-ALS-wrapper concern and never reaches this core (t/2033#6, e/53#8). */
+export interface SanitizeWarning {
+  reason: 'oversize-input';
+  originalLength: number;
+  cap: number;
+}
+export type SanitizeWarn = (warning: SanitizeWarning) => void;
+
+// t/2027 — control-char obfuscation hardening. Attackers split a dangerous
+// keyword with control characters the browser later elides (`java\tscript:`,
+// `javascript\0:`, `<scr\0ipt>`), slipping past a contiguous-literal match. An
+// optional CTRL class folded between every keyword letter neutralizes these;
+// because the whole obfuscated span is replaced, embedded control chars are
+// removed only inside the dangerous match — legit whitespace/newlines elsewhere
+// (markdown, code fences) are untouched. Set = C0 controls + DEL, NOT space:
+// 0x20 isn't stripped mid-scheme by browsers, so folding it would false-positive
+// on legit prose ("the java script docs"). TAB/CR/LF/NUL are the real live
+// vectors; the rest of C0+DEL is conservative, fail-safe over-inclusion. The
+// tag-name fold is likewise conservative (a spec tokenizer ends the tag name at
+// TAB/LF/FF/space rather than eliding it) — over-inclusive removal, still safe.
+const CTRL = '[\\x00-\\x1F\\x7F]*';
+const gap = (word: string): string => word.split('').join(CTRL);
+const EXECUTABLE_TAGS = new RegExp(
+  `</?(?:${['script', 'iframe', 'object', 'embed', 'style'].map(gap).join('|')})\\b[^>]*>`,
+  'gi',
+);
+const DANGEROUS_SCHEME = new RegExp(`\\b(?:${gap('javascript')}|${gap('vbscript')})${CTRL}:`, 'gi');
+// t/2030 (Finding B) — broadened from data:text/html to the whole executable-markup
+// media-type FAMILY (TL e/52#2, option b). `data:image/svg+xml`,
+// `application/xhtml+xml`, `application/xml`, `text/xml` and any future `*+xml`
+// subtype can all carry executable <script> when navigated/embedded. Rule: any
+// `data:` whose subtype ENDS IN `html` or `xml` — that captures html, xhtml,
+// xml, svg+xml, xhtml+xml, and future `foo+xml` in one shot. Non-markup media
+// (`image/png`, `application/json`, base64 blobs) never match, so legit inline
+// data URLs are untouched. The `data` keyword, `:`/`/` separators, media type,
+// and the `html`/`xml` core keep the t/2027 control-char fold; the optional
+// subtype prefix (`svg+`, `xhtml+`) is not folded — a control char there is an
+// exotic non-vector and folding a `*`-quantified run risks needless backtracking.
+const CTRL_TYPE = `(?:[a-z]${CTRL})+`;                    // media type, control-tolerant
+const DATA_SUBTYPE = `[a-z0-9.+-]*(?:${gap('html')}|${gap('xml')})`; // …ends html|xml
+const DATA_MARKUP = new RegExp(
+  `\\b${gap('data')}${CTRL}:${CTRL}${CTRL_TYPE}${CTRL}/${CTRL}${DATA_SUBTYPE}\\b`,
+  'gi',
+);
+
+// t/2030 — HTML character-reference candidate: named (`&colon`), decimal (`&#106`),
+// or hex (`&#x6a`). The trailing `;` is OPTIONAL: browsers/HTML decode many refs
+// without it, so decodeEntitiesFixedPoint decodes a liberal SUPERSET — anything a
+// current-or-future renderer might decode, we decode first. Over-decoding is free
+// here because sanitizeText only rewrites when a threat surfaces (clean inputs are
+// returned verbatim), so an over-eager decode never corrupts legit content.
+const ENTITY = /&(#[xX][0-9a-fA-F]+|#[0-9]+|[a-zA-Z][a-zA-Z0-9]*);?/g;
+
+/** Decode one matched character reference; returns the match VERBATIM if it is not
+ *  a real entity, or if it decodes to `<`/`>` (see below). */
+function decodeEntityRef(match: string, ref: string): string {
+  let decoded: string;
+  if (ref[0] === '#') {
+    // Use the renderer's OWN numeric decoder (micromark, same family react-markdown
+    // uses) rather than a hand-rolled table, for byte-for-byte parity: it maps
+    // out-of-range / surrogate / C0+C1 control / noncharacter code points to U+FFFD
+    // exactly as the renderer does, so our shadow never diverges from what renders
+    // (TL's load-bearing decode-identically-to-the-renderer decision, e/52#2).
+    decoded = ref[1] === 'x' || ref[1] === 'X'
+      ? decodeNumericCharacterReference(ref.slice(2), 16)
+      : decodeNumericCharacterReference(ref.slice(1), 10);
+  } else {
+    const named = decodeNamedCharacterReference(ref);
+    if (named === false) return match; // not a real named entity — leave verbatim
+    decoded = named;
+  }
+  // Leave `<`/`>`-producing refs ENCODED. Entity-decoded angle brackets are always
+  // inert character DATA — no renderer turns `&lt;script&gt;` into a live tag (that
+  // needs a LITERAL `<` in the source). Decoding them would only feed the tag
+  // matcher false positives and corrupt legit escaped-markup prose, with zero
+  // security gain; schemes never require `<`/`>`. (TL flag: t/2030 build refinement.)
+  if (decoded === '<' || decoded === '>') return match;
+  return decoded;
+}
+
+/**
+ * Decode HTML character references to a fixed point (collapses layered encodings
+ * like `&amp;colon;` → `&colon;` → `:`).
+ *
+ * Termination: every changing pass STRICTLY SHRINKS the string. Each entity span
+ * `&…;?` is ≥3 chars and decodes to ≤2 UTF-16 units — verified across all 2125
+ * named entities (worst source-vs-decoded margin is +2) and true for numeric refs
+ * (`&#…` ≥3 chars → 1 code point). So the loop runs at most `length` passes and
+ * the cap below is UNREACHABLE in practice. We nonetheless THROW past it (never a
+ * bounded value-return, which would reintroduce js/incomplete-multi-character-
+ * sanitization, t/2001#6): a hit means the shrink invariant was broken by a future
+ * edit, and returning a partially-decoded string could hide a live scheme.
+ */
+function decodeEntitiesFixedPoint(s: string): string {
+  let out = s;
+  let prev: string;
+  const cap = out.length + 1;
+  let iter = 0;
+  do {
+    prev = out;
+    out = out.replace(ENTITY, decodeEntityRef);
+    if (++iter > cap) {
+      throw new ActionableError({
+        goal: 'Canonicalize HTML character references before XSS scheme/tag matching',
+        problem: 'Entity decode did not converge within the shrink-invariant bound — a decode pass grew or oscillated the string.',
+        location: 'contentSanitizerCore.ts decodeEntitiesFixedPoint',
+        nextSteps: [
+          'Confirm ENTITY only matches spans that decode to a strictly shorter string',
+          'A newly added named entity decoding to ≥3 UTF-16 units would break the bound',
+        ],
+      });
+    }
+  } while (out !== prev);
+  return out;
+}
+
+/**
+ * Neutralize executable tags + dangerous URL schemes in a single string.
+ *
+ * t/2023 (CodeQL js/incomplete-multi-character-sanitization): a SINGLE pass is
+ * bypassable because removing one match can reform another — `<scr<script>ipt>`
+ * strips the inner tag and leaves `<script>`, and removing tags can concatenate
+ * halves into a scheme (`java<script></script>script:` → `javascript:`). So each
+ * removal is applied to a FIXED POINT: repeat `replace` until the string stops
+ * changing (the canonical CodeQL-recognized remediation — the loop exits ONLY on
+ * stability, never on a bound, so the result provably contains no residual match).
+ *
+ * Order matters: strip executable tags fully first — that both handles nested
+ * tags and exposes any scheme that tag-splitting concealed — then neutralize
+ * schemes. Scheme/data replacements never contain `<`, so they can't reform a
+ * tag, so the tag loop need not re-run afterward.
+ *
+ * Termination: every changed tag-pass strictly shrinks the string (each removes
+ * ≥1 tag); scheme substitutions are shrinking and idempotent after the first
+ * pass — so every loop converges. No fail-closed bound is needed (an early bound
+ * would let the loop return a possibly-unsanitized string, which is the very
+ * defect this query flags).
+ *
+ * Per-match linear: the folded `[\x00-\x1F\x7F]*` classes sit between distinct
+ * literals (no `X*X*` adjacency, no nested/overlapping unbounded quantifiers), so
+ * the control-char fold adds no ReDoS. The tag `[^>]*` tail's O(n) per-position
+ * worst-case scan (pathological no-`>` input → O(n²)) is bounded by the
+ * MAX_SANITIZE_INPUT truncation in sanitizeText (t/2029).
+ */
+function neutralize(s: string): string {
+  let out = s;
+  let prev: string;
+  // TERMINATION INVARIANT (nothing else bounds these loops — they exit ONLY on
+  // stability, `out === prev`): every replacement below MUST strictly shrink the
+  // string OR replace with an irreversible sentinel that can never re-match its
+  // own pattern. Tag removal deletes chars; `javascript:`/`vbscript:` → `blocked:`
+  // and the data-markup family → `data:blocked` are sentinels that don't re-match.
+  // A future rule that could GROW the string or oscillate would infinite-loop here.
+  do { prev = out; out = out.replace(EXECUTABLE_TAGS, ''); } while (out !== prev);
+  do { prev = out; out = out.replace(DANGEROUS_SCHEME, 'blocked:'); } while (out !== prev);
+  do { prev = out; out = out.replace(DATA_MARKUP, 'data:blocked'); } while (out !== prev);
+  return out;
+}
+
+/**
+ * Sanitize a single string (pure — no ALS budget, no logger import).
+ *
+ * t/2030 — decode-into-shadow, rewrite-only-on-threat. We match against an
+ * entity-DECODED shadow (so `javascript&colon;` / `&#106;avascript:` are caught
+ * the way a renderer would realize them), but rewrite conservatively:
+ *   - decode a liberal superset of character references into `decoded`;
+ *   - run the neutralizers on `decoded`;
+ *   - if nothing matched (`cleaned === decoded`) the whole string is CLEAN → return
+ *     it BYTE-FOR-BYTE, so a threat-free field's legit `&amp;`/`&lt;`/`&copy;`/code
+ *     fences are never mangled;
+ *   - only genuinely-dangerous inputs are returned in canonicalized form.
+ * Granularity is whole-string, not per-match: a field that mixes a real threat with
+ * benign entities returns the decoded form, so those co-located benign entities are
+ * decoded too. That is directionally safe (over-decoding, never under) and round-trips
+ * invisibly through the renderer (CommonMark re-escapes a bare `&` on serialization);
+ * the `<`/`>` exclusion still protects escaped-markup structure even in that case.
+ *
+ * @param onWarn optional observability hook — invoked with `oversize-input` when the
+ *   input exceeds MAX_SANITIZE_INPUT and is truncated. The host logs it (server →
+ *   pino; desktop → flight recorder); the core never imports a logger. A throwing
+ *   hook can never break sanitization (the call is guarded).
+ */
+export function sanitizeText(s: string, onWarn?: SanitizeWarn): string {
+  let base = s;
+  // t/2029 DoS backstop: truncate oversized input BEFORE the O(n²)-prone loops
+  // (and before entity decode, so decode is length-bounded too). Surface it via
+  // onWarn (never the content — secrets rule); a throwing hook must not break us.
+  if (base.length > MAX_SANITIZE_INPUT) {
+    if (onWarn) {
+      try {
+        onWarn({ reason: 'oversize-input', originalLength: base.length, cap: MAX_SANITIZE_INPUT });
+      } catch { /* telemetry — silent by design: an onWarn throw must never break sanitization */ }
+    }
+    base = base.slice(0, MAX_SANITIZE_INPUT);
+  }
+  const decoded = decodeEntitiesFixedPoint(base);
+  const cleaned = neutralize(decoded);
+  return cleaned === decoded ? base : cleaned;
+}

--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -27,6 +27,14 @@ COPY lib/ ./lib/
 WORKDIR /build/taxonomy-editor
 RUN --mount=type=cache,target=/root/.npm npm ci
 
+# Install shared-lib deps too (t/2035): lib/ is a self-contained package with its
+# own package.json, and the sanitizer core's renderer-parity decoders must resolve
+# from lib/node_modules during build:server (tsc). Mirrors the test-electron CI job
+# (ci.yml "Install shared lib dependencies"). Without this, build:container's tsc
+# fails TS2307 on the lib/ core's decoder imports.
+WORKDIR /build/lib
+RUN --mount=type=cache,target=/root/.npm npm ci
+
 # Copy source and build
 WORKDIR /build
 COPY taxonomy-editor/src/ ./taxonomy-editor/src/

--- a/taxonomy-editor/src/server/security/contentSanitizer.ts
+++ b/taxonomy-editor/src/server/security/contentSanitizer.ts
@@ -2,37 +2,35 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 /**
- * Conservative server-side content sanitization (t/856, XSS defense-in-depth).
+ * Server-side content sanitization (t/856, XSS defense-in-depth).
  *
- * Stored XSS is already triple-mitigated client-side (react-markdown drops raw
- * HTML, strips javascript:/data: URLs, strict CSP blocks inline scripts). This
- * adds a server-side layer so the defense doesn't rely solely on the renderer:
- * a future renderer swap or CSP regression shouldn't make stored content
- * instantly exploitable.
+ * The pure sanitize logic — entity-decode canonicalization (t/2030), executable
+ * tag / dangerous-scheme neutralization (t/856/t/2027), and the per-string
+ * MAX_SANITIZE_INPUT cap (t/2029) — lives in the shared, dependency-light
+ * `lib/sanitize/contentSanitizerCore.ts` so the Electron main-process
+ * admin-promote path can share ONE copy (t/2035; extracted per TL t/2033#6).
  *
- * Deliberately NARROW to avoid corrupting legitimate markdown/code: it only
- * neutralizes executable tag blocks (script/iframe/style/object/embed) and
- * dangerous URL schemes — it does not strip ordinary HTML-like text, `<`/`>`
- * comparison operators, or fenced code content structure.
- *
- * t/2030 — entity/numeric-char-ref canonicalization. CommonMark (react-markdown)
- * decodes HTML entities and numeric character references in link destinations
- * BEFORE the URL scheme is honored, so a literal-only matcher misses
- * `javascript&colon;alert(1)` and `&#106;avascript:` — both reconstitute a live
- * scheme at render. We defeat this by decoding refs into a SHADOW copy, matching
- * against it, and rewriting only when the shadow reveals a threat (see
- * sanitizeUserText). Design: t/2030#1, TL sign-off e/52#2.
+ * This server module is the server-only WRAPPER around that core. It adds the two
+ * server-specific concerns the core deliberately excludes:
+ *   1. the t/2031 aggregate wall-time DoS budget (AsyncLocalStorage) — a defense
+ *      for the PUBLIC HTTP surface against remote event-loop exhaustion; and
+ *   2. pino logging (`log.security.warn`) — injected into the core via its `onWarn`
+ *      hook for the oversize-input warning, and emitted directly here for the
+ *      budget-exhausted warning (which the core never raises — it has no budget).
  */
 
 import { AsyncLocalStorage } from 'async_hooks';
 import { performance } from 'perf_hooks';
-import { decodeNamedCharacterReference } from 'decode-named-character-reference';
-import { decodeNumericCharacterReference } from 'micromark-util-decode-numeric-character-reference';
-import { ActionableError } from '../../../../lib/debate/errors.js';
+import { sanitizeText, MAX_SANITIZE_INPUT } from '../../../../lib/sanitize/contentSanitizerCore.js';
+import type { SanitizeWarn } from '../../../../lib/sanitize/contentSanitizerCore.js';
 import { log } from '../logger.js';
 
+// Re-export the per-string cap so existing boundary tests keep a single source of
+// truth via this module (`../security/contentSanitizer.js`).
+export { MAX_SANITIZE_INPUT };
+
 // t/2031 — aggregate sanitize-work budget (multi-field DoS amplification).
-// sanitizeUserText is per-CALL capped (t/2029, ~150 ms worst at 32 KiB), but a walk
+// sanitizeText is per-CALL capped (t/2029, ~150 ms worst at 32 KiB), but a walk
 // that sanitizes many fields — community.ts `stripSensitiveKeys`, `sanitizeDeep` —
 // had no cap on field COUNT: ~1,600 crafted 32 KiB fields ≈ ~240 s of synchronous
 // event-loop block in one request. `withEndpointTimeout` can't preempt it (a
@@ -46,6 +44,11 @@ import { log } from '../logger.js';
 // string-leaf entry, so pure-structural object/array traversal with no string leaves
 // is not clipped by it — but that is O(field-count), already bounded by the request
 // body-size limit to low-single-digit seconds, not the O(n²) blow-up this addresses.)
+//
+// SERVER-ONLY (TL t/2033#6): the budget defends a public HTTP surface. The desktop
+// admin-promote path imports the pure core WITHOUT this wrapper — local-admin
+// event-loop stalls are self-inflicted and restart-recoverable, not a shared-service
+// DoS.
 //
 // TIME, not bytes (TL e/53#2): legit content is cheap (~1 ms even at 32 KiB — the
 // O(n²) fold cost only fires on crafted `<script`-repeat / deep-entity fields), so a
@@ -81,195 +84,19 @@ export function withSanitizeBudget<T>(fn: () => T): T {
   return budgetAls.run({ deadline: performance.now() + SANITIZE_WALL_BUDGET_MS, loggedTruncation: false }, fn);
 }
 
-// t/2029 — input-size cap (DoS backstop). The tag `[^>]*` tail scans O(n) per
-// starting position, so pathological input (`<script` repeated with no closing
-// `>`) costs O(n²) and can block the event loop (~1.6 s / 140 KB). The global
-// body limit is 50 MB and not every caller length-caps its fields
-// (`community.ts` sanitizes arbitrary content-map values), so the sanitizer must
-// self-defend. Truncating the INPUT bounds the cost to a fixed worst case while
-// leaving `[^>]*` unbounded — no per-tag length bound, hence no bypass. At CAP the
-// worst case is the nested tag-reforming "onion" (~4681 `<style>`-reforming layers)
-// that drives the fixed-point loop through ~O(layers²) passes: empirically ~120 ms
-// (a single no-`>` scan is ~70 ms) — always ≪ the pre-fix multi-second blow-up.
-// 32 KiB is 3.3× the
-// largest existing caller field cap (feedback text ≤10 000 chars), so legitimate
-// single-field content never reaches it. Truncate-then-sanitize is fail-safe: the
-// sanitizer still runs on the kept prefix, so a tag split by the cut is inert text.
-// (Slice is by UTF-16 code unit; a surrogate pair split at the boundary leaves a
-// lone surrogate — still inert text, a cosmetic data wrinkle, never a bypass.)
-// Exported for a single source of truth in the boundary tests.
-export const MAX_SANITIZE_INPUT = 32 * 1024;
-
-// t/2027 — control-char obfuscation hardening. Attackers split a dangerous
-// keyword with control characters the browser later elides (`java\tscript:`,
-// `javascript\0:`, `<scr\0ipt>`), slipping past a contiguous-literal match. An
-// optional CTRL class folded between every keyword letter neutralizes these;
-// because the whole obfuscated span is replaced, embedded control chars are
-// removed only inside the dangerous match — legit whitespace/newlines elsewhere
-// (markdown, code fences) are untouched. Set = C0 controls + DEL, NOT space:
-// 0x20 isn't stripped mid-scheme by browsers, so folding it would false-positive
-// on legit prose ("the java script docs"). TAB/CR/LF/NUL are the real live
-// vectors; the rest of C0+DEL is conservative, fail-safe over-inclusion. The
-// tag-name fold is likewise conservative (a spec tokenizer ends the tag name at
-// TAB/LF/FF/space rather than eliding it) — over-inclusive removal, still safe.
-const CTRL = '[\\x00-\\x1F\\x7F]*';
-const gap = (word: string): string => word.split('').join(CTRL);
-const EXECUTABLE_TAGS = new RegExp(
-  `</?(?:${['script', 'iframe', 'object', 'embed', 'style'].map(gap).join('|')})\\b[^>]*>`,
-  'gi',
-);
-const DANGEROUS_SCHEME = new RegExp(`\\b(?:${gap('javascript')}|${gap('vbscript')})${CTRL}:`, 'gi');
-// t/2030 (Finding B) — broadened from data:text/html to the whole executable-markup
-// media-type FAMILY (TL e/52#2, option b). `data:image/svg+xml`,
-// `application/xhtml+xml`, `application/xml`, `text/xml` and any future `*+xml`
-// subtype can all carry executable <script> when navigated/embedded. Rule: any
-// `data:` whose subtype ENDS IN `html` or `xml` — that captures html, xhtml,
-// xml, svg+xml, xhtml+xml, and future `foo+xml` in one shot. Non-markup media
-// (`image/png`, `application/json`, base64 blobs) never match, so legit inline
-// data URLs are untouched. The `data` keyword, `:`/`/` separators, media type,
-// and the `html`/`xml` core keep the t/2027 control-char fold; the optional
-// subtype prefix (`svg+`, `xhtml+`) is not folded — a control char there is an
-// exotic non-vector and folding a `*`-quantified run risks needless backtracking.
-const CTRL_TYPE = `(?:[a-z]${CTRL})+`;                    // media type, control-tolerant
-const DATA_SUBTYPE = `[a-z0-9.+-]*(?:${gap('html')}|${gap('xml')})`; // …ends html|xml
-const DATA_MARKUP = new RegExp(
-  `\\b${gap('data')}${CTRL}:${CTRL}${CTRL_TYPE}${CTRL}/${CTRL}${DATA_SUBTYPE}\\b`,
-  'gi',
-);
-
-// t/2030 — HTML character-reference candidate: named (`&colon`), decimal (`&#106`),
-// or hex (`&#x6a`). The trailing `;` is OPTIONAL: browsers/HTML decode many refs
-// without it, so decodeEntitiesFixedPoint decodes a liberal SUPERSET — anything a
-// current-or-future renderer might decode, we decode first. Over-decoding is free
-// here because sanitizeUserText only rewrites when a threat surfaces (clean inputs
-// are returned verbatim), so an over-eager decode never corrupts legit content.
-const ENTITY = /&(#[xX][0-9a-fA-F]+|#[0-9]+|[a-zA-Z][a-zA-Z0-9]*);?/g;
-
-/** Decode one matched character reference; returns the match VERBATIM if it is not
- *  a real entity, or if it decodes to `<`/`>` (see below). */
-function decodeEntityRef(match: string, ref: string): string {
-  let decoded: string;
-  if (ref[0] === '#') {
-    // Use the renderer's OWN numeric decoder (micromark, same family react-markdown
-    // uses) rather than a hand-rolled table, for byte-for-byte parity: it maps
-    // out-of-range / surrogate / C0+C1 control / noncharacter code points to U+FFFD
-    // exactly as the renderer does, so our shadow never diverges from what renders
-    // (TL's load-bearing decode-identically-to-the-renderer decision, e/52#2).
-    decoded = ref[1] === 'x' || ref[1] === 'X'
-      ? decodeNumericCharacterReference(ref.slice(2), 16)
-      : decodeNumericCharacterReference(ref.slice(1), 10);
-  } else {
-    const named = decodeNamedCharacterReference(ref);
-    if (named === false) return match; // not a real named entity — leave verbatim
-    decoded = named;
-  }
-  // Leave `<`/`>`-producing refs ENCODED. Entity-decoded angle brackets are always
-  // inert character DATA — no renderer turns `&lt;script&gt;` into a live tag (that
-  // needs a LITERAL `<` in the source). Decoding them would only feed the tag
-  // matcher false positives and corrupt legit escaped-markup prose, with zero
-  // security gain; schemes never require `<`/`>`. (TL flag: t/2030 build refinement.)
-  if (decoded === '<' || decoded === '>') return match;
-  return decoded;
-}
+// Injected into the pure core: log the per-string oversize-input truncation via
+// pino (never the content — secrets rule). Message + fields kept identical to the
+// pre-extraction inline log so server behavior is byte-preserving.
+const onWarn: SanitizeWarn = (w) => {
+  log.security.warn(
+    { originalLength: w.originalLength, cap: w.cap },
+    'sanitizeUserText: input exceeded cap — truncated before sanitization',
+  );
+};
 
 /**
- * Decode HTML character references to a fixed point (collapses layered encodings
- * like `&amp;colon;` → `&colon;` → `:`).
- *
- * Termination: every changing pass STRICTLY SHRINKS the string. Each entity span
- * `&…;?` is ≥3 chars and decodes to ≤2 UTF-16 units — verified across all 2125
- * named entities (worst source-vs-decoded margin is +2) and true for numeric refs
- * (`&#…` ≥3 chars → 1 code point). So the loop runs at most `length` passes and
- * the cap below is UNREACHABLE in practice. We nonetheless THROW past it (never a
- * bounded value-return, which would reintroduce js/incomplete-multi-character-
- * sanitization, t/2001#6): a hit means the shrink invariant was broken by a future
- * edit, and returning a partially-decoded string could hide a live scheme.
- */
-function decodeEntitiesFixedPoint(s: string): string {
-  let out = s;
-  let prev: string;
-  const cap = out.length + 1;
-  let iter = 0;
-  do {
-    prev = out;
-    out = out.replace(ENTITY, decodeEntityRef);
-    if (++iter > cap) {
-      throw new ActionableError({
-        goal: 'Canonicalize HTML character references before XSS scheme/tag matching',
-        problem: 'Entity decode did not converge within the shrink-invariant bound — a decode pass grew or oscillated the string.',
-        location: 'contentSanitizer.ts decodeEntitiesFixedPoint',
-        nextSteps: [
-          'Confirm ENTITY only matches spans that decode to a strictly shorter string',
-          'A newly added named entity decoding to ≥3 UTF-16 units would break the bound',
-        ],
-      });
-    }
-  } while (out !== prev);
-  return out;
-}
-
-/**
- * Neutralize executable tags + dangerous URL schemes in a single string.
- *
- * t/2023 (CodeQL js/incomplete-multi-character-sanitization): a SINGLE pass is
- * bypassable because removing one match can reform another — `<scr<script>ipt>`
- * strips the inner tag and leaves `<script>`, and removing tags can concatenate
- * halves into a scheme (`java<script></script>script:` → `javascript:`). So each
- * removal is applied to a FIXED POINT: repeat `replace` until the string stops
- * changing (the canonical CodeQL-recognized remediation — the loop exits ONLY on
- * stability, never on a bound, so the result provably contains no residual match).
- *
- * Order matters: strip executable tags fully first — that both handles nested
- * tags and exposes any scheme that tag-splitting concealed — then neutralize
- * schemes. Scheme/data replacements never contain `<`, so they can't reform a
- * tag, so the tag loop need not re-run afterward.
- *
- * Termination: every changed tag-pass strictly shrinks the string (each removes
- * ≥1 tag); scheme substitutions are shrinking and idempotent after the first
- * pass — so every loop converges. No fail-closed bound is needed (an early bound
- * would let the loop return a possibly-unsanitized string, which is the very
- * defect this query flags).
- *
- * Per-match linear: the folded `[\x00-\x1F\x7F]*` classes sit between distinct
- * literals (no `X*X*` adjacency, no nested/overlapping unbounded quantifiers), so
- * the control-char fold adds no ReDoS. The tag `[^>]*` tail's O(n) per-position
- * worst-case scan (pathological no-`>` input → O(n²)) is bounded by the
- * MAX_SANITIZE_INPUT truncation in sanitizeUserText (t/2029).
- */
-function neutralize(s: string): string {
-  let out = s;
-  let prev: string;
-  // TERMINATION INVARIANT (nothing else bounds these loops — they exit ONLY on
-  // stability, `out === prev`): every replacement below MUST strictly shrink the
-  // string OR replace with an irreversible sentinel that can never re-match its
-  // own pattern. Tag removal deletes chars; `javascript:`/`vbscript:` → `blocked:`
-  // and the data-markup family → `data:blocked` are sentinels that don't re-match.
-  // A future rule that could GROW the string or oscillate would infinite-loop here.
-  do { prev = out; out = out.replace(EXECUTABLE_TAGS, ''); } while (out !== prev);
-  do { prev = out; out = out.replace(DANGEROUS_SCHEME, 'blocked:'); } while (out !== prev);
-  do { prev = out; out = out.replace(DATA_MARKUP, 'data:blocked'); } while (out !== prev);
-  return out;
-}
-
-/**
- * Sanitize a single string.
- *
- * t/2030 — decode-into-shadow, rewrite-only-on-threat. We match against an
- * entity-DECODED shadow (so `javascript&colon;` / `&#106;avascript:` are caught
- * the way a renderer would realize them), but rewrite conservatively:
- *   - decode a liberal superset of character references into `decoded`;
- *   - run the neutralizers on `decoded`;
- *   - if nothing matched (`cleaned === decoded`) the whole string is CLEAN → return
- *     it BYTE-FOR-BYTE, so a threat-free field's legit `&amp;`/`&lt;`/`&copy;`/code
- *     fences are never mangled;
- *   - only genuinely-dangerous inputs are returned in canonicalized form.
- * Granularity is whole-string, not per-match: a field that mixes a real threat with
- * benign entities returns the decoded form, so those co-located benign entities are
- * decoded too. That is directionally safe (over-decoding, never under) and round-trips
- * invisibly through the renderer (CommonMark re-escapes a bare `&` on serialization);
- * the `<`/`>` exclusion still protects escaped-markup structure even in that case.
- * This preserves the module's narrow, fail-safe charter without position-mapping
- * matches from the shadow back into the original. Design: t/2030#1, TL e/52#2.
+ * Sanitize a single string on the server: the pure core plus the t/2031 aggregate
+ * wall-time budget.
  */
 export function sanitizeUserText(s: string): string {
   // t/2031 aggregate budget: once the walk-scoped wall-time budget is spent, drop
@@ -290,23 +117,7 @@ export function sanitizeUserText(s: string): string {
     }
     return '';
   }
-  let base = s;
-  // t/2029 DoS backstop: truncate oversized input BEFORE the O(n²)-prone loops
-  // (and before entity decode, so decode is length-bounded too).
-  // Best-effort log (never the content — secrets rule) so oversized input isn't
-  // invisible to ops; logging must never break sanitization, hence the try/catch.
-  if (base.length > MAX_SANITIZE_INPUT) {
-    try {
-      log.security.warn(
-        { originalLength: base.length, cap: MAX_SANITIZE_INPUT },
-        'sanitizeUserText: input exceeded cap — truncated before sanitization',
-      );
-    } catch { /* telemetry — silent by design: this catch wraps the logger itself, so it cannot log; sanitization must proceed regardless */ }
-    base = base.slice(0, MAX_SANITIZE_INPUT);
-  }
-  const decoded = decodeEntitiesFixedPoint(base);
-  const cleaned = neutralize(decoded);
-  return cleaned === decoded ? base : cleaned;
+  return sanitizeText(s, onWarn);
 }
 
 /**

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -140,6 +140,7 @@ export default defineConfig({
       '../../../lib/flight-recorder/**/*.test.ts',
       '../../../lib/search/**/*.test.ts',
       '../../../lib/entities/**/*.test.ts',
+      '../../../lib/sanitize/**/*.test.ts',
       '../../../lib/*.test.ts',
       // translation tests excluded — depend on ai-triad-data dictionary not available in CI
     ],


### PR DESCRIPTION
## Summary
Extracts the pure XSS/sanitize logic out of the server's hardened `contentSanitizer.ts` into a shared, dependency-light `lib/sanitize/contentSanitizerCore.ts`, so the Electron main-process admin-promote path can share ONE copy. Prereq for **t/2033** (blocks it). TL-ruled design in **t/2033#6**; placement blessed in **e/53#8**; owner-extracts pattern (t/1974).

## Why
`src/main/communityReviewIO` needs `sanitizeUserText` but can't import the server module — it pulls pino via `../logger.js`, and `src/main`→`src/server` violates tsconfig.main's boundary. Extracting the pure core (no pino, no ALS) with an **injectable `onWarn`** hook is what makes it importable from main.

## Changes
- **`lib/sanitize/contentSanitizerCore.ts` (NEW)** — pure `sanitizeText(s, onWarn?)`: entity-decode canonicalization (t/2030), tag/scheme/data:markup neutralization (t/856/t/2027/t/2030), per-string `MAX_SANITIZE_INPUT` cap (t/2029). No pino, no ALS budget. `onWarn` emits only `oversize-input`. Renderer-parity decoders via static ESM; `ActionableError` runaway-guard.
- **`server/security/contentSanitizer.ts`** — thin server-only **wrapper**: pure core + the t/2031 ALS wall-time budget (server-only — defends the public HTTP surface; desktop is local-admin, self-recoverable, TL t/2033#6) + pino injected as `onWarn`. **Behavior-preserving** — the 50 pre-existing t/2027-2031 tests pass unchanged (the regression guard). `budget-exhausted` log stays in the wrapper; `oversize-input` flows through `onWarn`.
- **`lib/package.json`** — the two renderer-parity decoders as **runtime `dependencies`** (used unconditionally by the core; must survive `npm ci --omit=dev` — security-review MAJOR fixed here).
- **`vite.config.ts`** — runs the co-located lib core tests in CI (Taxonomy Editor cleared the one-line include, p/133#6; Shared Lib flagged the silent-no-run trap, p/308#2).

## Dependency placement note
The decoders live in `lib/package.json` (not root): the CI `test-electron` and `lib-lint` jobs both `npm ci` in `lib/`, so a `lib/` file resolves them from `lib/node_modules`. I confirmed lib/node_modules suffices and left the project-root manifest untouched.

## Verification
- **64 tests**: 50 server behavior-preservation (t/2027-2031, unchanged) + 14 new lib core; full suite (6084) green.
- tsc server+main, eslint (server clean; lib 0 errors), dependency-cruiser (cruises lib/sanitize), vite build — all green.
- **Adversarial security review: clean behavior-preserving extraction** — equivalence line-for-line, budget boundary intact, onWarn throw-safe, decoder parity byte-identical, no new sink/ReDoS/secrets. Its one MAJOR (dep classification) is fixed in this PR.

## Sequencing
On merge → unblocks **t/2033** (ElectronMain imports the core, injects `getGlobalRecorder` as `onWarn`, adds the `tsconfig.main` allowlist entry for `lib/sanitize`, applies the redact-to-`''` array spec). t/2032 adopts the core in its traversal-dedup fast-follow.

@Shared Lib — tagging you on the `lib/sanitize/*` + `lib/package.json` hunks (your scope). Routed to TL pre-merge (auth-surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)