### PR TITLE
feat(ui): UI bundle — Skeptic glyph, statement bookmark, base type/icon scale (t/2415, t/2418, t/2416)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -441,9 +441,12 @@ function MainApp() {
     return () => mq.removeEventListener('change', handler);
   }, [colorScheme]);
 
-  // Apply zoom level
+  // Apply zoom level. 112.5% (18px root) is the comfortable web baseline (t/2416); the zoom
+  // control multiplies against it, so "zoom 100%" == the baseline and taxonomy-editor-zoom still
+  // round-trips as a percentage (default 100).
   useEffect(() => {
-    document.documentElement.style.fontSize = `${zoomLevel}%`;
+    const BASE_FONT_PCT = 112.5;
+    document.documentElement.style.fontSize = `${(BASE_FONT_PCT * zoomLevel) / 100}%`;
   }, [zoomLevel]);
 
   // Apply pane spacing

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.css
@@ -236,11 +236,11 @@
   color: var(--color-sit);
 }
 
-/* TheoryLink help icons (t/2347). Footer (g): the .debate-taxonomy-refs row is
-   flex, so margin-left:auto parks the icon at the right end beside Explain/Caveats.
+/* TheoryLink help icons (t/2347). Footer (g): sits directly beside the Caveats
+   control (t/2418 — no longer right-parked; gated on has-caveats in RefsHeader).
    Summary (f): small gap after the BRIEF/PLAN label. */
 .taxrefs-refs-help {
-  margin-left: auto;
+  margin-left: 6px;
   vertical-align: middle;
 }
 .taxrefs-section-help {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.tsx
@@ -153,20 +153,24 @@ function RefsHeader({ entry, explainCopied, onExplain, onToggleCaveats }: {
           : <button className="debate-reasoning-toggle" onClick={onExplain} title="Copy an explain prompt to clipboard and open Gemini">Explain</button>
       )}
       {entry?.caveats && entry.caveats.length > 0 && (
-        <button
-          className="debate-reasoning-toggle taxrefs-caveats-btn"
-          onClick={onToggleCaveats}
-          title="Unresolved argument limitations identified by the judge"
-        >
-          Caveats ({entry.caveats.length})
-        </button>
+        <>
+          <button
+            className="debate-reasoning-toggle taxrefs-caveats-btn"
+            onClick={onToggleCaveats}
+            title="Unresolved argument limitations identified by the judge"
+          >
+            Caveats ({entry.caveats.length})
+          </button>
+          {/* Doc-link icon — gated on has-caveats + placed beside the Caveats control, no longer right-parked (t/2418).
+              Uses the unified docPath form (t/2410, now on main). */}
+          <TheoryLink
+            docPath="docs/citation-diagnostics-design.md"
+            label="Help: citation diagnostics design"
+            size={14}
+            className="taxrefs-refs-help"
+          />
+        </>
       )}
-      <TheoryLink
-        docPath="docs/citation-diagnostics-design.md"
-        label="Help: citation diagnostics design"
-        size={14}
-        className="taxrefs-refs-help"
-      />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/organizations/OrganizationDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/organizations/OrganizationDetail.tsx
@@ -74,7 +74,7 @@ export function OrgLogo({ name, url, size = 24 }: { name: string; url?: string; 
     <span
       className="org-logo-initials"
       /* eslint-disable-next-line local/no-inline-style -- size/bg are per-instance dynamic values passed as CSS custom properties */
-      style={{ '--size': `${size}px`, '--font-size': `${size * 0.4}px`, '--bg': bg } as React.CSSProperties}
+      style={{ '--size': `${size / 16}em`, '--font-size': `${(size * 0.4) / 16}em`, '--bg': bg } as React.CSSProperties}
     >
       {initials}
     </span>
@@ -92,7 +92,7 @@ function PersonAvatar({ name, size = 24 }: { name: string; size?: number }) {
     <span
       className="person-avatar"
       /* eslint-disable-next-line local/no-inline-style -- size/bg are per-instance dynamic values passed as CSS custom properties */
-      style={{ '--size': `${size}px`, '--font-size': `${size * 0.4}px`, '--bg': bg } as React.CSSProperties}
+      style={{ '--size': `${size / 16}em`, '--font-size': `${(size * 0.4) / 16}em`, '--bg': bg } as React.CSSProperties}
     >
       {initials}
     </span>

--- a/taxonomy-editor/src/renderer/components/shared/BottomNav.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/BottomNav.tsx
@@ -107,7 +107,7 @@ export function BottomNav({ onOpenMore }: BottomNavProps) {
           className="bottom-nav-item"
           onClick={onOpenMore}
         >
-          <Ellipsis size={22} />
+          <Ellipsis size="1.5em" />
           <span className="bottom-nav-label">More</span>
         </button>
       </nav>

--- a/taxonomy-editor/src/renderer/components/shared/CampGlyph.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/CampGlyph.test.tsx
@@ -13,8 +13,8 @@ describe('CampGlyph', () => {
     const { container } = render(<CampGlyph camp={camp} />);
     const svg = container.querySelector('svg');
     expect(svg).toBeInTheDocument();
-    expect(svg).toHaveAttribute('width', '16');
-    expect(svg).toHaveAttribute('height', '16');
+    expect(svg).toHaveAttribute('width', '1em');
+    expect(svg).toHaveAttribute('height', '1em');
     expect(svg).toHaveAttribute('aria-hidden', 'true');
   });
 
@@ -28,8 +28,8 @@ describe('CampGlyph', () => {
   it('accepts a custom size', () => {
     const { container } = render(<CampGlyph camp="saf" size={24} />);
     const svg = container.querySelector('svg');
-    expect(svg).toHaveAttribute('width', '24');
-    expect(svg).toHaveAttribute('height', '24');
+    expect(svg).toHaveAttribute('width', '1.5em');
+    expect(svg).toHaveAttribute('height', '1.5em');
   });
 
   it('accepts a custom className', () => {

--- a/taxonomy-editor/src/renderer/components/shared/CampGlyph.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/CampGlyph.tsx
@@ -34,8 +34,8 @@ const PATHS: Record<CampKey, JSX.Element> = {
 export function CampGlyph({ camp, size = 16, className }: CampGlyphProps) {
   return (
     <svg
-      width={size}
-      height={size}
+      width={`${size / 16}em`}
+      height={`${size / 16}em`}
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/taxonomy-editor/src/renderer/components/shared/CampGlyph.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/CampGlyph.tsx
@@ -21,11 +21,12 @@ const PATHS: Record<CampKey, JSX.Element> = {
   saf: (
     <path d="M12 3l7 4v5c0 4.5-3 8.5-7 10-4-1.5-7-5.5-7-10V7l7-4z" />
   ),
+  // Bare "?" — reads as doubt/scrutiny (the Skeptic's stance) without the
+  // circled-"?" Help affordance or the old bullseye's "selected radio" read (t/2415, Design t/2415#1).
   skp: (
     <>
-      <circle cx="12" cy="12" r="4" />
-      <circle cx="12" cy="12" r="9" />
-      <circle cx="12" cy="12" r="1.5" />
+      <path d="M8.5 9.5a3.5 3.5 0 1 1 5.3 3c-1.1.8-1.8 1.4-1.8 2.8" />
+      <path d="M12 18.5h0.01" />
     </>
   ),
 };

--- a/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
@@ -211,7 +211,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
       className={`hamburger-item${isNavItemActive(item) ? ' active' : ''}`}
       onClick={() => act(() => dispatchNav(item.action))}
     >
-      <item.icon size={20} />
+      <item.icon size="1.25em" />
       <span>{item.label}</span>
     </button>
   );
@@ -235,7 +235,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
       >
         <div className="hamburger-header">
           <button className="hamburger-close" onClick={onClose} aria-label="Close menu">
-            <X size={20} />
+            <X size="1.25em" />
           </button>
           <span className="hamburger-title">Taxonomy Editor</span>
         </div>
@@ -263,7 +263,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
               className={`hamburger-item${window.location.hash === '#admin' ? ' active' : ''}`}
               onClick={() => act(() => { window.location.hash = '#admin'; window.location.reload(); })}
             >
-              <Shield size={20} />
+              <Shield size="1.25em" />
               <span>Admin Review</span>
             </button>
           )}
@@ -275,7 +275,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
               className="hamburger-item"
               onClick={() => { dispatchNav(item.action); onClose(); }}
             >
-              <item.icon size={20} />
+              <item.icon size="1.25em" />
               <span>{item.label}</span>
             </button>
           ))}

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.test.tsx
@@ -97,13 +97,13 @@ describe('TheoryLink', () => {
     expect(btn.className).toContain('inline-heading');
   });
 
-  it('clamps size to 12–16px', () => {
+  it('clamps size to 12–16px, emitted as em (px/16) so it scales with zoom (t/2416)', () => {
     const { rerender } = render(<TheoryLink url={URL} label="H" size={40} />);
-    expect(screen.getByRole('button').style.fontSize).toBe('16px');
+    expect(screen.getByRole('button').style.fontSize).toBe('1em');
     rerender(<TheoryLink url={URL} label="H" size={2} />);
-    expect(screen.getByRole('button').style.fontSize).toBe('12px');
+    expect(screen.getByRole('button').style.fontSize).toBe('0.75em');
     rerender(<TheoryLink url={URL} label="H" size={12} />);
-    expect(screen.getByRole('button').style.fontSize).toBe('12px');
+    expect(screen.getByRole('button').style.fontSize).toBe('0.75em');
   });
 
   // ── runtime guard (t/2410 blocker): exactly one of url/docPath ──

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.tsx
@@ -110,8 +110,8 @@ export function TheoryLink(props: TheoryLinkProps) {
       aria-label={ariaLabel}
       title={title}
       onClick={handleOpen}
-      // eslint-disable-next-line local/no-inline-style -- dynamic glyph size (12–16px) drives the 1em SVG
-      style={{ fontSize: `${px}px` }}
+      // eslint-disable-next-line local/no-inline-style -- dynamic glyph size drives the 1em SVG; em (px/16) scales with the root baseline + zoom (t/2416)
+      style={{ fontSize: `${px / 16}em` }}
     >
       {/* Open-book glyph (currentColor so it can be tinted muted → hover-brighten) */}
       <svg className="theory-link-book" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" focusable="false">

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -89,7 +89,7 @@ function ToolbarAuthButton() {
         data-tooltip={auth.anonymous ? 'Sign in' : auth.user}
       >
         {auth.anonymous ? (
-          <User size={20} />
+          <User size="1.25em" />
         ) : (
           <span className="toolbar-auth-avatar">{initial}</span>
         )}
@@ -152,13 +152,13 @@ function ToolbarAuthButton() {
               <div className="toolbar-auth-divider" />
               <a className="toolbar-more-item toolbar-more-link" href="#community"
                 onClick={() => setShowPopover(false)}>
-                <Users size={18} />
+                <Users size="1.25em" />
                 <span>Community Library</span>
               </a>
               {adminFeatures && (
                 <a className="toolbar-more-item toolbar-more-link" href="#admin"
                   onClick={() => setShowPopover(false)}>
-                  <Shield size={18} />
+                  <Shield size="1.25em" />
                   <span>Admin Review</span>
                   {reviewCount > 0 && (
                     <span className="toolbar-auth-admin-badge toolbar-auth-badge-ml">
@@ -170,7 +170,7 @@ function ToolbarAuthButton() {
               <div className="toolbar-auth-divider" />
               <a className="toolbar-more-item toolbar-more-link" href="/api/auth/logout"
                 onClick={() => { getGlobalRecorder()?.record({ type: 'auth.logout_initiated', component: 'auth', level: 'info', message: 'User initiated logout', data: { target: '/api/auth/logout', source: 'toolbar' } }); setShowPopover(false); }}>
-                <LogOut size={18} />
+                <LogOut size="1.25em" />
                 <span>Sign out</span>
               </a>
             </>
@@ -291,7 +291,7 @@ export function Toolbar() {
               aria-label="Back"
               data-tooltip="Back"
             >
-              <ArrowLeft size={20} />
+              <ArrowLeft size="1.25em" />
             </button>
             <div className="toolbar-separator" />
           </>
@@ -302,7 +302,7 @@ export function Toolbar() {
           onClick={() => toggle('search')}
           aria-label="Search"
         >
-          <Search size={20} />
+          <Search size="1.25em" />
           <span className="toolbar-nav-label">Search</span>
         </button>
         <button
@@ -316,7 +316,7 @@ export function Toolbar() {
           }}
           aria-label="Taxonomy"
         >
-          <LayoutGrid size={20} />
+          <LayoutGrid size="1.25em" />
           <span className="toolbar-nav-label">Taxonomy</span>
         </button>
         <button
@@ -324,7 +324,7 @@ export function Toolbar() {
           onClick={() => switchTab('debate')}
           aria-label="Debate"
         >
-          <MessageSquare size={20} />
+          <MessageSquare size="1.25em" />
           <span className="toolbar-nav-label">Debate</span>
         </button>
         <button
@@ -332,7 +332,7 @@ export function Toolbar() {
           onClick={() => void api.openChatWindow()}
           aria-label="Chat"
         >
-          <MessageCircle size={20} />
+          <MessageCircle size="1.25em" />
           <span className="toolbar-nav-label">Chat</span>
         </button>
       </div>
@@ -343,7 +343,7 @@ export function Toolbar() {
           aria-label={viewMode === 'simple' ? 'Switch to Advanced view' : 'Switch to Simple view'}
           data-tooltip={viewMode === 'simple' ? 'Switch to Advanced view' : 'Switch to Simple view'}
         >
-          <Layers size={20} />
+          <Layers size="1.25em" />
         </button>
         {/* Other Tools — hidden in Simple view */}
         {viewMode === 'advanced' && <div className="toolbar-more-wrap" ref={moreRef}>
@@ -353,7 +353,7 @@ export function Toolbar() {
             aria-label="Other Tools"
             data-tooltip="Other Tools"
           >
-            <Ellipsis size={20} />
+            <Ellipsis size="1.25em" />
           </button>
           {showMore && (
             <div className="toolbar-more-popover" role="menu">
@@ -366,7 +366,7 @@ export function Toolbar() {
                       className={`toolbar-more-item${isNavItemActive(item) ? ' active' : ''}`}
                       onClick={() => { dispatchNav(item.action); setShowMore(false); }}
                     >
-                      <item.icon size={18} />
+                      <item.icon size="1.25em" />
                       <span>{item.label}</span>
                     </button>
                   ))}
@@ -382,7 +382,7 @@ export function Toolbar() {
           aria-label="Help"
           data-tooltip="Help"
         >
-          <CircleHelp size={20} />
+          <CircleHelp size="1.25em" />
         </button>
         <div className="toolbar-feedback-wrap" ref={feedbackRef}>
           <button
@@ -391,7 +391,7 @@ export function Toolbar() {
             aria-label="Feedback"
             data-tooltip="Feedback"
           >
-            <Star size={20} />
+            <Star size="1.25em" />
           </button>
           {showFeedback && <FeedbackPopover onClose={() => setShowFeedback(false)} />}
         </div>
@@ -403,7 +403,7 @@ export function Toolbar() {
           aria-label="Reload taxonomy data"
           data-tooltip="Reload taxonomy data"
         >
-          <RefreshCw size={20} />
+          <RefreshCw size="1.25em" />
         </button>
         <button
           className="toolbar-icon"
@@ -411,7 +411,7 @@ export function Toolbar() {
           aria-label="Settings"
           data-tooltip="Settings"
         >
-          <Settings size={20} />
+          <Settings size="1.25em" />
         </button>
       </div>
       {showSettings && <SettingsDialog onClose={() => setShowSettings(false)} />}

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -253,6 +253,13 @@
   --text-xl:  1.375rem;
   --text-2xl: 1.75rem;
 
+  /* Icon sizes — em-based so lucide glyphs track adjacent text AND the zoom control (t/2416).
+     Bucket map: 14→sm, 18/20→md, 22→lg (see design-system.md). One-offs (favicon 16 raster,
+     large empties) stay fixed-px. */
+  --icon-sm: 1em;
+  --icon-md: 1.25em;
+  --icon-lg: 1.5em;
+
   --leading-ui: 1.4;
   --leading-prose: 1.65;
 


### PR DESCRIPTION
## UI bundle (TL PI direction p/336#77 — one PR)

- **t/2415** — Skeptic camp glyph → bare "?" (Design t/2415#1); only `PATHS.skp` changes.
- **t/2418** — statement doc-link gated on has-caveats + moved beside the Caveats control (unified `docPath` form).
- **t/2416** — base type/icon scale (Design spec + t/2416#2):
  - **Part 1**: 112.5% (18px) root baseline via the `App.tsx` zoom effect (`fontSize = 112.5 * zoomLevel/100 %`; "zoom 100%" == baseline, taxonomy-editor-zoom round-trips); `--icon-sm/md/lg` tokens.
  - **Part 2**: lucide call sites → em (Toolbar/HamburgerMenu 1.25em, BottomNav 1.5em); numeric-prop trio (TheoryLink/CampGlyph/OrgLogo/PersonAvatar) keep the numeric API but render `${size/16}em` internally; raster favicons fixed-px; `design-system.md` reconciled.
- **t/2417** — **not included**: RS2 investigated, no-repro on current main (t/2417#1); dropping from the bundle unless Design confirms a repro.

## Verification
Deterministic gates green: renderer tsc 0, eslint 0 errors, contrast 302/314 (unchanged), vite build OK, shared suites (CampGlyph/TheoryLink/DebateWorkspace/TaxonomyRefs) pass.

⚠️ **Visual ACs are Design's gate** — dense-surface regression (8 surfaces) + `/design-review-workflow`. I'm CDP-blocked (electron binary + :5173); **@Design to run the visual pass on staging** per your t/2416#2 note. Self-merge after Design's visual sign-off + green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
