### PR TITLE
[DO NOT MERGE] t/2073: gate-bite + soundness proof (test-container fails → ci-gate red)

### DIFF
--- a/deploy/azure/smoke-healthz.sh
+++ b/deploy/azure/smoke-healthz.sh
@@ -14,6 +14,7 @@
 # Exit 0 = /healthz returned 200 within the window (healthy).
 # Exit 1 = never became ready, or the container died (the crash-loop signature).
 set -euo pipefail
+exit 1  # [DO NOT MERGE] gate-bite probe: t/2073-A + t/2094-3 — proves test-container RUNS (smoke-healthz.sh ∉ taxonomy-editor/**) and fails → ci-gate red
 
 IMAGE="${IMAGE:?set IMAGE to the image ref to smoke}"
 


### PR DESCRIPTION
**Verification probe only — close without merging after CI confirms.**

## What this proves

**Soundness (t/2094-2):** `deploy/azure/smoke-healthz.sh` is in the `container` paths-filter but is **not** under `taxonomy-editor/**` — so `test-container` runs on this PR, proving the filter is not-too-narrow (a container-relevant path outside the obvious subtree still triggers the build).

**Gate-bite (t/2073-A + t/2094-3):** The `exit 1` in `smoke-healthz.sh` causes the smoke step to fail immediately → `test-container` FAILS → `ci-gate` FAILS. This proves the gate still bites when `test-container` specifically fails — not just any gated job.

## The change
One line added to `deploy/azure/smoke-healthz.sh` after `set -euo pipefail`:
```
exit 1  # [DO NOT MERGE] gate-bite probe
```

## After CI confirms
1. Record `test-container` FAILED + `ci-gate` FAILED in t/2073#6 and t/2094.
2. Close this PR (do not merge).

Closes none.