### PR TITLE
feat(ps): Add Get-DebateSessionState cmdlet (t/2330)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -122,6 +122,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-LatestFlightRecorderDump` | Find the most recent *non-stub* flight recorder dump (>10KB) for triage — skips the tiny startup/shutdown stubs that can be newer than the real dump (t/1712) |
 | `Get-AICostReport` | Token/cost usage report |
 | `Get-ViteDevStatus` | Vite dev server diagnostic — port owner, working dir, HTTP health, main/worktree/orphan classification (t/2196) |
+| `Get-DebateSessionState` | Read phase, transcript length, run_id, and updated_at from a debate JSON on disk — one-liner for interrupted-turn recovery diagnosis (t/2330) |
 
 ### Config
 | Cmdlet | Use when |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -207,6 +207,8 @@
         'Update-EntityMentionIndex'
         # t/2196 — Vite dev server diagnostic
         'Get-ViteDevStatus'
+        # t/2330 — Debate session state diagnostic
+        'Get-DebateSessionState'
     )
 
     # Aliases exported from this module

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -924,6 +924,8 @@ Export-ModuleMember -Function @(
     'Update-EntityMentionIndex'
     # t/2196 — Vite dev server diagnostic
     'Get-ViteDevStatus'
+    # t/2330 — Debate session state diagnostic
+    'Get-DebateSessionState'
 ) -Alias @(
     'Import-Document'
     'TaxonomyEditor'

--- a/scripts/AITriad/Public/Get-DebateSessionState.ps1
+++ b/scripts/AITriad/Public/Get-DebateSessionState.ps1
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-DebateSessionState {
+    <#
+    .SYNOPSIS
+        Reads phase, transcript length, run_id, and other state from a debate JSON on disk.
+    .DESCRIPTION
+        A one-liner diagnostic for interrupted-turn recovery and phase regression triage.
+        Locates the debate file by ID under the debates data directory, reads key fields,
+        and returns a typed snapshot without loading the full object graph.
+
+        No AI calls are made — offline read only.
+    .PARAMETER DebateId
+        The debate UUID (with or without the 'debate-' prefix, e.g. 'd1c7f7b6-...' or
+        'debate-d1c7f7b6-...').
+    .PARAMETER DataRoot
+        Optional override for the data root. Defaults to $env:AI_TRIAD_DATA_ROOT, then
+        .aitriad.json resolution.
+    .OUTPUTS
+        PSCustomObject with: DebateId, Phase, TranscriptLength, RunId, UpdatedAt,
+        PayloadBytes, FilePath.
+    .EXAMPLE
+        Get-DebateSessionState -DebateId d1c7f7b6-a170-45bb-9f14-37baf9a8ea2b
+    .EXAMPLE
+        Get-DebateSessionState 'd1c7f7b6-a170-45bb-9f14-37baf9a8ea2b' | Select-Object Phase, TranscriptLength
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Get-TaxonomyHealth
+    .LINK
+        Test-OntologyCompliance
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DebateId,
+
+        [Parameter()]
+        [string]$DataRoot
+    )
+
+    process {
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = 'Stop'
+
+        # Strip optional 'debate-' prefix so both forms are accepted
+        $CleanId = $DebateId -replace '^debate-', ''
+
+        $DebatesDir = if ($DataRoot) {
+            Join-Path $DataRoot (& { Initialize-DataConfig; $script:DataConfig.debates_dir })
+        } else {
+            Get-DebatesDir
+        }
+
+        $FilePath = Join-Path $DebatesDir "debate-$CleanId.json"
+
+        if (-not (Test-Path $FilePath)) {
+            throw (New-ActionableError `
+                -Goal        "Read debate session state for '$CleanId'" `
+                -Problem     "Debate file not found: $FilePath" `
+                -Location    "Get-DebateSessionState" `
+                -NextSteps   "Verify the DebateId is correct and the data root is reachable. Run Get-DebatesDir to confirm the resolved path.")
+        }
+
+        $Item    = Get-Item $FilePath
+        $Raw     = Get-Content $FilePath -Raw -Encoding utf8
+        $Debate  = $Raw | ConvertFrom-Json
+
+        $Phase            = if ($Debate.PSObject.Properties['phase'])      { [string]$Debate.phase }      else { $null }
+        $RunId            = if ($Debate.PSObject.Properties['run_id'])     { [string]$Debate.run_id }     else { $null }
+        $UpdatedAt        = if ($Debate.PSObject.Properties['updated_at']) { [string]$Debate.updated_at } else { $null }
+        $TranscriptLength = if ($Debate.PSObject.Properties['transcript']) { @($Debate.transcript).Count } else { 0 }
+
+        [PSCustomObject]@{
+            DebateId         = $CleanId
+            Phase            = $Phase
+            TranscriptLength = $TranscriptLength
+            RunId            = $RunId
+            UpdatedAt        = $UpdatedAt
+            PayloadBytes     = $Item.Length
+            FilePath         = $Item.FullName
+        }
+    }
+}

--- a/tests/Get-DebateSessionState.Tests.ps1
+++ b/tests/Get-DebateSessionState.Tests.ps1
@@ -1,0 +1,89 @@
+# Tag: debate (t/2330)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+# ── Discovery-time: compute skip predicate ─────────────────────────────────
+# Pester 5 evaluates -Skip during Discovery (before BeforeAll).  Resolve data
+# availability here at script scope so the predicate is ready in time.
+# git worktree list points us at the main checkout regardless of whether we
+# are running from the shared tree or a linked worktree.
+$_wt = & git worktree list --porcelain 2>$null
+$_mainRoot = ($_wt | Where-Object { $_ -match '^worktree ' } | Select-Object -First 1) -replace '^worktree ',''
+$_cfg      = if ($_mainRoot) { Join-Path $_mainRoot '.aitriad.json' } else { $null }
+$script:DEBATES_AVAILABLE = if (-not [string]::IsNullOrWhiteSpace($env:AI_TRIAD_DATA_ROOT)) {
+    Test-Path (Join-Path $env:AI_TRIAD_DATA_ROOT 'debates')
+} elseif ($_cfg -and (Test-Path $_cfg)) {
+    $_cfgData = Get-Content $_cfg -Raw | ConvertFrom-Json
+    $_dr = [System.IO.Path]::GetFullPath((Join-Path (Split-Path $_cfg -Parent) $_cfgData.data_root))
+    Test-Path (Join-Path $_dr 'debates')
+} else { $false }
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    # Load a real sample debate ID for the happy-path tests via module-scope call
+    $DebatesDir = & (Get-Module AITriad) { Get-DebatesDir }
+    $SampleFile = if ($DebatesDir -and (Test-Path $DebatesDir)) {
+        Get-ChildItem $DebatesDir -Filter 'debate-*.json' -File -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+    } else { $null }
+    $script:SampleId   = if ($SampleFile) { $SampleFile.BaseName -replace '^debate-', '' } else { $null }
+    $script:SamplePath = if ($SampleFile) { $SampleFile.FullName } else { $null }
+}
+
+Describe 'Get-DebateSessionState' -Tag 'debate' {
+
+    It 'Returns a result for a valid debate ID' -Skip:(-not $script:DEBATES_AVAILABLE) {
+        $result = Get-DebateSessionState -DebateId $script:SampleId
+        $result | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Result has all required output fields' -Skip:(-not $script:DEBATES_AVAILABLE) {
+        $result = Get-DebateSessionState -DebateId $script:SampleId
+        $result.PSObject.Properties.Name | Should -Contain 'DebateId'
+        $result.PSObject.Properties.Name | Should -Contain 'Phase'
+        $result.PSObject.Properties.Name | Should -Contain 'TranscriptLength'
+        $result.PSObject.Properties.Name | Should -Contain 'RunId'
+        $result.PSObject.Properties.Name | Should -Contain 'UpdatedAt'
+        $result.PSObject.Properties.Name | Should -Contain 'PayloadBytes'
+        $result.PSObject.Properties.Name | Should -Contain 'FilePath'
+    }
+
+    It 'DebateId in output matches input (without debate- prefix)' -Skip:(-not $script:DEBATES_AVAILABLE) {
+        $result = Get-DebateSessionState -DebateId $script:SampleId
+        $result.DebateId | Should -Be $script:SampleId
+    }
+
+    It 'Accepts debate- prefix and strips it' -Skip:(-not $script:DEBATES_AVAILABLE) {
+        $result = Get-DebateSessionState -DebateId "debate-$($script:SampleId)"
+        $result.DebateId | Should -Be $script:SampleId
+    }
+
+    It 'FilePath points to a real file' -Skip:(-not $script:DEBATES_AVAILABLE) {
+        $result = Get-DebateSessionState -DebateId $script:SampleId
+        Test-Path $result.FilePath | Should -Be $true
+    }
+
+    It 'PayloadBytes is positive' -Skip:(-not $script:DEBATES_AVAILABLE) {
+        $result = Get-DebateSessionState -DebateId $script:SampleId
+        $result.PayloadBytes | Should -BeGreaterThan 0
+    }
+
+    It 'TranscriptLength is a non-negative integer' -Skip:(-not $script:DEBATES_AVAILABLE) {
+        $result = Get-DebateSessionState -DebateId $script:SampleId
+        $result.TranscriptLength | Should -BeGreaterOrEqual 0
+    }
+
+    It 'Throws ActionableError for unknown debate ID' {
+        { Get-DebateSessionState -DebateId '00000000-0000-0000-0000-000000000000' } |
+            Should -Throw
+    }
+
+    It 'Accepts pipeline input' -Skip:(-not $script:DEBATES_AVAILABLE) {
+        $result = $script:SampleId | Get-DebateSessionState
+        $result.DebateId | Should -Be $script:SampleId
+    }
+}


### PR DESCRIPTION
## Summary
- New `Get-DebateSessionState -DebateId <uuid>` cmdlet for interrupted-turn recovery diagnosis
- Returns: `DebateId`, `Phase`, `TranscriptLength`, `RunId`, `UpdatedAt`, `PayloadBytes`, `FilePath`
- Accepts `debate-` prefix or bare UUID; pipeline input supported
- Resolves data path via `Get-DebatesDir` (env var → `.aitriad.json` → defaults)

## Test plan
- [x] Pester `Get-DebateSessionState.Tests.ps1` — 9/9 pass, 0 skipped (all paths including happy-path with real data)
- [x] `Test-ModuleManifest` passes
- [x] Smoke: `Get-DebateSessionState -DebateId 0118b903-...` returns correct phase/transcript/bytes
- [x] `/add-ps-cmdlet` self-cert — no deviations
- [ ] CI `test-powershell` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)