### PR TITLE
test(debate-store): hermeticity guard for useDebateStore/debateSlices tests (t/2354)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore.test.ts
@@ -329,6 +329,19 @@ vi.mock('@lib/debate/vocabularyContext', () => ({
   formatVocabularyContext: vi.fn().mockReturnValue(''),
 }));
 
+// Defensive embedder stub (t/2354): the real renderer embedder (onnxruntime + MiniLM)
+// is only reached via the real electron-bridge, which is mocked above — but stub it
+// directly too so no code path can load the model (the CI "embed OOM" / "Embedding
+// unavailable" flake) even if a future change imports it here. Deterministic, no model load.
+vi.mock('../utils/localEmbedding', () => ({
+  tryInitLocalEmbedding: vi.fn().mockResolvedValue(false),
+  isLocalEmbeddingReady: vi.fn().mockReturnValue(false),
+  getLocalEmbeddingBackend: vi.fn().mockReturnValue('mock'),
+  notifyBridgeFallback: vi.fn(),
+  localComputeEmbedding: vi.fn().mockResolvedValue([]),
+  localComputeEmbeddings: vi.fn().mockResolvedValue([]),
+}));
+
 // Global __APP_VERSION__
 vi.stubGlobal('__APP_VERSION__', '0.7.4');
 
@@ -342,6 +355,20 @@ const localStorageMock = {
   key: vi.fn(),
 };
 vi.stubGlobal('localStorage', localStorageMock);
+
+// ── Hermeticity guard (t/2354) ──────────────────────────────
+// Block the raw network so these unit tests can NEVER make a live AI call. The AI
+// boundaries are mocked above (@bridge, orchestration, turnPipeline, …), but this
+// is the fail-fast backstop: any un-mocked or cross-file-bled path that tries to
+// hit the network throws loudly HERE (attributed to this suite) instead of a
+// nondeterministic live Gemini 429 in CI — so the isolation can't silently regress.
+// Plain throwing functions (not vi.fn) so vi.clearAllMocks can't strip the guard.
+const blockNetwork = (what: string) => () => {
+  throw new Error(`[t/2354 hermeticity guard] ${what} is blocked in unit tests — mock the AI/embedding boundary instead of making a live call`);
+};
+vi.stubGlobal('fetch', blockNetwork('fetch'));
+vi.stubGlobal('WebSocket', blockNetwork('WebSocket'));
+vi.stubGlobal('XMLHttpRequest', blockNetwork('XMLHttpRequest'));
 
 // ── Import the store under test ─────────────────────────────
 
@@ -1537,6 +1564,16 @@ describe('Reflection edits', () => {
         expect.objectContaining({ source: 'debate_reflection' }),
       );
     });
+  });
+});
+
+// ── hermeticity guard self-check (t/2354) ───────────────────
+// Fails if the network guard is ever removed, so the keyless/no-live-AI isolation
+// can't silently regress into the CI 429/embed-OOM flake.
+describe('hermeticity guard (t/2354)', () => {
+  it('blocks fetch so no live AI call can happen in this suite', () => {
+    expect(() => (globalThis as unknown as { fetch: (u: string) => unknown }).fetch('https://example.test'))
+      .toThrow(/hermeticity guard/);
   });
 });
 

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
@@ -1129,3 +1129,13 @@ describe('Synthesis slice: propose_new apply (t/1773, ruling B)', () => {
   });
 });
 
+// ── hermeticity guard self-check (t/2354) ───────────────────
+// Fails if the harness network guard is ever removed, so the keyless/no-live-AI
+// isolation can't silently regress into the CI 429/embed-OOM flake.
+describe('hermeticity guard (t/2354)', () => {
+  it('blocks fetch so no live AI call can happen in this suite', () => {
+    expect(() => (globalThis as unknown as { fetch: (u: string) => unknown }).fetch('https://example.test'))
+      .toThrow(/hermeticity guard/);
+  });
+});
+

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/storeTestHarness.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/storeTestHarness.ts
@@ -339,6 +339,19 @@ vi.mock('@lib/debate/vocabularyContext', () => ({
   formatVocabularyContext: vi.fn().mockReturnValue(''),
 }));
 
+// Defensive embedder stub (t/2354): the real renderer embedder (onnxruntime + MiniLM)
+// is only reached via the real electron-bridge, which is mocked above — but stub it
+// directly too so no code path can load the model (the CI "embed OOM" / "Embedding
+// unavailable" flake) even if a future change imports it here. Deterministic, no model load.
+vi.mock('../../../utils/localEmbedding', () => ({
+  tryInitLocalEmbedding: vi.fn().mockResolvedValue(false),
+  isLocalEmbeddingReady: vi.fn().mockReturnValue(false),
+  getLocalEmbeddingBackend: vi.fn().mockReturnValue('mock'),
+  notifyBridgeFallback: vi.fn(),
+  localComputeEmbedding: vi.fn().mockResolvedValue([]),
+  localComputeEmbeddings: vi.fn().mockResolvedValue([]),
+}));
+
 // Global __APP_VERSION__
 vi.stubGlobal('__APP_VERSION__', '0.7.4');
 
@@ -352,6 +365,20 @@ const localStorageMock = {
   key: vi.fn(),
 };
 vi.stubGlobal('localStorage', localStorageMock);
+
+// ── Hermeticity guard (t/2354) ──────────────────────────────
+// Block the raw network so these unit tests can NEVER make a live AI call. The AI
+// boundaries are mocked above (@bridge, orchestration, turnPipeline, …), but this
+// is the fail-fast backstop: any un-mocked or cross-file-bled path that tries to
+// hit the network throws loudly HERE (attributed to this suite) instead of a
+// nondeterministic live Gemini 429 in CI — so the isolation can't silently regress.
+// Plain throwing functions (not vi.fn) so vi.clearAllMocks can't strip the guard.
+const blockNetwork = (what: string) => () => {
+  throw new Error(`[t/2354 hermeticity guard] ${what} is blocked in unit tests — mock the AI/embedding boundary instead of making a live call`);
+};
+vi.stubGlobal('fetch', blockNetwork('fetch'));
+vi.stubGlobal('WebSocket', blockNetwork('WebSocket'));
+vi.stubGlobal('XMLHttpRequest', blockNetwork('XMLHttpRequest'));
 
 // ── Import the store under test ─────────────────────────────
 


### PR DESCRIPTION
## Summary
Hardens `useDebateStore.test.ts` + `debateSlices.test.ts` (+ shared `storeTestHarness.ts`) against the CI `test-electron` flake (Gemini 429 / embed-OOM) so a non-deterministic build gate can't block unrelated PRs.

## Finding
Both suites **already mock the AI/embedding boundaries** (`@bridge`, `@lib/debate/orchestration`, `turnPipeline`, `doctrinalAnchoring`, `api.computeEmbeddings`) and **pass keyless in isolation — 5/5 runs, zero network/model-load**. The real renderer embedder (`localEmbedding` → onnxruntime/MiniLM) is only reachable through the real `electron-bridge`, which these tests mock — so in isolation there is **no live AI/embedding path** here.

## Change (fail-fast backstop, per the ticket's "add a guard/assertion")
- **Block raw network** (`fetch`/`WebSocket`/`XMLHttpRequest`) with throwing stubs in both files' setup — any un-mocked or cross-file-bled path throws loudly **in-suite** instead of a live Gemini call.
- **Defensively mock the renderer embedder** (`utils/localEmbedding`) to deterministic no-op vectors so the real model can never load (the OOM path).
- **Guard self-check test** in each file — fails if the guard is ever removed, so the isolation can't silently regress.

## Verification
- Keyless (`GEMINI_API_KEY= ANTHROPIC_API_KEY= GROQ_API_KEY= AI_API_KEY=`) ×5 consecutive runs: **165/165 pass, 0 guard trips**.
- tsc clean; eslint clean on the test files.
- Existing assertions unchanged (additive only).

## ⚠️ Flag for TL
Since these files are hermetic in isolation, if #701's flake **recurs** the live call originates in **another suite** in the shared `test-electron` run (not these two). Recommend a follow-up to sweep for tests importing the real `electron-bridge`/`@lib/ai-client` if it resurfaces. This PR makes these two files provably clean + self-guarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)