### PR TITLE
fix(security): patch brace-expansion to 5.0.9 in npm bundle (CVE-2026-69152, t/2173)

### DIFF
--- a/deploy/azure/Dockerfile.base
+++ b/deploy/azure/Dockerfile.base
@@ -44,6 +44,14 @@ RUN npm pack ip-address@10.3.1 --pack-destination /tmp \
     && tar -xzf /tmp/ip-address-10.3.1.tgz --strip-components=1 \
          -C /usr/local/lib/node_modules/npm/node_modules/ip-address \
     && rm /tmp/ip-address-10.3.1.tgz
+# brace-expansion 5.0.9 fixes CVE-2026-69152 (HIGH). npm@latest bundles 5.0.7;
+# same npm pack + direct extraction pattern as ip-address above. (t/2173)
+RUN npm pack brace-expansion@5.0.9 --pack-destination /tmp \
+    && rm -rf /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
+    && mkdir -p /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
+    && tar -xzf /tmp/brace-expansion-5.0.9.tgz --strip-components=1 \
+         -C /usr/local/lib/node_modules/npm/node_modules/brace-expansion \
+    && rm /tmp/brace-expansion-5.0.9.tgz
 
 # System dependencies (runtime only — build tools like make/g++ live in the app
 # Dockerfile's builder stage, not here).


### PR DESCRIPTION
## Summary

- npm@latest bundles brace-expansion 5.0.7; CVE-2026-69152 (HIGH) fixed in 5.0.9
- Same `npm pack` + direct tarball extraction pattern as PR #489 (ip-address fix)
- Avoids running `npm install` inside npm's own package dir (would trigger @npmcli/docs 404)

## Test plan

- [ ] Base Image `build-and-push` succeeds
- [ ] Trivy scan shows brace-expansion 5.0.9, CVE-2026-69152 closed
- [ ] Security tab shows 0 open error alerts on main

Closes t/2173 (final error-severity CVE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)