### PR TITLE
fix(devops): add --repo flag to gh workflow run in Invoke-ContainerBuild.ps1

### DIFF
--- a/operations/devops/Invoke-ContainerBuild.ps1
+++ b/operations/devops/Invoke-ContainerBuild.ps1
@@ -143,7 +143,7 @@ Write-Host "  ci.yml run ${runId}: success — green."
 # ── Step 3: Dispatch ───────────────────────────────────────────────────────────
 $pushVal = if ($Push) { 'true' } else { 'false' }
 Write-Host "Dispatching container.yml for $Sha (push=$pushVal)..."
-gh workflow run container.yml --ref main -f sha=$Sha -f push=$pushVal
+gh workflow run container.yml --repo $Repo --ref main -f sha=$Sha -f push=$pushVal
 if ($LASTEXITCODE -ne 0) {
     Fail -Goal     'Dispatch container build' `
          -Problem  "gh workflow run container.yml exited $LASTEXITCODE." `


### PR DESCRIPTION
## Summary
- `gh workflow run container.yml` was missing `--repo $Repo`, causing gh to infer the repo from git context — which fails when the script is run from a directory outside the git working tree
- Added `--repo $Repo` to match how all other `gh api` calls in the script already specify the repo explicitly

## Test plan
- [ ] Invoke-ContainerBuild.ps1 dispatches successfully regardless of shell cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)