### PR TITLE
refactor(bridge): make onChatStreamUrlMetadata a required contract method (t/2462 follow-up)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -149,7 +149,7 @@ export const api: AppAPI = {
   onChatStreamChunk: (cb) => window.electronAPI.onChatStreamChunk(cb),
   onChatStreamDone: (cb) => window.electronAPI.onChatStreamDone(cb),
   onChatStreamError: (cb) => window.electronAPI.onChatStreamError(cb),
-  onChatStreamUrlMetadata: (cb) => window.electronAPI.onChatStreamUrlMetadata?.(cb) ?? (() => {}),
+  onChatStreamUrlMetadata: (cb) => window.electronAPI.onChatStreamUrlMetadata(cb),
   setDebateTemperature: (temp) => window.electronAPI.setDebateTemperature(temp),
 
   // Embeddings & NLI — local WebNN/WASM first, IPC fallback

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -197,8 +197,9 @@ export interface AppAPI {
   onChatStreamChunk: (callback: (chunk: string) => void) => () => void;
   onChatStreamDone: (callback: (fullText: string) => void) => () => void;
   onChatStreamError: (callback: (error: string) => void) => () => void;
-  /** url_context grounding metadata (t/2462) — optional; only the Gemini backend emits it. */
-  onChatStreamUrlMetadata?: (callback: (metadata: unknown) => void) => () => void;
+  /** url_context grounding metadata (t/2462). Both bridges implement it; a no-op unsubscribe
+   *  when the backend never emits metadata, so consumers need no optional-chaining. */
+  onChatStreamUrlMetadata: (callback: (metadata: unknown) => void) => () => void;
   setDebateTemperature: (temp: number | null) => Promise<void>;
 
   // --- Proxy tier & usage ---

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -105,7 +105,7 @@ export interface ElectronAPI {
   onChatStreamChunk: (callback: (chunk: string) => void) => () => void;
   onChatStreamDone: (callback: (fullText: string) => void) => () => void;
   onChatStreamError: (callback: (error: string) => void) => () => void;
-  onChatStreamUrlMetadata?: (callback: (metadata: unknown) => void) => () => void;
+  onChatStreamUrlMetadata: (callback: (metadata: unknown) => void) => () => void;
   setDebateTemperature: (temp: number | null) => Promise<void>;
   onGenerateTextProgress: (callback: (progress: { attempt: number; maxRetries: number; backoffSeconds: number; limitType: string; limitMessage: string }) => void) => () => void;
   // onBriefTimeout / onBriefRetriesExhausted removed (t/2307) — brief-timeout now


### PR DESCRIPTION
Residual from t/2462 (flagged by TL, t/2462#8): both bridges now implement `onChatStreamUrlMetadata`, so it no longer needs to be optional.

- `bridge/types.ts` (AppAPI) + `types/electron.d.ts`: drop the `?` → required.
- `electron-bridge.ts`: remove the now-redundant `?.(cb) ?? (() => {})` guard.

Lets Chat drop optional-chaining on `api.onChatStreamUrlMetadata` in useChatStore. The 5 bridge test mocks use `as AppAPI` casts (unaffected); web-bridge + electron-bridge both implement the required method.

**Verify:** deterministic gates green (tsc main/server/renderer, eslint, depcruise, vite build). `/trivial-change` self-cert.

t/2462

🤖 Generated with [Claude Code](https://claude.com/claude-code)