### PR TITLE
fix(debate): community export calls loadCommunityDebateSession (t/2400)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.export.test.ts
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.export.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Contract tests for community debate pdf/markdown export routing (t/2400).
+// Guards: community debate export calls loadCommunityDebateSession, not loadDebateSession.
+
+import { describe, it, expect, vi } from 'vitest';
+import { resolveExportLoader } from './DebateTab';
+import type { SessionRowData } from './DebateTable';
+
+function makeRow(overrides: Partial<SessionRowData> = {}): SessionRowData {
+  return { id: 'row-1', title: 'Test', created_at: '2026-01-01', updated_at: '2026-01-01', phase: '', ...overrides };
+}
+
+describe('resolveExportLoader — community export discriminator (t/2400)', () => {
+  it('calls loadCommunityDebateSession — not loadPersonal — for community=true (markdown/pdf)', async () => {
+    const loadPersonal = vi.fn().mockResolvedValue({});
+    const loadCommunity = vi.fn().mockResolvedValue({});
+    await resolveExportLoader(makeRow({ id: 'c-1', community: true }), loadPersonal, loadCommunity);
+    expect(loadCommunity).toHaveBeenCalledWith('c-1');
+    expect(loadPersonal).not.toHaveBeenCalled();
+  });
+
+  it('calls loadPersonal — not loadCommunity — for community=false', async () => {
+    const loadPersonal = vi.fn().mockResolvedValue({});
+    const loadCommunity = vi.fn().mockResolvedValue({});
+    await resolveExportLoader(makeRow({ id: 'p-1', community: false }), loadPersonal, loadCommunity);
+    expect(loadPersonal).toHaveBeenCalledWith('p-1');
+    expect(loadCommunity).not.toHaveBeenCalled();
+  });
+
+  it('calls loadPersonal when community is absent (personal debates — backward compat)', async () => {
+    const loadPersonal = vi.fn().mockResolvedValue({});
+    const loadCommunity = vi.fn().mockResolvedValue({});
+    await resolveExportLoader(makeRow({ id: 'p-2' }), loadPersonal, loadCommunity);
+    expect(loadPersonal).toHaveBeenCalledWith('p-2');
+    expect(loadCommunity).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -153,6 +153,18 @@ function formatDateLong(iso: string): string {
   });
 }
 
+/**
+ * Picks the correct session loader for pdf/markdown export (t/2400).
+ * Exported for unit testing — do not call from outside DebateTab.
+ */
+export function resolveExportLoader(
+  rowSession: Pick<SessionRowData, 'id' | 'community'>,
+  loadPersonal: (id: string) => Promise<unknown>,
+  loadCommunity: (id: string) => Promise<unknown>,
+): Promise<unknown> {
+  return rowSession.community ? loadCommunity(rowSession.id) : loadPersonal(rowSession.id);
+}
+
 export function DebateTab() {
   const {
     sessions, sessionsLoading, loadSessions,
@@ -401,7 +413,7 @@ export function DebateTab() {
   const handleRowCommunityExport = useCallback(async (cd: CommunityDebate, format: string) => {
     if (format === 'markdown' || format === 'pdf') {
       setPendingExportFormat(format);
-      setPendingExportSession({ id: cd.id, title: cd.title, updated_at: cd.updated_at, phase: cd.phase ?? '', created_at: cd.updated_at });
+      setPendingExportSession({ id: cd.id, title: cd.title, updated_at: cd.updated_at, phase: cd.phase ?? '', created_at: cd.updated_at, community: true });
       return;
     }
     try {
@@ -500,7 +512,7 @@ export function DebateTab() {
             if (rowSession) {
               // Table row export — load full session then export.
               // (activeDebate is not set in table mode; Condition 2)
-              api.loadDebateSession(rowSession.id).then(full => {
+              resolveExportLoader(rowSession, api.loadDebateSession, api.loadCommunityDebateSession).then(full => {
                 void runExport(fmt, opts, full);
               }).catch((err: Error) => {
                 getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-tab', level: 'error', message: 'Row pdf/md export: failed to load session', error: { name: err.name ?? 'Error', message: String(err), stack: err.stack } });

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -24,6 +24,8 @@ export interface SessionRowData {
   topic_text?: string;
   model?: string;
   turn_count?: number;
+  /** True when this row represents a community debate — drives onConfirm to call loadCommunityDebateSession (t/2400). */
+  community?: boolean;
 }
 
 export type AuthStatus = { anonymous?: boolean } | null | undefined;


### PR DESCRIPTION
## Summary
- Adds `community?: boolean` discriminator to `SessionRowData` so `onConfirm` can distinguish community vs personal exports
- Extracts `resolveExportLoader()` as a testable pure helper that routes to `loadCommunityDebateSession` (community) or `loadDebateSession` (personal)
- Updates `handleRowCommunityExport` setter to stamp `community: true` on the pending export session

## Test plan
- [ ] `DebateTab.export.test.ts` — 3 contract tests: `community=true` routes to loadCommunityDebateSession, `community=false` and absent route to loadPersonal (backward compat)
- [ ] Full debate suite: 66/66 pass in wt-2400

Fixes t/2400
