### PR TITLE
fix(server): harden news-report handler — FR entry events (t/2553) + 404 for missing debate (t/2554)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/newsReportNotFound.test.ts
+++ b/taxonomy-editor/src/server/__tests__/newsReportNotFound.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+
+/**
+ * t/2554 — POST /api/debates/:id/news-report must distinguish a *missing* debate
+ * (a well-defined client condition) from a genuine server fault:
+ *   1. loadDebateSession throws ActionableError (not-found) → 404 + ActionableError body
+ *   2. loadDebateSession throws any other error            → 500 (unchanged)
+ *
+ * Prevention arm of Incident 3 (news-report 500, t/2552#2): the missing-debate
+ * case previously surfaced as an opaque 500. Complements t/2553 (FR entry events),
+ * which made the failure diagnosable; this makes the response correct.
+ *
+ * The not-found path returns before the dynamic import()/AI call, so mocking only
+ * loadDebateSession (and stubbing the heavy aiBackends chain) is sufficient.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+import { ActionableError } from '../../../../lib/debate/errors.js';
+
+// Controllable loadDebateSession — each test sets its rejection.
+const loadDebateSession = vi.fn();
+vi.mock('../storage/fileIO.js', () => ({ loadDebateSession: (...a: unknown[]) => loadDebateSession(...a) }));
+// Avoid the heavy aiBackends import chain — the not-found/500 paths never reach it.
+vi.mock('../ai/aiBackends.js', () => ({ generateTextByUsage: vi.fn() }));
+
+import { registerDebatesRoutes } from '../routes/debates.js';
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body: unknown) => Promise<void> | void;
+
+function makeRouter() {
+  const handlers: Record<string, Handler> = {};
+  const reg = (m: string) => (p: string, h: Handler) => { handlers[`${m} ${p}`] = h; };
+  return {
+    router: { get: reg('GET'), post: reg('POST'), put: reg('PUT'), patch: reg('PATCH'), del: reg('DELETE') },
+    handlers,
+  };
+}
+
+// param() extracts :id from req.url against '/api/debates/:id/news-report'.
+function fakeReq(id: string): IncomingMessage {
+  return { url: `/api/debates/${id}/news-report`, method: 'POST' } as unknown as IncomingMessage;
+}
+
+function fakeRes(): ServerResponse & { _status?: number; _body?: string } {
+  const res = {
+    writeHead: vi.fn((s: number) => { res._status = s; }),
+    end: vi.fn((b?: string) => { res._body = b; }),
+    setHeader: vi.fn(),
+  } as unknown as ServerResponse & { _status?: number; _body?: string };
+  return res;
+}
+
+describe('POST /api/debates/:id/news-report — missing debate → 404 (t/2554)', () => {
+  let newsReport: Handler;
+  beforeEach(() => {
+    loadDebateSession.mockReset();
+    const { router, handlers } = makeRouter();
+    registerDebatesRoutes(router as never, {} as never);
+    newsReport = handlers['POST /api/debates/:id/news-report'];
+  });
+
+  it('returns 404 with an ActionableError body when the debate is not in storage', async () => {
+    // Exactly what loadDebateSession throws for an absent blob.
+    loadDebateSession.mockRejectedValue(new ActionableError({
+      goal: 'Load debate session',
+      problem: 'Debate session not found: ghost-1',
+      location: 'server/fileIO.ts → loadDebateSession',
+      nextSteps: ['Verify the debate ID exists via listDebateSessions()'],
+    }));
+
+    const res = fakeRes();
+    await newsReport(fakeReq('ghost-1'), res, undefined);
+
+    expect(res._status).toBe(404);
+    const body = JSON.parse(res._body!);
+    // ActionableError shape (Goal/Error/Location/Resolve) surfaces in the message
+    // (dev/test env returns the full message; production strips internals).
+    expect(body.error).toContain('Goal:');
+    expect(body.error).toContain('Location:');
+    expect(body.error).toContain('ghost-1');
+    expect(body.error).toContain('not in storage');
+  });
+
+  it('still returns 500 when loadDebateSession fails for a non-not-found reason', async () => {
+    // A genuine backend/parse fault is NOT an ActionableError → must stay a 500.
+    loadDebateSession.mockRejectedValue(new Error('S3 connection reset'));
+
+    const res = fakeRes();
+    await newsReport(fakeReq('debate-real'), res, undefined);
+
+    expect(res._status).toBe(500);
+  });
+});

--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -279,13 +279,21 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
   });
 
   post('/api/debates/:id/news-report', async (req, res) => {
+    // t/2553: entry breadcrumb BEFORE the try — a catch-only recorder leaves no FR
+    // event when the handler fails fast (39ms 500), so triage cannot tell "threw
+    // before try" / "dynamic import failed" / "route not found" apart. param() is
+    // non-throwing (returns '' when absent), so it is safe outside the try.
+    const debateId = param(req, 'id', '/api/debates/:id/news-report');
+    getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debates', level: 'info', message: 'news-report: started', data: { debateId, phase: 'started' } });
     try {
-      const debateId = param(req, 'id', '/api/debates/:id/news-report');
       const session = await fileIO.loadDebateSession(debateId) as Record<string, unknown>;
       const transcript = (session.transcript ?? []) as Array<{ type: string; content: string; speaker: string }>;
       const hasSynthesis = transcript.some(e => e.type === 'synthesis' || e.type === 'concluding');
       if (!hasSynthesis) { error(res, 'A synthesis must exist before generating a news report.', 400); return; }
 
+      // t/2553: breadcrumb immediately before the dynamic imports — the import()
+      // calls are the most likely fast-failure site (module resolution / runtime).
+      getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debates', level: 'info', message: 'news-report: importing', data: { debateId, phase: 'importing' } });
       // @ts-expect-error — lib/debate uses bundler moduleResolution; dynamic import resolves at runtime
       const { extractTranscriptHighlights, summarizeArgumentNetwork } = await import('../../../lib/debate/newsReport.js');
       // @ts-expect-error — lib/debate uses bundler moduleResolution; dynamic import resolves at runtime

--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -20,6 +20,7 @@ import { getStorageUserId, getAnonymousSessionId } from '../security/userContext
 import * as rateLimiter from '../security/rateLimiter.js';
 import { getDataRoot } from '../config.js';
 import type { DebateDelta } from '../../../../lib/debate/types.js';
+import { ActionableError } from '../../../../lib/debate/errors.js';
 
 // t/1461: per-{userId,debateId} in-flight guard against the concurrent debate-save
 // cascade — an actively-used debate fires saveDebate from many store transitions,
@@ -285,8 +286,35 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
     // non-throwing (returns '' when absent), so it is safe outside the try.
     const debateId = param(req, 'id', '/api/debates/:id/news-report');
     getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debates', level: 'info', message: 'news-report: started', data: { debateId, phase: 'started' } });
+
     try {
-      const session = await fileIO.loadDebateSession(debateId) as Record<string, unknown>;
+      // t/2554: a missing debate blob is a well-defined client condition (the
+      // Incident-3 debate was absent from storage, downstream of an EPERM .tmp
+      // stranding), not a server fault — surface it as a 404 with an ActionableError
+      // body instead of an opaque 500. loadDebateSession throws an ActionableError
+      // ONLY for the not-found case; genuine backend/parse failures throw other
+      // error types, so we isolate just this call: a not-found returns 404 here,
+      // and anything else re-throws to the outer 500 catch below. (Same discriminator
+      // the debate-load GET path models — cf. 79a86b3b.)
+      let session: Record<string, unknown>;
+      try {
+        session = await fileIO.loadDebateSession(debateId) as Record<string, unknown>;
+      } catch (loadErr) {
+        if (loadErr instanceof ActionableError) {
+          const notFound = new ActionableError({
+            goal: 'Generate a news report for this debate',
+            problem: `Debate ${debateId} is not in storage; it may have been lost to a write failure`,
+            location: 'server/routes/debates.ts → POST /api/debates/:id/news-report',
+            nextSteps: ['Re-run the debate to regenerate it', 'If it vanished unexpectedly, see incident t/2552 (storage write-failure)'],
+            innerError: loadErr,
+          });
+          getGlobalRecorder()?.record({ type: 'system.error', component: 'debates', level: 'warn', message: 'News report: debate not found', error: { name: notFound.name, message: notFound.message, stack: notFound.stack } });
+          error(res, String(notFound), 404, notFound);
+          return;
+        }
+        throw loadErr; // genuine unexpected failure → outer catch → 500
+      }
+
       const transcript = (session.transcript ?? []) as Array<{ type: string; content: string; speaker: string }>;
       const hasSynthesis = transcript.some(e => e.type === 'synthesis' || e.type === 'concluding');
       if (!hasSynthesis) { error(res, 'A synthesis must exist before generating a news report.', 400); return; }


### PR DESCRIPTION
Two changes hardening `POST /api/debates/:id/news-report` from the 2026-08-13 incident cluster (Incident 3). Same handler, sequential same-agent work, no peer blocked between them → batched into one PR.

## t/2553 — FR entry breadcrumbs (observability)
The handler recorded a flight-recorder event only in its catch block; a 39ms 500 produced **zero** server FR events, so triage could not tell "route not registered" / "threw before try" / "dynamic import failed" apart. Adds two info-level `debate.lifecycle` breadcrumbs:
- `news-report: started` at handler entry, before the try (`param()` is non-throwing → `debateId` captured safely).
- `news-report: importing` immediately before the dynamic `import()` calls.

Reuses the existing `debate.lifecycle` EventType (phase in `data`) rather than adding to the Shared-Lib-owned `EventType` union.

## t/2554 — 404 for a missing debate (correctness)
A missing debate blob (the Incident-3 condition, downstream of an EPERM `.tmp` stranding) surfaced as an opaque 500. `loadDebateSession` throws an `ActionableError` **only** for not-found, so the load call is isolated inside the outer try: not-found → **404** with a news-report-specific `ActionableError` body (Goal/Problem/Location/Next Steps); any non-`ActionableError` re-throws to the existing outer catch and stays a **500**. Mirrors the debate-load GET 404 model (cf. 79a86b3b).

Regression test `newsReportNotFound.test.ts`: not-found id → 404 + ActionableError shape; non-not-found load failure → 500.

## Design gate
- t/2553: `/trivial-change` self-cert (instrumentation-only).
- t/2554: created by TL, who pre-blessed self-cert (*"Quality-review or /add-test self-cert eligible"*). Single-scope hardening of an existing REST endpoint's error path + regression test, following the existing 404 pattern. No cross-role interface or data-model change.

## Verification
- `tsc -p tsconfig.server.json --noEmit` → clean.
- `eslint` on changed files → clean.
- `newsReportNotFound` (2), `routeTable`, `debatesDeltaSave`, `debatesInFlightGuard` → 12 passed.
- Remaining local vitest failures are the known local-only undici/Node-version skew (CI runs Node 22).

Closes t/2553, closes t/2554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)