### PR TITLE
feat(diagnostics): add Get-ViteDevStatus cmdlet (t/2196)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -119,6 +119,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-FlightRecorderDump` | Pull flight recorder from server |
 | `Get-LatestFlightRecorderDump` | Find the most recent *non-stub* flight recorder dump (>10KB) for triage — skips the tiny startup/shutdown stubs that can be newer than the real dump (t/1712) |
 | `Get-AICostReport` | Token/cost usage report |
+| `Get-ViteDevStatus` | Vite dev server diagnostic — port owner, working dir, HTTP health, main/worktree/orphan classification (t/2196) |
 
 ### Config
 | Cmdlet | Use when |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -204,6 +204,8 @@
         'Get-EntityReport'
         # t/1894 — Entity ontology Phase 2-B: batch mention indexer (entity_mentions.json)
         'Update-EntityMentionIndex'
+        # t/2196 — Vite dev server diagnostic
+        'Get-ViteDevStatus'
     )
 
     # Aliases exported from this module

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -546,6 +546,21 @@ class OrganizationEdgeIntegrityReport {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+class ViteDevStatus {
+    [int]     $Port
+    [bool]    $Listening
+    [int]     $ProcessId
+    [string]  $ProcessName
+    [string]  $WorkingDirectory
+    [bool]    $IsMainRepo
+    [bool]    $IsRegisteredWorktree
+    [bool]    $IsOrphanedWorktree
+    [int]     $RootHttpStatus
+    [int]     $IndexHttpStatus
+    [string]  $Summary
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Module-scoped taxonomy store
 # ─────────────────────────────────────────────────────────────────────────────
 $script:TaxonomyData = @{}
@@ -901,6 +916,8 @@ Export-ModuleMember -Function @(
     'Get-EntityReport'
     # t/1894 — Entity ontology Phase 2-B: batch mention indexer (entity_mentions.json)
     'Update-EntityMentionIndex'
+    # t/2196 — Vite dev server diagnostic
+    'Get-ViteDevStatus'
 ) -Alias @(
     'Import-Document'
     'TaxonomyEditor'

--- a/scripts/AITriad/Public/Get-ViteDevStatus.ps1
+++ b/scripts/AITriad/Public/Get-ViteDevStatus.ps1
@@ -33,6 +33,12 @@ function Get-ViteWorktreeList {
     if ($out) { [string[]]$out } else { $null }
 }
 
+function Get-ViteCimProcess {
+    param([int]$ProcessId)
+    # Get-CimInstance is Windows-only; isolated here so tests can mock on Linux CI
+    Get-CimInstance Win32_Process -Filter "ProcessId = $ProcessId" -ErrorAction SilentlyContinue
+}
+
 function Get-ViteDevStatus {
     <#
     .SYNOPSIS
@@ -88,8 +94,7 @@ function Get-ViteDevStatus {
     $Result.ProcessId = $ListeningPid
 
     # ── Step 2: process info via CIM ───────────────────────────────────────────
-    $CimProc = Get-CimInstance Win32_Process -Filter "ProcessId = $ListeningPid" `
-        -ErrorAction SilentlyContinue
+    $CimProc = Get-ViteCimProcess -ProcessId $ListeningPid
     if ($CimProc) {
         $Result.ProcessName = [string]$CimProc.Name
         $CmdLine = if ($CimProc.PSObject.Properties['CommandLine'] -and $CimProc.CommandLine) {

--- a/scripts/AITriad/Public/Get-ViteDevStatus.ps1
+++ b/scripts/AITriad/Public/Get-ViteDevStatus.ps1
@@ -1,13 +1,36 @@
 # Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root.
 
-# Private helper — isolated so tests can mock via InModuleScope
+# Private helpers — isolated so tests can mock via InModuleScope
+
 function Get-ViteListeningPid {
     param([int]$Port)
     $lines = & netstat -ano 2>$null
     $match = $lines | Select-String -Pattern "TCP\s+\S+:$Port\s+\S+\s+LISTENING\s+(\d+)" |
         Select-Object -First 1
     if ($match) { [int]$match.Matches[0].Groups[1].Value } else { $null }
+}
+
+function Get-ViteHttpStatus {
+    param([string]$Uri, [int]$TimeoutSec)
+    try {
+        $r = Invoke-WebRequest -Uri $Uri -UseBasicParsing -TimeoutSec $TimeoutSec -ErrorAction Stop
+        [int]$r.StatusCode
+    } catch {
+        if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+    }
+}
+
+function Get-ViteGitRoot {
+    param([string]$Path)
+    $out = & git -C $Path rev-parse --show-toplevel 2>$null
+    if ($out) { ([string]$out).Trim() } else { $null }
+}
+
+function Get-ViteWorktreeList {
+    param([string]$RepoRoot)
+    $out = & git -C $RepoRoot worktree list --porcelain 2>$null
+    if ($out) { [string[]]$out } else { $null }
 }
 
 function Get-ViteDevStatus {
@@ -73,42 +96,25 @@ function Get-ViteDevStatus {
             [string]$CimProc.CommandLine
         } else { '' }
 
-        # Infer working directory: find \node_modules\ in CommandLine.
+        # Infer working directory: find \node_modules\ or /node_modules/ in CommandLine.
         # Everything before it is the Vite project dir; git rev-parse gives repo root.
         $NodeModulesIdx = $CmdLine.IndexOf('\node_modules\')
         if ($NodeModulesIdx -lt 0) { $NodeModulesIdx = $CmdLine.IndexOf('/node_modules/') }
         if ($NodeModulesIdx -ge 0) {
             $ProjectDir = $CmdLine.Substring(0, $NodeModulesIdx).Trim('"').Trim("'")
-            if ((Test-Path $ProjectDir -ErrorAction SilentlyContinue)) {
-                $GitRoot = & git -C $ProjectDir rev-parse --show-toplevel 2>$null
-                if ($GitRoot) {
-                    $Result.WorkingDirectory = ([string]$GitRoot).Trim()
-                } else {
-                    $Result.WorkingDirectory = $ProjectDir
-                }
+            $GitRoot = Get-ViteGitRoot -Path $ProjectDir
+            if ($GitRoot) {
+                $Result.WorkingDirectory = $GitRoot
+            } else {
+                $Result.WorkingDirectory = $ProjectDir
             }
         }
     }
 
     # ── Step 3: HTTP health probes ─────────────────────────────────────────────
     $BaseUrl = "http://localhost:$Port"
-    foreach ($Path in @('/', '/index.tsx')) {
-        $Code = 0
-        try {
-            $Resp = Invoke-WebRequest -Uri "$BaseUrl$Path" -UseBasicParsing `
-                -TimeoutSec $TimeoutSec -ErrorAction Stop
-            $Code = [int]$Resp.StatusCode
-        } catch {
-            if ($_.Exception.Response) {
-                $Code = [int]$_.Exception.Response.StatusCode
-            }
-        }
-        if ($Path -eq '/') {
-            $Result.RootHttpStatus = $Code
-        } else {
-            $Result.IndexHttpStatus = $Code
-        }
-    }
+    $Result.RootHttpStatus  = Get-ViteHttpStatus -Uri "$BaseUrl/"         -TimeoutSec $TimeoutSec
+    $Result.IndexHttpStatus = Get-ViteHttpStatus -Uri "$BaseUrl/index.tsx" -TimeoutSec $TimeoutSec
 
     # ── Step 4: worktree classification ────────────────────────────────────────
     if ($Result.WorkingDirectory) {
@@ -119,7 +125,7 @@ function Get-ViteDevStatus {
         if ($WorkDir -ieq $MainRoot) {
             $Result.IsMainRepo = $true
         } else {
-            $WorktreeRaw = & git -C $MainRoot worktree list --porcelain 2>$null
+            $WorktreeRaw = Get-ViteWorktreeList -RepoRoot $MainRoot
             if ($WorktreeRaw) {
                 $RegisteredPaths = @($WorktreeRaw | Select-String '^worktree ' |
                     ForEach-Object { $_.Line.Substring('worktree '.Length) })

--- a/scripts/AITriad/Public/Get-ViteDevStatus.ps1
+++ b/scripts/AITriad/Public/Get-ViteDevStatus.ps1
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# Private helper — isolated so tests can mock via InModuleScope
+function Get-ViteListeningPid {
+    param([int]$Port)
+    $lines = & netstat -ano 2>$null
+    $match = $lines | Select-String -Pattern "TCP\s+\S+:$Port\s+\S+\s+LISTENING\s+(\d+)" |
+        Select-Object -First 1
+    if ($match) { [int]$match.Matches[0].Groups[1].Value } else { $null }
+}
+
+function Get-ViteDevStatus {
+    <#
+    .SYNOPSIS
+        Reports the status of a Vite dev server on a given port.
+    .DESCRIPTION
+        Identifies the process listening on port 5173 (or a custom port),
+        resolves its working directory from the process CommandLine, performs
+        HTTP health probes against / and /index.tsx, and classifies whether
+        the process is running from the main repo, a registered git worktree,
+        or an orphaned worktree.
+
+        Background: diagnosing t/2113 Q4 required manual netstat + process
+        list + curl + worktree tracing. This cmdlet covers that in one call.
+    .PARAMETER Port
+        Port to check. Default: 5173 (Vite default).
+    .PARAMETER TimeoutSec
+        HTTP probe timeout in seconds (1–30). Default: 3.
+    .EXAMPLE
+        Get-ViteDevStatus
+    .EXAMPLE
+        Get-ViteDevStatus -Port 5174 | Format-List
+    .EXAMPLE
+        (Get-ViteDevStatus).IsOrphanedWorktree
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Test-TaxEditorHealth
+    #>
+    [CmdletBinding()]
+    [OutputType('ViteDevStatus')]
+    param(
+        [ValidateRange(1, 65535)]
+        [int]$Port = 5173,
+
+        [ValidateRange(1, 30)]
+        [int]$TimeoutSec = 3
+    )
+
+    Set-StrictMode -Version Latest
+    $PSNativeCommandUseErrorActionPreference = $false
+
+    $Result = [ViteDevStatus]::new()
+    $Result.Port = $Port
+
+    # ── Step 1: port check ─────────────────────────────────────────────────────
+    $ListeningPid = Get-ViteListeningPid -Port $Port
+    if ($null -eq $ListeningPid) {
+        $Result.Listening = $false
+        $Result.Summary = "Port $Port is not in use."
+        return $Result
+    }
+    $Result.Listening = $true
+    $Result.ProcessId = $ListeningPid
+
+    # ── Step 2: process info via CIM ───────────────────────────────────────────
+    $CimProc = Get-CimInstance Win32_Process -Filter "ProcessId = $ListeningPid" `
+        -ErrorAction SilentlyContinue
+    if ($CimProc) {
+        $Result.ProcessName = [string]$CimProc.Name
+        $CmdLine = if ($CimProc.PSObject.Properties['CommandLine'] -and $CimProc.CommandLine) {
+            [string]$CimProc.CommandLine
+        } else { '' }
+
+        # Infer working directory: find \node_modules\ in CommandLine.
+        # Everything before it is the Vite project dir; git rev-parse gives repo root.
+        $NodeModulesIdx = $CmdLine.IndexOf('\node_modules\')
+        if ($NodeModulesIdx -lt 0) { $NodeModulesIdx = $CmdLine.IndexOf('/node_modules/') }
+        if ($NodeModulesIdx -ge 0) {
+            $ProjectDir = $CmdLine.Substring(0, $NodeModulesIdx).Trim('"').Trim("'")
+            if ((Test-Path $ProjectDir -ErrorAction SilentlyContinue)) {
+                $GitRoot = & git -C $ProjectDir rev-parse --show-toplevel 2>$null
+                if ($GitRoot) {
+                    $Result.WorkingDirectory = ([string]$GitRoot).Trim()
+                } else {
+                    $Result.WorkingDirectory = $ProjectDir
+                }
+            }
+        }
+    }
+
+    # ── Step 3: HTTP health probes ─────────────────────────────────────────────
+    $BaseUrl = "http://localhost:$Port"
+    foreach ($Path in @('/', '/index.tsx')) {
+        $Code = 0
+        try {
+            $Resp = Invoke-WebRequest -Uri "$BaseUrl$Path" -UseBasicParsing `
+                -TimeoutSec $TimeoutSec -ErrorAction Stop
+            $Code = [int]$Resp.StatusCode
+        } catch {
+            if ($_.Exception.Response) {
+                $Code = [int]$_.Exception.Response.StatusCode
+            }
+        }
+        if ($Path -eq '/') {
+            $Result.RootHttpStatus = $Code
+        } else {
+            $Result.IndexHttpStatus = $Code
+        }
+    }
+
+    # ── Step 4: worktree classification ────────────────────────────────────────
+    if ($Result.WorkingDirectory) {
+        # $script:RepoRoot is set by AITriad.psm1 during module load
+        $MainRoot = $script:RepoRoot.TrimEnd('/\')
+        $WorkDir  = $Result.WorkingDirectory.TrimEnd('/\')
+
+        if ($WorkDir -ieq $MainRoot) {
+            $Result.IsMainRepo = $true
+        } else {
+            $WorktreeRaw = & git -C $MainRoot worktree list --porcelain 2>$null
+            if ($WorktreeRaw) {
+                $RegisteredPaths = @($WorktreeRaw | Select-String '^worktree ' |
+                    ForEach-Object { $_.Line.Substring('worktree '.Length) })
+                $OtherWorktrees  = @($RegisteredPaths | Where-Object { $_.TrimEnd('/\') -ine $MainRoot })
+                $IsRegistered    = @($OtherWorktrees  | Where-Object { $_.TrimEnd('/\') -ieq $WorkDir }).Count -gt 0
+                if ($IsRegistered) {
+                    $Result.IsRegisteredWorktree = $true
+                } else {
+                    $Result.IsOrphanedWorktree = $true
+                }
+            }
+        }
+    }
+
+    # ── Step 5: summary ────────────────────────────────────────────────────────
+    $Location = if     ($Result.IsMainRepo)           { 'main repo' }
+                elseif ($Result.IsRegisteredWorktree) { 'registered worktree' }
+                elseif ($Result.IsOrphanedWorktree)   { 'ORPHANED worktree' }
+                else                                  { 'unknown location' }
+
+    $HttpInfo      = "/ -> $($Result.RootHttpStatus), /index.tsx -> $($Result.IndexHttpStatus)"
+    $Result.Summary = "PID $($Result.ProcessId) ($($Result.ProcessName)) | $Location | HTTP: $HttpInfo"
+
+    $Result
+}

--- a/tests/Get-ViteDevStatus.Tests.ps1
+++ b/tests/Get-ViteDevStatus.Tests.ps1
@@ -1,0 +1,94 @@
+# Tag: health (t/2196)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-ViteDevStatus' -Tag 'health' {
+
+    It 'Is exported from the module' {
+        Get-Command Get-ViteDevStatus -Module AITriad -ErrorAction Stop | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Has Port and TimeoutSec parameters' {
+        $cmd = Get-Command Get-ViteDevStatus -Module AITriad -ErrorAction Stop
+        ($cmd.Parameters.Keys -contains 'Port')       | Should -Be $true
+        ($cmd.Parameters.Keys -contains 'TimeoutSec') | Should -Be $true
+    }
+
+    It 'Returns Listening=false and early-exit summary when port is not in use' {
+        InModuleScope AITriad {
+            Mock Get-ViteListeningPid { $null }
+            $r = Get-ViteDevStatus -Port 5173
+            $r.GetType().Name | Should -Be 'ViteDevStatus'
+            $r.Listening      | Should -Be $false
+            $r.Summary        | Should -BeLike '*not in use*'
+        }
+    }
+
+    It 'Returns ViteDevStatus object with populated fields on happy path' {
+        InModuleScope AITriad {
+            Mock Get-ViteListeningPid { 9999 }
+            Mock Get-CimInstance {
+                [PSCustomObject]@{
+                    Name        = 'node.exe'
+                    CommandLine = '"C:\Program Files\nodejs\node.exe" "C:\repos\main\taxonomy-editor\node_modules\.bin\vite"'
+                }
+            }
+            Mock Invoke-WebRequest {
+                param($Uri)
+                [PSCustomObject]@{ StatusCode = 200 }
+            }
+
+            # stub git calls to avoid hitting real filesystem
+            Mock git { 'C:\repos\main' } -ParameterFilter { $args -contains 'rev-parse' }
+            Mock git {
+                'worktree C:\repos\main'
+            } -ParameterFilter { $args -contains 'list' }
+
+            $r = Get-ViteDevStatus -Port 5173
+            $r.GetType().Name | Should -Be 'ViteDevStatus'
+            $r.Listening      | Should -Be $true
+            $r.ProcessId      | Should -Be 9999
+            $r.ProcessName    | Should -Be 'node.exe'
+            $r.RootHttpStatus | Should -Be 200
+            $r.Summary        | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'Sets IsOrphanedWorktree=$true when workdir not in git worktree list' {
+        InModuleScope AITriad {
+            Mock Get-ViteListeningPid { 9999 }
+            # Quoted path so Trim('"') strips cleanly; wt-2196 root is guaranteed to exist
+            Mock Get-CimInstance {
+                [PSCustomObject]@{
+                    Name        = 'node.exe'
+                    CommandLine = '"C:\Users\jsnov\repos\wt-2196\node_modules\.bin\vite"'
+                }
+            }
+            Mock Invoke-WebRequest { [PSCustomObject]@{ StatusCode = 200 } }
+            # rev-parse resolves to an orphan path distinct from anything in the worktree list
+            Mock git { 'C:\repos\orphan-unregistered' } -ParameterFilter { $args -contains 'rev-parse' }
+            # worktree list contains only main — not the orphan path
+            Mock git { 'worktree C:\repos\main-only' } -ParameterFilter { $args -contains 'list' }
+
+            $r = Get-ViteDevStatus -Port 5173
+            $r.IsOrphanedWorktree   | Should -Be $true
+            $r.IsMainRepo           | Should -Be $false
+            $r.IsRegisteredWorktree | Should -Be $false
+        }
+    }
+}
+
+Describe 'Get-ViteDevStatus - manifest' -Tag 'health' {
+    It 'FunctionsToExport includes Get-ViteDevStatus' {
+        $manifestPath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psd1'
+        $manifest = Test-ModuleManifest -Path $manifestPath
+        $manifest.ExportedFunctions.Keys | Should -Contain 'Get-ViteDevStatus'
+    }
+}

--- a/tests/Get-ViteDevStatus.Tests.ps1
+++ b/tests/Get-ViteDevStatus.Tests.ps1
@@ -37,19 +37,14 @@ Describe 'Get-ViteDevStatus' -Tag 'health' {
             Mock Get-CimInstance {
                 [PSCustomObject]@{
                     Name        = 'node.exe'
-                    CommandLine = '"C:\Program Files\nodejs\node.exe" "C:\repos\main\taxonomy-editor\node_modules\.bin\vite"'
+                    CommandLine = '"C:\repos\main\taxonomy-editor\node_modules\.bin\vite"'
                 }
             }
-            Mock Invoke-WebRequest {
-                param($Uri)
-                [PSCustomObject]@{ StatusCode = 200 }
+            Mock Get-ViteHttpStatus { 200 }
+            Mock Get-ViteGitRoot   { 'C:\repos\main' }
+            Mock Get-ViteWorktreeList {
+                @('worktree C:\repos\main', 'HEAD abc123', 'branch refs/heads/main')
             }
-
-            # stub git calls to avoid hitting real filesystem
-            Mock git { 'C:\repos\main' } -ParameterFilter { $args -contains 'rev-parse' }
-            Mock git {
-                'worktree C:\repos\main'
-            } -ParameterFilter { $args -contains 'list' }
 
             $r = Get-ViteDevStatus -Port 5173
             $r.GetType().Name | Should -Be 'ViteDevStatus'
@@ -64,18 +59,19 @@ Describe 'Get-ViteDevStatus' -Tag 'health' {
     It 'Sets IsOrphanedWorktree=$true when workdir not in git worktree list' {
         InModuleScope AITriad {
             Mock Get-ViteListeningPid { 9999 }
-            # Quoted path so Trim('"') strips cleanly; wt-2196 root is guaranteed to exist
             Mock Get-CimInstance {
                 [PSCustomObject]@{
                     Name        = 'node.exe'
-                    CommandLine = '"C:\Users\jsnov\repos\wt-2196\node_modules\.bin\vite"'
+                    CommandLine = '"C:\repos\orphan\node_modules\.bin\vite"'
                 }
             }
-            Mock Invoke-WebRequest { [PSCustomObject]@{ StatusCode = 200 } }
-            # rev-parse resolves to an orphan path distinct from anything in the worktree list
-            Mock git { 'C:\repos\orphan-unregistered' } -ParameterFilter { $args -contains 'rev-parse' }
-            # worktree list contains only main — not the orphan path
-            Mock git { 'worktree C:\repos\main-only' } -ParameterFilter { $args -contains 'list' }
+            Mock Get-ViteHttpStatus { 200 }
+            # rev-parse resolves to an orphan path not in the worktree list
+            Mock Get-ViteGitRoot { 'C:\repos\orphan-unregistered' }
+            # worktree list contains only main — the orphan path is absent
+            Mock Get-ViteWorktreeList {
+                @('worktree C:\repos\main-only', 'HEAD abc123', 'branch refs/heads/main')
+            }
 
             $r = Get-ViteDevStatus -Port 5173
             $r.IsOrphanedWorktree   | Should -Be $true

--- a/tests/Get-ViteDevStatus.Tests.ps1
+++ b/tests/Get-ViteDevStatus.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'Get-ViteDevStatus' -Tag 'health' {
     It 'Returns ViteDevStatus object with populated fields on happy path' {
         InModuleScope AITriad {
             Mock Get-ViteListeningPid { 9999 }
-            Mock Get-CimInstance {
+            Mock Get-ViteCimProcess {
                 [PSCustomObject]@{
                     Name        = 'node.exe'
                     CommandLine = '"C:\repos\main\taxonomy-editor\node_modules\.bin\vite"'
@@ -59,7 +59,7 @@ Describe 'Get-ViteDevStatus' -Tag 'health' {
     It 'Sets IsOrphanedWorktree=$true when workdir not in git worktree list' {
         InModuleScope AITriad {
             Mock Get-ViteListeningPid { 9999 }
-            Mock Get-CimInstance {
+            Mock Get-ViteCimProcess {
                 [PSCustomObject]@{
                     Name        = 'node.exe'
                     CommandLine = '"C:\repos\orphan\node_modules\.bin\vite"'


### PR DESCRIPTION
## Summary
- New `Get-ViteDevStatus` cmdlet: port 5173 owner detection, working-dir inference from CommandLine node_modules path, HTTP health probes (`/` and `/index.tsx`), git worktree classification (main / registered / orphaned)
- `ViteDevStatus` typed class added to `AITriad.psm1`
- Cmdlet-reference entry added under Health & Diagnostics
- 6 Pester tests: exported, parameters, not-listening, happy-path mock, orphan detection, manifest

## Test plan
- [x] `Invoke-Pester tests/Get-ViteDevStatus.Tests.ps1` -- 6/6 pass
- [x] `Test-ModuleManifest` passes
- [x] Self-certified under `/add-ps-cmdlet` -- no deviations

Closes t/2196

Generated with Claude Code