### PR TITLE
feat(config): backend adapter validation in verify:config (t/2097)

### DIFF
--- a/scripts/AITriad/Public/Test-AIModelsConfig.ps1
+++ b/scripts/AITriad/Public/Test-AIModelsConfig.ps1
@@ -99,7 +99,33 @@ function Test-AIModelsConfig {
         return [PSCustomObject]@{ Path = $Path; Pass = $false; Issues = @($Issues) }
     }
 
-    $Models = if ($Cfg.PSObject.Properties['models']) { @($Cfg.models) } else { @() }
+    $Models   = if ($Cfg.PSObject.Properties['models'])   { @($Cfg.models) }   else { @() }
+    $Backends = if ($Cfg.PSObject.Properties['backends']) { @($Cfg.backends) } else { @() }
+
+    # ── Check A: UnknownAdapter — each backends[].id must match a callProvider switch case ──
+    # Parse switch cases from client.ts so the check stays current when new adapters are added.
+    $ClientTsPath = Join-Path $script:RepoRoot 'lib/ai-client/client.ts'
+    $KnownAdapters = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    $AdapterSetValid = $false
+    if (Test-Path $ClientTsPath) {
+        $ClientTs = Get-Content $ClientTsPath -Raw
+        [regex]::Matches($ClientTs, "case '(\w+)':") | ForEach-Object { [void]$KnownAdapters.Add($_.Groups[1].Value) }
+        [void]$KnownAdapters.Add('gemini')  # default case — no explicit switch arm
+        $AdapterSetValid = $true
+    }
+
+    $BackendIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    $BackendIdx = 0
+    foreach ($B in $Backends) {
+        $BId = if ($B.PSObject.Properties['id']) { [string]$B.id } else { '' }
+        if (-not [string]::IsNullOrWhiteSpace($BId)) {
+            [void]$BackendIds.Add($BId)
+            if ($AdapterSetValid -and -not $KnownAdapters.Contains($BId)) {
+                Add-Issue 'Error' 'UnknownAdapter' "backends[$BackendIdx] ($BId)" "Backend id '$BId' has no matching switch case in lib/ai-client/client.ts callProvider — requests will silently fall through to the gemini default."
+            }
+        }
+        $BackendIdx++
+    }
 
     # Backends whose real provider API model names legitimately carry the vendor
     # name as a prefix (gemini-2.5-flash, claude-opus-4-6, deepseek-chat). For
@@ -120,6 +146,11 @@ function Test-AIModelsConfig {
         if ([string]::IsNullOrWhiteSpace($Id))      { Add-Issue 'Error' 'IncompleteModel' $Where 'Missing/empty id.' }
         if ([string]::IsNullOrWhiteSpace($ApiId))   { Add-Issue 'Error' 'IncompleteModel' $Where 'Missing/empty apiModelId.' }
         if ([string]::IsNullOrWhiteSpace($Backend)) { Add-Issue 'Error' 'IncompleteModel' $Where 'Missing/empty backend.' }
+
+        # ── Check B: DanglingModelBackend — models[].backend must be in backends[].id ──
+        if ($Backend -and $BackendIds.Count -gt 0 -and -not $BackendIds.Contains($Backend)) {
+            Add-Issue 'Error' 'DanglingModelBackend' $Where "Backend '$Backend' is not declared in backends[].id — likely a typo."
+        }
 
         if ($Id) { $ModelIds.Add($Id) }
 

--- a/tests/Test-AIModelsConfig.Tests.ps1
+++ b/tests/Test-AIModelsConfig.Tests.ps1
@@ -146,6 +146,38 @@ Describe 'Test-AIModelsConfig' -Tag 'config' {
         ($usageWarnings.Detail -join ' ') | Should -Not -Match 'gemini-3\.5-flash' -Because 'the valid usage model resolves and must not warn'
     }
 
+    It 'reports UnknownAdapter and DanglingModelBackend for a fake backend entry (t/2097)' {
+        # FAKE_BAD_BACKEND is declared in backends[] but has no client.ts switch case → UnknownAdapter.
+        # UNDECLARED_BACKEND is not in backends[] at all → DanglingModelBackend.
+        $json = @'
+{
+  "backends": [
+    { "id": "gemini",           "label": "Gemini" },
+    { "id": "FAKE_BAD_BACKEND", "label": "Fake"   }
+  ],
+  "models": [
+    { "id": "gemini-3.5-flash",  "apiModelId": "gemini-3.5-flash", "backend": "gemini"               },
+    { "id": "fake-model",        "apiModelId": "fake-model-api",   "backend": "FAKE_BAD_BACKEND"      },
+    { "id": "dangling-model",    "apiModelId": "dangling-api",     "backend": "UNDECLARED_BACKEND"    }
+  ]
+}
+'@
+        $path = Join-Path $TestDrive 'fake-backend.json'
+        [System.IO.File]::WriteAllBytes($path, [System.Text.Encoding]::UTF8.GetBytes($json))
+        $result = Test-AIModelsConfig -Path $path -WarningAction SilentlyContinue
+
+        $result.Pass | Should -BeFalse -Because 'UnknownAdapter and DanglingModelBackend are Error-severity and must fail Pass'
+        $checks = @($result.Issues.Check)
+        $checks | Should -Contain 'UnknownAdapter'       -Because 'FAKE_BAD_BACKEND has no switch case in client.ts callProvider'
+        $checks | Should -Contain 'DanglingModelBackend' -Because 'dangling-model references UNDECLARED_BACKEND which is not in backends[].id'
+
+        @($result.Issues | Where-Object { $_.Check -eq 'UnknownAdapter' })[0].Severity       | Should -Be 'Error'
+        @($result.Issues | Where-Object { $_.Check -eq 'DanglingModelBackend' })[0].Severity  | Should -Be 'Error'
+
+        ($result.Issues | Where-Object { $_.Detail -match "'gemini'" -and $_.Check -in @('UnknownAdapter','DanglingModelBackend') }) |
+            Should -BeNullOrEmpty -Because 'gemini is a known adapter and must not be flagged'
+    }
+
     It 'does not check usages when no sibling ai-usages.json exists (skip-if-absent)' {
         $json = @'
 { "models": [ { "id": "gemini-3.5-flash", "apiModelId": "gemini-3.5-flash", "backend": "gemini" } ] }


### PR DESCRIPTION
## Summary
- Adds `UnknownAdapter` check: each `backends[].id` must match a `callProvider` switch case in `lib/ai-client/client.ts`. Known adapter set is parsed live so it updates automatically when new adapters are added.
- Adds `DanglingModelBackend` check: each `models[].backend` must be declared in `backends[].id`. A model referencing an undeclared backend silently misroutes.
- Adds one Pester test covering both checks with gate proof.

## Test plan
- [ ] 7/7 Test-AIModelsConfig.Tests.ps1 green (verified locally)
- [ ] Gate proof: FAKE_BAD_BACKEND → UnknownAdapter fires, Pass=false ✓; real config passes ✓
- [ ] CI test-powershell green

🤖 Generated with [Claude Code](https://claude.com/claude-code)