### PR TITLE
fix(debate): Switch model aborts in-flight opening run and restarts (t/2505)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/useBriefTimeoutEvents.test.ts
+++ b/taxonomy-editor/src/renderer/components/debate/useBriefTimeoutEvents.test.ts
@@ -33,6 +33,14 @@ vi.mock('../../hooks/useDebateStore', () => ({
   },
 }));
 
+// retryWithModel aborts the in-flight pipeline (t/2505) — mock the guard so we can assert
+// it fires and keep this a hermetic hook test (no real abort-controller/store side effects).
+// vi.hoisted so the fn exists before the hoisted vi.mock factory references it.
+const mockCancelAndResetAbort = vi.hoisted(() => vi.fn());
+vi.mock('../../hooks/useDebateStore/shared/guards', () => ({
+  cancelAndResetAbort: mockCancelAndResetAbort,
+}));
+
 vi.mock('@lib/flight-recorder/index', () => ({
   getGlobalRecorder: () => null,
 }));
@@ -102,15 +110,24 @@ describe('useBriefTimeoutEvents', () => {
     expect(result.current.dialogData?.currentModel).toBe('gemini-flash');
   });
 
-  it('retryWithModel clears both and calls runOpeningStatements', () => {
+  it('retryWithModel aborts the in-flight run, clears the guard, and restarts on the new model (t/2505)', () => {
     const { result } = renderHook(() => useBriefTimeoutEvents(DEBATE_ID));
     act(() => emitExhausted());
 
     act(() => result.current.retryWithModel('claude-sonnet-5'));
 
     expect(result.current.dialogData).toBeNull();
-    expect(useDebateStore.setState).toHaveBeenCalledWith({ debateModel: 'claude-sonnet-5' });
-    expect(mockRunOpeningStatements).toHaveBeenCalled();
+    // Aborts the superseded pipeline so it stops burning attempts on the old model...
+    expect(mockCancelAndResetAbort).toHaveBeenCalledTimes(1);
+    // ...sets the new model AND clears debateGenerating so the re-entry guard doesn't
+    // block the restart (the original no-op bug)...
+    expect(useDebateStore.setState).toHaveBeenCalledWith({ debateModel: 'claude-sonnet-5', debateGenerating: null });
+    // ...then kicks off the fresh run.
+    expect(mockRunOpeningStatements).toHaveBeenCalledTimes(1);
+    // Abort must happen before the restart, else the new run's fresh controller would be
+    // torn down. (invocationCallOrder increases with call sequence.)
+    expect(mockCancelAndResetAbort.mock.invocationCallOrder[0])
+      .toBeLessThan(mockRunOpeningStatements.mock.invocationCallOrder[0]);
   });
 
   it('ignores events for a different debateId', () => {

--- a/taxonomy-editor/src/renderer/components/debate/useBriefTimeoutEvents.ts
+++ b/taxonomy-editor/src/renderer/components/debate/useBriefTimeoutEvents.ts
@@ -5,6 +5,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useDebateStore } from '../../hooks/useDebateStore';
+import { cancelAndResetAbort } from '../../hooks/useDebateStore/shared/guards';
 import { POVER_INFO } from '@lib/debate/types';
 import type { SpeakerId } from '@lib/debate/types';
 
@@ -98,15 +99,25 @@ export function useBriefTimeoutEvents(activeDebateId: string | null): UseBriefTi
   const retryWithModel = useCallback((model: string) => {
     setDialogData(null);
     setToastData(null);
-    useDebateStore.setState({ debateModel: model });
+    // Abort the in-flight opening pipeline before restarting (t/2505). It was started with
+    // the old model captured at pipeline start (makeStageGenerate), so a bare debateModel
+    // update can't redirect it — it would keep burning attempts on the old model, and the
+    // runOpeningStatements re-entry guard (debateGenerating) would then block the restart as
+    // a silent no-op. cancelAndResetAbort() lets the superseded pipeline self-discard
+    // (createDebateGuard captures its own controller); clearing debateGenerating reopens the
+    // guard so the fresh run proceeds. Set debateModel first so the new run picks it up.
+    cancelAndResetAbort();
+    useDebateStore.setState({ debateModel: model, debateGenerating: null });
+    void useDebateStore.getState().runOpeningStatements();
+    // Log the outcome — the abort + restart we just performed — not intent. Previously this
+    // fired ahead of a guard that could swallow the retry, so the FR event overstated it.
     getGlobalRecorder()?.record({
       type: 'debate.lifecycle',
       component: 'brief-timeout',
       level: 'info',
-      message: 'Retrying opening statements with new model after brief timeout',
+      message: 'Aborted in-flight opening pipeline and restarted with new model after brief timeout',
       data: { model },
     });
-    void useDebateStore.getState().runOpeningStatements();
   }, []);
 
   // User clicks "Switch model" on the toast before retries are exhausted —

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/runOpeningStatements.abort.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/runOpeningStatements.abort.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Negative assertion for the Switch-model abort fix (t/2505): when a run is superseded
+// mid-pipeline (Switch-model restart aborts it and installs a fresh controller), the
+// abandoned run must bail at the post-pipeline guard and write NO opening transcript
+// entry after the interrupted-line — otherwise a duplicate/mixed-model opening lands.
+// Import the harness FIRST so its hoisted mocks (incl. runOpeningPipeline) register
+// before the store graph is imported.
+import { describe, it, expect, vi } from 'vitest';
+import { makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+import { runOpeningPipeline } from '@lib/debate/turnPipeline';
+import { newAbortController, cancelAndResetAbort } from '../shared/guards';
+
+describe('runOpeningStatements — superseded run writes no opening (t/2505)', () => {
+  it('does not write an opening transcript entry after being aborted during the pipeline', async () => {
+    const session = makeSession({ active_povers: ['skeptic'], phase: 'opening' });
+    useDebateStore.setState({
+      activeDebate: session as unknown as ReturnType<typeof useDebateStore.getState>['activeDebate'],
+      activeDebateId: session.id,
+    });
+
+    // Simulate a Switch-model restart happening DURING the opening pipeline: abort this
+    // run's captured controller, then install a fresh (un-aborted) one — exactly what
+    // retryWithModel → runOpeningStatements does. With the captured-controller guard fix,
+    // this run's isStillValid() must now return false and bail before writing an opening.
+    vi.mocked(runOpeningPipeline).mockImplementation(async () => {
+      cancelAndResetAbort();
+      newAbortController();
+      return {} as unknown as Awaited<ReturnType<typeof runOpeningPipeline>>;
+    });
+
+    await useDebateStore.getState().runOpeningStatements();
+
+    const transcript = useDebateStore.getState().activeDebate?.transcript ?? [];
+
+    // The superseded run must reach the post-pipeline guard, write its single "interrupted"
+    // system marker, and bail. This entry is written ONLY on the isStillValid()-false path
+    // (clarificationSlice.ts:993) — so asserting it is present makes this a real regression
+    // guard: without the captured-controller fix, isStillValid() would return true (the live
+    // global points at the fresh controller), the run would fall through to assemble an
+    // opening, and this marker would never appear.
+    const interrupted = transcript.filter(
+      (e) => e.type === 'system' && typeof e.content === 'string' && e.content.includes('Opening generation interrupted'),
+    );
+    expect(interrupted).toHaveLength(1);
+
+    // …and NO opening is written, and nothing follows the interrupted line (the TL's
+    // negative assertion): the abandoned run does not produce a duplicate/mixed-model opening.
+    expect(transcript.filter((e) => e.type === 'opening')).toHaveLength(0);
+    expect(transcript[transcript.length - 1]).toBe(interrupted[0]);
+
+    // Pipeline entered exactly once (aborted on the first speaker; the run bails, no re-loop).
+    expect(vi.mocked(runOpeningPipeline)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.abortCapture.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.abortCapture.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression tests for the captured-abort-controller fix (t/2505). A Switch-model restart
+// aborts the in-flight run and then starts a fresh one, which reassigns the module-global
+// `_abortController` via newAbortController(). A guard that reads the live global would then
+// see the *new* (un-aborted) controller and wrongly report the superseded run as still valid
+// — so the abandoned pipeline would keep writing (duplicate/mixed transcript entries).
+// createDebateGuard captures its own controller so the superseded run reliably self-discards.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createDebateGuard, newAbortController, cancelAndResetAbort } from './guards';
+
+const getD = (id: string | null) => () => ({ activeDebateId: id });
+
+describe('createDebateGuard — captured abort controller (t/2505)', () => {
+  beforeEach(() => { cancelAndResetAbort(); });
+
+  it('is valid while its run is active', () => {
+    newAbortController();
+    expect(createDebateGuard(getD('d1'))()).toBe(true);
+  });
+
+  it('bails once its own controller is aborted', () => {
+    newAbortController();
+    const guard = createDebateGuard(getD('d1'));
+    cancelAndResetAbort();
+    expect(guard()).toBe(false);
+  });
+
+  it('a superseded run self-discards even after a NEW controller is installed (the regression)', () => {
+    newAbortController();                       // old run's controller (AC_old)
+    const oldGuard = createDebateGuard(getD('d1'));
+    // Switch-model restart: abort AC_old, then the fresh run installs AC_new (un-aborted).
+    cancelAndResetAbort();
+    newAbortController();                        // AC_new — NOT aborted
+    const newGuard = createDebateGuard(getD('d1'));
+    // Pre-fix this read the live global (AC_new) and returned true → old pipeline kept writing.
+    expect(oldGuard()).toBe(false);
+    // The fresh run is unaffected.
+    expect(newGuard()).toBe(true);
+  });
+
+  it('still bails when the active debate changes (existing behavior preserved)', () => {
+    newAbortController();
+    let id: string | null = 'd1';
+    const guard = createDebateGuard(() => ({ activeDebateId: id }));
+    id = 'd2';
+    expect(guard()).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.ts
@@ -14,13 +14,23 @@ export let _abortController: AbortController | null = null;
 
 /**
  * Guard against race conditions in async debate operations.
- * Captures the active debate ID at call time; returns a checker that
- * verifies the debate hasn't changed during an await.
+ * Captures the active debate ID *and this run's abort controller* at call time;
+ * returns a checker that verifies the debate hasn't changed and this run hasn't
+ * been superseded during an await.
+ *
+ * Capturing the controller matters when a new run replaces the module-global
+ * `_abortController` via newAbortController() (e.g. Switch-model restart, t/2505):
+ * a bare `_abortController.signal.aborted` read would see the *new* run's fresh
+ * (un-aborted) controller and wrongly report the superseded run as still valid,
+ * so the abandoned pipeline would keep writing. The captured reference stays
+ * pinned to this run's controller, so cancelAndResetAbort() reliably discards it.
  */
 export function createDebateGuard(get: () => { activeDebateId: string | null }): () => boolean {
   const capturedId = get().activeDebateId;
+  const capturedAbort = _abortController;
   return () => {
-    if (_abortController?.signal.aborted) return false;
+    if (capturedAbort?.signal.aborted) return false; // this run superseded/cancelled
+    if (_abortController?.signal.aborted) return false; // current run cancelled (existing behavior)
     if (capturedId !== get().activeDebateId) {
       console.warn(`[debate] Active debate changed during async operation (was ${capturedId}, now ${get().activeDebateId}). Discarding stale results.`);
       return false;


### PR DESCRIPTION
On a brief timeout, 'Switch model' updated `debateModel` but never cancelled the running opening pipeline (which captured the old model at start), so it kept burning attempts and the `runOpeningStatements` re-entry guard (`debateGenerating`) then blocked the restart as a silent no-op.

**Fix:**
- `retryWithModel`: `cancelAndResetAbort()` → clear `debateGenerating` → set new `debateModel` → `runOpeningStatements()`. FR event now logs outcome, not intent.
- `createDebateGuard` now **captures its own abort controller** at creation. It previously read the module-global `_abortController`, which the fresh run reassigns via `newAbortController()` — so the superseded pipeline would read the new (un-aborted) controller and keep writing a duplicate/mixed-model opening. Strictly more conservative; full useDebateStore suite green (148 tests).

**Tests:** guards-level regression (captured guard bails after abort even with a newer controller installed), store-level negative assertion (superseded run writes the interrupted marker and NO opening after it — verified to fail without the capture fix), and the retryWithModel orchestration/ordering.

Design approved by Main TL (t/2505#2); DebateUI cleared the file edit (p/101#114). Deferred the cosmetic interrupted-message wording tweak as non-blocking. Closes t/2505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)