### PR TITLE
fix(debate): null-guard linked_nodes/conflict_ids in bdi_entropy computation (t/2169)

### DIFF
--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -813,8 +813,8 @@ export function reScoreSituationsForCruxesDetailed(input: SituationReScoreInput)
       relevance,
       diversity,
       freshness,
-      bdi_entropy: computeBdiEntropy(sit.linked_nodes, input.nodeCategoryLookup),
-      conflict_openness: computeConflictOpenness(sit.conflict_ids, new Set()),
+      bdi_entropy: computeBdiEntropy(sit.linked_nodes ?? [], input.nodeCategoryLookup),
+      conflict_openness: computeConflictOpenness(sit.conflict_ids ?? [], new Set()),
     };
     components.set(sit.id, comp);
 


### PR DESCRIPTION
## Summary

Hotfix for real-data crash introduced in PR #468 (f9ca93f2).

`sit.linked_nodes` and `sit.conflict_ids` are `undefined` on sit-164/165/166 in production data. `computeBdiEntropy` and `computeConflictOpenness` receive arrays — passing `undefined` throws at the first phase transition, aborting every debate. Fix: `?? []` at both call sites so missing arrays degrade to 0 rather than crashing.

Root cause and repro documented at t/2169#4.

## Test plan

- [x] `npx vitest run` — 2891 pass, 11 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)