### PR TITLE
feat(debate-diagnostics): LoadingProgress bar + elapsed timer while diagnostics window loads (t/2500)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.css
@@ -233,29 +233,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.diag-loading {
-  display: flex;
-  align-items: center;
-  gap: var(--sp-2);
-  padding: var(--sp-3);
-  color: var(--text-muted);
-  font-size: var(--text-sm);
-}
-
-.diag-loading-spinner {
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent, #f97316);
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  flex-shrink: 0;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.test.tsx
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { DebateSession } from '../../../types/debate';
+
+// ---------------------------------------------------------------------------
+// Module mocks (must be hoisted)
+// ---------------------------------------------------------------------------
+
+vi.mock('./useDiagnosticsState', () => ({ useDiagnosticsState: vi.fn() }));
+
+vi.mock('../../shared/LoadingProgress', () => ({
+  LoadingProgress: ({ label }: { label?: string }) => (
+    <div data-testid="loading-progress">{label}</div>
+  ),
+}));
+
+vi.mock('../chat', () => ({ DiagnosticsChatSidebar: () => null }));
+vi.mock('./OverviewTabRouter', () => ({ OverviewTabRouter: () => null }));
+vi.mock('./EntryDetailRouter', () => ({ EntryDetailRouter: () => null }));
+
+vi.mock('./helpers', () => ({
+  DiagSearchContext: { Provider: ({ children }: { children: React.ReactNode }) => <>{children}</> },
+  SearchBar: () => null,
+  speakerLabel: (s: string) => s,
+}));
+
+vi.mock('../../shared/CopyLinkButton', () => ({ CopyLinkButton: () => null }));
+vi.mock('../../shared/TheoryLink', () => ({ TheoryLink: () => null }));
+
+vi.mock('@lib/electron-shared/povMeta', () => ({
+  POV_META: {
+    accelerationist: { cssVar: '--acc', label: 'Accelerationist' },
+    safetyist: { cssVar: '--saf', label: 'Safetyist' },
+    skeptic: { cssVar: '--skp', label: 'Skeptic' },
+  },
+}));
+
+vi.mock('@bridge', () => ({
+  api: { clipboardWriteText: vi.fn(), openExternal: vi.fn() },
+  isElectronMode: false,
+}));
+
+vi.mock('../../../lib/flightRecorderInit', () => ({ triggerManualDump: vi.fn() }));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import { DiagnosticsWindow } from './DiagnosticsWindow';
+import { useDiagnosticsState } from './useDiagnosticsState';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noop = () => {};
+
+function makeState(overrides: Partial<ReturnType<typeof useDiagnosticsState>> = {}): ReturnType<typeof useDiagnosticsState> {
+  return {
+    debate: null,
+    setDebate: noop,
+    selectedEntry: null,
+    setSelectedEntry: noop,
+    localOverride: false,
+    setLocalOverride: noop,
+    showHelp: false,
+    setShowHelp: noop,
+    searchQuery: '',
+    setSearchQuery: noop,
+    sq: '',
+    entryTab: 'details',
+    setEntryTab: noop,
+    overviewTab: 'transcript',
+    setOverviewTab: noop,
+    transcriptSpeakerFilter: null,
+    setTranscriptSpeakerFilter: noop,
+    focusedNodeId: null,
+    setFocusedNodeId: noop,
+    anFilterNodeId: '',
+    setAnFilterNodeId: noop,
+    anFilterMode: 'all',
+    setAnFilterMode: noop,
+    taxNodeMap: new Map(),
+    policyMap: new Map(),
+    allEdges: [],
+    selectedTaxRefId: null,
+    setSelectedTaxRefId: noop,
+    selectedPolicyId: null,
+    setSelectedPolicyId: noop,
+    textCopyMenu: null,
+    setTextCopyMenu: noop,
+    nodeLabels: new Map(),
+    tabContentRef: { current: null },
+    searchInputRef: { current: null },
+    sidebarTranscriptRef: { current: null },
+    handleUpdateSubScore: noop,
+    handleChatNavigate: noop,
+    entry: null,
+    diag: undefined,
+    turnValTrail: undefined,
+    meta: undefined,
+    an: undefined,
+    commitments: undefined,
+    nodeWeights: new Map(),
+    proxiedModeratorTrace: null,
+    effectiveOverviewTab: 'transcript',
+    perTurnUtilities: [],
+    matchCount: 0,
+    deepLinkError: null,
+    ...overrides,
+  } as ReturnType<typeof useDiagnosticsState>;
+}
+
+const minimalDebate: DebateSession = {
+  id: 'test-debate',
+  title: 'Test Debate',
+  created_at: '2026-01-01T00:00:00.000Z',
+  transcript: [],
+  topic: { text: 'test', scope: null, critique: null } as unknown as DebateSession['topic'],
+} as unknown as DebateSession;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DiagnosticsWindow — loading state', () => {
+  const mockUseDiagnosticsState = vi.mocked(useDiagnosticsState);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('shows LoadingProgress while debate is null and no error', () => {
+    mockUseDiagnosticsState.mockReturnValue(makeState({ debate: null, deepLinkError: null }));
+    render(<DiagnosticsWindow />);
+    expect(screen.getByTestId('loading-progress')).toBeTruthy();
+    expect(screen.getByText('Loading debate…')).toBeTruthy();
+  });
+
+  it('hides LoadingProgress once debate is loaded', () => {
+    mockUseDiagnosticsState.mockReturnValue(makeState({ debate: minimalDebate, deepLinkError: null }));
+    render(<DiagnosticsWindow />);
+    expect(screen.queryByTestId('loading-progress')).toBeNull();
+  });
+
+  it('shows error text instead of LoadingProgress on deepLinkError', () => {
+    mockUseDiagnosticsState.mockReturnValue(makeState({ debate: null, deepLinkError: 'Debate not found: xyz' }));
+    render(<DiagnosticsWindow />);
+    expect(screen.queryByTestId('loading-progress')).toBeNull();
+    expect(screen.getByText('Debate not found: xyz')).toBeTruthy();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
@@ -21,7 +21,8 @@ import { TheoryLink } from '../../shared/TheoryLink';
 import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
 import type { OverviewTab } from './types';
 import type { DebateSession } from '../../../types/debate';
-import type { RefObject } from 'react';
+import { useRef, type RefObject } from 'react';
+import { LoadingProgress } from '../../shared/LoadingProgress';
 import './DiagnosticsWindow.css';
 
 // ---------------------------------------------------------------------------
@@ -333,6 +334,7 @@ function DiagnosticsHeader({
 // ---------------------------------------------------------------------------
 
 export function DiagnosticsWindow({ initialData }: { initialData?: Record<string, unknown> } = {}) {
+  const loadStartRef = useRef(Date.now());
   const state = useDiagnosticsState(initialData);
   const {
     debate,
@@ -382,12 +384,7 @@ export function DiagnosticsWindow({ initialData }: { initialData?: Record<string
       {!debate && !showHelp && (
         deepLinkError
           ? <p style={{ color: 'var(--error, var(--danger))', padding: '1rem' }}>{deepLinkError}</p>
-          : (
-            <div className="diag-loading" role="status" aria-live="polite">
-              <span className="diag-loading-spinner" aria-hidden="true" />
-              <span>Loading debate data… large debates may take a while.</span>
-            </div>
-          )
+          : <LoadingProgress label="Loading debate…" startedAt={loadStartRef.current} />
       )}
 
       {/* ── Main content area ── */}


### PR DESCRIPTION
Replaces the hand-rolled `diag-loading` spinner in the diagnostics popout with the shared `LoadingProgress` component (t/2498/#875).

## Changes
- **`DiagnosticsWindow.tsx`** — `useRef(Date.now())` captures load-start at first render; passed as `startedAt` so the elapsed timer reflects window-open time, not bar-visibility time (TL condition t/2500#2). Replace `diag-loading` div with `<LoadingProgress label="Loading debate…" startedAt={loadStartRef.current} />`.
- **`DiagnosticsWindow.css`** — remove dead `.diag-loading`, `.diag-loading-spinner`, `@keyframes spin`.
- **`DiagnosticsWindow.test.tsx`** (new) — 3-case loading→loaded transition: loading state shows bar, loaded state hides it, error state shows error text instead.

## Verification
- tsc: clean
- eslint: exit 0 (pre-existing inline-style warnings only)
- vitest scoped: 3/3 pass
- Full verify: 2 test files fail on undici Node-version skew (pre-existing local env issue t/2053/t/2113, not my changes; CI uses Node 22.x)

## Manual visual check (AC requirement)
CDP cannot reach the diagnostics popout. Manual check pending — will screenshot and record in t/2500 before merge.

## Design
Approved at t/2500#2 (TL p/398#12). One deviation from t/2500#1: `useRef(Date.now())` inside component rather than module scope (TL correction — stale on HMR/reopen).

t/2500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
