### PR TITLE
fix(docker): bump base image :07-30→:08-04 — tag removed from GHCR (t/2051)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -70,10 +70,10 @@ RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
 
 # ── Stage 3: Runtime ──
 # CI smoke = liveness-only (any HTTP status passes; t/2067). Data-readiness proven at staging
-# (deploy-staging.yml Test-TaxEditorHealth /healthz). :2026-07-30 exonerated in t/2047 — root
-# cause was t/2061 (isDataAvailable path mismatch, app-side), not the base. Gate base bumps on
-# staging /healthz, not CI green.
-FROM ghcr.io/jpsnover/ai-triad-base:2026-07-30 AS runtime
+# (deploy-staging.yml Test-TaxEditorHealth /healthz). :2026-07-30 was exonerated in t/2047 —
+# root cause was t/2061 (isDataAvailable path mismatch, app-side). Bumped to :2026-08-04 because
+# :2026-07-30 was removed from GHCR; gate base bumps on staging /healthz, not CI green.
+FROM ghcr.io/jpsnover/ai-triad-base:2026-08-04 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Taxonomy Editor"


### PR DESCRIPTION
## Summary

- `:2026-07-30` was deleted from GHCR after newer date-tagged builds (`2026-08-01`, `2026-08-03`, `2026-08-04`) were published
- `container.yml` `build-and-push` failed with `Base image tag '2026-07-30' not found in GHCR` when cutting `v0.13.8`
- Updated `FROM` to `:2026-08-04` (current latest); updated comment to record deletion reason while preserving exoneration context (`:07-30` was not the t/2047 root cause — that was t/2061, app-side)

## Test plan

- [ ] CI `test-container` green (builds image with `:2026-08-04` base)
- [ ] After merge: cut a new `v*` tag → `container.yml` succeeds → staging auto-deploys → `Test-TaxEditorHealth` confirms readiness (the t/2051 proof chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)