### PR TITLE
fix(bridge): missing onBriefTimeout/onBriefRetriesExhausted delegates in electron-bridge (t/2221)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -367,6 +367,8 @@ export const api: AppAPI = {
   focusNodeInMainWindow: (nodeId) => window.electronAPI.focusNodeInMainWindow(nodeId),
   onTerminalData: (cb) => window.electronAPI.onTerminalData(cb),
   onTerminalExit: (cb) => window.electronAPI.onTerminalExit(cb),
+  onBriefTimeout: (cb) => window.electronAPI.onBriefTimeout(cb),
+  onBriefRetriesExhausted: (cb) => window.electronAPI.onBriefRetriesExhausted(cb),
   captureScreenshot: (opts) => window.electronAPI.captureScreenshot(opts),
 
   // Feature flags — single-user desktop, no server flags


### PR DESCRIPTION
## Summary
- Adds 2 missing delegates to `electron-bridge.ts` that caused a fatal crash ("bridge.onBriefTimeout is not a function") on the Debate tab in Electron mode
- Re-applied from TL commit 8f95dffd (branch t2210-brief-timeout-ux) per p/336#32
- `web-bridge.ts` already has the browser-local bus (t/2218, PR #530); this wires the Electron path via `window.electronAPI`

## Test plan
- [ ] CI green
- [ ] Debate tab no longer crashes on open in Electron mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)