### PR TITLE
feat(ui): Simple/Advanced view mode — renderer conditional changes (t/2120)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/preferencesBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/preferencesBridge.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2117 — UserPreferences types + BridgeAPI extension + Zustand store + bridge implementations.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AppAPI, UserPreferences } from '../types';
+
+// ── Type-level: verify AppAPI contract ──────────────────────────────────────
+
+describe('AppAPI preferences contract', () => {
+  it('AppAPI includes getPreferences and setPreferences', () => {
+    const dummy = {} as AppAPI;
+    expect('getPreferences' in dummy || dummy.getPreferences === undefined).toBe(true);
+    expect('setPreferences' in dummy || dummy.setPreferences === undefined).toBe(true);
+  });
+});
+
+// ── electron-bridge delegation ──────────────────────────────────────────────
+
+describe('electron-bridge preferences', () => {
+  const origWindow = (globalThis as Record<string, unknown>).window;
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).window = origWindow;
+    vi.resetModules();
+  });
+
+  it('delegates getPreferences to window.electronAPI when present', async () => {
+    const prefs: UserPreferences = { viewMode: 'advanced' };
+    (globalThis as Record<string, unknown>).window = {
+      electronAPI: { getPreferences: vi.fn().mockResolvedValue(prefs) },
+    };
+    const mod = await import('../electron-bridge');
+    const result = await mod.api.getPreferences();
+    expect(result).toEqual(prefs);
+    expect(window.electronAPI.getPreferences).toHaveBeenCalled();
+  });
+
+  it('returns null when getPreferences IPC handler is not yet wired (t/2118)', async () => {
+    (globalThis as Record<string, unknown>).window = { electronAPI: {} };
+    const mod = await import('../electron-bridge');
+    const result = await mod.api.getPreferences();
+    expect(result).toBeNull();
+  });
+
+  it('delegates setPreferences to window.electronAPI when present', async () => {
+    const setFn = vi.fn().mockResolvedValue(undefined);
+    (globalThis as Record<string, unknown>).window = {
+      electronAPI: { setPreferences: setFn },
+    };
+    const mod = await import('../electron-bridge');
+    const prefs: UserPreferences = { viewMode: 'simple' };
+    await mod.api.setPreferences(prefs);
+    expect(setFn).toHaveBeenCalledWith(prefs);
+  });
+
+  it('resolves without error when setPreferences IPC handler is not yet wired (t/2118)', async () => {
+    (globalThis as Record<string, unknown>).window = { electronAPI: {} };
+    const mod = await import('../electron-bridge');
+    await expect(mod.api.setPreferences({ viewMode: 'simple' })).resolves.toBeUndefined();
+  });
+});
+
+// ── preferencesStore ────────────────────────────────────────────────────────
+
+describe('preferencesStore', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('defaults viewMode to simple when bridge returns null', async () => {
+    vi.doMock('../../bridge/index', () => ({
+      api: { getPreferences: vi.fn().mockResolvedValue(null), setPreferences: vi.fn().mockResolvedValue(undefined) },
+    }));
+    const { usePreferencesStore } = await import('../../store/preferencesStore');
+    const store = usePreferencesStore.getState();
+    await store.hydrate();
+    expect(usePreferencesStore.getState().viewMode).toBe('simple');
+  });
+
+  it('hydrates viewMode from stored value', async () => {
+    const prefs: UserPreferences = { viewMode: 'advanced' };
+    vi.doMock('../../bridge/index', () => ({
+      api: { getPreferences: vi.fn().mockResolvedValue(prefs), setPreferences: vi.fn().mockResolvedValue(undefined) },
+    }));
+    const { usePreferencesStore } = await import('../../store/preferencesStore');
+    await usePreferencesStore.getState().hydrate();
+    expect(usePreferencesStore.getState().viewMode).toBe('advanced');
+  });
+
+  it('setViewMode updates local state and calls setPreferences', async () => {
+    const setFn = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('../../bridge/index', () => ({
+      api: { getPreferences: vi.fn().mockResolvedValue(null), setPreferences: setFn },
+    }));
+    const { usePreferencesStore } = await import('../../store/preferencesStore');
+    await usePreferencesStore.getState().setViewMode('advanced');
+    expect(usePreferencesStore.getState().viewMode).toBe('advanced');
+    expect(setFn).toHaveBeenCalledWith({ viewMode: 'advanced' });
+  });
+
+  it('defaults to simple and does not throw when bridge errors during hydration', async () => {
+    vi.doMock('../../bridge/index', () => ({
+      api: { getPreferences: vi.fn().mockRejectedValue(new Error('network')), setPreferences: vi.fn() },
+    }));
+    const { usePreferencesStore } = await import('../../store/preferencesStore');
+    await expect(usePreferencesStore.getState().hydrate()).resolves.toBeUndefined();
+    expect(usePreferencesStore.getState().viewMode).toBe('simple');
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -5,7 +5,7 @@
  * Electron bridge — delegates every AppAPI method to window.electronAPI (IPC).
  * Used when the app runs inside Electron (desktop mode).
  */
-import type { AppAPI } from './types';
+import type { AppAPI, UserPreferences } from './types';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
 import {
@@ -24,6 +24,13 @@ void tryInitLocalEmbedding();
 const localDiagCallbacks = new Set<(state: unknown) => void>();
 
 export const api: AppAPI = {
+  // User preferences — delegates to IPC (get-preferences / set-preferences) once
+  // ElectronMain handler lands (t/2118). Graceful-degrade until then.
+  getPreferences: (): Promise<UserPreferences | null> =>
+    window.electronAPI.getPreferences?.() ?? Promise.resolve(null),
+  setPreferences: (prefs: UserPreferences): Promise<void> =>
+    window.electronAPI.setPreferences?.(prefs) ?? Promise.resolve(),
+
   // Taxonomy directories
   getTaxonomyDirs: () => window.electronAPI.getTaxonomyDirs(),
   getActiveTaxonomyDir: () => window.electronAPI.getActiveTaxonomyDir(),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -101,7 +101,17 @@ export type ContainerMentions = _ContainerMentions;
 
 export interface OrgFilters { type?: string; pov?: string }
 
+export type ViewMode = 'simple' | 'advanced';
+
+export interface UserPreferences {
+  viewMode: ViewMode;
+}
+
 export interface AppAPI {
+  // --- User preferences ---
+  getPreferences: () => Promise<UserPreferences | null>;
+  setPreferences: (prefs: UserPreferences) => Promise<void>;
+
   // --- Taxonomy directories ---
   getTaxonomyDirs: () => Promise<string[]>;
   getActiveTaxonomyDir: () => Promise<string>;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -5,7 +5,7 @@
  * Web bridge — implements AppAPI via REST and WebSocket calls to the server.
  * Used when the app runs in a browser served by the container.
  */
-import type { AppAPI, SourceDocumentResolution, DebateDelta } from './types';
+import type { AppAPI, SourceDocumentResolution, DebateDelta, UserPreferences } from './types';
 import { instrumentBridge } from './instrumentBridge';
 import { ActionableError } from '@lib/debate/errors';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
@@ -740,6 +740,10 @@ if (import.meta.hot) {
 // ── The bridge ──
 
 const rawApi: AppAPI = {
+  // User preferences
+  getPreferences: () => get<UserPreferences | null>('/api/preferences').catch(() => null),
+  setPreferences: (prefs: UserPreferences) => put('/api/preferences', prefs, { idempotent: true }).then(() => {}),
+
   // Taxonomy directories
   getTaxonomyDirs: () => get('/api/taxonomy-dirs'),
   getActiveTaxonomyDir: () => get('/api/taxonomy-dir/active'),

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -27,6 +27,7 @@ import { LineageDetailView } from '../shared/LineageDetailView';
 import type { DebateSession } from '../../types/debate';
 import { POVER_INFO } from '@lib/debate/types';
 import { ParameterHistoryPanel } from '../analysis/ParameterHistoryPanel';
+import { usePreferencesStore } from '../../store/preferencesStore';
 import { api, isElectronMode } from '@bridge';
 import { trackExport } from '../../lib/analyticsEmitter';
 import './DebateTab.css';
@@ -917,6 +918,7 @@ function DebateDetailSummary({
   // Calibration is an admin/power-user tool — show only for admins (t/1036).
   // Desktop (Electron) owners are admin-equivalent; web requires the admin flag.
   const showAdminControls = isElectronMode() || useFlag('permission-admin-features');
+  const viewMode = usePreferencesStore(s => s.viewMode);
   const topic = debate.topic.final || debate.topic.refined || debate.topic.original;
 
   const handleShare = useCallback(async () => {
@@ -968,7 +970,7 @@ function DebateDetailSummary({
         </div>
         <div className="debate-tab-spacer" />
         <ExportDropdown onExport={onExport} />
-        {showAdminControls && (
+        {showAdminControls && viewMode !== 'simple' && (
           <button className="btn" onClick={() => setShowCalibration(!showCalibration)}>
             Calibration
           </button>
@@ -979,7 +981,7 @@ function DebateDetailSummary({
         {exportStatus && <span className="debate-detail-export-status">{exportStatus}</span>}
       </div>
 
-      {showCalibration && (
+      {showCalibration && viewMode !== 'simple' && (
         <ParameterHistoryPanel onClose={() => setShowCalibration(false)} />
       )}
 
@@ -997,23 +999,25 @@ function DebateDetailSummary({
       </div>
 
       <div className="debate-detail-grid">
-        <DebateStatsSection debate={debate} />
+        {viewMode !== 'simple' && <DebateStatsSection debate={debate} />}
 
-        <div className="debate-detail-section">
-          <h3>Timestamps</h3>
-          <div className="debate-detail-meta-row">
-            <span className="debate-detail-label">Created:</span>
-            <span>{formatDateLong(debate.created_at)}</span>
+        {viewMode !== 'simple' && (
+          <div className="debate-detail-section">
+            <h3>Timestamps</h3>
+            <div className="debate-detail-meta-row">
+              <span className="debate-detail-label">Created:</span>
+              <span>{formatDateLong(debate.created_at)}</span>
+            </div>
+            <div className="debate-detail-meta-row">
+              <span className="debate-detail-label">Updated:</span>
+              <span>{formatDateLong(debate.updated_at)}</span>
+            </div>
           </div>
-          <div className="debate-detail-meta-row">
-            <span className="debate-detail-label">Updated:</span>
-            <span>{formatDateLong(debate.updated_at)}</span>
-          </div>
-        </div>
+        )}
 
-        <DebateSourceSection debate={debate} />
+        {viewMode !== 'simple' && <DebateSourceSection debate={debate} />}
 
-        <DebateConfigSection debate={debate} />
+        {viewMode !== 'simple' && <DebateConfigSection debate={debate} />}
       </div>
     </div>
   );

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect, useRef, Fragment } from 'react';
 import {
   Search, LayoutGrid, MessageSquare, MessageCircle, ArrowLeft,
-  Ellipsis, CircleHelp, Star,
+  Ellipsis, CircleHelp, Star, Layers,
   RefreshCw, Settings, User, Users, Shield, LogOut,
 } from 'lucide-react';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
@@ -17,6 +17,7 @@ import { useFlag } from '../../hooks/useFeatureFlags';
 import { useTierInfo } from '../../hooks/useTierInfo';
 import { FeedbackPopover } from './FeedbackPopover';
 import { NAV_ITEMS, getVisibleNavItems, getSecondaryByGroup, type NavItem, type NavAction } from '../../data/navConfig';
+import { usePreferencesStore } from '../../store/preferencesStore';
 import './Toolbar.css';
 
 type ToolbarPanel = 'search' | 'related' | 'attrFilter' | 'attrInfo' | 'lineage' | 'prompts' | 'console' | 'fallacy' | 'edges' | 'policyAlignment' | 'policyDashboard' | 'vocabulary' | 'calibration';
@@ -224,6 +225,7 @@ export function Toolbar() {
     return false;
   };
   const moreHasActive = secondaryGroups.flatMap(g => g.items).some(i => isNavItemActive(i));
+  const { viewMode, setViewMode } = usePreferencesStore(state => ({ viewMode: state.viewMode, setViewMode: state.setViewMode }));
 
   // Escape key navigates back
   useEffect(() => {
@@ -334,8 +336,16 @@ export function Toolbar() {
         </button>
       </div>
       <div className="toolbar-bottom">
-        {/* Other Tools */}
-        <div className="toolbar-more-wrap" ref={moreRef}>
+        <button
+          className={`toolbar-icon${viewMode === 'advanced' ? ' toolbar-icon-active' : ''}`}
+          onClick={() => void setViewMode(viewMode === 'simple' ? 'advanced' : 'simple')}
+          aria-label={viewMode === 'simple' ? 'Switch to Advanced view' : 'Switch to Simple view'}
+          data-tooltip={viewMode === 'simple' ? 'Switch to Advanced view' : 'Switch to Simple view'}
+        >
+          <Layers size={20} />
+        </button>
+        {/* Other Tools — hidden in Simple view */}
+        {viewMode === 'advanced' && <div className="toolbar-more-wrap" ref={moreRef}>
           <button
             className={`toolbar-icon${moreHasActive || showMore ? ' toolbar-icon-active' : ''}`}
             onClick={() => setShowMore(v => !v)}
@@ -363,7 +373,7 @@ export function Toolbar() {
               ))}
             </div>
           )}
-        </div>
+        </div>}
         <div className="toolbar-separator" />
         <button
           className="toolbar-icon"

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -35,6 +35,7 @@ import { EditConflictBadge, type NodeConflict } from '../conflict/edit-conflicts
 import { triggerPovNodeRegeneration } from '../../utils/regeneratePlainDescription';
 import { generateAphorism } from '../../utils/regenerateAphorism';
 import { useDescriptionMode, resolveDescription, DescriptionToggle } from '../shared/DescriptionToggle';
+import { usePreferencesStore } from '../../store/preferencesStore';
 import { EmptyState } from '../shared/EmptyState';
 import { OverflowMenu, type OverflowMenuEntry } from '../shared/OverflowMenu';
 import { CopyLinkButton } from '../shared/CopyLinkButton';
@@ -122,10 +123,18 @@ function getNodeAphorism(node: PovNode): string | undefined {
 
 export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRelated, chipDepth = 0, conflict, resolveUrl }: NodeDetailProps) {
   const { updatePovNode, deletePovNode, movePovNodeCategory, movePovNode, validationErrors, getAllNodeIds, getAllConflictIds, runAttributeFilter, showAttributeInfo, navigateToLineage, setToolbarPanel, selectedEdge, relatedNodeId, loadEdges, edgesFile, setSelectedNodeId, getLabelForId, aggregatedCruxes, showCruxDetail, conflicts } = useTaxonomyStore();
+  const { viewMode } = usePreferencesStore(state => ({ viewMode: state.viewMode }));
   const [descMode, setDescMode] = useDescriptionMode();
   const [showDelete, setShowDelete] = useState(false);
   const [activeTab, setActiveTab] = useState<NodeDetailTabId>('content');
   const [expandedLineage, setExpandedLineage] = useState<string | null>(null);
+
+  // Reset to a visible tab when switching to Simple (which hides most tabs).
+  useEffect(() => {
+    if (viewMode === 'simple' && activeTab !== 'content' && activeTab !== 'related') {
+      setActiveTab('content');
+    }
+  }, [viewMode]);
   const [showDtDrilldown, setShowDtDrilldown] = useState(false);
   const [relatedSplitPct, setRelatedSplitPct] = useState(40);
   const splitContainerRef = useRef<HTMLDivElement>(null);
@@ -422,6 +431,7 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
         cruxCount={cruxCount}
         factCount={factCount}
         editHistoryLength={getEditHistoryLength(node)}
+        viewMode={viewMode}
       />
 
       {/* Tab content */}
@@ -690,9 +700,10 @@ interface NodeDetailTabBarProps {
   cruxCount: number;
   factCount: number;
   editHistoryLength: number | undefined;
+  viewMode: 'simple' | 'advanced';
 }
 
-function NodeDetailTabBar({ activeTab, setActiveTab, conflictCount, cruxCount, factCount, editHistoryLength }: NodeDetailTabBarProps) {
+function NodeDetailTabBar({ activeTab, setActiveTab, conflictCount, cruxCount, factCount, editHistoryLength, viewMode }: NodeDetailTabBarProps) {
   return (
     <div className="node-detail-tabs">
       <button
@@ -702,59 +713,61 @@ function NodeDetailTabBar({ activeTab, setActiveTab, conflictCount, cruxCount, f
         Content
       </button>
       <button
-        className={`node-detail-tab ${activeTab === 'attributes' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('attributes')}
-      >
-        Attributes
-      </button>
-      <button
         className={`node-detail-tab ${activeTab === 'related' ? 'node-detail-tab-active' : ''}`}
         onClick={() => setActiveTab('related')}
       >
         Related
       </button>
-      <button
-        className={`node-detail-tab ${activeTab === 'conflicts' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('conflicts')}
-      >
-        Conflicts{conflictCount > 0 ? ` (${conflictCount})` : ''}
-      </button>
-      <button
-        className={`node-detail-tab ${activeTab === 'cruxes' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('cruxes')}
-      >
-        Cruxes{cruxCount > 0 ? ` (${cruxCount})` : ''}
-      </button>
-      <button
-        className={`node-detail-tab ${activeTab === 'phrases' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('phrases')}
-      >
-        Phrases
-      </button>
-      <button
-        className={`node-detail-tab ${activeTab === 'sources' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('sources')}
-      >
-        Sources
-      </button>
-      <button
-        className={`node-detail-tab ${activeTab === 'facts' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('facts')}
-      >
-        Facts{factCount > 0 ? ` (${factCount})` : ''}
-      </button>
-      <button
-        className={`node-detail-tab ${activeTab === 'research' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('research')}
-      >
-        Research
-      </button>
-      <button
-        className={`node-detail-tab ${activeTab === 'history' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('history')}
-      >
-        History{editHistoryLength ? ` (${editHistoryLength})` : ''}
-      </button>
+      {viewMode === 'advanced' && <>
+        <button
+          className={`node-detail-tab ${activeTab === 'attributes' ? 'node-detail-tab-active' : ''}`}
+          onClick={() => setActiveTab('attributes')}
+        >
+          Attributes
+        </button>
+        <button
+          className={`node-detail-tab ${activeTab === 'conflicts' ? 'node-detail-tab-active' : ''}`}
+          onClick={() => setActiveTab('conflicts')}
+        >
+          Conflicts{conflictCount > 0 ? ` (${conflictCount})` : ''}
+        </button>
+        <button
+          className={`node-detail-tab ${activeTab === 'cruxes' ? 'node-detail-tab-active' : ''}`}
+          onClick={() => setActiveTab('cruxes')}
+        >
+          Cruxes{cruxCount > 0 ? ` (${cruxCount})` : ''}
+        </button>
+        <button
+          className={`node-detail-tab ${activeTab === 'phrases' ? 'node-detail-tab-active' : ''}`}
+          onClick={() => setActiveTab('phrases')}
+        >
+          Phrases
+        </button>
+        <button
+          className={`node-detail-tab ${activeTab === 'sources' ? 'node-detail-tab-active' : ''}`}
+          onClick={() => setActiveTab('sources')}
+        >
+          Sources
+        </button>
+        <button
+          className={`node-detail-tab ${activeTab === 'facts' ? 'node-detail-tab-active' : ''}`}
+          onClick={() => setActiveTab('facts')}
+        >
+          Facts{factCount > 0 ? ` (${factCount})` : ''}
+        </button>
+        <button
+          className={`node-detail-tab ${activeTab === 'research' ? 'node-detail-tab-active' : ''}`}
+          onClick={() => setActiveTab('research')}
+        >
+          Research
+        </button>
+        <button
+          className={`node-detail-tab ${activeTab === 'history' ? 'node-detail-tab-active' : ''}`}
+          onClick={() => setActiveTab('history')}
+        >
+          History{editHistoryLength ? ` (${editHistoryLength})` : ''}
+        </button>
+      </>}
     </div>
   );
 }
@@ -818,6 +831,8 @@ interface DescriptionSectionProps {
 }
 
 function DescriptionSection({ pov, node, readOnly, err, descMode, setDescMode, maybeRegenAphorism, update, updatePovNode, renderMentionField, descriptionMention }: DescriptionSectionProps) {
+  const { viewMode } = usePreferencesStore(state => ({ viewMode: state.viewMode }));
+  const effectiveDescMode = viewMode === 'simple' ? 'plain' as const : descMode;
   return (
     <div className={`form-group ${err('description') ? 'has-error' : ''}`}>
       <div className="description-header">
@@ -825,9 +840,9 @@ function DescriptionSection({ pov, node, readOnly, err, descMode, setDescMode, m
           Description
           <FieldHelp text={`Genus-differentia format:\n"${CATEGORY_SINGULAR[node.category]} within [POV] discourse that [differentia].\nEncompasses: ...\nExcludes: ..."\nEncompasses and Excludes must each start on a new line.`} />
         </label>
-        <DescriptionToggle mode={descMode} onToggle={setDescMode} hasPlainDescription={!!node.plain_description} />
+        {viewMode === 'advanced' && <DescriptionToggle mode={descMode} onToggle={setDescMode} hasPlainDescription={!!node.plain_description} />}
       </div>
-      {descMode === 'formal' ? (
+      {effectiveDescMode === 'formal' ? (
         <div className="prose" onBlur={maybeRegenAphorism}>
           <HighlightedTextarea
             value={node.description}

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -704,70 +704,32 @@ interface NodeDetailTabBarProps {
 }
 
 function NodeDetailTabBar({ activeTab, setActiveTab, conflictCount, cruxCount, factCount, editHistoryLength, viewMode }: NodeDetailTabBarProps) {
+  // Content + Related always show; the rest are Advanced-only (t/2120).
+  const tabs: { id: NodeDetailTabId; label: string; advanced?: boolean }[] = [
+    { id: 'content', label: 'Content' },
+    { id: 'related', label: 'Related' },
+    { id: 'attributes', label: 'Attributes', advanced: true },
+    { id: 'conflicts', label: `Conflicts${conflictCount > 0 ? ` (${conflictCount})` : ''}`, advanced: true },
+    { id: 'cruxes', label: `Cruxes${cruxCount > 0 ? ` (${cruxCount})` : ''}`, advanced: true },
+    { id: 'phrases', label: 'Phrases', advanced: true },
+    { id: 'sources', label: 'Sources', advanced: true },
+    { id: 'facts', label: `Facts${factCount > 0 ? ` (${factCount})` : ''}`, advanced: true },
+    { id: 'research', label: 'Research', advanced: true },
+    { id: 'history', label: `History${editHistoryLength ? ` (${editHistoryLength})` : ''}`, advanced: true },
+  ];
   return (
     <div className="node-detail-tabs">
-      <button
-        className={`node-detail-tab ${activeTab === 'content' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('content')}
-      >
-        Content
-      </button>
-      <button
-        className={`node-detail-tab ${activeTab === 'related' ? 'node-detail-tab-active' : ''}`}
-        onClick={() => setActiveTab('related')}
-      >
-        Related
-      </button>
-      {viewMode === 'advanced' && <>
-        <button
-          className={`node-detail-tab ${activeTab === 'attributes' ? 'node-detail-tab-active' : ''}`}
-          onClick={() => setActiveTab('attributes')}
-        >
-          Attributes
-        </button>
-        <button
-          className={`node-detail-tab ${activeTab === 'conflicts' ? 'node-detail-tab-active' : ''}`}
-          onClick={() => setActiveTab('conflicts')}
-        >
-          Conflicts{conflictCount > 0 ? ` (${conflictCount})` : ''}
-        </button>
-        <button
-          className={`node-detail-tab ${activeTab === 'cruxes' ? 'node-detail-tab-active' : ''}`}
-          onClick={() => setActiveTab('cruxes')}
-        >
-          Cruxes{cruxCount > 0 ? ` (${cruxCount})` : ''}
-        </button>
-        <button
-          className={`node-detail-tab ${activeTab === 'phrases' ? 'node-detail-tab-active' : ''}`}
-          onClick={() => setActiveTab('phrases')}
-        >
-          Phrases
-        </button>
-        <button
-          className={`node-detail-tab ${activeTab === 'sources' ? 'node-detail-tab-active' : ''}`}
-          onClick={() => setActiveTab('sources')}
-        >
-          Sources
-        </button>
-        <button
-          className={`node-detail-tab ${activeTab === 'facts' ? 'node-detail-tab-active' : ''}`}
-          onClick={() => setActiveTab('facts')}
-        >
-          Facts{factCount > 0 ? ` (${factCount})` : ''}
-        </button>
-        <button
-          className={`node-detail-tab ${activeTab === 'research' ? 'node-detail-tab-active' : ''}`}
-          onClick={() => setActiveTab('research')}
-        >
-          Research
-        </button>
-        <button
-          className={`node-detail-tab ${activeTab === 'history' ? 'node-detail-tab-active' : ''}`}
-          onClick={() => setActiveTab('history')}
-        >
-          History{editHistoryLength ? ` (${editHistoryLength})` : ''}
-        </button>
-      </>}
+      {tabs
+        .filter(tab => !tab.advanced || viewMode === 'advanced')
+        .map(tab => (
+          <button
+            key={tab.id}
+            className={`node-detail-tab ${activeTab === tab.id ? 'node-detail-tab-active' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/store/preferencesStore.ts
+++ b/taxonomy-editor/src/renderer/store/preferencesStore.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { create } from 'zustand';
+import type { ViewMode, UserPreferences } from '../bridge/types';
+
+interface PreferencesState {
+  viewMode: ViewMode;
+  setViewMode: (mode: ViewMode) => Promise<void>;
+  /** Load persisted preferences from the bridge and hydrate the store. */
+  hydrate: () => Promise<void>;
+}
+
+export const usePreferencesStore = create<PreferencesState>()((set) => ({
+  viewMode: 'simple',
+
+  setViewMode: async (mode: ViewMode) => {
+    set({ viewMode: mode });
+    try {
+      const { api } = await import('../bridge/index');
+      await api.setPreferences({ viewMode: mode });
+    } catch { /* best-effort — local state already updated */ }
+  },
+
+  hydrate: async () => {
+    try {
+      const { api } = await import('../bridge/index');
+      const prefs: UserPreferences | null = await api.getPreferences();
+      if (prefs?.viewMode) {
+        set({ viewMode: prefs.viewMode });
+      }
+    } catch { /* default 'simple' stands on error */ }
+  },
+}));
+
+((window as unknown as { __ZUSTAND_STORES__?: Record<string, unknown> }).__ZUSTAND_STORES__ ??= {} as Record<string, unknown>).preferences = usePreferencesStore;

--- a/taxonomy-editor/src/renderer/store/preferencesStore.ts
+++ b/taxonomy-editor/src/renderer/store/preferencesStore.ts
@@ -3,6 +3,7 @@
 
 import { create } from 'zustand';
 import type { ViewMode, UserPreferences } from '../bridge/types';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
 
 interface PreferencesState {
   viewMode: ViewMode;
@@ -19,7 +20,9 @@ export const usePreferencesStore = create<PreferencesState>()((set) => ({
     try {
       const { api } = await import('../bridge/index');
       await api.setPreferences({ viewMode: mode });
-    } catch { /* best-effort — local state already updated */ }
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'preferencesStore', level: 'error', message: 'Failed to persist view mode preference', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+    }
   },
 
   hydrate: async () => {
@@ -29,7 +32,9 @@ export const usePreferencesStore = create<PreferencesState>()((set) => ({
       if (prefs?.viewMode) {
         set({ viewMode: prefs.viewMode });
       }
-    } catch { /* default 'simple' stands on error */ }
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'preferencesStore', level: 'error', message: 'Failed to hydrate preferences from bridge', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+    }
   },
 }));
 

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -5,6 +5,7 @@ import type { Organization, OrganizationEdge } from '@lib/organizations/types';
 import type { EntityDetail, EntitySummary, EntityListQuery } from '@lib/entities/types';
 import type { ContainerMentions } from '@lib/entities/mentionTypes';
 import type { EdgesFile } from '@lib/debate/taxonomyTypes';
+import type { UserPreferences } from '../bridge/types';
 
 export interface ElectronAPI {
   processVersions: Record<string, string | undefined>;
@@ -258,6 +259,11 @@ export interface ElectronAPI {
   // Container mentions (t/1901). Optional — wired by the container-mentions IPC handler
   // (ElectronMain, t/1903). Until then undefined and the bridge fails loud.
   getContainerMentions?: (id: string) => Promise<ContainerMentions | null>;
+
+  // User preferences (t/2117). Optional — wired by ElectronMain in t/2118.
+  // Until then the bridge degrades gracefully (returns null / no-ops).
+  getPreferences?: () => Promise<UserPreferences | null>;
+  setPreferences?: (prefs: UserPreferences) => Promise<void>;
 
   // Deep-link URL
   getWebAppUrl?: () => Promise<string | null>;


### PR DESCRIPTION
## Summary

- **Toolbar**: Always-visible view mode toggle (Layers icon); Other Tools (`…`) popover hidden in Simple view
- **NodeDetail tabs**: Only Content + Related shown in Simple; active tab resets to Content on mode switch
- **POV description**: Forced to Plain in Simple (toggle hidden); stored preference preserved for Advanced
- **DebateTab**: STATISTICS, TIMESTAMPS, SOURCE, CONFIGURATION panels + Calibration button hidden in Simple (co-authored with DebateUI)
- **electron.d.ts**: Adds optional `getPreferences?`/`setPreferences?` to `ElectronAPI` (graceful-degrade until ElectronMain t/2118 lands)

All areas update immediately on toggle — no navigation or restart required.

## Blockers / Notes

- Branched from `feat/preferences-foundation-t2117` (t/2117) — depends on `usePreferencesStore` and bridge types
- Full e2e persistence requires t/2118 (ElectronMain IPC) + t/2119 (ServerAPI REST)
- Committed with `--no-verify` (TL-authorized p/336#10 — pre-existing `debateEngine.ts:956 moderator_mode` type error in DebateTool scope, unrelated to this change)

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.main.json` — clean (renderer types + electron.d.ts)
- [x] Visual: toggle button in toolbar; Other Tools disappears in Simple; NodeDetail shows 2 tabs; description Plain-only; debate panels hidden
- [ ] Full e2e persistence pending t/2118 + t/2119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
