### PR TITLE
fix(deploy): remove deploy-azure.yml from GitHub health check (t/2425)

### DIFF
--- a/scripts/AITriad/Public/Test-GitHubHealth.ps1
+++ b/scripts/AITriad/Public/Test-GitHubHealth.ps1
@@ -124,7 +124,10 @@ function Test-GitHubHealth {
     }
 
     # ── Latest Workflow Runs ─────────────────────────────────────────────
-    $KeyWorkflows = @('ci.yml', 'deploy-azure.yml', 'health-monitor.yml')
+    # deploy-azure.yml excluded: checking the last deploy creates a circular
+    # dependency — a failed deploy blocks all future deploys from passing the
+    # pre-traffic smoke gate (t/2425).
+    $KeyWorkflows = @('ci.yml', 'health-monitor.yml')
 
     # t/1975 — scope the workflow-runs query to the deployed line (default: main)
     # so a red PR/branch run doesn't false-FAIL the CI-health category in a prod

--- a/tests/Test-GitHubHealth.BranchScope.Tests.ps1
+++ b/tests/Test-GitHubHealth.BranchScope.Tests.ps1
@@ -49,11 +49,11 @@ Describe 'Test-GitHubHealth branch scoping (t/1975)' -Tag 'health' {
 
             $result = Test-GitHubHealth 6>$null
 
-            @($script:WfUris).Count | Should -Be 3 -Because 'all three key workflows are queried'
+            @($script:WfUris).Count | Should -Be 2 -Because 'ci.yml and health-monitor.yml are queried (deploy-azure.yml excluded, t/2425)'
             foreach ($u in $script:WfUris) { $u | Should -Match 'branch=main' -Because 'the query must be scoped to the deployed line' }
 
             $wfChecks = @($result.Checks | Where-Object { $_.Check -like 'Workflow:*' })
-            @($wfChecks).Count | Should -Be 3
+            @($wfChecks).Count | Should -Be 2
             @($wfChecks | Where-Object { -not $_.Pass }).Count | Should -Be 0 -Because 'branch=main returns only the green main run; the red non-main run is filtered out (the t/1975 fix)'
             $wfChecks[0].Check | Should -Match '@main' -Because 'the scoping is visible in the check label'
         }


### PR DESCRIPTION
## Summary
- Test-GitHubHealth checks the last completed \deploy-azure.yml\ run; a failed deploy sets \GitHubOk=false\ and blocks all future deploys via the pre-traffic smoke gate — circular dependency
- Remove \deploy-azure.yml\ from \\\; keep \ci.yml\ + \health-monitor.yml\

## Root cause
Prod deploy at midnight (t/2403 null bug) set \deploy-azure.yml @main = failure\. Next deploy attempt aborted at smoke gate with \GitHub: FAIL\ despite 26/26 endpoints passing.

## Test plan
- [ ] CI green
- [ ] Re-trigger prod deploy — smoke gate passes GitHub check
- [ ] \deploy-azure.yml\ no longer in \Test-GitHubHealth\ check list

🤖 Generated with [Claude Code](https://claude.com/claude-code)