### PR TITLE
ci: paths-filter test-container so docs-only PRs skip the container build (t/2094)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       schema: ${{ steps.filter.outputs.schema }}
       lib: ${{ steps.filter.outputs.lib }}
       python: ${{ steps.filter.outputs.python }}
+      container: ${{ steps.filter.outputs.container }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         id: filter
@@ -98,6 +99,33 @@ jobs:
             python:
               - 'scripts/requirements*.txt'
               - '.github/ci/**'
+              - '.github/workflows/ci.yml'
+            # 'container' gates test-container (t/2094). SOUNDNESS: ci-gate treats
+            # a SKIPPED gated job as satisfied, so this list must cover EVERYTHING
+            # the container build reads, or a container-affecting change skips the
+            # build and false-greens (the t/2025 shape). Derived from the actual
+            # COPY set of taxonomy-editor/Dockerfile (builder+prod-deps+runtime
+            # stages) + the base Dockerfile + the readiness smoke:
+            #   taxonomy-editor/**  — Dockerfile, src, tsconfig*, vite.config,
+            #                         scripts, package*.json, pty-broker.py
+            #   lib/**              — COPY lib/ (server build input)
+            #   ai-models.json, ai-usages.json, .aitriad.json, CHANGELOG.md — COPY'd
+            #   taxonomy/schemas/** — COPY taxonomy/schemas/
+            #   scripts/**          — COPY scripts/ into the runtime image
+            #   deploy/azure/Dockerfile.base — pulled-or-built + hadolint'd here
+            #   deploy/azure/smoke-healthz.sh — the readiness smoke this job runs
+            # (taxonomy-snapshot/ is STUBBED in-job, so it is NOT a repo input.)
+            container:
+              - 'taxonomy-editor/**'
+              - 'lib/**'
+              - 'scripts/**'
+              - 'taxonomy/schemas/**'
+              - 'ai-models.json'
+              - 'ai-usages.json'
+              - '.aitriad.json'
+              - 'CHANGELOG.md'
+              - 'deploy/azure/Dockerfile.base'
+              - 'deploy/azure/smoke-healthz.sh'
               - '.github/workflows/ci.yml'
 
   test-powershell:
@@ -478,9 +506,18 @@ jobs:
   # reds the gate. The only cost is a wasted container build on a PR whose tests
   # already failed — free on this public repo's runner minutes, the tradeoff the
   # ticket sanctions (wall-time over redundant compute).
+  #
+  # PATHS-FILTERED (t/2094): gated on the `container` filter so docs-only / PS-doc
+  # PRs (which touch none of the image's COPY inputs) SKIP the ~270s build — the
+  # largest relative win on the PR class the fleet files most. skipped == OK
+  # through ci-gate. SOUNDNESS: the `container` filter (in `changes` above) must
+  # cover every input the image build reads, or a container-affecting change
+  # skips the build and false-greens (t/2025 shape) — see that filter's comment.
   test-container:
     needs: [changes]
-    if: always() && !cancelled()
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.container == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,12 @@ jobs:
             #   deploy/azure/Dockerfile.base — pulled-or-built + hadolint'd here
             #   deploy/azure/smoke-healthz.sh — the readiness smoke this job runs
             # (taxonomy-snapshot/ is STUBBED in-job, so it is NOT a repo input.)
+            # '.dockerignore' governs what every COPY actually copies from the
+            # root build context (context: .), so a .dockerignore-only edit can
+            # change the image — it must trigger the build (t/2094 review, TL2).
             container:
               - 'taxonomy-editor/**'
+              - '.dockerignore'
               - 'lib/**'
               - 'scripts/**'
               - 'taxonomy/schemas/**'


### PR DESCRIPTION
## What
Adds a `container` paths-filter to the `changes` job and gates `test-container` on it (same idiom as every other gated job). Docs-only / PS-doc PRs that touch none of the image's COPY inputs now **skip** the ~270s container build.

## Why (t/2094 — child of t/2073)
`test-container` was the only gated job with no paths-filter (`if: always() && !cancelled()`). A docs-only PR skipped the test matrix but still spent ~270s building+smoking a container no docs change can affect — ~98% of a docs-only PR's merge-gating wall-time (measured 268s on PR #331's run). Docs-only is the PR class the fleet files most often.

## Filter derivation (soundness is the whole risk)
`ci-gate` treats a SKIPPED gated job as satisfied, so the filter must cover **everything the image build reads** or a container-affecting change false-greens (t/2025 shape). Derived from the actual `COPY` set of `taxonomy-editor/Dockerfile` (builder + prod-deps + runtime stages) + `deploy/azure/Dockerfile.base` (built/linted here) + `deploy/azure/smoke-healthz.sh` (the readiness smoke):

| Filter path | Why |
|---|---|
| `taxonomy-editor/**` | Dockerfile, src, tsconfig*, vite.config, scripts, package*.json, pty-broker.py |
| `lib/**` | `COPY lib/` (server build input) |
| `scripts/**` | `COPY scripts/` into runtime image |
| `taxonomy/schemas/**` | `COPY taxonomy/schemas/` |
| `ai-models.json`, `ai-usages.json`, `.aitriad.json`, `CHANGELOG.md` | COPY'd in builder/runtime |
| `deploy/azure/Dockerfile.base` | pulled-or-built + hadolint'd in this job |
| `deploy/azure/smoke-healthz.sh` | the readiness smoke this job runs |
| `.github/workflows/ci.yml` | per convention (ci.yml edit runs the full suite) |

`taxonomy-snapshot/` is **stubbed in-job**, so it is not a repo input (correctly excluded).

## Verification (post-merge, per AC — the filter must be live on main)
- Skip path: docs-only PR → `test-container` SKIPPED, `ci-gate` green (+ docs-only before/after timing).
- Soundness: a PR touching `deploy/azure/Dockerfile.base` (outside `taxonomy-editor/**`) still RUNS `test-container`.
- Gate bite: a deliberately-failed `test-container` reds `ci-gate` (shared with t/2073-A).

This PR itself edits `ci.yml` → `test-container` runs (full-fat), so it exercises the run path.

Refs t/2094.