### PR TITLE
feat(analytics): sessions list + subject WHO breakdown (t/2562)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/analytics.engagement.test.ts
+++ b/taxonomy-editor/src/server/__tests__/analytics.engagement.test.ts
@@ -140,7 +140,7 @@ describe('queryEngagement — rollup math', () => {
       nodeEvent('saf-bel-001', 'saf', 'bel', { user: 'alice' }),
       nodeEvent('saf-bel-001', 'saf', 'bel', { user: 'bob' }),
     ], async () => {
-      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', 'alice');
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', { user: 'alice' });
       expect(result.aggregate.tool.uniqueUsers).toBe(2);
       expect(result.user!.tool.uniqueUsers).toBeUndefined();
     });
@@ -151,7 +151,7 @@ describe('queryEngagement — rollup math', () => {
       nodeEvent('skp-bel-001', 'skp', 'bel', { user: 'alice', duration_ms: 10000 }),
       nodeEvent('skp-bel-002', 'skp', 'bel', { user: 'bob', duration_ms: 5000 }),
     ], async () => {
-      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', 'alice');
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', { user: 'alice' });
       // aggregate sees both
       expect(result.aggregate.tool.visits).toBe(2);
       // user subtree sees only alice
@@ -215,6 +215,143 @@ describe('queryEngagement — rollup math', () => {
     ], async () => {
       const agg = (await analytics.queryEngagement('2026-08-10', '2026-08-10')).aggregate;
       expect(Object.keys(agg.camps).sort()).toEqual(['acc', 'cc', 'saf', 'skp']);
+    });
+  });
+
+  // ── t/2562 additions ──
+
+  it('session filter: aggregate tree is scoped to the session, users list is unfiltered', async () => {
+    await withEvents([
+      dwell({ user: 'alice', session_id: 's1', duration_ms: 8000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'bob',   session_id: 's2', duration_ms: 3000, detail: { subject_type: 'node', subject_id: 'saf-bel-001', pov: 'saf', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', { session: 's1' });
+      // aggregate uses sourceState = sessionState: only s1's event
+      expect(result.aggregate.tool.visits).toBe(1);
+      expect(result.aggregate.tool.engagedMs).toBe(8000);
+      expect(Object.keys(result.aggregate.camps)).toEqual(['acc']);
+      // users list always drawn from aggState — both users appear
+      expect(result.users.map(u => u.user).sort()).toEqual(['alice', 'bob']);
+    });
+  });
+
+  it('sessions list: startTime = min timestamp, engagedMs summed, nodeCount = distinct subject_ids', async () => {
+    await withEvents([
+      dwell({ session_id: 's1', timestamp: '2026-08-10T10:00:00Z', duration_ms: 5000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ session_id: 's1', timestamp: '2026-08-10T09:00:00Z', duration_ms: 2000, detail: { subject_type: 'node', subject_id: 'acc-bel-002', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ session_id: 's1', timestamp: '2026-08-10T11:00:00Z', duration_ms: 1000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: false, capped: false } }),
+      dwell({ session_id: 's2', timestamp: '2026-08-10T12:00:00Z', duration_ms: 9000, detail: { subject_type: 'node', subject_id: 'saf-des-001', pov: 'saf', cat: 'des', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', { includeSessions: true });
+      expect(result.sessions).toBeDefined();
+      const s1 = result.sessions!.find(s => s.session === 's1')!;
+      expect(s1).toBeDefined();
+      expect(s1.startTime).toBe('2026-08-10T09:00:00Z');  // min timestamp
+      expect(s1.engagedMs).toBe(8000);                    // 5000 + 2000 + 1000
+      expect(s1.nodeCount).toBe(2);                       // acc-bel-001 + acc-bel-002 (distinct)
+      const s2 = result.sessions!.find(s => s.session === 's2')!;
+      expect(s2.engagedMs).toBe(9000);
+      expect(s2.nodeCount).toBe(1);
+    });
+  });
+
+  it('sessions list scoped by user: only that user\'s sessions returned', async () => {
+    await withEvents([
+      dwell({ user: 'alice', session_id: 'sa1', timestamp: '2026-08-10T08:00:00Z', duration_ms: 4000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'bob',   session_id: 'sb1', timestamp: '2026-08-10T09:00:00Z', duration_ms: 6000, detail: { subject_type: 'node', subject_id: 'saf-bel-001', pov: 'saf', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', { user: 'alice', includeSessions: true });
+      expect(result.sessions).toBeDefined();
+      const sessionIds = result.sessions!.map(s => s.session);
+      expect(sessionIds).toContain('sa1');
+      expect(sessionIds).not.toContain('sb1');
+    });
+  });
+
+  it('querySubjectBreakdown groupBy=user: one row per distinct user, correct sums', async () => {
+    await withEvents([
+      dwell({ user: 'alice', session_id: 's1', duration_ms: 5000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'alice', session_id: 's2', duration_ms: 3000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'bob',   session_id: 's3', duration_ms: 7000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'alice', session_id: 's4', duration_ms: 1000, detail: { subject_type: 'node', subject_id: 'saf-bel-001', pov: 'saf', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.querySubjectBreakdown('2026-08-10', '2026-08-10', 'acc-bel-001', 'user');
+      expect(result.rows).toHaveLength(2);
+      const alice = result.rows.find(r => 'user' in r && r.user === 'alice') as { user: string; engagedMs: number; visits: number };
+      const bob   = result.rows.find(r => 'user' in r && r.user === 'bob')   as { user: string; engagedMs: number; visits: number };
+      expect(alice.engagedMs).toBe(8000);  // 5000 + 3000
+      expect(alice.visits).toBe(2);
+      expect(bob.engagedMs).toBe(7000);
+      expect(bob.visits).toBe(1);
+    });
+  });
+
+  it('querySubjectBreakdown groupBy=session: one row per distinct session_id', async () => {
+    await withEvents([
+      dwell({ user: 'alice', session_id: 's1', duration_ms: 5000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'alice', session_id: 's1', duration_ms: 2000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: false, capped: false } }),
+      dwell({ user: 'bob',   session_id: 's2', duration_ms: 9000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.querySubjectBreakdown('2026-08-10', '2026-08-10', 'acc-bel-001', 'session');
+      expect(result.rows).toHaveLength(2);
+      const s1 = result.rows.find(r => 'session' in r && r.session === 's1') as { session: string; engagedMs: number; visits: number };
+      expect(s1.engagedMs).toBe(7000);  // 5000 + 2000
+      expect(s1.visits).toBe(2);
+    });
+  });
+
+  it('querySubjectBreakdown: empty result when no events match subject', async () => {
+    await withEvents([
+      dwell({ detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.querySubjectBreakdown('2026-08-10', '2026-08-10', 'nonexistent-node', 'user');
+      expect(result.rows).toEqual([]);
+    });
+  });
+
+  it('regression: queryEngagement with no opts is byte-identical (no sessions key)', async () => {
+    await withEvents([
+      nodeEvent('acc-bel-001', 'acc', 'bel', { duration_ms: 5000 }),
+      nodeEvent('saf-des-001', 'saf', 'des', { duration_ms: 3000 }),
+    ], async () => {
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10');
+      expect(result.user).toBeUndefined();
+      expect(result.sessions).toBeUndefined();
+      // Verify the key is truly absent (not just undefined-valued)
+      expect(Object.prototype.hasOwnProperty.call(result, 'sessions')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(result, 'user')).toBe(false);
+    });
+  });
+
+  it('combined session + includeSessions: sessions still drawn from aggState', async () => {
+    await withEvents([
+      dwell({ user: 'alice', session_id: 'sa', timestamp: '2026-08-10T10:00:00Z', duration_ms: 6000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'bob',   session_id: 'sb', timestamp: '2026-08-10T11:00:00Z', duration_ms: 4000, detail: { subject_type: 'node', subject_id: 'saf-bel-001', pov: 'saf', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.queryEngagement('2026-08-10', '2026-08-10', { session: 'sa', includeSessions: true });
+      // aggregate (sourceState = sessionState for 'sa') sees only sa's event
+      expect(result.aggregate.tool.visits).toBe(1);
+      expect(result.aggregate.tool.engagedMs).toBe(6000);
+      // sessions come from aggState — both sessions present
+      expect(result.sessions).toBeDefined();
+      const sessionIds = result.sessions!.map(s => s.session);
+      expect(sessionIds.sort()).toEqual(['sa', 'sb']);
+    });
+  });
+
+  it('(TL condition) querySubjectBreakdown groupBy=session with user filter: only that user\'s sessions', async () => {
+    await withEvents([
+      dwell({ user: 'alice', session_id: 'sa1', duration_ms: 5000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'alice', session_id: 'sa2', duration_ms: 3000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+      dwell({ user: 'bob',   session_id: 'sb1', duration_ms: 9000, detail: { subject_type: 'node', subject_id: 'acc-bel-001', pov: 'acc', cat: 'bel', engaged: true, capped: false } }),
+    ], async () => {
+      const result = await analytics.querySubjectBreakdown('2026-08-10', '2026-08-10', 'acc-bel-001', 'session', 'alice');
+      // only alice's sessions
+      expect(result.rows).toHaveLength(2);
+      const sessionIds = result.rows.map(r => ('session' in r ? r.session : ''));
+      expect(sessionIds.sort()).toEqual(['sa1', 'sa2']);
+      // bob's session excluded
+      expect(sessionIds).not.toContain('sb1');
     });
   });
 });

--- a/taxonomy-editor/src/server/community/analytics.ts
+++ b/taxonomy-editor/src/server/community/analytics.ts
@@ -363,14 +363,24 @@ export interface EngagementUserEntry {
   lastActive: string;
 }
 
+/** Per-session rollup (admin-gated; present only when opts.includeSessions is requested). */
+export interface EngagementSessionEntry {
+  session: string;
+  startTime: string;    // ISO — first view.dwell timestamp for this session within [from, to]
+  engagedMs: number;
+  nodeCount: number;    // distinct visited subject_ids (100-char cap, matches node accumulator)
+}
+
 export interface EngagementQueryResult {
   aggregate: EngagementTree;
   /** Per-day engaged totals for section 1 of the dashboard. */
   daily: EngagementDailyEntry[];
   /** Per-user rollup for section 5; caller must strip for non-admins before sending. */
   users: EngagementUserEntry[];
-  /** Present when a `user` param was requested. */
+  /** Present when opts.user was requested. */
   user?: EngagementTree;
+  /** Present only when opts.includeSessions; admin-gated by the route layer. */
+  sessions?: EngagementSessionEntry[];
 }
 
 interface EngAccum {
@@ -406,6 +416,7 @@ function sealAccum(acc: EngAccum, withUsers: boolean): EngagementNodeResult {
 
 interface DailyEngAccum { visits: number; engagedVisits: number; engagedMs: number }
 interface UserEngAccum { visits: number; engagedVisits: number; engagedMs: number; lastActive: string; campCounts: Map<string, number> }
+interface SessionEngEntry { startTime: string; engagedMs: number; nodes: Set<string>; user: string }
 
 interface EngState {
   tool: EngAccum;
@@ -415,10 +426,12 @@ interface EngState {
   tabs: Map<string, EngAccum>;
   daily: Map<string, DailyEngAccum>;
   userSummaries: Map<string, UserEngAccum>;
+  /** null when not tracking sessions (ordinary queries pay no allocation cost). */
+  sessionEntries: Map<string, SessionEngEntry> | null;
 }
 
-function mkState(): EngState {
-  return { tool: mkAccum(), camps: new Map(), categories: new Map(), nodes: new Map(), tabs: new Map(), daily: new Map(), userSummaries: new Map() };
+function mkState(includeSessions = false): EngState {
+  return { tool: mkAccum(), camps: new Map(), categories: new Map(), nodes: new Map(), tabs: new Map(), daily: new Map(), userSummaries: new Map(), sessionEntries: includeSessions ? new Map() : null };
 }
 
 function getOrMake(m: Map<string, EngAccum>, key: string): EngAccum {
@@ -470,6 +483,18 @@ function placeEvent(state: EngState, evt: AnalyticsEvent): void {
     const tabKey = (typeof d.subject_id === 'string' && d.subject_id) ? d.subject_id.slice(0, 100) : 'unknown';
     addToAccum(getOrMake(state.tabs, tabKey), evt);
   }
+
+  // Session entry tracking — gated on sessionEntries != null (only allocated when includeSessions)
+  if (state.sessionEntries !== null) {
+    const sessId = evt.session_id;
+    let se = state.sessionEntries.get(sessId);
+    if (!se) { se = { startTime: evt.timestamp, engagedMs: 0, nodes: new Set(), user: evt.user }; state.sessionEntries.set(sessId, se); }
+    if (evt.timestamp < se.startTime) se.startTime = evt.timestamp;
+    se.engagedMs += typeof evt.duration_ms === 'number' ? evt.duration_ms : 0;
+    // nodeCount: cap subject_id at 100 chars to match the node accumulator bound above
+    const subId = typeof d.subject_id === 'string' && d.subject_id ? d.subject_id.slice(0, 100) : '';
+    if (subId) se.nodes.add(subId);
+  }
 }
 
 function buildTree(state: EngState, withUsers: boolean): EngagementTree {
@@ -494,20 +519,32 @@ function buildTree(state: EngState, withUsers: boolean): EngagementTree {
 /**
  * Aggregate view.dwell events into a tool→camp→category→node engagement tree,
  * a daily series, and a per-user rollup — all in one pass.
- * When `user` is provided, also returns that user's subtree (without uniqueUsers).
- * Callers are responsible for stripping `users` before sending to non-admin clients.
+ * opts.user    → also returns that user's subtree (without uniqueUsers).
+ * opts.session → aggregate + daily recomputed for that session only (§7.1).
+ * opts.includeSessions → adds sessions list (scoped to opts.user if set; admin-gated by caller).
+ * No opts → output is byte-identical to the pre-extension t/2463 result.
+ * Callers are responsible for stripping users/sessions before sending to non-admin clients.
  */
-export async function queryEngagement(from: string, to: string, user?: string): Promise<EngagementQueryResult> {
+export async function queryEngagement(
+  from: string,
+  to: string,
+  opts?: { user?: string; session?: string; includeSessions?: boolean },
+): Promise<EngagementQueryResult> {
   const events = await readEvents(from, to);
-  const aggState = mkState();
-  const userState = user ? mkState() : null;
+  const aggState = mkState(!!opts?.includeSessions);
+  const userState = opts?.user ? mkState(false) : null;
+  const sessionState = opts?.session ? mkState(false) : null;
+
   for (const evt of events) {
     if (evt.event_type !== 'view.dwell') continue;
     placeEvent(aggState, evt);
-    if (userState && evt.user === user) placeEvent(userState, evt);
+    if (userState && evt.user === opts!.user) placeEvent(userState, evt);
+    if (sessionState && evt.session_id === opts!.session) placeEvent(sessionState, evt);
   }
 
-  const daily: EngagementDailyEntry[] = Array.from(aggState.daily.entries())
+  const sourceState = sessionState ?? aggState;
+
+  const daily: EngagementDailyEntry[] = Array.from(sourceState.daily.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([date, d]) => ({ date, visits: d.visits, engagedVisits: d.engagedVisits, engagedMs: d.engagedMs }));
 
@@ -518,10 +555,58 @@ export async function queryEngagement(from: string, to: string, user?: string): 
     })
     .sort((a, b) => b.lastActive.localeCompare(a.lastActive));
 
+  let sessions: EngagementSessionEntry[] | undefined;
+  if (opts?.includeSessions && aggState.sessionEntries) {
+    const filterUser = opts.user;
+    sessions = Array.from(aggState.sessionEntries.entries())
+      .filter(([, se]) => !filterUser || se.user === filterUser)
+      .map(([session, se]) => ({ session, startTime: se.startTime, engagedMs: se.engagedMs, nodeCount: se.nodes.size }))
+      .sort((a, b) => a.startTime.localeCompare(b.startTime));
+  }
+
   return {
-    aggregate: buildTree(aggState, true),
+    aggregate: buildTree(sourceState, true),
     daily,
     users,
     ...(userState ? { user: buildTree(userState, false) } : {}),
+    ...(sessions !== undefined ? { sessions } : {}),
   };
+}
+
+/** Subject-scoped WHO breakdown for the leaf panel (spec §7.3).
+ *  One row per distinct user or session that viewed this subject, summing engagedMs + visits.
+ *  If user is provided, only that user's events are included (for the user-scoped leaf panel). */
+export type SubjectBreakdownRow =
+  | { user: string; engagedMs: number; visits: number }
+  | { session: string; engagedMs: number; visits: number };
+
+export interface SubjectBreakdownResult { rows: SubjectBreakdownRow[]; }
+
+export async function querySubjectBreakdown(
+  from: string,
+  to: string,
+  subjectId: string,
+  groupBy: 'user' | 'session',
+  user?: string,
+): Promise<SubjectBreakdownResult> {
+  const events = await readEvents(from, to);
+  const acc = new Map<string, { engagedMs: number; visits: number }>();
+  for (const evt of events) {
+    if (evt.event_type !== 'view.dwell') continue;
+    if (typeof evt.detail.subject_id !== 'string' || evt.detail.subject_id !== subjectId) continue;
+    if (user !== undefined && evt.user !== user) continue;
+    const key = groupBy === 'user' ? evt.user : evt.session_id;
+    let entry = acc.get(key);
+    if (!entry) { entry = { engagedMs: 0, visits: 0 }; acc.set(key, entry); }
+    entry.visits++;
+    entry.engagedMs += typeof evt.duration_ms === 'number' ? evt.duration_ms : 0;
+  }
+  const rows: SubjectBreakdownRow[] = Array.from(acc.entries())
+    .sort(([, a], [, b]) => b.engagedMs - a.engagedMs)
+    .map(([key, e]) =>
+      groupBy === 'user'
+        ? { user: key, engagedMs: e.engagedMs, visits: e.visits }
+        : { session: key, engagedMs: e.engagedMs, visits: e.visits },
+    );
+  return { rows };
 }

--- a/taxonomy-editor/src/server/routes/session.ts
+++ b/taxonomy-editor/src/server/routes/session.ts
@@ -192,7 +192,7 @@ export function registerSessionRoutes(r: Router, ctx: ServerCtx): void {
 
     if (user && user !== currentUserId && !requireAdmin(res)) return;
 
-    const { users, ...rest } = await analytics.queryEngagement(from, to, user);
+    const { users, ...rest } = await analytics.queryEngagement(from, to, user ? { user } : undefined);
     json(res, isAdmin(currentUserId) ? { ...rest, users } : rest);
   });
 


### PR DESCRIPTION
## Summary

- `queryEngagement` gains an `opts` object (`user`/`session`/`includeSessions`); `session` scopes the aggregate tree to a single session; `includeSessions` emits a `sessions[]` list (startTime, engagedMs, nodeCount per session)
- New `querySubjectBreakdown` export for the leaf-panel WHO breakdown (§7.3 of usage-hierarchy-navigation spec), grouped by user or session, with optional user filter (TL condition t/2562#2)
- `routes/session.ts`: trivial call-site update to pass `{ user }` opts object
- 9 new test cases: session filter, sessions list, user scope, subject groupBy=user/session, empty subject, regression (no-opts byte-identity), combined session+includeSessions, TL condition (groupBy=session + user filter)

## Test plan

- [x] `npx vitest run src/server/__tests__/analytics.engagement.test.ts` — 20/20 pass
- [x] `tsc -p tsconfig.server.json --noEmit` — clean
- [ ] CI green on this head

Closes t/2562

🤖 Generated with [Claude Code](https://claude.com/claude-code)