### PR TITLE
feat(debate): per-statement elapsed-time store slice for progress indicator (t/2214)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/generation.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/generation.ts
@@ -56,7 +56,7 @@ export async function generateTextWithProgress(
   set: (partial: any) => void,
   timeoutMs?: number,
 ): Promise<{ text: string }> {
-  set({ debateActivity: activity, debateProgress: null });
+  set({ debateGeneratingStartedAt: Date.now(), debateActivity: activity, debateProgress: null });
   const unsubscribe = api.onGenerateTextProgress((progress: Record<string, unknown>) => {
     set({ debateProgress: normalizeProgress(progress) });
   });
@@ -65,7 +65,7 @@ export async function generateTextWithProgress(
     return result;
   } finally {
     unsubscribe();
-    set({ debateProgress: null, debateActivity: null });
+    set({ debateProgress: null, debateActivity: null, debateGeneratingStartedAt: null });
   }
 }
 
@@ -206,7 +206,7 @@ export function makeStageGenerate(
   model: string,
 ): (prompt: string, callModel: string, options: { temperature?: number; timeoutMs?: number }, label: string) => Promise<string> {
   return async (prompt, callModel, options, label) => {
-    set({ debateActivity: label, debateProgress: null });
+    set({ debateGeneratingStartedAt: Date.now(), debateActivity: label, debateProgress: null });
     const unsubscribe = api.onGenerateTextProgress((progress: Record<string, unknown>) => {
       set({ debateProgress: normalizeProgress(progress) });
     });
@@ -215,7 +215,7 @@ export function makeStageGenerate(
       return result.text;
     } finally {
       unsubscribe();
-      set({ debateProgress: null, debateActivity: null });
+      set({ debateProgress: null, debateActivity: null, debateGeneratingStartedAt: null });
     }
   };
 }

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/configSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/configSlice.ts
@@ -15,6 +15,7 @@ import { cancelAndResetAbort } from '../shared/guards';
 export interface ConfigSlice {
   // Generation state
   debateGenerating: SpeakerId | null;
+  debateGeneratingStartedAt: number | null;
   debateError: string | null;
   debateProgress: { attempt: number; maxRetries: number; backoffSeconds?: number; limitType?: string; limitMessage?: string; phase?: string } | null;
   debateActivity: string | null;
@@ -91,6 +92,7 @@ export interface ConfigSlice {
 
 export const createConfigSlice: StateCreator<DebateStore, [], [], ConfigSlice> = (set, get) => ({
   debateGenerating: null,
+  debateGeneratingStartedAt: null,
   debateError: null,
   debateProgress: null,
   debateActivity: null,
@@ -157,7 +159,7 @@ export const createConfigSlice: StateCreator<DebateStore, [], [], ConfigSlice> =
   cancelDebate: () => {
     const debateId = get().activeDebateId;
     cancelAndResetAbort();
-    set({ debateGenerating: null, debateActivity: null });
+    set({ debateGenerating: null, debateGeneratingStartedAt: null, debateActivity: null });
     if (debateId) {
       getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: debateId, message: 'debate.ended', data: { reason: 'cancelled' } });
       trackDebateAbandon(debateId, 'cancelled');
@@ -199,7 +201,7 @@ export const createConfigSlice: StateCreator<DebateStore, [], [], ConfigSlice> =
   setDiagPopoutOpen: (open) => set({ diagPopoutOpen: open }),
   inspectNode: (nodeId) => set({ inspectedNodeId: nodeId }),
   setSelectedRef: (ref) => set({ selectedRef: ref }),
-  setGenerating: (pover) => set({ debateGenerating: pover }),
+  setGenerating: (pover) => set({ debateGenerating: pover, debateGeneratingStartedAt: pover !== null ? Date.now() : null }),
   setError: (error) => set({ debateError: error, debateRetryAction: error ? get().debateRetryAction : null, dailyLimitPaused: error ? get().dailyLimitPaused : false }),
   setErrorWithRetry: (error, retryAction) => set({ debateError: error, debateRetryAction: retryAction }),
 });


### PR DESCRIPTION
## Summary
- Adds `debateGeneratingStartedAt: number | null` to `ConfigSlice` (interface + initial state + cancelDebate clear + setGenerating set/clear)
- Sets `Date.now()` before `debateGenerating` speaker is assigned in both `generateTextWithProgress` and `makeStageGenerate` (TL note 2 ordering), cleared in the finally block
- Store-only slice — `StatementProgressIndicator` component (DebateWorkspace scope, t/2214#4) reads this field to drive the M:SS count-up timer

## Test plan
- [ ] main tsc: clean ✓
- [ ] server tsc: clean ✓
- [ ] eslint: 0 errors ✓
- [ ] vitest useDebateStore: 213/213 passed ✓
- [ ] CI green (renderer tsc verified on origin/main; worktree pnpm virtual store gap for mdast/unified in unrelated files only)

Part of t/2214 (store slice). DebateWorkspace component half already committed (t/2214#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
