### PR TITLE
refactor(debate): move "Rerun with Insights" into composer Tools menu (t/2308)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
@@ -665,6 +665,8 @@ function ToolsMenu({
   requestSynthesis,
   requestProbingQuestions,
   requestReflections,
+  canRerunInsights,
+  onRerunInsights,
 }: {
   disableAnalysis: boolean;
   isClosed: boolean;
@@ -681,6 +683,8 @@ function ToolsMenu({
   requestSynthesis: () => void | Promise<void>;
   requestProbingQuestions: () => void | Promise<void>;
   requestReflections: () => void | Promise<void>;
+  canRerunInsights: boolean;
+  onRerunInsights: () => void | Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -698,6 +702,11 @@ function ToolsMenu({
   items.push({ kind: 'divider', key: 'div-1' });
   items.push({ kind: 'item', key: 'synthesize', label: 'Synthesize', title: hasSynthesis ? 'Synthesis already generated' : 'Generate a synthesis of agreements, disagreements, and open questions', disabled: disableAnalysis || hasSynthesis, onSelect: () => void requestSynthesis() });
   items.push({ kind: 'item', key: 'probe', label: 'Probe', title: 'Get AI-suggested probing questions to deepen the debate', disabled: disableAnalysis || isClosed, onSelect: () => void requestProbingQuestions() });
+  // Relocated from the floating inline button below the transcript (t/2308). Shown only
+  // under its original eligibility: closed, non-exploration debate with no exploration summary.
+  if (canRerunInsights) {
+    items.push({ kind: 'item', key: 'rerun-insights', label: 'Rerun with Insights', title: 'Extract insights from this debate and use them to seed a new, better debate', disabled: disableAnalysis, onSelect: () => void onRerunInsights() });
+  }
   if (showAdminControls) {
     items.push({ kind: 'divider', key: 'div-2' });
     items.push({ kind: 'item', key: 'dump', label: 'Export flight recorder', title: 'Export flight recorder (Ctrl+Alt+D)', onSelect: () => { void triggerManualDump(); } });
@@ -773,8 +782,8 @@ function DebateModals({
 }
 
 export function DebateActions({ showParamHistory, setShowParamHistory, showEvaluation, setShowEvaluation }: { showParamHistory: boolean; setShowParamHistory: (v: boolean) => void; showEvaluation: boolean; setShowEvaluation: (v: boolean) => void }) {
-  const { activeDebate, debateGenerating, debateError, debateRetryAction, dailyLimitPaused, askQuestion, crossRespond, requestSynthesis, requestProbingQuestions, requestReflections, toggleStepMode, setDebatePhase, setError, audience, setAudience } = useDebateStore(
-    useShallow(s => ({ activeDebate: s.activeDebate, debateGenerating: s.debateGenerating, debateError: s.debateError, debateRetryAction: s.debateRetryAction, dailyLimitPaused: s.dailyLimitPaused, askQuestion: s.askQuestion, crossRespond: s.crossRespond, requestSynthesis: s.requestSynthesis, requestProbingQuestions: s.requestProbingQuestions, requestReflections: s.requestReflections, toggleStepMode: s.toggleStepMode, setDebatePhase: s.setDebatePhase, setError: s.setError, audience: s.audience, setAudience: s.setAudience }))
+  const { activeDebate, debateGenerating, debateError, debateRetryAction, dailyLimitPaused, askQuestion, crossRespond, requestSynthesis, requestProbingQuestions, requestReflections, toggleStepMode, setDebatePhase, setError, audience, setAudience, explorationSummary, extractAndSeedFromDebate } = useDebateStore(
+    useShallow(s => ({ activeDebate: s.activeDebate, debateGenerating: s.debateGenerating, debateError: s.debateError, debateRetryAction: s.debateRetryAction, dailyLimitPaused: s.dailyLimitPaused, askQuestion: s.askQuestion, crossRespond: s.crossRespond, requestSynthesis: s.requestSynthesis, requestProbingQuestions: s.requestProbingQuestions, requestReflections: s.requestReflections, toggleStepMode: s.toggleStepMode, setDebatePhase: s.setDebatePhase, setError: s.setError, audience: s.audience, setAudience: s.setAudience, explorationSummary: s.explorationSummary, extractAndSeedFromDebate: s.extractAndSeedFromDebate }))
   );
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
@@ -800,6 +809,8 @@ export function DebateActions({ showParamHistory, setShowParamHistory, showEvalu
   const isSocratic = (activeDebate.active_povers ?? []).filter(p => p !== 'user').length < 2;
   const hasSynthesis = activeDebate.transcript.some(e => e.type === 'concluding');
   const hasEvaluations = !!activeDebate.neutral_evaluations?.length;
+  // Same eligibility the removed inline RerunInsightsSlot used (t/2308).
+  const canRerunInsights = isClosed && activeDebate.protocol_id !== 'exploration' && !explorationSummary;
 
   const mentionOptions = AI_MENTION_OPTIONS.filter(o => activeDebate.active_povers.includes(o.id as SpeakerId));
 
@@ -943,6 +954,8 @@ export function DebateActions({ showParamHistory, setShowParamHistory, showEvalu
               requestSynthesis={requestSynthesis}
               requestProbingQuestions={requestProbingQuestions}
               requestReflections={requestReflections}
+              canRerunInsights={canRerunInsights}
+              onRerunInsights={() => extractAndSeedFromDebate(activeDebate.id)}
             />
             <AudienceSelect audience={audience} setAudience={setAudience} disabled={disableAnalysis || isClosed} />
           </div>

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -742,26 +742,6 @@ function DebateTranscriptColumn({
   );
 }
 
-function RerunInsightsSlot({ isExploration, activeDebate, explorationSummary, extractAndSeedFromDebate }: {
-  isExploration: boolean;
-  activeDebate: ActiveDebateSession;
-  explorationSummary: DWStore['explorationSummary'];
-  extractAndSeedFromDebate: DWStore['extractAndSeedFromDebate'];
-}) {
-  if (isExploration || activeDebate.phase !== 'closed' || explorationSummary) return null;
-  return (
-    <div className="debate-rerun-insights">
-      <button
-        className="btn btn-explore"
-        onClick={() => void extractAndSeedFromDebate(activeDebate.id)}
-        title="Extract insights from this debate and use them to seed a new, better debate"
-      >
-        Rerun with Insights
-      </button>
-    </div>
-  );
-}
-
 function PhaseActionBar({
   showRemoteOverlay, activeDebate, isClarificationPhase, isEditClaimsPhase, isOpeningPhase, isDebatePhase, isExplorationClosed,
   showParamHistory, setShowParamHistory, showEvaluation, setShowEvaluation,
@@ -801,15 +781,13 @@ function NeutralEvalSlot({ showEvaluation, activeDebate }: { showEvaluation: boo
 }
 
 function DebateActionRegion({
-  activeDebate, isExploration, isExplorationClosed, explorationSummary, extractAndSeedFromDebate,
+  activeDebate, isExplorationClosed, explorationSummary,
   showRemoteOverlay, isClarificationPhase, isEditClaimsPhase, isOpeningPhase, isDebatePhase,
   showParamHistory, setShowParamHistory, showEvaluation, setShowEvaluation,
 }: {
   activeDebate: ActiveDebateSession;
-  isExploration: boolean;
   isExplorationClosed: boolean;
   explorationSummary: DWStore['explorationSummary'];
-  extractAndSeedFromDebate: DWStore['extractAndSeedFromDebate'];
   showRemoteOverlay: boolean;
   isClarificationPhase: boolean;
   isEditClaimsPhase: boolean;
@@ -824,13 +802,6 @@ function DebateActionRegion({
     <>
       {/* Exploration summary card — shown when exploration debate closes */}
       {isExplorationClosed && explorationSummary && <ExplorationSummaryCard />}
-
-      <RerunInsightsSlot
-        isExploration={isExploration}
-        activeDebate={activeDebate}
-        explorationSummary={explorationSummary}
-        extractAndSeedFromDebate={extractAndSeedFromDebate}
-      />
 
       <PhaseActionBar
         showRemoteOverlay={showRemoteOverlay}
@@ -1248,7 +1219,7 @@ export function DebateWorkspace({ onExport, exportStatus }: {
     diagPopoutOpen, setDiagPopoutOpen, defaultTier, setDefaultTier,
     driverIsRemote,
     selectedRef, setSelectedRef,
-    explorationSummary, extractExplorationSummary, extractAndSeedFromDebate,
+    explorationSummary, extractExplorationSummary,
   } = useDebateStore(
     useShallow(s => ({
       activeDebate: s.activeDebate, debateLoading: s.debateLoading, debateError: s.debateError, debateGenerating: s.debateGenerating,
@@ -1260,7 +1231,6 @@ export function DebateWorkspace({ onExport, exportStatus }: {
       selectedRef: s.selectedRef, setSelectedRef: s.setSelectedRef,
       explorationSummary: s.explorationSummary,
       extractExplorationSummary: s.extractExplorationSummary,
-      extractAndSeedFromDebate: s.extractAndSeedFromDebate,
     }))
   );
   const { runSemanticSearch, setFindQuery: setStoreFindQuery, setFindMode: setStoreFindMode, setToolbarPanel } = useTaxonomyStore();
@@ -1385,10 +1355,8 @@ export function DebateWorkspace({ onExport, exportStatus }: {
 
       <DebateActionRegion
         activeDebate={activeDebate}
-        isExploration={isExploration}
         isExplorationClosed={isExplorationClosed}
         explorationSummary={explorationSummary}
-        extractAndSeedFromDebate={extractAndSeedFromDebate}
         showRemoteOverlay={showRemoteOverlay}
         isClarificationPhase={isClarificationPhase}
         isEditClaimsPhase={isEditClaimsPhase}


### PR DESCRIPTION
Relocates the floating "Rerun with Insights" button (rendered inline below the transcript when a non-exploration debate closed) into the composer `Tools ▾` menu, so secondary actions live in one place (t/2283 action-bar direction).

- `ToolsMenu` gains a `rerun-insights` item calling `extractAndSeedFromDebate(activeDebate.id)` — same handler and tooltip as the old button, disabled while analysis is running.
- The item is only built under the old slot's eligibility: closed, non-exploration debate with no `explorationSummary`.
- `RerunInsightsSlot` and its prop threading removed. It had no CSS rule of its own, so there is no dead CSS to delete.

Verified in an isolated worktree off fresh `origin/main`: main/server/renderer tsc clean, eslint 0 errors, depcruise clean, vite build OK, `vitest run src/renderer/components/debate-workspace/` 260/260 pass. Visual/keyboard/4-theme verification requested from Design (menu markup is the existing `ActionMenu`, unchanged).

Closes t/2308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)