### PR TITLE
feat(debate): AbortSignal-aware generateText — cancel reaches the fetch (t/2508)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/cancellation.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/cancellation.test.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { isCancellationError, makeCancellationError } from '../cancellation';
+
+describe('cancellation tagging (t/2508)', () => {
+  it('makeCancellationError produces an AbortError tagged cancelled', () => {
+    const e = makeCancellationError();
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe('AbortError');
+    expect((e as Error & { cancelled?: boolean }).cancelled).toBe(true);
+  });
+
+  it('makeCancellationError carries a custom message', () => {
+    expect(makeCancellationError('POST /api/ai/generate cancelled by caller').message)
+      .toBe('POST /api/ai/generate cancelled by caller');
+  });
+
+  it('isCancellationError recognises a tagged cancellation', () => {
+    expect(isCancellationError(makeCancellationError())).toBe(true);
+  });
+
+  it('isCancellationError rejects a plain AbortError (e.g. a timeout)', () => {
+    // A request timeout surfaces as an untagged AbortError — must NOT read as a user cancel,
+    // otherwise a timeout would silently bail instead of retrying/surfacing.
+    const timeout = new DOMException('The operation was aborted', 'AbortError');
+    expect(isCancellationError(timeout)).toBe(false);
+  });
+
+  it('isCancellationError rejects ordinary errors and nullish values', () => {
+    expect(isCancellationError(new Error('boom'))).toBe(false);
+    expect(isCancellationError(null)).toBe(false);
+    expect(isCancellationError(undefined)).toBe(false);
+    expect(isCancellationError({ cancelled: false })).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/__tests__/resilience.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/resilience.test.ts
@@ -124,6 +124,52 @@ describe('resilience', () => {
     });
   });
 
+  describe('resilientFetch — caller abort signal (t/2508)', () => {
+    it('threads a composed signal into fetch when a caller signal is provided', async () => {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { ok: true }));
+      const controller = new AbortController();
+      await resilientFetch('/api/ai/generate', { method: 'POST' }, defaultOpts({ category: 'ai', signal: controller.signal }));
+      const passed = fetchSpy.mock.calls[0][1].signal as AbortSignal;
+      expect(passed).toBeInstanceOf(AbortSignal);
+      expect(passed.aborted).toBe(false);
+    });
+
+    it('does NOT retry when the caller aborts mid-request, even with retries available', async () => {
+      const controller = new AbortController();
+      fetchSpy.mockImplementation(() => {
+        controller.abort();
+        return Promise.reject(new DOMException('The operation was aborted', 'AbortError'));
+      });
+      await expect(
+        resilientFetch('/api/test', {}, defaultOpts({ maxRetries: 3, signal: controller.signal })),
+      ).rejects.toBeInstanceOf(DOMException);
+      expect(fetchSpy).toHaveBeenCalledTimes(1); // caller cancel is non-retryable
+    });
+
+    it('a caller abort does not trip the circuit breaker', async () => {
+      const controller = new AbortController();
+      fetchSpy.mockImplementation(() => {
+        controller.abort();
+        return Promise.reject(new DOMException('The operation was aborted', 'AbortError'));
+      });
+      await expect(
+        resilientFetch('/api/test', {}, defaultOpts({ category: 'ai', signal: controller.signal })),
+      ).rejects.toBeTruthy();
+      expect(getResilienceState().circuits.ai.consecutiveFailures).toBe(0);
+    });
+
+    it('without a caller signal, a timeout-style abort still retries (unchanged behavior)', async () => {
+      fetchSpy
+        .mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'))
+        .mockResolvedValueOnce(mockFetchResponse(200, { ok: true }));
+      const promise = resilientFetch('/api/test', {}, defaultOpts({ maxRetries: 1 }));
+      await vi.advanceTimersByTimeAsync(5000);
+      const res = await promise;
+      expect(res.ok).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('resilientFetch — retry on 5xx', () => {
     it('retries on 500 and succeeds on second attempt', async () => {
       fetchSpy

--- a/taxonomy-editor/src/renderer/bridge/cancellation.ts
+++ b/taxonomy-editor/src/renderer/bridge/cancellation.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Deliberate-cancellation error tagging (t/2508, HLD t/2506#1).
+ *
+ * When a user aborts an in-flight AI request (Switch model mid-brief, Cancel debate),
+ * the bridge rejects with an error carrying `cancelled: true`. Downstream pipeline
+ * catches use {@link isCancellationError} to bail quietly — no error toast, no
+ * auto-retry — instead of treating it as a failure.
+ *
+ * The tag travels with the error rather than being inferred from a live abort
+ * controller: `cancelAndResetAbort()` nulls the debate controller and a replacement
+ * run may install a fresh one, so by the time an abandoned request's rejection
+ * reaches its catch the live controller no longer reflects that request. The tag
+ * makes detection race-free.
+ *
+ * Zero-dependency by design so both bridges (`web-bridge`, `electron-bridge`) and the
+ * debate-store `guards` module can import it without an import cycle.
+ */
+
+export function isCancellationError(err: unknown): boolean {
+  return (err as { cancelled?: boolean } | null)?.cancelled === true;
+}
+
+/** Build the tagged cancellation error the bridge rejects with on a caller abort. */
+export function makeCancellationError(message = 'AI request cancelled by caller'): Error {
+  const e = new Error(message);
+  e.name = 'AbortError';
+  (e as Error & { cancelled: boolean }).cancelled = true;
+  return e;
+}

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -6,6 +6,7 @@
  * Used when the app runs inside Electron (desktop mode).
  */
 import type { AppAPI, UserPreferences } from './types';
+import { makeCancellationError } from './cancellation';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
 import {
@@ -143,7 +144,31 @@ export const api: AppAPI = {
   importKeysFromSharing: (payload, passphrase) => window.electronAPI.importKeysFromSharing(payload, passphrase),
 
   // AI generation
-  generateText: (prompt, model, timeout, temperature) => window.electronAPI.generateText(prompt, model, timeout, temperature),
+  generateText: (prompt, model, timeout, temperature, opts) => {
+    // Correlate the request so the cancel channel can target it (t/2508). The main-process
+    // handler ignores an unknown trailing arg until it wires requestId + AbortController (t/2509).
+    const requestId = opts?.requestId ?? crypto.randomUUID();
+    const invoke = window.electronAPI.generateText(prompt, model, timeout, temperature, requestId);
+    const signal = opts?.signal;
+    if (!signal) return invoke;
+    // Race the invoke against the abort signal so the renderer promise rejects PROMPTLY on a
+    // user cancel — this makes t/2505's "new model starts immediately" work even before t/2509
+    // lands. cancelGenerate is feature-detected, so this is safe in either landing order; the
+    // main-process request itself keeps running until t/2509 (resource leak closed there).
+    const cancel = () => window.electronAPI.cancelGenerate?.(requestId);
+    if (signal.aborted) {
+      cancel();
+      return Promise.reject(makeCancellationError('generateText cancelled by caller'));
+    }
+    return new Promise<{ text: string }>((resolve, reject) => {
+      const onAbort = () => { cancel(); reject(makeCancellationError('generateText cancelled by caller')); };
+      signal.addEventListener('abort', onAbort, { once: true });
+      invoke.then(
+        (r) => { signal.removeEventListener('abort', onAbort); resolve(r); },
+        (e) => { signal.removeEventListener('abort', onAbort); reject(e); },
+      );
+    });
+  },
   generateTextWithSearch: (prompt, model) => window.electronAPI.generateTextWithSearch(prompt, model),
   startChatStream: (sys, msgs, model, temp, urlContext) => window.electronAPI.startChatStream(sys, msgs, model, temp, urlContext),
   onChatStreamChunk: (cb) => window.electronAPI.onChatStreamChunk(cb),

--- a/taxonomy-editor/src/renderer/bridge/resilience.ts
+++ b/taxonomy-editor/src/renderer/bridge/resilience.ts
@@ -21,6 +21,26 @@ export interface ResilientFetchOptions {
   maxRetries: number;
   critical: boolean;
   category: EndpointCategory;
+  /** Caller abort signal (t/2508). Composed with the per-attempt timeout so a
+   *  deliberate cancel physically tears down the socket. A caller abort is
+   *  non-retryable and does not trip the circuit breaker. */
+  signal?: AbortSignal;
+}
+
+/** Compose the caller signal with the per-attempt timeout controller. Prefers the
+ *  native `AbortSignal.any` (Electron 35 / Node 20.3+); manual link is a fallback so
+ *  the composition never throws in an older runtime. */
+function anySignal(caller: AbortSignal | undefined, timeout: AbortSignal): AbortSignal {
+  if (!caller) return timeout;
+  if (typeof AbortSignal.any === 'function') return AbortSignal.any([caller, timeout]);
+  const ctrl = new AbortController();
+  const onAbort = () => ctrl.abort();
+  if (caller.aborted || timeout.aborted) ctrl.abort();
+  else {
+    caller.addEventListener('abort', onAbort, { once: true });
+    timeout.addEventListener('abort', onAbort, { once: true });
+  }
+  return ctrl.signal;
 }
 
 // ── Config accessors (backed by runtime config, falls back to hardcoded defaults) ──
@@ -245,7 +265,10 @@ export async function resilientFetch(
     const start = performance.now();
 
     try {
-      const res = await fetch(path, { ...init, signal: controller.signal });
+      // Compose the caller's abort signal (if any) with the per-attempt timeout (t/2508).
+      // Without this, `signal: controller.signal` would overwrite init.signal and a
+      // deliberate cancel could never reach the socket.
+      const res = await fetch(path, { ...init, signal: anySignal(opts.signal, controller.signal) });
       clearTimeout(timer);
       recordLatency(category, performance.now() - start);
 
@@ -279,6 +302,9 @@ export async function resilientFetch(
     } catch (err) {
       clearTimeout(timer);
       recordLatency(category, performance.now() - start);
+      // Deliberate caller cancel (t/2508): not a server failure — don't trip the circuit,
+      // don't retry, don't log an error. Re-throw so the bridge can tag it as a cancellation.
+      if (opts.signal?.aborted) throw err;
       onCircuitFailure(category, (err as Error).name === 'AbortError' ? 'timeout' : (err as Error).name);
 
       if (attempt < maxRetries && isRetryableError(err)) {

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -101,6 +101,19 @@ export type ContainerMentions = _ContainerMentions;
 
 export interface OrgFilters { type?: string; pov?: string }
 
+/**
+ * Per-call options for {@link AppAPI.generateText} (t/2508, HLD t/2506#1).
+ * `signal` lets a caller abort an in-flight AI request — in web builds it tears
+ * down the fetch; in Electron it fires the `cancelGenerate` IPC (feature-detected).
+ * `requestId` correlates the request across bridge → transport → provider so the
+ * cancel channel can target the exact in-flight request. Optional throughout, so
+ * no-signal callers behave exactly as before.
+ */
+export interface GenerateTextOptions {
+  signal?: AbortSignal;
+  requestId?: string;
+}
+
 export type ViewMode = 'simple' | 'advanced';
 
 export interface UserPreferences {
@@ -187,7 +200,7 @@ export interface AppAPI {
   importKeysFromSharing: (payload: { v: number; salt: string; iv: string; data: string; tag: string }, passphrase: string) => Promise<string[]>;
 
   // --- AI generation ---
-  generateText: (prompt: string, model?: string, timeoutMs?: number, temperature?: number) => Promise<{ text: string; tokenUsage?: { inputTokens: number; outputTokens: number; totalTokens: number } }>;
+  generateText: (prompt: string, model?: string, timeoutMs?: number, temperature?: number, opts?: GenerateTextOptions) => Promise<{ text: string; tokenUsage?: { inputTokens: number; outputTokens: number; totalTokens: number } }>;
   generateTextWithSearch: (prompt: string, model?: string) => Promise<{
     text: string;
     searchQueries?: string[];

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -7,6 +7,7 @@
  */
 import type { AppAPI, SourceDocumentResolution, DebateDelta, UserPreferences } from './types';
 import { instrumentBridge } from './instrumentBridge';
+import { makeCancellationError } from './cancellation';
 import { ActionableError } from '@lib/debate/errors';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
@@ -48,6 +49,9 @@ interface FetchOptions {
   maxRetries?: number;
   idempotent?: boolean;
   critical?: boolean;
+  /** Caller abort signal (t/2508) — threaded to the fetch so a deliberate cancel
+   *  tears down the request; on abort `post` throws a tagged cancellation error. */
+  signal?: AbortSignal;
 }
 
 const DEFAULT_READ_TIMEOUT_MS = 30_000;
@@ -221,8 +225,15 @@ async function post<T = unknown>(path: string, body?: unknown, opts?: FetchOptio
       maxRetries: opts?.maxRetries ?? defaultMaxRetries(cat, 'POST', opts?.idempotent),
       critical: opts?.critical ?? (cat !== 'telemetry'),
       category: cat,
+      signal: opts?.signal,
     });
   } catch (err) {
+    // Caller-initiated cancel (t/2508: Switch model / Cancel debate) — not a network
+    // error and not a timeout. Skip the scary system.error and propagate a distinguishable
+    // tagged cancellation so pipeline catches bail quietly (no toast, no retry).
+    if (opts?.signal?.aborted) {
+      throw makeCancellationError(`POST ${path} cancelled by caller`);
+    }
     getGlobalRecorder()?.record({
       type: 'system.error',
       component: 'web-bridge',
@@ -931,8 +942,8 @@ const rawApi: AppAPI = {
   },
 
   // AI generation
-  generateText: (prompt, model, timeout, temperature) => {
-    const requestId = crypto.randomUUID();
+  generateText: (prompt, model, timeout, temperature, opts) => {
+    const requestId = opts?.requestId ?? crypto.randomUUID();
     const body: Record<string, unknown> = { prompt, model, timeout, temperature };
     const byokKey = sessionStorage.getItem('byok-api-key');
     if (byokKey) body.apiKey = byokKey;
@@ -944,7 +955,9 @@ const rawApi: AppAPI = {
       message: `AI generate request: ${model ?? 'default'}`,
       data: { requestId, ..._activeDebateId ? { debateId: _activeDebateId } : {} },
     });
-    return post('/api/ai/generate', body, undefined, { 'x-request-id': requestId });
+    // Thread the abort signal (t/2508) into the fetch so cancel physically tears down
+    // the request; the server also aborts the provider call on client disconnect (t/2510).
+    return post('/api/ai/generate', body, { signal: opts?.signal }, { 'x-request-id': requestId });
   },
   generateTextWithSearch: (prompt, model) => {
     const requestId = crypto.randomUUID();

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/generation.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/generation.test.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Isolate the two generation helpers from the debate-store graph — only their real deps
+// (the bridge `api`, the flight recorder, and the real `guards` live-binding for
+// `_abortController`) run; everything else generation.ts imports is stubbed (t/2508).
+const generateText = vi.fn();
+vi.mock('@bridge', () => ({
+  api: {
+    generateText: (...args: unknown[]) => generateText(...args),
+    onGenerateTextProgress: () => () => {},
+  },
+}));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+vi.mock('../store', () => ({ useDebateStore: { getState: () => ({ debateWarnings: [] }), setState: vi.fn() } }));
+vi.mock('@lib/debate/helpers', () => ({ parseAIJson: () => null }));
+vi.mock('../../../prompts/debate', () => ({ entrySummarizationPrompt: () => 'prompt' }));
+vi.mock('./taxonomyContext', () => ({ findNodeMetaInStore: () => undefined }));
+vi.mock('./docTitles', () => ({ getDocTitles: () => ({}) }));
+
+import { generateTextWithProgress, makeStageGenerate } from './generation';
+import { newAbortController, cancelAndResetAbort, makeCancellationError } from './guards';
+
+describe('generation helpers thread the abort signal (t/2508)', () => {
+  beforeEach(() => {
+    generateText.mockReset();
+    cancelAndResetAbort(); // reset the module-level controller between cases
+  });
+
+  it('generateTextWithProgress passes the live abort signal to api.generateText', async () => {
+    const ctrl = newAbortController();
+    generateText.mockResolvedValue({ text: 'hi' });
+    await generateTextWithProgress('prompt', 'model-x', 'activity', vi.fn());
+    expect(generateText).toHaveBeenCalledWith('prompt', 'model-x', undefined, undefined, { signal: ctrl.signal });
+  });
+
+  it('generateTextWithProgress re-throws a tagged cancellation (does not swallow)', async () => {
+    newAbortController();
+    generateText.mockRejectedValue(makeCancellationError());
+    await expect(generateTextWithProgress('p', 'm', 'a', vi.fn())).rejects.toMatchObject({ cancelled: true });
+  });
+
+  it('makeStageGenerate threads the live signal alongside model/temperature/timeout', async () => {
+    const ctrl = newAbortController();
+    generateText.mockResolvedValue({ text: 'out' });
+    const gen = makeStageGenerate(vi.fn(), 'base-model');
+    await gen('prompt', 'call-model', { temperature: 0.4, timeoutMs: 1234 }, 'label');
+    expect(generateText).toHaveBeenCalledWith('prompt', 'call-model', 1234, 0.4, { signal: ctrl.signal });
+  });
+
+  it('with no active controller the signal is undefined (no-signal callers unchanged)', async () => {
+    cancelAndResetAbort(); // _abortController = null
+    generateText.mockResolvedValue({ text: 'hi' });
+    await generateTextWithProgress('p', 'm', 'a', vi.fn());
+    expect(generateText).toHaveBeenCalledWith('p', 'm', undefined, undefined, { signal: undefined });
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/generation.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/generation.ts
@@ -8,6 +8,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { parseAIJson } from '@lib/debate/helpers';
 import { entrySummarizationPrompt } from '../../../prompts/debate';
 import { findNodeMetaInStore } from './taxonomyContext';
+import { _abortController, isCancellationError } from './guards';
 // getDocTitles lives in a store-free module to avoid a load-order cycle (t/1779);
 // re-exported here so existing importers (debate*Slice) stay unchanged.
 export { getDocTitles } from './docTitles';
@@ -61,8 +62,18 @@ export async function generateTextWithProgress(
     set({ debateProgress: normalizeProgress(progress) });
   });
   try {
-    const result = await api.generateText(prompt, model, timeoutMs);
+    // Thread the live debate abort signal (t/2508) so cancelAndResetAbort() physically
+    // kills the in-flight request instead of merely gating late results. Read inline:
+    // the currently-active controller is the one owning this call at await time.
+    const result = await api.generateText(prompt, model, timeoutMs, undefined, { signal: _abortController?.signal });
     return result;
+  } catch (err) {
+    if (isCancellationError(err)) {
+      // Deliberate cancel (Switch model / Cancel debate) — record at info, not error,
+      // and re-throw the tagged error so the caller's catch can bail quietly (t/2508).
+      getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', message: `AI generation cancelled: ${activity}` });
+    }
+    throw err;
   } finally {
     unsubscribe();
     set({ debateProgress: null, debateActivity: null, debateGeneratingStartedAt: null });
@@ -211,8 +222,14 @@ export function makeStageGenerate(
       set({ debateProgress: normalizeProgress(progress) });
     });
     try {
-      const result = await api.generateText(prompt, callModel || model, options.timeoutMs, options.temperature);
+      // Thread the live debate abort signal (t/2508) — see generateTextWithProgress.
+      const result = await api.generateText(prompt, callModel || model, options.timeoutMs, options.temperature, { signal: _abortController?.signal });
       return result.text;
+    } catch (err) {
+      if (isCancellationError(err)) {
+        getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', message: `AI generation cancelled: ${label}` });
+      }
+      throw err;
     } finally {
       unsubscribe();
       set({ debateProgress: null, debateActivity: null, debateGeneratingStartedAt: null });

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/guards.ts
@@ -39,6 +39,11 @@ export function newAbortController(): AbortController {
   return _abortController;
 }
 
+// Deliberate-cancellation tagging (t/2508) lives in the zero-dependency bridge module
+// so both bridges and this debate-store module share one definition without an import
+// cycle. Re-exported here for the debate-store consumers (generation.ts, slice catches).
+export { isCancellationError, makeCancellationError } from '../../../bridge/cancellation';
+
 // ── Single-driver guard (t/657) ────────────────────────────────────────
 const _driverChannel = typeof BroadcastChannel !== 'undefined'
   ? new BroadcastChannel('aitriad-debate-driver') : null;

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -38,7 +38,7 @@ import { mapErrorToUserMessage } from '../../../utils/errorMessages';
 import { isLineageDataLoaded } from '../../../data/lineageCategories';
 import { getConfiguredModel, getSpeakerModel, resolveBriefModel } from '../shared/modelConfig';
 import { generateTextWithProgress, summarizeTranscriptEntry, makeStageGenerate } from '../shared/generation';
-import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE } from '../shared/guards';
+import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE, isCancellationError } from '../shared/guards';
 import { pushWarning, recordDiagnostic } from '../shared/diagnostics';
 import { runNeutralCheckpoint } from '../shared/neutralCheckpoint';
 import { buildLineageContext, getRelevantTaxonomyContext, formatDebaterEdgeContext, enrichPolicyRefs, serializeNodeSourceMap, getAllKnownNodeIds } from '../shared/taxonomyContext';
@@ -276,6 +276,8 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         });
       }
     } catch (err) {
+      // User cancel / model switch (t/2508) — bail quietly, no toast (helper logged info).
+      if (isCancellationError(err)) { set({ debateGenerating: null, debateActivity: null }); return; }
       getGlobalRecorder()?.record({
         type: 'system.error',
         debate_id: activeDebate?.id,
@@ -545,6 +547,8 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
       await get().beginDebate();
       return;
     } catch (err) {
+      // User cancel / model switch (t/2508) — bail quietly (finally clears state); no toast.
+      if (isCancellationError(err)) return;
       getGlobalRecorder()?.record({
         type: 'system.error',
         debate_id: activeDebate?.id,
@@ -678,6 +682,8 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
           }
         }
       } catch (err) {
+        // User cancel / model switch (t/2508) — bail quietly (finally clears state); no toast.
+        if (isCancellationError(err)) return;
         getGlobalRecorder()?.record({
           type: 'system.error',
           debate_id: activeDebate?.id,
@@ -1109,6 +1115,15 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
           void extractClaimsAndUpdateAN(statement, poverId, lastEntry.id, taxonomyRefs.map(r => r.node_id), get, set, meta.my_claims);
         }
       } catch (err) {
+        // Deliberate cancel / model switch mid-brief (t/2508): the shared generation helper
+        // already recorded the info event. Bail quietly — no error toast, no auto-retry —
+        // instead of classifying it as a transient failure. t/2505's retryWithModel starts a
+        // fresh run on the new model immediately after aborting this one.
+        if (isCancellationError(err)) {
+          releaseDebateDriver();
+          set({ debateGenerating: null, debateActivity: null, debateProgress: null });
+          return;
+        }
         const httpStatus = (err as { httpStatus?: number }).httpStatus;
         // Broadened classification (t/2492): transient timeout/5xx/network now auto-retry, not just 429.
         const { retryable: isRetryable, reason: retryReason } = classifyAiRetry(err);

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateLoopSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateLoopSlice.ts
@@ -84,7 +84,7 @@ import { mapErrorToUserMessage } from '../../../utils/errorMessages';
 import { cosineSimilarity, scoreNodesLexical } from '../../../utils/taxonomyRelevance';
 import { getConfiguredModel, getSpeakerModel } from '../shared/modelConfig';
 import { generateTextWithProgress, phaseGuardedSet, summarizeTranscriptEntry, makeStageGenerate, routeTurnValidatorHintsIntoSuggestions, getSourceEvidenceIndex, getDocTitles } from '../shared/generation';
-import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE } from '../shared/guards';
+import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE, isCancellationError } from '../shared/guards';
 import { pushWarning, recordDiagnostic, recordSignalHistory, getSignalValue, movingAverageSignal, incrementGapInjectionCount, _gapInjectionCount } from '../shared/diagnostics';
 import { runNeutralCheckpoint } from '../shared/neutralCheckpoint';
 import { buildLineageContext, enrichPolicyRefs, serializeNodeSourceMap, formatEdgeContext, formatDebaterEdgeContext, getRelevantTaxonomyContext, getAllKnownNodeIds, getAllPolicyIds, findNodeMetaInStore, getTaxonomyContext } from '../shared/taxonomyContext';
@@ -223,6 +223,8 @@ export const createDebateLoopSlice: StateCreator<DebateStore, [], [], DebateLoop
           await summarizeTranscriptEntry(lastEntry.id, statement, info.label, model, get, set);
         }
       } catch (err) {
+        // User cancel / model switch (t/2508) — bail quietly, no error toast (helper logged info).
+        if (isCancellationError(err)) { set({ debateGenerating: null }); return; }
         getGlobalRecorder()?.record({
           type: 'system.error',
           debate_id: activeDebate?.id,

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
@@ -87,7 +87,7 @@ import { mapErrorToUserMessage } from '../../../utils/errorMessages';
 import { cosineSimilarity, scoreNodesLexical } from '../../../utils/taxonomyRelevance';
 import { getConfiguredModel, getSpeakerModel } from '../shared/modelConfig';
 import { generateTextWithProgress, phaseGuardedSet, summarizeTranscriptEntry, makeStageGenerate, routeTurnValidatorHintsIntoSuggestions, getSourceEvidenceIndex, getDocTitles } from '../shared/generation';
-import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE } from '../shared/guards';
+import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE, isCancellationError } from '../shared/guards';
 import { pushWarning, recordDiagnostic, recordSignalHistory, getSignalValue, movingAverageSignal, incrementGapInjectionCount, _gapInjectionCount } from '../shared/diagnostics';
 import { runNeutralCheckpoint } from '../shared/neutralCheckpoint';
 import { enrichPolicyRefs, serializeNodeSourceMap, formatEdgeContext, formatDebaterEdgeContext, getRelevantTaxonomyContext, getAllKnownNodeIds, getAllPolicyIds, findNodeMetaInStore, getTaxonomyContext } from '../shared/taxonomyContext';
@@ -368,6 +368,9 @@ export const createDebatePhaseSlice: StateCreator<DebateStore, [], [], DebatePha
               const { statement: newStatement, meta: newMeta } = regenAssembled;
               return { statement: newStatement, debaterClaims: newMeta.my_claims };
             } catch (err) {
+              // Propagate a user cancel to the outer catch (t/2508) rather than silently
+              // falling back to the un-regenerated statement.
+              if (isCancellationError(err)) throw err;
               getGlobalRecorder()?.record({
                 type: 'system.error',
                 debate_id: activeDebate?.id,
@@ -401,6 +404,8 @@ export const createDebatePhaseSlice: StateCreator<DebateStore, [], [], DebatePha
 
       await runGapInjectionCheck(get, set, addTranscriptEntry, activeDebate);
     } catch (err) {
+      // User cancel / model switch (t/2508) — bail quietly, no error toast (helper logged info).
+      if (isCancellationError(err)) { releaseDebateDriver(); set({ debateGenerating: null, debateActivity: null }); return; }
       getGlobalRecorder()?.record({ type: 'system.error', component: 'debate-store', level: 'error', debate_id: activeDebate.id, message: `Pipeline failed for ${responderPover} R${crossRespondRound}`, data: { round: crossRespondRound, speaker: responderPover, error: String(err), stack: (err as Error).stack?.slice(0, 500), transcript_length: get().activeDebate?.transcript.length } });
       if (isDailyLimitError(err)) {
         addTranscriptEntry({ type: 'system', speaker: 'system', content: DAILY_LIMIT_MESSAGE, taxonomy_refs: [] });
@@ -1416,6 +1421,8 @@ async function runModeratorStep(selectionInput: ModeratorSelectionInput, selecti
         releaseDebateDriver(); return null;
       }
     } catch (err) {
+      // User cancel / model switch (t/2508) — bail quietly, no error toast (helper logged info).
+      if (isCancellationError(err)) { releaseDebateDriver(); set({ debateGenerating: null, debateActivity: null }); return null; }
       getGlobalRecorder()?.record({
         type: 'system.error',
         debate_id: activeDebate?.id,

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
@@ -85,7 +85,7 @@ import { usePromptConfigStore } from '../../usePromptConfigStore';
 import { mapErrorToUserMessage } from '../../../utils/errorMessages';
 import { getConfiguredModel, getSpeakerModel } from '../shared/modelConfig';
 import { generateTextWithProgress, phaseGuardedSet, summarizeTranscriptEntry, makeStageGenerate, routeTurnValidatorHintsIntoSuggestions, getSourceEvidenceIndex, getDocTitles } from '../shared/generation';
-import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE } from '../shared/guards';
+import { createDebateGuard, newAbortController, _abortController, claimDebateDriver, releaseDebateDriver, isDailyLimitError, DAILY_LIMIT_MESSAGE, isCancellationError } from '../shared/guards';
 import { pushWarning, recordDiagnostic, recordSignalHistory, getSignalValue, movingAverageSignal, incrementGapInjectionCount, _gapInjectionCount } from '../shared/diagnostics';
 import { runNeutralCheckpoint } from '../shared/neutralCheckpoint';
 import { enrichPolicyRefs, serializeNodeSourceMap, formatEdgeContext, formatDebaterEdgeContext, getRelevantTaxonomyContext, getAllKnownNodeIds, getAllPolicyIds, findNodeMetaInStore, getTaxonomyContext } from '../shared/taxonomyContext';
@@ -693,6 +693,9 @@ export const createDebateReflectionSlice: StateCreator<DebateStore, [], [], Deba
 
         set({ reflections: [...results] });
       } catch (err) {
+        // User cancel / model switch (t/2508) — stop the reflection loop quietly, don't push
+        // a spurious "Error:" reflection entry (helper already logged the info event).
+        if (isCancellationError(err)) return;
         getGlobalRecorder()?.record({
           type: 'system.error',
           debate_id: activeDebate?.id,

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/synthesisSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/synthesisSlice.ts
@@ -36,7 +36,7 @@ import { useTaxonomyStore } from '../../useTaxonomyStore';
 import { mapErrorToUserMessage } from '../../../utils/errorMessages';
 import { getConfiguredModel } from '../shared/modelConfig';
 import { generateTextWithProgress, phaseGuardedSet } from '../shared/generation';
-import { createDebateGuard, newAbortController, _abortController, isDailyLimitError, DAILY_LIMIT_MESSAGE } from '../shared/guards';
+import { createDebateGuard, newAbortController, _abortController, isDailyLimitError, DAILY_LIMIT_MESSAGE, isCancellationError } from '../shared/guards';
 import { pushWarning, recordDiagnostic } from '../shared/diagnostics';
 import { runNeutralCheckpoint } from '../shared/neutralCheckpoint';
 import { getRelevantTaxonomyContext, formatDebaterEdgeContext, enrichPolicyRefs, serializeNodeSourceMap, getNodeLabelForFactCheck, getTaxonomyContext } from '../shared/taxonomyContext';
@@ -987,6 +987,8 @@ export const createSynthesisSlice: StateCreator<DebateStore, [], [], SynthesisSl
 
       runLineageDebateSummary(get, activeDebate);
     } catch (err) {
+      // User cancel / model switch (t/2508) — bail quietly, no error toast (helper logged info).
+      if (isCancellationError(err)) { set({ debateGenerating: null, debateActivity: null }); return; }
       getGlobalRecorder()?.record({
         type: 'system.error',
         debate_id: activeDebate?.id,
@@ -1066,6 +1068,8 @@ export const createSynthesisSlice: StateCreator<DebateStore, [], [], SynthesisSl
         metadata: { probing_questions: questions, round: probingRound },
       });
     } catch (err) {
+      // User cancel / model switch (t/2508) — bail quietly, no error toast (helper logged info).
+      if (isCancellationError(err)) { set({ debateGenerating: null, debateActivity: null }); return; }
       getGlobalRecorder()?.record({
         type: 'system.error',
         debate_id: activeDebate?.id,
@@ -1140,6 +1144,8 @@ export const createSynthesisSlice: StateCreator<DebateStore, [], [], SynthesisSl
       // Generate AN nodes and edges from the fact-check points and commit them.
       applyFactCheckToArgumentNetwork(get, set, entryId, selectedText, result, validated);
     } catch (err) {
+      // User cancel / model switch (t/2508) — bail quietly (finally clears state); no toast.
+      if (isCancellationError(err)) return;
       getGlobalRecorder()?.record({
         type: 'system.error',
         debate_id: activeDebate?.id,

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -95,7 +95,14 @@ export interface ElectronAPI {
   importKeysFromSharing: (payload: { v: number; salt: string; iv: string; data: string; tag: string }, passphrase: string) => Promise<string[]>;
 
   // AI generation
-  generateText: (prompt: string, model?: string, timeoutMs?: number, temperature?: number) => Promise<{ text: string }>;
+  // `requestId` (t/2508) correlates the request so `cancelGenerate` can abort the exact
+  // in-flight provider call. Optional trailing arg — ignored by the handler until the
+  // main-process AbortController map lands (t/2509); harmless before then.
+  generateText: (prompt: string, model?: string, timeoutMs?: number, temperature?: number, requestId?: string) => Promise<{ text: string }>;
+  // Fire-and-forget cancel for an in-flight generateText (t/2508). Optional — wired by the
+  // ai:cancel-generate IPC channel (ElectronMain, t/2509). Feature-detected by electron-bridge,
+  // so it lands safely in either order; an unknown requestId is a silent no-op main-side.
+  cancelGenerate?: (requestId: string) => void;
   generateTextWithSearch: (prompt: string, model?: string) => Promise<{
     text: string;
     searchQueries?: string[];


### PR DESCRIPTION
Renderer slice of t/2506 (HLD t/2506#1). Threads a caller `AbortSignal` through the bridge into the actual fetch and gives the debate pipeline a race-free cancellation path, so Switch-model / Cancel-debate mid-generation aborts the in-flight request instead of only gating late results.

## What
- **types.ts / cancellation.ts (new):** `generateText(..., opts?: { signal?, requestId? })`; zero-dep `isCancellationError`/`makeCancellationError` shared by both bridges + guards (no import cycle).
- **resilience.ts:** compose the caller signal with the per-attempt timeout via `AbortSignal.any` (the fetch call previously *overwrote* `init.signal`). Caller cancel is non-retryable and does not trip the circuit.
- **web-bridge.ts:** thread the signal; a caller cancel is distinguished from a timeout (no scary system.error) and surfaced as a tagged cancellation.
- **electron-bridge.ts:** requestId + race the invoke against the signal so the renderer promise rejects promptly (new model starts immediately even before t/2509); `cancelGenerate` feature-detected.
- **shared/generation.ts:** both helpers read the live `_abortController.signal` and pass it into every `api.generateText` (one edit point, all slices); tagged cancel → info FR event, not error.
- **Pipeline catches** (openings, clarify, topic-synthesis, doc-analysis, debate loop, cross-respond, moderator, synthesis, probing, fact-check, reflection) bail quietly on a tagged cancellation — no error toast, no auto-retry. Keeps `cancelDebate()` (now physically aborting across all phases) from newly toasting.

## Tests
`cancellation.test.ts` (tagging), `resilience.test.ts` (compose + non-retryable caller cancel + circuit untouched + no-signal unchanged), `generation.test.ts` (live-signal threading + tagged-cancel rethrow).

## Gates (local, worktree)
main/server/renderer tsc ✓ · eslint 0 errors ✓ · depcruise ✓ · vitest (bridge + useDebateStore + new) 385+48 ✓ · vite build ✓

## Sequencing
Blocked-by **t/2507** (Shared Lib) for full end-to-end. Degrades gracefully (no signal = today's behavior; electron cancel feature-detected), so it is safe to land independently per the HLD. Web path closes the client→server connection on cancel immediately; the residual provider-side leak closes with t/2507/t/2509/t/2510.

## Deviation
HLD prescribes FR event `ai.cancelled`; that type isn't in the `EventType` union (`lib/flight-recorder`, Shared Lib scope). Used `debate.lifecycle` info to match this module's existing abort paths and stay in-scope — adding `ai.cancelled` belongs with t/2507. Flagged to Shared Lib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)