### PR TITLE
refactor(debate): use direct ai-client DEFAULT_TEMPERATURE imports (t/2146)

### DIFF
--- a/lib/debate/calibrationLogger/extract.ts
+++ b/lib/debate/calibrationLogger/extract.ts
@@ -19,6 +19,7 @@ import type { DocMetaMap } from '../evidenceFromSummaries.js';
 import { PROMPT_VERSION } from '../prompts.js';
 import { DEFAULT_ATTACK_WEIGHTS } from '../qbaf.js';
 import { POLARITY_RESOLVED_THRESHOLD, SEMANTIC_RECYCLING_THRESHOLD, ATTACK_DEDUP_THRESHOLD } from '../constants.js';
+import { DEFAULT_TEMPERATURE } from '../../ai-client/defaults.js';
 import { computeAgentUtility } from '../agentUtility.js';
 import type { AgentUtility } from '../agentUtility.js';
 import { computeOperationalClosure } from '../operationalClosure.js';
@@ -421,7 +422,7 @@ export function extractCalibrationData(
 
     structural_error_rate: totalTurns > 0 ? structuralErrors / totalTurns : 0,
     repetition_rate: totalTurns > 0 ? repetitionWarnings / totalTurns : 0,
-    draft_temperature: config.draftTemperature ?? 0.7,
+    draft_temperature: config.draftTemperature ?? DEFAULT_TEMPERATURE,
 
     argumentative_saturation_signals_at_transition: signalsAtTransition,
     argumentative_saturation_weights: config.argumentativeSaturationWeights ?? {

--- a/lib/debate/constants.ts
+++ b/lib/debate/constants.ts
@@ -17,5 +17,3 @@ export const DEFAULT_AI_TIMEOUT_MS = 120_000;
 
 /** Default relevance threshold for taxonomy node selection during debate turns. */
 export const DEFAULT_RELEVANCE_THRESHOLD = 0.45;
-
-export { DEFAULT_TEMPERATURE } from '../ai-client/defaults.js';

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -82,7 +82,7 @@ import { extractClaimsPrompt, classifyClaimsPrompt, formatArgumentNetworkContext
 import { embedDoctrinalBoundaries, computeDoctrinalAnchoring, checkThresholdAnomalies, type BoundaryEmbeddings, type DoctrinalAnchoringConfig } from './doctrinalAnchoring.js';
 import { extractCalibrationData, appendCalibrationLog, readCalibrationLog } from './calibrationLogger.js';
 import { DEFAULT_ATTACK_WEIGHTS } from './qbaf.js';
-import { DEFAULT_AI_TIMEOUT_MS, DEFAULT_RELEVANCE_THRESHOLD, DEFAULT_TEMPERATURE } from './constants.js';
+import { DEFAULT_AI_TIMEOUT_MS, DEFAULT_RELEVANCE_THRESHOLD } from './constants.js';
 import { computeStrategicHints } from './strategicHints.js';
 import { evaluateLookahead, type LookaheadDiagnostics } from './lookaheadGate.js';
 import { runOvergenPipeline, type OvergenDiagnostics } from './overgenPipeline.js';
@@ -157,8 +157,8 @@ import type { ModeratorSelectionCallbacks, ModeratorSelectionInput, TurnRetryCal
 import { pruneSessionData, pruneModeratorState } from './sessionPruning.js';
 import { getGlobalRecorder } from '../flight-recorder/index.js';
 import { callByUsage } from '../ai-client/usageRegistry.js';
-import { runTurnPipeline, assemblePipelineResult, runOpeningPipeline, assembleOpeningPipelineResult, getOpeningRepairHints } from './turnPipeline.js';
-import type { TurnPipelineInput, OpeningPipelineInput } from './turnPipeline.js';
+import { DEFAULT_TEMPERATURE } from '../ai-client/defaults.js';
+import { runTurnPipeline, assemblePipelineResult, runOpeningPipeline, assembleOpeningPipelineResult, getOpeningRepairHints, type TurnPipelineInput, type OpeningPipelineInput } from './turnPipeline.js';
 import { TopicPipeline } from './topicPipeline.js';
 import { ClaimExtractionPipeline } from './claimExtractionPipeline.js';
 import { SynthesisPipeline } from './synthesisPipeline.js';

--- a/lib/debate/debateEngine/phases/crossRespond.ts
+++ b/lib/debate/debateEngine/phases/crossRespond.ts
@@ -25,7 +25,7 @@ import { runModeratorSelection, executeTurnWithRetry, type ModeratorSelectionCal
 import { pruneSessionData, pruneModeratorState } from '../../sessionPruning.js';
 import { getGlobalRecorder } from '../../../flight-recorder/index.js';
 import { runTurnPipeline, assemblePipelineResult, type TurnPipelineInput } from '../../turnPipeline.js';
-import { DEFAULT_TEMPERATURE } from '../../constants.js';
+import { DEFAULT_TEMPERATURE } from '../../../ai-client/defaults.js';
 import { resolveStageModel, resolveModelForSpeaker, recordRateLimit, clearRateLimitBackoff, isRateLimitError } from '../modelResolution.js';
 import { _rescoreSituations, buildSignalContext, recordSignalHistory, updatePeakTracker, accumulateContextManifest } from '../adaptiveStaging.js';
 import { enrichTaxonomyRefs, getRelevantTaxonomyContext, formatDebaterEdgeContext, formatModeratorEdgeContext, routeTurnValidatorHints } from '../taxonomyContext.js';

--- a/lib/debate/explorationSummary.ts
+++ b/lib/debate/explorationSummary.ts
@@ -8,6 +8,7 @@ import type {
   ArgumentNetworkNode,
   ArgumentNetworkEdge,
 } from './types.js';
+import { DEFAULT_TEMPERATURE } from '../ai-client/defaults.js';
 
 // ── ExplorationSummary Interface ─────────────────────────
 
@@ -88,7 +89,6 @@ export interface ExplorationSummary {
 // ── Constants ────────────────────────────────────────────
 
 const AN_NODE_LIMIT = 20;
-const DEFAULT_TEMPERATURE = 0.7;
 const MIN_ROUNDS = 6;
 const MAX_ROUNDS = 20;
 const MIN_SITUATION_CAP = 5;


### PR DESCRIPTION
## Summary
- Remove `DEFAULT_TEMPERATURE` re-export from `constants.ts` (added in t/2127 — superseded by this approach)
- Import `DEFAULT_TEMPERATURE` directly from `lib/ai-client/defaults.js` in each file that uses it
- Fold the two `turnPipeline.js` import lines into one inline-`type` import to stay at the 1500-line ESLint ceiling in `debateEngine.ts`
- `calibrationLogger/extract.ts`: new coverage — replaces hardcoded `0.7` fallback for `draft_temperature`

## Files changed
- `lib/debate/constants.ts` — remove DEFAULT_TEMPERATURE re-export
- `lib/debate/debateEngine.ts` — direct ai-client import; fold turnPipeline imports
- `lib/debate/debateEngine/phases/crossRespond.ts` — direct ai-client import
- `lib/debate/explorationSummary.ts` — remove local const; direct ai-client import
- `lib/debate/calibrationLogger/extract.ts` — add import; use DEFAULT_TEMPERATURE

## Test plan
- [ ] lib-lint: 0 errors, debateEngine.ts at 1500 lines
- [ ] 2884/2884 debate tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)