### PR TITLE
feat(ai-client): add source + truncated fields to UrlContextEntry (t/2485)

### DIFF
--- a/lib/ai-client/types.ts
+++ b/lib/ai-client/types.ts
@@ -55,6 +55,10 @@ export interface GeminiContent {
 export interface UrlContextEntry {
   retrievedUrl: string;
   urlRetrievalStatus: string;
+  /** Whether the entry came from the provider's grounding response or was fetched by the app. */
+  source?: 'provider' | 'app-fetch';
+  /** Whether the retrieved content was truncated before storage. */
+  truncated?: boolean;
 }
 
 export interface UrlContextMetadata {


### PR DESCRIPTION
## Summary
- Adds `source?: 'provider' | 'app-fetch'` and `truncated?: boolean` to `UrlContextEntry` in `lib/ai-client/types.ts`
- Types-only, no behavior change
- Unblocks Chat chip work (URL source display) and ServerAPI/ElectronMain producers (excess property check was failing without these fields)

Self-certifying under /trivial-change. Change: 2 optional fields on UrlContextEntry interface. Files: lib/ai-client/types.ts. Lines changed: 4 additions. Verify gate: additive optional fields cannot regress tsc; CI is the gate. Deviations: none.

Closes t/2485 (lib portion — per TL ruling t/2485#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)