### PR TITLE
fix(web-bridge): surface server detail for anon_route_blocked 403 (t/…

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/sessionRecovery.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/sessionRecovery.test.ts
@@ -194,3 +194,34 @@ describe('auth-wall recovery — HTTP 200 + text/html login page (t/1840)', () =
     expect(mockGlobalFetch).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('403 anon_route_blocked error message (t/2232)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGlobalFetch.mockResolvedValue(mockResponse(200));
+  });
+
+  it('surfaces the server detail string when reason is anon_route_blocked', async () => {
+    mockResilientFetch.mockResolvedValue(
+      mockResponse(403, { reason: 'anon_route_blocked', detail: 'Sign in at /.auth/login/github to unlock full access.' }),
+    );
+
+    const { bridgeGet } = await import('../web-bridge');
+    const err = await bridgeGet('/api/debates').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    const nextSteps = (err as { nextSteps?: string[] }).nextSteps ?? [];
+    expect(nextSteps).toContain('Sign in at /.auth/login/github to unlock full access.');
+    expect(nextSteps.join(' ')).not.toContain('API key');
+  });
+
+  it('falls back to generic auth message when reason is absent', async () => {
+    mockResilientFetch.mockResolvedValue(
+      mockResponse(403, { error: 'Forbidden' }),
+    );
+
+    const { bridgeGet } = await import('../web-bridge');
+    const err = await bridgeGet('/api/debates').catch((e: unknown) => e);
+    const nextSteps = (err as { nextSteps?: string[] }).nextSteps ?? [];
+    expect(nextSteps.join(' ')).toContain('API key');
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -39,9 +39,15 @@ function throwHttpError(status: number, err: ActionableError): never {
 
 function nextStepsForStatus(status: number, responseText: string): string[] {
   if (status === 403) {
-    let reason: string | undefined;
-    try { reason = (JSON.parse(responseText) as Record<string, unknown>).error as string; } catch { /* telemetry — silent by design */ }
-    if (reason) return [reason, 'Check your API key tier supports this backend'];
+    try {
+      const body = JSON.parse(responseText) as Record<string, unknown>;
+      if (body.reason === 'anon_route_blocked') {
+        const detail = typeof body.detail === 'string' ? body.detail : 'Sign in with GitHub at /.auth/login/github';
+        return [detail];
+      }
+      const error = typeof body.error === 'string' ? body.error : undefined;
+      if (error) return [error, 'Check your API key tier supports this backend'];
+    } catch { /* telemetry — silent by design */ }
     return ['Verify your authentication', 'Check your API key tier supports this backend'];
   }
   return ['Check the server is running', 'Verify your authentication'];


### PR DESCRIPTION
…2232)

nextStepsForStatus now checks body.reason === 'anon_route_blocked' first and uses the server's body.detail string as the next step (e.g. 'Sign in at /.auth/login/github'). Generic 'Check your API key tier' text no longer appears for auth-gate 403s. Adds two tests covering the branching logic.