### PR TITLE
ops(devops): scripted PR re-trigger for required-context swaps (t/2076)

### DIFF
--- a/deploy/azure/runbooks/context-swap.md
+++ b/deploy/azure/runbooks/context-swap.md
@@ -1,0 +1,103 @@
+# Runbook: Required-Context Swap Protocol
+
+**Owner:** DevOps. **Last updated:** 2026-08-04
+
+Changing which status contexts are required on `main` silently strands every open PR that predates the swap: the new check never reports on those PRs, so armed auto-merge cannot fire. This runbook makes the swap and the re-trigger a single atomic operation.
+
+See also: `docs/orca-github-workflow.md` §5 (costs) and §6 item 4.
+
+---
+
+## When this applies
+
+Any change to `required_status_checks.contexts` on the `main` branch — adding a context, removing one, or renaming one — requires running the re-trigger step below before considering the change complete.
+
+---
+
+## Protocol
+
+### Step 1 — Make the protection change
+
+```bash
+# Example: update required contexts via GitHub API
+gh api repos/jpsnover/ai-triad-research/branches/main/protection \
+  --method PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["ci-gate", "CodeQL"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+```
+
+Verify the change took effect:
+
+```bash
+gh api repos/jpsnover/ai-triad-research/branches/main/protection/required_status_checks \
+  --jq '.contexts'
+```
+
+### Step 2 — Re-trigger every open PR (mandatory)
+
+Run immediately after the protection change — do not skip, do not defer:
+
+```powershell
+# Dry-run: shows what would be triggered
+./operations/devops/Invoke-ContextSwapRetrigger.ps1 -WhatIf
+
+# Live run: triggers ci.yml and codeql.yml on every open PR's branch
+./operations/devops/Invoke-ContextSwapRetrigger.ps1
+```
+
+The script:
+- Auto-fetches the current required contexts from the live branch protection
+- Prints a **before** table showing each PR's current check state
+- Close-reopens each open non-draft PR to synthesize a fresh `pull_request` event, causing all PR-triggered workflows (ci.yml, codeql.yml, etc.) to run without modifying the branch
+- Polls up to 8 minutes for terminal state
+- Prints an **after** table with `before → after` per context per PR
+- Exits 0 if all PRs report all required contexts as `success`; exits 1 otherwise
+
+**Trade-off:** close-reopen sends GitHub notifications and briefly de-arms auto-merge. For the rare context-swap operation this is acceptable; it is the only mechanism that reliably re-triggers all PR workflows without `workflow_dispatch` on each workflow file or empty commits on each branch.
+
+Optional parameters:
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `-Repo` | `jpsnover/ai-triad-research` | Target repo |
+| `-RequiredContexts` | fetched from live protection | Override which contexts to verify |
+| `-TimeoutMinutes` | `8` | Extend for slow CI |
+| `-WhatIf` | off | Dry-run |
+
+### Step 3 — Confirm
+
+The script exits with a summary. If any PR is not green:
+
+1. Check the after table — identify which context is missing or non-success.
+2. Re-run without `-WhatIf` to trigger again, or trigger that specific PR manually: `gh pr view <N>` → push an empty commit.
+3. Do not consider the swap complete until the script exits 0.
+
+---
+
+## Enforcement mechanism
+
+A **feedback rule** (`context-swap-reminder`) fires on every Bash/PowerShell tool call and injects a reminder to run this protocol if a protection change is in progress.
+
+**Limitations (both must be stated per ticket t/2076):**
+
+1. **Session-start lag (t/1625):** A feedback rule is pinned to the manifest loaded at session start. A rule created mid-session is not active until the next session start — the creating session cannot verify it fires.
+
+2. **Broad trigger (condition parser limitation):** The Orca condition parser does not support substring matching on `input.command`. The rule therefore fires on *all* Bash/PowerShell calls, not only protection-change calls. A 1-hour cooldown limits noise. Operators should dismiss it unless they are performing a context swap.
+
+The rule is advisory: it surfaces the reminder but cannot block the protection call. The script's exit code and the before/after table are the authoritative gate.
+
+---
+
+## Precedents
+
+- Six-contexts → `ci-gate` swap (t/1962): stranded open PRs discovered after the fact.
+- `strict: true` evaluation (t/2074): planned swap that this protocol covers going forward.

--- a/operations/devops/Invoke-ContextSwapRetrigger.ps1
+++ b/operations/devops/Invoke-ContextSwapRetrigger.ps1
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Re-triggers CI on every open PR after a required-status-context swap.
+.DESCRIPTION
+    After changing which status contexts are required on main, every open PR that
+    predates the swap lacks the new check — its armed auto-merge cannot fire.
+    This script:
+      1. Enumerates all open, non-draft PRs.
+      2. Captures the current check-run state for each required context (before).
+      3. Re-triggers all PR workflows via close-then-reopen on each PR. This
+         synthesizes a fresh pull_request event, which causes every PR-triggered
+         workflow (ci.yml, codeql.yml, etc.) to run against the same head SHA
+         without any code change or empty commit on the branch.
+      4. Waits for the new check runs to reach a terminal state (up to -TimeoutMinutes).
+      5. Prints a per-PR x per-context before/after table.
+    Exits 0 when every PR reports every required context as success; exits 1 otherwise.
+
+    See deploy/azure/runbooks/context-swap.md for the full protocol.
+
+    TRADE-OFF: close-reopen sends GitHub notifications and briefly de-arms auto-merge.
+    For the rare context-swap operation this is acceptable; it is the only mechanism
+    that reliably re-triggers all PR workflows without modifying workflow files or
+    pushing empty commits.
+.PARAMETER Repo
+    GitHub repository slug (owner/name). Default: jpsnover/ai-triad-research.
+.PARAMETER RequiredContexts
+    Status context names to verify. If omitted, fetched live from branch protection.
+.PARAMETER TimeoutMinutes
+    Max minutes to wait for checks to reach a terminal state. Default: 8.
+.PARAMETER WhatIf
+    Show what would be triggered without actually triggering anything.
+.EXAMPLE
+    ./operations/devops/Invoke-ContextSwapRetrigger.ps1
+.EXAMPLE
+    ./operations/devops/Invoke-ContextSwapRetrigger.ps1 -WhatIf
+.EXAMPLE
+    ./operations/devops/Invoke-ContextSwapRetrigger.ps1 -RequiredContexts 'ci-gate','CodeQL' -TimeoutMinutes 12
+#>
+
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [string]   $Repo             = 'jpsnover/ai-triad-research',
+    [string[]] $RequiredContexts,
+    [int]      $TimeoutMinutes   = 8,
+    [switch]   $WhatIf
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$TerminalStates = @('success', 'failure', 'cancelled', 'timed_out', 'action_required', 'skipped', 'neutral')
+
+function Get-CheckMap {
+    param([string]$Sha)
+    $raw = gh api "repos/$Repo/commits/$Sha/check-runs" 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $raw) { return @{} }
+    $map = @{}
+    foreach ($r in ($raw | ConvertFrom-Json).check_runs) {
+        $map[$r.name] = if ($r.conclusion) { $r.conclusion } else { $r.status }
+    }
+    return $map
+}
+
+function Format-Row {
+    param([hashtable]$Before, [hashtable]$After, [object]$PR, [bool]$ShowAfter)
+    $titleWidth = 32
+
+    $title = if ($PR.title.Length -le $titleWidth - 2) {
+        $PR.title
+    } else {
+        "$($PR.title.Substring(0, $titleWidth - 5))..."
+    }
+
+    $row = "#$($PR.number)".PadRight(5) + $title.PadRight($titleWidth)
+    foreach ($ctx in $script:RequiredContexts) {
+        $bef = if ($Before.ContainsKey($ctx)) { $Before[$ctx] } else { '—' }
+        if ($ShowAfter) {
+            $aft  = if ($After.ContainsKey($ctx)) { $After[$ctx] } else { '—' }
+            $cell = "$bef → $aft"
+        } else {
+            $cell = $bef
+        }
+        $row += $cell.PadRight($script:CtxWidth)
+    }
+    return $row
+}
+
+# ── 1. Resolve required contexts ──────────────────────────────────────────────
+if (-not $RequiredContexts) {
+    $protection       = gh api "repos/$Repo/branches/main/protection/required_status_checks" | ConvertFrom-Json
+    $RequiredContexts = [string[]]$protection.contexts
+}
+
+$script:RequiredContexts = $RequiredContexts
+$script:CtxWidth         = [Math]::Max(16, ($RequiredContexts | Measure-Object -Property Length -Maximum).Maximum + 6)
+
+Write-Host "Repo:              $Repo"
+Write-Host "Required contexts: $($RequiredContexts -join ', ')"
+Write-Host "Mechanism:         close-reopen (synthesizes pull_request event)"
+
+# ── 2. Get open non-draft PRs ─────────────────────────────────────────────────
+$allPRs = gh pr list --repo $Repo --state open --json number,title,headRefName,headRefOid,isDraft | ConvertFrom-Json
+$prs    = @($allPRs | Where-Object { -not $_.isDraft })
+
+if ($prs.Count -eq 0) {
+    Write-Host "`nNo open non-draft PRs. Nothing to do."
+    exit 0
+}
+Write-Host "`n$($prs.Count) open PR(s) found."
+
+# ── 3. Capture before state ───────────────────────────────────────────────────
+Write-Host "`nCapturing check state before trigger..."
+$beforeMap = @{}
+foreach ($pr in $prs) {
+    $beforeMap[$pr.number] = Get-CheckMap -Sha $pr.headRefOid
+}
+
+# ── 4. Print before table ─────────────────────────────────────────────────────
+$titleWidth = 32
+$header     = 'PR'.PadRight(5) + 'Title'.PadRight($titleWidth) + (($RequiredContexts | ForEach-Object { $_.PadRight($script:CtxWidth) }) -join '')
+$sep        = '-' * $header.Length
+
+Write-Host "`nBEFORE"
+Write-Host $header
+Write-Host $sep
+foreach ($pr in $prs) {
+    Write-Host (Format-Row -Before $beforeMap[$pr.number] -After @{} -PR $pr -ShowAfter $false)
+}
+
+# ── 5. Close-reopen each PR ───────────────────────────────────────────────────
+Write-Host ''
+if ($WhatIf) {
+    Write-Host '[WhatIf] Would close-reopen:'
+} else {
+    Write-Host 'Triggering via close-reopen...'
+}
+
+foreach ($pr in $prs) {
+    $msg = "  PR #$($pr.number)  $($pr.title)"
+    Write-Host $msg
+    if (-not $WhatIf) {
+        gh pr close $pr.number --repo $Repo 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { Write-Warning "  Failed to close PR #$($pr.number)" }
+        Start-Sleep -Milliseconds 500
+        gh pr reopen $pr.number --repo $Repo 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { Write-Warning "  Failed to reopen PR #$($pr.number)" }
+    }
+}
+
+if ($WhatIf) {
+    Write-Host "`n[WhatIf] No PRs were modified. Run without -WhatIf to apply."
+    exit 0
+}
+
+# ── 6. Poll until terminal or timeout ─────────────────────────────────────────
+Write-Host "`nPolling for check results (timeout: $TimeoutMinutes min)..."
+$deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+$afterMap = @{}
+foreach ($pr in $prs) { $afterMap[$pr.number] = @{} }
+
+do {
+    Start-Sleep -Seconds 20
+    $allTerminal = $true
+    foreach ($pr in $prs) {
+        $runs = Get-CheckMap -Sha $pr.headRefOid
+        $afterMap[$pr.number] = $runs
+        foreach ($ctx in $RequiredContexts) {
+            $state = if ($runs.ContainsKey($ctx)) { $runs[$ctx] } else { '' }
+            if (-not $state -or $state -notin $TerminalStates) { $allTerminal = $false }
+        }
+    }
+} while (-not $allTerminal -and (Get-Date) -lt $deadline)
+
+if (-not $allTerminal) {
+    Write-Warning "Timed out before all checks reached a terminal state. Re-run to check again."
+}
+
+# ── 7. Print after table ──────────────────────────────────────────────────────
+Write-Host "`nAFTER  (before → after)"
+Write-Host $header
+Write-Host $sep
+
+$allGreen = $true
+foreach ($pr in $prs) {
+    Write-Host (Format-Row -Before $beforeMap[$pr.number] -After $afterMap[$pr.number] -PR $pr -ShowAfter $true)
+    foreach ($ctx in $RequiredContexts) {
+        $aft = if ($afterMap[$pr.number].ContainsKey($ctx)) { $afterMap[$pr.number][$ctx] } else { '' }
+        if ($aft -ne 'success') { $allGreen = $false }
+    }
+}
+
+Write-Host ''
+if ($allGreen) {
+    Write-Host 'All PRs report all required contexts as success. Safe to proceed.'
+    exit 0
+} else {
+    Write-Warning 'Some PRs are missing required contexts or report non-success. Check the table above.'
+    exit 1
+}


### PR DESCRIPTION
## Summary

- Adds `operations/devops/Invoke-ContextSwapRetrigger.ps1`: enumerates open PRs, prints before table, close-reopens each to synthesize a `pull_request` event, polls to terminal state, prints before→after table per PR × required context, exits 1 if any PR is still missing a required context
- Adds `deploy/azure/runbooks/context-swap.md`: protocol doc covering the two-step swap+re-trigger operation, close-reopen trade-off, and enforcement mechanism with both limitations stated
- Feedback rule `context-swap-reminder` created in Orca (workspace scope): fires on Bash/PowerShell with 1-hour cooldown, injecting the reminder at the moment of a protection change

Resolves t/2076. Parent epic: t/2072.

## Test plan

- [ ] `./operations/devops/Invoke-ContextSwapRetrigger.ps1 -WhatIf` runs from a clean checkout and prints the before table + would-trigger list without modifying any PR
- [ ] Script exits 0 when all open PRs already report all required contexts (idempotent case)
- [ ] Feedback rule fires in the next session when a Bash/PowerShell call is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)