### PR TITLE
ci: flip test-container to liveness smoke, drop github coupling (t/2067)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,19 +600,19 @@ jobs:
           load: true
           tags: ai-triad-test:ci
 
-      - name: Run container readiness smoke — /healthz==200 (t/2048)
+      - name: Run container liveness smoke — server starts + answers (t/2048, t/2067)
         timeout-minutes: 8
         env:
           IMAGE: ai-triad-test:ci
-          # READINESS: pass ONLY on a real /healthz==200 (taxonomy data loaded via
-          # the github-api fetch). A clean single curl capture means a
-          # connection-refused ("000") can never pass — the gate-integrity trap
-          # that this whole incident (t/2047) is about. On a 503 timeout the script
-          # runs an in-container github-reachability probe to discriminate
-          # "CI-can't-fetch" (→ readiness gate moves to the deploy stage, t/2049)
-          # from a real current-main readiness bug.
-          SMOKE_MODE: readiness
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # LIVENESS: pass as soon as /healthz RESPONDS with any HTTP status (not
+          # "000" = connection refused). CI builds bake only a stub snapshot and
+          # run without real github-api creds — they can prove the container boots
+          # and listens, not that it loaded data. Zero external-service dependency
+          # → no github-reachability flake in the required PR gate (t/2067).
+          # Readiness (data loaded via github-api fetch) is enforced pre-traffic at
+          # the deploy stage by t/2049 (real env + creds) — catches the t/2047
+          # class without coupling the required PR gate to api.github.com.
+          SMOKE_MODE: liveness
         run: bash deploy/azure/smoke-healthz.sh
 
       - name: Cleanup

--- a/deploy/azure/smoke-healthz.sh
+++ b/deploy/azure/smoke-healthz.sh
@@ -30,6 +30,14 @@ IMAGE="${IMAGE:?set IMAGE to the image ref to smoke}"
 #               + creds); it's what catches the t/2047 class (starts but never
 #               data-ready). da74e499 RED / efd068fe GREEN is its AC.
 SMOKE_MODE="${SMOKE_MODE:-readiness}"
+# GITHUB_TOKEN is only required in readiness mode (github-api data-load fetch).
+# In liveness mode no external fetch is needed — default to empty so the script
+# doesn't abort when called without it (e.g. CI liveness gate, t/2067).
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+if [ "${SMOKE_MODE}" = "readiness" ] && [ -z "${GITHUB_TOKEN}" ]; then
+  echo "::error::GITHUB_TOKEN required for SMOKE_MODE=readiness (public read is enough)"
+  exit 1
+fi
 
 # READY_TIMEOUT covers real cold start: onnx model is baked, so startup is
 # app init + (readiness) the github-api taxonomy fetch (public repo, a few MB).
@@ -60,7 +68,7 @@ docker run -d --name "$NAME" -p "${PORT}:${PORT}" \
   -e NODE_ENV=production \
   -e STORAGE_MODE=github-api \
   -e GITHUB_REPO="${GITHUB_REPO:-jpsnover/ai-triad-data}" \
-  -e GITHUB_TOKEN="${GITHUB_TOKEN:?set GITHUB_TOKEN (public read is enough)}" \
+  -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
   -e AI_TRIAD_DATA_ROOT=/tmp/taxonomy-cache \
   -e AUTH_DISABLED=1 \
   -e PORT="${PORT}" \


### PR DESCRIPTION
## Summary

- **Finding #1 (doc/wiring mismatch):** `smoke-healthz.sh` co-located doc already described CI as liveness; `ci.yml` was wired to `readiness`. Flipping ci.yml makes them agree — no doc edit needed.
- **Finding #2 (latent flake):** `SMOKE_MODE=readiness` + `GITHUB_TOKEN` in the required PR gate coupled `ci-gate` to `api.github.com` reachability. A transient github unreachability from a CI runner would false-red the required gate. Removed at source: flip to `liveness` + drop `GITHUB_TOKEN` = zero external-service dep in the required PR gate.
- **smoke-healthz.sh fix:** `${GITHUB_TOKEN:?…}` in the `docker run` line would abort the script in liveness mode when no token is passed. Changed to `${GITHUB_TOKEN:-}` (empty default) + readiness-only early-exit guard (token still required for readiness invocations).

## Safety

Readiness coverage is NOT dropped — t/2049 (Done, PR #334) delivers the pre-traffic readiness canary at the deploy stage. The t/2047 class is caught pre-traffic; it just moves from PR-gate to deploy-gate. Main TL sequencing condition verified met (t/2067#1).

## Gate verification (TL condition — t/2067#3)

GREEN run: this PR's CI.
RED run: TBD — will push a gate-verification branch with a crash-loop container and paste both run URLs in t/2067 completion comment before closing.

## Test plan
- [ ] This PR passes `ci-gate` green (liveness smoke on good image)
- [ ] RED verification: separate branch with crash-loop server → `test-container` RED → `ci-gate` RED

Relates: t/2067, t/2048, t/2049, t/2065