### PR TITLE
feat(bandColor): add exported DIVERGENCE_BANDS band-set (t/2236 follow-up)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/bandColor.ts
+++ b/taxonomy-editor/src/renderer/lib/bandColor.ts
@@ -32,3 +32,10 @@ export const BUDGET_BANDS: readonly BandEntry[] = [
   { threshold: 0.8,  color: 'warning' },
   { threshold: 0,    color: '' },
 ];
+
+/** Interpretation-divergence score (SituationDetail). */
+export const DIVERGENCE_BANDS: readonly BandEntry[] = [
+  { threshold: 0.40, color: '#22c55e' },
+  { threshold: 0.20, color: '#f59e0b' },
+  { threshold: 0,    color: '#ef4444' },
+];


### PR DESCRIPTION
Adds the interpretation-divergence band-set (.40/.20) to bandColor.ts so t/2250's SituationDetail drops its local DIVERGENCE_SCORE_BANDS. TL-directed (p/359). DebateUI does the SituationDetail swap once this lands. Additive-only, no behavior change.