### PR TITLE
prompt(voice): add literal-accuracy style constraints to VOICE AUTHENTICITY block (t/2044)

### DIFF
--- a/lib/debate/prompts/shared-instructions.ts
+++ b/lib/debate/prompts/shared-instructions.ts
@@ -67,7 +67,13 @@ VOICE AUTHENTICITY:
 - Concessions move the debate forward — make them freely when the evidence warrants it.
   But concede in your own voice, not with diplomatic stock phrases ("correctly identifies,"
   "is well-founded," "is valid"). Show what accepting the point costs you and where it
-  leads next.`;
+  leads next.
+- Avoid "X is a Y [dressed as / disguised as / wearing the hat of] a Z" constructions and
+  double-barreled tropes ("a bug not a feature", "wolf in sheep's clothing"). No cinematic
+  metaphors or performative flair.
+- State dualities and surface-vs-substance contrasts directly: describe what something *does*
+  or *is*, not what it "looks like" or "pretends to be." Prefer literal, mechanical accuracy
+  over literary punchiness.`;
 
 // Original MUST_CORE_BEHAVIORS (~1,400 tokens) and MUST_EXTENDED (~350 tokens)
 // compressed into the block above (~300 tokens). See t/295 for rationale.


### PR DESCRIPTION
## Summary
- Adds 2 compressed bullets to the `VOICE AUTHENTICITY` block in `MUST_CORE_BEHAVIORS` (`shared-instructions.ts`) covering all four owner-requested style rules:
  1. Avoid "X dressed-as/disguised-as a Z" constructions and double-barreled tropes
  2. State surface-vs-substance contrasts literally; prefer mechanical accuracy over literary punchiness
- `allInstructions()` injects `MUST_CORE_BEHAVIORS` first into every speaker turn (opening/turn/cross-respond) — one insertion covers all debater output
- Synthesis/moderator paths not touched (constraints target debater rhetorical voice)

## Self-cert
Self-certifying under /trivial-change — +6 lines, single scope, no new API, no interface/schema/data-model change.

## Test plan
- [x] `npx vitest run prompts.test.ts` — 164 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)