### PR TITLE
fix(deploy): resolve BaseUrl from AZ CLI when null in CI (t/2403)

### DIFF
--- a/scripts/AITriad/Public/Test-AzureHealth.ps1
+++ b/scripts/AITriad/Public/Test-AzureHealth.ps1
@@ -87,7 +87,17 @@ function Test-AzureHealth {
     Set-StrictMode -Version Latest
     if ($CheckConfig) { $UseCLI = $true }
 
-    $BaseUrl = $BaseUrl.TrimEnd('/')
+    # Get-TaxEditorBaseUrl returns $null in CI environments with no local config.
+    # When -UseCLI/-CheckConfig is active, resolve the FQDN from the Container App
+    # so the HTTP health checks have a valid target. (t/2403)
+    if ([string]::IsNullOrWhiteSpace($BaseUrl) -and $UseCLI) {
+        $FqdnOut = & az containerapp show -g $ResourceGroup -n $AppName `
+            --query 'properties.configuration.ingress.fqdn' -o tsv 2>$null
+        if ($LASTEXITCODE -eq 0 -and $FqdnOut) {
+            $BaseUrl = "https://$($FqdnOut.Trim())"
+        }
+    }
+    $BaseUrl = if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) { $BaseUrl.TrimEnd('/') } else { '' }
     $Checks = [System.Collections.Generic.List[PSObject]]::new()
 
     # ── Azure Status Page ────────────────────────────────────────────────


### PR DESCRIPTION
Get-TaxEditorBaseUrl returns $null in GitHub Actions (no local config), causing
$BaseUrl.TrimEnd('/') to throw "You cannot call a method on a null-valued expression"
in the post-deploy Verify Bicep Config step. When -UseCLI/-CheckConfig is active,
auto-resolve the FQDN from the Container App's ingress config so HTTP health checks
have a valid target. Falls back to '' (graceful failures) if AZ CLI also can't resolve.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
