### PR TITLE
fix(web-bridge): context-specific resolve steps for 404 not-found (t/2366)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/httpErrorSteps.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/httpErrorSteps.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { nextStepsForStatus } from './httpErrorSteps';
+
+describe('nextStepsForStatus', () => {
+  const GENERIC = ['Check the server is running', 'Verify your authentication'];
+
+  describe('404 — resource not found (t/2366)', () => {
+    it('gives debate-specific steps for a "Debate not found" body (not generic server/auth copy)', () => {
+      const steps = nextStepsForStatus(404, JSON.stringify({ error: 'Debate not found', requestId: 'r1' }));
+      expect(steps[0]).toMatch(/debate session was not found/i);
+      expect(steps[1]).toMatch(/anonymously.*rotated your session/i);
+      expect(steps).not.toEqual(GENERIC);
+    });
+
+    it('matches "Debate session not found" phrasing too', () => {
+      const steps = nextStepsForStatus(404, JSON.stringify({ error: 'Debate session not found' }));
+      expect(steps[0]).toMatch(/debate session was not found/i);
+    });
+
+    it('gives generic-not-found (non-debate) steps for other structured not-found bodies', () => {
+      const steps = nextStepsForStatus(404, JSON.stringify({ error: 'Crux not found: x' }));
+      expect(steps[0]).toMatch(/requested item was not found/i);
+      expect(steps[0]).not.toMatch(/debate/i);
+      expect(steps).not.toEqual(GENERIC);
+    });
+
+    it('detects "not found" even when the body is plain text, not JSON', () => {
+      const steps = nextStepsForStatus(404, 'Debate not found');
+      expect(steps[0]).toMatch(/debate session was not found/i);
+    });
+
+    it('falls back to generic copy for an unexpected 404 (missing route, no "not found" in body)', () => {
+      expect(nextStepsForStatus(404, '<html>404</html>')).toEqual(GENERIC);
+      expect(nextStepsForStatus(404, JSON.stringify({ error: 'Route /api/nope is not registered' }))).toEqual(GENERIC);
+    });
+  });
+
+  describe('403 — unchanged behavior', () => {
+    it('returns the anon_route_blocked detail', () => {
+      const steps = nextStepsForStatus(403, JSON.stringify({ reason: 'anon_route_blocked', detail: 'Sign in first' }));
+      expect(steps).toEqual(['Sign in first']);
+    });
+
+    it('surfaces the server error message + tier hint', () => {
+      const steps = nextStepsForStatus(403, JSON.stringify({ error: 'Backend not allowed on your tier' }));
+      expect(steps).toEqual(['Backend not allowed on your tier', 'Check your API key tier supports this backend']);
+    });
+
+    it('uses generic auth copy when the body is unparseable', () => {
+      expect(nextStepsForStatus(403, 'nope')).toEqual([
+        'Verify your authentication',
+        'Check your API key tier supports this backend',
+      ]);
+    });
+  });
+
+  it('returns generic copy for other statuses (e.g. 500)', () => {
+    expect(nextStepsForStatus(500, 'boom')).toEqual(GENERIC);
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/httpErrorSteps.ts
+++ b/taxonomy-editor/src/renderer/bridge/httpErrorSteps.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Maps an HTTP error status + response body to user-actionable ActionableError
+ * "next steps". Pure and side-effect-free so it can be unit-tested at the leaf
+ * (importing web-bridge.ts pulls in the whole bridge/resilience/crypto graph).
+ */
+export function nextStepsForStatus(status: number, responseText: string): string[] {
+  if (status === 403) {
+    try {
+      const body = JSON.parse(responseText) as Record<string, unknown>;
+      if (body.reason === 'anon_route_blocked') {
+        const detail = typeof body.detail === 'string' ? body.detail : 'Sign in with GitHub at /.auth/login/github';
+        return [detail];
+      }
+      const error = typeof body.error === 'string' ? body.error : undefined;
+      if (error) return [error, 'Check your API key tier supports this backend'];
+    } catch { /* telemetry — silent by design */ }
+    return ['Verify your authentication', 'Check your API key tier supports this backend'];
+  }
+  if (status === 404) {
+    // A structured "…not found" body means the resource is genuinely gone — the
+    // server clearly ran and auth isn't the issue, so the generic "check the
+    // server / verify auth" copy is misleading (t/2366). Give context-specific
+    // steps for resource-not-found; fall through to generic only for unexpected
+    // 404s (missing routes, HTML error pages — no "not found" in the body).
+    let errorText: string | undefined;
+    try {
+      const body = JSON.parse(responseText) as Record<string, unknown>;
+      errorText = typeof body.error === 'string' ? body.error : undefined;
+    } catch { /* telemetry — silent by design: non-JSON 404 body (missing route / HTML), errorText stays undefined */ }
+    const haystack = errorText ?? responseText;
+    if (/not found/i.test(haystack)) {
+      if (/debate/i.test(haystack)) {
+        return [
+          'This debate session was not found — it may have been deleted',
+          'If signed in anonymously, clearing browser data may have rotated your session ID; old debates are no longer accessible',
+        ];
+      }
+      return [
+        'The requested item was not found — it may have been deleted or moved',
+        'If signed in anonymously, clearing browser data may have rotated your session ID',
+      ];
+    }
+  }
+  return ['Check the server is running', 'Verify your authentication'];
+}

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -12,6 +12,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
 import { encryptKeysForSharing, decryptKeysFromSharing } from '../utils/keyShareCrypto';
 import { resilientFetch, categorizeEndpoint, registerConnectionPoolProvider, type EndpointCategory } from './resilience';
+import { nextStepsForStatus } from './httpErrorSteps';
 import { onQuotaMilestone } from '../hooks/useQuotaWarning';
 export { getResilienceState, subscribeResilience, resetResilience } from './resilience';
 export type { ResilienceStatus, CircuitState, ThrottleState, EndpointCategory } from './resilience';
@@ -37,21 +38,7 @@ function throwHttpError(status: number, err: ActionableError): never {
   throw err;
 }
 
-function nextStepsForStatus(status: number, responseText: string): string[] {
-  if (status === 403) {
-    try {
-      const body = JSON.parse(responseText) as Record<string, unknown>;
-      if (body.reason === 'anon_route_blocked') {
-        const detail = typeof body.detail === 'string' ? body.detail : 'Sign in with GitHub at /.auth/login/github';
-        return [detail];
-      }
-      const error = typeof body.error === 'string' ? body.error : undefined;
-      if (error) return [error, 'Check your API key tier supports this backend'];
-    } catch { /* telemetry — silent by design */ }
-    return ['Verify your authentication', 'Check your API key tier supports this backend'];
-  }
-  return ['Check the server is running', 'Verify your authentication'];
-}
+// nextStepsForStatus moved to ./httpErrorSteps (leaf module, unit-tested) — t/2366.
 
 // ── Resilient fetch options for callers ──
 


### PR DESCRIPTION
## Problem (t/2366, diagnosed from a debate 404 dump)

When `GET /api/debates/:id` returns 404, the web-bridge wrapped it in an `ActionableError` whose resolve steps were **"Check the server is running / Verify your authentication."** Both are misleading: the server clearly ran (it returned a structured `{ error: "…not found" }` body) and auth isn't the problem — the debate simply doesn't exist (deleted, or an anonymous session ID rotated after a browser-data clear).

## Fix

`nextStepsForStatus` now handles 404 explicitly: if the body says "…not found", it returns resource-appropriate steps instead of the generic server/auth copy —

- **debate 404** → "This debate session was not found — it may have been deleted" + "If signed in anonymously, clearing browser data may have rotated your session ID; old debates are no longer accessible"
- **other not-found** → generic resource-not-found + the session-rotation hint

The old server/auth copy is now reserved for **unexpected** 404s (missing routes, HTML error pages — no "not found" in the body), exactly as the ticket asked.

Detection reads the parsed `body.error` (falling back to raw text for non-JSON bodies), matching the server's `{ error, requestId }` shape from `httpKit.error()`.

## Refactor for testability

Extracted the helper from `web-bridge.ts` into a **side-effect-free leaf module** (`httpErrorSteps.ts`) — importing `web-bridge.ts` pulls in the whole bridge/resilience/crypto graph (module-level `registerConnectionPoolProvider`/`instrumentBridge`), which makes a focused unit test fragile. `web-bridge.ts` now imports the helper; behavior is unchanged for 403/500/other.

## Tests & gates

- New `httpErrorSteps.test.ts` — **9 cases**: debate / generic / plain-text / unexpected 404, plus unchanged 403 (anon-blocked, tier-error, unparseable) and 500. All green.
- renderer tsc **0/0**; eslint clean on changed files.

## Scope / self-cert

Client-side (renderer) copy fix, single-owner (taxonomy-editor), mirrors the existing 403 branch pattern. Ticket authored by Diagnostics (no TL design gate). No server change.
