### PR TITLE
fix(debate): persist adaptive_staging_diagnostics in the GUI per-round path (t/2423)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/adaptiveStagingDiagnostics.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/adaptiveStagingDiagnostics.test.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Prevention test for t/2423: adaptive_staging_diagnostics must be written
+// to the session on every GUI crossRespond round when adaptive staging is
+// enabled. The engine batch path (runAdaptiveCrossRespond) always writes it;
+// this test guards the GUI per-round path (evaluateAdaptiveStaging) which
+// previously accumulated signal telemetry into module-level state only and
+// never wrote it back to the session — leaving termination_reason = 'unknown'
+// on 1167/1168 real post-cutoff debates (t/2422 audit).
+import { describe, it, expect, vi } from 'vitest';
+import { mockApi, makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+import { runModeratorSelection, executeTurnWithRetry } from '@lib/debate/orchestration';
+import { loadProvisionalWeights } from '@lib/debate/phaseTransitions';
+
+const makeTurnResult = (speaker: string) => ({
+  statement: `${speaker} response`,
+  taxonomyRefs: [],
+  meta: { move_types: ['CHALLENGE'], policy_refs: [] },
+  validation: { outcome: 'accept', score: 0.9, repairHints: [], clarifies_taxonomy: [] },
+  attempts: [{ statement: `${speaker} response`, score: 0.9 }],
+  pipelineResult: {
+    draft: {},
+    total_time_ms: 100,
+    stage_diagnostics: [{ stage: 'draft', prompt: 'p', raw_response: 'r' }],
+    topicAlignmentResult: null,
+  },
+  aborted: false,
+});
+
+const makeModResult = (speaker: string) => ({
+  responder: speaker,
+  focusPoint: 'test focus',
+  addressing: 'all',
+  agreementDetected: false,
+  selectionResult: {},
+  intervention: null,
+  interventionBriefInjection: '',
+  modState: {
+    budget_remaining: 10, budget_total: 10, health_history: [],
+    consecutive_decline: 0, round: 1, phase: 'debate', required_gap: 2,
+    rounds_since_last_intervention: 5, burden_per_debater: {},
+  },
+  healthScore: { value: 0.8, trend: 0, components: {} },
+  earlyReturn: false,
+  diagnostics: { selectionPrompt: '', selectionResponse: '' },
+});
+
+describe('adaptive_staging_diagnostics — GUI per-round path (t/2423 prevention)', () => {
+  it('populates adaptive_staging_diagnostics.signal_telemetry after each crossRespond round', async () => {
+    // Supply a proper pacing config so evaluateAdaptiveStaging can build PhaseTransitionConfig.
+    vi.mocked(loadProvisionalWeights).mockReturnValue({
+      pacing_presets: { moderate: { maxTotalRounds: 10 } },
+      phase_bounds: { min_confrontation_rounds: 2, min_argumentation_rounds: 2, min_concluding_rounds: 2 },
+      network: { gc_trigger: 200, gc_target: 150 },
+    } as any);
+
+    vi.mocked(runModeratorSelection).mockResolvedValue(makeModResult('accelerationist') as any);
+    vi.mocked(executeTurnWithRetry).mockResolvedValue(makeTurnResult('accelerationist') as any);
+
+    useDebateStore.setState({
+      activeDebate: makeSession({
+        phase: 'debate',
+        active_povers: ['accelerationist', 'safetyist', 'skeptic'],
+        transcript: [
+          { id: 'o1', timestamp: 't', type: 'opening', speaker: 'accelerationist', content: 'Opening A', taxonomy_refs: [] },
+          { id: 'o2', timestamp: 't', type: 'opening', speaker: 'safetyist', content: 'Opening S', taxonomy_refs: [] },
+          { id: 'o3', timestamp: 't', type: 'opening', speaker: 'skeptic', content: 'Opening K', taxonomy_refs: [] },
+        ],
+        adaptive_staging: {
+          enabled: true,
+          pacing: 'moderate',
+          phase_state: {
+            current_phase: 'confrontation',
+            rounds_in_phase: 0,
+            total_rounds_elapsed: 0,
+            argumentation_exit_threshold: 0.6,
+            concluding_exit_threshold: 0.7,
+            regression_count: 0,
+            gc_ran_this_phase: false,
+          },
+        },
+        argument_network: { nodes: [], edges: [] },
+        diagnostics: {
+          enabled: true,
+          entries: {},
+          overview: {
+            total_ai_calls: 0, total_response_time_ms: 0,
+            claims_accepted: 0, claims_rejected: 0,
+            move_type_counts: {}, disagreement_type_counts: {},
+          },
+        },
+      }) as any,
+      initialCrossRespondRounds: 3,
+    });
+
+    await useDebateStore.getState().crossRespond();
+
+    const debate = useDebateStore.getState().activeDebate!;
+    expect(debate.adaptive_staging_diagnostics).toBeDefined();
+    expect(debate.adaptive_staging_diagnostics!.signal_telemetry.length).toBeGreaterThanOrEqual(1);
+    expect(debate.adaptive_staging_diagnostics!.total_predicate_evaluations).toBeGreaterThanOrEqual(1);
+    expect(mockApi.saveDebateSession).toHaveBeenCalled();
+  });
+
+  it('accumulates signal_telemetry across multiple rounds', async () => {
+    vi.mocked(loadProvisionalWeights).mockReturnValue({
+      pacing_presets: { moderate: { maxTotalRounds: 10 } },
+      phase_bounds: { min_confrontation_rounds: 2, min_argumentation_rounds: 2, min_concluding_rounds: 2 },
+      network: { gc_trigger: 200, gc_target: 150 },
+    } as any);
+
+    const baseSession = makeSession({
+      phase: 'debate',
+      active_povers: ['accelerationist', 'safetyist'],
+      transcript: [
+        { id: 'o1', timestamp: 't', type: 'opening', speaker: 'accelerationist', content: 'Opening A', taxonomy_refs: [] },
+        { id: 'o2', timestamp: 't', type: 'opening', speaker: 'safetyist', content: 'Opening S', taxonomy_refs: [] },
+      ],
+      adaptive_staging: {
+        enabled: true,
+        pacing: 'moderate',
+        phase_state: {
+          current_phase: 'confrontation',
+          rounds_in_phase: 0,
+          total_rounds_elapsed: 0,
+          argumentation_exit_threshold: 0.6,
+          concluding_exit_threshold: 0.7,
+          regression_count: 0,
+          gc_ran_this_phase: false,
+        },
+      },
+      argument_network: { nodes: [], edges: [] },
+      diagnostics: {
+        enabled: true,
+        entries: {},
+        overview: {
+          total_ai_calls: 0, total_response_time_ms: 0,
+          claims_accepted: 0, claims_rejected: 0,
+          move_type_counts: {}, disagreement_type_counts: {},
+        },
+      },
+    });
+
+    useDebateStore.setState({ activeDebate: baseSession as any, initialCrossRespondRounds: 3 });
+
+    for (const speaker of ['accelerationist', 'safetyist']) {
+      vi.mocked(runModeratorSelection).mockResolvedValueOnce(makeModResult(speaker) as any);
+      vi.mocked(executeTurnWithRetry).mockResolvedValueOnce(makeTurnResult(speaker) as any);
+      await useDebateStore.getState().crossRespond();
+    }
+
+    const debate = useDebateStore.getState().activeDebate!;
+    expect(debate.adaptive_staging_diagnostics!.signal_telemetry.length).toBeGreaterThanOrEqual(2);
+    expect(debate.adaptive_staging_diagnostics!.total_predicate_evaluations).toBeGreaterThanOrEqual(2);
+  });
+
+  it('records a phases entry when evaluatePhaseTransition returns transition', async () => {
+    const { evaluatePhaseTransition } = await import('@lib/debate/phaseTransitions');
+    vi.mocked(evaluatePhaseTransition).mockReturnValueOnce({
+      action: 'transition', reason: 'saturation threshold reached',
+      confidence_deferred: false, veto_active: false, force_active: false,
+      components: {},
+    } as any);
+    vi.mocked(loadProvisionalWeights).mockReturnValue({
+      pacing_presets: { moderate: { maxTotalRounds: 10 } },
+      phase_bounds: { min_confrontation_rounds: 2, min_argumentation_rounds: 2, min_concluding_rounds: 2 },
+      network: { gc_trigger: 200, gc_target: 150 },
+    } as any);
+
+    vi.mocked(runModeratorSelection).mockResolvedValue(makeModResult('accelerationist') as any);
+    vi.mocked(executeTurnWithRetry).mockResolvedValue(makeTurnResult('accelerationist') as any);
+
+    useDebateStore.setState({
+      activeDebate: makeSession({
+        phase: 'debate',
+        active_povers: ['accelerationist', 'safetyist', 'skeptic'],
+        transcript: [
+          { id: 'o1', timestamp: 't', type: 'opening', speaker: 'accelerationist', content: 'Opening A', taxonomy_refs: [] },
+          { id: 'o2', timestamp: 't', type: 'opening', speaker: 'safetyist', content: 'Opening S', taxonomy_refs: [] },
+          { id: 'o3', timestamp: 't', type: 'opening', speaker: 'skeptic', content: 'Opening K', taxonomy_refs: [] },
+        ],
+        adaptive_staging: {
+          enabled: true,
+          pacing: 'moderate',
+          phase_state: {
+            current_phase: 'confrontation',
+            rounds_in_phase: 2,
+            total_rounds_elapsed: 2,
+            argumentation_exit_threshold: 0.6,
+            concluding_exit_threshold: 0.7,
+            regression_count: 0,
+            gc_ran_this_phase: false,
+          },
+        },
+        argument_network: { nodes: [], edges: [] },
+        diagnostics: {
+          enabled: true,
+          entries: {},
+          overview: {
+            total_ai_calls: 0, total_response_time_ms: 0,
+            claims_accepted: 0, claims_rejected: 0,
+            move_type_counts: {}, disagreement_type_counts: {},
+          },
+        },
+      }) as any,
+      initialCrossRespondRounds: 3,
+    });
+
+    await useDebateStore.getState().crossRespond();
+
+    const debate = useDebateStore.getState().activeDebate!;
+    expect(debate.adaptive_staging_diagnostics!.phases.length).toBeGreaterThanOrEqual(1);
+    expect(debate.adaptive_staging_diagnostics!.phases[0].exit_reason).toBe('saturation threshold reached');
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/storeTestHarness.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/storeTestHarness.ts
@@ -225,6 +225,7 @@ vi.mock('@lib/debate/taxonomyGapAnalysis', () => ({
 
 vi.mock('@lib/debate/moderator', () => ({
   updateModeratorState: vi.fn().mockReturnValue({}),
+  computeDebateHealthScore: vi.fn().mockReturnValue({ value: 0.8, trend: 0, components: {} }),
   MOVE_RESPONSE_CONFIG: {},
   DIRECT_RESPONSE_PATTERNS: [],
 }));
@@ -274,12 +275,18 @@ vi.mock('@lib/debate/phaseTransitions', () => ({
   loadProvisionalWeights: vi.fn().mockReturnValue({}),
   initPhaseState: vi.fn().mockReturnValue({ current_phase: 'confrontation', rounds_in_phase: 0, total_rounds_elapsed: 0 }),
   evaluatePhaseTransition: vi.fn().mockReturnValue({ action: 'continue', reason: 'test' }),
-  advanceRound: vi.fn().mockReturnValue({ current_phase: 'confrontation', rounds_in_phase: 1, total_rounds_elapsed: 1 }),
+  advanceRound: vi.fn().mockReturnValue({ current_phase: 'confrontation', rounds_in_phase: 1, total_rounds_elapsed: 1, argumentation_exit_threshold: 0.6, concluding_exit_threshold: 0.7 }),
   applyTransition: vi.fn().mockReturnValue({ current_phase: 'confrontation', rounds_in_phase: 0, total_rounds_elapsed: 1 }),
   buildSignalRegistry: vi.fn().mockReturnValue([]),
   computeSaturationScore: vi.fn().mockReturnValue(0),
   computeConvergenceScore: vi.fn().mockReturnValue(0),
   detectCruxNodes: vi.fn().mockReturnValue([]),
+  buildPhaseContext: vi.fn().mockReturnValue({ phase_progress: 0.3, rationale: 'test', approaching_transition: false }),
+  buildSignalTelemetry: vi.fn().mockReturnValue({ round: 1, phase: 'confrontation', composite: { convergence_score: 0.1, saturation_score: 0.1 }, signals: {}, action: 'continue', reason: 'test', phase_progress: 0.3, predicate_ms: 0 }),
+  initAdaptiveDiagnostics: vi.fn().mockImplementation(() => ({
+    signal_telemetry: [], phases: [], regressions: [], gc_events: [],
+    total_predicate_evaluations: 0, confidence_deferrals: 0, vetoes_fired: 0, forces_fired: 0, network_size_peak: 0,
+  })),
 }));
 
 vi.mock('@lib/debate/gapCheck', () => ({

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
@@ -70,6 +70,9 @@ import {
   computeSaturationScore,
   computeConvergenceScore,
   detectCruxNodes,
+  buildPhaseContext,
+  buildSignalTelemetry,
+  initAdaptiveDiagnostics,
 } from '@lib/debate/phaseTransitions';
 import { runTurnPipeline, assemblePipelineResult } from '@lib/debate/turnPipeline';
 import { evaluateLookaheadPerClaim, buildClaimAnalysis } from '@lib/debate/lookaheadGate';
@@ -713,6 +716,44 @@ function evaluateAdaptiveStaging(get: _Get, set: _Set, addTranscriptEntry: _AddE
   const satScore = computeSaturationScore(signals, signalCtx, coldStart);
   const convScore = computeConvergenceScore(signalCtx, coldStart);
   recordPhaseSignals(postDebate, signals, signalCtx, advanced, crossRespondRound, lastConvSignal, lastClaimsAccepted, satScore, convScore, asHealthScore, result, config);
+
+  // Accumulate adaptive_staging_diagnostics for the GUI per-round path (t/2423). The engine
+  // batch loop (runAdaptiveCrossRespond) writes `diag` once at loop end, but GUI debates run
+  // round-by-round through this function — so without accumulating here, the session never
+  // carries adaptive_staging_diagnostics and termination_reason / convergence_score_at_termination
+  // stay unpopulated on live sessions. Mutations land on postDebate, which applyPhaseTransitionResult
+  // writes back in the same set().
+  if (!postDebate.adaptive_staging_diagnostics) {
+    postDebate.adaptive_staging_diagnostics = initAdaptiveDiagnostics();
+  }
+  const diag = postDebate.adaptive_staging_diagnostics;
+  const currentPhaseStartRound = diag.phases.length > 0
+    ? Math.max(...diag.phases[diag.phases.length - 1].rounds) + 1
+    : 1;
+  diag.total_predicate_evaluations++;
+  if (result.confidence_deferred) diag.confidence_deferrals++;
+  if (result.veto_active) diag.vetoes_fired++;
+  if (result.force_active) diag.forces_fired++;
+  diag.network_size_peak = Math.max(diag.network_size_peak, signalCtx.network.nodeCount);
+
+  const phaseCtx = buildPhaseContext(advanced, config, satScore, convScore);
+  diag.signal_telemetry.push(buildSignalTelemetry(advanced, signalCtx, signals, result, phaseCtx.phase_progress, 0));
+
+  // `advanced.current_phase` is the phase we're exiting (the transition is applied below).
+  if (result.action === 'transition' || result.action === 'force_transition' || result.action === 'terminate') {
+    diag.phases.push({
+      phase: advanced.current_phase,
+      rounds: Array.from({ length: crossRespondRound - currentPhaseStartRound + 1 }, (_, i) => currentPhaseStartRound + i),
+      exit_reason: result.reason,
+      force_active: result.force_active,
+    });
+  } else if (result.action === 'regress') {
+    diag.regressions.push({
+      from_round: crossRespondRound,
+      crux_id: 'unknown',
+      threshold_after: advanced.argumentation_exit_threshold,
+    });
+  }
 
   // Apply transition (skipped in step mode — user controls phase manually)
   applyPhaseTransitionResult(get, set, addTranscriptEntry, advanced, result, config, postDebate.adaptive_staging!.step_mode);


### PR DESCRIPTION
## Summary
GUI debates run round-by-round through `evaluateAdaptiveStaging` (`debatePhaseSlice.ts`), which evaluated phase transitions but never accumulated `adaptive_staging_diagnostics` onto the session — only the engine batch loop did. So real GUI-run adaptive debates carried `adaptive_staging` (enabled) but not `*_diagnostics`, leaving `termination_reason='unknown'` / `convergence_score_at_termination=null` on live sessions (CL audit, t/2423).

## Fix (per DebateTool's spec, e/85)
Each round now: inits diagnostics if absent → pushes a `signal_telemetry` entry → bumps counters (predicate evals / confidence deferrals / vetoes / forces / network peak) → records a `phases` entry on transition/force_transition/terminate (or a `regressions` entry on regress). Mutates `postDebate` before `applyPhaseTransitionResult`'s `set()` writes it back.

## Verification
renderer tsc 0, eslint 0 errors (no new complexity warning), useDebateStore suite 128/128, build OK.

**Prevention test** (lib/debate GUI-path fixture) is DebateTool's per e/85 — coordinating whether it rides this branch or lands adjacent. Closes t/2423 once the test is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
