### PR TITLE
docs(ux): document --bg-tertiary token (t/2261)

### DIFF
--- a/docs/ux/design-system.md
+++ b/docs/ux/design-system.md
@@ -45,6 +45,7 @@ All colors are CSS custom properties on `:root` scoped by `data-theme`.
 |---|---|
 | `--bg-primary` | Main content background |
 | `--bg-secondary` | Alternate rows, subtle sections |
+| `--bg-tertiary` | Neutral chip/inset surface, one step past `--bg-secondary` toward `--border-color` (midpoint: light #edf1f6, dark #2b3544, bkc #3b2d3c, harvard #e5e0d8; ~40 sites; defined t/2261, e/70 Finding 3) |
 | `--bg-panel` | Panel backgrounds, dividers |
 | `--bg-input` | Input field backgrounds |
 | `--bg-hover` | Hover states |


### PR DESCRIPTION
Documents the --bg-tertiary neutral-surface token (defined across 4 themes in #589). Closes the design-system documentation for e/70 Finding 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)