### PR TITLE
docs(agents): elevate create-role `ogit add -f` to a numbered step (t/2204)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ Orca config files (`.orca.yaml`, `AGENTS.md`, `.orca/` directory) live in a **se
 - Run `ogit` from the repo root — `.orca-git` is not visible from subdirectories
 - A **new** nested `AGENTS.md` needs `ogit add -f` — the overlay whitelist alone does not stage it
 
+**Creating a role/instance?** After `create_role`/`create_instance`, the generated nested `AGENTS.md` is tracked by **neither** repo until you overlay-track it — do this **before** your next commit:
+
+1. `ogit add -f <new-role>/AGENTS.md`  (the overlay whitelist alone does not stage a *new* nested file — t/1971)
+2. `sh .githooks/agent-file-owner.sh --audit`  → expect **clean**
+3. Commit normally. **Never** `--no-verify` past the audit — that strands the file with no backing repo (F3 orphan; Pattern #146). If the audit instead flags a `.worktrees/<name>/AGENTS.md`, that is a worktree checkout of a main-tracked file — do **not** ogit-add it (t/2205).
+
 **Which repo owns an `AGENTS.md`? Don't recall it — ask (t/2080):**
 
 ```


### PR DESCRIPTION
Closes t/2204 AC1. Pattern #146 workflow-gap fix: the `ogit add -f` guidance for a new role's AGENTS.md was a buried aside, so agents `--no-verify`'d past the NEITHER-tracked audit instead of overlay-tracking. Adds a numbered 'Creating a role/instance?' block to §Orca Overlay Repo (ogit add -f → --audit → commit; never --no-verify), plus the t/2205 note not to ogit-add `.worktrees/` false-positives.

Docs-only, 6 insertions to root AGENTS.md. Companion to feedback rule `create-role-overlay-track` (AC2). AC3 (rule verification) + AC4 (7-day no-recurrence) remain for a later session per t/1625.

Self-cert: /trivial-change (docs-only). TL admin-merge on green per docs-only convention.