### PR TITLE
feat(observability): add auth.session_created_at to FR context (t/2490 Gap 1)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -45,16 +45,21 @@ let _embeddingInfo: { backend: string; execution_provider?: string; calibration_
 void getElectronAPI()?.getEmbeddingInfo?.().then(info => { _embeddingInfo = info; }).catch(() => {});
 
 // ── Cached auth state (fetched once, used synchronously in context) ──
-let _authState: { mode: string; user_type: string } | null = null;
+let _authState: { mode: string; user_type: string; session_created_at?: string } | null = null;
 if (getElectronAPI()) {
   _authState = { mode: 'local', user_type: 'authenticated' };
 } else {
   void fetch('/api/auth/me').then(r => r.ok ? r.json() : null).then(data => {
     if (!data) return;
     const isAnon = !!(data as { anonymous?: boolean }).anonymous;
+    // session_created_at: server-provided anon-session mint time (first-seen for legacy sessions),
+    // exposed on /api/auth/me per t/2493. Absent for authenticated/Electron. Session age explains
+    // stale debate references in dumps (t/2490 Gap 1).
+    const createdAt = (data as { session_created_at?: unknown }).session_created_at;
     _authState = {
       mode: isAnon ? 'optional' : 'required',
       user_type: isAnon ? 'anonymous' : 'authenticated',
+      ...(typeof createdAt === 'string' ? { session_created_at: createdAt } : {}),
     };
   }).catch(() => { /* flight recorder init — silent by design */ });
 }


### PR DESCRIPTION
Consumes `session_created_at` from `/api/auth/me` (exposed by t/2493) into the cached `_authState`, surfacing `auth.session_created_at` in the flight-recorder context snapshot. Session age immediately explains stale debate references in anon-chat dumps (2026-08-11 triage).

Single-file renderer change; `session_created_at` flows into the existing `auth` context block automatically. Absent for authenticated/Electron sessions.

Gap 2 (chat/debate linkage on `ai.request`) stays blocked on t/2494 (server half).

Closes t/2490 Gap 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)