### PR TITLE
docs: policy count (t/2351) + CONVERGES_WITH 8th edge type (t/2352)

### DIFF
--- a/docs/artifact-guide.md
+++ b/docs/artifact-guide.md
@@ -348,7 +348,7 @@ The key design insight is that the same policy can be referenced by multiple nod
 
 ### Where They Are Stored
 
-- **Central registry**: `taxonomy/Origin/policy_actions.json` — the single source of truth for all ~270 policies with their `id`, `action`, `source_povs`, and `member_count`
+- **Central registry**: `taxonomy/Origin/policy_actions.json` — the single source of truth for all ~1,547 policies with their `id`, `action`, `source_povs`, and `member_count`
 - **On taxonomy nodes**: `node.graph_attributes.policy_actions[]` — array of `{ policy_id, action, framing }` objects linking the node to specific policies with node-specific framing
 - **Policy-to-policy edges**: `taxonomy/Origin/edges.json` — ~452 edges typed CONTRADICTS, COMPLEMENTS, or TENSION_WITH between policies
 - **Policy embeddings**: `taxonomy/Origin/embeddings.json` — 384-dimensional vectors (all-MiniLM-L6-v2) for policy text, enabling semantic similarity search

--- a/docs/taxonomy-ontology-guide.md
+++ b/docs/taxonomy-ontology-guide.md
@@ -151,9 +151,11 @@ This field is populated organically by the attribute extraction process, not bat
 
 **Canonical edge types:**
 
-The taxonomy uses 7 AIF-aligned edge types for relationships between nodes:
+The taxonomy uses 8 canonical edge types for relationships between nodes. The first seven are AIF-aligned; `CONVERGES_WITH` is the project's consensus/convergence extension (not a native AIF locution):
 
-`SUPPORTS`, `CONTRADICTS`, `ASSUMES`, `WEAKENS`, `RESPONDS_TO`, `TENSION_WITH`, `INTERPRETS`
+`SUPPORTS`, `CONTRADICTS`, `ASSUMES`, `WEAKENS`, `RESPONDS_TO`, `TENSION_WITH`, `INTERPRETS`, `CONVERGES_WITH`
+
+`CONVERGES_WITH` marks that a POV/camp node has reached consensus with another node (e.g. a situation node); it drives debate convergence scoring but is semantically inert in QBAF strength computation (QBAF mapping tracked in B-305).
 
 ---
 
@@ -217,7 +219,7 @@ interpretations   conceptual)           interact
   - `scheme` — an argumentative pattern or reasoning method
   - `bridging` — connects claims to schemes (rare)
 - If the node has `possible_fallacies`, each must have a `type` field (one of: `formal`, `informal_structural`, `informal_contextual`, `cognitive_bias`) and a `confidence` level (`likely`, `possible`, `borderline`).
-- Edge types connecting this node to others must be one of the 7 canonical types.
+- Edge types connecting this node to others must be one of the 8 canonical types.
 
 ### When Adding a Situation Node
 


### PR DESCRIPTION
Two doc-accuracy fixes from the 2026-08-09 CL review.

**t/2352 (complete)** — `taxonomy-ontology-guide.md`: "7 AIF-aligned edge types" → **8 canonical edge types**, append `CONVERGES_WITH` + gloss. TL ruled it sanctioned (schema enum, PS writer, edge-discovery prompts, convergence scoring, renderer); QBAF mapping tracked in B-305. Both "7" references fixed (L154, L222).

**t/2351 (partial)** — `artifact-guide.md`: policy registry `~270` → **`~1,547`** (`policy_actions.json` policy_count). Remaining t/2351 items flagged to TL: the policy-to-policy-edges paragraph (data has 0 such edges vs stated ~452; code path exists) and the lineage §6 restructure.

Docs-only; no code paths.