### PR TITLE
fix(adaptive-staging): wire real extraction status into confidence gate (t/2208)

### DIFF
--- a/lib/debate/claimExtractionPipeline/extract.ts
+++ b/lib/debate/claimExtractionPipeline/extract.ts
@@ -99,6 +99,13 @@ export async function extractClaims(
     trace.response_time_ms = Date.now() - extractStart;
     ctx.recordDiagnostic(entryId, { extraction_trace: trace });
     updateExtractionSummary(ctx, trace);
+    // Stamp failure onto entry so adaptive-staging confidence gate gets a real signal.
+    const entryOnErr = ctx.session.transcript.find(e => e.id === entryId);
+    if (entryOnErr) {
+      if (!entryOnErr.metadata) entryOnErr.metadata = {};
+      (entryOnErr.metadata as Record<string, unknown>).claim_extraction_status = 'parse_error';
+      (entryOnErr.metadata as Record<string, unknown>).extracted_claims_accepted = 0;
+    }
     ctx.warn(`Claim extraction for ${POVER_INFO[speaker].label}`, err, 'Skipping — argument network will be incomplete for this turn');
     return;
   }
@@ -579,6 +586,19 @@ export async function extractClaims(
   });
 
   updateExtractionSummary(ctx, trace);
+
+  // Stamp extraction results onto the entry so the adaptive-staging confidence
+  // gate reads actual extraction quality each round (t/2208).
+  const entryOnSuccess = ctx.session.transcript.find(e => e.id === entryId);
+  if (entryOnSuccess) {
+    if (!entryOnSuccess.metadata) entryOnSuccess.metadata = {};
+    const confStatus: 'ok' | 'truncated' | 'parse_error' =
+      (trace.status === 'ok' || trace.status === 'no_new_nodes') ? 'ok'
+      : trace.status === 'truncated_response' ? 'truncated'
+      : 'parse_error';
+    (entryOnSuccess.metadata as Record<string, unknown>).claim_extraction_status = confStatus;
+    (entryOnSuccess.metadata as Record<string, unknown>).extracted_claims_accepted = trace.candidates_accepted;
+  }
 
   // Update unanswered claims ledger
   ctx.session.unanswered_claims_ledger = updateUnansweredLedger(

--- a/lib/debate/debateEngine/adaptiveStaging.ts
+++ b/lib/debate/debateEngine/adaptiveStaging.ts
@@ -72,7 +72,7 @@ export function buildSignalContext(engine: DebateEngineInternals, round: number)
         round,
         speaker: e.speaker,
         text: e.content,
-        extraction_status: lastAttempt?.validation?.outcome ?? 'unknown',
+        extraction_status: (meta?.claim_extraction_status as 'ok' | 'truncated' | 'parse_error') ?? 'ok',
         claims_accepted: (meta?.extracted_claims_accepted as number) ?? 0,
         claims_rejected: (meta?.extracted_claims_rejected as number) ?? 0,
         category_validity_ratio: 1.0,

--- a/lib/debate/signalConfidence.test.ts
+++ b/lib/debate/signalConfidence.test.ts
@@ -208,3 +208,38 @@ describe('isConfidenceDeferred', () => {
     expect(isConfidenceDeferred(globalConf)).toBe(true);
   });
 });
+
+// ── Regression: t/2208 — extraction_conf pinned at 0.200 ────────────────────
+// Root cause: adaptiveStaging fed TurnValidationOutcome ('pass'/'retry'/…) to
+// computeExtractionConfidence, which only accepts 'ok'/'truncated'/'parse_error'.
+// Every unrecognised value hit the default branch → statusScore=0, claimsAccepted=0
+// → 0.5·0 + 0.3·0 + 0.2·1 = 0.200 every round, always below the 0.40 floor.
+// Fix: extractClaims stamps claim_extraction_status ('ok'|'truncated'|'parse_error')
+// onto entry metadata; buildSignalContext reads that field instead of outcome.
+
+describe('regression t/2208 – extraction_conf above floor when extraction succeeds', () => {
+  it('ok status with ≥2 accepted claims clears the confidence floor', () => {
+    // Reproduces the all-defaults case that was pinned at 0.200 pre-fix.
+    const extractionConf = computeExtractionConfidence('ok', 2, 1.0);
+    // 0.5·1 + 0.3·min(1, 2/2) + 0.2·1 = 1.0
+    expect(extractionConf).toBeGreaterThan(DEFAULT_CONFIDENCE_FLOOR);
+  });
+
+  it('TurnValidationOutcome values are NOT accepted as extraction status', () => {
+    // Any TurnValidationOutcome ('pass','retry','accept_with_flag','skipped') falls
+    // to the default branch → statusScore 0. Confidence must stay below the floor
+    // when claims are also 0 (the pre-fix all-defaults scenario).
+    for (const wrongEnum of ['pass', 'retry', 'accept_with_flag', 'skipped']) {
+      const conf = computeExtractionConfidence(wrongEnum, 0, 1.0);
+      // 0.5·0 + 0.3·0 + 0.2·1 = 0.200 < 0.40 floor
+      expect(isConfidenceDeferred(conf)).toBe(true);
+    }
+  });
+
+  it('ok status with 0 claims (no_new_nodes case) still clears the floor', () => {
+    // no_new_nodes extraction maps to 'ok' — extraction ran fine, just no novel claims.
+    const extractionConf = computeExtractionConfidence('ok', 0, 1.0);
+    // 0.5·1 + 0.3·0 + 0.2·1 = 0.7
+    expect(extractionConf).toBeGreaterThan(DEFAULT_CONFIDENCE_FLOOR);
+  });
+});


### PR DESCRIPTION
## Summary
- `extractClaims` now stamps `claim_extraction_status` (`'ok'|'truncated'|'parse_error'`) and `extracted_claims_accepted` onto `entry.metadata` at the end of each extraction (both success path and adapter-error early-return)
- `buildSignalContext` reads `claim_extraction_status` from metadata instead of `TurnValidationOutcome` (`'pass'`/`'retry'`/…), which always fell to the default branch of `computeExtractionConfidence` giving `0.5·0+0.3·0+0.2·1 = 0.200` every round
- Regression tests added to `signalConfidence.test.ts` covering the t/2208 scenario

## Root cause
`adaptiveStaging.ts:buildSignalContext` line 75 read `lastAttempt?.validation?.outcome` — a `TurnValidationOutcome` — where `computeExtractionConfidence` expects `'ok'|'truncated'|'parse_error'`. Since none of `'pass'/'retry'/'accept_with_flag'/'skipped'` match those cases, `statusScore` was always 0. Combined with `claimsAccepted=0` (the field was never written to metadata), the gate was permanently stuck at `0.200 < 0.40 floor`, deferring every phase transition until the escalation ladder forced it (~6 rounds/phase regardless of saturation/convergence/caps).

## Test plan
- [x] `npx vitest run signalConfidence.test.ts` — 33 tests pass (3 new regression specs)
- [x] `npx vitest run` (full debate suite) — 116 passed, 1 skipped
- [ ] CL to re-run t/2192 pilot and confirm phases exit on signals/caps, not escalation ladder

Closes t/2208. Unblocks t/2192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)