### PR TITLE
chore(debate): extract relevance thresholds into PROVISIONAL_WEIGHTS_FALLBACK (t/2187)

### DIFF
--- a/lib/debate/calibrationOptimizer.ts
+++ b/lib/debate/calibrationOptimizer.ts
@@ -27,6 +27,7 @@ import {
   replicationGateByConfig,
 } from './calibrationLogger.js';
 import { PINNED_EVALUATOR_MODEL } from './neutralEvaluator.js';
+import { PROVISIONAL_WEIGHTS_FALLBACK } from './phaseTransitions.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -238,11 +239,11 @@ export function applyRelevanceThresholdAdaptation(
       return { applied: false, reason: 'adaptation_enabled is false (manual override)' };
     }
 
-    const oldValue = weights.relevance?.embedding_threshold ?? 0.48;
+    const oldValue = weights.relevance?.embedding_threshold ?? PROVISIONAL_WEIGHTS_FALLBACK.relevance!.embedding_threshold;
     if (oldValue === newValue) {
       return { applied: false, reason: 'file already at recommended value' };
     }
-    if (!weights.relevance) weights.relevance = {};
+    if (!weights.relevance) weights.relevance = { ...PROVISIONAL_WEIGHTS_FALLBACK.relevance! };
     weights.relevance.embedding_threshold = newValue;
 
     // Record adjustment metadata

--- a/lib/debate/debateEngine/taxonomyContext.ts
+++ b/lib/debate/debateEngine/taxonomyContext.ts
@@ -23,6 +23,7 @@ import {
   NON_APPROVED_EDGE_CONFIDENCE_FILTER,
   EDGE_CONTEXT_TOP_N,
 } from '../debateConfig.js';
+import { loadProvisionalWeights } from '../phaseTransitions.js';
 
 export function getNodeLabelMap(engine: DebateEngineInternals): Map<string, string> {
   if (engine._nodeLabelMap) return engine._nodeLabelMap;
@@ -238,8 +239,8 @@ export async function getRelevantTaxonomyContext(engine: DebateEngineInternals, 
 
   const relevanceOpts: RelevanceOptions = {
     scoringMode,
-    embeddingThreshold: 0.48,
-    lexicalThreshold: 0.22,
+    embeddingThreshold: loadProvisionalWeights().relevance!.embedding_threshold,
+    lexicalThreshold: loadProvisionalWeights().relevance!.lexical_threshold,
     minPerCategory: parseInt(process.env.TAXONOMY_MIN_PER_BDI || '') || TAXONOMY_MIN_NODES_PER_BDI_DEFAULT,
     maxTotal: parseInt(process.env.TAXONOMY_MAX_NODES || '') || TAXONOMY_MAX_POV_NODES_DEFAULT,
     nodeEmbeddings: roundFocusVector ? engine.taxonomy.embeddings as Record<string, { pov: string; vector: number[]; exclusion_vector?: number[] }> : undefined,

--- a/lib/debate/phaseTransitions.test.ts
+++ b/lib/debate/phaseTransitions.test.ts
@@ -1461,3 +1461,14 @@ describe('calibration-config.json budget parity', () => {
     expect(PROVISIONAL_WEIGHTS_FALLBACK.budget).toEqual(jsonBudget);
   });
 });
+
+// ── Relevance parity gate (t/2187) ───────────────────────────
+describe('calibration-config.json relevance parity', () => {
+  it('hardcoded relevance thresholds match calibration-config.json relevance block', () => {
+    const { relevance: jsonRelevance } = calibrationConfigJson as unknown as {
+      relevance: { embedding_threshold: number; lexical_threshold: number };
+    };
+    expect(PROVISIONAL_WEIGHTS_FALLBACK.relevance?.embedding_threshold).toBe(jsonRelevance.embedding_threshold);
+    expect(PROVISIONAL_WEIGHTS_FALLBACK.relevance?.lexical_threshold).toBe(jsonRelevance.lexical_threshold);
+  });
+});

--- a/lib/debate/phaseTransitions.ts
+++ b/lib/debate/phaseTransitions.ts
@@ -49,6 +49,13 @@ interface ProvisionalWeights {
   crux_detection?: { min_base_strength: number; min_cross_pov_attackers: number; min_total_cross_pov_edges: number };
   /** Pinned neutral-evaluator model — calibration invariant (t/1846). */
   evaluator?: { model: string; version: number };
+  /** Calibration-coupled relevance thresholds (t/2187). Required fields mirror calibration-config.json. */
+  relevance?: {
+    embedding_threshold: number;
+    lexical_threshold: number;
+    adaptation_enabled?: boolean;
+    adaptation_history?: Array<{ from: number; to: number; timestamp: string; rationale?: string }>;
+  };
 }
 
 // Exported so the parity test can compare the hardcoded values directly against
@@ -78,6 +85,7 @@ export const PROVISIONAL_WEIGHTS_FALLBACK: ProvisionalWeights = {
   network: { gc_trigger: 175, gc_target: 150, hard_cap: 200 },
   budget: { soft_multiplier: 8, hard_multiplier: 15, max_soft_multiplier: 10 },
   evaluator: { model: 'gemini-3.5-flash-lite', version: 1 },
+  relevance: { embedding_threshold: 0.48, lexical_threshold: 0.22 },
 };
 
 let _cachedWeights: ProvisionalWeights | null = null;

--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -13,6 +13,7 @@ import type { TrackedCrux, ArgumentNetworkNode } from './types.js';
 import { stripExcludes } from './helpers.js';
 import { filterByExclusionRatio, type ExclusionFilterResult } from './exclusionGuard.js';
 import { POV_PREFIXES } from './nodeIdUtils.js';
+import { loadProvisionalWeights } from './phaseTransitions.js';
 import { WELL_TESTED_EXCLUSION, isReeligible } from './debateTested.js';
 
 export interface NodeRelevanceScore {
@@ -176,15 +177,15 @@ export function scoreNodeRelevanceMeanTopN(
 export function selectRelevantNodes(
   povNodes: PovNode[],
   scores: Map<string, number>,
-  thresholdOrOpts: number | RelevanceOptions = 0.48,
+  thresholdOrOpts: number | RelevanceOptions = loadProvisionalWeights().relevance!.embedding_threshold,
   minPerCategory: number = 3,
   maxTotal?: number,
 ): ScoredPovNode[] {
   const opts = typeof thresholdOrOpts === 'number' ? { threshold: thresholdOrOpts } : thresholdOrOpts;
   const threshold = opts.threshold ?? (
     opts.scoringMode === 'lexical'
-      ? (opts.lexicalThreshold ?? 0.22)
-      : (opts.embeddingThreshold ?? 0.48)
+      ? (opts.lexicalThreshold ?? loadProvisionalWeights().relevance!.lexical_threshold)
+      : (opts.embeddingThreshold ?? loadProvisionalWeights().relevance!.embedding_threshold)
   );
   minPerCategory = opts.minPerCategory ?? minPerCategory;
   maxTotal = opts.maxTotal ?? maxTotal;
@@ -443,15 +444,15 @@ export function buildSituationRootLookup(
 export function selectRelevantSituationNodes(
   situationNodes: SituationNode[],
   scores: Map<string, number>,
-  thresholdOrOpts: number | RelevanceOptions = 0.48,
+  thresholdOrOpts: number | RelevanceOptions = loadProvisionalWeights().relevance!.embedding_threshold,
   min: number = 3,
   max: number = 15,
 ): ScoredSituationNode[] {
   const opts = typeof thresholdOrOpts === 'number' ? { threshold: thresholdOrOpts } : thresholdOrOpts;
   const threshold = opts.threshold ?? (
     opts.scoringMode === 'lexical'
-      ? (opts.lexicalThreshold ?? 0.22)
-      : (opts.embeddingThreshold ?? 0.48)
+      ? (opts.lexicalThreshold ?? loadProvisionalWeights().relevance!.lexical_threshold)
+      : (opts.embeddingThreshold ?? loadProvisionalWeights().relevance!.embedding_threshold)
   );
 
   // Branch boosting: identify top root categories and boost their descendants


### PR DESCRIPTION
## Summary

- Moves calibration-coupled `0.48`/`0.22` embedding/lexical threshold literals out of `taxonomyRelevance.ts`, `taxonomyContext.ts`, and `calibrationOptimizer.ts` into `PROVISIONAL_WEIGHTS_FALLBACK.relevance` in `phaseTransitions.ts`
- Widens `ProvisionalWeights.relevance` interface to cover all fields already read by `calibrationOptimizer` (`adaptation_enabled`, `adaptation_history`)
- All production call sites use `loadProvisionalWeights().relevance!` at point-of-use (no module-level capture, so `resetWeightsCache()` is honoured)
- `calibrationOptimizer` empty-relevance init spreads fallback to populate both required fields
- Parity gate added to `phaseTransitions.test.ts` asserting fallback values match `calibration-config.json` relevance block

## Test plan

- [ ] `npx vitest run` in `lib/debate` — 2893 tests pass (116/117 files, 1 pre-existing skip)
- [ ] Parity gate `calibration-config.json relevance parity` passes
- [ ] No `0.48`/`0.22` literals remain in production `.ts` files under `lib/debate` (only in `phaseTransitions.ts` as the canonical fallback definition)
- [ ] `tsc -p lib/tsconfig.json` — no new errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)