### PR TITLE
fix(renderer): create missing utils/theme.ts and usePopoutTheme (t/2338)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/usePopoutTheme.ts
+++ b/taxonomy-editor/src/renderer/hooks/usePopoutTheme.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Apply and live-update theme in popout windows (t/2338).
+// Popouts don't go through MainApp (which sets data-theme reactively),
+// so they read the stored theme on mount and listen for storage events
+// from the main window so a theme change is reflected immediately.
+
+import { useEffect } from 'react';
+import { applyThemeToRoot, getStoredTheme, THEME_STORAGE_KEY } from '../utils/theme';
+
+export function usePopoutTheme(): void {
+  useEffect(() => {
+    // Apply immediately on mount
+    applyThemeToRoot(getStoredTheme());
+
+    // Live-update when the main window changes the theme
+    const handler = (e: StorageEvent) => {
+      if (e.key === THEME_STORAGE_KEY && e.newValue) {
+        applyThemeToRoot(e.newValue);
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+}

--- a/taxonomy-editor/src/renderer/utils/theme.ts
+++ b/taxonomy-editor/src/renderer/utils/theme.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Shared theme utilities for main-window and popout paths (t/2338).
+// Centralized here so both callers resolve 'system' identically and
+// read/write the same localStorage key — no forking.
+
+export const THEME_STORAGE_KEY = 'taxonomy-editor-theme';
+
+const DEFAULT_THEME = 'harvard';
+
+/** Resolve 'system' to an actual data-theme value; pass named schemes through. */
+function resolveScheme(scheme: string): string {
+  if (scheme === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return scheme;
+}
+
+/** Set data-theme on <html>. Resolves 'system' via media query. */
+export function applyThemeToRoot(scheme: string): void {
+  document.documentElement.setAttribute('data-theme', resolveScheme(scheme));
+}
+
+/** Read the persisted theme from localStorage; defaults to 'harvard'. */
+export function getStoredTheme(): string {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored) return stored;
+  } catch {
+    // localStorage unavailable
+  }
+  return DEFAULT_THEME;
+}


### PR DESCRIPTION
## Summary
- `settingsSlice.ts` imported `applyThemeToRoot`, `getStoredTheme`, and `THEME_STORAGE_KEY` from `../../../utils/theme` after a half-landed refactor (t/2338), but the file was never committed — crashing Vite on startup with "Failed to resolve import"
- `PovProgressionWindow.tsx` similarly imports `usePopoutTheme` which also didn't exist

## Files created
- **`src/renderer/utils/theme.ts`** — `THEME_STORAGE_KEY` (`'taxonomy-editor-theme'`), `applyThemeToRoot(scheme)` (sets `data-theme` on `<html>`, resolves `'system'` via media query), `getStoredTheme()` (reads localStorage, defaults to `'harvard'`)
- **`src/renderer/hooks/usePopoutTheme.ts`** — applies stored theme on mount + `StorageEvent` listener so popout windows live-update when the main window changes theme

## Test plan
- [ ] `show-taxonomyEditor -dev` starts without Vite import errors
- [ ] Debate tab renders without crash
- [ ] Switching theme in Settings updates the main window and any open popouts
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)