### PR TITLE
feat(chat): app-fetch chip affordance + universal URL context gate (t/2485)

### DIFF
--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -69,6 +69,7 @@ export type EventType =
   | 'chat.user-message'
   | 'chat.thinking-stripped'
   | 'chat.url-context-decision'
+  | 'chat.url-context-result'
   // User interaction
   | 'user.action'
   | 'ui.navigate'

--- a/taxonomy-editor/src/renderer/components/chat/UrlContextChip.css
+++ b/taxonomy-editor/src/renderer/components/chat/UrlContextChip.css
@@ -28,3 +28,15 @@
   background: color-mix(in srgb, var(--warning) 10%, transparent);
   color: var(--text-muted);
 }
+
+.url-context-chip--app-fetch {
+  background: color-mix(in srgb, var(--text-secondary) 10%, transparent);
+  border-style: dashed;
+}
+
+.url-context-chip-truncated {
+  margin-left: 4px;
+  font-size: 0.65rem;
+  opacity: 0.7;
+  flex-shrink: 0;
+}

--- a/taxonomy-editor/src/renderer/components/chat/UrlContextChip.test.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/UrlContextChip.test.tsx
@@ -55,6 +55,58 @@ describe('UrlContextChip', () => {
     render(<UrlContextChip metadata={meta} />);
     expect(screen.getByText('read: not-a-url')).toBeTruthy();
   });
+
+  it('app-fetch chip: adds --app-fetch modifier and "Fetched by app:" tooltip', () => {
+    const meta = {
+      urlMetadata: [
+        { retrievedUrl: 'https://example.com/page', urlRetrievalStatus: 'SUCCESS', source: 'app-fetch' as const },
+      ],
+    };
+    render(<UrlContextChip metadata={meta as UrlContextMetadata} />);
+    const chip = screen.getByText('read: example.com');
+    expect(chip.className).toContain('url-context-chip--app-fetch');
+    expect(chip.getAttribute('title')).toBe('Fetched by app: https://example.com/page');
+  });
+
+  it('app-fetch failed chip: "Couldn\'t fetch:" tooltip', () => {
+    const meta = {
+      urlMetadata: [
+        { retrievedUrl: 'https://blocked.io/', urlRetrievalStatus: 'ERROR_BLOCKED', source: 'app-fetch' as const },
+      ],
+    };
+    render(<UrlContextChip metadata={meta as UrlContextMetadata} />);
+    const chip = screen.getByText("couldn't read: blocked.io");
+    expect(chip.className).toContain('url-context-chip--app-fetch');
+    expect(chip.getAttribute('title')).toBe("Couldn't fetch: https://blocked.io/");
+  });
+
+  it('truncated badge renders when truncated is true', () => {
+    const meta = {
+      urlMetadata: [
+        { retrievedUrl: 'https://long.example.com/', urlRetrievalStatus: 'SUCCESS', source: 'app-fetch' as const, truncated: true },
+      ],
+    };
+    render(<UrlContextChip metadata={meta as UrlContextMetadata} />);
+    expect(screen.getByText('[truncated]')).toBeTruthy();
+  });
+
+  it('no truncated badge when truncated is absent', () => {
+    const meta: UrlContextMetadata = {
+      urlMetadata: [{ retrievedUrl: 'https://example.com/', urlRetrievalStatus: 'SUCCESS' }],
+    };
+    render(<UrlContextChip metadata={meta} />);
+    expect(screen.queryByText('[truncated]')).toBeNull();
+  });
+
+  it('absent source defaults to provider behavior — no --app-fetch class', () => {
+    const meta: UrlContextMetadata = {
+      urlMetadata: [{ retrievedUrl: 'https://example.com/', urlRetrievalStatus: 'SUCCESS' }],
+    };
+    render(<UrlContextChip metadata={meta} />);
+    const chip = screen.getByText('read: example.com');
+    expect(chip.className).not.toContain('url-context-chip--app-fetch');
+    expect(chip.getAttribute('title')).toBe('Read: https://example.com/');
+  });
 });
 
 describe('chatSystemPrompt urlContext param', () => {
@@ -74,16 +126,12 @@ describe('chatSystemPrompt urlContext param', () => {
     expect(prompt).not.toContain("you have not visited that URL");
   });
 
-  it('non-Gemini model gates urlContext to false → honest-fail text in prompt', async () => {
-    // backendForModel('claude-3-5-sonnet') === 'claude', not 'gemini'
-    // so URL_PATTERN.test(msg) && backendForModel(model) === 'gemini' is false
-    const { backendForModel } = await import('../../hooks/useTaxonomyStore');
+  it('urlContext=true (URL detected, no model gate since t/2485) → grounding prompt', async () => {
+    // Gate is now purely URL presence (extractHttpUrls); no backend check.
+    // Any URL detection produces urlContext=true regardless of model.
     const { chatSystemPrompt } = await import('../../prompts/chat');
-    const nonGeminiModel = 'claude-3-5-sonnet';
-    const urlContext = /https?:\/\/\S+/.test('https://example.com') && backendForModel(nonGeminiModel) === 'gemini';
-    expect(urlContext).toBe(false);
-    const prompt = chatSystemPrompt('Label', 'pov', 'personality', 'inform', 'topic', 'ctx', urlContext);
-    expect(prompt).toContain("you have not visited that URL");
-    expect(prompt).not.toContain("url_context tool");
+    const prompt = chatSystemPrompt('Label', 'pov', 'personality', 'inform', 'topic', 'ctx', true);
+    expect(prompt).toContain("url_context tool");
+    expect(prompt).not.toContain("you have not visited that URL");
   });
 });

--- a/taxonomy-editor/src/renderer/components/chat/UrlContextChip.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/UrlContextChip.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import type { UrlContextMetadata } from '@lib/ai-client/index';
+import type { UrlContextMetadata, UrlContextEntry } from '@lib/ai-client/index';
 import './UrlContextChip.css';
+
+type UrlContextEntryExt = UrlContextEntry & { source?: 'provider' | 'app-fetch'; truncated?: boolean };
 
 function hostnameFrom(url: string): string {
   try {
@@ -19,17 +21,25 @@ export function UrlContextChip({ metadata }: { metadata: UrlContextMetadata }) {
   return (
     <div className="url-context-chips" aria-label="URL context">
       {entries.map((entry, i) => {
-        const success = entry.urlRetrievalStatus === 'SUCCESS';
-        const host = hostnameFrom(entry.retrievedUrl);
+        const e = entry as UrlContextEntryExt;
+        const success = e.urlRetrievalStatus === 'SUCCESS';
+        const isAppFetch = e.source === 'app-fetch';
+        const host = hostnameFrom(e.retrievedUrl);
+        const tooltip = isAppFetch
+          ? (success ? `Fetched by app: ${e.retrievedUrl}` : `Couldn't fetch: ${e.retrievedUrl}`)
+          : (success ? `Read: ${e.retrievedUrl}` : `Couldn't read: ${e.retrievedUrl}`);
         return (
           <span
             key={i}
-            className={`url-context-chip${success ? '' : ' url-context-chip--failed'}`}
-            title={success
-              ? `Read: ${entry.retrievedUrl}`
-              : `Couldn't read: ${entry.retrievedUrl}`}
+            className={[
+              'url-context-chip',
+              success ? '' : 'url-context-chip--failed',
+              isAppFetch ? 'url-context-chip--app-fetch' : '',
+            ].filter(Boolean).join(' ')}
+            title={tooltip}
           >
             {success ? `read: ${host}` : `couldn't read: ${host}`}
+            {e.truncated && <span className="url-context-chip-truncated">[truncated]</span>}
           </span>
         );
       })}

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -11,7 +11,8 @@ import type {
 import type { SpeakerId, TaxonomyRef } from '../types/debate';
 import { POVER_INFO } from '../types/debate';
 import type { PovNode, CrossCuttingNode as SituationNode } from '../types/taxonomy';
-import { useTaxonomyStore, backendForModel, getStoredModel } from './useTaxonomyStore';
+import { useTaxonomyStore, getStoredModel } from './useTaxonomyStore';
+import { extractHttpUrls } from '../../../../lib/url-fetch/extractHttpUrls';
 import { mapErrorToUserMessage } from '../utils/errorMessages';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { api } from '@bridge';
@@ -40,8 +41,6 @@ function getConfiguredModel(): string {
   return getStoredModel();
 }
 
-const URL_PATTERN = /https?:\/\/\S+/;
-
 function isUrlContextMetadata(payload: unknown): payload is UrlContextMetadata {
   if (!payload || typeof payload !== 'object') return false;
   const p = payload as Record<string, unknown>;
@@ -69,6 +68,16 @@ async function streamChatWithProgress(
   const unsubMeta = api.onChatStreamUrlMetadata?.((payload) => {
     if (isUrlContextMetadata(payload)) {
       urlContextMetadata = payload;
+      getGlobalRecorder()?.record({
+        type: 'chat.url-context-result',
+        component: 'chat-store',
+        level: 'info',
+        message: 'URL context metadata received',
+        data: {
+          entry_count: payload.urlMetadata.length,
+          success_count: payload.urlMetadata.filter(e => e.urlRetrievalStatus === 'SUCCESS').length,
+        },
+      });
     } else {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-store', level: 'debug', message: 'onChatStreamUrlMetadata payload did not match UrlContextMetadata shape', error: { name: 'TypeError', message: 'Non-conforming url-context metadata', stack: '' } });
     }
@@ -426,8 +435,9 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       const model = getConfiguredModel();
       const temperature = CHAT_MODE_TEMPERATURE[activeChat.mode];
 
-      const urlDetected = URL_PATTERN.test(message.trim());
-      const urlContext = urlDetected && backendForModel(model) === 'gemini';
+      const detectedUrls = extractHttpUrls(message.trim());
+      const urlDetected = detectedUrls.length > 0;
+      const urlContext = urlDetected;
       getGlobalRecorder()?.record({
         type: 'chat.url-context-decision',
         component: 'chat-store',
@@ -436,7 +446,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         data: {
           url_detected: urlDetected,
           url_context_enabled: urlContext,
-          gating_reason: !urlDetected ? 'no-url' : urlContext ? 'enabled' : 'model-not-capable',
+          gating_reason: !urlDetected ? 'no-url' : 'enabled',
           ingestion_path: urlContext ? 'provider' : 'none',
           model,
         },
@@ -460,12 +470,15 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         .filter(Boolean);
       const userContent = chatContinuationPrompt(message.trim(), transcriptText, priorClaims);
 
+      const activity = urlContext
+        ? `Fetching page for ${info.label}…`
+        : `${info.label} is thinking…`;
       const { text: fullText, urlContextMetadata } = await streamChatWithProgress(
         systemInstruction,
         [{ role: 'user', content: userContent }],
         model,
         temperature,
-        `${info.label} is thinking...`,
+        activity,
         set,
         (chunk) => get().appendStreamingText(chunk),
         urlContext,


### PR DESCRIPTION
## Summary
- **Slice A** (`useChatStore`): replace `URL_PATTERN` regex with `extractHttpUrls` (deduped, capped at 10); drop `backendForModel==='gemini'` gate — URL presence alone enables urlContext for all models. Activity label becomes "Fetching page for \<POVer\>…" when urlContext is true. Adds `chat.url-context-result` FR event on metadata receipt; adds `'chat.url-context-result'` to `EventType` union.
- **Slice B** (`UrlContextChip`): local `UrlContextEntryExt` type adds optional `source` and `truncated` fields. App-fetch chips get dashed border + muted background + "Fetched by app:" tooltip. Absent `source` defaults to provider behavior. Truncated entries show `[truncated]` badge.
- 6 new tests (13 total), all passing. tsc: 0 errors.

## Test plan
- [ ] tsc: 0 renderer errors (`check-renderer-tsc.sh`)
- [ ] vitest: 13/13 `UrlContextChip.test.tsx` passing
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)