### PR TITLE
feat(shared): LoadingProgress — indeterminate bar + elapsed timer (t/2498)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/LoadingProgress.css
+++ b/taxonomy-editor/src/renderer/components/shared/LoadingProgress.css
@@ -1,0 +1,59 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Shared indeterminate loading bar + elapsed timer (t/2498). Class prefix lp-* (styles.css is frozen). */
+
+.lp-root {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.lp-bar {
+  position: relative;
+  height: 4px;
+  border-radius: 2px;
+  overflow: hidden;
+  background: var(--border-color, rgba(127, 127, 127, 0.25));
+}
+
+.lp-bar-indeterminate {
+  position: absolute;
+  top: 0;
+  left: -40%;
+  height: 100%;
+  width: 40%;
+  border-radius: 2px;
+  background: var(--focus-ring, #4c8bf5);
+  animation: lp-indeterminate 1.2s ease-in-out infinite;
+}
+
+@keyframes lp-indeterminate {
+  0% { left: -40%; }
+  100% { left: 100%; }
+}
+
+/* Respect reduced-motion: replace the sweep with a gentle pulse. */
+@media (prefers-reduced-motion: reduce) {
+  .lp-bar-indeterminate {
+    left: 0;
+    width: 100%;
+    animation: lp-pulse 1.6s ease-in-out infinite;
+  }
+  @keyframes lp-pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+  }
+}
+
+.lp-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.8rem;
+  color: var(--text-secondary, #6b7280);
+}
+
+.lp-elapsed {
+  font-variant-numeric: tabular-nums;
+}

--- a/taxonomy-editor/src/renderer/components/shared/LoadingProgress.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/LoadingProgress.test.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { LoadingProgress, formatElapsed } from './LoadingProgress';
+
+describe('formatElapsed (t/2498) — M:SS, minutes not zero-padded (t/2214)', () => {
+  it.each([
+    [0, '0:00'],
+    [5_000, '0:05'],
+    [65_000, '1:05'],
+    [83_000, '1:23'],
+    [725_000, '12:05'],
+  ])('%ims → %s', (ms, expected) => {
+    expect(formatElapsed(ms)).toBe(expected);
+  });
+
+  it('never produces a leading-zero minute or a negative time', () => {
+    expect(formatElapsed(-1000)).toBe('0:00');
+    expect(formatElapsed(600_000)).toBe('10:00');
+  });
+});
+
+describe('LoadingProgress (t/2498)', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.runOnlyPendingTimers(); vi.useRealTimers(); });
+
+  it('renders the bar + ticking elapsed timer (delayMs=0)', () => {
+    render(<LoadingProgress label="Loading debate…" delayMs={0} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-busy', 'true');
+    expect(bar).toHaveAttribute('aria-label', 'Loading debate…');
+    expect(screen.getByText('0:00')).toBeInTheDocument();
+
+    act(() => { vi.advanceTimersByTime(2_000); });
+    expect(screen.getByText('0:02')).toBeInTheDocument();
+  });
+
+  it('delayMs suppresses render for fast loads', () => {
+    const { container } = render(<LoadingProgress delayMs={300} />);
+    // Before the delay elapses, nothing renders (anti-flash).
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+
+    act(() => { vi.advanceTimersByTime(300); });
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('elapsed is measured from startedAt, not from first paint (delay does not distort it)', () => {
+    const now = Date.now();
+    // Load started 5s ago; the bar appears after a 300ms delay but must read ~0:05, not 0:00.
+    render(<LoadingProgress startedAt={now - 5_000} delayMs={300} />);
+    act(() => { vi.advanceTimersByTime(300); });
+    expect(screen.getByText('0:05')).toBeInTheDocument();
+  });
+
+  it('clears the interval on unmount (no timer leak)', () => {
+    const { unmount } = render(<LoadingProgress delayMs={0} />);
+    expect(vi.getTimerCount()).toBeGreaterThan(0); // the 1s tick interval is armed
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('a11y: indeterminate (no aria-valuenow), non-chattering counter', () => {
+    render(<LoadingProgress label="Loading…" delayMs={0} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).not.toHaveAttribute('aria-valuenow');
+    expect(screen.getByText('0:00')).toHaveAttribute('aria-live', 'off');
+  });
+
+  it('omitting label falls back to aria-label "Loading"; showElapsed=false hides the counter', () => {
+    render(<LoadingProgress delayMs={0} showElapsed={false} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-label', 'Loading');
+    expect(screen.queryByText(/\d:\d\d/)).toBeNull();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/LoadingProgress.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/LoadingProgress.tsx
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useEffect, useRef, useState } from 'react';
+import './LoadingProgress.css';
+
+export interface LoadingProgressProps {
+  /** Visible + screen-reader label, e.g. "Loading debate…". Omit → bar only (aria-label falls back to "Loading"). */
+  label?: string;
+  /** Anti-flash: suppress render until this many ms since load start. Default 300. The elapsed timer still
+   *  counts from load start, so a bar that appears at 300ms already reads 0:00→0:01… correctly. */
+  delayMs?: number;
+  /** Load-start epoch (ms). Elapsed measures from HERE, not from first paint. Default = mount time. */
+  startedAt?: number;
+  /** Show the mm:ss elapsed counter. Default true. */
+  showElapsed?: boolean;
+  /** Extra class on the root for consumer layout. */
+  className?: string;
+}
+
+/** Format elapsed milliseconds as mm:ss (minutes are not zero-padded). Exported for chat adoption (t/2479). */
+export function formatElapsed(ms: number): string {
+  const totalSec = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Indeterminate loading bar + elapsed-time counter (t/2498). Consumer-controlled lifecycle:
+ * mount while loading, unmount when done. The elapsed timer measures from `startedAt` (default mount
+ * time), NOT from when the bar becomes visible, so `delayMs` anti-flash doesn't distort the reading.
+ * Import directly (no barrel — PR #777 convention).
+ */
+export function LoadingProgress({
+  label,
+  delayMs = 300,
+  startedAt,
+  showElapsed = true,
+  className,
+}: LoadingProgressProps) {
+  // Capture load start once at mount (explicit startedAt wins). A later load should remount the component.
+  const startRef = useRef<number>(startedAt ?? Date.now());
+  const [visible, setVisible] = useState(delayMs <= 0);
+  const [elapsedMs, setElapsedMs] = useState(() => Date.now() - startRef.current);
+
+  useEffect(() => {
+    if (delayMs <= 0) return;
+    const t = setTimeout(() => setVisible(true), delayMs);
+    return () => clearTimeout(t);
+  }, [delayMs]);
+
+  useEffect(() => {
+    if (!showElapsed) return;
+    const id = setInterval(() => setElapsedMs(Date.now() - startRef.current), 1000);
+    return () => clearInterval(id);
+  }, [showElapsed]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className={`lp-root${className ? ` ${className}` : ''}`}
+      role="progressbar"
+      aria-busy="true"
+      aria-label={label ?? 'Loading'}
+    >
+      <div className="lp-bar">
+        <div className="lp-bar-indeterminate" />
+      </div>
+      {(label || showElapsed) && (
+        <div className="lp-meta">
+          {label && <span className="lp-label">{label}</span>}
+          {/* aria-live="off": the label is announced once via aria-label; the ticking counter must not chatter. */}
+          {showElapsed && <span className="lp-elapsed" aria-live="off">{formatElapsed(elapsedMs)}</span>}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Shared `LoadingProgress` component for t/2497 (prerequisite). Immediate consumers: debate window (t/2499, DebateUI) + debate-diagnostics window (t/2500, DebateDiagnostics) — both coded against the published contract (t/2498#1). **TL-approved** at t/2498#2.

## Component
`components/shared/LoadingProgress.tsx`:
- Indeterminate progress bar + **M:SS** elapsed counter (minutes not zero-padded, per t/2214).
- `delayMs` (default 300) anti-flash gate; **elapsed measured from `startedAt`** (default mount), NOT from first paint — a bar appearing at 300ms already reads correct elapsed.
- Consumer-controlled lifecycle (mount while loading, unmount when done); always indeterminate/busy while mounted.
- **A11y:** `role="progressbar"` + `aria-busy` + `aria-label` (falls back to "Loading"), indeterminate (no `aria-valuenow`), counter `aria-live="off"` (announced once, no per-tick chatter).
- Interval cleared on unmount (no leak). Direct import, **no barrel** (PR #777). `formatElapsed` exported for future chat adoption (t/2479) — chat NOT migrated here.
- CSS: `lp-*` prefix (styles.css frozen); indeterminate keyframe + `prefers-reduced-motion` fallback.

## Tests (`LoadingProgress.test.tsx`, 12)
Fake-timer: ticking each second; `delayMs` suppresses render for fast loads; elapsed from `startedAt` not first paint; unmount clears interval (`getTimerCount()===0`); a11y attrs + non-chattering counter; label/showElapsed variants; `formatElapsed` M:SS table.

## Verify
Deterministic gates green (tsc main/renderer, eslint, depcruise, vite build); 12/12 tests.

## Notes
Design + full props contract reviewed and approved by Quality (TL) — t/2498#1/#2. No consumer-contract changes. Self-merging on green unblocks t/2499 + t/2500.

t/2498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
