### PR TITLE
docs(agents): PR-flow practice rules — batch sequential PRs; merge promptly on green (q/40)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,11 @@ Confirm all four first:
 
 A squash-merge of a stale head ships the *old* content on the *old* commit's green — the fix you pushed never lands. Verify; don't assume the PR reflects your last push. The advisory `pre-self-merge-verify` Instant Feedback hook nudges this on every `gh pr merge`; this rule is the contract.
 
+### PR-Flow Practice Rules (approved q/40, 2026-08-12)
+
+- **Batch sequential same-feature work.** When one agent works sequentially on a feature and no other agent is blocked between steps, stage all steps on one branch and open a **single PR** — not a PR per step (the URL-context feature burned 6 CI cycles for one feature). Split anyway when the accumulated diff exceeds ~400 changed lines or mixes unrelated concerns; and revert to per-step PRs the moment a peer needs an intermediate step on `main`.
+- **Merge promptly on green.** Once CI is green on your current head, complete the pre-self-merge verification (above) and merge within ~15 minutes — or record the hold (pending decision, blocked dependency, review condition) as a PR/ticket comment so the delay is visible. A green PR sitting unmerged with no recorded hold is drift: it invites stale-head merges and landing races. (Deliberate holds are fine — record them; PR #879's multi-hour hold for a manual visual check was correct *because* it was recorded.)
+
 ### Subsystem Map
 
 Detailed conventions and build/test commands live in each subtree's `AGENTS.md` (loaded when you work in that scope). This is the orientation map only.


### PR DESCRIPTION
## Summary

Adds the two owner-approved (q/40) PR-flow practice rules to root AGENTS.md, under Pre-Self-Merge Verification:

- **Batch sequential same-feature work**: one branch, one PR when no peer is blocked between steps; split at ~400 changed lines or mixed concerns
- **Merge promptly on green**: ~15 min after green + pre-self-merge verification, or record the hold so the delay is visible

Origin: DevOps weekly workflow review (p/331#80), TL amendments, owner approval q/40.

Docs-only change — no code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)