### PR TITLE
chore(ci): pass BUILD_SHA build-arg to docker/build-push-action (t/2438)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -232,6 +232,7 @@ jobs:
           load: ${{ steps.push_mode.outputs.load }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: BUILD_SHA=${{ github.sha }}
           cache-from: type=gha,scope=shared-docker
           cache-to: type=gha,scope=shared-docker,mode=min
 


### PR DESCRIPTION
## Summary
- Adds `build-args: BUILD_SHA=${{ github.sha }}` to the `docker/build-push-action` step in `container.yml`
- Enables `build_commit_sha` to be baked into the container image for flight recorder dumps (parent t/2434)
- Dependent on t/2437 (ARG declaration in Dockerfile) for end-to-end effect

## Self-cert
Self-certifying under /trivial-change.
Change: add `build-args: BUILD_SHA` to build-push-action in container.yml
Files: `.github/workflows/container.yml`
Lines changed: 1 addition, 0 deletions
Verify gate: YAML-only workflow change, no npm/pester scope
Deviations: file outside operations/devops scope; TL-assigned via p/331#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)