### PR TITLE
docs(agents): split role-specific content out of root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,34 +8,12 @@ AI Triad Research — multi-perspective research platform for AI policy/safety l
 
 ## Build & Test Commands
 
-```powershell
-# Load the PowerShell module (required before using any cmdlet)
-Import-Module ./scripts/AITriad/AITriad.psm1
+Build and test commands are role-specific — see the owning subtree's `AGENTS.md` (they load automatically when you work in that scope):
 
-# Run all Pester tests
-Invoke-Pester ./tests/
-
-# Run a single Pester test by name
-Invoke-Pester ./tests/ -FullNameFilter '*test name pattern*'
-
-# Build distributable module
-./scripts/Build-Module.ps1 -Clean
-
-# Validate built manifest
-Test-ModuleManifest -Path ./build/AITriad/AITriad.psd1
-```
-
-```bash
-# Taxonomy Editor (Electron + React)
-cd taxonomy-editor && npm ci && npm test        # run vitest suite
-cd taxonomy-editor && npm run test:watch         # watch mode
-cd taxonomy-editor && npm run dev                # dev server (port 5173)
-cd taxonomy-editor && npx tsc --noEmit -p tsconfig.main.json  # type check
-
-# POViewer / Summary Viewer (no test suites yet)
-cd poviewer && npm ci && npm run dev             # port 5174
-cd summary-viewer && npm ci && npm run dev       # port 5175
-```
+- **PowerShell module / Pester / manifest** → `scripts/AGENTS.md`
+- **Taxonomy Editor / poviewer / summary-viewer (npm, vitest, tsc)** → `taxonomy-editor/AGENTS.md`
+- **Debate engine (vitest)** → `lib/debate/AGENTS.md`
+- **CI pipeline (`ci.yml` jobs)** → `operations/devops/AGENTS.md`
 
 ## Architecture
 
@@ -63,19 +41,13 @@ git config core.hooksPath .githooks
 
 The hook is self-documenting (see its header comment). Owner / emergency override: `git commit --no-verify`.
 
-### PowerShell Module (`scripts/AITriad/`)
+### Subsystem Map
 
-40+ cmdlets in `Public/`, internal helpers in `Private/`, AI prompt templates in `Prompts/`. Module manifest: `AITriad.psd1` (v0.8.0). Companion modules loaded alongside: `AIEnrich.psm1` (multi-backend AI abstraction with streaming, retry, token tracking) and `DocConverters.psm1` (PDF/DOCX/HTML to Markdown via pandoc/gs).
+Detailed conventions and build/test commands live in each subtree's `AGENTS.md` (loaded when you work in that scope). This is the orientation map only.
 
-### Electron Apps (3 independent apps, each Vite + React 19 + Electron 35 + TypeScript)
-
-- **taxonomy-editor/** — Main editing UI for the taxonomy graph. Includes integrated Edge Browser. Uses Zustand for state, Zod for validation.
-- **poviewer/** — POV analysis viewer. Uses pdfjs-dist and Google GenAI SDK.
-- **summary-viewer/** — Summary browser.
-
-### Debate Engine (`lib/debate/`, 22 TypeScript files)
-
-Three-agent BDI debate system. Characters: Accelerationist (accelerationist), Safetyist (safetyist), Skeptic (skeptic). Entry points: `Show-TriadDialogue` (PowerShell) or `npm run debate` (CLI via tsx). `aiAdapter.ts` abstracts multi-backend AI calls; `prompts.ts` has 27+ prompt templates.
+- **PowerShell module** (`scripts/AITriad/`) — 40+ cmdlets (Public/Private split), AI prompt templates in `Prompts/`, companion `AIEnrich.psm1` (multi-backend AI abstraction) + `DocConverters.psm1` (doc→Markdown). → `scripts/AGENTS.md`
+- **Electron apps** — 3 independent apps, each Vite + React 19 + Electron 35 + TypeScript: **taxonomy-editor/** (main editing UI; Zustand + Zod), **poviewer/** (POV analysis; pdfjs-dist), **summary-viewer/**. → `taxonomy-editor/AGENTS.md`
+- **Debate engine** (`lib/debate/`) — three-agent BDI system (Accelerationist / Safetyist / Skeptic). Entry points: `Show-TriadDialogue` (PowerShell) or `npm run debate` (CLI). `aiAdapter.ts` abstracts multi-backend AI calls. → `lib/debate/AGENTS.md`
 
 ### Taxonomy Model
 
@@ -87,7 +59,7 @@ Four POV camps with BDI categories (Beliefs, Desires, Intentions). Node IDs: `{p
 
 Configured in `ai-models.json` (single source of truth for PS and Electron). Backends: Google Gemini (free tier), Anthropic Claude, Groq (free tier). Keys via `Register-AIBackend` or env vars (`GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `AI_API_KEY` fallback).
 
-**Before landing any `ai-models.json` edit, run `npm run verify:config`.** The registry's completeness gates live in other packages' test suites (taxonomy-editor vitest + the `tests/` Pester suite), so a root-config edit gets no local signal that it must satisfy them — that is how an incomplete registry edit went red in CI (t/1933). `scripts/Verify-Config.ps1` runs all six registry gates in one command and exits non-zero (naming the failing gate) if any fails: `Test-AIModelsConfig.Tests.ps1`, `ModelLiteralLint.Tests.ps1` (Pester), and `keysValidation`, `resolveApiModelId`, `configInvariant`, `modelDiscovery` (vitest, delegated to taxonomy-editor). Requires `pwsh` + `taxonomy-editor/node_modules` (`npm ci` there once).
+**Before landing any `ai-models.json` edit, run `npm run verify:config`** — it runs all six registry-completeness gates (whose signal lives in other packages' suites) in one command and exits non-zero naming the failing gate; skipping it is how an incomplete edit went red in CI (t/1933). Adding a backend? Follow the `/add-ai-backend` playbook — it enumerates every coupling site.
 
 ## Shell Quoting Rule
 
@@ -104,22 +76,6 @@ All unrecoverable errors must use `New-ActionableError` (PowerShell) or `Actiona
 - **Suppress verbose output** — pass `verbose:false` and `include_ids:false` on all MCP list/create calls unless IDs or full detail are specifically needed.
 - **Don't re-read AGENTS.md** — it is already injected as `claudeMd` every session.
 - **Reference, don't inline** — use `t/KEY`, `e/N`, `d/<slug>` in comments and emails rather than copying ticket/doc content.
-
-## Version Update Checklist
-
-When bumping the module version, verify that **all** of the following files are updated consistently:
-
-1. `scripts/AITriad/AITriad.psd1` — source manifest (`ModuleVersion`)
-2. `build/AITriad/AITriad.psd1` — built manifest (rebuilt via `Build-Module.ps1 -Clean`)
-3. `CLAUDE.md` — the version mentioned in the Architecture / PowerShell Module section
-
-After updating, run `Test-ModuleManifest -Path ./build/AITriad/AITriad.psd1` to confirm the build is coherent. Never publish to PSGallery without rebuilding first — the build manifest must match the source manifest.
-
-## CI Pipeline (`.github/workflows/ci.yml`)
-
-Two jobs on push/PR to main:
-1. **test-powershell** — Pester tests, module build, manifest validation
-2. **test-electron** — `npm ci`, TypeScript check, build (taxonomy-editor only)
 
 ## Incident Response
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,10 @@ Configured in `ai-models.json` (single source of truth for PS and Electron). Bac
 
 When writing, editing, or executing code containing special shell characters (template literals, nested quotes, apostrophes, backticks, `$` variables, f-strings), **always use Edit/Write tools** instead of Bash `sed`, `awk`, or heredocs. When running Python/PowerShell scripts that contain quotes or f-strings, write the script to a temp file with the `Write` tool and execute it, rather than inlining in a heredoc or `bash -c`. Shell escaping is the #1 source of silent corruption bugs.
 
+## Git Forensics on the Bash Tool
+
+On some Windows agents, MSYS path conversion mangles the `<path>` half of a git colon-revspec (`git show <ref>:<path>`, `cat-file`, `rev-parse <ref>:<path>`) — a **valid** ref then reports a spurious `unknown revision or path`, masquerading as a missing commit/file. It is environment-dependent (varies by Git-for-Windows install; confirmed on ≥2 agents, not reproduced on others), so don't dismiss a peer's report as "just their config." Discriminator: valid ref + `unknown revision` = suspect MSYS, not a real absence. Fix: prefix `MSYS_NO_PATHCONV=1`, or run the git command via the PowerShell tool.
+
 ## Error Handling Convention
 
 All unrecoverable errors must use `New-ActionableError` (PowerShell) or `ActionableError` (TypeScript) with four fields: **Goal**, **Problem**, **Location**, **Next Steps**. Never use bare `throw "message"`. Prefer recovery (retry, fallback, partial results) over failure. See `docs/error-handling.md`.


### PR DESCRIPTION
## What

Split role-specific content out of the root `AGENTS.md`. Root is inherited by **all ~35 roles** in the workspace (research, management, ops, and the deep renderer-component roles), so every line is a token cost paid ~35× and a relevance cost for the many agents who never touch that subsystem.

**Root: 128 → 83 lines (−35%).** No content is deleted outright except where it's already documented by the owning subtree — it moves to the `AGENTS.md` of the subtree that owns it and reaches those roles via hierarchical inheritance. No coverage lost.

## What moved / changed at root (this PR)

| Root section | Action | Destination |
|---|---|---|
| Build & Test Commands (PS + npm blocks) | Replaced with pointer list | `scripts/` + `taxonomy-editor/` AGENTS.md |
| PowerShell Module / Electron Apps / Debate Engine | Condensed into one **Subsystem Map** (orientation + pointers) | detail already in each subtree |
| AI Backends — `verify:config` paragraph | Trimmed ~6 lines → 2 (gate + `/add-ai-backend` pointer) | rationale already in the playbook |
| Version Update Checklist | Removed | `scripts/AGENTS.md` (companion below) |
| CI Pipeline (`ci.yml` jobs) | Removed | already in `operations/devops/AGENTS.md` (line 21) |

**Kept at root** (genuinely cross-cutting): Project Overview, Two-Repo Split, Orca Overlay, Shared-Checkout Commit Guard, Taxonomy Model + Data File Convention, Shell Quoting, Error Handling, Token Efficiency, Incident Response.

## Companion overlay changes (NOT in this PR — land via `ogit`)

The child `AGENTS.md` files are **overlay-tracked** (`.orca-git`) and live in **other roles' scopes**, so they can't ride in this main-repo PR. They need owner review + an `ogit` commit. Two files:

### `scripts/AGENTS.md` (PowerShell role) — append

```markdown
## Build & Test

```powershell
Import-Module ./scripts/AITriad/AITriad.psm1              # required before any cmdlet
Invoke-Pester ./tests/                                    # all Pester tests
Invoke-Pester ./tests/ -FullNameFilter '*name pattern*'   # single test by name
./scripts/Build-Module.ps1 -Clean                         # build distributable module
Test-ModuleManifest -Path ./build/AITriad/AITriad.psd1    # validate built manifest
```

## Version Update Checklist

When bumping the module version, update both manifests consistently:

1. `scripts/AITriad/AITriad.psd1` — source manifest (`ModuleVersion`, authoritative)
2. `build/AITriad/AITriad.psd1` — built manifest (rebuilt via `Build-Module.ps1 -Clean`)

Then run `Test-ModuleManifest -Path ./build/AITriad/AITriad.psd1` to confirm the build is coherent. Never publish to PSGallery without rebuilding first — the build manifest must match the source manifest.
```

> Note: the old root checklist had a 3rd item ("CLAUDE.md — the version mentioned in the PowerShell Module section"). That prose version reference is removed from root here, so the checklist drops to 2 items with the source manifest as authoritative.

### `taxonomy-editor/AGENTS.md` (Rosetta Stone role) — append to Tech Stack / new section

```markdown
## Build & Test

```bash
# Taxonomy Editor (Electron + React)
cd taxonomy-editor && npm ci && npm test                       # run vitest suite
cd taxonomy-editor && npm run test:watch                        # watch mode
cd taxonomy-editor && npm run dev                               # dev server (port 5173)
cd taxonomy-editor && npx tsc --noEmit -p tsconfig.main.json    # type check

# POViewer / Summary Viewer (no test suites yet)
cd poviewer && npm ci && npm run dev                            # port 5174
cd summary-viewer && npm ci && npm run dev                      # port 5175
```
```

### No change needed
- **`lib/debate/AGENTS.md`** — already has the vitest commands (`## Testing`); entry points now carried in the root Subsystem Map.
- **`operations/devops/AGENTS.md`** — already documents `ci.yml`'s two jobs (line 21).

## ⚠️ Reviewer note — dual-tracking of root `AGENTS.md`

`git ls-files` shows root `AGENTS.md` is tracked in **both** the main repo **and** the overlay (`.orca-git`). This PR updates the **main-repo** copy. Someone should confirm whether the overlay copy needs a matching `ogit` commit to stay in sync, or whether the overlay copy is stale/ignored. Flagging rather than guessing.

## Landing sequence (to avoid a coverage gap)

Land the two companion overlay additions **first** (or concurrently), **then** merge this PR — otherwise the PowerShell and Taxonomy Editor roles lose their build commands in the window between.

## Test plan

Docs-only. No code paths touched. Rendering/inheritance is verified by each child role loading its own `AGENTS.md` in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
