### PR TITLE
fix(security): M5 ID traversal sweep — assertSafeId on all IPC path-construction sites (t/2531)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/chatIO.safeId.test.ts
+++ b/taxonomy-editor/src/main/__tests__/chatIO.safeId.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression tests for M5 assertSafeId guards in chatIO.ts (t/2531).
+// Verifies traversal-style IDs are rejected before path construction;
+// valid IDs are accepted by loadChatSession, saveChatSession, deleteChatSession.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn(() => true));
+const mockReadFileSync = vi.hoisted(() => vi.fn(() => '{"id":"abc-123","title":"Test","created_at":"","updated_at":"","mode":"chat","pover":"acc"}'));
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockUnlinkSync = vi.hoisted(() => vi.fn());
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    writeFileSync: mockWriteFileSync,
+    unlinkSync: mockUnlinkSync,
+    mkdirSync: mockMkdirSync,
+    default: { ...actual, existsSync: mockExistsSync, readFileSync: mockReadFileSync, writeFileSync: mockWriteFileSync, unlinkSync: mockUnlinkSync, mkdirSync: mockMkdirSync },
+  };
+});
+
+vi.mock('../fileIO.js', () => ({
+  resolveDataPath: vi.fn(() => '/fake/chats'),
+}));
+
+import { loadChatSession, saveChatSession, deleteChatSession } from '../chatIO.js';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('chatIO — assertSafeId traversal guards', () => {
+  it.each(['../../etc/passwd', '../shadow', 'a/b', '/abs/path', 'bad id'])(
+    'loadChatSession rejects "%s"', (id) => {
+      expect(() => loadChatSession(id)).toThrow();
+    },
+  );
+
+  it('loadChatSession accepts valid id', () => {
+    expect(() => loadChatSession('abc-123')).not.toThrow();
+  });
+
+  it.each(['../../etc/passwd', '../shadow', 'a/b'])(
+    'deleteChatSession rejects "%s"', (id) => {
+      expect(() => deleteChatSession(id)).toThrow();
+    },
+  );
+
+  it('deleteChatSession accepts valid id', () => {
+    expect(() => deleteChatSession('abc-123')).not.toThrow();
+    expect(mockUnlinkSync).toHaveBeenCalled();
+  });
+
+  it.each(['../../etc/passwd', '../shadow', 'a/b'])(
+    'saveChatSession rejects traversal in session.id "%s"', (id) => {
+      expect(() => saveChatSession({ id })).toThrow();
+    },
+  );
+
+  it('saveChatSession accepts valid session.id', () => {
+    expect(() => saveChatSession({ id: 'abc-123' })).not.toThrow();
+    expect(mockWriteFileSync).toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/main/__tests__/debateHandlers.harvest.safeId.test.ts
+++ b/taxonomy-editor/src/main/__tests__/debateHandlers.harvest.safeId.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression tests for M5 assertSafeId guards in debateHandlers.ts harvest
+// handlers (t/2531): harvest-create-conflict, harvest-add-verdict,
+// harvest-save-manifest all construct paths from user-supplied IDs.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockExistsSync = vi.hoisted(() => vi.fn(() => true));
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn(() => '{"id":"x"}'));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { getFocusedWindow: vi.fn(() => null), fromWebContents: vi.fn(() => null), getAllWindows: vi.fn(() => []) },
+  dialog: { showSaveDialog: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp'), getVersion: vi.fn(() => '1.0.0') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false), encryptString: vi.fn(), decryptString: vi.fn() },
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+    writeFileSync: mockWriteFileSync,
+    mkdirSync: mockMkdirSync,
+    readFileSync: mockReadFileSync,
+    default: { ...actual, existsSync: mockExistsSync, writeFileSync: mockWriteFileSync, mkdirSync: mockMkdirSync, readFileSync: mockReadFileSync },
+  };
+});
+
+vi.mock('../debateIO.js', () => ({
+  listDebateSessions: vi.fn(),
+  loadDebateSession: vi.fn(),
+  saveDebateSession: vi.fn(),
+  deleteDebateSession: vi.fn(),
+  loadDebateComments: vi.fn(),
+  saveDebateComments: vi.fn(),
+}));
+
+vi.mock('../debateExport.js', () => ({
+  debateToText: vi.fn(),
+  debateToMarkdown: vi.fn(),
+  debateToPdf: vi.fn(),
+  debateToPackage: vi.fn(),
+}));
+
+vi.mock('../fileIO.js', () => ({
+  getDataRootPath: vi.fn(() => '/fake/data'),
+  loadDataConfig: vi.fn(() => ({ taxonomy_dir: 'taxonomy' })),
+  getSourcesDir: vi.fn(() => null),
+}));
+
+vi.mock('../embeddings.js', () => ({ generateText: vi.fn() }));
+vi.mock('../ipcSchemas.js', () => ({
+  VALID_POV: { parse: vi.fn() },
+  NodeId: { parse: vi.fn() },
+}));
+
+vi.mock('../../../../lib/debate/errors.js', () => ({
+  ActionableError: class ActionableError extends Error {
+    constructor(args: { goal: string; problem: string; location: string; nextSteps: string[] }) {
+      super(args.problem);
+      this.name = 'ActionableError';
+    }
+  },
+}));
+
+vi.mock('../../../../lib/debate/persistence.js', () => ({ renameSyncWithRetry: vi.fn() }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+vi.mock('../../../../lib/ai-client/index.js', () => ({ DEFAULT_MODEL: 'gemini-2.0-flash' }));
+
+import { registerDebateHandlers } from '../ipc/debateHandlers.js';
+
+function getHandler(channel: string): (event: unknown, ...args: unknown[]) => Promise<unknown> {
+  const calls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls;
+  const entry = calls.find((c: unknown[]) => c[0] === channel);
+  if (!entry) throw new Error(`${channel} not registered`);
+  return entry[1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  registerDebateHandlers();
+});
+
+const TRAVERSAL_IDS = ['../../etc/passwd', '../shadow', 'a/b', '/abs/path'];
+
+describe('harvest-create-conflict — assertSafeId on claim_id', () => {
+  it.each(TRAVERSAL_IDS)('rejects traversal claim_id "%s"', async (id) => {
+    const handler = getHandler('harvest-create-conflict');
+    await expect(handler({}, { claim_id: id })).rejects.toThrow();
+  });
+
+  it('accepts valid claim_id', async () => {
+    const handler = getHandler('harvest-create-conflict');
+    await expect(handler({}, { claim_id: 'conflict-001' })).resolves.toBeDefined();
+  });
+});
+
+describe('harvest-add-verdict — assertSafeId on conflictId', () => {
+  it.each(TRAVERSAL_IDS)('rejects traversal conflictId "%s"', async (id) => {
+    const handler = getHandler('harvest-add-verdict');
+    await expect(handler({}, id, {})).rejects.toThrow();
+  });
+
+  it('accepts valid conflictId (file not found → not-found path)', async () => {
+    mockExistsSync.mockReturnValue(false);
+    const handler = getHandler('harvest-add-verdict');
+    const result = await handler({}, 'conflict-001', {});
+    expect((result as { updated: boolean }).updated).toBe(false);
+  });
+});
+
+describe('harvest-save-manifest — assertSafeId on debate_id', () => {
+  it.each(TRAVERSAL_IDS)('rejects traversal debate_id "%s"', async (id) => {
+    const handler = getHandler('harvest-save-manifest');
+    await expect(handler({}, { debate_id: id })).rejects.toThrow();
+  });
+
+  it('accepts valid debate_id', async () => {
+    const handler = getHandler('harvest-save-manifest');
+    await expect(handler({}, { debate_id: 'debate-xyz' })).resolves.toBeDefined();
+  });
+});

--- a/taxonomy-editor/src/main/__tests__/debateIO.safeId.test.ts
+++ b/taxonomy-editor/src/main/__tests__/debateIO.safeId.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression tests for M5 assertSafeId guards in debateIO.ts (t/2531).
+// Verifies traversal-style debate IDs are rejected in loadDebateSession,
+// saveDebateSession, deleteDebateSession, loadDebateComments, saveDebateComments.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn(() => true));
+const mockReadFileSync = vi.hoisted(() => vi.fn(() => '{"id":"abc-123","title":"T","created_at":"","updated_at":"","phase":"open","transcript":[]}'));
+const mockWriteFileSync = vi.hoisted(() => vi.fn());
+const mockUnlinkSync = vi.hoisted(() => vi.fn());
+const mockMkdirSync = vi.hoisted(() => vi.fn());
+const mockStatSync = vi.hoisted(() => vi.fn(() => ({ mtimeMs: 1 })));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  const mockReadFileProm = vi.fn(async () => '{"id":"x","title":"","created_at":"","updated_at":"","phase":"open","transcript":[]}');
+  const mockPromises = { ...actual.promises, readFile: mockReadFileProm };
+  const overrides = { existsSync: mockExistsSync, readFileSync: mockReadFileSync, writeFileSync: mockWriteFileSync, unlinkSync: mockUnlinkSync, mkdirSync: mockMkdirSync, statSync: mockStatSync, promises: mockPromises };
+  return { ...actual, ...overrides, default: { ...actual, ...overrides } };
+});
+
+vi.mock('../fileIO.js', () => ({
+  resolveDataPath: vi.fn(() => '/fake/debates'),
+}));
+
+vi.mock('../../../../lib/debate/calibrationLogger.js', () => ({
+  extractCalibrationData: vi.fn(),
+  appendCalibrationLog: vi.fn(),
+}));
+
+vi.mock('../../../../lib/debate/persistence.js', () => ({
+  safeSerialize: vi.fn((v: unknown) => ({ json: JSON.stringify(v), hadError: false })),
+  atomicWriteSync: vi.fn(),
+  renameSyncWithRetry: vi.fn(),
+}));
+
+vi.mock('../../../../lib/debate/errors.js', () => ({
+  ActionableError: class ActionableError extends Error {
+    constructor(args: { goal: string; problem: string; location: string; nextSteps: string[] }) {
+      super(args.problem);
+      this.name = 'ActionableError';
+    }
+  },
+}));
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: vi.fn(() => null),
+}));
+
+import {
+  loadDebateSession,
+  saveDebateSession,
+  deleteDebateSession,
+  loadDebateComments,
+  saveDebateComments,
+} from '../debateIO.js';
+
+beforeEach(() => vi.clearAllMocks());
+
+const TRAVERSAL_IDS = ['../../etc/passwd', '../shadow', 'a/b', '/abs/path'];
+
+describe('debateIO — assertSafeId traversal guards', () => {
+  it.each(TRAVERSAL_IDS)('loadDebateSession rejects "%s"', async (id) => {
+    await expect(loadDebateSession(id)).rejects.toThrow();
+  });
+
+  it('loadDebateSession accepts valid id', async () => {
+    await expect(loadDebateSession('abc-123')).resolves.toBeDefined();
+  });
+
+  it.each(TRAVERSAL_IDS)('saveDebateSession rejects traversal in session.id "%s"', (id) => {
+    expect(() => saveDebateSession({ id, transcript: [] }, 'test')).toThrow();
+  });
+
+  it('saveDebateSession accepts valid id', () => {
+    expect(() => saveDebateSession({ id: 'abc-123', transcript: [] }, 'test')).not.toThrow();
+  });
+
+  it.each(TRAVERSAL_IDS)('deleteDebateSession rejects "%s"', (id) => {
+    expect(() => deleteDebateSession(id)).toThrow();
+  });
+
+  it.each(TRAVERSAL_IDS)('loadDebateComments rejects "%s"', (id) => {
+    expect(() => loadDebateComments(id)).toThrow();
+  });
+
+  it('loadDebateComments accepts valid id', () => {
+    expect(() => loadDebateComments('abc-123')).not.toThrow();
+  });
+
+  it.each(TRAVERSAL_IDS)('saveDebateComments rejects "%s"', (id) => {
+    expect(() => saveDebateComments(id, {})).toThrow();
+  });
+
+  it('saveDebateComments accepts valid id', () => {
+    expect(() => saveDebateComments('abc-123', {})).not.toThrow();
+  });
+});

--- a/taxonomy-editor/src/main/chatIO.ts
+++ b/taxonomy-editor/src/main/chatIO.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { resolveDataPath } from './fileIO.js';
+import { assertSafeId } from '../../../lib/electron-shared/safeId.js';
 
 const CHATS_DIR = resolveDataPath('chats');
 
@@ -24,6 +25,7 @@ function ensureChatsDir(): void {
 }
 
 function chatFilePath(id: string): string {
+  assertSafeId(id, 'chat session id');
   return path.join(CHATS_DIR, `chat-${id}.json`);
 }
 

--- a/taxonomy-editor/src/main/debateIO.ts
+++ b/taxonomy-editor/src/main/debateIO.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { resolveDataPath } from './fileIO.js';
+import { assertSafeId } from '../../../lib/electron-shared/safeId.js';
 import { extractCalibrationData, appendCalibrationLog } from '../../../lib/debate/calibrationLogger.js';
 import { safeSerialize, atomicWriteSync, renameSyncWithRetry } from '../../../lib/debate/persistence.js';
 import { ActionableError } from '../../../lib/debate/errors.js';
@@ -41,6 +42,7 @@ function ensureDebatesDir(): void {
 }
 
 function debateFilePath(id: string): string {
+  assertSafeId(id, 'debate id');
   return path.join(DEBATES_DIR, `debate-${id}.json`);
 }
 
@@ -305,6 +307,7 @@ export function deleteDebateSession(id: string): void {
 // ── Debate comments ────────────────────────────────────────
 
 function commentsFilePath(debateId: string): string {
+  assertSafeId(debateId, 'debate id');
   return path.join(DEBATES_DIR, `debate-${debateId}-comments.json`);
 }
 

--- a/taxonomy-editor/src/main/fileIO.ts
+++ b/taxonomy-editor/src/main/fileIO.ts
@@ -11,6 +11,7 @@ import { renameSyncWithRetry } from '../../../lib/debate/persistence.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 import { parseNpy, extractNodeVectors } from '../../../lib/npy.js';
 import { resolveRepoRootForApp } from '../../../lib/electron-shared/resolveRepoRootForApp.js';
+import { assertSafeId } from '../../../lib/electron-shared/safeId.js';
 import type { Entity } from '../../../lib/entities/types.js';
 import { serializeEdgesJson } from '../../../lib/edges/serializeEdges.js';
 import type { ContainerMentions, EntityMentionsFile } from '../../../lib/entities/mentionTypes.js';
@@ -179,6 +180,7 @@ export function getActiveTaxonomyDirName(): string {
 }
 
 export function setActiveTaxonomyDir(dirName: string): void {
+  assertSafeId(dirName, 'taxonomy directory name');
   const newDir = path.join(TAXONOMY_BASE, dirName);
   if (!fs.existsSync(newDir)) {
     throw new ActionableError({

--- a/taxonomy-editor/src/main/ipc/debateHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/debateHandlers.ts
@@ -26,6 +26,7 @@ import { renameSyncWithRetry } from '../../../../lib/debate/persistence.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { DEFAULT_MODEL } from '../../../../lib/ai-client/index.js';
 import { VALID_POV, NodeId } from '../ipcSchemas.js';
+import { assertSafeId } from '../../../../lib/electron-shared/safeId.js';
 
 export function registerDebateHandlers(): void {
   // ── Debate session handlers ────────────────────────────
@@ -205,7 +206,7 @@ export function registerDebateHandlers(): void {
   // ── Harvest IPC handlers ──────────────────────────────────
 
   ipcMain.handle('harvest-create-conflict', async (_event, conflict: Record<string, unknown>) => {
-    const conflictId = conflict.claim_id as string;
+    const conflictId = assertSafeId(conflict.claim_id as string, 'conflict id');
     const conflictsDir = path.join(getDataRootPath(), 'conflicts');
     if (!fs.existsSync(conflictsDir)) fs.mkdirSync(conflictsDir, { recursive: true });
     const filePath = path.join(conflictsDir, `${conflictId}.json`);
@@ -273,6 +274,7 @@ export function registerDebateHandlers(): void {
   });
 
   ipcMain.handle('harvest-add-verdict', async (_event, conflictId: string, verdict: Record<string, unknown>) => {
+    assertSafeId(conflictId, 'conflict id');
     const conflictsDir = path.join(getDataRootPath(), 'conflicts');
     const filePath = path.join(conflictsDir, `${conflictId}.json`);
     if (!fs.existsSync(filePath)) return { updated: false, error: `Conflict ${conflictId} not found` };
@@ -303,7 +305,7 @@ export function registerDebateHandlers(): void {
   ipcMain.handle('harvest-save-manifest', async (_event, manifest: Record<string, unknown>) => {
     const harvestsDir = path.join(getDataRootPath(), 'harvests');
     if (!fs.existsSync(harvestsDir)) fs.mkdirSync(harvestsDir, { recursive: true });
-    const debateId = manifest.debate_id as string;
+    const debateId = assertSafeId(manifest.debate_id as string, 'debate id');
     const filePath = path.join(harvestsDir, `${debateId}.json`);
     fs.writeFileSync(filePath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
     console.log(`[harvest] Saved manifest: ${debateId}`);


### PR DESCRIPTION
## Summary

- Applies `assertSafeId` (t/2526) at every IPC path-construction site where a caller-supplied ID reaches `path.join` without validation
- **`chatIO.ts`**: `chatFilePath(id)` — chat session load/save/delete
- **`debateIO.ts`**: `debateFilePath(id)` + `commentsFilePath(debateId)` — debate session CRUD and comments
- **`fileIO.ts`**: `setActiveTaxonomyDir(dirName)` — taxonomy directory switch
- **`ipc/debateHandlers.ts`**: `harvest-create-conflict` (claim_id), `harvest-add-verdict` (conflictId), `harvest-save-manifest` (debate_id) — three harvest handlers that previously constructed file paths from unvalidated IPC args

## Test plan

- [ ] 53 regression tests across 3 new files: `chatIO.safeId.test.ts`, `debateIO.safeId.test.ts`, `debateHandlers.harvest.safeId.test.ts`
- [ ] Traversal IDs (`../../etc/passwd`, `/abs/path`, `a/b`) rejected; valid alphanumeric-hyphen IDs accepted end-to-end
- [ ] `npx tsc --noEmit -p tsconfig.main.json` — clean

Completes t/2531 (M13 landed in PR #923, M5 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)