### PR TITLE
chore(flight-recorder): extract capacity constants to lib (t/2125)

### DIFF
--- a/lib/flight-recorder/constants.ts
+++ b/lib/flight-recorder/constants.ts
@@ -1,0 +1,8 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/** Ring buffer capacity for primary recorders (renderer process, debate CLI). */
+export const RECORDER_CAPACITY_DEFAULT = 5000;
+
+/** Ring buffer capacity for secondary recorders (ElectronMain process). */
+export const RECORDER_CAPACITY_SECONDARY = 2000;

--- a/lib/flight-recorder/index.ts
+++ b/lib/flight-recorder/index.ts
@@ -23,6 +23,7 @@ export type {
   ErrorCategory,
 } from './types.js';
 export { DEFAULT_CONFIG } from './types.js';
+export { RECORDER_CAPACITY_DEFAULT, RECORDER_CAPACITY_SECONDARY } from './constants.js';
 
 // ── Global singleton ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `lib/flight-recorder/constants.ts` exporting `RECORDER_CAPACITY_DEFAULT = 5000` and `RECORDER_CAPACITY_SECONDARY = 2000`
- Re-export both constants from `lib/flight-recorder/index.ts`
- Cross-scope consumers (`flightRecorderInit.ts`, `main.ts`, `cli.ts`) retain their current inline values pending adoption tickets

## Test plan
- [ ] CI green (`ci-gate` + `CodeQL Analysis`)
- [ ] tsc clean on lib scope (no new errors introduced)

Note: local verify shows a pre-existing `debateEngine.ts(956)` TS2353 error (`moderator_mode` not in `DebateSession`) — unrelated to this change, present on origin/main at `6ada9aae`, CI passes it. See t/2125#1 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)