### PR TITLE
feat(cmdlet): New-OpEd Grounding elements carry a Reflection (how/where each is used)

### DIFF
--- a/scripts/AITriad/Prompts/op-ed-generation-user.prompt
+++ b/scripts/AITriad/Prompts/op-ed-generation-user.prompt
@@ -20,10 +20,10 @@ AUTHOR (for the authority line / bio):
 SOURCE MATERIAL (use as factual grounding; quote or paraphrase from it where it strengthens a pillar — do not invent statistics it does not support):
 {{SOURCE_MATERIAL}}
 
-YOUR CAMP'S REGISTERED POSITIONS — these are this camp's actual belief / desire / intention nodes, retrieved as the most relevant to this topic (most relevant first). Argue FROM them: build the thesis and evidence pillars on these commitments and do NOT contradict them. They are the substance of your camp, not optional background:
+YOUR CAMP'S REGISTERED POSITIONS — these are this camp's actual belief / desire / intention nodes, retrieved as the most relevant to this topic (most relevant first). Each is prefixed with its [id]. Argue FROM them: build the thesis and evidence pillars on these commitments and do NOT contradict them. They are the substance of your camp, not optional background:
 {{GROUNDING_NODES}}
 
-CONCRETE STRESS-CASE SITUATIONS from your camp's situation library (most relevant first) — you may use one or two as the opening scene or as an evidence pillar, grounding an abstract position in a specific scenario:
+CONCRETE STRESS-CASE SITUATIONS from your camp's situation library (most relevant first), each prefixed with its [id] — you may use one or two as the opening scene or as an evidence pillar, grounding an abstract position in a specific scenario:
 {{SITUATIONS}}
 
 {{PITCH_INSTRUCTION}}

--- a/scripts/AITriad/Prompts/op-ed-grounding-reflection.prompt
+++ b/scripts/AITriad/Prompts/op-ed-grounding-reflection.prompt
@@ -1,0 +1,11 @@
+You are auditing how a finished op-ed used a set of source positions. Do not rewrite or judge the essay — only report, for each provided element, how and where it shows up in the text.
+
+THE FINISHED OP-ED:
+{{OPED_BODY}}
+
+THE ELEMENTS THAT WERE PROVIDED AS SOURCE MATERIAL (each with its [id] and a short label):
+{{GROUNDING_LIST}}
+
+For EACH element id above, judge against the actual essay text and write one sentence saying HOW and WHERE it is reflected — name the concrete structural place it most influenced (the lede, the thesis, the first / second / third evidence pillar, the "To Be Sure" counterargument, the solution/call-to-action, or the closing) and what it contributed. If an element is not actually reflected in the essay, set its reflection to exactly "not directly used". Be honest: only claim a placement that is really present in the text.
+
+Return ONLY a JSON object: { "grounding_usage": [ { "id": "<the [id]>", "reflection": "<one sentence>" }, ... ] } with exactly one entry per element id shown above. No commentary outside the JSON.

--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -27,8 +27,10 @@ function New-OpEd {
         relevance the debate engine uses (Get-RelevantTaxonomyNodes) and injected
         as the positions the essay must argue from — so the op-ed reflects THIS
         project's registered camp, not the model's generic priors. The elements
-        used and their relevance scores are returned on the Grounding field. Pass
-        -VoiceOnly (or set the counts to 0) to write from voice alone; if the
+        used and their relevance scores are returned on the Grounding field, each
+        annotated (via a second lightweight AI call that reads the finished essay)
+        with a Reflection explaining how and where it is reflected in the draft.
+        Pass -VoiceOnly (or set the counts to 0) to write from voice alone; if the
         taxonomy / embeddings / Python are unavailable, retrieval degrades to
         voice-only with a warning rather than failing.
 
@@ -90,8 +92,10 @@ function New-OpEd {
     .OUTPUTS
         [PSCustomObject] with Headline, Subtitle, Body, Pitch, WordCount, Pov,
         Outlet, Model, Backend, and Grounding — an array of the taxonomy elements
-        injected (Id, Type [bdi|situation], POV, Category, Label, RelevanceScore),
-        ordered as retrieved.
+        injected (Id, Type [bdi|situation], POV, Category, Label, RelevanceScore,
+        and Reflection — the model's one-sentence account of how and where that
+        element is reflected in the essay, or '(not reported)'), ordered as
+        retrieved.
     .EXAMPLE
         New-OpEd -Topic 'Mandatory pre-deployment audits for frontier AI models' `
             -Pov safetyist -Outlet WashingtonPost `
@@ -102,10 +106,10 @@ function New-OpEd {
         intention nodes and situations.
     .EXAMPLE
         $oped = New-OpEd -Topic 'Open-weight models and biosecurity' -Pov skeptic
-        $oped.Grounding | Format-Table Id, Type, Category, RelevanceScore
+        $oped.Grounding | Format-Table Id, Category, RelevanceScore, Reflection
 
-        Inspects which taxonomy nodes and situations grounded the essay and how
-        relevant each was.
+        Inspects which taxonomy nodes and situations grounded the essay, how
+        relevant each was, and how/where each is reflected in the draft.
     .EXAMPLE
         New-OpEd -Url 'https://example.com/ai-jobs-report' -Pov accelerationist `
             -Outlet WallStreetJournal -IncludePitch -OutputPath ./oped.md
@@ -303,10 +307,11 @@ function New-OpEd {
                 foreach ($n in $BdiNodes) {
                     $desc = [string]$n.Description
                     if ($desc.Length -gt 240) { $desc = $desc.Substring(0, 240) + '…' }
-                    [void]$sb.AppendLine("- [$($n.Category)] $($n.Label): $desc")
+                    # Prefix the node id so the model can reference it back in grounding_usage.
+                    [void]$sb.AppendLine("- [$($n.Id)] [$($n.Category)] $($n.Label): $desc")
                     $Grounding.Add([PSCustomObject]@{
                         Id = $n.Id; Type = 'bdi'; POV = $n.POV; Category = $n.Category
-                        Label = $n.Label; RelevanceScore = $n.Score
+                        Label = $n.Label; RelevanceScore = $n.Score; Reflection = ''
                     })
                 }
                 $GroundingNodesText = $sb.ToString().TrimEnd()
@@ -317,10 +322,10 @@ function New-OpEd {
                 foreach ($s in $SitNodes) {
                     $desc = [string]$s.Description
                     if ($desc.Length -gt 300) { $desc = $desc.Substring(0, 300) + '…' }
-                    [void]$sb2.AppendLine("- $($s.Label): $desc")
+                    [void]$sb2.AppendLine("- [$($s.Id)] $($s.Label): $desc")
                     $Grounding.Add([PSCustomObject]@{
                         Id = $s.Id; Type = 'situation'; POV = $s.POV; Category = 'Situation'
-                        Label = $s.Label; RelevanceScore = $s.Score
+                        Label = $s.Label; RelevanceScore = $s.Score; Reflection = ''
                     })
                 }
                 $SituationsText = $sb2.ToString().TrimEnd()
@@ -439,6 +444,60 @@ function New-OpEd {
         @($Body -split '\s+' | Where-Object { $_ -ne '' }).Count
     }
 
+    # ── Reflection pass: map each grounding element to how/where it's reflected ──
+    # A separate lightweight call that reads the FINISHED essay. Deliberately NOT
+    # folded into the main call: asking for the essay AND per-element usage in one
+    # JSON response makes the metadata contend with the body for the output token
+    # budget and truncates the essay (observed). Judging against the real text
+    # also yields truthful placements rather than mid-write predictions.
+    # Best-effort — any failure leaves Reflection as '(not reported)'.
+    if (@($Grounding).Count -gt 0 -and -not [string]::IsNullOrWhiteSpace($Body)) {
+        foreach ($g in $Grounding) { $g.Reflection = '(not reported)' }
+        try {
+            $glb = [System.Text.StringBuilder]::new()
+            foreach ($g in $Grounding) {
+                [void]$glb.AppendLine("- [$($g.Id)] ($($g.Type)/$($g.Category)) $($g.Label)")
+            }
+            $ReflPrompt = Get-Prompt -Name 'op-ed-grounding-reflection' -Replacements @{
+                OPED_BODY      = $Body
+                GROUNDING_LIST = $glb.ToString().TrimEnd()
+            }
+            $ReflSchema = @{
+                type       = 'object'
+                properties = @{
+                    grounding_usage = @{
+                        type  = 'array'
+                        items = @{
+                            type       = 'object'
+                            properties = @{ id = @{ type = 'string' }; reflection = @{ type = 'string' } }
+                            required   = @('id', 'reflection')
+                        }
+                    }
+                }
+                required   = @('grounding_usage')
+            }
+            $ReflMax = [Math]::Max(4000, (@($Grounding).Count * 150) + 3000)
+            $ReflResult = Invoke-AIApi -Prompt $ReflPrompt -Model $Model -Temperature 0.2 `
+                -MaxTokens $ReflMax -JsonMode -ResponseSchema $ReflSchema
+            if ($ReflResult -and -not [string]::IsNullOrWhiteSpace($ReflResult.Text)) {
+                $ReflParsed = $ReflResult.Text | ConvertFrom-Json
+                if ($ReflParsed.PSObject.Properties.Name -contains 'grounding_usage') {
+                    $UsageMap = @{}
+                    foreach ($u in @($ReflParsed.grounding_usage)) {
+                        if ($null -ne $u -and $u.PSObject.Properties.Name -contains 'id') {
+                            $UsageMap[[string]$u.id] = [string]$u.reflection
+                        }
+                    }
+                    foreach ($g in $Grounding) {
+                        if ($UsageMap.ContainsKey($g.Id)) { $g.Reflection = $UsageMap[$g.Id] }
+                    }
+                }
+            }
+        } catch {
+            Write-Warning "Grounding-reflection pass failed; Grounding.Reflection left as '(not reported)'. ($($_.Exception.Message))"
+        }
+    }
+
     $Output = [PSCustomObject]@{
         Headline  = $Headline
         Subtitle  = $Subtitle
@@ -470,12 +529,13 @@ function New-OpEd {
             [void]$md.AppendLine()
             [void]$md.AppendLine('---')
             [void]$md.AppendLine()
-            [void]$md.AppendLine('## Taxonomy grounding (relevance)')
+            [void]$md.AppendLine('## Taxonomy grounding (relevance + how it is reflected)')
             [void]$md.AppendLine()
-            [void]$md.AppendLine('| Element | Type | Category | Relevance |')
-            [void]$md.AppendLine('|---|---|---|---|')
+            [void]$md.AppendLine('| Element | Type | Category | Relevance | Reflected in the op-ed |')
+            [void]$md.AppendLine('|---|---|---|---|---|')
             foreach ($g in $Grounding) {
-                [void]$md.AppendLine("| $($g.Id) — $($g.Label) | $($g.Type) | $($g.Category) | $([Math]::Round([double]$g.RelevanceScore, 4)) |")
+                $refl = ([string]$g.Reflection) -replace '\|', '\|'
+                [void]$md.AppendLine("| $($g.Id) — $($g.Label) | $($g.Type) | $($g.Category) | $([Math]::Round([double]$g.RelevanceScore, 4)) | $refl |")
             }
         }
         $Utf8NoBom = [System.Text.UTF8Encoding]::new($false)

--- a/tests/New-OpEd.Tests.ps1
+++ b/tests/New-OpEd.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'New-OpEd' -Tag 'oped' {
     BeforeAll {
         Import-Module "$PSScriptRoot/../scripts/AITriad/AITriad.psm1" -Force
 
-        # Standard structured response the mocked backend returns.
+        # Essay call (has a SystemInstruction) returns this.
         $script:GoodJson = @{
             headline      = 'Stop Stalling on AI Safety'
             subtitle      = 'The cost of delay is measured in trust'
@@ -13,6 +13,29 @@ Describe 'New-OpEd' -Tag 'oped' {
             word_count    = 11
             pitch_email   = 'Subject: Op-Ed Submission: Stop Stalling on AI Safety'
         } | ConvertTo-Json
+
+        # Reflection call (no SystemInstruction) returns this. Deliberately reports
+        # 2 of the 3 mock ids (omits saf-intentions-004) to exercise the fallback.
+        $script:ReflJson = @{
+            grounding_usage = @(
+                @{ id = 'saf-beliefs-001'; reflection = 'Anchors the thesis in the second paragraph.' }
+                @{ id = 'sit-012'; reflection = 'Opens the lede as the concrete scene.' }
+            )
+        } | ConvertTo-Json -Depth 5
+
+        # Branching backend mock: the essay call carries a SystemInstruction, the
+        # reflection call does not. Captures only the essay prompt/system so the
+        # second call doesn't clobber assertions.
+        $script:MockAI = {
+            if ($SystemInstruction) {
+                $script:capturedSystem = $SystemInstruction
+                $script:capturedPrompt = $Prompt
+                [PSCustomObject]@{ Text = $script:GoodJson; Backend = 'gemini' }
+            } else {
+                $script:capturedReflPrompt = $Prompt
+                [PSCustomObject]@{ Text = $script:ReflJson; Backend = 'gemini' }
+            }
+        }
 
         # Fixture the mocked retriever returns: 2 safetyist BDI nodes + 1 situation.
         $script:MockNodes = @(
@@ -26,11 +49,7 @@ Describe 'New-OpEd' -Tag 'oped' {
         BeforeEach {
             $script:capturedSystem = $null
             $script:capturedPrompt = $null
-            Mock Invoke-AIApi {
-                $script:capturedSystem = $SystemInstruction
-                $script:capturedPrompt = $Prompt
-                [PSCustomObject]@{ Text = $script:GoodJson; Backend = 'gemini' }
-            } -ModuleName AITriad
+            Mock Invoke-AIApi -MockWith $script:MockAI -ModuleName AITriad
             # Mock retrieval so existing tests never touch the data repo / Python.
             Mock Get-RelevantTaxonomyNodes { $script:MockNodes } -ModuleName AITriad
         }
@@ -95,10 +114,8 @@ Describe 'New-OpEd' -Tag 'oped' {
     Context 'Taxonomy grounding' {
         BeforeEach {
             $script:capturedPrompt = $null
-            Mock Invoke-AIApi {
-                $script:capturedPrompt = $Prompt
-                [PSCustomObject]@{ Text = $script:GoodJson; Backend = 'gemini' }
-            } -ModuleName AITriad
+            $script:capturedReflPrompt = $null
+            Mock Invoke-AIApi -MockWith $script:MockAI -ModuleName AITriad
         }
 
         It 'Surfaces the injected elements and their relevance scores on Grounding' {
@@ -113,12 +130,23 @@ Describe 'New-OpEd' -Tag 'oped' {
             ($r.Grounding | Where-Object Id -eq 'sit-012').Category | Should -Be 'Situation'
         }
 
-        It 'Injects the retrieved node text into the user prompt' {
+        It 'Injects the retrieved node text (with ids) into the user prompt' {
             Mock Get-RelevantTaxonomyNodes { $script:MockNodes } -ModuleName AITriad
             New-OpEd -Topic 'audits' -Pov safetyist | Out-Null
             $script:capturedPrompt | Should -Match 'Irreversibility demands caution'
             $script:capturedPrompt | Should -Match 'Undetected jailbreak at scale'
             $script:capturedPrompt | Should -Match 'REGISTERED POSITIONS'
+            # The id is prefixed so the model can reference it in grounding_usage.
+            $script:capturedPrompt | Should -Match '\[saf-beliefs-001\]'
+        }
+
+        It 'Joins the model grounding_usage back onto each element as Reflection' {
+            Mock Get-RelevantTaxonomyNodes { $script:MockNodes } -ModuleName AITriad
+            $r = New-OpEd -Topic 'audits' -Pov safetyist
+            ($r.Grounding | Where-Object Id -eq 'saf-beliefs-001').Reflection | Should -Match 'thesis'
+            ($r.Grounding | Where-Object Id -eq 'sit-012').Reflection        | Should -Match 'lede'
+            # saf-intentions-004 was not in grounding_usage → explicit fallback.
+            ($r.Grounding | Where-Object Id -eq 'saf-intentions-004').Reflection | Should -Be '(not reported)'
         }
 
         It 'Filters retrieved nodes to the requested POV' {


### PR DESCRIPTION
## Summary
Follow-up to #905. Each element in `New-OpEd`'s `Grounding` array now carries a **`Reflection`** — a one-sentence account of **how and where** that belief / desire / intention / situation is reflected in the essay (which structural place — lede, a specific evidence pillar, the "To Be Sure", the solution, the close — and what it contributed), or `(not reported)`.

## Design: a separate reflection pass (not folded into generation)
Reflections are computed by a **second, lightweight AI call that reads the finished essay** — deliberately *not* added to the generation call's JSON output. Asking for the essay *and* per-element usage in one response makes the metadata contend with the body for the output-token budget and **truncates the essay** (observed live: the one-call form hit `max_tokens`, fell back to raw text, and left every reflection empty). Reading the real text also yields **truthful placements** instead of mid-write predictions.

- Injected grounding lines are prefixed with their `[id]`; the pass returns `{ id, reflection }` per id, joined back onto each `Grounding` element.
- **Best-effort:** essay/retrieval unaffected if the reflection call fails (`Reflection` stays `(not reported)`); skipped entirely when `-VoiceOnly` or no grounding. New prompt file `op-ed-grounding-reflection.prompt`.
- `-OutputPath` Markdown grounding table gains a **"Reflected in the op-ed"** column.

## Testing
- **19/19 Pester** (`-Tag oped`) with a **two-call branching mock** (the essay call carries a `SystemInstruction`, the reflection call doesn't): asserts id-prefixed injection, the reflection join, and the not-reported fallback.
- **Live-verified:** clean 617-word draft; all 7 grounding elements mapped to specific structural placements, e.g. an intentions node → *"directly shapes the solution and call-to-action…"*, a situation → *"anchors the third evidence pillar…"*.

Trade-off: one extra (cheap, `temperature 0.2`) AI call per grounded generation — documented in the help. Files are in the PowerShell role's scope; authored by the Computational Linguist as prompt/retrieval-quality work per the user's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)