### PR TITLE
fix(env): set PYTHONUTF8=1 fleet-wide to kill cp1252 encoding failures (t/2046)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,6 +636,11 @@ jobs:
       always() && !cancelled() &&
       (github.event_name != 'pull_request' || needs.changes.outputs.python == 'true')
     runs-on: ubuntu-latest
+    # PYTHONUTF8=1: PEP 540 UTF-8 Mode — forces UTF-8 for stdio AND open() on win32.
+    # Recurring 7× on the win32 fleet for non-ASCII (em-dashes, arrows, etc.) — t/2046.
+    # Harmless on Linux (already UTF-8) but keeps CI/local behaviour uniform.
+    env:
+      PYTHONUTF8: '1'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
@@ -643,6 +648,15 @@ jobs:
           python-version: '3.12'
           cache: pip
           cache-dependency-path: scripts/requirements.txt
+      - name: Assert PYTHONUTF8=1 is active (t/2046 — a bare export can silently be absent)
+        run: |
+          python -c "
+          import sys
+          assert sys.flags.utf8_mode == 1, f'utf8_mode={sys.flags.utf8_mode} expected 1'
+          assert sys.stdout.encoding.lower() == 'utf-8', f'stdout={sys.stdout.encoding}'
+          assert sys.getfilesystemencoding().lower() == 'utf-8', f'fs={sys.getfilesystemencoding()}'
+          print('PYTHONUTF8 assertion OK:', sys.flags.utf8_mode, sys.stdout.encoding, sys.getfilesystemencoding())
+          "
       - name: Install Python deps (CPU-only torch to cut install weight)
         working-directory: scripts
         run: |

--- a/deploy/azure/Dockerfile.base
+++ b/deploy/azure/Dockerfile.base
@@ -65,3 +65,5 @@ RUN groupadd -r aitriad && useradd -r -g aitriad -d /home/aitriad -m aitriad \
 ENV XDG_CACHE_HOME=/home/aitriad/.cache
 ENV XDG_CONFIG_HOME=/home/aitriad/.config
 ENV XDG_DATA_HOME=/home/aitriad/.local/share
+# PYTHONUTF8=1: PEP 540 UTF-8 Mode — UTF-8 for stdio AND open() (t/2046, 7 fleet instances).
+ENV PYTHONUTF8=1

--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -90,6 +90,9 @@ ENV TAXONOMY_CACHE_DIR=/tmp/taxonomy-cache
 ENV PORT=7862
 ENV NODE_ENV=production
 ENV PYTHONUNBUFFERED=1
+# PYTHONUTF8=1: PEP 540 UTF-8 Mode — forces UTF-8 for stdio AND open() on all platforms.
+# Prevents UnicodeEncodeError/DecodeError on non-ASCII from pty-broker.py (t/2046).
+ENV PYTHONUTF8=1
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- **Primary fix (host-level):** `PYTHONUTF8=1` set as a persistent Windows User environment variable via `SetEnvironmentVariable`, so every agent shell (PowerShell, Bash) across all `wt-<role>` worktrees inherits it. Verified: `sys.flags.utf8_mode=1`, stdout/fs encoding=`utf-8`, and non-ASCII writes (`→ — ✓`) succeed where they previously raised `UnicodeEncodeError`.
- **CI parity (ci.yml):** `python-embed-smoke` job gets a job-level `env: PYTHONUTF8: '1'` plus an **assertion step** that hard-fails if the flag is absent — satisfies AC t/1589 (a bare export that can be silently absent).
- **Container parity (Dockerfiles):** `ENV PYTHONUTF8=1` added to `taxonomy-editor/Dockerfile` runtime stage (alongside `PYTHONUNBUFFERED=1`) and `deploy/azure/Dockerfile.base`. Harmless on Linux (already UTF-8); ensures uniform behaviour when pty-broker.py runs in-container.

## Why not PYTHONIOENCODING=utf-8

`PYTHONUTF8=1` (PEP 540) fixes **both** stdio and `open()` default encoding. `PYTHONIOENCODING` fixes only stdio. The recurring failures included file-I/O paths.

## Acceptance criteria checklist (t/2046)

- [x] AC1: Fresh shell probe → `1 utf-8 utf-8` (verified locally before this PR)
- [x] AC2: Non-ASCII script succeeds (verified: `→ — ✓` printed, exit 0)
- [x] AC3: Rationale co-located at each config point (all three files carry `# PYTHONUTF8=1: PEP 540 … t/2046` comments)
- [x] AC4: CI assertion step, not a bare export

Fixes t/2046. Ping Sage on merge to close the pattern loop.