### PR TITLE
fix(server): prefer .aitriad.json over scripts/ when resolving PROJECT_ROOT (t/2475)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/config.projectRoot.test.ts
+++ b/taxonomy-editor/src/server/__tests__/config.projectRoot.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+//
+// t/2475 — resolveProjectRoot must PREFER the `.aitriad.json` marker over the
+// ambiguous `scripts/` marker. `taxonomy-editor/` has its own `scripts/`, so a
+// walk that accepted either marker stopped one level short at `taxonomy-editor/`
+// in local compiled/dev runs — mis-resolving PROJECT_ROOT and 404-ing the
+// root-only ai-models.json / ai-usages.json registries. These tests drive the
+// pure resolver against simulated on-disk layouts (real temp dirs), since the
+// module-level PROJECT_ROOT is frozen from the real __dirname at import time.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { resolveProjectRoot } from '../config.js';
+
+let root: string;
+
+// Build a directory tree under `root` from a list of relative dir paths, plus a
+// list of relative file paths (empty files). Returns nothing; `root` is the base.
+function scaffold(dirs: string[], files: string[] = []): void {
+  for (const d of dirs) fs.mkdirSync(path.join(root, d), { recursive: true });
+  for (const f of files) {
+    fs.mkdirSync(path.join(root, path.dirname(f)), { recursive: true });
+    fs.writeFileSync(path.join(root, f), '');
+  }
+}
+
+describe('t/2475 — resolveProjectRoot prefers .aitriad.json over scripts/', () => {
+  beforeEach(() => {
+    // realpathSync: macOS/Windows temp dirs are symlinks; resolveProjectRoot uses
+    // path.resolve (no symlink deref), so compare against the resolved base.
+    root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'projroot-')));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('local compiled dist: resolves the monorepo root, NOT taxonomy-editor/ (the regression)', () => {
+    // root/ has .aitriad.json + scripts/; taxonomy-editor/ has its OWN scripts/.
+    scaffold(
+      ['scripts', 'taxonomy-editor/scripts', 'taxonomy-editor/dist/server'],
+      ['.aitriad.json', 'ai-models.json', 'ai-usages.json'],
+    );
+    const startDir = path.join(root, 'taxonomy-editor', 'dist', 'server');
+    const resolved = resolveProjectRoot(startDir);
+    expect(resolved).toBe(root);
+    expect(resolved).not.toBe(path.join(root, 'taxonomy-editor'));
+    // the registries the bug couldn't find are present at the resolved root
+    expect(fs.existsSync(path.join(resolved, 'ai-models.json'))).toBe(true);
+  });
+
+  it('local source layout: resolves the monorepo root from src/server', () => {
+    scaffold(
+      ['scripts', 'taxonomy-editor/scripts', 'taxonomy-editor/src/server'],
+      ['.aitriad.json'],
+    );
+    const startDir = path.join(root, 'taxonomy-editor', 'src', 'server');
+    expect(resolveProjectRoot(startDir)).toBe(root);
+  });
+
+  it('container /app layout: resolves /app (.aitriad.json at the marker level)', () => {
+    // Mirrors the Dockerfile: .aitriad.json + registries + scripts/ all at /app.
+    scaffold(['scripts', 'dist/server'], ['.aitriad.json', 'ai-models.json', 'ai-usages.json']);
+    const startDir = path.join(root, 'dist', 'server');
+    expect(resolveProjectRoot(startDir)).toBe(root);
+  });
+
+  it('no .aitriad.json anywhere: falls back to the scripts/ marker', () => {
+    scaffold(['scripts', 'dist/server']); // no .aitriad.json
+    const startDir = path.join(root, 'dist', 'server');
+    expect(resolveProjectRoot(startDir)).toBe(root);
+  });
+
+  it('ambiguity guard: with a nested scripts/ closer than the config root, .aitriad.json still wins', () => {
+    // sub/ (closer) has scripts/ but no config; root (farther) has .aitriad.json.
+    scaffold(['sub/scripts', 'sub/dist/server'], ['.aitriad.json']);
+    const startDir = path.join(root, 'sub', 'dist', 'server');
+    // scripts-first would return sub/; config-first must return root.
+    expect(resolveProjectRoot(startDir)).toBe(root);
+    expect(resolveProjectRoot(startDir)).not.toBe(path.join(root, 'sub'));
+  });
+});

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -32,17 +32,33 @@ interface AiTriadConfig {
 
 // In source: __dirname = .../taxonomy-editor/src/server (3 levels to monorepo root)
 // Compiled:  __dirname = .../taxonomy-editor/dist/server (3 levels to monorepo root)
-// Container: __dirname = /app/dist/server (only 2 levels to /app which has scripts/)
-// Resolve by checking which ancestor has .aitriad.json or scripts/
-const PROJECT_ROOT = (() => {
-  const hasMarker = (d: string) =>
-    fs.existsSync(path.join(d, '.aitriad.json')) || fs.existsSync(path.join(d, 'scripts'));
-  for (let i = 2; i <= 6; i++) {
-    const candidate = path.resolve(__dirname, '../'.repeat(i));
-    if (hasMarker(candidate)) return candidate;
-  }
-  return path.resolve(__dirname, '../../..');
-})();
+// Container: __dirname = /app/dist/server (2 levels to /app, which has .aitriad.json)
+//
+// t/2475: resolve by ancestor marker, but PREFER `.aitriad.json` over `scripts/`.
+// `.aitriad.json` exists only at the monorepo root (and at /app in the container);
+// `scripts/` is AMBIGUOUS because `taxonomy-editor/` has its own `scripts/` dir. A
+// single-pass walk that accepted either marker stopped one level short at
+// `taxonomy-editor/` in local compiled/dev runs, so getProjectRoot() pointed there
+// and the root-only ai-models.json / ai-usages.json failed to load — breaking every
+// registry-backed path (non-Gemini /api/ai/chat-stream fallback, /api/ai/generate)
+// locally. Prod was unaffected: the container copies `.aitriad.json` + both
+// registries to /app at the marker level (taxonomy-editor/Dockerfile). Two-pass
+// fixes both: config-marker first; `scripts/` only as a fallback for any layout
+// lacking `.aitriad.json`.
+//
+// Extracted as a pure function so a regression test can drive it with a simulated
+// dist layout (PROJECT_ROOT itself is import-time-frozen from the real __dirname).
+export function resolveProjectRoot(startDir: string): string {
+  const candidates: string[] = [];
+  for (let i = 2; i <= 6; i++) candidates.push(path.resolve(startDir, '../'.repeat(i)));
+  const byConfig = candidates.find(d => fs.existsSync(path.join(d, '.aitriad.json')));
+  if (byConfig) return byConfig;
+  const byScripts = candidates.find(d => fs.existsSync(path.join(d, 'scripts')));
+  if (byScripts) return byScripts;
+  return path.resolve(startDir, '../../..');
+}
+
+const PROJECT_ROOT = resolveProjectRoot(__dirname);
 
 const DEFAULT_CONFIG: AiTriadConfig = {
   data_root: '.',


### PR DESCRIPTION
## Summary

Fixes t/2475 (found during t/2455 live verification): `config.ts`'s `PROJECT_ROOT` marker walk accepted `.aitriad.json` **or** `scripts/` as the monorepo-root marker. Since `taxonomy-editor/` has its own `scripts/`, a local compiled/dev run (`npm run dev:server`, `node dist/.../server.js`) stopped one level short at `taxonomy-editor/` → `getProjectRoot()` mis-resolved and the **root-only** `ai-models.json` / `ai-usages.json` failed to load, breaking every registry-backed path (non-Gemini `/api/ai/chat-stream` fallback, `/api/ai/generate`) locally.

**Prod was unaffected** — the container copies `.aitriad.json` + both registries + `scripts/` to `/app` at the marker level (`Dockerfile:153-157`), so `/app` resolves at i=2 by the config marker. No Dockerfile change needed.

## Fix (`config.ts` only)

Two-pass resolver, `.aitriad.json` preferred over `scripts/`; the `scripts/` shortcut is now last-resort (kept for any layout lacking the config marker). Extracted to a pure exported `resolveProjectRoot(startDir)` so the resolution is unit-testable (module-level `PROJECT_ROOT` is frozen from the real `__dirname` at import).

## Behaviour (all resolve correctly)

| Layout | startDir | Resolves via |
|---|---|---|
| Local dist (**the bug**) | `taxonomy-editor/dist/server` | root, i=3 `.aitriad.json` (skips `taxonomy-editor/`) |
| Local source | `taxonomy-editor/src/server` | root, i=4 `.aitriad.json` |
| Container | `/app/dist/server` | `/app`, i=2 `.aitriad.json` |
| No config marker | any | `scripts/` fallback preserved |

## Test plan

`src/server/__tests__/config.projectRoot.test.ts` (node) drives `resolveProjectRoot` against temp-dir layouts:

- [x] local-dist returns the root, **NOT** `taxonomy-editor/` (the regression)
- [x] local-source, container `/app`, `scripts/`-only fallback
- [x] nested-`scripts/` ambiguity guard (config-first wins over a closer `scripts/`)
- [x] `tsc --project tsconfig.server.json --noEmit` clean; eslint clean

Design approved by Quality (TL) at t/2475#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
