### PR TITLE
obs: add build_commit_sha to flight recorder context snapshot (t/2404)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -20,6 +20,7 @@ import { showDumpToast, showDumpErrorToast, showDumpPendingToast } from './dumpT
 
 declare const __APP_VERSION__: string;
 declare const __BUILD_DATE__: string;
+declare const __BUILD_SHA__: string;
 declare const __COMPONENT_VERSIONS__: Record<string, string>;
 
 function getDeploymentMode(): string {
@@ -673,6 +674,7 @@ export function initFlightRecorder(): FlightRecorder {
         app: {
           version: typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : undefined,
           build_date: typeof __BUILD_DATE__ !== 'undefined' ? __BUILD_DATE__ : undefined,
+          build_commit_sha: typeof __BUILD_SHA__ !== 'undefined' ? __BUILD_SHA__ : undefined,
           build_fingerprint: `build-${(window as unknown as { __BUILD_FINGERPRINT?: string }).__BUILD_FINGERPRINT ?? 'unknown'}`,
           deployment_mode: getDeploymentMode(),
           vite_target: import.meta.env.VITE_TARGET ?? 'electron',

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -20,6 +20,14 @@ function getGitVersion(): string {
   }
 }
 
+function getGitSha(): string {
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
 export default defineConfig({
   plugins: [
     react(),
@@ -74,6 +82,7 @@ export default defineConfig({
     'import.meta.env.VITE_TARGET': JSON.stringify(process.env.VITE_TARGET || 'electron'),
     __APP_VERSION__: JSON.stringify(getGitVersion()),
     __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
+    __BUILD_SHA__: JSON.stringify(getGitSha()),
     __CHANGELOG_MD__: JSON.stringify(
       fs.readFileSync(path.resolve(import.meta.dirname, '../CHANGELOG.md'), 'utf-8')
     ),


### PR DESCRIPTION
## Summary
- Adds `getGitSha()` helper to `vite.config.ts` (mirrors existing `getGitVersion()` pattern)
- Injects result as `__BUILD_SHA__` Vite define constant (mirrors `__BUILD_DATE__`)
- Surfaces it as `context.app.build_commit_sha` in the FR context event in `flightRecorderInit.ts`

## Motivation
Triaging today's DebateTable crash (flight-recorder-2026-08-09T20-04-29.222Z) required cross-referencing `git log --format="%H %ai"` against `build_date` to confirm the t/2389 fix wasn't in the crashing build. With `build_commit_sha` present, that's a direct lookup — no timestamp math.

## Test plan
- [ ] CI verify gate passes
- [ ] Next FR dump includes `context.app.build_commit_sha` matching `git rev-parse HEAD` at build time

Closes t/2404

🤖 Generated with [Claude Code](https://claude.com/claude-code)