### PR TITLE
fix(gate): evaluate annotated selectors in styles.css without --all (t/2372)

### DIFF
--- a/taxonomy-editor/scripts/__fixtures__/contrast/theme-tokens.css
+++ b/taxonomy-editor/scripts/__fixtures__/contrast/theme-tokens.css
@@ -13,3 +13,17 @@
   --fill-dark: #a35012;
   --fill-light: #60a5fa;
 }
+
+/* t/2372: selectors that live in the stylesFile itself. In default mode the
+   stylesFile is normally excluded — but an ANNOTATED selector must still be
+   evaluated (a deliberate "check this control"), while an unannotated one stays
+   opt-in (--all). These two pin that distinction. */
+/* contrast-nontext */
+.fx-styles-annotated {
+  background: transparent;
+  color: #94a3b8;   /* 2.56:1 on #fff → flagged at the 3:1 floor, even in default mode */
+}
+.fx-styles-unannotated {
+  background: var(--fill-light);
+  color: #ffffff;   /* fails, but excluded in default mode; only surfaces under --all */
+}

--- a/taxonomy-editor/scripts/check-contrast.mjs
+++ b/taxonomy-editor/scripts/check-contrast.mjs
@@ -345,13 +345,31 @@ export function check({
   const findings = [];
   const undefinedTokens = new Map();
 
-  const files = cssFiles(rendererDir).filter((f) => all || f !== stylesFile);
+  // Always scan every file. styles.css is normally excluded by default (scanning
+  // all of it surfaces ~hundreds of noisy pre-existing findings → opt-in via --all),
+  // but a selector carrying an explicit annotation (contrast-fill / contrast-nontext)
+  // is a deliberate "check this control" statement, so THOSE are evaluated even in
+  // the stylesFile without --all. Unannotated stylesFile rules stay opt-in (t/2372).
+  const files = cssFiles(rendererDir);
 
   for (const file of files) {
     const css = readFileSync(file, 'utf8');
     const annotations = extractAnnotations(css);
     const nonTextSel = extractNonText(css);
     const rules = parseRules(css);
+
+    // In default mode the stylesFile contributes ONLY its annotated selectors.
+    const annotatedOnly = !all && file === stylesFile;
+    const isAnnotated = (b) => {
+      const control = b.replace(/::?[\w-]+(\([^)]*\))?/g, '').trim();
+      if (nonTextSel.has(b) || (control && nonTextSel.has(control))) return true;
+      return annotations.some((a) =>
+        a.selectors.some((s) => {
+          const sb = splitThemeScope(s).base;
+          return sb === b || sb === control;
+        }),
+      );
+    };
 
     // base selector -> theme ('*' for unscoped) -> decls
     const index = new Map();
@@ -375,6 +393,7 @@ export function check({
     for (const [base, slot] of index) {
       const hasColorAnywhere = Object.values(slot).some((d) => d.color);
       if (!hasColorAnywhere) continue;
+      if (annotatedOnly && !isAnnotated(base)) continue;
 
       for (const theme of THEMES) {
         const tokens = themeTokens[theme];

--- a/taxonomy-editor/scripts/check-contrast.test.mjs
+++ b/taxonomy-editor/scripts/check-contrast.test.mjs
@@ -99,3 +99,29 @@ describe('token-contrast checker — no false positives', () => {
     assert.equal(contrastOn('.fx-nontext-pass:hover').length, 0);
   });
 });
+
+describe('token-contrast checker — annotated selectors in the stylesFile (t/2372)', () => {
+  // CI runs the gate without --all, which excludes the stylesFile. An annotated
+  // selector there (e.g. .field-help-btn) must still be evaluated; an unannotated
+  // one must stay opt-in. `result` above is a default (no --all) run.
+  it('evaluates an ANNOTATED selector defined in the stylesFile in default mode', () => {
+    assert.ok(contrastOn('.fx-styles-annotated').length > 0, 'annotated stylesFile selector must be checked in default mode');
+    assert.ok(contrastOn('.fx-styles-annotated').every((f) => f.required === 3.0), 'scored at its non-text floor');
+  });
+
+  it('still EXCLUDES an unannotated stylesFile selector in default mode', () => {
+    assert.equal(contrastOn('.fx-styles-unannotated').length, 0, 'unannotated stylesFile rules stay opt-in (--all)');
+  });
+
+  it('includes the unannotated stylesFile selector only under --all', () => {
+    const allRun = check({
+      rendererDir: FIXTURES,
+      stylesFile: join(FIXTURES, 'theme-tokens.css'),
+      all: true,
+    });
+    assert.ok(
+      allRun.findings.some((f) => f.kind === 'contrast' && f.selector === '.fx-styles-unannotated'),
+      '--all must scan every stylesFile rule',
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to t/2359 (which I flagged on close). CI runs `check-contrast.sh` **without `--all`**, and default mode excludes `styles.css` — so `.field-help-btn`'s `/* contrast-nontext */` guard was **inert in CI** (only `.theory-link`, in its own file, was live). The shared `--text-muted` token stays caught via `.theory-link`, but a `.field-help-btn`-specific sub-3:1 regression would slip through (fragile transitive-canary coupling).

## Fix (Design's preferred approach — not `--all`)
Scan every file, but in default mode the **stylesFile contributes ONLY its explicitly-annotated selectors** (`contrast-fill` / `contrast-nontext`, pseudo-classes stripped). Unannotated stylesFile rules stay opt-in (`--all`). An annotation is a deliberate "check this control," so it's honored regardless of the default exclusion.

## Verify
- Default count **unchanged: 302/314** — `.field-help-btn` passes at slate-500 → **zero new noise, no ceiling re-baseline**.
- Reverting light `--text-muted` to slate-400 now flags **both** `.theory-link` **and** `.field-help-btn` in **default** mode (previously only `.theory-link`).
- 3 new self-tests: annotated stylesFile selector evaluated in default; unannotated excluded in default; unannotated included under `--all`. **14/14** pass; eslint clean.

Closes the transitive-canary gap so `.field-help-btn` is guarded directly in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)