### PR TITLE
feat(session): expose anon session_created_at on /api/auth/me (t/2493)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/anonSessionCreated.test.ts
+++ b/taxonomy-editor/src/server/__tests__/anonSessionCreated.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment node
+// t/2493 — anon session_created_at: the companion `anon_session_created` cookie
+// (mint / first-seen marker) and its exposure as `session_created_at` on
+// /api/auth/me for the flight-recorder auth snapshot (t/2490 Gap 1).
+
+import { describe, it, expect, afterEach } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { Handler, Router } from '../httpKit.js';
+import type { ServerCtx } from '../routes/context.js';
+import { registerSessionRoutes } from '../routes/session.js';
+import {
+  ANON_SESSION_CREATED_COOKIE,
+  anonSessionCreatedCookie,
+  anonSessionCookiesWithCreated,
+  readValidCreatedMs,
+} from '../routes/anonSessionCreated.js';
+
+const VALID_UUID = '11111111-2222-4333-8444-555555555555'; // shape crypto.randomUUID() mints
+const FLOOR_MS = Date.parse('2025-01-01T00:00:00Z');
+
+const reqWith = (cookie?: string, headers: Record<string, string> = {}): IncomingMessage =>
+  ({ headers: { cookie, ...headers } } as unknown as IncomingMessage);
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+describe('anonSessionCreatedCookie (t/2493)', () => {
+  it('carries HttpOnly + SameSite=Lax + Path=/ + 1yr Max-Age and the epoch-ms value', () => {
+    const c = anonSessionCreatedCookie(1_700_000_000_000);
+    expect(c).toMatch(/^anon_session_created=1700000000000;/);
+    expect(c).toContain('HttpOnly');
+    expect(c).toContain('SameSite=Lax');
+    expect(c).toContain('Path=/');
+    expect(c).toContain('Max-Age=31536000');
+  });
+});
+
+describe('readValidCreatedMs (t/2493 cond. 1 — untrusted client cookie)', () => {
+  const now = FLOOR_MS + 10_000_000;
+
+  it('returns the ms for a sane in-range integer', () => {
+    const ms = now - 5000;
+    expect(readValidCreatedMs(reqWith(`${ANON_SESSION_CREATED_COOKIE}=${ms}`), now)).toBe(ms);
+  });
+
+  it('returns null when the cookie is absent', () => {
+    expect(readValidCreatedMs(reqWith('other=1'), now)).toBeNull();
+    expect(readValidCreatedMs(reqWith(undefined), now)).toBeNull();
+  });
+
+  it('rejects non-integer / garbage values', () => {
+    expect(readValidCreatedMs(reqWith(`${ANON_SESSION_CREATED_COOKIE}=not-a-number`), now)).toBeNull();
+    expect(readValidCreatedMs(reqWith(`${ANON_SESSION_CREATED_COOKIE}=17e11`), now)).toBeNull();
+    expect(readValidCreatedMs(reqWith(`${ANON_SESSION_CREATED_COOKIE}=-1700000000000`), now)).toBeNull();
+  });
+
+  it('rejects a value earlier than the product-launch floor (forged past)', () => {
+    expect(readValidCreatedMs(reqWith(`${ANON_SESSION_CREATED_COOKIE}=${FLOOR_MS - 1}`), now)).toBeNull();
+  });
+
+  it('rejects a future value beyond the clock-skew window (forged future)', () => {
+    const future = now + 6 * 60 * 1000; // > 5min skew
+    expect(readValidCreatedMs(reqWith(`${ANON_SESSION_CREATED_COOKIE}=${future}`), now)).toBeNull();
+  });
+
+  it('tolerates a small forward clock skew', () => {
+    const skewed = now + 60 * 1000; // 1min < 5min skew
+    expect(readValidCreatedMs(reqWith(`${ANON_SESSION_CREATED_COOKIE}=${skewed}`), now)).toBe(skewed);
+  });
+});
+
+describe('anonSessionCookiesWithCreated (t/2493 cond. 2 — mint-site marker)', () => {
+  const createdOf = (cookies: string[]) =>
+    cookies.find(c => c.startsWith(`${ANON_SESSION_CREATED_COOKIE}=`));
+
+  it('appends created=now when a fresh UUID is minted (no existing id)', () => {
+    const now = FLOOR_MS + 1_000;
+    const cookies = anonSessionCookiesWithCreated(reqWith(undefined), now);
+    expect(cookies.some(c => c.startsWith('anon_session_id='))).toBe(true);
+    expect(createdOf(cookies)).toBe(anonSessionCreatedCookie(now));
+  });
+
+  it('OVERWRITES a lingering stale created cookie on fresh mint (invalid id → new UUID)', () => {
+    const now = FLOOR_MS + 2_000;
+    // Old created marker present, but the id cookie is malformed → resolveAnonSessionId
+    // mints a fresh UUID, so the new session must NOT inherit the old timestamp.
+    const stale = FLOOR_MS + 1;
+    const req = reqWith(`anon_session_id=not-a-uuid; ${ANON_SESSION_CREATED_COOKIE}=${stale}`);
+    const cookies = anonSessionCookiesWithCreated(req, now);
+    expect(createdOf(cookies)).toBe(anonSessionCreatedCookie(now));
+    expect(createdOf(cookies)).not.toContain(String(stale));
+  });
+
+  it('does NOT append a created cookie when a valid id is reused (existing marker untouched)', () => {
+    const now = FLOOR_MS + 3_000;
+    const cookies = anonSessionCookiesWithCreated(reqWith(`anon_session_id=${VALID_UUID}`), now);
+    expect(cookies.some(c => c.startsWith(`anon_session_id=${VALID_UUID}`))).toBe(true);
+    expect(createdOf(cookies)).toBeUndefined();
+  });
+});
+
+// ── /api/auth/me exposure ────────────────────────────────────────────────────
+
+interface CapturedRes {
+  status: number;
+  headers: Record<string, string | string[]>;
+  body: unknown;
+}
+
+function mockRes(): { res: ServerResponse; captured: CapturedRes } {
+  const captured: CapturedRes = { status: 0, headers: {}, body: undefined };
+  const res = {
+    writableEnded: false,
+    headersSent: false,
+    setHeader(k: string, v: string | string[]) { captured.headers[k] = v; },
+    writeHead(status: number, hdrs?: Record<string, string>) {
+      captured.status = status;
+      if (hdrs) Object.assign(captured.headers, hdrs);
+      (this as unknown as { headersSent: boolean }).headersSent = true;
+    },
+    end(body?: string) {
+      captured.body = body ? JSON.parse(body) : undefined;
+      (this as unknown as { writableEnded: boolean }).writableEnded = true;
+    },
+  } as unknown as ServerResponse;
+  return { res, captured };
+}
+
+function authMeHandler(): Handler {
+  let handler: Handler | undefined;
+  const r = {
+    get: (path: string, h: Handler) => { if (path === '/api/auth/me') handler = h; },
+    post: () => {}, put: () => {}, patch: () => {}, del: () => {},
+  } as unknown as Router;
+  registerSessionRoutes(r, { broadcastEvent: () => {} } as unknown as ServerCtx);
+  if (!handler) throw new Error('/api/auth/me handler not registered');
+  return handler;
+}
+
+async function callAuthMe(req: IncomingMessage): Promise<CapturedRes> {
+  const { res, captured } = mockRes();
+  await authMeHandler()(req, res, undefined);
+  return captured;
+}
+
+const setCookieHeader = (c: CapturedRes): string =>
+  Array.isArray(c.headers['Set-Cookie']) ? (c.headers['Set-Cookie'] as string[]).join('\n') : String(c.headers['Set-Cookie'] ?? '');
+
+describe('/api/auth/me session_created_at (t/2493)', () => {
+  const savedAuthEnabled = process.env.WEBSITE_AUTH_ENABLED;
+  afterEach(() => {
+    if (savedAuthEnabled === undefined) delete process.env.WEBSITE_AUTH_ENABLED;
+    else process.env.WEBSITE_AUTH_ENABLED = savedAuthEnabled;
+  });
+
+  it('returns session_created_at (from a valid created cookie) without re-backfilling', async () => {
+    delete process.env.WEBSITE_AUTH_ENABLED;
+    const ms = Date.now() - 60_000;
+    const c = await callAuthMe(reqWith(`anon_session_id=${VALID_UUID}; ${ANON_SESSION_CREATED_COOKIE}=${ms}`));
+    expect((c.body as { session_created_at?: string }).session_created_at).toBe(new Date(ms).toISOString());
+    expect(setCookieHeader(c)).not.toContain(ANON_SESSION_CREATED_COOKIE); // no backfill needed
+  });
+
+  it('lazy-backfills (Set-Cookie + ~now) when id present but created cookie absent', async () => {
+    delete process.env.WEBSITE_AUTH_ENABLED;
+    const before = Date.now();
+    const c = await callAuthMe(reqWith(`anon_session_id=${VALID_UUID}`));
+    const iso = (c.body as { session_created_at?: string }).session_created_at;
+    expect(iso).toBeDefined();
+    expect(Date.parse(iso!)).toBeGreaterThanOrEqual(before);
+    expect(setCookieHeader(c)).toContain(`${ANON_SESSION_CREATED_COOKIE}=`);
+  });
+
+  it('discards a forged created cookie and re-backfills with now (never echoes the raw value)', async () => {
+    delete process.env.WEBSITE_AUTH_ENABLED;
+    const forged = Date.now() + 10 * 60 * 1000; // future → invalid
+    const before = Date.now();
+    const c = await callAuthMe(reqWith(`anon_session_id=${VALID_UUID}; ${ANON_SESSION_CREATED_COOKIE}=${forged}`));
+    const iso = (c.body as { session_created_at?: string }).session_created_at!;
+    expect(Date.parse(iso)).toBeGreaterThanOrEqual(before);
+    expect(Date.parse(iso)).toBeLessThan(forged);            // not the forged value
+    expect(setCookieHeader(c)).toContain(`${ANON_SESSION_CREATED_COOKIE}=`); // repaired
+  });
+
+  it('omits session_created_at when there is no anon_session_id cookie', async () => {
+    delete process.env.WEBSITE_AUTH_ENABLED;
+    const c = await callAuthMe(reqWith('other=1'));
+    expect((c.body as { session_created_at?: string }).session_created_at).toBeUndefined();
+    expect(setCookieHeader(c)).not.toContain(ANON_SESSION_CREATED_COOKIE);
+  });
+
+  it('omits session_created_at for authenticated users', async () => {
+    process.env.WEBSITE_AUTH_ENABLED = 'true';
+    const c = await callAuthMe(reqWith(
+      `anon_session_id=${VALID_UUID}`,
+      { 'x-ms-client-principal-name': 'alice@example.com' },
+    ));
+    expect((c.body as { anonymous: boolean }).anonymous).toBe(false);
+    expect((c.body as { session_created_at?: string }).session_created_at).toBeUndefined();
+  });
+});

--- a/taxonomy-editor/src/server/routes/anonSessionCreated.ts
+++ b/taxonomy-editor/src/server/routes/anonSessionCreated.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2493: companion "session created at" marker for the anonymous session.
+//
+// `anon_session_id` is an opaque crypto.randomUUID() with no embedded time
+// (security/accessControl.ts), so nothing records when an anon session began.
+// This module owns a small HttpOnly companion cookie, `anon_session_created`,
+// carrying the mint (or first-seen) instant as epoch-ms, so /api/auth/me can
+// expose `session_created_at` for the flight-recorder auth snapshot
+// (t/2490 Gap 1). Kept import-safe (no server.ts import) and shared by the two
+// mint sites (server.ts) and the backfill/read in /api/auth/me (session.ts).
+
+import type { IncomingMessage } from 'http';
+import { parseCookies } from '../httpCookies.js';
+import { resolveAnonSessionId, anonymousSessionCookies } from '../security/accessControl.js';
+
+export const ANON_SESSION_CREATED_COOKIE = 'anon_session_created';
+
+// Sane floor: nothing legitimate predates the project's existence, so a client
+// cookie earlier than this is forged/garbage and is treated as absent.
+// 2025-01-01T00:00:00Z — comfortably before the first anon session could exist.
+const ANON_SESSION_EPOCH_FLOOR_MS = 1_735_689_600_000;
+
+// Tolerate small forward clock skew before rejecting a "future" cookie.
+const CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+// Mirror of anonymousSessionCookies' Secure gating (security/accessControl.ts) —
+// replicated here (not imported) to avoid a cross-scope edit; SameSite / Path /
+// HttpOnly / Max-Age are kept in parity with the id cookie so the two travel
+// together identically.
+function secureSuffix(): string {
+  return process.env.NODE_ENV === 'production' || process.env.ALLOWED_ORIGINS ? '; Secure' : '';
+}
+
+/** Build the Set-Cookie string for the created marker (epoch-ms), 1yr persistence
+ *  to match the id cookie. HttpOnly — read server-side only, echoed to the client
+ *  as an ISO string via /api/auth/me, never as the raw cookie value. */
+export function anonSessionCreatedCookie(epochMs: number): string {
+  return `${ANON_SESSION_CREATED_COOKIE}=${epochMs}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000${secureSuffix()}`;
+}
+
+/**
+ * Mint the anon-session cookies (id + auth flag, via accessControl) and append the
+ * `anon_session_created` marker WHENEVER a fresh UUID is minted. On fresh mint the
+ * marker is written unconditionally (= now) so a new session can never inherit a
+ * stale created cookie left by an independently-cleared id (t/2493 cond. 2). A
+ * reused id leaves any existing created cookie untouched. `nowMs` is injectable
+ * for deterministic tests.
+ */
+export function anonSessionCookiesWithCreated(req: IncomingMessage, nowMs: number = Date.now()): string[] {
+  const existingId = parseCookies(req).get('anon_session_id');
+  const id = resolveAnonSessionId(existingId); // t/2464: reuse-not-rotate
+  const cookies = anonymousSessionCookies(id);
+  if (id !== existingId) cookies.push(anonSessionCreatedCookie(nowMs)); // t/2493: fresh mint
+  return cookies;
+}
+
+/**
+ * Read the client-supplied created cookie as a trusted-iff-sane epoch-ms.
+ *
+ * The cookie round-trips through the client, so a UA can forge it (t/2493 cond. 1).
+ * Returns the ms only when it parses as an integer within [floor, now + skew];
+ * otherwise null, signalling the caller to re-backfill with `now` and overwrite.
+ * The raw value is never echoed into a response.
+ */
+export function readValidCreatedMs(req: IncomingMessage, nowMs: number): number | null {
+  const raw = parseCookies(req).get(ANON_SESSION_CREATED_COOKIE);
+  if (raw === undefined) return null;
+  if (!/^\d{1,15}$/.test(raw)) return null;              // integer epoch-ms only
+  const ms = Number(raw);
+  if (!Number.isSafeInteger(ms)) return null;
+  if (ms < ANON_SESSION_EPOCH_FLOOR_MS) return null;     // predates product → forged
+  if (ms > nowMs + CLOCK_SKEW_MS) return null;           // future → forged
+  return ms;
+}

--- a/taxonomy-editor/src/server/routes/session.ts
+++ b/taxonomy-editor/src/server/routes/session.ts
@@ -26,6 +26,10 @@ import { requireAdmin } from '../community/admin/reviewRegistry.js';
 import { isAdmin } from '../community/community.js';
 import * as analytics from '../community/analytics.js';
 import { parseCookies } from '../httpCookies.js';
+import { anonSessionCreatedCookie, readValidCreatedMs } from './anonSessionCreated.js';
+// Re-exported so server.ts's pre-route anon mint sites import it here (keeps the
+// server.ts import list flat / at its max-lines ceiling — t/2493).
+export { anonSessionCookiesWithCreated } from './anonSessionCreated.js';
 
 /** Resolve analytics user key for anonymous requests (t/2465).
  *  Returns 'anon:' + first 12 chars of anon_session_id (HttpOnly — server-reads only),
@@ -54,10 +58,31 @@ export function registerSessionRoutes(r: Router, ctx: ServerCtx): void {
       : '';
     const isAnon = !principalName;
     const authOpt = process.env.AUTH_OPTIONAL === '1';
+
+    // t/2493: session_created_at = the anon session's mint time; for sessions
+    // predating this feature (id cookie set, no created marker) it is the
+    // first-seen time (this request), lazily backfilled server-side so the FR
+    // field (t/2490 Gap 1) populates for the existing user base too. The created
+    // cookie is untrusted client input — a bad/forged value is discarded and
+    // re-backfilled with now; the raw cookie value is never echoed, only an ISO
+    // string derived from a validated ms. Authenticated users: omitted (no
+    // reliable account-creation source in Easy Auth headers).
+    let sessionCreatedAt: string | undefined;
+    if (isAnon && parseCookies(req).get('anon_session_id') !== undefined) {
+      const now = Date.now();
+      let createdMs = readValidCreatedMs(req, now);
+      if (createdMs === null) {
+        createdMs = now;
+        res.setHeader('Set-Cookie', anonSessionCreatedCookie(createdMs)); // backfill / repair forged value
+      }
+      sessionCreatedAt = new Date(createdMs).toISOString();
+    }
+
     json(res, {
       user: principalName || resolveAnonSessionKey(req),
       idp: idp || '',
       anonymous: isAnon,
+      ...(sessionCreatedAt ? { session_created_at: sessionCreatedAt } : {}),
       capabilities: {
         ai: !isAnon || !authOpt,
         write: !isAnon || !authOpt,

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -36,7 +36,7 @@ import { GitHubAPIBackend } from './storage/githubAPIBackend.js';
 import { SessionBranchManager } from './storage/sessionBranchManager.js';
 import { runWithUser, getCurrentUserId, setSessionBranchName, deriveStorageUserId } from './security/userContext.js';
 import type { UserContext } from './security/userContext.js';
-import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, missingApiKeyError, anonymousSessionCookies, resolveAnonSessionId, resolveTestPersonaOverride } from './security/accessControl.js';
+import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, missingApiKeyError, resolveTestPersonaOverride } from './security/accessControl.js';
 import { sanitizeUserText } from './security/contentSanitizer.js';
 import { isFreeTierAiPath } from './anonAiRoutes.js';
 import { getRollbackStatus } from './rollbackStatus.js';
@@ -67,7 +67,7 @@ import { registerChatRoutes } from './routes/chat.js';
 import { registerDiagnosticsRoutes } from './routes/diagnostics.js';
 import { registerSupportRoutes } from './routes/support.js';
 import { registerSourcesRoutes } from './routes/sources.js';
-import { registerSessionRoutes } from './routes/session.js';
+import { registerSessionRoutes, anonSessionCookiesWithCreated } from './routes/session.js';
 import { registerPreferencesRoutes } from './routes/preferences.js';
 import { buildLoginPage, FORBIDDEN_PAGE, SW_HEAL_SCRIPT_CSP_HASH, loginPageHeaders } from './loginPage.js';
 import type { ServerCtx } from './routes/context.js';
@@ -892,7 +892,7 @@ function handleAnonAuthEndpoints(req: http.IncomingMessage, res: http.ServerResp
   if (urlPath === '/.auth/anonymous' && authOptional) {
     res.writeHead(302, {
       'Location': '/',
-      'Set-Cookie': anonymousSessionCookies(resolveAnonSessionId(parseCookies(req).get('anon_session_id'))), // t/2464
+      'Set-Cookie': anonSessionCookiesWithCreated(req), // t/2464 (id) + t/2493 (created marker on fresh mint)
     });
     res.end();
     return true;
@@ -908,7 +908,7 @@ function handleAnonAuthEndpoints(req: http.IncomingMessage, res: http.ServerResp
   if (urlPath === '/api/auth/anonymous' && req.method === 'POST' && authOptional) {
     res.writeHead(200, {
       'Content-Type': 'application/json',
-      'Set-Cookie': anonymousSessionCookies(resolveAnonSessionId(parseCookies(req).get('anon_session_id'))), // t/2464
+      'Set-Cookie': anonSessionCookiesWithCreated(req), // t/2464 (id) + t/2493 (created marker on fresh mint)
     });
     res.end(JSON.stringify({ ok: true, anonymous: true }));
     return true;


### PR DESCRIPTION
Closes t/2493. Exposes `session_created_at` on `GET /api/auth/me` for the flight-recorder auth snapshot (t/2490 Gap 1).

## Problem
`anon_session_id` is an opaque `crypto.randomUUID()` with no embedded time — nothing recorded when an anon session began, and the renderer can't read the HttpOnly id cookie, so it had no session-age source.

## Change
- New HttpOnly companion cookie `anon_session_created` (epoch-ms), minted alongside `anon_session_id` **only when a fresh UUID is minted**.
- `GET /api/auth/me` returns ISO `session_created_at` derived from it; authenticated users omitted (no reliable Easy Auth account-creation source).
- Logic in the import-safe leaf module `routes/anonSessionCreated.ts`, re-exported through `routes/session.ts` so `server.ts` stays at its `max-lines` ceiling.

## TL auth-surface conditions (t/2493#2) — all folded in
1. **Untrusted cookie**: parsed as a bounded integer epoch-ms; unparseable / pre-launch-floor / future-beyond-5min-skew → discarded and re-backfilled with `now`. The raw cookie value is never echoed — only a validated-ms ISO string.
2. **Fresh mint overwrites unconditionally** — a new session can never inherit a stale created cookie left by an independently-cleared id.
3. **First-seen semantics documented** at the response field; lazy backfill in `/api/auth/me` populates the field for sessions predating the feature.

## Tests
15 unit tests (`__tests__/anonSessionCreated.test.ts`): cookie validation (forged past/future/garbage, skew tolerance), mint overwrite-vs-reuse, and `/api/auth/me` present / lazy-backfill / forged→backfill / omit-when-no-id / omit-when-authed. `tsc` + `eslint` clean; routeTable snapshot unchanged (no route added).

> Pre-existing worktree note: `githubApi.test.ts` / `t2020Security.test.ts` fail locally on the `undici major-version skew` invariant (a worktree dep-install artifact in untouched storage code); green in CI.

Reviewer: routing to a **Quality (TL)** instance per t/2493#2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
