### PR TITLE
fix(debate): type framing_choices as {frame,why}[] (t/2043)

### DIFF
--- a/lib/debate/types/pipeline.ts
+++ b/lib/debate/types/pipeline.ts
@@ -165,7 +165,7 @@ export interface OpeningPlanWorkProduct {
   strategic_goal: string;
   core_thesis: string;
   argument_structure: { point: string; evidence: string; taxonomy_anchor: string }[];
-  framing_choices: string;
+  framing_choices: { frame: string; why: string }[];
   anticipated_challenges: string[];
   target_nodes?: string[];
 }


### PR DESCRIPTION
## Summary
- `OpeningPlanWorkProduct.framing_choices` was declared `string` but the PLAN stage prompt produces `{frame: string; why: string}[]`
- Corrects the type to match the actual runtime shape already present in all debate outputs
- Closes the type gap before t/2042 frame-survival metric work begins

## Self-cert
Self-certifying under /trivial-change.
Change: correct `framing_choices` type declaration to match prompt schema
Files: `lib/debate/types/pipeline.ts`
Lines changed: 1 addition, 1 deletion
Verify gate: 2842 tests passed at e8076b20
Deviations: interface field change, but grep confirms zero field-wise consumers today

## Test plan
- [x] `npx vitest run` — 114 files, 2842 tests, all pass
- [x] grep confirms no code reads `framing_choices` field-wise (only JSON serialization path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)