### PR TITLE
fix(shared): restore reviewed SpeakerIdentity (#575) over mis-merged #574 (t/2242)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.css
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.css
@@ -1,34 +1,82 @@
-/* SpeakerIdentity — shared speaker identity component (t/2242) */
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
 
-.si-inline {
+/*
+ * Shared speaker identity (t/2242). One component, three shapes — each matching
+ * what its surface renders today, so adoption is a swap rather than a restyle.
+ */
+
+.speaker-identity {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  border-left: 3px solid transparent;
-  padding-left: 6px;
-  font-weight: 600;
-  font-size: 0.82rem;
-  line-height: 1.4;
+  gap: 6px;
+  min-width: 0;
 }
 
-.si-avatar {
-  display: flex;
+.speaker-identity-glyph-wrap {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: color-mix(in srgb, currentColor 15%, transparent);
   flex-shrink: 0;
-  overflow: hidden;
 }
 
-.si-badge {
-  display: inline-flex;
-  align-items: center;
+.speaker-identity-glyph {
+  flex-shrink: 0;
+}
+
+.speaker-identity-label {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── inline: transcript header ── */
+
+.speaker-identity-inline .speaker-identity-label {
+  font-size: var(--text-sm);
+}
+
+/* ── avatar: chat bubble — glyph in a tinted circle ── */
+
+.speaker-identity-avatar {
+  gap: 8px;
+}
+
+.speaker-identity-avatar .speaker-identity-glyph-wrap {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  justify-content: center;
+  background: color-mix(in srgb, currentColor 15%, transparent);
+}
+
+.speaker-identity-avatar .speaker-identity-label {
+  font-size: var(--text-sm);
+}
+
+/* ── badge: diagnostics exchange — solid fill, label reversed out ── */
+
+.speaker-identity-badge {
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+}
+
+.speaker-identity-badge .speaker-identity-label {
+  font-size: var(--text-2xs);
   font-weight: 700;
-  font-size: 0.72rem;
+  color: var(--text-primary);
+}
+
+/*
+ * White reverses out ONLY over a real accent fill. An unknown speaker gets no
+ * fill (resolveSpeaker returns no color), so an unconditional `#fff` here would
+ * print white on `--bg-tertiary` — invisible in the light/harvard/bkc themes.
+ * TL asked us to verify exactly this when endorsing the #888 → no-color change
+ * (e/67#7).
+ */
+.speaker-identity-badge-filled .speaker-identity-label,
+.speaker-identity-badge-filled .speaker-identity-glyph {
   color: #fff;
-  white-space: nowrap;
 }

--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.test.tsx
@@ -1,88 +1,141 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
-import { resolveSpeaker, SpeakerIdentity } from './SpeakerIdentity';
+// t/2242 — `resolveSpeaker` is the single speaker lookup replacing 3+ scattered
+// label/color copies and the diagnostics `debaterColor` map. The alias cases
+// matter most: `Prometheus`/`Sentinel`/`Cassandra` previously existed only in
+// DebateExchangeRich's segmentation regex, so this table is now the source of
+// truth for them (TL e/67#4).
 
-describe('resolveSpeaker', () => {
-  it('resolves canonical camp IDs', () => {
-    expect(resolveSpeaker('accelerationist')).toEqual({ label: 'Accelerationist', camp: 'acc', color: 'var(--color-acc)' });
-    expect(resolveSpeaker('safetyist')).toEqual({ label: 'Safetyist', camp: 'saf', color: 'var(--color-saf)' });
-    expect(resolveSpeaker('skeptic')).toEqual({ label: 'Skeptic', camp: 'skp', color: 'var(--color-skp)' });
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('../../types/debate', () => ({
+  POVER_INFO: {
+    accelerationist: { label: 'Accelerationist', color: 'var(--color-acc)' },
+    safetyist: { label: 'Safetyist', color: 'var(--color-saf)' },
+    skeptic: { label: 'Skeptic', color: 'var(--color-skp)' },
+  },
+}));
+
+import { SpeakerIdentity, resolveSpeaker } from './SpeakerIdentity';
+
+describe('resolveSpeaker — POV speakers', () => {
+  it.each([
+    ['accelerationist', 'Accelerationist', 'acc'],
+    ['safetyist', 'Safetyist', 'saf'],
+    ['skeptic', 'Skeptic', 'skp'],
+  ])('resolves %s to its label, color, and camp', (id, label, camp) => {
+    const r = resolveSpeaker(id);
+    expect(r).toMatchObject({ id, label, camp });
+    expect(r.color).toBeTruthy();
   });
 
-  it('resolves legacy persona aliases case-insensitively', () => {
-    expect(resolveSpeaker('Prometheus').camp).toBe('acc');
-    expect(resolveSpeaker('prometheus').camp).toBe('acc');
-    expect(resolveSpeaker('Sentinel').camp).toBe('saf');
-    expect(resolveSpeaker('CASSANDRA').camp).toBe('skp');
-  });
-
-  it('resolves fixed speakers', () => {
-    expect(resolveSpeaker('user')).toEqual({ label: 'You', camp: undefined, color: undefined });
-    expect(resolveSpeaker('moderator')).toEqual({ label: 'Moderator', camp: undefined, color: 'var(--color-moderator, #8b5cf6)' });
-    expect(resolveSpeaker('system')).toEqual({ label: 'System', camp: undefined, color: undefined });
-    expect(resolveSpeaker('document')).toEqual({ label: 'Document', camp: undefined, color: undefined });
-  });
-
-  it('falls back to the raw string for unknown speakers', () => {
-    expect(resolveSpeaker('unknown-bot')).toEqual({ label: 'unknown-bot', camp: undefined, color: undefined });
-    expect(resolveSpeaker('')).toEqual({ label: '', camp: undefined, color: undefined });
-  });
-
-  it('all three camps return distinct colors', () => {
-    const colors = ['accelerationist', 'safetyist', 'skeptic'].map(s => resolveSpeaker(s).color);
-    expect(new Set(colors).size).toBe(3);
-  });
-});
-
-describe('SpeakerIdentity — inline variant (default)', () => {
-  it('renders the resolved label', () => {
-    const { getByText } = render(<SpeakerIdentity speaker="accelerationist" />);
-    expect(getByText('Accelerationist')).toBeInTheDocument();
-  });
-
-  it('resolves legacy alias and renders camp label', () => {
-    const { getByText } = render(<SpeakerIdentity speaker="Prometheus" />);
-    expect(getByText('Accelerationist')).toBeInTheDocument();
-  });
-
-  it('applies si-inline class and camp modifier', () => {
-    const { container } = render(<SpeakerIdentity speaker="safetyist" />);
-    const el = container.firstChild as HTMLElement;
-    expect(el.className).toContain('si-inline');
-    expect(el.className).toContain('si-camp-saf');
-  });
-
-  it('forwards custom className', () => {
-    const { container } = render(<SpeakerIdentity speaker="skeptic" className="custom" />);
-    expect((container.firstChild as HTMLElement).className).toContain('custom');
+  it('accepts a display label, not just the canonical id', () => {
+    expect(resolveSpeaker('Safetyist')).toMatchObject({ id: 'safetyist', label: 'Safetyist', camp: 'saf' });
   });
 });
 
-describe('SpeakerIdentity — badge variant', () => {
-  it('applies si-badge class', () => {
+describe('resolveSpeaker — persona aliases (the regex this replaces)', () => {
+  it.each([
+    ['Prometheus', 'accelerationist', 'acc'],
+    ['Sentinel', 'safetyist', 'saf'],
+    ['Cassandra', 'skeptic', 'skp'],
+  ])('maps %s to its camp', (alias, id, camp) => {
+    expect(resolveSpeaker(alias)).toMatchObject({ id, camp });
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(resolveSpeaker('  pROMETHEUS ')).toMatchObject({ id: 'accelerationist', camp: 'acc' });
+  });
+});
+
+describe('resolveSpeaker — non-POV participants', () => {
+  it.each([
+    ['user', 'You'],
+    ['system', 'System'],
+    ['document', 'Document'],
+    ['moderator', 'Moderator'],
+  ])('labels %s as %s', (id, label) => {
+    expect(resolveSpeaker(id)).toMatchObject({ id, label });
+  });
+
+  it('gives none of them a camp, so no glyph is implied', () => {
+    for (const id of ['user', 'system', 'document', 'moderator']) {
+      expect(resolveSpeaker(id).camp).toBeUndefined();
+    }
+  });
+
+  it('colors only the moderator', () => {
+    expect(resolveSpeaker('moderator').color).toContain('--color-moderator');
+    expect(resolveSpeaker('user').color).toBeUndefined();
+    expect(resolveSpeaker('system').color).toBeUndefined();
+  });
+});
+
+describe('resolveSpeaker — unknown speakers', () => {
+  it('degrades to a titlecased label with NO color, never a fake camp accent', () => {
+    const r = resolveSpeaker('nemesis');
+    expect(r.label).toBe('Nemesis');
+    expect(r.color).toBeUndefined();
+    expect(r.camp).toBeUndefined();
+  });
+});
+
+describe('SpeakerIdentity rendering', () => {
+  it('renders glyph + label for a POV speaker', () => {
+    const { container } = render(<SpeakerIdentity speaker="accelerationist" />);
+    expect(screen.getByText('Accelerationist')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('omits the glyph for a speaker with no camp', () => {
+    const { container } = render(<SpeakerIdentity speaker="moderator" />);
+    expect(screen.getByText('Moderator')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('supports a glyph-only render', () => {
+    const { container } = render(<SpeakerIdentity speaker="skeptic" showLabel={false} />);
+    expect(screen.queryByText('Skeptic')).toBeNull();
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it.each(['inline', 'avatar', 'badge'] as const)('carries the %s variant and camp classes', (variant) => {
+    const { container } = render(<SpeakerIdentity speaker="safetyist" variant={variant} />);
+    const root = container.querySelector('.speaker-identity') as HTMLElement;
+    expect(root.classList.contains(`speaker-identity-${variant}`)).toBe(true);
+    expect(root.classList.contains('camp-saf')).toBe(true);
+  });
+
+  it('fills the badge with the accent, since its label reverses out to white', () => {
     const { container } = render(<SpeakerIdentity speaker="safetyist" variant="badge" />);
-    expect(container.querySelector('.si-badge')).toBeInTheDocument();
+    const root = container.querySelector('.speaker-identity-badge') as HTMLElement;
+    expect(root.style.background).toBeTruthy();
+    expect(root.classList.contains('speaker-identity-badge-filled')).toBe(true);
   });
 
-  it('uses camp color as background', () => {
-    const { container } = render(<SpeakerIdentity speaker="safetyist" variant="badge" />);
-    const el = container.querySelector('.si-badge') as HTMLElement;
-    expect(el.style.background).toBe('var(--color-saf)');
-  });
-});
-
-describe('SpeakerIdentity — avatar variant', () => {
-  it('applies si-avatar class', () => {
-    const { container } = render(<SpeakerIdentity speaker="skeptic" variant="avatar" />);
-    expect(container.querySelector('.si-avatar')).toBeInTheDocument();
+  // Legibility guard (TL e/67#7): white-on-white. An unknown speaker gets no
+  // accent fill, so the badge keeps its `--bg-tertiary` background — reversing
+  // the label out to white there would make it invisible in the light themes.
+  it('does NOT reverse an unfilled badge to white, so an unknown speaker stays legible', () => {
+    const { container } = render(<SpeakerIdentity speaker="nemesis" variant="badge" />);
+    const root = container.querySelector('.speaker-identity-badge') as HTMLElement;
+    expect(root.style.background).toBeFalsy();
+    expect(root.classList.contains('speaker-identity-badge-filled')).toBe(false);
+    expect(screen.getByText('Nemesis')).toBeInTheDocument();
   });
 
-  it('sets aria-label to the resolved label', () => {
-    const { container } = render(<SpeakerIdentity speaker="skeptic" variant="avatar" />);
-    const el = container.querySelector('.si-avatar') as HTMLElement;
-    expect(el.getAttribute('aria-label')).toBe('Skeptic');
+  it('resolves an alias end-to-end so a segmented transcript name renders correctly', () => {
+    render(<SpeakerIdentity speaker="Cassandra" variant="badge" />);
+    expect(screen.getByText('Skeptic')).toBeInTheDocument();
+  });
+
+  it('defaults its tooltip to the resolved label and lets a caller override', () => {
+    const { rerender, container } = render(<SpeakerIdentity speaker="skeptic" />);
+    expect(container.querySelector('.speaker-identity')).toHaveAttribute('title', 'Skeptic');
+
+    rerender(<SpeakerIdentity speaker="skeptic" title="Turn 4 — Skeptic" />);
+    expect(container.querySelector('.speaker-identity')).toHaveAttribute('title', 'Turn 4 — Skeptic');
   });
 });

--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.tsx
@@ -1,123 +1,168 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
+/**
+ * One "who is speaking" surface for the whole app (t/2242).
+ *
+ * Three independent systems used to answer this question for the same four-camp
+ * taxonomy: the transcript's glyph + colored label, the diagnostics exchange
+ * renderer's solid pill (colored through its own lowercase map with an `#888`
+ * fallback), and chat's circular avatar — plus 3+ copies of the label/color
+ * lookup scattered across components.
+ *
+ * `resolveSpeaker` is the single lookup, and per TL (e/67#4) it is the source of
+ * truth for the persona aliases: `Prometheus`/`Sentinel`/`Cassandra` existed
+ * ONLY inside the `DebateExchangeRich` segmentation regex, with no canonical map
+ * anywhere. Everything else composes existing foundations rather than
+ * re-authoring them — labels and colors come from `POVER_INFO` (the soul docs),
+ * camps from `povToCamp` + `CampGlyph`, and the POV key type from
+ * `@lib/debate/types`.
+ */
+
+import { POVER_INFO } from '../../types/debate';
+import type { SpeakerId } from '../../types/debate';
 import { CampGlyph, povToCamp } from './CampGlyph';
 import type { CampKey } from './CampGlyph';
 import './SpeakerIdentity.css';
 
-// ── Identity resolution ───────────────────────────────────
+/** Every speaker the UI can render, including the non-POV participants. */
+export type AnySpeaker = SpeakerId | 'system' | 'document' | 'moderator';
 
-const ALIAS_TO_CAMP: Record<string, CampKey> = {
-  accelerationist: 'acc',
-  safetyist: 'saf',
-  skeptic: 'skp',
-  // Legacy persona aliases (DebateExchangeRich segmentation source)
-  prometheus: 'acc',
-  sentinel: 'saf',
-  cassandra: 'skp',
-};
-
-const CAMP_LABEL: Record<CampKey, string> = {
-  acc: 'Accelerationist',
-  saf: 'Safetyist',
-  skp: 'Skeptic',
-};
-
-const CAMP_COLOR: Record<CampKey, string> = {
-  acc: 'var(--color-acc)',
-  saf: 'var(--color-saf)',
-  skp: 'var(--color-skp)',
-};
-
-const FIXED: Record<string, { label: string; color?: string }> = {
-  user:      { label: 'You' },
-  moderator: { label: 'Moderator', color: 'var(--color-moderator, #8b5cf6)' },
-  system:    { label: 'System' },
-  document:  { label: 'Document' },
-};
+export type SpeakerVariant = 'inline' | 'avatar' | 'badge';
 
 export interface ResolvedSpeaker {
+  /** Canonical id — the POV key, or the non-POV participant name. */
+  id: AnySpeaker;
+  /** Display label ("Accelerationist", "You", "Moderator", …). */
   label: string;
-  camp: CampKey | undefined;
-  color: string | undefined;
+  /** Accent color, or undefined for participants that carry no camp color. */
+  color?: string;
+  /** Camp key for glyph rendering; undefined for non-POV participants. */
+  camp?: CampKey;
 }
 
 /**
- * Canonical speaker resolver. Accepts any of:
- *   - Debate engine IDs ('accelerationist', 'safetyist', 'skeptic', 'user')
- *   - Legacy persona aliases ('Prometheus', 'Sentinel', 'Cassandra') — case-insensitive
- *   - Fixed roles ('moderator', 'system', 'document')
- *
- * Returns label + camp + CSS color. This is the single lookup replacing all
- * per-surface speaker maps and regex fallbacks (t/2242).
+ * Persona aliases → POV key. New table by necessity: TL confirmed (e/67#4) no
+ * canonical alias map exists anywhere in the tree, and Rosetta verified against
+ * the soul docs (e/67#5) that their `.label`s are the plain camp names, not the
+ * personas. Add future aliases HERE, not in a consumer's regex.
+ */
+const SPEAKER_ALIASES: Record<string, SpeakerId> = {
+  prometheus: 'accelerationist',
+  sentinel: 'safetyist',
+  cassandra: 'skeptic',
+};
+
+/** Non-POV participants. Mirrors the labels `debate-workspace/utils.ts` has always used. */
+const NON_POV_LABELS: Record<'system' | 'document' | 'moderator' | 'user', string> = {
+  system: 'System',
+  document: 'Document',
+  moderator: 'Moderator',
+  user: 'You',
+};
+
+const MODERATOR_COLOR = 'var(--color-moderator, #8b5cf6)';
+
+/**
+ * Resolve any speaker reference — canonical id, display label, or persona alias,
+ * in any case — to its identity. Unknown input degrades to a titlecased label
+ * with no color rather than the old `#888` fallback, so an unrecognized speaker
+ * reads as "unstyled", never as a real camp.
  */
 export function resolveSpeaker(nameOrId: string): ResolvedSpeaker {
-  const lower = nameOrId.toLowerCase();
-  const camp = ALIAS_TO_CAMP[lower] ?? povToCamp(lower);
-  if (camp) {
-    return { label: CAMP_LABEL[camp], camp, color: CAMP_COLOR[camp] };
+  const key = nameOrId.trim().toLowerCase();
+  const id = (SPEAKER_ALIASES[key] ?? key) as AnySpeaker;
+
+  if (id === 'system' || id === 'document' || id === 'moderator' || id === 'user') {
+    return {
+      id,
+      label: NON_POV_LABELS[id],
+      color: id === 'moderator' ? MODERATOR_COLOR : undefined,
+    };
   }
-  const fixed = FIXED[lower];
-  if (fixed) return { label: fixed.label, camp: undefined, color: fixed.color };
-  return { label: nameOrId, camp: undefined, color: undefined };
+
+  const info = POVER_INFO[id as Exclude<SpeakerId, 'user'>];
+  if (info) {
+    return { id, label: info.label, color: info.color, camp: povToCamp(id) };
+  }
+
+  return { id, label: nameOrId.charAt(0).toUpperCase() + nameOrId.slice(1) };
 }
 
-// ── Component ─────────────────────────────────────────────
-
-export interface SpeakerIdentityProps {
-  /** Speaker ID, full name, or legacy alias (Prometheus / Sentinel / Cassandra). */
+/**
+ * Speaker identity in one of three shapes:
+ * - `inline` — glyph + colored label (transcript header)
+ * - `avatar` — circular glyph chip + label (chat bubble)
+ * - `badge`  — solid-fill pill (diagnostics exchange)
+ *
+ * Pass `showLabel={false}` for glyph-only, or a speaker with no camp to get a
+ * label-only render (which is what `INodeRow` needs).
+ */
+export function SpeakerIdentity({
+  speaker,
+  variant = 'inline',
+  size = 16,
+  showLabel = true,
+  className,
+  title,
+}: {
   speaker: string;
-  /**
-   * Rendering mode:
-   * - 'inline'  — glyph + colored label with 3px left-border accent (transcript)
-   * - 'avatar'  — circular glyph container (chat bubbles)
-   * - 'badge'   — colored pill with white text (diagnostics exchange)
-   */
-  variant?: 'inline' | 'avatar' | 'badge';
-  /** Glyph size in px. Defaults: inline=16, avatar=14, badge=12. */
+  variant?: SpeakerVariant;
   size?: number;
+  showLabel?: boolean;
   className?: string;
+  title?: string;
+}) {
+  const resolved = resolveSpeaker(speaker);
+  const props = { resolved, size, showLabel, title, rootClass: rootClassFor(resolved.camp, variant, className) };
+  return variant === 'badge' ? <SpeakerBadge {...props} /> : <SpeakerGlyphAndLabel {...props} />;
 }
 
-export function SpeakerIdentity({ speaker, variant = 'inline', size, className }: SpeakerIdentityProps) {
-  const { label, camp, color } = resolveSpeaker(speaker);
-  const cls = (base: string) => `${base}${camp ? ` si-camp-${camp}` : ''}${className ? ` ${className}` : ''}`;
+function rootClassFor(camp: CampKey | undefined, variant: SpeakerVariant, className?: string): string {
+  return [`speaker-identity speaker-identity-${variant}`, camp && `camp-${camp}`, className]
+    .filter(Boolean)
+    .join(' ');
+}
 
-  if (variant === 'avatar') {
-    const sz = size ?? 14;
-    return (
-      <div
-        className={cls('si-avatar')}
-        style={{ color: color ?? 'var(--text-secondary)', width: sz, height: sz }}
-        aria-label={label}
-      >
-        {camp && <CampGlyph camp={camp} size={sz} />}
-      </div>
-    );
-  }
+interface VariantProps {
+  resolved: ResolvedSpeaker;
+  rootClass: string;
+  size: number;
+  showLabel: boolean;
+  title?: string;
+}
 
-  if (variant === 'badge') {
-    const sz = size ?? 12;
-    return (
-      <span
-        className={cls('si-badge')}
-        style={{ background: color ?? 'var(--text-secondary)' }}
-      >
-        {camp && <CampGlyph camp={camp} size={sz} />}
-        {label}
-      </span>
-    );
-  }
-
-  // inline (default)
-  const sz = size ?? 16;
+/**
+ * Solid-fill pill (diagnostics exchange). The accent travels as a background
+ * rather than `currentColor` because the label reverses out to white on top —
+ * but only when there IS a fill. An unknown speaker resolves to no color, and
+ * white-on-`--bg-tertiary` would be invisible in the light themes, so the
+ * `-filled` modifier gates the reversal (TL flagged this in e/67#7).
+ */
+function SpeakerBadge({ resolved: { label, color, camp }, rootClass, size, showLabel, title }: VariantProps) {
+  const className = color ? `${rootClass} speaker-identity-badge-filled` : rootClass;
   return (
-    <span
-      className={cls('si-inline')}
-      style={{ color: color ?? undefined, borderLeftColor: color ?? 'transparent' }}
-    >
-      {camp && <CampGlyph camp={camp} size={sz} />}
-      {label}
+    /* eslint-disable-next-line local/no-inline-style -- accent is per-speaker data (POVER_INFO), not a static token */
+    <span className={className} style={color ? { background: color } : undefined} title={title ?? label}>
+      {camp && <CampGlyph camp={camp} size={size} className="speaker-identity-glyph" />}
+      {showLabel && <span className="speaker-identity-label">{label}</span>}
+    </span>
+  );
+}
+
+/** Glyph + colored label — the `inline` (transcript) and `avatar` (chat) shapes. */
+function SpeakerGlyphAndLabel({ resolved: { label, color, camp }, rootClass, size, showLabel, title }: VariantProps) {
+  const accent = color ? { color } : undefined;
+  return (
+    <span className={rootClass} title={title ?? label}>
+      {camp && (
+        /* eslint-disable-next-line local/no-inline-style -- accent is per-speaker data; CampGlyph strokes currentColor */
+        <span className="speaker-identity-glyph-wrap" style={accent}>
+          <CampGlyph camp={camp} size={size} className="speaker-identity-glyph" />
+        </span>
+      )}
+      {/* eslint-disable-next-line local/no-inline-style -- accent is per-speaker data (POVER_INFO), not a static token */}
+      {showLabel && <span className="speaker-identity-label" style={accent}>{label}</span>}
     </span>
   );
 }


### PR DESCRIPTION
## Why this PR exists
Two duplicate PRs added `shared/SpeakerIdentity.*` for t/2242: **#574** (single commit, earlier) and **#575** (reviewed + approved). **#574 was merged to main by mistake**, shipping the inferior version, and **#575 then went CONFLICTING** and could not land.

Main currently has #574''s version, which is **missing the badge-legibility fix**: an unfilled/unknown speaker badge renders `#fff` on `--bg-tertiary` = white-on-light, **invisible in the light/harvard/bkc themes** (the exact case TL flagged in e/67#7). It also has 13 tests vs #575''s 25.

## What this does
Replaces the three `SpeakerIdentity` files on main with **#575''s reviewed content verbatim** — the version TL endorsed (e/67) and I reviewed/approved (e/67#12):
- `resolveSpeaker` single lookup (POVER_INFO + persona-alias table; no `#888` fallback)
- `speaker-identity-badge-filled` modifier gating the white reversal → unfilled badges fall back to `--text-primary` (fixes the invisible-badge bug now on main)
- 25 tests incl. alias/case/whitespace/unknown-degradation + the legibility regression test

Original component authored by the t/2242 lead (019fddc2). #574 is closed as the duplicate; #575 closed (its content lands here).

## Test plan
- [ ] CI green (renderer-tsc / test-electron / test-container / CodeQL)

Fixes the main regression from the #574 mis-merge · t/2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)