### PR TITLE
fix(chat): readable error on chat-stream 4xx + clean up stale empty session (t/2491)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.test.ts
@@ -278,6 +278,23 @@ describe('useChatStore', () => {
       expect(state.chatStreamingText).toBeNull();
       expect(state.chatError).toContain('Response failed');
     });
+
+    it('deletes the pre-saved empty session when the opening fails (t/2491)', async () => {
+      mockApi.startChatStream.mockRejectedValueOnce(new Error('opening failed'));
+      mockApi.deleteChatSession.mockClear();
+
+      useChatStore.setState({
+        activeChat: makeChatSession({ id: 'empty-1', transcript: [] }) as never,
+      });
+
+      await useChatStore.getState().generateOpening();
+
+      // The empty session is cleaned from storage rather than left stale.
+      expect(mockApi.deleteChatSession).toHaveBeenCalledWith('empty-1');
+      const state = useChatStore.getState();
+      expect(state.chatError).toContain('Failed to start conversation');
+      expect(state.chatGenerating).toBe(false);
+    });
   });
 
   // t/2453 — reasoning models (DeepSeek/Groq) prepend <think>…</think> before their

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -368,6 +368,16 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-store', level: 'error', message: 'Failed to generate opening message', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
       set({ chatError: `Failed to start conversation: ${mapErrorToUserMessage(err)}`, chatStreamingText: null });
+      // createChat pre-saved an empty session before generation; the opening never landed, so remove
+      // it from storage + the sidebar list rather than leaving a stale empty chat (t/2491). Cleanup
+      // failures must not mask the original error, so they're swallowed after being recorded.
+      try {
+        await api.deleteChatSession(activeChat.id);
+        const sessions = await api.listChatSessions();
+        set({ sessions: sessions as ChatSessionSummary[] });
+      } catch (cleanupErr) {
+        getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-store', level: 'warn', message: 'Failed to clean up empty chat session after opening failure', error: { name: (cleanupErr as Error).name ?? 'Error', message: String(cleanupErr), stack: (cleanupErr as Error).stack } });
+      }
     } finally {
       set({ chatGenerating: false });
     }

--- a/taxonomy-editor/src/renderer/utils/errorMessages.test.ts
+++ b/taxonomy-editor/src/renderer/utils/errorMessages.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { mapErrorToUserMessage } from './errorMessages';
+import { ActionableError } from '@lib/debate/errors';
+
+describe('mapErrorToUserMessage — ActionableError surfaces .problem, not the raw block (t/2491)', () => {
+  it('returns the one-line problem, not the full Goal/Error/Location/Resolve message', () => {
+    const err = new ActionableError({
+      goal: 'Stream chat response',
+      problem: 'Rate limit exceeded. Retry in 30s.',
+      location: 'web-bridge.startChatStream',
+      nextSteps: ['Wait for the rate limit to reset', 'Use your own API key'],
+    });
+    // Sanity: the raw .message IS the formatted block we must NOT show.
+    expect(err.message).toMatch(/Goal:|Resolve:|Location:/);
+
+    const shown = mapErrorToUserMessage(err);
+    expect(shown).toBe('Rate limit exceeded. Retry in 30s.');
+    expect(shown).not.toMatch(/Goal:|Location:|Resolve:/);
+  });
+
+  it('a missing-key 422 ActionableError shows only its problem line', () => {
+    const err = new ActionableError({
+      goal: 'Stream chat response',
+      problem: 'No API key configured for the selected backend.',
+      location: 'web-bridge.startChatStream',
+      nextSteps: ['Open Settings → API Keys'],
+    });
+    expect(mapErrorToUserMessage(err)).toBe('No API key configured for the selected backend.');
+  });
+
+  it('non-ActionableError paths are unchanged (rate-limit heuristic still maps)', () => {
+    expect(mapErrorToUserMessage(new Error('HTTP 429 rate limit'))).toMatch(/rate limited/i);
+  });
+
+  it('a plain string error is returned mapped, not crashed', () => {
+    expect(typeof mapErrorToUserMessage('something went wrong')).toBe('string');
+  });
+});

--- a/taxonomy-editor/src/renderer/utils/errorMessages.ts
+++ b/taxonomy-editor/src/renderer/utils/errorMessages.ts
@@ -1,7 +1,13 @@
+import { ActionableError } from '@lib/debate/errors';
+
 /**
  * Translate raw error messages into user-friendly, actionable guidance.
  */
 export function mapErrorToUserMessage(err: unknown): string {
+  // ActionableError already carries a one-line human-readable `problem`; its `.message` is the full
+  // Goal/Error/Location/Resolve block, which must never be surfaced raw to users (t/2491).
+  if (err instanceof ActionableError) return err.problem;
+
   const msg = err instanceof Error ? err.message : String(err);
   const errorCode = (err as Record<string, unknown> | null)?.errorCode;
 


### PR DESCRIPTION
Client-side half of t/2489 (split per TL guardrail #4). Two chat-stream error-path bugs that predate/outlive the anon-403 fix (any 4xx: 429, 422, …).

## Fixes
1. **Raw ActionableError on 4xx.** `mapErrorToUserMessage` (`errorMessages.ts`) used `err.message`, which for `ActionableError` is the full `Goal/Error/Location/Resolve` block — leaking raw to the chat panel. Now returns `err.problem` (the one-line human-readable string) when `err instanceof ActionableError`. Improves **all** callers; no consumer benefits from the raw block.
2. **Stale pre-saved empty session.** `createChat` saves an empty session before generation; `generateOpening`'s catch previously only set `chatError`. It now deletes that empty session + refreshes the sidebar list (mirrors the existing `deleteChat` action). The cleanup is wrapped in its own try/catch so a cleanup failure is recorded but can't mask the original stream error. `generateOpening` only runs on an empty transcript, so the session is definitively empty at failure.

## Tests
- `errorMessages.test.ts` (new) — ActionableError → `.problem`, never the block; non-ActionableError heuristics unchanged.
- `useChatStore.test.ts` — "deletes the pre-saved empty session when the opening fails".
26 tests pass; deterministic gates green (tsc main/renderer, eslint, depcruise, vite build).

## Notes
- Self-cert `/trivial-change`. Both files are Rosetta scope (diagnosis by Chat, t/2491#1). Signed-in happy path unchanged (no pre-save failure on `sendMessage`).

t/2491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
