### PR TITLE
fix(debate-workspace): display fallback → defaultDisplayTier (t/2282)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -73,7 +73,6 @@
  * Flag-gated via `.debate-redesign` on the card root, so flag-off stays full-width.
  */
 .debate-statement.debate-type-fact-check.debate-redesign .debate-statement-content,
-.debate-statement.debate-type-fact-check.debate-redesign .debate-fact-check-web-evidence-body,
 .debate-redesign .debate-fact-check-web-evidence-body {
   max-width: 95ch;
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -1004,7 +1004,11 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
   const isPover = entry.speaker !== 'system' && entry.speaker !== 'user';
   const camp = isPover ? povToCamp(entry.speaker) : undefined;
   const activeDebate = useDebateStore(s => s.activeDebate);
-  const defaultTier = useDebateStore(s => s.responseLength);
+  // Display-tier fallback is the (unpersisted) defaultDisplayTier, NOT responseLength
+  // (t/2269 Option 2 / t/2282): responseLength governs generation verbosity only, so a
+  // fresh debate renders at Medium by default without shortening what the model writes.
+  // Per-entry entry.display_tier still wins below.
+  const defaultTier = useDebateStore(s => s.defaultDisplayTier);
   const setEntryDisplayTier = useDebateStore(s => s.setEntryDisplayTier);
   const askQuestion = useDebateStore(s => s.askQuestion);
   const debateGenerating = useDebateStore(s => s.debateGenerating);


### PR DESCRIPTION
DebateWorkspace half of **t/2269 Option 2** (TL-decided, t/2269#2). Switches StatementCard's display-tier fallback from `s.responseLength` to the unpersisted `s.defaultDisplayTier` ('medium', landed in PR #608).

- A freshly opened debate now renders each step at **Medium** by default, without shortening what the model generates — `responseLength` (generation verbosity) is untouched, so the Detailed tier stays genuinely detailed.
- Per-entry `entry.display_tier` override still wins (unchanged).
- Folds in the TL-logged **t/2273 CSS tidy** (same file): drops the redundant `.debate-fact-check-web-evidence-body` member of the grouped selector at `StatementCard.css:75` (subsumed by the broader `.debate-redesign` clause); the `.debate-statement-content` cap is kept.

Self-cert per TL (single-scope, UI-only). tsc clean, debate-workspace vitest 250/250.

Closes t/2282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)