### PR TITLE
feat(bridge): wire DEBATE_CHAT_REDESIGN flag into Electron getFlags (t/2235)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -371,8 +371,12 @@ export const api: AppAPI = {
   onBriefRetriesExhausted: (cb) => window.electronAPI.onBriefRetriesExhausted(cb),
   captureScreenshot: (opts) => window.electronAPI.captureScreenshot(opts),
 
-  // Feature flags — single-user desktop, no server flags
-  getFlags: () => Promise.resolve({}),
+  // Feature flags — desktop has no server. Source DEBATE_CHAT_REDESIGN from a
+  // build-time env var (VITE_DEBATE_CHAT_REDESIGN) for local testing; default
+  // false → existing UX intact. (t/2235)
+  getFlags: () => Promise.resolve({
+    DEBATE_CHAT_REDESIGN: import.meta.env.VITE_DEBATE_CHAT_REDESIGN === 'true',
+  }),
 
   // UsageID registry — stub (desktop has no server-side usage registry)
   getUsageRegistry: () => Promise.resolve({}),


### PR DESCRIPTION
## Summary
Closes the Electron gap TL flagged in t/2235#1: `electron-bridge.ts` `getFlags()` hard-returned `{}`, so `DEBATE_CHAT_REDESIGN` could never be `true` on desktop. Now sources it from a build-time env var, defaulting `false`.

```ts
getFlags: () => Promise.resolve({
  DEBATE_CHAT_REDESIGN: import.meta.env.VITE_DEBATE_CHAT_REDESIGN === 'true',
}),
```

- **Env-var source** `VITE_DEBATE_CHAT_REDESIGN` — build-time-inlined by Vite (matches the existing `VITE_TARGET` pattern), no preload/IPC round-trip → readable from the renderer (AC #1)
- **Default false** — any value other than the literal `'true'` → `false`; existing UX 100% intact (AC #2, #4)
- **Local testing** — `VITE_DEBATE_CHAT_REDESIGN=true` flips ON (AC #3, env-var arm). Settings-UI toggle is optional per AC, deferred
- Consumption path (`useFlag('DEBATE_CHAT_REDESIGN')`) already works via the t/899 flag system — no new infra

**Follow-up (routed separately):** web-build seed default is a coordinated ServerAPI one-liner (register `DEBATE_CHAT_REDESIGN` default-false in the server flag seed).

## Test plan
- [x] `pnpm run build` (tsc main + vite build) exits 0 — env var resolves, renderer bundles
- [x] `vitest run src/renderer/bridge/` — 96/96 pass incl. AppAPI completeness guard
- [ ] CI green

Closes t/2235 · parent t/2234

🤖 Generated with [Claude Code](https://claude.com/claude-code)