### PR TITLE
fix(debate): skip interrupted-turn auto-resume for socratic protocol (t/2539)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/interruptedTurnSocratic.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/interruptedTurnSocratic.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression guard for t/2539 (Q5 of t/2536): interrupted-turn recovery in
+// loadDebate must NOT auto-resume via crossRespond for a socratic debate. Socratic
+// has a single AI debater, so crossRespond bails ("Need at least 2 AI debaters")
+// and leaves an error toast on resume. The fix skips the auto-resume for
+// protocol_id === 'socratic' (the user drives the next turn). This test loads a
+// socratic session carrying an interrupted_turn, lets the recovery's 100ms timer
+// fire, and asserts crossRespond was never called — with a non-socratic control
+// arm proving the assertion is non-vacuous.
+//
+// The store records via getGlobalRecorder(); override it (keeping the real module's
+// other exports) to capture the event stream and assert on the skip lifecycle event.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { recorded } = vi.hoisted(() => ({ recorded: [] as Array<Record<string, unknown>> }));
+
+vi.mock('@lib/flight-recorder/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@lib/flight-recorder/index')>();
+  return {
+    ...actual,
+    getGlobalRecorder: () => ({ record: (e: Record<string, unknown>) => { recorded.push(e); }, setEventContext: () => {} }),
+  };
+});
+
+// Harness FIRST so its hoisted vi.mock registrations run before the store imports.
+import { resetStore, makeSession, mockApi } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+
+type Entry = { id: string; timestamp: string; type: string; speaker: string; content: string; taxonomy_refs: string[] };
+function entry(id: string, type = 'statement', speaker = 'accelerationist'): Entry {
+  return { id, timestamp: '2026-05-01T00:00:00.000Z', type, speaker, content: `content-${id}`, taxonomy_refs: [] };
+}
+
+// The recovery auto-resume is scheduled on a 100ms setTimeout; wait past it (real timers).
+const afterRecoveryTimer = () => new Promise((r) => setTimeout(r, 150));
+
+describe('interrupted-turn recovery — socratic protocol guard (t/2539)', () => {
+  beforeEach(() => {
+    resetStore();
+    recorded.length = 0;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT auto-resume crossRespond for a socratic debate with an interrupted_turn', async () => {
+    const crossRespond = vi.fn().mockResolvedValue(undefined);
+    useDebateStore.setState({ crossRespond: crossRespond as never });
+
+    mockApi.loadDebateSession.mockResolvedValue(makeSession({
+      id: 'd-socratic',
+      phase: 'debate',
+      protocol_id: 'socratic',
+      active_povers: ['skeptic'],
+      transcript: [entry('e1', 'opening', 'skeptic')],
+      interrupted_turn: { speaker: 'skeptic', phase: 'debate', round: 1, timestamp: '2026-05-01T00:00:00.000Z' },
+    }));
+
+    await useDebateStore.getState().loadDebate('d-socratic');
+    await afterRecoveryTimer();
+
+    // The auto-resume must have been skipped — crossRespond never fired…
+    expect(crossRespond).not.toHaveBeenCalled();
+    // …the skip was recorded…
+    expect(recorded.some(e => e.message === 'Interrupted-turn auto-resume skipped for socratic protocol')).toBe(true);
+    // …no "Need at least 2 AI debaters" error leaked, and the generating indicator
+    // was never left stuck on the resume speaker.
+    const st = useDebateStore.getState();
+    expect(st.debateError ?? '').not.toContain('at least 2');
+    expect(st.debateGenerating).toBeNull();
+
+    // Witness that the recovery path actually ran (not a vacuous pass): the
+    // [Recovered] system entry was appended and interrupted_turn was cleared.
+    expect(st.activeDebate?.transcript.some(e => e.type === 'system' && e.content.includes('[Recovered]'))).toBe(true);
+    expect(st.activeDebate?.interrupted_turn).toBeUndefined();
+  });
+
+  it('control: a non-socratic debate with an interrupted_turn DOES auto-resume via crossRespond', async () => {
+    const crossRespond = vi.fn().mockResolvedValue(undefined);
+    useDebateStore.setState({ crossRespond: crossRespond as never });
+
+    mockApi.loadDebateSession.mockResolvedValue(makeSession({
+      id: 'd-standard',
+      phase: 'debate',
+      protocol_id: 'structured',
+      active_povers: ['accelerationist', 'safetyist', 'skeptic'],
+      transcript: [entry('e1', 'opening', 'accelerationist'), entry('e2', 'opening', 'safetyist')],
+      interrupted_turn: { speaker: 'accelerationist', phase: 'debate', round: 1, timestamp: '2026-05-01T00:00:00.000Z' },
+    }));
+
+    await useDebateStore.getState().loadDebate('d-standard');
+    await afterRecoveryTimer();
+
+    expect(crossRespond).toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -634,7 +634,14 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
           void get().saveDebate('loadDebate:interrupted_turn_recovery');
           setTimeout(() => {
             const s = get();
-            if (s.activeDebateId === id && !s.debateGenerating) {
+            if (s.activeDebate?.protocol_id === 'socratic') {
+              // Socratic is user-driven (ask/probe/summarize) with a single AI
+              // debater; crossRespond requires >=2 AI debaters and would bail with a
+              // "Need at least 2 AI debaters" error toast. The interrupted_turn field
+              // is already cleared above, so there is nothing to auto-resume — the
+              // user simply drives the next turn. Sibling of t/2536 (Q5). (t/2539)
+              getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'info', debate_id: id, message: 'Interrupted-turn auto-resume skipped for socratic protocol' });
+            } else if (s.activeDebateId === id && !s.debateGenerating) {
               getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'info', debate_id: id, message: 'Auto-resuming after interrupted turn recovery' });
               // Engage the generating indicator up front so the Continue button is
               // disabled during crossRespond's ramp-up (edge load + moderator


### PR DESCRIPTION
Fixes t/2539 (Q5 sibling of t/2536, different call site).

`loadDebate`'s interrupted-turn recovery fired `crossRespond()` unconditionally via a 100ms `setTimeout`. For a socratic debate (single AI debater), `crossRespond` bails with "Need at least 2 AI debaters" and leaves the error toast on resume.

## Fix
Guard the auto-resume: when `protocol_id === 'socratic'`, skip it (the `interrupted_turn` field is already cleared, so the user just drives the next turn) and record a lifecycle skip event.

**Deviation from the ticket sketch:** the ticket set `debateGenerating` then cleared it in the socratic branch; instead the guard runs *before* `debateGenerating` is set — nothing to clear, no transient indicator flip. Same outcome, cleaner.

## Test
`interruptedTurnSocratic.test.ts` — loads a socratic session with an `interrupted_turn`, lets the recovery timer fire, asserts `crossRespond` is NOT called and the skip event is recorded. A non-socratic control arm proves the assertion is non-vacuous. Verified as a faithful witness: removing the guard makes `crossRespond` fire once and the test fails.

## Diagnosis
Filed by Diagnostics as Q5 of the t/2536 FR analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)