### PR TITLE
chore(constants): import DEFAULT_TEMPERATURE in explorationSummary.ts (t/2147)

### DIFF
--- a/lib/debate/explorationSummary.ts
+++ b/lib/debate/explorationSummary.ts
@@ -8,6 +8,7 @@ import type {
   ArgumentNetworkNode,
   ArgumentNetworkEdge,
 } from './types.js';
+import { DEFAULT_TEMPERATURE } from './constants.js';
 
 // ── ExplorationSummary Interface ─────────────────────────
 
@@ -88,7 +89,6 @@ export interface ExplorationSummary {
 // ── Constants ────────────────────────────────────────────
 
 const AN_NODE_LIMIT = 20;
-const DEFAULT_TEMPERATURE = 0.7;
 const MIN_ROUNDS = 6;
 const MAX_ROUNDS = 20;
 const MIN_SITUATION_CAP = 5;


### PR DESCRIPTION
## Summary
- Replace local `const DEFAULT_TEMPERATURE = 0.7` in `explorationSummary.ts` with an import from `./constants.js`
- `constants.ts` re-exports `DEFAULT_TEMPERATURE` from `lib/ai-client/defaults.js` (established in t/2127)
- Consistent pattern across all debate-scope files (debateEngine.ts, crossRespond.ts)

## Test plan
- [ ] lib-lint: 0 errors
- [ ] 2884 debate tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)