### PR TITLE
fix(dev): kill stale vite on :5173 + fix ogit GIT_INDEX_FILE clobber in audit (Pattern #146 facet 2)

### DIFF
--- a/.githooks/agent-file-owner.sh
+++ b/.githooks/agent-file-owner.sh
@@ -62,7 +62,7 @@ overlay_dir="$root/.orca-git"
 have_overlay=0
 [ -d "$overlay_dir" ] && have_overlay=1
 
-ogit() { git --git-dir="$overlay_dir" --work-tree="$root" -C "$root" "$@"; }
+ogit() { GIT_INDEX_FILE="$overlay_dir/index" git --git-dir="$overlay_dir" --work-tree="$root" -C "$root" "$@"; }
 
 main_tracked()    { git -C "$root" ls-files -- '*AGENTS.md' 'AGENTS.md' 2>/dev/null | sort -u; }
 overlay_tracked() { [ "$have_overlay" -eq 1 ] || return 0

--- a/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
+++ b/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
@@ -432,6 +432,15 @@ function Start-LegacyElectronMode {
         }
     }
 
+    # Clear any stale process on port 5173 (vite dev server port) before launching
+    $staleConn = Get-NetTCPConnection -LocalPort 5173 -State Listen -ErrorAction SilentlyContinue
+    if ($staleConn) {
+        $stalePid = $staleConn.OwningProcess | Select-Object -First 1
+        Write-Info "Port 5173 in use by PID $stalePid — stopping stale dev server"
+        Stop-Process -Id $stalePid -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Milliseconds 500
+    }
+
     # Launch
     Push-Location $AppDir
     try {


### PR DESCRIPTION
Lands a parked commit (authored by @jpsnover + Diagnostics, 2026-08-06). Two independent dev/infra fixes:

## 1. `Show-TaxonomyEditor.ps1` — kill stale vite on :5173
`-Dev` now stops any process holding port 5173 before `npm run dev`, eliminating the recurring "Port already in use" error. (No conflict — file untouched on main since.)

## 2. `agent-file-owner.sh` — fix ogit `GIT_INDEX_FILE` clobber (**second Pattern #146 root cause**)
`git commit` sets `GIT_INDEX_FILE` to the *main-repo* index. The audit's `ogit()` inherited that env, so `ogit ls-files` read the **wrong index** → false double-track / tracked-by-neither failures **on every commit**. Fix: `ogit()` now sets `GIT_INDEX_FILE` explicitly to the overlay index.

This is a **distinct cause** from the `.worktrees` prune (#509 / t/2205): that one false-positived on worktree *checkouts*; this one false-positives at *commit time* via index clobber. Both are needed — cherry-pick **auto-merged** cleanly onto #509 (different regions of the file); verified both present.

## Gate verification
`sh .githooks/agent-file-owner.sh --audit` → exit 0, clean. Both fixes coexist in `on_disk()` (prune) and `ogit()` (index). The GIT_INDEX_FILE behavior was authored + validated by the reporter against live commits.

Relates t/2205, Pattern #146.