### PR TITLE
revert: t/2250 bandColor consumer — broke origin/main (missing lib/bandColor)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
@@ -25,14 +25,7 @@ import { api } from '@bridge';
 import { triggerSituationNodeRegeneration } from '../../utils/regeneratePlainDescription';
 import { useDescriptionMode, DescriptionToggle, type DescriptionMode } from '../shared/DescriptionToggle';
 import { StakeholderSection } from '../organizations/StakeholderSection';
-import { bandColor, type BandEntry } from '../../lib/bandColor';
 import './SituationDetail.css';
-
-const DIVERGENCE_SCORE_BANDS: readonly BandEntry[] = [
-  { threshold: 0.40, color: '#22c55e' },
-  { threshold: 0.20, color: '#f59e0b' },
-  { threshold: 0,    color: '#ef4444' },
-];
 
 interface SituationDetailProps {
   node: SituationNode;
@@ -45,10 +38,6 @@ interface SituationDetailProps {
 
 type SitTab = 'overview' | 'attributes' | 'accelerationist' | 'safetyist' | 'skeptic' | 'debate' | 'sources' | 'research';
 type SitPov = 'accelerationist' | 'safetyist' | 'skeptic';
-
-function isPovTab(tab: SitTab): boolean {
-  return tab === 'accelerationist' || tab === 'safetyist' || tab === 'skeptic';
-}
 
 type ErrFn = (field: string) => string | undefined;
 type UpdateFn = (updates: Partial<SituationNode>) => void;
@@ -300,7 +289,7 @@ function SitOverviewTab({
 
       {node.interpretation_divergence != null && (() => {
         const div = node.interpretation_divergence;
-        const color = bandColor(div, DIVERGENCE_SCORE_BANDS);
+        const color = div > 0.40 ? '#22c55e' : div >= 0.20 ? '#f59e0b' : '#ef4444';
         const label = div > 0.40 ? 'High divergence' : div >= 0.20 ? 'Moderate divergence' : 'Low divergence';
         return (
           <div className="form-group">
@@ -766,7 +755,7 @@ export function SituationDetail({ node, readOnly, onPin, onRelated, onDebate, ch
           <SituationDebatePanel node={node} onLaunched={() => {}} />
         )}
 
-        {isPovTab(activeTab) && (
+        {(activeTab === 'accelerationist' || activeTab === 'safetyist' || activeTab === 'skeptic') && (
           <SitPovTab
             node={node}
             activeTab={activeTab}


### PR DESCRIPTION
**Emergency revert (broken-main incident).** Commit 2a226754 (t/2250, PR #556) imports `../../lib/bandColor` in SituationDetail.tsx, but `lib/bandColor.ts` (t/2236's deliverable) is not on origin/main — t/2236's PR was never opened. Every build against origin/main fails on the unresolved import.

Reverts the premature consumer to restore green. Re-land order: t/2236 (bandColor utility) FIRST, then t/2250 re-lands against it. Coordinated by TL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)