### PR TITLE
chore(pnpm): PS launcher scripts and advisory strings npm to pnpm (t/2138)

### DIFF
--- a/scripts/AITriad/Private/Invoke-DependencyCheck.ps1
+++ b/scripts/AITriad/Private/Invoke-DependencyCheck.ps1
@@ -296,17 +296,17 @@ function Invoke-DependencyCheck {
             else {
                 DWarn "$App — node_modules missing"
                 if ($IsInstallMode -and $Fix -and $HasNode) {
-                    DFix "Running npm install in $App..."
+                    DFix "Running pnpm install in $App..."
                     Push-Location $AppDir
                     try {
-                        npm install 2>&1 | Out-Null
-                        if ($LASTEXITCODE -eq 0) { $Ctx.Fixed++; DPass "$App — npm install succeeded" }
-                        else { DFail "$App — npm install failed (exit code $LASTEXITCODE)" }
+                        pnpm install 2>&1 | Out-Null
+                        if ($LASTEXITCODE -eq 0) { $Ctx.Fixed++; DPass "$App — pnpm install succeeded" }
+                        else { DFail "$App — pnpm install failed (exit code $LASTEXITCODE)" }
                     }
-                    catch { DFail "$App — npm install failed: $_" }
+                    catch { DFail "$App — pnpm install failed: $_" }
                     finally { Pop-Location }
                 }
-                else { DSkip "Run 'npm install' in $App/" }
+                else { DSkip "Run 'pnpm install' in $App/" }
             }
         }
     }

--- a/scripts/AITriad/Public/Show-POViewer.ps1
+++ b/scripts/AITriad/Public/Show-POViewer.ps1
@@ -47,16 +47,16 @@ function Show-POViewer {
     try {
         $NodeModules = Join-Path $AppDir 'node_modules'
         if (-not (Test-Path $NodeModules)) {
-            Write-Warn "node_modules/ not found — running npm install first"
-            npm install
+            Write-Warn "node_modules/ not found — running pnpm install first"
+            pnpm install
             if ($LASTEXITCODE -ne 0) {
-                Write-Fail "npm install failed (exit code $LASTEXITCODE) in $AppDir"
+                Write-Fail "pnpm install failed (exit code $LASTEXITCODE) in $AppDir"
                 return
             }
         }
         npm run dev
         if ($LASTEXITCODE -ne 0) {
-            Write-Fail "npm run dev failed (exit code $LASTEXITCODE). Try: cd $AppDir && npm install && npm run dev"
+            Write-Fail "npm run dev failed (exit code $LASTEXITCODE). Try: cd $AppDir && pnpm install && npm run dev"
         }
     }
     finally { Pop-Location }

--- a/scripts/AITriad/Public/Show-SummaryViewer.ps1
+++ b/scripts/AITriad/Public/Show-SummaryViewer.ps1
@@ -47,16 +47,16 @@ function Show-SummaryViewer {
     try {
         $NodeModules = Join-Path $AppDir 'node_modules'
         if (-not (Test-Path $NodeModules)) {
-            Write-Warn "node_modules/ not found — running npm install first"
-            npm install
+            Write-Warn "node_modules/ not found — running pnpm install first"
+            pnpm install
             if ($LASTEXITCODE -ne 0) {
-                Write-Fail "npm install failed (exit code $LASTEXITCODE) in $AppDir"
+                Write-Fail "pnpm install failed (exit code $LASTEXITCODE) in $AppDir"
                 return
             }
         }
         npm run dev
         if ($LASTEXITCODE -ne 0) {
-            Write-Fail "npm run dev failed (exit code $LASTEXITCODE). Try: cd $AppDir && npm install && npm run dev"
+            Write-Fail "npm run dev failed (exit code $LASTEXITCODE). Try: cd $AppDir && pnpm install && npm run dev"
         }
     }
     finally { Pop-Location }

--- a/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
+++ b/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
@@ -410,7 +410,7 @@ function Start-LegacyElectronMode {
         Write-Warn "Node modules not installed in taxonomy-editor/."
         $Choice = $Host.UI.PromptForChoice(
             'Missing Node Modules',
-            "Run 'npm install' in the taxonomy-editor directory?",
+            "Run 'pnpm install' in the taxonomy-editor directory?",
             @('&Yes', '&No'),
             0
         )
@@ -418,9 +418,9 @@ function Start-LegacyElectronMode {
             Write-Step 'Installing Node modules'
             Push-Location $AppDir
             try {
-                npm install
+                pnpm install
                 if ($LASTEXITCODE -ne 0) {
-                    Write-Fail "npm install failed (exit code $LASTEXITCODE)."
+                    Write-Fail "pnpm install failed (exit code $LASTEXITCODE)."
                     return
                 }
                 Write-OK 'Node modules installed.'

--- a/scripts/AITriad/Public/Show-WorkflowRunner.ps1
+++ b/scripts/AITriad/Public/Show-WorkflowRunner.ps1
@@ -83,15 +83,15 @@ function Show-WorkflowRunner {
         Write-Host '[workflow] Installing node modules...' -ForegroundColor Cyan
         Push-Location $AppDir
         try {
-            npm install
+            pnpm install
             if ($LASTEXITCODE -ne 0) {
                 throw (New-ActionableError `
                     -Goal 'Install Workflow Runner dependencies' `
-                    -Problem "npm install failed (exit code $LASTEXITCODE)" `
+                    -Problem "pnpm install failed (exit code $LASTEXITCODE)" `
                     -Location 'Show-WorkflowRunner' `
                     -NextSteps @(
                         "cd $AppDir"
-                        'npm install'
+                        'pnpm install'
                     ))
             }
             Write-Host '[workflow] Node modules installed.' -ForegroundColor Green

--- a/scripts/Project-Template/Public/Invoke-DependencyAudit.ps1
+++ b/scripts/Project-Template/Public/Invoke-DependencyAudit.ps1
@@ -61,7 +61,7 @@ function Invoke-DependencyAudit {
                 Write-Warning "Failed to parse npm audit output: $_"
             }
         } else {
-            Write-Warning 'npm: node_modules not found. Run npm ci first.'
+            Write-Warning 'npm: node_modules not found. Run pnpm install first.'
         }
     }
 

--- a/scripts/Project-Template/Public/Invoke-LicenseAudit.ps1
+++ b/scripts/Project-Template/Public/Invoke-LicenseAudit.ps1
@@ -48,7 +48,7 @@ function Invoke-LicenseAudit {
             -Goal 'Run license audit' `
             -Problem 'No package.json found' `
             -Location 'Invoke-LicenseAudit' `
-            -NextSteps @('Pass -AppDir pointing to a directory with package.json', 'Run npm ci first') -Throw
+            -NextSteps @('Pass -AppDir pointing to a directory with package.json', 'Run pnpm install first') -Throw
     }
 
     Write-Output "Auditing licenses in: $AppDir"
@@ -70,7 +70,7 @@ function Invoke-LicenseAudit {
     try { $packages = $raw | ConvertFrom-Json } catch { Write-Warning "Failed to parse license data: $_" }
 
     if (-not $packages) {
-        Write-Warning 'Could not parse license data. Run npm ci and try again.'
+        Write-Warning 'Could not parse license data. Run pnpm install and try again.'
         return
     }
 

--- a/scripts/Verify-Config.ps1
+++ b/scripts/Verify-Config.ps1
@@ -122,7 +122,7 @@ if (-not (Test-Path (Join-Path $TaxEditor 'node_modules'))) {
     # would trigger the module-load taxonomy scan this command has no need for).
     Write-Host '  FAIL vitest — taxonomy-editor/node_modules is missing.' -ForegroundColor Red
     Write-Host '        Goal:  run the vitest registry gates' -ForegroundColor DarkYellow
-    Write-Host "        Fix:   run 'npm ci' in $TaxEditor, then re-run verify:config" -ForegroundColor DarkYellow
+    Write-Host "        Fix:   run 'pnpm install' in $TaxEditor, then re-run verify:config" -ForegroundColor DarkYellow
     $Results['vitest:collection (4 files)'] = $false
     $Results['vitest:run'] = $false
 }


### PR DESCRIPTION
## Summary
- Switches 5 live-executing `npm install` calls to `pnpm install` in PS launcher scripts (Invoke-DependencyCheck, Show-POViewer, Show-SummaryViewer, Show-TaxonomyEditor legacy dev mode, Show-WorkflowRunner)
- Updates advisory strings in Verify-Config.ps1, Invoke-DependencyAudit.ps1, Invoke-LicenseAudit.ps1

## Test plan
- [x] Pester: 907 passed, 13 failed (all pre-existing data-dependency failures, unrelated to these changes)
- [x] Diff: 8 files, 24 symmetric npm→pnpm substitutions only
- [x] review-ps checklist: clean

Parent: t/2078 (pnpm shared-store migration). Landing after DevOps CI PR per p/346#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)