### PR TITLE
feat(theme): shared usePopoutTheme() hook — popouts honor selected scheme + live-update (t/2338)

### DIFF
--- a/taxonomy-editor/src/renderer/components/PovProgression/PovProgressionWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/PovProgression/PovProgressionWindow.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
 import './PovProgressionWindow.css';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { usePopoutTheme } from '../../hooks/usePopoutTheme';
 import type { DebateSession } from '../../types/debate';
 import { PovProgressionView } from './PovProgressionView';
 
@@ -18,14 +19,8 @@ export function PovProgressionWindow() {
   const [debate, setDebate] = useState<DebateSession | null>(null);
   const [nodeLabels, setNodeLabels] = useState<Map<string, string>>(new Map());
 
-  // Apply theme — popouts don't go through MainApp which sets data-theme
-  useEffect(() => {
-    const root = document.documentElement;
-    if (!root.getAttribute('data-theme')) {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-    }
-  }, []);
+  // Apply the selected theme + live-update — popouts don't go through MainApp (t/2338).
+  usePopoutTheme();
 
   // Subscribe to diagnostics state — same payload structure
   useEffect(() => {

--- a/taxonomy-editor/src/renderer/hooks/usePopoutTheme.test.tsx
+++ b/taxonomy-editor/src/renderer/hooks/usePopoutTheme.test.tsx
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { usePopoutTheme } from './usePopoutTheme';
+import { THEME_STORAGE_KEY } from '../utils/theme';
+
+// Controllable matchMedia: tests flip `prefersDark` and fire captured change listeners.
+let prefersDark = false;
+let mediaListeners: Array<() => void> = [];
+
+function installMatchMedia() {
+  prefersDark = false;
+  mediaListeners = [];
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      get matches() { return prefersDark; },
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: (_: string, cb: () => void) => { mediaListeners.push(cb); },
+      removeEventListener: (_: string, cb: () => void) => {
+        mediaListeners = mediaListeners.filter((l) => l !== cb);
+      },
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function fireOsFlip(dark: boolean) {
+  prefersDark = dark;
+  act(() => { mediaListeners.forEach((l) => l()); });
+}
+
+/** Simulate the main window persisting a theme, which fires `storage` in this window. */
+function fireStorage(newValue: string | null) {
+  act(() => {
+    window.dispatchEvent(new StorageEvent('storage', { key: THEME_STORAGE_KEY, newValue }));
+  });
+}
+
+const theme = () => document.documentElement.getAttribute('data-theme');
+
+describe('usePopoutTheme', () => {
+  beforeEach(() => {
+    installMatchMedia();
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  describe('mount-apply reads localStorage, not OS', () => {
+    it.each(['light', 'dark', 'bkc', 'harvard'] as const)(
+      'applies the selected %s theme on mount',
+      (scheme) => {
+        localStorage.setItem(THEME_STORAGE_KEY, scheme);
+        renderHook(() => usePopoutTheme());
+        expect(theme()).toBe(scheme);
+      },
+    );
+
+    it('defaults to harvard when nothing is stored (not OS light/dark)', () => {
+      prefersDark = true; // OS says dark; selected theme must still win
+      renderHook(() => usePopoutTheme());
+      expect(theme()).toBe('harvard');
+    });
+
+    it('resolves system → dark/light via prefers-color-scheme', () => {
+      localStorage.setItem(THEME_STORAGE_KEY, 'system');
+      prefersDark = true;
+      renderHook(() => usePopoutTheme());
+      expect(theme()).toBe('dark');
+    });
+
+    it('overrides a stale data-theme already on the root', () => {
+      document.documentElement.setAttribute('data-theme', 'light');
+      localStorage.setItem(THEME_STORAGE_KEY, 'bkc');
+      renderHook(() => usePopoutTheme());
+      expect(theme()).toBe('bkc');
+    });
+  });
+
+  describe('live-update via storage event (the cross-window transport)', () => {
+    it('follows a main-window switch to a non-OS scheme (bkc)', () => {
+      localStorage.setItem(THEME_STORAGE_KEY, 'light');
+      renderHook(() => usePopoutTheme());
+      expect(theme()).toBe('light');
+
+      localStorage.setItem(THEME_STORAGE_KEY, 'bkc');
+      fireStorage('bkc');
+      expect(theme()).toBe('bkc');
+    });
+
+    it('follows a switch to harvard', () => {
+      renderHook(() => usePopoutTheme());
+      fireStorage('harvard');
+      expect(theme()).toBe('harvard');
+    });
+
+    it('falls back to stored default when newValue is null (removeItem/clear)', () => {
+      localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+      renderHook(() => usePopoutTheme());
+      // localStorage still resolves to dark; a null newValue must not blank the theme.
+      fireStorage(null);
+      expect(theme()).toBe('dark');
+    });
+
+    it('ignores storage events for unrelated keys', () => {
+      localStorage.setItem(THEME_STORAGE_KEY, 'bkc');
+      renderHook(() => usePopoutTheme());
+      act(() => {
+        window.dispatchEvent(new StorageEvent('storage', { key: 'some-other-key', newValue: 'light' }));
+      });
+      expect(theme()).toBe('bkc');
+    });
+  });
+
+  describe('live-update on OS flip while system is selected', () => {
+    it('re-resolves when the OS toggles dark and scheme is system', () => {
+      localStorage.setItem(THEME_STORAGE_KEY, 'system');
+      renderHook(() => usePopoutTheme());
+      expect(theme()).toBe('light');
+      fireOsFlip(true);
+      expect(theme()).toBe('dark');
+    });
+
+    it('ignores OS flips when a fixed scheme is selected', () => {
+      localStorage.setItem(THEME_STORAGE_KEY, 'bkc');
+      renderHook(() => usePopoutTheme());
+      fireOsFlip(true);
+      expect(theme()).toBe('bkc');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes both listeners on unmount', () => {
+      localStorage.setItem(THEME_STORAGE_KEY, 'light');
+      const { unmount } = renderHook(() => usePopoutTheme());
+      unmount();
+
+      // After unmount, neither transport should mutate the root.
+      localStorage.setItem(THEME_STORAGE_KEY, 'bkc');
+      fireStorage('bkc');
+      expect(theme()).toBe('light');
+
+      localStorage.setItem(THEME_STORAGE_KEY, 'system');
+      fireOsFlip(true);
+      expect(theme()).toBe('light');
+    });
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/usePopoutTheme.ts
+++ b/taxonomy-editor/src/renderer/hooks/usePopoutTheme.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * usePopoutTheme (t/2338) — shared theme hook for all popout windows.
+ *
+ * Popout BrowserWindows don't mount MainApp, so nothing sets their `data-theme`.
+ * Historically each popout read OS `prefers-color-scheme` once at mount, so it
+ * ignored the user's selected ColorScheme (bkc/harvard were impossible) and never
+ * live-updated. This hook fixes both, sharing one resolver with the main window
+ * (utils/theme.ts) so the two paths can't drift.
+ *
+ * Behavior:
+ *  - Mount: apply the selected theme from localStorage (the source of truth) —
+ *    unconditionally, so any stale/OS default gets corrected.
+ *  - Live update: a same-origin `storage` event fires in *other* windows when the
+ *    main window's applyTheme persists, so the popout follows theme changes with
+ *    no IPC. Also follows OS light/dark flips while the selected scheme is `system`.
+ *  - Cleans up both listeners on unmount.
+ *
+ * Drop-in for the 4 popout entry points: call `usePopoutTheme()` once at the top
+ * of the window component; no args, no return.
+ */
+
+import { useEffect } from 'react';
+import { applyThemeToRoot, getStoredTheme, parseColorScheme, THEME_STORAGE_KEY } from '../utils/theme';
+
+export function usePopoutTheme(): void {
+  useEffect(() => {
+    // Mount: localStorage is the source of truth (not OS prefers-color-scheme).
+    applyThemeToRoot(getStoredTheme());
+
+    // Live update: the main window's applyTheme localStorage write fires `storage`
+    // in this (other) same-origin window.
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== THEME_STORAGE_KEY) return;
+      // newValue is null on removeItem/clear — fall back to the stored default.
+      const scheme = parseColorScheme(e.newValue) ?? getStoredTheme();
+      applyThemeToRoot(scheme);
+    };
+    window.addEventListener('storage', onStorage);
+
+    // Live update for OS-level light/dark flips, but only while `system` is selected.
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const onMediaChange = () => {
+      if (getStoredTheme() === 'system') applyThemeToRoot('system');
+    };
+    media.addEventListener('change', onMediaChange);
+
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      media.removeEventListener('change', onMediaChange);
+    };
+  }, []);
+}

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
@@ -6,6 +6,7 @@ import type { TaxonomyStore } from '../types';
 import { api } from '@bridge';
 import { DEFAULT_MODEL } from '@lib/ai-client/defaults';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { applyThemeToRoot, getStoredTheme, THEME_STORAGE_KEY } from '../../../utils/theme';
 
 /**
  * Default Community Library server — the Azure Container Apps production deployment.
@@ -226,25 +227,12 @@ export function backendForModel(model: string): AIBackend {
   return 'gemini';
 }
 
-function getStoredTheme(): ColorScheme {
-  try {
-    const stored = localStorage.getItem('taxonomy-editor-theme');
-    if (stored === 'light' || stored === 'dark' || stored === 'bkc' || stored === 'harvard' || stored === 'system') return stored;
-  } catch (err) {
-    getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Failed to read stored theme from localStorage', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-  }
-  return 'harvard';
-}
-
+// Theme resolution core moved to utils/theme.ts (t/2338) so the popout path
+// (usePopoutTheme) and this main-window path share one resolver and can't fork.
+// applyTheme here = shared applyThemeToRoot + the main-window-only localStorage persist.
 function applyTheme(scheme: ColorScheme) {
-  const root = document.documentElement;
-  if (scheme === 'system') {
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-  } else {
-    root.setAttribute('data-theme', scheme);
-  }
-  try { localStorage.setItem('taxonomy-editor-theme', scheme); } catch (err) {
+  applyThemeToRoot(scheme);
+  try { localStorage.setItem(THEME_STORAGE_KEY, scheme); } catch (err) {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'taxonomy-store', level: 'warn', message: 'Failed to persist theme to localStorage', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
   }
 }

--- a/taxonomy-editor/src/renderer/utils/theme.ts
+++ b/taxonomy-editor/src/renderer/utils/theme.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Shared theme resolution core (t/2338).
+ *
+ * Single source of truth for turning a selected `ColorScheme` into a
+ * `data-theme` attribute on the document root. Both the main-window path
+ * (`applyTheme` in settingsSlice.ts) and the popout path (`usePopoutTheme`)
+ * call `applyThemeToRoot` so the resolution logic can never fork — a popout
+ * must resolve bkc/harvard/system exactly like the main window.
+ *
+ * `applyThemeToRoot` deliberately does NOT persist to localStorage: only the
+ * main window owns the stored theme; popouts are read-only followers.
+ *
+ * `ColorScheme` is imported type-only to avoid a runtime import cycle with
+ * settingsSlice (which imports the runtime helpers from here).
+ */
+
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import type { ColorScheme } from '../hooks/useTaxonomyStore/slices/settingsSlice';
+
+export const THEME_STORAGE_KEY = 'taxonomy-editor-theme';
+
+const DEFAULT_THEME: ColorScheme = 'harvard';
+
+/** Coerce an arbitrary string (e.g. a localStorage value) to a valid ColorScheme, or null. */
+export function parseColorScheme(value: string | null | undefined): ColorScheme | null {
+  if (value === 'light' || value === 'dark' || value === 'bkc' || value === 'harvard' || value === 'system') {
+    return value;
+  }
+  return null;
+}
+
+/** Read the user's selected theme from localStorage, falling back to the app default. */
+export function getStoredTheme(): ColorScheme {
+  try {
+    return parseColorScheme(localStorage.getItem(THEME_STORAGE_KEY)) ?? DEFAULT_THEME;
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'theme', level: 'warn', message: 'Failed to read stored theme from localStorage', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+  }
+  return DEFAULT_THEME;
+}
+
+/**
+ * Resolve a ColorScheme and set `data-theme` on the document root.
+ * `system` resolves to light/dark via `prefers-color-scheme`. Does NOT persist.
+ */
+export function applyThemeToRoot(scheme: ColorScheme): void {
+  const root = document.documentElement;
+  if (scheme === 'system') {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+  } else {
+    root.setAttribute('data-theme', scheme);
+  }
+}


### PR DESCRIPTION
## Summary
Shared `usePopoutTheme()` hook so popout windows honor the user's **selected** ColorScheme (incl. **bkc/harvard**) and **live-update** on a main-window theme change. Fixes the shared defect root-caused in t/2337: every popout read OS `prefers-color-scheme` once at mount.

## Changes
- **New `utils/theme.ts`** — extracts scheme→DOM resolution out of `applyTheme`: `applyThemeToRoot`, `getStoredTheme`, `parseColorScheme`, `THEME_STORAGE_KEY`. One resolver shared by the main-window and popout paths so they can't fork. `settingsSlice.applyTheme` = `applyThemeToRoot` + the main-window-only localStorage persist (**behavior unchanged — regression guard**).
- **New `hooks/usePopoutTheme.ts`** — applies the stored scheme on mount (localStorage = source of truth), live-updates via the same-origin `storage` event (no IPC), follows OS light/dark flips while `system` is selected, handles `newValue===null`, cleans up both listeners on unmount.
- **`PovProgressionWindow.tsx`** swapped onto the hook (Rosetta-owned; folded in per t/2338#1).
- **`usePopoutTheme.test.tsx`** — 14 cases: mount-apply across all 4 themes + system, storage live-update to non-OS schemes (bkc/harvard), null-newValue fallback, unrelated-key ignore, OS-flip while system, listener cleanup.

## Contract for sibling adopters (t/2337 / t/2339 / t/2340)
`import { usePopoutTheme } from '../../hooks/usePopoutTheme'` → call `usePopoutTheme()` once at the top of the window component; delete the ad-hoc prefers-color-scheme block. No args, no return.

## Landing gate (TL, t/2338#3)
⚠️ **Empirical cross-window verify is required before merge** — prove **bkc or harvard** live-updates an already-open popout (light/dark could pass on a prefers-color-scheme coincidence and mask a dead transport). Popouts are unreachable via electron-mcp (t/2325) → **human eyeball**. Storage-first transport; IPC fallback if storage doesn't cross BrowserWindows.

Design + sign-off: t/2338#2, t/2338#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)