### PR TITLE
test: liveness gate RED verification (t/2067 — DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,7 @@ jobs:
           tags: ai-triad-test:ci
 
       - name: Replace with crash-loop image (gate-proof only — t/2067)
-        if: github.ref == 'refs/heads/test/gate-verify-t2067'
+        if: github.head_ref == 'test/gate-verify-t2067'
         run: |
           # Override the built image with one that exits immediately — proves the
           # liveness gate catches crash-loop containers (t/2067 RED verification).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,19 +600,19 @@ jobs:
           load: true
           tags: ai-triad-test:ci
 
-      - name: Run container readiness smoke — /healthz==200 (t/2048)
+      - name: Run container liveness smoke — server starts + answers (t/2048, t/2067)
         timeout-minutes: 8
         env:
           IMAGE: ai-triad-test:ci
-          # READINESS: pass ONLY on a real /healthz==200 (taxonomy data loaded via
-          # the github-api fetch). A clean single curl capture means a
-          # connection-refused ("000") can never pass — the gate-integrity trap
-          # that this whole incident (t/2047) is about. On a 503 timeout the script
-          # runs an in-container github-reachability probe to discriminate
-          # "CI-can't-fetch" (→ readiness gate moves to the deploy stage, t/2049)
-          # from a real current-main readiness bug.
-          SMOKE_MODE: readiness
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # LIVENESS: pass as soon as /healthz RESPONDS with any HTTP status (not
+          # "000" = connection refused). CI builds bake only a stub snapshot and
+          # run without real github-api creds — they can prove the container boots
+          # and listens, not that it loaded data. Zero external-service dependency
+          # → no github-reachability flake in the required PR gate (t/2067).
+          # Readiness (data loaded via github-api fetch) is enforced pre-traffic at
+          # the deploy stage by t/2049 (real env + creds) — catches the t/2047
+          # class without coupling the required PR gate to api.github.com.
+          SMOKE_MODE: liveness
         run: bash deploy/azure/smoke-healthz.sh
 
       - name: Cleanup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,6 +600,13 @@ jobs:
           load: true
           tags: ai-triad-test:ci
 
+      - name: Replace with crash-loop image (gate-proof only — t/2067)
+        if: github.ref == 'refs/heads/test/gate-verify-t2067'
+        run: |
+          # Override the built image with one that exits immediately — proves the
+          # liveness gate catches crash-loop containers (t/2067 RED verification).
+          printf 'FROM busybox\nCMD ["sh","-c","exit 1"]' | docker build -t ai-triad-test:ci -
+
       - name: Run container liveness smoke — server starts + answers (t/2048, t/2067)
         timeout-minutes: 8
         env:

--- a/deploy/azure/smoke-healthz.sh
+++ b/deploy/azure/smoke-healthz.sh
@@ -30,6 +30,14 @@ IMAGE="${IMAGE:?set IMAGE to the image ref to smoke}"
 #               + creds); it's what catches the t/2047 class (starts but never
 #               data-ready). da74e499 RED / efd068fe GREEN is its AC.
 SMOKE_MODE="${SMOKE_MODE:-readiness}"
+# GITHUB_TOKEN is only required in readiness mode (github-api data-load fetch).
+# In liveness mode no external fetch is needed — default to empty so the script
+# doesn't abort when called without it (e.g. CI liveness gate, t/2067).
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+if [ "${SMOKE_MODE}" = "readiness" ] && [ -z "${GITHUB_TOKEN}" ]; then
+  echo "::error::GITHUB_TOKEN required for SMOKE_MODE=readiness (public read is enough)"
+  exit 1
+fi
 
 # READY_TIMEOUT covers real cold start: onnx model is baked, so startup is
 # app init + (readiness) the github-api taxonomy fetch (public repo, a few MB).
@@ -60,7 +68,7 @@ docker run -d --name "$NAME" -p "${PORT}:${PORT}" \
   -e NODE_ENV=production \
   -e STORAGE_MODE=github-api \
   -e GITHUB_REPO="${GITHUB_REPO:-jpsnover/ai-triad-data}" \
-  -e GITHUB_TOKEN="${GITHUB_TOKEN:?set GITHUB_TOKEN (public read is enough)}" \
+  -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
   -e AI_TRIAD_DATA_ROOT=/tmp/taxonomy-cache \
   -e AUTH_DISABLED=1 \
   -e PORT="${PORT}" \


### PR DESCRIPTION
**DO NOT MERGE — gate-verification only (t/2067#3 TL condition)**

This branch adds a branch-scoped step that replaces the built image with a crash-loop busybox image (exits immediately). Purpose: prove the new liveness gate fires RED on a crash-loop container — the failure mode the flip is meant to catch.

Expected: `test-container` RED → `ci-gate` RED.

Evidence will be pasted in t/2067 completion comment alongside the GREEN run from PR #337.