### PR TITLE
fix(flight-recorder): record error-boundary crash synchronously before dump (t/2297)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/__tests__/flightRecorderReactError.test.ts
+++ b/taxonomy-editor/src/renderer/lib/__tests__/flightRecorderReactError.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RecordInput } from '@lib/flight-recorder/types';
+
+/**
+ * Regression tests for t/2297: the error boundary must emit a `system.error`
+ * flight-recorder event *synchronously* — the instant the boundary fires — so a
+ * dump triggered afterward (auto, or via the "Dump Log" button) can never be
+ * missing the very crash that produced it.
+ *
+ * The bug: `dumpOnReactError` recorded the crash inside an async IIFE, behind a
+ * DEV-only `await _resolveStack(...)`. The event therefore landed in the ring
+ * buffer *after* a microtask (and after source-map fetches in dev), racing the
+ * dump. The fix records the crash inline, then defers only the dump + enrichment.
+ */
+
+const h = vi.hoisted(() => {
+  const recordCalls: RecordInput[] = [];
+  return {
+    recordCalls,
+    fakeRecorder: {
+      record: vi.fn((input: RecordInput) => { recordCalls.push(input); }),
+      buildDump: vi.fn(() => ({ ndjson: '{}', droppedByCategory: {}, meta: {} })),
+    },
+    dumpFlightRecorder: vi.fn().mockResolvedValue({ filePath: '/tmp/dump.ndjson', filename: 'dump.ndjson' }),
+    reportError: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => h.fakeRecorder,
+  setGlobalRecorder: vi.fn(),
+  FlightRecorder: class {},
+}));
+
+vi.mock('@bridge', () => ({
+  api: {
+    dumpFlightRecorder: h.dumpFlightRecorder,
+    reportError: h.reportError,
+    clipboardWriteText: vi.fn(),
+    openFlightRecorderViewer: vi.fn(),
+  },
+}));
+
+vi.mock('../dumpToast', () => ({
+  showDumpToast: vi.fn(),
+  showDumpErrorToast: vi.fn(),
+  showDumpPendingToast: vi.fn(() => () => { /* dismiss */ }),
+}));
+
+describe('dumpOnReactError — crash event is recorded synchronously (t/2297)', () => {
+  beforeEach(() => {
+    h.recordCalls.length = 0;
+    h.fakeRecorder.record.mockClear();
+    h.dumpFlightRecorder.mockClear();
+    h.reportError.mockClear();
+  });
+
+  it('records a system.error crash event synchronously, before the dump is persisted', async () => {
+    const { dumpOnReactError } = await import('../flightRecorderInit');
+
+    const err = new Error('Rendered more hooks than during the previous render');
+    err.name = 'Invariant Violation';
+    const componentStack = '\n    at NewsReportModal\n    at ErrorBoundary';
+
+    dumpOnReactError(err, componentStack);
+
+    // Synchronous: the crash is already in the buffer the instant the call returns.
+    expect(h.fakeRecorder.record).toHaveBeenCalledTimes(1);
+    const ev = h.recordCalls[0];
+    expect(ev.type).toBe('system.error');
+    expect(ev.component).toBe('react-error-boundary');
+    expect(ev.level).toBe('fatal');
+    expect(ev.error).toMatchObject({ name: 'Invariant Violation', message: err.message });
+    expect(ev.error?.stack).toBeDefined();
+    expect((ev.data as Record<string, unknown>)?.component_stack).toContain('at NewsReportModal');
+
+    // ...but the dump has NOT been persisted yet — it is deferred to a microtask,
+    // so the crash always precedes the dump in ordering.
+    expect(h.dumpFlightRecorder).not.toHaveBeenCalled();
+
+    // Flush microtasks: the dump now runs, with the crash already buffered.
+    await vi.waitFor(() => expect(h.dumpFlightRecorder).toHaveBeenCalledTimes(1));
+  });
+
+  it('reports the crash to the server after recording it locally', async () => {
+    const { dumpOnReactError } = await import('../flightRecorderInit');
+
+    const err = new Error('boom');
+    dumpOnReactError(err, undefined);
+
+    // Local record is synchronous; server report is fire-and-forget on a microtask.
+    expect(h.fakeRecorder.record).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(h.reportError).toHaveBeenCalledTimes(1));
+    expect(h.reportError.mock.calls[0][0]).toMatchObject({ name: 'Error', message: 'boom' });
+  });
+});

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -437,21 +437,30 @@ export function initFlightRecorder(): FlightRecorder {
 
       // Set up error boundary hook for popup — forward crash event to main window's recorder
       (globalThis as unknown as { __onErrorBoundaryCatch: (err: Error, stack?: string) => void }).__onErrorBoundaryCatch = (error, componentStack) => {
-        void (async () => {
-          const resolved = import.meta.env.DEV && componentStack
-            ? await _resolveStack(componentStack).catch(() => undefined)
-            : undefined;
-          shim.record({
-            type: 'system.error',
-            component: 'react-error-boundary',
-            level: 'fatal',
-            message: error.message,
-            error: { name: error.name, message: error.message, stack: error.stack?.slice(0, 500) },
-            data: componentStack
-              ? { component_stack: componentStack.slice(0, 1000), ...(resolved !== undefined ? { component_stack_resolved: resolved.slice(0, 1000) } : {}) }
-              : undefined,
-          });
-        })();
+        // Forward the crash SYNCHRONOUSLY first (t/2297) so it reaches the main
+        // recorder before the user can click "Dump Log" — the popup's dump pulls
+        // from the main buffer, so a late (post-await) forward could miss the dump.
+        shim.record({
+          type: 'system.error',
+          component: 'react-error-boundary',
+          level: 'fatal',
+          message: error.message,
+          error: { name: error.name, message: error.message, stack: error.stack?.slice(0, 500) },
+          data: componentStack ? { component_stack: componentStack.slice(0, 1000) } : undefined,
+        });
+        // DEV-only: resolve bundle positions to source coordinates and forward as a
+        // follow-up enrichment (lifecycle, not a second crash) once resolution completes.
+        if (import.meta.env.DEV && componentStack) {
+          void _resolveStack(componentStack).then(resolved => {
+            shim.record({
+              type: 'lifecycle',
+              component: 'react-error-boundary',
+              level: 'debug',
+              message: `Resolved component stack for: ${error.message}`,
+              data: { component_stack_resolved: resolved.slice(0, 1000) },
+            });
+          }).catch(() => { /* source-map resolution is best-effort */ });
+        }
       };
 
       // Set up manual dump trigger for popup — request main window to dump
@@ -912,6 +921,34 @@ export async function triggerManualDump(): Promise<void> {
 }
 
 /**
+ * Snapshot store state for crash diagnosis. Synchronous getState reads only, so
+ * safe to run inline in the error path; only runs on error, no perf impact on
+ * normal renders. Returns undefined if stores are unavailable or corrupted.
+ */
+function snapshotStoresForCrash(): Record<string, unknown> | undefined {
+  try {
+    const stores = getStores();
+    if (!stores) return undefined;
+    const taxState = (stores.useTaxonomyStore as { getState: () => Record<string, unknown> }).getState();
+    const debateState = (stores.useDebateStore as { getState: () => Record<string, unknown> }).getState();
+    const debate = debateState.activeDebate as Record<string, unknown> | null;
+    return {
+      active_tab: taxState.activeTab ?? null,
+      toolbar_panel: taxState.toolbarPanel ?? null,
+      selected_node_id: taxState.selectedNodeId ?? null,
+      search_mode: taxState.findMode ?? null,
+      search_query: (taxState.findQuery as string)?.slice(0, 200) || null,
+      debate_phase: debate?.phase ?? null,
+      debate_generating: !!debateState.debateGenerating,
+      dirty_files: [...((taxState.dirty as Set<string>) ?? [])],
+    };
+  } catch {
+    /* flight recorder init — silent by design (store may be corrupted) */
+    return undefined;
+  }
+}
+
+/**
  * Called from ErrorBoundary.componentDidCatch to dump on React render errors.
  */
 export function dumpOnReactError(
@@ -924,51 +961,42 @@ export function dumpOnReactError(
   // Track immediately — error boundary dumps bypass cooldown
   recordDump();
 
-  void (async () => {
-    // Snapshot store state for crash diagnosis — only runs on error, no perf impact on normal renders
-    let stateSnapshot: Record<string, unknown> | undefined;
-    try {
-      const stores = getStores();
-      if (stores) {
-        const taxState = (stores.useTaxonomyStore as { getState: () => Record<string, unknown> }).getState();
-        const debateState = (stores.useDebateStore as { getState: () => Record<string, unknown> }).getState();
-        const debate = debateState.activeDebate as Record<string, unknown> | null;
-        stateSnapshot = {
-          active_tab: taxState.activeTab ?? null,
-          toolbar_panel: taxState.toolbarPanel ?? null,
-          selected_node_id: taxState.selectedNodeId ?? null,
-          search_mode: taxState.findMode ?? null,
-          search_query: (taxState.findQuery as string)?.slice(0, 200) || null,
-          debate_phase: debate?.phase ?? null,
-          debate_generating: !!debateState.debateGenerating,
-          dirty_files: [...((taxState.dirty as Set<string>) ?? [])],
-        };
-      }
-    } catch { /* flight recorder init — silent by design (store may be corrupted) */ }
+  const stateSnapshot = snapshotStoresForCrash();
 
+  const baseData: Record<string, unknown> = {
+    ...(componentStack ? { component_stack: componentStack.slice(0, 1000) } : {}),
+    ...(stateSnapshot ? { state_snapshot: stateSnapshot } : {}),
+  };
+
+  // Record the crash SYNCHRONOUSLY, before any async work (t/2297). This guarantees
+  // the crash lands in the ring buffer the instant the boundary fires — so a dump
+  // that follows (auto or via the "Dump Log" button) can never be missing the very
+  // error that triggered it. The DEV-only source-map resolution below is best-effort
+  // enrichment for the dump's trigger context; it must not gate the buffered event.
+  recorder.record({
+    type: 'system.error',
+    component: 'react-error-boundary',
+    level: 'fatal',
+    message: error.message,
+    error: { name: error.name, message: error.message, stack: error.stack?.slice(0, 500) },
+    data: Object.keys(baseData).length > 0 ? baseData : undefined,
+  });
+
+  void (async () => {
     // DEV-only: resolve bundle positions in component_stack to source coordinates
+    // for the dump's trigger context (the buffered event above already stands alone).
     const resolvedStack = import.meta.env.DEV && componentStack
       ? await _resolveStack(componentStack).catch(() => undefined)
       : undefined;
 
-    const data: Record<string, unknown> = {
-      ...(componentStack ? { component_stack: componentStack.slice(0, 1000) } : {}),
+    const dumpContext: Record<string, unknown> = {
+      ...baseData,
       ...(resolvedStack !== undefined ? { component_stack_resolved: resolvedStack.slice(0, 1000) } : {}),
-      ...(stateSnapshot ? { state_snapshot: stateSnapshot } : {}),
     };
-
-    recorder.record({
-      type: 'system.error',
-      component: 'react-error-boundary',
-      level: 'fatal',
-      message: error.message,
-      error: { name: error.name, message: error.message, stack: error.stack?.slice(0, 500) },
-      data: Object.keys(data).length > 0 ? data : undefined,
-    });
 
     void persistDump(recorder, 'error_boundary', {
       name: error.name, message: error.message, stack: error.stack?.slice(0, 500),
-    }, Object.keys(data).length > 0 ? data : undefined);
+    }, Object.keys(dumpContext).length > 0 ? dumpContext : undefined);
 
     // Report to server for aggregation
     api.reportError(


### PR DESCRIPTION
## Problem (t/2297)
When the React error boundary caught a crash and the user clicked **Dump Log**, the dump could contain **zero record of what crashed** — no component, message, or stack (observed on `flight-recorder-2026-08-08T13:42:46`, the t/2296 hooks-violation crash, diagnosed only from the screenshot).

**Root cause:** the `system.error` event was recorded *inside an async IIFE*, behind a DEV-only `await _resolveStack(...)`. The crash landed in the ring buffer a microtask (and, in dev, several source-map fetches) after the boundary fired — racing the dump. In the popup, the crash is forwarded to the *main* recorder and the "Dump Log" button pulls from the *main* buffer, so a late forward could miss the dump entirely.

## Fix
Record the crash **synchronously** the instant the boundary fires, in both paths:
- **`dumpOnReactError`** (main window): emit the `system.error` inline; defer only the dump + DEV source-map enrichment. State snapshot extracted to `snapshotStoresForCrash()` to keep complexity under the eslint gate.
- **popup `__onErrorBoundaryCatch`**: forward the crash synchronously so it reaches the main recorder before the user can click Dump Log; the DEV resolved-stack becomes a follow-up `lifecycle` enrichment rather than gating the crash event.

## Test
New `flightRecorderReactError.test.ts` asserts the crash is recorded synchronously and the dump is only persisted afterward (2 cases). Existing `webPopupShim.test.ts` still green.

## Verification
- renderer tsc: clean
- eslint: 0 errors; no new warnings (`dumpOnReactError` complexity back under the gate)
- vitest (flight-recorder scope): 9/9 pass

Scope: single file in `taxonomy-editor/` + its test. No API/schema/interface changes.

Co-Authored-By: Diagnostics (Orca) <main.operations-diagnostics@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)