### PR TITLE
fix(debate): build typePresence from injected situations only (t/2193)

### DIFF
--- a/lib/debate/taxonomyRelevance.ts
+++ b/lib/debate/taxonomyRelevance.ts
@@ -797,10 +797,12 @@ export function reScoreSituationsForCruxesDetailed(input: SituationReScoreInput)
     }
   }
 
-  // Count existing disagreement types for diversity bonus
+  // Count disagreement types already injected (not full candidate pool) for diversity bonus.
+  // A candidate whose type is not yet injected scores 1; using the full pool made has() always
+  // true and returned 0 for every node (t/2193).
   const typePresence = new Set<string>();
   for (const sit of input.situationNodes) {
-    if (sit.disagreement_type) typePresence.add(sit.disagreement_type);
+    if (input.injectedSitIds.has(sit.id) && sit.disagreement_type) typePresence.add(sit.disagreement_type);
   }
 
   for (const sit of input.situationNodes) {


### PR DESCRIPTION
## Summary
- `computeDiversityComponent` always returned 0 because `typePresence` was built from the full candidate pool — `has()` was trivially true for any node whose type appeared anywhere in the candidate set (t/2193)
- Fix: filter to `input.injectedSitIds` only, so `typePresence` reflects types already injected in this debate, not all candidate types
- Adds 3 regression tests: turn-1 all-1 case, mid-debate partial-subset case, and explicit pre-fix regression guard asserting non-zero diversity variance

## Test plan
- [x] `npx vitest run lib/debate/taxonomyRelevance.test.ts` — 62/62 pass (3 new diversity tests)
- [ ] CI green before merge
- [ ] AC2 (post-merge): run a situation-injecting debate, verify `diversity` shows non-zero variance in cal log

Closes t/2193

Co-Authored-By: DebateTool (Orca) <main.lib-debate@ai-triad-research.orca.local>