### PR TITLE
fix(chat): strip reasoning <think> blocks so they never render to users (t/2453)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
@@ -53,7 +53,7 @@ vi.mock('@lib/flight-recorder/index', () => ({
   getGlobalRecorder: () => ({ record: vi.fn() }),
 }));
 
-import { useChatStore } from './useChatStore';
+import { useChatStore, parseChatResponse } from './useChatStore';
 
 function makeChatSession(overrides: Record<string, unknown> = {}) {
   return {
@@ -274,6 +274,40 @@ describe('useChatStore', () => {
       const state = useChatStore.getState();
       expect(state.chatStreamingText).toBeNull();
       expect(state.chatError).toContain('Response failed');
+    });
+  });
+
+  // t/2453 — reasoning models (DeepSeek/Groq) prepend <think>…</think> before their
+  // JSON; those blocks must never reach user-visible content via any fallback path.
+  describe('parseChatResponse — strips reasoning <think> blocks (t/2453)', () => {
+    const THINK = '<think>internal chain of thought\nspanning lines</think>';
+
+    it('strips the think block on the JSON-parse-failure fallback', () => {
+      const r = parseChatResponse(THINK + 'plain prose, not JSON');
+      expect(r.response).toBe('plain prose, not JSON');
+      expect(r.response).not.toMatch(/<think/i);
+      expect(r.taxonomyRefs).toEqual([]);
+    });
+
+    it('parses JSON that is prefixed by a think block', () => {
+      const r = parseChatResponse(THINK + '{"response":"hi","taxonomy_refs":[{"node_id":"acc-B-001","relevance":"x"}]}');
+      expect(r.response).toBe('hi');
+      expect(r.taxonomyRefs).toEqual([{ node_id: 'acc-B-001', relevance: 'x' }]);
+    });
+
+    it('strips the think block when parsed JSON has no response field (raw-text fallback)', () => {
+      const r = parseChatResponse(THINK + '{"taxonomy_refs":[]}');
+      expect(r.response).not.toMatch(/<think/i);
+      expect(r.response).toBe('{"taxonomy_refs":[]}');
+    });
+
+    it('handles the <thinking> variant, case-insensitively', () => {
+      expect(parseChatResponse('<THINKING>x</THINKING>done').response).toBe('done');
+    });
+
+    it('leaves think-free responses unchanged', () => {
+      expect(parseChatResponse('{"response":"ok"}').response).toBe('ok');
+      expect(parseChatResponse('just text').response).toBe('just text');
     });
   });
 });

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -78,11 +78,18 @@ function getTaxonomyContext(pov: string): TaxonomyContext {
   return { povNodes, situationNodes };
 }
 
+/** Remove reasoning-model `<think>…</think>` / `<thinking>…</thinking>` blocks that
+ *  DeepSeek/Groq prepend before their JSON, so they never leak into user-visible
+ *  content (t/2453 — production bug: the raw think dump was rendered in chat). */
+function stripThinkingBlocks(text: string): string {
+  return text.replace(/<think(?:ing)?[\s\S]*?<\/think(?:ing)?>/gi, '').trim();
+}
+
 /** Parse the POVer's JSON response into content + taxonomy refs */
-function parseChatResponse(text: string): { response: string; taxonomyRefs: TaxonomyRef[] } {
+export function parseChatResponse(text: string): { response: string; taxonomyRefs: TaxonomyRef[] } {
   try {
-    const parsed = JSON.parse(stripCodeFences(text));
-    const response = parsed.response || text.trim();
+    const parsed = JSON.parse(stripCodeFences(stripThinkingBlocks(text)));
+    const response = parsed.response || stripThinkingBlocks(text);
     const taxonomyRefs: TaxonomyRef[] = Array.isArray(parsed.taxonomy_refs)
       ? parsed.taxonomy_refs
         .filter((r: Record<string, unknown>) => r.node_id && typeof r.node_id === 'string')
@@ -94,7 +101,7 @@ function parseChatResponse(text: string): { response: string; taxonomyRefs: Taxo
     return { response, taxonomyRefs };
   } catch (err) {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-store', level: 'debug', message: 'Chat response JSON parse failed, using raw text', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-    return { response: text.trim(), taxonomyRefs: [] };
+    return { response: stripThinkingBlocks(text), taxonomyRefs: [] };
   }
 }
 


### PR DESCRIPTION
**Production bug (user saw it live).** Reasoning models (DeepSeek/Groq) prepend `<think>…</think>` before their JSON. In `parseChatResponse` (`useChatStore.ts`), `JSON.parse` fails on the think prefix and the catch fell back to `text.trim()` — the full think dump — which was stored as `entry.content` and rendered to the user. Reproducer: exported transcript `chat-review-and-critique-…-20260811.md`.

**Fix:** new `stripThinkingBlocks()` applied at three points:
- the `JSON.parse` input (so a think-prefixed-but-valid JSON still parses),
- the catch-path raw-text fallback (the reported line),
- the `parsed.response || …` fallback (line 85 — same leak when the JSON has no `response` field; not in the report but fixed for completeness).

Handles `<think>`/`<thinking>`, case-insensitive, multiple blocks. **Regression tests** (`useChatStore.test.ts`) cover all three paths + think-free passthrough; `parseChatResponse` is now exported for direct unit testing.

Reported by Chat (p/132). Self-cert: `/add-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
