### PR TITLE
feat(debate-diagnostics): adopt SpeakerIdentity in DebateExchangeRich and INodeRow (t/2259)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/DebateExchangeRich.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/DebateExchangeRich.tsx
@@ -3,8 +3,11 @@
 
 import { useMemo } from 'react';
 import { debaterColor } from './constants';
+import { useFlag } from '../../../../hooks/useFeatureFlags';
+import { SpeakerIdentity } from '../../../shared/SpeakerIdentity';
 
 export function DebateExchangeRich({ content }: { content: string }) {
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
   const segments = useMemo(() => {
     const speakerRe = /^(Accelerationist|Safetyist|Skeptic|Prometheus|Sentinel|Cassandra)\s*(\[[^\]]*\])?:\s*/gm;
     const matches: { index: number; end: number; speaker: string; tag?: string }[] = [];
@@ -35,12 +38,13 @@ export function DebateExchangeRich({ content }: { content: string }) {
         <div key={i} style={{ marginBottom: 8 }}>
           {seg.speaker && (
             <div style={{ marginBottom: 3 }}>
-              <span style={{
-                display: 'inline-block', padding: '2px 8px', borderRadius: 4, fontWeight: 700, fontSize: '0.72rem',
-                color: '#fff', background: debaterColor(seg.speaker),
-              }}>
-                {seg.speaker}
-              </span>
+              {chatRedesign
+                ? <SpeakerIdentity speaker={seg.speaker} variant="badge" />
+                : <span style={{
+                    display: 'inline-block', padding: '2px 8px', borderRadius: 4, fontWeight: 700, fontSize: '0.72rem',
+                    color: '#fff', background: debaterColor(seg.speaker),
+                  }}>{seg.speaker}</span>
+              }
               {seg.tag && (
                 <span style={{ marginLeft: 6, fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', fontStyle: 'italic' }}>{seg.tag}</span>
               )}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
@@ -3,6 +3,8 @@
 
 import './INodeRow.css';
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { useFlag } from '../../../../hooks/useFeatureFlags';
+import { resolveSpeaker } from '../../../shared/SpeakerIdentity';
 import type { ArgumentNetworkNode, ArgumentNetworkEdge } from '../../../../types/debate';
 import { POVER_INFO } from '../../../../types/debate';
 import type { SpeakerId } from '../../../../types/debate';
@@ -179,7 +181,8 @@ function IdStatementCell({ node, statementId, searchQuery, onGotoEntry }: {
 
 /** Col 2: Speaker label with descriptive tooltip. */
 function SpeakerCell({ node }: { node: ArgumentNetworkNode }) {
-  const label = speakerLabel(node.speaker);
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
+  const label = chatRedesign ? resolveSpeaker(node.speaker).label : speakerLabel(node.speaker);
   const desc: Record<string, string> = {
     Accelerationist: 'Accelerationist — advocates rapid AI development',
     Safetyist: 'Safetyist — prioritizes AI safety and alignment',
@@ -350,10 +353,11 @@ function DebaterBlock({ expanded, sourceNode, onGotoEntry, stmtIdByEntry, search
   searchQuery?: string;
   gotoClassName: string;
 }) {
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
   if (!(expanded && sourceNode)) return null;
   return (
     <div className="inr-debater-block">
-      <span className="inr-text-muted">Debater:</span> <strong>{speakerLabel(sourceNode.speaker)}</strong>
+      <span className="inr-text-muted">Debater:</span> <strong>{chatRedesign ? resolveSpeaker(sourceNode.speaker).label : speakerLabel(sourceNode.speaker)}</strong>
       {onGotoEntry && sourceNode.source_entry_id && (
         <button
           onClick={() => onGotoEntry(sourceNode.source_entry_id)}


### PR DESCRIPTION
## Summary

- Gate `DebateExchangeRich` speaker pill on `DEBATE_CHAT_REDESIGN`: flag-on renders `<SpeakerIdentity variant="badge" />`, flag-off keeps the existing inline `debaterColor` span
- Gate `SpeakerCell` and `DebaterBlock` in `INodeRow` on `DEBATE_CHAT_REDESIGN`: flag-on calls `resolveSpeaker(speaker).label`, flag-off keeps local `speakerLabel()` function
- Both files import `useFlag` from `../../../../hooks/useFeatureFlags` and the new shared utilities from `../../../shared/SpeakerIdentity` (corrected from spec: `SpeakerIdentity.tsx` is at `components/shared/`, 3 levels up from `window/shared/`, not 4)

## Test plan

- [ ] TSC clean: `npx tsc -p tsconfig.main.json --noEmit` exits 0
- [ ] Scoped vitest: 451 tests pass; 2 pre-existing worktree failures (jszip/zod) unaffected by this change
- [ ] Flag-off: speaker display unchanged from current behavior
- [ ] Flag-on (`DEBATE_CHAT_REDESIGN=true`): `DebateExchangeRich` renders `SpeakerIdentity` badge; `INodeRow` speaker cells use `resolveSpeaker().label`

🤖 Generated with [Claude Code](https://claude.com/claude-code)