### PR TITLE
feat(debate-workspace): unified phase indicator + shared bandColor util (t/2238, t/2236)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/ClaimsView.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/ClaimsView.tsx
@@ -6,15 +6,12 @@ import type { ArgumentNetworkNode, ArgumentNetworkEdge, TranscriptEntry } from '
 import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
 import { speakerLabel, STRENGTH_BAND, getNodeLabel } from './utils';
+import { bandColor as computeBandColor, CONFIDENCE_BANDS } from '../../lib/bandColor';
 import './ClaimsView.css';
 
 const ATTACK_TYPE_WEIGHTS: Record<string, number> = { rebut: 1.0, undercut: 1.05, undermine: 1.1 };
 
 type ClaimAttribution = NonNullable<ArgumentNetworkNode['claim_taxonomy_attribution']>;
-
-function bandColorFor(computed: number): string {
-  return computed >= 0.8 ? '#22c55e' : computed >= 0.5 ? '#3b82f6' : computed >= 0.3 ? '#f59e0b' : '#ef4444';
-}
 
 function bdiLabelFor(node: ArgumentNetworkNode): string {
   return node.bdi_category === 'belief' ? 'Belief' : node.bdi_category === 'desire' ? 'Desire' : node.bdi_category === 'intention' ? 'Intention' : '';
@@ -55,7 +52,11 @@ function UnattributedBadge({ reason }: { reason: string }) {
 
 function AttributedBadge({ attr }: { attr: ClaimAttribution }) {
   const conf = attr.attribution_confidence;
-  const confColor = conf >= 0.7 ? '#22c55e' : conf >= 0.5 ? '#3b82f6' : '#f59e0b';
+  const confColor = computeBandColor(conf, [
+    { threshold: 0.7, color: '#22c55e' },
+    { threshold: 0.5, color: '#3b82f6' },
+    { threshold: 0,   color: '#f59e0b' },
+  ]);
   const secCount = attr.secondary_refs?.length ?? 0;
   const attrTip = `Attributed to ${attr.primary_ref} (confidence: ${conf.toFixed(2)})\n${getNodeLabel(attr.primary_ref)}${secCount > 0 ? `\n\n${secCount} secondary ref${secCount !== 1 ? 's' : ''}: ${attr.secondary_refs!.map((s: { node_id: string; similarity: number }) => `${s.node_id} (${s.similarity.toFixed(2)})`).join(', ')}` : ''}`;
   return (
@@ -186,7 +187,7 @@ export function ClaimNodeRow({ node, attacks, supports, allNodes, strengthMap, s
   const computed = strengthMap.get(node.id) ?? node.computed_strength ?? base;
   const delta = computed - base;
   const band = STRENGTH_BAND(computed);
-  const bandColor = bandColorFor(computed);
+  const bandColor = computeBandColor(computed, CONFIDENCE_BANDS);
   const bdiLabel = bdiLabelFor(node);
 
   return (

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.css
@@ -1,0 +1,171 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/*
+ * Unified phase indicator (t/2238, DEBATE_CHAT_REDESIGN). One coordinated widget
+ * that nests the adaptive sub-phase track inside the active "Debate" session step,
+ * replacing the two independent stacked bars behind the flag.
+ */
+
+.unified-phase-indicator {
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.unified-phase-steps {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.unified-phase-step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.unified-phase-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.unified-phase-step.active .unified-phase-dot {
+  border-color: var(--focus-ring);
+  background: var(--focus-ring);
+  color: #fff;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus-ring) 20%, transparent);
+}
+
+.unified-phase-step.completed .unified-phase-dot {
+  border-color: var(--success);
+  background: var(--success);
+  color: #fff;
+}
+
+.unified-phase-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.unified-phase-step.active .unified-phase-label {
+  color: var(--text-primary);
+}
+
+.unified-phase-step.completed .unified-phase-label {
+  color: var(--success);
+}
+
+.unified-phase-line {
+  width: 24px;
+  height: 2px;
+  background: var(--border-color);
+  margin: 0 4px;
+  flex-shrink: 0;
+  transition: background 0.25s ease;
+}
+
+.unified-phase-line.completed {
+  background: var(--success);
+}
+
+/* ── Nested adaptive sub-track ── */
+
+.unified-phase-subtrack {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  /* Indent under the "Debate" step (3rd step: two dots + labels + lines before it). */
+  padding-left: 30px;
+}
+
+.unified-phase-subcaption {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.unified-phase-subsegments {
+  display: flex;
+  gap: 3px;
+  height: 20px;
+  flex: 1;
+  max-width: 360px;
+}
+
+.unified-phase-subseg {
+  flex: 1;
+  position: relative;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.unified-phase-subseg.active {
+  border-color: color-mix(in srgb, currentColor 40%, var(--border-color));
+}
+
+.unified-phase-subseg.completed {
+  opacity: 0.6;
+}
+
+.unified-phase-subfill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  opacity: 0.2;
+  transition: width 0.4s ease;
+}
+
+.unified-phase-subseg.active .unified-phase-subfill {
+  opacity: 0.25;
+}
+
+.unified-phase-subseg.completed .unified-phase-subfill {
+  opacity: 0.15;
+}
+
+.unified-phase-sublabel {
+  position: relative;
+  z-index: 1;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.unified-phase-subseg.active .unified-phase-sublabel {
+  color: var(--text-primary);
+}
+
+.unified-phase-subhint {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  color: var(--success);
+  white-space: nowrap;
+  animation: phase-hint-pulse 2s ease-in-out infinite;
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
@@ -17,6 +17,8 @@ import { useTierInfo } from '../../hooks/useTierInfo';
 import { isElectronMode } from '@bridge';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { triggerManualDump } from '../../lib/flightRecorderInit';
+import { bandColor, BUDGET_BANDS } from '../../lib/bandColor';
+import './DebateActionBar.css';
 
 export function ProgressIndicator() {
   const { debateActivity, debateProgress } = useDebateStore(
@@ -41,8 +43,6 @@ export function ProgressIndicator() {
   );
 }
 
-const BUDGET_WARN_THRESHOLD = 0.8;
-const BUDGET_URGENT_THRESHOLD = 0.95;
 
 function formatResetTime(resetsAt: string): string {
   const ms = new Date(resetsAt).getTime() - Date.now();
@@ -63,10 +63,11 @@ export function TokenBudgetIndicator() {
   if (pct < 0.01) return null;
   const remaining = Math.max(0, tokensPerDay - tokensToday);
   const remainingK = remaining >= 1000 ? `${Math.round(remaining / 1000)}k` : String(remaining);
-  const isUrgent = pct >= BUDGET_URGENT_THRESHOLD;
-  const isWarning = pct >= BUDGET_WARN_THRESHOLD;
+  const level = bandColor(pct, BUDGET_BANDS);
+  const isUrgent = level === 'urgent';
+  const isWarning = level === 'warning';
   const resetLabel = resetsAt ? formatResetTime(resetsAt) : '';
-  const levelClass = isUrgent ? ' urgent' : isWarning ? ' warning' : '';
+  const levelClass = level ? ` ${level}` : '';
   return (
     <div className={`token-budget-indicator${levelClass}`}>
       {isUrgent ? (
@@ -159,6 +160,93 @@ export function SessionPhaseStepper({ phase, roundCount }: { phase: string; roun
           </div>
         );
       })}
+    </div>
+  );
+}
+
+/**
+ * Adaptive sub-phase track, nested under the "Debate" session step in the
+ * unified indicator (t/2238). Same data as {@link PhaseProgressBar} but rendered
+ * as a compact secondary row so both dimensions read as one widget.
+ */
+function UnifiedAdaptiveSubTrack({ currentPhase, phaseProgress, roundsInPhase, approachingTransition, rationale }: {
+  currentPhase: AdaptivePhase;
+  phaseProgress: number;
+  roundsInPhase: number;
+  approachingTransition: boolean;
+  rationale?: string;
+}) {
+  const currentIdx = ADAPTIVE_PHASES.indexOf(currentPhase);
+  return (
+    <div className="unified-phase-subtrack" title={rationale || `${ADAPTIVE_PHASE_LABELS[currentPhase]} — round ${roundsInPhase}`}>
+      <span className="unified-phase-subcaption">Debate stage</span>
+      <div className="unified-phase-subsegments">
+        {ADAPTIVE_PHASES.map((phase, idx) => {
+          const isActive = idx === currentIdx;
+          const isCompleted = idx < currentIdx;
+          const fillPct = isCompleted ? 100 : isActive ? Math.min(100, phaseProgress * 100) : 0;
+          return (
+            <div
+              key={phase}
+              className={`unified-phase-subseg${isActive ? ' active' : ''}${isCompleted ? ' completed' : ''}`}
+              title={`${ADAPTIVE_PHASE_LABELS[phase]}${isActive ? ` — ${Math.round(phaseProgress * 100)}% (round ${roundsInPhase})` : ''}`}
+            >
+              {/* eslint-disable-next-line local/no-inline-style -- fill width + per-phase color are runtime values (mirrors PhaseProgressBar) */}
+              <div className="unified-phase-subfill" style={{ width: `${fillPct}%`, background: ADAPTIVE_PHASE_COLORS[phase] }} />
+              <span className="unified-phase-sublabel">{ADAPTIVE_PHASE_LABELS[phase]}</span>
+            </div>
+          );
+        })}
+      </div>
+      {approachingTransition && (
+        <span className="unified-phase-subhint">Approaching transition</span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Single coordinated phase indicator (t/2238, DEBATE_CHAT_REDESIGN). Reconciles
+ * the session stepper (Refine → Opening → Debate → Complete) and the adaptive
+ * sub-phase bar by nesting the adaptive stages inside the active "Debate" step,
+ * so a researcher reads one widget instead of two unrelated scales. The flag-off
+ * path still renders {@link SessionPhaseStepper} + {@link PhaseProgressBar}.
+ */
+export function UnifiedPhaseIndicator({ phase, roundCount, adaptive }: {
+  phase: string;
+  roundCount: number;
+  adaptive?: {
+    currentPhase: AdaptivePhase;
+    phaseProgress: number;
+    roundsInPhase: number;
+    approachingTransition: boolean;
+    rationale?: string;
+  };
+}) {
+  const stepIdx = SESSION_STEPS.findIndex(s => s.key === phase);
+  const activeIdx = stepIdx >= 0 ? stepIdx : (phase === 'setup' || phase === 'edit-claims' ? 0 : -1);
+
+  return (
+    <div className="unified-phase-indicator">
+      <div className="unified-phase-steps">
+        {SESSION_STEPS.map((step, idx) => {
+          const completed = idx < activeIdx || phase === 'closed';
+          const active = idx === activeIdx && phase !== 'closed';
+          return (
+            <div key={step.key} className={`unified-phase-step${completed ? ' completed' : ''}${active ? ' active' : ''}`}>
+              <div className="unified-phase-dot">{completed ? '✓' : idx + 1}</div>
+              <span className="unified-phase-label">
+                {step.label}
+                {active && step.key === 'debate' && roundCount > 0 ? ` (${roundCount})` : ''}
+              </span>
+              {idx < SESSION_STEPS.length - 1 && <div className={`unified-phase-line${completed ? ' completed' : ''}`} />}
+            </div>
+          );
+        })}
+      </div>
+      {adaptive && phase === 'debate' && (
+        <UnifiedAdaptiveSubTrack {...adaptive} />
+      )}
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
@@ -180,9 +180,17 @@ vi.mock('./StatementCard', () => ({
 vi.mock('./DebateActionBar', () => ({
   PhaseProgressBar: () => <div data-testid="phase-progress" />,
   SessionPhaseStepper: () => <div data-testid="session-stepper" />,
+  UnifiedPhaseIndicator: ({ adaptive }: any) => (
+    <div data-testid="unified-phase-indicator" data-has-adaptive={adaptive ? 'yes' : 'no'} />
+  ),
   ProgressIndicator: () => <div data-testid="progress-indicator" />,
   DebaterToggles: () => <div data-testid="debater-toggles" />,
   DebateActions: () => <div data-testid="debate-actions" />,
+}));
+// Controllable feature-flag mock (default: all flags off — preserves existing flag-off tests).
+const mockFlags: Record<string, boolean> = {};
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFlag: (name: string) => mockFlags[name] ?? false,
 }));
 vi.mock('./ClarificationPanel', () => ({
   ClarificationActions: () => <div data-testid="clarification-actions" />,
@@ -451,6 +459,40 @@ describe('phase routing', () => {
     });
     render(<DebateWorkspace />);
     expect(screen.getByTestId('phase-progress')).toBeInTheDocument();
+  });
+
+  describe('DEBATE_CHAT_REDESIGN flag on — unified phase indicator (t/2238)', () => {
+    beforeEach(() => { mockFlags.DEBATE_CHAT_REDESIGN = true; });
+    afterEach(() => { delete mockFlags.DEBATE_CHAT_REDESIGN; });
+
+    it('replaces the stacked stepper + progress bar with a single unified indicator', () => {
+      mockStore.activeDebate = makeDebate({ phase: 'debate' });
+      render(<DebateWorkspace />);
+      expect(screen.getByTestId('unified-phase-indicator')).toBeInTheDocument();
+      expect(screen.queryByTestId('session-stepper')).toBeNull();
+      expect(screen.queryByTestId('phase-progress')).toBeNull();
+    });
+
+    it('nests adaptive staging into the unified indicator during the debate phase', () => {
+      mockStore.activeDebate = makeDebate({
+        phase: 'debate',
+        adaptive_staging: { enabled: true, current_phase: 'argumentation', phase_progress: 0.6, rounds_in_phase: 2, approaching_transition: true },
+      });
+      render(<DebateWorkspace />);
+      expect(screen.getByTestId('unified-phase-indicator')).toHaveAttribute('data-has-adaptive', 'yes');
+    });
+
+    it('omits the adaptive sub-track when staging is disabled', () => {
+      mockStore.activeDebate = makeDebate({ phase: 'debate' });
+      render(<DebateWorkspace />);
+      expect(screen.getByTestId('unified-phase-indicator')).toHaveAttribute('data-has-adaptive', 'no');
+    });
+
+    it('hides the unified indicator when the debate is closed', () => {
+      mockStore.activeDebate = makeDebate({ phase: 'closed' });
+      render(<DebateWorkspace />);
+      expect(screen.queryByTestId('unified-phase-indicator')).toBeNull();
+    });
   });
 
   it('renders ClaimsEditor in edit-claims phase', () => {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -34,7 +34,8 @@ import { useUserProfile } from '../../hooks/useAuthStatus';
 import { CommunityShareBanner } from '../shared/CommunityShareBanner';
 import { CoverageBadge } from './TaxonomyRefs';
 import { StatementCard, ProbingCard, FactCheckCard, EntryDeleteControls, HighlightedText, PhaseHairline } from './StatementCard';
-import { PhaseProgressBar, SessionPhaseStepper, DebaterToggles, DebateActions } from './DebateActionBar';
+import { PhaseProgressBar, SessionPhaseStepper, UnifiedPhaseIndicator, DebaterToggles, DebateActions } from './DebateActionBar';
+import { useFlag } from '../../hooks/useFeatureFlags';
 import { StatementProgressIndicator } from './StatementProgressIndicator';
 import { ClarificationActions, ClaimsEditor, RefinedTopicEditor, TopicScoreComparison } from './ClarificationPanel';
 import { OpeningActions } from './OpeningPanel';
@@ -635,36 +636,58 @@ function DebatePhaseHeader({ activeDebate, isDebatePhase, isOpeningPhase }: {
   isDebatePhase: boolean;
   isOpeningPhase: boolean;
 }) {
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
+  const staging = (activeDebate as any).adaptive_staging as {
+    enabled: boolean;
+    current_phase: AdaptivePhase;
+    phase_progress: number;
+    rounds_in_phase: number;
+    approaching_transition: boolean;
+    rationale?: string;
+  } | undefined;
+  const showSessionPhase = activeDebate.phase !== 'setup' && activeDebate.phase !== 'closed';
+  const showAdaptivePhase = isDebatePhase && activeDebate.phase !== 'closed' && !!staging?.enabled;
+  const roundCount = activeDebate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length;
+
   return (
     <>
-      {/* Session phase stepper — always visible once debate has started */}
-      {activeDebate.phase !== 'setup' && activeDebate.phase !== 'closed' && (
-        <SessionPhaseStepper
-          phase={activeDebate.phase}
-          roundCount={activeDebate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length}
-        />
-      )}
-
-      {/* Adaptive phase progress bar — shown during debate phase when adaptive staging is enabled */}
-      {isDebatePhase && activeDebate.phase !== 'closed' && (activeDebate as any).adaptive_staging?.enabled && (() => {
-        const staging = (activeDebate as any).adaptive_staging as {
-          enabled: boolean;
-          current_phase: AdaptivePhase;
-          phase_progress: number;
-          rounds_in_phase: number;
-          approaching_transition: boolean;
-          rationale?: string;
-        };
-        return (
-          <PhaseProgressBar
-            currentPhase={staging.current_phase || 'confrontation'}
-            phaseProgress={staging.phase_progress || 0}
-            roundsInPhase={staging.rounds_in_phase || 0}
-            approachingTransition={staging.approaching_transition || false}
-            rationale={staging.rationale}
+      {chatRedesign ? (
+        /* Unified indicator (t/2238): session stepper with the adaptive sub-phase nested in the Debate step. */
+        showSessionPhase && (
+          <UnifiedPhaseIndicator
+            phase={activeDebate.phase}
+            roundCount={roundCount}
+            adaptive={showAdaptivePhase && staging ? {
+              currentPhase: staging.current_phase || 'confrontation',
+              phaseProgress: staging.phase_progress || 0,
+              roundsInPhase: staging.rounds_in_phase || 0,
+              approachingTransition: staging.approaching_transition || false,
+              rationale: staging.rationale,
+            } : undefined}
           />
-        );
-      })()}
+        )
+      ) : (
+        <>
+          {/* Session phase stepper — always visible once debate has started */}
+          {showSessionPhase && (
+            <SessionPhaseStepper
+              phase={activeDebate.phase}
+              roundCount={roundCount}
+            />
+          )}
+
+          {/* Adaptive phase progress bar — shown during debate phase when adaptive staging is enabled */}
+          {showAdaptivePhase && staging && (
+            <PhaseProgressBar
+              currentPhase={staging.current_phase || 'confrontation'}
+              phaseProgress={staging.phase_progress || 0}
+              roundsInPhase={staging.rounds_in_phase || 0}
+              approachingTransition={staging.approaching_transition || false}
+              rationale={staging.rationale}
+            />
+          )}
+        </>
+      )}
 
       {/* Debater toggle pills */}
       {(isDebatePhase || isOpeningPhase) && (

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -17,6 +17,8 @@ import {
   fixMarkdownLinks, stripLeadingHeadings,
   META_TIERS, TIER_LABELS,
 } from './utils';
+import { bandColor as computeBandColor } from '../../lib/bandColor';
+import type { BandEntry } from '../../lib/bandColor';
 import type { AnchorHTMLAttributes, HTMLAttributes } from 'react';
 import { parseEntityRef } from '@lib/entities/types';
 import type { FactVerdict, FactDiscrepancy } from '@lib/debate/types';
@@ -105,12 +107,12 @@ function ConvBadge({ text, color }: { text: string; color: string }) {
   return <span className="convergence-badge" style={{ color }}>{text}</span>;
 }
 
-function bandBadge(value: number, bands: [number, string, string][]): ReactNode {
-  for (const [threshold, label, color] of bands) {
-    if (value >= threshold) return <ConvBadge text={label} color={color} />;
-  }
-  const fallback = bands[bands.length - 1];
-  return <ConvBadge text={fallback[1]} color={fallback[2]} />;
+type LabeledBand = BandEntry & { label: string };
+
+function bandBadge(value: number, bands: readonly LabeledBand[]): ReactNode {
+  const color = computeBandColor(value, bands);
+  const label = (bands.find(b => value >= b.threshold) ?? bands.at(-1))!.label;
+  return <ConvBadge text={label} color={color} />;
 }
 
 function ConvCell({ label, span, children }: { label: string; span?: boolean; children: ReactNode }) {
@@ -135,7 +137,7 @@ function PolarityCell({ md }: { md: ConvergenceSignals['move_polarity'] }) {
       <span style={{ color: '#ef4444' }}>{md?.confrontational ?? 0}C</span>{' / '}
       <span style={{ color: '#22c55e' }}>{md?.collaborative ?? 0}S</span>
       {' = '}<strong>{pctFmt(md?.ratio ?? 0)}</strong>
-      {bandBadge(md?.ratio ?? 0, [[0.5, 'cooperative', '#22c55e'], [0, 'confrontational', '#ef4444']])}
+      {bandBadge(md?.ratio ?? 0, [{ threshold: 0.5, label: 'cooperative', color: '#22c55e' }, { threshold: 0, label: 'confrontational', color: '#ef4444' }])}
     </ConvCell>
   );
 }
@@ -146,7 +148,7 @@ function EngagementCell({ ed }: { ed: ConvergenceSignals['dialectical_engagement
   return (
     <ConvCell label="Dialectical Engagement">
       {edTargeted}/{edTotal} targeted = <strong>{pctFmt(ed?.ratio ?? 0)}</strong>
-      {bandBadge(ed?.ratio ?? 0, [[0.7, 'deep', '#22c55e'], [0.4, 'moderate', '#f59e0b'], [0, 'standalone', '#ef4444']])}
+      {bandBadge(ed?.ratio ?? 0, [{ threshold: 0.7, label: 'deep', color: '#22c55e' }, { threshold: 0.4, label: 'moderate', color: '#f59e0b' }, { threshold: 0, label: 'standalone', color: '#ef4444' }])}
     </ConvCell>
   );
 }
@@ -158,7 +160,7 @@ function RedundancyCell({ rr }: { rr: ConvergenceSignals['argument_redundancy'] 
       avg <strong>{pctFmt(rr?.avg_self_overlap ?? 0)}</strong>, max <strong>{pctFmt(rrMaxOverlap)}</strong>
       {rr?.semantic_max_similarity != null && <>, sem <strong>{pctFmt(rr.semantic_max_similarity)}</strong></>}
       {rr?.semantically_recycled ? <ConvBadge text="semantic repeat" color="#ef4444" />
-        : bandBadge(rrMaxOverlap, [[0.5, 'repeating', '#f59e0b'], [0, 'fresh', '#22c55e']])}
+        : bandBadge(rrMaxOverlap, [{ threshold: 0.5, label: 'repeating', color: '#f59e0b' }, { threshold: 0, label: 'fresh', color: '#22c55e' }])}
     </ConvCell>
   );
 }
@@ -168,7 +170,7 @@ function CounterargCell({ so }: { so: ConvergenceSignals['dominant_counterargume
     <ConvCell label="Dominant Counterargument">
       {so ? (
         <>{so.node_id} str={so.strength?.toFixed(2)}
-          {bandBadge(so.strength ?? 0, [[0.7, 'strong', '#ef4444'], [0.5, 'moderate', '#f59e0b'], [0, 'weak', '#22c55e']])}
+          {bandBadge(so.strength ?? 0, [{ threshold: 0.7, label: 'strong', color: '#ef4444' }, { threshold: 0.5, label: 'moderate', color: '#f59e0b' }, { threshold: 0, label: 'weak', color: '#22c55e' }])}
         </>
       ) : <span style={{ color: 'var(--text-muted)' }}>none</span>}
     </ConvCell>
@@ -192,7 +194,7 @@ function DriftCell({ pd }: { pd: ConvergenceSignals['position_drift'] }) {
   return (
     <ConvCell label="Position Drift">
       opening: <strong>{pctFmt(pdOverlap)}</strong>, drift: <strong>{pctFmt(pd?.drift ?? 0)}</strong>
-      {bandBadge(pdOverlap, [[0.6, 'anchored', '#f59e0b'], [0.3, 'evolved', '#22c55e'], [0, 'shifted', '#3b82f6']])}
+      {bandBadge(pdOverlap, [{ threshold: 0.6, label: 'anchored', color: '#f59e0b' }, { threshold: 0.3, label: 'evolved', color: '#22c55e' }, { threshold: 0, label: 'shifted', color: '#3b82f6' }])}
     </ConvCell>
   );
 }

--- a/taxonomy-editor/src/renderer/lib/bandColor.ts
+++ b/taxonomy-editor/src/renderer/lib/bandColor.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+export type BandEntry = { threshold: number; color: string };
+
+/** Returns the color from the first band where value >= threshold. */
+export function bandColor(value: number, bands: readonly BandEntry[]): string {
+  for (const { threshold, color } of bands) {
+    if (value >= threshold) return color;
+  }
+  return bands.at(-1)?.color ?? '';
+}
+
+/** Claim / argument strength (ClaimsView primary banding). */
+export const CONFIDENCE_BANDS: readonly BandEntry[] = [
+  { threshold: 0.8, color: '#22c55e' },
+  { threshold: 0.5, color: '#3b82f6' },
+  { threshold: 0.3, color: '#f59e0b' },
+  { threshold: 0,   color: '#ef4444' },
+];
+
+/** Concession-asymmetry magnitude; returns CSS variable tokens. */
+export const RISK_BANDS: readonly BandEntry[] = [
+  { threshold: 0.3,  color: 'var(--danger)' },
+  { threshold: 0.15, color: 'var(--warning)' },
+  { threshold: 0,    color: 'var(--success)' },
+];
+
+/** Token-budget consumption level; returns CSS class suffix string. */
+export const BUDGET_BANDS: readonly BandEntry[] = [
+  { threshold: 0.95, color: 'urgent' },
+  { threshold: 0.8,  color: 'warning' },
+  { threshold: 0,    color: '' },
+];


### PR DESCRIPTION
## Summary

Lands two tangled-in-one-file DebateWorkspace changes together (PM-approved single PR, p/188#14).

### t/2238 — Unified phase indicator (behind `DEBATE_CHAT_REDESIGN`)
`DebatePhaseHeader` previously stacked two unreconciled indicators (`SessionPhaseStepper` on a 5-step session scale + `PhaseProgressBar` on a 3-step adaptive scale). New `UnifiedPhaseIndicator` renders **one** widget: the session stepper (Refine → Opening → Debate → Complete) with the adaptive sub-phase (Confrontation → Argumentation → Concluding) **nested under the active "Debate" step**.

- Gated on `useFlag('DEBATE_CHAT_REDESIGN')`. **Flag OFF** → existing `SessionPhaseStepper` + `PhaseProgressBar` unchanged (both remain exported/intact).
- New co-located `DebateActionBar.css` (uses defined theme tokens; `styles.css` stays frozen).

### t/2236 — Shared `bandColor` utility (in-scope portion)
Extracts `bandColor(value, bands)` + named `CONFIDENCE`/`RISK`/`BUDGET` band-sets into `src/renderer/lib/bandColor.ts`, replacing 4 in-scope score-to-color sites (`ClaimsView` ×2, `DebateActionBar` `TokenBudgetIndicator`, `StatementCard`). Visual output identical. The 3 out-of-scope sites are tracked separately in **t/2249** (DebateDiagnostics) and **t/2250** (DebateUI).

## Verification
- `tsc -p tsconfig.main.json` clean
- 247 scoped vitest pass, incl. 4 new flag-on tests (unified replaces both bars; adaptive nests; sub-track omitted when staging off; hidden when closed)
- eslint 0 errors

## Tickets
Closes t/2238. Advances t/2236 (in-scope portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
