### PR TITLE
fix(types): add talmudic_references to DebateSession interface

### DIFF
--- a/lib/debate/types/session.ts
+++ b/lib/debate/types/session.ts
@@ -272,6 +272,10 @@ export interface DebateSession {
   audience?: DebateAudience;
   /** Moderator mode used for this session ('standard' | 'talmudic'). Optional for back-compat with pre-Talmudic sessions. */
   moderator_mode?: string;
+  /** Talmudic corpus metadata stamped at session creation — present when moderatorMode is 'talmudic' and a corpus was loaded. */
+  talmudic_references?:
+    | { enabled: true; corpus_name: string; corpus_path: string; corpus_version: string }
+    | { enabled: false };
   phase: 'setup' | 'clarification' | 'edit-claims' | 'opening' | 'debate' | 'closed' | 'cancelled';
   topic: {
     original: string;


### PR DESCRIPTION
## Summary

- `debateEngine.ts:957` assigns `talmudic_references` to the session literal but the field was absent from `DebateSession` in `types/session.ts`, causing renderer tsc to fail (reported via p/61#56)
- Adds discriminated union `{ enabled: true; corpus_name; corpus_path; corpus_version } | { enabled: false }` matching the two shapes the engine produces
- Pre-existing gap; confirmed fails with stash applied

## Test plan

- [ ] CI renderer tsc clean (this is the targeted failure)
- [ ] `npx vitest run` in `lib/debate` passes

Self-certifying under /trivial-change: 4 lines added, single file `lib/debate/types/session.ts`, no new exports, no interface-shape change (addition only), no auth surface.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)