### PR TITLE
feat(lib): SSRF-guarded fetchUrlForPrompt utility (t/2482)

### DIFF
--- a/lib/url-fetch/extractHttpUrls.ts
+++ b/lib/url-fetch/extractHttpUrls.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Pure, renderer-safe HTTP URL extraction (t/2483#2).
+ * Zero node:* imports — importable from server, Electron main, and renderer alike.
+ * Direct import path only; not re-exported from any barrel.
+ */
+
+const HTTP_URL_RE = /https?:\/\/[^\s<>"')\]]+/gi;
+
+/**
+ * Extract unique http/https URLs from a block of text.
+ * @param text  Input text (chat message, prompt, etc.)
+ * @param max   Maximum number of URLs to return. Default: 10.
+ */
+export function extractHttpUrls(text: string, max = 10): string[] {
+  const seen = new Set<string>();
+  const results: string[] = [];
+  let match: RegExpExecArray | null;
+  HTTP_URL_RE.lastIndex = 0;
+  while ((match = HTTP_URL_RE.exec(text)) !== null) {
+    const url = match[0].replace(/[.,;:!?]+$/, ''); // strip trailing punctuation
+    if (!seen.has(url)) {
+      seen.add(url);
+      results.push(url);
+      if (results.length >= max) break;
+    }
+  }
+  return results;
+}

--- a/lib/url-fetch/fetchUrlForPrompt.test.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.test.ts
@@ -293,4 +293,22 @@ describe('fetchUrlForPrompt', () => {
     if (result.ok) return;
     expect(result.reason).toBe('timeout');
   }, 5000);
+
+  // Pinning test: </script\t\n bar> — end-tag with whitespace+attribute — must be stripped.
+  // <\/script\s*> misses this (stops before "bar"); <\/script\b[^>]*> catches it.
+  it('strips script/style end-tags that contain whitespace and attributes', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      // The close tag </script\t\n bar> has whitespace+attribute before >
+      // If not stripped, "evil()" leaks into the prompt text
+      res.end('<html><body>safe<script>evil()</script\t\n bar>end</body></html>');
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.text).not.toContain('evil');
+    expect(result.text).toContain('safe');
+    expect(result.text).toContain('end');
+  });
 });

--- a/lib/url-fetch/fetchUrlForPrompt.test.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.test.ts
@@ -1,0 +1,296 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import * as http from 'node:http';
+import { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// contentSanitizerCore imports decode-named-character-reference which only exists in
+// taxonomy-editor/node_modules (not root). Mock it here so url-fetch tests don't
+// depend on the taxonomy-editor install; sanitization behavior is tested in the
+// server's own sanitizer test suite.
+vi.mock('../sanitize/contentSanitizerCore.js', () => ({
+  sanitizeText: (s: string) => s,
+}));
+import { fetchUrlForPrompt, isPrivateIp, normalizeIp } from './fetchUrlForPrompt.js';
+
+// All happy-path tests override checkAddress to allow 127.0.0.1 (our test server).
+// SSRF tests use the default isPrivateIp so 127.0.0.1 is naturally blocked.
+const ALLOW_ALL: (ip: string) => boolean = () => false;
+
+// ── Test server helpers ────────────────────────────────────────────────────
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+function startServer(handler: Handler): Promise<{ url: string; server: http.Server }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ url: `http://127.0.0.1:${port}`, server });
+    });
+    server.on('error', reject);
+  });
+}
+
+function stopServer(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+}
+
+// ── normalizeIp unit tests (TL change #4) ─────────────────────────────────
+
+describe('normalizeIp', () => {
+  it('passes through plain IPv4 unchanged', () => {
+    expect(normalizeIp('192.168.1.1')).toBe('192.168.1.1');
+  });
+
+  it('normalizes dotted-decimal mapped IPv6 to IPv4', () => {
+    expect(normalizeIp('::ffff:192.168.1.1')).toBe('192.168.1.1');
+    expect(normalizeIp('::FFFF:10.0.0.1')).toBe('10.0.0.1');
+  });
+
+  it('normalizes hex-word mapped IPv6 to IPv4', () => {
+    // ::ffff:c0a8:0101 → 192.168.1.1
+    expect(normalizeIp('::ffff:c0a8:0101')).toBe('192.168.1.1');
+    // ::ffff:7f00:0001 → 127.0.0.1
+    expect(normalizeIp('::ffff:7f00:0001')).toBe('127.0.0.1');
+  });
+
+  it('leaves non-mapped IPv6 unchanged', () => {
+    expect(normalizeIp('::1')).toBe('::1');
+    expect(normalizeIp('2001:db8::1')).toBe('2001:db8::1');
+  });
+});
+
+// ── isPrivateIp unit tests (TL change #4 — via normalizeIp) ───────────────
+
+describe('isPrivateIp', () => {
+  it('blocks loopback', () => {
+    expect(isPrivateIp('127.0.0.1')).toBe(true);
+    expect(isPrivateIp('127.255.255.255')).toBe(true);
+    expect(isPrivateIp('::1')).toBe(true);
+  });
+
+  it('blocks RFC-1918 ranges', () => {
+    expect(isPrivateIp('10.0.0.1')).toBe(true);
+    expect(isPrivateIp('172.16.0.1')).toBe(true);
+    expect(isPrivateIp('172.31.255.255')).toBe(true);
+    expect(isPrivateIp('192.168.0.1')).toBe(true);
+  });
+
+  it('blocks link-local / metadata endpoint', () => {
+    expect(isPrivateIp('169.254.169.254')).toBe(true);
+    expect(isPrivateIp('169.254.0.1')).toBe(true);
+  });
+
+  it('blocks CGNAT 100.64/10', () => {
+    expect(isPrivateIp('100.64.0.1')).toBe(true);
+    expect(isPrivateIp('100.127.255.255')).toBe(true);
+  });
+
+  it('allows public IPs', () => {
+    expect(isPrivateIp('8.8.8.8')).toBe(false);
+    expect(isPrivateIp('1.1.1.1')).toBe(false);
+    expect(isPrivateIp('93.184.216.34')).toBe(false);
+  });
+
+  it('blocks IPv4-mapped IPv6 loopback after normalization', () => {
+    expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateIp('::ffff:7f00:0001')).toBe(true);
+  });
+
+  it('blocks IPv4-mapped IPv6 RFC-1918 after normalization', () => {
+    expect(isPrivateIp('::ffff:c0a8:0101')).toBe(true);  // 192.168.1.1
+    expect(isPrivateIp('::ffff:10.0.0.1')).toBe(true);
+  });
+});
+
+// ── fetchUrlForPrompt integration tests ───────────────────────────────────
+
+describe('fetchUrlForPrompt', () => {
+  let server: http.Server | undefined;
+  let baseUrl: string;
+
+  afterEach(async () => {
+    if (server) {
+      await stopServer(server);
+      server = undefined;
+    }
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────
+
+  it('fetches plain text and returns trimmed content', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('  Hello world  ');
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.text).toContain('Hello world');
+    expect(result.finalUrl).toBe(baseUrl);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('fetches HTML, extracts title and strips tags', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><head><title>Test Page</title></head><body><p>Hello <b>world</b></p></body></html>');
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.title).toBe('Test Page');
+    expect(result.text).toContain('Hello');
+    expect(result.text).toContain('world');
+    expect(result.text).not.toContain('<b>');
+  });
+
+  it('follows redirects and returns finalUrl', async () => {
+    ({ url: baseUrl, server } = await startServer((req, res) => {
+      if (req.url === '/') {
+        res.writeHead(301, { Location: '/dest' });
+        res.end();
+      } else {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('redirected');
+      }
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.finalUrl).toContain('/dest');
+    expect(result.text).toContain('redirected');
+  });
+
+  it('applies tokenBudget truncation', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ABCDEFGHIJ');
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL, tokenBudget: 5 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.text).toBe('ABCDE');
+    expect(result.truncated).toBe(true);
+  });
+
+  // ── SSRF blocking ─────────────────────────────────────────────────────
+
+  it('blocks loopback via default isPrivateIp (no checkAddress override)', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('should not reach');
+    }));
+    // No checkAddress override — 127.0.0.1 is blocked by default isPrivateIp
+    const result = await fetchUrlForPrompt(baseUrl);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('ssrf-blocked');
+  });
+
+  it('blocks when injectable checkAddress returns true for resolved IP', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('blocked');
+    }));
+    // Inject a predicate that blocks everything regardless
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: () => true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('ssrf-blocked');
+  });
+
+  // ── Error cases ───────────────────────────────────────────────────────
+
+  it('returns http-error for non-2xx status', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found');
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('http-error');
+  });
+
+  it('returns unsupported-content for non-text content-type', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/pdf' });
+      res.end('%PDF');
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('unsupported-content');
+  });
+
+  it('returns too-many-redirects after redirect cap (TL change #5)', async () => {
+    ({ url: baseUrl, server } = await startServer((req, res) => {
+      // Always redirect to /next, regardless of path — infinite loop
+      res.writeHead(302, { Location: `${baseUrl}/next` });
+      res.end();
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL, maxRedirects: 2 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('too-many-redirects');
+  });
+
+  it('returns too-large when Content-Length exceeds maxBytes', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, {
+        'Content-Type': 'text/plain',
+        'Content-Length': '1000000',
+      });
+      res.end('x');
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL, maxBytes: 100 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('too-large');
+  });
+
+  it('aborts mid-stream when body exceeds maxBytes (TL change #3)', async () => {
+    // Server streams 200 bytes in two chunks of 150 each; maxBytes = 100
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      // No Content-Length — so the pre-check won't catch it; the streaming counter must
+      res.write('A'.repeat(60));
+      res.write('B'.repeat(60));
+      res.end('C'.repeat(60));
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL, maxBytes: 100 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('too-large');
+  });
+
+  it('returns network for an invalid URL scheme', async () => {
+    const result = await fetchUrlForPrompt('ftp://example.com/file', { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('network');
+  });
+
+  it('returns timeout when server hangs beyond timeoutMs', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, _res) => {
+      // Never respond — simulate a hung server
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL, timeoutMs: 100 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('timeout');
+  }, 5000);
+});

--- a/lib/url-fetch/fetchUrlForPrompt.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.ts
@@ -182,8 +182,8 @@ function htmlToText(html: string): { text: string; title: string | undefined } {
 
   let text = html
     .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, '')
-    .replace(/<script\b[\s\S]*?<\/script\s*>/gi, ' ')
-    .replace(/<style\b[\s\S]*?<\/style\s*>/gi, ' ')
+    .replace(/<script\b[\s\S]*?<\/script\b[^>]*>/gi, ' ')
+    .replace(/<style\b[\s\S]*?<\/style\b[^>]*>/gi, ' ')
     .replace(/<(?:br|\/p|\/div|\/h[1-6]|\/li|\/tr|\/blockquote)[^>]*>/gi, '\n')
     .replace(/<[^>]+>/g, ' ');
 

--- a/lib/url-fetch/fetchUrlForPrompt.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.ts
@@ -164,15 +164,16 @@ function readBody(res: http.IncomingMessage, maxBytes: number): Promise<string |
 // ── HTML → plain text ──────────────────────────────────────────────────────
 
 function decodeBasicEntities(s: string): string {
+  // Numeric refs first, then named, then &amp; LAST — prevents &amp;lt; double-unescaping to <
   return s
-    .replace(/&amp;/gi, '&')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(parseInt(n, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
     .replace(/&lt;/gi, '<')
     .replace(/&gt;/gi, '>')
     .replace(/&quot;/gi, '"')
     .replace(/&apos;/gi, "'")
     .replace(/&nbsp;/gi, ' ')
-    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(parseInt(n, 10)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)));
+    .replace(/&amp;/gi, '&');
 }
 
 function htmlToText(html: string): { text: string; title: string | undefined } {
@@ -181,8 +182,8 @@ function htmlToText(html: string): { text: string; title: string | undefined } {
 
   let text = html
     .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, '')
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script\b[\s\S]*?<\/script\s*>/gi, ' ')
+    .replace(/<style\b[\s\S]*?<\/style\s*>/gi, ' ')
     .replace(/<(?:br|\/p|\/div|\/h[1-6]|\/li|\/tr|\/blockquote)[^>]*>/gi, '\n')
     .replace(/<[^>]+>/g, ' ');
 

--- a/lib/url-fetch/fetchUrlForPrompt.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.ts
@@ -1,0 +1,306 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * SSRF-guarded URL fetch for prompt grounding (t/2482).
+ *
+ * Security design — all 5 TL-required changes implemented (t/2482#2):
+ *
+ * 1. INJECTABLE checkAddress PREDICATE — UrlFetchOptions.checkAddress replaces a
+ *    hardcoded isPrivateIp call so tests can pass `() => false` to allow a localhost
+ *    server without needing to mock dns.lookup. Default = isPrivateIp.
+ *
+ * 2. IP-PINNED REQUESTS (closes DNS-rebind TOCTOU) — requests use node:http /
+ *    node:https with `host: resolvedIp` (connect to the IP we just validated),
+ *    `servername: hostname` (SNI + cert validation against original hostname), and
+ *    `Host: hostname` header (correct HTTP/1.1 virtual hosting). This prevents the
+ *    window between DNS pre-check and TCP connect where a rebind can swap the IP.
+ *
+ * 3. MID-STREAM maxBytes ABORT — Content-Length is pre-checked before streaming
+ *    begins; the body reader also maintains a running byte counter and calls
+ *    res.destroy() + resolves null the moment it crosses maxBytes, so oversized
+ *    responses never fully buffer.
+ *
+ * 4. IPv4-MAPPED IPv6 NORMALIZATION — addresses like `::ffff:127.0.0.1` or
+ *    `::ffff:c0a8:0101` are normalized to their IPv4 equivalents before the
+ *    private-range checks, preventing a bypass via the dual-stack representation.
+ *
+ * 5. too-many-redirects IS A DISTINCT REASON — redirect cap exhaustion returns
+ *    `{ ok: false, reason: 'too-many-redirects' }` rather than 'network', so
+ *    callers can surface a precise message and telemetry can distinguish redirect
+ *    loops from hard connectivity failures.
+ *
+ * Node-only: imports node:dns, node:http, node:https. Never export through a barrel
+ * that the renderer can reach — direct import path only.
+ */
+
+import { promises as dns } from 'node:dns';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import { sanitizeText } from '../sanitize/contentSanitizerCore.js';
+import type { UrlFetchOptions, UrlFetchResult } from './types.js';
+
+const DEFAULT_MAX_BYTES = 1_572_864; // 1.5 MB
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_REDIRECTS = 5;
+
+// ── IP normalization + private-range check ─────────────────────────────────
+
+/**
+ * Normalize an IPv4-mapped IPv6 address to its IPv4 form.
+ * TL change #4: `::ffff:a.b.c.d` (dotted-decimal) and `::ffff:XXYY:ZZWW`
+ * (hex-word) both collapse to `a.b.c.d` before range checks so dual-stack
+ * representations cannot bypass the RFC-1918 / loopback blocks.
+ */
+export function normalizeIp(ip: string): string {
+  // Dotted-decimal form: ::ffff:192.168.1.1
+  const dotted = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i.exec(ip);
+  if (dotted) return dotted[1];
+  // Hex-word form: ::ffff:c0a8:0101  (two 16-bit hex groups)
+  const hexWord = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(ip);
+  if (hexWord) {
+    const hi = parseInt(hexWord[1], 16);
+    const lo = parseInt(hexWord[2], 16);
+    return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+  }
+  return ip;
+}
+
+/** Returns true when the (already-normalized) IP should be blocked. */
+export function isPrivateIp(ip: string): boolean {
+  const norm = normalizeIp(ip);
+
+  // IPv4 range checks
+  const parts = norm.split('.');
+  if (parts.length === 4) {
+    const [a, b, c] = parts.map(Number);
+    if (a === 127) return true;                            // loopback
+    if (a === 10) return true;                             // RFC-1918 10/8
+    if (a === 172 && b >= 16 && b <= 31) return true;    // RFC-1918 172.16/12
+    if (a === 192 && b === 168) return true;              // RFC-1918 192.168/16
+    if (a === 169 && b === 254) return true;              // link-local / metadata
+    if (a === 0) return true;                              // unspecified
+    if (a === 100 && (b & 0xc0) === 64) return true;     // CGNAT 100.64/10
+    if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+    if (a === 192 && b === 0 && c === 2) return true;    // TEST-NET-1
+    if (a === 255) return true;                            // broadcast
+    return false;
+  }
+
+  // IPv6 checks (after normalization, mapped addresses are already IPv4 above)
+  const lower = norm.toLowerCase();
+  if (lower === '::1') return true;                 // loopback
+  if (lower === '::') return true;                  // unspecified
+  if (lower.startsWith('fe80:')) return true;       // link-local
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // ULA
+  if (lower.startsWith('ff')) return true;          // multicast
+  if (lower.startsWith('64:ff9b:')) return true;   // NAT64
+  return false;
+}
+
+// ── IP-pinned HTTP request (TL change #2) ─────────────────────────────────
+
+function makeRequest(
+  resolvedIp: string,
+  hostname: string,
+  port: number,
+  path: string,
+  isHttps: boolean,
+  timeoutMs: number,
+): Promise<http.IncomingMessage> {
+  return new Promise((resolve, reject) => {
+    let timedOut = false;
+    const options: http.RequestOptions & https.RequestOptions = {
+      method: 'GET',
+      host: resolvedIp,       // connect to the pre-validated IP — closes rebind TOCTOU
+      servername: hostname,   // SNI for TLS + certificate CN/SAN validation
+      port,
+      path,
+      headers: {
+        'Host': hostname,     // correct HTTP/1.1 virtual-host routing
+        'User-Agent': 'AI-Triad-Research/1.0 (url-fetch)',
+        'Accept': 'text/html, text/plain;q=0.9, */*;q=0.1',
+        'Accept-Encoding': 'identity', // avoid gzip complications
+      },
+    };
+    const lib = isHttps ? https : http;
+    const req = lib.request(options, resolve);
+    req.setTimeout(timeoutMs, () => {
+      timedOut = true;
+      req.destroy();
+    });
+    req.on('error', err => {
+      if (timedOut) reject(Object.assign(new Error('timeout'), { isTimeout: true }));
+      else reject(err);
+    });
+    req.end();
+  });
+}
+
+// ── Streaming body reader with mid-stream abort (TL change #3) ────────────
+
+function readBody(res: http.IncomingMessage, maxBytes: number): Promise<string | null> {
+  return new Promise(resolve => {
+    let settled = false;
+    const done = (val: string | null) => { if (!settled) { settled = true; resolve(val); } };
+    const chunks: Buffer[] = [];
+    let total = 0;
+    res.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        res.destroy(); // abort mid-stream immediately
+        done(null);
+        return;
+      }
+      chunks.push(chunk);
+    });
+    res.on('end', () => done(Buffer.concat(chunks).toString('utf-8')));
+    res.on('error', () => done(null));
+    // destroy() triggers 'close' but not 'end' — ensure we resolve
+    res.on('close', () => done(null));
+  });
+}
+
+// ── HTML → plain text ──────────────────────────────────────────────────────
+
+function decodeBasicEntities(s: string): string {
+  return s
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'")
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(parseInt(n, 10)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)));
+}
+
+function htmlToText(html: string): { text: string; title: string | undefined } {
+  const titleMatch = /<title[^>]*>([^<]*)<\/title>/i.exec(html);
+  const title = titleMatch ? decodeBasicEntities(titleMatch[1].trim()) : undefined;
+
+  let text = html
+    .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, '')
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<(?:br|\/p|\/div|\/h[1-6]|\/li|\/tr|\/blockquote)[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+
+  text = decodeBasicEntities(text)
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n[ \t]+/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  return { text, title };
+}
+
+// ── Main entry point ───────────────────────────────────────────────────────
+
+export async function fetchUrlForPrompt(
+  url: string,
+  opts: UrlFetchOptions = {},
+): Promise<UrlFetchResult> {
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxRedirects = opts.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const checkAddress = opts.checkAddress ?? isPrivateIp; // TL change #1
+
+  let currentUrl = url;
+  let redirectCount = 0;
+
+  for (;;) {
+    let parsed: URL;
+    try {
+      parsed = new URL(currentUrl);
+    } catch {
+      return { ok: false, reason: 'network' };
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return { ok: false, reason: 'network' };
+    }
+
+    const isHttps = parsed.protocol === 'https:';
+    const hostname = parsed.hostname;
+    const port = parsed.port ? parseInt(parsed.port, 10) : (isHttps ? 443 : 80);
+    const path = (parsed.pathname || '/') + parsed.search;
+
+    // DNS pre-resolution + SSRF check (TL changes #1, #4)
+    let resolvedIp: string;
+    try {
+      const addrs = await dns.lookup(hostname, { all: true });
+      if (!addrs.length) return { ok: false, reason: 'network' };
+      // Normalize each address (IPv4-mapped IPv6) then apply the check
+      const firstAllowed = addrs.find(a => !checkAddress(normalizeIp(a.address)));
+      if (!firstAllowed) return { ok: false, reason: 'ssrf-blocked' };
+      resolvedIp = firstAllowed.address;
+    } catch {
+      return { ok: false, reason: 'network' };
+    }
+
+    // IP-pinned request (TL change #2)
+    let res: http.IncomingMessage;
+    try {
+      res = await makeRequest(resolvedIp, hostname, port, path, isHttps, timeoutMs);
+    } catch (err) {
+      if ((err as { isTimeout?: boolean }).isTimeout) return { ok: false, reason: 'timeout' };
+      return { ok: false, reason: 'network' };
+    }
+
+    // Redirect handling (TL change #5 — distinct reason)
+    if (res.statusCode !== undefined && res.statusCode >= 300 && res.statusCode < 400) {
+      const location = res.headers.location;
+      res.destroy();
+      if (!location) return { ok: false, reason: 'network' };
+      if (redirectCount >= maxRedirects) return { ok: false, reason: 'too-many-redirects' };
+      redirectCount++;
+      try {
+        currentUrl = new URL(location, currentUrl).href;
+      } catch {
+        return { ok: false, reason: 'network' };
+      }
+      continue;
+    }
+
+    // HTTP errors
+    if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+      res.destroy();
+      return { ok: false, reason: 'http-error' };
+    }
+
+    // Content-Type gate — only fetch text (HTML or plain)
+    const contentType = res.headers['content-type'] ?? '';
+    const isHtml = contentType.includes('text/html');
+    const isText = contentType.includes('text/plain');
+    if (!isHtml && !isText) {
+      res.destroy();
+      return { ok: false, reason: 'unsupported-content' };
+    }
+
+    // Content-Length pre-check (TL change #3 — first half)
+    const clHeader = res.headers['content-length'];
+    if (clHeader !== undefined && parseInt(clHeader, 10) > maxBytes) {
+      res.destroy();
+      return { ok: false, reason: 'too-large' };
+    }
+
+    // Stream with mid-stream abort (TL change #3 — second half)
+    const raw = await readBody(res, maxBytes);
+    if (raw === null) return { ok: false, reason: 'too-large' };
+
+    // HTML → text, then XSS safety pass via shared core
+    const { text: extracted, title } = isHtml ? htmlToText(raw) : { text: raw, title: undefined };
+    const safe = sanitizeText(extracted);
+
+    // Soft token-budget truncation
+    let text = safe;
+    let truncated = false;
+    if (opts.tokenBudget !== undefined && text.length > opts.tokenBudget) {
+      text = text.slice(0, opts.tokenBudget);
+      truncated = true;
+    }
+
+    return { ok: true, text, title, finalUrl: currentUrl, truncated };
+  }
+}

--- a/lib/url-fetch/types.ts
+++ b/lib/url-fetch/types.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Result types for SSRF-guarded URL fetching (t/2482).
+ * Node-only module — direct import path, never via a shared barrel
+ * (barrels that the renderer can reach must not pull in node:http/node:dns).
+ */
+
+export type UrlFetchFailureReason =
+  | 'ssrf-blocked'
+  | 'timeout'
+  | 'too-large'
+  | 'http-error'
+  | 'unsupported-content'
+  | 'network'
+  | 'too-many-redirects';
+
+export type UrlFetchResult =
+  | { ok: true; text: string; title: string | undefined; finalUrl: string; truncated: boolean }
+  | { ok: false; reason: UrlFetchFailureReason };
+
+export interface UrlFetchOptions {
+  /** Max response body size in bytes before abort. Default: 1.5 MB. */
+  maxBytes?: number;
+  /** Total request timeout in milliseconds. Default: 10 000. */
+  timeoutMs?: number;
+  /** Max redirect hops to follow. Default: 5. */
+  maxRedirects?: number;
+  /** Soft character budget: truncates extracted text to this length when set. */
+  tokenBudget?: number;
+  /**
+   * Predicate that returns true when an IP address should be blocked (private/SSRF).
+   * Default: internal isPrivateIp (blocks RFC-1918, loopback, link-local, CGNAT, etc.).
+   * Tests override this to return false so a localhost test server is reachable.
+   */
+  checkAddress?: (ip: string) => boolean;
+}


### PR DESCRIPTION
## Summary

- New `lib/url-fetch/` module: `types.ts` (types-first commit) + `fetchUrlForPrompt.ts` + `fetchUrlForPrompt.test.ts`
- SSRF-guarded URL fetch for prompt grounding — all models can now fetch URL content before sending to AI (blocks t/2483 ServerAPI, t/2484 ElectronMain)

## All 5 TL-required changes (t/2482#2) implemented

1. **Injectable `checkAddress` predicate** — `UrlFetchOptions.checkAddress?: (ip: string) => boolean` (default = `isPrivateIp`); tests override to allow localhost without mocking `dns.lookup`
2. **IP-pinned requests** — `node:http`/`node:https` with `host: resolvedIp`, `servername: hostname` (SNI), `Host: hostname` header; closes DNS-rebind TOCTOU window
3. **Mid-stream `maxBytes` abort** — Content-Length pre-check + streaming byte counter with `res.destroy()` on overflow
4. **IPv4-mapped IPv6 normalization** — `::ffff:a.b.c.d` (dotted) and `::ffff:XXYY:ZZWW` (hex-word) → IPv4 before all range checks
5. **`too-many-redirects` as distinct reason** — redirect cap exhaustion is a separate `UrlFetchFailureReason` value, not overloaded into `'network'`

## Test plan

- 24/24 passing: `normalizeIp` unit (4), `isPrivateIp` unit (7, incl. mapped-IPv6 normalization), integration (13)
- Integration covers: plain text fetch, HTML title extraction + tag stripping, redirect following, `tokenBudget` truncation, SSRF block (default + injectable), HTTP error, unsupported content-type, too-many-redirects, too-large (Content-Length pre-check), mid-stream abort, invalid scheme, timeout
- `sanitizeText` mocked in tests (package only in `taxonomy-editor/node_modules`); XSS sanitization tested by the server's own suite

## Notes

- Node-only: direct import path only, never via a barrel the renderer can reach
- `isPrivateIp` and `normalizeIp` exported for unit testability

🤖 Generated with [Claude Code](https://claude.com/claude-code)
