### PR TITLE
test(ontology): split SituationBDI gate test from live-data assertion + extract check helper (t/2332)

### DIFF
--- a/scripts/AITriad/Private/Test-SituationBdiDecomposition.ps1
+++ b/scripts/AITriad/Private/Test-SituationBdiDecomposition.ps1
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-SituationBdiDecomposition {
+    <#
+    .SYNOPSIS
+        Pure per-POV BDI-decomposition compliance logic for situation nodes.
+    .DESCRIPTION
+        Extracted from Test-OntologyCompliance (t/1312) so the check logic can be
+        unit-tested against synthetic fixtures independent of the live corpus
+        (t/2332 — decouple the live-data baseline from the required CI gate).
+
+        Every non-deprecated situation must carry an interpretations block where
+        {accelerationist, safetyist, skeptic} each hold a nested object with
+        non-empty belief + desire + intention. A situation is exempt when its
+        description starts with the '[DEPRECATED]' prefix (CL confirmed t/1312#2).
+
+        No I/O, no host output — callers format the pass/fail Detail line. This
+        keeps the CL-approved wording in Test-OntologyCompliance while the
+        classification logic lives here where it can be exercised directly.
+    .PARAMETER Node
+        Situation node object(s) (as parsed from situations.json). Accepts an
+        array or pipeline input; each must expose .id, and optionally
+        .description / .interpretations.
+    .OUTPUTS
+        [pscustomobject] with counts (Pass, NonDeprecated, Deprecated,
+        NonDecomposed, Empty, Fail) and capped id samples (NonDecomposedIds,
+        EmptyIds — first 10 each, matching the cmdlet's Detail sampling).
+    .EXAMPLE
+        $r = Test-SituationBdiDecomposition -Node $situations.nodes
+        if ($r.Fail -gt 0) { ... }
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(ValueFromPipeline = $true)]
+        [AllowNull()]
+        [object[]]$Node
+    )
+
+    begin {
+        Set-StrictMode -Version Latest
+
+        $pass = 0; $empty = 0; $nonDecomposed = 0; $nonDep = 0; $deprecated = 0
+        $nonDecomposedIds = [System.Collections.Generic.List[string]]::new()
+        $emptyIds         = [System.Collections.Generic.List[string]]::new()
+    }
+
+    process {
+        foreach ($N in @($Node)) {
+            if ($null -eq $N) { continue }
+
+            # Exemption: [DEPRECATED] description prefix (CL confirmed t/1312#2)
+            $desc = if ($N.PSObject.Properties['description']) { [string]$N.description } else { '' }
+            if ($desc.TrimStart().StartsWith('[DEPRECATED]')) {
+                $deprecated++
+                continue
+            }
+            $nonDep++
+
+            $interps = if ($N.PSObject.Properties['interpretations']) { $N.interpretations } else { $null }
+
+            # 'empty': block missing/null, or all three POV entries are falsy/blank
+            $hasAnyPov = $false
+            if ($interps) {
+                foreach ($pov in 'accelerationist', 'safetyist', 'skeptic') {
+                    if ($interps.PSObject.Properties[$pov]) {
+                        $val = $interps.$pov
+                        if ($val) { $hasAnyPov = $true; break }
+                    }
+                }
+            }
+            if (-not $hasAnyPov) {
+                $empty++
+                if ($emptyIds.Count -lt 10) { $emptyIds.Add([string]$N.id) }
+                continue
+            }
+
+            # Full-BDI: each POV entry must be a dict with non-empty belief/desire/intention
+            $allOk = $true
+            foreach ($pov in 'accelerationist', 'safetyist', 'skeptic') {
+                if (-not $interps.PSObject.Properties[$pov]) { $allOk = $false; break }
+                $p = $interps.$pov
+                # Reject strings (legacy flat text) — must be a nested object
+                if ($p -is [string]) { $allOk = $false; break }
+                if (-not $p -or -not $p.PSObject.Properties['belief'] -or -not $p.PSObject.Properties['desire'] -or -not $p.PSObject.Properties['intention']) {
+                    $allOk = $false; break
+                }
+                $b = if ($p.belief)    { [string]$p.belief    } else { '' }
+                $d = if ($p.desire)    { [string]$p.desire    } else { '' }
+                $i = if ($p.intention) { [string]$p.intention } else { '' }
+                if (-not $b.Trim() -or -not $d.Trim() -or -not $i.Trim()) { $allOk = $false; break }
+            }
+            if ($allOk) {
+                $pass++
+            } else {
+                $nonDecomposed++
+                if ($nonDecomposedIds.Count -lt 10) { $nonDecomposedIds.Add([string]$N.id) }
+            }
+        }
+    }
+
+    end {
+        [pscustomobject][ordered]@{
+            Pass             = $pass
+            NonDeprecated    = $nonDep
+            Deprecated       = $deprecated
+            NonDecomposed    = $nonDecomposed
+            Empty            = $empty
+            Fail             = $nonDecomposed + $empty
+            NonDecomposedIds = $nonDecomposedIds.ToArray()
+            EmptyIds         = $emptyIds.ToArray()
+        }
+    }
+}

--- a/scripts/AITriad/Public/Test-OntologyCompliance.ps1
+++ b/scripts/AITriad/Public/Test-OntologyCompliance.ps1
@@ -379,67 +379,24 @@ function Test-OntologyCompliance {
     # Every non-deprecated situation must carry a proper interpretations block where
     # {accelerationist, safetyist, skeptic} each have non-empty belief + desire +
     # intention. Deprecation is signalled by a description that starts with '[DEPRECATED]'.
-    $SitPass = 0
-    $SitEmpty = 0
-    $SitNonDecomposed = 0
-    $SitNonDep = 0
-    $SitDeprecated = 0
-    $SitNonDecomposedIds = [System.Collections.Generic.List[string]]::new()
-    $SitEmptyIds        = [System.Collections.Generic.List[string]]::new()
-    foreach ($Entry in $AllNodes.Values) {
-        if ($Entry.POV -ne 'situations') { continue }
-        $N = $Entry.Node
-
-        # Exemption: [DEPRECATED] description prefix (CL confirmed t/1312#2)
-        $Desc = if ($N.PSObject.Properties['description']) { [string]$N.description } else { '' }
-        if ($Desc.TrimStart().StartsWith('[DEPRECATED]')) {
-            $SitDeprecated++
-            continue
-        }
-        $SitNonDep++
-
-        $Interps = if ($N.PSObject.Properties['interpretations']) { $N.interpretations } else { $null }
-
-        # 'empty': block missing/null, or all three POV entries are falsy/blank
-        $HasAnyPov = $false
-        if ($Interps) {
-            foreach ($Pov in 'accelerationist','safetyist','skeptic') {
-                if ($Interps.PSObject.Properties[$Pov]) {
-                    $Val = $Interps.$Pov
-                    if ($Val) { $HasAnyPov = $true; break }
-                }
-            }
-        }
-        if (-not $HasAnyPov) {
-            $SitEmpty++
-            if ($SitEmptyIds.Count -lt 10) { $SitEmptyIds.Add([string]$N.id) }
-            continue
-        }
-
-        # Full-BDI: each POV entry must be a dict with non-empty belief/desire/intention
-        $AllOk = $true
-        foreach ($Pov in 'accelerationist','safetyist','skeptic') {
-            if (-not $Interps.PSObject.Properties[$Pov]) { $AllOk = $false; break }
-            $P = $Interps.$Pov
-            # Reject strings (legacy flat text) — must be a nested object
-            if ($P -is [string]) { $AllOk = $false; break }
-            if (-not $P -or -not $P.PSObject.Properties['belief'] -or -not $P.PSObject.Properties['desire'] -or -not $P.PSObject.Properties['intention']) {
-                $AllOk = $false; break
-            }
-            $B = if ($P.belief)    { [string]$P.belief    } else { '' }
-            $D = if ($P.desire)    { [string]$P.desire    } else { '' }
-            $I = if ($P.intention) { [string]$P.intention } else { '' }
-            if (-not $B.Trim() -or -not $D.Trim() -or -not $I.Trim()) { $AllOk = $false; break }
-        }
-        if ($AllOk) {
-            $SitPass++
-        } else {
-            $SitNonDecomposed++
-            if ($SitNonDecomposedIds.Count -lt 10) { $SitNonDecomposedIds.Add([string]$N.id) }
-        }
+    # Classification logic extracted to the Private helper Test-SituationBdiDecomposition
+    # (t/2332) so it can be unit-tested against synthetic fixtures independent of the live
+    # corpus — the live-data NNN/NNN baseline now lives in the data-triggered compliance
+    # job (tests/data-compliance/), not this required gate. CL-approved Detail wording
+    # (t/1312#2) stays here, below.
+    $SitNodes = foreach ($Entry in $AllNodes.Values) {
+        if ($Entry.POV -eq 'situations') { $Entry.Node }
     }
+    $SitResult = Test-SituationBdiDecomposition -Node @($SitNodes)
+    $SitPass             = $SitResult.Pass
+    $SitNonDep           = $SitResult.NonDeprecated
+    $SitDeprecated       = $SitResult.Deprecated
+    $SitNonDecomposed    = $SitResult.NonDecomposed
+    $SitEmpty            = $SitResult.Empty
+    $SitNonDecomposedIds = @($SitResult.NonDecomposedIds)
+    $SitEmptyIds         = @($SitResult.EmptyIds)
 
-    $SitFail = $SitNonDecomposed + $SitEmpty
+    $SitFail = $SitResult.Fail
     if ($SitFail -eq 0) {
         Add-Check -Category 'BDI' `
             -Check   'Situation interpretations: per-POV BDI decomposition' `

--- a/tests/Test-OntologyCompliance.SituationBDI.Tests.ps1
+++ b/tests/Test-OntologyCompliance.SituationBDI.Tests.ps1
@@ -6,12 +6,15 @@
 
 <#
 .SYNOPSIS
-    Tests for the situation BDI-decomposition compliance check added to
-    Test-OntologyCompliance under t/1312. Wording approved by CL at t/1312#2.
+    Gate tests for the situation BDI-decomposition compliance check in
+    Test-OntologyCompliance (t/1312, wording approved by CL at t/1312#2).
 .NOTES
-    Live-data baseline may shift as t/1306 backfill lands. Update the
-    128/283 numbers when that happens — that's the intended way this
-    regression trip-wire records backfill progress.
+    These tests verify the *check logic* — presence, CL-approved wording, Detail
+    shape, and (fixture-based) correct classification of non-decomposed nodes.
+    They do NOT assert the live-corpus NNN/NNN count: that live-data baseline was
+    moved to tests/data-compliance/ (t/2332) so a situations-data change can no
+    longer red this required merge gate. See the data-compliance suite for the
+    live count trip-wire.
 #>
 
 BeforeAll {
@@ -40,6 +43,7 @@ Describe 'Situation BDI-decomposition compliance check (t/1312)' -Tag 'taxonomy'
     It 'The Detail line has the CL-approved shape (pass/total accounting)' {
         # Both pass and fail states share the "$Pass / $NonDep non-deprecated" prefix.
         # Fail-state breakdown (non-decomposed / missing) only appears when status=='fail'.
+        # Shape only — no exact count — so live-corpus drift can't break this gate.
         $script:BdiCheck.Detail | Should -Match '\d+ / \d+ non-deprecated situations'
         if ($script:BdiCheck.Status -eq 'fail') {
             $script:BdiCheck.Detail | Should -Match 'belief \+ desire \+ intention'
@@ -65,39 +69,91 @@ Describe 'Situation BDI-decomposition compliance check (t/1312)' -Tag 'taxonomy'
             $script:BdiCheck.Fix | Should -Match 'Invoke-AIByUsage'
         }
     }
+}
 
-    It 'Live-data baseline: 440 / 440 non-deprecated situations pass, 1 exempt (post-t/2323 backfill)' {
-        # Trip-wire updated after CL's t/1306 backfill merged (CL sign-off p/23#62,
-        # data-repo commit f202ddd2). Situation corpus is now fully BDI-decomposed;
-        # the 1 exempt node uses the [DEPRECATED] description prefix per CL's Q1 answer.
-        # Baseline bumped 411->412 for t/1655: corpus grew by one net compliant
-        # non-deprecated situation (CL-confirmed via live Test-OntologyCompliance).
-        # Baseline bumped 412->435 for t/1805: the workflow-app v1.0.0 pipeline wrote
-        # 23 new situations (sit-448..470) un-enriched (pre-decomposition string/empty
-        # interpretations). The trip-wire fired correctly; the 23 were decomposed via
-        # enrichment.situation-bdi-decomposition (existing narrative preserved) and
-        # merged with CL sign-off. Creation-path gap tracked separately (t/1805 step 2).
-        # Baseline bumped 435->440 for t/2323: 5 new situations (sit-471..475) added
-        # with flat-string interpretations; decomposed via enrichment.situation-bdi-decomposition.
-        $script:BdiCheck.Status | Should -Be 'pass'
-        $script:BdiCheck.Detail | Should -Match '440 / 440'
-        $script:BdiCheck.Detail | Should -Match '1 exempt via \[DEPRECATED\] prefix'
+Describe 'Situation BDI-decomposition classification logic (fixture-based, t/2332)' -Tag 'taxonomy' {
+    # The live-data NNN/NNN baseline moved to tests/data-compliance/ so it no longer
+    # gates code merges. This suite keeps the *logic* covered in the required gate by
+    # driving the extracted Private helper (Test-SituationBdiDecomposition) with a
+    # synthetic fixture — decoupled from live corpus size. Fixture is JSON parsed via
+    # ConvertFrom-Json so node shape matches production (situations.json) exactly.
+
+    BeforeAll {
+        $script:FixtureJson = @'
+{
+  "nodes": [
+    {
+      "id": "sit-fixture-pass",
+      "description": "A situation that is fully decomposed across all three POVs.",
+      "interpretations": {
+        "accelerationist": { "belief": "b", "desire": "d", "intention": "i" },
+        "safetyist":       { "belief": "b", "desire": "d", "intention": "i" },
+        "skeptic":         { "belief": "b", "desire": "d", "intention": "i" }
+      }
+    },
+    {
+      "id": "sit-fixture-flatstring",
+      "description": "A situation with legacy flat-string interpretations.",
+      "interpretations": {
+        "accelerationist": "accelerationists welcome this",
+        "safetyist":       "safetyists worry about this",
+        "skeptic":         "skeptics doubt this"
+      }
+    },
+    {
+      "id": "sit-fixture-missingblock",
+      "description": "A situation with no interpretations block at all."
+    },
+    {
+      "id": "sit-fixture-partialbdi",
+      "description": "A situation where one POV is missing the intention field.",
+      "interpretations": {
+        "accelerationist": { "belief": "b", "desire": "d", "intention": "i" },
+        "safetyist":       { "belief": "b", "desire": "d" },
+        "skeptic":         { "belief": "b", "desire": "d", "intention": "i" }
+      }
+    },
+    {
+      "id": "sit-fixture-deprecated",
+      "description": "[DEPRECATED] superseded situation, exempt from the check.",
+      "interpretations": {}
+    }
+  ]
+}
+'@
+        $script:Fixture = $script:FixtureJson | ConvertFrom-Json
+        $script:Result = InModuleScope AITriad -Parameters @{ Nodes = $script:Fixture.nodes } {
+            param($Nodes)
+            Test-SituationBdiDecomposition -Node $Nodes
+        }
     }
 
-    It 'Deprecation is signalled by the [DEPRECATED] description prefix (CL Q1 answer)' {
-        # Verify the fixture we ran against carries at least one [DEPRECATED] situation
-        # so the exemption path was exercised.
-        InModuleScope AITriad {
-            $tax = Get-TaxonomyDir
-            $sitPath = Join-Path $tax 'situations.json'
-            Test-Path $sitPath | Should -Be $true
-            $sit = Get-Content -Raw -Path $sitPath -Encoding utf8 | ConvertFrom-Json
-            $deprecated = @($sit.nodes | Where-Object {
-                $_.PSObject.Properties['description'] -and
-                ([string]$_.description).TrimStart().StartsWith('[DEPRECATED]')
-            })
-            $deprecated.Count | Should -BeGreaterThan 0
-        }
+    It 'Counts the fully-decomposed situation as passing' {
+        $script:Result.Pass | Should -Be 1
+    }
+
+    It 'Flags the legacy flat-string interpretation as non-decomposed' {
+        $script:Result.NonDecomposedIds | Should -Contain 'sit-fixture-flatstring'
+    }
+
+    It 'Flags a POV missing the intention field as non-decomposed' {
+        $script:Result.NonDecomposedIds | Should -Contain 'sit-fixture-partialbdi'
+        $script:Result.NonDecomposed | Should -Be 2
+    }
+
+    It 'Flags the missing interpretations block as empty' {
+        $script:Result.EmptyIds | Should -Contain 'sit-fixture-missingblock'
+        $script:Result.Empty | Should -Be 1
+    }
+
+    It 'Exempts the [DEPRECATED]-prefixed situation from the non-deprecated set' {
+        $script:Result.Deprecated | Should -Be 1
+        # 5 nodes total, 1 deprecated → 4 non-deprecated evaluated
+        $script:Result.NonDeprecated | Should -Be 4
+    }
+
+    It 'Reports total failures = non-decomposed + empty' {
+        $script:Result.Fail | Should -Be 3
     }
 }
 

--- a/tests/data-compliance/Test-SituationBDI.LiveData.Tests.ps1
+++ b/tests/data-compliance/Test-SituationBDI.LiveData.Tests.ps1
@@ -1,0 +1,69 @@
+# Tag: taxonomy, DataCompliance (t/1312, relocated t/2332)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Live-data compliance trip-wire for the situation BDI-decomposition check.
+    Asserts the current situations corpus (../ai-triad-data) is fully decomposed.
+.NOTES
+    RELOCATED from the required `test-powershell` merge gate to a data-triggered /
+    scheduled job (t/2324 TL decision; t/2331 DevOps job; t/2332 PowerShell move).
+
+    WHY THIS IS NOT A CODE GATE: this asserts an exact live-corpus count, which is a
+    property of the DATA repo, not of any code change. Sitting it in the code merge
+    gate coupled every unrelated code PR to data-corpus completeness — a single
+    non-decomposed situation (sit-471..475, t/2323) reds the whole fleet. It now runs
+    where the data actually changes; regressions alert the data/PS owner instead of
+    blocking code merges. The check *logic* stays covered in the code gate via a
+    fixture-based test (tests/Test-OntologyCompliance.SituationBDI.Tests.ps1, t/2332).
+
+    UPDATING THE BASELINE is still the intended way to record backfill progress:
+    - 411->412 (t/1655): corpus grew by one net compliant non-deprecated situation.
+    - 412->435 (t/1805): workflow-app v1.0.0 wrote sit-448..470 un-enriched; decomposed
+      via enrichment.situation-bdi-decomposition, merged with CL sign-off.
+    - 435->440 (t/2323): sit-471..475 added with flat-string interpretations; decomposed
+      via enrichment.situation-bdi-decomposition.
+    When this trip-wire fires, run the backfill on the flagged ids, then bump the count.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    $script:Ontology = Test-OntologyCompliance -Quiet -PassThru -ErrorAction Continue 2>$null
+    $script:BdiCheck = $script:Ontology.Checks |
+        Where-Object { $_.Category -eq 'BDI' -and $_.Check -like '*BDI decomposition*' } |
+        Select-Object -First 1
+}
+
+Describe 'Situation BDI-decomposition live-data baseline (t/1312, relocated t/2332)' -Tag 'taxonomy', 'DataCompliance' {
+
+    It 'The BDI-decomposition check is present against the live corpus' {
+        $script:BdiCheck | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Live-data baseline: 440 / 440 non-deprecated situations pass, 1 exempt (post-t/2323 backfill)' {
+        $script:BdiCheck.Status | Should -Be 'pass'
+        $script:BdiCheck.Detail | Should -Match '440 / 440'
+        $script:BdiCheck.Detail | Should -Match '1 exempt via \[DEPRECATED\] prefix'
+    }
+
+    It 'Deprecation is signalled by the [DEPRECATED] description prefix (CL Q1 answer)' {
+        # Verify the live corpus carries at least one [DEPRECATED] situation so the
+        # exemption path is exercised against real data.
+        InModuleScope AITriad {
+            $tax = Get-TaxonomyDir
+            $sitPath = Join-Path $tax 'situations.json'
+            Test-Path $sitPath | Should -Be $true
+            $sit = Get-Content -Raw -Path $sitPath -Encoding utf8 | ConvertFrom-Json
+            $deprecated = @($sit.nodes | Where-Object {
+                $_.PSObject.Properties['description'] -and
+                ([string]$_.description).TrimStart().StartsWith('[DEPRECATED]')
+            })
+            $deprecated.Count | Should -BeGreaterThan 0
+        }
+    }
+}


### PR DESCRIPTION
Implements the PowerShell half of **t/2332** (parent t/2324) — decouples the SituationBDI check from live-corpus completeness so a situations-data change can no longer red the required `test-powershell` merge gate (the t/2323 fleet blocker). Per TL decision t/2324#1 (decouple + prevent; drift-tolerant % rejected).

## What changed
- **Extract check logic** → new pure Private helper `Test-SituationBdiDecomposition` (no I/O, returns counts + id samples). `Test-OntologyCompliance` now calls it; the CL-approved Detail wording (t/1312#2) is unchanged.
- **Gate test** (`tests/Test-OntologyCompliance.SituationBDI.Tests.ps1`): drop the live `440/440` count assertions; add a **fixture-based** logic suite driving the helper with a synthetic JSON corpus (pass / flat-string / partial-BDI / empty / [DEPRECATED]). Presence/wording/shape tests stay — all corpus-size-independent.
- **Relocate** the live-data `NNN/NNN` trip-wire → `tests/data-compliance/Test-SituationBDI.LiveData.Tests.ps1`, tagged `DataCompliance`, for the DevOps data-triggered/scheduled job (**t/2331**) to run. Gate exclusion is **path-based** (`tests/data-compliance/`) per p/227.

## Coverage / sequencing
No gap: the live trip-wire still runs (in the gate too) until DevOps lands `ExcludePath`. This PR can land first; t/2331 then adds `ExcludePath` + the scheduled job.

**Part 2** (write-time BDI enforcement in the workflow-app pipeline) is cross-scope and tracked separately on t/2332.

## Verification
- Full Pester suite: **972 passed / 0 failed / 51 skipped**.
- New/changed test files: **15/15 pass** (6 fixture logic + 3 live-data + shape/presence + ingestion no-op).
- `Test-ModuleManifest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)