### PR TITLE
feat(chat): adopt canonical streaming in ChatWorkspace (t/2251)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.tsx
@@ -27,7 +27,7 @@ import { useTierInfo, isFreeTier } from '../../hooks/useTierInfo';
 import { GeminiOnboardingModal } from '../settings/GeminiOnboardingModal';
 import { CampGlyph, povToCamp } from '../shared/CampGlyph';
 import { EmptyState } from '../shared/EmptyState';
-import { ThinkingIndicator, MessageBubble } from '../shared/ChatBubble';
+import { ThinkingIndicator, MessageBubble, StreamingBubble } from '../shared/ChatBubble';
 import './ChatWorkspace.css';
 
 // ── Helpers ──────────────────────────────────────────────
@@ -187,7 +187,7 @@ function ChatMessage({ entry, selectedRef, onSelectRef }: { entry: ChatEntry; se
 // ── Progress indicator ───────────────────────────────────
 
 function ProgressIndicator() {
-  const { chatProgress, chatActivity } = useChatStore();
+  const chatActivity = useChatStore(s => s.chatActivity);
 
   if (!chatActivity) return null;
 
@@ -197,12 +197,6 @@ function ProgressIndicator() {
         <span>{chatActivity}</span>
         <span className="dot-animation" />
       </span>
-      {chatProgress && chatProgress.attempt > 1 && (
-        <span className="chat-generating-retry">
-          Retry {chatProgress.attempt}/{chatProgress.maxRetries}
-          {chatProgress.backoffSeconds ? ` (${chatProgress.backoffSeconds}s)` : ''}
-        </span>
-      )}
     </ThinkingIndicator>
   );
 }
@@ -414,9 +408,10 @@ function ChatTranscript({ activeChat, chatGenerating, chatActivity, selectedRef,
   onSelectRef: (ref: EntityRef | null) => void;
   transcriptEndRef: React.RefObject<HTMLDivElement | null>;
 }) {
+  const chatStreamingText = useChatStore(s => s.chatStreamingText);
   return (
     <div className="chat-transcript">
-      {activeChat.transcript.length === 0 && chatGenerating ? (
+      {activeChat.transcript.length === 0 && chatGenerating && chatStreamingText == null ? (
         <div className="chat-generating-hero">
           <div className="chat-generating-spinner" />
           <span>{chatActivity || 'Preparing conversation...'}</span>
@@ -426,7 +421,15 @@ function ChatTranscript({ activeChat, chatGenerating, chatActivity, selectedRef,
           {activeChat.transcript.map((entry) => (
             <ChatMessage key={entry.id} entry={entry} selectedRef={selectedRef} onSelectRef={onSelectRef} />
           ))}
-          <ProgressIndicator />
+          {chatStreamingText != null ? (
+            <div className="chat-message">
+              <div className="chat-message-body">
+                <StreamingBubble content={chatStreamingText} className="chat-message-content markdown-body prose" />
+              </div>
+            </div>
+          ) : (
+            <ProgressIndicator />
+          )}
         </>
       )}
       <div ref={transcriptEndRef} />

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
@@ -9,11 +9,10 @@ const { mockApi } = vi.hoisted(() => {
     loadChatSession: vi.fn(),
     saveChatSession: vi.fn().mockResolvedValue(undefined),
     deleteChatSession: vi.fn().mockResolvedValue(undefined),
-    generateText: vi.fn().mockResolvedValue({ text: '{"response":"hello","taxonomy_refs":[]}' }),
-    onGenerateTextProgress: vi.fn().mockReturnValue(() => {}),
     setDebateTemperature: vi.fn().mockResolvedValue(undefined),
     hasApiKey: vi.fn().mockResolvedValue(true),
-    startChatStream: vi.fn().mockResolvedValue('streamed-text'),
+    startChatStream: vi.fn().mockResolvedValue('{"response":"hello","taxonomy_refs":[]}'),
+    onChatStreamChunk: vi.fn().mockReturnValue(() => {}),
     trackEvent: vi.fn(),
   };
   return { mockApi };
@@ -84,7 +83,7 @@ describe('useChatStore', () => {
       chatLoading: false,
       chatGenerating: false,
       chatError: null,
-      chatProgress: null,
+      chatStreamingText: null,
       chatActivity: null,
       chatModel: null,
     });
@@ -211,7 +210,6 @@ describe('useChatStore', () => {
 
       await useChatStore.getState().sendMessage('duplicate request');
 
-      expect(mockApi.generateText).not.toHaveBeenCalled();
       expect(mockApi.startChatStream).not.toHaveBeenCalled();
     });
 
@@ -223,8 +221,59 @@ describe('useChatStore', () => {
 
       await useChatStore.getState().generateOpening();
 
-      expect(mockApi.generateText).not.toHaveBeenCalled();
       expect(mockApi.startChatStream).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('streaming (t/2251)', () => {
+    it('transcript entry content equals concatenated stream chunks', async () => {
+      const chunks = ['Hello', ', ', 'world', '!'];
+      let chunkCb: ((chunk: string) => void) | null = null;
+
+      mockApi.onChatStreamChunk.mockImplementationOnce((cb: (chunk: string) => void) => {
+        chunkCb = cb;
+        return () => { chunkCb = null; };
+      });
+      mockApi.startChatStream.mockImplementationOnce(async () => {
+        chunks.forEach(c => chunkCb?.(c));
+        return chunks.join('');
+      });
+      mockApi.listChatSessions.mockResolvedValueOnce([]);
+
+      useChatStore.setState({
+        activeChat: makeChatSession({
+          transcript: [{ id: 'e1', timestamp: '2026-01-01T00:00:00Z', speaker: 'accelerationist', content: 'Opening', taxonomy_refs: [] }],
+        }) as never,
+      });
+
+      await useChatStore.getState().sendMessage('follow-up');
+
+      const state = useChatStore.getState();
+      const lastEntry = state.activeChat!.transcript[state.activeChat!.transcript.length - 1];
+      expect(lastEntry.content).toBe(chunks.join(''));
+      expect(state.chatStreamingText).toBeNull();
+      expect(state.chatGenerating).toBe(false);
+    });
+
+    it('chatStreamingText is cleared on error', async () => {
+      mockApi.onChatStreamChunk.mockImplementationOnce((cb: (chunk: string) => void) => {
+        cb('partial');
+        return () => {};
+      });
+      mockApi.startChatStream.mockRejectedValueOnce(new Error('stream failed'));
+      mockApi.listChatSessions.mockResolvedValue([]);
+
+      useChatStore.setState({
+        activeChat: makeChatSession({
+          transcript: [{ id: 'e1', timestamp: '2026-01-01T00:00:00Z', speaker: 'accelerationist', content: 'Hi', taxonomy_refs: [] }],
+        }) as never,
+      });
+
+      await useChatStore.getState().sendMessage('test');
+
+      const state = useChatStore.getState();
+      expect(state.chatStreamingText).toBeNull();
+      expect(state.chatError).toContain('Response failed');
     });
   });
 });

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -45,21 +45,22 @@ function getConfiguredModel(): string {
   }
 }
 
-async function generateTextWithProgress(
-  prompt: string,
+async function streamChatWithProgress(
+  systemInstruction: string,
+  messages: { role: 'user' | 'model'; content: string }[],
   model: string,
+  temperature: number,
   activity: string,
   set: (partial: Partial<ChatStore>) => void,
-): Promise<{ text: string }> {
-  set({ chatActivity: activity, chatProgress: null });
-  const unsubscribe = api.onGenerateTextProgress((progress) => {
-    set({ chatProgress: progress as ChatStore['chatProgress'] });
-  });
+  onChunk: (chunk: string) => void,
+): Promise<string> {
+  set({ chatActivity: activity, chatStreamingText: null });
+  const unsubChunk = api.onChatStreamChunk(onChunk);
   try {
-    return await api.generateText(prompt, model);
+    return await api.startChatStream(systemInstruction, messages, model, temperature);
   } finally {
-    unsubscribe();
-    set({ chatProgress: null, chatActivity: null });
+    unsubChunk();
+    set({ chatStreamingText: null, chatActivity: null });
   }
 }
 
@@ -130,7 +131,7 @@ interface ChatStore {
   chatLoading: boolean;
   chatGenerating: boolean;
   chatError: string | null;
-  chatProgress: { attempt: number; maxRetries: number; backoffSeconds?: number; limitType?: string; limitMessage?: string } | null;
+  chatStreamingText: string | null;
   chatActivity: string | null;
   chatModel: string | null;
 
@@ -142,6 +143,7 @@ interface ChatStore {
   renameChat: (id: string, newTitle: string) => Promise<void>;
   changeMode: (mode: ChatMode) => Promise<void>;
   saveChat: () => Promise<void>;
+  appendStreamingText: (chunk: string) => void;
   sendMessage: (message: string) => Promise<void>;
   generateOpening: () => Promise<void>;
 }
@@ -154,7 +156,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   chatLoading: false,
   chatGenerating: false,
   chatError: null,
-  chatProgress: null,
+  chatStreamingText: null,
   chatActivity: null,
   chatModel: null,
 
@@ -267,36 +269,43 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     await api.saveChatSession(updated);
   },
 
+  appendStreamingText: (chunk) => {
+    set((state) => ({ chatStreamingText: (state.chatStreamingText ?? '') + chunk }));
+  },
+
   generateOpening: async () => {
     const { activeChat, saveChat, chatGenerating } = get();
     if (!activeChat || activeChat.transcript.length > 0 || chatGenerating) return;
 
     const isStillValid = createChatGuard(get);
-    set({ chatGenerating: true, chatError: null });
+    set({ chatGenerating: true, chatError: null, chatStreamingText: null });
 
     try {
       const info = POVER_INFO[activeChat.pover];
       const ctx = getTaxonomyContext(info.pov);
       const taxonomyBlock = formatTaxonomyContext(ctx, info.pov, undefined, CHAT_CONTEXT_CONFIG);
       const model = getConfiguredModel();
+      const temperature = CHAT_MODE_TEMPERATURE[activeChat.mode];
 
-      // Set per-mode temperature before generating
-      await api.setDebateTemperature(CHAT_MODE_TEMPERATURE[activeChat.mode]);
-
-      const systemBlock = chatSystemPrompt(
+      const systemInstruction = chatSystemPrompt(
         info.label, info.pov, info.personality,
         activeChat.mode, activeChat.topic, taxonomyBlock,
       );
-      const userBlock = chatOpeningPrompt(activeChat.mode, activeChat.topic);
-      const prompt = `${systemBlock}\n\n${userBlock}`;
+      const userContent = chatOpeningPrompt(activeChat.mode, activeChat.topic);
 
-      const result = await generateTextWithProgress(
-        prompt, model, `${info.label} is thinking...`, set,
+      const fullText = await streamChatWithProgress(
+        systemInstruction,
+        [{ role: 'user', content: userContent }],
+        model,
+        temperature,
+        `${info.label} is thinking...`,
+        set,
+        (chunk) => get().appendStreamingText(chunk),
       );
 
       if (!isStillValid()) return;
 
-      const { response, taxonomyRefs } = parseChatResponse(result.text);
+      const { response, taxonomyRefs } = parseChatResponse(fullText);
 
       const entry: ChatEntry = {
         id: generateId(),
@@ -319,7 +328,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       set({ sessions: sessions as ChatSessionSummary[] });
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-store', level: 'error', message: 'Failed to generate opening message', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      set({ chatError: `Failed to start conversation: ${mapErrorToUserMessage(err)}` });
+      set({ chatError: `Failed to start conversation: ${mapErrorToUserMessage(err)}`, chatStreamingText: null });
     } finally {
       set({ chatGenerating: false });
     }
@@ -330,7 +339,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     if (!activeChat || !message.trim() || chatGenerating) return;
 
     const isStillValid = createChatGuard(get);
-    set({ chatGenerating: true, chatError: null });
+    set({ chatGenerating: true, chatError: null, chatStreamingText: null });
 
     // Add user message to transcript
     const userEntry: ChatEntry = {
@@ -366,11 +375,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       const ctx = getTaxonomyContext(info.pov);
       const taxonomyBlock = formatTaxonomyContext(ctx, info.pov, undefined, CHAT_CONTEXT_CONFIG);
       const model = getConfiguredModel();
+      const temperature = CHAT_MODE_TEMPERATURE[activeChat.mode];
 
-      // Set per-mode temperature before generating
-      await api.setDebateTemperature(CHAT_MODE_TEMPERATURE[activeChat.mode]);
-
-      const systemBlock = chatSystemPrompt(
+      const systemInstruction = chatSystemPrompt(
         info.label, info.pov, info.personality,
         activeChat.mode, activeChat.topic, taxonomyBlock,
       );
@@ -386,16 +393,21 @@ export const useChatStore = create<ChatStore>((set, get) => ({
           return firstSentence.trim();
         })
         .filter(Boolean);
-      const userBlock = chatContinuationPrompt(message.trim(), transcriptText, priorClaims);
-      const prompt = `${systemBlock}\n\n${userBlock}`;
+      const userContent = chatContinuationPrompt(message.trim(), transcriptText, priorClaims);
 
-      const result = await generateTextWithProgress(
-        prompt, model, `${info.label} is thinking...`, set,
+      const fullText = await streamChatWithProgress(
+        systemInstruction,
+        [{ role: 'user', content: userContent }],
+        model,
+        temperature,
+        `${info.label} is thinking...`,
+        set,
+        (chunk) => get().appendStreamingText(chunk),
       );
 
       if (!isStillValid()) return;
 
-      const { response, taxonomyRefs } = parseChatResponse(result.text);
+      const { response, taxonomyRefs } = parseChatResponse(fullText);
 
       const poverEntry: ChatEntry = {
         id: generateId(),
@@ -419,7 +431,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     } catch (err) {
       if (!isStillValid()) return;
       getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-store', level: 'error', message: 'Failed to send chat message', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      set({ chatError: `Response failed: ${mapErrorToUserMessage(err)}` });
+      set({ chatError: `Response failed: ${mapErrorToUserMessage(err)}`, chatStreamingText: null });
     } finally {
       set({ chatGenerating: false });
     }


### PR DESCRIPTION
## Summary
- Adds `chatStreamingText: string | null` to `useChatStore`; switches `generateOpening`/`sendMessage` from `api.generateText` to `api.startChatStream` + `api.onChatStreamChunk`
- `StreamingBubble` (from `shared/ChatBubble.tsx`) renders while streaming; `ThinkingIndicator` shown only during the thinking phase (before first chunk)
- `chatStreamingText` cleared at the top of each call and on error/abort (TL conditions 1 + 2)
- Removes dead state (`chatProgress`) after the old `generateText` path is gone (TL condition 4)
- Two new tests: transcript content equals concatenated chunks; `chatStreamingText` cleared on error (TL condition 3)

## Design
- TL approval: e/68#2 (conditions 1–4 enumerated there)
- `streamChatWithProgress` replaces `generateTextWithProgress`; accepts `onChunk` callback so chunk accumulation stays in store action scope via `get().appendStreamingText`
- `StreamingBubble` wrapped in `.chat-message > .chat-message-body` with `className="chat-message-content markdown-body prose"` — same visual treatment as committed assistant messages, inline styles suppressed
- Hero state (empty transcript, generating, no chunks yet) preserved; transitions to `StreamingBubble` on first chunk

## Test plan
- [x] `bash scripts/check-renderer-tsc.sh` — 0/0 errors
- [x] `tsc -p tsconfig.main.json --noEmit` — clean
- [x] `tsc -p tsconfig.server.json --noEmit` — clean
- [x] `eslint src/ --max-warnings=4256` — 661 warnings (well under ceiling)
- [x] `npm run depcruise` — no violations
- [x] `vitest run src/renderer/hooks/useChatStore.test.ts` — 13/13 pass (incl. 2 new streaming tests)
- [x] `vite build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)