### PR TITLE
feat(sync): mount TheoryLink help icon in SaveBar footer (t/2345)

### DIFF
--- a/taxonomy-editor/src/renderer/components/sync/SaveBar.tsx
+++ b/taxonomy-editor/src/renderer/components/sync/SaveBar.tsx
@@ -9,6 +9,7 @@ import { type SyncStatus } from '../../utils/syncApi';
 import { useOnlineStatus } from '../../hooks/useOnlineStatus';
 import { triggerManualDump } from '../../lib/flightRecorderInit';
 import { useFlag } from '../../hooks/useFeatureFlags';
+import { TheoryLink } from '../shared';
 import { UnsyncedChangesDrawer } from './UnsyncedChangesDrawer';
 import { SyncDiagnosticsDialog } from './SyncDiagnosticsDialog';
 import { TaxonomyDiffPanel } from './TaxonomyDiffPanel';
@@ -125,6 +126,10 @@ export function SaveBar() {
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
           </button>
         )}
+        <TheoryLink
+          url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/architecture-overview.md"
+          label="Help: architecture overview"
+        />
         <div className="zoom-controls">
           <button className="btn btn-ghost btn-sm" onClick={zoomOut} title="Zoom out (Ctrl+-)">-</button>
           <button


### PR DESCRIPTION
Mounts the TheoryLink component in the `save-bar-right` icon cluster, between the flight-recorder dump button and zoom controls. Opens `docs/architecture-overview.md` externally via `api.openExternal`.

- Import `TheoryLink` from `../shared`
- `url`: architecture-overview GitHub blob URL
- `label`: `"Help: architecture overview"` (distinct aria-label)
- Unconditional (not flag-gated); renders same in Electron + web

Self-cert: component contract verified against t/2343 spec. TL self-cert accepted (p/400#2).

Resolves t/2345.
