### PR TITLE
feat(cmdlet): Test-DebatePersistence — pre-flight atomic write+rename probe (t/2545)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -110,6 +110,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Test-AIApiKey` | Probe AI backend auth endpoints (no tokens consumed) — confirm a key is present and accepted before running jobs |
 | `Test-AIBackendHealth` | Full completion round-trip probe per backend — use before a debate run to surface degraded/unreachable models (t/2212) |
 | `Test-DebateIndexIntegrity` | Validate debate-*.json field types for UI-crash regressions — catches the object-as-title bug (t/2335) |
+| `Test-DebatePersistence` | Pre-flight atomic write+rename probe for the debates output dir — call before AI generation to surface LOCKED/NO_PERMISSION early (t/2545) |
 | `Get-ContainerAppRevision` | Query ACA revisions by mode (Active/Stale/Fqdn) — replaces raw `az containerapp revision` calls (t/1498) |
 | `New-ContainerAppRevision` | Blue-green: deploy a new ACA revision at 0% traffic; returns real `RevisionName` for the promotion chain (t/1500 Phase 3) |
 | `Set-ContainerAppTraffic` | Shift traffic to a named revision with retry — call BEFORE `Disable-ContainerAppRevision` in rollback (t/1500 Phase 3) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -215,6 +215,8 @@
         'Test-DebateIndexIntegrity'
         # t/2367 — Debate blob existence check in Azure storage
         'Test-DebateSession'
+        # t/2545 — Pre-flight atomic write+rename probe for debate output dir
+        'Test-DebatePersistence'
     )
 
     # Aliases exported from this module

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -560,6 +560,12 @@ class ViteDevStatus {
     [string]  $Summary
 }
 
+class DebatePersistenceResult {
+    [string] $Status       # OK | LOCKED | NO_PERMISSION
+    [string] $Path
+    [string] $LockHolder   # process name if identifiable, otherwise $null
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Module-scoped taxonomy store
 # ─────────────────────────────────────────────────────────────────────────────
@@ -916,6 +922,8 @@ Export-ModuleMember -Function @(
     'Test-DebateIndexIntegrity'
     # t/2367 — Debate blob existence check in Azure storage
     'Test-DebateSession'
+    # t/2545 — Pre-flight atomic write+rename probe for debate output dir
+    'Test-DebatePersistence'
     # Op-ed generation in a POV Soul-document voice
     'New-OpEd'
 ) -Alias @(

--- a/scripts/AITriad/Public/Test-DebatePersistence.ps1
+++ b/scripts/AITriad/Public/Test-DebatePersistence.ps1
@@ -1,0 +1,85 @@
+function Test-DebatePersistence {
+    <#
+    .SYNOPSIS
+        Probes the debate output directory with an atomic write+rename before AI generation begins.
+    .DESCRIPTION
+        Writes a random-named sentinel .tmp file to the debates directory, renames it to .json
+        (matching the atomic-write pattern used by the debate engine), then deletes it.
+        Returns a DebatePersistenceResult with Status OK, LOCKED, or NO_PERMISSION so callers
+        can surface a user-facing warning before expensive AI generation starts.
+    .PARAMETER DebatesDir
+        Path to the debates output directory. Defaults to Get-DebatesDir.
+    .OUTPUTS
+        DebatePersistenceResult
+    .EXAMPLE
+        $r = Test-DebatePersistence
+        if ($r.Status -ne 'OK') { Write-Warning "Debate saves will fail: $($r.Status) at $($r.Path)" }
+    #>
+    [CmdletBinding()]
+    [OutputType('DebatePersistenceResult')]
+    param(
+        [Parameter()]
+        [string]$DebatesDir
+    )
+
+    Set-StrictMode -Version Latest
+
+    if ([string]::IsNullOrWhiteSpace($DebatesDir)) {
+        $DebatesDir = Get-DebatesDir
+    }
+
+    if (-not (Test-Path -LiteralPath $DebatesDir -PathType Container)) {
+        try {
+            $null = New-Item -ItemType Directory -Path $DebatesDir -Force -ErrorAction Stop
+        } catch {
+            $r = [DebatePersistenceResult]::new()
+            $r.Status     = 'NO_PERMISSION'
+            $r.Path       = $DebatesDir
+            $r.LockHolder = $null
+            return $r
+        }
+    }
+
+    $BaseName  = "persist-probe-$([System.IO.Path]::GetRandomFileName())"
+    $TmpPath   = Join-Path $DebatesDir "$BaseName.tmp"
+    $FinalPath = Join-Path $DebatesDir "$BaseName.json"
+
+    try {
+        [System.IO.File]::WriteAllText($TmpPath, '{"probe":true}')
+
+        Rename-Item -LiteralPath $TmpPath -NewName "$BaseName.json" -ErrorAction Stop
+
+        Remove-Item -LiteralPath $FinalPath -ErrorAction Stop
+
+        $r = [DebatePersistenceResult]::new()
+        $r.Status     = 'OK'
+        $r.Path       = $DebatesDir
+        $r.LockHolder = $null
+        return $r
+
+    } catch [System.UnauthorizedAccessException] {
+        $r = [DebatePersistenceResult]::new()
+        $r.Status     = 'NO_PERMISSION'
+        $r.Path       = $DebatesDir
+        $r.LockHolder = $null
+        return $r
+
+    } catch [System.IO.IOException] {
+        $r = [DebatePersistenceResult]::new()
+        $r.Status     = 'LOCKED'
+        $r.Path       = $DebatesDir
+        $r.LockHolder = $null
+        return $r
+
+    } catch {
+        $r = [DebatePersistenceResult]::new()
+        $r.Status     = 'NO_PERMISSION'
+        $r.Path       = $DebatesDir
+        $r.LockHolder = $null
+        return $r
+
+    } finally {
+        if (Test-Path -LiteralPath $TmpPath)   { Remove-Item -LiteralPath $TmpPath   -ErrorAction SilentlyContinue }
+        if (Test-Path -LiteralPath $FinalPath) { Remove-Item -LiteralPath $FinalPath -ErrorAction SilentlyContinue }
+    }
+}

--- a/tests/Test-DebatePersistence.Tests.ps1
+++ b/tests/Test-DebatePersistence.Tests.ps1
@@ -1,0 +1,123 @@
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Regression tests for Test-DebatePersistence (t/2545).
+#>
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../scripts/AITriad/AITriad.psm1" -Force
+}
+
+Describe 'Test-DebatePersistence' -Tag 'debate', 'persistence' {
+
+    It 'Is exported from the AITriad module' {
+        Get-Command -Module AITriad -Name 'Test-DebatePersistence' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Returns Status=OK against a writable temp directory' {
+        $Dir = Join-Path ([System.IO.Path]::GetTempPath()) "debate-probe-$([System.IO.Path]::GetRandomFileName())"
+        $null = New-Item -ItemType Directory -Path $Dir -Force
+
+        try {
+            $result = Test-DebatePersistence -DebatesDir $Dir
+            $result.Status     | Should -Be 'OK'
+            $result.Path       | Should -Be $Dir
+            $result.LockHolder | Should -BeNullOrEmpty
+        } finally {
+            Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Returns a DebatePersistenceResult typed object' {
+        $Dir = Join-Path ([System.IO.Path]::GetTempPath()) "debate-probe-$([System.IO.Path]::GetRandomFileName())"
+        $null = New-Item -ItemType Directory -Path $Dir -Force
+
+        try {
+            $result = Test-DebatePersistence -DebatesDir $Dir
+            $result.GetType().Name | Should -Be 'DebatePersistenceResult'
+        } finally {
+            Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Creates the debates directory if it does not exist' {
+        $Dir = Join-Path ([System.IO.Path]::GetTempPath()) "debate-probe-missing-$([System.IO.Path]::GetRandomFileName())"
+        $Dir | Should -Not -Exist
+
+        try {
+            $result = Test-DebatePersistence -DebatesDir $Dir
+            $result.Status | Should -Be 'OK'
+            $Dir           | Should -Exist
+        } finally {
+            Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Returns Status=NO_PERMISSION when the directory is read-only (Windows ACL)' -Skip:(-not $IsWindows) {
+        $Dir = Join-Path ([System.IO.Path]::GetTempPath()) "debate-probe-ro-$([System.IO.Path]::GetRandomFileName())"
+        $null = New-Item -ItemType Directory -Path $Dir -Force
+
+        try {
+            $acl = Get-Acl $Dir
+            $acl.SetAccessRuleProtection($true, $false)
+            $denyRule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+                [System.Security.Principal.WindowsIdentity]::GetCurrent().Name,
+                'Write',
+                'Deny'
+            )
+            $acl.AddAccessRule($denyRule)
+            Set-Acl -Path $Dir -AclObject $acl
+
+            $result = Test-DebatePersistence -DebatesDir $Dir
+            $result.Status | Should -Be 'NO_PERMISSION'
+        } finally {
+            # Restore write before cleanup
+            $acl2 = Get-Acl $Dir
+            $acl2.SetAccessRuleProtection($false, $true)
+            Set-Acl -Path $Dir -AclObject $acl2 -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Returns Status=LOCKED when Rename-Item throws IOException' {
+        # Must use InModuleScope so the mock intercepts the call inside the module
+        InModuleScope AITriad {
+            $Dir = Join-Path ([System.IO.Path]::GetTempPath()) "debate-probe-locked-$([System.IO.Path]::GetRandomFileName())"
+            $null = New-Item -ItemType Directory -Path $Dir -Force
+            try {
+                Mock Rename-Item { throw [System.IO.IOException]::new('File is locked by another process') }
+                $result = Test-DebatePersistence -DebatesDir $Dir
+                $result.Status | Should -Be 'LOCKED'
+            } finally {
+                Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'Leaves no probe files behind after a successful run' {
+        $Dir = Join-Path ([System.IO.Path]::GetTempPath()) "debate-probe-clean-$([System.IO.Path]::GetRandomFileName())"
+        $null = New-Item -ItemType Directory -Path $Dir -Force
+
+        try {
+            $null = Test-DebatePersistence -DebatesDir $Dir
+            @(Get-ChildItem $Dir -Filter 'persist-probe-*').Count | Should -Be 0
+        } finally {
+            Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Leaves no probe files behind after a LOCKED failure' {
+        InModuleScope AITriad {
+            $Dir = Join-Path ([System.IO.Path]::GetTempPath()) "debate-probe-clean-locked-$([System.IO.Path]::GetRandomFileName())"
+            $null = New-Item -ItemType Directory -Path $Dir -Force
+            try {
+                Mock Rename-Item { throw [System.IO.IOException]::new('File is locked') }
+                $null = Test-DebatePersistence -DebatesDir $Dir
+                @(Get-ChildItem $Dir -Filter 'persist-probe-*').Count | Should -Be 0
+            } finally {
+                Remove-Item -LiteralPath $Dir -Recurse -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `Test-DebatePersistence` cmdlet (t/2545): probes the debates output directory with an atomic write+rename before AI generation starts, returning `Status` (OK/LOCKED/NO_PERMISSION), `Path`, and `LockHolder`
- New `DebatePersistenceResult` typed class in `AITriad.psm1`
- Prevents the EPERM cascade pattern where ~80s of AI generation completes before a broken save path is discovered

## Test plan
- [x] 8 Pester tests: OK path, typed output, dir auto-creation, read-only ACL → NO_PERMISSION (Windows), IOException mock via `InModuleScope` → LOCKED, probe-file cleanup on success and failure — all pass
- [x] `Test-ModuleManifest` passes; `Test-DebatePersistence` appears in exported functions
- [ ] Full `Invoke-Pester ./tests/` — CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
