### PR TITLE
chore(ipc): FR instrumentation for nli-classify handler (t/2329)

### DIFF
--- a/taxonomy-editor/src/main/ipc/aiHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/aiHandlers.ts
@@ -112,7 +112,20 @@ export function registerAiHandlers(): void {
   });
 
   ipcMain.handle('nli-classify', async (_event, pairs: NliPair[]) => {
-    return { results: await classifyNli(pairs) };
+    const t0 = Date.now();
+    getGlobalRecorder()?.record({ type: 'system.info', component: 'ipc-handlers', level: 'info', message: `nli-classify start: ${pairs.length} pairs` });
+    try {
+      const results = await classifyNli(pairs);
+      getGlobalRecorder()?.record({ type: 'system.info', component: 'ipc-handlers', level: 'info', message: `nli-classify ok: ${results.length} results in ${Date.now() - t0}ms`, data: { duration_ms: Date.now() - t0, result_count: results.length } });
+      return { results };
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'ipc-handlers', level: 'error',
+        message: `nli-classify failed after ${Date.now() - t0}ms`,
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      throw err;
+    }
   });
 
   ipcMain.handle('generate-text', async (event, prompt: string, model?: string, timeoutMs?: number, temperature?: number) => {


### PR DESCRIPTION
## Summary

Adds flight recorder events to the `nli-classify` IPC handler:
- `system.info` on start with pair count
- `system.info` on success with duration_ms and result count
- `system.error` on failure with full error message (includes Python stderr from `ActionableError` thrown by `classifyNliBatch`)

Uses existing `system.info`/`system.error` event types (no new FR dictionary entries needed). Relates to t/2327.

## Test plan

- [ ] `tsc -p tsconfig.main.json --noEmit` passes (verified)
- [ ] Run nli-classify — FR dump shows start + ok events
- [ ] Kill Python subprocess mid-run — FR dump shows error event with stderr in message

🤖 Generated with [Claude Code](https://claude.com/claude-code)