### PR TITLE
feat(debate): move Title column to rightmost in debate table (t/2363)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.css
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.css
@@ -30,11 +30,6 @@
 .debate-table colgroup .col-actions { width: 11.5rem; }
 .debate-table colgroup .col-cb      { width: 2rem; }
 
-@media (min-width: 1024px) {
-  /* Desktop only: cap title column so it doesn't grow to fill all excess space */
-  .debate-table colgroup .col-title { width: 35%; }
-}
-
 /* ──────────────────────────────────────────────
    Header
 ────────────────────────────────────────────── */
@@ -51,8 +46,7 @@
   user-select: none;
 }
 
-.debate-table thead th.col-turns,
-.debate-table thead th.col-actions {
+.debate-table thead th.col-turns {
   text-align: right;
 }
 
@@ -190,7 +184,7 @@
 /* Actions cell */
 .debate-table td.col-actions {
   white-space: nowrap;
-  text-align: right;
+  text-align: left;
 }
 
 /* Checkbox cell */
@@ -234,7 +228,7 @@
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .debate-table-action-btn {
@@ -346,10 +340,17 @@
   }
 
   .debate-table tbody tr {
+    display: flex;
+    flex-direction: column;
     border: 1px solid var(--border-color);
     border-radius: 6px;
     margin-bottom: 0.75rem;
     padding: 0.5rem 0.75rem;
+  }
+
+  /* Title is last in DOM but should appear first in card view */
+  .debate-table td.col-title {
+    order: -1;
   }
 
   .debate-table tbody tr.selected {

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -196,12 +196,12 @@ function MyColGroup({ editMode }: { editMode: boolean }) {
   return (
     <colgroup>
       {editMode && <col className="col-cb" />}
-      <col className="col-title" />
       <col className="col-status" />
       <col className="col-date" />
       <col className="col-turns" />
       <col className="col-model" />
       <col className="col-actions" />
+      <col className="col-title" />
     </colgroup>
   );
 }
@@ -209,12 +209,12 @@ function MyColGroup({ editMode }: { editMode: boolean }) {
 function CommunityColGroup() {
   return (
     <colgroup>
-      <col className="col-title" />
       <col className="col-status" />
       <col className="col-date" />
       <col className="col-turns" />
       <col className="col-model" />
       <col className="col-actions" />
+      <col className="col-title" />
     </colgroup>
   );
 }
@@ -316,42 +316,6 @@ export function DebateTableRow({
         </td>
       )}
 
-      {/* Title */}
-      <td className="col-title">
-        {isRenaming ? (
-          <input
-            className="debate-table-rename-input"
-            value={renameValue}
-            autoFocus
-            onClick={e => e.stopPropagation()}
-            onChange={e => setRenameValue(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter' && renameValue.trim()) {
-                e.stopPropagation();
-                commitRename();
-              } else if (e.key === 'Escape') {
-                setRenamingId(null);
-              }
-            }}
-            onBlur={commitRename}
-          />
-        ) : (
-          <div
-            className="debate-table-title-text"
-            title={safeTitle}
-            onDoubleClick={!editMode ? handleDoubleClick : undefined}
-          >
-            {safeTitle}
-          </div>
-        )}
-        {/* Model shown as secondary line on tablet (col hidden) */}
-        {s.model && (
-          <div className="debate-table-title-secondary model-secondary">
-            {s.model}
-          </div>
-        )}
-      </td>
-
       {/* Status */}
       <td className="col-status">
         <StatusPill phase={s.phase} />
@@ -430,6 +394,42 @@ export function DebateTableRow({
           </div>
         )}
       </td>
+
+      {/* Title — rightmost so it absorbs extra window width */}
+      <td className="col-title">
+        {isRenaming ? (
+          <input
+            className="debate-table-rename-input"
+            value={renameValue}
+            autoFocus
+            onClick={e => e.stopPropagation()}
+            onChange={e => setRenameValue(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && renameValue.trim()) {
+                e.stopPropagation();
+                commitRename();
+              } else if (e.key === 'Escape') {
+                setRenamingId(null);
+              }
+            }}
+            onBlur={commitRename}
+          />
+        ) : (
+          <div
+            className="debate-table-title-text"
+            title={safeTitle}
+            onDoubleClick={!editMode ? handleDoubleClick : undefined}
+          >
+            {safeTitle}
+          </div>
+        )}
+        {/* Model shown as secondary line on tablet (col hidden) */}
+        {s.model && (
+          <div className="debate-table-title-secondary model-secondary">
+            {s.model}
+          </div>
+        )}
+      </td>
     </tr>
   );
 }
@@ -482,18 +482,6 @@ export function CommunityTableRow({
       onClick={handleRowClick}
       onKeyDown={handleKeyDown}
     >
-      {/* Title */}
-      <td className="col-title">
-        <div className="debate-table-title-text" title={cd.title}>
-          {cd.title}
-        </div>
-        {submitter && (
-          <div className="debate-table-title-secondary">
-            by {submitter}
-          </div>
-        )}
-      </td>
-
       {/* Status */}
       <td className="col-status">
         <StatusPill phase={cd.phase} />
@@ -540,6 +528,18 @@ export function CommunityTableRow({
             </button>
           )}
         </div>
+      </td>
+
+      {/* Title — rightmost so it absorbs extra window width */}
+      <td className="col-title">
+        <div className="debate-table-title-text" title={cd.title}>
+          {cd.title}
+        </div>
+        {submitter && (
+          <div className="debate-table-title-secondary">
+            by {submitter}
+          </div>
+        )}
       </td>
     </tr>
   );
@@ -593,9 +593,6 @@ function MyTable(props: DebateTableMyProps & { sort: SortState; onSort: (col: So
         <thead>
           <tr>
             {editMode && <th scope="col" className="col-cb" aria-label="Select row" />}
-            <th scope="col" className="col-title" aria-sort={getSortAttr('title', sort)}>
-              <SortHeader label="Title" col="title" sort={sort} onSort={onSort} />
-            </th>
             <th scope="col" className="col-status" aria-sort={getSortAttr('status', sort)}>
               <SortHeader label="Status" col="status" sort={sort} onSort={onSort} />
             </th>
@@ -610,6 +607,9 @@ function MyTable(props: DebateTableMyProps & { sort: SortState; onSort: (col: So
             </th>
             <th scope="col" className="col-actions">
               Actions
+            </th>
+            <th scope="col" className="col-title" aria-sort={getSortAttr('title', sort)}>
+              <SortHeader label="Title" col="title" sort={sort} onSort={onSort} />
             </th>
           </tr>
         </thead>
@@ -686,9 +686,6 @@ function CommunityTable(
         <CommunityColGroup />
         <thead>
           <tr>
-            <th scope="col" className="col-title" aria-sort={getSortAttr('title', sort)}>
-              <SortHeader label="Title" col="title" sort={sort} onSort={onSort} />
-            </th>
             <th scope="col" className="col-status" aria-sort={getSortAttr('status', sort)}>
               <SortHeader label="Status" col="status" sort={sort} onSort={onSort} />
             </th>
@@ -703,6 +700,9 @@ function CommunityTable(
             </th>
             <th scope="col" className="col-actions">
               Actions
+            </th>
+            <th scope="col" className="col-title" aria-sort={getSortAttr('title', sort)}>
+              <SortHeader label="Title" col="title" sort={sort} onSort={onSort} />
             </th>
           </tr>
         </thead>


### PR DESCRIPTION
## Summary

- Moves `col-title` to the rightmost position in both My and Community debate tables so the title absorbs spare window width rather than being pinned first
- Updated all 6 sites: both colgroups, both `<thead>` rows, `DebateTableRow` body, and `CommunityTableRow` body
- CSS: removed desktop 35% width cap, left-aligned actions cell/buttons, added phone-card `flex+order:-1` fix so title still renders first visually at ≤600px

## Test plan

- [x] All 58 debate component tests pass (`vitest run src/renderer/components/debate/`)
- [x] ESLint: 0 errors, 553 warnings (under 4256 ceiling)
- [ ] Visual check: My Debates and Community tabs both show Title rightmost
- [ ] Phone-width card view: Title appears first (order:-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
