### PR TITLE
feat(build): renderer Node-builtin externalization gate (t/2551)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/__tests__/flightRecorderReactError.test.ts
+++ b/taxonomy-editor/src/renderer/lib/__tests__/flightRecorderReactError.test.ts
@@ -97,3 +97,48 @@ describe('dumpOnReactError — crash event is recorded synchronously (t/2297)', 
     expect(h.reportError.mock.calls[0][0]).toMatchObject({ name: 'Error', message: 'boom' });
   });
 });
+
+/**
+ * Observability arm for t/2551: when the crash is a Node-builtin externalization
+ * throw (t/2550's child_process class), the dump must name the failing module in a
+ * first-class `externalized_module` field so triage sees the import chain without a
+ * human repro. Ordinary crashes must NOT carry the field.
+ */
+describe('dumpOnReactError — externalized-module attribution (t/2551 observability)', () => {
+  beforeEach(() => {
+    h.recordCalls.length = 0;
+    h.fakeRecorder.record.mockClear();
+    h.dumpFlightRecorder.mockClear();
+    h.reportError.mockClear();
+  });
+
+  it('records externalized_module (module + accessed binding) for a Vite externalization crash', async () => {
+    const { dumpOnReactError } = await import('../flightRecorderInit');
+
+    // The exact runtime message Vite's browser-external stub throws on named-binding
+    // access — the shape t/2550's child_process crash produced.
+    const err = new Error(
+      'Module "child_process" has been externalized for browser compatibility. ' +
+      'Cannot access "child_process.execFileSync" in client code. See https://vite.dev/guide/troubleshooting.html for more details.',
+    );
+
+    dumpOnReactError(err, '\n    at useCommentStore\n    at DebateTab');
+
+    expect(h.fakeRecorder.record).toHaveBeenCalledTimes(1);
+    const data = h.recordCalls[0].data as Record<string, unknown>;
+    expect(data.externalized_module).toEqual({
+      module: 'child_process',
+      accessed: 'child_process.execFileSync',
+    });
+  });
+
+  it('omits externalized_module for an ordinary crash', async () => {
+    const { dumpOnReactError } = await import('../flightRecorderInit');
+
+    dumpOnReactError(new Error('Rendered more hooks than during the previous render'), undefined);
+
+    expect(h.fakeRecorder.record).toHaveBeenCalledTimes(1);
+    const data = (h.recordCalls[0].data ?? {}) as Record<string, unknown>;
+    expect(data.externalized_module).toBeUndefined();
+  });
+});

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -828,13 +828,17 @@ export function initFlightRecorder(): FlightRecorder {
 
   window.addEventListener('error', (event) => {
     const err = event.error instanceof Error ? event.error : new Error(String(event.error ?? event.message));
+    // An externalized-builtin link failure can throw at module eval, before React
+    // mounts — so it surfaces here rather than via the error boundary. Name the
+    // module in the dump either way (t/2551 observability arm).
+    const externalizedModule = extractExternalizedModule(err);
     recorder.record({
       type: 'system.error',
       component: 'unknown',
       level: 'fatal',
       message: err.message,
       error: { name: err.name, message: err.message, stack: err.stack?.slice(0, 500) },
-      data: { hmr_timestamps: extractHmrTimestamps(err.stack), load_generation: loadGeneration },
+      data: { hmr_timestamps: extractHmrTimestamps(err.stack), load_generation: loadGeneration, ...(externalizedModule ? { externalized_module: externalizedModule } : {}) },
     });
     if (canAutoDump()) {
       recordDump();
@@ -961,6 +965,24 @@ function snapshotStoresForCrash(): Record<string, unknown> | undefined {
 }
 
 /**
+ * When a renderer-reachable module imports a Node built-in that Vite externalized
+ * for the browser, accessing a named binding throws at bundle eval with a message
+ * that names the module — e.g. `Module "child_process" has been externalized for
+ * browser compatibility. Cannot access "child_process.execFileSync" in client code.`
+ * (t/2550's crash). Surface that module id as a first-class dump field so the NEXT
+ * such crash names its failing built-in / import chain instead of leaving triage to
+ * a human repro (t/2551 observability arm; the vite.config.ts build gate is the
+ * prevention arm). Returns undefined for ordinary errors.
+ */
+function extractExternalizedModule(error: Error): { module: string; accessed?: string } | undefined {
+  const msg = String(error?.message ?? '');
+  const mod = /Module "([^"]+)" has been externalized for browser compatibility/.exec(msg);
+  if (!mod) return undefined;
+  const accessed = /Cannot access "([^"]+)" in client code/.exec(msg)?.[1];
+  return { module: mod[1], ...(accessed ? { accessed } : {}) };
+}
+
+/**
  * Called from ErrorBoundary.componentDidCatch to dump on React render errors.
  */
 export function dumpOnReactError(
@@ -974,10 +996,12 @@ export function dumpOnReactError(
   recordDump();
 
   const stateSnapshot = snapshotStoresForCrash();
+  const externalizedModule = extractExternalizedModule(error);
 
   const baseData: Record<string, unknown> = {
     ...(componentStack ? { component_stack: componentStack.slice(0, 1000) } : {}),
     ...(stateSnapshot ? { state_snapshot: stateSnapshot } : {}),
+    ...(externalizedModule ? { externalized_module: externalizedModule } : {}),
   };
 
   // Record the crash SYNCHRONOUSLY, before any async work (t/2297). This guarantees

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -12,6 +12,63 @@ import path from 'path';
 const require = createRequire(import.meta.url);
 const isWeb = process.env.VITE_TARGET === 'web';
 
+// ── Renderer Node-builtin externalization gate (t/2551) ──────────────────────
+// lib/debate/ (and other lib/*) is shared between Node (server/CLI/main) and the
+// renderer. When a renderer-reachable module imports a Node built-in, Vite/rolldown
+// externalizes it ("Module X has been externalized for browser compatibility") and
+// emits a *warning* — the build stays green. But the shim is a stub: a NAMED import
+// of an externalized builtin throws at module link (t/2550: `import { execFileSync }
+// from 'child_process'` in persistence.ts crashed the Debate tab on load), while
+// default/namespace imports only throw on lazy property access (why fs/path/crypto
+// were tolerated). vitest/tsc don't catch it — the crash only manifests at renderer
+// bundle eval. This gate promotes rolldown's own externalization signal to a hard
+// error for any builtin outside the allowlist, so the next child_process-class import
+// fails the build instead of prod (TL design t/2551#1).
+//
+// ALLOWLIST = the exact builtins a clean build currently externalizes, enumerated
+// from the real build log (t/2551). This is a latent-hazard REGISTER (these are all
+// externalized today and would throw on eager use), NOT a safe-list — burn-down is
+// welcome but out of scope. `child_process` is deliberately absent → any re-introduction
+// errors the build. `node:` and bare specifiers are normalized to the same key.
+const RENDERER_BUILTIN_ALLOWLIST = new Set<string>([
+  'crypto', // lib/debate/comments.ts, talmudicReferences.ts — shimmed, lazy access (t/2551)
+  'fs',     // lib/debate/*, lib/flight-recorder, lib/ai-client — shimmed, lazy access (t/2551)
+  'net',    // lib/flight-recorder/flightRecorder.ts — shimmed, lazy access (t/2551)
+  'os',     // lib/flight-recorder/flightRecorder.ts — shimmed, lazy access (t/2551)
+  'path',   // lib/debate/*, lib/flight-recorder, lib/ai-client — shimmed, lazy access (t/2551)
+]);
+
+const EXTERNALIZED_RE = /Module "([^"]+)" has been externalized for browser compatibility/;
+
+// Rolldown/Rollup plugin: intercept every externalization log; collect any builtin
+// outside the allowlist; fail the build at buildEnd (this.error → non-zero exit).
+// Collecting-then-failing (rather than throwing inside onLog) aggregates ALL offenders
+// into one actionable message and guarantees the build aborts.
+function rendererNodeBuiltinGate() {
+  const violations = new Map<string, string>(); // normalized builtin -> first log line
+  return {
+    name: 't2551-renderer-node-builtin-gate',
+    onLog(_level: string, log: { message?: string } | string) {
+      const message = typeof log === 'string' ? log : (log?.message ?? '');
+      const match = EXTERNALIZED_RE.exec(message);
+      if (!match) return;
+      const builtin = match[1].replace(/^node:/, '');
+      if (!RENDERER_BUILTIN_ALLOWLIST.has(builtin) && !violations.has(builtin)) {
+        violations.set(builtin, message);
+      }
+    },
+    buildEnd(this: { error: (msg: string) => never }) {
+      if (violations.size === 0) return;
+      const detail = [...violations.values()].map((m) => `    ${m}`).join('\n');
+      this.error(
+        `[t/2551 renderer node-builtin gate] ${violations.size} renderer-reachable module(s) import a Node built-in that Vite externalized for the browser and is NOT on the allowlist: ${[...violations.keys()].join(', ')}.\n` +
+        `A named import of an externalized builtin throws at renderer bundle eval (crashes the tab). Fix by moving the importing code into a Node-only module that is NOT reachable from the renderer import graph. ` +
+        `If the builtin is genuinely renderer-safe and shimmed, add it to RENDERER_BUILTIN_ALLOWLIST in taxonomy-editor/vite.config.ts with a one-line why + burn-down ref.\n${detail}`
+      );
+    },
+  };
+}
+
 function getGitVersion(): string {
   try {
     return execSync('git describe --tags --always', { encoding: 'utf8' }).trim();
@@ -35,6 +92,7 @@ function getGitSha(): string {
 
 export default defineConfig({
   plugins: [
+    rendererNodeBuiltinGate(),
     react(),
     ...(isWeb ? [VitePWA({
       registerType: 'autoUpdate',


### PR DESCRIPTION
TL-approved design t/2551#1 + AC addendum #2. **Blocked by t/2550** (must land first so the gate is born green).

## Gate (`taxonomy-editor/vite.config.ts`)
A rolldown plugin intercepts Vite's own `Module "X" has been externalized for browser compatibility` logs and fails the build (`buildEnd` → `this.error`) on any builtin outside an explicit allowlist. Promotes the real bundler signal — no second resolver, no new deps, co-located at point of use. Runs on Electron + web targets.

**Allowlist** (enumerated from a real clean build log): `crypto, fs, net, os, path`. **Deviation from the design's assumed seed** (`fs/path/crypto`): the real build also externalizes `os`+`net` (flight-recorder) — enumerated per the design's "exact set from a clean build log" instruction. `child_process` deliberately absent.

## Observability arm (`flightRecorderInit.ts`)
Error-boundary + window-error paths extract the externalized module id into a first-class `externalized_module` dump field so the next such crash names its import chain. 2 new tests (green).

## Both-arms proof (AC addendum #2 — proof in a REQUIRED CI check)
- **FIRE:** this PR's base still carries the live t/2550 `child_process` violation, so the current `test-electron (taxonomy-editor)` Build run goes **red naming child_process** — the authentic FIRE proof in a required check (run URL to be cited in the ticket). Local FIRE: `vite build` exits 1, `RolldownError [t/2551 ...]: ... child_process`.
- **CLEAN:** after t/2550 lands I rebase onto it (violation gone) → same PR's CI goes green with zero new warnings.

Draft until t/2550 lands + rebase. Do not merge before then (born-green requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)