### PR TITLE
fix(debate-store): coalesce concurrent loads + load-guard against state regression (t/2326)

### DIFF
--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -61,6 +61,8 @@ export type EventType =
   | 'state.save'
   | 'state.save-coalesced'
   | 'state.load'
+  | 'state.load-coalesced'
+  | 'state.load-guard'
   | 'state.error'
   | 'state.init'
   // Chat

--- a/taxonomy-editor/src/renderer/components/debate-workspace/ClarificationPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/ClarificationPanel.tsx
@@ -956,7 +956,7 @@ export function RefinedTopicEditor() {
   const handleSave = async () => {
     updateTopic({ final: editText.trim() });
     setEditing(false);
-    await saveDebate();
+    await saveDebate('ClarificationPanel:editTopic');
   };
 
   const handleCancel = () => {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -997,7 +997,7 @@ function useDebateWorkspaceEffects({
     if (!activeDebate) return;
     if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
     autoSaveTimer.current = setTimeout(() => {
-      void saveDebate();
+      void saveDebate('DebateWorkspace:autoSave');
     }, 2000);
     return () => {
       if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);

--- a/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.tsx
@@ -1176,7 +1176,7 @@ export function NewDebateDialog({ onClose, onAtCap }: NewDebateDialogProps) {
       getGlobalRecorder()?.record({ type: 'user.action', component: 'new-debate', level: 'info', message: 'debate.created', data: buildDebateCreatedData({ id, sourceType: sourceTypeArg, povers, userIsPover, effectiveModel, protocolId, temperature, audience, stepMode, multiProvider, modelTier, speakerModels, stageModels, creationWeights }) });
       const store = useDebateStore.getState();
       store.updatePhase('clarification');
-      await store.saveDebate();
+      await store.saveDebate('NewDebateDialog:create');
       const popoutResult = await api.openDebateWindow(id).catch((err: Error) => {
         getGlobalRecorder()?.record({ type: 'system.error', component: 'new-debate-dialog', level: 'warn', message: 'Failed to open debate popout window', error: { name: err.name ?? 'Error', message: String(err), stack: err.stack } });
         return undefined;

--- a/taxonomy-editor/src/renderer/components/debate/SituationDebatePanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationDebatePanel.tsx
@@ -100,7 +100,7 @@ export function SituationDebatePanel({ node, onLaunched }: SituationDebatePanelP
       const session = store.activeDebate;
       if (session) {
         applySituationDebateConfig(session, { effectiveModel, pacing, useAdaptiveStaging, temperature, audience, protocolId });
-        await store.saveDebate();
+        await store.saveDebate('SituationDebatePanel:applyConfig');
       }
 
       setActiveTab('debate');

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore.test.ts
@@ -936,13 +936,13 @@ describe('Error handling', () => {
       useDebateStore.setState({ activeDebate: makeSession() as any });
       mockApi.saveDebateSession.mockRejectedValueOnce(new Error('Disk full'));
 
-      await useDebateStore.getState().saveDebate();
+      await useDebateStore.getState().saveDebate('test');
 
       expect(useDebateStore.getState().debateError).toBeTruthy();
     });
 
     it('does nothing when activeDebate is null', async () => {
-      await useDebateStore.getState().saveDebate();
+      await useDebateStore.getState().saveDebate('test');
       expect(mockApi.saveDebateSession).not.toHaveBeenCalled();
     });
   });

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
@@ -54,7 +54,7 @@ describe('saveDebate', () => {
   it('saves current activeDebate via IPC', async () => {
     useDebateStore.setState({ activeDebate: makeSession() as any });
 
-    await useDebateStore.getState().saveDebate();
+    await useDebateStore.getState().saveDebate('test');
 
     expect(mockApi.saveDebateSession).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'session-1' }),
@@ -67,7 +67,7 @@ describe('saveDebate', () => {
       sessions: [{ id: 'session-1', title: 'Old Title', updated_at: 'old', phase: 'setup' }],
     });
 
-    await useDebateStore.getState().saveDebate();
+    await useDebateStore.getState().saveDebate('test');
 
     const sessions = useDebateStore.getState().sessions;
     expect(sessions[0].title).toBe('Updated Title');

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/loadDebateCoalescing.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/loadDebateCoalescing.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression test for t/2326: concurrent loadDebateSession calls must not regress
+// phase/transcript during interrupted-turn recovery, and no save may emit
+// caller:"unknown". Reproduces the d1c7f7b6 incident — three hooks mounting on
+// debate-window open each fire loadDebate; the 2nd/3rd used to resolve with the
+// stale on-disk snapshot and re-apply it over the first load's recovery.
+//
+// The store records via getGlobalRecorder(); we override it here (keeping the real
+// module's other exports) to capture the event stream and assert on the state-guard
+// and save diagnostics.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { recorded } = vi.hoisted(() => ({ recorded: [] as Array<Record<string, unknown>> }));
+
+vi.mock('@lib/flight-recorder/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lib/flight-recorder/index')>();
+  return {
+    ...actual,
+    getGlobalRecorder: () => ({ record: (e: Record<string, unknown>) => { recorded.push(e); }, setEventContext: () => {} }),
+  };
+});
+
+// Harness FIRST so its hoisted vi.mock registrations run before the store imports.
+import { resetStore, makeSession, mockApi } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+
+type Entry = { id: string; timestamp: string; type: string; speaker: string; content: string; taxonomy_refs: string[] };
+function entry(id: string, type = 'statement', speaker = 'accelerationist'): Entry {
+  return { id, timestamp: '2026-05-01T00:00:00.000Z', type, speaker, content: `content-${id}`, taxonomy_refs: [] };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('loadDebate concurrent coalescing + load-guard (t/2326)', () => {
+  beforeEach(() => {
+    resetStore();
+    recorded.length = 0;
+    // Stub auto-resume so the interrupted-turn recovery's setTimeout → crossRespond
+    // does no real work if it fires; the test asserts on the synchronous recovery.
+    useDebateStore.setState({ crossRespond: vi.fn().mockResolvedValue(undefined) as never });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('coalesces N concurrent loads into one IPC and one applied snapshot — no shrinkage, no regression, no caller:"unknown"', async () => {
+    const disk = makeSession({
+      id: 'd-race',
+      phase: 'opening',
+      transcript: [entry('e1', 'opening'), entry('e2')],
+      interrupted_turn: { speaker: 'accelerationist', phase: 'opening', round: 1, timestamp: '2026-05-01T00:00:00.000Z' },
+    });
+
+    // Hold the load pending so we can observe coalescing before it resolves.
+    let resolveLoad!: (v: unknown) => void;
+    mockApi.loadDebateSession.mockImplementation(() => new Promise((r) => { resolveLoad = r; }));
+
+    const p1 = useDebateStore.getState().loadDebate('d-race');
+    const p2 = useDebateStore.getState().loadDebate('d-race');
+    const p3 = useDebateStore.getState().loadDebate('d-race');
+
+    // Only the first load fires the IPC; the other two share its in-flight promise.
+    expect(mockApi.loadDebateSession).toHaveBeenCalledTimes(1);
+    expect(recorded.filter((e) => e.type === 'state.load-coalesced')).toHaveLength(2);
+
+    resolveLoad(structuredClone(disk));
+    await Promise.all([p1, p2, p3]);
+    await flush(); // let the recovery's void saveDebate() settle
+
+    const st = useDebateStore.getState();
+    // Recovery appended exactly one [Recovered] system entry (2 → 3); no later load
+    // re-applied the 2-entry disk snapshot over it.
+    expect(st.activeDebate?.id).toBe('d-race');
+    expect(st.activeDebate?.transcript).toHaveLength(3);
+    expect(st.activeDebate?.transcript.some((e) => e.type === 'system')).toBe(true);
+
+    // State-guard never fired.
+    const guardErrors = recorded.filter((e) =>
+      e.component === 'state-guard' && /shrinkage|regression/i.test(String(e.message ?? '')));
+    expect(guardErrors).toEqual([]);
+
+    // No save emitted caller:"unknown" — and the recovery save carried its caller.
+    const saveEvents = recorded.filter((e) => e.type === 'state.save');
+    expect(saveEvents.length).toBeGreaterThan(0);
+    for (const s of saveEvents) {
+      expect((s.data as { caller?: string } | undefined)?.caller).toBeTruthy();
+      expect((s.data as { caller?: string } | undefined)?.caller).not.toBe('unknown');
+    }
+
+    // The load itself was cleared from the in-flight map.
+    expect(useDebateStore.getState()._loadInFlight['d-race']).toBeUndefined();
+  });
+
+  it('load-guard refuses a snapshot that is behind the in-memory state', async () => {
+    // In-memory is AHEAD: phase "debate", 3 transcript entries.
+    useDebateStore.setState({
+      activeDebateId: 'd-guard',
+      activeDebate: makeSession({
+        id: 'd-guard',
+        phase: 'debate',
+        transcript: [entry('a'), entry('b'), entry('c')],
+      }) as never,
+    });
+
+    // Disk read is BEHIND: phase "opening", 2 entries (a stale snapshot).
+    mockApi.loadDebateSession.mockResolvedValue(makeSession({
+      id: 'd-guard',
+      phase: 'opening',
+      transcript: [entry('a'), entry('b')],
+    }));
+
+    await useDebateStore.getState().loadDebate('d-guard');
+
+    const st = useDebateStore.getState();
+    // In-memory state preserved — the stale snapshot was refused.
+    expect(st.activeDebate?.phase).toBe('debate');
+    expect(st.activeDebate?.transcript).toHaveLength(3);
+    expect(recorded.filter((e) => e.type === 'state.load-guard').length).toBeGreaterThan(0);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/saveDebateDocMeta.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/saveDebateDocMeta.test.ts
@@ -82,7 +82,7 @@ describe('saveDebate doc_meta stamping (t/1779)', () => {
     });
     store.setState({ activeDebate: makeSession(['doc1']) as unknown as DebateStore['activeDebate'] });
 
-    await store.getState().saveDebate();
+    await store.getState().saveDebate('test');
 
     expect(docMetaOf(store)).toEqual({
       doc1: { title: 'Doc One', resolved_url: 'https://example/1', provenance_label: 'arXiv 2023' },
@@ -96,7 +96,7 @@ describe('saveDebate doc_meta stamping (t/1779)', () => {
     mockLoadDocTitles.mockResolvedValue({ doc1: { title: 'Doc One' } });
     store.setState({ activeDebate: makeSession(null) as unknown as DebateStore['activeDebate'] });
 
-    await store.getState().saveDebate();
+    await store.getState().saveDebate('test');
 
     expect(docMetaOf(store)).toBeUndefined();
   });

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/storeTestHarness.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/storeTestHarness.ts
@@ -367,6 +367,7 @@ function resetStore(): void {
     activeDebateId: null,
     activeDebate: null,
     debateLoading: false,
+    _loadInFlight: {},
     debateGenerating: null,
     debateError: null,
     responseLength: 'detailed',

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/phaseOrder.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/phaseOrder.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Single source of truth for debate phase ordering. Shared by the t/194
+// state-guard (store.ts — detects phase regression / transcript shrinkage after
+// the fact) and the t/2326 load-guard (sessionSlice.loadDebate — refuses to apply
+// a loaded snapshot that is behind the in-memory state). Keeping one PHASE_ORDER
+// and one comparison keeps the two guards consistent.
+
+export const PHASE_ORDER: Record<string, number> = {
+  setup: 0,
+  clarification: 1,
+  'edit-claims': 2,
+  opening: 3,
+  debate: 4,
+  closed: 5,
+};
+
+/** Ordinal for a phase, or -1 for an unknown/unordered phase. */
+export function phaseIndex(phase: string): number {
+  return PHASE_ORDER[phase] ?? -1;
+}
+
+/**
+ * True when `current` is strictly AHEAD of `candidate` — applying `candidate` over
+ * `current` would be a phase regression or a transcript shrinkage. This is the
+ * load-side analog of the t/194 state-guard's two checks, combined: refuse the
+ * apply if EITHER the candidate's phase is earlier OR its transcript is shorter.
+ * Unknown phases (idx -1) never trigger a phase regression on their own.
+ */
+export function isStateAhead(
+  current: { phase: string; transcript: unknown[] },
+  candidate: { phase: string; transcript: unknown[] },
+): boolean {
+  const curPhaseIdx = phaseIndex(current.phase);
+  const candPhaseIdx = phaseIndex(candidate.phase);
+  const phaseRegression = curPhaseIdx >= 0 && candPhaseIdx >= 0 && candPhaseIdx < curPhaseIdx;
+  const transcriptShrinkage = candidate.transcript.length < current.transcript.length;
+  return phaseRegression || transcriptShrinkage;
+}

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -33,6 +33,7 @@ import type { CampOrigin, StandardizedTerm, ColloquialTerm } from '@lib/dictiona
 import { resetDoctrinalAnchoringCache } from '../shared/taxonomyContext';
 import { resetNeutralMapping } from '../shared/neutralCheckpoint';
 import { resetSignalHistory, resetGapInjectionCount, setGapInjectionCount } from '../shared/diagnostics';
+import { isStateAhead } from '../shared/phaseOrder';
 
 declare const __APP_VERSION__: string;
 
@@ -49,6 +50,12 @@ export interface SessionSlice {
   createConflictDebate: (claimId: string) => Promise<string>;
   loadDebate: (id: string) => Promise<void>;
   loadDebateFromData: (raw: unknown, opts?: { readOnly?: boolean }) => void;
+  // Concurrent-load coalescing (t/2326): loads of the same debate id in flight at
+  // once share ONE promise, so a debate window that mounts N hooks fires the IPC —
+  // and applies the loaded snapshot — exactly once. Mirrors the save-coalescing
+  // (_saveInFlight/_saveDirty) below. Keyed by debate id; entries are cleared when
+  // their load settles.
+  _loadInFlight: Record<string, Promise<void>>;
   deleteDebate: (id: string) => Promise<void>;
   renameDebate: (id: string, newTitle: string) => Promise<void>;
   closeDebate: () => void;
@@ -57,7 +64,11 @@ export interface SessionSlice {
   togglePover: (poverId: SpeakerId) => Promise<void>;
   updatePhase: (phase: DebateSession['phase']) => void;
   updateTopic: (topic: Partial<DebateSession['topic']>) => void;
-  saveDebate: (caller?: string) => Promise<void>;
+  // `caller` is required (t/2326): a diagnostic label naming the trigger of every
+  // save. Making it mandatory kills the `caller:"unknown"` blind spot that hid a
+  // regressed-state save in the d1c7f7b6 incident — tsc now flags any save site
+  // that omits it.
+  saveDebate: (caller: string) => Promise<void>;
   _saveInFlight: boolean;
   _saveDirty: boolean;
   // Snapshot-diff dirty tracking for incremental (delta) save on web (t/1637).
@@ -185,13 +196,13 @@ function rebuildOverviewDiagnostics(activeDebate: DebateSession): void {
 }
 
 /** Assemble the flight-recorder save-diagnostics payload for a debate. */
-function buildSaveDiag(activeDebate: DebateSession, caller?: string) {
+function buildSaveDiag(activeDebate: DebateSession, caller: string) {
   const payloadBytes = JSON.stringify(activeDebate).length;
   const turnCount = activeDebate.transcript.length;
   const nodeCount = (activeDebate as unknown as Record<string, unknown>).argument_network
     ? ((activeDebate as unknown as Record<string, { nodes?: unknown[] }>).argument_network?.nodes?.length ?? 0)
     : 0;
-  return { phase: activeDebate.phase, transcript_length: turnCount, caller: caller ?? 'unknown', payload_bytes: payloadBytes, turn_count: turnCount, node_count: nodeCount };
+  return { phase: activeDebate.phase, transcript_length: turnCount, caller, payload_bytes: payloadBytes, turn_count: turnCount, node_count: nodeCount };
 }
 type SaveDiag = ReturnType<typeof buildSaveDiag>;
 
@@ -315,6 +326,7 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
   debateLoading: false,
   _saveInFlight: false,
   _saveDirty: false,
+  _loadInFlight: {},
   _lastSyncedVersion: null,
   _lastSyncedSnapshot: null,
 
@@ -523,106 +535,142 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
   },
 
   loadDebate: async (id) => {
-    resetDoctrinalAnchoringCache();
-    resetSignalHistory();
-    resetGapInjectionCount();
-    resetNeutralMapping();
-    set({ debateLoading: true, debateError: null, debateWarnings: [], newsReport: null, newsReportLoading: false, newsReportError: null });
-    try {
-      const raw = await api.loadDebateSession(id);
-      const session = raw as DebateSession;
-      session.active_povers = normalizeActivePovers(session.active_povers);
-      for (const entry of session.transcript) {
-        entry.speaker = migrateSpeakerId(entry.speaker) as SpeakerId;
-      }
-      if (session.opening_order) {
-        session.opening_order = session.opening_order.map(s => migrateSpeakerId(s)) as typeof session.opening_order;
-      }
-      if (session.argument_network?.nodes) {
-        for (const node of session.argument_network.nodes) {
-          node.speaker = migrateSpeakerId(node.speaker) as typeof node.speaker;
+    // t/2326: coalesce concurrent loads of the same debate id to a single in-flight
+    // request. On debate-window open several hooks mount and each fires loadDebate;
+    // without this, the 2nd/3rd load resolves with a now-stale disk snapshot and
+    // re-applies it over interrupted-turn recovery, regressing phase/transcript
+    // (incident d1c7f7b6). Sharing one promise means the IPC fires — and the snapshot
+    // applies — exactly once. Mirrors the save-coalescing (_saveInFlight) below.
+    const existing = get()._loadInFlight[id];
+    if (existing !== undefined) {
+      getGlobalRecorder()?.record({ type: 'state.load-coalesced', component: 'debate-store', level: 'info', debate_id: id, message: 'Load coalesced — sharing in-flight request' });
+      return existing;
+    }
+    const runLoad = async (): Promise<void> => {
+      resetDoctrinalAnchoringCache();
+      resetSignalHistory();
+      resetGapInjectionCount();
+      resetNeutralMapping();
+      set({ debateLoading: true, debateError: null, debateWarnings: [], newsReport: null, newsReportLoading: false, newsReportError: null });
+      try {
+        const raw = await api.loadDebateSession(id);
+        const session = raw as DebateSession;
+        session.active_povers = normalizeActivePovers(session.active_povers);
+        for (const entry of session.transcript) {
+          entry.speaker = migrateSpeakerId(entry.speaker) as SpeakerId;
         }
-      }
+        if (session.opening_order) {
+          session.opening_order = session.opening_order.map(s => migrateSpeakerId(s)) as typeof session.opening_order;
+        }
+        if (session.argument_network?.nodes) {
+          for (const node of session.argument_network.nodes) {
+            node.speaker = migrateSpeakerId(node.speaker) as typeof node.speaker;
+          }
+        }
 
-      for (const entry of session.transcript) {
-        if (entry.type === 'concluding' && entry.metadata?.synthesis) {
-          const synthesis = entry.metadata.synthesis as { areas_of_disagreement?: { bdi_layer?: string }[] };
-          if (Array.isArray(synthesis.areas_of_disagreement)) {
-            for (const d of synthesis.areas_of_disagreement) {
-              if (d.bdi_layer) {
-                d.bdi_layer = normalizeBdiLayer(d.bdi_layer as Parameters<typeof normalizeBdiLayer>[0]);
+        for (const entry of session.transcript) {
+          if (entry.type === 'concluding' && entry.metadata?.synthesis) {
+            const synthesis = entry.metadata.synthesis as { areas_of_disagreement?: { bdi_layer?: string }[] };
+            if (Array.isArray(synthesis.areas_of_disagreement)) {
+              for (const d of synthesis.areas_of_disagreement) {
+                if (d.bdi_layer) {
+                  d.bdi_layer = normalizeBdiLayer(d.bdi_layer as Parameters<typeof normalizeBdiLayer>[0]);
+                }
               }
             }
           }
         }
-      }
-      const runId = generateId();
-      session.run_id = runId;
-      set({ activeDebateId: id, activeDebate: session, debateLoading: false, debateModel: session.debate_model || null, debateTemperature: session.debate_temperature ?? null, audience: session.audience ?? 'policymakers', openingOrder: session.opening_order ?? [], selectedDiagEntry: null, _lastSyncedVersion: session._saveVersion ?? 0, _lastSyncedSnapshot: structuredClone(session) });
-      setActiveDebateId(id);
-      setGapInjectionCount(session.gap_injections?.length ?? 0);
-      if (!get().vocabularyTerms) {
-        api.loadDictionary().then(dict => {
-          if (dict.standardized.length > 0 && get().activeDebateId === id) {
-            set({ vocabularyTerms: { standardized: dict.standardized as StandardizedTerm[], colloquial: dict.colloquial as ColloquialTerm[] } });
-          }
-        }).catch((err: unknown) => {
-          getGlobalRecorder()?.record({ type: 'system.error', debate_id: id, component: 'debate-store', level: 'warn', message: 'Dictionary load failed on debate resume (non-critical)', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-        });
-      }
-      usePromptConfigStore.getState().loadSessionConfig(
-        (session as unknown as Record<string, unknown>).prompt_config as Record<string, number | boolean | string> | undefined
-      );
-      api.setDebateTemperature(session.debate_temperature ?? null).catch((err: unknown) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-store', level: 'warn', message: 'setDebateTemperature failed (non-critical)', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); });
-      try { api.sendDiagnosticsState({ debate: session, selectedEntry: null }); } catch (e) { getGlobalRecorder()?.record({ type: 'system.error', debate_id: id, component: 'debate-store', level: 'warn', message: 'Diagnostics broadcast to popout failed (loadDebate)', error: { name: (e as Error).name ?? 'Error', message: String(e), stack: (e as Error).stack } }); }
-      getGlobalRecorder()?.setEventContext({ debate_id: id, run_id: runId });
-      getGlobalRecorder()?.record({ type: 'state.load', component: 'debate-store', level: 'info', debate_id: id, run_id: runId, message: 'Debate loaded', data: { phase: session.phase, transcript_length: session.transcript.length, an_nodes: (session as unknown as Record<string, unknown>).argument_network ? ((session as unknown as Record<string, unknown>).argument_network as { nodes?: unknown[] }).nodes?.length ?? 0 : 0 } });
-      getGlobalRecorder()?.record({ type: 'debate.phase', component: 'debate-store', level: 'info', debate_id: id, run_id: runId, message: 'debate.start', data: { phase: session.phase, topic: session.topic.final, povers: session.active_povers, protocol: session.protocol_id, model: session.debate_model, transcript_length: session.transcript.length, resumed: true } });
-
-      if (session.interrupted_turn) {
-        const resumeSpeaker = session.interrupted_turn.speaker as SpeakerId;
-        const speakerLabel = POVER_INFO[session.interrupted_turn.speaker as Exclude<SpeakerId, 'user'>]?.label ?? session.interrupted_turn.speaker;
-        getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'info', debate_id: id, message: 'Interrupted turn detected on load', data: session.interrupted_turn });
-        get().addTranscriptEntry({
-          type: 'system',
-          speaker: 'system',
-          content: `[Recovered] ${speakerLabel}'s turn was interrupted when the window closed (round ${session.interrupted_turn.round}, ${session.interrupted_turn.phase} phase). Auto-resuming…`,
-          taxonomy_refs: [],
-          metadata: { interrupted_turn_recovery: true, ...session.interrupted_turn },
-        });
-        const fresh = get().activeDebate;
-        if (fresh) {
-          const { interrupted_turn: _, ...cleaned } = fresh;
-          set({ activeDebate: cleaned as DebateSession });
+        // t/2326 load-guard: if the in-memory state is already AHEAD of this loaded
+        // snapshot (later phase or longer transcript), refuse to apply it — a stale
+        // disk read must not clobber interrupted-turn recovery or live generation.
+        // Load-side analog of the t/194 state-guard; shares isStateAhead so the two
+        // stay consistent. Coalescing kills the concurrent-burst case; this also
+        // covers a single load that resolves after in-memory advanced.
+        const inMemory = get().activeDebate;
+        if (inMemory && inMemory.id === id && isStateAhead(inMemory, session)) {
+          getGlobalRecorder()?.record({ type: 'state.load-guard', component: 'debate-store', level: 'warn', debate_id: id, message: 'Load skipped — in-memory state is ahead of loaded snapshot', data: { current_phase: inMemory.phase, loaded_phase: session.phase, current_transcript: inMemory.transcript.length, loaded_transcript: session.transcript.length } });
+          set({ debateLoading: false });
+          return;
         }
-        void get().saveDebate('loadDebate:interrupted_turn_recovery');
-        setTimeout(() => {
-          const s = get();
-          if (s.activeDebateId === id && !s.debateGenerating) {
-            getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'info', debate_id: id, message: 'Auto-resuming after interrupted turn recovery' });
-            // Engage the generating indicator up front so the Continue button is
-            // disabled during crossRespond's ramp-up (edge load + moderator
-            // selection); crossRespond otherwise sets debateGenerating too late,
-            // leaving Continue live long enough for a click to double-fire the
-            // resumed round (t/1656). crossRespond owns the flag from here and
-            // clears it on completion/error.
-            set({ debateGenerating: resumeSpeaker, debateActivity: `${speakerLabel} is resuming…`, debateStepStartedAt: Date.now() });
-            void s.crossRespond().finally(() => {
-              // Safety net: if crossRespond bailed before taking ownership of the
-              // indicator (no activeDebate, driver-claim denied, <2 debaters), our
-              // sentinel is still set — clear it so the indicator isn't stuck on.
-              if (get().debateGenerating === resumeSpeaker) {
-                set({ debateGenerating: null, debateActivity: null });
-              }
-            });
-          } else {
-            getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'info', debate_id: id, message: 'Loop not auto-resumed', data: { reason: s.activeDebateId !== id ? 'debate_switched' : 'already_generating', activeDebateId: s.activeDebateId, debateGenerating: s.debateGenerating } });
+        const runId = generateId();
+        session.run_id = runId;
+        set({ activeDebateId: id, activeDebate: session, debateLoading: false, debateModel: session.debate_model || null, debateTemperature: session.debate_temperature ?? null, audience: session.audience ?? 'policymakers', openingOrder: session.opening_order ?? [], selectedDiagEntry: null, _lastSyncedVersion: session._saveVersion ?? 0, _lastSyncedSnapshot: structuredClone(session) });
+        setActiveDebateId(id);
+        setGapInjectionCount(session.gap_injections?.length ?? 0);
+        if (!get().vocabularyTerms) {
+          api.loadDictionary().then(dict => {
+            if (dict.standardized.length > 0 && get().activeDebateId === id) {
+              set({ vocabularyTerms: { standardized: dict.standardized as StandardizedTerm[], colloquial: dict.colloquial as ColloquialTerm[] } });
+            }
+          }).catch((err: unknown) => {
+            getGlobalRecorder()?.record({ type: 'system.error', debate_id: id, component: 'debate-store', level: 'warn', message: 'Dictionary load failed on debate resume (non-critical)', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+          });
+        }
+        usePromptConfigStore.getState().loadSessionConfig(
+          (session as unknown as Record<string, unknown>).prompt_config as Record<string, number | boolean | string> | undefined
+        );
+        api.setDebateTemperature(session.debate_temperature ?? null).catch((err: unknown) => { getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-store', level: 'warn', message: 'setDebateTemperature failed (non-critical)', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); });
+        try { api.sendDiagnosticsState({ debate: session, selectedEntry: null }); } catch (e) { getGlobalRecorder()?.record({ type: 'system.error', debate_id: id, component: 'debate-store', level: 'warn', message: 'Diagnostics broadcast to popout failed (loadDebate)', error: { name: (e as Error).name ?? 'Error', message: String(e), stack: (e as Error).stack } }); }
+        getGlobalRecorder()?.setEventContext({ debate_id: id, run_id: runId });
+        getGlobalRecorder()?.record({ type: 'state.load', component: 'debate-store', level: 'info', debate_id: id, run_id: runId, message: 'Debate loaded', data: { phase: session.phase, transcript_length: session.transcript.length, an_nodes: (session as unknown as Record<string, unknown>).argument_network ? ((session as unknown as Record<string, unknown>).argument_network as { nodes?: unknown[] }).nodes?.length ?? 0 : 0 } });
+        getGlobalRecorder()?.record({ type: 'debate.phase', component: 'debate-store', level: 'info', debate_id: id, run_id: runId, message: 'debate.start', data: { phase: session.phase, topic: session.topic.final, povers: session.active_povers, protocol: session.protocol_id, model: session.debate_model, transcript_length: session.transcript.length, resumed: true } });
+
+        if (session.interrupted_turn) {
+          const resumeSpeaker = session.interrupted_turn.speaker as SpeakerId;
+          const speakerLabel = POVER_INFO[session.interrupted_turn.speaker as Exclude<SpeakerId, 'user'>]?.label ?? session.interrupted_turn.speaker;
+          getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'info', debate_id: id, message: 'Interrupted turn detected on load', data: session.interrupted_turn });
+          get().addTranscriptEntry({
+            type: 'system',
+            speaker: 'system',
+            content: `[Recovered] ${speakerLabel}'s turn was interrupted when the window closed (round ${session.interrupted_turn.round}, ${session.interrupted_turn.phase} phase). Auto-resuming…`,
+            taxonomy_refs: [],
+            metadata: { interrupted_turn_recovery: true, ...session.interrupted_turn },
+          });
+          const fresh = get().activeDebate;
+          if (fresh) {
+            const { interrupted_turn: _, ...cleaned } = fresh;
+            set({ activeDebate: cleaned as DebateSession });
           }
-        }, 100);
+          void get().saveDebate('loadDebate:interrupted_turn_recovery');
+          setTimeout(() => {
+            const s = get();
+            if (s.activeDebateId === id && !s.debateGenerating) {
+              getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'info', debate_id: id, message: 'Auto-resuming after interrupted turn recovery' });
+              // Engage the generating indicator up front so the Continue button is
+              // disabled during crossRespond's ramp-up (edge load + moderator
+              // selection); crossRespond otherwise sets debateGenerating too late,
+              // leaving Continue live long enough for a click to double-fire the
+              // resumed round (t/1656). crossRespond owns the flag from here and
+              // clears it on completion/error.
+              set({ debateGenerating: resumeSpeaker, debateActivity: `${speakerLabel} is resuming…`, debateStepStartedAt: Date.now() });
+              void s.crossRespond().finally(() => {
+                // Safety net: if crossRespond bailed before taking ownership of the
+                // indicator (no activeDebate, driver-claim denied, <2 debaters), our
+                // sentinel is still set — clear it so the indicator isn't stuck on.
+                if (get().debateGenerating === resumeSpeaker) {
+                  set({ debateGenerating: null, debateActivity: null });
+                }
+              });
+            } else {
+              getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'info', debate_id: id, message: 'Loop not auto-resumed', data: { reason: s.activeDebateId !== id ? 'debate_switched' : 'already_generating', activeDebateId: s.activeDebateId, debateGenerating: s.debateGenerating } });
+            }
+          }, 100);
+        }
+      } catch (err) {
+        getGlobalRecorder()?.record({ type: 'state.error', component: 'debate-store', level: 'error', debate_id: id, message: 'Failed to load debate', error: { name: 'LoadError', message: String(err), stack: (err as Error).stack } });
+        set({ debateLoading: false, debateError: mapErrorToUserMessage(err) });
       }
-    } catch (err) {
-      getGlobalRecorder()?.record({ type: 'state.error', component: 'debate-store', level: 'error', debate_id: id, message: 'Failed to load debate', error: { name: 'LoadError', message: String(err), stack: (err as Error).stack } });
-      set({ debateLoading: false, debateError: mapErrorToUserMessage(err) });
+    };
+    const promise = runLoad();
+    set((state) => ({ _loadInFlight: { ...state._loadInFlight, [id]: promise } }));
+    try {
+      await promise;
+    } finally {
+      set((state) => {
+        const next = { ...state._loadInFlight };
+        delete next[id];
+        return { _loadInFlight: next };
+      });
     }
   },
 
@@ -922,13 +970,13 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
     await saveDebate('setDebatePhase');
   },
 
-  saveDebate: async (caller?: string) => {
+  saveDebate: async (caller: string) => {
     const { activeDebate, _saveInFlight } = get();
     if (!activeDebate) return;
 
     if (_saveInFlight) {
       set({ _saveDirty: true });
-      getGlobalRecorder()?.record({ type: 'state.save-coalesced', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: `Save coalesced (in-flight), caller: ${caller ?? 'unknown'}` });
+      getGlobalRecorder()?.record({ type: 'state.save-coalesced', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: `Save coalesced (in-flight), caller: ${caller}` });
       return;
     }
 
@@ -959,7 +1007,7 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
         // user is told their debate is at risk — see computeSaveErrorState. record()
         // stays inline here per ADR-003.
         const { isDurableSaveLoss, atRiskTurns, debateError } = computeSaveErrorState(err, activeDebate);
-        getGlobalRecorder()?.record({ type: 'state.error', component: 'debate-store', level: 'error', debate_id: activeDebate.id, message: isDurableSaveLoss ? 'Durable debate save failed — recovery copy preserved' : 'Failed to save debate', error: { name: isDurableSaveLoss ? 'DurableSaveError' : 'SaveError', message: String(err), stack: (err as Error).stack }, data: { caller: caller ?? 'unknown', payload_bytes: JSON.stringify(activeDebate).length, turn_count: activeDebate.transcript.length, save_degraded: isDurableSaveLoss, at_risk_turns: atRiskTurns } });
+        getGlobalRecorder()?.record({ type: 'state.error', component: 'debate-store', level: 'error', debate_id: activeDebate.id, message: isDurableSaveLoss ? 'Durable debate save failed — recovery copy preserved' : 'Failed to save debate', error: { name: isDurableSaveLoss ? 'DurableSaveError' : 'SaveError', message: String(err), stack: (err as Error).stack }, data: { caller, payload_bytes: JSON.stringify(activeDebate).length, turn_count: activeDebate.transcript.length, save_degraded: isDurableSaveLoss, at_risk_turns: atRiskTurns } });
         set({ debateError });
       }
     } finally {

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/store.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/store.ts
@@ -15,6 +15,7 @@ import { createDebateReflectionSlice } from './slices/debateReflectionSlice';
 import { createExplorationSlice } from './slices/explorationSlice';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { api } from '@bridge';
+import { PHASE_ORDER } from './shared/phaseOrder';
 
 export const useDebateStore = create<DebateStore>()((...a) => ({
   ...createConfigSlice(...a),
@@ -112,9 +113,9 @@ if (typeof window !== 'undefined') {
   });
 }
 
-// State-clobber detection (t/194)
-const PHASE_ORDER: Record<string, number> = { setup: 0, clarification: 1, 'edit-claims': 2, opening: 3, debate: 4, closed: 5 };
-
+// State-clobber detection (t/194). PHASE_ORDER is shared with the t/2326 load-guard
+// (sessionSlice.loadDebate) via ./shared/phaseOrder so both guards order phases
+// identically.
 useDebateStore.subscribe((state, prev) => {
   const curr = state.activeDebate;
   const old = prev.activeDebate;


### PR DESCRIPTION
## Summary
Fixes data corruption from concurrent `loadDebateSession` calls on debate-window open (incident `d1c7f7b6`). Three hooks mount and each fires `loadDebate`; the first ran interrupted-turn recovery (transcript 2→3, phase advancing), then the 2nd/3rd resolved with the stale on-disk snapshot and re-applied it — firing `Transcript shrinkage 3→2` / `Phase regression debate→opening` and persisting the regressed state via a `caller:"unknown"` save.

Store-level fix (TL-validated design, t/2326#1):
1. **Coalesce** concurrent `loadDebate` of the same id to one in-flight promise (`_loadInFlight`, mirrors save-coalescing) — IPC fires and snapshot applies exactly once.
2. **Load-guard** in `loadDebate`: refuse to apply a snapshot when in-memory phase/transcript is already ahead. Load-side analog of the t/194 state-guard; shares `PHASE_ORDER`/`isStateAhead` via new `shared/phaseOrder.ts`.
3. **`caller` now required** on `saveDebate` — kills the `caller:"unknown"` blind spot; tsc flags any omitting site. Fixed the 4 omitting sites.

## Regression test
`loadDebateCoalescing.test.ts`: N concurrent loads racing recovery → one IPC + one applied snapshot, no shrinkage/regression, no `caller:"unknown"`; plus a direct load-guard test.

## Cross-scope (trivial, additive, required for compile — owners being notified)
- `lib/flight-recorder/types.ts`: +`state.load-coalesced`/+`state.load-guard` (**Shared Lib**)
- `components/debate-workspace/{ClarificationPanel,DebateWorkspace}.tsx`: caller arg (**DebateWorkspace**)
- `components/debate/{NewDebateDialog,SituationDebatePanel}.tsx`: caller arg (**DebateUI**)

## Verification
tsc (renderer/main/server) clean · eslint gate 0 errors · depcruise clean · store suites 185/185 incl. new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
Co-Authored-By: Diagnostics (Orca) <main.operations-diagnostics@ai-triad-research.orca.local>