### PR TITLE
fix(docker): pin base node to exact patch 22.23.1 — no silent minor bumps (t/2047)

### DIFF
--- a/deploy/azure/Dockerfile.base
+++ b/deploy/azure/Dockerfile.base
@@ -14,7 +14,13 @@
 #
 # The app Dockerfile (taxonomy-editor/Dockerfile) uses this as its runtime base.
 
-FROM node:22-bookworm-slim
+# Node PINNED to an exact patch (not the floating `22-bookworm-slim`). A floating
+# minor let a routine base rebuild silently ship node 22.23.1 -> 22.23.2, whose
+# undici 6.28.0 / TLS session-reuse change broke the github-api fetch -> /healthz
+# 503 -> P1 prod crash-loop (t/2047). Pinning makes every node bump a deliberate,
+# reviewable PR. RE-BUMP to 22.23.2+ only after the github-api fetch is hardened
+# under undici 6.28.0 (Server Storage, t/2053) — see that ticket before bumping.
+FROM node:22.23.1-bookworm-slim
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Research — base image with Node 22 and baked ONNX embedding model"


### PR DESCRIPTION
## What
Pin `deploy/azure/Dockerfile.base` from floating `FROM node:22-bookworm-slim` to exact `node:22.23.1-bookworm-slim`.

## Why (t/2047 P1 root cause)
A floating minor let a routine base rebuild silently advance node **22.23.1 → 22.23.2**. 22.23.2 (security release) bumped **undici → 6.28.0** + changed **TLS session reuse**, breaking the github-api `fetch()` data load → `/tmp/taxonomy-cache` never populated → `/healthz` 503 → prod crash-loop. Diagnosis: t/2047#6. Pinning makes every node bump a deliberate, reviewable PR (gate-gap #4).

## Re-bump gate (co-located at the FROM line)
Do NOT bump to 22.23.2+ until the github-api fetch is hardened under undici 6.28.0 — **Server Storage, t/2053**.

## Impact
Forward-looking only — changes what the NEXT base build resolves node to. No prod change on merge (prod already on base :2026-07-20 / node 22.23.1 via #297).

🤖 Generated with [Claude Code](https://claude.com/claude-code)