### PR TITLE
fix(theme): define --bar per-theme (share bars hardcoded #3b82f6) (t/2565)

### DIFF
--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -48,6 +48,7 @@
   --success: #22c55e; --success-text: #15803d; /* AA green TEXT on --bg-primary; --success stays fill (t/2260) */
   --warning: #a16207;
   --focus-ring: #3b82f6;
+  --bar: #3b82f6; /* data-blue share-bar fill; was undefined → hardcoded fallback (t/2565) */
 
   /* Scrollbar */
   --scrollbar-track: #f1f5f9;
@@ -107,6 +108,7 @@
   --success: #22c55e; --success-text: #22c55e; /* reuses fill; AA on dark bg (t/2260) */
   --warning: #f59e0b;
   --focus-ring: #60a5fa;
+  --bar: #60a5fa; /* data-blue share-bar fill (t/2565) */
 
   /* Scrollbar */
   --scrollbar-track: #111827;
@@ -166,6 +168,7 @@
   --success: #00ff4c; --success-text: #00ff4c; /* reuses fill; AA on dark bg (t/2260) */
   --warning: #d9a441;
   --focus-ring: #4d7a8b;
+  --bar: #6a9fd4; /* data-blue share-bar fill (t/2565) */
 
   /* Scrollbar */
   --scrollbar-track: #1f1f1f;
@@ -223,6 +226,7 @@
   --success: #2D6A4F; --success-text: #2D6A4F; /* reuses forest green; already AA (t/2260) */
   --warning: #8B6508;
   --focus-ring: #A51C30;
+  --bar: #3f6fae; /* data-blue share-bar fill (t/2565) */
 
   /* Scrollbar */
   --scrollbar-track: #F3F0EB;


### PR DESCRIPTION
## Summary
Design-review finding on t/2561: `--bar` was referenced but **defined in no theme**, so `UsageHierarchy` share bars (`.uh-bar-fill { background: var(--bar, #3b82f6) }`) rendered the same hardcoded blue in all 4 themes (same class as the historical `--accent` bug).

Defines `--bar` in each `[data-theme]` block with Design-blessed data-blue values (p/29#97):

| theme | `--bar` |
|---|---|
| light | `#3b82f6` |
| dark | `#60a5fa` |
| bkc | `#6a9fd4` |
| harvard | `#3f6fae` |

Zero component edits — fixed at the design-system level.

## Scope correction (verified)
The ticket listed `PovProgression` as a second `--bar` consumer; it isn't. Its mini-bars use `--pov-color` (inline per-POV fill) + `--bar-h` (height) and reference `--bar` nowhere — the match was a `--bar-h` false-positive. Design confirmed and corrected the t/2561 note (p/29#97). So this is **UsageHierarchy-only**; AC #2's PovProgression clause was already true.

## Test plan
- [x] renderer-tsc `0 / 0`
- [x] styles.css 17705 ≤ 17800 ceiling
- [x] `vite build` clean
- [ ] CI green; Design confirms the 4 themes visually in re-review

Closes t/2565 · unblocks t/2558

🤖 Generated with [Claude Code](https://claude.com/claude-code)