### PR TITLE
feat(debate): graceful degradation on brief/plan exhaustion (t/2229)

### DIFF
--- a/lib/debate/__tests__/pipelineFaults.test.ts
+++ b/lib/debate/__tests__/pipelineFaults.test.ts
@@ -4,7 +4,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { runTurnPipeline } from '../turnPipeline.js';
 import type { TurnPipelineInput, StageGenerateFn } from '../turnPipeline.js';
-import { ActionableError } from '../errors.js';
 
 // ── Shared helpers ──────────────────────────────────────
 
@@ -119,64 +118,54 @@ function makeThrowingGenerate(
 // ── Test 1: BRIEF stage AI failure ──────────────────────
 
 describe('pipeline fault: BRIEF stage AI failure', () => {
-  it('throws ActionableError immediately when brief generation fails', async () => {
+  it('degrades the turn (not throw) when brief parse exhausts after retries (t/2229)', async () => {
     const generate = makeGenerate([
       ['brief', '{broken json with no structure'],
     ]);
 
-    await expect(
-      runTurnPipeline(makeBaseInput(), generate),
-    ).rejects.toThrow(ActionableError);
-
-    await expect(
-      runTurnPipeline(makeBaseInput(), generate),
-    ).rejects.toThrow(/Brief stage failed to parse/);
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
+    const briefDiags = result.stage_diagnostics.filter(d => d.stage === 'brief');
+    expect((briefDiags[briefDiags.length - 1] as Record<string, unknown>).degraded).toBe(true);
   });
 
-  it('does not run downstream stages after brief failure', async () => {
+  it('still runs downstream stages after brief exhaustion (degrade path) (t/2229)', async () => {
     const generate = makeGenerate([
       ['brief', '{broken'],
     ]);
 
-    try {
-      await runTurnPipeline(makeBaseInput(), generate);
-    } catch {
-      // expected
-    }
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
 
     const calls = (generate as ReturnType<typeof vi.fn>).mock.calls;
     const labels = calls.map((c: unknown[]) => c[3] as string);
-    expect(labels.some((l: string) => l.includes('plan'))).toBe(false);
-    expect(labels.some((l: string) => l.includes('draft'))).toBe(false);
-    expect(labels.some((l: string) => l.includes('cite'))).toBe(false);
+    // After brief exhaustion, pipeline continues: plan, draft, and cite should run
+    expect(labels.some((l: string) => l.includes('draft'))).toBe(true);
+    expect(labels.some((l: string) => l.includes('cite'))).toBe(true);
   });
 });
 
 // ── Test 2: PLAN stage parse failure ────────────────────
 
 describe('pipeline fault: PLAN stage parse failure', () => {
-  it('throws ActionableError when plan parsing fails after retries', async () => {
+  it('degrades the turn (not throw) when plan parse exhausts after retries (t/2229)', async () => {
     const generate = makeGenerate([
       ['plan', 'not valid json at all {{{'],
     ]);
 
-    await expect(
-      runTurnPipeline(makeBaseInput(), generate),
-    ).rejects.toThrow(ActionableError);
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
   });
 
-  it('includes stage name in the error', async () => {
+  it('marks the last plan stage_diagnostic with degraded: true on exhaustion (t/2229)', async () => {
     const generate = makeGenerate([
       ['plan', '<<<corrupt>>>'],
     ]);
 
-    try {
-      await runTurnPipeline(makeBaseInput(), generate);
-      expect.unreachable('should have thrown');
-    } catch (err) {
-      expect(err).toBeInstanceOf(ActionableError);
-      expect((err as ActionableError).problem).toMatch(/[Pp]lan/i);
-    }
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
+    const planDiags = result.stage_diagnostics.filter(d => d.stage === 'plan');
+    expect((planDiags[planDiags.length - 1] as Record<string, unknown>).degraded).toBe(true);
   });
 });
 
@@ -340,24 +329,20 @@ describe('pipeline fault: draft quality pre-check failure', () => {
 // ── Test 8: Orchestration-level retry (repairHints) ─────
 
 describe('pipeline fault: orchestration-level retry with repairHints', () => {
-  it('reduces MAX_STAGE_RETRIES to 0 when repairHints are provided', async () => {
+  it('reduces MAX_STAGE_RETRIES to 0 when repairHints are provided — degrades after 1 attempt (t/2229)', async () => {
     const generate = makeGenerate([
       ['brief', '{broken json'],
     ]);
 
-    try {
-      await runTurnPipeline(
-        makeBaseInput({ repairHints: ['Fix the draft statement to be more specific'] }),
-        generate,
-      );
-      expect.unreachable('should have thrown');
-    } catch (err) {
-      expect(err).toBeInstanceOf(ActionableError);
-    }
+    const result = await runTurnPipeline(
+      makeBaseInput({ repairHints: ['Fix the draft statement to be more specific'] }),
+      generate,
+    );
+    expect(result.degraded_turn).toBe(true);
 
     const calls = (generate as ReturnType<typeof vi.fn>).mock.calls;
     const briefCalls = calls.filter((c: unknown[]) => (c[3] as string).includes('brief'));
-    // With repairHints (outer retry), MAX_STAGE_RETRIES = 0, so only 1 brief attempt
+    // With repairHints (outer retry), MAX_STAGE_RETRIES = 0, so only 1 brief attempt before degrading
     expect(briefCalls.length).toBe(1);
   });
 

--- a/lib/debate/__tests__/stageParseRetry.test.ts
+++ b/lib/debate/__tests__/stageParseRetry.test.ts
@@ -114,15 +114,10 @@ describe('runTurnPipeline plan-stage parse-failure retry (t/2228)', () => {
     expect(callCount()).toBe(4);
   });
 
-  it('throws ActionableError after exhausting all plan parse retries (MAX_STAGE_RETRIES+1 = 4 attempts)', async () => {
+  it('degrades the turn after exhausting all plan parse retries (MAX_STAGE_RETRIES+1 = 4 attempts) (t/2229)', async () => {
     const { generate, callCount } = makeRetryingGenerate('plan', 999, '');
-    try {
-      await runTurnPipeline(makeBaseInput(), generate);
-      expect.unreachable('should have thrown');
-    } catch (err) {
-      expect(err).toBeInstanceOf(ActionableError);
-      expect((err as ActionableError).problem).toMatch(/Plan stage failed to parse after 4 attempt\(s\)/);
-    }
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
     expect(callCount()).toBe(4);
   });
 });
@@ -137,9 +132,10 @@ describe('runTurnPipeline brief-stage parse-failure retry (t/2228)', () => {
     expect(callCount()).toBe(2);
   });
 
-  it('throws ActionableError after exhausting all brief parse retries', async () => {
+  it('degrades the turn after exhausting all brief parse retries (t/2229)', async () => {
     const { generate, callCount } = makeRetryingGenerate('brief', 999, '');
-    await expect(runTurnPipeline(makeBaseInput(), generate)).rejects.toBeInstanceOf(ActionableError);
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
     expect(callCount()).toBe(4);
   });
 });

--- a/lib/debate/__tests__/turnDegrade.test.ts
+++ b/lib/debate/__tests__/turnDegrade.test.ts
@@ -1,0 +1,139 @@
+// Regression tests for t/2229: graceful degradation when brief/plan parse retries are exhausted.
+// Covers: pipeline completes (no throw) on brief exhaustion, plan exhaustion; flag reaches result + stage_diagnostics.
+// Opening pipeline is NOT tested here — it still throws on exhaustion (by design).
+
+import { describe, it, expect, vi } from 'vitest';
+import { runTurnPipeline } from '../turnPipeline.js';
+import type { TurnPipelineInput, StageGenerateFn } from '../turnPipeline.js';
+
+// ── Shared fixtures ──────────────────────────────────────
+
+const VALID_BRIEF = {
+  situation_assessment: 'Debate centers on AI governance.',
+  key_claims_to_address: [],
+  relevant_commitments: [],
+  edge_tensions: [],
+  phase_considerations: 'argumentation',
+};
+
+const VALID_PLAN = {
+  strategic_goal: 'Rebut the overreach argument by citing proportionate-regulation evidence from the EU AI Act.',
+  planned_moves: [{ move: 'REBUT', target: 'safetyist', detail: 'Cite EU AI Act data showing risk-based frameworks outperform blanket bans.' }],
+  target_claims: ['strict regulation is counterproductive'],
+  argument_sketch: 'Use EU AI Act 2026 compliance data to show risk-based frameworks outperform blanket restrictions while preserving safety outcomes.',
+  anticipated_responses: ['Safetyist may cite recent safety incidents'],
+};
+
+const VALID_DRAFT = {
+  statement: 'Proportionate regulation frameworks produce better outcomes.',
+  turn_symbols: [],
+  claim_sketches: [{ claim: 'Proportionate regulation works', targets: [] }],
+  key_assumptions: [],
+  disagreement_type: 'EMPIRICAL',
+};
+
+const VALID_CITE = { taxonomy_refs: [], policy_refs: [], move_annotations: [], grounding_confidence: 0.8 };
+
+function makeBaseInput(overrides?: Partial<TurnPipelineInput>): TurnPipelineInput {
+  return {
+    label: 'Accelerationist',
+    pov: 'accelerationist',
+    personality: 'Bold',
+    topic: 'AI governance',
+    taxonomyContext: '',
+    commitmentContext: '',
+    establishedPoints: '',
+    edgeContext: '',
+    concessionHint: '',
+    recentTranscript: 'Safetyist: Strict regulation needed.',
+    focusPoint: 'regulation',
+    addressing: 'Safetyist',
+    phase: 'argumentation',
+    priorMoves: ['REBUT'],
+    turnsSinceLastConcession: 2,
+    priorRefs: [],
+    availablePovNodeIds: [],
+    model: 'test-model',
+    skipPreCheck: true,
+    ...overrides,
+  };
+}
+
+// Returns broken JSON for `stage` on every call; other stages return valid JSON.
+function makeAlwaysFailGenerate(stage: string): StageGenerateFn {
+  return vi.fn(async (_p: string, _m: string, _o: unknown, label: string) => {
+    if (label.includes(stage)) return '<<<broken json that cannot parse>>>';
+    if (label.includes('brief')) return JSON.stringify(VALID_BRIEF);
+    if (label.includes('plan')) return JSON.stringify(VALID_PLAN);
+    if (label.includes('draft')) return JSON.stringify(VALID_DRAFT);
+    if (label.includes('cite')) return JSON.stringify(VALID_CITE);
+    return '{}';
+  }) as unknown as StageGenerateFn;
+}
+
+// ── Brief exhaustion → degrade ───────────────────────────
+
+describe('runTurnPipeline brief exhaustion → graceful degradation (t/2229)', () => {
+  it('does not throw and returns degraded_turn: true when brief always fails', async () => {
+    const generate = makeAlwaysFailGenerate('brief');
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
+  });
+
+  it('marks the last brief stage_diagnostic with degraded: true', async () => {
+    const generate = makeAlwaysFailGenerate('brief');
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    const briefDiags = result.stage_diagnostics.filter(d => d.stage === 'brief');
+    expect(briefDiags.length).toBeGreaterThan(0);
+    const lastBriefDiag = briefDiags[briefDiags.length - 1];
+    expect((lastBriefDiag as Record<string, unknown>).degraded).toBe(true);
+  });
+
+  it('still produces a draft statement when brief is degraded', async () => {
+    const generate = makeAlwaysFailGenerate('brief');
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.draft.statement).toBeTruthy();
+  });
+});
+
+// ── Plan exhaustion → degrade ────────────────────────────
+
+describe('runTurnPipeline plan exhaustion → graceful degradation (t/2229)', () => {
+  it('does not throw and returns degraded_turn: true when plan always fails', async () => {
+    const generate = makeAlwaysFailGenerate('plan');
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
+  });
+
+  it('marks the last plan stage_diagnostic with degraded: true', async () => {
+    const generate = makeAlwaysFailGenerate('plan');
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    const planDiags = result.stage_diagnostics.filter(d => d.stage === 'plan');
+    expect(planDiags.length).toBeGreaterThan(0);
+    const lastPlanDiag = planDiags[planDiags.length - 1];
+    expect((lastPlanDiag as Record<string, unknown>).degraded).toBe(true);
+  });
+
+  it('still produces a draft statement when plan is degraded', async () => {
+    const generate = makeAlwaysFailGenerate('plan');
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.draft.statement).toBeTruthy();
+  });
+});
+
+// ── Normal success → no degraded flag ───────────────────
+
+describe('runTurnPipeline normal success — no degraded_turn flag', () => {
+  it('does not set degraded_turn when brief and plan parse successfully', async () => {
+    const generate = vi.fn(async (_p: string, _m: string, _o: unknown, label: string) => {
+      if (label.includes('brief')) return JSON.stringify(VALID_BRIEF);
+      if (label.includes('plan')) return JSON.stringify(VALID_PLAN);
+      if (label.includes('draft')) return JSON.stringify(VALID_DRAFT);
+      if (label.includes('cite')) return JSON.stringify(VALID_CITE);
+      return '{}';
+    }) as unknown as StageGenerateFn;
+
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBeUndefined();
+  });
+});

--- a/lib/debate/debateEngine/phases/crossRespond.ts
+++ b/lib/debate/debateEngine/phases/crossRespond.ts
@@ -1001,6 +1001,7 @@ export async function runCrossRespondRound(engine: DebateEngineInternals, round:
         ? pipelineResult.plan.anticipated_responses : undefined,
       ignored_evidence_doc_ids: pipelineResult.ignoredEvidenceDocIds,
     },
+    degraded: pipelineResult.degraded_turn,
   });
 
   // ── Talmudic reference response + dialectical diagnostic record ──

--- a/lib/debate/debateEngine/phases/diversityInjection.ts
+++ b/lib/debate/debateEngine/phases/diversityInjection.ts
@@ -257,6 +257,7 @@ export async function runDiversityRound(engine: DebateEngineInternals, round: nu
         diversity_round: true,
         extracted_claims_accepted: (meta as Record<string, unknown>).extracted_claims_accepted ?? 0,
       },
+      degraded: pipelineResult.degraded_turn,
     });
 
     engine.checkAborted();

--- a/lib/debate/formatters.ts
+++ b/lib/debate/formatters.ts
@@ -366,6 +366,10 @@ export function buildHarvestOutput(
   getNodeLabel: (id: string) => string | null,
   allNodeIds: Set<string>,
 ): object {
+  const degradedTurnIds = session.transcript
+    .filter(e => e.degraded)
+    .map(e => e.id);
+
   return {
     debate_id: session.id,
     debate_title: session.title,
@@ -374,5 +378,6 @@ export function buildHarvestOutput(
     debate_refs: extractDebateRefCandidates(session, getNodeLabel),
     verdicts: extractVerdictCandidates(session),
     concepts: extractConceptCandidates(session, allNodeIds),
+    degraded_turn_ids: degradedTurnIds.length > 0 ? degradedTurnIds : undefined,
   };
 }

--- a/lib/debate/turnPipeline.test.ts
+++ b/lib/debate/turnPipeline.test.ts
@@ -400,7 +400,7 @@ describe('Brief stage parse-failure retry', () => {
     expect(briefDiags[1].parse_error).toBeUndefined();
   });
 
-  it('throws after all brief retries exhausted', async () => {
+  it('degrades the turn after all brief retries exhausted (t/2229)', async () => {
     const generate = vi.fn(async (_prompt: string, _model: string, _options: unknown, label: string) => {
       if (label.includes('brief')) return 'not valid json';
       if (label.includes('plan')) return JSON.stringify(VALID_PLAN);
@@ -409,11 +409,11 @@ describe('Brief stage parse-failure retry', () => {
       return '{}';
     }) as unknown as StageGenerateFn;
 
-    await expect(runTurnPipeline(makeBaseInput(), generate))
-      .rejects.toThrow(/Brief stage failed to parse after 4 attempt/);
+    const result = await runTurnPipeline(makeBaseInput(), generate);
+    expect(result.degraded_turn).toBe(true);
   });
 
-  it('skips brief retry during outer retry (repairHints present)', async () => {
+  it('degrades after 1 attempt when repairHints present (MAX_STAGE_RETRIES=0) (t/2229)', async () => {
     let briefCallCount = 0;
     const generate = vi.fn(async (_prompt: string, _model: string, _options: unknown, label: string) => {
       if (label.includes('brief')) {
@@ -423,8 +423,8 @@ describe('Brief stage parse-failure retry', () => {
       return '{}';
     }) as unknown as StageGenerateFn;
 
-    await expect(runTurnPipeline(makeBaseInput({ repairHints: ['fix something'] }), generate))
-      .rejects.toThrow(/Brief stage failed to parse/);
+    const result = await runTurnPipeline(makeBaseInput({ repairHints: ['fix something'] }), generate);
+    expect(result.degraded_turn).toBe(true);
     expect(briefCallCount).toBe(1);
   });
 });

--- a/lib/debate/turnPipeline/runTurn.ts
+++ b/lib/debate/turnPipeline/runTurn.ts
@@ -48,6 +48,7 @@ export async function runTurnPipeline(
   const pipelineStart = Date.now();
   const isOuterRetry = (input.repairHints?.length ?? 0) > 0;
   const MAX_STAGE_RETRIES = isOuterRetry ? 0 : 3;
+  let degradedTurn = false;
 
   // Per-component char counts for prompt growth forensics (t/221)
   const hintsChars =
@@ -120,12 +121,20 @@ export async function runTurnPipeline(
           console.log(`[pipeline] Brief parse failed (attempt ${briefAttempt}), retrying: ${briefParsed.error}`);
           continue;
         }
-        throw new ActionableError({
-          goal: 'Run debate turn pipeline',
-          problem: `Brief stage failed to parse after ${briefAttempt + 1} attempt(s) — downstream stages would operate on empty context. ${briefParsed.error}`,
-          location: 'turnPipeline.runPipeline',
-          nextSteps: ['Check the AI model response quality', 'Try a different model'],
+        // Retries exhausted — degrade the turn rather than aborting the debate (t/2229).
+        getGlobalRecorder()?.record({
+          type: 'turn.repair', component: 'turn-pipeline', level: 'warn',
+          speaker: input.label,
+          message: `BRIEF exhausted after ${briefAttempt + 1} attempt(s) — degrading turn`,
+          data: { stage: 'brief', attempt: briefAttempt, error: briefParsed.error },
         });
+        console.log(`[pipeline] Brief stage exhausted after ${briefAttempt + 1} attempt(s) — degrading turn`);
+        const lastBriefDiag = stageDiags[stageDiags.length - 1];
+        (lastBriefDiag as Record<string, unknown>).degraded = true;
+        brief = briefParsed.product;
+        briefJson = '{}';
+        degradedTurn = true;
+        break;
       }
       brief = tagProvenance(briefParsed.product, {
         pipeline_run: isOuterRetry ? 1 : 0,
@@ -242,12 +251,20 @@ export async function runTurnPipeline(
           console.log(`[pipeline] Plan parse failed (attempt ${planAttempt}), retrying: ${planParsed.error}`);
           continue;
         }
-        throw new ActionableError({
-          goal: 'Run debate turn pipeline',
-          problem: `Plan stage failed to parse after ${planAttempt + 1} attempt(s) — downstream stages would operate on empty context. ${planParsed.error}`,
-          location: 'turnPipeline.runPipeline',
-          nextSteps: ['Check the AI model response quality', 'Try a different model'],
+        // Retries exhausted — degrade the turn rather than aborting the debate (t/2229).
+        getGlobalRecorder()?.record({
+          type: 'turn.repair', component: 'turn-pipeline', level: 'warn',
+          speaker: input.label,
+          message: `PLAN exhausted after ${planAttempt + 1} attempt(s) — degrading turn`,
+          data: { stage: 'plan', attempt: planAttempt, error: planParsed.error },
         });
+        console.log(`[pipeline] Plan stage exhausted after ${planAttempt + 1} attempt(s) — degrading turn`);
+        const lastPlanDiag = stageDiags[stageDiags.length - 1];
+        (lastPlanDiag as Record<string, unknown>).degraded = true;
+        plan = planParsed.product;
+        planJson = '{}';
+        degradedTurn = true;
+        break;
       }
 
       // Validate plan
@@ -1400,5 +1417,6 @@ export async function runTurnPipeline(
     total_time_ms: Date.now() - pipelineStart,
     topicAlignmentResult,
     qualityGateResult,
+    degraded_turn: degradedTurn || undefined,
   };
 }

--- a/lib/debate/types/pipeline.ts
+++ b/lib/debate/types/pipeline.ts
@@ -41,6 +41,8 @@ export interface StageDiagnostics {
   input_tokens?: number;
   /** Output tokens produced by this stage's API call (from CacheUsage). */
   output_tokens?: number;
+  /** True when this stage's parse retries were exhausted and the turn was degraded gracefully (t/2229). */
+  degraded?: true;
 }
 
 /** Per-component char counts for prompt growth forensics (t/221). */
@@ -149,6 +151,8 @@ export interface TurnPipelineResult {
     repair_outcome?: 'fixed' | 'partial' | 'unchanged';
   };
   final_text?: string;
+  /** True when brief or plan parse retries were exhausted and the turn degraded gracefully (t/2229). */
+  degraded_turn?: boolean;
 }
 
 // ── Opening pipeline types ───────────────────────────

--- a/lib/debate/types/session.ts
+++ b/lib/debate/types/session.ts
@@ -112,6 +112,8 @@ export interface TranscriptEntry {
    *  Surfaced to readers as "Caveats" alongside the statement. */
   caveats?: string[];
   model?: string;
+  /** True when this turn's brief or plan parse retries were exhausted and degraded gracefully (t/2229). */
+  degraded?: boolean;
 }
 
 export type ModelTier = 'basic' | 'advanced';

--- a/taxonomy-editor/src/renderer/utils/debateValidation.test.ts
+++ b/taxonomy-editor/src/renderer/utils/debateValidation.test.ts
@@ -156,27 +156,26 @@ describe('validateTurn — judge fallback (gap 11.5)', () => {
   });
 });
 
-// ── Gap 11.6: Pipeline aborts on Brief/Plan parse failure ──
+// ── Gap 11.6: Pipeline degrades on Brief/Plan parse exhaustion (t/2229) ──
 
-describe('runTurnPipeline — early abort (gap 11.6)', () => {
-  it('throws when brief stage returns unparseable response', async () => {
+describe('runTurnPipeline — graceful degradation on parse exhaustion (gap 11.6)', () => {
+  it('degrades (not throws) when brief stage returns unparseable response after retries', async () => {
     const generate = async () => 'NOT JSON';
-    await expect(
-      runTurnPipeline(
-        {
-          label: 'test', pov: 'safetyist', personality: 'test', topic: 'test',
-          taxonomyContext: '', commitmentContext: '', establishedPoints: '',
-          edgeContext: '', concessionHint: '', recentTranscript: '',
-          focusPoint: '', addressing: 'all', phase: 'argumentation',
-          priorMoves: [], priorRefs: [], availablePovNodeIds: [],
-          model: 'test-model',
-        },
-        generate,
-      ),
-    ).rejects.toThrow('Brief stage failed to parse');
+    const result = await runTurnPipeline(
+      {
+        label: 'test', pov: 'safetyist', personality: 'test', topic: 'test',
+        taxonomyContext: '', commitmentContext: '', establishedPoints: '',
+        edgeContext: '', concessionHint: '', recentTranscript: '',
+        focusPoint: '', addressing: 'all', phase: 'argumentation',
+        priorMoves: [], priorRefs: [], availablePovNodeIds: [],
+        model: 'test-model',
+      },
+      generate,
+    );
+    expect(result.degraded_turn).toBe(true);
   });
 
-  it('throws when plan stage returns unparseable response', async () => {
+  it('degrades (not throws) when plan stage returns unparseable response after retries', async () => {
     let callCount = 0;
     const generate = async () => {
       callCount++;
@@ -194,19 +193,18 @@ describe('runTurnPipeline — early abort (gap 11.6)', () => {
       // Plan fails
       return '<<TRUNCATED';
     };
-    await expect(
-      runTurnPipeline(
-        {
-          label: 'test', pov: 'safetyist', personality: 'test', topic: 'test',
-          taxonomyContext: '', commitmentContext: '', establishedPoints: '',
-          edgeContext: '', concessionHint: '', recentTranscript: '',
-          focusPoint: '', addressing: 'all', phase: 'argumentation',
-          priorMoves: [], priorRefs: [], availablePovNodeIds: [],
-          model: 'test-model',
-        },
-        generate,
-      ),
-    ).rejects.toThrow('Plan stage failed to parse');
+    const result = await runTurnPipeline(
+      {
+        label: 'test', pov: 'safetyist', personality: 'test', topic: 'test',
+        taxonomyContext: '', commitmentContext: '', establishedPoints: '',
+        edgeContext: '', concessionHint: '', recentTranscript: '',
+        focusPoint: '', addressing: 'all', phase: 'argumentation',
+        priorMoves: [], priorRefs: [], availablePovNodeIds: [],
+        model: 'test-model',
+      },
+      generate,
+    );
+    expect(result.degraded_turn).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- When brief or plan parse retries exhaust in `runTurnPipeline`, degrade the turn gracefully instead of aborting the debate
- `degraded_turn: true` threads from `TurnPipelineResult` → `TranscriptEntry.degraded` via `addEntry` in crossRespond + diversityInjection — reaches persisted `debate-<id>.json`
- `buildHarvestOutput` emits `degraded_turn_ids[]` so CL t/2192 sweep can filter degraded turns
- Opening pipeline retains throw-on-exhaustion by design (no fallback shape)
- 7 new regression tests in `turnDegrade.test.ts`; 9 existing tests updated

## Test plan
- [ ] `npx vitest run __tests__/turnDegrade.test.ts` — 7 new degradation tests pass
- [ ] `npx vitest run __tests__/pipelineFaults.test.ts __tests__/stageParseRetry.test.ts turnPipeline.test.ts` — all 45 pass
- [ ] tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)