### PR TITLE
fix(deploy): traffic pin to deploy.ps1 + stale smoke-image comment (t/2049, t/2081)

### DIFF
--- a/.github/workflows/smoke-image.yml
+++ b/.github/workflows/smoke-image.yml
@@ -5,8 +5,8 @@
 #      (taxonomy-editor@sha256:da74e499… , base :2026-07-30) to prove it goes
 #      RED, and the known-good gemini image (@sha256:efd068fe…) to prove GREEN.
 #   2. Ad-hoc runtime check of any published image.
-# The durable pre-push gate lives inline in container.yml (build → smoke → push);
-# this workflow is the reusable/standalone harness.
+# The durable pre-deploy runtime gate lives in deploy-azure.yml (0%-traffic
+# health+acceptance check, t/2049); this workflow is the reusable/standalone harness.
 
 name: Image Smoke
 

--- a/deploy/azure/deploy.ps1
+++ b/deploy/azure/deploy.ps1
@@ -148,6 +148,28 @@ if (-not (Test-Path $bicepFile)) {
     throw "Bicep template not found at $bicepFile"
 }
 
+# ── Capture current active revisions for traffic pin (t/2049) ──
+# In activeRevisionsMode 'Multiple' with no ingress.traffic block, a full Bicep
+# apply promotes the LATEST revision to 100% before any readiness check — the
+# t/2047 bypass. Capture each app's current active revision BEFORE the apply and
+# pass both as traffic pins so Bicep holds 100% on the known-good revision.
+# $ErrorActionPreference='Stop' (above) ensures an az failure aborts rather than
+# passing a silent empty pin — empty is only correct for a genuine first deploy.
+Write-Step 'Capturing current active revisions for traffic pin'
+$moduleRoot = Join-Path $PSScriptRoot '..\..\scripts\AITriad\AITriad.psm1'
+Import-Module $moduleRoot -Force
+
+function Get-ActiveRevisionPin {
+    param([string]$App)
+    $Active = @(Get-ContainerAppRevision -Mode Active -AppName $App -ResourceGroup $ResourceGroup)
+    if ($Active.Count -eq 0) { return '' }
+    return (@($Active | Sort-Object -Property TrafficWeight -Descending)[0]).Name
+}
+$ProdPin    = Get-ActiveRevisionPin -App 'taxonomy-editor'
+$StagingPin = Get-ActiveRevisionPin -App 'taxonomy-editor-staging'
+Write-OK "Prod pin / rollback target: '$ProdPin'"
+Write-OK "Staging pin target:         '$StagingPin'"
+
 $deployParams = @("containerImage=$ContainerImage")
 if ($GoogleClientId)                { $deployParams += "googleClientId=$GoogleClientId" }
 if ($GoogleClientSecret)            { $deployParams += "googleClientSecret=$GoogleClientSecret" }
@@ -160,6 +182,8 @@ if ($GitHubAppInstallationId)       { $deployParams += "githubAppInstallationId=
 if ($GitHubAppPrivateKeySecretName) { $deployParams += "githubAppPrivateKeySecretName=$GitHubAppPrivateKeySecretName" }
 if ($GitHubWebhookSecret)           { $deployParams += "githubWebhookSecret=$GitHubWebhookSecret" }
 if ($BudgetAlertEmail)              { $deployParams += "budgetAlertEmail=$BudgetAlertEmail" }
+$deployParams += "trafficPinRevisionName=$ProdPin"
+$deployParams += "trafficPinRevisionNameStaging=$StagingPin"
 
 $deployResult = az deployment group create `
     --resource-group $ResourceGroup `


### PR DESCRIPTION
Two small fixes; both needed, neither touches container-gated code.

## deploy.ps1 — traffic pin for t/2049 (sole-promoter condition #1)

Mirrors the `deploy-azure.yml` t/2049 change (PR #334) so the manual Bicep-apply path is no longer a bypass. Without this, a `deploy.ps1` run in `activeRevisionsMode: Multiple` with no `ingress.traffic` block auto-promotes the latest revision to 100% before any readiness gate — the t/2047 shape.

**Change:** before the `az deployment group create` call, captures each app's current active revision (`Get-ContainerAppRevision -Mode Active`, sorted by TrafficWeight desc) and passes both as `trafficPinRevisionName` / `trafficPinRevisionNameStaging` params. `$ErrorActionPreference='Stop'` (already set globally at L85) ensures az failure aborts rather than silently passing an empty pin. Empty → `latestRevision@100` (genuine first/only deploy — correct).

## smoke-image.yml — fix stale header comment (t/2081#4, Main TL p/28#223)

L8 previously claimed: *"The durable pre-push gate lives inline in container.yml (build → smoke → push)."* `container.yml` has no smoke step. The real pre-deploy runtime gate is in `deploy-azure.yml` (0%-traffic health+acceptance check, t/2049). Fixed to point at the correct location.

## Docs-only skip proof (t/2094-1)

Neither `deploy/azure/deploy.ps1` nor `.github/workflows/smoke-image.yml` is in any `ci.yml` paths-filter, so this PR also serves as the skip-path proof for t/2094: `test-container` should be SKIPPED and `ci-gate` should be GREEN.