### PR TITLE
feat(server): flip DEBATE_CHAT_REDESIGN seed default ON (t/2258)

### DIFF
--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -109,8 +109,8 @@ const SEED_FLAGS: Record<string, FlagDef> = {
     created_by: 'seed',
   },
   'DEBATE_CHAT_REDESIGN': {
-    name: 'DEBATE_CHAT_REDESIGN', enabled: false, scope: 'global',
-    description: 'Gate new debate chat UX (t/2235); toggleable via admin flag CRUD',
+    name: 'DEBATE_CHAT_REDESIGN', enabled: true, scope: 'global',
+    description: 'Gate new debate chat UX — ON by default (t/2258 rollout)',
     created_at: '2026-08-07T00:00:00.000Z', updated_at: '2026-08-07T00:00:00.000Z',
     created_by: 'seed',
   },


### PR DESCRIPTION
## Summary

- Flips \DEBATE_CHAT_REDESIGN\ seed default from \alse\ to \	rue\ in \eatureFlags.ts\
- All preconditions met: t/2243 (crash-risk guard) landed, t/2242 (SpeakerIdentity adoptions) landed
- Fresh deployments now serve the redesign by default; existing Azure instances with an overriding \eature-flags.json\ are unaffected until DevOps flips the deployed flag value via admin CRUD

## Test plan

- featureFlags.test.ts (16/16) pass — seed count and flag resolution already covered
- Server tsc clean

**Post-merge:** DevOps must flip \DEBATE_CHAT_REDESIGN: true\ in the deployed \eature-flags.json\ on staging then prod (seed alone does not override an existing deployed file — see merge logic at featureFlags.ts:142).

Co-Authored-By: ServerAPI (Orca) <main.taxonomy-editor-src-server@ai-triad-research.orca.local>