### PR TITLE
feat(retrieval): Excludes-veto pass for taxonomy node assignments (t/2286)

### DIFF
--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -573,6 +573,8 @@ $script:TaxonomyCacheLastCheck = $null  # UTC time of last staleness check (cool
 # Provisional threshold (0.45) — calibrate against SAF-167 repro case and a
 # good-vs-bad attribution distribution before treating this as a tuned gate.
 $script:RetrievalConfidenceThreshold = 0.45
+# CL-owned: veto when sim(kp, excludes_text) - sim(kp, core_text) > this margin (0.0 = any positive margin).
+$script:ExcludesVetoMargin = 0.0
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Load ai-models.json — single source of truth for backend/model lists

--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -854,6 +854,24 @@ function Finalize-Summary {
         }
     }
 
+    # -- Excludes-veto pass (t/2286) ------------------------------------------
+    # Runs after confidence pass so retrieval_low_confidence is already present.
+    if ($script:TaxonomyData -and $script:TaxonomyData.Count -gt 0) {
+        $AllKpsForVeto = [System.Collections.Generic.List[object]]::new()
+        foreach ($Camp in $Camps) {
+            $CampDataVeto = $SummaryObject.pov_summaries.$Camp
+            if (-not $CampDataVeto -or -not (Has-Field $CampDataVeto 'key_points')) { continue }
+            $kpListVeto = Get-Field $CampDataVeto 'key_points'
+            if ($kpListVeto) { foreach ($kp in @($kpListVeto)) { [void]$AllKpsForVeto.Add($kp) } }
+        }
+        if ($AllKpsForVeto.Count -gt 0) {
+            $VetoStats = Invoke-ExcludesVetoPass -KeyPoints $AllKpsForVeto.ToArray()
+            if ($VetoStats.VetoCount -gt 0 -or $VetoStats.AmbiguousCount -gt 0) {
+                Write-Host "  │  excludes-veto: $($VetoStats.VetoCount) vetoed, $($VetoStats.AmbiguousCount) ambiguous" -ForegroundColor DarkYellow
+            }
+        }
+    }
+
     $SoProps = $SummaryObject.PSObject.Properties
     if ($SoProps['factual_claims'] -and $null -ne $SummaryObject.factual_claims) { $FactualClaims = $SummaryObject.factual_claims } else { $FactualClaims = @() }
     if ($SoProps['unmapped_concepts'] -and $null -ne $SummaryObject.unmapped_concepts) { $UnmappedConcs = $SummaryObject.unmapped_concepts } else { $UnmappedConcs = @() }

--- a/scripts/AITriad/Private/Test-ExcludesVeto.ps1
+++ b/scripts/AITriad/Private/Test-ExcludesVeto.ps1
@@ -1,0 +1,151 @@
+function Get-ExcludesFragments {
+    [CmdletBinding()]
+    param([string]$Description)
+    $MarkerIdx = $Description.IndexOf('Excludes:', [System.StringComparison]::OrdinalIgnoreCase)
+    if ($MarkerIdx -lt 0) { return $null }
+    $Core = $Description.Substring(0, $MarkerIdx).Trim()
+    $Excl = $Description.Substring($MarkerIdx + 'Excludes:'.Length).Trim()
+    if ([string]::IsNullOrWhiteSpace($Core) -or [string]::IsNullOrWhiteSpace($Excl)) { return $null }
+    return @{ Core = $Core; Excludes = $Excl }
+}
+
+function Invoke-BatchEmbedVeto {
+    [CmdletBinding()]
+    param([System.Collections.Generic.List[hashtable]]$Items)
+    $EmbedScript = Join-Path (Join-Path $script:RepoRoot 'scripts') 'embed_taxonomy.py'
+    if (-not (Test-Path $EmbedScript)) { $EmbedScript = Join-Path $script:ModuleRoot 'embed_taxonomy.py' }
+    if (-not (Test-Path $EmbedScript)) { return $null }
+    $BatchItems = [System.Collections.Generic.List[object]]::new()
+    foreach ($Item in $Items) { $BatchItems.Add([ordered]@{ id = $Item.EmbedId; text = $Item.Text }) }
+    $BatchJson = $BatchItems | ConvertTo-Json -Compress -Depth 3
+    try {
+        $Raw = $BatchJson | & python $EmbedScript batch-encode 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($Raw)) { return $null }
+        $Parsed = $Raw | ConvertFrom-Json
+        $Map = @{}
+        foreach ($Prop in $Parsed.PSObject.Properties) { $Map[$Prop.Name] = [double[]]@($Prop.Value) }
+        return $Map
+    } catch { return $null }
+}
+
+function Test-ExcludesVeto {
+    [CmdletBinding()]
+    param(
+        [double[]]$KpVec,
+        [double[]]$CoreVec,
+        [double[]]$ExclVec,
+        [double]$VetoMargin
+    )
+    $Dim = $KpVec.Count
+    if ($CoreVec.Count -ne $Dim -or $ExclVec.Count -ne $Dim) {
+        return @{ Verdict = 'Pass'; Margin = 0.0 }
+    }
+    $KpNormSq = 0.0; $CoreNormSq = 0.0; $ExclNormSq = 0.0
+    $DotCore  = 0.0; $DotExcl    = 0.0
+    for ($i = 0; $i -lt $Dim; $i++) {
+        $KpNormSq   += $KpVec[$i]   * $KpVec[$i]
+        $CoreNormSq += $CoreVec[$i] * $CoreVec[$i]
+        $ExclNormSq += $ExclVec[$i] * $ExclVec[$i]
+        $DotCore    += $KpVec[$i]   * $CoreVec[$i]
+        $DotExcl    += $KpVec[$i]   * $ExclVec[$i]
+    }
+    $KpNorm   = [Math]::Sqrt($KpNormSq)
+    $CoreNorm = [Math]::Sqrt($CoreNormSq)
+    $ExclNorm = [Math]::Sqrt($ExclNormSq)
+    $SimCore  = if ($KpNorm * $CoreNorm -gt 0.0) { $DotCore / ($KpNorm * $CoreNorm) } else { 0.0 }
+    $SimExcl  = if ($KpNorm * $ExclNorm -gt 0.0) { $DotExcl / ($KpNorm * $ExclNorm) } else { 0.0 }
+    $Margin   = [Math]::Round($SimExcl - $SimCore, 6)
+    $Verdict  = if ($Margin -gt $VetoMargin)    { 'Veto' }
+                elseif ($Margin -gt 0.0)         { 'Ambiguous' }
+                else                              { 'Pass' }
+    return @{ Verdict = $Verdict; Margin = $Margin }
+}
+
+function Invoke-ExcludesVetoPass {
+    [CmdletBinding()]
+    param([object[]]$KeyPoints)
+    if (-not $script:TaxonomyData -or $script:TaxonomyData.Count -eq 0) {
+        return @{ VetoCount = 0; AmbiguousCount = 0 }
+    }
+
+    # Build flat node description map
+    $NodeDescMap = @{}
+    foreach ($PovKey in $script:TaxonomyData.Keys) {
+        $PovObj = $script:TaxonomyData[$PovKey]
+        if (-not $PovObj.PSObject.Properties['nodes']) { continue }
+        foreach ($N in @($PovObj.nodes)) {
+            if ($N.PSObject.Properties['id'] -and $N.PSObject.Properties['description']) {
+                $NodeDescMap[[string]$N.id] = [string]$N.description
+            }
+        }
+    }
+
+    # Collect candidate kps and cache parsed Excludes: fragments per node
+    $Candidates    = [System.Collections.Generic.List[hashtable]]::new()
+    $NodeFragments = @{}  # nodeId → @{Core; Excludes} or $null sentinel
+    for ($Idx = 0; $Idx -lt $KeyPoints.Count; $Idx++) {
+        $kp = $KeyPoints[$Idx]
+        if (-not $kp.PSObject.Properties['taxonomy_node_id']) { continue }
+        $NodeId = [string]$kp.taxonomy_node_id
+        if ([string]::IsNullOrWhiteSpace($NodeId)) { continue }
+        if (-not $kp.PSObject.Properties['attribution_text']) { continue }
+        $AttrText = [string]$kp.attribution_text
+        if ([string]::IsNullOrWhiteSpace($AttrText)) { continue }
+        if (-not $NodeDescMap.ContainsKey($NodeId)) { continue }
+        if (-not $NodeFragments.ContainsKey($NodeId)) {
+            $Frags = Get-ExcludesFragments -Description $NodeDescMap[$NodeId]
+            $NodeFragments[$NodeId] = $Frags  # $null = no Excludes: marker; stored to skip re-parse
+            if ($null -eq $Frags) { continue }
+        } elseif ($null -eq $NodeFragments[$NodeId]) {
+            continue
+        }
+        $Candidates.Add(@{ Idx = $Idx; KeyPoint = $kp; NodeId = $NodeId; Text = $AttrText })
+    }
+
+    if ($Candidates.Count -eq 0) { return @{ VetoCount = 0; AmbiguousCount = 0 } }
+
+    # Build single batch: kp texts + unique core/excl node fragments
+    $BatchItems = [System.Collections.Generic.List[hashtable]]::new()
+    foreach ($Cand in $Candidates) {
+        $BatchItems.Add(@{ EmbedId = "vkp_$($Cand.Idx)"; Text = $Cand.Text })
+    }
+    foreach ($NodeId in $NodeFragments.Keys) {
+        $Frags = $NodeFragments[$NodeId]
+        if ($null -eq $Frags) { continue }
+        $BatchItems.Add(@{ EmbedId = "vcore_$NodeId"; Text = $Frags.Core })
+        $BatchItems.Add(@{ EmbedId = "vexcl_$NodeId"; Text = $Frags.Excludes })
+    }
+
+    $VectorMap = Invoke-BatchEmbedVeto -Items $BatchItems
+    if ($null -eq $VectorMap) { return @{ VetoCount = 0; AmbiguousCount = 0 } }
+
+    $VetoCount      = 0
+    $AmbiguousCount = 0
+    $Delta          = $script:ExcludesVetoMargin
+
+    foreach ($Cand in $Candidates) {
+        $KpId   = "vkp_$($Cand.Idx)"
+        $CoreId = "vcore_$($Cand.NodeId)"
+        $ExclId = "vexcl_$($Cand.NodeId)"
+        if (-not $VectorMap.ContainsKey($KpId))  { continue }
+        if (-not $VectorMap.ContainsKey($CoreId)) { continue }
+        if (-not $VectorMap.ContainsKey($ExclId)) { continue }
+        $KpVec   = [double[]]$VectorMap[$KpId]
+        $CoreVec = [double[]]$VectorMap[$CoreId]
+        $ExclVec = [double[]]$VectorMap[$ExclId]
+        $Result  = Test-ExcludesVeto -KpVec $KpVec -CoreVec $CoreVec -ExclVec $ExclVec -VetoMargin $Delta
+        switch ($Result.Verdict) {
+            'Veto' {
+                Set-KeyPointField $Cand.KeyPoint 'taxonomy_node_id' $null
+                Set-KeyPointField $Cand.KeyPoint 'retrieval_low_confidence' $true
+                $VetoCount++
+            }
+            'Ambiguous' {
+                Set-KeyPointField $Cand.KeyPoint 'retrieval_low_confidence' $true
+                $AmbiguousCount++
+            }
+        }
+    }
+
+    return @{ VetoCount = $VetoCount; AmbiguousCount = $AmbiguousCount }
+}

--- a/tests/Test-ExcludesVeto.Tests.ps1
+++ b/tests/Test-ExcludesVeto.Tests.ps1
@@ -1,0 +1,222 @@
+BeforeAll {
+    Import-Module "$PSScriptRoot/../scripts/AITriad/AITriad.psm1" -Force
+}
+
+Describe 'Get-ExcludesFragments' -Tag 'retrieval' {
+    It 'Returns $null when no Excludes: marker present' {
+        InModuleScope AITriad {
+            $Result = Get-ExcludesFragments -Description 'Broad AI governance and policy mechanisms.'
+            $Result | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Splits description at Excludes: into Core and Excludes strings' {
+        InModuleScope AITriad {
+            $Result = Get-ExcludesFragments -Description 'Regulatory oversight mechanisms. Excludes: voluntary commitments only.'
+            $Result           | Should -Not -BeNullOrEmpty
+            $Result.Core      | Should -Be 'Regulatory oversight mechanisms.'
+            $Result.Excludes  | Should -Be 'voluntary commitments only.'
+        }
+    }
+
+    It 'Is case-insensitive on the Excludes: marker' {
+        InModuleScope AITriad {
+            $Result = Get-ExcludesFragments -Description 'Core content here. excludes: lower case marker.'
+            $Result           | Should -Not -BeNullOrEmpty
+            $Result.Core      | Should -Be 'Core content here.'
+            $Result.Excludes  | Should -Be 'lower case marker.'
+        }
+    }
+
+    It 'Returns $null when core text is empty (marker at start)' {
+        InModuleScope AITriad {
+            $Result = Get-ExcludesFragments -Description 'Excludes: something here'
+            $Result | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'Test-ExcludesVeto' -Tag 'retrieval' {
+    It 'Returns Veto when excludes sim > core sim and margin > delta' {
+        InModuleScope AITriad {
+            # sim(KpVec, ExclVec) = 1.0, sim(KpVec, CoreVec) = 0.0 → margin = 1.0 > delta (0.0) → Veto
+            $KpVec   = [double[]]::new(384); $KpVec[0]   = 1.0
+            $ExclVec = [double[]]::new(384); $ExclVec[0] = 1.0
+            $CoreVec = [double[]]::new(384); $CoreVec[1] = 1.0
+            $Result = Test-ExcludesVeto -KpVec $KpVec -CoreVec $CoreVec -ExclVec $ExclVec -VetoMargin 0.0
+            $Result.Verdict | Should -Be 'Veto'
+            $Result.Margin  | Should -BeGreaterThan 0.0
+        }
+    }
+
+    It 'Returns Pass when core sim >= excludes sim (margin <= 0)' {
+        InModuleScope AITriad {
+            # sim(KpVec, CoreVec) = 1.0, sim(KpVec, ExclVec) = 0.0 → margin = -1.0 ≤ 0 → Pass
+            $KpVec   = [double[]]::new(384); $KpVec[0]   = 1.0
+            $CoreVec = [double[]]::new(384); $CoreVec[0] = 1.0
+            $ExclVec = [double[]]::new(384); $ExclVec[1] = 1.0
+            $Result = Test-ExcludesVeto -KpVec $KpVec -CoreVec $CoreVec -ExclVec $ExclVec -VetoMargin 0.0
+            $Result.Verdict | Should -Be 'Pass'
+            $Result.Margin  | Should -BeLessOrEqual 0.0
+        }
+    }
+
+    It 'Returns Ambiguous when 0 < margin <= delta' {
+        InModuleScope AITriad {
+            # VecD = [0.6, 0.8, 0...]: sim(VecD, VecA) = 0.6, sim(VecD, VecB) = 0.8
+            # margin = 0.8 - 0.6 = 0.2; with delta = 0.3 → Ambiguous
+            $VecA = [double[]]::new(384); $VecA[0] = 1.0
+            $VecB = [double[]]::new(384); $VecB[1] = 1.0
+            $VecD = [double[]]::new(384); $VecD[0] = 0.6; $VecD[1] = 0.8
+            $Result = Test-ExcludesVeto -KpVec $VecD -CoreVec $VecA -ExclVec $VecB -VetoMargin 0.3
+            $Result.Verdict | Should -Be 'Ambiguous'
+            $Result.Margin  | Should -BeGreaterThan 0.0
+            $Result.Margin  | Should -BeLessOrEqual 0.3
+        }
+    }
+}
+
+Describe 'Invoke-ExcludesVetoPass' -Tag 'retrieval' {
+    It 'Nulls taxonomy_node_id and sets retrieval_low_confidence on Veto' {
+        InModuleScope AITriad {
+            $script:ExcludesVetoMargin = 0.0
+            $script:TaxonomyData = @{
+                'saf' = [PSCustomObject]@{
+                    nodes = @(
+                        [PSCustomObject]@{
+                            id          = 'saf-bel-167'
+                            label       = 'Behavioral telemetry'
+                            description = 'AI monitoring controls. Excludes: software-only behavioral telemetry.'
+                        }
+                    )
+                }
+            }
+            # kp and excludes both map to dim-0 unit vec; core maps to dim-1
+            # margin = sim(kp, excl) - sim(kp, core) = 1.0 - 0.0 = 1.0 > 0 → Veto
+            Mock Invoke-BatchEmbedVeto {
+                $V0 = [double[]]::new(384); $V0[0] = 1.0
+                $V1 = [double[]]::new(384); $V1[1] = 1.0
+                return @{
+                    'vkp_0'             = $V0
+                    'vcore_saf-bel-167' = $V1
+                    'vexcl_saf-bel-167' = $V0
+                }
+            }
+            $kp = [PSCustomObject]@{
+                taxonomy_node_id        = 'saf-bel-167'
+                attribution_text        = 'platform product mandates'
+                retrieval_low_confidence = $false
+            }
+            Invoke-ExcludesVetoPass -KeyPoints @($kp)
+            $kp.taxonomy_node_id        | Should -BeNullOrEmpty
+            $kp.retrieval_low_confidence | Should -BeTrue
+        }
+    }
+
+    It 'Does not veto kp assigned to a node without Excludes: marker' {
+        InModuleScope AITriad {
+            $script:ExcludesVetoMargin = 0.0
+            $script:TaxonomyData = @{
+                'acc' = [PSCustomObject]@{
+                    nodes = @(
+                        [PSCustomObject]@{
+                            id          = 'acc-bel-001'
+                            label       = 'AI progress'
+                            description = 'Belief in accelerating AI development.'
+                        }
+                    )
+                }
+            }
+            Mock Invoke-BatchEmbedVeto { return @{} }
+            $kp = [PSCustomObject]@{
+                taxonomy_node_id = 'acc-bel-001'
+                attribution_text = 'AI should advance quickly'
+            }
+            Invoke-ExcludesVetoPass -KeyPoints @($kp)
+            $kp.taxonomy_node_id | Should -Be 'acc-bel-001'
+            Assert-MockCalled Invoke-BatchEmbedVeto -Times 0
+        }
+    }
+
+    It 'Forces retrieval_low_confidence true on Ambiguous without nulling node_id' {
+        InModuleScope AITriad {
+            $script:ExcludesVetoMargin = 0.5
+            $script:TaxonomyData = @{
+                'saf' = [PSCustomObject]@{
+                    nodes = @(
+                        [PSCustomObject]@{
+                            id          = 'saf-bel-010'
+                            label       = 'Some node'
+                            description = 'Core monitoring content. Excludes: excluded edge cases.'
+                        }
+                    )
+                }
+            }
+            # VecD margin = 0.2, delta = 0.5 → Ambiguous
+            Mock Invoke-BatchEmbedVeto {
+                $VecA = [double[]]::new(384); $VecA[0] = 1.0
+                $VecB = [double[]]::new(384); $VecB[1] = 1.0
+                $VecD = [double[]]::new(384); $VecD[0] = 0.6; $VecD[1] = 0.8
+                return @{
+                    'vkp_0'             = $VecD
+                    'vcore_saf-bel-010' = $VecA
+                    'vexcl_saf-bel-010' = $VecB
+                }
+            }
+            $kp = [PSCustomObject]@{
+                taxonomy_node_id        = 'saf-bel-010'
+                attribution_text        = 'borderline content'
+                retrieval_low_confidence = $false
+            }
+            Invoke-ExcludesVetoPass -KeyPoints @($kp)
+            $kp.taxonomy_node_id        | Should -Be 'saf-bel-010'
+            $kp.retrieval_low_confidence | Should -BeTrue
+        }
+    }
+
+    It 'Skips kp with null taxonomy_node_id without throwing' {
+        InModuleScope AITriad {
+            $script:ExcludesVetoMargin = 0.0
+            $script:TaxonomyData = @{
+                'acc' = [PSCustomObject]@{
+                    nodes = @(
+                        [PSCustomObject]@{
+                            id          = 'acc-bel-001'
+                            label       = 'Some'
+                            description = 'Core. Excludes: bad.'
+                        }
+                    )
+                }
+            }
+            Mock Invoke-BatchEmbedVeto { return @{} }
+            $kp = [PSCustomObject]@{ taxonomy_node_id = $null; attribution_text = 'some text' }
+            { Invoke-ExcludesVetoPass -KeyPoints @($kp) } | Should -Not -Throw
+            Assert-MockCalled Invoke-BatchEmbedVeto -Times 0
+        }
+    }
+
+    It 'Returns zero counts gracefully when Invoke-BatchEmbedVeto returns $null' {
+        InModuleScope AITriad {
+            $script:ExcludesVetoMargin = 0.0
+            $script:TaxonomyData = @{
+                'saf' = [PSCustomObject]@{
+                    nodes = @(
+                        [PSCustomObject]@{
+                            id          = 'saf-bel-001'
+                            label       = 'Some'
+                            description = 'Core content. Excludes: excluded content.'
+                        }
+                    )
+                }
+            }
+            Mock Invoke-BatchEmbedVeto { return $null }
+            $kp = [PSCustomObject]@{
+                taxonomy_node_id = 'saf-bel-001'
+                attribution_text = 'some text'
+            }
+            $Result = Invoke-ExcludesVetoPass -KeyPoints @($kp)
+            $Result.VetoCount | Should -Be 0
+            $Result.AmbiguousCount | Should -Be 0
+        }
+    }
+}

--- a/tests/Test-ExcludesVeto.Tests.ps1
+++ b/tests/Test-ExcludesVeto.Tests.ps1
@@ -134,7 +134,7 @@ Describe 'Invoke-ExcludesVetoPass' -Tag 'retrieval' {
             }
             Invoke-ExcludesVetoPass -KeyPoints @($kp)
             $kp.taxonomy_node_id | Should -Be 'acc-bel-001'
-            Assert-MockCalled Invoke-BatchEmbedVeto -Times 0
+            Should -Invoke Invoke-BatchEmbedVeto -Times 0 -Exactly
         }
     }
 
@@ -191,7 +191,7 @@ Describe 'Invoke-ExcludesVetoPass' -Tag 'retrieval' {
             Mock Invoke-BatchEmbedVeto { return @{} }
             $kp = [PSCustomObject]@{ taxonomy_node_id = $null; attribution_text = 'some text' }
             { Invoke-ExcludesVetoPass -KeyPoints @($kp) } | Should -Not -Throw
-            Assert-MockCalled Invoke-BatchEmbedVeto -Times 0
+            Should -Invoke Invoke-BatchEmbedVeto -Times 0 -Exactly
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds semantic relative-margin veto pass that runs after the retrieval confidence pass in `Invoke-DocumentSummary`
- Hard-veto (margin > δ): nulls `taxonomy_node_id`, forces `retrieval_low_confidence = true`
- Ambiguous (0 < margin ≤ δ): preserves assignment, forces `retrieval_low_confidence = true`
- δ stored as `$script:ExcludesVetoMargin = 0.0` (CL-owned; any positive margin vetoes by default)
- Subprocess wrapper (`Invoke-BatchEmbedVeto`) is isolated from confidence pass for independent mocking

## Design
Approved by TL (t/2286#3) and Comp Linguist (t/2286#4). Substring approach rejected; relative semantic margin confirmed.

## Test plan
- [ ] `Invoke-Pester ./tests/Test-ExcludesVeto.Tests.ps1` — 12 tests, 0 failures (verified locally)
- [ ] Full suite `Invoke-Pester ./tests/` — 962 passed, 0 failed (verified locally)
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
