### PR TITLE
fix(analysis): SummaryCard count-metric from child kind + a11y minors (t/2561 design review)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.css
+++ b/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.css
@@ -75,7 +75,7 @@
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-1, 0 4px 16px rgba(0, 0, 0, 0.15));
   display: flex;
   flex-direction: column;
 }

--- a/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.test.tsx
@@ -325,7 +325,48 @@ describe('leaf cross-axis panel', () => {
   });
 });
 
-// ── 6. View toggle ─────────────────────────────────────────────────────────────
+// ── 6. Summary card count-metric (spec §2.2) ──────────────────────────────────
+
+describe('summary card count-metric (spec §2.2)', () => {
+  it('shows root count as "Items" using firstChild-kind fallback', () => {
+    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    // Root firstChild = taxonomy (section kind, countUnit=''), falls back to root's countUnit='Items'
+    expect(screen.getByText('Items')).toBeTruthy();
+  });
+
+  it('shows "Nodes" at a category node — child kind, not hidden', async () => {
+    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    // Drill: root → taxonomy → acc → acc-bel (category with 2 node children)
+    fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
+    await waitFor(() => screen.getByRole('button', { name: /drill into accelerationist/i }));
+    fireEvent.click(screen.getByRole('button', { name: /drill into accelerationist/i }));
+    await waitFor(() => screen.getByRole('button', { name: /drill into beliefs/i }));
+    fireEvent.click(screen.getByRole('button', { name: /drill into beliefs/i }));
+    // SummaryCard: countUnit comes from child kind 'node' → 'Nodes'; childCount = 2
+    await waitFor(() => expect(screen.getByText('Nodes')).toBeTruthy());
+    // count value is 2 (acc-bel has acc-bel-001 and acc-bel-002)
+    const summaryMetrics = document.querySelectorAll('.uh-summary-metric');
+    const nodesMetric = Array.from(summaryMetrics).find(m => m.querySelector('.uh-summary-label')?.textContent === 'Nodes');
+    expect(nodesMetric?.querySelector('.uh-summary-value')?.textContent).toBe('2');
+  });
+
+  it('hides count metric at a leaf node (no spurious "0 Nodes")', async () => {
+    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    // Drill to acc-bel-001 (true leaf, no children)
+    fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
+    await waitFor(() => screen.getByRole('button', { name: /drill into accelerationist/i }));
+    fireEvent.click(screen.getByRole('button', { name: /drill into accelerationist/i }));
+    await waitFor(() => screen.getByRole('button', { name: /drill into beliefs/i }));
+    fireEvent.click(screen.getByRole('button', { name: /drill into beliefs/i }));
+    await waitFor(() => screen.getByRole('button', { name: /drill into acc-bel-001/i }));
+    fireEvent.click(screen.getByRole('button', { name: /drill into acc-bel-001/i }));
+    // Leaf: no count metric should render
+    await waitFor(() => expect(MOCK_LOAD_SUBJECT).toHaveBeenCalledWith('acc-bel-001', 'user'));
+    expect(screen.queryByText('Nodes')).toBeNull();
+  });
+});
+
+// ── 7. View toggle ─────────────────────────────────────────────────────────────
 
 describe('view toggle', () => {
   it('switches to tree view and shows expand/collapse controls', async () => {

--- a/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.tsx
@@ -69,8 +69,9 @@ function ScopeBar({ scopeUser, scopeSession, users, sessions, onSetUser, onClear
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        const triggeredRef = sessionOpen ? sessionBtnRef : userBtnRef;
         setUserOpen(false); setSessionOpen(false);
-        userBtnRef.current?.focus();
+        triggeredRef.current?.focus();
       }
     };
     document.addEventListener('mousedown', onDown);
@@ -163,9 +164,15 @@ function BreadcrumbNav({ drillPath, onNavigate }: { drillPath: string[]; onNavig
 // ── Section 3: Summary card ───────────────────────────────────────────────────
 
 function SummaryCard({ node, scope }: { node: TreeNode; scope: AnalyticsScope }) {
-  const childCount = Object.keys(node.children ?? {}).length;
-  const kind = inferKind(node.id);
-  const { countUnit } = getKind(kind);
+  const children = Object.entries(node.children ?? {});
+  const childCount = children.length;
+  const firstChildKey = children[0]?.[0];
+  // §2.2: unit comes from CHILD kind (like DrillTable column header), falls back to current kind.
+  // This yields "Nodes" at a category level and "Items" at the mixed root.
+  const childKind = firstChildKey ? inferKind(firstChildKey) : null;
+  const countUnit = childKind
+    ? (getKind(childKind).countUnit || getKind(inferKind(node.id)).countUnit)
+    : getKind(inferKind(node.id)).countUnit;
   const showUsers = scope.kind !== 'session' && node.uniqueUsers != null;
 
   return (
@@ -178,7 +185,7 @@ function SummaryCard({ node, scope }: { node: TreeNode; scope: AnalyticsScope })
         <div className="uh-summary-value">{fmtNumber(node.visits)}</div>
         <div className="uh-summary-label">Visits</div>
       </div>
-      {countUnit && (
+      {countUnit && childCount > 0 && (
         <div className="uh-summary-metric">
           <div className="uh-summary-value">{fmtNumber(childCount)}</div>
           <div className="uh-summary-label">{countUnit}</div>


### PR DESCRIPTION
## Summary

- **🟠 count-metric fix (spec §2.2):** `SummaryCard` now derives `countUnit` from the first child's kind (same pattern as `DrillTable` column header), falling back to the current node's kind. A `category` node (Beliefs) now shows "Nodes" with the child count instead of hiding the metric entirely. Also adds `childCount > 0` guard to suppress the spurious "0 Nodes" on leaf nodes.
- **Esc focus-return:** returns focus to the session pill when the session picker was open (was always returning to user pill).
- **CSS:** picker dropdown `rgba()` box-shadow → `var(--shadow-1, …)` design-system token.

## Test plan

- [x] 3 new vitest cases pinning spec §2.2: root shows "Items", category shows "Nodes", leaf hides count
- [x] 142/142 tests passing (full analysis suite)
- [x] Refs t/2565 (Rosetta) for `--bar` token definition (🔴 finding, not this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
