### PR TITLE
fix(server): add owned_by to /api/debates/:id 404 body (t/2396)

### DIFF
--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -121,7 +121,7 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
     catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'debates', level: 'warn', message: 'Failed to load debate session', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
       let owned_by = 'unknown';
-      try { if (await community.loadCommunityItem('debates', id)) owned_by = 'community'; } catch { /* silent */ }
+      try { if (await community.loadCommunityItem('debates', id)) owned_by = 'community'; } catch { /* telemetry — silent by design */ }
       error(res, String(err), 404, err, { storageUserId: getStorageUserId(), owned_by });
     }
   });

--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -14,6 +14,7 @@ import type { ServerResponse } from 'http';
 import { json, error, param } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import * as fileIO from '../storage/fileIO.js';
+import * as community from '../community/community.js';
 import * as ai from '../ai/aiBackends.js';
 import { getStorageUserId, getAnonymousSessionId } from '../security/userContext.js';
 import * as rateLimiter from '../security/rateLimiter.js';
@@ -115,10 +116,13 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
   });
 
   get('/api/debates/:id', async (req, res) => {
-    try { json(res, await fileIO.loadDebateSession(param(req, 'id', '/api/debates/:id'))); }
+    const id = param(req, 'id', '/api/debates/:id');
+    try { json(res, await fileIO.loadDebateSession(id)); }
     catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'debates', level: 'warn', message: 'Failed to load debate session', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      error(res, String(err), 404, err, { storageUserId: getStorageUserId() });
+      let owned_by = 'unknown';
+      try { if (await community.loadCommunityItem('debates', id)) owned_by = 'community'; } catch { /* silent */ }
+      error(res, String(err), 404, err, { storageUserId: getStorageUserId(), owned_by });
     }
   });
 


### PR DESCRIPTION
## Summary

- When `GET /api/debates/:id` returns 404, the response body now includes `owned_by: 'community' | 'unknown'`
- After the user-scoped lookup fails, a best-effort community check runs: if the debate ID exists in the community store, `owned_by: 'community'` (wrong endpoint — should use `/api/community/debates/:id`); otherwise `owned_by: 'unknown'` (session rotation or genuinely missing)
- Community lookup failure is silent (try/catch) — never blocks the 404 response
- `storageUserId` (requester) is unchanged; `owned_by` is additive

## Test plan

- [ ] `tsc --project tsconfig.server.json --noEmit` — clean (exit 0 ✓)
- [ ] CI green on `05279119`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
