### PR TITLE
fix(security): M13 open-file RCE guard — containment + extension denylist (t/2531)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/systemHandlers.openFile.test.ts
+++ b/taxonomy-editor/src/main/__tests__/systemHandlers.openFile.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression tests for M13 open-file RCE guard (t/2531).
+// Verifies: executable extensions refused; path traversal refused;
+// path outside both roots refused; valid file within data root opened.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+
+const mockShellOpenPath = vi.hoisted(() => vi.fn());
+const mockFsExistsSync = vi.hoisted(() => vi.fn(() => true));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  shell: { openPath: mockShellOpenPath, openExternal: vi.fn() },
+  clipboard: { writeText: vi.fn() },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  dialog: { showOpenDialog: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp'), getVersion: vi.fn(() => '1.0.0') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false), encryptString: vi.fn(), decryptString: vi.fn() },
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return { ...actual, existsSync: mockFsExistsSync, default: { ...actual, existsSync: mockFsExistsSync } };
+});
+
+// On Windows, path.resolve('/fake/...') converts to a drive-letter path, breaking the
+// startsWith containment check. Use path.posix.resolve — it normalizes '..' sequences
+// without adding a Windows drive prefix, keeping tests portable across platforms.
+vi.mock('path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('path')>();
+  const posixResolve = actual.posix.resolve.bind(actual.posix);
+  return { ...actual, default: { ...actual, resolve: posixResolve, sep: '/' }, resolve: posixResolve, sep: '/' };
+});
+
+const DATA_ROOT = '/fake/data';
+const PROJECT_ROOT_VAL = '/fake/root';
+
+vi.mock('../fileIO.js', () => ({
+  PROJECT_ROOT: '/fake/root',
+  getDataRootPath: vi.fn(() => '/fake/data'),
+  resolveDataPath: vi.fn((p: string) => `/fake/data/${p}`),
+  writeJsonFileAtomic: vi.fn(),
+}));
+
+vi.mock('../../../../lib/debate/errors.js', () => ({ ActionableError: class extends Error {} }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+
+import { registerSystemHandlers } from '../ipc/systemHandlers.js';
+
+function getHandler(channel: string): (event: unknown, ...args: unknown[]) => unknown {
+  const calls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls;
+  const entry = calls.find((c: unknown[]) => c[0] === channel);
+  if (!entry) throw new Error(`${channel} not registered`);
+  return entry[1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFsExistsSync.mockReturnValue(true);
+  registerSystemHandlers();
+});
+
+describe('open-file M13 guard', () => {
+  const handler = () => getHandler('open-file');
+
+  it.each(['.exe', '.bat', '.cmd', '.ps1', '.lnk', '.sh', '.py', '.rb', '.jar'])(
+    'blocks executable extension %s', (ext) => {
+      handler()({}, `${DATA_ROOT}/malware${ext}`);
+      expect(mockShellOpenPath).not.toHaveBeenCalled();
+    },
+  );
+
+  it('blocks path traversal outside data root', () => {
+    handler()({}, `${DATA_ROOT}/../../etc/passwd`);
+    expect(mockShellOpenPath).not.toHaveBeenCalled();
+  });
+
+  it('blocks path outside both roots', () => {
+    handler()({}, '/tmp/external.pdf');
+    expect(mockShellOpenPath).not.toHaveBeenCalled();
+  });
+
+  it('allows valid file inside data root with safe extension', () => {
+    handler()({}, `${DATA_ROOT}/docs/paper.pdf`);
+    expect(mockShellOpenPath).toHaveBeenCalledWith(`${DATA_ROOT}/docs/paper.pdf`);
+  });
+
+  it('allows valid file inside PROJECT_ROOT with safe extension', () => {
+    handler()({}, `${PROJECT_ROOT_VAL}/docs/readme.md`);
+    expect(mockShellOpenPath).toHaveBeenCalledWith(`${PROJECT_ROOT_VAL}/docs/readme.md`);
+  });
+
+  it('blocks if file does not exist even with safe path+ext', () => {
+    mockFsExistsSync.mockReturnValue(false);
+    handler()({}, `${DATA_ROOT}/missing.pdf`);
+    expect(mockShellOpenPath).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/main/ipc/systemHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/systemHandlers.ts
@@ -13,6 +13,12 @@ import { PROJECT_ROOT, getDataRootPath, writeJsonFileAtomic } from '../fileIO.js
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 
+// Extensions that execute on open — blocked regardless of directory (M13, t/2531).
+const BLOCKED_OPEN_EXTS = new Set([
+  '.exe', '.bat', '.cmd', '.com', '.ps1', '.vbs', '.lnk', '.msi', '.scr', '.pif',
+  '.sh', '.py', '.rb', '.jar',
+]);
+
 export function registerSystemHandlers(): void {
   ipcMain.handle('open-external', (_event, url: string) => {
     // Only allow http/https URLs
@@ -22,10 +28,16 @@ export function registerSystemHandlers(): void {
   });
 
   ipcMain.handle('open-file', (_event, filePath: string) => {
-    // Only allow opening files that actually exist on disk
-    if (fs.existsSync(filePath)) {
-      void shell.openPath(filePath);
-    }
+    // S-M13: Containment + extension denylist before shell.openPath.
+    // shell.openPath executes .exe/.bat/.ps1/.lnk etc. — restrict to known safe
+    // directories and non-executable extensions to prevent renderer-bug RCE.
+    const resolved = path.resolve(filePath);
+    const dataRoot = getDataRootPath();
+    const inDataRoot = resolved.startsWith(dataRoot + path.sep);
+    const inProjectRoot = resolved.startsWith(PROJECT_ROOT + path.sep);
+    if (!inDataRoot && !inProjectRoot) return;
+    if (BLOCKED_OPEN_EXTS.has(path.extname(resolved).toLowerCase())) return;
+    if (fs.existsSync(resolved)) void shell.openPath(resolved);
   });
 
   // Clipboard (Electron 40: renderer clipboard API deprecated → use main process)


### PR DESCRIPTION
## Summary

- Adds directory-containment guard to `open-file` IPC handler: path must resolve inside `getDataRootPath()` or `PROJECT_ROOT` — the only two roots with legitimate callers (zero renderer call sites outside these roots, TL-audited t/2531#2)
- Adds 14-extension executable denylist (`.exe`, `.bat`, `.cmd`, `.com`, `.ps1`, `.vbs`, `.lnk`, `.msi`, `.scr`, `.pif`, `.sh`, `.py`, `.rb`, `.jar`) before `shell.openPath`
- 14-case regression test in `src/main/__tests__/systemHandlers.openFile.test.ts`; uses `path.posix.resolve` in mock for portable `..` normalization without Windows drive-letter mangling

## Test plan

- [ ] `npx vitest run src/main/__tests__/systemHandlers.openFile.test.ts` — 14/14 green
- [ ] `npx tsc --noEmit -p tsconfig.main.json` — clean

Fixes M13 milestone of t/2531. M5 (ID traversal sweep) remains blocked on t/2526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)