### PR TITLE
feat(scripts): add Test-AIBackendHealth cmdlet (t/2225)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -107,6 +107,8 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-FreeTierStatus` | Live free-tier budget/usage report (live config + token consumption) |
 | `Test-AzureHealth` | Azure infra status |
 | `Test-GitHubHealth` | GitHub platform + CI status |
+| `Test-AIApiKey` | Probe AI backend auth endpoints (no tokens consumed) — confirm a key is present and accepted before running jobs |
+| `Test-AIBackendHealth` | Full completion round-trip probe per backend — use before a debate run to surface degraded/unreachable models (t/2212) |
 | `Get-ContainerAppRevision` | Query ACA revisions by mode (Active/Stale/Fqdn) — replaces raw `az containerapp revision` calls (t/1498) |
 | `New-ContainerAppRevision` | Blue-green: deploy a new ACA revision at 0% traffic; returns real `RevisionName` for the promotion chain (t/1500 Phase 3) |
 | `Set-ContainerAppTraffic` | Shift traffic to a named revision with retry — call BEFORE `Disable-ContainerAppRevision` in rollback (t/1500 Phase 3) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -170,6 +170,7 @@
         # t/1308 — cc→sit migration
         'Invoke-CcToSitMigration'
         'Test-AIApiKey'
+        'Test-AIBackendHealth'
         'Test-AIModelsConfig'
         # t/1492 — GHCR cleanup
         'Remove-StaleContainerImages'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -882,6 +882,7 @@ Export-ModuleMember -Function @(
     # t/1308 — cc→sit migration
     'Invoke-CcToSitMigration'
     'Test-AIApiKey'
+    'Test-AIBackendHealth'
     'Test-AIModelsConfig'
     # t/1492 — GHCR cleanup
     'Remove-StaleContainerImages'

--- a/scripts/AITriad/Public/Test-AIBackendHealth.ps1
+++ b/scripts/AITriad/Public/Test-AIBackendHealth.ps1
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Probes each AI backend with a minimal completion request and reports latency and status.
+.DESCRIPTION
+    Sends a 1-token completion probe ("ping") through the same Invoke-AIApi path used by all
+    production cmdlets, using the default model for each backend from ai-models.json. Reports
+    reachability, round-trip latency, and whether the completion succeeded.
+
+    Unlike Test-AIApiKey (which hits an auth-only /models endpoint without consuming tokens),
+    Test-AIBackendHealth exercises the full completion stack — key resolution, serialization,
+    transport, and deserialization. A backend that passes Test-AIApiKey but fails here has a
+    model-level or quota problem.
+
+    Per-backend failure is returned as a row with status 'error' or 'timeout', not a thrown
+    exception. Only unrecoverable setup failures (e.g., ai-models.json not found) throw.
+
+.PARAMETER Backend
+    Single backend to probe. One of: gemini, claude, groq, openai, deepseek, azure, zai,
+    moonshot, ollama.
+
+.PARAMETER All
+    Probe every backend that has a default model in ai-models.json.
+
+.PARAMETER TimeoutSec
+    Per-probe timeout in seconds. Default 15.
+
+.EXAMPLE
+    Test-AIBackendHealth -Backend gemini
+    # Returns one row: backend, model, status, latency_ms.
+
+.EXAMPLE
+    Test-AIBackendHealth -All | Format-Table Backend, Model, Status, LatencyMs, ErrorMessage
+
+.EXAMPLE
+    Test-AIBackendHealth -All | Where-Object Status -ne 'ok'
+    # Surface only degraded backends before starting a debate run.
+
+.LINK
+    Test-AIApiKey
+.LINK
+    Show-AITriadHelp
+#>
+function Test-AIBackendHealth {
+    [CmdletBinding(DefaultParameterSetName = 'One')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'One', Position = 0)]
+        [ValidateSet('gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama')]
+        [string]$Backend,
+
+        [Parameter(Mandatory, ParameterSetName = 'All')]
+        [switch]$All,
+
+        [ValidateRange(1, 300)]
+        [int]$TimeoutSec = 15
+    )
+
+    Set-StrictMode -Version Latest
+
+    # ── Load ai-models.json defaults ────────────────────────────────────
+    $ConfigPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..' '..' '..' 'ai-models.json'))
+    if (-not (Test-Path $ConfigPath)) {
+        throw (New-ActionableError `
+            -Goal     'Load AI backend defaults for health probe' `
+            -Problem  "ai-models.json not found at: $ConfigPath" `
+            -Location 'Test-AIBackendHealth' `
+            -NextSteps 'Verify the repo root contains ai-models.json and that the module is loaded from its expected path.')
+    }
+    $Config  = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+    $Defaults = $Config.defaults
+
+    # ── Inner probe ──────────────────────────────────────────────────────
+    function _Probe-Backend {
+        param([string]$B, [string]$ModelId, [int]$Timeout)
+
+        $Row = [ordered]@{
+            Backend      = $B
+            Model        = $ModelId
+            Status       = 'error'
+            LatencyMs    = $null
+            ErrorMessage = $null
+            TestedAt     = [datetime]::UtcNow
+        }
+
+        if ([string]::IsNullOrEmpty($ModelId)) {
+            $Row['ErrorMessage'] = "No default model configured for backend '$B' in ai-models.json."
+            return [PSCustomObject]$Row
+        }
+
+        $Sw = [System.Diagnostics.Stopwatch]::StartNew()
+        $AIResult = Invoke-AIApi `
+            -Prompt         'ping' `
+            -Model          $ModelId `
+            -MaxTokens      5 `
+            -TimeoutSec     $Timeout `
+            -MaxRetries     0 `
+            -Temperature    0.0 `
+            -SkipTokenCheck `
+            -WarningVariable WarnVar
+        $Sw.Stop()
+
+        $Row['LatencyMs'] = [int]$Sw.ElapsedMilliseconds
+
+        if ($null -ne $AIResult -and $AIResult.PSObject.Properties['Text']) {
+            $Row['Status'] = 'ok'
+        } else {
+            $WarnText = if (@($WarnVar).Count -gt 0) { "$($WarnVar[0])" } else { $null }
+            $IsTimeout = ($Sw.ElapsedMilliseconds -ge ($Timeout * 1000 - 500)) -or
+                         ($WarnText -match 'timeout|timed.out|TaskCanceled|OperationCanceled')
+            $Row['Status']       = if ($IsTimeout) { 'timeout' } else { 'error' }
+            $Row['ErrorMessage'] = if ($WarnText) { $WarnText } else {
+                if ($IsTimeout) { "Backend '$B' did not respond within ${Timeout}s." }
+                else            { "Invoke-AIApi returned null for backend '$B'." }
+            }
+        }
+
+        return [PSCustomObject]$Row
+    }
+
+    # ── Dispatch ─────────────────────────────────────────────────────────
+    if ($PSCmdlet.ParameterSetName -eq 'All') {
+        foreach ($B in $Defaults.PSObject.Properties.Name) {
+            $MId = $Defaults.$B
+            _Probe-Backend -B $B -ModelId $MId -Timeout $TimeoutSec
+        }
+    } else {
+        $MId = if ($Defaults.PSObject.Properties[$Backend]) { $Defaults.$Backend } else { $null }
+        _Probe-Backend -B $Backend -ModelId $MId -Timeout $TimeoutSec
+    }
+}

--- a/tests/Test-AIBackendHealth.Tests.ps1
+++ b/tests/Test-AIBackendHealth.Tests.ps1
@@ -1,0 +1,107 @@
+# Tag: enrichment (t/2212)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Unit tests for Test-AIBackendHealth (t/2212).
+.DESCRIPTION
+    Mocks Invoke-AIApi to verify status/latency/error-message output without
+    hitting live backends. Exercises: ok, timeout, error, and -All dispatch.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-AIBackendHealth' -Tag 'enrichment' {
+
+    Context 'Single backend — ok' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad {
+                [PSCustomObject]@{ Text = 'pong'; Backend = 'gemini'; Model = 'gemini-3.6-flash'; Truncated = $false; Usage = $null; RawResponse = $null }
+            }
+        }
+
+        It 'Returns status ok when Invoke-AIApi succeeds' {
+            $Result = Test-AIBackendHealth -Backend gemini
+            $Result.Status   | Should -Be 'ok'
+            $Result.Backend  | Should -Be 'gemini'
+            $Result.LatencyMs | Should -BeGreaterOrEqual 0
+            $Result.ErrorMessage | Should -BeNullOrEmpty
+        }
+
+        It 'Populates Model from ai-models.json defaults' {
+            $Result = Test-AIBackendHealth -Backend gemini
+            $Result.Model | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'Single backend — error (null result, no timeout)' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad { $null }
+        }
+
+        It 'Returns status error when Invoke-AIApi returns null' {
+            $Result = Test-AIBackendHealth -Backend gemini
+            $Result.Status | Should -Be 'error'
+            $Result.ErrorMessage | Should -Not -BeNullOrEmpty
+        }
+
+        It 'Does not throw — failure is a reported row' {
+            { Test-AIBackendHealth -Backend claude } | Should -Not -Throw
+        }
+    }
+
+    Context 'Single backend — timeout' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad {
+                # Simulate a slow call by writing a timeout warning, then returning null.
+                Write-Warning 'Request timed out after 15 seconds (TaskCanceled)'
+                $null
+            }
+        }
+
+        It 'Returns status timeout when warning contains timeout keyword' {
+            $Result = Test-AIBackendHealth -Backend gemini -TimeoutSec 15
+            $Result.Status | Should -Be 'timeout'
+        }
+    }
+
+    Context '-All dispatch' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad {
+                [PSCustomObject]@{ Text = 'ok'; Backend = 'x'; Model = 'x'; Truncated = $false; Usage = $null; RawResponse = $null }
+            }
+        }
+
+        It 'Emits one row per backend in ai-models.json defaults' {
+            $Results = @(Test-AIBackendHealth -All)
+            $Results.Count | Should -BeGreaterThan 1
+        }
+
+        It 'All rows have required properties' {
+            $Results = @(Test-AIBackendHealth -All)
+            foreach ($R in $Results) {
+                $R.PSObject.Properties.Name | Should -Contain 'Backend'
+                $R.PSObject.Properties.Name | Should -Contain 'Model'
+                $R.PSObject.Properties.Name | Should -Contain 'Status'
+                $R.PSObject.Properties.Name | Should -Contain 'LatencyMs'
+                $R.PSObject.Properties.Name | Should -Contain 'ErrorMessage'
+            }
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'Rejects an unknown backend name' {
+            { Test-AIBackendHealth -Backend 'nonexistent-backend' } | Should -Throw
+        }
+
+        It 'Requires either -Backend or -All' {
+            { Test-AIBackendHealth } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
Salvages Test-AIBackendHealth from commit 8f95dffd (shared-tree incident t/2222).

**Self-certified against /add-ps-cmdlet — no deviations.**

- 9/9 Pester tests pass locally
- verify:config PS gates pass (Test-AIModelsConfig, ModelLiteralLint)
- verify:config vitest gate fails on main and in this worktree identically — pre-existing missing file `main/__tests__/resolveApiModelId.test.ts` not on origin/main; not introduced by this change