### PR TITLE
refactor(debate): use shared DIVERGENCE_BANDS in SituationDetail (t/2250)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
@@ -25,14 +25,8 @@ import { api } from '@bridge';
 import { triggerSituationNodeRegeneration } from '../../utils/regeneratePlainDescription';
 import { useDescriptionMode, DescriptionToggle, type DescriptionMode } from '../shared/DescriptionToggle';
 import { StakeholderSection } from '../organizations/StakeholderSection';
-import { bandColor, type BandEntry } from '../../lib/bandColor';
+import { bandColor, DIVERGENCE_BANDS } from '../../lib/bandColor';
 import './SituationDetail.css';
-
-const DIVERGENCE_SCORE_BANDS: readonly BandEntry[] = [
-  { threshold: 0.40, color: '#22c55e' },
-  { threshold: 0.20, color: '#f59e0b' },
-  { threshold: 0,    color: '#ef4444' },
-];
 
 interface SituationDetailProps {
   node: SituationNode;
@@ -300,7 +294,7 @@ function SitOverviewTab({
 
       {node.interpretation_divergence != null && (() => {
         const div = node.interpretation_divergence;
-        const color = bandColor(div, DIVERGENCE_SCORE_BANDS);
+        const color = bandColor(div, DIVERGENCE_BANDS);
         const label = div > 0.40 ? 'High divergence' : div >= 0.20 ? 'Moderate divergence' : 'Low divergence';
         return (
           <div className="form-group">


### PR DESCRIPTION
## Summary
- Replace local `DIVERGENCE_SCORE_BANDS` const in `SituationDetail.tsx` with shared `DIVERGENCE_BANDS` export from `bandColor.ts` (landed ab5225cf)
- Drop local `BandEntry` type import (no longer needed)
- Byte-identical band values — no visual change

## Test plan
- [ ] `npm run verify` clean (tsc + eslint + depcruise + vitest) — confirmed locally before PR
- [ ] No divergence score coloring regression (values identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)