### PR TITLE
docs(process): prevention-per-incident rule + failure-class taxonomy (t/2379)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,3 +117,14 @@ All unrecoverable errors must use `New-ActionableError` (PowerShell) or `Actiona
 
 - **Live incident: claim follow-ups before filing.** Before `create_ticket` for a follow-up during an active incident, claim it on the incident anchor thread (or route through the incident coordinator) — prevents concurrent duplicate filings across roles (this bit twice: t/2053+t/2054, t/2061+t/2062).
 - The Technical Lead coordinates incidents (runs `/tl-incident-response`); the anchor ticket is the source of truth for status and follow-up claims.
+
+### Prevention-per-incident: every diagnosis files observability AND prevention (t/2379)
+
+Every incident diagnosis produces **two** kinds of follow-up, not one:
+
+1. **Observability** — make it *diagnosable* next time (the flight-recorder field / log line / metric the diagnosis wished it had had).
+2. **Prevention** — make it *not recur*: the gate, test, or guard that would have caught it before prod.
+
+**A diagnosis that files only observability tickets is incomplete.** Map each incident to a **failure class** (see `docs/CodeReview/failure-classes.md`) and file the prevention that closes that class's gap *for this surface*. Rationale: quality coverage is point-in-time — each gate was sufficient when written; without a prevention ticket per incident, coverage lags system growth and the next prod bug finds the gap, not a gate.
+
+**Gate-touching prevention tickets** (a new/changed CI step, deploy gate, verify script, or config validation) route to **Main (TL)** for Gate Verification: proven with **both arms** (a deliberate failure fires the gate; the clean case passes with zero noise), reliable enough to block prod (a flaky blocking gate is the *next* incident), and config co-located at point of use. See the *Gate signal integrity* rules under **Code Review & Quality** (the tech-lead scope's `AGENTS.md`).

--- a/docs/CodeReview/failure-classes.md
+++ b/docs/CodeReview/failure-classes.md
@@ -1,0 +1,54 @@
+# Failure-Class Taxonomy — Prospective Review Checklist
+
+**Last updated:** 2026-08-09
+**Owner:** Diagnostics (source analysis) / Tech Lead (review checklist)
+**Source:** e/84 systemic quality analysis of the 2026-08-09 Azure production bug sweep.
+
+Purpose: turn post-incident hindsight into foresight. Before landing a change — especially at a producer/consumer seam, on a deploy path, or touching config — ask **"which of these classes could this change introduce?"** and require the corresponding test or gate. Each incident maps to one of five structural classes.
+
+## The Core Gap
+
+CI proves individual components work **in isolation, in the CI environment, with authenticated users.** Production requires **integrated** components, for **all user types**, in the **prod environment**. Every gap between those two sentences is one of the classes below.
+
+## Class 1 — Cross-scope semantic contract violations
+
+Two components each correct in isolation, broken at the seam. The invariant *"what I can list, I can load"* holds for neither producer nor consumer alone.
+
+- **Examples:** community debate 404 (`listDebateSessionsMeta` surfaces it, `loadDebateSession` can't resolve it for the user — t/2368); CORS crash (`getCorsOrigin()` returns `[]` → `undefined` → Node 22 `setHeader()` throws — t/723); AUTH_OPTIONAL serving HTML to JSON-expecting API clients.
+- **Prevention:** contract-invariant tests at every producer→consumer seam.
+
+## Class 2 — User/identity path gaps
+
+A flow tested for only one identity type.
+
+- **Examples:** community 404 — the anonymous user path was never tested; AUTH_OPTIONAL acceptance tests ran without establishing an anonymous session.
+- **Prevention:** an explicit user-type matrix `{anon, authenticated, admin}` × key flows.
+
+## Class 3 — Runtime / environment divergence
+
+Works in dev/CI, fails in prod because the runtime environment differs.
+
+- **Examples:** `NODE_ENV=production` changes config init and produces the CORS crash; a floating `FROM node:22` picked up a patch bump (22.23.1→22.23.2) on rebuild — CI tested the old image, prod got the new one (t/2047).
+- **Prevention:** a prod-config CI variant; pinned base-image digests; a pre-promotion smoke gate (t/2376/2377).
+
+## Class 4 — Infrastructure configuration drift
+
+Deployed state diverges from declared intent between deploys.
+
+- **Examples:** CLI `--set-env-vars` config wiped by the next Bicep apply (t/2049/2050); ACA auto-promotes traffic to the latest revision unless `ingress.traffic` is explicitly pinned.
+- **Prevention:** post-deploy config verification — actual ACA state vs Bicep intent (t/2378).
+
+## Class 5 — CI gate blind spots
+
+A gate that was sufficient when written, outgrown as the system added surfaces.
+
+- **Examples:** renderer type errors invisible to the server `tsconfig`; the shell-quoting junk-spray guard condition was too narrow (t/2222).
+- **Prevention:** gate-coverage review after every incident (the Prevention-per-incident rule); cross-project `tsc` in CI.
+
+## How to use this
+
+- **Reviewing a change:** ask which class(es) it could introduce; require the corresponding contract test, user-type coverage, prod-config check, or gate before approving.
+- **After an incident:** classify it here, then file a **prevention** ticket (not only observability) that closes that class's gap *for the affected surface* — per the *Prevention-per-incident* rule in the root `AGENTS.md` **Incident Response** section.
+- **Gate-touching prevention** routes to **Main (TL)** for a Gate-Verification review (both arms proven, reliable enough to block, config co-located).
+
+Coverage is point-in-time. This checklist exists so it tracks system growth prospectively, rather than waiting for the next prod bug to find the next gap.


### PR DESCRIPTION
Implements t/2379 (from Diagnostics' e/84 systemic quality analysis).

**Two docs, no code:**
1. Root `AGENTS.md` (Incident Response) — new **Prevention-per-incident** rule: every incident diagnosis files *both* observability AND prevention follow-ups; map to a failure class; gate-touching prevention routes to Main (TL) for Gate Verification.
2. `docs/CodeReview/failure-classes.md` — the 5-class taxonomy (cross-scope contract violations, user-path gaps, environment divergence, infra drift, gate blind spots) as a **prospective review checklist**, extracted from e/84 so the rule's reference resolves.

Approved by the human. Docs-only; root AGENTS.md is main-repo-tracked (ordinary PR flow, TL admin-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)