### PR TITLE
feat(server): abort provider request on client disconnect (t/2510)

### DIFF
--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -13,6 +13,7 @@ export type EventType =
   | 'ai.retry'
   | 'ai.fallback'
   | 'ai.call_by_usage'
+  | 'ai.cancelled' // t/2510: request cancelled by client disconnect (info, not a failure)
   // Argument network
   | 'an.extract'
   | 'an.commit'

--- a/taxonomy-editor/src/server/__tests__/aiRetryProgress.test.ts
+++ b/taxonomy-editor/src/server/__tests__/aiRetryProgress.test.ts
@@ -94,6 +94,9 @@ function makeReq() {
     method: 'POST',
     headers: {},
     socket: { remoteAddress: '127.0.0.1' },
+    // http.IncomingMessage is an EventEmitter; the handler subscribes to 'close'
+    // to abort on client disconnect (t/2510). No-op mock — 'close' never fires here.
+    on: vi.fn(),
   };
 }
 

--- a/taxonomy-editor/src/server/__tests__/generateAbort.test.ts
+++ b/taxonomy-editor/src/server/__tests__/generateAbort.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+//
+// t/2510 — /api/ai/generate aborts the provider request on client disconnect.
+// Two things to prove without booting the HTTP server:
+//   1. The clean-arm guard: a 'close' after normal completion must NOT abort
+//      (shouldAbortOnClientClose), while a mid-flight disconnect must.
+//   2. The signal is actually honored end-to-end: a pre-aborted signal threaded
+//      through generateTextByUsage → generateText → withRetry rejects with
+//      AbortError BEFORE any provider fetch (no network, no retry ladder).
+
+import { describe, it, expect } from 'vitest';
+import { shouldAbortOnClientClose, isAbortError } from '../routes/ai.js';
+import * as ai from '../ai/aiBackends.js';
+
+describe('t/2510 — disconnect-abort clean/failure arms', () => {
+  it('aborts only on a mid-flight disconnect (failure arm), never after completion (clean arm)', () => {
+    // finished=false, responseEnded=false → client dropped mid-generate → abort
+    expect(shouldAbortOnClientClose(false, false)).toBe(true);
+    // finished=true → request already settled → no abort (clean arm)
+    expect(shouldAbortOnClientClose(true, false)).toBe(false);
+    // responseEnded=true → response already written → no abort (clean arm)
+    expect(shouldAbortOnClientClose(false, true)).toBe(false);
+    expect(shouldAbortOnClientClose(true, true)).toBe(false);
+  });
+});
+
+describe('t/2510 — the signal is honored through the server generate path', () => {
+  const preAborted = () => { const c = new AbortController(); c.abort(); return c.signal; };
+
+  it('generateText rejects with AbortError on a pre-aborted signal (no provider call)', async () => {
+    // explicit fake key skips key resolution; withRetry sees signal.aborted and throws
+    // AbortError before invoking callProvider — so no network happens.
+    await expect(
+      ai.generateText('prompt', undefined, undefined, undefined, ['fake-key'], { signal: preAborted() }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('generateTextByUsage forwards the signal (pre-aborted → AbortError)', async () => {
+    await expect(
+      ai.generateTextByUsage('server.chat-response', { prompt: 'hi' }, undefined, undefined, ['fake-key'], preAborted()),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+});
+
+describe('t/2510 — isAbortError distinguishes cancel from timeout and failure', () => {
+  it('true only for AbortError; a per-attempt TimeoutError and generic errors are NOT cancellations', () => {
+    expect(isAbortError(new DOMException('Aborted', 'AbortError'))).toBe(true);
+    const abortErr = new Error('x'); abortErr.name = 'AbortError';
+    expect(isAbortError(abortErr)).toBe(true);
+    // a timeout is a failure, not a user cancel — must keep the existing error mapping
+    expect(isAbortError(new DOMException('Timed out', 'TimeoutError'))).toBe(false);
+    expect(isAbortError(new Error('network down'))).toBe(false);
+    expect(isAbortError(undefined)).toBe(false);
+    expect(isAbortError('AbortError')).toBe(false); // a bare string is not an error object
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -331,7 +331,7 @@ function normalizeExplicitKeys(explicitApiKey: string | string[] | undefined): s
 // friendly id — fixedTemperature is resolved for currentModel on each attempt so
 // fallback models get their own value, not the primary's (t/2108).
 function buildGenerateOptions(
-  options: { temperature?: number } | undefined,
+  options: { temperature?: number; signal?: AbortSignal } | undefined,
   timeoutMs: number | undefined,
   currentModel: string,
   entryMap: Record<string, ModelEntry>,
@@ -341,6 +341,9 @@ function buildGenerateOptions(
     temperature: options?.temperature ?? _debateTemperature ?? 0.7,
     timeoutMs: timeoutMs ?? getDefaultTimeout(currentModel),
     ...(entry?.fixedTemperature != null ? { fixedTemperature: entry.fixedTemperature } : {}),
+    // t/2510: caller cancellation (client disconnect) → callProvider passes this into
+    // the provider fetch's init.signal (AbortSignal.any with the per-attempt timeout).
+    ...(options?.signal ? { signal: options.signal } : {}),
   };
 }
 
@@ -362,7 +365,7 @@ export async function generateText(
   onRetry?: (p: GenerateTextProgress) => void,
   timeoutMs?: number,
   explicitApiKey?: string | string[],
-  options?: { temperature?: number },
+  options?: { temperature?: number; signal?: AbortSignal },
 ): Promise<GenerateResult> {
   const resolved = model || DEFAULT_MODEL;
   const explicitKeys = normalizeExplicitKeys(explicitApiKey);
@@ -394,6 +397,9 @@ export async function generateText(
       SERVER_RETRY_CONFIG,
       `${backend}/${apiModel}`,
       (msg: string) => reportProviderRetry(msg, backend, apiModel, onRetry),
+      // t/2510: signal-aware backoff + pre-attempt abort check; an AbortError is
+      // rethrown non-retryable so a deliberate cancel never enters the retry ladder.
+      options?.signal,
     );
 
     try {
@@ -487,6 +493,7 @@ export async function generateTextByUsage(
   overrides?: Partial<UsageConfig>,
   onRetry?: (p: GenerateTextProgress) => void,
   explicitApiKey?: string | string[],
+  signal?: AbortSignal, // t/2510: caller cancellation (client disconnect) → provider fetch
 ): Promise<GenerateResult> {
   const repoRoot = getProjectRoot();
   const config = getUsage(usageId, repoRoot);
@@ -502,7 +509,7 @@ export async function generateTextByUsage(
     data: { usageId, model: merged.model, hasOverrides: !!overrides, valueKeys: Object.keys(values) },
   });
 
-  return generateText(prompt, merged.model, onRetry, merged.timeoutMs, explicitApiKey, { temperature: merged.temperature });
+  return generateText(prompt, merged.model, onRetry, merged.timeoutMs, explicitApiKey, { temperature: merged.temperature, signal });
 }
 
 /**

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -149,6 +149,22 @@ async function enforceKeyPresent(res: http.ServerResponse, backend: AIBackend, t
   return true;
 }
 
+/** True for a deliberate cancellation (client disconnect → AbortController.abort()).
+ *  The ai-client throws `DOMException('Aborted','AbortError')` and rethrows it
+ *  non-retryable (t/2507), so name-matching distinguishes cancel from a genuine
+ *  failure — and from a per-attempt timeout, which surfaces as `TimeoutError`. */
+export function isAbortError(err: unknown): boolean {
+  return !!err && typeof err === 'object' && (err as { name?: unknown }).name === 'AbortError';
+}
+
+/** Clean-arm guard for the `/api/ai/generate` disconnect abort (t/2510): abort ONLY
+ *  when the request hasn't finished AND the response isn't already written. A `'close'`
+ *  that fires after normal completion (response sent) must not false-abort. Exported
+ *  for unit testing the clean/failure arms without booting the HTTP server. */
+export function shouldAbortOnClientClose(finished: boolean, responseEnded: boolean): boolean {
+  return !finished && !responseEnded;
+}
+
 /** Generate via the standard chat-response usage; on a free-tier 429 with the whole
  *  free pool exhausted, retry ONCE with the admin-registered paid Gemini key after a
  *  deliberate 3s throttle (t/948). Re-throws the original error when there's no paid
@@ -157,11 +173,11 @@ async function generateWithPaidFallback(
   prompt: string,
   usageOverrides: Record<string, unknown>,
   explicitKey: string | string[] | undefined,
-  ctx: { isFree: boolean; backend: AIBackend; requestModel: string; t0: number; onRetry?: (p: GenerateTextProgress) => void },
+  ctx: { isFree: boolean; backend: AIBackend; requestModel: string; t0: number; onRetry?: (p: GenerateTextProgress) => void; signal?: AbortSignal },
 ): Promise<Awaited<ReturnType<typeof ai.generateText>>> {
-  const { isFree, backend, requestModel, t0, onRetry } = ctx;
+  const { isFree, backend, requestModel, t0, onRetry, signal } = ctx;
   try {
-    return await ai.generateTextByUsage('server.chat-response', { prompt }, usageOverrides, onRetry, explicitKey);
+    return await ai.generateTextByUsage('server.chat-response', { prompt }, usageOverrides, onRetry, explicitKey, signal);
   } catch (genErr) {
     const paidKey = (ai.is429Error(genErr) && isFree) ? await getPaidGeminiFallbackKey() : null;
     if (!paidKey) throw genErr; // non-free, non-429, or no paid key → outer 429 mapping records it
@@ -174,7 +190,7 @@ async function generateWithPaidFallback(
     // cooldown so the next request reverts to the free pool.
     await new Promise(r => setTimeout(r, 3000));
     try {
-      const result = await ai.generateTextByUsage('server.chat-response:paid-fallback', { prompt }, usageOverrides, onRetry, paidKey);
+      const result = await ai.generateTextByUsage('server.chat-response:paid-fallback', { prompt }, usageOverrides, onRetry, paidKey, signal);
       getGlobalRecorder()?.record({
         type: 'ai.response', component: 'ai-generate', level: 'info', duration_ms: Date.now() - t0,
         message: `Paid fallback succeeded for ${backend}/${requestModel}`,
@@ -322,6 +338,14 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
       const rc = getRequestContext();
       if (rc) rc.debateId = debateId.slice(0, 64);
     }
+    // t/2510: cancel the in-flight provider request when the client disconnects
+    // mid-generate. `finished` is the clean-arm — a 'close' that fires AFTER the
+    // response has been sent (normal completion) must NOT abort. abort() is
+    // idempotent, so a duplicate 'close' is harmless.
+    const t0 = Date.now();
+    const abort = new AbortController();
+    let finished = false;
+    req.on('close', () => { if (shouldAbortOnClientClose(finished, res.writableEnded)) abort.abort(); });
     try {
       // Free-tier cost is bounded by tokensPerDay + per-IP rate limits; the redundant
       // per-prompt char cap was removed in t/812 (broke long debate prompts).
@@ -346,7 +370,6 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
       // retry timeline is visible in the flight recorder (mirrors lib/debate
       // aiAdapter). Prompt content is never recorded — only its length.
       const requestModel = effectiveModel ?? DEFAULT_MODEL;
-      const t0 = Date.now();
       getGlobalRecorder()?.record({
         type: 'ai.request', component: 'ai-generate', level: 'info',
         message: `generate ${backend}/${requestModel}`,
@@ -364,6 +387,7 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
         const result = await generateWithPaidFallback(prompt, usageOverrides, explicitKey, {
           isFree, backend, requestModel, t0,
           onRetry: (p) => ctx.emitToUser(userId, 'generate-text-progress', p),
+          signal: abort.signal, // t/2510: client disconnect → abort the provider fetch
         });
 
         getGlobalRecorder()?.record({
@@ -378,6 +402,20 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
       }
     } catch (err) {
       const modelLabel = model ?? 'default';
+      // t/2510: client disconnected mid-generate → the provider fetch was aborted.
+      // Not a failure: log ai.cancelled at info (correlate via x-request-id), skip the
+      // failure mappings + 500, and write nothing (the socket is already gone). The
+      // retry attempt count lives in the ai-client ladder's ai.retry events (same
+      // requestId), so it is not re-surfaced here.
+      if (isAbortError(err)) {
+        getGlobalRecorder()?.record({
+          type: 'ai.cancelled', component: 'ai-generate', level: 'info',
+          duration_ms: Date.now() - t0,
+          message: `generate cancelled (client disconnect): ${modelLabel}`,
+          data: { model: modelLabel, requestId: String(req.headers['x-request-id'] ?? ''), reason: 'client_disconnect' },
+        });
+        return;
+      }
       if (respondIfContextTooLong(res, err, modelLabel)) return; // t/997 → context_too_long 400
       if (respondIfUpstream429(res, err, modelLabel)) return;    // t/920 → retryable 429
       // t/1362: also log at error level via Pino so the 500 is visible in
@@ -391,6 +429,8 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
         data: { model: modelLabel, promptLength: prompt?.length },
       });
       error(res, String(err), 500, err);
+    } finally {
+      finished = true; // clean-arm: any later 'close' (normal completion) won't abort
     }
   });
 


### PR DESCRIPTION
## Summary

Server slice of the AbortSignal-aware AI generation HLD (t/2506#1): when a client aborts its `/api/ai/generate` fetch mid-flight, the in-flight provider request + retry ladder are physically cancelled instead of burning the full timeout/retry budget (the t/2505 330s-burn class).

## Change

- **Route** (`routes/ai.ts`): per-request `AbortController`; `req.on('close')` aborts it, guarded by a **clean-arm** `shouldAbortOnClientClose(finished, res.writableEnded)` so a 'close' after normal completion never false-aborts. `abort()` is idempotent.
- **Threading** (`ai/aiBackends.ts`): `generateTextByUsage → generateText → buildGenerateOptions` (`opts.signal` → `callProvider` fetch) **and** `withRetry`'s signal arg (signal-aware backoff + AbortError-non-retryable) — mirrors `createAIClient`. No-signal calls are byte-identical.
- **Distinguishable cancel** (`isAbortError`): the catch logs `ai.cancelled` at **info** (elapsed + x-request-id) and returns — never a 500, never a failure. A per-attempt `TimeoutError` stays a failure.
- **`ai.cancelled` EventType** added to `lib/flight-recorder/types.ts` — trivial additive union widening, no runtime change (Shared Lib notified; self-managed per the <5-line cross-scope rule).

## Deviations from the HLD (flagged)

1. `generateText` opts threaded **signal only**, not `requestId` — the server correlates FR via the existing `x-request-id` request header, so a threaded `requestId` would be dead server-side.
2. `ai.cancelled` logs **elapsed**, not **attempt** — the retry attempt count lives inside the ai-client `withRetry` loop (its `ai.retry` events already record attempts under the same `requestId`); it is not surfaced at the route boundary.

## Test plan (gate arms)

`__tests__/generateAbort.test.ts`:
- [x] **clean/failure arm** — `shouldAbortOnClientClose`: abort only on mid-flight disconnect, never after completion
- [x] **signal honored** — pre-aborted signal rejects `generateText` + `generateTextByUsage` with AbortError **before any provider call** (no network, no retry)
- [x] **distinguishable** — `isAbortError` true for AbortError, false for TimeoutError / generic / non-object
- [x] no-signal AI-path suites byte-identical (freeTier, fallbackChain, paidGeminiFallback, aiRetryProgress — 35 tests green); tsc + eslint clean (pre-existing handler-complexity warning unchanged in count)

Design pre-approved (t/2506#1) — implemented directly, deviations flagged above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
