### PR TITLE
fix(taxonomy-store): surface stale-embeddings degradation, kill the fire-and-forget swallow (t/2064)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -32,6 +32,7 @@ import { GitProgressBanner } from './components/sync/GitProgressBanner';
 import { AnonymousBanner } from './components/community/AnonymousBanner';
 import { ResilienceBanner } from './components/shared/ResilienceBanner';
 import { QuotaBanner } from './components/shared/QuotaBanner';
+import { EmbeddingsStaleBanner } from './components/shared/EmbeddingsStaleBanner';
 import { pullDataTracked } from './utils/syncApi';
 import { useFeatureFlagStore, useFlag } from './hooks/useFeatureFlags';
 import { PrecacheToast } from './components/shared/PrecacheToast';
@@ -550,6 +551,7 @@ function MainApp() {
       <AnonymousBanner />
       <ResilienceBanner />
       <QuotaBanner />
+      <EmbeddingsStaleBanner />
       {/* Data update banner */}
       {dataUpdate && (
         <div

--- a/taxonomy-editor/src/renderer/components/shared/EmbeddingsStaleBanner.css
+++ b/taxonomy-editor/src/renderer/components/shared/EmbeddingsStaleBanner.css
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* t/2064 — coarse non-blocking stale-embeddings degradation banner. Uses defined design
+   tokens only (--warning / --border-color / --text-primary / --bg-secondary). */
+
+.embeddings-stale-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  border-left: 3px solid var(--warning);
+}
+
+.embeddings-stale-banner-icon {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  color: var(--warning);
+}
+
+.embeddings-stale-banner-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.embeddings-stale-banner-dismiss {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 2px 6px;
+}
+
+.embeddings-stale-banner-dismiss:hover {
+  color: var(--text-primary);
+}

--- a/taxonomy-editor/src/renderer/components/shared/EmbeddingsStaleBanner.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EmbeddingsStaleBanner.test.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2064 — the coarse stale-embeddings banner renders iff the store's degradation flag
+// is set, and its dismiss clears the flag. (Store-side flag logic is covered in
+// useTaxonomyStore.test.ts; this locks the UI-visibility half of the AC.)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { EmbeddingsStaleBanner } from './EmbeddingsStaleBanner';
+
+const mockState: { embeddingsStale: boolean; dismissEmbeddingsStale: () => void } = {
+  embeddingsStale: false,
+  dismissEmbeddingsStale: vi.fn(),
+};
+vi.mock('../../hooks/useTaxonomyStore', () => ({
+  useTaxonomyStore: (selector: (s: typeof mockState) => unknown) => selector(mockState),
+}));
+
+describe('EmbeddingsStaleBanner (t/2064)', () => {
+  beforeEach(() => {
+    cleanup();
+    mockState.embeddingsStale = false;
+    (mockState.dismissEmbeddingsStale as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('renders nothing when embeddings are not stale', () => {
+    const { container } = render(<EmbeddingsStaleBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the coarse degradation notice when embeddingsStale is set', () => {
+    mockState.embeddingsStale = true;
+    render(<EmbeddingsStaleBanner />);
+    expect(screen.getByRole('status')).toBeTruthy();
+    expect(screen.getByText(/similarity results may be outdated/i)).toBeTruthy();
+  });
+
+  it('clears the flag via dismissEmbeddingsStale when dismissed', () => {
+    mockState.embeddingsStale = true;
+    render(<EmbeddingsStaleBanner />);
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(mockState.dismissEmbeddingsStale).toHaveBeenCalledTimes(1);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/EmbeddingsStaleBanner.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EmbeddingsStaleBanner.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
+import './EmbeddingsStaleBanner.css';
+
+/**
+ * Coarse, non-blocking degradation banner for t/2064. When a post-save embedding
+ * refresh reports stale nodes (or the refresh call rejects), the store sets
+ * `embeddingsStale` — the save itself succeeded durably, but similarity / related-node
+ * results may be temporarily out of date. This surfaces that honestly instead of the
+ * old fire-and-forget swallow, without blocking the save. Per-node badging is a
+ * fast-follow; this coarse "any stale → one banner" indicator is the TL-scoped v1.
+ */
+export function EmbeddingsStaleBanner() {
+  const embeddingsStale = useTaxonomyStore((s) => s.embeddingsStale);
+  const dismiss = useTaxonomyStore((s) => s.dismissEmbeddingsStale);
+
+  if (!embeddingsStale) return null;
+
+  return (
+    <div className="embeddings-stale-banner" role="status" aria-live="polite">
+      <svg className="embeddings-stale-banner-icon" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <path d="M8 1l7 14H1L8 1z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+        <line x1="8" y1="6" x2="8" y2="9.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+        <circle cx="8" cy="12" r="0.6" fill="currentColor" />
+      </svg>
+      <span className="embeddings-stale-banner-text">
+        Embeddings stale — similarity results may be outdated until the next successful save.
+      </span>
+      <button
+        className="embeddings-stale-banner-dismiss"
+        onClick={dismiss}
+        aria-label="Dismiss stale-embeddings notice"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore.test.ts
@@ -1314,6 +1314,56 @@ describe('useTaxonomyStore', () => {
       useTaxonomyStore.getState().dismissSaveError();
       expect(useTaxonomyStore.getState().saveError).toBeNull();
     });
+
+    // t/2064: the post-save embedding refresh reports { staleNodeIds }; surface degradation
+    // via the embeddingsStale store flag (NOT saveError — the durable save already succeeded),
+    // instead of the old fire-and-forget swallow. The refresh is non-blocking, so flush a tick.
+    const flushRefresh = () => new Promise((r) => setTimeout(r, 0));
+
+    it('flags embeddingsStale when the refresh returns stale nodes; save stays clean (t/2064 AC)', async () => {
+      mockApi.updateNodeEmbeddings.mockResolvedValueOnce({ staleNodeIds: ['acc-beliefs-001'] });
+      useTaxonomyStore.setState({ accelerationist: makePovFile(), dirty: new Set(['accelerationist']) });
+
+      await useTaxonomyStore.getState().save();
+      await flushRefresh();
+
+      expect(mockApi.updateNodeEmbeddings).toHaveBeenCalled();
+      expect(useTaxonomyStore.getState().embeddingsStale).toBe(true);
+      expect(useTaxonomyStore.getState().staleEmbeddingNodeIds).toEqual(['acc-beliefs-001']);
+      expect(useTaxonomyStore.getState().saveError).toBeNull(); // durable save unaffected
+    });
+
+    it('clears embeddingsStale when the refresh reports full success (empty staleNodeIds)', async () => {
+      mockApi.updateNodeEmbeddings.mockResolvedValueOnce({ staleNodeIds: [] });
+      useTaxonomyStore.setState({
+        embeddingsStale: true, staleEmbeddingNodeIds: ['stale-prior'],
+        accelerationist: makePovFile(), dirty: new Set(['accelerationist']),
+      });
+
+      await useTaxonomyStore.getState().save();
+      await flushRefresh();
+
+      expect(useTaxonomyStore.getState().embeddingsStale).toBe(false);
+      expect(useTaxonomyStore.getState().staleEmbeddingNodeIds).toEqual([]);
+    });
+
+    it('flags embeddingsStale when the refresh rejects — no silent swallow (t/2064)', async () => {
+      mockApi.updateNodeEmbeddings.mockRejectedValueOnce(new Error('embed OOM'));
+      useTaxonomyStore.setState({ accelerationist: makePovFile(), dirty: new Set(['accelerationist']) });
+
+      await useTaxonomyStore.getState().save();
+      await flushRefresh();
+
+      expect(useTaxonomyStore.getState().embeddingsStale).toBe(true);
+      expect(useTaxonomyStore.getState().saveError).toBeNull(); // durable save still succeeded
+    });
+
+    it('dismissEmbeddingsStale clears the flag', () => {
+      useTaxonomyStore.setState({ embeddingsStale: true, staleEmbeddingNodeIds: ['x'] });
+      useTaxonomyStore.getState().dismissEmbeddingsStale();
+      expect(useTaxonomyStore.getState().embeddingsStale).toBe(false);
+      expect(useTaxonomyStore.getState().staleEmbeddingNodeIds).toEqual([]);
+    });
   });
 
   // ═══════════════════════════════════════════════

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
@@ -103,6 +103,11 @@ export interface TaxonomyDataSlice {
   validationErrors: ValidationErrors;
   saveError: string | null;
   loadError: string | null;
+  // t/2064: the post-save embedding refresh degraded (non-empty staleNodeIds, or the call
+  // rejected). Surfaced as a coarse non-blocking banner — NOT a saveError, since the durable
+  // file-save itself succeeded; only similarity/related-node results may be temporarily stale.
+  embeddingsStale: boolean;
+  staleEmbeddingNodeIds: string[];
   integrityIssues: ValidationIssue[];
   fixIntegrityErrors: () => void;
   loading: boolean;
@@ -122,6 +127,7 @@ export interface TaxonomyDataSlice {
   loadAll: (force?: boolean) => Promise<void>;
   save: () => Promise<void>;
   dismissSaveError: () => void;
+  dismissEmbeddingsStale: () => void;
 
   updatePovNode: (pov: Pov, nodeId: string, updates: Partial<PovNode>, editSource?: { source: TextEditSource; debateId?: string; reason?: string }) => void;
   createPovNode: (pov: Pov, category: Category) => string;
@@ -187,6 +193,8 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
   validationErrors: {},
   saveError: null,
   loadError: null,
+  embeddingsStale: false,
+  staleEmbeddingNodeIds: [],
   integrityIssues: [],
   loading: false,
   backgroundLoading: false,
@@ -315,6 +323,7 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
   },
 
   dismissSaveError: () => set({ saveError: null, integrityIssues: [] }),
+  dismissEmbeddingsStale: () => set({ embeddingsStale: false, staleEmbeddingNodeIds: [] }),
 
   fixIntegrityErrors: () => {
     const state = get();
@@ -547,10 +556,25 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
           // Positive marker that the post-save embedding phase started — distinct from
           // save.completed (file write), pairs with save.embedding-refresh-failed (t/1710).
           getGlobalRecorder()?.record({ type: 'state.change', component: 'taxonomy-store', level: 'info', message: 'save.embedding-refresh-dispatched', data: { node_count: nodesToEmbed.length } });
-          api.updateNodeEmbeddings(nodesToEmbed).catch((err) => {
-            getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Failed to update node embeddings after save', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-            console.warn('[save] Failed to update embeddings:', err);
-          });
+          // t/2064: consume the resolved { staleNodeIds } instead of swallowing the outcome.
+          // Non-blocking (per TL): the durable file-save already succeeded above — any degradation
+          // is surfaced via the embeddingsStale store flag (a coarse banner), never as saveError.
+          api.updateNodeEmbeddings(nodesToEmbed)
+            .then((result) => {
+              const stale = result?.staleNodeIds ?? [];
+              if (stale.length > 0) {
+                getGlobalRecorder()?.record({ type: 'state.change', component: 'taxonomy-store', level: 'warn', message: 'save.embedding-refresh-stale', data: { stale_count: stale.length, node_count: nodesToEmbed.length } });
+                set({ embeddingsStale: true, staleEmbeddingNodeIds: stale });
+              } else if (get().embeddingsStale) {
+                set({ embeddingsStale: false, staleEmbeddingNodeIds: [] }); // full success clears prior degradation
+              }
+            })
+            .catch((err) => {
+              // Reject: cannot confirm the refresh — degrade (flag) rather than swallow (t/2064).
+              getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Failed to update node embeddings after save', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+              console.warn('[save] Failed to update embeddings:', err);
+              set({ embeddingsStale: true, staleEmbeddingNodeIds: nodesToEmbed.map(n => n.id) });
+            });
         }
       } catch (embedErr) {
         // Non-fatal: the save already succeeded. Surface as a warning, never as saveError.


### PR DESCRIPTION
## What
Slice-3 (renderer visibility) of the embeddings blocker **t/2060**. Kills the false-success bug: `taxonomyDataSlice.ts` dispatched `updateNodeEmbeddings` fire-and-forget and swallowed failures, so save reported clean while embeddings went stale (similarity/related-node silently wrong until restart).

## Change
Consumes the landed `{ staleNodeIds: string[] }` contract (slice-2, `95fcef06`):
- non-empty → set `embeddingsStale` store flag (+ `staleEmbeddingNodeIds`) + `save.embedding-refresh-stale` FR
- empty → clear prior degradation
- reject → set the flag (no silent swallow)

Per TL (t/2060#4/#7): post-save async, non-blocking → surface via the **store flag, not `saveError`** (the durable save succeeded). Coarse non-blocking `EmbeddingsStaleBanner` in the App shell reads it; per-node badge = fast-follow.

## Files
`taxonomyDataSlice.ts` (flag + dismiss + consume result) · `EmbeddingsStaleBanner.tsx`/`.css` (new) · `App.tsx` (mount) · tests (store 4 + banner 3).

## Verify (worktree off 9d61c858)
renderer tsc 0/0 · eslint 0 errors (`save` complexity bumped on an already-over-ceiling method — no new warning) · vitest 123/123.

## Self-cert
Single renderer slice consuming slice-2's landed cross-scope contract; no new interfaces; design ratified by ElectronMain (t/2060#7). Diagnostics/ElectronMain-filed (not TL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)