### PR TITLE
fix(docker): pin all base image FROM lines to digest (t/2375)

### DIFF
--- a/.github/workflows/base-image.yml
+++ b/.github/workflows/base-image.yml
@@ -41,6 +41,17 @@ jobs:
           dockerfile: deploy/azure/Dockerfile.base
           failure-threshold: error
 
+      - name: Verify digest-pinned FROM lines
+        run: |
+          UNPINNED=$(grep -E '^FROM\s' deploy/azure/Dockerfile.base | grep -v '@sha256:' || true)
+          if [ -n "$UNPINNED" ]; then
+            echo "::error::Non-digest-pinned FROM lines found in deploy/azure/Dockerfile.base:"
+            echo "$UNPINNED"
+            echo "All base images must use the form: FROM image:tag@sha256:<digest>"
+            exit 1
+          fi
+          echo "All FROM lines are digest-pinned."
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -103,10 +103,20 @@ jobs:
           dockerfile: taxonomy-editor/Dockerfile
           failure-threshold: error
 
+      - name: Verify digest-pinned FROM lines
+        run: |
+          UNPINNED=$(grep -E '^FROM\s' taxonomy-editor/Dockerfile | grep -v '@sha256:' || true)
+          if [ -n "$UNPINNED" ]; then
+            echo "::error::Non-digest-pinned FROM lines found in taxonomy-editor/Dockerfile:"
+            echo "$UNPINNED"
+            echo "All base images must use the form: FROM image:tag@sha256:<digest>"
+            exit 1
+          fi
+          echo "All FROM lines are digest-pinned."
+
       - name: Verify base image exists
         run: |
-          BASE_TAG=$(grep -oP 'FROM ghcr\.io/jpsnover/ai-triad-base:\K\S+' taxonomy-editor/Dockerfile | head -1)
-          BASE_TAG="${BASE_TAG%% *}"
+          BASE_TAG=$(grep -oP 'FROM ghcr\.io/jpsnover/ai-triad-base:\K[^@ ]+' taxonomy-editor/Dockerfile | head -1)
           echo "Base image tag: $BASE_TAG"
           if [ "$BASE_TAG" = "latest" ]; then
             echo "Using :latest — checking it exists..."

--- a/deploy/azure/Dockerfile.base
+++ b/deploy/azure/Dockerfile.base
@@ -21,7 +21,7 @@
 # 503 -> P1 prod crash-loop (t/2047). Pinning makes every node bump a deliberate,
 # reviewable PR. RE-BUMP to 22.23.2+ only after the github-api fetch is hardened
 # under undici 6.28.0 (Server Storage, t/2053) — see that ticket before bumping.
-FROM node:22.23.2-bookworm-slim
+FROM node:22.23.2-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Research — base image with Node 22 and baked ONNX embedding model"

--- a/deploy/azure/runbooks/digest-pin-upgrade.md
+++ b/deploy/azure/runbooks/digest-pin-upgrade.md
@@ -1,0 +1,79 @@
+# Digest-Pinned Base Image Upgrade
+
+**Why pinning matters:** A floating tag (e.g. `node:22.23.2-bookworm-slim`) silently picks up patch bumps on every rebuild. CI proves the old image works; prod gets the new one. The t/2047 outage was caused by exactly this: a `node:22.23.1→22.23.2` bump changed undici's TLS behaviour and crashed `/healthz` in prod.
+
+Both Dockerfiles now use `FROM image:tag@sha256:<digest>`. Every base-image bump is a deliberate PR.
+
+---
+
+## When to bump
+
+Bump the digest when:
+- A monthly base-image rebuild runs (base-image.yml fires on the 1st of each month).
+- A CVE fix requires a newer node patch version.
+- The `Dockerfile.base` comment says a bump is unblocked (e.g. `RE-BUMP to 22.23.2+ only after...`).
+
+---
+
+## How to get the new digest
+
+### node:X.Y.Z-bookworm-slim (Docker Hub)
+
+```powershell
+$tag = "22.23.2-bookworm-slim"   # change as needed
+$token = (Invoke-RestMethod -Uri "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull").token
+$headers = @{ Authorization = "Bearer $token"; Accept = "application/vnd.oci.image.index.v1+json" }
+$resp = Invoke-WebRequest -Uri "https://registry-1.docker.io/v2/library/node/manifests/$tag" -Headers $headers
+$resp.Headers['Docker-Content-Digest']
+```
+
+Or with curl:
+
+```bash
+TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/node:pull" | jq -r .token)
+curl -sI -H "Authorization: Bearer $TOKEN" \
+     -H "Accept: application/vnd.oci.image.index.v1+json" \
+     "https://registry-1.docker.io/v2/library/node/manifests/${TAG}" \
+  | grep -i docker-content-digest
+```
+
+### ghcr.io/jpsnover/ai-triad-base:<date-tag> (GHCR)
+
+```bash
+gh api "user/packages/container/ai-triad-base/versions" \
+  --jq '.[] | select(.metadata.container.tags[] | contains("<date-tag>")) | .name'
+```
+
+---
+
+## Upgrade procedure
+
+1. **Trigger base-image workflow** (if bumping the base image itself):
+   - Update `FROM node:X.Y.Z-bookworm-slim@sha256:<new-digest>` in `deploy/azure/Dockerfile.base`.
+   - Push via PR and run the **Base Image** workflow.
+   - Note the new base-image digest from the workflow output (`steps.build.outputs.digest`).
+
+2. **Update Dockerfiles** (worktree, never on shared main):
+   - `deploy/azure/Dockerfile.base` — bump node digest if the node version changed.
+   - `taxonomy-editor/Dockerfile` — bump node digest (builder + prod-deps stages) and/or base digest (runtime stage).
+
+3. **Smoke before promoting:**
+   - Container workflow builds the app image and runs `smoke-healthz.sh` against the published digest.
+   - Verify `/healthz` returns HTTP 200 on **staging** before triggering `deploy-azure.yml` for prod.
+   - Keep the previous GHCR digest handy as the rollback target (see [production-release.md](production-release.md)).
+
+4. **CI gate:** The "Verify digest-pinned FROM lines" step in both `container.yml` and `base-image.yml` fails if any `FROM` line lacks `@sha256:`. A PR that reverts to a floating tag will not build.
+
+---
+
+## Recovery path
+
+If a digest bump breaks prod, forward-deploy using the last known-good image digest:
+
+```bash
+az containerapp update \
+  --name <app-name> --resource-group <rg> \
+  --image ghcr.io/jpsnover/taxonomy-editor@sha256:<last-good-digest>
+```
+
+The last-good digest is recorded in the container.yml build output for each successful push. Check `gh run list --workflow container.yml` for recent successful runs and read the `digest` job output.

--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -7,7 +7,7 @@
 # (see deploy/azure/Dockerfile.base)
 
 # ── Stage 1: Build ──
-FROM node:22.23.2-bookworm-slim AS builder
+FROM node:22.23.2-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS builder
 
 WORKDIR /build
 
@@ -84,7 +84,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     PATH="/tmp:$PATH" npm run build:container
 
 # ── Stage 2: Production dependencies (with build tools for native modules) ──
-FROM node:22.23.2-bookworm-slim AS prod-deps
+FROM node:22.23.2-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS prod-deps
 
 # node-pty requires make/g++/python3 for compilation when prebuilds
 # are unavailable. The runtime base image is intentionally slim (no
@@ -114,7 +114,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --prod 
 # root cause was t/2061 (isDataAvailable path mismatch, app-side). Bumped to :2026-08-05 to
 # pull in Debian/Python security patches clearing ~25 Python runtime CVE rules (t/2157).
 # Gate base bumps on staging /healthz, not CI green.
-FROM ghcr.io/jpsnover/ai-triad-base:2026-08-05 AS runtime
+FROM ghcr.io/jpsnover/ai-triad-base:2026-08-05@sha256:a4cca2a1bd85b7a3f83826e9ba937efbf54d84032225b84c3e82624efcfcd780 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Taxonomy Editor"


### PR DESCRIPTION
## Summary

- Replaces floating `FROM node:22.23.2-bookworm-slim` with digest-pinned form in both Dockerfiles (builder, prod-deps, and base-image stages)
- Pins `FROM ghcr.io/jpsnover/ai-triad-base:2026-08-05` to its GHCR digest in the runtime stage
- Adds "Verify digest-pinned FROM lines" CI step to both `container.yml` and `base-image.yml` — fails if any `FROM` lacks `@sha256:` pinning
- Fixes base-tag parser in `container.yml` to strip `@sha256:` suffix before GHCR tag existence check
- Adds `deploy/azure/runbooks/digest-pin-upgrade.md` documenting when/how to bump digests and the required staging smoke gate

**Root cause addressed:** t/2047 (2026-07-31 P1 outage) — `node:22.23.1→22.23.2` silent rebuild broke `/healthz` in prod; CI was green on the old image while prod got the new one.

Digests captured 2026-08-09:
- `node:22.23.2-bookworm-slim` → `sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436`
- `ai-triad-base:2026-08-05` → `sha256:a4cca2a1bd85b7a3f83826e9ba937efbf54d84032225b84c3e82624efcfcd780`

## Test plan

- [ ] CI passes (hadolint + digest-lint gate both green)
- [ ] Container build succeeds with pinned digests
- [ ] Confirm "Verify digest-pinned FROM lines" step fails on a branch that reverts one FROM to a floating tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)