### PR TITLE
feat(prefs): UserPreferences types + BridgeAPI extension + Zustand store (t/2117)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/preferencesBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/preferencesBridge.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2117 — UserPreferences types + BridgeAPI extension + Zustand store + bridge implementations.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AppAPI, UserPreferences } from '../types';
+
+// ── Type-level: verify AppAPI contract ──────────────────────────────────────
+
+describe('AppAPI preferences contract', () => {
+  it('AppAPI includes getPreferences and setPreferences', () => {
+    const dummy = {} as AppAPI;
+    expect('getPreferences' in dummy || dummy.getPreferences === undefined).toBe(true);
+    expect('setPreferences' in dummy || dummy.setPreferences === undefined).toBe(true);
+  });
+});
+
+// ── electron-bridge delegation ──────────────────────────────────────────────
+
+describe('electron-bridge preferences', () => {
+  const origWindow = (globalThis as Record<string, unknown>).window;
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).window = origWindow;
+    vi.resetModules();
+  });
+
+  it('delegates getPreferences to window.electronAPI when present', async () => {
+    const prefs: UserPreferences = { viewMode: 'advanced' };
+    (globalThis as Record<string, unknown>).window = {
+      electronAPI: { getPreferences: vi.fn().mockResolvedValue(prefs) },
+    };
+    const mod = await import('../electron-bridge');
+    const result = await mod.api.getPreferences();
+    expect(result).toEqual(prefs);
+    expect(window.electronAPI.getPreferences).toHaveBeenCalled();
+  });
+
+  it('returns null when getPreferences IPC handler is not yet wired (t/2118)', async () => {
+    (globalThis as Record<string, unknown>).window = { electronAPI: {} };
+    const mod = await import('../electron-bridge');
+    const result = await mod.api.getPreferences();
+    expect(result).toBeNull();
+  });
+
+  it('delegates setPreferences to window.electronAPI when present', async () => {
+    const setFn = vi.fn().mockResolvedValue(undefined);
+    (globalThis as Record<string, unknown>).window = {
+      electronAPI: { setPreferences: setFn },
+    };
+    const mod = await import('../electron-bridge');
+    const prefs: UserPreferences = { viewMode: 'simple' };
+    await mod.api.setPreferences(prefs);
+    expect(setFn).toHaveBeenCalledWith(prefs);
+  });
+
+  it('resolves without error when setPreferences IPC handler is not yet wired (t/2118)', async () => {
+    (globalThis as Record<string, unknown>).window = { electronAPI: {} };
+    const mod = await import('../electron-bridge');
+    await expect(mod.api.setPreferences({ viewMode: 'simple' })).resolves.toBeUndefined();
+  });
+});
+
+// ── preferencesStore ────────────────────────────────────────────────────────
+
+describe('preferencesStore', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('defaults viewMode to simple when bridge returns null', async () => {
+    vi.doMock('../../bridge/index', () => ({
+      api: { getPreferences: vi.fn().mockResolvedValue(null), setPreferences: vi.fn().mockResolvedValue(undefined) },
+    }));
+    const { usePreferencesStore } = await import('../../store/preferencesStore');
+    const store = usePreferencesStore.getState();
+    await store.hydrate();
+    expect(usePreferencesStore.getState().viewMode).toBe('simple');
+  });
+
+  it('hydrates viewMode from stored value', async () => {
+    const prefs: UserPreferences = { viewMode: 'advanced' };
+    vi.doMock('../../bridge/index', () => ({
+      api: { getPreferences: vi.fn().mockResolvedValue(prefs), setPreferences: vi.fn().mockResolvedValue(undefined) },
+    }));
+    const { usePreferencesStore } = await import('../../store/preferencesStore');
+    await usePreferencesStore.getState().hydrate();
+    expect(usePreferencesStore.getState().viewMode).toBe('advanced');
+  });
+
+  it('setViewMode updates local state and calls setPreferences', async () => {
+    const setFn = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('../../bridge/index', () => ({
+      api: { getPreferences: vi.fn().mockResolvedValue(null), setPreferences: setFn },
+    }));
+    const { usePreferencesStore } = await import('../../store/preferencesStore');
+    await usePreferencesStore.getState().setViewMode('advanced');
+    expect(usePreferencesStore.getState().viewMode).toBe('advanced');
+    expect(setFn).toHaveBeenCalledWith({ viewMode: 'advanced' });
+  });
+
+  it('defaults to simple and does not throw when bridge errors during hydration', async () => {
+    vi.doMock('../../bridge/index', () => ({
+      api: { getPreferences: vi.fn().mockRejectedValue(new Error('network')), setPreferences: vi.fn() },
+    }));
+    const { usePreferencesStore } = await import('../../store/preferencesStore');
+    await expect(usePreferencesStore.getState().hydrate()).resolves.toBeUndefined();
+    expect(usePreferencesStore.getState().viewMode).toBe('simple');
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -5,7 +5,7 @@
  * Electron bridge — delegates every AppAPI method to window.electronAPI (IPC).
  * Used when the app runs inside Electron (desktop mode).
  */
-import type { AppAPI } from './types';
+import type { AppAPI, UserPreferences } from './types';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
 import {
@@ -24,6 +24,13 @@ void tryInitLocalEmbedding();
 const localDiagCallbacks = new Set<(state: unknown) => void>();
 
 export const api: AppAPI = {
+  // User preferences — delegates to IPC (get-preferences / set-preferences) once
+  // ElectronMain handler lands (t/2118). Graceful-degrade until then.
+  getPreferences: (): Promise<UserPreferences | null> =>
+    window.electronAPI.getPreferences?.() ?? Promise.resolve(null),
+  setPreferences: (prefs: UserPreferences): Promise<void> =>
+    window.electronAPI.setPreferences?.(prefs) ?? Promise.resolve(),
+
   // Taxonomy directories
   getTaxonomyDirs: () => window.electronAPI.getTaxonomyDirs(),
   getActiveTaxonomyDir: () => window.electronAPI.getActiveTaxonomyDir(),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -101,7 +101,17 @@ export type ContainerMentions = _ContainerMentions;
 
 export interface OrgFilters { type?: string; pov?: string }
 
+export type ViewMode = 'simple' | 'advanced';
+
+export interface UserPreferences {
+  viewMode: ViewMode;
+}
+
 export interface AppAPI {
+  // --- User preferences ---
+  getPreferences: () => Promise<UserPreferences | null>;
+  setPreferences: (prefs: UserPreferences) => Promise<void>;
+
   // --- Taxonomy directories ---
   getTaxonomyDirs: () => Promise<string[]>;
   getActiveTaxonomyDir: () => Promise<string>;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -5,7 +5,7 @@
  * Web bridge — implements AppAPI via REST and WebSocket calls to the server.
  * Used when the app runs in a browser served by the container.
  */
-import type { AppAPI, SourceDocumentResolution, DebateDelta } from './types';
+import type { AppAPI, SourceDocumentResolution, DebateDelta, UserPreferences } from './types';
 import { instrumentBridge } from './instrumentBridge';
 import { ActionableError } from '@lib/debate/errors';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
@@ -740,6 +740,10 @@ if (import.meta.hot) {
 // ── The bridge ──
 
 const rawApi: AppAPI = {
+  // User preferences
+  getPreferences: () => get<UserPreferences | null>('/api/preferences').catch(() => null),
+  setPreferences: (prefs: UserPreferences) => put('/api/preferences', prefs, { idempotent: true }).then(() => {}),
+
   // Taxonomy directories
   getTaxonomyDirs: () => get('/api/taxonomy-dirs'),
   getActiveTaxonomyDir: () => get('/api/taxonomy-dir/active'),

--- a/taxonomy-editor/src/renderer/store/preferencesStore.ts
+++ b/taxonomy-editor/src/renderer/store/preferencesStore.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { create } from 'zustand';
+import type { ViewMode, UserPreferences } from '../bridge/types';
+
+interface PreferencesState {
+  viewMode: ViewMode;
+  setViewMode: (mode: ViewMode) => Promise<void>;
+  /** Load persisted preferences from the bridge and hydrate the store. */
+  hydrate: () => Promise<void>;
+}
+
+export const usePreferencesStore = create<PreferencesState>()((set) => ({
+  viewMode: 'simple',
+
+  setViewMode: async (mode: ViewMode) => {
+    set({ viewMode: mode });
+    try {
+      const { api } = await import('../bridge/index');
+      await api.setPreferences({ viewMode: mode });
+    } catch { /* best-effort — local state already updated */ }
+  },
+
+  hydrate: async () => {
+    try {
+      const { api } = await import('../bridge/index');
+      const prefs: UserPreferences | null = await api.getPreferences();
+      if (prefs?.viewMode) {
+        set({ viewMode: prefs.viewMode });
+      }
+    } catch { /* default 'simple' stands on error */ }
+  },
+}));
+
+((window as unknown as { __ZUSTAND_STORES__?: Record<string, unknown> }).__ZUSTAND_STORES__ ??= {} as Record<string, unknown>).preferences = usePreferencesStore;

--- a/taxonomy-editor/src/renderer/store/preferencesStore.ts
+++ b/taxonomy-editor/src/renderer/store/preferencesStore.ts
@@ -3,6 +3,7 @@
 
 import { create } from 'zustand';
 import type { ViewMode, UserPreferences } from '../bridge/types';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
 
 interface PreferencesState {
   viewMode: ViewMode;
@@ -19,7 +20,9 @@ export const usePreferencesStore = create<PreferencesState>()((set) => ({
     try {
       const { api } = await import('../bridge/index');
       await api.setPreferences({ viewMode: mode });
-    } catch { /* best-effort — local state already updated */ }
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'preferencesStore', level: 'error', message: 'Failed to persist view mode preference', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+    }
   },
 
   hydrate: async () => {
@@ -29,7 +32,9 @@ export const usePreferencesStore = create<PreferencesState>()((set) => ({
       if (prefs?.viewMode) {
         set({ viewMode: prefs.viewMode });
       }
-    } catch { /* default 'simple' stands on error */ }
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'preferencesStore', level: 'error', message: 'Failed to hydrate preferences from bridge', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+    }
   },
 }));
 


### PR DESCRIPTION
## Summary

- Adds `ViewMode` type and `UserPreferences` interface to `bridge/types.ts`
- Extends `AppAPI` with `getPreferences()` / `setPreferences()` methods
- `electron-bridge.ts`: graceful-degrade via optional chaining until t/2118 IPC handler lands
- `web-bridge.ts`: `GET /api/preferences` + `PUT /api/preferences` (idempotent)
- New `renderer/store/preferencesStore.ts`: Zustand store, defaults to `'simple'`, hydrates on init, optimistic `setViewMode` with best-effort persist
- 9 unit tests covering type contract, delegation, null fallback, hydration, round-trip, error resilience

## Blocks

t/2118 (ElectronMain IPC), t/2119 (ServerAPI REST), t/2120 (UI) — all depend on these types and channel names.

## Notes

- TL review required before merge (cross-scope interface: BridgeAPI + UserPreferences per p/336#2)
- Committed with `--no-verify` (TL-authorized p/336#4 — pre-commit hook flagging pre-existing AGENTS.md tracking drift unrelated to this change)

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.main.json` — clean
- [x] `npx vitest run src/renderer/bridge/__tests__/preferencesBridge.test.ts` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
