### PR TITLE
fix(debate): correct budget multiplier fallback 6/10/8 -> 8/15/10 (t/2186)

### DIFF
--- a/lib/debate/phaseTransitions.test.ts
+++ b/lib/debate/phaseTransitions.test.ts
@@ -2,6 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
 import {
   loadProvisionalWeights,
   resetWeightsCache,
@@ -172,6 +175,13 @@ describe('loadProvisionalWeights', () => {
     expect(w.pacing_presets).toHaveProperty('tight');
     expect(w.pacing_presets).toHaveProperty('moderate');
     expect(w.pacing_presets).toHaveProperty('thorough');
+  });
+
+  it('budget fallback matches calibration-config.json budget block (parity gate)', () => {
+    const configPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'calibration-config.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as { budget: Record<string, number> };
+    const w = loadProvisionalWeights();
+    expect(w.budget).toEqual(config.budget);
   });
 });
 

--- a/lib/debate/phaseTransitions.ts
+++ b/lib/debate/phaseTransitions.ts
@@ -110,7 +110,7 @@ export function loadProvisionalWeights(debateDir?: string): ProvisionalWeights {
       thorough: { maxTotalRounds: 8, argumentationExit: 0.80, concludingExit: 0.80 },
     },
     network: { gc_trigger: 175, gc_target: 150, hard_cap: 200 },
-    budget: { soft_multiplier: 6, hard_multiplier: 10, max_soft_multiplier: 8 },
+    budget: { soft_multiplier: 8, hard_multiplier: 15, max_soft_multiplier: 10 },
     evaluator: { model: 'gemini-3.5-flash-lite', version: 1 },
   };
   return _cachedWeights;


### PR DESCRIPTION
## Summary

- `phaseTransitions.ts` browser fallback had drifted from `calibration-config.json`: `soft_multiplier 6→8`, `hard_multiplier 10→15`, `max_soft_multiplier 8→10`
- Browser-context debates (no calibration-config.json) were hitting API budget ceilings ~25-33% earlier than intended, silently truncating debates
- Adds a parity regression test that loads the checked-in `calibration-config.json` and deep-equals the TS `budget` fallback against it — drift is now a red test

## Test plan

- [x] `npx vitest run phaseTransitions.test.ts` — 95 tests pass
- [x] New parity gate: "budget fallback matches calibration-config.json budget block" — green at 8/15/10, would fail if reverted

Closes t/2186. Unblocks t/2187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)