### PR TITLE
fix(community): version listing index so toEntry schema changes bust cache (t/2384)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/communityListingIndex.test.ts
+++ b/taxonomy-editor/src/server/__tests__/communityListingIndex.test.ts
@@ -145,4 +145,65 @@ describe('community listing index (t/726)', () => {
     expect(ids(second)).toEqual(['2', '1']);
     expect(mem.itemReads('debate-')).toBe(0); // served from index
   });
+
+  // ── Index versioning (t/2384) ─────────────────────────────────────────────
+  //
+  // A toEntry schema change must bust the cached index so new fields appear
+  // immediately — the count-only staleness check doesn't catch this.
+
+  function debateFileWithModel(id: string) {
+    return JSON.stringify({
+      id, title: `Debate ${id}`, created_at: '2026-01-01', updated_at: '2026-06-01',
+      phase: 'synthesis',
+      debate_model: 'claude-sonnet-5',
+      transcript: [{ type: 'opening' }, { type: 'statement' }, { type: 'statement' }],
+    });
+  }
+
+  it('old bare-array index (pre-versioning) is ignored → fresh rebuild returns new fields', async () => {
+    mem.put(path.join(debatesDir(), 'debate-m.json'), debateFileWithModel('m'));
+    // Simulate the stale pre-t/2362 index: a raw array with no model/turn_count.
+    mem.put(indexPath(debatesDir()), JSON.stringify([
+      { id: 'm', title: 'Debate m', created_at: '2026-01-01', updated_at: '2026-06-01', phase: 'synthesis', community_metadata: null },
+    ]));
+
+    mem.resetReads();
+    const result = await userContext.runWithUser(authedCtx, () => community.listCommunityDebates());
+
+    expect(result.length).toBe(1);
+    const entry = result[0] as { model?: string; turn_count?: number };
+    expect(entry.model).toBe('claude-sonnet-5');
+    expect(entry.turn_count).toBe(3); // opening + statement + statement
+    expect(mem.itemReads('debate-')).toBeGreaterThan(0); // full scan ran — stale cache skipped
+  });
+
+  it('index with wrong schema version is ignored → fresh rebuild returns new fields', async () => {
+    mem.put(path.join(debatesDir(), 'debate-m.json'), debateFileWithModel('m'));
+    // Simulate a versioned index from a previous toEntry shape (debate-v1 → current is debate-v2).
+    mem.put(indexPath(debatesDir()), JSON.stringify({
+      version: 'debate-v1',
+      entries: [{ id: 'm', title: 'Debate m', created_at: '2026-01-01', updated_at: '2026-06-01', phase: 'synthesis', community_metadata: null }],
+    }));
+
+    mem.resetReads();
+    const result = await userContext.runWithUser(authedCtx, () => community.listCommunityDebates());
+
+    expect(result.length).toBe(1);
+    const entry = result[0] as { model?: string; turn_count?: number };
+    expect(entry.model).toBe('claude-sonnet-5');
+    expect(entry.turn_count).toBe(3);
+    expect(mem.itemReads('debate-')).toBeGreaterThan(0); // full scan ran — stale version skipped
+  });
+
+  it('matching version index is served without per-file reads', async () => {
+    mem.put(path.join(debatesDir(), 'debate-m.json'), debateFileWithModel('m'));
+    // Build a valid current-version index.
+    await userContext.runWithUser(authedCtx, () => community.listCommunityDebates());
+
+    mem.resetReads();
+    const result = await userContext.runWithUser(authedCtx, () => community.listCommunityDebates());
+
+    expect((result[0] as { model?: string }).model).toBe('claude-sonnet-5');
+    expect(mem.itemReads('debate-')).toBe(0); // served from valid versioned index
+  });
 });

--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -50,11 +50,21 @@ export function isAdmin(userId?: string): boolean {
 
 const COMMUNITY_INDEX_FILE = '_index.json';
 
+// Bump when toEntry shape changes so stale caches are replaced on next list.
+const CHAT_INDEX_VERSION = 'chat-v1';
+const DEBATE_INDEX_VERSION = 'debate-v2'; // v2: added model + turn_count (t/2362/t/2384)
+
 interface ListingIndexSpec<T> {
   dir: string;
   prefix: string;
   toEntry: (parsed: any) => T;
   malformedMessage: string;
+  version: string;
+}
+
+interface ListingIndex<T> {
+  version: string;
+  entries: T[];
 }
 
 /** Direct-child item files in `dir` matching `prefix` (excludes `_index.json`). */
@@ -86,25 +96,35 @@ async function rebuildListingIndex<T>(spec: ListingIndexSpec<T>): Promise<T[]> {
     }
   }
   // Best-effort: a read-only context (or exhausted API) just keeps full-scanning.
+  const index: ListingIndex<T> = { version: spec.version, entries };
   await backend.writeFile(
     path.join(spec.dir, COMMUNITY_INDEX_FILE),
-    JSON.stringify(entries, null, 2),
+    JSON.stringify(index, null, 2),
   ).catch((err) => { log.server.warn({ err }, 'Community listing index write failed (best-effort)'); });
   return entries;
 }
 
 /**
  * Serve a community listing from its `_index.json`, rebuilding when the index is
- * absent (cold start) or its entry count no longer matches the directory. When a
- * stale index exists, the cached copy is returned immediately and the rebuild
- * runs in the background. Returns entries unsorted — callers apply their own sort.
+ * absent (cold start), its version doesn't match the current toEntry schema, or its
+ * entry count no longer matches the directory. A version mismatch (toEntry schema
+ * change) forces a synchronous rebuild so callers always get up-to-date fields.
+ * A count drift returns the cached copy immediately and rebuilds in the background.
+ * Returns entries unsorted — callers apply their own sort.
  */
 async function listViaIndex<T>(spec: ListingIndexSpec<T>): Promise<T[]> {
   const backend = getUserContentBackend();
   let cached: T[] | null = null;
   try {
     const raw = await backend.readFile(path.join(spec.dir, COMMUNITY_INDEX_FILE));
-    if (raw !== null) cached = JSON.parse(raw) as T[];
+    if (raw !== null) {
+      const parsed = JSON.parse(raw);
+      // Old format was a bare array; new format is { version, entries }.
+      // Any version mismatch (incl. old format) → cache miss → synchronous rebuild.
+      if (!Array.isArray(parsed) && parsed?.version === spec.version) {
+        cached = (parsed as ListingIndex<T>).entries;
+      }
+    }
   } catch { /* telemetry — silent by design */ cached = null; }
 
   if (cached !== null) {
@@ -139,6 +159,7 @@ export async function listCommunityChats(): Promise<unknown[]> {
   const items = await listViaIndex<CommunityChatEntry>({
     dir: communityChatsDir(),
     prefix: 'chat-',
+    version: CHAT_INDEX_VERSION,
     malformedMessage: 'Skipping malformed community chat file',
     toEntry: (parsed) => ({
       id: parsed.id,
@@ -156,6 +177,7 @@ export async function listCommunityDebates(): Promise<unknown[]> {
   const items = await listViaIndex<CommunityDebateEntry>({
     dir: communityDebatesDir(),
     prefix: 'debate-',
+    version: DEBATE_INDEX_VERSION,
     malformedMessage: 'Skipping malformed community debate file',
     toEntry: (parsed) => ({
       id: parsed.id,


### PR DESCRIPTION
## Summary

- **Root cause:** `listViaIndex` only checked staleness by file count; a `toEntry` schema change (t/2362 added `model`/`turn_count`) produces the same count, so the pre-fix `_index.json` was served indefinitely after deploy
- **Fix:** add a `version` field to `ListingIndexSpec` and embed it in the persisted index as `{ version, entries }`; any mismatch (including the old bare-array format) forces a synchronous rebuild
- **`DEBATE_INDEX_VERSION` bumped to `'debate-v2'`** so the stale staging/prod index is bust on first request after this lands — no separate operational step needed

## Test plan

- [x] 3 new regression tests in `communityListingIndex.test.ts`: old bare-array format, wrong version string, matching-version cache hit (0 item reads)
- [x] All 8 tests pass (`npx vitest run src/server/__tests__/communityListingIndex.test.ts`)
- [ ] Staging: verify `GET /api/community/debates` returns `model`/`turn_count` after deploy (unblocks t/2362)

Closes t/2384. Unblocks t/2362.

Co-Authored-By: Server Community (Orca) <main.taxonomy-editor-src-server-community@ai-triad-research.orca.local>

Generated with [Claude Code](https://claude.com/claude-code)