### PR TITLE
feat(shared): TheoryLink component + F1-to-nearest hotkey (t/2343)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -36,6 +36,7 @@ import { QuotaBanner } from './components/shared/QuotaBanner';
 import { EmbeddingsStaleBanner } from './components/shared/EmbeddingsStaleBanner';
 import { pullDataTracked } from './utils/syncApi';
 import { useFeatureFlagStore, useFlag } from './hooks/useFeatureFlags';
+import { useTheoryLinkHotkey } from './hooks/useTheoryLinkHotkey';
 import { PrecacheToast } from './components/shared/PrecacheToast';
 import { usePrecache } from './hooks/usePrecache';
 import { DiagnosticsDrawer } from './components/shared/DiagnosticsDrawer';
@@ -174,6 +175,10 @@ export function App() {
   }, []);
 
   useEffect(() => { void useFeatureFlagStore.getState().refresh(); }, []);
+
+  // F1-to-nearest TheoryLink — registered before the popout early-returns so it
+  // covers the main app and every window mode App renders (t/2343).
+  useTheoryLinkHotkey();
 
   // If this window was opened as a diagnostics popout, render only that
   if (hash === '#diagnostics-window') {

--- a/taxonomy-editor/src/renderer/components/debate/DebatePopoutWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebatePopoutWindow.tsx
@@ -12,6 +12,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useDebateStore } from '../../hooks/useDebateStore';
 import { markAsPopout } from '../../hooks/useDebateStore/shared/guards';
 import { usePopoutTheme } from '../../hooks/usePopoutTheme';
+import { useTheoryLinkHotkey } from '../../hooks/useTheoryLinkHotkey';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { DebateWorkspace } from '../debate-workspace';
 import { parseDebateHash, shouldShowLoadError, type DebateLoadTarget } from './popoutLoad';
@@ -22,6 +23,7 @@ import './DebatePopoutWindow.css';
 
 export function DebatePopoutWindow() {
   usePopoutTheme();
+  useTheoryLinkHotkey(); // F1-to-nearest must work in the popout document too (t/2343)
   useEffect(() => { markAsPopout(); }, []);
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.css
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.css
@@ -1,0 +1,49 @@
+/* TheoryLink (t/2343) — mirrors .field-help-btn tokens: muted foreground, brightens on hover.
+   Co-located because styles.css is frozen (no new selectors). */
+.theory-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  line-height: 1;
+  vertical-align: middle;
+  transition: color 0.15s;
+}
+
+.theory-link:hover,
+.theory-link:focus-visible {
+  color: var(--focus-ring);
+}
+
+.theory-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.theory-link-book {
+  width: 1em;
+  height: 1em;
+  display: block;
+}
+
+/* Small ↗ external-jump badge tucked into the top-right corner of the glyph. */
+.theory-link-badge {
+  position: absolute;
+  top: -0.15em;
+  right: -0.32em;
+  width: 0.62em;
+  height: 0.62em;
+  display: block;
+}
+
+.theory-link-badge svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.test.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const openExternal = vi.fn().mockResolvedValue(undefined);
+vi.mock('@bridge', () => ({ api: { openExternal: (url: string) => openExternal(url) } }));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+
+import { TheoryLink } from './TheoryLink';
+
+const URL = 'https://github.com/org/repo/blob/main/docs/theory.md';
+
+describe('TheoryLink', () => {
+  beforeEach(() => { openExternal.mockClear(); });
+
+  it('renders a button with the distinct aria-label and default tooltip', () => {
+    render(<TheoryLink url={URL} label="Help: debate overview" />);
+    const btn = screen.getByRole('button', { name: 'Help: debate overview' });
+    expect(btn).toHaveAttribute('title', 'Open theory notes on GitHub');
+    expect(btn).toHaveAttribute('data-theory-link');
+  });
+
+  it('appends className to the base class (never replaces it)', () => {
+    render(<TheoryLink url={URL} label="Help" className="inline-heading" />);
+    const btn = screen.getByRole('button', { name: 'Help' });
+    expect(btn.className).toContain('theory-link');
+    expect(btn.className).toContain('inline-heading');
+  });
+
+  it('clamps size to 14–16px', () => {
+    const { rerender } = render(<TheoryLink url={URL} label="H" size={40} />);
+    expect(screen.getByRole('button').style.fontSize).toBe('16px');
+    rerender(<TheoryLink url={URL} label="H" size={2} />);
+    expect(screen.getByRole('button').style.fontSize).toBe('14px');
+    rerender(<TheoryLink url={URL} label="H" size={15} />);
+    expect(screen.getByRole('button').style.fontSize).toBe('15px');
+  });
+
+  it('opens the url externally on click (via bridge, not window/shell)', async () => {
+    const user = userEvent.setup();
+    render(<TheoryLink url={URL} label="Help" />);
+    await user.click(screen.getByRole('button', { name: 'Help' }));
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith(URL);
+  });
+
+  it('activates on Enter and Space (native button keyboard)', async () => {
+    const user = userEvent.setup();
+    render(<TheoryLink url={URL} label="Help" />);
+    const btn = screen.getByRole('button', { name: 'Help' });
+    btn.focus();
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+    expect(openExternal).toHaveBeenCalledTimes(2);
+    expect(openExternal).toHaveBeenCalledWith(URL);
+  });
+
+  it('uses a custom tooltip when provided', () => {
+    render(<TheoryLink url={URL} label="Help" tooltip="Read the spec" />);
+    expect(screen.getByRole('button', { name: 'Help' })).toHaveAttribute('title', 'Read the spec');
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * TheoryLink (t/2343) — shared open-book help affordance that opens an external
+ * GitHub theory-notes doc. Muted glyph that brightens on hover (mirrors
+ * .field-help-btn), with a small ↗ external-jump badge + tooltip so the
+ * open-in-browser behavior is discoverable.
+ *
+ * Activation routes through the bridge (`api.openExternal`) — never shell/window
+ * directly — so it works in both the Electron (shell.openExternal) and web
+ * (window.open, https-guarded) builds.
+ *
+ * The `data-theory-link` attribute marks the button for the app-level F1
+ * hotkey (see useTheoryLinkHotkey), which activates the nearest instance.
+ */
+
+import { api } from '@bridge';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import './TheoryLink.css';
+
+export interface TheoryLinkProps {
+  /** Full GitHub blob URL to open externally. */
+  url: string;
+  /** Accessible label, distinct per instance (e.g. "Help: debate system overview"). */
+  label: string;
+  /** Glyph size in px, clamped to 14–16. Default 15. */
+  size?: number;
+  /** Hover tooltip text. Default "Open theory notes on GitHub". */
+  tooltip?: string;
+  /** Extra class(es) for inline positioning by consumers — appended to the base class. */
+  className?: string;
+}
+
+const DEFAULT_TOOLTIP = 'Open theory notes on GitHub';
+
+export function TheoryLink({ url, label, size = 15, tooltip = DEFAULT_TOOLTIP, className }: TheoryLinkProps) {
+  const px = Math.min(16, Math.max(14, size));
+
+  const handleOpen = () => {
+    void api.openExternal(url).catch((err) => {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'theory-link',
+        level: 'error',
+        message: 'Failed to open theory link externally',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className={`theory-link ${className ?? ''}`}
+      data-theory-link
+      aria-label={label}
+      title={tooltip}
+      onClick={handleOpen}
+      // eslint-disable-next-line local/no-inline-style -- dynamic glyph size (14–16px) drives the 1em SVG
+      style={{ fontSize: `${px}px` }}
+    >
+      {/* Open-book glyph (currentColor so it can be tinted muted → hover-brighten) */}
+      <svg className="theory-link-book" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+        <path d="M2 4h6a3 3 0 0 1 3 3v13a2.5 2.5 0 0 0-2.5-2H2z" />
+        <path d="M22 4h-6a3 3 0 0 0-3 3v13a2.5 2.5 0 0 1 2.5-2H22z" />
+      </svg>
+      {/* External-jump badge (↗) — visual affordance paired with the tooltip text */}
+      <span className="theory-link-badge" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" focusable="false">
+          <line x1="6" y1="18" x2="18" y2="6" />
+          <polyline points="9 6 18 6 18 15" />
+        </svg>
+      </span>
+    </button>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/shared/index.ts
+++ b/taxonomy-editor/src/renderer/components/shared/index.ts
@@ -23,6 +23,7 @@ export * from './ProposalReviewDialog';
 export * from './ReflectionsPanel';
 export * from './StartupProgressScreen';
 export * from './TabBar';
+export * from './TheoryLink';
 export * from './TerminalPanel';
 export * from './TimelineScrubber';
 export * from './Toolbar';

--- a/taxonomy-editor/src/renderer/hooks/useTheoryLinkHotkey.test.tsx
+++ b/taxonomy-editor/src/renderer/hooks/useTheoryLinkHotkey.test.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+import { render, act } from '@testing-library/react';
+
+const openExternal = vi.fn().mockResolvedValue(undefined);
+vi.mock('@bridge', () => ({ api: { openExternal: (url: string) => openExternal(url) } }));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+
+import { TheoryLink } from '../components/shared/TheoryLink';
+import { useTheoryLinkHotkey } from './useTheoryLinkHotkey';
+
+// jsdom does no layout: offsetParent is null and getClientRects() is empty, so the
+// hook's visibility filter would drop every link. Make attached elements report visible.
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    configurable: true,
+    get() { return this.parentNode; },
+  });
+});
+
+function HookMount() { useTheoryLinkHotkey(); return null; }
+
+function pressF1() {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'F1', bubbles: true }));
+  });
+}
+
+function stubRect(el: Element, left: number, top: number) {
+  el.getBoundingClientRect = () => ({ left, top, right: left + 10, bottom: top + 10, width: 10, height: 10, x: left, y: top, toJSON: () => ({}) }) as DOMRect;
+}
+
+describe('useTheoryLinkHotkey', () => {
+  beforeEach(() => { openExternal.mockClear(); });
+  afterEach(() => { document.body.innerHTML = ''; });
+
+  it('F1 activates the TheoryLink in the focused element\'s enclosing section', () => {
+    render(
+      <>
+        <HookMount />
+        <section data-testid="sec-a">
+          <input data-testid="input-a" />
+          <TheoryLink url="https://x/a" label="A" />
+        </section>
+        <section>
+          <TheoryLink url="https://x/b" label="B" />
+        </section>
+      </>,
+    );
+    (document.querySelector('[data-testid="input-a"]') as HTMLElement).focus();
+    pressF1();
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://x/a');
+  });
+
+  it('is a no-op (does not open anything) when no TheoryLink is present', () => {
+    render(<><HookMount /><input /></>);
+    (document.querySelector('input') as HTMLElement).focus();
+    pressF1();
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the geometrically nearest link when focus has no enclosing link', () => {
+    render(
+      <>
+        <HookMount />
+        <TheoryLink url="https://x/near" label="near" />
+        <TheoryLink url="https://x/far" label="far" />
+        <input data-testid="anchor" />
+      </>,
+    );
+    const anchor = document.querySelector('[data-testid="anchor"]') as HTMLElement;
+    const [near, far] = Array.from(document.querySelectorAll('.theory-link')) as HTMLElement[];
+    stubRect(anchor, 100, 100);
+    stubRect(near, 110, 105); // close to anchor
+    stubRect(far, 900, 900);  // far away
+    anchor.focus();
+    pressF1();
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://x/near');
+  });
+
+  it('fires exactly once even when the hook is registered by two components (ref-counted single listener)', () => {
+    render(
+      <>
+        <HookMount />
+        <HookMount />
+        <TheoryLink url="https://x/solo" label="solo" />
+      </>,
+    );
+    (document.querySelector('.theory-link') as HTMLElement).focus();
+    pressF1();
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://x/solo');
+  });
+
+  it('removes the listener on unmount', () => {
+    const { unmount } = render(<><HookMount /><TheoryLink url="https://x/a" label="A" /></>);
+    unmount();
+    pressF1();
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useTheoryLinkHotkey.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTheoryLinkHotkey.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * useTheoryLinkHotkey (t/2343) — app-root F1 handler that activates the nearest
+ * TheoryLink. Register once at each window root; the popout is a separate
+ * document so it must register too (App.tsx renders it, and DebatePopoutWindow
+ * registers as well — the ref-counted guard below makes double-registration a
+ * no-op, so exactly one keydown listener exists per document and F1 fires once).
+ *
+ * Resolution is pure-DOM (no registry): from the focused element, climb ancestors
+ * and take the nearest enclosing section that contains a visible TheoryLink;
+ * within that section (or as a whole-document fallback) pick the geometrically
+ * nearest one. If no TheoryLink is present we do NOT preventDefault, leaving F1's
+ * default behavior intact.
+ */
+
+import { useEffect } from 'react';
+
+const SELECTOR = '.theory-link[data-theory-link]';
+
+function isVisible(el: HTMLElement): boolean {
+  // offsetParent is null for display:none (and fixed elements, which we don't use here).
+  return el.offsetParent !== null || el.getClientRects().length > 0;
+}
+
+function visibleLinks(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(SELECTOR)).filter(isVisible);
+}
+
+function centerDistanceSq(a: DOMRect, b: DOMRect): number {
+  const ax = a.left + a.width / 2;
+  const ay = a.top + a.height / 2;
+  const bx = b.left + b.width / 2;
+  const by = b.top + b.height / 2;
+  return (ax - bx) ** 2 + (ay - by) ** 2;
+}
+
+function geometricNearest(candidates: HTMLElement[], ref: Element): HTMLElement {
+  const refRect = ref.getBoundingClientRect();
+  let best = candidates[0];
+  let bestD = Infinity;
+  for (const el of candidates) {
+    const d = centerDistanceSq(refRect, el.getBoundingClientRect());
+    if (d < bestD) {
+      bestD = d;
+      best = el;
+    }
+  }
+  return best;
+}
+
+/** Returns true if a TheoryLink was found and activated. */
+export function activateNearestTheoryLink(): boolean {
+  const all = visibleLinks();
+  if (all.length === 0) return false;
+  const allSet = new Set(all);
+  const active = document.activeElement as HTMLElement | null;
+
+  // 1. Ancestor-walk: nearest enclosing section that contains a visible TheoryLink
+  //    ("the section you're in"), with geometric tie-break inside that section.
+  if (active && active !== document.body) {
+    let node: HTMLElement | null = active;
+    while (node) {
+      const within = Array.from(node.querySelectorAll<HTMLElement>(SELECTOR)).filter((el) => allSet.has(el));
+      if (within.length > 0) {
+        (within.length === 1 ? within[0] : geometricNearest(within, active)).click();
+        return true;
+      }
+      node = node.parentElement;
+    }
+  }
+
+  // 2. Fallback: geometrically nearest to the focused element (or viewport-ish body).
+  geometricNearest(all, active ?? document.body).click();
+  return true;
+}
+
+// Module-level ref-counted listener: multiple callers in the same document share
+// ONE keydown listener, so App.tsx + DebatePopoutWindow both registering never
+// double-fires F1. Per-document module state (each BrowserWindow has its own JS
+// context), so every window still gets its own single listener.
+let listenerCount = 0;
+let handler: ((e: KeyboardEvent) => void) | null = null;
+
+function ensureListener(): void {
+  if (listenerCount === 0) {
+    handler = (e: KeyboardEvent) => {
+      if (e.key !== 'F1') return;
+      if (activateNearestTheoryLink()) e.preventDefault();
+    };
+    window.addEventListener('keydown', handler, true);
+  }
+  listenerCount += 1;
+}
+
+function releaseListener(): void {
+  listenerCount -= 1;
+  if (listenerCount <= 0) {
+    listenerCount = 0;
+    if (handler) {
+      window.removeEventListener('keydown', handler, true);
+      handler = null;
+    }
+  }
+}
+
+export function useTheoryLinkHotkey(): void {
+  useEffect(() => {
+    ensureListener();
+    return releaseListener;
+  }, []);
+}


### PR DESCRIPTION
## Summary
Shared **TheoryLink** open-book help affordance that opens an external GitHub theory-notes doc, plus the **F1-to-nearest** hotkey. Prereq (t/2343, parent t/2342) unblocking the 4 mount tickets (t/2344–2347). TL design sign-off: t/2343#4.

## What's here
- **`shared/TheoryLink.tsx`** + co-located **`TheoryLink.css`** (styles.css is frozen). `currentColor` inline SVG open-book + ↗ external-jump badge; muted `var(--text-muted)` → hover `var(--focus-ring)`, mirroring `.field-help-btn`. Props: `url`, `label` (aria-label), `size` (clamped 14–16), `tooltip`, `className` (**appended** to base — TL condition 1). Activation → `api.openExternal` (bridge; Electron shell.openExternal + web window.open) — never shell/window directly.
- **`hooks/useTheoryLinkHotkey.ts`** — F1 activates the nearest TheoryLink: pure-DOM ancestor-walk (nearest enclosing section) + geometric-nearest fallback; no `preventDefault` when none present. **Ref-counted single listener** so registering in both `App.tsx` (covers all window modes) and `DebatePopoutWindow.tsx` (separate document — TL condition 2) never double-fires.
- **`shared/index.ts`** re-export.
- **11 unit tests** (aria-label, className-append, size-clamp, click + Enter + Space → openExternal; F1 ancestor-walk + geometric fallback + no-op-when-absent + single-fire + cleanup).

## TL conditions
1. ✅ `className` reinstated (appended to base class).
2. ✅ Hook registered in App root **and** DebatePopoutWindow root; ref-count prevents double-fire.
3. ⚠️ **Theme legibility — see note.** No mount consumer exists yet (the 4 mounts are blocked on this prereq), so nothing renders TheoryLink in-app to eyeball, and the shared dev port 5173 is currently held by another instance. Verified by **token-parity**: identical tokens to the shipped, Design-reviewed `.field-help-btn` (muted → focus-ring) across all themes. Proposing the live 4-theme + popout eyeball at first mount (t/2344). **Flagged to TL for concurrence before merge.**

## Cross-scope note
`DebatePopoutWindow.tsx` is DebateUI scope; the 2-line hook registration there is **TL-directed** (t/2343#4 condition 2) for popout F1 coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)