### PR TITLE
fix(githooks): prune .worktrees in AGENTS.md ownership audit — unblock fleet commits (t/2080)

### DIFF
--- a/.githooks/agent-file-owner.sh
+++ b/.githooks/agent-file-owner.sh
@@ -68,11 +68,14 @@ main_tracked()    { git -C "$root" ls-files -- '*AGENTS.md' 'AGENTS.md' 2>/dev/n
 overlay_tracked() { [ "$have_overlay" -eq 1 ] || return 0
                     ogit ls-files -- '*AGENTS.md' 'AGENTS.md' 2>/dev/null | sort -u; }
 
-# Prune the expensive/irrelevant trees. `.claude` holds linked worktrees, whose
-# AGENTS.md are checkouts of the same tracked paths and would double-count.
+# Prune the expensive/irrelevant trees. `.claude` and `.worktrees` both hold
+# linked worktrees, whose AGENTS.md are checkouts of the same tracked paths —
+# walking them double-counts and false-positives as tracked-by-neither at their
+# nested paths (t/2080 recurrence: fleet uses BOTH worktree roots). Adding a
+# third worktree location must be reflected here.
 on_disk() {
   ( cd "$root" && find . \
-      \( -name node_modules -o -name .git -o -name .orca-git -o -name .claude \
+      \( -name node_modules -o -name .git -o -name .orca-git -o -name .claude -o -name .worktrees \
          -o -name dist -o -name build -o -name out \) -prune \
       -o -name AGENTS.md -print 2>/dev/null ) | sed 's|^\./||' | sort -u
 }


### PR DESCRIPTION
## Fleet-wide blocker (Sage pattern #146, 4 instances)
The pre-commit AGENTS.md ownership audit exits 1 → every commit needs `--no-verify`.

## Root cause — worktree false-positive, NOT overlay drift
`on_disk()` prunes `.claude` (one linked-worktree root) but **not `.worktrees`** — the fleet's other worktree root. `find` descends into nested worktree checkouts and flags their `AGENTS.md` as `TRACKED BY NEITHER`:
```
.worktrees/t2193/AGENTS.md
.worktrees/t2193/operations/devops/azure/AGENTS.md
.worktrees/t2197/AGENTS.md   … etc
```
These are **checkouts of the main-tracked root/azure `AGENTS.md`** at nested paths — legit, not orphans. `ogit add -f` on them would be **wrong** (transient worktree paths in the overlay). This is why agents used `--no-verify`. Worsens as worktrees proliferate.

## Fix
Add `.worktrees` to the prune list; comment notes the hardcoded-dir fragility (a 3rd worktree root must be added here too).

## Gate Verification (against the live repro — shared checkout with nested worktrees)
| Case | Expected | Actual |
|---|---|---|
| Clean tree | exit 0 | ✅ `clean — tracking sets disjoint, nothing orphaned` |
| Planted `scripts/__probe/AGENTS.md` orphan | exit 1 | ✅ exit 1, named the file |
| Probe removed | exit 0 | ✅ |

Guard still catches genuine orphans — the fix removes only the worktree-checkout noise.

## Separate follow-up (not this PR)
The genuine 'new-role AGENTS.md never `ogit add -f`'d' orphan (Diagnostics p/334#12) is a real but distinct **create-role workflow gap** — filed separately.

Self-cert: /trivial-change (1 prune term + comment), with Gate Verification per the gate-signal-integrity rule.