### PR TITLE
feat(lib/sanitize): shared stripSensitiveKeys traversal (t/2037)

### DIFF
--- a/lib/sanitize/stripSensitiveKeys.test.ts
+++ b/lib/sanitize/stripSensitiveKeys.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment node
+
+import { describe, it, expect, vi } from 'vitest';
+import { stripSensitiveKeys, SENSITIVE_KEYS, SECRET_PREFIX_RE } from './stripSensitiveKeys.js';
+
+// Marker sanitizer: proves the injected fn ran on a given string (and only surviving ones).
+const tag = (s: string): string => `S(${s})`;
+
+describe('stripSensitiveKeys', () => {
+  it('drops SENSITIVE_KEYS entries wholesale (and sanitizes survivors)', () => {
+    const out = stripSensitiveKeys(
+      { keep: 'x', api_key: 'anything', token: 't', _internal: { a: 1 } },
+      tag,
+    );
+    expect(out).toEqual({ keep: 'S(x)' });
+  });
+
+  it('object branch: skips secret-prefixed string VALUES entirely (never kept, never sanitized)', () => {
+    const out = stripSensitiveKeys({ a: 'sk-live-xyz', b: 'AIzaFoo', c: 'normal' }, tag);
+    expect(out).toEqual({ c: 'S(normal)' }); // a + b dropped by SECRET_PREFIX_RE
+  });
+
+  it('array branch: redacts secret-prefixed elements to "" and sanitizes the rest in place', () => {
+    const out = stripSensitiveKeys(['sk-abc', 'hello', 'Bearer tok'], tag);
+    expect(out).toEqual(['', 'S(hello)', '']); // shape preserved; secrets blanked, not dropped
+  });
+
+  it('array branch: non-string elements recurse with the sanitize fn threaded', () => {
+    const out = stripSensitiveKeys([{ x: 'y', secret: 's' }], tag);
+    expect(out).toEqual([{ x: 'S(y)' }]);
+  });
+
+  it('recurses into nested objects, threading the sanitize fn', () => {
+    const out = stripSensitiveKeys({ outer: { inner: 'v', password: 'p' } }, tag);
+    expect(out).toEqual({ outer: { inner: 'S(v)' } });
+  });
+
+  it('passes scalars / null through untouched (no sanitize call)', () => {
+    const sanitize = vi.fn((s: string) => s);
+    expect(stripSensitiveKeys(42, sanitize)).toBe(42);
+    expect(stripSensitiveKeys(null, sanitize)).toBeNull();
+    expect(sanitize).not.toHaveBeenCalled();
+  });
+
+  it('invokes the injected sanitize fn for each surviving string (object + array)', () => {
+    const sanitize = vi.fn((s: string) => s.toUpperCase());
+    stripSensitiveKeys({ a: 'x', arr: ['y'] }, sanitize);
+    expect(sanitize).toHaveBeenCalledWith('x');
+    expect(sanitize).toHaveBeenCalledWith('y');
+  });
+
+  it('exposes the frozen parity-anchor constants', () => {
+    expect(SENSITIVE_KEYS.has('api_key')).toBe(true);
+    expect(SENSITIVE_KEYS.has('diagnostics_state')).toBe(true);
+    expect(SENSITIVE_KEYS.size).toBe(19); // drift guard — a dropped/added key trips this
+    expect(SECRET_PREFIX_RE.test('sk-abc')).toBe(true);
+    expect(SECRET_PREFIX_RE.test('AIzaXYZ')).toBe(true);
+    expect(SECRET_PREFIX_RE.test('Bearer tok')).toBe(true);
+    expect(SECRET_PREFIX_RE.test('normal-text')).toBe(false);
+  });
+});

--- a/lib/sanitize/stripSensitiveKeys.ts
+++ b/lib/sanitize/stripSensitiveKeys.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * PURE secret-strip + sanitize TRAVERSAL for the community-promote path (t/2037,
+ * extracted from the byte-identical copies in server/community/community.ts (t/2032)
+ * and main/communityReviewIO.ts (t/2033) per the owner-extract / consumers-adopt rule).
+ *
+ * The KEY SET (`SENSITIVE_KEYS`) and the secret-prefix screen (`SECRET_PREFIX_RE`) were
+ * verified byte-identical across both copies before sharing (t/2037 parity check); the
+ * only per-transport difference was the sanitize call, so the traversal takes the
+ * `sanitize` fn as a parameter — the server passes its pino+ALS-budget `sanitizeUserText`
+ * (keeping `withSanitizeBudget` OUTSIDE this helper — the ALS budget is a server-HTTP-only
+ * concern, t/2033#6), the desktop passes the pure `sanitizeText` bound to its
+ * flight-recorder `onWarn`. No logger, no ALS, no transport coupling.
+ */
+
+/** Keys whose VALUES are dropped wholesale from the public community blob. */
+export const SENSITIVE_KEYS: ReadonlySet<string> = new Set<string>([
+  'api_key', 'apiKey', 'api_keys', 'apiKeys',
+  'secret', 'token', 'password', 'credential', 'credentials',
+  'authorization', 'auth_token', 'access_token', 'refresh_token',
+  'private_key', 'privateKey',
+  'flight_recorder', 'debug', '_internal', 'diagnostics_state',
+]);
+
+/**
+ * Single source of truth for the secret-prefix screen — used by BOTH the object and
+ * array branches so the array branch can never ship without a secret screen (the
+ * two-branches-one-updated drift the t/2032 fix closed). Kept byte-identical to the
+ * original community.ts copy.
+ */
+export const SECRET_PREFIX_RE = /^(sk-|AIza|gsk_|key-|xai-|Bearer\s)/;
+
+/**
+ * Recursively strip sensitive keys + secret-prefixed strings and sanitize the rest,
+ * before a community record is served publicly.
+ *
+ * @param obj      the value to screen (object / array / scalar).
+ * @param sanitize per-transport text sanitizer applied to surviving string values
+ *   (server: pino+ALS `sanitizeUserText`; desktop: pure `sanitizeText` + FR `onWarn`).
+ *
+ * Array string elements have no key to omit, so each is screened in place —
+ * secret-prefix FIRST (redacted to '' so a `sk-…` value can't leak while the array
+ * shape is preserved), else sanitized; non-strings recurse. Object entries drop any
+ * SENSITIVE_KEYS key, skip secret-prefixed string values entirely, sanitize surviving
+ * strings, and recurse into nested objects/arrays.
+ */
+export function stripSensitiveKeys(obj: unknown, sanitize: (s: string) => string): unknown {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) {
+    return obj.map((v) => {
+      if (typeof v !== 'string') return stripSensitiveKeys(v, sanitize);
+      if (SECRET_PREFIX_RE.test(v)) return '';
+      return sanitize(v);
+    });
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    if (SENSITIVE_KEYS.has(key)) continue;
+    if (typeof value === 'string') {
+      if (SECRET_PREFIX_RE.test(value)) continue;
+      result[key] = sanitize(value);
+      continue;
+    }
+    result[key] = stripSensitiveKeys(value, sanitize);
+  }
+  return result;
+}


### PR DESCRIPTION
Low-pri drift-guard fast-follow to t/2032 + t/2033. Extracts the byte-identical secret-strip + sanitize traversal (in `server/community/community.ts` + `main/communityReviewIO.ts`) into one shared `lib/sanitize/stripSensitiveKeys.ts` (owner-extract / consumers-adopt, t/1974 pattern; self-cert — pure extraction, no behavior change).

## Parity verified before sharing (t/1929 drift lesson)
- `SENSITIVE_KEYS` — byte-identical, **19 keys** (same order) in both copies.
- `SECRET_PREFIX_RE` — identical (`^(sk-|AIza|gsk_|key-|xai-|Bearer\s)`).
- Traversal logic identical; **sole difference = the sanitize call** → injected as `sanitize: (s) => string`, so the server keeps pino+ALS `sanitizeUserText` (`withSanitizeBudget` stays OUTSIDE — server-HTTP-only, t/2033#6) and the desktop keeps pure `sanitizeText` + FR `onWarn`.

## Scope
**Pure additive** — this PR adds the shared module + test only; it imports nothing and nothing imports it yet, so it can't affect consumers. **Consumer adoption is separate**, in each owner's scope (Server Community `community.ts`; ElectronMain `communityReviewIO.ts`) — their existing t/2032/t/2033 regression tests must stay green. Pinging both to adopt.

## Verification
vitest **8/8** (SENSITIVE_KEYS drop, object/array secret-prefix screen, nested recursion, injected-fn invocation, constant drift-guard); module tsc clean. `lib/sanitize/**/*.test.ts` already in the vitest include (t/2035).

🤖 Generated with [Claude Code](https://claude.com/claude-code)