### PR TITLE
ci(pr-triage): enable live closing on schedule (t/2075)

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -37,11 +37,10 @@ jobs:
         with:
           script: |
             // ── 0. Dry-run resolution ──────────────────────────────────────────────
-            // Schedule ALWAYS runs dry — inputs don't exist on cron trigger so
-            // reading inputs.dry_run on a schedule silently returns undefined → false,
-            // which would execute LIVE. Resolve explicitly by eventName.
+            // Schedule runs LIVE — observation runs validated (t/2075#5, TL approved).
+            // Dispatch default remains dry_run=true (safe for manual runs).
             const dryRun = context.eventName === 'schedule'
-              ? true
+              ? false
               : (context.payload.inputs?.dry_run === 'true');
 
             core.info(`PR triage — trigger=${context.eventName}, dryRun=${dryRun}`);


### PR DESCRIPTION
## Summary
- Flips schedule dry-run default from \	rue\ to \alse\ after TL-approved observation run
- Dry-run #1 output confirmed correct at t/2075#5 (p/338#2 approval)
- \workflow_dispatch\ default stays \dry_run=true\ — manual runs remain safe

## Test plan
- [ ] CI green on this PR
- [ ] Next Monday cron run executes LIVE and posts digest to t/2075