### PR TITLE
fix(debate-workspace): display-tier control binding (t/2318) + turn-timer stamp (t/2319)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -391,8 +391,8 @@ const GLOBAL_TIER_TITLES: Record<string, string> = {
 const GLOBAL_MODE_IDS = [{ id: 'text', label: 'Text' }, { id: 'analysis', label: 'Analysis' }] as const;
 
 function GlobalModeControl({ defaultTier, setDefaultTier }: {
-  defaultTier: DWStore['responseLength'];
-  setDefaultTier: DWStore['setResponseLength'];
+  defaultTier: DWStore['defaultDisplayTier'];
+  setDefaultTier: DWStore['setDefaultDisplayTier'];
 }) {
   const activeMode = META_TIERS.has(defaultTier) ? 'analysis' : 'text';
   const [lastText, setLastText] = useState<GlobalTextTier>(
@@ -486,8 +486,8 @@ function DebateToolbar({
   onExport?: (format: string) => void;
   diagnosticsEnabled: boolean;
   toggleDiagnostics: () => void;
-  defaultTier: DWStore['responseLength'];
-  setDefaultTier: DWStore['setResponseLength'];
+  defaultTier: DWStore['defaultDisplayTier'];
+  setDefaultTier: DWStore['setDefaultDisplayTier'];
   // When true, renders as the action cluster inside the redesigned header's Band 1
   // (t/2293): the standalone title span is dropped (the header h2 carries the topic)
   // and the frozen `.debate-toolbar` bar chrome is neutralized via `.debate-hdr-actions`.
@@ -1143,7 +1143,7 @@ function computeSelectionAnchor(
   selection: Selection,
   entry: ActiveTranscriptEntry,
   selectedText: string,
-  defaultTier: DWStore['responseLength'],
+  defaultTier: DWStore['defaultDisplayTier'],
 ): { startOffset: number; endOffset: number; tier: DetailTier } {
   const isSub = ['opening', 'statement', 'fact-check', 'cross_respond'].includes(entry.type);
   const tier: DetailTier = isSub ? ((entry as any).display_tier ?? defaultTier ?? 'detailed') : 'detailed';
@@ -1165,7 +1165,7 @@ function computeSelectionAnchor(
   return { startOffset, endOffset, tier };
 }
 
-function useDebateSelectionMenu(activeDebate: DWStore['activeDebate'], defaultTier: DWStore['responseLength']) {
+function useDebateSelectionMenu(activeDebate: DWStore['activeDebate'], defaultTier: DWStore['defaultDisplayTier']) {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [commentPopover, setCommentPopover] = useState<CommentPopoverState | null>(null);
 
@@ -1226,7 +1226,10 @@ export function DebateWorkspace({ onExport, exportStatus }: {
       runClarification: s.runClarification, runOpeningStatements: s.runOpeningStatements, saveDebate: s.saveDebate, compressOldTranscript: s.compressOldTranscript,
       diagnosticsEnabled: s.diagnosticsEnabled, toggleDiagnostics: s.toggleDiagnostics, selectedDiagEntry: s.selectedDiagEntry, selectDiagEntry: s.selectDiagEntry,
       diagPopoutOpen: s.diagPopoutOpen, setDiagPopoutOpen: s.setDiagPopoutOpen,
-      defaultTier: s.responseLength, setDefaultTier: s.setResponseLength,
+      // Header Text/Analysis control + statement display fallback bind to the
+      // display tier (defaultDisplayTier, default Medium), NOT responseLength
+      // (generation verbosity, default Detailed) — t/2318.
+      defaultTier: s.defaultDisplayTier, setDefaultTier: s.setDefaultDisplayTier,
       driverIsRemote: s.driverIsRemote,
       selectedRef: s.selectedRef, setSelectedRef: s.setSelectedRef,
       explorationSummary: s.explorationSummary,

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
@@ -224,6 +224,33 @@ describe('Config slice: getConfiguredModel behavior', () => {
     expect(useDebateStore.getState().responseLength).toBe('claims');
   });
 
+  it('setDefaultDisplayTier sets the display default and clears overrides without touching responseLength (t/2318)', () => {
+    const session = makeSession({
+      transcript: [
+        { id: 'e1', timestamp: 't', type: 'statement', speaker: 'accelerationist', content: 'X', taxonomy_refs: [], display_tier: 'brief' },
+      ],
+    });
+    useDebateStore.setState({ activeDebate: session as any, defaultDisplayTier: 'detailed', responseLength: 'detailed' });
+
+    useDebateStore.getState().setDefaultDisplayTier('medium');
+
+    expect(useDebateStore.getState().defaultDisplayTier).toBe('medium');
+    // The header control targets the display tier only — generation verbosity is untouched.
+    expect(useDebateStore.getState().responseLength).toBe('detailed');
+    expect(useDebateStore.getState().activeDebate!.transcript[0].display_tier).toBeUndefined();
+  });
+
+  it('stamps debateStepStartedAt when a production generation action starts, not only setGenerating (t/2319)', async () => {
+    useDebateStore.setState({ activeDebate: makeSession() as any, debateStepStartedAt: null });
+    mockApi.generateText.mockResolvedValue({ text: '{"questions":["Q1"]}' });
+
+    await useDebateStore.getState().runClarification();
+
+    // runClarification sets debateGenerating at step start; the fix stamps the step
+    // timer there so StatementProgressIndicator counts up instead of sticking at 0:00.
+    expect(useDebateStore.getState().debateStepStartedAt).not.toBeNull();
+  });
+
   // t/2269 (TL Option 2): the debate-step view default is Medium, but that must NOT
   // shorten generation. defaultDisplayTier (view fallback) and responseLength
   // (generation verbosity) are independent store fields — guard against re-coupling.

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -246,7 +246,7 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
     const model = getConfiguredModel();
     const topic = activeDebate.topic.final;
 
-    set({ debateGenerating: 'system' as SpeakerId });
+    set({ debateGenerating: 'system' as SpeakerId, debateStepStartedAt: Date.now() });
     const lineageCtx = buildLineageContext();
     const prompt = activeDebate.source_type === 'situations'
       ? situationClarificationPrompt(topic, activeDebate.source_content, activeDebate.audience, lineageCtx)
@@ -601,7 +601,7 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
     // Runs here so it executes whether the user submitted answers or skipped clarification
     if (activeDebate && !activeDebate.document_analysis &&
         (activeDebate.source_type === 'document' || activeDebate.source_type === 'url')) {
-      set({ debateGenerating: 'system' as SpeakerId });
+      set({ debateGenerating: 'system' as SpeakerId, debateStepStartedAt: Date.now() });
       const model = getConfiguredModel();
       newAbortController();
       const isStillValid = createDebateGuard(get);
@@ -901,7 +901,7 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         continue;
       }
 
-      set({ debateGenerating: poverId });
+      set({ debateGenerating: poverId, debateStepStartedAt: Date.now() });
       const info = POVER_INFO[poverId];
 
       try {

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/configSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/configSlice.ts
@@ -81,6 +81,7 @@ export interface ConfigSlice {
 
   // Actions
   setResponseLength: (length: 'claims' | 'brief' | 'medium' | 'detailed' | 'reasoning' | 'convergence') => void;
+  setDefaultDisplayTier: (tier: 'claims' | 'brief' | 'medium' | 'detailed' | 'reasoning' | 'convergence') => void;
   setAudience: (audience: DebateAudience) => void;
   setEntryDisplayTier: (entryId: string, tier: 'claims' | 'brief' | 'medium' | 'detailed' | 'reasoning' | 'convergence' | 'terms' | 'lineage' | undefined) => void;
   setOpeningOrder: (order: Exclude<SpeakerId, 'user'>[]) => void;
@@ -135,6 +136,24 @@ export const createConfigSlice: StateCreator<DebateStore, [], [], ConfigSlice> =
 
   setResponseLength: (length) => {
     set({ responseLength: length });
+    const debate = get().activeDebate;
+    if (debate) {
+      let changed = false;
+      for (const entry of debate.transcript) {
+        if (entry.display_tier) {
+          entry.display_tier = undefined;
+          changed = true;
+        }
+      }
+      if (changed) set({ activeDebate: { ...debate } });
+    }
+  },
+  // Sets the default *display* tier for statements (the header Text/Analysis control,
+  // t/2269) — distinct from responseLength (generation verbosity). Clears per-entry
+  // display_tier overrides so every statement snaps to the new default, mirroring
+  // setResponseLength. StatementCard renders `entry.display_tier ?? defaultDisplayTier`.
+  setDefaultDisplayTier: (tier) => {
+    set({ defaultDisplayTier: tier });
     const debate = get().activeDebate;
     if (debate) {
       let changed = false;

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateLoopSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateLoopSlice.ts
@@ -144,7 +144,7 @@ export const createDebateLoopSlice: StateCreator<DebateStore, [], [], DebateLoop
 
     // Generate responses sequentially so each sees prior responses
     for (const poverId of respondingPovers) {
-      set({ debateGenerating: poverId });
+      set({ debateGenerating: poverId, debateStepStartedAt: Date.now() });
 
       const info = POVER_INFO[poverId];
       const currentTranscriptForRelevance = formatRecentTranscript(get().activeDebate!.transcript, 4, get().activeDebate!.context_summaries);

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
@@ -142,7 +142,7 @@ export const createDebatePhaseSlice: StateCreator<DebateStore, [], [], DebatePha
     if (await runPostTerminationTurn(activeDebate, aiPovers, topic, model, get, set, isStillValid, addTranscriptEntry, saveDebate)) return;
 
     // Step 1: Active moderator — delegate to shared orchestration
-    set({ debateGenerating: 'system' as SpeakerId, debateActivity: 'Moderator selection...' });
+    set({ debateGenerating: 'system' as SpeakerId, debateActivity: 'Moderator selection...', debateStepStartedAt: Date.now() });
 
     const { crossRespondRound, phase, totalRoundsForPhase } = computeRoundAndPhase(activeDebate, aiPovers, get, set);
 
@@ -1123,7 +1123,7 @@ async function runPostTerminationTurn(activeDebate: DebateSession, aiPovers: _Ai
   const phase = 'concluding';
   const focusPoint = 'Give your final statement on this debate.';
   const addressingLabel = 'all';
-  set({ debateGenerating: responderPover, debateActivity: `${POVER_INFO[responderPover].label} is preparing...` });
+  set({ debateGenerating: responderPover, debateActivity: `${POVER_INFO[responderPover].label} is preparing...`, debateStepStartedAt: Date.now() });
 
   const info = POVER_INFO[responderPover];
   const currentTranscript = formatRecentTranscript(get().activeDebate!.transcript, 8, get().activeDebate!.context_summaries);
@@ -1167,7 +1167,7 @@ async function runPostTerminationTurn(activeDebate: DebateSession, aiPovers: _Ai
 
 async function buildTurnPipelineContext(responderPover: _ModResult['responder'], activeDebate: DebateSession, topic: string, model: string, intervention: _ModResult['intervention'], interventionBriefInjection: _ModResult['interventionBriefInjection'], focusPoint: _ModResult['focusPoint'], addressingLabel: _ModResult['addressing'], phase: DebatePhase, get: _Get, set: _Set) {
     // Step 2: Generate the cross-response
-    set({ debateGenerating: responderPover, debateActivity: `${POVER_INFO[responderPover].label} is preparing...` });
+    set({ debateGenerating: responderPover, debateActivity: `${POVER_INFO[responderPover].label} is preparing...`, debateStepStartedAt: Date.now() });
 
     const info = POVER_INFO[responderPover];
     const currentTranscript = formatRecentTranscript(get().activeDebate!.transcript, 8, get().activeDebate!.context_summaries);

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
@@ -619,7 +619,7 @@ export const createDebateReflectionSlice: StateCreator<DebateStore, [], [], Deba
       const info = POVER_INFO[pover];
       if (!info) continue;
 
-      set({ debateGenerating: pover as SpeakerId });
+      set({ debateGenerating: pover as SpeakerId, debateStepStartedAt: Date.now() });
 
       const taxState = useTaxonomyStore.getState();
       const povKey = info.pov as 'accelerationist' | 'safetyist' | 'skeptic';

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -606,7 +606,7 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
             // leaving Continue live long enough for a click to double-fire the
             // resumed round (t/1656). crossRespond owns the flag from here and
             // clears it on completion/error.
-            set({ debateGenerating: resumeSpeaker, debateActivity: `${speakerLabel} is resuming…` });
+            set({ debateGenerating: resumeSpeaker, debateActivity: `${speakerLabel} is resuming…`, debateStepStartedAt: Date.now() });
             void s.crossRespond().finally(() => {
               // Safety net: if crossRespond bailed before taking ownership of the
               // indicator (no activeDebate, driver-claim denied, <2 debaters), our


### PR DESCRIPTION
Two DebateUI-reported bugs (e/74 → t/2318, e/75 → t/2319), both in DebateWorkspace + useDebateStore scope. Combined here since they're cohesive debate-control fixes sharing one live-verify pass; happy to split if preferred.

## t/2318 — header Text/Analysis control changed AI verbosity, not display tier
`GlobalModeControl` was fed `defaultTier: s.responseLength` (generation verbosity, default **Detailed**) instead of the display tier (default **Medium**). In `DebateWorkspace` `defaultTier` is used **only** for display — the control, the `entry.display_tier ?? defaultTier` fallback, and the selection menu — never for generation, so it was wholly mis-bound. Fixed the single source at `DebateWorkspace.tsx:1229` → `defaultDisplayTier`/`setDefaultDisplayTier`, which corrects the control **and** the statement display default together.

**Deviation from the email:** the prescribed `setDefaultDisplayTier` setter **did not exist** — added it to `configSlice` (mirrors `setResponseLength`, clears per-entry overrides).

## t/2319 — turn timer stuck at 0:00
`StatementProgressIndicator` counts only while `debateStepStartedAt !== null`, but that step timer is only ever stamped by `setGenerating` — which **production never calls**; it sets `debateGenerating` raw at **9 sites across 5 slices**, never stamping the timer. Stamped `debateStepStartedAt: Date.now()` at each generation start-site.

**Verified** production sets `debateGenerating` exactly once per step, so a fresh per-step stamp gives a timer that starts at 0 each turn and doesn't reset mid-step (no t/2266 regression); nothing reads `debateGeneratingStartedAt`.

## Tests & gates
- New: `setDefaultDisplayTier` store test (t/2318); a production-action stamp test — `runClarification` now sets `debateStepStartedAt` (t/2319).
- renderer tsc 0, eslint 0 errors, depcruise clean, vite build ok, debate-workspace vitest **260/260**, store slices **68/68**.

Both require **live electron-mcp sign-off** (per TL p/357#36) before the tickets close — standing that up next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)