### PR TITLE
fix(flight-recorder): reclassify WASM init failure as lifecycle, not system.error (t/2295)

### DIFF
--- a/taxonomy-editor/src/renderer/utils/localEmbedding.ts
+++ b/taxonomy-editor/src/renderer/utils/localEmbedding.ts
@@ -113,11 +113,17 @@ async function doInit(): Promise<boolean> {
       // Bridge fallback active → WASM failure is harmless noise, so suppress the
       // console warn (the flight recorder still captures it at debug for diagnostics).
       if (!_hasBridgeFallback) console.warn('[localEmbedding] WASM init failed:', err);
+      // Reclassified system.error → lifecycle (t/2295): with the bridge fallback
+      // active (ONNX/DML is the live path in Electron) this WASM failure is an
+      // expected fallback, not a real error. Emitting it as `type: system.error`
+      // made triage grep for `type:system.error` surface expected noise. The
+      // `level` (debug when harmless, warn when it actually degrades to no backend)
+      // still carries severity.
       getGlobalRecorder()?.record({
-        type: 'system.error',
+        type: 'lifecycle',
         component: 'localEmbedding',
         level: wasmFailLevel,
-        message: 'WASM init failed',
+        message: _hasBridgeFallback ? 'WASM init skipped (ONNX active)' : 'WASM init failed',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
     }


### PR DESCRIPTION
## Summary
`localEmbedding.ts` logged the WASM-init fallback failure as `type: system.error` even though it is an expected fallback when the bridge/ONNX path is active (the live path in Electron). This made triage grep for `type:system.error` surface expected fallback noise.

## Change
- Reclassify the WASM-init-failed flight-recorder event `type: 'system.error'` → `type: 'lifecycle'`.
- The `level` (debug when the bridge fallback makes it harmless, warn when it degrades to no backend) still carries severity.
- When the bridge fallback is active the message now reads `WASM init skipped (ONNX active)` instead of the misleading `WASM init failed`.

Self-certified against `/trivial-change` — single file, diagnostic-label-only change, no public API or schema change.

Closes t/2295.