### PR TITLE
fix(debate): surface model+turn_count in community list rows (t/2362)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.community.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.community.test.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CommunityTableRow } from './DebateTable';
+import type { CommunityDebate } from '../../hooks/useCommunityStore';
+
+function makeRow(overrides: Partial<CommunityDebate> = {}): CommunityDebate {
+  return {
+    id: 'test-id',
+    title: 'Test debate',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderRow(cd: CommunityDebate) {
+  return render(
+    <table>
+      <tbody>
+        <CommunityTableRow
+          cd={cd}
+          isSelected={false}
+          onOpen={vi.fn()}
+          onExport={vi.fn()}
+          onCopy={vi.fn<() => Promise<void>>().mockResolvedValue(undefined)}
+          copyingId={null}
+          showCopy={false}
+          onPhoneSelect={vi.fn()}
+          isPhone={false}
+        />
+      </tbody>
+    </table>,
+  );
+}
+
+describe('CommunityTableRow — TURNS and MODEL field mapping (t/2362)', () => {
+  it('renders turn_count when present', () => {
+    renderRow(makeRow({ turn_count: 7 }));
+    expect(screen.getByText('7')).toBeTruthy();
+  });
+
+  it('renders model when present', () => {
+    renderRow(makeRow({ model: 'claude-opus-4-8' }));
+    expect(screen.getByText('claude-opus-4-8')).toBeTruthy();
+  });
+
+  it('renders — for turn_count when absent', () => {
+    const { getAllByText } = renderRow(makeRow());
+    // Both turns and model cells fall back to —
+    expect(getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders both turn_count and model together', () => {
+    renderRow(makeRow({ turn_count: 3, model: 'gemini-flash-lite' }));
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('gemini-flash-lite')).toBeTruthy();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -132,8 +132,8 @@ function applySortCommunity(rows: CommunityDebate[], sort: SortState): Community
       case 'title':  return mul * a.title.localeCompare(b.title);
       case 'status': return mul * (a.phase ?? '').localeCompare(b.phase ?? '');
       case 'date':   return mul * (new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime());
-      case 'turns':  return 0; // CommunityDebate may not have turn_count
-      case 'model':  return 0;
+      case 'turns':  return mul * ((a.turn_count ?? 0) - (b.turn_count ?? 0));
+      case 'model':  return mul * (a.model ?? '').localeCompare(b.model ?? '');
       default:       return 0;
     }
   });
@@ -506,16 +506,12 @@ export function CommunityTableRow({
 
       {/* Turns */}
       <td className="col-turns">
-        {'turn_count' in cd && (cd as { turn_count?: number }).turn_count != null
-          ? (cd as { turn_count?: number }).turn_count
-          : '—'}
+        {cd.turn_count != null ? cd.turn_count : '—'}
       </td>
 
       {/* Model */}
       <td className="col-model">
-        {'model' in cd && typeof (cd as { model?: string }).model === 'string'
-          ? (cd as { model?: string }).model || '—'
-          : '—'}
+        {cd.model || '—'}
       </td>
 
       {/* Actions */}


### PR DESCRIPTION
## Summary
- Replace duck-type `in` guards in `CommunityTableRow` with direct `.turn_count`/`.model` property access (t/2362)
- Fix `applySortCommunity` stubs: TURNS and MODEL now sort with real numeric/string comparison
- Add `DebateTable.community.test.tsx`: 4 tests asserting fields render correctly when present and fall back to `—` when absent

## Dependencies
- Server Community PR #717 (`4e855861`) — `CommunityDebateEntry` now sends `model`/`turn_count`
- Rosetta Stone PR #719 (`1549214a`) — `CommunityDebate` type carries `model?`/`turn_count?`

## Test plan
- [x] ESLint `--max-warnings=4256`: exit 0 (1 pre-existing complexity warning, not introduced here)
- [x] vitest scoped: 4/4 tests pass
- [ ] CI full gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)