### PR TITLE
fix(debate): null-guard sit.linked_nodes and sit.conflict_ids in bdi_entropy/conflict_openness (t/2169)

### DIFF
--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -813,8 +813,8 @@ export function reScoreSituationsForCruxesDetailed(input: SituationReScoreInput)
       relevance,
       diversity,
       freshness,
-      bdi_entropy: computeBdiEntropy(sit.linked_nodes, input.nodeCategoryLookup),
-      conflict_openness: computeConflictOpenness(sit.conflict_ids, new Set()),
+      bdi_entropy: computeBdiEntropy(sit.linked_nodes ?? [], input.nodeCategoryLookup),
+      conflict_openness: computeConflictOpenness(sit.conflict_ids ?? [], new Set()),
     };
     components.set(sit.id, comp);
 


### PR DESCRIPTION
## Summary
- sit-164/165/166 have `undefined` `linked_nodes`/`conflict_ids` in real data
- `computeBdiEntropy` crashes on `linkedNodeIds.length` when the array is undefined
- Add `?? []` fallback at both call sites — missing arrays degrade gracefully to 0

## Test plan
- [ ] Existing 59 `taxonomyRelevance.test.ts` tests cover both code paths (non-empty arrays compute real values; empty arrays return 0)
- [ ] CI green
