### PR TITLE
feat(server): GET/PUT /api/preferences REST routes for web build (t/2119)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/__snapshots__/routeTable.test.ts.snap
+++ b/taxonomy-editor/src/server/__tests__/__snapshots__/routeTable.test.ts.snap
@@ -192,6 +192,8 @@ exports[`server.ts route table (t/1295 — zero-behaviour-change guard) > ordere
   "GET /api/analytics/query",
   "POST /focus-node",
   "POST /debug/events",
+  "GET /api/preferences",
+  "PUT /api/preferences",
 ]
 `;
 
@@ -274,6 +276,7 @@ exports[`server.ts route table (t/1295 — zero-behaviour-change guard) > route 
   "GET /api/organizations/by-topic/:topicRef",
   "GET /api/policy-registry",
   "GET /api/policy-source-index",
+  "GET /api/preferences",
   "GET /api/proposals",
   "GET /api/proxy/tier",
   "GET /api/proxy/usage",
@@ -384,6 +387,7 @@ exports[`server.ts route table (t/1295 — zero-behaviour-change guard) > route 
   "PUT /api/edges/bulk-status",
   "PUT /api/edges/status",
   "PUT /api/edges/swap",
+  "PUT /api/preferences",
   "PUT /api/proposals/:filename",
   "PUT /api/taxonomy-dir/active",
   "PUT /api/taxonomy/:pov",

--- a/taxonomy-editor/src/server/__tests__/preferences.test.ts
+++ b/taxonomy-editor/src/server/__tests__/preferences.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+//
+// t/2119 — GET /api/preferences + PUT /api/preferences transport routes.
+// fs, flight-recorder, userContext, and config are mocked. Drives real handlers
+// via a captured Router + minimal req/res (same pattern as mentions.test.ts).
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+const { readFileSyncMock, writeFileSyncMock, mkdirSyncMock, recordMock, getStorageUserIdMock, resolveDataPathMock } = vi.hoisted(() => ({
+  readFileSyncMock: vi.fn(),
+  writeFileSyncMock: vi.fn(),
+  mkdirSyncMock: vi.fn(),
+  recordMock: vi.fn(),
+  getStorageUserIdMock: vi.fn(() => '_local'),
+  resolveDataPathMock: vi.fn((p: string) => `/data/${p}`),
+}));
+
+vi.mock('fs', () => ({ default: { readFileSync: readFileSyncMock, writeFileSync: writeFileSyncMock, mkdirSync: mkdirSyncMock } }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: recordMock }) }));
+vi.mock('../security/userContext.js', () => ({ getStorageUserId: getStorageUserIdMock }));
+vi.mock('../config.js', () => ({ resolveDataPath: resolveDataPathMock }));
+
+import type { ServerCtx } from '../routes/context.js';
+import { createRouter, type Handler } from '../httpKit.js';
+import { registerPreferencesRoutes } from '../routes/preferences.js';
+
+function makeRes(): ServerResponse & { _status: number; _body: unknown } {
+  let _status = 200;
+  let _body: unknown;
+  return {
+    writableEnded: false, headersSent: false,
+    writeHead(s: number) { _status = s; (this as { headersSent: boolean }).headersSent = true; },
+    end(b?: string) { _body = b ? JSON.parse(b) : undefined; (this as { writableEnded: boolean }).writableEnded = true; },
+    get _status() { return _status; },
+    get _body() { return _body; },
+  } as unknown as ServerResponse & { _status: number; _body: unknown };
+}
+
+function makeReq(method: string): IncomingMessage {
+  return { url: '/api/preferences', method, headers: {} } as unknown as IncomingMessage;
+}
+
+async function invokeGet(): Promise<{ status: number; body: unknown }> {
+  const routes: { method: string; path: string; handler: Handler }[] = [];
+  registerPreferencesRoutes(createRouter(routes), {} as ServerCtx);
+  const route = routes.find(r => r.method === 'GET' && r.path === '/api/preferences');
+  if (!route) throw new Error('GET /api/preferences not registered');
+  const res = makeRes();
+  await route.handler(makeReq('GET'), res, undefined);
+  return { status: res._status, body: res._body };
+}
+
+async function invokePut(body: unknown): Promise<{ status: number }> {
+  const routes: { method: string; path: string; handler: Handler }[] = [];
+  registerPreferencesRoutes(createRouter(routes), {} as ServerCtx);
+  const route = routes.find(r => r.method === 'PUT' && r.path === '/api/preferences');
+  if (!route) throw new Error('PUT /api/preferences not registered');
+  const res = makeRes();
+  await route.handler(makeReq('PUT'), res, body);
+  return { status: res._status };
+}
+
+describe('GET /api/preferences (t/2119)', () => {
+  beforeEach(() => { readFileSyncMock.mockReset(); recordMock.mockReset(); });
+
+  it('returns null when no prefs file exists (ENOENT)', async () => {
+    readFileSyncMock.mockImplementation(() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }); });
+    const { status, body } = await invokeGet();
+    expect(status).toBe(200);
+    expect(body).toBeNull();
+  });
+
+  it('returns stored prefs when file exists', async () => {
+    readFileSyncMock.mockReturnValue(JSON.stringify({ viewMode: 'advanced' }));
+    const { status, body } = await invokeGet();
+    expect(status).toBe(200);
+    expect(body).toEqual({ viewMode: 'advanced' });
+  });
+});
+
+describe('PUT /api/preferences (t/2119)', () => {
+  beforeEach(() => { writeFileSyncMock.mockReset(); mkdirSyncMock.mockReset(); recordMock.mockReset(); });
+
+  it('writes prefs and returns 204 for a valid body', async () => {
+    const { status } = await invokePut({ viewMode: 'simple' });
+    expect(status).toBe(204);
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('_local.json'),
+      JSON.stringify({ viewMode: 'simple' }),
+      'utf8',
+    );
+  });
+
+  it('returns 400 and does not write for an invalid schema', async () => {
+    const { status } = await invokePut({ viewMode: 'superuser' });
+    expect(status).toBe(400);
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/routeTable.test.ts
+++ b/taxonomy-editor/src/server/__tests__/routeTable.test.ts
@@ -21,7 +21,7 @@ describe('server.ts route table (t/1295 — zero-behaviour-change guard)', () =>
   const routes = extractRoutes(serverEntry);
 
   it('registers exactly 190 routes', () => {
-    expect(routes.length).toBe(190); // +GET /api/admin/usages (t/1265); +GET /api/organizations/:id/edges (t/1530); +POST/DELETE /api/cruxes/:id/evidence (t/1541); +PATCH /api/debates/:id (t/1636); +GET /api/entity/:ref (t/1786); +GET /api/public/pov/:pov/node/:nodeId (t/1788); +PUT /api/edges (t/1821); +GET /api/entities (t/1883); +GET /api/container-mentions/:containerId (t/1902); +GET /api/greatest-hits (t/1998)
+    expect(routes.length).toBe(192); // +GET /api/admin/usages (t/1265); +GET /api/organizations/:id/edges (t/1530); +POST/DELETE /api/cruxes/:id/evidence (t/1541); +PATCH /api/debates/:id (t/1636); +GET /api/entity/:ref (t/1786); +GET /api/public/pov/:pov/node/:nodeId (t/1788); +PUT /api/edges (t/1821); +GET /api/entities (t/1883); +GET /api/container-mentions/:containerId (t/1902); +GET /api/greatest-hits (t/1998); +GET/PUT /api/preferences (t/2119)
   });
 
   // GATE 1 — set identity: sorted (method, path) multiset. Fails on any add/drop.

--- a/taxonomy-editor/src/server/routes/preferences.ts
+++ b/taxonomy-editor/src/server/routes/preferences.ts
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2119: web-build transport for user preferences. GET returns the stored
+// UserPreferences object or null (client falls back to default 'simple').
+// PUT validates the body with Zod (400 on bad schema) and persists to a
+// per-user JSON file; returns 204. Shape matches UserPreferences in bridge/types.ts.
+
+import fs from 'fs';
+import path from 'path';
+import { z } from 'zod';
+import type { Router } from '../httpKit.js';
+import type { ServerCtx } from './context.js';
+import { json, error } from '../httpKit.js';
+import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+import { resolveDataPath } from '../config.js';
+import { getStorageUserId } from '../security/userContext.js';
+
+const UserPreferencesSchema = z.object({
+  viewMode: z.enum(['simple', 'advanced']),
+});
+
+function prefsFilePath(): string {
+  return resolveDataPath(path.join('preferences', `${getStorageUserId()}.json`));
+}
+
+export function registerPreferencesRoutes(r: Router, _ctx: ServerCtx): void {
+  const { get, put } = r;
+
+  // GET /api/preferences — null when no file yet (client defaults to 'simple').
+  // NB: path is a string literal (not a const) so extractRoutes.ts can see it.
+  get('/api/preferences', async (_req, res) => {
+    try {
+      const raw = fs.readFileSync(prefsFilePath(), 'utf8');
+      json(res, JSON.parse(raw));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') { json(res, null); return; }
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'server', level: 'error',
+        message: 'Failed to read preferences',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      error(res, String(err), 500, err);
+    }
+  });
+
+  // PUT /api/preferences — Zod-validated; 400 on bad schema, 204 on success.
+  put('/api/preferences', async (_req, res, body) => {
+    try {
+      const parsed = UserPreferencesSchema.safeParse(body);
+      if (!parsed.success) {
+        error(res, 'Invalid preferences: ' + parsed.error.message, 400);
+        return;
+      }
+      const filePath = prefsFilePath();
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, JSON.stringify(parsed.data), 'utf8');
+      json(res, null, 204);
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'server', level: 'error',
+        message: 'Failed to write preferences',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      error(res, String(err), 500, err);
+    }
+  });
+}

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -66,6 +66,7 @@ import { registerDiagnosticsRoutes } from './routes/diagnostics.js';
 import { registerSupportRoutes } from './routes/support.js';
 import { registerSourcesRoutes } from './routes/sources.js';
 import { registerSessionRoutes } from './routes/session.js';
+import { registerPreferencesRoutes } from './routes/preferences.js';
 import { buildLoginPage, FORBIDDEN_PAGE, SW_HEAL_SCRIPT_CSP_HASH, loginPageHeaders } from './loginPage.js';
 import type { ServerCtx } from './routes/context.js';
 import { listFlags, setFlag, deleteFlag, type FlagDef } from './featureFlags.js';
@@ -440,6 +441,11 @@ registerSyncRoutes(router, serverCtx);
 // file pipeline, to preserve snapshot order). /focus-node broadcasts via the new
 // ctx.broadcastEvent (broadcastEvent stays in server.ts with the WebSocket set).
 registerSessionRoutes(router, serverCtx);
+
+// ── User preferences (t/2119) ──
+// GET /api/preferences + PUT /api/preferences — per-user JSON file storage for
+// the web build. Brand-new paths — no collision.
+registerPreferencesRoutes(router, serverCtx);
 
 // ── Static file serving ──
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/preferences` — returns `UserPreferences | null` (null when no file stored, client defaults to `simple`)
- Adds `PUT /api/preferences` — Zod-validates body (`{ viewMode: simple | advanced }`), 400 on bad schema, 204 on success
- Per-user storage at `{dataRoot}/preferences/{storageUserId}.json` (direct fs, local-only config precedent)
- Route count 190->192; routeTable snapshots updated

Self-cert: /add-rest-endpoint pattern (t/2119#1). Blocked by t/2117 (now merged d7f2f8b1).

## Test plan

- [x] 4 unit tests pass: GET null (ENOENT), GET stored, PUT valid (204 + writes file), PUT invalid schema (400, no write)
- [x] tsc -p tsconfig.server.json clean
- [x] routeTable.test.ts passes at 192 routes, snapshots updated

Co-authored-by: ServerAPI (Orca) <main.taxonomy-editor-src-server@ai-triad-research.orca.local>