### PR TITLE
obs(debate): add applyReflectionProposal.start FR event with edgesFileLoaded flag

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
@@ -840,7 +840,7 @@ export const createDebateReflectionSlice: StateCreator<DebateStore, [], [], Deba
     const { reflections } = get();
     const reflection = reflections.find(r => r.pover === pover);
     const proposal = reflection?.new_item_proposals?.[proposalIndex];
-    getGlobalRecorder()?.record({ type: 'state.change', component: 'reflection-proposal', level: 'info', message: 'applyReflectionProposal.called', data: { pover, proposalIndex, category: proposal?.category, edgeCount: proposal?.proposed_edges.length } });
+    getGlobalRecorder()?.record({ type: 'state.change', component: 'reflection-proposal', level: 'info', message: 'applyReflectionProposal.start', data: { pover, proposalIndex, category: proposal?.category, edgeCount: proposal?.proposed_edges.length, edgesFileLoaded: !!useTaxonomyStore.getState().edgesFile } });
     if (!reflection || !proposal) { getGlobalRecorder()?.record({ type: 'state.error', component: 'reflection-proposal', level: 'warn', message: 'applyReflectionProposal.result', data: { ok: false, error: 'Proposal not found', pover, proposalIndex } }); return { ok: false, error: 'Proposal not found' }; }
 
     const taxStore = useTaxonomyStore.getState();


### PR DESCRIPTION
## Summary

- Renames the entry-point FR event in `applyReflectionProposal` from `.called` to `.start`
- Adds `edgesFileLoaded: !!useTaxonomyStore.getState().edgesFile` to the data payload

This makes future edge-persistence failures (like t/2055) a one-event grep — previously diagnosing required scanning all 295 FR events to confirm zero `loadEdgesFile` calls.

## Test plan
- [ ] tsc passes (`npx tsc --noEmit` — clean)
- [ ] Single-line change to FR instrumentation only — no logic paths altered

Closes t/2056

🤖 Generated with [Claude Code](https://claude.com/claude-code)