### PR TITLE
fix(taxonomy): fail-closed write-time BDI decomposition for new situations (t/2332)

### DIFF
--- a/scripts/AITriad/Private/Invoke-ProposalApply.ps1
+++ b/scripts/AITriad/Private/Invoke-ProposalApply.ps1
@@ -49,8 +49,10 @@ function Invoke-ProposalApply {
 
     switch ($Proposal.action) {
         'NEW' {
-            # Validate node ID format + category consistency
-            try { Test-PovNodeId -Id $Proposal.suggested_id -Category $Proposal.category } catch {
+            # Validate node ID format + category consistency. $null = suppresses
+            # Test-PovNodeId's $true return so it doesn't pollute the function's
+            # result-object output stream (t/2332 pipeline hygiene).
+            try { $null = Test-PovNodeId -Id $Proposal.suggested_id -Category $Proposal.category } catch {
                 return [PSCustomObject]@{ Success = $false; Error = $_.Exception.Message }
             }
 
@@ -94,6 +96,22 @@ function Invoke-ProposalApply {
             # t/1550 — generate aphorism on create. Fail-open (Set-NodeAphorism
             # skips situations/pillars and returns without mutating on AI failure).
             Set-NodeAphorism -Node $NodeObj -Pov $Proposal.pov -Reason 'proposal-NEW'
+
+            # t/2332 — write-time BDI-decomposition enforcement for new situations.
+            # A cross-cutting node is minted with empty interpretations above; decompose
+            # it into per-POV BDI at creation so a non-compliant situation is never
+            # committed (the sit-471..475 / t/2323 regression). FAIL-CLOSED (TL t/2332#4):
+            # on persistent enrichment failure, skip this single proposal (additive) rather
+            # than commit an empty-interpretation node. The scheduled trip-wire is a
+            # backstop, not the primary guard.
+            if ($IsCrossCutting) {
+                try {
+                    Set-SituationBdiInterpretation -Node $NodeObj
+                }
+                catch {
+                    return [PSCustomObject]@{ Success = $false; Error = $_.Exception.Message }
+                }
+            }
             $Raw.nodes += $NodeObj
         }
 

--- a/scripts/AITriad/Private/Set-SituationBdiInterpretation.ps1
+++ b/scripts/AITriad/Private/Set-SituationBdiInterpretation.ps1
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Set-SituationBdiInterpretation {
+    <#
+    .SYNOPSIS
+        Populate a situation node's per-POV BDI interpretations at creation time.
+    .DESCRIPTION
+        Write-time enforcement of the situation BDI-decomposition invariant (t/2332,
+        TL decision t/2324#1). New cross-cutting (situation) nodes are otherwise minted
+        with empty interpretations (Invoke-ProposalApply) and only caught later by the
+        scheduled compliance trip-wire (tests/data-compliance/) — the mechanism behind
+        the sit-448..470 (t/1805) and sit-471..475 (t/2323) regressions.
+
+        Calls the CL-owned UsageID 'enrichment.situation-bdi-decomposition' (reused, not
+        forked) with a flash-lite backend fallback so a transient failure on the primary
+        model does not block the pipeline. On SUCCESS it mutates $Node.interpretations in
+        place to the per-POV {belief, desire, intention, summary} shape.
+
+        FAIL-CLOSED (TL, t/2332#4): unlike the cosmetic aphorism (Set-NodeAphorism, which
+        is fail-open), BDI decomposition is the load-bearing invariant this gate exists
+        for. On persistent failure — AI error after fallback, empty/invalid response, or
+        an incomplete decomposition (any POV missing a non-empty belief/desire/intention)
+        — this throws an ActionableError. The caller rejects that single proposal (per-node
+        skip; proposals are additive) rather than committing a non-compliant node.
+    .PARAMETER Node
+        The situation node object to enrich in place. Must expose .id, .label,
+        .description, and a settable .interpretations property.
+    .OUTPUTS
+        None. Mutates $Node.interpretations on success; throws on failure.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [psobject]$Node
+    )
+
+    Set-StrictMode -Version Latest
+
+    $sitId = [string]$Node.id
+    $label = if ($Node.PSObject.Properties['label']) { [string]$Node.label } else { '' }
+    $desc  = if ($Node.PSObject.Properties['description']) { [string]$Node.description } else { '' }
+
+    # Render the existing per-POV interpretations (empty at mint, or legacy flat text)
+    # as anchor context for the decomposition.
+    $existingLines = foreach ($pov in 'accelerationist', 'safetyist', 'skeptic') {
+        $val = ''
+        if ($Node.PSObject.Properties['interpretations'] -and $Node.interpretations -and
+            $Node.interpretations.PSObject.Properties[$pov]) {
+            $raw = $Node.interpretations.$pov
+            if ($raw -is [string]) { $val = $raw }
+            elseif ($raw -and $raw.PSObject.Properties['summary']) { $val = [string]$raw.summary }
+        }
+        if ([string]::IsNullOrWhiteSpace($val)) { "${pov}: (none)" } else { "${pov}: $val" }
+    }
+    $existing = $existingLines -join "`n"
+
+    $fail = {
+        param($Problem)
+        throw (New-ActionableError -PassThru `
+            -Goal "Decompose situation '$sitId' into per-POV BDI interpretations at creation" `
+            -Problem $Problem `
+            -Location 'Set-SituationBdiInterpretation' `
+            -NextSteps @(
+                "The situation proposal was skipped fail-closed so a non-decomposed node is not committed (t/2332).",
+                "Re-run the proposal apply once the AI backend recovers, or run enrichment.situation-bdi-decomposition on '$sitId' manually via Invoke-AIByUsage.",
+                'If this recurs, check AI backend availability and the gemini-3.5-flash-lite fallback key.'
+            ))
+    }
+
+    try {
+        $result = Invoke-AIByUsage -UsageId 'enrichment.situation-bdi-decomposition' `
+            -Values @{
+                situation_id             = $sitId
+                label                    = $label
+                description              = $desc
+                existing_interpretations = $existing
+            } `
+            -FallbackModels 'gemini-3.5-flash-lite'
+    }
+    catch {
+        & $fail "AI enrichment failed after backend fallback: $($_.Exception.Message)"
+    }
+
+    if (-not $result -or -not $result.Text) {
+        & $fail 'AI enrichment returned an empty response.'
+    }
+
+    # Strip ```json fences (mirrors Repair-PovLineage parse pattern) then parse.
+    $clean = [string]$result.Text -replace '^\s*```json\s*', '' -replace '\s*```\s*$', ''
+    try {
+        $bdi = $clean | ConvertFrom-Json
+    }
+    catch {
+        & $fail "AI response was not valid JSON: $($_.Exception.Message)"
+    }
+
+    # Validate + build the compliant interpretations block. Every POV must carry a
+    # non-empty belief + desire + intention (the exact predicate the gate enforces).
+    $newInterps = [ordered]@{}
+    foreach ($pov in 'accelerationist', 'safetyist', 'skeptic') {
+        if (-not $bdi.PSObject.Properties[$pov] -or -not $bdi.$pov) {
+            & $fail "Decomposition is missing the '$pov' POV."
+        }
+        $p = $bdi.$pov
+        $belief    = if ($p.PSObject.Properties['belief'])    { [string]$p.belief }    else { '' }
+        $desire    = if ($p.PSObject.Properties['desire'])    { [string]$p.desire }    else { '' }
+        $intention = if ($p.PSObject.Properties['intention']) { [string]$p.intention } else { '' }
+        $summary   = if ($p.PSObject.Properties['summary'])   { [string]$p.summary }   else { '' }
+        if (-not $belief.Trim() -or -not $desire.Trim() -or -not $intention.Trim()) {
+            & $fail "POV '$pov' is missing a non-empty belief, desire, or intention."
+        }
+        $newInterps[$pov] = [pscustomobject][ordered]@{
+            belief    = $belief
+            desire    = $desire
+            intention = $intention
+            summary   = $summary
+        }
+    }
+
+    $Node.interpretations = [pscustomobject]$newInterps
+}

--- a/tests/Set-SituationBdiInterpretation.Tests.ps1
+++ b/tests/Set-SituationBdiInterpretation.Tests.ps1
@@ -1,0 +1,165 @@
+# Tag: taxonomy (t/2332)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for write-time BDI-decomposition enforcement on new situation nodes
+    (t/2332, TL fail-closed decision t/2332#4).
+.NOTES
+    Set-SituationBdiInterpretation (Private) enriches a minted situation node's
+    interpretations via the CL-owned UsageID and FAILS CLOSED on any persistent
+    failure. Invoke-ProposalApply skips that single proposal (per-node, additive)
+    rather than committing a non-compliant node. AI is mocked — no live calls.
+
+    The fixture node is built in script scope and passed into InModuleScope via
+    -Parameters (a PSCustomObject is a reference, so in-scope mutations are visible
+    to the assertions here). Fixtures defined in BeforeAll are NOT visible inside
+    InModuleScope, which runs in the module's scope — hence the explicit passing.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    function New-FixtureSituationNode {
+        # Mirrors the shape minted in Invoke-ProposalApply (NEW + situations).
+        [pscustomobject][ordered]@{
+            id              = 'sit-fixture-900'
+            label           = 'A contested AGI governance scenario'
+            description     = 'A situation where camps disagree on AGI oversight.'
+            interpretations = [pscustomobject][ordered]@{
+                accelerationist = ''
+                safetyist       = ''
+                skeptic         = ''
+            }
+            linked_nodes    = @()
+            conflict_ids    = @()
+        }
+    }
+
+    $script:GoodBdiJson = @'
+{
+  "accelerationist": { "belief": "b-acc", "desire": "d-acc", "intention": "i-acc", "summary": "s-acc" },
+  "safetyist":       { "belief": "b-saf", "desire": "d-saf", "intention": "i-saf", "summary": "s-saf" },
+  "skeptic":         { "belief": "b-skp", "desire": "d-skp", "intention": "i-skp", "summary": "s-skp" }
+}
+'@
+}
+
+Describe 'Set-SituationBdiInterpretation — success path (t/2332)' -Tag 'taxonomy' {
+
+    It 'Populates all three POVs with non-empty belief/desire/intention/summary' {
+        $node = New-FixtureSituationNode
+        InModuleScope AITriad -Parameters @{ Node = $node; Good = $script:GoodBdiJson } {
+            param($Node, $Good)
+            Mock Invoke-AIByUsage { [pscustomobject]@{ Text = $Good } }
+            Set-SituationBdiInterpretation -Node $Node
+        }
+        foreach ($pov in 'accelerationist', 'safetyist', 'skeptic') {
+            $node.interpretations.$pov.belief    | Should -Not -BeNullOrEmpty
+            $node.interpretations.$pov.desire    | Should -Not -BeNullOrEmpty
+            $node.interpretations.$pov.intention | Should -Not -BeNullOrEmpty
+            $node.interpretations.$pov.summary   | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'Strips a ```json code fence before parsing' {
+        $node = New-FixtureSituationNode
+        $fenced = '```json' + "`n" + $script:GoodBdiJson + "`n" + '```'
+        InModuleScope AITriad -Parameters @{ Node = $node; Fenced = $fenced } {
+            param($Node, $Fenced)
+            Mock Invoke-AIByUsage { [pscustomobject]@{ Text = $Fenced } }
+            { Set-SituationBdiInterpretation -Node $Node } | Should -Not -Throw
+        }
+        $node.interpretations.skeptic.belief | Should -Be 'b-skp'
+    }
+
+    It 'Passes a flash-lite backend fallback to the enrichment call' {
+        $node = New-FixtureSituationNode
+        InModuleScope AITriad -Parameters @{ Node = $node; Good = $script:GoodBdiJson } {
+            param($Node, $Good)
+            Mock Invoke-AIByUsage { [pscustomobject]@{ Text = $Good } }
+            Set-SituationBdiInterpretation -Node $Node
+            Should -Invoke Invoke-AIByUsage -Times 1 -ParameterFilter {
+                $UsageId -eq 'enrichment.situation-bdi-decomposition' -and
+                $FallbackModels -contains 'gemini-3.5-flash-lite'
+            }
+        }
+    }
+}
+
+Describe 'Set-SituationBdiInterpretation — fail-closed paths (t/2332)' -Tag 'taxonomy' {
+
+    It 'Throws when the AI call throws (after fallback) and leaves the node un-mutated' {
+        $node = New-FixtureSituationNode
+        InModuleScope AITriad -Parameters @{ Node = $node } {
+            param($Node)
+            Mock Invoke-AIByUsage { throw 'backend exhausted' }
+            { Set-SituationBdiInterpretation -Node $Node } | Should -Throw
+        }
+        # Never mutated to a compliant-looking block — still the empty mint state.
+        $node.interpretations.accelerationist | Should -Be ''
+    }
+
+    It 'Throws on an empty AI response' {
+        $node = New-FixtureSituationNode
+        InModuleScope AITriad -Parameters @{ Node = $node } {
+            param($Node)
+            Mock Invoke-AIByUsage { [pscustomobject]@{ Text = '' } }
+            { Set-SituationBdiInterpretation -Node $Node } | Should -Throw
+        }
+    }
+
+    It 'Throws on invalid JSON' {
+        $node = New-FixtureSituationNode
+        InModuleScope AITriad -Parameters @{ Node = $node } {
+            param($Node)
+            Mock Invoke-AIByUsage { [pscustomobject]@{ Text = 'not json at all' } }
+            { Set-SituationBdiInterpretation -Node $Node } | Should -Throw
+        }
+    }
+
+    It 'Throws on an incomplete decomposition (a POV missing intention)' {
+        $node = New-FixtureSituationNode
+        $partial = @'
+{
+  "accelerationist": { "belief": "b", "desire": "d", "intention": "i", "summary": "s" },
+  "safetyist":       { "belief": "b", "desire": "d", "intention": "",  "summary": "s" },
+  "skeptic":         { "belief": "b", "desire": "d", "intention": "i", "summary": "s" }
+}
+'@
+        InModuleScope AITriad -Parameters @{ Node = $node; Partial = $partial } {
+            param($Node, $Partial)
+            Mock Invoke-AIByUsage { [pscustomobject]@{ Text = $Partial } }
+            { Set-SituationBdiInterpretation -Node $Node } | Should -Throw
+        }
+    }
+}
+
+Describe 'Invoke-ProposalApply — per-node skip on enrichment failure (t/2332)' -Tag 'taxonomy' {
+
+    It 'Rejects a situation NEW proposal (Success=false) when BDI enrichment fails — before any write' {
+        # Read-only: the fail-closed path returns before $Raw.nodes is appended or the
+        # file is written, so this exercises the real Invoke-ProposalApply against the
+        # live situations.json without mutating it. sit-99901 passes Test-PovNodeId
+        # (^sit-\d{3,}$) and is far above the real corpus so the collision check clears.
+        InModuleScope AITriad {
+            Mock Set-SituationBdiInterpretation { throw 'enrichment failed' }
+            $proposal = [pscustomobject]@{
+                action       = 'NEW'
+                pov          = 'situations'
+                suggested_id = 'sit-99901'
+                category     = $null
+                label        = 'A contested scenario that fails enrichment'
+                description  = 'A fresh situation node whose decomposition errors out.'
+            }
+            $result = Invoke-ProposalApply -Proposal $proposal
+            $result.Success | Should -Be $false
+            $result.Error   | Should -Match 'enrichment failed'
+            Should -Invoke Set-SituationBdiInterpretation -Times 1
+        }
+    }
+}


### PR DESCRIPTION
Implements **Part 2 of t/2332** (parent t/2324) — the durable, write-time half of the SituationBDI decouple. Part 1 (#674, merged) moved the live-data assertion out of the merge gate; this stops situations from being **born** non-compliant in the first place.

## Root cause
`Invoke-ProposalApply` mints new cross-cutting (situation) nodes with **empty interpretations** and nothing decomposes them at creation — so every pipeline-created situation is born non-compliant and only caught later by the trip-wire. This is the sit-448..470 (t/1805) and sit-471..475 (t/2323) mechanism.

## Fix (TL decision t/2324#1 + fail-closed confirm t/2332#4)
- **New Private helper `Set-SituationBdiInterpretation`** — decomposes a minted situation into per-POV `{belief,desire,intention,summary}` via the CL-owned UsageID `enrichment.situation-bdi-decomposition` (reused, not forked), with a **`gemini-3.5-flash-lite` backend fallback** so a transient primary-model failure doesn't block the pipeline.
- **Fail-closed**: on persistent failure (AI error after fallback, empty/invalid response, or an incomplete decomposition) it throws `ActionableError`; `Invoke-ProposalApply` rejects that single proposal (`Success=false`, per-node skip — proposals are additive) rather than committing a non-compliant node. Contrast the cosmetic aphorism (`Set-NodeAphorism`, fail-open) — BDI decomposition is the load-bearing invariant the gate exists for.
- **Pipeline hygiene**: suppress `Test-PovNodeId`'s `$true` return in the NEW branch so it no longer pollutes the function's result-object output stream.

## Tests
- Success: all POVs populated, ```json fence strip, flash-lite fallback asserted.
- 4 fail-closed paths: AI throw / empty / invalid JSON / incomplete BDI.
- Read-only integration test: per-node skip through the real `Invoke-ProposalApply` (returns before any write; live data unchanged).
- AI mocked — no live calls. **Full Pester: 980 passed / 0 failed / 51 skipped**; new file 8/8; live `situations.json` confirmed unmodified.

The scheduled trip-wire (`tests/data-compliance/`, t/2331) is now a backstop, not the primary guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)