### PR TITLE
fix(debate): null-guard title sort/filter — localeCompare crash (t/2385)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -252,7 +252,7 @@ export function DebateTab() {
     const q = searchQuery.trim().toLowerCase();
     if (!q) return orderedSessions;
     return orderedSessions.filter(s =>
-      s.title.toLowerCase().includes(q) ||
+      (s.title ?? '').toLowerCase().includes(q) ||
       (s.topic_text && s.topic_text.toLowerCase().includes(q))
     );
   }, [orderedSessions, searchQuery]);

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.community.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.community.test.tsx
@@ -3,7 +3,8 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { CommunityTableRow } from './DebateTable';
+import { CommunityTableRow, applySortMy, applySortCommunity } from './DebateTable';
+import type { SessionRowData } from './DebateTable';
 import type { CommunityDebate } from '../../hooks/useCommunityStore';
 
 function makeRow(overrides: Partial<CommunityDebate> = {}): CommunityDebate {
@@ -35,6 +36,77 @@ function renderRow(cd: CommunityDebate) {
     </table>,
   );
 }
+
+// ── Sort null-title regression (t/2385) ──────────────────────────────────────
+
+function makeSession(overrides: Partial<SessionRowData> = {}): SessionRowData {
+  return {
+    id: 's1',
+    title: 'Normal debate',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    phase: 'complete',
+    ...overrides,
+  };
+}
+
+function makeCommunityDebate(overrides: Partial<CommunityDebate> = {}): CommunityDebate {
+  return {
+    id: 'c1',
+    title: 'Community debate',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as CommunityDebate;
+}
+
+describe('applySortMy — null/undefined title (t/2385)', () => {
+  const sort = { col: 'title' as const, dir: 'asc' as const };
+
+  it('does not throw when a session has a null title', () => {
+    const rows = [
+      makeSession({ id: 's1', title: 'Gamma' }),
+      makeSession({ id: 's2', title: null as unknown as string }),
+      makeSession({ id: 's3', title: 'Alpha' }),
+    ];
+    expect(() => applySortMy(rows, sort)).not.toThrow();
+  });
+
+  it('sorts null titles as empty string (before non-empty)', () => {
+    const rows = [
+      makeSession({ id: 's1', title: 'Beta' }),
+      makeSession({ id: 's2', title: null as unknown as string }),
+    ];
+    const result = applySortMy(rows, sort);
+    expect(result[0].id).toBe('s2');
+    expect(result[1].id).toBe('s1');
+  });
+});
+
+describe('applySortCommunity — null/undefined title (t/2385)', () => {
+  const sort = { col: 'title' as const, dir: 'asc' as const };
+
+  it('does not throw when a community debate has a null title', () => {
+    const rows = [
+      makeCommunityDebate({ id: 'c1', title: 'Zeta' }),
+      makeCommunityDebate({ id: 'c2', title: null as unknown as string }),
+      makeCommunityDebate({ id: 'c3', title: 'Alpha' }),
+    ];
+    expect(() => applySortCommunity(rows, sort)).not.toThrow();
+  });
+
+  it('sorts null titles as empty string (before non-empty)', () => {
+    const rows = [
+      makeCommunityDebate({ id: 'c1', title: 'Beta' }),
+      makeCommunityDebate({ id: 'c2', title: null as unknown as string }),
+    ];
+    const result = applySortCommunity(rows, sort);
+    expect(result[0].id).toBe('c2');
+    expect(result[1].id).toBe('c1');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 describe('CommunityTableRow — TURNS and MODEL field mapping (t/2362)', () => {
   it('renders turn_count when present', () => {

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -109,12 +109,12 @@ function formatDate(iso: string): string {
   });
 }
 
-function applySortMy(rows: SessionRowData[], sort: SortState): SessionRowData[] {
+export function applySortMy(rows: SessionRowData[], sort: SortState): SessionRowData[] {
   if (!sort.col || sort.dir === 'none') return rows;
   const mul = sort.dir === 'asc' ? 1 : -1;
   return [...rows].sort((a, b) => {
     switch (sort.col) {
-      case 'title':  return mul * a.title.localeCompare(b.title);
+      case 'title':  return mul * (a.title ?? '').localeCompare(b.title ?? '');
       case 'status': return mul * (a.phase ?? '').localeCompare(b.phase ?? '');
       case 'date':   return mul * (new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime());
       case 'turns':  return mul * ((a.turn_count ?? 0) - (b.turn_count ?? 0));
@@ -124,12 +124,12 @@ function applySortMy(rows: SessionRowData[], sort: SortState): SessionRowData[] 
   });
 }
 
-function applySortCommunity(rows: CommunityDebate[], sort: SortState): CommunityDebate[] {
+export function applySortCommunity(rows: CommunityDebate[], sort: SortState): CommunityDebate[] {
   if (!sort.col || sort.dir === 'none') return rows;
   const mul = sort.dir === 'asc' ? 1 : -1;
   return [...rows].sort((a, b) => {
     switch (sort.col) {
-      case 'title':  return mul * a.title.localeCompare(b.title);
+      case 'title':  return mul * (a.title ?? '').localeCompare(b.title ?? '');
       case 'status': return mul * (a.phase ?? '').localeCompare(b.phase ?? '');
       case 'date':   return mul * (new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime());
       case 'turns':  return mul * ((a.turn_count ?? 0) - (b.turn_count ?? 0));

--- a/taxonomy-editor/src/renderer/components/debate/communityFilter.test.ts
+++ b/taxonomy-editor/src/renderer/components/debate/communityFilter.test.ts
@@ -32,4 +32,13 @@ describe('filterCommunityDebates', () => {
   it('does not throw when community_metadata is absent', () => {
     expect(() => filterCommunityDebates(debates, 'lovelace')).not.toThrow();
   });
+
+  it('does not throw when a debate has a null title (t/2385)', () => {
+    const withNull = [
+      ...debates,
+      { id: '4', title: null, updated_at: '2026-01-01' } as unknown as CommunityDebate,
+    ];
+    expect(() => filterCommunityDebates(withNull, 'safety')).not.toThrow();
+    expect(filterCommunityDebates(withNull, 'safety').map(d => d.id)).toEqual(['1']);
+  });
 });

--- a/taxonomy-editor/src/renderer/components/debate/communityFilter.ts
+++ b/taxonomy-editor/src/renderer/components/debate/communityFilter.ts
@@ -12,7 +12,7 @@ export function filterCommunityDebates(debates: CommunityDebate[], query: string
   const q = query.trim().toLowerCase();
   if (!q) return debates;
   return debates.filter(cd =>
-    cd.title.toLowerCase().includes(q) ||
+    (cd.title ?? '').toLowerCase().includes(q) ||
     (cd.community_metadata?.submitted_by_display?.toLowerCase().includes(q) ?? false)
   );
 }


### PR DESCRIPTION
## Summary

- `applySortMy` / `applySortCommunity` (DebateTable.tsx:117,132): `(a.title ?? '').localeCompare(b.title ?? '')` — fixes the confirmed crash
- `filteredSessions` (DebateTab.tsx:255): `(s.title ?? '').toLowerCase()` — same gap in My-tab filter
- `filterCommunityDebates` (communityFilter.ts:15): `(cd.title ?? '').toLowerCase()` — same gap in Community filter
- Exports `applySortMy` / `applySortCommunity` for direct unit testing
- Adds regression tests: sort + filter with null-title entries assert no throw

## Test plan

- [ ] `npx vitest run src/renderer/components/debate/` → 63 tests pass (includes new null-title regression cases)
- [ ] `npx tsc --noEmit` → clean
- [ ] `npx eslint` on changed files → 0 errors

Fixes t/2385. Self-certified: /trivial-change (pure null-guard, no logic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
