### PR TITLE
fix(types): add moderator_mode to DebateSession interface (t/2135)

### DIFF
--- a/lib/debate/types/session.ts
+++ b/lib/debate/types/session.ts
@@ -270,6 +270,8 @@ export interface DebateSession {
   app_version?: string;
   /** Target audience for tone, language, and concern prioritization. */
   audience?: DebateAudience;
+  /** Moderator mode used for this session ('standard' | 'talmudic'). Optional for back-compat with pre-Talmudic sessions. */
+  moderator_mode?: string;
   phase: 'setup' | 'clarification' | 'edit-claims' | 'opening' | 'debate' | 'closed' | 'cancelled';
   topic: {
     original: string;


### PR DESCRIPTION
Fixes tsc error blocking renderer ceiling (fleet-wide). `debateEngine.ts:956` and `crossRespond.ts:1010` both write `moderator_mode` into the session object but the field was absent from `DebateSession`.

Field is optional (`?`) for back-compat with pre-Talmudic sessions.

Self-certifying under /trivial-change: 1-line type addition, single scope, no behavioral change.