### PR TITLE
feat(debate): mount TheoryLink in Debates list-view header (t/2346)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -23,6 +23,7 @@ import { PromptDetailPanel } from '../chat/PromptsPanel';
 import type { PromptCatalogEntry } from '../../data/promptCatalog';
 import { PROMPT_CATALOG } from '../../data/promptCatalog';
 import { ToolbarPaneRenderer, isFullWidthPanel, PhoneToolClose } from '../shared/ToolbarPaneRenderer';
+import { TheoryLink } from '../shared';
 import { LineageDetailView } from '../shared/LineageDetailView';
 import type { DebateSession } from '../../types/debate';
 import { POVER_INFO } from '@lib/debate/types';
@@ -617,6 +618,7 @@ function DebateListHeaderActions(props: DebateListProps) {
           <button className="btn btn-sm" onClick={handleNewDebate}>
             + New
           </button>
+          <TheoryLink url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/theory-of-success.md" label="Help: theory of success" />
           <button className="pane-collapse-btn" onClick={() => setListCollapsed(true)} title="Collapse" aria-label="Collapse panel">&lsaquo;</button>
         </>
       ) : (

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -23,7 +23,7 @@ import { PromptDetailPanel } from '../chat/PromptsPanel';
 import type { PromptCatalogEntry } from '../../data/promptCatalog';
 import { PROMPT_CATALOG } from '../../data/promptCatalog';
 import { ToolbarPaneRenderer, isFullWidthPanel, PhoneToolClose } from '../shared/ToolbarPaneRenderer';
-import { TheoryLink } from '../shared';
+import { TheoryLink } from '../shared/TheoryLink';
 import { LineageDetailView } from '../shared/LineageDetailView';
 import type { DebateSession } from '../../types/debate';
 import { POVER_INFO } from '@lib/debate/types';


### PR DESCRIPTION
## Summary
- Mounts `TheoryLink` in `DebateListHeaderActions` so users can open the theory-of-success doc directly from the Debates list-view header (t/2346)
- Depends on TheoryLink component (t/2343, PR #695, already on main)

## Test plan
- [x] tsc --noEmit: clean
- [x] ESLint `--max-warnings=4256`: exit 0
- [x] depcruise: no violations (1443 modules)
- [ ] CI full gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)