### PR TITLE
fix(ci): replace rerequestSuite with workflow_dispatch in pr-triage Case B (t/2115)

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -225,24 +225,25 @@ jobs:
                 continue;
               }
 
-              // Case B: ci-gate never ran — rerequest all check suites
+              // Case B: ci-gate never ran — dispatch ci.yml on the PR branch.
+              // rerequestSuite always 403s with GITHUB_TOKEN (t/2115); workflow_dispatch
+              // with actions:write works and targets the branch directly.
               if (!ciGate) {
                 if (!dryRun) {
-                  const { data: suitesData } = await github.rest.checks.listSuitesForRef({
-                    owner, repo, ref: pr.head.sha,
-                  });
-                  for (const suite of suitesData.check_suites) {
-                    try {
-                      await github.rest.checks.rerequestSuite({
-                        owner, repo, check_suite_id: suite.id,
-                      });
-                    } catch (e) {
-                      core.warning(`rerequestSuite ${suite.id} on #${pr.number}: ${e.message}`);
-                    }
+                  try {
+                    await github.rest.actions.createWorkflowDispatch({
+                      owner, repo,
+                      workflow_id: 'ci.yml',
+                      ref: pr.head.ref,
+                    });
+                  } catch (e) {
+                    core.warning(`workflow-dispatch ci.yml on #${pr.number} (${pr.head.ref}): ${e.message}`);
+                    digestItems.push({ pr, reason: `ci-gate absent — workflow dispatch failed: ${e.message}` });
+                    continue;
                   }
                 }
-                retriggeredPRs.push({ pr, action: 'rerequest-suite (ci-gate never ran)' });
-                core.info(`${dryRun ? '[DRY]' : '[LIVE]'} rerequest-suite #${pr.number}`);
+                retriggeredPRs.push({ pr, action: `workflow-dispatch ci.yml on ${pr.head.ref} (ci-gate never ran)` });
+                core.info(`${dryRun ? '[DRY]' : '[LIVE]'} workflow-dispatch ci.yml #${pr.number} (${pr.head.ref})`);
                 continue;
               }
 


### PR DESCRIPTION
## Summary
- `checks.rerequestSuite` always 403s with GITHUB_TOKEN even with `actions: write` declared
- Replaced Case B re-trigger path with `actions.createWorkflowDispatch` on `ci.yml` targeting the PR head branch — works with the existing `actions: write` permission
- Failure path now surfaces the PR in the digest (with the error message) rather than silently logging a warning while counting it as re-triggered

## Test plan
- [ ] CI green on this PR
- [ ] Dispatch `pr-triage.yml` with a fleet PR where ci-gate never ran — confirm `[LIVE] workflow-dispatch ci.yml` in the log, no 403 warning
- [ ] Verified on PR #414 or equivalent in the next triage run

Fixes t/2115 / relates to t/2075

🤖 Generated with [Claude Code](https://claude.com/claude-code)