### PR TITLE
feat(community): add optional model + turn_count to CommunityDebate type (t/2362)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useCommunityStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useCommunityStore.ts
@@ -26,6 +26,11 @@ export interface CommunityChat extends CommunityItem {
 
 export interface CommunityDebate extends CommunityItem {
   phase?: string;
+  // Populated by the community list payload once the server-side surfacing lands
+  // (t/2368, ServerAPI); optional so the type is valid before/after that. Lets
+  // DebateTable read cd.model / cd.turn_count directly instead of duck-typing (t/2362).
+  model?: string;
+  turn_count?: number;
 }
 
 export interface Submission {


### PR DESCRIPTION
Rosetta slice of t/2362 (TL Quality approved, t/2362#2). Adds to the `CommunityDebate` interface in `useCommunityStore.ts`:
```ts
model?: string;
turn_count?: number;
```
Lets `DebateTable` read `cd.model` / `cd.turn_count` directly instead of `'model' in cd` duck-typing.

**Optional fields → valid before and after** the server-side surfacing (now folded into **t/2368**, ServerAPI) lands; no runtime behavior change on its own. Landing it now unblocks DebateUI's DebateTable work without waiting on the server (the "immediately valid" concern in the coordination note is satisfied by the fields being optional). DebateUI's render work + the t/2368 data population land separately.

Type-only change (adding optional interface fields) — renderer-tsc/test-electron confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)