### PR TITLE
fix(ci): normalize short SHA to full SHA in container ci-gate (t/2402)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -20,7 +20,7 @@ on:
         default: 'true'
         type: boolean
       sha:
-        description: 'Commit SHA to build (must have CI-green status). Leave blank to use dispatched ref HEAD — racy at fleet commit rate.'
+        description: 'Commit SHA to build (must have CI-green status). Full 40-char SHA required — short SHAs are auto-expanded via API. Leave blank to use dispatched ref HEAD — racy at fleet commit rate.'
         required: false
         type: string
 
@@ -46,6 +46,17 @@ jobs:
           TARGET_SHA: ${{ inputs.sha || github.sha }}
         run: |
           echo "Checking CI status for ${TARGET_SHA}..."
+
+          # Normalize short SHA to full 40-char SHA (GitHub head_sha filter requires full SHA)
+          if [ ${#TARGET_SHA} -lt 40 ]; then
+            FULL_SHA=$(gh api "repos/${{ github.repository }}/commits/${TARGET_SHA}" --jq '.sha' 2>/dev/null || echo "")
+            if [ -z "$FULL_SHA" ]; then
+              echo "::error::Cannot resolve '${TARGET_SHA}' to a commit. Check the SHA and try again."
+              exit 1
+            fi
+            echo "Expanded short SHA ${TARGET_SHA} → ${FULL_SHA}"
+            TARGET_SHA="$FULL_SHA"
+          fi
 
           # Get the latest CI run for this commit
           RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${TARGET_SHA}&per_page=1" \


### PR DESCRIPTION
## Summary
- GitHub's `head_sha` filter requires a full 40-char SHA; short SHAs return empty results
- ci-gate was failing with "No CI run found" when `--field sha=<short>` was passed
- Auto-expand short SHAs via `gh api .../commits/{sha}` before querying workflow runs

## Test plan
- [ ] Dispatch `container.yml` with a short SHA (e.g. `c677b588`) — ci-gate expands and passes
- [ ] Dispatch with full SHA — unchanged behavior (length check skips normalization)
- [ ] Dispatch with invalid SHA — ci-gate fails with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)