### PR TITLE
fix(deploy): revert runtime base :2026-07-30 → :2026-07-20 (P1 t/2047)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,6 +128,11 @@ updates:
     ignore:
       - dependency-name: node
         update-types: [version-update:semver-major]
+      # ai-triad-base HELD (t/2047): the 2026-07-30 bump (0b33fc18) crash-looped prod
+      # (readiness regression, full init then 503→SIGTERM). Do NOT auto-bump until the
+      # base regression is fixed AND a docker-run/GET-/health pre-deploy smoke gate
+      # exists to catch runtime crashes before traffic (t/2047 gaps #1/#4).
+      - dependency-name: "jpsnover/ai-triad-base"
 
   - package-ecosystem: docker
     directory: /deploy/azure

--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -69,7 +69,12 @@ COPY taxonomy-editor/package.json taxonomy-editor/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
 
 # ── Stage 3: Runtime ──
-FROM ghcr.io/jpsnover/ai-triad-base:2026-07-30 AS runtime
+# Base HELD at :2026-07-20 — reverts Dependabot bump 0b33fc18 (:2026-07-20 → :2026-07-30).
+# The :2026-07-30 base broke the container readiness path: the app inits fully, then
+# readiness returns 503 → SIGTERM → crash-loop → P1 prod outage (t/2047). :2026-07-20 is
+# the known-good gemini base now serving prod. Do NOT bump until Docker fixes the base
+# regression AND a docker-run + GET /health pre-deploy smoke gate exists (t/2047 gaps #1/#4).
+FROM ghcr.io/jpsnover/ai-triad-base:2026-07-20 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Taxonomy Editor"


### PR DESCRIPTION
Immediate roll-forward-safe fix for the P1 (t/2047): the 2026-07-30 base bump (0b33fc18) crash-looped prod (readiness 503 after full init → SIGTERM). Pins runtime base back to known-good :2026-07-20 + holds ai-triad-base in Dependabot until the base regression is fixed + a docker-run/health pre-deploy smoke exists. Docker owns the base diff.