### PR TITLE
fix(server-storage): null-safe title sort in listSources (t/2388)

### DIFF
--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -1204,7 +1204,7 @@ export async function discoverSources(): Promise<DiscoveredSource[]> {
       });
     } catch { /* telemetry — silent by design;  skip */ }
   }
-  return sources.sort((a, b) => a.title.localeCompare(b.title));
+  return sources.sort((a, b) => (a.title ?? '').localeCompare(b.title ?? ''));
 }
 
 export async function loadSummary(docId: string): Promise<unknown | null> {


### PR DESCRIPTION
## Summary

- `fileIO.ts:1207`: `a.title.localeCompare(b.title)` crashes when any source JSON has a null/missing `title` field
- Fix: `(a.title ?? '').localeCompare(b.title ?? '')` — same pattern as t/2385

## Test plan
- [ ] tsc clean
- [ ] `listSources()` no longer crashes when a source entry has `title: null` or no title field

🤖 Generated with [Claude Code](https://claude.com/claude-code)