### PR TITLE
feat(chat): web-bridge startChatStream over /api/ai/chat-stream SSE (t/2462)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/chatStreamBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/chatStreamBridge.test.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment jsdom
+
+// Web-bridge startChatStream (t/2462) — SSE parsing + dispatch against the t/2457
+// POST /api/ai/chat-stream contract, shape-identical to the Electron preload surface.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockResilientFetch = vi.fn<(path: string, init: RequestInit, opts: unknown) => Promise<Response>>();
+
+vi.mock('../resilience', () => ({
+  resilientFetch: (...args: unknown[]) => mockResilientFetch(args[0] as string, args[1] as RequestInit, args[2]),
+  categorizeEndpoint: () => 'ai',
+  registerConnectionPoolProvider: vi.fn(),
+  getResilienceState: vi.fn(),
+  subscribeResilience: vi.fn(),
+  resetResilience: vi.fn(),
+}));
+
+vi.mock('@lib/debate/errors', () => ({
+  ActionableError: class ActionableError extends Error {
+    goal: string; problem: string; location: string; nextSteps: string[]; httpStatus?: number;
+    constructor(opts: { goal: string; problem: string; location: string; nextSteps: string[] }) {
+      super(opts.problem);
+      this.name = 'ActionableError';
+      this.goal = opts.goal; this.problem = opts.problem; this.location = opts.location; this.nextSteps = opts.nextSteps;
+    }
+  },
+}));
+
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+vi.mock('../instrumentBridge', () => ({ instrumentBridge: (raw: unknown) => raw }));
+vi.mock('../../utils/keyShareCrypto', () => ({ encryptKeysForSharing: vi.fn(), decryptKeysFromSharing: vi.fn() }));
+const mockQuotaMilestone = vi.fn();
+vi.mock('../../hooks/useQuotaWarning', () => ({ onQuotaMilestone: (...a: unknown[]) => mockQuotaMilestone(...a) }));
+
+vi.stubGlobal('fetch', vi.fn());
+
+import { api } from '../web-bridge';
+
+/** A real streaming SSE Response. `chunks` are enqueued in order so buffer-splitting across
+ *  network reads is exercised (a single frame may span two enqueues). */
+function sseResponse(chunks: string[], status = 200): Response {
+  const enc = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return new Response(body, { status, headers: { 'content-type': 'text/event-stream' } });
+}
+
+function frame(obj: unknown): string {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+function jsonErrorResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+const MSGS = [{ role: 'user' as const, content: 'hello' }];
+
+beforeEach(() => {
+  mockResilientFetch.mockReset();
+  mockQuotaMilestone.mockReset();
+  sessionStorage.clear();
+});
+
+describe('web-bridge startChatStream — SSE happy path (t/2462)', () => {
+  it('emits each chunk to onChatStreamChunk, returns accumulated fullText, fires onChatStreamDone', async () => {
+    mockResilientFetch.mockResolvedValue(sseResponse([
+      frame({ type: 'chunk', text: 'Hel' }),
+      frame({ type: 'chunk', text: 'lo!' }),
+      frame({ type: 'done', fullText: 'Hello!' }),
+    ]));
+    const chunks: string[] = [];
+    const done: string[] = [];
+    const offChunk = api.onChatStreamChunk((c) => chunks.push(c));
+    const offDone = api.onChatStreamDone((f) => done.push(f));
+
+    const result = await api.startChatStream('sys', MSGS, 'gemini-2.5-flash', 0.5, false);
+
+    expect(chunks).toEqual(['Hel', 'lo!']);
+    expect(result).toBe('Hello!');
+    expect(done).toEqual(['Hello!']);
+    offChunk(); offDone();
+  });
+
+  it('handles a frame split across two network reads', async () => {
+    mockResilientFetch.mockResolvedValue(sseResponse([
+      'data: {"type":"chunk","tex',
+      't":"split"}\n\ndata: {"type":"done","fullText":"split"}\n\n',
+    ]));
+    const chunks: string[] = [];
+    const off = api.onChatStreamChunk((c) => chunks.push(c));
+    const result = await api.startChatStream('sys', MSGS);
+    expect(chunks).toEqual(['split']);
+    expect(result).toBe('split');
+    off();
+  });
+
+  it('surfaces url_context metadata to onChatStreamUrlMetadata before done', async () => {
+    const meta = { url_metadata: [{ retrieved_url: 'https://x.test', url_retrieval_status: 'SUCCESS' }] };
+    mockResilientFetch.mockResolvedValue(sseResponse([
+      frame({ type: 'chunk', text: 'grounded' }),
+      frame({ type: 'chat-stream-url-metadata', urlContextMetadata: meta }),
+      frame({ type: 'done', fullText: 'grounded' }),
+    ]));
+    const received: unknown[] = [];
+    const off = api.onChatStreamUrlMetadata?.((m) => received.push(m)) ?? (() => {});
+    await api.startChatStream('sys', MSGS, undefined, undefined, true);
+    expect(received).toEqual([meta]);
+    off();
+  });
+});
+
+describe('web-bridge startChatStream — request shaping (t/2462)', () => {
+  it('threads urlContext, messages, model, temperature, and BYOK key into the request body', async () => {
+    sessionStorage.setItem('byok-api-key', 'user-key-123');
+    mockResilientFetch.mockResolvedValue(sseResponse([frame({ type: 'done', fullText: '' })]));
+
+    await api.startChatStream('my-sys', MSGS, 'gemini-2.5-pro', 0.9, true);
+
+    const [path, init, opts] = mockResilientFetch.mock.calls[0];
+    expect(path).toBe('/api/ai/chat-stream');
+    expect(init.method).toBe('POST');
+    expect((opts as { maxRetries: number }).maxRetries).toBe(0); // never auto-retry a POST mutation
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      systemInstruction: 'my-sys', model: 'gemini-2.5-pro', temperature: 0.9, urlContext: true, apiKey: 'user-key-123',
+    });
+    expect(body.messages).toEqual(MSGS);
+  });
+
+  it('omits apiKey when no BYOK key is stored and defaults urlContext to false', async () => {
+    mockResilientFetch.mockResolvedValue(sseResponse([frame({ type: 'done', fullText: '' })]));
+    await api.startChatStream('sys', MSGS);
+    const body = JSON.parse(mockResilientFetch.mock.calls[0][1].body as string);
+    expect(body.apiKey).toBeUndefined();
+    expect(body.urlContext).toBe(false);
+  });
+});
+
+describe('web-bridge startChatStream — error paths (t/2462)', () => {
+  it('rejects and fires onChatStreamError on an SSE error event', async () => {
+    mockResilientFetch.mockResolvedValue(sseResponse([
+      frame({ type: 'chunk', text: 'partial' }),
+      frame({ type: 'error', message: 'model exploded', code: 'STREAM_ERROR' }),
+    ]));
+    const errors: string[] = [];
+    const off = api.onChatStreamError((e) => errors.push(e));
+    await expect(api.startChatStream('sys', MSGS)).rejects.toThrow('model exploded');
+    expect(errors).toEqual(['model exploded']);
+    off();
+  });
+
+  it('normalizes a non-200 JSON error (429) into a rejection + onChatStreamError, and fires quota milestone', async () => {
+    mockResilientFetch.mockResolvedValue(
+      jsonErrorResponse(429, { error: 'Daily token limit exceeded', limitType: 'tokens_per_day' }),
+    );
+    const errors: string[] = [];
+    const off = api.onChatStreamError((e) => errors.push(e));
+    await expect(api.startChatStream('sys', MSGS)).rejects.toThrow(/Daily token limit/i);
+    expect(errors).toHaveLength(1);
+    expect(mockQuotaMilestone).toHaveBeenCalledWith(100, undefined);
+    off();
+  });
+
+  it('unsubscribe removes a chunk listener', async () => {
+    mockResilientFetch.mockResolvedValue(sseResponse([
+      frame({ type: 'chunk', text: 'x' }),
+      frame({ type: 'done', fullText: 'x' }),
+    ]));
+    const seen: string[] = [];
+    const off = api.onChatStreamChunk((c) => seen.push(c));
+    off(); // unsubscribe before streaming
+    await api.startChatStream('sys', MSGS);
+    expect(seen).toEqual([]);
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/chatStream.ts
+++ b/taxonomy-editor/src/renderer/bridge/chatStream.ts
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Chat streaming (SSE) transport for the web bridge (t/2462). Extracted as a leaf module
+ * (like httpErrorSteps.ts / resilience.ts) to keep web-bridge.ts under the max-lines cap and
+ * to unit-test the SSE parsing/dispatch in isolation.
+ *
+ * Shape-identical to the Electron preload: startChatStream resolves with the accumulated
+ * fullText or rejects with an ActionableError; onChatStream* callbacks fire as events arrive.
+ *
+ * Server contract (POST /api/ai/chat-stream, t/2457):
+ *   data: {type:'chunk',text}                              → chunk listeners
+ *   data: {type:'chat-stream-url-metadata',urlContextMetadata} → url-metadata listeners
+ *   data: {type:'done',fullText}                           → resolve + done listeners
+ *   data: {type:'error',message,code}                      → reject + error listeners
+ * Pre-SSE failures (auth / rate limit / missing key) arrive instead as a non-200 JSON body.
+ */
+
+import { ActionableError } from '@lib/debate/errors';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { categorizeEndpoint, type ResilientFetchOptions } from './resilience';
+import { nextStepsForStatus } from './httpErrorSteps';
+import { onQuotaMilestone } from '../hooks/useQuotaWarning';
+
+type ChatChunkCb = (chunk: string) => void;
+type ChatDoneCb = (fullText: string) => void;
+type ChatErrorCb = (error: string) => void;
+type ChatUrlMetadataCb = (metadata: unknown) => void;
+
+const chunkCbs = new Set<ChatChunkCb>();
+const doneCbs = new Set<ChatDoneCb>();
+const errorCbs = new Set<ChatErrorCb>();
+const urlMetadataCbs = new Set<ChatUrlMetadataCb>();
+
+/** Subscription surface exposed via the bridge's onChatStream* methods. */
+export const chatStreamBus = {
+  onChunk: (cb: ChatChunkCb): (() => void) => { chunkCbs.add(cb); return () => { chunkCbs.delete(cb); }; },
+  onDone: (cb: ChatDoneCb): (() => void) => { doneCbs.add(cb); return () => { doneCbs.delete(cb); }; },
+  onError: (cb: ChatErrorCb): (() => void) => { errorCbs.add(cb); return () => { errorCbs.delete(cb); }; },
+  onUrlMetadata: (cb: ChatUrlMetadataCb): (() => void) => { urlMetadataCbs.add(cb); return () => { urlMetadataCbs.delete(cb); }; },
+};
+
+const CHAT_STREAM_TIMEOUT_MS = 180_000;
+
+function errShape(err: unknown): { name: string; message: string; stack?: string } {
+  return { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack };
+}
+
+function emitError(message: string): void {
+  for (const cb of errorCbs) {
+    try { cb(message); } catch { /* telemetry — silent by design */ }
+  }
+}
+
+/** Parse an SSE byte stream, invoking `onEvent` once per `data:` JSON payload. */
+async function consumeSse(res: Response, onEvent: (evt: Record<string, unknown>) => void): Promise<void> {
+  const reader = res.body?.getReader();
+  if (!reader) return;
+  const decoder = new TextDecoder();
+  let buffer = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let sep: number;
+    while ((sep = buffer.indexOf('\n\n')) !== -1) {
+      const frame = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      const data = frame
+        .split('\n')
+        .filter((l) => l.startsWith('data:'))
+        .map((l) => l.replace(/^data:\s?/, ''))
+        .join('\n');
+      if (!data) continue;
+      try {
+        onEvent(JSON.parse(data) as Record<string, unknown>);
+      } catch (err) {
+        getGlobalRecorder()?.record({ type: 'system.error', component: 'web-bridge', level: 'warn', message: 'chat-stream: malformed SSE data frame', error: errShape(err) });
+      }
+    }
+  }
+}
+
+/** Build a normalized ActionableError from a non-200 chat-stream response (JSON error emitted
+ *  before SSE headers). Mirrors the AI-relevant branches of web-bridge `post()`. */
+async function buildHttpError(res: Response): Promise<ActionableError> {
+  const budgetWarning = res.headers.get('X-Token-Budget-Warning');
+  if (budgetWarning) {
+    const milestone = parseInt(budgetWarning, 10);
+    if (!isNaN(milestone) && milestone >= 0 && milestone <= 100) {
+      onQuotaMilestone(milestone, res.headers.get('X-Token-Budget-Resets') ?? undefined);
+    }
+  }
+  if (res.status === 429) {
+    const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+    if (data.limitType === 'tokens_per_day' && !budgetWarning) onQuotaMilestone(100, data.resetsAt as string | undefined);
+    const msg = data.limitType === 'tokens_per_day'
+      ? 'Daily token limit exceeded. Try again tomorrow or use your own API key.'
+      : `Rate limit exceeded. Retry in ${Math.ceil(((data.retryAfterMs as number) || 60_000) / 1000)}s.`;
+    const err = new ActionableError({ goal: 'Stream chat response', problem: msg, location: 'chatStream.startChatStream', nextSteps: ['Wait for the rate limit to reset', 'Use your own API key to avoid shared limits'] });
+    (err as ActionableError & { httpStatus: number; limitType: string }).httpStatus = 429;
+    (err as ActionableError & { limitType: string }).limitType = String(data.limitType ?? '');
+    return err;
+  }
+  if (res.status === 422) {
+    const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+    const err = new ActionableError({ goal: 'Stream chat response', problem: (data.message as string) || 'No API key configured for the selected backend.', location: 'chatStream.startChatStream', nextSteps: ['Open Settings → API Keys and add a key for this backend', 'Switch to a backend that has a key configured'] });
+    (err as ActionableError & { httpStatus: number }).httpStatus = 422;
+    return err;
+  }
+  const text = await res.text().catch(() => '');
+  const err = new ActionableError({ goal: 'Stream chat response', problem: `POST /api/ai/chat-stream failed with HTTP ${res.status}: ${text}`, location: 'chatStream.startChatStream', nextSteps: nextStepsForStatus(res.status, text) });
+  (err as ActionableError & { httpStatus: number }).httpStatus = res.status;
+  return err;
+}
+
+export interface ChatStreamArgs {
+  systemInstruction: string;
+  messages: { role: 'user' | 'model'; content: string }[];
+  model?: string;
+  temperature?: number;
+  urlContext?: boolean;
+}
+
+/** The web bridge's session-recovering fetch (injected to avoid a circular import). */
+type ChatFetch = (path: string, init: RequestInit, opts: ResilientFetchOptions) => Promise<Response>;
+
+/** Drive one chat-stream request: POST → read SSE body → dispatch. Resolves the accumulated
+ *  fullText, or rejects with an ActionableError (also surfaced to onChatStreamError listeners). */
+export async function runChatStream(fetchFn: ChatFetch, args: ChatStreamArgs): Promise<string> {
+  const { systemInstruction, messages, model, temperature, urlContext } = args;
+  const requestId = crypto.randomUUID();
+  const body: Record<string, unknown> = { systemInstruction, messages, model, temperature, urlContext: !!urlContext };
+  const byokKey = sessionStorage.getItem('byok-api-key');
+  if (byokKey) body.apiKey = byokKey;
+  getGlobalRecorder()?.record({ type: 'ai.request', component: 'web-bridge', level: 'info', message: `chat-stream request: ${model ?? 'default'}`, data: { requestId, urlContext: !!urlContext, messageCount: messages.length } });
+
+  const path = '/api/ai/chat-stream';
+  let res: Response;
+  try {
+    res = await fetchFn(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-request-id': requestId },
+      body: JSON.stringify(body),
+    }, {
+      timeoutMs: CHAT_STREAM_TIMEOUT_MS,
+      maxRetries: 0, // POST mutation — never auto-retry (Client Network Resilience rule 2)
+      critical: true,
+      category: categorizeEndpoint(path, 'POST'),
+    });
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'web-bridge', level: 'error', message: 'chat-stream network error', error: errShape(err) });
+    const failure = (err instanceof DOMException && err.name === 'AbortError')
+      ? new ActionableError({ goal: 'Stream chat response', problem: `chat-stream timed out after ${Math.round(CHAT_STREAM_TIMEOUT_MS / 1000)}s`, location: 'chatStream.startChatStream', nextSteps: ['The server may be overloaded — try again', 'Check server logs for errors'] })
+      : (err as Error);
+    emitError(failure.message ?? String(failure));
+    throw failure;
+  }
+
+  // Non-200 responses are JSON errors (server writes them before committing SSE headers).
+  if (!res.ok) {
+    const err = await buildHttpError(res);
+    emitError(err.message);
+    throw err;
+  }
+
+  let fullText = '';
+  let streamError: ActionableError | null = null;
+  try {
+    await consumeSse(res, (evt) => {
+      switch (evt.type) {
+        case 'chunk': {
+          const text = typeof evt.text === 'string' ? evt.text : '';
+          if (text) { fullText += text; for (const cb of chunkCbs) cb(text); }
+          break;
+        }
+        case 'chat-stream-url-metadata':
+          for (const cb of urlMetadataCbs) cb(evt.urlContextMetadata);
+          break;
+        case 'done':
+          if (typeof evt.fullText === 'string') fullText = evt.fullText;
+          break;
+        case 'error':
+          streamError = new ActionableError({ goal: 'Stream chat response', problem: typeof evt.message === 'string' ? evt.message : 'The chat stream failed on the server.', location: 'chatStream.startChatStream', nextSteps: ['Try sending your message again', 'Check server logs for errors'] });
+          break;
+      }
+    });
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'web-bridge', level: 'error', message: 'chat-stream: reading the SSE body failed', error: errShape(err) });
+    const failure = new ActionableError({ goal: 'Stream chat response', problem: `The chat stream was interrupted: ${String(err)}`, location: 'chatStream.startChatStream', nextSteps: ['Check your network connection and try again'] });
+    emitError(failure.message);
+    throw failure;
+  }
+
+  if (streamError) {
+    const e: ActionableError = streamError;
+    emitError(e.message);
+    throw e;
+  }
+  for (const cb of doneCbs) cb(fullText);
+  return fullText;
+}

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -145,10 +145,11 @@ export const api: AppAPI = {
   // AI generation
   generateText: (prompt, model, timeout, temperature) => window.electronAPI.generateText(prompt, model, timeout, temperature),
   generateTextWithSearch: (prompt, model) => window.electronAPI.generateTextWithSearch(prompt, model),
-  startChatStream: (sys, msgs, model, temp) => window.electronAPI.startChatStream(sys, msgs, model, temp),
+  startChatStream: (sys, msgs, model, temp, urlContext) => window.electronAPI.startChatStream(sys, msgs, model, temp, urlContext),
   onChatStreamChunk: (cb) => window.electronAPI.onChatStreamChunk(cb),
   onChatStreamDone: (cb) => window.electronAPI.onChatStreamDone(cb),
   onChatStreamError: (cb) => window.electronAPI.onChatStreamError(cb),
+  onChatStreamUrlMetadata: (cb) => window.electronAPI.onChatStreamUrlMetadata?.(cb) ?? (() => {}),
   setDebateTemperature: (temp) => window.electronAPI.setDebateTemperature(temp),
 
   // Embeddings & NLI — local WebNN/WASM first, IPC fallback

--- a/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
@@ -96,7 +96,7 @@ function extractResultMeta(method: string, args: unknown[], value: unknown): Rec
 /** Methods that should NOT be wrapped. */
 const SKIP = new Set([
   // Event listeners return unsubscribe functions, not promises
-  'onChatStreamChunk', 'onChatStreamDone', 'onChatStreamError',
+  'onChatStreamChunk', 'onChatStreamDone', 'onChatStreamError', 'onChatStreamUrlMetadata',
   'onDiagnosticsStateUpdate', 'onDiagnosticsPopoutClosed', 'onReExtractClaims',
   'onDebateWindowLoad', 'onDebatePopoutClosed',
   'onGenerateTextProgress', 'onReloadTaxonomy', 'onFocusNode', 'onTaxonomyUpdated',

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -193,10 +193,12 @@ export interface AppAPI {
     searchQueries?: string[];
     citations?: GroundingCitation[];
   }>;
-  startChatStream: (systemInstruction: string, messages: { role: 'user' | 'model'; content: string }[], model?: string, temperature?: number) => Promise<string>;
+  startChatStream: (systemInstruction: string, messages: { role: 'user' | 'model'; content: string }[], model?: string, temperature?: number, urlContext?: boolean) => Promise<string>;
   onChatStreamChunk: (callback: (chunk: string) => void) => () => void;
   onChatStreamDone: (callback: (fullText: string) => void) => () => void;
   onChatStreamError: (callback: (error: string) => void) => () => void;
+  /** url_context grounding metadata (t/2462) — optional; only the Gemini backend emits it. */
+  onChatStreamUrlMetadata?: (callback: (metadata: unknown) => void) => () => void;
   setDebateTemperature: (temp: number | null) => Promise<void>;
 
   // --- Proxy tier & usage ---

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -13,6 +13,7 @@ import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
 import { encryptKeysForSharing, decryptKeysFromSharing } from '../utils/keyShareCrypto';
 import { resilientFetch, categorizeEndpoint, registerConnectionPoolProvider, type EndpointCategory } from './resilience';
 import { nextStepsForStatus } from './httpErrorSteps';
+import { runChatStream, chatStreamBus } from './chatStream';
 import { onQuotaMilestone } from '../hooks/useQuotaWarning';
 export { getResilienceState, subscribeResilience, resetResilience } from './resilience';
 export type { ResilienceStatus, CircuitState, ThrottleState, EndpointCategory } from './resilience';
@@ -960,10 +961,14 @@ const rawApi: AppAPI = {
     });
     return post('/api/ai/generate', body, undefined, { 'x-request-id': requestId });
   },
-  startChatStream: () => Promise.reject(new Error('Streaming chat not supported in web mode')),
-  onChatStreamChunk: () => () => {},
-  onChatStreamDone: () => () => {},
-  onChatStreamError: () => () => {},
+  // Chat streaming (SSE) — transport lives in ./chatStream (leaf module, t/2462). Shape-identical
+  // to the Electron preload so useChatStore consumes one contract from both bridges.
+  startChatStream: (systemInstruction, messages, model, temperature, urlContext) =>
+    runChatStream(fetchWithSessionRecovery, { systemInstruction, messages, model, temperature, urlContext }),
+  onChatStreamChunk: (cb) => chatStreamBus.onChunk(cb),
+  onChatStreamDone: (cb) => chatStreamBus.onDone(cb),
+  onChatStreamError: (cb) => chatStreamBus.onError(cb),
+  onChatStreamUrlMetadata: (cb) => chatStreamBus.onUrlMetadata(cb),
   setDebateTemperature: (temp) => post('/api/ai/temperature', { temp }).then(() => {}),
 
   // Proxy tier & usage


### PR DESCRIPTION
Web renderer half of t/2455 Stage 1 (t/2462). Implements `startChatStream` in the web bridge against the t/2457 `POST /api/ai/chat-stream` SSE contract, shape-identical to the Electron preload so `useChatStore` consumes **one contract from both bridges** (the parent's dual-build AC). Unblocks t/2459 Phase B.

## What
- **`bridge/chatStream.ts`** (new leaf module) — SSE transport: reads `res.body` as a stream, dispatches `chunk`→onChatStreamChunk, `chat-stream-url-metadata`→onChatStreamUrlMetadata, `done`→resolve(fullText)+onChatStreamDone, `error`→reject+onChatStreamError. Non-200 responses (JSON errors written before SSE headers) normalized like `post()` (429 quota milestone + `Retry`, 422 missing-key, generic via `nextStepsForStatus`). `maxRetries: 0` (never auto-retry a POST mutation), 180s timeout, BYOK key from sessionStorage. Extracted so `web-bridge.ts` stays under the max-lines cap and the transport is unit-testable in isolation.
- **`bridge/types.ts`** (AppAPI) — add `urlContext?` + optional `onChatStreamUrlMetadata`. #830/#835 updated only the Electron *preload*; the shared renderer contract needed these for the one-contract AC.
- **`electron-bridge.ts`** — forward `urlContext`, expose `onChatStreamUrlMetadata`.
- **`instrumentBridge.ts`** — add `onChatStreamUrlMetadata` to SKIP (subscriptions return an unsubscribe, not a promise).
- **`web-bridge.ts`** — thin delegators to `runChatStream` / `chatStreamBus`.

## Tests (`bridge/__tests__/chatStreamBridge.test.ts`, 8)
SSE happy path (chunks→fullText, done listener), frame split across two network reads, url-metadata delivery, request shaping (urlContext/model/temperature/BYOK threaded, `maxRetries=0`), SSE `error` event → rejection + onChatStreamError, non-200/429 JSON → normalized rejection + quota milestone, unsubscribe.

## Verify
Deterministic gates green: `tsc` (main + server + renderer), `eslint`, `depcruise`, `vite build`; chat-stream suite 8/8. (Full `vitest run` includes lib/debate live-AI tests that flake on network — CI runs them.)

## Notes
- Self-certified `/add-bridge-method`. **Flagged deviation** (see t/2462#5): ticket scoped `web-bridge.ts` only, but satisfying the "one contract" AC required the AppAPI + electron-bridge + instrumentBridge edits too — all within my renderer/bridge scope, no cross-role changes.

t/2462

🤖 Generated with [Claude Code](https://claude.com/claude-code)
