### PR TITLE
feat(lib): extract config validator + repair/guard the Refresh Models write path (t/2039)

### DIFF
--- a/lib/ai-config/validate.test.ts
+++ b/lib/ai-config/validate.test.ts
@@ -83,6 +83,13 @@ describe('findDanglingRefs', () => {
   it('tolerates absent optional surfaces', () => {
     expect(findDanglingRefs({ models: [], defaults: {} })).toEqual([]);
   });
+
+  it('tolerates a null tier value without throwing (typeof null === "object" guard, t/2039#3)', () => {
+    const r = cleanRegistry();
+    (r.debateTiers as Record<string, unknown>).broken = null;
+    expect(() => findDanglingRefs(r)).not.toThrow();
+    expect(findDanglingRefs(r)).toEqual([]);
+  });
 });
 
 describe('findChainlessDefaults', () => {

--- a/lib/ai-config/validate.test.ts
+++ b/lib/ai-config/validate.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment node
+
+import { describe, it, expect } from 'vitest';
+import {
+  findDanglingRefs,
+  findChainlessDefaults,
+  KNOWN_VERBATIM,
+  CHAIN_EXEMPT_BACKENDS,
+  type ValidatableRegistry,
+} from './validate.js';
+
+// A referentially-clean baseline: every referenced id resolves to a models[] entry
+// (or is KNOWN_VERBATIM), and every non-exempt default has a non-empty chain.
+function cleanRegistry(): ValidatableRegistry {
+  return {
+    models: [
+      { id: 'gemini-flash', backend: 'gemini' },
+      { id: 'gemini-pro', backend: 'gemini' },
+      { id: 'claude-opus', backend: 'claude' },
+      { id: 'llama-local', backend: 'ollama' },
+    ],
+    defaults: { gemini: 'gemini-flash', claude: 'claude-opus', ollama: 'llama-local' },
+    debateTiers: {
+      _comment: 'basic = cheap tier; advanced = strong tier',
+      basic: { gemini: 'gemini-flash' },
+      advanced: { gemini: 'gemini-pro', claude: 'claude-opus' },
+    },
+    fallbackChains: {
+      'gemini-flash': ['gemini-pro'],
+      'claude-opus': ['gemini-pro'],
+      'gemini-pro': ['gemini-flash'],
+    },
+  };
+}
+
+describe('findDanglingRefs', () => {
+  it('returns [] for a referentially-clean registry', () => {
+    expect(findDanglingRefs(cleanRegistry())).toEqual([]);
+  });
+
+  it('flags a dangling defaults value', () => {
+    const r = cleanRegistry();
+    r.defaults.claude = 'claude-ghost';
+    expect(findDanglingRefs(r)).toContain('claude-ghost');
+  });
+
+  it('flags a dangling debateTiers value', () => {
+    const r = cleanRegistry();
+    (r.debateTiers!.advanced as Record<string, string>).gemini = 'gemini-ghost';
+    expect(findDanglingRefs(r)).toContain('gemini-ghost');
+  });
+
+  it('flags a dangling fallbackChains VALUE (failover target)', () => {
+    const r = cleanRegistry();
+    r.fallbackChains!['gemini-flash'] = ['gemini-ghost'];
+    expect(findDanglingRefs(r)).toContain('gemini-ghost');
+  });
+
+  it('does NOT flag an orphan fallbackChains KEY (inert — never a selection value)', () => {
+    const r = cleanRegistry();
+    // key resolves to no model, but its VALUES all resolve → not dangling.
+    r.fallbackChains!['claude-retired'] = ['gemini-pro'];
+    expect(findDanglingRefs(r)).toEqual([]);
+  });
+
+  it('does NOT flag a KNOWN_VERBATIM id even with no models[] entry', () => {
+    const r = cleanRegistry();
+    r.defaults.deepseek = 'deepseek-chat'; // KNOWN_VERBATIM, no models[] entry
+    expect(KNOWN_VERBATIM.has('deepseek-chat')).toBe(true);
+    expect(findDanglingRefs(r)).toEqual([]);
+  });
+
+  it('skips the "_comment" key without crashing and returns sorted unique ids', () => {
+    const r = cleanRegistry();
+    r.defaults.claude = 'zeta-ghost';
+    r.fallbackChains!['gemini-flash'] = ['alpha-ghost', 'alpha-ghost'];
+    expect(findDanglingRefs(r)).toEqual(['alpha-ghost', 'zeta-ghost']); // sorted + de-duped
+  });
+
+  it('tolerates absent optional surfaces', () => {
+    expect(findDanglingRefs({ models: [], defaults: {} })).toEqual([]);
+  });
+});
+
+describe('findChainlessDefaults', () => {
+  it('returns [] when every non-exempt default has a non-empty chain', () => {
+    expect(findChainlessDefaults(cleanRegistry())).toEqual([]);
+  });
+
+  it('flags a non-exempt default whose chain is missing', () => {
+    const r = cleanRegistry();
+    delete r.fallbackChains!['claude-opus'];
+    expect(findChainlessDefaults(r)).toEqual(['claude default "claude-opus" has no fallbackChain']);
+  });
+
+  it('flags a non-exempt default whose chain is empty', () => {
+    const r = cleanRegistry();
+    r.fallbackChains!['claude-opus'] = [];
+    expect(findChainlessDefaults(r)).toEqual(['claude default "claude-opus" has no fallbackChain']);
+  });
+
+  it('does NOT flag a CHAIN_EXEMPT (ollama) default with no chain', () => {
+    const r = cleanRegistry();
+    expect(CHAIN_EXEMPT_BACKENDS.has('ollama')).toBe(true);
+    // llama-local (ollama default) has no fallbackChains entry — exempt.
+    expect(findChainlessDefaults(r)).toEqual([]);
+  });
+
+  it('returns offenders sorted', () => {
+    const r = cleanRegistry();
+    r.models.push({ id: 'gpt', backend: 'openai' });
+    r.defaults.openai = 'gpt'; // no chain → offender
+    delete r.fallbackChains!['claude-opus']; // offender
+    expect(findChainlessDefaults(r)).toEqual([
+      'claude default "claude-opus" has no fallbackChain',
+      'openai default "gpt" has no fallbackChain',
+    ]);
+  });
+});

--- a/lib/ai-config/validate.ts
+++ b/lib/ai-config/validate.ts
@@ -59,8 +59,10 @@ export function findDanglingRefs(registry: ValidatableRegistry): string[] {
   }
 
   for (const [tier, tierValue] of Object.entries(registry.debateTiers ?? {})) {
-    // Skip the "_comment" documentation key (a string, not a backend map).
-    if (tier === '_comment' || typeof tierValue !== 'object') continue;
+    // Skip the "_comment" documentation key (a string, not a backend map). The
+    // `tierValue === null` guard is load-bearing: typeof null === 'object', so a null
+    // tier would otherwise fall through to Object.values(null) and throw (t/2039#3).
+    if (tier === '_comment' || tierValue === null || typeof tierValue !== 'object') continue;
     for (const modelId of Object.values(tierValue)) {
       referenced.push(modelId);
     }

--- a/lib/ai-config/validate.ts
+++ b/lib/ai-config/validate.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * PURE ai-models.json config invariants (t/2039, extracted from
+ * lib/debate/__tests__/configInvariant.test.ts per the shared-utility rule,
+ * TL t/2038#1). No I/O, no logger — importable by BOTH the Refresh Models write
+ * path (lib/electron-shared/modelDiscovery.ts) and the CI invariant test
+ * (lib/debate), so the write-path repair/guard and the CI gate are provably the
+ * SAME code (they must never drift — the t/2038 corruption class).
+ *
+ * The registry references models by `id` in three RUNTIME-affecting surfaces:
+ * `defaults` values, `debateTiers.{tier}.{backend}` values, and `fallbackChains`
+ * string[] VALUES. A reference that resolves to no `models[]` entry is dangling;
+ * a non-exempt default with no failover chain is a silent prod-failover no-op
+ * (the t/1628 class). id-KEYED maps (contextWindows/pricing/modelCapabilities)
+ * are inert when stale and are deliberately NOT checked — same rationale as the
+ * orphan chain-KEY deviation below.
+ */
+
+/** Minimal structural shape the invariants operate on. The extended
+ *  `AIModelsConfig` (modelDiscovery.ts) and the debate test's `ModelRegistry`
+ *  are both assignable to this — no shared nominal type, no circular import. */
+export interface ValidatableRegistry {
+  models: { id: string; backend: string }[];
+  defaults: Record<string, string>;
+  /** Carries a leading "_comment" STRING key alongside the per-tier backend maps. */
+  debateTiers?: Record<string, string | Record<string, string>>;
+  fallbackChains?: Record<string, string[]>;
+}
+
+// KNOWN_VERBATIM — documented exempt friendlyIds (Gate Co-Location, t/1589):
+// 'deepseek-chat' is the one genuine case where friendlyId === real provider
+// model-id, so it legitimately has no separate `models[]` entry to resolve to.
+export const KNOWN_VERBATIM: ReadonlySet<string> = new Set<string>(['deepseek-chat']);
+
+// Backends exempt from the fallback-chain requirement (rationale co-located,
+// t/1589): 'ollama' runs a LOCAL model — there is no cloud provider to fail over
+// to, and a chain would point at a backend the user may lack keys for, defeating
+// the offline/local-only contract. Local outage is surfaced, not masked.
+export const CHAIN_EXEMPT_BACKENDS: ReadonlySet<string> = new Set<string>(['ollama']);
+
+/**
+ * Every model-id REFERENCE that resolves to no `models[]` entry, excluding
+ * KNOWN_VERBATIM. Scans selection/failover VALUES only:
+ *   - `defaults.*`
+ *   - `debateTiers.{tier}.{backend}` (skips the "_comment" string key)
+ *   - `fallbackChains` string[] VALUES
+ * A `fallbackChains` KEY is NOT checked: it is never a selection value and never a
+ * failover target, so an orphan key is inert (the documented deviation). Returns
+ * sorted unique ids; `[]` means the config is referentially clean.
+ */
+export function findDanglingRefs(registry: ValidatableRegistry): string[] {
+  const modelIds = new Set(registry.models.map((m) => m.id));
+  const referenced: string[] = [];
+
+  for (const modelId of Object.values(registry.defaults ?? {})) {
+    referenced.push(modelId);
+  }
+
+  for (const [tier, tierValue] of Object.entries(registry.debateTiers ?? {})) {
+    // Skip the "_comment" documentation key (a string, not a backend map).
+    if (tier === '_comment' || typeof tierValue !== 'object') continue;
+    for (const modelId of Object.values(tierValue)) {
+      referenced.push(modelId);
+    }
+  }
+
+  for (const chain of Object.values(registry.fallbackChains ?? {})) {
+    for (const modelId of chain) referenced.push(modelId);
+  }
+
+  return [...new Set(referenced)]
+    .filter((id) => !modelIds.has(id) && !KNOWN_VERBATIM.has(id))
+    .sort();
+}
+
+/**
+ * Every non-CHAIN_EXEMPT default whose `fallbackChains[defaultId]` is missing or
+ * empty — a live default with no failover is the t/1628 prod-failover-no-op class.
+ * Returns sorted human-readable offenders (`${backend} default "${id}" has no
+ * fallbackChain`), the exact format the CI test's inline loop produces today so
+ * the write-path guard and the test share one message. `[]` means clean.
+ */
+export function findChainlessDefaults(registry: ValidatableRegistry): string[] {
+  const offenders: string[] = [];
+  for (const [backend, modelId] of Object.entries(registry.defaults ?? {})) {
+    if (CHAIN_EXEMPT_BACKENDS.has(backend)) continue;
+    const chain = registry.fallbackChains?.[modelId];
+    if (!Array.isArray(chain) || chain.length === 0) {
+      offenders.push(`${backend} default "${modelId}" has no fallbackChain`);
+    }
+  }
+  return offenders.sort();
+}

--- a/lib/electron-shared/modelDiscovery.test.ts
+++ b/lib/electron-shared/modelDiscovery.test.ts
@@ -281,4 +281,23 @@ describe('refreshAIModels — repair + guard (t/2039)', () => {
     expect(result.gemini).toBeDefined();
     expect(result.groq).toBeDefined();
   });
+
+  it('AC-b2 (t/2039#3): REFUSES when a RESOLVING default is chain-less (guard via findChainlessDefaults)', async () => {
+    // gpt-x is in models[] (resolves, so NOT dangling) but has no fallbackChain and no other
+    // openai model to repoint to — this exercises the chainless-only refuse path at the
+    // integration layer (AC-b covers the dangling path; validate.test.ts covers detection).
+    const cfg = clone(VALID_CONFIG);
+    cfg.backends.push({ id: 'openai', label: 'OpenAI' });
+    cfg.models.push({ id: 'gpt-x', apiModelId: 'gpt-x', label: 'GPT-X', backend: 'openai' });
+    cfg.defaults.openai = 'gpt-x';
+    const original = JSON.stringify(cfg);
+    fileContent = original;
+
+    const result = await refreshAIModels({ loadApiKey: () => null, repoRoot: '/fake' });
+
+    expect(result.written).toBe(false);
+    expect(result.configWarning).toContain('gpt-x');
+    expect(result.configWarning).toContain('has no fallbackChain');
+    expect(fileContent).toBe(original); // byte-for-byte untouched
+  });
 });

--- a/lib/electron-shared/modelDiscovery.test.ts
+++ b/lib/electron-shared/modelDiscovery.test.ts
@@ -162,7 +162,12 @@ describe('curateGeminiModels', () => {
 // azure) backend, leaving defaults.zai -> zai-glm-5-2 dangling -> HTTP 1211. This test
 // is RED on the old `config.models = newModels` and GREEN after the merge fix.
 
-const BASE_CONFIG = {
+// A VALID, real-schema registry: fallbackChains keyed by MODEL-ID (as in the live
+// ai-models.json + the configInvariant gate), every default resolves, every non-exempt
+// default has a non-empty chain. The prior fixture keyed chains by backend and left
+// defaults.azure dangling — harmless to the old merge test, but the t/2039 guard now
+// correctly REFUSES such an invalid registry, so the write-path tests need a valid one.
+const VALID_CONFIG = {
   backends: [
     { id: 'gemini', label: 'Gemini' },
     { id: 'azure', label: 'Azure' },
@@ -170,17 +175,26 @@ const BASE_CONFIG = {
   ],
   models: [
     { id: 'gemini-2.5-flash', apiModelId: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', backend: 'gemini' },
+    { id: 'gemini-2.5-pro', apiModelId: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', backend: 'gemini' },
     { id: 'zai-glm-5-2', apiModelId: 'glm-5-2', label: 'GLM-5.2', backend: 'zai' },
+    { id: 'azure-gpt-5', apiModelId: 'gpt-5', label: 'Azure GPT-5', backend: 'azure' },
   ],
   defaults: { gemini: 'gemini-2.5-flash', zai: 'zai-glm-5-2', azure: 'azure-gpt-5' },
-  debateTiers: { premium: { zai: 'zai-glm-5-2' } },
-  fallbackChains: { zai: ['zai-glm-5-2', 'gemini-2.5-flash'] },
+  debateTiers: { _comment: 'basic = cheap; advanced = strong', premium: { zai: 'zai-glm-5-2' } },
+  fallbackChains: {
+    'gemini-2.5-flash': ['gemini-2.5-pro'],
+    'zai-glm-5-2': ['gemini-2.5-flash'],
+    'azure-gpt-5': ['gemini-2.5-flash'],
+  },
   lastRefreshed: null,
 };
 
-describe('refreshAIModels — merge, not replace (t/1711)', () => {
+// deep clone so each test mutates an isolated copy
+const clone = <T>(o: T): T => JSON.parse(JSON.stringify(o));
+
+describe('refreshAIModels — merge, not replace + write on clean (t/1711 / t/2039 AC-c,d)', () => {
   beforeEach(() => {
-    fileContent = JSON.stringify(BASE_CONFIG);
+    fileContent = JSON.stringify(VALID_CONFIG);
     // No key for any backend + no network: probed backends fall back to existing entries,
     // and ollama's localhost probe fails fast — no real IO. The bug reproduces regardless.
     vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('no network in test'); }));
@@ -189,20 +203,22 @@ describe('refreshAIModels — merge, not replace (t/1711)', () => {
     vi.unstubAllGlobals();
   });
 
-  it('preserves non-probed backends (zai/azure) — models, defaults, tiers, chains survive a refresh', async () => {
-    await refreshAIModels({ loadApiKey: () => null, repoRoot: '/fake' });
+  it('preserves non-probed backends (zai/azure) and writes cleanly (no repair warning)', async () => {
+    const result = await refreshAIModels({ loadApiKey: () => null, repoRoot: '/fake' });
     const saved = JSON.parse(fileContent);
 
-    // The exact failure: the zai model entry must survive (was deleted by replace).
+    // t/1711: the non-probed backend entries + their references survive the refresh.
     expect(saved.models.some((m: { id: string }) => m.id === 'zai-glm-5-2')).toBe(true);
-    // defaults.zai must remain non-dangling (points at a model that still exists).
     expect(saved.defaults.zai).toBe('zai-glm-5-2');
-    expect(saved.models.some((m: { id: string }) => m.id === saved.defaults.zai)).toBe(true);
-    // Non-probed backend registry + its curated references round-trip untouched.
     expect(saved.backends.some((b: { id: string }) => b.id === 'zai')).toBe(true);
     expect(saved.backends.some((b: { id: string }) => b.id === 'azure')).toBe(true);
     expect(saved.debateTiers.premium.zai).toBe('zai-glm-5-2');
-    expect(saved.fallbackChains.zai).toContain('zai-glm-5-2');
+    expect(saved.fallbackChains['zai-glm-5-2']).toContain('gemini-2.5-flash'); // model-id keyed
+
+    // t/2039 AC-c: clean success writes, bumps lastRefreshed, and reports no warning.
+    expect(result.written).toBe(true);
+    expect(result.configWarning).toBeUndefined();
+    expect(saved.lastRefreshed).not.toBeNull();
   });
 
   it('does not reduce the models[] count for backends not probed', async () => {
@@ -211,5 +227,58 @@ describe('refreshAIModels — merge, not replace (t/1711)', () => {
     const after = JSON.parse(fileContent).models.filter((m: { backend: string }) => m.backend === 'zai').length;
     expect(after).toBe(before);
     expect(after).toBeGreaterThan(0);
+  });
+});
+
+// ── refreshAIModels: repair pass + validate-before-write guard (t/2039) ─────────────
+describe('refreshAIModels — repair + guard (t/2039)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('no network in test'); }));
+  });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('AC-a: prunes a dangling fallbackChains target and still writes', async () => {
+    const cfg = clone(VALID_CONFIG);
+    cfg.fallbackChains['gemini-2.5-flash'] = ['gemini-phantom', 'gemini-2.5-pro']; // phantom target
+    fileContent = JSON.stringify(cfg);
+
+    const result = await refreshAIModels({ loadApiKey: () => null, repoRoot: '/fake' });
+    const saved = JSON.parse(fileContent);
+
+    expect(result.written).toBe(true);
+    expect(saved.fallbackChains['gemini-2.5-flash']).toEqual(['gemini-2.5-pro']); // phantom pruned
+    expect(result.configWarning).toMatch(/pruned/);
+    // the surviving chain is non-empty, so the gemini default is still guarded
+    expect(saved.defaults.gemini).toBe('gemini-2.5-flash');
+  });
+
+  it('repairs a dangling default by repointing to a surviving same-backend model that has a chain', async () => {
+    const cfg = clone(VALID_CONFIG);
+    cfg.defaults.gemini = 'gemini-gone'; // dangling; gemini-2.5-flash survives WITH a chain
+    fileContent = JSON.stringify(cfg);
+
+    const result = await refreshAIModels({ loadApiKey: () => null, repoRoot: '/fake' });
+    const saved = JSON.parse(fileContent);
+
+    expect(result.written).toBe(true);
+    expect(saved.defaults.gemini).toBe('gemini-2.5-flash'); // repointed to the chain-bearing model
+    expect(result.configWarning).toMatch(/repointed dangling default/);
+  });
+
+  it('AC-b: REFUSES to write an unrepairable dangling default; on-disk file byte-unchanged', async () => {
+    const cfg = clone(VALID_CONFIG);
+    cfg.backends.push({ id: 'groq', label: 'Groq' });
+    cfg.defaults.groq = 'groq-phantom'; // dangling; groq is probed but has NO models to repoint to
+    const original = JSON.stringify(cfg);
+    fileContent = original;
+
+    const result = await refreshAIModels({ loadApiKey: () => null, repoRoot: '/fake' });
+
+    expect(result.written).toBe(false);
+    expect(result.configWarning).toContain('groq-phantom');
+    expect(fileContent).toBe(original); // writeFileSync never called → byte-for-byte untouched
+    // per-backend results are still populated on refuse (discovery ran; only the write is gated)
+    expect(result.gemini).toBeDefined();
+    expect(result.groq).toBeDefined();
   });
 });

--- a/lib/electron-shared/modelDiscovery.ts
+++ b/lib/electron-shared/modelDiscovery.ts
@@ -529,7 +529,8 @@ export async function refreshAIModels(deps: ModelDiscoveryDeps): Promise<Refresh
   //    default if it resolves, else drop that entry. Skip the "_comment" string key.
   if (config.debateTiers) {
     for (const [tier, tierValue] of Object.entries(config.debateTiers)) {
-      if (tier === '_comment' || typeof tierValue !== 'object') continue;
+      // `tierValue === null` guard: typeof null === 'object' (t/2039#3 null-tier nit).
+      if (tier === '_comment' || tierValue === null || typeof tierValue !== 'object') continue;
       for (const [backend, modelId] of Object.entries(tierValue)) {
         if (resolves(modelId)) continue;
         const repaired = config.defaults[backend];
@@ -563,6 +564,16 @@ export async function refreshAIModels(deps: ModelDiscoveryDeps): Promise<Refresh
     result.configWarning =
       `Refused to write ai-models.json — the refreshed registry is invalid (${reasons.join(' | ')}). The existing file is unchanged.`;
     console.warn(`[ModelDiscovery] REFUSED write: ${result.configWarning}`);
+    // t/2039#3: a refused write is a t/2038 corruption-class event — surface it in the
+    // flight recorder too (beyond console + the RefreshResult field) so a diagnostics
+    // dump captures which refs would have broken. Lists only ids/backends, no secrets.
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'model-discovery-refresh',
+      level: 'warn',
+      message: result.configWarning,
+      data: { dangling, chainless },
+    });
     return result;
   }
 

--- a/lib/electron-shared/modelDiscovery.ts
+++ b/lib/electron-shared/modelDiscovery.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { ActionableError } from '../debate/errors.js';
 import { getGlobalRecorder } from '../flight-recorder/index.js';
+import { findDanglingRefs, findChainlessDefaults, KNOWN_VERBATIM, CHAIN_EXEMPT_BACKENDS } from '../ai-config/validate.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -16,6 +17,13 @@ export interface AIModelsConfig {
   backends: { id: string; label: string }[];
   models: ModelEntry[];
   defaults: Record<string, string>;
+  // Runtime-affecting model-id reference surfaces. Previously omitted from this
+  // type — they survived only by JSON round-trip through load/saveModelConfig.
+  // Made type-visible (t/2039) so the refresh repair pass + guard can operate on
+  // them. `debateTiers` carries a leading "_comment" string key alongside the
+  // per-tier backend maps.
+  debateTiers?: Record<string, string | Record<string, string>>;
+  fallbackChains?: Record<string, string[]>;
   lastRefreshed: string | null;
 }
 
@@ -33,6 +41,14 @@ export interface RefreshResult {
   deepseek: BackendResult;
   ollama:   BackendResult;
   totalModels: number;
+  // t/2039 validate-before-write guard outcome (consumed by the Settings panel,
+  // t/2041). `written` is false iff the guard REFUSED to persist because the
+  // repaired registry would still be invalid — in that case ai-models.json is
+  // left byte-untouched. `configWarning` is present iff there is something to
+  // report: the refusal reason when !written, or a non-fatal note when repairs
+  // were applied on the successful-write path.
+  written: boolean;
+  configWarning?: string;
 }
 
 export interface ModelDiscoveryDeps {
@@ -451,6 +467,7 @@ export async function refreshAIModels(deps: ModelDiscoveryDeps): Promise<Refresh
     deepseek: { ok: false, count: 0 },
     ollama:   { ok: false, count: 0 },
     totalModels: 0,
+    written: false,
   };
 
   const existingClaude = config.models.filter(m => m.backend === 'claude');
@@ -471,20 +488,92 @@ export async function refreshAIModels(deps: ModelDiscoveryDeps): Promise<Refresh
   const probed = new Set<string>(ALL_BACKENDS);
   const preserved = config.models.filter(m => !probed.has(m.backend));
   config.models = [...preserved, ...newModels];
-  config.lastRefreshed = new Date().toISOString();
+  // ── Repair pass (t/2039) ──────────────────────────────────────────────────────
+  // Extend the merge repair from defaults-only to ALL runtime model-id reference
+  // surfaces, on the merged in-memory config, BEFORE the validate-before-write guard.
+  const resolves = (id: string): boolean =>
+    config.models.some(m => m.id === id) || KNOWN_VERBATIM.has(id);
+  const repairs: string[] = [];
 
-  // Repoint only genuinely dangling defaults, checked against the full merged set (not
-  // just the re-probed models) so a surviving non-probed backend's default is never
-  // falsely rewritten.
+  // 1. fallbackChains VALUES: prune failover targets that no longer resolve. A dead
+  //    target is already a no-op, so pruning is strictly a repair (KNOWN_VERBATIM kept).
+  if (config.fallbackChains) {
+    for (const [key, chain] of Object.entries(config.fallbackChains)) {
+      const kept = chain.filter(resolves);
+      if (kept.length !== chain.length) {
+        config.fallbackChains[key] = kept;
+        repairs.push(`pruned ${chain.length - kept.length} dangling fallbackChains["${key}"] target(s)`);
+      }
+    }
+  }
+
+  // 2. defaults: repoint a dangling default to a surviving same-backend model that
+  //    ITSELF has a non-empty chain (chain-exempt backend → any surviving same-backend
+  //    model). Never silently repoint to a chain-less model — that just relocates the
+  //    invariant break; the guard below refuses instead. Checked against the full merged
+  //    set so a surviving non-probed backend's default is never falsely rewritten.
   for (const [backend, defaultId] of Object.entries(config.defaults)) {
-    if (!config.models.some(m => m.id === defaultId)) {
-      const first = config.models.find(m => m.backend === backend);
-      if (first) config.defaults[backend] = first.id;
+    if (resolves(defaultId)) continue;
+    const candidates = config.models.filter(m => m.backend === backend);
+    const pick = CHAIN_EXEMPT_BACKENDS.has(backend)
+      ? candidates[0]
+      : candidates.find(m => (config.fallbackChains?.[m.id]?.length ?? 0) > 0);
+    if (pick) {
+      config.defaults[backend] = pick.id;
+      repairs.push(`repointed dangling default["${backend}"] -> ${pick.id}`);
+    }
+    // else: leave dangling — the guard refuses the write below.
+  }
+
+  // 3. debateTiers VALUES: repoint a dangling {tier}.{backend} to the repaired backend
+  //    default if it resolves, else drop that entry. Skip the "_comment" string key.
+  if (config.debateTiers) {
+    for (const [tier, tierValue] of Object.entries(config.debateTiers)) {
+      if (tier === '_comment' || typeof tierValue !== 'object') continue;
+      for (const [backend, modelId] of Object.entries(tierValue)) {
+        if (resolves(modelId)) continue;
+        const repaired = config.defaults[backend];
+        if (repaired && resolves(repaired)) {
+          tierValue[backend] = repaired;
+          repairs.push(`repointed dangling debateTiers.${tier}.${backend} -> ${repaired}`);
+        } else {
+          delete tierValue[backend];
+          repairs.push(`dropped dangling debateTiers.${tier}.${backend}`);
+        }
+      }
     }
   }
 
   result.totalModels = config.models.length;
+
+  // ── Validate-before-write guard (t/2039) ───────────────────────────────────────
+  // Run the invariants IN-PROCESS on the repaired registry (TL t/2038#1: the pure
+  // invariant fns, NOT a shell-out to the 6-gate verify:config runner). If anything
+  // still dangles or a live non-exempt default is chain-less, REFUSE to write — leave
+  // ai-models.json byte-untouched and report why. Never persist a known-invalid
+  // registry (the t/2038 corruption class). Per-backend results above are already
+  // populated (discovery ran) so a refuse still reports "discovered, not saved".
+  const dangling = findDanglingRefs(config);
+  const chainless = findChainlessDefaults(config);
+  if (dangling.length > 0 || chainless.length > 0) {
+    const reasons: string[] = [];
+    if (dangling.length > 0) reasons.push(`dangling refs: ${dangling.join(', ')}`);
+    if (chainless.length > 0) reasons.push(chainless.join('; '));
+    result.written = false;
+    result.configWarning =
+      `Refused to write ai-models.json — the refreshed registry is invalid (${reasons.join(' | ')}). The existing file is unchanged.`;
+    console.warn(`[ModelDiscovery] REFUSED write: ${result.configWarning}`);
+    return result;
+  }
+
+  // Clean (or fully repaired): persist. Bump lastRefreshed only on the write path so a
+  // refused refresh leaves the on-disk timestamp untouched too.
+  config.lastRefreshed = new Date().toISOString();
   saveModelConfig(deps.repoRoot, config);
+  result.written = true;
+  if (repairs.length > 0) {
+    result.configWarning = `Refresh repaired config before writing: ${repairs.join('; ')}.`;
+  }
   console.log(`[ModelDiscovery] Saved ${newModels.length} models to ai-models.json`);
 
   return result;

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -141,6 +141,7 @@ export default defineConfig({
       '../../../lib/search/**/*.test.ts',
       '../../../lib/entities/**/*.test.ts',
       '../../../lib/sanitize/**/*.test.ts',
+      '../../../lib/ai-config/**/*.test.ts',
       '../../../lib/*.test.ts',
       // translation tests excluded — depend on ai-triad-data dictionary not available in CI
     ],


### PR DESCRIPTION
Core fix for **t/2038** (TL design **t/2038#1**; detailed design **t/2039#1**). Refresh Models could persist an `ai-models.json` with dangling `fallbackChains`/`defaults`/`debateTiers` refs when a probed backend dropped a model → reds `configInvariant` / silent prod-failover no-op (the t/1628/t/2038 class).

## What
- **NEW `lib/ai-config/validate.ts`** — pure `findDanglingRefs` + `findChainlessDefaults` (+ `KNOWN_VERBATIM`/`CHAIN_EXEMPT_BACKENDS`), extracted from `configInvariant.test.ts` so the write path and the CI gate share ONE copy (shared-utility rule). No I/O/logger. + co-located unit tests.
- **`modelDiscovery.ts`** — `AIModelsConfig` now type-visibly carries `fallbackChains` + `debateTiers` (were round-trip-only). `refreshAIModels` extends the merge repair to ALL runtime surfaces: prune dangling `fallbackChains` values; repoint a dangling default only to a **chain-bearing** same-backend model (never silently to a chain-less one); repoint/drop dangling `debateTiers` values. Then a **validate-before-write guard** runs the invariants in-process and **REFUSES to write** (leaves `ai-models.json` byte-untouched) on any residual break. Per TL: in-process invariants, not a shell-out to the 6-gate `verify:config` runner.
- **`RefreshResult`** gains `written: boolean` + `configWarning?: string` (frozen for the Settings panel t/2041 + DebateTool dedup t/2040).
- **`vite.config.ts`** — add `lib/ai-config` to the vitest `test.include` (self-cert-cleared by Taxonomy Editor, p/10#81; the `lib/*.test.ts` catch-all doesn't match subdirs).

## Sequencing (consumer-first, by necessity)
Extending the shared `RefreshResult` with two top-level fields breaks `SettingsDialog`'s `Exclude<keyof…>` backend-loop at **tsc**. So **t/2041 landed first** (#290, `bb617477`) with a type-tolerant loop; this branch is rebased on top of it, so test-electron is green from the start. Frozen shape validated by both consumers (DebateTool p/64#27, Settings p/309#3/#9).

## Verification
- vitest: `validate` **13/13**; `modelDiscovery` **16/16** — prune-and-write, repoint-dangling-default, **refuse-and-file-byte-unchanged**, clean-write, + t/1711 merge preserved.
- `tsc -p tsconfig.main.json` clean. Renderer tsc adds **0** new errors (the 7 `mcp-server.ts` errors are a pre-existing local `@modelcontextprotocol/sdk` install gap — identical 7 on origin/main HEAD~1, absent on CI where the ceiling is 0).

## Deviation flag (per the Deviation Rule)
Replaced the existing t/1711 test's `BASE_CONFIG` (which keyed `fallbackChains` by **backend** and left `defaults.azure` dangling) with a `VALID_CONFIG` (real **model-id-keyed** schema, all defaults resolve + have chains). Why: the new guard correctly REFUSES an invalid registry, so the write-path tests need a valid fixture. The t/1711 merge property (non-probed zai/azure survive) is preserved and now asserted against a valid write.

## Routing
Novel write-path + shared-type logic → **Quality review against t/2038#1** (not self-cert; no pattern playbook fits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
