### PR TITLE
feat(attributes): BDI-scales doc-link beside Priority/Operationality/Confidence (t/2448)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.css
@@ -1,3 +1,11 @@
+/* Scale label + its doc-link (t/2448) — keep them on one line inside the cell so the
+   fixed attribute grid columns don't shift. */
+.ga-label-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .ga-confidence-row {
   display: flex;
   align-items: center;

--- a/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.test.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2448 — the BDI-scales doc-link (TheoryLink) renders beside each scale label
+// (Priority/Operationality via RankedSelectCell, Confidence via ConfidenceCell) and
+// opens the docs/bdi-scales.md GitHub blob URL through the bridge.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { RankedSelectCell, ConfidenceCell } from './GraphAttributesPanel';
+
+const openExternal = vi.fn().mockResolvedValue(undefined);
+vi.mock('@bridge', () => ({ api: { openExternal: (...args: unknown[]) => openExternal(...args) } }));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }));
+
+const BDI_DOC_URL = 'https://github.com/jpsnover/ai-triad-research/blob/main/docs/bdi-scales.md';
+
+describe('GraphAttributesPanel — BDI scale doc-links (t/2448)', () => {
+  beforeEach(() => { openExternal.mockClear(); cleanup(); });
+
+  it('renders the doc link beside a RankedSelectCell label and opens docs/bdi-scales.md', () => {
+    render(<RankedSelectCell label="Priority" value={3} options={[{ value: 3, label: '3 — Important' }]} />);
+    const link = screen.getByRole('button', { name: /how the bdi scales work/i });
+    expect(link).toBeTruthy();
+    fireEvent.click(link);
+    expect(openExternal).toHaveBeenCalledWith(BDI_DOC_URL);
+  });
+
+  it('renders the doc link beside the Confidence label and opens docs/bdi-scales.md', () => {
+    render(<ConfidenceCell value={0.5} />);
+    const link = screen.getByRole('button', { name: /how the bdi scales work/i });
+    expect(link).toBeTruthy();
+    fireEvent.click(link);
+    expect(openExternal).toHaveBeenCalledWith(BDI_DOC_URL);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.tsx
@@ -7,7 +7,15 @@ import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import type { PolicyRegistryEntry } from '../../hooks/useTaxonomyStore';
 import { FALLACY_CATALOG } from '../../data/fallacyInfo';
 import { api } from '@bridge';
+import { TheoryLink } from '../shared/TheoryLink';
 import './GraphAttributesPanel.css';
+
+// Doc-link to the BDI scales reference (t/2448), rendered beside each scale label
+// (Priority / Operationality / Confidence — one doc documents all three). Kept inside
+// the scale cell so the fixed attribute grid columns don't shift.
+function BdiScaleDocLink() {
+  return <TheoryLink docPath="docs/bdi-scales.md" size={12} tooltip="How the BDI scales work" />;
+}
 
 interface GraphAttributesPanelProps {
   attrs: GraphAttributes;
@@ -152,7 +160,7 @@ function confidenceColor(val: number): string {
   return 'var(--color-warning, #f59e0b)';
 }
 
-function ConfidenceCell({ value, readOnly, doctrinallyAnchored, evidentialConfidence, history, onUpdate }: {
+export function ConfidenceCell({ value, readOnly, doctrinallyAnchored, evidentialConfidence, history, onUpdate }: {
   value: number;
   readOnly?: boolean;
   doctrinallyAnchored?: boolean;
@@ -162,7 +170,10 @@ function ConfidenceCell({ value, readOnly, doctrinallyAnchored, evidentialConfid
 }) {
   return (
     <div className="ga-cell">
-      <div className="ga-label">Confidence</div>
+      <div className="ga-label-row">
+        <span className="ga-label">Confidence</span>
+        <BdiScaleDocLink />
+      </div>
       <div className="ga-confidence-row">
         <input
           type="range"
@@ -198,7 +209,7 @@ function ConfidenceCell({ value, readOnly, doctrinallyAnchored, evidentialConfid
   );
 }
 
-function RankedSelectCell({ label, value, options, badge, history, readOnly, onUpdate }: {
+export function RankedSelectCell({ label, value, options, badge, history, readOnly, onUpdate }: {
   label: string;
   value: number;
   options: Array<{ value: number; label: string }>;
@@ -209,7 +220,10 @@ function RankedSelectCell({ label, value, options, badge, history, readOnly, onU
 }) {
   return (
     <div className="ga-cell">
-      <div className="ga-label">{label}</div>
+      <div className="ga-label-row">
+        <span className="ga-label">{label}</span>
+        <BdiScaleDocLink />
+      </div>
       <select
         value={value}
         disabled={readOnly || !onUpdate}


### PR DESCRIPTION
Adds the BDI-scales doc-link beside each scale label in the node **Attributes** tab (`GraphAttributesPanel`), per t/2448 (PI-requested).

**Placements (one doc, 3 labels):** Priority (Desires) + Operationality (Intentions) via the shared `RankedSelectCell`, and Confidence (Beliefs) via `ConfidenceCell`. The link sits inside each scale cell (`.ga-label-row`) so the fixed attribute grid columns don't shift.

**Control:** unified `TheoryLink` (`docPath="docs/bdi-scales.md"`, `size=12`, tooltip "How the BDI scales work"), imported directly from `../shared/TheoryLink` — **not** the `BookmarkLink` the ticket named (retired in `5e1392ff`, epic t/2409/t/2410), and not via the `../shared` barrel (t/2420). See deviation note t/2448#1.

**Test:** `RankedSelectCell`/`ConfidenceCell` exported; `GraphAttributesPanel.test.tsx` asserts each renders the doc link and opens the `docs/bdi-scales.md` GitHub blob URL through the bridge.

Doc target authored in t/2447 (PR #815, auto-merge armed); the link resolves once that merges. Self-cert: `/add-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
