### PR TITLE
fix(taxonomy): TaxonomyRefDetail grows instead of inner-scrolling (t/2414)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/TaxonomyRefDetail.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/TaxonomyRefDetail.css
@@ -7,8 +7,9 @@
   border: 1px solid var(--border);
   border-left: 3px solid var(--accent);
   border-radius: 4px;
-  max-height: 70vh;
-  overflow-y: auto;
+  /* No own height cap (t/2414): grow to fit content (e.g. a long Steelman Vulnerability)
+     instead of an inner fixed-height scrollbar that clips it. The enclosing detail pane /
+     diagnostics entry-tab (overflow-y:auto) handles overflow. */
 }
 
 .taxref-header-pad {


### PR DESCRIPTION
## Summary
Drop `.taxref-detail`'s own-scroll cap (`max-height:70vh; overflow-y:auto`, TaxonomyRefDetail.css:10). A long **Steelman Vulnerability** rendered via `TaxonomyRefDetail` (the read-only reference / diagnostics view in t3.png) was clipped by this inner fixed-height scrollbar. The panel now grows to fit; overflow is handled by the enclosing detail pane / diagnostics entry-tab (both `overflow-y:auto`), per the AC.

## Root cause (component corrected)
The ticket description pointed at `NodeDetail` + `styles.css`; the static trace there was cap-free. TL corrected it (t/2414#4): the read-only path is **`TaxonomyRefDetail`**, and `.taxref-detail` is the only capped element on that steelman path (the `.taxref-steelman-*` blocks have no cap). Rule carried over verbatim in the t/1849 migration.

## Verification
- contrast ratchet unchanged (302/314)
- CSS-only, `.taxref-steelman-*` unaffected; other TaxonomyRefDetail sections just grow with the panel
- ⚠️ **Not visually verified before/after** — couldn't stand up a current-main instance (electron binary install fails + :5173 occupied, see t/2414#3). Relying on AC intent + confirmed outer-scroll. **Needs a visual eyeball** on a running build (Text/read-only ref view with a long steelman).

Self-cert /trivial-change. Closes t/2414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
