### PR TITLE
fix(debate): thread dialecticalStyle through adaptive config instead of hardcoding adversarial (t/2511)

### DIFF
--- a/lib/debate/debateEngine.lifecycle.test.ts
+++ b/lib/debate/debateEngine.lifecycle.test.ts
@@ -1083,6 +1083,24 @@ describe('Adaptive staging initialization', () => {
     expect(stored).toEqual(override);
   });
 
+  it('threads dialecticalStyle from config into _adaptiveConfig (t/2511)', () => {
+    const config = createDefaultConfig({ useAdaptiveStaging: true, dialecticalStyle: 'integrative' });
+    const engine = new DebateEngine(config, createMockAdapter(), createMinimalTaxonomy());
+    (engine as unknown as { initSession: () => void }).initSession();
+    const adaptiveConfig = (engine as unknown as { _adaptiveConfig: { dialecticalStyle: string } | null })._adaptiveConfig;
+    expect(adaptiveConfig).not.toBeNull();
+    expect(adaptiveConfig!.dialecticalStyle).toBe('integrative');
+  });
+
+  it('defaults dialecticalStyle to adversarial when not set (t/2511)', () => {
+    const config = createDefaultConfig({ useAdaptiveStaging: true });
+    const engine = new DebateEngine(config, createMockAdapter(), createMinimalTaxonomy());
+    (engine as unknown as { initSession: () => void }).initSession();
+    const adaptiveConfig = (engine as unknown as { _adaptiveConfig: { dialecticalStyle: string } | null })._adaptiveConfig;
+    expect(adaptiveConfig).not.toBeNull();
+    expect(adaptiveConfig!.dialecticalStyle).toBe('adversarial');
+  });
+
   it('does not create adaptive diagnostics when useAdaptiveStaging is false', async () => {
     const responses: string[] = [];
     for (let i = 0; i < 200; i++) {

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -1032,7 +1032,7 @@ export class DebateEngine {
         useAdaptiveStaging: true,
         maxTotalRounds: this.config.maxTotalRounds ?? preset.maxTotalRounds,
         pacing,
-        dialecticalStyle: 'adversarial',
+        dialecticalStyle: this.config.dialecticalStyle ?? 'adversarial',
         argumentationExitThreshold: this.config.argumentationExitThreshold ?? preset.argumentationExit,
         concludingExitThreshold: this.config.concludingExitThreshold ?? preset.concludingExit,
         allowEarlyTermination: this.config.allowEarlyTermination ?? true,

--- a/lib/debate/debateEngine/internals.ts
+++ b/lib/debate/debateEngine/internals.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { type DebateSession, type DebateSourceType, type SpeakerId, type DebatePacing } from '../types.js';
+import type { DialecticalStyle } from '../types/phase.js';
 
 // ── Lifecycle stages (for stopAfterStage on resume) ─────
 
@@ -56,6 +57,8 @@ export interface DebateConfig {
   useAdaptiveStaging?: boolean;
   /** Pacing preset — controls max rounds and exit thresholds. Default: 'moderate'. */
   pacing?: DebatePacing;
+  /** Dialectical style — controls phase exit thresholds. Default: 'adversarial'. Preset-specific: socratic→integrative, deep→deliberative, quick→adversarial. */
+  dialecticalStyle?: DialecticalStyle;
   /** Override max total rounds (otherwise derived from pacing preset). */
   maxTotalRounds?: number;
   /** Override exploration exit threshold (otherwise derived from pacing preset). */


### PR DESCRIPTION
## Summary

- `debateEngine.ts:1035` hardcoded `dialecticalStyle: 'adversarial'` when building adaptive-staging config, silently overriding any preset or user selection
- `socratic` (integrative) and `deep` (deliberative) presets were running with adversarial exit thresholds instead of their intended behavior
- Fix: add `dialecticalStyle?: DialecticalStyle` to `DebateConfig`, read `this.config.dialecticalStyle ?? 'adversarial'` instead of the literal

## Changes

- `lib/debate/debateEngine/internals.ts` — add `dialecticalStyle?: DialecticalStyle` to `DebateConfig`
- `lib/debate/debateEngine.ts:1035` — thread from config instead of hardcoding
- `lib/debate/debateEngine.lifecycle.test.ts` — two new tests covering both cases

## Test plan

- [x] `npx vitest run debateEngine.lifecycle.test.ts` — 49/49 pass
- [x] `tsc --noEmit` — clean
- [x] New tests: "threads dialecticalStyle from config" and "defaults to adversarial when not set"

Generated with [Claude Code](https://claude.com/claude-code)