### PR TITLE
fix(server): AbortError skips the generateText fallback chain (t/2524)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/generateAbortNoFallback.test.ts
+++ b/taxonomy-editor/src/server/__tests__/generateAbortNoFallback.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+//
+// t/2524 — a deliberate cancellation (AbortError) must not advance generateText's
+// fallback chain, which would emit a spurious warn-level `ai.fallback` per remaining
+// chain entry on every user cancel. Captures the flight-recorder events and asserts
+// none is `ai.fallback` when a multi-entry chain is aborted.
+
+import { describe, it, expect, vi } from 'vitest';
+
+const rec = vi.hoisted(() => ({ events: [] as Array<{ type: string; message?: string }> }));
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: (e: { type: string; message?: string }) => { rec.events.push(e); } }),
+}));
+
+// Provide a key for every backend so generateText reaches the retry layer (and thus
+// the AbortError path) rather than the no-key skip branch. Keep all other config exports.
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return { ...actual, getApiKeys: vi.fn(async () => ['test-key']) };
+});
+
+import * as ai from '../ai/aiBackends.js';
+import { buildModelsToTry } from '../ai/aiBackends.js';
+
+describe('t/2524 — AbortError short-circuits the fallback chain', () => {
+  it('a pre-aborted generateText rejects AbortError and emits NO ai.fallback events', async () => {
+    rec.events = [];
+    const model = 'gemini-flash-lite-latest';
+    // Non-vacuous guard: this model expands to a multi-entry chain, so WITHOUT the
+    // fix the catch would emit an ai.fallback for each remaining entry.
+    expect(buildModelsToTry(model, false).length).toBeGreaterThan(1);
+
+    const c = new AbortController();
+    c.abort();
+    await expect(
+      ai.generateText('prompt', model, undefined, undefined, undefined, { signal: c.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    // The per-chain-entry "failed after retries — falling back" warn is the spurious
+    // event this fix suppresses. (Unrelated ai.fallback INFO events — e.g. the
+    // "Auto-generated fallback chain" note during chain construction — are fine.)
+    const fallbackWarns = rec.events.filter(
+      e => e.type === 'ai.fallback' && /failed after retries/.test(e.message ?? ''),
+    );
+    expect(fallbackWarns).toHaveLength(0);
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -414,6 +414,11 @@ export async function generateText(
       }
       return { text: result.text, tokenUsage: mapUsage(result.usage) };
     } catch (err) {
+      // t/2524: a deliberate cancellation (client disconnect) must NOT advance the
+      // fallback chain — otherwise every remaining chain entry emits a spurious
+      // warn-level ai.fallback on user cancel. Rethrow AbortError immediately (same
+      // name-check as t/2507; DOMException-compatible).
+      if ((err as { name?: unknown } | null)?.name === 'AbortError') throw err;
       lastError = err;
       if (mi < modelsToTry.length - 1) {
         const nextModel = modelsToTry[mi + 1];


### PR DESCRIPTION
## Summary

Fixes t/2524 (Shared Lib-diagnosed; fix is in ServerAPI-scope `aiBackends.ts`). `generateText`'s per-model `catch` advanced the fallback chain on **any** error — including a deliberate cancellation. On client disconnect that emitted a spurious warn-level `ai.fallback` (`'<model> failed after retries — falling back'`) for every remaining chain entry (residual telemetry noise from the t/2510/t/2522 disconnect-abort work).

**Fix (one line, top of catch):** rethrow `AbortError` immediately, before advancing the chain — same DOMException-compatible name-check as t/2507. A deliberate cancel exits at once, no fallback churn.

## Test plan

`generateAbortNoFallback.test.ts` — drives `generateText` with a multi-entry chain (precondition-asserted **non-vacuous**) + a pre-aborted signal; asserts it rejects `AbortError` with **zero** `'failed after retries'` `ai.fallback` warns. (Unrelated chain-construction `ai.fallback` **info** events are correctly not matched.)

**Both arms verified:** reverting the one-line fix makes the test fail. 26 AI-path tests green; tsc + eslint clean.

Diagnosed + requested by Shared Lib (t/2524); they close the ticket once this is on main. No deviations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
