### PR TITLE
fix(server): open PATCH /api/debates/:id to anonymous users (t/2230)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/accessControl.test.ts
+++ b/taxonomy-editor/src/server/__tests__/accessControl.test.ts
@@ -283,6 +283,17 @@ describe('isAnonAllowedRoute (t/763 anon_route_blocked classification)', () => {
     expect(isAnonAllowedRoute('PUT', '/api/chats')).toBe(true);
     expect(isAnonAllowedRoute('DELETE', '/api/chats/xyz')).toBe(true);
   });
+  it('allows anonymous PATCH to own debate (saveDebateDelta, t/2230)', () => {
+    expect(isAnonAllowedRoute('PATCH', '/api/debates/abc-123')).toBe(true);
+    expect(isAnonAllowedRoute('PATCH', '/api/debates/some-other-id')).toBe(true);
+  });
+  it('PATCH anon guard is exact-segment: blocks chats and debate sub-paths (t/2230 Q4)', () => {
+    // Must not silently inherit anon write access via the broad user-content prefix.
+    expect(isAnonAllowedRoute('PATCH', '/api/chats/abc')).toBe(false);
+    expect(isAnonAllowedRoute('PATCH', '/api/debates/abc/comments')).toBe(false);
+    expect(isAnonAllowedRoute('PATCH', '/api/debates/abc/news-report')).toBe(false);
+    expect(isAnonAllowedRoute('PATCH', '/api/debates')).toBe(false);
+  });
   it('blocks other writes', () => {
     expect(isAnonAllowedRoute('PUT', '/api/taxonomy/accelerationist')).toBe(false);
     expect(isAnonAllowedRoute('DELETE', '/api/conflicts/c1')).toBe(false);

--- a/taxonomy-editor/src/server/__tests__/applyDebateDeltaToStorage.test.ts
+++ b/taxonomy-editor/src/server/__tests__/applyDebateDeltaToStorage.test.ts
@@ -163,4 +163,24 @@ describe('applyDebateDeltaToStorage (t/1635)', () => {
       userContext.runWithUser(anonCtx, () => fileIO.applyDebateDeltaToStorage(delta)),
     ).rejects.toMatchObject({ statusCode: 409, code: 'version_conflict', currentVersion: 4 });
   });
+
+  it('IDOR guard: session B cannot PATCH a debate created by session A (t/2230)', async () => {
+    const sessA = { ...anonCtx, anonymousSessionId: 'sess-idor-a' };
+    const sessB = { ...anonCtx, anonymousSessionId: 'sess-idor-b' };
+
+    // Session A seeds a debate at version 2.
+    await userContext.runWithUser(sessA, () =>
+      fileIO.saveDebateSession({ id: 'idor-debate', title: 'Owned by A', _saveVersion: 2 }));
+
+    // Session B attempts to PATCH the same debate ID — must not find it.
+    const delta = makeDelta({ debateId: 'idor-debate', baseVersion: 2 });
+    await expect(
+      userContext.runWithUser(sessB, () => fileIO.applyDebateDeltaToStorage(delta)),
+    ).rejects.toMatchObject({ statusCode: 409, code: 'version_conflict', currentVersion: null });
+
+    // Session A's debate is untouched.
+    const reloaded = await userContext.runWithUser(sessA, () =>
+      fileIO.loadDebateSession('idor-debate')) as { _saveVersion: number };
+    expect(reloaded._saveVersion).toBe(2);
+  });
 });

--- a/taxonomy-editor/src/server/__tests__/debateAnonAllowlist.test.ts
+++ b/taxonomy-editor/src/server/__tests__/debateAnonAllowlist.test.ts
@@ -44,6 +44,7 @@ const ANON_ALLOWED_ROUTES: Array<{ method: string; path: string; desc: string }>
   { method: 'POST', path: '/api/chats', desc: 'create chat (user content, t/1501)' },
   { method: 'PUT', path: '/api/debates', desc: 'save debate (user content)' },
   { method: 'PUT', path: '/api/debates/abc-123', desc: 'update debate (user content)' },
+  { method: 'PATCH', path: '/api/debates/abc-123', desc: 'save debate delta (saveDebateDelta, t/2230)' },
   { method: 'DELETE', path: '/api/debates/abc-123', desc: 'delete own debate' },
 
   // --- Safe POSTs ---

--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -15,7 +15,8 @@ import { json, error, param } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import * as fileIO from '../storage/fileIO.js';
 import * as ai from '../ai/aiBackends.js';
-import { getStorageUserId } from '../security/userContext.js';
+import { getStorageUserId, getAnonymousSessionId } from '../security/userContext.js';
+import * as rateLimiter from '../security/rateLimiter.js';
 import { getDataRoot } from '../config.js';
 import type { DebateDelta } from '../../../../lib/debate/types.js';
 
@@ -27,6 +28,7 @@ import type { DebateDelta } from '../../../../lib/debate/types.js';
 // slow-save diagnostic FR log that feeds the Server Storage blob-timeout ticket (t/1469).
 const inFlightDebateSaves = new Set<string>();
 const SLOW_DEBATE_SAVE_MS = 5_000;
+const ANON_DEBATE_SAVE_RPM = 30;
 
 /** Append a calibration data point when the saved debate has a concluding entry.
  *  Never blocks/aborts the save — a failure is recorded to the flight recorder. */
@@ -176,6 +178,15 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
       res.writeHead(409, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'save_in_progress', message: 'A save for this debate is already in progress; your newest changes will be saved on the next attempt.' }));
       return;
+    }
+    const anonSessionId = getAnonymousSessionId();
+    if (anonSessionId) {
+      const r = rateLimiter.checkRate(`anon-debate-save:${anonSessionId}`, ANON_DEBATE_SAVE_RPM, 60_000);
+      if (!r.allowed) {
+        const retryAfter = Math.max(1, Math.ceil((r.retryAfterMs ?? 60_000) / 1000));
+        res.setHeader('Retry-After', String(retryAfter));
+        return json(res, { error: 'rate_limited', message: 'Too many requests', retryAfter }, 429);
+      }
     }
     inFlightDebateSaves.add(saveKey);
     const startedAt = Date.now();

--- a/taxonomy-editor/src/server/security/accessControl.ts
+++ b/taxonomy-editor/src/server/security/accessControl.ts
@@ -273,6 +273,8 @@ function isAnonBlockedRoute(urlPath: string): boolean {
 
 // Anonymous users can save/delete their own ephemeral chats and debates.
 // Matches both '/api/debates' (create/save) and '/api/debates/{id}' (update/delete).
+// NOTE: this is used only for POST/PUT/DELETE — PATCH has its own narrow check below
+// (t/2230) to prevent future sub-paths from silently inheriting anon write access.
 function isAnonUserContentRoute(urlPath: string): boolean {
   return urlPath === '/api/chats' || urlPath.startsWith('/api/chats/')
     || urlPath === '/api/debates' || urlPath.startsWith('/api/debates/');
@@ -310,6 +312,11 @@ export function isAnonAllowedRoute(method: string, urlPath: string): boolean {
 
   const isMutation = method === 'POST' || method === 'PUT' || method === 'DELETE';
   if (isMutation && isAnonUserContentRoute(urlPath)) return true;
+
+  // PATCH is allowed only for debate delta saves on a specific debate id (t/2230).
+  // Deliberately not routed through isAnonUserContentRoute — that prefix match would
+  // silently grant anon PATCH to /api/chats/:id and future debate sub-paths.
+  if (method === 'PATCH') return /^\/api\/debates\/[^/]+$/.test(urlPath);
 
   if (method === 'PUT' || method === 'DELETE') return false;
 


### PR DESCRIPTION
## Summary

- Opens PATCH /api/debates/:id to anonymous users, resolving the POST/PATCH inconsistency where anon could create but never save debate deltas
- Auth gate narrowed to exact single-segment path only — not the broad user-content prefix — preventing future sub-paths from silently inheriting anon write access (Q4 hardening per security review)
- Per-session rate limit (30/min, ALS-keyed anon_session_id) added to the PATCH handler

## Guardrails

- Ownership/IDOR: enforced by construction via session-namespaced anon store paths
- Rate-limit: 30/min per ALS anon session + pre-existing M7 per-IP outer bound
- Quota/TTL: pre-existing maxSessionSizeBytes + sessionTtlMs sweep

## Tests (94/94 green)

- accessControl.test.ts: PATCH allowed for /api/debates/:id only, blocked for chats and sub-paths
- debateAnonAllowlist.test.ts: PATCH in debate pipeline allowlist
- applyDebateDeltaToStorage.test.ts: IDOR regression (session B cannot PATCH session A's debate)

## Process

- Design: TL-reviewed and approved (t/2230#2, t/2230#3)
- Security-reviewer: confirmed safe (t/2230#6)
- Server Auth rate-limit analysis: t/2230#4, 30/min endorsed by TL

🤖 Generated with [Claude Code](https://claude.com/claude-code)