### PR TITLE
feat(model-discovery): replace Claude candidate probe with live /v1/models catalog (t/2322)

### DIFF
--- a/lib/electron-shared/modelDiscovery.test.ts
+++ b/lib/electron-shared/modelDiscovery.test.ts
@@ -9,7 +9,7 @@ vi.mock('fs', () => ({
   },
 }));
 
-import { curateGeminiModels, refreshAIModels } from './modelDiscovery.js';
+import { curateGeminiModels, curateClaudeModels, discoverClaudeModels, refreshAIModels } from './modelDiscovery.js';
 
 function model(name: string, displayName: string, methods = ['generateContent']) {
   return { name: `models/${name}`, displayName, supportedGenerationMethods: methods };
@@ -299,5 +299,123 @@ describe('refreshAIModels — repair + guard (t/2039)', () => {
     expect(result.configWarning).toContain('gpt-x');
     expect(result.configWarning).toContain('has no fallbackChain');
     expect(fileContent).toBe(original); // byte-for-byte untouched
+  });
+});
+
+// ── curateClaudeModels ─────────────────────────────────────────────────────────
+
+function claudeModel(id: string, display_name = '') {
+  return { id, display_name: display_name || id, type: 'model' };
+}
+
+describe('curateClaudeModels', () => {
+  it('filters to claude-* models only', () => {
+    const result = curateClaudeModels([
+      claudeModel('claude-sonnet-4-6', 'Claude Sonnet 4.6'),
+      claudeModel('gpt-4o', 'GPT-4o'),
+      claudeModel('gemini-2.5-flash', 'Gemini 2.5 Flash'),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].apiModelId).toBe('claude-sonnet-4-6');
+  });
+
+  it('strips 8-digit date suffix from friendlyId', () => {
+    const result = curateClaudeModels([
+      claudeModel('claude-sonnet-4-6-20250514', 'Claude Sonnet 4.6'),
+    ]);
+    expect(result[0].id).toBe('claude-sonnet-4-6');
+    expect(result[0].apiModelId).toBe('claude-sonnet-4-6-20250514');
+  });
+
+  it('applies claude-3-5 → claude-3.5 prefix transform', () => {
+    const result = curateClaudeModels([
+      claudeModel('claude-3-5-sonnet-20241022', 'Claude 3.5 Sonnet'),
+    ]);
+    expect(result[0].id).toBe('claude-3.5-sonnet');
+  });
+
+  it('deduplicates alias + dated variant, keeping longer apiModelId', () => {
+    const result = curateClaudeModels([
+      claudeModel('claude-sonnet-4-6', 'Sonnet 4.6 alias'),
+      claudeModel('claude-sonnet-4-6-20250514', 'Sonnet 4.6'),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].apiModelId).toBe('claude-sonnet-4-6-20250514');
+    expect(result[0].id).toBe('claude-sonnet-4-6');
+  });
+
+  it('excludes image/embed/tts/audio variants', () => {
+    const result = curateClaudeModels([
+      claudeModel('claude-image-gen-1'),
+      claudeModel('claude-embed-v1'),
+      claudeModel('claude-tts-1'),
+      claudeModel('claude-audio-v1'),
+      claudeModel('claude-sonnet-4-6', 'Claude Sonnet 4.6'),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].apiModelId).toBe('claude-sonnet-4-6');
+  });
+
+  it('sets backend to claude on all entries', () => {
+    const result = curateClaudeModels([
+      claudeModel('claude-sonnet-4-6', 'Claude Sonnet 4.6'),
+      claudeModel('claude-haiku-4-5-20251001', 'Claude Haiku 4.5'),
+    ]);
+    for (const m of result) {
+      expect(m.backend).toBe('claude');
+    }
+  });
+
+  it('uses display_name as label', () => {
+    const result = curateClaudeModels([claudeModel('claude-opus-4-8', 'Claude Opus 4.8')]);
+    expect(result[0].label).toBe('Claude Opus 4.8');
+  });
+
+  it('returns empty array when no models match', () => {
+    expect(curateClaudeModels([claudeModel('gpt-4'), claudeModel('gemini-2.5')])).toEqual([]);
+  });
+});
+
+// ── discoverClaudeModels: catalog path ────────────────────────────────────────
+
+describe('discoverClaudeModels — live catalog', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns curated models from /v1/models on success', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: 'claude-sonnet-4-6-20250514', display_name: 'Claude Sonnet 4.6', type: 'model' },
+          { id: 'claude-haiku-4-5-20251001',  display_name: 'Claude Haiku 4.5',  type: 'model' },
+        ],
+      }),
+    })));
+
+    const result = await discoverClaudeModels('test-key');
+    expect(result).toHaveLength(2);
+    expect(result.map(m => m.id).sort()).toEqual(['claude-haiku-4-5', 'claude-sonnet-4-6']);
+    expect(result.every(m => m.backend === 'claude')).toBe(true);
+  });
+
+  it('falls back to probe list on non-ok catalog response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if ((url as string).includes('/v1/models')) {
+        return { ok: false, status: 403, text: async () => 'forbidden' };
+      }
+      // probe calls also fail (no real network)
+      throw new Error('no network');
+    }));
+
+    const result = await discoverClaudeModels('test-key');
+    // Probe falls through with no valid models — result is empty (not an error).
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('falls back to probe list on catalog network error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network error'); }));
+
+    const result = await discoverClaudeModels('test-key');
+    expect(Array.isArray(result)).toBe(true);
   });
 });

--- a/lib/electron-shared/modelDiscovery.ts
+++ b/lib/electron-shared/modelDiscovery.ts
@@ -184,8 +184,46 @@ export async function discoverGroqModels(apiKey: string): Promise<ModelEntry[]> 
     });
 }
 
-// ── Anthropic: probe candidate model IDs ───────────────────────────────────────
+// ── Anthropic: live /v1/models catalog + candidate-probe fallback ──────────────
 
+interface AnthropicModelInfo {
+  id: string;
+  display_name: string;
+  type: string;
+}
+
+const CLAUDE_EXCLUDE_RE = /image|embed|tts|audio/i;
+
+function claudeFriendlyId(apiModelId: string): string {
+  return apiModelId
+    .replace(/-\d{8}$/, '')
+    .replace(/^claude-3-5-/, 'claude-3.5-');
+}
+
+export function curateClaudeModels(rawModels: AnthropicModelInfo[]): ModelEntry[] {
+  const entries = rawModels
+    .filter(m => m.id.startsWith('claude-'))
+    .filter(m => !CLAUDE_EXCLUDE_RE.test(m.id))
+    .map(m => ({
+      id: claudeFriendlyId(m.id),
+      apiModelId: m.id,
+      label: m.display_name || m.id,
+      backend: 'claude',
+    }));
+
+  // Dedup: two IDs that share a friendlyId (e.g. alias + dated version) → keep
+  // the longer apiModelId (dated/specific wins over the alias).
+  const seen = new Map<string, ModelEntry>();
+  for (const m of entries) {
+    const existing = seen.get(m.id);
+    if (!existing || m.apiModelId.length > existing.apiModelId.length) {
+      seen.set(m.id, m);
+    }
+  }
+  return [...seen.values()];
+}
+
+// Probe list: fallback when the live catalog is unreachable.
 const CLAUDE_CANDIDATES: { apiModelId: string; label: string }[] = [
   { apiModelId: 'claude-opus-5',                  label: 'Opus 5 (alias)' },
   { apiModelId: 'claude-sonnet-5',                label: 'Sonnet 5 (alias)' },
@@ -206,8 +244,8 @@ const CLAUDE_CANDIDATES: { apiModelId: string; label: string }[] = [
   { apiModelId: 'claude-opus-4-6',                label: 'Opus 4.6 (alias)' },
 ];
 
-export async function discoverClaudeModels(apiKey: string): Promise<ModelEntry[]> {
-  console.log(`[ModelDiscovery] Probing ${CLAUDE_CANDIDATES.length} Claude model candidates...`);
+async function probeClaudeCandidates(apiKey: string): Promise<ModelEntry[]> {
+  console.log(`[ModelDiscovery] Claude catalog unavailable — probing ${CLAUDE_CANDIDATES.length} candidates...`);
   const results: ModelEntry[] = [];
 
   const probeModel = async (candidate: typeof CLAUDE_CANDIDATES[0]): Promise<boolean> => {
@@ -247,10 +285,7 @@ export async function discoverClaudeModels(apiKey: string): Promise<ModelEntry[]
     const probes = await Promise.all(batch.map(c => probeModel(c).then(valid => ({ ...c, valid }))));
     for (const p of probes) {
       if (p.valid) {
-        const friendlyId = p.apiModelId
-          .replace(/-\d{8}$/, '')
-          .replace(/^claude-3-5-/, 'claude-3.5-');
-        results.push({ id: friendlyId, apiModelId: p.apiModelId, label: p.label, backend: 'claude' });
+        results.push({ id: claudeFriendlyId(p.apiModelId), apiModelId: p.apiModelId, label: p.label, backend: 'claude' });
       }
     }
   }
@@ -263,6 +298,40 @@ export async function discoverClaudeModels(apiKey: string): Promise<ModelEntry[]
     }
   }
   return [...seen.values()];
+}
+
+export async function discoverClaudeModels(apiKey: string): Promise<ModelEntry[]> {
+  try {
+    const resp = await fetch('https://api.anthropic.com/v1/models', {
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+    });
+    if (resp.ok) {
+      const json = await resp.json() as { data: AnthropicModelInfo[] };
+      const models = curateClaudeModels(json.data ?? []);
+      if (models.length > 0) {
+        console.log(`[ModelDiscovery] Claude: ${models.length} models via /v1/models catalog`);
+        return models;
+      }
+      console.warn('[ModelDiscovery] Claude /v1/models returned empty list; falling back to probe');
+    } else {
+      const body = await resp.text();
+      console.warn(`[ModelDiscovery] Claude /v1/models HTTP ${resp.status}: ${body.slice(0, 100)}; falling back to probe`);
+    }
+  } catch (err) {
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'model-discovery',
+      level: 'error',
+      message: 'Claude /v1/models catalog fetch failed',
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    console.warn('[ModelDiscovery] Claude /v1/models failed; falling back to probe:', err);
+  }
+
+  return probeClaudeCandidates(apiKey);
 }
 
 export function getKnownClaudeModels(): ModelEntry[] {


### PR DESCRIPTION
## Summary
- Add `curateClaudeModels` (exported, testable) — filters Anthropic `/v1/models` catalog to selectable text models with friendlyId transforms + dedup
- `discoverClaudeModels` now calls `GET /v1/models` first; falls back to `CLAUDE_CANDIDATES` probe on catalog error or empty response
- New Claude models now auto-discover on Refresh without a code change

## Test plan
- [x] 28 tests pass (11 new: `curateClaudeModels` × 8 + `discoverClaudeModels` catalog path × 3)
- [x] `npm run verify:config` green — all 6 registry gates
- [ ] Live: Refresh models with a valid Anthropic key shows catalog-discovered models

## Notes
- `CLAUDE_CANDIDATES` probe list retained as fallback — no behavior regression on catalog unavailability
- Relates to t/2321 (adds Opus 5 + Sonnet 5 to the probe fallback list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)