### PR TITLE
fix(server): pin error-level logs so 500s survive in flight-recorder dumps (t/2552)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/serverLogBuffer.test.ts
+++ b/taxonomy-editor/src/server/__tests__/serverLogBuffer.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { recordServerLog, drainServerLogLines, _resetServerLogBuffer, MAX_LOG_LINES } from '../serverLogBuffer.js';
+import { recordServerLog, drainServerLogLines, _resetServerLogBuffer, MAX_LOG_LINES, MAX_ERROR_LOG_LINES } from '../serverLogBuffer.js';
 
 describe('serverLogBuffer', () => {
   beforeEach(() => { _resetServerLogBuffer(); });
@@ -67,5 +67,39 @@ describe('serverLogBuffer', () => {
     recordServerLog(JSON.stringify({ msg: 'a' }));
     drainServerLogLines().push({ msg: 'injected' });
     expect(drainServerLogLines()).toHaveLength(1);
+  });
+
+  // t/2552: the incident — an error line (level 50) evicted from the main ring by
+  // info-level request traffic before the dump triggered.
+  it('pins an error line so info-level flooding cannot evict it (t/2552)', () => {
+    recordServerLog(JSON.stringify({ level: 50, component: 'server', requestId: 'req-err', msg: 'boom 500' }));
+    // Flood the 250-entry main ring with far more info lines than its cap.
+    for (let i = 0; i < MAX_LOG_LINES + 50; i++) recordServerLog(JSON.stringify({ level: 30, n: i }));
+
+    const lines = drainServerLogLines();
+    const errors = lines.filter(l => l.level === 50);
+    expect(errors).toHaveLength(1);                       // survived, exactly once
+    expect(errors[0]).toMatchObject({ requestId: 'req-err', msg: 'boom 500' });
+    expect(lines[0]).toMatchObject({ requestId: 'req-err' }); // evicted error prepended (oldest)
+  });
+
+  it('does not duplicate an error still within the main ring window (t/2552)', () => {
+    recordServerLog(JSON.stringify({ level: 50, msg: 'err-1' }));
+    recordServerLog(JSON.stringify({ level: 30, msg: 'info-1' }));
+    const lines = drainServerLogLines();
+    expect(lines).toHaveLength(2);                        // no dup — error still in main
+    expect(lines.filter(l => l.msg === 'err-1')).toHaveLength(1);
+  });
+
+  it('caps the pinned error buffer at MAX_ERROR_LOG_LINES (t/2552)', () => {
+    const total = MAX_ERROR_LOG_LINES + 20;
+    for (let i = 0; i < total; i++) recordServerLog(JSON.stringify({ level: 50, e: i }));
+    // Evict every error from the main ring so drain sources them from the error ring.
+    for (let i = 0; i < MAX_LOG_LINES; i++) recordServerLog(JSON.stringify({ level: 30, n: i }));
+
+    const errors = drainServerLogLines().filter(l => l.level === 50);
+    expect(errors).toHaveLength(MAX_ERROR_LOG_LINES);     // only the most recent 50 pinned
+    expect(errors[errors.length - 1].e).toBe(total - 1);  // newest kept
+    expect(errors[0].e).toBe(total - MAX_ERROR_LOG_LINES); // oldest 20 dropped
   });
 });

--- a/taxonomy-editor/src/server/serverLogBuffer.ts
+++ b/taxonomy-editor/src/server/serverLogBuffer.ts
@@ -15,9 +15,19 @@
 export const MAX_LOG_LINES = 250;
 const MAX_LINE_BYTES = 4_096;
 
+// t/2552: pino error/fatal level. A 500's error line (level 50) was evicted from
+// the 250-entry main ring by info-level (level 30) access-log traffic — one entry
+// per request — before the dump triggered, so the 500 was invisible offline.
+export const MAX_ERROR_LOG_LINES = 50;
+const PINO_ERROR_LEVEL = 50;
+
 const SENSITIVE_KEY = /^(api_?key|token|password|secret|authorization|cookie|credentials?)$/i;
 
 const buffer: Record<string, unknown>[] = [];
+// t/2552: a secondary, smaller ring that pins error/fatal (level ≥ 50) entries so
+// they survive info-level flooding of the main ring. Entries here are the SAME
+// object references pushed into `buffer`, so drain dedups by reference identity.
+const errorBuffer: Record<string, unknown>[] = [];
 
 /** Recursively drop sensitive keys (defense-in-depth on top of pino redaction). */
 function scrub(value: unknown, depth = 0): void {
@@ -48,18 +58,39 @@ export function recordServerLog(chunk: string): void {
       }
       buffer.push(entry);
       if (buffer.length > MAX_LOG_LINES) buffer.shift();
+      // t/2552: also pin error/fatal into the secondary ring (same object ref) so
+      // a burst of info-level requests can't evict the one line that explains a 500.
+      if (typeof entry.level === 'number' && entry.level >= PINO_ERROR_LEVEL) {
+        errorBuffer.push(entry);
+        if (errorBuffer.length > MAX_ERROR_LOG_LINES) errorBuffer.shift();
+      }
     } catch {
       /* telemetry — silent by design: never let log buffering break logging (recursion-safe) */
     }
   }
 }
 
-/** A copy of the buffered log lines, oldest first (for inclusion in a server dump). */
+/**
+ * A copy of the buffered log lines, oldest first (for inclusion in a server dump).
+ *
+ * t/2552: returns the main ring PLUS any pinned error/fatal entries that the main
+ * ring has already evicted, so a 500's error line survives info-level flooding.
+ * Dedup is by object-reference identity — a pinned error is the SAME object that
+ * was pushed into `buffer`, so one still in the main window is filtered out of the
+ * error tail (never duplicated). Evicted errors are, by construction, older than
+ * every entry left in the main ring (they were pushed out by newer traffic), so
+ * they are prepended to keep the result chronological without sorting.
+ */
 export function drainServerLogLines(): Record<string, unknown>[] {
-  return buffer.slice();
+  const main = buffer.slice();
+  if (errorBuffer.length === 0) return main;
+  const inMain = new Set(main);
+  const evictedErrors = errorBuffer.filter(e => !inMain.has(e));
+  return evictedErrors.length === 0 ? main : [...evictedErrors, ...main];
 }
 
-/** Test-only: clear the buffer. */
+/** Test-only: clear both buffers. */
 export function _resetServerLogBuffer(): void {
   buffer.length = 0;
+  errorBuffer.length = 0;
 }


### PR DESCRIPTION
## Why (t/2552, Incident 3)
The merged flight-recorder dump for the 2026-08-13 news-report 500 held info-level (level 30) Pino lines but **not** the level-50 error line for the failing request — the 500 was invisible offline. Root cause (diagnosis t/2552#3): all three layers pass level-50 through unfiltered; the loss is **ring eviction**. The 250-entry main log ring fills with one info-level access-log entry per request, so 250+ requests between the error and the dump trigger push the error line out.

## Fix
Add a secondary pinned ring `errorBuffer` (cap `MAX_ERROR_LOG_LINES = 50`) that receives error/fatal (`level >= 50`) entries alongside the main ring — the **same object reference**, so `drainServerLogLines()` dedups by identity. Drain returns the main ring plus any pinned errors the main ring has already evicted, **prepended** (an evicted error is by construction older than everything left in main, so no sorting is needed). Error-level logs can no longer be evicted by info-level volume.

Scoped entirely to `serverLogBuffer.ts` (ServerAPI core layer); no consumer or merger change needed — `server.ts` `appendServerLogs` and `Merge-FlightRecorderDumps.ps1` already include whatever drain returns.

## Tests (`serverLogBuffer.test.ts`)
- An error survives a 300-line info flood — present exactly once, prepended oldest-first.
- An error still inside the main-ring window is not duplicated.
- The error ring caps at 50, keeping the most recent.

## Design gate
Created by Diagnostics (not TL) → no TL design gate. Single-scope bug fix following the file's own stated "separate small buffer" pattern; self-certified.

## Verification
`tsc -p tsconfig.server.json --noEmit` clean; `eslint` clean on changed files; `serverLogBuffer.test.ts` → 10 passed (3 new + 7 existing).

Closes t/2552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)