### PR TITLE
chore(pnpm): migrate lib/debate to pnpm@11.20.0 (t/2140)

### DIFF
--- a/lib/debate/package.json
+++ b/lib/debate/package.json
@@ -1,4 +1,5 @@
 {
   "type": "module",
-  "sideEffects": false
+  "sideEffects": false,
+  "packageManager": "pnpm@11.20.0"
 }

--- a/lib/debate/pnpm-lock.yaml
+++ b/lib/debate/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
Add `packageManager: pnpm@11.20.0` to `lib/debate/package.json` and commit `pnpm-lock.yaml` generated by fresh `pnpm install`.

**Deviation from ticket:** no `package-lock.json` existed, so `pnpm import` was skipped — fresh install used instead (DevOps 2 p/348#3).

`pnpm install --frozen-lockfile` verified green locally.