### PR TITLE
feat(scripts): cross-encoder re-ranking for Get-RelevantTaxonomyNodes (t/2287)

### DIFF
--- a/scripts/AITriad/Private/Invoke-RerankScoring.ps1
+++ b/scripts/AITriad/Private/Invoke-RerankScoring.ps1
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Invoke-RerankScoring {
+    <#
+    .SYNOPSIS
+        Scores (query, candidate) pairs with the cross-encoder for live re-ranking (t/2287).
+    .DESCRIPTION
+        Thin wrapper over `evaluate_embeddings.py rerank`: pipes a JSON payload via
+        stdin and parses the [{id, score, raw}] result. Isolated as a Private helper
+        so Get-RelevantTaxonomyNodes' rerank ordering logic stays unit-testable
+        without a live model — tests Mock this function.
+
+        NEVER throws — returns $null on any failure (Python/script/model unavailable,
+        non-zero exit, empty/invalid output) so the caller degrades to bi-encoder order.
+        `score` is the cross-encoder sigmoid (0-1 display scale); `raw` is the logit.
+    .PARAMETER Query
+        The query text.
+    .PARAMETER Candidates
+        Array of objects each with `id` and `text` properties (the candidate nodes).
+    .PARAMETER RerankerModel
+        Cross-encoder model name.
+    .OUTPUTS
+        [PSCustomObject[]] with id/score/raw properties, or $null on failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Query,
+        [Parameter(Mandatory)][object[]]$Candidates,
+        [string]$RerankerModel = 'cross-encoder/ms-marco-MiniLM-L-6-v2'
+    )
+
+    Set-StrictMode -Version Latest
+    if (@($Candidates).Count -eq 0) { return $null }
+
+    try {
+        $EvalScript = Join-Path (Join-Path $script:RepoRoot 'scripts') 'evaluate_embeddings.py'
+        if (-not (Test-Path $EvalScript)) { $EvalScript = Join-Path $script:ModuleRoot 'evaluate_embeddings.py' }
+        if (-not (Test-Path $EvalScript)) {
+            Write-Verbose "Invoke-RerankScoring: evaluate_embeddings.py not found at $EvalScript"
+            return $null
+        }
+        if (Get-Command python -ErrorAction SilentlyContinue) { $PythonCmd = 'python' } else { $PythonCmd = 'python3' }
+
+        $Payload = ([ordered]@{
+                query          = $Query
+                candidates     = @($Candidates | ForEach-Object { [ordered]@{ id = $_.id; text = $_.text } })
+                reranker_model = $RerankerModel
+            } | ConvertTo-Json -Depth 5 -Compress)
+
+        $PrevEAP = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        try {
+            $__RrSw = [System.Diagnostics.Stopwatch]::StartNew()
+            $RrOut = $Payload | & $PythonCmd $EvalScript rerank --reranker-model $RerankerModel 2>$null
+            $__RrSw.Stop()
+            Add-StageTiming -Name 'cross-encoder rerank (subprocess)' -Milliseconds $__RrSw.Elapsed.TotalMilliseconds
+        }
+        finally { $ErrorActionPreference = $PrevEAP }
+
+        if ($LASTEXITCODE -ne 0 -or -not $RrOut -or "$RrOut".Trim().Length -eq 0) {
+            Write-Verbose "Invoke-RerankScoring: subprocess failed (exit $LASTEXITCODE) or produced no output"
+            return $null
+        }
+        # ConvertFrom-Json returns a single object for a 1-element array — wrap to guarantee array.
+        return @($RrOut | ConvertFrom-Json)
+    }
+    catch {
+        Write-Verbose "Invoke-RerankScoring: $($_.Exception.Message)"
+        return $null
+    }
+}

--- a/scripts/AITriad/Private/Invoke-SummaryPipeline.ps1
+++ b/scripts/AITriad/Private/Invoke-SummaryPipeline.ps1
@@ -48,6 +48,10 @@ function Invoke-SummaryPipeline {
         Enable two-stage FIRE sniff.
     .PARAMETER TaxonomyJsonOverride
         Pre-computed taxonomy JSON (for chunked pipeline passing parent-level taxonomy).
+    .PARAMETER CrossEncoderRerank
+        Cross-encoder re-rank the RAG candidates (t/2287). Forwarded to
+        Get-RelevantTaxonomyNodes. Default OFF; no effect when -FullTaxonomy or
+        -TaxonomyJsonOverride bypass RAG.
     #>
     [CmdletBinding()]
     param(
@@ -64,7 +68,8 @@ function Invoke-SummaryPipeline {
         [switch]$IterativeExtraction,
         [switch]$AutoFire,
         [string]$TaxonomyJsonOverride = '',
-        [int]$RagMaxTotal = 300
+        [int]$RagMaxTotal = 300,
+        [switch]$CrossEncoderRerank
     )
 
     Set-StrictMode -Version Latest
@@ -107,7 +112,8 @@ function Invoke-SummaryPipeline {
             $AllPovs = @('accelerationist', 'safetyist', 'skeptic')
             $TaxonomyJson = Get-RelevantTaxonomyNodes -Query $QueryText `
                 -MaxTotal $RagMaxTotal -MinPerCategory 3 `
-                -POV $AllPovs -IncludeSituations -Format context
+                -POV $AllPovs -IncludeSituations -Format context `
+                -CrossEncoderRerank:$CrossEncoderRerank
             Write-Verbose "Pipeline: RAG selected ~$([int]($TaxonomyJson.Length / 4)) tokens of taxonomy"
         }
         catch {

--- a/scripts/AITriad/Public/Get-RelevantTaxonomyNodes.ps1
+++ b/scripts/AITriad/Public/Get-RelevantTaxonomyNodes.ps1
@@ -41,8 +41,24 @@ function Get-RelevantTaxonomyNodes {
         (all-MiniLM-L6-v2) as the cached taxonomy embeddings.
     .PARAMETER ApiKey
         Deprecated — ignored. No API key required; embeddings are computed locally.
+    .PARAMETER CrossEncoderRerank
+        After bi-encoder top-K retrieval, re-score the top-$RerankTopN (query, node)
+        pairs with a cross-encoder and re-sort by that score. Cross-encoders catch
+        vocabulary-collision mismatches the bi-encoder cosine misses (epic t/2285).
+        Default OFF. On any failure (Python/model unavailable, subprocess error) the
+        pass warns and keeps the bi-encoder ranking — it never throws. When on, each
+        reranked node's Score is the cross-encoder sigmoid score (a display 0–1 scale,
+        NOT the bi-encoder cosine and NOT cross-comparable with a rerank-off score).
+    .PARAMETER RerankTopN
+        Number of top bi-encoder candidates to re-rank when -CrossEncoderRerank is
+        set. Default: 10. Nodes beyond this keep their bi-encoder order.
+    .PARAMETER RerankerModel
+        Cross-encoder model for re-ranking. Default: cross-encoder/ms-marco-MiniLM-L-6-v2.
     .EXAMPLE
         Get-RelevantTaxonomyNodes -Query "AI regulation and liability frameworks"
+    .EXAMPLE
+        # Cross-encoder re-ranking of the top-10 bi-encoder candidates
+        Get-RelevantTaxonomyNodes -Query $DocText -CrossEncoderRerank
     .EXAMPLE
         Get-RelevantTaxonomyNodes -Query $DocText -MaxTotal 40 -Format context
     .EXAMPLE
@@ -107,7 +123,15 @@ function Get-RelevantTaxonomyNodes {
         # Pre-computed query embedding. When supplied (e.g. callers that batch
         # many chunk queries in one embed subprocess), the per-call encode
         # subprocess is skipped entirely — avoids a ~6s cold model load per call.
-        [double[]]$QueryVector = @()
+        [double[]]$QueryVector = @(),
+
+        # Cross-encoder re-ranking (t/2287). Default OFF; see comment-based help.
+        [switch]$CrossEncoderRerank,
+
+        [ValidateRange(1, 100)]
+        [int]$RerankTopN = 10,
+
+        [string]$RerankerModel = 'cross-encoder/ms-marco-MiniLM-L-6-v2'
     )
 
     Set-StrictMode -Version Latest
@@ -346,6 +370,8 @@ function Get-RelevantTaxonomyNodes {
             desires_selected       = ($CatCounts['Desires'] ?? 0)
             intentions_selected    = ($CatCounts['Intentions'] ?? 0)
             synthetic_nodes_scored = $SynScoredCount
+            rerank_applied         = $false  # set true below if cross-encoder rerank ran
+            rerank_top1_delta      = 0        # bi-encoder rank the new #1 climbed from (rank-overturn signal, t/2287#5)
         }
 
     # ── Look up full node data ────────────────────────────────────────────────
@@ -365,6 +391,73 @@ function Get-RelevantTaxonomyNodes {
             $Obj = ConvertTo-TaxonomyNode -PovKey $S.POV -Node $NodeData -Score $S.Similarity
             $Results.Add($Obj)
         }
+    }
+
+    # ── Optional cross-encoder re-ranking (t/2287) ────────────────────────────
+    # After bi-encoder top-K retrieval, re-score the top-$RerankTopN (query, node)
+    # pairs with a cross-encoder and re-sort. Catches vocabulary-collision
+    # mismatches the bi-encoder misses (epic t/2285). Default OFF. The scoring
+    # subprocess is isolated in Invoke-RerankScoring, which NEVER throws and
+    # returns $null on any failure — so we degrade to the bi-encoder ranking.
+    if ($CrossEncoderRerank -and $Results.Count -gt 0) {
+      # Defensive: rerank must NEVER break core retrieval — any error here degrades
+      # to the bi-encoder ranking. $Results is only reassigned after the reorder
+      # succeeds, so a throw leaves the bi-encoder order intact.
+      try {
+        $RerankN = [Math]::Min($RerankTopN, $Results.Count)
+        $TopSlice = @($Results[0..($RerankN - 1)])
+        # Preserve bi-encoder order for the rerank_top1_delta diagnostic (CL t/2287#5)
+        $BiEncoderOrder = @($TopSlice | ForEach-Object { $_.Id })
+
+        $Candidates = @($TopSlice | ForEach-Object {
+            if ($_.Description) { $Text = "$($_.Label). $($_.Description)" } else { $Text = $_.Label }
+            [PSCustomObject]@{ id = $_.Id; text = $Text }
+        })
+        $Scored = Invoke-RerankScoring -Query $QueryText -Candidates $Candidates -RerankerModel $RerankerModel
+
+        if ($null -eq $Scored -or @($Scored).Count -eq 0) {
+            Write-Warning "Cross-encoder rerank unavailable — keeping bi-encoder ranking."
+        }
+        else {
+            $Scored = @($Scored)
+            $ScoreMap = @{}
+            foreach ($S in $Scored) { $ScoreMap[$S.id] = $S }
+            $NodeById = @{}
+            foreach ($N in $TopSlice) { $NodeById[$N.Id] = $N }
+
+            # Reorder the reranked slice by cross-encoder score desc; overwrite each
+            # node's Score with the CE sigmoid score (the surfaced confidence).
+            $RerankedNodes = [System.Collections.Generic.List[PSObject]]::new()
+            foreach ($S in @($Scored | Sort-Object { $_.score } -Descending)) {
+                if ($NodeById.ContainsKey($S.id)) {
+                    $Node = $NodeById[$S.id]
+                    $Node.Score = [Math]::Round([double]$S.score, 6)
+                    $RerankedNodes.Add($Node)
+                }
+            }
+            # Any slice node the scorer didn't return keeps its place at the slice tail
+            foreach ($N in $TopSlice) {
+                if (-not $ScoreMap.ContainsKey($N.Id)) { $RerankedNodes.Add($N) }
+            }
+            # Tail beyond the reranked slice keeps bi-encoder order
+            if ($Results.Count -gt $RerankN) { $Tail = @($Results[$RerankN..($Results.Count - 1)]) } else { $Tail = @() }
+            $Results = [System.Collections.Generic.List[PSObject]]::new()
+            foreach ($N in $RerankedNodes) { $Results.Add($N) }
+            foreach ($N in $Tail) { $Results.Add($N) }
+
+            # rerank_top1_delta = how far the new #1 climbed from its bi-encoder
+            # position (0 = unchanged). This rank-overturn is the divergence
+            # diagnostic the epic monitors (CL t/2287#5).
+            $RerankTop1Delta = [Math]::Max(0, $BiEncoderOrder.IndexOf($RerankedNodes[0].Id))
+            if (Test-Path variable:script:LastRAGMetrics) {
+                $script:LastRAGMetrics.flags['rerank_applied'] = $true
+                $script:LastRAGMetrics.flags['rerank_top1_delta'] = $RerankTop1Delta
+            }
+        }
+      }
+      catch {
+          Write-Warning "Cross-encoder rerank error: $($_.Exception.Message). Keeping bi-encoder ranking."
+      }
     }
 
     # ── Format output ─────────────────────────────────────────────────────────

--- a/scripts/AITriad/Public/Invoke-POVSummary.ps1
+++ b/scripts/AITriad/Public/Invoke-POVSummary.ps1
@@ -94,7 +94,10 @@ function Invoke-POVSummary {
         [ArgumentCompleter({ param($cmd, $param, $word) $script:ValidModelIds | Where-Object { $_ -like "$word*" } })]
         [string]$ModelEscalation = "gemini-2.5-flash",
 
-        [int]$RagMaxTotal = 300
+        [int]$RagMaxTotal = 300,
+
+        # Cross-encoder re-ranking of RAG candidates (t/2287). Default OFF.
+        [switch]$CrossEncoderRerank
     )
 
     Set-StrictMode -Version Latest
@@ -297,7 +300,8 @@ function Invoke-POVSummary {
         -FullTaxonomy:$FullTaxonomy `
         -IterativeExtraction:$IterativeExtraction `
         -AutoFire:$AutoFire `
-        -RagMaxTotal           $RagMaxTotal
+        -RagMaxTotal           $RagMaxTotal `
+        -CrossEncoderRerank:$CrossEncoderRerank
 
     if (-not $pipelineResult.Success) {
         Write-Fail "Pipeline failed: $($pipelineResult.Error)"

--- a/scripts/evaluate_embeddings.py
+++ b/scripts/evaluate_embeddings.py
@@ -10,8 +10,10 @@ Subcommands
 -----------
   compare-models    Encoder ablation: compare MRR across embedding models.
   rerank-baseline   Cross-encoder reranking on top-K bi-encoder candidates.
+  rerank            Live per-query cross-encoder scoring for re-ranking (stdin/stdout).
 
-Used by Compare-EmbeddingModel and Test-RerankerBaseline PowerShell cmdlets.
+Used by Compare-EmbeddingModel, Test-RerankerBaseline, and (rerank)
+Get-RelevantTaxonomyNodes -CrossEncoderRerank PowerShell cmdlets.
 """
 
 import argparse
@@ -28,6 +30,18 @@ _SKIP_FILES = {
     "lineage_categories.json", "_archived_edges.json",
     "interpretation_embeddings.json",
 }
+# Maximum stdin buffer (50 MB) — mirrors embed_taxonomy.py; prevents resource
+# exhaustion from piped input on the live `rerank` path.
+_MAX_STDIN_BYTES = 50 * 1024 * 1024
+
+
+def _sigmoid(x: float) -> float:
+    """Numerically stable logistic sigmoid, 1/(1+e^-x), overflow-safe both tails."""
+    if x >= 0:
+        z = np.exp(-x)
+        return float(1.0 / (1.0 + z))
+    z = np.exp(x)
+    return float(z / (1.0 + z))
 
 
 def _resolve_taxonomy_dir(override=None):
@@ -333,6 +347,55 @@ def cmd_rerank_baseline(args):
     json.dump(output, sys.stdout, indent=2)
 
 
+def cmd_rerank(args):
+    """Score (query, candidate) pairs with a cross-encoder for live re-ranking.
+
+    Reads a single JSON object from stdin:
+        {"query": "...",
+         "candidates": [{"id": "acc-beliefs-001", "text": "Label. Description"}, ...],
+         "reranker_model": "cross-encoder/ms-marco-MiniLM-L-6-v2"}   # optional
+
+    Writes a JSON array to stdout, sorted by score descending:
+        [{"id": "...", "score": <sigmoid(logit) 0-1>, "raw": <logit>}, ...]
+
+    `score` is sigmoid(logit): a stable, per-pair, set-independent 0-1 display
+    scale (endorsed over min-max, which is set-dependent — its top is ~1.0 even
+    when every candidate is poor, killing the low-confidence signal; t/2287#5).
+    It is a DISPLAY scale, NOT a probability; a confidence gate on this scale
+    needs its own calibration — the bi-encoder 0.45 threshold is invalid here.
+    `raw` is the underlying logit, retained for diagnostics. Only JSON goes to
+    stdout; all progress/diagnostic logging goes to stderr.
+    """
+    raw = sys.stdin.read(_MAX_STDIN_BYTES)
+    payload = json.loads(raw) if raw.strip() else {}
+    query = payload.get("query", "")
+    candidates = payload.get("candidates", []) or []
+    if not query or not candidates:
+        json.dump([], sys.stdout)
+        return
+
+    from sentence_transformers import CrossEncoder
+
+    model_name = payload.get("reranker_model") or args.reranker_model
+    print(f"Loading cross-encoder: {model_name}...", file=sys.stderr)
+    reranker = CrossEncoder(model_name, trust_remote_code=False)
+
+    pairs = [(query, c.get("text", "")) for c in candidates]
+    print(f"Scoring {len(pairs)} (query, candidate) pairs...", file=sys.stderr)
+    logits = reranker.predict(pairs)
+
+    results = []
+    for c, logit in zip(candidates, logits):
+        lf = float(logit)
+        results.append({
+            "id": c.get("id", ""),
+            "score": round(_sigmoid(lf), 6),
+            "raw": round(lf, 6),
+        })
+    results.sort(key=lambda r: r["score"], reverse=True)
+    json.dump(results, sys.stdout)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Evaluate embedding quality for taxonomy attribution.")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -356,11 +419,23 @@ def main():
         help="Cross-encoder model for reranking",
     )
 
+    rr = sub.add_parser(
+        "rerank",
+        help="Live per-query cross-encoder scoring (stdin JSON {query, candidates[]} -> [{id, score, raw}])",
+    )
+    rr.add_argument(
+        "--reranker-model",
+        default="cross-encoder/ms-marco-MiniLM-L-6-v2",
+        help="Cross-encoder model (stdin 'reranker_model' overrides this)",
+    )
+
     args = parser.parse_args()
     if args.command == "compare-models":
         cmd_compare_models(args)
     elif args.command == "rerank-baseline":
         cmd_rerank_baseline(args)
+    elif args.command == "rerank":
+        cmd_rerank(args)
 
 
 if __name__ == "__main__":

--- a/tests/Get-RelevantTaxonomyNodes.Rerank.Tests.ps1
+++ b/tests/Get-RelevantTaxonomyNodes.Rerank.Tests.ps1
@@ -1,0 +1,93 @@
+# Tag: ingestion (t/2287)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Get-RelevantTaxonomyNodes -CrossEncoderRerank (t/2287).
+.DESCRIPTION
+    Exercises the cross-encoder re-ranking pass with the scoring subprocess
+    (Invoke-RerankScoring) mocked, so the reorder / metrics / fallback logic is
+    verified without a live model. The synthetic reorder stands in for the
+    mechanism; the real SAF-167 repro fixture is CL-owned and tracked in t/2294.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-RelevantTaxonomyNodes -CrossEncoderRerank (t/2287)' -Tag 'ingestion' {
+
+    # Shared fixture: 3 Beliefs nodes; the query is closest to acc-beliefs-001
+    # by bi-encoder cosine (0.99 > saf 0.11 > skp 0.00).
+    BeforeEach {
+        InModuleScope AITriad {
+            Mock Assert-TaxonomyCacheFresh { }  # keep our seeded cache; don't reload from disk
+            $script:CachedSyntheticVectors = @{}  # non-null → skip synthetic-file load
+            $script:LastRAGMetrics = $null
+
+            $script:CachedEmbeddings = @{
+                'acc-beliefs-001' = [double[]]@(1, 0, 0)
+                'saf-beliefs-001' = [double[]]@(0, 1, 0)
+                'skp-beliefs-001' = [double[]]@(0, 0, 1)
+            }
+            $script:TaxonomyData = @{
+                'accelerationist' = [PSCustomObject]@{ nodes = @([PSCustomObject]@{ id = 'acc-beliefs-001'; label = 'Acc B1'; description = 'Accelerationist belief one.'; category = 'Beliefs'; parent_id = ''; children = @() }) }
+                'safetyist'       = [PSCustomObject]@{ nodes = @([PSCustomObject]@{ id = 'saf-beliefs-001'; label = 'Saf B1'; description = 'Safetyist belief one.'; category = 'Beliefs'; parent_id = ''; children = @() }) }
+                'skeptic'         = [PSCustomObject]@{ nodes = @([PSCustomObject]@{ id = 'skp-beliefs-001'; label = 'Skp B1'; description = 'Skeptic belief one.'; category = 'Beliefs'; parent_id = ''; children = @() }) }
+            }
+        }
+    }
+
+    It 'reranks top-1 by cross-encoder score, overwriting Score and setting metrics' {
+        InModuleScope AITriad {
+            # Cross-encoder promotes saf (bi-encoder rank 2) to #1.
+            Mock Invoke-RerankScoring {
+                @(
+                    [PSCustomObject]@{ id = 'saf-beliefs-001'; score = 0.99; raw = 5.0 }
+                    [PSCustomObject]@{ id = 'acc-beliefs-001'; score = 0.20; raw = -1.0 }
+                    [PSCustomObject]@{ id = 'skp-beliefs-001'; score = 0.10; raw = -2.5 }
+                )
+            }
+
+            $r = Get-RelevantTaxonomyNodes -Query 'q' -QueryVector ([double[]]@(0.9, 0.1, 0.0)) `
+                -CrossEncoderRerank -Format objects 3>$null
+
+            $r[0].Id | Should -Be 'saf-beliefs-001'          # reordered (was acc)
+            $r[0].Score | Should -Be 0.99                    # Score overwritten with CE score
+            $script:LastRAGMetrics.flags['rerank_applied'] | Should -BeTrue
+            $script:LastRAGMetrics.flags['rerank_top1_delta'] | Should -Be 1   # climbed from bi-encoder rank 2
+        }
+    }
+
+    It 'falls back to bi-encoder ranking when the scorer is unavailable (never throws)' {
+        InModuleScope AITriad {
+            Mock Invoke-RerankScoring { $null }   # simulate python/model unavailable
+
+            # Direct call: a throw here would fail the test as an error, so a clean
+            # return proves the never-throw fallback contract.
+            $r = Get-RelevantTaxonomyNodes -Query 'q' -QueryVector ([double[]]@(0.9, 0.1, 0.0)) `
+                -CrossEncoderRerank -Format objects 3>$null
+
+            $r[0].Id | Should -Be 'acc-beliefs-001'           # bi-encoder order preserved
+            $script:LastRAGMetrics.flags['rerank_applied'] | Should -BeFalse
+            $script:LastRAGMetrics.flags['rerank_top1_delta'] | Should -Be 0
+        }
+    }
+
+    It 'does not invoke the scorer and leaves ranking unchanged when switch is off' {
+        InModuleScope AITriad {
+            Mock Invoke-RerankScoring { throw 'should not be called' }
+
+            $r = Get-RelevantTaxonomyNodes -Query 'q' -QueryVector ([double[]]@(0.9, 0.1, 0.0)) `
+                -Format objects 3>$null
+
+            $r[0].Id | Should -Be 'acc-beliefs-001'
+            $script:LastRAGMetrics.flags['rerank_applied'] | Should -BeFalse
+            Should -Invoke Invoke-RerankScoring -Times 0 -Exactly
+        }
+    }
+}


### PR DESCRIPTION
## Cross-encoder re-ranking for `Get-RelevantTaxonomyNodes` (t/2287)

Lands the **rerank mechanism** onto current `main`. TL-approved to land (t/2287#8, t/2287#13): complete, green, **default OFF**, low-risk. This is the whole of t/2287 now — the Cond-1 confidence coupling was dropped (below).

### What's in
- `evaluate_embeddings.py` — live `rerank` subcommand (stdin JSON → `[{id, score=sigmoid(logit), raw}]`), reuses ms-marco CrossEncoder; warm 10-pair predict ~21ms (≪ 2s AC).
- `Get-RelevantTaxonomyNodes` — `-CrossEncoderRerank` (**default OFF**) + `-RerankTopN` / `-RerankerModel`; comment-based help with the scale caveat; rerank pass overwrites `.Score` with the CE sigmoid; `rerank_applied` + `rerank_top1_delta` metrics; never-throw graceful fallback to bi-encoder order.
- `Invoke-RerankScoring` (Private) — isolated scoring subprocess wrapper; returns `$null` on any failure.
- `-CrossEncoderRerank` threaded via `Invoke-POVSummary` → `Invoke-SummaryPipeline`.
- 3 Pester tests (reorder / never-throw fallback / switch-off no-op).

### Cond-1 (t/2288 CE-score confidence coupling) — DROPPED per TL (t/2287#13)
Two grounds: (1) structural — `$script:LastCrossEncoderScores` is overwritten per **chunk** in `Get-RelevantTaxonomyNodes`, while `Invoke-RetrievalConfidencePass` is a **single batch pass** keyed to each key_point's `attribution_text` (t/2287#11); (2) deeper/semantic — the rerank CE score measures **chunk→node** while `retrieval_confidence` measures **attribution→node**, so it's the wrong quantity even with working plumbing. `retrieval_confidence` stays bi-encoder cosine (t/2288, unaffected). CE-confidence is deferred and tracked as **t/2301** (blocked_by t/2287). The dead side-channel that only fed this coupling has been **removed** from this PR.

### Not in this PR
- CL's **t/2290** (`mechanism_type` prompt) — was stacked underneath on the source branch; landing on CL's own PR #635.

### Verification
- Rerank tests: 3/0.
- Full PS Pester suite on this branch (current main base): exit 0, zero failures.
- Does **not** touch `metric-provenance-register.md` (independent of the #635 / t/2294 register sequencing).

Epic real-repro AC stays OPEN on t/2288 (reclassified per CL t/2287#9); rerank stays default-OFF pending CL net-improvement validation (TL t/2287#8).

Co-Authored-By: Computational Linguist (Orca) <main.research-comp-linguist@ai-triad-research.orca.local>
Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>
