### PR TITLE
fix(ui): split inline Zustand object selectors to stop render loop (t/2142)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -225,7 +225,8 @@ export function Toolbar() {
     return false;
   };
   const moreHasActive = secondaryGroups.flatMap(g => g.items).some(i => isNavItemActive(i));
-  const { viewMode, setViewMode } = usePreferencesStore(state => ({ viewMode: state.viewMode, setViewMode: state.setViewMode }));
+  const viewMode = usePreferencesStore(state => state.viewMode);
+  const setViewMode = usePreferencesStore(state => state.setViewMode);
 
   // Escape key navigates back
   useEffect(() => {

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -123,7 +123,7 @@ function getNodeAphorism(node: PovNode): string | undefined {
 
 export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRelated, chipDepth = 0, conflict, resolveUrl }: NodeDetailProps) {
   const { updatePovNode, deletePovNode, movePovNodeCategory, movePovNode, validationErrors, getAllNodeIds, getAllConflictIds, runAttributeFilter, showAttributeInfo, navigateToLineage, setToolbarPanel, selectedEdge, relatedNodeId, loadEdges, edgesFile, setSelectedNodeId, getLabelForId, aggregatedCruxes, showCruxDetail, conflicts } = useTaxonomyStore();
-  const { viewMode } = usePreferencesStore(state => ({ viewMode: state.viewMode }));
+  const viewMode = usePreferencesStore(state => state.viewMode);
   const [descMode, setDescMode] = useDescriptionMode();
   const [showDelete, setShowDelete] = useState(false);
   const [activeTab, setActiveTab] = useState<NodeDetailTabId>('content');
@@ -793,7 +793,7 @@ interface DescriptionSectionProps {
 }
 
 function DescriptionSection({ pov, node, readOnly, err, descMode, setDescMode, maybeRegenAphorism, update, updatePovNode, renderMentionField, descriptionMention }: DescriptionSectionProps) {
-  const { viewMode } = usePreferencesStore(state => ({ viewMode: state.viewMode }));
+  const viewMode = usePreferencesStore(state => state.viewMode);
   const effectiveDescMode = viewMode === 'simple' ? 'plain' as const : descMode;
   return (
     <div className={`form-group ${err('description') ? 'has-error' : ''}`}>


### PR DESCRIPTION
## Summary

Inline object selectors create a new object ref on every render. Zustand strict-equality check always sees a new value → re-render → crash ("Maximum update depth exceeded").

**3 sites fixed:**
- `Toolbar.tsx:228` — split `{ viewMode, setViewMode }` into two scalar selectors
- `NodeDetail.tsx:126` — `{ viewMode }` → `state.viewMode`
- `NodeDetail.tsx:796` (DescriptionSection) — same

DebateTab.tsx already used scalar selectors — no change needed.

## Root cause

Introduced by db9a67ba (t/2120). `DebateTab.tsx` was written correctly; the regression was in Toolbar and NodeDetail.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.main.json` — clean
- [ ] App starts without hitting error boundary
- [ ] Simple/Advanced toggle works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)