### PR TITLE
feat(server): analytics engagement route — session/sessions/subject additions (t/2559)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/engagementRoute.test.ts
+++ b/taxonomy-editor/src/server/__tests__/engagementRoute.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment node
+
+/**
+ * t/2559 — route-layer contract for GET /api/analytics/engagement (spec §7):
+ * param validation (safe-ID class, t/2526), admin gating of the session/subject/
+ * sessions extensions (TL p/333#89), and response shaping. The aggregation math
+ * lives in community/analytics.ts and is covered by analytics.engagement.test.ts;
+ * here the analytics module is mocked so we assert *only* the route's behavior.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+// Admin identity is a single flag both isAdmin() and requireAdmin() read, mirroring
+// how the real requireAdmin derives admin state from the request context.
+let adminState = false;
+vi.mock('../community/community.js', () => ({ isAdmin: () => adminState }));
+vi.mock('../community/admin/reviewRegistry.js', () => ({
+  requireAdmin: (res: ServerResponse & { _status?: number; _body?: string }) => {
+    if (adminState) return true;
+    res.writeHead(403, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Forbidden' }));
+    return false;
+  },
+}));
+
+const queryEngagement = vi.fn();
+const querySubjectBreakdown = vi.fn();
+vi.mock('../community/analytics.js', () => ({
+  queryEngagement: (...a: unknown[]) => queryEngagement(...a),
+  querySubjectBreakdown: (...a: unknown[]) => querySubjectBreakdown(...a),
+}));
+
+import { registerSessionRoutes } from '../routes/session.js';
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body: unknown) => Promise<void> | void;
+
+function makeRouter() {
+  const handlers: Record<string, Handler> = {};
+  const reg = (m: string) => (p: string, h: Handler) => { handlers[`${m} ${p}`] = h; };
+  return {
+    router: { get: reg('GET'), post: reg('POST'), put: reg('PUT'), patch: reg('PATCH'), del: reg('DELETE') },
+    handlers,
+  };
+}
+
+function fakeReq(query = ''): IncomingMessage {
+  return { url: `/api/analytics/engagement${query}`, method: 'GET', headers: {} } as unknown as IncomingMessage;
+}
+
+function fakeRes(): ServerResponse & { _status?: number; _body?: string } {
+  const res = {
+    writeHead: vi.fn((s: number) => { res._status = s; }),
+    end: vi.fn((b?: string) => { res._body = b; }),
+    setHeader: vi.fn(),
+  } as unknown as ServerResponse & { _status?: number; _body?: string };
+  return res;
+}
+
+const ENGAGE_RESULT = {
+  aggregate: { tool: { visits: 1 }, camps: {}, tabs: {} },
+  daily: [],
+  users: [{ user: 'alice' }],
+  sessions: [{ session: 's1', startTime: '2026-08-10T09:00:00Z', engagedMs: 100, nodeCount: 1 }],
+};
+
+describe('GET /api/analytics/engagement — route layer (t/2559)', () => {
+  let engagement: Handler;
+  beforeEach(() => {
+    adminState = false;
+    queryEngagement.mockReset().mockResolvedValue(ENGAGE_RESULT);
+    querySubjectBreakdown.mockReset().mockResolvedValue({ rows: [{ user: 'alice', engagedMs: 100, visits: 2 }] });
+    const { router, handlers } = makeRouter();
+    // ctx only needs broadcastEvent for /focus-node; engagement handler ignores it.
+    registerSessionRoutes(router as never, { broadcastEvent: vi.fn() } as never);
+    engagement = handlers['GET /api/analytics/engagement'];
+  });
+
+  // ── Safe-ID validation (t/2526), before any auth or query ──
+  it('400s a non-safe-ID session param', async () => {
+    const res = fakeRes();
+    await engagement(fakeReq('?session=bad%2Fid'), res, undefined);
+    expect(res._status).toBe(400);
+    expect(queryEngagement).not.toHaveBeenCalled();
+  });
+
+  it('400s a non-safe-ID subject param', async () => {
+    const res = fakeRes();
+    await engagement(fakeReq('?subject=bad%2Fid&groupBy=user'), res, undefined);
+    expect(res._status).toBe(400);
+    expect(querySubjectBreakdown).not.toHaveBeenCalled();
+  });
+
+  // ── Subject WHO breakdown (§7.3) — admin-only, groupBy required ──
+  it('403s a non-admin subject breakdown', async () => {
+    const res = fakeRes();
+    await engagement(fakeReq('?subject=acc-bel-001&groupBy=user'), res, undefined);
+    expect(res._status).toBe(403);
+    expect(querySubjectBreakdown).not.toHaveBeenCalled();
+  });
+
+  it('400s subject breakdown with a missing/invalid groupBy (admin)', async () => {
+    adminState = true;
+    const res = fakeRes();
+    await engagement(fakeReq('?subject=acc-bel-001&groupBy=teams'), res, undefined);
+    expect(res._status).toBe(400);
+    expect(querySubjectBreakdown).not.toHaveBeenCalled();
+  });
+
+  it('serves subject breakdown for an admin and threads the optional user filter (TL addendum)', async () => {
+    adminState = true;
+    const res = fakeRes();
+    await engagement(fakeReq('?subject=acc-bel-001&groupBy=session&user=alice'), res, undefined);
+    expect(res._status ?? 200).toBe(200);
+    expect(querySubjectBreakdown).toHaveBeenCalledWith(expect.any(String), expect.any(String), 'acc-bel-001', 'session', 'alice');
+    expect(JSON.parse(res._body!)).toEqual({ rows: [{ user: 'alice', engagedMs: 100, visits: 2 }] });
+    expect(queryEngagement).not.toHaveBeenCalled();
+  });
+
+  // ── Session scope (§7.1) — admin-only ──
+  it('403s a non-admin ?session= request', async () => {
+    const res = fakeRes();
+    await engagement(fakeReq('?session=s1'), res, undefined);
+    expect(res._status).toBe(403);
+    expect(queryEngagement).not.toHaveBeenCalled();
+  });
+
+  it('serves a session-scoped tree for an admin and passes session through', async () => {
+    adminState = true;
+    const res = fakeRes();
+    await engagement(fakeReq('?session=s1'), res, undefined);
+    expect(res._status ?? 200).toBe(200);
+    expect(queryEngagement).toHaveBeenCalledWith(expect.any(String), expect.any(String), { user: undefined, session: 's1', includeSessions: true });
+  });
+
+  // ── Response shaping / gating of users + sessions (§7.2) ──
+  it('strips users and sessions for a non-admin base request', async () => {
+    const res = fakeRes();
+    await engagement(fakeReq(''), res, undefined);
+    expect(res._status ?? 200).toBe(200);
+    // non-admin → includeSessions:false
+    expect(queryEngagement).toHaveBeenCalledWith(expect.any(String), expect.any(String), { user: undefined, session: undefined, includeSessions: false });
+    const body = JSON.parse(res._body!);
+    expect(body).toHaveProperty('aggregate');
+    expect(body).not.toHaveProperty('users');
+    expect(body).not.toHaveProperty('sessions');
+  });
+
+  it('includes users and sessions for an admin base request', async () => {
+    adminState = true;
+    const res = fakeRes();
+    await engagement(fakeReq(''), res, undefined);
+    expect(queryEngagement).toHaveBeenCalledWith(expect.any(String), expect.any(String), { user: undefined, session: undefined, includeSessions: true });
+    const body = JSON.parse(res._body!);
+    expect(body.users).toEqual(ENGAGE_RESULT.users);
+    expect(body.sessions).toEqual(ENGAGE_RESULT.sessions);
+  });
+
+  it('403s a non-admin querying another user (existing gating unchanged)', async () => {
+    const res = fakeRes();
+    await engagement(fakeReq('?user=someone-else'), res, undefined);
+    expect(res._status).toBe(403);
+    expect(queryEngagement).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/server/routes/session.ts
+++ b/taxonomy-editor/src/server/routes/session.ts
@@ -14,13 +14,14 @@
 // cap (TRACE_MAX_EVENTS_PER_BATCH) is used only by /debug/events, so it moves in
 // as module-local state. All other helpers are pure module imports.
 
-import type { IncomingMessage } from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error, getClientIp } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { log } from '../logger.js';
 import { deriveStorageUserId } from '../security/userContext.js';
+import { isSafeId } from '../storage/fileIO.js';
 import { getQuotaLimits } from '../security/quotas.js';
 import { requireAdmin } from '../community/admin/reviewRegistry.js';
 import { isAdmin } from '../community/community.js';
@@ -40,6 +41,40 @@ export function resolveAnonSessionKey(req: IncomingMessage): string {
 }
 
 const TRACE_MAX_EVENTS_PER_BATCH = 100;
+
+/** Derive the analytics user id for a request from the Easy Auth principal headers
+ *  (only when Azure auth is enabled), falling back to '_local'. */
+function deriveRequestUserId(req: IncomingMessage): string {
+  const azureAuth = process.env.WEBSITE_AUTH_ENABLED === 'True' || process.env.WEBSITE_AUTH_ENABLED === 'true';
+  const principalName = azureAuth ? (req.headers['x-ms-client-principal-name'] as string) || '' : '';
+  const idp = azureAuth ? (req.headers['x-ms-client-principal-idp'] as string) || '' : '';
+  return deriveStorageUserId(principalName || '_local', idp || '_local');
+}
+
+/** §7.3 subject WHO breakdown — admin-only. Extracted so the engagement handler
+ *  stays under the complexity ceiling (ADR-007). `subject` is already validated. */
+async function serveSubjectBreakdown(
+  res: ServerResponse, from: string, to: string,
+  subject: string, groupBy: string | undefined, user: string | undefined,
+): Promise<void> {
+  if (!requireAdmin(res)) return;
+  if (groupBy !== 'user' && groupBy !== 'session') { error(res, "groupBy must be 'user' or 'session'", 400); return; }
+  json(res, await analytics.querySubjectBreakdown(from, to, subject, groupBy, user));
+}
+
+/** Engagement tree (+ §7.1 session scope, §7.2 sessions list). The session scope,
+ *  other-user subtree, users table, and sessions list are all admin-only; non-admins
+ *  receive only the anonymized aggregate. */
+async function serveEngagementTree(
+  res: ServerResponse, from: string, to: string,
+  user: string | undefined, session: string | undefined,
+  currentUserId: string, admin: boolean,
+): Promise<void> {
+  const needsAdmin = session !== undefined || (user !== undefined && user !== currentUserId);
+  if (needsAdmin && !requireAdmin(res)) return;
+  const { users, sessions, ...rest } = await analytics.queryEngagement(from, to, { user, session, includeSessions: admin });
+  json(res, admin ? { ...rest, users, ...(sessions ? { sessions } : {}) } : rest);
+}
 
 export function registerSessionRoutes(r: Router, ctx: ServerCtx): void {
   const { get, post } = r;
@@ -178,22 +213,31 @@ export function registerSessionRoutes(r: Router, ctx: ServerCtx): void {
 
   // t/2467: engagement tree (view.dwell roll-up — tool→camp→category→node).
   // Aggregate + daily open to any authenticated caller.
-  // Per-user subtree (other-user) and users table are admin-gated.
+  // t/2559 (spec §7) — three admin-only extensions over the same single pass:
+  //   ?session=<id>              → aggregate/daily recomputed for one session (§7.1)
+  //   sessions[] (admin)         → per-session rollup for the session picker (§7.2)
+  //   ?subject=<id>&groupBy=…     → WHO breakdown rows, optional &user= scope (§7.3)
+  // The per-user subtree, users table, sessions list, and the session/subject
+  // extensions are all admin-gated (TL p/333#89). `session`/`subject` are validated
+  // with the shared safe-ID validator (t/2526) at the boundary. `user` is an in-memory
+  // equality filter only (never a path) and can legitimately carry email-derived chars
+  // (e.g. `+` from deriveStorageUserId), so it is deliberately NOT safe-ID-constrained.
   get('/api/analytics/engagement', async (req, res) => {
     const url = new URL(req.url!, 'http://localhost');
     const from = url.searchParams.get('from') || new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
     const to = url.searchParams.get('to') || new Date().toISOString().slice(0, 10);
     const user = url.searchParams.get('user') || undefined;
+    const session = url.searchParams.get('session') || undefined;
+    const subject = url.searchParams.get('subject') || undefined;
+    const groupBy = url.searchParams.get('groupBy') || undefined;
 
-    const azureAuth = process.env.WEBSITE_AUTH_ENABLED === 'True' || process.env.WEBSITE_AUTH_ENABLED === 'true';
-    const principalName = azureAuth ? (req.headers['x-ms-client-principal-name'] as string) || '' : '';
-    const idp = azureAuth ? (req.headers['x-ms-client-principal-idp'] as string) || '' : '';
-    const currentUserId = deriveStorageUserId(principalName || '_local', idp || '_local');
+    // t/2526 safe-ID validation at the boundary, before any query.
+    if (session !== undefined && !isSafeId(session)) { error(res, 'Invalid session id', 400); return; }
+    if (subject !== undefined && !isSafeId(subject)) { error(res, 'Invalid subject id', 400); return; }
 
-    if (user && user !== currentUserId && !requireAdmin(res)) return;
-
-    const { users, ...rest } = await analytics.queryEngagement(from, to, user ? { user } : undefined);
-    json(res, isAdmin(currentUserId) ? { ...rest, users } : rest);
+    const currentUserId = deriveRequestUserId(req);
+    if (subject !== undefined) { await serveSubjectBreakdown(res, from, to, subject, groupBy, user); return; }
+    await serveEngagementTree(res, from, to, user, session, currentUserId, isAdmin(currentUserId));
   });
 
   // ── Focus node (inter-app communication) ──


### PR DESCRIPTION
Route half of **t/2559** (spec §7), consuming the t/2562 aggregation primitives (`queryEngagement` opts + `querySubjectBreakdown`, landed `b8b6c80f`). Contract agreed with Server Community at t/2559#2/#3.

## Additions to `GET /api/analytics/engagement`
- `?session=<id>` → session-scoped `aggregate`/`daily` (§7.1) — **admin-only**
- `sessions[]` per-session rollup (§7.2) — included for admins, stripped for non-admins
- `?subject=<id>&groupBy=user|session[&user=<id>]` → WHO breakdown `{ rows }` (§7.3) — **admin-only**; the optional `&user=` (TL addendum t/2562#2) threads to `querySubjectBreakdown`

## Validation & gating
- `session`/`subject` validated with the t/2526 shared `isSafeId` at the boundary → 400 before any query; `groupBy` restricted to `user|session` → 400.
- **`user` is deliberately NOT `isSafeId`-validated** — it's an in-memory equality filter (never a path), and `deriveStorageUserId` can emit email-derived chars (`+`, etc.) that `isSafeId` would wrongly reject, regressing the existing `?user=` path. (This corrects my own earlier note on t/2559#5 that said I'd validate `user`.)
- Admin gating per TL (p/333#89): session scope, subject breakdown, other-user subtree, users table, and sessions list are all admin-only; non-admins get the anonymized aggregate.
- Handler decomposed (`deriveRequestUserId` / `serveSubjectBreakdown` / `serveEngagementTree`) to stay under the ADR-007 complexity ceiling.

## Design gate
TL routed the route half to me as self-cert; the cross-role interface it consumes was TL-signed-off separately on t/2562. Self-certified — no deviation from the agreed §7 shapes.

## Verification
`tsc -p tsconfig.server.json --noEmit` clean; `eslint` clean (no complexity warning); route tests (`engagementRoute.test.ts`, 10) + `routeTable` invariant + existing `analytics.engagement` suite → 34 passed.

Closes t/2559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)