### PR TITLE
chore: null-safe localeCompare in sort comparators (t/2389)

### DIFF
--- a/taxonomy-editor/src/renderer/components/conflict/ConflictsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/conflict/ConflictsTab.tsx
@@ -73,10 +73,10 @@ export function ConflictsTab() {
   // Alpha-bucket grouping (zero-dependency, always available)
   const alphaClusters = useMemo(() => {
     if (conflicts.length === 0) return [];
-    const sorted = [...conflicts].sort((a, b) => a.claim_label.localeCompare(b.claim_label));
+    const sorted = [...conflicts].sort((a, b) => (a.claim_label ?? '').localeCompare(b.claim_label ?? ''));
     const buckets = new Map<string, string[]>();
     for (const c of sorted) {
-      const first = (c.claim_label[0] || '#').toUpperCase();
+      const first = ((c.claim_label ?? '')[0] || '#').toUpperCase();
       const key = /[A-Z]/.test(first) ? first : '#';
       if (!buckets.has(key)) buckets.set(key, []);
       buckets.get(key)!.push(c.claim_id);

--- a/taxonomy-editor/src/renderer/components/organizations/OrganizationsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/organizations/OrganizationsTab.tsx
@@ -77,7 +77,7 @@ export function OrganizationsTab() {
         return stance && (stance.tier === 'leans_toward' || stance.tier === 'champions');
       });
     }
-    return list.slice().sort((a, b) => a.name.localeCompare(b.name));
+    return list.slice().sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
   }, [organizations, searchQuery, filters]);
 
   return (

--- a/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.tsx
@@ -52,14 +52,17 @@ function matchesSearch(e: EntitySummary, q: string): boolean {
   );
 }
 
+/** Null-safe locale compare — real data can carry null in string-typed fields (t/2389, cf. the t/2385 title crash). */
+const cmpStr = (a?: string | null, b?: string | null): number => (a ?? '').localeCompare(b ?? '');
+
 function compareEntities(a: EntitySummary, b: EntitySummary, sort: SortKey): number {
   switch (sort) {
-    case 'type': return a.entity_type.localeCompare(b.entity_type) || a.name.localeCompare(b.name);
-    case 'status': return a.status.localeCompare(b.status) || a.name.localeCompare(b.name);
-    case 'confidence': return (b.confidence ?? -1) - (a.confidence ?? -1) || a.name.localeCompare(b.name);
-    case 'modified': return (b.last_modified ?? '').localeCompare(a.last_modified ?? '') || a.name.localeCompare(b.name);
+    case 'type': return cmpStr(a.entity_type, b.entity_type) || cmpStr(a.name, b.name);
+    case 'status': return cmpStr(a.status, b.status) || cmpStr(a.name, b.name);
+    case 'confidence': return (b.confidence ?? -1) - (a.confidence ?? -1) || cmpStr(a.name, b.name);
+    case 'modified': return cmpStr(b.last_modified, a.last_modified) || cmpStr(a.name, b.name);
     case 'name':
-    default: return a.name.localeCompare(b.name);
+    default: return cmpStr(a.name, b.name);
   }
 }
 


### PR DESCRIPTION
## Summary

Audit follow-up to the t/2385 title-`localeCompare` crash (t/2389). Data-sourced string fields typed as `string` can be null in real JSON data — `null.localeCompare()` is a hard render crash. Audited the four flagged sort sites; guarded the three that need it.

## Audit result

| Site | Field | Finding | Action |
|---|---|---|---|
| ConflictsTab:76,79 | `claim_label` | data-sourced; typed optional in sibling conflict types; also crashes at `claim_label[0]` | **guard** both |
| OrganizationsTab:80 | `name` | data-sourced | **guard** |
| EntityBrowserPanel:57,58,62 | `entity_type`/`status`/`name` | data-sourced; file already guards `confidence`/`last_modified` in same comparator | **guard** via `cmpStr()` helper |
| SimilarSearchPanel:165 | `description` | provably non-null (`getDescription` typed `: string` with `''` fallbacks; `label` is `\|\| r.id`) | **no change** |

`cmpStr()` extraction keeps `compareEntities` under the eslint complexity ceiling (inline `?? ''` would have pushed it to 28) and folds in the existing `last_modified` guard.

## Verification

- renderer tsc — 0 errors
- eslint (3 files) — 0 errors; warning count 9→8 (introduced none; removed the transient complexity warning; remaining 8 are pre-existing inline-style + OrganizationsTab complexity)
- vitest `EntityBrowserPanel.test.tsx` — 11/11
- vite build — OK

Behavior-preserving (`?? ''` is a no-op when the field is present). Self-cert: **/trivial-change**.

Closes t/2389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
