### PR TITLE
fix(poviewer): restore read-source-file IPC handler with dialog-path allowlist (t/2540)

### DIFF
--- a/poviewer/src/main/ipcHandlers.test.ts
+++ b/poviewer/src/main/ipcHandlers.test.ts
@@ -5,6 +5,8 @@
 //   M4  — 'get-api-key' is gone; 'has-api-key' returns a boolean (never the key).
 //   M7  — 'add-source' rejects metadata whose id fails SAFE_ID_RE.
 //   M10 — 'extract-pdf-text' rejects paths outside the data root / sources dir.
+// Plus t/2540: 'read-source-file' (restored from the ef8bac78 regression) serves only
+// dialog-returned paths — allowlisted read succeeds, non-allowlisted path → 400.
 
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import fs from 'node:fs';
@@ -12,6 +14,7 @@ import path from 'node:path';
 
 const captured = vi.hoisted(() => ({
   handlers: {} as Record<string, (...args: unknown[]) => unknown>,
+  showOpen: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -20,7 +23,7 @@ vi.mock('electron', () => ({
       captured.handlers[channel] = fn;
     },
   },
-  dialog: {},
+  dialog: { showOpenDialog: (opts: unknown) => captured.showOpen(opts) },
   shell: {},
   BrowserWindow: { getAllWindows: () => [] },
   safeStorage: { isEncryptionAvailable: () => false },
@@ -148,5 +151,47 @@ describe('t/2534 M9pov: set-taxonomy-dir confinement', () => {
       thrown = err;
     }
     expect((thrown as { statusCode?: number } | undefined)?.statusCode).toBe(400);
+  });
+});
+
+describe('t/2540: read-source-file dialog-returned-path allowlist', () => {
+  const allowedFile = path.join(TMP_SOURCES, 'allowed.md');
+  beforeAll(() => {
+    fs.writeFileSync(allowedFile, '# Allowed\n\nhello world\n');
+    captured.showOpen.mockReset();
+  });
+
+  it('reads a file the native open dialog handed out (add-file flow repro)', async () => {
+    // Simulates AddSourceDialog: openSourceFileDialog() then readSourceFile(fp).
+    captured.showOpen.mockResolvedValueOnce({ canceled: false, filePaths: [allowedFile] });
+    const paths = await captured.handlers['open-source-file-dialog'](EVENT) as string[];
+    expect(paths).toEqual([allowedFile]);
+    const content = await captured.handlers['read-source-file'](EVENT, allowedFile);
+    expect(content).toContain('hello world');
+  });
+
+  it('refuses a path the dialog never returned — statusCode 400, four-field ActionableError', async () => {
+    const outside = path.resolve(path.parse(process.cwd()).root, 'etc', 'passwd');
+    let thrown: unknown;
+    try {
+      await captured.handlers['read-source-file'](EVENT, outside);
+    } catch (err) {
+      /* telemetry — silent by design (test captures the expected throw) */
+      thrown = err;
+    }
+    expect(thrown).toBeDefined();
+    expect((thrown as { statusCode?: number }).statusCode).toBe(400);
+    expect((thrown as { goal?: string }).goal).toBeDefined();
+    expect((thrown as { problem?: string }).problem).toBeDefined();
+    expect((thrown as { location?: string }).location).toBeDefined();
+    expect(Array.isArray((thrown as { nextSteps?: string[] }).nextSteps)).toBe(true);
+  });
+
+  it('a path authorized this session survives path.resolve normalization', async () => {
+    captured.showOpen.mockResolvedValueOnce({ canceled: false, filePaths: [allowedFile] });
+    await captured.handlers['open-source-file-dialog'](EVENT);
+    // A non-normalized spelling of the same file (extra "./" segment) must still match.
+    const messy = path.join(path.dirname(allowedFile), '.', path.basename(allowedFile));
+    await expect(captured.handlers['read-source-file'](EVENT, messy)).resolves.toContain('hello world');
   });
 });

--- a/poviewer/src/main/ipcHandlers.ts
+++ b/poviewer/src/main/ipcHandlers.ts
@@ -61,6 +61,13 @@ const sourceMetadataSchema = z.object({
 });
 const oneSourceMetadata = z.tuple([sourceMetadataSchema]);
 
+// t/2540: dialog-returned-path allowlist. The `read-source-file` handler serves ONLY paths
+// the native open dialog handed to the renderer this session (populated by
+// 'open-source-file-dialog'). Users may legitimately pick source files anywhere on disk, so a
+// fixed-root containment (as in extract-pdf-text) would be wrong here — the native dialog IS the
+// authorization. Restores the handler dropped in ef8bac78 which broke AddSourceDialog's add-file flow.
+const dialogAuthorizedSourcePaths = new Set<string>();
+
 export function registerIpcHandlers(): void {
   // === No-arg handlers (no validation needed) ===
 
@@ -93,10 +100,38 @@ export function registerIpcHandlers(): void {
       properties: ['openFile', 'multiSelections'],
     });
     if (result.canceled || result.filePaths.length === 0) return null;
+    // t/2540: authorize exactly these dialog-vetted paths for a later read-source-file read.
+    for (const fp of result.filePaths) dialogAuthorizedSourcePaths.add(path.resolve(fp));
     return result.filePaths;
   });
 
   // === Single string arg ===
+
+  // t/2540: restore the read-source-file handler dropped in ef8bac78 — AddSourceDialog's
+  // add-file flow calls it after open-source-file-dialog. Containment is the dialog-returned-path
+  // allowlist (dialogAuthorizedSourcePaths), NOT a fixed root: the native dialog is the authorization.
+  validatedHandle('read-source-file', oneString, (_event, filePath) => {
+    const resolved = path.resolve(filePath);
+    if (!dialogAuthorizedSourcePaths.has(resolved)) {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'poviewer-ipc',
+        level: 'warn',
+        message: 'read-source-file refused a path not authorized by the native open dialog',
+        error: { name: 'SecurityError', message: resolved },
+      });
+      throw Object.assign(new ActionableError({
+        goal: 'Read a source file selected via the Add Source dialog',
+        problem: `Refused to read a path the native file dialog did not return this session: ${resolved}`,
+        location: 'ipcHandlers.ts:read-source-file',
+        nextSteps: [
+          'Select the file through Add Source → Browse — the native dialog authorizes the path',
+          'Paths are only readable when handed out by dialog.showOpenDialog in this session',
+        ],
+      }), { statusCode: 400 });
+    }
+    return readSourceFileContent(resolved);
+  });
 
   validatedHandle('set-taxonomy-dir', oneString, (_event, dirName) => {
     setActiveTaxonomyDir(dirName);


### PR DESCRIPTION
Restores the `read-source-file` IPC handler dropped in **ef8bac78** ("code review fixes — validated IPC"), which left the preload exposure and the `AddSourceDialog` caller in place → **Add Source → pick a file → "Failed to read file"** (a live regression, not dead code). Per TL-approved design at t/2540#1 (Option 1).

## Approach — dialog-returned-path allowlist (not fixed-root containment)
Users legitimately pick source files anywhere, so the native open dialog is the authorization:
- `open-source-file-dialog` records each `path.resolve`'d path it hands the renderer (`dialogAuthorizedSourcePaths`).
- The restored `read-source-file` (`validatedHandle` + `oneString`) resolves its arg and serves **only** allowlisted paths; a miss throws a **400 four-field ActionableError** (mirrors the `safeId.ts` idiom) + an FR warn. Uses the deliberately-left `readSourceFileContent` import (t/2534).

Closes **L13** from the security review (t/2525): the surface goes from "dangerous if wired" to wired-with-containment. No preload/renderer/`electron.d.ts` changes — only the handler was dropped.

## Tests (`ipcHandlers.test.ts`)
- Allowlisted path reads succeed (add-file repro: open-dialog → read).
- Non-allowlisted absolute path → `statusCode 400` four-field ActionableError.
- A `path.resolve`-normalized spelling of an authorized path still reads.

## Gates (worktree)
poviewer main tsc ✓ · eslint 0 ✓ · vitest 14/14 (11 t/2534 + 3 t/2540) ✓ · vite build ✓

Implementation review routed to **Quality (Tech Lead)** per t/2540#1 — holding self-merge for sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)