### PR TITLE
fix(embed): align DEFAULT_FIELD_WEIGHTS to description-only (t/2429)

### DIFF
--- a/scripts/embed_taxonomy.py
+++ b/scripts/embed_taxonomy.py
@@ -139,7 +139,7 @@ CONFLICTS_DIR: Optional[Path] = None  # set in _resolve_taxonomy_dir
 
 # Default weights for multi-field embedding.  Must sum to 1.0.
 # Fields: description, assumes, lineage, epistemic_type, rhetorical_strategy
-DEFAULT_FIELD_WEIGHTS = (0.8, 0.2, 0.0, 0.0, 0.0)
+DEFAULT_FIELD_WEIGHTS = (1.0, 0.0, 0.0, 0.0, 0.0)
 
 
 def _package_version(pkg_name: str) -> str:
@@ -386,7 +386,7 @@ def cmd_generate(args):
     per field first would flatten the weight ratios (t/268, see combination site).
 
     Weights are configurable via --field-weights (DEFAULT_FIELD_WEIGHTS =
-    0.8/0.2/0/0/0). Policies and conflicts each use a single embedding of their
+    1/0/0/0/0). Policies and conflicts each use a single embedding of their
     action/claim text, normalized individually.
     """
     nodes = _load_taxonomy_nodes()

--- a/scripts/test_embed_envelope.py
+++ b/scripts/test_embed_envelope.py
@@ -37,7 +37,7 @@ def test_envelope_stamps_encoder_versions_and_composition():
 
     # Composition descriptor records the recipe accurately.
     comp = env["composition"]
-    assert "0.8/0.2" in comp  # the DEFAULT weights, rendered dynamically
+    assert "1/0/0/0/0" in comp  # the DEFAULT weights, rendered dynamically
     assert "single final L2 normalize" in comp
     assert "incl. Excludes" in comp  # description is verbatim, not Excludes-stripped
 
@@ -45,7 +45,7 @@ def test_envelope_stamps_encoder_versions_and_composition():
     assert env["model"] == "all-MiniLM-L6-v2"
     assert env["dimension"] == 384
     assert env["node_count"] == 1
-    assert env["field_weights"]["description"] == 0.8
+    assert env["field_weights"]["description"] == 1.0
 
 
 def test_composition_descriptor_reflects_actual_weights():


### PR DESCRIPTION
## Summary

- `embed_taxonomy.py:142`: `DEFAULT_FIELD_WEIGHTS` corrected from `(0.8, 0.2, 0.0, 0.0, 0.0)` to `(1.0, 0.0, 0.0, 0.0, 0.0)`
- `embed_taxonomy.py:389`: cmd_generate docstring updated to match
- `test_embed_envelope.py:40`: composition descriptor assertion updated to `"1/0/0/0/0"`
- `test_embed_envelope.py:48`: bonus fix — `field_weights["description"] == 0.8` → `1.0` (missed in spec, caught by running tests; flagged to CL at p/23#124)

## Verification

- `python scripts/test_embed_envelope.py` → OK (exit 0)
- Pester: 1048 passed, 0 failed (cc292584)
- Pre-land grep clean: no other hardcoded `0.8/0.2` or `0.8, 0.2` refs remain in `scripts/`

TL pre-approved at t/2429 (t/2425#4). Self-cert: /trivial-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>