### PR TITLE
fix(deps): force js-yaml >=4.3.1 via pnpm override (CVE-2026-59870, t/2253)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   ip-address: '>=10.3.1'
   uuid: '>=11.1.1'
   '@opentelemetry/core': '>=2.8.0'
+  js-yaml: '>=4.3.1'
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ overrides:
   ip-address: ">=10.3.1"
   uuid: ">=11.1.1"
   "@opentelemetry/core": ">=2.8.0"
+  js-yaml: ">=4.3.1"
 
 allowBuilds:
   '@google/genai': true

--- a/taxonomy-editor/pnpm-lock.yaml
+++ b/taxonomy-editor/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   ip-address: '>=10.3.1'
   uuid: '>=11.1.1'
   '@opentelemetry/core': '>=2.8.0'
+  js-yaml: '>=4.3.1'
 
 importers:
 
@@ -3579,8 +3580,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -8021,7 +8022,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.6.1
-      js-yaml: 4.3.0
+      js-yaml: 5.2.3
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -8322,7 +8323,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2(supports-color@10.2.2)
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
-      js-yaml: 4.3.0
+      js-yaml: 5.2.3
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -8552,7 +8553,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 5.2.3
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -8725,7 +8726,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
       builder-util: 26.15.3(supports-color@10.2.2)
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 5.2.3
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -9765,7 +9766,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary
- Adds `js-yaml: ">=4.3.1"` to `pnpm-workspace.yaml` overrides (resolves to 5.2.3)
- Regenerates standalone `taxonomy-editor/pnpm-lock.yaml` via `sync-standalone-lockfile.mjs`
- Clears Dependabot alert #319 (CVE-2026-59870 — quadratic CPU in `!!omap`)

**Exploitability:** DoS requires parsing attacker-controlled YAML with `!!omap`. No runtime path in this codebase parses user-supplied YAML, so real-world risk is low — but clearing a high advisory is the right call regardless.

## Test plan
- [ ] dependency-audit gate green (no new/un-baselined advisories)
- [ ] `pnpm install --frozen-lockfile` stays green (lockfile-overrides-check)
- [ ] test-container green (standalone lockfile synced correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
