### PR TITLE
fix(edge-browser): legible empty-state for edges with no rationale

### DIFF
--- a/taxonomy-editor/src/renderer/components/edge-browser/EdgeDetailPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/edge-browser/EdgeDetailPanel.test.tsx
@@ -103,8 +103,8 @@ describe('EdgeDetailPanel (t/1009)', () => {
 
     render(<EdgeDetailPanel />);
 
-    // Falls back to an em-dash and records the failure to the flight recorder.
-    expect(await screen.findByText('—')).toBeDefined();
+    // Falls back to the empty-state placeholder and records the failure to the flight recorder.
+    expect(await screen.findByText(/No rationale recorded/)).toBeDefined();
     expect(record).toHaveBeenCalled();
   });
 });

--- a/taxonomy-editor/src/renderer/components/edge-browser/EdgeDetailPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/edge-browser/EdgeDetailPanel.tsx
@@ -140,7 +140,7 @@ function RationaleSection({ rationale, loading, clamped, onToggleClamp }: {
           )}
         </>
       ) : (
-        <div className="edge-detail-rationale" style={{ color: 'var(--text-muted)' }}>&mdash;</div>
+        <div className="edge-detail-rationale" style={{ color: 'var(--text-secondary)', fontStyle: 'italic' }}>No rationale recorded for this edge.</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Problem
The Edge Detail panel showed a blank box for edges with no rationale (e.g. the `acc-desires-001` self-loop, which has `rationale: null` in `edges.json`). The empty-state em-dash was drawn in `var(--text-muted)`, which fails AA contrast in the light/Harvard/BKC themes — so it rendered nearly invisible and the panel looked broken.

## Fix
Replace the muted `—` with an italic **"No rationale recorded for this edge."** in `var(--text-secondary)` (a defined, AA-passing token). Updated the matching assertion in `EdgeDetailPanel.test.tsx`.

## Test
`vitest run src/renderer/components/edge-browser/EdgeDetailPanel.test.tsx` → 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)