### PR TITLE
fix(debate): runtime typeof guard + FR logging for object-title crash (t/2334)

### DIFF
--- a/taxonomy-editor/src/main/debateIO.ts
+++ b/taxonomy-editor/src/main/debateIO.ts
@@ -66,9 +66,19 @@ function saveIndex(index: DebateIndex): void {
 function extractSummary(data: Record<string, unknown>): DebateSessionSummary {
   const transcript = Array.isArray(data.transcript) ? data.transcript : [];
   const topic = data.topic as { final?: string; original?: string } | undefined;
+  const rawTitle = data.title;
+  const titleStr = typeof rawTitle === 'string' ? rawTitle : undefined;
+  if (rawTitle !== undefined && rawTitle !== null && typeof rawTitle !== 'string') {
+    // `as string` cast (t/2334) silences TS but doesn't coerce at runtime — log so FR shows the corruption
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'debateIO', level: 'warn',
+      message: 'extractSummary: title is not a string — falling back to topic (t/2334)',
+      data: { id: data.id as string, title_type: typeof rawTitle, title_keys: Object.keys(rawTitle as object) },
+    });
+  }
   return {
     id: data.id as string,
-    title: (data.title as string) || topic?.final || topic?.original || 'Untitled',
+    title: titleStr || topic?.final || topic?.original || 'Untitled',
     created_at: data.created_at as string,
     updated_at: data.updated_at as string,
     phase: data.phase as string,

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -254,7 +254,7 @@ export function DebateTableRow({
   // Defensive guard: extractSummary may return title as {final,original} if debateIO.ts is
   // invoked before the t/2334 fix is present on disk. Coerce to string so React never sees
   // an object. The main-process FR log in debateIO.ts captures the corruption event.
-  const rawTitle: unknown = safeTitle;
+  const rawTitle: unknown = s.title;
   const safeTitle = typeof rawTitle === 'string' ? rawTitle
     : (rawTitle as { final?: string; original?: string })?.final
       ?? (rawTitle as { final?: string; original?: string })?.original

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -251,6 +251,14 @@ export function DebateTableRow({
 }: DebateTableRowProps) {
   const isRenaming = renamingId === s.id;
   const colSpan = editMode ? 7 : 6;
+  // Defensive guard: extractSummary may return title as {final,original} if debateIO.ts is
+  // invoked before the t/2334 fix is present on disk. Coerce to string so React never sees
+  // an object. The main-process FR log in debateIO.ts captures the corruption event.
+  const rawTitle: unknown = safeTitle;
+  const safeTitle = typeof rawTitle === 'string' ? rawTitle
+    : (rawTitle as { final?: string; original?: string })?.final
+      ?? (rawTitle as { final?: string; original?: string })?.original
+      ?? 'Untitled';
 
   const handleRowClick = useCallback(() => {
     if (editMode) {
@@ -276,11 +284,11 @@ export function DebateTableRow({
     // Double-click title cell to rename (only when not in edit-mode bulk flow)
     e.stopPropagation();
     setRenamingId(s.id);
-    setRenameValue(s.title);
+    setRenameValue(safeTitle);
   }, [s, setRenamingId, setRenameValue]);
 
   const commitRename = useCallback(() => {
-    if (renameValue.trim() && renameValue.trim() !== s.title) {
+    if (renameValue.trim() && renameValue.trim() !== safeTitle) {
       void onRename(s.id, renameValue.trim());
     }
     setRenamingId(null);
@@ -301,7 +309,7 @@ export function DebateTableRow({
         <td className="col-cb" onClick={e => e.stopPropagation()}>
           <input
             type="checkbox"
-            aria-label={`Select ${s.title}`}
+            aria-label={`Select ${safeTitle}`}
             checked={isSelected}
             onChange={() => onToggleSelect(s.id)}
           />
@@ -330,10 +338,10 @@ export function DebateTableRow({
         ) : (
           <div
             className="debate-table-title-text"
-            title={s.title}
+            title={safeTitle}
             onDoubleClick={!editMode ? handleDoubleClick : undefined}
           >
-            {s.title}
+            {safeTitle}
           </div>
         )}
         {/* Model shown as secondary line on tablet (col hidden) */}
@@ -372,8 +380,8 @@ export function DebateTableRow({
               type="button"
               className="debate-table-action-btn"
               title="Rename"
-              aria-label={`Rename "${s.title}"`}
-              onClick={() => { setRenamingId(s.id); setRenameValue(s.title); }}
+              aria-label={`Rename "${safeTitle}"`}
+              onClick={() => { setRenamingId(s.id); setRenameValue(safeTitle); }}
             >
               &#9998;
             </button>
@@ -381,7 +389,7 @@ export function DebateTableRow({
               type="button"
               className="debate-table-action-btn"
               title="Move up"
-              aria-label={`Move "${s.title}" up`}
+              aria-label={`Move "${safeTitle}" up`}
               disabled={idx === 0}
               onClick={() => onMoveSession(s.id, 'up')}
             >
@@ -391,7 +399,7 @@ export function DebateTableRow({
               type="button"
               className="debate-table-action-btn"
               title="Move down"
-              aria-label={`Move "${s.title}" down`}
+              aria-label={`Move "${safeTitle}" down`}
               disabled={idx === totalRows - 1}
               onClick={() => onMoveSession(s.id, 'down')}
             >
@@ -404,7 +412,7 @@ export function DebateTableRow({
               type="button"
               className="debate-table-action-btn primary"
               title="Open in popout window"
-              aria-label={`Open "${s.title}" in window`}
+              aria-label={`Open "${safeTitle}" in window`}
               onClick={() => onOpen(s.id)}
             >
               Open
@@ -414,7 +422,7 @@ export function DebateTableRow({
               type="button"
               className="debate-table-action-btn"
               title="Share to community"
-              aria-label={`Share "${s.title}" to community`}
+              aria-label={`Share "${safeTitle}" to community`}
               onClick={() => onShare(s)}
             >
               Share


### PR DESCRIPTION
## Summary
- The prior fix used `(data.title as string)` — a TypeScript compile-time cast that does nothing at runtime. If `data.title` is `{final, original}`, it is truthy, so `||` short-circuits and the object reaches `DebateTableRow` unchanged, crashing React with "Objects are not valid as a React child".
- Confirmed still live in FR dump `flight-recorder-2026-08-08T23-27-48.294Z.jsonl` (build `2ad381a7`, same build as the prior fix).

## Two-layer fix
1. **`debateIO.ts` `extractSummary()`** — `typeof rawTitle === 'string'` runtime check + FR `warn` event logging `title_type` and `title_keys` so future dumps show the corruption at its source
2. **`DebateTable.tsx` `DebateTableRow`** — `safeTitle` coercion using the same `{final,original}` fallback logic, so the component never renders a non-string even if an on-disk session with the corrupt shape loads before a re-index

## Test plan
- [ ] Open debate tab with a `debate-*.json` that has `title: {final, original}` — crash should not occur; FR dump should show `debateIO: title is not a string` warn event
- [ ] Normal debate sessions with string titles continue to display correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)