### PR TITLE
ci(doc-accuracy): promote doc-link check to hard gate (t/2093)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,9 @@
 # ── continue-on-error flip taxonomy ──
 # FLIPPED — enforcing now (continue-on-error removed):
 #   quality-gates (t/1292; .ts/.tsx LOC moved to ESLint max-lines per ADR-007, t/1692)
+#   doc-accuracy  doc-link steps (t/2093; repo at zero dead links after t/2092)
 # FLIP-PENDING (remove continue-on-error to enforce):
-#   doc-accuracy  (t/1324)
+#   doc-accuracy  doc-claims + REPO_MAP steps (t/1324)
 # NEVER-FLIP (annotation-only by design — continue-on-error stays permanently):
 #   debate-eval        — nondeterministic AI scores, signal not gate (t/1329)
 #   commit-hygiene     — visibility not friction, never fails CI (t/1319)
@@ -384,13 +385,11 @@ jobs:
       # Doc-link check (t/2091): links in main-repo-tracked docs must resolve
       # against `git ls-files`, not the on-disk working tree — a public doc
       # linking an overlay-only path (t/2089) 404s for public-repo viewers.
-      # Advisory (continue-on-error) like the claims-lint; remove to enforce.
+      # ENFORCING (t/2093): repo at zero dead links after t/2092; gate is now hard.
       - name: Doc link self-test (t/2091 regression)
-        continue-on-error: true
         run: bash .github/scripts/check-doc-links.sh --self-test
 
       - name: Check doc links (main-repo presence)
-        continue-on-error: true
         run: bash .github/scripts/check-doc-links.sh
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6

--- a/REPO_MAP.md
+++ b/REPO_MAP.md
@@ -428,5 +428,3 @@ Auto-generated from import graph. Files ranked by import count within each direc
 - **types.ts** (2) — CaseStatus, CasePriority, Attachment, CaseResponse, SupportCaseSystemInfo +7 more
 - **supportStore.ts** (1) — attachmentBlobPath, createCase, getCase, listCasesForUser, listAllCases +6 more
 
-
-<!-- CI gate proof (t/2093): [dead-link-sentinel](./nonexistent-for-ci-gate-test.md) -->

--- a/REPO_MAP.md
+++ b/REPO_MAP.md
@@ -428,3 +428,5 @@ Auto-generated from import graph. Files ranked by import count within each direc
 - **types.ts** (2) — CaseStatus, CasePriority, Attachment, CaseResponse, SupportCaseSystemInfo +7 more
 - **supportStore.ts** (1) — attachmentBlobPath, createCase, getCase, listCasesForUser, listAllCases +6 more
 
+
+<!-- CI gate proof (t/2093): [dead-link-sentinel](./nonexistent-for-ci-gate-test.md) -->


### PR DESCRIPTION
Drops `continue-on-error` from the two `check-doc-links.sh` CI steps, promoting the doc-link check from advisory to a hard CI gate.

**Why now:** The repo reached zero public dead links in t/2092 (PRs #329 + #330). The check already exits non-zero on any dead link — removing `continue-on-error` is the only change required.

**Scope:** Only the two doc-link steps are flipped. The `check-doc-claims.sh` and REPO\_MAP freshness steps remain advisory (separate flip-pending tickets).

**AC proof:** The second commit adds a deliberate dead link to REPO\_MAP.md — CI should go red on `doc-accuracy`. The third commit (pushed before merge) reverts it, confirming the gate clears on a clean repo. See t/2093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)