### PR TITLE
ci: parallelize test-container off the test matrix (t/2073)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,12 +462,24 @@ jobs:
         continue-on-error: true
         run: node scripts/validate-schemas.mjs
 
+  # ── test-container: build+readiness-smoke, PARALLELIZED off the test jobs (t/2073) ──
+  # WAS `needs: [test-powershell, test-electron]` with a `!contains(failure)`
+  # guard — i.e. the container build waited for the ENTIRE test matrix before
+  # starting, purely as a fail-fast "don't build on red" gate, NOT a data
+  # dependency (the Dockerfile does its own `npm ci`/build and reuses no artifact
+  # from those jobs — verified t/2073). That serialization put container
+  # (~250s) *after* the long-pole test-electron/taxonomy-editor (~420s), so the
+  # merge-gating critical path was electron+container in series (~11–12.5 min).
+  # Decoupling it to `needs: [changes]` runs it CONCURRENTLY, collapsing the path
+  # to max(electron, container) ≈ electron alone — ~35% off the full-fat path.
+  # Coverage is UNCHANGED: `ci-gate` (below) lists test-container in its own
+  # `needs` and independently blocks on its failure, so a red container still
+  # reds the gate. The only cost is a wasted container build on a PR whose tests
+  # already failed — free on this public repo's runner minutes, the tradeoff the
+  # ticket sanctions (wall-time over redundant compute).
   test-container:
-    needs: [test-powershell, test-electron]
-    if: >-
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+    needs: [changes]
+    if: always() && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@
 # What:  Runs all quality gates: Pester tests with coverage, ESLint + TypeScript
 #        checks for all 4 Electron apps (matrix), and a container smoke test.
 # Before: Triggers automatically on push/PR to main. No manual setup needed.
-# After:  All checks must pass before merging. The test-container job depends on
-#         test-powershell and test-electron completing successfully.
+# After:  All checks must pass before merging. test-container runs in PARALLEL
+#         with the test matrix (it reuses no test artifact — t/2073); the
+#         always-runs ci-gate job is what blocks the merge on any red gated job.
 #
 # ── continue-on-error flip taxonomy ──
 # FLIPPED — enforcing now (continue-on-error removed):


### PR DESCRIPTION
## What
Decouples `test-container` from `needs: [test-powershell, test-electron]` → `needs: [changes]`, so the container build+readiness-smoke runs **concurrently** with the test matrix instead of serialized behind it.

## Why (t/2073 — cut merge-gating wall-time)
Profiling ≥5 real full-fat PRs shows the merge-gating critical path is:
`changes` (5s) → `test-electron/taxonomy-editor` (~420s, long pole of the matrix) → `test-container` (~250s, gated behind the whole matrix) → `ci-gate` (4s) ≈ **11–12.5 min**.

`test-container` is serialized behind the tests purely as a fail-fast "don't build on red" gate — **not a data dependency**. The Dockerfile does its own `npm ci`/build and reuses no artifact from the test jobs (verified). Running it in parallel collapses the path from `electron + container` to `max(electron, container) ≈ electron` — **~35% off the full-fat path** (~11.5m → ~7.5m).

## Coverage / gate integrity (unchanged)
`ci-gate` still lists `test-container` in its own `needs` and independently blocks on its failure, so a red container still reds the gate. Nothing is dropped or moved off the gate. The only cost is a redundant container build on a PR whose tests already failed — free on this public repo's runner minutes.

## Verification
- Full-fat PR: this PR itself (ends green, container runs concurrently).
- Docs-only skip-path + deliberately-failed-job gate proof: posted on t/2073.

Refs t/2073.