### PR TITLE
fix(debate-workspace): neutral phase pill (AA) + humanize duplicate title/source — t/2293 review

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.css
@@ -81,6 +81,22 @@
   font-size: 0.72rem;
   color: var(--text-muted);
 }
+/* Phase pill — neutral chip per spec (t/2293 review): text-secondary on bg-tertiary,
+   which meets AA in all 4 themes. NOT the shared .debate-phase-indicator (focus-ring
+   blue, fails AA in light/bkc). The ● dot uses currentColor so it stays neutral too. */
+.debate-hdr-phase {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
 .debate-hdr-status-dot {
   width: 6px;
   height: 6px;

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.test.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { humanizeUrl, deriveHeaderTitle } from './DebateHeader';
+
+// ── humanizeUrl ─────────────────────────────────────────────
+
+describe('humanizeUrl', () => {
+  it('drops scheme, www., and trailing slash', () => {
+    expect(humanizeUrl('https://www.techpolicy.press/why-new-mexico-v-meta-matters/'))
+      .toBe('techpolicy.press/why-new-mexico-v-meta-matters');
+  });
+  it('handles http and no-www', () => {
+    expect(humanizeUrl('http://example.com/a/b')).toBe('example.com/a/b');
+  });
+  it('leaves a non-URL untouched', () => {
+    expect(humanizeUrl('Why New Mexico v. Meta Matters')).toBe('Why New Mexico v. Meta Matters');
+  });
+});
+
+// ── deriveHeaderTitle (t/2293 review — title/source dedup) ───
+
+describe('deriveHeaderTitle', () => {
+  it('humanizes a raw-URL "Discuss:" topic and suppresses the duplicate source line', () => {
+    const r = deriveHeaderTitle(
+      'Discuss: https://www.techpolicy.press/why-new-mexico-v-meta-matters/',
+      'https://www.techpolicy.press/why-new-mexico-v-meta-matters/'
+    );
+    expect(r.displayTitle).toBe('techpolicy.press/why-new-mexico-v-meta-matters');
+    expect(r.sourceDisplay).toBeNull();
+  });
+
+  it('keeps a clean refined title and shows the humanized source when they differ', () => {
+    const r = deriveHeaderTitle(
+      'Why New Mexico v. Meta Matters',
+      'https://www.techpolicy.press/why-new-mexico-v-meta-matters/'
+    );
+    expect(r.displayTitle).toBe('Why New Mexico v. Meta Matters');
+    expect(r.sourceDisplay).toBe('techpolicy.press/why-new-mexico-v-meta-matters');
+  });
+
+  it('returns null source when there is no source_ref', () => {
+    const r = deriveHeaderTitle('Some plain topic', null);
+    expect(r.displayTitle).toBe('Some plain topic');
+    expect(r.sourceDisplay).toBeNull();
+  });
+
+  it('strips a leading "Discuss:" case-insensitively for a non-URL topic', () => {
+    const r = deriveHeaderTitle('discuss: The ethics of AI', undefined);
+    expect(r.displayTitle).toBe('The ethics of AI');
+    expect(r.sourceDisplay).toBeNull();
+  });
+
+  it('falls back to the original topic when stripping would leave it empty', () => {
+    const r = deriveHeaderTitle('Discuss:', null);
+    expect(r.displayTitle).toBe('Discuss:');
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.tsx
@@ -21,6 +21,26 @@ function poverTurnCount(activeDebate: ActiveDebateSession, pover: string): numbe
   return activeDebate.transcript.filter(e => e.speaker === pover && TURN_ENTRY_TYPES.has(e.type)).length;
 }
 
+/** Humanize a URL for display: drop the scheme + leading `www.` and any trailing slash. */
+export function humanizeUrl(s: string): string {
+  return s.replace(/^https?:\/\/(www\.)?/i, '').replace(/\/+$/, '');
+}
+
+/** Derive the header's display title + source subtitle (t/2293 review). Some debates
+ *  have a raw-URL `topic.final` like "Discuss: https://www.…/foo" which would make the
+ *  h2 and the source line show the same URL twice. Strip a leading "Discuss:", humanize
+ *  a bare-URL topic, and suppress the source line when it would merely repeat the title. */
+export function deriveHeaderTitle(topicFinal: string, sourceRef: string | null | undefined): {
+  displayTitle: string; sourceDisplay: string | null;
+} {
+  const stripped = (topicFinal ?? '').replace(/^\s*discuss:\s*/i, '').trim();
+  const titleIsUrl = /^https?:\/\//i.test(stripped);
+  const displayTitle = (titleIsUrl ? humanizeUrl(stripped) : stripped) || (topicFinal ?? '');
+  if (!sourceRef) return { displayTitle, sourceDisplay: null };
+  const humanSource = humanizeUrl(sourceRef);
+  return { displayTitle, sourceDisplay: humanSource === displayTitle ? null : humanSource };
+}
+
 /** Redesigned debate window header (t/2293) — three bands: title+source, status+
  *  metadata, and a per-POV DEBATERS strip. Rendered in the fixed header slot so the
  *  action controls stay always-visible (no scroll regression). The action cluster and
@@ -38,6 +58,7 @@ export function DebateHeader({
   // POVs actually present, in canonical acc → saf → skp order; falls back to all three
   // if the session doesn't declare active_povers (spec §edge cases).
   const presentPovers = AI_POVERS.filter(p => (activeDebate.active_povers ?? AI_POVERS).includes(p));
+  const { displayTitle, sourceDisplay } = deriveHeaderTitle(activeDebate.topic.final, activeDebate.source_ref);
   const created = new Date(activeDebate.created_at);
   const audienceLabel = activeDebate.audience
     ? (DEBATE_AUDIENCES.find(a => a.id === activeDebate.audience)?.label ?? activeDebate.audience)
@@ -48,9 +69,9 @@ export function DebateHeader({
       {/* Band 1 — title + source, action controls right */}
       <div className="debate-hdr-band debate-hdr-band1">
         <div className="debate-hdr-title-block">
-          <h2 className="debate-hdr-title" title={activeDebate.topic.final}>{activeDebate.topic.final}</h2>
-          {activeDebate.source_ref && (
-            <span className="debate-hdr-source" title={activeDebate.source_ref}>{activeDebate.source_ref}</span>
+          <h2 className="debate-hdr-title" title={activeDebate.topic.final}>{displayTitle}</h2>
+          {sourceDisplay && (
+            <span className="debate-hdr-source" title={activeDebate.source_ref ?? undefined}>{sourceDisplay}</span>
           )}
         </div>
         {actions}
@@ -59,7 +80,7 @@ export function DebateHeader({
       {/* Band 2 — status pills left, muted metadata right */}
       <div className="debate-hdr-band debate-hdr-band2">
         <div className="debate-hdr-status">
-          <span className="debate-phase-indicator">
+          <span className="debate-hdr-phase">
             <span className="debate-hdr-status-dot" aria-hidden="true" />
             {phaseLabel}
           </span>

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
@@ -351,31 +351,31 @@ describe('phase routing', () => {
   it('shows "Topic Refinement" phase title for clarification phase', () => {
     mockStore.activeDebate = makeDebate({ phase: 'clarification' });
     const { container } = render(<DebateWorkspace />);
-    expect(container.querySelector('.debate-phase-indicator')?.textContent).toBe('Topic Refinement');
+    expect(container.querySelector('.debate-hdr-phase')?.textContent).toBe('Topic Refinement');
   });
 
   it('shows "Opening Statements" phase title for opening phase', () => {
     mockStore.activeDebate = makeDebate({ phase: 'opening' });
     const { container } = render(<DebateWorkspace />);
-    expect(container.querySelector('.debate-phase-indicator')?.textContent).toBe('Opening Statements');
+    expect(container.querySelector('.debate-hdr-phase')?.textContent).toBe('Opening Statements');
   });
 
   it('shows "Debate" phase title for debate phase', () => {
     mockStore.activeDebate = makeDebate({ phase: 'debate' });
     const { container } = render(<DebateWorkspace />);
-    expect(container.querySelector('.debate-phase-indicator')?.textContent).toBe('Debate');
+    expect(container.querySelector('.debate-hdr-phase')?.textContent).toBe('Debate');
   });
 
   it('shows "Debate Closed" phase title for closed phase', () => {
     mockStore.activeDebate = makeDebate({ phase: 'closed' });
     const { container } = render(<DebateWorkspace />);
-    expect(container.querySelector('.debate-phase-indicator')?.textContent).toBe('Debate Closed');
+    expect(container.querySelector('.debate-hdr-phase')?.textContent).toBe('Debate Closed');
   });
 
   it('shows "Setting up..." phase title for setup phase', () => {
     mockStore.activeDebate = makeDebate({ phase: 'setup' });
     const { container } = render(<DebateWorkspace />);
-    expect(container.querySelector('.debate-phase-indicator')?.textContent).toBe('Setting up...');
+    expect(container.querySelector('.debate-hdr-phase')?.textContent).toBe('Setting up...');
   });
 
   it('renders ClarificationActions in clarification phase when no substantive transcript entries', () => {


### PR DESCRIPTION
Fix-forward for Design's visual-review findings on t/2293 (the redesign PR #627 merged at 14:57, ~4 min before the review landed; details t/2293#5, t/2293#6).

## Findings addressed
**🔴 Phase-indicator AA (blocker).** The Band-2 phase pill reused the shared `.debate-phase-indicator` (`color: var(--focus-ring)` blue), failing WCAG AA in **light (3.68:1)** and **bkc (3.51:1)**. Rather than recolor the shared class globally (it has other callsites — per Design's caution), the header now uses a dedicated **`.debate-hdr-phase`** chip: `var(--text-secondary)` on `var(--bg-tertiary)`, uppercase, keeping the ● dot (currentColor). Meets AA in all 4 themes.

**🟡 Title/source URL duplication (strong-should).** Raw-URL topics (`topic.final` = `"Discuss: https://www.…/foo"`) made the h2 and the source subtitle show the same URL twice. New `deriveHeaderTitle`/`humanizeUrl` helpers: strip a leading `Discuss:`, humanize a bare-URL topic (drop scheme/`www.`/trailing slash), and suppress the source line when it would merely repeat the title. Clean refined titles are unchanged and still show the humanized source.

## Tests
New `DebateHeader.test.tsx` unit-tests the pure helpers (raw-URL dedup incl. the exact review debate, clean-title case, no-source, case-insensitive `Discuss:`, empty-strip fallback). Updated 5 phase-title assertions in `DebateWorkspace.test.tsx` to the renamed `.debate-hdr-phase`.

## Gates
renderer tsc 0, eslint 0 errors, depcruise clean, vite build ok, debate-workspace vitest **260/260**.

Scoped to DebateWorkspace files only (fresh branch off current origin/main — no reversion of intervening main changes). Design re-verifies (4 themes) and marks t/2293 Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)