### PR TITLE
feat(debate-workspace): Fact Check section in transcript outline nav (t/2275)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.css
@@ -71,7 +71,8 @@
   margin-top: 4px;
 }
 
-.transcript-outline-round .transcript-outline-link {
+.transcript-outline-round .transcript-outline-link,
+.transcript-outline-factcheck .transcript-outline-link {
   padding-left: 24px;
   color: var(--text-primary);
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.test.tsx
@@ -64,4 +64,55 @@ describe('TranscriptOutline', () => {
     const rounds = screen.getAllByRole('button').map(b => b.textContent).filter(t => t?.startsWith('Round'));
     expect(rounds).toEqual(['Round 1', 'Round 1']);
   });
+
+  it('adds a grouped "Fact Check" section with numbered sub-items when fact-checks exist (t/2275)', () => {
+    const transcript: OutlineTranscriptEntry[] = [
+      entry('o1', 'opening', 'acc'),
+      entry('y1', 'synthesis', 'acc'),
+      entry('f1', 'fact-check', 'system'),
+      entry('f2', 'fact-check', 'system'),
+    ];
+    render(<TranscriptOutline transcript={transcript} />);
+    const labels = screen.getAllByRole('button').map(b => b.textContent);
+    expect(labels).toEqual(['Opening Statements', 'Synthesis', 'Fact Check', 'Fact Check 1', 'Fact Check 2']);
+  });
+
+  it('renders no "Fact Check" section when the debate has zero fact-checks (t/2275)', () => {
+    const transcript: OutlineTranscriptEntry[] = [
+      entry('o1', 'opening', 'acc'),
+      entry('y1', 'synthesis', 'acc'),
+    ];
+    render(<TranscriptOutline transcript={transcript} />);
+    const labels = screen.getAllByRole('button').map(b => b.textContent);
+    expect(labels.some(l => l?.startsWith('Fact Check'))).toBe(false);
+  });
+
+  it('groups fact-checks after Synthesis even when interleaved among debate turns (t/2275)', () => {
+    const transcript: OutlineTranscriptEntry[] = [
+      entry('d1', 'statement', 'acc'),
+      entry('f1', 'fact-check', 'system'), // interleaved mid-debate
+      entry('d2', 'statement', 'saf'),
+      entry('y1', 'synthesis', 'acc'),
+      entry('f2', 'fact-check', 'system'),
+    ];
+    render(<TranscriptOutline transcript={transcript} />);
+    const labels = screen.getAllByRole('button').map(b => b.textContent);
+    // Fact Check section is appended last, after Synthesis, despite f1 being interleaved.
+    expect(labels).toEqual(['Cross-Examination', 'Round 1', 'Synthesis', 'Fact Check', 'Fact Check 1', 'Fact Check 2']);
+  });
+
+  it('anchors a fact-check sub-item to its transcript entry id (t/2275)', () => {
+    const scrollIntoView = vi.fn();
+    const getById = vi.spyOn(document, 'getElementById').mockReturnValue({ scrollIntoView } as unknown as HTMLElement);
+    const transcript: OutlineTranscriptEntry[] = [
+      entry('y1', 'synthesis', 'acc'),
+      entry('f1', 'fact-check', 'system'),
+      entry('f2', 'fact-check', 'system'),
+    ];
+    render(<TranscriptOutline transcript={transcript} />);
+    fireEvent.click(screen.getByText('Fact Check 2'));
+    expect(getById).toHaveBeenCalledWith('debate-entry-f2');
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' });
+    getById.mockRestore();
+  });
 });

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TranscriptOutline.tsx
@@ -18,7 +18,7 @@ type OutlineItem = {
   key: string;
   label: string;
   targetEntryId: string;
-  kind: 'section' | 'round';
+  kind: 'section' | 'round' | 'factcheck';
 };
 
 const DEBATE_TYPES = new Set(['statement', 'cross_respond']);
@@ -35,6 +35,10 @@ function buildOutline(transcript: readonly OutlineTranscriptEntry[]): OutlineIte
   let section: 'opening' | 'debate' | 'synthesis' | null = null;
   let roundSpeakers = new Set<string>();
   let roundNum = 0;
+  // Fact-checks are collected across the whole pass and emitted as a single
+  // grouped section appended at the end (t/2275) — so they stay grouped and
+  // sort after Synthesis even when interleaved among debate turns.
+  const factChecks: OutlineTranscriptEntry[] = [];
 
   for (const entry of transcript) {
     const t = entry.type;
@@ -64,10 +68,23 @@ function buildOutline(transcript: readonly OutlineTranscriptEntry[]): OutlineIte
         section = 'synthesis';
         items.push({ key: `sec-synthesis-${entry.id}`, label: 'Synthesis', targetEntryId: entry.id, kind: 'section' });
       }
+    } else if (t === 'fact-check') {
+      factChecks.push(entry);
     }
-    // Other types (probing, fact-check, clarification, system, question) are
-    // not outline anchors; they stay inline in the transcript.
+    // Other types (probing, clarification, system, question) are not outline
+    // anchors; they stay inline in the transcript.
   }
+
+  // Grouped "Fact Check" section appended last, with a numbered sub-item per
+  // fact-check anchoring to its entry. Omitted entirely when there are none.
+  if (factChecks.length > 0) {
+    const first = factChecks[0];
+    items.push({ key: `sec-factcheck-${first.id}`, label: 'Fact Check', targetEntryId: first.id, kind: 'section' });
+    factChecks.forEach((fc, i) => {
+      items.push({ key: `factcheck-${i + 1}-${fc.id}`, label: `Fact Check ${i + 1}`, targetEntryId: fc.id, kind: 'factcheck' });
+    });
+  }
+
   return items;
 }
 


### PR DESCRIPTION
Adds a grouped **Fact Check** section to the debate transcript outline nav so users can jump to fact-checks.

- `buildOutline` collects `type: 'fact-check'` entries and appends a `Fact Check` section + numbered `Fact Check N` sub-items after the main pass, each anchoring to the existing `debate-entry-<id>` via `scrollToEntry` (no new store/server state).
- Append-at-end keeps the section grouped and after Synthesis even when fact-checks are interleaved among debate turns.
- New `kind: 'factcheck'` reuses the round indent in the co-located `TranscriptOutline.css`.
- Section omitted when there are zero fact-checks.

Design approved by Quality (TL) at t/2275#2 (numbered labels, append-at-end, `kind:'factcheck'`).

**Tests** (`TranscriptOutline.test.tsx`): present/absent/interleaved-ordering/anchor-target. Gates: tsc clean, eslint 0, debate-workspace vitest 250/250.

Closes t/2275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)