### PR TITLE
docs(ux): mode-vs-value visual distinction spec (t/2274)

### DIFF
--- a/docs/ux/debate-view-mode-controls.md
+++ b/docs/ux/debate-view-mode-controls.md
@@ -190,3 +190,65 @@ No animation changes required; the redesign rides the existing seam.
 - Do **not** disable inapplicable Analysis options in place; hide them (per-statement), matching current behavior.
 - Do **not** change the flip animation logic — the two-mode seam already matches `isTextToText`.
 - Do **not** duplicate the label map between `StatementCard.tsx` and `DebateWorkspace.tsx`; consolidate.
+
+## 13. Mode vs value visual distinction (t/2274)
+
+**Problem (shipped state).** Both segmented groups share `.debate-mode-group` + `.debate-mode-seg-active`, so the **Mode toggle** and the **value pills** render identically — same `--bg-secondary` track, same solid `var(--focus-ring)` selection fill. In the header they read as one flat five-pill row (`TEXT · ANALYSIS · BRIEF · MEDIUM · DETAILED`), and a filled `TEXT` looks like the same kind of thing as a filled `MEDIUM`. Users can't tell the first group *switches families* and the second *picks a value within the family*.
+
+**Decision — make them two different control archetypes, so only one group carries a filled selection.** The mode toggle stays the loud, primary "switch"; the value selector becomes a lighter, underlined "tabs" treatment. This removes the second competing blue fill entirely — the eye immediately separates "the filled box = mode" from "the underlined text = value." Applies to **both** control sites (per-statement `StatementTierPills` and global `GlobalModeControl`) for one consistent language.
+
+**Markup change (both sites).** The two group `<span>`s currently share `className="debate-mode-group"`. Add a modifier so they can diverge:
+- Mode group → `class="debate-mode-group debate-mode-group--mode"`
+- Value group → `class="debate-mode-group debate-mode-group--value"`
+
+**CSS (deltas against `DebateWorkspace.css`).**
+
+```css
+/* Mode toggle: unchanged — stays a solid segmented control (the "switch").
+   .debate-mode-group--mode keeps the --bg-secondary track + --border-color
+   border; its active seg keeps the solid var(--focus-ring) fill + #fff text. */
+
+/* Value selector: drop the box, become underlined tabs (the lighter treatment). */
+.debate-mode-group--value {
+  background: transparent;      /* was --bg-secondary */
+  border: none;                 /* was 1px --border-color */
+  border-radius: 0;
+  gap: 2px;
+}
+.debate-mode-group--value .debate-mode-seg {
+  padding: 1px 4px 2px;         /* room for the underline */
+  border-bottom: 2px solid transparent;
+}
+.debate-mode-group--value .debate-mode-seg-active,
+.debate-mode-group--value .debate-mode-seg-active:hover {
+  background: transparent;      /* NO fill — the key change */
+  color: var(--text-primary);
+  border-bottom-color: var(--focus-ring);   /* selection = underline */
+}
+.debate-mode-group--value .debate-mode-seg:hover {
+  background: transparent;
+  color: var(--text-primary);
+}
+
+/* Override marker: the active value seg is no longer filled, so the #fff dot
+   would vanish. Recolor it to the accent so it reads on --bg-primary. */
+.debate-mode-group--value .debate-mode-seg-overridden::after {
+  background: var(--focus-ring);   /* was #fff */
+}
+```
+
+**Separation.** Bump the inter-group spacing on `.debate-tier-pills` (`gap: 4px` → `gap: 10px`). Keep `.debate-mode-separator` (1px × 14px `--border-color`) between the groups — the boxed-vs-open contrast plus the wider gap is enough; do not add a heavier rule.
+
+**Contrast (all four themes, AA).**
+- Mode active — `#fff` on `var(--focus-ring)`: unchanged, already AA (light #3b82f6, dark #60a5fa, bkc #4d7a8b, harvard #A51C30).
+- Value active — `--text-primary` on `--bg-primary`: the app's primary text pairing, always AA. The 2px underline is `--focus-ring` (a UI indicator needing ≥3:1 vs `--bg-primary`, met in all four themes).
+- Value inactive — `--text-secondary` on `--bg-primary`: the existing muted pairing.
+
+**Alternative considered (lower-churn, not recommended).** Keep both as boxed segmented controls but give the value-active a *tinted* fill — `background: color-mix(in srgb, var(--focus-ring) 18%, var(--bg-primary)); color: var(--text-primary)` — so mode = bold accent, value = pale accent. Same hue, different weight. Less unmistakable than the box-vs-underline split (both still read as "filled pills"), and `color-mix` tinting must be re-checked per theme. Prefer the underline treatment unless implementation wants to avoid the markup change.
+
+**Acceptance (this section).**
+1. Mode toggle and value selector are visually distinct at a glance — mode = filled segmented box, value = underlined tabs; only the mode group carries a solid fill.
+2. Applied to both per-statement and global controls; consistent with `.debate-redesign`.
+3. Selection obvious in both groups; all states meet AA in light + dark (+ bkc + harvard).
+4. Colors via tokens only (`--focus-ring`, `--text-primary/secondary`, `--bg-*`) — no hard-coded hex.
+5. Override dot remains visible on the new underlined value treatment (recolored to `--focus-ring`).


### PR DESCRIPTION
Design spec (§13) for increasing visual distinction between the Text/Analysis mode toggle and its tier value pills. Mode stays a solid segmented control; values become underlined tabs (no competing fill), wider separation, override dot recolored to accent. Token-only, AA across all 4 themes. Impl (DebateWorkspace) to be ticketed once approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)