### PR TITLE
fix(bridge): downgrade expected getDataRoot 403 out of FR error level (t/2395)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRecord = vi.fn();
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: mockRecord, intern: (_ns: string, v: string) => v }),
+}));
+
+vi.mock('../../lib/analyticsEmitter', () => ({
+  trackAICall: vi.fn(),
+}));
+
+import { instrumentBridge } from '../instrumentBridge';
+import type { AppAPI } from '../types';
+
+/** Build a minimal AppAPI whose only method rejects with the given httpStatus. */
+function apiRejectingWith(method: string, httpStatus?: number): AppAPI {
+  const err = Object.assign(new Error(`HTTP ${httpStatus ?? 'network'}`), { httpStatus });
+  return { [method]: () => Promise.reject(err) } as unknown as AppAPI;
+}
+
+/** Return the failure-record the wrapped call emitted (the last recorded event). */
+function lastRecord(): { level: string; message: string; data?: { http_status?: number } } {
+  return mockRecord.mock.calls.at(-1)?.[0] as { level: string; message: string; data?: { http_status?: number } };
+}
+
+describe('instrumentBridge — expected-status downgrade (t/2395)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('downgrades an expected 403 on getDataRoot to debug', async () => {
+    const api = instrumentBridge(apiRejectingWith('getDataRoot', 403));
+    await expect((api as unknown as { getDataRoot: () => Promise<string> }).getDataRoot()).rejects.toThrow();
+
+    const rec = lastRecord();
+    expect(rec.level).toBe('debug');
+    expect(rec.message).toBe('bridge.getDataRoot expected 403');
+    expect(rec.data?.http_status).toBe(403);
+  });
+
+  it('keeps a NON-expected status on getDataRoot at error (no blanket downgrade)', async () => {
+    const api = instrumentBridge(apiRejectingWith('getDataRoot', 500));
+    await expect((api as unknown as { getDataRoot: () => Promise<string> }).getDataRoot()).rejects.toThrow();
+
+    const rec = lastRecord();
+    expect(rec.level).toBe('error');
+    expect(rec.message).toBe('bridge.getDataRoot failed');
+  });
+
+  it('keeps a 403 on an unlisted method at error (per-method allowlist)', async () => {
+    const api = instrumentBridge(apiRejectingWith('loadEdges', 403));
+    await expect((api as unknown as { loadEdges: () => Promise<unknown> }).loadEdges()).rejects.toThrow();
+
+    const rec = lastRecord();
+    expect(rec.level).toBe('error');
+    expect(rec.message).toBe('bridge.loadEdges failed');
+  });
+
+  it('still records the event when downgraded (ADR-003 — level drops, record stays)', async () => {
+    const api = instrumentBridge(apiRejectingWith('getDataRoot', 403));
+    await expect((api as unknown as { getDataRoot: () => Promise<string> }).getDataRoot()).rejects.toThrow();
+
+    // start (debug) + failure (debug) — the failure event is still present
+    const failure = mockRecord.mock.calls
+      .map((c) => c[0] as { message: string })
+      .find((e) => e.message === 'bridge.getDataRoot expected 403');
+    expect(failure).toBeDefined();
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
@@ -110,6 +110,25 @@ const SKIP = new Set([
   'adminReviewStats', 'adminReviewConfigured',
 ]);
 
+/**
+ * Bridge methods where a specific HTTP status is an EXPECTED, non-error outcome —
+ * the caller handles it gracefully (e.g. returns a default). Such rejections are
+ * recorded at `debug` instead of `error`, so flight-recorder dumps aren't polluted
+ * by a false alarm on every session, while ADR-003 is honored (the event is still
+ * recorded; only the LEVEL drops). Keep this narrow and PER-METHOD: a blanket
+ * status downgrade would mask a real authorization bug on some other call
+ * (TL optionality-aware condition, t/1339 / t/1340).
+ */
+const EXPECTED_STATUS: Record<string, ReadonlySet<number>> = {
+  // 403 for non-admin/anonymous users; App.tsx catches it and returns '' (t/2395).
+  getDataRoot: new Set([403]),
+};
+
+/** True when `httpStatus` is a known non-error outcome for `method` (see EXPECTED_STATUS). */
+function isExpectedStatus(method: string, httpStatus: number | undefined): boolean {
+  return httpStatus !== undefined && (EXPECTED_STATUS[method]?.has(httpStatus) ?? false);
+}
+
 /** Categorize bridge methods for the recorder. */
 function inferCategory(method: string): string {
   if (method.startsWith('generate') || method.startsWith('startChat') || method === 'nliClassify') return 'ai';
@@ -160,11 +179,12 @@ export function instrumentBridge(raw: AppAPI): AppAPI {
         const httpStatus = typeof (err as { httpStatus?: unknown }).httpStatus === 'number'
           ? (err as { httpStatus: number }).httpStatus
           : undefined;
+        const expected = !isAI && isExpectedStatus(key, httpStatus);
         getGlobalRecorder()?.record({
           type: isAI ? 'ai.error' : 'system.error',
           component: recorder?.intern('component', 'bridge') as string | number,
-          level: 'error',
-          message: `bridge.${key} failed (sync)`,
+          level: expected ? 'debug' : 'error',
+          message: expected ? `bridge.${key} expected ${httpStatus} (sync)` : `bridge.${key} failed (sync)`,
           duration_ms,
           error: normalizeError(err),
           data: { method: key, category, ...(httpStatus !== undefined && { http_status: httpStatus }) },
@@ -204,11 +224,12 @@ export function instrumentBridge(raw: AppAPI): AppAPI {
           const httpStatus = typeof (err as { httpStatus?: unknown }).httpStatus === 'number'
             ? (err as { httpStatus: number }).httpStatus
             : undefined;
+          const expected = !isAI && isExpectedStatus(key, httpStatus);
           recorder?.record({
             type: isAI ? 'ai.error' : 'system.error',
             component: recorder.intern('component', 'bridge') as string | number,
-            level: 'error',
-            message: `bridge.${key} failed`,
+            level: expected ? 'debug' : 'error',
+            message: expected ? `bridge.${key} expected ${httpStatus}` : `bridge.${key} failed`,
             duration_ms,
             error: normalizeError(err),
             data: { method: key, category, ...(httpStatus !== undefined && { http_status: httpStatus }) },


### PR DESCRIPTION
## What

`instrumentBridge` logged `bridge.getDataRoot failed` at **level:error** for the 403 every anonymous/non-admin session receives on startup. The caller (`App.tsx`) already handles it — catches, re-logs at `warn`, returns `''`. The bridge-level error record was a duplicate false alarm on every session, polluting flight-recorder dumps (t/2395, same class as t/1339 / t/1340).

## Fix

Added a narrow **per-method** `EXPECTED_STATUS` allowlist in `instrumentBridge.ts`. A listed `(method, status)` pair records at `debug` instead of `error`; everything else stays `error`.

- **Not a blanket 403 downgrade** — that would mask a genuine authorization bug on some other bridge call (TL optionality-aware condition, t/1339#1 / t/1340#1).
- **ADR-003 honored** — the event is still recorded; only the LEVEL drops.
- Only `getDataRoot: 403` is listed today. Applied to both the async-rejection and sync-throw handlers.

## Tests (new `instrumentBridge.test.ts`, 4)

- expected 403 on `getDataRoot` → `debug`
- non-expected 500 on `getDataRoot` → `error` (no blanket downgrade)
- 403 on an unlisted method (`loadEdges`) → `error` (per-method)
- record still emitted when downgraded

## Verify

`tsc` clean; scoped vitest 4/4 pass; eslint 0 errors (2 pre-existing complexity warnings, untouched functions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
