### PR TITLE
fix(debate): remove child_process from renderer-reachable import graph (t/2550)

### DIFF
--- a/lib/debate/__tests__/importGraph.test.ts
+++ b/lib/debate/__tests__/importGraph.test.ts
@@ -1,0 +1,124 @@
+// Renderer-safety regression test (t/2550).
+//
+// Asserts that lib/debate/comments.ts's transitive import graph does NOT reach
+// 'child_process'. If this test fails, a Node-only module has been re-introduced
+// into the renderer bundle's import chain — which crashes the Debate tab.
+//
+// This is a STATIC analysis test: it reads TypeScript source files and
+// follows import statements without actually executing the modules.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Root of lib/debate source (one level up from __tests__)
+const LIB_DEBATE_DIR = resolve(__dirname, '..');
+// Root of lib/ (for resolving ../flight-recorder etc.)
+const LIB_DIR = resolve(LIB_DEBATE_DIR, '..');
+
+const IMPORT_RE = /^(?:import|export)\s[^'"]*?['"]([^'"]+)['"]/gm;
+
+function tryResolveTs(specifier: string, fromDir: string): string | null {
+  if (!specifier.startsWith('.')) return null;
+
+  const base = specifier.replace(/\.js$/, '');
+  const candidates = [
+    resolve(fromDir, base + '.ts'),
+    resolve(fromDir, base, 'index.ts'),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  return null;
+}
+
+function collectTransitiveSpecifiers(
+  entryFile: string,
+): { specifiers: Set<string>; visited: Set<string> } {
+  const specifiers = new Set<string>();
+  const visited = new Set<string>();
+
+  function visit(filePath: string): void {
+    if (visited.has(filePath)) return;
+    visited.add(filePath);
+
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      return;
+    }
+
+    let match: RegExpExecArray | null;
+    IMPORT_RE.lastIndex = 0;
+    while ((match = IMPORT_RE.exec(content)) !== null) {
+      const specifier = match[1];
+      specifiers.add(specifier);
+
+      const resolved = tryResolveTs(specifier, dirname(filePath));
+      if (resolved) visit(resolved);
+    }
+  }
+
+  visit(entryFile);
+  return { specifiers, visited };
+}
+
+describe('lib/debate/comments.ts import graph — renderer safety (t/2550)', () => {
+  const entryFile = join(LIB_DEBATE_DIR, 'comments.ts');
+
+  it('entry file exists', () => {
+    expect(existsSync(entryFile)).toBe(true);
+  });
+
+  it('does not transitively import child_process', () => {
+    const { specifiers, visited } = collectTransitiveSpecifiers(entryFile);
+
+    const nodeBuiltins = [...specifiers].filter(
+      s => s === 'child_process' || s === 'node:child_process',
+    );
+
+    if (nodeBuiltins.length > 0) {
+      // Provide a useful diagnostic: which file introduced the import
+      const offenders: string[] = [];
+      for (const f of visited) {
+        try {
+          const content = readFileSync(f, 'utf-8');
+          if (/['"](?:node:)?child_process['"]/.test(content)) {
+            offenders.push(f.replace(LIB_DIR, '<lib>'));
+          }
+        } catch { /* skip */ }
+      }
+      expect.fail(
+        `child_process found in comments.ts transitive import graph.\n` +
+        `Offending files:\n${offenders.map(f => `  ${f}`).join('\n')}\n\n` +
+        `Fix: move Node-only code to a separate module (e.g. lockHolder.ts) and inject ` +
+        `it via callback so persistence.ts stays free of child_process imports.`,
+      );
+    }
+
+    expect(nodeBuiltins).toHaveLength(0);
+  });
+
+  it('does not transitively import lockHolder.ts (Node-only module must stay out of renderer graph)', () => {
+    const { specifiers } = collectTransitiveSpecifiers(entryFile);
+
+    const lockHolderImports = [...specifiers].filter(
+      s => s.includes('lockHolder'),
+    );
+    expect(lockHolderImports).toHaveLength(0);
+  });
+
+  it('persistence.ts source does not contain a top-level child_process import', () => {
+    const persistenceFile = join(LIB_DEBATE_DIR, 'persistence.ts');
+    const content = readFileSync(persistenceFile, 'utf-8');
+
+    // Match a top-level (non-dynamic) import of child_process
+    const hasTopLevelImport = /^import\s[^'"]*?['"](?:node:)?child_process['"]/m.test(content);
+    expect(hasTopLevelImport).toBe(false);
+  });
+});

--- a/lib/debate/__tests__/lockHolder.test.ts
+++ b/lib/debate/__tests__/lockHolder.test.ts
@@ -1,0 +1,163 @@
+// Tests for lockHolder.ts — io.lock-holder FR event emission (t/2544)
+// and execFileSync argv injection guard (t/2549).
+//
+// lockHolder.ts is Node-only (child_process import). These tests must stay
+// in their own file so the child_process mock doesn't leak into renderer-safe
+// persistence tests (persistenceRetryBudget.test.ts).
+
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import { setGlobalRecorder, clearGlobalRecorder, type FlightRecorder } from '../../flight-recorder/index.js';
+import type { RecordInput } from '../../flight-recorder/types.js';
+
+vi.mock('child_process', () => {
+  const execFileSync = vi.fn();
+  return { default: { execFileSync }, execFileSync };
+});
+
+import { execFileSync } from 'child_process';
+import { recordLockHolder } from '../lockHolder.js';
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+beforeAll(() => {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('[test] network blocked')));
+});
+afterAll(() => { vi.unstubAllGlobals(); });
+
+function installCaptureRecorder(): RecordInput[] {
+  const captured: RecordInput[] = [];
+  const fake = { record: (e: RecordInput) => { captured.push(e); } } as unknown as FlightRecorder;
+  setGlobalRecorder(fake);
+  return captured;
+}
+
+afterEach(() => { vi.restoreAllMocks(); mockExecFileSync.mockClear(); clearGlobalRecorder(); });
+
+// ── t/2544: io.lock-holder FR event emission ─────────────
+
+describe('recordLockHolder — io.lock-holder event (t/2544)', () => {
+  it('emits io.lock-holder with processName and pid when handle.exe succeeds', () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecFileSync.mockReturnValue(
+      'Defender.exe  pid: 1234  type: File  8C: C:\\data\\debates\\debate-abc.json\n' as unknown as Buffer,
+    );
+
+    const captured = installCaptureRecorder();
+    recordLockHolder('C:\\data\\debates\\debate-abc.json');
+
+    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
+    expect(lockEvents).toHaveLength(1);
+    expect(lockEvents[0].level).toBe('warn');
+    expect(lockEvents[0].data).toMatchObject({ processName: 'Defender.exe', pid: 1234 });
+    expect(lockEvents[0].data).not.toHaveProperty('unavailable');
+    expect(lockEvents[0].message).toMatch(/Defender\.exe.*1234/);
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('emits io.lock-holder with unavailable:true when handle.exe is absent', () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT: handle.exe not found'), { code: 'ENOENT' });
+    });
+
+    const captured = installCaptureRecorder();
+    recordLockHolder('C:\\data\\debates\\debate-abc.json');
+
+    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
+    expect(lockEvents).toHaveLength(1);
+    expect(lockEvents[0].data).toMatchObject({ unavailable: true });
+    expect(lockEvents[0].message).toMatch(/unavailable/i);
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('emits io.lock-holder with unavailable:true when handle.exe output is not parseable', () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    mockExecFileSync.mockReturnValue('No matching handles found.\n' as unknown as Buffer);
+
+    const captured = installCaptureRecorder();
+    recordLockHolder('C:\\data\\debates\\debate-abc.json');
+
+    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
+    expect(lockEvents).toHaveLength(1);
+    expect(lockEvents[0].data).toMatchObject({ unavailable: true, reason: 'handle.exe output not parseable' });
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('emits io.lock-holder with unavailable:true and reason "non-Windows" on non-Windows platforms', () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    const captured = installCaptureRecorder();
+    recordLockHolder('/tmp/debate-abc.json');
+
+    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
+    expect(lockEvents).toHaveLength(1);
+    expect(lockEvents[0].data).toMatchObject({ unavailable: true, reason: 'non-Windows' });
+    // execFileSync must NOT be called on non-Windows
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('records filePath in event data', () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    const captured = installCaptureRecorder();
+    recordLockHolder('/some/path/debate-abc.json');
+
+    expect(captured[0].data).toMatchObject({ filePath: '/some/path/debate-abc.json' });
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+
+  it('does not throw when no global recorder is installed', () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+    // No recorder installed — clearGlobalRecorder() already called in afterEach
+    expect(() => recordLockHolder('/tmp/debate-abc.json')).not.toThrow();
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+});
+
+// ── t/2549: execFileSync argv injection guard ─────────────
+//
+// filePath with shell metacharacters must reach execFileSync as a distinct
+// argv element, not as part of a shell command string.
+// Previously execSync(`handle.exe "${filePath}"`) allowed injection via
+// embedded quotes/metacharacters (CodeQL #5530).
+
+describe('recordLockHolder — execFileSync argv injection guard (t/2549)', () => {
+  it('passes filePath with shell metacharacters as a single argv element', () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+    const maliciousPath = 'C:\\debates\\file-with-"quotes"&meta$chars.json';
+
+    mockExecFileSync.mockReturnValue(
+      'SomeProcess.exe  pid: 9999  type: File  A0: ' + maliciousPath + '\n' as unknown as Buffer,
+    );
+
+    installCaptureRecorder();
+    recordLockHolder(maliciousPath);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'handle.exe',
+      [maliciousPath],
+      expect.objectContaining({ timeout: 2000 }),
+    );
+
+    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+  });
+});

--- a/lib/debate/__tests__/persistenceRetryBudget.test.ts
+++ b/lib/debate/__tests__/persistenceRetryBudget.test.ts
@@ -1,8 +1,8 @@
-// Fault injection tests for atomicWriteSync retry budget scaling (t/2546),
-// io.lock-holder FR event on exhaustion (t/2544), and execFileSync argv
-// injection guard (t/2549).
+// Fault injection tests for atomicWriteSync retry budget scaling (t/2546)
+// and onLockExhausted callback contract (t/2544).
 //
-// Uses vi.mock('child_process') to intercept execFileSync calls in queryLockHolder.
+// child_process is no longer imported by persistence.ts (t/2550 hot-fix);
+// the lock-holder diagnostic is in lockHolder.ts and tested in lockHolder.test.ts.
 
 import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
 import fs from 'fs';
@@ -12,15 +12,7 @@ import { makeStorageError } from './faultInjection.js';
 import { setGlobalRecorder, clearGlobalRecorder, type FlightRecorder } from '../../flight-recorder/index.js';
 import type { RecordInput } from '../../flight-recorder/types.js';
 
-vi.mock('child_process', () => {
-  const execFileSync = vi.fn();
-  return { default: { execFileSync }, execFileSync };
-});
-
-import { execFileSync } from 'child_process';
 import { atomicWriteSync, renameSyncWithRetry } from '../persistence.js';
-
-const mockExecFileSync = vi.mocked(execFileSync);
 
 // ── Hermetic isolation ────────────────────────────────────
 beforeAll(() => {
@@ -49,13 +41,12 @@ function installCaptureRecorder(): RecordInput[] {
   return captured;
 }
 
-afterEach(() => { vi.restoreAllMocks(); mockExecFileSync.mockClear(); clearGlobalRecorder(); });
+afterEach(() => { vi.restoreAllMocks(); clearGlobalRecorder(); });
 
 // ── t/2546: wall-clock budget scales with payload size ───
 
 describe('renameSyncWithRetry — wall-clock budget (t/2546)', () => {
   it('wall-clock budget: continues past 7-attempt limit while deadline not reached', () => {
-    // Atomics.wait mocked → no real sleep, Date.now frozen → deadline never expires
     vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
     vi.spyOn(Date, 'now').mockReturnValue(0); // deadline = 30000, 0 < 30000 always true
 
@@ -63,7 +54,6 @@ describe('renameSyncWithRetry — wall-clock budget (t/2546)', () => {
     vi.spyOn(fs, 'renameSync').mockImplementation(() => {
       callCount++;
       if (callCount <= 15) throw makeStorageError('EPERM', 'operation not permitted');
-      // 16th call succeeds (void return from mock = success)
     });
 
     expect(() => renameSyncWithRetry('a.tmp', 'a.json', 7, 30_000)).not.toThrow();
@@ -85,30 +75,27 @@ describe('renameSyncWithRetry — wall-clock budget (t/2546)', () => {
     expect(callCount).toBe(8);
   });
 
-  it('wall-clock deadline exceeded: single attempt then throws (budget=0ms)', () => {
+  it('wall-clock deadline exceeded: single attempt then invokes onLockExhausted callback', () => {
     vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
-    // deadline = Date.now()(call 1=0) + 30000 = 30000
-    // budget check = Date.now()(call 2=31000) < 30000 → false immediately
     let nowCall = 0;
     vi.spyOn(Date, 'now').mockImplementation(() => { nowCall++; return nowCall === 1 ? 0 : 31_000; });
 
-    const captured = installCaptureRecorder();
     let callCount = 0;
     vi.spyOn(fs, 'renameSync').mockImplementation(() => {
       callCount++;
       throw makeStorageError('EPERM', 'operation not permitted');
     });
 
-    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 7, 30_000)).toThrow('EPERM');
-    // Budget exhausted after 1 attempt (first Date.now check sees 31000 > 30000)
+    const onLockExhausted = vi.fn();
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 7, 30_000, onLockExhausted)).toThrow('EPERM');
     expect(callCount).toBe(1);
-    // io.lock-holder emitted on budget exhaustion
-    expect(captured.some(e => e.type === 'io.lock-holder')).toBe(true);
+    // callback fired with the target path
+    expect(onLockExhausted).toHaveBeenCalledOnce();
+    expect(onLockExhausted).toHaveBeenCalledWith('a.json');
   });
 
   it('atomicWriteSync large payload (>200KB): scales to wall-clock budget end-to-end', () => {
     vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
-    // Date.now always returns 0 → 0 < 30000 always true → wall-clock never expires
     vi.spyOn(Date, 'now').mockReturnValue(0);
 
     const target = tmpPath('large-e2e.json');
@@ -118,7 +105,6 @@ describe('renameSyncWithRetry — wall-clock budget (t/2546)', () => {
     vi.spyOn(fs, 'renameSync').mockImplementation(() => {
       callCount++;
       if (callCount <= 10) throw makeStorageError('EPERM', 'operation not permitted');
-      // Succeed on call 11 (void = success)
     });
 
     expect(() => atomicWriteSync(target, content)).not.toThrow();
@@ -139,7 +125,6 @@ describe('renameSyncWithRetry — wall-clock budget (t/2546)', () => {
 
     try { atomicWriteSync(target, '{"small":true}'); } catch (e) { caught = e; }
 
-    // Small file → fixed budget → eventually throws ActionableError (both rename paths exhausted)
     expect(caught).toBeDefined();
     cleanup(target);
   });
@@ -163,125 +148,70 @@ describe('renameSyncWithRetry — wall-clock budget (t/2546)', () => {
   });
 });
 
-// ── t/2544: io.lock-holder FR event on exhaustion ────────
+// ── t/2544: onLockExhausted callback contract ────────────
+//
+// queryLockHolder and the io.lock-holder FR event are in lockHolder.ts;
+// tested in lockHolder.test.ts. Here we verify persistence.ts's callback contract:
+// the callback is invoked on transient-EPERM budget exhaustion, not on success
+// or non-transient errors.
 
-describe('renameSyncWithRetry — io.lock-holder event (t/2544)', () => {
-  it('emits io.lock-holder with processName and pid when handle.exe succeeds', () => {
-    // Simulate Windows platform for queryLockHolder
-    const origPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-
-    mockExecFileSync.mockReturnValue(
-      'Defender.exe  pid: 1234  type: File  8C: C:\\data\\debates\\debate-abc.json\n' as unknown as Buffer,
-    );
-
-    const captured = installCaptureRecorder();
+describe('renameSyncWithRetry — onLockExhausted callback (t/2544)', () => {
+  it('invokes onLockExhausted with target path on EPERM budget exhaustion', () => {
     vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
     vi.spyOn(fs, 'renameSync').mockImplementation(() => {
       throw makeStorageError('EPERM', 'operation not permitted');
     });
 
-    // maxRetries=0 → i=0, withinBudget=0<0=false → budget exhausted immediately
-    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0)).toThrow('EPERM');
-
-    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
-    expect(lockEvents).toHaveLength(1);
-    expect(lockEvents[0].data).toMatchObject({ processName: 'Defender.exe', pid: 1234 });
-    expect(lockEvents[0].data).not.toHaveProperty('unavailable');
-
-    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+    const onLockExhausted = vi.fn();
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0, undefined, onLockExhausted)).toThrow('EPERM');
+    expect(onLockExhausted).toHaveBeenCalledOnce();
+    expect(onLockExhausted).toHaveBeenCalledWith('a.json');
   });
 
-  it('emits io.lock-holder with unavailable:true when handle.exe absent', () => {
-    const origPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
-
-    mockExecFileSync.mockImplementation(() => {
-      throw Object.assign(new Error('ENOENT: handle.exe not found'), { code: 'ENOENT' });
-    });
-
-    const captured = installCaptureRecorder();
+  it('invokes onLockExhausted on EACCES budget exhaustion', () => {
     vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
     vi.spyOn(fs, 'renameSync').mockImplementation(() => {
-      throw makeStorageError('EPERM', 'operation not permitted');
+      throw makeStorageError('EACCES', 'permission denied');
     });
 
-    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0)).toThrow('EPERM');
-
-    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
-    expect(lockEvents).toHaveLength(1);
-    expect(lockEvents[0].data).toMatchObject({ unavailable: true });
-
-    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+    const onLockExhausted = vi.fn();
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0, undefined, onLockExhausted)).toThrow('EACCES');
+    expect(onLockExhausted).toHaveBeenCalledOnce();
   });
 
-  it('emits io.lock-holder with unavailable:true on non-Windows', () => {
-    const origPlatform = process.platform;
-    // Ensure non-Windows platform
-    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
-
-    const captured = installCaptureRecorder();
-    vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
-    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
-      throw makeStorageError('EPERM', 'operation not permitted');
-    });
-
-    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0)).toThrow('EPERM');
-
-    const lockEvents = captured.filter(e => e.type === 'io.lock-holder');
-    expect(lockEvents).toHaveLength(1);
-    expect(lockEvents[0].data).toMatchObject({ unavailable: true, reason: 'non-Windows' });
-    // execSync never called on non-Windows
-    expect(mockExecFileSync).not.toHaveBeenCalled();
-
-    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
-  });
-
-  it('does NOT emit io.lock-holder on non-transient errors (EXDEV)', () => {
-    const captured = installCaptureRecorder();
+  it('does NOT invoke onLockExhausted on non-transient errors (EXDEV)', () => {
     vi.spyOn(fs, 'renameSync').mockImplementation(() => {
       throw makeStorageError('EXDEV', 'cross-device link not permitted');
     });
 
-    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0)).toThrow('EXDEV');
-    expect(captured.some(e => e.type === 'io.lock-holder')).toBe(false);
+    const onLockExhausted = vi.fn();
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0, undefined, onLockExhausted)).toThrow('EXDEV');
+    expect(onLockExhausted).not.toHaveBeenCalled();
   });
-});
 
-// ── t/2549: execFileSync argv — shell metachar regression ────
-//
-// Regression guard: filePath containing shell metacharacters must reach
-// execFileSync as a single argv element, not be interpreted by a shell.
-// Previously execSync(`handle.exe "${filePath}"`) allowed injection via
-// embedded quotes/metacharacters in the path (CodeQL #5530).
+  it('does NOT invoke onLockExhausted on success', () => {
+    vi.spyOn(fs, 'renameSync').mockReturnValue(undefined);
 
-describe('queryLockHolder — execFileSync argv injection guard (t/2549)', () => {
-  it('passes filePath with shell metacharacters as single argv element (not shell-interpreted)', () => {
-    const origPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const onLockExhausted = vi.fn();
+    expect(() => renameSyncWithRetry('a.tmp', 'a.json', 0, undefined, onLockExhausted)).not.toThrow();
+    expect(onLockExhausted).not.toHaveBeenCalled();
+  });
 
-    // Path containing characters that would break shell interpolation
-    const maliciousPath = 'C:\\debates\\file-with-"quotes"&meta$chars.json';
-
-    mockExecFileSync.mockReturnValue(
-      'SomeProcess.exe  pid: 9999  type: File  A0: ' + maliciousPath + '\n' as unknown as Buffer,
-    );
-
+  it('atomicWriteSync threads onLockExhausted callback to renameSyncWithRetry', () => {
     vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
     vi.spyOn(fs, 'renameSync').mockImplementation(() => {
       throw makeStorageError('EPERM', 'operation not permitted');
     });
 
-    expect(() => renameSyncWithRetry(maliciousPath + '.tmp', maliciousPath, 0)).toThrow('EPERM');
+    const target = tmpPath('callback-thread.json');
+    const onLockExhausted = vi.fn();
 
-    // execFileSync must have been called with filePath as a separate argv element,
-    // not as part of a shell command string.
-    expect(mockExecFileSync).toHaveBeenCalledWith(
-      'handle.exe',
-      [maliciousPath],
-      expect.objectContaining({ timeout: 2000 }),
-    );
+    let caught: unknown;
+    try { atomicWriteSync(target, '{"x":1}', onLockExhausted); } catch (e) { caught = e; }
 
-    Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+    expect(caught).toBeDefined();
+    // Callback fired at least once (primary rename + .tmp2 fallback may both exhaust)
+    expect(onLockExhausted).toHaveBeenCalled();
+    cleanup(target);
   });
 });

--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -23,6 +23,7 @@ import { generateSlug, formatDebateMarkdown, buildDiagnosticsOutput, buildHarves
 import { ActionableError } from './errors.js';
 import { runExploreFirstPipeline } from './explorationPreset.js';
 import { safeSerialize, atomicWriteSync } from './persistence.js';
+import { recordLockHolder } from './lockHolder.js';
 import { computeQualityScore } from './qualityScore.js';
 
 // ── CLI Config schema ────────────────────────────────────
@@ -576,7 +577,7 @@ async function main(): Promise<void> {
 
   const jsonPath = path.join(outputDir, `${slug}-debate.json`);
   try {
-    atomicWriteSync(jsonPath, sessionJson);
+    atomicWriteSync(jsonPath, sessionJson, recordLockHolder);
     log(`Wrote debate JSON (atomic): ${jsonPath}`);
   } catch (err) {
     getGlobalRecorder()?.record({ type: 'state.error', component: 'cli', level: 'error', message: `Failed to write debate JSON to '${jsonPath}'`, error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });

--- a/lib/debate/lockHolder.ts
+++ b/lib/debate/lockHolder.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+//
+// Node-only module — NOT reachable from the renderer bundle.
+// Imported only by main-process / CLI callers (cli.ts, server).
+// Do NOT import this from any module in comments.ts's import graph.
+
+import { execFileSync } from 'child_process';
+import { getGlobalRecorder } from '../flight-recorder/index.js';
+
+type LockHolderInfo = {
+  processName?: string;
+  pid?: number;
+  unavailable?: boolean;
+  reason?: string;
+};
+
+// t/2544: identify the process holding a file lock (Windows only, handle.exe).
+// Uses execFileSync argv form — no shell interpolation (t/2549 CodeQL #5530).
+function queryLockHolder(filePath: string): LockHolderInfo {
+  if (process.platform !== 'win32') return { unavailable: true, reason: 'non-Windows' };
+  try {
+    const output = execFileSync('handle.exe', [filePath], { timeout: 2000, encoding: 'utf-8' });
+    // handle.exe output: "<ProcessName>  pid: <pid>  type: File  <handle>: <path>"
+    const match = output.match(/^(\S+)\s+pid:\s+(\d+)\s/m);
+    if (match) return { processName: match[1], pid: parseInt(match[2], 10) };
+    return { unavailable: true, reason: 'handle.exe output not parseable' };
+  } catch {
+    return { unavailable: true, reason: 'handle.exe not on PATH or timed out' };
+  }
+}
+
+/**
+ * Query the lock holder for filePath and emit an io.lock-holder FR event.
+ * Pass as the onLockExhausted callback to atomicWriteSync / renameSyncWithRetry.
+ */
+export function recordLockHolder(filePath: string): void {
+  const lockHolder = queryLockHolder(filePath);
+  getGlobalRecorder()?.record({
+    type: 'io.lock-holder', component: 'persistence', level: 'warn',
+    message: lockHolder.unavailable
+      ? `io.lock-holder: unavailable (${lockHolder.reason})`
+      : `io.lock-holder: ${lockHolder.processName} pid ${lockHolder.pid}`,
+    data: { filePath, ...lockHolder },
+  });
+}

--- a/lib/debate/persistence.ts
+++ b/lib/debate/persistence.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import fs from 'fs';
-import { execFileSync } from 'child_process';
 import { getGlobalRecorder } from '../flight-recorder/index.js';
 import { ActionableError } from './errors.js';
 
@@ -39,20 +38,6 @@ export function safeSerialize(value: unknown, indent: number = 2): { json: strin
   }
 }
 
-// t/2544: identify the process holding a file lock (Windows only, requires handle.exe on PATH).
-function queryLockHolder(filePath: string): { processName?: string; pid?: number; unavailable?: boolean; reason?: string } {
-  if (process.platform !== 'win32') return { unavailable: true, reason: 'non-Windows' };
-  try {
-    const output = execFileSync('handle.exe', [filePath], { timeout: 2000, encoding: 'utf-8' });
-    // handle.exe output: "<ProcessName>  pid: <pid>  type: File  <handle>: <path>"
-    const match = output.match(/^(\S+)\s+pid:\s+(\d+)\s/m);
-    if (match) return { processName: match[1], pid: parseInt(match[2], 10) };
-    return { unavailable: true, reason: 'handle.exe output not parseable' };
-  } catch {
-    return { unavailable: true, reason: 'handle.exe not on PATH or timed out' };
-  }
-}
-
 /**
  * Rename with exponential-backoff retry for transient Windows file locks.
  * EPERM / EACCES on rename are almost always caused by antivirus, search
@@ -63,10 +48,17 @@ function queryLockHolder(filePath: string): { processName?: string; pid?: number
  * time grows with file size, so a fixed attempt budget starves large files.
  * Small files use the default maxRetries=7 (~6.35s total) unchanged.
  *
- * On budget exhaustion, emits io.lock-holder FR event naming the lock holder
- * (via handle.exe if on PATH; unavailable:true otherwise) before rethrowing.
+ * onLockExhausted: optional callback invoked when a transient EPERM/EACCES
+ * exhausts the budget. Injected by Node-only callers (cli.ts via lockHolder.ts)
+ * so persistence.ts stays free of child_process imports (renderer-safe).
  */
-export function renameSyncWithRetry(oldPath: string, newPath: string, maxRetries = 7, maxWallClockMs?: number): void {
+export function renameSyncWithRetry(
+  oldPath: string,
+  newPath: string,
+  maxRetries = 7,
+  maxWallClockMs?: number,
+  onLockExhausted?: (filePath: string) => void,
+): void {
   const deadline = maxWallClockMs !== undefined ? Date.now() + maxWallClockMs : undefined;
   for (let i = 0; ; i++) {
     try {
@@ -86,17 +78,7 @@ export function renameSyncWithRetry(oldPath: string, newPath: string, maxRetries
         Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
         continue;
       }
-      // t/2544: budget exhausted on a transient error — identify the lock holder before rethrowing.
-      if (isTransient) {
-        const lockHolder = queryLockHolder(newPath);
-        getGlobalRecorder()?.record({
-          type: 'io.lock-holder', component: 'persistence', level: 'warn',
-          message: lockHolder.unavailable
-            ? `io.lock-holder: unavailable (${lockHolder.reason})`
-            : `io.lock-holder: ${lockHolder.processName} pid ${lockHolder.pid}`,
-          data: { filePath: newPath, ...lockHolder },
-        });
-      }
+      if (isTransient) onLockExhausted?.(newPath);
       throw err;
     }
   }
@@ -143,7 +125,11 @@ export async function renameWithRetry(oldPath: string, newPath: string, maxRetri
  * wall-clock cap instead of the 7-attempt (~6.35s) small-file budget, since
  * AV scan time grows with file size. Small-file fast-fail behavior is unchanged.
  */
-export function atomicWriteSync(filePath: string, content: string): void {
+export function atomicWriteSync(
+  filePath: string,
+  content: string,
+  onLockExhausted?: (filePath: string) => void,
+): void {
   // codeql[js/insecure-temporary-file] FP: same-directory atomic write via rename, not an os.tmpdir() temp file
   const tmpPath = `${filePath}.tmp`;
   fs.writeFileSync(tmpPath, content, 'utf-8');
@@ -151,7 +137,7 @@ export function atomicWriteSync(filePath: string, content: string): void {
   const bytes = Buffer.byteLength(content, 'utf-8');
   const wallClockCapMs = bytes > 200 * 1024 ? 30_000 : undefined;
   try {
-    renameSyncWithRetry(tmpPath, filePath, 7, wallClockCapMs);
+    renameSyncWithRetry(tmpPath, filePath, 7, wallClockCapMs, onLockExhausted);
     return;
   } catch (renameErr) {
     const renameCode = (renameErr as NodeJS.ErrnoException).code;
@@ -178,7 +164,7 @@ export function atomicWriteSync(filePath: string, content: string): void {
     try {
       fs.writeFileSync(tmp2Path, content, 'utf-8');
       // writeFileSync closes the handle on return, flushing OS write buffers.
-      renameSyncWithRetry(tmp2Path, filePath, 7, wallClockCapMs);
+      renameSyncWithRetry(tmp2Path, filePath, 7, wallClockCapMs, onLockExhausted);
       // .tmp2 rename succeeded — clean up the original .tmp (best-effort)
       try { fs.unlinkSync(tmpPath); } catch { /* best-effort */ }
       getGlobalRecorder()?.record({


### PR DESCRIPTION
## Summary

- Removes top-level `import { execFileSync } from 'child_process'` from `persistence.ts`, crashing the Debate tab (renderer bundle cannot load externalized `child_process`)
- Extracts `queryLockHolder`/`recordLockHolder` to `lib/debate/lockHolder.ts` — Node-only, not reachable from `comments.ts` import graph
- Adds optional `onLockExhausted` callback to `renameSyncWithRetry`/`atomicWriteSync`; `cli.ts` injects `recordLockHolder`
- Preserves `execFileSync` argv form from t/2549 (CodeQL #5530 fix, no shell injection)

## Test plan

- [x] `importGraph.test.ts` — static analysis: comments.ts transitive graph never reaches child_process
- [x] `lockHolder.test.ts` — io.lock-holder FR event emission and execFileSync argv guard
- [x] `persistenceRetryBudget.test.ts` — rewritten with callback spy; no child_process mock
- [x] 22/22 tests green locally
- [ ] CI green
- [ ] /smoke-ui Debate tab loads after merge

Closes t/2550. Incorporates t/2549 argv fix (lockHolder.ts owns it now).

Co-Authored-By: DebateTool (Orca) <main.lib-debate@ai-triad-research.orca.local>