### PR TITLE
fix(security): upgrade ip-address to 10.3.1 in npm bundle (CVE-2026-69192, t/2177)

### DIFF
--- a/deploy/azure/Dockerfile.base
+++ b/deploy/azure/Dockerfile.base
@@ -33,6 +33,10 @@ LABEL org.opencontainers.image.licenses="MIT"
 # CI Trivy scan to confirm clearance — pin after first successful scan. (t/2174)
 # hadolint ignore=DL3016
 RUN npm install -g npm@latest
+# ip-address 10.3.1 fixes CVE-2026-69192 (HIGH). npm@latest bundles 10.2.0;
+# upgrade explicitly within npm's own bundle until npm ships 10.3.1+. (t/2177)
+# hadolint ignore=DL3016
+RUN cd /usr/local/lib/node_modules/npm && npm install ip-address@10.3.1
 
 # System dependencies (runtime only — build tools like make/g++ live in the app
 # Dockerfile's builder stage, not here).


### PR DESCRIPTION
## Summary

- Adds `RUN cd /usr/local/lib/node_modules/npm && npm install ip-address@10.3.1` to `Dockerfile.base`
- `npm@latest` (installed in PR #470) upgraded ip-address 10.1.0 → 10.2.0 but CVE-2026-69192 requires 10.3.1. Explicitly upgrades ip-address within npm's own bundle until npm ships 10.3.1+.

## Test plan

- [ ] CI Trivy gate passes
- [ ] `build-and-push` succeeds
- [ ] GitHub Security alert #5496 (CVE-2026-69192) closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)