### PR TITLE
docs(sage): record pattern #148 -- bash double-quoting unsafe for special-char filenames

### DIFF
--- a/operations/sage/docs/LessonsLearned.md
+++ b/operations/sage/docs/LessonsLearned.md
@@ -3022,3 +3022,24 @@ Institutional memory for failure patterns across the AI Triad Research project.
 **Status:** Active — 1 instance (Rosetta Stone p/6#47). Single occurrence; recorded because bare-stash-in-shared-tree is a recurring pattern setup.
 
 **Applies To:** All agents working in the shared main checkout alongside concurrent uncommitted changes from other agents.
+
+---
+
+## #148 [Build] Bash Double-Quoting Does Not Prevent `$(...)` / `%` Expansion in Filenames — Use PowerShell `Remove-Item` on win32
+
+**Pattern:** On Windows MSYS bash, filenames containing `$(`, `)`, or `%` characters expand inside double-quoted strings — `rm "file$(expr)"` triggers command substitution for `expr` before `rm` runs. The filename is never passed literally; bash evaluates the special chars regardless of double quotes. Result: the wrong path is removed, or the command errors with an unexpected substitution.
+
+**Instances:**
+- 2026-08-06 — DebateUI (p/83#6): `rm` on filenames containing `$(`, `)`, `%` — bash expanded them despite double-quoting. Fix: PowerShell `Remove-Item` with a literal string array, which treats all characters as literal with no shell expansion.
+
+**Root Cause:** In bash, double quotes suppress word-splitting and glob expansion but do NOT prevent command substitution (`$(...)`) or variable expansion (`$var`, `%VAR%`). On MSYS bash on Windows, `%VAR%` can also expand in some contexts. A filename containing these chars must be passed via a mechanism with no expansion layer — PowerShell single-quoted strings or `Remove-Item` with an array.
+
+**Prevention:**
+1. **On win32, use the PowerShell tool for `rm`/`del` when filenames may contain `$(`, `)`, `$`, or `%`** — `Remove-Item -LiteralPath 'file$(expr)'` or pass as an array; single quotes in PowerShell are always literal.
+2. **In bash, single quotes suppress command substitution** — `rm 'file$(expr)'` is safe, but single quotes cannot span across variable interpolation, making them error-prone for dynamic filenames.
+3. **When constructing dynamic filenames in bash, use `printf '%s' "$var"` or `$'...'` quoting** and test with `echo` first to see what the shell actually expands.
+4. **Companion to ADR-004 / Shell Quoting Rule** — special chars in file _content_ use Edit/Write tools; special chars in file _names_ at deletion time require PowerShell.
+
+**Status:** Active — 1 instance (DebateUI p/83#6).
+
+**Applies To:** All agents using Bash `rm`/`mv`/`cp` with dynamically-named files on win32 that may contain shell metacharacters.

--- a/operations/sage/docs/lessons/build.md
+++ b/operations/sage/docs/lessons/build.md
@@ -1808,3 +1808,24 @@ Failure patterns related to builds, CI, tooling, environment, and git operations
 **Status:** Active — 1 instance (DevOps, p/26#63). Silent wrong-branch push; high damage potential.
 
 **Applies To:** All agents pushing from a worktree where the worktree branch name differs from the PR remote target branch.
+
+---
+
+## #148 [Build] Bash Double-Quoting Does Not Prevent `$(...)` / `%` Expansion in Filenames — Use PowerShell `Remove-Item` on win32
+
+**Pattern:** On Windows MSYS bash, filenames containing `$(`, `)`, or `%` characters expand inside double-quoted strings — `rm "file$(expr)"` triggers command substitution for `expr` before `rm` runs. The filename is never passed literally. Result: wrong path removed or command errors on unexpected substitution.
+
+**Instances:**
+- 2026-08-06 — DebateUI (p/83#6): `rm` on filenames with `$(`, `)`, `%` — bash expanded them despite double-quoting. Fix: PowerShell `Remove-Item` with a literal string array.
+
+**Root Cause:** In bash, double quotes suppress word-splitting and glob expansion but NOT command substitution (`$(...)`) or variable expansion. A filename containing these chars must reach the filesystem layer via a mechanism with no expansion — PowerShell single-quoted strings or `Remove-Item -LiteralPath`.
+
+**Prevention:**
+1. **On win32, use PowerShell `Remove-Item -LiteralPath`** (or an array argument) for filenames that may contain `$(`, `)`, `$`, or `%`.
+2. In bash, single quotes ARE safe for literal filenames — `rm 'file$(expr)'` — but can't span variable interpolation; risky for dynamic filenames.
+3. Test with `echo` before `rm` to see what bash actually expands.
+4. **Companion to ADR-004 / Shell Quoting Rule** — special chars in file _content_ use Edit/Write tools; special chars in file _names_ at deletion time require PowerShell.
+
+**Status:** Active — 1 instance (DebateUI p/83#6).
+
+**Applies To:** All agents using Bash `rm`/`mv`/`cp` on win32 with dynamically-named files that may contain shell metacharacters.


### PR DESCRIPTION
Records pattern #148 — `rm` on filenames with `$(`, `)`, `%` expands despite double-quoting in MSYS bash. Fix: PowerShell `Remove-Item -LiteralPath` or array argument treats all chars as literal.

**Source:** p/83#6 (DebateUI)

**Files changed:** LessonsLearned.md, lessons/build.md

🤖 Sage (Orca) — operations/sage
