### PR TITLE
refactor(debate-diagnostics): apply shared bandColor to ScoreBadge + CommitmentsPanel (t/2249)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useMemo } from 'react';
 import type { CommitmentStore, ArgumentNetworkNode, ArgumentNetworkEdge } from '../../../../types/debate';
 import { POVER_INFO } from '../../../../types/debate';
 import type { SpeakerId } from '../../../../types/debate';
+import { bandColor, RISK_BANDS } from '../../../../lib/bandColor';
 
 // NOTE: speakerLabel and AifBadge stay in DiagnosticsWindow.tsx (parent).
 // This component uses a local copy of speakerLabel to remain self-contained.
@@ -129,7 +130,7 @@ export function CommitmentsPanel({ commitments, nodes, edges, onGoToNode }: {
             <strong style={{ fontSize: '0.8rem' }}>{speakerLabel(pov)}</strong>
             {asymmetryByPov[pov] != null && (() => {
               const a = asymmetryByPov[pov]!;
-              const color = Math.abs(a) > 0.3 ? 'var(--danger)' : Math.abs(a) > 0.15 ? 'var(--warning)' : 'var(--success)';
+              const color = bandColor(Math.abs(a), RISK_BANDS);
               const label = Math.abs(a) > 0.3 ? 'high' : Math.abs(a) > 0.15 ? 'moderate' : 'balanced';
               return (
                 <span

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ScoreBadge.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ScoreBadge.tsx
@@ -2,18 +2,20 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import './ScoreBadge.css';
+import { bandColor } from '../../../../lib/bandColor';
+import type { BandEntry } from '../../../../lib/bandColor';
+
+const SCORE_BANDS: readonly BandEntry[] = [
+  { threshold: 0.7, color: 'score-badge--success' },
+  { threshold: 0.4, color: 'score-badge--warning' },
+  { threshold: 0,   color: 'score-badge--danger' },
+];
 
 interface ScoreBadgeProps {
   value: number;
   label: string;
   tooltip?: string;
   compact?: boolean;
-}
-
-function bandClass(value: number): string {
-  if (value >= 0.7) return 'score-badge--success';
-  if (value >= 0.4) return 'score-badge--warning';
-  return 'score-badge--danger';
 }
 
 export function ScoreBadge({ value, label, tooltip, compact = false }: ScoreBadgeProps) {
@@ -23,7 +25,7 @@ export function ScoreBadge({ value, label, tooltip, compact = false }: ScoreBadg
 
   return (
     <span
-      className={`score-badge ${bandClass(clamped)}`}
+      className={`score-badge ${bandColor(clamped, SCORE_BANDS)}`}
       title={tooltip ?? `${humanize(label)}: ${clamped.toFixed(2)} (0–1 scale)`}
     >
       <span className="score-badge-label">{displayLabel}</span>


### PR DESCRIPTION
## Summary
- `ScoreBadge`: replace local `bandClass()` with `bandColor(clamped, SCORE_BANDS)` using the shared utility from `lib/bandColor`. Local `SCORE_BANDS` const preserves the component-specific 0.7/0.4 thresholds and class-suffix return values
- `CommitmentsPanel`: replace hardcoded `Math.abs(a) > 0.3 ? 'var(--danger)' : …` ternary with `bandColor(Math.abs(a), RISK_BANDS)` — exact match, single source of truth
- No behavioral change — same thresholds, same colors, no new cross-scope file edits

## Test plan
- [ ] CI green (tsc, eslint, vitest, vite build)
- [ ] ScoreBadge colors unchanged (success/warning/danger CSS classes still apply correctly)
- [ ] CommitmentsPanel asymmetry badge colors unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)