### PR TITLE
fix(debate-tab): table layout — tablet panel cap + col-title overflow (t/2311)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.css
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.css
@@ -18,15 +18,22 @@
 }
 
 /* ──────────────────────────────────────────────
-   Column sizing — Title is the flex column
+   Column sizing — Title auto-fits at ≤1023px (model hidden, fewer fixed cols);
+   capped at 35% on desktop only so it doesn't absorb all excess width.
+   col-actions widened to 11.5rem for Share button (t/2311).
 ────────────────────────────────────────────── */
 .debate-table colgroup .col-title   { width: auto; }
-.debate-table colgroup .col-status  { width: 7rem; }
-.debate-table colgroup .col-date    { width: 9rem; }
-.debate-table colgroup .col-turns   { width: 4rem; }
-.debate-table colgroup .col-model   { width: 10rem; }
-.debate-table colgroup .col-actions { width: 10rem; }
+.debate-table colgroup .col-status  { width: 6rem; }
+.debate-table colgroup .col-date    { width: 7.5rem; }
+.debate-table colgroup .col-turns   { width: 3.5rem; }
+.debate-table colgroup .col-model   { width: 9rem; }
+.debate-table colgroup .col-actions { width: 11.5rem; }
 .debate-table colgroup .col-cb      { width: 2rem; }
+
+@media (min-width: 1024px) {
+  /* Desktop only: cap title column so it doesn't grow to fill all excess space */
+  .debate-table colgroup .col-title { width: 35%; }
+}
 
 /* ──────────────────────────────────────────────
    Header
@@ -393,5 +400,15 @@
 
 .debate-tab-table-mode .list-panel.debate-session-list {
   /* Override the inline `style.width` set by useResizablePanel */
+  flex: 1;
+}
+
+/* Tablet band (768–1023px): tablet-mode sets width:30%/max-width:320px on the list panel
+   which overrides flex:1 via specificity. When table-mode is also active, release
+   that cap so the panel fills the full two-column container. */
+.two-column.tablet-mode.debate-tab-table-mode .list-panel.debate-session-list {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: none !important;
   flex: 1;
 }


### PR DESCRIPTION
## Summary
- **T1 (tablet 768–1023px):** `styles.css` 4-class `tablet-mode` rule (`max-width:320px !important`) outranked the 2-class `debate-tab-table-mode` rule, capping the list panel at 320px even in table-mode. Fix: add a 5-class rule `.two-column.tablet-mode.debate-tab-table-mode .list-panel.debate-session-list` that releases the cap (`width:auto !important; min-width:0 !important; max-width:none !important; flex:1`). Also removes `min-width:34rem` from `.debate-table` (original source of horizontal scroll).
- **T2 (desktop >1023px):** Scope `col-title:35%` to `@media (min-width:1024px)` only. At ≤1023px, `col-title` reverts to `auto` — prevents overflow at ~700px (phone-lg) where the model column is hidden and fixed columns total 30.5rem, leaving insufficient room for a 35% title column. `col-actions` widened from 10rem to 11.5rem to accommodate the Share button.

## Test plan
- [ ] tsc: 0 errors, eslint: 0 warnings (via `npm run verify`)
- [ ] At ~961px (tablet band): list panel fills full container width, no horizontal scroll
- [ ] At ~1560px (desktop): no dead gap, ACTIONS (Share) fully visible, col-title capped at 35%
- [ ] At ~700px (phone-lg): no horizontal scroll, col-title auto-fits remaining space

Fixes t/2311

🤖 Generated with [Claude Code](https://claude.com/claude-code)