### PR TITLE
fix(a11y): light --text-muted → slate-500 for WCAG 1.4.11 non-text floor (t/2358)

### DIFF
--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -31,7 +31,7 @@
   /* Text */
   --text-primary: #1e293b;
   --text-secondary: #475569;
-  --text-muted: #94a3b8;
+  --text-muted: #64748b;  /* was #94a3b8 — slate-400 = 2.56:1, below WCAG 1.4.11 non-text floor for help icons (t/2358) */
   --border-color: #e2e8f0;
 
   /* Category detail backgrounds */


### PR DESCRIPTION
## Summary
Light-theme `--text-muted` was `#94a3b8` (slate-400) ≈ **2.56:1** on near-white surfaces — below the **WCAG 1.4.11 3:1 non-text floor** for the shared help-icon affordances (`.field-help-btn` `(?)` and all `.theory-link` Book icons). Bump to **`#64748b`** (slate-500).

## Why this value (Design decision, t/2358#1)
- **4.76:1** on `--bg-primary`, **≥3.86:1** on the darkest near-white panel (`--bg-panel #e2e8f0`) — clears 3:1 on every surface the affordance sits on.
- Stays the lightest text token (secondary=slate-600, primary=slate-800) → preserves the "recede until wanted, brighten on hover" intent.
- **Light theme only** — dark/harvard/bkc already ≥3:1 and untouched.
- One token lifts every help icon app-wide (`.field-help-btn` predates TheoryLink).

## Scope / process
- Single **existing-token value** change (no new selector → within the styles.css freeze). 1 line.
- t/2358 is **Design-owned**; they routed the styles.css change to me (the file owner) and will run `/design-review-workflow` (verify icons ≥3:1 live in light + spot-check hover/focus) before closing.
- Gate-gap that let the sub-3:1 value ship is split to **t/2359** (mine, separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)