### PR TITLE
feat(main): updateNodeEmbeddings reports staleNodeIds (t/2060 slice-2)

### DIFF
--- a/taxonomy-editor/src/main/embeddings.ts
+++ b/taxonomy-editor/src/main/embeddings.ts
@@ -241,24 +241,55 @@ async function embedItems(items: { id: string; text: string }[]): Promise<Record
   });
 }
 
-export async function updateNodeEmbeddings(nodes: NodeEmbeddingInput[]): Promise<void> {
-  if (nodes.length === 0) return;
+/**
+ * Re-embed a set of nodes and update embeddings.json.
+ *
+ * Returns `{ staleNodeIds }` — the requested nodes whose embedding could NOT be refreshed this
+ * call (empty = full success). The renderer surfaces a non-blocking "embeddings stale" warning
+ * on any non-empty result so a failed embedding update can never masquerade as a clean save
+ * (t/2060, the false-success blocker; contract TL-approved t/2060#4). A DirectML GPU OOM in the
+ * embed pass no longer throws away the whole update — the affected nodes surface in staleNodeIds
+ * instead, and successfully-embedded nodes are still persisted (partial success).
+ */
+export async function updateNodeEmbeddings(nodes: NodeEmbeddingInput[]): Promise<{ staleNodeIds: string[] }> {
+  if (nodes.length === 0) return { staleNodeIds: [] };
 
   const filePath = io.getEmbeddingsPath();
   const items = nodes.map(n => ({ id: n.id, text: n.text }));
   console.log(`[embeddings] Updating ${nodes.length} node embeddings...`);
 
-  // Try ONNX native batch, fall back to Python subprocess (shared helper).
-  const vectors = await embedItems(items);
+  // Primary embeddings. A failure here (e.g. a DirectML GPU OOM, t/2060) must NOT throw away the
+  // whole update, or the renderer can't tell which nodes went stale — leave the failed ids out of
+  // `vectors` so they surface in staleNodeIds below, and record the failure (ADR-003).
+  let vectors: Record<string, number[]> = {};
+  try {
+    vectors = await embedItems(items);
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'embeddings', level: 'error',
+      message: 'updateNodeEmbeddings: embedding pass failed — affected nodes left stale',
+      data: { requested: nodes.length },
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+  }
 
-  // Generate exclusion vectors for nodes that have exclusionText
+  // Exclusion vectors are a SECONDARY signal — a failure here doesn't make a node's primary
+  // embedding stale, so it never contributes to staleNodeIds; skip + log (warn) and continue.
   const exclItems = nodes
     .filter(n => n.exclusionText)
     .map(n => ({ id: n.id, text: n.exclusionText! }));
   let exclVectors: Record<string, number[]> = {};
   if (exclItems.length > 0) {
     console.log(`[embeddings] Generating ${exclItems.length} exclusion vectors...`);
-    exclVectors = await embedItems(exclItems);
+    try {
+      exclVectors = await embedItems(exclItems);
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'embeddings', level: 'warn',
+        message: 'updateNodeEmbeddings: exclusion embedding pass failed — exclusion vectors skipped (primary embeddings unaffected)',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+    }
   }
 
   // Read existing embeddings.json (fresh, not from cache)
@@ -277,8 +308,10 @@ export async function updateNodeEmbeddings(nodes: NodeEmbeddingInput[]): Promise
     };
   }
 
-  // Merge new vectors (with dimension validation)
+  // Merge new vectors (with dimension validation); track which requested nodes actually got a
+  // fresh vector persisted this call.
   const expectedDim = data.dimension || 384;
+  const written = new Set<string>();
   for (const node of nodes) {
     if (vectors[node.id]) {
       const vec = vectors[node.id];
@@ -295,16 +328,31 @@ export async function updateNodeEmbeddings(nodes: NodeEmbeddingInput[]): Promise
         vector: vec,
         exclusion_vector: (exclVec && exclVec.length === expectedDim) ? exclVec : null,
       };
+      written.add(node.id);
     }
   }
-  data.node_count = Object.keys(data.nodes).length;
 
-  // Write back
-  fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
-  console.log(`[embeddings] Updated embeddings.json (${data.node_count} total nodes)`);
+  // Only persist when we actually refreshed ≥1 vector — a total embed failure (all stale) must
+  // NOT rewrite the file (and a prior read-miss default-structure write would CLOBBER existing
+  // embeddings.json with an empty one, t/2060 data-loss guard).
+  if (written.size > 0) {
+    data.node_count = Object.keys(data.nodes).length;
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
+    console.log(`[embeddings] Updated embeddings.json (${data.node_count} total nodes)`);
+    io.invalidateCache();
+  }
 
-  // Invalidate in-memory cache so next read picks up new data
-  io.invalidateCache();
+  // Any requested node without a freshly-persisted vector is STALE (its text changed but its
+  // stored vector wasn't refreshed) — the contract the renderer surfaces (t/2060).
+  const staleNodeIds = nodes.filter(n => !written.has(n.id)).map(n => n.id);
+  if (staleNodeIds.length > 0) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'embeddings', level: 'warn',
+      message: 'updateNodeEmbeddings: some nodes left with stale embeddings',
+      data: { stale: staleNodeIds.length, requested: nodes.length },
+    });
+  }
+  return { staleNodeIds };
 }
 
 // ---------- NLI cross-encoder classification ----------

--- a/taxonomy-editor/src/main/ipc/aiHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/aiHandlers.ts
@@ -88,7 +88,10 @@ export function registerAiHandlers(): void {
 
   ipcMain.handle('update-node-embeddings', async (_event, nodes: NodeEmbeddingInput[]) => {
     try {
-      await updateNodeEmbeddings(nodes);
+      // Resolves { staleNodeIds } (empty = full success) — an embed OOM surfaces as stale ids,
+      // not a throw, so the renderer can flag the degradation (t/2060). Only a genuinely
+      // unexpected fault (e.g. file-write) reaches the catch below.
+      return await updateNodeEmbeddings(nodes);
     } catch (err) {
       getGlobalRecorder()?.record({
         type: 'system.error',

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -150,7 +150,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   computeEmbeddings: (texts: string[], ids?: string[]): Promise<{ vectors: number[][] }> =>
     ipcRenderer.invoke('compute-embeddings', texts, ids),
 
-  updateNodeEmbeddings: (nodes: { id: string; text: string; pov: string; exclusionText?: string }[]): Promise<void> =>
+  updateNodeEmbeddings: (nodes: { id: string; text: string; pov: string; exclusionText?: string }[]): Promise<{ staleNodeIds: string[] }> =>
     ipcRenderer.invoke('update-node-embeddings', nodes),
 
   computeQueryEmbedding: (text: string): Promise<{ vector: number[] }> =>

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -195,7 +195,10 @@ export interface AppAPI {
 
   // --- Embeddings & NLI ---
   computeEmbeddings: (texts: string[], ids?: string[]) => Promise<{ vectors: number[][] }>;
-  updateNodeEmbeddings: (nodes: { id: string; text: string; pov: string; exclusionText?: string }[]) => Promise<void>;
+  // Resolves { staleNodeIds } — requested nodes whose embedding couldn't be refreshed (empty =
+  // full success). Consumers surface a non-blocking "embeddings stale" warning on non-empty
+  // (t/2060). Electron computes it; the web transport returns [] (server backend doesn't DML-OOM).
+  updateNodeEmbeddings: (nodes: { id: string; text: string; pov: string; exclusionText?: string }[]) => Promise<{ staleNodeIds: string[] }>;
   computeQueryEmbedding: (text: string) => Promise<{ vector: number[] }>;
   nliClassify: (pairs: Array<{ text_a: string; text_b: string }>) => Promise<{
     results: Array<{

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -965,7 +965,10 @@ const rawApi: AppAPI = {
 
   // Embeddings & NLI
   computeEmbeddings: (texts, ids) => post('/api/embeddings/compute', { texts, ids }),
-  updateNodeEmbeddings: (nodes) => post('/api/embeddings/update-nodes', { nodes }).then(() => {}),
+  // Web transport: the server embedding backend (Python/Gemini) has no DirectML GPU-OOM failure
+  // mode, so nothing goes stale on this path → always [] (t/2060 staleNodeIds contract). If the
+  // server route later reports partial failures, thread them through here.
+  updateNodeEmbeddings: (nodes) => post('/api/embeddings/update-nodes', { nodes }).then(() => ({ staleNodeIds: [] as string[] })),
   computeQueryEmbedding: (text) => post('/api/embeddings/query', { text }),
   nliClassify: (pairs) => post('/api/nli/classify', { pairs }),
 

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -105,7 +105,7 @@ export interface ElectronAPI {
 
   // Embeddings & NLI
   computeEmbeddings: (texts: string[], ids?: string[]) => Promise<{ vectors: number[][] }>;
-  updateNodeEmbeddings: (nodes: { id: string; text: string; pov: string; exclusionText?: string }[]) => Promise<void>;
+  updateNodeEmbeddings: (nodes: { id: string; text: string; pov: string; exclusionText?: string }[]) => Promise<{ staleNodeIds: string[] }>;
   computeQueryEmbedding: (text: string) => Promise<{ vector: number[] }>;
   nliClassify: (pairs: Array<{ text_a: string; text_b: string }>) => Promise<{ results: Array<{ nli_label: string; nli_entailment: number; nli_neutral: number; nli_contradiction: number; margin: number }> }>;
 


### PR DESCRIPTION
Slice 2 of the urgent embeddings blocker (TL partition + contract t/2060#4). `updateNodeEmbeddings` now resolves `{ staleNodeIds: string[] }` (empty = full success) instead of `Promise<void>` — the IPC↔renderer staleness contract all 3 slices build to. A DirectML GPU-OOM (or any embed failure) no longer throws away the whole update: affected ids surface in `staleNodeIds`, successfully-embedded nodes still persist (partial success, forward-compatible with slice-1's chunk+CPU-fallback). **No-clobber guard:** the file is written only when ≥1 vector refreshed, so a total failure can't overwrite embeddings.json (data-loss fix). Threaded through preload/bridge/electron.d.ts (electron) + web-bridge (returns [] — server backend doesn't DML-OOM). **Non-breaking** to the renderer's current `.catch` usage; lands interface-first so slice-3 (t/2064, Taxonomy Editor) builds on it. Verify: tsc main+renderer clean; src/main 95/95, renderer useTaxonomyStore 116/116, eslint clean. Behavioral OOM proof = TL-mandated live-DirectML-host gate (rides slice-1) + slice-3 test; isolated behavioral unit test impractical (embeddings.ts couples electron net+safeStorage+module-load probes). No separate review gate per t/2060#4.