### PR TITLE
fix(infra): revert premature ai-rosetta-stone rename

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -52,7 +52,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/taxonomy-editor
   RESOURCE_GROUP: ai-triad
-  CONTAINER_APP_NAME: ai-rosetta-stone
+  CONTAINER_APP_NAME: taxonomy-editor
 
 jobs:
   preflight:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,7 +27,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/taxonomy-editor
   RESOURCE_GROUP: ai-triad
-  CONTAINER_APP_NAME: ai-rosetta-stone-staging
+  CONTAINER_APP_NAME: taxonomy-editor-staging
 
 jobs:
   deploy-staging:

--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  APP_URL: https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io
+  APP_URL: https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io
 
 jobs:
   health-check:
@@ -82,7 +82,7 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `Health check failure: ai-rosetta-stone unreachable`,
+                title: `Health check failure: taxonomy-editor unreachable`,
                 body: [
                   `## Health Check Alert`,
                   ``,
@@ -95,8 +95,8 @@ jobs:
                   `### Troubleshooting`,
                   ``,
                   '```bash',
-                  `az containerapp show --name ai-rosetta-stone -g ai-triad --query "properties.runningStatus"`,
-                  `az containerapp logs show --name ai-rosetta-stone -g ai-triad --type console`,
+                  `az containerapp show --name taxonomy-editor -g ai-triad --query "properties.runningStatus"`,
+                  `az containerapp logs show --name taxonomy-editor -g ai-triad --type console`,
                   '```',
                   ``,
                   `Close this issue once the app is back online.`

--- a/deploy/azure/runbooks/deployment-facts.md
+++ b/deploy/azure/runbooks/deployment-facts.md
@@ -1,6 +1,6 @@
 # Deployment Facts — Canonical Source of Truth
 
-**Owner:** DevOps. **Last verified:** 2026-07-27 against Azure via `az containerapp list` / `az containerapp env list` (see [Re-verify](#re-verify)).
+**Owner:** DevOps. **Last verified:** 2026-08-09 against Azure via `az containerapp list` / `az containerapp env list` (see [Re-verify](#re-verify)).
 
 This is the single source of truth for the deployment's identity facts. The DevOps, Azure, and Docker `AGENTS.md` files **link here — they must not restate these values inline** (inline copies drift out of sync; that drift was the t/1735 bug).
 
@@ -8,11 +8,11 @@ This is the single source of truth for the deployment's identity facts. The DevO
 
 | Fact | Value |
 |---|---|
-| Container App | `ai-rosetta-stone` |
+| Container App | `taxonomy-editor` |
 | Resource Group | `ai-triad` |
 | Region | East US |
 | ACA Environment | `cae-aitriad` (Consumption plan) |
-| App URL | https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io |
+| App URL | https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io |
 | Env domain suffix | `yellowbush-aeda037d.eastus.azurecontainerapps.io` |
 | Container Image | `ghcr.io/jpsnover/taxonomy-editor:latest` — **GHCR, not Azure Container Registry** |
 | Storage Account / File Share | `staitriadkvwl3nywge4iw` / `taxonomy-data` |
@@ -25,10 +25,10 @@ This is the single source of truth for the deployment's identity facts. The DevO
 
 | Fact | Value |
 |---|---|
-| Container App | `ai-rosetta-stone-staging` |
+| Container App | `taxonomy-editor-staging` |
 | Resource Group | `ai-triad` |
 | Region | East US |
-| App URL | https://ai-rosetta-stone-staging.yellowbush-aeda037d.eastus.azurecontainerapps.io |
+| App URL | https://taxonomy-editor-staging.yellowbush-aeda037d.eastus.azurecontainerapps.io |
 
 ## Re-verify
 


### PR DESCRIPTION
## Summary

- Reverts `ai-rosetta-stone` → `taxonomy-editor` in all 4 files where the premature rename was applied
- The ACA app in Azure was **never renamed** — `taxonomy-editor` is the live app; `ai-rosetta-stone` does not exist
- This was causing health-monitor.yml to 404 every 15 minutes (GH issue #602, ~24h false alert), and would cause deploy-azure.yml / deploy-staging.yml to fail with ResourceNotFound on any deploy attempt

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/health-monitor.yml` | `APP_URL` + issue text + `az` commands → `taxonomy-editor` |
| `.github/workflows/deploy-azure.yml` | `CONTAINER_APP_NAME` → `taxonomy-editor` |
| `.github/workflows/deploy-staging.yml` | `CONTAINER_APP_NAME` → `taxonomy-editor-staging` |
| `deploy/azure/runbooks/deployment-facts.md` | All `ai-rosetta-stone` refs → `taxonomy-editor`; Last verified → 2026-08-09 |

## Root cause

The rename was applied to workflow files and deployment-facts.md on main before the Azure resources were actually renamed. Apply the rename again **after** `az containerapp update --name taxonomy-editor ... --name ai-rosetta-stone` is run and verified healthy.

## Verification

```
az containerapp show --name taxonomy-editor -g ai-triad --query "properties.runningStatus" -o tsv
# Running

curl -s -o /dev/null -w "%{http_code}" \
  https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/healthz
# 200
```

GH issue #602 closed as false alarm.

## Test plan

- [ ] CI green on this PR
- [ ] Health monitor next run passes (no new issue #602-style alert)
- [ ] Merge and confirm health-monitor run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)