### PR TITLE
feat(debate-workspace): busy-state Begin Debate + S1 elapsed timer (t/2451)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/ClarificationPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/ClarificationPanel.tsx
@@ -399,7 +399,7 @@ function SetupActionButtons({
         onClick={onBeginDebate}
         disabled={isGenerating || submitting}
       >
-        Begin Debate
+        {isGenerating || submitting ? 'Starting…' : 'Begin Debate'}
       </button>
     </div>
   );
@@ -436,9 +436,16 @@ function DebateSetupFooter() {
     return cheap.length > 0 ? cheap : all.slice(0, 3);
   }, []);
 
+  const [submitting, setSubmitting] = useState(false);
+
   const handleBeginDebate = async () => {
-    await beginDebate();
-    await runOpeningStatements();
+    setSubmitting(true);
+    try {
+      await beginDebate();
+      await runOpeningStatements();
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleExploreFirst = async () => {
@@ -622,7 +629,7 @@ function DebateSetupFooter() {
           overflowTriggerRef={overflowTriggerRef}
           overflowMenuRef={overflowMenuRef}
           isGenerating={isGenerating}
-          submitting={false}
+          submitting={submitting}
           onExploreFirst={handleExploreFirst}
           onRefine={runClarification}
           onBeginDebate={handleBeginDebate}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -327,3 +327,25 @@
   font-style: italic;
   white-space: nowrap;
 }
+
+/* S1 elapsed timer — shown while opening statements load */
+.debate-s1-timer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: var(--sp-3);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.debate-s1-timer-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid var(--border-color);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -987,6 +987,28 @@ function StatementFooter({ entry, activeDebate, activeTier, debateGenerating, as
   );
 }
 
+// ── Elapsed timer for S1 (shown while opening statements load) ──────────
+
+function ElapsedTimer({ since, active }: { since: string; active: boolean }) {
+  const [elapsed, setElapsed] = useState(() => Math.max(0, Math.floor((Date.now() - new Date(since).getTime()) / 1000)));
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => {
+      setElapsed(Math.max(0, Math.floor((Date.now() - new Date(since).getTime()) / 1000)));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [since, active]);
+  if (!active) return null;
+  const m = Math.floor(elapsed / 60);
+  const s = elapsed % 60;
+  return (
+    <div className="debate-s1-timer">
+      <span className="debate-s1-timer-spinner" aria-hidden="true" />
+      Generating opening statements… {m > 0 ? `${m}m ` : ''}{s}s
+    </div>
+  );
+}
+
 // ── Main cards ──────────────────────────────────────────
 
 export function StatementCard({ entry, statementId, findQuery = '', matchOffset = 0, findCurrentIndex = -1, entryIndex, totalEntries }: {
@@ -1176,6 +1198,8 @@ export function StatementCard({ entry, statementId, findQuery = '', matchOffset 
             isTruncated={isTruncated}
             setEntryDisplayTier={setEntryDisplayTier}
           />
+          <ElapsedTimer since={entry.timestamp} active={statementId === 'S1' && !!debateGenerating} />
+
           <StatementFooter entry={entry} activeDebate={activeDebate} activeTier={activeTier} debateGenerating={debateGenerating} askQuestion={askQuestion} />
         </>
       )}


### PR DESCRIPTION
## Summary
Salvaged the completed, low-risk UX from the stranded shared-tree WIP reconciled in t/2449:

- **ClarificationPanel** — "Begin Debate" shows **"Starting…"** while `beginDebate` + `runOpeningStatements` are in flight (`submitting` threaded through `SetupActionButtons`). Prevents an accidental double-submit.
- **StatementCard** — an **ElapsedTimer** under the S1 card shows "Generating opening statements… Xs" with a spinner while opening statements load. The timer owns its own visibility via an `active` prop (keeps StatementCard's complexity delta to +1).

## Deliberately excluded
The stranded WIP also swapped the `convergence`-tier `TheoryLink` for a `terms`-tier bare-anchor "🔖 spec" link. That **removed an existing help link**, used a bare `<a>` instead of `TheoryLink`, and is entangled with an unfinished vocabulary-tier feature — so it is **not** in this PR. The convergence link is preserved unchanged. Full stranded WIP is archived on branch `t2449-statementcard-wip-preserve` (@ a8c0ecc5) for later evaluation.

## Test plan
- [x] renderer tsc gate: 0 / 0 errors
- [x] eslint: 0 errors (StatementCard complexity 16→17, +1 for the new render guard, under the warnings ceiling)
- [x] scoped vitest `src/renderer/components/debate-workspace/`: 19 files / 267 tests pass
- [x] `@keyframes spin` confirmed globally defined (spinner animates)

Relates to t/2449 · closes t/2451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
