### PR TITLE
feat(debate): LoadingProgress bar + elapsed timer during popout window load (t/2499)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebatePopoutWindow.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebatePopoutWindow.test.tsx
@@ -14,12 +14,14 @@ const {
   mockLoadDebateFromData,
   mockLoadAll,
   mockOnDebateWindowLoad,
+  storeState,
 } = vi.hoisted(() => ({
   mockLoadCommunityDebateSession: vi.fn().mockResolvedValue({ id: 'abc-123', found: true }),
   mockLoadDebate: vi.fn().mockResolvedValue(undefined),
   mockLoadDebateFromData: vi.fn(),
   mockLoadAll: vi.fn().mockResolvedValue(undefined),
   mockOnDebateWindowLoad: vi.fn(),
+  storeState: { activeDebateId: null as string | null, debateError: null as string | null },
 }));
 
 // Captured IPC callback — populated when DebatePopoutWindow registers its onDebateWindowLoad listener.
@@ -37,9 +39,7 @@ vi.mock('@bridge', () => ({
 }));
 
 vi.mock('../../hooks/useDebateStore', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const useDebateStore = (selector: (s: any) => any) =>
-    selector({ activeDebateId: null, debateError: null });
+  const useDebateStore = (selector: (s: typeof storeState) => unknown) => selector(storeState);
   useDebateStore.getState = () => ({
     loadDebate: mockLoadDebate,
     loadDebateFromData: mockLoadDebateFromData,
@@ -59,6 +59,11 @@ vi.mock('../../hooks/useTaxonomyStore', () => {
 });
 
 vi.mock('../debate-workspace', () => ({ DebateWorkspace: () => null }));
+vi.mock('../shared/LoadingProgress', () => ({
+  LoadingProgress: ({ label }: { label?: string }) => (
+    <div data-testid="loading-progress" aria-label={label ?? 'Loading'} />
+  ),
+}));
 
 vi.mock('./useBriefTimeoutEvents', () => ({
   useBriefTimeoutEvents: () => ({
@@ -89,6 +94,8 @@ describe('DebatePopoutWindow — runLoad routing (t/2399)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedDebateWindowLoadCb = null;
+    storeState.activeDebateId = null;
+    storeState.debateError = null;
     mockLoadCommunityDebateSession.mockResolvedValue({ id: 'abc-123', found: true });
     mockLoadAll.mockResolvedValue(undefined);
   });
@@ -142,5 +149,33 @@ describe('DebatePopoutWindow — runLoad routing (t/2399)', () => {
       expect(mockLoadDebate).toHaveBeenCalledWith('abc-123');
     });
     expect(mockLoadCommunityDebateSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('DebatePopoutWindow — loading progress (t/2499)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedDebateWindowLoadCb = null;
+    storeState.activeDebateId = null;
+    storeState.debateError = null;
+    mockLoadAll.mockResolvedValue(undefined);
+    setHash('');
+  });
+
+  it('shows LoadingProgress while taxonomy and debate are loading', () => {
+    // loadAll never resolves → ready stays false
+    mockLoadAll.mockReturnValue(new Promise(() => {}));
+    const { getByTestId } = render(<DebatePopoutWindow />);
+    expect(getByTestId('loading-progress')).not.toBeNull();
+  });
+
+  it('hides LoadingProgress once taxonomy is ready and debate is active', async () => {
+    // Store already has an active debate (simulates debate loaded before/during taxonomy init)
+    storeState.activeDebateId = 'debate-abc';
+    const { queryByTestId } = render(<DebatePopoutWindow />);
+    // loadAll resolves → ready=true; activeDebateId already set → component advances past loading gate
+    await waitFor(() => {
+      expect(queryByTestId('loading-progress')).toBeNull();
+    });
   });
 });

--- a/taxonomy-editor/src/renderer/components/debate/DebatePopoutWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebatePopoutWindow.tsx
@@ -6,7 +6,7 @@
  * initializes stores independently, and renders DebateWorkspace.
  */
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useDebateStore } from '../../hooks/useDebateStore';
@@ -19,12 +19,15 @@ import { parseDebateHash, shouldShowLoadError, type DebateLoadTarget } from './p
 import { useBriefTimeoutEvents } from './useBriefTimeoutEvents';
 import { BriefTimeoutToast } from './BriefTimeoutToast';
 import { BriefTimeoutDialog } from './BriefTimeoutDialog';
+import { LoadingProgress } from '../shared/LoadingProgress';
 import './DebatePopoutWindow.css';
 
 export function DebatePopoutWindow() {
   usePopoutTheme();
   useTheoryLinkHotkey(); // F1-to-nearest must work in the popout document too (t/2343)
   useEffect(() => { markAsPopout(); }, []);
+  // Captured at component mount — before any async work — so the elapsed timer reflects true window-open time.
+  const loadStartRef = useRef(Date.now());
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const activeDebateId = useDebateStore(s => s.activeDebateId);
@@ -152,7 +155,7 @@ export function DebatePopoutWindow() {
   if (!ready || !activeDebateId) {
     return (
       <div className="debate-popout-fullscreen">
-        <p className="debate-popout-hint">Loading debate...</p>
+        <LoadingProgress label="Loading debate…" startedAt={loadStartRef.current} />
       </div>
     );
   }


### PR DESCRIPTION
Replaces the plain "Loading debate..." text in `DebatePopoutWindow` with the shared `LoadingProgress` component (t/2498/#875).

## Changes
- `DebatePopoutWindow.tsx`: add `useRef(Date.now())` at component mount to capture true load-start time; swap loading branch to `<LoadingProgress label="Loading debate…" startedAt={loadStartRef.current} />`
- `DebatePopoutWindow.test.tsx`: make store mock mutable via `vi.hoisted` `storeState`; add `LoadingProgress` mock; add 2 transition tests (loading visible while pending, hidden once ready+debate active)

## Verify
- renderer tsc: 0 errors
- eslint on changed files: 0 warnings
- scoped vitest: 6/6 (including 2 new)
- Full vitest: pre-existing undici skew fails server tests locally (Node version mismatch, not my change); CI on Node 22 is authoritative

## Design
Approved at t/2499#2 (Quality TL e/87#2). No deviations.

t/2499

🤖 Generated with [Claude Code](https://claude.com/claude-code)