### PR TITLE
fix(debate-diagnostics): use POV_META.cssVar for all camp name colors (t/2419)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
@@ -18,6 +18,7 @@ import { OverviewTabRouter } from './OverviewTabRouter';
 import { EntryDetailRouter } from './EntryDetailRouter';
 import { CopyLinkButton } from '../../shared/CopyLinkButton';
 import { BookmarkLink } from '../../shared/BookmarkLink';
+import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
 import type { OverviewTab } from './types';
 import type { DebateSession } from '../../../types/debate';
 import type { RefObject } from 'react';
@@ -78,7 +79,7 @@ function HelpContent() {
       <p>Reading the network:</p>
       <ul>
         <li><strong>AN-1, AN-2, ...</strong> — claim identifiers, in order of appearance</li>
-        <li><strong>(Accelerationist), (Safetyist), (Skeptic)</strong> — who made the claim</li>
+        <li>{/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}<strong>(<span style={{ color: `var(${POV_META.accelerationist.cssVar})` }}>Accelerationist</span>), (<span style={{ color: `var(${POV_META.safetyist.cssVar})` }}>Safetyist</span>), (<span style={{ color: `var(${POV_META.skeptic.cssVar})` }}>Skeptic</span>)</strong> — who made the claim</li>
         <li><span className="diag-help-attack">&larr; AN-6 rebut via REFRAME</span> — claim AN-6 attacks
           this claim. &quot;rebut&quot; is the attack type; &quot;REFRAME&quot; is the dialectical scheme
           (the argumentative strategy used)</li>
@@ -442,7 +443,8 @@ export function DiagnosticsWindow({ initialData }: { initialData?: Record<string
                               title={`${speakerLabel(e.speaker)} [${e.type}]: ${e.content.slice(0, 80)}`}
                             >
                               <span className="diag-sidebar-stmt-id">{stmtId}</span>
-                              <span className="diag-sidebar-speaker">{speakerLabel(e.speaker)}</span>
+                              {/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}
+                              <span className="diag-sidebar-speaker" style={{ color: `var(${POV_META[e.speaker as PovMetaKey]?.cssVar ?? '--text-primary'})` }}>{speakerLabel(e.speaker)}</span>
                               <span onClick={(ev) => ev.stopPropagation()} className="diag-sidebar-copylink">
                                 <CopyLinkButton hash={`#diagnostics-window?debateId=${debate.id}&entry=${i}&tab=${entryTab}`} title="Copy link to this entry" />
                               </span>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.parts.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.parts.tsx
@@ -22,6 +22,7 @@ import {
   TaxRefsTab, DetailsTab, BriefTab, PlanTab, LookaheadTab, CiteTab,
   ExclusionGuardTab, AffectTab,
 } from './entry-tabs';
+import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
 import type { EntryDetailRouterProps } from './EntryDetailRouter';
 import {
   isTabEnabled,
@@ -114,7 +115,8 @@ export function EntryHeader({ p, m }: PartProps) {
           className="edr-stmt-badge"
         >{stmtId}</span>
       )}
-      <strong className="edr-speaker">{speakerLabel(entry.speaker)}</strong>
+      {/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}
+      <strong className="edr-speaker" style={{ color: `var(${POV_META[entry.speaker as PovMetaKey]?.cssVar ?? '--text-primary'})` }}>{speakerLabel(entry.speaker)}</strong>
       <span className="edr-entry-type">{entry.type}</span>
       <button
         onClick={() => { void api.clipboardWriteText(entry.id); }}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/OverviewTabRouter.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/OverviewTabRouter.tsx
@@ -25,6 +25,7 @@ import { GroundingPanel } from '../../analysis/GroundingPanel';
 import { PovProgressionView } from '../../PovProgression/PovProgressionView';
 import { PromptDiffContent } from '../../chat/PromptDiffWindow';
 import { CommitmentsPanel } from './shared';
+import { BookmarkLink } from '../../shared/BookmarkLink';
 
 declare const __COMPONENT_VERSIONS__: Record<string, string>;
 
@@ -74,7 +75,7 @@ function TopicScopeSection({ debate, effectiveOverviewTab }: { debate: DebateSes
   const scope = debate.topic.scope as TopicScope;
   return (
     <div className="ovr-topic-scope">
-      <h4 className="ovr-h4">Topic Scope</h4>
+      <h4 className="ovr-h4">Topic Scope <BookmarkLink docPath="docs/topic-scope.md" label="About Topic Scope" size="xs" /></h4>
       <div className="ovr-mb-8">
         <span className="ovr-scope-prop">{scope.core_proposition}</span>
       </div>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
@@ -12,6 +12,7 @@ import { INodeRow } from '../shared';
 import { BookmarkLink } from '../../../shared/BookmarkLink';
 import { Highlight, speakerLabel } from '../helpers';
 import type { OverviewTab } from '../types';
+import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
 
 interface ArgumentNetwork {
   nodes: ArgumentNetworkNode[];
@@ -186,7 +187,8 @@ export function ArgumentNetworkTab({
               title={`Go to ${stmtId ?? entryId} in transcript`}
             >
               <span className="ant-stmt-id">{stmtId ?? entryId}</span>
-              <span className="ant-speaker">{speakerLabel(srcEntry.speaker)}</span>
+              {/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}
+              <span className="ant-speaker" style={{ color: `var(${POV_META[srcEntry.speaker as PovMetaKey]?.cssVar ?? '--text-primary'})` }}>{speakerLabel(srcEntry.speaker)}</span>
               <span className="ant-muted">
                 {srcEntry.content.length > 200 ? srcEntry.content.slice(0, 200) + '…' : srcEntry.content}
               </span>
@@ -197,7 +199,8 @@ export function ArgumentNetworkTab({
             <div className="ant-mod-banner">
               <div className="ant-mod-row">
                 <span className="ant-mod-label">Moderator</span>
-                <span className="ant-bold">→ {speakerLabel(trace.selected)}</span>
+                {/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}
+                <span className="ant-bold" style={{ color: `var(${POV_META[trace.selected as PovMetaKey]?.cssVar ?? '--text-primary'})` }}>→ {speakerLabel(trace.selected)}</span>
                 {trace.selection_reason && (
                   <span className="ant-reason-chip">
                     {trace.selection_reason.replace(/_/g, ' ')}
@@ -221,11 +224,12 @@ export function ArgumentNetworkTab({
               {trace.candidates && trace.candidates.length > 0 && (
                 <div className="ant-candidates">
                   {trace.candidates.map((c, i) => (
-                    // eslint-disable-next-line local/no-inline-style -- opacity/fontWeight are data-driven (selected candidate)
+                    // eslint-disable-next-line local/no-inline-style -- opacity/fontWeight/color are data-driven (selected candidate, per-camp from POV_META.cssVar)
                     <span key={i} style={{
                       fontSize: 'var(--text-2xs)',
                       opacity: c.debater === trace.selected ? 1 : 0.6,
                       fontWeight: c.debater === trace.selected ? 700 : 400,
+                      color: `var(${POV_META[c.debater as PovMetaKey]?.cssVar ?? '--text-primary'})`,
                     }}>
                       #{c.rank} {speakerLabel(c.debater)}
                       {c.computed_strength != null && ` (${c.computed_strength.toFixed(2)})`}
@@ -270,11 +274,9 @@ export function ArgumentNetworkTab({
   );
 }
 
-const MINIMAP_SPEAKER_COLORS: Record<string, string> = {
-  accelerationist: 'var(--color-acc, #b84e13)',
-  safetyist: 'var(--color-saf, #2b5fad)',
-  skeptic: 'var(--color-skp, #7b4fa6)',
-};
+const MINIMAP_SPEAKER_COLORS: Record<string, string> = Object.fromEntries(
+  Object.entries(POV_META).filter(([k]) => k !== 'situations').map(([k, v]) => [k, `var(${v.cssVar})`])
+);
 const MINIMAP_DEGRADE_CEILING = 80;
 
 function ArgNetMinimap({ nodes, edges }: { nodes: ArgumentNetworkNode[]; edges: ArgumentNetworkEdge[] }) {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/EmotionalRegisterTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/EmotionalRegisterTab.tsx
@@ -15,6 +15,7 @@ import {
 } from '@lib/debate/affectSignals';
 import { getDebatePhase } from '@lib/debate/types';
 import { BookmarkLink } from '../../../shared/BookmarkLink';
+import { POV_META } from '@lib/electron-shared/povMeta';
 
 interface EmotionalRegisterTabProps {
   debate: DebateSession;
@@ -22,11 +23,9 @@ interface EmotionalRegisterTabProps {
   setLocalOverride: (v: boolean) => void;
 }
 
-const SPEAKER_COLORS: Record<string, string> = {
-  accelerationist: 'var(--color-acc)',
-  safetyist: 'var(--color-saf)',
-  skeptic: 'var(--color-skp)',
-};
+const SPEAKER_COLORS: Record<string, string> = Object.fromEntries(
+  Object.entries(POV_META).filter(([k]) => k !== 'situations').map(([k, v]) => [k, `var(${v.cssVar})`])
+);
 
 const CATEGORY_COLORS: Record<AffectCategory, string> = {
   urgency: 'var(--warning)',

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/UtilityTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/UtilityTab.tsx
@@ -8,6 +8,7 @@ import { UTILITY_WEIGHTS } from '../types';
 import type { UtilitySnapshot } from '../types';
 import { ScoreBadge } from '../shared';
 import { BookmarkLink } from '../../../shared/BookmarkLink';
+import { POV_META } from '@lib/electron-shared/povMeta';
 
 interface UtilityTabProps {
   debate: DebateSession;
@@ -21,7 +22,9 @@ export function UtilityTab({ debate, perTurnUtilities, setSelectedEntry, setLoca
   const latest = perTurnUtilities[perTurnUtilities.length - 1];
   const speakers = Object.keys(latest.byAgent);
   const maxComposite = Math.max(...perTurnUtilities.flatMap(s => Object.values(s.byAgent).map(a => a.composite)), 0.01);
-  const speakerColors: Record<string, string> = { accelerationist: 'var(--color-acc)', safetyist: 'var(--color-saf)', skeptic: 'var(--color-skp)' };
+  const speakerColors: Record<string, string> = Object.fromEntries(
+    Object.entries(POV_META).filter(([k]) => k !== 'situations').map(([k, v]) => [k, `var(${v.cssVar})`])
+  );
 
   const getTrend = (speaker: string): { icon: string; color: string; label: string } => {
     if (perTurnUtilities.length < 2) return { icon: '—', color: 'var(--text-muted)', label: 'insufficient data' };

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.tsx
@@ -6,6 +6,7 @@ import type { CommitmentStore, ArgumentNetworkNode, ArgumentNetworkEdge } from '
 import { POVER_INFO } from '../../../../types/debate';
 import type { SpeakerId } from '../../../../types/debate';
 import { bandColor, RISK_BANDS } from '../../../../lib/bandColor';
+import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
 import './CommitmentsPanel.css';
 
 // NOTE: speakerLabel and AifBadge stay in DiagnosticsWindow.tsx (parent).
@@ -128,7 +129,8 @@ export function CommitmentsPanel({ commitments, nodes, edges, onGoToNode }: {
       {Object.entries(commitments).map(([pov, store]) => (
         <div key={pov} className="commit-panel-pov-row">
           <div className="commit-panel-pov-header">
-            <strong className="commit-panel-pov-label">{speakerLabel(pov)}</strong>
+            {/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}
+            <strong className="commit-panel-pov-label" style={{ color: `var(${POV_META[pov as PovMetaKey]?.cssVar ?? '--text-primary'})` }}>{speakerLabel(pov)}</strong>
             {asymmetryByPov[pov] != null && (() => {
               const a = asymmetryByPov[pov]!;
               const color = bandColor(Math.abs(a), RISK_BANDS);

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/TensionsListDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/TensionsListDetail.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useMemo } from 'react';
 import { useTaxonomyStore } from '../../../../hooks/useTaxonomyStore';
+import { nodeIdColor } from './constants';
 
 export function TensionsListDetail({ content }: { content: string }) {
   const [selected, setSelected] = useState<number | null>(null);
@@ -55,11 +56,6 @@ export function TensionsListDetail({ content }: { content: string }) {
   const sel = selected != null ? tensions[selected] : null;
   const relationColor = (r: string) => r === 'CONTRADICTS' ? 'var(--danger)' : r === 'TENSION_WITH' ? 'var(--warning)' : 'var(--success)';
   const relationIcon = (r: string) => r === 'TENSION_WITH' ? '⟷' : r === 'CONTRADICTS' ? '✕' : '✓';
-  const sourcePov = (id: string) => id.startsWith('acc-') ? 'acc' : id.startsWith('saf-') ? 'saf' : id.startsWith('skp-') ? 'skp' : id.startsWith('sit-') ? 'sit' : '';
-  const povColor = (id: string) => {
-    const p = sourcePov(id);
-    return p === 'acc' ? 'var(--color-acc)' : p === 'saf' ? 'var(--color-saf)' : p === 'skp' ? 'var(--color-skp)' : p === 'sit' ? 'var(--success)' : '#888';
-  };
 
   const selRationale = sel ? edgeRationale.get(`${sel.source}|${sel.target}|${sel.relation}`) : undefined;
   const RATIONALE_TRUNCATE = 200;
@@ -74,11 +70,11 @@ export function TensionsListDetail({ content }: { content: string }) {
             borderLeft: selected === i ? '3px solid var(--color-acc)' : '3px solid transparent',
             borderBottom: '1px solid var(--border)',
           }}>
-            <span style={{ color: povColor(t.source), fontWeight: 600 }}>{t.source}</span>
+            <span style={{ color: nodeIdColor(t.source), fontWeight: 600 }}>{t.source}</span>
             <span style={{ color: relationColor(t.relation), fontSize: 'var(--text-2xs)', fontWeight: 700, margin: '0 4px' }}>
               {relationIcon(t.relation)}
             </span>
-            <span style={{ color: povColor(t.target), fontWeight: 600 }}>{t.target}</span>
+            <span style={{ color: nodeIdColor(t.target), fontWeight: 600 }}>{t.target}</span>
             <span style={{ marginLeft: 6, color: 'var(--text-muted)', fontSize: 'var(--text-2xs)' }}>{(t.confidence ?? 0).toFixed(2)}</span>
           </div>
         ))}
@@ -98,7 +94,7 @@ export function TensionsListDetail({ content }: { content: string }) {
             <div style={{ display: 'flex', alignItems: 'center', padding: '12px 12px 8px', gap: 8 }}>
               <div style={{ flex: 1 }}>
                 <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 600, marginBottom: 2 }}>Source</div>
-                <div style={{ fontWeight: 600, color: povColor(sel.source), fontSize: '0.78rem', lineHeight: 1.3 }}>
+                <div style={{ fontWeight: 600, color: nodeIdColor(sel.source), fontSize: '0.78rem', lineHeight: 1.3 }}>
                   {nodeLabel.get(sel.source) || sel.source}
                 </div>
                 <div style={{ fontFamily: 'monospace', fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 2 }}>{sel.source}</div>
@@ -108,7 +104,7 @@ export function TensionsListDetail({ content }: { content: string }) {
               </div>
               <div style={{ flex: 1 }}>
                 <div style={{ fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em', fontWeight: 600, marginBottom: 2 }}>Target</div>
-                <div style={{ fontWeight: 600, color: povColor(sel.target), fontSize: '0.78rem', lineHeight: 1.3 }}>
+                <div style={{ fontWeight: 600, color: nodeIdColor(sel.target), fontSize: '0.78rem', lineHeight: 1.3 }}>
                   {nodeLabel.get(sel.target) || sel.target}
                 </div>
                 <div style={{ fontFamily: 'monospace', fontSize: 'var(--text-2xs)', color: 'var(--text-muted)', marginTop: 2 }}>{sel.target}</div>


### PR DESCRIPTION
## Summary
- Replace all local ad-hoc camp color maps (`SPEAKER_COLORS`, `speakerColors`, `MINIMAP_SPEAKER_COLORS`, `sourcePov`/`povColor` helpers) with canonical `POV_META[key].cssVar` from `@lib/electron-shared/povMeta`
- Every POV/camp name in debate-diagnostics now renders in its theme-aware CSS variable (`--color-acc`, `--color-saf`, `--color-skp`) via one consistent mechanism
- Also folds CL.Investigate1's `BookmarkLink` for Topic Scope into `OverviewTabRouter` h4 (diff from t/2419#1)

## Files changed (8)
- `TensionsListDetail.tsx` — remove `sourcePov`/`povColor`, use `nodeIdColor()` (already derives from POV_META)
- `CommitmentsPanel.tsx` — add camp color to POV label
- `EmotionalRegisterTab.tsx` — replace hardcoded `SPEAKER_COLORS` map
- `UtilityTab.tsx` — replace hardcoded `speakerColors` map
- `ArgumentNetworkTab.tsx` — replace `MINIMAP_SPEAKER_COLORS`; color `ant-speaker`, moderator selected, candidates
- `EntryDetailRouter.parts.tsx` — color `edr-speaker`
- `DiagnosticsWindow.tsx` — color sidebar speaker; split help-text Acc/Saf/Skp into individually-colored spans
- `OverviewTabRouter.tsx` — BookmarkLink on Topic Scope h4

## Test plan
- [ ] Renderer tsc: 0/0 errors (verified locally)
- [ ] UI: open debate diagnostics, verify Accelerationist/Safetyist/Skeptic labels render in green/red/yellow in both light and dark themes
- [ ] Self-cert: UI-only, POV_META pattern per NodeDetail.tsx:891

🤖 Generated with [Claude Code](https://claude.com/claude-code)