### PR TITLE
chore(constants): extract SEMANTIC_DEDUP_THRESHOLD in summary-viewer (t/2148)

### DIFF
--- a/summary-viewer/src/renderer/constants.ts
+++ b/summary-viewer/src/renderer/constants.ts
@@ -1,0 +1,1 @@
+export const SEMANTIC_DEDUP_THRESHOLD = 0.85;

--- a/summary-viewer/src/renderer/store/useStore.ts
+++ b/summary-viewer/src/renderer/store/useStore.ts
@@ -8,6 +8,7 @@ import { rankBySimilarity } from '../utils/similarity';
 import { mapErrorToUserMessage } from '../utils/errorMessages';
 import type { SemanticResult } from '../utils/similarity';
 import { buildPotentialEdgesSystemPrompt, buildPotentialEdgesUserPrompt } from '../prompts/potentialEdges';
+import { SEMANTIC_DEDUP_THRESHOLD } from '../constants';
 import { buildHierarchyPlacementUserPrompt, buildAttributeExtractionUserPrompt, buildEdgeDiscoveryUserPrompt } from '../prompts/userPromptBuilders';
 import type { AIBackend, AIModel } from './aiModels';
 import { getStoredBackend, getStoredModel, storeBackend, storeModel, DEFAULT_MODELS } from './aiModels';
@@ -253,7 +254,7 @@ export const useStore = create<SummaryViewerState>((set, get) => ({
       if (cache.size > 0) {
         const queryText = `${label}: ${description}`;
         const queryVector = await window.electronAPI.computeQueryEmbedding(queryText);
-        const matches = rankBySimilarity(queryVector, cache, 0.85, 1);
+        const matches = rankBySimilarity(queryVector, cache, SEMANTIC_DEDUP_THRESHOLD, 1);
         if (matches.length > 0) {
           const match = matches[0];
           const taxonomy = get().taxonomy;


### PR DESCRIPTION
## Summary
- Extracts hardcoded `0.85` similarity threshold from `useStore.ts` into `SEMANTIC_DEDUP_THRESHOLD` constant in new `summary-viewer/src/renderer/constants.ts`
- Leaves `0.4` (UI slider pre-filter) and `0.0` (ranked browse) as-is per ticket scope

## Test plan
- [ ] CI green (no logic change — pure constant extraction)

Generated with [Claude Code](https://claude.com/claude-code)