### PR TITLE
fix(codeql): dismiss intentional file<->network flow warnings in taxonomyLoader (t/2156)

### DIFF
--- a/lib/debate/taxonomyLoader.ts
+++ b/lib/debate/taxonomyLoader.ts
@@ -436,6 +436,7 @@ export async function htmlToMarkdown(html: string): Promise<string> {
   const tmpDir = fs.mkdtempSync(path.join(tmpdir(), 'aitriad-'));
   const tmpFile = path.join(tmpDir, 'input.html');
   try {
+    // codeql[js/http-to-file-access] intentional: network HTML written to an app-generated mkdtempSync path for markitdown conversion; path is not user-controlled
     fs.writeFileSync(tmpFile, html, 'utf-8');
     return await runMarkitdown(tmpFile);
   } catch {
@@ -491,6 +492,7 @@ export async function loadSourceContent(filePath: string): Promise<string> {
 }
 
 export async function fetchUrlContent(url: string): Promise<string> {
+  // codeql[js/file-access-to-http] intentional: URL sourced from operator CLI config file, not untrusted network input; no SSRF risk
   const response = await fetch(url);
   if (!response.ok) {
     throw new ActionableError({


### PR DESCRIPTION
## Summary

Resolves CodeQL alerts #4049 (`js/http-to-file-access`) and #4054 (`js/file-access-to-http`) in `lib/debate/taxonomyLoader.ts` via inline suppression comments with documented rationale.

**Alert #4049 (line 439):** Network-fetched HTML written to a temp file for `markitdown` conversion. The write path is `path.join(mkdtempSync(...), 'input.html')` — fully app-controlled, not derived from user input. Safe to dismiss.

**Alert #4054 (line 494):** URL passed to `fetch()` is sourced from the operator CLI config file (`config.url`), not from untrusted network data. No SSRF risk. Safe to dismiss.

Both match the existing pattern in this file (`codeql[js/bad-tag-filter]` at line 470).

## Test plan

- [x] All 2884 debate tests pass (`npx vitest run` in `lib/debate`)
- [x] Self-certifying under /trivial-change: 2 comment lines, single file, no behavior change, no new exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)