### PR TITLE
feat(debate-workspace): cap debate prose at 68ch behind DEBATE_CHAT_REDESIGN (t/2240)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -53,6 +53,17 @@
   max-width: none;
 }
 
+/*
+ * Readable measure for debate prose (t/2240, DEBATE_CHAT_REDESIGN). Chat already
+ * caps its AI markdown at 68ch (ChatWorkspace.css); the debate surface — longer
+ * sessions, denser text — was the one left unconstrained. Same value so the two
+ * surfaces read as one system. `.debate-redesign` lands on the card root only
+ * when the flag is on, so the flag-off measure stays `none`.
+ */
+.debate-statement.debate-redesign .debate-statement-content.prose {
+  max-width: 68ch;
+}
+
 /* Model badge — hoisted from inline */
 .debate-model-badge {
   font-size: var(--text-2xs);

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.prose.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.prose.test.tsx
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2240 — debate prose was the one AI-markdown surface with no measure cap
+// (`max-width: none`), while chat capped the same kind of text at 68ch. CSS
+// can't read a feature flag, so the gate is a `debate-redesign` class on the
+// card root; these tests pin that class to the flag rather than the 68ch value
+// itself, which lives in StatementCard.css and isn't applied under jsdom.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+// ── Mocks ────────────────────────────────────────────────────
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+vi.mock('remark-gfm', () => ({ default: {} }));
+
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: vi.fn() }),
+}));
+
+const debateState = {
+  activeDebate: { transcript: [], speaker_models: {} },
+  responseLength: 'detailed',
+  setEntryDisplayTier: vi.fn(),
+  askQuestion: vi.fn(),
+  debateGenerating: null,
+  diagnosticsEnabled: false,
+  toggleDiagnostics: vi.fn(),
+  selectDiagEntry: vi.fn(),
+  deleteTranscriptEntries: vi.fn(),
+};
+
+vi.mock('../../hooks/useDebateStore', () => ({
+  useDebateStore: Object.assign(
+    (selector: (s: typeof debateState) => unknown) => selector(debateState),
+    { getState: () => debateState },
+  ),
+}));
+
+vi.mock('zustand/react/shallow', () => ({ useShallow: (fn: unknown) => fn }));
+
+const mockFlags: Record<string, boolean> = {};
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFlag: (name: string) => mockFlags[name] ?? false,
+}));
+
+vi.mock('../../hooks/useCommentStore', () => ({
+  COMMENT_TYPE_META: {},
+  useCommentStore: (selector?: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      commentsFile: null,
+      filters: { types: new Set(), authors: new Set(), searchText: '', showResolved: true },
+      focusedCommentId: null,
+      focusComment: vi.fn(),
+      setSidebarOpen: vi.fn(),
+      toggleSidebar: vi.fn(),
+    };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock('../../hooks/useTaxonomyStore', () => ({
+  useTaxonomyStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector({}),
+    { getState: () => ({ policyRegistry: null }) },
+  ),
+}));
+vi.mock('@bridge', () => ({
+  api: { focusNodeInMainWindow: vi.fn(), clipboardWriteText: vi.fn(), openExternal: vi.fn() },
+}));
+
+vi.mock('./ClaimsView', () => ({ ClaimsView: () => <div data-testid="claims-view" /> }));
+vi.mock('./VocabularyPanel', () => ({ LineageTermsView: () => null, VocabTermsView: () => null }));
+vi.mock('./TaxonomyRefs', () => ({ TaxonomyRefsSection: () => <div data-testid="taxonomy-refs" /> }));
+vi.mock('../../utils/lineageMatcher', () => ({ lineageMarkdownComponents: {}, extractLineageNames: () => [] }));
+vi.mock('../../utils/vocabularyAnnotations', () => ({ getDebateMarkdownComponents: () => ({}) }));
+
+import { StatementCard } from './StatementCard';
+import type { TranscriptEntry } from '@lib/debate/types';
+
+function makeEntry(over: Partial<TranscriptEntry> = {}): TranscriptEntry {
+  return {
+    id: 'e1',
+    timestamp: '2026-01-01T00:00:00Z',
+    type: 'statement',
+    speaker: 'accelerationist',
+    content: 'Some statement prose.',
+    taxonomy_refs: [],
+    display_tier: 'detailed',
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete mockFlags.DEBATE_CHAT_REDESIGN;
+  if (!window.matchMedia) {
+    window.matchMedia = vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }) as unknown as typeof window.matchMedia;
+  }
+});
+
+describe('StatementCard prose measure (t/2240)', () => {
+  it('leaves the card unscoped when the flag is off, so max-width stays none', () => {
+    const { container } = render(<StatementCard entry={makeEntry()} />);
+    expect(container.querySelector('.debate-statement')?.classList.contains('debate-redesign')).toBe(false);
+  });
+
+  it('scopes the card for the 68ch measure when the flag is on', () => {
+    mockFlags.DEBATE_CHAT_REDESIGN = true;
+    const { container } = render(<StatementCard entry={makeEntry()} />);
+    expect(container.querySelector('.debate-statement')?.classList.contains('debate-redesign')).toBe(true);
+  });
+
+  it('keeps the speaker and type classes intact alongside the scope class', () => {
+    mockFlags.DEBATE_CHAT_REDESIGN = true;
+    const { container } = render(<StatementCard entry={makeEntry()} />);
+    const card = container.querySelector('.debate-statement') as HTMLElement;
+    expect(card.classList.contains('debate-speaker-accelerationist')).toBe(true);
+    expect(card.classList.contains('debate-type-statement')).toBe(true);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -1013,6 +1013,9 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
   const selectDiagEntry = useDebateStore(s => s.selectDiagEntry);
   const deleteTranscriptEntries = useDebateStore(s => s.deleteTranscriptEntries);
   const qbafEnabled = useFlag('release-qbaf-analysis');
+  // Gates the collapse toggle (t/2241) and doubles as the scoping hook for
+  // redesign-only styling (t/2240 prose measure) — CSS can't read a flag, so it
+  // becomes `.debate-redesign` on the card root.
   const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
   // Per-card collapse (t/2241) — deliberately local, not persisted to the debate
   // store: it is a reading aid for the current scroll session, not debate state.
@@ -1116,7 +1119,7 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
 
   return (
     <div
-      className={`debate-statement debate-speaker-${entry.speaker} debate-type-${entry.type}${isCollapsed ? ' debate-statement-collapsed' : ''}`}
+      className={`debate-statement debate-speaker-${entry.speaker} debate-type-${entry.type}${chatRedesign ? ' debate-redesign' : ''}${isCollapsed ? ' debate-statement-collapsed' : ''}`}
       data-entry-id={entry.id}
       data-is-pover={isPover ? 'true' : 'false'}
     >


### PR DESCRIPTION
Closes t/2240 (child of t/2234, design critique §3 MAJOR).

## What

`ChatWorkspace.css` caps chat's AI markdown at `68ch`; `StatementCard.css` had `max-width: none` on the same kind of text — so the surface with *longer* sessions and higher density was the unconstrained one. This applies the same `68ch` behind the flag, so the two surfaces read as one system.

## On the "no JS changes" AC

CSS can't read a feature flag, so gating needs one class hook: `debate-redesign` on the card root, set from the existing `useFlag` pattern already in `StatementCard`. No logic, no state, no new props — and the class is deliberately generic so later flagged CSS-only work (t/2247) can hang rules off it rather than adding another flag read per rule.

## Against the ACs

- **Flag off:** `max-width: none` untouched — the new rule is scoped under `.debate-statement.debate-redesign`, which isn't present.
- **Flag on:** `68ch`, matching chat.
- **Tiers:** the rule targets `.debate-statement-content.prose`, which brief/medium/detailed all share; meta views (claims/lineage/terms) don't carry `.prose` and are unaffected.

## Verification

- 246/246 scoped vitest, incl. 3 new cases pinning the scope class to both flag arms (the `68ch` value itself isn't applied under jsdom, so the tests pin the gate, not the number)
- `tsc` main clean · eslint 0 errors · `vite build` clean

Flag ships off by default. Worth a visual pass before the flag flips — the constraint interacts with tier-flip height animation in a way only a real render will show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)