### PR TITLE
chore(debate): add protocol_id to "crossRespond entered" FR event (t/2537)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
@@ -110,7 +110,7 @@ export const createDebatePhaseSlice: StateCreator<DebateStore, [], [], DebatePha
       getGlobalRecorder()?.record({ type: 'lifecycle', component: 'debate-store', level: 'warn', debate_id: activeDebate.id, message: 'Debate driver claim denied — another window owns it' });
       return;
     }
-    getGlobalRecorder()?.record({ type: 'debate.round', component: 'debate-store', level: 'debug', debate_id: activeDebate?.id, message: 'crossRespond entered', data: { phase: activeDebate?.phase, transcript_length: activeDebate?.transcript.length, adaptive_phase: activeDebate?.adaptive_staging?.phase_state?.current_phase } });
+    getGlobalRecorder()?.record({ type: 'debate.round', component: 'debate-store', level: 'debug', debate_id: activeDebate?.id, message: 'crossRespond entered', data: { protocol_id: activeDebate?.protocol_id, phase: activeDebate?.phase, transcript_length: activeDebate?.transcript.length, adaptive_phase: activeDebate?.adaptive_staging?.phase_state?.current_phase } });
 
     // Guard: if openings completed but abort guard prevented phase transition, fix it now
     if (activeDebate.phase === 'opening' && activeDebate.transcript.some(e => e.type === 'opening')) {


### PR DESCRIPTION
Fixes t/2537 (Q3a observability from the t/2536 diagnosis).

The `crossRespond entered` event (`debatePhaseSlice.ts`) omitted `protocol_id`, so diagnosing the socratic crossRespond bug required cross-referencing the separate `debate.start` event to establish the protocol. Adding `protocol_id: activeDebate?.protocol_id` to the `data` field makes the protocol visible at the point of entry.

Log-field addition only; no behavioral change. Self-cert `/trivial-change`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)