### PR TITLE
fix(constants): complete DEFAULT_MODEL swap in vernacular.ts (t/2180)

### DIFF
--- a/taxonomy-editor/src/renderer/prompts/vernacular.ts
+++ b/taxonomy-editor/src/renderer/prompts/vernacular.ts
@@ -16,7 +16,7 @@ Rules:
 8. Use active voice when possible.
 9. Return ONLY the rewritten text — no labels, no explanation.`;
 
-export const VERNACULAR_MODEL = 'gemini-flash-lite-latest';
+export const VERNACULAR_MODEL = DEFAULT_MODEL;
 export const VERNACULAR_TEMPERATURE = 0.2;
 export const VERNACULAR_TIMEOUT = 15_000;
 export const VERNACULAR_VERSION = 'flash-lite:v1';


### PR DESCRIPTION
## Summary

Completes the fix from #486: the import was added but `VERNACULAR_MODEL` still used the hardcoded literal. One-line swap to `= DEFAULT_MODEL`.

Deviation: #486 missed this assignment — caught in post-merge review (t/2180#1).

## Test plan

- [x] `tsc -p tsconfig.main.json` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)