### PR TITLE
fix(turnPipeline): raise parse-failure retries 1->3, fix plan stage missing retry guard (t/2228)

### DIFF
--- a/lib/debate/__tests__/stageParseRetry.test.ts
+++ b/lib/debate/__tests__/stageParseRetry.test.ts
@@ -1,0 +1,211 @@
+// Regression tests for t/2228: stage parse-failure retry (brief + plan, runTurnPipeline + runOpeningPipeline).
+// Covers: success-after-retry (guard fires, pipeline completes) and exhaustion (guard bounds, throws after MAX_STAGE_RETRIES+1).
+
+import { describe, it, expect, vi } from 'vitest';
+import { runTurnPipeline, runOpeningPipeline } from '../turnPipeline.js';
+import type { TurnPipelineInput, StageGenerateFn } from '../turnPipeline.js';
+import type { OpeningPipelineInput } from '../turnPipeline.js';
+import { ActionableError } from '../errors.js';
+
+// ── Shared fixtures ──────────────────────────────────────
+
+const VALID_BRIEF = {
+  situation_assessment: 'Debate centers on AI governance.',
+  key_claims_to_address: [],
+  relevant_commitments: [],
+  edge_tensions: [],
+  phase_considerations: 'argumentation',
+};
+
+const VALID_PLAN = {
+  strategic_goal: 'Rebut the overreach argument by citing proportionate-regulation evidence from the EU AI Act.',
+  planned_moves: [{ move: 'REBUT', target: 'safetyist', detail: 'Cite EU AI Act data showing risk-based frameworks outperform blanket bans.' }],
+  target_claims: ['strict regulation is counterproductive'],
+  argument_sketch: 'Use EU AI Act 2026 compliance data to show risk-based frameworks outperform blanket restrictions while preserving safety outcomes.',
+  anticipated_responses: ['Safetyist may cite recent safety incidents'],
+};
+
+const VALID_DRAFT = {
+  statement: 'Proportionate regulation frameworks produce better outcomes than blanket restrictions, as EU AI Act 2026 compliance data demonstrates.',
+  turn_symbols: [],
+  claim_sketches: [{ claim: 'Proportionate regulation works', targets: [] }],
+  key_assumptions: [],
+  disagreement_type: 'EMPIRICAL',
+};
+
+const VALID_CITE = { taxonomy_refs: [], policy_refs: [], move_annotations: [], grounding_confidence: 0.8 };
+
+function makeBaseInput(overrides?: Partial<TurnPipelineInput>): TurnPipelineInput {
+  return {
+    label: 'Accelerationist',
+    pov: 'accelerationist',
+    personality: 'Bold',
+    topic: 'AI governance',
+    taxonomyContext: '',
+    commitmentContext: '',
+    establishedPoints: '',
+    edgeContext: '',
+    concessionHint: '',
+    recentTranscript: 'Safetyist: Strict regulation needed.',
+    focusPoint: 'regulation',
+    addressing: 'Safetyist',
+    phase: 'argumentation',
+    priorMoves: ['REBUT'],
+    turnsSinceLastConcession: 2,
+    priorRefs: [],
+    availablePovNodeIds: [],
+    model: 'test-model',
+    skipPreCheck: true,
+    ...overrides,
+  };
+}
+
+function makeOpeningInput(overrides?: Partial<OpeningPipelineInput>): OpeningPipelineInput {
+  return {
+    label: 'Accelerationist',
+    pov: 'accelerationist',
+    personality: 'Bold',
+    topic: 'AI governance',
+    taxonomyContext: '',
+    priorStatements: '',
+    isFirst: true,
+    model: 'test-model',
+    briefMaxRetries: 0, // disable timeout-retry path for these tests
+    ...overrides,
+  };
+}
+
+// Generate factory: returns broken JSON for a stage the first N times, then valid JSON.
+function makeRetryingGenerate(
+  stage: string,
+  failCount: number,
+  validResponse: string,
+): { generate: StageGenerateFn; callCount: () => number } {
+  let count = 0;
+  const generate = vi.fn(async (_p: string, _m: string, _o: unknown, label: string) => {
+    if (label.includes(stage)) {
+      count++;
+      if (count <= failCount) return '<<<broken json that cannot parse>>>';
+      return validResponse;
+    }
+    if (label.includes('brief')) return JSON.stringify(VALID_BRIEF);
+    if (label.includes('plan')) return JSON.stringify(VALID_PLAN);
+    if (label.includes('draft')) return JSON.stringify(VALID_DRAFT);
+    if (label.includes('cite')) return JSON.stringify(VALID_CITE);
+    return '{}';
+  }) as unknown as StageGenerateFn;
+  return { generate, callCount: () => count };
+}
+
+// ── runTurnPipeline: PLAN stage retry ────────────────────
+
+describe('runTurnPipeline plan-stage parse-failure retry (t/2228)', () => {
+  it('retries plan parse failure and completes pipeline on second attempt', async () => {
+    const { generate, callCount } = makeRetryingGenerate('plan', 1, JSON.stringify(VALID_PLAN));
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.draft.statement).toBeTruthy();
+    expect(callCount()).toBe(2);
+  });
+
+  it('retries plan parse failure 3 times and succeeds on 4th attempt', async () => {
+    const { generate, callCount } = makeRetryingGenerate('plan', 3, JSON.stringify(VALID_PLAN));
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.draft.statement).toBeTruthy();
+    expect(callCount()).toBe(4);
+  });
+
+  it('throws ActionableError after exhausting all plan parse retries (MAX_STAGE_RETRIES+1 = 4 attempts)', async () => {
+    const { generate, callCount } = makeRetryingGenerate('plan', 999, '');
+    try {
+      await runTurnPipeline(makeBaseInput(), generate);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ActionableError);
+      expect((err as ActionableError).problem).toMatch(/Plan stage failed to parse after 4 attempt\(s\)/);
+    }
+    expect(callCount()).toBe(4);
+  });
+});
+
+// ── runTurnPipeline: BRIEF stage retry ───────────────────
+
+describe('runTurnPipeline brief-stage parse-failure retry (t/2228)', () => {
+  it('retries brief parse failure and completes pipeline on second attempt', async () => {
+    const { generate, callCount } = makeRetryingGenerate('brief', 1, JSON.stringify(VALID_BRIEF));
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.draft.statement).toBeTruthy();
+    expect(callCount()).toBe(2);
+  });
+
+  it('throws ActionableError after exhausting all brief parse retries', async () => {
+    const { generate, callCount } = makeRetryingGenerate('brief', 999, '');
+    await expect(runTurnPipeline(makeBaseInput(), generate)).rejects.toBeInstanceOf(ActionableError);
+    expect(callCount()).toBe(4);
+  });
+});
+
+// ── runOpeningPipeline: PLAN stage retry (new loop, t/2228) ─
+
+const VALID_OPENING_DRAFT = {
+  statement: 'AI governance requires proportionate frameworks that balance safety with innovation across deployment contexts.',
+  claim_sketches: [],
+};
+const VALID_OPENING_CITE = { taxonomy_refs: [], policy_refs: [] };
+
+function makeOpeningRetryGenerate(
+  stage: string,
+  failCount: number,
+  validResponse: string,
+): { generate: StageGenerateFn; callCount: () => number } {
+  let count = 0;
+  const generate = vi.fn(async (_p: string, _m: string, _o: unknown, label: string) => {
+    if (label.includes(stage)) {
+      count++;
+      if (count <= failCount) return '<<<broken>>>';
+      return validResponse;
+    }
+    if (label.includes('opening brief')) return JSON.stringify(VALID_BRIEF);
+    if (label.includes('opening plan')) return JSON.stringify(VALID_PLAN);
+    if (label.includes('opening draft')) return JSON.stringify(VALID_OPENING_DRAFT);
+    if (label.includes('opening cite')) return JSON.stringify(VALID_OPENING_CITE);
+    return '{}';
+  }) as unknown as StageGenerateFn;
+  return { generate, callCount: () => count };
+}
+
+describe('runOpeningPipeline plan-stage parse-failure retry (t/2228)', () => {
+  it('retries opening plan parse failure and completes on second attempt', async () => {
+    const { generate, callCount } = makeOpeningRetryGenerate('opening plan', 1, JSON.stringify(VALID_PLAN));
+    const result = await runOpeningPipeline(makeOpeningInput(), generate);
+    expect(result.brief).toBeTruthy();
+    expect(result.plan).toBeTruthy();
+    expect(callCount()).toBe(2);
+  });
+
+  it('throws ActionableError after exhausting all opening plan parse retries', async () => {
+    const { generate, callCount } = makeOpeningRetryGenerate('opening plan', 999, '');
+    try {
+      await runOpeningPipeline(makeOpeningInput(), generate);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ActionableError);
+      expect((err as ActionableError).problem).toMatch(/Plan stage failed to parse after 4 attempt\(s\)/);
+    }
+    expect(callCount()).toBe(4);
+  });
+});
+
+describe('runOpeningPipeline brief-stage parse-failure retry (t/2228)', () => {
+  it('retries opening brief parse failure and completes on second attempt', async () => {
+    const { generate, callCount } = makeOpeningRetryGenerate('opening brief', 1, JSON.stringify(VALID_BRIEF));
+    const result = await runOpeningPipeline(makeOpeningInput(), generate);
+    expect(result.brief).toBeTruthy();
+    expect(callCount()).toBe(2);
+  });
+
+  it('throws ActionableError after exhausting all opening brief parse retries', async () => {
+    const { generate, callCount } = makeOpeningRetryGenerate('opening brief', 999, '');
+    await expect(runOpeningPipeline(makeOpeningInput(), generate)).rejects.toBeInstanceOf(ActionableError);
+    expect(callCount()).toBe(4);
+  });
+});

--- a/lib/debate/turnPipeline.test.ts
+++ b/lib/debate/turnPipeline.test.ts
@@ -410,7 +410,7 @@ describe('Brief stage parse-failure retry', () => {
     }) as unknown as StageGenerateFn;
 
     await expect(runTurnPipeline(makeBaseInput(), generate))
-      .rejects.toThrow(/Brief stage failed to parse after 2 attempt/);
+      .rejects.toThrow(/Brief stage failed to parse after 4 attempt/);
   });
 
   it('skips brief retry during outer retry (repairHints present)', async () => {

--- a/lib/debate/turnPipeline/opening.ts
+++ b/lib/debate/turnPipeline/opening.ts
@@ -95,7 +95,7 @@ export async function runOpeningPipeline(
 
   // ── Stage 1: BRIEF (with parse-failure retry and configurable timeout retry) ──
   const isOpeningOuterRetry = (input.repairHints?.length ?? 0) > 0;
-  const MAX_OPENING_RETRIES = isOpeningOuterRetry ? 0 : 1;
+  const MAX_OPENING_RETRIES = isOpeningOuterRetry ? 0 : 3;
   const briefTimeoutMs = input.briefTimeoutMs ?? DEFAULT_BRIEF_TIMEOUT_MS;
   const briefMaxRetries = input.briefMaxRetries ?? DEFAULT_BRIEF_MAX_RETRIES;
   let brief: OpeningBriefWorkProduct | undefined;
@@ -169,34 +169,50 @@ export async function runOpeningPipeline(
     break;
   }
 
-  // ── Stage 2: PLAN ──
-  onProgress?.('plan', `${input.label} is planning...`);
-  const planPromptText = planOpeningStagePrompt(stageInput, briefJson);
-  t0 = Date.now();
-  const planRaw = await generate(
-    planPromptText, oPlanModel, { temperature: temps.plan_temperature }, `${input.label} opening plan`,
-  );
-  elapsed = Date.now() - t0;
-  const planParsed = parseStageResponse<OpeningPlanWorkProduct>(planRaw, 'plan');
-  stageDiags.push({
-    stage: 'plan', prompt: planPromptText, raw_response: planRaw,
-    model: oPlanModel, temperature: temps.plan_temperature,
-    response_time_ms: elapsed, work_product: planParsed.product as unknown as Record<string, unknown>,
-    parse_error: planParsed.error,
-  });
-  if (planParsed.error) {
-    throw new ActionableError({
-      goal: 'Run opening statement pipeline',
-      problem: `Plan stage failed to parse — downstream stages would operate on empty context. ${planParsed.error}`,
-      location: 'turnPipeline.runOpeningPipeline',
-      nextSteps: ['Check the AI model response quality', 'Try a different model'],
+  // ── Stage 2: PLAN (with parse-failure retry, mirrors runTurn.ts plan stage) ──
+  let plan: OpeningPlanWorkProduct | undefined;
+  let planJson = '';
+  for (let planAttempt = 0; planAttempt <= MAX_OPENING_RETRIES; planAttempt++) {
+    onProgress?.('plan', `${input.label} is planning${planAttempt > 0 ? ` (retry ${planAttempt})` : ''}...`);
+    const planPromptText = planOpeningStagePrompt(stageInput, briefJson);
+    t0 = Date.now();
+    const planRaw = await generate(
+      planPromptText, oPlanModel, { temperature: temps.plan_temperature }, `${input.label} opening plan`,
+    );
+    elapsed = Date.now() - t0;
+    const planParsed = parseStageResponse<OpeningPlanWorkProduct>(planRaw, 'plan');
+    stageDiags.push({
+      stage: 'plan', prompt: planPromptText, raw_response: planRaw,
+      model: oPlanModel, temperature: temps.plan_temperature,
+      response_time_ms: elapsed, work_product: planParsed.product as unknown as Record<string, unknown>,
+      parse_error: planParsed.error,
+      retry_trigger: planAttempt > 0 ? 'stage-retry' : 'initial',
     });
+    if (planParsed.error) {
+      if (planAttempt < MAX_OPENING_RETRIES) {
+        getGlobalRecorder()?.record({
+          type: 'turn.repair', component: 'turn-pipeline', level: 'warn',
+          speaker: input.label,
+          message: `Opening PLAN parse failed (attempt ${planAttempt}), retrying`,
+          data: { stage: 'plan', attempt: planAttempt, error: planParsed.error },
+        });
+        console.log(`[pipeline] Opening plan parse failed (attempt ${planAttempt}), retrying: ${planParsed.error}`);
+        continue;
+      }
+      throw new ActionableError({
+        goal: 'Run opening statement pipeline',
+        problem: `Plan stage failed to parse after ${planAttempt + 1} attempt(s) — downstream stages would operate on empty context. ${planParsed.error}`,
+        location: 'turnPipeline.runOpeningPipeline',
+        nextSteps: ['Check the AI model response quality', 'Try a different model'],
+      });
+    }
+    plan = tagProvenance(planParsed.product, {
+      pipeline_run: 0, stage: 'plan', attempt: planAttempt,
+      model: oPlanModel, timestamp: new Date().toISOString(),
+    });
+    planJson = toPromptJson(plan);
+    break;
   }
-  const plan = tagProvenance(planParsed.product, {
-    pipeline_run: 0, stage: 'plan', attempt: 0,
-    model: oPlanModel, timestamp: new Date().toISOString(),
-  });
-  const planJson = toPromptJson(plan);
 
   // ── Stage 3: DRAFT ──
   onProgress?.('draft', `${input.label} is drafting...`);
@@ -290,7 +306,7 @@ export async function runOpeningPipeline(
 
   return {
     brief: brief!,
-    plan,
+    plan: plan!,
     draft,
     cite,
     stage_diagnostics: stageDiags,

--- a/lib/debate/turnPipeline/runTurn.ts
+++ b/lib/debate/turnPipeline/runTurn.ts
@@ -47,7 +47,7 @@ export async function runTurnPipeline(
   const stageDiags: StageDiagnostics[] = [];
   const pipelineStart = Date.now();
   const isOuterRetry = (input.repairHints?.length ?? 0) > 0;
-  const MAX_STAGE_RETRIES = isOuterRetry ? 0 : 1;
+  const MAX_STAGE_RETRIES = isOuterRetry ? 0 : 3;
 
   // Per-component char counts for prompt growth forensics (t/221)
   const hintsChars =
@@ -232,9 +232,19 @@ export async function runTurnPipeline(
         output_tokens: planUsage?.outputTokens,
       });
       if (planParsed.error) {
+        if (planAttempt < MAX_STAGE_RETRIES) {
+          getGlobalRecorder()?.record({
+            type: 'turn.repair', component: 'turn-pipeline', level: 'warn',
+            speaker: input.label,
+            message: `PLAN parse failed (attempt ${planAttempt}), retrying`,
+            data: { stage: 'plan', attempt: planAttempt, error: planParsed.error },
+          });
+          console.log(`[pipeline] Plan parse failed (attempt ${planAttempt}), retrying: ${planParsed.error}`);
+          continue;
+        }
         throw new ActionableError({
           goal: 'Run debate turn pipeline',
-          problem: `Plan stage failed to parse — downstream stages would operate on empty context. ${planParsed.error}`,
+          problem: `Plan stage failed to parse after ${planAttempt + 1} attempt(s) — downstream stages would operate on empty context. ${planParsed.error}`,
           location: 'turnPipeline.runPipeline',
           nextSteps: ['Check the AI model response quality', 'Try a different model'],
         });


### PR DESCRIPTION
## Summary

- `MAX_STAGE_RETRIES` raised from 1 to 3 in `runTurn.ts` (brief + plan get 4 total parse-failure attempts)
- `MAX_OPENING_RETRIES` raised from 1 to 3 in `opening.ts` (same)
- **Bug fix:** plan stage in `runTurn.ts` was missing the `planAttempt < MAX_STAGE_RETRIES` guard before throwing — parse failures threw immediately after attempt 0 despite being inside a retry loop. Only validation failures had the retry path. Now mirrors the brief stage pattern.
- `opening.ts` plan stage: converted from a single attempt to a retry loop matching `runTurn.ts` plan pattern (previously had zero retries on parse failure).
- 9 new regression tests in `stageParseRetry.test.ts` covering success-after-retry and exhaustion (throw after MAX+1 attempts) for brief + plan in both `runTurnPipeline` and `runOpeningPipeline`.

**Root cause:** free-tier JSON truncation causes transient parse failures. 1 retry was insufficient; compound failure probability over 15-29 turns killed most debates before finalization. Blocks t/2192 round-count sweep.

## Test plan

- [x] `stageParseRetry.test.ts`: 9 new tests — success-after-retry + exhaustion paths for all 4 affected sites
- [x] Updated `turnPipeline.test.ts` expected error message (2->4 attempts)
- [x] Full suite: 2916 passed, 0 failures
- [x] TL approved (t/2228#2): exhaustion path asserted, follow-up filed for graceful degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)