### PR TITLE
feat(debate): orphaned .tmp sweep + startup recovery (t/2555)

### DIFF
--- a/lib/debate/__tests__/sweepOrphans.test.ts
+++ b/lib/debate/__tests__/sweepOrphans.test.ts
@@ -1,0 +1,206 @@
+// Fault injection tests for sweepOrphanedTempFiles (t/2555).
+//
+// Self-cert: /add-fault-test pattern. The "fault" (write killed between .tmp
+// and rename) is simulated by creating the stranded .tmp file directly —
+// equivalent to the state left by atomicWriteSync when its rename budget
+// exhausts. No FaultHarness used (FaultHarness targets AI/network; file-system
+// faults are injected via real temp files and vi.spyOn(fs)).
+
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { setGlobalRecorder, clearGlobalRecorder, type FlightRecorder } from '../../flight-recorder/index.js';
+import type { RecordInput } from '../../flight-recorder/types.js';
+import { sweepOrphanedTempFiles, type OrphanResult } from '../persistence.js';
+
+beforeAll(() => {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('[test] network blocked')));
+});
+afterAll(() => { vi.unstubAllGlobals(); });
+
+function installCaptureRecorder(): RecordInput[] {
+  const captured: RecordInput[] = [];
+  const fake = { record: (e: RecordInput) => { captured.push(e); } } as unknown as FlightRecorder;
+  setGlobalRecorder(fake);
+  return captured;
+}
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'sweep-test-'));
+}
+
+function rmDir(dir: string): void {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+afterEach(() => { vi.restoreAllMocks(); clearGlobalRecorder(); });
+
+// ── AC: fault injected → sweep recovers ──────────────────
+
+describe('sweepOrphanedTempFiles — recovery (t/2555)', () => {
+  it('recovers a valid stranded .json.tmp file', () => {
+    const dir = makeTmpDir();
+    try {
+      const content = JSON.stringify({ id: 'debate-abc', rounds: [] });
+      fs.writeFileSync(path.join(dir, 'debate-abc.json.tmp'), content, 'utf-8');
+
+      const results: OrphanResult[] = [];
+      const captured = installCaptureRecorder();
+      sweepOrphanedTempFiles(dir, r => results.push(r));
+
+      expect(results).toHaveLength(1);
+      expect(results[0].recovered).toBe(true);
+      expect(fs.existsSync(path.join(dir, 'debate-abc.json'))).toBe(true);
+      expect(fs.existsSync(path.join(dir, 'debate-abc.json.tmp'))).toBe(false);
+
+      const events = captured.filter(e => e.type === 'io.tmp-orphan');
+      expect(events).toHaveLength(1);
+      expect(events[0].level).toBe('warn');
+      expect(events[0].data).toMatchObject({ recovered: true });
+    } finally {
+      rmDir(dir);
+    }
+  });
+
+  it('recovers a valid stranded .json.tmp2 file', () => {
+    const dir = makeTmpDir();
+    try {
+      const content = JSON.stringify({ id: 'debate-xyz', rounds: [] });
+      fs.writeFileSync(path.join(dir, 'debate-xyz.json.tmp2'), content, 'utf-8');
+
+      const results: OrphanResult[] = [];
+      sweepOrphanedTempFiles(dir, r => results.push(r));
+
+      expect(results[0].recovered).toBe(true);
+      expect(fs.existsSync(path.join(dir, 'debate-xyz.json'))).toBe(true);
+      expect(fs.existsSync(path.join(dir, 'debate-xyz.json.tmp2'))).toBe(false);
+    } finally {
+      rmDir(dir);
+    }
+  });
+
+  it('preserves orphan and emits error-level event when JSON is invalid (truncated write)', () => {
+    const dir = makeTmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'debate-bad.json.tmp'), '{"id":"debate-bad","rounds":[{', 'utf-8');
+
+      const results: OrphanResult[] = [];
+      const captured = installCaptureRecorder();
+      sweepOrphanedTempFiles(dir, r => results.push(r));
+
+      expect(results[0].recovered).toBe(false);
+      expect(fs.existsSync(path.join(dir, 'debate-bad.json.tmp'))).toBe(true);
+
+      const events = captured.filter(e => e.type === 'io.tmp-orphan');
+      expect(events[0].level).toBe('error');
+      expect(events[0].data).toMatchObject({ recovered: false });
+    } finally {
+      rmDir(dir);
+    }
+  });
+
+  it('preserves orphan when final path already exists (concurrent write safety)', () => {
+    const dir = makeTmpDir();
+    try {
+      const existing = JSON.stringify({ id: 'debate-exist', rounds: ['round1'] });
+      const orphan = JSON.stringify({ id: 'debate-exist', rounds: ['round1', 'round2'] });
+      fs.writeFileSync(path.join(dir, 'debate-exist.json'), existing, 'utf-8');
+      fs.writeFileSync(path.join(dir, 'debate-exist.json.tmp'), orphan, 'utf-8');
+
+      const results: OrphanResult[] = [];
+      sweepOrphanedTempFiles(dir, r => results.push(r));
+
+      expect(results[0].recovered).toBe(false);
+      expect(results[0].reason).toMatch(/already exists/);
+      // Existing file must not be overwritten
+      expect(JSON.parse(fs.readFileSync(path.join(dir, 'debate-exist.json'), 'utf-8')).rounds).toHaveLength(1);
+      // Orphan preserved for manual review
+      expect(fs.existsSync(path.join(dir, 'debate-exist.json.tmp'))).toBe(true);
+    } finally {
+      rmDir(dir);
+    }
+  });
+
+  it('recovers both .tmp and .tmp2 orphans in the same directory', () => {
+    const dir = makeTmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'a.json.tmp'), JSON.stringify({ id: 'a' }), 'utf-8');
+      fs.writeFileSync(path.join(dir, 'b.json.tmp2'), JSON.stringify({ id: 'b' }), 'utf-8');
+
+      const results: OrphanResult[] = [];
+      sweepOrphanedTempFiles(dir, r => results.push(r));
+
+      expect(results).toHaveLength(2);
+      expect(results.every(r => r.recovered)).toBe(true);
+      expect(fs.existsSync(path.join(dir, 'a.json'))).toBe(true);
+      expect(fs.existsSync(path.join(dir, 'b.json'))).toBe(true);
+    } finally {
+      rmDir(dir);
+    }
+  });
+});
+
+// ── AC: clean run emits nothing ───────────────────────────
+
+describe('sweepOrphanedTempFiles — clean run (t/2555)', () => {
+  it('emits no FR events and invokes no callback when no orphans exist', () => {
+    const dir = makeTmpDir();
+    try {
+      // Put a regular debate file — should be ignored
+      fs.writeFileSync(path.join(dir, 'debate-clean.json'), JSON.stringify({ id: 'clean' }), 'utf-8');
+
+      const results: OrphanResult[] = [];
+      const captured = installCaptureRecorder();
+      sweepOrphanedTempFiles(dir, r => results.push(r));
+
+      expect(results).toHaveLength(0);
+      expect(captured.filter(e => e.type === 'io.tmp-orphan')).toHaveLength(0);
+    } finally {
+      rmDir(dir);
+    }
+  });
+
+  it('returns silently when the directory does not exist', () => {
+    const nonexistent = path.join(os.tmpdir(), `sweep-nonexistent-${Date.now()}`);
+    expect(() => sweepOrphanedTempFiles(nonexistent)).not.toThrow();
+  });
+
+  it('does not process .json files or other extensions', () => {
+    const dir = makeTmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'debate.json'), '{}', 'utf-8');
+      fs.writeFileSync(path.join(dir, 'debate.json.bak'), '{}', 'utf-8');
+      fs.writeFileSync(path.join(dir, 'debate.tmp'), '{}', 'utf-8'); // wrong extension pattern
+
+      const results: OrphanResult[] = [];
+      sweepOrphanedTempFiles(dir, r => results.push(r));
+
+      expect(results).toHaveLength(0);
+    } finally {
+      rmDir(dir);
+    }
+  });
+});
+
+// ── Result shape ──────────────────────────────────────────
+
+describe('sweepOrphanedTempFiles — result shape', () => {
+  it('OrphanResult contains tmpPath, finalPath, recovered, and optional reason', () => {
+    const dir = makeTmpDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'debate-shape.json.tmp'), JSON.stringify({ id: 'shape' }), 'utf-8');
+
+      const results: OrphanResult[] = [];
+      sweepOrphanedTempFiles(dir, r => results.push(r));
+
+      const r = results[0];
+      expect(r.tmpPath).toBe(path.join(dir, 'debate-shape.json.tmp'));
+      expect(r.finalPath).toBe(path.join(dir, 'debate-shape.json'));
+      expect(r.recovered).toBe(true);
+      expect(r.reason).toBeUndefined();
+    } finally {
+      rmDir(dir);
+    }
+  });
+});

--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -22,7 +22,7 @@ import { FlightRecorder, getGlobalRecorder, setGlobalRecorder, RECORDER_CAPACITY
 import { generateSlug, formatDebateMarkdown, buildDiagnosticsOutput, buildHarvestOutput } from './formatters.js';
 import { ActionableError } from './errors.js';
 import { runExploreFirstPipeline } from './explorationPreset.js';
-import { safeSerialize, atomicWriteSync } from './persistence.js';
+import { safeSerialize, atomicWriteSync, sweepOrphanedTempFiles } from './persistence.js';
 import { recordLockHolder } from './lockHolder.js';
 import { computeQualityScore } from './qualityScore.js';
 
@@ -468,6 +468,9 @@ async function main(): Promise<void> {
   }
 
   // Mirror the CLI's cal-log isolation into the engine so both write paths use the same root (t/2219).
+  // Recover any .tmp/.tmp2 orphans left by a previously interrupted write (t/2555).
+  sweepOrphanedTempFiles(outputDir);
+
   engineConfig.calibrationDataRoot = config.outputDir != null ? outputDir : dataRoot;
 
   const partialPath = path.join(outputDir, `${slug}-partial.json`);

--- a/lib/debate/persistence.ts
+++ b/lib/debate/persistence.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import fs from 'fs';
+import path from 'path';
 import { getGlobalRecorder } from '../flight-recorder/index.js';
 import { ActionableError } from './errors.js';
 
@@ -208,5 +209,85 @@ export function atomicWriteSync(
         innerError: tmp2Err,
       });
     }
+  }
+}
+
+// ── Orphaned temp-file sweep (t/2555) ────────────────────
+
+export type OrphanResult = {
+  tmpPath: string;
+  finalPath: string;
+  recovered: boolean;
+  reason?: string;
+};
+
+/**
+ * Scan debatesDir for stranded `.json.tmp` and `.json.tmp2` files left by
+ * interrupted atomic writes. Both extensions are produced by atomicWriteSync:
+ * `.tmp` by the primary write; `.tmp2` by the rename-fallback path when the
+ * primary rename exhausts its EPERM/EACCES budget (persistence.ts:163-167).
+ *
+ * For each orphan:
+ *   - Validates JSON parsability. writeFileSync completes before returning,
+ *     so any existing .tmp file contains a full write — partial writes produce
+ *     malformed JSON via OS-level truncation, which JSON.parse catches. Zod
+ *     validation would be stricter but risks rejecting structurally valid
+ *     debates from older schema versions. JSON.parse is the right boundary.
+ *   - If valid and final path absent: renames to the final path (recovered).
+ *   - If final path already exists: preserves orphan for manual review.
+ *   - If JSON invalid: preserves orphan — it is the durable copy of the write.
+ *   - Emits io.tmp-orphan FR event either way; invokes onOrphan callback if
+ *     provided (used by tests to inspect results without a real recorder).
+ *
+ * Clean runs (no orphans) emit nothing.
+ */
+export function sweepOrphanedTempFiles(
+  debatesDir: string,
+  onOrphan?: (result: OrphanResult) => void,
+): void {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(debatesDir);
+  } catch {
+    return;
+  }
+
+  const tmpNames = entries.filter(
+    name => name.endsWith('.json.tmp') || name.endsWith('.json.tmp2'),
+  );
+
+  for (const name of tmpNames) {
+    const tmpPath = path.join(debatesDir, name);
+    const finalPath = path.join(debatesDir, name.replace(/\.tmp2?$/, ''));
+
+    let recovered = false;
+    let reason: string | undefined;
+
+    try {
+      const content = fs.readFileSync(tmpPath, 'utf-8');
+      JSON.parse(content);
+
+      if (fs.existsSync(finalPath)) {
+        reason = 'final path already exists — preserved for manual review';
+      } else {
+        fs.renameSync(tmpPath, finalPath);
+        recovered = true;
+      }
+    } catch (err) {
+      reason = (err as NodeJS.ErrnoException).code ?? (err as Error).message;
+    }
+
+    const result: OrphanResult = { tmpPath, finalPath, recovered, reason };
+    onOrphan?.(result);
+
+    getGlobalRecorder()?.record({
+      type: 'io.tmp-orphan',
+      component: 'persistence',
+      level: recovered ? 'warn' : 'error',
+      message: recovered
+        ? `io.tmp-orphan: recovered ${name} → ${path.basename(finalPath)}`
+        : `io.tmp-orphan: could not recover ${name} (${reason ?? 'unknown'})`,
+      data: { tmpPath, finalPath, recovered, reason },
+    });
   }
 }

--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -111,6 +111,7 @@ export type EventType =
   | 'io.recovered'    // t/1627: atomicWriteSync recovered a rename-exhausted write via in-place copy fallback
   | 'io.data-loss'    // t/1627: atomicWriteSync could not persist; new content preserved at tmpPath
   | 'io.lock-holder'  // t/2544: lock holder identified on EPERM exhaustion (handle.exe / unavailable fallback)
+  | 'io.tmp-orphan'   // t/2555: stranded .tmp/.tmp2 file detected at startup sweep (recovered or preserved)
   // Lock instrumentation
   | 'lock.acquire_attempt'
   | 'lock.acquired'


### PR DESCRIPTION
## Summary

- Adds `sweepOrphanedTempFiles(debatesDir)` to `persistence.ts` — scans for `*.json.tmp` and `*.json.tmp2` orphans left by interrupted atomic writes
- Both extensions are produced by `atomicWriteSync`: `.tmp` by the primary write path, `.tmp2` by the rename-fallback path when primary rename exhausts its EPERM budget
- Validates JSON parsability, renames to final path if valid and absent, preserves orphan otherwise; emits `io.tmp-orphan` FR event either way
- Clean runs (no orphans) emit nothing
- Called at CLI startup after outputDir is prepared
- Adds `io.tmp-orphan` to `EventType` union

## Test plan

- [x] Recovery: valid `.json.tmp` and `.json.tmp2` files are renamed to final path
- [x] Invalid JSON: orphan preserved, error-level FR event emitted
- [x] Final-path conflict: existing debate not overwritten; orphan preserved for manual review
- [x] Both extensions in one sweep pass
- [x] Clean run: no orphans, no events emitted
- [x] Non-existent directory: returns silently
- [x] Non-matching extensions ignored
- [x] Result shape: tmpPath, finalPath, recovered, reason
- [x] 9/9 tests green locally
- [ ] CI green

Closes t/2555 (prevention part). Remediation of debate 5f395c48 pending blob-side listing (Server Storage scope — to be split per ticket instruction).

Co-Authored-By: DebateTool (Orca) <main.lib-debate@ai-triad-research.orca.local>