### PR TITLE
docs(server): document undici skew as local-only failure, fix misleading error message (t/2281)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/githubApi.test.ts
+++ b/taxonomy-editor/src/server/__tests__/githubApi.test.ts
@@ -9,6 +9,11 @@
  * Tests GitHubAPIBackend and SessionBranchManager against mocked GitHub APIs
  * to validate: session lifecycle, batch commits, PR creation, cache behavior,
  * circuit breaker, rate limit handling, and concurrent mutation safety.
+ *
+ * LOCAL-ONLY FAILURE MODE (t/2281): if these tests fail with "undici major-version skew",
+ * your local Node is outside the required range (package.json engines: ">=22 <23").
+ * CI uses node:22.23.2 (Dockerfile) which bundles undici 6.x matching the userland pin.
+ * Fix: switch to Node 22.x via nvm/fnm. This is not a test or code defect.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';

--- a/taxonomy-editor/src/server/__tests__/t2020Security.test.ts
+++ b/taxonomy-editor/src/server/__tests__/t2020Security.test.ts
@@ -11,6 +11,10 @@
  *      (stripHtmlFallback: single-pass entity decode before tag stripping)
  *  - js/insecure-temporary-file (anonymousSessionStore: private mkdtemp base dir)
  *  - js/insecure-temporary-file (githubAPIBackend: randomised .tmp suffix)
+ *
+ * LOCAL-ONLY FAILURE MODE (t/2281): GitHubAPIBackend tests fail with "undici major-version skew"
+ * when local Node is outside the required range (package.json engines: ">=22 <23"). CI uses
+ * node:22.23.2 (Dockerfile) which bundles undici 6.x matching the userland pin. Fix: use Node 22.x.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';

--- a/taxonomy-editor/src/server/storage/undiciInvariant.ts
+++ b/taxonomy-editor/src/server/storage/undiciInvariant.ts
@@ -19,8 +19,10 @@ export function assertUndiciMajorInvariant(
       `undici major-version skew: userland ${userlandVersion} vs node built-in ${bundledVersion}. ` +
       `The GitHub dispatcher passes an undici.Agent as dispatcher: to Node's built-in fetch — ` +
       `mismatched majors cause fetch to silently ignore the dispatcher and fall back to TLS ` +
-      `session caching (CVE-2026-58040 condition). Pin undici in package.json to match the ` +
-      `node base-image's bundled major. (t/2053, t/2113)`,
+      `session caching (CVE-2026-58040 condition). ` +
+      `LOCAL-ONLY: CI uses node:22.23.2 (Dockerfile) which bundles undici 6.x matching the ` +
+      `userland pin. Your local Node (${bundledVersion.split('.')[0]}.x) is outside the required ` +
+      `range — switch to Node 22.x (see package.json engines: ">=22 <23") via nvm/fnm. (t/2053, t/2113, t/2281)`,
     );
   }
 }


### PR DESCRIPTION
## Summary

- **Determination**: githubApi + t2020Security fail locally-only, not in CI. CI is and remains green.
- **Root cause**: local Node 24.15.0 bundles undici 7.24.4; CI uses `node:22.23.2` (Dockerfile) which bundles undici 6.x matching the userland pin (`6.28.0`). `package.json engines` already constrains `">=22 <23"` — developer is running a Node outside the required range.
- Fixes misleading error message in `undiciInvariant.ts` (previously said "pin undici in package.json" — wrong advice; the real fix is switch to Node 22.x via nvm/fnm)
- Adds co-located failure-mode comment to both test files so future developers see the explanation at the test site, not just in ticket history

## Test plan

- No behavioral change — pure documentation/comment additions
- CI test-container + test-electron already green (confirmed on recent runs); this PR adds no logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
