### PR TITLE
feat(auth): persist anon_session_id — reuse-not-rotate at login endpoints (t/2464)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/accessControl.test.ts
+++ b/taxonomy-editor/src/server/__tests__/accessControl.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import path from 'path';
-import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, callerTierIdentity, clientSafeMessage, missingApiKeyError, expiredAuthCookies, anonymousSessionCookies, hasEasyAuthSessionCookie, resolveTestPersonaOverride } from '../security/accessControl.js';
+import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, callerTierIdentity, clientSafeMessage, missingApiKeyError, expiredAuthCookies, anonymousSessionCookies, isValidAnonSessionId, resolveAnonSessionId, hasEasyAuthSessionCookie, resolveTestPersonaOverride } from '../security/accessControl.js';
 import { deriveStorageUserId } from '../security/userContext.js';
 import { resolveTier } from '../ai/proxyTiers.js';
 
@@ -34,7 +34,60 @@ describe('expiredAuthCookies (t/897)', () => {
   });
 });
 
-describe('anonymousSessionCookies (t/1483)', () => {
+describe('isValidAnonSessionId (t/2464)', () => {
+  it('accepts a well-formed UUID v4', () => {
+    expect(isValidAnonSessionId('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    expect(isValidAnonSessionId('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe(true);
+  });
+
+  it('rejects wrong version bit (not 4)', () => {
+    expect(isValidAnonSessionId('550e8400-e29b-31d4-a716-446655440000')).toBe(false); // version 3
+    expect(isValidAnonSessionId('550e8400-e29b-51d4-a716-446655440000')).toBe(false); // version 5
+  });
+
+  it('rejects wrong variant bits (not [89ab])', () => {
+    expect(isValidAnonSessionId('550e8400-e29b-41d4-0716-446655440000')).toBe(false); // variant 0x
+    expect(isValidAnonSessionId('550e8400-e29b-41d4-f716-446655440000')).toBe(false); // variant fx
+  });
+
+  it('rejects wrong length', () => {
+    expect(isValidAnonSessionId('550e8400-e29b-41d4-a716-44665544000')).toBe(false);  // 35 chars
+    expect(isValidAnonSessionId('550e8400-e29b-41d4-a716-4466554400000')).toBe(false); // 37 chars
+  });
+
+  it('rejects empty string, path traversal, SQL injection', () => {
+    expect(isValidAnonSessionId('')).toBe(false);
+    expect(isValidAnonSessionId('../etc/passwd')).toBe(false);
+    expect(isValidAnonSessionId("'; DROP TABLE sessions; --")).toBe(false);
+    expect(isValidAnonSessionId('UPPERCASE-UUID-4XXX-AXXX-XXXXXXXXXXXX')).toBe(false);
+  });
+});
+
+describe('resolveAnonSessionId (t/2464)', () => {
+  it('reuses a valid existing cookie value', () => {
+    const id = '550e8400-e29b-41d4-a716-446655440000';
+    expect(resolveAnonSessionId(id)).toBe(id);
+  });
+
+  it('mints a fresh UUID when existing is undefined', () => {
+    const result = resolveAnonSessionId(undefined);
+    expect(isValidAnonSessionId(result)).toBe(true);
+  });
+
+  it('mints a fresh UUID when existing is malformed — never echoes unvalidated input', () => {
+    const malformed = '../evil';
+    const result = resolveAnonSessionId(malformed);
+    expect(result).not.toBe(malformed);
+    expect(isValidAnonSessionId(result)).toBe(true);
+  });
+
+  it('mints a fresh UUID when existing is an empty string', () => {
+    const result = resolveAnonSessionId('');
+    expect(isValidAnonSessionId(result)).toBe(true);
+  });
+});
+
+describe('anonymousSessionCookies (t/1483 + t/2464)', () => {
   const saved = { env: process.env.NODE_ENV, origins: process.env.ALLOWED_ORIGINS };
   afterEach(() => {
     process.env.NODE_ENV = saved.env;
@@ -42,15 +95,21 @@ describe('anonymousSessionCookies (t/1483)', () => {
     else process.env.ALLOWED_ORIGINS = saved.origins;
   });
 
-  it('mints exactly the auth_anonymous flag + a fresh anon_session_id from the injected id', () => {
-    const out = anonymousSessionCookies(() => 'fixed-id-123');
+  it('mints exactly the auth_anonymous flag + the provided anon_session_id', () => {
+    const out = anonymousSessionCookies('fixed-id-123');
     expect(out).toHaveLength(2);
     expect(out[0]).toMatch(/^auth_anonymous=1;/);
     expect(out[1]).toMatch(/^anon_session_id=fixed-id-123;/);
   });
 
+  it('anon_session_id carries Max-Age=31536000 (1yr persistence); auth_anonymous does not', () => {
+    const out = anonymousSessionCookies('x');
+    expect(out[0]).not.toContain('Max-Age'); // session-scoped flag cookie
+    expect(out[1]).toContain('Max-Age=31536000');
+  });
+
   it('marks both cookies HttpOnly + SameSite=Lax so JS never reads them and CSRF is limited', () => {
-    for (const c of anonymousSessionCookies(() => 'x')) {
+    for (const c of anonymousSessionCookies('x')) {
       expect(c).toContain('HttpOnly');
       expect(c).toContain('SameSite=Lax');
       expect(c).toContain('Path=/');
@@ -60,19 +119,19 @@ describe('anonymousSessionCookies (t/1483)', () => {
   it('adds Secure in production', () => {
     process.env.NODE_ENV = 'production';
     delete process.env.ALLOWED_ORIGINS;
-    for (const c of anonymousSessionCookies(() => 'x')) expect(c).toContain('; Secure');
+    for (const c of anonymousSessionCookies('x')) expect(c).toContain('; Secure');
   });
 
   it('adds Secure when a cross-origin allowlist is configured (HTTPS deploy)', () => {
     process.env.NODE_ENV = 'development';
     process.env.ALLOWED_ORIGINS = 'https://app.example.com';
-    for (const c of anonymousSessionCookies(() => 'x')) expect(c).toContain('; Secure');
+    for (const c of anonymousSessionCookies('x')) expect(c).toContain('; Secure');
   });
 
   it('omits Secure in plain local dev so the cookie is still settable over HTTP', () => {
     process.env.NODE_ENV = 'development';
     delete process.env.ALLOWED_ORIGINS;
-    for (const c of anonymousSessionCookies(() => 'x')) expect(c).not.toContain('Secure');
+    for (const c of anonymousSessionCookies('x')) expect(c).not.toContain('Secure');
   });
 });
 

--- a/taxonomy-editor/src/server/security/accessControl.ts
+++ b/taxonomy-editor/src/server/security/accessControl.ts
@@ -65,20 +65,44 @@ export function expiredAuthCookies(presentCookieNames: string[]): string[] {
     `${n}=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Lax`);
 }
 
+// UUID v4: version bit = 4, variant bits = [89ab]. Matches exactly
+// crypto.randomUUID() output — length and charset are checked simultaneously.
+const ANON_SESSION_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+/** t/2464: true iff `id` has the exact shape produced by crypto.randomUUID(). */
+export function isValidAnonSessionId(id: string): boolean {
+  return ANON_SESSION_UUID_RE.test(id);
+}
+
+/**
+ * t/2464: reuse-not-rotate. Returns `existing` when it is a well-formed UUID v4
+ * (the only shape this server ever mints), otherwise mints a fresh one.
+ *
+ * INVARIANT: `existing` MUST come from parseCookies(req) — never from a query
+ * parameter, request body, or header. The HttpOnly flag prevents JS from forging
+ * the cookie; query/body/header inputs are untrusted and must never reach here.
+ */
+export function resolveAnonSessionId(existing: string | undefined): string {
+  return (existing !== undefined && isValidAnonSessionId(existing))
+    ? existing
+    : crypto.randomUUID();
+}
+
 /**
  * Mint the two anonymous-session cookies: the `auth_anonymous=1` flag the auth
- * gate reads and a fresh `anon_session_id`. Shared by GET /.auth/anonymous (302)
- * and POST /api/auth/anonymous (JSON, t/1483) so the Secure-flag gating can't
- * drift between the two mint sites. HttpOnly (never read by JS; the session id
- * is never echoed in a response body) and SameSite=Lax. Secure is added in
- * production or whenever cross-origin is configured, matching the deployed HTTPS
- * posture while staying settable over plain HTTP in local dev.
+ * gate reads and the `anon_session_id` pseudonymous identifier. Shared by
+ * GET /.auth/anonymous (302) and POST /api/auth/anonymous (JSON, t/1483) so
+ * the Secure-flag gating can't drift between the two mint sites.
+ * HttpOnly (never read by JS) and SameSite=Lax. Secure is added in production
+ * or whenever cross-origin is configured. Max-Age=1yr on anon_session_id makes
+ * it persistent across browser sessions (t/2464); auth_anonymous stays session-
+ * scoped so it acts as a "logged in anonymously" signal only while the tab is open.
  */
-export function anonymousSessionCookies(randomId: () => string): string[] {
+export function anonymousSessionCookies(sessionId: string): string[] {
   const secureSuffix = process.env.NODE_ENV === 'production' || process.env.ALLOWED_ORIGINS ? '; Secure' : '';
   return [
     `auth_anonymous=1; Path=/; HttpOnly; SameSite=Lax${secureSuffix}`,
-    `anon_session_id=${randomId()}; Path=/; HttpOnly; SameSite=Lax${secureSuffix}`,
+    `anon_session_id=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000${secureSuffix}`,
   ];
 }
 

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -36,7 +36,7 @@ import { GitHubAPIBackend } from './storage/githubAPIBackend.js';
 import { SessionBranchManager } from './storage/sessionBranchManager.js';
 import { runWithUser, getCurrentUserId, setSessionBranchName, deriveStorageUserId } from './security/userContext.js';
 import type { UserContext } from './security/userContext.js';
-import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, missingApiKeyError, anonymousSessionCookies, resolveTestPersonaOverride } from './security/accessControl.js';
+import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, missingApiKeyError, anonymousSessionCookies, resolveAnonSessionId, resolveTestPersonaOverride } from './security/accessControl.js';
 import { sanitizeUserText } from './security/contentSanitizer.js';
 import { getRollbackStatus } from './rollbackStatus.js';
 import { getErrorSummaryCached, type ErrorEntry } from './errorAggregation.js';
@@ -891,7 +891,7 @@ function handleAnonAuthEndpoints(req: http.IncomingMessage, res: http.ServerResp
   if (urlPath === '/.auth/anonymous' && authOptional) {
     res.writeHead(302, {
       'Location': '/',
-      'Set-Cookie': anonymousSessionCookies(() => crypto.randomUUID()),
+      'Set-Cookie': anonymousSessionCookies(resolveAnonSessionId(parseCookies(req).get('anon_session_id'))), // t/2464
     });
     res.end();
     return true;
@@ -907,7 +907,7 @@ function handleAnonAuthEndpoints(req: http.IncomingMessage, res: http.ServerResp
   if (urlPath === '/api/auth/anonymous' && req.method === 'POST' && authOptional) {
     res.writeHead(200, {
       'Content-Type': 'application/json',
-      'Set-Cookie': anonymousSessionCookies(() => crypto.randomUUID()),
+      'Set-Cookie': anonymousSessionCookies(resolveAnonSessionId(parseCookies(req).get('anon_session_id'))), // t/2464
     });
     res.end(JSON.stringify({ ok: true, anonymous: true }));
     return true;


### PR DESCRIPTION
## Summary

- Add `isValidAnonSessionId` (UUID v4 regex) and `resolveAnonSessionId` (reuse-or-mint) to `security/accessControl.ts`
- `anonymousSessionCookies` signature: `randomId: () => string` → `sessionId: string`; adds `Max-Age=31536000` to `anon_session_id` only (auth_anonymous stays session-scoped)
- Both anonymous-login endpoints (`/.auth/anonymous` + `POST /api/auth/anonymous`) now source the session ID from `parseCookies(req)` exclusively — never query/body/header (INVARIANT comment in `resolveAnonSessionId`)
- Side benefit: fixes t/2433-class debate orphaning (ID no longer rotates on re-login)
- 4-line call-site touch to `server.ts` — ServerAPI ack'd (p/135#27)

TL design approval: t/2464#2

## Test plan

- [ ] `isValidAnonSessionId`: valid UUID v4, wrong version/variant bits, wrong length, empty, path traversal
- [ ] `resolveAnonSessionId`: valid existing → reused; absent → fresh UUID; malformed → fresh UUID (never echoes invalid input)
- [ ] `anonymousSessionCookies`: Max-Age present on `anon_session_id`, absent on `auth_anonymous`; Secure/HttpOnly/SameSite unchanged
- [ ] `shareShell.test.ts`: static-scan assertions still pass (exact-path guards unchanged)
- [ ] CI green (local undici skew failures are Node 7.x local-only; CI runs Node 22.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)