### PR TITLE
feat(debate): Map-based BrowserWindow for multi-window debate popout (t/2303)

### DIFF
--- a/taxonomy-editor/src/main/main.ts
+++ b/taxonomy-editor/src/main/main.ts
@@ -25,7 +25,7 @@ console.log('[main] fileIO import OK');
 let mainWindow: BrowserWindow | null = null;
 let diagWindow: BrowserWindow | null = null;
 let povProgWindow: BrowserWindow | null = null;
-let debateWindow: BrowserWindow | null = null;
+const debateWindows = new Map<string, BrowserWindow>();
 let promptDiffWindow: BrowserWindow | null = null;
 let chatWindow: BrowserWindow | null = null;
 let diffWindow: BrowserWindow | null = null;
@@ -603,18 +603,27 @@ void app.whenReady().then(() => {
     });
   });
 
-  // Debate popout window
+  // Debate popout windows (Map-based, up to 5 simultaneous)
   ipcMain.handle('open-debate-window', (_event, debateId: string) => {
-    if (debateWindow && !debateWindow.isDestroyed()) {
-      // Reuse existing window — send the new debate ID
-      debateWindow.webContents.send('debate-window-load', debateId);
-      if (debateWindow.isMinimized()) debateWindow.restore();
-      debateWindow.show();
-      debateWindow.focus();
+    // Per-id dedup: focus existing window for this debateId (never counts against cap)
+    const existing = debateWindows.get(debateId);
+    if (existing && !existing.isDestroyed()) {
+      if (existing.isMinimized()) existing.restore();
+      existing.show();
+      existing.focus();
       return;
     }
+    // Prune stale destroyed entries before cap check
+    for (const [id, w] of debateWindows.entries()) {
+      if (w.isDestroyed()) debateWindows.delete(id);
+    }
+    if (debateWindows.size >= 5) {
+      return { atCap: true };
+    }
+    const offset = debateWindows.size * 30;
     const preloadPath = path.join(__dirname, 'preload.cjs');
-    debateWindow = new BrowserWindow({
+    const win = new BrowserWindow({
+      ...(offset > 0 ? { x: offset, y: offset } : {}),
       width: 1100,
       height: 800,
       minWidth: 700,
@@ -628,23 +637,24 @@ void app.whenReady().then(() => {
         sandbox: true,
       },
     });
-    hardenWindow(debateWindow);
+    hardenWindow(win);
+    debateWindows.set(debateId, win);
     const debateHash = `debate-window?id=${encodeURIComponent(debateId)}`;
     const isDev = !app.isPackaged;
     if (isDev) {
-      void debateWindow.loadURL(`http://localhost:5173#${debateHash}`);
+      void win.loadURL(`http://localhost:5173#${debateHash}`);
     } else {
-      void debateWindow.loadFile(path.join(PROJECT_ROOT, 'taxonomy-editor/dist/renderer/index.html'), { hash: debateHash });
+      void win.loadFile(path.join(PROJECT_ROOT, 'taxonomy-editor/dist/renderer/index.html'), { hash: debateHash });
     }
     // Send debate ID on every load (initial + HMR reload)
-    debateWindow.webContents.on('did-finish-load', () => {
+    win.webContents.on('did-finish-load', () => {
       console.log('[Main] debate-window did-finish-load, sending debate ID:', debateId);
-      debateWindow?.webContents.send('debate-window-load', debateId);
+      if (!win.isDestroyed()) win.webContents.send('debate-window-load', debateId);
     });
-    debateWindow.on('closed', () => {
-      debateWindow = null;
+    win.on('closed', () => {
+      debateWindows.delete(debateId);
       if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send('debate-popout-closed');
+        mainWindow.webContents.send('debate-popout-closed', debateId);
       }
     });
   });
@@ -654,9 +664,10 @@ void app.whenReady().then(() => {
     sendFocusNode(nodeId);
   });
 
-  ipcMain.handle('close-debate-window', () => {
-    if (debateWindow && !debateWindow.isDestroyed()) {
-      debateWindow.close();
+  ipcMain.handle('close-debate-window', (_event, debateId: string) => {
+    const win = debateWindows.get(debateId);
+    if (win && !win.isDestroyed()) {
+      win.close();
     }
   });
 });

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -241,8 +241,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // Debate popout window
-  openDebateWindow: (debateId: string): Promise<void> => ipcRenderer.invoke('open-debate-window', debateId),
-  closeDebateWindow: (): Promise<void> => ipcRenderer.invoke('close-debate-window'),
+  openDebateWindow: (debateId: string): Promise<{ atCap: true } | void> => ipcRenderer.invoke('open-debate-window', debateId),
+  closeDebateWindow: (debateId: string): Promise<void> => ipcRenderer.invoke('close-debate-window', debateId),
   onDebateWindowLoad: (callback: (debateId: string) => void) => {
     // Stop buffering — the React component is now listening directly.
     _debateBufferActive = false;
@@ -261,8 +261,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       _debateBufferActive = true;
     };
   },
-  onDebatePopoutClosed: (callback: () => void) => {
-    const listener = () => callback();
+  onDebatePopoutClosed: (callback: (debateId: string) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, debateId: string) => callback(debateId);
     ipcRenderer.on('debate-popout-closed', listener);
     return () => { ipcRenderer.removeListener('debate-popout-closed', listener); };
   },

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -330,7 +330,7 @@ export const api: AppAPI = {
 
   // Debate popout
   openDebateWindow: (id) => window.electronAPI.openDebateWindow(id),
-  closeDebateWindow: () => window.electronAPI.closeDebateWindow(),
+  closeDebateWindow: (debateId) => window.electronAPI.closeDebateWindow(debateId),
   getCliFileArg: () => window.electronAPI.getCliFileArg(),
 
   // Terminal

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -374,8 +374,8 @@ export interface AppAPI {
   openPromptDiffWindow: (debateId: string, entryId: string) => Promise<void>;
 
   // --- Debate popout ---
-  openDebateWindow: (debateId: string) => Promise<void>;
-  closeDebateWindow: () => Promise<void>;
+  openDebateWindow: (debateId: string) => Promise<{ atCap: true } | void>;
+  closeDebateWindow: (debateId: string) => Promise<void>;
   getCliFileArg: () => Promise<{ type: string; path: string; data?: unknown; error?: string } | null>;
 
   // --- Terminal ---
@@ -412,7 +412,7 @@ export interface AppAPI {
   requestReExtractClaims: (entryId: string) => void;
   onReExtractClaims: (callback: (entryId: string) => void) => () => void;
   onDebateWindowLoad: (callback: (debateId: string) => void) => () => void;
-  onDebatePopoutClosed: (callback: () => void) => () => void;
+  onDebatePopoutClosed: (callback: (debateId: string) => void) => () => void;
   onGenerateTextProgress: (callback: (progress: {
     attempt: number;
     maxRetries: number;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -1278,7 +1278,7 @@ const rawApi: AppAPI = {
   openDebateWindow: async (debateId) => {
     openAppWindow(`debate-window?id=${encodeURIComponent(debateId)}`);
   },
-  closeDebateWindow: async () => { /* no-op in web mode */ },
+  closeDebateWindow: async (_debateId: string) => { /* no-op in web mode */ },
 
   getCliFileArg: async () => null, // No CLI mode in browser
 

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -182,11 +182,11 @@ export interface ElectronAPI {
   onDiagnosticsPopoutClosed: (callback: () => void) => () => void;
 
   // Debate popout
-  openDebateWindow: (debateId: string) => Promise<void>;
-  closeDebateWindow: () => Promise<void>;
+  openDebateWindow: (debateId: string) => Promise<{ atCap: true } | void>;
+  closeDebateWindow: (debateId: string) => Promise<void>;
   getCliFileArg: () => Promise<{ type: string; path: string; data?: unknown; error?: string } | null>;
   onDebateWindowLoad: (callback: (debateId: string) => void) => () => void;
-  onDebatePopoutClosed: (callback: () => void) => () => void;
+  onDebatePopoutClosed: (callback: (debateId: string) => void) => () => void;
   requestReExtractClaims: (entryId: string) => void;
   onReExtractClaims: (callback: (entryId: string) => void) => () => void;
 


### PR DESCRIPTION
## Summary

- Replaces `debateWindow` singleton ref with `Map<debateId, BrowserWindow>` to support multiple simultaneous debate popouts (parent t/2302)
- `open-debate-window`: per-id dedup (focus existing window, never counts against cap) → stale-entry prune → cap=5 guard returning `{ atCap: true }` → new window with 30px cascade offset per open window
- Per-window `closed` handler: removes Map entry, emits `debate-popout-closed` **with `debateId` payload** (contract for t/2304)
- `close-debate-window`: now takes `debateId`, targets specific Map entry
- Bridge layer updated: `preload.cts`, `types/electron.d.ts`, `bridge/types.ts`, `bridge/electron-bridge.ts`, `bridge/web-bridge.ts`

## Test plan

- [ ] `tsc -p tsconfig.main.json --noEmit` passes (verified locally)
- [ ] Open 2+ debate popouts with different IDs — each gets its own window
- [ ] Open same debate ID twice — focuses existing window
- [ ] Open 6th debate — main window receives `atCap: true` (t/2304 will surface this as UI toast)
- [ ] Close any popout — `debate-popout-closed` fires with correct `debateId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)