### PR TITLE
feat(debate): decoupled defaultDisplayTier store field (t/2269, TL Option 2)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
@@ -223,6 +223,17 @@ describe('Config slice: getConfiguredModel behavior', () => {
     expect(transcript[1].display_tier).toBeUndefined();
     expect(useDebateStore.getState().responseLength).toBe('claims');
   });
+
+  // t/2269 (TL Option 2): the debate-step view default is Medium, but that must NOT
+  // shorten generation. defaultDisplayTier (view fallback) and responseLength
+  // (generation verbosity) are independent store fields — guard against re-coupling.
+  it('defaults defaultDisplayTier to medium while responseLength stays detailed (t/2269)', () => {
+    useDebateStore.setState({ responseLength: 'detailed', defaultDisplayTier: 'medium' });
+    // Changing generation length must not move the view default…
+    useDebateStore.getState().setResponseLength('brief');
+    expect(useDebateStore.getState().responseLength).toBe('brief');
+    expect(useDebateStore.getState().defaultDisplayTier).toBe('medium');
+  });
 });
 
 // ── Config Slice — per-step debate timer (t/2266) ──

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/configSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/configSlice.ts
@@ -23,6 +23,13 @@ export interface ConfigSlice {
 
   // Config
   responseLength: 'claims' | 'brief' | 'medium' | 'detailed' | 'reasoning' | 'convergence';
+  // Default *display* tier for debate steps, decoupled from responseLength (t/2269, TL Option 2).
+  // responseLength shapes generation verbosity (the `length` arg into the debater prompts, so it
+  // sets how much the model writes); this only sets the view fallback — StatementCard renders
+  // `entry.display_tier ?? defaultDisplayTier`. Kept separate so the default view can be Medium
+  // without shortening what gets generated (which would make the Detailed tier no longer detailed).
+  // Unpersisted, like responseLength.
+  defaultDisplayTier: 'claims' | 'brief' | 'medium' | 'detailed' | 'reasoning' | 'convergence';
   audience: DebateAudience;
   debateModel: string | null;
   debateTemperature: number | null;
@@ -99,6 +106,7 @@ export const createConfigSlice: StateCreator<DebateStore, [], [], ConfigSlice> =
   debateProgress: null,
   debateActivity: null,
   responseLength: 'detailed',
+  defaultDisplayTier: 'medium',
   audience: 'policymakers' as DebateAudience,
   debateModel: null,
   debateTemperature: null,


### PR DESCRIPTION
Implements the **Rosetta Stone store half** of t/2269 per TL's Option 2 decision (t/2269#2).

Adds an unpersisted `defaultDisplayTier: 'medium'` field to `ConfigSlice`. `responseLength` stays `'detailed'` — it shapes **generation verbosity** (the `length` arg into the debater prompts), so the batch's Option 1 (defaulting it to `medium`) would have shortened what the model writes and made the Detailed tier no longer detailed. This field is the **view fallback only**, decoupled from generation.

Includes a regression test guarding the decoupling (changing `responseLength` must not move `defaultDisplayTier`).

**Follow-up (separate scope):** a DebateWorkspace sub-task wires `StatementCard.tsx:1007/1040` to read `defaultDisplayTier` for the display fallback — blocked on this landing (shared field must exist on main first). Filing it now.

Verified: renderer tsc clean; useDebateStore vitest 126/126. Self-cert per TL (single-scope, pattern-simple).