### PR TITLE
docs(cl): convergence-signals + synthetic-phrases guides with in-app bookmarks

### DIFF
--- a/research/comp-linguist/docs/convergence-signals-guide.md
+++ b/research/comp-linguist/docs/convergence-signals-guide.md
@@ -1,0 +1,192 @@
+# Convergence Signals — the "Conv" Analysis View
+
+**Last updated:** 2026-08-11
+
+Every substantive debate turn carries a per-turn **convergence signal**: a small set of
+measurements taken the moment a turn's claims are extracted into the argument network.
+The **Conv** view (select **Analysis → Conv** on any statement card) renders that signal
+as a seven-field card. This guide explains each field, how it is computed, how to read its
+colored badge, and why the set exists.
+
+The signal is computed in `lib/debate/convergenceSignals.ts` (`computeConvergenceSignals`)
+and rendered by `ConvergenceInlineCard` in
+`taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx`. The same
+fields appear, per-round and in aggregate, in the diagnostics
+**Convergence Signals** panel.
+
+## Why these fields exist
+
+A three-agent debate can fail in ways that a transcript alone hides. The debaters can circle
+the same points, drift onto adjacent topics, agree too early without engaging, or trade
+assertions that never connect to each other. The convergence signal is an instrument panel:
+each field is a gauge for one specific failure mode, read one turn at a time.
+
+The design goal is **convergence on the real disagreement** — the crux — rather than either
+premature consensus or endless talking-past. A healthy debate should show turns that engage
+prior arguments (not standalone assertions), advance rather than repeat, concede when the
+evidence warrants it, let positions evolve, and keep returning to the cruxes until they
+resolve. Each field below maps to one of those expectations.
+
+These per-turn signals are not decorative. They feed two downstream computations in the same
+module:
+
+- **Process reward** (`computeProcessReward`) — a continuous `[0,1]` per-turn quality score
+  whose components are drawn directly from these fields: engagement, novelty
+  (`1 − redundancy`), consistency (concession coherence), grounding, move quality, and crux
+  relevance. This is the "process reward" in PRM terms: each turn is scored as an intermediate
+  reasoning step, independent of the final debate outcome.
+- **Uncertainty / collapse detection** (`computeUncertaintyMetric`) — an anti-sycophancy
+  metric that flags premature consensus when agreement looks superficial (high support ratio,
+  low engagement, high recycling).
+
+They also underpin the calibration metrics the Computational Linguist tracks across debates:
+`crux_addressed_rate`, `repetition_rate`, `convergence_score`, and
+`situation_crux_alignment`.
+
+## The seven fields
+
+Each field shows a computed value and a colored status badge. Badges are thresholded bands:
+green is the healthy reading, amber is a caution, red is the failure signal. Blue is neutral
+information (movement without a value judgment).
+
+### 1. Polarity — is the turn advancing or resolving?
+
+Format: `{N}C / {M}S = {ratio}%` with a **cooperative** / **confrontational** badge.
+
+`C` counts the turn's **confrontational** dialectical moves; `S` counts its **collaborative**
+(support) moves. `ratio = collaborative / (confrontational + collaborative)`.
+
+- Confrontational moves: counterexample, undercut, empirical challenge, burden-shift,
+  expose-assumption.
+- Collaborative moves: concede, concede-and-pivot, conditional-agree, integrate, steel-build,
+  identify-crux.
+
+Bands: `ratio ≥ 0.5` → **cooperative** (green); below → **confrontational** (red).
+
+Neither reading is "good" on its own — the right mix is phase-dependent. Confrontation is
+expected while positions are being pressure-tested; cooperation is expected as a debate moves
+toward synthesis. Polarity tells you which mode a turn is in so you can judge whether it fits
+the phase.
+
+### 2. Dialectical Engagement — is the claim wired into the argument, or dropped in?
+
+Format: `{targeted}/{total} targeted = {ratio}%` with a **deep** / **moderate** /
+**standalone** badge.
+
+A claim from this turn is **targeted** if it has an edge (supports or attacks) to a node
+*outside* this turn; it is **standalone** if it connects to nothing but its own turn. The
+ratio is `targeted / (targeted + standalone)`.
+
+Bands: `ratio ≥ 0.7` → **deep** (green); `≥ 0.4` → **moderate** (amber); below → **standalone**
+(red).
+
+This is the primary "talking past each other" detector. A turn full of standalone claims adds
+text without joining the shared argument. A deep turn attaches its claims to what has already
+been said. Engagement is the largest single component of the process reward (weight 0.20).
+
+### 3. Argument Redundancy — is the debater making progress or restating?
+
+Format: `avg {A}%, max {B}%` (and `sem {C}%` when semantic similarity is available) with a
+**fresh** / **repeating** / **semantic repeat** badge.
+
+Word overlap between this turn and the same speaker's up-to-10 prior turns, reported as the
+average and the maximum. When turn embeddings are present, a **semantic** similarity
+(embedding cosine, not just shared words) is also shown; if it crosses the semantic-recycling
+threshold the turn is flagged as a paraphrased repeat even when the wording differs.
+
+Bands: semantically recycled → **semantic repeat** (red); else `max ≥ 0.5` → **repeating**
+(amber); else → **fresh** (green).
+
+High redundancy means the debater is circling — restating an earlier argument rather than
+evolving the position. Novelty (`1 − redundancy`) is a process-reward component (weight 0.20),
+so a repeating turn is scored down.
+
+### 4. Dominant Counterargument — what is the strongest live objection?
+
+Format: `{node_id} str={strength}` with a **strong** / **moderate** / **weak** badge, or
+`none`.
+
+The single strongest attack currently aimed at this speaker's claims, identified by **QBAF**
+strength (the quantitative bipolar argumentation framework score, which propagates support and
+attack weights through the network). Shows the attacking node's id and its strength.
+
+Bands: `strength ≥ 0.7` → **strong** (red); `≥ 0.5` → **moderate** (amber); below → **weak**
+(green). `none` means no attack is currently landing on this speaker.
+
+This field names the objection the speaker most needs to answer. A persistent strong
+counterargument that the speaker never addresses is a sign the debate is not converging on it.
+
+### 5. Concession — intellectual honesty under pressure
+
+Format: `{K} attacks, used: Y/N — [Taken | Missed | N/A]`.
+
+`K` is the number of **strong** attacks (QBAF strength ≥ 0.6) the speaker faced this turn.
+`used: Y/N` reports whether the turn actually used a concession move. The outcome badge
+combines the two:
+
+- **N/A** — no strong attack faced (nothing to concede to).
+- **Taken** (green) — faced a strong attack and conceded.
+- **Missed** (red) — faced a strong attack and did *not* concede.
+
+Concession is the strongest convergence signal available: a debater explicitly acknowledging
+an opponent's point. A **Missed** outcome is stubbornness under evidence — the enemy of
+convergence. Concession coherence is the process-reward "consistency" component: taken scores
+1.0, missed scores 0.3, N/A scores a neutral 0.7. A taken concession also boosts the
+convergence tracker directly (`boostConvergenceOnConcession`).
+
+### 6. Position Drift — is the position evolving or frozen?
+
+Format: `opening: {overlap}%, drift: {delta}%` with an **anchored** / **evolved** / **shifted**
+badge.
+
+`overlap` is the word overlap between this turn and the speaker's own opening statement — how
+close the speaker still is to where they started. `drift` is the turn-over-turn change in that
+overlap (the absolute delta from the speaker's previous turn), i.e. how much the position moved
+*this* turn.
+
+Bands on `overlap`: `≥ 0.6` → **anchored** (amber); `≥ 0.3` → **evolved** (green); below →
+**shifted** (blue).
+
+A permanently anchored speaker is not learning from the exchange; a healthy debate shows
+positions that evolve. A large shift is neither good nor bad on its own (blue is neutral) — it
+is movement worth noticing, which may be genuine updating or may be drift off the topic.
+
+### 7. Crux Engagement — are they engaging the actual disagreement?
+
+Format: `this turn: Yes/No | cumulative: {N} | follow-through: {F}` with a **resolving** /
+**no follow-through** badge. This field spans the full width of the card.
+
+- **this turn** — did this turn's claims engage a tracked crux? A crux is engaged if the turn
+  produced one of its attacking claims, if a crux changed state on this turn, or if any edge
+  connects a turn claim to a crux node.
+- **cumulative** — running count of this speaker's crux-engaging turns.
+- **follow-through** — cumulative count of crux-engaging turns that *also* carried a
+  collaborative move. Engaging a crux and then working toward resolving it, not just naming it.
+
+Badges: `cumulative > 0` and `follow-through = 0` → **no follow-through** (amber); `cumulative >
+0` and `follow-through > 0` → **resolving** (green).
+
+Cruxes are the disagreement points that, if resolved, would change a debater's position.
+Engaging them is the whole point of the debate; following through is how they get resolved. A
+high cumulative count with zero follow-through means the debaters keep circling the crux without
+moving it — the amber warning exists precisely to surface that pattern. Crux relevance is a
+process-reward component (weight 0.15).
+
+## Reading the card in practice
+
+Read the seven fields as one gauge cluster, not seven independent numbers:
+
+- **Healthy, converging turn:** deep engagement, fresh (low redundancy), a taken or N/A
+  concession, an evolving position, and crux follow-through. The debater is joining the
+  argument and moving it.
+- **Circling:** repeating or semantic-repeat redundancy, standalone engagement, and crux
+  engagement with no follow-through. Text is being produced but the disagreement is not moving.
+- **Premature agreement / collapse:** cooperative polarity plus standalone engagement plus high
+  redundancy is the exact combination `computeUncertaintyMetric` flags — agreement that looks
+  superficial rather than earned. Cross-check with the diagnostics uncertainty panel.
+- **Stubbornness:** a persistent strong Dominant Counterargument alongside repeated **Missed**
+  concessions and an anchored position.
+
+An empty card ("No convergence data for this turn") means the signal has not been computed yet;
+signals are produced after each turn's claims are extracted, so the current in-flight turn will
+not have one until it completes.

--- a/research/comp-linguist/docs/synthetic-phrases-theory-of-success.md
+++ b/research/comp-linguist/docs/synthetic-phrases-theory-of-success.md
@@ -1,0 +1,168 @@
+# Synthetic Phrases — Theory of Success, Generation, and Use
+
+**Last updated:** 2026-08-11
+
+The **Phrases** tab on a taxonomy node shows a set of **synthetic statements** — machine-generated
+sentences that express the node's position, grouped into seven **archetypes** (e.g. "45 synthetic
+statements across 7 archetypes"). This document explains what problem those statements solve, the
+theory for why they should solve it, how they are generated, and how they are used at attribution
+time.
+
+It is the reference behind the Phrases-tab bookmark. For the broader tab anatomy (all phrase source
+types, not just synthetic), see [`_phrases_tab_guide.md`](../_phrases_tab_guide.md). For the full
+build plan and cmdlet inventory, see
+[`synthetic-corpus-implementation-plan.md`](synthetic-corpus-implementation-plan.md).
+
+## The problem: attribution needs a wide semantic surface
+
+The core runtime task is **claim-to-node attribution**: given a claim from a document or a debate
+turn, find the taxonomy node it belongs to. This is done by embedding the claim and comparing it,
+by cosine similarity, against a stored vector for each node.
+
+The baseline representation is one 384-dim vector per node (`all-MiniLM-L6-v2`), computed from the
+node's **description text only** (`embeddings.json`, loaded in `taxonomyLoader.ts`). That single
+vector is a narrow target. A node's description is written in one register — usually the clipped,
+academic phrasing of the source literature — but a real claim expressing the same position can
+arrive as a policy demand, a defensive rebuttal, an appeal to an intellectual tradition, or a
+concrete example. Those phrasings sit in different regions of embedding space, so a single
+description vector misses them.
+
+Two symptoms follow. First, attribution accuracy is capped: measured against the golden test set of
+human-validated claims, top-1 recall leaves a large fraction of claims mis-attributed on the first
+try. Second, **confusable neighbors** — nodes in the same POV and BDI category, often sharing a
+taxonomy parent — collapse together, because their description vectors are close and there is
+nothing else to separate them.
+
+## The theory of success
+
+The synthetic corpus is a bet with a specific, falsifiable mechanism:
+
+> If each node is represented by *many* vectors that deliberately span the different rhetorical
+> styles a claim can take — and if those vectors are pruned so none of them drifts closer to a
+> neighbor node than to their own — then multi-vector attribution will catch claims that a single
+> description vector misses, **without** increasing confusion between neighbors.
+
+Two moving parts have to both hold:
+
+1. **Breadth raises recall.** More vectors per node, spread across archetypes and audience
+   registers, give the scorer more "hooks." A claim phrased as a policy implication can match the
+   node's policy-implication statements even when it is far from the description vector. This is why
+   the target is ~40 statements per node rather than a handful.
+2. **Contrastive discipline protects precision.** Breadth is only safe if the added vectors stay on
+   the correct side of every neighbor boundary. A statement that could equally describe a
+   neighbor — a **boundary violator** — is worse than useless: it actively poaches the neighbor's
+   claims. So generation is neighbor-aware and every statement passes a poaching gate before it is
+   allowed into the pool.
+
+The success criterion is empirical and pre-registered: a **pilot** (20–30 nodes, mixed easy/hard)
+must show a **Mean Reciprocal Rank lift of ≥ 0.10** over the description-only baseline before
+full-scale generation is authorized. If a cheaper intervention (a better encoder, or a cross-encoder
+reranker on the top-K) captures most of the available lift, the corpus does not earn its API budget
+and the bet is off. The corpus is not assumed to work; it has to beat that bar on the golden set.
+
+## How the statements are generated
+
+Generation is neighbor-aware and quality-gated. The pipeline (`New-SyntheticCorpus`, archetype
+prompts in `_archetype_templates.py`) produces, for each node, a pool of candidates that is then
+pruned down to the keepers shown in the tab.
+
+### Seven archetypes — semantic breadth
+
+Each archetype is a prompt template that asks the model to express the node's position in one
+rhetorical mode. These are exactly the seven groups shown in the Phrases tab:
+
+| Archetype | Label in tab | What it produces |
+|-----------|--------------|------------------|
+| `surface_claim` | Surface Claims | Direct, debate-ready assertions of the position |
+| `assumption_expression` | Assumption Expressions | The hidden assumptions the position rests on |
+| `defensive_formulation` | Defensive Formulations | Rebuttals to the position's known vulnerabilities (steelman attacks) |
+| `counterargument_response` | Counterargument Responses | Replies to specific logical criticisms (e.g. fallacy accusations) |
+| `policy_implication` | Policy Implications | Concrete policy proposals the position implies |
+| `intellectual_lineage` | Intellectual Lineage | The position grounded in named intellectual traditions |
+| `real_world_example` | Real-World Examples | Concrete scenarios that illustrate the position |
+
+The seven modes are chosen to cover the ways the same position actually shows up in debate and
+documents — the register axis that a single description vector cannot span.
+
+### Audience modulation — register coverage
+
+Most archetypes are additionally generated in **audience-modulated** variants for three overlays,
+each shown as a small badge on the statement:
+
+- **Industry** (`industry_leader`) — business pragmatics, ROI framing.
+- **Policy** (`policymaker`) — regulatory and governance framing.
+- **Technical** (`technical_researcher`) — precise, mechanistic vocabulary.
+
+Audience adds register coverage on top of the archetype's semantic mode, so the pool reaches
+claims phrased for different readers.
+
+### Neighbor-awareness — the anti-poaching mechanism
+
+Before generation, the pipeline computes each node's **confusable neighbors**
+(`Get-ConfusableNeighbors`) using content signal (BM25 on `description` + `assumes`) blended with
+graph signal (same BDI category and POV, shared taxonomy parent) — deliberately **not** using
+embeddings, because embedding proximity is contaminated by the very model whose errors the corpus
+is meant to fix. Generation prompts are anchored to POV vocabulary profiles built from
+high-confidence debate claims, so the synthetic language matches how claims are actually phrased.
+
+### Prune-and-regenerate — the quality gate
+
+Candidates (~45–50 per node) are embedded and passed through the pruning cycle
+(`Invoke-CorpusPrune`) down to ~40 keepers:
+
+1. **Poaching check** — is the statement's embedding closer to a neighbor node than to its own? If
+   so it is a boundary violator and is pruned.
+2. **Redundancy check** — is it a near-duplicate of another kept statement for the same node
+   (intra-node cosine above threshold)? If so it adds no breadth and is pruned.
+3. **Rationale filter** — the model emits a `rationale` for why the statement belongs to this node
+   and not its neighbors; a rationale that reveals the model was actually thinking about a neighbor
+   is a signal to prune.
+
+If a node's prune rate exceeds ~25%, it is **regenerated** with strengthened contrastive
+instructions that name the specific neighbor it kept colliding with (max two cycles). Nodes that
+stay high-prune-rate are flagged as "hard nodes" for review. Each entry keeps a `pruned` flag and
+`prune_reason`; the tab shows only the keepers (`!pruned`).
+
+## How the statements are used
+
+### At attribution time — multi-vector scoring
+
+The payoff is at scoring time. When synthetic embeddings are exported
+(`Export-SyntheticEmbeddings` → `synthetic_embeddings.json`) and loaded, each node carries a
+`vectors[]` array (the synthetic statements' embeddings) alongside its single description vector.
+The scorer then has two modes:
+
+- **Single-vector** (`scoreNodeRelevance`) — cosine of the query against the one description
+  vector. This is the current baseline.
+- **Multi-vector mean-of-top-N** (`scoreNodeRelevanceMeanTopN`) — cosine of the query against
+  *every* vector in `node.vectors`, sorted descending, averaged over the top N. Falls back to
+  single-vector when no `vectors` array is present.
+
+**Mean-of-top-3** is the intended production aggregation, not max-similarity. The reason is directly
+tied to the theory of success: mean-of-top-N requires a *cluster* of the node's statements to be
+near the claim, which dampens the poaching risk from a single rogue vector. Max-sim would let one
+boundary-violating statement win an attribution on its own; averaging the top few demands
+agreement.
+
+### In the Phrases tab — inspection
+
+The tab (`PhrasesPanel.tsx`) loads the per-POV synthetic corpus for the node's POV
+(`api.loadSyntheticCorpus`), filters to this node's un-pruned entries, and groups them by archetype
+in the fixed order above. When no synthetic entries exist for a node it falls back to the older flat
+`debate_claims_corpus.json` and shows a "legacy corpus" badge. The tab is the human-readable window
+onto exactly the vectors the multi-vector scorer uses — it is where you inspect whether a node's
+generated statements are on-target and whether any read like a neighbor's.
+
+## Current status
+
+The corpus is in **pilot** scope — the mechanism and pipeline are built and a small set of nodes is
+generated and pruned; full-scale generation (~700 nodes × ~40 statements) is gated on the pilot MRR
+lift clearing the ≥ 0.10 bar on the golden set. The Phrases tab already renders the archetype-grouped
+synthetic view for nodes that have a corpus, falling back to legacy for the rest. The TypeScript
+multi-vector loader/scorer path is specified and partially in place; the production attribution
+pipeline switches to mean-of-top-N once `synthetic_embeddings.json` is available for a POV.
+
+Until the evaluation clears the gate, treat the synthetic phrases as a **candidate** improvement
+under measurement, not a shipped one. Every number that matters — MRR, Recall@1/3/5, per-vector
+poaching rate — is measured against the human-validated golden set, and the corpus keeps its budget
+only by beating the baseline there.

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -875,7 +875,19 @@ function StatementBody({
   return (
     <div className={`debate-statement-body${isMetaView ? ' meta-view' : ''}`} ref={bodyRef} id={`debate-statement-body-${entry.id}`}>
       <div key={flipKey} ref={innerRef} className={`debate-flip-inner${flipping ? ' flipping' : ''}`} onAnimationEnd={handleFlipEnd}>
-      {isMetaView && <div className="debate-meta-mode-label">{TIER_LABELS[displayedTier]?.toUpperCase()}</div>}
+      {isMetaView && (
+        <div className="debate-meta-mode-label">
+          {TIER_LABELS[displayedTier]?.toUpperCase()}
+          {displayedTier === 'convergence' && (
+            <TheoryLink
+              docPath="research/comp-linguist/docs/convergence-signals-guide.md"
+              anchor="the-seven-fields"
+              label="Help: convergence signals"
+              size={12}
+            />
+          )}
+        </div>
+      )}
       {displayedTier === 'terms' && vocabResolutions && vocabResolutions.length > 0 ? (
         <div className="debate-statement-content">
           <VocabTermsView resolutions={vocabResolutions} ambiguities={meta?.vocabulary_ambiguities as { colloquial: string; offset?: number }[] | undefined} statementText={entry.content} />

--- a/taxonomy-editor/src/renderer/components/policy/PhrasesPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/policy/PhrasesPanel.tsx
@@ -4,6 +4,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { TheoryLink } from '../shared/TheoryLink';
 
 // ── Types ──
 
@@ -211,6 +212,11 @@ export function PhrasesPanel({ nodeId }: { nodeId: string }) {
         {totalCount} synthetic {totalCount === 1 ? 'statement' : 'statements'}
         {' across '}
         {grouped!.length} {grouped!.length === 1 ? 'archetype' : 'archetypes'}
+        <TheoryLink
+          docPath="research/comp-linguist/docs/synthetic-phrases-theory-of-success.md"
+          label="Help: synthetic phrases theory & usage"
+          size={12}
+        />
       </div>
       <div className="phrases-archetype-list">
         {grouped!.map(([archetype, entries]) => {


### PR DESCRIPTION
Add two Computational Linguist reference docs and wire each into the UI via a
TheoryLink bookmark:

- research/comp-linguist/docs/convergence-signals-guide.md — the seven-field
  "Conv" analysis view: each field's meaning, computation, colored bands, and
  the theory (process reward + collapse detection). Bookmarked from the CONV
  meta-mode label in StatementCard.
- research/comp-linguist/docs/synthetic-phrases-theory-of-success.md — the
  synthetic corpus theory of success, generation (archetypes, audiences,
  anti-poaching, prune-and-regenerate), and multi-vector attribution usage.
  Bookmarked from the Phrases-tab summary in PhrasesPanel.

Bookmarks use the standard TheoryLink doc-link affordance; additive only, no
behavioral change to either component.

Co-Authored-By: Computational Linguist (Orca) <main.research-comp-linguist@ai-triad-research.orca.local>
