### PR TITLE
feat(debate): per-turn stepping for socratic step mode (t/2516)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/askQuestionSocraticStep.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/askQuestionSocraticStep.test.ts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression test for socratic per-turn stepping (t/2516). In a socratic + step-mode run,
+// one user question must produce exactly ONE AI response (then pause for the next question),
+// instead of every respondingPover auto-running in a single askQuestion call.
+// Import the harness FIRST so its hoisted mocks register before the store graph is imported.
+import { describe, it, expect } from 'vitest';
+import { mockApi, makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+
+describe('askQuestion — socratic step mode (t/2516)', () => {
+  const povResponse = JSON.stringify({
+    statement: 'A short response from the speaker for testing.',
+    taxonomy_refs: [], policy_refs: [], my_claims: [],
+  });
+
+  function setup(overrides: Record<string, unknown>) {
+    const session = makeSession({
+      phase: 'debate',
+      active_povers: ['accelerationist', 'safetyist', 'skeptic'],
+      ...overrides,
+    });
+    useDebateStore.setState({
+      activeDebate: session as unknown as ReturnType<typeof useDebateStore.getState>['activeDebate'],
+      activeDebateId: session.id,
+    });
+    mockApi.generateText.mockResolvedValue({ text: povResponse });
+  }
+
+  function statementCount(): number {
+    return (useDebateStore.getState().activeDebate?.transcript ?? []).filter((e) => e.type === 'statement').length;
+  }
+
+  it('produces exactly one AI response per question in socratic + step_mode', async () => {
+    setup({ protocol_id: 'socratic', adaptive_staging: { enabled: true, step_mode: true } });
+    await useDebateStore.getState().askQuestion('What about X?');
+    // No @-mention → all three AI povers would respond without the break; step mode stops at one.
+    expect(statementCount()).toBe(1);
+  });
+
+  it('produces all responders when step_mode is off (control — proves the guard is the cause)', async () => {
+    setup({ protocol_id: 'socratic', adaptive_staging: { enabled: true, step_mode: false } });
+    await useDebateStore.getState().askQuestion('What about X?');
+    expect(statementCount()).toBe(3);
+  });
+
+  it('produces all responders for a non-socratic protocol even with step_mode on', async () => {
+    setup({ protocol_id: 'structured', adaptive_staging: { enabled: true, step_mode: true } });
+    await useDebateStore.getState().askQuestion('What about X?');
+    expect(statementCount()).toBe(3);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateLoopSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateLoopSlice.ts
@@ -240,6 +240,15 @@ export const createDebateLoopSlice: StateCreator<DebateStore, [], [], DebateLoop
           taxonomy_refs: [],
         });
       }
+
+      // Socratic step mode (t/2516): one AI response per user question. Break after the
+      // first responder so generation pauses for the user's next question instead of
+      // letting the remaining respondingPovers auto-run. Placed at the end of the loop
+      // body (after the try/catch) so exactly one turn is produced even if it errored.
+      // protocol_id + step_mode are set at debate creation and don't change mid-turn.
+      if (activeDebate.adaptive_staging?.step_mode && activeDebate.protocol_id === 'socratic') {
+        break;
+      }
     }
 
     set({ debateGenerating: null });


### PR DESCRIPTION
`askQuestion` looped over all `respondingPovers` in one call, so a single user question triggered every matching speaker — generation only paused at phase boundaries. The socratic protocol promises "user asks, one AI responds at a time."

**Fix (one guard in `debateLoopSlice.ts`):** break out of the responder loop after the first turn when the session is `socratic` + `adaptive_staging.step_mode`, so generation pauses for the next user question. Placed at the end of the loop body so exactly one turn is produced even if it errored. No lib/debate or schema changes (`protocol_id` + `step_mode` already on the session).

**Test:** `askQuestionSocraticStep.test.ts` — socratic+step → 1 response; step-off and non-socratic controls → all 3 (verified to fail without the break). Full useDebateStore suite green (160).

Implements t/2516 per DebateTool's design (t/2516#1, e/88). DebateTool owns the ticket and will close it after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)