### PR TITLE
chore(ci): add workflow_dispatch to codeql.yml (t/2189)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,7 @@ on:
   schedule:
     # Weekly scan — catches new CVE patterns even without code changes
     - cron: '0 6 * * 1'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch:` to the `on:` block of `codeql.yml`
- No inputs needed — enables `gh workflow run codeql.yml --ref main` or the Actions "Run workflow" button
- Existing push/pull_request/schedule triggers unchanged

## Why
No way to manually kick a CodeQL scan of main to confirm a fix cleared an alert. Previously had to land another `.ts` change or wait for the Monday cron.

## Test plan
- [ ] `workflow_dispatch:` present in `on:` block, other triggers unmodified
- [ ] CI passes (CodeQL still fires on this PR as a pull_request trigger)
- [ ] After merge: verify `gh workflow run codeql.yml --ref main` starts a run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)