### PR TITLE
fix(shared): filled speaker badge AA contrast in dark/bkc (t/2263)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.css
+++ b/taxonomy-editor/src/renderer/components/shared/SpeakerIdentity.css
@@ -80,3 +80,17 @@
 .speaker-identity-badge-filled .speaker-identity-glyph {
   color: #fff;
 }
+
+/*
+ * ...but in the dark and bkc themes the camp fills (--color-acc/saf/skp) are
+ * LIGHT, so white-on-fill fails AA (6/12 combos, 2.39–3.18:1). Reverse out to
+ * --bg-primary instead there — a dark foreground on the light fill — which lands
+ * every failing combo at 5.18–7.42:1. light/harvard keep #fff (their fills are
+ * dark: 5.08–7.48:1). Verified against all 12 theme×camp combos (t/2263).
+ */
+[data-theme="dark"] .speaker-identity-badge-filled .speaker-identity-label,
+[data-theme="dark"] .speaker-identity-badge-filled .speaker-identity-glyph,
+[data-theme="bkc"] .speaker-identity-badge-filled .speaker-identity-label,
+[data-theme="bkc"] .speaker-identity-badge-filled .speaker-identity-glyph {
+  color: var(--bg-primary);
+}


### PR DESCRIPTION
## Live AA defect (default-on main)
The filled `SpeakerIdentity` badge reversed its label/glyph to `#fff` over the camp accent fill (`--color-acc/saf/skp`). In dark + bkc those fills are **light**, so white-on-fill failed WCAG AA in **6/12 theme×camp combos** (2.39–3.18:1). Live since #578 flipped `DEBATE_CHAT_REDESIGN` on by default.

## Fix (verified, all 12 combos)
Reverse the label/glyph out to `var(--bg-primary)` under `[data-theme="dark"|"bkc"]` — a dark foreground on the light fill — same root cause + remedy as the #581 phase glyphs.

| | dark fills | bkc fills |
|---|---|---|
| **after** (`--bg-primary`) | acc 7.42 · saf 6.82 · skp 5.95 | acc 5.20 · saf 5.23 · skp 5.18 |

light/harvard keep `#fff` (dark fills, 5.08–7.48:1). `inline`/`avatar` variants unaffected (camp color on bg, not reversed).

Fix authored by DebateWorkspace (e/70#3), Design-endorsed (e/70#6), TL "land now" (e/70#8); I re-verified all 12 combos independently before landing.

## Test plan
- [x] renderer-tsc `0 / 0`
- [x] SpeakerIdentity vitest 25/25 (structure intact; contrast is jsdom-invisible — the t/2264 lint will make this class CI-catchable)
- [ ] CI green

Closes t/2263

🤖 Generated with [Claude Code](https://claude.com/claude-code)