### PR TITLE
chore(debate): reword opening interrupted message for switch-model abort (t/2518)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -1001,7 +1001,7 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         );
         if (!isStillValid()) {
           console.warn(`[debate-store] Debate state changed after ${info.label} opening pipeline — remaining speakers will be skipped. activeDebateId: ${get().activeDebateId}, aborted: ${_abortController?.signal.aborted}`);
-          addTranscriptEntry({ type: 'system', speaker: 'system', content: `Opening generation interrupted after ${info.label} — debate state changed during generation.`, taxonomy_refs: [] });
+          addTranscriptEntry({ type: 'system', speaker: 'system', content: `Opening generation interrupted after ${info.label} — superseded by a model switch or a debate change.`, taxonomy_refs: [] });
           getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate?.id, message: 'runOpeningStatements aborted post-pipeline', data: { speaker: info.label } });
           return;
         }
@@ -1031,7 +1031,7 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
           }
           if (!isStillValid()) {
             console.warn(`[debate-store] Debate state changed after ${info.label} opening retry — remaining speakers will be skipped. activeDebateId: ${get().activeDebateId}, aborted: ${_abortController?.signal.aborted}`);
-            addTranscriptEntry({ type: 'system', speaker: 'system', content: `Opening generation interrupted after ${info.label} retry — debate state changed during generation.`, taxonomy_refs: [] });
+            addTranscriptEntry({ type: 'system', speaker: 'system', content: `Opening generation interrupted after ${info.label} retry — superseded by a model switch or a debate change.`, taxonomy_refs: [] });
             getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate?.id, message: 'runOpeningStatements aborted post-retry', data: { speaker: info.label } });
             return;
           }


### PR DESCRIPTION
The isStillValid()-false bail (and retry twin) wrote "…interrupted after {label} — debate state changed during generation." Post-t/2505 this path also fires on a Switch-model restart, where "debate state changed" is inaccurate. Reworded both to "…superseded by a model switch or a debate change."

String-only, info-level system entry; no behavior change. Self-cert /trivial-change. Deferred from t/2505. Closes t/2518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)