### PR TITLE
feat(storage): gate undici userland/bundled major skew — invariant + dispatcher-honored test (t/2113)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/githubApi.test.ts
+++ b/taxonomy-editor/src/server/__tests__/githubApi.test.ts
@@ -12,6 +12,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Agent } from 'undici';
+import { assertUndiciMajorInvariant } from '../storage/githubRestClient.js';
 import type { FlightRecorder, RecordInput } from '../../../../lib/flight-recorder/index';
 
 // ── Mock setup ──────────────────────────────────────────────────────────
@@ -1710,7 +1712,7 @@ describe('GitHubAPIBackend — undici dispatcher (t/2053)', () => {
     const calls = vi.mocked(globalThis.fetch).mock.calls;
     expect(calls.length).toBeGreaterThan(0);
     for (const [, init] of calls) {
-      expect((init as RequestInit & { dispatcher?: unknown }).dispatcher).toBeDefined();
+      expect((init as RequestInit & { dispatcher?: unknown }).dispatcher).toBeInstanceOf(Agent);
     }
   });
 
@@ -1747,5 +1749,32 @@ describe('GitHubAPIBackend — undici dispatcher (t/2053)', () => {
     expect(errorEvents.length).toBeGreaterThan(0);
 
     backend.shutdown();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// t/2113: undici major-version invariant — gate fires from both directions
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('assertUndiciMajorInvariant', () => {
+  it('passes when userland and bundled majors match', () => {
+    expect(() => assertUndiciMajorInvariant('6.28.0', '6.21.0')).not.toThrow();
+    expect(() => assertUndiciMajorInvariant('7.0.0', '7.24.4')).not.toThrow();
+  });
+
+  it('throws when bundled major is ahead of userland (node base-image bumped without package.json update)', () => {
+    expect(() => assertUndiciMajorInvariant('6.28.0', '7.24.4')).toThrow(/undici major-version skew/);
+    expect(() => assertUndiciMajorInvariant('6.28.0', '7.24.4')).toThrow(/6\.28\.0/);
+    expect(() => assertUndiciMajorInvariant('6.28.0', '7.24.4')).toThrow(/7\.24\.4/);
+  });
+
+  it('throws when userland major is ahead of bundled (Dependabot bump without node base-image update)', () => {
+    expect(() => assertUndiciMajorInvariant('8.9.0', '6.21.0')).toThrow(/undici major-version skew/);
+    expect(() => assertUndiciMajorInvariant('8.9.0', '6.21.0')).toThrow(/8\.9\.0/);
+    expect(() => assertUndiciMajorInvariant('8.9.0', '6.21.0')).toThrow(/6\.21\.0/);
+  });
+
+  it('passes when bundled version is undefined (node <22 without bundled undici)', () => {
+    expect(() => assertUndiciMajorInvariant('6.28.0', undefined)).not.toThrow();
   });
 });

--- a/taxonomy-editor/src/server/storage/githubRestClient.ts
+++ b/taxonomy-editor/src/server/storage/githubRestClient.ts
@@ -22,11 +22,39 @@
  */
 
 import crypto from 'crypto';
+import { createRequire } from 'module';
 import { Agent } from 'undici';
 import { type SyncCredentials } from '../security/githubAppAuth.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import type { RecordInput } from '../../../../lib/flight-recorder/index.js';
 import { getRequestId } from '../logger.js';
+
+// Invariant guard: the Agent below is constructed from userland undici and passed as
+// dispatcher: to Node's built-in fetch. This only works correctly when the userland
+// major equals the node-bundled major — mismatched majors cause fetch to silently
+// ignore the dispatcher, re-enabling TLS session caching (CVE-2026-58040, t/2053).
+// Exported for testing both throw directions without process manipulation. (t/2113)
+export function assertUndiciMajorInvariant(
+  userlandVersion: string,
+  bundledVersion: string | undefined,
+): void {
+  if (!bundledVersion) return; // node <22 has no bundled undici — skip
+  const userlandMajor = parseInt(userlandVersion.split('.')[0], 10);
+  const bundledMajor = parseInt(bundledVersion.split('.')[0], 10);
+  if (userlandMajor !== bundledMajor) {
+    throw new Error(
+      `undici major-version skew: userland ${userlandVersion} vs node built-in ${bundledVersion}. ` +
+      `The GitHub dispatcher passes an undici.Agent as dispatcher: to Node's built-in fetch — ` +
+      `mismatched majors cause fetch to silently ignore the dispatcher and fall back to TLS ` +
+      `session caching (CVE-2026-58040 condition). Pin undici in package.json to match the ` +
+      `node base-image's bundled major. (t/2053, t/2113)`,
+    );
+  }
+}
+assertUndiciMajorInvariant(
+  (createRequire(import.meta.url)('undici/package.json') as { version: string }).version,
+  process.versions.undici,
+);
 
 // ── Transport constants (moved with the transport) ─────────────────────────
 const GITHUB_API = 'https://api.github.com';


### PR DESCRIPTION
## Summary

- Exports `assertUndiciMajorInvariant(userlandVersion, bundledVersion)` from `githubRestClient.ts`, called at module load against the real versions — throws if the majors diverge
- Rationale at point of use (not only in ticket history): mismatched majors cause Node's built-in `fetch` to silently ignore the `dispatcher:` argument, re-enabling TLS session caching (CVE-2026-58040 / t/2053 condition)
- Gate fires from **both** directions: bundled-ahead (node base-image bumped) and userland-ahead (Dependabot bump) — both tested with explicit version pairs, satisfying the acceptance criterion that the failure case was deliberately triggered
- Strengthens the t/2053 dispatcher test from `.toBeDefined()` → `.toBeInstanceOf(Agent)`, ruling out silent fallback to a wrong dispatcher type

## Test plan
- [ ] `assertUndiciMajorInvariant` describe block: 4 tests, both throw directions exercised
- [ ] Dispatcher test now asserts `Agent` instance, not merely defined
- [ ] `npx tsc -p tsconfig.server.json --noEmit` clean
- [ ] All 84 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)