### PR TITLE
chore(constants): centralize similarity thresholds in constants.ts (t/2126)

### DIFF
--- a/lib/debate/calibrationLogger/extract.ts
+++ b/lib/debate/calibrationLogger/extract.ts
@@ -18,6 +18,7 @@ import { computeSourceAuthority } from '../sourceAuthority.js';
 import type { DocMetaMap } from '../evidenceFromSummaries.js';
 import { PROMPT_VERSION } from '../prompts.js';
 import { DEFAULT_ATTACK_WEIGHTS } from '../qbaf.js';
+import { POLARITY_RESOLVED_THRESHOLD, SEMANTIC_RECYCLING_THRESHOLD, ATTACK_DEDUP_THRESHOLD } from '../constants.js';
 import { computeAgentUtility } from '../agentUtility.js';
 import type { AgentUtility } from '../agentUtility.js';
 import { computeOperationalClosure } from '../operationalClosure.js';
@@ -439,19 +440,19 @@ export function extractCalibrationData(
     crux_match_stats: cruxMatchStats,
     crux_undecided_rate: cruxUndecidedRate,
     counterfactual_type_distribution: cfTypeDist,
-    polarity_resolved_threshold: config.polarityResolvedThreshold ?? 0.85,
+    polarity_resolved_threshold: config.polarityResolvedThreshold ?? POLARITY_RESOLVED_THRESHOLD,
 
     relevance_score_variance: relevanceVariance,
     max_nodes_cap: config.maxNodesCap ?? 50,
 
     recycling_novelty_agreement: recyclingAgreement,
-    semantic_recycling_threshold: config.semanticRecyclingThreshold ?? 0.85,
+    semantic_recycling_threshold: config.semanticRecyclingThreshold ?? SEMANTIC_RECYCLING_THRESHOLD,
 
     taxonomy_mapped_ratio: taxonomyMappedRatio,
     cluster_min_similarity: config.clusterMinSimilarity ?? 0.55,
 
     near_miss_duplicate_count: nearMissDups,
-    duplicate_similarity_threshold: config.duplicateSimilarityThreshold ?? 0.85,
+    duplicate_similarity_threshold: config.duplicateSimilarityThreshold ?? ATTACK_DEDUP_THRESHOLD,
 
     borderline_claim_survival_rate: borderlineSurvival,
     fire_confidence_threshold: config.fireConfidenceThreshold ?? 0.7,

--- a/lib/debate/calibrationLogger/history.ts
+++ b/lib/debate/calibrationLogger/history.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { DEFAULT_TEMPERATURE } from '../../ai-client/defaults.js';
 import { DEFAULT_ATTACK_WEIGHTS } from '../qbaf.js';
+import { POLARITY_RESOLVED_THRESHOLD, SEMANTIC_RECYCLING_THRESHOLD, ATTACK_DEDUP_THRESHOLD } from '../constants.js';
 
 // ── Parameter snapshots & history ────────────────────────────
 
@@ -88,11 +89,11 @@ export function captureSnapshot(weightsPath?: string): ParameterSnapshot {
     },
     recent_window: 8,
     gc_trigger: weights?.network?.gc_trigger ?? 175,
-    polarity_resolved: 0.85,
+    polarity_resolved: POLARITY_RESOLVED_THRESHOLD,
     max_nodes_cap: 50,
-    semantic_recycling_threshold: 0.85,
+    semantic_recycling_threshold: SEMANTIC_RECYCLING_THRESHOLD,
     cluster_min_similarity: 0.55,
-    duplicate_similarity_threshold: 0.85,
+    duplicate_similarity_threshold: ATTACK_DEDUP_THRESHOLD,
     fire_confidence_threshold: 0.7,
     cohesion_clear_theme: 0.60,
     kp_divisor: 500,

--- a/lib/debate/confidenceDedup.ts
+++ b/lib/debate/confidenceDedup.ts
@@ -21,8 +21,10 @@ import type { WeightHistoryEntry } from './taxonomyTypes.js';
 
 // ── Configuration ───────────────────────────────────────
 
+import { ATTACK_DEDUP_THRESHOLD } from './constants.js';
+
 export const TOPIC_DEDUP_THRESHOLD = 0.80;
-export const ATTACK_DEDUP_THRESHOLD = 0.85;
+export { ATTACK_DEDUP_THRESHOLD };
 
 // ── Index types ─────────────────────────────────────────
 

--- a/lib/debate/constants.ts
+++ b/lib/debate/constants.ts
@@ -2,3 +2,12 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 export const DOC_TRUNCATION_LIMIT = 50_000;
+
+/** Cosine similarity threshold for detecting semantic recycling across debate turns. */
+export const SEMANTIC_RECYCLING_THRESHOLD = 0.85;
+
+/** Cosine similarity threshold for deduplicating attack moves in the argument network. */
+export const ATTACK_DEDUP_THRESHOLD = 0.85;
+
+/** Polarity score threshold for classifying a crux as resolved (support or attack direction). */
+export const POLARITY_RESOLVED_THRESHOLD = 0.85;

--- a/lib/debate/convergenceSignals.ts
+++ b/lib/debate/convergenceSignals.ts
@@ -18,8 +18,9 @@ import type { MoveAnnotation } from './helpers.js';
 import { computeQbafStrengths } from './qbaf.js';
 import type { QbafNode, QbafEdge } from './qbaf.js';
 import { cosineSimilarity } from './taxonomyRelevance.js';
+import { SEMANTIC_RECYCLING_THRESHOLD } from './constants.js';
 
-export const SEMANTIC_RECYCLING_THRESHOLD = 0.85;
+export { SEMANTIC_RECYCLING_THRESHOLD };
 export const ARCO_DRIFT_THRESHOLD = 0.5;
 /** Below this max-clause-similarity, the turn is considered to engage with
  *  no clause of the resolution — i.e., a candidate for redirect. */

--- a/lib/debate/cruxResolution.ts
+++ b/lib/debate/cruxResolution.ts
@@ -14,8 +14,7 @@ import type {
 import { detectCruxNodes } from './phaseTransitions.js';
 import { getGlobalRecorder } from '../flight-recorder/index.js';
 import { ActionableError } from './errors.js';
-
-const POLARITY_RESOLVED_THRESHOLD = 0.85;
+import { POLARITY_RESOLVED_THRESHOLD } from './constants.js';
 const STRENGTH_CONCESSION_THRESHOLD = 0.3;
 const IRREDUCIBLE_STABLE_TURNS = 3;
 const POLARITY_STABILITY_EPSILON = 0.05;


### PR DESCRIPTION
## Summary
- Adds `SEMANTIC_RECYCLING_THRESHOLD`, `ATTACK_DEDUP_THRESHOLD`, and `POLARITY_RESOLVED_THRESHOLD` to `lib/debate/constants.ts` as the single source of truth
- Source modules (`convergenceSignals.ts`, `confidenceDedup.ts`, `cruxResolution.ts`) re-export from constants instead of defining locally
- Calibration logger defaults (`history.ts`, `extract.ts`) now reference named constants instead of bare `0.85`

Self-certifying under /trivial-change: 6 files, all lib/debate scope, no new public API, no interface changes. 229 tests pass at f73f9a7f.

## Test plan
- [x] `npx vitest run` — 229 tests pass (constants, convergenceSignals, confidenceDedup, calibrationLogger suites)
- [x] All 6 changed files staged and committed before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)