### PR TITLE
feat(app): mount YourActivityPanel on #your-activity route (t/2469 wiring)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -63,6 +63,7 @@ const DiffWindow = recordingLazy(() => import('./components/shared/DiffWindow').
 const HarvestDialog = recordingLazy(() => import('./components/shared/HarvestDialog').then(m => ({ default: m.HarvestDialog })));
 const AnalyticsDashboard = recordingLazy(() => import('./components/analysis/AnalyticsDashboard').then(m => ({ default: m.AnalyticsDashboard })));
 const EngagementDashboard = recordingLazy(() => import('./components/analysis/EngagementDashboard').then(m => ({ default: m.EngagementDashboard })));
+const YourActivityPanel = recordingLazy(() => import('./components/analysis/YourActivityPanel').then(m => ({ default: m.YourActivityPanel })));
 const CommunityLibrary = recordingLazy(() => import('./components/community/CommunityLibrary').then(m => ({ default: m.CommunityLibrary })));
 const AdminPanel = recordingLazy(() => import('./components/settings/AdminPanel').then(m => ({ default: m.AdminPanel })));
 const AdminReviewPanel = recordingLazy(() => import('./components/settings/AdminReviewPanel').then(m => ({ default: m.AdminReviewPanel })));
@@ -210,6 +211,12 @@ export function App() {
   // the per-user data it serves.
   if (hash === '#engagement' && isAdmin) {
     return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><EngagementDashboard /></Suspense></ErrorBoundary>;
+  }
+  // Self-only "Your Activity" view (t/2469). No admin gate — the panel requests only the
+  // caller's OWN engagement subtree, and the server (t/2467) never returns other users' rows
+  // to a non-admin. Reached from the Help menu (Settings-owned HelpDialog entry).
+  if (hash === '#your-activity') {
+    return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><YourActivityPanel /></Suspense></ErrorBoundary>;
   }
   if (hash === '#community' && communityFlag) {
     return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><CommunityLibrary /></Suspense></ErrorBoundary>;


### PR DESCRIPTION
App-shell wiring for the self-only engagement view (t/2469). The panel + engagementTree landed via #852; this adds the missing route so the view is reachable.

- `App.tsx`: lazy-load `YourActivityPanel` (via `recordingLazy`, mirroring EngagementDashboard) and mount it on `hash === '#your-activity'`. **No admin gate** — the panel requests only the caller's own subtree, and the server (t/2467) never returns other users' rows to a non-admin.

**Context / ordering:** #852 merged the panel WITHOUT this mount (raced the planned order). This PR makes the route reachable, which in turn unblocks (a) Analysis's live `?user=self` non-admin verify — skipped in the #852 race, the t/2469 make-or-break — and (b) Settings' Help-menu entry (#857), which navigates here. Suggested merge order: **this → #857**.

**Verify:** deterministic gates green (tsc main + renderer, eslint, depcruise, vite build) on current main; the 14 YourActivityPanel tests are already on main via #852. `/trivial-change` (7-line route addition).

t/2469

🤖 Generated with [Claude Code](https://claude.com/claude-code)