### PR TITLE
fix(analysis): null-guard unmapped_arguments/cross_pov_gaps in TaxonomyGapPanel (t/2432)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/TaxonomyGapPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/TaxonomyGapPanel.tsx
@@ -515,8 +515,8 @@ export function TaxonomyGapPanel({ debate }: Props) {
     <div className="tgap-root">
       <SummaryBanner summary={analysis.summary} />
       <PovCoverageSection analysis={analysis} />
-      <UnmappedArgumentsSection args={analysis.unmapped_arguments} />
-      <CrossPovGapsSection gaps={analysis.cross_pov_gaps} />
+      <UnmappedArgumentsSection args={analysis.unmapped_arguments ?? []} />
+      <CrossPovGapsSection gaps={analysis.cross_pov_gaps ?? []} />
       {injections.length > 0 && <GapInjectionsSection injections={injections} />}
       {proposals.length > 0 && <CrossCuttingProposalsSection proposals={proposals} />}
     </div>


### PR DESCRIPTION
## Summary
- Add `?? []` fallback on `analysis.unmapped_arguments` and `analysis.cross_pov_gaps` props at TaxonomyGapPanel.tsx:518-519
- Older community/closed debate format omits these fields (null/undefined); bare iteration crashes when user switches to the Gaps tab

## Test plan
- [x] `npx vitest run TaxonomyGapPanel.test.tsx` — 11/11 pass

Part of t/2432 (Analysis scope slice — TaxonomyGapPanel.tsx is owned by analysis/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)