### PR TITLE
fix(devops): anchor overlay ls-files to repo root (guard b2 CWD fix, t/2477)

### DIFF
--- a/operations/devops/check-shared-drift.ps1
+++ b/operations/devops/check-shared-drift.ps1
@@ -120,7 +120,8 @@ try {
             # Guard (b1): not tracked in main repo
             if (Invoke-Git @('-C', $RepoRoot, 'ls-files', $f)) { $remainingJunk += $f; continue }
             # Guard (b2): not tracked in overlay (skip check when no overlay present)
-            if ((Test-Path $overlayGitDir) -and (Invoke-Git @('--git-dir', $overlayGitDir, 'ls-files', $f))) {
+            # -C $RepoRoot anchors path resolution to repo root regardless of script CWD (t/2477)
+            if ((Test-Path $overlayGitDir) -and (Invoke-Git @('-C', $RepoRoot, '--git-dir', $overlayGitDir, 'ls-files', $f))) {
                 $remainingJunk += $f; continue
             }
             # Guard (c): re-stat — file must still be 0 bytes at deletion time


### PR DESCRIPTION
## Summary
Fixes guard (b2) in `check-shared-drift.ps1` auto-remediation loop: adds `-C $RepoRoot` to the overlay `ls-files` call so path resolution is anchored to the repo root regardless of script invocation CWD.

Without this fix, running the script from a subdirectory or worktree CWD caused the repo-root-relative path `$f` to resolve incorrectly, potentially false-blocking legitimate 0-byte junk deletion. TL diagnosed at p/331#64.

Self-certifying under /trivial-change: 1 line changed, single scope (operations/devops), no new public API, no interface changes. Fixes t/2477.

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>