### PR TITLE
chore(analysis): remove dead countPolicyEdges() edge-summary path (t/2353)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/PolicyAlignmentPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/PolicyAlignmentPanel.test.tsx
@@ -23,7 +23,6 @@ function makeStore(overrides: Record<string, unknown> = {}) {
     skeptic: { nodes: [] },
     situations: { nodes: [] },
     policyRegistry: [],
-    edgesFile: null,
     setToolbarPanel: vi.fn(),
     ...overrides,
   };
@@ -128,22 +127,6 @@ describe('PolicyAlignmentPanel', () => {
 
     fireEvent.click(header);
     expect(screen.queryByText('Accelerate via pol-001')).toBeNull();
-  });
-
-  it('shows edge summary (contradicts/complements/tensions) when edgesFile has matching edges', () => {
-    storeValue = makeStoreWithPolicies();
-    storeValue.edgesFile = {
-      edges: [
-        { source: 'pol-001', target: 'other', type: 'CONTRADICTS' },
-        { source: 'pol-001', target: 'other2', type: 'COMPLEMENTS' },
-      ],
-    };
-    render(<PolicyAlignmentPanel />);
-
-    fireEvent.click(screen.getByText('pol-001').closest('button')!);
-
-    expect(screen.getByText('1 contradicts')).toBeInTheDocument();
-    expect(screen.getByText('1 complements')).toBeInTheDocument();
   });
 
   it('calls setToolbarPanel(null) when Close is clicked', () => {

--- a/taxonomy-editor/src/renderer/components/analysis/PolicyAlignmentPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/PolicyAlignmentPanel.tsx
@@ -4,7 +4,7 @@
 import { useState, useMemo } from 'react';
 import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
-import type { Pov, EdgesFile } from '../../types/taxonomy';
+import type { Pov } from '../../types/taxonomy';
 
 interface PolicyUsage {
   nodeId: string;
@@ -17,27 +17,13 @@ interface SharedPolicy {
   action: string;
   povs: string[];
   usages: PolicyUsage[];
-  edgeSummary: { contradicts: number; complements: number; tensions: number };
 }
 
-// Count edges touching a policy id, bucketed by edge type.
-function countPolicyEdges(edgesFile: EdgesFile | null, polId: string): SharedPolicy['edgeSummary'] {
-  let contradicts = 0, complements = 0, tensions = 0;
-  if (edgesFile) {
-    for (const edge of edgesFile.edges) {
-      if (edge.source !== polId && edge.target !== polId) continue;
-      if (edge.type === 'CONTRADICTS') contradicts++;
-      else if (edge.type === 'COMPLEMENTS') complements++;
-      else if (edge.type === 'TENSION_WITH') tensions++;
-    }
-  }
-  return { contradicts, complements, tensions };
-}
 
 export function PolicyAlignmentPanel() {
   const {
     accelerationist, safetyist, skeptic, situations,
-    policyRegistry, edgesFile, setToolbarPanel,
+    policyRegistry, setToolbarPanel,
   } = useTaxonomyStore();
   const [filter, setFilter] = useState<'cross-pov' | 'all-shared'>('cross-pov');
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -76,12 +62,11 @@ export function PolicyAlignmentPanel() {
         action: reg.action,
         povs,
         usages,
-        edgeSummary: countPolicyEdges(edgesFile, polId),
       });
     }
 
     return result.sort((a, b) => b.povs.length - a.povs.length || b.usages.length - a.usages.length);
-  }, [accelerationist, safetyist, skeptic, situations, policyRegistry, edgesFile]);
+  }, [accelerationist, safetyist, skeptic, situations, policyRegistry]);
 
   const filtered = useMemo(() => {
     let list = sharedPolicies;
@@ -152,13 +137,6 @@ export function PolicyAlignmentPanel() {
 
               {isExpanded && (
                 <div className="policy-alignment-detail">
-                  {pol.edgeSummary.contradicts + pol.edgeSummary.complements + pol.edgeSummary.tensions > 0 && (
-                    <div className="policy-alignment-edges">
-                      {pol.edgeSummary.contradicts > 0 && <span className="ga-policy-edge-contradicts">{pol.edgeSummary.contradicts} contradicts</span>}
-                      {pol.edgeSummary.complements > 0 && <span className="ga-policy-edge-complements">{pol.edgeSummary.complements} complements</span>}
-                      {pol.edgeSummary.tensions > 0 && <span className="ga-policy-edge-tension">{pol.edgeSummary.tensions} tensions</span>}
-                    </div>
-                  )}
                   <div className="policy-alignment-framings">
                     {pol.usages.map((u, i) => (
                       <div key={i} className="policy-alignment-framing">


### PR DESCRIPTION
## Summary
- Remove `countPolicyEdges()` function and `edgeSummary` field from `SharedPolicy` — pol- edges were eliminated in 1c7131be (t/1310) and edges.json has 0 pol- endpoints, so the function always returned `{0,0,0}` and the UI block never rendered
- Remove the `COMPLEMENTS` bucket — it was a legacy type alias reclassified by `Resolve-EdgeType.ps1` to `SUPPORTS`; it could never match a stored edge even if pol- edges returned
- Remove the matching test case + `edgesFile: null` from store fixture; delete a 0-byte junk file (`{,`) from analysis scope (t/2222 artifact)

## Test plan
- [x] `npx eslint PolicyAlignmentPanel.tsx PolicyAlignmentPanel.test.tsx` — 0 errors (1 pre-existing unused-disable warning unrelated to this change)
- [x] `npx vitest run PolicyAlignmentPanel.test.tsx` — 8/8 pass
- [x] `npx tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)