### PR TITLE
chore(storage): Test-DebateSession cmdlet — debate blob existence (t/2367)

### DIFF
--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -212,6 +212,8 @@
         'Get-DebateSessionState'
         # t/2335 — Debate index field-type integrity check
         'Test-DebateIndexIntegrity'
+        # t/2367 — Debate blob existence check in Azure storage
+        'Test-DebateSession'
     )
 
     # Aliases exported from this module

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -913,6 +913,8 @@ Export-ModuleMember -Function @(
     'Get-DebateSessionState'
     # t/2335 — Debate index field-type integrity check
     'Test-DebateIndexIntegrity'
+    # t/2367 — Debate blob existence check in Azure storage
+    'Test-DebateSession'
 ) -Alias @(
     'Import-Document'
     'TaxonomyEditor'

--- a/scripts/AITriad/Public/Test-DebateSession.ps1
+++ b/scripts/AITriad/Public/Test-DebateSession.ps1
@@ -1,0 +1,174 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-DebateSession {
+    <#
+    .SYNOPSIS
+        Tests whether a debate blob exists in Azure Blob Storage.
+    .DESCRIPTION
+        Checks Azure Blob Storage for a debate JSON at
+        users/{userId}/debates/debate-{debateId}.json in the 'user-content' container.
+
+        When -UserId is supplied the check is a direct blob show (fast).
+        Without -UserId the command scans all user prefixes and returns the first match.
+
+        Returns a result object regardless of existence; only unrecoverable errors throw.
+        Requires az CLI logged in with storage account access.
+    .PARAMETER DebateId
+        The debate UUID (with or without the 'debate-' prefix, e.g. 'd1c7f7b6-...' or
+        'debate-d1c7f7b6-...').
+    .PARAMETER UserId
+        Azure AD user GUID that owns the debate. When omitted the command scans all
+        'users/' prefixes — slower and requires list permissions.
+    .PARAMETER StorageAccount
+        Storage account name. Default: auto-detected from resource group.
+    .PARAMETER ResourceGroup
+        Azure resource group name. Default: ai-triad.
+    .OUTPUTS
+        PSCustomObject with: Exists, StoragePath, OwnerId, SizeBytes.
+    .EXAMPLE
+        Test-DebateSession -DebateId d1c7f7b6-a170-45bb-9f14-37baf9a8ea2b -UserId abc-123
+    .EXAMPLE
+        Test-DebateSession d1c7f7b6-a170-45bb-9f14-37baf9a8ea2b
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Get-DebateSessionState
+    .LINK
+        Get-TaxEditorBlob
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DebateId,
+
+        [Parameter()]
+        [string]$UserId,
+
+        [Parameter()]
+        [string]$StorageAccount,
+
+        [Parameter()]
+        [string]$ResourceGroup = 'ai-triad'
+    )
+
+    Set-StrictMode -Version Latest
+    $CallerName = 'Test-DebateSession'
+    $Container  = 'user-content'
+
+    # ── Validate az CLI ──────────────────────────────────────────────────────
+    $AzCmd = Get-Command az -ErrorAction SilentlyContinue
+    if (-not $AzCmd) {
+        throw (New-ActionableError `
+            -Goal    'Check debate blob existence' `
+            -Problem 'Azure CLI (az) not found on PATH' `
+            -Location $CallerName `
+            -NextSteps @('Install Azure CLI: https://aka.ms/installazurecli'))
+    }
+
+    $AccountJson = & az account show --output json 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $AccountJson) {
+        throw (New-ActionableError `
+            -Goal    'Check debate blob existence' `
+            -Problem 'Azure CLI is not logged in' `
+            -Location $CallerName `
+            -NextSteps @('Run: az login', 'Verify subscription: az account show'))
+    }
+
+    # ── Resolve storage account ──────────────────────────────────────────────
+    if (-not $StorageAccount) {
+        $AccountListJson = & az storage account list -g $ResourceGroup `
+            --query "[?starts_with(name,'staitriad')].name" -o json 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $AccountListJson) {
+            throw (New-ActionableError `
+                -Goal    'Resolve storage account' `
+                -Problem "No storage accounts found in resource group '$ResourceGroup'" `
+                -Location $CallerName `
+                -NextSteps @('Pass -StorageAccount explicitly',
+                             "Check: az storage account list -g $ResourceGroup"))
+        }
+        $Accounts = @($AccountListJson | ConvertFrom-Json)
+        if ($Accounts.Count -eq 0) {
+            throw (New-ActionableError `
+                -Goal    'Resolve storage account' `
+                -Problem "No 'staitriad*' storage accounts found in '$ResourceGroup'" `
+                -Location $CallerName `
+                -NextSteps @('Pass -StorageAccount explicitly'))
+        }
+        $StorageAccount = [string]$Accounts[0]
+    }
+
+    # Strip optional 'debate-' prefix
+    $CleanId = $DebateId -replace '^debate-', ''
+
+    # ── Direct lookup (UserId known) ─────────────────────────────────────────
+    if ($UserId) {
+        $BlobName  = "users/$UserId/debates/debate-$CleanId.json"
+        $ShowJson  = & az storage blob show `
+            --account-name  $StorageAccount `
+            --container-name $Container `
+            --name          $BlobName `
+            --auth-mode     login `
+            --output        json 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $ShowJson) {
+            return [PSCustomObject]@{ Exists = $false; StoragePath = $null; OwnerId = $null; SizeBytes = 0L }
+        }
+        $Blob      = $ShowJson | ConvertFrom-Json
+        $SizeBytes = 0L
+        if ($Blob.PSObject.Properties['properties'] -and
+            $Blob.properties.PSObject.Properties['contentLength']) {
+            $SizeBytes = [long]$Blob.properties.contentLength
+        }
+        return [PSCustomObject]@{
+            Exists      = $true
+            StoragePath = $BlobName
+            OwnerId     = $UserId
+            SizeBytes   = $SizeBytes
+        }
+    }
+
+    # ── Scan (no UserId) ─────────────────────────────────────────────────────
+    $ListJson = & az storage blob list `
+        --account-name   $StorageAccount `
+        --container-name $Container `
+        --prefix         'users/' `
+        --auth-mode      login `
+        --output         json 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $ListJson) {
+        throw (New-ActionableError `
+            -Goal    "Scan for debate '$CleanId' across all users" `
+            -Problem "Failed to list blobs in container '$Container'" `
+            -Location $CallerName `
+            -NextSteps @(
+                "Verify storage access: az storage blob list --account-name $StorageAccount --container-name $Container --auth-mode login",
+                'Pass -UserId to use a targeted blob show instead'))
+    }
+
+    $EscapedId = [regex]::Escape($CleanId)
+    $Pattern   = "^users/([^/]+)/debates/debate-$EscapedId\.json$"
+    $Match     = @($ListJson | ConvertFrom-Json) | Where-Object {
+        $_.PSObject.Properties['name'] -and $_.name -match $Pattern
+    } | Select-Object -First 1
+
+    if (-not $Match) {
+        return [PSCustomObject]@{ Exists = $false; StoragePath = $null; OwnerId = $null; SizeBytes = 0L }
+    }
+
+    $ExtractedOwnerId = $null
+    if ($Match.name -match '^users/([^/]+)/') { $ExtractedOwnerId = $Matches[1] }
+
+    $SizeBytes = 0L
+    if ($Match.PSObject.Properties['properties'] -and
+        $Match.properties.PSObject.Properties['contentLength']) {
+        $SizeBytes = [long]$Match.properties.contentLength
+    }
+
+    return [PSCustomObject]@{
+        Exists      = $true
+        StoragePath = $Match.name
+        OwnerId     = $ExtractedOwnerId
+        SizeBytes   = $SizeBytes
+    }
+}

--- a/tests/Test-DebateSession.Tests.ps1
+++ b/tests/Test-DebateSession.Tests.ps1
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Test-DebateSession (t/2367).
+.DESCRIPTION
+    Covers: az CLI validation, storage account auto-resolve, direct blob show
+    (with UserId), prefix scan (without UserId), not-found returns, OwnerId
+    extraction, and SizeBytes propagation.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-DebateSession' -Tag 'health','azure' {
+
+    # ── az CLI validation ────────────────────────────────────────────────────
+
+    It 'Throws when az CLI is not found' {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        { Test-DebateSession -DebateId 'abc-123' 2>$null } | Should -Throw
+    }
+
+    It 'Throws when az CLI is not logged in' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 1; return $null } -ModuleName AITriad
+        { Test-DebateSession -DebateId 'abc-123' -StorageAccount 'staitriadx' 2>$null } | Should -Throw
+    }
+
+    It 'Throws when no staitriad* storage account is found' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'show') { return '{"id":"sub-123"}' }
+            return '[]'
+        } -ModuleName AITriad
+        { Test-DebateSession -DebateId 'abc-123' 2>$null } | Should -Throw
+    }
+
+    # ── direct lookup (UserId provided) ─────────────────────────────────────
+
+    It 'Returns Exists=$true with correct fields when blob is found (UserId path)' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'show' -and $args -contains 'account') {
+                return '{"id":"sub-123"}'
+            }
+            if ($args -contains 'blob' -and $args -contains 'show') {
+                return '{"name":"users/user-001/debates/debate-abc-123.json","properties":{"contentLength":4096}}'
+            }
+            return '[]'
+        } -ModuleName AITriad
+
+        $Result = Test-DebateSession -DebateId 'abc-123' -UserId 'user-001' -StorageAccount 'staitriadx'
+        $Result.Exists      | Should -BeTrue
+        $Result.StoragePath | Should -Be 'users/user-001/debates/debate-abc-123.json'
+        $Result.OwnerId     | Should -Be 'user-001'
+        $Result.SizeBytes   | Should -Be 4096
+    }
+
+    It 'Returns Exists=$false when blob show returns exit code 1 (UserId path)' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            if ($args -contains 'show' -and $args -contains 'account') {
+                $global:LASTEXITCODE = 0
+                return '{"id":"sub-123"}'
+            }
+            $global:LASTEXITCODE = 1
+            return $null
+        } -ModuleName AITriad
+
+        $Result = Test-DebateSession -DebateId 'abc-123' -UserId 'user-001' -StorageAccount 'staitriadx'
+        $Result.Exists      | Should -BeFalse
+        $Result.StoragePath | Should -BeNullOrEmpty
+        $Result.OwnerId     | Should -BeNullOrEmpty
+        $Result.SizeBytes   | Should -Be 0
+    }
+
+    It 'Strips debate- prefix from DebateId before constructing blob path' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        $script:CapturedArgs = @()
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            $script:CapturedArgs = @($args)
+            if ($args -contains 'show' -and $args -contains 'account') {
+                return '{"id":"sub-123"}'
+            }
+            return '{"name":"users/user-001/debates/debate-abc-123.json","properties":{"contentLength":1}}'
+        } -ModuleName AITriad
+
+        Test-DebateSession -DebateId 'debate-abc-123' -UserId 'user-001' -StorageAccount 'staitriadx' | Out-Null
+        $script:CapturedArgs | Where-Object { $_ -like '*debate-abc-123*' } |
+            Should -Not -BeNullOrEmpty -Because 'debate- prefix must be stripped once, not doubled'
+    }
+
+    # ── prefix scan (no UserId) ──────────────────────────────────────────────
+
+    It 'Returns Exists=$true with extracted OwnerId when scan finds the blob' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'show' -and $args -contains 'account') {
+                return '{"id":"sub-123"}'
+            }
+            if ($args -contains 'blob' -and $args -contains 'list') {
+                return @'
+[
+  {"name":"users/user-abc/debates/debate-deadbeef-0001.json","properties":{"contentLength":2048}},
+  {"name":"users/user-abc/debates/debate-other-id.json","properties":{"contentLength":512}}
+]
+'@
+            }
+            return '[]'
+        } -ModuleName AITriad
+
+        $Result = Test-DebateSession -DebateId 'deadbeef-0001' -StorageAccount 'staitriadx'
+        $Result.Exists      | Should -BeTrue
+        $Result.StoragePath | Should -Be 'users/user-abc/debates/debate-deadbeef-0001.json'
+        $Result.OwnerId     | Should -Be 'user-abc'
+        $Result.SizeBytes   | Should -Be 2048
+    }
+
+    It 'Returns Exists=$false when scan finds no matching blob' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'show' -and $args -contains 'account') {
+                return '{"id":"sub-123"}'
+            }
+            if ($args -contains 'blob' -and $args -contains 'list') {
+                return '[{"name":"users/user-abc/debates/debate-other-id.json","properties":{"contentLength":512}}]'
+            }
+            return '[]'
+        } -ModuleName AITriad
+
+        $Result = Test-DebateSession -DebateId 'deadbeef-0001' -StorageAccount 'staitriadx'
+        $Result.Exists  | Should -BeFalse
+        $Result.OwnerId | Should -BeNullOrEmpty
+    }
+
+    It 'Throws when blob list fails in scan mode' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            if ($args -contains 'show' -and $args -contains 'account') {
+                $global:LASTEXITCODE = 0
+                return '{"id":"sub-123"}'
+            }
+            $global:LASTEXITCODE = 1
+            return $null
+        } -ModuleName AITriad
+
+        { Test-DebateSession -DebateId 'deadbeef-0001' -StorageAccount 'staitriadx' 2>$null } | Should -Throw
+    }
+
+    # ── storage account auto-resolve ─────────────────────────────────────────
+
+    It 'Auto-resolves storage account when -StorageAccount is not supplied' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'show' -and $args -contains 'account') { return '{"id":"sub-123"}' }
+            if ($args -contains 'account' -and $args -contains 'list') { return '["staitriadauto"]' }
+            if ($args -contains 'blob' -and $args -contains 'show') {
+                return '{"name":"users/u1/debates/debate-abc-123.json","properties":{"contentLength":100}}'
+            }
+            return '[]'
+        } -ModuleName AITriad
+
+        $Result = Test-DebateSession -DebateId 'abc-123' -UserId 'u1'
+        $Result.Exists | Should -BeTrue
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Test-DebateSession` public cmdlet that checks whether a debate blob exists in Azure Blob Storage
- Direct blob show when `-UserId` is supplied; prefix scan across all `users/` prefixes otherwise
- Returns `Exists / StoragePath / OwnerId / SizeBytes` — never throws on not-found, only on CLI/infra failures

## Implementation
- `scripts/AITriad/Public/Test-DebateSession.ps1` — new cmdlet
- `scripts/AITriad/AITriad.psd1` + `AITriad.psm1` — registered in both (per t/2335 lesson)
- `tests/Test-DebateSession.Tests.ps1` — 10 Pester tests

## Self-cert
- `/add-ps-cmdlet` checklist complete: `[CmdletBinding()]` + `[OutputType]`, `New-ActionableError` for all failures, both export files updated, `Get-Command Test-DebateSession` verified post-import, 10/10 tests pass, `Test-ModuleManifest` clean
- `/review-ps` complete: StrictMode guards, `PSObject.Properties` checks on all JSON fields, `@()` wraps before `.Count`

## Test plan
- [ ] `Invoke-Pester ./tests/Test-DebateSession.Tests.ps1` — 10/10 pass (verified locally)
- [ ] `Test-ModuleManifest -Path ./scripts/AITriad/AITriad.psd1` — clean (verified locally)
- [ ] CI green at `0a5b4cd155fa0ef7a1d5860d220fa2fc97841bbf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)