### PR TITLE
docs(comp-linguist): fix three wrong-relative-path links (t/2092)

### DIFF
--- a/research/comp-linguist/analyses/wisdom-generating-topics.md
+++ b/research/comp-linguist/analyses/wisdom-generating-topics.md
@@ -343,4 +343,4 @@ When all three conditions hold, the debate becomes a structured search for the b
 ---
 
 *Drafted: 2026-05-21 | Computational Linguist | AI Triad Research*
-*Related: [epistemic-infrastructure-framing.md](./epistemic-infrastructure-framing.md), [calibration-methodology.md](./calibration-methodology.md), [consensus-detection-spec.md](./consensus-detection-spec.md)*
+*Related: [epistemic-infrastructure-framing.md](./epistemic-infrastructure-framing.md), [calibration-methodology.md](../docs/calibration-methodology.md), [consensus-detection-spec.md](../docs/consensus-detection-spec.md)*

--- a/research/comp-linguist/docs/topic-wisdom-evaluation-spec.md
+++ b/research/comp-linguist/docs/topic-wisdom-evaluation-spec.md
@@ -4,7 +4,7 @@
 
 This spec adds a **topic wisdom evaluation** step to the debate setup flow, inserted between topic refinement and clause decomposition. It scores candidate topics across 10 dimensions -- 5 deterministic and 5 LLM-assessed -- and triggers an LLM-powered reframing pass when the score falls below threshold.
 
-Grounded in [wisdom-generating-topics.md](./wisdom-generating-topics.md). Implementation owned by Shared Lib.
+Grounded in [wisdom-generating-topics.md](../analyses/wisdom-generating-topics.md). Implementation owned by Shared Lib.
 
 ---
 


### PR DESCRIPTION
All three flagged links were path errors — the two "missing" specs exist in docs/ while the links said ./ from analyses/. Repointed; every relative link in both files verified resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)