### PR TITLE
chore(git): make AGENTS.md repo ownership disjoint by construction (t/2080)

### DIFF
--- a/.githooks/agent-file-owner.sh
+++ b/.githooks/agent-file-owner.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+# ─────────────────────────────────────────────────────────────────────────────
+# agent-file-owner.sh — answer "which repo owns this AGENTS.md?" in one command,
+# and fail when the answer is ambiguous or missing (t/2080).
+#
+# WHY: this project spans three repos with different rules — the public code repo
+# (`git`), the private Orca overlay (`git --git-dir=.orca-git`), and the SSH data
+# repo. `AGENTS.md` was tracked in the first two with NO coordination between
+# them, so "which repo does this file belong to" had to be answered per file,
+# from memory, at commit time. Two concrete failures that produced:
+#   • root `AGENTS.md` was tracked in BOTH repos and silently DIVERGED — the
+#     overlay carried a stale pre-refactor revision behind main's current one,
+#     surviving at least one hand-reconcile (overlay 6675678, t/2066).
+#   • two role files (`…/components/chat/AGENTS.md`, `…/components/settings/`)
+#     were tracked in NEITHER repo — ignored by main, never `add -f`d into the
+#     overlay. They existed in exactly one place on one machine, one
+#     `git clean -xfd` from unrecoverable. Recovered at overlay 01d782f.
+# The second case is the important one: the answer set is not {main, overlay} but
+# {main, overlay, NEITHER}, and NEITHER is invisible to both repos' `status`.
+#
+# THE RULE this enforces (stated as a predicate, not a per-file convention):
+#   An AGENTS.md is MAIN-repo-tracked iff a PUBLIC-repo consumer needs it
+#   without the overlay. Everything else is OVERLAY-tracked. Never both.
+# Today that predicate yields exactly the two paths in MAIN_OWNED below.
+#
+# USAGE:
+#   sh .githooks/agent-file-owner.sh --path <file>   # → main | overlay | NEITHER
+#   sh .githooks/agent-file-owner.sh --audit         # → exit 1 on any violation
+#
+# EXIT CODES: 0 = clean, 1 = violation found (audit), 2 = internal error.
+# Callers that must not block on a broken guard should treat ONLY 1 as fatal.
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -u
+
+# ── Gate configuration, co-located at point of use (t/1589) ──────────────────
+# The complete set of AGENTS.md the MAIN repo tracks. Adding a path here is a
+# deliberate act: it publishes that file to the public repo. The matching
+# re-exclusions live in `.orca-gitignore` — the two lists must stay disjoint,
+# which is what check 1 below enforces.
+#
+#   AGENTS.md                            — root project instructions; a public
+#                                          contributor cloning only the code repo
+#                                          needs these to build and test.
+#   operations/devops/azure/AGENTS.md    — Azure deploy/runbook detail, referenced
+#                                          by name from the root file; a dangling
+#                                          reference in the public repo is worse
+#                                          than the content being public.
+MAIN_OWNED='AGENTS.md
+operations/devops/azure/AGENTS.md'
+
+root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "agent-file-owner: not inside a git work tree" >&2; exit 2; }
+
+overlay_dir="$root/.orca-git"
+
+# The overlay is a PRIVATE repo and is absent from any public/CI checkout. When it
+# is missing we cannot see the overlay's tracking set, so checks 1 and 2 are
+# skipped and only the main-side allowlist check runs. This is a real coverage
+# limitation, stated here rather than assumed: CI can catch "main tracks something
+# it shouldn't", but only a developer checkout can catch double-tracked/NEITHER.
+have_overlay=0
+[ -d "$overlay_dir" ] && have_overlay=1
+
+ogit() { git --git-dir="$overlay_dir" --work-tree="$root" -C "$root" "$@"; }
+
+main_tracked()    { git -C "$root" ls-files -- '*AGENTS.md' 'AGENTS.md' 2>/dev/null | sort -u; }
+overlay_tracked() { [ "$have_overlay" -eq 1 ] || return 0
+                    ogit ls-files -- '*AGENTS.md' 'AGENTS.md' 2>/dev/null | sort -u; }
+
+# Prune the expensive/irrelevant trees. `.claude` holds linked worktrees, whose
+# AGENTS.md are checkouts of the same tracked paths and would double-count.
+on_disk() {
+  ( cd "$root" && find . \
+      \( -name node_modules -o -name .git -o -name .orca-git -o -name .claude \
+         -o -name dist -o -name build -o -name out \) -prune \
+      -o -name AGENTS.md -print 2>/dev/null ) | sed 's|^\./||' | sort -u
+}
+
+# ── --path <file> ────────────────────────────────────────────────────────────
+mode_path() {
+  rel=$1
+  # Normalize an absolute or ./-prefixed path to repo-relative.
+  case "$rel" in
+    "$root"/*) rel=${rel#"$root"/} ;;
+    ./*)       rel=${rel#./} ;;
+  esac
+
+  in_main=0;    main_tracked    | grep -qxF -- "$rel" && in_main=1
+  in_overlay=0; overlay_tracked | grep -qxF -- "$rel" && in_overlay=1
+
+  if [ "$in_main" -eq 1 ] && [ "$in_overlay" -eq 1 ]; then
+    echo "BOTH  ← violation: double-tracked, run --audit"; return 1
+  fi
+  [ "$in_main" -eq 1 ]    && { echo "main"; return 0; }
+  [ "$in_overlay" -eq 1 ] && { echo "overlay"; return 0; }
+  if [ "$have_overlay" -eq 0 ]; then
+    echo "NEITHER (overlay absent — cannot distinguish overlay from untracked)"
+    return 0
+  fi
+  echo "NEITHER  ← violation: backed up nowhere, run --audit"; return 1
+}
+
+# ── --audit ──────────────────────────────────────────────────────────────────
+mode_audit() {
+  rc=0
+  mt=$(main_tracked)
+  ot=$(overlay_tracked)
+
+  # Check 1 — double-tracked. Must be empty: the two tracking sets are disjoint
+  # by construction (main .gitignore allowlist ∩ .orca-gitignore re-exclusions).
+  if [ "$have_overlay" -eq 1 ]; then
+    both=$(printf '%s\n' "$mt" "$ot" | grep -v '^$' | sort | uniq -d)
+    if [ -n "$both" ]; then
+      echo "✖ DOUBLE-TRACKED in both the code repo and the overlay:" >&2
+      printf '%s\n' "$both" | sed 's/^/    /' >&2
+      printf '%s\n' "$both" | while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        # --verify -q is required: plain `rev-parse` ECHOES an unresolvable arg to
+        # stdout instead of failing quietly, which garbles this line for a file
+        # that is staged but not yet in HEAD.
+        mb=$(git -C "$root" rev-parse --verify -q "HEAD:$f" 2>/dev/null) || mb='(not in HEAD)'
+        ob=$(ogit rev-parse --verify -q "HEAD:$f" 2>/dev/null) || ob='(not in HEAD)'
+        [ "$mb" = "$ob" ] || echo "    └─ and they have DIVERGED: main $mb vs overlay $ob" >&2
+      done
+      echo "  Fix: pick one home per the predicate in this file's header, then" >&2
+      echo "       'git rm --cached' it from the other repo." >&2
+      rc=1
+    fi
+  fi
+
+  # Check 2 — tracked by NEITHER repo. This is the unrecoverable one.
+  if [ "$have_overlay" -eq 1 ]; then
+    orphans=$(printf '%s\n' "$(on_disk)" | grep -v '^$' | while IFS= read -r f; do
+      printf '%s\n' "$mt" | grep -qxF -- "$f" && continue
+      printf '%s\n' "$ot" | grep -qxF -- "$f" && continue
+      echo "$f"
+    done)
+    if [ -n "$orphans" ]; then
+      echo "✖ TRACKED BY NEITHER REPO — these exist only on this machine:" >&2
+      printf '%s\n' "$orphans" | sed 's/^/    /' >&2
+      echo "  Fix (overlay is the default home for role instructions):" >&2
+      echo "    git --git-dir=.orca-git --work-tree=. add -f <path>" >&2
+      echo "  A new nested AGENTS.md needs '-f' — the overlay whitelist alone" >&2
+      echo "  does not stage it, which is exactly how the t/2080 pair was lost." >&2
+      rc=1
+    fi
+  fi
+
+  # Check 3 — main tracks exactly MAIN_OWNED, no more and no less.
+  extra=$(printf '%s\n' "$mt" | grep -v '^$' | while IFS= read -r f; do
+    printf '%s\n' "$MAIN_OWNED" | grep -qxF -- "$f" || echo "$f"
+  done)
+  if [ -n "$extra" ]; then
+    echo "✖ The CODE repo tracks an AGENTS.md outside its allowlist:" >&2
+    printf '%s\n' "$extra" | sed 's/^/    /' >&2
+    echo "  Role instructions belong in the overlay. If this file genuinely must" >&2
+    echo "  be public, add it to MAIN_OWNED here AND re-exclude it in" >&2
+    echo "  .orca-gitignore — both, or it becomes double-tracked." >&2
+    rc=1
+  fi
+
+  missing=$(printf '%s\n' "$MAIN_OWNED" | while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    printf '%s\n' "$mt" | grep -qxF -- "$f" || echo "$f"
+  done)
+  if [ -n "$missing" ]; then
+    echo "✖ Allowlisted in MAIN_OWNED but NOT tracked by the code repo:" >&2
+    printf '%s\n' "$missing" | sed 's/^/    /' >&2
+    echo "  Fix: git add -f <path>   (.gitignore ignores **/AGENTS.md by default)" >&2
+    rc=1
+  fi
+
+  [ "$rc" -eq 0 ] && [ "${QUIET:-0}" != "1" ] && {
+    if [ "$have_overlay" -eq 1 ]; then
+      echo "agent-file-owner: clean — tracking sets disjoint, nothing orphaned."
+    else
+      echo "agent-file-owner: clean (overlay absent — allowlist check only)."
+    fi
+  }
+  return $rc
+}
+
+case "${1:-}" in
+  --path)  [ $# -ge 2 ] || { echo "usage: $0 --path <file>" >&2; exit 2; }
+           mode_path "$2" ;;
+  --audit) mode_audit ;;
+  *)       echo "usage: $0 --path <file> | --audit" >&2; exit 2 ;;
+esac

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,6 +25,37 @@
 # Documented in root AGENTS.md so a fresh clone re-enables enforcement.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ── AGENTS.md tracking audit (t/2080) ────────────────────────────────────────
+# Runs FIRST and on EVERY commit, before the branch logic below returns early —
+# this guards WHAT you are committing, not WHERE, so a worktree commit on a named
+# branch (which exits 0 below) must still be checked.
+#
+# Guards two failures the branch rules cannot see: a file tracked in BOTH the code
+# repo and the overlay (free to diverge — root AGENTS.md did), and a role
+# AGENTS.md tracked by NEITHER (existing in one place on one machine; two were
+# found that way, recovered at overlay 01d782f).
+#
+# Only exit 1 blocks. Exit 2 (internal error) and a missing script both ALLOW the
+# commit, matching this hook's fail-OPEN rule: a broken guard must never block
+# legitimate work. Skipped entirely when the private overlay is absent, since the
+# audit cannot see the overlay's tracking set from a public checkout.
+if [ -f "$(git rev-parse --show-toplevel 2>/dev/null)/.githooks/agent-file-owner.sh" ]; then
+  QUIET=1 sh "$(git rev-parse --show-toplevel)/.githooks/agent-file-owner.sh" --audit
+  if [ $? -eq 1 ]; then
+    cat >&2 <<'MSG'
+
+  ✖ BLOCKED: AGENTS.md tracking is ambiguous (t/2080). Details above.
+
+  Query one file's home:
+    sh .githooks/agent-file-owner.sh --path <file>
+
+  Owner / emergency override (bypasses this hook):
+    git commit --no-verify
+MSG
+    exit 1
+  fi
+fi
+
 # Normalize BOTH paths through `cd && pwd` so the comparison is format-stable on
 # Git-for-Windows (where --absolute-git-dir yields `C:/…` but a relative dir cd's
 # to `/c/…`). Mixing the two styles would read the main checkout as a worktree and

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,24 @@ AGENTS.md
 CLAUDE.md
 GEMINI.md
 
+# ── The AGENTS.md this repo DOES track, stated explicitly (t/2080) ───────────
+# Rule: an AGENTS.md is tracked HERE iff a public-repo consumer needs it WITHOUT
+# the private Orca overlay. Everything else lives in the overlay (.orca-git).
+#
+# Before these lines, tracking happened only via `git add -f`, so the set was
+# implied by commit history rather than declared — and the overlay's own
+# whitelist (`!**/AGENTS.md`, unconditional) had no way to know what this repo
+# had claimed. Every `add -f` silently produced a file tracked in BOTH repos,
+# free to diverge; root AGENTS.md did exactly that. Declaring the set here and
+# re-excluding the same two paths in `.orca-gitignore` makes the two tracking
+# sets disjoint by construction.
+#
+# Adding a path here publishes that file. Do it only with the matching
+# `.orca-gitignore` re-exclusion, or you re-create the double-track.
+# `.githooks/agent-file-owner.sh --audit` fails if the two lists drift apart.
+!/AGENTS.md
+!/operations/devops/azure/AGENTS.md
+
 # Orca: local overrides (personal, not shared)
 AGENTS.local.md
 CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,19 @@ Orca config files (`.orca.yaml`, `AGENTS.md`, `.orca/` directory) live in a **se
 
 - **`git` commands** operate on the main project repo
 - **`ogit` commands** (alias for `git --git-dir=.orca-git --work-tree=.`) operate on the overlay
-- **Never `git add` or `git commit`** files tracked by the overlay: `.orca.yaml`, `AGENTS.md`, `.orca/`, `.orca-gitignore`
-- If you need to update AGENTS.md, edit it normally but commit via `ogit`, not `git`
+- **Never `git add` or `git commit`** files tracked by the overlay: `.orca.yaml`, `.orca/`, `.orca-gitignore`, and every **nested** `AGENTS.md`
 - Run `ogit` from the repo root — `.orca-git` is not visible from subdirectories
+- A **new** nested `AGENTS.md` needs `ogit add -f` — the overlay whitelist alone does not stage it
+
+**Which repo owns an `AGENTS.md`? Don't recall it — ask (t/2080):**
+
+```
+sh .githooks/agent-file-owner.sh --path <file>    # → main | overlay | NEITHER
+```
+
+The rule is a predicate, not a list: a file is **main-repo-tracked iff a public-repo consumer needs it without the overlay**. Today that is exactly two files — this root `AGENTS.md` (commit it with **`git`**, not `ogit`) and `operations/devops/azure/AGENTS.md`. Every other `AGENTS.md` is overlay-only.
+
+The two sets are **disjoint by construction**: the code repo's allowlist lives in `.gitignore`, the matching re-exclusions in `.orca-gitignore`. Both `AGENTS.md` above were previously tracked in *both* repos and had silently diverged. The pre-commit hook runs `agent-file-owner.sh --audit` on every commit and **refuses** one that re-creates a double-track — or that leaves a nested `AGENTS.md` tracked by **neither** repo, the state that left two role files with a single unbacked copy on one machine.
 
 ### Shared-Checkout Commit Guard (git pre-commit hook)
 


### PR DESCRIPTION
Closes the multi-repo foot-gun half of the GitHub-workflow epic (t/2072 §6 item 7).

## Problem

`AGENTS.md` was tracked in both the code repo and the private Orca overlay with **no coordination between the two allowlists**: `.gitignore` ignores `**/AGENTS.md`, so main-tracking only ever happened via `git add -f`; `.orca-gitignore` whitelists `!**/AGENTS.md` unconditionally and cannot see what main claimed. Every `add -f` silently created a double-tracked file.

Two concrete failures found by audit:

- Root `AGENTS.md` was tracked in both repos and had **already diverged** — the overlay carried a 127-line pre-refactor revision behind main's current 87-line one, surviving a hand-reconcile (overlay `6675678`, t/2066).
- The answer set was never {main, overlay} but **{main, overlay, NEITHER}**. Two role files (`components/chat`, `components/settings`) were tracked by *no* repo — invisible to both repos' `status`, one `git clean -xfd` from unrecoverable. Recovered at overlay `01d782f`.

## Fix

The rule is a predicate, not a per-file convention: **an `AGENTS.md` is code-repo-tracked iff a public-repo consumer needs it without the overlay.** Today that is exactly two files, so no file moves — the rule ratifies current state.

- `.gitignore` — declare the tracked set explicitly rather than implying it from commit history, predicate co-located at point of use.
- `.githooks/agent-file-owner.sh` (new) — `--path` answers ownership in one command; `--audit` fails on double-tracked, tracked-by-neither, or allowlist drift.
- `.githooks/pre-commit` — run `--audit` **first, on every commit**, before the branch logic returns early: this guards *what* is committed, not *where*. Fail-open on internal error, matching the hook's existing rule.
- `AGENTS.md` — the old guidance ("commit AGENTS.md via `ogit`") was itself **wrong for the root file**. Replaced the remembered convention with the predicate plus the query command.

Matching re-exclusions landed in `.orca-gitignore` (overlay `00a1cc0`) — that pairing is what makes the two tracking sets **disjoint by construction** rather than periodically reconciled.

## Gate proof (t/1589 Gate Verification)

Run at the hook level against the shared checkout, where the overlay is visible:

| Case | Expected | Actual |
|---|---|---|
| Clean tree | allow | exit 0 |
| Double-track re-created (`ogit add -f AGENTS.md`) | refuse | exit 1, names the file **and its divergence** |
| Orphan `scripts/__probe/AGENTS.md` | refuse | exit 1, names the file + the `add -f` fix |
| Reverted to clean | allow | exit 0 |

Also proved at script level: main tracking a file outside the allowlist (`git add -f lib/debate/AGENTS.md`) → exit 1. Zero tolerated noise — the audit is green on `main` as of this change.

## Known limitation (stated, not assumed)

The overlay is private and absent from CI and any public checkout. When `.orca-git` is missing, the double-tracked and tracked-by-neither checks **cannot run** and are skipped; only the main-side allowlist check applies. So CI catches "main tracks something it shouldn't", but only a developer checkout catches the other two. Documented in the script header.

Separately: `core.hooksPath` is an absolute path to the shared checkout, so the new hook goes live for the fleet when the shared tree fast-forwards past this merge.

## Decisions recorded, not silently dropped

The data-repo sweep guard and an overlay-side hook were **considered and declined with reasons** (t/2080#2, owner-approved) — AC 3 permits acceptance with a recorded rationale. Both guard a *recoverable* failure, unlike the near-loss above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)