### PR TITLE
fix(deps): declare @types/mdast + unified as explicit devDeps (t/2248)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -330,6 +333,9 @@ importers:
       typescript-eslint:
         specifier: ^8.65.0
         version: 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)

--- a/taxonomy-editor/package.json
+++ b/taxonomy-editor/package.json
@@ -10,7 +10,9 @@
     "name": "Jeffrey Snover",
     "email": "jsnover13@gmail.com"
   },
-  "engines": { "node": ">=22 <23" },
+  "engines": {
+    "node": ">=22 <23"
+  },
   "main": "dist/main/taxonomy-editor/src/main/main.js",
   "scripts": {
     "dev": "npm run build:main && concurrently \"npm run dev:vite\" \"npm run dev:electron\"",
@@ -77,6 +79,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/mdast": "^4.0.4",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
@@ -94,11 +97,12 @@
     "pino-pretty": "^13.1.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
+    "unified": "^11.0.5",
     "vite": "^8.2.0",
     "vite-plugin-pwa": "^1.3.0",
-    "workbox-window": "^7.4.1",
     "vitest": "^4.1.10",
-    "wait-on": "^9.1.0"
+    "wait-on": "^9.1.0",
+    "workbox-window": "^7.4.1"
   },
   "overrides": {
     "axios": ">=1.8.4",

--- a/taxonomy-editor/pnpm-lock.yaml
+++ b/taxonomy-editor/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -159,6 +162,9 @@ importers:
       typescript-eslint:
         specifier: ^8.65.0
         version: 8.65.0(eslint@10.8.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.12.0)(jiti@2.6.1)(terser@5.48.0)


### PR DESCRIPTION
## Summary
Fixes the local `check-renderer-tsc.sh` verify gate failing on every **fresh worktree** (found while landing t/2235; bites the fleet post-t/2222).

**Root cause:** `refLinkifyPlugin.ts` + `colorizePovPlugin.ts` do `import type { … } from ''mdast''` / `''unified''`. Both were transitive-only (via react-markdown/remark) and did not hoist where tsc resolves them under `--frozen-lockfile` on a clean worktree → 6 `TS2307`/`TS7006` errors, gate fails.

**Fix:** promote `@types/mdast` + `unified` to explicit devDependencies so `--frozen-lockfile` installs them deterministically. `unified` pins the version already in the tree (no churn). No manual post-install step, no hoist-config change needed (DevOps loop not required).

## Test plan (on a genuinely fresh worktree, per AC)
- [x] Reproduced: fresh worktree + `pnpm install --frozen-lockfile` → `check-renderer-tsc.sh` FAILS (6 errors)
- [x] After fix, clean-wipe `node_modules` + `pnpm install --frozen-lockfile` → exit 0 (no lockfile drift)
- [x] `check-renderer-tsc.sh` → `0 / 0 errors (OK)` from the clean install
- [ ] CI green

Note: `pnpm-lock.yaml` (root-owned) updated as the standard generated byproduct of a scoped devDep add.

Closes t/2248

🤖 Generated with [Claude Code](https://claude.com/claude-code)