### PR TITLE
refactor(ai-client): replace hardcoded 0.7 with DEFAULT_TEMPERATURE constant (t/2123)

### DIFF
--- a/lib/ai-client/providers/azure.ts
+++ b/lib/ai-client/providers/azure.ts
@@ -4,6 +4,7 @@
 import { ActionableError } from '../../debate/errors.js';
 import { withTimeout } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
+import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
 function resolveEndpoint(): string {
   const endpoint = process.env.AZURE_OPENAI_ENDPOINT;
@@ -41,7 +42,7 @@ export async function generateViaAzure(
 
   const reqBody: Record<string, unknown> = {
     messages,
-    temperature: opts.temperature ?? 0.7,
+    temperature: opts.temperature ?? DEFAULT_TEMPERATURE,
     max_tokens: opts.maxTokens ?? 8192,
   };
   if (opts.jsonMode) {

--- a/lib/ai-client/providers/deepseek.ts
+++ b/lib/ai-client/providers/deepseek.ts
@@ -4,6 +4,7 @@
 import { ActionableError } from '../../debate/errors.js';
 import { withTimeout } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
+import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
 export async function generateViaDeepSeek(
   fetchFn: FetchFn,
@@ -28,7 +29,7 @@ export async function generateViaDeepSeek(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
         max_tokens: opts.maxTokens ?? 8192,
         ...(opts.jsonMode ? {
           response_format: { type: 'json_object' },
@@ -115,7 +116,7 @@ export async function generateViaDeepSeekStream(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
         max_tokens: opts.maxTokens ?? 8192,
         stream: true,
         stream_options: { include_usage: true },

--- a/lib/ai-client/providers/gemini.ts
+++ b/lib/ai-client/providers/gemini.ts
@@ -4,6 +4,7 @@
 import { ActionableError } from '../../debate/errors.js';
 import { withTimeout } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult, ToolCall } from '../types.js';
+import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
 export const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
 
@@ -55,7 +56,7 @@ export async function generateViaGemini(
   const timeoutMs = opts.timeoutMs!;
 
   const genConfig: Record<string, unknown> = {
-    temperature: opts.temperature ?? 0.7,
+    temperature: opts.temperature ?? DEFAULT_TEMPERATURE,
     maxOutputTokens: opts.maxTokens ?? 16384,
   };
   if (opts.jsonMode || opts.responseSchema) {

--- a/lib/ai-client/providers/groq.ts
+++ b/lib/ai-client/providers/groq.ts
@@ -4,6 +4,7 @@
 import { ActionableError } from '../../debate/errors.js';
 import { withTimeout } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
+import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
 export async function generateViaGroq(
   fetchFn: FetchFn,
@@ -28,7 +29,7 @@ export async function generateViaGroq(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
         max_tokens: opts.maxTokens ?? 8192,
         ...(opts.responseSchema ? {
           response_format: {

--- a/lib/ai-client/providers/moonshot.ts
+++ b/lib/ai-client/providers/moonshot.ts
@@ -4,6 +4,7 @@
 import { ActionableError } from '../../debate/errors.js';
 import { withTimeout } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
+import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
 const MOONSHOT_BASE = 'https://api.moonshot.ai/v1';
 
@@ -30,7 +31,7 @@ export async function generateViaMoonshot(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
         max_tokens: opts.maxTokens ?? 8192,
         ...(opts.jsonMode ? {
           response_format: { type: 'json_object' },

--- a/lib/ai-client/providers/ollama.ts
+++ b/lib/ai-client/providers/ollama.ts
@@ -4,6 +4,7 @@
 import { ActionableError } from '../../debate/errors.js';
 import { withTimeout } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
+import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
 export const OLLAMA_BASE = 'http://localhost:11434';
 
@@ -40,7 +41,7 @@ export async function generateViaOllama(
   const reqBody: Record<string, unknown> = {
     model: apiModelId,
     messages,
-    temperature: opts.temperature ?? 0.7,
+    temperature: opts.temperature ?? DEFAULT_TEMPERATURE,
     max_tokens: opts.maxTokens ?? 8192,
   };
 

--- a/lib/ai-client/providers/zai.ts
+++ b/lib/ai-client/providers/zai.ts
@@ -4,6 +4,7 @@
 import { ActionableError } from '../../debate/errors.js';
 import { withTimeout } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
+import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
 export async function generateViaZai(
   fetchFn: FetchFn,
@@ -28,7 +29,7 @@ export async function generateViaZai(
       body: JSON.stringify({
         model: apiModelId,
         messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? 0.7,
+        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
         max_tokens: opts.maxTokens ?? 16384,
         ...(opts.responseSchema ? {
           response_format: {


### PR DESCRIPTION
## Summary

- Imports `DEFAULT_TEMPERATURE` from `ai-client/defaults.ts` in all 7 provider files
- Replaces every inline `?? 0.7` temperature literal with `?? DEFAULT_TEMPERATURE`
- Providers updated: azure, gemini, groq, ollama, moonshot, deepseek (x2, incl. stream variant), zai

Closes t/2123. The constant itself (DEFAULT_TEMPERATURE = 0.7) was landed in a prior commit (3d794259) as part of t/2122.

## Test plan

- [ ] CI green (ci-gate + CodeQL)
- [ ] No behavioral change -- value remains 0.7, sourced from the constant

Generated with Claude Code
