### PR TITLE
fix(debate-workspace): debate header scrolls with the transcript

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.css
@@ -11,6 +11,13 @@
   border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
 }
+/* Header now scrolls with the transcript (rendered as the first child of the padded
+   .debate-scroll-content) rather than staying pinned. Cancel the container's 16px
+   padding on top/left/right so the header still bleeds edge-to-edge and sits flush at
+   the top; the container's row gap supplies the space to the first transcript card. */
+.debate-scroll-content > .debate-hdr {
+  margin: -16px -16px 0;
+}
 .debate-hdr-band {
   padding: 8px 12px;
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -1300,33 +1300,6 @@ export function DebateWorkspace({ onExport, exportStatus }: {
     <div className="debate-workspace-row" data-phase={isClarificationPhase ? 'setup' : undefined}>
     {chatRedesign && <TranscriptOutline transcript={activeDebate.transcript} />}
     <div className="debate-workspace">
-      {/* Fixed header — always visible (t/2293): title+source, status, DEBATERS strip,
-          with the action controls anchored top-right in Band 1. */}
-      <DebateHeader
-        activeDebate={activeDebate}
-        coverageMap={coverageMap}
-        strengthWeighted={strengthWeighted}
-        phaseLabel={PHASE_TITLES[activeDebate.phase] || activeDebate.phase}
-        actions={
-          <DebateToolbar
-            activeDebate={activeDebate}
-            headerVariant
-            isExploration={isExploration}
-            isCrossCutting={isCrossCutting}
-            onShowCCDetails={() => setShowCCDetails(true)}
-            commentSidebarOpen={commentSidebarOpen}
-            toggleCommentSidebar={toggleCommentSidebar}
-            commentsFile={commentsFile}
-            exportStatus={exportStatus}
-            onExport={onExport}
-            diagnosticsEnabled={diagnosticsEnabled}
-            toggleDiagnostics={toggleDiagnostics}
-            defaultTier={defaultTier}
-            setDefaultTier={setDefaultTier}
-          />
-        }
-      />
-
       {/* Cross-cutting context dialog */}
       <CrossCuttingDialog activeDebate={activeDebate} show={showCCDetails} onClose={() => setShowCCDetails(false)} />
 
@@ -1346,9 +1319,34 @@ export function DebateWorkspace({ onExport, exportStatus }: {
       {/* Remote driver overlay — popout window is driving this debate */}
       <RemoteDriverOverlay show={showRemoteOverlay} />
 
-      {/* Scrollable content: debaters, transcript (the topic/metadata header is now
-          the fixed DebateHeader above, t/2293) */}
+      {/* Scrollable content: header (title+status+DEBATERS strip), debaters, transcript.
+          The header scrolls with the transcript rather than staying pinned (user request):
+          on a phone the fixed header consumed ~half the viewport. */}
       <div className="debate-scroll-content" onContextMenu={handleContextMenu}>
+        <DebateHeader
+          activeDebate={activeDebate}
+          coverageMap={coverageMap}
+          strengthWeighted={strengthWeighted}
+          phaseLabel={PHASE_TITLES[activeDebate.phase] || activeDebate.phase}
+          actions={
+            <DebateToolbar
+              activeDebate={activeDebate}
+              headerVariant
+              isExploration={isExploration}
+              isCrossCutting={isCrossCutting}
+              onShowCCDetails={() => setShowCCDetails(true)}
+              commentSidebarOpen={commentSidebarOpen}
+              toggleCommentSidebar={toggleCommentSidebar}
+              commentsFile={commentsFile}
+              exportStatus={exportStatus}
+              onExport={onExport}
+              diagnosticsEnabled={diagnosticsEnabled}
+              toggleDiagnostics={toggleDiagnostics}
+              defaultTier={defaultTier}
+              setDefaultTier={setDefaultTier}
+            />
+          }
+        />
         <DebatePhaseHeader activeDebate={activeDebate} isDebatePhase={isDebatePhase} isOpeningPhase={isOpeningPhase} />
         <DebateTranscriptColumn
           activeDebate={activeDebate}


### PR DESCRIPTION
Moves `DebateHeader` out of the fixed slot and into `.debate-scroll-content` so the debate header (title, Comments/Share/Diagnostics/Text·Analysis controls, status, and the DEBATERS strip) scrolls away with the transcript instead of staying pinned.

**Why:** on a phone the fixed header consumed ~half the viewport, leaving almost no room for the actual debate. Reported directly by the user (mobile web/community view).

**Detail:** a co-located rule `.debate-scroll-content > .debate-hdr { margin: -16px -16px 0 }` cancels the scroll container's 16px padding so the header still bleeds edge-to-edge and sits flush at the top; the container row-gap spaces it from the first transcript card.

**Note:** this deliberately reverses the always-visible-header intent of t/2293 (desktop loses always-pinned Diagnostics / Text·Analysis controls) per the user's request to apply it on all viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
