### PR TITLE
fix(debate): compute real bdi_entropy and conflict_openness in mid-debate rescore (t/2169)

### DIFF
--- a/lib/debate/debateEngine/adaptiveStaging.ts
+++ b/lib/debate/debateEngine/adaptiveStaging.ts
@@ -4,7 +4,7 @@
 import type { DebateEngineInternals } from './internals.js';
 import { type ArgumentNetworkEdge, type SignalContext } from '../types.js';
 import { detectCruxNodes } from '../phaseTransitions.js';
-import { type SituationNode } from '../taxonomyTypes.js';
+import { type SituationNode, type Category } from '../taxonomyTypes.js';
 import { reScoreSituationsForCruxesDetailed } from '../taxonomyRelevance.js';
 import { computeTaxonomyGapAnalysis } from '../taxonomyGapAnalysis.js';
 
@@ -23,6 +23,13 @@ export function _rescoreSituations(engine: DebateEngineInternals): void {
     engine.session.transcript.flatMap(e => e.taxonomy_refs).map(r => r.node_id).filter(id => id.startsWith('sit-')),
   );
 
+  const nodeCategoryLookup = new Map<string, Category>();
+  for (const pov of ['accelerationist', 'safetyist', 'skeptic'] as const) {
+    for (const node of engine.taxonomy[pov].nodes) {
+      nodeCategoryLookup.set(node.id, node.category);
+    }
+  }
+
   const rescoreResult = reScoreSituationsForCruxesDetailed({
     situationNodes: sitNodes,
     cruxes: engine.session.crux_tracker,
@@ -31,6 +38,7 @@ export function _rescoreSituations(engine: DebateEngineInternals): void {
     injectedSitIds,
     referencedSitIds,
     edges: engine.taxonomy.edges?.edges,
+    nodeCategoryLookup,
   });
   engine._situationScoreAdjustments = rescoreResult.adjustments;
   // Persist components for calibration logging (last-write-wins per node across rounds).

--- a/lib/debate/taxonomyRelevance.test.ts
+++ b/lib/debate/taxonomyRelevance.test.ts
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect } from 'vitest';
-import { selectRelevantNodes, selectRelevantSituationNodes, buildSituationRootLookup, scoreNodeRelevanceMeanTopN, cosineSimilarity, computePolicymakerRelevanceBoost, filterByTopicConstraints } from './taxonomyRelevance.js';
-import type { LineageBoostConfig, LineageBoostResult, BranchBoostResult, RelevanceOptions, ScoredPovNode, ScoredSituationNode, PovDiversityResult } from './taxonomyRelevance.js';
+import { selectRelevantNodes, selectRelevantSituationNodes, buildSituationRootLookup, scoreNodeRelevanceMeanTopN, cosineSimilarity, computePolicymakerRelevanceBoost, filterByTopicConstraints, reScoreSituationsForCruxesDetailed } from './taxonomyRelevance.js';
+import type { LineageBoostConfig, LineageBoostResult, BranchBoostResult, RelevanceOptions, ScoredPovNode, ScoredSituationNode, PovDiversityResult, SituationReScoreInput } from './taxonomyRelevance.js';
 import type { TopicScope } from './types.js';
 import type { PovNode, Category, SituationNode } from './taxonomyTypes.js';
 
@@ -1210,5 +1210,82 @@ describe('selectRelevantNodes — wellTested hardExclude', () => {
     });
 
     expect(result.map(r => r.node.id)).toContain('acc-beliefs-reelig');
+  });
+});
+
+describe('reScoreSituationsForCruxesDetailed — bdi_entropy computation', () => {
+  function makeSit(id: string, linkedNodes: string[], conflictIds: string[] = []): SituationNode {
+    return {
+      id,
+      label: id,
+      description: 'test',
+      interpretations: { accelerationist: 'acc', safetyist: 'saf', skeptic: 'skp' },
+      linked_nodes: linkedNodes,
+      conflict_ids: conflictIds,
+    } as SituationNode;
+  }
+
+  it('produces non-zero bdi_entropy when linked nodes span multiple BDI categories', () => {
+    const nodeCategoryLookup = new Map<string, Category>([
+      ['acc-b-001', 'Beliefs'],
+      ['acc-d-001', 'Desires'],
+      ['acc-i-001', 'Intentions'],
+    ]);
+    const result = reScoreSituationsForCruxesDetailed({
+      situationNodes: [makeSit('sit-001', ['acc-b-001', 'acc-d-001', 'acc-i-001'])],
+      cruxes: [],
+      anNodes: [],
+      nodeEmbeddings: {},
+      injectedSitIds: new Set(),
+      referencedSitIds: new Set(),
+      nodeCategoryLookup,
+    });
+    const components = result.components.get('sit-001');
+    expect(components).toBeDefined();
+    // Equal spread across all 3 BDI categories → normalized entropy = 1.0
+    expect(components!.bdi_entropy).toBeCloseTo(1.0, 5);
+  });
+
+  it('produces zero bdi_entropy when all linked nodes share one BDI category', () => {
+    const nodeCategoryLookup = new Map<string, Category>([
+      ['acc-b-001', 'Beliefs'],
+      ['acc-b-002', 'Beliefs'],
+    ]);
+    const result = reScoreSituationsForCruxesDetailed({
+      situationNodes: [makeSit('sit-002', ['acc-b-001', 'acc-b-002'])],
+      cruxes: [],
+      anNodes: [],
+      nodeEmbeddings: {},
+      injectedSitIds: new Set(),
+      referencedSitIds: new Set(),
+      nodeCategoryLookup,
+    });
+    const components = result.components.get('sit-002');
+    expect(components).toBeDefined();
+    expect(components!.bdi_entropy).toBe(0);
+  });
+
+  it('bdi_entropy varies across situations with different BDI distributions', () => {
+    const nodeCategoryLookup = new Map<string, Category>([
+      ['acc-b-001', 'Beliefs'],
+      ['acc-d-001', 'Desires'],
+      ['acc-i-001', 'Intentions'],
+      ['saf-b-001', 'Beliefs'],
+    ]);
+    const sitMixed = makeSit('sit-mixed', ['acc-b-001', 'acc-d-001', 'acc-i-001']);
+    const sitSingle = makeSit('sit-single', ['saf-b-001']);
+    const result = reScoreSituationsForCruxesDetailed({
+      situationNodes: [sitMixed, sitSingle],
+      cruxes: [],
+      anNodes: [],
+      nodeEmbeddings: {},
+      injectedSitIds: new Set(),
+      referencedSitIds: new Set(),
+      nodeCategoryLookup,
+    });
+    expect(result.components.get('sit-mixed')!.bdi_entropy).toBeGreaterThan(
+      result.components.get('sit-single')!.bdi_entropy,
+    );
+    expect(result.components.get('sit-single')!.bdi_entropy).toBe(0);
   });
 });

--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -7,7 +7,7 @@
  * for each debater's prompt.
  */
 
-import type { PovNode, SituationNode } from './taxonomyTypes.js';
+import type { PovNode, SituationNode, Category } from './taxonomyTypes.js';
 import { cosineSimilarity } from '../embeddings/similarity.js';
 import type { TrackedCrux, ArgumentNetworkNode } from './types.js';
 import { stripExcludes } from './helpers.js';
@@ -726,6 +726,8 @@ import {
   computeDiversityComponent,
   computeMidDebateFreshness,
   computeInterpretsBoost,
+  computeBdiEntropy,
+  computeConflictOpenness,
   type SituationScoreComponents,
 } from './situationScoring.js';
 
@@ -745,6 +747,8 @@ export interface SituationReScoreInput {
   referencedSitIds: ReadonlySet<string>;
   /** Taxonomy edges — used for INTERPRETS boost scoring. */
   edges?: readonly { source: string; target: string; type: string; status?: string }[];
+  /** Category lookup for all POV nodes — required to compute bdi_entropy per situation. */
+  nodeCategoryLookup: ReadonlyMap<string, Category>;
 }
 
 export interface SituationReScoreResult {
@@ -809,8 +813,8 @@ export function reScoreSituationsForCruxesDetailed(input: SituationReScoreInput)
       relevance,
       diversity,
       freshness,
-      bdi_entropy: 0, // not computed in mid-debate context
-      conflict_openness: 0, // not computed in mid-debate context
+      bdi_entropy: computeBdiEntropy(sit.linked_nodes, input.nodeCategoryLookup),
+      conflict_openness: computeConflictOpenness(sit.conflict_ids, new Set()),
     };
     components.set(sit.id, comp);
 


### PR DESCRIPTION
## Summary
- eScoreSituationsForCruxesDetailed hardcoded di_entropy=0 and conflict_openness=0 in situation_component_scores, making them useless for the Bennett-hypothesis correlation analysis (t/2164)
- Adds 
odeCategoryLookup: ReadonlyMap<string, Category> to SituationReScoreInput; builds the map from all three POV node arrays in _rescoreSituations and passes it through
- computeBdiEntropy and computeConflictOpenness now produce real values at each phase-transition rescore
- conflict_openness uses 
ew Set() as resolved conflicts — semantically correct for mid-debate (no conflicts resolved during a debate)

## Test plan
- [ ] 3 new unit tests in 	axonomyRelevance.test.ts: equal BDI spread → entropy 1.0; single-category → entropy 0; mixed vs single → mixed > single
- [ ] All 59 	axonomyRelevance.test.ts tests green
- [ ] CI green