### PR TITLE
chore(build): getGitSha() reads BUILD_SHA before git exec (t/2439)

### DIFF
--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -21,6 +21,11 @@ function getGitVersion(): string {
 }
 
 function getGitSha(): string {
+  // Container builds (Docker) inject the commit as BUILD_SHA — the build context has no
+  // .git, so git exec would fall through to 'unknown' (t/2434). Prefer it when set; local
+  // and Electron builds leave it unset and keep using git exec unchanged (t/2439).
+  const fromEnv = process.env.BUILD_SHA?.trim();
+  if (fromEnv) return fromEnv;
   try {
     return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
   } catch {


### PR DESCRIPTION
`getGitSha()` in `taxonomy-editor/vite.config.ts` now prefers `process.env.BUILD_SHA` (trimmed, when non-empty) before falling back to `git rev-parse HEAD`, then `'unknown'`.

**Why:** Docker/web-container builds have no `.git` in the build context, so the git-exec path fell through to `'unknown'`, surfacing as `build_commit_sha "unknown"` in web-container flight-recorder dumps (t/2434). The Docker build injects the commit as `BUILD_SHA` (siblings t/2437/t/2438).

**Behavior:** `BUILD_SHA` unset (local + Electron builds) → git-exec path unchanged. `BUILD_SHA` set → returned verbatim, no git exec.

Ticket: t/2439 (child of t/2434). Self-cert: /trivial-change (single-file, no behavior change outside container builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
