### PR TITLE
fix(debate): load edges on-demand before node creation in applyReflectionProposal (t/2055)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
@@ -967,6 +967,43 @@ describe('Synthesis slice: propose_new apply (t/1773, ruling B)', () => {
     expect(useDebateStore.getState().newItemProposalStatus['accelerationist#0']).toBeUndefined();
   });
 
+  it('resumed debate (edges never lazy-loaded): loads edges on demand, then persists node + edges (t/2055 AC1)', async () => {
+    mockTaxonomyState.saveError = null;
+    mockTaxonomyState.accelerationist.nodes = [{ id: 'acc-B-001' }];
+    mockTaxonomyState.edgesFile = null; // resumed debate w/ no new turns: neither lazy-load trigger fired
+    // loadEdges populates the file on demand, mirroring the real lazy load.
+    mockTaxonomyState.loadEdges.mockImplementationOnce(async () => { mockTaxonomyState.edgesFile = { edges: [] }; });
+    useDebateStore.setState({ reflections: makeProposalReflections() as any, newItemProposalStatus: {}, activeDebateId: 'debate-1' });
+
+    const result = await useDebateStore.getState().applyReflectionProposal('accelerationist', 0);
+
+    expect(mockTaxonomyState.loadEdges).toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: true, createdNodeId: 'new-node-id' });
+    expect(mockTaxonomyState.createPovNode).toHaveBeenCalledWith('accelerationist', 'Beliefs');
+    const edgeCall = vi.mocked(useTaxonomyStore.setState).mock.calls
+      .map(c => c[0] as { edgesFile?: { edges: unknown[] } })
+      .find(arg => arg && arg.edgesFile);
+    expect(edgeCall!.edgesFile!.edges).toHaveLength(1);
+    expect(useDebateStore.getState().newItemProposalStatus['accelerationist#0']).toBe('approved');
+  });
+
+  it('load failure leaves NO partial node — guard runs before node creation (t/2055 AC3)', async () => {
+    mockTaxonomyState.saveError = null;
+    mockTaxonomyState.accelerationist.nodes = [{ id: 'acc-B-001' }];
+    mockTaxonomyState.edgesFile = null; // loadEdges (default no-op mock) fails to populate it
+    useDebateStore.setState({ reflections: makeProposalReflections() as any, newItemProposalStatus: {}, activeDebateId: 'debate-1' });
+
+    const result = await useDebateStore.getState().applyReflectionProposal('accelerationist', 0);
+
+    expect(mockTaxonomyState.loadEdges).toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Edges file not loaded');
+    // Guard bailed BEFORE createProposalNode → no node created, no save, nothing approved.
+    expect(mockTaxonomyState.createPovNode).not.toHaveBeenCalled();
+    expect(mockTaxonomyState.save).not.toHaveBeenCalled();
+    expect(useDebateStore.getState().newItemProposalStatus['accelerationist#0']).toBeUndefined();
+  });
+
   it('dismissReflectionProposal marks the proposal dismissed without touching the taxonomy', () => {
     useDebateStore.setState({ reflections: makeProposalReflections() as any, newItemProposalStatus: {} });
 

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
@@ -856,6 +856,22 @@ export const createDebateReflectionSlice: StateCreator<DebateStore, [], [], Deba
       return { ok: false, error: 'All proposed edge targets no longer exist — cannot create an unconnected node.' };
     }
 
+    // t/2055: the edges file MUST be loaded before we create the node. loadEdges() is
+    // lazy — triggered on turn generation (debatePhaseSlice) or the Related Edges panel —
+    // so a RESUMED debate opened straight to reflections (no new turns) never triggered it:
+    // edgesFile stayed null and the proposal's edges were silently dropped AFTER the node
+    // was already created. Load it here and bail BEFORE createProposalNode, so a load
+    // failure never leaves a node persisted without its edges (AC3).
+    let currentEdgesFile = useTaxonomyStore.getState().edgesFile;
+    if (!currentEdgesFile) {
+      await useTaxonomyStore.getState().loadEdges();
+      currentEdgesFile = useTaxonomyStore.getState().edgesFile;
+    }
+    if (!currentEdgesFile) {
+      getGlobalRecorder()?.record({ type: 'state.error', component: 'reflection-proposal', level: 'error', message: 'applyReflectionProposal.result', data: { ok: false, error: 'edges file not loaded', pover, proposalIndex } });
+      return { ok: false, error: 'Edges file not loaded — cannot persist proposed edges.' };
+    }
+
     const createResult = await createProposalNode(povKey, proposal, taxStore, get, pover, proposalIndex);
     if (!createResult.ok) return { ok: false, error: createResult.error };
     const newId = createResult.nodeId;
@@ -864,11 +880,7 @@ export const createDebateReflectionSlice: StateCreator<DebateStore, [], [], Deba
     // endpoint (new_node_role). Persist them together with the node in ONE save() call — both
     // the pov file (marked dirty by createPovNode/updatePovNode) and the edges file are
     // written in the same save, so there is never an orphaned node on disk (t/1725 AC2).
-    const currentEdgesFile = useTaxonomyStore.getState().edgesFile;
-    if (!currentEdgesFile) {
-      getGlobalRecorder()?.record({ type: 'state.error', component: 'reflection-proposal', level: 'error', message: 'applyReflectionProposal.result', data: { ok: false, error: 'edges file not loaded', pover, proposalIndex } });
-      return { ok: false, error: 'Edges file not loaded — cannot persist proposed edges.' };
-    }
+    // `currentEdgesFile` was loaded + null-checked above, before node creation (t/2055).
     const newEdges: Edge[] = liveEdges.map(pe => {
       const confidence = typeof pe.confidence === 'number' ? pe.confidence : 0.7;
       return {


### PR DESCRIPTION
## What
Resumed-debate reflection edge-drop fix (t/2055, filed by Diagnostics with FR evidence).

## Root cause
`loadEdges()` is lazy (turn generation / Related Edges panel only). A **resumed** debate opened straight to Post-Debate Reflections never triggered it → `edgesFile` stayed null → the hard guard in `applyReflectionProposal` bailed **after** the node was created, silently dropping the proposal's edges with no retry.

## Fix
Move the edges guard **before** `createProposalNode` and make it an **eager load** (null → `loadEdges()` → re-check). Fixes the drop (loads on demand) and guarantees no partial node when edges can't load (AC3). Post-creation guard removed; the loaded/null-checked ref is reused for the atomic node+edges save.

## Tests (debateSlices.test.ts)
- Resumed debate: edges lazy-load then node + edge persist (AC1)
- Load failure: no `createPovNode`, no `save`, not approved — no partial node (AC3)

## Verify (worktree off 2c7bdf10)
renderer tsc 0/0 · eslint 0 errors (`applyReflectionProposal` complexity 18→19, a pre-existing over-ceiling warning — no new warning) · useDebateStore vitest 210/210.

## Self-cert
Single-file correctness fix reusing the established lazy `loadEdges` pattern; no new interfaces / data-model change. Diagnostics-filed (not TL); self-certified per the trivial/pattern-following meta-rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)