### PR TITLE
test(registry): expand buildModelEntryMap parity test + shared-reference docstring (t/2109)

### DIFF
--- a/lib/ai-client/registry.test.ts
+++ b/lib/ai-client/registry.test.ts
@@ -121,10 +121,31 @@ describe('buildModelEntryMap (t/2107)', () => {
     expect(map['gemini-flash-latest']?.apiModelId).toBe('gemini-2.5-flash-pinned');
   });
 
-  it('key set matches buildModelIdMap exactly (parity contract)', () => {
-    const entryKeys = new Set(Object.keys(buildModelEntryMap(reg)));
-    const idKeys = new Set(Object.keys(buildModelIdMap(reg)));
-    expect(entryKeys).toEqual(idKeys);
+  it.each([
+    ['simple', reg],
+    [
+      'collision guard (explicit *-latest wins)',
+      {
+        backends: [{ id: 'gemini', label: 'Gemini' }],
+        models: [
+          { id: 'gemini-flash-latest', apiModelId: 'gemini-2.5-flash-pinned', label: 'Pinned', backend: 'gemini' },
+          { id: 'gemini-2.5-flash', apiModelId: 'gemini-2.5-flash', label: 'Flash 2.5', backend: 'gemini' },
+          { id: 'gemini-2.0-flash', apiModelId: 'gemini-2.0-flash', label: 'Flash 2.0', backend: 'gemini' },
+        ],
+      } as ModelRegistry,
+    ],
+    [
+      'unparseable ids (no aliases synthesized)',
+      {
+        backends: [{ id: 'ollama', label: 'Ollama' }],
+        models: [
+          { id: 'ollama-gemma', apiModelId: 'gemma:7b', label: 'Gemma', backend: 'ollama' },
+          { id: 'ollama-llama3', apiModelId: 'llama3:8b', label: 'Llama', backend: 'ollama' },
+        ],
+      } as ModelRegistry,
+    ],
+  ])('key set matches buildModelIdMap exactly — %s (parity contract)', (_name, r) => {
+    expect(new Set(Object.keys(buildModelEntryMap(r)))).toEqual(new Set(Object.keys(buildModelIdMap(r))));
   });
 });
 

--- a/lib/ai-client/registry.ts
+++ b/lib/ai-client/registry.ts
@@ -98,6 +98,13 @@ function parseVersionedModelId(id: string): { family: string; version: number } 
  * No internal caching — call contract is identical to buildModelIdMap.
  * Callers are responsible for caching (cache the map, not the registry).
  *
+ * **Mutation hazard**: returned entries are shared references into the registry — treat them as
+ * read-only; do not mutate. A synthesized `*-latest` alias and its source id share the same
+ * object, so mutating through one mutates the other.
+ *
+ * **Alias `.id` field**: for a synthesized `*-latest` alias, `entry.id` is the *concrete* model id
+ * (e.g. `gemini-flash-latest` → `.id === 'gemini-2.5-flash'`), not the alias key.
+ *
  * Migration: `buildModelIdMap(r)[id]` → `buildModelEntryMap(r)[id]?.apiModelId`
  */
 export function buildModelEntryMap(registry: ModelRegistry): Record<string, ModelEntry> {


### PR DESCRIPTION
## Summary
- Converts the single `key set matches buildModelIdMap exactly` test into `it.each` covering three fixtures: simple, collision guard (explicit `*-latest` in models[] wins), and unparseable ids (no aliases synthesized). The original test on `reg` alone couldn't detect drift in either collision guard.
- Adds docstring to `buildModelEntryMap`: entries are shared references → read-only; synthesized alias `.id` is the concrete model id, not the alias key.
- No behavior change to `buildModelEntryMap` itself.

## Test plan
- [x] `key set matches buildModelIdMap exactly — simple (parity contract)` ✓
- [x] `key set matches buildModelIdMap exactly — collision guard (explicit *-latest wins) (parity contract)` ✓
- [x] `key set matches buildModelIdMap exactly — unparseable ids (no aliases synthesized) (parity contract)` ✓
- [x] All 39 registry tests pass

Self-certifying under /trivial-change. Change: expand parity it.each + docstring note. Files: lib/ai-client/registry.ts, lib/ai-client/registry.test.ts. Lines changed: 32 additions, 4 deletions. Verify gate: passed at 6aff0dea. Deviations: none.

Closes t/2109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)