### PR TITLE
feat(debate-tab): at-cap UI when max popout windows reached (t/2304)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -350,7 +350,11 @@ export function DebateTab() {
   // Condition 3 (t/2305 web path): openDebateWindow already has a working web-bridge
   // impl (openAppWindow(`debate-window?id=…`)) — no stub to fix, confirmed in web-bridge.ts.
   const handleRowOpen = useCallback((id: string) => {
-    api.openDebateWindow(id).catch((err: Error) => {
+    api.openDebateWindow(id).then((result) => {
+      if (result && result.atCap) {
+        setQuotaError('Close a debate window — max 5 open');
+      }
+    }).catch((err: Error) => {
       getGlobalRecorder()?.record({
         type: 'system.error',
         component: 'debate-tab',
@@ -478,7 +482,10 @@ export function DebateTab() {
         </div>
       )}
       {showNewDialog && (
-        <NewDebateDialog onClose={() => setShowNewDialog(false)} />
+        <NewDebateDialog
+          onClose={() => setShowNewDialog(false)}
+          onAtCap={() => setQuotaError('Close a debate window — max 5 open')}
+        />
       )}
       {pendingExportFormat && (
         <ExportOptionsDialog

--- a/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
@@ -35,6 +35,7 @@ const STYLE_PRESETS: { id: DialecticalStyle; label: string; desc: string }[] = [
 
 interface NewDebateDialogProps {
   onClose: () => void;
+  onAtCap?: () => void;
 }
 
 const AUDIENCE_DESCRIPTIONS: Record<string, string> = {
@@ -907,7 +908,7 @@ function DebateSettingsDialog({
 
 // ── Main dialog ───────────────────────────────────────────────────────────────
 
-export function NewDebateDialog({ onClose }: NewDebateDialogProps) {
+export function NewDebateDialog({ onClose, onAtCap }: NewDebateDialogProps) {
   const { createDebate, loadDebate } = useDebateStore(
     useShallow(s => ({ createDebate: s.createDebate, loadDebate: s.loadDebate }))
   );
@@ -1176,7 +1177,8 @@ export function NewDebateDialog({ onClose }: NewDebateDialogProps) {
       const store = useDebateStore.getState();
       store.updatePhase('clarification');
       await store.saveDebate();
-      api.openDebateWindow(id).catch(() => { /* fallback: stays inline */ });
+      const popoutResult = await api.openDebateWindow(id).catch(() => undefined);
+      if (popoutResult && popoutResult.atCap) onAtCap?.();
 
       // Generate title via model call (Q5 resolved); announce for screen readers
       try {


### PR DESCRIPTION
## Summary

Surfaces "Close a debate window — max 5 open" when `openDebateWindow` returns `{ atCap: true }` (5 popout windows already live).

- `handleRowOpen` (DebateTab): `.then()` checks `result.atCap` → `setQuotaError` (reuses existing dismissible error bar)
- `NewDebateDialog`: added optional `onAtCap?` callback; `DebateTab` wires it to `setQuotaError`; debate still created and shown inline when at cap
- Bridge contract (`Promise<{ atCap: true } | void>`) already landed with PR #638

**Depends on #639** (t/2305 tables — introduces `DebateTable.tsx` where the Open button lives). Rebase onto main once #639 merges.

Rosetta Stone handles the `guards.ts` per-debateId close bookkeeping (their scope).

## Test plan

- [ ] Open 5 debate windows; click Open on a 6th → error bar shows "Close a debate window — max 5 open"
- [ ] Create a new debate via NewDebateDialog when 5 windows are open → debate created inline, same error bar
- [ ] Dismiss error bar → clears
- [ ] Normal Open (< 5 windows) → no error bar

Generated with Claude Code

Co-Authored-By: DebateUI (Orca) <main.taxonomy-editor-src-renderer-components-debate@ai-triad-research.orca.local>
