### PR TITLE
revert(infra): revert premature rename taxonomy-editor → ai-rosetta-stone (all 18 files)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -52,7 +52,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/taxonomy-editor
   RESOURCE_GROUP: ai-triad
-  CONTAINER_APP_NAME: ai-rosetta-stone
+  CONTAINER_APP_NAME: taxonomy-editor
 
 jobs:
   preflight:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -27,7 +27,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/taxonomy-editor
   RESOURCE_GROUP: ai-triad
-  CONTAINER_APP_NAME: ai-rosetta-stone-staging
+  CONTAINER_APP_NAME: taxonomy-editor-staging
 
 jobs:
   deploy-staging:

--- a/.github/workflows/health-monitor.yml
+++ b/.github/workflows/health-monitor.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  APP_URL: https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io
+  APP_URL: https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io
 
 jobs:
   health-check:
@@ -82,7 +82,7 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `Health check failure: ai-rosetta-stone unreachable`,
+                title: `Health check failure: taxonomy-editor unreachable`,
                 body: [
                   `## Health Check Alert`,
                   ``,
@@ -95,8 +95,8 @@ jobs:
                   `### Troubleshooting`,
                   ``,
                   '```bash',
-                  `az containerapp show --name ai-rosetta-stone -g ai-triad --query "properties.runningStatus"`,
-                  `az containerapp logs show --name ai-rosetta-stone -g ai-triad --type console`,
+                  `az containerapp show --name taxonomy-editor -g ai-triad --query "properties.runningStatus"`,
+                  `az containerapp logs show --name taxonomy-editor -g ai-triad --type console`,
                   '```',
                   ``,
                   `Close this issue once the app is back online.`

--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -65,7 +65,7 @@ After deploying, add GitHub login (zero code change):
 
 ```bash
 az containerapp auth update \
-  --name ai-rosetta-stone \
+  --name taxonomy-editor \
   --resource-group ai-triad \
   --enabled-providers GitHub \
   --github-client-id <your-github-oauth-app-id> \

--- a/deploy/azure/Sync-AzureTriadData.ps1
+++ b/deploy/azure/Sync-AzureTriadData.ps1
@@ -14,7 +14,7 @@
     and pull latest data from GitHub into the Azure-mounted data volume.
 .PARAMETER ServerUrl
     Base URL of the Azure-hosted Taxonomy Editor.
-    Default: https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io
+    Default: https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io
 .PARAMETER AdminKey
     Admin API key matching ADMIN_API_KEY on the server. Falls back to
     $env:AITRIAD_ADMIN_KEY if not specified.
@@ -43,7 +43,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$ServerUrl = 'https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io',
+    [string]$ServerUrl = 'https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io',
 
     [string]$AdminKey,
 
@@ -129,7 +129,7 @@ if (-not $resolvedKey) {
     Write-Host ''
     Write-Host '  The key must match ADMIN_API_KEY on the Azure container.' -ForegroundColor White
     Write-Host '  Set it with:' -ForegroundColor Yellow
-    Write-Host '    az containerapp update --name ai-rosetta-stone -g ai-triad \' -ForegroundColor Yellow
+    Write-Host '    az containerapp update --name taxonomy-editor -g ai-triad \' -ForegroundColor Yellow
     Write-Host '      --set-env-vars "ADMIN_API_KEY=<your-secret-key>"' -ForegroundColor Yellow
     exit 1
 }

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -429,7 +429,7 @@ var containerEnv = paidTierEnabled
   : envWithFreeTier
 
 resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
-  name: 'ai-rosetta-stone'
+  name: 'taxonomy-editor'
   location: location
   tags: tags
   identity: {
@@ -461,7 +461,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
     template: {
       containers: [
         {
-          name: 'ai-rosetta-stone'
+          name: 'taxonomy-editor'
           image: containerImage
           resources: {
             cpu: json('1.0')
@@ -538,7 +538,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
 // runs independently so a bad staging deploy cannot affect production.
 
 resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
-  name: 'ai-rosetta-stone-staging'
+  name: 'taxonomy-editor-staging'
   location: location
   tags: union(tags, { environment: 'staging' })
   identity: {
@@ -566,7 +566,7 @@ resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
     template: {
       containers: [
         {
-          name: 'ai-rosetta-stone'
+          name: 'taxonomy-editor'
           image: containerImage
           resources: {
             cpu: json('0.25')

--- a/deploy/azure/runbooks/api-mode-cutover-checklist.md
+++ b/deploy/azure/runbooks/api-mode-cutover-checklist.md
@@ -52,7 +52,7 @@ Document results before proceeding with production cutover.
 
 ```bash
 # Verify app is healthy without Azure Files
-curl -s https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/health
+curl -s https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/health
 
 # Delete the storage account (removes file share + all data)
 az storage account delete --name staitriadkvwl3nywge4iw -g ai-triad --yes

--- a/deploy/azure/runbooks/cache-corruption.md
+++ b/deploy/azure/runbooks/cache-corruption.md
@@ -22,8 +22,8 @@
 
 3. **If UI is unreachable, restart the container:**
    ```bash
-   ACTIVE=$(az containerapp revision list --name ai-rosetta-stone -g ai-triad --query "[?properties.trafficWeight > \`0\`].name | [0]" -o tsv)
-   az containerapp revision restart --name ai-rosetta-stone -g ai-triad --revision "$ACTIVE"
+   ACTIVE=$(az containerapp revision list --name taxonomy-editor -g ai-triad --query "[?properties.trafficWeight > \`0\`].name | [0]" -o tsv)
+   az containerapp revision restart --name taxonomy-editor -g ai-triad --revision "$ACTIVE"
    ```
    Restarting clears `/tmp/taxonomy-cache/` and forces a full cold-start fetch.
 

--- a/deploy/azure/runbooks/deployment-facts.md
+++ b/deploy/azure/runbooks/deployment-facts.md
@@ -8,11 +8,11 @@ This is the single source of truth for the deployment's identity facts. The DevO
 
 | Fact | Value |
 |---|---|
-| Container App | `ai-rosetta-stone` |
+| Container App | `taxonomy-editor` |
 | Resource Group | `ai-triad` |
 | Region | East US |
 | ACA Environment | `cae-aitriad` (Consumption plan) |
-| App URL | https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io |
+| App URL | https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io |
 | Env domain suffix | `yellowbush-aeda037d.eastus.azurecontainerapps.io` |
 | Container Image | `ghcr.io/jpsnover/taxonomy-editor:latest` — **GHCR, not Azure Container Registry** |
 | Storage Account / File Share | `staitriadkvwl3nywge4iw` / `taxonomy-data` |
@@ -25,10 +25,10 @@ This is the single source of truth for the deployment's identity facts. The DevO
 
 | Fact | Value |
 |---|---|
-| Container App | `ai-rosetta-stone-staging` |
+| Container App | `taxonomy-editor-staging` |
 | Resource Group | `ai-triad` |
 | Region | East US |
-| App URL | https://ai-rosetta-stone-staging.yellowbush-aeda037d.eastus.azurecontainerapps.io |
+| App URL | https://taxonomy-editor-staging.yellowbush-aeda037d.eastus.azurecontainerapps.io |
 
 ## Re-verify
 

--- a/deploy/azure/runbooks/operational-commands.md
+++ b/deploy/azure/runbooks/operational-commands.md
@@ -6,30 +6,30 @@ production Container App. For the full deploy procedure see
 Remote Diagnostics Cmdlets section in `operations/devops/AGENTS.md`.
 
 **Live deployment identifiers** (source of truth: `operations/devops/AGENTS.md` "Live Deployment"):
-Resource Group `ai-triad`, Container App `ai-rosetta-stone`, image
+Resource Group `ai-triad`, Container App `taxonomy-editor`, image
 `ghcr.io/jpsnover/taxonomy-editor:latest`, region East US.
 
 ## Container App
 
 ```bash
 # Redeploy latest image
-az containerapp update --name ai-rosetta-stone -g ai-triad --image ghcr.io/jpsnover/taxonomy-editor:latest
+az containerapp update --name taxonomy-editor -g ai-triad --image ghcr.io/jpsnover/taxonomy-editor:latest
 
 # Check container status
-az containerapp show --name ai-rosetta-stone -g ai-triad --query "properties.runningStatus"
+az containerapp show --name taxonomy-editor -g ai-triad --query "properties.runningStatus"
 
 # View console logs
-az containerapp logs show --name ai-rosetta-stone -g ai-triad --type console
+az containerapp logs show --name taxonomy-editor -g ai-triad --type console
 ```
 
 ## Auth & Access
 
 ```bash
 # Update allowed users (server-side allowlist)
-az containerapp update --name ai-rosetta-stone -g ai-triad --set-env-vars "ALLOWED_USERS=user1,user2"
+az containerapp update --name taxonomy-editor -g ai-triad --set-env-vars "ALLOWED_USERS=user1,user2"
 
 # Update GitHub OAuth secret
-az containerapp auth github update --name ai-rosetta-stone -g ai-triad --client-secret <new-secret>
+az containerapp auth github update --name taxonomy-editor -g ai-triad --client-secret <new-secret>
 ```
 
 > **Env-var drift trap:** CLI `--set-env-vars` on the Container App is wiped by the next

--- a/deploy/azure/runbooks/production-release.md
+++ b/deploy/azure/runbooks/production-release.md
@@ -78,8 +78,8 @@
 
 2. Check production health:
    ```bash
-   curl -s https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/health | python -m json.tool
-   curl -s https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/healthz
+   curl -s https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/health | python -m json.tool
+   curl -s https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/healthz
    ```
 
 3. Or use the PowerShell diagnostics:
@@ -97,7 +97,7 @@
 
 5. Scan flight-recorder logs for startup errors:
    ```bash
-   az containerapp logs show --name ai-rosetta-stone -g ai-triad --type console --tail 50
+   az containerapp logs show --name taxonomy-editor -g ai-triad --type console --tail 50
    ```
 
 ## Rollback
@@ -106,19 +106,19 @@ If post-deploy issues are found after traffic shift:
 
 1. List revisions and identify the previous good one:
    ```bash
-   az containerapp revision list --name ai-rosetta-stone -g ai-triad \
+   az containerapp revision list --name taxonomy-editor -g ai-triad \
      --query "[?properties.active].{name:name, traffic:properties.trafficWeight, created:properties.createdTime}" -o table
    ```
 
 2. Shift traffic back to the previous revision:
    ```bash
-   az containerapp ingress traffic set --name ai-rosetta-stone -g ai-triad \
+   az containerapp ingress traffic set --name taxonomy-editor -g ai-triad \
      --revision-weight "<previous-revision>=100"
    ```
 
 3. Deactivate the broken revision:
    ```bash
-   az containerapp revision deactivate --name ai-rosetta-stone -g ai-triad \
+   az containerapp revision deactivate --name taxonomy-editor -g ai-triad \
      --revision "<broken-revision>"
    ```
 
@@ -155,8 +155,8 @@ All alerts route to the `ag-aitriad-restart-alert` action group, which emails `A
 
 ### Response Steps
 
-1. **ImagePullBackOff alert:** Check GHCR package visibility (`ghcr.io/jpsnover/taxonomy-editor` must be public). Verify `registries` is empty on the container app (`az containerapp show --name ai-rosetta-stone -g ai-triad --query 'properties.configuration.registries'`). If a credential was re-added, remove it and create a new revision.
-2. **Restart loop alert:** Check container logs (`az containerapp logs show --name ai-rosetta-stone -g ai-triad --type console`). May indicate app crash, OOM, or bad deploy. Rollback to previous revision if needed.
+1. **ImagePullBackOff alert:** Check GHCR package visibility (`ghcr.io/jpsnover/taxonomy-editor` must be public). Verify `registries` is empty on the container app (`az containerapp show --name taxonomy-editor -g ai-triad --query 'properties.configuration.registries'`). If a credential was re-added, remove it and create a new revision.
+2. **Restart loop alert:** Check container logs (`az containerapp logs show --name taxonomy-editor -g ai-triad --type console`). May indicate app crash, OOM, or bad deploy. Rollback to previous revision if needed.
 3. **Health check issue:** Run `Invoke-TaxEditorSmokeTest -Detailed` for full diagnosis. Check Azure status page for platform outages.
 
 ## Registry Auth (GHCR)

--- a/deploy/azure/runbooks/rate-limit-exhaustion.md
+++ b/deploy/azure/runbooks/rate-limit-exhaustion.md
@@ -23,16 +23,16 @@
    ```
 3. **If burst from container scaling:** Check replica count — multiple instances share the rate limit
    ```bash
-   az containerapp revision list --name ai-rosetta-stone -g ai-triad --query "[?properties.active].{name:name, replicas:properties.replicas}" -o table
+   az containerapp revision list --name taxonomy-editor -g ai-triad --query "[?properties.active].{name:name, replicas:properties.replicas}" -o table
    ```
 4. **Immediate mitigation:** Scale to 0 temporarily to stop polling storm:
    ```bash
-   az containerapp update --name ai-rosetta-stone -g ai-triad --min-replicas 0 --max-replicas 0
+   az containerapp update --name taxonomy-editor -g ai-triad --min-replicas 0 --max-replicas 0
    ```
 5. **Wait for reset:** Rate limit resets hourly. Check `github.rateLimit.resetsAt` on `/health`.
 6. **Restore:** Scale back up:
    ```bash
-   az containerapp update --name ai-rosetta-stone -g ai-triad --min-replicas 1 --max-replicas 5
+   az containerapp update --name taxonomy-editor -g ai-triad --min-replicas 1 --max-replicas 5
    ```
 
 ## Prevention

--- a/deploy/azure/runbooks/token-keyvault-failure.md
+++ b/deploy/azure/runbooks/token-keyvault-failure.md
@@ -18,7 +18,7 @@
 
 2. **Check managed identity assignment:**
    ```bash
-   az containerapp show --name ai-rosetta-stone -g ai-triad --query "identity"
+   az containerapp show --name taxonomy-editor -g ai-triad --query "identity"
    ```
    Should show `type: SystemAssigned` with a `principalId`.
 
@@ -40,8 +40,8 @@
 6. **Force token refresh:**
    ```bash
    # Restart the container to clear cached token
-   ACTIVE=$(az containerapp revision list --name ai-rosetta-stone -g ai-triad --query "[?properties.trafficWeight > \`0\`].name | [0]" -o tsv)
-   az containerapp revision restart --name ai-rosetta-stone -g ai-triad --revision "$ACTIVE"
+   ACTIVE=$(az containerapp revision list --name taxonomy-editor -g ai-triad --query "[?properties.trafficWeight > \`0\`].name | [0]" -o tsv)
+   az containerapp revision restart --name taxonomy-editor -g ai-triad --revision "$ACTIVE"
    ```
 
 ## Prevention

--- a/docs/data-flow-azure.md
+++ b/docs/data-flow-azure.md
@@ -216,15 +216,15 @@ GitHub (ai-triad-data, main branch)
 
 ```bash
 # 1. Check health endpoint
-curl https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/healthz
+curl https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/healthz
 # Expected: {"status":"healthy","dataRoot":"/data"}
 
 # 2. Check data availability
-curl https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/data/available
+curl https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/data/available
 # Expected: true
 
 # 3. Check copy status (during startup)
-curl https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/status
+curl https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/status
 # Expected: {"state":"complete"} or progress details
 ```
 
@@ -232,11 +232,11 @@ curl https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/s
 
 ```bash
 # 4. Check what git revision the app is running from (NOTE: POST, not GET)
-curl -X POST https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/data/check-updates
+curl -X POST https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/data/check-updates
 # Shows local HEAD vs origin/main — are they the same?
 
 # 5. Check sync status (uncommitted local changes)
-curl https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/sync/status
+curl https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/sync/status
 # Shows count of files changed locally but not committed
 ```
 
@@ -265,18 +265,18 @@ Debates save to `{dataRoot}/debates/` on every action (turn, phase transition, r
 
 ```bash
 # List debates via API
-curl https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/debates
+curl https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/debates
 ```
 
 ### Container Logs (for deeper diagnosis)
 
 ```bash
 # Console logs (app output)
-az containerapp logs show --name ai-rosetta-stone -g ai-triad \
+az containerapp logs show --name taxonomy-editor -g ai-triad \
   --type console --tail 100
 
 # System events (probes, OOM, restarts)
-az containerapp logs show --name ai-rosetta-stone -g ai-triad \
+az containerapp logs show --name taxonomy-editor -g ai-triad \
   --type system --tail 50
 ```
 

--- a/docs/github-api-first-briefing.md
+++ b/docs/github-api-first-briefing.md
@@ -35,7 +35,7 @@ The code repo never contains data. The data repo is the single source of truth f
 The **Taxonomy Editor** is the primary app. It runs in two modes:
 
 - **Desktop (Electron)**: Runs locally on macOS/Windows. Reads/writes data directly from the local filesystem via Node.js `fs` module. The data repo is cloned locally.
-- **Web (Azure Container Apps)**: Hosted at `https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io`. A Node.js HTTP server serves a React SPA. Currently reads/writes data from an Azure Files SMB mount that contains a clone of the data repo.
+- **Web (Azure Container Apps)**: Hosted at `https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io`. A Node.js HTTP server serves a React SPA. Currently reads/writes data from an Azure Files SMB mount that contains a clone of the data repo.
 
 Both modes share the same React frontend. A "bridge" pattern abstracts the difference: `electron-bridge.ts` (IPC to Electron main process) vs `web-bridge.ts` (REST calls to server). The bridge implements a shared `AppAPI` interface with 100+ methods.
 

--- a/docs/multi-environment-deployment-plan.md
+++ b/docs/multi-environment-deployment-plan.md
@@ -6,7 +6,7 @@ The AI Triad project currently has a single Azure Container Apps deployment. We 
 
 ## Current State
 
-- **Single deployment**: `ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io`
+- **Single deployment**: `taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io`
 - **Single Azure Files share**: `/data` (10 GB) with taxonomy, debates, summaries
 - **Single data repo**: `jpsnover/ai-triad-data` on GitHub (main branch)
 - **Git sync exists** (`gitRepoStore.ts`): per-user session branches, commit-on-write, PR creation, rebase conflict resolution — but only Phase 1-2 are implemented

--- a/docs/sync-github-app-setup.md
+++ b/docs/sync-github-app-setup.md
@@ -11,8 +11,8 @@ doc is the one-time setup needed to actually turn it on.
 | Field | Value |
 |---|---|
 | GitHub App name | `ai-triad-sync` (or similar — must be globally unique) |
-| Homepage URL | `https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io` |
-| Webhook URL | `https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/sync/webhook/github` |
+| Homepage URL | `https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io` |
+| Webhook URL | `https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io/api/sync/webhook/github` |
 | Webhook secret | generate with `openssl rand -hex 32` — save this, we need it below |
 | Callback URL | (leave blank) |
 | Expire user authorization tokens | leave default |

--- a/scripts/AITriad/Private/Get-TaxEditorBaseUrl.ps1
+++ b/scripts/AITriad/Private/Get-TaxEditorBaseUrl.ps1
@@ -8,7 +8,7 @@
 # Env-var override lets ops re-point cmdlets at a staging revision without
 # editing code (e.g., $env:TAXEDITOR_BASE_URL = 'https://taxonomy-editor--stg.-.io').
 
-$script:TaxEditorBaseUrlDefault = 'https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io'
+$script:TaxEditorBaseUrlDefault = 'https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io'
 
 function Get-TaxEditorBaseUrl {
     <#
@@ -23,7 +23,7 @@ function Get-TaxEditorBaseUrl {
         Trailing slash is stripped so consumers can safely do "$BaseUrl/api/foo".
     .EXAMPLE
         Get-TaxEditorBaseUrl
-        # https://ai-rosetta-stone.yellowbush-aeda037d.eastus.azurecontainerapps.io
+        # https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io
 
         $env:TAXEDITOR_BASE_URL = 'https://taxonomy-editor--staging.eastus.azurecontainerapps.io'
         Get-TaxEditorBaseUrl


### PR DESCRIPTION
## Summary

Atomic `git revert 0a8e16a7` — reverts the complete rename commit across all 18 files.

The rename was applied to `origin/main` before Azure resources were actually renamed. `ai-rosetta-stone` never existed in Azure, causing:
- health-monitor.yml hitting a non-existent FQDN → false 404 alert (~24h, issue #602)
- `main.bicep` declaring `ai-rosetta-stone` as the ACA resource name — **next `deploy-azure.yml` run would rename the live app for real → prod outage**
- `Get-TaxEditorBaseUrl.ps1` and `Sync-AzureTriadData.ps1` pointing to broken URLs

Previous PR #689 was a **partial** manual revert (4/18 files) and was closed in favor of this complete revert.

## What this reverts

All 18 files from commit `0a8e16a7`:

| Category | Files |
|---|---|
| IaC | `deploy/azure/main.bicep` |
| CI/CD | `deploy-azure.yml`, `deploy-staging.yml`, `health-monitor.yml` |
| PowerShell | `Get-TaxEditorBaseUrl.ps1`, `Sync-AzureTriadData.ps1` |
| Runbooks | `deployment-facts.md`, `operational-commands.md`, `production-release.md`, `cache-corruption.md`, `rate-limit-exhaustion.md`, `token-keyvault-failure.md`, `api-mode-cutover-checklist.md` |
| Docs | `data-flow-azure.md`, `github-api-first-briefing.md`, `multi-environment-deployment-plan.md`, `sync-github-app-setup.md`, `README.md` |

## Verification

- `git grep ai-rosetta-stone` on this branch → **0 matches**
- Live production app: `taxonomy-editor` → `/healthz` 200 ✓
- `main.bicep` resource names restored to `taxonomy-editor` / `taxonomy-editor-staging`

## Test plan

- [ ] CI green
- [ ] Health monitor next run passes (no new issue)
- [ ] TL admin-merge

Re-apply the rename correctly **after** `az containerapp update --name taxonomy-editor --new-name ai-rosetta-stone` runs and staging is verified healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)