### PR TITLE
fix(main): stop masking a DirectML GPU-OOM behind a sentence-transformers message (t/2057)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/embeddingErrors.test.ts
+++ b/taxonomy-editor/src/main/__tests__/embeddingErrors.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { buildEmbeddingFailureError, DML_OOM_RE } from '../embeddingErrors.js';
+import { ActionableError } from '../../../../lib/debate/errors.js';
+
+/**
+ * t/2057: an embedding failure caused by a DirectML GPU out-of-memory used to surface a
+ * misleading "sentence-transformers is missing / pip install" message, because the IPC handlers
+ * appended the Python diagnosis to EVERY failure unconditionally. `buildEmbeddingFailureError`
+ * now leads with the real GPU cause on an OOM and keeps the Python-diagnosis behavior otherwise.
+ * `diagnose` is injected here so the test never spawns a Python subprocess.
+ */
+const DIAG = 'FAKE-PY-DIAGNOSIS';
+const diag = (): string => DIAG;
+
+// The real onnxruntime DML OOM string (FR flight-recorder-2026-07-31T18-10-25, seq 179/234).
+const DML_OOM_MSG =
+  'Error: Non-zero status code returned while running Add node. 8007000E Not enough memory resources are available';
+
+describe('buildEmbeddingFailureError — DirectML OOM (t/2057)', () => {
+  it('leads with the GPU OOM cause, NOT the Python diagnosis', () => {
+    const e = buildEmbeddingFailureError('Update embeddings', 'loc', 'Embedding update failed', new Error(DML_OOM_MSG), diag);
+    expect(e).toBeInstanceOf(ActionableError);
+    expect(e.problem).toMatch(/^DirectML \(GPU\) execution provider ran out of GPU memory/);
+    expect(e.problem).toContain('8007000E');                 // the real cause is surfaced
+    expect(e.problem).toContain(`also unavailable: ${DIAG}`); // Python status demoted to secondary
+    // The FIRST next step must not send the dev to pip-install (the bug being fixed).
+    expect(e.nextSteps[0]).not.toMatch(/pip.*sentence-transformers/i);
+    expect(e.nextSteps[0]).toMatch(/GPU|VRAM/);
+  });
+
+  it('matches the OOM on each known HRESULT / phrasing', () => {
+    for (const m of ['8007000E', 'E_OUTOFMEMORY', 'Not enough memory resources are available']) {
+      expect(DML_OOM_RE.test(m)).toBe(true);
+      const e = buildEmbeddingFailureError('g', 'loc', 'prefix', new Error(`onnx: ${m}`), diag);
+      expect(e.problem).toMatch(/ran out of GPU memory/);
+    }
+  });
+});
+
+describe('buildEmbeddingFailureError — non-OOM failure keeps Python-diagnosis behavior (t/2057)', () => {
+  it('uses the problem prefix + appends the Python diagnosis, with Python next steps', () => {
+    const e = buildEmbeddingFailureError('Compute query embedding', 'loc', 'Query embedding failed', new Error('boom'), diag);
+    expect(e.problem).toBe(`Query embedding failed: boom. ${DIAG}`);
+    expect(e.problem).not.toMatch(/GPU memory/);
+    expect(e.nextSteps[0]).toMatch(/Python.*PATH/i);
+    expect(e.nextSteps.some(s => /pip install sentence-transformers/.test(s))).toBe(true);
+  });
+
+  it('handles a non-Error thrown value', () => {
+    const e = buildEmbeddingFailureError('g', 'loc', 'Prefix', 'string failure', diag);
+    expect(e.problem).toBe(`Prefix: string failure. ${DIAG}`);
+  });
+});

--- a/taxonomy-editor/src/main/embeddingErrors.ts
+++ b/taxonomy-editor/src/main/embeddingErrors.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Embedding-failure error assembly (t/2057). Pure, electron-free (imports only ActionableError
+// + the Python diagnostic) so it is directly unit-testable without mocking electron/embeddings.
+// Used by the embedding IPC handlers in ipc/aiHandlers.ts.
+
+import { ActionableError } from '../../../lib/debate/errors.js';
+import { diagnosePythonEmbeddings } from './diagnosePython.js';
+
+// A DirectML (GPU) execution-provider out-of-memory: onnxruntime surfaces HRESULT 8007000E /
+// E_OUTOFMEMORY ("Not enough memory resources are available") when the DML EP exhausts GPU
+// memory during inference. This is a DISTINCT failure from a missing Python sentence-transformers
+// fallback — the handlers previously appended diagnosePythonEmbeddings() to EVERY embedding
+// failure unconditionally, so a GPU OOM surfaced a misleading "install sentence-transformers"
+// message that sent devs down the wrong path (t/2057).
+export const DML_OOM_RE = /8007000E|E_OUTOFMEMORY|not enough memory/i;
+
+/**
+ * Build the surfaced ActionableError for an embedding-path failure (t/2057).
+ *
+ * On a DirectML GPU OOM, lead with the real GPU cause and demote the Python-fallback status to a
+ * secondary clause; otherwise keep the prior Python-diagnosis behavior byte-for-byte. `diagnose`
+ * is injectable so tests need not spawn Python subprocesses (default = the real probe).
+ *
+ * NOTE (t/2058): this only fixes the error MESSAGE. Actually recovering from a GPU OOM by
+ * retrying on the CPU execution provider lives in lib/embeddings/onnxEmbedding.ts (Shared Lib).
+ */
+export function buildEmbeddingFailureError(
+  goal: string,
+  location: string,
+  problemPrefix: string,
+  err: unknown,
+  diagnose: () => string = diagnosePythonEmbeddings,
+): ActionableError {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (DML_OOM_RE.test(msg)) {
+    return new ActionableError({
+      goal,
+      problem: `DirectML (GPU) execution provider ran out of GPU memory (${msg.trim()}). `
+        + `Python sentence-transformers fallback also unavailable: ${diagnose()}`,
+      location,
+      nextSteps: [
+        'Close other GPU-intensive applications to free VRAM, then retry',
+        'Automatic CPU-provider fallback on a GPU OOM is tracked in t/2058 — until it lands, restarting the app may select the CPU provider',
+        'Or install Python sentence-transformers (pip3 install sentence-transformers) for a CPU-based fallback',
+      ],
+    });
+  }
+  return new ActionableError({
+    goal,
+    problem: `${problemPrefix}: ${msg}. ${diagnose()}`,
+    location,
+    nextSteps: [
+      'Verify Python is installed and accessible on PATH',
+      'Run "pip install sentence-transformers" to install the embedding model',
+      'Check the console log for detailed Python diagnostics',
+    ],
+  });
+}

--- a/taxonomy-editor/src/main/ipc/aiHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/aiHandlers.ts
@@ -13,10 +13,10 @@ import { PROJECT_ROOT, getDataRootPath } from '../fileIO.js';
 import { computeEmbeddings, computeQueryEmbedding, generateText, generateTextWithSearch, generateChatStream, updateNodeEmbeddings, classifyNli, setDebateTemperature, getEmbeddingInfo } from '../embeddings.js';
 import type { ChatMessage, NodeEmbeddingInput, NliPair } from '../embeddings.js';
 import { refreshAIModels } from '../modelDiscovery.js';
-import { diagnosePythonEmbeddings } from '../diagnosePython.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { DEFAULT_TEMPERATURE } from '../../../../lib/ai-client/index.js';
+import { buildEmbeddingFailureError } from '../embeddingErrors.js';
 
 export function registerAiHandlers(): void {
   ipcMain.handle('load-ai-models', () => {
@@ -55,19 +55,13 @@ export function registerAiHandlers(): void {
         message: 'Operation failed',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error('[IPC] compute-embeddings failed:', msg);
-      const diagnosis = diagnosePythonEmbeddings();
-      throw new ActionableError({
-        goal: 'Compute text embeddings for taxonomy nodes',
-        problem: `Embedding computation failed: ${msg}. ${diagnosis}`,
-        location: 'ipcHandlers.computeEmbeddings',
-        nextSteps: [
-          'Verify Python is installed and accessible on PATH',
-          'Run "pip install sentence-transformers" to install the embedding model',
-          'Check the console log for detailed Python diagnostics',
-        ],
-      });
+      console.error('[IPC] compute-embeddings failed:', err instanceof Error ? err.message : String(err));
+      throw buildEmbeddingFailureError(
+        'Compute text embeddings for taxonomy nodes',
+        'ipcHandlers.computeEmbeddings',
+        'Embedding computation failed',
+        err,
+      );
     }
   });
 
@@ -82,19 +76,13 @@ export function registerAiHandlers(): void {
         message: 'Operation failed',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error('[IPC] compute-query-embedding failed:', msg);
-      const diagnosis = diagnosePythonEmbeddings();
-      throw new ActionableError({
-        goal: 'Compute embedding for a search query',
-        problem: `Query embedding failed: ${msg}. ${diagnosis}`,
-        location: 'ipcHandlers.computeQueryEmbedding',
-        nextSteps: [
-          'Verify Python is installed and accessible on PATH',
-          'Run "pip install sentence-transformers" to install the embedding model',
-          'Check the console log for detailed Python diagnostics',
-        ],
-      });
+      console.error('[IPC] compute-query-embedding failed:', err instanceof Error ? err.message : String(err));
+      throw buildEmbeddingFailureError(
+        'Compute embedding for a search query',
+        'ipcHandlers.computeQueryEmbedding',
+        'Query embedding failed',
+        err,
+      );
     }
   });
 
@@ -109,19 +97,13 @@ export function registerAiHandlers(): void {
         message: 'Operation failed',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error('[IPC] update-node-embeddings failed:', msg);
-      const diagnosis = diagnosePythonEmbeddings();
-      throw new ActionableError({
-        goal: `Update embeddings for ${nodes.length} taxonomy node(s)`,
-        problem: `Embedding update failed: ${msg}. ${diagnosis}`,
-        location: 'ipcHandlers.updateNodeEmbeddings',
-        nextSteps: [
-          'Verify Python is installed and accessible on PATH',
-          'Run "pip install sentence-transformers" to install the embedding model',
-          'Check the console log for detailed Python diagnostics',
-        ],
-      });
+      console.error('[IPC] update-node-embeddings failed:', err instanceof Error ? err.message : String(err));
+      throw buildEmbeddingFailureError(
+        `Update embeddings for ${nodes.length} taxonomy node(s)`,
+        'ipcHandlers.updateNodeEmbeddings',
+        'Embedding update failed',
+        err,
+      );
     }
   });
 


### PR DESCRIPTION
Fixes t/2057 (Diagnostics). The three embedding IPC handlers in `aiHandlers.ts` appended `diagnosePythonEmbeddings()` ("…sentence-transformers is missing / pip install") to EVERY failure unconditionally, so a DirectML GPU out-of-memory (`8007000E`/`E_OUTOFMEMORY`) surfaced a misleading Python-centric error. Extracted the error assembly to a pure, electron-free `embeddingErrors.ts`: on a DML OOM it leads with the real GPU cause + GPU next-steps and demotes the Python status to a secondary clause (matching the ticket's item-2 wording); non-OOM failures keep prior behavior byte-for-byte. Item 3 (CPU-EP auto-retry) is the real recovery and lives in `lib/embeddings/onnxEmbedding.ts` → filed as **t/2058** (Shared Lib). Tests: `embeddingErrors.test.ts` 4/4 (OOM leads with GPU/not pip; each HRESULT phrasing; non-OOM unchanged; non-Error throw); full `src/main` 95/95; tsc-main + eslint clean. Self-cert `/add-test`. Triage in t/2057#1.