### PR TITLE
refactor(debate-diagnostics): adopt usePopoutTheme() in diagnostics popout (t/2339)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/useDiagnosticsState.ts
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/useDiagnosticsState.ts
@@ -13,6 +13,7 @@ import { countMatches } from './helpers';
 import type { OverviewTab, EntryTab, UtilitySnapshot } from './types';
 import { UTILITY_WEIGHTS } from './types';
 import { parseHashParams } from '../../../lib/parseHash';
+import { usePopoutTheme } from '../../../hooks/usePopoutTheme';
 
 function countMatchesInValue(value: unknown, term: string): number {
   if (typeof value === 'string') return countMatches(value, term);
@@ -459,14 +460,7 @@ export function useDiagnosticsState(initialData?: Record<string, unknown>) {
     });
   }, [loadTaxonomyData]);
 
-  // Apply theme
-  useEffect(() => {
-    const root = document.documentElement;
-    if (!root.getAttribute('data-theme')) {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-    }
-  }, []);
+  usePopoutTheme();
 
   // IPC state updates from main window
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Replaces the ad-hoc `useEffect` OS-prefers-color-scheme block in `useDiagnosticsState.ts` with a single `usePopoutTheme()` call
- Diagnostics popout now honors the user's selected theme (incl. bkc/harvard) and live-updates without a reopen
- Self-certified under /trivial-change: 1 file, 2 additions / 8 deletions, no new exports, single scope

## Test plan

- [ ] Verify gate passed at 365bf0b0
- [ ] AC: diagnostics popout renders selected theme on open (incl. bkc/harvard) and live-updates — pending human eyeball (t/2313, unblocked by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)