### PR TITLE
feat(server-community): surface model + turn_count in community debate listing (t/2362)

### DIFF
--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -132,6 +132,7 @@ interface CommunityChatEntry {
 interface CommunityDebateEntry {
   id: unknown; title: string; created_at: string; updated_at: string;
   phase: string; community_metadata: unknown;
+  model?: string; turn_count?: number;
 }
 
 export async function listCommunityChats(): Promise<unknown[]> {
@@ -163,6 +164,10 @@ export async function listCommunityDebates(): Promise<unknown[]> {
       updated_at: parsed.updated_at || parsed.created_at || '',
       phase: parsed.phase || 'unknown',
       community_metadata: stripOriginalId(parsed.community_metadata || null), // t/856
+      model: typeof parsed.debate_model === 'string' ? parsed.debate_model : undefined,
+      turn_count: Array.isArray(parsed.transcript)
+        ? parsed.transcript.filter((t: { type: string }) => t.type === 'statement' || t.type === 'opening').length
+        : undefined,
     }),
   });
   return [...items].sort((a, b) => (b.updated_at || '').localeCompare(a.updated_at || ''));


### PR DESCRIPTION
## Summary
- `CommunityDebateEntry` interface gains `model?: string` and `turn_count?: number`
- `toEntry` lambda extracts `debate_model` and counts `statement|opening` transcript entries
- Mirrors the My-tab path in `debateIO.ts` `extractSummary()` — same field names, same filter predicate

## Test plan
- [ ] CI green (tsc server config passes locally)
- [ ] DebateUI + Rosetta downstream slices (client type + renderer) land after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)