### PR TITLE
chore(verify-config): wire registryCompleteness gate as 7th verify:config gate (t/2488)

### DIFF
--- a/scripts/Verify-Config.ps1
+++ b/scripts/Verify-Config.ps1
@@ -10,9 +10,9 @@
     the tests/ Pester suite). An agent editing the root config gets no local
     signal that those suites gate it — which is how a registry edit can go green
     locally and red in CI (t/1933). This script gives that edit a single local
-    command that runs all six gates and exits non-zero if any fails.
+    command that runs all seven gates and exits non-zero if any fails.
 
-    Six gates (see t/1950#1 for the corrected inventory):
+    Seven gates (see t/1950#1 for the original inventory; t/2486 adds gate 7):
       Pester (run directly):
         - tests/Test-AIModelsConfig.Tests.ps1   config gate
         - tests/ModelLiteralLint.Tests.ps1      -Model literals name registered models
@@ -21,14 +21,15 @@
         - taxonomy-editor/src/main/__tests__/modelConfigCache.test.ts   id->apiId map
         - lib/debate/__tests__/configInvariant.test.ts                  fallbackChain / default invariants
         - lib/electron-shared/modelDiscovery.test.ts                    model discovery
+        - taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/__tests__/registryCompleteness.test.ts   renderer accessor-chain completeness
 
     The vitest half is the fiddly part. taxonomy-editor's vitest include-globs
     are relative to taxonomy-editor/src/renderer, so passing repo-root-relative
     paths as filters silently matches ZERO tests and exits 0 — a false green that
     looks exactly like success (t/1950#1). This script defends against that by:
       1. filtering with bare basenames (CWD-independent substring match), and
-      2. verifying `vitest list` collects EXACTLY the four expected files before
-         running — a collected count other than four is a FAILURE, not success.
+      2. verifying `vitest list` collects EXACTLY the five expected files before
+         running — a collected count other than five is a FAILURE, not success.
 .EXAMPLE
     npm run verify:config
 .EXAMPLE
@@ -55,10 +56,11 @@ $TaxEditor  = Join-Path $RepoRoot 'taxonomy-editor'
 # collected file's path. Fragments are specific enough to detect a basename
 # collision (a stray same-named test elsewhere would list under a different path).
 $VitestGates = [ordered]@{
-    'keysValidation'   = 'server/__tests__/keysValidation.test.ts'
-    'modelConfigCache'  = 'main/__tests__/modelConfigCache.test.ts'
-    'configInvariant'  = 'lib/debate/__tests__/configInvariant.test.ts'
-    'modelDiscovery'   = 'lib/electron-shared/modelDiscovery.test.ts'
+    'keysValidation'        = 'server/__tests__/keysValidation.test.ts'
+    'modelConfigCache'      = 'main/__tests__/modelConfigCache.test.ts'
+    'configInvariant'       = 'lib/debate/__tests__/configInvariant.test.ts'
+    'modelDiscovery'        = 'lib/electron-shared/modelDiscovery.test.ts'
+    'registryCompleteness'  = 'hooks/useTaxonomyStore/slices/__tests__/registryCompleteness.test.ts'
 }
 $PesterGates = @(
     (Join-Path $RepoRoot 'tests/Test-AIModelsConfig.Tests.ps1')
@@ -123,7 +125,7 @@ if (-not (Test-Path (Join-Path $TaxEditor 'node_modules'))) {
     Write-Host '  FAIL vitest — taxonomy-editor/node_modules is missing.' -ForegroundColor Red
     Write-Host '        Goal:  run the vitest registry gates' -ForegroundColor DarkYellow
     Write-Host "        Fix:   run 'pnpm install' in $TaxEditor, then re-run verify:config" -ForegroundColor DarkYellow
-    $Results['vitest:collection (4 files)'] = $false
+    $Results['vitest:collection (5 files)'] = $false
     $Results['vitest:run'] = $false
 }
 else {
@@ -150,16 +152,16 @@ else {
             $collectionOk = $false
         }
     }
-    $Results['vitest:collection (4 files)'] = $collectionOk
+    $Results['vitest:collection (5 files)'] = $collectionOk
 
     if ($collectionOk) {
         Write-Host "  PASS collection — all $($VitestGates.Count) gate files collected" -ForegroundColor Green
 
-        # Step 2 — RUN the four collected files.
+        # Step 2 — RUN the five collected files.
         & npm exec --silent -- vitest run @Filters
         $runOk = ($LASTEXITCODE -eq 0)
         if ($runOk) {
-            Write-Host "  PASS vitest run — all 4 gate suites green" -ForegroundColor Green
+            Write-Host "  PASS vitest run — all 5 gate suites green" -ForegroundColor Green
         } else {
             Write-Host "  FAIL vitest run — one or more suites failed (exit $LASTEXITCODE, see output above)" -ForegroundColor Red
         }
@@ -193,5 +195,5 @@ if ($failed.Count -gt 0) {
 }
 
 Write-Host ''
-Write-Host 'verify:config PASSED — all 6 registry gates green.' -ForegroundColor Green
+Write-Host 'verify:config PASSED — all 7 registry gates green.' -ForegroundColor Green
 exit 0


### PR DESCRIPTION
## Summary
- Adds `registryCompleteness.test.ts` (landed in #865 / t/2486) to `$VitestGates` in `Verify-Config.ps1`
- Bumps collection guard label and count literals 4→5
- Updates header comment and final success message to reflect 7 total gates

## Test plan
- [x] Pester suite: 1066 passed, 0 failed (run locally in worktree)
- [ ] CI vitest collection guard will confirm exactly 5 files are collected including the new renderer gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)