### PR TITLE
feat(chat): extract shared MessageBubble, ThinkingIndicator, StreamingBubble (t/2246)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -330,6 +333,9 @@ importers:
       typescript-eslint:
         specifier: ^8.65.0
         version: 8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)

--- a/taxonomy-editor/package.json
+++ b/taxonomy-editor/package.json
@@ -78,6 +78,8 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/qrcode": "^1.5.6",
+    "@types/mdast": "^4.0.4",
+    "unified": "^11.0.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.5",

--- a/taxonomy-editor/pnpm-lock.yaml
+++ b/taxonomy-editor/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
@@ -159,6 +162,9 @@ importers:
       typescript-eslint:
         specifier: ^8.65.0
         version: 8.65.0(eslint@10.8.0(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@24.12.0)(jiti@2.6.1)(terser@5.48.0)

--- a/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.tsx
@@ -27,6 +27,7 @@ import { useTierInfo, isFreeTier } from '../../hooks/useTierInfo';
 import { GeminiOnboardingModal } from '../settings/GeminiOnboardingModal';
 import { CampGlyph, povToCamp } from '../shared/CampGlyph';
 import { EmptyState } from '../shared/EmptyState';
+import { ThinkingIndicator, MessageBubble } from '../shared/ChatBubble';
 import './ChatWorkspace.css';
 
 // ── Helpers ──────────────────────────────────────────────
@@ -174,9 +175,9 @@ function ChatMessage({ entry, selectedRef, onSelectRef }: { entry: ChatEntry; se
             {speakerLabel(entry.speaker)}
           </span>
         </div>
-        <div className="chat-message-content markdown-body prose">
+        <MessageBubble role={isUser ? 'user' : 'assistant'} className="chat-message-content markdown-body prose">
           <Markdown remarkPlugins={[remarkGfm, remarkColorizePov, remarkLinkifyRefs]} components={mdComponents}>{entry.content}</Markdown>
-        </div>
+        </MessageBubble>
         <TaxonomyRefsSection refs={entry.taxonomy_refs} selectedRef={selectedRef} onSelectRef={onSelectRef} />
       </div>
     </div>
@@ -191,7 +192,7 @@ function ProgressIndicator() {
   if (!chatActivity) return null;
 
   return (
-    <div className="chat-generating">
+    <ThinkingIndicator className="chat-generating">
       <span className="chat-generating-dots">
         <span>{chatActivity}</span>
         <span className="dot-animation" />
@@ -202,7 +203,7 @@ function ProgressIndicator() {
           {chatProgress.backoffSeconds ? ` (${chatProgress.backoffSeconds}s)` : ''}
         </span>
       )}
-    </div>
+    </ThinkingIndicator>
   );
 }
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import './DiagnosticsChatSidebar.css';
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { MessageBubble, ThinkingIndicator, StreamingBubble } from '../../shared/ChatBubble';
 import type { DebateSession } from '../../../types/debate';
 import { POVER_INFO } from '../../../types/debate';
 import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
@@ -668,80 +668,15 @@ function ChatEmptyState({ isWeb }: { isWeb: boolean }) {
   );
 }
 
-function MessageBubble({ msg, onNavigate }: { msg: ChatMessage; onNavigate: (cmd: NavigateCommand) => void }) {
-  if (msg.isError) {
-    return (
-      <div className="dchat-error-bubble">
-        <div className="dchat-error-label">
-          <span aria-hidden="true">⚠</span>
-          <span>Error</span>
-        </div>
-        <div style={{ whiteSpace: 'pre-wrap' }}>{msg.content.replace(/^Error:\s*/i, '')}</div>
-      </div>
-    );
-  }
+function NavFooter({ navigation, onNavigate }: { navigation: NavigateCommand; onNavigate: (cmd: NavigateCommand) => void }) {
   return (
-    <div
-      style={{
-        alignSelf: msg.role === 'user' ? 'flex-end' : 'flex-start',
-        maxWidth: '90%',
-        padding: '6px 10px',
-        borderRadius: 8,
-        fontSize: '0.75rem',
-        lineHeight: 1.4,
-        background: msg.role === 'user' ? 'color-mix(in srgb, var(--warning) 15%, transparent)' : 'var(--bg-tertiary, rgba(255,255,255,0.05))',
-        color: 'var(--text-primary, var(--border-color))',
-        border: msg.role === 'user' ? '1px solid color-mix(in srgb, var(--warning) 30%, transparent)' : '1px solid var(--border)',
-        userSelect: 'text',
-        cursor: 'text',
-      }}
+    <div style={{
+      marginTop: 4, paddingTop: 4, borderTop: '1px solid var(--border)',
+      fontSize: 'var(--text-2xs)', color: 'var(--warning)', cursor: 'pointer',
+    }}
+      onClick={() => onNavigate(navigation)}
     >
-      {msg.role === 'assistant' ? (
-        <div className="diag-chat-markdown">
-          <Markdown remarkPlugins={[remarkGfm, remarkColorizePov]}>{msg.content}</Markdown>
-        </div>
-      ) : (
-        <div style={{ whiteSpace: 'pre-wrap' }}>{msg.content}</div>
-      )}
-      {msg.navigation && (
-        <div style={{
-          marginTop: 4, paddingTop: 4, borderTop: '1px solid var(--border)',
-          fontSize: 'var(--text-2xs)', color: 'var(--warning)', cursor: 'pointer',
-        }}
-          onClick={() => msg.navigation && onNavigate(msg.navigation)}
-        >
-          Navigated to {msg.navigation.entry ?? 'overview'}{msg.navigation.tab ? ` → ${msg.navigation.tab}` : ''}{msg.navigation.overviewTab ? ` → ${msg.navigation.overviewTab}` : ''}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function StreamingBubble({ streamingText }: { streamingText: string }) {
-  return (
-    <div style={{
-      alignSelf: 'flex-start', maxWidth: '90%',
-      padding: '6px 10px', borderRadius: 8,
-      fontSize: '0.75rem', lineHeight: 1.4,
-      background: 'var(--bg-tertiary, rgba(255,255,255,0.05))',
-      color: 'var(--text-primary, var(--border-color))',
-      border: '1px solid var(--border)',
-      userSelect: 'text', cursor: 'text',
-    }}>
-      <div className="diag-chat-markdown">
-        <Markdown remarkPlugins={[remarkGfm, remarkColorizePov]}>{streamingText}</Markdown>
-      </div>
-    </div>
-  );
-}
-
-function ThinkingIndicator({ activity }: { activity: string | null }) {
-  return (
-    <div style={{
-      alignSelf: 'flex-start', padding: '6px 10px', borderRadius: 8,
-      fontSize: '0.7rem', color: 'var(--text-muted)', fontStyle: 'italic',
-    }}>
-      {activity || 'Thinking...'}
+      Navigated to {navigation.entry ?? 'overview'}{navigation.tab ? ` → ${navigation.tab}` : ''}{navigation.overviewTab ? ` → ${navigation.overviewTab}` : ''}
     </div>
   );
 }
@@ -793,11 +728,27 @@ function ChatScrollArea({
       {messages.length === 0 && !generating && (
         <ChatEmptyState isWeb={isWeb} />
       )}
-      {messages.filter(m => m.role !== 'system').map(msg => (
-        <MessageBubble key={msg.id} msg={msg} onNavigate={onNavigate} />
-      ))}
+      {messages.filter(m => m.role !== 'system').map(msg => {
+        const displayContent = msg.isError ? msg.content.replace(/^Error:\s*/i, '') : msg.content;
+        return (
+          <MessageBubble
+            key={msg.id}
+            role={msg.role as 'user' | 'assistant'}
+            isError={msg.isError}
+            footer={msg.navigation ? <NavFooter navigation={msg.navigation} onNavigate={onNavigate} /> : undefined}
+          >
+            {msg.isError || msg.role !== 'assistant' ? (
+              <div style={{ whiteSpace: 'pre-wrap' }}>{displayContent}</div>
+            ) : (
+              <div className="diag-chat-markdown">
+                <Markdown remarkPlugins={[remarkGfm, remarkColorizePov]}>{displayContent}</Markdown>
+              </div>
+            )}
+          </MessageBubble>
+        );
+      })}
       {generating && streamingText && (
-        <StreamingBubble streamingText={streamingText} />
+        <StreamingBubble content={streamingText} mdClassName="diag-chat-markdown" />
       )}
       {generating && !streamingText && (
         <ThinkingIndicator activity={activity} />

--- a/taxonomy-editor/src/renderer/components/shared/ChatBubble.css
+++ b/taxonomy-editor/src/renderer/components/shared/ChatBubble.css
@@ -1,6 +1,6 @@
-/* DiagnosticsChatSidebar — co-located styles (prefix: dchat-) */
+/* Shared chat bubble styles (prefix: chat-bubble-) */
 
-.dchat-error-bubble {
+.chat-bubble-error {
   align-self: flex-start;
   max-width: 90%;
   padding: 6px 10px;
@@ -14,7 +14,7 @@
   cursor: text;
 }
 
-.dchat-error-label {
+.chat-bubble-error-label {
   display: flex;
   align-items: center;
   gap: 4px;

--- a/taxonomy-editor/src/renderer/components/shared/ChatBubble.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/ChatBubble.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import './ChatBubble.css';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { remarkColorizePov } from '../../utils/colorizePovPlugin';
+
+/** Canonical remark plugin set shared across all chat surfaces. */
+export const CHAT_REMARK_PLUGINS = [remarkGfm, remarkColorizePov];
+
+/**
+ * Shared bubble container for a completed chat turn.
+ *
+ * - When `className` is provided, inline bubble styles are suppressed so the
+ *   caller's CSS classes own the layout (e.g. ChatWorkspace's CSS-class surface).
+ * - When `isError` is true, renders the error-bubble variant regardless of other props.
+ * - `footer` is rendered below children (e.g. a navigation action link).
+ */
+export function MessageBubble({ role, children, footer, isError, className, style }: {
+  role: 'user' | 'assistant';
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+  isError?: boolean;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  if (isError) {
+    return (
+      <div className="chat-bubble-error">
+        <div className="chat-bubble-error-label">
+          <span aria-hidden="true">⚠</span>
+          <span>Error</span>
+        </div>
+        {children}
+      </div>
+    );
+  }
+
+  const defaultStyle: React.CSSProperties = className ? {} : {
+    alignSelf: role === 'user' ? 'flex-end' : 'flex-start',
+    maxWidth: '90%',
+    padding: '6px 10px',
+    borderRadius: 8,
+    fontSize: '0.75rem',
+    lineHeight: 1.4,
+    background: role === 'user'
+      ? 'color-mix(in srgb, var(--warning) 15%, transparent)'
+      : 'var(--bg-tertiary, rgba(255,255,255,0.05))',
+    color: 'var(--text-primary, var(--border-color))',
+    border: role === 'user'
+      ? '1px solid color-mix(in srgb, var(--warning) 30%, transparent)'
+      : '1px solid var(--border)',
+    userSelect: 'text',
+    cursor: 'text',
+  };
+
+  return (
+    <div className={className} style={{ ...defaultStyle, ...style }}>
+      {children}
+      {footer}
+    </div>
+  );
+}
+
+/**
+ * Thinking-phase indicator: shown when the AI is processing but has not yet
+ * emitted any streaming content.
+ *
+ * - With no `children`: renders `activity || 'Thinking...'` with inline styles.
+ * - With `children`: renders them instead (callers supply their own DOM structure,
+ *   e.g. `.chat-generating-dots` with animation spans).
+ * - When `className` is provided, inline styles are suppressed.
+ */
+export function ThinkingIndicator({ activity, className, style, children }: {
+  activity?: string | null;
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+}) {
+  const defaultStyle: React.CSSProperties = className ? {} : {
+    alignSelf: 'flex-start',
+    padding: '6px 10px',
+    borderRadius: 8,
+    fontSize: '0.7rem',
+    color: 'var(--text-muted)',
+    fontStyle: 'italic',
+  };
+
+  return (
+    <div className={className} style={{ ...defaultStyle, ...style }}>
+      {children ?? (activity || 'Thinking...')}
+    </div>
+  );
+}
+
+/**
+ * Streaming bubble: shown while the AI is actively streaming output.
+ * Renders Markdown using the canonical plugin set.
+ * When `className` is provided, inline bubble styles are suppressed.
+ */
+export function StreamingBubble({ content, mdClassName, className, style }: {
+  content: string;
+  mdClassName?: string;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const defaultStyle: React.CSSProperties = className ? {} : {
+    alignSelf: 'flex-start',
+    maxWidth: '90%',
+    padding: '6px 10px',
+    borderRadius: 8,
+    fontSize: '0.75rem',
+    lineHeight: 1.4,
+    background: 'var(--bg-tertiary, rgba(255,255,255,0.05))',
+    color: 'var(--text-primary, var(--border-color))',
+    border: '1px solid var(--border)',
+    userSelect: 'text',
+    cursor: 'text',
+  };
+
+  return (
+    <div className={className} style={{ ...defaultStyle, ...style }}>
+      <div className={mdClassName}>
+        <Markdown remarkPlugins={CHAT_REMARK_PLUGINS}>{content}</Markdown>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `shared/ChatBubble.tsx` with three shared components: `MessageBubble`, `ThinkingIndicator`, `StreamingBubble`
- `DiagnosticsChatSidebar` adopts shared components; its local duplicates removed and `DiagnosticsChatSidebar.css` deleted (styles moved to `shared/ChatBubble.css` with `chat-bubble-*` prefix)
- `ChatWorkspace` `ProgressIndicator` uses `ThinkingIndicator`; `ChatMessage` content area uses `MessageBubble`
- Adds `@types/mdast` and `unified` as explicit `devDependencies` to fix pnpm hoisting gap in fresh worktrees (pre-existing issue masked by stale main-tree node_modules)

## Design
- `className` prop suppresses inline bubble styles so ChatWorkspace's CSS-class layout is unaffected
- `isError` variant on `MessageBubble` preserves DebateDiagnostics error-bubble rendering (approved by DebateDiagnostics p/367#2)
- `children ?? (activity || 'Thinking...')` dual-use pattern lets ChatWorkspace pass animated DOM via children while DiagnosticsChatSidebar uses the `activity` prop
- TL design approval: e/66#2

## Test plan
- [ ] `tsc -p tsconfig.main.json --noEmit` — clean
- [ ] `tsc -p tsconfig.server.json --noEmit` — clean
- [ ] `bash scripts/check-renderer-tsc.sh` — 0/0 errors
- [ ] `eslint src/ --max-warnings=4256` — 0 errors
- [ ] `npm run depcruise` — no violations
- [ ] CI green (vitest failures in githubApi.test.ts are pre-existing undici/Node-24 version skew, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
