### PR TITLE
fix(taxonomy): hide raw node ID from POV list rows (t/2317)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeTree.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeTree.test.tsx
@@ -171,10 +171,14 @@ describe('NodeTree', () => {
     expect(screen.getByText(/Safety beliefs/)).toBeDefined();
   });
 
-  it('displays node IDs alongside labels', () => {
+  it('shows labels but hides raw node IDs in list rows (t/2317)', () => {
     render(<NodeTree nodes={NODES} selectedNodeId={null} onSelect={vi.fn()} />);
-    expect(screen.getByText('acc-B-001')).toBeDefined();
-    expect(screen.getByText('acc-D-001')).toBeDefined();
+    // Human-readable labels are shown...
+    expect(screen.getByText('Open dev is safe')).toBeDefined();
+    expect(screen.getByText('Maximize progress')).toBeDefined();
+    // ...but the raw node IDs are no longer rendered for end users.
+    expect(screen.queryByText('acc-B-001')).toBeNull();
+    expect(screen.queryByText('acc-D-001')).toBeNull();
   });
 });
 

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeTree.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeTree.tsx
@@ -478,18 +478,27 @@ function NodeItem({ node, isSelected, onSelect, score, indent, relationship, isM
       {node.graph_attributes?.aphorism && (
         <div className="node-item-aphorism">{node.graph_attributes.aphorism}</div>
       )}
-      <div className="node-item-id">
-        {node.id}
-        {relationship && <span className="node-item-rel">{REL_LABELS[relationship] || relationship}</span>}
-        {score !== undefined && <span className="node-item-score">{Math.round(score * 100)}%</span>}
-        {priorityValue && <span className="node-item-priority">{priorityValue.label}</span>}
-        {/* Beliefs always show the chip (legacy: "Untested" when no record); Desire/Intention
-            nodes show it only once they carry a debate_tested record — see t/1661. Situations
-            never reach NodeItem (node is PovNode), so BDI-only gating is implicit. */}
-        {showDebateTestedChip && (node.category === 'Beliefs' || !!node.graph_attributes?.debate_tested) && (
-          <DebateTestedChip record={node.graph_attributes?.debate_tested} description={node.description} compact />
-        )}
-      </div>
+      {/* Raw node.id removed from end-user view per t/2317. Class name kept ('node-item-id')
+          to reuse existing styles.css layout; the row now carries only relationship + metric
+          chips. Guarded so it never renders an empty line in sort modes with no metadata. */}
+      {(() => {
+        // Beliefs always show the chip (legacy: "Untested" when no record); Desire/Intention
+        // nodes show it only once they carry a debate_tested record — see t/1661. Situations
+        // never reach NodeItem (node is PovNode), so BDI-only gating is implicit.
+        const showChip = showDebateTestedChip && (node.category === 'Beliefs' || !!node.graph_attributes?.debate_tested);
+        const hasMeta = !!relationship || score !== undefined || !!priorityValue || showChip;
+        if (!hasMeta) return null;
+        return (
+          <div className="node-item-id">
+            {relationship && <span className="node-item-rel">{REL_LABELS[relationship] || relationship}</span>}
+            {score !== undefined && <span className="node-item-score">{Math.round(score * 100)}%</span>}
+            {priorityValue && <span className="node-item-priority">{priorityValue.label}</span>}
+            {showChip && (
+              <DebateTestedChip record={node.graph_attributes?.debate_tested} description={node.description} compact />
+            )}
+          </div>
+        );
+      })()}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Hides the raw node ID line (e.g. `acc-desires-007 is a …`) from POV list rows per t/2317 — the user wants it hidden from end users.

- `NodeItem` (`NodeTree.tsx`) no longer renders `{node.id}`.
- The `.node-item-id` container is now guarded (`hasMeta`) so it never renders an empty line in sort modes with no metadata.
- **Preserved** (per TL caveat): relationship label, similarity `%`, priority P-value, and the Debate-Tested chip (t/1585/t/1661).
- Reuses existing `styles.css` layout — no new selectors (styles.css frozen); class name `node-item-id` retained.

## Judgment call
Kept the **relationship phrase** ("is a" / "part of" / "specializes") — it's a hierarchy edge descriptor shown only on child rows, not a raw token like the ID. Acceptance criteria only mandated removing `{node.id}`. Easy to also drop if the user prefers.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (0 errors; pre-existing complexity warning untouched)
- [ ] Live verify across sort modes: id / label / similarity / priority / debate_tested — no empty line, chips intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>