### PR TITLE
fix(node-detail): steelman vulnerability editor grows to fit content (t/2414)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.css
@@ -357,6 +357,18 @@
   margin-bottom: 4px;
 }
 
+/* Steelman Vulnerability editors grow to fit their content instead of scrolling inside
+   the fixed rows={3}/rows={2} textarea (t/2414). The reported box clipped a long steelman
+   at ~3 lines with empty space below; field-sizing:content auto-sizes the textarea to its
+   text, min-height keeps the initial multi-row size, and the Content tab's own scroll
+   handles very long values. Engines without field-sizing keep the rows-based height (no
+   regression). Scoped to the vulnerability editor so other .ga-promoted-text / assumption
+   consumers are untouched. */
+.nd-vulnerability-input {
+  field-sizing: content;
+  min-height: calc(1.4em * 3 + 12px);
+}
+
 /* ── Debate-Tested metrics row (t/1585) ── */
 
 .nd-metrics-row {


### PR DESCRIPTION
Fixes the **actual** repro in t/2414 (user screenshot `t1.png`): the editable **Steelman Vulnerability** box in the NodeDetail **Content** tab clips a long steelman at ~3 lines with an inner scrollbar, despite empty space below.

**Root cause (corrected):** that box is a `<textarea rows={3}>` (`.nd-vulnerability-input`, NodeDetail.tsx:869), which scrolls inside its fixed 3-row height by design. The earlier fix (#782) addressed a *different* render path — the read-only `TaxonomyRefDetail` box in the diagnostics popout — so it never touched what the user sees.

**Fix:** `field-sizing: content` on `.nd-vulnerability-input` so the textarea auto-grows to its text, with a `min-height` preserving the initial ~3-row size. The Content tab's own scroll handles very long values. Engines without `field-sizing` fall back to today's rows-based height (no regression). Scoped to the vulnerability editor only — assumptions and read-only `.ga-promoted-text` consumers untouched.

Self-cert: `/trivial-change` (single-file CSS, scoped selector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
