### PR TITLE
feat(debate): Socratic (elenchus) moderator prompt mode (t/2513)

### DIFF
--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -48,7 +48,7 @@ interface CLIConfig {
   apiKey?: string;
   temperature?: number;
   audience?: string;
-  moderatorMode?: 'standard' | 'talmudic';
+  moderatorMode?: 'standard' | 'talmudic' | 'socratic';
   talmudicReferences?: {
     enabled: boolean;
     corpusPath: string;
@@ -370,13 +370,13 @@ async function main(): Promise<void> {
   log(`Model: ${model}`);
 
   const moderatorMode = config.moderatorMode ?? 'standard';
-  if (moderatorMode !== 'standard' && moderatorMode !== 'talmudic') {
+  if (moderatorMode !== 'standard' && moderatorMode !== 'talmudic' && moderatorMode !== 'socratic') {
     throw new ActionableError({
       goal: 'Validate debate configuration',
       problem: `Unknown moderator mode: ${moderatorMode}`,
       location: 'cli.main',
       nextSteps: [
-        'Set "moderatorMode" to "standard" or "talmudic"',
+        'Set "moderatorMode" to "standard", "talmudic", or "socratic"',
         'Remove the field to use standard moderation',
       ],
     });

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -395,8 +395,7 @@ export class DebateEngine {
       }
     }
 
-    const derivedModeratorMode = config.moderatorMode
-      ?? (config.protocolId === 'socratic' ? 'socratic' : undefined);
+    const derivedModeratorMode = config.moderatorMode ?? (config.protocolId === 'socratic' ? 'socratic' : undefined);
     this.config = { ...config, stageModels: merged, moderatorMode: derivedModeratorMode };
     this._talmudicCorpus = initTalmudicCorpusFromConfig(this.config);
     this.adapter = adapter;

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -395,7 +395,9 @@ export class DebateEngine {
       }
     }
 
-    this.config = { ...config, stageModels: merged };
+    const derivedModeratorMode = config.moderatorMode
+      ?? (config.protocolId === 'socratic' ? 'socratic' : undefined);
+    this.config = { ...config, stageModels: merged, moderatorMode: derivedModeratorMode };
     this._talmudicCorpus = initTalmudicCorpusFromConfig(this.config);
     this.adapter = adapter;
     this.taxonomy = taxonomy;

--- a/lib/debate/mcp-server.ts
+++ b/lib/debate/mcp-server.ts
@@ -98,7 +98,7 @@ server.tool(
     rounds: z.number().optional().describe('Number of rounds (default: 3)'),
     activePovers: z.array(z.string()).optional().describe('Active perspectives (default: all three)'),
     audience: z.string().optional().describe('Target audience'),
-    moderatorMode: z.enum(['standard', 'talmudic']).optional().describe('Moderator strategy (default: standard; talmudic is method-only)'),
+    moderatorMode: z.enum(['standard', 'talmudic', 'socratic']).optional().describe('Moderator strategy (default: standard; talmudic enables source-card dialectics; socratic enables elenchus inquiry)'),
     responseLength: z.enum(['brief', 'medium', 'detailed']).optional().describe('Response length preset'),
     pacing: z.string().optional().describe('Pacing preset'),
     outputDir: z.string().optional().describe('Output directory for session JSON'),

--- a/lib/debate/orchestration.ts
+++ b/lib/debate/orchestration.ts
@@ -710,7 +710,7 @@ export async function runModeratorSelection(
         target_debater: labelMap[String(parsed.target_debater ?? '').toLowerCase()] ?? undefined,
         trigger_reasoning: parsed.trigger_reasoning as string | undefined,
         trigger_evidence: parsed.trigger_evidence as SelectionResult['trigger_evidence'] | undefined,
-        dialectical_diagnostic: moderatorMode === 'talmudic'
+        dialectical_diagnostic: (moderatorMode === 'talmudic' || moderatorMode === 'socratic')
           ? parseDialecticalDiagnostic(parsed.dialectical_diagnostic, focusPoint)
           : undefined,
       };

--- a/lib/debate/prompts/moderator.ts
+++ b/lib/debate/prompts/moderator.ts
@@ -100,8 +100,34 @@ Add a "dialectical_diagnostic" field to your JSON response:
 }
 ` : '';
 
+  const socraticBlock = moderatorMode === 'socratic' ? `
+=== SOCRATIC (ELENCHUS) MODERATION MODE ===
+You are operating in Socratic moderation mode. Your role is to conduct elenctic examination — non-adversarial, single-thread inquiry that moves from position to assumption to aporia or refinement.
+
+Core sequence (one thread at a time):
+1. ELICIT: Draw out the interlocutor's exact position on the crux this round — what precisely do they claim?
+2. SURFACE: Identify the operative assumption their position depends on — what must be true for their claim to hold?
+3. PROBE: Offer a counter-case — a scenario, precedent, or reductio — that tests whether the assumption holds under pressure.
+4. RESOLUTION: Drive toward either (a) a contradiction the interlocutor must resolve, or (b) a refined, more precise definition that survives the probe.
+
+Constraints:
+- One inquiry thread per round — do not split attention across multiple lines of questioning
+- Non-adversarial: you are testing for precision, not seeking defeat
+- Draw only from what debaters have stated — do not introduce new evidence or claims of your own
+- If no operative assumption is yet visible, direct this round toward eliciting a clearer position first
+
+Add a "dialectical_diagnostic" field to your JSON response:
+{
+  "focused_crux": "the position or claim being examined this round",
+  "disagreement_type": "empirical|causal|definitional|normative|mixed|unclear",
+  "premise_under_examination": "the operative assumption being tested, or null if still eliciting",
+  "distinction_or_analogy_tested": "the counter-case or scenario being probed, or null",
+  "unresolved_outcome": "the contradiction to resolve or the refined definition still needed, or null"
+}
+` : '';
+
   return `You are a debate moderator analyzing the current state of a structured debate.
-${talmudicBlock}
+${talmudicBlock}${socraticBlock}
 ROLE: You are procedurally authoritative but not substantively neutral. You evaluate PROCESS (who is evading, what claims are unaddressed, which arguments lack evidence) but not SUBSTANCE (who is right). Your choices about what to highlight are inherently selective — be transparent about WHY you are directing attention to a particular point. When describing the debate state, use observable facts ("Safetyist has not responded to AN-5") rather than evaluative judgments ("Safetyist's argument is weak").
 ${audienceLine}${phaseObjective}${sourceAnchorSection}${topicAnchoringBlock ?? ''}${driftDetectionBlock}
 === RECENT DEBATE EXCHANGE ===

--- a/lib/debate/prompts/moderator.ts
+++ b/lib/debate/prompts/moderator.ts
@@ -104,10 +104,12 @@ Add a "dialectical_diagnostic" field to your JSON response:
 === SOCRATIC (ELENCHUS) MODERATION MODE ===
 You are operating in Socratic moderation mode. Your role is to conduct elenctic examination — non-adversarial, single-thread inquiry that moves from position to assumption to aporia or refinement.
 
+PRECEDENCE: This mode supersedes any adversarial phase directives below. Do not enforce confrontation-phase push-for-disagreement rules — single-thread elenctic inquiry applies throughout all phases.
+
 Core sequence (one thread at a time):
 1. ELICIT: Draw out the interlocutor's exact position on the crux this round — what precisely do they claim?
 2. SURFACE: Identify the operative assumption their position depends on — what must be true for their claim to hold?
-3. PROBE: Offer a counter-case — a scenario, precedent, or reductio — that tests whether the assumption holds under pressure.
+3. PROBE: Construct a reductio or counter-case derived from the interlocutor's own stated premises — does the assumption hold when pushed to its logical consequence? Do not introduce external scenarios, precedents, or evidence not already in the transcript.
 4. RESOLUTION: Drive toward either (a) a contradiction the interlocutor must resolve, or (b) a refined, more precise definition that survives the probe.
 
 Constraints:

--- a/lib/debate/types/moderator.ts
+++ b/lib/debate/types/moderator.ts
@@ -345,7 +345,7 @@ export interface InterventionResponseFields {
 
 // ── Talmudic Moderator types ───────────────────────────
 
-export type ModeratorMode = 'standard' | 'talmudic';
+export type ModeratorMode = 'standard' | 'talmudic' | 'socratic';
 
 export type DialecticalDisagreementType = 'empirical' | 'causal' | 'definitional' | 'normative' | 'mixed' | 'unclear';
 


### PR DESCRIPTION
## Summary
- Adds `'socratic'` to `ModeratorMode` type union (`types/moderator.ts`)
- Adds a distinct elenchus prompt block to `moderatorSelectionPrompt`: elicit position → surface operative assumption → probe with reductio/counter-case from interlocutor's own premises → aporia or refined definition. Non-adversarial, single-thread-per-round. Includes PRECEDENCE line overriding adversarial confrontation-phase directives. Emits `dialectical_diagnostic` with same schema as talmudic mode.
- Wires `protocolId === 'socratic'` → `moderatorMode: 'socratic'` in `DebateEngine` constructor (explicit config override wins)
- Extends `dialectical_diagnostic` parsing in `orchestration.ts` to cover socratic mode
- Updates `cli.ts` and `mcp-server.ts` validation/Zod enum to accept `'socratic'`

## Known limitations (tracked separately)
- t/2514: selection is still N-party in socratic mode (no single-interlocutor gating)
- t/2515: agreement-detection telos unchanged — convergence logic is not reoriented for elenchus

## Test plan
- [x] All 2939 existing tests pass (121/122 files, 1 pre-existing skip)
- [ ] CL sign-off on prompt text (AC requirement — pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)