### PR TITLE
fix(a11y): keyboard operability for camp rows and sort headers (t/2468, t/2469)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
@@ -116,7 +116,7 @@ function CampDistribution({
             onClick={() => onSelectCamp(isActive ? null : c.key)}
             role="button"
             tabIndex={0}
-            onKeyDown={e => e.key === 'Enter' && onSelectCamp(isActive ? null : c.key)}
+            onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && onSelectCamp(isActive ? null : c.key)}
           >
             <div className="eng-camp-row-head">
               <span className="eng-camp-label">{label}</span>
@@ -237,6 +237,8 @@ function PerUserTable({ users }: { users: UserRow[] }) {
   const Th = ({ col, label, align = 'right' }: { col: UserSortCol; label: string; align?: 'left' | 'right' }) => (
     <th
       onClick={() => handleSort(col)}
+      onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && handleSort(col)}
+      tabIndex={0}
       className="eng-th"
       /* eslint-disable-next-line local/no-inline-style -- dynamic: sort-active color + textAlign per column */
       style={{ textAlign: align, color: sortCol === col ? 'var(--text-primary)' : 'var(--text-muted)' }}
@@ -369,6 +371,7 @@ export function EngagementDashboard() {
             <input
               type="text"
               className="eng-user-filter"
+              aria-label="Filter by user"
               placeholder="Filter by user…"
               value={userFilter}
               onChange={e => setUserFilter(e.target.value)}

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.tsx
@@ -67,7 +67,7 @@ function CampBars({
             onClick={() => onSelectCamp(isActive ? null : c.key)}
             role="button"
             tabIndex={0}
-            onKeyDown={e => e.key === 'Enter' && onSelectCamp(isActive ? null : c.key)}
+            onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && onSelectCamp(isActive ? null : c.key)}
           >
             <div className="yap-camp-row-head">
               <span className="yap-camp-label">{label}</span>


### PR DESCRIPTION
## Summary

- Space-key support added to camp-row `onKeyDown` in `EngagementDashboard` and `YourActivityPanel` (WCAG 2.1.1 A — role=button must respond to both Enter and Space)
- `tabIndex={0}` + Enter/Space `onKeyDown` added to `<Th>` sort headers in `PerUserTable` (mouse-only sort was flagged as WCAG 2.1.1 A)
- `aria-label="Filter by user"` added to the per-user filter `<input>`

Design flagged all three in p/426#2 as part of sign-off for t/2468 and t/2469; folded before final Done per Design's recommendation.

## Test plan

- [x] 118/118 analysis suite green (no regressions)
- [x] ESLint clean on both changed files
- [x] Design sign-off already received (p/426#2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
