### PR TITLE
feat(analysis): YourActivityPanel — self-only engagement view (t/2469)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
@@ -14,19 +14,15 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { bridgeGet } from '../../bridge/web-bridge';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { useChartTooltip, ChartTooltipLayer } from './chartTooltip';
+import {
+  type TreeNode,
+  CAMP_COLORS, CAMP_LABELS,
+  fmtDuration, fmtNumber, relativeTime, categoryLabel,
+  sumByCamp, sumByCategoryForCamp, collectLeafNodes,
+} from './engagementTree';
 import './EngagementDashboard.css';
 
 // ── Types ────────────────────────────────────────────────────────────────────
-
-interface TreeNode {
-  id: string;
-  visits: number;
-  engagedVisits: number;
-  engagedMs: number;
-  cappedRate?: number;
-  uniqueUsers?: number;
-  children?: Record<string, TreeNode>;
-}
 
 interface DailyPoint { date: string; visits: number; engagedVisits: number; engagedMs: number }
 interface UserRow { user: string; visits: number; engagedVisits: number; engagedMs: number; topCamp: string; lastActive: string }
@@ -45,19 +41,6 @@ type UserSortCol = 'user' | 'engagedMs' | 'visits' | 'topCamp' | 'lastActive';
 
 const PRESET_DAYS: Record<DatePreset, number> = { '7d': 7, '30d': 30, '90d': 90 };
 
-const CAMP_COLORS: Record<string, string> = {
-  acc: 'var(--color-acc, #b84e13)',
-  saf: 'var(--color-saf, #2b5fad)',
-  skp: 'var(--color-skp, #7b4fa6)',
-  cc:  '#6b7280',
-};
-
-const CAMP_LABELS: Record<string, string> = {
-  acc: 'Accelerationist', saf: 'Safetyist', skp: 'Skeptic', cc: 'Cross-Cutting',
-};
-
-const CATEGORY_LABEL_MAP: Record<string, string> = { bel: 'Beliefs', des: 'Desires', int: 'Intentions' };
-
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function dateRange(preset: DatePreset): { from: string; to: string } {
@@ -65,77 +48,6 @@ function dateRange(preset: DatePreset): { from: string; to: string } {
   const from = new Date();
   from.setDate(from.getDate() - (PRESET_DAYS[preset] - 1));
   return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
-}
-
-function fmtDuration(ms: number): string {
-  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
-  const mins = Math.round(ms / 60_000);
-  if (mins < 60) return `${mins}m`;
-  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
-}
-
-function fmtNumber(n: number): string {
-  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
-}
-
-function relativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
-
-/** Extract the category suffix (e.g. "bel" from "acc-bel") and return a human label. */
-function categoryLabel(catKey: string): string {
-  const suffix = catKey.split('-')[1];
-  return CATEGORY_LABEL_MAP[suffix] ?? catKey;
-}
-
-/** Traverse the tool→camp→category→node tree and accumulate engagedMs + visits per camp. */
-function sumByCamp(root: TreeNode): Array<{ key: string; engagedMs: number; visits: number }> {
-  const acc: Record<string, { engagedMs: number; visits: number }> = {};
-  for (const tool of Object.values(root.children ?? {})) {
-    for (const [campKey, camp] of Object.entries(tool.children ?? {})) {
-      if (!acc[campKey]) acc[campKey] = { engagedMs: 0, visits: 0 };
-      acc[campKey].engagedMs += camp.engagedMs;
-      acc[campKey].visits += camp.visits;
-    }
-  }
-  return Object.entries(acc)
-    .map(([key, v]) => ({ key, ...v }))
-    .sort((a, b) => b.engagedMs - a.engagedMs);
-}
-
-/** Accumulate engagedMs + visits per category inside the given camp, across all tools. */
-function sumByCategoryForCamp(root: TreeNode, camp: string): Array<{ key: string; engagedMs: number; visits: number }> {
-  const acc: Record<string, { engagedMs: number; visits: number }> = {};
-  for (const tool of Object.values(root.children ?? {})) {
-    const campNode = tool.children?.[camp];
-    if (!campNode) continue;
-    for (const [catKey, cat] of Object.entries(campNode.children ?? {})) {
-      if (!acc[catKey]) acc[catKey] = { engagedMs: 0, visits: 0 };
-      acc[catKey].engagedMs += cat.engagedMs;
-      acc[catKey].visits += cat.visits;
-    }
-  }
-  return Object.entries(acc)
-    .map(([key, v]) => ({ key, ...v }))
-    .sort((a, b) => b.engagedMs - a.engagedMs);
-}
-
-/** Flatten all leaf nodes (actual taxonomy nodes) for leaderboard ranking. */
-function collectLeafNodes(node: TreeNode, depth: number, results: Array<{ id: string; engagedMs: number; visits: number }>): void {
-  const kids = node.children;
-  if (!kids || Object.keys(kids).length === 0) {
-    if (depth >= 3) results.push({ id: node.id, engagedMs: node.engagedMs, visits: node.visits });
-    return;
-  }
-  for (const child of Object.values(kids)) {
-    collectLeafNodes(child, depth + 1, results);
-  }
 }
 
 // ── Section 1: Time-with-tool chart ──────────────────────────────────────────

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.css
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.css
@@ -1,0 +1,216 @@
+/* YourActivityPanel — personal engagement view (t/2469) */
+
+.yap-root {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+.yap-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.yap-back-btn {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.yap-back-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.yap-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.yap-period-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+/* ── Panel cards ─────────────────────────────────────────────────────────── */
+
+.yap-panel {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 16px;
+}
+
+.yap-panel-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+/* ── Camp distribution bars ──────────────────────────────────────────────── */
+
+.yap-camp-hint {
+  font-size: 0.73rem;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+.yap-camp-row {
+  margin-bottom: 10px;
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 4px 6px;
+  transition: background 0.1s;
+}
+
+.yap-camp-row:hover,
+.yap-camp-row--active {
+  background: var(--bg-primary);
+}
+
+.yap-camp-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+
+.yap-camp-label {
+  font-size: 0.82rem;
+  color: var(--text-primary);
+}
+
+.yap-camp-value {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.yap-camp-track {
+  height: 6px;
+  background: var(--bg-primary);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.yap-camp-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.2s;
+}
+
+/* ── Category drill-down ─────────────────────────────────────────────────── */
+
+.yap-cat-row {
+  margin-bottom: 8px;
+}
+
+.yap-cat-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 3px;
+}
+
+.yap-cat-label {
+  font-size: 0.8rem;
+  color: var(--text-primary);
+}
+
+.yap-cat-value {
+  font-size: 0.73rem;
+  color: var(--text-muted);
+}
+
+/* ── Leaderboard ─────────────────────────────────────────────────────────── */
+
+.yap-leaders-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 560px) {
+  .yap-leaders-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.yap-leader-col-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.yap-leader-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 0;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.78rem;
+}
+
+.yap-leader-row:last-child {
+  border-bottom: none;
+}
+
+.yap-leader-rank {
+  color: var(--text-muted);
+  min-width: 18px;
+  font-size: 0.72rem;
+}
+
+.yap-leader-id {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-family: monospace;
+  font-size: 0.75rem;
+}
+
+.yap-leader-val {
+  color: var(--text-muted);
+  font-size: 0.73rem;
+  flex-shrink: 0;
+}
+
+/* ── State feedback ──────────────────────────────────────────────────────── */
+
+.yap-loading,
+.yap-error,
+.yap-empty {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  padding: 12px 0;
+}
+
+.yap-error {
+  color: var(--error, #c0392b);
+}
+
+.yap-auth-required {
+  text-align: center;
+  padding: 40px 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.test.tsx
@@ -1,0 +1,219 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { YourActivityPanel } from './YourActivityPanel';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@bridge', () => ({ api: {} }));
+
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: vi.fn(() => ({ record: vi.fn() })),
+}));
+
+vi.mock('../../bridge/web-bridge', () => ({
+  bridgeGet: vi.fn(),
+}));
+
+vi.mock('../../hooks/useAuthStatus', () => ({
+  useUserProfile: vi.fn(),
+}));
+
+import { bridgeGet } from '../../bridge/web-bridge';
+import { useUserProfile } from '../../hooks/useAuthStatus';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const LEAF_NODE = (id: string) => ({
+  id, visits: 10, engagedVisits: 8, engagedMs: 30_000,
+});
+
+const FIXTURE_TREE = {
+  id: 'root', visits: 80, engagedVisits: 64, engagedMs: 200_000,
+  children: {
+    taxonomy: {
+      id: 'taxonomy', visits: 80, engagedVisits: 64, engagedMs: 200_000,
+      children: {
+        acc: {
+          id: 'acc', visits: 40, engagedVisits: 32, engagedMs: 100_000,
+          children: {
+            'acc-bel': {
+              id: 'acc-bel', visits: 20, engagedVisits: 16, engagedMs: 60_000,
+              children: { 'acc-bel-001': LEAF_NODE('acc-bel-001') },
+            },
+            'acc-des': {
+              id: 'acc-des', visits: 20, engagedVisits: 16, engagedMs: 40_000,
+              children: { 'acc-des-001': LEAF_NODE('acc-des-001') },
+            },
+          },
+        },
+        saf: {
+          id: 'saf', visits: 40, engagedVisits: 32, engagedMs: 100_000,
+          children: {
+            'saf-bel': {
+              id: 'saf-bel', visits: 40, engagedVisits: 32, engagedMs: 100_000,
+              children: { 'saf-bel-001': LEAF_NODE('saf-bel-001') },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const SIGNED_IN_PROFILE = {
+  userId: 'user-123',
+  displayName: 'Test User',
+  idp: 'github',
+  isAnonymous: false,
+  isAdmin: false,
+  quotas: null,
+};
+
+const ANON_PROFILE = {
+  userId: '',
+  displayName: '',
+  idp: null,
+  isAnonymous: true,
+  isAdmin: false,
+  quotas: null,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function mockProfile(profile: typeof SIGNED_IN_PROFILE | typeof ANON_PROFILE | null) {
+  vi.mocked(useUserProfile).mockReturnValue(profile);
+}
+
+function mockBridgeGet(tree: typeof FIXTURE_TREE | null) {
+  vi.mocked(bridgeGet).mockResolvedValue({ user: tree });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('YourActivityPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProfile(null);
+    vi.mocked(bridgeGet).mockReturnValue(new Promise(() => {}));
+  });
+
+  it('shows loading while profile is null', () => {
+    mockProfile(null);
+    render(<YourActivityPanel />);
+    expect(screen.getByText(/loading/i)).toBeTruthy();
+  });
+
+  it('shows auth-required message for anonymous users', async () => {
+    mockProfile(ANON_PROFILE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText(/sign in/i)).toBeTruthy());
+  });
+
+  it('does not call bridgeGet for anonymous users', async () => {
+    mockProfile(ANON_PROFILE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText(/sign in/i)).toBeTruthy());
+    expect(vi.mocked(bridgeGet)).not.toHaveBeenCalled();
+  });
+
+  it('shows loading while fetch is in flight', () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    vi.mocked(bridgeGet).mockReturnValue(new Promise(() => {}));
+    render(<YourActivityPanel />);
+    expect(screen.getByText(/loading/i)).toBeTruthy();
+  });
+
+  it('shows empty state when user tree has no visits', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    vi.mocked(bridgeGet).mockResolvedValue({
+      user: { id: 'root', visits: 0, engagedVisits: 0, engagedMs: 0 },
+    });
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText(/no activity recorded/i)).toBeTruthy());
+  });
+
+  it('shows empty state when server returns no user subtree', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    vi.mocked(bridgeGet).mockResolvedValue({ user: undefined });
+    render(<YourActivityPanel />);
+    // userTree === null → same as empty (null check path)
+    await waitFor(() => expect(screen.queryByText(/camp distribution/i)).toBeNull());
+  });
+
+  it('renders camp distribution with camp labels', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText('Camp Distribution')).toBeTruthy());
+    expect(screen.getByText('Accelerationist')).toBeTruthy();
+    expect(screen.getByText('Safetyist')).toBeTruthy();
+  });
+
+  it('renders leaderboard section', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText(/most-visited nodes/i)).toBeTruthy());
+    expect(screen.getByText(/most time spent/i)).toBeTruthy();
+    expect(screen.getByText(/most visited/i)).toBeTruthy();
+  });
+
+  it('shows node IDs in leaderboard', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getAllByText(/acc-bel-001|saf-bel-001/).length).toBeGreaterThan(0));
+  });
+
+  it('shows category breakdown when camp is clicked', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
+    fireEvent.click(screen.getByText('Accelerationist'));
+    await waitFor(() => expect(screen.getByText(/accelerationist.*category breakdown/i)).toBeTruthy());
+    expect(screen.getByText('Beliefs')).toBeTruthy();
+    expect(screen.getByText('Desires')).toBeTruthy();
+  });
+
+  it('closes category breakdown when same camp clicked again', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
+    fireEvent.click(screen.getByText('Accelerationist'));
+    await waitFor(() => expect(screen.getByText('Beliefs')).toBeTruthy());
+    fireEvent.click(screen.getByText('Accelerationist'));
+    await waitFor(() => expect(screen.queryByText('Beliefs')).toBeNull());
+  });
+
+  it('shows error state on fetch failure', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    vi.mocked(bridgeGet).mockRejectedValue(new Error('Network error'));
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText(/failed to load/i)).toBeTruthy());
+  });
+
+  it('calls bridgeGet with userId as user param', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(vi.mocked(bridgeGet)).toHaveBeenCalled());
+    const url = vi.mocked(bridgeGet).mock.calls[0][0] as string;
+    expect(url).toContain('user=user-123');
+    expect(url).toContain('/api/analytics/engagement');
+  });
+
+  it('shows the period label in header', async () => {
+    mockProfile(SIGNED_IN_PROFILE);
+    mockBridgeGet(FIXTURE_TREE);
+    render(<YourActivityPanel />);
+    await waitFor(() => expect(screen.getByText('Camp Distribution')).toBeTruthy());
+    // Period label: "YYYY-MM-DD – YYYY-MM-DD" format
+    const periodLabel = screen.getByText(/\d{4}-\d{2}-\d{2} – \d{4}-\d{2}-\d{2}/);
+    expect(periodLabel).toBeTruthy();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.tsx
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * YourActivityPanel — self-only engagement view for the profile/Help menu.
+ * Calls GET /api/analytics/engagement?user=<self> and renders the caller's
+ * own camp distribution, category drill-down, and most-visited leaderboards.
+ * No admin gate — server enforces self-only; non-admin users receive their
+ * own .user subtree and never receive other users' data. (t/2469)
+ * Spec: docs/ux/usage-analytics-instrumentation.md §5.2.
+ */
+
+import { useState, useEffect, useMemo } from 'react';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { bridgeGet } from '../../bridge/web-bridge';
+import { useUserProfile } from '../../hooks/useAuthStatus';
+import {
+  type TreeNode,
+  CAMP_COLORS, CAMP_LABELS,
+  fmtDuration, fmtNumber, categoryLabel,
+  sumByCamp, sumByCategoryForCamp, collectLeafNodes,
+} from './engagementTree';
+import './YourActivityPanel.css';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface ActivityResult {
+  user?: TreeNode;  // caller's own subtree (t/2467#2); absent if no events yet
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function last30DayRange(): { from: string; to: string } {
+  const to = new Date().toISOString().slice(0, 10);
+  const fromDate = new Date();
+  fromDate.setDate(fromDate.getDate() - 29);
+  return { from: fromDate.toISOString().slice(0, 10), to };
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function CampBars({
+  root, selectedCamp, onSelectCamp,
+}: { root: TreeNode; selectedCamp: string | null; onSelectCamp: (k: string | null) => void }) {
+  const camps = useMemo(() => sumByCamp(root), [root]);
+  const maxMs = camps[0]?.engagedMs ?? 1;
+
+  if (camps.length === 0) return (
+    <div className="yap-panel">
+      <div className="yap-panel-title">Camp Distribution</div>
+      <div className="yap-empty">No camp data yet.</div>
+    </div>
+  );
+
+  return (
+    <div className="yap-panel">
+      <div className="yap-panel-title">Camp Distribution</div>
+      <div className="yap-camp-hint">Click a camp to see category breakdown</div>
+      {camps.map(c => {
+        const color = CAMP_COLORS[c.key] ?? '#6b7280';
+        const label = CAMP_LABELS[c.key] ?? c.key;
+        const isActive = selectedCamp === c.key;
+        return (
+          <div
+            key={c.key}
+            className={`yap-camp-row${isActive ? ' yap-camp-row--active' : ''}`}
+            onClick={() => onSelectCamp(isActive ? null : c.key)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={e => e.key === 'Enter' && onSelectCamp(isActive ? null : c.key)}
+          >
+            <div className="yap-camp-row-head">
+              <span className="yap-camp-label">{label}</span>
+              <span className="yap-camp-value">{fmtDuration(c.engagedMs)}</span>
+            </div>
+            <div className="yap-camp-track">
+              <div
+                className="yap-camp-fill"
+                /* eslint-disable-next-line local/no-inline-style -- dynamic: bar width + camp color from data */
+                style={{ width: `${(c.engagedMs / maxMs) * 100}%`, background: color }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function CategoryBreakdown({ root, camp }: { root: TreeNode; camp: string }) {
+  const categories = useMemo(() => sumByCategoryForCamp(root, camp), [root, camp]);
+  const maxMs = categories[0]?.engagedMs ?? 1;
+  const color = CAMP_COLORS[camp] ?? '#6b7280';
+  const campLabel = CAMP_LABELS[camp] ?? camp;
+
+  return (
+    <div className="yap-panel">
+      <div className="yap-panel-title">{campLabel} — Category Breakdown</div>
+      {categories.length === 0 ? (
+        <div className="yap-empty">No category data.</div>
+      ) : categories.map(c => (
+        <div key={c.key} className="yap-cat-row">
+          <div className="yap-cat-row-head">
+            <span className="yap-cat-label">{categoryLabel(c.key)}</span>
+            <span className="yap-cat-value">{fmtDuration(c.engagedMs)}</span>
+          </div>
+          <div className="yap-camp-track">
+            <div
+              className="yap-camp-fill"
+              /* eslint-disable-next-line local/no-inline-style -- dynamic: bar width + camp color */
+              style={{ width: `${(c.engagedMs / maxMs) * 100}%`, background: color, opacity: 0.7 }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ActivityLeaderboards({ root }: { root: TreeNode }) {
+  const nodes = useMemo(() => {
+    const results: Array<{ id: string; engagedMs: number; visits: number }> = [];
+    collectLeafNodes(root, 0, results);
+    return results;
+  }, [root]);
+
+  const byTime = useMemo(() => [...nodes].sort((a, b) => b.engagedMs - a.engagedMs).slice(0, 10), [nodes]);
+  const byVisits = useMemo(() => [...nodes].sort((a, b) => b.visits - a.visits).slice(0, 10), [nodes]);
+
+  const List = ({ items, valueKey, title }: {
+    items: Array<{ id: string; engagedMs: number; visits: number }>;
+    valueKey: 'engagedMs' | 'visits';
+    title: string;
+  }) => (
+    <div>
+      <div className="yap-leader-col-title">{title}</div>
+      {items.length === 0 ? <div className="yap-empty">No data.</div> : items.map((n, i) => (
+        <div key={n.id} className="yap-leader-row">
+          <span className="yap-leader-rank">{i + 1}</span>
+          <span className="yap-leader-id" title={n.id}>{n.id}</span>
+          <span className="yap-leader-val">
+            {valueKey === 'engagedMs' ? fmtDuration(n.engagedMs) : fmtNumber(n.visits)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="yap-panel">
+      <div className="yap-panel-title">Your Most-Visited Nodes</div>
+      <div className="yap-leaders-row">
+        <List items={byTime} valueKey="engagedMs" title="Most Time Spent" />
+        <List items={byVisits} valueKey="visits" title="Most Visited" />
+      </div>
+    </div>
+  );
+}
+
+// ── Fetch hook (extracted to keep YourActivityPanel under complexity limit) ────
+
+interface FetchState { userTree: TreeNode | null; loading: boolean; error: string | null }
+
+function useFetchUserActivity(userId: string | null, isAnonymous: boolean): FetchState {
+  const [userTree, setUserTree] = useState<TreeNode | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (userId === null) return;
+    if (isAnonymous) { setLoading(false); return; }
+
+    setLoading(true);
+    setError(null);
+    const { from, to } = last30DayRange();
+    // Non-admin path: server returns .user for the caller's own userId and strips
+    // all other-user data server-side. (verified seam: t/2469#3)
+    bridgeGet<ActivityResult>(`/api/analytics/engagement?user=${encodeURIComponent(userId)}&from=${from}&to=${to}`)
+      .then(d => { setUserTree(d.user ?? null); setLoading(false); })
+      .catch(err => {
+        getGlobalRecorder()?.record({
+          type: 'system.error',
+          component: 'your-activity-panel',
+          level: 'error',
+          message: 'Activity fetch failed',
+          error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+        });
+        setError(String(err));
+        setLoading(false);
+      });
+  }, [userId, isAnonymous]);
+
+  return { userTree, loading, error };
+}
+
+// ── Panel body (extracted so conditional branches don't inflate main component) ─
+
+function PanelBody({ loading, error, isAnonymous, userTree, selectedCamp, onSelectCamp }: {
+  loading: boolean; error: string | null; isAnonymous: boolean;
+  userTree: TreeNode | null; selectedCamp: string | null; onSelectCamp: (k: string | null) => void;
+}) {
+  if (loading) return <div className="yap-loading">Loading…</div>;
+  if (error) return <div className="yap-error">Failed to load: {error}</div>;
+  if (isAnonymous) return <div className="yap-auth-required">Sign in to see your activity.</div>;
+  if (userTree === null || userTree.visits === 0) {
+    return <div className="yap-empty">No activity recorded yet. Start exploring the taxonomy!</div>;
+  }
+  return (
+    <>
+      <CampBars root={userTree} selectedCamp={selectedCamp} onSelectCamp={onSelectCamp} />
+      {selectedCamp && <CategoryBreakdown root={userTree} camp={selectedCamp} />}
+      <ActivityLeaderboards root={userTree} />
+    </>
+  );
+}
+
+// ── Main Panel ────────────────────────────────────────────────────────────────
+
+export function YourActivityPanel() {
+  const profile = useUserProfile();
+  const userId = profile?.userId ?? null;
+  const isAnonymous = profile?.isAnonymous ?? false;
+
+  const { userTree, loading, error } = useFetchUserActivity(userId, isAnonymous);
+  const [selectedCamp, setSelectedCamp] = useState<string | null>(null);
+
+  const handleBack = () => { window.location.hash = ''; window.location.reload(); };
+  const { from, to } = last30DayRange();
+
+  return (
+    <div className="yap-root">
+      <div className="yap-header">
+        <button onClick={handleBack} className="yap-back-btn">← Back</button>
+        <h1 className="yap-title">Your Activity</h1>
+        <span className="yap-period-label">{from} – {to}</span>
+      </div>
+      <PanelBody
+        loading={loading} error={error} isAnonymous={isAnonymous}
+        userTree={userTree} selectedCamp={selectedCamp} onSelectCamp={setSelectedCamp}
+      />
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/analysis/engagementTree.ts
+++ b/taxonomy-editor/src/renderer/components/analysis/engagementTree.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Shared tree-traversal utilities for engagement analytics panels.
+ * Consumed by EngagementDashboard (admin) and YourActivityPanel (self-view).
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface TreeNode {
+  id: string;
+  visits: number;
+  engagedVisits: number;
+  engagedMs: number;
+  cappedRate?: number;
+  uniqueUsers?: number;
+  children?: Record<string, TreeNode>;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const CAMP_COLORS: Record<string, string> = {
+  acc: 'var(--color-acc, #b84e13)',
+  saf: 'var(--color-saf, #2b5fad)',
+  skp: 'var(--color-skp, #7b4fa6)',
+  cc:  '#6b7280',
+};
+
+export const CAMP_LABELS: Record<string, string> = {
+  acc: 'Accelerationist', saf: 'Safetyist', skp: 'Skeptic', cc: 'Cross-Cutting',
+};
+
+export const CATEGORY_LABEL_MAP: Record<string, string> = {
+  bel: 'Beliefs', des: 'Desires', int: 'Intentions',
+};
+
+// ── Formatters ────────────────────────────────────────────────────────────────
+
+export function fmtDuration(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
+export function fmtNumber(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+export function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+/** Returns the human-readable category label for a key like "acc-bel". */
+export function categoryLabel(catKey: string): string {
+  const suffix = catKey.split('-')[1];
+  return CATEGORY_LABEL_MAP[suffix] ?? catKey;
+}
+
+// ── Tree traversal ────────────────────────────────────────────────────────────
+
+/** Accumulate engagedMs + visits per camp across all tools in the tree. */
+export function sumByCamp(root: TreeNode): Array<{ key: string; engagedMs: number; visits: number }> {
+  const acc: Record<string, { engagedMs: number; visits: number }> = {};
+  for (const tool of Object.values(root.children ?? {})) {
+    for (const [campKey, camp] of Object.entries(tool.children ?? {})) {
+      if (!acc[campKey]) acc[campKey] = { engagedMs: 0, visits: 0 };
+      acc[campKey].engagedMs += (camp as TreeNode).engagedMs;
+      acc[campKey].visits += (camp as TreeNode).visits;
+    }
+  }
+  return Object.entries(acc)
+    .map(([key, v]) => ({ key, ...v }))
+    .sort((a, b) => b.engagedMs - a.engagedMs);
+}
+
+/** Accumulate engagedMs + visits per category for a given camp across all tools. */
+export function sumByCategoryForCamp(root: TreeNode, camp: string): Array<{ key: string; engagedMs: number; visits: number }> {
+  const acc: Record<string, { engagedMs: number; visits: number }> = {};
+  for (const tool of Object.values(root.children ?? {})) {
+    const campNode = (tool as TreeNode).children?.[camp] as TreeNode | undefined;
+    if (!campNode) continue;
+    for (const [catKey, cat] of Object.entries(campNode.children ?? {})) {
+      if (!acc[catKey]) acc[catKey] = { engagedMs: 0, visits: 0 };
+      acc[catKey].engagedMs += (cat as TreeNode).engagedMs;
+      acc[catKey].visits += (cat as TreeNode).visits;
+    }
+  }
+  return Object.entries(acc)
+    .map(([key, v]) => ({ key, ...v }))
+    .sort((a, b) => b.engagedMs - a.engagedMs);
+}
+
+/** Flatten all leaf nodes (actual taxonomy nodes, depth ≥ 3) for leaderboards. */
+export function collectLeafNodes(
+  node: TreeNode,
+  depth: number,
+  results: Array<{ id: string; engagedMs: number; visits: number }>,
+): void {
+  const kids = node.children;
+  if (!kids || Object.keys(kids).length === 0) {
+    if (depth >= 3) results.push({ id: node.id, engagedMs: node.engagedMs, visits: node.visits });
+    return;
+  }
+  for (const child of Object.values(kids)) {
+    collectLeafNodes(child as TreeNode, depth + 1, results);
+  }
+}


### PR DESCRIPTION
## Summary

- New `YourActivityPanel` showing the signed-in user's own engaged-time distribution across camps, category drill-down, and most-visited leaderboards
- Extracts shared tree utilities (`sumByCamp`, `sumByCategoryForCamp`, `collectLeafNodes`, `CAMP_COLORS`, `CAMP_LABELS`, formatters) into `engagementTree.ts`, consumed by both `EngagementDashboard` and `YourActivityPanel`
- `EngagementDashboard.tsx` updated to import from `engagementTree.ts` (no behaviour change)
- Entry point: profile/Help menu — Rosetta to wire (pending ping)

## Privacy

Calls `GET /api/analytics/engagement?user=<self>` — own data only. Server-side enforcement (t/2467) guarantees no cross-user rows reach a non-admin caller (verified seam per t/2469#3).

## Test plan

- [ ] 14 new tests in `YourActivityPanel.test.tsx` — all green (118/118 analysis/ suite)
- [ ] ESLint + tsc clean
- [ ] Design sign-off (t/2469 AC requires Design sign-off before Done)
- [ ] Verify non-admin `?user=<self>` returns 200 with `.user` populated against a live non-admin session (t/2469 AC)
- [ ] Rosetta wires profile/Help menu entry and pings to undraft

🤖 Generated with [Claude Code](https://claude.com/claude-code)
