### PR TITLE
feat(summary-viewer): real PDF viewer in pane 3 (Phase 1) — t/2291

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
 
   summary-viewer:
     dependencies:
+      pdfjs-dist:
+        specifier: ^6.2.108
+        version: 6.2.108
       react:
         specifier: ^19.2.8
         version: 19.2.8

--- a/summary-viewer/THIRD-PARTY-NOTICES.txt
+++ b/summary-viewer/THIRD-PARTY-NOTICES.txt
@@ -929,5 +929,190 @@ THE SOFTWARE.
 
 -----------
 
+The following npm package may be included in this product:
+
+ - pdfjs-dist@6.2.108
+
+This package contains the following license:
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+-----------
+
 This file was generated with the generate-license-file npm package!
 https://www.npmjs.com/package/generate-license-file

--- a/summary-viewer/package.json
+++ b/summary-viewer/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "pdfjs-dist": "^6.2.108",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",

--- a/summary-viewer/src/main/fileIO.ts
+++ b/summary-viewer/src/main/fileIO.ts
@@ -739,3 +739,22 @@ export function readSnapshot(sourceId: string): string {
   }
   return fs.readFileSync(filePath, 'utf-8');
 }
+
+// === Raw PDF resolution (mirrors poviewer/src/main/fileIO.ts) ===
+// The renderer is sandboxed (no fs), so the raw PDF is read here and shipped
+// over IPC as bytes. Sources store the original document under <id>/raw/*.pdf.
+
+export function findRawPdfPath(sourceId: string): string | null {
+  const rawDir = path.join(SOURCES_DIR, sourceId, 'raw');
+  if (!fs.existsSync(rawDir)) return null;
+  const files = fs.readdirSync(rawDir);
+  const pdf = files.find(f => f.toLowerCase().endsWith('.pdf'));
+  if (!pdf) return null;
+  return path.join(rawDir, pdf);
+}
+
+export function readRawPdfBytes(sourceId: string): Buffer | null {
+  const pdfPath = findRawPdfPath(sourceId);
+  if (!pdfPath) return null;
+  return fs.readFileSync(pdfPath);
+}

--- a/summary-viewer/src/main/ipcHandlers.ts
+++ b/summary-viewer/src/main/ipcHandlers.ts
@@ -20,6 +20,7 @@ import {
   updateNodeFields,
   persistEdges,
   getNodesByPovCategory,
+  readRawPdfBytes,
   PROJECT_ROOT,
 } from './fileIO';
 import type { AddTaxonomyNodeRequest } from './fileIO';
@@ -112,6 +113,15 @@ export function registerIpcHandlers(): void {
 
   validatedHandle('clipboard-write-text', oneString, (_event, text) => {
     clipboard.writeText(text);
+  });
+
+  // Ships the raw PDF for a source to the sandboxed renderer as an ArrayBuffer
+  // (pane 3 real-PDF viewer). Returns null when the source has no raw PDF —
+  // the renderer falls back to the Markdown snapshot. Mirrors poviewer.
+  validatedHandle('get-pdf-bytes', oneString, (_event, sourceId) => {
+    const buf = readRawPdfBytes(sourceId);
+    if (!buf) return null;
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
   });
 
   // === Optional / string + optional string ===

--- a/summary-viewer/src/main/preload.ts
+++ b/summary-viewer/src/main/preload.ts
@@ -22,6 +22,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   loadSnapshot: (sourceId: string): Promise<string> =>
     ipcRenderer.invoke('load-snapshot', sourceId),
 
+  getPdfBytes: (sourceId: string): Promise<ArrayBuffer | null> =>
+    ipcRenderer.invoke('get-pdf-bytes', sourceId),
+
   loadTaxonomy: (): Promise<unknown> =>
     ipcRenderer.invoke('load-taxonomy'),
 

--- a/summary-viewer/src/renderer/components/DocumentPane.tsx
+++ b/summary-viewer/src/renderer/components/DocumentPane.tsx
@@ -8,6 +8,7 @@ import remarkGfm from 'remark-gfm';
 import { useStore } from '../store/useStore';
 import { buildSearchRegex, type SearchMode } from '../utils/searchRegex';
 import { cosineSimilarity } from '../utils/similarity';
+import PdfViewer from './PdfViewer';
 
 export default function DocumentPane() {
   const selectedKeyPoint = useStore(s => s.selectedKeyPoint);
@@ -32,6 +33,9 @@ export default function DocumentPane() {
     index: number; text: string; score: number; el: HTMLElement;
   }>>([]);
 
+  // ── PDF mode state (Phase 1, t/2291) ──────────────────────────────
+  const [pdfData, setPdfData] = useState<ArrayBuffer | null>(null);
+
   const keyPointData = useMemo(() => {
     if (!selectedKeyPoint) return null;
     const summary = summaries[selectedKeyPoint.docId];
@@ -42,6 +46,31 @@ export default function DocumentPane() {
 
   const snapshotText = selectedKeyPoint ? snapshots[selectedKeyPoint.docId] || '' : '';
   const source = selectedKeyPoint ? sources.find(s => s.id === selectedKeyPoint.docId) : null;
+  const isPdfSource = source?.sourceType === 'pdf';
+
+  // ── Fetch raw PDF bytes for pdf-type sources; null → Markdown fallback ──
+  // (no raw PDF on disk, fetch error, or non-pdf type all leave pdfData null).
+  useEffect(() => {
+    if (!selectedKeyPoint || !isPdfSource) {
+      setPdfData(null);
+      return;
+    }
+    let cancelled = false;
+    setPdfData(null);
+    window.electronAPI.getPdfBytes(selectedKeyPoint.docId)
+      .then(bytes => { if (!cancelled) setPdfData(bytes); })
+      .catch(err => {
+        getGlobalRecorder()?.record({
+          type: 'system.error',
+          component: 'document-pane',
+          level: 'error',
+          message: 'getPdfBytes failed',
+          error: { name: (err as Error).name ?? 'Error', message: String(err) },
+        });
+        if (!cancelled) setPdfData(null);
+      });
+    return () => { cancelled = true; };
+  }, [selectedKeyPoint, isPdfSource]);
 
   // Find and highlight the verbatim quote in the snapshot
   const renderedContent = useMemo(() => {
@@ -506,6 +535,33 @@ export default function DocumentPane() {
             Click a key point, claim, or concept to view its source document
           </div>
         </div>
+      </>
+    );
+  }
+
+  // PDF mode — render the real PDF viewer instead of the Markdown shadow.
+  // Falls through to the Markdown render below when pdfData is null (no raw
+  // PDF, still loading, or fetch failed). Find/Similar/verbatim-highlight are
+  // Markdown-only in Phase 1 (t/2291); the excerpt banner is kept since it
+  // doesn't depend on the rendered document DOM.
+  if (isPdfSource && pdfData) {
+    return (
+      <>
+        <div className="pane-header">
+          <h2>{source?.title || selectedKeyPoint.docId}</h2>
+        </div>
+        {keyPointData && (
+          <div className="excerpt-banner">
+            <div className="excerpt-banner-label">Excerpt Context</div>
+            <div className="excerpt-banner-context">{keyPointData.excerpt_context}</div>
+            {keyPointData.verbatim && (
+              <div className="excerpt-banner-quote">
+                &ldquo;{keyPointData.verbatim}&rdquo;
+              </div>
+            )}
+          </div>
+        )}
+        <PdfViewer data={pdfData} />
       </>
     );
   }

--- a/summary-viewer/src/renderer/components/PdfViewer.css
+++ b/summary-viewer/src/renderer/components/PdfViewer.css
@@ -1,0 +1,159 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/* PDF viewer (pane 3) — ported from poviewer's pdf styles, trimmed to the
+   subset this viewer uses (no point chips, no context menu, no highlight).
+   All tokens resolve against summary-viewer's :root. The `spin` keyframe is
+   defined once in styles.css and reused here. */
+
+.pdf-viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.pdf-viewer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px var(--pane-padding);
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-card);
+  flex-shrink: 0;
+}
+
+.pdf-viewer-badge {
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  background: rgba(231, 76, 60, 0.12);
+  color: var(--color-saf);
+  text-transform: uppercase;
+}
+
+.pdf-viewer-info {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+.pdf-toolbar-spacer {
+  flex: 1;
+}
+
+.pdf-zoom-btn {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-input);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: var(--font-size-lg);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+  transition: all 0.1s;
+}
+
+.pdf-zoom-btn:hover {
+  color: var(--text-bright);
+  border-color: var(--text-muted);
+}
+
+.pdf-scale-label {
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  min-width: 36px;
+  text-align: center;
+}
+
+.pdf-scroll-container {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 0;
+  background: var(--bg-app);
+}
+
+.pdf-page-wrapper {
+  background: white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  flex-shrink: 0;
+}
+
+.pdf-page-canvas {
+  display: block;
+}
+
+.pdf-page-number {
+  text-align: center;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  padding: 4px 0 2px;
+}
+
+.pdf-page-loading {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.pdf-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: 100%;
+  color: var(--text-secondary);
+}
+
+.spinner-ring {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--border-color);
+  border-top-color: var(--color-acc);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+/* pdf.js text layer — transparent, absolutely-positioned spans over the canvas
+   so text is selectable/copyable. Positioning CSS is token-free and copied
+   verbatim from the pdf.js reference viewer. */
+.textLayer {
+  position: absolute;
+  text-align: initial;
+  inset: 0;
+  overflow: hidden;
+  opacity: 0.25;
+  line-height: 1;
+  -webkit-text-size-adjust: none;
+  -moz-text-size-adjust: none;
+  text-size-adjust: none;
+  forced-color-adjust: none;
+  transform-origin: 0 0;
+  z-index: 2;
+}
+
+.textLayer :is(span, br) {
+  color: transparent;
+  position: absolute;
+  white-space: pre;
+  cursor: text;
+  transform-origin: 0% 0%;
+}
+
+.textLayer span::selection {
+  background: rgba(59, 130, 246, 0.35);
+}

--- a/summary-viewer/src/renderer/components/PdfViewer.tsx
+++ b/summary-viewer/src/renderer/components/PdfViewer.tsx
@@ -1,0 +1,289 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Real embedded PDF viewer for pane 3 — a trimmed port of poviewer's PdfViewer.
+// Renders a source's raw PDF (canvas + selectable pdf.js text layer) with lazy,
+// IntersectionObserver-driven page rendering and zoom. Phase 1 (t/2291): no
+// point overlays, no excerpt analysis, no in-document search — the DocumentPane
+// search/highlight features remain Markdown-only until Phase 2 re-plumbs them
+// onto the text layer.
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import * as pdfjsLib from 'pdfjs-dist';
+import { TextLayer } from 'pdfjs-dist';
+import pdfjsWorkerUrl from 'pdfjs-dist/build/pdf.worker.mjs?url';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import './PdfViewer.css';
+
+// Configure pdf.js worker — version-locked via Vite ?url import from pdfjs-dist
+// (same-origin asset, so it runs under the existing CSP unchanged).
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorkerUrl;
+
+type PDFDocumentProxy = Awaited<ReturnType<typeof pdfjsLib.getDocument>['promise']>;
+type PDFPageProxy = Awaited<ReturnType<PDFDocumentProxy['getPage']>>;
+
+interface Props {
+  /** Raw PDF bytes shipped from the main process over IPC. */
+  data: ArrayBuffer;
+}
+
+// === PdfPageView (single page canvas + selectable text layer) ===
+
+interface PageViewProps {
+  pdfDoc: PDFDocumentProxy;
+  pageIndex: number;
+  scale: number;
+  isVisible: boolean;
+}
+
+function PdfPageView({ pdfDoc, pageIndex, scale, isVisible }: PageViewProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const textLayerRef = useRef<HTMLDivElement>(null);
+  const [rendered, setRendered] = useState(false);
+  const [pageSize, setPageSize] = useState<{ width: number; height: number } | null>(null);
+  const renderTaskRef = useRef<ReturnType<PDFPageProxy['render']> | null>(null);
+  const textLayerInstanceRef = useRef<TextLayer | null>(null);
+
+  useEffect(() => {
+    if (!isVisible) return;
+
+    let cancelled = false;
+
+    async function renderPage() {
+      try {
+        const page = await pdfDoc.getPage(pageIndex + 1);
+        if (cancelled) return;
+
+        const viewport = page.getViewport({ scale });
+        setPageSize({ width: viewport.width, height: viewport.height });
+
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+
+        canvas.width = viewport.width * window.devicePixelRatio;
+        canvas.height = viewport.height * window.devicePixelRatio;
+        canvas.style.width = `${viewport.width}px`;
+        canvas.style.height = `${viewport.height}px`;
+
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+        ctx.setTransform(window.devicePixelRatio, 0, 0, window.devicePixelRatio, 0, 0);
+
+        if (renderTaskRef.current) {
+          renderTaskRef.current.cancel();
+        }
+
+        const renderTask = page.render({ canvasContext: ctx, viewport, canvas });
+        renderTaskRef.current = renderTask;
+        await renderTask.promise;
+        if (cancelled) return;
+
+        // Render selectable text layer over the canvas
+        const textLayerDiv = textLayerRef.current;
+        if (textLayerDiv) {
+          textLayerDiv.innerHTML = '';
+          textLayerDiv.style.width = `${viewport.width}px`;
+          textLayerDiv.style.height = `${viewport.height}px`;
+
+          if (textLayerInstanceRef.current) {
+            textLayerInstanceRef.current.cancel();
+          }
+
+          const textContent = await page.getTextContent();
+          if (cancelled) return;
+
+          const textLayer = new TextLayer({
+            textContentSource: textContent,
+            container: textLayerDiv,
+            viewport,
+          });
+          textLayerInstanceRef.current = textLayer;
+          await textLayer.render();
+        }
+
+        if (!cancelled) setRendered(true);
+      } catch (err: unknown) {
+        if (err instanceof Error && err.message !== 'Rendering cancelled') {
+          getGlobalRecorder()?.record({
+            type: 'system.error',
+            component: 'pdf-viewer',
+            level: 'error',
+            message: `Error rendering page ${pageIndex + 1}`,
+            error: { name: err.name, message: err.message },
+          });
+          console.error(`[PdfViewer] Error rendering page ${pageIndex + 1}:`, err);
+        }
+        /* telemetry — silent by design (rendering cancelled) */
+      }
+    }
+
+    renderPage();
+
+    return () => {
+      cancelled = true;
+      if (renderTaskRef.current) {
+        renderTaskRef.current.cancel();
+        renderTaskRef.current = null;
+      }
+      if (textLayerInstanceRef.current) {
+        textLayerInstanceRef.current.cancel();
+        textLayerInstanceRef.current = null;
+      }
+    };
+  }, [pdfDoc, pageIndex, scale, isVisible]);
+
+  const width = pageSize?.width ?? 612 * scale;
+  const height = pageSize?.height ?? 792 * scale;
+
+  return (
+    <div className="pdf-page-wrapper" style={{ width, height, position: 'relative' }}>
+      <canvas ref={canvasRef} className="pdf-page-canvas" />
+      <div ref={textLayerRef} className="textLayer" />
+      {!rendered && isVisible && (
+        <div className="pdf-page-loading">Loading page {pageIndex + 1}...</div>
+      )}
+    </div>
+  );
+}
+
+// === PdfViewer (main component) ===
+
+export default function PdfViewer({ data }: Props) {
+  const [pdfDoc, setPdfDoc] = useState<PDFDocumentProxy | null>(null);
+  const [numPages, setNumPages] = useState(0);
+  const [scale, setScale] = useState(1.0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [visiblePages, setVisiblePages] = useState<Set<number>>(new Set());
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Load the PDF document from the provided bytes
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadPdf() {
+      setLoading(true);
+      setError(null);
+      setPdfDoc(null);
+      setVisiblePages(new Set());
+
+      try {
+        // getDocument transfers the buffer, so pass a copy to keep `data` reusable
+        // across re-renders (source switches).
+        const bytes = new Uint8Array(data.slice(0));
+        const doc = await pdfjsLib.getDocument({ data: bytes }).promise;
+        if (cancelled) return;
+        setPdfDoc(doc);
+        setNumPages(doc.numPages);
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          getGlobalRecorder()?.record({
+            type: 'system.error',
+            component: 'pdf-viewer',
+            level: 'error',
+            message: 'Failed to load PDF',
+            error: { name: (err as Error).name ?? 'Error', message: String(err) },
+          });
+          console.error('[PdfViewer] Failed to load PDF:', err);
+          setError(err instanceof Error ? err.message : 'Failed to load PDF');
+          setLoading(false);
+        }
+        /* telemetry — silent by design (cancelled) */
+      }
+    }
+
+    loadPdf();
+    return () => { cancelled = true; };
+  }, [data]);
+
+  // Lazily render pages as they scroll into view (+ neighbours)
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !pdfDoc) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        setVisiblePages(prev => {
+          const next = new Set(prev);
+          for (const entry of entries) {
+            const pageIdx = Number(entry.target.getAttribute('data-page-index'));
+            if (entry.isIntersecting) {
+              next.add(pageIdx);
+              if (pageIdx > 0) next.add(pageIdx - 1);
+              if (pageIdx < numPages - 1) next.add(pageIdx + 1);
+            }
+          }
+          return next;
+        });
+      },
+      { root: container, rootMargin: '200px 0px', threshold: 0 },
+    );
+
+    const sentinels = container.querySelectorAll<HTMLDivElement>('[data-page-index]');
+    sentinels.forEach(el => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [pdfDoc, numPages]);
+
+  const handleZoomIn = useCallback(() => setScale(s => Math.min(s + 0.25, 3.0)), []);
+  const handleZoomOut = useCallback(() => setScale(s => Math.max(s - 0.25, 0.5)), []);
+
+  if (loading) {
+    return (
+      <div className="pdf-viewer">
+        <div className="pdf-viewer-header">
+          <span className="pdf-viewer-badge">PDF</span>
+          <span className="pdf-viewer-info">Loading PDF...</span>
+        </div>
+        <div className="pdf-loading">
+          <div className="spinner-ring" />
+          <span>Rendering PDF document...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="pdf-viewer">
+        <div className="pdf-viewer-header">
+          <span className="pdf-viewer-badge">PDF</span>
+          <span className="pdf-viewer-info">Error</span>
+        </div>
+        <div className="pdf-loading">
+          <span style={{ color: 'var(--color-saf)' }}>Failed to load PDF: {error}</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!pdfDoc) return null;
+
+  return (
+    <div className="pdf-viewer">
+      <div className="pdf-viewer-header">
+        <span className="pdf-viewer-badge">PDF</span>
+        <span className="pdf-viewer-info">{numPages} pages</span>
+        <div className="pdf-toolbar-spacer" />
+        <button className="pdf-zoom-btn" onClick={handleZoomOut} title="Zoom out">&minus;</button>
+        <span className="pdf-scale-label">{Math.round(scale * 100)}%</span>
+        <button className="pdf-zoom-btn" onClick={handleZoomIn} title="Zoom in">+</button>
+      </div>
+      <div className="pdf-scroll-container" ref={scrollContainerRef}>
+        {Array.from({ length: numPages }, (_, i) => (
+          <div key={i} data-page-index={i}>
+            <PdfPageView
+              pdfDoc={pdfDoc}
+              pageIndex={i}
+              scale={scale}
+              isVisible={visiblePages.has(i)}
+            />
+            <div className="pdf-page-number">Page {i + 1}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/summary-viewer/src/renderer/types/electron.d.ts
+++ b/summary-viewer/src/renderer/types/electron.d.ts
@@ -28,6 +28,7 @@ export interface ElectronAPI {
   discoverSources: () => Promise<unknown[]>;
   loadSummary: (docId: string) => Promise<unknown>;
   loadSnapshot: (sourceId: string) => Promise<string>;
+  getPdfBytes: (sourceId: string) => Promise<ArrayBuffer | null>;
   loadTaxonomy: () => Promise<unknown>;
   loadPolicyRegistry: () => Promise<unknown>;
   addTaxonomyNode: (req: AddTaxonomyNodeRequest) => Promise<AddTaxonomyNodeResult>;


### PR DESCRIPTION
Implements **t/2291** (design note: t/2284#1). PDF-type sources now render as a real paged PDF in pane 3 (canvas + selectable pdf.js text layer, lazy IntersectionObserver paging, zoom) instead of the garbled Markdown shadow. Direct, trimmed port of poviewer's proven `get-pdf-bytes` IPC + viewer pattern.

## Changes
**Main process** (`summary-viewer/src/main/`)
- `fileIO.ts`: `findRawPdfPath` / `readRawPdfBytes` (`<id>/raw/*.pdf`)
- `ipcHandlers.ts`: `get-pdf-bytes` `validatedHandle` → `ArrayBuffer|null`
- `preload.ts` + `electron.d.ts`: `getPdfBytes(sourceId)`

**Renderer** (`summary-viewer/src/renderer/`)
- New `PdfViewer.tsx` (~290 LOC) + co-located `PdfViewer.css` (dropped poviewer's point chips / excerpt menu / text mapping; all CSS tokens resolve in summary-viewer)
- `DocumentPane.tsx`: routes `sourceType === 'pdf'` + bytes-present → `<PdfViewer>` via early return; **Markdown path unchanged** and remains the fallback (null bytes → Markdown, covering the 31/739 no-raw-PDF sources + non-pdf types)

**Build**
- `pdfjs-dist ^6.2.108` (matches poviewer); workspace-root `pnpm-lock.yaml` +3 lines (reuses poviewer's locked version)
- **No CSP/sandbox change** — worker bundles as a same-origin `?url` asset (confirmed in `vite build` output)

## Scope
Phase 1 only. Find-in-document / Similar / verbatim-highlight stay **Markdown-only** (they walk the Markdown DOM); PDF-mode re-plumbing tracked in **t/2292**.

## Notes / deviation
`THIRD-PARTY-NOTICES.txt`: pdfjs-dist Apache-2.0 block **appended manually** (version-matched to poviewer's repo-blessed block). `generate-license-file` under pnpm's non-flat `node_modules` only resolves direct deps — auto-regen would have **truncated 99 legit transitive entries** (react-markdown's micromark/mdast/unist tree). Diff is purely additive (+185/−0); no existing entry dropped. The `licenses` script itself is broken under pnpm and worth a separate fix.

## Verify (worktree)
tsc main ✓ · tsc renderer ✓ · vite build ✓ · eslint ✓ · vitest 14/14 ✓

Runtime visual sign-off not performed (build/type/test only); port is faithful to poviewer so risk is low.