### PR TITLE
fix(debate): re-land dropped fail-safe communityReadOnly default + tests (t/2399 TL#6.3)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/webBridgeOpenDebateWindow.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/webBridgeOpenDebateWindow.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// web-bridge openDebateWindow URL construction (t/2399, TL "complement" unit test).
+// Verifies the desktop path threads `source` into the popout hash so a community
+// debate opens against the community endpoint. The parse side is covered by
+// popoutLoad.test.ts (parseDebateHash reads source=community back out).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => undefined }));
+
+import { api } from './web-bridge';
+
+describe('web-bridge openDebateWindow — source propagation (t/2399)', () => {
+  let openSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // jsdom is a desktop UA (no iPad/Android), so openAppWindow uses window.open.
+    openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  it('appends &source=community to the debate-window hash when source is given', async () => {
+    await api.openDebateWindow('abc-123', 'community');
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const url = String(openSpy.mock.calls[0][0]);
+    expect(url).toContain('debate-window?id=abc-123&source=community');
+  });
+
+  it('omits source entirely when not provided (personal open, backward-compatible)', async () => {
+    await api.openDebateWindow('abc-123');
+    const url = String(openSpy.mock.calls[0][0]);
+    expect(url).toContain('debate-window?id=abc-123');
+    expect(url).not.toContain('source=');
+  });
+
+  it('url-encodes both id and source', async () => {
+    await api.openDebateWindow('a/b 1', 'com munity');
+    const url = String(openSpy.mock.calls[0][0]);
+    expect(url).toContain('id=a%2Fb%201');
+    expect(url).toContain('source=com%20munity');
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/loadDebateFromDataReadOnly.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/loadDebateFromDataReadOnly.test.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// loadDebateFromData read-only default (t/2399, TL#6.3 + Diagnostics test item 4).
+// The harness (all vi.mock/vi.hoisted setup) is imported FIRST so its hoisted mocks
+// register before the store import resolves.
+import { describe, it, expect } from 'vitest';
+import { makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+
+describe('loadDebateFromData — communityReadOnly default (t/2399)', () => {
+  it('defaults to read-only (fail-safe) when readOnly is not specified', () => {
+    // loadDebateFromData is the raw-data load entry; its only caller is the community
+    // popout (readOnly:true). A caller that omits readOnly is loading data of unknown
+    // provenance and must NOT become silently editable + auto-saving over it.
+    useDebateStore.getState().loadDebateFromData(makeSession());
+    expect(useDebateStore.getState().communityReadOnly).toBe(true);
+  });
+
+  it('honors an explicit readOnly:true (community load)', () => {
+    useDebateStore.getState().loadDebateFromData(makeSession(), { readOnly: true });
+    expect(useDebateStore.getState().communityReadOnly).toBe(true);
+  });
+
+  it('honors an explicit readOnly:false (caller opts into editability)', () => {
+    useDebateStore.getState().loadDebateFromData(makeSession(), { readOnly: false });
+    expect(useDebateStore.getState().communityReadOnly).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -717,13 +717,18 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
       audience: session.audience ?? 'policymakers',
       openingOrder: session.opening_order ?? [],
       selectedDiagEntry: null,
-      communityReadOnly: opts?.readOnly ?? false,
+      // Fail-safe default (t/2399 TL#6.3): loadDebateFromData is the raw-data load entry, and its
+      // only caller today is the community popout (readOnly:true). A future caller that omits
+      // readOnly is loading data of unknown provenance — default to read-only so it can never
+      // silently become editable + auto-save over foreign/community content (store.ts autosave
+      // guard keys off communityReadOnly). Personal loads go through loadDebate, not this path.
+      communityReadOnly: opts?.readOnly ?? true,
       _lastSyncedVersion: session._saveVersion ?? 0,
       _lastSyncedSnapshot: structuredClone(session),
     });
     setGapInjectionCount(session.gap_injections?.length ?? 0);
     getGlobalRecorder()?.setEventContext({ debate_id: session.id, run_id: runId });
-    getGlobalRecorder()?.record({ type: 'state.load', component: 'debate-store', level: 'info', debate_id: session.id, run_id: runId, message: 'Debate loaded from data', data: { phase: session.phase, transcript_length: session.transcript.length, readOnly: opts?.readOnly ?? false } });
+    getGlobalRecorder()?.record({ type: 'state.load', component: 'debate-store', level: 'info', debate_id: session.id, run_id: runId, message: 'Debate loaded from data', data: { phase: session.phase, transcript_length: session.transcript.length, readOnly: opts?.readOnly ?? true } });
   },
 
   deleteDebate: async (id) => {


### PR DESCRIPTION
## Summary

Dropped-fix recovery. My #755 commit `6703cfa4` was lost when the #755 branch was rebased/rebuilt before merge (TL confirmed via merge-base: `6703cfa4` is not in `origin/main`). The bridge change + DebateUI's contract test landed; this restores the three items that didn't:

- **sessionSlice.ts:720 (TL#6.3)** — fail-safe `communityReadOnly` default: read-only when `loadDebateFromData` omits `readOnly`. Inert today (sole caller — the community popout — passes `readOnly:true`); closes the latent future-editable risk TL#6.3 flagged.
- **loadDebateFromData safe-default test** (Diagnostics test item 4).
- **web-bridge `openDebateWindow` URL test** (TL "complement").

## Verification (current main, c677b588 base)
- renderer tsc — 0 errors
- eslint — 0 errors
- `useDebateStore` + popout suites — 131/131

Routed to TL for review + self-merge per p/336#66. Closes the t/2399 rebase regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
