### PR TITLE
feat(endpoints): list→load contract test + -UserType anon mode (t/2374)

### DIFF
--- a/scripts/AITriad/Private/Invoke-ListLoadContractTest.ps1
+++ b/scripts/AITriad/Private/Invoke-ListLoadContractTest.ps1
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Invoke-ListLoadContractTest {
+    <#
+    .SYNOPSIS
+        Tests the list→load contract for a collection endpoint (t/2374).
+    .DESCRIPTION
+        Fetches a list endpoint, parses the first item's id, then attempts to load
+        it via the load endpoint template. A 404 on a listed item is a contract
+        violation. Covers the t/2368 scenario (list community as anon → load → 200).
+        Skips gracefully (Pass=$true, description tagged 'skipped') when the list
+        is empty. Never throws — callers receive a result row unconditionally.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$BaseUrl,
+        [string]$ListPath,
+        [string]$LoadTemplate,
+        [string]$Category,
+        [string]$Description,
+        [object]$Session,
+        [int]$TimeoutSec = 15
+    )
+
+    $ListParams = @{
+        BaseUrl               = $BaseUrl
+        Path                  = $ListPath
+        TimeoutSec            = $TimeoutSec
+        ExpectJson            = $true
+        AcceptableStatusCodes = @(200, 304)
+    }
+    if ($Session) { $ListParams.Session = $Session }
+    $ListCheck = Invoke-RemoteCheck @ListParams
+
+    if (-not $ListCheck.Success) {
+        $r = [EndpointTestResult]::new()
+        $r.Endpoint    = $LoadTemplate
+        $r.Category    = $Category
+        $r.Description = $Description
+        $r.Status      = $ListCheck.StatusCode
+        $r.Pass        = $false
+        $r.Ms          = $ListCheck.ResponseMs
+        $r.Error       = "list request failed: $($ListCheck.Error)"
+        return $r
+    }
+
+    $Items = @($ListCheck.Body)
+    if ($Items.Count -eq 0) {
+        $r = [EndpointTestResult]::new()
+        $r.Endpoint    = $LoadTemplate
+        $r.Category    = $Category
+        $r.Description = "$Description (skipped — list empty)"
+        $r.Status      = $ListCheck.StatusCode
+        $r.Pass        = $true
+        $r.Ms          = $ListCheck.ResponseMs
+        return $r
+    }
+
+    $FirstItem = $Items[0]
+    $ItemId    = $null
+    if ($FirstItem.PSObject.Properties['id']) {
+        $ItemId = [string]$FirstItem.id
+    }
+    if ([string]::IsNullOrWhiteSpace($ItemId)) {
+        $r = [EndpointTestResult]::new()
+        $r.Endpoint    = $LoadTemplate
+        $r.Category    = $Category
+        $r.Description = $Description
+        $r.Status      = 0
+        $r.Pass        = $false
+        $r.Ms          = $ListCheck.ResponseMs
+        $r.Error       = "list item has no 'id' field — unexpected schema"
+        return $r
+    }
+
+    $LoadPath   = $LoadTemplate -replace '\{id\}', $ItemId
+    $LoadParams = @{
+        BaseUrl               = $BaseUrl
+        Path                  = $LoadPath
+        TimeoutSec            = $TimeoutSec
+        AcceptableStatusCodes = @(200, 304)
+    }
+    if ($Session) { $LoadParams.Session = $Session }
+    $LoadCheck = Invoke-RemoteCheck @LoadParams
+
+    $r = [EndpointTestResult]::new()
+    $r.Endpoint    = $LoadPath
+    $r.Category    = $Category
+    $r.Description = $Description
+    $r.Status      = $LoadCheck.StatusCode
+    $r.Pass        = $LoadCheck.Success
+    $r.Ms          = $ListCheck.ResponseMs + $LoadCheck.ResponseMs
+    $r.Error       = $LoadCheck.Error
+    $r
+}

--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -107,6 +107,23 @@ function Invoke-TaxEditorSmokeTest {
     }
     Write-Host ''
 
+    # t/2374 — anonymous community pass: re-runs Community endpoints as an anon user
+    # to catch auth-scope contract bugs (t/2368: listed items must be loadable by the
+    # listing user). Included in the default run so staging always exercises anon paths.
+    Write-Host '=== Anon Community Endpoints ===' -ForegroundColor Cyan
+    $AnonEndpoints = @(Test-TaxEditorEndpoints -BaseUrl $BaseUrl -TimeoutSec $TimeoutSec `
+        -Category Community -UserType Anonymous)
+
+    foreach ($Ep in $AnonEndpoints) {
+        $Icon = if ($Ep.Pass) { '[PASS]' } else { '[FAIL]' }
+        $Color = if ($Ep.Pass) { 'Green' } else { 'Red' }
+        Write-Host "  $Icon [anon] $($Ep.Endpoint) — $($Ep.Status) $($Ep.Ms)ms" -ForegroundColor $Color
+        if (-not $Ep.Pass -and $Ep.Error) {
+            Write-Host "        $($Ep.Error)" -ForegroundColor DarkRed
+        }
+    }
+    Write-Host ''
+
     # ── Phase 3: Azure infrastructure ───────────────────────────────────
     Write-Host '=== Azure Infrastructure ===' -ForegroundColor Cyan
     $Azure = Test-AzureHealth -BaseUrl $BaseUrl -TimeoutSec $TimeoutSec
@@ -130,7 +147,7 @@ function Invoke-TaxEditorSmokeTest {
     Write-Host ''
 
     # ── Summary ──────────────────────────────────────────────────────────
-    $AllResults = $Endpoints
+    $AllResults = @($Endpoints) + @($AnonEndpoints)
     $Passed = @($AllResults | Where-Object { $_.Pass }).Count
     $Failed = @($AllResults | Where-Object { -not $_.Pass }).Count
     $Total = $AllResults.Count

--- a/scripts/AITriad/Public/Test-TaxEditorEndpoints.ps1
+++ b/scripts/AITriad/Public/Test-TaxEditorEndpoints.ps1
@@ -61,7 +61,11 @@ function Test-TaxEditorEndpoints {
         [string]$Category,
 
         [Parameter()]
-        [switch]$AnonymousSession
+        [switch]$AnonymousSession,
+
+        [Parameter()]
+        [ValidateSet('Authenticated', 'Anonymous', 'Admin')]
+        [string]$UserType = 'Authenticated'
     )
 
     Set-StrictMode -Version Latest
@@ -113,12 +117,14 @@ function Test-TaxEditorEndpoints {
         $Endpoints = @($Endpoints | Where-Object { $_.Cat -eq $Category })
     }
 
-    # Anonymous session establishment (t/1500 Phase 3, TL note 1).
+    # Anonymous session establishment (t/1500 Phase 3, TL note 1; -UserType t/2374).
+    # -AnonymousSession is the legacy switch; -UserType Anonymous is the new param.
     $Session = $null
-    if ($AnonymousSession) {
+    $UseAnon = $AnonymousSession -or ($UserType -eq 'Anonymous')
+    if ($UseAnon) {
         $Session = New-AnonymousWebSession -BaseUrl $BaseUrl -TimeoutSec $TimeoutSec
         if (-not $Session) {
-            Write-Warning "AnonymousSession: /.auth/anonymous did not establish a session at $BaseUrl; proceeding unauthenticated."
+            Write-Warning "Anonymous session: /.auth/anonymous did not establish a session at $BaseUrl; proceeding unauthenticated."
         }
     }
 
@@ -210,6 +216,37 @@ function Test-TaxEditorEndpoints {
         $Result.NodeCount   = $NodeCount
         $Result.Error       = $Check.Error
         $Results.Add($Result)
+    }
+
+    # -- List→load contract tests (t/2374) ----------------------------------------
+    # Runs when the category scope includes Community or Debate endpoints. Catches
+    # cross-endpoint contract violations: a listed item that 404s on load is a bug
+    # (t/2368 scenario: list community as anon → attempt load → expect 200).
+    $RunCommunityContract = -not $Category -or $Category -eq 'Community'
+    $RunDebateContract    = -not $Category -or $Category -eq 'Debate'
+
+    if ($RunCommunityContract) {
+        Write-Verbose "Running list→load contract test for Community debates..."
+        $Results.Add((Invoke-ListLoadContractTest `
+            -BaseUrl      $BaseUrl `
+            -ListPath     '/api/community/debates' `
+            -LoadTemplate '/api/community/debates/{id}' `
+            -Category     'Community' `
+            -Description  'Community debate list→load contract (t/2374)' `
+            -Session      $Session `
+            -TimeoutSec   $TimeoutSec))
+    }
+
+    if ($RunDebateContract) {
+        Write-Verbose "Running list→load contract test for user debates..."
+        $Results.Add((Invoke-ListLoadContractTest `
+            -BaseUrl      $BaseUrl `
+            -ListPath     '/api/debates/list' `
+            -LoadTemplate '/api/debates/{id}' `
+            -Category     'Debate' `
+            -Description  'User debate list→load contract (t/2374)' `
+            -Session      $Session `
+            -TimeoutSec   $TimeoutSec))
     }
 
     @($Results)

--- a/tests/Test-TaxEditorEndpoints.Contract.Tests.ps1
+++ b/tests/Test-TaxEditorEndpoints.Contract.Tests.ps1
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for list→load contract checking and -UserType parameter (t/2374).
+.DESCRIPTION
+    Covers: -UserType Anonymous session setup, Invoke-ListLoadContractTest
+    happy path, contract violation (t/2368 scenario), and empty-list skip.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-TaxEditorEndpoints — UserType + list→load contract (t/2374)' -Tag 'contract','health' {
+
+    # ── UserType session setup ────────────────────────────────────────────────
+
+    Context 'UserType=Anonymous — establishes anon session before sweep' {
+
+        It 'calls New-AnonymousWebSession exactly once when -UserType Anonymous' {
+            InModuleScope AITriad {
+                $script:AnonCalls = 0
+                Mock Get-TaxEditorBaseUrl -MockWith { 'https://stub.example.com' }
+                Mock New-AnonymousWebSession -MockWith { $script:AnonCalls++; $null }
+                Mock Invoke-RemoteCheck -MockWith {
+                    [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 5
+                        Body = $null; RawBody = '{"status":"ok"}'; Error = $null; ContentType = 'application/json' }
+                }
+
+                Test-TaxEditorEndpoints -BaseUrl 'https://stub' -Category Health `
+                    -UserType Anonymous 6>$null
+
+                $script:AnonCalls | Should -Be 1 `
+                    -Because '-UserType Anonymous must establish one anon session before the sweep'
+            }
+        }
+
+        It 'does NOT call New-AnonymousWebSession when -UserType Authenticated (default)' {
+            InModuleScope AITriad {
+                $script:AnonCalls = 0
+                Mock Get-TaxEditorBaseUrl -MockWith { 'https://stub.example.com' }
+                Mock New-AnonymousWebSession -MockWith { $script:AnonCalls++; $null }
+                Mock Invoke-RemoteCheck -MockWith {
+                    [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 5
+                        Body = $null; RawBody = '{"status":"ok"}'; Error = $null; ContentType = 'application/json' }
+                }
+
+                Test-TaxEditorEndpoints -BaseUrl 'https://stub' -Category Health 6>$null
+
+                $script:AnonCalls | Should -Be 0 `
+                    -Because 'Authenticated (default) must not establish an anon session'
+            }
+        }
+
+        It '-AnonymousSession switch still calls New-AnonymousWebSession (backward compat)' {
+            InModuleScope AITriad {
+                $script:AnonCalls = 0
+                Mock Get-TaxEditorBaseUrl -MockWith { 'https://stub.example.com' }
+                Mock New-AnonymousWebSession -MockWith { $script:AnonCalls++; $null }
+                Mock Invoke-RemoteCheck -MockWith {
+                    [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 5
+                        Body = $null; RawBody = '{"status":"ok"}'; Error = $null; ContentType = 'application/json' }
+                }
+
+                Test-TaxEditorEndpoints -BaseUrl 'https://stub' -Category Health `
+                    -AnonymousSession 6>$null
+
+                $script:AnonCalls | Should -Be 1 `
+                    -Because '-AnonymousSession must still work for backward compatibility'
+            }
+        }
+    }
+
+    # ── Invoke-ListLoadContractTest — happy path ──────────────────────────────
+
+    Context 'List→load contract — happy path (list 200 → load 200)' {
+
+        It 'returns Pass=true and the resolved load URL when both requests succeed' {
+            InModuleScope AITriad {
+                $script:CallNum = 0
+                Mock Invoke-RemoteCheck -MockWith {
+                    $script:CallNum++
+                    if ($script:CallNum -eq 1) {
+                        # list response
+                        [PSCustomObject]@{
+                            Success = $true; StatusCode = 200; ResponseMs = 10
+                            Body    = @([PSCustomObject]@{ id = 'debate-abc' })
+                            RawBody = $null; Error = $null; ContentType = 'application/json'
+                        }
+                    } else {
+                        # load response
+                        [PSCustomObject]@{
+                            Success = $true; StatusCode = 200; ResponseMs = 12
+                            Body    = [PSCustomObject]@{ id = 'debate-abc' }
+                            RawBody = $null; Error = $null; ContentType = 'application/json'
+                        }
+                    }
+                }
+
+                $Result = Invoke-ListLoadContractTest `
+                    -BaseUrl      'https://stub' `
+                    -ListPath     '/api/community/debates' `
+                    -LoadTemplate '/api/community/debates/{id}' `
+                    -Category     'Community' `
+                    -Description  'Community debate list→load contract (t/2374)' `
+                    -TimeoutSec   15
+
+                $Result.Pass     | Should -Be $true  -Because '200 list + 200 load satisfies the contract'
+                $Result.Endpoint | Should -Be '/api/community/debates/debate-abc' `
+                    -Because 'endpoint must be the resolved load URL'
+                $Result.Category | Should -Be 'Community'
+            }
+        }
+    }
+
+    # ── Invoke-ListLoadContractTest — contract violation ──────────────────────
+
+    Context 'List→load contract — violation (list 200 → load 404) — t/2368 scenario' {
+
+        It 'returns Pass=false when load returns 404 for a listed item' {
+            InModuleScope AITriad {
+                $script:CallNum = 0
+                Mock Invoke-RemoteCheck -MockWith {
+                    $script:CallNum++
+                    if ($script:CallNum -eq 1) {
+                        # list returns an item
+                        [PSCustomObject]@{
+                            Success = $true; StatusCode = 200; ResponseMs = 8
+                            Body    = @([PSCustomObject]@{ id = 'debate-xyz' })
+                            RawBody = $null; Error = $null; ContentType = 'application/json'
+                        }
+                    } else {
+                        # load returns 404 — the t/2368 scenario
+                        [PSCustomObject]@{
+                            Success = $false; StatusCode = 404; ResponseMs = 7
+                            Body    = $null; RawBody = $null
+                            Error   = '404 Not Found'; ContentType = $null
+                        }
+                    }
+                }
+
+                $Result = Invoke-ListLoadContractTest `
+                    -BaseUrl      'https://stub' `
+                    -ListPath     '/api/community/debates' `
+                    -LoadTemplate '/api/community/debates/{id}' `
+                    -Category     'Community' `
+                    -Description  'Community debate list→load contract (t/2374)' `
+                    -TimeoutSec   15
+
+                $Result.Pass   | Should -Be $false `
+                    -Because '404 on a listed item is a contract violation (t/2368 scenario)'
+                $Result.Status | Should -Be 404
+            }
+        }
+    }
+
+    # ── Invoke-ListLoadContractTest — empty list ──────────────────────────────
+
+    Context 'List→load contract — empty list (no items to load)' {
+
+        It 'returns Pass=true with a skipped description when the list is empty' {
+            InModuleScope AITriad {
+                Mock Invoke-RemoteCheck -MockWith {
+                    [PSCustomObject]@{
+                        Success = $true; StatusCode = 200; ResponseMs = 6
+                        Body    = @()   # empty list
+                        RawBody = $null; Error = $null; ContentType = 'application/json'
+                    }
+                }
+
+                $Result = Invoke-ListLoadContractTest `
+                    -BaseUrl      'https://stub' `
+                    -ListPath     '/api/community/debates' `
+                    -LoadTemplate '/api/community/debates/{id}' `
+                    -Category     'Community' `
+                    -Description  'Community debate list→load contract (t/2374)' `
+                    -TimeoutSec   15
+
+                $Result.Pass        | Should -Be $true `
+                    -Because 'an empty list is not a violation — nothing listed means nothing to verify'
+                $Result.Description | Should -BeLike '*skipped*' `
+                    -Because 'description must signal the skip so callers can distinguish from a true pass'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `Invoke-ListLoadContractTest` private helper: fetches a collection endpoint, parses first item id, loads it; returns `Pass=$false` on 404 — catches the t/2368 scenario (list community as anon → attempt load → expect 200)
- `Test-TaxEditorEndpoints`: new `-UserType` param (`Authenticated|Anonymous|Admin`); `Anonymous` calls `New-AnonymousWebSession`; `-AnonymousSession` kept for backward compat
- Contract tests auto-run when Category scope includes Community or Debate
- `Invoke-TaxEditorSmokeTest`: anon community pass added to Phase 2 default run (catches auth-scope contract bugs post-deploy)

## Test plan

- [x] 6 new Pester tests (`-Tag contract,health`): anon session setup (3), list→load happy path, 404 violation (t/2368), empty-list skip
- [x] 6/6 passing
- [x] Full regression: 1056 passed, 0 failed (edb15dbd)

Self-cert: `/add-ps-cmdlet` + `/add-test`. Deviation: modifying existing cmdlet + adding private helper (covered under routine extension self-cert, TL approved at p/360#30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>