### PR TITLE
feat(registry): add buildModelEntryMap + fix usageRegistry fixedTemperature drop (t/2107)

### DIFF
--- a/lib/ai-client/index.ts
+++ b/lib/ai-client/index.ts
@@ -4,7 +4,7 @@
 export type { GenerateOptions, ProviderResult, TokenUsage, RateLimitType, RateLimitHeaders, RetryProgress, BackendId, ApiKeyBackend, FetchFn, ToolDefinition, ToolCall, ToolResult, ModelCapabilities } from './types.js';
 export type { ModelEntry, ModelRegistry, ModelPricing } from './registry.js';
 export { ALL_API_KEY_BACKENDS } from './types.js';
-export { resolveBackend, resolveModel, buildModelIdMap, getApiModelId, getDefaultTimeout, getModelCapabilities, filterByCapabilities, estimateCost } from './registry.js';
+export { resolveBackend, resolveModel, buildModelIdMap, buildModelEntryMap, getApiModelId, getDefaultTimeout, getModelCapabilities, filterByCapabilities, estimateCost } from './registry.js';
 export { withTimeout, withRetry, retryableFetch, parseRateLimitType, parseRateLimitHeaders, CLI_RETRY_CONFIG, SERVER_RETRY_CONFIG } from './retry.js';
 export type { RetryConfig } from './retry.js';
 export { generateViaGemini, GEMINI_BASE, GEMINI_SAFETY_SETTINGS, toGeminiSchema } from './providers/gemini.js';

--- a/lib/ai-client/registry.test.ts
+++ b/lib/ai-client/registry.test.ts
@@ -11,6 +11,7 @@ import {
   resolveBackend,
   resolveModel,
   getDefaultTimeout,
+  buildModelEntryMap,
 } from './registry.js';
 import type { ModelRegistry } from './registry.js';
 
@@ -57,6 +58,43 @@ describe('resolveModel — fixedTemperature (t/2068)', () => {
 
   it('leaves fixedTemperature undefined for an entry without it', () => {
     expect(resolveModel(reg, 'gemini-2.5-flash').fixedTemperature).toBeUndefined();
+  });
+});
+
+describe('buildModelEntryMap (t/2107)', () => {
+  const reg: ModelRegistry = {
+    backends: [{ id: 'moonshot', label: 'Moonshot' }, { id: 'gemini', label: 'Gemini' }],
+    models: [
+      { id: 'moonshot-kimi-k3', apiModelId: 'kimi-k3', label: 'Kimi K3', backend: 'moonshot', fixedTemperature: 1 },
+      { id: 'gemini-2.5-flash', apiModelId: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', backend: 'gemini' },
+      { id: 'gemini-2.0-flash', apiModelId: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', backend: 'gemini' },
+    ],
+  };
+
+  it('returns full ModelEntry including fixedTemperature', () => {
+    const map = buildModelEntryMap(reg);
+    expect(map['moonshot-kimi-k3']).toMatchObject({
+      apiModelId: 'kimi-k3', backend: 'moonshot', fixedTemperature: 1,
+    });
+  });
+
+  it('returns entry without fixedTemperature for standard models', () => {
+    const map = buildModelEntryMap(reg);
+    expect(map['gemini-2.5-flash']?.fixedTemperature).toBeUndefined();
+    expect(map['gemini-2.5-flash']?.apiModelId).toBe('gemini-2.5-flash');
+  });
+
+  it('-latest alias resolves to highest-versioned entry and carries its attributes', () => {
+    const reg2: ModelRegistry = {
+      backends: [{ id: 'moonshot', label: 'Moonshot' }],
+      models: [
+        { id: 'moonshot-kimi-1', apiModelId: 'kimi-1', label: 'Kimi 1', backend: 'moonshot', fixedTemperature: 1 },
+        { id: 'moonshot-kimi-2', apiModelId: 'kimi-2', label: 'Kimi 2', backend: 'moonshot', fixedTemperature: 1 },
+      ],
+    };
+    const map = buildModelEntryMap(reg2);
+    // No -latest aliases for these (parseVersionedModelId won't match), but explicit entries present
+    expect(map['moonshot-kimi-2']?.apiModelId).toBe('kimi-2');
   });
 });
 

--- a/lib/ai-client/registry.test.ts
+++ b/lib/ai-client/registry.test.ts
@@ -12,6 +12,7 @@ import {
   resolveModel,
   getDefaultTimeout,
   buildModelEntryMap,
+  buildModelIdMap,
 } from './registry.js';
 import type { ModelRegistry } from './registry.js';
 
@@ -84,17 +85,46 @@ describe('buildModelEntryMap (t/2107)', () => {
     expect(map['gemini-2.5-flash']?.apiModelId).toBe('gemini-2.5-flash');
   });
 
-  it('-latest alias resolves to highest-versioned entry and carries its attributes', () => {
+  it('synthesized -latest alias points at the highest-versioned entry', () => {
+    // gemini-2.5-flash and gemini-2.0-flash both parse to family gemini-flash;
+    // 2.5 > 2.0, so gemini-flash-latest should point at the 2.5 entry.
+    const map = buildModelEntryMap(reg);
+    expect(map['gemini-flash-latest']?.apiModelId).toBe('gemini-2.5-flash');
+    expect(map['gemini-flash-latest']?.id).toBe('gemini-2.5-flash');
+  });
+
+  it('synthesized -latest alias carries fixedTemperature from the source entry', () => {
+    // Use gemini-format IDs which parseVersionedModelId matches.
+    // gemini-2.5-flash (fixedTemperature: 1) wins over 2.0; alias must carry the constraint.
     const reg2: ModelRegistry = {
-      backends: [{ id: 'moonshot', label: 'Moonshot' }],
+      backends: [{ id: 'gemini', label: 'Gemini' }],
       models: [
-        { id: 'moonshot-kimi-1', apiModelId: 'kimi-1', label: 'Kimi 1', backend: 'moonshot', fixedTemperature: 1 },
-        { id: 'moonshot-kimi-2', apiModelId: 'kimi-2', label: 'Kimi 2', backend: 'moonshot', fixedTemperature: 1 },
+        { id: 'gemini-2.0-flash', apiModelId: 'gemini-2.0-flash', label: 'Flash 2.0', backend: 'gemini' },
+        { id: 'gemini-2.5-flash', apiModelId: 'gemini-2.5-flash', label: 'Flash 2.5', backend: 'gemini', fixedTemperature: 1 },
       ],
     };
     const map = buildModelEntryMap(reg2);
-    // No -latest aliases for these (parseVersionedModelId won't match), but explicit entries present
-    expect(map['moonshot-kimi-2']?.apiModelId).toBe('kimi-2');
+    expect(map['gemini-flash-latest']?.apiModelId).toBe('gemini-2.5-flash');
+    expect(map['gemini-flash-latest']?.fixedTemperature).toBe(1);
+  });
+
+  it('explicit *-latest in models[] wins over synthesized alias (collision guard)', () => {
+    const reg3: ModelRegistry = {
+      backends: [{ id: 'gemini', label: 'Gemini' }],
+      models: [
+        { id: 'gemini-flash-latest', apiModelId: 'gemini-2.5-flash-pinned', label: 'Pinned', backend: 'gemini' },
+        { id: 'gemini-2.5-flash', apiModelId: 'gemini-2.5-flash', label: 'Flash 2.5', backend: 'gemini' },
+        { id: 'gemini-2.0-flash', apiModelId: 'gemini-2.0-flash', label: 'Flash 2.0', backend: 'gemini' },
+      ],
+    };
+    const map = buildModelEntryMap(reg3);
+    expect(map['gemini-flash-latest']?.apiModelId).toBe('gemini-2.5-flash-pinned');
+  });
+
+  it('key set matches buildModelIdMap exactly (parity contract)', () => {
+    const entryKeys = new Set(Object.keys(buildModelEntryMap(reg)));
+    const idKeys = new Set(Object.keys(buildModelIdMap(reg)));
+    expect(entryKeys).toEqual(idKeys);
   });
 });
 

--- a/lib/ai-client/registry.ts
+++ b/lib/ai-client/registry.ts
@@ -85,6 +85,50 @@ function parseVersionedModelId(id: string): { family: string; version: number } 
   return null;
 }
 
+/**
+ * Non-lossy alternative to {@link buildModelIdMap}.
+ *
+ * Returns the full `ModelEntry` for every friendly model id the registry
+ * exposes, including per-model attributes (fixedTemperature, backend, label, …).
+ * Keyed identically to `buildModelIdMap`: explicit model ids from models[],
+ * plus synthesized `*-latest` aliases pointing at the highest-versioned entry
+ * in each family (so the alias entry carries that entry's fixedTemperature,
+ * not a synthetic undefined).
+ *
+ * No internal caching — call contract is identical to buildModelIdMap.
+ * Callers are responsible for caching (cache the map, not the registry).
+ *
+ * Migration: `buildModelIdMap(r)[id]` → `buildModelEntryMap(r)[id]?.apiModelId`
+ */
+export function buildModelEntryMap(registry: ModelRegistry): Record<string, ModelEntry> {
+  const map: Record<string, ModelEntry> = {};
+  for (const m of registry.models) {
+    map[m.id] = m;
+  }
+
+  const families = new Map<string, { entry: ModelEntry; version: number }[]>();
+  for (const m of registry.models) {
+    const parsed = parseVersionedModelId(m.id);
+    if (!parsed) continue;
+    const latestKey = `${parsed.family}-latest`;
+    if (map[latestKey]) continue;
+    if (!families.has(latestKey)) families.set(latestKey, []);
+    families.get(latestKey)!.push({ entry: m, version: parsed.version });
+  }
+  for (const [alias, members] of families) {
+    if (map[alias]) continue;
+    members.sort((a, b) => b.version - a.version);
+    map[alias] = members[0].entry;
+  }
+
+  return map;
+}
+
+/**
+ * @deprecated Use {@link buildModelEntryMap} instead — this projection discards
+ * per-model attributes (fixedTemperature, …) and cannot carry them to callers.
+ * Three breakages traced to this lossy shape: t/2083, t/2068, t/2104.
+ */
 export function buildModelIdMap(registry: ModelRegistry): Record<string, string> {
   const map: Record<string, string> = {};
   for (const m of registry.models) {

--- a/lib/ai-client/usageRegistry.test.ts
+++ b/lib/ai-client/usageRegistry.test.ts
@@ -69,13 +69,20 @@ const TEST_USAGES: Record<string, UsageConfig> = {
     message: 'Fixed prompt text',
     tags: ['enrichment'],
   },
+  'moonshot.test': {
+    description: 'Usage targeting a fixedTemperature model',
+    model: 'moonshot-kimi-k3',
+    message: 'Test prompt',
+    temperature: 0.7,
+  },
 };
 
 const TEST_MODELS = {
-  backends: [{ id: 'gemini', label: 'Gemini' }],
+  backends: [{ id: 'gemini', label: 'Gemini' }, { id: 'moonshot', label: 'Moonshot' }],
   models: [
     { id: 'gemini-2.5-flash', apiModelId: 'gemini-2.5-flash', label: 'Flash', backend: 'gemini' },
     { id: 'claude-sonnet-4-6', apiModelId: 'claude-sonnet-4-6', label: 'Sonnet', backend: 'claude' },
+    { id: 'moonshot-kimi-k3', apiModelId: 'kimi-k3', label: 'Kimi K3', backend: 'moonshot', fixedTemperature: 1 },
   ],
 };
 
@@ -134,7 +141,7 @@ describe('listUsages', () => {
 
   it('returns all entries when no tag filter', () => {
     const all = listUsages('/repo');
-    expect(all).toHaveLength(3);
+    expect(all).toHaveLength(4);
     expect(all.map(e => e.id)).toContain('enrichment.test');
     expect(all.map(e => e.id)).toContain('debate.brief');
   });
@@ -222,6 +229,16 @@ describe('callByUsage', () => {
     const [, backend, , apiModelId] = mockCallProvider.mock.calls[0];
     expect(backend).toBe('claude');
     expect(apiModelId).toBe('claude-sonnet-4-6');
+  });
+
+  it('carries fixedTemperature from registry entry to provider opts (t/2107)', async () => {
+    const deps = makeDeps();
+    await callByUsage('moonshot.test', {}, deps);
+
+    const [, backend, , apiModelId, , opts] = mockCallProvider.mock.calls[0];
+    expect(backend).toBe('moonshot');
+    expect(apiModelId).toBe('kimi-k3');
+    expect(opts.fixedTemperature).toBe(1);
   });
 
   it('throws ActionableError for unknown UsageID', async () => {

--- a/lib/ai-client/usageRegistry.ts
+++ b/lib/ai-client/usageRegistry.ts
@@ -98,7 +98,7 @@ export async function callByUsage(
     ? renderTemplate(config.messageTemplate, values)
     : config.message ?? '';
 
-  const { apiModelId, backend } = resolveModel(models, config.model);
+  const { apiModelId, backend, fixedTemperature } = resolveModel(models, config.model);
 
   const opts: GenerateOptions = {
     temperature: config.temperature,
@@ -108,6 +108,7 @@ export async function callByUsage(
     responseSchema: config.responseSchema,
     systemMessage,
     tools: config.tools,
+    ...(fixedTemperature != null ? { fixedTemperature } : {}),
   };
 
   getGlobalRecorder()?.record({


### PR DESCRIPTION
## Summary

- Adds `buildModelEntryMap(registry)` to `lib/ai-client/registry.ts` — non-lossy accessor returning `Record<string, ModelEntry>` (full entry including `fixedTemperature`) keyed identically to `buildModelIdMap` (explicit ids + `-latest` aliases)
- Marks `buildModelIdMap` `@deprecated` with pointer to replacement — 3 breakages traced to its lossy `Record<string,string>` projection (t/2083, t/2068, t/2104)
- Fixes `usageRegistry.ts:101`: `resolveModel` was called correctly but destructured only `{ apiModelId, backend }`, silently dropping `fixedTemperature`

## Test plan
- [ ] `buildModelEntryMap` returns full `ModelEntry` including `fixedTemperature` (registry.test.ts)
- [ ] `-latest` aliases carry the highest-versioned entry's attributes (registry.test.ts)
- [ ] `callByUsage` for a `fixedTemperature` model carries it into `GenerateOptions` (usageRegistry.test.ts)
- [ ] No regression on gemini/claude/groq (existing suite, 51/51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)