### PR TITLE
fix(debate): guard partial-cache crash in computeInterpretationDivergence (t/2277)

### DIFF
--- a/lib/debate/computeInterpretationDivergence.test.ts
+++ b/lib/debate/computeInterpretationDivergence.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { cosineSimilarity } from '../embeddings/similarity.js';
+
+/**
+ * Degenerate-embedding tests for cosineSimilarity — guards the claim that
+ * computeInterpretationDivergence.ts's null-guard (incomplete cached embeddings)
+ * is the correct defence, and that cosineSimilarity itself never produces NaN
+ * for valid-typed (non-undefined) degenerate inputs. (t/2277)
+ */
+describe('cosineSimilarity degenerate inputs', () => {
+  it('returns 0 for empty vectors', () => {
+    expect(cosineSimilarity([], [])).toBe(0);
+  });
+
+  it('returns 0 for length-mismatched vectors', () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2])).toBe(0);
+  });
+
+  it('returns 0 for zero-magnitude vectors', () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+    expect(cosineSimilarity([0, 0, 0], [0, 0, 0])).toBe(0);
+  });
+
+  it('never returns NaN for any valid-typed degenerate input', () => {
+    const cases: [number[], number[]][] = [
+      [[], []],
+      [[0], [0]],
+      [[0, 0, 0], [1, 2, 3]],
+      [[1, 2], [1, 2, 3]],
+    ];
+    for (const [a, b] of cases) {
+      expect(Number.isNaN(cosineSimilarity(a, b))).toBe(false);
+    }
+  });
+
+  it('returns 1 for identical unit vectors', () => {
+    const v = [0.5, 0.3, 0.8];
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1.0);
+  });
+});

--- a/lib/debate/computeInterpretationDivergence.ts
+++ b/lib/debate/computeInterpretationDivergence.ts
@@ -159,7 +159,8 @@ async function main(): Promise<void> {
   const idToPov = new Map<string, { sitId: string; pov: string }>();
 
   for (const sit of situations) {
-    if (interpEmbs.nodes[sit.id]) {
+    const cached = interpEmbs.nodes[sit.id];
+    if (cached && POVS.every(p => Array.isArray((cached as unknown as Record<string, unknown>)[p]))) {
       skippedCount++;
       continue;
     }
@@ -202,6 +203,11 @@ async function main(): Promise<void> {
     const embs = interpEmbs.nodes[sit.id];
     if (!embs) {
       console.warn(`  [${sit.id}] Missing embeddings — skipping divergence computation`);
+      continue;
+    }
+    const missingPovs = POVS.filter(p => !Array.isArray((embs as unknown as Record<string, unknown>)[p]));
+    if (missingPovs.length > 0) {
+      console.warn(`  [${sit.id}] Incomplete cached embeddings (missing: ${missingPovs.join(', ')}) — re-run to fix`);
       continue;
     }
 


### PR DESCRIPTION
## Summary

- **Cache-skip strengthened**: `computeInterpretationDivergence.ts` now validates all 3 POV arrays are present before skipping a cached node; a partial stub (from an interrupted run) is re-embedded on the next run instead of silently skipped and then crashing.
- **Null-guard in divergence loop**: incomplete `embs` entries now warn + skip rather than propagating `undefined` into `cosineSimilarity` (which would throw `TypeError: Cannot read properties of undefined (reading 'length')`).
- **New test**: `computeInterpretationDivergence.test.ts` verifies `cosineSimilarity` degenerate inputs (empty, length-mismatch, zero-magnitude) never produce NaN — confirming the NaN-safety claim from the ticket investigation.

## Root cause (t/2277 investigation)

Hypothesis 1 (IPC/in-memory enrichment) is **ruled out** — no main-process or server code writes `interpretation_divergence`; the field is set exclusively by the batch script and lives on disk. The `mean NaN` logged by `taxonomyContext.ts` was the empty-`withDiv` `0/0` case already fixed in PR #600 (t/2270), not an actual `NaN` field value on any node.

## Test plan

- [x] `npx vitest run computeInterpretationDivergence.test.ts` — 5/5 pass
- [x] `npx vitest run` (full suite) — 2928/2939 pass, 11 pre-existing skips, 0 new failures
- [x] `tsc -p tsconfig.json --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)