### PR TITLE
docs(deploy): correct hub description — all roles root at shared checkout (t/2096)

### DIFF
--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -107,4 +107,4 @@ See `deploy/azure/runbooks/` for procedures covering:
 
 ## Development workflow (post-cutover, 2026-07-31)
 
-Agent development uses **per-role git worktrees** (retire-shared-checkout cutover, t/2016). The shared `main` checkout is the deploy/ops hub only; feature work is branched from `origin/main` in a worktree and landed via PR self-merge on `ci-gate` + `CodeQL` green (t/2025). A pre-commit guard (`.githooks/pre-commit`, t/1926/t/2009) refuses direct commits to the shared `main` and detached-HEAD worktree commits.
+Agent development is rooted at the **shared `main` checkout** — role `AGENTS.md` and `.orca/` are overlay-tracked and do not exist in any worktree, so every agent session runs from the hub (t/2096). `wt-*` worktrees are **per-task landing/isolation trees**, not role homes: feature work is branched from `origin/main`, landed via PR self-merge on `ci-gate` + `CodeQL` green (t/2025), and the worktree sits detached at `origin/main` between tasks. A pre-commit guard (`.githooks/pre-commit`, t/1926/t/2009) refuses direct commits to the shared `main` and detached-HEAD worktree commits.


### PR DESCRIPTION
## Summary

Re-land of `9a12cfd6` which was closed without merging via PR #357.

Single line change in `deploy/azure/README.md` — corrects the development workflow description: the shared `main` checkout is the hub for **all** agent sessions (not deploy/ops only), because role `AGENTS.md` and `.orca/` are overlay-tracked and absent from worktrees. Wording approved by TL at t/2096#7.

## Test plan

- [ ] CI green (doc-only, no code touched)
- [ ] `origin/main:deploy/azure/README.md` line 110 reads the corrected text post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)