### PR TITLE
fix(debate): per-debate popout-close bookkeeping for multi-window (t/2310)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.popoutClose.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.popoutClose.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { initDebatePopoutCloseHandler } from './guards';
+import { useDebateStore } from '../store';
+
+// Multi-window debate popouts (t/2310): the main window may show one debate while
+// other debates have their own popout windows open. When a popout closes,
+// `debate-popout-closed` carries the closed debateId; the main window must only
+// reclaim the driver + reload when the closed popout was driving ITS active debate —
+// an unrelated debate's popout close must be a no-op for this window.
+describe('initDebatePopoutCloseHandler — per-debate close gate (t/2310)', () => {
+  let captured: ((debateId: string) => void) | null = null;
+  const api = {
+    onDebatePopoutClosed: (cb: (debateId: string) => void) => {
+      captured = cb;
+      return () => { /* unsubscribe */ };
+    },
+  };
+
+  beforeEach(() => {
+    captured = null;
+    // Real store; override loadDebate with a spy so reloadActiveDebateFromStorage is observable.
+    useDebateStore.setState({
+      activeDebateId: 'debate-A',
+      driverIsRemote: true,
+      loadDebate: vi.fn(),
+    } as unknown as Partial<ReturnType<typeof useDebateStore.getState>>);
+  });
+
+  it('reclaims driver + reloads when the closed popout is this window\'s active debate', () => {
+    initDebatePopoutCloseHandler(api);
+    captured?.('debate-A');
+    expect(useDebateStore.getState().driverIsRemote).toBe(false);
+    expect(useDebateStore.getState().loadDebate).toHaveBeenCalledWith('debate-A');
+  });
+
+  it('ignores a different debate\'s popout close (no clobber of the displayed debate)', () => {
+    initDebatePopoutCloseHandler(api);
+    captured?.('debate-B');
+    expect(useDebateStore.getState().driverIsRemote).toBe(true);
+    expect(useDebateStore.getState().loadDebate).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.ts
@@ -108,8 +108,12 @@ export function markAsPopout(): void {
   _driverChannel?.postMessage({ type: 'claim', windowId: _windowId });
 }
 
-export function initDebatePopoutCloseHandler(api: { onDebatePopoutClosed: (cb: () => void) => () => void }): () => void {
-  return api.onDebatePopoutClosed(() => {
+export function initDebatePopoutCloseHandler(api: { onDebatePopoutClosed: (cb: (debateId: string) => void) => () => void }): () => void {
+  return api.onDebatePopoutClosed((debateId) => {
+    // Multi-window (t/2310): only reclaim the driver + reload when the popout that closed
+    // was driving THIS window's active debate. A different debate's popout closing must not
+    // clobber the displayed debate's driver/reload state now that N popouts can be open.
+    if (debateId !== useDebateStore.getState().activeDebateId) return;
     useDebateStore.setState({ driverIsRemote: false });
     reloadActiveDebateFromStorage();
   });


### PR DESCRIPTION
## What

Renderer-side per-debate close bookkeeping for multi-window debate popouts (t/2310, child of t/2302). Companion to the main-process Map change landed in t/2303 / #638.

`initDebatePopoutCloseHandler` (in `hooks/useDebateStore/shared/guards.ts`) previously reset `driverIsRemote` + reloaded the active debate on **any** popout close. With N popouts now possible, it consumes the closed `debateId` (contract from #638) and only reclaims when that id matches **this window's** `activeDebateId` — an unrelated debate's popout close is a no-op, so it can't clobber the displayed debate's driver/reload state.

The single-driver model is already per-active-debate (BroadcastChannel + `activeDebateId`), so no separate open-popout Set is needed — the id gate is sufficient.

## Why here (not `components/debate/guards.ts`)

t/2304 named `components/debate/guards.ts`, but the real `initDebatePopoutCloseHandler` lives in `hooks/useDebateStore/shared/guards.ts`, which `resolve_owner` gives to Rosetta Stone (not DebateUI). Split agreed with DebateUI; tracked as t/2310. DebateUI owns the remaining at-cap UI (t/2304).

## Tests

`guards.popoutClose.test.ts` — real store, spied `loadDebate`:
- closed id == active debate → `driverIsRemote:false` + `loadDebate(id)` called
- closed id != active debate → state unchanged, `loadDebate` not called

## Verification

- renderer tsc: 0 errors
- eslint (changed files): clean
- vitest (scoped): 2/2 pass

## Design review

Self-certified — small single-scope change implementing the design locked at parent t/2302 (#1). No new cross-role interface (consumes the #638 contract).

Closes t/2310.
