### PR TITLE
fix(debate-workspace): call useFlag unconditionally — fixes debate popup hook-count crash (t/2298)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.test.tsx
@@ -2,8 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useRef } from 'react';
 import { render, screen } from '@testing-library/react';
-import { ProgressIndicator, PhaseProgressBar, DebaterToggles, TokenBudgetIndicator } from './DebateActionBar';
+import { ProgressIndicator, PhaseProgressBar, DebaterToggles, TokenBudgetIndicator, DebateActions } from './DebateActionBar';
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -86,12 +87,20 @@ vi.mock('../../hooks/useTierInfo', () => ({
   useTierInfo: () => mockTierInfo,
 }));
 
+// isElectronMode is controllable so the t/2298 regression test can vary it across renders.
+const bridgeState = vi.hoisted(() => ({ electron: true }));
 vi.mock('@bridge', () => ({
-  isElectronMode: () => true,
+  isElectronMode: () => bridgeState.electron,
 }));
 
+// Real useFlag wraps a Zustand selector — i.e. it consumes a React hook.
+// The mock must too, otherwise calling it conditionally (the t/2298 bug) is
+// invisible to React's hook counter and the regression can't be reproduced.
 vi.mock('../../hooks/useFeatureFlags', () => ({
-  useFlag: () => false,
+  useFlag: () => {
+    useRef(null);
+    return false;
+  },
 }));
 
 afterEach(() => { vi.clearAllMocks(); });
@@ -301,5 +310,65 @@ describe('TokenBudgetIndicator', () => {
     };
     render(<TokenBudgetIndicator />);
     expect(screen.getByText(/resets in 2h \d+m/)).toBeInTheDocument();
+  });
+});
+
+// ── DebateActions — hook-count stability (t/2298 regression) ─────────
+//
+// `useFlag('permission-admin-features')` was called conditionally as the RHS of
+// `isElectronMode() || useFlag(...)`. When isElectronMode() flips between renders
+// of the same fiber, the hook count changed and React crashed the debate popup
+// with "Rendered fewer/more hooks than expected". The test varies isElectronMode()
+// across a rerender of the SAME instance — the only way to catch a re-introduction.
+
+describe('DebateActions — hook-count stability (t/2298)', () => {
+  const noop = () => {};
+  const actionsProps = {
+    showParamHistory: false,
+    setShowParamHistory: noop,
+    showEvaluation: false,
+    setShowEvaluation: noop,
+  };
+
+  afterEach(() => {
+    bridgeState.electron = true;
+  });
+
+  const primeStore = () => {
+    mockStore.activeDebate = {
+      phase: 'active',
+      active_povers: ['accelerationist', 'safetyist'],
+      transcript: [],
+      neutral_evaluations: [],
+    };
+    mockStore.debateGenerating = null;
+    mockStore.debateError = null;
+    mockStore.debateRetryAction = null;
+    mockStore.dailyLimitPaused = false;
+    mockStore.toggleStepMode = vi.fn();
+    mockStore.setDebatePhase = vi.fn();
+    mockStore.setError = vi.fn();
+  };
+
+  it('keeps a stable hook count when isElectronMode() flips across renders', () => {
+    primeStore();
+
+    // First render short-circuits the old `||` (Electron true → useFlag skipped).
+    bridgeState.electron = true;
+    const { rerender } = render(<DebateActions {...actionsProps} />);
+
+    // Flip to web: the old code would now CALL useFlag → hook count changes → crash.
+    bridgeState.electron = false;
+    expect(() => rerender(<DebateActions {...actionsProps} />)).not.toThrow();
+
+    // Flip back for good measure — count must stay stable in both directions.
+    bridgeState.electron = true;
+    expect(() => rerender(<DebateActions {...actionsProps} />)).not.toThrow();
+  });
+
+  it('mounts without crashing in the web build (isElectronMode() false)', () => {
+    primeStore();
+    bridgeState.electron = false;
+    expect(() => render(<DebateActions {...actionsProps} />)).not.toThrow();
   });
 });

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
@@ -785,7 +785,11 @@ export function DebateActions({ showParamHistory, setShowParamHistory, showEvalu
   const [showNewsReport, setShowNewsReport] = useState(false);
   const [crossRespondTurns, setCrossRespondTurns] = useState(1);
   const inputRef = useRef<HTMLInputElement>(null);
-  const showAdminControls = isElectronMode() || useFlag('permission-admin-features');
+  // useFlag is a React hook — call it unconditionally, above any early return.
+  // isElectronMode() is a plain function and can stay in the `||`; only the hook must be unconditional.
+  // A conditional hook here crashed the popup with "Rendered fewer hooks than expected" (t/2298).
+  const adminFlag = useFlag('permission-admin-features');
+  const showAdminControls = isElectronMode() || adminFlag;
   const { isAdaptive, isStepMode, currentAdaptivePhase } = deriveAdaptiveState(activeDebate);
 
   if (!activeDebate) return null;


### PR DESCRIPTION
Fixes the production crash shipped in the action-bar redesign (63ad30a8, #614, t/2283): the debate popup threw React's **"Rendered fewer hooks than expected"** on open.

## Root cause
`DebateActionBar.tsx` wrote `const showAdminControls = isElectronMode() || useFlag('permission-admin-features')`. `useFlag` is a React hook (wraps a Zustand selector); the `||` short-circuit made it **conditional**. When `isElectronMode()` differs between renders (`window.electronAPI` absent on the first sync render, then present), the hook count changes and React aborts.

## Fix
Call the hook unconditionally with the other hooks, above the `if (!activeDebate) return null` early return:
```tsx
const adminFlag = useFlag('permission-admin-features');
const showAdminControls = isElectronMode() || adminFlag;
```
`isElectronMode()` is a plain function — it stays in the `||`. Audited the file for sibling `X() || useY()` patterns: none remain.

## Regression test
`DebateActionBar.test.tsx`: the `useFlag` mock now consumes a real hook (matching the real Zustand-selector wrapper), and the test rerenders the **same fiber** with `isElectronMode()` flipped, asserting a stable hook count. **Verified it fails on the pre-fix code** ("Rendered more hooks than during the previous render") and passes after the fix. A second test covers the web build (`isElectronMode()` false).

## Gates
- `tsc -p tsconfig.main.json` clean
- eslint 0 errors on both files
- debate-workspace vitest **252/252** (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)