### PR TITLE
fix(server): carry URL fragment through anonymous login for debate deep links (t/2474)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/loginPage.test.ts
+++ b/taxonomy-editor/src/server/__tests__/loginPage.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+//
+// t/2474 — the login page's inline script must carry a URL fragment through the
+// anonymous flow so a pasted community-debate deep link survives login, and
+// auto-continue known deep-link routes past the interstitial. Both behaviours are
+// gated on the anonymous option actually being offered (`.anon-link` present in the
+// DOM ⇔ showAnonymous=true), and auto-continue has a one-shot loop breaker.
+//
+// We run the ACTUAL served script — extracted from buildLoginPage()'s HTML — inside
+// jsdom against the ACTUAL served body markup, so the test tracks the shipped page,
+// not a copy. location is stubbed (jsdom cannot navigate); sessionStorage is real.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import crypto from 'crypto';
+import { buildLoginPage, SW_HEAL_SCRIPT_CSP_HASH } from '../loginPage.js';
+
+function extractScript(html: string): string {
+  const m = html.match(/<script>([\s\S]*?)<\/script>/);
+  if (!m) throw new Error('login page has no inline script');
+  return m[1];
+}
+function extractBody(html: string): string {
+  const m = html.match(/<body>([\s\S]*)<\/body>/);
+  if (!m) throw new Error('login page has no body');
+  return m[1];
+}
+
+// Render the served page into jsdom, stub location with the given hash, run the
+// inline script, and return the location.replace spy + the (possibly rewritten)
+// anon link element.
+function runLoginScript(showAnonymous: boolean, hash: string) {
+  const html = buildLoginPage(showAnonymous);
+  document.body.innerHTML = extractBody(html);
+  const replace = vi.fn();
+  vi.stubGlobal('location', { hash, replace, reload: vi.fn() });
+  // document.readyState is 'complete' under jsdom → the script's run() fires now.
+  new Function(extractScript(html))();
+  return { replace, anon: document.querySelector('.anon-link') as HTMLAnchorElement | null };
+}
+
+describe('t/2474 — login-page deep-link hash-carry + auto-continue', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    document.body.innerHTML = '';
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('hash-carry: a non-debate hash is appended to the anon link, no auto-continue', () => {
+    const { replace, anon } = runLoginScript(true, '#pov/acc-beliefs-001');
+    expect(anon?.getAttribute('href')).toBe('/.auth/anonymous#pov/acc-beliefs-001');
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('auto-continue: a #debate-window hash carries AND replaces to the anon endpoint', () => {
+    const hash = '#debate-window?id=e6547b31&source=community';
+    const { replace, anon } = runLoginScript(true, hash);
+    expect(anon?.getAttribute('href')).toBe('/.auth/anonymous' + hash);
+    expect(replace).toHaveBeenCalledWith('/.auth/anonymous' + hash);
+    // one-shot marker is set so a re-serve can't loop
+    expect(sessionStorage.getItem('anon_autocontinue')).toBe('1');
+  });
+
+  it('loop breaker: with the marker already set, hash-carry still fires but auto-continue does NOT', () => {
+    sessionStorage.setItem('anon_autocontinue', '1');
+    const hash = '#debate-window?id=e6547b31&source=community';
+    const { replace, anon } = runLoginScript(true, hash);
+    expect(anon?.getAttribute('href')).toBe('/.auth/anonymous' + hash); // interstitial link still usable
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('no hash: the anon link is untouched and nothing navigates', () => {
+    const { replace, anon } = runLoginScript(true, '');
+    expect(anon?.getAttribute('href')).toBe('/.auth/anonymous');
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('required-auth mode (showAnonymous=false): no anon link, so no hash-carry and NO auto-continue even for a debate hash', () => {
+    const { replace, anon } = runLoginScript(false, '#debate-window?id=e6547b31&source=community');
+    expect(anon).toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+    // policy bypass guard: the login surface advertised no path toward /.auth/anonymous
+    expect(document.body.innerHTML).not.toContain('/.auth/anonymous');
+  });
+
+  it('production path: script in <head> fires on DOMContentLoaded (readyState "loading")', () => {
+    // In the served page the script runs during head-parse — body not yet present,
+    // readyState="loading" — so the deep-link logic MUST defer to DOMContentLoaded.
+    // The 'complete'-readyState tests above would pass even if that wiring broke.
+    const html = buildLoginPage(true);
+    document.body.innerHTML = extractBody(html);
+    const hash = '#debate-window?id=e6547b31&source=community';
+    const replace = vi.fn();
+    vi.stubGlobal('location', { hash, replace, reload: vi.fn() });
+    const rsSpy = vi.spyOn(document, 'readyState', 'get').mockReturnValue('loading');
+    try {
+      new Function(extractScript(html))();
+      expect(replace).not.toHaveBeenCalled(); // deferred — nothing yet
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+      expect(replace).toHaveBeenCalledWith('/.auth/anonymous' + hash);
+    } finally {
+      rsSpy.mockRestore();
+    }
+  });
+
+  it('CSP hash stays in sync with the actual served script (no drift)', () => {
+    const script = extractScript(buildLoginPage(true));
+    const expected = `'sha256-${crypto.createHash('sha256').update(script).digest('base64')}'`;
+    expect(SW_HEAL_SCRIPT_CSP_HASH).toBe(expected);
+  });
+});

--- a/taxonomy-editor/src/server/loginPage.ts
+++ b/taxonomy-editor/src/server/loginPage.ts
@@ -37,6 +37,28 @@ export function loginPageHeaders(req: http.IncomingMessage): http.OutgoingHttpHe
 // the current SW re-registers after a successful login. The script text is static,
 // so its CSP sha256 is derived from this same constant and can never drift out of
 // sync (script-src has no 'unsafe-inline'; a hash source is the safe way in).
+//
+// t/2474: a second IIFE carries the URL fragment through the anonymous flow so a
+// pasted community-debate deep link (`/#debate-window?id=...`) survives login. The
+// hash fragment never reaches the server, so the auth gate serves this login page
+// for such a cold visit; without help the anon link discards the fragment. Per
+// RFC 7231 §7.1.2, a 302 whose Location has no fragment re-applies the request
+// URL's fragment — so navigating to `/.auth/anonymous#debate-window?...` lands the
+// visitor on `/#debate-window?...` with session cookies set. Two behaviours:
+//   (1) Hash-carry (always, when a hash is present): rewrite `.anon-link`'s href to
+//       `/.auth/anonymous` + the current hash.
+//   (2) Auto-continue (known deep-link routes only): for `#debate-window` hashes,
+//       replace to the anon endpoint immediately — paste-in-incognito opens the
+//       debate with no interstitial.
+// Both are gated on `.anon-link` being present in the DOM: it exists iff
+// buildLoginPage was called with showAnonymous=true, so in required-auth mode this
+// script advertises NO path toward /.auth/anonymous (TL t/2474#2, req. change 1).
+// Auto-continue is guarded by a one-shot sessionStorage marker so a failed anon
+// handshake (cookies blocked / endpoint error) that re-serves this page cannot
+// loop — on the second pass we fall through to the interstitial with the
+// hash-carried link intact. If sessionStorage is unavailable we do NOT
+// auto-continue (can't guarantee the loop breaker), only hash-carry (req. change 2).
+// Staying in this one constant keeps a single CSP hash source (no drift).
 const SW_HEAL_SCRIPT =
   `(function(){try{if(!('serviceWorker' in navigator))return;` +
   `navigator.serviceWorker.getRegistrations().then(function(regs){` +
@@ -47,7 +69,15 @@ const SW_HEAL_SCRIPT =
   `var stuck=regs.length>0||!!navigator.serviceWorker.controller;` +
   `if(stuck&&sessionStorage.getItem('sw_login_cleared')!=='1'){sessionStorage.setItem('sw_login_cleared','1');` +
   `Promise.all(regs.map(function(r){return r.unregister();})).then(function(){location.reload();}).catch(function(){});}` +
-  `}).catch(function(){});}catch(e){}})();`;
+  `}).catch(function(){});}catch(e){}})();` +
+  `(function(){try{var h=location.hash;if(!h)return;function run(){` +
+  `var a=document.querySelector('.anon-link');if(!a)return;` +
+  `var target='/.auth/anonymous'+h;a.setAttribute('href',target);` +
+  `if(h.indexOf('#debate-window')===0){var go=false;` +
+  `try{if(sessionStorage.getItem('anon_autocontinue')!=='1'){sessionStorage.setItem('anon_autocontinue','1');go=true;}}catch(e){go=false;}` +
+  `if(go)location.replace(target);}}` +
+  `if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',run);}else{run();}` +
+  `}catch(e){}})();`;
 export const SW_HEAL_SCRIPT_CSP_HASH = `'sha256-${crypto.createHash('sha256').update(SW_HEAL_SCRIPT).digest('base64')}'`;
 
 export function buildLoginPage(showAnonymous: boolean): string {


### PR DESCRIPTION
## Summary

Fixes t/2474 (UAT, PI-reported): pasting a community-debate deep link (`/#debate-window?id=...&source=community`) into an incognito window showed the login page and, on continuing anonymously, discarded the fragment and landed on the app root.

The hash fragment never reaches the server, so the auth gate can't distinguish a deep-link from a cold visit. Fix is entirely in `loginPage.ts`'s inline script (one CSP-hashed constant):

- **Hash-carry (any hash present):** rewrite `.anon-link`'s href → `/.auth/anonymous` + the current hash. The fragment rides the anonymous 302 (RFC 7231 §7.1.2: a `Location` with no fragment re-applies the request URL's fragment), so the visitor lands on `/#debate-window?...` with session cookies set.
- **Auto-continue (`#debate-window` routes only):** `location.replace('/.auth/anonymous' + hash)` immediately — paste-in-incognito opens the debate with no interstitial.

Per TL review (t/2474#2):
- **Both behaviours gated on `.anon-link` presence in the DOM** — it exists iff `showAnonymous=true`, so required-auth mode advertises no path toward `/.auth/anonymous` (req. change 1).
- **One-shot `sessionStorage` loop breaker**; if storage is unavailable we hash-carry only (never auto-continue), so a failed anon handshake that re-serves this page cannot loop (req. change 2).

No API allowlist widened — anonymous community-debate reads are already permitted (`debateAnonAllowlist`); this only fixes *entry*. The CSP `script-src` sha256 auto-derives from the same constant, so no separate hash change and no drift.

## Test plan

`src/server/__tests__/loginPage.test.ts` (jsdom) runs the **actual served script** against the served body:

- [x] hash-carry (non-debate hash) — href rewritten, no navigation
- [x] auto-continue (`#debate-window`) — href rewritten + `location.replace` called, marker set
- [x] loop breaker (marker pre-set) — hash-carry fires, no auto-replace
- [x] no hash — anon link untouched, no navigation
- [x] required-auth (`showAnonymous=false`) — no `.anon-link`, no navigation, body contains no `/.auth/anonymous`
- [x] production path — script in `<head>` (readyState `loading`) defers to `DOMContentLoaded`, then fires
- [x] CSP hash stays in sync with the served script (no drift)
- [x] `tsc --project tsconfig.server.json --noEmit` clean; eslint clean; shareShell + publicShare suites green

## AC coverage

- incognito paste of a community-debate URL → debate renders with no credential prompt ✓ (auto-continue)
- hashless incognito visit → login page with both options ✓ (no-hash test)
- hash survives the anonymous 302 round-trip ✓ (hash-carry)
- regression test in the loginPage/shareShell test family ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
