### PR TITLE
fix(main): sanitize community-promote array elements + XSS parity via shared lib core (t/2033)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/communityReviewIO.test.ts
+++ b/taxonomy-editor/src/main/__tests__/communityReviewIO.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { stripSensitiveKeys } from '../communityReviewIO.js';
+
+/**
+ * t/2033 (sibling of t/2032): the desktop admin-promote path's `stripSensitiveKeys` recursed
+ * array elements straight back through itself, so array-of-strings elements hit the scalar
+ * early-return and were published to the public community blob VERBATIM — bypassing both the
+ * secret-prefix screen and XSS sanitization. Fix mirrors the server (community.ts) exactly:
+ * secret-prefix → redact to '' (array, preserve shape) / omit key (object); else the shared lib
+ * `sanitizeText` neutralizes executable tags + dangerous schemes; non-strings recurse.
+ *
+ * `communityReviewIO` has no static electron import, so the real function is exercised directly
+ * (not a replica — a replica is exactly how the array bypass shipped untested, t/2032).
+ */
+describe('stripSensitiveKeys — array-element screening (t/2033)', () => {
+  it('REGRESSION: array-of-strings XSS payload is neutralized (was published verbatim)', () => {
+    const out = stripSensitiveKeys({ tags: ['<script>alert(1)</script>', 'ok'] }) as { tags: string[] };
+    expect(out.tags[0]).not.toContain('<script>');   // executable tag stripped
+    expect(out.tags[0]).toBe('alert(1)');
+    expect(out.tags[1]).toBe('ok');                    // clean string byte-for-byte
+    expect(out.tags).toHaveLength(2);                  // array shape preserved
+  });
+
+  it('REGRESSION: array-of-strings secret-prefix value is redacted to \'\' (was leaked)', () => {
+    const out = stripSensitiveKeys({ keys: ['sk-LEAKED', 'AIzaLEAKED', 'plain'] }) as { keys: string[] };
+    expect(out.keys).toEqual(['', '', 'plain']);       // redact-to-'' FIRST, shape preserved
+  });
+
+  it('array dangerous scheme is neutralized', () => {
+    const out = stripSensitiveKeys({ links: ['javascript:alert(1)'] }) as { links: string[] };
+    expect(out.links[0]).not.toMatch(/javascript:/i);
+    expect(out.links[0]).toBe('blocked:alert(1)');
+  });
+
+  it('array non-string elements recurse (objects screened, scalars pass through)', () => {
+    const out = stripSensitiveKeys({
+      items: [{ body: '<iframe src=x>', api_key: 'sk-drop' }, 42, null],
+    }) as { items: [Record<string, unknown>, number, null] };
+    expect(out.items[0]).not.toHaveProperty('api_key'); // SENSITIVE_KEYS omitted in nested object
+    expect(out.items[0].body).not.toContain('<iframe'); // sanitized
+    expect(out.items[1]).toBe(42);
+    expect(out.items[2]).toBeNull();
+  });
+});
+
+describe('stripSensitiveKeys — object-property parity + nesting (t/2033)', () => {
+  it('object string property is XSS-sanitized (parity — was stored verbatim pre-fix)', () => {
+    // The sanitizer is deliberately narrow: it removes executable TAG MARKUP, not text content,
+    // so the `x` between the tags survives — `<script>x</script>hi` → `xhi`. The live <script>
+    // markup (the actual XSS vector) is gone; that's the security property.
+    const out = stripSensitiveKeys({ body: '<script>x</script>hi' }) as { body: string };
+    expect(out.body).toBe('xhi');
+    expect(out.body).not.toContain('<script');
+  });
+
+  it('object secret-prefix property omits the whole key (asymmetry vs array redact-to-\'\')', () => {
+    const out = stripSensitiveKeys({ leak: 'sk-SECRET', keep: 'safe' }) as Record<string, unknown>;
+    expect(out).not.toHaveProperty('leak');
+    expect(out.keep).toBe('safe');
+  });
+
+  it('SENSITIVE_KEYS are dropped', () => {
+    const out = stripSensitiveKeys({ token: 'x', password: 'y', title: 'ok' }) as Record<string, unknown>;
+    expect(out).toEqual({ title: 'ok' });
+  });
+
+  it('deep nesting (object → array → object) is fully screened', () => {
+    const out = stripSensitiveKeys({
+      outer: { tags: ['<script>bad</script>', 'sk-leak'], meta: { secret: 'z', note: 'keep' } },
+    }) as { outer: { tags: string[]; meta: Record<string, unknown> } };
+    expect(out.outer.tags).toEqual(['bad', '']);        // XSS neutralized + secret redacted
+    expect(out.outer.meta).not.toHaveProperty('secret'); // SENSITIVE_KEYS dropped at depth
+    expect(out.outer.meta.note).toBe('keep');
+  });
+
+  it('clean scalars and strings pass through unchanged', () => {
+    const out = stripSensitiveKeys({ n: 1, b: true, s: 'plain text & fine' }) as Record<string, unknown>;
+    expect(out).toEqual({ n: 1, b: true, s: 'plain text & fine' });
+  });
+});

--- a/taxonomy-editor/src/main/communityReviewIO.ts
+++ b/taxonomy-editor/src/main/communityReviewIO.ts
@@ -3,6 +3,7 @@
 
 import crypto from 'crypto';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
+import { sanitizeText, type SanitizeWarning } from '../../../lib/sanitize/contentSanitizerCore.js';
 
 let _client: CommunityReviewClient | null = null;
 
@@ -111,13 +112,51 @@ function scanSensitive(obj: unknown, found = new Set<string>()): Set<string> {
   return found;
 }
 
-function stripSensitiveKeys(obj: unknown): unknown {
+// t/2032/t/2033: single source of truth for the secret-prefix screen — applied in BOTH the
+// object and array branches of stripSensitiveKeys, so the array branch can't ship without a
+// secret screen. Kept byte-identical to the server's community.ts SECRET_PREFIX_RE (t/2032) so
+// the two copies of this promote path (both publish to the same public 'community' blob) screen
+// identically.
+const SECRET_PREFIX_RE = /^(sk-|AIza|gsk_|key-|xai-|Bearer\s)/;
+
+// Observability hook for the pure lib sanitizer (t/2033). The desktop promote path injects a
+// flight-recorder onWarn rather than importing a logger (the lib core stays logger-agnostic;
+// the server wraps it with pino). NEVER logs content (secrets rule) — only the oversize-input
+// truncation fact. A throwing hook can't break sanitization (the core guards the call).
+const onSanitizeWarn = (w: SanitizeWarning): void => {
+  getGlobalRecorder()?.record({
+    type: 'system.error', component: 'community-review-io', level: 'warn',
+    message: `sanitizeText: input exceeded cap (${w.cap}) — truncated before sanitization`,
+    data: { reason: w.reason, originalLength: w.originalLength, cap: w.cap },
+  });
+};
+
+// Exported for direct regression testing (t/2033): the test must exercise THIS function, not
+// an inline replica — a replica is exactly how the array-branch bypass shipped untested.
+export function stripSensitiveKeys(obj: unknown): unknown {
   if (obj === null || typeof obj !== 'object') return obj;
-  if (Array.isArray(obj)) return obj.map(stripSensitiveKeys);
+  if (Array.isArray(obj)) {
+    // t/2033 (sibling of t/2032): array string elements have no key to omit, so screen each in
+    // PLACE — secret-prefix FIRST (redact to '' so a `sk-…` value can't leak, preserving array
+    // shape), else neutralize executable tags/schemes via the shared lib core; non-strings recurse.
+    // The prior `obj.map(stripSensitiveKeys)` sent string elements to the scalar early-return,
+    // bypassing both the secret screen AND sanitization (the stored-XSS / secret-leak bug).
+    return obj.map((v) => {
+      if (typeof v !== 'string') return stripSensitiveKeys(v);
+      if (SECRET_PREFIX_RE.test(v)) return '';
+      return sanitizeText(v, onSanitizeWarn);
+    });
+  }
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
     if (SENSITIVE_KEYS.has(key)) continue;
-    if (typeof value === 'string' && /^(sk-|AIza|gsk_|key-|xai-|Bearer\s)/.test(value)) continue;
+    if (typeof value === 'string') {
+      // Object property: secret-prefix → omit the whole key (there IS a key to drop); else
+      // XSS-sanitize the value (t/2033 parity — this branch previously stored strings verbatim).
+      if (SECRET_PREFIX_RE.test(value)) continue;
+      result[key] = sanitizeText(value, onSanitizeWarn);
+      continue;
+    }
     result[key] = stripSensitiveKeys(value);
   }
   return result;


### PR DESCRIPTION
Closes **t/2033** (ElectronMain sibling of t/2032). **Auth-surface → holding for TL pre-merge review; auto-merge NOT armed.**

`communityReviewIO.ts` `stripSensitiveKeys` recursed array elements back through itself, so array-of-strings elements hit the scalar early-return and were promoted to the **same public `community` Azure blob** as the server **verbatim** — bypassing the secret-prefix screen and (this desktop copy never had one) XSS sanitization. Stored-XSS + secret-leak on the admin-promote path.

### Fix (TL-approved design t/2033#3/#6; adopts the t/2035 shared core)
- Import pure **`sanitizeText`** from `lib/sanitize/contentSanitizerCore` — not the server wrapper (pino + t/2031 ALS budget aren't importable from `src/main`; the aggregate-DoS budget is a server-HTTP-only concern, desktop promote is local-admin). Inject a flight-recorder **`onWarn`** for the oversize-truncation signal.
- Rewrite `stripSensitiveKeys` to mirror the server's t/2032 governing spec **byte-identically**, single `SECRET_PREFIX_RE` both branches:
  - **array** string element → secret-prefix redacted to `''` **first** (preserve shape), else `sanitizeText`, non-string recurse;
  - **object** property → secret-prefix omits the key, else `sanitizeText` the value (XSS parity — was stored verbatim).
- Export `stripSensitiveKeys` for direct regression testing (a replica test is how the array bypass shipped untested).
- Traversal-dedup across the two copies stays a **fast-follow** (TL t/2033#3), not this ticket.

### Tests / verify
`communityReviewIO.test.ts` — array XSS neutralized, array secret→`''` (shape kept), array scheme→`blocked:`, array non-string recurse, object XSS-sanitized, object secret omits key, SENSITIVE_KEYS dropped, deep object→array→object nesting, clean pass-through. **9/9; full `src/main` suite 91/91**; `tsc -p tsconfig.main.json` + eslint clean.

**Note:** main tsc/vitest need lib deps (`npm ci` in `lib/` — the t/2035 decoders); CI's `test-electron` already does this (ci.yml:172). No `tsconfig.main` change (lib core pulled in transitively under rootDir). **CodeQL is now a required gate — please confirm the CodeQL check-run is green on the head before merge (a sanitizer change can mint its own alert).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
