### PR TITLE
chore(constants): TOAST_DURATION_ERROR 3000->5000 for accessibility (t/2128)

### DIFF
--- a/taxonomy-editor/src/renderer/constants.ts
+++ b/taxonomy-editor/src/renderer/constants.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 export const TOAST_DURATION_SUCCESS = 5000;
-export const TOAST_DURATION_ERROR = 3000;
+// Errors persist longer than info/feedback so users have time to read them (accessibility).
+export const TOAST_DURATION_ERROR = 5000;
 export const TOAST_DURATION_INFO = 3000;
 export const TOAST_DURATION_FEEDBACK = 3000;


### PR DESCRIPTION
Follow-up to #420 (per reviewer request).

Sets `TOAST_DURATION_ERROR = 5000` (was 3000) so error toasts persist longer than info/feedback — users need more time to read errors (accessibility). Adds an inline comment documenting the intent to prevent a future "normalize to 3000" regression.

Side effect: restores CommunityLibrary error toasts to their original 5000ms (#420 had normalized them to 3000), making that call site fully behavior-neutral vs pre-extraction.

Ticket: t/2128

Co-Authored-By: Rosetta Stone 2 (Rosetta Stone) (Orca) <rosetta-stone-2.taxonomy-editor@ai-triad-research.orca.local>