### PR TITLE
feat(debate-diagnostics): wire BookmarkLink into 17 GUI placements (t/2394)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/DiagnosticsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/DiagnosticsPanel.tsx
@@ -9,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { EntryView } from './EntryView';
 import { OverviewView } from './OverviewView';
 import './DiagnosticsPanel.css';
+import { BookmarkLink } from '../../shared';
 
 export function DiagnosticsPanel() {
   const { selectedDiagEntry, selectDiagEntry, activeDebate } = useDebateStore(
@@ -98,6 +99,7 @@ export function DiagnosticsPanel() {
             }} className="btn btn-sm diag-panel-action-btn" title="Show how each Perspective's taxonomy context and citations evolve across turns">
               Perspective Progression
             </button>
+            <BookmarkLink docPath="docs/why-not-just-prompt-a-debate.md" size="xs" />
           </div>
         </div>
         <div className="diagnostics-panel-body">

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/DiagnosticsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/DiagnosticsPanel.tsx
@@ -9,7 +9,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { EntryView } from './EntryView';
 import { OverviewView } from './OverviewView';
 import './DiagnosticsPanel.css';
-import { BookmarkLink } from '../../shared';
+import { BookmarkLink } from '../../shared/BookmarkLink';
 
 export function DiagnosticsPanel() {
   const { selectedDiagEntry, selectDiagEntry, activeDebate } = useDebateStore(

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/WhatIfSection.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/WhatIfSection.tsx
@@ -8,6 +8,7 @@ import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
 import type { ArgumentNetworkNode, ArgumentNetworkEdge } from '../../../types/debate';
 import { CollapsibleSection, speakerLabel } from './helpers';
+import { BookmarkLink } from '../../shared';
 
 /** What-If Mode (D-Q6): counterfactual strength propagation via DF-QuAD. */
 export function WhatIfSection({ nodes, edges }: { nodes: ArgumentNetworkNode[]; edges: ArgumentNetworkEdge[] }) {
@@ -67,6 +68,7 @@ export function WhatIfSection({ nodes, edges }: { nodes: ArgumentNetworkNode[]; 
 
   return (
     <CollapsibleSection title={`What-If Mode — counterfactual strength propagation${active ? ' (active)' : ''}`} defaultOpen={active}>
+      <BookmarkLink docPath="docs/mid-debate-gap-analysis-design.md" size="xs" />
       <div className="whatif-header">
         <button
           className={`btn btn-sm whatif-toggle ${active ? 'whatif-toggle-active' : ''}`}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/WhatIfSection.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/WhatIfSection.tsx
@@ -8,7 +8,7 @@ import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
 import type { ArgumentNetworkNode, ArgumentNetworkEdge } from '../../../types/debate';
 import { CollapsibleSection, speakerLabel } from './helpers';
-import { BookmarkLink } from '../../shared';
+import { BookmarkLink } from '../../shared/BookmarkLink';
 
 /** What-If Mode (D-Q6): counterfactual strength propagation via DF-QuAD. */
 export function WhatIfSection({ nodes, edges }: { nodes: ArgumentNetworkNode[]; edges: ArgumentNetworkEdge[] }) {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
@@ -17,7 +17,7 @@ import { DiagSearchContext, SearchBar, speakerLabel } from './helpers';
 import { OverviewTabRouter } from './OverviewTabRouter';
 import { EntryDetailRouter } from './EntryDetailRouter';
 import { CopyLinkButton } from '../../shared/CopyLinkButton';
-import { BookmarkLink } from '../../shared';
+import { BookmarkLink } from '../../shared/BookmarkLink';
 import type { OverviewTab } from './types';
 import type { DebateSession } from '../../../types/debate';
 import type { RefObject } from 'react';

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
@@ -17,6 +17,7 @@ import { DiagSearchContext, SearchBar, speakerLabel } from './helpers';
 import { OverviewTabRouter } from './OverviewTabRouter';
 import { EntryDetailRouter } from './EntryDetailRouter';
 import { CopyLinkButton } from '../../shared/CopyLinkButton';
+import { BookmarkLink } from '../../shared';
 import type { OverviewTab } from './types';
 import type { DebateSession } from '../../../types/debate';
 import type { RefObject } from 'react';
@@ -321,6 +322,7 @@ function DiagnosticsHeader({
       >
         {showHelp ? 'Close Help' : 'Help'}
       </button>
+      <BookmarkLink docPath="docs/debate-diagnostics-field-guide.md" size="xs" />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CitationsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CitationsTab.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import type { EntryDiagnostics } from '../../../../types/debate';
 import { Highlight } from '../helpers';
 import './CitationsTab.css';
+import { BookmarkLink } from '../../../shared';
 
 interface CitationResolutionDiag {
   path: 'tool-calling' | 'bank-scrub';
@@ -304,6 +305,7 @@ export function CitationsTab({ diag, searchQuery }: CitationsTabProps) {
 
   return (
     <div className="ctn-root">
+      <BookmarkLink docPath="docs/citation-resolution-design.md" size="xs" />
       <SummaryCards citationResDiag={citationResDiag} />
       <MatchedCitations citationResDiag={citationResDiag} />
       <FabricatedCitations citationResDiag={citationResDiag} />

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CitationsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CitationsTab.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import type { EntryDiagnostics } from '../../../../types/debate';
 import { Highlight } from '../helpers';
 import './CitationsTab.css';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 
 interface CitationResolutionDiag {
   path: 'tool-calling' | 'bank-scrub';

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ExclusionGuardTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ExclusionGuardTab.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { Section } from '../helpers';
 import type { EntryDiagnostics } from '../../../../types/debate';
+import { BookmarkLink } from '../../../shared';
 
 interface ExclusionViolation {
   claim_id: string;
@@ -70,6 +71,7 @@ function ClaimExtractionGuardSection({ diag }: ExclusionGuardTabProps) {
 
   return (
     <Section title="Claim Extraction Guard" defaultOpen>
+      <BookmarkLink docPath="docs/scope-enforcement.md" anchor="claim-extraction-guard" size="xs" />
       {exclusionGuard ? (
         <>
           <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginBottom: 6 }}>
@@ -104,6 +106,7 @@ function DraftScopeCheckSection({ diag }: ExclusionGuardTabProps) {
 
   return (
     <Section title="Draft Scope Check" defaultOpen>
+      <BookmarkLink docPath="docs/scope-enforcement.md" anchor="draft-scope-check" size="xs" />
       {scopeDriftCheck ? (
         <>
           <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginBottom: 6 }}>
@@ -140,6 +143,7 @@ function TaxonomyInjectionSection({ diag }: ExclusionGuardTabProps) {
   };
   return (
     <Section title={`Taxonomy Context Injection — ${tit.considered} considered, ${tit.demoted} demoted`} defaultOpen>
+      <BookmarkLink docPath="docs/scope-enforcement.md" anchor="taxonomy-context-injection-demotion" size="xs" />
       {tit.demoted > 0 && tit.demoted_nodes ? (
         tit.demoted_nodes.map((n, i) => (
           <div key={i} style={{
@@ -167,6 +171,7 @@ function SituationInjectionSection({ diag }: ExclusionGuardTabProps) {
   };
   return (
     <Section title={`Situation Injection — ${sit.considered} considered, ${sit.excluded} excluded`} defaultOpen>
+      <BookmarkLink docPath="docs/scope-enforcement.md" anchor="situation-injection-filtering" size="xs" />
       {sit.excluded > 0 && sit.excluded_situations ? (
         sit.excluded_situations.map((s, i) => (
           <div key={i} style={{

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ExclusionGuardTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ExclusionGuardTab.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { Section } from '../helpers';
 import type { EntryDiagnostics } from '../../../../types/debate';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 
 interface ExclusionViolation {
   claim_id: string;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { Highlight, CopyButton } from '../helpers';
 import './LookaheadTab.css';
+import { BookmarkLink } from '../../../shared';
 
 export interface LookaheadTabProps {
   lookaheadDiag: any;
@@ -115,6 +116,7 @@ export function LookaheadTab(props: LookaheadTabProps) {
           color: lookaheadDiag.final_pass ? 'var(--success)' : 'var(--danger)',
         }}>{lookaheadDiag.final_pass ? '✓ PASS' : '✗ FAIL'}</span>
         <span>LOOKAHEAD</span>
+        <BookmarkLink docPath="docs/utility-function-and-lookahead.md" anchor="how-the-lookahead-gate-works" size="xs" />
         <span>{(lookaheadDiag.elapsed_ms / 1000).toFixed(1)}s</span>
         {lookaheadDiag.regen_triggered && <span className="look-regen-badge">REGEN TRIGGERED</span>}
       </div>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { Highlight, CopyButton } from '../helpers';
 import './LookaheadTab.css';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 
 export interface LookaheadTabProps {
   lookaheadDiag: any;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/AdaptiveStagingTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/AdaptiveStagingTab.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import type { DebateSession } from '../../../../types/debate';
 import './AdaptiveStagingTab.css';
+import { BookmarkLink } from '../../../shared';
 
 interface AdaptiveStagingDiagnostics {
   phases: { phase: string; rounds: number[]; exit_reason: string }[];
@@ -72,6 +73,7 @@ export function AdaptiveStagingTab({ debate }: AdaptiveStagingTabProps) {
       {diag && <>
       <div className="adst-diag-header">
         <span className="adst-title">Adaptive Staging Diagnostics</span>
+        <BookmarkLink docPath="docs/adaptive-staging-signals.md" size="xs" />
         <button onClick={downloadSignals} className="adst-download-btn">
           Download Signals JSON
         </button>
@@ -126,6 +128,7 @@ export function AdaptiveStagingTab({ debate }: AdaptiveStagingTabProps) {
       {diag.signal_telemetry.length > 0 && (
         <div>
           <div className="adst-section-header">Signal Telemetry (per round)</div>
+          <BookmarkLink docPath="docs/adaptive-staging-signals.md" anchor="signal-glossary" size="xs" />
           <div className="adst-telemetry-scroll">
             <table className="adst-telemetry-table">
               <thead>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/AdaptiveStagingTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/AdaptiveStagingTab.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import type { DebateSession } from '../../../../types/debate';
 import './AdaptiveStagingTab.css';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 
 interface AdaptiveStagingDiagnostics {
   phases: { phase: string; rounds: number[]; exit_reason: string }[];

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
@@ -9,6 +9,7 @@ import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
 import { useTaxonomyStore } from '../../../../hooks/useTaxonomyStore';
 import { INodeRow } from '../shared';
+import { BookmarkLink } from '../../../shared';
 import { Highlight, speakerLabel } from '../helpers';
 import type { OverviewTab } from '../types';
 
@@ -135,6 +136,7 @@ export function ArgumentNetworkTab({
         <span className="ant-header-summary">
           {an.nodes.length} I-nodes · {caCount} CA · {raCount} RA{modCount > 0 ? ` · ${modCount} moderator decisions` : ''}
         </span>
+        <BookmarkLink docPath="docs/reading-the-argument-network.md" anchor="node-types" size="xs" />
         <button
           onClick={() => setAllExpanded(!allExpanded)}
           className="ant-expand-btn"
@@ -350,6 +352,7 @@ function ArgNetMinimap({ nodes, edges }: { nodes: ArgumentNetworkNode[]; edges: 
         <span className="ant-legend-item">
           <span className="ant-legend-support" /> support
         </span>
+        <BookmarkLink docPath="docs/aif-debate-tool-analysis.md" size="xs" />
       </div>
     </div>
   );

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
@@ -9,7 +9,7 @@ import { computeQbafStrengths } from '@lib/debate/qbaf';
 import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
 import { useTaxonomyStore } from '../../../../hooks/useTaxonomyStore';
 import { INodeRow } from '../shared';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 import { Highlight, speakerLabel } from '../helpers';
 import type { OverviewTab } from '../types';
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/EmotionalRegisterTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/EmotionalRegisterTab.tsx
@@ -14,6 +14,7 @@ import {
   type AffectProfile,
 } from '@lib/debate/affectSignals';
 import { getDebatePhase } from '@lib/debate/types';
+import { BookmarkLink } from '../../../shared';
 
 interface EmotionalRegisterTabProps {
   debate: DebateSession;
@@ -120,6 +121,7 @@ export function EmotionalRegisterTab({ debate, setSelectedEntry, setLocalOverrid
       <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)', marginBottom: 12 }}>
         Emotional register across {turnData.length} statements. Affect computed from lexical signals (Wachsmuth Emotional Appeal).
       </div>
+      <BookmarkLink docPath="docs/emotional-registers.md" size="xs" />
 
       {/* Concluding-outrage warnings */}
       {warnings.length > 0 && (

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/EmotionalRegisterTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/EmotionalRegisterTab.tsx
@@ -14,7 +14,7 @@ import {
   type AffectProfile,
 } from '@lib/debate/affectSignals';
 import { getDebatePhase } from '@lib/debate/types';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 
 interface EmotionalRegisterTabProps {
   debate: DebateSession;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ReflectionsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ReflectionsTab.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { POVER_INFO } from '../../../../types/debate';
 import type { DebateSession } from '../../../../types/debate';
+import { BookmarkLink } from '../../../shared';
 
 interface ReflectionEdit {
   edit_type: string;
@@ -46,6 +47,7 @@ export function ReflectionsTab({ debate }: ReflectionsTabProps) {
       <div style={{ marginBottom: 8, color: 'var(--text-muted)', fontSize: '0.7rem' }}>
         {allResults.length} debater{allResults.length !== 1 ? 's' : ''} reflected, {totalEdits} edit{totalEdits !== 1 ? 's' : ''} proposed{approved > 0 ? `, ${approved} applied` : ''}
       </div>
+      <BookmarkLink docPath="docs/debate-system-overview.md" anchor="reflections" size="xs" />
       {allResults.map((r, ri) => {
         const poverInfo = Object.values(POVER_INFO).find(p => p.pov === r.pover);
         const color = poverInfo?.color || '#888';

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ReflectionsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ReflectionsTab.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { POVER_INFO } from '../../../../types/debate';
 import type { DebateSession } from '../../../../types/debate';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 
 interface ReflectionEdit {
   edit_type: string;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/UtilityTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/UtilityTab.tsx
@@ -7,7 +7,7 @@ import { speakerLabel } from '../helpers';
 import { UTILITY_WEIGHTS } from '../types';
 import type { UtilitySnapshot } from '../types';
 import { ScoreBadge } from '../shared';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 
 interface UtilityTabProps {
   debate: DebateSession;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/UtilityTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/UtilityTab.tsx
@@ -7,6 +7,7 @@ import { speakerLabel } from '../helpers';
 import { UTILITY_WEIGHTS } from '../types';
 import type { UtilitySnapshot } from '../types';
 import { ScoreBadge } from '../shared';
+import { BookmarkLink } from '../../../shared';
 
 interface UtilityTabProps {
   debate: DebateSession;
@@ -37,6 +38,7 @@ export function UtilityTab({ debate, perTurnUtilities, setSelectedEntry, setLoca
       <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)', marginBottom: 12 }}>
         Per-agent utility across {perTurnUtilities.length} turns. Composite = weighted sum of position strength, attack effectiveness, and crux engagement.
       </div>
+      <BookmarkLink docPath="docs/utility-function-and-lookahead.md" size="xs" />
 
       {/* Per-speaker summary cards */}
       {speakers.map(speaker => {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
@@ -11,6 +11,7 @@ import type { SpeakerId } from '../../../../types/debate';
 import { explainNodeStrength } from '../../../../utils/qbafExplain';
 import { SUB_SCORE_TIPS, BELIEF_KEYS } from './constants';
 import { ScoreBadge } from './ScoreBadge';
+import { BookmarkLink } from '../../../shared';
 
 // NOTE: speakerLabel stays in DiagnosticsWindow.tsx (parent). A local copy is provided here
 // for self-contained compilation. When integrating, pass speakerLabel as a prop or import
@@ -94,6 +95,7 @@ function SubScoreRow({ node, onUpdateSubScore }: { node: ArgumentNetworkNode; on
           </span>
         );
       })}
+      <BookmarkLink docPath="docs/bdi-sub-score-calibration.md" size="xs" />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
@@ -11,7 +11,7 @@ import type { SpeakerId } from '../../../../types/debate';
 import { explainNodeStrength } from '../../../../utils/qbafExplain';
 import { SUB_SCORE_TIPS, BELIEF_KEYS } from './constants';
 import { ScoreBadge } from './ScoreBadge';
-import { BookmarkLink } from '../../../shared';
+import { BookmarkLink } from '../../../shared/BookmarkLink';
 
 // NOTE: speakerLabel stays in DiagnosticsWindow.tsx (parent). A local copy is provided here
 // for self-contained compilation. When integrating, pass speakerLabel as a prop or import


### PR DESCRIPTION
## Summary

- Adds `BookmarkLink` (xs size) at 17 locations across 12 debate-diagnostics components, linking each panel/tab to its relevant explainer doc on GitHub
- Depends on PR #751 (BookmarkLink shared component by Rosetta Stone), already on main

## Placements

| Component | Doc linked |
|---|---|
| DiagnosticsWindow header | debate-diagnostics-field-guide.md |
| DiagnosticsPanel actions | why-not-just-prompt-a-debate.md |
| ArgumentNetworkTab header | reading-the-argument-network.md#node-types |
| ArgumentNetworkTab legend | aif-debate-tool-analysis.md |
| UtilityTab description | utility-function-and-lookahead.md |
| AdaptiveStagingTab title | adaptive-staging-signals.md |
| AdaptiveStagingTab signal telemetry | adaptive-staging-signals.md#signal-glossary |
| EmotionalRegisterTab description | emotional-registers.md |
| ReflectionsTab summary | debate-system-overview.md#reflections |
| ExclusionGuardTab × 4 sections | scope-enforcement.md (per-section anchors) |
| LookaheadTab header | utility-function-and-lookahead.md#how-the-lookahead-gate-works |
| CitationsTab | citation-resolution-design.md |
| INodeRow SubScoreRow | bdi-sub-score-calibration.md |
| WhatIfSection | mid-debate-gap-analysis-design.md |

## Test plan

- [ ] Renderer TSC: 0 errors ✓
- [ ] ESLint: 0 errors (267 pre-existing warnings) ✓
- [ ] Scoped vitest debate-diagnostics: 416 passed ✓
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)