### PR TITLE
chore(constants): use DEFAULT_MODEL in runtimeConfig.ts (t/2179)

### DIFF
--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -20,6 +20,7 @@ import path from 'path';
 import { getDataRoot } from './config.js';
 import { log } from './logger.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
+import { DEFAULT_MODEL } from '../../../lib/ai-client/index.js';
 
 // ── Types (mirror runtime-config-spec.md §3) ──
 
@@ -152,7 +153,7 @@ const DEFAULTS: RuntimeConfig = {
     platform: { requestsPerMinute: 60, tokensPerDay: 2_000_000, allowedBackends: [...KNOWN_BACKENDS] }, // t/1513: all system backends — key-presence gates actual availability
     byok: { requestsPerMinute: 30, tokensPerDay: 2_000_000, allowedBackends: [...KNOWN_BACKENDS] }, // t/965: 500K → 2M (a single 10-round debate uses 300–500K; BYOK users pay their own API). t/1513: BYOK users bring their own keys — no reason to cap the backend set
     anonymous: { requestsPerMinute: 10, tokensPerDay: 100_000, allowedBackends: ['gemini', 'claude', 'groq'] }, // t/1513: intentionally limited — anonymous users bring no keys, so they use platform-provided keys (same rationale as free tier); do NOT widen without a cost/abuse review
-    free: { requestsPerMinute: 6, tokensPerDay: 500_000, allowedBackends: ['gemini'], pinnedModel: 'gemini-flash-lite-latest' }, // t/1061: 50K → 500K (single debate round ≈ 54K; 50K budget made debates non-functional)
+    free: { requestsPerMinute: 6, tokensPerDay: 500_000, allowedBackends: ['gemini'], pinnedModel: DEFAULT_MODEL }, // t/1061: 50K → 500K (single debate round ≈ 54K; 50K budget made debates non-functional)
   },
   quotas: {
     defaultMaxChats: 25,


### PR DESCRIPTION
## Summary
- Replace hardcoded `'gemini-flash-lite-latest'` in `runtimeConfig.ts` free-tier `pinnedModel` default with `DEFAULT_MODEL` imported from `lib/ai-client`
- Import-swap only — no behavioral change; value is identical

## Test plan
- [x] `tsc -p tsconfig.server.json --noEmit` passes clean
- [x] Self-certified via /trivial-change (import-swap, single file, no logic change)

Part of t/2178 / GitHub #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)