### PR TITLE
refactor(debate-workspace): route in-scope score-color sites through bandColor (t/2236)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/ClaimsView.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/ClaimsView.tsx
@@ -6,15 +6,12 @@ import type { ArgumentNetworkNode, ArgumentNetworkEdge, TranscriptEntry } from '
 import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
 import { speakerLabel, STRENGTH_BAND, getNodeLabel } from './utils';
+import { bandColor as computeBandColor, CONFIDENCE_BANDS } from '../../lib/bandColor';
 import './ClaimsView.css';
 
 const ATTACK_TYPE_WEIGHTS: Record<string, number> = { rebut: 1.0, undercut: 1.05, undermine: 1.1 };
 
 type ClaimAttribution = NonNullable<ArgumentNetworkNode['claim_taxonomy_attribution']>;
-
-function bandColorFor(computed: number): string {
-  return computed >= 0.8 ? '#22c55e' : computed >= 0.5 ? '#3b82f6' : computed >= 0.3 ? '#f59e0b' : '#ef4444';
-}
 
 function bdiLabelFor(node: ArgumentNetworkNode): string {
   return node.bdi_category === 'belief' ? 'Belief' : node.bdi_category === 'desire' ? 'Desire' : node.bdi_category === 'intention' ? 'Intention' : '';
@@ -55,7 +52,11 @@ function UnattributedBadge({ reason }: { reason: string }) {
 
 function AttributedBadge({ attr }: { attr: ClaimAttribution }) {
   const conf = attr.attribution_confidence;
-  const confColor = conf >= 0.7 ? '#22c55e' : conf >= 0.5 ? '#3b82f6' : '#f59e0b';
+  const confColor = computeBandColor(conf, [
+    { threshold: 0.7, color: '#22c55e' },
+    { threshold: 0.5, color: '#3b82f6' },
+    { threshold: 0,   color: '#f59e0b' },
+  ]);
   const secCount = attr.secondary_refs?.length ?? 0;
   const attrTip = `Attributed to ${attr.primary_ref} (confidence: ${conf.toFixed(2)})\n${getNodeLabel(attr.primary_ref)}${secCount > 0 ? `\n\n${secCount} secondary ref${secCount !== 1 ? 's' : ''}: ${attr.secondary_refs!.map((s: { node_id: string; similarity: number }) => `${s.node_id} (${s.similarity.toFixed(2)})`).join(', ')}` : ''}`;
   return (
@@ -186,7 +187,7 @@ export function ClaimNodeRow({ node, attacks, supports, allNodes, strengthMap, s
   const computed = strengthMap.get(node.id) ?? node.computed_strength ?? base;
   const delta = computed - base;
   const band = STRENGTH_BAND(computed);
-  const bandColor = bandColorFor(computed);
+  const bandColor = computeBandColor(computed, CONFIDENCE_BANDS);
   const bdiLabel = bdiLabelFor(node);
 
   return (

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
@@ -17,6 +17,7 @@ import { useTierInfo } from '../../hooks/useTierInfo';
 import { isElectronMode } from '@bridge';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { triggerManualDump } from '../../lib/flightRecorderInit';
+import { bandColor, BUDGET_BANDS } from '../../lib/bandColor';
 
 export function ProgressIndicator() {
   const { debateActivity, debateProgress } = useDebateStore(
@@ -41,9 +42,6 @@ export function ProgressIndicator() {
   );
 }
 
-const BUDGET_WARN_THRESHOLD = 0.8;
-const BUDGET_URGENT_THRESHOLD = 0.95;
-
 function formatResetTime(resetsAt: string): string {
   const ms = new Date(resetsAt).getTime() - Date.now();
   if (ms <= 0) return 'resets soon';
@@ -63,10 +61,11 @@ export function TokenBudgetIndicator() {
   if (pct < 0.01) return null;
   const remaining = Math.max(0, tokensPerDay - tokensToday);
   const remainingK = remaining >= 1000 ? `${Math.round(remaining / 1000)}k` : String(remaining);
-  const isUrgent = pct >= BUDGET_URGENT_THRESHOLD;
-  const isWarning = pct >= BUDGET_WARN_THRESHOLD;
+  const level = bandColor(pct, BUDGET_BANDS);
+  const isUrgent = level === 'urgent';
+  const isWarning = level === 'warning';
   const resetLabel = resetsAt ? formatResetTime(resetsAt) : '';
-  const levelClass = isUrgent ? ' urgent' : isWarning ? ' warning' : '';
+  const levelClass = level ? ` ${level}` : '';
   return (
     <div className={`token-budget-indicator${levelClass}`}>
       {isUrgent ? (

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -17,6 +17,8 @@ import {
   fixMarkdownLinks, stripLeadingHeadings,
   META_TIERS, TIER_LABELS,
 } from './utils';
+import { bandColor as computeBandColor } from '../../lib/bandColor';
+import type { BandEntry } from '../../lib/bandColor';
 import type { AnchorHTMLAttributes, HTMLAttributes } from 'react';
 import { parseEntityRef } from '@lib/entities/types';
 import type { FactVerdict, FactDiscrepancy } from '@lib/debate/types';
@@ -105,12 +107,12 @@ function ConvBadge({ text, color }: { text: string; color: string }) {
   return <span className="convergence-badge" style={{ color }}>{text}</span>;
 }
 
-function bandBadge(value: number, bands: [number, string, string][]): ReactNode {
-  for (const [threshold, label, color] of bands) {
-    if (value >= threshold) return <ConvBadge text={label} color={color} />;
-  }
-  const fallback = bands[bands.length - 1];
-  return <ConvBadge text={fallback[1]} color={fallback[2]} />;
+type LabeledBand = BandEntry & { label: string };
+
+function bandBadge(value: number, bands: readonly LabeledBand[]): ReactNode {
+  const color = computeBandColor(value, bands);
+  const label = (bands.find(b => value >= b.threshold) ?? bands.at(-1))!.label;
+  return <ConvBadge text={label} color={color} />;
 }
 
 function ConvCell({ label, span, children }: { label: string; span?: boolean; children: ReactNode }) {
@@ -135,7 +137,7 @@ function PolarityCell({ md }: { md: ConvergenceSignals['move_polarity'] }) {
       <span style={{ color: '#ef4444' }}>{md?.confrontational ?? 0}C</span>{' / '}
       <span style={{ color: '#22c55e' }}>{md?.collaborative ?? 0}S</span>
       {' = '}<strong>{pctFmt(md?.ratio ?? 0)}</strong>
-      {bandBadge(md?.ratio ?? 0, [[0.5, 'cooperative', '#22c55e'], [0, 'confrontational', '#ef4444']])}
+      {bandBadge(md?.ratio ?? 0, [{ threshold: 0.5, label: 'cooperative', color: '#22c55e' }, { threshold: 0, label: 'confrontational', color: '#ef4444' }])}
     </ConvCell>
   );
 }
@@ -146,7 +148,7 @@ function EngagementCell({ ed }: { ed: ConvergenceSignals['dialectical_engagement
   return (
     <ConvCell label="Dialectical Engagement">
       {edTargeted}/{edTotal} targeted = <strong>{pctFmt(ed?.ratio ?? 0)}</strong>
-      {bandBadge(ed?.ratio ?? 0, [[0.7, 'deep', '#22c55e'], [0.4, 'moderate', '#f59e0b'], [0, 'standalone', '#ef4444']])}
+      {bandBadge(ed?.ratio ?? 0, [{ threshold: 0.7, label: 'deep', color: '#22c55e' }, { threshold: 0.4, label: 'moderate', color: '#f59e0b' }, { threshold: 0, label: 'standalone', color: '#ef4444' }])}
     </ConvCell>
   );
 }
@@ -158,7 +160,7 @@ function RedundancyCell({ rr }: { rr: ConvergenceSignals['argument_redundancy'] 
       avg <strong>{pctFmt(rr?.avg_self_overlap ?? 0)}</strong>, max <strong>{pctFmt(rrMaxOverlap)}</strong>
       {rr?.semantic_max_similarity != null && <>, sem <strong>{pctFmt(rr.semantic_max_similarity)}</strong></>}
       {rr?.semantically_recycled ? <ConvBadge text="semantic repeat" color="#ef4444" />
-        : bandBadge(rrMaxOverlap, [[0.5, 'repeating', '#f59e0b'], [0, 'fresh', '#22c55e']])}
+        : bandBadge(rrMaxOverlap, [{ threshold: 0.5, label: 'repeating', color: '#f59e0b' }, { threshold: 0, label: 'fresh', color: '#22c55e' }])}
     </ConvCell>
   );
 }
@@ -168,7 +170,7 @@ function CounterargCell({ so }: { so: ConvergenceSignals['dominant_counterargume
     <ConvCell label="Dominant Counterargument">
       {so ? (
         <>{so.node_id} str={so.strength?.toFixed(2)}
-          {bandBadge(so.strength ?? 0, [[0.7, 'strong', '#ef4444'], [0.5, 'moderate', '#f59e0b'], [0, 'weak', '#22c55e']])}
+          {bandBadge(so.strength ?? 0, [{ threshold: 0.7, label: 'strong', color: '#ef4444' }, { threshold: 0.5, label: 'moderate', color: '#f59e0b' }, { threshold: 0, label: 'weak', color: '#22c55e' }])}
         </>
       ) : <span style={{ color: 'var(--text-muted)' }}>none</span>}
     </ConvCell>
@@ -192,7 +194,7 @@ function DriftCell({ pd }: { pd: ConvergenceSignals['position_drift'] }) {
   return (
     <ConvCell label="Position Drift">
       opening: <strong>{pctFmt(pdOverlap)}</strong>, drift: <strong>{pctFmt(pd?.drift ?? 0)}</strong>
-      {bandBadge(pdOverlap, [[0.6, 'anchored', '#f59e0b'], [0.3, 'evolved', '#22c55e'], [0, 'shifted', '#3b82f6']])}
+      {bandBadge(pdOverlap, [{ threshold: 0.6, label: 'anchored', color: '#f59e0b' }, { threshold: 0.3, label: 'evolved', color: '#22c55e' }, { threshold: 0, label: 'shifted', color: '#3b82f6' }])}
     </ConvCell>
   );
 }


### PR DESCRIPTION
## Summary

Completes the **in-scope** portion of t/2236: routes 3 DebateWorkspace score-to-color sites through the shared `bandColor()` util (which already landed on main as `6d8521e7`).

- `ClaimsView` — `bandColorFor` → `CONFIDENCE_BANDS`; `AttributedBadge` confidence → `bandColor` w/ inline bands
- `StatementCard` — `bandBadge` helper → `bandColor`
- `DebateActionBar` — `TokenBudgetIndicator` → `BUDGET_BANDS`

Visual output identical (thresholds unchanged). No new dependencies.

## Context
Re-cut clean off latest main after the combined PR #558 was closed (PM-approved, p/188#18). t/2238 lands separately via #560. The 3 out-of-scope call-sites (`ScoreBadge`, `CommitmentsPanel`, `SituationDetail`) are tracked in t/2249 (DebateDiagnostics) and t/2250 (DebateUI).

## Verification
These 3 file changes were verified together earlier (tsc `-p tsconfig.main.json` clean; 247 scoped vitest pass; eslint 0 errors); content is byte-identical here. CI re-verifies.

Closes t/2236 (in-scope portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
