### PR TITLE
fix(security): Register-AIBackend localhost server auth — bearer token, loopback binding, key masking (t/2527)

### DIFF
--- a/scripts/AITriad/Public/Register-AIBackend.ps1
+++ b/scripts/AITriad/Public/Register-AIBackend.ps1
@@ -110,20 +110,23 @@ function Register-AIBackend {
         return $Key.Substring(0, 4) + ('*' * ($Key.Length - 8)) + $Key.Substring($Key.Length - 4)
     }
 
+    # Masked-only — unmasked keys never leave the server process (t/2527)
     $InitialState = @{
-        gemini_key    = $Persisted['GEMINI_API_KEY']
-        anthropic_key = $Persisted['ANTHROPIC_API_KEY']
-        groq_key      = $Persisted['GROQ_API_KEY']
-        openai_key    = $Persisted['OPENAI_API_KEY']
-        ollama_url    = $Persisted['OLLAMA_BASE_URL']
-        zai_key       = $Persisted['ZAI_API_KEY']
-        ai_model      = $Persisted['AI_MODEL']
+        ollama_url       = $Persisted['OLLAMA_BASE_URL']
+        ai_model         = $Persisted['AI_MODEL']
         gemini_masked    = Get-MaskedKey $Persisted['GEMINI_API_KEY']
         anthropic_masked = Get-MaskedKey $Persisted['ANTHROPIC_API_KEY']
         groq_masked      = Get-MaskedKey $Persisted['GROQ_API_KEY']
         openai_masked    = Get-MaskedKey $Persisted['OPENAI_API_KEY']
         zai_masked       = Get-MaskedKey $Persisted['ZAI_API_KEY']
     } | ConvertTo-Json
+
+    # Per-run CSPRNG bearer token — injected into the browser URL, required on every endpoint (t/2527).
+    # The ?token= query param lands in browser history; this is an accepted risk for an ephemeral
+    # localhost server (same pattern as Jupyter). Token is never persisted.
+    $Token          = [Convert]::ToBase64String([Security.Cryptography.RandomNumberGenerator]::GetBytes(24))
+    $ExpectedHost   = "127.0.0.1:$Port"
+    $ExpectedOrigin = "http://127.0.0.1:$Port"
 
     # ── HTML ──────────────────────────────────────────────────────────────────
     $Html = @"
@@ -375,6 +378,7 @@ function Register-AIBackend {
 <script>
 const state = $InitialState;
 const models = $ModelsJson;
+const TOKEN = '$Token';
 
 // Populate fields
 function init() {
@@ -422,7 +426,7 @@ function toggleReveal(inputId, btn) {
     if (inp.dataset.dirty === 'false') {
       const backendMap = { 'gemini-key': 'gemini', 'anthropic-key': 'anthropic', 'groq-key': 'groq', 'openai-key': 'openai' };
       const backend = backendMap[inputId];
-      fetch('/api/reveal?backend=' + backend)
+      fetch('/api/reveal?backend=' + backend, { headers: { 'Authorization': 'Bearer ' + TOKEN } })
         .then(r => r.json())
         .then(d => {
           if (d.key) { inp.value = d.key; inp.dataset.dirty = 'false'; }
@@ -453,7 +457,7 @@ function testKey(backend) {
   setStatus(backend, 'pending', 'Testing...');
   fetch('/api/test', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + TOKEN },
     body: JSON.stringify({ backend, key })
   })
   .then(r => r.json())
@@ -487,7 +491,7 @@ function save() {
 
   fetch('/api/save', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + TOKEN },
     body: JSON.stringify(data)
   })
   .then(r => r.json())
@@ -516,8 +520,10 @@ init();
 "@
 
     # ── HTTP Server ───────────────────────────────────────────────────────────
+    # Bound to 127.0.0.1 only — never '+', '*', or 'localhost' (which can bind
+    # dual-stack or be remapped via the hosts file). t/2527 loopback-only binding.
     $Listener = [System.Net.HttpListener]::new()
-    $Prefix   = "http://localhost:$Port/"
+    $Prefix   = "http://127.0.0.1:$Port/"
     $Listener.Prefixes.Add($Prefix)
 
     try {
@@ -533,11 +539,51 @@ init();
     Write-OK "Configuration UI running at $Prefix"
     Write-Info 'Press Ctrl+C to close when done.'
 
-    # Open browser
+    # Open browser with one-time token in URL (token-in-URL is an accepted risk for
+    # ephemeral localhost servers — same pattern as Jupyter Notebook; t/2527).
+    $BrowserUrl = "http://127.0.0.1:$Port/?token=$Token"
     if (-not $NoBrowser) {
-        if ($IsMacOS)     { Start-Process 'open' -ArgumentList $Prefix }
-        elseif ($IsLinux) { Start-Process 'xdg-open' -ArgumentList $Prefix -ErrorAction SilentlyContinue }
-        else              { Start-Process $Prefix }
+        if ($IsMacOS)     { Start-Process 'open' -ArgumentList $BrowserUrl }
+        elseif ($IsLinux) { Start-Process 'xdg-open' -ArgumentList $BrowserUrl -ErrorAction SilentlyContinue }
+        else              { Start-Process $BrowserUrl }
+    }
+
+    # ── Auth helpers (t/2527) ─────────────────────────────────────────────────
+    function Test-OriginAndHost {
+        param($Req)
+        $H = $Req.Headers['Host']
+        if ($H -ne $ExpectedHost) { return 'forbidden' }
+        $O = $Req.Headers['Origin']
+        if ($O -and $O -ne $ExpectedOrigin) { return 'forbidden' }
+        return 'ok'
+    }
+
+    function Test-BearerToken {
+        param($Req)
+        $Auth = $Req.Headers['Authorization']
+        if (-not $Auth -or -not $Auth.StartsWith('Bearer ')) { return $false }
+        $Submitted = $Auth.Substring(7)
+        $T = [System.Text.Encoding]::UTF8.GetBytes($Token)
+        $S = [System.Text.Encoding]::UTF8.GetBytes($Submitted)
+        return [System.Security.Cryptography.CryptographicOperations]::FixedTimeEquals($T, $S)
+    }
+
+    function Send-Unauthorized {
+        param($Resp)
+        $Resp.StatusCode = 401
+        $B = [System.Text.Encoding]::UTF8.GetBytes('{"error":"Unauthorized"}')
+        $Resp.ContentType = 'application/json'
+        $Resp.ContentLength64 = $B.Length
+        $Resp.OutputStream.Write($B, 0, $B.Length)
+    }
+
+    function Send-Forbidden {
+        param($Resp)
+        $Resp.StatusCode = 403
+        $B = [System.Text.Encoding]::UTF8.GetBytes('{"error":"Forbidden"}')
+        $Resp.ContentType = 'application/json'
+        $Resp.ContentLength64 = $B.Length
+        $Resp.OutputStream.Write($B, 0, $B.Length)
     }
 
     $ServerRunning = $true
@@ -562,6 +608,17 @@ init();
                 switch ("$Method $Path") {
 
                     'GET /' {
+                        # Validate ?token= (browser nav — no Bearer header available on initial load)
+                        $QToken = ''
+                        $Q = $Request.Url.Query
+                        if ($Q -match '[?&]token=([^&]+)') { $QToken = [Uri]::UnescapeDataString($Matches[1]) }
+                        $TBytes  = [System.Text.Encoding]::UTF8.GetBytes($Token)
+                        $QTBytes = [System.Text.Encoding]::UTF8.GetBytes($QToken)
+                        if (-not [System.Security.Cryptography.CryptographicOperations]::FixedTimeEquals($TBytes, $QTBytes)) {
+                            Send-Unauthorized $Response; break
+                        }
+                        $ReqHost = $Request.Headers['Host']
+                        if ($ReqHost -ne $ExpectedHost) { Send-Forbidden $Response; break }
                         $Buffer = [System.Text.Encoding]::UTF8.GetBytes($Html)
                         $Response.ContentType = 'text/html; charset=utf-8'
                         $Response.ContentLength64 = $Buffer.Length
@@ -569,6 +626,8 @@ init();
                     }
 
                     'GET /api/reveal' {
+                        if ((Test-OriginAndHost $Request) -eq 'forbidden') { Send-Forbidden $Response; break }
+                        if (-not (Test-BearerToken $Request)) { Send-Unauthorized $Response; break }
                         $Query   = $Request.Url.Query
                         if ($Query -match 'backend=(\w+)') { $Backend = $Matches[1] } else { $Backend = '' }
                         $KeyMap  = @{ gemini = 'GEMINI_API_KEY'; anthropic = 'ANTHROPIC_API_KEY'; groq = 'GROQ_API_KEY'; openai = 'OPENAI_API_KEY'; ollama = 'OLLAMA_BASE_URL'; zai = 'ZAI_API_KEY' }
@@ -584,6 +643,8 @@ init();
                     }
 
                     'POST /api/test' {
+                        if ((Test-OriginAndHost $Request) -eq 'forbidden') { Send-Forbidden $Response; break }
+                        if (-not (Test-BearerToken $Request)) { Send-Unauthorized $Response; break }
                         $Reader = [System.IO.StreamReader]::new($Request.InputStream)
                         $Body   = $Reader.ReadToEnd() | ConvertFrom-Json
                         $Reader.Close()
@@ -694,6 +755,8 @@ init();
                     }
 
                     'POST /api/save' {
+                        if ((Test-OriginAndHost $Request) -eq 'forbidden') { Send-Forbidden $Response; break }
+                        if (-not (Test-BearerToken $Request)) { Send-Unauthorized $Response; break }
                         $Reader = [System.IO.StreamReader]::new($Request.InputStream)
                         $Body   = $Reader.ReadToEnd() | ConvertFrom-Json
                         $Reader.Close()

--- a/tests/Register-AIBackend.Auth.Tests.ps1
+++ b/tests/Register-AIBackend.Auth.Tests.ps1
@@ -123,8 +123,10 @@ Describe 'Register-AIBackend auth hardening (t/2527)' -Tag 'security' {
         $status | Should -Be 403
     }
 
-    It 'GET /api/reveal with spoofed Host header returns 403 (DNS-rebinding block)' {
-        # Use .NET HttpClient to set the Host header — Invoke-WebRequest restricts it
+    It 'GET /api/reveal with spoofed Host header is rejected (DNS-rebinding block)' {
+        # Use .NET HttpClient to set the Host header — Invoke-WebRequest restricts it.
+        # On Linux, HttpListener rejects a Host-mismatch before the handler runs (404);
+        # on Windows our handler fires and returns 403. Both prove the request was blocked.
         $status = $null
         try {
             $handler = [System.Net.Http.HttpClientHandler]::new()
@@ -141,6 +143,6 @@ Describe 'Register-AIBackend auth hardening (t/2527)' -Tag 'security' {
         } catch {
             # connection refused or other transport error — server not ready
         }
-        $status | Should -Be 403
+        $status | Should -BeIn @(403, 404)
     }
 }

--- a/tests/Register-AIBackend.Auth.Tests.ps1
+++ b/tests/Register-AIBackend.Auth.Tests.ps1
@@ -1,0 +1,146 @@
+# Tag: security (t/2527)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Regression tests for t/2527 — Register-AIBackend localhost HTTP server auth hardening.
+    Source-level assertions + live-server integration tests.
+#>
+
+BeforeAll {
+    $ModulePath  = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    $SourcePath  = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'Public' 'Register-AIBackend.ps1'
+    $script:Src  = Get-Content $SourcePath -Raw
+
+    # Start server on an ephemeral test port with no browser
+    $script:TestPort = 19943
+    $script:Job = Start-Job -ScriptBlock {
+        param($ModPath, $Port)
+        Import-Module $ModPath -Force -WarningAction SilentlyContinue
+        Register-AIBackend -NoBrowser -Port $Port
+    } -ArgumentList $ModulePath, $script:TestPort
+
+    # Wait up to 4 s for the listener to accept connections (expect 401 on unauth GET /)
+    $script:ServerReady = $false
+    for ($i = 0; $i -lt 40; $i++) {
+        Start-Sleep -Milliseconds 100
+        try {
+            $null = Invoke-WebRequest -Uri "http://127.0.0.1:$($script:TestPort)/" -UseBasicParsing -ErrorAction Stop
+        } catch {
+            if ($_.Exception.Response) { $script:ServerReady = $true; break }
+        }
+    }
+}
+
+AfterAll {
+    if ($script:Job) {
+        Stop-Job  $script:Job -ErrorAction SilentlyContinue
+        Remove-Job $script:Job -ErrorAction SilentlyContinue
+    }
+}
+
+Describe 'Register-AIBackend auth hardening (t/2527)' -Tag 'security' {
+
+    # ── Source-level assertions ────────────────────────────────────────────────
+
+    It 'HttpListener $Prefix binds to 127.0.0.1 only (not localhost or wildcard)' {
+        # Check the specific $Prefix assignment used for Prefixes.Add — not doc/Ollama references
+        $script:Src | Should -Match '\$Prefix\s*=\s*"http://127\.0\.0\.1:'
+        $script:Src | Should -Not -Match '\$Prefix\s*=\s*"http://localhost:'
+        $script:Src | Should -Not -Match '\$Prefix\s*=\s*"http://\+:'
+        $script:Src | Should -Not -Match '\$Prefix\s*=\s*"http://\*:'
+    }
+
+    It 'Uses FixedTimeEquals for constant-time token comparison' {
+        $script:Src | Should -Match 'FixedTimeEquals'
+    }
+
+    It 'InitialState contains no unmasked API key fields' {
+        # Unmasked keys must not appear as hashtable entries in $InitialState
+        $script:Src | Should -Not -Match "gemini_key\s*=\s*\`$Persisted"
+        $script:Src | Should -Not -Match "anthropic_key\s*=\s*\`$Persisted"
+        $script:Src | Should -Not -Match "groq_key\s*=\s*\`$Persisted"
+        $script:Src | Should -Not -Match "openai_key\s*=\s*\`$Persisted"
+        $script:Src | Should -Not -Match "zai_key\s*=\s*\`$Persisted"
+    }
+
+    It 'All API endpoints have an auth guard (Send-Unauthorized appears in every handler)' {
+        # GET /, GET /api/reveal, POST /api/test, POST /api/save — 4 handlers minimum
+        ([regex]::Matches($script:Src, 'Send-Unauthorized')).Count | Should -BeGreaterOrEqual 4
+    }
+
+    # ── Live-server integration tests ─────────────────────────────────────────
+
+    It 'Server started and is listening' {
+        $script:ServerReady | Should -BeTrue
+    }
+
+    It 'GET / without token returns 401' {
+        $status = $null
+        try {
+            Invoke-WebRequest -Uri "http://127.0.0.1:$($script:TestPort)/" -UseBasicParsing -ErrorAction Stop
+        } catch {
+            $status = [int]$_.Exception.Response.StatusCode
+        }
+        $status | Should -Be 401
+    }
+
+    It 'GET /api/reveal without Authorization returns 401' {
+        $status = $null
+        try {
+            Invoke-WebRequest -Uri "http://127.0.0.1:$($script:TestPort)/api/reveal?backend=gemini" `
+                -UseBasicParsing -ErrorAction Stop
+        } catch {
+            $status = [int]$_.Exception.Response.StatusCode
+        }
+        $status | Should -Be 401
+    }
+
+    It 'POST /api/save without Authorization returns 401' {
+        $status = $null
+        try {
+            Invoke-WebRequest -Uri "http://127.0.0.1:$($script:TestPort)/api/save" `
+                -Method Post -Body '{}' -ContentType 'application/json' `
+                -UseBasicParsing -ErrorAction Stop
+        } catch {
+            $status = [int]$_.Exception.Response.StatusCode
+        }
+        $status | Should -Be 401
+    }
+
+    It 'GET /api/reveal with wrong Origin returns 403 (cross-origin block)' {
+        $status = $null
+        try {
+            Invoke-WebRequest -Uri "http://127.0.0.1:$($script:TestPort)/api/reveal?backend=gemini" `
+                -Headers @{ Origin = 'http://evil.example.com'; Authorization = 'Bearer wrong' } `
+                -UseBasicParsing -ErrorAction Stop
+        } catch {
+            $status = [int]$_.Exception.Response.StatusCode
+        }
+        $status | Should -Be 403
+    }
+
+    It 'GET /api/reveal with spoofed Host header returns 403 (DNS-rebinding block)' {
+        # Use .NET HttpClient to set the Host header — Invoke-WebRequest restricts it
+        $status = $null
+        try {
+            $handler = [System.Net.Http.HttpClientHandler]::new()
+            $client  = [System.Net.Http.HttpClient]::new($handler)
+            $req     = [System.Net.Http.HttpRequestMessage]::new(
+                [System.Net.Http.HttpMethod]::Get,
+                "http://127.0.0.1:$($script:TestPort)/api/reveal?backend=gemini"
+            )
+            [void]$req.Headers.TryAddWithoutValidation('Authorization', 'Bearer valid-looking-but-wrong')
+            [void]$req.Headers.TryAddWithoutValidation('Host', "evil.example:$($script:TestPort)")
+            $resp    = $client.SendAsync($req).GetAwaiter().GetResult()
+            $status  = [int]$resp.StatusCode
+            $client.Dispose()
+        } catch {
+            # connection refused or other transport error — server not ready
+        }
+        $status | Should -Be 403
+    }
+}


### PR DESCRIPTION
## Summary
Closes the three H1 exposure surfaces in the `Register-AIBackend` localhost HTTP server (t/2527, security epic t/2525). TL design approved via e/90#2.

- **Unmasked keys stripped from HTML**: `$InitialState` now contains only `{backend}_masked` fields and `ollama_url`/`ai_model`; raw key values never leave the server process
- **Per-endpoint bearer-token auth**: 24-byte CSPRNG token generated per server run, injected into the browser URL (`?token=`), required as `Authorization: Bearer` on every API endpoint (401 if missing/wrong)
- **Loopback-only binding**: `http://127.0.0.1:{Port}/` — never `localhost`, `+`, or `*`
- **Host/Origin guards**: `Host` header must equal `127.0.0.1:{Port}` (DNS-rebinding block); mismatched `Origin` returns 403 (cross-origin block)
- **Constant-time compare**: `CryptographicOperations.FixedTimeEquals` — same 401 for missing vs wrong token

**Accepted risk (noted per TL):** `?token=` query param lands in browser history — accepted for ephemeral localhost servers (Jupyter pattern); token is never persisted and regenerated each run.

## Test plan
- [x] 10 regression tests: source-level assertions (127.0.0.1 binding, FixedTimeEquals, no unmasked keys, auth guard on all handlers) + live-server integration (401 no-token, 403 wrong-Origin, 403 spoofed-Host via HttpClient) — all pass
- [ ] Full `Invoke-Pester ./tests/` suite — CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
