### PR TITLE
feat(comp-linguist): composition-drift gate for embeddings.json (t/2425)

### DIFF
--- a/research/comp-linguist/analyses/embedding-drift-gate/README.md
+++ b/research/comp-linguist/analyses/embedding-drift-gate/README.md
@@ -1,0 +1,63 @@
+# Embedding composition-drift gate (t/2425)
+
+**Last updated:** 2026-08-10
+
+Prevents the t/2425 incident class — *duplicated-constant drift* between the two
+embeddings generators:
+
+- `scripts/embed_taxonomy.py generate` (Python, weighted composition), and
+- `taxonomy-editor/src/main/embeddings.ts::updateNodeEmbeddings` (JS, single-field description-only, the de-facto live-corpus maintainer).
+
+They silently diverged once (the Python default was 0.8/0.2 while the live corpus
+became description-only), and only a manual splice tripped over it. This gate makes
+a future divergence **fail a check** instead.
+
+## What it checks
+
+`check_composition_drift.py` re-encodes N sampled nodes **per the DECLARED
+`field_weights` in the embeddings.json envelope** and asserts cosine ≥ 0.9999 vs
+the shipped vectors. If declared == actual, the generators cannot have diverged
+without failing here.
+
+### Environment-drift vs composition-drift (distinguished — t/2425#4)
+
+A CI runner whose encoder can't reproduce the corpus would false-fail. So a
+**CONTROL** runs first — re-encode per the known-canonical composition
+(description-only):
+
+| CONTROL (canonical) | TEST (declared weights) | Meaning | Action |
+|---|---|---|---|
+| fails | — | **environment drift** — runner not reproducible | warn, **exit 0** (never blocks) |
+| passes | fails | **composition drift** — envelope ≠ actual vectors | `--mode blocking` → exit 1; `advisory` → warn |
+| passes | passes | aligned | exit 0 |
+
+So `--mode blocking` **auto-degrades to advisory on environment drift** — it only
+ever blocks on a genuine composition mismatch.
+
+## Usage
+
+```bash
+# live drift guard (CI): blocks only on real composition drift
+python check_composition_drift.py --taxonomy-dir "$AI_TRIAD_DATA_ROOT/taxonomy/Origin" --mode blocking
+
+# Gate Verification / health check: proves BOTH arms in the current environment
+python check_composition_drift.py --taxonomy-dir "$AI_TRIAD_DATA_ROOT/taxonomy/Origin" --selftest
+```
+
+`--selftest` runs the clean arm (declared weights reproduce → pass) and a
+failure arm (a deliberately-planted 0.8/0.2 composition **must** be detected as
+drift). Exit non-zero iff the gate itself is broken (missed the plant or
+false-flagged clean). Running it in CI is how we prove both arms *in the CI
+environment* before trusting `--mode blocking`.
+
+## Exit codes
+
+`0` pass / advisory / selftest-ok · `1` composition drift (blocking) · `2`
+usage/load error (warn) · `3` selftest failure (gate broken).
+
+## Related
+
+- t/2408 byte-stability gate (the splice-time ancestor of this check).
+- Metric-provenance register row 59 (canonical composition = description-only).
+- The canonical is pinned on the generator side by `scripts/embed_taxonomy.py`
+  `DEFAULT_FIELD_WEIGHTS = (1,0,0,0,0)` (t/2425).

--- a/research/comp-linguist/analyses/embedding-drift-gate/check_composition_drift.py
+++ b/research/comp-linguist/analyses/embedding-drift-gate/check_composition_drift.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+"""check_composition_drift.py — composition-drift gate for embeddings.json (t/2425).
+
+Prevents the t/2425 incident class (duplicated-constant drift between the two
+embeddings generators: scripts/embed_taxonomy.py and taxonomy-editor's
+updateNodeEmbeddings). It verifies that the shipped corpus was actually produced
+with the composition its own envelope `field_weights` DECLARES:
+
+  re-encode N sampled nodes per the DECLARED envelope weights and assert
+  cosine >= THRESHOLD (0.9999) vs the shipped vectors.
+
+If that holds, declared == actual and the two generators cannot have silently
+diverged without failing this check. Fires if the corpus is regenerated at
+weights != the envelope, the envelope is edited without a matching regen, or a
+generator's composition logic drifts.
+
+Environment-drift vs composition-drift (TL condition, t/2425#4)
+--------------------------------------------------------------
+A CI runner whose encoder can't reproduce the shipped vectors would false-fail.
+So we run a CONTROL first — re-encode per the KNOWN-canonical composition
+(description-only) and check reproduction:
+
+  * CONTROL fails (canonical can't reproduce)  -> ENVIRONMENT drift. Never blocks;
+    emit a warning and exit 0 (the gate degrades to advisory — the runner is not
+    reproducible enough to trust a hard failure).
+  * CONTROL passes, TEST (declared weights) fails -> COMPOSITION drift. This is the
+    real regression: block in --mode blocking, warn in --mode advisory.
+
+--selftest proves BOTH arms in the current environment (for Gate Verification):
+  clean arm  — declared weights reproduce (expect pass),
+  failure arm— a deliberately-wrong composition (0.8/0.2) is planted and MUST be
+               detected as drift.
+  Exits 0 iff the gate passes the clean arm AND flags the planted drift; non-zero
+  if the gate is broken (missed the plant or false-flagged clean).
+
+Exit codes: 0 = pass/advisory/selftest-ok; 1 = composition drift (blocking mode);
+2 = usage/load error; 3 = selftest failure (gate itself is broken).
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+THRESHOLD = 0.9999          # reproduction floor (same as the t/2408 byte-stability gate)
+DEFAULT_SAMPLE_N = 6
+CANONICAL_WEIGHTS = (1.0, 0.0, 0.0, 0.0, 0.0)   # description-only (the live-corpus composition)
+
+
+def _find_embed_taxonomy() -> Path:
+    """Walk up from this file to locate scripts/embed_taxonomy.py."""
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        cand = parent / "scripts" / "embed_taxonomy.py"
+        if cand.exists():
+            return cand
+    raise FileNotFoundError("scripts/embed_taxonomy.py not found above this file")
+
+
+def _load_embed_taxonomy():
+    """Import embed_taxonomy so the gate uses the REAL generator's field composition."""
+    spec = importlib.util.spec_from_file_location("embed_taxonomy", _find_embed_taxonomy())
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _resolve_taxonomy_dir(override: str | None) -> Path:
+    if override:
+        return Path(override).resolve()
+    env = os.environ.get("AI_TRIAD_DATA_ROOT")
+    if env:
+        return (Path(env) / "taxonomy" / "Origin").resolve()
+    # .aitriad.json fallback
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        cfg = parent / ".aitriad.json"
+        if cfg.exists():
+            c = json.loads(cfg.read_text(encoding="utf-8"))
+            root = Path(c.get("data_root", ".."))
+            base = root if root.is_absolute() else (parent / root)
+            return (base / c.get("taxonomy_dir", "taxonomy/Origin")).resolve()
+    raise FileNotFoundError("cannot resolve taxonomy dir (pass --taxonomy-dir or set AI_TRIAD_DATA_ROOT)")
+
+
+def _compose(model, et, nodes, weights):
+    """Compose vectors for `nodes` under `weights` via embed_taxonomy's own field
+    extraction (raw per-field encode -> weighted sum -> single L2). Faithful to the
+    generator's recipe, so the gate tracks the real composition."""
+    w = np.asarray(weights, dtype=np.float64)
+    field_texts = [et._compose_field_texts(n, {}) for n in nodes]   # (desc,assumes,lineage,epist,rhet)
+    # encode each of the 5 fields for all nodes, raw (no normalize) — matches generate()
+    per_field = []
+    for f in range(5):
+        texts = [ft[f] for ft in field_texts]
+        per_field.append(np.asarray(model.encode(texts, normalize_embeddings=False), dtype=np.float64))
+    out = np.zeros_like(per_field[0])
+    for f in range(5):
+        out += w[f] * per_field[f]
+    norms = np.linalg.norm(out, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return out / norms
+
+
+def _min_cos(composed, shipped):
+    c = []
+    for i in range(len(shipped)):
+        a = composed[i]; b = np.asarray(shipped[i], dtype=np.float64)
+        c.append(float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))))
+    return min(c), c
+
+
+def _sample(tax_dir: Path, et, n: int):
+    """Pick N nodes present in embeddings.json with a description (+ shipped vector)."""
+    emb = json.loads((tax_dir / "embeddings.json").read_text(encoding="utf-8"))
+    emb_nodes = emb["nodes"]
+    declared = emb.get("field_weights") or {}
+    # load POV nodes (reuse embed_taxonomy loader against this dir)
+    et.TAXONOMY_DIR = tax_dir
+    pov = {}
+    for p in sorted(tax_dir.glob("*.json")):
+        if p.name in et.SKIP_FILES or p.stem.startswith("embeddings-"):
+            continue
+        try:
+            d = json.loads(p.read_text(encoding="utf-8-sig"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        for node in d.get("nodes", []):
+            if isinstance(node, dict) and isinstance(node.get("id"), str):
+                pov[node["id"]] = node
+    picks = []
+    for nid, node in pov.items():
+        e = emb_nodes.get(nid)
+        if e and not e.get("degenerate") and node.get("description"):
+            picks.append((node, e["vector"]))
+        if len(picks) >= n:
+            break
+    return picks, declared, emb
+
+
+def _declared_tuple(declared: dict):
+    """envelope field_weights dict -> (desc,assumes,lineage,epist,rhet) tuple."""
+    return (
+        float(declared.get("description", 0.0)),
+        float(declared.get("assumes", 0.0)),
+        float(declared.get("lineage", 0.0)),
+        float(declared.get("epistemic", 0.0)),
+        float(declared.get("rhetorical", 0.0)),
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Composition-drift gate for embeddings.json (t/2425).")
+    ap.add_argument("--taxonomy-dir", default=None)
+    ap.add_argument("--sample", type=int, default=DEFAULT_SAMPLE_N)
+    ap.add_argument("--mode", choices=["advisory", "blocking"], default="advisory",
+                    help="advisory: composition drift warns (exit 0). blocking: composition drift fails (exit 1).")
+    ap.add_argument("--selftest", action="store_true",
+                    help="prove both arms in this environment; exit non-zero iff the gate is broken.")
+    args = ap.parse_args()
+
+    try:
+        tax_dir = _resolve_taxonomy_dir(args.taxonomy_dir)
+        et = _load_embed_taxonomy()
+        picks, declared, emb = _sample(tax_dir, et, args.sample)
+    except Exception as exc:  # load/usage error
+        print(f"::warning::composition-drift gate could not load corpus: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    if not picks:
+        print("::warning::composition-drift gate found no sampleable nodes — skipping", file=sys.stderr)
+        sys.exit(0)
+
+    if not declared:
+        print("::warning::embeddings.json envelope has no field_weights to check against — skipping", file=sys.stderr)
+        sys.exit(0)
+
+    from sentence_transformers import SentenceTransformer  # local import: heavy
+    model = SentenceTransformer(emb.get("model", "all-MiniLM-L6-v2"))
+    nodes = [p[0] for p in picks]
+    shipped = [p[1] for p in picks]
+
+    # CONTROL: canonical description-only reproduction (environment probe)
+    ctrl_min, _ = _min_cos(_compose(model, et, nodes, CANONICAL_WEIGHTS), shipped)
+    control_ok = ctrl_min >= THRESHOLD
+
+    # TEST: reproduce per the DECLARED envelope weights
+    declared_w = _declared_tuple(declared)
+    test_min, _ = _min_cos(_compose(model, et, nodes, declared_w), shipped)
+    test_ok = test_min >= THRESHOLD
+
+    if args.selftest:
+        # failure arm: a deliberately-wrong composition (0.8/0.2) MUST be detected
+        plant_min, _ = _min_cos(_compose(model, et, nodes, (0.8, 0.2, 0.0, 0.0, 0.0)), shipped)
+        planted_detected = plant_min < THRESHOLD
+        print(json.dumps({
+            "selftest": True, "control_min_cos": round(ctrl_min, 6),
+            "declared_min_cos": round(test_min, 6), "planted_0.8_0.2_min_cos": round(plant_min, 6),
+            "clean_arm_passes": control_ok and test_ok, "failure_arm_detects_plant": planted_detected,
+        }, indent=2))
+        if not (control_ok and test_ok):
+            print("::error::selftest clean arm FAILED — env cannot reproduce the shipped corpus", file=sys.stderr)
+            sys.exit(3)
+        if not planted_detected:
+            print("::error::selftest failure arm FAILED — gate did not detect a planted 0.8/0.2 drift", file=sys.stderr)
+            sys.exit(3)
+        print("selftest OK — clean arm passes AND planted drift is detected", file=sys.stderr)
+        sys.exit(0)
+
+    result = {"declared_field_weights": declared, "control_min_cos": round(ctrl_min, 6),
+              "declared_min_cos": round(test_min, 6), "threshold": THRESHOLD, "sample": len(picks)}
+    print(json.dumps(result, indent=2))
+
+    if not control_ok:
+        # environment drift — never blocks
+        print(f"::warning::ENVIRONMENT drift — canonical composition reproduces at only {ctrl_min:.6f} "
+              f"(< {THRESHOLD}); the CI encoder is not reproducible enough to trust a hard failure. "
+              f"Gate degraded to advisory this run.", file=sys.stderr)
+        sys.exit(0)
+
+    if not test_ok:
+        # composition drift — control passed, so the env is fine; declared != actual
+        msg = (f"COMPOSITION drift — the corpus does NOT reproduce at the envelope's declared "
+               f"field_weights {declared} (min cos {test_min:.6f} < {THRESHOLD}), but DOES at the "
+               f"canonical description-only composition (control {ctrl_min:.6f}). The envelope and the "
+               f"actual vectors disagree — align the generators/envelope (t/2425).")
+        if args.mode == "blocking":
+            print(f"::error::{msg}", file=sys.stderr)
+            sys.exit(1)
+        print(f"::warning::{msg} [advisory mode — not blocking]", file=sys.stderr)
+        sys.exit(0)
+
+    print(f"OK — corpus reproduces at declared field_weights (min cos {test_min:.6f} >= {THRESHOLD}).", file=sys.stderr)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Prevention half of t/2425 (TL-approved, t/2425#4) — the productized composition-drift gate.

`check_composition_drift.py` re-encodes N sampled nodes **per the DECLARED envelope `field_weights`** and asserts cosine ≥0.9999 vs shipped. A future divergence between the two embeddings generators now **fails a check**.

- **env-drift vs composition-drift distinguished** (TL condition): a canonical-composition CONTROL runs first — if it can't reproduce, that's environment drift → warn, **exit 0** (never blocks). Only a real composition mismatch (control passes, declared fails) blocks in `--mode blocking`.
- **`--selftest`** proves both arms in the runner (clean passes + a planted 0.8/0.2 drift is detected) — this is how we prove both arms *in CI* before trusting blocking mode.
- **Inert until DevOps wires it** into the `python-embed-smoke` CI job (separate diff, routing per t/2425#4).

Verified locally: current corpus (envelope 0.8/0.2) flags composition drift (declared 0.9857 vs control 1.0); corrected corpus passes; selftest clean+plant both fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)