### PR TITLE
chore(build): explicit !**/.orca/** exclude in electron-builder files (t/2543)

### DIFF
--- a/taxonomy-editor/electron-builder.yml
+++ b/taxonomy-editor/electron-builder.yml
@@ -9,6 +9,11 @@ directories:
 files:
   - dist/**/*
   - "!dist/**/*.map"
+  # Belt-and-suspenders: never bundle Orca overlay artifacts (.orca/activity/
+  # activity-hook.js et al.). Already safe by construction — files: only pulls
+  # dist/**/*, and .orca/ lives in src/ and is never imported into dist/ — but
+  # this makes the exclusion explicit and auditable. (t/2543, sec L7)
+  - "!**/.orca/**"
   - node_modules/**/*
   - package.json
 


### PR DESCRIPTION
Part 2 of t/2543 (security tracker L7, parent t/2525). Coordinated for Orca Support; TL-approved in t/2543#2.

## Change
Add an explicit `!**/.orca/**` exclude to `taxonomy-editor/electron-builder.yml` `files:`. Already safe by construction (`files:` pulls only `dist/**/*`; `.orca/` lives in `src/` and never lands in `dist/`), but the explicit belt-and-suspenders exclude makes the intent auditable.

## Artifact verification (not just config — TL note t/2543#2)
Packaged a fresh `app.asar` via `electron-builder --dir`:
- `asar list` → **18,002 entries**
- `grep -i orca` → **empty** (no matches)
- `grep -i activity-hook` → **empty** (no matches)

No `.orca/` content in the bundle, confirmed against the built artifact.

Build notes (environment, not the change): the local agent couldn't do the node-pty native rebuild (winpty/node-gyp toolchain) nor download the Electron dist (socket hang up), so packaging used `-c.npmRebuild=false` and `-c.electronDist=<cached dist>` — neither affects electron-builder's file selection, so the asar contents are faithful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)