### PR TITLE
fix(server): /healthz names warming vs failed data-load, not a bare 503 (t/2059)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/healthzReadiness.test.ts
+++ b/taxonomy-editor/src/server/__tests__/healthzReadiness.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2059: /healthz must render a permanently-failed data load distinctly from a
+// normal cold-start warm-up (not a silent bare 503). These assert the two states
+// render distinctly and that `failed` carries the underlying cause.
+
+import { describe, it, expect } from 'vitest';
+import { classifyDataUnavailable, DATA_LOAD_GRACE_S } from '../routes/readiness.js';
+import type { ServerCtx } from '../routes/context.js';
+
+function makeCtx(backend: unknown): ServerCtx {
+  return { getGithubBackend: () => backend } as unknown as ServerCtx;
+}
+
+describe('classifyDataUnavailable (t/2059 — /healthz warming vs failed)', () => {
+  it('within grace, no failure signal → warming', () => {
+    const r = classifyDataUnavailable(makeCtx(null), 5);
+    expect(r.state).toBe('warming');
+    expect(r.reason).toMatch(/in progress/);
+  });
+
+  it('past grace with no data → failed, names grace exhaustion', () => {
+    const r = classifyDataUnavailable(makeCtx(null), DATA_LOAD_GRACE_S + 1);
+    expect(r.state).toBe('failed');
+    expect(r.reason).toMatch(/grace .*exhausted/);
+  });
+
+  it('github circuit open → failed even within the grace window', () => {
+    const backend = { getCircuitState: () => 'open' };
+    const r = classifyDataUnavailable(makeCtx(backend), 1);
+    expect(r.state).toBe('failed');
+    expect(r.reason).toMatch(/circuit open/);
+  });
+
+  it('backend getDataLoadStatus=failed → failed, surfaces the concrete cause (t/2053)', () => {
+    const backend = {
+      getCircuitState: () => 'closed',
+      getDataLoadStatus: () => ({ status: 'failed' as const, error: 'fetch failed: ECONNRESET' }),
+    };
+    const r = classifyDataUnavailable(makeCtx(backend), 1);
+    expect(r.state).toBe('failed');
+    expect(r.reason).toContain('ECONNRESET');
+  });
+
+  it('backend without getDataLoadStatus still classifies (feature-detected, no hard dep on t/2053)', () => {
+    const backend = { getCircuitState: () => 'closed' }; // no getDataLoadStatus method
+    const warming = classifyDataUnavailable(makeCtx(backend), 2);
+    const failed = classifyDataUnavailable(makeCtx(backend), DATA_LOAD_GRACE_S + 5);
+    expect(warming.state).toBe('warming');
+    expect(failed.state).toBe('failed');
+  });
+
+  it('warming and failed render distinct states AND distinct reasons', () => {
+    const warming = classifyDataUnavailable(makeCtx(null), 1);
+    const failed = classifyDataUnavailable(makeCtx(null), DATA_LOAD_GRACE_S + 30);
+    expect(warming.state).not.toBe(failed.state);
+    expect(warming.reason).not.toBe(failed.reason);
+  });
+});

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -14,6 +14,7 @@ import path from 'path';
 import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error } from '../httpKit.js';
+import { classifyDataUnavailable, type ReadinessState } from './readiness.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { getProjectRoot, getDataRoot, hasApiKey, STORAGE_MODE } from '../config.js';
 import { getConfig } from '../runtimeConfig.js';
@@ -22,6 +23,26 @@ import * as community from '../community/community.js';
 import * as fileIO from '../storage/fileIO.js';
 import { log } from '../logger.js';
 import { LLMS_TXT } from '../llmsTxt.js';
+
+// t/2059: throttle the readiness log to state transitions. ACA probes /healthz
+// every few seconds, so logging every not-ready probe would spam the log. Emit
+// once when the state flips — error for `failed`, info for `warming` — so the
+// server log names the state without drowning it.
+let lastReadinessState: ReadinessState['state'] | null = null;
+
+function logReadinessTransition(readiness: ReadinessState, dataRoot: string): void {
+  if (readiness.state === lastReadinessState) return;
+  lastReadinessState = readiness.state;
+  if (readiness.state === 'failed') {
+    log.server.error({ dataRoot, reason: readiness.reason }, 'Readiness: data-load failed');
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'healthz', level: 'error',
+      message: 'Readiness: data-load failed', data: { reason: readiness.reason },
+    });
+  } else {
+    log.server.info({ dataRoot, reason: readiness.reason }, 'Readiness: warming (data load in progress)');
+  }
+}
 
 export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
   const { get, put } = r;
@@ -40,12 +61,19 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
   });
 
   get('/healthz', async (_req, res) => {
+    const dataRoot = fileIO.getDataRootPath();
     const dataAvailable = await fileIO.isDataAvailable();
     if (dataAvailable) {
-      json(res, { status: 'healthy', dataRoot: fileIO.getDataRootPath() });
-    } else {
-      json(res, { status: 'unhealthy', reason: 'taxonomy data not found', dataRoot: fileIO.getDataRootPath() }, 503);
+      json(res, { status: 'healthy', dataRoot });
+      return;
     }
+    // Not ready → still 503 (readiness semantics unchanged), but name WHY so a
+    // permanent data-load failure is distinguishable from a normal cold-start
+    // warm-up, in both the body and the server log (t/2059). `state` is
+    // 'warming' | 'failed'; on 'failed', `reason` carries the underlying cause.
+    const readiness = classifyDataUnavailable(ctx, process.uptime());
+    logReadinessTransition(readiness, dataRoot);
+    json(res, { status: 'unhealthy', state: readiness.state, reason: readiness.reason, dataRoot }, 503);
   });
 
   get('/health', async (_req, res) => {

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -64,6 +64,10 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
     const dataRoot = fileIO.getDataRootPath();
     const dataAvailable = await fileIO.isDataAvailable();
     if (dataAvailable) {
+      // Reset the readiness-log throttle so a later re-failure (a flapping
+      // replica: failed → healthy → failed) re-logs instead of being swallowed
+      // by the sentinel still reading its pre-recovery state (Quality t/2059#5).
+      lastReadinessState = null;
       json(res, { status: 'healthy', dataRoot });
       return;
     }

--- a/taxonomy-editor/src/server/routes/readiness.ts
+++ b/taxonomy-editor/src/server/routes/readiness.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2059: /healthz readiness diagnosis. When the taxonomy data isn't available,
+// a bare 503 cannot tell a normal cold-start warm-up apart from a *permanent*
+// data-load failure — that ambiguity is exactly what turned the t/2047 incident
+// into a multi-agent log hunt ("app inits fully, no exception, readiness 503"
+// gives a responder nothing to act on). This classifies the not-ready state so
+// both the /healthz body and the server log name it:
+//   - 'warming' : startup grace, data load in progress → 503 is expected.
+//   - 'failed'  : data load has permanently failed → 503 with the underlying cause.
+//
+// The 503 status itself is unchanged (readiness semantics preserved) — this is
+// purely diagnostic content. Deploy probes (ACA) key on the status CODE, not the
+// body, so adding these fields is backward-compatible.
+
+import type { ServerCtx } from './context.js';
+
+/**
+ * Startup grace window (seconds). A GitHub cold-start data load (a repo-tree
+ * fetch + conflicts warm) completes in well under this; past it, an unavailable
+ * dataset is treated as a permanent failure rather than a still-loading warm-up.
+ */
+export const DATA_LOAD_GRACE_S = 60;
+
+export interface ReadinessState {
+  state: 'warming' | 'failed';
+  reason: string;
+}
+
+// Structural view of the optional data-load status the storage backend may
+// expose (Server Storage, t/2053: `getDataLoadStatus()`). Feature-detected so
+// /healthz names a cause whether or not that method is present on the running
+// backend — no hard build/runtime dependency on t/2053 landing first.
+interface DataLoadStatusProvider {
+  getDataLoadStatus?: () => { status: 'loading' | 'ready' | 'failed'; error?: string };
+}
+
+/**
+ * Classify a not-ready (`isDataAvailable() === false`) /healthz result as either
+ * a normal warm-up or a permanent failure, and name the cause. Pure: `uptimeS`
+ * (seconds since process start, e.g. `process.uptime()`) is injected so callers
+ * and tests control the grace clock deterministically.
+ */
+export function classifyDataUnavailable(ctx: ServerCtx, uptimeS: number): ReadinessState {
+  const backend = ctx.getGithubBackend();
+
+  // 1. Richest signal, when the backend exposes it (t/2053): its own data-load
+  //    status carries the concrete transport cause.
+  const provider = backend as unknown as DataLoadStatusProvider | null;
+  const status = typeof provider?.getDataLoadStatus === 'function' ? provider.getDataLoadStatus() : null;
+  if (status?.status === 'failed') {
+    return { state: 'failed', reason: `data-load failed: ${status.error ?? 'unknown cause'}` };
+  }
+
+  // 2. Transport circuit open ⇒ the GitHub data load is systematically failing.
+  if (backend && backend.getCircuitState() === 'open') {
+    return { state: 'failed', reason: 'data-load failed: github-api circuit open' };
+  }
+
+  // 3. No definitive failure signal: within the grace window this is a normal
+  //    cold-start warm-up; past it, an indefinite 503 is a permanent failure.
+  if (uptimeS <= DATA_LOAD_GRACE_S) {
+    return { state: 'warming', reason: `data load in progress (uptime ${Math.round(uptimeS)}s)` };
+  }
+  return {
+    state: 'failed',
+    reason: `data-load failed: taxonomy data still unavailable after ${Math.round(uptimeS)}s (grace ${DATA_LOAD_GRACE_S}s exhausted)`,
+  };
+}


### PR DESCRIPTION
## What & why (t/2059)

`/healthz` returned a **bare 503 with no reason** when taxonomy data was unavailable — a *permanent* data-load failure looked byte-identical to a normal cold-start warm-up. That ambiguity is what turned the t/2047 incident into a multi-agent log hunt.

This classifies the not-ready state and names it in **both the response body and the server log**:
- `warming` — startup grace, data load in progress → 503 expected.
- `failed` — data-load permanently failed → 503 with the underlying cause.

## Design

- `routes/readiness.ts` — pure `classifyDataUnavailable(ctx, uptimeS)`. Failure signals, in order: backend `getDataLoadStatus()` (Server Storage, t/2053), github circuit `open`, then grace-window exhaustion (`DATA_LOAD_GRACE_S = 60`).
- `getDataLoadStatus()` is **feature-detected** — `/healthz` names a cause whether or not that method is present on the running backend. **No hard dependency on t/2053 landing**; when it lands, the cause auto-enriches with the concrete transport error.
- `routes/meta.ts` — `/healthz` handler renders `{ status, state, reason, dataRoot }` on the 503 path. Readiness log is **throttled to state transitions** (ACA probes every few seconds) — error on flip to `failed`, info on `warming`.

## Contract safety (per AC)
- **503 status unchanged** — readiness semantics preserved; new body fields are additive.
- ACA deploy probes key on the **status code**, not the body → backward-compatible.
- No route added/removed — `routeTable` snapshot unchanged.

## Scope note (flagged to TL)
t/2059#1 also asked to elevate the `server.ts:1370-81` conflicts-warm failure to ERROR + set readiness `failed`. The later t/2053 re-attribution (#7/#8, decisive A/B #12–15) established the conflicts-warm is a **perf co-symptom, non-fatal to readiness** — wiring it into `failed` would misclassify. **Recommending that sub-item be descoped**; not implemented here. See ticket comment.

## Tests
`__tests__/healthzReadiness.test.ts` — 6 cases: warming within grace, failed past grace, circuit-open→failed, `getDataLoadStatus=failed` surfaces the cause, feature-detect w/o the method, and warming/failed render distinct state **and** reason. `npx tsc -p tsconfig.main.json` clean; scoped vitest green.

Review routing: **Quality** (diagnostic-content change, not a consumed-contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)