### PR TITLE
fix(main): migrate resolveModelEntry to buildModelEntryMap, thread fixedTemperature (t/2104)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/embeddings.fixedTemperature.test.ts
+++ b/taxonomy-editor/src/main/__tests__/embeddings.fixedTemperature.test.ts
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import type { ModelRegistry } from '../../../../lib/ai-client/index.js';
+
+// ── Module mocks (hoisted by vitest) ──────────────────────────────────────────
+
+vi.mock('electron', () => ({
+  net: { fetch: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp/test-app') },
+}));
+
+// PROJECT_ROOT provided statically; findModelsConfig picks candidates[0] = '/fake/root/ai-models.json'
+vi.mock('../fileIO.js', () => ({
+  PROJECT_ROOT: '/fake/root',
+  resolveDataPath: vi.fn(),
+}));
+
+vi.mock('../apiKeyStore.js', () => ({
+  loadApiKey: vi.fn(() => 'fake-api-key'),
+}));
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: vi.fn(() => null),
+  setGlobalRecorder: vi.fn(),
+}));
+
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  tryWarmup: vi.fn(),
+  computeEmbedding: vi.fn(),
+  computeEmbeddings: vi.fn(),
+  getExecutionProvider: vi.fn(),
+  dispose: vi.fn(),
+}));
+
+vi.mock('../../../../lib/embeddings/embeddingResolver.js', () => ({
+  resolveEmbeddings: vi.fn(),
+}));
+
+vi.mock('../../../../lib/electron-shared/embeddingIO.js', () => ({
+  createEmbeddingIO: vi.fn(() => ({
+    read: vi.fn(),
+    write: vi.fn(),
+    invalidateCache: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../../lib/search/tavily.js', () => ({
+  tavilySearch: vi.fn(),
+  buildSearchAugmentedPrompt: vi.fn(),
+}));
+
+// Keep buildModelEntryMap + resolveBackend real; mock callProvider + withRetry
+// vi.hoisted ensures mockCallProvider is available inside the hoisted vi.mock factory
+const mockCallProvider = vi.hoisted(() => vi.fn());
+vi.mock('../../../../lib/ai-client/index.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../lib/ai-client/index.js')>();
+  return {
+    ...actual,
+    callProvider: mockCallProvider,
+    // withRetry: just invoke the thunk — tests assert on callProvider, not retry logic
+    withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
+    generateViaDeepSeekStream: vi.fn(),
+  };
+});
+
+// ── Fake registry ──────────────────────────────────────────────────────────────
+// Three explicit entries cover all 4 AC test cases:
+//   'groq-fixed'      — groq backend, fixedTemperature: 1 (cases 1 + 3)
+//   'groq-plain'      — groq backend, no fixedTemperature (case 2)
+//   'claude-sonnet-3' — triggers alias synthesis → 'claude-sonnet-latest' (case 4)
+//
+// parseVersionedModelId only handles gemini-X.Y-* and claude-*-N patterns;
+// moonshot-kimi-k3 is NOT parsed by it, so we use claude-sonnet-3 (family:
+// 'claude-sonnet', version: 3) to exercise the alias path that IS load-bearing.
+const FAKE_REGISTRY: ModelRegistry = {
+  backends: [
+    { id: 'groq', label: 'Groq' },
+    { id: 'claude', label: 'Claude' },
+  ],
+  models: [
+    { id: 'groq-fixed', apiModelId: 'groq-fixed-api', label: 'Fixed Temp Test', backend: 'groq', fixedTemperature: 1 },
+    { id: 'groq-plain', apiModelId: 'groq-plain-api', label: 'Plain Test', backend: 'groq' },
+    // claude-sonnet-3 → family 'claude-sonnet', version 3 → synthesized alias 'claude-sonnet-latest'
+    { id: 'claude-sonnet-3', apiModelId: 'claude-sonnet-3-fake', label: 'Sonnet 3 Test', backend: 'claude', fixedTemperature: 1 },
+  ],
+};
+
+// Sentinel fd — intercepted by all fs spies below
+const FAKE_FD = 99;
+const FAKE_MTIME = 1_700_000_000_000;
+
+// ── Module under test (imported AFTER mocks) ───────────────────────────────────
+import { generateText, generateChatStream } from '../embeddings.js';
+
+// ── fs spies: intercept ai-models.json reads in resolveModelEntry ─────────────
+// existsSync → false: findModelsConfig falls through to candidates[0] ('/fake/root/ai-models.json')
+// openSync → FAKE_FD; readFileSync(FAKE_FD) → fake registry JSON; closeSync → no-op
+// The cache loads on the first call and stays warm (mtime unchanged across calls).
+beforeAll(() => {
+  vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+  vi.spyOn(fs, 'openSync').mockReturnValue(FAKE_FD as ReturnType<typeof fs.openSync>);
+  vi.spyOn(fs, 'fstatSync').mockReturnValue({ mtimeMs: FAKE_MTIME } as unknown as fs.Stats);
+  vi.spyOn(fs, 'readFileSync').mockImplementation(
+    ((fdOrPath: unknown) =>
+      fdOrPath === FAKE_FD ? JSON.stringify(FAKE_REGISTRY) : '') as typeof fs.readFileSync,
+  );
+  vi.spyOn(fs, 'closeSync').mockImplementation((() => {}) as typeof fs.closeSync);
+
+  mockCallProvider.mockResolvedValue({ text: 'test response' });
+});
+
+beforeEach(() => {
+  // Clear call history only (implementations preserved — vi.clearAllMocks does not remove them)
+  vi.clearAllMocks();
+  mockCallProvider.mockResolvedValue({ text: 'test response' });
+});
+
+// opts is always the 6th arg to callProvider(electronFetch, backend, prompt, resolvedModel, apiKey, opts)
+const captureOpts = () => mockCallProvider.mock.calls[0]?.[5] as Record<string, unknown> | undefined;
+
+describe('fixedTemperature flows through to callProvider', () => {
+  it('case 1 — generateText: fixedTemperature: 1 reaches opts when entry has it', async () => {
+    await generateText('test prompt', 'groq-fixed');
+    const opts = captureOpts();
+    expect(opts?.fixedTemperature).toBe(1);
+  });
+
+  it('case 2 — generateText: fixedTemperature absent from opts when entry lacks it', async () => {
+    await generateText('test prompt', 'groq-plain');
+    const opts = captureOpts();
+    expect(opts?.fixedTemperature).toBeUndefined();
+  });
+
+  it('case 3 — generateChatStream: fixedTemperature: 1 reaches opts for non-gemini backend', async () => {
+    await generateChatStream('system', [{ role: 'user', content: 'hi' }], vi.fn(), 'groq-fixed');
+    const opts = captureOpts();
+    expect(opts?.fixedTemperature).toBe(1);
+  });
+
+  it('case 4 — -latest alias: claude-sonnet-latest resolves fixedTemperature from claude-sonnet-3', async () => {
+    // buildModelEntryMap synthesizes 'claude-sonnet-latest' pointing at 'claude-sonnet-3'
+    // (highest versioned member of the claude-sonnet family, per parseVersionedModelId).
+    // Consumer proof: entryMap['claude-sonnet-latest'] carries fixedTemperature: 1 from the source entry.
+    await generateText('test prompt', 'claude-sonnet-latest');
+    const opts = captureOpts();
+    expect(opts?.fixedTemperature).toBe(1);
+  });
+});

--- a/taxonomy-editor/src/main/embeddings.ts
+++ b/taxonomy-editor/src/main/embeddings.ts
@@ -31,8 +31,7 @@ import {
   getDefaultTimeout,
   GEMINI_BASE,
   GEMINI_SAFETY_SETTINGS,
-  buildModelIdMap,
-  getApiModelId,
+  buildModelEntryMap,
   callProvider,
   withRetry,
   SERVER_RETRY_CONFIG,
@@ -40,7 +39,7 @@ import {
   DEFAULT_MODEL,
 } from '../../../lib/ai-client/index.js';
 import type { GenerateOptions, RateLimitType as SharedRateLimitType, FetchFn } from '../../../lib/ai-client/index.js';
-import type { ModelRegistry } from '../../../lib/ai-client/index.js';
+import type { ModelEntry, ModelRegistry } from '../../../lib/ai-client/index.js';
 
 // ── Electron net.fetch wrapper ──
 // Electron's net.fetch requires Buffer.from for string bodies in some cases.
@@ -565,11 +564,11 @@ function findModelsConfig(): string {
   return candidates[0];
 }
 
-// Cache the model ID map, reload when ai-models.json changes
-let _modelMapCache: Record<string, string> | null = null;
+// Cache the full model entry map (non-lossy — carries fixedTemperature etc.), reload when ai-models.json changes
+let _modelMapCache: Record<string, ModelEntry> | null = null;
 let _modelMapMtime = 0;
 
-function resolveApiModelId(friendlyId: string): string {
+function resolveModelEntry(friendlyId: string): ModelEntry | undefined {
   // Hoisted so the catch can name the file it failed on (t/1704) and advance the
   // mtime guard when the file was statted but its contents failed to parse (t/1702).
   let configPath: string | undefined;
@@ -589,7 +588,7 @@ function resolveApiModelId(friendlyId: string): string {
       // (t/1702). ﻿ is the BOM code point.
       const raw = fs.readFileSync(fd, 'utf-8').replace(/^﻿/, '');
       const config = JSON.parse(raw) as ModelRegistry;
-      _modelMapCache = buildModelIdMap(config);
+      _modelMapCache = buildModelEntryMap(config);
       _modelMapMtime = stat.mtimeMs;
       console.log(`[model-map] Loaded ${Object.keys(_modelMapCache!).length} mappings from ${configPath}`);
     }
@@ -604,7 +603,7 @@ function resolveApiModelId(friendlyId: string): string {
       data: { configPath },
       error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
     });
-    if (!_modelMapCache) _modelMapCache = {};
+    if (!_modelMapCache) _modelMapCache = {} as Record<string, ModelEntry>;
     // Advance the mtime guard so a file that was found but failed to parse is not
     // re-read (and re-recorded) on every subsequent call — the flooding observed
     // in t/1702. statMtime is 0 only when openSync/fstatSync threw (missing file), in
@@ -615,7 +614,12 @@ function resolveApiModelId(friendlyId: string): string {
   } finally {
     if (fd !== undefined) fs.closeSync(fd);
   }
-  return getApiModelId(_modelMapCache!, friendlyId);
+  return _modelMapCache?.[friendlyId];
+}
+
+/** Return a fixedTemperature override for GenerateOptions when the entry requires one. */
+function fixedTempOverride(entry: ModelEntry | undefined): { fixedTemperature?: number } {
+  return entry?.fixedTemperature != null ? { fixedTemperature: entry.fixedTemperature } : {};
 }
 
 let _lastLoggedModel: string | null = null;
@@ -638,7 +642,8 @@ export async function generateText(
 ): Promise<string> {
   const friendlyModel = model || DEFAULT_MODEL;
   const backend = resolveBackend(friendlyModel);
-  const resolvedModel = resolveApiModelId(friendlyModel);
+  const entry = resolveModelEntry(friendlyModel);
+  const resolvedModel = entry?.apiModelId ?? friendlyModel;
 
   const apiKey = backend === 'ollama' ? 'ollama-local' : loadApiKey(backend);
   const keySource = backend === 'ollama' ? 'local (no key needed)' : apiKey ? 'Electron encrypted store' : '(not found)';
@@ -669,6 +674,7 @@ export async function generateText(
   const opts: GenerateOptions = {
     temperature: temperature ?? _debateTemperature ?? 0.7,
     timeoutMs: timeoutMs ?? getDefaultTimeout(friendlyModel),
+    ...fixedTempOverride(entry),
   };
 
   const providerFn = backend === 'deepseek'
@@ -754,7 +760,8 @@ export async function generateChatStream(
 ): Promise<string> {
   const friendlyModel = model || DEFAULT_MODEL;
   const backend = resolveBackend(friendlyModel);
-  const resolvedModel = resolveApiModelId(friendlyModel);
+  const entry = resolveModelEntry(friendlyModel);
+  const resolvedModel = entry?.apiModelId ?? friendlyModel;
 
   const apiKey = backend === 'ollama' ? 'ollama-local' : loadApiKey(backend);
   if (!apiKey) {
@@ -778,6 +785,7 @@ export async function generateChatStream(
     const opts: GenerateOptions = {
       temperature: temperature ?? 0.7,
       timeoutMs: getDefaultTimeout(friendlyModel),
+      ...fixedTempOverride(entry),
     };
     const providerResult = backend === 'deepseek'
       ? await generateViaDeepSeekStream(electronFetch, prompt, resolvedModel, apiKey, opts, onChunk)
@@ -995,7 +1003,7 @@ export async function generateTextWithSearch(
     ],
   });
 
-  const apiModel = resolveApiModelId(resolvedModel);
+  const apiModel = resolveModelEntry(resolvedModel)?.apiModelId ?? resolvedModel;
   const url = `${GEMINI_BASE}/${apiModel}:generateContent?key=${apiKey}`;
 
   console.log(`[AI] Grounded search: ${resolvedModel} with google_search tool`);


### PR DESCRIPTION
## Summary

- Migrates `embeddings.ts` from the lossy `buildModelIdMap` (`Record<string,string>`) to `buildModelEntryMap` (`Record<string,ModelEntry>`) — the non-lossy t/2107 accessor
- `resolveApiModelId` renamed `resolveModelEntry` → returns `ModelEntry|undefined`; callers derive `apiModelId` via `entry?.apiModelId ?? friendlyModel`
- `fixedTempOverride(entry)` helper applies the TL-approved `!= null` spread idiom, keeping complexity in bounds
- Three call sites updated: `generateText:669`, `generateChatStream:778`, `generateTextWithSearch:1001` (third site not in original ticket, found in sweep)
- 4 unit tests per AC: fixedTemperature present, absent, non-gemini chat stream, `-latest` alias synthesis

## Test plan
- [ ] `npx tsc --noEmit -p tsconfig.main.json` — clean
- [ ] `npx vitest run src/main/__tests__/embeddings.fixedTemperature.test.ts` — 4/4 pass
- [ ] CI all green (CodeQL required gate)

Fixes t/2104. TL-approved design at t/2104#2; conditions at t/2104#4+6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)