### PR TITLE
feat(analysis): useAnalytics hook — session scope + sessions list + subject WHO breakdown (t/2560)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useAnalytics.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useAnalytics.test.ts
@@ -128,6 +128,32 @@ describe('useAnalytics — subject WHO breakdown (§7.3)', () => {
     expect(mockGet).toHaveBeenLastCalledWith('/api/analytics/engagement?subject=sit-01b&groupBy=session');
     expect(hook.current.subject.isEmpty).toBe(true);
   });
+
+  // Contract v2 (t/2560#2, t/2562#2): under user scope the WHO query threads &user=
+  // so the user-scoped leaf panel gets by-session rows for that user only.
+  it('threads &user= when the active scope is a user (v2)', async () => {
+    mockGet.mockResolvedValueOnce({ aggregate: leaf(5), daily: [] });
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'user', user: 'alice@x.com' } }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+
+    mockGet.mockResolvedValueOnce([{ key: 's1', engagedMs: 500, visits: 2 }]);
+    act(() => { hook.current.loadSubjectBreakdown('src-l02', 'session'); });
+    await waitFor(() => expect(hook.current.subject.loading).toBe(false));
+
+    expect(mockGet).toHaveBeenLastCalledWith('/api/analytics/engagement?subject=src-l02&groupBy=session&user=alice%40x.com');
+  });
+
+  it('omits &user= under non-user scope (all / session)', async () => {
+    mockGet.mockResolvedValueOnce({ aggregate: leaf(5), daily: [] });
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'session', session: 's9' } }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+
+    mockGet.mockResolvedValueOnce([]);
+    act(() => { hook.current.loadSubjectBreakdown('src-l02', 'user'); });
+    await waitFor(() => expect(hook.current.subject.loading).toBe(false));
+
+    expect(mockGet).toHaveBeenLastCalledWith('/api/analytics/engagement?subject=src-l02&groupBy=user');
+  });
 });
 
 describe('useAnalytics — refetch + stale-response guard', () => {

--- a/taxonomy-editor/src/renderer/hooks/useAnalytics.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useAnalytics.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Mock-driven tests for useAnalytics (t/2560) — one per new surface from spec §7:
+// session scope (§7.1), sessions list riding the response (§7.2), subject WHO
+// breakdown (§7.3), plus loading/empty/error and the stale-response guard.
+// Live-verify against the real endpoint is noted for after t/2559 lands the server.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useAnalytics } from './useAnalytics';
+import type { EngagementResult, SubjectBreakdownRow, SessionRow, DateRange } from './useAnalytics';
+
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: vi.fn() }),
+}));
+
+vi.mock('../bridge/web-bridge', () => ({ bridgeGet: vi.fn() }));
+
+import { bridgeGet } from '../bridge/web-bridge';
+const mockGet = vi.mocked(bridgeGet);
+
+const RANGE: DateRange = { from: '2026-08-06', to: '2026-08-13' };
+
+function leaf(visits: number, engagedMs = 1000): import('../components/analysis/engagementTree').TreeNode {
+  return { id: 'root', visits, engagedVisits: visits, engagedMs };
+}
+
+const SESSIONS: SessionRow[] = [
+  { id: 's1', startTime: '2026-08-13T09:00:00.000Z', engagedMs: 4000, nodeCount: 3 },
+  { id: 's2', startTime: '2026-08-13T10:00:00.000Z', engagedMs: 1500, nodeCount: 1 },
+];
+
+afterEach(() => { vi.restoreAllMocks(); mockGet.mockReset(); });
+
+describe('useAnalytics — engagement scope (§7.1)', () => {
+  it('fetches the whole-population aggregate for scope "all" and reports non-empty', async () => {
+    const result: EngagementResult = { aggregate: leaf(42), daily: [] };
+    mockGet.mockResolvedValue(result);
+
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+
+    expect(mockGet).toHaveBeenCalledWith('/api/analytics/engagement?from=2026-08-06&to=2026-08-13');
+    expect(hook.current.engagement.data).toEqual(result);
+    expect(hook.current.engagement.isEmpty).toBe(false);
+  });
+
+  it('threads &user= for user scope', async () => {
+    mockGet.mockResolvedValue({ aggregate: leaf(5), daily: [] });
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'user', user: 'alice@x.com' } }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+    expect(mockGet).toHaveBeenCalledWith('/api/analytics/engagement?from=2026-08-06&to=2026-08-13&user=alice%40x.com');
+  });
+
+  it('threads &session= for session scope and returns the recomputed aggregate', async () => {
+    const scoped: EngagementResult = { aggregate: leaf(9, 7777), daily: [] };
+    mockGet.mockResolvedValue(scoped);
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'session', session: 's1' } }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+    expect(mockGet).toHaveBeenCalledWith('/api/analytics/engagement?from=2026-08-06&to=2026-08-13&session=s1');
+    expect(hook.current.engagement.data?.aggregate.engagedMs).toBe(7777);
+  });
+
+  it('reports isEmpty when the aggregate has zero visits', async () => {
+    mockGet.mockResolvedValue({ aggregate: leaf(0), daily: [] });
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+    expect(hook.current.engagement.isEmpty).toBe(true);
+  });
+
+  it('surfaces an error and leaves data null', async () => {
+    mockGet.mockRejectedValue(new Error('boom'));
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+    expect(hook.current.engagement.error).toContain('boom');
+    expect(hook.current.engagement.data).toBeNull();
+  });
+});
+
+describe('useAnalytics — sessions list (§7.2)', () => {
+  it('exposes sessions riding the user-scope response, with no second round-trip', async () => {
+    mockGet.mockResolvedValue({ aggregate: leaf(5), daily: [], sessions: SESSIONS });
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'user', user: 'alice' } }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+
+    expect(mockGet).toHaveBeenCalledTimes(1); // no separate sessions fetch
+    expect(hook.current.sessions.data).toEqual(SESSIONS);
+    expect(hook.current.sessions.isEmpty).toBe(false);
+  });
+
+  it('is empty under non-user scope even if the payload carried sessions', async () => {
+    mockGet.mockResolvedValue({ aggregate: leaf(5), daily: [], sessions: SESSIONS });
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'all' } }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+    expect(hook.current.sessions.isEmpty).toBe(true);
+  });
+});
+
+describe('useAnalytics — subject WHO breakdown (§7.3)', () => {
+  it('fetches ?subject=&groupBy=user on demand', async () => {
+    mockGet.mockResolvedValueOnce({ aggregate: leaf(5), daily: [] }); // initial engagement
+    const rows: SubjectBreakdownRow[] = [
+      { key: 'alice', engagedMs: 3000, visits: 4 },
+      { key: 'bob', engagedMs: 1000, visits: 1 },
+    ];
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+
+    mockGet.mockResolvedValueOnce(rows);
+    act(() => { hook.current.loadSubjectBreakdown('src-l02', 'user'); });
+    await waitFor(() => expect(hook.current.subject.loading).toBe(false));
+
+    expect(mockGet).toHaveBeenLastCalledWith('/api/analytics/engagement?subject=src-l02&groupBy=user');
+    expect(hook.current.subject.data).toEqual(rows);
+    expect(hook.current.subject.isEmpty).toBe(false);
+  });
+
+  it('reports isEmpty for a subject with no rows, and groupBy=session in the query', async () => {
+    mockGet.mockResolvedValueOnce({ aggregate: leaf(5), daily: [] });
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+
+    mockGet.mockResolvedValueOnce([]);
+    act(() => { hook.current.loadSubjectBreakdown('sit-01b', 'session'); });
+    await waitFor(() => expect(hook.current.subject.loading).toBe(false));
+
+    expect(mockGet).toHaveBeenLastCalledWith('/api/analytics/engagement?subject=sit-01b&groupBy=session');
+    expect(hook.current.subject.isEmpty).toBe(true);
+  });
+});
+
+describe('useAnalytics — refetch + stale-response guard', () => {
+  it('re-runs the engagement fetch on refetch()', async () => {
+    mockGet.mockResolvedValue({ aggregate: leaf(1), daily: [] });
+    const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
+    await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
+    expect(mockGet).toHaveBeenCalledTimes(1);
+
+    act(() => { hook.current.refetch(); });
+    await waitFor(() => expect(mockGet).toHaveBeenCalledTimes(2));
+  });
+
+  it('applies only the latest scope response when scope changes mid-flight', async () => {
+    // First (user=alice) resolves slowly; the rerender to session=s1 resolves first.
+    let resolveAlice!: (v: EngagementResult) => void;
+    mockGet.mockImplementationOnce(() => new Promise<EngagementResult>(r => { resolveAlice = r; }));
+    mockGet.mockResolvedValueOnce({ aggregate: leaf(2, 222), daily: [] }); // session=s1
+
+    const { result: hook, rerender } = renderHook(
+      (props: { scope: import('./useAnalytics').AnalyticsScope }) => useAnalytics({ range: RANGE, scope: props.scope }),
+      { initialProps: { scope: { kind: 'user', user: 'alice' } as import('./useAnalytics').AnalyticsScope } },
+    );
+
+    rerender({ scope: { kind: 'session', session: 's1' } });
+    await waitFor(() => expect(hook.current.engagement.data?.aggregate.engagedMs).toBe(222));
+
+    // The late alice response must be ignored (stale request id).
+    act(() => { resolveAlice({ aggregate: leaf(999, 999), daily: [] }); });
+    await Promise.resolve();
+    expect(hook.current.engagement.data?.aggregate.engagedMs).toBe(222);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useAnalytics.ts
+++ b/taxonomy-editor/src/renderer/hooks/useAnalytics.ts
@@ -79,6 +79,12 @@ export interface UseAnalyticsResult {
   sessions: AsyncState<SessionRow[]>;
   /** Subject WHO breakdown; fetched on demand via loadSubjectBreakdown. */
   subject: AsyncState<SubjectBreakdownRow[]>;
+  /**
+   * Fetch the WHO breakdown for a subject. Signature is stable across contract v2:
+   * when the active scope is `user`, the query threads `&user=` automatically so the
+   * user-scoped leaf panel gets rows for that user only (t/2560#2, t/2562#2). Callers
+   * do not pass the user — it follows the hook's active scope.
+   */
   loadSubjectBreakdown: (subjectId: string, groupBy: SubjectGroupBy) => void;
   /** Re-run the main engagement fetch. */
   refetch: () => void;
@@ -95,8 +101,11 @@ function engagementQuery(from: string, to: string, scope: AnalyticsScope): strin
   return base;
 }
 
-function subjectQuery(subjectId: string, groupBy: SubjectGroupBy): string {
-  return `${ENGAGEMENT}?subject=${encodeURIComponent(subjectId)}&groupBy=${groupBy}`;
+function subjectQuery(subjectId: string, groupBy: SubjectGroupBy, user?: string): string {
+  const base = `${ENGAGEMENT}?subject=${encodeURIComponent(subjectId)}&groupBy=${groupBy}`;
+  // Contract v2 (t/2560#2, t/2562#2): under user scope the leaf panel shows the
+  // by-session breakdown FOR THAT USER, so thread the active user into the WHO query.
+  return user ? `${base}&user=${encodeURIComponent(user)}` : base;
 }
 
 /** Stable string key for a scope, so effects re-run on semantic change only. */
@@ -133,6 +142,11 @@ export function useAnalytics({ range, scope = { kind: 'all' } }: UseAnalyticsOpt
   const engReq = useRef(0);
   const subjReq = useRef(0);
 
+  // Current scope, read at loadSubjectBreakdown call time so the WHO query threads the
+  // active user (contract v2) without re-creating the stable callback on every scope change.
+  const scopeRef = useRef<AnalyticsScope>(scope);
+  scopeRef.current = scope;
+
   const runEngagement = useCallback(() => {
     const id = ++engReq.current;
     setEngagement(LOADING);
@@ -155,7 +169,9 @@ export function useAnalytics({ range, scope = { kind: 'all' } }: UseAnalyticsOpt
   const loadSubjectBreakdown = useCallback((subjectId: string, groupBy: SubjectGroupBy) => {
     const id = ++subjReq.current;
     setSubject(LOADING);
-    bridgeGet<SubjectBreakdownRow[]>(subjectQuery(subjectId, groupBy))
+    const activeScope = scopeRef.current;
+    const userFilter = activeScope.kind === 'user' ? activeScope.user : undefined;
+    bridgeGet<SubjectBreakdownRow[]>(subjectQuery(subjectId, groupBy, userFilter))
       .then(rows => {
         if (id !== subjReq.current) return;
         setSubject({ data: rows, loading: false, error: null, isEmpty: rows.length === 0 });

--- a/taxonomy-editor/src/renderer/hooks/useAnalytics.ts
+++ b/taxonomy-editor/src/renderer/hooks/useAnalytics.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * useAnalytics — data hook for the usage-hierarchy UI (t/2560, spec §7 of
+ * docs/ux/usage-hierarchy-navigation.md). Lifts the engagement fetch that lived
+ * inline in EngagementDashboard.tsx into a reusable hook and extends it with the
+ * three additions the hierarchy UI (Analysis's UsageHierarchy.tsx, t/2561) needs:
+ *
+ *   §7.1  scope the aggregate TreeNode to a session (alongside the existing user scope)
+ *   §7.2  a per-user `sessions` list riding the engagement response (no 2nd round-trip)
+ *   §7.3  a subject-scoped WHO breakdown (?subject=&groupBy=user|session)
+ *
+ * Web-only admin route (bridgeGet → /api/analytics/engagement); the server strips
+ * per-user data for non-admins exactly as it already does for `users`. The server
+ * side of §7.1/§7.3 lands in t/2559 in parallel — this hook is built + tested
+ * against the spec-fixed shapes with mocks; live-verify after t/2559 merges.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { bridgeGet } from '../bridge/web-bridge';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import type { TreeNode } from '../components/analysis/engagementTree';
+
+// ── Contract types (frozen; published at t/2560#1) ───────────────────────────
+
+/** ISO yyyy-mm-dd range; the component derives it from the 7d/30d/90d presets. */
+export interface DateRange { from: string; to: string }
+
+/** Daily engagement point (existing shape). */
+export interface DailyPoint { date: string; visits: number; engagedVisits: number; engagedMs: number }
+
+/** Per-user leaderboard row (existing shape; admin-only). */
+export interface UserRow {
+  user: string;
+  visits: number;
+  engagedVisits: number;
+  engagedMs: number;
+  topCamp: string;
+  lastActive: string;
+}
+
+/**
+ * Main-tree scope. `session` scope returns the WHOLE aggregate TreeNode recomputed
+ * for that session (§7.1) — the client never holds the raw event log to do this.
+ */
+export type AnalyticsScope =
+  | { kind: 'all' }
+  | { kind: 'user'; user: string }
+  | { kind: 'session'; session: string };
+
+/** §7.2 — per-user session row (id + start + engagedMs + node count). */
+export interface SessionRow { id: string; startTime: string; engagedMs: number; nodeCount: number }
+
+/** Engagement response, extended with `sessions` (§7.2). */
+export interface EngagementResult {
+  aggregate: TreeNode;        // recomputed for the active scope (all | user | session)
+  user?: TreeNode;            // present when scope.kind === 'user' (existing)
+  daily: DailyPoint[];
+  users?: UserRow[];          // admin-only; stripped server-side for non-admins
+  sessions?: SessionRow[];    // admin-only; present when scope.kind === 'user' (§7.2)
+}
+
+/** §7.3 — subject WHO breakdown grouping. */
+export type SubjectGroupBy = 'user' | 'session';
+
+/** §7.3 — one WHO-breakdown row; `key` is a user id or session id per groupBy. */
+export interface SubjectBreakdownRow { key: string; engagedMs: number; visits: number }
+
+/** Uniform async envelope so every surface exposes loading / empty / error. */
+export interface AsyncState<T> { data: T | null; loading: boolean; error: string | null; isEmpty: boolean }
+
+export interface UseAnalyticsOptions { range: DateRange; scope?: AnalyticsScope }
+
+export interface UseAnalyticsResult {
+  /** Main engagement tree, reactive on { range, scope }. */
+  engagement: AsyncState<EngagementResult>;
+  /** View over engagement.data.sessions — rides the same fetch, mirrors its loading/error; populated only under user scope. */
+  sessions: AsyncState<SessionRow[]>;
+  /** Subject WHO breakdown; fetched on demand via loadSubjectBreakdown. */
+  subject: AsyncState<SubjectBreakdownRow[]>;
+  loadSubjectBreakdown: (subjectId: string, groupBy: SubjectGroupBy) => void;
+  /** Re-run the main engagement fetch. */
+  refetch: () => void;
+}
+
+// ── Query builders ───────────────────────────────────────────────────────────
+
+const ENGAGEMENT = '/api/analytics/engagement';
+
+function engagementQuery(from: string, to: string, scope: AnalyticsScope): string {
+  const base = `${ENGAGEMENT}?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
+  if (scope.kind === 'user') return `${base}&user=${encodeURIComponent(scope.user)}`;
+  if (scope.kind === 'session') return `${base}&session=${encodeURIComponent(scope.session)}`;
+  return base;
+}
+
+function subjectQuery(subjectId: string, groupBy: SubjectGroupBy): string {
+  return `${ENGAGEMENT}?subject=${encodeURIComponent(subjectId)}&groupBy=${groupBy}`;
+}
+
+/** Stable string key for a scope, so effects re-run on semantic change only. */
+function scopeKeyOf(scope: AnalyticsScope): string {
+  return scope.kind === 'user' ? `user:${scope.user}`
+    : scope.kind === 'session' ? `session:${scope.session}`
+    : 'all';
+}
+
+function recordError(message: string, err: unknown): void {
+  getGlobalRecorder()?.record({
+    type: 'system.error',
+    component: 'use-analytics',
+    level: 'error',
+    message,
+    error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+  });
+}
+
+const LOADING = <T,>(): AsyncState<T> => ({ data: null, loading: true, error: null, isEmpty: false });
+const IDLE = <T,>(): AsyncState<T> => ({ data: null, loading: false, error: null, isEmpty: false });
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useAnalytics({ range, scope = { kind: 'all' } }: UseAnalyticsOptions): UseAnalyticsResult {
+  const { from, to } = range;
+  const scopeKey = scopeKeyOf(scope);
+
+  const [engagement, setEngagement] = useState<AsyncState<EngagementResult>>(LOADING);
+  const [subject, setSubject] = useState<AsyncState<SubjectBreakdownRow[]>>(IDLE);
+
+  // Monotonic request ids: a response is applied only if it is the latest in flight
+  // for its surface, so a rapid scope/subject switch can never apply a stale result.
+  const engReq = useRef(0);
+  const subjReq = useRef(0);
+
+  const runEngagement = useCallback(() => {
+    const id = ++engReq.current;
+    setEngagement(LOADING);
+    bridgeGet<EngagementResult>(engagementQuery(from, to, scope))
+      .then(d => {
+        if (id !== engReq.current) return;
+        setEngagement({ data: d, loading: false, error: null, isEmpty: (d.aggregate?.visits ?? 0) === 0 });
+      })
+      .catch(err => {
+        if (id !== engReq.current) return;
+        recordError('Engagement query failed', err);
+        setEngagement({ data: null, loading: false, error: String(err), isEmpty: false });
+      });
+    // Deps are the primitives from/to/scopeKey — scopeKey encodes every scope field,
+    // so a semantic scope change re-runs the fetch without depending on the object identity.
+  }, [from, to, scopeKey]);
+
+  useEffect(() => { runEngagement(); }, [runEngagement]);
+
+  const loadSubjectBreakdown = useCallback((subjectId: string, groupBy: SubjectGroupBy) => {
+    const id = ++subjReq.current;
+    setSubject(LOADING);
+    bridgeGet<SubjectBreakdownRow[]>(subjectQuery(subjectId, groupBy))
+      .then(rows => {
+        if (id !== subjReq.current) return;
+        setSubject({ data: rows, loading: false, error: null, isEmpty: rows.length === 0 });
+      })
+      .catch(err => {
+        if (id !== subjReq.current) return;
+        recordError('Subject breakdown query failed', err);
+        setSubject({ data: null, loading: false, error: String(err), isEmpty: false });
+      });
+  }, []);
+
+  // §7.2 — sessions ride the engagement response under user scope. Expose them as
+  // their own AsyncState view (mirrors engagement's loading/error) so the session
+  // picker and the "by session" leaf breakdown render without a second round-trip.
+  const sessions = useMemo<AsyncState<SessionRow[]>>(() => ({
+    data: engagement.data?.sessions ?? null,
+    loading: engagement.loading,
+    error: engagement.error,
+    isEmpty: scope.kind !== 'user' || (engagement.data?.sessions?.length ?? 0) === 0,
+  }), [engagement, scope.kind]);
+
+  return { engagement, sessions, subject, loadSubjectBreakdown, refetch: runEngagement };
+}


### PR DESCRIPTION
Renderer-hook slice of the usage-hierarchy UI (t/2558, spec §7). Contract published interface-first at t/2560#1 so Analysis's `UsageHierarchy.tsx` (t/2561) builds against the frozen `UseAnalyticsResult` shape.

## What
New `useAnalytics` hook — lifts the engagement fetch that lived inline in `EngagementDashboard.tsx` into a reusable hook and extends it with the three spec §7 additions:
- **§7.1** session scope (`?session=`) → whole aggregate TreeNode recomputed for that session (alongside existing `?user=`)
- **§7.2** per-user `sessions` list riding the engagement response — no second round-trip
- **§7.3** subject WHO breakdown (`?subject=&groupBy=user|session`), on-demand

Each surface exposes a uniform `AsyncState` (data/loading/error/isEmpty). Monotonic request ids drop stale responses on rapid scope/subject switches. Web-only admin route (`bridgeGet`) — no Electron bridge/IPC. ADR-003 flight-recording in each catch.

## Tests
11 mock-driven tests: scope threading (all/user/session), isEmpty/error, sessions riding the response (+ empty under non-user scope), subject breakdown (both groupBy) + empty, refetch, and the stale-response guard.

## Notes
Self-cert (extends existing engagement fetch pattern). **Deviation flagged** (t/2560#1): no prior `useAnalytics` hook existed despite the ticket's "existing t/2463 hook" phrasing — created it from the inline fetch. Server side (§7.1/§7.3) lands in t/2559 in parallel; tests are mock-driven, **live-verify after t/2559 merges**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)