### PR TITLE
feat(pipeline): emit retrieval_confidence + taxonomy_node_candidates (t/2288)

### DIFF
--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -570,6 +570,9 @@ $script:EmbeddingsTimestamp = $null      # LastWriteTime of embeddings.json
 $script:CachedSyntheticVectors = $null   # Lazy-loaded (multi-vector synthetic embeddings)
 $script:SyntheticTimestamp = $null       # LastWriteTime of synthetic_embeddings.json
 $script:TaxonomyCacheLastCheck = $null  # UTC time of last staleness check (cooldown)
+# Provisional threshold (0.45) — calibrate against SAF-167 repro case and a
+# good-vs-bad attribution distribution before treating this as a tuned gate.
+$script:RetrievalConfidenceThreshold = 0.45
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Load ai-models.json — single source of truth for backend/model lists

--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -836,6 +836,24 @@ function Finalize-Summary {
         Write-Host "  │  ⚠ $Warn" -ForegroundColor Yellow
     }
 
+    # -- Retrieval confidence pass (t/2288) ------------------------------------
+    # Runs after hallucinated-ID nulling so only valid assignments get scored.
+    if ($script:CachedEmbeddings -and $script:CachedEmbeddings.Count -gt 0) {
+        $AllKpsForConf = [System.Collections.Generic.List[object]]::new()
+        foreach ($Camp in $Camps) {
+            $CampDataConf = $SummaryObject.pov_summaries.$Camp
+            if (-not $CampDataConf -or -not (Has-Field $CampDataConf 'key_points')) { continue }
+            $kpListConf = Get-Field $CampDataConf 'key_points'
+            if ($kpListConf) {
+                foreach ($kp in @($kpListConf)) { [void]$AllKpsForConf.Add($kp) }
+            }
+        }
+        if ($AllKpsForConf.Count -gt 0) {
+            Invoke-RetrievalConfidencePass -KeyPoints $AllKpsForConf.ToArray() `
+                -Threshold $script:RetrievalConfidenceThreshold
+        }
+    }
+
     $SoProps = $SummaryObject.PSObject.Properties
     if ($SoProps['factual_claims'] -and $null -ne $SummaryObject.factual_claims) { $FactualClaims = $SummaryObject.factual_claims } else { $FactualClaims = @() }
     if ($SoProps['unmapped_concepts'] -and $null -ne $SummaryObject.unmapped_concepts) { $UnmappedConcs = $SummaryObject.unmapped_concepts } else { $UnmappedConcs = @() }

--- a/scripts/AITriad/Private/Invoke-RetrievalConfidencePass.ps1
+++ b/scripts/AITriad/Private/Invoke-RetrievalConfidencePass.ps1
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Invoke-BatchEmbedAttribution {
+    # Isolated wrapper so Pester tests can mock this without touching Python.
+    # Input:  list of @{EmbedId='kp_N'; Text='attribution text...'}
+    # Output: hashtable EmbedId -> double[] (null on failure)
+    [CmdletBinding()]
+    param([System.Collections.Generic.List[hashtable]]$Items)
+
+    $EmbedScript = Join-Path (Join-Path $script:RepoRoot 'scripts') 'embed_taxonomy.py'
+    if (-not (Test-Path $EmbedScript)) {
+        $EmbedScript = Join-Path $script:ModuleRoot 'embed_taxonomy.py'
+    }
+    if (-not (Test-Path $EmbedScript)) { return $null }
+
+    $BatchItems = [System.Collections.Generic.List[object]]::new()
+    foreach ($Item in $Items) {
+        $BatchItems.Add([ordered]@{ id = $Item.EmbedId; text = $Item.Text })
+    }
+    $BatchJson = $BatchItems | ConvertTo-Json -Compress -Depth 3
+
+    try {
+        $Raw = $BatchJson | & python $EmbedScript batch-encode 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($Raw)) { return $null }
+        $Parsed = $Raw | ConvertFrom-Json
+        $Map = @{}
+        foreach ($Prop in $Parsed.PSObject.Properties) {
+            $Map[$Prop.Name] = [double[]]@($Prop.Value)
+        }
+        return $Map
+    } catch {
+        return $null
+    }
+}
+
+function Set-KeyPointField {
+    param([object]$KeyPoint, [string]$Name, $Value)
+    if ($KeyPoint.PSObject.Properties[$Name]) {
+        $KeyPoint.$Name = $Value
+    } else {
+        $KeyPoint | Add-Member -NotePropertyName $Name -NotePropertyValue $Value -Force
+    }
+}
+
+function Invoke-RetrievalConfidencePass {
+    <#
+    .SYNOPSIS
+        Adds retrieval_confidence, taxonomy_node_candidates, and retrieval_low_confidence
+        to each key_point that has a valid taxonomy_node_id and attribution_text.
+    .DESCRIPTION
+        Called from Invoke-DocumentSummary after the hallucinated-ID nulling pass (which
+        has already set invalid taxonomy_node_id values to $null). Only key_points with
+        a non-null node ID and non-empty attribution_text are processed.
+
+        All attribution_text values are batch-embedded in one Python subprocess call
+        (embed_taxonomy.py batch-encode). Cosine similarity is then computed in-memory
+        against $script:CachedEmbeddings (loaded earlier by Get-RelevantTaxonomyNodes).
+
+        Degrades gracefully on any failure — never throws, never modifies existing fields
+        on error. $script:TaxonomyData is guaranteed loaded by Assert-TaxonomyCacheFresh
+        (called inside Get-RelevantTaxonomyNodes earlier in the same pipeline run).
+    .PARAMETER KeyPoints
+        Flat array of key_point PSObjects from all POV camps for a single document.
+    .PARAMETER Threshold
+        Confidence value below which retrieval_low_confidence is set to $true.
+        Provisional — calibrate against SAF-167 repro case and a good-vs-bad
+        attribution distribution. Caller should pass $script:RetrievalConfidenceThreshold.
+    #>
+    [CmdletBinding()]
+    param(
+        [object[]]$KeyPoints,
+        [double]$Threshold = 0.45
+    )
+
+    # Guard: CachedEmbeddings must be loaded (Get-RelevantTaxonomyNodes always runs first)
+    if (-not $script:CachedEmbeddings -or $script:CachedEmbeddings.Count -eq 0) {
+        Write-Verbose 'Invoke-RetrievalConfidencePass: CachedEmbeddings not loaded — skipping confidence pass'
+        return
+    }
+
+    # Collect workable key_points
+    $WorkItems = [System.Collections.Generic.List[hashtable]]::new()
+    for ($Idx = 0; $Idx -lt $KeyPoints.Count; $Idx++) {
+        $kp = $KeyPoints[$Idx]
+        if (-not $kp.taxonomy_node_id) { continue }
+        if (-not $kp.PSObject.Properties['attribution_text']) { continue }
+        $AttrText = [string]$kp.attribution_text
+        if ([string]::IsNullOrWhiteSpace($AttrText)) { continue }
+        if (-not $script:CachedEmbeddings.ContainsKey($kp.taxonomy_node_id)) { continue }
+        $WorkItems.Add(@{ Idx = $Idx; KeyPoint = $kp; EmbedId = "kp_$Idx"; Text = $AttrText })
+    }
+    if ($WorkItems.Count -eq 0) { return }
+
+    # Batch-embed all attribution_texts in one subprocess call
+    $VectorMap = Invoke-BatchEmbedAttribution -Items $WorkItems
+    if ($null -eq $VectorMap) {
+        Write-Verbose 'Invoke-RetrievalConfidencePass: batch-encode failed — skipping confidence pass'
+        return
+    }
+
+    # Build node-id → label map from TaxonomyData (guaranteed populated by Assert-TaxonomyCacheFresh)
+    $LabelMap = @{}
+    foreach ($PovKey in $script:TaxonomyData.Keys) {
+        $PovObj = $script:TaxonomyData[$PovKey]
+        if (-not $PovObj.PSObject.Properties['nodes']) { continue }
+        foreach ($N in @($PovObj.nodes)) {
+            if ($N.PSObject.Properties['id'] -and $N.PSObject.Properties['label']) {
+                $LabelMap[[string]$N.id] = [string]$N.label
+            }
+        }
+    }
+
+    # Determine vector dimensionality from any cached embedding
+    $SampleVec = $null
+    foreach ($V in $script:CachedEmbeddings.Values) { $SampleVec = [double[]]$V; break }
+    if ($null -eq $SampleVec) { return }
+    $Dim = $SampleVec.Count
+
+    foreach ($Item in $WorkItems) {
+        $kp      = $Item.KeyPoint
+        $EmbedId = $Item.EmbedId
+        if (-not $VectorMap.ContainsKey($EmbedId)) { continue }
+
+        $QueryVec = [double[]]$VectorMap[$EmbedId]
+        if ($QueryVec.Count -ne $Dim) { continue }
+
+        # Compute query L2 norm
+        $QNormSq = 0.0
+        for ($i = 0; $i -lt $Dim; $i++) { $QNormSq += $QueryVec[$i] * $QueryVec[$i] }
+        $QNorm = [Math]::Sqrt($QNormSq)
+        if ($QNorm -eq 0) { continue }
+
+        # Score every cached node against the query vector
+        $Scores = [System.Collections.Generic.List[PSObject]]::new()
+        foreach ($NodeId in $script:CachedEmbeddings.Keys) {
+            $NodeVec = [double[]]$script:CachedEmbeddings[$NodeId]
+            if ($NodeVec.Count -ne $Dim) { continue }
+            $Dot = 0.0; $NNormSq = 0.0
+            for ($i = 0; $i -lt $Dim; $i++) {
+                $Dot    += $QueryVec[$i] * $NodeVec[$i]
+                $NNormSq += $NodeVec[$i]  * $NodeVec[$i]
+            }
+            $D   = $QNorm * [Math]::Sqrt($NNormSq)
+            $Sim = if ($D -gt 0.0) { [Math]::Round($Dot / $D, 4) } else { 0.0 }
+            $Scores.Add([PSCustomObject]@{ Id = $NodeId; Score = $Sim })
+        }
+        $Ranked = @($Scores | Sort-Object Score -Descending)
+
+        # retrieval_confidence = similarity of the ASSIGNED node (included in candidates if top-3)
+        $AssignedHits = @($Ranked | Where-Object { $_.Id -eq $kp.taxonomy_node_id })
+        $Confidence   = if ($AssignedHits.Count -gt 0) { $AssignedHits[0].Score } else { 0.0 }
+
+        # taxonomy_node_candidates = top-3 by similarity (assigned node included when it ranks there)
+        $Top3 = @($Ranked | Select-Object -First 3 | ForEach-Object {
+            $CId = $_.Id; $CScore = $_.Score
+            [PSCustomObject]@{
+                id    = $CId
+                label = if ($LabelMap.ContainsKey($CId)) { $LabelMap[$CId] } else { '' }
+                score = $CScore
+            }
+        })
+
+        Set-KeyPointField $kp 'retrieval_confidence'     $Confidence
+        Set-KeyPointField $kp 'taxonomy_node_candidates' $Top3
+        Set-KeyPointField $kp 'retrieval_low_confidence' ($Confidence -lt $Threshold)
+    }
+}

--- a/tests/Invoke-RetrievalConfidencePass.Tests.ps1
+++ b/tests/Invoke-RetrievalConfidencePass.Tests.ps1
@@ -1,0 +1,222 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '../scripts/AITriad/AITriad.psm1') -Force
+}
+
+Describe 'Invoke-RetrievalConfidencePass' -Tag 'retrieval', 'confidence' {
+
+    # All BeforeEach/It blocks use InModuleScope so they can access private functions
+    # and set $script:* module variables. Vectors are defined inline inside each
+    # InModuleScope scriptblock — outer-scope variables do not cross that boundary.
+    #
+    # Vector layout (384-dim, all-MiniLM-L6-v2 dim):
+    #   VecA: unit vector at dim 0  (assigned to acc-bel-001)
+    #   VecB: unit vector at dim 1  (assigned to saf-bel-001, orthogonal to VecA)
+    # cosine(VecA, VecA) = 1.0, cosine(VecA, VecB) = 0.0
+
+    BeforeEach {
+        InModuleScope AITriad {
+            $VecA = [double[]]::new(384); $VecA[0] = 1.0
+            $VecB = [double[]]::new(384); $VecB[1] = 1.0
+            $script:CachedEmbeddings = @{
+                'acc-bel-001' = $VecA
+                'saf-bel-001' = $VecB
+            }
+            $script:TaxonomyData = @{
+                acc = [PSCustomObject]@{
+                    nodes = @(
+                        [PSCustomObject]@{ id = 'acc-bel-001'; label = 'Accelerationist Belief 1' }
+                    )
+                }
+                saf = [PSCustomObject]@{
+                    nodes = @(
+                        [PSCustomObject]@{ id = 'saf-bel-001'; label = 'Safetyist Belief 1' }
+                    )
+                }
+            }
+            $script:RetrievalConfidenceThreshold = 0.45
+        }
+    }
+
+    Context 'happy path — confidence fields written' {
+        It 'writes retrieval_confidence, taxonomy_node_candidates, retrieval_low_confidence' {
+            InModuleScope AITriad {
+                $QVec = [double[]]::new(384); $QVec[0] = 1.0
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_0' = $QVec } }
+
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'some text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+
+                $kp.PSObject.Properties.Name | Should -Contain 'retrieval_confidence'
+                $kp.PSObject.Properties.Name | Should -Contain 'taxonomy_node_candidates'
+                $kp.PSObject.Properties.Name | Should -Contain 'retrieval_low_confidence'
+            }
+        }
+
+        It 'confidence equals cosine similarity of attribution_text vector vs assigned node' {
+            InModuleScope AITriad {
+                # Query exactly matches acc-bel-001 vector → similarity = 1.0
+                $QVec = [double[]]::new(384); $QVec[0] = 1.0
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_0' = $QVec } }
+
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'aligned text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+
+                $kp.retrieval_confidence | Should -Be 1.0
+            }
+        }
+
+        It 'retrieval_low_confidence is false when confidence is at or above threshold' {
+            InModuleScope AITriad {
+                $QVec = [double[]]::new(384); $QVec[0] = 1.0  # aligned with acc-bel-001 → confidence 1.0 ≥ 0.45
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_0' = $QVec } }
+
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'aligned text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+
+                $kp.retrieval_low_confidence | Should -Be $false
+            }
+        }
+
+        It 'retrieval_low_confidence is true when confidence is below threshold' {
+            InModuleScope AITriad {
+                # Query aligned with acc-bel-001 (dim 0); assigned node saf-bel-001 (dim 1) → cosine 0.0 < 0.45
+                $QVec = [double[]]::new(384); $QVec[0] = 1.0
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_0' = $QVec } }
+
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'saf-bel-001'; attribution_text = 'misaligned text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+
+                $kp.retrieval_low_confidence | Should -Be $true
+                $kp.retrieval_confidence     | Should -Be 0.0
+            }
+        }
+    }
+
+    Context 'taxonomy_node_candidates — top-3 and assigned node inclusion' {
+        It 'top-3 candidates are sorted descending by score' {
+            InModuleScope AITriad {
+                $QVec = [double[]]::new(384); $QVec[0] = 1.0
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_0' = $QVec } }
+
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'aligned text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+
+                $candidates = @($kp.taxonomy_node_candidates)
+                $candidates.Count | Should -BeLessOrEqual 3
+                $candidates[0].score | Should -BeGreaterOrEqual $candidates[-1].score
+            }
+        }
+
+        It 'includes the assigned node in candidates when it ranks in the top-3' {
+            InModuleScope AITriad {
+                # acc-bel-001 scores 1.0 → top of ranking → must appear in top-3
+                $QVec = [double[]]::new(384); $QVec[0] = 1.0
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_0' = $QVec } }
+
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'aligned text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+
+                $candidateIds = @($kp.taxonomy_node_candidates | ForEach-Object { $_.id })
+                $candidateIds | Should -Contain 'acc-bel-001'
+            }
+        }
+
+        It 'candidate labels come from TaxonomyData' {
+            InModuleScope AITriad {
+                $QVec = [double[]]::new(384); $QVec[0] = 1.0
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_0' = $QVec } }
+
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'aligned text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+
+                $top = $kp.taxonomy_node_candidates | Where-Object { $_.id -eq 'acc-bel-001' }
+                $top.label | Should -Be 'Accelerationist Belief 1'
+            }
+        }
+
+        It 'emits empty string label for node not found in TaxonomyData (rare fallback)' {
+            InModuleScope AITriad {
+                # Add cached embedding for a node not in TaxonomyData
+                $GhostVec = [double[]]::new(384); $GhostVec[2] = 1.0
+                $script:CachedEmbeddings['ghost-001'] = $GhostVec
+
+                $QVec = [double[]]::new(384); $QVec[2] = 1.0  # aligns with ghost-001 → score 1.0
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_0' = $QVec } }
+
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'ghost-001'; attribution_text = 'ghostly text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+
+                $top = @($kp.taxonomy_node_candidates)[0]
+                $top.id    | Should -Be 'ghost-001'
+                $top.label | Should -Be ''
+            }
+        }
+    }
+
+    Context 'graceful degradation' {
+        It 'skips all key_points when CachedEmbeddings is empty' {
+            InModuleScope AITriad {
+                $script:CachedEmbeddings = @{}
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'some text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+                $kp.PSObject.Properties.Name | Should -Not -Contain 'retrieval_confidence'
+            }
+        }
+
+        It 'skips all key_points when CachedEmbeddings is null' {
+            InModuleScope AITriad {
+                $script:CachedEmbeddings = $null
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'some text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+                $kp.PSObject.Properties.Name | Should -Not -Contain 'retrieval_confidence'
+            }
+        }
+
+        It 'skips all key_points when batch-encode subprocess fails' {
+            InModuleScope AITriad {
+                Mock Invoke-BatchEmbedAttribution { return $null }
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'some text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+                $kp.PSObject.Properties.Name | Should -Not -Contain 'retrieval_confidence'
+            }
+        }
+
+        It 'skips key_points with null taxonomy_node_id' {
+            InModuleScope AITriad {
+                Mock Invoke-BatchEmbedAttribution { @{} }
+                $kp = [PSCustomObject]@{ taxonomy_node_id = $null; attribution_text = 'some text'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+                $kp.PSObject.Properties.Name | Should -Not -Contain 'retrieval_confidence'
+            }
+        }
+
+        It 'skips key_points missing the attribution_text property' {
+            InModuleScope AITriad {
+                Mock Invoke-BatchEmbedAttribution { @{} }
+                $kp = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; point = 'claim' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp) -Threshold 0.45
+                $kp.PSObject.Properties.Name | Should -Not -Contain 'retrieval_confidence'
+            }
+        }
+
+        It 'processes key_points with a vector independently of those without one' {
+            InModuleScope AITriad {
+                $QVec = [double[]]::new(384); $QVec[0] = 1.0
+                # Batch-encode returns only kp_1 (simulating kp_0 missing from response)
+                Mock Invoke-BatchEmbedAttribution { @{ 'kp_1' = $QVec } }
+
+                $kp0 = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'text 0'; point = 'claim 0' }
+                $kp1 = [PSCustomObject]@{ taxonomy_node_id = 'acc-bel-001'; attribution_text = 'text 1'; point = 'claim 1' }
+                Invoke-RetrievalConfidencePass -KeyPoints @($kp0, $kp1) -Threshold 0.45
+
+                # kp0 has no vector returned → no confidence fields
+                $kp0.PSObject.Properties.Name | Should -Not -Contain 'retrieval_confidence'
+                # kp1 has a vector → fields written
+                $kp1.PSObject.Properties.Name | Should -Contain 'retrieval_confidence'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New private helper `Invoke-RetrievalConfidencePass` batch-embeds all `attribution_text` values in one Python subprocess call per document
- Computes cosine similarity against cached node embeddings; writes `retrieval_confidence`, `taxonomy_node_candidates` (top-3, assigned node included when it ranks), `retrieval_low_confidence` to each key_point PSObject
- `$script:RetrievalConfidenceThreshold = 0.45` added to module init (provisional — calibrate against SAF-167 distribution per t/2288#3)
- Degrades gracefully on subprocess failure or empty embedding cache (never throws)

## Design
Approved at t/2288#3. Metric confirmed by Comp Linguist at t/2288#4: bi-encoder cosine is correct because cross-encoder rerank (t/2287) is off by default — cosine IS the assignment score today.

## Test plan
- [x] 14 new Pester tests in `tests/Invoke-RetrievalConfidencePass.Tests.ps1`
- [x] Full suite: 950 passed, 0 failed, 51 skipped
- [x] Covers: happy path, threshold boundary, top-3 inclusion of assigned node, label lookup, graceful degradation (6 skip cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)