### PR TITLE
feat(chat): per-entry source + truncated on app-fetch UrlContextEntry (t/2502)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/chatUrlInject.test.ts
+++ b/taxonomy-editor/src/server/__tests__/chatUrlInject.test.ts
@@ -12,8 +12,8 @@ import type { UrlFetchResult } from '../../../../lib/url-fetch/types.js';
 import { buildUrlInjectedPrompt } from '../routes/chat.js';
 
 type Msg = { role: 'user' | 'model'; content: string };
-const ok = (url: string, text: string): UrlFetchResult =>
-  ({ ok: true, text, title: 'T', finalUrl: url, truncated: false });
+const ok = (url: string, text: string, truncated = false): UrlFetchResult =>
+  ({ ok: true, text, title: 'T', finalUrl: url, truncated });
 const fail = (): UrlFetchResult => ({ ok: false, reason: 'ssrf-blocked' });
 
 describe('t/2483 — buildUrlInjectedPrompt', () => {
@@ -29,8 +29,8 @@ describe('t/2483 — buildUrlInjectedPrompt', () => {
     expect(combinedPrompt).toContain('BODY(https://b.example)');
     expect(combinedPrompt).toContain('System: sys'); // instruction preserved
     expect(urlMeta).toEqual([
-      { retrievedUrl: 'https://a.example', urlRetrievalStatus: 'SUCCESS' },
-      { retrievedUrl: 'https://b.example', urlRetrievalStatus: 'SUCCESS' },
+      { retrievedUrl: 'https://a.example', urlRetrievalStatus: 'SUCCESS', source: 'app-fetch', truncated: false },
+      { retrievedUrl: 'https://b.example', urlRetrievalStatus: 'SUCCESS', source: 'app-fetch', truncated: false },
     ]);
   });
 
@@ -42,7 +42,23 @@ describe('t/2483 — buildUrlInjectedPrompt', () => {
     expect(combinedPrompt).not.toContain('System (fetched URL content):');
     expect(combinedPrompt).not.toContain('Content of');
     expect(combinedPrompt).toContain('System: sys');
-    expect(urlMeta).toEqual([{ retrievedUrl: 'https://blocked.example', urlRetrievalStatus: 'FAILED' }]);
+    expect(urlMeta).toEqual([{ retrievedUrl: 'https://blocked.example', urlRetrievalStatus: 'FAILED', source: 'app-fetch', truncated: false }]);
+  });
+
+  it('sets per-entry source:"app-fetch" + truncated on each entry (Option C — t/2502)', async () => {
+    const msgs: Msg[] = [{ role: 'user', content: 'https://full.example https://cut.example https://bad.example' }];
+    const fetchFn = vi.fn(async (url: string) =>
+      url.includes('bad') ? fail()
+        : ok(url, 'BODY', url.includes('cut')), // 'cut' → truncated true
+    );
+    const { urlMeta } = await buildUrlInjectedPrompt(msgs, '', true, fetchFn);
+    expect(urlMeta).toEqual([
+      { retrievedUrl: 'https://full.example', urlRetrievalStatus: 'SUCCESS', source: 'app-fetch', truncated: false },
+      { retrievedUrl: 'https://cut.example', urlRetrievalStatus: 'SUCCESS', source: 'app-fetch', truncated: true },
+      { retrievedUrl: 'https://bad.example', urlRetrievalStatus: 'FAILED', source: 'app-fetch', truncated: false },
+    ]);
+    // every app-fetch entry is tagged, both success and failure
+    expect(urlMeta.every(e => e.source === 'app-fetch')).toBe(true);
   });
 
   it('frames injected content as untrusted source material (prompt-injection hardening — t/2483#4)', async () => {

--- a/taxonomy-editor/src/server/routes/chat.ts
+++ b/taxonomy-editor/src/server/routes/chat.ts
@@ -91,10 +91,12 @@ async function gatherUrlContent(
     if (result.ok) {
       injectedBlock += `\n\nContent of ${result.finalUrl} fetched at ${new Date().toISOString()}:\n${result.text}`;
       budget -= result.text.length;
-      urlMeta.push({ retrievedUrl: result.finalUrl, urlRetrievalStatus: 'SUCCESS' });
+      // t/2502: per-entry source + truncated (Option C, TL t/2485#4) so the payload is
+      // self-describing; renderer reads source per entry, absent ⇒ 'provider'.
+      urlMeta.push({ retrievedUrl: result.finalUrl, urlRetrievalStatus: 'SUCCESS', source: 'app-fetch', truncated: result.truncated });
       if (budget <= 0) break;
     } else {
-      urlMeta.push({ retrievedUrl: url, urlRetrievalStatus: 'FAILED' });
+      urlMeta.push({ retrievedUrl: url, urlRetrievalStatus: 'FAILED', source: 'app-fetch', truncated: false });
     }
   }
   const fetched = urlMeta.filter(e => e.urlRetrievalStatus === 'SUCCESS').length;


### PR DESCRIPTION
## Summary

Fixes t/2502 (t/2483 follow-up, Option C per TL ruling t/2485#4): makes the app-fetch url-metadata payload **self-describing** by tagging each `UrlContextEntry` per entry, so the renderer distinguishes app-fetched vs provider-grounded per entry.

In `gatherUrlContent` (`chat.ts`): each constructed entry now carries `source: 'app-fetch'`; SUCCESS entries carry `result.truncated`, FAILED entries `false`. Uses the optional `UrlContextEntry.source`/`truncated` fields landed in t/2501.

- **Event-level `source` retained** for back-compat.
- **Provider path (`streamGeminiChat`) untouched** — its entries omit `source`, so the renderer defaults them to `'provider'`.

## AC coverage

- [x] app-fetch entries carry `source:'app-fetch'` + `truncated` per entry
- [x] provider path emits no `source` field (unchanged)
- [x] event-level `source` retained
- [x] test covers per-entry fields on SUCCESS (truncated true/false) and FAILED

## Test plan

`chatUrlInject.test.ts` — new per-entry test (full=truncated:false, cut=truncated:true, bad=FAILED, all source:'app-fetch'); existing SUCCESS/FAILED assertions updated for the new fields. 12 tests green; tsc clean; eslint clean (no net-new warning).

Design pre-approved by Main (TL) via t/2485#4; implemented directly on t/2501 landing per p/333#79. No deviations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
