### PR TITLE
fix(ai-client): honor fixedTemperature in groq/deepseek/zai providers (t/2070)

### DIFF
--- a/lib/ai-client/providers/deepseek.ts
+++ b/lib/ai-client/providers/deepseek.ts
@@ -28,7 +28,7 @@ export async function generateViaDeepSeek(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
         max_tokens: opts.maxTokens ?? 8192,
         ...(opts.jsonMode ? {
           response_format: { type: 'json_object' },
@@ -115,7 +115,7 @@ export async function generateViaDeepSeekStream(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
         max_tokens: opts.maxTokens ?? 8192,
         stream: true,
         stream_options: { include_usage: true },

--- a/lib/ai-client/providers/groq.ts
+++ b/lib/ai-client/providers/groq.ts
@@ -28,7 +28,7 @@ export async function generateViaGroq(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
         max_tokens: opts.maxTokens ?? 8192,
         ...(opts.responseSchema ? {
           response_format: {

--- a/lib/ai-client/providers/zai.ts
+++ b/lib/ai-client/providers/zai.ts
@@ -28,7 +28,7 @@ export async function generateViaZai(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
         max_tokens: opts.maxTokens ?? 16384,
         ...(opts.responseSchema ? {
           response_format: {


### PR DESCRIPTION
## Summary
- Wire `opts.fixedTemperature ?? opts.temperature ?? 0.7` in `groq.ts`, `deepseek.ts` (non-streaming + streaming), and `zai.ts` — matching the existing moonshot pattern
- Without this, any `fixedTemperature` entry in `ai-models.json` is a silent no-op for these three providers
- Prerequisite for the live-test phase of t/2070 (auditing whether groq-qwen3, deepseek-v4-flash/pro need temperature=1)

## Self-cert
Self-certifying under /trivial-change: 4 one-line edits, single scope (lib/ai-client/providers/), no new public API, no interface changes (fixedTemperature already exists in GenerateOptions). Verify: providers/groq.ts, deepseek.ts, zai.ts pass tsc clean; all TS2591 errors are pre-existing in unrelated files.

## Test plan
- [x] `npm run typecheck` -- groq.ts, deepseek.ts, zai.ts produce no errors
- [ ] Live-test groq-qwen3, deepseek-v4-flash, deepseek-v4-pro at temperature=0.7 (step 1 of t/2070, separate follow-up)
- [ ] If any constrain temperature: add fixedTemperature: 1 to ai-models.json + npm run verify:config

Generated with [Claude Code](https://claude.com/claude-code)
