### PR TITLE
feat(debate-workspace): mode toggle (neutral segmented) + value dropdown (t/2278)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.css
@@ -52,25 +52,29 @@
 
 /* ─── Two-mode segmented controls (t/2172) ─────────────────────────────── */
 
+/* Mode toggle — neutral segmented control (t/2274 §13, owner design). The track
+   is a subtle inset; the SELECTED segment is a raised light pill (NO accent fill),
+   so the mode toggle reads as a different control type than the value dropdown. */
 .debate-mode-group {
   display: inline-flex;
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  overflow: hidden;
+  padding: 2px;
+  gap: 2px;
 }
 
 .debate-mode-seg {
   background: transparent;
-  border: none;
+  border: 1px solid transparent;   /* reserve the pill border so selection doesn't shift layout */
+  border-radius: var(--radius-sm);
   color: var(--text-secondary);
   font-size: var(--text-2xs);
   font-weight: 600;
-  padding: 1px 6px;
+  padding: 1px 8px;
   cursor: pointer;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  transition: background 0.1s, color 0.1s;
+  letter-spacing: 0;
+  transition: background 0.1s, color 0.1s, box-shadow 0.1s;
   display: inline-flex;
   align-items: center;
   gap: 2px;
@@ -78,18 +82,17 @@
 }
 
 .debate-mode-seg:hover {
-  background: var(--bg-hover);
   color: var(--text-primary);
 }
 
-.debate-mode-seg-active {
-  background: var(--focus-ring);
-  color: #fff;
-}
-
+/* Selected = raised neutral pill, NOT an accent fill (the change that makes the
+   two groups read as different control types). */
+.debate-mode-seg-active,
 .debate-mode-seg-active:hover {
-  background: var(--focus-ring);
-  color: #fff;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border-color: var(--border-color);
+  box-shadow: var(--shadow-1);
 }
 
 .debate-mode-separator {
@@ -130,4 +133,41 @@
 
 .debate-tier-global .debate-mode-group {
   font-size: inherit;
+}
+
+/* Value selector — dropdown button + menu (t/2274 §13, owner design), replacing
+   the old inline value pills. A native <select> styled as the button = keyboard
+   access for free (open/navigate/select, Esc closes, focus returns). Reuses the
+   .debate-detail-dropdown base; these tweaks give title-case labels + the override
+   affordance. */
+.debate-value-dropdown-wrap {
+  display: inline-flex;
+  align-items: center;
+}
+.debate-value-dropdown {
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-primary);
+  height: auto;
+  padding: 1px 4px;
+}
+/* Per-statement override marker on the dropdown button (value differs from the
+   global default) — a --focus-ring dot; "Match global default" (last menu item)
+   clears it. */
+.debate-value-override-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--focus-ring);
+  display: inline-block;
+  margin-left: 4px;
+  flex-shrink: 0;
+}
+
+/* Spacing between the mode toggle and the value dropdown (the old 1px divider is
+   dropped per the owner mock). Overrides the Rosetta-owned styles.css base
+   (.debate-tier-pills gap:4px); element+class specificity wins regardless of
+   stylesheet order. */
+span.debate-tier-pills {
+  gap: 8px;
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
@@ -308,20 +308,25 @@ describe('toolbar', () => {
     expect(screen.getByText('Detailed')).toBeInTheDocument();
   });
 
-  it('renders five mode segments in text mode (2 mode + 3 sub-options)', () => {
+  it('renders 2 mode segments + a value dropdown with the text-tier options (t/2274 §13)', () => {
     const { container } = render(<DebateWorkspace />);
-    const segs = container.querySelectorAll('.debate-mode-seg');
-    expect(segs.length).toBe(5);
+    // Mode toggle = 2 neutral segments; value selector is now a <select>, not pills.
+    expect(container.querySelectorAll('.debate-mode-seg').length).toBe(2);
+    const select = container.querySelector('select.debate-value-dropdown') as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    const opts = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+    expect(opts).toEqual(['Brief', 'Medium', 'Detailed']);
   });
 
-  it('marks Text mode and active sub-option as active', () => {
+  it('marks Text mode active and reflects the current value in the dropdown (t/2274 §13)', () => {
     mockStore.responseLength = 'brief';
     const { container } = render(<DebateWorkspace />);
+    // Only the mode toggle carries an active segment now (no accent-filled value pill).
     const activeSegs = container.querySelectorAll('.debate-mode-seg-active');
-    expect(activeSegs.length).toBe(2);
-    const activeTexts = Array.from(activeSegs).map((el) => el.textContent);
-    expect(activeTexts).toContain('Text');
-    expect(activeTexts).toContain('Brief');
+    expect(activeSegs.length).toBe(1);
+    expect(activeSegs[0].textContent).toBe('Text');
+    const select = container.querySelector('select.debate-value-dropdown') as HTMLSelectElement;
+    expect(select.value).toBe('brief');
   });
 
   it('does not render Export button when onExport prop is not provided', () => {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -410,7 +410,6 @@ function GlobalModeControl({ defaultTier, setDefaultTier }: {
 
   const subTiers = activeMode === 'text' ? GLOBAL_TEXT_TIERS : GLOBAL_ANALYSIS_TIERS;
   const modeRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const subRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const handleModeSelect = useCallback((mode: 'text' | 'analysis') => {
     if (mode === activeMode) return;
@@ -435,21 +434,8 @@ function GlobalModeControl({ defaultTier, setDefaultTier }: {
     requestAnimationFrame(() => modeRefs.current[next]?.focus());
   }, [handleModeSelect]);
 
-  const handleSubKey = useCallback((e: { key: string; preventDefault(): void }, idx: number) => {
-    const len = subTiers.length;
-    let next = idx;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (idx + 1) % len;
-    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (idx - 1 + len) % len;
-    else if (e.key === 'Home') next = 0;
-    else if (e.key === 'End') next = len - 1;
-    else return;
-    e.preventDefault();
-    handleSubSelect(subTiers[next]);
-    requestAnimationFrame(() => subRefs.current[next]?.focus());
-  }, [subTiers, handleSubSelect]);
-
   return (
-    <span className="debate-tier-global" style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center' }}>
+    <span className="debate-tier-global" style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
       <span role="radiogroup" aria-label="View mode" className="debate-mode-group">
         {GLOBAL_MODE_IDS.map(({ id, label }, i) => (
           <button
@@ -467,32 +453,19 @@ function GlobalModeControl({ defaultTier, setDefaultTier }: {
           </button>
         ))}
       </span>
-      <span className="debate-mode-separator" aria-hidden="true" />
-      <span
-        role="radiogroup"
+      {/* Value selector — native <select> dropdown (t/2274 §13). Global control has
+          no per-statement override, so no dot / match-global item here. */}
+      <select
+        className="debate-detail-dropdown debate-value-dropdown"
         aria-label={activeMode === 'text' ? 'Text detail level' : 'Analysis view'}
-        className="debate-mode-group"
+        value={defaultTier}
+        title={GLOBAL_TIER_TITLES[defaultTier]}
+        onChange={(e) => handleSubSelect(e.target.value)}
       >
-        {subTiers.map((tier, i) => {
-          const isActive = defaultTier === tier;
-          return (
-            <button
-              key={tier}
-              ref={el => { subRefs.current[i] = el; }}
-              type="button"
-              role="radio"
-              aria-checked={isActive}
-              tabIndex={isActive ? 0 : -1}
-              className={`debate-mode-seg${isActive ? ' debate-mode-seg-active' : ''}`}
-              onClick={() => handleSubSelect(tier)}
-              onKeyDown={(e) => handleSubKey(e, i)}
-              title={GLOBAL_TIER_TITLES[tier]}
-            >
-              {TIER_LABELS[tier]}
-            </button>
-          );
-        })}
-      </span>
+        {subTiers.map(tier => (
+          <option key={tier} value={tier}>{TIER_LABELS[tier]}</option>
+        ))}
+      </select>
     </span>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -510,7 +510,6 @@ function StatementTierPills({ entry, activeTier, setEntryDisplayTier, vocabResol
   const isOverridden = entry.display_tier != null;
 
   const modeRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const subRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const handleModeSelect = useCallback((mode: 'text' | 'analysis') => {
     if (mode === activeMode) return;
@@ -535,19 +534,6 @@ function StatementTierPills({ entry, activeTier, setEntryDisplayTier, vocabResol
     requestAnimationFrame(() => modeRefs.current[next]?.focus());
   }, [handleModeSelect]);
 
-  const handleSubKey = useCallback((e: { key: string; preventDefault(): void }, idx: number) => {
-    const len = subTiers.length;
-    let next = idx;
-    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') next = (idx + 1) % len;
-    else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') next = (idx - 1 + len) % len;
-    else if (e.key === 'Home') next = 0;
-    else if (e.key === 'End') next = len - 1;
-    else return;
-    e.preventDefault();
-    handleSubSelect(subTiers[next]);
-    requestAnimationFrame(() => subRefs.current[next]?.focus());
-  }, [subTiers, handleSubSelect]);
-
   return (
     <span className="debate-tier-pills">
       <span role="radiogroup" aria-label="View mode" className="debate-mode-group">
@@ -567,43 +553,36 @@ function StatementTierPills({ entry, activeTier, setEntryDisplayTier, vocabResol
           </button>
         ))}
       </span>
-      <span className="debate-mode-separator" aria-hidden="true" />
-      <span
-        role="radiogroup"
-        aria-label={activeMode === 'text' ? 'Text detail level' : 'Analysis view'}
-        className="debate-mode-group"
-      >
-        {subTiers.map((tier, i) => {
-          const isActive = activeTier === tier;
-          return (
-            <button
-              key={tier}
-              ref={el => { subRefs.current[i] = el; }}
-              type="button"
-              role="radio"
-              aria-checked={isActive}
-              tabIndex={isActive ? 0 : -1}
-              className={`debate-mode-seg${isActive ? ' debate-mode-seg-active' : ''}${isActive && isOverridden ? ' debate-mode-seg-overridden' : ''}`}
-              aria-label={`${TIER_LABELS[tier]}${isActive && isOverridden ? ', overrides global default' : ''}`}
-              onClick={(e) => { e.stopPropagation(); handleSubSelect(tier); }}
-              onKeyDown={(e) => handleSubKey(e, i)}
-              title={TIER_TITLES[tier]}
-            >
-              {TIER_LABELS[tier]}
-            </button>
-          );
-        })}
-      </span>
-      {isOverridden && (
-        <button
-          type="button"
-          className="debate-mode-match-global"
-          onClick={(e) => { e.stopPropagation(); setEntryDisplayTier(entry.id, undefined); }}
-          title="Clear override — revert to global default"
+      {/* Value selector — native <select> styled as a dropdown button (t/2274 §13).
+          Native gives keyboard access for free (open/navigate/select, Esc closes,
+          focus returns). Override → dot on the button + "Match global default" item. */}
+      <span className="debate-value-dropdown-wrap">
+        <select
+          className="debate-detail-dropdown debate-value-dropdown"
+          aria-label={activeMode === 'text' ? 'Text detail level' : 'Analysis view'}
+          value={activeTier}
+          title={TIER_TITLES[activeTier]}
+          onClick={(e) => e.stopPropagation()}
+          onChange={(e) => {
+            e.stopPropagation();
+            const v = e.target.value;
+            if (v === '__match_global__') setEntryDisplayTier(entry.id, undefined);
+            else handleSubSelect(v);
+          }}
         >
-          ↺ match global
-        </button>
-      )}
+          {subTiers.map(tier => (
+            <option key={tier} value={tier}>{TIER_LABELS[tier]}</option>
+          ))}
+          {isOverridden && <option value="__match_global__">Match global default</option>}
+        </select>
+        {isOverridden && (
+          <span
+            className="debate-value-override-dot"
+            title="Overrides global default"
+            aria-label="Overrides global default"
+          />
+        )}
+      </span>
     </span>
   );
 }


### PR DESCRIPTION
Implements the owner-directed design in spec §13 (t/2274), replacing the flat five-pill row so the mode toggle and value selector read as two different control types.

- **Mode toggle → neutral segmented control**: selected segment is a raised light pill (`--bg-primary` + `--border-color` + `--shadow-1` + `--text-primary`), **no accent fill**. Mode a11y (radiogroup / roving tabindex / Arrow-Home-End) unchanged.
- **Value selector → native `<select>`** styled as the dropdown button (reuses `.debate-detail-dropdown`), replacing the inline value pills. Native = keyboard-accessible for free (open/navigate/select, Esc closes, focus returns).
- **Per-statement override**: `--focus-ring` dot on the button + "Match global default" as the last menu item (clears via `setEntryDisplayTier(id, undefined)`). Global control has neither.
- 1px divider dropped per the mock; spacing via `gap`. Both sites (StatementTierPills + GlobalModeControl).

Token-only (`--shadow-1` for the pill shadow), AA across all four themes. Tests updated for the dropdown structure.

**Design signed off** (t/2278#7) — four-theme computed-style pass, all ACs met. tsc clean, eslint 0 errors, debate-workspace vitest 250/250.

Closes t/2278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)