### PR TITLE
feat(cal): log per-situation component scores for weak-vs-specific correlation (t/2163)

### DIFF
--- a/lib/debate/calibrationLogger/extract.ts
+++ b/lib/debate/calibrationLogger/extract.ts
@@ -19,6 +19,7 @@ import type { DocMetaMap } from '../evidenceFromSummaries.js';
 import { PROMPT_VERSION } from '../prompts.js';
 import { DEFAULT_ATTACK_WEIGHTS } from '../qbaf.js';
 import { POLARITY_RESOLVED_THRESHOLD, SEMANTIC_RECYCLING_THRESHOLD, ATTACK_DEDUP_THRESHOLD } from '../constants.js';
+import { weightedSituationScore, MID_DEBATE_WEIGHTS } from '../situationScoring.js';
 import { DEFAULT_TEMPERATURE } from '../../ai-client/defaults.js';
 import { computeAgentUtility } from '../agentUtility.js';
 import type { AgentUtility } from '../agentUtility.js';
@@ -475,6 +476,23 @@ export function extractCalibrationData(
     situation_crux_alignment: sitCruxAlignment,
     situation_reference_rate: sitNodesInjected > 0 ? sitNodesReferenced / sitNodesInjected : null,
     situation_max_nodes: config.explorationSummary?.recommended_config?.situation_cap ?? config.situationMaxNodes ?? 8,
+    situation_component_scores: (() => {
+      const scoreMap = session.situation_score_map;
+      if (!scoreMap || Object.keys(scoreMap).length === 0) return null;
+      const referencedSitIds = new Set(
+        session.transcript.flatMap(e => e.taxonomy_refs ?? []).map(r => r.node_id).filter(id => id.startsWith('sit-')),
+      );
+      return Object.entries(scoreMap).map(([node_id, comp]) => ({
+        node_id,
+        composite: weightedSituationScore(comp, MID_DEBATE_WEIGHTS),
+        referenced: referencedSitIds.has(node_id),
+        relevance: comp.relevance,
+        diversity: comp.diversity,
+        freshness: comp.freshness,
+        bdi_entropy: comp.bdi_entropy,
+        conflict_openness: comp.conflict_openness,
+      }));
+    })(),
 
     agent_utilities: agentUtilities,
     low_value_claims_rejected: lowValueRejected,

--- a/lib/debate/calibrationLogger/schema.ts
+++ b/lib/debate/calibrationLogger/schema.ts
@@ -218,6 +218,22 @@ export interface CalibrationDataPoint {
   situation_reference_rate: number | null;
   /** Max situation nodes cap used */
   situation_max_nodes: number;
+  /**
+   * Per-injected-situation component scores from the final mid-debate re-scoring snapshot
+   * (last-write-wins — not averaged across rounds). bdi_entropy and conflict_openness are
+   * always 0 in mid-debate context. composite = weightedSituationScore(components, MID_DEBATE_WEIGHTS).
+   * Null when adaptive staging did not run or no situations were scored.
+   */
+  situation_component_scores: Array<{
+    node_id: string;
+    composite: number;
+    referenced: boolean;
+    relevance: number;
+    diversity: number;
+    freshness: number;
+    bdi_entropy: number;
+    conflict_openness: number;
+  }> | null;
 
   // ── Per-claim drift / sycophancy ──
   /** Whether the per-claim sycophancy guard fired during this debate */

--- a/lib/debate/debateEngine/adaptiveStaging.ts
+++ b/lib/debate/debateEngine/adaptiveStaging.ts
@@ -5,7 +5,7 @@ import type { DebateEngineInternals } from './internals.js';
 import { type ArgumentNetworkEdge, type SignalContext } from '../types.js';
 import { detectCruxNodes } from '../phaseTransitions.js';
 import { type SituationNode } from '../taxonomyTypes.js';
-import { reScoreSituationsForCruxes } from '../taxonomyRelevance.js';
+import { reScoreSituationsForCruxesDetailed } from '../taxonomyRelevance.js';
 import { computeTaxonomyGapAnalysis } from '../taxonomyGapAnalysis.js';
 
 /** Re-score situations against emerging cruxes at phase transitions. */
@@ -23,7 +23,7 @@ export function _rescoreSituations(engine: DebateEngineInternals): void {
     engine.session.transcript.flatMap(e => e.taxonomy_refs).map(r => r.node_id).filter(id => id.startsWith('sit-')),
   );
 
-  engine._situationScoreAdjustments = reScoreSituationsForCruxes({
+  const rescoreResult = reScoreSituationsForCruxesDetailed({
     situationNodes: sitNodes,
     cruxes: engine.session.crux_tracker,
     anNodes: anForRescore.nodes,
@@ -32,6 +32,10 @@ export function _rescoreSituations(engine: DebateEngineInternals): void {
     referencedSitIds,
     edges: engine.taxonomy.edges?.edges,
   });
+  engine._situationScoreAdjustments = rescoreResult.adjustments;
+  // Persist components for calibration logging (last-write-wins per node across rounds).
+  const prevMap = engine.session.situation_score_map ?? {};
+  engine.session.situation_score_map = { ...prevMap, ...Object.fromEntries(rescoreResult.components) };
 }
 
 // ── Adaptive staging helpers ─────────────────────────────

--- a/lib/debate/types/session.ts
+++ b/lib/debate/types/session.ts
@@ -461,6 +461,8 @@ export interface DebateSession {
   };
   /** Round at which a diversity-injection round fired (max 1 per debate). Absent if never triggered. */
   diversity_round_fired?: number;
+  /** Per-situation component scores from mid-debate re-scoring (last-write-wins across rounds). Populated when adaptive staging re-scores situations. Only includes scored situation nodes. */
+  situation_score_map?: Record<string, import('../situationScoring.js').SituationScoreComponents>;
   /** Crux-to-situation promotion candidates with BDI-enriched drafts (populated post-debate). */
   promotion_candidates?: Array<{
     crux_id: string;


### PR DESCRIPTION
## Summary

Closes the data gap that was blocking t/2145 AC2 (weak-vs-specific correlation analysis). Persists per-situation `SituationScoreComponents` from the mid-debate re-scoring phase into the session and exposes them in the calibration log with a `referenced` flag for single-row joins.

- **`adaptiveStaging.ts`**: Switch from `reScoreSituationsForCruxes()` to `reScoreSituationsForCruxesDetailed()`; persist the returned `components` map to `session.situation_score_map` (last-write-wins across re-scoring rounds)
- **`types/session.ts`**: Add `situation_score_map?: Record<string, SituationScoreComponents>` to `DebateSession`
- **`calibrationLogger/schema.ts`**: Add `situation_component_scores` array — one entry per scored situation with `node_id`, `composite` (weighted sum via `MID_DEBATE_WEIGHTS`), `referenced` (bool), and all 5 component fields
- **`calibrationLogger/extract.ts`**: Build `situation_component_scores` from `session.situation_score_map` + transcript `taxonomy_refs`; `referenced` flag enables breadth↔engagement as a single-row join

**Note:** `bdi_entropy` and `conflict_openness` are always 0 in mid-debate context (only `relevance`, `diversity`, `freshness` are computed there) — documented in schema comment per CL guidance (t/2163#2).

**Expected merge order:** Merge PR #454 (t/2150+t/2151) first; this PR will need a trivial rebase on `extract.ts` around the `situation_max_nodes` line that #454 also touches.

## Test plan

- [x] All 124 relevant tests pass (calibrationLogger, adaptiveStaging, situationScoring suites)
- [x] `situation_component_scores` is null when `situation_score_map` is absent (no adaptive staging)
- [x] `referenced: true` only for nodes that appear in transcript `taxonomy_refs`
- [x] Composite computed from `MID_DEBATE_WEIGHTS` via `weightedSituationScore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)