### PR TITLE
fix(settings): de-conflate backend selection into a 3-state reason enum — never tier-gate BYOK (t/2036)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -101,10 +101,16 @@ export const api: AppAPI = {
   deleteAllApiKeys: () => window.electronAPI.deleteAllApiKeys(),
   hasApiKey: (backend) => window.electronAPI.hasApiKey(backend),
   getAvailableBackends: async () => {
-    // Desktop has no community server; availability is local key presence.
+    // Desktop has no community server and NO tier — main-process generateText uses the
+    // user's own keys and never touches the proxy, so availability is purely local key
+    // presence. A keyless backend is therefore `no_key`, NEVER `tier_restricted`
+    // (t/2036: don't mislabel a missing key as tier-blocked, which used to disable it).
     // Backend list is the canonical exhaustive one (t/1956) — never hand-maintain here (t/1958).
     return Promise.all(
-      ALL_API_KEY_BACKENDS.map(async (id) => ({ id, available: await window.electronAPI.hasApiKey(id) })),
+      ALL_API_KEY_BACKENDS.map(async (id) => {
+        const available = await window.electronAPI.hasApiKey(id);
+        return available ? { id, available } : { id, available, reason: 'no_key' as const };
+      }),
     );
   },
   getApiKeySummary: () => window.electronAPI.getApiKeySummary(),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -171,7 +171,7 @@ export interface AppAPI {
    * presence in anonymous (BYOK) and Electron modes. Used to gate multi-provider
    * debates so speakers are only assigned to usable backends.
    */
-  getAvailableBackends: () => Promise<{ id: string; available: boolean; models?: string[]; reason?: string }[]>;
+  getAvailableBackends: () => Promise<{ id: string; available: boolean; models?: string[]; reason?: 'tier_restricted' | 'no_key' }[]>;
   getApiKeySummary: () => Promise<{ backend: string; hasKey: boolean; maskedKey: string | null }[]>;
   exportKeysForSharing: (passphrase: string) => Promise<{ dataUrl: string; payloadText: string }>;
   importKeysFromSharing: (payload: { v: number; salt: string; iv: string; data: string; tag: string }, passphrase: string) => Promise<string[]>;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -869,14 +869,23 @@ const rawApi: AppAPI = {
     return get(`/api/keys/has${backend ? `?backend=${backend}` : ''}`);
   },
   getAvailableBackends: async () => {
-    // Anonymous (BYOK) keys live in sessionStorage — the server can't see them,
-    // so derive availability locally, mirroring hasApiKey's anonymous branch.
-    if (await isAnonymous()) {
-      return ALL_API_KEY_BACKENDS.map((id) => ({ id, available: !!sessionStorage.getItem(`byok-${id}`) }));
-    }
-    const res = await get<{ backends: { id: string; available: boolean; models?: string[]; reason?: string }[] }>('/api/backends/available')
+    // The server computes the authoritative per-backend `reason` (tier_restricted vs
+    // no_key) from the caller's resolved tier — including for an anonymous caller
+    // (`/api/backends/available` has no auth gate; resolveTier('') → anonymous/free).
+    const res = await get<{ backends: { id: string; available: boolean; models?: string[]; reason?: 'tier_restricted' | 'no_key' }[] }>('/api/backends/available')
       .catch(bridgeWarn('getAvailableBackends failed', { backends: [] }));
-    return res.backends;
+    if (!(await isAnonymous())) return res.backends;
+    // Anonymous (BYOK) keys live in sessionStorage — the server can't see them, so it
+    // reports every in-tier backend as `no_key`. Overlay local key presence to flip
+    // those to available. Keep `tier_restricted` as-is: the server 403s those even with
+    // a key, so the honest unlock is signing in, not entering a key (t/2036, #3).
+    return res.backends.map((b) => {
+      if (b.reason === 'tier_restricted') return b;
+      const hasLocal = !!sessionStorage.getItem(`byok-${b.id}`);
+      return hasLocal
+        ? { id: b.id, available: true, models: b.models }
+        : { id: b.id, available: false, reason: 'no_key' as const };
+    });
   },
   getApiKeySummary: async () => {
     return ALL_API_KEY_BACKENDS.map((b) => {

--- a/taxonomy-editor/src/renderer/components/chat/NewChatDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/NewChatDialog.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2036 — NewChatDialog backend dropdown regression. Before the fix this dialog
+// FILTERED tier-unavailable backends out of the list entirely (worse than SettingsDialog's
+// disable). These assertions lock the 3-state de-conflation: every backend renders;
+// no-key is selectable "(bring your own key)"; tier-forbidden is honestly "(sign in to use)";
+// and a free-tier-pool backend stays plain (usable without a key).
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: {
+    hasApiKey: vi.fn().mockResolvedValue(false),
+    getAvailableBackends: vi.fn().mockResolvedValue([]),
+  },
+}));
+vi.mock('@bridge', () => ({ api: mockApi }));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+
+vi.mock('../../hooks/useChatStore', () => ({
+  useChatStore: () => ({ createChat: vi.fn().mockResolvedValue('chat-1'), loadChat: vi.fn() }),
+}));
+
+vi.mock('../../hooks/useTaxonomyStore', () => ({
+  useTaxonomyStore: () => ({ aiBackend: 'gemini' as const, geminiModel: 'gemini-flash' }),
+  AI_BACKENDS: [
+    { value: 'gemini', label: 'Google Gemini' },
+    { value: 'moonshot', label: 'Moonshot' },
+    { value: 'azure', label: 'Azure OpenAI' },
+  ],
+  MODELS_BY_BACKEND: {
+    gemini: [{ value: 'gemini-flash', label: 'Flash' }],
+    moonshot: [{ value: 'kimi-k2', label: 'Kimi K2' }],
+    azure: [{ value: 'gpt-4o-azure', label: 'GPT-4o (Azure)' }],
+  },
+}));
+
+let mockTier: { allowedBackends: string[] } | null = null;
+let mockIsFree = false;
+vi.mock('../../hooks/useTierInfo', () => ({
+  useTierInfo: () => ({ tier: mockTier }),
+  isFreeTier: () => mockIsFree,
+}));
+
+import { NewChatDialog } from './NewChatDialog';
+
+async function revealBackendSelect() {
+  const user = userEvent.setup();
+  render(<NewChatDialog onClose={vi.fn()} />);
+  await user.click(screen.getByLabelText(/use a different model/i));
+  // The backend select is the first combobox once the custom-model fields appear.
+  return screen.getAllByRole('combobox')[0];
+}
+
+describe('NewChatDialog backend dropdown (t/2036)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTier = null;
+    mockIsFree = false;
+    mockApi.hasApiKey.mockResolvedValue(false);
+  });
+
+  it('renders all 3 states — no filtering-out; no-key selectable, tier-restricted honest', async () => {
+    mockApi.getAvailableBackends.mockResolvedValue([
+      { id: 'gemini', available: true },                            // #1
+      { id: 'moonshot', available: false, reason: 'no_key' },       // #2
+      { id: 'azure', available: false, reason: 'tier_restricted' }, // #3
+    ]);
+    const select = await revealBackendSelect();
+    // #3 present (not filtered out) + honest + disabled
+    const azure = await within(select).findByRole('option', { name: 'Azure OpenAI (sign in to use)' });
+    expect(azure).toBeDisabled();
+    // #2 selectable BYOK
+    const moonshot = within(select).getByRole('option', { name: 'Moonshot (bring your own key)' });
+    expect(moonshot).not.toBeDisabled();
+    // #1 plain
+    expect(within(select).getByRole('option', { name: 'Google Gemini' })).not.toBeDisabled();
+  });
+
+  it('free-tier-pool backend stays plain + selectable (usable without a key)', async () => {
+    mockIsFree = true;
+    mockTier = { allowedBackends: ['gemini'] };
+    // Server reports gemini no_key (pool key isn't in keyStore), but it's free-tier usable.
+    mockApi.getAvailableBackends.mockResolvedValue([{ id: 'gemini', available: false, reason: 'no_key' }]);
+    const select = await revealBackendSelect();
+    const gemini = within(select).getByRole('option', { name: 'Google Gemini' });
+    expect(gemini).not.toBeDisabled();
+    expect(gemini.textContent).toBe('Google Gemini'); // no "(bring your own key)" suffix
+  });
+});

--- a/taxonomy-editor/src/renderer/components/chat/NewChatDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/NewChatDialog.tsx
@@ -13,6 +13,7 @@ import type { SpeakerId } from '../../types/debate';
 import type { ChatMode } from '../../types/chat';
 import { CHAT_MODE_INFO } from '../../types/chat';
 import { AI_POVERS } from '@lib/debate/types';
+import { backendSelectState, type BackendAvailabilityEntry } from '../shared/backendSelectState';
 import './NewChatDialog.css';
 
 interface NewChatDialogProps {
@@ -39,7 +40,9 @@ export function NewChatDialog({ onClose }: NewChatDialogProps) {
   const availableModels = MODELS_BY_BACKEND[selectedBackend] || [];
   const [customModel, setCustomModel] = useState<string>(globalModel);
   const [keyStatus, setKeyStatus] = useState<Record<string, boolean>>({});
-  const [tierAvailable, setTierAvailable] = useState<Set<string> | null>(null);
+  // t/2036: per-backend availability with `reason` (no_key #2 vs tier_restricted #3),
+  // replacing the tierAvailable Set that conflated no-key with tier-blocked.
+  const [availByReason, setAvailByReason] = useState<Record<string, BackendAvailabilityEntry>>({});
   const { tier: tierInfo } = useTierInfo();
   const freeTier = isFreeTier(tierInfo);
 
@@ -54,7 +57,7 @@ export function NewChatDialog({ onClose }: NewChatDialogProps) {
     };
     void check();
     void api.getAvailableBackends()
-      .then(backends => setTierAvailable(new Set(backends.filter(b => b.available).map(b => b.id))))
+      .then(backends => setAvailByReason(Object.fromEntries(backends.map(b => [b.id, { available: b.available, reason: b.reason }]))))
       .catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'new-chat-dialog', level: 'warn', message: 'Failed to load available backends', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); });
   }, []);
 
@@ -153,11 +156,21 @@ export function NewChatDialog({ onClose }: NewChatDialogProps) {
                   if (models.length > 0) setCustomModel(models[0].value);
                 }}
               >
-                {AI_BACKENDS.filter(b => !tierAvailable || tierAvailable.has(b.value)).map((b) => (
-                  <option key={b.value} value={b.value}>
-                    {b.label}{keyStatus[b.value] === false && !(freeTier && tierInfo?.allowedBackends.includes(b.value)) ? ' (no key)' : ''}
-                  </option>
-                ))}
+                {AI_BACKENDS.map((b) => {
+                  // t/2036: render every backend (no longer filter out non-tier ones).
+                  // Free-tier-pool backends are usable without a key (platform key), so
+                  // keep them plain+selectable; otherwise apply the 3-state helper
+                  // (no-key→"(bring your own key)"; tier-forbidden→disabled "(sign in to use)").
+                  const freeUsable = freeTier && !!tierInfo?.allowedBackends.includes(b.value);
+                  const state = freeUsable
+                    ? { selectable: true, suffix: '' }
+                    : backendSelectState(availByReason[b.value], keyStatus[b.value] === true);
+                  return (
+                    <option key={b.value} value={b.value} disabled={!state.selectable}>
+                      {b.label}{state.suffix}
+                    </option>
+                  );
+                })}
               </select>
               <select
                 className="new-chat-model-select"

--- a/taxonomy-editor/src/renderer/components/settings/SettingsDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/SettingsDialog.test.tsx
@@ -1,5 +1,5 @@
 ﻿import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const { mockApi } = vi.hoisted(() => ({
@@ -53,6 +53,8 @@ vi.mock('../../hooks/useTaxonomyStore', () => ({
     { value: 'openai', label: 'OpenAI' },
     { value: 'deepseek', label: 'DeepSeek' },
     { value: 'ollama', label: 'Ollama' },
+    { value: 'azure', label: 'Azure OpenAI' },
+    { value: 'moonshot', label: 'Moonshot' },
   ],
   MODELS_BY_BACKEND: {
     gemini: [
@@ -64,6 +66,8 @@ vi.mock('../../hooks/useTaxonomyStore', () => ({
     openai: [{ value: 'gpt-4o', label: 'GPT-4o' }],
     deepseek: [{ value: 'deepseek-chat', label: 'DeepSeek Chat' }],
     ollama: [{ value: 'llama3', label: 'LLaMA 3' }],
+    azure: [{ value: 'gpt-4o-azure', label: 'GPT-4o (Azure)' }],
+    moonshot: [{ value: 'kimi-k2', label: 'Kimi K2' }],
   },
   initAIModels: vi.fn().mockResolvedValue(undefined),
 }));
@@ -149,5 +153,24 @@ describe('SettingsDialog', () => {
     await user.click(screen.getByText('Save'));
     expect(mockApi.addApiKey).toHaveBeenCalledWith('AIzaSyTestKey', 'gemini');
     expect(await screen.findByText(/key saved/i)).toBeInTheDocument();
+  });
+
+  it('de-conflates the 3 backend states — has-key plain, no-key selectable BYOK, tier-restricted honest (t/2036)', async () => {
+    mockApi.getAvailableBackends.mockResolvedValueOnce([
+      { id: 'gemini', available: true },                            // #1 has key + tier-ok
+      { id: 'moonshot', available: false, reason: 'no_key' },       // #2 BYOK-permitted, no key
+      { id: 'azure', available: false, reason: 'tier_restricted' }, // #3 tier forbids BYOK
+    ]);
+    render(<SettingsDialog onClose={onClose} />);
+    const backendSelect = screen.getAllByRole('combobox')[0];
+    // #3 — restricted + honest label, and (the bug) NOT disabled-away as "(not on your tier)"
+    const azure = await within(backendSelect).findByRole('option', { name: 'Azure OpenAI (sign in to use)' });
+    expect(azure).toBeDisabled();
+    // #2 — the key regression: a keyless BYOK-permitted backend stays SELECTABLE
+    const moonshot = within(backendSelect).getByRole('option', { name: 'Moonshot (bring your own key)' });
+    expect(moonshot).not.toBeDisabled();
+    // #1 — plain, no suffix
+    const gemini = within(backendSelect).getByRole('option', { name: 'Google Gemini' });
+    expect(gemini).not.toBeDisabled();
   });
 });

--- a/taxonomy-editor/src/renderer/components/settings/SettingsDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/SettingsDialog.tsx
@@ -10,6 +10,7 @@ import type { ColorScheme, AIBackend, AIModel } from '../../hooks/useTaxonomySto
 import { AI_BACKENDS, MODELS_BY_BACKEND, initAIModels } from '../../hooks/useTaxonomyStore';
 import { KeySharingDialog } from './KeySharingDialog';
 import { useDescriptionMode, type DescriptionMode } from '../shared/DescriptionToggle';
+import { backendSelectState, type BackendAvailabilityEntry } from '../shared/backendSelectState';
 import './SettingsDialog.css';
 
 interface SettingsDialogProps {
@@ -490,7 +491,10 @@ export function SettingsDialog({ onClose }: SettingsDialogProps) {
   const [endpointInput, setEndpointInput] = useState('');
 
   const models = MODELS_BY_BACKEND[aiBackend] || [];
-  const [tierAvailable, setTierAvailable] = useState<Set<string> | null>(null);
+  // t/2036: per-backend availability keyed by id. `reason` distinguishes no_key (#2,
+  // BYOK-selectable) from tier_restricted (#3, honestly restricted) — replaces the
+  // lossy `tierAvailable` Set that conflated "no key" with "not on your tier".
+  const [availByReason, setAvailByReason] = useState<Record<string, BackendAvailabilityEntry>>({});
 
   useEffect(() => {
     void Promise.all(
@@ -501,7 +505,7 @@ export function SettingsDialog({ onClose }: SettingsDialogProps) {
     ).then((results) => setHasKey(Object.fromEntries(results)))
       .catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'settings-dialog', level: 'warn', message: 'hasApiKey check failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); });
     void api.getAvailableBackends()
-      .then(backends => setTierAvailable(new Set(backends.filter(b => b.available).map(b => b.id))))
+      .then(backends => setAvailByReason(Object.fromEntries(backends.map(b => [b.id, { available: b.available, reason: b.reason }]))))
       .catch((err) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'settings-dialog', level: 'warn', message: 'Failed to load available backends', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); });
   }, [keySuccess, keyRefreshTrigger]);
 
@@ -593,10 +597,13 @@ export function SettingsDialog({ onClose }: SettingsDialogProps) {
             onChange={(e) => setAIBackend(e.target.value as AIBackend)}
           >
             {AI_BACKENDS.map((b) => {
-              const blocked = tierAvailable && !tierAvailable.has(b.value);
+              // t/2036 3-state: has-key→plain; no-key-but-BYOK-permitted→selectable "(bring your
+              // own key)"; tier-forbidden (web anon/free)→disabled "(sign in to use)". Never
+              // disable merely for a missing key — that was the ADR-002-violating conflation.
+              const state = backendSelectState(availByReason[b.value], !!hasKey[b.value]);
               return (
-                <option key={b.value} value={b.value} disabled={!!blocked}>
-                  {b.label}{blocked ? ' (not on your tier)' : hasKey[b.value] ? '' : ' (no key)'}
+                <option key={b.value} value={b.value} disabled={!state.selectable}>
+                  {b.label}{state.suffix}
                 </option>
               );
             })}

--- a/taxonomy-editor/src/renderer/components/shared/backendSelectState.test.ts
+++ b/taxonomy-editor/src/renderer/components/shared/backendSelectState.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2036 — locks the 3-state de-conflation at the kit boundary. The original bug was
+// collapsing "no key" and "tier-forbidden" into one disabled "(not on your tier)"; these
+// assertions guarantee no-key stays SELECTABLE (BYOK) and only tier-forbidden is restricted.
+
+import { describe, it, expect } from 'vitest';
+import { backendSelectState } from './backendSelectState';
+
+describe('backendSelectState (t/2036)', () => {
+  it('#1 has key + tier-ok → selectable, plain label', () => {
+    expect(backendSelectState({ available: true }, true)).toEqual({ selectable: true, suffix: '' });
+  });
+
+  it('#2 no key but BYOK-permitted → selectable, "(bring your own key)"', () => {
+    expect(backendSelectState({ available: false, reason: 'no_key' }, false))
+      .toEqual({ selectable: true, suffix: ' (bring your own key)' });
+  });
+
+  it('#3 tier forbids BYOK → NOT selectable, "(sign in to use)"', () => {
+    expect(backendSelectState({ available: false, reason: 'tier_restricted' }, false))
+      .toEqual({ selectable: false, suffix: ' (sign in to use)' });
+  });
+
+  it('tier_restricted stays restricted even if a local key is present (server 403s it)', () => {
+    // Guards the web-anonymous trap: a stored key must NOT unlock a tier-forbidden backend.
+    expect(backendSelectState({ available: false, reason: 'tier_restricted' }, true).selectable).toBe(false);
+  });
+
+  it('missing entry (availability not loaded) → never disabled; falls back to key presence', () => {
+    // No entry + has key → plain #1; no entry + no key → BYOK prompt #2. Never blocks selection.
+    expect(backendSelectState(undefined, true)).toEqual({ selectable: true, suffix: '' });
+    expect(backendSelectState(undefined, false)).toEqual({ selectable: true, suffix: ' (bring your own key)' });
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/backendSelectState.ts
+++ b/taxonomy-editor/src/renderer/components/shared/backendSelectState.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2036 — backend-selection de-conflation. The original bug: the AI-backend
+// dropdowns collapsed a lossy `available` boolean (tier AND key) into a single
+// "(not on your tier)" state, so a backend the user simply had no key for read as
+// tier-blocked and was DISABLED — a BYOK user couldn't select it to enter a key
+// (violates ADR-002). This maps the authoritative per-backend `reason` to the three
+// real states, so the two dropdowns (SettingsDialog, NewChatDialog) stay in lockstep.
+//
+//   #1 has key + tier-ok  → selectable, plain label
+//   #2 no key, BYOK-permitted (desktop always; web byok/platform) → selectable, "(bring your own key)"
+//   #3 no key AND tier forbids BYOK (web anonymous/free) → NOT freely selectable, "(sign in to use)"
+//
+// Backend selection is never tier-gated for #1/#2 (TL ruling t/2036); #3 stays
+// honestly restricted because the server would 403 the call even with a key — the
+// unlock is signing in (→ byok tier), not entering a key (TL policy, p/56#215).
+
+/** One entry of the `getAvailableBackends()` result (bridge contract). */
+export interface BackendAvailabilityEntry {
+  available: boolean;
+  reason?: 'tier_restricted' | 'no_key';
+}
+
+export interface BackendSelectState {
+  /** false only for #3 (tier-forbidden) — never disable merely for a missing key. */
+  selectable: boolean;
+  /** Label suffix incl. leading space, or '' for the plain has-key state. */
+  suffix: string;
+}
+
+/**
+ * Resolve a backend's dropdown state from its availability entry + local key presence.
+ * `entry` may be undefined (availability not loaded / backend absent) — in that case we
+ * fall back to `hasKey` and never disable, so a load hiccup can't re-block selection.
+ */
+export function backendSelectState(
+  entry: BackendAvailabilityEntry | undefined,
+  hasKey: boolean,
+): BackendSelectState {
+  // #3 — tier forbids BYOK (server 403s regardless of a key). Honest restriction.
+  if (entry?.reason === 'tier_restricted') {
+    return { selectable: false, suffix: ' (sign in to use)' };
+  }
+  // #1 — usable (key present AND tier-ok, per the entry) or a known local key.
+  if (entry?.available || (!entry && hasKey)) {
+    return { selectable: true, suffix: '' };
+  }
+  // #2 — no key but BYOK-permitted: selectable, prompt to bring a key.
+  return { selectable: true, suffix: ' (bring your own key)' };
+}


### PR DESCRIPTION
## What

De-conflate AI-backend selection into a 3-state `reason` enum so backend **selection is never tier-gated** (ADR-002 BYOK). Fixes t/2036 (owner bug: Azure/Moonshot disabled "(not on your tier)" → a BYOK user couldn't select one to enter a key).

Option A, per TL approval (t/2036#3). Design write-up: t/2036#4.

## The 3 states (shared, tested helper)

`components/shared/backendSelectState.ts` maps the authoritative per-backend `reason` → dropdown state, keeping the two dropdowns in lockstep (the drift that caused the original conflation):

| state | condition | dropdown |
|---|---|---|
| #1 | has key + tier-ok | selectable, plain |
| #2 | no key, BYOK-permitted (desktop always; web byok/platform) | **selectable, "(bring your own key)"** |
| #3 | no key AND tier forbids BYOK (web anonymous/free) | restricted, **"(sign in to use)"** |

#3 stays honestly restricted because the server 403s it even with a key — the unlock is signing in (→ byok tier), owner-ratified policy (t/2036#4). Desktop is tierless (main-process BYOK, no proxy) → always #1/#2, never #3.

## Changes (renderer-only; no server / tier-resolution change)

- `bridge/electron-bridge.ts` — desktop emits `reason:'no_key'` (never `tier_restricted`)
- `bridge/web-bridge.ts` — anonymous branch fetches the server's authoritative tier info (`/api/backends/available` works unauthenticated) + overlays local sessionStorage keys; keeps `tier_restricted` honest
- `bridge/types.ts` — tighten `reason` to `'tier_restricted' | 'no_key'`
- `SettingsDialog.tsx` / `NewChatDialog.tsx` — option keyed off the helper; NewChatDialog no longer filters non-tier backends out; free-tier-pool backends stay plain+selectable
- tests — helper (3 states + load-fallback) + both dialogs (all states × surfaces)

Server dispatch unchanged: `byok` + `platform` already allow all backends (runtimeConfig).

## Verify (worktree off 581047f3)

- renderer / main / server **tsc: 0 errors**
- **eslint: 0 errors** (pre-existing warnings only)
- scoped vitest **16** (helper 6 + SettingsDialog + NewChatDialog) + **754** debate tests (no ripple from the anon `available` change)

## Condition 1 (load-bearing e2e) — status for your call

Deterministic + architectural proof complete: the "selectable-but-server-rejected" trap is **architecturally impossible on desktop** (tierless, no proxy — you accepted this, p/56#206/#208), so the call path is unchanged and "real call succeeds" holds by construction. The RTL dialog tests are the UI-observable proof — they assert Azure now renders as a **selectable** `<option>` (not `disabled`) with the "(bring your own key)" suffix, and tier_restricted renders disabled "(sign in to use)".

**Deviation flag (per the rule):** condition 1 asked for a live *real Azure call succeeds*; I did deterministic + architectural + RTL-DOM proof instead, because the actual paid call needs a real Azure key+endpoint (BYOK = the owner's), which I don't have in the worktree. Happy to run the live generation with an owner-provided key, or stand up the desktop app for a live UI walkthrough — your call whether either is a pre-merge gate, or the proof above suffices.
