### PR TITLE
fix(persistence): scale atomicWriteSync retry budget with payload size + io.lock-holder (t/2546, t/2544)

### DIFF
--- a/lib/debate/__tests__/persistenceRetryBudget.test.ts
+++ b/lib/debate/__tests__/persistenceRetryBudget.test.ts
@@ -11,7 +11,10 @@ import { makeStorageError } from './faultInjection.js';
 import { setGlobalRecorder, clearGlobalRecorder, type FlightRecorder } from '../../flight-recorder/index.js';
 import type { RecordInput } from '../../flight-recorder/types.js';
 
-vi.mock('child_process', () => ({ execSync: vi.fn() }));
+vi.mock('child_process', () => {
+  const execSync = vi.fn();
+  return { default: { execSync }, execSync };
+});
 
 import { execSync } from 'child_process';
 import { atomicWriteSync, renameSyncWithRetry } from '../persistence.js';

--- a/lib/debate/__tests__/persistenceRetryBudget.test.ts
+++ b/lib/debate/__tests__/persistenceRetryBudget.test.ts
@@ -1,0 +1,245 @@
+// Fault injection tests for atomicWriteSync retry budget scaling (t/2546)
+// and io.lock-holder FR event on exhaustion (t/2544).
+//
+// Uses vi.mock('child_process') to intercept execSync calls in queryLockHolder.
+
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { makeStorageError } from './faultInjection.js';
+import { setGlobalRecorder, clearGlobalRecorder, type FlightRecorder } from '../../flight-recorder/index.js';
+import type { RecordInput } from '../../flight-recorder/types.js';
+
+vi.mock('child_process', () => ({ execSync: vi.fn() }));
+
+import { execSync } from 'child_process';
+import { atomicWriteSync, renameSyncWithRetry } from '../persistence.js';
+
+const mockExecSync = vi.mocked(execSync);
+
+// ── Hermetic isolation ────────────────────────────────────
+beforeAll(() => {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('[test] network blocked')));
+});
+afterAll(() => { vi.unstubAllGlobals(); });
+
+// ── Helpers ───────────────────────────────────────────────
+
+function tmpPath(suffix: string): string {
+  return path.join(os.tmpdir(), `retry-budget-${Date.now()}-${suffix}`);
+}
+
+function cleanup(...paths: string[]): void {
+  for (const p of paths) {
+    try { fs.unlinkSync(p); } catch { /* ignore */ }
+    try { fs.unlinkSync(`${p}.tmp`); } catch { /* ignore */ }
+    try { fs.unlinkSync(`${p}.tmp2`); } catch { /* ignore */ }
+  }
+}
+
+function installCaptureRecorder(): RecordInput[] {
+  const captured: RecordInput[] = [];
+  const fake = { record: (e: RecordInput) => { captured.push(e); } } as unknown as FlightRecorder;
+  setGlobalRecorder(fake);
+  return captured;
+}
+
+afterEach(() => { vi.restoreAllMocks(); mockExecSync.mockClear(); clearGlobalRecorder(); });
+
+// ── t/2546: wall-clock budget scales with payload size ───
+
+describe('renameSyncWithRetry — wall-clock budget (t/2546)', () => {
+  it('wall-clock budget: continues past 7-attempt limit while deadline not reached', () => {
+    // Atomics.wait mocked → no real sleep, Date.now frozen → deadline never expires
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+    vi.spyOn(Date, 'now').mockReturnValue(0); // deadline = 30000, 0 < 30000 always true
+
+    let callCount = 0;
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      callCount++;
+      if (callCount <= 15) throw makeStorageError('EPERM', 'operation not permitted');
+      // 16th call succeeds (void return from mock = success)
+    });
+
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 7, 30_000)).not.toThrow();
+    // 15 failures then 1 success — well past the 8-attempt fixed-budget limit
+    expect(callCount).toBe(16);
+  });
+
+  it('fixed budget (no wall-clock): fails after 8 attempts regardless of lock duration', () => {
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+
+    let callCount = 0;
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      callCount++;
+      throw makeStorageError('EPERM', 'operation not permitted');
+    });
+
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 7)).toThrow('EPERM');
+    // i=0..7: retries when i<7, throws on i=7 → 8 total attempts
+    expect(callCount).toBe(8);
+  });
+
+  it('wall-clock deadline exceeded: single attempt then throws (budget=0ms)', () => {
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+    // deadline = Date.now()(call 1=0) + 30000 = 30000
+    // budget check = Date.now()(call 2=31000) < 30000 → false immediately
+    let nowCall = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => { nowCall++; return nowCall === 1 ? 0 : 31_000; });
+
+    const captured = installCaptureRecorder();
+    let callCount = 0;
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      callCount++;
+      throw makeStorageError('EPERM', 'operation not permitted');
+    });
+
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 7, 30_000)).toThrow('EPERM');
+    // Budget exhausted after 1 attempt (first Date.now check sees 31000 > 30000)
+    expect(callCount).toBe(1);
+    // io.lock-holder emitted on budget exhaustion
+    expect(captured.some(e => e.type === 'io.lock-holder')).toBe(true);
+  });
+
+  it('atomicWriteSync large payload (>200KB): scales to wall-clock budget end-to-end', () => {
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+    // Date.now always returns 0 → 0 < 30000 always true → wall-clock never expires
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+
+    const target = tmpPath('large-e2e.json');
+    const content = 'x'.repeat(210 * 1024); // 210KB > 200KB threshold
+
+    let callCount = 0;
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      callCount++;
+      if (callCount <= 10) throw makeStorageError('EPERM', 'operation not permitted');
+      // Succeed on call 11 (void = success)
+    });
+
+    expect(() => atomicWriteSync(target, content)).not.toThrow();
+    // More than 8 calls confirms wall-clock path (fixed budget would fail at 8)
+    expect(callCount).toBeGreaterThan(8);
+    cleanup(target);
+  });
+
+  it('atomicWriteSync small payload (≤200KB): uses fixed 7-retry budget', () => {
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+
+    const target = tmpPath('small-e2e.json');
+    let caught: unknown;
+
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw makeStorageError('EPERM', 'operation not permitted');
+    });
+
+    try { atomicWriteSync(target, '{"small":true}'); } catch (e) { caught = e; }
+
+    // Small file → fixed budget → eventually throws ActionableError (both rename paths exhausted)
+    expect(caught).toBeDefined();
+    cleanup(target);
+  });
+
+  it('io.retry FR events emitted with attempt count on large-payload retry', () => {
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+
+    const captured = installCaptureRecorder();
+    let callCount = 0;
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      callCount++;
+      if (callCount <= 3) throw makeStorageError('EPERM', 'operation not permitted');
+    });
+
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 7, 30_000)).not.toThrow();
+    const retries = captured.filter(e => e.type === 'io.retry');
+    expect(retries).toHaveLength(3);
+    expect(retries[0].data).toMatchObject({ attempt: 1, code: 'EPERM' });
+    expect(retries[2].data).toMatchObject({ attempt: 3, code: 'EPERM' });
+  });
+});
+
+// ── t/2544: io.lock-holder FR event on exhaustion ────────
+
+describe('renameSyncWithRetry — io.lock-holder event (t/2544)', () => {
+  it('emits io.lock-holder with processName and pid when handle.exe succeeds', () => {
+    // Simulate Windows platform for queryLockHolder
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecSync.mockReturnValue(
+      'Defender.exe  pid: 1234  type: File  8C: C:\\data\\debates\\debate-abc.json\n' as unknown as Buffer,
+    );
+
+    const captured = installCaptureRecorder();
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw makeStorageError('EPERM', 'operation not permitted');
+    });
+
+    // maxRetries=0 → i=0, withinBudget=0<0=false → budget exhausted immediately
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0)).toThrow('EPERM');
+
+    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
+    expect(lockEvents).toHaveLength(1);
+    expect(lockEvents[0].data).toMatchObject({ processName: 'Defender.exe', pid: 1234 });
+    expect(lockEvents[0].data).not.toHaveProperty('unavailable');
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('emits io.lock-holder with unavailable:true when handle.exe absent', () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT: handle.exe not found'), { code: 'ENOENT' });
+    });
+
+    const captured = installCaptureRecorder();
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw makeStorageError('EPERM', 'operation not permitted');
+    });
+
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0)).toThrow('EPERM');
+
+    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
+    expect(lockEvents).toHaveLength(1);
+    expect(lockEvents[0].data).toMatchObject({ unavailable: true });
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('emits io.lock-holder with unavailable:true on non-Windows', () => {
+    const origPlatform = process.platform;
+    // Ensure non-Windows platform
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    const captured = installCaptureRecorder();
+    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw makeStorageError('EPERM', 'operation not permitted');
+    });
+
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0)).toThrow('EPERM');
+
+    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
+    expect(lockEvents).toHaveLength(1);
+    expect(lockEvents[0].data).toMatchObject({ unavailable: true, reason: 'non-Windows' });
+    // execSync never called on non-Windows
+    expect(mockExecSync).not.toHaveBeenCalled();
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('does NOT emit io.lock-holder on non-transient errors (EXDEV)', () => {
+    const captured = installCaptureRecorder();
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw makeStorageError('EXDEV', 'cross-device link not permitted');
+    });
+
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0)).toThrow('EXDEV');
+    expect(captured.some(e => e.type === 'io.lock-holder')).toBe(false);
+  });
+});

--- a/lib/debate/persistence.ts
+++ b/lib/debate/persistence.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import fs from 'fs';
+import { execSync } from 'child_process';
 import { getGlobalRecorder } from '../flight-recorder/index.js';
 import { ActionableError } from './errors.js';
 
@@ -38,27 +39,63 @@ export function safeSerialize(value: unknown, indent: number = 2): { json: strin
   }
 }
 
+// t/2544: identify the process holding a file lock (Windows only, requires handle.exe on PATH).
+function queryLockHolder(filePath: string): { processName?: string; pid?: number; unavailable?: boolean; reason?: string } {
+  if (process.platform !== 'win32') return { unavailable: true, reason: 'non-Windows' };
+  try {
+    const output = execSync(`handle.exe "${filePath}"`, { timeout: 2000, encoding: 'utf-8' });
+    // handle.exe output: "<ProcessName>  pid: <pid>  type: File  <handle>: <path>"
+    const match = output.match(/^(\S+)\s+pid:\s+(\d+)\s/m);
+    if (match) return { processName: match[1], pid: parseInt(match[2], 10) };
+    return { unavailable: true, reason: 'handle.exe output not parseable' };
+  } catch {
+    return { unavailable: true, reason: 'handle.exe not on PATH or timed out' };
+  }
+}
+
 /**
  * Rename with exponential-backoff retry for transient Windows file locks.
  * EPERM / EACCES on rename are almost always caused by antivirus, search
  * indexer, or another process briefly holding the target file open.
+ *
+ * When maxWallClockMs is provided (large payloads >200KB), retries continue
+ * until the wall-clock cap is hit rather than a fixed attempt count — AV scan
+ * time grows with file size, so a fixed attempt budget starves large files.
+ * Small files use the default maxRetries=7 (~6.35s total) unchanged.
+ *
+ * On budget exhaustion, emits io.lock-holder FR event naming the lock holder
+ * (via handle.exe if on PATH; unavailable:true otherwise) before rethrowing.
  */
-export function renameSyncWithRetry(oldPath: string, newPath: string, maxRetries = 7): void {
-  for (let i = 0; i <= maxRetries; i++) {
+export function renameSyncWithRetry(oldPath: string, newPath: string, maxRetries = 7, maxWallClockMs?: number): void {
+  const deadline = maxWallClockMs !== undefined ? Date.now() + maxWallClockMs : undefined;
+  for (let i = 0; ; i++) {
     try {
       fs.renameSync(oldPath, newPath);
       return;
     } catch (err: unknown) {
       const code = (err as NodeJS.ErrnoException).code;
-      if ((code === 'EPERM' || code === 'EACCES') && i < maxRetries) {
-        const delayMs = 50 * Math.pow(2, i);
+      const isTransient = code === 'EPERM' || code === 'EACCES';
+      const withinBudget = deadline !== undefined ? Date.now() < deadline : i < maxRetries;
+      if (isTransient && withinBudget) {
+        const delayMs = Math.min(50 * Math.pow(2, i), 5_000);
         getGlobalRecorder()?.record({
           type: 'io.retry', component: 'persistence', level: 'warn',
-          message: `renameSyncWithRetry failed (${code}), retry ${i + 1}/${maxRetries} after ${delayMs}ms`,
+          message: `renameSyncWithRetry failed (${code}), retry ${i + 1} after ${delayMs}ms`,
           data: { oldPath, newPath, attempt: i + 1, code, delayMs },
         });
         Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
         continue;
+      }
+      // t/2544: budget exhausted on a transient error — identify the lock holder before rethrowing.
+      if (isTransient) {
+        const lockHolder = queryLockHolder(newPath);
+        getGlobalRecorder()?.record({
+          type: 'io.lock-holder', component: 'persistence', level: 'warn',
+          message: lockHolder.unavailable
+            ? `io.lock-holder: unavailable (${lockHolder.reason})`
+            : `io.lock-holder: ${lockHolder.processName} pid ${lockHolder.pid}`,
+          data: { filePath: newPath, ...lockHolder },
+        });
       }
       throw err;
     }
@@ -102,18 +139,19 @@ export async function renameWithRetry(oldPath: string, newPath: string, maxRetri
  * as the sole durable copy of the write, and the failure is surfaced as an
  * ActionableError — never a silent loss of the payload.
  *
- * The retry budget is deliberately bounded by attempt count, not wall-clock:
- * the sync retry sleeps via Atomics.wait, which blocks the Electron main
- * thread, so more retries deepen the UI freeze without buying durability.
- * Durability beyond the retry window comes from the copy fallback and the
- * preserved artifact + a later re-persist, not from waiting longer here.
+ * Retry budget scales with payload size (t/2546): files >200KB get a 30s
+ * wall-clock cap instead of the 7-attempt (~6.35s) small-file budget, since
+ * AV scan time grows with file size. Small-file fast-fail behavior is unchanged.
  */
 export function atomicWriteSync(filePath: string, content: string): void {
   // codeql[js/insecure-temporary-file] FP: same-directory atomic write via rename, not an os.tmpdir() temp file
   const tmpPath = `${filePath}.tmp`;
   fs.writeFileSync(tmpPath, content, 'utf-8');
+  // t/2546: scale retry budget with payload size — AV scan time grows with file size.
+  const bytes = Buffer.byteLength(content, 'utf-8');
+  const wallClockCapMs = bytes > 200 * 1024 ? 30_000 : undefined;
   try {
-    renameSyncWithRetry(tmpPath, filePath);
+    renameSyncWithRetry(tmpPath, filePath, 7, wallClockCapMs);
     return;
   } catch (renameErr) {
     const renameCode = (renameErr as NodeJS.ErrnoException).code;
@@ -140,7 +178,7 @@ export function atomicWriteSync(filePath: string, content: string): void {
     try {
       fs.writeFileSync(tmp2Path, content, 'utf-8');
       // writeFileSync closes the handle on return, flushing OS write buffers.
-      renameSyncWithRetry(tmp2Path, filePath);
+      renameSyncWithRetry(tmp2Path, filePath, 7, wallClockCapMs);
       // .tmp2 rename succeeded — clean up the original .tmp (best-effort)
       try { fs.unlinkSync(tmpPath); } catch { /* best-effort */ }
       getGlobalRecorder()?.record({
@@ -160,7 +198,6 @@ export function atomicWriteSync(filePath: string, content: string): void {
       // The loader enumerates *.json only, so lingering .tmp/.tmp2 files are
       // invisible to it and cannot be mistaken for sessions (persistenceFaults.test).
       try { fs.unlinkSync(tmp2Path); } catch { /* best-effort */ }
-      const bytes = Buffer.byteLength(content, 'utf-8');
       const firstRenameCode = (renameErr as NodeJS.ErrnoException).code;
       const tmp2Code = (tmp2Err as NodeJS.ErrnoException).code;
       getGlobalRecorder()?.record({

--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -108,8 +108,9 @@ export type EventType =
   | 'storage.fallback'
   | 'flight-recorder.dump.written' // t/1352: dump persisted — records which backend received it
   | 'io.retry'
-  | 'io.recovered'   // t/1627: atomicWriteSync recovered a rename-exhausted write via in-place copy fallback
-  | 'io.data-loss'   // t/1627: atomicWriteSync could not persist; new content preserved at tmpPath
+  | 'io.recovered'    // t/1627: atomicWriteSync recovered a rename-exhausted write via in-place copy fallback
+  | 'io.data-loss'    // t/1627: atomicWriteSync could not persist; new content preserved at tmpPath
+  | 'io.lock-holder'  // t/2544: lock holder identified on EPERM exhaustion (handle.exe / unavailable fallback)
   // Lock instrumentation
   | 'lock.acquire_attempt'
   | 'lock.acquired'


### PR DESCRIPTION
## Summary
- **t/2546**: `renameSyncWithRetry` now accepts `maxWallClockMs` — files >200KB get a 30s wall-clock cap instead of the fixed 7-attempt (~6.35s) budget. Small files unchanged. Fixes EPERM cascade on large debate files (FFRS 2026-08-12T22:21Z, build dc9319b2).
- **t/2544**: On retry exhaustion emit `io.lock-holder` FR event — shells to `handle.exe` if on PATH (Windows), falls back to `unavailable:true`. No crash if absent or non-Windows.

## Test plan
- [x] 10 fault-injection tests in `persistenceRetryBudget.test.ts` (Atomics.wait mocked — no real sleeps)
- [x] wall-clock budget continues past 7-attempt limit; fixed budget still fails at 8 (regression)
- [x] deadline-expired → single attempt → throw + io.lock-holder emitted
- [x] io.lock-holder: handle.exe success, ENOENT fallback, non-Windows guard, EXDEV excluded
- [x] 37/37 persistence tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)