### PR TITLE
fix(build): absolute base path for web SPA — fixes /share/pov/:id blank page (t/2141)

### DIFF
--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
     })] : []),
   ],
   root: 'src/renderer',
-  base: './',
+  base: isWeb ? '/' : './',
   define: {
     // Expose build target to renderer code
     'import.meta.env.VITE_TARGET': JSON.stringify(process.env.VITE_TARGET || 'electron'),


### PR DESCRIPTION
## Summary

- `base: './'` in `vite.config.ts` emitted relative asset paths in the built `index.html`
- From `/share/pov/:id`, the browser resolved `./assets/index.js` to `/share/pov/assets/index.js`
- The SPA fallback served `index.html` (wrong MIME type) for the missing asset path
- ES module loader silently rejected it → React never mounted → blank page
- Fix: `base: isWeb ? '/' : './'` — absolute paths for web build; Electron keeps `'./'` (file:// URI requires relative)

## Root cause path

`vite.config.ts:69` → built `index.html` has `src="./assets/…"` → SPA fallback returns HTML for asset fetch → browser MIME rejection → blank `#root`

## Test plan

- [x] Electron build unaffected (`isWeb` false → `base: './'` preserved)
- [ ] Web build: `VITE_TARGET=web npm run build` → `dist/renderer/index.html` should have `src="/assets/…"` (absolute)
- [ ] Deploy to container: navigate to `/share/pov/<any-id>` in incognito → page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)