### PR TITLE
feat(prefs): IPC handlers for get-preferences / set-preferences (t/2118)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/prefsHandlers.test.ts
+++ b/taxonomy-editor/src/main/__tests__/prefsHandlers.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * t/2118 — covers get-preferences / set-preferences IPC handlers.
+ * AC: get-preferences returns null (no file) or parsed object;
+ *     set-preferences writes atomically (tmp → rename).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+
+type HandlerFn = (...args: unknown[]) => unknown;
+
+const mockHandle = vi.hoisted(() => ({} as Record<string, HandlerFn>));
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn() },
+  ipcMain: {
+    handle: vi.fn((channel: string, cb: HandlerFn) => { mockHandle[channel] = cb; }),
+  },
+}));
+
+import { app } from 'electron';
+import { registerPrefsHandlers } from '../ipc/prefsHandlers.js';
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'prefs-handler-'));
+const fakeEvent = {} as Electron.IpcMainInvokeEvent;
+
+beforeAll(() => {
+  vi.mocked(app.getPath).mockReturnValue(tmpRoot);
+  registerPrefsHandlers();
+});
+
+afterAll(() => { fs.rmSync(tmpRoot, { recursive: true, force: true }); });
+
+describe('get-preferences', () => {
+  it('returns null when preferences.json does not exist', async () => {
+    const result = await mockHandle['get-preferences'](fakeEvent);
+    expect(result).toBeNull();
+  });
+});
+
+describe('set-preferences / get-preferences round-trip', () => {
+  it('persists preferences and retrieves them', async () => {
+    const prefs = { viewMode: 'advanced' as const };
+    await mockHandle['set-preferences'](fakeEvent, prefs);
+    const result = await mockHandle['get-preferences'](fakeEvent);
+    expect(result).toEqual(prefs);
+  });
+
+  it('overwrites with a new value', async () => {
+    await mockHandle['set-preferences'](fakeEvent, { viewMode: 'simple' as const });
+    const result = await mockHandle['get-preferences'](fakeEvent);
+    expect(result).toEqual({ viewMode: 'simple' });
+  });
+});

--- a/taxonomy-editor/src/main/ipc/prefsHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/prefsHandlers.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// User preferences IPC handlers (t/2118). Backs the get-preferences /
+// set-preferences channels wired in electron-bridge.ts by t/2117.
+
+import { ipcMain, app } from 'electron';
+import fsp from 'fs/promises';
+import path from 'path';
+import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+
+function prefsFilePath(): string {
+  return path.join(app.getPath('userData'), 'preferences.json');
+}
+
+export function registerPrefsHandlers(): void {
+  ipcMain.handle('get-preferences', async (): Promise<unknown> => {
+    try {
+      const raw = await fsp.readFile(prefsFilePath(), 'utf-8');
+      return JSON.parse(raw) as unknown;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'prefsHandlers', level: 'error', message: 'get-preferences failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+      return null;
+    }
+  });
+
+  // Atomic write: write to a .tmp sidecar then rename into place so a crash
+  // mid-write never leaves a truncated preferences file.
+  ipcMain.handle('set-preferences', async (_event, prefs: unknown): Promise<void> => {
+    const dest = prefsFilePath();
+    const tmp = `${dest}.tmp`;
+    await fsp.mkdir(path.dirname(dest), { recursive: true });
+    await fsp.writeFile(tmp, JSON.stringify(prefs, null, 2) + '\n', 'utf-8');
+    await fsp.rename(tmp, dest);
+  });
+}

--- a/taxonomy-editor/src/main/ipcHandlers.ts
+++ b/taxonomy-editor/src/main/ipcHandlers.ts
@@ -24,8 +24,10 @@ import { registerMentionHandlers } from './ipc/mentionHandlers.js';
 import { registerFlightRecorderHandlers } from './ipc/flightRecorderHandlers.js';
 import { registerCommunityHandlers } from './ipc/communityHandlers.js';
 import { registerSystemHandlers } from './ipc/systemHandlers.js';
+import { registerPrefsHandlers } from './ipc/prefsHandlers.js';
 
 export function registerIpcHandlers(): void {
+  registerPrefsHandlers();
   registerTaxonomyHandlers();
   registerSourceHandlers();
   registerAiHandlers();

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -20,6 +20,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getEmbeddingInfo: (): Promise<{ backend: string; execution_provider?: string; calibration_version?: number }> =>
     ipcRenderer.invoke('get-embedding-info'),
 
+  // User preferences (t/2118)
+  getPreferences: (): Promise<unknown> =>
+    ipcRenderer.invoke('get-preferences'),
+  setPreferences: (prefs: unknown): Promise<void> =>
+    ipcRenderer.invoke('set-preferences', prefs),
+
   getTaxonomyDirs: (): Promise<string[]> =>
     ipcRenderer.invoke('get-taxonomy-dirs'),
 

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -5,11 +5,16 @@ import type { Organization, OrganizationEdge } from '@lib/organizations/types';
 import type { EntityDetail, EntitySummary, EntityListQuery } from '@lib/entities/types';
 import type { ContainerMentions } from '@lib/entities/mentionTypes';
 import type { EdgesFile } from '@lib/debate/taxonomyTypes';
+import type { UserPreferences } from '../bridge/types';
 
 export interface ElectronAPI {
   processVersions: Record<string, string | undefined>;
   osRelease: string;
   getEmbeddingInfo: () => Promise<{ backend: string; execution_provider?: string; calibration_version?: number }>;
+
+  // User preferences (t/2118) — optional until handler confirmed present
+  getPreferences?: () => Promise<UserPreferences | null>;
+  setPreferences?: (prefs: UserPreferences) => Promise<void>;
 
   // Taxonomy directories
   getTaxonomyDirs: () => Promise<string[]>;


### PR DESCRIPTION
## Summary

- Registers `get-preferences` and `set-preferences` `ipcMain.handle` channels in a new `src/main/ipc/prefsHandlers.ts` module
- Atomic write via `.tmp` sidecar + `fsp.rename` — a mid-write crash never leaves a truncated `preferences.json`
- `ENOENT` on first read returns `null` (no file = no saved prefs yet)
- Wired in `ipcHandlers.ts`, `preload.cts` (typed `unknown` to avoid renderer `@lib` dep chain), and `electron.d.ts` (`UserPreferences | null`)
- 3 unit tests: null on missing file, set+get round-trip, overwrite

## Test plan

- [ ] `npx tsc --noEmit -p tsconfig.main.json` — clean
- [ ] `npx vitest run src/main/__tests__/prefsHandlers.test.ts` — 3/3 pass
- [ ] CI green across all 6 checks

Closes t/2118

🤖 Generated with [Claude Code](https://claude.com/claude-code)