### PR TITLE
fix(chat): adopt usePopoutTheme() in ChatWindow (t/2340)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWindow.tsx
@@ -6,20 +6,14 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useTaxonomyStore, initAIModels } from '../../hooks/useTaxonomyStore';
 import { useChatStore } from '../../hooks/useChatStore';
 import { initDebateSessions } from '../../hooks/useDebateStore';
+import { usePopoutTheme } from '../../hooks/usePopoutTheme';
 import { parseHashParams } from '../../lib/parseHash';
 import { ChatTab } from './ChatTab';
 import './ChatWindow.css';
 
 export function ChatWindow() {
   const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (!root.getAttribute('data-theme')) {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      root.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
-    }
-  }, []);
+  usePopoutTheme();
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## Summary
- Replace ad-hoc `prefers-color-scheme` block in `ChatWindow.tsx` with `usePopoutTheme()` (landed in t/2338, #683)
- Chat popout now respects selected theme (incl. bkc/harvard) and live-updates without reopen

## Self-cert
/trivial-change — single file, no behavioral change beyond consuming the shared hook. Renderer tsc: 0/0.

## Test plan
- [ ] Open chat popout, cycle through all 4 themes in main window — popout updates live