### PR TITLE
fix(debate): show resolved brief model in brief-timeout toast/dialog (t/2504)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/__tests__/modelConfig.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/__tests__/modelConfig.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi } from 'vitest';
+
+// resolveBriefModel / getSpeakerModel are pure. modelConfig also imports the stores (only
+// getConfiguredModel uses them) — stub them so this stays a hermetic leaf test with no
+// store side-effects (avoids cross-file mock-graph coupling).
+vi.mock('../store', () => ({ useDebateStore: { getState: () => ({ debateModel: '' }) } }));
+vi.mock('../../useTaxonomyStore', () => ({ useTaxonomyStore: { getState: () => ({ geminiModel: '' }) } }));
+
+import { resolveBriefModel, getSpeakerModel } from '../modelConfig';
+
+describe('resolveBriefModel (t/2504 — brief-timeout toast model)', () => {
+  const FALLBACK = 'gemini-flash-lite-latest';
+
+  it('stage-level brief override wins over speaker model and base fallback', () => {
+    const debate = {
+      stage_models: { brief: 'cheap-brief' },
+      speaker_models: { skeptic: 'moonshot-kimi-k3' },
+    };
+    expect(resolveBriefModel(debate, 'skeptic', FALLBACK)).toBe('cheap-brief');
+  });
+
+  it('falls back to the speaker model when no brief stage override is set', () => {
+    const debate = { speaker_models: { skeptic: 'moonshot-kimi-k3' } };
+    expect(resolveBriefModel(debate, 'skeptic', FALLBACK)).toBe('moonshot-kimi-k3');
+    // and mirrors getSpeakerModel exactly in this case
+    expect(resolveBriefModel(debate, 'skeptic', FALLBACK)).toBe(getSpeakerModel(debate, 'skeptic', FALLBACK));
+  });
+
+  it('falls back to the base model when neither a brief override nor a speaker model is set', () => {
+    expect(resolveBriefModel({ speaker_models: {} }, 'skeptic', FALLBACK)).toBe(FALLBACK);
+    expect(resolveBriefModel(null, 'skeptic', FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('resolves per-speaker: each speaker gets its own model (no brief override)', () => {
+    const debate = {
+      speaker_models: { skeptic: 'moonshot-kimi-k3', accelerationist: 'gemini-2.5-flash' },
+    };
+    expect(resolveBriefModel(debate, 'skeptic', FALLBACK)).toBe('moonshot-kimi-k3');
+    expect(resolveBriefModel(debate, 'accelerationist', FALLBACK)).toBe('gemini-2.5-flash');
+    // a speaker with no per-speaker entry still falls back
+    expect(resolveBriefModel(debate, 'safetyist', FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('never returns empty string for a real debate (the bug: currentModel was "")', () => {
+    const debate = { speaker_models: { skeptic: 'moonshot-kimi-k3' } };
+    expect(resolveBriefModel(debate, 'skeptic', FALLBACK)).not.toBe('');
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/modelConfig.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/modelConfig.ts
@@ -9,6 +9,19 @@ export function getSpeakerModel(activeDebate: { speaker_models?: Record<string, 
   return activeDebate?.speaker_models?.[speaker] || fallbackModel;
 }
 
+/** Resolve the model a speaker's brief stage actually runs with — and thus the model the
+ *  brief-timeout toast/dialog must display (t/2504). Mirrors the pipeline's
+ *  `input.briefModel ?? input.model` (turnPipeline/runTurn.ts): the stage-level brief override
+ *  wins, else the speaker's model (speaker_models override, else the base fallback). Keep in
+ *  sync with the OpeningPipelineInput built at the emit site (clarificationSlice.ts). */
+export function resolveBriefModel(
+  activeDebate: { stage_models?: Record<string, string>; speaker_models?: Record<string, string> } | null,
+  speaker: string,
+  fallbackModel: string,
+): string {
+  return activeDebate?.stage_models?.brief || getSpeakerModel(activeDebate, speaker, fallbackModel);
+}
+
 /** Read the model for the current debate context.
  *  Priority: debate-specific override > global Settings model > default */
 export function getConfiguredModel(): string {

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -36,7 +36,7 @@ import { loadProvisionalWeights } from '@lib/debate/phaseTransitions';
 import { useTaxonomyStore } from '../../useTaxonomyStore';
 import { mapErrorToUserMessage } from '../../../utils/errorMessages';
 import { isLineageDataLoaded } from '../../../data/lineageCategories';
-import { getConfiguredModel, getSpeakerModel } from '../shared/modelConfig';
+import { getConfiguredModel, getSpeakerModel, resolveBriefModel } from '../shared/modelConfig';
 import { generateTextWithProgress, summarizeTranscriptEntry, makeStageGenerate } from '../shared/generation';
 import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE } from '../shared/guards';
 import { pushWarning, recordDiagnostic } from '../shared/diagnostics';
@@ -974,11 +974,16 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         // opening pipeline runs in this renderer, so emit and the same-window toast
         // consumer share @bridge's bus — no IPC. Previously web-only; the Electron
         // path routed through an unfed IPC channel and never fired.
+        // The model the brief actually runs with (stage override, else speaker/base model) —
+        // this is what the timeout toast/dialog must display so "Switch model" is an informed
+        // choice (t/2504). onBriefEvent is created per-speaker inside the aiPovers loop, so
+        // poverId/model already resolve the timed-out speaker (data.agent).
+        const resolvedBriefModel = resolveBriefModel(activeDebate, poverId, model);
         const onBriefEvent: BriefEventFn = (phase, data) => {
           if (phase === 'brief.timeout' || phase === 'brief.retrying') {
-            emitBriefTimeout({ debateId: activeDebate.id, speaker: data.agent, attempt: data.attempt, maxAttempts: data.maxRetries, currentModel: '' });
+            emitBriefTimeout({ debateId: activeDebate.id, speaker: data.agent, attempt: data.attempt, maxAttempts: data.maxRetries, currentModel: resolvedBriefModel });
           } else if (phase === 'brief.retries_exhausted') {
-            emitBriefRetriesExhausted({ debateId: activeDebate.id, speaker: data.agent, totalAttempts: data.attempt, currentModel: '' });
+            emitBriefRetriesExhausted({ debateId: activeDebate.id, speaker: data.agent, totalAttempts: data.attempt, currentModel: resolvedBriefModel });
           }
         };
 


### PR DESCRIPTION
Brief-timeout toast + retries-exhausted dialog showed no model because the producer hardcoded `currentModel: ''` on both emit sites. Extract `resolveBriefModel()` into `shared/modelConfig.ts` (mirrors the pipeline's `briefModel ?? model` resolution — stage brief override wins, else speaker/base model) and emit it from both `emitBriefTimeout` and `emitBriefRetriesExhausted`. `onBriefEvent` is per-speaker (inside the `aiPovers` loop), so the resolved model already matches the timed-out speaker.

Producer-level regression test (`modelConfig.test.ts`, 5 cases): stage-override wins, speaker-model fallback, base fallback, per-speaker resolution, never-empty.

Approved: Quality (TL) at t/2504#2 (Option A). Closes t/2504.

🤖 Generated with [Claude Code](https://claude.com/claude-code)