### PR TITLE
fix(node): pin node major to 22 in engines + Dockerfile (t/2113)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -7,7 +7,7 @@
 # (see deploy/azure/Dockerfile.base)
 
 # ── Stage 1: Build ──
-FROM node:22-bookworm-slim AS builder
+FROM node:22.23.2-bookworm-slim AS builder
 
 WORKDIR /build
 
@@ -53,7 +53,7 @@ WORKDIR /build/taxonomy-editor
 RUN npm run build:container
 
 # ── Stage 2: Production dependencies (with build tools for native modules) ──
-FROM node:22-bookworm-slim AS prod-deps
+FROM node:22.23.2-bookworm-slim AS prod-deps
 
 # node-pty requires make/g++/python3 for compilation when prebuilds
 # are unavailable. The runtime base image is intentionally slim (no

--- a/taxonomy-editor/package.json
+++ b/taxonomy-editor/package.json
@@ -9,6 +9,7 @@
     "name": "Jeffrey Snover",
     "email": "jsnover13@gmail.com"
   },
+  "engines": { "node": ">=22 <23" },
   "main": "dist/main/taxonomy-editor/src/main/main.js",
   "scripts": {
     "dev": "npm run build:main && concurrently \"npm run dev:vite\" \"npm run dev:electron\"",


### PR DESCRIPTION
## Summary

- `taxonomy-editor/package.json`: adds `"engines": { "node": ">=22 <23" }` so npm/dev tooling warns on wrong node major
- `taxonomy-editor/Dockerfile`: pins both build stages from floating `node:22-bookworm-slim` to exact `node:22.23.2-bookworm-slim` to match `Dockerfile.base`

Prerequisite for the undici userland/bundled major-skew gate (t/2113 step 3, owned by Server Storage). Without this pin, the invariant test would go red on every dev machine running node 24.

## Test plan

- [ ] CI passes (node 22 in ci.yml — both CI and engines field should agree)
- [ ] Dockerfile hadolint clean (no floating tag warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)