### PR TITLE
feat(settings): add Your Activity nav entry to HelpDialog (t/2469)

### DIFF
--- a/taxonomy-editor/src/renderer/components/settings/HelpDialog.css
+++ b/taxonomy-editor/src/renderer/components/settings/HelpDialog.css
@@ -72,6 +72,10 @@
 .helpdialog-ref-link { color: var(--accent); font-size: 0.85em; }
 .helpdialog-shortcuts-h4 { margin-top: 0; }
 
+.helpdialog-tab-sep { height: 1px; background: var(--border); margin: 6px 0; }
+.helpdialog-tab-nav { border-left: 2px solid transparent; color: var(--text-secondary); }
+.helpdialog-tab-nav:hover { color: var(--text-primary); }
+
 .helpdialog-resize-e { position: absolute; right: -4px; top: 0; width: 14px; height: 100%; cursor: ew-resize; z-index: 10; }
 .helpdialog-resize-s { position: absolute; bottom: -4px; left: 0; width: 100%; height: 14px; cursor: ns-resize; z-index: 10; }
 .helpdialog-resize-se { position: absolute; right: -4px; bottom: -4px; width: 20px; height: 20px; cursor: nwse-resize; opacity: 0.4; z-index: 11; }

--- a/taxonomy-editor/src/renderer/components/settings/HelpDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/HelpDialog.tsx
@@ -452,6 +452,16 @@ export function HelpDialog({ onClose, initialTab }: HelpDialogProps) {
                 )}
               </button>
             ))}
+            <div className="helpdialog-tab-sep" />
+            <button
+              className="helpdialog-tab helpdialog-tab-nav"
+              onClick={() => {
+                window.location.hash = '#your-activity';
+                onClose();
+              }}
+            >
+              Your Activity
+            </button>
           </div>
           <div className="helpdialog-content">
 


### PR DESCRIPTION
## Summary

- Adds a thin separator + **Your Activity** nav button below the content tabs in \`HelpDialog\`
- On click: sets \`window.location.hash = '#your-activity'\` and closes the dialog
- Visible to all signed-in users — no admin gate
- CSS: \`helpdialog-tab-sep\` (1px rule) + \`helpdialog-tab-nav\` (static inactive colors, no inline style needed)

## Dependency

**Merge after PR #858** (App.tsx \`#your-activity\` route mount). PR #852 (the panel) is already on main; #858 wires the route. Without #858 the hash falls through to the main app with no mount.

## Test plan

- [ ] Open Help dialog → confirm **Your Activity** appears below a separator, after Licenses
- [ ] Click Your Activity → dialog closes, URL hash becomes \`#your-activity\`, view mounts
- [ ] Existing tabs unaffected; no inline-style lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)