### PR TITLE
feat(debate-workspace): widen debate prose to 95ch + apply to fact-check panels

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -54,14 +54,27 @@
 }
 
 /*
- * Readable measure for debate prose (t/2240, DEBATE_CHAT_REDESIGN). Chat already
- * caps its AI markdown at 68ch (ChatWorkspace.css); the debate surface — longer
- * sessions, denser text — was the one left unconstrained. Same value so the two
- * surfaces read as one system. `.debate-redesign` lands on the card root only
- * when the flag is on, so the flag-off measure stays `none`.
+ * Readable measure for debate prose (t/2240, DEBATE_CHAT_REDESIGN). Chat caps
+ * its AI markdown at 68ch (ChatWorkspace.css); the debate surface — longer
+ * sessions, denser text — was the one left unconstrained. Widened to 95ch so
+ * the transcript fills more of the window while still capping line length for
+ * readability (the 68ch measure left too much empty space beside the text on
+ * wide windows). `.debate-redesign` lands on the card root only when the flag
+ * is on, so the flag-off measure stays `none`.
  */
 .debate-statement.debate-redesign .debate-statement-content.prose {
-  max-width: 68ch;
+  max-width: 95ch;
+}
+
+/*
+ * Same 95ch readable measure for fact-check panels. FactCheckCard is a separate
+ * component from StatementCard and its text containers aren't `.prose`, so the rule
+ * above doesn't reach them — cap them directly so both surfaces read as one system.
+ * Flag-gated via `.debate-redesign` on the card root, so flag-off stays full-width.
+ */
+.debate-statement.debate-type-fact-check.debate-redesign .debate-statement-content,
+.debate-statement.debate-type-fact-check.debate-redesign .debate-fact-check-web-evidence-body {
+  max-width: 95ch;
 }
 
 /* Model badge — hoisted from inline */

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -1432,6 +1432,9 @@ export function FactCheckCard({ entry, statementId, findQuery = '', matchOffset 
   const activeDebate = useDebateStore(s => s.activeDebate);
   const [showWebEvidence, setShowWebEvidence] = useState(false);
   const factCheck = entry.metadata?.fact_check as FactCheckMeta | undefined;
+  // Same scoping hook as StatementCard — carries the 95ch prose measure (t/2240)
+  // onto fact-check panels so both surfaces read as one system.
+  const chatRedesign = useFlag('DEBATE_CHAT_REDESIGN');
 
   const verdictClass = factCheck?.verdict
     ? `debate-fact-check-${factCheck.verdict}`
@@ -1441,7 +1444,7 @@ export function FactCheckCard({ entry, statementId, findQuery = '', matchOffset 
   const hasWebEvidence = !!(factCheck?.web_search_used || factCheck?.web_search_evidence || citations.length > 0);
 
   return (
-    <div className={`debate-statement debate-type-fact-check debate-speaker-system ${verdictClass}`}>
+    <div className={`debate-statement debate-type-fact-check debate-speaker-system ${verdictClass}${chatRedesign ? ' debate-redesign' : ''}`}>
       <FactCheckHeader
         statementId={statementId}
         factCheck={factCheck}


### PR DESCRIPTION
Widens the debate-prose readable measure from 68ch to 95ch (t/2240 follow-up) — the 68ch cap left too much empty space beside debate text on wide windows — and extends the same 95ch measure to fact-check panels, which were previously uncapped/full-width.

**Why two files:** `FactCheckCard` is a separate component from `StatementCard`; its text containers use `.markdown-body` (not `.prose`) and its root never got the `debate-redesign` scope, so the debate-prose rule never reached them. Added the flag hook + scope class to the card and a matching CSS cap.

Flag-gated via `.debate-redesign` on the card root — flag-off behavior is unchanged (debate stays `none`, fact-check stays full-width).

Verified locally: `tsc --noEmit` clean; StatementCard prose + factCheck vitest 7/7 pass.

Requested by Jeff (screenshot flagged the whitespace). DebateWorkspace notified (p/131).