### PR TITLE
fix(debate-workspace): restore glyph contrast in the unified phase indicator (t/2238)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.css
@@ -47,10 +47,33 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus-ring) 20%, transparent);
 }
 
+/*
+ * Dark's `--focus-ring` is a light blue (#60a5fa), where the white step numeral
+ * lands at ~2.5:1. Dark-on-light-blue gives ~6.7:1. The predecessor dodged this
+ * by using `var(--accent, #3b82f6)` — but `--accent` is undefined app-wide, so
+ * it silently pinned one fixed blue in every theme; the token here is real, and
+ * only dark needs the glyph inverted.
+ */
+[data-theme="dark"] .unified-phase-step.active .unified-phase-dot {
+  color: var(--bg-primary);
+}
+
 .unified-phase-step.completed .unified-phase-dot {
   border-color: var(--success);
   background: var(--success);
   color: #fff;
+}
+
+/*
+ * bkc's `--success` is neon (#00ff4c, luminance 0.72), so the white checkmark
+ * above lands at ~1.4:1 — effectively invisible. Dark-on-neon instead gives
+ * ~12:1. The other three themes keep the white glyph, which their darker greens
+ * carry. Caught auditing the flag-on path before DEBATE_CHAT_REDESIGN defaults
+ * ON (t/2257); the theme-aware token is otherwise an improvement over the
+ * hardcoded #10b981 this replaced — it is only bkc that inverts.
+ */
+[data-theme="bkc"] .unified-phase-step.completed .unified-phase-dot {
+  color: #1f1f1f;
 }
 
 .unified-phase-label {


### PR DESCRIPTION
Pre-flip audit finding, ahead of t/2257 / #578 defaulting `DEBATE_CHAT_REDESIGN` ON for local/Electron.

## Why now

Every flagged surface in t/2234 shipped with "no visual sign-off — flag is off by default." #578 retires that assumption. I audited my flag-on CSS against all four themes' token values and found two unreadable glyphs.

## Findings fixed here

| Theme | Element | Before | After |
|---|---|---|---|
| bkc | completed-step checkmark | **~1.4:1** (white on neon `#00ff4c`) | ~12:1 |
| dark | active-step numeral | **~2.5:1** (white on `#60a5fa`) | ~6.7:1 |

Both trace to the same root cause, and it is not a mistake in the tokens — it is that this widget uses *real* theme tokens where the predecessor used hardcoded values:

- completed fill was `#10b981` hardcoded → now `var(--success)`
- active fill was `var(--accent, #3b82f6)` → but **`--accent` is undefined app-wide**, so that silently pinned one blue across all four themes

Theme-awareness is the right call and it *improves* harvard (2.4:1 → 6.4:1) and bkc's active dot. It just needs the glyph inverted on the two themes whose fill is light. Fixed with two scoped `[data-theme=…]` overrides rather than by reverting to hardcodes.

## Deliberately NOT fixed here

Small green text on light backgrounds — the "Approaching transition" hint at `--text-2xs` in `--success` — is **~2.3:1 in the light theme**, failing AA. But the existing `PhaseProgressBar` hint it mirrors is `#10b981` at ~2.6:1, equally failing. This is a pre-existing app-wide token gap (there is no dark-green "success text" token), and picking a value is a design decision, not one to invent in a bug fix. Raising separately for Design.

Same for `--bg-tertiary`, which is referenced 40× across the renderer and **defined nowhere** — cosmetic, already noted by Rosetta on the SpeakerIdentity review.

## Verification

- Contrast computed from the actual `styles.css` token values per theme (WCAG relative luminance), not eyeballed
- 286/286 tests pass across debate-workspace + SpeakerIdentity · eslint 0 errors · vite build clean
- CSS-only change; no flag-off path touched (both overrides sit under `.unified-phase-*`, which only renders flag-on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)