### PR TITLE
feat(chat): FR observability for urlContext gating decision (t/2480)

### DIFF
--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -68,6 +68,7 @@ export type EventType =
   // Chat
   | 'chat.user-message'
   | 'chat.thinking-stripped'
+  | 'chat.url-context-decision'
   // User interaction
   | 'user.action'
   | 'ui.navigate'

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -422,7 +422,21 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       const model = getConfiguredModel();
       const temperature = CHAT_MODE_TEMPERATURE[activeChat.mode];
 
-      const urlContext = URL_PATTERN.test(message.trim()) && backendForModel(model) === 'gemini';
+      const urlDetected = URL_PATTERN.test(message.trim());
+      const urlContext = urlDetected && backendForModel(model) === 'gemini';
+      getGlobalRecorder()?.record({
+        type: 'chat.url-context-decision',
+        component: 'chat-store',
+        level: 'info',
+        message: 'URL context gating decision',
+        data: {
+          url_detected: urlDetected,
+          url_context_enabled: urlContext,
+          gating_reason: !urlDetected ? 'no-url' : urlContext ? 'enabled' : 'model-not-capable',
+          ingestion_path: urlContext ? 'provider' : 'none',
+          model,
+        },
+      });
       const systemInstruction = chatSystemPrompt(
         info.label, info.pov, info.personality,
         activeChat.mode, activeChat.topic, taxonomyBlock,


### PR DESCRIPTION
## Summary

- Records `chat.url-context-decision` flight-recorder event on every `sendMessage`: `url_detected`, `url_context_enabled`, `gating_reason` (`no-url`|`enabled`|`model-not-capable`), `ingestion_path` (`provider`|`none`), `model`
- Adds `'chat.url-context-decision'` to `EventType` union in `lib/flight-recorder/types.ts`
- `ingestion_path` is forward-compatible: t/2485 adds `'app-fetch'` value

Closes t/2480 item 2. Item 1 (Gemini-only hint) dropped per t/2480#2 — superseded by t/2485.

## Test plan

- [x] `check-renderer-tsc.sh` — 0 errors
- [x] `vitest run src/renderer/components/chat/` — 68/68 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)