### PR TITLE
fix(fileIO): null-guard title in source sort — crash on missing title (t/2387)

### DIFF
--- a/taxonomy-editor/src/main/fileIO.ts
+++ b/taxonomy-editor/src/main/fileIO.ts
@@ -619,7 +619,7 @@ export function discoverSources(): DiscoveredSource[] {
       });
     } catch { /* telemetry — silent by design;  skip */ }
   }
-  return sources.sort((a, b) => a.title.localeCompare(b.title));
+  return sources.sort((a, b) => (a.title ?? '').localeCompare(b.title ?? ''));
 }
 
 export function loadSummary(docId: string): unknown | null {


### PR DESCRIPTION
## Summary

- `fileIO.ts:622`: `a.title.localeCompare(b.title)` → `(a.title ?? '').localeCompare(b.title ?? '')`
- Prevents main-process crash when any source JSON has a null/missing `title` field
- Same pattern as t/2385; /trivial-change self-cert (one-line, single file, no behavioral change for valid data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)