### PR TITLE
feat(shared): unified doc-link control — docPath/anchor + dynamic tooltip (t/2410 PR-A)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.tsx
@@ -73,7 +73,7 @@ export function DebateHeader({
           <div className="debate-hdr-title-row">
             <h2 className="debate-hdr-title" title={activeDebate.topic.final}>{displayTitle}</h2>
             <TheoryLink
-              url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/debate-system-overview.md"
+              docPath="docs/debate-system-overview.md"
               label="Help: debate system overview"
               className="debate-hdr-theory-link"
             />

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
@@ -162,7 +162,7 @@ function RefsHeader({ entry, explainCopied, onExplain, onToggleCaveats }: {
         </button>
       )}
       <TheoryLink
-        url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/citation-diagnostics-design.md"
+        docPath="docs/citation-diagnostics-design.md"
         label="Help: citation diagnostics design"
         size={14}
         className="taxrefs-refs-help"
@@ -177,7 +177,7 @@ function BriefSection({ briefStage }: { briefStage: { work_product: Record<strin
       <summary className="debate-reasoning-section-title taxrefs-section-brief" onClick={suppressDetailsToggleForHelp}>
         BRIEF
         <TheoryLink
-          url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/artifact-guide.md"
+          docPath="docs/artifact-guide.md"
           label="Help: artifact guide"
           size={14}
           className="taxrefs-section-help"
@@ -352,7 +352,7 @@ function PlanSection({ planStage, selectedPlanNodeId, setSelectedPlanNodeId }: {
       <summary className="debate-reasoning-section-title taxrefs-section-plan" onClick={suppressDetailsToggleForHelp}>
         PLAN
         <TheoryLink
-          url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/artifact-guide.md"
+          docPath="docs/artifact-guide.md"
           label="Help: artifact guide"
           size={14}
           className="taxrefs-section-help"

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -650,7 +650,7 @@ function DebateListHeaderActions(props: DebateListProps) {
           <button className="btn btn-sm" onClick={handleNewDebate}>
             + New
           </button>
-          <TheoryLink url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/theory-of-success.md" label="Help: theory of success" />
+          <TheoryLink docPath="docs/theory-of-success.md" label="Help: theory of success" />
           <button className="pane-collapse-btn" onClick={() => setListCollapsed(true)} title="Collapse" aria-label="Collapse panel">&lsaquo;</button>
         </>
       ) : (

--- a/taxonomy-editor/src/renderer/components/shared/BookmarkLink.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/BookmarkLink.test.tsx
@@ -9,7 +9,8 @@ const openExternal = vi.fn().mockResolvedValue(undefined);
 vi.mock('@bridge', () => ({ api: { openExternal: (url: string) => openExternal(url) } }));
 vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
 
-import { BookmarkLink, buildDocUrl } from './BookmarkLink';
+import { BookmarkLink } from './BookmarkLink';
+import { buildDocUrl } from './TheoryLink';
 
 const BASE = 'https://github.com/jpsnover/ai-triad-research/blob/main';
 

--- a/taxonomy-editor/src/renderer/components/shared/BookmarkLink.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/BookmarkLink.tsx
@@ -16,8 +16,9 @@
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import './BookmarkLink.css';
-
-const REPO_BLOB_BASE = 'https://github.com/jpsnover/ai-triad-research/blob/main';
+// buildDocUrl is owned by the canonical doc-link control now (t/2410); BookmarkLink is
+// being retired once diagnostics migrate off it, so it consumes the shared builder.
+import { buildDocUrl } from './TheoryLink';
 
 export interface BookmarkLinkProps {
   /** Repo-relative path to the doc, e.g. "docs/reading-the-argument-network.md". */
@@ -30,11 +31,6 @@ export interface BookmarkLinkProps {
   size?: 'xs' | 'sm' | 'md';
   /** Extra class(es) for inline positioning by consumers — appended to the base classes. */
   className?: string;
-}
-
-/** Build the GitHub blob URL for a repo-relative doc path (+ optional anchor). */
-export function buildDocUrl(docPath: string, anchor?: string): string {
-  return `${REPO_BLOB_BASE}/${docPath}${anchor ? `#${anchor}` : ''}`;
 }
 
 export function BookmarkLink({ docPath, anchor, label = 'Learn more', size = 'sm', className }: BookmarkLinkProps) {

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.test.tsx
@@ -9,34 +9,41 @@ const openExternal = vi.fn().mockResolvedValue(undefined);
 vi.mock('@bridge', () => ({ api: { openExternal: (url: string) => openExternal(url) } }));
 vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
 
-import { TheoryLink } from './TheoryLink';
+import { TheoryLink, DocLink, buildDocUrl, humanizeDocName } from './TheoryLink';
 
-const URL = 'https://github.com/org/repo/blob/main/docs/theory.md';
+const BASE = 'https://github.com/jpsnover/ai-triad-research/blob/main';
+const URL = `${BASE}/docs/debate-system-overview.md`;
+
+describe('buildDocUrl', () => {
+  it('builds a jpsnover blob URL from a repo-relative path', () => {
+    expect(buildDocUrl('docs/x.md')).toBe(`${BASE}/docs/x.md`);
+  });
+  it('appends the anchor with a # when provided', () => {
+    expect(buildDocUrl('docs/x.md', 'sec-1')).toBe(`${BASE}/docs/x.md#sec-1`);
+  });
+});
+
+describe('humanizeDocName', () => {
+  it('Title-Cases the filename stem, dropping path, .md, and anchor', () => {
+    expect(humanizeDocName('docs/debate-system-overview.md')).toBe('Debate System Overview');
+    expect(humanizeDocName(`${BASE}/docs/reading-the-argument-network.md`)).toBe('Reading The Argument Network');
+    expect(humanizeDocName('docs/scope_enforcement.md#anchor')).toBe('Scope Enforcement');
+  });
+});
 
 describe('TheoryLink', () => {
   beforeEach(() => { openExternal.mockClear(); });
 
-  it('renders a button with the distinct aria-label and default tooltip', () => {
+  it('DocLink is an alias of TheoryLink', () => {
+    expect(DocLink).toBe(TheoryLink);
+  });
+
+  // ── url form (existing callers) ──
+  it('renders with an explicit label + dynamic tooltip from the url', () => {
     render(<TheoryLink url={URL} label="Help: debate overview" />);
     const btn = screen.getByRole('button', { name: 'Help: debate overview' });
-    expect(btn).toHaveAttribute('title', 'Open theory notes on GitHub');
+    expect(btn).toHaveAttribute('title', 'Open Debate System Overview in GitHub');
     expect(btn).toHaveAttribute('data-theory-link');
-  });
-
-  it('appends className to the base class (never replaces it)', () => {
-    render(<TheoryLink url={URL} label="Help" className="inline-heading" />);
-    const btn = screen.getByRole('button', { name: 'Help' });
-    expect(btn.className).toContain('theory-link');
-    expect(btn.className).toContain('inline-heading');
-  });
-
-  it('clamps size to 14–16px', () => {
-    const { rerender } = render(<TheoryLink url={URL} label="H" size={40} />);
-    expect(screen.getByRole('button').style.fontSize).toBe('16px');
-    rerender(<TheoryLink url={URL} label="H" size={2} />);
-    expect(screen.getByRole('button').style.fontSize).toBe('14px');
-    rerender(<TheoryLink url={URL} label="H" size={15} />);
-    expect(screen.getByRole('button').style.fontSize).toBe('15px');
   });
 
   it('opens the url externally on click (via bridge, not window/shell)', async () => {
@@ -49,16 +56,52 @@ describe('TheoryLink', () => {
   it('activates on Enter and Space (native button keyboard)', async () => {
     const user = userEvent.setup();
     render(<TheoryLink url={URL} label="Help" />);
-    const btn = screen.getByRole('button', { name: 'Help' });
-    btn.focus();
+    screen.getByRole('button', { name: 'Help' }).focus();
     await user.keyboard('{Enter}');
     await user.keyboard(' ');
     expect(openExternal).toHaveBeenCalledTimes(2);
     expect(openExternal).toHaveBeenCalledWith(URL);
   });
 
+  // ── docPath form (diagnostics + migrated callers) ──
+  it('builds the URL from docPath (+anchor) and opens it on click', async () => {
+    const user = userEvent.setup();
+    render(<TheoryLink docPath="docs/scope-enforcement.md" anchor="draft-scope-check" label="H" />);
+    await user.click(screen.getByRole('button', { name: 'H' }));
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith(`${BASE}/docs/scope-enforcement.md#draft-scope-check`);
+  });
+
+  it('derives the dynamic tooltip from docPath', () => {
+    render(<TheoryLink docPath="docs/reading-the-argument-network.md" label="H" />);
+    expect(screen.getByRole('button', { name: 'H' })).toHaveAttribute('title', 'Open Reading The Argument Network in GitHub');
+  });
+
+  // ── label / tooltip defaulting ──
+  it('defaults the aria-label to the tooltip when label is omitted', () => {
+    render(<TheoryLink docPath="docs/debate-system-overview.md" />);
+    const btn = screen.getByRole('button', { name: 'Open Debate System Overview in GitHub' });
+    expect(btn).toHaveAttribute('title', 'Open Debate System Overview in GitHub');
+  });
+
   it('uses a custom tooltip when provided', () => {
     render(<TheoryLink url={URL} label="Help" tooltip="Read the spec" />);
     expect(screen.getByRole('button', { name: 'Help' })).toHaveAttribute('title', 'Read the spec');
+  });
+
+  // ── misc ──
+  it('appends className to the base class (never replaces it)', () => {
+    render(<TheoryLink url={URL} label="H" className="inline-heading" />);
+    const btn = screen.getByRole('button', { name: 'H' });
+    expect(btn.className).toContain('theory-link');
+    expect(btn.className).toContain('inline-heading');
+  });
+
+  it('clamps size to 12–16px', () => {
+    const { rerender } = render(<TheoryLink url={URL} label="H" size={40} />);
+    expect(screen.getByRole('button').style.fontSize).toBe('16px');
+    rerender(<TheoryLink url={URL} label="H" size={2} />);
+    expect(screen.getByRole('button').style.fontSize).toBe('12px');
+    rerender(<TheoryLink url={URL} label="H" size={12} />);
+    expect(screen.getByRole('button').style.fontSize).toBe('12px');
   });
 });

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.tsx
@@ -2,10 +2,15 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 /**
- * TheoryLink (t/2343) — shared open-book help affordance that opens an external
- * GitHub theory-notes doc. Muted glyph that brightens on hover (mirrors
- * .field-help-btn), with a small ↗ external-jump badge + tooltip so the
- * open-in-browser behavior is discoverable.
+ * TheoryLink (t/2343, unified in t/2410) — the app's general doc-link affordance:
+ * a shared open-book glyph that opens a repo doc on GitHub in the system browser.
+ * (Name kept for continuity; `DocLink` is exported as a readability alias.) Muted
+ * glyph that brightens on hover (mirrors .field-help-btn), with a small ↗
+ * external-jump badge + tooltip so the open-in-browser behavior is discoverable.
+ *
+ * Accepts either a full `url` or a repo-relative `docPath` (+ optional `anchor`);
+ * the latter is built from a single `REPO_BLOB_BASE` constant so callers never
+ * hand-assemble URLs and the canonical org is swappable in one place (t/2410).
  *
  * Activation routes through the bridge (`api.openExternal`) — never shell/window
  * directly — so it works in both the Electron (shell.openExternal) and web
@@ -19,31 +24,63 @@ import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import './TheoryLink.css';
 
-export interface TheoryLinkProps {
-  /** Full GitHub blob URL to open externally. */
-  url: string;
-  /** Accessible label, distinct per instance (e.g. "Help: debate system overview"). */
-  label: string;
-  /** Glyph size in px, clamped to 14–16. Default 15. */
-  size?: number;
-  /** Hover tooltip text. Default "Open theory notes on GitHub". */
+/** Canonical GitHub repo for doc links — single source of truth (t/2410, TL-confirmed org). */
+const REPO_BLOB_BASE = 'https://github.com/jpsnover/ai-triad-research/blob/main';
+
+/** Build a GitHub blob URL from a repo-relative doc path (+ optional anchor). */
+export function buildDocUrl(docPath: string, anchor?: string): string {
+  return `${REPO_BLOB_BASE}/${docPath}${anchor ? `#${anchor}` : ''}`;
+}
+
+/**
+ * Humanize a doc filename into a Title-Cased display name (t/2410).
+ * Accepts a full URL or a repo-relative path; takes the last segment, drops the
+ * `#anchor` and `.md`, and turns `-`/`_` separators into Title-Cased words.
+ * e.g. `docs/debate-system-overview.md` → `"Debate System Overview"`.
+ * (Acronyms like `ai` → `Ai` are acceptable for v1 — no current doc hits this.)
+ */
+export function humanizeDocName(source: string): string {
+  const segment = source.split('#')[0].split('/').pop() ?? '';
+  const stem = segment.replace(/\.md$/i, '');
+  return stem
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+interface TheoryLinkBaseProps {
+  /** Accessible label. Optional — defaults to the tooltip text. */
+  label?: string;
+  /** Hover tooltip. Optional — defaults to `"Open {Doc Name} in GitHub"`. */
   tooltip?: string;
+  /** Glyph size in px, clamped to 12–16. Default 15. */
+  size?: number;
   /** Extra class(es) for inline positioning by consumers — appended to the base class. */
   className?: string;
 }
 
-const DEFAULT_TOOLTIP = 'Open theory notes on GitHub';
+/** Exactly one of `url` or `docPath` must be supplied (discriminated union). */
+export type TheoryLinkProps =
+  | (TheoryLinkBaseProps & { url: string; docPath?: never; anchor?: never })
+  | (TheoryLinkBaseProps & { docPath: string; anchor?: string; url?: never });
 
-export function TheoryLink({ url, label, size = 15, tooltip = DEFAULT_TOOLTIP, className }: TheoryLinkProps) {
-  const px = Math.min(16, Math.max(14, size));
+export function TheoryLink(props: TheoryLinkProps) {
+  const { label, tooltip, size = 15, className } = props;
+  const px = Math.min(16, Math.max(12, size));
+
+  const targetUrl = props.url ?? buildDocUrl(props.docPath ?? '', props.anchor);
+  const docName = humanizeDocName(props.docPath ?? props.url ?? '');
+  const title = tooltip ?? `Open ${docName} in GitHub`;
+  const ariaLabel = label ?? title;
 
   const handleOpen = () => {
-    void api.openExternal(url).catch((err) => {
+    void api.openExternal(targetUrl).catch((err) => {
       getGlobalRecorder()?.record({
         type: 'system.error',
         component: 'theory-link',
         level: 'error',
-        message: 'Failed to open theory link externally',
+        message: 'Failed to open doc link externally',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
     });
@@ -54,10 +91,10 @@ export function TheoryLink({ url, label, size = 15, tooltip = DEFAULT_TOOLTIP, c
       type="button"
       className={`theory-link ${className ?? ''}`}
       data-theory-link
-      aria-label={label}
-      title={tooltip}
+      aria-label={ariaLabel}
+      title={title}
       onClick={handleOpen}
-      // eslint-disable-next-line local/no-inline-style -- dynamic glyph size (14–16px) drives the 1em SVG
+      // eslint-disable-next-line local/no-inline-style -- dynamic glyph size (12–16px) drives the 1em SVG
       style={{ fontSize: `${px}px` }}
     >
       {/* Open-book glyph (currentColor so it can be tinted muted → hover-brighten) */}
@@ -75,3 +112,6 @@ export function TheoryLink({ url, label, size = 15, tooltip = DEFAULT_TOOLTIP, c
     </button>
   );
 }
+
+/** Readability alias — same component, clearer name at general doc-link call sites (t/2410). */
+export const DocLink = TheoryLink;

--- a/taxonomy-editor/src/renderer/components/sync/SaveBar.tsx
+++ b/taxonomy-editor/src/renderer/components/sync/SaveBar.tsx
@@ -127,7 +127,7 @@ export function SaveBar() {
           </button>
         )}
         <TheoryLink
-          url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/architecture-overview.md"
+          docPath="docs/architecture-overview.md"
           label="Help: architecture overview"
         />
         <div className="zoom-controls">

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -401,7 +401,7 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
           </span>
           <span className="nd-header-id">{node.id}</span>
           <TheoryLink
-            url="https://github.com/jpsnover/ai-triad-research/blob/main/docs/taxonomy-ontology-guide.md"
+            docPath="docs/taxonomy-ontology-guide.md"
             label="Help: taxonomy ontology guide"
             size={14}
           />
@@ -586,7 +586,7 @@ function NodeDetailHeaderTop({ pov, node, readOnly, err, update, maybeRegenAphor
       </div>
       <div className="nd-header-actions">
         <TheoryLink
-          url="https://github.com/jpsnover/ai-triad-research/blob/main/research/comp-linguist/analyses/epistemic-infrastructure-framing.md"
+          docPath="research/comp-linguist/analyses/epistemic-infrastructure-framing.md"
           label="Help: epistemic infrastructure framing"
         />
         {nodeTypeFromId(node.id) === 'pov' && (


### PR DESCRIPTION
## Summary
TL-approved (t/2410#2). Unifies the app's doc-link affordances onto `TheoryLink` so diagnostics can drop `BookmarkLink` (Child B).

- **API**: discriminated union — `url` **or** `docPath`(+`anchor`); URL built from a single `REPO_BLOB_BASE` (`jpsnover`, TL-confirmed).
- **Dynamic tooltip**: `"Open {Doc Name} in GitHub"` via new `humanizeDocName()` (Title Case). `label` now optional (defaults to tooltip).
- **Size clamp** relaxed 14–16 → **12–16** (diagnostics `xs`). F1 hotkey, ↗ badge, `api.openExternal` preserved. `DocLink` alias exported.
- `buildDocUrl` lifted to `TheoryLink` as the single builder; `BookmarkLink` now consumes it (fixes the barrel double-export).
- **Migrated all 8 main-window callers** `url=`→`docPath=` (org centralized). All were already `jpsnover` and every doc path resolves → **no BKC normalization needed, nothing to flag** (TL Q1).

**Sequencing**: `BookmarkLink` retirement is a follow-up after Child B removes its imports.

## Verification
renderer tsc 0 · eslint 0 errors · affected suites **98/98** · vite build OK.

Open questions all resolved in t/2410#2. Loop Design on the 12px glyph render — no 12px call site exists in PR-A yet (diagnostics adopt it in Child B / t/2412).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
