### PR TITLE
feat(debate-tab): at-cap error bar when popout quota reached (t/2304)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -350,7 +350,11 @@ export function DebateTab() {
   // Condition 3 (t/2305 web path): openDebateWindow already has a working web-bridge
   // impl (openAppWindow(`debate-window?id=…`)) — no stub to fix, confirmed in web-bridge.ts.
   const handleRowOpen = useCallback((id: string) => {
-    api.openDebateWindow(id).catch((err: Error) => {
+    api.openDebateWindow(id).then((result) => {
+      if (result && result.atCap) {
+        setQuotaError('Close a debate window — max 5 open');
+      }
+    }).catch((err: Error) => {
       getGlobalRecorder()?.record({
         type: 'system.error',
         component: 'debate-tab',
@@ -478,7 +482,10 @@ export function DebateTab() {
         </div>
       )}
       {showNewDialog && (
-        <NewDebateDialog onClose={() => setShowNewDialog(false)} />
+        <NewDebateDialog
+          onClose={() => setShowNewDialog(false)}
+          onAtCap={() => setQuotaError('Close a debate window — max 5 open')}
+        />
       )}
       {pendingExportFormat && (
         <ExportOptionsDialog

--- a/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
@@ -35,6 +35,7 @@ const STYLE_PRESETS: { id: DialecticalStyle; label: string; desc: string }[] = [
 
 interface NewDebateDialogProps {
   onClose: () => void;
+  onAtCap?: () => void;
 }
 
 const AUDIENCE_DESCRIPTIONS: Record<string, string> = {
@@ -907,7 +908,7 @@ function DebateSettingsDialog({
 
 // ── Main dialog ───────────────────────────────────────────────────────────────
 
-export function NewDebateDialog({ onClose }: NewDebateDialogProps) {
+export function NewDebateDialog({ onClose, onAtCap }: NewDebateDialogProps) {
   const { createDebate, loadDebate } = useDebateStore(
     useShallow(s => ({ createDebate: s.createDebate, loadDebate: s.loadDebate }))
   );
@@ -1176,7 +1177,11 @@ export function NewDebateDialog({ onClose }: NewDebateDialogProps) {
       const store = useDebateStore.getState();
       store.updatePhase('clarification');
       await store.saveDebate();
-      api.openDebateWindow(id).catch(() => { /* fallback: stays inline */ });
+      const popoutResult = await api.openDebateWindow(id).catch((err: Error) => {
+        getGlobalRecorder()?.record({ type: 'system.error', component: 'new-debate-dialog', level: 'warn', message: 'Failed to open debate popout window', error: { name: err.name ?? 'Error', message: String(err), stack: err.stack } });
+        return undefined;
+      });
+      if (popoutResult?.atCap) onAtCap?.();
 
       // Generate title via model call (Q5 resolved); announce for screen readers
       try {


### PR DESCRIPTION
## Summary
- `DebateTab.handleRowOpen`: adds `.then()` to check `result.atCap` and surface the existing `quotaError` bar with message "Close a debate window — max 5 open"
- `NewDebateDialog`: adds optional `onAtCap` callback prop; `openDebateWindow` call converted to `await` with atCap check + Error Recording Rule applied to `.catch()` (replaces silent fallback comment)
- No new UI components — reuses the existing dismissible `debate-tab-quota-error` bar from t/2305

## Depends on
- t/2302 (#638) — `openDebateWindow` contract (`{atCap:true}|void`) ✅ landed
- t/2310 (RS) — per-debate close handler in `guards.ts` ✅ landed

## Test plan
- [ ] Open 5 debate popout windows; opening a 6th shows the error bar
- [ ] "New Debate" → Begin → at-cap → error bar appears, dialog closes
- [ ] Dismiss button clears the error bar
- [ ] tsc: 0 errors, eslint: 0 errors

Fixes t/2304
