### PR TITLE
feat(debate): thread phaseBoundsOverride through CLI/batch config (t/2197)

### DIFF
--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -60,6 +60,7 @@ interface CLIConfig {
   pacing?: 'tight' | 'moderate' | 'thorough';
   maxTotalRounds?: number;
   allowEarlyTermination?: boolean;
+  phaseBoundsOverride?: { maxConfrontationRounds?: number; maxArgumentationRounds?: number; maxConcludingRounds?: number };
   throttleMs?: number;
   perturbation?: {
     inject_at_turn: number;
@@ -435,6 +436,7 @@ async function main(): Promise<void> {
     pacing: config.pacing,
     maxTotalRounds: config.maxTotalRounds,
     allowEarlyTermination: config.allowEarlyTermination,
+    phaseBoundsOverride: config.phaseBoundsOverride,
     throttleMs: config.throttleMs,
     perturbation: resolvePerturbationConfig(config, perturbationPrompt, perturbationTurn),
     salienceBeacon: config.salienceBeacon,

--- a/lib/debate/debateEngine.lifecycle.test.ts
+++ b/lib/debate/debateEngine.lifecycle.test.ts
@@ -1075,8 +1075,7 @@ describe('Finalization', () => {
 
 describe('Adaptive staging initialization', () => {
   it('accepts phaseBoundsOverride in DebateConfig and preserves it on the engine config (t/2197)', () => {
-    // _adaptiveConfig is built inside run(); this test verifies the field is accepted
-    // on DebateConfig and stored, so run() can wire it into PhaseTransitionConfig.
+    // _adaptiveConfig is built inside run(); verify the field survives to engine.config so run() can wire it.
     const override = { maxArgumentationRounds: 8, maxConcludingRounds: 2 };
     const config = createDefaultConfig({ useAdaptiveStaging: true, phaseBoundsOverride: override });
     const engine = new DebateEngine(config, createMockAdapter(), createMinimalTaxonomy());

--- a/lib/debate/debateEngine.lifecycle.test.ts
+++ b/lib/debate/debateEngine.lifecycle.test.ts
@@ -1074,6 +1074,16 @@ describe('Finalization', () => {
 // ── Adaptive staging initialization ─────────────────────
 
 describe('Adaptive staging initialization', () => {
+  it('accepts phaseBoundsOverride in DebateConfig and preserves it on the engine config (t/2197)', () => {
+    // _adaptiveConfig is built inside run(); this test verifies the field is accepted
+    // on DebateConfig and stored, so run() can wire it into PhaseTransitionConfig.
+    const override = { maxArgumentationRounds: 8, maxConcludingRounds: 2 };
+    const config = createDefaultConfig({ useAdaptiveStaging: true, phaseBoundsOverride: override });
+    const engine = new DebateEngine(config, createMockAdapter(), createMinimalTaxonomy());
+    const stored = (engine as unknown as { config: { phaseBoundsOverride?: typeof override } }).config.phaseBoundsOverride;
+    expect(stored).toEqual(override);
+  });
+
   it('does not create adaptive diagnostics when useAdaptiveStaging is false', async () => {
     const responses: string[] = [];
     for (let i = 0; i < 200; i++) {

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -1041,6 +1041,7 @@ export class DebateEngine {
         argumentationExitThreshold: this.config.argumentationExitThreshold ?? preset.argumentationExit,
         concludingExitThreshold: this.config.concludingExitThreshold ?? preset.concludingExit,
         allowEarlyTermination: this.config.allowEarlyTermination ?? true,
+        phaseBoundsOverride: this.config.phaseBoundsOverride,
       };
       this._phaseState = initPhaseState(this._adaptiveConfig);
       this._signalRegistry = buildSignalRegistry();

--- a/lib/debate/debateEngine/internals.ts
+++ b/lib/debate/debateEngine/internals.ts
@@ -64,6 +64,8 @@ export interface DebateConfig {
   concludingExitThreshold?: number;
   /** Allow early termination on health collapse. Default: true when adaptive staging is on. */
   allowEarlyTermination?: boolean;
+  /** Per-phase max-round overrides — passed into PhaseTransitionConfig so phaseTransitions.ts applies them. */
+  phaseBoundsOverride?: import('../types/phase.js').PhaseBoundsOverride;
   /** AbortSignal for external cancellation. When aborted, the engine stops at the next checkpoint. */
   signal?: AbortSignal;
   /** Model cost-tier ceiling for the failover chain. When set, `buildFailoverChain` filters out models with a higher tier rank than this model. Prevents cheap-run cost escalation via fallback. */


### PR DESCRIPTION
## Summary
- Add `phaseBoundsOverride?: PhaseBoundsOverride` to `DebateConfig` (`debateEngine/internals.ts`) and `CLIConfig` (`cli.ts`)
- Pass through at the `_adaptiveConfig` construction site in `debateEngine.ts` (alongside `pacing`/`maxTotalRounds`/`allowEarlyTermination`)
- Engine already consumes the field in `phaseTransitions.ts` — this is pure config-surface plumbing
- Adds engine-wiring test asserting the override is preserved on the engine config

## Test plan
- [x] `npx vitest run debateEngine.lifecycle.test.ts` — 47/47 pass
- [ ] CI green before merge

Closes t/2197

Co-Authored-By: DebateTool (Orca) <main.lib-debate@ai-triad-research.orca.local>