### PR TITLE
fix(docker): add ARG/ENV BUILD_SHA to builder stage before Vite build (t/2437)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -60,6 +60,12 @@ COPY CHANGELOG.md ./
 COPY taxonomy/schemas/ ./taxonomy/schemas/
 
 WORKDIR /build/taxonomy-editor
+
+# Expose commit SHA to Vite at build time so it's baked into the renderer bundle.
+# Empty default → fallback chain in vite.config.ts handles missing arg gracefully.
+ARG BUILD_SHA
+ENV BUILD_SHA=$BUILD_SHA
+
 # Cache mount required: pnpm store not in image layer — `pnpm licenses list` reads
 # package index files from the store.
 # pnpm shim: in workspace mode, `pnpm licenses list --prod` (called by generate-license-file)


### PR DESCRIPTION
## Summary
- Adds \ARG BUILD_SHA\ and \ENV BUILD_SHA=\\ in the builder stage of \	axonomy-editor/Dockerfile\, immediately before the \
pm run build:container\ step
- Exposes the commit SHA to Vite at build time so \ite.config.ts::getGitSha()\ can read \process.env.BUILD_SHA\
- Building without \--build-arg BUILD_SHA=<sha>\ still succeeds — empty default, fallback chain handles it

## Self-cert
Self-certifying under /trivial-change. Single file, 6 lines added, no new API/interface/schema changes.

Closes t/2437 (child of t/2434)

🤖 Generated with [Claude Code](https://claude.com/claude-code)