### PR TITLE
feat(bridge): default DEBATE_CHAT_REDESIGN ON for local/Electron (t/2257)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -371,11 +371,11 @@ export const api: AppAPI = {
   onBriefRetriesExhausted: (cb) => window.electronAPI.onBriefRetriesExhausted(cb),
   captureScreenshot: (opts) => window.electronAPI.captureScreenshot(opts),
 
-  // Feature flags — desktop has no server. Source DEBATE_CHAT_REDESIGN from a
-  // build-time env var (VITE_DEBATE_CHAT_REDESIGN) for local testing; default
-  // false → existing UX intact. (t/2235)
+  // Feature flags — desktop has no server. DEBATE_CHAT_REDESIGN defaults ON for
+  // the local/Electron build (t/2257); opt out with VITE_DEBATE_CHAT_REDESIGN=false.
+  // Web/server default is separate (companion Azure ticket, gated on t/2243).
   getFlags: () => Promise.resolve({
-    DEBATE_CHAT_REDESIGN: import.meta.env.VITE_DEBATE_CHAT_REDESIGN === 'true',
+    DEBATE_CHAT_REDESIGN: import.meta.env.VITE_DEBATE_CHAT_REDESIGN !== 'false',
   }),
 
   // UsageID registry — stub (desktop has no server-side usage registry)


### PR DESCRIPTION
## Summary
Owner decision (t/2234 rollout): default the Debate/Chat redesign **ON for the local/Electron build**. One-liner in `electron-bridge.ts` `getFlags()`:

```ts
DEBATE_CHAT_REDESIGN: import.meta.env.VITE_DEBATE_CHAT_REDESIGN !== 'false',
```

- Default **ON** (unset or any value other than the literal `'false'` → true)
- Opt out with `VITE_DEBATE_CHAT_REDESIGN=false`
- **No web/server default change** — that's the separate companion Azure ticket (gated on t/2243)

Completed flagged UX (t/2238–2241) shows immediately; SpeakerIdentity (t/2242, #577) and streaming (t/2251) appear incrementally as they land — default-on causes no breakage.

## Test plan
- [x] renderer-tsc `0 / 0 errors (OK)`
- [x] bridge vitest 96/96 (AppAPI completeness guard passes; no test asserted the old default)
- [ ] CI green

Closes t/2257

🤖 Generated with [Claude Code](https://claude.com/claude-code)