### PR TITLE
feat(debate): add required caller param to saveDebateSession (t/2328)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/debateIO.saveEnrich.test.ts
+++ b/taxonomy-editor/src/main/__tests__/debateIO.saveEnrich.test.ts
@@ -66,7 +66,7 @@ describe('saveDebateSession enriches total-loss ActionableError (t/1638)', () =>
     };
 
     let caught: unknown;
-    try { saveDebateSession(session); } catch (e) { caught = e; }
+    try { saveDebateSession(session, 'test'); } catch (e) { caught = e; }
 
     expect(caught).toBeInstanceOf(ActionableError);
     const ae = caught as ActionableError;
@@ -100,7 +100,7 @@ describe('saveDebateSession enriches total-loss ActionableError (t/1638)', () =>
     const session = { id: 'deb-min' }; // no run_id, no transcript
 
     let caught: unknown;
-    try { saveDebateSession(session); } catch (e) { caught = e; }
+    try { saveDebateSession(session, 'test'); } catch (e) { caught = e; }
 
     expect(caught).toBeInstanceOf(ActionableError);
     const ae = caught as ActionableError;

--- a/taxonomy-editor/src/main/debateIO.ts
+++ b/taxonomy-editor/src/main/debateIO.ts
@@ -211,7 +211,7 @@ function embedCalibrationIfCompleted(session: unknown): void {
   } catch { /* telemetry — silent by design;  calibration logging never blocks save */ }
 }
 
-export function saveDebateSession(session: unknown): void {
+export function saveDebateSession(session: unknown, caller: string): void {
   ensureDebatesDir();
   const data = session as { id: string };
   if (!data.id || typeof data.id !== 'string') {
@@ -267,6 +267,12 @@ export function saveDebateSession(session: unknown): void {
   } catch (err) {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'debateIO', level: 'warn', message: 'Debate index update after save failed', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
   }
+
+  getGlobalRecorder()?.record({
+    type: 'state.save', component: 'debateIO', level: 'info',
+    message: 'Debate saved',
+    data: { debate_id: data.id, caller, save_mode: 'electron-main' },
+  });
 }
 
 export function deleteDebateSession(id: string): void {

--- a/taxonomy-editor/src/main/ipc/debateHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/debateHandlers.ts
@@ -37,8 +37,8 @@ export function registerDebateHandlers(): void {
     return loadDebateSession(id);
   });
 
-  ipcMain.handle('save-debate-session', (_event, session: unknown) => {
-    saveDebateSession(session);
+  ipcMain.handle('save-debate-session', (_event, session: unknown, caller: string) => {
+    saveDebateSession(session, caller);
   });
 
   ipcMain.handle('delete-debate-session', (_event, id: string) => {

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -409,8 +409,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   loadDebateSession: (id: string): Promise<unknown> =>
     ipcRenderer.invoke('load-debate-session', id),
 
-  saveDebateSession: (session: unknown): Promise<void> =>
-    ipcRenderer.invoke('save-debate-session', session),
+  saveDebateSession: (session: unknown, caller: string): Promise<void> =>
+    ipcRenderer.invoke('save-debate-session', session, caller),
 
   deleteDebateSession: (id: string): Promise<void> =>
     ipcRenderer.invoke('delete-debate-session', id),

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -197,7 +197,7 @@ export const api: AppAPI = {
   listDebateSessions: () => window.electronAPI.listDebateSessions(),
   listDebateSessionsMeta: () => window.electronAPI.listDebateSessions(), // Electron mode: local fs is fast, reuse full list
   loadDebateSession: (id) => window.electronAPI.loadDebateSession(id),
-  saveDebateSession: (s) => window.electronAPI.saveDebateSession(s),
+  saveDebateSession: (s, caller) => window.electronAPI.saveDebateSession(s, caller),
   // Electron has no incremental save path — the local fs write is already cheap,
   // so `saveDebateDelta` exists only to keep `AppAPI` total. The store gates on
   // `isElectronMode()` and always routes Electron saves through the full

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -241,7 +241,7 @@ export interface AppAPI {
   listDebateSessions: () => Promise<unknown[]>;
   listDebateSessionsMeta: () => Promise<unknown[]>;
   loadDebateSession: (id: string) => Promise<unknown>;
-  saveDebateSession: (session: unknown) => Promise<void>;
+  saveDebateSession: (session: unknown, caller: string) => Promise<void>;
   /** Incremental save (web-only optimization; Electron delegates to a full save).
    *  Sends only the surfaces that changed since the last synced version. The server
    *  accepts the delta only if `delta.baseVersion` matches the stored `_saveVersion`

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -1004,7 +1004,7 @@ const rawApi: AppAPI = {
   listDebateSessions: () => get('/api/debates'),
   listDebateSessionsMeta: () => get('/api/debates/list'),
   loadDebateSession: (id) => get(`/api/debates/${encodeURIComponent(id)}`),
-  saveDebateSession: (session) => put('/api/debates', session, { timeoutMs: DEBATE_SAVE_TIMEOUT_MS }).then(() => {}),
+  saveDebateSession: (session, _caller) => put('/api/debates', session, { timeoutMs: DEBATE_SAVE_TIMEOUT_MS }).then(() => {}),
   saveDebateDelta: (delta) => patchDebateDelta(delta),
   deleteDebateSession: (id) => del(`/api/debates/${encodeURIComponent(id)}`).then(() => {}),
   loadDebateComments: (id) => get(`/api/debates/${encodeURIComponent(id)}/comments`),

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
@@ -58,6 +58,7 @@ describe('saveDebate', () => {
 
     expect(mockApi.saveDebateSession).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'session-1' }),
+      expect.any(String),
     );
   });
 

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -759,7 +759,7 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
       session.active_povers = normalizeActivePovers(session.active_povers);
       session.title = newTitle;
       session.updated_at = nowISO();
-      await api.saveDebateSession(session);
+      await api.saveDebateSession(session, 'renameDebate');
       if (get().activeDebateId === id) {
         set({ activeDebate: session });
       }

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -239,7 +239,7 @@ async function persistDebateToServer(activeDebate: DebateSession, saveDiag: Save
     const nextVersion = baseVersion + 1;
     activeDebate._saveVersion = nextVersion;
     const sent = structuredClone(activeDebate);
-    await api.saveDebateSession(activeDebate);
+    await api.saveDebateSession(activeDebate, saveDiag.caller);
     set({ _lastSyncedSnapshot: sent, _lastSyncedVersion: nextVersion });
     recordSaved('full', nextVersion);
   };
@@ -247,7 +247,7 @@ async function persistDebateToServer(activeDebate: DebateSession, saveDiag: Save
   if (isElectronMode()) {
     // Electron desktop: local full-save, no version bookkeeping (deltas are
     // a web-only optimization).
-    await api.saveDebateSession(activeDebate);
+    await api.saveDebateSession(activeDebate, saveDiag.caller);
     recordSaved('electron');
   } else if (_lastSyncedVersion === null || _lastSyncedSnapshot === null) {
     // Web, first save of a freshly-created (never-synced) session.
@@ -408,7 +408,7 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
         : undefined,
       origin: { mode: 'gui' },
     };
-    await api.saveDebateSession(session);
+    await api.saveDebateSession(session, 'createDebate');
     api.trackEvent('debate_start', 'debate', { topic: session.title, protocol: protocolId || 'structured' });
     trackDebateStart(id, session.title, protocolId || 'structured');
     const aiPoversForOrder = AI_POVERS.filter(p => povers.includes(p));

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/store.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/store.ts
@@ -106,9 +106,9 @@ if (typeof window !== 'undefined') {
           timestamp: new Date().toISOString(),
         },
       };
-      void api.saveDebateSession(session);
+      void api.saveDebateSession(session, 'beforeunload:interrupted-turn');
     } else {
-      void api.saveDebateSession(state.activeDebate);
+      void api.saveDebateSession(state.activeDebate, 'beforeunload');
     }
   });
 }

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -119,7 +119,7 @@ export interface ElectronAPI {
   // Debate sessions
   listDebateSessions: () => Promise<unknown[]>;
   loadDebateSession: (id: string) => Promise<unknown>;
-  saveDebateSession: (session: unknown) => Promise<void>;
+  saveDebateSession: (session: unknown, caller: string) => Promise<void>;
   deleteDebateSession: (id: string) => Promise<void>;
   exportDebateToFile: (session: unknown, format?: string, exportOptions?: { includeTaxonomyRefs?: boolean; includeReasoning?: boolean }) => Promise<{ cancelled: boolean; filePath?: string }>;
   loadDebateComments: (debateId: string) => Promise<unknown>;


### PR DESCRIPTION
## Summary
- Threads caller: string through saveDebateSession so state.save FR events record the originating call path
- IPC handler (debateHandlers.ts), preload bridge (preload.cts), and renderer bridge layer all updated to match
- sessionSlice / store pass a meaningful caller string at each save site
- Test arity fixed for new signature

## Test plan
- [ ] 	sc -p tsconfig.main.json --noEmit clean
- [ ] 
px vitest run src/main/__tests__/debateIO.saveEnrich.test.ts passes
- [ ] Flight recorder state.save events show caller field in dumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)