### PR TITLE
feat(settings): surface Refresh Models refuse/warn config-guard outcome (t/2041)

### DIFF
--- a/taxonomy-editor/src/renderer/components/settings/SettingsDialog.css
+++ b/taxonomy-editor/src/renderer/components/settings/SettingsDialog.css
@@ -118,3 +118,27 @@
   text-decoration: underline;
   cursor: pointer;
 }
+
+/* Refresh Models config-guard outcome (t/2041) */
+.settings-refresh-refused {
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--warning);
+  border-radius: 4px;
+  color: var(--warning);
+  font-size: 0.82rem;
+}
+
+.settings-refresh-refused-reason {
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+}
+
+.settings-refresh-repair {
+  margin-bottom: 8px;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-style: italic;
+}

--- a/taxonomy-editor/src/renderer/components/settings/SettingsDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/SettingsDialog.test.tsx
@@ -173,4 +173,45 @@ describe('SettingsDialog', () => {
     const gemini = within(backendSelect).getByRole('option', { name: 'Google Gemini' });
     expect(gemini).not.toBeDisabled();
   });
+
+  const cleanBackends = {
+    gemini: { ok: true, count: 3 }, claude: { ok: true, count: 2 }, groq: { ok: true, count: 1 },
+    openai: { ok: true, count: 1 }, deepseek: { ok: true, count: 1 }, ollama: { ok: true, count: 0 },
+  };
+
+  it('surfaces a refused write as a warning, not a green save (t/2041)', async () => {
+    const user = userEvent.setup();
+    mockApi.refreshAIModels.mockResolvedValueOnce({
+      ...cleanBackends, totalModels: 8,
+      written: false, configWarning: 'claude default "x" has no fallbackChain',
+    });
+    render(<SettingsDialog onClose={onClose} />);
+    await user.click(screen.getByText('Refresh Models'));
+    expect(await screen.findByText(/refused the write/i)).toBeInTheDocument();
+    expect(screen.getByText(/no fallbackChain/)).toBeInTheDocument();
+    expect(screen.getByText(/ai-models\.json unchanged/i)).toBeInTheDocument();
+    expect(screen.queryByText(/saved to ai-models\.json/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a non-fatal repair note on a written success (t/2041)', async () => {
+    const user = userEvent.setup();
+    mockApi.refreshAIModels.mockResolvedValueOnce({
+      ...cleanBackends, totalModels: 8,
+      written: true, configWarning: 'pruned 1 dangling fallback target',
+    });
+    render(<SettingsDialog onClose={onClose} />);
+    await user.click(screen.getByText('Refresh Models'));
+    expect(await screen.findByText(/Repaired before saving/i)).toBeInTheDocument();
+    expect(screen.getByText(/saved to ai-models\.json/i)).toBeInTheDocument();
+    expect(screen.queryByText(/refused the write/i)).not.toBeInTheDocument();
+  });
+
+  it('shows normal success with no warning on a clean refresh (t/2041)', async () => {
+    const user = userEvent.setup();
+    render(<SettingsDialog onClose={onClose} />);
+    await user.click(screen.getByText('Refresh Models'));
+    expect(await screen.findByText(/saved to ai-models\.json/i)).toBeInTheDocument();
+    expect(screen.queryByText(/refused the write/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Repaired before saving/i)).not.toBeInTheDocument();
+  });
 });

--- a/taxonomy-editor/src/renderer/components/settings/SettingsDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/SettingsDialog.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
-import type { RefreshResult } from '@lib/electron-shared/modelDiscovery';
+import type { RefreshResult, BackendResult } from '@lib/electron-shared/modelDiscovery';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import type { ColorScheme, AIBackend, AIModel } from '../../hooks/useTaxonomyStore';
 import { AI_BACKENDS, MODELS_BY_BACKEND, initAIModels } from '../../hooks/useTaxonomyStore';
@@ -341,24 +341,52 @@ function TestKeysButton({ hasKey }: { hasKey: Record<string, boolean> }) {
   );
 }
 
+// t/2039 froze two new top-level RefreshResult fields the config-guard write path
+// returns: `written` (false ⇒ the guard refused to persist) and `configWarning`
+// (refusal reason when !written; optional non-fatal repair note when written). Read
+// them through a tolerant view so this compiles both before AND after the shared type
+// gains them — t/2041 lands first, then t/2039 (see t/2041#1). Missing `written`
+// (pre-t/2039 runtime) reads as legacy success.
+type RefreshOutcome = RefreshResult & { written?: boolean; configWarning?: string };
+
 function RefreshModelsResult({ result, error }: { result: RefreshResult | null; error: string | null }) {
+  const outcome = result as RefreshOutcome | null;
+  const refused = outcome?.written === false;
+  const repairNote = outcome && outcome.written !== false ? outcome.configWarning : undefined;
+  // Robust to non-backend top-level keys (totalModels/written/configWarning): only
+  // entries whose value is a BackendResult object render as per-backend rows, so new
+  // scalar fields never misrender as bogus "failed" backends.
+  const backendRows = outcome
+    ? Object.entries(outcome).filter(
+        (e): e is [string, BackendResult] =>
+          typeof e[1] === 'object' && e[1] !== null && 'ok' in e[1],
+      )
+    : [];
   return (
     <>
-      {result && (
+      {outcome && (
         <div className="settings-refresh-result">
-          {(Object.keys(result) as (keyof RefreshResult)[])
-            .filter((b): b is Exclude<keyof RefreshResult, 'totalModels'> => b !== 'totalModels')
-            .map((b) => {
-            const r = result[b];
-            return (
-              <div key={b} className={`settings-refresh-line ${r.ok ? '' : 'settings-refresh-warn'}`}>
-                <span className="settings-refresh-backend">{b}</span>
-                <span>{r.ok ? `${r.count} models` : r.error || 'failed'}</span>
-              </div>
-            );
-          })}
+          {refused && (
+            <div className="settings-refresh-refused" role="alert">
+              <strong>Models not saved — the config guard refused the write.</strong>
+              {outcome.configWarning && (
+                <div className="settings-refresh-refused-reason">{outcome.configWarning}</div>
+              )}
+            </div>
+          )}
+          {repairNote && (
+            <div className="settings-refresh-repair">Repaired before saving: {repairNote}</div>
+          )}
+          {backendRows.map(([b, r]) => (
+            <div key={b} className={`settings-refresh-line ${r.ok ? '' : 'settings-refresh-warn'}`}>
+              <span className="settings-refresh-backend">{b}</span>
+              <span>{r.ok ? `${r.count} models` : r.error || 'failed'}</span>
+            </div>
+          ))}
           <div className="settings-refresh-total">
-            Total: {result.totalModels} models saved to ai-models.json
+            {refused
+              ? `${outcome.totalModels} models discovered — not saved (ai-models.json unchanged)`
+              : `Total: ${outcome.totalModels} models saved to ai-models.json`}
           </div>
         </div>
       )}


### PR DESCRIPTION
UI-surfacing slice of t/2038 (TL design t/2038#1). Renders the t/2039-frozen `RefreshResult` fields `written` + `configWarning` as a 3-state outcome in `RefreshModelsResult`:

- `written === false` → warning panel with the refusal reason; drops the green "saved to ai-models.json" total (shows "discovered — not saved"), never a silent green refresh.
- `written === true && configWarning` → normal success + a non-fatal repair note.
- else → unchanged success.

The per-backend row loop now uses a runtime `BackendResult` guard instead of `Exclude<keyof RefreshResult,'totalModels'>`, so the new top-level scalar fields don't widen `result[b]` and break `.ok` (this would otherwise redden t/2039's tsc). Read through a tolerant `RefreshOutcome` view so it compiles **before and after** t/2039 extends the shared type — **t/2041 lands first** (coordinated w/ Shared Lib, p/309), missing `written` reads as legacy success.

Render-only; no bridge/IPC/shared-type change. New co-located CSS in `SettingsDialog.css` (frozen `styles.css` untouched). +3 tests (refuse / repaired-success / clean-success).

Self-cert: /trivial-change (render-only, per t/2041's own authorization). Local verify green: tsc main+server, eslint, depcruise, vite build, settings tests 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)