### PR TITLE
feat(ai-client): urlContext tool option for Gemini provider (t/2456)

### DIFF
--- a/lib/ai-client/index.ts
+++ b/lib/ai-client/index.ts
@@ -1,13 +1,13 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-export type { GenerateOptions, ProviderResult, TokenUsage, RateLimitType, RateLimitHeaders, RetryProgress, BackendId, ApiKeyBackend, FetchFn, ToolDefinition, ToolCall, ToolResult, ModelCapabilities } from './types.js';
+export type { GenerateOptions, ProviderResult, TokenUsage, RateLimitType, RateLimitHeaders, RetryProgress, BackendId, ApiKeyBackend, FetchFn, ToolDefinition, ToolCall, ToolResult, ModelCapabilities, UrlContextEntry, UrlContextMetadata } from './types.js';
 export type { ModelEntry, ModelRegistry, ModelPricing } from './registry.js';
 export { ALL_API_KEY_BACKENDS } from './types.js';
 export { resolveBackend, resolveModel, buildModelIdMap, buildModelEntryMap, getApiModelId, getDefaultTimeout, getModelCapabilities, filterByCapabilities, estimateCost } from './registry.js';
 export { withTimeout, withRetry, retryableFetch, parseRateLimitType, parseRateLimitHeaders, CLI_RETRY_CONFIG, SERVER_RETRY_CONFIG } from './retry.js';
 export type { RetryConfig } from './retry.js';
-export { generateViaGemini, GEMINI_BASE, GEMINI_SAFETY_SETTINGS, toGeminiSchema } from './providers/gemini.js';
+export { generateViaGemini, generateViaGeminiStream, GEMINI_BASE, GEMINI_SAFETY_SETTINGS, toGeminiSchema } from './providers/gemini.js';
 export { generateViaClaude } from './providers/claude.js';
 export { generateViaGroq } from './providers/groq.js';
 export { generateViaOpenAI } from './providers/openai.js';

--- a/lib/ai-client/index.ts
+++ b/lib/ai-client/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-export type { GenerateOptions, ProviderResult, TokenUsage, RateLimitType, RateLimitHeaders, RetryProgress, BackendId, ApiKeyBackend, FetchFn, ToolDefinition, ToolCall, ToolResult, ModelCapabilities, UrlContextEntry, UrlContextMetadata } from './types.js';
+export type { GenerateOptions, ProviderResult, TokenUsage, RateLimitType, RateLimitHeaders, RetryProgress, BackendId, ApiKeyBackend, FetchFn, ToolDefinition, ToolCall, ToolResult, ModelCapabilities, UrlContextEntry, UrlContextMetadata, GeminiContentPart, GeminiContent } from './types.js';
 export type { ModelEntry, ModelRegistry, ModelPricing } from './registry.js';
 export { ALL_API_KEY_BACKENDS } from './types.js';
 export { resolveBackend, resolveModel, buildModelIdMap, buildModelEntryMap, getApiModelId, getDefaultTimeout, getModelCapabilities, filterByCapabilities, estimateCost } from './registry.js';

--- a/lib/ai-client/providers/gemini.test.ts
+++ b/lib/ai-client/providers/gemini.test.ts
@@ -186,4 +186,23 @@ describe('generateViaGeminiStream — urlContext', () => {
     expect(result.text).toBe('ok');
     expect(result.urlContextMetadata).toBeUndefined();
   });
+
+  it('sends geminiContents directly when provided, bypassing single-prompt construction', async () => {
+    let capturedBody = '';
+    const fetchFn: FetchFn = async (_url, init) => {
+      capturedBody = init?.body as string;
+      const encoder = new TextEncoder();
+      const data = encoder.encode(`data: ${JSON.stringify(streamChunk('reply'))}\n`);
+      const stream = new ReadableStream<Uint8Array>({ start(c) { c.enqueue(data); c.close(); } });
+      return { ok: true, status: 200, body: stream } as unknown as Response;
+    };
+    const contents = [
+      { role: 'user', parts: [{ text: 'hello' }] },
+      { role: 'model', parts: [{ text: 'hi' }] },
+      { role: 'user', parts: [{ text: 'what is 2+2?' }] },
+    ];
+    await generateViaGeminiStream(fetchFn, '', 'gemini-pro', 'key', { timeoutMs: 5000, geminiContents: contents });
+    const parsed = JSON.parse(capturedBody);
+    expect(parsed.contents).toEqual(contents);
+  });
 });

--- a/lib/ai-client/providers/gemini.test.ts
+++ b/lib/ai-client/providers/gemini.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { mapGeminiError } from './gemini.js';
+import { mapGeminiError, generateViaGemini, generateViaGeminiStream } from './gemini.js';
 import { ActionableError } from '../../debate/errors.js';
+import type { FetchFn } from '../types.js';
 
 function geminiErrorBody(status: string, reason?: string): string {
   const details = reason ? [{ '@type': 'type.googleapis.com/google.rpc.ErrorInfo', reason }] : [];
@@ -70,5 +71,119 @@ describe('mapGeminiError', () => {
     const body = geminiErrorBody('UNAUTHENTICATED', 'ACCESS_TOKEN_TYPE_UNSUPPORTED');
     const err = mapGeminiError(400, body);
     expect(err.message).toContain('OAuth access token');
+  });
+});
+
+// ── urlContext tool injection ────────────────────────────────────────────────
+
+function makeFetch(responseBody: unknown, status = 200): FetchFn {
+  return async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(responseBody),
+    body: null,
+  } as unknown as Response);
+}
+
+function geminiResponse(text: string, urlContextMetadata?: unknown) {
+  const candidate: Record<string, unknown> = {
+    content: { parts: [{ text }] },
+  };
+  if (urlContextMetadata !== undefined) candidate.urlContextMetadata = urlContextMetadata;
+  return { candidates: [candidate], usageMetadata: {} };
+}
+
+describe('generateViaGemini — urlContext', () => {
+  it('omits url_context tool when urlContext is not set', async () => {
+    let capturedBody = '';
+    const fetchFn: FetchFn = async (_url, init) => {
+      capturedBody = init?.body as string;
+      return { ok: true, status: 200, text: async () => JSON.stringify(geminiResponse('hello')), body: null } as unknown as Response;
+    };
+    await generateViaGemini(fetchFn, 'prompt', 'gemini-pro', 'key', { timeoutMs: 5000 });
+    const parsed = JSON.parse(capturedBody);
+    expect(parsed.tools).toBeUndefined();
+  });
+
+  it('includes url_context tool when urlContext is true', async () => {
+    let capturedBody = '';
+    const fetchFn: FetchFn = async (_url, init) => {
+      capturedBody = init?.body as string;
+      return { ok: true, status: 200, text: async () => JSON.stringify(geminiResponse('hello')), body: null } as unknown as Response;
+    };
+    await generateViaGemini(fetchFn, 'prompt', 'gemini-pro', 'key', { timeoutMs: 5000, urlContext: true });
+    const parsed = JSON.parse(capturedBody);
+    expect(parsed.tools).toEqual(expect.arrayContaining([{ url_context: {} }]));
+  });
+
+  it('parses urlContextMetadata when present in response', async () => {
+    const meta = { urlMetadata: [{ retrievedUrl: 'https://example.com', urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS' }] };
+    const fetchFn = makeFetch(geminiResponse('hello', meta));
+    const result = await generateViaGemini(fetchFn, 'prompt', 'gemini-pro', 'key', { timeoutMs: 5000, urlContext: true });
+    expect(result.urlContextMetadata).toEqual({ urlMetadata: [{ retrievedUrl: 'https://example.com', urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS' }] });
+  });
+
+  it('tolerates absent urlContextMetadata', async () => {
+    const fetchFn = makeFetch(geminiResponse('hello'));
+    const result = await generateViaGemini(fetchFn, 'prompt', 'gemini-pro', 'key', { timeoutMs: 5000, urlContext: true });
+    expect(result.urlContextMetadata).toBeUndefined();
+  });
+});
+
+// ── streaming path ───────────────────────────────────────────────────────────
+
+function makeStreamFetch(chunks: unknown[]): FetchFn {
+  return async () => {
+    const encoder = new TextEncoder();
+    const lines = chunks.map(c => `data: ${JSON.stringify(c)}\n`).join('\n');
+    const encoded = encoder.encode(lines);
+    let pos = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pos >= encoded.length) { controller.close(); return; }
+        controller.enqueue(encoded.slice(pos, pos + 64));
+        pos += 64;
+      },
+    });
+    return { ok: true, status: 200, body: stream } as unknown as Response;
+  };
+}
+
+function streamChunk(text: string, urlContextMetadata?: unknown) {
+  const candidate: Record<string, unknown> = { content: { parts: [{ text }] } };
+  if (urlContextMetadata !== undefined) candidate.urlContextMetadata = urlContextMetadata;
+  return { candidates: [candidate] };
+}
+
+describe('generateViaGeminiStream — urlContext', () => {
+  it('includes url_context tool in streaming request when urlContext is true', async () => {
+    let capturedBody = '';
+    const fetchFn: FetchFn = async (_url, init) => {
+      capturedBody = init?.body as string;
+      const encoder = new TextEncoder();
+      const data = encoder.encode(`data: ${JSON.stringify(streamChunk('hi'))}\n`);
+      const stream = new ReadableStream<Uint8Array>({ start(c) { c.enqueue(data); c.close(); } });
+      return { ok: true, status: 200, body: stream } as unknown as Response;
+    };
+    await generateViaGeminiStream(fetchFn, 'prompt', 'gemini-pro', 'key', { timeoutMs: 5000, urlContext: true });
+    const parsed = JSON.parse(capturedBody);
+    expect(parsed.tools).toEqual(expect.arrayContaining([{ url_context: {} }]));
+  });
+
+  it('accumulates streamed text and surfaces urlContextMetadata from last chunk', async () => {
+    const meta = { urlMetadata: [{ retrievedUrl: 'https://example.com', urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS' }] };
+    const fetchFn = makeStreamFetch([streamChunk('hel'), streamChunk('lo', meta)]);
+    const chunks: string[] = [];
+    const result = await generateViaGeminiStream(fetchFn, 'p', 'gemini-pro', 'key', { timeoutMs: 5000, urlContext: true }, c => chunks.push(c));
+    expect(result.text).toBe('hello');
+    expect(chunks).toEqual(['hel', 'lo']);
+    expect(result.urlContextMetadata).toEqual({ urlMetadata: [{ retrievedUrl: 'https://example.com', urlRetrievalStatus: 'URL_RETRIEVAL_STATUS_SUCCESS' }] });
+  });
+
+  it('tolerates absent urlContextMetadata in streaming response', async () => {
+    const fetchFn = makeStreamFetch([streamChunk('ok')]);
+    const result = await generateViaGeminiStream(fetchFn, 'p', 'gemini-pro', 'key', { timeoutMs: 5000, urlContext: true });
+    expect(result.text).toBe('ok');
+    expect(result.urlContextMetadata).toBeUndefined();
   });
 });

--- a/lib/ai-client/providers/gemini.ts
+++ b/lib/ai-client/providers/gemini.ts
@@ -3,7 +3,7 @@
 
 import { ActionableError } from '../../debate/errors.js';
 import { withTimeout } from '../retry.js';
-import type { FetchFn, GenerateOptions, ProviderResult, ToolCall } from '../types.js';
+import type { FetchFn, GenerateOptions, ProviderResult, ToolCall, UrlContextMetadata } from '../types.js';
 import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
 export const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
@@ -45,6 +45,34 @@ export function toGeminiSchema(schema: Record<string, unknown>): Record<string, 
   return result;
 }
 
+function buildGeminiTools(opts: GenerateOptions): unknown[] | undefined {
+  const tools: unknown[] = [];
+  if (opts.tools?.length) {
+    tools.push({
+      functionDeclarations: opts.tools.map(t => ({
+        name: t.name,
+        description: t.description,
+        parameters: toGeminiSchema(t.parameters),
+      })),
+    });
+  }
+  if (opts.urlContext) {
+    tools.push({ url_context: {} });
+  }
+  return tools.length ? tools : undefined;
+}
+
+function parseUrlContextMetadata(candidate: Record<string, unknown>): UrlContextMetadata | undefined {
+  const raw = candidate.urlContextMetadata as { urlMetadata?: { retrievedUrl?: string; urlRetrievalStatus?: string }[] } | undefined;
+  if (!raw?.urlMetadata?.length) return undefined;
+  return {
+    urlMetadata: raw.urlMetadata.map(e => ({
+      retrievedUrl: e.retrievedUrl ?? '',
+      urlRetrievalStatus: e.urlRetrievalStatus ?? '',
+    })),
+  };
+}
+
 export async function generateViaGemini(
   fetchFn: FetchFn,
   prompt: string,
@@ -74,15 +102,8 @@ export async function generateViaGemini(
   if (opts.systemMessage) {
     body.systemInstruction = { parts: [{ text: opts.systemMessage }] };
   }
-  if (opts.tools?.length) {
-    body.tools = [{
-      functionDeclarations: opts.tools.map(t => ({
-        name: t.name,
-        description: t.description,
-        parameters: toGeminiSchema(t.parameters),
-      })),
-    }];
-  }
+  const tools = buildGeminiTools(opts);
+  if (tools) body.tools = tools;
 
   const response = await withTimeout(
     fetchFn(url, {
@@ -109,7 +130,7 @@ export async function generateViaGemini(
   }
 
   let json: {
-    candidates?: { content: { parts: { text?: string; functionCall?: { name: string; args: Record<string, unknown> } }[] } }[];
+    candidates?: (Record<string, unknown> & { content: { parts: { text?: string; functionCall?: { name: string; args: Record<string, unknown> } }[] } })[];
     usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number; cachedContentTokenCount?: number; totalTokenCount?: number };
   };
   try {
@@ -130,7 +151,8 @@ export async function generateViaGemini(
       nextSteps: ['Retry the request', 'Try a different model'],
     });
   }
-  const parts = json.candidates[0].content.parts;
+  const candidate = json.candidates[0];
+  const parts = candidate.content.parts;
   const text = parts.filter(p => p.text).map(p => p.text).join('');
   const fnCalls = parts.filter(p => p.functionCall);
   const toolCalls: ToolCall[] | undefined = fnCalls.length > 0
@@ -147,7 +169,114 @@ export async function generateViaGemini(
     cachedTokens: um.cachedContentTokenCount,
     totalTokens: um.totalTokenCount,
   } : undefined;
-  return { text, usage, toolCalls };
+  const urlContextMetadata = parseUrlContextMetadata(candidate);
+  return { text, usage, toolCalls, urlContextMetadata };
+}
+
+export async function generateViaGeminiStream(
+  fetchFn: FetchFn,
+  prompt: string,
+  apiModelId: string,
+  apiKey: string,
+  opts: GenerateOptions,
+  onChunk?: (text: string) => void,
+): Promise<ProviderResult> {
+  const url = `${GEMINI_BASE}/${apiModelId}:streamGenerateContent?alt=sse&key=${apiKey}`;
+  const timeoutMs = opts.timeoutMs!;
+
+  const genConfig: Record<string, unknown> = {
+    temperature: opts.temperature ?? DEFAULT_TEMPERATURE,
+    maxOutputTokens: opts.maxTokens ?? 16384,
+  };
+
+  const body: Record<string, unknown> = {
+    contents: [{ parts: [{ text: prompt }] }],
+    generationConfig: genConfig,
+    safetySettings: GEMINI_SAFETY_SETTINGS,
+  };
+  if (opts.systemMessage) {
+    body.systemInstruction = { parts: [{ text: opts.systemMessage }] };
+  }
+  const tools = buildGeminiTools(opts);
+  if (tools) body.tools = tools;
+
+  const response = await withTimeout(
+    fetchFn(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+    timeoutMs,
+    'Gemini streaming API request',
+  );
+
+  if (response.status === 429 || response.status === 503) {
+    const errBody = await response.text().catch(() => '');
+    throw new ActionableError({
+      goal: 'Generate text via Gemini (streaming)',
+      problem: `Gemini ${response.status}: ${errBody.slice(0, 200)}`,
+      location: 'ai-client.generateViaGeminiStream',
+      nextSteps: ['Wait a minute and retry', 'Switch to a different AI provider (Settings → AI Model)', 'Check API quota'],
+    });
+  }
+  if (!response.ok) {
+    const errBody = await response.text().catch(() => '');
+    throw mapGeminiError(response.status, errBody);
+  }
+  if (!response.body) {
+    throw new ActionableError({
+      goal: 'Generate text via Gemini (streaming)',
+      problem: 'Gemini streaming response has no body',
+      location: 'ai-client.generateViaGeminiStream',
+      nextSteps: ['Retry the request', 'Fall back to non-streaming generateViaGemini'],
+    });
+  }
+
+  const chunks: string[] = [];
+  let urlContextMetadata: UrlContextMetadata | undefined;
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  const processPayload = (payload: string): void => {
+    if (!payload || payload === '[DONE]') return;
+    let parsed: { candidates?: (Record<string, unknown> & { content?: { parts?: { text?: string }[] } })[] };
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      return;
+    }
+    const candidate = parsed.candidates?.[0];
+    if (!candidate) return;
+    const text = candidate.content?.parts
+      ?.filter((p): p is { text: string } => typeof p.text === 'string')
+      .map(p => p.text)
+      .join('') ?? '';
+    if (text) {
+      chunks.push(text);
+      onChunk?.(text);
+    }
+    const meta = parseUrlContextMetadata(candidate);
+    if (meta) urlContextMetadata = meta;
+  };
+
+  const reader = response.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (line.startsWith('data: ')) processPayload(line.slice(6).trim());
+      }
+    }
+    if (buffer.startsWith('data: ')) processPayload(buffer.slice(6).trim());
+  } finally {
+    reader.releaseLock();
+  }
+
+  return { text: chunks.join(''), urlContextMetadata };
 }
 
 export function mapGeminiError(status: number, bodyText: string): ActionableError {

--- a/lib/ai-client/providers/gemini.ts
+++ b/lib/ai-client/providers/gemini.ts
@@ -189,8 +189,9 @@ export async function generateViaGeminiStream(
     maxOutputTokens: opts.maxTokens ?? 16384,
   };
 
+  const contents = opts.geminiContents ?? [{ role: 'user', parts: [{ text: prompt }] }];
   const body: Record<string, unknown> = {
-    contents: [{ parts: [{ text: prompt }] }],
+    contents,
     generationConfig: genConfig,
     safetySettings: GEMINI_SAFETY_SETTINGS,
   };

--- a/lib/ai-client/types.ts
+++ b/lib/ai-client/types.ts
@@ -34,6 +34,18 @@ export interface GenerateOptions {
    *  registry (ModelEntry.fixedTemperature) for reasoning models that reject arbitrary
    *  values, e.g. moonshot kimi-k3 which only accepts 1 (t/2068). */
   fixedTemperature?: number;
+  /** Gemini only: enable URL-context grounding. When set, the provider adds the
+   *  `url_context` tool entry so Gemini fetches URLs mentioned in the prompt. */
+  urlContext?: boolean;
+}
+
+export interface UrlContextEntry {
+  retrievedUrl: string;
+  urlRetrievalStatus: string;
+}
+
+export interface UrlContextMetadata {
+  urlMetadata: UrlContextEntry[];
 }
 
 export interface ProviderResult {
@@ -43,6 +55,8 @@ export interface ProviderResult {
   estimatedCostUsd?: number;
   /** First 200 chars of raw API response body when content is empty — aids FR diagnosis. */
   rawResponsePreview?: string;
+  /** Gemini URL-context grounding metadata — present when `urlContext` was enabled. */
+  urlContextMetadata?: UrlContextMetadata;
 }
 
 export interface TokenUsage {

--- a/lib/ai-client/types.ts
+++ b/lib/ai-client/types.ts
@@ -37,6 +37,19 @@ export interface GenerateOptions {
   /** Gemini only: enable URL-context grounding. When set, the provider adds the
    *  `url_context` tool entry so Gemini fetches URLs mentioned in the prompt. */
   urlContext?: boolean;
+  /** Gemini only: pre-built multi-turn contents array for chat streaming.
+   *  When provided, replaces the default single-turn `[{ parts: [{ text: prompt }] }]`
+   *  construction so callers can pass conversation history directly. */
+  geminiContents?: GeminiContent[];
+}
+
+export interface GeminiContentPart {
+  text: string;
+}
+
+export interface GeminiContent {
+  role: string;
+  parts: GeminiContentPart[];
 }
 
 export interface UrlContextEntry {


### PR DESCRIPTION
## Summary
- `GenerateOptions.urlContext?: boolean` — adds `{ url_context: {} }` to Gemini request tools (composable with `functionDeclarations`) on both non-streaming and new streaming paths
- `UrlContextEntry` / `UrlContextMetadata` types on `ProviderResult.urlContextMetadata?` — consumers get per-URL fetch status without any polling
- `generateViaGeminiStream` — new SSE streaming function following the deepseek stream pattern; unblocks ServerAPI (t/2457) and ElectronMain (t/2458) consumers

## What changed
- `lib/ai-client/types.ts` — `urlContext?` on `GenerateOptions`; `UrlContextEntry`, `UrlContextMetadata`; `urlContextMetadata?` on `ProviderResult`
- `lib/ai-client/providers/gemini.ts` — `buildGeminiTools()` helper (composable url_context + functionDeclarations); `parseUrlContextMetadata()` helper; non-streaming path updated; `generateViaGeminiStream` added
- `lib/ai-client/index.ts` — exports `UrlContextEntry`, `UrlContextMetadata`, `generateViaGeminiStream`
- `lib/ai-client/providers/gemini.test.ts` — 7 new tests covering tool injection, metadata parse, absent-metadata tolerance, streaming accumulation + onChunk + metadata surface

## Test plan
- [ ] `npx vitest run lib/ai-client/providers/gemini.test.ts` — 16/16 pass
- [ ] `npx vitest run lib/ai-client` — 165/165 pass
- [ ] No new tsc errors in ai-client scope

🤖 Generated with [Claude Code](https://claude.ai/claude-code)