### PR TITLE
ci: pre-pull buildkit with retry + pin driver image (t/2065)

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -44,8 +44,18 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
 
+      # Pre-pull buildkit with retry — see t/2065 (Docker Hub boot flake).
+      - name: Pre-pull buildkit image with retry (t/2065)
+        run: |
+          for i in 1 2 3; do
+            docker pull moby/buildkit:buildx-stable-1 && break
+            echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+          done
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4

--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -48,8 +48,12 @@ jobs:
       - name: Pre-pull buildkit image with retry (t/2065)
         run: |
           for i in 1 2 3; do
-            docker pull moby/buildkit:buildx-stable-1 && break
-            echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+            if docker pull moby/buildkit:buildx-stable-1; then break; fi
+            if [ "$i" -lt 3 ]; then
+              echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+            else
+              echo "buildkit pre-pull failed after $i attempts; setup-buildx will attempt its own pull"
+            fi
           done
 
       - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,8 +471,23 @@ jobs:
           mkdir -p taxonomy-snapshot
           echo '{"generated":"none","commit":"none","empty":true}' > taxonomy-snapshot/snapshot-meta.json
 
+      # Best-effort pre-pull with retry: the docker-container driver bootstraps
+      # from moby/buildkit pulled off Docker Hub, which intermittently fails
+      # "deadline exceeded" at BOOT → false-red before any build runs (t/2065).
+      # Pre-pulling into the host image cache means the driver bootstrap reuses
+      # the cached image (no re-pull); the retry absorbs transient Hub timeouts.
+      # Non-fatal — if all retries fail, setup-buildx still attempts its own pull.
+      - name: Pre-pull buildkit image with retry (t/2065)
+        run: |
+          for i in 1 2 3; do
+            docker pull moby/buildkit:buildx-stable-1 && break
+            echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+          done
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       - name: Extract base image tag from Dockerfile
         id: base_tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,8 +480,12 @@ jobs:
       - name: Pre-pull buildkit image with retry (t/2065)
         run: |
           for i in 1 2 3; do
-            docker pull moby/buildkit:buildx-stable-1 && break
-            echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+            if docker pull moby/buildkit:buildx-stable-1; then break; fi
+            if [ "$i" -lt 3 ]; then
+              echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+            else
+              echo "buildkit pre-pull failed after $i attempts; setup-buildx will attempt its own pull"
+            fi
           done
 
       - name: Set up Docker Buildx

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -115,8 +115,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Pre-pull buildkit with retry — see t/2065 (Docker Hub boot flake).
+      - name: Pre-pull buildkit image with retry (t/2065)
+        run: |
+          for i in 1 2 3; do
+            docker pull moby/buildkit:buildx-stable-1 && break
+            echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+          done
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -119,8 +119,12 @@ jobs:
       - name: Pre-pull buildkit image with retry (t/2065)
         run: |
           for i in 1 2 3; do
-            docker pull moby/buildkit:buildx-stable-1 && break
-            echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+            if docker pull moby/buildkit:buildx-stable-1; then break; fi
+            if [ "$i" -lt 3 ]; then
+              echo "buildkit pull attempt $i failed; retry in $((i * 10))s"; sleep $((i * 10))
+            else
+              echo "buildkit pre-pull failed after $i attempts; setup-buildx will attempt its own pull"
+            fi
           done
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
Fixes the recurring `test-container` buildx BOOT flake: the docker-container driver pulls `moby/buildkit` from Docker Hub at bootstrap and intermittently fails *deadline exceeded* before any build runs — a false-red unrelated to the change, and a mis-diagnosis burden on the container/deploy build path (surfaced during t/2047; hits the t/2048 smoke re-runs used to validate re-bumps).

**Change (3 build workflows: ci.yml `test-container`, container.yml, base-image.yml):**
- Best-effort **pre-pull-with-retry** of `moby/buildkit:buildx-stable-1` before each `setup-buildx` (3 attempts, 10s/20s backoff) → warms the host image cache so the driver bootstrap reuses it (no re-pull).
- **Pin** the driver image via `driver-opts: image=moby/buildkit:buildx-stable-1` (matches setup-buildx v4's current default — behavior-preserving).

**Why non-fatal:** if all retries fail, `setup-buildx` still attempts its own pull — so no regression on a hard Hub outage; the win is on transient timeouts.

**Alternative considered:** GHCR-mirror the buildkit image (removes Docker Hub entirely) — heavier (mirror-maintenance job), deferred as future work; retry+pin is the minimal no-new-infra fix.

Owner: DevOps (CI). Co-owned buildx-setup: **@Docker to review the driver-opts/pin choice.** Relates t/2047, t/2048.

🤖 Generated with [Claude Code](https://claude.com/claude-code)