### PR TITLE
refactor(server-community): admin review handler imports shared SENSITIVE_KEYS (t/2071)

### DIFF
--- a/taxonomy-editor/src/server/community/admin/communityReviewHandler.ts
+++ b/taxonomy-editor/src/server/community/admin/communityReviewHandler.ts
@@ -11,6 +11,7 @@
  */
 
 import { listSubmissions, approveSubmission, rejectSubmission } from '../community.js';
+import { SENSITIVE_KEYS } from '../../../../../lib/sanitize/stripSensitiveKeys.js';
 import type { ReviewAction, ReviewDomainHandler, ReviewItem } from './types.js';
 
 const DOMAIN = 'community';
@@ -52,16 +53,9 @@ function titleOf(data: unknown): string {
   return extractString(d.title) || extractString(d.topic) || '(untitled)';
 }
 
-// Sensitive keys stripped by community.ts → sanitizeForCommunity on promote.
-// Mirrored here ONLY to preview what will be removed; community.ts remains the
-// authoritative stripper. Keep roughly in sync.
-const SENSITIVE_KEYS = new Set([
-  'api_key', 'apiKey', 'api_keys', 'apiKeys',
-  'secret', 'token', 'password', 'credential', 'credentials',
-  'authorization', 'auth_token', 'access_token', 'refresh_token',
-  'private_key', 'privateKey',
-  'flight_recorder', 'debug', '_internal', 'diagnostics_state',
-]);
+// t/2071: the sensitive-key set is the shared lib/sanitize source of truth (imported
+// above) — scanSensitive() previews which of THOSE keys appear, so the admin "what
+// will be stripped" view can never drift from what community.ts actually strips.
 
 /** Which sensitive keys actually appear anywhere in the submission data. */
 function scanSensitive(obj: unknown, found = new Set<string>()): Set<string> {


### PR DESCRIPTION
Retire the last inline `SENSITIVE_KEYS` copy — t/2037 traversal-dedup residue. Low priority, `/trivial-change` self-cert.

## What
`admin/communityReviewHandler.ts` `scanSensitive()` is a **read-only preview** of which sensitive keys appear in a submission (admin review viewer) — NOT a stripper, no t/2032 array-bypass exposure. But its inline set carried a "keep roughly in sync" comment: if the shared set grows, the preview would silently under-report. Swap the inline `const SENSITIVE_KEYS = new Set([...])` for an import of the shared `lib/sanitize/stripSensitiveKeys` set so the preview can never drift from what `community.ts` actually strips. `scanSensitive()` logic unchanged.

## Result
Zero inline `SENSITIVE_KEYS = new Set` copies remain repo-wide (AC#2) — the lib module is the sole source.

## Verify (worktree off origin/main, triple npm ci)
- tsc main+server: 0 / 0 (5-`../` import path resolves)
- eslint: 0
- depcruise: 0 violations
- vitest: 22 green (communityReviewHandler + community)

Not auth-surface (read-only detector, no strip/serve path) → self-cert, no TL gate. Closes t/2071.