### PR TITLE
chore(constants): extract non-calibration debate config into debateConfig.ts (t/2182)

### DIFF
--- a/lib/debate/constants.ts
+++ b/lib/debate/constants.ts
@@ -17,3 +17,6 @@ export const DEFAULT_AI_TIMEOUT_MS = 120_000;
 
 /** Default relevance threshold for taxonomy node selection during debate turns. */
 export const DEFAULT_RELEVANCE_THRESHOLD = 0.45;
+
+/** Vector dimension for all-MiniLM-L6-v2 frame embeddings. */
+export const EMBEDDING_DIM = 384;

--- a/lib/debate/debateConfig.ts
+++ b/lib/debate/debateConfig.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Runtime-behavior knobs for the debate engine. Values here are tunable
+// configuration; structural invariants (embedding dim, dedup thresholds, etc.)
+// live in constants.ts. Calibration-coupled values (budget multipliers,
+// embedding/lexical thresholds) are in phaseTransitions.ts fallback and
+// covered by the parity gate in phaseTransitions.test.ts.
+
+// ── Timeouts ──────────────────────────────────────────────────────────────────
+
+export const CLAIM_VERIFY_SETTLE_TIMEOUT_MS = 30_000;
+export const SUMMARIZATION_TIMEOUT_MS = 15_000;
+export const JUDGE_TIMEOUT_MS = 20_000;
+
+// ── Generation parameters ─────────────────────────────────────────────────────
+
+export const EVALUATOR_TEMPERATURE = 0;
+export const SUMMARIZATION_TEMPERATURE = 0.3;
+export const SUMMARIZATION_MAX_TOKENS = 500;
+
+// ── Round / phase control ─────────────────────────────────────────────────────
+
+export const MIDPOINT_NEUTRAL_EVAL_ROUND_CAP = 3;
+export const DIVERSITY_MIN_ACTIVATION_ROUND = 3;
+export const DIVERSITY_REPETITION_RATE_THRESHOLD = 0.5;
+export const CROSS_POV_CITATION_ACTIVATION_ROUND = 4;
+
+// ── Transcript / context-window sizes ────────────────────────────────────────
+
+export const COMPRESSION_TRIGGER_TRANSCRIPT_LENGTH = 12;
+export const RECENT_TRANSCRIPT_WINDOW_TURNS = 8;
+export const PROBING_TRANSCRIPT_WINDOW_TURNS = 50;
+export const OVERGEN_TRANSCRIPT_WINDOW_TURNS = 6;
+export const PRIOR_MOVES_DIVERSITY_WINDOW = 6;
+export const PROCESS_REWARD_SIGNAL_HISTORY_DEPTH = 12;
+export const SOURCE_DOC_SUMMARY_CHAR_LIMIT = 2_000;
+
+// ── Node / claim limits ───────────────────────────────────────────────────────
+
+export const ESTABLISHED_POINTS_LIMIT = 14;
+export const PROBING_UNREFERENCED_NODES_CAP = 20;
+export const PROBING_UNCOVERED_CLAIMS_LIMIT = 10;
+export const CROSS_POV_NODE_DIVERSITY_LIMIT = 8;
+export const EDGE_CONTEXT_TOP_N = 15;
+export const TAXONOMY_MAX_POV_NODES_DEFAULT = 12;
+export const TAXONOMY_MIN_NODES_PER_BDI_DEFAULT = 3;
+export const EXPLORATION_SEEDING_RECOMMENDATION_SLICE = 10;
+
+// ── Scoring / strength thresholds ────────────────────────────────────────────
+
+export const CONCESSION_CANDIDATE_MIN_QBAF_STRENGTH = 0.65;
+export const RECENT_CITATION_PENALTY_MULTIPLIER = 0.55;
+export const TOPIC_SCORE_FLOOR_MULTIPLIER = 0.50;
+export const NON_APPROVED_EDGE_CONFIDENCE_FILTER = 0.75;
+export const LINEAGE_BOOST_INCREMENT = 0.08;
+export const PERTURBATION_ARCO_BASELINE = 0.5;
+
+// ── Insularity intervention limits ────────────────────────────────────────────
+
+export const INSULARITY_INTERVENTION_COOLDOWN_ROUNDS = 2;
+export const INSULARITY_INTERVENTION_PER_SPEAKER_CAP = 2;
+
+// ── Exploration seeding ───────────────────────────────────────────────────────
+
+export const EXPLORATION_EFFECTIVE_SITUATION_BOOST = 0.15;
+export const EXPLORATION_INEFFECTIVE_SITUATION_PENALTY = -0.10;
+/** [min, max] clamp applied to maxTotalRounds when seeding from situation data. */
+export const EXPLORATION_ROUNDS_CLAMP = [6, 20] as const;
+/** [min, max] clamp applied to argumentation/concluding exit thresholds when seeding. */
+export const EXPLORATION_EXIT_THRESHOLD_CLAMP = [0.4, 0.9] as const;
+/** [min, max] clamp applied to temperature when seeding from situation data. */
+export const EXPLORATION_TEMPERATURE_CLAMP = [0.3, 1.0] as const;
+
+// ── Doctrinal boundary weights ────────────────────────────────────────────────
+
+export const DOCTRINAL_HARDCODED_BOUNDARY_WEIGHT = 1.0;
+export const DOCTRINAL_SOFTCODED_BOUNDARY_WEIGHT = 0.7;

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -83,6 +83,7 @@ import { embedDoctrinalBoundaries, computeDoctrinalAnchoring, checkThresholdAnom
 import { extractCalibrationData, appendCalibrationLog, readCalibrationLog } from './calibrationLogger.js';
 import { DEFAULT_ATTACK_WEIGHTS } from './qbaf.js';
 import { DEFAULT_AI_TIMEOUT_MS, DEFAULT_RELEVANCE_THRESHOLD } from './constants.js';
+import { CLAIM_VERIFY_SETTLE_TIMEOUT_MS, EVALUATOR_TEMPERATURE, SUMMARIZATION_TEMPERATURE, SUMMARIZATION_MAX_TOKENS, SUMMARIZATION_TIMEOUT_MS } from './debateConfig.js';
 import { computeStrategicHints } from './strategicHints.js';
 import { evaluateLookahead, type LookaheadDiagnostics } from './lookaheadGate.js';
 import { runOvergenPipeline, type OvergenDiagnostics } from './overgenPipeline.js';
@@ -625,7 +626,6 @@ export class DebateEngine {
       // `_internal` accessor), so this gate continues to await them. Any future work that adds
       // post-completion async ordering (e.g. t/1767 entity/mention-metadata extraction) must
       // enqueue here and settle at this same point — do not scatter the ordering contract.
-      const CLAIM_VERIFY_SETTLE_TIMEOUT_MS = 30_000;
       if (this._pendingClaimVerifications.length > 0) {
         const settled = await Promise.race([
           Promise.allSettled(this._pendingClaimVerifications).then(() => true),
@@ -1238,7 +1238,7 @@ export class DebateEngine {
     const start = Date.now();
     try {
       const text = await this.adapter.generateText(prompt, evalModel, {
-        temperature: 0,
+        temperature: EVALUATOR_TEMPERATURE,
         timeoutMs: timeoutMs ?? DEFAULT_AI_TIMEOUT_MS,
         signal: this.config.signal,
       });
@@ -1370,9 +1370,9 @@ export class DebateEngine {
       const speaker = (POVER_INFO as Record<string, { label: string }>)[entry.speaker]?.label ?? entry.speaker;
       const prompt = entrySummarizationPrompt(entry.content, speaker);
       const raw = await this.adapter.generateText(prompt, resolveStageModel(this._internal, 'summary'), {
-        temperature: 0.3, // Low temp for faithful summarization
-        maxTokens: 500,
-        timeoutMs: 15000,
+        temperature: SUMMARIZATION_TEMPERATURE,
+        maxTokens: SUMMARIZATION_MAX_TOKENS,
+        timeoutMs: SUMMARIZATION_TIMEOUT_MS,
       });
       this.apiCallCount++;
 

--- a/lib/debate/debateEngine/adaptiveStaging.ts
+++ b/lib/debate/debateEngine/adaptiveStaging.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import type { DebateEngineInternals } from './internals.js';
+import { PROCESS_REWARD_SIGNAL_HISTORY_DEPTH } from '../debateConfig.js';
 import { type ArgumentNetworkEdge, type SignalContext } from '../types.js';
 import { detectCruxNodes } from '../phaseTransitions.js';
 import { type SituationNode, type Category } from '../taxonomyTypes.js';
@@ -148,7 +149,7 @@ export function buildSignalContext(engine: DebateEngineInternals, round: number)
       },
     },
 
-    processRewards: (engine.session.process_rewards ?? []).slice(-12).map(pr => ({
+    processRewards: (engine.session.process_rewards ?? []).slice(-PROCESS_REWARD_SIGNAL_HISTORY_DEPTH).map(pr => ({
       round: pr.round, score: pr.score,
     })),
 

--- a/lib/debate/debateEngine/context.ts
+++ b/lib/debate/debateEngine/context.ts
@@ -4,6 +4,7 @@
 import type { DebateEngineInternals } from './internals.js';
 import { type SpeakerId, POVER_INFO } from '../types.js';
 import { formatCommitments, formatEstablishedPoints } from '../argumentNetwork.js';
+import { ESTABLISHED_POINTS_LIMIT } from '../debateConfig.js';
 
 // ── Commitment context ─────────────────────────────────────
 
@@ -30,5 +31,5 @@ export function getEstablishedPointsContext(engine: DebateEngineInternals, pover
     speaker: POVER_INFO[n.speaker as Exclude<SpeakerId, 'user'>]?.label ?? n.speaker,
   }));
 
-  return formatEstablishedPoints(allNodes, POVER_INFO[poverId].label, 14, an.edges.filter(e => e.type !== 'revoice_of') as { source: string; target: string; type: 'supports' | 'attacks' }[]);
+  return formatEstablishedPoints(allNodes, POVER_INFO[poverId].label, ESTABLISHED_POINTS_LIMIT, an.edges.filter(e => e.type !== 'revoice_of') as { source: string; target: string; type: 'supports' | 'attacks' }[]);
 }

--- a/lib/debate/debateEngine/doctrinal.ts
+++ b/lib/debate/debateEngine/doctrinal.ts
@@ -6,6 +6,7 @@ import { type ExtendedAIAdapter } from '../aiAdapter.js';
 import { POVER_INFO, type PovKey } from '../types.js';
 import { embedDoctrinalBoundaries, computeDoctrinalAnchoring, checkThresholdAnomalies } from '../doctrinalAnchoring.js';
 import { getGlobalRecorder } from '../../flight-recorder/index.js';
+import { DOCTRINAL_HARDCODED_BOUNDARY_WEIGHT, DOCTRINAL_SOFTCODED_BOUNDARY_WEIGHT } from '../debateConfig.js';
 
 // ── Doctrinal boundary embedding + anchoring (t/114) ─────
 
@@ -16,8 +17,6 @@ export async function setupDoctrinalAnchoring(engine: DebateEngineInternals): Pr
   // Collect boundary strings per active POV, separated by type
   const boundaries: Record<string, string[]> = {};
   const boundaryWeights: Record<string, number[]> = {};
-  const HARDCODED_WEIGHT = 1.0;
-  const SOFTCODED_WEIGHT = 0.7;
   for (const pover of engine.config.activePovers) {
     const info = POVER_INFO[pover];
     if (!info?.boundaries) continue;
@@ -26,8 +25,8 @@ export async function setupDoctrinalAnchoring(engine: DebateEngineInternals): Pr
     if (allBoundaries.length === 0) continue;
     boundaries[info.pov] = allBoundaries;
     boundaryWeights[info.pov] = [
-      ...hardcoded.map(() => HARDCODED_WEIGHT),
-      ...softcoded.map(() => SOFTCODED_WEIGHT),
+      ...hardcoded.map(() => DOCTRINAL_HARDCODED_BOUNDARY_WEIGHT),
+      ...softcoded.map(() => DOCTRINAL_SOFTCODED_BOUNDARY_WEIGHT),
     ];
   }
   if (Object.keys(boundaries).length === 0) return;

--- a/lib/debate/debateEngine/explorationSeeding.ts
+++ b/lib/debate/debateEngine/explorationSeeding.ts
@@ -3,6 +3,14 @@
 
 import type { DebateEngineInternals } from './internals.js';
 import { getGlobalRecorder } from '../../flight-recorder/index.js';
+import {
+  EXPLORATION_EFFECTIVE_SITUATION_BOOST,
+  EXPLORATION_INEFFECTIVE_SITUATION_PENALTY,
+  EXPLORATION_SEEDING_RECOMMENDATION_SLICE,
+  EXPLORATION_ROUNDS_CLAMP,
+  EXPLORATION_EXIT_THRESHOLD_CLAMP,
+  EXPLORATION_TEMPERATURE_CLAMP,
+} from '../debateConfig.js';
 
 export function seedExplorationSummary(engine: DebateEngineInternals, summary: import('../explorationSummary.js').ExplorationSummary): void {
   if (summary.topic.final !== engine.session.topic.final &&
@@ -34,10 +42,10 @@ export function seedExplorationSummary(engine: DebateEngineInternals, summary: i
 
   // Step 2: Situation pre-filtering — store boost/penalty factors
   for (const sit of summary.effective_situations) {
-    engine._explorationBoosts.set(sit.id, 0.15);
+    engine._explorationBoosts.set(sit.id, EXPLORATION_EFFECTIVE_SITUATION_BOOST);
   }
   for (const sit of summary.ineffective_situations) {
-    engine._explorationBoosts.set(sit.id, -0.10);
+    engine._explorationBoosts.set(sit.id, EXPLORATION_INEFFECTIVE_SITUATION_PENALTY);
   }
   if (engine._explorationBoosts.size > 0) {
     getGlobalRecorder()?.record({
@@ -55,7 +63,7 @@ export function seedExplorationSummary(engine: DebateEngineInternals, summary: i
   // Step 3: AN priming — format argument sketch for Brief prompt injection
   const topNodes = [...summary.argument_sketch.nodes]
     .sort((a, b) => b.computed_strength - a.computed_strength)
-    .slice(0, 10);
+    .slice(0, EXPLORATION_SEEDING_RECOMMENDATION_SLICE);
   const primingParts: string[] = [];
   if (topNodes.length > 0) {
     const nodeLines = topNodes.map(
@@ -119,16 +127,16 @@ export function applyExplorationConfigDefaults(engine: DebateEngineInternals): v
     return;
   }
   if (engine.config.maxTotalRounds == null) {
-    engine.config.maxTotalRounds = Math.min(20, Math.max(6, rc.max_rounds));
+    engine.config.maxTotalRounds = Math.min(EXPLORATION_ROUNDS_CLAMP[1], Math.max(EXPLORATION_ROUNDS_CLAMP[0], rc.max_rounds));
   }
   if (engine.config.argumentationExitThreshold == null) {
-    engine.config.argumentationExitThreshold = Math.min(0.9, Math.max(0.4, rc.argumentation_exit_threshold));
+    engine.config.argumentationExitThreshold = Math.min(EXPLORATION_EXIT_THRESHOLD_CLAMP[1], Math.max(EXPLORATION_EXIT_THRESHOLD_CLAMP[0], rc.argumentation_exit_threshold));
   }
   if (engine.config.concludingExitThreshold == null) {
-    engine.config.concludingExitThreshold = Math.min(0.9, Math.max(0.4, rc.concluding_exit_threshold));
+    engine.config.concludingExitThreshold = Math.min(EXPLORATION_EXIT_THRESHOLD_CLAMP[1], Math.max(EXPLORATION_EXIT_THRESHOLD_CLAMP[0], rc.concluding_exit_threshold));
   }
   if (engine.config.temperature == null) {
-    engine.config.temperature = Math.min(1.0, Math.max(0.3, rc.temperature));
+    engine.config.temperature = Math.min(EXPLORATION_TEMPERATURE_CLAMP[1], Math.max(EXPLORATION_TEMPERATURE_CLAMP[0], rc.temperature));
   }
   if (engine.config.pacing == null) {
     engine.config.pacing = rc.pacing;

--- a/lib/debate/debateEngine/perturbation.ts
+++ b/lib/debate/debateEngine/perturbation.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import type { DebateEngineInternals } from './internals.js';
+import { PERTURBATION_ARCO_BASELINE } from '../debateConfig.js';
 
 // ── Perturbation testing (HDE B2) ─────────────────────
 
@@ -34,7 +35,7 @@ export function computePerturbationResult(engine: DebateEngineInternals): void {
 
   const preArco = preSignals.length > 0
     ? preSignals.reduce((sum, s) => sum + s.arco!.turn_similarity, 0) / preSignals.length
-    : 0.5; // Default baseline if no pre-injection ArCo available
+    : PERTURBATION_ARCO_BASELINE;
   const postArco = postSignals.length > 0
     ? postSignals.reduce((sum, s) => sum + s.arco!.turn_similarity, 0) / postSignals.length
     : 0;

--- a/lib/debate/debateEngine/phases/crossRespond.ts
+++ b/lib/debate/debateEngine/phases/crossRespond.ts
@@ -30,6 +30,20 @@ import { resolveStageModel, resolveModelForSpeaker, recordRateLimit, clearRateLi
 import { _rescoreSituations, buildSignalContext, recordSignalHistory, updatePeakTracker, accumulateContextManifest } from '../adaptiveStaging.js';
 import { enrichTaxonomyRefs, getRelevantTaxonomyContext, formatDebaterEdgeContext, formatModeratorEdgeContext, routeTurnValidatorHints } from '../taxonomyContext.js';
 import { getCommitmentContext, getEstablishedPointsContext } from '../context.js';
+import {
+  MIDPOINT_NEUTRAL_EVAL_ROUND_CAP,
+  COMPRESSION_TRIGGER_TRANSCRIPT_LENGTH,
+  SOURCE_DOC_SUMMARY_CHAR_LIMIT,
+  CONCESSION_CANDIDATE_MIN_QBAF_STRENGTH,
+  RECENT_TRANSCRIPT_WINDOW_TURNS,
+  PRIOR_MOVES_DIVERSITY_WINDOW,
+  CROSS_POV_CITATION_ACTIVATION_ROUND,
+  CROSS_POV_NODE_DIVERSITY_LIMIT,
+  INSULARITY_INTERVENTION_COOLDOWN_ROUNDS,
+  INSULARITY_INTERVENTION_PER_SPEAKER_CAP,
+  JUDGE_TIMEOUT_MS,
+  OVERGEN_TRANSCRIPT_WINDOW_TURNS,
+} from '../../debateConfig.js';
 import { injectPerturbation } from '../perturbation.js';
 import { shouldTriggerDiversityRound, runDiversityRound } from './diversityInjection.js';
 import { runProbingQuestions } from './probingQuestions.js';
@@ -39,7 +53,7 @@ import type { TalmudicReferenceSelection } from '../../types.js';
 // ── Phase: Cross-respond round ─────────────────────────────
 
 export async function runFixedCrossRespond(engine: DebateEngineInternals): Promise<void> {
-  const midpointRound = Math.min(3, Math.ceil(engine.config.rounds / 2));
+  const midpointRound = Math.min(MIDPOINT_NEUTRAL_EVAL_ROUND_CAP, Math.ceil(engine.config.rounds / 2));
   const w = loadProvisionalWeights();
   let gcRan = false;
 
@@ -83,7 +97,7 @@ export async function runFixedCrossRespond(engine: DebateEngineInternals): Promi
       await runProbingQuestions(engine, round);
     }
 
-    if (engine.session.transcript.length >= 12) {
+    if (engine.session.transcript.length >= COMPRESSION_TRIGGER_TRANSCRIPT_LENGTH) {
       await engine._synthesisPipeline.compressContext();
     }
 
@@ -107,7 +121,7 @@ export async function runAdaptiveCrossRespond(engine: DebateEngineInternals): Pr
   let currentPhaseStartRound = 1;
   let currentPhaseExitReason = '';
 
-  const midpointRound = Math.min(3, Math.ceil(config.maxTotalRounds / 2));
+  const midpointRound = Math.min(MIDPOINT_NEUTRAL_EVAL_ROUND_CAP, Math.ceil(config.maxTotalRounds / 2));
 
   while (!terminated) {
     engine.checkAborted();
@@ -314,7 +328,7 @@ export async function runAdaptiveCrossRespond(engine: DebateEngineInternals): Pr
       await runProbingQuestions(engine, round);
     }
 
-    if (engine.session.transcript.length >= 12) {
+    if (engine.session.transcript.length >= COMPRESSION_TRIGGER_TRANSCRIPT_LENGTH) {
       await engine._synthesisPipeline.compressContext();
     }
 
@@ -333,7 +347,7 @@ export async function runCrossRespondRound(engine: DebateEngineInternals, round:
   engine.checkAborted();
 
   const sourceDocSummary = engine.session.document_analysis?.claims_summary
-    ?? (engine.session.source_content ? engine.session.source_content.slice(0, 2000) : undefined);
+    ?? (engine.session.source_content ? engine.session.source_content.slice(0, SOURCE_DOC_SUMMARY_CHAR_LIMIT) : undefined);
 
   const moderatorModel = resolveStageModel(engine, 'moderator');
   const selectionCallbacks: ModeratorSelectionCallbacks = {
@@ -484,14 +498,14 @@ export async function runCrossRespondRound(engine: DebateEngineInternals, round:
   const concessionCandidateIds = concessionHint
     ? (concessionAN!.nodes
         .filter(n => n.speaker !== responder)
-        .filter(n => (n.computed_strength ?? n.base_strength ?? 0) >= 0.65)
+        .filter(n => (n.computed_strength ?? n.base_strength ?? 0) >= CONCESSION_CANDIDATE_MIN_QBAF_STRENGTH)
         .filter(n => !concessionAN!.edges.some(e => e.type === 'attacks' && e.source && concessionAN!.nodes.find(x => x.id === e.source)?.speaker === responder && e.target === n.id))
         .filter(n => !priorConceded.includes(n.id) && !priorConceded.includes(n.text))
         .sort((a, b) => (b.computed_strength ?? 0) - (a.computed_strength ?? 0))
         .slice(0, 2)
         .map(n => n.id))
     : [];
-  const updatedTranscript = formatRecentTranscript(engine.session.transcript, 8, engine.session.context_summaries);
+  const updatedTranscript = formatRecentTranscript(engine.session.transcript, RECENT_TRANSCRIPT_WINDOW_TURNS, engine.session.context_summaries);
 
   // Collect this debater's prior move_types for diversity enforcement
   const debaterTurns = engine.session.transcript
@@ -500,7 +514,7 @@ export async function runCrossRespondRound(engine: DebateEngineInternals, round:
     .filter(e => e.metadata)
     .flatMap(e => ((e.metadata as Record<string, unknown>)?.move_types as (string | import('../../helpers.js').MoveAnnotation)[]) ?? [])
     .map(m => getMoveName(m))
-    .slice(-6); // Last 3 turns × ~2 moves each
+    .slice(-PRIOR_MOVES_DIVERSITY_WINDOW); // Last 3 turns × ~2 moves each
 
   // Count turns since this debater last used a CONCEDE move
   let turnsSinceLastConcession = debaterTurns.length; // default: never conceded
@@ -522,13 +536,13 @@ export async function runCrossRespondRound(engine: DebateEngineInternals, round:
   ];
 
   // Gather cross-POV node IDs for late-round citation diversity (Rec 3)
-  const crossPovNodeIds = round >= 4
+  const crossPovNodeIds = round >= CROSS_POV_CITATION_ACTIVATION_ROUND
     ? Object.entries(taxMap)
         .filter(([key]) => key !== info.pov && key !== 'policyRegistry')
         .flatMap(([, file]) => file?.nodes?.map(n => n.id) ?? [])
         .filter(id => !priorRefsEarly.includes(id))
         .sort(() => Math.random() - 0.5)
-        .slice(0, 8)
+        .slice(0, CROSS_POV_NODE_DIVERSITY_LIMIT)
     : undefined;
 
   // ── Insularity intervention (BEA RUE, t/1130) ──
@@ -549,8 +563,8 @@ export async function runCrossRespondRound(engine: DebateEngineInternals, round:
       const lastRoundForSpeaker = speakerInterventions.length > 0
         ? Math.max(...speakerInterventions.map(i => i.round))
         : -Infinity;
-      const cooldownOk = round - lastRoundForSpeaker >= 2;
-      const capOk = speakerInterventions.length < 2;
+      const cooldownOk = round - lastRoundForSpeaker >= INSULARITY_INTERVENTION_COOLDOWN_ROUNDS;
+      const capOk = speakerInterventions.length < INSULARITY_INTERVENTION_PER_SPEAKER_CAP;
 
       if (cooldownOk && capOk) {
         const allCampNodes = Object.entries(
@@ -786,9 +800,9 @@ export async function runCrossRespondRound(engine: DebateEngineInternals, round:
       preCheckGenerate,
     ),
     assembleResult: (result) => assemblePipelineResult(result, knownIds),
-    callJudge: (p, l) => engine.generateWithModel(p, l, vConfig.judgeModel, 20000),
+    callJudge: (p, l) => engine.generateWithModel(p, l, vConfig.judgeModel, JUDGE_TIMEOUT_MS),
     callJudgeFallback: engine.config.model !== vConfig.judgeModel
-      ? (p, l) => engine.generateWithModel(p, l, engine.config.model, 20000)
+      ? (p, l) => engine.generateWithModel(p, l, engine.config.model, JUDGE_TIMEOUT_MS)
       : undefined,
   };
 
@@ -869,7 +883,7 @@ export async function runCrossRespondRound(engine: DebateEngineInternals, round:
             label: poverInfo.label,
             pov: poverInfo.pov,
             topic: engine.session.topic.final,
-            recentTranscript: formatRecentTranscript(engine.session.transcript, 6, engine.session.context_summaries),
+            recentTranscript: formatRecentTranscript(engine.session.transcript, OVERGEN_TRANSCRIPT_WINDOW_TURNS, engine.session.context_summaries),
             audience: engine.config.audience,
             currentCruxContext: engine.session.crux_tracker?.length
               ? engine.session.crux_tracker.map(c => `- ${c.description} [${c.state}]`).join('\n')

--- a/lib/debate/debateEngine/phases/diversityInjection.ts
+++ b/lib/debate/debateEngine/phases/diversityInjection.ts
@@ -11,6 +11,12 @@ import { runTurnPipeline, assemblePipelineResult, type TurnPipelineInput } from 
 import { resolveModelForSpeaker, recordRateLimit, clearRateLimitBackoff, isRateLimitError } from '../modelResolution.js';
 import { enrichTaxonomyRefs, getRelevantTaxonomyContext, formatDebaterEdgeContext } from '../taxonomyContext.js';
 import { getCommitmentContext, getEstablishedPointsContext } from '../context.js';
+import {
+  DIVERSITY_MIN_ACTIVATION_ROUND,
+  DIVERSITY_REPETITION_RATE_THRESHOLD,
+  PRIOR_MOVES_DIVERSITY_WINDOW,
+  JUDGE_TIMEOUT_MS,
+} from '../../debateConfig.js';
 
 // ── Diversity-injection round (t/1280) ─────────────────────
 
@@ -18,7 +24,7 @@ export function shouldTriggerDiversityRound(engine: DebateEngineInternals, round
   if (!engine.config.enableDiversityRound) return false;
   if (phase !== 'argumentation') return false;
   if (engine.session.diversity_round_fired != null) return false;
-  if (round < 3) return false;
+  if (round < DIVERSITY_MIN_ACTIVATION_ROUND) return false;
 
   const signals = engine.session.convergence_signals ?? [];
   const recentSignals = signals.filter(s => s.round >= round - 1);
@@ -27,7 +33,7 @@ export function shouldTriggerDiversityRound(engine: DebateEngineInternals, round
     s => s.argument_redundancy?.semantically_recycled === true,
   ).length;
   const repetitionRate = recycledCount / recentSignals.length;
-  if (repetitionRate < 0.5) return false;
+  if (repetitionRate < DIVERSITY_REPETITION_RATE_THRESHOLD) return false;
 
   const diag = engine.session.diagnostics;
   if (!diag) return false;
@@ -91,7 +97,7 @@ export async function runDiversityRound(engine: DebateEngineInternals, round: nu
       .filter(e => e.metadata)
       .flatMap(e => ((e.metadata as Record<string, unknown>)?.move_types as (string | import('../../helpers.js').MoveAnnotation)[]) ?? [])
       .map(m => getMoveName(m))
-      .slice(-6);
+      .slice(-PRIOR_MOVES_DIVERSITY_WINDOW);
     let turnsSinceLastConcession = debaterTurns.length;
     for (let i = debaterTurns.length - 1; i >= 0; i--) {
       const moves = ((debaterTurns[i].metadata as Record<string, unknown>)?.move_types as (string | import('../../helpers.js').MoveAnnotation)[]) ?? [];
@@ -185,7 +191,7 @@ export async function runDiversityRound(engine: DebateEngineInternals, round: nu
         preCheckGenerate,
       ),
       assembleResult: (result) => assemblePipelineResult(result, knownIds),
-      callJudge: (p, l) => engine.generateWithModel(p, l, vConfig.judgeModel, 20000),
+      callJudge: (p, l) => engine.generateWithModel(p, l, vConfig.judgeModel, JUDGE_TIMEOUT_MS),
       callJudgeFallback: engine.config.model !== vConfig.judgeModel
         ? (p, l) => engine.generateWithModel(p, l, engine.config.model, 20000)
         : undefined,

--- a/lib/debate/debateEngine/phases/opening.ts
+++ b/lib/debate/debateEngine/phases/opening.ts
@@ -11,6 +11,7 @@ import { resolveModelForSpeaker } from '../modelResolution.js';
 import { accumulateContextManifest } from '../adaptiveStaging.js';
 import { enrichTaxonomyRefs, getRelevantTaxonomyContext, formatDebaterEdgeContext } from '../taxonomyContext.js';
 import { getCommitmentContext, getEstablishedPointsContext } from '../context.js';
+import { EMBEDDING_DIM } from '../../constants.js';
 
 // ── Phase: Opening statements ──────────────────────────────
 
@@ -190,7 +191,7 @@ export async function runOpeningStatements(engine: DebateEngineInternals): Promi
           engine.session.frame_embeddings ??= {};
           engine.session.frame_embeddings[poverId] = {
             model: 'all-MiniLM-L6-v2',
-            dim: 384,
+            dim: EMBEDDING_DIM,
             frames: frames.map((frame, i) => ({ frame, embedding: vecs[i] })),
           };
         }

--- a/lib/debate/debateEngine/phases/probingQuestions.ts
+++ b/lib/debate/debateEngine/phases/probingQuestions.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import type { DebateEngineInternals } from '../internals.js';
+import { PROBING_UNREFERENCED_NODES_CAP, PROBING_TRANSCRIPT_WINDOW_TURNS, PROBING_UNCOVERED_CLAIMS_LIMIT } from '../../debateConfig.js';
 import { POV_KEYS } from '../../types.js';
 import { probingQuestionsPrompt } from '../../prompts.js';
 import { parseJsonRobust, formatRecentTranscript } from '../../helpers.js';
@@ -23,13 +24,13 @@ export async function runProbingQuestions(engine: DebateEngineInternals, round: 
   for (const pov of POV_KEYS) {
     const nodes = engine.taxonomy[pov]?.nodes ?? [];
     for (const n of nodes) {
-      if (!referencedIds.has(n.id) && unreferencedNodes.length < 20) {
+      if (!referencedIds.has(n.id) && unreferencedNodes.length < PROBING_UNREFERENCED_NODES_CAP) {
         unreferencedNodes.push(`[${n.id}] ${n.label}: ${n.description.slice(0, 100)}`);
       }
     }
   }
 
-  const transcript = formatRecentTranscript(engine.session.transcript, 50, engine.session.context_summaries);
+  const transcript = formatRecentTranscript(engine.session.transcript, PROBING_TRANSCRIPT_WINDOW_TURNS, engine.session.context_summaries);
   const hasSourceDoc = engine.config.sourceType === 'document' || engine.config.sourceType === 'url';
 
   // CT-4/CT-11: Compute uncovered document claims, sorted by QBAF strength weight (load-bearing first)
@@ -50,7 +51,7 @@ export async function runProbingQuestions(engine: DebateEngineInternals, round: 
             const text = documentClaims.find(dc => dc.id === c.claimId)?.text ?? c.claimId;
             return `[${c.claimId}] ${text}`;
           })
-          .slice(0, 10);
+          .slice(0, PROBING_UNCOVERED_CLAIMS_LIMIT);
       } catch (err) {
         getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: 'Probing coverage computation failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
       }

--- a/lib/debate/debateEngine/taxonomyContext.ts
+++ b/lib/debate/debateEngine/taxonomyContext.ts
@@ -14,6 +14,15 @@ import { loadGreatestHitsFile } from '../corpusCoverage.js';
 import { ActionableError } from '../errors.js';
 import { filterByExclusionAbsolute, SCOPE_BOUNDARY_THRESHOLD } from '../exclusionGuard.js';
 import { getGlobalRecorder } from '../../flight-recorder/index.js';
+import {
+  TOPIC_SCORE_FLOOR_MULTIPLIER,
+  RECENT_CITATION_PENALTY_MULTIPLIER,
+  TAXONOMY_MIN_NODES_PER_BDI_DEFAULT,
+  TAXONOMY_MAX_POV_NODES_DEFAULT,
+  LINEAGE_BOOST_INCREMENT,
+  NON_APPROVED_EDGE_CONFIDENCE_FILTER,
+  EDGE_CONTEXT_TOP_N,
+} from '../debateConfig.js';
 
 export function getNodeLabelMap(engine: DebateEngineInternals): Map<string, string> {
   if (engine._nodeLabelMap) return engine._nodeLabelMap;
@@ -185,7 +194,7 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
     const allIds = new Set([...anScores.keys(), ...(topicScores?.keys() ?? [])]);
     for (const id of allIds) {
       const anScore = anScores.get(id) ?? 0;
-      const topicFloor = (topicScores?.get(id) ?? 0) * 0.5;
+      const topicFloor = (topicScores?.get(id) ?? 0) * TOPIC_SCORE_FLOOR_MULTIPLIER;
       scores.set(id, Math.max(anScore, topicFloor));
     }
   } else if (hasEmbeddings && adapter.computeQueryEmbedding) {
@@ -215,7 +224,7 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
   if (priorRefs.length > 0) {
     const recent = new Set(priorRefs);
     for (const [id, score] of scores) {
-      if (recent.has(id)) scores.set(id, score * 0.55);
+      if (recent.has(id)) scores.set(id, score * RECENT_CITATION_PENALTY_MULTIPLIER);
     }
   }
 
@@ -231,8 +240,8 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
     scoringMode,
     embeddingThreshold: 0.48,
     lexicalThreshold: 0.22,
-    minPerCategory: parseInt(process.env.TAXONOMY_MIN_PER_BDI || '') || 3,
-    maxTotal: parseInt(process.env.TAXONOMY_MAX_NODES || '') || 12,
+    minPerCategory: parseInt(process.env.TAXONOMY_MIN_PER_BDI || '') || TAXONOMY_MIN_NODES_PER_BDI_DEFAULT,
+    maxTotal: parseInt(process.env.TAXONOMY_MAX_NODES || '') || TAXONOMY_MAX_POV_NODES_DEFAULT,
     nodeEmbeddings: roundFocusVector ? engine.taxonomy.embeddings as Record<string, { pov: string; vector: number[]; exclusion_vector?: number[] }> : undefined,
     queryVector: roundFocusVector ?? undefined,
   };
@@ -257,7 +266,7 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
     }
     relevanceOpts.lineageBoost = {
       traditions: lineageFrame.map(f => f.cluster_id),
-      boost: 0.08,
+      boost: LINEAGE_BOOST_INCREMENT,
       lineageByNode,
       nameToCluster,
     };
@@ -460,7 +469,7 @@ export function formatDebaterEdgeContext(engine: DebateEngineInternals, debaterP
 
   const relevantEdges = engine.taxonomy.edges.edges.filter(e => {
     if (!signalTypes.has(e.type)) return false;
-    if (e.status !== 'approved' && e.confidence < 0.75) return false;
+    if (e.status !== 'approved' && e.confidence < NON_APPROVED_EDGE_CONFIDENCE_FILTER) return false;
     const srcIsMine = e.source.startsWith(myPrefix);
     const tgtIsMine = e.target.startsWith(myPrefix);
     const srcIsOther = otherPrefixes.some(p => e.source.startsWith(p));
@@ -470,7 +479,7 @@ export function formatDebaterEdgeContext(engine: DebateEngineInternals, debaterP
 
   if (relevantEdges.length === 0) return { text: '', edges_used: [] };
 
-  const top = relevantEdges.sort((a, b) => b.confidence - a.confidence).slice(0, 15);
+  const top = relevantEdges.sort((a, b) => b.confidence - a.confidence).slice(0, EDGE_CONTEXT_TOP_N);
   const lines = [
     '',
     '=== KNOWN TENSIONS WITH OPPOSING POSITIONS ===',
@@ -497,7 +506,7 @@ export function formatModeratorEdgeContext(engine: DebateEngineInternals): { tex
 
   const relevantEdges = engine.taxonomy.edges.edges.filter(e => {
     if (!signalTypes.has(e.type)) return false;
-    if (e.status !== 'approved' && e.confidence < 0.75) return false;
+    if (e.status !== 'approved' && e.confidence < NON_APPROVED_EDGE_CONFIDENCE_FILTER) return false;
     const srcPrefix = activePrefixes.find(p => e.source.startsWith(p));
     const tgtPrefix = activePrefixes.find(p => e.target.startsWith(p));
     return srcPrefix && tgtPrefix && srcPrefix !== tgtPrefix;
@@ -505,7 +514,7 @@ export function formatModeratorEdgeContext(engine: DebateEngineInternals): { tex
 
   if (relevantEdges.length === 0) return { text: '', edges_used: [] };
 
-  const top = relevantEdges.sort((a, b) => b.confidence - a.confidence).slice(0, 15);
+  const top = relevantEdges.sort((a, b) => b.confidence - a.confidence).slice(0, EDGE_CONTEXT_TOP_N);
   const lines = ['', '=== KNOWN TENSIONS BETWEEN POSITIONS ==='];
   for (const e of top) {
     lines.push(`${e.source} ${e.type} ${e.target} (confidence: ${e.confidence.toFixed(2)})`);


### PR DESCRIPTION
## Summary
- New `lib/debate/debateConfig.ts` exports ~35 named runtime-behavior constants (timeouts, thresholds, window sizes, multipliers, clamp ranges) previously scattered as inline magic numbers
- `EMBEDDING_DIM = 384` extracted to `constants.ts`
- All consumer files updated to import and use the named constants — value-identical, no behavioral change

## Test plan
- [x] `npx vitest run` — 2891/2902 tests pass (same skips as main)
- [x] Pre-existing TS errors in `lib/tsconfig.json` (electron-shared, sanitize, corpus_version) confirmed pre-existing on origin/main — no new errors introduced
- [x] Self-certified /trivial-change: value-identical renames, no logic change, no new public API

Closes t/2182 Phase 1.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)