### PR TITLE
ci(gate): static token-contrast ratchet check (t/2264)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,31 @@ jobs:
       - name: Renderer type-check
         run: bash taxonomy-editor/scripts/check-renderer-tsc.sh
 
+  # ── contrast-check: static token-contrast ratchet gate (t/2264) ──
+  # Catches text reversed out over a tokenized fill that is light in some themes —
+  # the defect class vitest/jsdom is structurally blind to (applies no stylesheet).
+  # Four live defects (t/2234) were all this shape; all found by hand only.
+  # check-contrast.sh reads styles.css live (not a snapshot) and compares total
+  # findings against quality-gates.json contrast_ceilings (ceiling 314 on landing,
+  # ratchets down as pre-existing findings are fixed). Every new violation is a
+  # hard failure immediately. No pnpm install needed — zero node_modules deps.
+  # Path-filtered to `electron` changes (CSS lives under taxonomy-editor/).
+  contrast-check:
+    needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.electron == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        with:
+          node-version: '22'
+
+      - name: Static token-contrast check
+        run: bash taxonomy-editor/scripts/check-contrast.sh
+
   # ── Dependency audit: standalone security gate (t/1800) ──
   # SPLIT OUT of test-electron so a security-audit failure can never skip Test
   # again (the t/1800 false-green: audit sat before Test with no
@@ -808,9 +833,11 @@ jobs:
   # path-filtered to container/lib changes, skip = OK.
   # lib-lint (t/2217) is gated here: ESLint errors + tsc for shared lib;
   # path-filtered to lib changes, skip = OK.
+  # contrast-check (t/2264) is gated here: static token-contrast ratchet,
+  # path-filtered to electron changes, skip = OK.
   ci-gate:
     name: ci-gate
-    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc]
+    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/quality-gates.json
+++ b/quality-gates.json
@@ -6,5 +6,8 @@
   "max_file_bytes": 5242880,
   "tsc_error_ceilings": {
     "taxonomy-editor/tsconfig.json": 0
+  },
+  "contrast_ceilings": {
+    "taxonomy-editor/scripts/check-contrast.mjs": 314
   }
 }

--- a/taxonomy-editor/scripts/__fixtures__/contrast/cases.css
+++ b/taxonomy-editor/scripts/__fixtures__/contrast/cases.css
@@ -1,0 +1,61 @@
+/* Fixture cases for the contrast checker's self-test (t/2264).
+   Each block reproduces one shape from the real t/2234 defect corpus. */
+
+/* PASS — white on a dark fill (same block). */
+.fx-ok-same-block {
+  background: var(--fill-dark);
+  color: #fff;
+}
+
+/* FAIL — white on a light fill (same block). Shape of the phase-indicator glyphs. */
+.fx-fail-same-block {
+  background: var(--fill-light);
+  color: #fff;
+}
+
+/* FAIL — fill on the ancestor, text on a descendant. Shape of the badge defects;
+   a checker matching only same-block pairs misses this entirely. */
+.fx-ancestor {
+  background: var(--fill-light);
+}
+.fx-ancestor .fx-child {
+  color: #fff;
+}
+
+/* PASS — theme-scoped override inverts the glyph where the fill is light.
+   The override must cover EVERY theme whose fill is light: `:root` seeds all
+   four, so leaving bkc/harvard out reproduces the original defect there. That
+   is precisely the mistake the shipped fixes had to avoid. */
+.fx-scoped {
+  background: var(--fill-light);
+  color: #fff;
+}
+[data-theme="light"] .fx-scoped,
+[data-theme="bkc"] .fx-scoped,
+[data-theme="harvard"] .fx-scoped {
+  color: #111827;
+}
+[data-theme="dark"] .fx-scoped {
+  color: var(--bg-primary);
+}
+
+/* UNRESOLVABLE — fill token defined nowhere. Shape of the white-on-`--bg-tertiary`
+   defect: must be reported, never silently treated as "no background". */
+.fx-undefined-fill {
+  background: var(--fx-does-not-exist);
+  color: #fff;
+}
+
+/* FAIL — fill supplied at runtime via inline style, declared to the checker.
+   Shape of the filled-badge defect, invisible to CSS-only analysis. */
+/* contrast-fill: var(--fill-light), var(--fill-dark) */
+.fx-annotated .fx-label {
+  color: #fff;
+}
+
+/* PASS — translucent fill composited over the page surface, not compared raw.
+   Without alpha compositing this reads as a 1:1 false positive. */
+.fx-alpha {
+  background: rgba(184, 78, 19, 0.12);
+  color: #6b3a10;
+}

--- a/taxonomy-editor/scripts/__fixtures__/contrast/theme-tokens.css
+++ b/taxonomy-editor/scripts/__fixtures__/contrast/theme-tokens.css
@@ -1,0 +1,15 @@
+/* Fixture theme palette for the contrast checker's self-test (t/2264).
+   Mirrors the shape of styles.css: a :root base plus per-theme overrides. */
+
+:root,
+[data-theme="light"] {
+  --bg-primary: #ffffff;
+  --fill-dark: #b84e13;   /* dark fill  → white text passes */
+  --fill-light: #22c55e;  /* light fill → white text fails  */
+}
+
+[data-theme="dark"] {
+  --bg-primary: #111827;
+  --fill-dark: #a35012;
+  --fill-light: #60a5fa;
+}

--- a/taxonomy-editor/scripts/check-contrast.mjs
+++ b/taxonomy-editor/scripts/check-contrast.mjs
@@ -1,0 +1,504 @@
+#!/usr/bin/env node
+// Static token-contrast check (t/2264).
+//
+// Catches the defect class our test suite is structurally blind to: text
+// reversed out over a tokenized fill that is light in some themes. vitest runs
+// under jsdom, which applies no stylesheet, so no DOM-structure test can ever
+// evaluate computed color — every instance of this class (four in t/2234) was
+// found by hand-computing WCAG ratios against styles.css.
+//
+// Unlike scripts/check-camp-contrast.mjs, which hardcodes a snapshot of the
+// theme palette, this reads styles.css as the source of truth, so it cannot
+// drift from the real tokens.
+//
+// Usage:
+//   node scripts/check-contrast.mjs [--all] [--json]
+//     --all   also scan styles.css itself (noisy: pre-existing findings)
+//     --include-page-bg   also check text with no explicit fill against the
+//                         page surface (a broad AA audit, not this gate's class)
+//     --json  machine-readable output
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const RENDERER = join(ROOT, 'src', 'renderer');
+const STYLES = join(RENDERER, 'styles.css');
+
+const AA_NORMAL = 4.5;
+const AA_LARGE = 3.0; // >=24px, or >=18.66px bold
+const ROOT_FONT_PX = 16;
+
+// ── WCAG math (same as check-camp-contrast.mjs) ──────────────
+
+const lin = (c) => (c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+
+function luminance([r, g, b]) {
+  return 0.2126 * lin(r / 255) + 0.7152 * lin(g / 255) + 0.0722 * lin(b / 255);
+}
+
+function contrast(rgbA, rgbB) {
+  const [a, b] = [luminance(rgbA), luminance(rgbB)];
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+// ── CSS parsing ──────────────────────────────────────────────
+// Hand-rolled rather than postcss: the renderer's CSS is plain (no nesting),
+// and a zero-dependency check is easier for DevOps to wire into ci-gate.
+
+/** Strip comments, but first harvest `contrast-fill` annotations (see below). */
+function extractAnnotations(css) {
+  const anns = [];
+  const re = /\/\*\s*contrast-fill:\s*([^*]+?)\s*\*\/\s*([^{]+)\{/g;
+  let m;
+  while ((m = re.exec(css)) !== null) {
+    // A rule can list several selectors; the annotation applies to each.
+    const selectors = m[2].split(',').map((s) => s.trim()).filter(Boolean);
+    anns.push({ selectors, fills: m[1].split(',').map((s) => s.trim()) });
+  }
+  return anns;
+}
+
+function parseRules(css) {
+  const src = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rules = [];
+
+  const walk = (text) => {
+    let i = 0;
+    let buf = '';
+    while (i < text.length) {
+      const ch = text[i];
+      if (ch === '{') {
+        const selector = buf.trim();
+        let depth = 1;
+        let j = i + 1;
+        while (j < text.length && depth > 0) {
+          if (text[j] === '{') depth++;
+          else if (text[j] === '}') depth--;
+          if (depth > 0) j++;
+        }
+        const body = text.slice(i + 1, j);
+        if (selector.startsWith('@')) {
+          // @media / @supports wrap rules; @keyframes bodies are not rules we check.
+          if (!/^@(keyframes|font-face|import|charset)/.test(selector)) walk(body);
+        } else {
+          rules.push({ selector, decls: parseDecls(body) });
+        }
+        i = j + 1;
+        buf = '';
+        continue;
+      }
+      buf += ch;
+      i++;
+    }
+  };
+
+  walk(src);
+  return rules;
+}
+
+function parseDecls(body) {
+  const decls = {};
+  // Only top-level declarations (nested blocks were consumed by walk()).
+  for (const part of body.split(';')) {
+    if (part.includes('{')) continue;
+    const idx = part.indexOf(':');
+    if (idx === -1) continue;
+    const prop = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    if (prop && value) decls[prop] = value;
+  }
+  return decls;
+}
+
+// ── Theme token maps ─────────────────────────────────────────
+
+const THEMES = ['light', 'dark', 'bkc', 'harvard'];
+
+function buildThemeTokens(stylesFile = STYLES) {
+  const rules = parseRules(readFileSync(stylesFile, 'utf8'));
+  const tokens = Object.fromEntries(THEMES.map((t) => [t, {}]));
+
+  for (const { selector, decls } of rules) {
+    const targets = new Set();
+    for (const sel of selector.split(',').map((s) => s.trim())) {
+      if (sel === ':root') THEMES.forEach((t) => targets.add(t)); // :root is the base for all
+      const m = sel.match(/\[data-theme=["']?([a-z]+)["']?\]/);
+      if (m && THEMES.includes(m[1])) targets.add(m[1]);
+    }
+    if (!targets.size) continue;
+    for (const [prop, value] of Object.entries(decls)) {
+      if (!prop.startsWith('--')) continue;
+      for (const t of targets) tokens[t][prop] = value;
+    }
+  }
+  return tokens;
+}
+
+// ── Color resolution ─────────────────────────────────────────
+
+const NAMED = {
+  white: [255, 255, 255],
+  black: [0, 0, 0],
+  transparent: null,
+};
+
+class Unresolved extends Error {
+  constructor(token) {
+    super(`undefined token ${token}`);
+    this.token = token;
+  }
+}
+
+function parseHex(hex) {
+  let h = hex.slice(1);
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (h.length === 8) {
+    const rgb = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+    return [...rgb, parseInt(h.slice(6, 8), 16) / 255];
+  }
+  if (h.length !== 6) return null;
+  return [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+}
+
+/** Split a function's argument list on top-level commas. */
+function splitArgs(s) {
+  const out = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of s) {
+    if (ch === '(') depth++;
+    if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      out.push(cur.trim());
+      cur = '';
+      continue;
+    }
+    cur += ch;
+  }
+  if (cur.trim()) out.push(cur.trim());
+  return out;
+}
+
+/**
+ * Resolve a CSS color value to [r,g,b] for a given theme.
+ * Returns null for values that carry no color (transparent, none, currentColor
+ * with no context). Throws Unresolved for an undefined custom property — that
+ * is its own error class deliberately: silent fallthrough is exactly what hid
+ * the white-on-`--bg-tertiary` defect, and a checker that treats an unknown
+ * token as "no color" reproduces the blind spot it exists to catch.
+ */
+function resolveColor(value, tokens, seen = new Set()) {
+  if (!value) return null;
+  const v = value.trim();
+
+  if (v.startsWith('#')) return parseHex(v);
+  if (v in NAMED) return NAMED[v];
+  if (v === 'currentColor' || v === 'inherit' || v === 'none') return null;
+
+  const varM = v.match(/^var\(\s*(--[\w-]+)\s*(?:,\s*([\s\S]+))?\)$/);
+  if (varM) {
+    const [, token, fallback] = varM;
+    if (seen.has(token)) return null; // cycle guard
+    seen.add(token);
+    const defined = tokens[token];
+    if (defined !== undefined) return resolveColor(defined, tokens, seen);
+    if (fallback !== undefined) return resolveColor(fallback, tokens, seen);
+    throw new Unresolved(token);
+  }
+
+  const rgbM = v.match(/^rgba?\(([^)]+)\)$/);
+  if (rgbM) {
+    const parts = rgbM[1].split(/[\s,/]+/).filter(Boolean).map(Number);
+    if (parts.length >= 3 && parts.slice(0, 3).every((n) => !Number.isNaN(n))) {
+      // Keep alpha: a translucent fill must be composited over what is behind
+      // it, or `rgba(R,G,B,.12)` under `color: rgb(R,G,B)` reads as a 1:1
+      // false positive — the single most common chip pattern in this codebase.
+      const a = parts.length >= 4 && !Number.isNaN(parts[3]) ? parts[3] : 1;
+      return [parts[0], parts[1], parts[2], a];
+    }
+    return null;
+  }
+
+  // color-mix(in srgb, A p%, B) — approximate in sRGB. Good enough to rank a
+  // pair against a 4.5:1 threshold; flagged as approximate in the report.
+  const mixM = v.match(/^color-mix\(\s*in\s+[\w-]+\s*,\s*([\s\S]+)\)$/);
+  if (mixM) {
+    const args = splitArgs(mixM[1]);
+    if (args.length !== 2) return null;
+    const parse = (arg) => {
+      const pm = arg.match(/^([\s\S]+?)\s+([\d.]+)%$/);
+      return pm ? { color: pm[1], pct: parseFloat(pm[2]) / 100 } : { color: arg, pct: null };
+    };
+    const a = parse(args[0]);
+    const b = parse(args[1]);
+    const aPct = a.pct ?? (b.pct !== null ? 1 - b.pct : 0.5);
+    const ca = resolveColor(a.color, tokens, new Set(seen));
+    const cb = resolveColor(b.color, tokens, new Set(seen));
+    if (!ca || !cb) return null; // mixing with transparent → treat as unknown
+    return [0, 1, 2].map((i) => Math.round(ca[i] * aPct + cb[i] * (1 - aPct)));
+  }
+
+  return null;
+}
+
+/**
+ * Flatten a possibly-translucent color onto an opaque base. Alpha is normal
+ * source-over compositing; WCAG ratios are only meaningful between opaque
+ * colors, so every pair is flattened before comparison.
+ */
+function flatten(color, base) {
+  if (!color) return null;
+  const a = color.length === 4 ? color[3] : 1;
+  if (a >= 1) return color.slice(0, 3);
+  if (!base) return null;
+  return [0, 1, 2].map((i) => Math.round(color[i] * a + base[i] * (1 - a)));
+}
+
+// ── Selector indexing ────────────────────────────────────────
+
+/** `[data-theme="dark"] .a .b` → { theme: 'dark', base: '.a .b' } */
+function splitThemeScope(sel) {
+  const m = sel.match(/\[data-theme=["']?([a-z]+)["']?\]\s*/);
+  if (!m) return { theme: null, base: sel.trim() };
+  return { theme: m[1], base: sel.replace(m[0], '').trim() || ':root' };
+}
+
+/**
+ * Candidate ancestor selectors whose background could apply, nearest first.
+ * `.a .b.c` → ['.a .b.c', '.a .b', '.a .c', '.a'] — the compound split matters:
+ * the badge defects put the fill on `.speaker-identity-badge` while the text
+ * sits on `.speaker-identity-badge .speaker-identity-label`, so a checker that
+ * only looks at the same declaration block misses half the real corpus.
+ */
+function ancestorCandidates(base) {
+  const parts = base.split(/\s+/).filter(Boolean);
+  const out = [];
+  for (let i = parts.length; i > 0; i--) {
+    const chain = parts.slice(0, i);
+    out.push(chain.join(' '));
+    const last = chain[chain.length - 1];
+    const classes = last.match(/\.[\w-]+/g) || [];
+    if (classes.length > 1) {
+      for (const c of classes) out.push([...chain.slice(0, -1), c].join(' '));
+    }
+  }
+  return out;
+}
+
+function sizeThreshold(decls, tokens) {
+  const fsRaw = decls['font-size'];
+  const weight = parseInt(decls['font-weight'] || '400', 10);
+  let px = ROOT_FONT_PX;
+  if (fsRaw) {
+    let v = fsRaw.trim();
+    const varM = v.match(/^var\(\s*(--[\w-]+)/);
+    if (varM && tokens[varM[1]]) v = tokens[varM[1]].trim();
+    const rem = v.match(/^([\d.]+)rem$/);
+    const pxm = v.match(/^([\d.]+)px$/);
+    if (rem) px = parseFloat(rem[1]) * ROOT_FONT_PX;
+    else if (pxm) px = parseFloat(pxm[1]);
+  }
+  const large = px >= 24 || (px >= 18.66 && weight >= 700);
+  return { px, weight, min: large ? AA_LARGE : AA_NORMAL };
+}
+
+// ── Main check ───────────────────────────────────────────────
+
+function cssFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) out.push(...cssFiles(p));
+    else if (entry.endsWith('.css')) out.push(p);
+  }
+  return out;
+}
+
+export function check({
+  all = false,
+  includePageBg = false,
+  rendererDir = RENDERER,
+  stylesFile = STYLES,
+} = {}) {
+  const themeTokens = buildThemeTokens(stylesFile);
+  const findings = [];
+  const undefinedTokens = new Map();
+
+  const files = cssFiles(rendererDir).filter((f) => all || f !== stylesFile);
+
+  for (const file of files) {
+    const css = readFileSync(file, 'utf8');
+    const annotations = extractAnnotations(css);
+    const rules = parseRules(css);
+
+    // base selector -> theme ('*' for unscoped) -> decls
+    const index = new Map();
+    for (const { selector, decls } of rules) {
+      for (const sel of selector.split(',').map((s) => s.trim())) {
+        if (!sel) continue;
+        const { theme, base } = splitThemeScope(sel);
+        if (!index.has(base)) index.set(base, {});
+        const slot = index.get(base);
+        const key = theme || '*';
+        slot[key] = { ...(slot[key] || {}), ...decls };
+      }
+    }
+
+    const declsFor = (base, theme) => {
+      const slot = index.get(base);
+      if (!slot) return null;
+      return { ...(slot['*'] || {}), ...(slot[theme] || {}) };
+    };
+
+    for (const [base, slot] of index) {
+      const hasColorAnywhere = Object.values(slot).some((d) => d.color);
+      if (!hasColorAnywhere) continue;
+
+      for (const theme of THEMES) {
+        const tokens = themeTokens[theme];
+        const decls = declsFor(base, theme);
+        if (!decls?.color) continue;
+
+        let fg;
+        try {
+          fg = resolveColor(decls.color, tokens);
+        } catch (e) {
+          if (e instanceof Unresolved) {
+            undefinedTokens.set(e.token, (undefinedTokens.get(e.token) || 0) + 1);
+            continue;
+          }
+          throw e;
+        }
+        if (!fg) continue;
+
+        // Background: own rule, else nearest ancestor, else the page surface.
+        const backgrounds = [];
+        const ann = annotations.find((a) =>
+          a.selectors.some((s) => s === base || splitThemeScope(s).base === base),
+        );
+        if (ann) {
+          for (const f of ann.fills) backgrounds.push({ value: f, from: 'annotation' });
+        } else {
+          for (const cand of ancestorCandidates(base)) {
+            const d = declsFor(cand, theme);
+            const bg = d?.background || d?.['background-color'];
+            if (bg) {
+              backgrounds.push({ value: bg, from: cand });
+              break;
+            }
+          }
+          // No explicit fill anywhere up the chain. Falling back to the page
+          // surface turns this into a general "is all text AA?" audit — ~2400
+          // mostly pre-existing findings, which is a report, not a gate. The
+          // defect class this exists to stop is text reversed out over a FILL,
+          // so page-background pairs are opt-in.
+          if (!backgrounds.length) {
+            if (!includePageBg) continue;
+            backgrounds.push({ value: 'var(--bg-primary)', from: 'page default' });
+          }
+        }
+
+        const { px, weight, min } = sizeThreshold(decls, tokens);
+
+        for (const { value, from } of backgrounds) {
+          let bg;
+          try {
+            bg = resolveColor(value, tokens);
+          } catch (e) {
+            if (e instanceof Unresolved) {
+              undefinedTokens.set(e.token, (undefinedTokens.get(e.token) || 0) + 1);
+              findings.push({
+                kind: 'undefined-fill',
+                file: relative(ROOT, file),
+                selector: base,
+                theme,
+                detail: `background ${value} on ${from} — token ${e.token} is defined nowhere, so the fill silently falls through`,
+              });
+              continue;
+            }
+            throw e;
+          }
+          if (!bg) continue;
+
+          // Flatten both onto the page surface before comparing: a translucent
+          // chip fill sits over the page, and the text sits over the result.
+          const surface = resolveColor('var(--bg-primary)', tokens);
+          const bgFlat = flatten(bg, surface);
+          const fgFlat = flatten(fg, bgFlat);
+          if (!bgFlat || !fgFlat) continue;
+
+          const ratio = contrast(fgFlat, bgFlat);
+          if (ratio < min) {
+            findings.push({
+              kind: 'contrast',
+              file: relative(ROOT, file),
+              selector: base,
+              theme,
+              ratio: Number(ratio.toFixed(2)),
+              required: min,
+              fg: decls.color,
+              bg: value,
+              bgFrom: from,
+              text: `${px}px/${weight}`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return { findings, undefinedTokens };
+}
+
+// ── CLI ──────────────────────────────────────────────────────
+
+const invokedDirectly = process.argv[1] && process.argv[1].endsWith('check-contrast.mjs');
+if (!invokedDirectly) {
+  // Imported (self-test) — expose check() without running or exiting.
+} else {
+const args = process.argv.slice(2);
+const { findings, undefinedTokens } = check({
+  all: args.includes('--all'),
+  includePageBg: args.includes('--include-page-bg'),
+});
+
+if (args.includes('--json')) {
+  console.log(JSON.stringify({ findings, undefinedTokens: [...undefinedTokens] }, null, 2));
+} else {
+  const contrastFindings = findings.filter((f) => f.kind === 'contrast');
+  const fillFindings = findings.filter((f) => f.kind === 'undefined-fill');
+
+  console.log('Token contrast check — text over tokenized fills, per theme\n');
+
+  if (contrastFindings.length) {
+    console.log(`AA failures (${contrastFindings.length}):\n`);
+    for (const f of contrastFindings) {
+      console.log(`  ${f.file}`);
+      console.log(`    ${f.selector}  [${f.theme}]`);
+      console.log(`    ${f.ratio}:1  (needs ${f.required}:1 at ${f.text})`);
+      console.log(`    color ${f.fg} over ${f.bg}${f.bgFrom === 'annotation' ? ' (declared dynamic fill)' : ` (from ${f.bgFrom})`}\n`);
+    }
+  }
+
+  if (fillFindings.length) {
+    console.log(`Unresolvable fills (${fillFindings.length}) — cannot be verified:\n`);
+    for (const f of fillFindings) {
+      console.log(`  ${f.file}\n    ${f.selector}  [${f.theme}]\n    ${f.detail}\n`);
+    }
+  }
+
+  if (undefinedTokens.size) {
+    console.log('Undefined tokens referenced:');
+    for (const [t, n] of [...undefinedTokens].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${t}  (${n} resolution${n === 1 ? '' : 's'})`);
+    }
+    console.log('');
+  }
+
+  if (!findings.length) console.log('No AA failures found.\n');
+}
+
+process.exit(findings.length ? 1 : 0);
+}

--- a/taxonomy-editor/scripts/check-contrast.sh
+++ b/taxonomy-editor/scripts/check-contrast.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Static token-contrast ratchet gate (t/2264).
+# Catches text reversed out over a tokenized fill that is light in some themes —
+# the defect class jsdom/vitest is structurally blind to (applies no stylesheet).
+#
+# Ceiling stored in quality-gates.json → contrast_ceilings["taxonomy-editor/scripts/check-contrast.mjs"].
+# Same pattern as check-renderer-tsc.sh: start at the pre-existing baseline,
+# ratchet down. Every new violation is a hard failure immediately.
+#
+# Unlike check-camp-contrast.mjs (which hardcodes a token snapshot and only checks
+# the direction that passes), this reads styles.css as the live source of truth.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CONFIG="$REPO_ROOT/quality-gates.json"
+CEILING=$(node -e "const p=require('path').resolve(process.argv[1]);console.log(require(p).contrast_ceilings['taxonomy-editor/scripts/check-contrast.mjs'])" "$CONFIG")
+
+if [ -z "$CEILING" ] || [ "$CEILING" = "undefined" ]; then
+  echo "ERROR: contrast_ceilings[taxonomy-editor/scripts/check-contrast.mjs] not found in quality-gates.json"
+  exit 1
+fi
+
+cd "$REPO_ROOT/taxonomy-editor"
+JSON=$(node scripts/check-contrast.mjs --json 2>&1 || true)
+COUNT=$(echo "$JSON" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).findings.length))")
+
+if [ "$COUNT" -gt "$CEILING" ]; then
+  node scripts/check-contrast.mjs 2>&1 || true
+  echo ""
+  echo "FAIL: contrast findings ($COUNT) exceeded ceiling ($CEILING)"
+  echo "The ceiling only goes DOWN. Fix the new violations before merging."
+  exit 1
+fi
+
+echo "contrast check: $COUNT / $CEILING findings (OK)"

--- a/taxonomy-editor/scripts/check-contrast.test.mjs
+++ b/taxonomy-editor/scripts/check-contrast.test.mjs
@@ -1,0 +1,74 @@
+// Self-test for the token-contrast checker (t/2264).
+//
+// The checker exists because contrast defects are invisible to the rest of our
+// suite. That makes its own detection the thing most worth guarding: a silent
+// regression here would restore the blind spot while still reporting green.
+//
+// Each case mirrors one shape from the real t/2234 defect corpus.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { check } from './check-contrast.mjs';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__', 'contrast');
+
+const result = check({
+  rendererDir: FIXTURES,
+  stylesFile: join(FIXTURES, 'theme-tokens.css'),
+});
+
+const contrastOn = (selector) =>
+  result.findings.filter((f) => f.kind === 'contrast' && f.selector === selector);
+
+describe('token-contrast checker — detection', () => {
+  it('flags white over a light fill in the same block', () => {
+    const hits = contrastOn('.fx-fail-same-block');
+    assert.ok(hits.length > 0, 'expected at least one finding');
+    assert.ok(hits.every((f) => f.ratio < 4.5), 'all findings should be below AA');
+  });
+
+  it('flags a fill on the ancestor with the text on a descendant', () => {
+    // The badge defects had this shape; same-block-only matching misses them.
+    assert.ok(contrastOn('.fx-ancestor .fx-child').length > 0);
+  });
+
+  it('flags a runtime fill declared via a contrast-fill annotation', () => {
+    // The filled-badge defect: the fill arrives as an inline style, so CSS-only
+    // analysis cannot see it without the annotation.
+    assert.ok(contrastOn('.fx-annotated .fx-label').length > 0);
+  });
+
+  it('reports an undefined fill token instead of silently skipping it', () => {
+    const hits = result.findings.filter(
+      (f) => f.kind === 'undefined-fill' && f.selector === '.fx-undefined-fill',
+    );
+    assert.ok(hits.length > 0, 'expected at least one finding');
+    assert.ok([...result.undefinedTokens.keys()].includes('--fx-does-not-exist'));
+  });
+});
+
+describe('token-contrast checker — no false positives', () => {
+  it('passes white over a dark fill', () => {
+    assert.equal(contrastOn('.fx-ok-same-block').length, 0);
+  });
+
+  it('passes a theme-scoped override that inverts the glyph', () => {
+    // The shape of both shipped fixes: [data-theme=…] overriding the base rule.
+    assert.equal(contrastOn('.fx-scoped').length, 0);
+  });
+
+  it('composites a translucent fill rather than comparing it raw', () => {
+    // Without alpha compositing, a 12% tint of C under `color: C` resolves to
+    // the same two colors and reads as an impossible 1:1 — the shape of ~70
+    // false positives on the real tree. The tint may still legitimately fail on
+    // a dark surface, so the assertion is that compositing HAPPENED, not that
+    // the pair passes.
+    const hits = contrastOn('.fx-alpha');
+    assert.ok(
+      hits.every((f) => f.ratio !== 1),
+      'a translucent fill must be flattened onto the surface before comparison',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

DevOps integration half of t/2264 — wires the DebateWorkspace prototype (PR #596) into ci-gate as a required check.

**This PR includes all of #596** (prototype commits) plus the CI integration commit. #596 can be closed as superseded.

## What's new in this PR (over #596)

- **`taxonomy-editor/scripts/check-contrast.sh`** — ratchet wrapper, mirrors `check-renderer-tsc.sh` (t/2252). Reads ceiling from `quality-gates.json`; prints human-readable output on failure.
- **`quality-gates.json`** — `contrast_ceilings` ceiling = **314** (278 contrast + 36 undefined-fill findings on current main). Ratchets down as pre-existing findings are fixed; every new violation fails immediately.
- **`ci.yml`** — new `contrast-check` job (electron path-filter, no pnpm install — zero node_modules deps) wired into `ci-gate needs`.

## Gate-verification

The check will report 314 findings (≤ ceiling) on current main → **green**. Any PR that introduces a new reversed-out-text-over-tokenized-fill defect will push the count above 314 → **red**. The ceiling only goes down.

## Baseline rationale

278 pre-existing contrast findings + 36 undefined-fill findings = 314. These are all unrelated to t/2234; burning them down is follow-up work, not a blocker for landing the gate.

## Note on `check-camp-contrast.mjs`

As flagged in #596 / t/2264#3, `scripts/check-camp-contrast.mjs` hardcodes a token snapshot and only checks the direction that passes (camp-on-background). This check subsumes it. Filing a follow-up to delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
