### PR TITLE
feat(shared): add SpeakerIdentity + resolveSpeaker single lookup (t/2242)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.css
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.css
@@ -66,9 +66,17 @@
 .speaker-identity-badge .speaker-identity-label {
   font-size: var(--text-2xs);
   font-weight: 700;
-  color: #fff;
+  color: var(--text-primary);
 }
 
-.speaker-identity-badge .speaker-identity-glyph {
+/*
+ * White reverses out ONLY over a real accent fill. An unknown speaker gets no
+ * fill (resolveSpeaker returns no color), so an unconditional `#fff` here would
+ * print white on `--bg-tertiary` — invisible in the light/harvard/bkc themes.
+ * TL asked us to verify exactly this when endorsing the #888 → no-color change
+ * (e/67#7).
+ */
+.speaker-identity-badge-filled .speaker-identity-label,
+.speaker-identity-badge-filled .speaker-identity-glyph {
   color: #fff;
 }

--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.css
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.css
@@ -1,0 +1,74 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/*
+ * Shared speaker identity (t/2242). One component, three shapes — each matching
+ * what its surface renders today, so adoption is a swap rather than a restyle.
+ */
+
+.speaker-identity {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.speaker-identity-glyph-wrap {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.speaker-identity-glyph {
+  flex-shrink: 0;
+}
+
+.speaker-identity-label {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── inline: transcript header ── */
+
+.speaker-identity-inline .speaker-identity-label {
+  font-size: var(--text-sm);
+}
+
+/* ── avatar: chat bubble — glyph in a tinted circle ── */
+
+.speaker-identity-avatar {
+  gap: 8px;
+}
+
+.speaker-identity-avatar .speaker-identity-glyph-wrap {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  justify-content: center;
+  background: color-mix(in srgb, currentColor 15%, transparent);
+}
+
+.speaker-identity-avatar .speaker-identity-label {
+  font-size: var(--text-sm);
+}
+
+/* ── badge: diagnostics exchange — solid fill, label reversed out ── */
+
+.speaker-identity-badge {
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+}
+
+.speaker-identity-badge .speaker-identity-label {
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  color: #fff;
+}
+
+.speaker-identity-badge .speaker-identity-glyph {
+  color: #fff;
+}

--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.test.tsx
@@ -112,6 +112,18 @@ describe('SpeakerIdentity rendering', () => {
     const { container } = render(<SpeakerIdentity speaker="safetyist" variant="badge" />);
     const root = container.querySelector('.speaker-identity-badge') as HTMLElement;
     expect(root.style.background).toBeTruthy();
+    expect(root.classList.contains('speaker-identity-badge-filled')).toBe(true);
+  });
+
+  // Legibility guard (TL e/67#7): white-on-white. An unknown speaker gets no
+  // accent fill, so the badge keeps its `--bg-tertiary` background — reversing
+  // the label out to white there would make it invisible in the light themes.
+  it('does NOT reverse an unfilled badge to white, so an unknown speaker stays legible', () => {
+    const { container } = render(<SpeakerIdentity speaker="nemesis" variant="badge" />);
+    const root = container.querySelector('.speaker-identity-badge') as HTMLElement;
+    expect(root.style.background).toBeFalsy();
+    expect(root.classList.contains('speaker-identity-badge-filled')).toBe(false);
+    expect(screen.getByText('Nemesis')).toBeInTheDocument();
   });
 
   it('resolves an alias end-to-end so a segmented transcript name renders correctly', () => {

--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2242 — `resolveSpeaker` is the single speaker lookup replacing 3+ scattered
+// label/color copies and the diagnostics `debaterColor` map. The alias cases
+// matter most: `Prometheus`/`Sentinel`/`Cassandra` previously existed only in
+// DebateExchangeRich's segmentation regex, so this table is now the source of
+// truth for them (TL e/67#4).
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../types/debate', () => ({
+  POVER_INFO: {
+    accelerationist: { label: 'Accelerationist', color: 'var(--color-acc)' },
+    safetyist: { label: 'Safetyist', color: 'var(--color-saf)' },
+    skeptic: { label: 'Skeptic', color: 'var(--color-skp)' },
+  },
+}));
+
+import { SpeakerIdentity, resolveSpeaker } from './SpeakerIdentity';
+
+describe('resolveSpeaker — POV speakers', () => {
+  it.each([
+    ['accelerationist', 'Accelerationist', 'acc'],
+    ['safetyist', 'Safetyist', 'saf'],
+    ['skeptic', 'Skeptic', 'skp'],
+  ])('resolves %s to its label, color, and camp', (id, label, camp) => {
+    const r = resolveSpeaker(id);
+    expect(r).toMatchObject({ id, label, camp });
+    expect(r.color).toBeTruthy();
+  });
+
+  it('accepts a display label, not just the canonical id', () => {
+    expect(resolveSpeaker('Safetyist')).toMatchObject({ id: 'safetyist', label: 'Safetyist', camp: 'saf' });
+  });
+});
+
+describe('resolveSpeaker — persona aliases (the regex this replaces)', () => {
+  it.each([
+    ['Prometheus', 'accelerationist', 'acc'],
+    ['Sentinel', 'safetyist', 'saf'],
+    ['Cassandra', 'skeptic', 'skp'],
+  ])('maps %s to its camp', (alias, id, camp) => {
+    expect(resolveSpeaker(alias)).toMatchObject({ id, camp });
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(resolveSpeaker('  pROMETHEUS ')).toMatchObject({ id: 'accelerationist', camp: 'acc' });
+  });
+});
+
+describe('resolveSpeaker — non-POV participants', () => {
+  it.each([
+    ['user', 'You'],
+    ['system', 'System'],
+    ['document', 'Document'],
+    ['moderator', 'Moderator'],
+  ])('labels %s as %s', (id, label) => {
+    expect(resolveSpeaker(id)).toMatchObject({ id, label });
+  });
+
+  it('gives none of them a camp, so no glyph is implied', () => {
+    for (const id of ['user', 'system', 'document', 'moderator']) {
+      expect(resolveSpeaker(id).camp).toBeUndefined();
+    }
+  });
+
+  it('colors only the moderator', () => {
+    expect(resolveSpeaker('moderator').color).toContain('--color-moderator');
+    expect(resolveSpeaker('user').color).toBeUndefined();
+    expect(resolveSpeaker('system').color).toBeUndefined();
+  });
+});
+
+describe('resolveSpeaker — unknown speakers', () => {
+  it('degrades to a titlecased label with NO color, never a fake camp accent', () => {
+    const r = resolveSpeaker('nemesis');
+    expect(r.label).toBe('Nemesis');
+    expect(r.color).toBeUndefined();
+    expect(r.camp).toBeUndefined();
+  });
+});
+
+describe('SpeakerIdentity rendering', () => {
+  it('renders glyph + label for a POV speaker', () => {
+    const { container } = render(<SpeakerIdentity speaker="accelerationist" />);
+    expect(screen.getByText('Accelerationist')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('omits the glyph for a speaker with no camp', () => {
+    const { container } = render(<SpeakerIdentity speaker="moderator" />);
+    expect(screen.getByText('Moderator')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('supports a glyph-only render', () => {
+    const { container } = render(<SpeakerIdentity speaker="skeptic" showLabel={false} />);
+    expect(screen.queryByText('Skeptic')).toBeNull();
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it.each(['inline', 'avatar', 'badge'] as const)('carries the %s variant and camp classes', (variant) => {
+    const { container } = render(<SpeakerIdentity speaker="safetyist" variant={variant} />);
+    const root = container.querySelector('.speaker-identity') as HTMLElement;
+    expect(root.classList.contains(`speaker-identity-${variant}`)).toBe(true);
+    expect(root.classList.contains('camp-saf')).toBe(true);
+  });
+
+  it('fills the badge with the accent, since its label reverses out to white', () => {
+    const { container } = render(<SpeakerIdentity speaker="safetyist" variant="badge" />);
+    const root = container.querySelector('.speaker-identity-badge') as HTMLElement;
+    expect(root.style.background).toBeTruthy();
+  });
+
+  it('resolves an alias end-to-end so a segmented transcript name renders correctly', () => {
+    render(<SpeakerIdentity speaker="Cassandra" variant="badge" />);
+    expect(screen.getByText('Skeptic')).toBeInTheDocument();
+  });
+
+  it('defaults its tooltip to the resolved label and lets a caller override', () => {
+    const { rerender, container } = render(<SpeakerIdentity speaker="skeptic" />);
+    expect(container.querySelector('.speaker-identity')).toHaveAttribute('title', 'Skeptic');
+
+    rerender(<SpeakerIdentity speaker="skeptic" title="Turn 4 — Skeptic" />);
+    expect(container.querySelector('.speaker-identity')).toHaveAttribute('title', 'Turn 4 — Skeptic');
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.tsx
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * One "who is speaking" surface for the whole app (t/2242).
+ *
+ * Three independent systems used to answer this question for the same four-camp
+ * taxonomy: the transcript's glyph + colored label, the diagnostics exchange
+ * renderer's solid pill (colored through its own lowercase map with an `#888`
+ * fallback), and chat's circular avatar — plus 3+ copies of the label/color
+ * lookup scattered across components.
+ *
+ * `resolveSpeaker` is the single lookup, and per TL (e/67#4) it is the source of
+ * truth for the persona aliases: `Prometheus`/`Sentinel`/`Cassandra` existed
+ * ONLY inside the `DebateExchangeRich` segmentation regex, with no canonical map
+ * anywhere. Everything else composes existing foundations rather than
+ * re-authoring them — labels and colors come from `POVER_INFO` (the soul docs),
+ * camps from `povToCamp` + `CampGlyph`, and the POV key type from
+ * `@lib/debate/types`.
+ */
+
+import { POVER_INFO } from '../../types/debate';
+import type { SpeakerId } from '../../types/debate';
+import { CampGlyph, povToCamp } from './CampGlyph';
+import type { CampKey } from './CampGlyph';
+import './SpeakerIdentity.css';
+
+/** Every speaker the UI can render, including the non-POV participants. */
+export type AnySpeaker = SpeakerId | 'system' | 'document' | 'moderator';
+
+export type SpeakerVariant = 'inline' | 'avatar' | 'badge';
+
+export interface ResolvedSpeaker {
+  /** Canonical id — the POV key, or the non-POV participant name. */
+  id: AnySpeaker;
+  /** Display label ("Accelerationist", "You", "Moderator", …). */
+  label: string;
+  /** Accent color, or undefined for participants that carry no camp color. */
+  color?: string;
+  /** Camp key for glyph rendering; undefined for non-POV participants. */
+  camp?: CampKey;
+}
+
+/**
+ * Persona aliases → POV key. New table by necessity: TL confirmed (e/67#4) no
+ * canonical alias map exists anywhere in the tree, and Rosetta verified against
+ * the soul docs (e/67#5) that their `.label`s are the plain camp names, not the
+ * personas. Add future aliases HERE, not in a consumer's regex.
+ */
+const SPEAKER_ALIASES: Record<string, SpeakerId> = {
+  prometheus: 'accelerationist',
+  sentinel: 'safetyist',
+  cassandra: 'skeptic',
+};
+
+/** Non-POV participants. Mirrors the labels `debate-workspace/utils.ts` has always used. */
+const NON_POV_LABELS: Record<'system' | 'document' | 'moderator' | 'user', string> = {
+  system: 'System',
+  document: 'Document',
+  moderator: 'Moderator',
+  user: 'You',
+};
+
+const MODERATOR_COLOR = 'var(--color-moderator, #8b5cf6)';
+
+/**
+ * Resolve any speaker reference — canonical id, display label, or persona alias,
+ * in any case — to its identity. Unknown input degrades to a titlecased label
+ * with no color rather than the old `#888` fallback, so an unrecognized speaker
+ * reads as "unstyled", never as a real camp.
+ */
+export function resolveSpeaker(nameOrId: string): ResolvedSpeaker {
+  const key = nameOrId.trim().toLowerCase();
+  const id = (SPEAKER_ALIASES[key] ?? key) as AnySpeaker;
+
+  if (id === 'system' || id === 'document' || id === 'moderator' || id === 'user') {
+    return {
+      id,
+      label: NON_POV_LABELS[id],
+      color: id === 'moderator' ? MODERATOR_COLOR : undefined,
+    };
+  }
+
+  const info = POVER_INFO[id as Exclude<SpeakerId, 'user'>];
+  if (info) {
+    return { id, label: info.label, color: info.color, camp: povToCamp(id) };
+  }
+
+  return { id, label: nameOrId.charAt(0).toUpperCase() + nameOrId.slice(1) };
+}
+
+/**
+ * Speaker identity in one of three shapes:
+ * - `inline` — glyph + colored label (transcript header)
+ * - `avatar` — circular glyph chip + label (chat bubble)
+ * - `badge`  — solid-fill pill (diagnostics exchange)
+ *
+ * Pass `showLabel={false}` for glyph-only, or a speaker with no camp to get a
+ * label-only render (which is what `INodeRow` needs).
+ */
+export function SpeakerIdentity({
+  speaker,
+  variant = 'inline',
+  size = 16,
+  showLabel = true,
+  className,
+  title,
+}: {
+  speaker: string;
+  variant?: SpeakerVariant;
+  size?: number;
+  showLabel?: boolean;
+  className?: string;
+  title?: string;
+}) {
+  const resolved = resolveSpeaker(speaker);
+  const props = { resolved, size, showLabel, title, rootClass: rootClassFor(resolved.camp, variant, className) };
+  return variant === 'badge' ? <SpeakerBadge {...props} /> : <SpeakerGlyphAndLabel {...props} />;
+}
+
+function rootClassFor(camp: CampKey | undefined, variant: SpeakerVariant, className?: string): string {
+  return [`speaker-identity speaker-identity-${variant}`, camp && `camp-${camp}`, className]
+    .filter(Boolean)
+    .join(' ');
+}
+
+interface VariantProps {
+  resolved: ResolvedSpeaker;
+  rootClass: string;
+  size: number;
+  showLabel: boolean;
+  title?: string;
+}
+
+/**
+ * Solid-fill pill (diagnostics exchange). The accent travels as a background
+ * rather than `currentColor` because the label reverses out to white on top.
+ */
+function SpeakerBadge({ resolved: { label, color, camp }, rootClass, size, showLabel, title }: VariantProps) {
+  return (
+    /* eslint-disable-next-line local/no-inline-style -- accent is per-speaker data (POVER_INFO), not a static token */
+    <span className={rootClass} style={color ? { background: color } : undefined} title={title ?? label}>
+      {camp && <CampGlyph camp={camp} size={size} className="speaker-identity-glyph" />}
+      {showLabel && <span className="speaker-identity-label">{label}</span>}
+    </span>
+  );
+}
+
+/** Glyph + colored label — the `inline` (transcript) and `avatar` (chat) shapes. */
+function SpeakerGlyphAndLabel({ resolved: { label, color, camp }, rootClass, size, showLabel, title }: VariantProps) {
+  const accent = color ? { color } : undefined;
+  return (
+    <span className={rootClass} title={title ?? label}>
+      {camp && (
+        /* eslint-disable-next-line local/no-inline-style -- accent is per-speaker data; CampGlyph strokes currentColor */
+        <span className="speaker-identity-glyph-wrap" style={accent}>
+          <CampGlyph camp={camp} size={size} className="speaker-identity-glyph" />
+        </span>
+      )}
+      {/* eslint-disable-next-line local/no-inline-style -- accent is per-speaker data (POVER_INFO), not a static token */}
+      {showLabel && <span className="speaker-identity-label" style={accent}>{label}</span>}
+    </span>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.tsx
@@ -134,12 +134,16 @@ interface VariantProps {
 
 /**
  * Solid-fill pill (diagnostics exchange). The accent travels as a background
- * rather than `currentColor` because the label reverses out to white on top.
+ * rather than `currentColor` because the label reverses out to white on top —
+ * but only when there IS a fill. An unknown speaker resolves to no color, and
+ * white-on-`--bg-tertiary` would be invisible in the light themes, so the
+ * `-filled` modifier gates the reversal (TL flagged this in e/67#7).
  */
 function SpeakerBadge({ resolved: { label, color, camp }, rootClass, size, showLabel, title }: VariantProps) {
+  const className = color ? `${rootClass} speaker-identity-badge-filled` : rootClass;
   return (
     /* eslint-disable-next-line local/no-inline-style -- accent is per-speaker data (POVER_INFO), not a static token */
-    <span className={rootClass} style={color ? { background: color } : undefined} title={title ?? label}>
+    <span className={className} style={color ? { background: color } : undefined} title={title ?? label}>
       {camp && <CampGlyph camp={camp} size={size} className="speaker-identity-glyph" />}
       {showLabel && <span className="speaker-identity-label">{label}</span>}
     </span>


### PR DESCRIPTION
Part 1 of t/2242 (child of t/2234, design critique §2 + §6). **Rosetta Stone to review + land** per the split agreed in e/67 — this adds one new file plus tests and touches no existing shared code. No consumers change here; adoption lands per scope afterward, as Rosetta asked (land-order: component on main before any adopter imports it).

## What

Three surfaces answered "who is speaking" three different ways for the same four-camp taxonomy, with 3+ copies of the label/color lookup, plus a fourth path in diagnostics coloring regex-matched names through its own lowercase map with an `#888` fallback.

`resolveSpeaker(nameOrId)` is the single lookup. It accepts a canonical id, a display label, or a persona alias, in any case.

## The alias table is new, by necessity

Per TL (e/67#4) and confirmed by Rosetta against the soul docs (e/67#5): `Prometheus`/`Sentinel`/`Cassandra` existed **only** inside `DebateExchangeRich.tsx:9`'s segmentation regex — there is no canonical alias map anywhere. So this table becomes the source of truth, with a comment saying future aliases go here rather than into a consumer's regex.

**Behavior change worth calling out:** an unrecognized speaker now resolves to a titlecased label with **no color**, where `debaterColor` returned `#888`. Unstyled reads as "unknown"; a grey pill reads as a real camp. Adoption should expect that difference.

## Everything else composes what exists

- labels + colors → `POVER_INFO` (soul docs) — the same source `speakerLabel`/`speakerColor` already used
- camp + glyph → `povToCamp` + `CampGlyph`
- types → `SpeakerId` via the renderer's `@lib/debate/types` re-export

**One deviation to flag:** TL pointed at the camp type at `lib/debate/types/session.ts:585`, but that is an inline union inside `InterpretationRevisionProposal`, not an exported type. The exported equivalent is `SpeakerId` (`types/phase.ts:6`) with `PovKey`/`POV_KEYS` (`types/synthesis.ts:224`). I used `SpeakerId` and did not redefine anything — flagging in case a different type was meant.

## Variants

`inline` (transcript glyph + colored label), `avatar` (chat circular chip), `badge` (diagnostics solid pill). Each matches what its surface renders today so adoption is a swap, not a restyle. `showLabel={false}` gives glyph-only; a camp-less speaker renders label-only, which is what `INodeRow` needs.

## Verification

- 24/24 new tests: every POV, all three aliases, case/whitespace insensitivity, all four non-POV participants, unknown-speaker degradation, all three variants, glyph-only, badge fill, alias end-to-end, tooltip default + override
- `tsc -p tsconfig.main.json` clean (AC) · eslint 0 errors 0 warnings · depcruise 0 violations · `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)