### PR TITLE
fix(build): deterministically resolve virtual:pwa-register/react in electron build (t/2356)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/pwaRegisterStub.ts
+++ b/taxonomy-editor/src/renderer/lib/pwaRegisterStub.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Deterministic stub for `virtual:pwa-register/react` (t/2356).
+//
+// The `vite-plugin-pwa` virtual module is only provided when the plugin is
+// registered, which happens for the WEB build only (VITE_TARGET=web). The
+// ELECTRON build imports UpdatePrompt.tsx (which imports the virtual module)
+// but never renders it — yet rolldown-vite still resolves the import while
+// walking the module graph, and without the plugin that resolution is a race:
+// intermittently it fails the whole build with
+//   "Rolldown failed to resolve import virtual:pwa-register/react".
+//
+// vite.config.ts aliases the virtual specifier to this file for electron builds
+// so resolution is always deterministic. This stub mirrors the shape of the
+// real `useRegisterSW` react hook but does nothing (no service worker in
+// Electron). It is never actually invoked because UpdatePrompt is web-only.
+
+import { useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+interface RegisterSWOptions {
+  immediate?: boolean;
+  onNeedRefresh?: () => void;
+  onOfflineReady?: () => void;
+  onRegisteredSW?: (swScriptUrl: string, registration: ServiceWorkerRegistration | undefined) => void;
+  onRegisterError?: (error: unknown) => void;
+}
+
+export function useRegisterSW(_options: RegisterSWOptions = {}): {
+  needRefresh: [boolean, Dispatch<SetStateAction<boolean>>];
+  offlineReady: [boolean, Dispatch<SetStateAction<boolean>>];
+  updateServiceWorker: (reloadPage?: boolean) => Promise<void>;
+} {
+  const needRefresh = useState(false);
+  const offlineReady = useState(false);
+  return {
+    needRefresh,
+    offlineReady,
+    updateServiceWorker: async (_reloadPage?: boolean) => {
+      /* no-op: no service worker in the Electron build */
+    },
+  };
+}

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -86,6 +86,12 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // Electron build omits vite-plugin-pwa (web-only), so the plugin never
+      // provides `virtual:pwa-register/react`. UpdatePrompt.tsx imports it, and
+      // rolldown intermittently fails to resolve the unprovided virtual module
+      // during the electron build (t/2356). Alias it to a deterministic stub so
+      // resolution never races. Web build keeps the real plugin-provided module.
+      ...(isWeb ? {} : { 'virtual:pwa-register/react': path.resolve(import.meta.dirname, 'src/renderer/lib/pwaRegisterStub.ts') }),
       '@bridge': isWeb
         ? path.resolve(import.meta.dirname, 'src/renderer/bridge/web-bridge.ts')
         : path.resolve(import.meta.dirname, 'src/renderer/bridge/index.ts'),


### PR DESCRIPTION
## Problem (t/2356)

`test-electron` intermittently fails at the **build** step with:
```
✗ Build failed: [vite]: Rolldown failed to resolve import "virtual:pwa-register/react"
  from taxonomy-editor/src/renderer/components/shared/UpdatePrompt.tsx
```
The `virtual:pwa-register/react` module is provided by `vite-plugin-pwa`, which the config registers **for the web build only** (`isWeb`). The electron build walks `UpdatePrompt.tsx`'s import of that specifier but has no plugin to provide it — rolldown resolves it intermittently, so the whole build fails non-deterministically and blocks any PR when it hits (seen on #701). `main` builds the identical code green, confirming it's environmental, not a code regression.

## Fix

Alias `virtual:pwa-register/react` to a real no-op stub module (`src/renderer/lib/pwaRegisterStub.ts`) **for electron builds only**; the web build keeps the plugin-provided module. Resolution now points at a concrete file, so it can never race or fail regardless of plugin registration or tree-shaking order. This is the ticket's "add the virtual module to the resolver config explicitly" direction.

The stub mirrors the shape of the real `useRegisterSW` hook (typed, no `any`) but does nothing — and is never actually invoked, since `UpdatePrompt` is web-only (`App.tsx` gates it on `VITE_TARGET === 'web'`).

## Verification

- **3× cache-cleared electron builds** (`rm -rf node_modules/.vite dist/renderer && vite build`) — all green.
- Renderer tsc: **0 / 0**. eslint clean on the new stub.

## Self-cert

Build-config reliability fix, single-owner (taxonomy-editor), per the TL's fix directions on t/2356. No runtime behavior change (electron never renders `UpdatePrompt`).
