### PR TITLE
feat(cmdlet): ground New-OpEd in the POV taxonomy (BDI nodes + situations) with relevance scores

### DIFF
--- a/scripts/AITriad/Prompts/op-ed-generation-user.prompt
+++ b/scripts/AITriad/Prompts/op-ed-generation-user.prompt
@@ -20,6 +20,12 @@ AUTHOR (for the authority line / bio):
 SOURCE MATERIAL (use as factual grounding; quote or paraphrase from it where it strengthens a pillar — do not invent statistics it does not support):
 {{SOURCE_MATERIAL}}
 
+YOUR CAMP'S REGISTERED POSITIONS — these are this camp's actual belief / desire / intention nodes, retrieved as the most relevant to this topic (most relevant first). Argue FROM them: build the thesis and evidence pillars on these commitments and do NOT contradict them. They are the substance of your camp, not optional background:
+{{GROUNDING_NODES}}
+
+CONCRETE STRESS-CASE SITUATIONS from your camp's situation library (most relevant first) — you may use one or two as the opening scene or as an evidence pillar, grounding an abstract position in a specific scenario:
+{{SITUATIONS}}
+
 {{PITCH_INSTRUCTION}}
 
 Return ONLY a JSON object with these fields:

--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -21,6 +21,17 @@ function New-OpEd {
         set explicitly with -WordCount). Optionally emits the standard pitch
         cover email (-IncludePitch) and writes a Markdown file (-OutputPath).
 
+        The substance is grounded (by default) in the project taxonomy: the POV's
+        most topic-relevant BDI nodes (its actual beliefs / desires / intentions)
+        and situation-library stress cases are retrieved via the same embedding
+        relevance the debate engine uses (Get-RelevantTaxonomyNodes) and injected
+        as the positions the essay must argue from — so the op-ed reflects THIS
+        project's registered camp, not the model's generic priors. The elements
+        used and their relevance scores are returned on the Grounding field. Pass
+        -VoiceOnly (or set the counts to 0) to write from voice alone; if the
+        taxonomy / embeddings / Python are unavailable, retrieval degrades to
+        voice-only with a warning rather than failing.
+
         Prompts are production artifacts: the structural rules live in
         Prompts/op-ed-generation-system.prompt and the task contract in
         Prompts/op-ed-generation-user.prompt; the voice block is built from the
@@ -66,15 +77,35 @@ function New-OpEd {
         maximum polish, pass -Model gemini-3.1-pro-preview.
     .PARAMETER Temperature
         Sampling temperature. Defaults to 0.8 for creative prose.
+    .PARAMETER VoiceOnly
+        Skip taxonomy grounding and write from the camp voice + general knowledge
+        alone. By default the essay is grounded in retrieved BDI nodes and
+        situations.
+    .PARAMETER MaxGroundingNodes
+        Maximum POV BDI nodes to retrieve and inject as registered positions
+        (0-40, default 12). 0 disables BDI grounding.
+    .PARAMETER MaxSituations
+        Maximum situation-library stress cases to retrieve and inject (0-15,
+        default 3). 0 disables situation grounding.
     .OUTPUTS
         [PSCustomObject] with Headline, Subtitle, Body, Pitch, WordCount, Pov,
-        Outlet, Model, and Backend.
+        Outlet, Model, Backend, and Grounding — an array of the taxonomy elements
+        injected (Id, Type [bdi|situation], POV, Category, Label, RelevanceScore),
+        ordered as retrieved.
     .EXAMPLE
         New-OpEd -Topic 'Mandatory pre-deployment audits for frontier AI models' `
             -Pov safetyist -Outlet WashingtonPost `
             -NewsHook 'the Senate AI oversight bill scheduled for a floor vote next week'
 
-        Drafts an 800-word Washington Post-length guest essay in the Safetyist voice.
+        Drafts an 800-word Washington Post-length guest essay in the Safetyist
+        voice, grounded in the Safetyist camp's most relevant belief/desire/
+        intention nodes and situations.
+    .EXAMPLE
+        $oped = New-OpEd -Topic 'Open-weight models and biosecurity' -Pov skeptic
+        $oped.Grounding | Format-Table Id, Type, Category, RelevanceScore
+
+        Inspects which taxonomy nodes and situations grounded the essay and how
+        relevant each was.
     .EXAMPLE
         New-OpEd -Url 'https://example.com/ai-jobs-report' -Pov accelerationist `
             -Outlet WallStreetJournal -IncludePitch -OutputPath ./oped.md
@@ -123,7 +154,15 @@ function New-OpEd {
         [string]$Model = 'gemini-3.6-flash',
 
         [ValidateRange(0.0, 2.0)]
-        [double]$Temperature = 0.8
+        [double]$Temperature = 0.8,
+
+        [switch]$VoiceOnly,
+
+        [ValidateRange(0, 40)]
+        [int]$MaxGroundingNodes = 12,
+
+        [ValidateRange(0, 15)]
+        [int]$MaxSituations = 3
     )
 
     Set-StrictMode -Version Latest
@@ -228,6 +267,71 @@ function New-OpEd {
         }
     }
 
+    # ── Ground the essay in the camp's registered taxonomy ───────────────────
+    # Retrieve the POV's most topic-relevant BDI nodes (its actual beliefs /
+    # desires / intentions) and situation-library stress cases via the same
+    # embedding relevance the debate engine uses, and inject them as the
+    # substance the essay must argue from. This is what makes the op-ed reflect
+    # THIS project's taxonomy rather than the model's generic priors. Grounded by
+    # default; -VoiceOnly (or zeroed counts) skips it. Retrieval failure (data
+    # repo / embeddings.json / Python unavailable) degrades to voice-only with a
+    # warning rather than failing the whole generation.
+    $Grounding = [System.Collections.Generic.List[PSObject]]::new()
+    $GroundingNodesText = '(none — argue from your camp voice and general knowledge)'
+    $SituationsText     = '(none supplied)'
+    if (-not $VoiceOnly -and ($MaxGroundingNodes -gt 0 -or $MaxSituations -gt 0)) {
+        # Query = the topic signal, plus the hook/thesis and a slice of any source.
+        $QueryParts = @($Topic, $NewsHook, $Thesis) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        if ($PSCmdlet.ParameterSetName -eq 'FromUrl' -and $SourceMaterial.Length -gt 0) {
+            $QueryParts += $SourceMaterial.Substring(0, [Math]::Min(1500, $SourceMaterial.Length))
+        }
+        $RetrievalQuery = $QueryParts -join '. '
+
+        try {
+            $WantSituations = $MaxSituations -gt 0
+            $PovArg = if ($WantSituations) { @($PovKey, 'situations') } else { @($PovKey) }
+            $Relevant = Get-RelevantTaxonomyNodes -Query $RetrievalQuery -POV $PovArg `
+                -IncludeSituations:$WantSituations -MaxTotal 50 -MinPerCategory 2
+
+            $BdiNodes = @($Relevant | Where-Object { $_.POV -eq $PovKey } |
+                Sort-Object Score -Descending | Select-Object -First $MaxGroundingNodes)
+            $SitNodes = @($Relevant | Where-Object { $_.POV -eq 'situations' } |
+                Sort-Object Score -Descending | Select-Object -First $MaxSituations)
+
+            if (@($BdiNodes).Count -gt 0) {
+                $sb = [System.Text.StringBuilder]::new()
+                foreach ($n in $BdiNodes) {
+                    $desc = [string]$n.Description
+                    if ($desc.Length -gt 240) { $desc = $desc.Substring(0, 240) + '…' }
+                    [void]$sb.AppendLine("- [$($n.Category)] $($n.Label): $desc")
+                    $Grounding.Add([PSCustomObject]@{
+                        Id = $n.Id; Type = 'bdi'; POV = $n.POV; Category = $n.Category
+                        Label = $n.Label; RelevanceScore = $n.Score
+                    })
+                }
+                $GroundingNodesText = $sb.ToString().TrimEnd()
+            }
+
+            if (@($SitNodes).Count -gt 0) {
+                $sb2 = [System.Text.StringBuilder]::new()
+                foreach ($s in $SitNodes) {
+                    $desc = [string]$s.Description
+                    if ($desc.Length -gt 300) { $desc = $desc.Substring(0, 300) + '…' }
+                    [void]$sb2.AppendLine("- $($s.Label): $desc")
+                    $Grounding.Add([PSCustomObject]@{
+                        Id = $s.Id; Type = 'situation'; POV = $s.POV; Category = 'Situation'
+                        Label = $s.Label; RelevanceScore = $s.Score
+                    })
+                }
+                $SituationsText = $sb2.ToString().TrimEnd()
+            }
+
+            Write-Verbose "Grounding: $(@($BdiNodes).Count) BDI nodes + $(@($SitNodes).Count) situations retrieved"
+        } catch {
+            Write-Warning "Taxonomy grounding unavailable — writing voice-only. ($($_.Exception.Message))"
+        }
+    }
+
     # ── Assemble prompt-fill values for the optional fields ──────────────────
     $NewsHookText = if ([string]::IsNullOrWhiteSpace($NewsHook)) {
         '(none supplied — invent a plausible current news hook and make clear in the lede what timely event it assumes, so the author can verify it against real events before submitting)'
@@ -262,6 +366,8 @@ function New-OpEd {
         THESIS            = $ThesisText
         AUTHOR_BIO        = $AuthorBioText
         SOURCE_MATERIAL   = $SourceMaterial
+        GROUNDING_NODES   = $GroundingNodesText
+        SITUATIONS        = $SituationsText
         PITCH_INSTRUCTION = $PitchInstruction
     }
 
@@ -343,6 +449,7 @@ function New-OpEd {
         Outlet    = $Outlet
         Model     = $Model
         Backend   = $Result.Backend
+        Grounding = $Grounding.ToArray()
     }
 
     # ── Optionally write a Markdown file ─────────────────────────────────────
@@ -358,6 +465,18 @@ function New-OpEd {
             [void]$md.AppendLine('## Pitch cover email')
             [void]$md.AppendLine()
             [void]$md.AppendLine($Pitch)
+        }
+        if (@($Grounding).Count -gt 0) {
+            [void]$md.AppendLine()
+            [void]$md.AppendLine('---')
+            [void]$md.AppendLine()
+            [void]$md.AppendLine('## Taxonomy grounding (relevance)')
+            [void]$md.AppendLine()
+            [void]$md.AppendLine('| Element | Type | Category | Relevance |')
+            [void]$md.AppendLine('|---|---|---|---|')
+            foreach ($g in $Grounding) {
+                [void]$md.AppendLine("| $($g.Id) — $($g.Label) | $($g.Type) | $($g.Category) | $([Math]::Round([double]$g.RelevanceScore, 4)) |")
+            }
         }
         $Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
         [System.IO.File]::WriteAllText($OutputPath, $md.ToString(), $Utf8NoBom)

--- a/tests/New-OpEd.Tests.ps1
+++ b/tests/New-OpEd.Tests.ps1
@@ -13,6 +13,13 @@ Describe 'New-OpEd' -Tag 'oped' {
             word_count    = 11
             pitch_email   = 'Subject: Op-Ed Submission: Stop Stalling on AI Safety'
         } | ConvertTo-Json
+
+        # Fixture the mocked retriever returns: 2 safetyist BDI nodes + 1 situation.
+        $script:MockNodes = @(
+            [PSCustomObject]@{ Id = 'saf-beliefs-001'; POV = 'safetyist'; Category = 'Beliefs';    Label = 'Irreversibility demands caution'; Description = 'Some harms cannot be undone.'; Score = 0.71 }
+            [PSCustomObject]@{ Id = 'saf-intentions-004'; POV = 'safetyist'; Category = 'Intentions'; Label = 'Mandate pre-deployment audits'; Description = 'Independent audits before release.'; Score = 0.66 }
+            [PSCustomObject]@{ Id = 'sit-012'; POV = 'situations'; Category = 'Situations'; Label = 'Undetected jailbreak at scale'; Description = 'A model bypasses filters post-release.'; Score = 0.58 }
+        )
     }
 
     Context 'Happy path — topic input' {
@@ -24,6 +31,8 @@ Describe 'New-OpEd' -Tag 'oped' {
                 $script:capturedPrompt = $Prompt
                 [PSCustomObject]@{ Text = $script:GoodJson; Backend = 'gemini' }
             } -ModuleName AITriad
+            # Mock retrieval so existing tests never touch the data repo / Python.
+            Mock Get-RelevantTaxonomyNodes { $script:MockNodes } -ModuleName AITriad
         }
 
         It 'Returns a populated structured object' {
@@ -83,10 +92,70 @@ Describe 'New-OpEd' -Tag 'oped' {
         }
     }
 
+    Context 'Taxonomy grounding' {
+        BeforeEach {
+            $script:capturedPrompt = $null
+            Mock Invoke-AIApi {
+                $script:capturedPrompt = $Prompt
+                [PSCustomObject]@{ Text = $script:GoodJson; Backend = 'gemini' }
+            } -ModuleName AITriad
+        }
+
+        It 'Surfaces the injected elements and their relevance scores on Grounding' {
+            Mock Get-RelevantTaxonomyNodes { $script:MockNodes } -ModuleName AITriad
+            $r = New-OpEd -Topic 'pre-deployment audits' -Pov safetyist
+            @($r.Grounding).Count | Should -Be 3
+            $bdi = @($r.Grounding | Where-Object Type -eq 'bdi')
+            $sit = @($r.Grounding | Where-Object Type -eq 'situation')
+            $bdi.Count | Should -Be 2
+            $sit.Count | Should -Be 1
+            ($r.Grounding | Where-Object Id -eq 'saf-beliefs-001').RelevanceScore | Should -Be 0.71
+            ($r.Grounding | Where-Object Id -eq 'sit-012').Category | Should -Be 'Situation'
+        }
+
+        It 'Injects the retrieved node text into the user prompt' {
+            Mock Get-RelevantTaxonomyNodes { $script:MockNodes } -ModuleName AITriad
+            New-OpEd -Topic 'audits' -Pov safetyist | Out-Null
+            $script:capturedPrompt | Should -Match 'Irreversibility demands caution'
+            $script:capturedPrompt | Should -Match 'Undetected jailbreak at scale'
+            $script:capturedPrompt | Should -Match 'REGISTERED POSITIONS'
+        }
+
+        It 'Filters retrieved nodes to the requested POV' {
+            # Retriever returns a mix; a foreign-POV node must not be injected.
+            Mock Get-RelevantTaxonomyNodes {
+                $script:MockNodes + [PSCustomObject]@{ Id = 'acc-beliefs-009'; POV = 'accelerationist'; Category = 'Beliefs'; Label = 'Permissionless innovation'; Description = 'x'; Score = 0.9 }
+            } -ModuleName AITriad
+            $r = New-OpEd -Topic 'audits' -Pov safetyist
+            @($r.Grounding | Where-Object Id -eq 'acc-beliefs-009').Count | Should -Be 0
+        }
+
+        It '-VoiceOnly skips retrieval and returns empty Grounding' {
+            Mock Get-RelevantTaxonomyNodes { $script:MockNodes } -ModuleName AITriad
+            $r = New-OpEd -Topic 'x' -Pov safetyist -VoiceOnly
+            @($r.Grounding).Count | Should -Be 0
+            Should -Invoke Get-RelevantTaxonomyNodes -ModuleName AITriad -Times 0
+        }
+
+        It 'Zeroed counts disable retrieval entirely' {
+            Mock Get-RelevantTaxonomyNodes { $script:MockNodes } -ModuleName AITriad
+            New-OpEd -Topic 'x' -Pov safetyist -MaxGroundingNodes 0 -MaxSituations 0 | Out-Null
+            Should -Invoke Get-RelevantTaxonomyNodes -ModuleName AITriad -Times 0
+        }
+
+        It 'Degrades to voice-only when retrieval fails' {
+            Mock Get-RelevantTaxonomyNodes { throw 'embeddings.json not found' } -ModuleName AITriad
+            $r = New-OpEd -Topic 'x' -Pov safetyist 3>$null
+            $r.Body | Should -Match 'First paragraph'
+            @($r.Grounding).Count | Should -Be 0
+        }
+    }
+
     Context 'URL input' {
         It 'Fetches and converts the URL into source material' {
             Mock Invoke-WebRequest { [PSCustomObject]@{ Content = '<html><body><p>Source body text.</p></body></html>' } } -ModuleName AITriad
             Mock ConvertFrom-Html { 'Source body text.' } -ModuleName AITriad
+            Mock Get-RelevantTaxonomyNodes { @() } -ModuleName AITriad
             $script:seenPrompt = $null
             Mock Invoke-AIApi {
                 $script:seenPrompt = $Prompt
@@ -101,15 +170,17 @@ Describe 'New-OpEd' -Tag 'oped' {
     }
 
     Context 'Degradation and errors' {
+        # These exercise response handling, not grounding — run voice-only so no
+        # retrieval subprocess is attempted.
         It 'Falls back to raw text when the response is not valid JSON' {
             Mock Invoke-AIApi { [PSCustomObject]@{ Text = 'Just some prose, not JSON.'; Backend = 'gemini' } } -ModuleName AITriad
-            $r = New-OpEd -Topic 'x' -Pov skeptic 3>$null
+            $r = New-OpEd -Topic 'x' -Pov skeptic -VoiceOnly 3>$null
             $r.Body | Should -Match 'Just some prose'
         }
 
         It 'Throws an actionable error when the backend returns nothing' {
             Mock Invoke-AIApi { [PSCustomObject]@{ Text = ''; Backend = 'gemini' } } -ModuleName AITriad
-            { New-OpEd -Topic 'x' -Pov skeptic } | Should -Throw
+            { New-OpEd -Topic 'x' -Pov skeptic -VoiceOnly } | Should -Throw
         }
 
         It 'Rejects an unknown POV at parameter binding' {


### PR DESCRIPTION
## Summary
Follow-up to #901. `New-OpEd` previously used only the camp's **Soul document** (voice) — the arguments were the model improvising within that voice. This grounds the **substance** in the project taxonomy.

It now retrieves the POV's most topic-relevant **BDI nodes** (its actual beliefs / desires / intentions) and **situation-library** stress cases via `Get-RelevantTaxonomyNodes` — the same embedding relevance the debate engine uses — and injects them as the positions the essay must argue from. The op-ed reflects **this project's registered camp**, not generic LLM priors.

## What's new
- **Grounded by default.** `-VoiceOnly` (or `-MaxGroundingNodes 0 -MaxSituations 0`) reverts to voice-only.
- New params: `-VoiceOnly`, `-MaxGroundingNodes` (0–40, default 12), `-MaxSituations` (0–15, default 3).
- **Output object gains `Grounding`** — an array of the injected elements `{ Id, Type (bdi|situation), POV, Category, Label, RelevanceScore }`, so the caller sees exactly which taxonomy elements shaped the essay and how relevant each was. `-OutputPath` Markdown gets a matching grounding-relevance table.
- Two new prompt sections (registered positions + stress-case situations) in `op-ed-generation-user.prompt`.

## Robustness
Retrieval is wrapped: if the data repo / `embeddings.json` / Python are unavailable, it **degrades to voice-only with a warning** rather than failing the generation (recovery-over-failure convention).

## Testing
- **+6 Pester tests** (18 total, `-Tag oped`, mocked retriever → keyless/data-free): grounding surfaced with scores, prompt injection, POV filtering, `-VoiceOnly`/zeroed-count skip, and failure degradation. **18/18 green.**
- **Live-verified end to end:** retrieved 8 real Safetyist BDI nodes (relevance 0.72–0.77) + 1 situation (0.69), injected them, and produced a 608-word grounded op-ed; `Grounding` populated correctly.

Example:
```powershell
$oped = New-OpEd -Topic 'Open-weight models and biosecurity' -Pov skeptic
$oped.Grounding | Format-Table Id, Type, Category, RelevanceScore
```

No manifest/export change (enhancement to an existing cmdlet, reusing existing public retrieval API — stays within the `/add-ps-cmdlet` pattern). Files are in the PowerShell role's scope; authored by the Computational Linguist as prompt/retrieval-quality work per the user's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)