### PR TITLE
chore(constants): extract UI toast timeout constants (t/2128)

### DIFF
--- a/taxonomy-editor/src/renderer/components/community/CommunityLibrary.tsx
+++ b/taxonomy-editor/src/renderer/components/community/CommunityLibrary.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useCommunityStore, type CommunityChat, type CommunityDebate } from '../../hooks/useCommunityStore';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { TOAST_DURATION_INFO, TOAST_DURATION_ERROR } from '../../constants';
 
 type Tab = 'chats' | 'debates';
 
@@ -140,7 +141,7 @@ export function CommunityLibrary() {
 
   useEffect(() => { void fetchChats(); void fetchDebates(); }, []);
 
-  const showToast = (text: string, type: 'info' | 'error' = 'info', durationMs = 3000) => {
+  const showToast = (text: string, type: 'info' | 'error' = 'info', durationMs = TOAST_DURATION_INFO) => {
     setToastMsg({ text, type });
     setTimeout(() => setToastMsg(null), durationMs);
   };
@@ -151,7 +152,7 @@ export function CommunityLibrary() {
       showToast('Copied to your library!');
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'CommunityLibrary', level: 'error', message: 'Failed to copy community item', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      showToast(`Error: ${err instanceof Error ? err.message : String(err)}`, 'error', 5000);
+      showToast(`Error: ${err instanceof Error ? err.message : String(err)}`, 'error', TOAST_DURATION_ERROR);
     }
   };
 
@@ -161,7 +162,7 @@ export function CommunityLibrary() {
       showToast('Removed from community library.');
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'CommunityLibrary', level: 'error', message: 'Failed to remove community item', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      showToast(`Removal failed: ${err instanceof Error ? err.message : String(err)}`, 'error', 5000);
+      showToast(`Removal failed: ${err instanceof Error ? err.message : String(err)}`, 'error', TOAST_DURATION_ERROR);
     }
   };
 

--- a/taxonomy-editor/src/renderer/components/settings/AdminPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/AdminPanel.tsx
@@ -10,6 +10,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useShallow } from 'zustand/react/shallow';
 import { AdminErrorsTab } from './AdminErrorsTab';
 import { UsageBrowserTab } from './UsageBrowserTab';
+import { TOAST_DURATION_SUCCESS, TOAST_DURATION_INFO } from '../../constants';
 import './AdminPanel.css';
 
 type AdminTab = 'submissions' | 'enrichment' | 'errors' | 'usages';
@@ -112,7 +113,7 @@ function EnrichmentRepairSection() {
     }
     setRepairMsg(`Repair complete: ${ok} succeeded, ${fail} failed`);
     setRepairing(false);
-    setTimeout(() => setRepairMsg(null), 5000);
+    setTimeout(() => setRepairMsg(null), TOAST_DURATION_SUCCESS);
   }, [retryEnrichment]);
 
   return (
@@ -188,7 +189,7 @@ export function AdminPanel() {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'AdminPanel', level: 'error', message: 'Failed to approve submission', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
       setMsg(`Error: ${err instanceof Error ? err.message : String(err)}`);
     }
-    setTimeout(() => setMsg(null), 3000);
+    setTimeout(() => setMsg(null), TOAST_DURATION_INFO);
   };
 
   const handleReject = async (id: string) => {
@@ -200,7 +201,7 @@ export function AdminPanel() {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'AdminPanel', level: 'error', message: 'Failed to reject submission', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
       setMsg(`Error: ${err instanceof Error ? err.message : String(err)}`);
     }
-    setTimeout(() => setMsg(null), 3000);
+    setTimeout(() => setMsg(null), TOAST_DURATION_INFO);
   };
 
   const handleBack = () => { window.location.hash = '#community'; };

--- a/taxonomy-editor/src/renderer/components/settings/RuntimeConfigPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/RuntimeConfigPanel.tsx
@@ -7,6 +7,7 @@ import {
   type RuntimeConfig, type ConfigState,
 } from '../../hooks/useRuntimeConfigStore';
 import { isElectronMode } from '@bridge';
+import { TOAST_DURATION_INFO } from '../../constants';
 import './RuntimeConfigPanel.css';
 
 // ── Field metadata ──
@@ -431,7 +432,7 @@ export function RuntimeConfigPanel() {
 
   useEffect(() => {
     if (!saveSuccess) return;
-    const t = setTimeout(() => setSaveSuccess(false), 3000);
+    const t = setTimeout(() => setSaveSuccess(false), TOAST_DURATION_INFO);
     return () => clearTimeout(t);
   }, [saveSuccess]);
 

--- a/taxonomy-editor/src/renderer/components/settings/SupportAdminPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/SupportAdminPanel.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '@bridge';
 import type { SupportCaseSummary, SupportCaseDetail } from '../../bridge/types';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { TOAST_DURATION_INFO } from '../../constants';
 import './SupportAdminPanel.css';
 
 const STATUS_OPTIONS = ['all', 'open', 'in-progress', 'resolved', 'closed'] as const;
@@ -134,7 +135,7 @@ export function SupportAdminPanel() {
       await api.respondToSupportCase(expandedId, responseText.trim());
       setResponseText('');
       setResponseSuccess('Response sent');
-      setTimeout(() => setResponseSuccess(null), 3000);
+      setTimeout(() => setResponseSuccess(null), TOAST_DURATION_INFO);
       void loadDetail(expandedId);
     } catch (err) {
       getGlobalRecorder()?.record({

--- a/taxonomy-editor/src/renderer/constants.ts
+++ b/taxonomy-editor/src/renderer/constants.ts
@@ -2,4 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 export const TOAST_DURATION_SUCCESS = 5000;
+export const TOAST_DURATION_ERROR = 3000;
+export const TOAST_DURATION_INFO = 3000;
 export const TOAST_DURATION_FEEDBACK = 3000;


### PR DESCRIPTION
Extracts hardcoded UI toast/message-dismiss timeouts to named constants in `taxonomy-editor/src/renderer/constants.ts`.

## Changes
- Add `TOAST_DURATION_ERROR = 3000` and `TOAST_DURATION_INFO = 3000` (alongside existing `TOAST_DURATION_SUCCESS = 5000`, `TOAST_DURATION_FEEDBACK = 3000`).
- Replace hardcoded `5000`/`3000` literals with the named constants in: CommunityLibrary, AdminPanel, SupportAdminPanel, RuntimeConfigPanel.

## Behavior
Behavior-neutral except CommunityLibrary error toasts, normalized 5000→3000 to match the ticket's `ERROR=3000` spec (also matches AdminPanel's existing 3000ms error timing).

## Verification
- `check-renderer-tsc.sh`: no new errors from these files
- eslint: clean on all 5 files
- Scoped vitest: AdminPanel + RuntimeConfigPanel tests pass (18/18)

Ticket: t/2128 · Closes #45

Co-Authored-By: Rosetta Stone 2 (Rosetta Stone) (Orca) <rosetta-stone-2.taxonomy-editor@ai-triad-research.orca.local>