### PR TITLE
feat(debate-workspace): add StatementProgressIndicator + wire into DebateWorkspace (t/2224)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -34,7 +34,8 @@ import { useUserProfile } from '../../hooks/useAuthStatus';
 import { CommunityShareBanner } from '../shared/CommunityShareBanner';
 import { CoverageBadge } from './TaxonomyRefs';
 import { StatementCard, ProbingCard, FactCheckCard, EntryDeleteControls, HighlightedText, PhaseHairline } from './StatementCard';
-import { PhaseProgressBar, SessionPhaseStepper, ProgressIndicator, DebaterToggles, DebateActions } from './DebateActionBar';
+import { PhaseProgressBar, SessionPhaseStepper, DebaterToggles, DebateActions } from './DebateActionBar';
+import { StatementProgressIndicator } from './StatementProgressIndicator';
 import { ClarificationActions, ClaimsEditor, RefinedTopicEditor, TopicScoreComparison } from './ClarificationPanel';
 import { OpeningActions } from './OpeningPanel';
 import { ExplorationSummaryCard } from './ExplorationSummaryCard';
@@ -805,10 +806,7 @@ function DebateTranscriptColumn({
             </span>
             <span className="debate-statement-type">thinking...</span>
           </div>
-          <ProgressIndicator />
-          <div className="debate-generating-dots">
-            <span /><span /><span />
-          </div>
+          <StatementProgressIndicator />
         </div>
       )}
       <div ref={transcriptEndRef} />

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementProgressIndicator.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementProgressIndicator.css
@@ -1,0 +1,72 @@
+.stmt-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 1.5rem;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  padding: 4px 0;
+}
+
+/* Spinner icon — CSS-only rotating ring */
+.stmt-progress-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  border-top-color: var(--text-secondary);
+  animation: stmt-spin 0.9s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes stmt-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Error icon — simple ⚠ shape via CSS */
+.stmt-progress-icon--error {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.stmt-progress-icon--error::before {
+  content: '⚠';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--color-warning, #d97706);
+}
+
+.stmt-progress--error {
+  color: var(--color-warning, #d97706);
+}
+
+.stmt-progress-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
+}
+
+.stmt-progress-timer {
+  font-variant-numeric: tabular-nums;
+  font-style: normal;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  letter-spacing: 0.5px;
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementProgressIndicator.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementProgressIndicator.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useDebateStore } from '../../hooks/useDebateStore';
+import './StatementProgressIndicator.css';
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+export function StatementProgressIndicator() {
+  const { debateGenerating, debateActivity, debateGeneratingStartedAt, debateError } = useDebateStore(
+    useShallow(s => ({
+      debateGenerating: s.debateGenerating,
+      debateActivity: s.debateActivity,
+      debateGeneratingStartedAt: s.debateGeneratingStartedAt,
+      debateError: s.debateError,
+    }))
+  );
+
+  const [elapsed, setElapsed] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (debateGenerating && debateGeneratingStartedAt !== null) {
+      setElapsed(Date.now() - debateGeneratingStartedAt);
+      intervalRef.current = setInterval(() => {
+        setElapsed(Date.now() - (debateGeneratingStartedAt as number));
+      }, 1000);
+    } else {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [debateGenerating, debateGeneratingStartedAt]);
+
+  // TL note 1: clear interval immediately when error occurs — don't wait for unmount
+  useEffect(() => {
+    if (debateError && intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, [debateError]);
+
+  if (!debateGenerating && !debateError) return null;
+
+  if (debateError) {
+    return (
+      <div className="stmt-progress stmt-progress--error" role="alert">
+        <span className="stmt-progress-icon stmt-progress-icon--error" aria-hidden="true" />
+        <span className="stmt-progress-label">{debateError}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="stmt-progress stmt-progress--generating" aria-live="polite">
+      <span className="stmt-progress-spinner" aria-hidden="true" />
+      <span className="stmt-progress-label">{debateActivity ?? 'Generating…'}</span>
+      <span className="stmt-progress-timer" aria-label={`Elapsed: ${formatElapsed(elapsed)}`}>
+        {formatElapsed(elapsed)}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Lands `StatementProgressIndicator.tsx` and `.css` rescued from shared-tree preservation commit `8f95dffd` (t/2222 incident)
- Replaces `ProgressIndicator` + `debate-generating-dots` with the new component: CSS spinner + activity label + elapsed timer during generation; error state on `debateError`
- DebateWorkspace.tsx reconciled against current main (post-#532) — hunk applied cleanly, no conflicts

## Test plan
- [ ] 15/15 scoped vitest files green (243 tests) in worktree
- [ ] tsc/eslint/depcruise/vite build green
- [ ] Two pre-existing integration test failures (`t2020Security.test.ts`, undici skew) unrelated to this change and present on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)
