### PR TITLE
docs(files): delink 10 FILES.md from sibling overlay AGENTS.md (t/2092 Group A)

### DIFF
--- a/lib/debate/FILES.md
+++ b/lib/debate/FILES.md
@@ -1,6 +1,6 @@
 # DebateTool — File Inventory
 
-Reference index of the key modules in `lib/debate/` (the debate engine core). **Reference only** — behavioral norms, conventions, and testing/parent-role guidance live in [AGENTS.md](./AGENTS.md). This index drifts as the tree evolves; it is also discoverable via directory listing, `resolve_owner`, and `REPO_MAP.md`.
+Reference index of the key modules in `lib/debate/` (the debate engine core). **Reference only** — behavioral norms, conventions, and testing/parent-role guidance live in `AGENTS.md`. This index drifts as the tree evolves; it is also discoverable via directory listing, `resolve_owner`, and `REPO_MAP.md`.
 
 ## Key Modules
 

--- a/taxonomy-editor/src/main/FILES.md
+++ b/taxonomy-editor/src/main/FILES.md
@@ -1,7 +1,7 @@
 # ElectronMain — File Inventory
 
 Reference inventory of the Electron main-process files in `taxonomy-editor/src/main/`.
-Behavioral norms live in [AGENTS.md](./AGENTS.md); this file is discovery only.
+Behavioral norms live in `AGENTS.md`; this file is discovery only.
 
 | File | Purpose |
 |------|---------|

--- a/taxonomy-editor/src/renderer/components/analysis/FILES.md
+++ b/taxonomy-editor/src/renderer/components/analysis/FILES.md
@@ -2,7 +2,7 @@
 
 Reference inventory of the analysis/dashboard components in this scope
 (`taxonomy-editor/src/renderer/components/analysis/`). Behavioral norms live in
-[AGENTS.md](./AGENTS.md).
+`AGENTS.md`.
 
 | File | Purpose |
 |------|---------|

--- a/taxonomy-editor/src/renderer/components/conflict/FILES.md
+++ b/taxonomy-editor/src/renderer/components/conflict/FILES.md
@@ -1,6 +1,6 @@
 # Conflict — File Inventory
 
-Reference inventory for the conflict detection/resolution UI. Behavioral norms and conventions live in [AGENTS.md](./AGENTS.md).
+Reference inventory for the conflict detection/resolution UI. Behavioral norms and conventions live in `AGENTS.md`.
 
 | File | Purpose |
 |------|---------|

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/FILES.md
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/FILES.md
@@ -1,6 +1,6 @@
 # DebateDiagnostics — File Inventory
 
-Directory map for `taxonomy-editor/src/renderer/components/debate-diagnostics/`. Reference only — behavioral norms live in [AGENTS.md](./AGENTS.md).
+Directory map for `taxonomy-editor/src/renderer/components/debate-diagnostics/`. Reference only — behavioral norms live in `AGENTS.md`.
 
 ```
 debate-diagnostics/

--- a/taxonomy-editor/src/renderer/components/debate-workspace/FILES.md
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/FILES.md
@@ -1,6 +1,6 @@
 # DebateWorkspace — File Inventory
 
-Reference inventory for the DebateWorkspace scope. Behavioral norms live in [AGENTS.md](./AGENTS.md).
+Reference inventory for the DebateWorkspace scope. Behavioral norms live in `AGENTS.md`.
 
 ## Components (`debate-workspace/`)
 

--- a/taxonomy-editor/src/renderer/components/debate/FILES.md
+++ b/taxonomy-editor/src/renderer/components/debate/FILES.md
@@ -1,6 +1,6 @@
 # DebateUI — File Inventory
 
-Reference inventory for the DebateUI scope (`components/debate/`). Behavioral norms — including the "Not in Scope — route, don't build" container-vs-workspace boundary — live in [AGENTS.md](./AGENTS.md).
+Reference inventory for the DebateUI scope (`components/debate/`). Behavioral norms — including the "Not in Scope — route, don't build" container-vs-workspace boundary — live in `AGENTS.md`.
 
 ## Key Files
 

--- a/taxonomy-editor/src/renderer/components/edge-browser/FILES.md
+++ b/taxonomy-editor/src/renderer/components/edge-browser/FILES.md
@@ -1,6 +1,6 @@
 # EdgeBrowser — File Inventory
 
-Reference inventory of `taxonomy-editor/src/renderer/components/edge-browser/`. Behavioral conventions live in [AGENTS.md](./AGENTS.md).
+Reference inventory of `taxonomy-editor/src/renderer/components/edge-browser/`. Behavioral conventions live in `AGENTS.md`.
 
 | File | Purpose |
 |------|---------|

--- a/taxonomy-editor/src/renderer/components/sync/FILES.md
+++ b/taxonomy-editor/src/renderer/components/sync/FILES.md
@@ -1,6 +1,6 @@
 # Sync — File Inventory
 
-Reference inventory for the Sync role's scope (`taxonomy-editor/src/renderer/components/sync/`). Behavioral norms and conventions live in [AGENTS.md](./AGENTS.md).
+Reference inventory for the Sync role's scope (`taxonomy-editor/src/renderer/components/sync/`). Behavioral norms and conventions live in `AGENTS.md`.
 
 | File | Purpose |
 |------|---------|

--- a/taxonomy-editor/src/server/FILES.md
+++ b/taxonomy-editor/src/server/FILES.md
@@ -2,7 +2,7 @@
 
 Core-layer files owned by **ServerAPI Main** (the HTTP/wiring layer). Cluster
 modules (auth/keys, storage, AI proxy, community/admin) belong to the sub-roles —
-see the Sub-roles table in [AGENTS.md](./AGENTS.md).
+see the Sub-roles table in `AGENTS.md`.
 
 | File | Purpose |
 |------|---------|


### PR DESCRIPTION
## What
Uniform 1-line delink across **10 main-repo-tracked `FILES.md`**: `[AGENTS.md](./AGENTS.md)` → `` `AGENTS.md` `` (inline code).

## Why
Each `FILES.md` (public) linked its sibling `AGENTS.md`, which is an **Orca overlay file — not in the public repo**, so the link 404s for public viewers. Surfaced by the new doc-link check (t/2091). Delinking preserves the fleet-facing pointer and removes the public dead link. Not repointed to root `/AGENTS.md` (sibling AGENTS.md carry role-specific guidance; the target has no public equivalent).

## Scope discipline (per TL conditions, t/2092#2)
- **Uniform delink only** — nothing else bundled; each diff is the single link line (10 files, 10 insertions, 10 deletions).
- No generator exists (confirmed) — hand edit is the durable fix.
- Group B (comp-linguist) is **out of scope** here — handled in #329.

## Verification
`bash .github/scripts/check-doc-links.sh` on this branch: **Group A → 0**. The 3 residual warnings are Group B, clearing when #329 lands.

## Owners notified (object to your FILES.md wording before merge)
DebateTool, ElectronMain, ServerAPI, Analysis, Conflict, DebateUI, DebateDiagnostics, DebateWorkspace, EdgeBrowser, Sync.

Routed to **TL** for diff verification + admin-merge (docs-only main-repo PR).

Ref: t/2092

🤖 Generated with [Claude Code](https://claude.com/claude-code)