### PR TITLE
fix(summaries): null-guard title sort to prevent crash on null source titles (t/2386)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/SummariesTab.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/SummariesTab.test.tsx
@@ -2,14 +2,14 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }));
 vi.mock('@bridge', () => ({
   api: {
-    discoverSources: () => Promise.resolve([]),
-    loadSummary: () => Promise.resolve(null),
-    loadSnapshot: () => Promise.resolve(null),
+    discoverSources: vi.fn(() => Promise.resolve([])),
+    loadSummary: vi.fn(() => Promise.resolve(null)),
+    loadSnapshot: vi.fn(() => Promise.resolve(null)),
   },
 }));
 vi.mock('../../hooks/useTaxonomyStore', () => ({
@@ -35,5 +35,16 @@ describe('SummariesTab (t/1025)', () => {
   it('shows the empty state when no summarized sources exist', async () => {
     render(<SummariesTab />);
     await waitFor(() => expect(screen.getByText('No sources with summaries found.')).toBeInTheDocument());
+  });
+
+  it('does not crash sorting by title when sources have null titles (t/2386)', async () => {
+    const { api } = await import('@bridge');
+    vi.mocked(api.discoverSources).mockResolvedValueOnce([
+      { id: 'src-1', title: null as unknown as string, authors: [], tags: [], datePublished: '', dateIngested: '', summarized: true },
+      { id: 'src-2', title: null as unknown as string, authors: [], tags: [], datePublished: '', dateIngested: '', summarized: true },
+    ]);
+    render(<SummariesTab />);
+    await waitFor(() => expect(screen.queryByText('No sources with summaries found.')).toBeNull());
+    expect(() => fireEvent.click(screen.getByText('Title'))).not.toThrow();
   });
 });

--- a/taxonomy-editor/src/renderer/components/analysis/SummariesTab.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/SummariesTab.tsx
@@ -491,7 +491,7 @@ export function SummariesTab() {
     const sorted = [...result].sort((a, b) => {
       let cmp: number;
       if (sortField === 'title') {
-        cmp = a.title.localeCompare(b.title);
+        cmp = (a.title ?? '').localeCompare(b.title ?? '');
       } else {
         const av = a[sortField] || '';
         const bv = b[sortField] || '';


### PR DESCRIPTION
## Summary
- Guard `a.title.localeCompare(b.title)` with `?? ''` on both operands in `SummariesTab.tsx:494` — `SourceInfo.title` is typed `string` but on-disk JSON can carry null/undefined values, crashing the tab when the user clicks the Title sort button
- Add regression test: mocks `discoverSources` to return two sources with null titles, clicks the Title sort button, asserts no throw

## Test plan
- [x] `npx vitest run SummariesTab.test.tsx` — 3/3 pass (including new regression test)
- [x] `npx tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)