### PR TITLE
fix(deps): bump brace-expansion + correct hub doc (t/2047)

### DIFF
--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -107,4 +107,4 @@ See `deploy/azure/runbooks/` for procedures covering:
 
 ## Development workflow (post-cutover, 2026-07-31)
 
-Agent development uses **per-role git worktrees** (retire-shared-checkout cutover, t/2016). The shared `main` checkout is the deploy/ops hub only; feature work is branched from `origin/main` in a worktree and landed via PR self-merge on `ci-gate` + `CodeQL` green (t/2025). A pre-commit guard (`.githooks/pre-commit`, t/1926/t/2009) refuses direct commits to the shared `main` and detached-HEAD worktree commits.
+Agent development is rooted at the **shared `main` checkout** — role `AGENTS.md` and `.orca/` are overlay-tracked and do not exist in any worktree, so every agent session runs from the hub (t/2096). `wt-*` worktrees are **per-task landing/isolation trees**, not role homes: feature work is branched from `origin/main`, landed via PR self-merge on `ci-gate` + `CodeQL` green (t/2025), and the worktree sits detached at `origin/main` between tasks. A pre-commit guard (`.githooks/pre-commit`, t/1926/t/2009) refuses direct commits to the shared `main` and detached-HEAD worktree commits.

--- a/poviewer/package-lock.json
+++ b/poviewer/package-lock.json
@@ -2281,9 +2281,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -5779,9 +5779,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
## Commits
- docs(deploy): correct hub description — all roles root at shared checkout (t/2096)
- fix(deps): bump brace-expansion 5.0.8→5.0.9 in poviewer (GHSA-rgw5-rvv9-x895)


🤖 Generated with [Claude Code](https://claude.com/claude-code)