### PR TITLE
fix(debate): auto-retry transient failures (timeout/5xx/network), not just 429 (t/2492)

### DIFF
--- a/lib/ai-client/retry.ts
+++ b/lib/ai-client/retry.ts
@@ -89,6 +89,11 @@ export async function withRetry<T>(
   label: string,
   onLog?: (msg: string) => void,
 ): Promise<T> {
+  // NOTE (t/2492): this is the low-level per-call AI-client retry layer. The renderer's
+  // user-facing debate/chat orchestration retry uses a separate, independent classifier at
+  // taxonomy-editor/src/renderer/utils/retryClassifier.ts — intentionally NOT shared (different
+  // layer, different budget). If you change the transient-retry set here, check whether that
+  // classifier wants the same, and vice versa.
   for (let attempt = 1; attempt <= config.maxRetries; attempt++) {
     try {
       return await fn();

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/crossSliceAndRegressions.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/crossSliceAndRegressions.test.ts
@@ -410,6 +410,64 @@ describe('runOpeningStatements — failure halts flow (t/920)', () => {
 
     vi.mocked(runOpeningPipeline).mockResolvedValue({});
   });
+
+  it('auto-retries on a transient TIMEOUT (no httpStatus), not just 429 (t/2492)', async () => {
+    const { runOpeningPipeline } = await import('@lib/debate/turnPipeline');
+    // The PI case: a ~3-min timeout with no httpStatus. Pre-fix this got 1 attempt + manual banner.
+    const timeoutError = Object.assign(new Error('Request timed out after 180s'), { name: 'AbortError' });
+    vi.mocked(runOpeningPipeline).mockRejectedValue(timeoutError);
+
+    const session = makeSession({
+      phase: 'opening',
+      active_povers: ['accelerationist'],
+      topic: { original: 'Test', refined: null, final: 'Test topic' },
+    });
+    useDebateStore.setState({ activeDebate: session as any, debateModel: 'gemini-2.0-flash' });
+
+    // Fake timers so the transient backoff (5s expo) flushes instantly instead of stalling the test.
+    vi.useFakeTimers();
+    try {
+      const run = useDebateStore.getState().runOpeningStatements();
+      await vi.runAllTimersAsync();
+      await run;
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // Auto-retry engaged (initial + at least one retry) — the honest banner appears only after the cap.
+    expect(vi.mocked(runOpeningPipeline).mock.calls.length).toBeGreaterThanOrEqual(2);
+    const state = useDebateStore.getState();
+    expect(state.debateError).toBeTruthy();
+    expect(state.debateGenerating).toBeNull();
+
+    vi.mocked(runOpeningPipeline).mockResolvedValue({});
+  });
+
+  it('does NOT retry a daily-limit error — immediate pause banner (t/2492)', async () => {
+    const { runOpeningPipeline } = await import('@lib/debate/turnPipeline');
+    const dailyLimitError = Object.assign(
+      new Error('Daily AI usage limit reached'),
+      { httpStatus: 429, limitType: 'tokens_per_day' },
+    );
+    vi.mocked(runOpeningPipeline).mockRejectedValue(dailyLimitError);
+
+    const session = makeSession({
+      phase: 'opening',
+      active_povers: ['accelerationist'],
+      topic: { original: 'Test', refined: null, final: 'Test topic' },
+    });
+    useDebateStore.setState({ activeDebate: session as any, debateModel: 'gemini-2.0-flash' });
+
+    await useDebateStore.getState().runOpeningStatements();
+
+    // Exactly one attempt — daily-limit halts immediately, no auto-retry.
+    expect(vi.mocked(runOpeningPipeline).mock.calls.length).toBe(1);
+    const state = useDebateStore.getState();
+    expect(state.dailyLimitPaused).toBe(true);
+    expect(state.debateError).toMatch(/Daily/i);
+
+    vi.mocked(runOpeningPipeline).mockResolvedValue({});
+  });
 });
 
 // ── Retry Action Tracking (t/953) ──────────────────────────

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -20,6 +20,7 @@ import { api, emitBriefTimeout, emitBriefRetriesExhausted } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { generateId, nowISO, parseAIJson, parsePoverResponse, formatRecentTranscript } from '@lib/debate/helpers';
 import { formatTaxonomyContext } from '../../../utils/taxonomyContext';
+import { classifyAiRetry, retryReasonLabel } from '../../../utils/retryClassifier';
 import { formatCommitments, formatEstablishedPoints } from '../../../prompts/argumentNetwork';
 import { formatVocabularyContext } from '@lib/debate/vocabularyContext';
 import {
@@ -872,17 +873,27 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
 
     console.log(`[debate-store] Opening statements: aiPovers=${JSON.stringify(aiPovers)}, existingOpenings=${JSON.stringify([...existingOpenings])}, resolvedOrder=${JSON.stringify(resolvedOrder)}`);
 
-    const MAX_OPENING_RETRIES = 1;
+    // Auto-retry policy (t/2492): transient failures (429 / 5xx / timeout / network) retry up to
+    // MAX_OPENING_RETRIES with expo backoff, bounded by a total-elapsed budget so a multi-minute
+    // timeout × N passes can't strand the user before the honest exhaustion banner.
+    const MAX_OPENING_RETRIES = 2;
+    const OPENING_RETRY_BUDGET_MS = 8 * 60 * 1000; // 8 min total across all passes
     const openingStartedAt = Date.now();
     let openingRetryPass = 0;
     let failedSpeakers: string[] = [];
     let hasRetryableFailure = false;
     let retryBackoffMs = 5000;
+    let lastRetryReason = retryReasonLabel('non_retryable');
 
     while (openingRetryPass <= MAX_OPENING_RETRIES) {
       if (openingRetryPass > 0) {
+        // Budget guard: don't launch another pass if we'd blow the total-elapsed budget.
+        if (Date.now() - openingStartedAt + retryBackoffMs > OPENING_RETRY_BUDGET_MS) {
+          console.log(`[debate-store] Opening retry budget (${OPENING_RETRY_BUDGET_MS}ms) exhausted — stopping`);
+          break;
+        }
         console.log(`[debate-store] Opening retry pass ${openingRetryPass} — waiting ${retryBackoffMs}ms`);
-        set({ debateActivity: `Rate-limited — retrying openings in ${Math.ceil(retryBackoffMs / 1000)}s...` });
+        set({ debateActivity: `A speaker ${lastRetryReason} — retrying openings in ${Math.ceil(retryBackoffMs / 1000)}s...` });
         await new Promise(resolve => setTimeout(resolve, retryBackoffMs));
         if (!isStillValid()) break;
       }
@@ -1094,9 +1105,10 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         }
       } catch (err) {
         const httpStatus = (err as { httpStatus?: number }).httpStatus;
-        const isRetryable = httpStatus === 429 && !isDailyLimitError(err);
-        console.error(`[debate] ${info.label} opening statement failed (status=${httpStatus ?? 'unknown'}):`, err);
-        getGlobalRecorder()?.record({ type: 'system.error', debate_id: activeDebate?.id, component: 'debate-engine', level: 'error', message: `Opening statement failed: ${info.label} (status=${httpStatus ?? 'unknown'})`, error: { name: (err as Error).name ?? 'Error', message: (err as Error).message ?? String(err), stack: (err as Error).stack?.slice(0, 500) } });
+        // Broadened classification (t/2492): transient timeout/5xx/network now auto-retry, not just 429.
+        const { retryable: isRetryable, reason: retryReason } = classifyAiRetry(err);
+        console.error(`[debate] ${info.label} opening statement failed (status=${httpStatus ?? 'unknown'}, retry=${retryReason}):`, err);
+        getGlobalRecorder()?.record({ type: 'system.error', debate_id: activeDebate?.id, component: 'debate-engine', level: 'error', message: `Opening statement failed: ${info.label} (status=${httpStatus ?? 'unknown'})`, data: { retry_reason: retryReason, retryable: isRetryable, retry_pass: openingRetryPass }, error: { name: (err as Error).name ?? 'Error', message: (err as Error).message ?? String(err), stack: (err as Error).stack?.slice(0, 500) } });
         if (isDailyLimitError(err)) {
           addTranscriptEntry({
             type: 'system',
@@ -1113,15 +1125,22 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
           type: 'system',
           speaker: 'system',
           content: isRetryable
-            ? `${info.label} was rate limited — retrying automatically…`
+            ? `${info.label} ${retryReasonLabel(retryReason)} — retrying automatically…`
             : `${info.label} failed to deliver opening statement: ${mapErrorToUserMessage(err)}`,
           taxonomy_refs: [],
         });
         failedSpeakers.push(info.label);
         if (isRetryable) {
           hasRetryableFailure = true;
-          const msgMatch = String(err).match(/Retry in (\d+)s/);
-          retryBackoffMs = msgMatch ? parseInt(msgMatch[1], 10) * 1000 : 5000;
+          lastRetryReason = retryReasonLabel(retryReason);
+          if (retryReason === 'rate_limit') {
+            // Honor the server's advertised Retry-After when present.
+            const msgMatch = String(err).match(/Retry in (\d+)s/);
+            retryBackoffMs = msgMatch ? parseInt(msgMatch[1], 10) * 1000 : 5000;
+          } else {
+            // Exponential backoff for transient timeout/5xx/network (5s, 10s, …), capped at 30s.
+            retryBackoffMs = Math.min(5000 * 2 ** openingRetryPass, 30_000);
+          }
           break;
         }
       }
@@ -1153,7 +1172,7 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
           return `Opening statements failed for ${missingLabels.join(', ')} after ${attempts} attempt${attempts > 1 ? 's' : ''} (${elapsedStr}).`;
         })(),
       });
-      getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'warn', debate_id: activeDebate?.id, message: 'runOpeningStatements partial failure', data: { missingSpeakers } });
+      getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'warn', debate_id: activeDebate?.id, message: 'runOpeningStatements partial failure', data: { missingSpeakers, retry_passes: openingRetryPass, last_retry_reason: lastRetryReason, elapsed_ms: Date.now() - openingStartedAt } });
       await saveDebate('runOpeningStatements:partialFailure');
       return;
     }

--- a/taxonomy-editor/src/renderer/utils/retryClassifier.test.ts
+++ b/taxonomy-editor/src/renderer/utils/retryClassifier.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { classifyAiRetry, retryReasonLabel } from './retryClassifier';
+
+// Helper: build an error carrying an httpStatus (as the bridge attaches it).
+function httpErr(status: number, message = 'boom'): Error & { httpStatus: number } {
+  return Object.assign(new Error(message), { httpStatus: status });
+}
+
+describe('classifyAiRetry (t/2492) — transient failures retry, terminal ones do not', () => {
+  it('429 rate-limit is retryable (reason: rate_limit)', () => {
+    expect(classifyAiRetry(httpErr(429))).toEqual({ retryable: true, reason: 'rate_limit' });
+  });
+
+  it('daily-limit is NOT retryable even though it surfaces as 429', () => {
+    const err = Object.assign(new Error('Daily limit'), { httpStatus: 429, limitType: 'tokens_per_day' });
+    expect(classifyAiRetry(err)).toEqual({ retryable: false, reason: 'non_retryable' });
+  });
+
+  it.each([502, 503, 504, 529])('transient 5xx %i is retryable (reason: server)', (status) => {
+    expect(classifyAiRetry(httpErr(status))).toEqual({ retryable: true, reason: 'server' });
+  });
+
+  it.each([400, 401, 403, 422, 500])('terminal HTTP %i is NOT retryable', (status) => {
+    expect(classifyAiRetry(httpErr(status))).toEqual({ retryable: false, reason: 'non_retryable' });
+  });
+
+  // The PI-reported case: a ~3-minute failure with no httpStatus.
+  it('AbortError (request timeout) is retryable (reason: timeout)', () => {
+    const err = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    expect(classifyAiRetry(err)).toEqual({ retryable: true, reason: 'timeout' });
+  });
+
+  it.each([
+    'Request timed out after 180s',
+    'ETIMEDOUT',
+    'deadline exceeded',
+  ])('timeout message %j is retryable (reason: timeout)', (message) => {
+    expect(classifyAiRetry(new Error(message))).toEqual({ retryable: true, reason: 'timeout' });
+  });
+
+  it.each([
+    'TypeError: Failed to fetch',
+    'fetch failed',
+    'ECONNRESET',
+    'socket hang up',
+  ])('network message %j is retryable (reason: network)', (message) => {
+    expect(classifyAiRetry(new Error(message))).toEqual({ retryable: true, reason: 'network' });
+  });
+
+  it('content/schema errors (no httpStatus, not timeout/network) are NOT retryable', () => {
+    expect(classifyAiRetry(new Error('Cannot parse JSON after all repair attempts'))).toEqual({
+      retryable: false, reason: 'non_retryable',
+    });
+  });
+
+  it('an unrecognized bare error is NOT retryable (fail closed)', () => {
+    expect(classifyAiRetry('something odd')).toEqual({ retryable: false, reason: 'non_retryable' });
+    expect(classifyAiRetry(undefined)).toEqual({ retryable: false, reason: 'non_retryable' });
+  });
+});
+
+describe('retryReasonLabel (t/2492)', () => {
+  it('produces distinct human labels per reason', () => {
+    expect(retryReasonLabel('rate_limit')).toMatch(/rate limited/i);
+    expect(retryReasonLabel('server')).toMatch(/server error/i);
+    expect(retryReasonLabel('timeout')).toMatch(/timed out/i);
+    expect(retryReasonLabel('network')).toMatch(/network/i);
+    expect(retryReasonLabel('non_retryable')).toMatch(/failed/i);
+  });
+});

--- a/taxonomy-editor/src/renderer/utils/retryClassifier.ts
+++ b/taxonomy-editor/src/renderer/utils/retryClassifier.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Renderer-side transient-failure classifier for AI-call auto-retry (t/2492).
+ *
+ * The bug this fixes: debate opening-statement retry engaged ONLY on HTTP 429, so a ~3-minute
+ * timeout / 5xx / network failure was classified non-retryable → 1 attempt → manual Retry banner.
+ * This broadens "retryable" to all transient failures while still refusing terminal ones.
+ *
+ * NOT shared with `lib/ai-client/retry.ts` by design (TL, t/2492#2): that is the low-level
+ * per-call AI-client retry layer (server-side 5× + model fallback); this is the renderer's
+ * user-facing debate/chat orchestration retry. Keep the two policies independent; if you change
+ * the transient-status set here, consider whether lib/ai-client/retry.ts wants the same.
+ */
+
+import { isDailyLimitError } from '../hooks/useDebateStore/shared/guards';
+
+/** Why a failure was (not) retried — stamped onto FR retry/exhaustion events + banner text. */
+export type RetryReason = 'rate_limit' | 'server' | 'timeout' | 'network' | 'non_retryable';
+
+export interface RetryClassification {
+  retryable: boolean;
+  reason: RetryReason;
+}
+
+/** HTTP statuses treated as transient server failures (in addition to 429 rate-limiting). */
+const TRANSIENT_SERVER_STATUSES = new Set([502, 503, 504, 529]);
+
+/**
+ * Classify an AI-call failure for auto-retry.
+ *
+ * Retryable: 429 rate-limit (unless daily-limit), transient 5xx (502/503/504/529),
+ * request timeouts (AbortError / "timed out"), and network failures (failed to fetch).
+ * Not retryable: daily-limit, other 4xx (auth/validation), and content/schema errors
+ * (JSON-parse failures carry no httpStatus and match no transient signature → non_retryable).
+ */
+export function classifyAiRetry(err: unknown): RetryClassification {
+  // Daily-limit is a hard stop even though it surfaces as 429.
+  if (isDailyLimitError(err)) return { retryable: false, reason: 'non_retryable' };
+
+  const httpStatus = (err as { httpStatus?: number } | null | undefined)?.httpStatus;
+
+  if (httpStatus === 429) return { retryable: true, reason: 'rate_limit' };
+  if (typeof httpStatus === 'number' && TRANSIENT_SERVER_STATUSES.has(httpStatus)) {
+    return { retryable: true, reason: 'server' };
+  }
+  // Any other explicit HTTP status is a terminal client/server response (401/403/422/400/500…).
+  if (typeof httpStatus === 'number') return { retryable: false, reason: 'non_retryable' };
+
+  // No httpStatus — inspect name/message for timeout and network signatures.
+  const name = (err as { name?: string } | null | undefined)?.name ?? '';
+  const message = String((err as { message?: unknown } | null | undefined)?.message ?? err ?? '');
+  if (name === 'AbortError' || /timed?\s*out|timeout|ETIMEDOUT|deadline exceeded/i.test(message)) {
+    return { retryable: true, reason: 'timeout' };
+  }
+  if (/failed to fetch|network|fetch failed|ECONNRESET|ENOTFOUND|socket hang up/i.test(message)) {
+    return { retryable: true, reason: 'network' };
+  }
+
+  return { retryable: false, reason: 'non_retryable' };
+}
+
+/** User-facing banner fragment for a retry-in-progress, by reason. */
+export function retryReasonLabel(reason: RetryReason): string {
+  switch (reason) {
+    case 'rate_limit': return 'was rate limited';
+    case 'server': return 'hit a temporary server error';
+    case 'timeout': return 'timed out';
+    case 'network': return 'hit a network error';
+    default: return 'failed';
+  }
+}


### PR DESCRIPTION
Fixes the UAT/PI-reported high-pri bug (t/2492): debate opening-statement auto-retry engaged **only on HTTP 429**, so a ~3-minute timeout/5xx/network failure got 1 attempt + a manual Retry button. TL-approved design at t/2492#1/#2.

## Root cause
`clarificationSlice.ts` `isRetryable = httpStatus === 429 && !isDailyLimitError`. The retry *machinery* (retry-pass loop, backoff, t/2442 countdown UI) was fine — only the classifier was too narrow. A timeout has no `httpStatus` → non-retryable → the honest banner after 1 attempt.

## Fix
- **`renderer/utils/retryClassifier.ts`** (new) — `classifyAiRetry(err) → { retryable, reason }`. Retryable: 429 (`rate_limit`), 502/503/504/529 (`server`), AbortError/timeout (`timeout`), failed-to-fetch/ECONNRESET/… (`network`). Terminal: daily-limit, other 4xx (auth/validation), content/schema (JSON-parse). Fail-closed on unrecognized errors.
- **`clarificationSlice.ts`** — uses the classifier; transient cap **1→2**; **8-min total-elapsed budget** checked before each retry (so a multi-min timeout ×N can't strand the user); expo backoff 5s→30s for transient, server `Retry in Ns` honored for rate-limit; **classification reason stamped on the FR error + exhaustion events + banner text** (per TL).
- **`lib/ai-client/retry.ts`** — reciprocal cross-reference comment only (TL-directed; the two retry layers stay independent). *Shared Lib ack requested.*

## Tests
- `retryClassifier.test.ts` — every reason branch incl. the PI 3-min-timeout case and fail-closed.
- `crossSliceAndRegressions.test.ts` +2 — simulated timeout → auto-retry engages (fake timers flush backoff); daily-limit → immediate halt, no retry. Pre-existing 429 harness still green. 44/44.

## Sweep (TL Q3 — `httpStatus === 429` repo-wide)
Only `clarificationSlice.ts:1097` was a retry-gate bug (fixed). `sessionSlice.ts:301` = save-error classifier (401/402/403, not retry); `lib/ai-client/retry.ts` = separate low-level layer; `chatStream.ts`/`web-bridge.ts`/`instrumentBridge.ts` = error construction/normalization. No other retry-gate to fix.

## Verify
Deterministic gates green (tsc main/server/renderer, eslint, depcruise, vite build); retry suites 44/44.

## Review-ack gating (holding self-merge)
- [ ] **Shared Lib** — the comment-only cross-reference in `lib/ai-client/retry.ts`
- [ ] **DebateUI** — FYI on the banner-text change (state-driven; their t/2442 component unchanged)

t/2492

🤖 Generated with [Claude Code](https://claude.com/claude-code)
