### PR TITLE
feat(chat): adopt SpeakerIdentity in ChatWorkspace, PromptDiffTree, PromptDiffPane (t/2255)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.tsx
@@ -26,8 +26,10 @@ import { useGeminiOnboarding } from '../../hooks/useGeminiOnboarding';
 import { useTierInfo, isFreeTier } from '../../hooks/useTierInfo';
 import { GeminiOnboardingModal } from '../settings/GeminiOnboardingModal';
 import { CampGlyph, povToCamp } from '../shared/CampGlyph';
+import { SpeakerIdentity } from '../shared/SpeakerIdentity';
 import { EmptyState } from '../shared/EmptyState';
 import { ThinkingIndicator, MessageBubble, StreamingBubble } from '../shared/ChatBubble';
+import { useFlag } from '../../hooks/useFeatureFlags';
 import './ChatWorkspace.css';
 
 // ── Helpers ──────────────────────────────────────────────
@@ -161,14 +163,17 @@ function ChatMessage({ entry, selectedRef, onSelectRef }: { entry: ChatEntry; se
   const isUser = entry.speaker === 'user';
   const camp = povToCamp(entry.speaker);
   const mdComponents = useMemo(() => ({ span: makeRefLinkSpan(onSelectRef) }), [onSelectRef]);
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
 
   return (
     <div className={`chat-message chat-speaker-${entry.speaker}${isUser ? ' chat-message-user' : ''}`}>
-      {camp && (
-        <div className={`chat-message-avatar camp-${camp}`}>
-          <CampGlyph camp={camp} size={14} />
-        </div>
-      )}
+      {chatRedesign
+        ? <SpeakerIdentity variant="avatar" speaker={entry.speaker} />
+        : (camp && (
+          <div className={`chat-message-avatar camp-${camp}`}>
+            <CampGlyph camp={camp} size={14} />
+          </div>
+        ))}
       <div className="chat-message-body">
         <div className="chat-message-header">
           <span className={`chat-message-speaker${camp ? ` camp-speaker-${camp}` : ''}`}>

--- a/taxonomy-editor/src/renderer/components/chat/PromptDiffPane.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/PromptDiffPane.tsx
@@ -8,6 +8,8 @@ import type { CitationResolutionDiagnostics } from '@lib/debate/citationResoluti
 import { POVER_INFO } from '../../types/debate';
 import type { SpeakerId } from '../../types/debate';
 import { humanizeSpeakerIds } from '../../utils/humanizeSpeakers';
+import { resolveSpeaker } from '../shared/SpeakerIdentity';
+import { useFlag } from '../../hooks/useFeatureFlags';
 import './PromptDiffPane.css';
 
 const STAGE_COLORS: Record<string, string> = {
@@ -913,6 +915,7 @@ function PaneHeader({ node, viewMode, pane, stats, isReference, paneIndex, preSc
   onClose: () => void;
   stageColor: string;
 }) {
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
   return (
     <div className="pdp-header">
       {node.kind === 'tool-call' ? (
@@ -925,7 +928,7 @@ function PaneHeader({ node, viewMode, pane, stats, isReference, paneIndex, preSc
         <StageBadges node={node} viewMode={viewMode} stageColor={stageColor} />
       )}
       <span className="pdp-muted">
-        S{node.entryIndex + 1} {speakerLabel(node.speaker)}
+        S{node.entryIndex + 1} {chatRedesign ? resolveSpeaker(node.speaker).label : speakerLabel(node.speaker)}
       </span>
       <span className="pdp-2xs-muted">
         ({pane.lines.filter(l => l.type !== 'ghost').length} lines)

--- a/taxonomy-editor/src/renderer/components/chat/PromptDiffTree.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/PromptDiffTree.tsx
@@ -7,6 +7,8 @@ import { DEFAULT_MODEL } from '@lib/ai-client/defaults';
 import { POVER_INFO } from '../../types/debate';
 import type { SpeakerId, DebateSession, TurnAttempt } from '../../types/debate';
 import type { CitationResolutionDiagnostics } from '@lib/debate/citationResolution.js';
+import { resolveSpeaker } from '../shared/SpeakerIdentity';
+import { useFlag } from '../../hooks/useFeatureFlags';
 
 export type DiffViewMode = 'prompts' | 'responses';
 
@@ -289,6 +291,7 @@ export function PromptDiffTree({ debate, focusedEntryId, onSelectNode, selectedN
     new Set(focusedEntryId ? [focusedEntryId] : [])
   );
   const [expandedStages, setExpandedStages] = useState<Set<string>>(new Set());
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
 
   const toggleEntry = useCallback((id: string) => {
     setExpandedEntries(prev => {
@@ -429,7 +432,7 @@ export function PromptDiffTree({ debate, focusedEntryId, onSelectNode, selectedN
                 {hasPrompts ? (isExpanded ? '▼' : '▶') : '·'}
               </span>
               <span className="pdt-fw-600">S{idx + 1}</span>
-              <span>{speakerLabel(entry.speaker)}</span>
+              <span>{chatRedesign ? resolveSpeaker(entry.speaker).label : speakerLabel(entry.speaker)}</span>
               <span className="pdt-muted-2xs">({entry.type})</span>
               {totalRuns > 1 && (
                 <span className="pdt-muted-2xs">


### PR DESCRIPTION
## Summary

- `ChatWorkspace` `ChatMessage`: replaces manual `CampGlyph` div with `<SpeakerIdentity variant="avatar" />` under `DEBATE_CHAT_REDESIGN` gate; flag-off path unchanged
- `PromptDiffTree`: `resolveSpeaker(entry.speaker).label` under gate; flag-off keeps local `speakerLabel()`
- `PromptDiffPane` `PaneHeader`: `resolveSpeaker(node.speaker).label` under gate; flag-off keeps local `speakerLabel()`

Adoption child of t/2242. All three sites gated on `DEBATE_CHAT_REDESIGN` per TL design (e/67).

## Contrast analysis (e/70#7)

- **avatar variant**: camp color on page background, not reversed — 5.08–7.42:1 all 4 themes (per e/70#3 audit). Safe.
- **PromptDiff* resolveSpeaker**: text-only label swap, no color or visual element added. Safe.

## Test plan

- [ ] tsc: clean (verified locally)
- [ ] ESLint: 1 pre-existing warning on line 399 (inline style, unrelated), within 4256 max-warnings gate
- [ ] CI green
- [ ] 4-theme Electron visual pass as fast-follow (Design owns per e/70#6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
