### PR TITLE
lint(server): ban module-level calls in server/storage via no-restricted-syntax (t/2114)

### DIFF
--- a/taxonomy-editor/eslint.config.mjs
+++ b/taxonomy-editor/eslint.config.mjs
@@ -77,6 +77,18 @@ export default tseslint.config(
       'local/no-inline-style': 'warn',
     },
   },
+  // ── Block A-storage: ban module-level throw-capable calls in server/storage (t/2113, t/2114) ──
+  {
+    files: ['src/server/storage/**/*.ts'],
+    ignores: TEST_GLOBS,
+    rules: {
+      'no-restricted-syntax': ['error', {
+        selector: 'Program > ExpressionStatement > CallExpression',
+        message:
+          'Module-level call expressions are banned in server/storage — they fire at import time and can crash Vitest collection or the container on startup. Move invariant checks into a constructor or explicit init function. See undiciInvariant.ts + GitHubRestClient constructor as the canonical pattern. (t/2113, t/2114)',
+      }],
+    },
+  },
   // ── Block B: LOC budget for test source (syntactic parse; tests are outside the
   //    tsconfig project). Deliberately NOT the async/FR rules — un-ignoring tests only
   //    to enforce the ceiling, not to surface pre-existing test violations as gate noise. ──


### PR DESCRIPTION
## Summary
- Adds `no-restricted-syntax` error block for `src/server/storage/**/*.ts` targeting `Program > ExpressionStatement > CallExpression`
- Bans bare module-level calls that fire at import time — root cause of t/2113's silent 0-test-collected Vitest failure (`assertUndiciMajorInvariant` at module scope)
- No new plugin; `no-restricted-syntax` is core ESLint
- Verified: canary test file in storage dir raises the error; fixed `githubRestClient.ts` (post t/2113) is clean

## Test plan
- [ ] `npx eslint src/server/storage/` — clean (post-t/2113 files already fixed)
- [ ] Canary with a bare module-level call in storage raises the expected error
- [ ] CI green

Part 1 of 2 (Part 2: ServerAPI AGENTS.md convention note, t/2114)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
