### PR TITLE
chore(chat): record chat.thinking-stripped flight-recorder event (t/2454)

### DIFF
--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -67,6 +67,7 @@ export type EventType =
   | 'state.init'
   // Chat
   | 'chat.user-message'
+  | 'chat.thinking-stripped'
   // User interaction
   | 'user.action'
   | 'ui.navigate'

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
@@ -3,7 +3,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockApi } = vi.hoisted(() => {
+const { mockApi, mockRecord } = vi.hoisted(() => {
+  const mockRecord = vi.fn();
   const mockApi = {
     listChatSessions: vi.fn().mockResolvedValue([]),
     loadChatSession: vi.fn(),
@@ -50,7 +51,7 @@ vi.mock('../prompts/chat', () => ({
 }));
 
 vi.mock('@lib/flight-recorder/index', () => ({
-  getGlobalRecorder: () => ({ record: vi.fn() }),
+  getGlobalRecorder: () => ({ record: mockRecord }),
 }));
 
 import { useChatStore, parseChatResponse } from './useChatStore';
@@ -308,6 +309,34 @@ describe('useChatStore', () => {
     it('leaves think-free responses unchanged', () => {
       expect(parseChatResponse('{"response":"ok"}').response).toBe('ok');
       expect(parseChatResponse('just text').response).toBe('just text');
+    });
+  });
+
+  // t/2454 — observability: emit a flight-recorder event when a <think> block is stripped,
+  // so thinking-model incidents are diagnosable from a dump without a live repro.
+  describe('parseChatResponse — records chat.thinking-stripped (t/2454)', () => {
+    beforeEach(() => { mockRecord.mockClear(); });
+
+    it('records chat.thinking-stripped with model + byte count when a block is stripped', () => {
+      const text = '<think>reasoning</think>{"response":"hi"}';
+      parseChatResponse(text, 'deepseek-r1');
+      const rec = mockRecord.mock.calls.map(c => c[0]).find(r => r.type === 'chat.thinking-stripped');
+      expect(rec).toBeTruthy();
+      expect(rec.component).toBe('chat-store');
+      expect(rec.level).toBe('debug');
+      expect(rec.data.model).toBe('deepseek-r1');
+      expect(rec.data.blockLength).toBe(text.length - '{"response":"hi"}'.length);
+    });
+
+    it('emits no chat.thinking-stripped record for a think-free response (no noise)', () => {
+      parseChatResponse('{"response":"ok"}', 'gemini-flash');
+      expect(mockRecord.mock.calls.map(c => c[0]).some(r => r.type === 'chat.thinking-stripped')).toBe(false);
+    });
+
+    it('records model as null when the model is unknown', () => {
+      parseChatResponse('<think>x</think>hi');
+      const rec = mockRecord.mock.calls.map(c => c[0]).find(r => r.type === 'chat.thinking-stripped');
+      expect(rec.data.model).toBeNull();
     });
   });
 });

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
@@ -16,7 +16,7 @@ const { mockApi, mockRecord } = vi.hoisted(() => {
     onChatStreamChunk: vi.fn().mockReturnValue(() => {}),
     trackEvent: vi.fn(),
   };
-  return { mockApi };
+  return { mockApi, mockRecord };
 });
 
 vi.mock('@bridge', () => ({ api: mockApi }));

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -86,10 +86,23 @@ function stripThinkingBlocks(text: string): string {
 }
 
 /** Parse the POVer's JSON response into content + taxonomy refs */
-export function parseChatResponse(text: string): { response: string; taxonomyRefs: TaxonomyRef[] } {
+export function parseChatResponse(text: string, model?: string): { response: string; taxonomyRefs: TaxonomyRef[] } {
+  const stripped = stripThinkingBlocks(text);
+  // Observability (t/2454): a stripped-vs-input difference means a reasoning model
+  // (DeepSeek/Groq) emitted a <think> block. Record it so thinking-model incidents are
+  // diagnosable from a flight-recorder dump without a live repro. Silent otherwise.
+  if (stripped !== text.trim()) {
+    getGlobalRecorder()?.record({
+      type: 'chat.thinking-stripped',
+      component: 'chat-store',
+      level: 'debug',
+      message: 'Stripped thinking block from model response',
+      data: { model: model ?? null, blockLength: text.length - stripped.length },
+    });
+  }
   try {
-    const parsed = JSON.parse(stripCodeFences(stripThinkingBlocks(text)));
-    const response = parsed.response || stripThinkingBlocks(text);
+    const parsed = JSON.parse(stripCodeFences(stripped));
+    const response = parsed.response || stripped;
     const taxonomyRefs: TaxonomyRef[] = Array.isArray(parsed.taxonomy_refs)
       ? parsed.taxonomy_refs
         .filter((r: Record<string, unknown>) => r.node_id && typeof r.node_id === 'string')
@@ -101,7 +114,7 @@ export function parseChatResponse(text: string): { response: string; taxonomyRef
     return { response, taxonomyRefs };
   } catch (err) {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-store', level: 'debug', message: 'Chat response JSON parse failed, using raw text', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-    return { response: stripThinkingBlocks(text), taxonomyRefs: [] };
+    return { response: stripped, taxonomyRefs: [] };
   }
 }
 
@@ -312,7 +325,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
       if (!isStillValid()) return;
 
-      const { response, taxonomyRefs } = parseChatResponse(fullText);
+      const { response, taxonomyRefs } = parseChatResponse(fullText, model);
 
       const entry: ChatEntry = {
         id: generateId(),
@@ -414,7 +427,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
       if (!isStillValid()) return;
 
-      const { response, taxonomyRefs } = parseChatResponse(fullText);
+      const { response, taxonomyRefs } = parseChatResponse(fullText, model);
 
       const poverEntry: ChatEntry = {
         id: generateId(),


### PR DESCRIPTION
Observability follow-up to t/2453 (the `<think>`-leak fix). `stripThinkingBlocks()` silently discards think content; when a reasoning model misbehaves (empty/malformed JSON inside the block) there was no flight-recorder signal to diagnose from.

`parseChatResponse` now computes the stripped text once and, when it differs from the input, records a **`chat.thinking-stripped`** (level: `debug`) event with `{ model, blockLength }`. Silent when no think block (no noise on normal models). `model` is threaded in from both send call sites.

**Cross-scope note:** adds the `chat.thinking-stripped` EventType next to the existing `chat.user-message` in `lib/flight-recorder/types.ts` (Shared Lib) — a 1-line additive union member with direct precedent; self-managed as trivial and done atomically with the consumer to avoid a broken-main window. Shared Lib notified.

Regression tests (`useChatStore.test.ts`): record fires with model + byte count; **no** record for a think-free response; `model` is `null` when unknown.

Ticket: t/2454 (chore, filed by Chat). AC met (`chat.thinking-stripped` at debug level, model + stripped byte count, silent when no block). Self-cert: `/add-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
