### PR TITLE
chore(flight-recorder): add debate.source to FR context snapshot (t/2435)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -700,6 +700,11 @@ export function initFlightRecorder(): FlightRecorder {
         },
         debate: debate ? {
           id: debate.id,
+          // Community (read-only, viewing a shared debate) vs personal (editable). Lets
+          // triage read the source directly instead of inferring it from a comments-404
+          // error chain (t/2435). communityReadOnly is the store's durable representation
+          // of the `source=community` load path.
+          source: (debateState.communityReadOnly ? 'community' : 'personal') as 'community' | 'personal' | null,
           phase: debate.phase,
           adaptive_phase: debate.adaptive_staging?.current_phase ?? null,
           transcript_length: debate.transcript?.length ?? 0,


### PR DESCRIPTION
Adds `debate.source` (`"community" | "personal" | null`) to the debate sub-object of the flight-recorder context snapshot (`flightRecorderInit.ts`).

**Why:** the `merged-50200d30` triage (2026-08-10) had to infer community-vs-personal from a comments-404 error chain because the snapshot didn't carry the source. It now reads directly.

**Source of truth:** `debateState.communityReadOnly` — the store's durable representation of the `source=community` read-only load path. `true` → `community`, else `personal`.

Ticket: t/2435 (chore, filed by Diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
