### PR TITLE
fix(server): remove no-op .git replace in SSH→HTTPS conversion (t/2098)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/dataSshConversion.test.ts
+++ b/taxonomy-editor/src/server/__tests__/dataSshConversion.test.ts
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment node
+
+import { describe, it, expect } from 'vitest';
+import { convertSshToHttps } from '../routes/data.js';
+
+describe('convertSshToHttps', () => {
+  it('converts SSH URL with .git suffix', () => {
+    expect(convertSshToHttps('git@github.com:owner/repo.git')).toBe('https://github.com/owner/repo.git');
+  });
+
+  it('converts SSH URL without .git suffix', () => {
+    expect(convertSshToHttps('git@github.com:owner/repo')).toBe('https://github.com/owner/repo');
+  });
+
+  it('leaves HTTPS URL unchanged', () => {
+    expect(convertSshToHttps('https://github.com/owner/repo.git')).toBe('https://github.com/owner/repo.git');
+  });
+
+  it('leaves non-GitHub SSH URL unchanged', () => {
+    expect(convertSshToHttps('git@gitlab.com:owner/repo.git')).toBe('git@gitlab.com:owner/repo.git');
+  });
+});

--- a/taxonomy-editor/src/server/routes/data.ts
+++ b/taxonomy-editor/src/server/routes/data.ts
@@ -24,6 +24,12 @@ import { log } from '../logger.js';
 import * as fileIO from '../storage/fileIO.js';
 import * as ai from '../ai/aiBackends.js';
 
+/** Converts a git SSH remote URL to HTTPS. Non-SSH URLs are returned unchanged. */
+export function convertSshToHttps(remoteUrl: string): string {
+  if (!remoteUrl.startsWith('git@github.com:')) return remoteUrl;
+  return remoteUrl.replace('git@github.com:', 'https://github.com/');
+}
+
 export function registerDataRoutes(r: Router, ctx: ServerCtx): void {
   const { get, post } = r;
   const { serverRecorder } = ctx;
@@ -180,7 +186,7 @@ export function registerDataRoutes(r: Router, ctx: ServerCtx): void {
 
       // If remote is SSH, convert to HTTPS for public repo access without keys
       if (remoteUrl.startsWith('git@github.com:')) {
-        const httpsUrl = remoteUrl.replace('git@github.com:', 'https://github.com/').replace(/\.git$/, '.git');
+        const httpsUrl = convertSshToHttps(remoteUrl);
         log.dataPull.info({ httpsUrl }, 'Converting SSH remote to HTTPS');
         await runGit(['remote', 'set-url', 'origin', httpsUrl]);
       }


### PR DESCRIPTION
## Summary
- Extracts `convertSshToHttps()` helper from inline route logic, removing the no-op `.replace(/\.git$/, '.git')` that triggered CodeQL alert 5402 (`js/identity-replacement`)
- Adds `dataSshConversion.test.ts` covering both `o/r.git` and `o/r` SSH URL forms (4 tests)

## Test plan
- [ ] `npx vitest run src/server/__tests__/dataSshConversion.test.ts` — 4 pass
- [ ] CodeQL alert 5402 closes on next main scan

Closes t/2098

🤖 Generated with [Claude Code](https://claude.com/claude-code)