### PR TITLE
fix(security): remove hardcoded Neo4j password fallback (t/2530 M2)

### DIFF
--- a/scripts/AITriad/Public/Export-TaxonomyToGraph.ps1
+++ b/scripts/AITriad/Public/Export-TaxonomyToGraph.ps1
@@ -70,8 +70,14 @@ function Export-TaxonomyToGraph {
     if ($Credential) {
         $Pair = "$($Credential.UserName):$($Credential.GetNetworkCredential().Password)"
     } else {
-        if ($env:NEO4J_PASSWORD) { $Neo4jPwd = $env:NEO4J_PASSWORD } else { $Neo4jPwd = 'aitriad2026' }
-        $Pair = "neo4j:$Neo4jPwd"
+        if (-not $env:NEO4J_PASSWORD) {
+            throw (New-ActionableError `
+                -Goal 'Connect to Neo4j' `
+                -Problem 'NEO4J_PASSWORD environment variable is not set and no -Credential was provided' `
+                -Location 'Export-TaxonomyToGraph' `
+                -NextSteps 'Set $env:NEO4J_PASSWORD or pass -Credential (Get-Credential) with the Neo4j password.')
+        }
+        $Pair = "neo4j:$($env:NEO4J_PASSWORD)"
     }
     $Bytes = [System.Text.Encoding]::ASCII.GetBytes($Pair)
     $AuthHeader['Authorization'] = "Basic $([Convert]::ToBase64String($Bytes))"

--- a/scripts/AITriad/Public/Install-GraphDatabase.ps1
+++ b/scripts/AITriad/Public/Install-GraphDatabase.ps1
@@ -16,7 +16,8 @@ function Install-GraphDatabase {
     .PARAMETER Force
         Remove and recreate the container even if it already exists.
     .PARAMETER Password
-        Neo4j password. Falls back to NEO4J_PASSWORD env var, then 'aitriad2026'.
+        Neo4j password. Falls back to NEO4J_PASSWORD env var. If neither is provided,
+        a random password is generated and printed once — copy it to $env:NEO4J_PASSWORD.
     .PARAMETER DataPath
         Path for persistent database storage. Default: ~/ai-triad-graphdb.
     .EXAMPLE
@@ -44,13 +45,27 @@ function Install-GraphDatabase {
     param(
         [switch]$Force,
 
-        [string]$Password = $(if ($env:NEO4J_PASSWORD) { $env:NEO4J_PASSWORD } else { 'aitriad2026' }),
+        [string]$Password = '',
 
         [string]$DataPath = (Join-Path $HOME 'ai-triad-graphdb')
     )
 
     Set-StrictMode -Version Latest
     $ErrorActionPreference = 'Stop'
+
+    # Resolve password: explicit param > env var > generate once
+    if ([string]::IsNullOrWhiteSpace($Password)) {
+        if ($env:NEO4J_PASSWORD) {
+            $Password = $env:NEO4J_PASSWORD
+        } else {
+            $Password = [Convert]::ToBase64String([Security.Cryptography.RandomNumberGenerator]::GetBytes(18))
+            Write-Host ''
+            Write-Host '  Neo4j password generated (not persisted):' -ForegroundColor Yellow
+            Write-Host "  $Password" -ForegroundColor Cyan
+            Write-Host '  Set $env:NEO4J_PASSWORD = ''<above>'' to reuse it.' -ForegroundColor Yellow
+            Write-Host ''
+        }
+    }
 
     $ContainerName = 'ai-triad-neo4j'
 

--- a/scripts/AITriad/Public/Invoke-CypherQuery.ps1
+++ b/scripts/AITriad/Public/Invoke-CypherQuery.ps1
@@ -63,8 +63,14 @@ function Invoke-CypherQuery {
     if ($Credential) {
         $Pair = "$($Credential.UserName):$($Credential.GetNetworkCredential().Password)"
     } else {
-        if ($env:NEO4J_PASSWORD) { $Neo4jPwd = $env:NEO4J_PASSWORD } else { $Neo4jPwd = 'aitriad2026' }
-        $Pair = "neo4j:$Neo4jPwd"
+        if (-not $env:NEO4J_PASSWORD) {
+            throw (New-ActionableError `
+                -Goal 'Run Cypher query' `
+                -Problem 'NEO4J_PASSWORD environment variable is not set and no -Credential was provided' `
+                -Location 'Invoke-CypherQuery' `
+                -NextSteps 'Set $env:NEO4J_PASSWORD or pass -Credential (Get-Credential) with the Neo4j password.')
+        }
+        $Pair = "neo4j:$($env:NEO4J_PASSWORD)"
     }
     $Bytes = [System.Text.Encoding]::ASCII.GetBytes($Pair)
     $AuthHeader = @{ Authorization = "Basic $([Convert]::ToBase64String($Bytes))" }

--- a/tests/Neo4j-PasswordHardening.Tests.ps1
+++ b/tests/Neo4j-PasswordHardening.Tests.ps1
@@ -1,0 +1,79 @@
+# Tag: security (t/2530 M2)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Regression tests for t/2530 M2 — removal of hardcoded Neo4j 'aitriad2026' password fallback.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Neo4j password hardening (t/2530 M2)' -Tag 'security' {
+
+    It 'Invoke-CypherQuery throws when NEO4J_PASSWORD is unset and no -Credential provided' {
+        $prev = $env:NEO4J_PASSWORD
+        $env:NEO4J_PASSWORD = $null
+        try {
+            { Invoke-CypherQuery -Query 'MATCH (n) RETURN n LIMIT 1' } | Should -Throw
+        } finally {
+            $env:NEO4J_PASSWORD = $prev
+        }
+    }
+
+    It 'Invoke-CypherQuery error message is actionable (Goal/Problem/Location)' {
+        $prev = $env:NEO4J_PASSWORD
+        $env:NEO4J_PASSWORD = $null
+        try {
+            $err = $null
+            try { Invoke-CypherQuery -Query 'MATCH (n) RETURN n LIMIT 1' } catch { $err = $_ }
+            $err | Should -Not -BeNullOrEmpty
+            "$err" | Should -Match 'NEO4J_PASSWORD'
+        } finally {
+            $env:NEO4J_PASSWORD = $prev
+        }
+    }
+
+    It 'Export-TaxonomyToGraph throws when NEO4J_PASSWORD is unset and no -Credential provided' {
+        $prev = $env:NEO4J_PASSWORD
+        $env:NEO4J_PASSWORD = $null
+        try {
+            { Export-TaxonomyToGraph } | Should -Throw
+        } finally {
+            $env:NEO4J_PASSWORD = $prev
+        }
+    }
+
+    It 'Export-TaxonomyToGraph error message is actionable (Goal/Problem/Location)' {
+        $prev = $env:NEO4J_PASSWORD
+        $env:NEO4J_PASSWORD = $null
+        try {
+            $err = $null
+            try { Export-TaxonomyToGraph } catch { $err = $_ }
+            $err | Should -Not -BeNullOrEmpty
+            "$err" | Should -Match 'NEO4J_PASSWORD'
+        } finally {
+            $env:NEO4J_PASSWORD = $prev
+        }
+    }
+
+    It 'Install-GraphDatabase source contains no hardcoded aitriad2026 password' {
+        $src = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'Public' 'Install-GraphDatabase.ps1') -Raw
+        $src | Should -Not -Match 'aitriad2026'
+    }
+
+    It 'Export-TaxonomyToGraph source contains no hardcoded aitriad2026 password' {
+        $src = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'Public' 'Export-TaxonomyToGraph.ps1') -Raw
+        $src | Should -Not -Match 'aitriad2026'
+    }
+
+    It 'Invoke-CypherQuery source contains no hardcoded aitriad2026 password' {
+        $src = Get-Content (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'Public' 'Invoke-CypherQuery.ps1') -Raw
+        $src | Should -Not -Match 'aitriad2026'
+    }
+}


### PR DESCRIPTION
## Summary
- Removes hardcoded `'aitriad2026'` Neo4j password fallback from all three affected files (t/2530 M2)
- `Invoke-CypherQuery` / `Export-TaxonomyToGraph`: throw `New-ActionableError` when `NEO4J_PASSWORD` is unset and no `-Credential` provided — no silent fallback
- `Install-GraphDatabase`: resolves password from `-Password` param → `NEO4J_PASSWORD` env var → CSPRNG-generated random (printed once, never persisted); updates `.PARAMETER` doc

## Test plan
- [x] 7 regression tests: throw-on-missing-credential for both query cmdlets, actionable error contains guidance, source-level absence of `aitriad2026` literal in all three files — all pass
- [ ] Full `Invoke-Pester ./tests/` suite — CI green before merge

## Risk
Low — the hardcoded fallback was only reached when both `-Credential` and `NEO4J_PASSWORD` were absent. Users relying on the implicit default need to set `$env:NEO4J_PASSWORD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
