### PR TITLE
feat(chat): wire urlContext through useChatStore (t/2459 Stage 1 Phase B)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/UrlContextChip.test.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/UrlContextChip.test.tsx
@@ -73,4 +73,17 @@ describe('chatSystemPrompt urlContext param', () => {
     expect(prompt).toContain("ground your response");
     expect(prompt).not.toContain("you have not visited that URL");
   });
+
+  it('non-Gemini model gates urlContext to false → honest-fail text in prompt', async () => {
+    // backendForModel('claude-3-5-sonnet') === 'claude', not 'gemini'
+    // so URL_PATTERN.test(msg) && backendForModel(model) === 'gemini' is false
+    const { backendForModel } = await import('../../hooks/useTaxonomyStore');
+    const { chatSystemPrompt } = await import('../../prompts/chat');
+    const nonGeminiModel = 'claude-3-5-sonnet';
+    const urlContext = /https?:\/\/\S+/.test('https://example.com') && backendForModel(nonGeminiModel) === 'gemini';
+    expect(urlContext).toBe(false);
+    const prompt = chatSystemPrompt('Label', 'pov', 'personality', 'inform', 'topic', 'ctx', urlContext);
+    expect(prompt).toContain("you have not visited that URL");
+    expect(prompt).not.toContain("url_context tool");
+  });
 });

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -16,6 +16,7 @@ import { mapErrorToUserMessage } from '../utils/errorMessages';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { api } from '@bridge';
 import { DEFAULT_MODEL } from '@lib/ai-client/defaults';
+import type { UrlContextMetadata } from '@lib/ai-client/index';
 import { formatTaxonomyContext } from '../utils/taxonomyContext';
 import type { TaxonomyContext, FormatContextConfig } from '../utils/taxonomyContext';
 import {
@@ -45,6 +46,19 @@ function getConfiguredModel(): string {
   }
 }
 
+const URL_PATTERN = /https?:\/\/\S+/;
+
+function isUrlContextMetadata(payload: unknown): payload is UrlContextMetadata {
+  if (!payload || typeof payload !== 'object') return false;
+  const p = payload as Record<string, unknown>;
+  if (!Array.isArray(p.urlMetadata)) return false;
+  return (p.urlMetadata as unknown[]).every(
+    (e) => typeof e === 'object' && e !== null &&
+      typeof (e as Record<string, unknown>).retrievedUrl === 'string' &&
+      typeof (e as Record<string, unknown>).urlRetrievalStatus === 'string',
+  );
+}
+
 async function streamChatWithProgress(
   systemInstruction: string,
   messages: { role: 'user' | 'model'; content: string }[],
@@ -53,13 +67,24 @@ async function streamChatWithProgress(
   activity: string,
   set: (partial: Partial<ChatStore>) => void,
   onChunk: (chunk: string) => void,
-): Promise<string> {
+  urlContext?: boolean,
+): Promise<{ text: string; urlContextMetadata?: UrlContextMetadata }> {
   set({ chatActivity: activity, chatStreamingText: null });
+  let urlContextMetadata: UrlContextMetadata | undefined;
   const unsubChunk = api.onChatStreamChunk(onChunk);
+  const unsubMeta = api.onChatStreamUrlMetadata?.((payload) => {
+    if (isUrlContextMetadata(payload)) {
+      urlContextMetadata = payload;
+    } else {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-store', level: 'debug', message: 'onChatStreamUrlMetadata payload did not match UrlContextMetadata shape', error: { name: 'TypeError', message: 'Non-conforming url-context metadata', stack: '' } });
+    }
+  });
   try {
-    return await api.startChatStream(systemInstruction, messages, model, temperature);
+    const text = await api.startChatStream(systemInstruction, messages, model, temperature, urlContext);
+    return { text, urlContextMetadata };
   } finally {
     unsubChunk();
+    unsubMeta?.();
     set({ chatStreamingText: null, chatActivity: null });
   }
 }
@@ -313,7 +338,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       );
       const userContent = chatOpeningPrompt(activeChat.mode, activeChat.topic);
 
-      const fullText = await streamChatWithProgress(
+      const { text: fullText } = await streamChatWithProgress(
         systemInstruction,
         [{ role: 'user', content: userContent }],
         model,
@@ -397,9 +422,11 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       const model = getConfiguredModel();
       const temperature = CHAT_MODE_TEMPERATURE[activeChat.mode];
 
+      const urlContext = URL_PATTERN.test(message.trim());
       const systemInstruction = chatSystemPrompt(
         info.label, info.pov, info.personality,
         activeChat.mode, activeChat.topic, taxonomyBlock,
+        urlContext,
       );
       const transcriptText = formatTranscriptForContext(
         withUserMsg.transcript, info.label,
@@ -415,7 +442,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         .filter(Boolean);
       const userContent = chatContinuationPrompt(message.trim(), transcriptText, priorClaims);
 
-      const fullText = await streamChatWithProgress(
+      const { text: fullText, urlContextMetadata } = await streamChatWithProgress(
         systemInstruction,
         [{ role: 'user', content: userContent }],
         model,
@@ -423,6 +450,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         `${info.label} is thinking...`,
         set,
         (chunk) => get().appendStreamingText(chunk),
+        urlContext,
       );
 
       if (!isStillValid()) return;
@@ -435,6 +463,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         speaker: activeChat.pover,
         content: response,
         taxonomy_refs: taxonomyRefs,
+        ...(urlContextMetadata && { url_context_metadata: urlContextMetadata }),
       };
 
       const updated = {

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -11,7 +11,7 @@ import type {
 import type { SpeakerId, TaxonomyRef } from '../types/debate';
 import { POVER_INFO } from '../types/debate';
 import type { PovNode, CrossCuttingNode as SituationNode } from '../types/taxonomy';
-import { useTaxonomyStore } from './useTaxonomyStore';
+import { useTaxonomyStore, backendForModel } from './useTaxonomyStore';
 import { mapErrorToUserMessage } from '../utils/errorMessages';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { api } from '@bridge';
@@ -422,7 +422,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       const model = getConfiguredModel();
       const temperature = CHAT_MODE_TEMPERATURE[activeChat.mode];
 
-      const urlContext = URL_PATTERN.test(message.trim());
+      const urlContext = URL_PATTERN.test(message.trim()) && backendForModel(model) === 'gemini';
       const systemInstruction = chatSystemPrompt(
         info.label, info.pov, info.personality,
         activeChat.mode, activeChat.topic, taxonomyBlock,


### PR DESCRIPTION
## Summary

- URL detection on outgoing message (`URL_PATTERN`); flag passed to `chatSystemPrompt` (7th arg) and `startChatStream` (9th arg)
- `isUrlContextMetadata()` type guard narrows unknown IPC payload; non-conforming payloads dropped + logged via flight recorder
- `streamChatWithProgress` subscribes to `onChatStreamUrlMetadata?` (optional-chain until t/2462 follow-up makes it required), returns `{ text, urlContextMetadata }`
- `generateOpening` + `sendMessage` destructure new return; `poverEntry` spreads `url_context_metadata` when present

Completes t/2459 Stage 1. Phase A (UI + prompt) landed in PR #838.

## Test plan

- [x] `check-renderer-tsc.sh` — 0 errors
- [x] `vitest run src/renderer/components/chat/` — 67/67 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)