### PR TITLE
feat(debate): configurable brief-stage timeout + brief.timeout/retrying events (t/2215)

### DIFF
--- a/lib/debate/briefTimeout.test.ts
+++ b/lib/debate/briefTimeout.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { runOpeningPipeline } from './turnPipeline.js';
+import type { OpeningPipelineInput, BriefEventFn } from './turnPipeline.js';
+import type { StageGenerateFn } from './turnPipeline/types.js';
+
+// ── Minimal fixture ─────────────────────────────────────────
+
+const INPUT: OpeningPipelineInput = {
+  label: 'Accelerationist',
+  pov: 'acc',
+  personality: 'optimist',
+  topic: 'Is AI good?',
+  taxonomyContext: '',
+  priorStatements: '',
+  isFirst: true,
+  model: 'test-model',
+  briefTimeoutMs: 200,
+  briefMaxRetries: 2,
+};
+
+// Stage-appropriate minimal JSON responses
+const STAGE_RESPONSES: Record<string, string> = {
+  brief: JSON.stringify({ claim_sketches: [], situation_assessment: 'ok', prior_context_summary: '' }),
+  plan: JSON.stringify({ framing_choices: [], argument_skeleton: [] }),
+  draft: JSON.stringify({ statement: 'Test statement.', key_assumptions: [], claim_sketches: [] }),
+  cite: JSON.stringify({ taxonomy_refs: [], policy_refs: [] }),
+};
+
+function stageKey(label: string): string {
+  for (const key of Object.keys(STAGE_RESPONSES)) {
+    if (label.includes(key)) return key;
+  }
+  return 'draft';
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('runOpeningPipeline — brief timeout events', () => {
+  it('emits brief.timeout and brief.retrying when first brief call times out, then succeeds on retry', async () => {
+    let briefCalls = 0;
+    const generate: StageGenerateFn = async (_prompt, _model, _opts, label) => {
+      if (label.includes('brief')) {
+        briefCalls++;
+        if (briefCalls === 1) {
+          throw new DOMException('The operation was aborted', 'AbortError');
+        }
+      }
+      return STAGE_RESPONSES[stageKey(label)];
+    };
+
+    const events: Array<{ phase: string; data: unknown }> = [];
+    const onBriefEvent: BriefEventFn = (phase, data) => events.push({ phase, data });
+
+    await runOpeningPipeline(INPUT, generate, undefined, onBriefEvent);
+
+    const phases = events.map(e => e.phase);
+    expect(phases).toContain('brief.timeout');
+    expect(phases).toContain('brief.retrying');
+    expect(phases).not.toContain('brief.retries_exhausted');
+
+    const timeoutEvent = events.find(e => e.phase === 'brief.timeout')!;
+    const data = timeoutEvent.data as { agent: string; attempt: number; maxRetries: number; elapsedMs: number };
+    expect(data.agent).toBe('Accelerationist');
+    expect(data.attempt).toBe(0);
+    expect(data.maxRetries).toBe(2);
+    expect(data.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('emits brief.retries_exhausted and rethrows when all timeout retries fail', async () => {
+    const generate: StageGenerateFn = async (_prompt, _model, _opts, label) => {
+      if (label.includes('brief')) {
+        throw new DOMException('The operation was aborted', 'AbortError');
+      }
+      return STAGE_RESPONSES[stageKey(label)];
+    };
+
+    const events: Array<{ phase: string; data: unknown }> = [];
+    const onBriefEvent: BriefEventFn = (phase, data) => events.push({ phase, data });
+
+    await expect(
+      runOpeningPipeline(INPUT, generate, undefined, onBriefEvent),
+    ).rejects.toThrow();
+
+    const phases = events.map(e => e.phase);
+    // 3 attempts (0, 1, 2) each emit brief.timeout
+    expect(events.filter(e => e.phase === 'brief.timeout')).toHaveLength(3);
+    // 2 retrying events (after attempt 0 and 1)
+    expect(events.filter(e => e.phase === 'brief.retrying')).toHaveLength(2);
+    expect(phases).toContain('brief.retries_exhausted');
+  });
+
+  it('does not emit brief timeout events on clean brief call', async () => {
+    const generate: StageGenerateFn = async (_prompt, _model, _opts, label) =>
+      STAGE_RESPONSES[stageKey(label)];
+
+    const events: Array<{ phase: string }> = [];
+    const onBriefEvent: BriefEventFn = (phase) => events.push({ phase });
+
+    await runOpeningPipeline(INPUT, generate, undefined, onBriefEvent);
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('forwards briefTimeoutMs to the generate call options', async () => {
+    const seenTimeouts: (number | undefined)[] = [];
+    const generate: StageGenerateFn = async (_prompt, _model, opts, label) => {
+      if (label.includes('brief')) seenTimeouts.push(opts.timeoutMs);
+      return STAGE_RESPONSES[stageKey(label)];
+    };
+
+    await runOpeningPipeline({ ...INPUT, briefTimeoutMs: 5_000 }, generate, undefined, undefined);
+
+    expect(seenTimeouts[0]).toBe(5_000);
+  });
+});

--- a/lib/debate/calibrationOptimizer.ts
+++ b/lib/debate/calibrationOptimizer.ts
@@ -27,7 +27,7 @@ import {
   replicationGateByConfig,
 } from './calibrationLogger.js';
 import { PINNED_EVALUATOR_MODEL } from './neutralEvaluator.js';
-import { PROVISIONAL_WEIGHTS_FALLBACK } from './phaseTransitions.js';
+import { loadProvisionalWeights } from './phaseTransitions.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -239,11 +239,11 @@ export function applyRelevanceThresholdAdaptation(
       return { applied: false, reason: 'adaptation_enabled is false (manual override)' };
     }
 
-    const oldValue = weights.relevance?.embedding_threshold ?? PROVISIONAL_WEIGHTS_FALLBACK.relevance!.embedding_threshold;
+    const oldValue = weights.relevance?.embedding_threshold ?? loadProvisionalWeights().relevance!.embedding_threshold;
     if (oldValue === newValue) {
       return { applied: false, reason: 'file already at recommended value' };
     }
-    if (!weights.relevance) weights.relevance = { ...PROVISIONAL_WEIGHTS_FALLBACK.relevance! };
+    if (!weights.relevance) weights.relevance = { ...loadProvisionalWeights().relevance! };
     weights.relevance.embedding_threshold = newValue;
 
     // Record adjustment metadata

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -954,7 +954,7 @@ export class DebateEngine {
       app_version: this.config.appVersion,
       audience: this.config.audience,
       moderator_mode: this.config.moderatorMode ?? 'standard',
-      talmudic_references: this._talmudicCorpus ? { enabled: true, corpus_name: this._talmudicCorpus.name, corpus_path: path.resolve(this.config.talmudicReferences!.corpusPath), corpus_version: this._talmudicCorpus.version } : { enabled: false },
+      talmudic_references: this._talmudicCorpus ? { enabled: true, corpus_name: this._talmudicCorpus.name, corpus_path: path.resolve(this.config.talmudicReferences!.corpusPath), corpus_version: String(this._talmudicCorpus.version) } : { enabled: false },
       phase: 'setup',
       topic: {
         original: this.config.topic,
@@ -1264,6 +1264,10 @@ export class DebateEngine {
       totalRounds: this.config.rounds,
       message: message ?? phase,
     });
+  }
+
+  briefProgress(phase: string, speaker: string | undefined, message: string, brief: import('./debateEngine/internals.js').DebateProgress['brief']): void {
+    this.onProgress?.({ phase, speaker, totalRounds: this.config.rounds, message, brief });
   }
 
   private emitSnapshot(trigger: 'round_complete' | 'error'): void {

--- a/lib/debate/debateEngine/internals.ts
+++ b/lib/debate/debateEngine/internals.ts
@@ -74,6 +74,10 @@ export interface DebateConfig {
   stopAfterStage?: LifecycleStage;
   /** Minimum delay (ms) between consecutive API calls. 0 = no throttle (default). Recommended: 500-1000 for free-tier APIs. */
   throttleMs?: number;
+  /** Timeout per brief-stage AI call (ms). Default: 60,000. Overrides the backend default for the brief stage only, enabling faster retries on slow models. */
+  briefTimeoutMs?: number;
+  /** Max brief-stage timeout retries before aborting the opening. Default: 3. */
+  briefMaxRetries?: number;
   /** Perturbation testing config — inject adversarial prompt at a specific turn for resilience evaluation. Evaluation/benchmark only. */
   perturbation?: import('../types.js').PerturbationConfig;
   /** Run topic wisdom scoring at setup. Default: true. */
@@ -137,6 +141,8 @@ export interface DebateProgress {
   message: string;
   /** Present when phase is 'retry' — retry attempt details. */
   retry?: { attempt: number; maxRetries: number; backoffSeconds: number };
+  /** Present when phase is 'brief.timeout', 'brief.retrying', or 'brief.retries_exhausted'. */
+  brief?: { agent: string; attempt: number; maxRetries: number; elapsedMs: number };
 }
 
 /**
@@ -205,6 +211,7 @@ export interface DebateEngineInternals {
 
   // ── helper methods that remain on the orchestrator ──
   progress(phase: string, speaker?: string, message?: string, round?: number): void;
+  briefProgress(phase: string, speaker: string | undefined, message: string, brief: NonNullable<DebateProgress['brief']>): void;
   warn(operation: string, error: unknown, recovery: string): void;
   checkAborted(): void;
   emitSnapshot(trigger: 'round_complete' | 'error'): void;

--- a/lib/debate/debateEngine/phases/opening.ts
+++ b/lib/debate/debateEngine/phases/opening.ts
@@ -101,6 +101,8 @@ export async function runOpeningStatements(engine: DebateEngineInternals): Promi
       citeModel: engine.config.stageModels?.cite,
       userSeedClaims: userSeeds.length > 0 ? userSeeds : undefined,
       availablePovNodeIds: [...engine.getKnownNodeIds()],
+      briefTimeoutMs: engine.config.briefTimeoutMs,
+      briefMaxRetries: engine.config.briefMaxRetries,
       ...(engine.config.temperature != null ? {
         stageTemperatures: {
           brief_temperature: engine.config.temperature,
@@ -119,12 +121,22 @@ export async function runOpeningStatements(engine: DebateEngineInternals): Promi
       round: 0,
       turn_index: engine.session.transcript.length,
     });
+    const onBriefEvent: import('../../turnPipeline.js').BriefEventFn = (phase, data) => {
+      const msg = phase === 'brief.timeout'
+        ? `${data.agent} brief timed out after ${Math.round(data.elapsedMs / 1000)}s (attempt ${data.attempt + 1}/${data.maxRetries + 1})`
+        : phase === 'brief.retrying'
+        ? `${data.agent} brief retrying (attempt ${data.attempt + 1}/${data.maxRetries + 1})`
+        : `${data.agent} brief retries exhausted after ${data.attempt + 1} attempts`;
+      engine.briefProgress(phase, poverId, msg, data);
+    };
+
     let pipelineResult = await engine.executeWithModelFailover(poverId, async (model) => {
       const input = { ...pipelineInput, model };
       let result = await runOpeningPipeline(
         input,
         engine.stageGenerate.bind(engine),
         (_stage, label) => engine.progress('opening', poverId, label),
+        onBriefEvent,
       );
 
       const repairHints = getOpeningRepairHints(result);
@@ -135,6 +147,7 @@ export async function runOpeningStatements(engine: DebateEngineInternals): Promi
             { ...input, repairHints },
             engine.stageGenerate.bind(engine),
             (_stage, label) => engine.progress('opening', poverId, label),
+            onBriefEvent,
           );
         } catch (err) {
           getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-engine', level: 'warn', debate_id: engine.session?.id, message: 'Opening retry failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });

--- a/lib/debate/turnPipeline/opening.ts
+++ b/lib/debate/turnPipeline/opening.ts
@@ -18,6 +18,20 @@ import type { StageGenerateFn, StageProgressFn } from './types.js';
 
 // ── Opening pipeline ──────────────────────────────────
 
+const DEFAULT_BRIEF_TIMEOUT_MS = 60_000;
+const DEFAULT_BRIEF_MAX_RETRIES = 3;
+
+function isBriefTimeout(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === 'AbortError') return true;
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('timed out') || msg.includes('AbortError') || msg.includes('The operation was aborted');
+}
+
+export type BriefEventFn = (
+  phase: 'brief.timeout' | 'brief.retrying' | 'brief.retries_exhausted',
+  data: { agent: string; attempt: number; maxRetries: number; elapsedMs: number },
+) => void;
+
 export interface OpeningPipelineInput {
   label: string;
   pov: string;
@@ -42,12 +56,17 @@ export interface OpeningPipelineInput {
   repairHints?: string[];
   /** Available POV node IDs for CITE validation (unknown node detection). */
   availablePovNodeIds?: string[];
+  /** Timeout per brief-stage AI call (ms). Default: 60,000. */
+  briefTimeoutMs?: number;
+  /** Max brief-stage timeout retries. Default: 3. */
+  briefMaxRetries?: number;
 }
 
 export async function runOpeningPipeline(
   input: OpeningPipelineInput,
   generate: StageGenerateFn,
   onProgress?: StageProgressFn,
+  onBriefEvent?: BriefEventFn,
 ): Promise<OpeningPipelineResult> {
   const temps = {
     ...DEFAULT_STAGE_TEMPERATURES,
@@ -74,20 +93,47 @@ export async function runOpeningPipeline(
   const stageDiags: StageDiagnostics[] = [];
   const pipelineStart = Date.now();
 
-  // ── Stage 1: BRIEF (with parse-failure retry) ──
+  // ── Stage 1: BRIEF (with parse-failure retry and configurable timeout retry) ──
   const isOpeningOuterRetry = (input.repairHints?.length ?? 0) > 0;
   const MAX_OPENING_RETRIES = isOpeningOuterRetry ? 0 : 1;
+  const briefTimeoutMs = input.briefTimeoutMs ?? DEFAULT_BRIEF_TIMEOUT_MS;
+  const briefMaxRetries = input.briefMaxRetries ?? DEFAULT_BRIEF_MAX_RETRIES;
   let brief: OpeningBriefWorkProduct | undefined;
   let briefJson = '';
-  let t0: number;
-  let elapsed: number;
+  let t0: number = Date.now();
+  let elapsed: number = 0;
   for (let briefAttempt = 0; briefAttempt <= MAX_OPENING_RETRIES; briefAttempt++) {
     onProgress?.('brief', `${input.label} is briefing${briefAttempt > 0 ? ` (retry ${briefAttempt})` : ''}...`);
     const briefPrompt = briefOpeningStagePrompt(stageInput);
-    t0 = Date.now();
-    const briefRaw = await generate(
-      briefPrompt, oBriefModel, { temperature: temps.brief_temperature }, `${input.label} opening brief`,
-    );
+    let briefRaw!: string;
+    for (let tout = 0; tout <= briefMaxRetries; tout++) {
+      t0 = Date.now();
+      try {
+        briefRaw = await generate(
+          briefPrompt, oBriefModel,
+          { temperature: temps.brief_temperature, timeoutMs: briefTimeoutMs },
+          `${input.label} opening brief`,
+        );
+        break;
+      } catch (err) {
+        if (isBriefTimeout(err)) {
+          const elapsedMs = Date.now() - t0;
+          const evData = { agent: input.label, attempt: tout, maxRetries: briefMaxRetries, elapsedMs };
+          onBriefEvent?.('brief.timeout', evData);
+          getGlobalRecorder()?.record({
+            type: 'ai.error', component: 'turn-pipeline', level: 'warn', speaker: input.label,
+            message: `Opening brief timed out after ${Math.round(elapsedMs / 1000)}s (attempt ${tout + 1}/${briefMaxRetries + 1})`,
+            data: evData,
+          });
+          if (tout < briefMaxRetries) {
+            onBriefEvent?.('brief.retrying', { ...evData, attempt: tout + 1 });
+            continue;
+          }
+          onBriefEvent?.('brief.retries_exhausted', evData);
+        }
+        throw err;
+      }
+    }
     elapsed = Date.now() - t0;
     const briefParsed = parseStageResponse<OpeningBriefWorkProduct>(briefRaw, 'brief');
     stageDiags.push({


### PR DESCRIPTION
## Summary

- **Configurable brief timeout**: adds `briefTimeoutMs` (default 60 s) and `briefMaxRetries` (default 3) to `DebateConfig`, replacing the implicit 240 s x 5-retry ceiling on moonshot/zai (~20 min) with a ~3 min bounded retry loop scoped to the brief stage only
- **Structured events**: emits `brief.timeout` / `brief.retrying` / `brief.retries_exhausted` over `DebateProgress` (new `brief` sub-object with agent, attempt, maxRetries, elapsedMs) via `DebateEngineInternals.briefProgress()` — prerequisite for t/2210 toast/dialog
- **Fault-injection test**: `briefTimeout.test.ts` — 4 cases (single-retry success, full exhaustion, clean path, timeout forwarding)
- **Fix**: `calibrationOptimizer.ts` imported removed `PROVISIONAL_WEIGHTS_FALLBACK` (dropped in #513) — repointed to `loadProvisionalWeights()` — unblocks t/2214 and Comp Linguist AC2 run
- **Fix**: `debateEngine.ts:957` corpus_version number to string type mismatch

## Test plan

- [x] `npx vitest run` in worktree: 2903 passed, 11 skipped, 0 failed
- [x] `briefTimeout.test.ts`: 4/4 fault-injection cases pass
- [x] `/review-ts` self-cert: no findings in lib/debate scope

Blocks: t/2210 (renderer brief-timeout UX)
Fixes: pre-existing build break from #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)