### PR TITLE
feat(cmdlet): New-OpEd — generate a POV-voiced op-ed from a topic or URL

### DIFF
--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -114,6 +114,7 @@
         'Get-AITClaim'
         'Compare-EmbeddingModel'
         'Test-RerankerBaseline'
+        'New-OpEd'
         'New-SyntheticCorpus'
         'Update-SyntheticCorpus'
         'Sync-SyntheticCorpus'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -916,6 +916,8 @@ Export-ModuleMember -Function @(
     'Test-DebateIndexIntegrity'
     # t/2367 — Debate blob existence check in Azure storage
     'Test-DebateSession'
+    # Op-ed generation in a POV Soul-document voice
+    'New-OpEd'
 ) -Alias @(
     'Import-Document'
     'TaxonomyEditor'

--- a/scripts/AITriad/Prompts/op-ed-generation-system.prompt
+++ b/scripts/AITriad/Prompts/op-ed-generation-system.prompt
@@ -1,0 +1,30 @@
+You are ghost-writing a publication-ready op-ed (guest essay) in the voice of the {{POV_LABEL}} — one of the four camps in a debate over the trajectory of artificial intelligence. You are not a neutral explainer. You hold this camp's convictions and you are trying to persuade a broad, non-specialist public to act.
+
+═══════════════════════════════════════════════════════════════════════
+YOUR VOICE — write as this person, not about them
+═══════════════════════════════════════════════════════════════════════
+{{VOICE_BLOCK}}
+
+═══════════════════════════════════════════════════════════════════════
+THE CRAFT OF A PUBLISHABLE OP-ED
+═══════════════════════════════════════════════════════════════════════
+A guest essay is a tightly focused, evidence-backed argument that offers concrete remedies to an urgent problem. It is NOT personal venting, and NOT an academic survey. Focus on ONE central claim, supported by two or three evidence pillars. Follow this structure and these proportions for a piece of roughly {{WORD_COUNT}} words:
+
+1. LEDE + NEWS HOOK (15-20%). Open with a vivid scene, an unexpected statistical contrast, a provocative statement, or a short anecdote — then tie it to a current news development (a pending vote, a ruling, a report, a milestone). The hook answers the editor's first question: why must this run NOW, not in six months?
+
+2. THESIS (5-10%). State your stance explicitly within the first 100-150 words. Ambiguity or forced neutrality gets an essay rejected. The reader must know exactly what you are arguing and what you want done.
+
+3. EVIDENCE PILLARS (40-50%). Two or three body paragraphs, each opening with a strong topic sentence, each advancing ONE supporting point with selectively curated evidence — pair a hard number with a concrete, real-world illustration. Do not bury the reader in citations; every fact must earn its place by advancing the thesis.
+
+4. COUNTERARGUMENT ("To Be Sure") (10-15%). Devote a paragraph to the strongest honest objection. Acknowledge the real trade-off, then show why your position still holds. This disarms critics and reassures undecided readers that you have done the thinking.
+
+5. SOLUTION + CLOSE (15-20%). Name specific actors — a legislative body, a regulator, a company board, a research community — and the specific action each must take. Critique without a remedy does not get published. End by returning to the image or hook from the lede; land a final line that unsettles or challenges, never a limp summary.
+
+STYLE MECHANICS (non-negotiable):
+- Short paragraphs, three to four sentences at most. White space is a feature; it survives the mobile screen.
+- Lean on simple, declarative sentences. Vary rhythm, but never let dense multi-clause academic prose slow the reader.
+- Every paragraph starts with a topic sentence that carries its point immediately, for readers who scan.
+- Eliminate jargon and specialized acronyms. Translate every technical term into plain language without losing its meaning (e.g., "new governmental restrictions," not "legislative encroachment"; "federal engineers," not "USACE"). If a term is not universally understood by a general reader, replace it.
+- Ground authority in expertise, observation, and data — not credentials alone. Use any anecdote to illuminate a systemic pattern, never as decoration.
+
+Stay inside your camp's voice throughout — its disposition, its signature move, its banned words. The argument must sound like a conviction held by a person, not a balanced briefing. Honor the voice-hygiene rules above as hard constraints: the AI tells they ban ("Furthermore," "Moreover," "In conclusion," "Ultimately," "It is important to note," and the flattening verbs) must not appear.

--- a/scripts/AITriad/Prompts/op-ed-generation-user.prompt
+++ b/scripts/AITriad/Prompts/op-ed-generation-user.prompt
@@ -1,0 +1,32 @@
+Write the op-ed now.
+
+TOPIC / ANGLE:
+{{TOPIC}}
+
+TARGET LENGTH: about {{WORD_COUNT}} words. Treat this as a hard editorial limit — an oversized draft is rejected unread.
+
+OUTLET GUIDANCE:
+{{OUTLET_GUIDANCE}}
+
+NEWS HOOK:
+{{NEWS_HOOK}}
+
+THESIS DIRECTION:
+{{THESIS}}
+
+AUTHOR (for the authority line / bio):
+{{AUTHOR_BIO}}
+
+SOURCE MATERIAL (use as factual grounding; quote or paraphrase from it where it strengthens a pillar — do not invent statistics it does not support):
+{{SOURCE_MATERIAL}}
+
+{{PITCH_INSTRUCTION}}
+
+Return ONLY a JSON object with these fields:
+- "headline": a suggested headline (editors write their own, but propose a strong one — active, specific, under ~12 words)
+- "subtitle": a one-line deck/subtitle that sharpens the thesis (may be empty string)
+- "body_markdown": the full essay as Markdown. Short paragraphs. No section labels or headers inside the body — it must read as continuous prose. Do NOT repeat the headline inside the body.
+- "word_count": your integer count of the words in body_markdown
+- "pitch_email": the pitch cover email if one was requested above, otherwise an empty string
+
+Do not include any commentary outside the JSON.

--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -1,0 +1,368 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function New-OpEd {
+    <#
+    .SYNOPSIS
+        Generates a publication-ready op-ed (guest essay) on a topic or URL,
+        written in the authentic voice of one of the AI Triad POV camps.
+    .DESCRIPTION
+        New-OpEd assembles a system prompt from two sources — the OpEd Project /
+        Harvard Kennedy School structural blueprint (lede + news hook, early
+        thesis, two-to-three evidence pillars, a "To Be Sure" counterargument,
+        and a solution that names specific actors) and the camp's Soul document
+        (disposition, rhetorical style, signature move, prose-style and
+        voice-hygiene rules, value hierarchy, epistemic stance, and
+        anti-patterns) — then asks the model to draft the essay in that voice.
+
+        The subject can be supplied as free text (-Topic) or fetched from a URL
+        (-Url), which is converted to Markdown and passed as source material. The
+        target length is derived from the chosen -Outlet's editorial limits (or
+        set explicitly with -WordCount). Optionally emits the standard pitch
+        cover email (-IncludePitch) and writes a Markdown file (-OutputPath).
+
+        Prompts are production artifacts: the structural rules live in
+        Prompts/op-ed-generation-system.prompt and the task contract in
+        Prompts/op-ed-generation-user.prompt; the voice block is built from the
+        Soul document at lib/debate/soul-docs/<pov>.soul.json.
+    .PARAMETER Topic
+        The subject or angle for the essay, as free text. Mandatory in the
+        default 'FromTopic' parameter set; optional alongside -Url to steer the
+        angle of a fetched source.
+    .PARAMETER Url
+        A web page to use as source material. The page is fetched and converted
+        to Markdown, then handed to the model as factual grounding. Mandatory in
+        the 'FromUrl' parameter set.
+    .PARAMETER Pov
+        The camp voice to write in. One of accelerationist, safetyist, skeptic
+        (short forms acc / saf / skp accepted). Loads the matching Soul document.
+    .PARAMETER Outlet
+        Target publication category. Sets the default word-count band and
+        audience/tone guidance from real editorial specifications. Overridden by
+        an explicit -WordCount.
+    .PARAMETER WordCount
+        Explicit target length (300-2000 words). Overrides the -Outlet default.
+    .PARAMETER NewsHook
+        The timely peg (a pending vote, ruling, report, or milestone) that
+        justifies publishing now. Strongly recommended — op-eds without a news
+        hook are routinely rejected. If omitted, the model constructs a plausible
+        hook and the draft should be re-checked against real current events.
+    .PARAMETER Thesis
+        An explicit stance to argue. If omitted, the model derives a thesis
+        consistent with the camp's value hierarchy.
+    .PARAMETER AuthorBio
+        Author credentials for the authority line / bio (e.g.,
+        'a health economist at ...').
+    .PARAMETER IncludePitch
+        Also generate the standard pitch cover email (subject line, thesis
+        summary, credentials) per the submission protocol.
+    .PARAMETER OutputPath
+        If supplied, writes the headline, body, and any pitch to a Markdown file
+        at this path (UTF-8, no BOM).
+    .PARAMETER Model
+        AI model to use. Defaults to gemini-3.6-flash — a deliberate step up from
+        the flash-lite enrichment default because long-form persuasive prose needs
+        a stronger tier; a GA model is preferred over a preview as a default. For
+        maximum polish, pass -Model gemini-3.1-pro-preview.
+    .PARAMETER Temperature
+        Sampling temperature. Defaults to 0.8 for creative prose.
+    .OUTPUTS
+        [PSCustomObject] with Headline, Subtitle, Body, Pitch, WordCount, Pov,
+        Outlet, Model, and Backend.
+    .EXAMPLE
+        New-OpEd -Topic 'Mandatory pre-deployment audits for frontier AI models' `
+            -Pov safetyist -Outlet WashingtonPost `
+            -NewsHook 'the Senate AI oversight bill scheduled for a floor vote next week'
+
+        Drafts an 800-word Washington Post-length guest essay in the Safetyist voice.
+    .EXAMPLE
+        New-OpEd -Url 'https://example.com/ai-jobs-report' -Pov accelerationist `
+            -Outlet WallStreetJournal -IncludePitch -OutputPath ./oped.md
+
+        Fetches the article as source material, writes a WSJ-length essay in the
+        Accelerationist voice, includes a pitch email, and saves it to disk.
+    .LINK
+        Invoke-AIApi
+    .LINK
+        Show-TriadDialogue
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'FromTopic')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, Position = 0, ParameterSetName = 'FromTopic')]
+        [Parameter(Position = 0, ParameterSetName = 'FromUrl')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Topic,
+
+        [Parameter(Mandatory, ParameterSetName = 'FromUrl')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Url,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('accelerationist', 'safetyist', 'skeptic', 'acc', 'saf', 'skp')]
+        [string]$Pov,
+
+        [ValidateSet('WashingtonPost', 'NYTimes', 'WallStreetJournal', 'USAToday',
+            'ForeignAffairs', 'Politico', 'Regional', 'Generic')]
+        [string]$Outlet = 'Generic',
+
+        [ValidateRange(300, 2000)]
+        [int]$WordCount,
+
+        [string]$NewsHook = '',
+
+        [string]$Thesis = '',
+
+        [string]$AuthorBio = '',
+
+        [switch]$IncludePitch,
+
+        [string]$OutputPath,
+
+        [ValidateScript({ Test-AIModelId $_ })]
+        [string]$Model = 'gemini-3.6-flash',
+
+        [ValidateRange(0.0, 2.0)]
+        [double]$Temperature = 0.8
+    )
+
+    Set-StrictMode -Version Latest
+
+    # ── Normalize the POV to its canonical Soul-document name ────────────────
+    $PovMap = @{
+        acc = 'accelerationist'; accelerationist = 'accelerationist'
+        saf = 'safetyist';       safetyist       = 'safetyist'
+        skp = 'skeptic';         skeptic         = 'skeptic'
+    }
+    $PovKey = $PovMap[$Pov.ToLowerInvariant()]
+
+    # ── Load the Soul document (lives in the code repo, not the data repo) ───
+    # $script:ModuleRoot is scripts/AITriad; soul docs live at
+    # <repo-root>/lib/debate/soul-docs/<pov>.soul.json.
+    $RepoRoot = Split-Path -Parent (Split-Path -Parent $script:ModuleRoot)
+    $SoulPath = Join-Path $RepoRoot (Join-Path 'lib/debate/soul-docs' "$PovKey.soul.json")
+    if (-not (Test-Path $SoulPath)) {
+        throw (New-ActionableError -PassThru `
+            -Goal 'Generate an op-ed in a POV voice' `
+            -Problem "Soul document not found for POV '$PovKey': $SoulPath" `
+            -Location 'New-OpEd' `
+            -NextSteps @(
+                "Confirm lib/debate/soul-docs/$PovKey.soul.json exists in the repo",
+                'Run from a full checkout; Soul documents ship with the code repo, not the data repo'
+            ))
+    }
+    try {
+        $Soul = Get-Content -Path $SoulPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        throw (New-ActionableError -PassThru `
+            -Goal 'Generate an op-ed in a POV voice' `
+            -Problem "Soul document at $SoulPath is not valid JSON: $($_.Exception.Message)" `
+            -Location 'New-OpEd' `
+            -NextSteps 'Validate the Soul document JSON and retry.')
+    }
+
+    # ── Build the voice block from the Soul document ─────────────────────────
+    $v = $Soul.voice
+    $VoiceLines = [System.Collections.Generic.List[string]]::new()
+    $VoiceLines.Add("PERSONALITY: $($Soul.personality)")
+    $VoiceLines.Add("DISPOSITION: $($v.disposition)")
+    $VoiceLines.Add("RHETORICAL STYLE: $($v.style)")
+    $VoiceLines.Add("REASONING MODE: $($v.reasoning)")
+    $VoiceLines.Add("PREFERRED EVIDENCE: $($v.evidence)")
+    $VoiceLines.Add("SIGNATURE MOVE: $($v.signature)")
+    $VoiceLines.Add('')
+    $VoiceLines.Add([string]$v.prose_style)
+    $VoiceLines.Add('')
+    $VoiceLines.Add([string]$v.voice_hygiene)
+    $VoiceLines.Add('')
+    $VoiceLines.Add('VALUE HIERARCHY (in priority order):')
+    $rank = 1
+    foreach ($val in @($Soul.value_hierarchy)) { $VoiceLines.Add("  $rank. $val"); $rank++ }
+    $VoiceLines.Add('')
+    $VoiceLines.Add('EPISTEMIC STANCE:')
+    foreach ($e in @($Soul.epistemic_stance)) { $VoiceLines.Add("  - $e") }
+    $VoiceLines.Add('')
+    $VoiceLines.Add('ANTI-PATTERNS (never do these):')
+    foreach ($a in @($Soul.anti_patterns)) { $VoiceLines.Add("  - $a") }
+    $VoiceBlock = $VoiceLines -join "`n"
+
+    # ── Resolve the target word count from the outlet band (unless explicit) ─
+    $OutletBands = @{
+        WashingtonPost    = @{ Words = 800;  Guidance = 'The Washington Post: max 800 words, strong news hook, hyperlink-able sources, zero jargon; national public audience.' }
+        NYTimes           = @{ Words = 800;  Guidance = 'The New York Times Guest Essay: ~800 words, sharp thesis, general national readership.' }
+        WallStreetJournal = @{ Words = 900;  Guidance = 'The Wall Street Journal: 600-1200 words, rapid thesis, business/policy relevance, market and regulatory framing, zero jargon; executives, investors, policymakers.' }
+        USAToday          = @{ Words = 650;  Guidance = 'USA Today: 550-750 words, embed verifiable source references, plain and direct; broad national audience.' }
+        ForeignAffairs    = @{ Words = 1200; Guidance = 'Foreign Affairs / policy platform: 800-1500 words, deeper structural analysis permitted; subject specialists, Hill staff, agency officials.' }
+        Politico          = @{ Words = 1000; Guidance = 'Politico: ~1000 words, policy-mechanics focus, timely; Hill and agency audience.' }
+        Regional          = @{ Words = 650;  Guidance = 'Regional / local daily: 500-800 words, direct regional relevance, local anecdotes, state-level calls to action; municipal voters and state legislators.' }
+        Generic           = @{ Words = 800;  Guidance = 'General-interest opinion desk: ~800 words, strong news hook, plain language, broad public audience.' }
+    }
+    $Band = $OutletBands[$Outlet]
+    $TargetWords = if ($PSBoundParameters.ContainsKey('WordCount')) { $WordCount } else { $Band.Words }
+
+    # ── Resolve source material: fetch + convert the URL if given ────────────
+    $SourceMaterial = '(no external source supplied — argue from the topic and general knowledge)'
+    if ($PSCmdlet.ParameterSetName -eq 'FromUrl') {
+        Write-Verbose "Fetching source material from $Url"
+        try {
+            $Resp = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 30
+        } catch {
+            throw (New-ActionableError -PassThru `
+                -Goal 'Generate an op-ed from a URL' `
+                -Problem "Failed to fetch source URL '$Url': $($_.Exception.Message)" `
+                -Location 'New-OpEd' `
+                -NextSteps @(
+                    'Confirm the URL is reachable and returns HTML',
+                    'Supply the material via -Topic text instead, or try a different URL'
+                ))
+        }
+        $Markdown = ConvertFrom-Html -Html ([string]$Resp.Content) -SourceUrl $Url
+        # Cap the source to keep the prompt within a sane token budget.
+        $MaxChars = 12000
+        if ($Markdown.Length -gt $MaxChars) {
+            $Markdown = $Markdown.Substring(0, $MaxChars) + "`n`n[... source truncated ...]"
+        }
+        $SourceMaterial = $Markdown
+        if (-not $PSBoundParameters.ContainsKey('Topic') -or [string]::IsNullOrWhiteSpace($Topic)) {
+            $Topic = "Write an op-ed responding to the source material below (from $Url). Choose the sharpest angle consistent with your camp's convictions."
+        }
+    }
+
+    # ── Assemble prompt-fill values for the optional fields ──────────────────
+    $NewsHookText = if ([string]::IsNullOrWhiteSpace($NewsHook)) {
+        '(none supplied — invent a plausible current news hook and make clear in the lede what timely event it assumes, so the author can verify it against real events before submitting)'
+    } else { $NewsHook }
+
+    $ThesisText = if ([string]::IsNullOrWhiteSpace($Thesis)) {
+        '(none supplied — derive a clear, arguable thesis that follows from your camp value hierarchy)'
+    } else { $Thesis }
+
+    $AuthorBioText = if ([string]::IsNullOrWhiteSpace($AuthorBio)) {
+        '(none supplied — write a generic authority line the author can replace, e.g. "[Author], [affiliation]")'
+    } else { $AuthorBio }
+
+    $PitchInstruction = if ($IncludePitch) {
+        'ALSO write a pitch cover email in "pitch_email". Use this layout: a subject line "Op-Ed Submission: [Headline]"; one or two sentences opening with the news hook and summarizing the thesis and proposed solution; one sentence of author credentials; and a closing note that the full draft is pasted below. Keep it under 150 words and do not paste the essay itself into the pitch.'
+    } else {
+        'No pitch email is needed; return an empty string for "pitch_email".'
+    }
+
+    # ── Load prompt templates ────────────────────────────────────────────────
+    $SystemPrompt = Get-Prompt -Name 'op-ed-generation-system' -Replacements @{
+        POV_LABEL       = $Soul.label
+        VOICE_BLOCK     = $VoiceBlock
+        WORD_COUNT      = "$TargetWords"
+        OUTLET_GUIDANCE = $Band.Guidance
+    }
+    $UserPrompt = Get-Prompt -Name 'op-ed-generation-user' -Replacements @{
+        TOPIC             = $Topic
+        WORD_COUNT        = "$TargetWords"
+        OUTLET_GUIDANCE   = $Band.Guidance
+        NEWS_HOOK         = $NewsHookText
+        THESIS            = $ThesisText
+        AUTHOR_BIO        = $AuthorBioText
+        SOURCE_MATERIAL   = $SourceMaterial
+        PITCH_INSTRUCTION = $PitchInstruction
+    }
+
+    # ── Response schema — structured output for clean field extraction ───────
+    $Schema = @{
+        type       = 'object'
+        properties = @{
+            headline      = @{ type = 'string' }
+            subtitle      = @{ type = 'string' }
+            body_markdown = @{ type = 'string' }
+            word_count    = @{ type = 'integer' }
+            pitch_email   = @{ type = 'string' }
+        }
+        required   = @('headline', 'body_markdown', 'word_count')
+    }
+
+    # Budget output tokens generously. The default model is a "thinking" model
+    # (gemini-3.x pro/flash) whose reasoning tokens are billed against the same
+    # output budget — too small a cap starves the visible response and truncates
+    # the JSON mid-string (parse then falls back to raw text). Allow ~3 tokens
+    # per target word for prose plus a large fixed reserve for reasoning, the
+    # optional pitch, and JSON overhead.
+    $MaxTokens = [int]([math]::Ceiling($TargetWords * 3)) + 5000
+
+    Write-Verbose "Generating op-ed: pov='$PovKey' outlet='$Outlet' words=$TargetWords model='$Model' temp=$Temperature"
+
+    $Result = Invoke-AIApi `
+        -Prompt $UserPrompt `
+        -SystemInstruction $SystemPrompt `
+        -Model $Model `
+        -Temperature $Temperature `
+        -MaxTokens $MaxTokens `
+        -JsonMode `
+        -ResponseSchema $Schema
+
+    if ($null -eq $Result -or [string]::IsNullOrWhiteSpace($Result.Text)) {
+        throw (New-ActionableError -PassThru `
+            -Goal 'Generate an op-ed in a POV voice' `
+            -Problem 'The AI backend returned no text.' `
+            -Location 'New-OpEd' `
+            -NextSteps @(
+                'Confirm an API key is registered for the selected model backend',
+                'Retry, or try a different -Model'
+            ))
+    }
+
+    # ── Parse the structured response, degrading gracefully to raw text ──────
+    $Headline = ''
+    $Subtitle = ''
+    $Body     = ''
+    $Pitch    = ''
+    $ReportedWords = 0
+    try {
+        $Parsed = $Result.Text | ConvertFrom-Json
+        $Headline = [string]$Parsed.headline
+        if ($Parsed.PSObject.Properties.Name -contains 'subtitle')    { $Subtitle = [string]$Parsed.subtitle }
+        $Body = [string]$Parsed.body_markdown
+        # -IncludePitch deterministically controls the pitch field; never surface
+        # a pitch the caller did not ask for, even if the model volunteered one.
+        if ($IncludePitch -and $Parsed.PSObject.Properties.Name -contains 'pitch_email') { $Pitch = [string]$Parsed.pitch_email }
+        if ($Parsed.PSObject.Properties.Name -contains 'word_count')  { $ReportedWords = [int]$Parsed.word_count }
+    } catch {
+        Write-Warning "Response was not valid JSON; returning raw text as the body. ($($_.Exception.Message))"
+        $Body = [string]$Result.Text
+    }
+
+    # Prefer an actual count over the model's self-report.
+    $ActualWords = if ([string]::IsNullOrWhiteSpace($Body)) { 0 } else {
+        @($Body -split '\s+' | Where-Object { $_ -ne '' }).Count
+    }
+
+    $Output = [PSCustomObject]@{
+        Headline  = $Headline
+        Subtitle  = $Subtitle
+        Body      = $Body
+        Pitch     = $Pitch
+        WordCount = $ActualWords
+        Pov       = $PovKey
+        Outlet    = $Outlet
+        Model     = $Model
+        Backend   = $Result.Backend
+    }
+
+    # ── Optionally write a Markdown file ─────────────────────────────────────
+    if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+        $md = [System.Text.StringBuilder]::new()
+        if ($Headline) { [void]$md.AppendLine("# $Headline"); [void]$md.AppendLine() }
+        if ($Subtitle) { [void]$md.AppendLine("*$Subtitle*"); [void]$md.AppendLine() }
+        [void]$md.AppendLine($Body)
+        if ($Pitch) {
+            [void]$md.AppendLine()
+            [void]$md.AppendLine('---')
+            [void]$md.AppendLine()
+            [void]$md.AppendLine('## Pitch cover email')
+            [void]$md.AppendLine()
+            [void]$md.AppendLine($Pitch)
+        }
+        $Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+        [System.IO.File]::WriteAllText($OutputPath, $md.ToString(), $Utf8NoBom)
+        Write-Verbose "Wrote op-ed to $OutputPath"
+    }
+
+    return $Output
+}

--- a/tests/New-OpEd.Tests.ps1
+++ b/tests/New-OpEd.Tests.ps1
@@ -1,0 +1,119 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+Describe 'New-OpEd' -Tag 'oped' {
+    BeforeAll {
+        Import-Module "$PSScriptRoot/../scripts/AITriad/AITriad.psm1" -Force
+
+        # Standard structured response the mocked backend returns.
+        $script:GoodJson = @{
+            headline      = 'Stop Stalling on AI Safety'
+            subtitle      = 'The cost of delay is measured in trust'
+            body_markdown = "First paragraph makes the case.`n`nSecond paragraph adds evidence."
+            word_count    = 11
+            pitch_email   = 'Subject: Op-Ed Submission: Stop Stalling on AI Safety'
+        } | ConvertTo-Json
+    }
+
+    Context 'Happy path — topic input' {
+        BeforeEach {
+            $script:capturedSystem = $null
+            $script:capturedPrompt = $null
+            Mock Invoke-AIApi {
+                $script:capturedSystem = $SystemInstruction
+                $script:capturedPrompt = $Prompt
+                [PSCustomObject]@{ Text = $script:GoodJson; Backend = 'gemini' }
+            } -ModuleName AITriad
+        }
+
+        It 'Returns a populated structured object' {
+            $r = New-OpEd -Topic 'Pre-deployment audits for frontier models' -Pov safetyist
+            $r.Headline  | Should -Be 'Stop Stalling on AI Safety'
+            $r.Subtitle  | Should -Match 'trust'
+            $r.Body      | Should -Match 'First paragraph'
+            $r.Pov       | Should -Be 'safetyist'
+            $r.Outlet    | Should -Be 'Generic'
+            $r.Backend   | Should -Be 'gemini'
+        }
+
+        It 'Counts the actual body words rather than trusting the model self-report' {
+            $r = New-OpEd -Topic 'x' -Pov skeptic
+            # Body has 9 whitespace-separated words; model claimed 11.
+            $r.WordCount | Should -Be 9
+        }
+
+        It 'Injects the Soul-document voice into the system prompt' {
+            New-OpEd -Topic 'x' -Pov accelerationist | Out-Null
+            $script:capturedSystem | Should -Match 'VALUE HIERARCHY'
+            $script:capturedSystem | Should -Match 'ANTI-PATTERNS'
+            # Accelerationist personality string from the Soul doc.
+            $script:capturedSystem | Should -Match 'forward-looking'
+        }
+
+        It 'Derives the target word count from the outlet band' {
+            New-OpEd -Topic 'x' -Pov safetyist -Outlet ForeignAffairs | Out-Null
+            $script:capturedPrompt | Should -Match '1200 words'
+        }
+
+        It 'Lets an explicit -WordCount override the outlet band' {
+            New-OpEd -Topic 'x' -Pov safetyist -Outlet ForeignAffairs -WordCount 500 | Out-Null
+            $script:capturedPrompt | Should -Match '500 words'
+        }
+
+        It 'Normalizes short-form POV aliases to the canonical name' {
+            (New-OpEd -Topic 'x' -Pov acc).Pov | Should -Be 'accelerationist'
+            (New-OpEd -Topic 'x' -Pov saf).Pov | Should -Be 'safetyist'
+            (New-OpEd -Topic 'x' -Pov skp).Pov | Should -Be 'skeptic'
+        }
+
+        It 'Emits a pitch email only when -IncludePitch is set' {
+            (New-OpEd -Topic 'x' -Pov skeptic).Pitch                 | Should -BeNullOrEmpty
+            (New-OpEd -Topic 'x' -Pov skeptic -IncludePitch).Pitch   | Should -Match 'Op-Ed Submission'
+        }
+
+        It 'Writes a Markdown file when -OutputPath is supplied' {
+            $out = Join-Path ([System.IO.Path]::GetTempPath()) "oped-$([guid]::NewGuid()).md"
+            try {
+                New-OpEd -Topic 'x' -Pov safetyist -OutputPath $out | Out-Null
+                Test-Path $out | Should -BeTrue
+                (Get-Content -Raw $out) | Should -Match '# Stop Stalling on AI Safety'
+            } finally {
+                Remove-Item $out -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    Context 'URL input' {
+        It 'Fetches and converts the URL into source material' {
+            Mock Invoke-WebRequest { [PSCustomObject]@{ Content = '<html><body><p>Source body text.</p></body></html>' } } -ModuleName AITriad
+            Mock ConvertFrom-Html { 'Source body text.' } -ModuleName AITriad
+            $script:seenPrompt = $null
+            Mock Invoke-AIApi {
+                $script:seenPrompt = $Prompt
+                [PSCustomObject]@{ Text = $script:GoodJson; Backend = 'gemini' }
+            } -ModuleName AITriad
+
+            $r = New-OpEd -Url 'https://example.com/article' -Pov accelerationist
+            $r.Headline | Should -Be 'Stop Stalling on AI Safety'
+            $script:seenPrompt | Should -Match 'Source body text'
+            Should -Invoke Invoke-WebRequest -ModuleName AITriad -Times 1
+        }
+    }
+
+    Context 'Degradation and errors' {
+        It 'Falls back to raw text when the response is not valid JSON' {
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = 'Just some prose, not JSON.'; Backend = 'gemini' } } -ModuleName AITriad
+            $r = New-OpEd -Topic 'x' -Pov skeptic 3>$null
+            $r.Body | Should -Match 'Just some prose'
+        }
+
+        It 'Throws an actionable error when the backend returns nothing' {
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = ''; Backend = 'gemini' } } -ModuleName AITriad
+            { New-OpEd -Topic 'x' -Pov skeptic } | Should -Throw
+        }
+
+        It 'Rejects an unknown POV at parameter binding' {
+            { New-OpEd -Topic 'x' -Pov 'centrist' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds the **`New-OpEd`** public PowerShell cmdlet: drafts a publication-ready op-ed (guest essay) in the authentic voice of an AI Triad POV camp, following the OpEd Project / Harvard Kennedy School structural blueprint.

The voice is assembled from the camp's **Soul document** (`lib/debate/soul-docs/<pov>.soul.json`) — disposition, prose_style, voice_hygiene, value_hierarchy, epistemic_stance, anti_patterns — and injected into a system prompt that also encodes op-ed craft (lede + news hook, early thesis, 2–3 evidence pillars, a "To Be Sure" counterargument, and a solution naming specific actors).

## Usage
```powershell
New-OpEd -Topic 'Pre-deployment safety audits for frontier AI' -Pov safetyist `
    -Outlet WashingtonPost -NewsHook 'a Senate markup next week' -IncludePitch

New-OpEd -Url 'https://example.com/article' -Pov accelerationist `
    -Outlet WallStreetJournal -OutputPath ./oped.md
```

## Parameters
- **`-Topic`** / **`-Url`** (parameter sets) — subject as text, or a URL fetched + converted to Markdown source material.
- **`-Pov`** — `accelerationist` | `safetyist` | `skeptic` (short forms `acc`/`saf`/`skp`).
- **`-Outlet`** — sets the word-count band from real editorial specs; **`-WordCount`** overrides.
- **`-NewsHook`**, **`-Thesis`**, **`-AuthorBio`** — steer the draft.
- **`-IncludePitch`** — emit the standard pitch cover email (deterministic; gated in-cmdlet, not left to the model).
- **`-OutputPath`** — write Markdown (UTF-8, no BOM).
- **`-Model`** (validated by `Test-AIModelId`), **`-Temperature`** (default 0.8).

## Design notes
- Structural rules live in `Prompts/op-ed-generation-{system,user}.prompt`; the cmdlet requests JSON (`-JsonMode` + `responseSchema`) and **degrades to raw text** if parsing fails.
- **Default model `gemini-3.6-flash`** — a deliberate, documented deviation from the flash-lite enrichment default: long-form persuasive prose needs a stronger tier, and a GA model beats a preview as a default. `-Model gemini-3.1-pro-preview` for max polish.
- **Token budget** sized for thinking-model reasoning overhead (`words*3 + 5000`) — an undersized cap truncates the JSON mid-string (caught in live testing).

## Testing
- **12 Pester tests** (`-Tag oped`), mocked backend → keyless/CI-safe: happy path, actual-word-count vs model self-report, Soul-voice injection, outlet→word-count derivation + override, POV alias normalization, `-IncludePitch` gating, file output, URL fetch/convert, JSON→raw fallback, empty-backend actionable error, invalid-POV rejection.
- `Test-ModuleManifest` passes; added to **both** `Export-ModuleMember` and `FunctionsToExport`.
- **Live-verified end to end** (764-word WaPo-length safetyist draft + pitch).

Followed **`/add-ps-cmdlet`** (design-review exemption). Note: files land in the PowerShell role's scope — authored by the Computational Linguist as prompt-bearing work per the user's direct request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)