### PR TITLE
fix(debate-diagnostics): null-guard an.edges for community debates (t/2432)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/OverviewView.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/OverviewView.tsx
@@ -406,7 +406,7 @@ function PanelArgumentNetworkSection({ an }: { an: ActiveDebate['argument_networ
 
 function WhatIfWrapper({ an }: { an: ActiveDebate['argument_network'] }) {
   if (!an || an.nodes.length === 0) return null;
-  return <WhatIfSection nodes={an.nodes} edges={an.edges} />;
+  return <WhatIfSection nodes={an.nodes} edges={an.edges ?? []} />;
 }
 
 function CommitmentStoresSection({ commitments }: { commitments: ActiveDebate['commitments'] }) {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.test.tsx
@@ -169,4 +169,17 @@ describe('ArgumentNetworkTab', () => {
     expect(options).toContain('Novel arguments');
     expect(options).toContain('Attributed only');
   });
+
+  // Regression: community/older debates may have argument_network.edges = null
+  it('renders without crash when an.edges is null (community debate format)', () => {
+    const nodes = [makeNode('n1', 'e1', 'Community claim')];
+    expect(() => {
+      render(
+        <ArgumentNetworkTab
+          {...makeProps({ an: { nodes, edges: null as any } })}
+        />,
+      );
+    }).not.toThrow();
+    expect(screen.getByTestId('inode-n1')).toBeInTheDocument();
+  });
 });

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.tsx
@@ -49,15 +49,17 @@ export function ArgumentNetworkTab({
   setLocalOverride,
   nodeLabels,
 }: ArgumentNetworkTabProps) {
-  const caCount = an.edges.filter(e => e.type === 'attacks').length;
-  const raCount = an.edges.filter(e => e.type === 'supports').length;
+  // Community/older debates may omit edges entirely — guard all usages
+  const edges = an.edges ?? [];
+  const caCount = edges.filter(e => e.type === 'attacks').length;
+  const raCount = edges.filter(e => e.type === 'supports').length;
   // Statement-ID map — matches S{round} from the main transcript view.
   const stmtIdByEntry = new Map<string, string>();
   debate.transcript.forEach((e, i) => stmtIdByEntry.set(e.id, `S${i + 1}`));
 
   // Compute QBAF strengths from edges
   const qbafNodes: QbafNode[] = an.nodes.map(n => ({ id: n.id, base_strength: n.base_strength ?? 0.5 }));
-  const qbafEdges: QbafEdge[] = an.edges.map(e => ({
+  const qbafEdges: QbafEdge[] = edges.map(e => ({
     source: e.source, target: e.target,
     type: e.type as 'attacks' | 'supports',
     weight: e.weight ?? 0.5,
@@ -132,7 +134,7 @@ export function ArgumentNetworkTab({
 
   return (
     <div className="ant-root">
-      <ArgNetMinimap nodes={an.nodes} edges={an.edges} />
+      <ArgNetMinimap nodes={an.nodes} edges={edges} />
       <div className="ant-header-row">
         <span className="ant-header-summary">
           {an.nodes.length} I-nodes · {caCount} CA · {raCount} RA{modCount > 0 ? ` · ${modCount} moderator decisions` : ''}
@@ -241,9 +243,9 @@ export function ArgumentNetworkTab({
           )}
           {/* AN nodes from this entry */}
           {groupNodes.map(n => {
-            const attacks = an.edges.filter(e => e.target === n.id && e.type === 'attacks');
-            const supports = an.edges.filter(e => e.target === n.id && e.type === 'supports');
-            const isSource = an.edges.some(e => e.source === n.id);
+            const attacks = edges.filter(e => e.target === n.id && e.type === 'attacks');
+            const supports = edges.filter(e => e.target === n.id && e.type === 'supports');
+            const isSource = edges.some(e => e.source === n.id);
             return (
               <INodeRow
                 key={n.id}
@@ -251,7 +253,7 @@ export function ArgumentNetworkTab({
                 attacks={attacks}
                 supports={supports}
                 allNodes={an.nodes}
-                allEdges={an.edges}
+                allEdges={edges}
                 isSource={isSource}
                 computedStrength={strengthMap.get(n.id)}
                 strengthMap={strengthMap}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/useDiagnosticsState.ts
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/useDiagnosticsState.ts
@@ -193,7 +193,7 @@ async function applyDeepLink(
 function countAnMatches(an: ArgumentNetwork, sq: string): number {
   let count = 0;
   for (const n of an.nodes) count += countMatches(n.id, sq) + countMatches(n.text, sq) + countMatches(n.speaker, sq);
-  for (const e of an.edges) count += countMatches(e.source, sq) + countMatches(e.warrant || '', sq) + countMatches(e.scheme || '', sq);
+  for (const e of (an.edges ?? [])) count += countMatches(e.source, sq) + countMatches(e.warrant || '', sq) + countMatches(e.scheme || '', sq);
   return count;
 }
 


### PR DESCRIPTION
## Summary

- Community/older debates may have `argument_network.edges = null`; 8 call sites in `ArgumentNetworkTab` (`.filter`, `.map`, `.some`) and `countAnMatches` in `useDiagnosticsState` iterated edges directly, causing **"TypeError: e is not iterable"** ~1 s after opening the diagnostics popout on a community debate
- Fix: `const edges = an.edges ?? []` at the top of `ArgumentNetworkTab`; `an.edges ?? []` guards in `WhatIfWrapper` and `countAnMatches`
- Regression test added: renders without crash when `an.edges` is null

## Test plan

- [x] `npx vitest run src/renderer/components/debate-diagnostics/` — 26 files, 465 tests pass
- [x] New test: `ArgumentNetworkTab > renders without crash when an.edges is null (community debate format)`
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
