### PR TITLE
fix(ci): gate lib/debate tsc on ci-gate; add debate-scoped tsconfig (t/2217)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,13 +334,17 @@ jobs:
       - name: Check quality gates
         run: bash scripts/check-quality-gates.sh
 
-  # ── lib lint: ESLint for the shared lib (max-lines ADR-007 + async-safety) ──
+  # ── lib lint + typecheck: ESLint + tsc for the shared lib ──
   # lib is NOT a test-electron matrix app, so its `eslint .` runs nowhere else in
   # CI — without this job t/1685's max-lines gate is local-only (t/1692). Plain
   # `npm run lint`, NO --max-warnings=0: only ESLint ERRORS gate (hard-fail
   # max-lines + async-safety rules). The ADR-007 soft-warn LOC tier (t/1695,
   # warn@1000/1500) and pre-existing unused-disable warnings are advisory by
   # design; gating on them would re-introduce gate noise (t/1692#1, t/1695).
+  # TypeScript check added (t/2217): `lib/debate/tsconfig.json` covers lib/debate
+  # + its lib deps (ai-client, dictionary, flight-recorder). A dangling ESM import
+  # in calibrationOptimizer.ts passed CI green because tsc was never run for lib.
+  # lib-lint is now in ci-gate so tsc errors block merges.
   lib-lint:
     needs: [changes]
     if: >-
@@ -366,6 +370,10 @@ jobs:
       - name: Lint (errors gate; warnings advisory — see header)
         working-directory: lib
         run: pnpm run lint
+
+      - name: TypeScript check — lib/debate (t/2217)
+        working-directory: lib
+        run: pnpm exec tsc --noEmit -p debate/tsconfig.json
 
   # ── Commit hygiene: flags anonymous / undersized commit subjects (t/1319) ──
   # Annotation-only by design — never flips (t/1319). Visibility, not friction.
@@ -758,16 +766,18 @@ jobs:
   # sound because the path-filter is sound, so a FAILED `changes` job — which would
   # wrongly SKIP the code jobs — must fail the gate too, else untested code
   # false-greens. Scope = exact parity with the pre-t/1962 required-6 (the 3 code
-  # job IDs); lib-lint / dependency-audit / schema-validation are intentionally NOT
-  # gated here (not required contexts today — separate decision). Add future
-  # *required* jobs to `needs`; their path-filtered skips report OK.
+  # job IDs); dependency-audit / schema-validation are intentionally NOT gated here
+  # (not required contexts today — separate decision). Add future *required* jobs
+  # to `needs`; their path-filtered skips report OK.
   # python-embed-smoke (t/1989) is gated here: validates pip embedding stack value-
   # stability, path-filtered to requirements/.github/ci changes, skip = OK.
   # dependency-coverage (t/2077) is gated here: build-path dep coverage check,
   # path-filtered to container/lib changes, skip = OK.
+  # lib-lint (t/2217) is gated here: ESLint errors + tsc for shared lib;
+  # path-filtered to lib changes, skip = OK.
   ci-gate:
     name: ci-gate
-    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check]
+    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/lib/debate/calibrationOptimizer.ts
+++ b/lib/debate/calibrationOptimizer.ts
@@ -27,7 +27,7 @@ import {
   replicationGateByConfig,
 } from './calibrationLogger.js';
 import { PINNED_EVALUATOR_MODEL } from './neutralEvaluator.js';
-import { PROVISIONAL_WEIGHTS_FALLBACK } from './phaseTransitions.js';
+import { loadProvisionalWeights } from './phaseTransitions.js';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
@@ -239,11 +239,11 @@ export function applyRelevanceThresholdAdaptation(
       return { applied: false, reason: 'adaptation_enabled is false (manual override)' };
     }
 
-    const oldValue = weights.relevance?.embedding_threshold ?? PROVISIONAL_WEIGHTS_FALLBACK.relevance!.embedding_threshold;
+    const oldValue = weights.relevance?.embedding_threshold ?? loadProvisionalWeights().relevance!.embedding_threshold;
     if (oldValue === newValue) {
       return { applied: false, reason: 'file already at recommended value' };
     }
-    if (!weights.relevance) weights.relevance = { ...PROVISIONAL_WEIGHTS_FALLBACK.relevance! };
+    if (!weights.relevance) weights.relevance = { ...loadProvisionalWeights().relevance! };
     weights.relevance.embedding_threshold = newValue;
 
     // Record adjustment metadata

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -954,7 +954,7 @@ export class DebateEngine {
       app_version: this.config.appVersion,
       audience: this.config.audience,
       moderator_mode: this.config.moderatorMode ?? 'standard',
-      talmudic_references: this._talmudicCorpus ? { enabled: true, corpus_name: this._talmudicCorpus.name, corpus_path: path.resolve(this.config.talmudicReferences!.corpusPath), corpus_version: this._talmudicCorpus.version } : { enabled: false },
+      talmudic_references: this._talmudicCorpus ? { enabled: true, corpus_name: this._talmudicCorpus.name, corpus_path: path.resolve(this.config.talmudicReferences!.corpusPath), corpus_version: String(this._talmudicCorpus.version) } : { enabled: false },
       phase: 'setup',
       topic: {
         original: this.config.topic,

--- a/lib/debate/tsconfig.json
+++ b/lib/debate/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": [
+    "**/*.ts",
+    "../ai-client/**/*.ts",
+    "../dictionary/**/*.ts",
+    "../flight-recorder/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/__tests__",
+    "../ai-client/**/*.test.ts",
+    "../ai-client/__tests__",
+    "../dictionary/__tests__",
+    "../flight-recorder/**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `lib/debate/tsconfig.json` scoped to lib/debate + lib deps (ai-client, dictionary, flight-recorder), excluding electron-shared which needs types not available in lib's node_modules
- Add TypeScript check step to `lib-lint` CI job: `pnpm exec tsc --noEmit -p debate/tsconfig.json`
- Add `lib-lint` to `ci-gate` needs so tsc errors block merges (was advisory-only)

## Root cause (see t/2217#1)

A dangling ESM import (`PROVISIONAL_WEIGHTS_FALLBACK` removed from `phaseTransitions.ts` in #513 but left in `calibrationOptimizer.ts`) merged green because:

1. `lib/tsconfig.json` covers `lib/debate/` but was never run in CI — `lib-lint` ran ESLint only
2. Vitest's Vite module transform doesn't do native ESM named-export validation — missing exports silently become `undefined`, so tests that import the module passed without error

The `SyntaxError: does not provide an export named '...'` only fires under native ESM (`npx tsx`, `node --input-type=module`), which is exactly the CLI production path.

## Test plan

- [ ] `lib-lint` CI job passes: ESLint green + `tsc --noEmit -p debate/tsconfig.json` clean
- [ ] CI gate correctly reflects lib-lint result (fail on tsc error, skip on non-lib PR)
- [ ] Verified locally: `pnpm exec tsc --noEmit -p debate/tsconfig.json` in `lib/` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)