### PR TITLE
fix(flight-recorder): read debate protocol from protocol_id (t/2517)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -718,7 +718,7 @@ export function initFlightRecorder(): FlightRecorder {
           temperature: debateState.debateTemperature,
           is_generating: !!debateState.debateGenerating,
           convergence_signals_count: debate.convergence_signals?.length ?? 0,
-          protocol: debate.protocol ?? null,
+          protocol: debate.protocol_id ?? null,
           calibration_version: _embeddingInfo?.calibration_version ?? undefined,
         } : null,
         taxonomy: {


### PR DESCRIPTION
## Problem
The flight-recorder debate context snapshot (`flightRecorderInit.ts:721`) read `debate.protocol`, a field that does not exist on `DebateSession`. The persisted field is `protocol_id` (`sessionSlice.ts:398`, engine `debateEngine.ts:983`). Result: `protocol: null` recorded on **every** run regardless of the protocol selected — masking protocol-vs-behavior triage (surfaced by t/2512, confirmed in dump `flight-recorder-2026-08-12T09-51-14.723Z.jsonl`).

## Fix
Read the correct field: `debate.protocol_id ?? null`. `debate` is typed `DebateSession`, which declares `protocol_id?: string` (`lib/debate/types/session.ts:331`) — the change is strictly more type-safe.

## Verification
- `check-renderer-tsc.sh`: 0 errors
- One-line, single-file, renderer-only.

Closes t/2517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)