### PR TITLE
feat(debate): enforce single-interlocutor invariant for socratic protocol (t/2514)

### DIFF
--- a/lib/debate/debateEngine.lifecycle.test.ts
+++ b/lib/debate/debateEngine.lifecycle.test.ts
@@ -77,6 +77,24 @@ describe('DebateEngine construction', () => {
     const engine = new DebateEngine(config, adapter, taxonomy);
     expect(engine).toBeDefined();
   });
+
+  it('throws ActionableError when socratic protocol has multiple active povers (t/2514)', () => {
+    const config = createDefaultConfig({
+      protocolId: 'socratic',
+      activePovers: ['accelerationist', 'safetyist'],
+    });
+    expect(() => new DebateEngine(config, createMockAdapter(), createMinimalTaxonomy()))
+      .toThrow('exactly one active POV');
+  });
+
+  it('accepts socratic protocol with exactly one active pover (t/2514)', () => {
+    const config = createDefaultConfig({
+      protocolId: 'socratic',
+      activePovers: ['safetyist'],
+    });
+    const engine = new DebateEngine(config, createMockAdapter(), createMinimalTaxonomy());
+    expect(engine).toBeDefined();
+  });
 });
 
 // ── Session initialization via run() ─────────────────────

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -397,6 +397,16 @@ export class DebateEngine {
 
     const derivedModeratorMode = config.moderatorMode ?? (config.protocolId === 'socratic' ? 'socratic' : undefined);
     this.config = { ...config, stageModels: merged, moderatorMode: derivedModeratorMode };
+
+    if (this.config.protocolId === 'socratic' && this.config.activePovers.length !== 1) {
+      throw new ActionableError({
+        goal: 'Initialize a Socratic debate',
+        problem: `Socratic protocol requires exactly one active POV (the interlocutor under examination), but ${this.config.activePovers.length} were provided: ${this.config.activePovers.join(', ')}`,
+        location: 'DebateEngine constructor',
+        nextSteps: ['Set activePovers to a single debater (e.g. ["safetyist"]) when using protocolId: "socratic".'],
+      });
+    }
+
     this._talmudicCorpus = initTalmudicCorpusFromConfig(this.config);
     this.adapter = adapter;
     this.taxonomy = taxonomy;

--- a/lib/debate/debateEngine.ts
+++ b/lib/debate/debateEngine.ts
@@ -254,10 +254,7 @@ export class DebateEngine {
   private _boundaryEmbeddings: BoundaryEmbeddings | null = null;
   private _signalHistory: Map<string, { round: number; value: number }[]> = new Map();
   private _peakTrackers: Map<string, number> = new Map();
-  /** Debate-wide hint failure streaks for hopeless hint suppression.
-   *  Tracked globally (not per-speaker) because hint suppressibility is a model
-   *  capability — if the model can't produce specific claims for one speaker,
-   *  it can't for any of them. */
+  /** Debate-wide hint failure streaks — global (not per-speaker); suppressibility is model-wide. */
   private _hintStreaks = new Map<string, import('./types.js').HintStreak>();
   /** Cached prior crux context string — seeded from registry at debate start, injected into Brief stage. */
   private _priorCruxContext: string = '';
@@ -397,16 +394,7 @@ export class DebateEngine {
 
     const derivedModeratorMode = config.moderatorMode ?? (config.protocolId === 'socratic' ? 'socratic' : undefined);
     this.config = { ...config, stageModels: merged, moderatorMode: derivedModeratorMode };
-
-    if (this.config.protocolId === 'socratic' && this.config.activePovers.length !== 1) {
-      throw new ActionableError({
-        goal: 'Initialize a Socratic debate',
-        problem: `Socratic protocol requires exactly one active POV (the interlocutor under examination), but ${this.config.activePovers.length} were provided: ${this.config.activePovers.join(', ')}`,
-        location: 'DebateEngine constructor',
-        nextSteps: ['Set activePovers to a single debater (e.g. ["safetyist"]) when using protocolId: "socratic".'],
-      });
-    }
-
+    if (this.config.protocolId === 'socratic' && this.config.activePovers.length !== 1) throw new ActionableError({ goal: 'Initialize a Socratic debate', problem: `Socratic requires exactly one active POV; got ${this.config.activePovers.length}: ${this.config.activePovers.join(', ')}`, location: 'DebateEngine constructor', nextSteps: ['Pass a single debater in activePovers when using protocolId: "socratic".'] });
     this._talmudicCorpus = initTalmudicCorpusFromConfig(this.config);
     this.adapter = adapter;
     this.taxonomy = taxonomy;

--- a/lib/debate/prompts/moderator.ts
+++ b/lib/debate/prompts/moderator.ts
@@ -118,6 +118,8 @@ Constraints:
 - Draw only from what debaters have stated — do not introduce new evidence or claims of your own
 - If no operative assumption is yet visible, direct this round toward eliciting a clearer position first
 
+SELECTION (deterministic — do not use judgment here): There is exactly one interlocutor listed under ACTIVE DEBATERS. Your "responder" MUST always be that interlocutor. Your "addressing" MUST be "moderator". There is no panel to rotate; the moderator is the questioner throughout. Do not select any other speaker as responder.
+
 Add a "dialectical_diagnostic" field to your JSON response:
 {
   "focused_crux": "the position or claim being examined this round",


### PR DESCRIPTION
## Summary
- Throw `ActionableError` in `DebateEngine` constructor when `protocolId === 'socratic'` and `activePovers.length !== 1` — fail-closed on misconfiguration
- Add deterministic SELECTION instruction to the socratic moderator prompt block: the lone interlocutor is always responder, moderator always questioner; retires N1 contradiction from t/2513
- Two new construction tests in `debateEngine.lifecycle.test.ts` (51/51 green)

## Test plan
- [x] `npx vitest run lib/debate/debateEngine.lifecycle.test.ts` — 51/51 passed
- [x] Rebased onto `origin/main` (includes t/2511 `dialecticalStyle` fix at line 1046)
- [x] Engine invariant: multi-pover socratic throws; single-pover socratic constructs cleanly
- [x] Moderator prompt: SELECTION block is deterministic — no panel rotation for socratic

🤖 Generated with [Claude Code](https://claude.com/claude-code)