### PR TITLE
feat(retrieval): extraction-scope guard — flag out-of-scope key_points (t/2370)

### DIFF
--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -877,6 +877,13 @@ function Finalize-Summary {
         }
     }
 
+    # -- Out-of-scope guard pass (t/2370) -------------------------------------
+    # Runs after M5 so mechanism5_flag/mechanism5_candidates are populated.
+    # Flag-only: sets out_of_scope_flag; actuation gated on calibration (t/2370#1).
+    if ($script:CachedEmbeddings -and $script:CachedEmbeddings.Count -gt 0 -and $AllKpsForM5 -and $AllKpsForM5.Count -gt 0) {
+        Invoke-OutOfScopeGuardPass -KeyPointItems $AllKpsForM5.ToArray()
+    }
+
     # -- Excludes-veto pass (t/2286) ------------------------------------------
     # Runs after confidence pass so retrieval_low_confidence is already present.
     if ($script:TaxonomyData -and $script:TaxonomyData.Count -gt 0) {

--- a/scripts/AITriad/Private/Invoke-OutOfScopeGuardPass.ps1
+++ b/scripts/AITriad/Private/Invoke-OutOfScopeGuardPass.ps1
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Invoke-OutOfScopeGuardPass {
+    <#
+    .SYNOPSIS
+        Flags key_points whose topic has no valid home in the POV taxonomy (t/2370).
+    .DESCRIPTION
+        Runs after Invoke-Mechanism5RetrievalPass. Applies a three-arm bar to identify
+        key_points that are genuinely out-of-scope for their POV taxonomy, where the
+        correct disposition is "unmapped / human review" rather than a forced assignment.
+
+        A key_point is flagged (out_of_scope_flag = $true) iff ALL three hold:
+          Arm A — best POV candidate is absolutely weak:
+                  mechanism5_candidates[0].score < Ceiling (default 0.30)
+          Arm B — already a flagged misfire:
+                  mechanism5_flag = $true
+          Arm C — no rescue candidate (false-positive guard):
+                  no POV-filtered top-3 candidate reaches GoodAlternativeFloor (default 0.45)
+
+        Ships FLAG-ONLY (no nulling of taxonomy_node_id). Calibration gate per t/2370#1:
+        reproduce the two named adjudication misfires empirically before enabling actuation.
+        Mirrors the Mechanism #5 surface-first discipline (t/2357).
+
+        Degrades gracefully — no-op when M5 did not run; never throws; never modifies
+        fields other than out_of_scope_flag and out_of_scope_top1_score.
+
+    .PARAMETER KeyPointItems
+        Array of hashtables @{KeyPoint=<PSObject>; POV='accelerationist'|'safetyist'|'skeptic'}.
+        Same format as Invoke-Mechanism5RetrievalPass.
+    .PARAMETER Ceiling
+        Arm A threshold: top-1 POV-filtered cosine must be below this to qualify.
+        Default 0.30 — provisional, calibration-gated (t/2370#1).
+        Registered: metric-provenance-register out_of_scope_ceiling (provisional).
+    .PARAMETER GoodAlternativeFloor
+        Arm C threshold: if any top-3 candidate meets or exceeds this score, the misfire
+        is retrieval-fixable (t/2341's lever) — not out-of-scope.
+        Default 0.45 — reuses RetrievalConfidenceThreshold.
+        Registered: metric-provenance-register good_alternative_floor (provisional).
+    #>
+    [CmdletBinding()]
+    param(
+        [object[]]$KeyPointItems,
+        [double]$Ceiling = 0.30,
+        [double]$GoodAlternativeFloor = 0.45
+    )
+
+    if (-not $KeyPointItems -or $KeyPointItems.Count -eq 0) { return }
+
+    $FlaggedCount = 0
+    foreach ($Item in $KeyPointItems) {
+        $kp = $Item.KeyPoint
+
+        # Arm B: only examine kps that M5 already flagged as misfires
+        $M5Flag = $false
+        if ($kp.PSObject.Properties['mechanism5_flag'] -and $kp.mechanism5_flag -eq $true) {
+            $M5Flag = $true
+        }
+        if (-not $M5Flag) { continue }
+
+        # Arm A: top-1 POV-filtered candidate score must be absolutely weak
+        $Top1Score = $null
+        if ($kp.PSObject.Properties['mechanism5_candidates'] -and $kp.mechanism5_candidates) {
+            $Cands = @($kp.mechanism5_candidates)
+            if ($Cands.Count -gt 0 -and $Cands[0].PSObject.Properties['score']) {
+                $Top1Score = [double]$Cands[0].score
+            }
+        }
+        if ($null -eq $Top1Score) { continue }  # M5 ran but no candidates — skip
+        if ($Top1Score -ge $Ceiling) { continue }  # Strong enough best candidate → not OOS
+
+        # Arm C: false-positive guard — no rescue candidate at or above good_alternative_floor
+        $Cands = @($kp.mechanism5_candidates)
+        $HasRescue = @($Cands | Where-Object {
+            $_.PSObject.Properties['score'] -and [double]$_.score -ge $GoodAlternativeFloor
+        }).Count -gt 0
+        if ($HasRescue) { continue }  # Retrieval-fixable misfire — leave for t/2341's lever
+
+        # All three arms pass: flag as out-of-scope
+        Set-KeyPointField $kp 'out_of_scope_flag'       $true
+        Set-KeyPointField $kp 'out_of_scope_top1_score' $Top1Score
+        $FlaggedCount++
+    }
+
+    if ($FlaggedCount -gt 0) {
+        Write-Host "  │  oos-guard: $FlaggedCount key_point(s) flagged out-of-scope (flag-only, t/2370)" -ForegroundColor DarkYellow
+    }
+}

--- a/scripts/AITriad/Private/Invoke-OutOfScopeGuardPass.ps1
+++ b/scripts/AITriad/Private/Invoke-OutOfScopeGuardPass.ps1
@@ -70,6 +70,8 @@ function Invoke-OutOfScopeGuardPass {
         if ($Top1Score -ge $Ceiling) { continue }  # Strong enough best candidate → not OOS
 
         # Arm C: false-positive guard — no rescue candidate at or above good_alternative_floor
+        # Defensive re-read: candidates are sorted descending by M5, so if top-1 < 0.30 all are < 0.45
+        # and this never fires in practice. Retained so actuation stays correct if sort order ever changes.
         $Cands = @($kp.mechanism5_candidates)
         $HasRescue = @($Cands | Where-Object {
             $_.PSObject.Properties['score'] -and [double]$_.score -ge $GoodAlternativeFloor

--- a/tests/Invoke-OutOfScopeGuardPass.Tests.ps1
+++ b/tests/Invoke-OutOfScopeGuardPass.Tests.ps1
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for the extraction-scope guard (t/2370) — flag-only mode.
+.DESCRIPTION
+    Covers: three-arm bar logic (A/B/C), flag-only behaviour (no nulling),
+    no-op when M5 didn't run, and the two adjudication-case patterns.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    InModuleScope AITriad {
+        # Build a key_point item as Invoke-DocumentSummary feeds to M5 / OOS guard
+        function script:OOS-KpItem {
+            param(
+                [string]$NodeId = 'saf-beliefs-001',
+                [string]$POV    = 'safetyist',
+                [bool]  $M5Flag = $true,
+                [double[]]$CandScores = @(0.22, 0.18, 0.11)
+            )
+            $Candidates = @($CandScores | ForEach-Object {
+                [PSCustomObject]@{ id = "saf-beliefs-$([int]($_ * 1000))"; score = $_ }
+            })
+            $kp = [PSCustomObject]@{
+                taxonomy_node_id     = $NodeId
+                point                = 'Human deliberation is defeasible and provisional'
+                attribution_text     = 'Human deliberation is defeasible and provisional'
+                retrieval_confidence = 0.21
+            }
+            if ($M5Flag) {
+                $kp | Add-Member -NotePropertyName 'mechanism5_flag'       -NotePropertyValue $true  -Force
+                $kp | Add-Member -NotePropertyName 'mechanism5_candidates' -NotePropertyValue $Candidates -Force
+            }
+            @{ KeyPoint = $kp; POV = $POV }
+        }
+    }
+}
+
+Describe 'Invoke-OutOfScopeGuardPass (t/2370)' -Tag 'oos','retrieval' {
+
+    # ── Arm B: no-op when M5 did not flag ────────────────────────────────────
+
+    Context 'Arm B — no-op when mechanism5_flag is absent or false' {
+
+        It 'Does NOT flag a kp that has no mechanism5_flag property' {
+            InModuleScope AITriad {
+                $Item = OOS-KpItem -M5Flag $false
+                $Item.KeyPoint.PSObject.Properties.Remove('mechanism5_flag')
+                $Item.KeyPoint.PSObject.Properties.Remove('mechanism5_candidates')
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.PSObject.Properties['out_of_scope_flag'] | Should -BeNullOrEmpty `
+                    -Because 'guard must be a no-op when M5 never ran'
+            }
+        }
+
+        It 'Does NOT flag a kp where mechanism5_flag = $false' {
+            InModuleScope AITriad {
+                $Item = OOS-KpItem -M5Flag $false
+                $Item.KeyPoint | Add-Member -NotePropertyName 'mechanism5_flag' -NotePropertyValue $false -Force
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.PSObject.Properties['out_of_scope_flag'] | Should -BeNullOrEmpty `
+                    -Because 'Arm B requires mechanism5_flag = $true'
+            }
+        }
+    }
+
+    # ── Arm A: top-1 score must be below the ceiling ─────────────────────────
+
+    Context 'Arm A — top-1 score ceiling (0.30)' {
+
+        It 'Does NOT flag when top-1 score = 0.30 (at the ceiling, not below)' {
+            InModuleScope AITriad {
+                $Item = OOS-KpItem -CandScores @(0.30, 0.18, 0.11)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.PSObject.Properties['out_of_scope_flag'] | Should -BeNullOrEmpty `
+                    -Because 'top-1 at exactly ceiling is not below it — Arm A does not pass'
+            }
+        }
+
+        It 'Does NOT flag when top-1 score = 0.45 (strong candidate)' {
+            InModuleScope AITriad {
+                $Item = OOS-KpItem -CandScores @(0.45, 0.30, 0.20)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.PSObject.Properties['out_of_scope_flag'] | Should -BeNullOrEmpty `
+                    -Because 'strong top-1 means not out-of-scope'
+            }
+        }
+
+        It 'Skips gracefully when mechanism5_candidates is absent (M5 flagged but no candidates)' {
+            InModuleScope AITriad {
+                $kp = [PSCustomObject]@{
+                    taxonomy_node_id = 'saf-beliefs-001'
+                    point            = 'some claim'
+                    mechanism5_flag  = $true
+                }
+                Invoke-OutOfScopeGuardPass -KeyPointItems @(@{ KeyPoint = $kp; POV = 'safetyist' })
+                $kp.PSObject.Properties['out_of_scope_flag'] | Should -BeNullOrEmpty `
+                    -Because 'cannot evaluate Arm A without candidates — must skip'
+            }
+        }
+    }
+
+    # ── Arm C: false-positive guard ───────────────────────────────────────────
+
+    Context 'Arm C — false-positive guard (good_alternative_floor = 0.45)' {
+
+        It 'Does NOT flag when a rescue candidate at 0.45 exists (retrieval-fixable)' {
+            InModuleScope AITriad {
+                # top-1 is 0.22 (below ceiling), BUT candidate #2 is 0.45 → retrieval-fixable
+                $Item = OOS-KpItem -CandScores @(0.22, 0.45, 0.10)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.PSObject.Properties['out_of_scope_flag'] | Should -BeNullOrEmpty `
+                    -Because 'Arm C: a rescue candidate >= 0.45 means the misfire is retrieval-fixable'
+            }
+        }
+
+        It 'DOES flag when top-1 < 0.30 AND no candidate reaches 0.45' {
+            InModuleScope AITriad {
+                $Item = OOS-KpItem -CandScores @(0.22, 0.18, 0.11)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.out_of_scope_flag | Should -BeTrue `
+                    -Because 'all three arms pass: M5 flagged, top-1 < 0.30, no rescue candidate'
+            }
+        }
+    }
+
+    # ── Flag-only: taxonomy_node_id must NOT be nulled ────────────────────────
+
+    Context 'Flag-only — taxonomy_node_id is never nulled' {
+
+        It 'Leaves taxonomy_node_id intact even when flagged out-of-scope' {
+            InModuleScope AITriad {
+                $Item = OOS-KpItem -NodeId 'saf-beliefs-129' -CandScores @(0.22, 0.18, 0.11)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.out_of_scope_flag | Should -BeTrue
+                $Item.KeyPoint.taxonomy_node_id | Should -Be 'saf-beliefs-129' `
+                    -Because 'flag-only mode must not null taxonomy_node_id (calibration gate not met)'
+            }
+        }
+
+        It 'Sets out_of_scope_top1_score to the top-1 candidate score when flagged' {
+            InModuleScope AITriad {
+                $Item = OOS-KpItem -CandScores @(0.22, 0.18, 0.11)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.out_of_scope_top1_score | Should -Be 0.22 `
+                    -Because 'diagnostic score must be recorded for calibration analysis'
+            }
+        }
+    }
+
+    # ── Adjudication case patterns ────────────────────────────────────────────
+
+    Context 'Adjudication case patterns — t/2341 misfires (t/2370#1)' {
+
+        It 'Pattern: defeasible-deliberation case (top-1 ~ 0.22, no rescue) flags as OOS' {
+            InModuleScope AITriad {
+                # saf-beliefs-129 assigned; best cosine ~ 0.22 (flat distribution)
+                $Item = OOS-KpItem -NodeId 'saf-beliefs-129' -CandScores @(0.22, 0.20, 0.19)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.out_of_scope_flag | Should -BeTrue `
+                    -Because 'defeasible-deliberation misfire has top-1 < 0.30 and no rescue >= 0.45'
+            }
+        }
+
+        It 'Pattern: grid-reliability case (top-1 ~ 0.24, literal-power collision, no rescue) flags as OOS' {
+            InModuleScope AITriad {
+                # saf-intentions-008 assigned; vocab collision; best cosine ~ 0.24
+                $Item = OOS-KpItem -NodeId 'saf-intentions-008' -POV 'safetyist' -CandScores @(0.24, 0.21, 0.17)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.out_of_scope_flag | Should -BeTrue `
+                    -Because 'grid-reliability misfire has top-1 < 0.30 and no rescue >= 0.45'
+            }
+        }
+
+        It 'Control: in-scope kp with strong candidate (top-1 >= 0.45) is never flagged' {
+            InModuleScope AITriad {
+                # A genuine safetyist claim about AI capability — has a real home
+                $Item = OOS-KpItem -NodeId 'saf-beliefs-001' -CandScores @(0.72, 0.60, 0.41)
+                Invoke-OutOfScopeGuardPass -KeyPointItems @($Item)
+                $Item.KeyPoint.PSObject.Properties['out_of_scope_flag'] | Should -BeNullOrEmpty `
+                    -Because 'a strongly-matched in-scope kp must never be flagged (over-exclusion guard)'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `Invoke-OutOfScopeGuardPass` private function: three-arm bar to flag key_points with no valid home in their POV taxonomy
  - **Arm A**: POV-filtered top-1 cosine `< 0.30` (absolutely weak candidate distribution)
  - **Arm B**: `mechanism5_flag = $true` (already a flagged misfire — never unmap a confident assignment)
  - **Arm C**: no top-3 candidate `>= 0.45` (rescue candidate exists → retrieval-fixable, not OOS)
- Ships **flag-only**: sets `out_of_scope_flag = $true` and `out_of_scope_top1_score`; never nulls `taxonomy_node_id`. Actuation gated on calibration (t/2370#1).
- Injected in `Invoke-DocumentSummary.ps1` after `Invoke-Mechanism5RetrievalPass`, before excludes-veto pass. No-op when M5 skipped.

## Test plan

- [x] 12 new tests (`-Tag oos,retrieval`): arm logic, flag-only invariant, adjudication-case patterns (defeasible-deliberation + grid-reliability), control (in-scope never flagged)
- [x] 12/12 passing, 0 failures
- [x] Full suite regression pending CI

## Calibration note (per t/2370#1)

The 0.30 ceiling is provisional. Before actuation is enabled, the two adjudication misfires must be reproduced empirically: embed their `attribution_text`, compute POV-filtered top-1 cosine, confirm both fall `< 0.30` while control in-scope key_points stay `>= 0.45`. The tests include the expected distribution pattern; real calibration run to be attached as a PR comment before enabling actuation.

## Notes

**Mandatory CL review required before merge** (per t/2370#1 — CL designed this feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>
