### PR TITLE
fix(debate): lineage pipeline no longer flagged broken for URL/document debates (t/2271)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/lineagePipelineStatus.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/lineagePipelineStatus.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// beginDebate lineage pipeline-status diagnostics (t/2271). A topic-specific lineage
+// frame is only computed during topic critique, so URL/document/situations debates
+// legitimately have no frame — their pipeline-status must be `info`, not `warn`.
+// Only a topic debate that *should* have a frame but doesn't warrants a warn.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRecord = vi.fn();
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: mockRecord }),
+}));
+
+import { mockApi, makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+
+function pipelineStatusRecords() {
+  return mockRecord.mock.calls
+    .map(c => c[0])
+    .filter((e: { type?: string }) => e?.type === 'lineage.pipeline-status');
+}
+
+describe('beginDebate: lineage.pipeline-status level (t/2271)', () => {
+  beforeEach(() => {
+    mockRecord.mockClear();
+    mockApi.loadDictionary.mockResolvedValue({ standardized: [], colloquial: [], lintViolations: [] });
+  });
+
+  it('warns for a topic debate with no computed lineage frame', async () => {
+    useDebateStore.setState({
+      activeDebate: makeSession({ phase: 'clarification', source_type: 'topic' }) as never,
+    });
+
+    await useDebateStore.getState().beginDebate();
+
+    const [status] = pipelineStatusRecords();
+    expect(status).toBeDefined();
+    expect(status.level).toBe('warn');
+    expect(status.data.lineage_frame_expected).toBe(true);
+    expect(status.data.boost_configured).toBe(false);
+  });
+
+  it('reports info (not warn) for a URL debate — no frame is expected', async () => {
+    useDebateStore.setState({
+      activeDebate: makeSession({
+        phase: 'clarification',
+        source_type: 'url',
+        source_ref: 'https://example.com/article',
+        source_content: 'Article text',
+      }) as never,
+    });
+    // Halt after the pipeline-status record so the document-analysis path doesn't run.
+    mockApi.generateText.mockResolvedValue({ text: '{}' });
+
+    await useDebateStore.getState().beginDebate();
+
+    const [status] = pipelineStatusRecords();
+    expect(status).toBeDefined();
+    expect(status.level).toBe('info');
+    expect(status.data.lineage_frame_expected).toBe(false);
+    expect(status.data.source_type).toBe('url');
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -352,10 +352,13 @@ function buildNameToCluster(mapping: ReturnType<typeof getLineageMapping>): Reco
   return nameToCluster;
 }
 
-/** Build relevance-selection options, applying a lineage-tradition boost when a frame + lineage data are available. */
-function buildRelevanceOptions(threshold: number, debate: ReturnType<typeof useDebateStore.getState>['activeDebate'], allPovNodes: PovNode[]): RelevanceOptions {
-  const relevanceOpts: RelevanceOptions = { threshold, minPerCategory: 3, maxTotal: 35 };
-  const lineageFrame = debate?.topic?.critique?.lineage_frame;
+/**
+ * Emit the per-turn lineage boost-check diagnostic. A topic-specific lineage frame is only
+ * computed during topic critique, so for URL/document/situations debates no frame is ever
+ * produced and the check has nothing to report — suppress it there as pure noise (t/2271).
+ */
+function recordLineageBoostCheck(lineageFrame: { cluster_id: string }[] | undefined, frameExpected: boolean): void {
+  if (!frameExpected && !(lineageFrame && lineageFrame.length > 0)) return;
   getGlobalRecorder()?.record({
     type: 'lineage.boost-check',
     component: 'debate-store',
@@ -365,8 +368,16 @@ function buildRelevanceOptions(threshold: number, debate: ReturnType<typeof useD
       has_lineage_frame: !!lineageFrame,
       frame_count: lineageFrame?.length ?? 0,
       lineage_data_loaded: isLineageDataLoaded(),
+      frame_expected: frameExpected,
     },
   });
+}
+
+/** Build relevance-selection options, applying a lineage-tradition boost when a frame + lineage data are available. */
+function buildRelevanceOptions(threshold: number, debate: ReturnType<typeof useDebateStore.getState>['activeDebate'], allPovNodes: PovNode[]): RelevanceOptions {
+  const relevanceOpts: RelevanceOptions = { threshold, minPerCategory: 3, maxTotal: 35 };
+  const lineageFrame = debate?.topic?.critique?.lineage_frame;
+  recordLineageBoostCheck(lineageFrame, debate?.source_type === 'topic');
   if (lineageFrame && lineageFrame.length > 0 && isLineageDataLoaded()) {
     const mapping = getLineageMapping();
     const lineageByNode = buildLineageByNode(allPovNodes);

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -570,17 +570,29 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
       const lineageDataLoaded = isLineageDataLoaded();
       const frameComputed = !!lineageFrame && lineageFrame.length > 0;
       const boostWillBeApplied = frameComputed && lineageDataLoaded;
+      // A topic-specific lineage frame is only computed during topic critique. URL/document/
+      // situations debates run no critique, so having no frame is expected — not a
+      // misconfiguration. Reserve the warn for topic debates that should have a frame but
+      // don't (data unloaded or empty distribution); everything else is info (t/2271).
+      const frameExpected = activeDebate.source_type === 'topic';
+      const expectedNoFrame = !frameExpected && !frameComputed;
       getGlobalRecorder()?.record({
         type: 'lineage.pipeline-status',
         component: 'debate-store',
-        level: boostWillBeApplied ? 'info' : 'warn',
+        level: boostWillBeApplied || expectedNoFrame ? 'info' : 'warn',
         debate_id: activeDebate.id,
-        message: boostWillBeApplied ? 'Lineage pipeline ready' : 'Lineage pipeline incomplete',
+        message: boostWillBeApplied
+          ? 'Lineage pipeline ready'
+          : expectedNoFrame
+            ? 'Lineage pipeline: no topic-specific frame (expected for URL/document/situations debate)'
+            : 'Lineage pipeline incomplete',
         data: {
           lineage_data_loaded: lineageDataLoaded,
           lineage_frame_computed: frameComputed,
+          lineage_frame_expected: frameExpected,
           lineage_frame_traditions: lineageFrame?.map((f: { cluster_id: string; label?: string }) => f.label ?? f.cluster_id) ?? [],
           boost_configured: boostWillBeApplied,
+          source_type: activeDebate.source_type,
           code_path: 'useDebateStore',
         },
       });


### PR DESCRIPTION
Fixes t/2271.

## Problem
For URL/document debates, every debate start logged `lineage.pipeline-status` at **warn** (`lineage_frame_computed:false`, `boost_configured:false`) and every turn logged a `lineage.boost-check` with `has_lineage_frame:false`. These read as a broken pipeline but are the expected, correct state.

## Root cause
A topic-specific lineage frame is only computed during **topic critique** (`topicCritiqueSlice`), from the topic's structurally-activated nodes. URL/document/situations debates run no topic critique, so `activeDebate.topic?.critique?.lineage_frame` is always null for them. The all-node fallback (`computeFallbackLineageContext`) would boost every tradition uniformly — a no-op — so the selective relevance boost legitimately does not apply. Debaters still get the fallback lineage *context string* via `buildLineageContext`; only the scoring boost is absent, which is correct.

## Fix (AC option B — honest diagnostics)
- `beginDebate`: `lineage.pipeline-status` is **info** (not warn) when no frame is expected (`source_type !== 'topic'`); warn is reserved for topic debates that should have a frame but don't. Adds `lineage_frame_expected` + `source_type` to the event.
- `buildRelevanceOptions`: per-turn `boost-check` suppressed for expected-no-frame debates. Emission extracted to `recordLineageBoostCheck` helper to keep the function under the complexity ceiling.
- New `lineagePipelineStatus.test.ts` locks in info-vs-warn by `source_type`.

## Verification
- renderer tsc: 0/0
- `debateSlices.test.ts` + `useDebateStore.test.ts`: 158 passing; new test: 2 passing
- eslint: net-zero new warnings (complexity warning avoided via helper extraction)