### PR TITLE
feat(debate-workspace): two-mode Text/Analysis segmented controls (t/2172)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.css
@@ -100,14 +100,17 @@
   flex-shrink: 0;
 }
 
-.debate-mode-override-dot {
+.debate-mode-seg-overridden::after {
+  content: '';
   display: inline-block;
-  width: 4px;
-  height: 4px;
+  width: 3px;
+  height: 3px;
   border-radius: 50%;
-  background: currentColor;
+  background: #fff;
+  margin-left: 3px;
   flex-shrink: 0;
-  opacity: 0.75;
+  opacity: 0.85;
+  vertical-align: middle;
 }
 
 .debate-mode-match-global {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.css
@@ -49,3 +49,82 @@
   border-left: 1px solid var(--border-color);
   background: var(--bg-primary);
 }
+
+/* ─── Two-mode segmented controls (t/2172) ─────────────────────────────── */
+
+.debate-mode-group {
+  display: inline-flex;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.debate-mode-seg {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  padding: 1px 6px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  transition: background 0.1s, color 0.1s;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+}
+
+.debate-mode-seg:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.debate-mode-seg-active {
+  background: var(--focus-ring);
+  color: #fff;
+}
+
+.debate-mode-seg-active:hover {
+  background: var(--focus-ring);
+  color: #fff;
+}
+
+.debate-mode-separator {
+  display: inline-block;
+  width: 1px;
+  height: 14px;
+  background: var(--border-color);
+  flex-shrink: 0;
+}
+
+.debate-mode-override-dot {
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+  opacity: 0.75;
+}
+
+.debate-mode-match-global {
+  background: none;
+  border: none;
+  color: var(--focus-ring);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+  padding: 0 2px;
+  opacity: 0.8;
+  white-space: nowrap;
+}
+.debate-mode-match-global:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.debate-tier-global .debate-mode-group {
+  font-size: inherit;
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
@@ -196,16 +196,17 @@ vi.mock('./OpeningPanel', () => ({
 vi.mock('./TaxonomyRefs', () => ({
   CoverageBadge: () => <div data-testid="coverage-badge" />,
 }));
-vi.mock('./utils', () => ({
-  speakerLabel: (s: string) => s.charAt(0).toUpperCase() + s.slice(1),
-  speakerColor: () => 'red',
-  nodeIdToTab: () => ({ tab: 'beliefs', colorVar: 'var(--color-acc)' }),
-  focusMainWindowNode: vi.fn(),
-  countOccurrences: () => 0,
-  ADAPTIVE_PHASES: ['confrontation', 'argumentation', 'concluding'],
-  ADAPTIVE_PHASE_LABELS: { confrontation: 'Confrontation', argumentation: 'Argumentation', concluding: 'Concluding' },
-  ADAPTIVE_PHASE_COLORS: { confrontation: '#ef4444', argumentation: '#f59e0b', concluding: '#22c55e' },
-}));
+vi.mock('./utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils')>();
+  return {
+    ...actual,
+    speakerLabel: (s: string) => s.charAt(0).toUpperCase() + s.slice(1),
+    speakerColor: () => 'red',
+    nodeIdToTab: () => ({ tab: 'beliefs', colorVar: 'var(--color-acc)' }),
+    focusMainWindowNode: vi.fn(),
+    countOccurrences: () => 0,
+  };
+});
 
 // ── Test fixture ──────────────────────────────────────────────
 
@@ -290,25 +291,29 @@ describe('toolbar', () => {
     expect(screen.getByText('Comments (0)')).toBeInTheDocument();
   });
 
-  it('renders tier pills — Brief, Med, Detail', () => {
+  it('renders two-mode control with Text/Analysis mode group and text sub-options', () => {
     render(<DebateWorkspace />);
+    expect(screen.getByText('Text')).toBeInTheDocument();
+    expect(screen.getByText('Analysis')).toBeInTheDocument();
     expect(screen.getByText('Brief')).toBeInTheDocument();
-    expect(screen.getByText('Med')).toBeInTheDocument();
-    expect(screen.getByText('Detail')).toBeInTheDocument();
+    expect(screen.getByText('Medium')).toBeInTheDocument();
+    expect(screen.getByText('Detailed')).toBeInTheDocument();
   });
 
-  it('renders all six tier pills', () => {
+  it('renders five mode segments in text mode (2 mode + 3 sub-options)', () => {
     const { container } = render(<DebateWorkspace />);
-    const pills = container.querySelectorAll('.debate-tier-pill');
-    expect(pills.length).toBe(6);
+    const segs = container.querySelectorAll('.debate-mode-seg');
+    expect(segs.length).toBe(5);
   });
 
-  it('marks the active tier pill', () => {
+  it('marks Text mode and active sub-option as active', () => {
     mockStore.responseLength = 'brief';
     const { container } = render(<DebateWorkspace />);
-    const activePills = container.querySelectorAll('.debate-tier-pill-active');
-    expect(activePills.length).toBe(1);
-    expect(activePills[0].textContent).toBe('Brief');
+    const activeSegs = container.querySelectorAll('.debate-mode-seg-active');
+    expect(activeSegs.length).toBe(2);
+    const activeTexts = Array.from(activeSegs).map((el) => el.textContent);
+    expect(activeTexts).toContain('Text');
+    expect(activeTexts).toContain('Brief');
   });
 
   it('does not render Export button when onExport prop is not provided', () => {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -15,6 +15,7 @@ import { computeCoverageMap, computeStrengthWeightedCoverage } from '@lib/debate
 import type { CoverageMap, StrengthWeightedCoverage } from '@lib/debate/coverageTracker';
 import {
   speakerLabel, speakerColor, nodeIdToTab, focusMainWindowNode, countOccurrences, renderedOffsetOf,
+  META_TIERS, TIER_LABELS,
 } from './utils';
 import type { AdaptivePhase } from './utils';
 import { CommentCreationPopover } from '../chat/CommentCreationPopover';
@@ -371,6 +372,123 @@ type CommentStoreState = ReturnType<typeof useCommentStore.getState>;
 type ActiveDebateSession = NonNullable<DWStore['activeDebate']>;
 type ActiveTranscriptEntry = ActiveDebateSession['transcript'][number];
 
+type GlobalTextTier = 'brief' | 'medium' | 'detailed';
+type GlobalAnalysisTier = 'reasoning' | 'claims' | 'convergence';
+const GLOBAL_TEXT_TIERS: GlobalTextTier[] = ['brief', 'medium', 'detailed'];
+const GLOBAL_ANALYSIS_TIERS: GlobalAnalysisTier[] = ['reasoning', 'claims', 'convergence'];
+const GLOBAL_TIER_TITLES: Record<string, string> = {
+  brief: 'Set all turns to brief (2–3 sentences)', medium: 'Set all turns to medium (key points)',
+  detailed: 'Set all turns to full content', reasoning: 'Show brief, plan & BDI (replaces text)',
+  claims: 'Show argument network claims', convergence: 'Show convergence diagnostics',
+};
+const GLOBAL_MODE_IDS = [{ id: 'text', label: 'Text' }, { id: 'analysis', label: 'Analysis' }] as const;
+
+function GlobalModeControl({ defaultTier, setDefaultTier }: {
+  defaultTier: DWStore['responseLength'];
+  setDefaultTier: DWStore['setResponseLength'];
+}) {
+  const activeMode = META_TIERS.has(defaultTier) ? 'analysis' : 'text';
+  const [lastText, setLastText] = useState<GlobalTextTier>(
+    activeMode === 'text' ? (defaultTier as GlobalTextTier) : 'detailed'
+  );
+  const [lastAnalysis, setLastAnalysis] = useState<GlobalAnalysisTier>(
+    activeMode === 'analysis' ? (defaultTier as GlobalAnalysisTier) : 'reasoning'
+  );
+
+  useEffect(() => {
+    if (META_TIERS.has(defaultTier)) setLastAnalysis(defaultTier as GlobalAnalysisTier);
+    else setLastText(defaultTier as GlobalTextTier);
+  }, [defaultTier]);
+
+  const subTiers = activeMode === 'text' ? GLOBAL_TEXT_TIERS : GLOBAL_ANALYSIS_TIERS;
+  const modeRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const subRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleModeSelect = useCallback((mode: 'text' | 'analysis') => {
+    if (mode === activeMode) return;
+    setDefaultTier(mode === 'text' ? lastText : lastAnalysis);
+  }, [activeMode, lastText, lastAnalysis, setDefaultTier]);
+
+  const handleSubSelect = useCallback((tier: string) => {
+    setDefaultTier(tier as GlobalTextTier | GlobalAnalysisTier);
+    if (activeMode === 'text') setLastText(tier as GlobalTextTier);
+    else setLastAnalysis(tier as GlobalAnalysisTier);
+  }, [activeMode, setDefaultTier]);
+
+  const handleModeKey = useCallback((e: { key: string; preventDefault(): void }, idx: number) => {
+    let next = idx;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (idx + 1) % 2;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (idx - 1 + 2) % 2;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = 1;
+    else return;
+    e.preventDefault();
+    handleModeSelect(GLOBAL_MODE_IDS[next].id);
+    requestAnimationFrame(() => modeRefs.current[next]?.focus());
+  }, [handleModeSelect]);
+
+  const handleSubKey = useCallback((e: { key: string; preventDefault(): void }, idx: number) => {
+    const len = subTiers.length;
+    let next = idx;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (idx + 1) % len;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (idx - 1 + len) % len;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = len - 1;
+    else return;
+    e.preventDefault();
+    handleSubSelect(subTiers[next]);
+    requestAnimationFrame(() => subRefs.current[next]?.focus());
+  }, [subTiers, handleSubSelect]);
+
+  return (
+    <span className="debate-tier-global" style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center' }}>
+      <span role="radiogroup" aria-label="View mode" className="debate-mode-group">
+        {GLOBAL_MODE_IDS.map(({ id, label }, i) => (
+          <button
+            key={id}
+            ref={el => { modeRefs.current[i] = el; }}
+            type="button"
+            role="radio"
+            aria-checked={activeMode === id}
+            tabIndex={activeMode === id ? 0 : -1}
+            className={`debate-mode-seg${activeMode === id ? ' debate-mode-seg-active' : ''}`}
+            onClick={() => handleModeSelect(id)}
+            onKeyDown={(e) => handleModeKey(e, i)}
+          >
+            {label}
+          </button>
+        ))}
+      </span>
+      <span className="debate-mode-separator" aria-hidden="true" />
+      <span
+        role="radiogroup"
+        aria-label={activeMode === 'text' ? 'Text detail level' : 'Analysis view'}
+        className="debate-mode-group"
+      >
+        {subTiers.map((tier, i) => {
+          const isActive = defaultTier === tier;
+          return (
+            <button
+              key={tier}
+              ref={el => { subRefs.current[i] = el; }}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              tabIndex={isActive ? 0 : -1}
+              className={`debate-mode-seg${isActive ? ' debate-mode-seg-active' : ''}`}
+              onClick={() => handleSubSelect(tier)}
+              onKeyDown={(e) => handleSubKey(e, i)}
+              title={GLOBAL_TIER_TITLES[tier]}
+            >
+              {TIER_LABELS[tier]}
+            </button>
+          );
+        })}
+      </span>
+    </span>
+  );
+}
+
 function DebateToolbar({
   activeDebate, isExploration, isCrossCutting, onShowCCDetails,
   commentSidebarOpen, toggleCommentSidebar, commentsFile,
@@ -431,18 +549,7 @@ function DebateToolbar({
       >
         {diagnosticsEnabled ? 'Diagnostics ON' : 'Diagnostics'}
       </button>
-      <span className="debate-tier-global" style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 2 }}>
-        {(['brief', 'medium', 'detailed', 'reasoning', 'claims', 'convergence'] as const).map(tier => (
-          <button
-            key={tier}
-            className={`debate-tier-pill${defaultTier === tier ? ' debate-tier-pill-active' : ''}`}
-            onClick={() => setDefaultTier(tier)}
-            title={tier === 'brief' ? 'Set all turns to brief (2-3 sentences)' : tier === 'medium' ? 'Set all turns to medium (key points)' : tier === 'detailed' ? 'Set all turns to full content' : tier === 'reasoning' ? 'Show brief, plan & BDI (replaces text)' : tier === 'claims' ? 'Show argument network claims' : 'Show convergence diagnostics'}
-          >
-            {tier === 'brief' ? 'Brief' : tier === 'medium' ? 'Med' : tier === 'detailed' ? 'Detail' : tier === 'reasoning' ? 'Plan' : tier === 'claims' ? 'Claims' : 'Conv'}
-          </button>
-        ))}
-      </span>
+      <GlobalModeControl defaultTier={defaultTier} setDefaultTier={setDefaultTier} />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -588,7 +588,6 @@ function StatementTierPills({ entry, activeTier, setEntryDisplayTier, vocabResol
               title={TIER_TITLES[tier]}
             >
               {TIER_LABELS[tier]}
-              {isActive && isOverridden && <span className="debate-mode-override-dot" aria-hidden="true" />}
             </button>
           );
         })}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -15,6 +15,7 @@ import { getDebateMarkdownComponents, type VocabResolution } from '../../utils/v
 import {
   speakerLabel, speakerColor, pctFmt, focusMainWindowNode,
   fixMarkdownLinks, stripLeadingHeadings,
+  META_TIERS, TIER_LABELS,
 } from './utils';
 import type { AnchorHTMLAttributes, HTMLAttributes } from 'react';
 import { parseEntityRef } from '@lib/entities/types';
@@ -430,12 +431,6 @@ function resolveDisplayContent(entry: TranscriptEntry, activeTier: string, isSub
   return { displayContent: stripLeadingHeadings(entry.content), isTruncated: false };
 }
 
-const META_TIERS = new Set(['reasoning', 'terms', 'lineage', 'claims', 'convergence']);
-
-const TIER_LABELS: Record<string, string> = {
-  brief: 'Brief', medium: 'Med', detailed: 'Detail', reasoning: 'Plan',
-  claims: 'Claims', terms: 'Terms', lineage: 'Lineage', convergence: 'Conv',
-};
 const TIER_TITLES: Record<string, string> = {
   brief: '2-3 sentences', medium: '1-2 paragraphs', detailed: 'Full response',
   reasoning: 'Brief, plan & BDI (replaces text)', claims: 'Argument network claims',
@@ -473,54 +468,141 @@ function StatementModelBadge({ entry, activeDebate }: { entry: TranscriptEntry; 
   );
 }
 
-function StatementTierPills({ entry, activeTier, detailDropdown, setEntryDisplayTier, vocabResolutions, hasLineageRefs }: {
+type TextTier = 'brief' | 'medium' | 'detailed';
+type AnalysisTier = 'reasoning' | 'terms' | 'lineage' | 'claims' | 'convergence';
+const TEXT_TIERS: TextTier[] = ['brief', 'medium', 'detailed'];
+const MODE_IDS = [{ id: 'text', label: 'Text' }, { id: 'analysis', label: 'Analysis' }] as const;
+
+function StatementTierPills({ entry, activeTier, setEntryDisplayTier, vocabResolutions, hasLineageRefs }: {
   entry: TranscriptEntry;
   activeTier: string;
-  detailDropdown: boolean;
   setEntryDisplayTier: SetEntryDisplayTier;
   vocabResolutions: VocabResolution[] | undefined;
   hasLineageRefs: boolean;
 }) {
+  const activeMode = META_TIERS.has(activeTier) ? 'analysis' : 'text';
+
+  const [lastText, setLastText] = useState<TextTier>(
+    activeMode === 'text' ? (activeTier as TextTier) : 'detailed'
+  );
+  const [lastAnalysis, setLastAnalysis] = useState<AnalysisTier>(
+    activeMode === 'analysis' ? (activeTier as AnalysisTier) : 'reasoning'
+  );
+
+  // Sync per-card memory when tier changes externally (global default reset, override clear).
+  useEffect(() => {
+    if (META_TIERS.has(activeTier)) setLastAnalysis(activeTier as AnalysisTier);
+    else setLastText(activeTier as TextTier);
+  }, [activeTier]);
+
+  const analysisOptions = useMemo<AnalysisTier[]>(
+    () => (['reasoning', 'terms', 'lineage', 'claims', 'convergence'] as AnalysisTier[]).filter(t => {
+      if (t === 'terms') return !!(vocabResolutions && vocabResolutions.length > 0);
+      if (t === 'lineage') return hasLineageRefs;
+      return true;
+    }),
+    [vocabResolutions, hasLineageRefs],
+  );
+
+  const subTiers = activeMode === 'text' ? TEXT_TIERS : analysisOptions;
+  const isOverridden = entry.display_tier != null;
+
+  const modeRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const subRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const handleModeSelect = useCallback((mode: 'text' | 'analysis') => {
+    if (mode === activeMode) return;
+    setEntryDisplayTier(entry.id, mode === 'text' ? lastText : lastAnalysis);
+  }, [activeMode, lastText, lastAnalysis, entry.id, setEntryDisplayTier]);
+
+  const handleSubSelect = useCallback((tier: string) => {
+    setEntryDisplayTier(entry.id, tier as TextTier | AnalysisTier);
+    if (activeMode === 'text') setLastText(tier as TextTier);
+    else setLastAnalysis(tier as AnalysisTier);
+  }, [activeMode, entry.id, setEntryDisplayTier]);
+
+  const handleModeKey = useCallback((e: { key: string; preventDefault(): void }, idx: number) => {
+    let next = idx;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (idx + 1) % 2;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (idx - 1 + 2) % 2;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = 1;
+    else return;
+    e.preventDefault();
+    handleModeSelect(MODE_IDS[next].id);
+    requestAnimationFrame(() => modeRefs.current[next]?.focus());
+  }, [handleModeSelect]);
+
+  const handleSubKey = useCallback((e: { key: string; preventDefault(): void }, idx: number) => {
+    const len = subTiers.length;
+    let next = idx;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (idx + 1) % len;
+    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (idx - 1 + len) % len;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = len - 1;
+    else return;
+    e.preventDefault();
+    handleSubSelect(subTiers[next]);
+    requestAnimationFrame(() => subRefs.current[next]?.focus());
+  }, [subTiers, handleSubSelect]);
+
   return (
     <span className="debate-tier-pills">
-      {detailDropdown ? (
-        <select
-          className="debate-detail-dropdown"
-          value={(['brief', 'medium', 'detailed'] as const).includes(activeTier as 'brief' | 'medium' | 'detailed') ? activeTier : 'detailed'}
-          onChange={(e) => { e.stopPropagation(); setEntryDisplayTier(entry.id, e.target.value as 'brief' | 'medium' | 'detailed'); }}
+      <span role="radiogroup" aria-label="View mode" className="debate-mode-group">
+        {MODE_IDS.map(({ id, label }, i) => (
+          <button
+            key={id}
+            ref={el => { modeRefs.current[i] = el; }}
+            type="button"
+            role="radio"
+            aria-checked={activeMode === id}
+            tabIndex={activeMode === id ? 0 : -1}
+            className={`debate-mode-seg${activeMode === id ? ' debate-mode-seg-active' : ''}`}
+            onClick={(e) => { e.stopPropagation(); handleModeSelect(id); }}
+            onKeyDown={(e) => handleModeKey(e, i)}
+          >
+            {label}
+          </button>
+        ))}
+      </span>
+      <span className="debate-mode-separator" aria-hidden="true" />
+      <span
+        role="radiogroup"
+        aria-label={activeMode === 'text' ? 'Text detail level' : 'Analysis view'}
+        className="debate-mode-group"
+      >
+        {subTiers.map((tier, i) => {
+          const isActive = activeTier === tier;
+          return (
+            <button
+              key={tier}
+              ref={el => { subRefs.current[i] = el; }}
+              type="button"
+              role="radio"
+              aria-checked={isActive}
+              tabIndex={isActive ? 0 : -1}
+              className={`debate-mode-seg${isActive ? ' debate-mode-seg-active' : ''}${isActive && isOverridden ? ' debate-mode-seg-overridden' : ''}`}
+              aria-label={`${TIER_LABELS[tier]}${isActive && isOverridden ? ', overrides global default' : ''}`}
+              onClick={(e) => { e.stopPropagation(); handleSubSelect(tier); }}
+              onKeyDown={(e) => handleSubKey(e, i)}
+              title={TIER_TITLES[tier]}
+            >
+              {TIER_LABELS[tier]}
+              {isActive && isOverridden && <span className="debate-mode-override-dot" aria-hidden="true" />}
+            </button>
+          );
+        })}
+      </span>
+      {isOverridden && (
+        <button
+          type="button"
+          className="debate-mode-match-global"
+          onClick={(e) => { e.stopPropagation(); setEntryDisplayTier(entry.id, undefined); }}
+          title="Clear override — revert to global default"
         >
-          <option value="brief">Brief</option>
-          <option value="medium">Medium</option>
-          <option value="detailed">Full</option>
-        </select>
-      ) : (
-        (['brief', 'medium', 'detailed'] as const).map(tier => (
-          <button
-            key={tier}
-            className={`debate-tier-pill${activeTier === tier ? ' debate-tier-pill-active' : ''}`}
-            onClick={(e) => { e.stopPropagation(); setEntryDisplayTier(entry.id, tier); }}
-            title={TIER_TITLES[tier]}
-          >
-            {TIER_LABELS[tier]}
-          </button>
-        ))
+          ↺ match global
+        </button>
       )}
-      {(['reasoning', 'terms', 'lineage', 'claims', 'convergence'] as const).map(tier => {
-        if (tier === 'terms' && !(vocabResolutions && vocabResolutions.length > 0)) return null;
-        if (tier === 'lineage' && !hasLineageRefs) return null;
-        const isSpecial = (tier === 'terms' || tier === 'lineage') && activeTier !== tier;
-        return (
-          <button
-            key={tier}
-            className={`debate-tier-pill${activeTier === tier ? ' debate-tier-pill-active' : ''}`}
-            onClick={(e) => { e.stopPropagation(); setEntryDisplayTier(entry.id, tier); }}
-            title={TIER_TITLES[tier]}
-            style={isSpecial ? { color: 'rgb(168, 85, 247)' } : undefined}
-          >
-            {TIER_LABELS[tier]}
-          </button>
-        );
-      })}
     </span>
   );
 }
@@ -554,7 +636,7 @@ function StatementDeleteActions({ entryIndex, totalEntries, deleteConfirm, setDe
 
 function StatementCardHeader({
   entry, statementId, camp, color, activeDebate, anNodeId,
-  showTierPills, detailDropdown, activeTier, setEntryDisplayTier, vocabResolutions, hasLineageRefs,
+  showTierPills, activeTier, setEntryDisplayTier, vocabResolutions, hasLineageRefs,
   qbafEnabled, netDelta, isPover, diagnosticsEnabled, toggleDiagnostics, selectDiagEntry,
   entryIndex, totalEntries, deleteConfirm, setDeleteConfirm,
 }: {
@@ -565,7 +647,6 @@ function StatementCardHeader({
   activeDebate: ActiveDebateT;
   anNodeId: string | null;
   showTierPills: boolean;
-  detailDropdown: boolean;
   activeTier: string;
   setEntryDisplayTier: SetEntryDisplayTier;
   vocabResolutions: VocabResolution[] | undefined;
@@ -605,7 +686,6 @@ function StatementCardHeader({
         <StatementTierPills
           entry={entry}
           activeTier={activeTier}
-          detailDropdown={detailDropdown}
           setEntryDisplayTier={setEntryDisplayTier}
           vocabResolutions={vocabResolutions}
           hasLineageRefs={hasLineageRefs}
@@ -838,7 +918,6 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
   const selectDiagEntry = useDebateStore(s => s.selectDiagEntry);
   const deleteTranscriptEntries = useDebateStore(s => s.deleteTranscriptEntries);
   const qbafEnabled = useFlag('release-qbaf-analysis');
-  const detailDropdown = useFlag('debate-detail-dropdown');
   const [deleteConfirm, setDeleteConfirm] = useState<'single' | 'after' | null>(null);
   const [showSymbolTooltips, setShowSymbolTooltips] = useState(false);
   const anNodeId = findAnNodeId(activeDebate, entry.id);
@@ -941,7 +1020,6 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
         activeDebate={activeDebate}
         anNodeId={anNodeId}
         showTierPills={showTierPills}
-        detailDropdown={detailDropdown}
         activeTier={activeTier}
         setEntryDisplayTier={setEntryDisplayTier}
         vocabResolutions={vocabResolutions}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/utils.ts
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/utils.ts
@@ -190,6 +190,20 @@ export function renderedOffsetOf(container: HTMLElement, node: Node, offset: num
   return preRange.toString().length;
 }
 
+// ── Tier metadata (shared across StatementCard + DebateWorkspace) ────────────
+
+/** Tiers that render a structured analysis view (not prose text). Used to derive
+ *  the active "mode" (Text vs Analysis) without a second store field. */
+export const META_TIERS = new Set(['reasoning', 'terms', 'lineage', 'claims', 'convergence']);
+
+/** Human-readable labels for every tier — single source of truth for both
+ *  per-statement controls and the global toolbar (consolidates the previously
+ *  duplicated maps; labels updated: Med→Medium, Detail→Detailed per t/2172). */
+export const TIER_LABELS: Record<string, string> = {
+  brief: 'Brief', medium: 'Medium', detailed: 'Detailed', reasoning: 'Plan',
+  claims: 'Claims', terms: 'Terms', lineage: 'Lineage', convergence: 'Conv',
+};
+
 // ── Find-in-debate helpers ────────────────────────────────
 
 export function countOccurrences(text: string, query: string): number {

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/configSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/configSlice.ts
@@ -73,7 +73,7 @@ export interface ConfigSlice {
   // Actions
   setResponseLength: (length: 'claims' | 'brief' | 'medium' | 'detailed' | 'reasoning' | 'convergence') => void;
   setAudience: (audience: DebateAudience) => void;
-  setEntryDisplayTier: (entryId: string, tier: 'claims' | 'brief' | 'medium' | 'detailed' | 'reasoning' | 'convergence' | 'terms' | 'lineage') => void;
+  setEntryDisplayTier: (entryId: string, tier: 'claims' | 'brief' | 'medium' | 'detailed' | 'reasoning' | 'convergence' | 'terms' | 'lineage' | undefined) => void;
   setOpeningOrder: (order: Exclude<SpeakerId, 'user'>[]) => void;
   setInitialCrossRespondRounds: (n: number) => void;
   clearWarnings: () => void;

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -9008,15 +9008,94 @@ a.vocab-term,
 
 /* ─── Detail Tier Pills (DT-3) ────────────────────────── */
 
+/* Outer row — holds Mode group + separator + Sub-option group (+ optional match-global btn) */
 .debate-tier-pills {
   display: inline-flex;
-  gap: 1px;
+  align-items: center;
+  gap: 4px;
   margin-left: 8px;
-  background: var(--border);
+  flex-wrap: wrap;           /* sub-option group wraps below ~360px (AC10) */
+}
+
+/* Each segmented group (Mode or Sub-option) */
+.debate-mode-group {
+  display: inline-flex;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   overflow: hidden;
 }
 
+/* Individual segment inside a group */
+.debate-mode-seg {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  padding: 1px 6px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  transition: background 0.1s, color 0.1s;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  white-space: nowrap;
+}
+
+.debate-mode-seg:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.debate-mode-seg-active {
+  background: var(--focus-ring);   /* defined accent: light=#3b82f6 dark=#60a5fa bkc=#4d7a8b harvard=#A51C30 */
+  color: #fff;
+}
+
+.debate-mode-seg-active:hover {
+  background: var(--focus-ring);
+  color: #fff;
+}
+
+/* Thin vertical bar between Mode group and Sub-option group */
+.debate-mode-separator {
+  display: inline-block;
+  width: 1px;
+  height: 14px;
+  background: var(--border-color);
+  flex-shrink: 0;
+}
+
+/* 3px dot after the active sub-option label when a per-statement override is active */
+.debate-mode-override-dot {
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+  opacity: 0.75;
+}
+
+/* "↺ match global" affordance that clears a per-statement override */
+.debate-mode-match-global {
+  background: none;
+  border: none;
+  color: var(--focus-ring);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+  padding: 0 2px;
+  opacity: 0.8;
+  white-space: nowrap;
+}
+.debate-mode-match-global:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+/* Legacy pill classes kept for any remaining usages (e.g. detail-dropdown fallback) */
 .debate-tier-pill {
   background: var(--bg-primary);
   border: none;
@@ -9036,13 +9115,13 @@ a.vocab-term,
 }
 
 .debate-tier-pill-active {
-  background: var(--accent, #3b82f6);
+  background: var(--focus-ring);   /* was: var(--accent, #3b82f6) — undefined token, always blue */
   color: #fff;
 }
 
 .debate-detail-dropdown {
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   color: var(--text-muted);
   font-size: var(--text-2xs);
   font-weight: 600;
@@ -9058,14 +9137,14 @@ a.vocab-term,
   color: var(--text-primary);
 }
 .debate-detail-dropdown:focus {
-  outline: 1px solid var(--accent, #3b82f6);
+  outline: 1px solid var(--focus-ring);
 }
 
 .debate-tier-truncated {
   display: inline-block;
   margin-top: 4px;
   font-size: var(--text-xs);
-  color: var(--accent, #3b82f6);
+  color: var(--focus-ring);
   cursor: pointer;
   opacity: 0.8;
 }
@@ -9077,8 +9156,8 @@ a.vocab-term,
 .debate-tier-global {
   font-size: var(--text-2xs);
 }
-.debate-tier-global .debate-tier-pill {
-  padding: 1px 6px;
+.debate-tier-global .debate-mode-group {
+  font-size: inherit;
 }
 
 .debate-diagnose-btn {

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -9017,83 +9017,6 @@ a.vocab-term,
   flex-wrap: wrap;           /* sub-option group wraps below ~360px (AC10) */
 }
 
-/* Each segmented group (Mode or Sub-option) */
-.debate-mode-group {
-  display: inline-flex;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-}
-
-/* Individual segment inside a group */
-.debate-mode-seg {
-  background: transparent;
-  border: none;
-  color: var(--text-secondary);
-  font-size: var(--text-2xs);
-  font-weight: 600;
-  padding: 1px 6px;
-  cursor: pointer;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  transition: background 0.1s, color 0.1s;
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  white-space: nowrap;
-}
-
-.debate-mode-seg:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.debate-mode-seg-active {
-  background: var(--focus-ring);   /* defined accent: light=#3b82f6 dark=#60a5fa bkc=#4d7a8b harvard=#A51C30 */
-  color: #fff;
-}
-
-.debate-mode-seg-active:hover {
-  background: var(--focus-ring);
-  color: #fff;
-}
-
-/* Thin vertical bar between Mode group and Sub-option group */
-.debate-mode-separator {
-  display: inline-block;
-  width: 1px;
-  height: 14px;
-  background: var(--border-color);
-  flex-shrink: 0;
-}
-
-/* 3px dot after the active sub-option label when a per-statement override is active */
-.debate-mode-override-dot {
-  display: inline-block;
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  background: currentColor;
-  flex-shrink: 0;
-  opacity: 0.75;
-}
-
-/* "↺ match global" affordance that clears a per-statement override */
-.debate-mode-match-global {
-  background: none;
-  border: none;
-  color: var(--focus-ring);
-  font-size: var(--text-2xs);
-  cursor: pointer;
-  padding: 0 2px;
-  opacity: 0.8;
-  white-space: nowrap;
-}
-.debate-mode-match-global:hover {
-  opacity: 1;
-  text-decoration: underline;
-}
 
 /* Legacy pill classes kept for any remaining usages (e.g. detail-dropdown fallback) */
 .debate-tier-pill {
@@ -9155,9 +9078,6 @@ a.vocab-term,
 
 .debate-tier-global {
   font-size: var(--text-2xs);
-}
-.debate-tier-global .debate-mode-group {
-  font-size: inherit;
 }
 
 .debate-diagnose-btn {


### PR DESCRIPTION
## Summary

- Replaces the flat tier pill strip with a two-group segmented control at both per-statement (`StatementTierPills`) and global toolbar (`GlobalModeControl`) level
- Mode (Text | Analysis) is derived from `META_TIERS` — no new store field; lossless mode switching via per-card `lastText`/`lastAnalysis` memory
- Override affordance: 3px dot + "↺ match global" button when `entry.display_tier` differs from global default
- Token fixes: `var(--accent)` → `var(--focus-ring)`, `var(--border)` → `var(--border-color)` (both were undefined in all themes)
- Drops `detailDropdown` feature-flag path from `StatementCard` (superseded by this design)

## Test plan

- [x] All 243 scoped vitest tests pass (`src/renderer/components/debate-workspace/`)
- [x] Updated `DebateWorkspace.test.tsx` utils mock to spread real module (fixes `META_TIERS` undefined); updated tier-pill assertions for new control
- [ ] Design review: `/design-review-workflow` (four themes + keyboard) — pending Design sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)