### PR TITLE
chore(devops): script + CI guard for dual-lockfile override sync (t/2188)

### DIFF
--- a/.github/scripts/check-lockfile-overrides.mjs
+++ b/.github/scripts/check-lockfile-overrides.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// .github/scripts/check-lockfile-overrides.mjs
+// Fails CI if pnpm-workspace.yaml overrides: diverges from taxonomy-editor/pnpm-lock.yaml.
+// Prevents ERR_PNPM_LOCKFILE_CONFIG_MISMATCH in the Dockerfile prod-deps stage (t/2188).
+//
+// Fix: node scripts/sync-standalone-lockfile.mjs
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const root = process.cwd()
+
+function stripQuotes(s) { return s.replace(/^['"]|['"]$/g, '') }
+
+function parseOverrides(content, label) {
+  const lines = content.split('\n')
+  const overrides = {}
+  let inOverrides = false
+  for (const line of lines) {
+    if (/^overrides:\s*$/.test(line)) { inOverrides = true; continue }
+    if (inOverrides) {
+      if (line.length > 0 && !/^\s/.test(line)) break
+      if (!line.trim()) continue
+      const m = line.match(/^\s+(.+?)\s*:\s+(.+?)\s*$/)
+      if (m) overrides[stripQuotes(m[1].trim())] = stripQuotes(m[2].trim())
+    }
+  }
+  if (!inOverrides) { console.error(`no overrides: block in ${label}`); process.exit(1) }
+  return overrides
+}
+
+const wsOverrides = parseOverrides(
+  readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf8'),
+  'pnpm-workspace.yaml',
+)
+const lfOverrides = parseOverrides(
+  readFileSync(join(root, 'taxonomy-editor', 'pnpm-lock.yaml'), 'utf8'),
+  'taxonomy-editor/pnpm-lock.yaml',
+)
+
+const allKeys = new Set([...Object.keys(wsOverrides), ...Object.keys(lfOverrides)])
+const mismatches = []
+for (const key of allKeys) {
+  const ws = wsOverrides[key]
+  const lf = lfOverrides[key]
+  if (ws !== lf) mismatches.push({ key, workspace: ws ?? '(missing)', lockfile: lf ?? '(missing)' })
+}
+
+if (mismatches.length > 0) {
+  console.error('FAIL: pnpm-workspace.yaml overrides != taxonomy-editor/pnpm-lock.yaml overrides')
+  console.error('Fix:  node scripts/sync-standalone-lockfile.mjs')
+  console.error('')
+  for (const { key, workspace, lockfile } of mismatches)
+    console.error(`  ${key}:  workspace=${workspace}  lockfile=${lockfile}`)
+  process.exit(1)
+}
+
+console.log(`OK: overrides in sync (${allKeys.size} entries)`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       lib: ${{ steps.filter.outputs.lib }}
       python: ${{ steps.filter.outputs.python }}
       container: ${{ steps.filter.outputs.container }}
+      lockfile-sync: ${{ steps.filter.outputs.lockfile-sync }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         id: filter
@@ -134,6 +135,13 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - '.npmrc'
+              - '.github/workflows/ci.yml'
+            # 'lockfile-sync' gates lockfile-overrides-check (t/2188). Triggers on any
+            # change to the two files the check compares — pnpm-workspace.yaml (source
+            # of truth for overrides) and taxonomy-editor/pnpm-lock.yaml (must match).
+            lockfile-sync:
+              - 'pnpm-workspace.yaml'
+              - 'taxonomy-editor/pnpm-lock.yaml'
               - '.github/workflows/ci.yml'
 
   test-powershell:
@@ -692,6 +700,26 @@ jobs:
           TRANSFORMERS_OFFLINE: '1'
         run: python .github/ci/assert_embed_stability.py
 
+  # ── lockfile-overrides-check: standalone lockfile divergence guard (t/2188) ──
+  # Confirms taxonomy-editor/pnpm-lock.yaml overrides: block matches root
+  # pnpm-workspace.yaml. A mismatch causes ERR_PNPM_LOCKFILE_CONFIG_MISMATCH in
+  # the Dockerfile prod-deps stage — three PRs rediscovered this (#478,#480,#485).
+  # Fix: node scripts/sync-standalone-lockfile.mjs
+  # Paths-filtered to pnpm-workspace.yaml + taxonomy-editor/pnpm-lock.yaml; skip = OK.
+  lockfile-overrides-check:
+    needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.lockfile-sync == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        with:
+          node-version: '22'
+      - name: Check lockfile overrides in sync
+        run: node .github/scripts/check-lockfile-overrides.mjs
+
   # ── dependency-coverage: build-path coverage check (t/2077) ────────────────
   # Parses taxonomy-editor/Dockerfile to derive which local packages are compiled
   # into the container but NOT installed by the prod-deps stage. Fails if any
@@ -739,7 +767,7 @@ jobs:
   # path-filtered to container/lib changes, skip = OK.
   ci-gate:
     name: ci-gate
-    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage]
+    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/sync-standalone-lockfile.mjs
+++ b/scripts/sync-standalone-lockfile.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// scripts/sync-standalone-lockfile.mjs
+// Regenerates taxonomy-editor/pnpm-lock.yaml to match root pnpm-workspace.yaml overrides.
+// Run after any change to the overrides: block in pnpm-workspace.yaml.
+//
+// Background: the Dockerfile prod-deps stage copies taxonomy-editor/pnpm-lock.yaml +
+// root pnpm-workspace.yaml and runs pnpm install --prod --frozen-lockfile. If the
+// standalone lockfile's overrides: block diverges from pnpm-workspace.yaml, pnpm
+// aborts with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH. A plain root `pnpm install` only
+// regenerates the root pnpm-lock.yaml — this script handles the standalone one.
+// (Three PRs rediscovered this the hard way: #478, #480, #485 — t/2185, t/2184.)
+
+import { readFileSync, writeFileSync, mkdtempSync, copyFileSync, rmSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { join, resolve, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const workspaceContent = readFileSync(join(repoRoot, 'pnpm-workspace.yaml'), 'utf8')
+
+function extractOverridesBlock(yaml) {
+  const lines = yaml.split('\n')
+  const result = []
+  let inOverrides = false
+  for (const line of lines) {
+    if (/^overrides:\s*$/.test(line)) {
+      inOverrides = true
+      result.push(line)
+      continue
+    }
+    if (inOverrides) {
+      if (line.length > 0 && !/^\s/.test(line)) break
+      result.push(line)
+    }
+  }
+  if (!inOverrides) throw new Error('No overrides: block found in pnpm-workspace.yaml')
+  return result.join('\n').trimEnd() + '\n'
+}
+
+const overridesBlock = extractOverridesBlock(workspaceContent)
+const tmpDir = mkdtempSync(join(tmpdir(), 'lockfile-sync-'))
+
+try {
+  writeFileSync(join(tmpDir, 'pnpm-workspace.yaml'), overridesBlock)
+  copyFileSync(join(repoRoot, 'taxonomy-editor', 'package.json'), join(tmpDir, 'package.json'))
+  copyFileSync(join(repoRoot, 'taxonomy-editor', 'pnpm-lock.yaml'), join(tmpDir, 'pnpm-lock.yaml'))
+  execSync('pnpm install --lockfile-only', { cwd: tmpDir, stdio: 'inherit' })
+  copyFileSync(join(tmpDir, 'pnpm-lock.yaml'), join(repoRoot, 'taxonomy-editor', 'pnpm-lock.yaml'))
+  console.log('taxonomy-editor/pnpm-lock.yaml updated')
+} finally {
+  rmSync(tmpDir, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- Adds `scripts/sync-standalone-lockfile.mjs` — one-command regen of `taxonomy-editor/pnpm-lock.yaml` from root `pnpm-workspace.yaml` overrides (automates the temp-dir method Rosetta used manually during t/2183)
- Adds `.github/scripts/check-lockfile-overrides.mjs` — CI script that compares the two `overrides:` blocks and exits non-zero on mismatch
- Adds `lockfile-overrides-check` CI job (paths-filtered to `pnpm-workspace.yaml` + `taxonomy-editor/pnpm-lock.yaml`, gated via `ci-gate`) — catches the divergence before `test-container` does

## Why
`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` in the Dockerfile prod-deps stage bit three PRs in the t/2183 Dependabot epic (#478, #480, #485). Each time the fix was rediscovered manually. This makes it a one-command fix and a CI gate.

## Test plan
- [ ] `node .github/scripts/check-lockfile-overrides.mjs` passes (7 entries in sync) — verified locally
- [ ] `lockfile-overrides-check` job appears green in CI checks
- [ ] `ci-gate` includes `lockfile-overrides-check` in its needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)