### PR TITLE
fix(comp-linguist): drift-gate --selftest warns (not fails) on env drift (t/2425)

### DIFF
--- a/research/comp-linguist/analyses/embedding-drift-gate/README.md
+++ b/research/comp-linguist/analyses/embedding-drift-gate/README.md
@@ -44,11 +44,14 @@ python check_composition_drift.py --taxonomy-dir "$AI_TRIAD_DATA_ROOT/taxonomy/O
 python check_composition_drift.py --taxonomy-dir "$AI_TRIAD_DATA_ROOT/taxonomy/Origin" --selftest
 ```
 
-`--selftest` runs the clean arm (declared weights reproduce → pass) and a
-failure arm (a deliberately-planted 0.8/0.2 composition **must** be detected as
-drift). Exit non-zero iff the gate itself is broken (missed the plant or
-false-flagged clean). Running it in CI is how we prove both arms *in the CI
-environment* before trusting `--mode blocking`.
+`--selftest` proves both arms: the **clean arm** (the runner reproduces the
+canonical composition) and the **failure arm** (a deliberately-planted 0.8/0.2
+composition **must** be detected as drift). It exits non-zero (3) **only** on a
+genuine gate defect — the env reproduces the corpus but the gate misses a planted
+drift. On **environment drift** (the runner can't reproduce even the canonical
+composition) it warns and exits 0 — warn-only on a shaky runner, same as
+`--mode blocking`; it never reds the build on env drift. Running it in CI is how
+we prove both arms *in the CI environment* before trusting `--mode blocking`.
 
 ## Exit codes
 

--- a/research/comp-linguist/analyses/embedding-drift-gate/check_composition_drift.py
+++ b/research/comp-linguist/analyses/embedding-drift-gate/check_composition_drift.py
@@ -204,15 +204,23 @@ def main():
         print(json.dumps({
             "selftest": True, "control_min_cos": round(ctrl_min, 6),
             "declared_min_cos": round(test_min, 6), "planted_0.8_0.2_min_cos": round(plant_min, 6),
-            "clean_arm_passes": control_ok and test_ok, "failure_arm_detects_plant": planted_detected,
+            "clean_arm_env_reproduces": control_ok, "failure_arm_detects_plant": planted_detected,
         }, indent=2))
-        if not (control_ok and test_ok):
-            print("::error::selftest clean arm FAILED — env cannot reproduce the shipped corpus", file=sys.stderr)
-            sys.exit(3)
+        if not control_ok:
+            # Environment drift — the runner can't reproduce even the canonical composition, so the
+            # gate is unverifiable here. Warn LOUDLY but exit 0 (warn-only on a shaky runner per
+            # t/2425#4) — NEVER red the build on environment drift, only on a real gate defect.
+            print(f"::warning::selftest UNVERIFIABLE — the CI encoder cannot reproduce the canonical "
+                  f"composition (control {ctrl_min:.6f} < {THRESHOLD}): environment drift, not a gate or "
+                  f"composition defect. Investigate the encoder stack. Advisory — not failing.", file=sys.stderr)
+            sys.exit(0)
         if not planted_detected:
-            print("::error::selftest failure arm FAILED — gate did not detect a planted 0.8/0.2 drift", file=sys.stderr)
+            # env reproduces (control ok) but the gate missed a planted drift -> the gate is broken
+            print("::error::selftest failure arm FAILED — env reproduces the corpus but the gate did NOT "
+                  "detect a planted 0.8/0.2 drift. The gate itself is broken.", file=sys.stderr)
             sys.exit(3)
-        print("selftest OK — clean arm passes AND planted drift is detected", file=sys.stderr)
+        print(f"selftest OK — clean arm (env reproduces canonical @ {ctrl_min:.6f}) AND failure arm "
+              f"(planted drift detected @ {plant_min:.6f}) both fire.", file=sys.stderr)
         sys.exit(0)
 
     result = {"declared_field_weights": declared, "control_min_cos": round(ctrl_min, 6),


### PR DESCRIPTION
Hardens the composition-drift gate's `--selftest` to fully honor the TL condition (t/2425#4): warn-only on a shaky runner.

Previously `--selftest` exited 3 (hard fail) when the runner couldn't reproduce the canonical composition — which would red a *future* shaky runner (env drift), contradicting the warn-only intent. Now:
- **environment drift** (control can't reproduce) → loud `::warning::` + **exit 0** (unverifiable, advisory) — same fallback as `--mode blocking`.
- **exit 3** is reserved for a genuine gate defect: env reproduces the corpus but the gate misses a planted drift.

Clean arm redefined as "env reproduces canonical"; the declared-vs-actual check stays `--mode blocking`'s job.

Verified locally across the full matrix: aligned → both arms fire (exit 0); perturbed-vector corpus (control 0.854) → UNVERIFIABLE warn (exit 0); planted 0.8/0.2 → detected; composition drift → blocking exit 1. The aligned path is already green in CI (DevOps PR #793 python-embed-smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)