### PR TITLE
feat(ipc): ai:cancel-generate channel + per-request AbortController map (t/2509)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/aiHandlers.cancelGenerate.test.ts
+++ b/taxonomy-editor/src/main/__tests__/aiHandlers.cancelGenerate.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Unit tests for ai:cancel-generate IPC channel + AbortController map (t/2509).
+// Exercises: map cleanup on success, failure, and cancel; unknown-id no-op;
+// no-requestId calls unchanged.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+
+const mockGenerateText = vi.hoisted(() => vi.fn());
+
+vi.mock('../embeddings.js', () => ({
+  generateText: mockGenerateText,
+  generateChatStream: vi.fn(),
+  generateTextWithSearch: vi.fn(),
+  computeEmbeddings: vi.fn(),
+  computeQueryEmbedding: vi.fn(),
+  updateNodeEmbeddings: vi.fn(),
+  classifyNli: vi.fn(),
+  setDebateTemperature: vi.fn(),
+  getEmbeddingInfo: vi.fn(),
+}));
+
+vi.mock('../../../../lib/ai-client/index.js', () => ({
+  resolveBackend: vi.fn(() => 'gemini'),
+  DEFAULT_MODEL: 'gemini-2.0-flash',
+  DEFAULT_TEMPERATURE: 0.7,
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp'), getVersion: vi.fn(() => '1.0.0') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false), encryptString: vi.fn(), decryptString: vi.fn() },
+}));
+
+vi.mock('../fileIO.js', () => ({
+  PROJECT_ROOT: '/fake/root',
+  getDataRootPath: vi.fn(() => '/fake/data'),
+  resolveDataPath: vi.fn((p: string) => `/fake/data/${p}`),
+}));
+
+vi.mock('../modelDiscovery.js', () => ({ refreshAIModels: vi.fn() }));
+vi.mock('../embeddingErrors.js', () => ({ buildEmbeddingFailureError: vi.fn() }));
+vi.mock('../../../../lib/debate/errors.js', () => ({ ActionableError: class extends Error {} }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+vi.mock('../../../../lib/debate/constants.js', () => ({ DEFAULT_RELEVANCE_THRESHOLD: 0.5 }));
+vi.mock('../../../../lib/url-fetch/fetchUrlForPrompt.js', () => ({ fetchUrlForPrompt: vi.fn() }));
+
+import { registerAiHandlers } from '../ipc/aiHandlers.js';
+
+function getHandler(channel: string): (event: unknown, ...args: unknown[]) => Promise<unknown> {
+  const calls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls;
+  const entry = calls.find((c: unknown[]) => c[0] === channel);
+  if (!entry) throw new Error(`${channel} handler not registered`);
+  return entry[1];
+}
+
+function makeSender() {
+  return { sender: { isDestroyed: () => false, send: vi.fn() } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  registerAiHandlers();
+});
+
+describe('ai:cancel-generate — unknown requestId is silent no-op', () => {
+  it('does not throw on unknown id', async () => {
+    const cancel = getHandler('ai:cancel-generate');
+    expect(cancel({}, 'nonexistent-id')).toBeUndefined();
+  });
+});
+
+describe('generate-text — AbortController map lifecycle', () => {
+  it('success path: map entry removed in finally', async () => {
+    mockGenerateText.mockResolvedValue('ok');
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    await handler({ sender }, 'prompt', undefined, undefined, undefined, 'req-1');
+    // After completion the cancel handler is a no-op (entry gone)
+    const cancel = getHandler('ai:cancel-generate');
+    expect(cancel({}, 'req-1')).toBeUndefined();
+  });
+
+  it('failure path: map entry removed even on throw', async () => {
+    mockGenerateText.mockRejectedValue(new Error('boom'));
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    await expect(handler({ sender }, 'prompt', undefined, undefined, undefined, 'req-2')).rejects.toThrow();
+    const cancel = getHandler('ai:cancel-generate');
+    expect(cancel({}, 'req-2')).toBeUndefined();
+  });
+
+  it('cancel path: AbortError rethrown without ActionableError wrapping', async () => {
+    mockGenerateText.mockImplementation((_p: string, _m: unknown, _r: unknown, _t: unknown, _temp: unknown, signal: AbortSignal) =>
+      new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          const e = new Error('cancelled');
+          e.name = 'AbortError';
+          reject(e);
+        });
+      }),
+    );
+
+    const handler = getHandler('generate-text');
+    const cancel = getHandler('ai:cancel-generate');
+    const { sender } = makeSender();
+
+    const resultP = handler({ sender }, 'prompt', undefined, undefined, undefined, 'req-3');
+    await cancel({}, 'req-3');
+    const err = await resultP.catch((e: Error) => e);
+    expect((err as Error).name).toBe('AbortError');
+  });
+
+  it('no-requestId call: behaves identically to today (no AbortController created)', async () => {
+    mockGenerateText.mockResolvedValue('result');
+    const handler = getHandler('generate-text');
+    const { sender } = makeSender();
+    const result = await handler({ sender }, 'prompt');
+    expect(result).toEqual({ text: 'result' });
+    // signal arg to generateText must be undefined
+    const signalArg = mockGenerateText.mock.calls[0][5];
+    expect(signalArg).toBeUndefined();
+  });
+});

--- a/taxonomy-editor/src/main/embeddings.ts
+++ b/taxonomy-editor/src/main/embeddings.ts
@@ -631,6 +631,7 @@ export async function generateText(
   onRetry?: (progress: GenerateTextProgress) => void,
   timeoutMs?: number,
   temperature?: number,
+  signal?: AbortSignal,
 ): Promise<string> {
   const friendlyModel = model || DEFAULT_MODEL;
   const backend = resolveBackend(friendlyModel);
@@ -667,6 +668,7 @@ export async function generateText(
     temperature: temperature ?? _debateTemperature ?? 0.7,
     timeoutMs: timeoutMs ?? getDefaultTimeout(friendlyModel),
     ...fixedTempOverride(entry),
+    ...(signal ? { signal } : {}),
   };
 
   const providerFn = backend === 'deepseek'

--- a/taxonomy-editor/src/main/ipc/aiHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/aiHandlers.ts
@@ -22,6 +22,10 @@ import { buildEmbeddingFailureError } from '../embeddingErrors.js';
 import { fetchUrlForPrompt } from '../../../../lib/url-fetch/fetchUrlForPrompt.js';
 import { extractHttpUrls } from '../../../../lib/url-fetch/extractHttpUrls.js';
 
+// ── Per-request AbortController map (t/2509) ──────────────────────────────
+
+const activeGenerations = new Map<string, AbortController>();
+
 // ── Fetch-and-inject helpers (t/2484) ─────────────────────────────────────
 
 const MAX_FETCH_URLS = 3;
@@ -147,14 +151,27 @@ export function registerAiHandlers(): void {
     }
   });
 
-  ipcMain.handle('generate-text', async (event, prompt: string, model?: string, timeoutMs?: number, temperature?: number) => {
+  ipcMain.handle('generate-text', async (event, prompt: string, model?: string, timeoutMs?: number, temperature?: number, requestId?: string) => {
+    const t0 = Date.now();
+    const controller = requestId ? new AbortController() : undefined;
+    if (requestId && controller) activeGenerations.set(requestId, controller);
     try {
       return {
         text: await generateText(prompt, model, (progress) => {
           event.sender.send('generate-text-progress', progress);
-        }, timeoutMs, temperature),
+        }, timeoutMs, temperature, controller?.signal),
       };
     } catch (err) {
+      if ((err as Error).name === 'AbortError' || controller?.signal.aborted) {
+        getGlobalRecorder()?.record({
+          type: 'system.info',
+          component: 'ipc-handlers',
+          level: 'info',
+          message: 'ai.cancelled',
+          data: { requestId, elapsed_ms: Date.now() - t0 },
+        });
+        throw err;
+      }
       getGlobalRecorder()?.record({
         type: 'system.error',
         component: 'ipc-handlers',
@@ -174,7 +191,13 @@ export function registerAiHandlers(): void {
           'Try a different AI backend if the current one is unreachable',
         ],
       });
+    } finally {
+      if (requestId) activeGenerations.delete(requestId);
     }
+  });
+
+  ipcMain.handle('ai:cancel-generate', (_event, requestId: string) => {
+    activeGenerations.get(requestId)?.abort();
   });
 
   ipcMain.handle('set-debate-temperature', (_event, temp: number | null) => {

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -162,8 +162,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   computeQueryEmbedding: (text: string): Promise<{ vector: number[] }> =>
     ipcRenderer.invoke('compute-query-embedding', text),
 
-  generateText: (prompt: string, model?: string, timeoutMs?: number, temperature?: number): Promise<{ text: string }> =>
-    ipcRenderer.invoke('generate-text', prompt, model, timeoutMs, temperature),
+  generateText: (prompt: string, model?: string, timeoutMs?: number, temperature?: number, requestId?: string): Promise<{ text: string }> =>
+    ipcRenderer.invoke('generate-text', prompt, model, timeoutMs, temperature, requestId),
+
+  cancelGenerate: (requestId: string): void =>
+    void ipcRenderer.invoke('ai:cancel-generate', requestId),
 
   setDebateTemperature: (temp: number | null): Promise<void> =>
     ipcRenderer.invoke('set-debate-temperature', temp),


### PR DESCRIPTION
## Summary

- `generateText` gains optional `signal?: AbortSignal` param threaded into `GenerateOptions` so abort reaches the provider fetch via the t/2507 retry ladder
- `generate-text` IPC handler accepts optional `requestId`; creates an `AbortController` per request stored in a module-level `Map`; entry removed in `finally` (no leak); `AbortError` rethrown at **info** level (`ai.cancelled` FR event) — not wrapped in `ActionableError`
- New fire-and-forget `ai:cancel-generate(requestId)` aborts the mapped controller; unknown/settled id = silent no-op (idempotent, double-cancel safe)
- `preload.cts` exposes `cancelGenerate(requestId)`; renderer (t/2508) feature-detects it before wiring abort listener — landing order independent

## Test plan

- [ ] 5 unit tests: cancel path (AbortError rethrown), success/failure map cleanup, no-requestId parity (signal undefined), unknown-id no-op
- [ ] `tsc --noEmit -p tsconfig.main.json` clean
- [ ] 13/13 tests pass across fetch-inject + cancel-generate suites

Closes t/2509. Part of t/2506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: ElectronMain (Orca) <main.taxonomy-editor-src-main@ai-triad-research.orca.local>