### PR TITLE
ci(embed-smoke): wire composition-drift gate into python-embed-smoke (t/2430)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,6 +768,22 @@ jobs:
           HF_HUB_OFFLINE: '1'
           TRANSFORMERS_OFFLINE: '1'
         run: python .github/ci/assert_embed_stability.py
+      - name: Checkout data repo (composition-drift gate, t/2430)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+        with:
+          repository: jpsnover/ai-triad-data
+          path: ai-triad-data
+          token: ${{ secrets.DATA_REPO_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Composition-drift gate — selftest + blocking (t/2430)
+        env:
+          AI_TRIAD_DATA_ROOT: ${{ github.workspace }}/ai-triad-data
+          HF_HUB_OFFLINE: '1'
+          TRANSFORMERS_OFFLINE: '1'
+        run: |
+          python research/comp-linguist/analyses/embedding-drift-gate/check_composition_drift.py \
+            --taxonomy-dir "$AI_TRIAD_DATA_ROOT/taxonomy/Origin" --selftest
+          python research/comp-linguist/analyses/embedding-drift-gate/check_composition_drift.py \
+            --taxonomy-dir "$AI_TRIAD_DATA_ROOT/taxonomy/Origin" --mode blocking
 
   # ── lockfile-overrides-check: standalone lockfile divergence guard (t/2188) ──
   # Confirms taxonomy-editor/pnpm-lock.yaml overrides: block matches root


### PR DESCRIPTION
## Summary
- Adds `ai-triad-data` checkout to `python-embed-smoke` job
- Runs `--selftest` (proves both arms: clean pass + planted 0.8/0.2 drift detected) then `--mode blocking` (blocks on genuine composition mismatch, exits 0 on environment-drift)
- TL-approved at t/2425#4; gate script landed at c580b0f4

## Test plan
- [ ] CI green — `python-embed-smoke` selftest output confirms both arms pass in runner
- [ ] `--mode blocking` exits 0 (no composition drift in current corpus)
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)