### PR TITLE
fix(vocab): guard VocabularyPanel mount effect against Strict Mode double-fire (t/2300)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.test.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2300 (sibling of t/2296) — the mount effect that loads the dictionary fired
+// twice under React Strict Mode's dev double-invoke. loadDictionary is an
+// idempotent local read (no AI cost), so impact is just a redundant fetch, but
+// a useRef guard set synchronously on the first fire holds it to one call. This
+// test pins that under a StrictMode wrapper.
+
+import { StrictMode } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { VocabularyPanel } from './VocabularyPanel';
+
+// ── Mocks ────────────────────────────────────────────────────
+
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: vi.fn() }),
+}));
+
+const bridgeGet = vi.fn();
+vi.mock('../../bridge/web-bridge', () => ({
+  bridgeGet: (...args: unknown[]) => bridgeGet(...args),
+}));
+
+beforeEach(() => {
+  // No electronAPI under jsdom → the component reads via bridgeGet('/api/dictionary').
+  bridgeGet.mockResolvedValue({ standardized: [], colloquial: [], lintViolations: [] });
+});
+
+afterEach(() => { vi.clearAllMocks(); });
+
+describe('VocabularyPanel — mount load guard (t/2300)', () => {
+  it('loads the dictionary exactly once under Strict Mode double-invoke', async () => {
+    render(
+      <StrictMode>
+        <VocabularyPanel />
+      </StrictMode>
+    );
+    await waitFor(() => expect(bridgeGet).toHaveBeenCalled());
+    expect(bridgeGet).toHaveBeenCalledTimes(1);
+    expect(bridgeGet).toHaveBeenCalledWith('/api/dictionary');
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { bridgeGet } from '../../bridge/web-bridge';
 import type { StandardizedTerm, ColloquialTerm, LintViolation, CampOrigin, CoinageStatus } from '@lib/dictionary';
@@ -32,7 +32,14 @@ export function VocabularyPanel() {
   const [expandedTerm, setExpandedTerm] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
+  // A useRef guard survives React 19 Strict Mode's dev double-invoke of mount
+  // effects, so the dictionary is loaded once rather than twice (t/2300, sibling
+  // of t/2296). Low impact here — loadDictionary is an idempotent local read —
+  // but the redundant fetch is avoided and the pattern matches NewsReportModal.
+  const loadStartedRef = useRef(false);
   useEffect(() => {
+    if (loadStartedRef.current) return;
+    loadStartedRef.current = true;
     void loadDictionary();
   }, []);
 


### PR DESCRIPTION
## What
Guards the `VocabularyPanel` mount effect with a `useRef` so `loadDictionary()` runs once.

## Why (t/2300, sibling of t/2296)
Under React 19 Strict Mode (dev only), mount effects are double-invoked, so `loadDictionary()` ran twice on mount. **Low impact** — it's an idempotent local read (`window.electronAPI.loadDictionary()` or `GET /api/dictionary`), no AI token cost, last-write-wins — but the redundant fetch is avoided and the pattern now matches the `NewsReportModal` fix (t/2296, f5a08863).

## Test
Adds `VocabularyPanel.test.tsx`: renders under `<StrictMode>` with a mocked `bridgeGet` and asserts the dictionary source is fetched exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)