### PR TITLE
feat(debate-workspace): unified phase indicator behind DEBATE_CHAT_REDESIGN (t/2238)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.css
@@ -1,0 +1,182 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/*
+ * Unified phase indicator (t/2238, DEBATE_CHAT_REDESIGN). One coordinated widget
+ * that nests the adaptive sub-phase track inside the active "Debate" session step,
+ * replacing the two independent stacked bars behind the flag.
+ */
+
+.unified-phase-indicator {
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.unified-phase-steps {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-wrap: wrap;
+}
+
+.unified-phase-step {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.unified-phase-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.unified-phase-step.active .unified-phase-dot {
+  border-color: var(--focus-ring);
+  background: var(--focus-ring);
+  color: #fff;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus-ring) 20%, transparent);
+}
+
+.unified-phase-step.completed .unified-phase-dot {
+  border-color: var(--success);
+  background: var(--success);
+  color: #fff;
+}
+
+.unified-phase-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.unified-phase-step.active .unified-phase-label {
+  color: var(--text-primary);
+}
+
+.unified-phase-step.completed .unified-phase-label {
+  color: var(--success);
+}
+
+.unified-phase-line {
+  width: 24px;
+  height: 2px;
+  background: var(--border-color);
+  margin: 0 4px;
+  flex-shrink: 0;
+  transition: background 0.25s ease;
+}
+
+.unified-phase-line.completed {
+  background: var(--success);
+}
+
+/* ── Nested adaptive sub-track ── */
+
+/*
+ * The sub-track belongs to the active "Debate" step; the connector below ties
+ * the indented row back to that step so the nesting reads structurally.
+ */
+.unified-phase-subtrack {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  margin-left: 10px;
+  padding-left: 14px;
+  border-left: 2px solid var(--border-color);
+}
+
+.unified-phase-subcaption {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.unified-phase-subsegments {
+  display: flex;
+  gap: 3px;
+  height: 20px;
+  flex: 1;
+  max-width: 360px;
+}
+
+.unified-phase-subseg {
+  flex: 1;
+  position: relative;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.unified-phase-subseg.completed {
+  opacity: 0.6;
+}
+
+.unified-phase-subfill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  opacity: 0.2;
+  transition: width 0.4s ease;
+}
+
+.unified-phase-subseg.active .unified-phase-subfill {
+  opacity: 0.25;
+}
+
+.unified-phase-subseg.completed .unified-phase-subfill {
+  opacity: 0.15;
+}
+
+.unified-phase-sublabel {
+  position: relative;
+  z-index: 1;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.unified-phase-subseg.active .unified-phase-sublabel {
+  color: var(--text-primary);
+}
+
+.unified-phase-subhint {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  color: var(--success);
+  white-space: nowrap;
+  animation: phase-hint-pulse 2s ease-in-out infinite;
+}
+
+.unified-phase-subrationale {
+  font-size: var(--text-2xs);
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
@@ -18,6 +18,7 @@ import { isElectronMode } from '@bridge';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { triggerManualDump } from '../../lib/flightRecorderInit';
 import { bandColor, BUDGET_BANDS } from '../../lib/bandColor';
+import './DebateActionBar.css';
 
 export function ProgressIndicator() {
   const { debateActivity, debateProgress } = useDebateStore(
@@ -158,6 +159,103 @@ export function SessionPhaseStepper({ phase, roundCount }: { phase: string; roun
           </div>
         );
       })}
+    </div>
+  );
+}
+
+/**
+ * Adaptive sub-phase track, nested under the "Debate" session step in the
+ * unified indicator (t/2238). Same data as {@link PhaseProgressBar} but rendered
+ * as a compact secondary row so both dimensions read as one widget.
+ */
+function UnifiedAdaptiveSubTrack({ currentPhase, phaseProgress, roundsInPhase, approachingTransition, rationale }: {
+  currentPhase: AdaptivePhase;
+  phaseProgress: number;
+  roundsInPhase: number;
+  approachingTransition: boolean;
+  rationale?: string;
+}) {
+  const currentIdx = ADAPTIVE_PHASES.indexOf(currentPhase);
+
+  return (
+    <div className="unified-phase-subtrack" title={rationale || `${ADAPTIVE_PHASE_LABELS[currentPhase]} stage, round ${roundsInPhase}`}>
+      <span className="unified-phase-subcaption">Stage</span>
+      <div className="unified-phase-subsegments">
+        {ADAPTIVE_PHASES.map((phase, idx) => {
+          const isActive = idx === currentIdx;
+          const isCompleted = idx < currentIdx;
+          const fillPct = isCompleted ? 100 : isActive ? Math.min(100, phaseProgress * 100) : 0;
+
+          return (
+            <div
+              key={phase}
+              className={`unified-phase-subseg${isActive ? ' active' : ''}${isCompleted ? ' completed' : ''}`}
+              title={`${ADAPTIVE_PHASE_LABELS[phase]}${isActive ? ` — ${Math.round(phaseProgress * 100)}% (round ${roundsInPhase})` : ''}`}
+            >
+              <div className="unified-phase-subfill" style={{ width: `${fillPct}%`, background: ADAPTIVE_PHASE_COLORS[phase] }} />
+              <span className="unified-phase-sublabel">{ADAPTIVE_PHASE_LABELS[phase]}</span>
+            </div>
+          );
+        })}
+      </div>
+      {approachingTransition && (
+        <span className="unified-phase-subhint">Approaching transition</span>
+      )}
+      {rationale && (
+        <span className="unified-phase-subrationale" title={rationale}>
+          {rationale.length > 80 ? rationale.slice(0, 77) + '...' : rationale}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Single coordinated phase indicator (t/2238, DEBATE_CHAT_REDESIGN). Reconciles
+ * the two previously-stacked scales — session phase (Refine → Opening → Debate →
+ * Complete) and adaptive sub-phase (Confrontation → Argumentation → Concluding) —
+ * by nesting the adaptive stages *inside* the active "Debate" step, so a
+ * researcher reads one widget instead of two unrelated progress bars. The
+ * flag-off path still renders {@link SessionPhaseStepper} + {@link PhaseProgressBar}.
+ */
+export function UnifiedPhaseIndicator({ phase, roundCount, adaptive }: {
+  phase: string;
+  roundCount: number;
+  adaptive?: {
+    currentPhase: AdaptivePhase;
+    phaseProgress: number;
+    roundsInPhase: number;
+    approachingTransition: boolean;
+    rationale?: string;
+  };
+}) {
+  const stepIdx = SESSION_STEPS.findIndex(s => s.key === phase);
+  const activeIdx = stepIdx >= 0 ? stepIdx : (phase === 'setup' || phase === 'edit-claims' ? 0 : -1);
+  const showSubTrack = !!adaptive && phase === 'debate';
+
+  return (
+    <div className="unified-phase-indicator">
+      <div className="unified-phase-steps">
+        {SESSION_STEPS.map((step, idx) => {
+          const completed = idx < activeIdx || phase === 'closed';
+          const active = idx === activeIdx && phase !== 'closed';
+          const hasSubTrack = active && step.key === 'debate' && showSubTrack;
+          return (
+            <div
+              key={step.key}
+              className={`unified-phase-step${completed ? ' completed' : ''}${active ? ' active' : ''}${hasSubTrack ? ' has-subtrack' : ''}`}
+            >
+              <div className="unified-phase-dot">{completed ? '✓' : idx + 1}</div>
+              <span className="unified-phase-label">
+                {step.label}
+                {active && step.key === 'debate' && roundCount > 0 ? ` (${roundCount})` : ''}
+              </span>
+              {idx < SESSION_STEPS.length - 1 && <div className={`unified-phase-line${completed ? ' completed' : ''}`} />}
+            </div>
+          );
+        })}
+      </div>
+      {showSubTrack && adaptive && <UnifiedAdaptiveSubTrack {...adaptive} />}
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebatePhaseIndicators.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebatePhaseIndicators.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useFlag } from '../../hooks/useFeatureFlags';
+import { PhaseProgressBar, SessionPhaseStepper, UnifiedPhaseIndicator } from './DebateActionBar';
+import type { AdaptivePhase } from './utils';
+
+interface AdaptiveStaging {
+  enabled: boolean;
+  current_phase: AdaptivePhase;
+  phase_progress: number;
+  rounds_in_phase: number;
+  approaching_transition: boolean;
+  rationale?: string;
+}
+
+/**
+ * Phase indicators for the debate workspace header. Behind `DEBATE_CHAT_REDESIGN`
+ * the two previously-stacked scales collapse into one {@link UnifiedPhaseIndicator}
+ * that nests the adaptive stage inside the Debate step (t/2238); with the flag off
+ * the original {@link SessionPhaseStepper} + {@link PhaseProgressBar} render exactly
+ * as before.
+ */
+export function DebatePhaseIndicators({ activeDebate, isDebatePhase }: {
+  activeDebate: { phase: string; transcript: { type: string }[] };
+  isDebatePhase: boolean;
+}) {
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
+  const staging = (activeDebate as any).adaptive_staging as AdaptiveStaging | undefined;
+
+  // Session stepper is visible once the debate has started; the adaptive stage only
+  // during an active debate phase with staging enabled (t/1027 hide-when-closed rules).
+  const showSessionPhase = activeDebate.phase !== 'setup' && activeDebate.phase !== 'closed';
+  const showAdaptivePhase = isDebatePhase && activeDebate.phase !== 'closed' && !!staging?.enabled;
+  const roundCount = activeDebate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length;
+  const adaptive = showAdaptivePhase && staging ? {
+    currentPhase: staging.current_phase || 'confrontation',
+    phaseProgress: staging.phase_progress || 0,
+    roundsInPhase: staging.rounds_in_phase || 0,
+    approachingTransition: staging.approaching_transition || false,
+    rationale: staging.rationale,
+  } : undefined;
+
+  if (chatRedesign) {
+    if (!showSessionPhase) return null;
+    return <UnifiedPhaseIndicator phase={activeDebate.phase} roundCount={roundCount} adaptive={adaptive} />;
+  }
+
+  return (
+    <>
+      {showSessionPhase && (
+        <SessionPhaseStepper phase={activeDebate.phase} roundCount={roundCount} />
+      )}
+      {adaptive && (
+        <PhaseProgressBar
+          currentPhase={adaptive.currentPhase}
+          phaseProgress={adaptive.phaseProgress}
+          roundsInPhase={adaptive.roundsInPhase}
+          approachingTransition={adaptive.approachingTransition}
+          rationale={adaptive.rationale}
+        />
+      )}
+    </>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
@@ -180,9 +180,17 @@ vi.mock('./StatementCard', () => ({
 vi.mock('./DebateActionBar', () => ({
   PhaseProgressBar: () => <div data-testid="phase-progress" />,
   SessionPhaseStepper: () => <div data-testid="session-stepper" />,
+  UnifiedPhaseIndicator: ({ adaptive }: any) => (
+    <div data-testid="unified-phase-indicator" data-has-adaptive={adaptive ? 'yes' : 'no'} />
+  ),
   ProgressIndicator: () => <div data-testid="progress-indicator" />,
   DebaterToggles: () => <div data-testid="debater-toggles" />,
   DebateActions: () => <div data-testid="debate-actions" />,
+}));
+// Controllable feature-flag mock (default: all flags off — preserves existing flag-off tests).
+const mockFlags: Record<string, boolean> = {};
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFlag: (name: string) => mockFlags[name] ?? false,
 }));
 vi.mock('./ClarificationPanel', () => ({
   ClarificationActions: () => <div data-testid="clarification-actions" />,
@@ -451,6 +459,46 @@ describe('phase routing', () => {
     });
     render(<DebateWorkspace />);
     expect(screen.getByTestId('phase-progress')).toBeInTheDocument();
+  });
+
+  describe('DEBATE_CHAT_REDESIGN on — unified phase indicator (t/2238)', () => {
+    beforeEach(() => { mockFlags.DEBATE_CHAT_REDESIGN = true; });
+    afterEach(() => { delete mockFlags.DEBATE_CHAT_REDESIGN; });
+
+    it('replaces the stacked stepper + progress bar with a single unified indicator', () => {
+      mockStore.activeDebate = makeDebate({
+        phase: 'debate',
+        adaptive_staging: { enabled: true, current_phase: 'confrontation', phase_progress: 0.5, rounds_in_phase: 3, approaching_transition: false },
+      });
+      render(<DebateWorkspace />);
+      expect(screen.getByTestId('unified-phase-indicator')).toBeInTheDocument();
+      expect(screen.queryByTestId('session-stepper')).toBeNull();
+      expect(screen.queryByTestId('phase-progress')).toBeNull();
+    });
+
+    it('nests adaptive staging into the unified indicator during the debate phase', () => {
+      mockStore.activeDebate = makeDebate({
+        phase: 'debate',
+        adaptive_staging: { enabled: true, current_phase: 'argumentation', phase_progress: 0.6, rounds_in_phase: 2, approaching_transition: true },
+      });
+      render(<DebateWorkspace />);
+      expect(screen.getByTestId('unified-phase-indicator')).toHaveAttribute('data-has-adaptive', 'yes');
+    });
+
+    it('omits the adaptive sub-track when staging is disabled', () => {
+      mockStore.activeDebate = makeDebate({ phase: 'debate' });
+      render(<DebateWorkspace />);
+      expect(screen.getByTestId('unified-phase-indicator')).toHaveAttribute('data-has-adaptive', 'no');
+    });
+
+    it('hides the unified indicator when the debate is closed (t/1027 parity)', () => {
+      mockStore.activeDebate = makeDebate({
+        phase: 'closed',
+        adaptive_staging: { enabled: true, current_phase: 'concluding', phase_progress: 1, rounds_in_phase: 4, approaching_transition: false },
+      });
+      render(<DebateWorkspace />);
+      expect(screen.queryByTestId('unified-phase-indicator')).toBeNull();
+    });
   });
 
   it('renders ClaimsEditor in edit-claims phase', () => {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -34,7 +34,8 @@ import { useUserProfile } from '../../hooks/useAuthStatus';
 import { CommunityShareBanner } from '../shared/CommunityShareBanner';
 import { CoverageBadge } from './TaxonomyRefs';
 import { StatementCard, ProbingCard, FactCheckCard, EntryDeleteControls, HighlightedText, PhaseHairline } from './StatementCard';
-import { PhaseProgressBar, SessionPhaseStepper, DebaterToggles, DebateActions } from './DebateActionBar';
+import { DebaterToggles, DebateActions } from './DebateActionBar';
+import { DebatePhaseIndicators } from './DebatePhaseIndicators';
 import { StatementProgressIndicator } from './StatementProgressIndicator';
 import { ClarificationActions, ClaimsEditor, RefinedTopicEditor, TopicScoreComparison } from './ClarificationPanel';
 import { OpeningActions } from './OpeningPanel';
@@ -637,34 +638,7 @@ function DebatePhaseHeader({ activeDebate, isDebatePhase, isOpeningPhase }: {
 }) {
   return (
     <>
-      {/* Session phase stepper — always visible once debate has started */}
-      {activeDebate.phase !== 'setup' && activeDebate.phase !== 'closed' && (
-        <SessionPhaseStepper
-          phase={activeDebate.phase}
-          roundCount={activeDebate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length}
-        />
-      )}
-
-      {/* Adaptive phase progress bar — shown during debate phase when adaptive staging is enabled */}
-      {isDebatePhase && activeDebate.phase !== 'closed' && (activeDebate as any).adaptive_staging?.enabled && (() => {
-        const staging = (activeDebate as any).adaptive_staging as {
-          enabled: boolean;
-          current_phase: AdaptivePhase;
-          phase_progress: number;
-          rounds_in_phase: number;
-          approaching_transition: boolean;
-          rationale?: string;
-        };
-        return (
-          <PhaseProgressBar
-            currentPhase={staging.current_phase || 'confrontation'}
-            phaseProgress={staging.phase_progress || 0}
-            roundsInPhase={staging.rounds_in_phase || 0}
-            approachingTransition={staging.approaching_transition || false}
-            rationale={staging.rationale}
-          />
-        );
-      })()}
+      <DebatePhaseIndicators activeDebate={activeDebate} isDebatePhase={isDebatePhase} />
 
       {/* Debater toggle pills */}
       {(isDebatePhase || isOpeningPhase) && (


### PR DESCRIPTION
Closes t/2238 (child of t/2234, design critique §1 BLOCKER).

## What

`DebatePhaseHeader` stacked two unreconciled phase indicators — the session stepper (Refine → Opening → Debate → Complete) and the adaptive-staging bar (Confrontation → Argumentation → Concluding) — on two different scales with no stated relationship.

Behind `DEBATE_CHAT_REDESIGN`, `UnifiedPhaseIndicator` renders the session stepper with the adaptive stage nested under the active **Debate** step as an indented sub-track with a connector rule, so the sub-phase visibly belongs to that step. This is fix direction (a) from the ticket — nest, not replace.

## Flag-off path is untouched

`SessionPhaseStepper` and `PhaseProgressBar` are unmodified and still exported (AC #3). With the flag off the rendered output is identical to `main`; existing tests covering that path pass unchanged.

## Notes

- The flag branch lives in a new `DebatePhaseIndicators.tsx` — inlining it in `DebateWorkspace.tsx` pushed that file past the 1500-line eslint `max-lines` cap (it was at 1483).
- New co-located `DebateActionBar.css` (styles.css stays frozen); defined tokens only (`--border-color` / `--focus-ring` / `--success` / `--text-*`).
- Parity kept flag-on: round count, per-segment fill + phase colors, `approaching_transition` hint, truncated rationale, and the t/1027 hide-when-closed rules.

## Verification

- 247/247 scoped vitest pass, incl. 4 new flag-on cases (unified replaces both bars; adaptive nests; sub-track omitted when staging off; hidden when closed)
- `tsc` main + server clean · eslint `--max-warnings=4256` 0 errors · depcruise 0 violations · `vite build` clean
- `check-renderer-tsc.sh` fails on `@types/mdast` in any fresh worktree — pre-existing, tracked as t/2248, not run in CI

Visual sign-off of the flag-on widget is not included (flag ships off by default); happy to add electron-mcp screenshots if wanted before the flag flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)