### PR TITLE
docs(sage): record #157 — gh pr reopen fails on Dependabot PRs

### DIFF
--- a/operations/sage/docs/LessonsLearned.md
+++ b/operations/sage/docs/LessonsLearned.md
@@ -3219,3 +3219,23 @@ Institutional memory for failure patterns across the AI Triad Research project.
 **Status:** Active — 1 instance (DevOps p/26#70).
 
 **Applies To:** All agents opening PRs from the shared checkout or any context where the working tree may be dirty.
+
+---
+
+## #157 [Build] `gh pr reopen` Fails on Dependabot PRs — Branch Deleted on Close; Use `@dependabot recreate`
+
+**Pattern:** `gh pr reopen <n>` returns "Could not open the pull request" for a closed Dependabot PR. Dependabot deletes its branch when a PR is closed — GitHub's GraphQL reopen mutation requires the head branch to exist. Attempting to reopen via `gh` or the GitHub UI both fail silently.
+
+**Instances:**
+- 2026-08-09 — DevOps (p/26#72): `gh pr reopen 649` failed — Dependabot branch deleted on close, making reopen impossible via GraphQL. Fix: commented `@dependabot recreate` on the closed PR; Dependabot opens a fresh PR.
+
+**Root Cause:** Dependabot auto-deletes its branch when a PR is closed (not merged). GitHub's reopen API requires the branch to exist. This is Dependabot-specific behavior — human PRs usually retain their branch after closing.
+
+**Prevention:**
+1. **Never `gh pr reopen` a closed Dependabot PR** — the branch is gone; reopen will always fail.
+2. **To reactivate a closed Dependabot PR:** comment `@dependabot recreate` on the closed PR — Dependabot creates a fresh branch and opens a new PR.
+3. **To rebase an open Dependabot PR:** comment `@dependabot rebase`.
+
+**Status:** Active — 1 instance (DevOps p/26#72).
+
+**Applies To:** All agents managing Dependabot PRs.

--- a/operations/sage/docs/lessons/build.md
+++ b/operations/sage/docs/lessons/build.md
@@ -1987,3 +1987,23 @@ Failure patterns related to builds, CI, tooling, environment, and git operations
 **Status:** Active — 1 instance (DevOps p/26#70).
 
 **Applies To:** All agents opening PRs from the shared checkout or any dirty working tree.
+
+---
+
+## #157 [Build] `gh pr reopen` Fails on Dependabot PRs — Branch Deleted on Close; Use `@dependabot recreate`
+
+**Pattern:** `gh pr reopen` fails on closed Dependabot PRs — Dependabot deletes its branch on close; GitHub's reopen API requires the branch to exist.
+
+**Instances:**
+- 2026-08-09 — DevOps (p/26#72): `gh pr reopen 649` failed. Fix: `@dependabot recreate` comment on the closed PR.
+
+**Root Cause:** Dependabot auto-deletes its branch on close. Reopen requires the branch; this is Dependabot-specific (human PRs usually retain their branch).
+
+**Prevention:**
+1. Never `gh pr reopen` a closed Dependabot PR — the branch is gone.
+2. To reactivate: comment `@dependabot recreate` — opens a fresh PR.
+3. To rebase an open Dependabot PR: comment `@dependabot rebase`.
+
+**Status:** Active — 1 instance (DevOps p/26#72).
+
+**Applies To:** All agents managing Dependabot PRs.


### PR DESCRIPTION
Records Pattern #157 from DevOps p/26#72.

**#157 (new)** — `gh pr reopen` returns "Could not open the pull request" for closed Dependabot PRs. Dependabot deletes its branch on close; GitHub's reopen API requires the branch to exist. Fix: comment `@dependabot recreate` on the closed PR — Dependabot opens a fresh one.

**Files changed:** LessonsLearned.md, lessons/build.md

🤖 Sage (Orca) — operations/sage
