### PR TITLE
fix(debate): route brief-timeout events through @bridge renderer-local bus (t/2307)

### DIFF
--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -315,17 +315,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => { ipcRenderer.removeListener('generate-text-progress', listener); };
   },
 
-  onBriefTimeout: (callback: (e: { debateId: string; speaker: string; attempt: number; maxAttempts: number; currentModel: string }) => void) => {
-    const listener = (_event: Electron.IpcRendererEvent, e: { debateId: string; speaker: string; attempt: number; maxAttempts: number; currentModel: string }) => callback(e);
-    ipcRenderer.on('brief-timeout', listener);
-    return () => { ipcRenderer.removeListener('brief-timeout', listener); };
-  },
-
-  onBriefRetriesExhausted: (callback: (e: { debateId: string; speaker: string; totalAttempts: number; currentModel: string }) => void) => {
-    const listener = (_event: Electron.IpcRendererEvent, e: { debateId: string; speaker: string; totalAttempts: number; currentModel: string }) => callback(e);
-    ipcRenderer.on('brief-retries-exhausted', listener);
-    return () => { ipcRenderer.removeListener('brief-retries-exhausted', listener); };
-  },
+  // Brief-timeout events moved to a renderer-local bus (t/2307). The opening
+  // pipeline runs in the renderer and the toast renders in the same window, so
+  // main never produced these events — the 'brief-timeout' / 'brief-retries-exhausted'
+  // IPC channels had zero senders. Removed to eliminate the dead listener.
 
   onReloadTaxonomy: (callback: () => void) => {
     const listener = () => callback();

--- a/taxonomy-editor/src/renderer/bridge/__tests__/briefTimeoutBus.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/briefTimeoutBus.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression: brief-timeout emit↔consume alignment across the @bridge seam (t/2307).
+//
+// The bug: clarificationSlice emitted via a hard `web-bridge` import (a module-local
+// Set), while the Electron consumer (useBriefTimeoutEvents → @bridge → electron-bridge)
+// subscribed to a *different* channel — an IPC channel with zero senders. So in the
+// Electron build the toast/dialog never fired.
+//
+// This test exercises the REAL wiring both sides use — emit via `@bridge`
+// (clarificationSlice's path) and subscribe via `@bridge` `api.onBriefTimeout`
+// (useBriefTimeoutEvents's path). In vitest `@bridge` resolves to the ELECTRON
+// bridge config (bridge/index.ts → electron-bridge), i.e. the build that was broken.
+// The existing useBriefTimeoutEvents.test.ts mocks `@bridge`, so it cannot catch a
+// mismatch in the emit↔consume seam — that gap is exactly what this covers.
+
+import { describe, it, expect } from 'vitest';
+import { api, emitBriefTimeout, emitBriefRetriesExhausted } from '@bridge';
+// Concrete web-bridge module — the target the WEB build's `@bridge` alias resolves
+// to directly. clarificationSlice now emits via `@bridge` (was a hard web-bridge
+// import), so we also assert the web resolution still exposes the emitters and that
+// emit↔consume aligns there — web was the only working build before t/2307, so a
+// silent web regression would be the worst case (TL t/2307#2).
+import { api as webApi, emitBriefTimeout as webEmitTimeout, emitBriefRetriesExhausted as webEmitExhausted } from '../web-bridge';
+
+type TimeoutPayload = { debateId: string; speaker: string; attempt: number; maxAttempts: number; currentModel: string };
+type ExhaustedPayload = { debateId: string; speaker: string; totalAttempts: number; currentModel: string };
+
+// Cast: onBriefTimeout / onBriefRetriesExhausted are on AppAPI; keep the payload
+// types explicit here so a signature drift on either side is a compile error.
+const bridge = api as unknown as {
+  onBriefTimeout: (cb: (e: TimeoutPayload) => void) => () => void;
+  onBriefRetriesExhausted: (cb: (e: ExhaustedPayload) => void) => () => void;
+};
+
+describe('brief-timeout @bridge emit↔consume seam (Electron config)', () => {
+  it('delivers emitBriefTimeout to a consumer subscribed via api.onBriefTimeout', () => {
+    const received: TimeoutPayload[] = [];
+    const unsub = bridge.onBriefTimeout((e) => received.push(e));
+
+    const payload: TimeoutPayload = { debateId: 'd1', speaker: 'safetyist', attempt: 1, maxAttempts: 3, currentModel: '' };
+    emitBriefTimeout(payload);
+
+    expect(received).toEqual([payload]);
+    unsub();
+  });
+
+  it('delivers emitBriefRetriesExhausted to a consumer subscribed via api.onBriefRetriesExhausted', () => {
+    const received: ExhaustedPayload[] = [];
+    const unsub = bridge.onBriefRetriesExhausted((e) => received.push(e));
+
+    const payload: ExhaustedPayload = { debateId: 'd1', speaker: 'skeptic', totalAttempts: 3, currentModel: '' };
+    emitBriefRetriesExhausted(payload);
+
+    expect(received).toEqual([payload]);
+    unsub();
+  });
+
+  it('stops delivering after unsubscribe', () => {
+    const received: TimeoutPayload[] = [];
+    const unsub = bridge.onBriefTimeout((e) => received.push(e));
+    unsub();
+
+    emitBriefTimeout({ debateId: 'd1', speaker: 'accelerationist', attempt: 2, maxAttempts: 3, currentModel: '' });
+
+    expect(received).toEqual([]);
+  });
+});
+
+// Web build: `@bridge` → web-bridge.ts directly. Guards against a silent web
+// regression from the slice's emit source switching to `@bridge` (TL t/2307#2).
+describe('brief-timeout web-bridge emit↔consume seam (Web config)', () => {
+  const webBridge = webApi as unknown as {
+    onBriefTimeout: (cb: (e: TimeoutPayload) => void) => () => void;
+    onBriefRetriesExhausted: (cb: (e: ExhaustedPayload) => void) => () => void;
+  };
+
+  it('exposes emitBriefTimeout / emitBriefRetriesExhausted', () => {
+    expect(typeof webEmitTimeout).toBe('function');
+    expect(typeof webEmitExhausted).toBe('function');
+  });
+
+  it('delivers web emitBriefTimeout to a web api.onBriefTimeout consumer', () => {
+    const received: TimeoutPayload[] = [];
+    const unsub = webBridge.onBriefTimeout((e) => received.push(e));
+
+    const payload: TimeoutPayload = { debateId: 'w1', speaker: 'safetyist', attempt: 1, maxAttempts: 3, currentModel: '' };
+    webEmitTimeout(payload);
+
+    expect(received).toEqual([payload]);
+    unsub();
+  });
+
+  it('delivers web emitBriefRetriesExhausted to a web api.onBriefRetriesExhausted consumer', () => {
+    const received: ExhaustedPayload[] = [];
+    const unsub = webBridge.onBriefRetriesExhausted((e) => received.push(e));
+
+    const payload: ExhaustedPayload = { debateId: 'w1', speaker: 'skeptic', totalAttempts: 3, currentModel: '' };
+    webEmitExhausted(payload);
+
+    expect(received).toEqual([payload]);
+    unsub();
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -26,6 +26,21 @@ void tryInitLocalEmbedding();
 // When the drawer is used instead, we also deliver to local callbacks.
 const localDiagCallbacks = new Set<(state: unknown) => void>();
 
+// Brief-timeout renderer-local event bus (t/2307). The debate pipeline runs in
+// THIS renderer window and the toast/dialog render in the SAME window, so emit
+// and consume share a module-local Set — no main-process IPC round-trip. Mirrors
+// web-bridge's bus so `@bridge` exposes an aligned channel in both builds. The old
+// 'brief-timeout' IPC channel was unfeedable (main never sees a renderer-side
+// timeout) and had zero senders — it is retired in favour of this local bus.
+// Types mirror the AppAPI inline shapes; NOT imported from useBriefTimeoutEvents.ts
+// (that file imports @bridge, which would create a circular dep).
+type BriefTimeoutPayload = { debateId: string; speaker: string; attempt: number; maxAttempts: number; currentModel: string };
+type BriefExhaustedPayload = { debateId: string; speaker: string; totalAttempts: number; currentModel: string };
+const briefTimeoutCbs = new Set<(e: BriefTimeoutPayload) => void>();
+const briefExhaustedCbs = new Set<(e: BriefExhaustedPayload) => void>();
+export function emitBriefTimeout(e: BriefTimeoutPayload): void { briefTimeoutCbs.forEach(cb => cb(e)); }
+export function emitBriefRetriesExhausted(e: BriefExhaustedPayload): void { briefExhaustedCbs.forEach(cb => cb(e)); }
+
 export const api: AppAPI = {
   // User preferences — delegates to IPC (get-preferences / set-preferences) once
   // ElectronMain handler lands (t/2118). Graceful-degrade until then.
@@ -370,8 +385,9 @@ export const api: AppAPI = {
   focusNodeInMainWindow: (nodeId) => window.electronAPI.focusNodeInMainWindow(nodeId),
   onTerminalData: (cb) => window.electronAPI.onTerminalData(cb),
   onTerminalExit: (cb) => window.electronAPI.onTerminalExit(cb),
-  onBriefTimeout: (cb) => window.electronAPI.onBriefTimeout(cb),
-  onBriefRetriesExhausted: (cb) => window.electronAPI.onBriefRetriesExhausted(cb),
+  // Renderer-local bus (t/2307) — see emitBriefTimeout above. Was a dead IPC channel.
+  onBriefTimeout: (cb) => { briefTimeoutCbs.add(cb); return () => briefTimeoutCbs.delete(cb); },
+  onBriefRetriesExhausted: (cb) => { briefExhaustedCbs.add(cb); return () => briefExhaustedCbs.delete(cb); },
   captureScreenshot: (opts) => window.electronAPI.captureScreenshot(opts),
 
   // Feature flags — desktop has no server. DEBATE_CHAT_REDESIGN defaults ON for

--- a/taxonomy-editor/src/renderer/bridge/index.ts
+++ b/taxonomy-editor/src/renderer/bridge/index.ts
@@ -14,6 +14,11 @@ import { instrumentBridge } from './instrumentBridge';
 export const api = instrumentBridge(rawApi);
 export type { AppAPI } from './types';
 
+// Brief-timeout emit surface (t/2307) — routed through @bridge so each build feeds
+// its own renderer-local bus. Web resolves @bridge → web-bridge (its own emitters);
+// Electron resolves @bridge → this file (electron-bridge's emitters).
+export { emitBriefTimeout, emitBriefRetriesExhausted } from './electron-bridge';
+
 export function setActiveDebateId(_id: string | null): void { /* no-op in Electron — no server logs to correlate */ }
 
 export function isElectronMode(): boolean {

--- a/taxonomy-editor/src/renderer/components/debate/useBriefTimeoutEvents.ts
+++ b/taxonomy-editor/src/renderer/components/debate/useBriefTimeoutEvents.ts
@@ -52,20 +52,11 @@ type BriefTimeoutBridge = {
   onBriefRetriesExhausted: (cb: (e: BriefRetriesExhaustedEvent) => void) => () => void;
 };
 
-// Type guard for the bridge additions (Rosetta Stone e/62 + ElectronMain preload).
-// The renderer-side wrapper exists in api once Rosetta Stone lands, but calling it
-// delegates to window.electronAPI which requires the preload to be wired too.
-// Guard at the preload layer to avoid a "is not a function" crash in the interim.
+// Both bridges expose onBriefTimeout / onBriefRetriesExhausted directly on `api`,
+// each feeding its own renderer-local event bus (t/2307: web-bridge and
+// electron-bridge are aligned via @bridge — no IPC, no electronAPI dependency).
+// Confirm the @bridge api provides both before subscribing.
 function briefTimeoutBridge(): BriefTimeoutBridge | null {
-  const electronAPI = (window as unknown as Record<string, unknown>)['electronAPI'] as Record<string, unknown> | undefined;
-  if (electronAPI) {
-    // Electron mode: require the preload to actually expose both handlers
-    if (typeof electronAPI['onBriefTimeout'] === 'function' && typeof electronAPI['onBriefRetriesExhausted'] === 'function') {
-      return api as unknown as BriefTimeoutBridge;
-    }
-    return null; // preload not yet wired — no-op until ElectronMain lands it
-  }
-  // Web mode: check api directly (web-bridge stubs land via t/2218)
   const a = api as unknown as Record<string, unknown>;
   if (typeof a['onBriefTimeout'] === 'function' && typeof a['onBriefRetriesExhausted'] === 'function') {
     return api as unknown as BriefTimeoutBridge;

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -16,8 +16,7 @@ import type { TopicScope, TopicScopeRiskLevel } from '@lib/debate/types';
 import type { PovNode, CrossCuttingNode as SituationNode } from '../../../types/taxonomy';
 import type { StandardizedTerm, ColloquialTerm } from '@lib/dictionary/types';
 import type { OpeningPipelineInput, BriefEventFn } from '@lib/debate/turnPipeline';
-import { api, isElectronMode } from '@bridge';
-import { emitBriefTimeout, emitBriefRetriesExhausted } from '../../../bridge/web-bridge';
+import { api, emitBriefTimeout, emitBriefRetriesExhausted } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { generateId, nowISO, parseAIJson, parsePoverResponse, formatRecentTranscript } from '@lib/debate/helpers';
 import { formatTaxonomyContext } from '../../../utils/taxonomyContext';
@@ -959,8 +958,11 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
           background: activeDebate.topic?.background || undefined,
         };
 
-        // Web-only: Electron routes brief-timeout events via IPC from ElectronMain.
-        const onBriefEvent: BriefEventFn | undefined = isElectronMode() ? undefined : (phase, data) => {
+        // Emit on the renderer-local brief-timeout bus (t/2307). Both builds: the
+        // opening pipeline runs in this renderer, so emit and the same-window toast
+        // consumer share @bridge's bus — no IPC. Previously web-only; the Electron
+        // path routed through an unfed IPC channel and never fired.
+        const onBriefEvent: BriefEventFn = (phase, data) => {
           if (phase === 'brief.timeout' || phase === 'brief.retrying') {
             emitBriefTimeout({ debateId: activeDebate.id, speaker: data.agent, attempt: data.attempt, maxAttempts: data.maxRetries, currentModel: '' });
           } else if (phase === 'brief.retries_exhausted') {

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -107,8 +107,8 @@ export interface ElectronAPI {
   onChatStreamError: (callback: (error: string) => void) => () => void;
   setDebateTemperature: (temp: number | null) => Promise<void>;
   onGenerateTextProgress: (callback: (progress: { attempt: number; maxRetries: number; backoffSeconds: number; limitType: string; limitMessage: string }) => void) => () => void;
-  onBriefTimeout: (callback: (e: { debateId: string; speaker: string; attempt: number; maxAttempts: number; currentModel: string }) => void) => () => void;
-  onBriefRetriesExhausted: (callback: (e: { debateId: string; speaker: string; totalAttempts: number; currentModel: string }) => void) => () => void;
+  // onBriefTimeout / onBriefRetriesExhausted removed (t/2307) — brief-timeout now
+  // uses a renderer-local bus in electron-bridge, not an IPC channel on electronAPI.
 
   // Embeddings & NLI
   computeEmbeddings: (texts: string[], ids?: string[]) => Promise<{ vectors: number[][] }>;


### PR DESCRIPTION
## Summary

Fixes **t/2307** — the brief-timeout toast + retries-exhausted dialog were **inert in the Electron build**.

`clarificationSlice` emitted via a hard `web-bridge` import (a module-local `Set`), while the Electron consumer (`useBriefTimeoutEvents` → `@bridge` → `electron-bridge`) subscribed to a `brief-timeout` **IPC channel with zero senders**. The opening pipeline runs entirely in the renderer, so main never produced those events — the IPC path was **structurally unfeedable**. Web worked only by coincidence (both emit and consume hit web-bridge's `Set`).

## Fix (option b — renderer-local emit in both builds)

Route emission through `@bridge` so each build feeds its own renderer-local bus, mirroring web-bridge's existing pattern (t/2218):

- **`electron-bridge.ts`** — module-local `Set` bus + `emitBriefTimeout`/`emitBriefRetriesExhausted`; `onBrief*` register into it (was dead IPC).
- **`bridge/index.ts`** — re-export the emitters so `@bridge` exposes them in the Electron/tsc/vitest resolution.
- **`clarificationSlice.ts`** — import emitters from `@bridge` (was a hard `web-bridge` import); drop the `isElectronMode` guard so emit fires in both builds.
- **`useBriefTimeoutEvents.ts`** *(DebateUI, approved p/266#4)* — guard checks `api.onBrief*`, not `window.electronAPI`.
- **`preload.cts`** *(ElectronMain, approved p/265#5)* + **`types/electron.d.ts`** — remove the dead IPC channels.

## Tests

New `bridge/__tests__/briefTimeoutBus.test.ts` asserts emit↔consume alignment across the seam in **both** resolutions:
- **Electron** (`@bridge` → `index.ts` → electron-bridge) — the build that was broken.
- **Web** (`web-bridge` directly) — guards against a silent web regression from the slice's emit source switch (TL t/2307#2).

The existing `useBriefTimeoutEvents.test.ts` mocks `@bridge`, so it could not catch the emit↔consume wiring gap. **Red→green:** on `main` the seam test can't even run — `@bridge`/index.ts didn't export `emitBriefTimeout` and `api.onBriefTimeout` dereferenced `window.electronAPI` (undefined in vitest → throws).

## Sign-offs

- Design: Technical Lead — **t/2307#2**
- Cross-scope removals: ElectronMain (p/265#5), DebateUI (p/266#4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
