### PR TITLE
feat(obs): add chat/debate linkage + auth type to chat-stream ai.request (t/2494)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/chatRequestObservability.test.ts
+++ b/taxonomy-editor/src/server/__tests__/chatRequestObservability.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+//
+// t/2494 (t/2490 Gap 2, server half) — the chat-stream ai.request flight-recorder
+// event gains chatSessionId, linkedDebateId, and auth_user_type so an anon-chat-403
+// dump is self-explanatory. These cover the two derivation helpers: caller-class
+// from the ALS user context, and the client-id bound (absent-field tolerance +
+// oversize guard). boundedId returning undefined is how absent fields drop out of
+// the serialized event (JSON.stringify omits undefined).
+
+import { describe, it, expect } from 'vitest';
+import { authUserType, boundedId } from '../routes/chat.js';
+import * as userContext from '../security/userContext.js';
+
+const ctx = (over: Partial<Parameters<typeof userContext.runWithUser>[0]>) => ({
+  principalName: 'alice', idp: 'github', storageUserId: 'alice', isAnonymous: false, ...over,
+});
+
+describe('t/2494 — chat-stream ai.request observability fields', () => {
+  describe('authUserType (caller class from ALS context)', () => {
+    it('returns "local" when there is no context', () => {
+      expect(authUserType()).toBe('local');
+    });
+    it('returns "local" for the _local single-user principal', () => {
+      const r = userContext.runWithUser(ctx({ principalName: '_local' }), authUserType);
+      expect(r).toBe('local');
+    });
+    it('returns "anonymous" for a cookie-only anonymous caller', () => {
+      const r = userContext.runWithUser(ctx({ principalName: 'anon-abc', isAnonymous: true }), authUserType);
+      expect(r).toBe('anonymous');
+    });
+    it('returns "authenticated" for a signed-in principal', () => {
+      const r = userContext.runWithUser(ctx({}), authUserType);
+      expect(r).toBe('authenticated');
+    });
+  });
+
+  describe('boundedId (client linkage id, safe for logging)', () => {
+    it('passes a normal id through unchanged', () => {
+      expect(boundedId('chat-123')).toBe('chat-123');
+    });
+    it('returns undefined for absent / empty / non-string (older-client tolerance)', () => {
+      expect(boundedId(undefined)).toBeUndefined();
+      expect(boundedId('')).toBeUndefined();
+      expect(boundedId(42)).toBeUndefined();
+      expect(boundedId(null)).toBeUndefined();
+      expect(boundedId({})).toBeUndefined();
+    });
+    it('caps an oversize value at 128 chars (recorder-bloat guard)', () => {
+      const big = 'x'.repeat(5000);
+      expect(boundedId(big)).toHaveLength(128);
+    });
+    it('an undefined field is omitted from the serialized event data', () => {
+      // Mirrors how the event is built: undefined values drop out of the JSON.
+      const data = { model: 'm', chatSessionId: boundedId(undefined), linkedDebateId: boundedId('d-1') };
+      expect(JSON.parse(JSON.stringify(data))).toEqual({ model: 'm', linkedDebateId: 'd-1' });
+    });
+  });
+});

--- a/taxonomy-editor/src/server/routes/chat.ts
+++ b/taxonomy-editor/src/server/routes/chat.ts
@@ -152,6 +152,22 @@ function callerIdentity(): { principalName: string; idp: string } {
   return callerTierIdentity(getCurrentUser());
 }
 
+/** Coarse caller auth class for the ai.request flight-recorder event (t/2494 —
+ *  observability only, never an auth decision): local single-user, cookie-only
+ *  anonymous, or a signed-in principal. Derived from the ALS user context. */
+export function authUserType(): 'local' | 'anonymous' | 'authenticated' {
+  const u = getCurrentUser();
+  if (!u || u.principalName === '_local') return 'local';
+  return u.isAnonymous ? 'anonymous' : 'authenticated';
+}
+
+/** Clamp a client-supplied linkage id for safe logging (t/2494): a non-empty
+ *  string capped at 128 chars, else undefined (absent-field tolerance for older
+ *  clients + guard against a malicious oversize value bloating the recorder). */
+export function boundedId(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v.slice(0, 128) : undefined;
+}
+
 /** Pure mirror of routes/ai.ts resolveGenerationContext. */
 function resolveGenerationContext(req: http.IncomingMessage, model: string | undefined): {
   tier: ResolvedTier; isFree: boolean; limitKey: string; effectiveModel: string | undefined; backend: AIBackend;
@@ -199,6 +215,8 @@ export function registerChatRoutes(r: Router, _ctx: ServerCtx): void {
       temperature,
       apiKey: clientKey,
       urlContext = false,
+      chatSessionId,   // t/2494: observability linkage (optional; older clients omit)
+      linkedDebateId,  // t/2494
     } = body as {
       systemInstruction?: string;
       messages?: ChatMessage[];
@@ -206,6 +224,8 @@ export function registerChatRoutes(r: Router, _ctx: ServerCtx): void {
       temperature?: number;
       apiKey?: string;
       urlContext?: boolean;
+      chatSessionId?: string;
+      linkedDebateId?: string;
     };
 
     try {
@@ -269,7 +289,14 @@ export function registerChatRoutes(r: Router, _ctx: ServerCtx): void {
       getGlobalRecorder()?.record({
         type: 'ai.request', component: 'ai-chat-stream', level: 'info',
         message: `chat-stream ${backend}/${requestModel}`,
-        data: { model: requestModel, backend, tier: tier.level, urlContext, messageCount: messages.length },
+        data: {
+          model: requestModel, backend, tier: tier.level, urlContext, messageCount: messages.length,
+          // t/2494 (Gap 2): chat/debate linkage + caller class so a flight-recorder
+          // dump explains the anon-chat-403 class without cross-referencing context.
+          auth_user_type: authUserType(),
+          chatSessionId: boundedId(chatSessionId),
+          linkedDebateId: boundedId(linkedDebateId),
+        },
       });
 
       // Commit SSE headers — no JSON error responses after this point.


### PR DESCRIPTION
## Summary

Fixes t/2494 (t/2490 Gap 2, server half): the chat-stream `ai.request` flight-recorder event now carries **chatSessionId**, **linkedDebateId**, and **auth_user_type** — so an anon-chat-403-class dump is self-explanatory without cross-referencing the context block.

- `auth_user_type` derived server-side from the ALS user context (`local` / `anonymous` / `authenticated`) — observability only, never an auth decision.
- `chatSessionId` / `linkedDebateId` read from the POST body, clamped by `boundedId` (non-empty string, <=128 chars). Absent-field tolerant (older clients omit them); undefined values drop out of the serialized event. Oversize guard prevents recorder bloat.
- Renderer half (startChatStream sending the two ids) is the companion Gap-2 client work (Rosetta scope).

## Self-cert

**/trivial-change** — single-file, additive log fields, no new API/interface/data-model, no auth-decision surface. No deviations.

## Test plan

`src/server/__tests__/chatRequestObservability.test.ts`:
- [x] authUserType → local (no ctx / _local), anonymous, authenticated
- [x] boundedId → passthrough, undefined for absent/empty/non-string, cap at 128
- [x] undefined field omitted from serialized event data (absent-field tolerance)
- [x] tsc clean; eslint clean (no net-new warning); chatUrlInject + routeTable green (23 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
