### PR TITLE
obs(cal): log actual situation cap + add situation_reference_rate metric (t/2150, t/2151)

### DIFF
--- a/lib/debate/calibrationLogger/extract.ts
+++ b/lib/debate/calibrationLogger/extract.ts
@@ -473,7 +473,8 @@ export function extractCalibrationData(
     situation_nodes_injected: sitNodesInjected,
     situation_nodes_referenced: sitNodesReferenced,
     situation_crux_alignment: sitCruxAlignment,
-    situation_max_nodes: config.situationMaxNodes ?? 8,
+    situation_reference_rate: sitNodesInjected > 0 ? sitNodesReferenced / sitNodesInjected : null,
+    situation_max_nodes: config.explorationSummary?.recommended_config?.situation_cap ?? config.situationMaxNodes ?? 8,
 
     agent_utilities: agentUtilities,
     low_value_claims_rejected: lowValueRejected,

--- a/lib/debate/calibrationLogger/schema.ts
+++ b/lib/debate/calibrationLogger/schema.ts
@@ -212,8 +212,10 @@ export interface CalibrationDataPoint {
   situation_nodes_injected: number;
   /** Number of situation nodes actually referenced in taxonomy_refs */
   situation_nodes_referenced: number;
-  /** Fraction of neutral evaluator cruxes that align with injected situation nodes (by word overlap) */
+  /** Fraction of neutral evaluator cruxes that share vocabulary with injected situation nodes (word-overlap proxy; not a measure of substantive engagement) */
   situation_crux_alignment: number | null;
+  /** Fraction of injected situation nodes actually referenced by debaters in taxonomy_refs; null when no situations injected */
+  situation_reference_rate: number | null;
   /** Max situation nodes cap used */
   situation_max_nodes: number;
 


### PR DESCRIPTION
## Summary

- **t/2150**: `situation_max_nodes` in the calibration log now reads `explorationSummary.recommended_config.situation_cap` (falls back to `situationMaxNodes ?? 8`), so the logged cap reflects the actual dynamic cap from exploration rather than always recording the static config default.
- **t/2151**: Adds `situation_reference_rate` (`number | null`) to `CalibrationLogEntry` — the fraction of injected situation nodes actually referenced by debaters in `taxonomy_refs`; `null` when no situations were injected. Clarifies `situation_crux_alignment` comment to note it is a word-overlap proxy, not a measure of substantive engagement.

## Test plan

- [x] All 2884 debate tests pass (`npx vitest run` in `lib/debate`)
- [x] All 90 calibrationLogger-specific tests pass
- [x] `situation_reference_rate: null` when `sitNodesInjected === 0` (safe divide)
- [x] `situation_max_nodes` falls back correctly when `explorationSummary` absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)