### PR TITLE
fix(bookmark-link): correct repo URL + land 6 missing explainer docs

### DIFF
--- a/docs/adaptive-staging-signals.md
+++ b/docs/adaptive-staging-signals.md
@@ -1,0 +1,190 @@
+# Adaptive Staging Signal Reference
+
+**Audience:** Researchers and developers diagnosing why a debate changed phase when it did, why it stalled, or why the engine vetoed or forced a transition.  
+**Related docs:** `debate-system-overview.md`, `aggregative-semantics-review.md`, `debate-diagnostics-field-guide.md`
+
+---
+
+## What adaptive staging does
+
+The debate engine doesn't run for a fixed number of rounds. Instead, it monitors a set of signals after each turn and decides whether to stay in the current phase, advance to the next, or — if quality degrades — regress to a prior phase. This is **adaptive staging**.
+
+The logic lives in a **predicate**: a function that reads the current signal state and returns an action (`stay`, `advance`, `regress`, `force`, `veto`). The predicate runs once per turn, after the turn is committed. Its decision is recorded in the signal telemetry alongside the signal values that produced it.
+
+---
+
+## Phase model
+
+The debate moves through three phases in order:
+
+| Phase | Purpose | Typical behavior |
+|---|---|---|
+| **Confrontation** | Establish positions; surface disagreements | Each agent asserts core claims; few attacks; crux set crystallizes |
+| **Argumentation** | Direct engagement with opponent claims | High CA-edge rate; crux engagement rises; saturation grows |
+| **Consolidation** | Synthesis and resolution | Attack rate drops; agents integrate opponent arguments or reaffirm positions with refinement |
+
+The engine advances from confrontation → argumentation when saturation and convergence signals cross their thresholds. It advances from argumentation → consolidation when saturation is high and convergence has plateaued. Consolidation ends the debate.
+
+Phases do not have a fixed round count. A debate can stay in confrontation for 2 rounds or 12, depending on how quickly the signals move.
+
+---
+
+## Signal glossary
+
+The signal telemetry table uses abbreviated column headers. This section defines each one.
+
+### Sat — Saturation score
+
+**What it measures:** The fraction of the configured crux set that has at least one attributed I-node with `computed_strength ≥ 0.3`. A crux is "saturated" when at least one agent has made a non-trivial claim about it.
+
+**Range:** 0.0 (no cruxes addressed) → 1.0 (all cruxes have at least one strong claim).
+
+**Role in phasing:** Saturation is the primary advance signal out of confrontation. When enough cruxes have claims, the debate has established enough shared ground to move into direct argumentation. A debate stuck at low saturation has agents asserting positions that don't connect to the core contested questions.
+
+**What to look for:** Saturation that rises quickly in confrontation and then plateaus in argumentation is normal — the cruxes were addressed early and subsequent rounds are deepening the engagement. Saturation that never rises above ~0.3 suggests the debate scope is misconfigured (agents are arguing about adjacent topics that don't touch the cruxes) or the crux set is too narrow.
+
+---
+
+### Conv — Convergence score
+
+**What it measures:** The cosine similarity between the centroid of all claims from each pair of agents. High convergence means agents are making semantically similar claims; low convergence means they are far apart in argument space.
+
+**Range:** 0.0 (debaters arguing about completely different things) → 1.0 (debaters making essentially the same claims).
+
+**Role in phasing:** Convergence is a *two-directional* signal. Early in a debate, low convergence is healthy — agents are staking out distinct positions. Moderate convergence in argumentation (0.4–0.6) means agents are engaging with each other's claim space. High convergence (> 0.7) in argumentation is a warning sign: debaters are restating each other rather than resolving disagreements, and the moderator will likely intervene. Very high convergence in consolidation may legitimately signal resolution.
+
+**What to look for:** Convergence that jumps from low to high without a corresponding rise in crux_engagement means the agents are *saying similar things* but haven't engaged the actual contested points — false consensus. The moderator's intervention system watches for this pattern and responds with reframing moves.
+
+---
+
+### Conf — Confidence (global)
+
+**What it measures:** A composite of three internal confidence estimates:
+- **Extraction confidence** — how consistently the engine extracted well-formed claims from turns (high variance = low confidence)
+- **Stability confidence** — how stable the argument network structure is round-to-round (frequent large restructurings = low stability)
+- **Global confidence** — the weighted composite displayed in the telemetry table
+
+**Range:** 0.0 → 1.0. Values below 0.4 are highlighted in red in the diagnostics table.
+
+**Role in phasing:** Low confidence can **defer** a phase transition even when other signals say advance. A confidence deferral means "the signals say we should move, but the signal data itself is unreliable enough that we should wait." The `confidence_deferrals` stat card counts how many times this happened in a debate.
+
+**What to look for:** Persistent low confidence (Conf < 0.4 for many rounds) suggests extraction quality problems — the model is producing malformed claims or the debate topic is producing ambiguous output. Check the Draft tab quality gate for repeated parse failures.
+
+---
+
+### TC — Topic Coherence
+
+**What it measures:** How semantically close new claims are to the crux centroid (the center of mass of the configured crux embeddings). High topic coherence means the debate is staying on topic; low coherence means claims are drifting away from the core questions.
+
+**Displayed as:** `1 − raw_signal`. The raw signal is a drift distance (high = far from centroid = bad); the displayed value inverts it so that high TC = high coherence = good.
+
+**Color coding in the telemetry table:**
+- TC > 0.7 → green (on-topic)
+- TC 0.4–0.7 → amber (moderate drift)
+- TC < 0.4 → red (significant drift)
+
+**Role in phasing:** TC is primarily an early-warning signal for scope drift. The exclusion guard acts on individual claims; TC acts on the debate as a whole. Sustained low TC across many rounds often precedes a batch of exclusion guard violations.
+
+**What to look for:** TC that drops suddenly after a specific turn — find that turn in the transcript and check its Exclusion tab. The claim that caused the drift is usually visible as a scope drift warning.
+
+---
+
+### Net — Network size
+
+**What it measures:** The number of I-nodes currently in the argument network at the end of this round.
+
+**Role in phasing:** Network size is a scaling input to several other signals and informs GC (garbage collection) decisions. A network that grows very large (> 80 nodes) can degrade extraction quality — the context window fills with claim-tracking data — and may trigger a GC event.
+
+**What to look for:** Network size that grows steadily every round without any GC events in a long debate may indicate the GC threshold is set too high for the debate's configured scope.
+
+---
+
+## Predicate actions
+
+After reading all signals, the predicate returns one of five actions:
+
+### `stay`
+
+No transition. Signals are within normal range for the current phase; continue accumulating turns. The most common action in any given round.
+
+### `advance`
+
+Move to the next phase. Triggered when the current phase's exit conditions are met — typically saturation and convergence crossing thresholds specific to that phase transition. A highlighted row (amber background) in the telemetry table marks when `advance` fired.
+
+### `regress`
+
+Return to a prior phase. Triggered when quality signals indicate the debate has backslid — typically when convergence drops sharply (agents have diverged after a period of engagement) combined with saturation falling (previously addressed cruxes are now contested again). After a regression, the exit threshold for the affected transition is **ratcheted up** — the bar is higher to advance through the same transition again. The `regressions` section of the Adaptive Staging tab shows which cruxes triggered each regression and the new threshold.
+
+### `force`
+
+Override normal flow and advance regardless of signal state. Used when the engine determines the current phase is unproductive — for example, confrontation has run for many rounds without saturation rising, suggesting agents are stuck. The `forces_fired` stat card counts forced transitions. A high force count relative to total phases means the engine is working around stalled signals rather than flowing through them naturally.
+
+### `veto`
+
+Block an advance that the signals would otherwise trigger. Used when the engine determines conditions aren't safe to advance despite signals crossing threshold — typically when `Conf` (confidence) is too low to trust the signal readings, or when a cooldown period has not elapsed since the last transition. The `vetoes_fired` stat card counts vetoed transitions.
+
+---
+
+## Confidence deferrals
+
+A **confidence deferral** occurs when the predicate would have returned `advance` based on saturation and convergence, but global confidence is below the deferral threshold. Instead of advancing, the predicate returns `stay` and increments the deferral counter.
+
+Deferrals are healthy in small numbers — they mean the engine is being appropriately cautious when signal data is noisy. A high deferral count (relative to total rounds) suggests the extraction pipeline is struggling: check the Draft tab for repeated quality gate failures, or check model availability logs if a backend was degraded during the debate run.
+
+---
+
+## GC events — Argument network garbage collection
+
+When the argument network grows large, the engine prunes low-value nodes to keep extraction context manageable. A **GC event** removes I-nodes that meet pruning criteria:
+
+- Computed QBAF strength below a floor threshold (effectively defeated and no longer influencing the graph)
+- No outgoing or incoming edges (isolated nodes that no other claim references)
+- Age above a recency threshold (very old nodes from early rounds that have not been re-engaged)
+
+The GC Events section shows:
+- **Round** — when the GC ran
+- **Before / After** — node count before and after pruning
+- **Pruned** — how many nodes were removed
+
+GC does not affect claims that have been committed to the commitment ledger — only their AN representation is removed. The claim still exists in the transcript and the commitment record.
+
+**What to look for:** GC that runs frequently and removes many nodes each time may indicate the network is growing faster than the debate is resolving — agents are adding claims without attacking enough to reduce the effective network size. Check the CA-edge-to-I-node ratio in the Argument Network tab.
+
+---
+
+## Regressions
+
+A regression entry records:
+- **Round** — when the regression was detected
+- **Crux** — which crux triggered it (the crux whose saturation status reversed)
+- **Threshold after** — the new, higher saturation threshold required to advance through this transition again
+
+Regressions are rare in well-configured debates. A debate with multiple regressions on the same crux suggests agents are repeatedly engaging and then abandoning that crux — a sign the crux may be underspecified or that the agents lack adequate taxonomy grounding for it.
+
+---
+
+## Downloading signals JSON
+
+The "Download Signals JSON" button in the Adaptive Staging tab exports the full `adaptive_staging_diagnostics` object as a JSON file. This contains:
+
+- `phases` — the complete phase timeline with round ranges and exit reasons
+- `signal_telemetry` — every per-round signal reading including the full `signals` object (not just the columns shown in the table), the raw confidence components, and the full predicate result
+- `gc_events`, `regressions`, and summary stats
+
+For debates longer than ~20 rounds, the JSON is more practical than the in-app table for finding patterns — it can be loaded into a notebook or queried with `jq`.
+
+---
+
+## Common diagnostic questions
+
+**Why did the debate stay in confrontation so long?**  
+Check Sat column in telemetry. If saturation was low for many rounds, agents weren't attributing claims to cruxes. Filter the Argument Network to "Attributed only" and check whether the attributed nodes are actually on crux topics. If few are, the crux set and the debate topic may be misaligned.
+
+**Why did the debate advance without fully resolving cruxes?**  
+Check whether a `force` action fired. If so, the engine overrode the normal advance conditions. Also check the Gaps overview tab — unaddressed cruxes at end-of-debate are visible there.
+
+**Why was a transition vetoed?**  
+Find the veto row in telemetry (it will show `action: veto`). Check the `Conf` value in that row — confidence below threshold is the most common veto cause. Also check `veto_active` in the predicate result (included in the JSON export).
+
+**Why did the debate regress?**  
+Find the regression entry in the Regressions section. Note the crux ID, then filter the Argument Network to that crux's taxonomy node ID to see what happened to the claims referencing it in the rounds around the regression.

--- a/docs/bdi-sub-score-calibration.md
+++ b/docs/bdi-sub-score-calibration.md
@@ -1,0 +1,167 @@
+# BDI Sub-Score Calibration Guide
+
+**Audience:** Researchers using the diagnostics window to understand claim strength scores, and anyone editing the belief sub-score sliders to inject domain expertise.  
+**Related docs:** `subsystem-debate-engine.md`, `qbaf-explainability-review.md`, `reading-the-argument-network.md`, `utility-function-and-lookahead.md`
+
+---
+
+## What BDI sub-scores are
+
+Every I-node (claim) in the Argument Network carries a **BDI category** — Belief, Desire, or Intention — drawn from the BDI (Belief-Desire-Intention) model of rational agents. The category determines what kind of claim is being made:
+
+- **Belief** — an assertion about how the world is. Factual, empirical, or descriptive. *"Current frontier AI systems require enormous compute to train."*
+- **Desire** — an assertion about how the world should be. Normative, value-laden, goal-expressing. *"AI development should be governed by international treaty."*
+- **Intention** — an assertion about what will be done. Action-oriented, mechanism-specifying, implementation-committing. *"We will implement mandatory compute audits through the BIS."*
+
+Each category is evaluated on three **sub-scores** specific to that type of claim. The sub-scores combine into the claim's `base_strength`, which is the starting QBAF weight before edge propagation.
+
+---
+
+## The nine sub-scores
+
+### Belief sub-scores
+
+Belief claims are factual assertions. The three sub-scores evaluate how well the claim holds up to epistemic scrutiny.
+
+**`evidence_quality`** — How well-supported is this claim by cited evidence?
+- ≥ 0.7: strong evidence cited — specific studies, data, or authoritative sources directly support the claim
+- 0.4–0.69: partial or indirect evidence — the claim is plausible but the cited evidence is tangential or not conclusive
+- < 0.4: unsupported or speculative — claim is asserted without evidence, or evidence cited doesn't support it
+
+**`source_reliability`** — How credible and authoritative are the sources cited?
+- ≥ 0.7: authoritative, peer-reviewed, or official sources
+- 0.4–0.69: mixed or secondary sources — credible but not the strongest available
+- < 0.4: no sources, or sources with known reliability issues
+
+**`falsifiability`** — Can this claim be tested or disproven with observable evidence?
+- ≥ 0.7: clearly testable with specific criteria — the claim has identifiable conditions under which it would be false
+- 0.4–0.69: partially testable — some testable component but also unfalsifiable elements
+- < 0.4: unfalsifiable or purely theoretical — no conceivable evidence could disprove it
+
+`base_strength` for Belief claims = average of the three sub-scores.
+
+---
+
+### Desire sub-scores
+
+Desire claims are normative assertions about what should happen. The three sub-scores evaluate the normative quality of the claim.
+
+**`values_grounding`** — Is this value claim explicitly grounded in stated values or principles?
+- ≥ 0.7: explicitly ties to named values, ethical frameworks, or stated principles — *"because human autonomy requires..."*
+- 0.4–0.69: implicitly value-laden but not explicitly grounded — the claim expresses a value without naming it
+- < 0.4: value claim without clear normative basis — assertion without ethical warrant
+
+**`tradeoff_acknowledgment`** — Does the claim acknowledge competing tradeoffs or costs?
+- ≥ 0.7: explicitly names costs, risks, or competing values — *"while this would slow deployment, it would..."*
+- 0.4–0.69: mentions tradeoffs in passing without developing them
+- < 0.4: presents the position as cost-free or ignores obvious downsides
+
+**`precedent_citation`** — Does the claim cite relevant precedent, norms, or established practice?
+- ≥ 0.7: cites specific precedents, case law, or established international norms
+- 0.4–0.69: references general precedent without specifics
+- < 0.4: no precedent cited — purely aspirational with no grounding in existing practice
+
+`base_strength` for Desire claims = average of the three sub-scores.
+
+---
+
+### Intention sub-scores
+
+Intention claims specify actions, mechanisms, or implementation paths. The three sub-scores evaluate how actionable and realistic the claim is.
+
+**`mechanism_specificity`** — How specific is the proposed mechanism, action, or implementation path?
+- ≥ 0.7: concrete steps, named actors, defined timelines — *"the BIS would require quarterly compute reports from facilities above 10^25 FLOP/s"*
+- 0.4–0.69: general approach without implementation detail — *"governments should regulate compute"*
+- < 0.4: vague aspiration with no actionable mechanism — *"we need better AI governance"*
+
+**`scope_bounding`** — Are the boundaries, limitations, and applicability conditions defined?
+- ≥ 0.7: explicitly defines where the proposal applies and where it doesn't — includes carve-outs, thresholds, jurisdictional scope
+- 0.4–0.69: some boundaries mentioned but incomplete
+- < 0.4: unbounded claim with no defined limits — applies "everywhere" or "to all AI"
+
+**`failure_mode_addressing`** — Does the claim address what could go wrong or how failures would be handled?
+- ≥ 0.7: explicitly names failure scenarios and mitigations — *"if X fails, Y provides a backstop"*
+- 0.4–0.69: acknowledges risk without specific mitigation — *"there are risks but they are manageable"*
+- < 0.4: no consideration of failure modes — assumes the mechanism works as designed
+
+`base_strength` for Intention claims = average of the three sub-scores.
+
+---
+
+## Why Belief sub-scores default to 0.5
+
+The AI scoring for Belief sub-scores has low inter-rater reliability at Q-0 (the first calibration round, before any human adjustment):
+
+| Sub-score | Q-0 calibration *r* |
+|---|---|
+| `evidence_quality` | −0.12 to 0.20 |
+| `source_reliability` | −0.12 to 0.20 |
+| `falsifiability` | −0.12 to 0.20 |
+
+These correlation values mean the AI's initial Belief sub-score assignments are barely better than chance compared to expert human ratings. The reasons are structural: evaluating evidence quality requires knowing whether the cited evidence is actually good (which requires domain expertise the model may not have for niche claims), and evaluating falsifiability requires understanding what would count as disconfirmation (which the model often conflates with "is this claim uncertain?").
+
+**The design response:** Belief sub-scores default to 0.5 at extraction. This produces a neutral `base_strength = 0.5` — the claim enters the QBAF with equal initial weight regardless of how evidence-laden it sounds. A human reviewer with domain expertise is expected to adjust the sliders in the INodeRow expanded view to reflect actual evidence quality.
+
+This is intentional: it is better to start neutral and let humans calibrate than to propagate AI-assigned evidence scores that are systematically unreliable.
+
+---
+
+## Why Desire and Intention sub-scores are AI-scored
+
+Desire and Intention sub-scores have meaningfully higher Q-0 calibration:
+
+| Category | Sub-score | Q-0 calibration *r* |
+|---|---|---|
+| Desire | `values_grounding` | 0.65 |
+| Desire | `tradeoff_acknowledgment` | 0.65 |
+| Desire | `precedent_citation` | 0.65 |
+| Intention | `mechanism_specificity` | 0.71 |
+| Intention | `scope_bounding` | 0.71 |
+| Intention | `failure_mode_addressing` | 0.71 |
+
+These properties are more reliably detectable from the text itself: whether a claim names values, acknowledges tradeoffs, or specifies concrete mechanisms is largely a matter of what language is present in the claim — the model can score these from surface features with reasonable accuracy. Belief sub-scores require external knowledge; Desire and Intention sub-scores are more self-contained.
+
+As a result, Desire and Intention sub-scores are assigned by the extraction model and not defaulted to 0.5. They still appear in the INodeRow slider view and can be adjusted, but they start from a meaningful AI-assigned value rather than a neutral placeholder.
+
+---
+
+## How base_strength feeds into QBAF
+
+`base_strength` is the initial node weight in the QBAF graph — the claim's strength *before any attacks or supports are applied*. It sets the starting point for strength propagation:
+
+1. A claim with `base_strength = 0.8` starts strong. It takes sustained, weighted attacks to push its `computed_strength` below 0.3 (the "defeated" threshold).
+2. A claim with `base_strength = 0.3` starts weak. Even a single moderate attack can push it below the threshold.
+3. A claim with `base_strength = 0.5` (the Belief default) is neutral — its fate depends entirely on whether it receives attacks or supports.
+
+This means the Belief-score sliders in the diagnostics window are not cosmetic. Changing a Belief claim's slider values changes its `base_strength`, which propagates through the QBAF computation and changes `computed_strength` for every claim that has an edge relationship with it. The Argument Network tab reflects these changes live.
+
+See `docs/qbaf-explainability-review.md` for the mathematical details of how strength propagation works.
+
+---
+
+## Using the sliders
+
+In the diagnostics window, Belief I-nodes in the expanded INodeRow view show editable sliders for the three Belief sub-scores. The sliders are the mechanism for injecting domain expertise into the debate's formal record.
+
+**When to adjust:**
+- You know a cited source is authoritative (or retracted): adjust `source_reliability`
+- A claim sounds falsifiable in language but isn't actually testable: lower `falsifiability`
+- A claim is well-evidenced from your domain knowledge even if the model didn't detect it: raise `evidence_quality`
+
+**What changes downstream:**
+- `base_strength` is recomputed as the average of the adjusted sub-scores
+- QBAF propagation reruns with the new base_strength
+- `computed_strength` updates for the adjusted node and all nodes with edge relationships to it
+- `position_strength` in the Utility tab updates accordingly — adjusting a strong agent claim up makes their utility rise; adjusting a weak claim down makes it fall further
+
+**Desire and Intention sliders** are also editable but start from AI-assigned values rather than 0.5. Adjust these when the model's scoring clearly missed something — a claim that sounds like it specifies a mechanism but doesn't actually name any actors or timelines, or a value claim that sounds grounded but is actually circular.
+
+---
+
+## Relationship to confidence impact
+
+When a debate's argument network is used to update taxonomy node confidence (visible in the Confidence Impact section of the Argument Network tab), the `base_strength` of attacking claims directly influences the magnitude of the confidence change.
+
+A high-`base_strength` attack on a taxonomy node's associated claim produces a larger confidence drop in the node's `confidence_history` than a low-`base_strength` attack. This means Belief sub-score adjustments made in the diagnostics window can propagate all the way to the living taxonomy — a correction you make to a mis-scored evidence_quality slider can change whether the taxonomy considers a node's belief well-supported or contested.
+
+The `robustness` field in the Confidence Impact trace (shown as a "2× confirmed" chip) indicates when a confidence change was driven by multiple independent high-`base_strength` claims, not just one — making it more resistant to reversal in subsequent debates.

--- a/docs/debate-diagnostics-field-guide.md
+++ b/docs/debate-diagnostics-field-guide.md
@@ -1,0 +1,243 @@
+# Debate Diagnostics: Field Guide
+
+**Audience:** Researchers and developers who run debates and want to understand what the engine did and why.  
+**Related docs:** `debate-system-overview.md`, `debate-diagnostics-proposal.md`, `aif-debate-tool-analysis.md`, `debate-turn-validation.md`
+
+---
+
+## Two views, one data source
+
+Debate diagnostics appear in two places, both reading from the same live debate state:
+
+**Inline panel** — a resizable strip docked at the bottom of the Debate tab. Shows a quick summary of the active debate: topic scope, argument network size, per-turn utility, coverage, and an entry view when you click a turn. Good for monitoring a running debate or doing a fast post-run check.
+
+**Diagnostics window** — a separate always-on-top popout (open via the popout button in the panel or from the Debate tab toolbar). Shows the full inspection surface: all overview tabs, all per-turn tabs, the chat sidebar, and a persistent search bar. Use this for deep debugging — it stays open while you interact with the main window.
+
+The panel and window are synchronized. Clicking a transcript entry in either one selects it in both. The window also receives live IPC updates as a debate runs, so you can watch claims accumulate in real time.
+
+---
+
+## Overview tabs
+
+The left sidebar of the diagnostics window lists overview tabs — debate-level views that span all turns. The inline panel surfaces a condensed version of the most useful ones under its "Overview" mode.
+
+### Transcript
+
+The canonical record: every turn in order, with speaker, content, and turn metadata. Click any row to jump to its per-entry tabs. The `S1`, `S2`, … statement IDs used elsewhere in the window (AN source headers, moderator focus references) map to positions in this list.
+
+### Argument Network
+
+The QBAF argument graph built up turn by turn. See *Reading the Argument Network* (`docs/reading-the-argument-network.md`) for a full walkthrough. Quick orientation:
+
+- **I-nodes** are claims (what was asserted). Each row is one I-node.
+- **CA edges** are attacks (rebut / undercut / undermine). Shown in red.
+- **RA edges** are supports (inference scheme + warrant). Shown in green.
+- The **minimap** at the top provides a spatial overview — nodes cluster by speaker, edges show the attack/support structure.
+- The **filter bar** lets you narrow to unattributed claims (no taxonomy anchor), novel arguments (genuinely new, not in the taxonomy), or anchored claims (grounded in a specific taxonomy node).
+- **Moderator banners** appear between groups of claims, showing which speaker the moderator selected next and why.
+
+The "Confidence Impact" section at the bottom of this tab (when present) shows which taxonomy nodes had their `confidence`, `priority`, or `operationality` history updated as a result of this debate — the direct link between a debate's arguments and the living taxonomy.
+
+### Utility
+
+Per-agent utility across all turns, displayed as sparklines with a summary card per speaker. Utility is a composite of three dimensions:
+
+| Dimension | What it measures |
+|---|---|
+| `position_strength` | Mean computed QBAF strength of this agent's undefeated claims (≥ 0.3 threshold) |
+| `attack_effectiveness` | Fraction of opponent claims weakened below 0.3 by this agent's attacks |
+| `crux_engagement` | Fraction of identified debate cruxes this agent has addressed |
+
+Each bar in the sparkline represents one turn; darker bars are turns where that agent spoke. Click a bar to jump to that turn's entry detail. Trend arrows (↑ ↓ →) summarize the last three turns.
+
+Utility drives the **lookahead gate** — before each turn is committed, the engine simulates the proposed claims against the live argument network and checks that composite utility increases by at least a threshold. If not, the engine generates a revised draft. The Lookahead per-entry tab shows the full gate trace.
+
+### Adaptive Staging
+
+Shows how the debate moved through phases (confrontation → argumentation → consolidation) and what signals drove each transition. See `docs/adaptive-staging-signals.md` for the signal glossary (Sat, Conv, Conf, TC). Useful diagnostic questions this tab answers:
+
+- Why did the phase change when it did? → Phase Timeline, exit_reason column
+- Why didn't the debate advance past confrontation? → signal telemetry, check Sat (saturation) and Conv (convergence) stayed low
+- What was the peak argument network size before GC? → Peak network stat card, GC Events section
+- Were any phase transitions vetoed or forced? → Vetoes / Forces stat cards
+
+The "Download Signals JSON" button exports the full per-round telemetry for offline analysis.
+
+### Reflections
+
+Agent self-summaries produced at reflection checkpoints during the debate. Each agent describes (in its own words) what arguments it has made, what concessions it has acknowledged, and what it intends to pursue. Reflections feed back into subsequent drafts — an agent whose reflection accurately captures its position will generate more consistent subsequent turns than one whose reflection has drifted.
+
+If you see an agent contradicting itself between turns, compare the reflection to the transcript: the gap usually shows up here first.
+
+### Emotional Register
+
+Tracks rhetorical register shifts per turn (e.g., assertive → conciliatory → dismissive). The register taxonomy is defined in `docs/emotional-registers.md`. Useful for spotting when a debate becomes rhetorically repetitive (register stuck on one value for many turns) or when a speaker is consistently using a register inappropriate to their stance.
+
+### Convergence
+
+Shows convergence score evolution over time — how close the debaters' argument centroids are getting. High convergence (> ~0.7) without a corresponding resolution of cruxes suggests the debaters are restating each other rather than engaging. The moderator uses this signal to select speakers and trigger focus interventions.
+
+### Topic Scope
+
+The debate topic's configured scope: the crux set, out-of-scope exclusions, and which taxonomy nodes are in play. This is the ground truth the exclusion guard and scope drift check use. If claims are being flagged as out-of-scope unexpectedly, check here first to verify the scope is what you intended.
+
+### Commitments
+
+The commitment ledger: every claim each agent has explicitly asserted, conceded, or challenged. Unlike the transcript, the ledger persists — a concession made in round 2 is still visible in round 8 even if the transcript has scrolled past it. The moderator uses the ledger to prevent agents from walking back acknowledged concessions.
+
+### Gaps / Grounding / Lineage
+
+- **Gaps** — taxonomy nodes that are in scope but have not been touched by any claim in this debate. A high gap count means the debate is narrower than the configured scope.
+- **Grounding** — how well individual claims are anchored to specific taxonomy nodes and source documents. Low grounding = more speculative, less evidence-based debate.
+- **Lineage** — which source documents and taxonomy paths contributed to each turn's taxonomy references.
+
+### POV Progression / Prompt Diff / Flight Recorder Context
+
+Developer/diagnostics tabs:
+- **POV Progression** — how each agent's position vector has shifted round by round.
+- **Prompt Diff** — diffs between successive prompt versions used in the same debate run, useful for understanding how context accumulates.
+- **Flight Recorder Context** — the last N entries from the flight recorder at the time of each turn. Use this to correlate debate-level events with system-level events (errors, slow IPC calls, model fallbacks).
+
+---
+
+## Per-entry tabs
+
+Click any transcript row to open its per-entry tabs. These show the full pipeline trace for a single turn: what the engine was told, what it produced at each stage, and what checks it ran.
+
+### Brief
+
+The "situation brief" injected at the start of this turn — a compressed summary of the debate state as of this round, presented to the drafting agent. Shows what the engine considered most salient: cruxes, recent arguments, commitments, and the moderator's focus point. A brief that's too compressed (or missing key context) often explains why a subsequent draft missed the mark.
+
+### Plan
+
+The structured plan the agent produced before drafting: argument structure (point → evidence → taxonomy anchor), rhetorical strategy, and the planned crux targets. Shows `argumentation_structure` items with their taxonomy anchors — click an anchor to expand the taxonomy reference detail inline.
+
+If the draft diverged significantly from the plan, the discrepancy usually surfaces here: the plan asked for specific evidence, the draft generalized it away.
+
+### Draft
+
+The largest and most information-dense tab. Covers the full draft pipeline:
+
+**Draft stage attempts** — if the engine retried the draft (stage retries), all attempts are shown in order. Each attempt shows the raw response, quality gate results, and what triggered the retry.
+
+**Quality gate** — four binary checks the draft must pass:
+- `grounded` — at least one claim is traceable to a taxonomy node or source document
+- `falsifiable` — claims contain testable propositions, not purely normative assertions
+- `engages` — the draft addresses at least one prior argument or crux rather than being purely expository
+- `topic_aligned` — the draft stays within the configured topic scope
+
+**Off-scope drift classification** — if topic alignment failed, this section classifies *how* the draft drifted: tangential (adjacent but off-topic), generic (no specificity to the debate topic), or contradictory (directly violated scope constraints).
+
+**Orchestration runs** — the outer retry loop. A single orchestration run contains one or more stage retries. Multiple orchestration runs mean the entire turn pipeline was restarted, typically because the quality gate could not be passed after the stage retry budget was exhausted.
+
+**Turn validation trail** — see the Validation section below.
+
+### Claims
+
+Extracted claims from this turn's final draft: each claim with its BDI category (Belief / Desire / Intention), its `base_strength` (computed from BDI sub-scores), and its taxonomy attribution. Claims that end up as I-nodes in the argument network appear here first. Claims that failed the exclusion guard are marked.
+
+### Evidence
+
+Grounding trace: for each claim, what source documents or taxonomy nodes were retrieved, what similarity scores they had, and whether the claim was considered supported.
+
+### Citations
+
+Source citation details: the specific documents cited in this turn, how they were resolved, and any fallbacks that occurred. See `docs/citation-resolution-design.md` for the resolution pipeline.
+
+### Lookahead
+
+The utility gate that runs *before* the draft is committed. Shows:
+
+**Utility delta gauge** — the composite utility change this draft's claims would produce: `Δu = composite_after − composite_before`. The threshold bar shows what the engine required. Green = passed; red = regeneration was triggered.
+
+**Strategic assessment** — the engine's interpretation of *why* the draft scored how it did: position dilution (new claims drag the mean strength down), attack plateau (agent already has good attack coverage and these claims don't extend it), crux avoidance (many cruxes unaddressed and the draft ignores them), etc.
+
+**Utility breakdown** — per-dimension delta table: `position_strength`, `attack_effectiveness`, `crux_engagement`, `composite`.
+
+**Tentative claims** — the claims that were simulated. Each shows its individual QBAF strength and marginal delta (how much it contributed or detracted from the composite).
+
+**Regen attempts** — if regeneration was triggered, each attempt shows the guidance that was injected ("STRONG FOUNDATIONS" = claims that improved utility in the prior attempt, "DO NOT USE" = claims that dragged it down) and the revised claims. A `low_utility_turn` warning at the bottom means all regen attempts also failed threshold — the engine committed the best available draft anyway, flagged for review.
+
+### Cite
+
+The citation-stage diagnostics: what the engine was asked to support with citations, which citation strategies it tried, and what was ultimately attached.
+
+### Moderator
+
+The moderator's deliberation for this turn: the full candidate ranking (all debaters with their computed strength scores), the selection rationale, the focus point it set for the next turn, any convergence intervention it recommended, and whether the intervention was validated and executed or suppressed.
+
+Key fields:
+- `health_score` / `health_components` — the moderator's self-assessed debate quality score and its component breakdown
+- `intervention_recommended` / `intervention_move` — whether the moderator proposed an intervention and what type
+- `intervention_suppressed_reason` — why a recommended intervention was not executed (cooldown, budget, low confidence)
+- `burden_per_debater` — how much argumentative "work" each debater has done (used to balance selection)
+
+### Exclusion
+
+The exclusion guard results for this specific turn. Four sections mirror the `ExclusionGuardTab` overview: claim extraction guard, draft scope check, taxonomy context injection demotion, and situation injection filtering. See `docs/scope-enforcement.md` for what each guardrail does and how to interpret similarity scores.
+
+### Tax Refs
+
+The taxonomy nodes referenced in this turn, with their full detail: label, BDI category, confidence, priority, operationality, and their position in the taxonomy graph. Click any node to expand its connections. This is the bridge between what an agent said and what the taxonomy actually contains.
+
+### Affect
+
+Emotional register classification for this specific turn — which register the model assigned, the confidence, and the prior turn's register for comparison.
+
+---
+
+## The chat sidebar
+
+The diagnostics window includes an AI chat sidebar (right panel, togglable). You can ask natural-language questions about the active debate: "Which agent made the most attacks?", "What cruxes have not been addressed?", "Why did the Safetyist's utility drop in round 4?" The chat has full access to the debate session data and can synthesize across turns in ways that manual tab inspection cannot.
+
+The chat is most useful for:
+- Summarizing patterns across many turns ("how did the argument network evolve?")
+- Explaining specific diagnostic values ("what does this low convergence score mean for this debate?")
+- Identifying what to look at next when you see an anomaly
+
+---
+
+## Common diagnostic workflows
+
+### "Why did the agent repeat itself?"
+
+1. Open **Lookahead** for the repeated turn. Check `strategic_assessment` — "crux avoidance" means the agent's draft missed the cruxes the moderator had flagged, so subsequent turns were also aimed at the same cruxes.
+2. Check **Utility** sparkline — repeated turns often show a flat or falling `attack_effectiveness` (agent is reinforcing its own position without landing on opponents).
+3. Check **Moderator** for that turn — if `selection_reason` was `lowest_strength`, the moderator was trying to give a trailing agent a chance to recover, which may have broken argumentative flow.
+
+### "Why was a claim flagged out of scope?"
+
+1. Open **Exclusion** for that entry. Find the violation in "Claim Extraction Guard."
+2. The violation row shows `similarity_main` (how close the claim is to the intended taxonomy target) and `similarity_exclusion` (how close it is to an exclusion vector). High exclusion similarity = the claim is semantically similar to something explicitly out of scope.
+3. Check **Topic Scope** overview tab to verify the exclusion vectors for this debate are what you intended. If the scope is too narrow, widen it in debate configuration.
+
+### "Why did the debate phase change early?"
+
+1. Open **Adaptive Staging** overview tab.
+2. Find the transition row in the Phase Timeline and read `exit_reason`.
+3. Scroll to that round in Signal Telemetry. Check which signal crossed its threshold: usually `Sat` (saturation — enough cruxes have claims) or `Conv` (convergence — debaters are too close together).
+4. If the transition was a `force`, it means the predicate overrode normal flow — check the Forces stat card and find the relevant telemetry row.
+
+### "Why did the moderator pick that speaker?"
+
+1. Open **Moderator** for the turn *before* the one you're questioning (the moderator decision is made at the end of each turn to set up the next one).
+2. Read `candidates` — the ranking shows all debaters with their `computed_strength` at that moment.
+3. `selection_reason` codes: `lowest_strength` (moderator chose the weakest agent to help them recover), `highest_crux_burden` (agent with most unaddressed cruxes), `round_robin` (default rotation), `intervention` (moderator triggered a specific move).
+
+### "Why does a speaker have a low position score?"
+
+1. Open **Utility** overview tab. Click a low bar in that speaker's sparkline to jump to the turn.
+2. In **Argument Network**, filter by that speaker. Check computed strength (QBAF value after edge propagation) vs. base strength (pre-edge value). A big gap means many of their claims are being successfully attacked.
+3. In the INodeRow expanded view, look at which attacks are landing (CA edges with high weight targeting this speaker's nodes). The attackers' claims have high computed strength if uncontested.
+
+### "A turn committed with `low_utility_turn` — should I be concerned?"
+
+Not necessarily. `low_utility_turn` means the lookahead gate failed on all regen attempts and the engine committed the best available draft anyway. It's most concerning when it appears multiple turns in a row for the same speaker — that usually means the speaker has exhausted its productive attack surface and the debate needs a moderator intervention or a topic extension. Check **Adaptive Staging** for whether the phase is near its exit threshold; the engine may be about to move on regardless.
+
+---
+
+## Performance notes
+
+The diagnostics window receives state via IPC from the main window. On very long debates (50+ turns), the argument network tab may be slow to render — use the "Expand All" / "Collapse All" toggle to manage rendering load. The minimap degrades gracefully: it switches to a text fallback above 80 nodes to avoid SVG performance issues.
+
+Downloading the adaptive staging signals JSON (button in the Adaptive Staging tab) is the recommended path for offline analysis of long-running debates — the raw JSON contains the full per-round signal history and is easier to analyze in a notebook than the in-app table.

--- a/docs/reading-the-argument-network.md
+++ b/docs/reading-the-argument-network.md
@@ -1,0 +1,167 @@
+# Reading the Argument Network
+
+**Audience:** Researchers using the debate diagnostics window to understand what arguments were made and how they relate.  
+**Related docs:** `aif-debate-tool-analysis.md`, `qbaf-explainability-review.md`, `debate-diagnostics-field-guide.md`
+
+---
+
+## What the Argument Network is
+
+The Argument Network (AN) is a typed graph built incrementally as the debate runs. After each debater turn, the engine extracts 1–4 key claims and maps how those claims relate to prior claims. By the end of a debate, the AN is a complete record of what was argued, who argued it, and what attacked or supported what — structured in a way that makes the logical relationships computable.
+
+This is different from the transcript. The transcript records what was *said*. The Argument Network records what was *argued* — the claims that the engine identified as the logically significant content of each turn, stripped of rhetorical framing.
+
+The AN follows the **Argument Interchange Format (AIF)**, a formal ontology for argumentation established by Chesnevar et al. (2006). See `docs/aif-debate-tool-analysis.md` for the full gap analysis and implementation details.
+
+---
+
+## Node types
+
+Every item in the Argument Network is one of four node types. The diagnostics window labels each one explicitly.
+
+### I-nodes (Information nodes)
+
+The claims themselves. An I-node asserts a proposition: "Scaling compute is sufficient for AGI," "Current AI systems exhibit demographic bias," "Mandatory compute audits would slow progress." Every claim extracted from every turn becomes an I-node.
+
+Each I-node has:
+- A unique identifier (`AN-1`, `AN-2`, … in statement order)
+- A **speaker** (Accelerationist / Safetyist / Skeptic)
+- A **BDI category** (Belief / Desire / Intention) — see below
+- A `base_strength` — the initial QBAF node weight, derived from BDI sub-scores
+- A `computed_strength` — the QBAF strength after edge propagation (attacks weaken it, supports strengthen it)
+- A `claim_taxonomy_attribution` — the taxonomy node(s) this claim is anchored to, if any
+
+### CA-nodes (Conflict Application nodes)
+
+Attack relationships. A CA-node represents the *act* of one claim attacking another. There are three attack types, each targeting a different part of the attacked argument:
+
+| Type | What it attacks | Example |
+|---|---|---|
+| **Rebut** | The conclusion directly — asserts the opposite | "No, scaling alone is NOT sufficient for AGI" |
+| **Undercut** | The inference — accepts the premise but denies it implies the conclusion | "Even if that study is accurate, it doesn't show what you claim it shows" |
+| **Undermine** | The premise credibility — attacks the evidence or source | "That study was retracted / has serious methodological flaws" |
+
+In the diagnostics window, CA-nodes appear as red edges between I-nodes. The attack type is shown in the expanded INodeRow view alongside the edge weight.
+
+### RA-nodes (Rule Application nodes)
+
+Support relationships and their warrants. An RA-node explains *why* one claim supports another — the inference scheme or reasoning pattern connecting evidence to conclusion. When you see a green "supports" edge, the RA-node is the warrant: "Argument from analogy," "Argument from evidence," "Argument from expert authority."
+
+RA-nodes are labeled with their **argumentation scheme** — the formal pattern of reasoning being used. Each scheme has associated **critical questions** that identify how to attack it most effectively. An attack that answers a critical question for the scheme produces a stronger undercut than a generic rebuttal.
+
+### PA-nodes (Preference Application nodes)
+
+Conflict resolution. A PA-node appears when the engine determines which of two competing arguments prevails, and why. Criteria include empirical evidence strength, logical validity, and precedent. PA-nodes are less common and appear primarily in synthesis and verdict contexts.
+
+---
+
+## How to read the minimap
+
+The minimap at the top of the Argument Network tab provides a spatial overview of the whole graph before you scroll through the claim list.
+
+**Layout:** Nodes are arranged by speaker in three arcs around a center point. Each speaker's claims form a cluster. Cross-arc edges are attacks or supports between different debaters; within-arc edges are a speaker building on their own prior claims.
+
+**Color:** Each node dot is colored by speaker (Accelerationist = orange-red, Safetyist = blue, Skeptic = purple). Edges are red (attacks) or green (supports) with low opacity to show density without obscuring nodes.
+
+**Density:** A minimap with many cross-arc red edges means the debate was combative — speakers were directly attacking each other's claims. A minimap with mostly within-arc edges and few cross-connections means speakers talked past each other. A minimap with many cross-arc green edges is rare — it means debaters were building on each other's reasoning rather than opposing it.
+
+**Scale limit:** The minimap degrades gracefully above 80 nodes (it switches to a "network too large" message). For large debates, use the filter bar to work through the graph in sections.
+
+---
+
+## Base strength vs. computed strength
+
+Every I-node has two strength values. Understanding the difference is key to reading the AN.
+
+**`base_strength`** is the initial weight assigned to the claim before any edges are considered. It is derived from the claim's **BDI sub-scores** (see `docs/bdi-sub-score-calibration.md`): how well-evidenced the claim is, how falsifiable it is, how grounded in values or precedent. A claim with strong evidence, clear scope, and named failure modes gets a high base_strength. A vague aspiration gets a low one.
+
+**`computed_strength`** is what QBAF gradual semantics produces after propagating all attack and support edges through the graph. A claim that starts with `base_strength = 0.8` but is successfully attacked by two strong opponent claims may end up with `computed_strength = 0.35`. Conversely, a weaker claim that receives strong support from well-established claims may rise from `base_strength = 0.5` to `computed_strength = 0.72`.
+
+The QBAF computation is iterative: strength values propagate from attacker to attacked, from supporter to supported, until the graph stabilizes. See `docs/qbaf-explainability-review.md` for the mathematical semantics.
+
+**Practical reading rules:**
+
+| Situation | What it means |
+|---|---|
+| `base_strength` high, `computed_strength` low | Claim is well-constructed but successfully attacked — find the attacking CA-edges |
+| `base_strength` low, `computed_strength` low | Claim is weak AND attacked — least defensible position in the debate |
+| `base_strength` low, `computed_strength` similar | Claim is weak but uncontested — opponents chose not to engage with it |
+| `base_strength` high, `computed_strength` similar | Strong claim that held up — the backbone of the speaker's position |
+| Large gap between the two in either direction | Interesting node — click to expand and see which edges drove the change |
+
+---
+
+## The claim attribution filters
+
+The filter bar above the claim list lets you narrow the AN to specific subsets. These are most useful when a large debate produces 50+ nodes.
+
+**All claims** — default view.
+
+**Unattributed only** — shows claims where `claim_taxonomy_attribution.unattributed_reason` is set. These are claims the engine could not anchor to any taxonomy node. Two sub-types:
+
+- **Novel arguments** — claims that appear genuinely new: no similar node exists in the taxonomy at above-threshold embedding similarity. These are the most interesting for taxonomy development — they represent arguments that the debate surfaced which the taxonomy doesn't yet cover.
+- **Other unattributed** — claims that drifted from the configured scope, were too general to anchor, or had taxonomy references that were demoted by the exclusion guard.
+
+**Novel arguments** — filter to just the novel subset. A high novel-to-total ratio means the debate is ranging beyond the taxonomy's current coverage.
+
+**Attributed only (Anchored)** — claims successfully grounded in a taxonomy node. These are the claims you can directly trace to a specific belief, desire, or intention in the taxonomy.
+
+**Filter by node ID** — type a taxonomy node ID (e.g., `acc-bel-042`) to see only claims attributed to that node. Useful for asking "what did each agent say about this specific concept?"
+
+---
+
+## Moderator banners
+
+Interleaved between groups of claims, gray "Moderator" banners record the moderator's deliberation at the end of each turn. Key fields:
+
+**→ [Speaker]** — who the moderator selected to speak next.
+
+**Selection reason** — why that speaker was chosen:
+- `lowest_strength` — moderator gave the floor to the agent with the weakest computed QBAF position
+- `highest_crux_burden` — agent with the most unaddressed cruxes gets priority
+- `round_robin` — default rotation, no strategic override
+- `intervention` — moderator triggered a specific debate move (reframe, challenge, synthesis request)
+
+**Focus point** — the specific argumentative question the moderator asked the next speaker to address. This shapes the brief that agent receives.
+
+**Convergence score** — how close the debaters' argument centroids were at this moment. If `conv_triggered` appears, the convergence exceeded the phase threshold and contributed to a phase transition.
+
+**Candidates** — the ranked list of all debaters and their computed strength at this point. The selected speaker is shown in bold.
+
+---
+
+## Confidence Impact trace
+
+At the bottom of the Argument Network tab, when present, is the Confidence Impact section. This shows which taxonomy nodes had their `confidence_history`, `priority_history`, or `operationality_history` updated as a result of this specific debate.
+
+Each row shows:
+- The taxonomy node ID and label
+- The value before and after (`value` = current value, `delta` = change)
+- The `attack_claim` that drove a confidence drop (if applicable)
+- A `robustness` chip if the change was confirmed by 2 or more independent arguments
+
+This is the direct output of the debate: how the living taxonomy was changed by what was argued. A debate with many confidence impacts is moving the taxonomy; a debate with zero is adding claims to the AN but not yet crossing the threshold for taxonomy updates.
+
+---
+
+## Navigating between AN and transcript
+
+Every I-node group is preceded by a clickable source-statement header showing the statement ID (`S3`, `S12`, …), the speaker, and an excerpt. Clicking this header jumps to that entry in the transcript tab and selects it in the per-entry tabs — so you can move from a claim in the AN directly to the full turn context, the draft diagnostics, and the lookahead gate results for that claim in one click.
+
+The reverse also works: clicking a turn in the transcript and opening the Claims per-entry tab shows exactly which I-nodes were extracted from that turn.
+
+---
+
+## What a "healthy" argument network looks like
+
+There's no single ideal shape, but a few patterns are worth knowing:
+
+**Productive disagreement:** Red CA-edges distributed across all three speakers, with rebuttal and undercut attacks dominating (direct engagement rather than source-undermining). High `computed_strength` variance — some claims won, some lost — indicating the debate actually changed something.
+
+**Talking past each other:** Few cross-speaker edges, mostly within-arc. Speakers are making new claims rather than engaging with existing ones. The convergence score will be low not because debaters are far apart but because they're simply not connecting.
+
+**Pile-on:** Many CA-edges all targeting one speaker's nodes, with that speaker's `computed_strength` collapsing across the board. The moderator should have intervened via `lowest_strength` selection, but if the debate is late in its run the opportunity may have passed.
+
+**False consensus:** High convergence score, but many cruxes still unaddressed. Debaters are making similar-sounding claims but haven't actually resolved the underlying disagreements. The Gaps tab will show high unaddressed crux count.
+
+**Novel-heavy:** High fraction of unattributed claims with `novel_argument` reason. The debate is ranging beyond the taxonomy. Productive for taxonomy expansion; less useful for measuring position change on existing nodes.

--- a/docs/scope-enforcement.md
+++ b/docs/scope-enforcement.md
@@ -1,0 +1,146 @@
+# Scope Enforcement: Exclusion Guards and Drift Detection
+
+**Audience:** Researchers and developers who need to understand why claims were flagged, blocked, or demoted during a debate, and how to configure scope correctly.  
+**Related docs:** `debate-system-overview.md`, `citation-diagnostics-design.md`, `debate-diagnostics-field-guide.md`
+
+---
+
+## The problem scope enforcement solves
+
+A debate configured around "AI governance mechanisms" should not produce claims about "quantum computing supply chains." A debate about "AI safety techniques" should not cite papers whose scope excludes the configured topic. Without active enforcement, large language models will drift — they fill context gaps with plausible-sounding content that is adjacent to the topic but outside it.
+
+The engine uses **embedding-based exclusion** to enforce scope at four points in the turn pipeline. Rather than checking keywords, it checks semantic similarity: if a claim's embedding is too close to a known out-of-scope concept's embedding, the claim is flagged regardless of its surface language.
+
+---
+
+## Exclusion vectors
+
+The core mechanism. An **exclusion vector** is an embedding representation of a concept or domain that is explicitly *outside* the debate's scope. Exclusion vectors are attached to taxonomy nodes and debate configurations.
+
+When the engine checks a claim against exclusion, it computes the cosine similarity between the claim's embedding and each applicable exclusion vector. High similarity means the claim is semantically close to an out-of-scope concept — flagged. Low similarity means the claim is safely within scope.
+
+**Similarity color bands** (used in the Exclusion Guard tab):
+- **Red** (> 0.8) — high similarity to exclusion vector: strong out-of-scope signal
+- **Amber** (0.6–0.8) — moderate similarity: borderline, worth inspecting
+- **Green** (< 0.6) — low similarity: within scope
+
+These thresholds are configurable per debate. The threshold value shown in each section of the Exclusion Guard tab is the one that was active for this turn.
+
+---
+
+## The four guardrails
+
+The engine applies scope enforcement at four distinct points, each visible as a section in the Exclusion Guard per-entry tab.
+
+### 1. Claim Extraction Guard
+
+**When it runs:** After claims are extracted from the turn draft, before they are inserted into the argument network.
+
+**What it checks:** Each extracted claim is checked against the exclusion vectors for the taxonomy nodes it was attributed to. If `similarity_exclusion > threshold`, the claim is flagged as a violation.
+
+**What happens on violation:** The claim is marked as `unattributed` with reason `exclusion_violation` and is not inserted into the argument network as an attributed node. It may still appear in the transcript (the agent said it) but it does not contribute to QBAF strength computations or crux engagement.
+
+**Reading the tab:** The header line shows how many claims were checked and how many exclusion vectors were in play. Violation rows show:
+- `claim_id` — the internal claim identifier
+- `claim_text` — the claim content
+- `node_id` — the taxonomy node it was attributed to
+- `similarity_main` — how similar the claim is to the *intended* taxonomy concept (should be high for a well-attributed claim)
+- `similarity_exclusion` — how similar the claim is to the *exclusion* vector for that node (should be low for an in-scope claim)
+
+A claim can have high `similarity_main` and high `similarity_exclusion` simultaneously — this means the claim is about the right topic but in a way that touches the excluded sub-domain. This is the most common false-positive pattern.
+
+**All clear:** If the banner shows "All N claims within scope — 0 exclusion violations," every extracted claim passed the check. This is the normal case.
+
+---
+
+### 2. Draft Scope Check
+
+**When it runs:** After the full draft text is produced, checking the draft as a whole rather than individual extracted claims.
+
+**What it checks:** The draft text is embedded and checked against exclusion vectors for all taxonomy nodes referenced in the turn. This catches out-of-scope content that may not have been extracted as a discrete claim — rhetorical framing, transitional arguments, background context — but is still semantically near excluded territory.
+
+**What happens on warning:** Scope drift warnings do not block the turn. They are logged as diagnostics. The `scope_drift_warnings` field records the debater, the taxonomy node whose exclusion vector triggered the warning, the similarity score, and an excerpt of the draft text near the flagged content.
+
+**Reading the tab:** Warning rows show the debater label, the triggering `node_id`, the similarity score (colored by band), and a draft excerpt showing approximately which part of the text triggered the warning.
+
+**Distinction from Claim Extraction Guard:** The extraction guard is binary (claim is flagged or not). The draft scope check is advisory (warning issued but turn proceeds). In practice, repeated scope drift warnings in successive turns often predict extraction guard violations a few rounds later — the model is drifting before the drift becomes claim-level.
+
+---
+
+### 3. Taxonomy Context Injection Demotion
+
+**When it runs:** Before the turn prompt is assembled, when the engine selects which taxonomy nodes to inject as context for the debater.
+
+**What it checks:** Candidate taxonomy nodes for context injection are screened against exclusion vectors. A node that is too similar to an exclusion vector is **demoted** — removed from the injected context — even if it is nominally in scope based on its taxonomy position.
+
+**Why this matters:** A debater that receives an out-of-scope taxonomy node as context will write about it. The most reliable way to prevent scope drift is to not inject the material in the first place. Demotion is the upstream prevention; the extraction guard is the downstream catch.
+
+**Reading the tab:** The section header shows how many nodes were considered and how many were demoted. Demoted node rows show the `node_id` and its `exclusion_similarity` score. Nodes in amber and red bands were the ones removed.
+
+**False demotion:** A legitimate taxonomy node can be demoted if it sits near a concept that is excluded. If you see important context missing from an agent's reasoning, check this section — the node you expected to appear may have been demoted. Widen the exclusion threshold or restructure the exclusion vector if this is causing problems.
+
+---
+
+### 4. Situation Injection Filtering
+
+**When it runs:** Alongside taxonomy context injection, when the engine selects which debate situations (configured scenario contexts) to inject.
+
+**What it checks:** Each candidate situation is checked against exclusion vectors. Situations that are too similar to excluded concepts are filtered out before injection.
+
+**What happens on filtering:** The situation is excluded from the turn's context. The engine continues with the remaining situations.
+
+**Reading the tab:** Similar to taxonomy injection: header shows considered and excluded counts; rows show `situation_id` and `exclusion_similarity`.
+
+---
+
+## Interpreting "all clear" vs. violation patterns
+
+### All four sections show "all clear"
+
+Normal. The turn's content was within scope at every check point. Most turns in a well-configured debate will look like this.
+
+### Claim Extraction Guard has violations, Draft Scope Check is clear
+
+The draft text as a whole stayed within scope, but one or more discrete extracted claims crossed into excluded territory. This typically means the agent's main argument was on-topic but included a supporting claim that touched excluded ground. The supporting claim was dropped from the AN; the turn still contributed its in-scope claims.
+
+### Draft Scope Check has warnings, Claim Extraction Guard is clear
+
+The draft *text* drifted near excluded territory but didn't produce any discrete out-of-scope *claims* — either the drift was in framing language rather than claim content, or the extraction process filtered it out before flagging. Monitor: if this pattern repeats for the same agent across several turns, it often progresses to extraction violations.
+
+### Taxonomy Injection shows high demotion count
+
+Many taxonomy nodes were considered and removed. The exclusion vectors are catching a lot. Two possibilities: (a) the debate topic genuinely has many near-scope nodes that need to be excluded, in which case this is correct behavior; (b) the exclusion vectors are too broad and are catching legitimate context. Check which `node_id`s were demoted against your intended scope — if you see nodes you wanted, narrow the exclusion vectors.
+
+### Extraction guard violations in consecutive turns from the same agent
+
+The agent is consistently drifting. Likely causes:
+1. The agent's reflection is inaccurate — it has built a self-model that includes out-of-scope territory
+2. The moderator's focus points are pointing toward near-scope content
+3. The crux set includes concepts that are semantically adjacent to excluded territory
+
+Check the Reflections overview tab for the affected agent and compare the reflection to the topic scope. Also check the Moderator per-entry tab for recent turns to see what focus points were set.
+
+---
+
+## Configuring scope
+
+Scope is configured at debate setup, not during a running debate. The relevant parameters:
+
+**Crux set** — the core contested questions. These define what the debate *is about*. Claims near the crux embeddings score high on topic coherence; claims far from them score low.
+
+**Exclusion vectors** — per-node vectors attached to taxonomy nodes in the data model, plus debate-level exclusion lists. A taxonomy node can have a main embedding (what it's about) and one or more exclusion embeddings (what it's *not* about, even though it's topically adjacent).
+
+**Threshold** — the cosine similarity cutoff for each guardrail. Lowering the threshold is more permissive (fewer violations); raising it is stricter (more violations, tighter scope enforcement). The threshold shown in the Exclusion Guard tab is the one that was active — if you see many false positives or false negatives, this is the value to tune.
+
+---
+
+## Common false-positive patterns
+
+**Policy mechanism claims near excluded implementation details:**  
+A debate about "AI compute governance" may legitimately discuss semiconductor supply chains as part of the argument. If semiconductor supply chains are in the exclusion list (because the debate is about governance *mechanisms*, not supply chain logistics), technically on-topic claims will be flagged. Solution: add a carve-out to the exclusion vector for the governance-mechanism framing, or raise the threshold for that specific node.
+
+**Citation text including excluded context:**  
+If a cited source discusses both in-scope and out-of-scope content, the claim extracted from that citation may inherit the out-of-scope signal from the source text. The Draft Scope Check is more likely to catch this than the Claim Extraction Guard (since the claim may be a clean summary of the in-scope portion).
+
+**Near-synonym node demotion:**  
+Two taxonomy nodes that are conceptually distinct but semantically similar in embedding space — e.g., "AI deployment risks" and "AI development risks" — can have overlapping exclusion vectors. Demoting one may inadvertently demote near-synonyms. Inspect the demoted node list carefully when you see unexpected demotion.

--- a/docs/utility-function-and-lookahead.md
+++ b/docs/utility-function-and-lookahead.md
@@ -1,0 +1,149 @@
+# Utility Function and the Lookahead Gate
+
+**Audience:** Researchers and developers who want to understand how the engine evaluates whether a debater's turn contributes meaningfully, and why turns are sometimes regenerated.  
+**Related docs:** `debate-system-overview.md`, `debate-diagnostics-field-guide.md`, `reading-the-argument-network.md`
+
+---
+
+## The core idea
+
+Before committing any debater turn, the engine runs a **lookahead gate**: it simulates what the proposed draft's claims would do to the live argument network and checks whether the result represents a meaningful contribution. If the simulated contribution falls below a threshold, the engine discards the draft, injects targeted guidance, and asks the model to try again.
+
+This prevents a class of failure the engine calls "padding" — turns that add word count without advancing the debate. A debater that keeps asserting "AI governance is important" without attacking specific opponent claims or engaging cruxes will consistently fail the lookahead gate, triggering regeneration.
+
+---
+
+## The three utility dimensions
+
+Composite utility is a weighted sum of three dimensions, computed for each agent independently at each turn.
+
+### `position_strength`
+
+The mean computed QBAF strength of this agent's **undefeated** I-nodes — claims with `computed_strength ≥ 0.3`. Claims that have fallen below 0.3 are excluded from the mean (they are effectively defeated and no longer contribute to the agent's position).
+
+High position strength means the agent's core claims are holding up under attack. Low position strength means most of the agent's claims have been successfully undermined.
+
+**What moves it:** Adding new claims with high `base_strength` and low attack surface raises it. Being successfully attacked across existing claims lowers it. Importantly, adding *weak* new claims (low `base_strength`) *lowers* position strength even without attacks — they pull the mean down. This is what produces "position dilution" in the strategic assessment.
+
+### `attack_effectiveness`
+
+The fraction of *opponent* I-nodes that this agent's attacks have weakened below 0.3.
+
+High attack effectiveness means the agent has successfully undermined its opponents' positions. Zero attack effectiveness means all of the agent's claims are defensive — they reinforce the agent's own position but land no blows on opponents.
+
+**What moves it:** Extracting claims that become CA-edges (attacks) against opponent nodes with high computed strength. An attack on an already-defeated node (computed_strength already < 0.3) does not improve attack_effectiveness — there is no credit for kicking a node that's already down.
+
+### `crux_engagement`
+
+The fraction of identified debate cruxes this agent has addressed. Cruxes are the specific contested questions the moderator has identified as the core of the disagreement — the points that, if resolved, would actually move the debate forward.
+
+High crux engagement means the agent is doing the argumentative work the debate requires. Zero crux engagement means the agent is making claims that are adjacent to the debate topic but not addressing its actual contested points.
+
+**What moves it:** Extracting claims that are semantically similar to (or directly reference) the identified crux nodes. The engine checks crux attribution during extraction, so a claim must be close to a crux in embedding space, not just in surface language.
+
+---
+
+## Weights and composite
+
+All three agents currently use equal weights:
+
+| Agent | `position` | `attack` | `crux` |
+|---|---|---|---|
+| Accelerationist | 0.33 | 0.34 | 0.33 |
+| Safetyist | 0.33 | 0.34 | 0.33 |
+| Skeptic | 0.33 | 0.34 | 0.33 |
+
+`composite = 0.33 × position_strength + 0.34 × attack_effectiveness + 0.33 × crux_engagement`
+
+The slight upweighting of `attack_effectiveness` reflects that productive debate requires engagement with opponent claims, not just the accumulation of one's own positions.
+
+These weights are defined in `taxonomy-editor/src/renderer/components/debate-diagnostics/window/types.ts` as `UTILITY_WEIGHTS` and can be tuned per-agent if future calibration warrants different values.
+
+---
+
+## How the lookahead gate works
+
+The lookahead gate runs at the end of each draft stage, before the turn is committed.
+
+**Step 1 — Simulate.** The engine takes the proposed draft's extracted claims (the "tentative claims") and simulates inserting them into a copy of the live argument network. It runs QBAF strength propagation on the resulting graph.
+
+**Step 2 — Measure delta.** It computes `utility_after` for the speaking agent on the simulated graph and compares it to `utility_before` (the current state). `Δu = utility_after.composite − utility_before.composite`.
+
+**Step 3 — Check threshold.** If `Δu ≥ threshold`, the draft passes and is committed. The default threshold is a small positive value — the draft must improve the agent's position, not just maintain it. If `Δu < threshold`, the draft fails.
+
+**Step 4 — Regenerate with guidance.** On failure, the engine runs per-claim marginal analysis to identify which individual claims contributed positively and which dragged utility down. It injects two lists into the next draft prompt:
+- **STRONG FOUNDATIONS** — claims from the failed attempt with positive marginal delta; the model is told to build on these
+- **DO NOT USE** — claims with negative marginal delta; the model is told to avoid repeating them
+
+**Step 5 — Retry or accept.** The model produces a revised draft. The gate runs again. If the revised draft passes, it is committed. The engine allows multiple regen attempts. If all attempts fail, the best available draft (highest `Δu` across all attempts) is committed anyway and flagged with `low_utility_turn`.
+
+---
+
+## Per-claim marginal delta
+
+Within a single lookahead attempt, the engine can run **per-claim marginal analysis**: it evaluates each tentative claim independently — simulating the network with *just that one claim* added — to measure its isolated contribution.
+
+This produces a `marginal_delta` for each claim: how much composite utility that single claim adds or subtracts, independent of the others. Negative marginal delta on a claim means it is actively hurting the agent's position when added (typically because it introduces a weak node that pulls down `position_strength`, or because it doesn't land any attacks).
+
+Per-claim analysis is what makes the STRONG FOUNDATIONS / DO NOT USE guidance meaningful. Rather than telling the model "your draft was bad, try again," the engine tells it exactly which claims were working and which weren't.
+
+---
+
+## Strategic assessment labels
+
+The Lookahead diagnostics tab produces a plain-language **strategic assessment** from the utility delta breakdown. The labels map to specific patterns:
+
+| Label | Pattern | How to read it |
+|---|---|---|
+| **Position dilution** | `Δposition < -0.03` and speaker had strong position | New claims are weaker than existing ones — they pull the mean down even without attacks |
+| **Position weakened** | `Δposition < -0.03` generically | New claims are undermining existing arguments |
+| **Position strengthened** | `Δposition > +0.03` | New claims reinforce the speaker's stance |
+| **No offensive impact** | `Δattack ≈ 0` and `attack_before < 0.3` | Claims are purely defensive — no blows landed |
+| **Attack plateau** | `Δattack ≈ 0` and `attack_before ≥ 0.3` | Agent already has good coverage; these claims extend nothing |
+| **Strong offensive move** | `Δattack > +0.05` | Attacks landed on opponent nodes |
+| **Crux avoidance** | `Δcrux ≈ 0` and `crux_before < 0.5` | Many cruxes unaddressed; draft ignores them |
+| **Cruxes fully addressed** | `Δcrux ≈ 0` and `crux_before ≥ 0.9` | No new crux territory available — agent is done with cruxes |
+| **Crux engagement improved** | `Δcrux > +0.05` | Speaker addressed previously unengaged disagreement points |
+| **Pattern: padding** | Failed + `Δposition < 0` + no attacks | Volume without advancement — the canonical regen case |
+| **Pattern: marginal** | Failed + `Δu ≥ 0` but below threshold | Slight improvement but not enough — claims need more specificity |
+| **Pattern: strong move** | Passed + `Δu > +0.05` | Turn meaningfully advances the speaker's position |
+
+---
+
+## Reading the Utility tab sparklines
+
+The Utility overview tab shows a sparkline per agent across all turns. Each bar is one turn:
+
+- **Darker bars** are turns where that agent spoke. Lighter bars are turns where another agent spoke — utility can still change between a speaker's turns because opponents are attacking their claims.
+- **Bar height** is normalized to the maximum composite utility seen across all agents and turns in this debate, so bars are comparable.
+- **Clicking a bar** jumps to that turn's per-entry tabs.
+- **Trend arrows** (↑ ↓ →) summarize the last three turns: +0.03 or more = rising, −0.03 or less = falling, within ±0.03 = flat.
+
+**Common patterns to look for:**
+
+- An agent whose composite *falls between its own turns* (during turns it didn't speak) is being successfully attacked. Check the Argument Network for CA-edges targeting that agent's claims.
+- An agent with consistently rising `crux_engagement` but falling `attack_effectiveness` is engaging the debate's core questions but failing to land offensive arguments — a defensively coherent but strategically weak position.
+- An agent with rising `attack_effectiveness` but falling `position_strength` is landing attacks but in the process introducing weak new claims that undermine its own position (position dilution).
+
+---
+
+## `low_utility_turn` — when to be concerned
+
+Every `low_utility_turn` flag means all lookahead attempts failed. Isolated occurrences are expected — a speaker sometimes runs out of productive moves before the moderator rotates. A cluster of `low_utility_turn` flags from the same agent across consecutive turns is a signal worth investigating:
+
+1. **Crux exhaustion** — the agent has addressed all accessible cruxes and has nothing new to bring. Check crux_engagement: if it's near 1.0, this is expected.
+2. **Position collapse** — the agent's nodes have been attacked into low computed_strength territory, and new claims on the same topics just continue to dilute. Check position_strength trend.
+3. **Topic narrowness** — the debate scope is too narrow for the agent to find productive attack surface. Check the Argument Network for the ratio of CA-edges to I-nodes; a high ratio means most claims are contested, leaving little new territory.
+4. **Model drift** — the model is producing claims that are semantically valid but structurally unhelpful (generic, non-falsifiable, unanchored). Check the DraftTab quality gate for repeated `falsifiable=false` or `engages=false` failures.
+
+---
+
+## Relationship to other diagnostic data
+
+**Argument Network** — the computed strength values in the AN are the direct inputs to utility. If you want to understand *why* utility is what it is, the AN is where to look: `position_strength` is computed from the mean of the agent's undefeated nodes; `attack_effectiveness` from how many opponent nodes have been pushed below 0.3.
+
+**Adaptive Staging** — the engine's phase transitions factor in convergence and saturation signals, not utility directly. But persistently low utility across all three agents often correlates with stagnation signals (low saturation, low convergence change) that trigger a phase transition or moderator intervention.
+
+**Moderator** — `lowest_strength` selection by the moderator is a utility-adjacent signal: the moderator reads `computed_strength` on individual nodes to identify which agent's position has been most weakened, then gives that agent the floor to recover.
+
+**Reflections** — agents produce reflection summaries that feed into subsequent turns. An agent with low utility that produces an inaccurate reflection (misidentifying its strongest claims) will continue to generate low-utility turns because the reflection shapes the brief it receives.

--- a/taxonomy-editor/src/renderer/components/shared/BookmarkLink.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/BookmarkLink.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ recor
 
 import { BookmarkLink, buildDocUrl } from './BookmarkLink';
 
-const BASE = 'https://github.com/Berkman-Klein-Center/ai-triad-research/blob/main';
+const BASE = 'https://github.com/jpsnover/ai-triad-research/blob/main';
 
 describe('buildDocUrl', () => {
   it('constructs a GitHub blob URL from a repo-relative path', () => {

--- a/taxonomy-editor/src/renderer/components/shared/BookmarkLink.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/BookmarkLink.tsx
@@ -17,7 +17,7 @@ import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import './BookmarkLink.css';
 
-const REPO_BLOB_BASE = 'https://github.com/Berkman-Klein-Center/ai-triad-research/blob/main';
+const REPO_BLOB_BASE = 'https://github.com/jpsnover/ai-triad-research/blob/main';
 
 export interface BookmarkLinkProps {
   /** Repo-relative path to the doc, e.g. "docs/reading-the-argument-network.md". */


### PR DESCRIPTION
## Summary

- Fixes `BookmarkLink` org in `REPO_BLOB_BASE`: `Berkman-Klein-Center` → `jpsnover` (all bookmark links were 404ing)
- Lands 6 explainer docs that were written in a prior session but never committed (stranded in wt-2385 / shared checkout untracked):
  - `docs/debate-diagnostics-field-guide.md`
  - `docs/scope-enforcement.md`
  - `docs/utility-function-and-lookahead.md`
  - `docs/adaptive-staging-signals.md`
  - `docs/reading-the-argument-network.md`
  - `docs/bdi-sub-score-calibration.md`

## Test plan

- [ ] Click a BookmarkLink in the diagnostics UI — URL opens `https://github.com/jpsnover/ai-triad-research/blob/main/docs/...` (no 404)
- [ ] Verify all 6 new doc files render on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)