### PR TITLE
chore(scripts): Pester test to catch psd1/psm1/Public-dir export-list drift (t/2336)

### DIFF
--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -98,6 +98,7 @@
         'Measure-DebateQuality'
         'Invoke-DebateAB'
         'Show-OSSLicenses'
+        'Get-AICostReport'
         'Get-FlightRecorderDump'
         'Get-LatestFlightRecorderDump'
         'Get-AzureFlightRecorder'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -709,22 +709,6 @@ Set-Alias -Name 'Workflow'             -Value 'Show-WorkflowRunner'    -Scope Gl
 # ─────────────────────────────────────────────────────────────────────────────
 # Deprecation wrappers — old cmdlet names delegate to new names
 # ─────────────────────────────────────────────────────────────────────────────
-function Find-CrossCuttingCandidates {
-    <#
-    .SYNOPSIS
-        DEPRECATED: Use Find-SituationCandidates instead.
-    #>
-    [CmdletBinding()]
-    param()
-
-    Write-Warning (New-ActionableError -Goal 'run Find-CrossCuttingCandidates' `
-        -Problem 'Find-CrossCuttingCandidates was renamed in the Situations migration' `
-        -Location 'AITriad module' `
-        -NextSteps 'Use Find-SituationCandidates instead' `
-        -PassThru)
-
-    Find-SituationCandidates @PSBoundParameters
-}
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Export public surface
@@ -792,6 +776,7 @@ Export-ModuleMember -Function @(
     'Repair-UnmappedConcepts'
     'Invoke-AITDebate'
     'Resume-AITDebate'
+    'Convert-DebateToAudio'
     'Convert-MD2PDF'
     'Show-Markdown'
     'Show-DebateDiagnostics'

--- a/scripts/AITriad/Public/Find-CrossCuttingCandidates.ps1
+++ b/scripts/AITriad/Public/Find-CrossCuttingCandidates.ps1
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Find-CrossCuttingCandidates {
+    <#
+    .SYNOPSIS
+        DEPRECATED: Use Find-SituationCandidates instead.
+    .DESCRIPTION
+        Renamed in the Situations migration. This wrapper emits a deprecation
+        warning and delegates to Find-SituationCandidates.
+    #>
+    [CmdletBinding()]
+    param()
+
+    Write-Warning (New-ActionableError -Goal 'run Find-CrossCuttingCandidates' `
+        -Problem 'Find-CrossCuttingCandidates was renamed in the Situations migration' `
+        -Location 'AITriad module' `
+        -NextSteps 'Use Find-SituationCandidates instead' `
+        -PassThru)
+
+    Find-SituationCandidates @PSBoundParameters
+}

--- a/tests/Test-ModuleExportSync.Tests.ps1
+++ b/tests/Test-ModuleExportSync.Tests.ps1
@@ -1,0 +1,46 @@
+# Tag: module (t/2336)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad'
+    $PublicDir  = Join-Path $ModulePath 'Public'
+    $PsdPath    = Join-Path $ModulePath 'AITriad.psd1'
+
+    Import-Module (Join-Path $ModulePath 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    # Public/*.ps1 basenames == expected function names
+    $script:PublicFiles   = @(Get-ChildItem $PublicDir -Filter '*.ps1' -File |
+                               Select-Object -ExpandProperty BaseName)
+
+    # FunctionsToExport from the manifest (psd1)
+    $script:PsdExports    = @((Import-PowerShellDataFile $PsdPath).FunctionsToExport)
+
+    # Functions actually exported by the psm1 (via Export-ModuleMember)
+    $script:ModuleExports = @((Get-Module AITriad).ExportedFunctions.Keys)
+}
+
+Describe 'AITriad module export-list sync' -Tag 'module' {
+
+    It 'Every Public/*.ps1 function is in Export-ModuleMember (psm1)' {
+        $Missing = @($script:PublicFiles | Where-Object { $_ -notin $script:ModuleExports })
+        $Missing.Count | Should -Be 0 -Because "Missing from Export-ModuleMember: $($Missing -join ', ')"
+    }
+
+    It 'Every Public/*.ps1 function is in FunctionsToExport (psd1)' {
+        $Missing = @($script:PublicFiles | Where-Object { $_ -notin $script:PsdExports })
+        $Missing.Count | Should -Be 0 -Because "Missing from FunctionsToExport: $($Missing -join ', ')"
+    }
+
+    It 'Export-ModuleMember has no entries without a backing Public/*.ps1 file' {
+        $Orphans = @($script:ModuleExports | Where-Object { $_ -notin $script:PublicFiles })
+        $Orphans.Count | Should -Be 0 -Because "No backing .ps1 in Public/: $($Orphans -join ', ')"
+    }
+
+    It 'FunctionsToExport has no entries without a backing Public/*.ps1 file' {
+        $Orphans = @($script:PsdExports | Where-Object { $_ -notin $script:PublicFiles })
+        $Orphans.Count | Should -Be 0 -Because "No backing .ps1 in Public/: $($Orphans -join ', ')"
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `tests/Test-ModuleExportSync.Tests.ps1` — 4 tests that CI-fail when any `Public/*.ps1` function is missing from `Export-ModuleMember` or `FunctionsToExport`, or either list has orphan entries with no backing file
- Fixes 3 pre-existing drift issues surfaced by the new test: `Convert-DebateToAudio` missing from psm1 export; `Get-AICostReport` missing from psd1; `Find-CrossCuttingCandidates` inline deprecation wrapper extracted to `Public/` per module convention
- Self-cert `/add-test`; drift fixes are behaviour-preserving

## Test plan
- [ ] `test-powershell` green (993/0/51 locally)
- [ ] `Test-ModuleManifest` passes

Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>