### PR TITLE
fix(debate): isolate cal log inside outputDir for experimental runs (t/2216)

### DIFF
--- a/lib/debate/calibrationLogger.test.ts
+++ b/lib/debate/calibrationLogger.test.ts
@@ -800,6 +800,53 @@ describe('appendCalibrationLog synthetic routing (t/1770)', () => {
   });
 });
 
+describe('appendCalibrationLog isolation: outputDir as calDataRoot (t/2216)', () => {
+  // Regression gate: when an isolated outputDir is used as the cal data root, the log
+  // must land inside it — not in any sibling directory (which is where path.dirname
+  // of a child-of-data-root path would land, contaminating the main cal log).
+
+  it('writes calibration log inside calDataRoot when calDataRoot IS outputDir', () => {
+    const mainDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'calib-main-'));
+    const outputDir = path.join(mainDataRoot, 'debates-t2216-scratch');
+    fs.mkdirSync(outputDir, { recursive: true });
+    try {
+      const dp = extractCalibrationData(makeMinimalSession(), 'local');
+      // This mirrors what cli.ts does post-fix: pass outputDir as calDataRoot
+      appendCalibrationLog(dp, outputDir);
+
+      // Log is inside outputDir
+      const isolatedCore = path.join(outputDir, 'calibration', 'core', 'calibration-log.jsonl');
+      expect(fs.existsSync(isolatedCore)).toBe(true);
+
+      // Main data root calibration dir is untouched
+      const mainCore = path.join(mainDataRoot, 'calibration', 'core', 'calibration-log.jsonl');
+      expect(fs.existsSync(mainCore)).toBe(false);
+    } finally {
+      fs.rmSync(mainDataRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('main cal log line count is unchanged when isolated run uses outputDir as calDataRoot', () => {
+    const mainDataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'calib-linecount-'));
+    const outputDir = path.join(mainDataRoot, 'debates-experiment');
+    fs.mkdirSync(outputDir, { recursive: true });
+    // Seed one real row in the main log
+    const seedDp = extractCalibrationData(makeMinimalSession(), 'local');
+    appendCalibrationLog(seedDp, mainDataRoot);
+    const mainCore = path.join(mainDataRoot, 'calibration', 'core', 'calibration-log.jsonl');
+    const linesBefore = fs.readFileSync(mainCore, 'utf-8').trim().split('\n').filter(Boolean).length;
+    try {
+      // Isolated run — passes outputDir, not mainDataRoot
+      const dp = extractCalibrationData(makeMinimalSession(), 'local');
+      appendCalibrationLog(dp, outputDir);
+      const linesAfter = fs.readFileSync(mainCore, 'utf-8').trim().split('\n').filter(Boolean).length;
+      expect(linesAfter).toBe(linesBefore);
+    } finally {
+      fs.rmSync(mainDataRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('extractCalibrationData source_authority from session.doc_meta (t/1769)', () => {
   // Anti-recurrence gate: before t/1769, source-authority calibration only worked
   // when the caller passed config.docMeta (the in-process engine path). The

--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -624,12 +624,16 @@ async function main(): Promise<void> {
   // Log calibration data point (non-blocking)
   try {
     const { extractCalibrationData, appendCalibrationLog } = await import('./calibrationLogger.js');
-    const dataRoot = path.dirname(outputDir); // outputDir is .../debates, data root is parent
+    // When outputDir is explicitly configured, write the cal log inside it so
+    // experimental/isolated runs don't contaminate the main data-root log (t/2216).
+    // path.dirname(outputDir) would still land in the main data root when the
+    // scratch dir is a direct child of it (e.g. ../ai-triad-data/debates-t2192).
+    const calDataRoot = config.outputDir != null ? outputDir : dataRoot;
     const dataPoint = extractCalibrationData(session, 'local', {
       explorationSummary: engineConfig.explorationSummary,
     });
-    appendCalibrationLog(dataPoint, dataRoot);
-    log(`Calibration data logged to ${dataRoot}/calibration/users/${dataPoint.origin || 'local'}/calibration-log.jsonl`);
+    appendCalibrationLog(dataPoint, calDataRoot);
+    log(`Calibration data logged to ${calDataRoot}/calibration/users/${dataPoint.origin || 'local'}/calibration-log.jsonl`);
   } catch (err) {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'cli', level: 'warn', message: 'Calibration logging failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
     log(`Calibration logging failed (non-critical): ${err instanceof Error ? err.message : err}`);


### PR DESCRIPTION
## Summary
- When `outputDir` is explicitly configured, write the calibration log inside it (`outputDir/calibration/...`) not in its parent directory
- `path.dirname(outputDir)` resolves to the main data root when the scratch dir is a direct child of it (e.g. `../ai-triad-data/debates-t2216`), silently contaminating the main cal log and requiring manual row surgery
- Default behavior unchanged: when `outputDir` is not configured, the main data-root cal log is used as before

## Test plan
- [ ] 2 new regression tests in `calibrationLogger.test.ts`: isolated run writes inside outputDir; main cal log line count unchanged after isolated run
- [ ] 2901/2912 debate tests pass locally (11 pre-existing skips)
- [ ] AC2 (live run verification) is post-merge; will notify CL once a situation-injecting run is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
