### PR TITLE
feat(main): multi-window chat — Map registry, 5-window cap, MRU focus (t/2564)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/chatWindow.multiWindow.test.ts
+++ b/taxonomy-editor/src/main/__tests__/chatWindow.multiWindow.test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Unit tests for multi-window chat registry (t/2564).
+// Verifies: cap enforcement, MRU focus-at-cap, cascade offset,
+// closed-event cleanup, main-window notification, and destroyed-window pruning.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+
+// ---------------------------------------------------------------------------
+// Shared mock state (module-level so vi.fn implementations close over them)
+// ---------------------------------------------------------------------------
+
+const mockWins: Record<string, unknown>[] = [];
+let winIdCounter = 0;
+
+function makeMockWin(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const id = ++winIdCounter;
+  return {
+    id,
+    isDestroyed: vi.fn(() => false),
+    isMinimized: vi.fn(() => false),
+    restore: vi.fn(),
+    show: vi.fn(),
+    focus: vi.fn(),
+    loadURL: vi.fn(async () => undefined),
+    loadFile: vi.fn(async () => undefined),
+    on: vi.fn(),
+    webContents: { send: vi.fn() },
+    ...overrides,
+  };
+}
+
+// vi.hoisted so these are available inside vi.mock factories.
+const mockHandle = vi.hoisted(() => vi.fn());
+const mockGetPrimaryDisplay = vi.hoisted(() =>
+  vi.fn(() => ({ workAreaSize: { width: 1920, height: 1080 } })),
+);
+
+// BrowserWindow mock: must use a regular function (not arrow) so `new BW()` works.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockBrowserWindow = vi.hoisted(() => vi.fn(function MockBW(this: any) {
+  const win = makeMockWin();
+  mockWins.push(win);
+  return win;
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: mockHandle },
+  BrowserWindow: MockBrowserWindow,
+  screen: { getPrimaryDisplay: mockGetPrimaryDisplay },
+  app: { isPackaged: false },
+}));
+
+vi.mock('../fileIO.js', () => ({ PROJECT_ROOT: '/fake/root' }));
+
+// ---------------------------------------------------------------------------
+
+import { registerChatWindowHandlers, chatWindows, MAX_CHAT_WINDOWS } from '../ipc/chatWindowHandlers.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getHandler(): (...args: unknown[]) => Promise<unknown> {
+  const calls = (mockHandle as ReturnType<typeof vi.fn>).mock.calls;
+  const entry = calls.find((c: unknown[]) => c[0] === 'open-chat-window');
+  if (!entry) throw new Error('open-chat-window handler not registered');
+  return entry[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+function makeMainWindow(destroyed = false) {
+  return { isDestroyed: () => destroyed, webContents: { send: vi.fn() } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWins.length = 0;
+  winIdCounter = 0;
+  chatWindows.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('registerChatWindowHandlers — open-chat-window', () => {
+  it('registers the open-chat-window IPC handler', () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
+    expect(mockHandle).toHaveBeenCalledWith('open-chat-window', expect.any(Function));
+  });
+
+  it('creates a new window and adds it to chatWindows', async () => {
+    const hardenWindow = vi.fn();
+    registerChatWindowHandlers('/fake/preload.cjs', () => makeMainWindow() as never, hardenWindow);
+    await getHandler()();
+
+    expect(MockBrowserWindow).toHaveBeenCalledTimes(1);
+    expect(chatWindows.size).toBe(1);
+    expect(hardenWindow).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes preloadPath into BrowserWindow webPreferences', async () => {
+    registerChatWindowHandlers('/my/preload.cjs', () => null, vi.fn());
+    await getHandler()();
+
+    const opts = (MockBrowserWindow as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(opts?.webPreferences?.preload).toBe('/my/preload.cjs');
+  });
+
+  it('applies cascade offset on second window', async () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
+    const handler = getHandler();
+
+    // First window: size was 0 → offset 0 → x/y undefined
+    await handler();
+    const firstOpts = (MockBrowserWindow as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(firstOpts?.x).toBeUndefined();
+
+    // Manually register first win so chatWindows.size === 1 before second call
+    chatWindows.set(mockWins[0]!.id as number, mockWins[0] as never);
+
+    await handler();
+    const secondOpts = (MockBrowserWindow as ReturnType<typeof vi.fn>).mock.calls[1]?.[0];
+    expect(secondOpts?.x).toBe(30);
+    expect(secondOpts?.y).toBe(30);
+  });
+
+  it('focuses MRU window (no new window) when at cap', async () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
+    const handler = getHandler();
+
+    for (let i = 0; i < MAX_CHAT_WINDOWS; i++) {
+      const win = makeMockWin();
+      chatWindows.set(win.id as number, win as never);
+    }
+    const mruWin = [...chatWindows.values()].at(-1) as unknown as Record<string, unknown>;
+
+    await handler();
+
+    expect(MockBrowserWindow).not.toHaveBeenCalled();
+    expect((mruWin.show as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    expect((mruWin.focus as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+
+  it('restores a minimized MRU window when at cap', async () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
+    const handler = getHandler();
+
+    for (let i = 0; i < MAX_CHAT_WINDOWS; i++) {
+      const win = makeMockWin({ isMinimized: vi.fn(() => true) });
+      chatWindows.set(win.id as number, win as never);
+    }
+    const mruWin = [...chatWindows.values()].at(-1) as unknown as Record<string, unknown>;
+
+    await handler();
+    expect((mruWin.restore as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+
+  it('prunes destroyed windows then creates a new one', async () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
+    const handler = getHandler();
+
+    for (let i = 0; i < MAX_CHAT_WINDOWS; i++) {
+      const win = makeMockWin({ isDestroyed: vi.fn(() => true) });
+      chatWindows.set(win.id as number, win as never);
+    }
+
+    await handler();
+
+    expect(MockBrowserWindow).toHaveBeenCalledTimes(1);
+    expect(chatWindows.size).toBe(1);
+  });
+
+  it('removes window from chatWindows on closed event', async () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => makeMainWindow() as never, vi.fn());
+    await getHandler()();
+
+    const win = mockWins[0]!;
+    const closedCb = (win.on as ReturnType<typeof vi.fn>).mock.calls
+      .find((c: unknown[]) => c[0] === 'closed')?.[1] as () => void;
+
+    expect(chatWindows.size).toBe(1);
+    closedCb();
+    expect(chatWindows.size).toBe(0);
+  });
+
+  it('sends chat-popout-closed to main window on chat close', async () => {
+    const mainWin = makeMainWindow();
+    registerChatWindowHandlers('/fake/preload.cjs', () => mainWin as never, vi.fn());
+    await getHandler()();
+
+    const win = mockWins[0]!;
+    const closedCb = (win.on as ReturnType<typeof vi.fn>).mock.calls
+      .find((c: unknown[]) => c[0] === 'closed')?.[1] as () => void;
+
+    closedCb();
+    expect(mainWin.webContents.send).toHaveBeenCalledWith('chat-popout-closed');
+  });
+
+  it('does not crash when main window is null on closed', async () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
+    await getHandler()();
+
+    const win = mockWins[0]!;
+    const closedCb = (win.on as ReturnType<typeof vi.fn>).mock.calls
+      .find((c: unknown[]) => c[0] === 'closed')?.[1] as () => void;
+
+    expect(() => closedCb()).not.toThrow();
+  });
+
+  it('does not crash when main window is destroyed on closed', async () => {
+    const mainWin = makeMainWindow(true);
+    registerChatWindowHandlers('/fake/preload.cjs', () => mainWin as never, vi.fn());
+    await getHandler()();
+
+    const win = mockWins[0]!;
+    const closedCb = (win.on as ReturnType<typeof vi.fn>).mock.calls
+      .find((c: unknown[]) => c[0] === 'closed')?.[1] as () => void;
+
+    expect(() => closedCb()).not.toThrow();
+  });
+});

--- a/taxonomy-editor/src/main/ipc/chatWindowHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/chatWindowHandlers.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Chat popout window management (t/2564): up to MAX_CHAT_WINDOWS concurrent
+// independent sessions. Each window's chat-stream events target only its own
+// webContents — no cross-stream contamination (aiHandlers uses event.sender.send).
+//
+// Web build: openChatWindow opens a new browser tab on every click; no cap is
+// enforced there — the browser handles tab management natively. This Electron
+// cap is intentionally not mirrored in web-bridge.ts.
+
+import { ipcMain, BrowserWindow, screen, app } from 'electron';
+import path from 'path';
+import { PROJECT_ROOT } from '../fileIO.js';
+
+export const MAX_CHAT_WINDOWS = 5;
+
+// Module-level registry: window id → BrowserWindow.
+// Exported so tests can reset state between runs.
+export const chatWindows = new Map<number, BrowserWindow>();
+
+export function registerChatWindowHandlers(
+  preloadPath: string,
+  getMainWindow: () => BrowserWindow | null,
+  hardenWindow: (win: BrowserWindow) => void,
+): void {
+  ipcMain.handle('open-chat-window', () => {
+    // Prune any windows destroyed without firing 'closed' (defensive).
+    for (const [id, win] of chatWindows) {
+      if (win.isDestroyed()) chatWindows.delete(id);
+    }
+
+    if (chatWindows.size >= MAX_CHAT_WINDOWS) {
+      // At cap: focus the most-recently-opened chat window (last Map entry).
+      const mruWin = [...chatWindows.values()].at(-1)!;
+      if (mruWin.isMinimized()) mruWin.restore();
+      mruWin.show();
+      mruWin.focus();
+      return;
+    }
+
+    const { width: screenW, height: screenH } = screen.getPrimaryDisplay().workAreaSize;
+    const offset = chatWindows.size * 30;
+
+    const win = new BrowserWindow({
+      width: Math.round(screenW * 0.5),
+      height: Math.round(screenH * 0.75),
+      x: offset || undefined,
+      y: offset || undefined,
+      minWidth: 400,
+      minHeight: 400,
+      title: 'POVer Chat',
+      alwaysOnTop: false,
+      webPreferences: {
+        preload: preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+
+    hardenWindow(win);
+
+    const isDev = !app.isPackaged;
+    if (isDev) {
+      void win.loadURL('http://localhost:5173#chat-window');
+    } else {
+      void win.loadFile(path.join(PROJECT_ROOT, 'taxonomy-editor/dist/renderer/index.html'), { hash: 'chat-window' });
+    }
+
+    chatWindows.set(win.id, win);
+
+    win.on('closed', () => {
+      chatWindows.delete(win.id);
+      const mainWindow = getMainWindow();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('chat-popout-closed');
+      }
+    });
+  });
+}

--- a/taxonomy-editor/src/main/main.ts
+++ b/taxonomy-editor/src/main/main.ts
@@ -22,13 +22,13 @@ import { warmupEmbeddingModel } from './embeddings.js';
 console.log('[main] embeddings import OK');
 import { PROJECT_ROOT } from './fileIO.js';
 console.log('[main] fileIO import OK');
+import { registerChatWindowHandlers } from './ipc/chatWindowHandlers.js';
 
 let mainWindow: BrowserWindow | null = null;
 let diagWindow: BrowserWindow | null = null;
 let povProgWindow: BrowserWindow | null = null;
 const debateWindows = new Map<string, BrowserWindow>();
 let promptDiffWindow: BrowserWindow | null = null;
-let chatWindow: BrowserWindow | null = null;
 let diffWindow: BrowserWindow | null = null;
 let focusServer: http.Server | null = null;
 
@@ -438,44 +438,7 @@ void app.whenReady().then(() => {
     }
   });
 
-  // Chat popout window
-  ipcMain.handle('open-chat-window', () => {
-    if (chatWindow && !chatWindow.isDestroyed()) {
-      if (chatWindow.isMinimized()) chatWindow.restore();
-      chatWindow.show();
-      chatWindow.focus();
-      return;
-    }
-    const preloadPath = path.join(__dirname, 'preload.cjs');
-    const { width: screenW, height: screenH } = screen.getPrimaryDisplay().workAreaSize;
-    chatWindow = new BrowserWindow({
-      width: Math.round(screenW * 0.5),
-      height: Math.round(screenH * 0.75),
-      minWidth: 400,
-      minHeight: 400,
-      title: 'POVer Chat',
-      alwaysOnTop: false,
-      webPreferences: {
-        preload: preloadPath,
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: true,
-      },
-    });
-    hardenWindow(chatWindow);
-    const isDev = !app.isPackaged;
-    if (isDev) {
-      void chatWindow.loadURL('http://localhost:5173#chat-window');
-    } else {
-      void chatWindow.loadFile(path.join(PROJECT_ROOT, 'taxonomy-editor/dist/renderer/index.html'), { hash: 'chat-window' });
-    }
-    chatWindow.on('closed', () => {
-      chatWindow = null;
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send('chat-popout-closed');
-      }
-    });
-  });
+  registerChatWindowHandlers(path.join(__dirname, 'preload.cjs'), () => mainWindow, hardenWindow);
 
   // Prompt Diff popout window
   ipcMain.handle('open-prompt-diff-window', (_event, debateId: string, entryId: string) => {


### PR DESCRIPTION
## Summary
- Replace singleton \chatWindow\ with \Map<number, BrowserWindow>\ supporting up to 5 concurrent independent chat sessions
- Extract handler to \ipc/chatWindowHandlers.ts\ (ADR-007 pattern); \main.ts\ calls \egisterChatWindowHandlers()\
- Sixth click focuses MRU window; cascade offset (30px/window); closed event frees slot and notifies main window

## Test plan
- [x] 11 unit tests in \chatWindow.multiWindow.test.ts\: cap enforcement, MRU restore+focus, cascade offset, closed-event cleanup, main-window notification, null/destroyed-main-window safety, destroyed-window pruning
- [x] \	sc -p tsconfig.main.json\ — clean
- [ ] CI green on this head

🤖 Generated with [Claude Code](https://claude.com/claude-code)