### PR TITLE
feat(fr): log count+ids in listDebateSessionsMeta ok event (t/2365)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
@@ -67,6 +67,15 @@ function extractResultMeta(method: string, args: unknown[], value: unknown): Rec
     const edges = v.edges;
     return { edge_count: Array.isArray(edges) ? edges.length : undefined };
   }
+  if (method === 'listDebateSessionsMeta') {
+    // Log returned debate IDs so a 404 dump can distinguish an orphaned index
+    // from user navigation: was the missing ID actually in the list? (t/2365)
+    if (!Array.isArray(v)) return undefined;
+    const ids = (v as Array<{ id?: unknown }>)
+      .map((s) => s?.id)
+      .filter((id): id is string => typeof id === 'string');
+    return { count: v.length, ids: ids.slice(0, 20) };
+  }
   if (method === 'generateText' || method === 'generateTextWithSearch') {
     const text = v.text;
     const meta: Record<string, unknown> = {};


### PR DESCRIPTION
## What
Adds `count` and `ids` (first 20 debate UUIDs) to the flight-recorder `bridge.listDebateSessionsMeta ok` event, via a new case in `extractResultMeta` (`src/renderer/bridge/instrumentBridge.ts`).

## Why (t/2365)
The event previously recorded only `duration_ms`, so a debate-404 dump couldn't answer the key diagnostic question: *was the missing ID actually in the returned list?* Now it discriminates an orphaned index from user navigation. Lightweight — UUIDs only, truncated to 20.

## Verify
Deterministic gates green locally (tsc main/server/renderer, eslint, depcruise, vite build). The only vitest failures are the documented LOCAL-ONLY undici major-version skew (local Node 24 vs CI Node 22) in `githubApi`/`t2020Security` suites — unrelated to this change, green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)