### PR TITLE
fix(debate-store): guard situation.divergence-summary against NaN divergence (t/2270)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -459,7 +459,7 @@ function buildInjectionManifest(
 
 /** Emit the situation interpretation-divergence summary — surfaces interpretation alignment at debate setup. */
 function recordSituationDivergence(filteredCC: SituationNode[], allCCNodes: SituationNode[]): void {
-  const withDiv = filteredCC.filter(n => n.interpretation_divergence != null);
+  const withDiv = filteredCC.filter(n => n.interpretation_divergence != null && !isNaN(n.interpretation_divergence!));
   if (withDiv.length > 0) {
     const high = withDiv.filter(n => n.interpretation_divergence! > 0.40).length;
     const medium = withDiv.filter(n => n.interpretation_divergence! >= 0.20 && n.interpretation_divergence! <= 0.40).length;


### PR DESCRIPTION
## Problem (t/2270)

Every debate turn's flight recorder logged `Situation divergence: … (mean NaN)` with `mean_divergence: null`. Root cause in `taxonomyContext.ts` `recordSituationDivergence`: `NaN != null` is `true` in JS, so situation nodes carrying a `NaN` `interpretation_divergence` passed the filter but fell into **no** comparison bucket (`>0.40`, `[0.20,0.40]`, `<0.20` are all false for NaN). Result: `activated_count > high+medium+low`, and the `reduce` sum propagated NaN into `mean` (`toFixed` → `"NaN"`, `JSON.stringify(NaN)` → `null`).

## Fix

Add `!isNaN(...)` to the filter guard so NaN scores are excluded. Now:
- the logged mean is always a valid number,
- `mean_divergence` is a number (never null),
- bucket totals (high+medium+low) equal `activated_count`.

## Upstream origin (routed separately)

The documented writer (`lib/debate/computeInterpretationDivergence.ts` → `cosineSimilarity`) is NaN-safe (zero-magnitude denom → 0), and standard JSON can't persist NaN (`→ null`). So the runtime NaN most plausibly survives via Electron IPC structured-clone from an in-memory enrichment path, or stale data. That investigation spans ElectronMain/Shared-Lib scope and is being routed separately per the ticket's acceptance criteria. This guard is the correct defensive fix regardless of origin — the summary must be robust to a NaN input.

## Verification

Renderer `tsc`: `0 / 0 errors`. Single-line change; CI gates cover the rest.

Co-Authored-By: Rosetta Stone 2 (Rosetta Stone) (Orca) <rosetta-stone-2.taxonomy-editor@ai-triad-research.orca.local>