### PR TITLE
fix(chat): honest-fail system instruction when user pastes a URL (t/2459 Stage 0)

### DIFF
--- a/taxonomy-editor/src/renderer/prompts/chat.ts
+++ b/taxonomy-editor/src/renderer/prompts/chat.ts
@@ -88,6 +88,9 @@ ${taxonomyContext}
 === CONVERSATION TOPIC ===
 ${topic}
 
+=== HANDLING LINKS ===
+When the user's message contains a URL: you have not visited that URL and cannot read its contents. Lead your response by stating this clearly (e.g., "I haven't read that link") and ask the user to paste the relevant text. Do not speculate about or summarise the page's contents.
+
 Respond ONLY with a JSON object in this exact format (no markdown, no code fences):
 {
   "response": "Your response text here (use markdown formatting for structure)",


### PR DESCRIPTION
## Summary
- Adds `=== HANDLING LINKS ===` section to `chatSystemPrompt` in `prompts/chat.ts`
- When a chat message contains a URL, the model leads by stating it has not read the link and asks the user to paste the relevant text
- Unconditional in Stage 0 (no backend has URL-context capability yet); Stage 1 (Gemini `url_context` tool + read-chip) follows after t/2456 types land
- Self-cert: /trivial-change (TL-authorized cross-scope, p/417#1)

## Test plan
- [ ] CI green
- [ ] Manual: paste a URL into chat — response leads with honest can't-read statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)