### PR TITLE
fix(debate): guard saveDebate against read-only community debates (t/2401)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/saveDebateReadOnly.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/saveDebateReadOnly.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// saveDebate communityReadOnly guard (t/2401). A read-only community debate must never
+// PUT to the personal endpoint, even when a component-level caller (the DebateWorkspace
+// auto-save timer, ClarificationPanel) bypasses the store.ts subscriber guard. The harness
+// (all vi.mock/vi.hoisted setup) is imported FIRST so its hoisted mocks register before the
+// store import resolves.
+import { describe, it, expect } from 'vitest';
+import { mockApi, makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+
+describe('saveDebate — communityReadOnly guard (t/2401)', () => {
+  it('does NOT persist when the loaded debate is read-only community', async () => {
+    useDebateStore.getState().loadDebateFromData(makeSession(), { readOnly: true });
+    expect(useDebateStore.getState().communityReadOnly).toBe(true);
+
+    await useDebateStore.getState().saveDebate('test-mutation');
+
+    expect(mockApi.saveDebateSession).not.toHaveBeenCalled();
+  });
+
+  it('persists normally for an editable (personal) debate', async () => {
+    useDebateStore.getState().loadDebateFromData(makeSession(), { readOnly: false });
+    expect(useDebateStore.getState().communityReadOnly).toBe(false);
+
+    await useDebateStore.getState().saveDebate('test-mutation');
+
+    expect(mockApi.saveDebateSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -971,8 +971,13 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
   },
 
   saveDebate: async (caller: string) => {
-    const { activeDebate, _saveInFlight } = get();
+    const { activeDebate, _saveInFlight, communityReadOnly } = get();
     if (!activeDebate) return;
+    // t/2401: authoritative read-only guard for ALL callers. A read-only community debate
+    // must never PUT to the personal endpoint. The store.ts auto-save subscriber has its own
+    // guard, but component-level callers (the DebateWorkspace auto-save timer, ClarificationPanel)
+    // bypass the subscriber — so the single source of truth lives here in the action.
+    if (communityReadOnly) return;
 
     if (_saveInFlight) {
       set({ _saveDirty: true });


### PR DESCRIPTION
## Summary

Read-only community debates could leak a `PUT /api/debates/<communityId>` to the **personal** endpoint (t/2401). The only `communityReadOnly` guard lived in the `store.ts` auto-save subscriber, but component-level callers — the `DebateWorkspace` auto-save timer (`DebateWorkspace.tsx:999`) and `ClarificationPanel` — call `saveDebate` directly and bypass it. Loading a community debate (`communityReadOnly: true`) + any state mutation → timer → `saveDebate` → personal-endpoint PUT.

## Fix

Option (a) from t/2401#1: a **single authoritative guard in the `saveDebate` action**, covering all present + future callers instead of per-call-site guards (the whack-a-mole this bug is).

```ts
const { activeDebate, _saveInFlight, communityReadOnly } = get();
if (!activeDebate) return;
if (communityReadOnly) return; // t/2401
```

The `store.ts:65` subscriber guard stays as a harmless debounce-avoidance optimization (avoids scheduling a timer that would no-op).

Entirely in Rosetta Stone scope (`useDebateStore/`); nothing changed in `debate-workspace/`.

## Verification

- vitest `saveDebateReadOnly.test.ts` — read-only → `saveDebateSession` NOT called; editable → persists (positive control)
- renderer tsc — 0 errors
- eslint — 0 errors
- full `useDebateStore` suite — 125/125

Self-cert: **/trivial-change**. Closes t/2401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
