### PR TITLE
fix(debate): record convergence_score in telemetry on all phases (t/2153)

### DIFF
--- a/lib/debate/phaseTransitions.test.ts
+++ b/lib/debate/phaseTransitions.test.ts
@@ -1227,7 +1227,7 @@ describe('buildSignalTelemetry', () => {
     expect(record.network_size).toBe(10);
   });
 
-  it('fills argumentative_saturation_score for non-synthesis phase', () => {
+  it('fills both composite scores for non-concluding phase', () => {
     const state = makePhaseState({ current_phase: 'argumentation' });
     const ctx = makeSignalContext();
     const signals = buildSignalRegistry();
@@ -1237,7 +1237,7 @@ describe('buildSignalTelemetry', () => {
     };
     const record = buildSignalTelemetry(state, ctx, signals, result, 0.5, 50);
     expect(record.composite.argumentative_saturation_score).not.toBeNull();
-    expect(record.composite.convergence_score).toBeNull();
+    expect(record.composite.convergence_score).not.toBeNull();
   });
 
   it('fills convergence_score for synthesis phase', () => {

--- a/lib/debate/phaseTransitions.ts
+++ b/lib/debate/phaseTransitions.ts
@@ -999,7 +999,7 @@ export function buildSignalTelemetry(
     signals: signalValues,
     composite: {
       argumentative_saturation_score: state.current_phase !== 'concluding' ? satScore : null,
-      convergence_score: state.current_phase === 'concluding' ? convScore : null,
+      convergence_score: convScore,
     },
     confidence: { extraction: extractionConf, stability: stabilityConf, global: globalConf },
     predicate_result: result,


### PR DESCRIPTION
## Summary

- `buildSignalTelemetry` in `phaseTransitions.ts` gated `composite.convergence_score` to the `concluding` phase only
- Most real debates terminate in `argumentation`/`confrontation` (API ceiling, max-rounds), so the score was always null in the calibration log — blocking `convergence_score_at_termination` in the calibration extractor (t/2153 AC3)
- Fix: remove the phase gate; `convScore` is already computed every round for the phase-transition predicate, so surfacing it in the composite on all rounds is correct
- `argumentative_saturation_score` retains its existing `concluding`-phase null guard (unchanged)

## Test plan

- [ ] `phaseTransitions.test.ts` updated: non-concluding phase now asserts `convergence_score` is non-null
- [ ] All 2891 tests pass in worktree
- [ ] After merge: trigger a real multi-round adaptive debate to confirm `convergence_score_at_termination` is non-null in calibration log (AC3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)