### PR TITLE
fix(calibration): two-pass situation_reference_rate — distinct inject…

### DIFF
--- a/lib/debate/calibrationLogger/extract-metrics.ts
+++ b/lib/debate/calibrationLogger/extract-metrics.ts
@@ -231,8 +231,7 @@ export function computeSituationAlignment(
   session: DebateSession,
   finalEval: NeutralEvaluation | undefined,
 ): { sitNodesInjected: number; sitNodesReferenced: number; sitCruxAlignment: number | null } {
-  let sitNodesInjected = 0;
-  let sitNodesReferenced = 0;
+  // Pass 1: collect all injected situation node IDs
   const injectedSitIds = new Set<string>();
   for (const entry of session.transcript) {
     const manifest = (entry.metadata as Record<string, unknown>)?.injection_manifest as {
@@ -241,13 +240,18 @@ export function computeSituationAlignment(
     if (manifest?.situationNodeIds) {
       for (const id of manifest.situationNodeIds) injectedSitIds.add(id);
     }
+  }
+  // Pass 2: count distinct injected sit IDs referenced across the transcript
+  const referencedInjected = new Set<string>();
+  for (const entry of session.transcript) {
     for (const ref of entry.taxonomy_refs ?? []) {
-      if (typeof ref.node_id === 'string' && ref.node_id.startsWith('sit-')) {
-        sitNodesReferenced++;
+      if (typeof ref.node_id === 'string' && injectedSitIds.has(ref.node_id)) {
+        referencedInjected.add(ref.node_id);
       }
     }
   }
-  sitNodesInjected = injectedSitIds.size;
+  const sitNodesInjected = injectedSitIds.size;
+  const sitNodesReferenced = referencedInjected.size;
 
   // Situation-crux alignment: do the neutral evaluator's cruxes match injected situation nodes?
   // Uses word overlap between crux descriptions and situation node labels/descriptions.

--- a/lib/debate/calibrationLogger/extract.test.ts
+++ b/lib/debate/calibrationLogger/extract.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from 'vitest';
 import type { DebateSession } from '../types.js';
 import { extractCalibrationData } from './extract.js';
 import type { CalibrationDataPoint } from './schema.js';
-import { computeConvergenceWithCensoring } from './extract-metrics.js';
+import { computeConvergenceWithCensoring, computeSituationAlignment } from './extract-metrics.js';
 
 // ── Minimal session factory ───────────────────────────────────────────────────
 
@@ -240,5 +240,74 @@ describe('computeConvergenceWithCensoring', () => {
     // denominator = 1 completed + 1 censored = 2 (unknown excluded)
     expect(result.censoring_rate).toBeCloseTo(1 / 2);
     expect(result.n_unknown).toBe(1);
+  });
+});
+
+// ── computeSituationAlignment (t/2168) ───────────────────────────────────────
+
+function makeTranscriptEntry(opts: {
+  situationNodeIds?: string[];
+  taxonomyRefs?: { node_id: string }[];
+}): unknown {
+  return {
+    type: 'statement',
+    speaker: 'accelerationist',
+    content: 'test',
+    taxonomy_refs: opts.taxonomyRefs ?? [],
+    metadata: opts.situationNodeIds
+      ? { injection_manifest: { situationNodeIds: opts.situationNodeIds } }
+      : {},
+  };
+}
+
+describe('computeSituationAlignment', () => {
+  it('multi-turn repeated reference of same sit- ID counts as 1 — rate never exceeds 1', () => {
+    // sit-001 injected once; referenced in 3 separate turns
+    const session = makeSession({
+      transcript: [
+        makeTranscriptEntry({ situationNodeIds: ['sit-001'], taxonomyRefs: [{ node_id: 'sit-001' }] }),
+        makeTranscriptEntry({ taxonomyRefs: [{ node_id: 'sit-001' }] }),
+        makeTranscriptEntry({ taxonomyRefs: [{ node_id: 'sit-001' }] }),
+      ],
+    });
+    const result = computeSituationAlignment(session, undefined);
+    expect(result.sitNodesInjected).toBe(1);
+    expect(result.sitNodesReferenced).toBe(1);  // distinct, not per-occurrence
+    // rate = 1/1 = 1.0, not 3.0
+  });
+
+  it('non-injected sit- ref does not inflate sitNodesReferenced', () => {
+    // sit-001 injected; sit-999 referenced but never injected
+    const session = makeSession({
+      transcript: [
+        makeTranscriptEntry({ situationNodeIds: ['sit-001'] }),
+        makeTranscriptEntry({ taxonomyRefs: [{ node_id: 'sit-999' }, { node_id: 'sit-001' }] }),
+      ],
+    });
+    const result = computeSituationAlignment(session, undefined);
+    expect(result.sitNodesInjected).toBe(1);
+    expect(result.sitNodesReferenced).toBe(1);  // sit-999 excluded, sit-001 counted once
+  });
+
+  it('zero injected → sitNodesReferenced is 0 and cruxAlignment is null', () => {
+    const session = makeSession({
+      transcript: [makeTranscriptEntry({ taxonomyRefs: [{ node_id: 'sit-001' }] })],
+    });
+    const result = computeSituationAlignment(session, undefined);
+    expect(result.sitNodesInjected).toBe(0);
+    expect(result.sitNodesReferenced).toBe(0);
+    expect(result.sitCruxAlignment).toBeNull();
+  });
+
+  it('two injected, one referenced → rate 0.5', () => {
+    const session = makeSession({
+      transcript: [
+        makeTranscriptEntry({ situationNodeIds: ['sit-001', 'sit-002'] }),
+        makeTranscriptEntry({ taxonomyRefs: [{ node_id: 'sit-001' }] }),
+      ],
+    });
+    const result = computeSituationAlignment(session, undefined);
+    expect(result.sitNodesInjected).toBe(2);
+    expect(result.sitNodesReferenced).toBe(1);
   });
 });


### PR DESCRIPTION
…ed refs only (t/2168)

`computeSituationAlignment` was counting per-occurrence sits across the full transcript, unfiltered by the injected set. A single sit- ID referenced in 3 turns reported sitNodesReferenced=3 against sitNodesInjected=1, giving situation_reference_rate=3.0 — impossible for a ratio that must be [0,1].

Fix: split into two passes.
- Pass 1: build injectedSitIds from all injection_manifest entries.
- Pass 2: collect distinct injected IDs found in taxonomy_refs into a Set. sitNodesReferenced = referencedInjected.size (distinct, not per-occurrence).

Tests added to extract.test.ts:
- multi-turn repeated ref of same ID counts as 1 (rate never exceeds 1)
- non-injected sit- ref excluded from count
- zero injected -> zero referenced, cruxAlignment null
- 2 injected / 1 referenced -> 0.5 rate