### PR TITLE
fix(debate): guard NewsReportModal mount effect against Strict Mode double-fire (t/2296)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/NewsReportModal.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/NewsReportModal.test.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2296 — the mount effect that kicks off news-report generation fired twice
+// under React Strict Mode's dev double-invoke: both invokes run synchronously
+// before the async generateNewsReport() sets newsReportLoading in the store, so
+// the store-state guard read false both times. A useRef set synchronously on
+// the first fire is the fix; this test pins it under a StrictMode wrapper.
+
+import { StrictMode } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { NewsReportModal } from './NewsReportModal';
+
+// ── Mocks ────────────────────────────────────────────────────
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+vi.mock('remark-gfm', () => ({ default: {} }));
+
+const debateStore: Record<string, any> = {
+  activeDebate: null,
+  newsReport: null,
+  newsReportLoading: false,
+  newsReportError: null,
+  generateNewsReport: vi.fn(),
+};
+
+vi.mock('../../hooks/useDebateStore', () => ({
+  useDebateStore: (selector: any) => selector(debateStore),
+}));
+
+vi.mock('zustand/react/shallow', () => ({ useShallow: (fn: any) => fn }));
+
+beforeEach(() => {
+  debateStore.activeDebate = null;
+  debateStore.newsReport = null;
+  debateStore.newsReportLoading = false;
+  debateStore.newsReportError = null;
+  // The async action never resolves here — the guard must hold without the
+  // store ever flipping newsReportLoading (that is the whole point of t/2296).
+  debateStore.generateNewsReport = vi.fn(() => new Promise(() => {}));
+});
+
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('NewsReportModal — mount generation guard (t/2296)', () => {
+  it('generates exactly once under Strict Mode double-invoke', async () => {
+    render(
+      <StrictMode>
+        <NewsReportModal onClose={vi.fn()} />
+      </StrictMode>
+    );
+    await waitFor(() => expect(debateStore.generateNewsReport).toHaveBeenCalled());
+    expect(debateStore.generateNewsReport).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not generate when an article is already present', async () => {
+    debateStore.newsReport = '# Existing headline\nsubhead\n\nbody';
+    render(
+      <StrictMode>
+        <NewsReportModal onClose={vi.fn()} />
+      </StrictMode>
+    );
+    // Let effects flush, then assert no generation was triggered.
+    await waitFor(() => expect(document.querySelector('.news-report-modal-window')).toBeTruthy());
+    expect(debateStore.generateNewsReport).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/NewsReportModal.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/NewsReportModal.tsx
@@ -84,9 +84,16 @@ export function NewsReportModal({ onClose }: { onClose: () => void }) {
     };
   }, []);
 
-  // Trigger generation on mount if no article yet
+  // Trigger generation on mount if no article yet.
+  // A useRef guard survives React 19 Strict Mode's dev double-invoke: the two
+  // mount effects run synchronously before the async generateNewsReport() sets
+  // newsReportLoading in the store, so the store-state guard reads false both
+  // times and both fire (t/2296). The ref is set synchronously on first fire.
+  const startedRef = useRef(false);
   useEffect(() => {
+    if (startedRef.current) return;
     if (!newsReport && !newsReportLoading && !newsReportError) {
+      startedRef.current = true;
       void generateNewsReport();
     }
   }, []);


### PR DESCRIPTION
## What
Guards the `NewsReportModal` mount effect with a `useRef` so it triggers `generateNewsReport()` exactly once.

## Why (t/2296)
Under React 19 Strict Mode (dev only), mount effects are intentionally double-invoked. Both invokes ran synchronously *before* the async `generateNewsReport()` set `newsReportLoading` in the store, so the `!newsReportLoading` store-state guard read `false` both times and both fired — doubling AI token cost per news report (flight recorder seq 838/839, 1.4ms apart). The ref is set synchronously on the first fire, so it survives the double-invoke.

- **Dev-only artifact** — production builds fire effects once. No data corruption (last write wins).
- Root cause per TL diagnosis (t/2296#1); action-bar redesign #614 exonerated.

## Test
Adds `NewsReportModal.test.tsx`: renders under a `<StrictMode>` wrapper with a never-resolving `generateNewsReport` mock (so `newsReportLoading` never flips) and asserts exactly one call. Fails on the un-guarded effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)