### PR TITLE
fix(moonshot): registry-driven fixedTemperature for kimi-k3 (t/2068)

### DIFF
--- a/ai-models.json
+++ b/ai-models.json
@@ -73,7 +73,8 @@
       "id": "moonshot-kimi-k3",
       "apiModelId": "kimi-k3",
       "label": "Kimi K3",
-      "backend": "moonshot"
+      "backend": "moonshot",
+      "fixedTemperature": 1
     },
     {
       "id": "gemini-3.6-flash",

--- a/lib/ai-client/client.ts
+++ b/lib/ai-client/client.ts
@@ -64,9 +64,15 @@ export function createAIClient(
           nextSteps: ['Increase the budget cap', 'Start a new session to reset the budget', 'Switch to a cheaper model'],
         });
       }
-      const { apiModelId, backend } = resolveModel(registry, model);
+      const { apiModelId, backend, fixedTemperature } = resolveModel(registry, model);
       const apiKey = await deps.resolveApiKey(backend);
-      const effectiveOpts = { ...opts, timeoutMs: opts?.timeoutMs ?? getDefaultTimeout(model) };
+      // Registry-driven per-model temperature constraint (t/2068): the model's
+      // fixedTemperature (if any) overrides the caller's temperature so providers send it.
+      const effectiveOpts = {
+        ...opts,
+        timeoutMs: opts?.timeoutMs ?? getDefaultTimeout(model),
+        ...(fixedTemperature != null ? { fixedTemperature } : {}),
+      };
       const t0 = performance.now();
       const result = await withRetry(
         () => callProvider(deps.fetch, backend, prompt, apiModelId, apiKey, effectiveOpts),

--- a/lib/ai-client/providers/moonshot.test.ts
+++ b/lib/ai-client/providers/moonshot.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi } from 'vitest';
+import { generateViaMoonshot } from './moonshot.js';
+import type { GenerateOptions } from '../types.js';
+
+function mockFetch(status: number, body: unknown): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+  });
+}
+
+const OK = { choices: [{ message: { content: 'hi' } }], usage: { total_tokens: 3 } };
+const opts = (o: Partial<GenerateOptions> = {}): GenerateOptions => ({ timeoutMs: 30_000, ...o });
+const bodyOf = (fetchFn: ReturnType<typeof vi.fn>) => JSON.parse(fetchFn.mock.calls[0][1].body);
+
+describe('generateViaMoonshot — temperature enforcement (t/2068)', () => {
+  it('sends fixedTemperature verbatim, overriding a caller temperature (kimi-k3 needs exactly 1)', async () => {
+    const fetchFn = mockFetch(200, OK);
+    await generateViaMoonshot(fetchFn, 'p', 'kimi-k3', 'key', opts({ temperature: 0.7, fixedTemperature: 1 }));
+    expect(bodyOf(fetchFn).temperature).toBe(1); // NOT 0.7 — the constraint wins
+  });
+
+  it('uses the caller temperature when no fixedTemperature is set', async () => {
+    const fetchFn = mockFetch(200, OK);
+    await generateViaMoonshot(fetchFn, 'p', 'moonshot-other', 'key', opts({ temperature: 0.3 }));
+    expect(bodyOf(fetchFn).temperature).toBe(0.3);
+  });
+
+  it('defaults to 0.7 when neither fixedTemperature nor temperature is set', async () => {
+    const fetchFn = mockFetch(200, OK);
+    await generateViaMoonshot(fetchFn, 'p', 'moonshot-other', 'key', opts());
+    expect(bodyOf(fetchFn).temperature).toBe(0.7);
+  });
+});

--- a/lib/ai-client/providers/moonshot.ts
+++ b/lib/ai-client/providers/moonshot.ts
@@ -30,7 +30,7 @@ export async function generateViaMoonshot(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
         max_tokens: opts.maxTokens ?? 8192,
         ...(opts.jsonMode ? {
           response_format: { type: 'json_object' },

--- a/lib/ai-client/registry.test.ts
+++ b/lib/ai-client/registry.test.ts
@@ -40,6 +40,26 @@ const TEST_REGISTRY: ModelRegistry = {
   },
 };
 
+describe('resolveModel — fixedTemperature (t/2068)', () => {
+  const reg: ModelRegistry = {
+    backends: [{ id: 'moonshot', label: 'Moonshot' }, { id: 'gemini', label: 'Gemini' }],
+    models: [
+      { id: 'moonshot-kimi-k3', apiModelId: 'kimi-k3', label: 'Kimi K3', backend: 'moonshot', fixedTemperature: 1 },
+      { id: 'gemini-2.5-flash', apiModelId: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', backend: 'gemini' },
+    ],
+  };
+
+  it('surfaces fixedTemperature from a registry entry', () => {
+    expect(resolveModel(reg, 'moonshot-kimi-k3')).toMatchObject({
+      apiModelId: 'kimi-k3', backend: 'moonshot', fixedTemperature: 1,
+    });
+  });
+
+  it('leaves fixedTemperature undefined for an entry without it', () => {
+    expect(resolveModel(reg, 'gemini-2.5-flash').fixedTemperature).toBeUndefined();
+  });
+});
+
 describe('getModelCapabilities', () => {
   it('returns backend defaults for a model with no overrides', () => {
     const caps = getModelCapabilities(TEST_REGISTRY, 'gemini-2.5-flash');

--- a/lib/ai-client/registry.ts
+++ b/lib/ai-client/registry.ts
@@ -11,6 +11,9 @@ export interface ModelEntry {
   apiModelId: string;
   label: string;
   backend: string;
+  /** Reasoning models that reject arbitrary temperature (e.g. moonshot kimi-k3, which
+   *  only accepts 1) — when set, the provider MUST send exactly this value (t/2068). */
+  fixedTemperature?: number;
 }
 
 export interface ModelPricing {
@@ -43,9 +46,9 @@ export function resolveBackend(model: string): BackendId {
   return 'gemini';
 }
 
-export function resolveModel(registry: ModelRegistry, friendlyId: string): { apiModelId: string; backend: string } {
+export function resolveModel(registry: ModelRegistry, friendlyId: string): { apiModelId: string; backend: string; fixedTemperature?: number } {
   const entry = registry.models.find(m => m.id === friendlyId);
-  if (entry) return { apiModelId: entry.apiModelId, backend: entry.backend };
+  if (entry) return { apiModelId: entry.apiModelId, backend: entry.backend, fixedTemperature: entry.fixedTemperature };
   if (friendlyId.startsWith('gemini')) return { apiModelId: friendlyId, backend: 'gemini' };
   if (friendlyId.startsWith('claude')) return { apiModelId: friendlyId, backend: 'claude' };
   if (friendlyId.startsWith('groq')) return { apiModelId: friendlyId, backend: 'groq' };

--- a/lib/ai-client/types.ts
+++ b/lib/ai-client/types.ts
@@ -30,6 +30,10 @@ export interface GenerateOptions {
   purpose?: string;
   /** Maximum accumulated cost (USD) before subsequent calls throw a budget-exceeded error. */
   maxCostUsd?: number;
+  /** Provider MUST send exactly this temperature, overriding `temperature`. Set from the
+   *  registry (ModelEntry.fixedTemperature) for reasoning models that reject arbitrary
+   *  values, e.g. moonshot kimi-k3 which only accepts 1 (t/2068). */
+  fixedTemperature?: number;
 }
 
 export interface ProviderResult {


### PR DESCRIPTION
High-pri bug (Diagnostics t/2068): `moonshot-kimi-k3` is a reasoning model that only accepts `temperature: 1`; the app sent `0.7` → **HTTP 400 on every call**, blocking the entire debate opening phase (all 5 generation calls).

## Fix — registry-driven (ticket's recommended; self-cert design t/2068#1)
- `ai-models.json`: `moonshot-kimi-k3` gains `"fixedTemperature": 1`
- `registry.ts`: `ModelEntry.fixedTemperature?`; `resolveModel` surfaces it
- `client.ts` `generateText`: threads `fixedTemperature` from `resolveModel` into `effectiveOpts` (the single site where the registry entry + opts meet)
- `types.ts`: `GenerateOptions.fixedTemperature?`
- `moonshot.ts`: `temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7` — **provider-level enforcement** (the hard AC)

Generalizes: the registry mechanism works for any backend; only `moonshot.ts` honors it today (the bug), other providers get the same one-liner when a reasoning model lands on them — **no current behavior change** since only kimi-k3 sets the field. (Not touching `claude.ts`, which already handles temperature-rejection via a conditional + 400-retry; this is the upfront-correct complement, no wasted round-trip.)

## Verification
- `npm run verify:config` — **all 6 registry gates green** (the AC gate for the ai-models.json change)
- All **11 ai-client vitest suites green (147 tests)** incl. new `moonshot.test.ts` (fixedTemperature overrides caller temp → 1; falls back to temp/0.7) + `registry.test.ts` (resolveModel surfaces fixedTemperature)
- tsc clean on the changed source

🤖 Generated with [Claude Code](https://claude.com/claude-code)