### PR TITLE
fix(neutral-eval/CodeQL): empty-cruxes retry + setNestedValue prototype-pollution (t/2153, t/2155)

### DIFF
--- a/lib/debate/neutralEvaluator.ts
+++ b/lib/debate/neutralEvaluator.ts
@@ -443,6 +443,47 @@ export async function runNeutralEvaluation(
     }
   }
 
+  // Empty-cruxes retry (t/2153): a valid-JSON response with cruxes:[] is a model
+  // capacity saturation signal on long debates — the lite model exhausts its effective
+  // window before identifying cruxes, yet the JSON parses cleanly (no parse-fail retry
+  // triggers). Retry once so calibration extraction gets a populated crux suite.
+  // If the retry also returns [] the debate may genuinely be crux-free; accept it
+  // without marking invalid (calibration still reads null via cruxes.length > 0 gate).
+  if (!parsed.evaluation_invalid && Array.isArray(parsed.cruxes) && parsed.cruxes.length === 0) {
+    getGlobalRecorder()?.record({
+      type: 'system.info', component: 'neutral-evaluator', level: 'warn',
+      message: `Neutral evaluation (${checkpoint}) valid parse returned 0 cruxes — retrying once (t/2153)`,
+    });
+    try {
+      const emptyCruxRetryResult = await config.adapter.generateText(prompt, config.model, {
+        temperature: 0.2,
+        maxTokens: EVALUATOR_MAX_TOKENS,
+        responseSchema: evaluationSchema,
+      });
+      const retryRaw = stripCodeFences(emptyCruxRetryResult);
+      const retryParsed = JSON.parse(retryRaw) as NeutralEvaluation;
+      if (Array.isArray(retryParsed.cruxes) && retryParsed.cruxes.length > 0) {
+        parsed = retryParsed;
+        rawText = retryRaw;
+        getGlobalRecorder()?.record({
+          type: 'system.info', component: 'neutral-evaluator', level: 'info',
+          message: `Neutral evaluation (${checkpoint}) empty-cruxes retry recovered ${retryParsed.cruxes.length} cruxes`,
+        });
+      } else {
+        getGlobalRecorder()?.record({
+          type: 'system.info', component: 'neutral-evaluator', level: 'info',
+          message: `Neutral evaluation (${checkpoint}) empty-cruxes retry also returned 0 cruxes — accepting as crux-free`,
+        });
+      }
+    } catch (emptyCruxRetryErr) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'neutral-evaluator', level: 'warn',
+        message: `Neutral evaluation (${checkpoint}) empty-cruxes retry failed to parse — keeping original 0-crux result`,
+        error: { name: (emptyCruxRetryErr as Error).name ?? 'Error', message: String(emptyCruxRetryErr) },
+      });
+    }
+  }
+
   // Ensure checkpoint and timestamp are set correctly regardless of AI output
   parsed.checkpoint = checkpoint;
   parsed.timestamp = new Date().toISOString();

--- a/taxonomy-editor/src/renderer/hooks/useRuntimeConfigStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useRuntimeConfigStore.ts
@@ -115,10 +115,16 @@ export function setNestedValue(obj: Record<string, unknown>, path: string, value
   if (parts.some(p => DANGEROUS_KEYS.has(p))) return;
   let cur = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    if (cur[parts[i]] == null || typeof cur[parts[i]] !== 'object') cur[parts[i]] = {};
-    cur = cur[parts[i]] as Record<string, unknown>;
+    const key = parts[i];
+    if (cur[key] == null || typeof cur[key] !== 'object') {
+      // Object.defineProperty bypasses the [[Set]] protocol and does not invoke the
+      // __proto__ setter, satisfying CodeQL js/prototype-pollution-utility (alert #4927).
+      Object.defineProperty(cur, key, { value: {}, configurable: true, writable: true, enumerable: true });
+    }
+    cur = cur[key] as Record<string, unknown>;
   }
-  cur[parts[parts.length - 1]] = value;
+  const lastKey = parts[parts.length - 1];
+  Object.defineProperty(cur, lastKey, { value, configurable: true, writable: true, enumerable: true });
 }
 
 export function countLeafDiffs(a: unknown, b: unknown): number {


### PR DESCRIPTION
## Summary

- **t/2155** — Use `Object.defineProperty` in `setNestedValue` to clear CodeQL alert #4927 (prototype pollution)
- **t/2153** — Add empty-cruxes retry in `runNeutralEvaluation`: when the neutral evaluator returns valid JSON but `cruxes: []`, retry once before accepting the result. Root cause: `gemini-3.5-flash-lite` saturates its effective context window on long debates, returning structurally valid but empty-crux JSON. The existing parse-fail retry never triggered because the parse succeeded. Both retry paths log to the flight recorder.

## Test plan

- [ ] Type check passes (`tsc --noEmit`, no new errors in `neutralEvaluator.ts`)
- [ ] CI green
- [ ] AC3 (t/2153): trigger a real multi-round debate post-deploy and confirm `crux_addressed_ratio` + `convergence_score_at_termination` + `termination_reason` co-populate in calibration log

🤖 Generated with [Claude Code](https://claude.com/claude-code)