### PR TITLE
fix(persistence): replace copyFileSync fallback with .tmp2 rename to prevent corrupt JSON (t/2211)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,3 +14,28 @@ Error: Cannot find module '.../git-credential-helper.js'
 **Impact:** Cosmetic only — the push completes successfully despite the error.
 
 **Action:** None required. The error can be safely ignored.
+
+## Windows: debate saves fail or produce corrupt JSON (EPERM on rename)
+
+**Error (flight recorder):**
+```
+io.retry: renameSyncWithRetry failed (EPERM), retry N/7 after Nms
+```
+followed by a subsequent `SyntaxError` loading the debate session.
+
+**Context:** Windows Defender and Windows Search Indexer briefly hold exclusive handles on files in actively-scanned directories. When a file rename is denied long enough to exhaust the retry budget, the atomic-write fallback triggers. In rare cases the target file ends up corrupt.
+
+**Root cause:** Windows AV/indexer scanning `ai-triad-data\debates\` during a save.
+
+**Fix (dev machines):** Exclude the debates directory from real-time scanning:
+
+*Windows Defender:*
+1. Open **Windows Security → Virus & threat protection → Manage settings**
+2. Under **Exclusions**, click **Add or remove exclusions → Add an exclusion → Folder**
+3. Add the path to your `ai-triad-data\debates\` directory
+
+*Windows Search Indexer:*
+1. Open **Control Panel → Indexing Options → Modify**
+2. Remove (exclude) your `ai-triad-data\` directory from the indexed locations
+
+**Impact without fix:** Debate saves may fail with an `ActionableError` naming a `.tmp` recovery artifact. The `.tmp` file holds the complete unsaved content — rename it to `<debate-id>.json` to recover the session.

--- a/lib/debate/__tests__/persistenceFaults.test.ts
+++ b/lib/debate/__tests__/persistenceFaults.test.ts
@@ -34,6 +34,7 @@ function cleanup(...paths: string[]): void {
   for (const p of paths) {
     try { fs.unlinkSync(p); } catch { /* ignore */ }
     try { fs.unlinkSync(`${p}.tmp`); } catch { /* ignore */ }
+    try { fs.unlinkSync(`${p}.tmp2`); } catch { /* ignore */ }
   }
 }
 
@@ -389,21 +390,27 @@ describe('atomicWriteSync EPERM retry (t/1271)', () => {
     expect(JSON.parse(fs.readFileSync(testFile, 'utf-8'))).toEqual({ recovered: true });
   });
 
-  it('recovers via copy fallback after rename retries are exhausted (t/1627)', { timeout: 10_000 }, () => {
-    // renameSync is denied forever (sustained AV/indexer lock), but copyFileSync
-    // is left real: the tmp still holds the full payload, so the copy fallback
-    // persists it in place. The write succeeds — no throw, no lost snapshot.
+  it('recovers via .tmp2 rename fallback when first rename is exhausted (t/1627, t/2211)', { timeout: 10_000 }, () => {
+    // renameSync is denied for the first 8 calls (1 initial + 7 retries for .tmp→target),
+    // then succeeds on call 9 (.tmp2→target). The write succeeds — no throw, no corruption.
     const captured = installCaptureRecorder();
-    const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
-      throw makeStorageError('EPERM', 'operation not permitted');
+    let callCount = 0;
+    const origRename = fs.renameSync;
+    const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation((...args: Parameters<typeof fs.renameSync>) => {
+      callCount++;
+      if (callCount <= 8) throw makeStorageError('EPERM', 'operation not permitted');
+      renameSpy.mockRestore();
+      return origRename(...args);
     });
 
     expect(() => atomicWriteSync(testFile, '{"data":true}')).not.toThrow();
-    // 1 initial + 7 retries = 8 rename attempts, all denied, before falling back.
-    expect(renameSpy).toHaveBeenCalledTimes(8);
-    // Copy fallback landed the payload at the real target and cleaned up the tmp.
+    // 8 denied attempts for .tmp→target, then 1 successful attempt for .tmp2→target.
+    expect(callCount).toBe(9);
+    // .tmp2 rename landed the payload at the real target.
     expect(JSON.parse(fs.readFileSync(testFile, 'utf-8'))).toEqual({ data: true });
+    // Both temp files cleaned up.
     expect(fs.existsSync(`${testFile}.tmp`)).toBe(false);
+    expect(fs.existsSync(`${testFile}.tmp2`)).toBe(false);
     // AC3: a recovery is recorded distinctly from a data-loss.
     const recovered = captured.filter(e => e.type === 'io.recovered');
     expect(recovered).toHaveLength(1);
@@ -434,13 +441,12 @@ describe('atomicWriteSync durable copy fallback (t/1627)', () => {
 
   afterEach(() => { vi.restoreAllMocks(); cleanup(testFile); });
 
-  it('throws ActionableError naming tmpPath and PRESERVES the tmp when rename and copy both fail', { timeout: 10_000 }, () => {
+  it('throws ActionableError naming tmpPath and PRESERVES the tmp when both renames fail (t/2211)', { timeout: 20_000 }, () => {
+    // renameSync is denied forever — both .tmp→target and .tmp2→target renames fail.
+    // No copyFileSync involved: the .tmp2 path avoids in-place writes to the locked target.
     const captured = installCaptureRecorder();
     const tmpFile = `${testFile}.tmp`;
     vi.spyOn(fs, 'renameSync').mockImplementation(() => {
-      throw makeStorageError('EPERM', 'operation not permitted');
-    });
-    vi.spyOn(fs, 'copyFileSync').mockImplementation(() => {
       throw makeStorageError('EPERM', 'operation not permitted');
     });
 
@@ -457,35 +463,33 @@ describe('atomicWriteSync durable copy fallback (t/1627)', () => {
     expect(ae.problem).toContain('EPERM');
     expect(`${ae.goal} ${ae.nextSteps.join(' ')}`).toContain(tmpFile);
 
-    // The tmp artifact is the sole durable copy — it must NOT be unlinked, and
+    // The .tmp artifact is the sole durable copy — it must NOT be unlinked, and
     // it must still hold the complete new content for recovery.
     expect(fs.existsSync(tmpFile)).toBe(true);
     expect(JSON.parse(fs.readFileSync(tmpFile, 'utf-8'))).toEqual({ turn: 42 });
+    // .tmp2 is a duplicate — best-effort cleaned up (no longer needed alongside .tmp).
+    expect(fs.existsSync(`${testFile}.tmp2`)).toBe(false);
 
     // AC3: a data-loss event is recorded, distinct from io.recovered, and it
     // names tmpPath so diagnostics can find the preserved payload.
     const dataLoss = captured.filter(e => e.type === 'io.data-loss');
     expect(dataLoss).toHaveLength(1);
-    expect(dataLoss[0].data).toMatchObject({ filePath: testFile, tmpPath: tmpFile, renameCode: 'EPERM', copyCode: 'EPERM' });
+    expect(dataLoss[0].data).toMatchObject({ filePath: testFile, tmpPath: tmpFile, renameCode: 'EPERM', tmp2Code: 'EPERM' });
     expect(dataLoss[0].message).toContain(tmpFile);
     expect(captured.some(e => e.type === 'io.recovered')).toBe(false);
   });
 
-  it('AC4: the next successful save re-persists the dropped snapshot', { timeout: 10_000 }, () => {
+  it('AC4: the next successful save re-persists the dropped snapshot (t/2211)', { timeout: 20_000 }, () => {
     const tmpFile = `${testFile}.tmp`;
-    // First save: both rename and copy denied → throws, tmp preserved.
+    // First save: both renames denied → throws, .tmp preserved.
     const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
-      throw makeStorageError('EPERM', 'operation not permitted');
-    });
-    const copySpy = vi.spyOn(fs, 'copyFileSync').mockImplementation(() => {
       throw makeStorageError('EPERM', 'operation not permitted');
     });
     expect(() => atomicWriteSync(testFile, '{"turn":42}')).toThrow(ActionableError);
     expect(fs.existsSync(testFile)).toBe(false);
 
-    // Lock clears: restore real fs, then save the full snapshot again.
+    // Lock clears: restore real renameSync, then save the full snapshot again.
     renameSpy.mockRestore();
-    copySpy.mockRestore();
     atomicWriteSync(testFile, '{"turn":42}');
 
     // The previously dropped snapshot is now durably persisted at the target,

--- a/lib/debate/persistence.ts
+++ b/lib/debate/persistence.ts
@@ -131,53 +131,58 @@ export function atomicWriteSync(filePath: string, content: string): void {
     // Sustained rename EPERM/EACCES: a Windows AV/indexer held an exclusive
     // handle on the target longer than the bounded retry budget. The atomic
     // directory-entry swap is unavailable, but tmpPath still holds the COMPLETE
-    // new content. Fallback: copy tmp *over* the target in place. copyFileSync
-    // opens the destination for write rather than requiring the rename swap, so
-    // it can win against a different lock class. It is non-atomic (a crash
-    // mid-copy can truncate the target), which is exactly why it is the
-    // fallback and not the primary path.
+    // new content. Fallback: write to .tmp2, fdatasync, then rename atomically.
+    // This avoids writing directly to the (possibly locked) target — the old
+    // copyFileSync approach could partially overwrite a locked target and produce
+    // corrupt JSON when the lock interrupted the copy (t/2211 incident: debate
+    // e8f41c82, 120161 bytes written, JSON corrupt at position 119988).
+    const tmp2Path = `${filePath}.tmp2`;
     try {
-      fs.copyFileSync(tmpPath, filePath);
-      try { fs.unlinkSync(tmpPath); } catch { /* best-effort cleanup */ }
+      fs.writeFileSync(tmp2Path, content, 'utf-8');
+      // writeFileSync closes the handle on return, flushing OS write buffers.
+      renameSyncWithRetry(tmp2Path, filePath);
+      // .tmp2 rename succeeded — clean up the original .tmp (best-effort)
+      try { fs.unlinkSync(tmpPath); } catch { /* best-effort */ }
       getGlobalRecorder()?.record({
         type: 'io.recovered', component: 'persistence', level: 'warn',
-        message: `atomicWriteSync: rename exhausted, recovered via in-place copy fallback`,
+        message: `atomicWriteSync: rename exhausted, recovered via .tmp2 rename fallback`,
         data: {
-          filePath, tmpPath,
+          filePath, tmpPath, tmp2Path,
           bytes: Buffer.byteLength(content, 'utf-8'),
           renameCode: (renameErr as NodeJS.ErrnoException).code,
         },
       });
       return;
-    } catch (copyErr) {
-      // Both strategies were denied — almost certainly the same exclusive lock
-      // on filePath. DO NOT unlink tmpPath: it is now the ONLY durable copy of
-      // the new content and serves as a recovery artifact for the next save.
-      // The loader enumerates *.json only, so a lingering .tmp is invisible to
-      // it and cannot be mistaken for a session (see persistenceFaults.test).
+    } catch (tmp2Err) {
+      // Both rename strategies were denied — DO NOT unlink tmpPath: it is the
+      // ONLY durable copy of the new content and serves as a recovery artifact.
+      // Best-effort clean up the .tmp2 orphan (it's a duplicate; .tmp is canonical).
+      // The loader enumerates *.json only, so lingering .tmp/.tmp2 files are
+      // invisible to it and cannot be mistaken for sessions (persistenceFaults.test).
+      try { fs.unlinkSync(tmp2Path); } catch { /* best-effort */ }
       const bytes = Buffer.byteLength(content, 'utf-8');
-      const renameCode = (renameErr as NodeJS.ErrnoException).code;
-      const copyCode = (copyErr as NodeJS.ErrnoException).code;
+      const firstRenameCode = (renameErr as NodeJS.ErrnoException).code;
+      const tmp2Code = (tmp2Err as NodeJS.ErrnoException).code;
       getGlobalRecorder()?.record({
         type: 'io.data-loss', component: 'persistence', level: 'error',
-        message: `atomicWriteSync: DATA LOSS RISK — rename and copy both failed; new content preserved at ${tmpPath}`,
-        data: { filePath, tmpPath, bytes, renameCode, copyCode },
+        message: `atomicWriteSync: DATA LOSS RISK — rename and .tmp2 rename both failed; new content preserved at ${tmpPath}`,
+        data: { filePath, tmpPath, tmp2Path, bytes, renameCode: firstRenameCode, tmp2Code },
         error: {
-          name: (copyErr as Error).name ?? 'Error',
-          message: (copyErr as Error).message,
-          stack: (copyErr as Error).stack,
+          name: (tmp2Err as Error).name ?? 'Error',
+          message: (tmp2Err as Error).message,
+          stack: (tmp2Err as Error).stack,
         },
       });
       throw new ActionableError({
         goal: `Persist ${bytes} bytes to ${filePath}`,
-        problem: `Atomic rename and in-place copy fallback were both denied (rename ${renameCode}, copy ${copyCode}) — the target is held by another process (Windows antivirus/indexer) longer than the retry budget allows.`,
+        problem: `Atomic rename and .tmp2 rename fallback were both denied (rename ${firstRenameCode}, fallback ${tmp2Code}) — the target is held by another process (Windows antivirus/indexer) longer than the retry budget allows.`,
         location: 'lib/debate/persistence.ts atomicWriteSync',
         nextSteps: [
           `The new content is preserved at ${tmpPath} and was NOT deleted — it is the only durable copy of this write. Do not remove it.`,
           `Retry the save once the lock clears: a subsequent successful atomicWriteSync replaces ${filePath}, after which ${tmpPath} may be removed.`,
           `If saves keep failing, exclude the debates directory from antivirus/search-indexer scanning.`,
         ],
-        innerError: copyErr,
+        innerError: tmp2Err,
       });
     }
   }

--- a/lib/debate/persistence.ts
+++ b/lib/debate/persistence.ts
@@ -131,7 +131,7 @@ export function atomicWriteSync(filePath: string, content: string): void {
     // Sustained rename EPERM/EACCES: a Windows AV/indexer held an exclusive
     // handle on the target longer than the bounded retry budget. The atomic
     // directory-entry swap is unavailable, but tmpPath still holds the COMPLETE
-    // new content. Fallback: write to .tmp2, fdatasync, then rename atomically.
+    // new content. Fallback: write to .tmp2, then rename atomically.
     // This avoids writing directly to the (possibly locked) target — the old
     // copyFileSync approach could partially overwrite a locked target and produce
     // corrupt JSON when the lock interrupted the copy (t/2211 incident: debate


### PR DESCRIPTION
## Summary

- **Bug:** `atomicWriteSync`'s EPERM-exhausted fallback called `copyFileSync(tmpPath, filePath)`, which could partially overwrite a Windows-locked target, producing corrupt JSON. Confirmed incident: debate `e8f41c82`, 120161 bytes written, `SyntaxError` at position 119988.
- **Fix:** Fallback now writes to `.tmp2` then renames atomically (`.tmp2 → filePath`). The target is never touched until a successful rename — the atomic-write invariant is preserved. If the second rename also fails, `.tmp2` is cleaned up, `.tmp` is preserved as the sole recovery artifact, and a hard `ActionableError` is thrown.
- **Tests:** Updated `persistenceFaults.test.ts` — new recovery test (fail 8, succeed on 9th rename), updated double-failure test (removes now-unused `copyFileSync` spy, asserts `tmp2Code` in event), bumped timeouts for double-retry wall-clock.
- **Docs:** `docs/troubleshooting.md` — AV/Search indexer exclusion guidance (AC3).

## Cross-scope note

`atomicWriteSync` lives in `lib/debate/persistence.ts` (DebateTool scope), but the TL routed t/2211 to ElectronMain. Changes touch `lib/debate/persistence.ts` and `lib/debate/__tests__/persistenceFaults.test.ts` outside my canonical path — flagging for TL awareness.

**TL review required before merge** (atomic-write-invariant change, per t/2211#1).

## Test plan

- [ ] `cd lib/debate && npx vitest run __tests__/persistenceFaults.test.ts` → 21/21 pass ✓
- [ ] `cd taxonomy-editor && npx tsc --noEmit -p tsconfig.main.json` → exit 0 ✓
- [ ] Normal save path unaffected (primary rename succeeds, fallback never fires)
- [ ] Recovery path: first 8 renames EPERM → `.tmp2` rename succeeds → payload at target, both temp files cleaned up
- [ ] Double-failure path: all renames EPERM → `ActionableError` thrown, `.tmp` preserved, `io.data-loss` recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
