### PR TITLE
fix(gate): contrast-check catches transparent-bg + non-text 3:1 controls (t/2359)

### DIFF
--- a/taxonomy-editor/scripts/__fixtures__/contrast/cases.css
+++ b/taxonomy-editor/scripts/__fixtures__/contrast/cases.css
@@ -59,3 +59,41 @@
   background: rgba(184, 78, 19, 0.12);
   color: #6b3a10;
 }
+
+/* ── t/2359: transparent-fill fall-through + non-text (3:1) floor ─────────── */
+
+/* FAIL (non-text) — transparent fill, muted glyph BELOW the 3:1 floor on the page
+   surface. Pins Gap 1 (a transparent control is evaluated, not silently skipped)
+   AND Gap 2 (scored at the 3:1 non-text floor). Shape of the muted help icon. */
+/* contrast-nontext */
+.fx-nontext-fail {
+  background: transparent;
+  color: #94a3b8;   /* 2.56:1 on #fff → below the 3:1 non-text floor */
+}
+
+/* PASS (non-text) — transparent fill, glyph at 3.68:1: clears the 3:1 non-text
+   floor but would FAIL the 4.5 text threshold, so a pass here proves the 3:1 rule
+   is what's applied (not 4.5). */
+/* contrast-nontext */
+.fx-nontext-pass {
+  background: transparent;
+  color: #3b82f6;   /* 3.68:1 on #fff */
+}
+
+/* PASS-BY-SKIP — a transparent TEXT control (no marker). It must NOT be audited
+   against the page surface by default (that broad audit is opt-in via
+   --include-page-bg), so it yields no finding even though 3.68:1 < 4.5. Pins the
+   flood guard that keeps Gap 1 from surfacing ~2400 page-bg findings. */
+.fx-transparent-text {
+  background: transparent;
+  color: #3b82f6;
+}
+
+/* PASS — :hover of a non-text control inherits the marker via pseudo-strip (same
+   control, not a broadened selector). Own opaque fill so it's always evaluated;
+   3.68:1 clears 3:1 but would fail 4.5 in every theme, so 0 findings proves the
+   pseudo-stripped inheritance applied the non-text floor. */
+.fx-nontext-pass:hover {
+  background: #ffffff;
+  color: #3b82f6;
+}

--- a/taxonomy-editor/scripts/check-contrast.mjs
+++ b/taxonomy-editor/scripts/check-contrast.mjs
@@ -28,6 +28,7 @@ const STYLES = join(RENDERER, 'styles.css');
 
 const AA_NORMAL = 4.5;
 const AA_LARGE = 3.0; // >=24px, or >=18.66px bold
+const NONTEXT = 3.0; // WCAG 1.4.11 — graphical objects / non-text controls (t/2359)
 const ROOT_FONT_PX = 16;
 
 // ── WCAG math (same as check-camp-contrast.mjs) ──────────────
@@ -58,6 +59,24 @@ function extractAnnotations(css) {
     anns.push({ selectors, fills: m[1].split(',').map((s) => s.trim()) });
   }
   return anns;
+}
+
+/**
+ * Harvest bare `/* contrast-nontext *\/` markers (t/2359). A marked selector is a
+ * graphical/non-text control (icon glyph, SVG stroke, border-only affordance) and
+ * is scored at the WCAG 1.4.11 3:1 floor instead of the 4.5/3.0 text thresholds.
+ * Boolean marker, parsed parallel to contrast-fill. Returns base selectors.
+ */
+function extractNonText(css) {
+  const set = new Set();
+  const re = /\/\*\s*contrast-nontext\s*\*\/\s*([^{]+?)\s*\{/g;
+  let m;
+  while ((m = re.exec(css)) !== null) {
+    for (const s of m[1].split(',').map((x) => x.trim()).filter(Boolean)) {
+      set.add(splitThemeScope(s).base);
+    }
+  }
+  return set;
 }
 
 function parseRules(css) {
@@ -331,6 +350,7 @@ export function check({
   for (const file of files) {
     const css = readFileSync(file, 'utf8');
     const annotations = extractAnnotations(css);
+    const nonTextSel = extractNonText(css);
     const rules = parseRules(css);
 
     // base selector -> theme ('*' for unscoped) -> decls
@@ -373,6 +393,13 @@ export function check({
         }
         if (!fg) continue;
 
+        // Non-text controls (icon glyph / SVG stroke / border ring) are scored at
+        // the WCAG 1.4.11 3:1 floor, not the text thresholds. The marker sits on the
+        // resting rule; strip pseudo-classes so :hover/:focus-visible states of the
+        // SAME control inherit it (not a broadening to other selectors) (t/2359).
+        const controlBase = base.replace(/::?[\w-]+(\([^)]*\))?/g, '').trim();
+        const isNonText = nonTextSel.has(base) || (!!controlBase && nonTextSel.has(controlBase));
+
         // Background: own rule, else nearest ancestor, else the page surface.
         const backgrounds = [];
         const ann = annotations.find((a) =>
@@ -381,26 +408,44 @@ export function check({
         if (ann) {
           for (const f of ann.fills) backgrounds.push({ value: f, from: 'annotation' });
         } else {
+          let sawTransparent = false;
           for (const cand of ancestorCandidates(base)) {
             const d = declsFor(cand, theme);
             const bg = d?.background || d?.['background-color'];
-            if (bg) {
-              backgrounds.push({ value: bg, from: cand });
-              break;
-            }
+            if (!bg) continue;
+            // `transparent`/`none` carry no color — see-through, so keep walking
+            // UP the chain instead of stopping here. Stopping at the first
+            // transparent fill is exactly what hid transparent-fill controls
+            // (the help icons) from the gate (t/2359).
+            const norm = bg.trim().toLowerCase();
+            if (norm === 'transparent' || norm === 'none') { sawTransparent = true; continue; }
+            backgrounds.push({ value: bg, from: cand });
+            break;
           }
-          // No explicit fill anywhere up the chain. Falling back to the page
-          // surface turns this into a general "is all text AA?" audit — ~2400
-          // mostly pre-existing findings, which is a report, not a gate. The
-          // defect class this exists to stop is text reversed out over a FILL,
-          // so page-background pairs are opt-in.
           if (!backgrounds.length) {
-            if (!includePageBg) continue;
-            backgrounds.push({ value: 'var(--bg-primary)', from: 'page default' });
+            // An explicit `background: transparent` up the chain is a positive
+            // statement that the page surface shows through, so evaluate against
+            // it even without --include-page-bg (distinct from "no fill declared
+            // anywhere", which stays the opt-in broad audit below). NOTE: assuming
+            // var(--bg-primary) here is optimistic — a transparent control shown
+            // only over a darker panel could pass against the page yet fail there;
+            // fine for the current set (.field-help-btn/.theory-link sit on the
+            // page surface). Scope the fall-through to non-text-annotated controls
+            // (or the opt-in broad audit) — evaluating EVERY transparent text
+            // control against the page surface floods the gate with the same ~2400
+            // page-bg findings the includePageBg flag deliberately gates off. (t/2359)
+            if (sawTransparent && (isNonText || includePageBg)) {
+              backgrounds.push({ value: 'var(--bg-primary)', from: 'page surface (transparent control)' });
+            } else if (includePageBg) {
+              backgrounds.push({ value: 'var(--bg-primary)', from: 'page default' });
+            } else {
+              continue;
+            }
           }
         }
 
         const { px, weight, min } = sizeThreshold(decls, tokens);
+        const minReq = isNonText ? NONTEXT : min;
 
         for (const { value, from } of backgrounds) {
           let bg;
@@ -430,14 +475,15 @@ export function check({
           if (!bgFlat || !fgFlat) continue;
 
           const ratio = contrast(fgFlat, bgFlat);
-          if (ratio < min) {
+          if (ratio < minReq) {
             findings.push({
               kind: 'contrast',
               file: relative(ROOT, file),
               selector: base,
               theme,
               ratio: Number(ratio.toFixed(2)),
-              required: min,
+              required: minReq,
+              nonText: isNonText,
               fg: decls.color,
               bg: value,
               bgFrom: from,

--- a/taxonomy-editor/scripts/check-contrast.test.mjs
+++ b/taxonomy-editor/scripts/check-contrast.test.mjs
@@ -47,6 +47,16 @@ describe('token-contrast checker — detection', () => {
     assert.ok(hits.length > 0, 'expected at least one finding');
     assert.ok([...result.undefinedTokens.keys()].includes('--fx-does-not-exist'));
   });
+
+  it('evaluates a transparent-fill non-text control against the page surface at 3:1 (t/2359)', () => {
+    // Gap 1: a `background: transparent` control was silently skipped (resolveColor
+    // → null → continue), hiding it from the gate. It must fall through to the page
+    // surface and be scored at the 3:1 non-text floor (Gap 2).
+    const hits = contrastOn('.fx-nontext-fail');
+    assert.ok(hits.length > 0, 'a transparent-fill control must be evaluated, not skipped');
+    assert.ok(hits.every((f) => f.required === 3.0), 'non-text controls score at the 3:1 floor');
+    assert.ok(hits.every((f) => f.ratio < 3.0), 'flagged only below 3:1');
+  });
 });
 
 describe('token-contrast checker — no false positives', () => {
@@ -70,5 +80,22 @@ describe('token-contrast checker — no false positives', () => {
       hits.every((f) => f.ratio !== 1),
       'a translucent fill must be flattened onto the surface before comparison',
     );
+  });
+
+  it('passes a non-text control at 3.68:1 that would fail the 4.5 text threshold (t/2359)', () => {
+    // Proves the 3:1 non-text floor is applied, not the 4.5 text threshold.
+    assert.equal(contrastOn('.fx-nontext-pass').length, 0);
+  });
+
+  it('does not audit an un-annotated transparent TEXT control against the page surface (t/2359)', () => {
+    // Flood guard: without the marker, a transparent control stays part of the
+    // opt-in --include-page-bg audit (its 3.68:1 < 4.5 would otherwise flag it).
+    assert.equal(contrastOn('.fx-transparent-text').length, 0);
+  });
+
+  it("applies the non-text floor to a control's :hover via pseudo-strip (t/2359)", () => {
+    // Same control, not a broadened selector. Opaque fill → always evaluated;
+    // 3.68:1 fails 4.5 in every theme, so 0 findings proves the 3:1 floor was used.
+    assert.equal(contrastOn('.fx-nontext-pass:hover').length, 0);
   });
 });

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.css
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.css
@@ -1,5 +1,7 @@
 /* TheoryLink (t/2343) — mirrors .field-help-btn tokens: muted foreground, brightens on hover.
    Co-located because styles.css is frozen (no new selectors). */
+/* graphical icon affordance — scored at the WCAG 1.4.11 3:1 non-text floor (t/2359) */
+/* contrast-nontext */
 .theory-link {
   display: inline-flex;
   align-items: center;

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -4990,7 +4990,7 @@ body {
   vertical-align: middle;
 }
 
-.field-help-btn {
+/* contrast-nontext */ .field-help-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Closes the two `check-contrast.mjs` gaps that let the sub-3:1 muted help icons pass (split from t/2358). Design coordinated the mechanism (t/2359#2, p/29#75).

## Gap 1 — transparent-bg controls silently skipped
The ancestor walk stopped at the first `transparent` fill and `resolveColor('transparent')=null` dropped the element. Now `transparent`/`none` is **see-through — keep walking up**; if the whole chain is transparent, fall through to the page surface. **Scoped to non-text-annotated controls** (or `--include-page-bg`) so it doesn't flood the gate with the ~2400 page-bg findings the opt-in audit deliberately excludes. (The `var(--bg-primary)` surface assumption is optimistic — commented in-code.)

## Gap 2 — no WCAG 1.4.11 non-text rule
Added a bare `/* contrast-nontext */` marker (parsed parallel to `contrast-fill:`) scoring the selector at the **3:1** floor instead of 4.5/3.0 text thresholds. Applied to **`.field-help-btn` + `.theory-link` only** (per Design). Pseudo-classes are stripped so the control's `:hover`/`:focus-visible` states inherit it (same control, not a broadened selector).

## Verification
- **Regression pin:** with pre-t/2358 slate-400, the gate FLAGS `.theory-link` (2.56/3) and total 321 > 314 → **RED**; with slate-500 it **PASSES** (302/314).
- Net **+2** = two pre-existing `.badge-outline` AA findings (bkc/harvard) the more-accurate transparent-walk correctly surfaces (within ceiling; not introduced here).
- 4 new self-test cases (transparent fall-through, 3:1 floor, flood guard, pseudo-strip); **11/11** pass. eslint clean.

## Notes for Design/DevOps
- `.field-help-btn` lives in the frozen `styles.css`, which the **default gate excludes** — its annotation is exercised only under `--all`. The token fix (t/2358) already lifted it ≥3:1. The default gate now catches co-located non-text controls (`.theory-link` ✓).
- Ceiling left at 314 (12 headroom); could be tightened to 302 in a follow-up once concurrent PRs settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)