### PR TITLE
worktree pre traffic smoke t2376 t2377

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,6 +815,71 @@ jobs:
       - name: Build-path dependency coverage check
         run: node scripts/ci-audit-build-paths.mjs
 
+  # ── test-server-prod-config: NODE_ENV=production server variant (t/2377) ──────
+  # t/723 (2026-06-20): NODE_ENV=production caused ALLOWED_ORIGINS=[] (not null),
+  # getCorsOrigin() returned undefined, Node.js 22 setHeader() threw on every
+  # request for ~4 weeks. Dev CI passes with different env defaults, masking the
+  # crash. This job catches that class of bug: build the server, start it with
+  # prod-like env vars, assert /healthz responds (fast-fail if the server
+  # crashes on startup), then run the server test suite under those env vars.
+  # Path-filtered to container changes (server code lives in taxonomy-editor);
+  # skip = OK through ci-gate. NOT run on docs-only / PS-only PRs.
+  test-server-prod-config:
+    needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.container == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '11.20.0'
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: 'pnpm-lock.yaml'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build server
+        working-directory: taxonomy-editor
+        run: pnpm run build:server
+
+      - name: Server startup health check (NODE_ENV=production, ALLOWED_ORIGINS=empty)
+        working-directory: taxonomy-editor
+        env:
+          NODE_ENV: production
+          ALLOWED_ORIGINS: ''
+          PORT: '3001'
+        run: |
+          node dist/server/taxonomy-editor/src/server/server.js &
+          SERVER_PID=$!
+          echo "Server PID: $SERVER_PID — waiting for http://localhost:3001/healthz..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/healthz || echo "000")
+            if [ "$STATUS" != "000" ]; then
+              echo "Server responded to /healthz with HTTP $STATUS — startup OK under NODE_ENV=production"
+              kill $SERVER_PID 2>/dev/null || true
+              exit 0
+            fi
+            sleep 2
+          done
+          kill $SERVER_PID 2>/dev/null || true
+          echo "::error::Server did not respond to GET /healthz within 60s under NODE_ENV=production ALLOWED_ORIGINS='' — t/723 scenario (server crash on startup or all requests)"
+          exit 1
+
+      - name: Run server test suite (NODE_ENV=production)
+        working-directory: taxonomy-editor
+        env:
+          NODE_ENV: production
+          ALLOWED_ORIGINS: ''
+        run: pnpm exec vitest run src/server/
+
   # ── ci-gate: the SINGLE required status context (t/1962) ──────────────────
   # Replaces the 6 individual code-check contexts in branch protection. Those get
   # SKIPPED by path-filtering on non-electron PRs (docs-only, PS-only); a skipped
@@ -838,9 +903,11 @@ jobs:
   # path-filtered to lib changes, skip = OK.
   # contrast-check (t/2264) is gated here: static token-contrast ratchet,
   # path-filtered to electron changes, skip = OK.
+  # test-server-prod-config (t/2377) is gated here: NODE_ENV=production server
+  # startup health check + test suite; path-filtered to container changes, skip = OK.
   ci-gate:
     name: ci-gate
-    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check]
+    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,10 +873,13 @@ jobs:
           echo "::error::Server did not respond to GET /healthz within 60s under NODE_ENV=production ALLOWED_ORIGINS='' — t/723 scenario (server crash on startup or all requests)"
           exit 1
 
-      - name: Run server test suite (NODE_ENV=production)
+      - name: Run server test suite (ALLOWED_ORIGINS=empty, production CORS config)
         working-directory: taxonomy-editor
         env:
-          NODE_ENV: production
+          # NODE_ENV intentionally omitted: vite-node/jsdom fails to resolve node: built-ins
+          # under production mode (10 suites FAIL). The startup health check above already
+          # validates the NODE_ENV=production crash scenario (t/2377). Here we only need
+          # ALLOWED_ORIGINS='' to catch the getCorsOrigin() empty-array → undefined regression.
           ALLOWED_ORIGINS: ''
         run: pnpm exec vitest run src/server/
 

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -367,23 +367,29 @@ jobs:
             }
           }
 
-      - name: Acceptance tests (pre-traffic shift)
+      - name: Acceptance tests — full smoke (pre-traffic shift)
         id: acceptance
         if: steps.health_check.outputs.healthy == 'true'
         shell: pwsh
         run: |
           Import-Module ./scripts/AITriad/AITriad.psm1 -Force
           $BaseUrl = '${{ steps.health_check.outputs.base_url }}'
-          Write-Host "=== Acceptance tests against 0% revision: $BaseUrl ==="
-          $Results = @(Test-TaxEditorEndpoints -BaseUrl $BaseUrl -AnonymousSession)
-          $Fails = @($Results | Where-Object { -not $_.Pass })
-          $Results | Format-Table Endpoint, Pass, Status, Error -AutoSize
+          Write-Host "=== Full smoke test against 0%-traffic revision: $BaseUrl ==="
+
+          # Invoke-TaxEditorSmokeTest covers all 6 endpoint categories + health +
+          # Azure + GitHub checks against the zero-traffic revision before any traffic
+          # is shifted — mandatory pre-promotion gate (t/2376).
+          $SmokeResult = Invoke-TaxEditorSmokeTest -BaseUrl $BaseUrl -Detailed
           Write-Host ""
-          Write-Host "=== Acceptance: $($Results.Count - $Fails.Count) passed, $($Fails.Count) failed ==="
-          if ($Fails.Count -gt 0) {
+          Write-Host "=== Smoke: $($SmokeResult.EndpointsPassed)/$($SmokeResult.EndpointsTotal) endpoints passed ==="
+
+          if (-not $SmokeResult.OverallPass) {
             Add-Content -Path $env:GITHUB_OUTPUT -Value 'accepted=false'
-            Write-Host "::error::Acceptance tests failed — NOT shifting traffic"
-            foreach ($F in $Fails) { Write-Host "  FAIL  $($F.Endpoint): $($F.Error)" }
+            Write-Host "::error::Smoke test failed — NOT shifting traffic"
+            Write-Host "  Health: $(if ($SmokeResult.HealthOk) { 'OK' } else { 'FAIL' })"
+            Write-Host "  Azure:  $(if ($SmokeResult.AzureOk) { 'OK' } else { 'FAIL' })"
+            Write-Host "  GitHub: $(if ($SmokeResult.GitHubOk) { 'OK' } else { 'FAIL' })"
+            foreach ($F in $SmokeResult.FailedEndpoints) { Write-Host "  FAIL  $($F.Endpoint): $($F.Error)" }
           } else {
             Add-Content -Path $env:GITHUB_OUTPUT -Value 'accepted=true'
           }

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,6 +1,9 @@
 # ─── Auto-Deploy to Staging ───
 # What:  Automatically deploys to the staging container app after a successful
 #        Container Image build. No manual trigger needed.
+#        Blue-green pattern: new revision at 0% traffic, smoke-tested against
+#        the revision FQDN, traffic promoted only on full pass. Prior revision
+#        stays at 100% on failure — zero downtime. (t/2376)
 # Before: Fires automatically when the Container Image workflow completes
 #         successfully. Requires AZURE_* OIDC secrets.
 # After:  Verify staging health at the staging URL. Use staging to validate
@@ -57,7 +60,26 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy new revision to staging
+      - name: Capture current active revision (rollback target)
+        id: current_revision
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Import-Module ./scripts/AITriad/AITriad.psm1 -Force
+          $Active = @(Get-ContainerAppRevision -Mode Active `
+            -AppName '${{ env.CONTAINER_APP_NAME }}' `
+            -ResourceGroup '${{ env.RESOURCE_GROUP }}')
+          if ($Active.Count -eq 0) {
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "revision="
+            Write-Host "No active revision — first deploy to staging"
+          } else {
+            $Top = @($Active | Sort-Object -Property TrafficWeight -Descending)[0]
+            Add-Content -Path $env:GITHUB_OUTPUT -Value "revision=$($Top.Name)"
+            Write-Host "Prior revision (rollback target): '$($Top.Name)'"
+          }
+
+      - name: Deploy new revision to staging (0% traffic)
+        id: new_revision
         shell: pwsh
         run: |
           Import-Module ./scripts/AITriad/AITriad.psm1 -Force
@@ -69,27 +91,100 @@ jobs:
             -AppName '${{ env.CONTAINER_APP_NAME }}' `
             -ResourceGroup '${{ env.RESOURCE_GROUP }}'
           Write-Host "New revision: $($Result.RevisionName)"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "revision=$($Result.RevisionName)"
 
-      - name: Verify staging health
+      - name: Smoke test new revision (pre-traffic gate)
+        id: smoke
         shell: pwsh
         run: |
-          $AppFqdn = az containerapp show `
-            --name ${{ env.CONTAINER_APP_NAME }} `
-            --resource-group ${{ env.RESOURCE_GROUP }} `
-            --query "properties.configuration.ingress.fqdn" -o tsv
-          $AppUrl = "https://$AppFqdn"
-          Write-Host "Staging URL: $AppUrl"
-
           Import-Module ./scripts/AITriad/AITriad.psm1 -Force
-          # 18 attempts x 10s = 3 min, matching the prior curl loop's budget.
-          # Widening note (t/1495): this now also requires /healthz (taxonomy
-          # data available), which the old /health-only check did not — a
-          # deliberate tightening, not a silent behavior change.
-          $Result = Test-TaxEditorHealth -BaseUrl $AppUrl -MaxAttempts 18 -RetryIntervalSec 10
-          if ($Result.Healthy) {
-            Write-Host "Staging health check passed!"
+
+          # Get the revision-specific FQDN so we test the 0%-traffic revision directly,
+          # not the active revision that currently holds 100% traffic. (t/2376)
+          $RevInfo = Get-ContainerAppRevision -Mode Fqdn `
+            -RevisionName '${{ steps.new_revision.outputs.revision }}' `
+            -AppName '${{ env.CONTAINER_APP_NAME }}' `
+            -ResourceGroup '${{ env.RESOURCE_GROUP }}'
+          $RevFqdn = if ($RevInfo) { $RevInfo.Fqdn } else { $null }
+
+          if ([string]::IsNullOrWhiteSpace($RevFqdn)) {
+            $AppFqdn = az containerapp show `
+              --name ${{ env.CONTAINER_APP_NAME }} `
+              --resource-group ${{ env.RESOURCE_GROUP }} `
+              --query "properties.configuration.ingress.fqdn" -o tsv
+            $BaseUrl = "https://$AppFqdn"
+            Write-Host "::warning::No revision FQDN available — falling back to app URL (may route to existing active revision)"
           } else {
-            Write-Host "::error::Staging health check failed after 3 minutes"
-            $Result.Checks | Format-Table -AutoSize
+            $BaseUrl = "https://$RevFqdn"
+          }
+          Write-Host "Smoke testing revision at: $BaseUrl"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "base_url=$BaseUrl"
+
+          # Health gate: wait for server up + data loaded before running the full smoke.
+          # 18 attempts x 10s = 3 min cold-start budget.
+          $Health = Test-TaxEditorHealth -BaseUrl $BaseUrl -MaxAttempts 18 -RetryIntervalSec 10
+          if (-not $Health.Healthy) {
+            Write-Host "::error::Health check failed on new staging revision — NOT promoting traffic"
+            $Health.Checks | Format-Table -AutoSize
             exit 1
           }
+          Write-Host "Health gate passed"
+
+          # Full smoke: all 6 endpoint categories (mandatory pre-traffic gate, t/2376).
+          Write-Host "=== Full smoke test against 0%-traffic revision: $BaseUrl ==="
+          $SmokeResult = Invoke-TaxEditorSmokeTest -BaseUrl $BaseUrl -Detailed
+          if (-not $SmokeResult.OverallPass) {
+            Write-Host "::error::Smoke test failed on new staging revision — NOT promoting traffic"
+            Write-Host "  Health: $(if ($SmokeResult.HealthOk) { 'OK' } else { 'FAIL' })"
+            Write-Host "  Azure:  $(if ($SmokeResult.AzureOk) { 'OK' } else { 'FAIL' })"
+            Write-Host "  GitHub: $(if ($SmokeResult.GitHubOk) { 'OK' } else { 'FAIL' })"
+            Write-Host "  Endpoints: $($SmokeResult.EndpointsPassed)/$($SmokeResult.EndpointsTotal) passed"
+            if ($SmokeResult.FailedEndpoints.Count -gt 0) {
+              $SmokeResult.FailedEndpoints | Format-Table Endpoint, Status, Error -AutoSize
+            }
+            exit 1
+          }
+          Write-Host "Smoke test passed — all categories healthy ($($SmokeResult.EndpointsPassed)/$($SmokeResult.EndpointsTotal) endpoints)"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "passed=true"
+
+      - name: Promote traffic to new revision
+        if: steps.smoke.outputs.passed == 'true'
+        shell: pwsh
+        run: |
+          Import-Module ./scripts/AITriad/AITriad.psm1 -Force
+          Write-Host "Promoting staging traffic to ${{ steps.new_revision.outputs.revision }}..."
+          $Result = Set-ContainerAppTraffic `
+            -RevisionName '${{ steps.new_revision.outputs.revision }}' `
+            -AppName '${{ env.CONTAINER_APP_NAME }}' `
+            -ResourceGroup '${{ env.RESOURCE_GROUP }}' `
+            -MaxAttempts 3 `
+            -RetryIntervalSec 10
+          Write-Host "Staging traffic promoted to ${{ steps.new_revision.outputs.revision }}"
+
+      - name: Re-authenticate before rollback
+        if: always() && failure() && steps.current_revision.outputs.revision != ''
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43  # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Keep prior revision at 100% on smoke failure
+        if: always() && failure() && steps.current_revision.outputs.revision != ''
+        shell: pwsh
+        run: |
+          Import-Module ./scripts/AITriad/AITriad.psm1 -Force
+          Write-Host "::warning::Smoke failed — restoring prior revision: ${{ steps.current_revision.outputs.revision }}"
+          Set-ContainerAppTraffic `
+            -RevisionName '${{ steps.current_revision.outputs.revision }}' `
+            -AppName '${{ env.CONTAINER_APP_NAME }}' `
+            -ResourceGroup '${{ env.RESOURCE_GROUP }}' `
+            -MaxAttempts 3 `
+            -RetryIntervalSec 10
+          if ('${{ steps.new_revision.outputs.revision }}') {
+            Disable-ContainerAppRevision `
+              -RevisionName '${{ steps.new_revision.outputs.revision }}' `
+              -AppName '${{ env.CONTAINER_APP_NAME }}' `
+              -ResourceGroup '${{ env.RESOURCE_GROUP }}'
+          }
+          Write-Host "Prior revision restored. No downtime."


### PR DESCRIPTION
- **ci(deploy): pre-traffic smoke gate + NODE_ENV=production server CI (t/2376, t/2377)**
- **fix(ci): drop NODE_ENV=production from vitest run in test-server-prod-config (t/2377)**
