### PR TITLE
fix(server-ai): thread fixedTemperature per-attempt through buildGenerateOptions (t/2108)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/aiBackendsFixedTemperature.test.ts
+++ b/taxonomy-editor/src/server/__tests__/aiBackendsFixedTemperature.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+
+/**
+ * t/2108 — buildGenerateOptions must thread fixedTemperature from the model
+ * registry into GenerateOptions on a per-attempt basis so that:
+ *   - a directly-requested model with fixedTemperature sends it
+ *   - a fallback model with fixedTemperature sends it (primary did not)
+ *   - a fallback model WITHOUT fixedTemperature does NOT inherit the primary's value
+ *   - a -latest alias resolves to the correct fixedTemperature via buildModelEntryMap
+ *
+ * withRetry is stubbed to pass-through (no delays) so fallback tests run fast.
+ * parseVersionedModelId only handles gemini-XX-* and claude-* patterns, so the
+ * alias test uses a gemini-pattern model id with fixedTemperature set.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ── Fake registry entries ─────────────────────────────────────────────────────
+
+// moonshot-kimi-k3: has fixedTemperature
+const FIXED_ENTRY = {
+  id: 'moonshot-kimi-k3', apiModelId: 'kimi-k3',
+  label: 'Kimi K3', backend: 'moonshot', fixedTemperature: 1,
+};
+// gemini-flash: no fixedTemperature
+const FREE_ENTRY = {
+  id: 'gemini-flash', apiModelId: 'gemini-2.0-flash',
+  label: 'Gemini Flash', backend: 'gemini',
+};
+// gemini-2.0-fixed: versioned gemini-pattern id (parseVersionedModelId matches
+// /^gemini-(\d+\.\d+)-(.+?)/ so the version MUST use X.Y dot notation).
+// buildModelEntryMap synthesises alias "gemini-fixed-latest" carrying fixedTemperature.
+// Included in the base registry so no per-test mock override is needed.
+const ALIAS_SOURCE = {
+  id: 'gemini-2.0-fixed', apiModelId: 'gemini-2.0-fixed',
+  label: 'Gemini Fixed', backend: 'gemini', fixedTemperature: 1,
+};
+
+const REGISTRY_JSON = JSON.stringify({
+  backends: [
+    { id: 'gemini', label: 'Gemini' },
+    { id: 'moonshot', label: 'Moonshot' },
+  ],
+  models: [FREE_ENTRY, FIXED_ENTRY, ALIAS_SOURCE],
+  fallbackChains: {
+    'moonshot-kimi-k3': ['gemini-flash'],
+    'gemini-flash': ['moonshot-kimi-k3'],
+  },
+  defaults: { gemini: 'gemini-flash', moonshot: 'moonshot-kimi-k3' },
+});
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('../ai/fsCache.js', () => ({
+  readFileWithMtime: vi.fn(() => ({ content: REGISTRY_JSON, mtimeMs: 1 })),
+}));
+
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return {
+    ...actual,
+    getProjectRoot: vi.fn(() => '/fake-root'),
+    getApiKeys: vi.fn(async () => ['fake-api-key']),
+    getApiKey: vi.fn(async () => 'fake-api-key'),
+  };
+});
+
+vi.mock('../../../../lib/ai-client/index.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../../../lib/ai-client/index.js')>();
+  return {
+    ...actual,
+    // No retries — call fn() once and propagate; makes fallback tests fast.
+    withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    callProvider: vi.fn(),
+  };
+});
+
+// ── Imports after mocks ───────────────────────────────────────────────────────
+
+import { generateText } from '../ai/aiBackends.js';
+import * as aiClient from '../../../../lib/ai-client/index.js';
+import { readFileWithMtime } from '../ai/fsCache.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const OK_RESULT = { text: 'ok', usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 } };
+const callProviderMock = () => vi.mocked(aiClient.callProvider);
+
+beforeEach(() => {
+  vi.mocked(aiClient.callProvider).mockResolvedValue(OK_RESULT);
+  vi.mocked(readFileWithMtime).mockReturnValue({ content: REGISTRY_JSON, mtimeMs: Date.now() });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('buildGenerateOptions fixedTemperature threading (t/2108)', () => {
+  it('passes fixedTemperature:1 to the provider when moonshot-kimi-k3 is the direct request', async () => {
+    await generateText('hello', 'moonshot-kimi-k3', undefined, undefined, 'fake-key');
+    const opts = callProviderMock().mock.calls[0][5];
+    expect(opts.fixedTemperature).toBe(1);
+  });
+
+  it('passes fixedTemperature:1 on the fallback attempt when the fallback model has it', async () => {
+    // No explicitApiKey — t/829 guard would filter cross-provider fallbacks when
+    // an explicit key is set. Without one, getApiKeys resolves per-backend (mocked).
+    // Primary (gemini-flash, no fixedTemperature) fails → fallback (moonshot-kimi-k3).
+    callProviderMock()
+      .mockRejectedValueOnce(new Error('gemini 503'))
+      .mockResolvedValueOnce(OK_RESULT);
+
+    await generateText('hello', 'gemini-flash');
+
+    expect(callProviderMock()).toHaveBeenCalledTimes(2);
+    expect(callProviderMock().mock.calls[0][5].fixedTemperature).toBeUndefined();
+    expect(callProviderMock().mock.calls[1][5].fixedTemperature).toBe(1);
+  });
+
+  it('does NOT carry the primary fixedTemperature onto a fallback that lacks it', async () => {
+    // Primary (moonshot-kimi-k3, fixedTemperature:1) fails → fallback (gemini-flash, none).
+    callProviderMock()
+      .mockRejectedValueOnce(new Error('moonshot 500'))
+      .mockResolvedValueOnce(OK_RESULT);
+
+    await generateText('hello', 'moonshot-kimi-k3');
+
+    expect(callProviderMock()).toHaveBeenCalledTimes(2);
+    expect(callProviderMock().mock.calls[0][5].fixedTemperature).toBe(1);
+    expect(callProviderMock().mock.calls[1][5].fixedTemperature).toBeUndefined();
+  });
+
+  it('resolves fixedTemperature via a -latest alias synthesised by buildModelEntryMap', async () => {
+    // gemini-2.0-fixed matches parseVersionedModelId (/gemini-\d+\.\d+-.../) →
+    // buildModelEntryMap synthesises alias "gemini-fixed-latest" carrying fixedTemperature:1.
+    // ALIAS_SOURCE is in REGISTRY_JSON so no per-test mock override is needed.
+    await generateText('hello', 'gemini-fixed-latest', undefined, undefined, 'fake-key');
+
+    const opts = callProviderMock().mock.calls[0][5];
+    expect(opts.fixedTemperature).toBe(1);
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -74,6 +74,9 @@ export interface BackendAvailability {
  * backends that 403 at generation time. tier_restricted takes precedence over
  * no_key (a missing key is moot if the tier forbids the backend).
  */
+// Narrow structural type is load-bearing: backendAvailability.test.ts passes {}
+// (no backends/models) to exercise the empty-registry path. Narrowing to ModelRegistry
+// would require a fully-populated object and break that test.
 export function computeAvailableBackends(
   registry: { backends?: { id: string }[]; models?: { id: string; backend: string }[] },
   allowedBackends: string[],

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -36,7 +36,7 @@ import {
   resolveBackend,
   callProvider,
   withRetry,
-  buildModelIdMap,
+  buildModelEntryMap,
   getApiModelId as getApiModelIdFromMap,
   getDefaultTimeout,
   withTimeout,
@@ -45,6 +45,8 @@ import {
   DEFAULT_MODEL,
   getUsage,
   renderTemplate,
+  type ModelEntry,
+  type ModelRegistry,
   type UsageConfig,
   type GenerateOptions,
   type ProviderResult,
@@ -65,11 +67,6 @@ export interface BackendAvailability {
   reason?: 'no_key' | 'tier_restricted' | 'rate_limited';
 }
 
-interface ModelRegistry {
-  backends?: { id: string }[];
-  models?: { id: string; backend: string }[];
-}
-
 /**
  * Pure computation behind GET /api/backends/available (t/772): a backend is
  * available only when BOTH a key exists for it AND it's authorized for the
@@ -78,7 +75,7 @@ interface ModelRegistry {
  * no_key (a missing key is moot if the tier forbids the backend).
  */
 export function computeAvailableBackends(
-  registry: ModelRegistry,
+  registry: { backends?: { id: string }[]; models?: { id: string; backend: string }[] },
   allowedBackends: string[],
   keyPresence: Record<string, boolean>,
 ): BackendAvailability[] {
@@ -118,22 +115,22 @@ export interface GenerateTextProgress {
 
 // ── Model ID mapping (mtime-cached) ──
 
-let _modelMapCache: Record<string, string> | null = null;
+let _modelEntryCache: Record<string, ModelEntry> | null = null;
 let _fallbackChainCache: Record<string, string[]> | null = null;
 let _defaultsCache: Record<string, string> | null = null;
 let _modelConfigMtime = 0;
 
-function loadModelConfig(): { modelMap: Record<string, string>; fallbackChains: Record<string, string[]>; defaults: Record<string, string> } {
+function loadModelConfig(): { entryMap: Record<string, ModelEntry>; fallbackChains: Record<string, string[]>; defaults: Record<string, string> } {
   try {
     const configPath = path.join(getProjectRoot(), 'ai-models.json');
-    const { content: raw, mtimeMs } = readFileWithMtime(configPath, _modelMapCache ? _modelConfigMtime : undefined);
+    const { content: raw, mtimeMs } = readFileWithMtime(configPath, _modelEntryCache ? _modelConfigMtime : undefined);
     if (raw !== null) {
-      const registry = JSON.parse(raw) as { models: { id: string; apiModelId?: string }[]; fallbackChains?: Record<string, string[]>; defaults?: Record<string, string> };
-      _modelMapCache = buildModelIdMap(registry as { models: { id: string; apiModelId: string; label: string; backend: string }[]; backends: [] });
+      const registry = JSON.parse(raw) as ModelRegistry;
+      _modelEntryCache = buildModelEntryMap(registry);
       _fallbackChainCache = registry.fallbackChains ?? {};
       _defaultsCache = registry.defaults ?? {};
       _modelConfigMtime = mtimeMs;
-      log.api.debug({ models: Object.keys(_modelMapCache!).length, chains: Object.keys(_fallbackChainCache!).length }, 'Reloaded model config');
+      log.api.debug({ models: Object.keys(_modelEntryCache!).length, chains: Object.keys(_fallbackChainCache!).length }, 'Reloaded model config');
     }
   } catch (err) {
     getGlobalRecorder()?.record({
@@ -144,15 +141,16 @@ function loadModelConfig(): { modelMap: Record<string, string>; fallbackChains: 
       error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
     });
     log.api.warn({ err }, 'Failed to load model config');
-    if (!_modelMapCache) _modelMapCache = {};
+    if (!_modelEntryCache) _modelEntryCache = {};
     if (!_fallbackChainCache) _fallbackChainCache = {};
     if (!_defaultsCache) _defaultsCache = {};
   }
-  return { modelMap: _modelMapCache!, fallbackChains: _fallbackChainCache!, defaults: _defaultsCache! };
+  return { entryMap: _modelEntryCache!, fallbackChains: _fallbackChainCache!, defaults: _defaultsCache! };
 }
 
 function loadModelMap(): Record<string, string> {
-  return loadModelConfig().modelMap;
+  const { entryMap } = loadModelConfig();
+  return Object.fromEntries(Object.entries(entryMap).map(([k, v]) => [k, v.apiModelId]));
 }
 
 function getFallbackChain(modelId: string): string[] {
@@ -321,15 +319,20 @@ function normalizeExplicitKeys(explicitApiKey: string | string[] | undefined): s
 }
 
 // Per-attempt generation options: explicit temperature > debate override > 0.7;
-// explicit timeout > backend default.
+// explicit timeout > backend default. entryMap is the full model registry keyed by
+// friendly id — fixedTemperature is resolved for currentModel on each attempt so
+// fallback models get their own value, not the primary's (t/2108).
 function buildGenerateOptions(
   options: { temperature?: number } | undefined,
   timeoutMs: number | undefined,
   currentModel: string,
+  entryMap: Record<string, ModelEntry>,
 ): GenerateOptions {
+  const entry = entryMap[currentModel];
   return {
     temperature: options?.temperature ?? _debateTemperature ?? 0.7,
     timeoutMs: timeoutMs ?? getDefaultTimeout(currentModel),
+    ...(entry?.fixedTemperature != null ? { fixedTemperature: entry.fixedTemperature } : {}),
   };
 }
 
@@ -356,6 +359,7 @@ export async function generateText(
   const resolved = model || DEFAULT_MODEL;
   const explicitKeys = normalizeExplicitKeys(explicitApiKey);
   const modelsToTry = buildModelsToTry(resolved, explicitKeys !== undefined);
+  const entryMap = loadModelConfig().entryMap;
 
   let lastError: unknown;
   for (let mi = 0; mi < modelsToTry.length; mi++) {
@@ -375,7 +379,7 @@ export async function generateText(
     }
 
     const apiModel = getApiModelId(currentModel);
-    const opts = buildGenerateOptions(options, timeoutMs, currentModel);
+    const opts = buildGenerateOptions(options, timeoutMs, currentModel, entryMap);
 
     const runWithRetry = (apiKey: string) => withRetry(
       () => callProvider(fetch, backend, prompt, apiModel, apiKey, opts),


### PR DESCRIPTION
## Summary

- **Root cause**: `buildGenerateOptions` in `aiBackends.ts` was looking up `fixedTemperature` via `buildModelIdMap` (which discards non-id fields), so `moonshot-kimi-k3`'s `fixedTemperature: 1` was never reaching the provider — causing Moonshot API 400 errors in the hosted web build.
- **Fix**: Migrated `_modelMapCache` → `_modelEntryCache` (using `buildModelEntryMap` from t/2107), then passed the full `entryMap` into `buildGenerateOptions` so it can look up `entry.fixedTemperature` per-attempt. Fallback models now get their own `fixedTemperature` value, not the primary's.
- **Also**: Removed the local `ModelRegistry` interface (narrower than lib type, caused TS2440 conflict) — the imported lib type is now the single definition.

## Dependency

**Depends on PR #361** (`feat/model-entry-map-t2107`) — branched from that commit. Once #361 merges to main, this PR should be rebased and CI will be clean.

## Test plan

- [x] `aiBackendsFixedTemperature.test.ts` — 4 new tests: direct request, fallback-to-fixed, fallback-no-carry, `-latest` alias resolution (all pass)
- [x] Full server suite: 86 test files / 918 tests passing
- [x] `tsc -p tsconfig.server.json` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)