### PR TITLE
feat(flight-recorder): probe module-fetch HTTP status on dynamic-import failure (t/2314)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useEffect, useState, lazy, Suspense } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import './App.css';
 import { api } from '@bridge';
 import { nodePovFromId } from '@lib/debate/nodeIdUtils';
@@ -23,6 +23,7 @@ import { StartupProgressScreen } from './components/shared/StartupProgressScreen
 import { initClientConfig } from './lib/clientConfig';
 import { initFlightRecorder } from './lib/flightRecorderInit';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { recordingLazy } from './utils/recordingLazy';
 import { initAnalytics } from './lib/analyticsEmitter';
 import { useBreakpoint } from './hooks/useBreakpoint';
 import { useIsTouchDevice } from './hooks/useIsTouchDevice';
@@ -41,30 +42,30 @@ import { DiagnosticsDrawer } from './components/shared/DiagnosticsDrawer';
 import { GlobalDetailPaneHost } from './components/shared/GlobalDetailPaneHost';
 
 // Lazy-loaded tab components — only fetched when their tab is selected
-const SituationsTab = lazy(() => import('./components/debate/SituationsTab').then(m => ({ default: m.SituationsTab })));
-const ConflictsTab = lazy(() => import('./components/conflict/ConflictsTab').then(m => ({ default: m.ConflictsTab })));
-const DebateTab = lazy(() => import('./components/debate/DebateTab').then(m => ({ default: m.DebateTab })));
-const ChatTab = lazy(() => import('./components/chat/ChatTab').then(m => ({ default: m.ChatTab })));
-const SummariesTab = lazy(() => import('./components/analysis/SummariesTab').then(m => ({ default: m.SummariesTab })));
-const CruxesTab = lazy(() => import('./components/debate/CruxesTab').then(m => ({ default: m.CruxesTab })));
-const ValidationTab = lazy(() => import('./components/taxonomy/ValidationTab').then(m => ({ default: m.ValidationTab })));
-const OrganizationsTab = lazy(() => import('./components/organizations/OrganizationsTab').then(m => ({ default: m.OrganizationsTab })));
+const SituationsTab = recordingLazy(() => import('./components/debate/SituationsTab').then(m => ({ default: m.SituationsTab })));
+const ConflictsTab = recordingLazy(() => import('./components/conflict/ConflictsTab').then(m => ({ default: m.ConflictsTab })));
+const DebateTab = recordingLazy(() => import('./components/debate/DebateTab').then(m => ({ default: m.DebateTab })));
+const ChatTab = recordingLazy(() => import('./components/chat/ChatTab').then(m => ({ default: m.ChatTab })));
+const SummariesTab = recordingLazy(() => import('./components/analysis/SummariesTab').then(m => ({ default: m.SummariesTab })));
+const CruxesTab = recordingLazy(() => import('./components/debate/CruxesTab').then(m => ({ default: m.CruxesTab })));
+const ValidationTab = recordingLazy(() => import('./components/taxonomy/ValidationTab').then(m => ({ default: m.ValidationTab })));
+const OrganizationsTab = recordingLazy(() => import('./components/organizations/OrganizationsTab').then(m => ({ default: m.OrganizationsTab })));
 
 // Lazy-loaded window/panel components — separate Electron windows or hash routes
-const DiagnosticsWindow = lazy(() => import('./components/debate-diagnostics').then(m => ({ default: m.DiagnosticsWindow })));
-const PovProgressionWindow = lazy(() => import('./components/PovProgression/PovProgressionWindow').then(m => ({ default: m.PovProgressionWindow })));
-const DebatePopoutWindow = lazy(() => import('./components/debate/DebatePopoutWindow').then(m => ({ default: m.DebatePopoutWindow })));
-const ChatWindow = lazy(() => import('./components/chat/ChatWindow').then(m => ({ default: m.ChatWindow })));
-const PromptDiffWindow = lazy(() => import('./components/chat/PromptDiffWindow').then(m => ({ default: m.PromptDiffWindow })));
-const DiffWindow = lazy(() => import('./components/shared/DiffWindow').then(m => ({ default: m.DiffWindow })));
-const HarvestDialog = lazy(() => import('./components/shared/HarvestDialog').then(m => ({ default: m.HarvestDialog })));
-const AnalyticsDashboard = lazy(() => import('./components/analysis/AnalyticsDashboard').then(m => ({ default: m.AnalyticsDashboard })));
-const CommunityLibrary = lazy(() => import('./components/community/CommunityLibrary').then(m => ({ default: m.CommunityLibrary })));
-const AdminPanel = lazy(() => import('./components/settings/AdminPanel').then(m => ({ default: m.AdminPanel })));
-const AdminReviewPanel = lazy(() => import('./components/settings/AdminReviewPanel').then(m => ({ default: m.AdminReviewPanel })));
+const DiagnosticsWindow = recordingLazy(() => import('./components/debate-diagnostics').then(m => ({ default: m.DiagnosticsWindow })));
+const PovProgressionWindow = recordingLazy(() => import('./components/PovProgression/PovProgressionWindow').then(m => ({ default: m.PovProgressionWindow })));
+const DebatePopoutWindow = recordingLazy(() => import('./components/debate/DebatePopoutWindow').then(m => ({ default: m.DebatePopoutWindow })));
+const ChatWindow = recordingLazy(() => import('./components/chat/ChatWindow').then(m => ({ default: m.ChatWindow })));
+const PromptDiffWindow = recordingLazy(() => import('./components/chat/PromptDiffWindow').then(m => ({ default: m.PromptDiffWindow })));
+const DiffWindow = recordingLazy(() => import('./components/shared/DiffWindow').then(m => ({ default: m.DiffWindow })));
+const HarvestDialog = recordingLazy(() => import('./components/shared/HarvestDialog').then(m => ({ default: m.HarvestDialog })));
+const AnalyticsDashboard = recordingLazy(() => import('./components/analysis/AnalyticsDashboard').then(m => ({ default: m.AnalyticsDashboard })));
+const CommunityLibrary = recordingLazy(() => import('./components/community/CommunityLibrary').then(m => ({ default: m.CommunityLibrary })));
+const AdminPanel = recordingLazy(() => import('./components/settings/AdminPanel').then(m => ({ default: m.AdminPanel })));
+const AdminReviewPanel = recordingLazy(() => import('./components/settings/AdminReviewPanel').then(m => ({ default: m.AdminReviewPanel })));
 
 const UpdatePrompt = import.meta.env.VITE_TARGET === 'web'
-  ? lazy(() => import('./components/shared/UpdatePrompt').then(m => ({ default: m.UpdatePrompt })))
+  ? recordingLazy(() => import('./components/shared/UpdatePrompt').then(m => ({ default: m.UpdatePrompt })))
   : null;
 
 const THEME_COLORS: Record<string, string> = {

--- a/taxonomy-editor/src/renderer/utils/recordingLazy.test.ts
+++ b/taxonomy-editor/src/renderer/utils/recordingLazy.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const recordSpy = vi.fn();
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: recordSpy }),
+}));
+
+import { probeModule, recordModuleFetchFailure } from './recordingLazy';
+
+const URL = 'http://127.0.0.1:5173/src/renderer/components/debate/DebateTab.tsx';
+
+function mockFetchOnce(impl: () => Promise<Response> | Response) {
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(impl())));
+}
+
+beforeEach(() => {
+  recordSpy.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('probeModule — t/2314 disambiguation', () => {
+  it('maps a 200 response to a clean status (stale-chunk cold-cache reload signal)', async () => {
+    mockFetchOnce(() => ({ ok: true, status: 200, text: async () => '' }) as unknown as Response);
+    const probe = await probeModule(URL);
+    expect(probe).toEqual({ status: 200, body: null, error: null });
+  });
+
+  it('captures the body of a 500 response (Vite compile-error signal)', async () => {
+    const compileError = 'Transform failed with 1 error: Unexpected token';
+    mockFetchOnce(() => ({ ok: false, status: 500, text: async () => compileError }) as unknown as Response);
+    const probe = await probeModule(URL);
+    expect(probe.status).toBe(500);
+    expect(probe.body).toBe(compileError);
+    expect(probe.error).toBeNull();
+  });
+
+  it('truncates a large error body to 500 chars', async () => {
+    mockFetchOnce(() => ({ ok: false, status: 500, text: async () => 'x'.repeat(2000) }) as unknown as Response);
+    const probe = await probeModule(URL);
+    expect(probe.body).toHaveLength(500);
+  });
+
+  it('maps a fetch rejection to error (crashed / unreachable server signal)', async () => {
+    mockFetchOnce(() => Promise.reject(new Error('Failed to fetch')));
+    const probe = await probeModule(URL);
+    expect(probe).toEqual({ status: null, body: null, error: 'Failed to fetch' });
+  });
+});
+
+describe('recordModuleFetchFailure', () => {
+  it('records a system.error with the module URL parsed from the rejection message', async () => {
+    await recordModuleFetchFailure(new TypeError(`Failed to fetch dynamically imported module: ${URL}`));
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+    const event = recordSpy.mock.calls[0][0];
+    expect(event).toMatchObject({
+      type: 'system.error',
+      component: 'module-loader',
+      level: 'error',
+      message: `Dynamic import failed: ${URL}`,
+    });
+    expect(event.data.module_url).toBe(URL);
+    expect(event.error).toMatchObject({ name: 'TypeError' });
+  });
+
+  it('records a null module_url when the message carries no URL', async () => {
+    await recordModuleFetchFailure(new Error('some unrelated failure'));
+    const event = recordSpy.mock.calls[0][0];
+    expect(event.message).toBe('Dynamic import failed');
+    expect(event.data.module_url).toBeNull();
+  });
+
+  it('handles a non-Error rejection value', async () => {
+    await recordModuleFetchFailure('boom');
+    const event = recordSpy.mock.calls[0][0];
+    expect(event.error).toMatchObject({ name: 'Error', message: 'boom' });
+  });
+});

--- a/taxonomy-editor/src/renderer/utils/recordingLazy.ts
+++ b/taxonomy-editor/src/renderer/utils/recordingLazy.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+
+// Chrome/Vite reject a failed dynamic import with a TypeError whose message embeds the
+// resolved module URL, e.g.:
+//   "Failed to fetch dynamically imported module: http://127.0.0.1:5173/src/renderer/components/debate/DebateTab.tsx"
+const MODULE_FETCH_ERROR_RE = /Failed to fetch dynamically imported module:?\s*(\S+)/i;
+
+// Cap the dev-only probe so an unreachable server can't stall the ErrorBoundary fallback.
+const PROBE_TIMEOUT_MS = 3000;
+
+interface ModuleProbe {
+  status: number | null; // HTTP status if the dev server answered
+  body: string | null;   // first 500 chars of a non-2xx body (e.g. a Vite compile error)
+  error: string | null;  // set when the fetch itself failed (connection refused ⇒ crashed server)
+}
+
+/**
+ * Dev-only: re-fetch the failed module URL to recover the server-side signal the bare
+ * import() rejection hides. Without it, a 500 compile error, a crashed/unreachable
+ * server, and a stale-chunk cold-cache reload all surface as the same browser error
+ * ("Failed to fetch dynamically imported module"), making triage impossible (t/2314,
+ * discovered during t/2313). The probe disambiguates them:
+ *   • 500 + body   ⇒ Vite compile/transform error (body carries the message)
+ *   • fetch error  ⇒ dev server crashed or unreachable
+ *   • 200          ⇒ module now serves fine ⇒ transient cold-cache full-reload
+ */
+// Exported for unit testing the 500 / fetch-error / 200 mapping; not part of the public API.
+export function probeModule(url: string): Promise<ModuleProbe> {
+  // Bare fetch is intentional here (cf. taxonomy-editor/AGENTS.md § Client Network
+  // Resilience). This is NOT a shipped network call: the sole caller gates it on
+  // `import.meta.hot`, so the whole branch is tree-shaken out of production bundles —
+  // it never routes user traffic and thus is outside the web-bridge mandate. It is a
+  // one-shot, no-retry, no-store status probe of an arbitrary Vite dev-server module
+  // URL; the bridge's /api retry + circuit-breaker semantics would mask the very status
+  // we are trying to read. The 3s AbortSignal timeout keeps a hung/unreachable server
+  // from stalling the ErrorBoundary fallback (the caller awaits this probe before
+  // re-throwing).
+  return fetch(url, { cache: 'no-store', signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) })
+    .then(async (res): Promise<ModuleProbe> => ({
+      status: res.status,
+      body: res.ok ? null : (await res.text()).slice(0, 500),
+      error: null,
+    }))
+    .catch((err: unknown): ModuleProbe => ({
+      status: null,
+      body: null,
+      error: err instanceof Error ? err.message : String(err),
+    }));
+}
+
+// Exported for unit testing the t/2314 disambiguation logic; not part of the public API.
+export async function recordModuleFetchFailure(err: unknown): Promise<void> {
+  const name = err instanceof Error ? err.name : 'Error';
+  const message = err instanceof Error ? err.message : String(err);
+  const stack = err instanceof Error ? err.stack : undefined;
+  const moduleUrl = MODULE_FETCH_ERROR_RE.exec(message)?.[1] ?? null;
+
+  // Probe only in dev (import.meta.hot present) — the whole branch is tree-shaken out of
+  // production builds, where there is no dev server to interrogate.
+  const probe: ModuleProbe = moduleUrl && import.meta.hot
+    ? await probeModule(moduleUrl)
+    : { status: null, body: null, error: null };
+
+  getGlobalRecorder()?.record({
+    type: 'system.error',
+    component: 'module-loader',
+    level: 'error',
+    message: moduleUrl ? `Dynamic import failed: ${moduleUrl}` : 'Dynamic import failed',
+    error: { name, message, stack },
+    data: {
+      module_url: moduleUrl,
+      http_status: probe.status,
+      probe_error: probe.error,
+      body_snippet: probe.body,
+    },
+  });
+}
+
+/**
+ * Drop-in replacement for React.lazy that records dynamic-import failures — with a
+ * dev-only HTTP-status probe of the module URL — before re-throwing, so Suspense /
+ * ErrorBoundary behaviour is unchanged. Use for every lazily-loaded tab/window so a
+ * "Failed to fetch dynamically imported module" leaves a self-diagnosing flight-recorder
+ * entry instead of an ambiguous browser error (t/2314).
+ */
+// `any` mirrors React.lazy's own generic constraint (ComponentType<any>); the project's
+// eslint base config does not enable no-explicit-any, so no disable directive is needed.
+export function recordingLazy<T extends ComponentType<any>>(
+  loader: () => Promise<{ default: T }>,
+): LazyExoticComponent<T> {
+  return lazy(() =>
+    loader().catch(async (err: unknown): Promise<{ default: T }> => {
+      await recordModuleFetchFailure(err);
+      throw err;
+    }),
+  );
+}


### PR DESCRIPTION
## What & why (t/2314)

During t/2313, a fatal `Failed to fetch dynamically imported module: DebateTab.tsx` gave triage no way to tell three failure modes apart — the flight recorder captured the browser-side rejection but never the Vite dev-server response. A 500 (compile error), a refused connection (crashed server), and a stale chunk that reloads (200) all produce the identical browser error.

## Change

- **New `src/renderer/utils/recordingLazy.ts`** — a drop-in `React.lazy` replacement. On `import()` rejection it records a `system.error` (`component: module-loader`) to the flight recorder and, **in dev only** (`import.meta.hot`-gated → tree-shaken from production bundles), re-fetches the module URL to capture the disambiguating HTTP status:
  - `500 + body` ⇒ Vite compile/transform error (body carries the message)
  - fetch error ⇒ crashed / unreachable server
  - `200` ⇒ module now serves fine ⇒ stale-chunk cold-cache reload
  - URL parsed from the rejection message; probe is one-shot, `no-store`, **3s `AbortSignal` timeout** so a hung server can't stall the ErrorBoundary fallback.
- **`App.tsx`** — convert all 20 `lazy(...)` tab/window call sites to `recordingLazy(...)`.
- **`recordingLazy.test.ts`** — 7 unit tests covering the 500 / fetch-error / 200 / truncation mapping and the record-event shape.

## Notes for review

- The probe's bare `fetch` is intentional and dev-only: gated on `import.meta.hot`, so it is **not shipped** and is outside the web-bridge mandate (which governs production `/api` traffic). Rationale is documented in-source; not added to the prod bare-fetch exception registry precisely because it never routes user traffic.
- No try/catch (ADR-003): failure recording flows through promise `.catch`; nothing is silently swallowed.

## Verification (worktree, pnpm)

renderer tsc 0 errors · eslint 0 errors (only pre-existing App.tsx warnings) · depcruise clean · vite build ✓ · `recordingLazy.test.ts` 7/7 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)