### PR TITLE
fix(security): suppress CVE-2026-8376 in .trivyignore (perl-modules-5.36, 32-bit only)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -25,3 +25,12 @@
 #            entry Trivy no longer reports.
 CVE-2026-13221
 CVE-2026-57433
+
+# ── CVE-2026-8376 — perl-modules-5.36, 32-bit regex only; no fix available ──────
+# Package:   perl-modules-5.36 (Debian bookworm)
+# Fix state: no upstream fix; Fixed Version empty as of 2026-08-03.
+# Exposure:  32-bit integer overflow in regex engine — not reachable on x86_64.
+#            Container runs x86_64 only; this path is not exploitable.
+# REVISIT:   drop when Debian ships a fixed perl-modules-5.36 or the node-26 base
+#            lands (t/1990, ~2026-10-28); re-scan and remove if cleared.
+CVE-2026-8376  # perl-modules-5.36, 32-bit regex only; no fix available; container is x86_64


### PR DESCRIPTION
## Summary

- Adds CVE-2026-8376 to `.trivyignore` per Diagnostics triage (p/168#5)
- perl-modules-5.36 32-bit regex integer overflow — no upstream fix (Fixed Version empty in Debian bookworm)
- Not exploitable on x86_64; container is x86_64-only
- Follows t/2006 policy: full exposure rationale + revisit trigger documented

Self-certifying under /trivial-change.
Change: add CVE-2026-8376 suppression with documentation
Files: `.trivyignore`
Lines changed: 9 additions, 0 deletions
Verify gate: n/a (config-only, no TS/PS code)
Deviations: file is root-owned (no competing agent; DevOps handles Trivy by domain)

## Test plan

- [ ] Trivy scan on next container build no longer flags CVE-2026-8376
- [ ] All other CI checks pass (config-only change, no code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)