### PR TITLE
fix(sec): PowerShell secrets hardening — M1,L1,L2,L3,L4,L14 (t/2530)

### DIFF
--- a/scripts/AIEnrich.psm1
+++ b/scripts/AIEnrich.psm1
@@ -266,12 +266,14 @@ function Measure-PromptTokens {
     $GeminiKey = Resolve-AIApiKey -ExplicitKey $ApiKey -Backend 'gemini'
     if ($GeminiKey) {
         try {
-            $CountUrl = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:countTokens?key=$GeminiKey"
+            # Key travels in the x-goog-api-key header, not the URL — a ?key= query
+            # param leaks via proxy logs and PS5.1 error-record URIs (t/2530 L1).
+            $CountUrl = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:countTokens'
             $CountBody = @{
                 contents = @(@{ parts = @(@{ text = $Text }) })
             } | ConvertTo-Json -Depth 5
             $BodyBytes = [System.Text.Encoding]::UTF8.GetBytes($CountBody)
-            $CountResponse = Invoke-RestMethod -Uri $CountUrl -Method POST -ContentType 'application/json; charset=utf-8' -Body $BodyBytes -TimeoutSec 10
+            $CountResponse = Invoke-RestMethod -Uri $CountUrl -Method POST -Headers @{ 'x-goog-api-key' = $GeminiKey } -ContentType 'application/json; charset=utf-8' -Body $BodyBytes -TimeoutSec 10
             return [PSCustomObject]@{
                 TokenCount = [int]$CountResponse.totalTokens
                 Method     = 'gemini-countTokens'
@@ -541,7 +543,10 @@ function Invoke-AIApi {
 
     switch ($Backend) {
         'gemini' {
-            $Uri = "https://generativelanguage.googleapis.com/v1beta/models/${ApiModelId}:generateContent?key=${ResolvedKey}"
+            # Key travels in the x-goog-api-key header, not the URL — a ?key= query
+            # param leaks via proxy logs and PS5.1 error-record URIs (t/2530 L1).
+            $Uri = "https://generativelanguage.googleapis.com/v1beta/models/${ApiModelId}:generateContent"
+            $Headers['x-goog-api-key'] = $ResolvedKey
 
             $Categories = @('HARASSMENT', 'HATE_SPEECH', 'SEXUALLY_EXPLICIT', 'DANGEROUS_CONTENT')
             $SafetyList = $Categories | ForEach-Object {
@@ -926,7 +931,10 @@ function Invoke-AIApi {
             { $_ -in 500, 502, 503 } { 'Server error — the API may be temporarily unavailable.' }
             default { '' }
         }
-        Write-Warning "$($Backend): API call failed (HTTP $StatusCode) — $($LastError.Exception.Message)"
+        # Scrub any key/token that the exception message or response body may echo
+        # before it reaches a log (t/2530 L14).
+        $SafeMsg = Protect-SensitiveText -Text $LastError.Exception.Message -Secret $ResolvedKey
+        Write-Warning "$($Backend): API call failed (HTTP $StatusCode) — $SafeMsg"
         if ($Hint) { Write-Warning "$($Backend): $Hint" }
         try {
             if ($LastError.Exception.Response) {
@@ -934,7 +942,8 @@ function Invoke-AIApi {
                 $ErrReader = [System.IO.StreamReader]::new($ErrStream)
                 $ErrBody   = $ErrReader.ReadToEnd()
                 $ErrReader.Close()
-                Write-Warning "$($Backend): Response body: $ErrBody"
+                $SafeBody = Protect-SensitiveText -Text $ErrBody -Secret $ResolvedKey
+                Write-Warning "$($Backend): Response body: $SafeBody"
             }
         } catch { }
 

--- a/scripts/AITriad/Private/Docker-Helpers.ps1
+++ b/scripts/AITriad/Private/Docker-Helpers.ps1
@@ -220,19 +220,43 @@ function Test-ContainerVersionCompat {
 function Get-ApiKeyEnvArgs {
     <#
     .SYNOPSIS
-        Builds Docker --env flags for any AI API keys found in the environment.
+        Builds Docker '--env-file' args for any AI API keys found in the environment.
+    .DESCRIPTION
+        Writes matching keys to a private, owner-only (0600) temp env-file and
+        returns @('--env-file', <path>). Passing secrets by file keeps them out of
+        the container's argv and `docker inspect` output — unlike `--env KEY=value`,
+        which exposes every value to any local user who can inspect the container
+        or its process list (t/2530 L3).
+
+        Returns @() when no keys are set (no file is written). The caller MUST
+        delete the returned file once `docker` has consumed it — the docker CLI
+        reads --env-file client-side at invocation, so the file can be removed
+        immediately after the `docker` call returns.
     #>
     [CmdletBinding()]
     param()
 
-    $envArgs = @()
+    Set-StrictMode -Version Latest
+
     $keyVars = @('GEMINI_API_KEY', 'ANTHROPIC_API_KEY', 'GROQ_API_KEY', 'AI_API_KEY', 'AI_MODEL')
+    $lines = [System.Collections.Generic.List[string]]::new()
     foreach ($var in $keyVars) {
         $val = [System.Environment]::GetEnvironmentVariable($var)
         if ($val) {
-            $envArgs += '--env'
-            $envArgs += "$var=$val"
+            # docker --env-file format is literal VAR=value, one per line; docker
+            # does not strip quotes, so write the raw value.
+            $lines.Add("$var=$val")
         }
     }
-    return $envArgs
+
+    if ($lines.Count -eq 0) {
+        return @()
+    }
+
+    $envFile = New-SecureTempPath -Prefix 'aitriad-docker-env' -Extension 'env'
+    Write-Utf8NoBom -Path $envFile -Value ($lines -join "`n") -Force
+    # Restrict to the current user before docker reads it.
+    Protect-UserSecretFile -Path $envFile
+
+    return @('--env-file', $envFile)
 }

--- a/scripts/AITriad/Private/Get-PandocHtmlArgs.ps1
+++ b/scripts/AITriad/Private/Get-PandocHtmlArgs.ps1
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-PandocHtmlArgs {
+    <#
+    .SYNOPSIS
+        Builds the pandoc argument list for rendering untrusted Markdown to HTML.
+    .DESCRIPTION
+        Centralises the pandoc invocation so the security-relevant flags are in
+        one testable place. The input Markdown is treated as untrusted, so
+        --sandbox is always passed first: it stops pandoc from reading arbitrary
+        local files the document references (e.g. via image/include paths) while
+        still allowing the explicitly-listed header file (t/2530 L4).
+    .PARAMETER InputPath
+        Path to the source Markdown file.
+    .PARAMETER OutputPath
+        Path for the generated HTML file.
+    .PARAMETER Title
+        Document title (metadata).
+    .PARAMETER HeaderFile
+        Path to an HTML fragment injected via --include-in-header (our own style).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$InputPath,
+        [Parameter(Mandatory)][string]$OutputPath,
+        [Parameter(Mandatory)][string]$Title,
+        [Parameter(Mandatory)][string]$HeaderFile
+    )
+
+    Set-StrictMode -Version Latest
+
+    return @(
+        # --sandbox MUST lead: the markdown is untrusted; block pandoc from
+        # reading arbitrary local files it references (t/2530 L4).
+        '--sandbox'
+        $InputPath
+        '-o', $OutputPath
+        '--standalone'
+        '--embed-resources'
+        '--metadata', "title=$Title"
+        '--include-in-header', $HeaderFile
+    )
+}

--- a/scripts/AITriad/Private/New-SecureTempPath.ps1
+++ b/scripts/AITriad/Private/New-SecureTempPath.ps1
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function New-SecureTempPath {
+    <#
+    .SYNOPSIS
+        Returns an unpredictable temp-file path to defeat symlink/pre-creation attacks.
+    .DESCRIPTION
+        A fixed temp filename (e.g. AITriad-Help.html) lets a local attacker
+        pre-create that path — as a symlink to a sensitive file, for example —
+        so a later write lands on an attacker-chosen target (arbitrary write).
+        This builds a path whose filename carries a cryptographically-random
+        component (via [System.IO.Path]::GetRandomFileName, RNG-backed), so the
+        name cannot be guessed or pre-created ahead of the write.
+
+        Returns the path only; it does not create the file.
+    .PARAMETER Prefix
+        Leading filename token (default 'AITriad').
+    .PARAMETER Extension
+        File extension, with or without a leading dot (default 'tmp').
+    .EXAMPLE
+        $TempPath = New-SecureTempPath -Prefix 'AITriad-Help' -Extension 'html'
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$Prefix = 'AITriad',
+        [string]$Extension = 'tmp'
+    )
+
+    Set-StrictMode -Version Latest
+
+    # GetRandomFileName yields 8 cryptographically-random chars + '.' + 3 more.
+    $rand = [System.IO.Path]::GetRandomFileName().Replace('.', '')
+    $ext  = $Extension.TrimStart('.')
+    $name = "$Prefix-$rand.$ext"
+    return (Join-Path ([System.IO.Path]::GetTempPath()) $name)
+}

--- a/scripts/AITriad/Private/Protect-SensitiveText.ps1
+++ b/scripts/AITriad/Private/Protect-SensitiveText.ps1
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Protect-SensitiveText {
+    <#
+    .SYNOPSIS
+        Redacts secret-looking tokens from text before it is logged.
+    .DESCRIPTION
+        AI API error bodies and exception messages can echo API keys, bearer
+        tokens, or `key=` query parameters straight into warnings and logs.
+        This replaces known secret shapes — and any explicitly-supplied literal
+        secret values — with [REDACTED], then caps the length, so diagnostics
+        never leak credentials.
+    .PARAMETER Text
+        The text to scrub. Null/empty is returned unchanged.
+    .PARAMETER Secret
+        Zero or more literal secret values to redact wherever they appear
+        (e.g. the resolved API key in scope at the call site).
+    .PARAMETER MaxLength
+        Cap the returned length (default 1000). 0 disables the cap.
+    .EXAMPLE
+        Write-Warning "Response body: $(Protect-SensitiveText -Text $ErrBody -Secret $ResolvedKey)"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0, ValueFromPipeline)]
+        [AllowEmptyString()]
+        [AllowNull()]
+        [string]$Text,
+
+        [string[]]$Secret = @(),
+
+        [int]$MaxLength = 1000
+    )
+
+    process {
+        if ([string]::IsNullOrEmpty($Text)) { return $Text }
+
+        $out = $Text
+
+        # 1) Explicit literal secrets first, longest-first so a shorter secret
+        #    that is a substring of a longer one doesn't leave a partial behind.
+        foreach ($s in (@($Secret) | Where-Object { $_ } | Sort-Object { $_.Length } -Descending)) {
+            $out = $out.Replace($s, '[REDACTED]')
+        }
+
+        # 2) Known secret shapes. Token-shaped patterns run BEFORE the header
+        #    key/value pattern: otherwise "Authorization: Bearer <tok>" has only
+        #    "Bearer" eaten as the value, leaving the token behind.
+        $patterns = @(
+            '(?i)\bBearer\s+[A-Za-z0-9._\-]+'
+            'AIza[0-9A-Za-z\-_]{20,}'        # Google API key
+            'sk-[A-Za-z0-9\-_]{16,}'         # OpenAI / Anthropic style
+            'gsk_[A-Za-z0-9]{16,}'           # Groq
+            '(?i)\bkey=[^&\s"'']+'           # ?key= query parameter
+            '(?i)(x-goog-api-key|api[_-]?key|authorization)["'']?\s*[:=]\s*["'']?[^\s"'',&}]+'
+        )
+        foreach ($p in $patterns) {
+            $out = [regex]::Replace($out, $p, '[REDACTED]')
+        }
+
+        if ($MaxLength -gt 0 -and $out.Length -gt $MaxLength) {
+            $out = $out.Substring(0, $MaxLength) + '…[truncated]'
+        }
+
+        return $out
+    }
+}

--- a/scripts/AITriad/Private/Protect-UserSecretFile.ps1
+++ b/scripts/AITriad/Private/Protect-UserSecretFile.ps1
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Protect-UserSecretFile {
+    <#
+    .SYNOPSIS
+        Restricts a file so only the current user can read it (secret at rest).
+    .DESCRIPTION
+        Files that persist API keys or other credentials must not be world- or
+        group-readable. On Unix this applies `chmod 600` (owner read/write only).
+        On Windows it replaces the DACL with a single explicit rule granting the
+        current user FullControl and disables inheritance, so other local
+        accounts cannot read the persisted secret.
+
+        Best-effort: if the platform ACL/chmod call fails, a warning is emitted
+        and the caller continues — hardening failure must not block the write
+        that already happened (prefer recovery over failure).
+    .PARAMETER Path
+        Path to an existing file to lock down.
+    .EXAMPLE
+        Write-Utf8NoBom -Path $envFile -Value $content -Force
+        Protect-UserSecretFile -Path $envFile
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$Path
+    )
+
+    Set-StrictMode -Version Latest
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        Write-Warning "Protect-UserSecretFile: path does not exist — $Path"
+        return
+    }
+
+    try {
+        if ($IsWindows) {
+            $acl = Get-Acl -LiteralPath $Path
+            # Disable inheritance and drop any inherited rules.
+            $acl.SetAccessRuleProtection($true, $false)
+            # Remove every existing explicit rule so only our rule remains.
+            @($acl.Access) | ForEach-Object { [void]$acl.RemoveAccessRule($_) }
+            $me = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+            $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+                $me,
+                [System.Security.AccessControl.FileSystemRights]::FullControl,
+                [System.Security.AccessControl.AccessControlType]::Allow)
+            $acl.AddAccessRule($rule)
+            Set-Acl -LiteralPath $Path -AclObject $acl
+        }
+        else {
+            # macOS / Linux — owner rw, no group/other.
+            & chmod 600 $Path
+            if ($LASTEXITCODE -ne 0) {
+                throw "chmod exited $LASTEXITCODE"
+            }
+        }
+    }
+    catch {
+        Write-Warning "Protect-UserSecretFile: could not restrict permissions on $Path — $($_.Exception.Message). The file may be readable by other local users."
+    }
+}

--- a/scripts/AITriad/Public/Compare-Taxonomy.ps1
+++ b/scripts/AITriad/Public/Compare-Taxonomy.ps1
@@ -367,7 +367,9 @@ $($DiffOnlyHtml.ToString())
     $Html = $Html -replace '{{DIFF_ONLY_SECTION}}', $DiffOnlySection
 
     # ── Write and open ───────────────────────────────────────────────────────
-    $TempPath = Join-Path ([System.IO.Path]::GetTempPath()) 'AITriad-TaxonomyCompare.html'
+    # Unpredictable name — a fixed temp filename lets a local attacker pre-create
+    # the path (e.g. as a symlink) to redirect this write (t/2530 L2).
+    $TempPath = New-SecureTempPath -Prefix 'AITriad-TaxonomyCompare' -Extension 'html'
     Set-Content -Path $TempPath -Value $Html -Encoding utf8
     Write-OK "Report written to $TempPath"
 

--- a/scripts/AITriad/Public/Register-AIBackend.ps1
+++ b/scripts/AITriad/Public/Register-AIBackend.ps1
@@ -616,8 +616,9 @@ init();
                             try {
                                 switch ($TestBackend) {
                                     'gemini' {
-                                        $Uri = "https://generativelanguage.googleapis.com/v1beta/models?key=$TestKey"
-                                        $R = Invoke-RestMethod -Uri $Uri -Method Get -TimeoutSec 10 -ErrorAction Stop
+                                        # Key in x-goog-api-key header, not ?key= URL (t/2530 L1).
+                                        $Uri = 'https://generativelanguage.googleapis.com/v1beta/models'
+                                        $R = Invoke-RestMethod -Uri $Uri -Method Get -Headers @{ 'x-goog-api-key' = $TestKey } -TimeoutSec 10 -ErrorAction Stop
                                         $TestResult = @{ ok = $true; message = "Valid — $(@($R.models).Count) models available" }
                                     }
                                     'anthropic' {
@@ -771,6 +772,8 @@ init();
                             $EnvLines.Add('# powershell_section_end')
 
                             Write-Utf8NoBom -Path $EnvFilePath -Value ($EnvLines -join "`n")  -Force
+                            # Persisted keys are secrets — restrict to the current user (t/2530 M1).
+                            Protect-UserSecretFile -Path $EnvFilePath
 
                             if ($Changes.Count -gt 0) {
                                 $SaveResult.message = "Saved: $($Changes -join ', '). Persisted to $EnvFilePath"

--- a/scripts/AITriad/Public/Show-AITriadHelp.ps1
+++ b/scripts/AITriad/Public/Show-AITriadHelp.ps1
@@ -751,9 +751,9 @@ function Show-AITriadHelp {
     $Html = $Html.Replace('{{COUNT}}',     [string]$CmdletCount)
     $Html = $Html.Replace('{{CATCOUNT}}',  [string]$CategoryCount)
 
-    # Write to temp directory with a fixed filename
-    $TempDir  = [System.IO.Path]::GetTempPath()
-    $TempPath = Join-Path $TempDir 'AITriad-Help.html'
+    # Unpredictable name — a fixed temp filename lets a local attacker pre-create
+    # the path (e.g. as a symlink) to redirect this write (t/2530 L2).
+    $TempPath = New-SecureTempPath -Prefix 'AITriad-Help' -Extension 'html'
     Set-Content -Path $TempPath -Value $Html -Encoding utf8
 
     if ($PassThru) {

--- a/scripts/AITriad/Public/Show-Markdown.ps1
+++ b/scripts/AITriad/Public/Show-Markdown.ps1
@@ -186,14 +186,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         continue
                     }
 
-                    $PandocArgs = @(
-                        $FilePath
-                        '-o', $TempHtml
-                        '--standalone'
-                        '--embed-resources'
-                        '--metadata', "title=$Title"
-                        '--include-in-header', $StyleFile
-                    )
+                    $PandocArgs = Get-PandocHtmlArgs -InputPath $FilePath -OutputPath $TempHtml -Title $Title -HeaderFile $StyleFile
 
                     $PandocErrors = @()
                     & $PandocPath @PandocArgs 2>&1 | ForEach-Object {

--- a/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
+++ b/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
@@ -547,7 +547,15 @@ function Start-ContainerMode {
     }
 
     # ── Build docker run arguments ────────────────────────────────────────
+    # Get-ApiKeyEnvArgs writes keys to a 0600 temp env-file and returns
+    # @('--env-file', <path>) — we delete that file once docker has read it (t/2530 L3).
     $envArgs = Get-ApiKeyEnvArgs
+    $envFilePath = if ($envArgs.Count -ge 2 -and $envArgs[0] -eq '--env-file') { $envArgs[1] } else { $null }
+    $removeEnvFile = {
+        if ($envFilePath -and (Test-Path -LiteralPath $envFilePath)) {
+            Remove-Item -LiteralPath $envFilePath -Force -ErrorAction SilentlyContinue
+        }
+    }
 
     # UID/GID for bind mount and tmpfs ownership
     $uid = $null
@@ -594,6 +602,7 @@ function Start-ContainerMode {
     if ($Detach) {
         Write-Step 'Starting Taxonomy Editor (detached)'
         $dockerOutput = docker @runArgs 2>&1
+        & $removeEnvFile   # docker has read --env-file; remove the secret now
         if ($LASTEXITCODE -ne 0) {
             $errorText = ($dockerOutput | Out-String).Trim()
             Write-Fail "Failed to start container (exit code $LASTEXITCODE)."
@@ -642,6 +651,7 @@ function Start-ContainerMode {
         $fgArgs = @($fgArgs[0..($fgArgs.Count - 2)]) + @('-d') + @($fgArgs[-1])
 
         $dockerOutput = docker @fgArgs 2>&1
+        & $removeEnvFile   # docker has read --env-file; remove the secret now
         if ($LASTEXITCODE -ne 0) {
             $errorText = ($dockerOutput | Out-String).Trim()
             Write-Fail "Failed to start container (exit code $LASTEXITCODE)."

--- a/tests/GeminiKeyInHeader.Tests.ps1
+++ b/tests/GeminiKeyInHeader.Tests.ps1
@@ -1,0 +1,49 @@
+# Tag: enrichment (t/2530)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    L1 regression (t/2530): the Gemini API key must travel in the x-goog-api-key
+    header, never as a ?key= URL query parameter (which leaks via proxy logs and
+    PS5.1 error-record URIs). Covers both PowerShell Gemini call sites in
+    AIEnrich.psm1 — Invoke-AIApi generateContent and Measure-PromptTokens
+    countTokens. Keyless (HTTP fully mocked) — always runs.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AIEnrich.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Gemini key in x-goog-api-key header, not ?key= URL (t/2530 L1)' -Tag 'enrichment' {
+
+    It 'Invoke-AIApi (generateContent): no key= in URL, key in header' {
+        $mockResponse = [PSCustomObject]@{
+            candidates    = @([PSCustomObject]@{
+                finishReason = 'STOP'
+                content      = [PSCustomObject]@{ parts = @([PSCustomObject]@{ text = 'ok' }) }
+            })
+            usageMetadata = [PSCustomObject]@{ promptTokenCount = 1; candidatesTokenCount = 1; totalTokenCount = 2 }
+        }
+        Mock Invoke-RestMethod { $mockResponse } -ModuleName AIEnrich
+
+        $null = Invoke-AIApi -Prompt 'test' -Model 'gemini-3.5-flash-lite' -ApiKey 'fake-key-123' 3>$null
+
+        Should -Invoke Invoke-RestMethod -ModuleName AIEnrich -Times 1 -Exactly -ParameterFilter {
+            $Uri -notmatch 'key=' -and $Headers['x-goog-api-key'] -eq 'fake-key-123'
+        }
+    }
+
+    It 'Measure-PromptTokens (countTokens): no key= in URL, key in header' {
+        Mock Invoke-RestMethod { [PSCustomObject]@{ totalTokens = 5 } } -ModuleName AIEnrich
+
+        $null = Measure-PromptTokens -Text 'hello world' -ApiKey 'fake-key-123'
+
+        Should -Invoke Invoke-RestMethod -ModuleName AIEnrich -Times 1 -Exactly -ParameterFilter {
+            $Uri -notmatch 'key=' -and $Headers['x-goog-api-key'] -eq 'fake-key-123'
+        }
+    }
+}

--- a/tests/Get-ApiKeyEnvArgs.EnvFile.Tests.ps1
+++ b/tests/Get-ApiKeyEnvArgs.EnvFile.Tests.ps1
@@ -1,0 +1,71 @@
+# Tag: unit (t/2530)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    L3 regression (t/2530): Get-ApiKeyEnvArgs passes AI keys to Docker via a
+    private 0600 --env-file, never as `--env KEY=value` argv (which leaks values
+    into `docker inspect` / the process list). Pure PS, keyless — always runs.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    $script:KeyVars = @('GEMINI_API_KEY', 'ANTHROPIC_API_KEY', 'GROQ_API_KEY', 'AI_API_KEY', 'AI_MODEL')
+    $script:SavedKeyVars = @{}
+    foreach ($v in $script:KeyVars) {
+        $script:SavedKeyVars[$v] = [Environment]::GetEnvironmentVariable($v)
+        [Environment]::SetEnvironmentVariable($v, $null)
+    }
+}
+
+AfterAll {
+    foreach ($v in $script:KeyVars) {
+        [Environment]::SetEnvironmentVariable($v, $script:SavedKeyVars[$v])
+    }
+}
+
+Describe 'Get-ApiKeyEnvArgs env-file (t/2530 L3)' -Tag 'unit' {
+
+    AfterEach {
+        foreach ($v in $script:KeyVars) { [Environment]::SetEnvironmentVariable($v, $null) }
+    }
+
+    It 'returns @() and writes no file when no keys are set' {
+        InModuleScope AITriad {
+            $result = @(Get-ApiKeyEnvArgs)
+            $result.Count | Should -Be 0
+        }
+    }
+
+    It 'returns --env-file (not --env) and keeps the secret out of argv' {
+        [Environment]::SetEnvironmentVariable('GEMINI_API_KEY', 'gemini-secret-xyz')
+        InModuleScope AITriad {
+            $result = @(Get-ApiKeyEnvArgs)
+            try {
+                $result[0] | Should -Be '--env-file'
+                $result.Count | Should -Be 2
+                # No --env style flag, and the raw secret never appears in argv.
+                ($result -contains '--env') | Should -BeFalse
+                ($result -join ' ') | Should -Not -Match 'gemini-secret-xyz'
+
+                $envFile = $result[1]
+                Test-Path -LiteralPath $envFile | Should -BeTrue
+                (Get-Content -Raw -LiteralPath $envFile) | Should -Match 'GEMINI_API_KEY=gemini-secret-xyz'
+
+                if (-not $IsWindows) {
+                    (Get-Item -LiteralPath $envFile).UnixMode | Should -Be '-rw-------'
+                }
+            }
+            finally {
+                if ($result.Count -ge 2 -and (Test-Path -LiteralPath $result[1])) {
+                    Remove-Item -LiteralPath $result[1] -Force
+                }
+            }
+        }
+    }
+}

--- a/tests/Get-PandocHtmlArgs.Tests.ps1
+++ b/tests/Get-PandocHtmlArgs.Tests.ps1
@@ -1,0 +1,43 @@
+# Tag: unit (t/2530)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    L4 regression (t/2530): Get-PandocHtmlArgs (used by Show-Markdown) must pass
+    --sandbox so pandoc cannot read arbitrary local files referenced by untrusted
+    Markdown. Pure PS, keyless — always runs.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-PandocHtmlArgs (t/2530 L4)' -Tag 'unit' {
+
+    It 'includes --sandbox' {
+        InModuleScope AITriad {
+            $pandocArgs = Get-PandocHtmlArgs -InputPath 'in.md' -OutputPath 'out.html' -Title 'T' -HeaderFile 'h.html'
+            $pandocArgs | Should -Contain '--sandbox'
+        }
+    }
+
+    It 'places --sandbox before the input path so it applies to the conversion' {
+        InModuleScope AITriad {
+            $pandocArgs = Get-PandocHtmlArgs -InputPath 'in.md' -OutputPath 'out.html' -Title 'T' -HeaderFile 'h.html'
+            [array]::IndexOf($pandocArgs, '--sandbox') | Should -BeLessThan ([array]::IndexOf($pandocArgs, 'in.md'))
+        }
+    }
+
+    It 'still wires the output, header, and title through' {
+        InModuleScope AITriad {
+            $pandocArgs = Get-PandocHtmlArgs -InputPath 'in.md' -OutputPath 'out.html' -Title 'My Title' -HeaderFile 'h.html'
+            $pandocArgs | Should -Contain 'out.html'
+            $pandocArgs | Should -Contain 'h.html'
+            $pandocArgs | Should -Contain 'title=My Title'
+        }
+    }
+}

--- a/tests/New-SecureTempPath.Tests.ps1
+++ b/tests/New-SecureTempPath.Tests.ps1
@@ -1,0 +1,50 @@
+# Tag: unit (t/2530)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    L2 regression (t/2530): New-SecureTempPath returns an unpredictable temp path
+    (no fixed filename) so a local attacker cannot pre-create the path as a
+    symlink to redirect a later write. Pure PS, keyless — always runs.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'New-SecureTempPath (t/2530 L2)' -Tag 'unit' {
+
+    It 'returns a path under the temp directory with the given prefix and extension' {
+        InModuleScope AITriad {
+            $tempRoot = [System.IO.Path]::GetTempPath()
+            $p = New-SecureTempPath -Prefix 'AITriad-Help' -Extension 'html'
+            $p | Should -BeLike (Join-Path $tempRoot 'AITriad-Help-*')
+            [System.IO.Path]::GetExtension($p) | Should -Be '.html'
+        }
+    }
+
+    It 'never returns the old fixed filenames' {
+        InModuleScope AITriad {
+            (Split-Path -Leaf (New-SecureTempPath -Prefix 'AITriad-Help' -Extension 'html')) | Should -Not -Be 'AITriad-Help.html'
+            (Split-Path -Leaf (New-SecureTempPath -Prefix 'AITriad-TaxonomyCompare' -Extension 'html')) | Should -Not -Be 'AITriad-TaxonomyCompare.html'
+        }
+    }
+
+    It 'produces a different path on each call (unguessable random component)' {
+        InModuleScope AITriad {
+            $a = New-SecureTempPath -Prefix 'x' -Extension 'tmp'
+            $b = New-SecureTempPath -Prefix 'x' -Extension 'tmp'
+            $a | Should -Not -Be $b
+        }
+    }
+
+    It 'tolerates an extension with a leading dot' {
+        InModuleScope AITriad {
+            [System.IO.Path]::GetExtension((New-SecureTempPath -Extension '.env')) | Should -Be '.env'
+        }
+    }
+}

--- a/tests/Protect-SensitiveText.Tests.ps1
+++ b/tests/Protect-SensitiveText.Tests.ps1
@@ -1,0 +1,65 @@
+# Tag: unit (t/2530)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    L14 regression (t/2530): Protect-SensitiveText scrubs API keys / tokens from
+    text (AI error bodies + exception messages) before it is logged. Pure PS,
+    keyless — always runs.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Protect-SensitiveText (t/2530 L14)' -Tag 'unit' {
+
+    It 'redacts an explicitly-supplied literal secret' {
+        InModuleScope AITriad {
+            $out = Protect-SensitiveText -Text 'the key was sekret-value-abc in the body' -Secret 'sekret-value-abc'
+            $out | Should -Not -Match 'sekret-value-abc'
+            $out | Should -Match '\[REDACTED\]'
+        }
+    }
+
+    It 'redacts a ?key= query parameter' {
+        InModuleScope AITriad {
+            (Protect-SensitiveText -Text 'GET https://api/models?key=AIzaSyABCDEF123456') | Should -Not -Match 'AIzaSy'
+        }
+    }
+
+    It 'redacts a Google AIza key, a Bearer token, sk-, and gsk_ tokens' {
+        InModuleScope AITriad {
+            (Protect-SensitiveText -Text 'AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456') | Should -Not -Match 'AIzaSyABCDEF'
+            (Protect-SensitiveText -Text 'Authorization: Bearer abc.def.ghijklmnop') | Should -Not -Match 'abc\.def\.ghijklmnop'
+            (Protect-SensitiveText -Text 'sk-ant-api03-AAAAAAAAAAAAAAAA') | Should -Not -Match 'sk-ant-api03-A'
+            (Protect-SensitiveText -Text 'gsk_ABCDEFGHIJKLMNOPQRST') | Should -Not -Match 'gsk_ABCDEFGH'
+        }
+    }
+
+    It 'returns null/empty input unchanged' {
+        InModuleScope AITriad {
+            (Protect-SensitiveText -Text '') | Should -Be ''
+            (Protect-SensitiveText -Text $null) | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'truncates output past MaxLength' {
+        InModuleScope AITriad {
+            $long = 'a' * 2000
+            $out = Protect-SensitiveText -Text $long -MaxLength 100
+            $out.Length | Should -BeLessThan 200
+            $out | Should -Match 'truncated'
+        }
+    }
+
+    It 'leaves benign text intact' {
+        InModuleScope AITriad {
+            (Protect-SensitiveText -Text 'model overloaded, please retry') | Should -Be 'model overloaded, please retry'
+        }
+    }
+}

--- a/tests/Protect-UserSecretFile.Tests.ps1
+++ b/tests/Protect-UserSecretFile.Tests.ps1
@@ -1,0 +1,51 @@
+# Tag: unit (t/2530)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    M1 regression (t/2530): Protect-UserSecretFile restricts a secret file to the
+    current user (chmod 600 on Unix; inheritance-off, owner-only DACL on Windows).
+    Pure PS, keyless — always runs.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Protect-UserSecretFile (t/2530 M1)' -Tag 'unit' {
+
+    It 'restricts a file to the current user only' {
+        InModuleScope AITriad {
+            $f = Join-Path $TestDrive 'secret.env'
+            Set-Content -LiteralPath $f -Value 'GEMINI_API_KEY=abc' -Encoding utf8
+
+            Protect-UserSecretFile -Path $f
+
+            if ($IsWindows) {
+                $acl = Get-Acl -LiteralPath $f
+                # Inheritance disabled and no non-owner accounts retained.
+                $acl.AreAccessRulesProtected | Should -BeTrue
+                $me = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+                foreach ($rule in $acl.Access) {
+                    $sid = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
+                    $sid | Should -Be $me
+                }
+            }
+            else {
+                # -rw------- : owner read/write, nothing for group/other.
+                (Get-Item -LiteralPath $f).UnixMode | Should -Be '-rw-------'
+            }
+        }
+    }
+
+    It 'does not throw when the target is missing (best-effort warn)' {
+        InModuleScope AITriad {
+            $missing = Join-Path $TestDrive 'nope.env'
+            { Protect-UserSecretFile -Path $missing -WarningAction SilentlyContinue } | Should -Not -Throw
+        }
+    }
+}


### PR DESCRIPTION
Closes the PowerShell half of security tracker **t/2525** (t/2530). **M2** (Neo4j password fallback) landed separately in #915; this PR is the other six findings, coordinated with Main via p/191.

Each fix ships a Pester regression test (19 new, all green; existing AIEnrich + module suites unaffected).

| ID | Fix | Files |
|----|-----|-------|
| **M1** | `~/.aitriad-env` restricted to current user (chmod 600 / owner-only DACL) | `Register-AIBackend.ps1` + new `Private/Protect-UserSecretFile.ps1` |
| **L1** | Gemini key → `x-goog-api-key` header (was `?key=` URL) | `AIEnrich.psm1` (generateContent + countTokens), `Register-AIBackend.ps1` (test call) |
| **L2** | Unpredictable temp filenames (symlink pre-creation → arbitrary write) | `Compare-Taxonomy.ps1`, `Show-AITriadHelp.ps1` + new `Private/New-SecureTempPath.ps1` |
| **L3** | Docker keys via 0600 `--env-file`, not `--env KEY=value` argv | `Private/Docker-Helpers.ps1` (`Get-ApiKeyEnvArgs`) + `Show-TaxonomyEditor.ps1` cleanup |
| **L4** | pandoc `--sandbox` on untrusted markdown | `Show-Markdown.ps1` + new `Private/Get-PandocHtmlArgs.ps1` |
| **L14** | Scrub key/token shapes from AI error bodies + exception messages before logging | `AIEnrich.psm1` + new `Private/Protect-SensitiveText.ps1` |

Notes:
- All new helpers are **Private** (no manifest export). `Test-ModuleManifest` passes.
- L1 also fixes the same-class leak in `Register-AIBackend`'s Gemini test call (line 619), beyond the two AIEnrich sites named in the ticket.
- L4 sandbox blocks pandoc from reading arbitrary local files a malicious doc references; the explicit `--include-in-header` style file is still honoured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)