### PR TITLE
feat(auth): allow anonymous users to use AI chat via the free tier (t/2489)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/anonAiRoutes.test.ts
+++ b/taxonomy-editor/src/server/__tests__/anonAiRoutes.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+//
+// t/2489 — anonymous users may use AI chat via the free tier. The exemption is the
+// FREE_TIER_AI_POST_PATHS allowlist consumed by isFreeTierRoute (server.ts); the
+// anon_route_blocked guard stays for everything else. These assert the allowlist
+// membership directly (the pure half; the freeTierEnabled() gate is applied by the
+// caller) plus the negative arm: other AI routes are NOT exempt.
+
+import { describe, it, expect } from 'vitest';
+import { isFreeTierAiPath, FREE_TIER_AI_POST_PATHS } from '../anonAiRoutes.js';
+
+describe('t/2489 — free-tier AI route allowlist (anon chat exemption)', () => {
+  it('POST /api/ai/chat-stream is on the allowlist (the new anon-chat exemption)', () => {
+    expect(isFreeTierAiPath('POST', '/api/ai/chat-stream')).toBe(true);
+    expect(FREE_TIER_AI_POST_PATHS).toContain('/api/ai/chat-stream');
+  });
+
+  it('the pre-existing free-tier routes remain exempt (no regression)', () => {
+    expect(isFreeTierAiPath('POST', '/api/ai/generate')).toBe(true);
+    expect(isFreeTierAiPath('POST', '/api/embeddings/compute')).toBe(true);
+    expect(isFreeTierAiPath('POST', '/api/embeddings/query')).toBe(true);
+  });
+
+  // ── Negative arm (TL guardrail #1): other AI routes stay anon-blocked ──
+  it('other AI routes are NOT exempt — the anon block still applies to them', () => {
+    // These have cost/abuse/key surface and must keep returning anon_route_blocked.
+    expect(isFreeTierAiPath('POST', '/api/keys')).toBe(false);
+    expect(isFreeTierAiPath('POST', '/api/ai/embed')).toBe(false);
+    expect(isFreeTierAiPath('POST', '/api/nli/entail')).toBe(false);
+    expect(isFreeTierAiPath('POST', '/api/ai/generate-stream')).toBe(false);
+  });
+
+  it('exact-match only — a sibling sub-path of an allowlisted route is NOT exempt', () => {
+    // Prefix bleed would expose /api/ai/generate/x, /api/ai/chat-stream/x, etc.
+    expect(isFreeTierAiPath('POST', '/api/ai/chat-stream/x')).toBe(false);
+    expect(isFreeTierAiPath('POST', '/api/ai/generate/x')).toBe(false);
+    expect(isFreeTierAiPath('POST', '/api/ai/chat-streamX')).toBe(false);
+  });
+
+  it('method-scoped — only POST is exempt (GET/PUT/DELETE of the same path are not)', () => {
+    expect(isFreeTierAiPath('GET', '/api/ai/chat-stream')).toBe(false);
+    expect(isFreeTierAiPath('PUT', '/api/ai/chat-stream')).toBe(false);
+    expect(isFreeTierAiPath('DELETE', '/api/ai/generate')).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/server/anonAiRoutes.ts
+++ b/taxonomy-editor/src/server/anonAiRoutes.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2489: the explicit allowlist of AI POST routes that keyless (anonymous)
+// callers may reach in AUTH_OPTIONAL mode via the FREE tier, extracted from the
+// inline isFreeTierRoute in server.ts so it is unit-testable without booting the
+// HTTP server (server.ts calls server.listen() at import).
+//
+// This is an EXEMPTION, not a removal of the anon block (TL t/2489#1): a listed
+// route escapes the `anon_route_blocked` 403 ONLY when the free tier is enabled;
+// every other AI route stays blocked. Reaching the free tier is load-bearing for
+// safety — resolveTier('') pins the model to free-tier Gemini (paid model ids are
+// downgraded, never billed), enforces free-tier RPM + daily-token limits, and
+// isBackendAllowed rejects non-Gemini. Routing anon chat through here (not the
+// generic anon-allowlist) is what carries all of guardrail #2.
+//
+// Exact-match (===) is load-bearing (Server-Auth p/135#8) — never widen to a
+// prefix: a prefix would expose sibling AI routes (e.g. /api/ai/generate/x) to
+// keyless callers. Add a route here only with an auth-surface (TL) review.
+
+/** POST paths keyless callers may reach via the free tier (exact-match only). */
+export const FREE_TIER_AI_POST_PATHS: readonly string[] = [
+  '/api/ai/generate',
+  '/api/embeddings/compute',
+  '/api/embeddings/query',
+  '/api/ai/chat-stream', // t/2489: anonymous users may use AI chat (free-tier Gemini)
+];
+
+/**
+ * Whether `method urlPath` is a free-tier-exempt AI route. Callers additionally
+ * gate on `freeTierEnabled()` (a matched route is only exempt when the server has
+ * a free-tier key) — kept separate so the path membership is a pure function.
+ */
+export function isFreeTierAiPath(method: string, urlPath: string): boolean {
+  return method === 'POST' && FREE_TIER_AI_POST_PATHS.includes(urlPath);
+}

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -38,6 +38,7 @@ import { runWithUser, getCurrentUserId, setSessionBranchName, deriveStorageUserI
 import type { UserContext } from './security/userContext.js';
 import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, missingApiKeyError, anonymousSessionCookies, resolveAnonSessionId, resolveTestPersonaOverride } from './security/accessControl.js';
 import { sanitizeUserText } from './security/contentSanitizer.js';
+import { isFreeTierAiPath } from './anonAiRoutes.js';
 import { getRollbackStatus } from './rollbackStatus.js';
 import { getErrorSummaryCached, type ErrorEntry } from './errorAggregation.js';
 import { isCaseStatus } from './support/types.js';
@@ -936,13 +937,12 @@ interface AuthGateCtx {
   idp: string;
 }
 
-/** Free tier (t/793): keyless POSTs to the three AI/embeddings paths when configured.
- *  Exact-match (===) is load-bearing (Server-Auth p/135#8) — never widen to a prefix.
- *  Extracted verbatim from the two identical call sites. */
+/** Free tier (t/793): keyless POSTs to the allowlisted AI/embeddings paths when
+ *  configured. Path membership is the exact-match FREE_TIER_AI_POST_PATHS allowlist
+ *  (t/2489, extracted to anonAiRoutes.ts for unit testing); the `freeTierEnabled()`
+ *  gate keeps a matched route exempt only when the server has a free-tier key. */
 function isFreeTierRoute(method: string, urlPath: string): boolean {
-  return method === 'POST'
-    && (urlPath === '/api/ai/generate' || urlPath === '/api/embeddings/compute' || urlPath === '/api/embeddings/query')
-    && proxyTiers.freeTierEnabled();
+  return isFreeTierAiPath(method, urlPath) && proxyTiers.freeTierEnabled();
 }
 
 /** AUTH_OPTIONAL mode gate: show login page / 401 unless signed in or anonymous. */


### PR DESCRIPTION
## Summary

Fixes t/2489: anonymous users hit `403 anon_route_blocked` on `POST /api/ai/chat-stream`. This exempts chat-stream so keyless web users can use AI chat — **without** weakening the anon guard for anything else (TL guardrails t/2489#1/#3).

## Change

- Add `/api/ai/chat-stream` to the free-tier AI route allowlist, **extracted** from the inline `isFreeTierRoute` into `anonAiRoutes.ts` (`FREE_TIER_AI_POST_PATHS` + `isFreeTierAiPath`) so it is unit-testable without booting the server. `server.ts`'s `isFreeTierRoute` now delegates to it. **Exact-match only** — a sibling sub-path (`/api/ai/chat-stream/x`) is not exempt.
- **Exempt, not remove** (guardrail #1): the `anon_route_blocked` guard is untouched for every other route.

## Why the free-tier path (not accessControl's anon-allowlist)

Routing anon chat through the **free tier** is what enforces the entire anon-tier policy (guardrail #2), for free:
- `resolveTier('')` → free tier **pins Gemini** — a requested paid model id is downgraded, never billed (`serverProvidedKey` uses `FREE_TIER_GEMINI_KEY`, not paid/BYOK keys).
- free-tier **RPM + daily-token limits** apply, keyed **per-IP** (harder to evade than a session cookie — your t/2489#3 ruling).
- `isBackendAllowed(free, …)` rejects non-Gemini.

`accessControl`'s generic anon-allowlist would bypass this pinning → wrong for a billable route.

## Guardrail #3 (app-fetch off for anon)

Anon is structurally Gemini-pinned, so it never reaches the non-Gemini app-fetch branch; the t/2483 handler also gates app-fetch off for the free/anonymous tier explicitly. Anon keeps Gemini native `url_context` grounding.

## Preconditions / safety

- Inert without `FREE_TIER_GEMINI_KEY` (`freeTierEnabled()` gate): anon still gets no AI, graceful (no crash). Signed-in behaviour unchanged.
- **Cost posture** (per your note): this enables unauthenticated AI on the public URL, bounded by the free-tier per-IP quota + Gemini-only enforcement.

## Client cleanup

Raw ActionableError on 4xx + stale pre-saved empty session → split to **t/2491** (Chat scope), filed + Todo.

## Test plan

`src/server/__tests__/anonAiRoutes.test.ts`:
- [x] `/api/ai/chat-stream` exempt; pre-existing free-tier routes still exempt (no regression)
- [x] **negative arm** (guardrail #1): other AI routes (`/api/keys`, `/api/nli/*`, `/api/ai/generate-stream`) stay `anon_route_blocked`
- [x] exact-match (no sub-path bleed); POST-only
- [x] `tsc` clean; eslint clean; debateAnonAllowlist + accessControl + routeTable suites green (102 tests)

Design approved with guardrails by Main (TL) at **t/2489#1 / t/2489#3**. Routing to Main (TL) for the auth-surface pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
