### PR TITLE
feat(server): seed DEBATE_CHAT_REDESIGN feature flag default (t/2235)

### DIFF
--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -108,6 +108,12 @@ const SEED_FLAGS: Record<string, FlagDef> = {
     created_at: '2026-06-26T00:00:00.000Z', updated_at: '2026-06-26T00:00:00.000Z',
     created_by: 'seed',
   },
+  'DEBATE_CHAT_REDESIGN': {
+    name: 'DEBATE_CHAT_REDESIGN', enabled: false, scope: 'global',
+    description: 'Gate new debate chat UX (t/2235); toggleable via admin flag CRUD',
+    created_at: '2026-08-07T00:00:00.000Z', updated_at: '2026-08-07T00:00:00.000Z',
+    created_by: 'seed',
+  },
 };
 
 // ── Config loading (mtime cache, quotas.ts pattern) ──


### PR DESCRIPTION
## Summary

- Adds `DEBATE_CHAT_REDESIGN` to the server flag seed defaults (`featureFlags.ts`) — disabled, global scope
- Web build resolves it via GET /api/flags → useFlag('DEBATE_CHAT_REDESIGN'), toggleable via existing admin flag CRUD UI
- Electron half already landed in PR #553 (Rosetta Stone, VITE_DEBATE_CHAT_REDESIGN env var)
- Unblocks t/2238–2242 consumers for ON-state visual testing on the web build

## Test plan

- featureFlags.test.ts — 16/16 pass; flag count shows 9 (new entry included)
- Server tsc clean

Trivial single-line seed addition following the existing pattern (t/899, debate-detail-dropdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
