### PR TITLE
docs(sage): record #141 — pinned base image date-tag GC'd from GHCR between CI and build

### DIFF
--- a/operations/sage/docs/LessonsLearned.md
+++ b/operations/sage/docs/LessonsLearned.md
@@ -2908,3 +2908,23 @@ Institutional memory for failure patterns across the AI Triad Research project.
 **Applies To:** All agents and humans tagging releases (`v*`) when the `main` tip is a Dependabot auto-merge commit.
 
 **Status:** Active — single instance; structural fix pending (t/2102). Same ci-gate family as the advancing-HEAD livelock; root cause is structural, not a timing race.
+
+---
+
+## #141 [Build] Pinned Base Image Date-Tag Deleted from GHCR Between CI and Container Build — "Tag Not Found"
+
+**Pattern:** A container build references a pinned `ai-triad-base` date-tag (e.g. `:2026-07-30`) in the Dockerfile. The tag exists at CI-run time. By the time the release container build runs (triggered by a `v*` tag), new `ai-triad-base` versions have been published, GHCR's GC has deleted the old date-tag, and the build fails "Base image tag '2026-07-30' not found in GHCR." The Dockerfile's pinned reference has gone stale between CI and the actual container build.
+
+**Instances:**
+- 2026-08-04 — DevOps (p/26#55): `v0.13.8` container build failed "Base image tag '2026-07-30' not found in GHCR." The date-tag existed at CI time but was GC'd when new `ai-triad-base` versions were published after lifting a Dependabot hold (queued bumps triggered a batch of publishes, accelerating GC of older tags). Fixed by PR #409 bumping base to `:2026-08-04`.
+
+**Root Cause:** GHCR's retention policy GCs older package versions when new ones are published. A Dockerfile pinned to a specific date-tag can silently become stale — CI passes (tag still exists at check time), but the subsequent container build (e.g. triggered by a `v*` release tag hours or days later) fails because the tag no longer exists. Batch publishing (multiple queued bumps releasing at once) accelerates the GC window unpredictably.
+
+**Prevention:**
+1. **Before tagging a release, verify the pinned base image tag still exists:** `gh api /orgs/jpsnover/packages/container/ai-triad-base/versions --jq '.[].metadata.container.tags[]'` — confirm the date-tag in `Dockerfile.base` appears in the output.
+2. **Keep the base-image pin recent.** An old date-tag is more vulnerable to GC. Regular base-image bumps (or Dependabot) shrink the window between pin age and deletion.
+3. **Bundle base-image tag verification into the pre-tag checklist** alongside the CI-run check (#140 prevention #1).
+
+**Applies To:** All agents tagging releases when the Dockerfile references a pinned `ai-triad-base` date-tag, especially after a batch of Dependabot or base-image bumps.
+
+**Status:** Active — single instance. Pairs with #140 (Dependabot merge commit CI gap) as the two release-tagging hazards surfaced 2026-08-04.

--- a/operations/sage/docs/lessons/build.md
+++ b/operations/sage/docs/lessons/build.md
@@ -1742,3 +1742,23 @@ Failure patterns related to builds, CI, tooling, environment, and git operations
 **Applies To:** All agents and humans tagging releases (`v*`) when the `main` tip is a Dependabot auto-merge commit.
 
 **Status:** Active — single instance; structural fix pending (t/2102). Same ci-gate family as the advancing-HEAD livelock; root cause is structural, not a timing race.
+
+---
+
+## [Build] Pinned Base Image Date-Tag Deleted from GHCR Between CI and Container Build — "Tag Not Found"
+
+**Pattern:** A container build references a pinned `ai-triad-base` date-tag (e.g. `:2026-07-30`) in the Dockerfile. The tag exists at CI-run time. By the time the release container build runs (triggered by a `v*` tag), new `ai-triad-base` versions have been published, GHCR's GC has deleted the old date-tag, and the build fails "Base image tag '2026-07-30' not found in GHCR." The Dockerfile's pinned reference has gone stale between CI and the actual container build.
+
+**Instances:**
+- 2026-08-04 — DevOps (p/26#55): `v0.13.8` container build failed "Base image tag '2026-07-30' not found in GHCR." The date-tag existed at CI time but was GC'd when new `ai-triad-base` versions were published after lifting a Dependabot hold (batch of queued publishes accelerated GC of older tags). Fixed by PR #409 bumping base to `:2026-08-04`.
+
+**Root Cause:** GHCR's retention policy GCs older package versions when new ones are published. A Dockerfile pinned to a specific date-tag can silently become stale — CI passes (tag still exists at check time), but the subsequent container build (e.g. triggered by a `v*` release tag hours or days later) fails because the tag no longer exists. Batch publishing (multiple queued bumps releasing at once) accelerates the GC window unpredictably.
+
+**Prevention:**
+1. **Before tagging a release, verify the pinned base image tag still exists:** `gh api /orgs/jpsnover/packages/container/ai-triad-base/versions --jq '.[].metadata.container.tags[]'` — confirm the date-tag in `Dockerfile.base` appears in the output.
+2. **Keep the base-image pin recent.** An old date-tag is more vulnerable to GC. Regular base-image bumps shrink the window between pin age and deletion.
+3. **Bundle base-image tag verification into the pre-tag checklist** alongside the CI-run check (#140 prevention #1).
+
+**Applies To:** All agents tagging releases when the Dockerfile references a pinned `ai-triad-base` date-tag, especially after a batch of Dependabot or base-image bumps.
+
+**Status:** Active — single instance. Pairs with #140 (Dependabot merge commit CI gap) as the two release-tagging hazards surfaced 2026-08-04.


### PR DESCRIPTION
## Summary
- Records new pattern #141: pinned base image date-tag GC'd from GHCR between CI and container build
- Added to both `LessonsLearned.md` (after #139) and `lessons/build.md` (at end)
- Source: DevOps p/26#55 — v0.13.8 build failed "Base image tag '2026-07-30' not found"; fixed by PR #409
- Prevention: `gh api .../ai-triad-base/versions` to verify tag exists before tagging
- Pairs with #140 (PR #411) as the two 2026-08-04 release-tagging hazards

## Test plan
- [ ] Verify #141 appears after #139 in `LessonsLearned.md`
- [ ] Verify entry is at end of `build.md`
- [ ] Verify Prevention #1 has the correct `gh api` command
- [ ] Note: #140 (PR #411) should merge before or alongside this for full cross-reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)