### PR TITLE
feat(models): add Claude Opus 5 + Sonnet 5 to registry and discovery (t/2321)

### DIFF
--- a/ai-models.json
+++ b/ai-models.json
@@ -95,6 +95,18 @@
       "backend": "gemini"
     },
     {
+      "id": "claude-opus-5",
+      "apiModelId": "claude-opus-5",
+      "label": "Opus 5 (alias)",
+      "backend": "claude"
+    },
+    {
+      "id": "claude-sonnet-5",
+      "apiModelId": "claude-sonnet-5",
+      "label": "Sonnet 5 (alias)",
+      "backend": "claude"
+    },
+    {
       "id": "claude-opus-4-8",
       "apiModelId": "claude-opus-4-8",
       "label": "Opus 4.8 (alias)",
@@ -738,6 +750,14 @@
       "gemini-3.1-pro-preview",
       "gemini-3.6-flash"
     ],
+    "claude-opus-5": [
+      "claude-sonnet-4-6",
+      "gemini-3.1-pro-preview"
+    ],
+    "claude-sonnet-5": [
+      "claude-haiku-4-5",
+      "gemini-3.6-flash"
+    ],
     "claude-opus-4-8": [
       "claude-sonnet-4-6",
       "gemini-3.1-pro-preview"
@@ -1010,6 +1030,16 @@
       "inputPer1M": 0.1,
       "outputPer1M": 0.4,
       "cachedInputPer1M": 0.025
+    },
+    "claude-opus-5": {
+      "inputPer1M": 5,
+      "outputPer1M": 25,
+      "cachedInputPer1M": 0.5
+    },
+    "claude-sonnet-5": {
+      "inputPer1M": 3,
+      "outputPer1M": 15,
+      "cachedInputPer1M": 0.3
     },
     "claude-opus-4-8": {
       "inputPer1M": 5,

--- a/lib/electron-shared/modelDiscovery.ts
+++ b/lib/electron-shared/modelDiscovery.ts
@@ -187,6 +187,8 @@ export async function discoverGroqModels(apiKey: string): Promise<ModelEntry[]> 
 // ── Anthropic: probe candidate model IDs ───────────────────────────────────────
 
 const CLAUDE_CANDIDATES: { apiModelId: string; label: string }[] = [
+  { apiModelId: 'claude-opus-5',                  label: 'Opus 5 (alias)' },
+  { apiModelId: 'claude-sonnet-5',                label: 'Sonnet 5 (alias)' },
   { apiModelId: 'claude-opus-4-8',                label: 'Opus 4.8 (alias)' },
   { apiModelId: 'claude-fable-5',                 label: 'Fable 5 (alias)' },
   { apiModelId: 'claude-opus-4-6-20250514',       label: 'Opus 4.6' },


### PR DESCRIPTION
## Summary
- Add `claude-opus-5` and `claude-sonnet-5` to `CLAUDE_CANDIDATES` in `modelDiscovery.ts` so Refresh probes and retains them
- Add both to `ai-models.json`: `models[]`, `fallbackChains`, and `pricing` sections
- Backend `claude` already exists — no backend-keyed sites changed

## Self-cert
/add-ai-backend §1 (model-keyed config sections only; backend already registered)

## Verify
`verify:config` green — all 6 registry gates pass (Pester ×2 + vitest ×4).

## Test plan
- [ ] Opus 5 and Sonnet 5 appear in debate Custom-model dropdown under both Basic and Frontier tiers
- [ ] After "Refresh models" both persist (not pruned)
- [ ] `npm run verify:config` green

Closes t/2321. Relates to t/2322 (live-catalog follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)