### PR TITLE
feat(vite): replace require() with createRequire for configLoader:native compat (t/2226)

### DIFF
--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -5,9 +5,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import { execSync } from 'child_process';
+import { createRequire } from 'module';
 import fs from 'fs';
 import path from 'path';
 
+const require = createRequire(import.meta.url);
 const isWeb = process.env.VITE_TARGET === 'web';
 
 function getGitVersion(): string {


### PR DESCRIPTION
## Summary
- Adds `import { createRequire } from "module"` and `const require = createRequire(import.meta.url)` to `vite.config.ts`
- Fixes the 5 remaining `require()` calls (`./package.json` fallback in `getGitVersion()` + 4 `**/package.json` reads in `__COMPONENT_VERSIONS__`) that would fail under Vite's native ESM configLoader
- Together with t/2220 (`__dirname` → `import.meta.dirname`), this eliminates all CJS-only patterns from the config file

## Test plan
- [x] `npm run build:main` (`tsc -p tsconfig.main.json`) exits 0 — confirmed locally
- [x] `npx vite build` exits 0 with zero unsupported-feature / native-configLoader warnings — confirmed locally
- [ ] CI green

Closes t/2226

🤖 Generated with [Claude Code](https://claude.com/claude-code)