### PR TITLE
fix(debate): thread calibrationDataRoot through engine to isolate cal log (t/2219)

### DIFF
--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -466,6 +466,9 @@ async function main(): Promise<void> {
     });
   }
 
+  // Mirror the CLI's cal-log isolation into the engine so both write paths use the same root (t/2219).
+  engineConfig.calibrationDataRoot = config.outputDir != null ? outputDir : dataRoot;
+
   const partialPath = path.join(outputDir, `${slug}-partial.json`);
   engineConfig.onSnapshot = (session, trigger) => {
     fs.writeFileSync(partialPath, JSON.stringify(session, null, 2), 'utf-8');

--- a/lib/debate/debateEngine.calIsolation.test.ts
+++ b/lib/debate/debateEngine.calIsolation.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression gate: engine respects calibrationDataRoot from DebateConfig (t/2219).
+// When set, the engine's appendCalibrationLog call must use it — not the system-resolved
+// dataRoot — so isolated experiment runs don't contaminate the main calibration log.
+
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+vi.mock('./calibrationLogger.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./calibrationLogger.js')>();
+  return {
+    ...actual,
+    appendCalibrationLog: vi.fn(),
+    readCalibrationLog: vi.fn().mockReturnValue([]),
+  };
+});
+
+import { DebateEngine } from './debateEngine.js';
+import { appendCalibrationLog } from './calibrationLogger.js';
+import { createMockAdapter, createMinimalTaxonomy, createDefaultConfig } from './debateEngine.testHelpers.js';
+
+const richResponse = JSON.stringify({
+  statement: 'Mock response', my_claims: [], taxonomy_refs: [],
+  move_types: [], claims: [], areas_of_agreement: [],
+  areas_of_disagreement: [], cruxes: [], unresolved_questions: [],
+  summary: 'Mock', responder: 'safetyist', addressing: 'accelerationist',
+  focus_point: 'test', agreement_detected: false, intervene: false,
+  suggested_move: 'PIN', target_debater: 'safetyist',
+  trigger_reasoning: 'r', trigger_evidence: 'e',
+  outcome: 'accept', score: 0.8, flags: [], clarifies_taxonomy: [],
+  overall_assessment: { notes: 'test' },
+});
+const manyResponses = Array.from({ length: 300 }, () => richResponse);
+
+describe('DebateEngine calibrationDataRoot isolation (t/2219)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls appendCalibrationLog with calibrationDataRoot when set', async () => {
+    const calRoot = '/isolated/cal-root';
+    const config = createDefaultConfig({ rounds: 1, calibrationDataRoot: calRoot });
+    const engine = new DebateEngine(config, createMockAdapter(manyResponses), createMinimalTaxonomy());
+    await engine.run();
+
+    const mockFn = vi.mocked(appendCalibrationLog);
+    expect(mockFn).toHaveBeenCalled();
+    expect(mockFn.mock.calls[0][1]).toBe(calRoot);
+  });
+
+  it('calls appendCalibrationLog with system dataRoot when calibrationDataRoot is not set', async () => {
+    const config = createDefaultConfig({ rounds: 1 });
+    const engine = new DebateEngine(config, createMockAdapter(manyResponses), createMinimalTaxonomy());
+    await engine.run();
+
+    const mockFn = vi.mocked(appendCalibrationLog);
+    expect(mockFn).toHaveBeenCalled();
+    // Must be a non-empty filesystem path — not '/isolated/cal-root'
+    const calledRoot = mockFn.mock.calls[0][1];
+    expect(typeof calledRoot).toBe('string');
+    expect(calledRoot.length).toBeGreaterThan(0);
+    expect(calledRoot).not.toBe('/isolated/cal-root');
+  });
+});

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -655,7 +655,6 @@ export class DebateEngine {
       if (this._overgenCoherenceGateMiss) {
         dataPoint.coherence_gate_miss = true;
       }
-      // Resolve data root — env var or .aitriad.json fallback
       const __engineDir = path.dirname(fileURLToPath(import.meta.url));
       const repoRoot = resolveRepoRoot(__engineDir);
       const dataRoot = resolveDataRoot(repoRoot);
@@ -801,11 +800,7 @@ export class DebateEngine {
 
   // ── Resume from checkpoint ──────────────────────────────
 
-  /**
-   * Resume a debate from a crash-recovery checkpoint. Runs only the
-   * missing tail: synthesis (if not already present) and all post-synthesis
-   * passes. Returns a complete session ready for output.
-   */
+  /** Resume from checkpoint — runs only the missing tail: synthesis + post-synthesis passes. */
   static async resume(
     checkpoint: DebateSession,
     config: DebateConfig,

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -659,7 +659,7 @@ export class DebateEngine {
       const __engineDir = path.dirname(fileURLToPath(import.meta.url));
       const repoRoot = resolveRepoRoot(__engineDir);
       const dataRoot = resolveDataRoot(repoRoot);
-      appendCalibrationLog(dataPoint, dataRoot);
+      appendCalibrationLog(dataPoint, this.config.calibrationDataRoot ?? dataRoot);
 
       // Post-debate adaptive threshold write-back
       this._claimPipeline.runPostDebateCalibration(dataRoot);

--- a/lib/debate/debateEngine/internals.ts
+++ b/lib/debate/debateEngine/internals.ts
@@ -78,6 +78,9 @@ export interface DebateConfig {
   briefTimeoutMs?: number;
   /** Max brief-stage timeout retries before aborting the opening. Default: 3. */
   briefMaxRetries?: number;
+  /** When set, calibration log writes go here instead of the resolved system data root.
+   *  Prevents isolated experiment runs from contaminating the main calibration log (t/2219). */
+  calibrationDataRoot?: string;
   /** Perturbation testing config — inject adversarial prompt at a specific turn for resilience evaluation. Evaluation/benchmark only. */
   perturbation?: import('../types.js').PerturbationConfig;
   /** Run topic wisdom scoring at setup. Default: true. */


### PR DESCRIPTION
## Summary

- `DebateConfig.calibrationDataRoot?: string` added to `internals.ts` — optional override for the cal-log write root inside the engine
- `debateEngine.ts:662` now calls `appendCalibrationLog(dataPoint, this.config.calibrationDataRoot ?? dataRoot)` instead of always using the system-resolved `dataRoot`
- `cli.ts` sets `engineConfig.calibrationDataRoot = config.outputDir != null ? outputDir : dataRoot` so both write paths (CLI and engine) share the same isolated root when `outputDir` is configured

**Root cause:** t/2216 fixed the CLI's cal-log write but missed the engine's independent `appendCalibrationLog` call at `debateEngine.ts:662`. Every isolated experiment run was still leaking two rows into the main calibration log (one from each writer). Blocks t/2192 round-count sweep.

## Test plan

- [x] `debateEngine.calIsolation.test.ts` — 2 new tests via `vi.mock`: verifies engine calls `appendCalibrationLog` with `calibrationDataRoot` when set; verifies system `dataRoot` is used as fallback when not set
- [x] Full debate test suite: 2907 passed, 0 failures
- [x] `tsc -p tsconfig.json --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
