### PR TITLE
fix(server): CACHE_DIR falls back to AI_TRIAD_DATA_ROOT before homedir (t/2061 Part B)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/configCacheDir.test.ts
+++ b/taxonomy-editor/src/server/__tests__/configCacheDir.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment node
+//
+// t/2061 — CACHE_DIR fallback chain. Root cause of the empty-data prod bug: the
+// container image sets AI_TRIAD_DATA_ROOT (=/tmp/taxonomy-cache) but NOT
+// TAXONOMY_CACHE_DIR, so CACHE_DIR fell straight through to the ~/.cache/taxonomy
+// homedir default and diverged from where the data actually lived — toRepoPath()
+// then couldn't strip the prefix, listDirectory returned empty, isDataAvailable was
+// always false. The fix inserts AI_TRIAD_DATA_ROOT as the middle fallback so the
+// cache dir tracks the same data root getDataRoot() resolves.
+//
+// CACHE_DIR is a module-level const resolved from process.env at import time, so each
+// case resets the module registry and re-imports under a fresh env.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
+
+describe('CACHE_DIR fallback chain (t/2061)', () => {
+  const orig = {
+    cache: process.env.TAXONOMY_CACHE_DIR,
+    dataRoot: process.env.AI_TRIAD_DATA_ROOT,
+  };
+
+  beforeEach(() => { vi.resetModules(); });
+
+  afterEach(() => {
+    restore('TAXONOMY_CACHE_DIR', orig.cache);
+    restore('AI_TRIAD_DATA_ROOT', orig.dataRoot);
+  });
+
+  function restore(key: string, value: string | undefined): void {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+
+  async function loadCacheDir(): Promise<string> {
+    return (await import('../config.js')).CACHE_DIR;
+  }
+
+  it('prefers TAXONOMY_CACHE_DIR when it is set (even if AI_TRIAD_DATA_ROOT is too)', async () => {
+    process.env.TAXONOMY_CACHE_DIR = '/explicit/cache';
+    process.env.AI_TRIAD_DATA_ROOT = '/data/root';
+    expect(await loadCacheDir()).toBe('/explicit/cache');
+  });
+
+  it('falls back to AI_TRIAD_DATA_ROOT when TAXONOMY_CACHE_DIR is unset (the t/2061 fix)', async () => {
+    delete process.env.TAXONOMY_CACHE_DIR;
+    process.env.AI_TRIAD_DATA_ROOT = '/tmp/taxonomy-cache';
+    // Pre-fix this returned ~/.cache/taxonomy, diverging from the data root.
+    expect(await loadCacheDir()).toBe('/tmp/taxonomy-cache');
+  });
+
+  it('falls back to the user-private homedir cache when neither env var is set', async () => {
+    delete process.env.TAXONOMY_CACHE_DIR;
+    delete process.env.AI_TRIAD_DATA_ROOT;
+    // The security-relevant default (not world-writable /tmp) is preserved.
+    expect(await loadCacheDir()).toBe(path.join(os.homedir(), '.cache', 'taxonomy'));
+  });
+});

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -298,10 +298,18 @@ export const STORAGE_MODE: StorageMode =
     ? process.env.STORAGE_MODE
     : (process.env.NODE_ENV === 'production' ? 'github-api' : 'filesystem');
 
-// Default to a user-private cache dir (not world-writable /tmp) to avoid
-// symlink-race vulnerabilities (CodeQL js/insecure-temporary-file).
-// Production always sets TAXONOMY_CACHE_DIR via environment.
-export const CACHE_DIR = process.env.TAXONOMY_CACHE_DIR || path.join(os.homedir(), '.cache', 'taxonomy');
+// t/2061: fall back to AI_TRIAD_DATA_ROOT (the same data root getDataRoot() uses)
+// before the homedir default. The container sets AI_TRIAD_DATA_ROOT but not
+// TAXONOMY_CACHE_DIR, so CACHE_DIR was defaulting to ~/.cache/taxonomy while the
+// data lived at AI_TRIAD_DATA_ROOT — toRepoPath() then couldn't strip the prefix,
+// listDirectory returned empty, and isDataAvailable was always false. Keying the
+// cache off the data root keeps the two aligned even if the Dockerfile drifts.
+// The final homedir default stays a user-private dir (not world-writable /tmp) to
+// avoid symlink-race vulns (CodeQL js/insecure-temporary-file); AI_TRIAD_DATA_ROOT
+// is an explicit operator-set env var (already resolved at line 80), not a
+// hardcoded tmp default, so this fallback does not reintroduce that concern.
+export const CACHE_DIR =
+  process.env.TAXONOMY_CACHE_DIR || process.env.AI_TRIAD_DATA_ROOT || path.join(os.homedir(), '.cache', 'taxonomy');
 
 // ── Server settings ──
 


### PR DESCRIPTION
## t/2061 Part B — ServerAPI (config.ts core-layer)

**Root cause (Server Storage triage, t/2061#1):** the container image sets `AI_TRIAD_DATA_ROOT` but not `TAXONOMY_CACHE_DIR`, so `CACHE_DIR` fell through to the `~/.cache/taxonomy` homedir default and diverged from where the data actually lived. `toRepoPath()` then couldn't strip the prefix → `listDirectory` returned empty → `isDataAvailable` was always false.

**Fix:** insert `AI_TRIAD_DATA_ROOT` (the same data root `getDataRoot()` resolves at config.ts:80) as the middle fallback:
```
CACHE_DIR = TAXONOMY_CACHE_DIR || AI_TRIAD_DATA_ROOT || ~/.cache/taxonomy
```
So the cache dir tracks the data root even if the Dockerfile drifts. Defense-in-depth complementing **Part A** (#307, Dockerfile sets `TAXONOMY_CACHE_DIR`) and **Part C** (fileIO.ts log, landed).

**Security note:** the homedir default stays a user-private dir (not world-writable `/tmp`), so the CodeQL `js/insecure-temporary-file` posture is unchanged — `AI_TRIAD_DATA_ROOT` is an explicit operator-set env var (already read at config.ts:80), not a hardcoded tmp default.

**Regression test** (`configCacheDir.test.ts`) pins all three tiers: explicit `TAXONOMY_CACHE_DIR` wins; `AI_TRIAD_DATA_ROOT` used when it's unset (the bug); homedir when neither is set.

**Verify (local):** configCacheDir 3/3 · tsc server 0 · eslint 0. Self-merge on green CI + CodeQL (now a required gate, t/2025). Refs t/2061.