### PR TITLE
fix(docker): bump base image to :2026-08-05 to clear Python CVEs (t/2157)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -111,9 +111,10 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --prod 
 # ── Stage 3: Runtime ──
 # CI smoke = liveness-only (any HTTP status passes; t/2067). Data-readiness proven at staging
 # (deploy-staging.yml Test-TaxEditorHealth /healthz). :2026-07-30 was exonerated in t/2047 —
-# root cause was t/2061 (isDataAvailable path mismatch, app-side). Bumped to :2026-08-04 because
-# :2026-07-30 was removed from GHCR; gate base bumps on staging /healthz, not CI green.
-FROM ghcr.io/jpsnover/ai-triad-base:2026-08-04 AS runtime
+# root cause was t/2061 (isDataAvailable path mismatch, app-side). Bumped to :2026-08-05 to
+# pull in Debian/Python security patches clearing ~25 Python runtime CVE rules (t/2157).
+# Gate base bumps on staging /healthz, not CI green.
+FROM ghcr.io/jpsnover/ai-triad-base:2026-08-05 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Taxonomy Editor"


### PR DESCRIPTION
## Summary
- Bumps runtime base from `:2026-08-04` → `:2026-08-05` in `taxonomy-editor/Dockerfile`
- The `:2026-08-05` base image was built by a `base-image.yml` dispatch (run/31004043082) triggered as part of this fix — `apt-get upgrade -y` in `Dockerfile.base` picks up the latest Debian/Python security patches, clearing ~25 Python runtime CVE rules (~250 Trivy hits)

## Gate before merging
- [ ] base-image.yml run/31004043082 completes green
- [ ] Trivy results from that run show Python CVE count reduced (error/warning → 0 or note-only)
- [ ] CI green on this PR

## Test plan
- Base image build completes and `:2026-08-05` is available in GHCR
- CI smoke gate passes (liveness, per t/2067)
- Staging readiness gate passes before prod deploy

Closes t/2157

🤖 Generated with [Claude Code](https://claude.com/claude-code)