### PR TITLE
feat(lib): frontier-tier models get 2x timeout in getDefaultTimeout (t/2495)

### DIFF
--- a/lib/ai-client/client.ts
+++ b/lib/ai-client/client.ts
@@ -70,7 +70,7 @@ export function createAIClient(
       // fixedTemperature (if any) overrides the caller's temperature so providers send it.
       const effectiveOpts = {
         ...opts,
-        timeoutMs: opts?.timeoutMs ?? getDefaultTimeout(model),
+        timeoutMs: opts?.timeoutMs ?? getDefaultTimeout(model, registry),
         ...(fixedTemperature != null ? { fixedTemperature } : {}),
       };
       const t0 = performance.now();

--- a/lib/ai-client/registry.test.ts
+++ b/lib/ai-client/registry.test.ts
@@ -420,4 +420,40 @@ describe('moonshot backend routing (t/1945)', () => {
   it('getDefaultTimeout uses the moonshot (240s) budget, mirroring zai', () => {
     expect(getDefaultTimeout('moonshot-kimi-k3')).toBe(240_000);
   });
+
+  // Frontier-tier 2× tests (t/2495)
+  const tierRegistry = {
+    backends: [],
+    models: [],
+    debateTiers: {
+      basic:    { claude: 'claude-haiku-4-5',       gemini: 'gemini-3.5-flash-lite', ollama: 'ollama-llama3', zai: 'zai-model' },
+      advanced: { claude: 'claude-sonnet-4-6',      gemini: 'gemini-3.1-pro-preview', ollama: 'ollama-llama3', zai: 'zai-model' },
+    },
+  };
+
+  it('getDefaultTimeout doubles for frontier claude (advanced ≠ basic)', () => {
+    expect(getDefaultTimeout('claude-sonnet-4-6', tierRegistry)).toBe(360_000); // 2× 180_000
+  });
+
+  it('getDefaultTimeout stays at base for basic claude', () => {
+    expect(getDefaultTimeout('claude-haiku-4-5', tierRegistry)).toBe(180_000);
+  });
+
+  it('getDefaultTimeout doubles for frontier gemini (advanced ≠ basic)', () => {
+    expect(getDefaultTimeout('gemini-3.1-pro-preview', tierRegistry)).toBe(240_000); // 2× 120_000
+  });
+
+  it('getDefaultTimeout stays at base for basic gemini', () => {
+    expect(getDefaultTimeout('gemini-3.5-flash-lite', tierRegistry)).toBe(120_000);
+  });
+
+  it('getDefaultTimeout stays at base for ollama/zai (same model in both tiers)', () => {
+    expect(getDefaultTimeout('ollama-llama3', tierRegistry)).toBe(300_000); // 1× — no frontier distinction
+    expect(getDefaultTimeout('zai-model',     tierRegistry)).toBe(240_000); // 1× — no frontier distinction
+  });
+
+  it('getDefaultTimeout returns base when no registry is passed (back-compat)', () => {
+    expect(getDefaultTimeout('claude-sonnet-4-6')).toBe(180_000);
+    expect(getDefaultTimeout('gemini-3.1-pro-preview')).toBe(120_000);
+  });
 });

--- a/lib/ai-client/registry.ts
+++ b/lib/ai-client/registry.ts
@@ -61,8 +61,7 @@ export function resolveModel(registry: ModelRegistry, friendlyId: string): { api
   return { apiModelId: friendlyId, backend: 'gemini' };
 }
 
-export function getDefaultTimeout(model: string): number {
-  const backend = resolveBackend(model);
+function baseTimeout(backend: string): number {
   switch (backend) {
     case 'ollama':    return 300_000;
     case 'deepseek':  return 180_000;
@@ -75,6 +74,24 @@ export function getDefaultTimeout(model: string): number {
     case 'gemini':    return 120_000;
     default:          return 120_000;
   }
+}
+
+/**
+ * Returns the default timeout for a model in milliseconds.
+ *
+ * When a registry is provided, frontier-tier models (those in
+ * debateTiers.advanced but NOT in debateTiers.basic for their backend)
+ * receive 2× the backend base. Same-model tiers (ollama, zai) are
+ * intentionally held at 1× — they have no frontier/basic distinction (t/2495).
+ */
+export function getDefaultTimeout(model: string, registry?: ModelRegistry): number {
+  const backend = resolveBackend(model);
+  const base = baseTimeout(backend);
+  if (!registry?.debateTiers) return base;
+  const advanced = registry.debateTiers['advanced']?.[backend];
+  const basic    = registry.debateTiers['basic']?.[backend];
+  if (advanced === model && advanced !== basic) return base * 2;
+  return base;
 }
 
 function parseVersionedModelId(id: string): { family: string; version: number } | null {

--- a/lib/debate/aiAdapter.ts
+++ b/lib/debate/aiAdapter.ts
@@ -166,11 +166,12 @@ function callEnvelopeProvider(
   backend: string,
   req: GenerateRequest,
   apiKey: string,
+  registry: ModelRegistry,
 ): Promise<ProviderResult> {
   const sysText = envelopeSystemText(req.envelope);
   return callProvider(fetch, backend, req.envelope.layer4_variable, req.model, apiKey, {
     ...req.options,
-    timeoutMs: req.options?.timeoutMs ?? getDefaultTimeout(req.model),
+    timeoutMs: req.options?.timeoutMs ?? getDefaultTimeout(req.model, registry),
     systemMessage: sysText || undefined,
   });
 }
@@ -292,7 +293,7 @@ export function createCLIAdapter(repoRoot: string, explicitApiKey?: string): Ext
   async function doGenerateText(prompt: string, model: string, options?: GenerateOptions): Promise<string> {
     const { apiModelId, backend, fixedTemperature } = resolveModel(registry, model);
     const apiKey = resolveApiKey(backend, explicitApiKey);
-    const timeoutMs = options?.timeoutMs ?? getDefaultTimeout(model);
+    const timeoutMs = options?.timeoutMs ?? getDefaultTimeout(model, registry);
     const opts = { ...options, timeoutMs, fixedTemperature };
 
     const t0 = performance.now();
@@ -360,7 +361,7 @@ export function createCLIAdapter(repoRoot: string, explicitApiKey?: string): Ext
       }
       process.stderr.write(`[cascade] ${backend}/${apiModelId} failed, trying ${fb.backend}/${fb.apiModelId}\n`);
       try {
-        const fbTimeoutMs = getDefaultTimeout(fbModel);
+        const fbTimeoutMs = getDefaultTimeout(fbModel, registry);
         const fbOpts = { ...opts, timeoutMs: fbTimeoutMs, fixedTemperature: fb.fixedTemperature };
         const fbResult = await callWithTimeout(
           (signal) => withRetry(
@@ -402,7 +403,7 @@ export function createCLIAdapter(repoRoot: string, explicitApiKey?: string): Ext
     });
     try {
       const result = await withRetry(
-        () => callEnvelopeProvider(backend, resolvedReq, apiKey),
+        () => callEnvelopeProvider(backend, resolvedReq, apiKey, registry),
         CLI_RETRY_CONFIG, `${backend}/${apiModelId}`, retryLog,
       );
 


### PR DESCRIPTION
## Summary

- `getDefaultTimeout(model, registry?)` now returns 2× the backend base for frontier-tier models (PI directive, t/2495)
- Frontier = in `debateTiers.advanced[backend]` AND differs from `debateTiers.basic[backend]`; same-model tiers (ollama, zai) stay at 1×
- Updated all call sites: `client.ts` (registry already in closure), `aiAdapter.ts` `doGenerateText` + fallback path, `callEnvelopeProvider` (new registry param)

## Changes

- `lib/ai-client/registry.ts`: extract `baseTimeout()` helper, add optional `registry` param to `getDefaultTimeout`
- `lib/ai-client/client.ts:73`: pass `registry` (already in closure — one-word change)
- `lib/debate/aiAdapter.ts:173,295,363`: pass `registry` at all three call sites; `callEnvelopeProvider` gets a new `registry` param
- `lib/ai-client/registry.test.ts`: 6 new tests covering all AC cases

## Test plan

- 45/45 passing (6 new): claude-sonnet 2× (360k), claude-haiku 1× (180k), gemini-pro 2× (240k), gemini-flash 1× (120k), ollama/zai same-model guard (1×), no-registry back-compat
- PS cmdlets `-TimeoutSec 120` left out of scope per ticket; scripts-owner follow-up recommended if PI directive applies there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
