### PR TITLE
feat(observability): thread chatSessionId onto chat-stream ai.request (t/2490 Gap 2)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/chatStreamBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/chatStreamBridge.test.ts
@@ -30,7 +30,8 @@ vi.mock('@lib/debate/errors', () => ({
   },
 }));
 
-vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+const recorded = vi.hoisted(() => [] as Array<{ type: string; data?: Record<string, unknown> }>);
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: (r: { type: string; data?: Record<string, unknown> }) => { recorded.push(r); } }) }));
 vi.mock('../instrumentBridge', () => ({ instrumentBridge: (raw: unknown) => raw }));
 vi.mock('../../utils/keyShareCrypto', () => ({ encryptKeysForSharing: vi.fn(), decryptKeysFromSharing: vi.fn() }));
 const mockQuotaMilestone = vi.fn();
@@ -67,6 +68,7 @@ beforeEach(() => {
   mockResilientFetch.mockReset();
   mockQuotaMilestone.mockReset();
   sessionStorage.clear();
+  recorded.length = 0;
 });
 
 describe('web-bridge startChatStream — SSE happy path (t/2462)', () => {
@@ -141,6 +143,23 @@ describe('web-bridge startChatStream — request shaping (t/2462)', () => {
     const body = JSON.parse(mockResilientFetch.mock.calls[0][1].body as string);
     expect(body.apiKey).toBeUndefined();
     expect(body.urlContext).toBe(false);
+  });
+
+  it('threads chatSessionId onto the POST body and the client ai.request event (t/2490 Gap 2)', async () => {
+    mockResilientFetch.mockResolvedValue(sseResponse([frame({ type: 'done', fullText: '' })]));
+    await api.startChatStream('sys', MSGS, 'gemini', 0.5, false, { chatSessionId: 'chat-abc' });
+    const body = JSON.parse(mockResilientFetch.mock.calls[0][1].body as string);
+    expect(body.chatSessionId).toBe('chat-abc'); // → server ai.request (t/2494)
+    const aiReq = recorded.find((r) => r.type === 'ai.request');
+    expect(aiReq?.data?.chatSessionId).toBe('chat-abc'); // → client dump
+  });
+
+  it('omits chatSessionId/linkedDebateId from the body when no context is passed (absent-tolerant)', async () => {
+    mockResilientFetch.mockResolvedValue(sseResponse([frame({ type: 'done', fullText: '' })]));
+    await api.startChatStream('sys', MSGS);
+    const body = JSON.parse(mockResilientFetch.mock.calls[0][1].body as string);
+    expect('chatSessionId' in body).toBe(false);
+    expect('linkedDebateId' in body).toBe(false);
   });
 });
 

--- a/taxonomy-editor/src/renderer/bridge/chatStream.ts
+++ b/taxonomy-editor/src/renderer/bridge/chatStream.ts
@@ -121,6 +121,12 @@ export interface ChatStreamArgs {
   model?: string;
   temperature?: number;
   urlContext?: boolean;
+  /** Chat/debate linkage for observability (t/2490 Gap 2): sent on the POST body so the
+   *  server ai.request carries it (t/2494), and included on the client ai.request event.
+   *  linkedDebateId has no source in the current chat model (POVer chats aren't
+   *  debate-linked) — wired as a forward-compatible passthrough, absent for now. */
+  chatSessionId?: string;
+  linkedDebateId?: string;
 }
 
 /** The web bridge's session-recovering fetch (injected to avoid a circular import). */
@@ -129,12 +135,16 @@ type ChatFetch = (path: string, init: RequestInit, opts: ResilientFetchOptions) 
 /** Drive one chat-stream request: POST → read SSE body → dispatch. Resolves the accumulated
  *  fullText, or rejects with an ActionableError (also surfaced to onChatStreamError listeners). */
 export async function runChatStream(fetchFn: ChatFetch, args: ChatStreamArgs): Promise<string> {
-  const { systemInstruction, messages, model, temperature, urlContext } = args;
+  const { systemInstruction, messages, model, temperature, urlContext, chatSessionId, linkedDebateId } = args;
   const requestId = crypto.randomUUID();
-  const body: Record<string, unknown> = { systemInstruction, messages, model, temperature, urlContext: !!urlContext };
+  // Chat/debate linkage → server ai.request (t/2494). JSON.stringify drops undefined keys, so
+  // absent chatSessionId/linkedDebateId simply don't appear on the wire (absent-tolerant).
+  const body: Record<string, unknown> = { systemInstruction, messages, model, temperature, urlContext: !!urlContext, chatSessionId, linkedDebateId };
   const byokKey = sessionStorage.getItem('byok-api-key');
   if (byokKey) body.apiKey = byokKey;
-  getGlobalRecorder()?.record({ type: 'ai.request', component: 'web-bridge', level: 'info', message: `chat-stream request: ${model ?? 'default'}`, data: { requestId, urlContext: !!urlContext, messageCount: messages.length } });
+  // t/2490 Gap 2: chat/debate linkage on the client ai.request makes the anon-chat-403 root
+  // cause self-evident without cross-referencing the context block (undefined fields drop out).
+  getGlobalRecorder()?.record({ type: 'ai.request', component: 'web-bridge', level: 'info', message: `chat-stream request: ${model ?? 'default'}`, data: { requestId, urlContext: !!urlContext, messageCount: messages.length, chatSessionId, linkedDebateId } });
 
   const path = '/api/ai/chat-stream';
   let res: Response;

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -206,7 +206,7 @@ export interface AppAPI {
     searchQueries?: string[];
     citations?: GroundingCitation[];
   }>;
-  startChatStream: (systemInstruction: string, messages: { role: 'user' | 'model'; content: string }[], model?: string, temperature?: number, urlContext?: boolean) => Promise<string>;
+  startChatStream: (systemInstruction: string, messages: { role: 'user' | 'model'; content: string }[], model?: string, temperature?: number, urlContext?: boolean, context?: { chatSessionId?: string; linkedDebateId?: string }) => Promise<string>;
   onChatStreamChunk: (callback: (chunk: string) => void) => () => void;
   onChatStreamDone: (callback: (fullText: string) => void) => () => void;
   onChatStreamError: (callback: (error: string) => void) => () => void;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -976,8 +976,8 @@ const rawApi: AppAPI = {
   },
   // Chat streaming (SSE) — transport lives in ./chatStream (leaf module, t/2462). Shape-identical
   // to the Electron preload so useChatStore consumes one contract from both bridges.
-  startChatStream: (systemInstruction, messages, model, temperature, urlContext) =>
-    runChatStream(fetchWithSessionRecovery, { systemInstruction, messages, model, temperature, urlContext }),
+  startChatStream: (systemInstruction, messages, model, temperature, urlContext, context) =>
+    runChatStream(fetchWithSessionRecovery, { systemInstruction, messages, model, temperature, urlContext, chatSessionId: context?.chatSessionId, linkedDebateId: context?.linkedDebateId }),
   onChatStreamChunk: (cb) => chatStreamBus.onChunk(cb),
   onChatStreamDone: (cb) => chatStreamBus.onDone(cb),
   onChatStreamError: (cb) => chatStreamBus.onError(cb),

--- a/taxonomy-editor/src/renderer/hooks/useChatStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useChatStore.ts
@@ -61,6 +61,7 @@ async function streamChatWithProgress(
   set: (partial: Partial<ChatStore>) => void,
   onChunk: (chunk: string) => void,
   urlContext?: boolean,
+  chatSessionId?: string,
 ): Promise<{ text: string; urlContextMetadata?: UrlContextMetadata }> {
   set({ chatActivity: activity, chatStreamingText: null });
   let urlContextMetadata: UrlContextMetadata | undefined;
@@ -83,7 +84,7 @@ async function streamChatWithProgress(
     }
   });
   try {
-    const text = await api.startChatStream(systemInstruction, messages, model, temperature, urlContext);
+    const text = await api.startChatStream(systemInstruction, messages, model, temperature, urlContext, chatSessionId ? { chatSessionId } : undefined);
     return { text, urlContextMetadata };
   } finally {
     unsubChunk();
@@ -349,6 +350,8 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         `${info.label} is thinking...`,
         set,
         (chunk) => get().appendStreamingText(chunk),
+        undefined,
+        activeChat.id,
       );
 
       if (!isStillValid()) return;
@@ -482,6 +485,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
         set,
         (chunk) => get().appendStreamingText(chunk),
         urlContext,
+        activeChat.id,
       );
 
       if (!isStillValid()) return;


### PR DESCRIPTION
The web chat-stream `ai.request` logged model + message count but not the chat/debate linkage, so the anon-chat-403 root cause needed cross-referencing the FR context block. Thread the active chat id from `useChatStore` → `startChatStream` → `runChatStream` onto (a) the POST body (so the **server** `ai.request`/t/2494 populates `chatSessionId`) and (b) the **client** `ai.request` FR event.

Scope confirmed with Diagnostics (t/2490#5, p/1#85): `linkedDebateId` wired as a forward-compatible passthrough (no debate-linked chat surface today); `auth_user_type` omitted from the client event (already in the FR context block + server event). Absent fields drop out via `JSON.stringify` (no branches, no added complexity). `startChatStream` signature widened with an optional `context` param; electron-bridge unchanged (5-arg impl stays assignable; electron chat doesn't hit the server chat-stream endpoint).

Test: `chatStreamBridge.test.ts` — chatSessionId on body + client event; absent-tolerant with no context. Bridge + useChatStore suites green (159).

Completes t/2490 (Gap 1 landed `3541e1b5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)