### PR TITLE
fix(sec): Gemini API key moved from ?key= URL to x-goog-api-key header (t/2535)

### DIFF
--- a/lib/ai-client/providers/gemini-embeddings.test.ts
+++ b/lib/ai-client/providers/gemini-embeddings.test.ts
@@ -82,14 +82,16 @@ describe('callGeminiBatchEmbed', () => {
       .rejects.toThrow('400');
   });
 
-  it('constructs correct URL with API key and model', async () => {
+  it('constructs correct URL and sends key in x-goog-api-key header (t/2535)', async () => {
     const fetchFn = mockFetch(200, { embeddings: [{ values: [1] }] });
 
     await callGeminiBatchEmbed(fetchFn, ['test'], 'RETRIEVAL_QUERY', 'my-api-key', FAST_RETRY);
 
     const url = fetchFn.mock.calls[0][0] as string;
+    const init = fetchFn.mock.calls[0][1] as RequestInit;
     expect(url).toContain('gemini-embedding-001:batchEmbedContents');
-    expect(url).toContain('key=my-api-key');
+    expect(url).not.toContain('key=');
+    expect((init.headers as Record<string, string>)['x-goog-api-key']).toBe('my-api-key');
   });
 
   it('sends correct request body with taskType and model', async () => {

--- a/lib/ai-client/providers/gemini-embeddings.ts
+++ b/lib/ai-client/providers/gemini-embeddings.ts
@@ -16,7 +16,7 @@ export async function callGeminiBatchEmbed(
   retryConfig: RetryConfig = SERVER_RETRY_CONFIG,
   timeoutMs: number = DEFAULT_EMBED_TIMEOUT_MS,
 ): Promise<number[][]> {
-  const url = `${GEMINI_BASE}/${GEMINI_EMBED_MODEL}:batchEmbedContents?key=${apiKey}`;
+  const url = `${GEMINI_BASE}/${GEMINI_EMBED_MODEL}:batchEmbedContents`;
   const requests = texts.map(text => ({
     model: `models/${GEMINI_EMBED_MODEL}`,
     content: { parts: [{ text }] },
@@ -26,7 +26,7 @@ export async function callGeminiBatchEmbed(
   return withRetry(async () => {
     const response = await fetchFn(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
       body: JSON.stringify({ requests }),
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/lib/ai-client/providers/gemini-search.ts
+++ b/lib/ai-client/providers/gemini-search.ts
@@ -31,11 +31,11 @@ export async function geminiGroundedSearch(
   apiModelId: string,
   apiKey: string,
 ): Promise<GroundedSearchResult> {
-  const url = `${GEMINI_BASE}/${apiModelId}:generateContent?key=${apiKey}`;
+  const url = `${GEMINI_BASE}/${apiModelId}:generateContent`;
 
   const response = await fetchFn(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
     body: JSON.stringify({
       contents: [{ parts: [{ text: prompt }] }],
       tools: [{ google_search: {} }],

--- a/lib/ai-client/providers/gemini.ts
+++ b/lib/ai-client/providers/gemini.ts
@@ -80,7 +80,7 @@ export async function generateViaGemini(
   apiKey: string,
   opts: GenerateOptions,
 ): Promise<ProviderResult> {
-  const url = `${GEMINI_BASE}/${apiModelId}:generateContent?key=${apiKey}`;
+  const url = `${GEMINI_BASE}/${apiModelId}:generateContent`;
   const timeoutMs = opts.timeoutMs!;
 
   const genConfig: Record<string, unknown> = {
@@ -107,7 +107,7 @@ export async function generateViaGemini(
 
   const response = await fetchFn(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
     body: JSON.stringify(body),
     signal: makeFetchSignal(timeoutMs, opts.signal),
   });
@@ -178,7 +178,7 @@ export async function generateViaGeminiStream(
   opts: GenerateOptions,
   onChunk?: (text: string) => void,
 ): Promise<ProviderResult> {
-  const url = `${GEMINI_BASE}/${apiModelId}:streamGenerateContent?alt=sse&key=${apiKey}`;
+  const url = `${GEMINI_BASE}/${apiModelId}:streamGenerateContent?alt=sse`;
   const timeoutMs = opts.timeoutMs!;
 
   const genConfig: Record<string, unknown> = {
@@ -200,7 +200,7 @@ export async function generateViaGeminiStream(
 
   const response = await fetchFn(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
     body: JSON.stringify(body),
     signal: makeFetchSignal(timeoutMs, opts.signal),
   });

--- a/lib/debate/aiAdapter.test.ts
+++ b/lib/debate/aiAdapter.test.ts
@@ -475,8 +475,9 @@ describe('aiAdapter', () => {
       const adapter = mod.createCLIAdapter('/fake/root');
       await adapter.generateText('test', 'gemini-2.5-flash');
 
-      const fetchUrl = mockFetch.mock.calls[0][0] as string;
-      expect(fetchUrl).toContain('key=gemini-specific-key');
+      const fetchOpts = mockFetch.mock.calls[0][1] as RequestInit;
+      expect(mockFetch.mock.calls[0][0] as string).toContain('generateContent');
+      expect((fetchOpts.headers as Record<string, string>)['x-goog-api-key']).toBe('gemini-specific-key');
     });
 
     it('uses ANTHROPIC_API_KEY for claude backend', async () => {
@@ -544,8 +545,8 @@ describe('aiAdapter', () => {
       const adapter = mod.createCLIAdapter('/fake/root');
       await adapter.generateText('test', 'gemini-2.5-flash');
 
-      const fetchUrl = mockFetch.mock.calls[0][0] as string;
-      expect(fetchUrl).toContain('key=universal-key');
+      const fetchOpts = mockFetch.mock.calls[0][1] as RequestInit;
+      expect((fetchOpts.headers as Record<string, string>)['x-goog-api-key']).toBe('universal-key');
     });
 
     it('throws ActionableError when no API key is available', async () => {
@@ -564,8 +565,8 @@ describe('aiAdapter', () => {
       const adapter = mod.createCLIAdapter('/fake/root', 'explicit-key');
       await adapter.generateText('test', 'gemini-2.5-flash');
 
-      const fetchUrl = mockFetch.mock.calls[0][0] as string;
-      expect(fetchUrl).toContain('key=explicit-key');
+      const fetchOpts = mockFetch.mock.calls[0][1] as RequestInit;
+      expect((fetchOpts.headers as Record<string, string>)['x-goog-api-key']).toBe('explicit-key');
     });
   });
 

--- a/lib/electron-shared/modelDiscovery.ts
+++ b/lib/electron-shared/modelDiscovery.ts
@@ -124,8 +124,8 @@ export function curateGeminiModels(rawModels: GeminiModelInfo[]): ModelEntry[] {
 }
 
 export async function discoverGeminiModels(apiKey: string): Promise<ModelEntry[]> {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}&pageSize=100`;
-  const resp = await fetch(url);
+  const url = `https://generativelanguage.googleapis.com/v1beta/models?pageSize=100`;
+  const resp = await fetch(url, { headers: { 'x-goog-api-key': apiKey } });
   if (!resp.ok) {
     const body = await resp.text();
     throw new ActionableError({


### PR DESCRIPTION
## Summary

- Moves Gemini API key from `?key=` query parameter to `x-goog-api-key` request header across all 4 call sites
- Prevents key leakage via proxy access logs, error telemetry, and browser network inspector
- Sites: `gemini.ts` (generateContent + streamGenerateContent), `gemini-search.ts`, `gemini-embeddings.ts`, `modelDiscovery.ts` (discoverGeminiModels)

## Test plan

- [x] Updated `gemini-embeddings.test.ts` assertion: now checks header presence + URL absence of `key=` instead of URL presence
- [x] 52/52 Gemini provider + modelDiscovery tests pass
- [x] Self-cert /trivial-change: 5 files, mechanical pattern fix, no new interface, all in lib/ scope

Part of t/2525 security epic (TS half; PS half is t/2530).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)