### PR TITLE
ci: published-image readiness smoke pre-staging (t/2103)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -252,3 +252,35 @@ jobs:
       - name: Image size report
         if: success()
         run: docker images ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}"
+
+  smoke-published:
+    needs: [build-and-push]
+    runs-on: ubuntu-latest
+    # Only runs when the image was actually pushed to GHCR.
+    # A no-push dispatch (push=false) skips this job; the workflow still
+    # succeeds so deploy-staging.yml is not spuriously blocked.
+    if: |
+      needs.build-and-push.result == 'success' &&
+      (github.event_name == 'push' || inputs.push == 'true')
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull published image by digest
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.digest }}"
+          echo "Pulling $IMAGE"
+          docker pull "$IMAGE"
+
+      - name: Readiness smoke against published image
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.digest }}
+          SMOKE_MODE: readiness
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash deploy/azure/smoke-healthz.sh


### PR DESCRIPTION
## Summary
- Adds `smoke-published` job to `container.yml` after `build-and-push`
- Pulls the just-pushed image by digest and runs `smoke-healthz.sh` in `SMOKE_MODE=readiness`
- A base bump that breaks data-readiness fails `container.yml` (conclusion != success), blocking `deploy-staging.yml`'s workflow_run gate before staging auto-deploy

## How it works
`deploy-staging.yml` fires only when Container Image completes with `conclusion == 'success'`. `smoke-published` failing makes the workflow fail — no staging promotion. Job is skipped on no-push dispatches so manual build-only runs are unaffected.

## Test plan
- [ ] Verify smoke-published passes on a healthy image in the next container.yml run
- [ ] Gate-verification (AC): dispatch against a known-failing image digest → smoke-published red, staging not promoted

Closes t/2103

Generated with Claude Code