### PR TITLE
chore(server): include storageUserId in 404 debate load response (t/2364)

### DIFF
--- a/taxonomy-editor/src/server/httpKit.ts
+++ b/taxonomy-editor/src/server/httpKit.ts
@@ -51,7 +51,7 @@ function recordServerError(route: string, status: number, message: string, cause
   });
 }
 
-export function error(res: ServerResponse, message: string, status = 500, cause?: unknown): void {
+export function error(res: ServerResponse, message: string, status = 500, cause?: unknown, extra?: Record<string, unknown>): void {
   // M4: don't leak internal detail (file paths, stack) to clients on server
   // errors in production — record the real message server-side, return generic.
   const route: string = (res as unknown as { __routePath?: string }).__routePath ?? 'server';
@@ -78,7 +78,7 @@ export function error(res: ServerResponse, message: string, status = 500, cause?
   }
   // t/853: strip ActionableError internals (location, resolve steps) from <500
   // responses in production; keep the user-actionable summary.
-  json(res, { error: clientSafeMessage(message, cause), requestId: getRequestId() }, status);
+  json(res, { error: clientSafeMessage(message, cause), requestId: getRequestId(), ...extra }, status);
 }
 
 /** t/1515/t/1516 — defense-in-depth wall-clock cap for handlers that call out to

--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -118,7 +118,7 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
     try { json(res, await fileIO.loadDebateSession(param(req, 'id', '/api/debates/:id'))); }
     catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'debates', level: 'warn', message: 'Failed to load debate session', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      error(res, String(err), 404, err);
+      error(res, String(err), 404, err, { storageUserId: getStorageUserId() });
     }
   });
 


### PR DESCRIPTION
## Summary
- Adds optional `extra?: Record<string, unknown>` param to `error()` in `httpKit.ts` — backward-compatible, spreads into the JSON response body after `error`/`requestId`
- `GET /api/debates/:id` 404 now includes `storageUserId` so the client FR event can distinguish orphaned-index 404s from anonymous-session-rotation 404s without a server dump

## Test plan
- [ ] `tsc --noEmit` clean ✅
- [ ] All existing `error()` callers unaffected (new param is optional)
- [ ] 404 response body: `{ error: "...", requestId: "...", storageUserId: "..." }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)