### PR TITLE
fix(deploy): pin ingress traffic + retention so a Bicep apply never auto-promotes (t/2049, t/2050)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -166,6 +166,38 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Capture current active revisions (traffic-pin + rollback targets)
+        id: current_revision
+        shell: pwsh
+        run: |
+          # t/2049 + t/2047 landmine: main.bicep defines BOTH the prod and staging
+          # apps, so EVERY apply reconciles BOTH. Capture each app's CURRENT ACTIVE
+          # revision BEFORE the apply and pass both as ingress traffic pins, so the
+          # apply holds traffic on the known-good revision (never auto-promoting a
+          # new one) — for both apps, regardless of which environment we deploy.
+          # The prod capture doubles as the rollback target.
+          $ErrorActionPreference = 'Stop'   # abort on az failure — never pass a
+                                            # silent empty pin when capture itself
+                                            # failed (t/2049#6). Empty is passed ONLY
+                                            # when there is verifiably no active
+                                            # revision (genuine first/only deploy).
+          Import-Module ./scripts/AITriad/AITriad.psm1 -Force
+          function Get-ActivePin {
+            param([string]$App, [string]$Rg)
+            $Active = @(Get-ContainerAppRevision -Mode Active -AppName $App -ResourceGroup $Rg)
+            if ($Active.Count -eq 0) { return '' }
+            # Steady state = exactly one revision at >0% traffic. If a prior deploy
+            # left a split, pin the highest-weight revision.
+            $Top = @($Active | Sort-Object -Property TrafficWeight -Descending)[0]
+            return $Top.Name
+          }
+          $ProdRev    = Get-ActivePin -App '${{ env.CONTAINER_APP_NAME }}'         -Rg '${{ env.RESOURCE_GROUP }}'
+          $StagingRev = Get-ActivePin -App '${{ env.CONTAINER_APP_NAME }}-staging' -Rg '${{ env.RESOURCE_GROUP }}'
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "revision=$ProdRev"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "staging_revision=$StagingRev"
+          Write-Host "Prod pin / rollback target: '$ProdRev'"
+          Write-Host "Staging pin target:         '$StagingRev'"
+
       - name: Preview Bicep changes (what-if)
         run: |
           echo "Previewing infrastructure changes..."
@@ -174,6 +206,8 @@ jobs:
             --template-file deploy/azure/main.bicep \
             --parameters \
               containerImage=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.resolve_tag.outputs.tag }} \
+              trafficPinRevisionName=${{ steps.current_revision.outputs.revision }} \
+              trafficPinRevisionNameStaging=${{ steps.current_revision.outputs.staging_revision }} \
               googleClientId=${{ secrets.GOOGLE_CLIENT_ID }} \
               googleClientSecret=${{ secrets.GOOGLE_CLIENT_SECRET }} \
               githubClientId=${{ secrets.GH_OAUTH_CLIENT_ID }} \
@@ -236,28 +270,33 @@ jobs:
             freeTierGeminiKey=${{ secrets.FREE_TIER_GEMINI_KEY }}
             geminiPaidKey=${{ secrets.GEMINI_PAID_KEY }}
             budgetAlertEmail=${{ vars.ALERT_EMAIL }}
+            trafficPinRevisionName=${{ steps.current_revision.outputs.revision }}
+            trafficPinRevisionNameStaging=${{ steps.current_revision.outputs.staging_revision }}
 
-      - name: Get current active revision
-        id: current_revision
-        shell: pwsh
-        run: |
-          Import-Module ./scripts/AITriad/AITriad.psm1 -Force
-          $Rev = Get-ContainerAppRevision -Mode Active `
-            -AppName '${{ env.CONTAINER_APP_NAME }}' `
-            -ResourceGroup '${{ env.RESOURCE_GROUP }}'
-          $RevName = if ($Rev) { $Rev.Name } else { '' }
-          Add-Content -Path $env:GITHUB_OUTPUT -Value "revision=$RevName"
-          Write-Host "Current active revision: $RevName"
+      # NOTE: the current active revision is now captured BEFORE the Bicep apply
+      # (see "Capture current active revisions" above) so it can be passed as the
+      # traffic pin. steps.current_revision.outputs.revision remains the rollback
+      # target below — and, with the pin, that revision holds 100% throughout the
+      # deploy, so it can never drop to 0% / go stale / be GC'd mid-deploy (t/2047).
 
       - name: Cleanup stale revisions
         shell: pwsh
         run: |
           Import-Module ./scripts/AITriad/AITriad.psm1 -Force
           Write-Host "Deactivating stale revisions to free resources..."
+          # t/2050: NEVER deactivate the captured rollback target. With the t/2049
+          # pin it stays at 100% (not stale) so it should never appear here, but we
+          # guard explicitly so no reorder or transient split can strand the
+          # rollback target the way t/2047 did.
+          $Protected = @('${{ steps.current_revision.outputs.revision }}') | Where-Object { $_ }
           $Stale = @(Get-ContainerAppRevision -Mode Stale `
             -AppName '${{ env.CONTAINER_APP_NAME }}' `
             -ResourceGroup '${{ env.RESOURCE_GROUP }}')
           foreach ($Rev in $Stale) {
+            if ($Protected -contains $Rev.Name) {
+              Write-Host "Skipping protected rollback target: $($Rev.Name)"
+              continue
+            }
             Disable-ContainerAppRevision -RevisionName $Rev.Name `
               -AppName '${{ env.CONTAINER_APP_NAME }}' `
               -ResourceGroup '${{ env.RESOURCE_GROUP }}'

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -31,6 +31,26 @@ param containerImage string = 'ghcr.io/jpsnover/taxonomy-editor:latest'
 @description('Unique suffix for globally unique resource names')
 param uniqueSuffix string = uniqueString(resourceGroup().id)
 
+// ── Traffic pin (t/2049 — pre-traffic canary/health gate) ──
+// In activeRevisionsMode 'Multiple' with NO ingress.traffic block, a full Bicep
+// apply reconciles traffic and promotes the LATEST revision to 100% — before the
+// deploy workflow's readiness gate ever runs (the t/2047 bypass). Worse: this
+// template defines BOTH the prod and staging apps, so EVERY apply reconciles
+// BOTH — a staging-intent deploy would silently wipe a manual prod rollback pin
+// and re-promote prod's latest (t/2049#6 landmine). To close this, each app's
+// ingress pins 100% traffic to an explicit, already-live revision. The deploy
+// workflow and deploy.ps1 capture each app's CURRENT ACTIVE revision and pass it
+// here, so a newly-created revision starts at 0% and is promoted only after
+// /healthz readiness + acceptance + persona gates pass. Empty = genuine
+// first/only deploy -> latest gets 100% (safe; there is nothing to hold).
+// NEVER pass empty as a silent fallback when the capture step FAILED — the
+// capture must abort instead (t/2049#6).
+@description('Full name of the revision to hold 100% PROD ingress traffic on during a Bicep apply (e.g. "taxonomy-editor--restore-gem"). Empty = first/only deploy (latest gets 100%).')
+param trafficPinRevisionName string = ''
+
+@description('Full name of the revision to hold 100% STAGING ingress traffic on during a Bicep apply. Empty = first/only staging deploy (latest gets 100%).')
+param trafficPinRevisionNameStaging string = ''
+
 // ── Resource Tags ──
 var tags = {
   project: 'ai-triad-research'
@@ -419,11 +439,22 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
     managedEnvironmentId: containerAppEnv.id
     configuration: {
       activeRevisionsMode: 'Multiple'
+      // t/2050: retain recent inactive revisions so a rollback / forensic target
+      // survives ACA garbage collection. The t/2047 outage's auto-rollback was a
+      // no-op because the prior good revision had been GC'd. 10 keeps roughly a
+      // sprint of history at negligible cost (inactive revisions run no replicas).
+      maxInactiveRevisions: 10
       ingress: {
         external: true
         targetPort: 7862
         transport: 'auto' // supports both HTTP and WebSocket
         allowInsecure: false
+        // t/2049: hold 100% traffic on an explicit, already-live revision so this
+        // apply never auto-promotes a new one (see the trafficPinRevisionName
+        // param header). Empty pin -> latest@100 (first/only deploy).
+        traffic: empty(trafficPinRevisionName)
+          ? [ { latestRevision: true, weight: 100 } ]
+          : [ { revisionName: trafficPinRevisionName, weight: 100 } ]
       }
       secrets: oauthSecrets
     }
@@ -517,11 +548,18 @@ resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
     managedEnvironmentId: containerAppEnv.id
     configuration: {
       activeRevisionsMode: 'Multiple'
+      // t/2050: retain recent inactive revisions (see prod app comment).
+      maxInactiveRevisions: 10
       ingress: {
         external: true
         targetPort: 7862
         transport: 'auto'
         allowInsecure: false
+        // t/2049: hold 100% staging traffic on an explicit live revision so a
+        // Bicep apply never auto-promotes a new one. Empty -> latest@100.
+        traffic: empty(trafficPinRevisionNameStaging)
+          ? [ { latestRevision: true, weight: 100 } ]
+          : [ { revisionName: trafficPinRevisionNameStaging, weight: 100 } ]
       }
       secrets: oauthSecrets
     }


### PR DESCRIPTION
Closes the two t/2047 post-mortem gaps that turned a bad image into a **full outage** instead of a no-op rollback:

- **t/2049** (gap #2) — pre-traffic canary/health gate: the new revision took 100% traffic before any readiness gate.
- **t/2050** (gap #3) — revision retention: auto-rollback was a no-op because the prior good revision had been GC'd.

## Root cause (empirically confirmed, t/2049#1)
In `activeRevisionsMode: 'Multiple'` with **no `ingress.traffic` block**, a full `az deployment group create` reconciles traffic and promotes the **latest** revision to 100% — *before* the workflow's readiness gate ever runs. `main.bicep` defines **both** the prod and staging apps, so **every** apply reconciles both: a staging-intent deploy could wipe a manual prod rollback pin and re-promote prod's latest (t/2049#6 landmine — confirmed live: prod is pinned to `restore-gem@100` only in live config, not the template).

## Fix
**`deploy/azure/main.bicep`**
- New params `trafficPinRevisionName` / `trafficPinRevisionNameStaging`; explicit `ingress.traffic` block on **both** apps that holds 100% on the pinned (already-live) revision. Empty → `latestRevision@100` (genuine first/only deploy).
- `maxInactiveRevisions: 10` on both apps (t/2050) so a rollback/forensic target survives ACA GC.

**`.github/workflows/deploy-azure.yml`**
- New **"Capture current active revisions"** step *before* the apply: captures prod + staging current-active, **aborts on `az` failure**, passes empty only when there is verifiably no active revision (t/2049#6 hardening). Passes both pins to the what-if + arm-deploy so the apply never auto-promotes either app.
- Cleanup step now **never deactivates the captured rollback target** (t/2050 belt-and-suspenders).

**Readiness gate (t/2049 condition #3): already satisfied — no change.** The existing "Health check new revision" step gates on `Test-TaxEditorHealth`, which requires `/healthz == 'healthy'` (data-loaded) plus `/health`, anon-auth, and an authenticated `/api/flags` — the exact data-not-ready catch.

## Proof — red-then-safe (isolated app in the existing ACA env; **zero prod/staging-app impact**)
Deployed a throwaway `t2049-proof` app (incremental mode → touches only that new resource) with the same ingress shape; forced new revisions via env-var bumps (promote-vs-pin is image-independent):

| Step | Apply | Result |
|---|---|---|
| 1 | `pin=''`, v1 (first) | `v1 @ 100` |
| 2 **RED** | `pin=''`, v2 (unpinned = old behavior) | **`v2 @ 100`, v1 → 0%** — auto-promote (the t/2047 bypass) |
| 3 **GREEN** | `pin=v2`, v3 | **`v2 holds 100%`, `v3 @ 0%`** — new revision starts at 0%; gate runs before promotion |

Throwaway app + deployment records deleted; prod (`restore-gem@100`) and staging (`latestRevision@100`) verified **untouched**. Read-only what-if against the real RG confirmed the fixed template resolves prod traffic to `restore-gem@100` (resource-level `changeType: Modify`, not `Delete`).

Bicep compiles clean; workflow YAML validates.

## Coordination / follow-ups
- **@DevOps — `deploy.ps1` (your file, condition #1):** mirror the same param contract (capture both apps' active revision, pass `trafficPinRevisionName` + `trafficPinRevisionNameStaging`, abort-on-capture-failure). Full contract in **t/2049#7**. This PR makes the workflow the sole-promoter; deploy.ps1 must match to close the last apply path.
- **Latent finding (separate ticket, not fixed here):** the workflow's post-Bicep blue-green steps hardcode `CONTAINER_APP_NAME: taxonomy-editor` (prod) regardless of `inputs.environment`, so a `staging` dispatch runs the blue-green promotion against the **prod** app. Pre-existing; the pin defuses the cross-app landmine regardless.

## Review
Requesting co-review from **@Technical Lead** + **@DevOps** before merge (per t/2049#2/#3). Both t/2049 + t/2050 are in one PR because they share the single red-then-safe proof and touch the same two files — happy to split if TL prefers the strict "t/2050 first" sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Azure (Orca) <main.operations-devops-azure@ai-triad-research.orca.local>
Co-Authored-By: Technical Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
