### PR TITLE
analysis(comp-linguist): extraction-noise tail is NOT overwhelmingly non-content (t/2392)

### DIFF
--- a/research/comp-linguist/analyses/t2392-extraction-noise/README.md
+++ b/research/comp-linguist/analyses/t2392-extraction-noise/README.md
@@ -1,0 +1,76 @@
+# t/2392 — Extraction-noise investigation: what actually lives in the low-cosine tail
+
+**Author:** Computational Linguist · **Date:** 2026-08-09 · **Ticket:** t/2392 (CL investigation → design; **do NOT implement**, TL-gated per t/2381#7)
+**Provenance:** empirical, **observed** (real production summaries, `../ai-triad-data/summaries/*.json`). Harnesses committed alongside (`classify_noise.py`, `verify_attr.py`, `mode_crosstab.py`). Single-rater hand-labeling (n=50), per t/2306/t/2294 caveat.
+
+## TL;DR — the ticket's premise does not survive measurement
+
+The side-finding was framed as "~2.67% of key_points are **overwhelmingly non-content fragments** (math/OCR/table/PII)." Measured against the full flagged population:
+
+1. **Clear structural noise is a minority of the tail (~⅓), not "overwhelmingly."** In a hand-labeled random 50-sample of the 293 `top-1 < 0.30` key_points: **~32% structural noise**, **~24% off-topic-but-real prose**, **~42% genuine in-scope claims that merely embed weakly.** The vivid math/PII exemplars in the ticket are real but not representative.
+2. **A cosine top-1 threshold is the wrong instrument.** Because ~42% of the `<0.30` band is genuine in-scope content, a drop/quarantine filter keyed on `top-1 < 0.30` would have a **~40%+ false-positive rate on real claims** — the precision risk the ticket flagged (its item 3) is the *dominant* effect, not a corner case. **NO-GO on any cosine-cutoff extraction guard.**
+3. **The real structural lever is `attribution_text` presence, and it is already decisive.** Of 10,972 assigned key_points, only **2,117 (19%) carry an `attribution_text`; those never score below 0.462** (min 0.462, p1 0.546) — **zero** in any low band. The entire low-cosine tail (293/293 at `<0.30`) is drawn from the **8,855 (81%) without `attribution_text`**.
+4. **The noise does not pollute the downstream flags the ticket named.** Mechanism #5 v1 (t/2357) and the t/2288 confidence pass **score `attribution_text` and skip key_points that lack it** (`Invoke-RetrievalConfidencePass.ps1:87`); the out-of-scope guard only examines M5-flagged misfires (`Invoke-OutOfScopeGuardPass.ps1:59`, Arm B). Since the tail is 100% no-`attribution_text`, **none of it reaches M5-v1 surfacing, t/2288, or the OOS guard.** The stated "inflates flag volume" harm does not occur. The real harm is **corpus pollution** — confident *wrong* taxonomy assignments in the persisted key_point set (~2.67%).
+
+## Method
+
+- Reused the t/2381 corpus-scan logic (`t2381_corpus_scan.py`): POV-filtered base top-1 cosine over `saf-/acc-/skp-` `embeddings.json` vectors, `all-MiniLM-L6-v2`, for every assigned key_point.
+- **Text field:** the scan (and the pipeline flag) uses `attribution_text` → `verbatim` → `point` fallback. `verify_attr.py` splits the distribution by `attribution_text` present/absent.
+- **Classification:** `classify_noise.py` auto-buckets each flagged item (deterministic regex: SSN/PII, table/finding-ID, OCR glue-ratio, math-notation, citation); everything unmatched defaults to `genuine_weak`. Auto is a **lower bound on noise** (defaults to genuine). Hand-labeled a seeded random 50-sample of the `<0.30` band into structural-noise / off-topic-real / genuine-in-scope for the true split.
+
+## Results
+
+### Distribution (AC-1) — matches the side-finding
+
+| band | n | % of 10,972 |
+|---|---|---|
+| top-1 < 0.30 | 293 | 2.67% |
+| top-1 < 0.35 | 734 | 6.69% |
+| top-1 < 0.40 | 1,500 | 13.67% |
+| top-1 < 0.45 | 2,617 | 23.85% |
+
+### `attribution_text` split — the decisive structural fact
+
+| population | n | min top-1 | median | `<0.30` | `<0.45` |
+|---|---|---|---|---|---|
+| **WITH** `attribution_text` | 2,117 | **0.462** | 0.767 | 0 (0%) | 0 (0%) |
+| **WITHOUT** `attribution_text` | 8,855 | 0.056 | 0.517 | 293 (3.3%) | 2,617 (29.6%) |
+
+`attribution_text` presence is not a pure extraction-mode artifact (present in ~13% of `fire` and ~24% of `single_shot` key_points), but its presence perfectly predicts "not in the low tail."
+
+### Composition of the `<0.30` band (hand-labeled 50-sample)
+
+| population | ~share | what it is | right lever |
+|---|---|---|---|
+| **structural noise** | ~32% | math/proof notation, OCR-glued spans, citation/author-lists, table/finding-ID rows, bios, PII/conversational | deterministic pre-emission filter (regex/heuristics) |
+| **off-topic-but-real** | ~24% | real prose out of AI-safety domain (satellite broadband, stock sales, DEI quotes, energy) | extraction-prompt scope/relevance rules |
+| **genuine in-scope, weak** | ~42% | real, relevant claims in non-taxonomy vocabulary (CBRN uplift, power-seeking, deception, lending bias) | **must be preserved — never dropped** |
+
+Auto-classifier lower bound agreed (21.5% clear-noise at `<0.30`, decaying to 9.9% at `<0.40` as the band fills with genuine content).
+
+## Design assessment (AC-2 / AC-3)
+
+**Is a cheap extraction-input guard warranted?** Partially, and only for one population:
+
+- **Cosine-cutoff guard (drop/quarantine on `top-1 < τ`): NO-GO.** ~42% false-positive on genuine claims at `<0.30`, worse at higher τ. Confirms and extends the t/2381 out-of-scope NO-GO — the signal cannot separate noise from weakly-embedded in-scope content at any threshold. No metric threshold to register (nothing derivable).
+- **Deterministic structural pre-filter (regex/heuristics) for the ~32% type-1 noise: WARRANTED but low-yield.** High-precision patterns (PII/SSN, `\bT\d+-AT-\d+\b`/`AATMF`/`====` table-IDs, OCR glue-ratio ≥ threshold, math-symbol density, bare author-list/citation shape) catch non-claim fragments **before key_point emission** with near-zero false-positive on prose. Corpus-wide volume is small: ~63–100 key_points (~0.6–0.9%). Value is **corpus hygiene** (removing confident wrong assignments), not downstream-flag reduction (which doesn't occur).
+- **Off-topic-but-real (~24%): out of scope for a *structural* filter** — it's a topicality judgment belonging to the extraction prompt's scope rules (cf. topic-scope enforcement), not a noise filter.
+
+**Where is the seam?** Two candidates, both **before** embedding/assignment:
+1. **Chunk-ingestion pre-filter** (preferred for OCR-garble/table/PII): reject or clean garbled/tabular/PII spans in `Invoke-DocumentSummary` *before* they reach the LLM — stops the fragment from ever becoming a key_point and saves the extraction call.
+2. **Post-extraction structural filter**: drop emitted key_points whose `verbatim`/`point` matches the high-precision noise patterns and that lack an `attribution_text`. Cheaper to add, but the fragment already consumed an extraction slot.
+
+**Precision guardrail (AC-3):** any structural filter must (a) act only on `verbatim`/`point` shape, never on cosine; (b) be validated to **zero** false-positives against a held-out set of genuine `<0.30` in-scope claims (the ~42% population — samples in `verify_attr` output); (c) prefer quarantine-for-review over hard-drop on first ship.
+
+## Recommendation (for TL — no implementation without decision)
+
+1. **Reject the cosine-cutoff extraction guard** — same NO-GO basis as t/2381; no registerable threshold.
+2. **If corpus hygiene is wanted,** scope a *narrow deterministic structural pre-filter* (type-1 noise only, ~0.6–0.9%), sited at chunk ingestion, quarantine-first, with a zero-false-positive acceptance gate on genuine-weak claims. Its patterns are a **lexicon** — register them at implementation time (not now).
+3. **De-scope the "downstream flag pollution" motivation** — empirically absent (tail is no-`attribution_text`; M5/t2288/OOS skip those). Re-anchor the justification on corpus-hygiene of wrong assignments if the work proceeds.
+4. **Off-topic-but-real** is a separate relevance-gate concern — route to the extraction-prompt owner, not this filter.
+
+**Decision requested:** proceed with the narrow structural pre-filter (rec 2) on the corpus-hygiene rationale, or close t/2392 as "characterized — no guard warranted at this yield"? Either is defensible; the yield is small and the cosine lever is dead.
+
+## Limitations
+
+Single-rater hand-labeling, n=50 of 293 (`<0.30`); the three-way split has ±~10pp sampling error but the **decision-relevant fact — a large genuine-in-scope fraction that forbids a cosine cutoff — is robust** (auto lower-bound and hand-label agree that genuine content dominates as the band widens). Category boundaries (off-topic-real vs genuine-weak) are judgment-sensitive; structural-noise vs everything-else is not.

--- a/research/comp-linguist/analyses/t2392-extraction-noise/README.md
+++ b/research/comp-linguist/analyses/t2392-extraction-noise/README.md
@@ -3,6 +3,12 @@
 **Author:** Computational Linguist · **Date:** 2026-08-09 · **Ticket:** t/2392 (CL investigation → design; **do NOT implement**, TL-gated per t/2381#7)
 **Provenance:** empirical, **observed** (real production summaries, `../ai-triad-data/summaries/*.json`). Harnesses committed alongside (`classify_noise.py`, `verify_attr.py`, `mode_crosstab.py`). Single-rater hand-labeling (n=50), per t/2306/t/2294 caveat.
 
+## DISPOSITION — CLOSED, no guard (TL ruling, t/2392#1 reply, p/349#32, 2026-08-09)
+
+**Ruled by Technical Lead:** both levers are **NO-GO**. (1) The cosine-cutoff extraction guard is dead — the tail is ~42% real content, the same non-separability as t/2381. (2) A maintained deterministic structural pre-filter is **not** justified: the ~0.6–0.9% true noise is too small and marginal (a subset of the already-redundant t/2288 flags), and structural detectors carry their own false-positive risk. **t/2392 is closed as "characterized — no guard."** This also closes the retrieval-quality program: option A(b) shipped; every other lever is NO-GO with documented rationale.
+
+**Do not re-litigate.** Revisit only if this noise causes a **concrete downstream harm** — if that is observed, flag it (new ticket referencing this doc), do not silently reopen a guard.
+
 ## TL;DR — the ticket's premise does not survive measurement
 
 The side-finding was framed as "~2.67% of key_points are **overwhelmingly non-content fragments** (math/OCR/table/PII)." Measured against the full flagged population:
@@ -69,7 +75,7 @@ Auto-classifier lower bound agreed (21.5% clear-noise at `<0.30`, decaying to 9.
 3. **De-scope the "downstream flag pollution" motivation** — empirically absent (tail is no-`attribution_text`; M5/t2288/OOS skip those). Re-anchor the justification on corpus-hygiene of wrong assignments if the work proceeds.
 4. **Off-topic-but-real** is a separate relevance-gate concern — route to the extraction-prompt owner, not this filter.
 
-**Decision requested:** proceed with the narrow structural pre-filter (rec 2) on the corpus-hygiene rationale, or close t/2392 as "characterized — no guard warranted at this yield"? Either is defensible; the yield is small and the cosine lever is dead.
+**Decision (TL, 2026-08-09):** neither guard ships — see DISPOSITION at top. Closed as "characterized — no guard." The narrow pre-filter (rec 2) was judged too small/marginal to maintain given structural detectors' own false-positive risk.
 
 ## Limitations
 

--- a/research/comp-linguist/analyses/t2392-extraction-noise/classify_noise.py
+++ b/research/comp-linguist/analyses/t2392-extraction-noise/classify_noise.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""t/2392: classify the extraction-noise flag population (top-1 < band) into
+categories: math_notation, ocr_garble, table_id, pii_conversational,
+citation_ref, genuine_weak. Reuses the t2381 corpus-scan logic + text field.
+Dumps full JSON for hand-verification and prints per-band category fractions.
+"""
+import json, glob, os, re
+import numpy as np
+
+DR = os.path.abspath('../ai-triad-data')
+HERE = os.path.dirname(__file__)
+
+base = json.load(open(DR + '/taxonomy/Origin/embeddings.json', encoding='utf-8'))['nodes']
+pov_mats, pov_ids = {}, {}
+for pref, pov in [('acc-', 'acc'), ('saf-', 'saf'), ('skp-', 'skp')]:
+    ids = [k for k in base if k.startswith(pref)]
+    M = np.asarray([base[k]['vector'] for k in ids], dtype=np.float32)
+    M = M / np.clip(np.linalg.norm(M, axis=1, keepdims=True), 1e-9, None)
+    pov_mats[pov] = M; pov_ids[pov] = ids
+
+def kp_field(o):
+    for f in ('attribution_text', 'verbatim', 'point'):
+        t = o.get(f)
+        if t:
+            return (' '.join(t) if isinstance(t, list) else t), f
+    return '', None
+
+rows = []  # (pov, node, text, field, file, conf)
+for fp in glob.glob(DR + '/summaries/*.json'):
+    try:
+        d = json.load(open(fp, encoding='utf-8'))
+    except Exception:
+        continue
+    fn = os.path.basename(fp)
+    def walk(o):
+        if isinstance(o, dict):
+            nid = o.get('taxonomy_node_id')
+            if isinstance(nid, str) and nid[:4] in ('acc-', 'saf-', 'skp-'):
+                txt, fld = kp_field(o)
+                if isinstance(txt, str) and len(txt) >= 20:
+                    rows.append((nid[:3], nid, txt, fld, fn, o.get('extraction_confidence')))
+            for v in o.values(): walk(v)
+        elif isinstance(o, list):
+            for v in o: walk(v)
+    walk(d)
+print('assigned key_points scanned:', len(rows))
+
+from sentence_transformers import SentenceTransformer
+model = SentenceTransformer('all-MiniLM-L6-v2')
+emb = model.encode([r[2] for r in rows], batch_size=256, convert_to_numpy=True, show_progress_bar=False)
+emb = emb / np.clip(np.linalg.norm(emb, axis=1, keepdims=True), 1e-9, None)
+
+top1 = np.empty(len(rows), dtype=np.float32); top1_node = [None]*len(rows)
+for pov in ('acc', 'saf', 'skp'):
+    idxs = [i for i, r in enumerate(rows) if r[0] == pov]
+    if not idxs: continue
+    sims = emb[idxs] @ pov_mats[pov].T
+    am, mx = sims.argmax(axis=1), sims.max(axis=1)
+    for j, i in enumerate(idxs):
+        top1[i] = mx[j]; top1_node[i] = pov_ids[pov][am[j]]
+
+# ---- classifier (ordered; first match wins) ----
+SSN = re.compile(r'\b\d{3}-\d{2}-\d{4}\b')
+TABLE_ID = re.compile(r'\b([A-Z]{1,5}\d*-[A-Z]{2,4}-\d{2,4}|AATMF|Finding ID|====|\[(?:CRITICAL|HIGH|MEDIUM|LOW)\s*:\s*\d+\])')
+MATH = re.compile(r'(iff\b|if and only if|Theorem|Lemma|Proposition|Corollary|Hahn-Banach|Credal|KL divergence|convex|almost surely|\bP0\b|P_0|\?exp|BF\(x\)|\\?\bBT scores|half planes|Separation Theorem|marginally|gambles)')
+CITATION = re.compile(r'(et al\.?|see for example|\(19\d\d\)|\(20\d\d\)|Chapter \d|arXiv|doi:|pp\.\s*\d)')
+FIRST_PERSON = re.compile(r"\b(I|my|me|you|your)\b", re.I)
+EMOTION = re.compile(r"(broke up|lost faith|running out of time|no one to talk|girlfriend|boyfriend|deflecting|blamed you|listens to me)", re.I)
+
+def token_glue_ratio(t):
+    toks = re.findall(r'\S+', t)
+    if not toks: return 0.0
+    longish = sum(1 for w in toks if len(w) >= 22)  # words with stripped spaces
+    return longish / len(toks)
+
+def classify(t):
+    if SSN.search(t) or EMOTION.search(t):
+        return 'pii_conversational'
+    if TABLE_ID.search(t):
+        return 'table_id'
+    if token_glue_ratio(t) >= 0.12 or re.search(r'[A-Za-z]{24,}', t):
+        return 'ocr_garble'
+    if MATH.search(t):
+        return 'math_notation'
+    if CITATION.search(t):
+        return 'citation_ref'
+    # short first-person conversational without emotion keywords
+    words = re.findall(r'\S+', t)
+    if len(words) <= 14 and FIRST_PERSON.search(t) and not re.search(r'\b(AI|model|system|data|risk|safety|policy|algorithm)\b', t, re.I):
+        return 'pii_conversational'
+    return 'genuine_weak'
+
+bands = [0.30, 0.35, 0.40]
+dump = {}
+for thr in bands:
+    idxs = [i for i in range(len(rows)) if top1[i] < thr]
+    cats = {}
+    items = []
+    for i in idxs:
+        pov, node, txt, fld, fn, conf = rows[i]
+        c = classify(txt)
+        cats[c] = cats.get(c, 0) + 1
+        items.append({'node': node, 'top1': round(float(top1[i]), 3), 'top1_node': top1_node[i],
+                      'cat': c, 'field': fld, 'conf': conf, 'file': fn, 'text': txt[:300]})
+    n = len(idxs)
+    print(f'\n=== band top-1 < {thr}: n={n} ===')
+    for c in sorted(cats, key=lambda k: -cats[k]):
+        print(f'  {c:20s} {cats[c]:4d}  ({100*cats[c]/n:4.1f}%)')
+    dump[str(thr)] = {'n': n, 'cats': cats, 'items': items}
+
+# noise vs genuine summary for the headline band
+b = dump['0.3']
+noise = sum(v for k, v in b['cats'].items() if k != 'genuine_weak')
+print(f"\n<0.30: NOISE {noise}/{b['n']} = {100*noise/b['n']:.1f}%  | genuine_weak {b['cats'].get('genuine_weak',0)} = {100*b['cats'].get('genuine_weak',0)/b['n']:.1f}%")
+
+# field-absence signal: how many flagged lack attribution_text
+for thr in bands:
+    it = dump[str(thr)]['items']
+    no_attr = sum(1 for x in it if x['field'] != 'attribution_text')
+    print(f"  <{thr}: {no_attr}/{len(it)} ({100*no_attr/len(it):.0f}%) had NO attribution_text (fell back to verbatim/point)")
+
+json.dump(dump, open(os.path.join(HERE, 'noise_classification.json'), 'w', encoding='utf-8'), ensure_ascii=False, indent=1)
+print('\nsaved noise_classification.json')

--- a/research/comp-linguist/analyses/t2392-extraction-noise/mode_crosstab.py
+++ b/research/comp-linguist/analyses/t2392-extraction-noise/mode_crosstab.py
@@ -1,0 +1,20 @@
+import json, glob, os
+from collections import Counter
+DR = os.path.abspath('../ai-triad-data')
+mode_has = Counter(); mode_no = Counter()
+for fp in glob.glob(DR + '/summaries/*.json'):
+    try: d = json.load(open(fp, encoding='utf-8'))
+    except Exception: continue
+    mode = (d.get('model_info') or {}).get('extraction_mode', 'MISSING')
+    def walk(o):
+        if isinstance(o, dict):
+            nid = o.get('taxonomy_node_id')
+            if isinstance(nid, str) and nid[:4] in ('acc-','saf-','skp-'):
+                (mode_has if o.get('attribution_text') else mode_no)[mode] += 1
+            for v in o.values(): walk(v)
+        elif isinstance(o, list):
+            for v in o: walk(v)
+    walk(d)
+print('extraction_mode | with_attr | without_attr')
+for m in sorted(set(mode_has)|set(mode_no)):
+    print(f'  {m:14s} {mode_has.get(m,0):6d}   {mode_no.get(m,0):6d}')

--- a/research/comp-linguist/analyses/t2392-extraction-noise/verify_attr.py
+++ b/research/comp-linguist/analyses/t2392-extraction-noise/verify_attr.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""Linchpin check for t/2392:
+(A) top-1 distribution split by attribution_text PRESENT vs ABSENT.
+(B) sample of <0.30 'genuine_weak' items for hand review.
+"""
+import json, glob, os, re, random
+import numpy as np
+
+DR = os.path.abspath('../ai-triad-data')
+HERE = os.path.dirname(__file__)
+random.seed(2392)
+
+base = json.load(open(DR + '/taxonomy/Origin/embeddings.json', encoding='utf-8'))['nodes']
+pov_mats, pov_ids = {}, {}
+for pref, pov in [('acc-', 'acc'), ('saf-', 'saf'), ('skp-', 'skp')]:
+    ids = [k for k in base if k.startswith(pref)]
+    M = np.asarray([base[k]['vector'] for k in ids], dtype=np.float32)
+    M = M / np.clip(np.linalg.norm(M, axis=1, keepdims=True), 1e-9, None)
+    pov_mats[pov] = M; pov_ids[pov] = ids
+
+rows = []  # (pov, node, text, has_attr, file)
+for fp in glob.glob(DR + '/summaries/*.json'):
+    try:
+        d = json.load(open(fp, encoding='utf-8'))
+    except Exception:
+        continue
+    fn = os.path.basename(fp)
+    def walk(o):
+        if isinstance(o, dict):
+            nid = o.get('taxonomy_node_id')
+            if isinstance(nid, str) and nid[:4] in ('acc-', 'saf-', 'skp-'):
+                at = o.get('attribution_text')
+                has_attr = bool(at)
+                txt = at if has_attr else (o.get('verbatim') or o.get('point') or '')
+                txt = ' '.join(txt) if isinstance(txt, list) else txt
+                if isinstance(txt, str) and len(txt) >= 20:
+                    rows.append((nid[:3], nid, txt, has_attr, fn))
+            for v in o.values(): walk(v)
+        elif isinstance(o, list):
+            for v in o: walk(v)
+    walk(d)
+
+from sentence_transformers import SentenceTransformer
+model = SentenceTransformer('all-MiniLM-L6-v2')
+emb = model.encode([r[2] for r in rows], batch_size=256, convert_to_numpy=True, show_progress_bar=False)
+emb = emb / np.clip(np.linalg.norm(emb, axis=1, keepdims=True), 1e-9, None)
+top1 = np.empty(len(rows), dtype=np.float32)
+for pov in ('acc', 'saf', 'skp'):
+    idxs = [i for i, r in enumerate(rows) if r[0] == pov]
+    if not idxs: continue
+    sims = emb[idxs] @ pov_mats[pov].T
+    mx = sims.max(axis=1)
+    for j, i in enumerate(idxs): top1[i] = mx[j]
+
+has = np.array([r[3] for r in rows])
+print('total key_points:', len(rows))
+print('WITH attribution_text:', int(has.sum()), ' WITHOUT:', int((~has).sum()))
+for label, mask in [('WITH attr', has), ('WITHOUT attr', ~has)]:
+    t = top1[mask]
+    pct = np.percentile(t, [0, 1, 5, 25, 50])
+    print(f'\n{label} (n={mask.sum()}): min={t.min():.3f} p1={pct[1]:.3f} p5={pct[2]:.3f} p25={pct[3]:.3f} median={pct[4]:.3f}')
+    for thr in (0.30, 0.35, 0.40, 0.45):
+        print(f'   < {thr}: {int((t<thr).sum())} ({100*(t<thr).mean():.1f}%)')
+
+# cross-tab: of the <0.30 population, how many have attribution_text?
+lo = top1 < 0.30
+print(f'\n<0.30 population n={int(lo.sum())}: with_attr={int((lo & has).sum())}  without_attr={int((lo & ~has).sum())}')
+
+# sample genuine_weak (WITHOUT attr, <0.30, not matching noise regexes) for hand review
+noise_re = re.compile(r'\b\d{3}-\d{2}-\d{4}\b|[A-Za-z]{24,}|AATMF|====|Theorem|iff\b|Credal|Hahn-Banach|et al', re.I)
+cand = [i for i in range(len(rows)) if lo[i] and not rows[i][3] and not noise_re.search(rows[i][2])]
+print(f'\n--- {len(cand)} <0.30 non-regex-noise samples; showing 40 random for hand review ---')
+for i in random.sample(cand, min(40, len(cand))):
+    print(f'  [{rows[i][1]} {top1[i]:.3f}] {rows[i][2][:150]}')


### PR DESCRIPTION
CL investigation of the t/2381 side-finding (t/2392). **Investigation → design; not implemented (TL-gated per t/2381#7).**

## Headline — the ticket's premise does not survive measurement
- **<0.30 band (293, 2.67%) is ~⅓ structural noise, not "overwhelmingly."** Hand-labeled random n=50: **~32% structural noise** (math/OCR/citation/table-ID/PII), **~24% off-topic-but-real**, **~42% genuine in-scope claims that embed weakly**.
- **Cosine-cutoff extraction guard = NO-GO** — ~40%+ false-positive on real content (the precision risk in the ticket's item 3 is the dominant effect). Same basis as the t/2381 out-of-scope NO-GO; no registerable threshold.
- **`attribution_text` is the decisive structural fact:** 2,117/10,972 (19%) carry one and **none score <0.462**; the entire low tail is the 8,855 without one.
- **Downstream-flag-pollution premise is empirically absent:** M5-v1 (t/2357), t/2288, and the OOS guard all skip no-`attribution_text` key_points, so the tail never reaches them. Real harm is **corpus pollution** (confident wrong assignments), not flag inflation.

## Design (for TL decision)
Reject the cosine guard. If corpus hygiene is wanted: a **narrow deterministic structural pre-filter** (type-1 noise only, ~0.6–0.9%) at chunk ingestion, quarantine-first, with a zero-false-positive gate on the genuine-weak population. Off-topic-but-real is a separate relevance-gate concern (extraction prompt), not this filter.

**Decision requested:** proceed with the narrow structural pre-filter on the corpus-hygiene rationale, or close t/2392 as "characterized — no guard warranted at this yield"?

Full analysis + reproducible harnesses (`classify_noise.py`, `verify_attr.py`, `mode_crosstab.py`) in `research/comp-linguist/analyses/t2392-extraction-noise/`. (Classification JSON not committed — contains real SSN/PII from the corpus.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)