### PR TITLE
fix(debate): thread fixedTemperature through aiAdapter callProvider sites (t/2068)

### DIFF
--- a/lib/debate/aiAdapter.ts
+++ b/lib/debate/aiAdapter.ts
@@ -290,10 +290,10 @@ export function createCLIAdapter(repoRoot: string, explicitApiKey?: string): Ext
   }
 
   async function doGenerateText(prompt: string, model: string, options?: GenerateOptions): Promise<string> {
-    const { apiModelId, backend } = resolveModel(registry, model);
+    const { apiModelId, backend, fixedTemperature } = resolveModel(registry, model);
     const apiKey = resolveApiKey(backend, explicitApiKey);
     const timeoutMs = options?.timeoutMs ?? getDefaultTimeout(model);
-    const opts = { ...options, timeoutMs };
+    const opts = { ...options, timeoutMs, fixedTemperature };
 
     const t0 = performance.now();
     getGlobalRecorder()?.record({
@@ -361,7 +361,7 @@ export function createCLIAdapter(repoRoot: string, explicitApiKey?: string): Ext
       process.stderr.write(`[cascade] ${backend}/${apiModelId} failed, trying ${fb.backend}/${fb.apiModelId}\n`);
       try {
         const fbTimeoutMs = getDefaultTimeout(fbModel);
-        const fbOpts = { ...opts, timeoutMs: fbTimeoutMs };
+        const fbOpts = { ...opts, timeoutMs: fbTimeoutMs, fixedTemperature: fb.fixedTemperature };
         const fbResult = await callWithTimeout(
           (signal) => withRetry(
             () => callProvider(signalFetch(fetch, signal), fb.backend, prompt, fb.apiModelId, fbKey, fbOpts),
@@ -390,9 +390,9 @@ export function createCLIAdapter(repoRoot: string, explicitApiKey?: string): Ext
   }
 
   async function doGenerate(request: GenerateRequest): Promise<GenerateResponse> {
-    const { apiModelId, backend } = resolveModel(registry, request.model);
+    const { apiModelId, backend, fixedTemperature } = resolveModel(registry, request.model);
     const apiKey = resolveApiKey(backend, explicitApiKey);
-    const resolvedReq = { ...request, model: apiModelId };
+    const resolvedReq = { ...request, model: apiModelId, options: { ...request.options, fixedTemperature } };
 
     const t0 = performance.now();
     getGlobalRecorder()?.record({


### PR DESCRIPTION
## Summary

Completes the t/2068 moonshot-kimi-k3 fix for the debate path. Shared Lib landed the registry mechanism + createAIClient threading in #315 (`04052430`), but `lib/debate/aiAdapter.ts` calls `callProvider` directly (bypassing `createAIClient`), dropping `fixedTemperature` before it reaches `moonshot.ts`.

Three additive one-liner fixes:
- **`doGenerateText` primary (~293):** destructure `fixedTemperature` from `resolveModel`, include in `opts`
- **`doGenerateText` fallback (~364):** use `fb.fixedTemperature` (fallback model's own constraint, not primary's)
- **`doGenerate` / envelope (~393,395):** inject into `resolvedReq.options` so `callEnvelopeProvider`'s `...req.options` carries it to `callProvider`

## Test plan
- [x] `aiAdapter.test.ts` 65/65 pass (verified locally on `ab366350`)
- [ ] CI green (6 checks)

Self-certifying under /trivial-change: 5 lines changed, single scope (lib/debate), no new exports, no interface changes (`GenerateOptions.fixedTemperature` already added by #315), no auth surface, no data model change.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)