### PR TITLE
fix(situation-detail): add type predicate to isPovTab for TS narrowing

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
@@ -46,7 +46,7 @@ interface SituationDetailProps {
 type SitTab = 'overview' | 'attributes' | 'accelerationist' | 'safetyist' | 'skeptic' | 'debate' | 'sources' | 'research';
 type SitPov = 'accelerationist' | 'safetyist' | 'skeptic';
 
-function isPovTab(tab: SitTab): boolean {
+function isPovTab(tab: SitTab): tab is SitPov {
   return tab === 'accelerationist' || tab === 'safetyist' || tab === 'skeptic';
 }
 


### PR DESCRIPTION
## Summary
- `isPovTab(tab: SitTab): boolean` → `tab is SitPov` so TypeScript narrows `activeTab` inside the JSX conditional
- Regression from PR #556 where the inline triple-check (which TS narrows automatically) was extracted to a helper without a type predicate

## Test plan
- [ ] `tsc --noEmit` clean (no SituationDetail errors)
- [ ] `npm run verify` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)