### PR TITLE
ops(drift): document post-claim restore-before-pull sequence (p/331#98)

### DIFF
--- a/operations/devops/check-shared-drift.ps1
+++ b/operations/devops/check-shared-drift.ps1
@@ -161,7 +161,7 @@ try {
                 $hints += "dirty tracked (0-diff, safe to drop) [$listed]: git checkout -- <files>"
             } else {
                 $listed = $dirtyFiles -join ', '
-                $hints += "dirty tracked with REAL DIFF (WIP) [$listed]: snapshot-first + owner-claim required — do NOT stash or auto-merge; escalate to TL"
+                $hints += "dirty tracked with REAL DIFF (WIP) [$listed]: snapshot-first + owner-claim required — do NOT stash or auto-merge; escalate to TL | POST-CLAIM pull: git restore <files> THEN git pull --ff-only (dirty tracked file silently blocks ff-merge even on byte-identical incoming content — restore first; p/331#98)"
             }
         }
         $result.RemediationHint = $hints -join ' | '


### PR DESCRIPTION
Captures the operational finding from p/331#98: after a TL-claimed dirty tracked file is committed via PR and merged into origin/main, a bare `git pull --ff-only` on the shared tree silently fails to advance HEAD when the dirty copy is still present — even when the incoming content is byte-identical. The pull exits 0 but HEAD does not move. Fix sequence: `git restore <file>` THEN `git pull --ff-only`.

Adds this note to the RemediationHint for the real-diff dirty-file case so the agent sees the correct post-claim sequence.

## Test plan
- [ ] Verify hint string appears in output when HasRealDiff=true
- [ ] Docs-only change: no behavior change, all CI skips OK

Self-certifying under /trivial-change — 1 line changed, my scope, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
