### PR TITLE
fix(storage): surface isDataAvailable failures at error level (t/2061)

### DIFF
--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -167,6 +167,16 @@ export async function isDataAvailable(): Promise<boolean> {
   try {
     const files = await backend.listDirectory(taxDir);
     const hasData = files.some(f => f.endsWith('.json') && f !== 'embeddings.json' && f !== 'edges.json');
+    if (!hasData) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'file-io',
+        level: 'error',
+        message: `isDataAvailable: no taxonomy JSON found in ${taxDir} (${files.length} entries) — check TAXONOMY_CACHE_DIR vs AI_TRIAD_DATA_ROOT alignment`,
+        data: { taxDir, fileCount: files.length, sample: files.slice(0, 5) },
+      });
+      log.server.error({ taxDir, fileCount: files.length }, 'isDataAvailable: no taxonomy JSON — check TAXONOMY_CACHE_DIR vs AI_TRIAD_DATA_ROOT');
+    }
     log.server.debug({ taxDir, fileCount: files.length, hasData }, 'isDataAvailable check');
     return hasData;
   } catch (err) {
@@ -177,7 +187,7 @@ export async function isDataAvailable(): Promise<boolean> {
       message: 'Operation failed',
       error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
     });
-    log.server.debug({ taxDir, err: String(err) }, 'isDataAvailable error');
+    log.server.error({ taxDir, err: String(err) }, 'isDataAvailable error');
     return false;
   }
 }


### PR DESCRIPTION
## Summary

- Promotes `isDataAvailable` catch log from `debug` → `error` level
- Adds error-level flight-recorder event + pino log when `hasData === false` (no-exception path), with `taxDir`, `fileCount`, and 5-entry sample to diagnose path mismatches at a glance

Root cause of t/2061: Dockerfile sets `AI_TRIAD_DATA_ROOT=/tmp/taxonomy-cache` but not `TAXONOMY_CACHE_DIR`, so `cacheDir` defaults to `/root/.cache/taxonomy`. `toRepoPath()` can't strip the prefix → `listDirectory` always returns empty → `isDataAvailable` returns false silently. This PR is the observability slice; path fixes in `config.ts` (ServerAPI) and `Dockerfile` (DevOps) are routed separately.

## Test plan
- [ ] `npx tsc -p tsconfig.server.json --noEmit` passes
- [ ] `npx vitest run src/server/__tests__/` passes
- [ ] Container with mismatched env: `/api/data/available=false` now produces error-level log with path info

🤖 Generated with [Claude Code](https://claude.com/claude-code)