### PR TITLE
fix(main): CDP debug port 9222 → 9223, avoids VS Code/Orca conflict (t/2325)

### DIFF
--- a/taxonomy-editor/src/main/main.ts
+++ b/taxonomy-editor/src/main/main.ts
@@ -283,8 +283,9 @@ process.on('unhandledRejection', (reason) => {
 });
 
 if (process.argv.includes('--debug-cdp') || process.env.DEBUG_CDP === '1') {
-  app.commandLine.appendSwitch('remote-debugging-port', '9222');
-  console.log('[main] CDP enabled on port 9222 (--debug-cdp)');
+  // Port 9223 avoids conflict with VS Code/Orca which occupies 9222 by default.
+  app.commandLine.appendSwitch('remote-debugging-port', '9223');
+  console.log('[main] CDP enabled on port 9223 (--debug-cdp)');
 }
 
 void app.whenReady().then(() => {


### PR DESCRIPTION
## Summary

- `--debug-cdp` / `DEBUG_CDP=1` flag now binds to port 9223 instead of 9222
- Port 9222 is VS Code's and Orca's default CDP port, causing attach conflicts during electron-mcp sessions
- Added inline comment explaining the allocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)