### PR TITLE
feat(taxonomy): remove redundant POV-name label + New button from list-panel header (t/2361)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/PovTab.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/PovTab.tsx
@@ -5,7 +5,7 @@ import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { useMobileNav } from '../../hooks/useMobileNav';
-import type { Pov, Category, PovNode } from '../../types/taxonomy';
+import type { Pov, PovNode } from '../../types/taxonomy';
 import { PROMPT_CATALOG, type PromptCatalogEntry } from '../../data/promptCatalog';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { useKeyboardNav } from '../../hooks/useKeyboardNav';
@@ -17,7 +17,6 @@ import type { DebateTestedTier } from '../../bridge/types';
 import './PovTab.css';
 import { NodeDetail } from './NodeDetail';
 import { SituationDetail } from '../debate/SituationDetail';
-import { NewNodeDialog } from '../shared/NewNodeDialog';
 import { PinnedPanel } from '../shared/PinnedPanel';
 import { SearchPreview } from '../edge-browser/SearchPreview';
 import { AnalysisPanel } from '../analysis/AnalysisPanel';
@@ -421,7 +420,7 @@ function step2NeedsAuth(steps: RecoveryStep[]): boolean {
 
 export function PovTab({ pov }: PovTabProps) {
   const {
-    selectedNodeId, setSelectedNodeId, createPovNode, pinnedStack, pinAtDepth,
+    selectedNodeId, setSelectedNodeId, pinnedStack, pinAtDepth,
     similarResults, similarLoading, similarError,
     runAnalyzeDistinction, analysisResult, analysisLoading, analysisError, clearAnalysis,
     navigateToSearchRelated,
@@ -464,7 +463,6 @@ export function PovTab({ pov }: PovTabProps) {
     }
   }, [syncStatus.main_updated_available, nodeConflicts.enabled, nodeConflicts.refresh]);
 
-  const [showNewDialog, setShowNewDialog] = useState(false);
   const [showSoulDoc, setShowSoulDoc] = useState(false);
   const [sortMode, setSortMode] = useState<SortMode>('label');
   const [dtTierFilter, setDtTierFilter] = useState<DebateTestedTier | 'all'>('all');
@@ -669,11 +667,6 @@ export function PovTab({ pov }: PovTabProps) {
 
   const selectedNode = file ? file.nodes.find(n => n.id === selectedNodeId) || null : null;
 
-  const handleCreate = (category: Category) => {
-    createPovNode(pov, category);
-    setShowNewDialog(false);
-  };
-
   const handlePin = () => {
     if (selectedNode) {
       pinAtDepth(0, {
@@ -815,8 +808,7 @@ export function PovTab({ pov }: PovTabProps) {
         <div className="list-panel" ref={listPanelRef} style={{ width }}>
           <div className="list-panel-header">
             <div className="list-panel-header-title">
-              <button className="btn btn-sm btn-ghost" onClick={() => setShowSoulDoc(true)} title="Soul document">&#x1f4dc;</button>
-              <h2>{pov}</h2>
+              <button className="btn btn-sm btn-ghost" onClick={() => setShowSoulDoc(true)} title="Soul document" aria-label="Soul document">&#x1f4dc;</button>
             </div>
             <div className="list-panel-header-actions">
               <select
@@ -832,9 +824,6 @@ export function PovTab({ pov }: PovTabProps) {
                 <option value="debate_tested">Sort: Debate-Tested (least)</option>
                 <option value="debate_tested_desc">Sort: Debate-Tested (most)</option>
               </select>
-              <button className="btn btn-sm" onClick={() => setShowNewDialog(true)}>
-                + New
-              </button>
               <button className="pane-collapse-btn" onClick={() => setListCollapsed(true)} title="Collapse">&lsaquo;</button>
             </div>
           </div>
@@ -974,12 +963,6 @@ export function PovTab({ pov }: PovTabProps) {
             />
           </div>
         </>
-      )}
-      {showNewDialog && (
-        <NewNodeDialog
-          onConfirm={handleCreate}
-          onCancel={() => setShowNewDialog(false)}
-        />
       )}
       {isPhone && (
         <div


### PR DESCRIPTION
Owner/Design decision (t/2361). The tab label above already names + highlights the active POV, so the header's POV-name `<h2>` was redundant (and truncated to "ACC…" at high zoom).

## Change 1 — remove redundant POV-name label
- Deleted `<h2>{pov}</h2>`; **kept** the soul-doc icon button and added `aria-label="Soul document"` so it retains an accessible name now that the adjacent `<h2>` is gone. `.list-panel-header-title` wrapper kept (now holds only the icon; flex layout still aligns icon-left / sort+collapse-right).

## Change 2 — remove "+ New" button + dead code
- Deleted the button and its orphaned PovTab code: `showNewDialog` state, `handleCreate`, the `{showNewDialog && <NewNodeDialog/>}` block, the `NewNodeDialog` import, `createPovNode` from the store destructure, and the now-unused `Category` type import.
- **Kept** the store action `createPovNode` — still used by `SummariesTab` + `debateReflectionSlice` (programmatic node creation unaffected; this removes only the manual entry point, per owner).
- `NewNodeDialog.tsx` **retained** — still re-exported by `shared/index.ts` (not a dangling dep-graph orphan); deletion deferred to a dead-code sweep to keep this tight.

## Verify
tsc clean; eslint only pre-existing complexity warnings (removal dropped PovTab complexity 53→52). Header renders `[📜 soul-doc] … [Sort ▾] [‹ collapse]`. **Design will design-review the header layout before close.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)