### PR TITLE
feat(debate-workspace): mount TheoryLink in debate window — header, artifact cards, statement footer (t/2347)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.css
@@ -33,6 +33,20 @@
   min-width: 0;
   flex: 1 1 auto;
 }
+/* Title + inline TheoryLink help icon (t/2347 mount e). min-width:0 keeps the
+   clamped h2 able to shrink/ellipsize beside the icon; the icon never shrinks. */
+.debate-hdr-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.debate-hdr-title-row .debate-hdr-title {
+  min-width: 0;
+}
+.debate-hdr-theory-link {
+  flex: 0 0 auto;
+}
 .debate-hdr-title {
   margin: 0;
   font-size: 1.1rem;

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.tsx
@@ -7,6 +7,7 @@ import { DEBATE_AUDIENCES, POVER_INFO } from '../../types/debate';
 import { AI_POVERS } from '@lib/debate/types';
 import type { CoverageMap, StrengthWeightedCoverage } from '@lib/debate/coverageTracker';
 import { CoverageBadge } from './TaxonomyRefs';
+import { TheoryLink } from '../shared/TheoryLink';
 import './DebateHeader.css';
 
 type DWStore = ReturnType<typeof useDebateStore.getState>;
@@ -69,7 +70,14 @@ export function DebateHeader({
       {/* Band 1 — title + source, action controls right */}
       <div className="debate-hdr-band debate-hdr-band1">
         <div className="debate-hdr-title-block">
-          <h2 className="debate-hdr-title" title={activeDebate.topic.final}>{displayTitle}</h2>
+          <div className="debate-hdr-title-row">
+            <h2 className="debate-hdr-title" title={activeDebate.topic.final}>{displayTitle}</h2>
+            <TheoryLink
+              url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/debate-system-overview.md"
+              label="Help: debate system overview"
+              className="debate-hdr-theory-link"
+            />
+          </div>
           {sourceDisplay && (
             <span className="debate-hdr-source" title={activeDebate.source_ref ?? undefined}>{sourceDisplay}</span>
           )}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
@@ -378,6 +378,12 @@ describe('phase routing', () => {
     expect(container.querySelector('.debate-hdr-phase')?.textContent).toBe('Setting up...');
   });
 
+  it('renders the debate-system-overview TheoryLink in the header (t/2347 mount e)', () => {
+    mockStore.activeDebate = makeDebate();
+    render(<DebateWorkspace />);
+    expect(screen.getByLabelText('Help: debate system overview')).toBeInTheDocument();
+  });
+
   it('renders ClarificationActions in clarification phase when no substantive transcript entries', () => {
     mockStore.activeDebate = makeDebate({ phase: 'clarification', transcript: [] });
     render(<DebateWorkspace />);

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.css
@@ -235,3 +235,15 @@
 .taxrefs-node-sit {
   color: var(--color-sit);
 }
+
+/* TheoryLink help icons (t/2347). Footer (g): the .debate-taxonomy-refs row is
+   flex, so margin-left:auto parks the icon at the right end beside Explain/Caveats.
+   Summary (f): small gap after the BRIEF/PLAN label. */
+.taxrefs-refs-help {
+  margin-left: auto;
+  vertical-align: middle;
+}
+.taxrefs-section-help {
+  margin-left: 6px;
+  vertical-align: middle;
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.planDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.planDetail.test.tsx
@@ -105,3 +105,20 @@ describe('TaxonomyRefsSection — PLAN anchor → inline POV detail (t/1724)', (
     expect(screen.queryByTestId('ref-detail')).toBeNull();
   });
 });
+
+describe('TheoryLink help icons — mounts f + g (t/2347)', () => {
+  it('renders the artifact-guide icon on BRIEF + PLAN and the citation-diagnostics icon in the statement footer, with distinct aria-labels', () => {
+    const stageDiagnostics = [
+      { stage: 'brief', raw_response: '', work_product: { situation_assessment: 'sa' } },
+      { stage: 'plan', raw_response: '', work_product: { strategic_goal: 'g', argument_structure: [] } },
+    ];
+    const entry = { id: 'e1', timestamp: 't', type: 'statement', speaker: 'accelerationist', content: 'x', taxonomy_refs: [], caveats: ['c1'] } as unknown as Parameters<typeof TaxonomyRefsSection>[0]['entry'];
+
+    render(<TaxonomyRefsSection refs={[]} entry={entry} stageDiagnostics={stageDiagnostics} forceExpanded />);
+
+    // (f) artifact-guide help renders on both the BRIEF and PLAN artifact cards
+    expect(screen.getAllByLabelText('Help: artifact guide')).toHaveLength(2);
+    // (g) citation-diagnostics help renders in the statement footer
+    expect(screen.getByLabelText('Help: citation diagnostics design')).toBeInTheDocument();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
@@ -15,7 +15,14 @@ import {
 import type { PolicyRefEntry } from './utils';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { TaxonomyRefDetail, type TaxRefNode } from '../taxonomy/TaxonomyRefDetail';
+import { TheoryLink } from '../shared/TheoryLink';
 import './TaxonomyRefs.css';
+
+// Prevents a TheoryLink click inside a <summary> from toggling its parent <details>
+// (t/2347 mount f) — keeps the summary natively interactive, no stopPropagation wrapper.
+function suppressDetailsToggleForHelp(e: React.MouseEvent) {
+  if ((e.target as HTMLElement).closest('.theory-link')) e.preventDefault();
+}
 
 export function CoverageBadge({ coverageMap, strengthWeighted }: { coverageMap: CoverageMap; strengthWeighted?: StrengthWeightedCoverage | null }) {
   const { stats } = coverageMap;
@@ -154,6 +161,12 @@ function RefsHeader({ entry, explainCopied, onExplain, onToggleCaveats }: {
           Caveats ({entry.caveats.length})
         </button>
       )}
+      <TheoryLink
+        url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/citation-diagnostics-design.md"
+        label="Help: citation diagnostics design"
+        size={14}
+        className="taxrefs-refs-help"
+      />
     </div>
   );
 }
@@ -161,7 +174,15 @@ function RefsHeader({ entry, explainCopied, onExplain, onToggleCaveats }: {
 function BriefSection({ briefStage }: { briefStage: { work_product: Record<string, unknown> } }) {
   return (
     <details open className="debate-reasoning-section">
-      <summary className="debate-reasoning-section-title taxrefs-section-brief">BRIEF</summary>
+      <summary className="debate-reasoning-section-title taxrefs-section-brief" onClick={suppressDetailsToggleForHelp}>
+        BRIEF
+        <TheoryLink
+          url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/artifact-guide.md"
+          label="Help: artifact guide"
+          size={14}
+          className="taxrefs-section-help"
+        />
+      </summary>
       <div className="debate-reasoning-section-body">
         {(briefStage.work_product as Record<string, unknown>).situation_assessment
           ? <p className="taxrefs-brief-text">{String((briefStage.work_product as Record<string, unknown>).situation_assessment)}</p>
@@ -328,7 +349,15 @@ function PlanSection({ planStage, selectedPlanNodeId, setSelectedPlanNodeId }: {
 }) {
   return (
     <details open className="debate-reasoning-section">
-      <summary className="debate-reasoning-section-title taxrefs-section-plan">PLAN</summary>
+      <summary className="debate-reasoning-section-title taxrefs-section-plan" onClick={suppressDetailsToggleForHelp}>
+        PLAN
+        <TheoryLink
+          url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/artifact-guide.md"
+          label="Help: artifact guide"
+          size={14}
+          className="taxrefs-section-help"
+        />
+      </summary>
       <div className="debate-reasoning-section-body">
         <PlanBody planStage={planStage} selectedPlanNodeId={selectedPlanNodeId} setSelectedPlanNodeId={setSelectedPlanNodeId} />
       </div>


### PR DESCRIPTION
Mounts the shared `TheoryLink` help affordance (t/2343, landed `56853de1`) at the 3 debate-window sites. **Self-cert against the t/2343 contract** (per ticket — no TL design review). All in DebateWorkspace scope; rendered inside `DebateWorkspace`, so they cover the docked **and** popped-out debate views (and both builds) automatically.

## Mounts
- **(e)** `DebateHeader` band-1 title row — beside the `<h2>` (new `.debate-hdr-title-row` flex wrapper). → `debate-system-overview.md`
- **(f)** `TaxonomyRefs` BriefSection + PlanSection — on the `<summary>` (`debate-reasoning-section-title`). → `artifact-guide.md`
- **(g)** `TaxonomyRefs` RefsHeader footer — beside Explain/Caveats (`margin-left:auto` parks it right). → `citation-diagnostics-design.md`

## Notes
- **Distinct aria-labels** per instance; F1-to-nearest auto-covered by the already-registered `useTheoryLinkHotkey` (App + popout roots).
- **(f) `<summary>` click:** the summary's `onClick` calls `preventDefault()` when the target is within `.theory-link`, so the help click doesn't toggle the `<details>` — no stopPropagation wrapper (summary stays natively interactive), no regression to the artifact-card toggle.
- **Direct import** `../shared/TheoryLink`, NOT the `../shared` barrel: the barrel re-exports `UpdatePrompt` (imports the Vite-only `virtual:pwa-register/react`) which breaks vitest module loads. New CSS co-located (styles.css frozen).

## Tests & gates
- New assertions that all three distinct help icons render at their sites (header + brief/plan/footer).
- renderer tsc 0, eslint 0 errors, depcruise clean, vite build ok, debate-workspace vitest **262/262**.

Live docked + popout eyeball per the AC to follow (electron-mcp doesn't auto-attach to the popout — manual per the AC note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)