### PR TITLE
feat(pov): move soul-document icon to the left of the POV name (t/2348)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/PovTab.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/PovTab.css
@@ -1,3 +1,11 @@
+/* Left group in the list-panel header: soul-doc icon sits immediately left of the POV name (t/2348) */
+.list-panel-header-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 .dt-filter-bar {
   display: flex;
   align-items: center;

--- a/taxonomy-editor/src/renderer/components/taxonomy/PovTab.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/PovTab.tsx
@@ -814,7 +814,10 @@ export function PovTab({ pov }: PovTabProps) {
         // eslint-disable-next-line local/no-inline-style -- width is a user-resized panel size from useResizablePanel
         <div className="list-panel" ref={listPanelRef} style={{ width }}>
           <div className="list-panel-header">
-            <h2>{pov}</h2>
+            <div className="list-panel-header-title">
+              <button className="btn btn-sm btn-ghost" onClick={() => setShowSoulDoc(true)} title="Soul document">&#x1f4dc;</button>
+              <h2>{pov}</h2>
+            </div>
             <div className="list-panel-header-actions">
               <select
                 className="sort-select"
@@ -832,7 +835,6 @@ export function PovTab({ pov }: PovTabProps) {
               <button className="btn btn-sm" onClick={() => setShowNewDialog(true)}>
                 + New
               </button>
-              <button className="btn btn-sm btn-ghost" onClick={() => setShowSoulDoc(true)} title="Soul document">&#x1f4dc;</button>
               <button className="pane-collapse-btn" onClick={() => setListCollapsed(true)} title="Collapse">&lsaquo;</button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Moves the 📜 **soul-document** icon in the POV list-panel header from the right-hand actions row to **immediately left of the POV name** (e.g. left of "SAFETYIST"), per t/2348.

## Change
- `PovTab.tsx`: wrap the soul-doc `<button>` + `<h2>{pov}</h2>` in a new `.list-panel-header-title` flex group (left side); removed the button from `.list-panel-header-actions`. Handler/state unchanged (`showSoulDoc` → `SoulDocDialog`) — **no behavior change**, icon still opens the dialog.
- `PovTab.css`: add `.list-panel-header-title { display:flex; align-items:center; gap:6px; min-width:0 }`. New selector in the **co-located** CSS (styles.css is frozen). `min-width:0` lets the name ellipsize rather than wrap at narrow widths.

## Self-cert
`/trivial-change`: single scope (components/taxonomy/, Rosetta-owned), 12 additions / 2 deletions, no new public API / interface / schema / auth surface. tsc clean; the only eslint warnings on PovTab.tsx are pre-existing complexity warnings, unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)