### PR TITLE
feat(server): add required caller param to saveDebateSession (t/2328)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/applyDebateDeltaToStorage.test.ts
+++ b/taxonomy-editor/src/server/__tests__/applyDebateDeltaToStorage.test.ts
@@ -90,7 +90,7 @@ describe('applyDebateDeltaToStorage (t/1635)', () => {
 
   // Seed a stored debate via the normal save path so the on-disk shape matches prod.
   async function seed(session: Record<string, unknown>): Promise<void> {
-    await userContext.runWithUser(ctx, () => fileIO.saveDebateSession(session));
+    await userContext.runWithUser(ctx, () => fileIO.saveDebateSession(session, 'test'));
   }
 
   it('exact version match: merges, bumps _saveVersion, writes, returns { newVersion }', async () => {
@@ -139,7 +139,7 @@ describe('applyDebateDeltaToStorage (t/1635)', () => {
   it('anonymous path: merges and mirrors back into the anon store', async () => {
     // Seed through the anon store via the normal save path.
     await userContext.runWithUser(anonCtx, () =>
-      fileIO.saveDebateSession({ id: 'ad1', title: 'A', phase: 'rounds', _saveVersion: 1 }));
+      fileIO.saveDebateSession({ id: 'ad1', title: 'A', phase: 'rounds', _saveVersion: 1 }, 'test'));
 
     const delta = makeDelta({ debateId: 'ad1', baseVersion: 1, changedFields: { phase: 'synthesis' } });
     const result = await userContext.runWithUser(anonCtx, () => fileIO.applyDebateDeltaToStorage(delta));
@@ -156,7 +156,7 @@ describe('applyDebateDeltaToStorage (t/1635)', () => {
 
   it('anonymous stale baseVersion: throws 409 carrying currentVersion', async () => {
     await userContext.runWithUser(anonCtx, () =>
-      fileIO.saveDebateSession({ id: 'ad2', title: 'A2', _saveVersion: 4 }));
+      fileIO.saveDebateSession({ id: 'ad2', title: 'A2', _saveVersion: 4 }, 'test'));
     const delta = makeDelta({ debateId: 'ad2', baseVersion: 1 });
 
     await expect(
@@ -170,7 +170,7 @@ describe('applyDebateDeltaToStorage (t/1635)', () => {
 
     // Session A seeds a debate at version 2.
     await userContext.runWithUser(sessA, () =>
-      fileIO.saveDebateSession({ id: 'idor-debate', title: 'Owned by A', _saveVersion: 2 }));
+      fileIO.saveDebateSession({ id: 'idor-debate', title: 'Owned by A', _saveVersion: 2 }, 'test'));
 
     // Session B attempts to PATCH the same debate ID — must not find it.
     const delta = makeDelta({ debateId: 'idor-debate', baseVersion: 2 });

--- a/taxonomy-editor/src/server/__tests__/dualBackendRouting.test.ts
+++ b/taxonomy-editor/src/server/__tests__/dualBackendRouting.test.ts
@@ -57,7 +57,7 @@ describe('dual-backend routing (t/698)', () => {
   });
 
   it('routes debate saves to the user-content backend, not taxonomy', async () => {
-    await userContext.runWithUser(ctx, () => fileIO.saveDebateSession({ id: 'd1', title: 'D' }));
+    await userContext.runWithUser(ctx, () => fileIO.saveDebateSession({ id: 'd1', title: 'D' }, 'test'));
     expect(uc.has('debate-d1.json')).toBe(true);
     expect(tax.has('debate-d1.json')).toBe(false);
   });
@@ -81,7 +81,7 @@ describe('dual-backend routing (t/698)', () => {
   });
 
   it('debate read round-trips through the user-content backend', async () => {
-    await userContext.runWithUser(ctx, () => fileIO.saveDebateSession({ id: 'd2', title: 'Two' }));
+    await userContext.runWithUser(ctx, () => fileIO.saveDebateSession({ id: 'd2', title: 'Two' }, 'test'));
     const loaded = await userContext.runWithUser(ctx, () => fileIO.loadDebateSession('d2')) as { id: string };
     expect(loaded.id).toBe('d2');
   });
@@ -92,7 +92,7 @@ describe('dual-backend routing (t/698)', () => {
     fileIO.setUserContentBackend(undefined as unknown as StorageBackend);
     // getUserContentBackend() returns the taxonomy backend when unset.
     expect(fileIO.getUserContentBackend()).toBe(single);
-    await userContext.runWithUser(ctx, () => fileIO.saveDebateSession({ id: 'd3', title: 'Three' }));
+    await userContext.runWithUser(ctx, () => fileIO.saveDebateSession({ id: 'd3', title: 'Three' }, 'test'));
     expect(single.has('debate-d3.json')).toBe(true);
   });
 });

--- a/taxonomy-editor/src/server/__tests__/multiuser-integration.test.ts
+++ b/taxonomy-editor/src/server/__tests__/multiuser-integration.test.ts
@@ -128,14 +128,14 @@ describe('Multi-user data isolation (integration)', () => {
       await fileIO.saveDebateSession({
         id: 'debate-1', title: 'Alice Debate', phase: 'completed',
         created_at: '2026-01-01', updated_at: '2026-01-01', transcript: [],
-      });
+      }, 'test');
     });
 
     await userContext.runWithUser(userB, async () => {
       await fileIO.saveDebateSession({
         id: 'debate-2', title: 'Bob Debate', phase: 'completed',
         created_at: '2026-01-02', updated_at: '2026-01-02', transcript: [],
-      });
+      }, 'test');
     });
 
     const aliceDebates = await userContext.runWithUser(userA, () => fileIO.listDebateSessions());

--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -407,7 +407,7 @@ export async function copyFromCommunity(type: 'chats' | 'debates', communityId: 
   if (type === 'chats') {
     await saveChatSession(copy);
   } else {
-    await saveDebateSession(copy);
+    await saveDebateSession(copy, 'community-fork');
   }
 
   return { newId: copy.id as string };

--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -139,7 +139,7 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
       // t/700: user content (debates/chats/community) lives in Azure Blob, keyed by
       // storageUserId — no GitHub session branch needed. Closing the github-api
       // rollback window (authorized e/19#28).
-      await fileIO.saveDebateSession(body);
+      await fileIO.saveDebateSession(body, 'PUT /api/debates');
 
       await logCalibrationIfComplete(body);
       recordSlowSaveIfNeeded(debateId, body, startedAt);

--- a/taxonomy-editor/src/server/storage/debateStore.ts
+++ b/taxonomy-editor/src/server/storage/debateStore.ts
@@ -182,7 +182,7 @@ export async function getDebatesQuotaStatus(): Promise<QuotaCheckResult> {
   return checkQuota('debates', files.length);
 }
 
-export async function saveDebateSession(session: unknown): Promise<void> {
+export async function saveDebateSession(session: unknown, caller: string): Promise<void> {
   const s = session as { id: string; title?: string; topic?: { final?: string; original?: string }; created_at?: string; updated_at?: string; phase?: string };
   assertSafeId(s.id, 'debate id');
   if (isAnonymousUser()) { const a = getAnonStore(); if (a) await a.store.saveDebate(a.sessionId, session); return; }
@@ -200,6 +200,7 @@ export async function saveDebateSession(session: unknown): Promise<void> {
     log.server.warn({ debateId: s.id, errorMessage }, 'Debate session serialized with sanitizing replacer — non-serializable fields stripped');
   }
   await backend.writeFile(debatePath, json);
+  log.server.info({ caller, debateId: s.id }, 'Debate session saved');
   // Maintain the lightweight index
   void upsertDebateIndex({
     id: s.id,


### PR DESCRIPTION
## Summary
- Adds required `caller: string` param (no default) to `saveDebateSession` in `debateStore.ts` — enforces that every call site identifies itself at compile time
- Logs `server.info { caller, debateId }` on each successful write so the save path is always traceable in FR dumps
- Updates both call sites: `PUT /api/debates` route and `community-fork` path
- Updates 9 test call sites with `'test'` caller

## Test plan
- [ ] `applyDebateDeltaToStorage.test.ts` — 4 passed (seed calls updated)
- [ ] `dualBackendRouting.test.ts` — all passed
- [ ] `multiuser-integration.test.ts` — all passed
- [ ] `debatesInFlightGuard.test.ts` — all passed (mock unaffected)
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)