### PR TITLE
feat(debate-workspace): per-turn collapse toggle on StatementCard (t/2241)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.collapse.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.collapse.test.tsx
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2241 — per-turn collapse toggle, gated on DEBATE_CHAT_REDESIGN. The tier
+// system re-summarizes content but never hides it, so skimming past turns
+// already read required scrolling the full body. These tests pin both arms of
+// the flag: off = the card renders exactly as before (no chevron), on = a
+// keyboard-reachable chevron collapses the card to its identity row.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ────────────────────────────────────────────────────
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+vi.mock('remark-gfm', () => ({ default: {} }));
+
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: vi.fn() }),
+}));
+
+const debateState = {
+  activeDebate: { transcript: [], speaker_models: {} },
+  responseLength: 'detailed',
+  setEntryDisplayTier: vi.fn(),
+  askQuestion: vi.fn(),
+  debateGenerating: null,
+  diagnosticsEnabled: false,
+  toggleDiagnostics: vi.fn(),
+  selectDiagEntry: vi.fn(),
+  deleteTranscriptEntries: vi.fn(),
+};
+
+vi.mock('../../hooks/useDebateStore', () => ({
+  useDebateStore: Object.assign(
+    (selector: (s: typeof debateState) => unknown) => selector(debateState),
+    { getState: () => debateState },
+  ),
+}));
+
+vi.mock('zustand/react/shallow', () => ({ useShallow: (fn: unknown) => fn }));
+
+// Controllable flag mock — every flag defaults off, matching production.
+const mockFlags: Record<string, boolean> = {};
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFlag: (name: string) => mockFlags[name] ?? false,
+}));
+
+vi.mock('../../hooks/useCommentStore', () => ({
+  COMMENT_TYPE_META: {},
+  useCommentStore: (selector?: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      commentsFile: null,
+      filters: { types: new Set(), authors: new Set(), searchText: '', showResolved: true },
+      focusedCommentId: null,
+      focusComment: vi.fn(),
+      setSidebarOpen: vi.fn(),
+      toggleSidebar: vi.fn(),
+    };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../hooks/useTaxonomyStore', () => ({
+  useTaxonomyStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector({}),
+    { getState: () => ({ policyRegistry: null }) },
+  ),
+}));
+vi.mock('@bridge', () => ({
+  api: { focusNodeInMainWindow: vi.fn(), clipboardWriteText: vi.fn(), openExternal: vi.fn() },
+}));
+
+vi.mock('./ClaimsView', () => ({ ClaimsView: () => <div data-testid="claims-view" /> }));
+vi.mock('./VocabularyPanel', () => ({ LineageTermsView: () => null, VocabTermsView: () => null }));
+vi.mock('./TaxonomyRefs', () => ({ TaxonomyRefsSection: () => <div data-testid="taxonomy-refs" /> }));
+vi.mock('../../utils/lineageMatcher', () => ({ lineageMarkdownComponents: {}, extractLineageNames: () => [] }));
+vi.mock('../../utils/vocabularyAnnotations', () => ({ getDebateMarkdownComponents: () => ({}) }));
+
+import { StatementCard } from './StatementCard';
+import type { TranscriptEntry } from '@lib/debate/types';
+
+// ── Fixtures ─────────────────────────────────────────────────
+
+function makeEntry(over: Partial<TranscriptEntry> = {}): TranscriptEntry {
+  return {
+    id: 'e1',
+    timestamp: '2026-01-01T00:00:00Z',
+    type: 'statement',
+    speaker: 'accelerationist',
+    content: 'One two three four five.',
+    taxonomy_refs: [],
+    display_tier: 'detailed',
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete mockFlags.DEBATE_CHAT_REDESIGN;
+  // jsdom lacks matchMedia; StatementCard's tier-change effect reads it.
+  if (!window.matchMedia) {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }) as unknown as typeof window.matchMedia;
+  }
+});
+
+// ── Flag off ─────────────────────────────────────────────────
+
+describe('StatementCard collapse — flag off', () => {
+  it('renders no collapse control and leaves the body visible', () => {
+    const { container } = render(<StatementCard entry={makeEntry()} />);
+
+    expect(screen.queryByRole('button', { name: /collapse this turn/i })).toBeNull();
+    expect(container.querySelector('.debate-statement-body')).toBeTruthy();
+    expect(container.querySelector('.debate-statement-collapsed')).toBeNull();
+  });
+});
+
+// ── Flag on ──────────────────────────────────────────────────
+
+describe('StatementCard collapse — flag on (t/2241)', () => {
+  beforeEach(() => { mockFlags.DEBATE_CHAT_REDESIGN = true; });
+
+  it('renders an expanded card with a collapse control by default', () => {
+    const { container } = render(<StatementCard entry={makeEntry()} />);
+
+    const btn = screen.getByRole('button', { name: /collapse this turn/i });
+    expect(btn).toHaveAttribute('aria-expanded', 'true');
+    expect(container.querySelector('.debate-statement-body')).toBeTruthy();
+  });
+
+  it('collapses to the identity row on click, hiding the body', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<StatementCard entry={makeEntry()} />);
+
+    await user.click(screen.getByRole('button', { name: /collapse this turn/i }));
+
+    expect(container.querySelector('.debate-statement-body')).toBeNull();
+    expect(container.querySelector('.debate-statement-collapsed')).toBeTruthy();
+    // Speaker identity survives so a collapsed card is still scannable.
+    expect(container.querySelector('.debate-statement-speaker')?.textContent).toBe('Accelerationist');
+  });
+
+  it('shows a word count while collapsed so long turns stay distinguishable', async () => {
+    const user = userEvent.setup();
+    render(<StatementCard entry={makeEntry()} />);
+
+    await user.click(screen.getByRole('button', { name: /collapse this turn/i }));
+
+    expect(screen.getByText('collapsed · 5 words')).toBeInTheDocument();
+  });
+
+  it('expands again on a second activation', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<StatementCard entry={makeEntry()} />);
+
+    await user.click(screen.getByRole('button', { name: /collapse this turn/i }));
+    await user.click(screen.getByRole('button', { name: /expand this turn/i }));
+
+    expect(container.querySelector('.debate-statement-body')).toBeTruthy();
+    expect(container.querySelector('.debate-statement-collapsed')).toBeNull();
+  });
+
+  it('toggles from the keyboard (AC: Enter/Space on the chevron)', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<StatementCard entry={makeEntry()} />);
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: /collapse this turn/i })).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(container.querySelector('.debate-statement-body')).toBeNull();
+
+    await user.keyboard(' ');
+    expect(container.querySelector('.debate-statement-body')).toBeTruthy();
+  });
+
+  it('keeps collapse independent per card', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <>
+        <StatementCard entry={makeEntry({ id: 'e1' })} />
+        <StatementCard entry={makeEntry({ id: 'e2', speaker: 'skeptic' })} />
+      </>,
+    );
+
+    const [first] = screen.getAllByRole('button', { name: /collapse this turn/i });
+    await user.click(first);
+
+    const cards = container.querySelectorAll('.debate-statement');
+    expect(cards[0].classList.contains('debate-statement-collapsed')).toBe(true);
+    expect(cards[1].classList.contains('debate-statement-collapsed')).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -259,3 +259,47 @@
 .debate-fact-check-severity-major .debate-fact-check-discrepancy-dimension {
   background: rgba(239, 68, 68, 0.15);
 }
+
+/* ── Per-turn collapse (t/2241, DEBATE_CHAT_REDESIGN) ── */
+
+/*
+ * Chevron sits at the head of the identity row. A collapsed card keeps the same
+ * left-border accent so the speaker is still readable in a scan of the rail.
+ */
+.debate-statement-collapse-btn {
+  background: none;
+  border: none;
+  padding: 0 2px;
+  margin: 0;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+}
+
+.debate-statement-collapse-btn:hover {
+  color: var(--text-primary);
+}
+
+.debate-statement-collapse-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.debate-statement-collapsed {
+  padding-top: var(--sp-2);
+  padding-bottom: var(--sp-2);
+}
+
+.debate-statement-collapsed .debate-statement-header {
+  margin-bottom: 0;
+}
+
+.debate-statement-collapsed-summary {
+  font-size: var(--text-2xs);
+  color: var(--text-secondary);
+  font-style: italic;
+  white-space: nowrap;
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -633,11 +633,37 @@ function StatementDeleteActions({ entryIndex, totalEntries, deleteConfirm, setDe
   );
 }
 
+/**
+ * Collapse chevron (t/2241, DEBATE_CHAT_REDESIGN). Skimming past turns already
+ * read is otherwise impossible — the tier system re-summarizes content but never
+ * hides it. A native <button> keeps Enter/Space working without key handlers.
+ */
+function StatementCollapseToggle({ collapsed, onToggle, entryId }: {
+  collapsed: boolean;
+  onToggle: () => void;
+  entryId: string;
+}) {
+  return (
+    <button
+      type="button"
+      className="debate-statement-collapse-btn"
+      onClick={(e) => { e.stopPropagation(); onToggle(); }}
+      aria-expanded={!collapsed}
+      aria-controls={`debate-statement-body-${entryId}`}
+      aria-label={collapsed ? 'Expand this turn' : 'Collapse this turn'}
+      title={collapsed ? 'Expand this turn' : 'Collapse this turn'}
+    >
+      {collapsed ? '▸' : '▾'}
+    </button>
+  );
+}
+
 function StatementCardHeader({
   entry, statementId, camp, color, activeDebate, anNodeId,
   showTierPills, activeTier, setEntryDisplayTier, vocabResolutions, hasLineageRefs,
   qbafEnabled, netDelta, isPover, diagnosticsEnabled, toggleDiagnostics, selectDiagEntry,
   entryIndex, totalEntries, deleteConfirm, setDeleteConfirm,
+  collapsible, collapsed, onToggleCollapse, collapsedSummary,
 }: {
   entry: TranscriptEntry;
   statementId?: string;
@@ -660,9 +686,16 @@ function StatementCardHeader({
   totalEntries?: number;
   deleteConfirm: 'single' | 'after' | null;
   setDeleteConfirm: (v: 'single' | 'after' | null) => void;
+  collapsible: boolean;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
+  collapsedSummary: string;
 }) {
   return (
     <div className="debate-statement-header">
+      {collapsible && (
+        <StatementCollapseToggle collapsed={collapsed} onToggle={onToggleCollapse} entryId={entry.id} />
+      )}
       {camp && <CampGlyph camp={camp} size={16} />}
       <span className="debate-statement-speaker" style={color ? { color } : undefined}>
         {speakerLabel(entry.speaker)}
@@ -676,6 +709,67 @@ function StatementCardHeader({
           {statementId}
         </span>
       )}
+      {collapsed ? (
+        <span className="debate-statement-collapsed-summary">{collapsedSummary}</span>
+      ) : (
+        <StatementCardHeaderDetail
+          entry={entry}
+          activeDebate={activeDebate}
+          anNodeId={anNodeId}
+          showTierPills={showTierPills}
+          activeTier={activeTier}
+          setEntryDisplayTier={setEntryDisplayTier}
+          vocabResolutions={vocabResolutions}
+          hasLineageRefs={hasLineageRefs}
+          qbafEnabled={qbafEnabled}
+          netDelta={netDelta}
+          isPover={isPover}
+          diagnosticsEnabled={diagnosticsEnabled}
+          toggleDiagnostics={toggleDiagnostics}
+          selectDiagEntry={selectDiagEntry}
+          entryIndex={entryIndex}
+          totalEntries={totalEntries}
+          deleteConfirm={deleteConfirm}
+          setDeleteConfirm={setDeleteConfirm}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Everything in the card header past the speaker identity. Split out so a
+ * collapsed card (t/2241) can render identity-only without duplicating the row,
+ * and so the header stays under the complexity ceiling. Rendered output is
+ * unchanged from before the split.
+ */
+function StatementCardHeaderDetail({
+  entry, activeDebate, anNodeId, showTierPills, activeTier, setEntryDisplayTier,
+  vocabResolutions, hasLineageRefs, qbafEnabled, netDelta, isPover,
+  diagnosticsEnabled, toggleDiagnostics, selectDiagEntry,
+  entryIndex, totalEntries, deleteConfirm, setDeleteConfirm,
+}: {
+  entry: TranscriptEntry;
+  activeDebate: ActiveDebateT;
+  anNodeId: string | null;
+  showTierPills: boolean;
+  activeTier: string;
+  setEntryDisplayTier: SetEntryDisplayTier;
+  vocabResolutions: VocabResolution[] | undefined;
+  hasLineageRefs: boolean;
+  qbafEnabled: boolean;
+  netDelta: number | undefined;
+  isPover: boolean;
+  diagnosticsEnabled: boolean;
+  toggleDiagnostics: () => void;
+  selectDiagEntry: ReturnType<typeof useDebateStore.getState>['selectDiagEntry'];
+  entryIndex?: number;
+  totalEntries?: number;
+  deleteConfirm: 'single' | 'after' | null;
+  setDeleteConfirm: (v: 'single' | 'after' | null) => void;
+}) {
+  return (
+    <>
       <StatementModelBadge entry={entry} activeDebate={activeDebate} />
       <span className="debate-statement-type">
         {entry.type}
@@ -712,7 +806,7 @@ function StatementCardHeader({
         </button>
       )}
       <StatementDeleteActions entryIndex={entryIndex} totalEntries={totalEntries} deleteConfirm={deleteConfirm} setDeleteConfirm={setDeleteConfirm} />
-    </div>
+    </>
   );
 }
 
@@ -797,7 +891,7 @@ function StatementBody({
   setEntryDisplayTier: SetEntryDisplayTier;
 }) {
   return (
-    <div className={`debate-statement-body${isMetaView ? ' meta-view' : ''}`} ref={bodyRef}>
+    <div className={`debate-statement-body${isMetaView ? ' meta-view' : ''}`} ref={bodyRef} id={`debate-statement-body-${entry.id}`}>
       <div key={flipKey} ref={innerRef} className={`debate-flip-inner${flipping ? ' flipping' : ''}`} onAnimationEnd={handleFlipEnd}>
       {isMetaView && <div className="debate-meta-mode-label">{TIER_LABELS[displayedTier]?.toUpperCase()}</div>}
       {displayedTier === 'terms' && vocabResolutions && vocabResolutions.length > 0 ? (
@@ -917,6 +1011,11 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
   const selectDiagEntry = useDebateStore(s => s.selectDiagEntry);
   const deleteTranscriptEntries = useDebateStore(s => s.deleteTranscriptEntries);
   const qbafEnabled = useFlag('release-qbaf-analysis');
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
+  // Per-card collapse (t/2241) — deliberately local, not persisted to the debate
+  // store: it is a reading aid for the current scroll session, not debate state.
+  const [collapsed, setCollapsed] = useState(false);
+  const toggleCollapsed = useCallback(() => setCollapsed(c => !c), []);
   const [deleteConfirm, setDeleteConfirm] = useState<'single' | 'after' | null>(null);
   const [showSymbolTooltips, setShowSymbolTooltips] = useState(false);
   const anNodeId = findAnNodeId(activeDebate, entry.id);
@@ -987,6 +1086,14 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
   const isMetaView = META_TIERS.has(displayedTier);
   const { displayContent, isTruncated } = resolveDisplayContent(entry, displayedTier, isSubstantive);
 
+  // Collapsed cards show a word count so a long turn is still distinguishable
+  // from a one-liner when skimming (t/2241).
+  const collapsedSummary = useMemo(() => {
+    const words = entry.content.trim().split(/\s+/).filter(Boolean).length;
+    return `collapsed · ${words} ${words === 1 ? 'word' : 'words'}`;
+  }, [entry.content]);
+  const isCollapsed = chatRedesign && collapsed;
+
   // Memoize the rendered statement body into a reconciliation-stable subtree so
   // CommentOverlay's imperatively-injected [data-comment-highlight] spans survive
   // comment-only re-renders (HLD t/1683#1, Decision 2 — t/1694). A stable element
@@ -1007,7 +1114,7 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
 
   return (
     <div
-      className={`debate-statement debate-speaker-${entry.speaker} debate-type-${entry.type}`}
+      className={`debate-statement debate-speaker-${entry.speaker} debate-type-${entry.type}${isCollapsed ? ' debate-statement-collapsed' : ''}`}
       data-entry-id={entry.id}
       data-is-pover={isPover ? 'true' : 'false'}
     >
@@ -1033,35 +1140,43 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
         totalEntries={totalEntries}
         deleteConfirm={deleteConfirm}
         setDeleteConfirm={setDeleteConfirm}
+        collapsible={chatRedesign}
+        collapsed={isCollapsed}
+        onToggleCollapse={toggleCollapsed}
+        collapsedSummary={collapsedSummary}
       />
-      <StatementDeleteConfirm
-        entry={entry}
-        activeDebate={activeDebate}
-        deleteConfirm={deleteConfirm}
-        setDeleteConfirm={setDeleteConfirm}
-        deleteTranscriptEntries={deleteTranscriptEntries}
-        entryIndex={entryIndex}
-        totalEntries={totalEntries}
-      />
-      <StatementTurnSymbols turnSymbols={turnSymbols} showSymbolTooltips={showSymbolTooltips} setShowSymbolTooltips={setShowSymbolTooltips} />
-      <StatementBody
-        entry={entry}
-        activeDebate={activeDebate}
-        displayedTier={displayedTier}
-        isMetaView={isMetaView}
-        flipKey={flipKey}
-        flipping={flipping}
-        handleFlipEnd={handleFlipEnd}
-        bodyRef={bodyRef}
-        innerRef={innerRef}
-        contentRef={contentRef}
-        vocabResolutions={vocabResolutions}
-        meta={meta}
-        renderedStatementBody={renderedStatementBody}
-        isTruncated={isTruncated}
-        setEntryDisplayTier={setEntryDisplayTier}
-      />
-      <StatementFooter entry={entry} activeDebate={activeDebate} activeTier={activeTier} debateGenerating={debateGenerating} askQuestion={askQuestion} />
+      {!isCollapsed && (
+        <>
+          <StatementDeleteConfirm
+            entry={entry}
+            activeDebate={activeDebate}
+            deleteConfirm={deleteConfirm}
+            setDeleteConfirm={setDeleteConfirm}
+            deleteTranscriptEntries={deleteTranscriptEntries}
+            entryIndex={entryIndex}
+            totalEntries={totalEntries}
+          />
+          <StatementTurnSymbols turnSymbols={turnSymbols} showSymbolTooltips={showSymbolTooltips} setShowSymbolTooltips={setShowSymbolTooltips} />
+          <StatementBody
+            entry={entry}
+            activeDebate={activeDebate}
+            displayedTier={displayedTier}
+            isMetaView={isMetaView}
+            flipKey={flipKey}
+            flipping={flipping}
+            handleFlipEnd={handleFlipEnd}
+            bodyRef={bodyRef}
+            innerRef={innerRef}
+            contentRef={contentRef}
+            vocabResolutions={vocabResolutions}
+            meta={meta}
+            renderedStatementBody={renderedStatementBody}
+            isTruncated={isTruncated}
+            setEntryDisplayTier={setEntryDisplayTier}
+          />
+          <StatementFooter entry={entry} activeDebate={activeDebate} activeTier={activeTier} debateGenerating={debateGenerating} askQuestion={askQuestion} />
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes t/2241 (child of t/2234, design critique §5 MAJOR).

## What

The brief/medium/detailed tier system changes a turn's content *length*, not its *visibility* — so in a 50-turn debate there was no way to skim past turns already read. Only concluding-statement sub-sections had true collapse.

Behind `DEBATE_CHAT_REDESIGN`, each `StatementCard` header gets a collapse chevron. Collapsed = identity row only: camp glyph, speaker, statement ID, and a word count (`collapsed · 240 words`) so a long turn stays distinguishable from a one-liner while scanning.

## Against the ACs

- **Flag off: no change** — no chevron, header renders byte-identically. Covered by a test.
- **Flag on: chevron; collapsed = header row only** — body, footer, turn symbols, and delete-confirm are all unmounted while collapsed.
- **Independent of tier pills** — tier lives in the debate store (`entry.display_tier`), untouched by collapse, so a tier choice survives a collapse/expand cycle.
- **State is local** — `useState` per card, nothing written to the store; collapse is a reading aid for the current scroll session, not debate state.
- **Keyboard accessible** — a native `<button>`, so Enter/Space work with no key handlers, plus `aria-expanded` / `aria-controls` / `aria-label`. Covered by a `user-event` tab + Enter + Space test.

## Structure note

Header content past the speaker identity moved into `StatementCardHeaderDetail` so the collapsed row doesn't duplicate the header markup and `StatementCardHeader` stays under the complexity ceiling. Pure extraction — rendered output is unchanged.

## Verification

- 250/250 scoped vitest pass, incl. 7 new cases in `StatementCard.collapse.test.tsx` (both flag arms, click toggle, keyboard toggle, word count, per-card independence)
- `tsc` main + server clean · eslint `--max-warnings=4256` 0 errors · depcruise 0 violations · `vite build` clean
- `check-renderer-tsc.sh` fails on `@types/mdast` in any fresh worktree — pre-existing t/2248, not a CI gate

Flag ships off by default, so no visual sign-off is included; happy to add screenshots before the flag flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)