### PR TITLE
sec(ci): harden workflows — image_tag injection, permissions blocks, pinned actions, lint gate (t/2529)

### DIFF
--- a/.github/ci/workflow-lint.py
+++ b/.github/ci/workflow-lint.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Workflow lint gate — enforces three conventions across all workflow YAML files.
+
+Checks:
+  1. All action `uses:` refs must be SHA-pinned (40-hex commit SHA), not tag/branch refs.
+  2. `${{ inputs.* }}` must not appear directly in shell run blocks — use env-var indirection.
+  3. Every workflow file must declare a `permissions:` block (workflow-level or job-level).
+
+Exit 0 = all checks pass. Exit 1 = violations found (details printed to stdout).
+Mechanically catches the M14/M15/L8 failure classes (t/2529).
+"""
+import re
+import sys
+import glob
+
+SHA_RE = re.compile(r'^[0-9a-f]{40}$')
+# matches: uses: owner/action@REF  (excludes local ./ paths)
+USES_RE = re.compile(r'^\s+uses:\s+([^./]\S+)@(\S+)')
+# Only flag bare ${{ inputs.VARNAME }} — raw value reaches the shell (injection risk).
+# Safe: ${{ inputs.X == 'val' && '1' || '' }} — expression produces a bounded value;
+# GitHub Actions evaluates the expression before the shell runs, never exposing the raw input.
+INPUTS_RE = re.compile(r'\$\{\{\s*inputs\.\w+\s*\}\}')
+YAML_KEY_RE = re.compile(r'^\s+\w[\w-]*:\s')
+PERMISSIONS_RE = re.compile(r'^\s*permissions:', re.MULTILINE)
+
+errors = []
+
+workflows = sorted(glob.glob('.github/workflows/*.yml'))
+if not workflows:
+    print('workflow-lint: no workflows found in .github/workflows/')
+    sys.exit(1)
+
+for path in workflows:
+    with open(path, encoding='utf-8') as f:
+        content = f.read()
+    lines = content.splitlines()
+
+    # ── Check 1: unpinned actions ──────────────────────────────────────────────
+    for i, line in enumerate(lines, 1):
+        m = USES_RE.match(line)
+        if m:
+            # Strip inline comment (e.g. `abc123  # v4` → `abc123`)
+            ref = m.group(2).split('#')[0].strip()
+            if not SHA_RE.match(ref):
+                errors.append(
+                    f'{path}:{i}: unpinned action ref @{ref!r} — pin to 40-char hex SHA'
+                )
+
+    # ── Check 2: ${{ inputs.* }} in shell run blocks ───────────────────────────
+    # Walk lines tracking whether we are inside a `run:` value context.
+    # State: in_run=False until we see a `run:` YAML key; then True until a sibling
+    # key at the same or shallower indent ends the block.
+    in_run = False
+    run_indent = 0
+    for i, line in enumerate(lines, 1):
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        if YAML_KEY_RE.match(line):
+            key = stripped.split(':')[0]
+            if key == 'run':
+                in_run = True
+                run_indent = indent
+                # Inline run: value on the same line
+                rest = stripped[len('run:'):].strip()
+                if rest and rest not in ('|', '|-', '>'):
+                    if INPUTS_RE.search(rest):
+                        errors.append(
+                            f'{path}:{i}: direct ${{{{ inputs.* }}}} in inline run: — '
+                            f'use env: block for shell indirection'
+                        )
+                # Block scalar (| or |-): content checked on subsequent lines
+            elif in_run and indent <= run_indent:
+                # New YAML key at same/shallower indent — run block ended
+                in_run = False
+        elif in_run:
+            if stripped and indent > run_indent:
+                # Block scalar content line
+                if INPUTS_RE.search(line):
+                    errors.append(
+                        f'{path}:{i}: direct ${{{{ inputs.* }}}} in run block content — '
+                        f'use env: block for shell indirection'
+                    )
+            elif stripped and indent <= run_indent:
+                in_run = False
+
+    # ── Check 3: missing permissions block ────────────────────────────────────
+    if not PERMISSIONS_RE.search(content):
+        errors.append(f'{path}: no permissions: block — add explicit minimal permissions')
+
+print(f'=== workflow-lint: {len(workflows)} workflows checked ===')
+for e in errors:
+    print(f'FAIL: {e}')
+
+if errors:
+    print(f'\n::error::workflow-lint: {len(errors)} violation(s) — see output above')
+    sys.exit(1)
+
+print('OK — 0 violations')

--- a/.github/ci/workflow-lint.py
+++ b/.github/ci/workflow-lint.py
@@ -3,10 +3,14 @@
 
 Checks:
   1. All action `uses:` refs must be SHA-pinned (40-hex commit SHA), not tag/branch refs.
-  2. `${{ inputs.* }}` must not appear directly in shell run blocks — use env-var indirection.
+     Matches BOTH plain key form ('        uses: a/b@ref') AND compact list-item form
+     ('      - uses: a/b@ref').  The original USES_RE missed the compact form (t/2529 GV fail).
+  2. `${{ inputs.VARNAME }}` must not appear directly in shell run blocks — use env-var indirection.
+     Bare refs only; conditional expressions (${{ inputs.X == 'val' && ... }}) are safe.
   3. Every workflow file must declare a `permissions:` block (workflow-level or job-level).
 
-Exit 0 = all checks pass. Exit 1 = violations found (details printed to stdout).
+Run with --self-test to execute the built-in fixture tests (both syntax forms must be caught).
+Exit 0 = all checks pass. Exit 1 = violations found or self-test failed.
 Mechanically catches the M14/M15/L8 failure classes (t/2529).
 """
 import re
@@ -14,17 +18,212 @@ import sys
 import glob
 
 SHA_RE = re.compile(r'^[0-9a-f]{40}$')
-# matches: uses: owner/action@REF  (excludes local ./ paths)
-USES_RE = re.compile(r'^\s+uses:\s+([^./]\S+)@(\S+)')
+
+# Matches both forms:
+#   plain key:       '        uses: owner/action@REF'
+#   compact step:    '      - uses: owner/action@REF'
+# Excludes local workflow calls (./path) which don't need SHA pins.
+USES_RE = re.compile(r'^\s*(?:-\s+)?uses:\s+([^./]\S+)@(\S+)')
+
 # Only flag bare ${{ inputs.VARNAME }} — raw value reaches the shell (injection risk).
 # Safe: ${{ inputs.X == 'val' && '1' || '' }} — expression produces a bounded value;
 # GitHub Actions evaluates the expression before the shell runs, never exposing the raw input.
 INPUTS_RE = re.compile(r'\$\{\{\s*inputs\.\w+\s*\}\}')
-YAML_KEY_RE = re.compile(r'^\s+\w[\w-]*:\s')
+
 PERMISSIONS_RE = re.compile(r'^\s*permissions:', re.MULTILINE)
 
-errors = []
 
+def parse_step_key(line):
+    """Return (key_name, line_indent) for a YAML key line, handling compact list-item form.
+
+    Examples:
+      '        run: |'       → ('run', 8)
+      '      - run: cmd'     → ('run', 6)   # indent = position of dash
+      '        uses: a/b@c'  → ('uses', 8)
+      '      - uses: a/b@c'  → ('uses', 6)
+    Returns (None, indent) when the line is not a YAML key line.
+    """
+    s = line.lstrip()
+    indent = len(line) - len(s)
+    if s.startswith('- '):
+        s = s[2:].lstrip()
+    if ':' not in s:
+        return None, indent
+    key = s.split(':')[0].strip()
+    if re.match(r'^\w[\w-]*$', key):
+        return key, indent
+    return None, indent
+
+
+def lint_file(path, content):
+    """Return list of violation strings for one workflow file."""
+    errs = []
+    lines = content.splitlines()
+
+    # ── Check 1: unpinned actions ──────────────────────────────────────────────
+    for i, line in enumerate(lines, 1):
+        m = USES_RE.match(line)
+        if m:
+            ref = m.group(2).split('#')[0].strip()
+            if not SHA_RE.match(ref):
+                errs.append(f'{path}:{i}: unpinned action ref @{ref!r} — pin to 40-char hex SHA')
+
+    # ── Check 2: bare ${{ inputs.* }} in shell run blocks ─────────────────────
+    # Walk lines tracking whether we're inside a `run:` value context.
+    in_run = False
+    run_indent = 0
+    for i, line in enumerate(lines, 1):
+        key, indent = parse_step_key(line)
+
+        if key is not None:
+            if key == 'run':
+                in_run = True
+                run_indent = indent
+                # Check inline run: value (same line, not a block scalar marker)
+                s = line.lstrip()
+                if s.startswith('- '):
+                    s = s[2:].lstrip()
+                rest = s[len('run:'):].strip()
+                if rest and rest not in ('|', '|-', '>'):
+                    if INPUTS_RE.search(rest):
+                        errs.append(
+                            f'{path}:{i}: direct ${{{{ inputs.* }}}} in inline run: — '
+                            f'use env: block for shell indirection'
+                        )
+            elif in_run and indent <= run_indent:
+                in_run = False
+        elif in_run:
+            stripped = line.lstrip()
+            if stripped and len(line) - len(stripped) > run_indent:
+                if INPUTS_RE.search(line):
+                    errs.append(
+                        f'{path}:{i}: direct ${{{{ inputs.* }}}} in run block content — '
+                        f'use env: block for shell indirection'
+                    )
+            elif stripped and len(line) - len(stripped) <= run_indent:
+                in_run = False
+
+    # ── Check 3: missing permissions block ────────────────────────────────────
+    if not PERMISSIONS_RE.search(content):
+        errs.append(f'{path}: no permissions: block — add explicit minimal permissions')
+
+    return errs
+
+
+def self_test():
+    """Verify that both uses: syntax forms and run: forms are correctly detected."""
+    print('=== workflow-lint self-test ===')
+    failures = []
+
+    # Fixture 1: compact list-item `- uses:` form must be caught by Check 1
+    fixture_compact_uses = """\
+permissions:
+  contents: read
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+"""
+    errs = lint_file('fixture_compact_uses', fixture_compact_uses)
+    if not any('unpinned action ref' in e for e in errs):
+        failures.append('Check 1 MISSED compact "- uses: action@v4" form')
+    else:
+        print('  PASS: Check 1 catches compact "- uses: action@v4"')
+
+    # Fixture 2: plain key `uses:` form must also be caught
+    fixture_plain_uses = """\
+permissions:
+  contents: read
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: step
+        uses: actions/checkout@v4
+"""
+    errs = lint_file('fixture_plain_uses', fixture_plain_uses)
+    if not any('unpinned action ref' in e for e in errs):
+        failures.append('Check 1 MISSED plain "  uses: action@v4" form')
+    else:
+        print('  PASS: Check 1 catches plain "  uses: action@v4"')
+
+    # Fixture 3: SHA-pinned ref must NOT be flagged
+    fixture_pinned = """\
+permissions:
+  contents: read
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+"""
+    errs = lint_file('fixture_pinned', fixture_pinned)
+    if any('unpinned' in e for e in errs):
+        failures.append('Check 1 incorrectly flagged a properly SHA-pinned action')
+    else:
+        print('  PASS: Check 1 ignores properly pinned action')
+
+    # Fixture 4: bare ${{ inputs.X }} in run block must be caught
+    fixture_inputs_run = """\
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        type: string
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: pull
+        run: docker pull "${{ inputs.image }}"
+"""
+    errs = lint_file('fixture_inputs_run', fixture_inputs_run)
+    if not any('inputs' in e for e in errs):
+        failures.append('Check 2 MISSED bare ${{ inputs.image }} in inline run:')
+    else:
+        print('  PASS: Check 2 catches bare ${{ inputs.image }} in inline run:')
+
+    # Fixture 5: conditional expression ${{ inputs.X == ... }} must NOT be flagged
+    fixture_inputs_expr = """\
+permissions:
+  contents: read
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        type: choice
+        options: [a, b]
+jobs:
+  job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - run: echo "mode=${{ inputs.mode == 'a' && '1' || '' }}"
+"""
+    errs = lint_file('fixture_inputs_expr', fixture_inputs_expr)
+    if any('inputs' in e for e in errs):
+        failures.append('Check 2 incorrectly flagged a conditional expression')
+    else:
+        print('  PASS: Check 2 ignores conditional ${{ inputs.X == ... }} expressions')
+
+    if failures:
+        for f in failures:
+            print(f'  FAIL: {f}')
+        print(f'\nSelf-test FAILED: {len(failures)} assertion(s)')
+        sys.exit(1)
+
+    print('Self-test PASSED — all assertions OK\n')
+
+
+# ── Entry point ────────────────────────────────────────────────────────────────
+if '--self-test' in sys.argv:
+    self_test()
+
+errors = []
 workflows = sorted(glob.glob('.github/workflows/*.yml'))
 if not workflows:
     print('workflow-lint: no workflows found in .github/workflows/')
@@ -33,60 +232,7 @@ if not workflows:
 for path in workflows:
     with open(path, encoding='utf-8') as f:
         content = f.read()
-    lines = content.splitlines()
-
-    # ── Check 1: unpinned actions ──────────────────────────────────────────────
-    for i, line in enumerate(lines, 1):
-        m = USES_RE.match(line)
-        if m:
-            # Strip inline comment (e.g. `abc123  # v4` → `abc123`)
-            ref = m.group(2).split('#')[0].strip()
-            if not SHA_RE.match(ref):
-                errors.append(
-                    f'{path}:{i}: unpinned action ref @{ref!r} — pin to 40-char hex SHA'
-                )
-
-    # ── Check 2: ${{ inputs.* }} in shell run blocks ───────────────────────────
-    # Walk lines tracking whether we are inside a `run:` value context.
-    # State: in_run=False until we see a `run:` YAML key; then True until a sibling
-    # key at the same or shallower indent ends the block.
-    in_run = False
-    run_indent = 0
-    for i, line in enumerate(lines, 1):
-        stripped = line.lstrip()
-        indent = len(line) - len(stripped)
-
-        if YAML_KEY_RE.match(line):
-            key = stripped.split(':')[0]
-            if key == 'run':
-                in_run = True
-                run_indent = indent
-                # Inline run: value on the same line
-                rest = stripped[len('run:'):].strip()
-                if rest and rest not in ('|', '|-', '>'):
-                    if INPUTS_RE.search(rest):
-                        errors.append(
-                            f'{path}:{i}: direct ${{{{ inputs.* }}}} in inline run: — '
-                            f'use env: block for shell indirection'
-                        )
-                # Block scalar (| or |-): content checked on subsequent lines
-            elif in_run and indent <= run_indent:
-                # New YAML key at same/shallower indent — run block ended
-                in_run = False
-        elif in_run:
-            if stripped and indent > run_indent:
-                # Block scalar content line
-                if INPUTS_RE.search(line):
-                    errors.append(
-                        f'{path}:{i}: direct ${{{{ inputs.* }}}} in run block content — '
-                        f'use env: block for shell indirection'
-                    )
-            elif stripped and indent <= run_indent:
-                in_run = False
-
-    # ── Check 3: missing permissions block ────────────────────────────────────
-    if not PERMISSIONS_RE.search(content):
-        errors.append(f'{path}: no permissions: block — add explicit minimal permissions')
+    errors.extend(lint_file(path, content))
 
 print(f'=== workflow-lint: {len(workflows)} workflows checked ===')
 for e in errors:

--- a/.github/workflows/batch-summarize.yml
+++ b/.github/workflows/batch-summarize.yml
@@ -14,6 +14,9 @@ on:
     paths:
       - 'TAXONOMY_VERSION'
 
+permissions:
+  contents: write
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -910,6 +910,19 @@ jobs:
           ALLOWED_ORIGINS: ''
         run: pnpm exec vitest run src/server/
 
+  # ── workflow-lint: enforce SHA-pinned actions, env-var indirection, permissions ──
+  # Mechanically catches the M14/M15/L8 failure classes (t/2529). Always runs —
+  # no path filter, since any workflow edit can introduce a violation.
+  # skip = N/A (no filter); failure = gate blocks. (t/2529)
+  workflow-lint:
+    needs: [changes]
+    if: always() && !cancelled() && needs.changes.result != 'failure' && needs.changes.result != 'cancelled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+      - name: Lint workflow YAML files
+        run: python3 .github/ci/workflow-lint.py
+
   # ── ci-gate: the SINGLE required status context (t/1962) ──────────────────
   # Replaces the 6 individual code-check contexts in branch protection. Those get
   # SKIPPED by path-filtering on non-electron PRs (docs-only, PS-only); a skipped
@@ -935,9 +948,11 @@ jobs:
   # path-filtered to electron changes, skip = OK.
   # test-server-prod-config (t/2377) is gated here: NODE_ENV=production server
   # startup health check + test suite; path-filtered to container changes, skip = OK.
+  # workflow-lint (t/2529) is gated here: SHA-pinned actions, env-var indirection,
+  # permissions block required; always runs, no path filter.
   ci-gate:
     name: ci-gate
-    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config]
+    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config, workflow-lint]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
         run: ln -s "$GITHUB_WORKSPACE/ai-triad-data" ../ai-triad-data
         continue-on-error: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 
@@ -292,7 +292,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 
@@ -365,7 +365,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 
@@ -426,7 +426,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 
@@ -487,7 +487,7 @@ jobs:
       - name: Check doc links (main-repo presence)
         run: bash .github/scripts/check-doc-links.sh
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 
@@ -531,7 +531,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
         continue-on-error: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         continue-on-error: true
         with:
           version: '11.20.0'
@@ -584,7 +584,7 @@ jobs:
         run: ln -s "$GITHUB_WORKSPACE/ai-triad-data" ../ai-triad-data
         continue-on-error: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         continue-on-error: true
         with:
           version: '11.20.0'
@@ -860,7 +860,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -236,8 +236,10 @@ jobs:
 
       - name: Determine push mode
         id: push_mode
+        env:
+          INPUTS_PUSH: ${{ inputs.push }}
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.push }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" && "$INPUTS_PUSH" == "true" ]]; then
             echo "push=true" >> $GITHUB_OUTPUT
             echo "load=false" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -74,6 +74,13 @@ jobs:
           INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           if [ -n "$INPUT_IMAGE_TAG" ]; then
+            # M14: allowlist image_tag before writing to GITHUB_OUTPUT.
+            # Rejects shell metacharacters, $() subexpressions, newlines, etc.
+            # Static error message — never echo the raw input (newline = command injection).
+            if [[ ! "$INPUT_IMAGE_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+              echo "::error::image_tag is invalid — must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+              exit 1
+            fi
             echo "tag=$INPUT_IMAGE_TAG" >> $GITHUB_OUTPUT
           else
             TAG="${GITHUB_REF_NAME#v}"
@@ -154,6 +161,11 @@ jobs:
           INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           if [ -n "$INPUT_IMAGE_TAG" ]; then
+            # M14: allowlist image_tag before writing to GITHUB_OUTPUT (same guard as preflight).
+            if [[ ! "$INPUT_IMAGE_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+              echo "::error::image_tag is invalid — must match ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+              exit 1
+            fi
             echo "tag=$INPUT_IMAGE_TAG" >> $GITHUB_OUTPUT
           else
             # Use the git tag name if triggered from a tag context, else 'latest'

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -86,7 +86,7 @@ jobs:
         run: ln -s "$GITHUB_WORKSPACE/ai-triad-data" ../ai-triad-data
         continue-on-error: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 
@@ -175,7 +175,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 
@@ -217,7 +217,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
         with:
           version: '11.20.0'
 

--- a/.github/workflows/smoke-image.yml
+++ b/.github/workflows/smoke-image.yml
@@ -26,17 +26,19 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull image
-        run: docker pull "${{ inputs.image }}"
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: docker pull "$IMAGE"
 
       - name: Smoke /healthz
         env:

--- a/.github/workflows/taxonomy-version-reminder.yml
+++ b/.github/workflows/taxonomy-version-reminder.yml
@@ -12,6 +12,10 @@ on:
     paths:
       - 'taxonomy/Origin/**'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
## Summary

- **M14**: Validate `image_tag` dispatch input in both `resolve_tag` steps of `deploy-azure.yml` before writing to `$GITHUB_OUTPUT`. Static error message (no raw tag echo — newline injection in error path). Fires in preflight before OIDC exchange.
- **M15**: Add explicit minimal `permissions:` blocks to `taxonomy-version-reminder.yml` (`contents:read`, `pull-requests:write`) and `batch-summarize.yml` (`contents:write`).
- **L8**: SHA-pin `actions/checkout@v7` → `3d3c42e5` (v7 SHA) and `docker/login-action@v4` → `dbcb8138` in `smoke-image.yml`; env-var indirection for `inputs.image` in Pull image step.
- **Bonus from lint pass**: Pin `dependabot/fetch-metadata@v3` → `25dd0e34`; env-var indirection for `inputs.push` in `container.yml` — both surfaced by the zero-noise baseline run.
- **Hardening #3**: New `.github/ci/workflow-lint.py` — enforces SHA-pinned actions, env-var indirection for bare `${{ inputs.* }}` in run blocks, permissions block presence. Wired into `ci.yml` as `workflow-lint` job in `ci-gate` needs. Zero-noise confirmed locally across all 22 workflows.

> **Note on checkout SHA mislabel**: The fleet labels `3d3c42e5...` as `# v6` but it is the v7 commit (v6 = `d23441a4...`). `smoke-image.yml` is correctly labeled `# v7`. Pre-existing mislabel in other workflows tracked separately.

## Gate Verification (TL required — both arms)

Per t/2529#2, TL must post run links for red arm (injected unpinned action → lint FAIL) and green arm (clean pass) on the ticket before this merges.

## Test plan

- [ ] CI green on this PR (workflow-lint job passes — green arm)
- [ ] TL posts red-arm run link on t/2529 (deliberate unpinned action → lint FAIL)
- [ ] TL posts green-arm run link on t/2529 (clean state passes with 0 noise)
- [ ] Self-merge after both arms recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)