### PR TITLE
feat(ai-client): signal-aware retry ladder — AbortSignal through retry/client/providers (t/2507)

### DIFF
--- a/lib/ai-client/client.ts
+++ b/lib/ai-client/client.ts
@@ -79,6 +79,7 @@ export function createAIClient(
         retryConfig,
         `${backend}/${apiModelId}`,
         deps.onRetryLog,
+        effectiveOpts.signal,
       );
       if (result.usage) {
         result.estimatedCostUsd = estimateCost(registry, apiModelId, result.usage);

--- a/lib/ai-client/providers/azure.ts
+++ b/lib/ai-client/providers/azure.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
 import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
@@ -49,18 +49,15 @@ export async function generateViaAzure(
     reqBody.response_format = { type: 'json_object' };
   }
 
-  const response = await withTimeout(
-    fetchFn(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'api-key': apiKey,
-      },
-      body: JSON.stringify(reqBody),
-    }),
-    timeoutMs,
-    'Azure OpenAI API request',
-  );
+  const response = await fetchFn(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'api-key': apiKey,
+    },
+    body: JSON.stringify(reqBody),
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 60_000, 'Reading Azure OpenAI response');
 

--- a/lib/ai-client/providers/claude.ts
+++ b/lib/ai-client/providers/claude.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult, ToolCall } from '../types.js';
 
 export async function generateViaClaude(
@@ -44,15 +44,12 @@ export async function generateViaClaude(
     'anthropic-version': '2023-06-01',
   };
 
-  const response = await withTimeout(
-    fetchFn('https://api.anthropic.com/v1/messages', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(reqBody),
-    }),
-    timeoutMs,
-    'Claude API request',
-  );
+  const response = await fetchFn('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(reqBody),
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 180_000, 'Reading Claude response');
 
@@ -67,15 +64,12 @@ export async function generateViaClaude(
   // Some models (e.g. claude-opus-4-7) reject temperature — retry without it
   if (response.status === 400 && reqBody.temperature != null && bodyText.includes('temperature')) {
     delete reqBody.temperature;
-    const retryResponse = await withTimeout(
-      fetchFn('https://api.anthropic.com/v1/messages', {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(reqBody),
-      }),
-      timeoutMs,
-      'Claude API request (retry without temperature)',
-    );
+    const retryResponse = await fetchFn('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(reqBody),
+      signal: makeFetchSignal(timeoutMs, opts.signal),
+    });
     const retryBodyText = await withTimeout(retryResponse.text(), 180_000, 'Reading Claude retry response');
     if (!retryResponse.ok) {
       throw new ActionableError({

--- a/lib/ai-client/providers/deepseek.ts
+++ b/lib/ai-client/providers/deepseek.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
 import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
@@ -19,26 +19,23 @@ export async function generateViaDeepSeek(
   if (opts.systemMessage) messages.push({ role: 'system', content: opts.systemMessage });
   messages.push({ role: 'user', content: prompt });
 
-  const response = await withTimeout(
-    fetchFn('https://api.deepseek.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: apiModelId,
-        messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
-        max_tokens: opts.maxTokens ?? 8192,
-        ...(opts.jsonMode ? {
-          response_format: { type: 'json_object' },
-        } : {}),
-      }),
+  const response = await fetchFn('https://api.deepseek.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: apiModelId,
+      messages,
+      temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
+      max_tokens: opts.maxTokens ?? 8192,
+      ...(opts.jsonMode ? {
+        response_format: { type: 'json_object' },
+      } : {}),
     }),
-    timeoutMs,
-    'DeepSeek API request',
-  );
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 60_000, 'Reading DeepSeek response');
 
@@ -106,26 +103,23 @@ export async function generateViaDeepSeekStream(
   if (opts.systemMessage) messages.push({ role: 'system', content: opts.systemMessage });
   messages.push({ role: 'user', content: prompt });
 
-  const response = await withTimeout(
-    fetchFn('https://api.deepseek.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: apiModelId,
-        messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
-        max_tokens: opts.maxTokens ?? 8192,
-        stream: true,
-        stream_options: { include_usage: true },
-        ...(opts.jsonMode ? { response_format: { type: 'json_object' } } : {}),
-      }),
+  const response = await fetchFn('https://api.deepseek.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: apiModelId,
+      messages,
+      temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
+      max_tokens: opts.maxTokens ?? 8192,
+      stream: true,
+      stream_options: { include_usage: true },
+      ...(opts.jsonMode ? { response_format: { type: 'json_object' } } : {}),
     }),
-    timeoutMs,
-    'DeepSeek streaming API request',
-  );
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   if (response.status === 429 || response.status === 503) {
     const errBody = await response.text().catch(() => '');

--- a/lib/ai-client/providers/gemini-search.ts
+++ b/lib/ai-client/providers/gemini-search.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+// no retry import needed — geminiGroundedSearch uses AbortSignal.timeout directly
 import type { FetchFn } from '../types.js';
 import { GEMINI_BASE, GEMINI_SAFETY_SETTINGS } from './gemini.js';
 
@@ -33,20 +33,17 @@ export async function geminiGroundedSearch(
 ): Promise<GroundedSearchResult> {
   const url = `${GEMINI_BASE}/${apiModelId}:generateContent?key=${apiKey}`;
 
-  const response = await withTimeout(
-    fetchFn(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ parts: [{ text: prompt }] }],
-        tools: [{ google_search: {} }],
-        generationConfig: { temperature: 0.2, maxOutputTokens: 16384 },
-        safetySettings: GEMINI_SAFETY_SETTINGS,
-      }),
+  const response = await fetchFn(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }] }],
+      tools: [{ google_search: {} }],
+      generationConfig: { temperature: 0.2, maxOutputTokens: 16384 },
+      safetySettings: GEMINI_SAFETY_SETTINGS,
     }),
-    60_000,
-    'Gemini grounded search',
-  );
+    signal: AbortSignal.timeout(60_000),
+  });
 
   if (!response.ok) {
     const body = await response.text();

--- a/lib/ai-client/providers/gemini.ts
+++ b/lib/ai-client/providers/gemini.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult, ToolCall, UrlContextMetadata } from '../types.js';
 import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
@@ -105,15 +105,12 @@ export async function generateViaGemini(
   const tools = buildGeminiTools(opts);
   if (tools) body.tools = tools;
 
-  const response = await withTimeout(
-    fetchFn(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }),
-    timeoutMs,
-    'Gemini API request',
-  );
+  const response = await fetchFn(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 60_000, 'Reading Gemini response');
 
@@ -201,15 +198,12 @@ export async function generateViaGeminiStream(
   const tools = buildGeminiTools(opts);
   if (tools) body.tools = tools;
 
-  const response = await withTimeout(
-    fetchFn(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }),
-    timeoutMs,
-    'Gemini streaming API request',
-  );
+  const response = await fetchFn(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   if (response.status === 429 || response.status === 503) {
     const errBody = await response.text().catch(() => '');

--- a/lib/ai-client/providers/groq.ts
+++ b/lib/ai-client/providers/groq.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
 import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
@@ -19,31 +19,28 @@ export async function generateViaGroq(
   if (opts.systemMessage) messages.push({ role: 'system', content: opts.systemMessage });
   messages.push({ role: 'user', content: prompt });
 
-  const response = await withTimeout(
-    fetchFn('https://api.groq.com/openai/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: apiModelId,
-        messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
-        max_tokens: opts.maxTokens ?? 8192,
-        ...(opts.responseSchema ? {
-          response_format: {
-            type: 'json_schema',
-            json_schema: { name: 'response', schema: opts.responseSchema, strict: true },
-          },
-        } : opts.jsonMode ? {
-          response_format: { type: 'json_object' },
-        } : {}),
-      }),
+  const response = await fetchFn('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: apiModelId,
+      messages,
+      temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
+      max_tokens: opts.maxTokens ?? 8192,
+      ...(opts.responseSchema ? {
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'response', schema: opts.responseSchema, strict: true },
+        },
+      } : opts.jsonMode ? {
+        response_format: { type: 'json_object' },
+      } : {}),
     }),
-    timeoutMs,
-    'Groq API request',
-  );
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 60_000, 'Reading Groq response');
 

--- a/lib/ai-client/providers/moonshot.ts
+++ b/lib/ai-client/providers/moonshot.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
 import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
@@ -21,26 +21,23 @@ export async function generateViaMoonshot(
   if (opts.systemMessage) messages.push({ role: 'system', content: opts.systemMessage });
   messages.push({ role: 'user', content: prompt });
 
-  const response = await withTimeout(
-    fetchFn(`${MOONSHOT_BASE}/chat/completions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: apiModelId,
-        messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
-        max_tokens: opts.maxTokens ?? 8192,
-        ...(opts.jsonMode ? {
-          response_format: { type: 'json_object' },
-        } : {}),
-      }),
+  const response = await fetchFn(`${MOONSHOT_BASE}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: apiModelId,
+      messages,
+      temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
+      max_tokens: opts.maxTokens ?? 8192,
+      ...(opts.jsonMode ? {
+        response_format: { type: 'json_object' },
+      } : {}),
     }),
-    timeoutMs,
-    'Moonshot API request',
-  );
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 60_000, 'Reading Moonshot response');
 

--- a/lib/ai-client/providers/ollama.ts
+++ b/lib/ai-client/providers/ollama.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
 import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
@@ -14,11 +14,9 @@ export const OLLAMA_BASE = 'http://localhost:11434';
  */
 export async function isOllamaAvailable(fetchFn: FetchFn): Promise<boolean> {
   try {
-    const res = await withTimeout(
-      fetchFn(`${OLLAMA_BASE}/api/tags`),
-      3000,
-      'Ollama availability check',
-    );
+    const res = await fetchFn(`${OLLAMA_BASE}/api/tags`, {
+      signal: AbortSignal.timeout(3000),
+    });
     return res.ok;
   } catch {
     return false;
@@ -52,15 +50,12 @@ export async function generateViaOllama(
     reqBody.format = 'json';
   }
 
-  const response = await withTimeout(
-    fetchFn(`${OLLAMA_BASE}/v1/chat/completions`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(reqBody),
-    }),
-    timeoutMs,
-    'Ollama API request',
-  );
+  const response = await fetchFn(`${OLLAMA_BASE}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(reqBody),
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 120_000, 'Reading Ollama response');
 

--- a/lib/ai-client/providers/openai.ts
+++ b/lib/ai-client/providers/openai.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
 
 export async function generateViaOpenAI(
@@ -23,18 +23,15 @@ export async function generateViaOpenAI(
     reqBody.instructions = opts.systemMessage;
   }
 
-  const response = await withTimeout(
-    fetchFn('https://api.openai.com/v1/responses', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(reqBody),
-    }),
-    timeoutMs,
-    'OpenAI API request',
-  );
+  const response = await fetchFn('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(reqBody),
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 60_000, 'Reading OpenAI response');
 

--- a/lib/ai-client/providers/zai.ts
+++ b/lib/ai-client/providers/zai.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { ActionableError } from '../../debate/errors.js';
-import { withTimeout } from '../retry.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
 import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
 import { DEFAULT_TEMPERATURE } from '../defaults.js';
 
@@ -19,31 +19,28 @@ export async function generateViaZai(
   if (opts.systemMessage) messages.push({ role: 'system', content: opts.systemMessage });
   messages.push({ role: 'user', content: prompt });
 
-  const response = await withTimeout(
-    fetchFn('https://api.z.ai/api/paas/v4/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: apiModelId,
-        messages,
-        temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
-        max_tokens: opts.maxTokens ?? 16384,
-        ...(opts.responseSchema ? {
-          response_format: {
-            type: 'json_schema',
-            json_schema: { name: 'response', schema: opts.responseSchema, strict: true },
-          },
-        } : opts.jsonMode ? {
-          response_format: { type: 'json_object' },
-        } : {}),
-      }),
+  const response = await fetchFn('https://api.z.ai/api/paas/v4/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: apiModelId,
+      messages,
+      temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
+      max_tokens: opts.maxTokens ?? 16384,
+      ...(opts.responseSchema ? {
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'response', schema: opts.responseSchema, strict: true },
+        },
+      } : opts.jsonMode ? {
+        response_format: { type: 'json_object' },
+      } : {}),
     }),
-    timeoutMs,
-    'Z.AI API request',
-  );
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
 
   const bodyText = await withTimeout(response.text(), 60_000, 'Reading Z.AI response');
 

--- a/lib/ai-client/retry.test.ts
+++ b/lib/ai-client/retry.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { withRetry, parseRateLimitHeaders, parseRateLimitType, retryableFetch } from './retry.js';
+import { withRetry, parseRateLimitHeaders, parseRateLimitType, retryableFetch, makeFetchSignal } from './retry.js';
 import type { RetryConfig } from './retry.js';
 
 const FAST_CONFIG: RetryConfig = {
@@ -116,6 +116,95 @@ describe('withRetry — auth error fast-fail', () => {
       throw new Error('JSON parse error: unexpected token');
     }, FAST_CONFIG, 'test')).rejects.toThrow('JSON parse');
     expect(calls).toBe(1);
+  });
+});
+
+describe('withRetry — AbortSignal (t/2507)', () => {
+  it('throws AbortError immediately without calling fn when signal is pre-aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let calls = 0;
+    await expect(withRetry(async () => { calls++; return 'ok'; }, FAST_CONFIG, 'test', undefined, controller.signal))
+      .rejects.toMatchObject({ name: 'AbortError' });
+    expect(calls).toBe(0);
+  });
+
+  it('does not retry AbortError thrown from fn', async () => {
+    let calls = 0;
+    await expect(withRetry(async () => {
+      calls++;
+      throw new DOMException('Aborted', 'AbortError');
+    }, FAST_CONFIG, 'test')).rejects.toMatchObject({ name: 'AbortError' });
+    expect(calls).toBe(1);
+  });
+
+  it('stops retrying and throws AbortError when signal fires during backoff', async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const p = withRetry(async () => {
+      calls++;
+      if (calls === 1) {
+        // abort while the first retry backoff would be sleeping
+        setTimeout(() => controller.abort(), 0);
+        throw new Error('fetch failed: ECONNRESET');
+      }
+      return 'ok';
+    }, FAST_CONFIG, 'test', undefined, controller.signal);
+    await expect(p).rejects.toMatchObject({ name: 'AbortError' });
+    expect(calls).toBe(1);
+  });
+});
+
+describe('retryableFetch — AbortSignal (t/2507)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws AbortError immediately when signal is pre-aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fetchFn = vi.fn();
+    await expect(retryableFetch({
+      label: 'test', url: 'https://example.com', init: { method: 'POST' },
+      timeoutMs: 5000, fetchFn, config: FAST_CONFIG, signal: controller.signal,
+    })).rejects.toMatchObject({ name: 'AbortError' });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('does not retry when fetch throws AbortError', async () => {
+    let calls = 0;
+    const fetchFn = vi.fn().mockImplementation(() => {
+      calls++;
+      throw new DOMException('Aborted', 'AbortError');
+    });
+    await expect(retryableFetch({
+      label: 'test', url: 'https://example.com', init: { method: 'POST' },
+      timeoutMs: 5000, fetchFn, config: FAST_CONFIG,
+    })).rejects.toMatchObject({ name: 'AbortError' });
+    expect(calls).toBe(1);
+  });
+});
+
+describe('makeFetchSignal (t/2507)', () => {
+  it('returns a signal that fires after the timeout with no caller signal', () => {
+    const sig = makeFetchSignal(100);
+    expect(sig).toBeInstanceOf(AbortSignal);
+    expect(sig.aborted).toBe(false);
+  });
+
+  it('returns an already-aborted signal when caller signal is pre-aborted', () => {
+    const controller = new AbortController();
+    controller.abort();
+    const sig = makeFetchSignal(30_000, controller.signal);
+    expect(sig.aborted).toBe(true);
+  });
+
+  it('combines caller signal and timeout — fires when caller aborts', async () => {
+    const controller = new AbortController();
+    const sig = makeFetchSignal(30_000, controller.signal);
+    expect(sig.aborted).toBe(false);
+    controller.abort();
+    expect(sig.aborted).toBe(true);
   });
 });
 

--- a/lib/ai-client/retry.ts
+++ b/lib/ai-client/retry.ts
@@ -13,6 +13,34 @@ export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): 
   ]);
 }
 
+/**
+ * Creates a per-attempt AbortSignal that fires on whichever comes first:
+ * the caller's signal or the per-attempt timeout. Replacing Promise.race
+ * (withTimeout on fetch) ensures the losing fetch is actually cancelled
+ * rather than left running in the background (t/2507).
+ */
+export function makeFetchSignal(timeoutMs: number, callerSignal?: AbortSignal): AbortSignal {
+  return callerSignal
+    ? AbortSignal.any([callerSignal, AbortSignal.timeout(timeoutMs)])
+    : AbortSignal.timeout(timeoutMs);
+}
+
+/** Sleeps for ms, but wakes early and throws AbortError when signal fires. */
+async function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+  return new Promise<void>((resolve, reject) => {
+    const tid = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    function onAbort() {
+      clearTimeout(tid);
+      reject(new DOMException('Aborted', 'AbortError'));
+    }
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 export function parseRateLimitType(bodyText: string): { limitType: RateLimitType; limitMessage: string } {
   try {
     const json = JSON.parse(bodyText);
@@ -88,6 +116,7 @@ export async function withRetry<T>(
   config: RetryConfig,
   label: string,
   onLog?: (msg: string) => void,
+  signal?: AbortSignal,
 ): Promise<T> {
   // NOTE (t/2492): this is the low-level per-call AI-client retry layer. The renderer's
   // user-facing debate/chat orchestration retry uses a separate, independent classifier at
@@ -95,9 +124,13 @@ export async function withRetry<T>(
   // layer, different budget). If you change the transient-retry set here, check whether that
   // classifier wants the same, and vice versa.
   for (let attempt = 1; attempt <= config.maxRetries; attempt++) {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     try {
       return await fn();
     } catch (err: unknown) {
+      // AbortError is non-retryable — rethrow immediately (t/2507).
+      // Use name-check rather than instanceof so DOMException works in all environments.
+      if ((err as { name?: unknown } | null)?.name === 'AbortError') throw err;
       const msg = err instanceof Error ? err.message : String(err);
       const lower = msg.toLowerCase();
       if (lower.includes('error 401') || lower.includes('error 403') ||
@@ -119,7 +152,7 @@ export async function withRetry<T>(
       const delay = isRateLimit ? Math.max(baseDelay, RATE_LIMIT_MIN_DELAY_S) : baseDelay;
       const errSummary = err instanceof ActionableError ? err.problem : msg.slice(0, 300);
       onLog?.(`[retry] ${label} attempt ${attempt}/${config.maxRetries} failed (${errSummary}), waiting ${delay}s...`);
-      await new Promise(r => setTimeout(r, delay * 1000));
+      await abortableSleep(delay * 1000, signal);
     }
   }
   throw new ActionableError({
@@ -138,19 +171,31 @@ export async function retryableFetch(opts: {
   fetchFn: FetchFn;
   config?: RetryConfig;
   onRetry?: (p: RetryProgress) => void;
+  signal?: AbortSignal;
 }): Promise<{ response: Response; bodyText: string }> {
   const config = opts.config ?? SERVER_RETRY_CONFIG;
   for (let attempt = 1; attempt <= config.maxRetries; attempt++) {
+    if (opts.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
     let response: Response;
     try {
-      response = await withTimeout(opts.fetchFn(opts.url, opts.init), opts.timeoutMs, opts.label);
+      response = await opts.fetchFn(opts.url, {
+        ...opts.init,
+        signal: makeFetchSignal(opts.timeoutMs, opts.signal),
+      });
     } catch (err: unknown) {
-      if (attempt === config.maxRetries) throw err instanceof Error ? err : new Error(String(err));
+      // AbortError is non-retryable (t/2507). Name-check works for both Error and DOMException.
+      if ((err as { name?: unknown } | null)?.name === 'AbortError') throw err;
+      if (attempt === config.maxRetries) {
+        if (err instanceof Error) throw err;
+        // Preserve non-Error throwables (e.g. DOMException where instanceof varies by environment)
+        if (err != null && typeof err === 'object') throw err as Error;
+        throw new Error(String(err));
+      }
       const backoff = config.strategy === 'fixed'
         ? (config.fixedDelays?.[attempt - 1] ?? 45)
         : Math.min(2 ** attempt, config.maxBackoffS ?? 30);
       opts.onRetry?.({ attempt, maxRetries: config.maxRetries, backoffSeconds: backoff, limitType: 'unknown', limitMessage: 'Network error. Retrying...' });
-      await new Promise(r => setTimeout(r, backoff * 1000));
+      await abortableSleep(backoff * 1000, opts.signal);
       continue;
     }
 
@@ -184,7 +229,7 @@ export async function retryableFetch(opts: {
         ? rateLimitHeaders.retryAfterSeconds  // respect server's guidance unconditionally
         : Math.max(exponentialBackoff, RATE_LIMIT_MIN_DELAY_S);
       opts.onRetry?.({ attempt, maxRetries: config.maxRetries, backoffSeconds: backoff, limitType, limitMessage, rateLimitHeaders });
-      await new Promise(r => setTimeout(r, backoff * 1000));
+      await abortableSleep(backoff * 1000, opts.signal);
       continue;
     }
 

--- a/lib/ai-client/types.ts
+++ b/lib/ai-client/types.ts
@@ -34,6 +34,8 @@ export interface GenerateOptions {
    *  registry (ModelEntry.fixedTemperature) for reasoning models that reject arbitrary
    *  values, e.g. moonshot kimi-k3 which only accepts 1 (t/2068). */
   fixedTemperature?: number;
+  /** Caller-provided AbortSignal to cancel the request and all retry attempts (t/2507). */
+  signal?: AbortSignal;
   /** Gemini only: enable URL-context grounding. When set, the provider adds the
    *  `url_context` tool entry so Gemini fetches URLs mentioned in the prompt. */
   urlContext?: boolean;


### PR DESCRIPTION
## Summary

- Adds `signal?: AbortSignal` to `GenerateOptions` so callers can cancel in-flight requests
- Replaces `withTimeout(fetchFn(...))` (Promise.race — loser fetch keeps running) with per-attempt `AbortSignal.any([callerSignal, AbortSignal.timeout(ms)])` passed as `signal` in fetch init — kills the fetch on timeout/cancel rather than abandoning it
- `withRetry` and `retryableFetch` now check `signal?.aborted` before each attempt; AbortError is non-retryable first (before the isRetryable classifier)
- `abortableSleep` helper wakes retry backoff delays early when signal fires
- All 9 providers + streaming paths + gemini-search updated; `withTimeout` kept only for `response.text()` body reads

## Test plan

- [x] `retry.test.ts`: pre-aborted signal, AbortError non-retry, mid-retry abort, `makeFetchSignal` unit tests — all new, all pass
- [x] Full lib suite: 3386 tests pass (0 failures)
- [x] `tsc -p tsconfig.json --noEmit`: clean
- [x] `tsc -p tsconfig.server.json --noEmit`: clean

Blocks: t/2508, t/2509, t/2510

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
