### PR TITLE
fix(debate-diagnostics): distinct error bubble style for chat error injections (t/2245)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.css
@@ -1,0 +1,25 @@
+/* DiagnosticsChatSidebar — co-located styles (prefix: dchat-) */
+
+.dchat-error-bubble {
+  align-self: flex-start;
+  max-width: 90%;
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  background: color-mix(in srgb, var(--danger, #ef4444) 12%, transparent);
+  color: var(--text-primary, var(--border-color));
+  border: 1px solid color-mix(in srgb, var(--danger, #ef4444) 30%, transparent);
+  user-select: text;
+  cursor: text;
+}
+
+.dchat-error-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--danger, #ef4444);
+  margin-bottom: 3px;
+}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
+import './DiagnosticsChatSidebar.css';
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import type { DebateSession } from '../../../types/debate';
 import { POVER_INFO } from '../../../types/debate';
@@ -24,6 +25,7 @@ interface ChatMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
   timestamp: string;
+  isError?: boolean;
   navigation?: NavigateCommand;
   suggestions?: string[];
 }
@@ -667,6 +669,17 @@ function ChatEmptyState({ isWeb }: { isWeb: boolean }) {
 }
 
 function MessageBubble({ msg, onNavigate }: { msg: ChatMessage; onNavigate: (cmd: NavigateCommand) => void }) {
+  if (msg.isError) {
+    return (
+      <div className="dchat-error-bubble">
+        <div className="dchat-error-label">
+          <span aria-hidden="true">⚠</span>
+          <span>Error</span>
+        </div>
+        <div style={{ whiteSpace: 'pre-wrap' }}>{msg.content.replace(/^Error:\s*/i, '')}</div>
+      </div>
+    );
+  }
   return (
     <div
       style={{
@@ -1088,8 +1101,9 @@ export function DiagnosticsChatSidebar({ debate, selectedEntry, currentTab, onNa
       setMessages(prev => [...prev, {
         id: crypto.randomUUID(),
         role: 'assistant',
-        content: `Error: ${err instanceof Error ? err.message : String(err)}`,
+        content: err instanceof Error ? err.message : String(err),
         timestamp: new Date().toISOString(),
+        isError: true,
       }]);
     } finally {
       runCleanups(cleanups);


### PR DESCRIPTION
## Summary
- Error messages injected by `DiagnosticsChatSidebar` on generation failure were rendered as normal assistant bubbles (identical appearance), making system failures indistinguishable from real AI responses
- Add `isError?: boolean` to `ChatMessage` interface; error injection sets `isError: true`
- `MessageBubble` early-returns a `.dchat-error-bubble` variant when `msg.isError`: red danger border/background (`color-mix(in srgb, var(--danger) …)`) matching `BriefTimeoutToast`'s token-based approach, with `⚠ Error` label header
- New co-located `DiagnosticsChatSidebar.css` (prefix `dchat-`) for static error styles — `styles.css` untouched

## Test plan
- [ ] Trigger a chat generation failure (e.g. bad API key or network off) — error renders with red border, `⚠ Error` label, distinct from assistant bubbles
- [ ] Normal assistant responses unaffected
- [ ] CI green (tsc, eslint, vitest, vite build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)