### PR TITLE
feat(debate-workspace): structural transcript navigator behind DEBATE_CHAT_REDESIGN (t/2239)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -41,6 +41,8 @@ import { ClarificationActions, ClaimsEditor, RefinedTopicEditor, TopicScoreCompa
 import { OpeningActions } from './OpeningPanel';
 import { ExplorationSummaryCard } from './ExplorationSummaryCard';
 import { EmptyState } from '../shared/EmptyState';
+import { TranscriptOutline } from './TranscriptOutline';
+import { useFlag } from '../../hooks/useFeatureFlags';
 import './DebateWorkspace.css';
 
 // ── Phase 7: Context menu state ──────────────────────────
@@ -727,6 +729,7 @@ function TranscriptEntryRow({
     <Fragment>
       {hairline}
       <div
+        id={`debate-entry-${entry.id}`}
         className={`debate-entry-wrapper${diagnosticsEnabled && selectedDiagEntry === entry.id ? ' diag-selected' : ''}`}
         onClick={diagnosticsEnabled ? () => selectDiagEntry(entry.id) : undefined}
       >
@@ -1355,6 +1358,7 @@ export function DebateWorkspace({ onExport, exportStatus }: {
   const isClarificationPhase = activeDebate.phase === 'clarification' || activeDebate.phase === 'setup';
   const isEditClaimsPhase = activeDebate.phase === 'edit-claims';
   const isOpeningPhase = activeDebate.phase === 'opening';
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
   const isDebatePhase = activeDebate.phase === 'debate'
     || activeDebate.phase === 'closed'
     || activeDebate.adaptive_staging?.phase_state?.current_phase != null;
@@ -1365,6 +1369,7 @@ export function DebateWorkspace({ onExport, exportStatus }: {
 
   return (
     <div className="debate-workspace-row" data-phase={isClarificationPhase ? 'setup' : undefined}>
+    {chatRedesign && <TranscriptOutline transcript={activeDebate.transcript} />}
     <div className="debate-workspace">
       {/* Fixed toolbar — always visible */}
       <DebateToolbar

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.css
@@ -1,0 +1,77 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/*
+ * Structural transcript navigator (t/2239, DEBATE_CHAT_REDESIGN). Persistent
+ * left rail listing phase sections and rounds; clicking scrolls the transcript.
+ * Read-only view over existing state.
+ */
+
+.transcript-outline {
+  flex: 0 0 160px;
+  align-self: stretch;
+  overflow-y: auto;
+  border-right: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  padding: 8px 0;
+  font-size: var(--text-xs);
+}
+
+.transcript-outline-title {
+  padding: 4px 12px 8px;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.transcript-outline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.transcript-outline-item {
+  margin: 0;
+}
+
+.transcript-outline-link {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 12px;
+  color: var(--text-primary);
+  font: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-left: 2px solid transparent;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.transcript-outline-link:hover {
+  background: color-mix(in srgb, var(--focus-ring) 12%, transparent);
+  border-left-color: var(--focus-ring);
+}
+
+.transcript-outline-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.transcript-outline-section .transcript-outline-link {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+.transcript-outline-round .transcript-outline-link {
+  padding-left: 24px;
+  color: var(--text-primary);
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.test.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { TranscriptOutline, type OutlineTranscriptEntry } from './TranscriptOutline';
+
+afterEach(cleanup);
+
+const entry = (id: string, type: string, speaker?: string): OutlineTranscriptEntry => ({ id, type, speaker });
+
+describe('TranscriptOutline', () => {
+  it('renders nothing when the transcript has no outline anchors', () => {
+    const { container } = render(<TranscriptOutline transcript={[entry('c1', 'clarification'), entry('s1', 'system')]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('derives phase sections and rounds (speaker-cycle heuristic) in transcript order', () => {
+    const transcript: OutlineTranscriptEntry[] = [
+      entry('o1', 'opening', 'acc'),
+      entry('o2', 'opening', 'saf'),
+      // Round 1: acc, saf, skp
+      entry('d1', 'statement', 'acc'),
+      entry('d2', 'statement', 'saf'),
+      entry('d3', 'statement', 'skp'),
+      // acc repeats -> Round 2
+      entry('d4', 'statement', 'acc'),
+      entry('d5', 'cross_respond', 'saf'),
+      entry('y1', 'synthesis', 'acc'),
+    ];
+    render(<TranscriptOutline transcript={transcript} />);
+    const labels = screen.getAllByRole('button').map(b => b.textContent);
+    expect(labels).toEqual([
+      'Opening Statements',
+      'Cross-Examination',
+      'Round 1',
+      'Round 2',
+      'Synthesis',
+    ]);
+  });
+
+  it('scrolls to the first entry of a section/round when clicked', () => {
+    const scrollIntoView = vi.fn();
+    const getById = vi.spyOn(document, 'getElementById').mockReturnValue({ scrollIntoView } as unknown as HTMLElement);
+    const transcript: OutlineTranscriptEntry[] = [
+      entry('d1', 'statement', 'acc'),
+      entry('d2', 'statement', 'saf'),
+      entry('d3', 'statement', 'acc'), // acc repeats -> Round 2 anchored at d3
+    ];
+    render(<TranscriptOutline transcript={transcript} />);
+    fireEvent.click(screen.getByText('Round 2'));
+    expect(getById).toHaveBeenCalledWith('debate-entry-d3');
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    getById.mockRestore();
+  });
+
+  it('starts a fresh round numbering for a new debate section', () => {
+    const transcript: OutlineTranscriptEntry[] = [
+      entry('d1', 'statement', 'acc'),
+      entry('o1', 'opening', 'acc'), // section change interrupts debate
+      entry('d2', 'statement', 'acc'), // new debate section -> Round 1 again
+    ];
+    render(<TranscriptOutline transcript={transcript} />);
+    const rounds = screen.getAllByRole('button').map(b => b.textContent).filter(t => t?.startsWith('Round'));
+    expect(rounds).toEqual(['Round 1', 'Round 1']);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.tsx
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useMemo } from 'react';
+import './TranscriptOutline.css';
+
+/**
+ * Minimal structural shape of a transcript entry the outline needs. Kept local
+ * so the outline stays decoupled from the store's full entry type (t/2239).
+ */
+export interface OutlineTranscriptEntry {
+  id: string;
+  type: string;
+  speaker?: string | null;
+}
+
+type OutlineItem = {
+  key: string;
+  label: string;
+  targetEntryId: string;
+  kind: 'section' | 'round';
+};
+
+const DEBATE_TYPES = new Set(['statement', 'cross_respond']);
+const SYNTHESIS_TYPES = new Set(['synthesis', 'concluding']);
+
+/**
+ * Derives a phase → round outline from the transcript. Sections mirror the
+ * in-transcript phase hairlines (Opening Statements / Cross-Examination /
+ * Synthesis). Rounds within the debate section use a speaker-cycle heuristic:
+ * a new round begins when a speaker repeats within the current cycle.
+ */
+function buildOutline(transcript: readonly OutlineTranscriptEntry[]): OutlineItem[] {
+  const items: OutlineItem[] = [];
+  let section: 'opening' | 'debate' | 'synthesis' | null = null;
+  let roundSpeakers = new Set<string>();
+  let roundNum = 0;
+
+  for (const entry of transcript) {
+    const t = entry.type;
+    if (t === 'opening') {
+      if (section !== 'opening') {
+        section = 'opening';
+        items.push({ key: `sec-opening-${entry.id}`, label: 'Opening Statements', targetEntryId: entry.id, kind: 'section' });
+      }
+    } else if (DEBATE_TYPES.has(t)) {
+      if (section !== 'debate') {
+        section = 'debate';
+        roundSpeakers = new Set();
+        roundNum = 0;
+        items.push({ key: `sec-debate-${entry.id}`, label: 'Cross-Examination', targetEntryId: entry.id, kind: 'section' });
+      }
+      const speaker = entry.speaker ?? '';
+      if (speaker && roundSpeakers.has(speaker)) {
+        roundSpeakers = new Set();
+      }
+      if (roundSpeakers.size === 0) {
+        roundNum += 1;
+        items.push({ key: `round-${roundNum}-${entry.id}`, label: `Round ${roundNum}`, targetEntryId: entry.id, kind: 'round' });
+      }
+      if (speaker) roundSpeakers.add(speaker);
+    } else if (SYNTHESIS_TYPES.has(t)) {
+      if (section !== 'synthesis') {
+        section = 'synthesis';
+        items.push({ key: `sec-synthesis-${entry.id}`, label: 'Synthesis', targetEntryId: entry.id, kind: 'section' });
+      }
+    }
+    // Other types (probing, fact-check, clarification, system, question) are
+    // not outline anchors; they stay inline in the transcript.
+  }
+  return items;
+}
+
+function scrollToEntry(entryId: string): void {
+  document.getElementById(`debate-entry-${entryId}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+/**
+ * Read-only structural navigator for the transcript (t/2239). Derived entirely
+ * from the transcript prop — no new store/server state. Rendered only when the
+ * DEBATE_CHAT_REDESIGN flag is on; phase hairlines remain the secondary markers.
+ */
+export function TranscriptOutline({ transcript }: { transcript: readonly OutlineTranscriptEntry[] }) {
+  const items = useMemo(() => buildOutline(transcript), [transcript]);
+  if (items.length === 0) return null;
+
+  return (
+    <nav className="transcript-outline" aria-label="Transcript outline">
+      <div className="transcript-outline-title">Outline</div>
+      <ul className="transcript-outline-list">
+        {items.map(item => (
+          <li key={item.key} className={`transcript-outline-item transcript-outline-${item.kind}`}>
+            <button
+              type="button"
+              className="transcript-outline-link"
+              onClick={() => scrollToEntry(item.targetEntryId)}
+              title={item.label}
+            >
+              {item.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}


### PR DESCRIPTION
feat(debate-workspace): structural transcript navigator behind DEBATE_CHAT_REDESIGN (t/2239)

Adds a persistent left-rail outline (phase section -> round) so researchers can
jump to a phase/round instead of only Ctrl+F full-text search. New
TranscriptOutline derives the outline from the transcript prop via useMemo — no
new store/server state. Sections mirror the in-transcript phase hairlines
(Opening Statements / Cross-Examination / Synthesis); debate rounds use a
speaker-cycle heuristic (new round when a speaker repeats in the current cycle).
Clicking scrolls to debate-entry-<id> (same scheme as handleChatNavigate).

DebateWorkspace: each entry wrapper gets id="debate-entry-<id>"; the rail renders
as the first child of debate-workspace-row only when useFlag('DEBATE_CHAT_REDESIGN')
is on. Flag off = no visible change (element absent; the id attribute is inert).
Phase hairlines remain as secondary in-transcript markers.

Verified: tsc -p tsconfig.main.json clean; 258 scoped vitest pass (incl. 4 new
TranscriptOutline tests); eslint 0 errors.

Co-Authored-By: DebateWorkspace (Orca) <main.taxonomy-editor-src-renderer-components-debate-workspace@ai-triad-research.orca.local>
