### PR TITLE
chore(orca): refresh review-ps skill sync marker (t/2452 drift claim)

### DIFF
--- a/.agents/skills/review-ps/.orca-managed
+++ b/.agents/skills/review-ps/.orca-managed
@@ -1,1 +1,1 @@
-{"source":"c:\\Users\\jsnov\\repos\\ai-triad-research\\.orca\\skills\\review-ps\\SKILL.md","content_hash":"b29fc8963c3e34e16ad8f1e15cf6954f3129b1542ccbfc95eab395305e350b79","orca_format_version":1,"synced_at":"2026-06-25T16:46:15.316Z","platform":"agents"}
+{"source":"c:\\Users\\jsnov\\repos\\ai-triad-research\\.orca\\skills\\review-ps\\SKILL.md","content_hash":"5af6c61c200b774fdc1cfadbd5df4d0e5eaf03c0caff1c2a13f009dd2924b8ae","orca_format_version":1,"synced_at":"2026-08-12T09:15:09.503Z","platform":"agents"}


### PR DESCRIPTION
One-line machine-generated update: Orca skill service re-synced `review-ps` SKILL.md (2026-08-12) and re-stamped `.agents/skills/review-ps/.orca-managed` (content_hash + synced_at). Claimed by TL from the t/2452 hourly shared-drift check (p/331#70) — origin/main still carried the June marker, so this is a genuine newer sync, preserved via worktree flow. Self-cert /trivial-change: 1 line, 1 file, no behavioral change.