### PR TITLE
feat(mechanism5): calibrated margin trigger — (top1−assigned) > 0.06 (t/2357)

### DIFF
--- a/scripts/AITriad/Private/Invoke-Mechanism5RetrievalPass.ps1
+++ b/scripts/AITriad/Private/Invoke-Mechanism5RetrievalPass.ps1
@@ -4,80 +4,87 @@
 function Invoke-Mechanism5RetrievalPass {
     <#
     .SYNOPSIS
-        Per-key_point re-retrieval pass (Mechanism #5, t/2357) — flag + surface.
+        Per-key_point re-retrieval pass (Mechanism #5, t/2357) — margin-triggered flag + surface.
     .DESCRIPTION
-        After Invoke-RetrievalConfidencePass has scored every key_point, this pass
-        identifies the ones where the existing assignment is likely a vocabulary-collision
-        misfire and surfaces per-key_point top-3 candidates so the t/2289 override path
-        can act on them.
+        After Invoke-RetrievalConfidencePass has scored every key_point, this pass identifies
+        assignments where a better candidate exists and surfaces per-key_point top-3 POV-filtered
+        candidates for the t/2289 override path.
 
-        A key_point is flagged when EITHER:
-          (1) retrieval_low_confidence = $true  (confidence < 0.45, from t/2288), OR
-          (2) the assigned node is absent from the per-key_point attribution_text top-3
-              (taxonomy_node_candidates doesn't include the assigned node_id).
+        A key_point is flagged when:
+          (top1_score − assigned_score) > MarginThreshold  (default 0.06, calibrated by CL t/2357)
 
-        For flagged key_points, the query is attribution_text (primary) / verbatim
-        (fallback) — NOT canonical_proposition (over-abstracted; Arm-1 finding).
+        where top1_score = taxonomy_node_candidates[0].score (per-key_point max, from t/2288 pass)
+        and   assigned_score = retrieval_confidence (cosine of assigned node, from t/2288 pass).
 
-        Scoring is done in-memory against $script:CachedEmbeddings (already loaded by
-        Get-RelevantTaxonomyNodes earlier in the same pipeline run), POV-filtered.
-        All queries are batch-embedded in a single Python subprocess to avoid cold
-        model-load cost per key_point.
+        ALL key_points are evaluated — high-confidence misfires are the primary target (real
+        misfires typically have good assigned-node confidence but a clearly dominant alternative).
+        A conf-gated pre-filter would miss them entirely.
 
-        Sets two new fields on each flagged key_point:
+        Query for POV-filtered surfacing: attribution_text (primary) / verbatim (fallback).
+        All flagged queries are batch-embedded in one Python subprocess.
+
+        Sets on each flagged key_point:
           mechanism5_flag       = $true
-          mechanism5_candidates = top-3 [PSCustomObject]@{id; label; score} per POV
+          mechanism5_candidates = top-3 [PSCustomObject]@{id; label; score} filtered to key_point's POV
 
-        v1 ships flag→surface only; auto-correct (replace taxonomy_node_id when the
-        top-1 beats the assigned node by a conservative margin) is a fast-follow (t/2357).
+        Auto-correct is cancelled (no safe band identified; near-synonyms regress). t/2357.
         Degrades gracefully — never throws, never modifies other fields on failure.
     .PARAMETER KeyPointItems
         Array of hashtables @{KeyPoint=<PSObject>; POV='accelerationist'|'safetyist'|'skeptic'}.
+    .PARAMETER MarginThreshold
+        Surface when top1_score exceeds assigned_score by more than this value.
+        Default 0.06 — calibrated from t/2341 adjudication study (CL, t/2357#8).
+        Registered: metric-provenance-register keypoint_surfacing_margin (provisional).
     #>
     [CmdletBinding()]
     param(
-        [object[]]$KeyPointItems
+        [object[]]$KeyPointItems,
+        [double]$MarginThreshold = 0.06
     )
 
-    # Guard: embeddings and taxonomy must be loaded (Get-RelevantTaxonomyNodes runs earlier)
+    # Guard: embeddings must be loaded (Get-RelevantTaxonomyNodes always runs first)
     if (-not $script:CachedEmbeddings -or $script:CachedEmbeddings.Count -eq 0) {
         Write-Verbose 'Invoke-Mechanism5RetrievalPass: CachedEmbeddings not loaded — skipping'
         return
     }
 
-    # Identify flagged key_points and build per-item query text
+    # Evaluate ALL key_points for the margin condition (high-conf misfires won't fire on a
+    # conf-gated pre-filter). Build query text only for those that exceed the threshold.
     $Flagged = [System.Collections.Generic.List[hashtable]]::new()
     foreach ($Item in $KeyPointItems) {
         $kp  = $Item.KeyPoint
         $Pov = [string]$Item.POV
         if (-not ($kp.PSObject.Properties['taxonomy_node_id'] -and $kp.taxonomy_node_id)) { continue }
 
-        # Condition 1: low retrieval confidence (set by Invoke-RetrievalConfidencePass)
-        $IsLowConf = $kp.PSObject.Properties['retrieval_low_confidence'] -and $kp.retrieval_low_confidence
-
-        # Condition 2: assigned node absent from attribution_text top-3 candidates
-        $IsAbsent = $true
+        # top1_score from the t/2288 candidates list ([0] is the per-key_point max)
+        $Top1Score = $null
         if ($kp.PSObject.Properties['taxonomy_node_candidates'] -and $kp.taxonomy_node_candidates) {
-            foreach ($Cand in @($kp.taxonomy_node_candidates)) {
-                if ($Cand.PSObject.Properties['id'] -and $Cand.id -eq $kp.taxonomy_node_id) {
-                    $IsAbsent = $false
-                    break
-                }
+            $Cands = @($kp.taxonomy_node_candidates)
+            if ($Cands.Count -gt 0 -and $Cands[0].PSObject.Properties['score']) {
+                $Top1Score = [double]$Cands[0].score
             }
         }
+        if ($null -eq $Top1Score) { continue }
 
-        if (-not $IsLowConf -and -not $IsAbsent) { continue }
+        # assigned_score = retrieval_confidence (cosine of assigned node, same scoring pass)
+        $AssignedScore = $null
+        if ($kp.PSObject.Properties['retrieval_confidence'] -and
+            $null -ne $kp.retrieval_confidence) {
+            $AssignedScore = [double]$kp.retrieval_confidence
+        }
+        if ($null -eq $AssignedScore) { continue }
 
-        # Query: attribution_text (primary) / verbatim (fallback)
+        if (($Top1Score - $AssignedScore) -le $MarginThreshold) { continue }
+
+        # Query: attribution_text (primary) / verbatim (fallback) — NOT canonical_proposition
         $QueryText = $null
-        if ($kp.PSObject.Properties['attribution_text'] -and -not [string]::IsNullOrWhiteSpace($kp.attribution_text)) {
+        if ($kp.PSObject.Properties['attribution_text'] -and
+            -not [string]::IsNullOrWhiteSpace($kp.attribution_text)) {
             $QueryText = [string]$kp.attribution_text
-        } elseif ($kp.PSObject.Properties['verbatim'] -and -not [string]::IsNullOrWhiteSpace($kp.verbatim)) {
-            if ($kp.verbatim -is [array]) {
-                $QueryText = $kp.verbatim -join ' '
-            } else {
-                $QueryText = [string]$kp.verbatim
-            }
+        } elseif ($kp.PSObject.Properties['verbatim'] -and
+                  -not [string]::IsNullOrWhiteSpace($kp.verbatim)) {
+            if ($kp.verbatim -is [array]) { $QueryText = $kp.verbatim -join ' ' }
+            else                          { $QueryText = [string]$kp.verbatim }
         }
         if ([string]::IsNullOrWhiteSpace($QueryText)) { continue }
 
@@ -91,9 +98,9 @@ function Invoke-Mechanism5RetrievalPass {
 
     if ($Flagged.Count -eq 0) { return }
 
-    Write-Verbose "Mechanism5: $($Flagged.Count) key_points flagged for per-key_point re-retrieval"
+    Write-Verbose "Mechanism5: $($Flagged.Count) key_point(s) exceed margin $MarginThreshold — surfacing POV candidates"
 
-    # Batch-embed all queries in one subprocess
+    # Batch-embed all flagged queries in one subprocess
     $EmbedItems = [System.Collections.Generic.List[hashtable]]::new()
     foreach ($F in $Flagged) {
         $EmbedItems.Add(@{ EmbedId = $F.EmbedId; Text = $F.Query })
@@ -131,7 +138,7 @@ function Invoke-Mechanism5RetrievalPass {
     if ($null -eq $SampleVec) { return }
     $Dim = $SampleVec.Count
 
-    $FlaggedCount = 0
+    $SurfacedCount = 0
     foreach ($F in $Flagged) {
         $kp      = $F.KeyPoint
         $EmbedId = $F.EmbedId
@@ -147,7 +154,7 @@ function Invoke-Mechanism5RetrievalPass {
         $QNorm = [Math]::Sqrt($QNormSq)
         if ($QNorm -eq 0) { continue }
 
-        # Score nodes filtered to this POV
+        # Score nodes filtered to this key_point's POV
         $PovPrefix = if ($PovPrefixMap.ContainsKey($Pov)) { $PovPrefixMap[$Pov] } else { $null }
         $Scores = [System.Collections.Generic.List[PSObject]]::new()
         foreach ($NodeId in $script:CachedEmbeddings.Keys) {
@@ -176,10 +183,10 @@ function Invoke-Mechanism5RetrievalPass {
 
         Set-KeyPointField $kp 'mechanism5_flag'       $true
         Set-KeyPointField $kp 'mechanism5_candidates' $Top3
-        $FlaggedCount++
+        $SurfacedCount++
     }
 
-    if ($FlaggedCount -gt 0) {
-        Write-Host "  │  mechanism5: $FlaggedCount key_point(s) flagged + surfaced" -ForegroundColor DarkCyan
+    if ($SurfacedCount -gt 0) {
+        Write-Host "  │  mechanism5: $SurfacedCount key_point(s) flagged + surfaced" -ForegroundColor DarkCyan
     }
 }

--- a/tests/Invoke-Mechanism5RetrievalPass.Tests.ps1
+++ b/tests/Invoke-Mechanism5RetrievalPass.Tests.ps1
@@ -7,10 +7,10 @@
 .SYNOPSIS
     Tests for Invoke-Mechanism5RetrievalPass (t/2357).
 .DESCRIPTION
-    Covers: v1 safety claim (taxonomy_node_id never mutated), flag criteria
-    (retrieval_low_confidence OR absent from candidates), query-text fallback
+    Covers: safety claim (taxonomy_node_id never mutated), margin trigger
+    ((top1_score - assigned_score) > MarginThreshold), query-text fallback
     (attribution_text -> verbatim), and graceful degradation (no embeddings,
-    batch-encode failure, kp missing taxonomy_node_id under StrictMode).
+    missing candidates/confidence fields, batch-encode failure, StrictMode guard).
 #>
 
 BeforeAll {
@@ -23,20 +23,23 @@ BeforeAll {
         # 3-dimensional unit vector along the given axis index.
         function script:M5-Vec { param([int]$Axis) $v = [double[]]@(0.0,0.0,0.0); $v[$Axis] = 1.0; $v }
 
-        # Minimal key_point with commonly-needed fields.
+        # Minimal key_point with margin-trigger fields.
+        # Top1Score / AssignedScore control whether the margin fires (> MarginThreshold = 0.06).
         function script:M5-KP {
             param(
-                [string]$NodeId      = 'acc-beliefs-001',
-                [string]$Attribution = 'some attribution text',
-                [string]$Verbatim    = '',
-                [bool]  $LowConf     = $false,
-                [object[]]$Candidates = @()
+                [string]$NodeId        = 'acc-beliefs-001',
+                [string]$Attribution   = 'some attribution text',
+                [string]$Verbatim      = '',
+                [double]$Top1Score     = 0.9,   # taxonomy_node_candidates[0].score
+                [double]$AssignedScore = 0.2,   # retrieval_confidence (margin = 0.7 > 0.06 → fires)
+                [string]$Top1Id        = 'acc-beliefs-002'
             )
+            $Cand = [PSCustomObject]@{ id = $Top1Id; score = $Top1Score; label = 'Top Node' }
             [PSCustomObject]@{
                 taxonomy_node_id         = $NodeId
                 attribution_text         = $Attribution
-                retrieval_low_confidence  = $LowConf
-                taxonomy_node_candidates  = $Candidates
+                retrieval_confidence     = $AssignedScore
+                taxonomy_node_candidates = @($Cand)
             }
         }
 
@@ -64,94 +67,113 @@ BeforeAll {
 
 Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
 
-    # ── v1 safety: taxonomy_node_id is NEVER mutated ───────────────────────────
+    # ── safety: taxonomy_node_id is NEVER mutated ──────────────────────────────
 
-    Context 'v1 safety — taxonomy_node_id never modified' {
+    Context 'Safety — taxonomy_node_id never modified' {
 
-        It 'Does not mutate taxonomy_node_id on a flagged key_point (low confidence)' {
+        It 'Does not mutate taxonomy_node_id on a margin-triggered key_point' {
             InModuleScope AITriad {
                 $vm = M5-SetFakeState -Pov 'acc'
                 Mock Invoke-BatchEmbedAttribution { $vm }
 
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $true
+                # margin = 0.9 - 0.2 = 0.7 > 0.06 → fires
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.9 -AssignedScore 0.2
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
                 $kp.taxonomy_node_id | Should -Be 'acc-beliefs-001' `
-                    -Because 'v1 flag+surface must never replace the assigned node'
+                    -Because 'flag+surface must never replace the assigned node'
             }
         }
 
-        It 'Does not mutate taxonomy_node_id when assigned node is absent from candidates' {
+        It 'Does not mutate taxonomy_node_id when a clearly better candidate exists' {
             InModuleScope AITriad {
                 $vm = M5-SetFakeState -Pov 'acc'
                 Mock Invoke-BatchEmbedAttribution { $vm }
 
-                $Cands = @([PSCustomObject]@{ id = 'acc-beliefs-002'; score = 0.9 })
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $false -Candidates $Cands
+                # large margin — a strong alternative is available
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.95 -AssignedScore 0.10 -Top1Id 'acc-beliefs-002'
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
                 $kp.taxonomy_node_id | Should -Be 'acc-beliefs-001' `
-                    -Because 'v1 must not auto-correct even when a better candidate exists'
+                    -Because 'auto-correct is cancelled; must never replace the assigned node'
             }
         }
     }
 
-    # ── flag criteria ──────────────────────────────────────────────────────────
+    # ── margin trigger ─────────────────────────────────────────────────────────
 
-    Context 'Flag criteria' {
+    Context 'Margin trigger' {
 
-        It 'Sets mechanism5_flag when retrieval_low_confidence is true' {
+        It 'Sets mechanism5_flag when (top1_score - assigned_score) exceeds MarginThreshold' {
             InModuleScope AITriad {
                 $vm = M5-SetFakeState -Pov 'acc'
                 Mock Invoke-BatchEmbedAttribution { $vm }
 
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $true
+                # margin = 0.9 - 0.2 = 0.7 > 0.06 (default threshold)
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.9 -AssignedScore 0.2
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
-                $kp.mechanism5_flag | Should -BeTrue -Because 'low confidence satisfies condition 1'
+                $kp.mechanism5_flag | Should -BeTrue -Because 'margin 0.7 exceeds threshold 0.06'
             }
         }
 
-        It 'Sets mechanism5_flag when assigned node is absent from taxonomy_node_candidates' {
+        It 'Sets mechanism5_flag even when assigned_score is high (high-conf misfire case)' {
             InModuleScope AITriad {
                 $vm = M5-SetFakeState -Pov 'acc'
                 Mock Invoke-BatchEmbedAttribution { $vm }
 
-                $Cands = @([PSCustomObject]@{ id = 'acc-beliefs-002'; score = 0.9 })
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $false -Candidates $Cands
+                # high confidence but top-1 dominates — the real-world misfire pattern
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.92 -AssignedScore 0.80
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
-                $kp.mechanism5_flag | Should -BeTrue -Because 'absent from candidates satisfies condition 2'
+                $kp.mechanism5_flag | Should -BeTrue -Because 'margin 0.12 > 0.06; high conf should not suppress flag'
             }
         }
 
-        It 'Does NOT flag when confidence is good and assigned node is in candidates' {
+        It 'Does NOT flag when margin is at or below MarginThreshold' {
             InModuleScope AITriad {
                 $script:CachedEmbeddings = @{ 'acc-beliefs-001' = M5-Vec 0 }
                 $script:TaxonomyData = @{}
-                Mock Invoke-BatchEmbedAttribution { @{} }
 
-                $Cands = @([PSCustomObject]@{ id = 'acc-beliefs-001'; score = 0.8 })
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $false -Candidates $Cands
+                # margin = 0.8 - 0.78 = 0.02 ≤ 0.06 → no flag (near-tie)
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.80 -AssignedScore 0.78
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
                 $kp.PSObject.Properties['mechanism5_flag'] | Should -BeNullOrEmpty `
-                    -Because 'neither condition is met; key_point must not be flagged'
+                    -Because 'near-tie (margin 0.02 ≤ 0.06) must not be flagged'
             }
         }
 
-        It 'Surfaces mechanism5_candidates (top-3) on a flagged key_point' {
+        It 'Surfaces mechanism5_candidates (top-3 POV-filtered) on a flagged key_point' {
             InModuleScope AITriad {
                 $vm = M5-SetFakeState -Pov 'acc'
                 Mock Invoke-BatchEmbedAttribution { $vm }
 
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $true
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.9 -AssignedScore 0.2
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
                 $kp.PSObject.Properties['mechanism5_candidates'] | Should -Not -BeNullOrEmpty
                 @($kp.mechanism5_candidates).Count | Should -BeLessOrEqual 3
                 $kp.mechanism5_candidates[0].PSObject.Properties['id']    | Should -Not -BeNullOrEmpty
                 $kp.mechanism5_candidates[0].PSObject.Properties['score'] | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It 'Accepts custom MarginThreshold parameter' {
+            InModuleScope AITriad {
+                $script:CachedEmbeddings = @{ 'acc-beliefs-001' = M5-Vec 0 }
+                $script:TaxonomyData = @{}
+
+                # margin = 0.80 - 0.78 = 0.02; fires at threshold 0.01, not at 0.06
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.80 -AssignedScore 0.78
+                Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' }) -MarginThreshold 0.06
+                $kp.PSObject.Properties['mechanism5_flag'] | Should -BeNullOrEmpty -Because 'margin 0.02 ≤ 0.06'
+
+                $kp2 = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.80 -AssignedScore 0.78
+                $vm2 = M5-SetFakeState -Pov 'acc'
+                Mock Invoke-BatchEmbedAttribution { $vm2 }
+                Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp2; POV = 'accelerationist' }) -MarginThreshold 0.01
+                $kp2.mechanism5_flag | Should -BeTrue -Because 'margin 0.02 > custom threshold 0.01'
             }
         }
     }
@@ -173,8 +195,8 @@ Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
                     taxonomy_node_id         = 'acc-beliefs-001'
                     attribution_text         = 'the attribution'
                     verbatim                 = 'the verbatim'
-                    retrieval_low_confidence  = $true
-                    taxonomy_node_candidates  = @()
+                    retrieval_confidence     = 0.2
+                    taxonomy_node_candidates = @([PSCustomObject]@{ id = 'acc-beliefs-002'; score = 0.9; label = '' })
                 }
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
@@ -195,8 +217,8 @@ Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
                 $kp = [PSCustomObject]@{
                     taxonomy_node_id         = 'acc-beliefs-001'
                     verbatim                 = 'only verbatim here'
-                    retrieval_low_confidence  = $true
-                    taxonomy_node_candidates  = @()
+                    retrieval_confidence     = 0.2
+                    taxonomy_node_candidates = @([PSCustomObject]@{ id = 'acc-beliefs-002'; score = 0.9; label = '' })
                 }
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
@@ -205,7 +227,7 @@ Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
             }
         }
 
-        It 'Skips a flagged key_point when both attribution_text and verbatim are absent' {
+        It 'Skips a margin-triggered key_point when both attribution_text and verbatim are absent' {
             InModuleScope AITriad {
                 $script:CachedEmbeddings = @{ 'acc-beliefs-001' = M5-Vec 0 }
                 $script:TaxonomyData = @{}
@@ -214,8 +236,8 @@ Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
 
                 $kp = [PSCustomObject]@{
                     taxonomy_node_id         = 'acc-beliefs-001'
-                    retrieval_low_confidence  = $true
-                    taxonomy_node_candidates  = @()
+                    retrieval_confidence     = 0.2
+                    taxonomy_node_candidates = @([PSCustomObject]@{ id = 'acc-beliefs-002'; score = 0.9; label = '' })
                 }
                 Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' })
 
@@ -234,7 +256,7 @@ Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
             InModuleScope AITriad {
                 $script:CachedEmbeddings = @{}
 
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $true
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.9 -AssignedScore 0.2
                 { Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' }) } |
                     Should -Not -Throw
 
@@ -247,9 +269,43 @@ Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
             InModuleScope AITriad {
                 $script:CachedEmbeddings = $null
 
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $true
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.9 -AssignedScore 0.2
                 { Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' }) } |
                     Should -Not -Throw
+            }
+        }
+
+        It 'Does not throw when taxonomy_node_candidates is absent — skips margin check' {
+            InModuleScope AITriad {
+                $script:CachedEmbeddings = @{ 'acc-beliefs-001' = M5-Vec 0 }
+                $script:TaxonomyData = @{}
+
+                $kp = [PSCustomObject]@{
+                    taxonomy_node_id     = 'acc-beliefs-001'
+                    attribution_text     = 'text'
+                    retrieval_confidence = 0.2
+                }
+                { Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' }) } |
+                    Should -Not -Throw
+                $kp.PSObject.Properties['mechanism5_flag'] | Should -BeNullOrEmpty `
+                    -Because 'missing candidates means top1_score is unknown; must skip'
+            }
+        }
+
+        It 'Does not throw when retrieval_confidence is absent — skips margin check' {
+            InModuleScope AITriad {
+                $script:CachedEmbeddings = @{ 'acc-beliefs-001' = M5-Vec 0 }
+                $script:TaxonomyData = @{}
+
+                $kp = [PSCustomObject]@{
+                    taxonomy_node_id         = 'acc-beliefs-001'
+                    attribution_text         = 'text'
+                    taxonomy_node_candidates = @([PSCustomObject]@{ id = 'acc-beliefs-002'; score = 0.9; label = '' })
+                }
+                { Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' }) } |
+                    Should -Not -Throw
+                $kp.PSObject.Properties['mechanism5_flag'] | Should -BeNullOrEmpty `
+                    -Because 'missing retrieval_confidence means assigned_score unknown; must skip'
             }
         }
 
@@ -259,7 +315,8 @@ Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
                 $script:TaxonomyData = @{}
                 Mock Invoke-BatchEmbedAttribution { $null }
 
-                $kp = M5-KP -NodeId 'acc-beliefs-001' -LowConf $true
+                # margin = 0.9 - 0.2 = 0.7 > 0.06 → reaches batch-encode
+                $kp = M5-KP -NodeId 'acc-beliefs-001' -Top1Score 0.9 -AssignedScore 0.2
                 { Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' }) } |
                     Should -Not -Throw
 
@@ -272,7 +329,7 @@ Describe 'Invoke-Mechanism5RetrievalPass' -Tag 'mechanism5','retrieval' {
             InModuleScope AITriad {
                 $script:CachedEmbeddings = @{ 'acc-beliefs-001' = M5-Vec 0 }
 
-                $kp = [PSCustomObject]@{ attribution_text = 'text'; retrieval_low_confidence = $true }
+                $kp = [PSCustomObject]@{ attribution_text = 'text'; retrieval_confidence = 0.2 }
                 { Invoke-Mechanism5RetrievalPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'accelerationist' }) } |
                     Should -Not -Throw -Because 'missing taxonomy_node_id must be skipped, not throw under StrictMode'
             }


### PR DESCRIPTION
## Summary
- Replaces the v1 two-condition surfacing predicate (low-conf OR absent-from-top-3) with a single calibrated margin check: surface when `taxonomy_node_candidates[0].score − retrieval_confidence > 0.06`
- Threshold 0.06 calibrated from t/2341 adjudication (CL, t/2357#8); registered as `keypoint_surfacing_margin` (provisional) in metric-provenance-register (PR #718)
- ALL key_points evaluated — high-confidence misfires are the primary target; a conf-gated pre-filter would never fire on them
- No re-embedding for flagging: both scores already computed by `Invoke-RetrievalConfidencePass` (same in-memory pass, directly comparable)
- Auto-correct remains cancelled (no safe band; near-synonyms regress)
- `MarginThreshold` exposed as a parameter (default 0.06) for CL recalibration

## Test plan
- [ ] CI green on `2b69f8d6`
- [ ] 17/17 Pester tests (`tests/Invoke-Mechanism5RetrievalPass.Tests.ps1`) — incl. high-conf misfire fires, near-tie does not, custom threshold, missing-field degradation
- [ ] CL validates against t/2294 fixture: SAF-167 margin ≈ 0.65 ≫ 0.06 → fires; clean near-tie margin ≤ 0.05 → silent
- [ ] TL self-merge on CI green + CL fixture validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)