### PR TITLE
ci: gate ai-models.json edits through their own registry checks (t/2090)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,19 @@ jobs:
         id: filter
         with:
           filters: |
+            # 'ai-models.json' is in powershell/electron/debate because the AI
+            # registry completeness gates run inside those job families (t/2090):
+            # powershell -> Test-AIModelsConfig + ModelLiteralLint (Pester);
+            # electron   -> keysValidation/resolveApiModelId/configInvariant/
+            #               modelDiscovery (taxonomy-editor vitest);
+            # debate     -> aiAdapter reads it at runtime for the golden evals.
+            # A pure ai-models.json edit used to match NO filter and skip all
+            # three, so its own gates never ran in CI (data-only PR ungated).
             powershell:
               - 'scripts/**'
               - 'tests/**'
               - 'lib/**'
+              - 'ai-models.json'
               - '.github/workflows/ci.yml'
             electron:
               - 'taxonomy-editor/**'
@@ -69,11 +78,13 @@ jobs:
               - 'summary-viewer/**'
               - 'workflow-app/**'
               - 'lib/**'
+              - 'ai-models.json'
               - '.github/workflows/ci.yml'
             debate:
               - 'lib/debate/**'
               - 'evals/**'
               - 'ai-usages.json'
+              - 'ai-models.json'
               - '.github/workflows/ci.yml'
             schema:
               - 'taxonomy/schemas/**'


### PR DESCRIPTION
Closes t/2090.

## Problem
A PR touching **only** `ai-models.json` matched **no** `dorny/paths-filter` in `ci.yml`, so every filter output was `false` and both `test-powershell` and `test-electron` **skipped** — exactly the jobs that run the six registry completeness gates:
- `test-powershell` → `Test-AIModelsConfig.Tests.ps1` + `ModelLiteralLint.Tests.ps1`
- `test-electron` (taxonomy-editor vitest) → `keysValidation`, `resolveApiModelId`, `configInvariant`, `modelDiscovery`

`ci-gate` then greened because `skipped == OK` by design → a data-only registry edit could merge with **zero** CI validation of the registry it changes.

## Fix
Add `ai-models.json` to the `powershell`, `electron`, and `debate` filters (all three have gated jobs that consume the registry — powershell/electron run its gates; debate's `aiAdapter` reads it at runtime for the golden evals). This **tightens** the load-bearing-filter invariant (every code path maps to the job(s) that test it), it does not weaken it. Inline comment added documenting the mapping.

## Gate verification
Follows after merge (post-merge, since `pull_request` uses the base-branch workflow): a test PR editing only `ai-models.json` to confirm `test-powershell` + `test-electron` now **run** (not skip), a deliberately-broken registry edit shown **red-blocked** by `ci-gate`, and a valid `ai-models.json`-only edit shown green + self-mergeable (t/1962 property preserved).