### PR TITLE
feat(server): key anonymous analytics events by truncated anon_session_id (t/2465)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/anonSessionKey.test.ts
+++ b/taxonomy-editor/src/server/__tests__/anonSessionKey.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+// t/2465 — resolveAnonSessionKey: anonymous analytics events keyed by
+// truncated anon_session_id cookie instead of the _anonymous bucket.
+
+import { describe, it, expect } from 'vitest';
+import type { IncomingMessage } from 'http';
+import { resolveAnonSessionKey } from '../routes/session.js';
+
+const reqWith = (cookie?: string): IncomingMessage =>
+  ({ headers: { cookie } } as unknown as IncomingMessage);
+
+describe('resolveAnonSessionKey (t/2465)', () => {
+  it('returns anon:<12-char prefix> when anon_session_id cookie is present', () => {
+    const key = resolveAnonSessionKey(reqWith('anon_session_id=abcdefghijklmnopqrstuvwxyz'));
+    expect(key).toBe('anon:abcdefghijkl');
+  });
+
+  it('truncates to exactly 12 chars for values longer than 12', () => {
+    const longVal = 'a'.repeat(50);
+    expect(resolveAnonSessionKey(reqWith(`anon_session_id=${longVal}`))).toBe('anon:aaaaaaaaaaaa');
+  });
+
+  it('returns _anonymous when no anon_session_id cookie is present', () => {
+    expect(resolveAnonSessionKey(reqWith(undefined))).toBe('_anonymous');
+    expect(resolveAnonSessionKey(reqWith('other=cookie'))).toBe('_anonymous');
+  });
+});

--- a/taxonomy-editor/src/server/routes/session.ts
+++ b/taxonomy-editor/src/server/routes/session.ts
@@ -14,6 +14,7 @@
 // cap (TRACE_MAX_EVENTS_PER_BATCH) is used only by /debug/events, so it moves in
 // as module-local state. All other helpers are pure module imports.
 
+import type { IncomingMessage } from 'http';
 import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error, getClientIp } from '../httpKit.js';
@@ -23,6 +24,15 @@ import { deriveStorageUserId } from '../security/userContext.js';
 import { getQuotaLimits } from '../security/quotas.js';
 import { requireAdmin } from '../community/admin/reviewRegistry.js';
 import * as analytics from '../community/analytics.js';
+import { parseCookies } from '../httpCookies.js';
+
+/** Resolve analytics user key for anonymous requests (t/2465).
+ *  Returns 'anon:' + first 12 chars of anon_session_id (HttpOnly — server-reads only),
+ *  or '_anonymous' when the cookie is absent (cookie-less fallback). */
+export function resolveAnonSessionKey(req: IncomingMessage): string {
+  const id = parseCookies(req).get('anon_session_id');
+  return id ? `anon:${id.slice(0, 12)}` : '_anonymous';
+}
 
 const TRACE_MAX_EVENTS_PER_BATCH = 100;
 
@@ -44,7 +54,7 @@ export function registerSessionRoutes(r: Router, ctx: ServerCtx): void {
     const isAnon = !principalName;
     const authOpt = process.env.AUTH_OPTIONAL === '1';
     json(res, {
-      user: principalName || '_anonymous',
+      user: principalName || resolveAnonSessionKey(req),
       idp: idp || '',
       anonymous: isAnon,
       capabilities: {


### PR DESCRIPTION
## Summary

- Adds `resolveAnonSessionKey(req)` in `routes/session.ts` — returns `'anon:' + first 12 chars` of `anon_session_id` cookie, or `'_anonymous'` (cookie-less fallback)
- `/api/auth/me` now returns per-session anonymous user keys instead of the flat `_anonymous` bucket
- Reuses `parseCookies()` (Map-based, prototype-pollution-safe, t/2019)
- 12-char truncation is a privacy requirement per HLD t/2460#2
- Independently landable from sibling t/2464

## Self-cert

/trivial-change — single-scope (`routes/session.ts`), <20 lines changed, no schema/interface changes, no new cross-role interfaces

## Test plan

- [x] 3 new unit tests: cookie present → `anon:xxxxxxxxxxxx`, long value truncated to 12, no cookie → `_anonymous`
- [x] `tsc --noEmit` clean
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)