### PR TITLE
feat(debate): compute real bdi_entropy and conflict_openness (t/2169)

### DIFF
--- a/lib/debate/calibrationLogger/schema.ts
+++ b/lib/debate/calibrationLogger/schema.ts
@@ -220,8 +220,11 @@ export interface CalibrationDataPoint {
   situation_max_nodes: number;
   /**
    * Per-injected-situation component scores from the final mid-debate re-scoring snapshot
-   * (last-write-wins — not averaged across rounds). bdi_entropy and conflict_openness are
-   * always 0 in mid-debate context. composite = weightedSituationScore(components, MID_DEBATE_WEIGHTS).
+   * (last-write-wins — not averaged across rounds). bdi_entropy = normalized Shannon entropy
+   * of the situation's linked taxonomy nodes across B/D/I categories. conflict_openness =
+   * fraction of linked conflict_ids not in the resolved set; in mid-debate context the
+   * resolved set is empty, so conflict_openness is 1.0 for situations with any conflict links
+   * and 0.0 for those without. composite = weightedSituationScore(components, MID_DEBATE_WEIGHTS).
    * Null when adaptive staging did not run or no situations were scored.
    */
   situation_component_scores: Array<{

--- a/lib/debate/debateEngine/adaptiveStaging.ts
+++ b/lib/debate/debateEngine/adaptiveStaging.ts
@@ -23,6 +23,14 @@ export function _rescoreSituations(engine: DebateEngineInternals): void {
     engine.session.transcript.flatMap(e => e.taxonomy_refs).map(r => r.node_id).filter(id => id.startsWith('sit-')),
   );
 
+  const nodeCategoryLookup = new Map(
+    [
+      ...engine.taxonomy.accelerationist.nodes,
+      ...engine.taxonomy.safetyist.nodes,
+      ...engine.taxonomy.skeptic.nodes,
+    ].map(n => [n.id, n.category]),
+  );
+
   const rescoreResult = reScoreSituationsForCruxesDetailed({
     situationNodes: sitNodes,
     cruxes: engine.session.crux_tracker,
@@ -31,6 +39,7 @@ export function _rescoreSituations(engine: DebateEngineInternals): void {
     injectedSitIds,
     referencedSitIds,
     edges: engine.taxonomy.edges?.edges,
+    nodeCategoryLookup,
   });
   engine._situationScoreAdjustments = rescoreResult.adjustments;
   // Persist components for calibration logging (last-write-wins per node across rounds).

--- a/lib/debate/taxonomyRelevance.test.ts
+++ b/lib/debate/taxonomyRelevance.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect } from 'vitest';
-import { selectRelevantNodes, selectRelevantSituationNodes, buildSituationRootLookup, scoreNodeRelevanceMeanTopN, cosineSimilarity, computePolicymakerRelevanceBoost, filterByTopicConstraints } from './taxonomyRelevance.js';
+import { selectRelevantNodes, selectRelevantSituationNodes, buildSituationRootLookup, scoreNodeRelevanceMeanTopN, cosineSimilarity, computePolicymakerRelevanceBoost, filterByTopicConstraints, reScoreSituationsForCruxesDetailed } from './taxonomyRelevance.js';
 import type { LineageBoostConfig, LineageBoostResult, BranchBoostResult, RelevanceOptions, ScoredPovNode, ScoredSituationNode, PovDiversityResult } from './taxonomyRelevance.js';
 import type { TopicScope } from './types.js';
 import type { PovNode, Category, SituationNode } from './taxonomyTypes.js';
@@ -1210,5 +1210,92 @@ describe('selectRelevantNodes — wellTested hardExclude', () => {
     });
 
     expect(result.map(r => r.node.id)).toContain('acc-beliefs-reelig');
+  });
+});
+
+// ── reScoreSituationsForCruxesDetailed — bdi_entropy + conflict_openness (t/2169) ──
+
+describe('reScoreSituationsForCruxesDetailed — bdi_entropy and conflict_openness', () => {
+  function makeSit(id: string, linkedNodes: string[], conflictIds: string[]): SituationNode {
+    return {
+      id, label: `Sit ${id}`, description: '', parent_id: null,
+      interpretations: { accelerationist: 'a', safetyist: 'b', skeptic: 'c' },
+      linked_nodes: linkedNodes,
+      conflict_ids: conflictIds,
+    };
+  }
+
+  const BASE_INPUT = {
+    cruxes: [],
+    anNodes: [],
+    nodeEmbeddings: {},
+    injectedSitIds: new Set<string>(),
+    referencedSitIds: new Set<string>(),
+  };
+
+  it('computes non-zero bdi_entropy when nodeCategoryLookup is provided with mixed categories', () => {
+    const sit = makeSit('sit-001', ['acc-beliefs-001', 'saf-desires-001', 'skp-intentions-001'], []);
+    const lookup = new Map<string, Category>([
+      ['acc-beliefs-001', 'Beliefs'],
+      ['saf-desires-001', 'Desires'],
+      ['skp-intentions-001', 'Intentions'],
+    ]);
+    const result = reScoreSituationsForCruxesDetailed({
+      ...BASE_INPUT,
+      situationNodes: [sit],
+      nodeCategoryLookup: lookup,
+    });
+    const comp = result.components.get('sit-001')!;
+    expect(comp.bdi_entropy).toBeCloseTo(1.0); // even spread → max entropy
+  });
+
+  it('computes zero bdi_entropy for single-category nodes', () => {
+    const sit = makeSit('sit-001', ['acc-beliefs-001', 'acc-beliefs-002'], []);
+    const lookup = new Map<string, Category>([
+      ['acc-beliefs-001', 'Beliefs'],
+      ['acc-beliefs-002', 'Beliefs'],
+    ]);
+    const result = reScoreSituationsForCruxesDetailed({
+      ...BASE_INPUT,
+      situationNodes: [sit],
+      nodeCategoryLookup: lookup,
+    });
+    expect(result.components.get('sit-001')!.bdi_entropy).toBeCloseTo(0);
+  });
+
+  it('falls back to zero bdi_entropy when nodeCategoryLookup is absent', () => {
+    const sit = makeSit('sit-001', ['acc-beliefs-001'], []);
+    const result = reScoreSituationsForCruxesDetailed({ ...BASE_INPUT, situationNodes: [sit] });
+    expect(result.components.get('sit-001')!.bdi_entropy).toBe(0);
+  });
+
+  it('computes conflict_openness = 1.0 for situations with conflict_ids when resolved set is empty', () => {
+    const sit = makeSit('sit-001', [], ['conflict-001', 'conflict-002']);
+    const result = reScoreSituationsForCruxesDetailed({ ...BASE_INPUT, situationNodes: [sit] });
+    expect(result.components.get('sit-001')!.conflict_openness).toBeCloseTo(1.0);
+  });
+
+  it('computes conflict_openness = 0 for situations with no conflict_ids', () => {
+    const sit = makeSit('sit-001', [], []);
+    const result = reScoreSituationsForCruxesDetailed({ ...BASE_INPUT, situationNodes: [sit] });
+    expect(result.components.get('sit-001')!.conflict_openness).toBe(0);
+  });
+
+  it('produces varying bdi_entropy across multiple situations', () => {
+    const sits = [
+      makeSit('sit-001', ['a', 'b', 'c'], []),
+      makeSit('sit-002', ['a', 'a'], []),
+    ];
+    const lookup = new Map<string, Category>([
+      ['a', 'Beliefs'], ['b', 'Desires'], ['c', 'Intentions'],
+    ]);
+    const result = reScoreSituationsForCruxesDetailed({
+      ...BASE_INPUT,
+      situationNodes: sits,
+      nodeCategoryLookup: lookup,
+    });
+    const e1 = result.components.get('sit-001')!.bdi_entropy;
+    const e2 = result.components.get('sit-002')!.bdi_entropy;
+    expect(e1).toBeGreaterThan(e2); // mixed > single-category
   });
 });

--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -7,7 +7,7 @@
  * for each debater's prompt.
  */
 
-import type { PovNode, SituationNode } from './taxonomyTypes.js';
+import type { PovNode, SituationNode, Category } from './taxonomyTypes.js';
 import { cosineSimilarity } from '../embeddings/similarity.js';
 import type { TrackedCrux, ArgumentNetworkNode } from './types.js';
 import { stripExcludes } from './helpers.js';
@@ -726,6 +726,8 @@ import {
   computeDiversityComponent,
   computeMidDebateFreshness,
   computeInterpretsBoost,
+  computeBdiEntropy,
+  computeConflictOpenness,
   type SituationScoreComponents,
 } from './situationScoring.js';
 
@@ -733,6 +735,8 @@ import {
 const DIVERSITY_BONUS = 0.15;
 /** Penalty for previously-injected but never-referenced situations. */
 const STALE_PENALTY = -0.20;
+const EMPTY_CATEGORY_MAP: ReadonlyMap<string, Category> = new Map();
+const EMPTY_CONFLICT_SET: ReadonlySet<string> = new Set();
 
 export interface SituationReScoreInput {
   situationNodes: readonly SituationNode[];
@@ -745,6 +749,14 @@ export interface SituationReScoreInput {
   referencedSitIds: ReadonlySet<string>;
   /** Taxonomy edges — used for INTERPRETS boost scoring. */
   edges?: readonly { source: string; target: string; type: string; status?: string }[];
+  /** Node ID → BDI category lookup for bdi_entropy computation. Built from all POV nodes. */
+  nodeCategoryLookup?: ReadonlyMap<string, Category>;
+  /**
+   * Set of conflict IDs that are resolved — used by conflict_openness computation.
+   * In mid-debate context, conflict resolution data is unavailable; callers pass an empty
+   * set so all linked conflicts are treated as open (produces binary 0/1 variance).
+   */
+  resolvedConflictIds?: ReadonlySet<string>;
 }
 
 export interface SituationReScoreResult {
@@ -809,8 +821,8 @@ export function reScoreSituationsForCruxesDetailed(input: SituationReScoreInput)
       relevance,
       diversity,
       freshness,
-      bdi_entropy: 0, // not computed in mid-debate context
-      conflict_openness: 0, // not computed in mid-debate context
+      bdi_entropy: computeBdiEntropy(sit.linked_nodes, input.nodeCategoryLookup ?? EMPTY_CATEGORY_MAP),
+      conflict_openness: computeConflictOpenness(sit.conflict_ids, input.resolvedConflictIds ?? EMPTY_CONFLICT_SET),
     };
     components.set(sit.id, comp);
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `bdi_entropy: 0` and `conflict_openness: 0` in `reScoreSituationsForCruxesDetailed` with real computation using `computeBdiEntropy` and `computeConflictOpenness` from `situationScoring.ts`
- Build `nodeCategoryLookup` from all three POV node arrays in `_rescoreSituations` (adaptiveStaging.ts) and thread it through to the detailed rescore call
- Extend `SituationReScoreInput` with optional `nodeCategoryLookup` and `resolvedConflictIds` fields; fall back to empty structures when absent
- Update `calibrationLogger/schema.ts` comment to reflect real computation semantics
- Add 6 unit tests covering mixed-category entropy, single-category entropy, absent-lookup fallback, conflict_openness with/without conflict_ids, and multi-situation variance

## Test plan

- [x] `npx vitest run taxonomyRelevance.test.ts` — 62 tests pass (6 new)
- [x] `npx vitest run` full debate suite — 2894 pass, 11 skipped, 0 failures

## Notes

Depends on t/2163 (`situation_score_map` session field) — targets `fix/situation-ref-rate-t2168`. AC5 requires CL to confirm operationalization before close; design comment posted at t/2169#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)