### PR TITLE
fix(deploy): TAXONOMY_CACHE_DIR=AI_TRIAD_DATA_ROOT in container (t/2061 Part A)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -80,8 +80,14 @@ LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-rese
 LABEL org.opencontainers.image.description="AI Triad Taxonomy Editor"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Cache dir created at runtime by the app (GitHubAPIBackend)
+# Cache dir created at runtime by the app (GitHubAPIBackend).
+# TAXONOMY_CACHE_DIR MUST match AI_TRIAD_DATA_ROOT (t/2061): config.ts's cacheDir
+# defaults to ~/.cache/taxonomy (=/root/.cache/taxonomy in-container) when unset,
+# while getDataRoot() uses AI_TRIAD_DATA_ROOT — the mismatch makes toRepoPath()'s
+# startsWith(cacheDir) check fail, so isDataAvailable() is always false → /healthz
+# 503 → crash-loop (the P1 latent readiness bug, t/2047). Keep these two in sync.
 ENV AI_TRIAD_DATA_ROOT=/tmp/taxonomy-cache
+ENV TAXONOMY_CACHE_DIR=/tmp/taxonomy-cache
 ENV PORT=7862
 ENV NODE_ENV=production
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
Part A of the t/2061 readiness fix (the node-agnostic :07-20 crash-loop the t/2048 smoke caught). Container left TAXONOMY_CACHE_DIR unset → cacheDir defaulted to /root/.cache/taxonomy → toRepoPath prefix mismatch → isDataAvailable() always false → /healthz 503. Pins the cache dir to the data root. Part C (fileIO surfacing) landed; Part B (ServerAPI config.ts fallback) is the recurrence guard. Analysis: t/2061#1.