### PR TITLE
feat(shared): BookmarkLink component for GitHub doc links (t/2393)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/BookmarkLink.css
+++ b/taxonomy-editor/src/renderer/components/shared/BookmarkLink.css
@@ -1,0 +1,48 @@
+/* BookmarkLink (t/2393) — muted inline bookmark glyph that brightens on hover.
+   Co-located because styles.css is frozen (no new selectors).
+   Muted foreground over the transparent page surface; scored at the WCAG 1.4.11
+   3:1 non-text floor by check-contrast.mjs (mirrors .theory-link, t/2359). */
+/* contrast-nontext */
+.bookmark-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  line-height: 1;
+  vertical-align: middle;
+  transition: color 0.15s;
+}
+
+.bookmark-link:hover,
+.bookmark-link:focus-visible {
+  color: var(--text-secondary);
+}
+
+.bookmark-link:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.bookmark-link-icon {
+  width: 1em;
+  height: 1em;
+  display: block;
+}
+
+/* Size variants drive the 1em glyph — inline, no layout shift in surrounding text. */
+.bookmark-link--xs {
+  font-size: 12px;
+}
+
+.bookmark-link--sm {
+  font-size: 14px;
+}
+
+.bookmark-link--md {
+  font-size: 16px;
+}

--- a/taxonomy-editor/src/renderer/components/shared/BookmarkLink.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/BookmarkLink.test.tsx
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const openExternal = vi.fn().mockResolvedValue(undefined);
+vi.mock('@bridge', () => ({ api: { openExternal: (url: string) => openExternal(url) } }));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+
+import { BookmarkLink, buildDocUrl } from './BookmarkLink';
+
+const BASE = 'https://github.com/Berkman-Klein-Center/ai-triad-research/blob/main';
+
+describe('buildDocUrl', () => {
+  it('constructs a GitHub blob URL from a repo-relative path', () => {
+    expect(buildDocUrl('docs/reading-the-argument-network.md')).toBe(
+      `${BASE}/docs/reading-the-argument-network.md`,
+    );
+  });
+
+  it('appends the anchor with a # when provided', () => {
+    expect(buildDocUrl('docs/x.md', 'computed-strength-vs-base-strength')).toBe(
+      `${BASE}/docs/x.md#computed-strength-vs-base-strength`,
+    );
+  });
+
+  it('omits the anchor when not provided', () => {
+    expect(buildDocUrl('docs/x.md')).not.toContain('#');
+  });
+});
+
+describe('BookmarkLink', () => {
+  beforeEach(() => { openExternal.mockClear(); });
+
+  it('renders a link-role control with the label as aria-label and tooltip', () => {
+    render(<BookmarkLink docPath="docs/x.md" label="Reading the argument network" />);
+    const el = screen.getByRole('link', { name: 'Reading the argument network' });
+    expect(el).toHaveAttribute('title', 'Reading the argument network');
+  });
+
+  it('defaults the label to "Learn more"', () => {
+    render(<BookmarkLink docPath="docs/x.md" />);
+    expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute('title', 'Learn more');
+  });
+
+  it('defaults to the sm size variant and applies xs/md when requested', () => {
+    const { rerender } = render(<BookmarkLink docPath="docs/x.md" label="H" />);
+    expect(screen.getByRole('link', { name: 'H' }).className).toContain('bookmark-link--sm');
+    rerender(<BookmarkLink docPath="docs/x.md" label="H" size="xs" />);
+    expect(screen.getByRole('link', { name: 'H' }).className).toContain('bookmark-link--xs');
+    rerender(<BookmarkLink docPath="docs/x.md" label="H" size="md" />);
+    expect(screen.getByRole('link', { name: 'H' }).className).toContain('bookmark-link--md');
+  });
+
+  it('appends className to the base classes (never replaces them)', () => {
+    render(<BookmarkLink docPath="docs/x.md" label="H" className="inline-heading" />);
+    const el = screen.getByRole('link', { name: 'H' });
+    expect(el.className).toContain('bookmark-link');
+    expect(el.className).toContain('inline-heading');
+  });
+
+  it('opens the constructed GitHub URL externally on click (via bridge, not window/shell)', async () => {
+    const user = userEvent.setup();
+    render(<BookmarkLink docPath="docs/reading-the-argument-network.md" anchor="strength" label="H" />);
+    await user.click(screen.getByRole('link', { name: 'H' }));
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith(
+      `${BASE}/docs/reading-the-argument-network.md#strength`,
+    );
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/BookmarkLink.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/BookmarkLink.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * BookmarkLink (t/2393) — small inline bookmark affordance that opens a GitHub
+ * explainer doc in the system browser. Used throughout the debate diagnostics UI
+ * (wiring tracked separately in t/2394).
+ *
+ * The consumer passes a repo-relative `docPath` (+ optional `anchor`); the
+ * GitHub blob URL is constructed here so callers never hand-assemble it. Opening
+ * routes through the bridge (`api.openExternal`) — never shell/window directly —
+ * so it works in both the Electron (shell.openExternal) and web (window.open,
+ * https-guarded) builds and never navigates the Electron window itself.
+ */
+
+import { api } from '@bridge';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import './BookmarkLink.css';
+
+const REPO_BLOB_BASE = 'https://github.com/Berkman-Klein-Center/ai-triad-research/blob/main';
+
+export interface BookmarkLinkProps {
+  /** Repo-relative path to the doc, e.g. "docs/reading-the-argument-network.md". */
+  docPath: string;
+  /** Optional anchor within the doc, e.g. "computed-strength-vs-base-strength". */
+  anchor?: string;
+  /** Tooltip + accessible label shown on hover. Defaults to "Learn more". */
+  label?: string;
+  /** Size variant. Defaults to "sm". */
+  size?: 'xs' | 'sm' | 'md';
+  /** Extra class(es) for inline positioning by consumers — appended to the base classes. */
+  className?: string;
+}
+
+/** Build the GitHub blob URL for a repo-relative doc path (+ optional anchor). */
+export function buildDocUrl(docPath: string, anchor?: string): string {
+  return `${REPO_BLOB_BASE}/${docPath}${anchor ? `#${anchor}` : ''}`;
+}
+
+export function BookmarkLink({ docPath, anchor, label = 'Learn more', size = 'sm', className }: BookmarkLinkProps) {
+  const handleOpen = () => {
+    const url = buildDocUrl(docPath, anchor);
+    void api.openExternal(url).catch((err) => {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'bookmark-link',
+        level: 'error',
+        message: 'Failed to open bookmark link externally',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className={`bookmark-link bookmark-link--${size} ${className ?? ''}`.trim()}
+      role="link"
+      aria-label={label}
+      title={label}
+      onClick={handleOpen}
+    >
+      {/* Bookmark glyph (currentColor so it can be tinted muted → hover-brighten) */}
+      <svg className="bookmark-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">
+        <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+      </svg>
+    </button>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/shared/index.ts
+++ b/taxonomy-editor/src/renderer/components/shared/index.ts
@@ -1,4 +1,5 @@
 // Barrel file — re-exports all components in this directory
+export * from './BookmarkLink';
 export * from './BottomNav';
 export * from './DetailPane';
 export * from './resolveRef';


### PR DESCRIPTION
## Summary

New shared `BookmarkLink` component (t/2393) — a small inline bookmark affordance that opens a repo-relative GitHub explainer doc in the system browser. Built for reuse across the debate-diagnostics UI; unblocks the wiring ticket **t/2394**.

## What it does

- `<BookmarkLink docPath="docs/x.md" anchor="section" label="…" size="sm" />`
- On click, opens `https://github.com/Berkman-Klein-Center/ai-triad-research/blob/main/<docPath>#<anchor>` via `api.openExternal` — never navigates the Electron window; works in both Electron and web builds.
- `xs` / `sm` (default) / `md` size variants, inline `display: inline-flex` so it sits beside text without layout shift.
- Muted glyph (`--text-muted`) brightening to `--text-secondary` on hover; `aria-label` + `title` from `label`, `role="link"`.
- `buildDocUrl()` exported for URL construction (and unit-tested directly).

## Accessibility / gates

- Co-located `BookmarkLink.css` (styles.css stays frozen), marked `/* contrast-nontext */` and scored at the WCAG 1.4.11 3:1 floor like `.theory-link`. Contrast ratchet unchanged at **302/314** — adds 0 findings.
- Renderer flight-recorder `system.error` on `openExternal` failure (ADR-003 renderer shape).

## Verification

- `check-renderer-tsc.sh` — 0 errors
- `eslint` (new files) — clean
- `vitest` `BookmarkLink.test.tsx` — 8/8 pass (URL construction, anchor append, click handler, size variants, default label, className append)
- `check-contrast.sh` — 302/314 (OK)

Closes t/2393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: DebateDiagnostics (Orca) — spec author
