### PR TITLE
[DO NOT MERGE] t/2090 gate verification: ai-models.json-only triggers registry gates

### DIFF
--- a/ai-models.json
+++ b/ai-models.json
@@ -1075,5 +1075,5 @@
       "cachedInputPer1M": 0.3
     }
   },
-  "lastRefreshed": "2026-07-26T12:23:03.226Z"
+  "lastRefreshed": "2026-08-03T12:00:00.000Z"
 }


### PR DESCRIPTION
**Throwaway verification PR — WILL BE CLOSED, not merged.** Proves the t/2090 filter fix (already on main via #322).

This edits **only** `ai-models.json` (a `lastRefreshed` bump). Pre-t/2090 this matched no paths-filter and both gate jobs skipped. Expected now:
- `test-powershell` + `test-electron` **RUN** (not skipped)
- all green, `ci-gate` green, self-mergeable (proves t/1962 property preserved)

A second push will introduce a deliberately-broken registry entry to prove `ci-gate` red-blocks it. Then this PR is closed.