### PR TITLE
feat(ps): Show-TaxonomyEditor syncs local repos with GitHub on launch (t/2478)

### DIFF
--- a/scripts/AITriad/Private/Update-GitRepository.ps1
+++ b/scripts/AITriad/Private/Update-GitRepository.ps1
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Update-GitRepository {
+    <#
+    .SYNOPSIS
+        Fast-forward a local git clone to its GitHub origin; never blocks the caller.
+    .DESCRIPTION
+        Launch-path repo sync used by Show-TaxonomyEditor (t/2478). Fetches origin
+        and applies a fast-forward-only pull. Designed to degrade, not fail: a
+        missing git, unreachable GitHub, or diverged local history produces a
+        warning and $false — the caller launches with the local copy. Returns
+        $true only when the repo is up to date or was fast-forwarded.
+    .PARAMETER Path
+        Root of the local clone (the directory containing .git).
+    .PARAMETER Label
+        Human-readable name used in status messages (e.g. 'data repository').
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [string]$Label = 'repository'
+    )
+
+    if (-not (Test-Path (Join-Path $Path '.git'))) {
+        Write-Verbose "Update-GitRepository: $Path is not a git repository — skipping"
+        return $false
+    }
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+        Write-Warn "git is not available — using the local copy of the $Label as-is"
+        return $false
+    }
+
+    Push-Location $Path
+    try {
+        $FetchOutput = git fetch origin 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "Could not fetch the $Label from GitHub — continuing with the local copy"
+            Write-Verbose ('git fetch: ' + (($FetchOutput | Out-String).Trim()))
+            return $false
+        }
+
+        $PullOutput = git pull --ff-only 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "The $Label cannot be fast-forwarded (local changes or diverged history) — continuing with the local copy"
+            Write-Info "Reconcile manually in ${Path}: commit or stash local work, then run 'git pull'"
+            Write-Verbose ('git pull --ff-only: ' + (($PullOutput | Out-String).Trim()))
+            return $false
+        }
+
+        if ((($PullOutput | Out-String)) -match 'Already up to date') {
+            Write-OK "The $Label is up to date with GitHub"
+        }
+        else {
+            Write-OK "The $Label was updated from GitHub"
+        }
+        return $true
+    }
+    finally {
+        Pop-Location
+    }
+}

--- a/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
+++ b/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
@@ -16,6 +16,11 @@ function Show-TaxonomyEditor {
         not available but Node.js is installed.
 
         Use -Dev to force legacy Electron dev mode even when Docker is available.
+
+        Before launching, the local data repository (and, in dev mode, the code
+        repository) is synced with GitHub via a fast-forward-only pull. If GitHub
+        is unreachable or local history has diverged, a warning is shown and the
+        launch proceeds with the local copy.
     .PARAMETER Port
         Port for the web server. Default: 7862.
     .PARAMETER DataPath
@@ -334,6 +339,12 @@ function Show-TaxonomyEditor {
         }
     }
 
+    # ── Keep the local data repo current with GitHub (t/2478) ────────────────
+    if ($ResolvedData -and (Test-Path (Join-Path $ResolvedData '.git'))) {
+        Write-Step 'Syncing data repository with GitHub'
+        $null = Update-GitRepository -Path $ResolvedData -Label 'data repository'
+    }
+
     # ── Launch container ─────────────────────────────────────────────────────
     Start-ContainerMode -Port $Port -DataPath $DataPath -NoBrowser:$NoBrowser `
         -Pull:$Pull -Detach:$Detach
@@ -361,6 +372,17 @@ function Start-LegacyElectronMode {
     if (-not (Test-Path $AppDir)) {
         Write-Fail "App directory not found: $AppDir"
         return
+    }
+
+    # ── Keep local repos current with GitHub (t/2478) ─────────────────────
+    # Dev mode builds from source, so the code repo matters here too.
+    Write-Step 'Syncing code repository with GitHub'
+    $null = Update-GitRepository -Path $CodeRoot -Label 'code repository'
+    $DevDataRoot = $null
+    try { $DevDataRoot = Get-DataRoot } catch { $DevDataRoot = $null }
+    if ($DevDataRoot -and (Test-Path (Join-Path $DevDataRoot '.git'))) {
+        Write-Step 'Syncing data repository with GitHub'
+        $null = Update-GitRepository -Path $DevDataRoot -Label 'data repository'
     }
 
     # Check data

--- a/tests/Update-GitRepository.Tests.ps1
+++ b/tests/Update-GitRepository.Tests.ps1
@@ -1,0 +1,117 @@
+# Tag: unit (t/2478)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Update-GitRepository, the launch-path repo sync used by
+    Show-TaxonomyEditor (t/2478).
+.DESCRIPTION
+    Exercises the helper against real temporary git repositories (bare origin +
+    clones) rather than mocks, because the contract under test is git's actual
+    fast-forward semantics: applies new origin commits, no-ops when current,
+    and never throws when the directory is not a repo or history has diverged —
+    launch must always proceed.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue -ErrorAction Stop
+}
+
+Describe 'Update-GitRepository' -Tag 'unit' {
+
+    BeforeEach {
+        $script:Root = Join-Path ([System.IO.Path]::GetTempPath()) "ugr-test-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        New-Item -ItemType Directory -Path $script:Root -Force | Out-Null
+
+        # Bare origin + a seed clone that pushes the initial commit.
+        $script:Bare = Join-Path $script:Root 'origin.git'
+        git init --bare --initial-branch=main $script:Bare 2>&1 | Out-Null
+
+        $script:Seed = Join-Path $script:Root 'seed'
+        git clone $script:Bare $script:Seed 2>&1 | Out-Null
+        Push-Location $script:Seed
+        git config user.email 'test@test.local'
+        git config user.name 'test'
+        Set-Content -Path 'file.txt' -Value 'v1'
+        git add file.txt 2>&1 | Out-Null
+        git commit -m 'v1' 2>&1 | Out-Null
+        git push origin HEAD:main 2>&1 | Out-Null
+        Pop-Location
+
+        # The clone under test.
+        $script:Local = Join-Path $script:Root 'local'
+        git clone $script:Bare $script:Local 2>&1 | Out-Null
+        Push-Location $script:Local
+        git config user.email 'test@test.local'
+        git config user.name 'test'
+        Pop-Location
+    }
+
+    AfterEach {
+        if (Test-Path $script:Root) {
+            Remove-Item $script:Root -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'fast-forwards the local clone when origin has new commits' {
+        Push-Location $script:Seed
+        Set-Content -Path 'file.txt' -Value 'v2'
+        git commit -am 'v2' 2>&1 | Out-Null
+        git push origin HEAD:main 2>&1 | Out-Null
+        Pop-Location
+
+        $Result = InModuleScope AITriad -Parameters @{ P = $script:Local } {
+            param($P)
+            Update-GitRepository -Path $P -Label 'test repository'
+        }
+
+        $Result | Should -BeTrue
+        Get-Content (Join-Path $script:Local 'file.txt') | Should -Be 'v2'
+    }
+
+    It 'returns $true when already up to date' {
+        $Result = InModuleScope AITriad -Parameters @{ P = $script:Local } {
+            param($P)
+            Update-GitRepository -Path $P -Label 'test repository'
+        }
+        $Result | Should -BeTrue
+    }
+
+    It 'returns $false and does not throw for a directory that is not a git repo' {
+        $Plain = Join-Path $script:Root 'plain'
+        New-Item -ItemType Directory -Path $Plain -Force | Out-Null
+
+        $Result = InModuleScope AITriad -Parameters @{ P = $Plain } {
+            param($P)
+            Update-GitRepository -Path $P -Label 'test repository'
+        }
+        $Result | Should -BeFalse
+    }
+
+    It 'returns $false and does not throw when local history has diverged (no fast-forward)' {
+        # Local-only commit...
+        Push-Location $script:Local
+        Set-Content -Path 'file.txt' -Value 'local-change'
+        git commit -am 'local divergence' 2>&1 | Out-Null
+        Pop-Location
+        # ...while origin advances separately.
+        Push-Location $script:Seed
+        Set-Content -Path 'file.txt' -Value 'remote-change'
+        git commit -am 'remote divergence' 2>&1 | Out-Null
+        git push origin HEAD:main 2>&1 | Out-Null
+        Pop-Location
+
+        $Result = InModuleScope AITriad -Parameters @{ P = $script:Local } {
+            param($P)
+            Update-GitRepository -Path $P -Label 'test repository'
+        }
+
+        $Result | Should -BeFalse
+        # Local work is untouched — the helper must never discard changes.
+        Get-Content (Join-Path $script:Local 'file.txt') | Should -Be 'local-change'
+    }
+}


### PR DESCRIPTION
## Summary

PI direct request (t/2478): `Show-TaxonomyEditor` now always ensures the local repo(s) have the latest changes from GitHub before launching.

- New `scripts/AITriad/Private/Update-GitRepository.ps1` — `git fetch origin` + `git pull --ff-only`, never throws: unreachable GitHub / missing git / diverged local history warns and continues with the local copy. Local work is never discarded.
- Container mode: syncs the data repository (ai-triad-data) when it is a git clone.
- Dev mode: syncs the code repository (builds from source) and the data repository.
- Docker image freshness unchanged (`-Pull` already covers the image).
- Help text updated.

## Tests

- `tests/Update-GitRepository.Tests.ps1` — 4 Pester tests against real temp bare+clone repos: fast-forward applied, already-up-to-date, non-repo no-throw, diverged-history no-throw with local work preserved.
- Full local gates: `Invoke-Pester ./tests/` 1066 passed / 0 failed (keys unset); `Test-ModuleManifest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)