### PR TITLE
feat(debate-workspace): add "🔖 spec" link to TERMS meta header (t/2471)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -194,11 +194,24 @@
 }
 
 .debate-meta-mode-label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
   font-size: var(--text-2xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   color: var(--text-muted);
   margin-bottom: var(--sp-2);
+}
+
+.debate-meta-mode-spec-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.debate-meta-mode-spec-link:hover {
+  color: var(--focus-ring);
+  text-decoration: underline;
 }
 
 /* ── Flip animation on tier/view change (t/1396) ─────── */

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.tsx
@@ -36,9 +36,13 @@ import { CommentOverlay, useEntryCommentCount } from '../chat/CommentHighlights'
 import { useCommentStore } from '../../hooks/useCommentStore';
 import type { DetailTier } from '@lib/debate/comments';
 import { TaxonomyRefsSection } from './TaxonomyRefs';
+import { api } from '@bridge';
 
 /** Remark pipeline for debate transcript text: GFM + POV colorization + ID-token ref links (t/1776). */
 const DEBATE_REMARK_PLUGINS = [remarkGfm, remarkColorizePov, remarkLinkifyRefs];
+
+/** Taxonomy Vocabulary System spec — linked from the TERMS meta-view header (t/2471). */
+const VOCAB_SPEC_URL = 'https://github.com/jpsnover/ai-triad-research/blob/main/docs/taxonomy-vocabulary-system-spec.md';
 
 /** Human-readable labels for the fact-check verdict taxonomy (t/1701 / t/1716). */
 const FACT_VERDICT_LABEL: Record<FactVerdict, string> = {
@@ -878,6 +882,10 @@ function StatementBody({
       {isMetaView && (
         <div className="debate-meta-mode-label">
           {TIER_LABELS[displayedTier]?.toUpperCase()}
+          {displayedTier === 'terms' && (
+            <a href="#" className="debate-meta-mode-spec-link" title="Open the Taxonomy Vocabulary System spec"
+              onClick={(e) => { e.preventDefault(); void api.openExternal(VOCAB_SPEC_URL); }}>🔖 spec</a>
+          )}
           {displayedTier === 'convergence' && (
             <TheoryLink
               docPath="research/comp-linguist/docs/convergence-signals-guide.md"


### PR DESCRIPTION
Adds a "🔖 spec" link beside the **TERMS** meta-view header in `StatementCard.tsx` that opens the [Taxonomy Vocabulary System spec](https://github.com/jpsnover/ai-triad-research/blob/main/docs/taxonomy-vocabulary-system-spec.md) on GitHub.

- Rendered **only** on `displayedTier === 'terms'` (not Lineage/Claims/Convergence/Reasoning).
- Opens via `api.openExternal` — the existing Electron external-link path used by `VocabularyPanel.tsx` (not a bare fetch; Client Network Resilience N/A).
- `.debate-meta-mode-label` made a flex row; new co-located `.debate-meta-mode-spec-link` rule uses defined tokens only (`--text-secondary` default, `--focus-ring` on hover). No new `styles.css` selectors.

**Gates (worktree):** renderer tsc 0/0 · scoped vitest 267 passed · eslint 0 errors (`StatementCard.tsx` at 1499/1500 lines — under the max-lines ceiling).

Closes t/2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
