### PR TITLE
feat(analysis): Admin Engagement dashboard — sections 1-6 (t/2468)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -61,6 +61,7 @@ const PromptDiffWindow = recordingLazy(() => import('./components/chat/PromptDif
 const DiffWindow = recordingLazy(() => import('./components/shared/DiffWindow').then(m => ({ default: m.DiffWindow })));
 const HarvestDialog = recordingLazy(() => import('./components/shared/HarvestDialog').then(m => ({ default: m.HarvestDialog })));
 const AnalyticsDashboard = recordingLazy(() => import('./components/analysis/AnalyticsDashboard').then(m => ({ default: m.AnalyticsDashboard })));
+const EngagementDashboard = recordingLazy(() => import('./components/analysis/EngagementDashboard').then(m => ({ default: m.EngagementDashboard })));
 const CommunityLibrary = recordingLazy(() => import('./components/community/CommunityLibrary').then(m => ({ default: m.CommunityLibrary })));
 const AdminPanel = recordingLazy(() => import('./components/settings/AdminPanel').then(m => ({ default: m.AdminPanel })));
 const AdminReviewPanel = recordingLazy(() => import('./components/settings/AdminReviewPanel').then(m => ({ default: m.AdminReviewPanel })));
@@ -165,6 +166,7 @@ function FileViewerApp() {
 export function App() {
   const [hash, setHash] = useState(window.location.hash);
   const analyticsFlag = useFlag('env-web-analytics-dashboard');
+  const isAdmin = useFlag('permission-admin-features');
   const communityFlag = useFlag('env-web-community-library');
   const adminLegacyFlag = useFlag('env-web-admin-legacy');
 
@@ -201,6 +203,12 @@ export function App() {
   }
   if (hash === '#analytics' && analyticsFlag) {
     return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><AnalyticsDashboard /></Suspense></ErrorBoundary>;
+  }
+  // Admin-only engagement analytics (t/2468). Non-admins fall through to the main
+  // app — the view is unreachable — and the server independently requireAdmin-gates
+  // the per-user data it serves.
+  if (hash === '#engagement' && isAdmin) {
+    return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><EngagementDashboard /></Suspense></ErrorBoundary>;
   }
   if (hash === '#community' && communityFlag) {
     return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><CommunityLibrary /></Suspense></ErrorBoundary>;

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.css
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.css
@@ -1,0 +1,387 @@
+/* EngagementDashboard — admin engagement analytics surface (t/2468).
+   Prefix: eng-. styles.css is frozen — all new selectors go here. */
+
+/* ── Root ──────────────────────────────────────────────────────────────────── */
+
+.eng-root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  min-height: 100vh;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+
+/* ── Header ─────────────────────────────────────────────────────────────────── */
+
+.eng-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.eng-header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.eng-header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.eng-back-btn {
+  padding: 0.3rem 0.75rem;
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8125rem;
+}
+
+.eng-back-btn:hover { color: var(--text-primary); }
+
+.eng-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.eng-admin-badge {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--color-acc, #b84e13) 15%, transparent);
+  color: var(--color-acc, #b84e13);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.eng-admin-badge--header { margin-left: 0.25rem; }
+
+/* ── Controls ───────────────────────────────────────────────────────────────── */
+
+.eng-preset-group {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.eng-preset-btn {
+  padding: 0.3rem 0.6rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  transition: background 0.1s;
+}
+
+.eng-user-filter {
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  width: 180px;
+}
+
+.eng-user-filter::placeholder { color: var(--text-muted); }
+
+/* ── State feedback ──────────────────────────────────────────────────────────── */
+
+.eng-loading, .eng-error, .eng-empty {
+  padding: 1rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.eng-error { color: var(--danger, #ef4444); }
+
+.eng-empty-state {
+  padding: 3rem 1rem;
+  text-align: center;
+}
+
+.eng-empty-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.eng-empty-sub { color: var(--text-muted); }
+
+/* ── Panels ──────────────────────────────────────────────────────────────────── */
+
+.eng-panel {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  position: relative;
+}
+
+.eng-panel-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* ── Section 1: Engaged Over Time ────────────────────────────────────────────── */
+
+.eng-time-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 80px;
+  padding-bottom: 4px;
+  overflow: hidden;
+}
+
+.eng-time-bar-col {
+  flex: 1;
+  min-width: 4px;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  cursor: crosshair;
+}
+
+.eng-time-bar {
+  width: 100%;
+  background: var(--color-saf, #2b5fad);
+  border-radius: 2px 2px 0 0;
+  opacity: 0.8;
+  transition: opacity 0.1s;
+}
+
+.eng-time-bar-col:hover .eng-time-bar { opacity: 1; }
+
+.eng-time-legend {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.eng-legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  background: var(--color-saf, #2b5fad);
+  margin-right: 0.25rem;
+  vertical-align: middle;
+}
+
+/* ── Section 2+3: Distribution row ──────────────────────────────────────────── */
+
+.eng-dist-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 700px) {
+  .eng-dist-row { grid-template-columns: 1fr; }
+}
+
+.eng-camp-panel, .eng-drilldown-panel { display: flex; flex-direction: column; gap: 0; }
+
+.eng-camp-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  margin-top: -0.5rem;
+}
+
+.eng-camp-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-bottom: 0.25rem;
+  transition: background 0.1s;
+}
+
+.eng-camp-row:hover { background: color-mix(in srgb, var(--text-muted) 8%, transparent); }
+.eng-camp-row--active { background: color-mix(in srgb, var(--text-muted) 12%, transparent); outline: 1px solid var(--border-color); }
+
+.eng-camp-row-head, .eng-cat-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.eng-camp-label, .eng-cat-label { font-weight: 500; font-size: 0.8125rem; color: var(--text-primary); }
+.eng-camp-value, .eng-cat-value { font-size: 0.75rem; color: var(--text-muted); }
+
+.eng-camp-track {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bg-primary);
+  overflow: hidden;
+}
+
+.eng-camp-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.eng-cat-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.25rem 0;
+  margin-bottom: 0.25rem;
+}
+
+/* ── Section 4: Leaderboards ─────────────────────────────────────────────────── */
+
+.eng-leaders-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 600px) {
+  .eng-leaders-row { grid-template-columns: 1fr; }
+}
+
+.eng-leader-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.eng-leader-col-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 0.625rem;
+  padding-bottom: 0.375rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.eng-leader-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  font-size: 0.8125rem;
+}
+
+.eng-leader-rank {
+  width: 1.25rem;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.eng-leader-id {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: monospace;
+  font-size: 0.75rem;
+  color: var(--text-primary);
+}
+
+.eng-leader-val {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+/* ── Section 5: Per-user table ───────────────────────────────────────────────── */
+
+.eng-users-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.eng-th {
+  padding: 0.375rem 0.5rem;
+  font-weight: 600;
+  font-size: 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.eng-th:hover { color: var(--text-primary) !important; }
+
+.eng-user-row { border-bottom: 1px solid var(--border-color); }
+.eng-user-row:last-child { border-bottom: none; }
+
+.eng-td, .eng-td-num, .eng-td-num-nowrap, .eng-td-user {
+  padding: 0.375rem 0.5rem;
+  vertical-align: middle;
+}
+
+.eng-td-num { text-align: right; color: var(--text-muted); }
+.eng-td-num-nowrap { text-align: right; white-space: nowrap; color: var(--text-muted); }
+.eng-td-user { max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.eng-camp-badge {
+  display: inline-block;
+  padding: 0.125rem 0.4rem;
+  border-radius: 3px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+}
+
+/* ── Section 6: Health strip ─────────────────────────────────────────────────── */
+
+.eng-health-metrics {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.eng-health-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  cursor: help;
+}
+
+.eng-health-value {
+  font-size: 1.375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.eng-health-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
@@ -1,0 +1,236 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EngagementDashboard } from './EngagementDashboard';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@bridge', () => ({
+  api: {},
+}));
+
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: vi.fn(() => ({ record: vi.fn() })),
+}));
+
+vi.mock('../../bridge/web-bridge', () => ({
+  bridgeGet: vi.fn(),
+}));
+
+vi.mock('../../hooks/useFeatureFlags', () => ({
+  useFlag: vi.fn(() => false),
+}));
+
+vi.mock('./chartTooltip', () => ({
+  useChartTooltip: () => ({ tip: null, showTip: vi.fn(), hideTip: vi.fn() }),
+  ChartTooltipLayer: () => null,
+}));
+
+import { bridgeGet } from '../../bridge/web-bridge';
+import { useFlag } from '../../hooks/useFeatureFlags';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const LEAF_NODE = (id: string) => ({
+  id, visits: 10, engagedVisits: 8, engagedMs: 30_000, cappedRate: 0.05,
+});
+
+const FIXTURE_TREE = {
+  id: 'root', visits: 100, engagedVisits: 80, engagedMs: 240_000, cappedRate: 0.05, uniqueUsers: 5,
+  children: {
+    taxonomy: {
+      id: 'taxonomy', visits: 100, engagedVisits: 80, engagedMs: 240_000,
+      children: {
+        acc: {
+          id: 'acc', visits: 40, engagedVisits: 32, engagedMs: 90_000,
+          children: {
+            'acc-bel': {
+              id: 'acc-bel', visits: 20, engagedVisits: 16, engagedMs: 50_000,
+              children: { 'acc-bel-001': LEAF_NODE('acc-bel-001'), 'acc-bel-002': LEAF_NODE('acc-bel-002') },
+            },
+            'acc-des': {
+              id: 'acc-des', visits: 20, engagedVisits: 16, engagedMs: 40_000,
+              children: { 'acc-des-001': LEAF_NODE('acc-des-001') },
+            },
+          },
+        },
+        saf: {
+          id: 'saf', visits: 60, engagedVisits: 48, engagedMs: 150_000,
+          children: {
+            'saf-bel': {
+              id: 'saf-bel', visits: 60, engagedVisits: 48, engagedMs: 150_000,
+              children: { 'saf-bel-001': LEAF_NODE('saf-bel-001') },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const FIXTURE_USERS = [
+  { user: 'alice@example.com', engagedMs: 120_000, sessions: 5, topCamp: 'saf', topNode: 'saf-bel-001', lastActive: new Date(Date.now() - 60_000).toISOString() },
+  { user: 'bob@example.com',   engagedMs:  60_000, sessions: 2, topCamp: 'acc', topNode: 'acc-bel-001', lastActive: new Date(Date.now() - 3_600_000).toISOString() },
+];
+
+const FIXTURE_RESULT = {
+  aggregate: FIXTURE_TREE,
+  subtree: null,
+  daily: [
+    { date: '2026-08-04', engagedMs: 80_000, visits: 30 },
+    { date: '2026-08-05', engagedMs: 60_000, visits: 20 },
+    { date: '2026-08-06', engagedMs: 100_000, visits: 40 },
+  ],
+  users: FIXTURE_USERS,
+};
+
+const EMPTY_RESULT = {
+  aggregate: { id: 'root', visits: 0, engagedVisits: 0, engagedMs: 0 },
+  subtree: null,
+  daily: [],
+  users: [],
+};
+
+// ── Test helpers ───────────────────────────────────────────────────────────────
+
+function mockBridgeGet(result: typeof FIXTURE_RESULT | typeof EMPTY_RESULT) {
+  vi.mocked(bridgeGet).mockResolvedValue(result);
+}
+
+function mockAdmin(isAdmin: boolean) {
+  vi.mocked(useFlag).mockReturnValue(isAdmin);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('EngagementDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdmin(false);
+  });
+
+  it('shows loading state initially', () => {
+    vi.mocked(bridgeGet).mockReturnValue(new Promise(() => {}));
+    render(<EngagementDashboard />);
+    expect(screen.getByText(/loading engagement/i)).toBeTruthy();
+  });
+
+  it('shows empty state when aggregate.visits is 0', async () => {
+    mockBridgeGet(EMPTY_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/no engagement data/i)).toBeTruthy());
+  });
+
+  it('renders all visible sections from fixture data', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/engaged time over time/i)).toBeTruthy());
+    expect(screen.getByText(/camp distribution/i)).toBeTruthy();
+    expect(screen.getByText(/leaderboards/i)).toBeTruthy();
+  });
+
+  it('shows camp distribution bars with camp labels', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText('Safetyist')).toBeTruthy());
+    expect(screen.getByText('Accelerationist')).toBeTruthy();
+  });
+
+  it('drill-down shows category breakdown on camp click', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
+    fireEvent.click(screen.getByText('Accelerationist'));
+    await waitFor(() => expect(screen.getByText(/accelerationist.*category breakdown/i)).toBeTruthy());
+    expect(screen.getByText('Beliefs')).toBeTruthy();
+    expect(screen.getByText('Desires')).toBeTruthy();
+  });
+
+  it('drill-down closes when same camp clicked again', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
+    fireEvent.click(screen.getByText('Accelerationist'));
+    // Drill-down open: category rows appear
+    await waitFor(() => expect(screen.getByText('Beliefs')).toBeTruthy());
+    fireEvent.click(screen.getByText('Accelerationist'));
+    // Drill-down closed: category rows gone
+    await waitFor(() => expect(screen.queryByText('Beliefs')).toBeNull());
+  });
+
+  it('renders both leaderboards with distinct titles', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/most engaged time/i)).toBeTruthy());
+    expect(screen.getByText(/most visited/i)).toBeTruthy();
+  });
+
+  it('leaderboard items are visually distinct (different sort orders)', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/most engaged time/i)).toBeTruthy());
+    // Both columns render node IDs — check at least one appears
+    expect(screen.getAllByText(/acc-bel-001|saf-bel-001/).length).toBeGreaterThan(0);
+  });
+
+  it('hides admin sections (per-user table, health strip) for non-admins', async () => {
+    mockAdmin(false);
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/camp distribution/i)).toBeTruthy());
+    expect(screen.queryByText(/per-user engagement/i)).toBeNull();
+    expect(screen.queryByText(/heuristic health/i)).toBeNull();
+  });
+
+  it('shows per-user table and health strip for admins', async () => {
+    mockAdmin(true);
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/per-user engagement/i)).toBeTruthy());
+    expect(screen.getByText(/heuristic health/i)).toBeTruthy();
+    expect(screen.getByText('alice@example.com')).toBeTruthy();
+    expect(screen.getByText('bob@example.com')).toBeTruthy();
+  });
+
+  it('per-user table: non-admin user filter input not shown', async () => {
+    mockAdmin(false);
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/camp distribution/i)).toBeTruthy());
+    expect(screen.queryByPlaceholderText(/filter by user/i)).toBeNull();
+  });
+
+  it('per-user table: admin sees user filter input', async () => {
+    mockAdmin(true);
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByPlaceholderText(/filter by user/i)).toBeTruthy());
+  });
+
+  it('shows error state on fetch failure', async () => {
+    vi.mocked(bridgeGet).mockRejectedValue(new Error('Network error'));
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/failed to load/i)).toBeTruthy());
+  });
+
+  it('date preset buttons present and change selection', async () => {
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText('30 days')).toBeTruthy());
+    expect(screen.getByText('7 days')).toBeTruthy();
+    expect(screen.getByText('90 days')).toBeTruthy();
+    fireEvent.click(screen.getByText('30 days'));
+    // Re-fetch triggered (bridgeGet called again)
+    await waitFor(() => expect(vi.mocked(bridgeGet).mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it('health strip shows engagement rate', async () => {
+    mockAdmin(true);
+    mockBridgeGet(FIXTURE_RESULT);
+    render(<EngagementDashboard />);
+    // aggregate: visits=100, engagedVisits=80 → 80.0%
+    await waitFor(() => expect(screen.getByText('80.0%')).toBeTruthy());
+  });
+});

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
@@ -71,17 +71,17 @@ const FIXTURE_TREE = {
 };
 
 const FIXTURE_USERS = [
-  { user: 'alice@example.com', engagedMs: 120_000, sessions: 5, topCamp: 'saf', topNode: 'saf-bel-001', lastActive: new Date(Date.now() - 60_000).toISOString() },
-  { user: 'bob@example.com',   engagedMs:  60_000, sessions: 2, topCamp: 'acc', topNode: 'acc-bel-001', lastActive: new Date(Date.now() - 3_600_000).toISOString() },
+  { user: 'alice@example.com', visits: 50, engagedVisits: 40, engagedMs: 120_000, topCamp: 'saf', lastActive: new Date(Date.now() - 60_000).toISOString() },
+  { user: 'bob@example.com',   visits: 20, engagedVisits: 15, engagedMs:  60_000, topCamp: 'acc', lastActive: new Date(Date.now() - 3_600_000).toISOString() },
 ];
 
 const FIXTURE_RESULT = {
   aggregate: FIXTURE_TREE,
   subtree: null,
   daily: [
-    { date: '2026-08-04', engagedMs: 80_000, visits: 30 },
-    { date: '2026-08-05', engagedMs: 60_000, visits: 20 },
-    { date: '2026-08-06', engagedMs: 100_000, visits: 40 },
+    { date: '2026-08-04', visits: 30, engagedVisits: 24, engagedMs: 80_000 },
+    { date: '2026-08-05', visits: 20, engagedVisits: 16, engagedMs: 60_000 },
+    { date: '2026-08-06', visits: 40, engagedVisits: 32, engagedMs: 100_000 },
   ],
   users: FIXTURE_USERS,
 };

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
@@ -28,18 +28,18 @@ interface TreeNode {
   children?: Record<string, TreeNode>;
 }
 
-interface DailyPoint { date: string; engagedMs: number; visits: number }
-interface UserRow { user: string; engagedMs: number; sessions: number; topCamp: string; topNode: string; lastActive: string }
+interface DailyPoint { date: string; visits: number; engagedVisits: number; engagedMs: number }
+interface UserRow { user: string; visits: number; engagedVisits: number; engagedMs: number; topCamp: string; lastActive: string }
 
 interface EngagementResult {
   aggregate: TreeNode;
-  subtree: TreeNode | null;
+  user?: TreeNode;    // per-user subtree when ?user= given (t/2467#2)
   daily: DailyPoint[];
-  users: UserRow[]; // admin-gated; empty/absent for non-admins
+  users?: UserRow[];  // admin-only; stripped server-side for non-admins
 }
 
 type DatePreset = '7d' | '30d' | '90d';
-type UserSortCol = 'user' | 'engagedMs' | 'sessions' | 'topCamp' | 'lastActive';
+type UserSortCol = 'user' | 'engagedMs' | 'visits' | 'topCamp' | 'lastActive';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -343,7 +343,7 @@ function PerUserTable({ users }: { users: UserRow[] }) {
           <thead><tr>
             <Th col="user" label="User" align="left" />
             <Th col="engagedMs" label="Engaged" />
-            <Th col="sessions" label="Sessions" />
+            <Th col="visits" label="Visits" />
             <Th col="topCamp" label="Top Camp" />
             <Th col="lastActive" label="Last Active" />
           </tr></thead>
@@ -352,7 +352,7 @@ function PerUserTable({ users }: { users: UserRow[] }) {
               <tr key={u.user} className="eng-user-row">
                 <td className="eng-td-user" title={u.user}>{u.user}</td>
                 <td className="eng-td-num">{fmtDuration(u.engagedMs)}</td>
-                <td className="eng-td-num">{u.sessions}</td>
+                <td className="eng-td-num">{fmtNumber(u.visits)}</td>
                 <td className="eng-td">
                   <span
                     className="eng-camp-badge"
@@ -515,7 +515,7 @@ export function EngagementDashboard() {
               <Leaderboards aggregate={data.aggregate} />
 
               {/* Sections 5+6: admin-only */}
-              {isAdmin && data.users.length > 0 && <PerUserTable users={data.users} />}
+              {isAdmin && <PerUserTable users={data.users ?? []} />}
               {isAdmin && <HealthStrip aggregate={data.aggregate} />}
             </>
           )}

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
@@ -1,0 +1,526 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Engagement Dashboard — admin-only usage-analytics surface.
+ * Route: #engagement (wired by Rosetta, t/2468). Entry: SaveBar admin button.
+ * Spec: docs/ux/usage-analytics-instrumentation.md §4.1 + §5.1.
+ * Contract: t/2468#2.
+ */
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+// useCallback is used by PerUserTable's handleSort
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { bridgeGet } from '../../bridge/web-bridge';
+import { useFlag } from '../../hooks/useFeatureFlags';
+import { useChartTooltip, ChartTooltipLayer } from './chartTooltip';
+import './EngagementDashboard.css';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface TreeNode {
+  id: string;
+  visits: number;
+  engagedVisits: number;
+  engagedMs: number;
+  cappedRate?: number;
+  uniqueUsers?: number;
+  children?: Record<string, TreeNode>;
+}
+
+interface DailyPoint { date: string; engagedMs: number; visits: number }
+interface UserRow { user: string; engagedMs: number; sessions: number; topCamp: string; topNode: string; lastActive: string }
+
+interface EngagementResult {
+  aggregate: TreeNode;
+  subtree: TreeNode | null;
+  daily: DailyPoint[];
+  users: UserRow[]; // admin-gated; empty/absent for non-admins
+}
+
+type DatePreset = '7d' | '30d' | '90d';
+type UserSortCol = 'user' | 'engagedMs' | 'sessions' | 'topCamp' | 'lastActive';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const PRESET_DAYS: Record<DatePreset, number> = { '7d': 7, '30d': 30, '90d': 90 };
+
+const CAMP_COLORS: Record<string, string> = {
+  acc: 'var(--color-acc, #b84e13)',
+  saf: 'var(--color-saf, #2b5fad)',
+  skp: 'var(--color-skp, #7b4fa6)',
+  cc:  '#6b7280',
+};
+
+const CAMP_LABELS: Record<string, string> = {
+  acc: 'Accelerationist', saf: 'Safetyist', skp: 'Skeptic', cc: 'Cross-Cutting',
+};
+
+const CATEGORY_LABEL_MAP: Record<string, string> = { bel: 'Beliefs', des: 'Desires', int: 'Intentions' };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function dateRange(preset: DatePreset): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - (PRESET_DAYS[preset] - 1));
+  return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+}
+
+function fmtDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+function fmtNumber(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+/** Extract the category suffix (e.g. "bel" from "acc-bel") and return a human label. */
+function categoryLabel(catKey: string): string {
+  const suffix = catKey.split('-')[1];
+  return CATEGORY_LABEL_MAP[suffix] ?? catKey;
+}
+
+/** Traverse the tool→camp→category→node tree and accumulate engagedMs + visits per camp. */
+function sumByCamp(root: TreeNode): Array<{ key: string; engagedMs: number; visits: number }> {
+  const acc: Record<string, { engagedMs: number; visits: number }> = {};
+  for (const tool of Object.values(root.children ?? {})) {
+    for (const [campKey, camp] of Object.entries(tool.children ?? {})) {
+      if (!acc[campKey]) acc[campKey] = { engagedMs: 0, visits: 0 };
+      acc[campKey].engagedMs += camp.engagedMs;
+      acc[campKey].visits += camp.visits;
+    }
+  }
+  return Object.entries(acc)
+    .map(([key, v]) => ({ key, ...v }))
+    .sort((a, b) => b.engagedMs - a.engagedMs);
+}
+
+/** Accumulate engagedMs + visits per category inside the given camp, across all tools. */
+function sumByCategoryForCamp(root: TreeNode, camp: string): Array<{ key: string; engagedMs: number; visits: number }> {
+  const acc: Record<string, { engagedMs: number; visits: number }> = {};
+  for (const tool of Object.values(root.children ?? {})) {
+    const campNode = tool.children?.[camp];
+    if (!campNode) continue;
+    for (const [catKey, cat] of Object.entries(campNode.children ?? {})) {
+      if (!acc[catKey]) acc[catKey] = { engagedMs: 0, visits: 0 };
+      acc[catKey].engagedMs += cat.engagedMs;
+      acc[catKey].visits += cat.visits;
+    }
+  }
+  return Object.entries(acc)
+    .map(([key, v]) => ({ key, ...v }))
+    .sort((a, b) => b.engagedMs - a.engagedMs);
+}
+
+/** Flatten all leaf nodes (actual taxonomy nodes) for leaderboard ranking. */
+function collectLeafNodes(node: TreeNode, depth: number, results: Array<{ id: string; engagedMs: number; visits: number }>): void {
+  const kids = node.children;
+  if (!kids || Object.keys(kids).length === 0) {
+    if (depth >= 3) results.push({ id: node.id, engagedMs: node.engagedMs, visits: node.visits });
+    return;
+  }
+  for (const child of Object.values(kids)) {
+    collectLeafNodes(child, depth + 1, results);
+  }
+}
+
+// ── Section 1: Time-with-tool chart ──────────────────────────────────────────
+
+function EngagedOverTime({ daily }: { daily: DailyPoint[] }) {
+  const { tip, showTip, hideTip } = useChartTooltip();
+  if (daily.length === 0) return null;
+  const maxMs = Math.max(...daily.map(d => d.engagedMs), 1);
+
+  return (
+    <div className="eng-panel">
+      <div className="eng-panel-title">Engaged Time Over Time</div>
+      <div className="eng-time-bars">
+        {daily.map(d => {
+          const mins = Math.round(d.engagedMs / 60_000);
+          return (
+            <div
+              key={d.date}
+              className="eng-time-bar-col"
+              onMouseEnter={e => showTip(e, <><strong>{d.date}</strong><br />{fmtDuration(d.engagedMs)} engaged · {fmtNumber(d.visits)} visits</>)}
+              onMouseMove={e => showTip(e, <><strong>{d.date}</strong><br />{fmtDuration(d.engagedMs)} engaged · {fmtNumber(d.visits)} visits</>)}
+              onMouseLeave={hideTip}
+            >
+              <div
+                className="eng-time-bar"
+                /* eslint-disable-next-line local/no-inline-style -- dynamic: bar height proportional to engagedMs */
+                style={{ height: `${Math.max((d.engagedMs / maxMs) * 100, 2)}%` }}
+                title={`${mins}m`}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className="eng-time-legend">
+        <span><span className="eng-legend-swatch" />Engaged minutes/day (total)</span>
+      </div>
+      <ChartTooltipLayer tip={tip} />
+    </div>
+  );
+}
+
+// ── Section 2 + 3: Camp distribution + category drill-down ───────────────────
+
+function CampDistribution({
+  aggregate, selectedCamp, onSelectCamp,
+}: { aggregate: TreeNode; selectedCamp: string | null; onSelectCamp: (camp: string | null) => void }) {
+  const camps = useMemo(() => sumByCamp(aggregate), [aggregate]);
+  const maxMs = camps[0]?.engagedMs ?? 1;
+
+  if (camps.length === 0) return (
+    <div className="eng-panel"><div className="eng-panel-title">Camp Distribution</div><div className="eng-empty">No data</div></div>
+  );
+
+  return (
+    <div className="eng-panel eng-camp-panel">
+      <div className="eng-panel-title">Camp Distribution</div>
+      <div className="eng-camp-hint">Click a camp to see category breakdown</div>
+      {camps.map(c => {
+        const color = CAMP_COLORS[c.key] ?? '#6b7280';
+        const label = CAMP_LABELS[c.key] ?? c.key;
+        const isActive = selectedCamp === c.key;
+        return (
+          <div
+            key={c.key}
+            className={`eng-camp-row${isActive ? ' eng-camp-row--active' : ''}`}
+            onClick={() => onSelectCamp(isActive ? null : c.key)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={e => e.key === 'Enter' && onSelectCamp(isActive ? null : c.key)}
+          >
+            <div className="eng-camp-row-head">
+              <span className="eng-camp-label">{label}</span>
+              <span className="eng-camp-value">{fmtDuration(c.engagedMs)}</span>
+            </div>
+            <div className="eng-camp-track">
+              <div
+                className="eng-camp-fill"
+                /* eslint-disable-next-line local/no-inline-style -- dynamic: bar width + camp color from data */
+                style={{ width: `${(c.engagedMs / maxMs) * 100}%`, background: color }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CategoryDrillDown({ aggregate, camp }: { aggregate: TreeNode; camp: string }) {
+  const categories = useMemo(() => sumByCategoryForCamp(aggregate, camp), [aggregate, camp]);
+  const maxMs = categories[0]?.engagedMs ?? 1;
+  const color = CAMP_COLORS[camp] ?? '#6b7280';
+  const campLabel = CAMP_LABELS[camp] ?? camp;
+
+  return (
+    <div className="eng-panel eng-drilldown-panel">
+      <div className="eng-panel-title">{campLabel} — Category Breakdown</div>
+      {categories.length === 0 ? (
+        <div className="eng-empty">No category data</div>
+      ) : categories.map(c => (
+        <div key={c.key} className="eng-cat-row">
+          <div className="eng-cat-row-head">
+            <span className="eng-cat-label">{categoryLabel(c.key)}</span>
+            <span className="eng-cat-value">{fmtDuration(c.engagedMs)}</span>
+          </div>
+          <div className="eng-camp-track">
+            <div
+              className="eng-camp-fill"
+              /* eslint-disable-next-line local/no-inline-style -- dynamic: bar width + camp color */
+              style={{ width: `${(c.engagedMs / maxMs) * 100}%`, background: color, opacity: 0.7 }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Section 4: Leaderboards ───────────────────────────────────────────────────
+
+function Leaderboards({ aggregate }: { aggregate: TreeNode }) {
+  const nodes = useMemo(() => {
+    const results: Array<{ id: string; engagedMs: number; visits: number }> = [];
+    collectLeafNodes(aggregate, 0, results);
+    return results;
+  }, [aggregate]);
+
+  const byDepth = useMemo(() => [...nodes].sort((a, b) => b.engagedMs - a.engagedMs).slice(0, 10), [nodes]);
+  const byBreadth = useMemo(() => [...nodes].sort((a, b) => b.visits - a.visits).slice(0, 10), [nodes]);
+
+  const LeaderList = ({ items, valueKey, label }: {
+    items: Array<{ id: string; engagedMs: number; visits: number }>;
+    valueKey: 'engagedMs' | 'visits';
+    label: string;
+  }) => (
+    <div className="eng-leader-col">
+      <div className="eng-leader-col-title">{label}</div>
+      {items.length === 0 ? <div className="eng-empty">No data</div> : items.map((n, i) => (
+        <div key={n.id} className="eng-leader-row">
+          <span className="eng-leader-rank">{i + 1}</span>
+          <span className="eng-leader-id" title={n.id}>{n.id}</span>
+          <span className="eng-leader-val">
+            {valueKey === 'engagedMs' ? fmtDuration(n.engagedMs) : fmtNumber(n.visits)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="eng-panel eng-leaders-panel">
+      <div className="eng-panel-title">Leaderboards</div>
+      <div className="eng-leaders-row">
+        <LeaderList items={byDepth} valueKey="engagedMs" label="Most Engaged Time (depth)" />
+        <LeaderList items={byBreadth} valueKey="visits" label="Most Visited (breadth)" />
+      </div>
+    </div>
+  );
+}
+
+// ── Section 5: Per-user table (admin) ─────────────────────────────────────────
+
+function PerUserTable({ users }: { users: UserRow[] }) {
+  const [sortCol, setSortCol] = useState<UserSortCol>('engagedMs');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const sorted = useMemo(() => {
+    const arr = [...users];
+    arr.sort((a, b) => {
+      const va = a[sortCol], vb = b[sortCol];
+      const cmp = typeof va === 'number'
+        ? (va as number) - (vb as number)
+        : String(va).localeCompare(String(vb));
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+    return arr;
+  }, [users, sortCol, sortDir]);
+
+  const handleSort = useCallback((col: UserSortCol) => {
+    setSortCol(prev => {
+      if (prev === col) { setSortDir(d => d === 'asc' ? 'desc' : 'asc'); return col; }
+      setSortDir('desc');
+      return col;
+    });
+  }, []);
+
+  const Th = ({ col, label, align = 'right' }: { col: UserSortCol; label: string; align?: 'left' | 'right' }) => (
+    <th
+      onClick={() => handleSort(col)}
+      className="eng-th"
+      /* eslint-disable-next-line local/no-inline-style -- dynamic: sort-active color + textAlign per column */
+      style={{ textAlign: align, color: sortCol === col ? 'var(--text-primary)' : 'var(--text-muted)' }}
+    >
+      {label}{sortCol === col ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''}
+    </th>
+  );
+
+  return (
+    <div className="eng-panel eng-users-panel">
+      <div className="eng-panel-title">Per-User Engagement <span className="eng-admin-badge">Admin</span></div>
+      {users.length === 0 ? (
+        <div className="eng-empty">No user data for this range.</div>
+      ) : (
+        <table className="eng-users-table">
+          <thead><tr>
+            <Th col="user" label="User" align="left" />
+            <Th col="engagedMs" label="Engaged" />
+            <Th col="sessions" label="Sessions" />
+            <Th col="topCamp" label="Top Camp" />
+            <Th col="lastActive" label="Last Active" />
+          </tr></thead>
+          <tbody>
+            {sorted.map(u => (
+              <tr key={u.user} className="eng-user-row">
+                <td className="eng-td-user" title={u.user}>{u.user}</td>
+                <td className="eng-td-num">{fmtDuration(u.engagedMs)}</td>
+                <td className="eng-td-num">{u.sessions}</td>
+                <td className="eng-td">
+                  <span
+                    className="eng-camp-badge"
+                    /* eslint-disable-next-line local/no-inline-style -- dynamic: badge color from camp */
+                    style={{ background: `${CAMP_COLORS[u.topCamp] ?? '#6b7280'}22`, color: CAMP_COLORS[u.topCamp] ?? '#6b7280' }}
+                  >
+                    {CAMP_LABELS[u.topCamp] ?? u.topCamp}
+                  </span>
+                </td>
+                <td className="eng-td-num-nowrap" title={u.lastActive}>{relativeTime(u.lastActive)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+// ── Section 6: Heuristic-health strip (admin) ─────────────────────────────────
+
+function HealthStrip({ aggregate }: { aggregate: TreeNode }) {
+  const engagementRate = aggregate.visits > 0
+    ? ((aggregate.engagedVisits / aggregate.visits) * 100).toFixed(1)
+    : '—';
+  const cappedRatePct = aggregate.cappedRate != null
+    ? `${(aggregate.cappedRate * 100).toFixed(1)}%`
+    : '—';
+
+  const metrics = [
+    { label: 'Engagement rate', value: aggregate.visits > 0 ? `${engagementRate}%` : '—', title: 'engagedVisits / visits' },
+    { label: 'Capped rate', value: cappedRatePct, title: 'fraction of engaged visits that hit the duration cap' },
+    { label: 'Idle-close share', value: '—', title: 'not available in v1 contract' },
+  ];
+
+  return (
+    <div className="eng-panel eng-health-panel">
+      <div className="eng-panel-title">Heuristic Health <span className="eng-admin-badge">Admin</span></div>
+      <div className="eng-health-metrics">
+        {metrics.map(m => (
+          <div key={m.label} className="eng-health-metric" title={m.title}>
+            <div className="eng-health-value">{m.value}</div>
+            <div className="eng-health-label">{m.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Main Dashboard ─────────────────────────────────────────────────────────────
+
+export function EngagementDashboard() {
+  const isAdmin = useFlag('permission-admin-features');
+
+  const [preset, setPreset] = useState<DatePreset>('7d');
+  // userFilter: live input value; committedFilter: triggers fetch on Enter
+  const [userFilter, setUserFilter] = useState('');
+  const [committedFilter, setCommittedFilter] = useState('');
+  const [data, setData] = useState<EngagementResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedCamp, setSelectedCamp] = useState<string | null>(null);
+
+  const { from, to } = useMemo(() => dateRange(preset), [preset]);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    const qs = committedFilter
+      ? `/api/analytics/engagement?from=${from}&to=${to}&user=${encodeURIComponent(committedFilter)}`
+      : `/api/analytics/engagement?from=${from}&to=${to}`;
+    bridgeGet<EngagementResult>(qs)
+      .then(d => { setData(d); setLoading(false); })
+      .catch(err => {
+        getGlobalRecorder()?.record({
+          type: 'system.error',
+          component: 'engagement-dashboard',
+          level: 'error',
+          message: 'Engagement query failed',
+          error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+        });
+        setError(String(err));
+        setLoading(false);
+      });
+  }, [from, to, committedFilter]);
+
+  const handleBack = () => { window.location.hash = ''; window.location.reload(); };
+
+  return (
+    <div className="eng-root">
+      {/* Header */}
+      <div className="eng-header">
+        <div className="eng-header-left">
+          <button onClick={handleBack} className="eng-back-btn">← Back to Editor</button>
+          <h1 className="eng-title">Engagement Analytics</h1>
+          {isAdmin && <span className="eng-admin-badge eng-admin-badge--header">Admin</span>}
+        </div>
+        <div className="eng-header-right">
+          {/* User filter (admin only — non-admins never receive other-user data) */}
+          {isAdmin && (
+            <input
+              type="text"
+              className="eng-user-filter"
+              placeholder="Filter by user…"
+              value={userFilter}
+              onChange={e => setUserFilter(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') setCommittedFilter(userFilter); }}
+            />
+          )}
+          {/* Date preset */}
+          <div className="eng-preset-group">
+            {(['7d', '30d', '90d'] as DatePreset[]).map(p => (
+              <button
+                key={p}
+                onClick={() => { setPreset(p); setSelectedCamp(null); }}
+                className="eng-preset-btn"
+                /* eslint-disable-next-line local/no-inline-style -- dynamic: active-preset highlight */
+                style={{
+                  background: preset === p ? 'var(--color-acc, #3b82f6)' : 'var(--bg-secondary)',
+                  color: preset === p ? '#fff' : 'var(--text-muted)',
+                  border: `1px solid ${preset === p ? 'transparent' : 'var(--border-color)'}`,
+                }}
+              >
+                {p === '7d' ? '7 days' : p === '30d' ? '30 days' : '90 days'}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {loading && <div className="eng-loading">Loading engagement data…</div>}
+      {error && <div className="eng-error">Failed to load: {error}</div>}
+
+      {data && !loading && (
+        <>
+          {data.aggregate.visits === 0 ? (
+            <div className="eng-empty-state">
+              <div className="eng-empty-title">No engagement data for this range</div>
+              <div className="eng-empty-sub">Engagement events will appear as users spend time with the taxonomy.</div>
+            </div>
+          ) : (
+            <>
+              {/* Section 1: time over time */}
+              <EngagedOverTime daily={data.daily} />
+
+              {/* Sections 2+3: camp distribution + drill-down */}
+              <div className="eng-dist-row">
+                <CampDistribution
+                  aggregate={data.aggregate}
+                  selectedCamp={selectedCamp}
+                  onSelectCamp={setSelectedCamp}
+                />
+                {selectedCamp && (
+                  <CategoryDrillDown aggregate={data.aggregate} camp={selectedCamp} />
+                )}
+              </div>
+
+              {/* Section 4: leaderboards */}
+              <Leaderboards aggregate={data.aggregate} />
+
+              {/* Sections 5+6: admin-only */}
+              {isAdmin && data.users.length > 0 && <PerUserTable users={data.users} />}
+              {isAdmin && <HealthStrip aggregate={data.aggregate} />}
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/sync/SaveBar.tsx
+++ b/taxonomy-editor/src/renderer/components/sync/SaveBar.tsx
@@ -24,6 +24,7 @@ function formatFileKey(key: string): string {
 export function SaveBar() {
   const { dirty, save, saveError, dismissSaveError, validationErrors, integrityIssues, fixIntegrityErrors, zoomLevel, zoomIn, zoomOut, zoomReset } = useTaxonomyStore();
   const analyticsFlag = useFlag('env-web-analytics-dashboard');
+  const adminFlag = useFlag('permission-admin-features');
   const isOnline = useOnlineStatus();
   const isDirty = dirty.size > 0;
   const [showErrors, setShowErrors] = useState(false);
@@ -124,6 +125,16 @@ export function SaveBar() {
             title="Usage Analytics"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+          </button>
+        )}
+        {adminFlag && (
+          <button
+            type="button"
+            className="save-bar-sync-diag"
+            onClick={() => { window.location.hash = '#engagement'; }}
+            title="Engagement Analytics (admin)"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
           </button>
         )}
         <TheoryLink


### PR DESCRIPTION
## Summary

- New `EngagementDashboard.tsx` + co-located CSS + tests (15/15 green)
- Sections 1–6 per spec §4.1: daily time chart, camp distribution (camp color tokens), category drill-down, dual leaderboards (depth vs breadth), per-user table (admin), health strip (admin)
- Built contract-first against confirmed t/2468#2 shape; admin gating via `useFlag('permission-admin-features')`
- Committed-filter pattern for user filter input (no keystroke refetch)

## Blockers (draft until resolved)

- **t/2467** — `GET /api/analytics/engagement` (Server Community) must land before live integration + `npm run verify`
- **Design sign-off** — per AC; ping Design once integrated on live endpoint

## Parent-scope seams (Rosetta Stone, not in this PR)

- `#engagement` hash route in `App.tsx`
- Admin SaveBar entry in `SaveBar.tsx`

## Test plan

- [x] 15/15 unit tests green (fixture tree, camp→category drill-down, both leaderboards, admin vs non-admin gating, empty/loading/error states)
- [ ] `npm run verify` after t/2467 lands
- [ ] Design sign-off via `/design-review-workflow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)