### PR TITLE
fix(theme): alias-bug sweep — repoint 23 wrong-name token refs (t/2568)

### DIFF
--- a/taxonomy-editor/src/renderer/components/PovProgression/PovProgressionView.css
+++ b/taxonomy-editor/src/renderer/components/PovProgression/PovProgressionView.css
@@ -21,7 +21,7 @@
 
 .pov-prog-header {
   padding: 10px 14px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   display: flex;
   align-items: center;
   gap: 12px;
@@ -47,7 +47,7 @@
 
 .pov-prog-turn-bar {
   padding: 6px 14px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   display: flex;
   gap: 4px;
   flex-wrap: wrap;
@@ -231,7 +231,7 @@
 /* ── Mini-map ────────────────────────────────────────────── */
 
 .pov-prog-mini {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   padding: 8px 10px;
   margin-bottom: 8px;
 }

--- a/taxonomy-editor/src/renderer/components/PovProgression/PovProgressionView.tsx
+++ b/taxonomy-editor/src/renderer/components/PovProgression/PovProgressionView.tsx
@@ -747,7 +747,7 @@ export function PovProgressionView({ session, nodeLabels }: PovProgressionViewPr
               className="btn btn-sm pov-prog-toggle-btn"
               style={{
                 '--btn-bg': mode === m ? 'var(--accent-color, #3b82f6)' : 'var(--bg-subtle)',
-                '--btn-color': mode === m ? '#fff' : 'var(--text)',
+                '--btn-color': mode === m ? '#fff' : 'var(--text-primary)',
               } as CSSProperties}
             >{m === 'since-opening' ? 'vs Opening' : m}</button>
           ))}
@@ -763,7 +763,7 @@ export function PovProgressionView({ session, nodeLabels }: PovProgressionViewPr
             className="btn btn-sm pov-prog-toggle-btn"
             style={{
               '--btn-bg': t.turnIndex === safeSelected ? 'var(--accent-color, #3b82f6)' : 'var(--bg-subtle)',
-              '--btn-color': t.turnIndex === safeSelected ? '#fff' : 'var(--text)',
+              '--btn-color': t.turnIndex === safeSelected ? '#fff' : 'var(--text-primary)',
             } as CSSProperties}
           >{t.label}</button>
         ))}

--- a/taxonomy-editor/src/renderer/components/PovProgression/PovProgressionWindow.css
+++ b/taxonomy-editor/src/renderer/components/PovProgression/PovProgressionWindow.css
@@ -6,6 +6,6 @@
   display: flex;
   flex-direction: column;
   background: var(--bg);
-  color: var(--text);
+  color: var(--text-primary);
   font-family: system-ui, sans-serif;
 }

--- a/taxonomy-editor/src/renderer/components/analysis/CalibrationDashboard.css
+++ b/taxonomy-editor/src/renderer/components/analysis/CalibrationDashboard.css
@@ -29,7 +29,7 @@
   font-size: var(--text-xs);
   padding: 3px 8px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-secondary);
   color: var(--text-primary);
 }
@@ -212,7 +212,7 @@
   grid-column: 1 / -1;
   margin: 12px 0 4px;
   font-size: 0.8rem;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   padding-top: 8px;
 }
 .cdash-health-box {

--- a/taxonomy-editor/src/renderer/components/analysis/ConvergenceSignalsPanel.css
+++ b/taxonomy-editor/src/renderer/components/analysis/ConvergenceSignalsPanel.css
@@ -95,14 +95,14 @@
 }
 
 .conv-table thead tr {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   position: sticky;
   top: 0;
   background: var(--bg-secondary);
 }
 
 .conv-table tbody tr {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   cursor: pointer;
 }
 
@@ -183,7 +183,7 @@
 
 .conv-verbatim-section {
   margin-top: 6px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   padding-top: var(--sp-1);
 }
 
@@ -250,7 +250,7 @@
 }
 
 .csig-filter-btn-all {
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .csig-table-scroll {

--- a/taxonomy-editor/src/renderer/components/analysis/ExtractionTimelinePanel.css
+++ b/taxonomy-editor/src/renderer/components/analysis/ExtractionTimelinePanel.css
@@ -18,13 +18,13 @@
 .etl-td {
   padding: 3px 6px;
   font-size: 0.7rem;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .etl-td-num {
   padding: 3px 6px;
   font-size: 0.7rem;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
@@ -48,7 +48,7 @@
   font-weight: 700;
   text-align: left;
   color: var(--text-muted);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   cursor: default;
 }
 
@@ -58,7 +58,7 @@
   font-weight: 700;
   text-align: right;
   color: var(--text-muted);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   cursor: default;
 }
 
@@ -312,7 +312,7 @@
 
 .etl-attr-section {
   margin-top: 8px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   padding-top: 6px;
 }
 

--- a/taxonomy-editor/src/renderer/components/analysis/ExtractionTimelinePanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/ExtractionTimelinePanel.tsx
@@ -80,8 +80,8 @@ function GrowthChart({ summary, traces }: { summary: ExtractionSummary; traces: 
       style={{ height: H }}
     >
       {plateauRect}
-      <line x1={PAD} y1={H - PAD} x2={W - PAD} y2={H - PAD} stroke="var(--border)" strokeWidth={0.5} />
-      <line x1={PAD} y1={PAD} x2={PAD} y2={H - PAD} stroke="var(--border)" strokeWidth={0.5} />
+      <line x1={PAD} y1={H - PAD} x2={W - PAD} y2={H - PAD} stroke="var(--border-color)" strokeWidth={0.5} />
+      <line x1={PAD} y1={PAD} x2={PAD} y2={H - PAD} stroke="var(--border-color)" strokeWidth={0.5} />
       <polyline fill="none" stroke="#22c55e" strokeWidth={1.5} points={points} />
       {summary.an_growth_series.map((p, i) => (
         <circle key={i} cx={x(p.round)} cy={y(p.cumulative_count)} r={2}
@@ -117,7 +117,7 @@ function RejectionSparkline({ traces }: { traces: ClaimExtractionTrace[] }) {
       /* eslint-disable-next-line local/no-inline-style -- dynamic: computed chart height */
       style={{ height: H }}
     >
-      <line x1={PAD} y1={H - PAD} x2={W - PAD} y2={H - PAD} stroke="var(--border)" strokeWidth={0.5} />
+      <line x1={PAD} y1={H - PAD} x2={W - PAD} y2={H - PAD} stroke="var(--border-color)" strokeWidth={0.5} />
       {traces.map((t, i) => {
         const x = PAD + i * (barW + 2);
         let yOffset = H - PAD;
@@ -193,7 +193,7 @@ const navBtn = (disabled: boolean): React.CSSProperties => ({
   fontSize: 'var(--text-2xs)',
   fontWeight: 600,
   borderRadius: 4,
-  border: '1px solid var(--border)',
+  border: '1px solid var(--border-color)',
   background: disabled ? 'transparent' : 'rgba(249,115,22,0.1)',
   color: disabled ? 'var(--text-muted)' : '#f97316',
   cursor: disabled ? 'not-allowed' : 'pointer',

--- a/taxonomy-editor/src/renderer/components/analysis/FactsPanel.css
+++ b/taxonomy-editor/src/renderer/components/analysis/FactsPanel.css
@@ -25,7 +25,7 @@
 
 .facts-card {
   margin-bottom: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   cursor: pointer;
 }

--- a/taxonomy-editor/src/renderer/components/analysis/NeutralEvaluationPanel.css
+++ b/taxonomy-editor/src/renderer/components/analysis/NeutralEvaluationPanel.css
@@ -119,7 +119,7 @@
 .neutral-eval-diagnostics-pre {
   font-size: var(--text-xs);
   background: var(--bg-tertiary, #1a1a2e);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   padding: 8px;
   max-height: 300px;

--- a/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.css
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWorkspace.css
@@ -83,7 +83,7 @@
 }
 
 .chat-share-error {
-  color: var(--red, #ef4444);
+  color: var(--danger, #ef4444);
   font-size: var(--text-xs);
   padding: var(--sp-1) var(--sp-3);
 }
@@ -133,7 +133,7 @@
   z-index: 20;
   margin-top: var(--sp-1);
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-2);
   min-width: 140px;

--- a/taxonomy-editor/src/renderer/components/conflict/ConflictDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/conflict/ConflictDetail.tsx
@@ -509,7 +509,7 @@ function ConflictHeaderSection({
             {' · '}
             <span
               className="cd-meta-stance"
-              style={{ color: stanceSummary.kind === 'contested' ? 'var(--color-warning, #d97706)' : 'var(--text-muted)' }}
+              style={{ color: stanceSummary.kind === 'contested' ? 'var(--warning, #d97706)' : 'var(--text-muted)' }}
               title={`${stanceSummary.supports} support / ${stanceSummary.disputes} dispute / ${stanceSummary.neutral} neutral / ${stanceSummary.qualifies} qualify — derived from instance stance, not a claim that the sides disagree`}
             >
               {stanceSummary.label} ({stanceSummary.detail})

--- a/taxonomy-editor/src/renderer/components/conflict/edit-conflicts/EditConflictBadge.css
+++ b/taxonomy-editor/src/renderer/components/conflict/edit-conflicts/EditConflictBadge.css
@@ -9,7 +9,7 @@
   align-items: center;
   gap: 4px;
   padding: 1px 6px;
-  border: 1px solid var(--color-warning);
+  border: 1px solid var(--warning);
   border-radius: var(--radius-md);
   font-size: var(--text-xs);
   line-height: 1.4;
@@ -23,7 +23,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--color-warning);
+  background: var(--warning);
   flex: 0 0 auto;
 }
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/chat/DiagnosticsChatSidebar.css
@@ -25,7 +25,7 @@
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);
 }
 
@@ -41,7 +41,7 @@
   padding: 1px 6px;
   border-radius: 4px;
   background: rgba(255, 255, 255, 0.06);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   flex: 1;
 }
 
@@ -83,7 +83,7 @@
 .diag-chat-nav-footer {
   margin-top: 4px;
   padding-top: 4px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   font-size: var(--text-2xs);
   color: var(--warning);
   cursor: pointer;
@@ -126,7 +126,7 @@
 
 .diag-chat-input-bar {
   padding: 8px 12px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   background: var(--bg-secondary);
 }
 
@@ -143,7 +143,7 @@
   font-size: 0.75rem;
   background: var(--bg-primary);
   color: var(--text-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   outline: none;
   font-family: inherit;
 }
@@ -185,7 +185,7 @@
   width: 5px;
   cursor: col-resize;
   flex-shrink: 0;
-  background: var(--border);
+  background: var(--border-color);
   transition: background 0.15s;
 }
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/OverviewView.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/OverviewView.css
@@ -25,7 +25,7 @@
 .ovw-badge-secondary-ml4 { font-size: var(--text-2xs); background: color-mix(in srgb, var(--text-secondary) 15%, transparent); color: var(--text-secondary); margin-left: 4px; }
 .ovw-toolbar-mb4 { display: flex; justify-content: flex-end; margin-bottom: 4px; }
 .ovw-toolbar-mb6 { display: flex; justify-content: flex-end; margin-bottom: 6px; }
-.ovw-toggle-btn { font-size: var(--text-2xs); padding: 2px 6px; border-radius: 3px; border: 1px solid var(--border); background: var(--bg-secondary); color: var(--text-primary); cursor: pointer; }
+.ovw-toggle-btn { font-size: var(--text-2xs); padding: 2px 6px; border-radius: 3px; border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary); cursor: pointer; }
 .ovw-caret { font-size: var(--text-2xs); margin-right: 2px; user-select: none; }
 .ovw-2xs-default { font-size: var(--text-2xs); cursor: default; }
 .ovw-warning-2xs { color: var(--warning); font-size: var(--text-2xs); }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/OverviewView.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/panel/OverviewView.tsx
@@ -73,7 +73,7 @@ function StrengthTimeline({ timeline, nodes, onSelectClaim }: {
         {/* Grid lines */}
         {[0, 0.25, 0.5, 0.75, 1.0].map(v => (
           <g key={v}>
-            <line x1={TIMELINE_PAD.left} y1={yScale(v)} x2={TIMELINE_W - TIMELINE_PAD.right} y2={yScale(v)} stroke="var(--border)" strokeWidth={0.5} opacity={0.4} />
+            <line x1={TIMELINE_PAD.left} y1={yScale(v)} x2={TIMELINE_W - TIMELINE_PAD.right} y2={yScale(v)} stroke="var(--border-color)" strokeWidth={0.5} opacity={0.4} />
             <text x={TIMELINE_PAD.left - 4} y={yScale(v) + 3} textAnchor="end" fill="var(--text-muted)" fontSize={8}>{v.toFixed(1)}</text>
           </g>
         ))}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.css
@@ -38,7 +38,7 @@
 }
 
 .diag-help thead tr {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .diag-help th {
@@ -92,7 +92,7 @@
   white-space: nowrap;
   font-family: var(--font-mono);
   background: none;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   padding: 1px 5px;
   cursor: pointer;
@@ -161,7 +161,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  border-right: 1px solid var(--border);
+  border-right: 1px solid var(--border-color);
   padding-right: var(--sp-2);
   margin-right: var(--sp-2);
   min-width: 120px;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
@@ -471,7 +471,7 @@ export function DiagnosticsWindow({ initialData }: { initialData?: Record<string
               minWidth: selectedEntry ? 280 : 0,
               maxWidth: selectedEntry ? '45%' : 'none',
               overflow: 'hidden', display: 'flex', flexDirection: 'column',
-              borderRight: selectedEntry ? '1px solid var(--border)' : 'none',
+              borderRight: selectedEntry ? '1px solid var(--border-color)' : 'none',
               marginRight: selectedEntry ? 8 : 0,
             }}>
               <OverviewTabRouter

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.css
@@ -38,7 +38,7 @@
   color: var(--text-muted);
   font-family: var(--font-mono, monospace);
   background: none;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   padding: 1px 4px;
   cursor: pointer;
@@ -67,7 +67,7 @@
   font-size: var(--text-2xs);
   font-weight: 600;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: color-mix(in srgb, var(--accent, #f97316) 10%, transparent);
   color: var(--accent, #f97316);
   cursor: pointer;
@@ -155,7 +155,7 @@
 .edr-tab-bar {
   display: flex;
   align-items: flex-end;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .edr-tab-ran-empty-marker {
@@ -178,7 +178,7 @@
 .edr-tab-copy-btn {
   font-size: var(--text-xs);
   padding: 3px 10px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -193,7 +193,7 @@
   min-height: 0;
   overflow-y: auto;
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-top: none;
   border-radius: 0 var(--radius-md) var(--radius-md) var(--radius-md);
   outline: none;
@@ -230,7 +230,7 @@
   position: fixed;
   z-index: 9999;
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: 0 4px 12px rgba(0,0,0,0.25);
   padding: 4px 0;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.parts.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/EntryDetailRouter.parts.tsx
@@ -100,7 +100,7 @@ export function EntryHeader({ p, m }: PartProps) {
   };
   const navBtnStyle = (disabled: boolean): React.CSSProperties => ({
     padding: '2px 8px', fontSize: 'var(--text-2xs)', fontWeight: 600,
-    borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)',
+    borderRadius: 'var(--radius-sm)', border: '1px solid var(--border-color)',
     background: disabled ? 'transparent' : 'color-mix(in srgb, var(--accent, var(--color-acc)) 10%, transparent)',
     color: disabled ? 'var(--text-muted)' : 'var(--accent, var(--color-acc))',
     cursor: disabled ? 'not-allowed' : 'pointer',
@@ -272,8 +272,8 @@ export function EntryTabBar({ p, m }: PartProps) {
       padding: '6px 12px',
       fontSize: 'var(--text-xs)',
       fontWeight: 600,
-      border: '1px solid var(--border)',
-      borderBottom: t.id === activeTab ? '1px solid var(--bg-primary)' : '1px solid var(--border)',
+      border: '1px solid var(--border-color)',
+      borderBottom: t.id === activeTab ? '1px solid var(--bg-primary)' : '1px solid var(--border-color)',
       background: t.id === activeTab ? 'var(--bg-primary)' : 'transparent',
       color: !enabled ? 'var(--text-muted)' : t.ranEmpty ? 'var(--warning, var(--warning))' : (t.id === activeTab ? 'var(--accent, var(--color-acc))' : 'var(--text-primary)'),
       cursor: enabled ? 'pointer' : 'not-allowed',

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/OverviewTabRouter.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/OverviewTabRouter.css
@@ -55,7 +55,7 @@
 /* --- Vocabulary Disambiguation --- */
 .ovr-mt-20 { margin-top: 20px; }
 .ovr-vocab-table { width: 100%; font-size: 0.7rem; border-collapse: collapse; margin-bottom: 8px; }
-.ovr-vocab-head-row { border-bottom: 1px solid var(--border); }
+.ovr-vocab-head-row { border-bottom: 1px solid var(--border-color); }
 .ovr-th-left { text-align: left; padding: 3px 8px; color: var(--text-muted); }
 .ovr-th-center { text-align: center; padding: 3px 8px; color: var(--text-muted); }
 .ovr-vocab-row { border-bottom: 1px solid color-mix(in srgb, var(--text-muted) 10%, transparent); }
@@ -88,7 +88,7 @@
 /* --- Transcript --- */
 .ovr-transcript { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
 .ovr-transcript-filters { display: flex; gap: 4px; padding: 4px 6px; flex-wrap: wrap; align-items: center; flex-shrink: 0; }
-.ovr-filter-btn { padding: 2px 8px; font-size: var(--text-2xs); font-weight: 600; border-radius: 4px; cursor: pointer; border: 1px solid var(--border); }
+.ovr-filter-btn { padding: 2px 8px; font-size: var(--text-2xs); font-weight: 600; border-radius: 4px; cursor: pointer; border: 1px solid var(--border-color); }
 .ovr-transcript-list { flex: 1; min-height: 0; overflow-y: auto; }
 .ovr-transcript-entry { padding: 4px 6px; cursor: pointer; border-radius: 4px; margin: 2px 0; font-size: 0.7rem; }
 .ovr-stmt-head { display: flex; align-items: baseline; gap: 6px; }
@@ -125,4 +125,4 @@
 .ovr-violation-claim { color: var(--text-primary); font-size: var(--text-2xs); }
 .ovr-violation-sims { display: flex; gap: 12px; font-size: var(--text-2xs); margin-top: 2px; color: var(--text-muted); }
 .ovr-drift-sim { margin-left: auto; font-family: monospace; font-weight: 600; }
-.ovr-drift-excerpt { color: var(--text-muted); font-style: italic; font-size: var(--text-2xs); padding: 3px 6px; border-left: 1px solid var(--border); margin-top: 2px; }
+.ovr-drift-excerpt { color: var(--text-muted); font-style: italic; font-size: var(--text-2xs); padding: 3px 6px; border-left: 1px solid var(--border-color); margin-top: 2px; }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/BriefTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/BriefTab.css
@@ -99,7 +99,7 @@
 }
 
 .brief-thead-row {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   text-align: left;
 }
 
@@ -144,7 +144,7 @@
 }
 
 .brief-tr-border {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .brief-td-grounding {
@@ -171,7 +171,7 @@
 .brief-turn-rule {
   flex: 1;
   height: 1px;
-  background: var(--border);
+  background: var(--border-color);
 }
 
 .brief-valbox {
@@ -195,7 +195,7 @@
 }
 
 .brief-valfooter {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   margin-top: 4px;
   padding-top: 3px;
   font-size: var(--text-2xs);

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/BriefTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/BriefTab.tsx
@@ -106,7 +106,7 @@ function DocumentClaimsSection({ workProduct, renderGrounding }: {
             return (
               <Fragment key={i}>
                 {/* eslint-disable-next-line local/no-inline-style -- dynamic borderBottom */}
-                <tr style={{ borderBottom: Array.isArray(dc.grounding) && dc.grounding.length > 0 ? 'none' : '1px solid var(--border)' }}>
+                <tr style={{ borderBottom: Array.isArray(dc.grounding) && dc.grounding.length > 0 ? 'none' : '1px solid var(--border-color)' }}>
                   <td className="brief-td-did">{dc.d_id}</td>
                   {/* eslint-disable-next-line local/no-inline-style -- dynamic stanceColor */}
                   <td style={{ padding: '3px 6px', verticalAlign: 'top', fontWeight: 600, color: stanceColor, textTransform: 'uppercase', fontSize: 'var(--text-2xs)' }}>{dc.stance}</td>
@@ -402,7 +402,7 @@ export function BriefTab(props: BriefTabProps) {
                   : 'var(--danger)';
                 return (
                   // eslint-disable-next-line local/no-inline-style -- dynamic selected background
-                  <tr key={i} style={{ borderBottom: '1px solid var(--border)', background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent' }}>
+                  <tr key={i} style={{ borderBottom: '1px solid var(--border-color)', background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent' }}>
                     <td className="brief-td-nowrap">
                       <button
                         onClick={() => setSelectedTaxRefId(isSelected ? null : n.node_id)}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CitationsTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CitationsTab.css
@@ -27,7 +27,7 @@
   padding: 6px 10px;
   border-radius: 4px;
   background: var(--bg-subtle);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   text-align: center;
 }
 
@@ -195,7 +195,7 @@
   padding: 4px 8px;
   border-radius: 3px;
   background: var(--bg-subtle);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   font-size: var(--text-2xs);
   color: var(--text-muted);
   display: flex;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CiteTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CiteTab.css
@@ -290,7 +290,7 @@
 .cit-hr-line {
   flex: 1;
   height: 1px;
-  background: var(--border);
+  background: var(--border-color);
 }
 
 .cit-raw-summary {
@@ -337,7 +337,7 @@
 .cit-muted { color: var(--text-muted); }
 
 .cit-breakdown {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   margin-top: 4px;
   padding-top: 3px;
   font-size: var(--text-2xs);

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CiteTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/CiteTab.tsx
@@ -96,7 +96,7 @@ function CiteTaxonomyRefsSection(props: CiteTaxRefsSectionProps) {
                 const nodeLabel = (taxNodeMap.get(r.node_id) as TaxRefNode | undefined)?.label;
                 return (
                   // eslint-disable-next-line local/no-inline-style -- selection-driven background
-                  <tr key={i} style={{ borderBottom: '1px solid var(--border)', background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent' }}>
+                  <tr key={i} style={{ borderBottom: '1px solid var(--border-color)', background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent' }}>
                     <td className="cit-td-node">
                       <div>
                         <button
@@ -308,7 +308,7 @@ export function CiteTab(props: CiteTabProps) {
                 const pol = policyMap.get(p);
                 return (
                   // eslint-disable-next-line local/no-inline-style -- selection-driven background
-                  <tr key={i} style={{ borderBottom: '1px solid var(--border)', background: isSelected ? 'color-mix(in srgb, var(--text-secondary) 8%, transparent)' : 'transparent' }}>
+                  <tr key={i} style={{ borderBottom: '1px solid var(--border-color)', background: isSelected ? 'color-mix(in srgb, var(--text-secondary) 8%, transparent)' : 'transparent' }}>
                     <td className="cit-td-pol">
                       <button
                         onClick={() => setSelectedPolicyId(isSelected ? null : p)}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ClaimsTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ClaimsTab.css
@@ -214,7 +214,7 @@
   font-style: italic;
   font-size: var(--text-2xs);
   padding-left: 4px;
-  border-left: 1px solid var(--border);
+  border-left: 1px solid var(--border-color);
 }
 
 .clm-repair-line {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/DetailsTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/DetailsTab.css
@@ -301,7 +301,7 @@
 .det-assumption {
   margin: 4px 0;
   padding-left: 8px;
-  border-left: 2px solid var(--border);
+  border-left: 2px solid var(--border-color);
 }
 
 .det-muted-7 {
@@ -367,7 +367,7 @@
   width: 60px;
   height: 6px;
   border-radius: 3px;
-  background: var(--border);
+  background: var(--border-color);
   overflow: hidden;
   flex-shrink: 0;
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/DraftTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/DraftTab.css
@@ -264,7 +264,7 @@
   margin-bottom: 6px;
 }
 
-.draft-tr-border { border-bottom: 1px solid var(--border); }
+.draft-tr-border { border-bottom: 1px solid var(--border-color); }
 .draft-tr-border-soft { border-bottom: 1px solid color-mix(in srgb, var(--text-muted) 10%, transparent); }
 
 .draft-th-left {
@@ -398,7 +398,7 @@
 }
 
 .draft-score-breakdown {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   margin-top: 4px;
   padding-top: 3px;
   font-size: var(--text-2xs);
@@ -407,7 +407,7 @@
 }
 
 .draft-caveats-box {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   margin-top: 4px;
   padding-top: 3px;
 }
@@ -437,7 +437,7 @@
 .draft-hr-line {
   flex: 1;
   height: 1px;
-  background: var(--border);
+  background: var(--border-color);
 }
 
 .draft-valscore-box {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/EvidenceTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/EvidenceTab.css
@@ -69,7 +69,7 @@
   padding: 6px 10px;
   border-radius: 4px;
   background: var(--bg-subtle);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   text-align: center;
 }
 
@@ -139,7 +139,7 @@
   color: var(--text-muted);
   font-style: italic;
   margin-top: 2px;
-  border-left: 2px solid var(--border);
+  border-left: 2px solid var(--border-color);
   padding-left: 6px;
 }
 
@@ -169,7 +169,7 @@
 }
 
 .evid-thead-row {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   color: var(--text-muted);
 }
 
@@ -296,7 +296,7 @@
   padding: 5px 8px;
   border-radius: 4px;
   background: var(--bg-subtle);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .evid-mono700 {
@@ -361,5 +361,5 @@
   font-style: italic;
   margin-top: 1px;
   padding-left: 4px;
-  border-left: 1px solid var(--border);
+  border-left: 1px solid var(--border-color);
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/EvidenceTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/EvidenceTab.tsx
@@ -265,7 +265,7 @@ function CitationPipelineSection({ evidenceWP }: { evidenceWP: EvidenceWP | unde
           {pipeline.map((p, pi) => (
             // eslint-disable-next-line local/no-inline-style -- dynamic cited-row highlight
             <tr key={pi} style={{
-              borderBottom: '1px solid var(--border)',
+              borderBottom: '1px solid var(--border-color)',
               background: p.cited ? 'color-mix(in srgb, var(--success) 5%, transparent)' : 'transparent',
             }}>
               <td className="evid-td-source">

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ExclusionGuardTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/ExclusionGuardTab.tsx
@@ -277,7 +277,7 @@ function WarningItem({ warning }: { warning: ScopeDriftWarning }) {
         fontStyle: 'italic',
         fontSize: 'var(--text-2xs)',
         padding: '3px 6px',
-        borderLeft: '1px solid var(--border)',
+        borderLeft: '1px solid var(--border-color)',
         marginTop: 2,
       }}>
         {warning.draft_excerpt.length > 200 ? warning.draft_excerpt.slice(0, 200) + '…' : warning.draft_excerpt}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.css
@@ -105,7 +105,7 @@
 }
 
 .look-thead-row {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   color: var(--text-muted);
 }
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/LookaheadTab.tsx
@@ -191,7 +191,7 @@ export function LookaheadTab(props: LookaheadTabProps) {
               const hintColor = utilityHintColor(hint);
               return (
                 // eslint-disable-next-line local/no-inline-style -- dynamic fontWeight for composite row
-                <tr key={k} style={{ borderBottom: '1px solid var(--border)', fontWeight: k === 'composite' ? 700 : 400 }}>
+                <tr key={k} style={{ borderBottom: '1px solid var(--border-color)', fontWeight: k === 'composite' ? 700 : 400 }}>
                   <td className="look-cell-p">{k.replace(/_/g, ' ')}</td>
                   <td className="look-cell-r">{b.toFixed(3)}</td>
                   <td className="look-cell-r">{a.toFixed(3)}</td>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/PlanTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/PlanTab.css
@@ -231,7 +231,7 @@
 .plan-sep-line {
   flex: 1;
   height: 1px;
-  background: var(--border);
+  background: var(--border-color);
 }
 
 .plan-fw400 {

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/TaxRefsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/entry-tabs/TaxRefsTab.tsx
@@ -94,7 +94,7 @@ function SourceCell({ src, isAN }: { src: RelevanceSource | undefined; isAN: boo
 function ScoringDetailRow({ src, isSelected, hasSourceData, setOverviewTab }: { src: RelevanceSource; isSelected: boolean; hasSourceData: boolean; setOverviewTab: (tab: OverviewTab) => void }) {
   const isAN = src.source === 'an';
   return (
-    <tr style={{ borderBottom: '1px solid var(--border)', background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent' }}>
+    <tr style={{ borderBottom: '1px solid var(--border-color)', background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent' }}>
       <td colSpan={hasSourceData ? 4 : 3} style={{ padding: '0 6px 4px 20px' }}>
         <details style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>
           <summary style={{ cursor: 'pointer', userSelect: 'none' }}>Scoring detail</summary>
@@ -133,7 +133,7 @@ function TaxRefRow({ r, hasSourceData, isSelected, src, tw, setSelectedTaxRefId,
     <Fragment>
       <tr
         style={{
-          borderBottom: src ? 'none' : '1px solid var(--border)',
+          borderBottom: src ? 'none' : '1px solid var(--border-color)',
           background: isSelected ? 'color-mix(in srgb, var(--warning) 8%, transparent)' : 'transparent',
         }}
       >
@@ -224,7 +224,7 @@ export function TaxRefsTab({ entry, meta, debate, taxRefCount, nodeWeights, taxN
         };
 
         return (
-          <div style={{ marginBottom: 10, padding: '8px 10px', background: 'var(--bg-secondary)', borderRadius: 6, border: '1px solid var(--border)', fontSize: '0.75rem' }}>
+          <div style={{ marginBottom: 10, padding: '8px 10px', background: 'var(--bg-secondary)', borderRadius: 6, border: '1px solid var(--border-color)', fontSize: '0.75rem' }}>
             {/* Header row: title + summary counts */}
             <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 6, flexWrap: 'wrap' }}>
               <span style={{ fontWeight: 600, color: 'var(--text-primary)' }}>AN Claim Coverage</span>
@@ -283,7 +283,7 @@ export function TaxRefsTab({ entry, meta, debate, taxRefCount, nodeWeights, taxN
           <col style={{ width: hasSourceData ? '62%' : '72%' }} />
         </colgroup>
         <thead>
-          <tr style={{ borderBottom: '1px solid var(--border)', textAlign: 'left' }}>
+          <tr style={{ borderBottom: '1px solid var(--border-color)', textAlign: 'left' }}>
             {hasSourceData && <th style={{ padding: '4px 6px', fontWeight: 600, color: 'var(--text-muted)' }}>Source</th>}
             <th style={{ padding: '4px 6px', fontWeight: 600, color: 'var(--text-muted)' }}>Id</th>
             <th style={{ padding: '4px 6px', fontWeight: 600, color: 'var(--text-muted)', textAlign: 'center' }}>Score</th>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/helpers.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/helpers.tsx
@@ -74,7 +74,7 @@ export function CopyButton({ text }: { text: string }) {
         setTimeout(() => setCopied(false), 1500);
       }}
       style={{
-        background: 'none', border: '1px solid var(--border)', borderRadius: 3,
+        background: 'none', border: '1px solid var(--border-color)', borderRadius: 3,
         color: copied ? 'var(--success)' : 'var(--text-muted)', cursor: 'pointer',
         fontSize: 'var(--text-2xs)', padding: '1px 6px', marginLeft: 6, flexShrink: 0,
       }}
@@ -198,7 +198,7 @@ export function SearchBar({ query, setQuery, matchCount, inputRef }: { query: st
         style={{
           flex: 1, padding: '4px 8px', fontSize: '0.75rem',
           background: 'var(--bg-primary)', color: 'var(--text-primary)',
-          border: '1px solid var(--border)', borderRadius: 4,
+          border: '1px solid var(--border-color)', borderRadius: 4,
         }}
       />
       {query && (
@@ -207,16 +207,16 @@ export function SearchBar({ query, setQuery, matchCount, inputRef }: { query: st
             {domCount > 0 ? `${currentIdx + 1}/${domCount}` : '0 matches'}
           </span>
           <button onClick={goPrev} title="Previous match (Shift+Enter)"
-            style={{ background: 'none', border: '1px solid var(--border)', borderRadius: 4, padding: '2px 5px', cursor: 'pointer', color: 'var(--text-muted)', fontSize: '0.7rem', lineHeight: 1 }}>
+            style={{ background: 'none', border: '1px solid var(--border-color)', borderRadius: 4, padding: '2px 5px', cursor: 'pointer', color: 'var(--text-muted)', fontSize: '0.7rem', lineHeight: 1 }}>
             ▲
           </button>
           <button onClick={goNext} title="Next match (Enter)"
-            style={{ background: 'none', border: '1px solid var(--border)', borderRadius: 4, padding: '2px 5px', cursor: 'pointer', color: 'var(--text-muted)', fontSize: '0.7rem', lineHeight: 1 }}>
+            style={{ background: 'none', border: '1px solid var(--border-color)', borderRadius: 4, padding: '2px 5px', cursor: 'pointer', color: 'var(--text-muted)', fontSize: '0.7rem', lineHeight: 1 }}>
             ▼
           </button>
           <button
             onClick={() => setQuery('')}
-            style={{ background: 'none', border: '1px solid var(--border)', borderRadius: 4, padding: '2px 6px', cursor: 'pointer', color: 'var(--text-muted)', fontSize: 'var(--text-2xs)' }}
+            style={{ background: 'none', border: '1px solid var(--border-color)', borderRadius: 4, padding: '2px 6px', cursor: 'pointer', color: 'var(--text-muted)', fontSize: 'var(--text-2xs)' }}
           >
             Clear
           </button>
@@ -240,7 +240,7 @@ export function ResizablePre({ text, tall = false }: { text: string; tall?: bool
         fontSize: tall ? '0.75rem' : '0.65rem',
         background: 'var(--bg-primary)',
         color: 'var(--text-primary)',
-        border: '1px solid var(--border)',
+        border: '1px solid var(--border-color)',
         borderRadius: 4,
         padding: '6px 8px',
         whiteSpace: 'pre-wrap',

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/AdaptiveStagingTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/AdaptiveStagingTab.css
@@ -62,7 +62,7 @@
   padding: 2px 8px;
   cursor: pointer;
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: transparent;
   color: var(--text-primary);
 }
@@ -102,7 +102,7 @@
 }
 
 .adst-row-border {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .adst-th-left {
@@ -133,7 +133,7 @@
 }
 
 .adst-telemetry-head-row {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   position: sticky;
   top: 0;
   background: var(--bg-primary);

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgumentNetworkTab.css
@@ -23,7 +23,7 @@
   font-size: var(--text-2xs);
   padding: 2px 6px;
   border-radius: 3px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-secondary);
   color: var(--text-primary);
   cursor: pointer;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ReflectionsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ReflectionsTab.tsx
@@ -74,7 +74,7 @@ export function ReflectionsTab({ debate }: ReflectionsTabProps) {
             {r.edits.map((edit, ei) => (
               <div key={ei} style={{
                 padding: '8px 10px', marginBottom: 6, borderRadius: 6,
-                border: `1px solid ${edit.status === 'approved' ? 'var(--success)44' : 'var(--border)'}`,
+                border: `1px solid ${edit.status === 'approved' ? 'var(--success)44' : 'var(--border-color)'}`,
                 opacity: edit.status === 'dismissed' ? 0.5 : 1,
               }}>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/CommitmentsPanel.css
@@ -69,7 +69,7 @@
   position: fixed;
   z-index: 9999;
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
   padding: 4px 0;

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/DebateExchangeRich.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/DebateExchangeRich.tsx
@@ -29,11 +29,11 @@ export function DebateExchangeRich({ content }: { content: string }) {
   }, [content]);
 
   if (segments.length <= 1 && !segments[0]?.speaker) {
-    return <pre style={{ fontSize: 'var(--text-2xs)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 300, overflow: 'auto', margin: '4px 0 8px', padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border)' }}>{content}</pre>;
+    return <pre style={{ fontSize: 'var(--text-2xs)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 300, overflow: 'auto', margin: '4px 0 8px', padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border-color)' }}>{content}</pre>;
   }
 
   return (
-    <div style={{ maxHeight: 300, overflow: 'auto', margin: '4px 0 8px', padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border)' }}>
+    <div style={{ maxHeight: 300, overflow: 'auto', margin: '4px 0 8px', padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border-color)' }}>
       {segments.map((seg, i) => (
         <div key={i} style={{ marginBottom: 8 }}>
           {seg.speaker && (

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/EdgesUsed.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/EdgesUsed.css
@@ -20,7 +20,7 @@
   padding: 8px 10px;
   background: var(--bg-secondary);
   border-radius: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .eu-edge-desc-heading {
@@ -84,7 +84,7 @@
   flex: 1 1 55%;
   max-height: 400px;
   overflow-y: auto;
-  border-left: 1px solid var(--border);
+  border-left: 1px solid var(--border-color);
   padding-left: 10px;
 }
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/INodeRow.tsx
@@ -513,7 +513,7 @@ export function INodeRow({ node, attacks, supports, allNodes, allEdges, isSource
     <div
       ref={rowRef}
       // eslint-disable-next-line local/no-inline-style -- focus-driven outline/borderRadius
-      style={{ margin: '6px 0', paddingBottom: 6, borderBottom: '1px solid var(--border)', outline: focused ? '2px solid var(--warning)' : 'none', borderRadius: focused ? 4 : 0, fontSize: '0.85rem' }}
+      style={{ margin: '6px 0', paddingBottom: 6, borderBottom: '1px solid var(--border-color)', outline: focused ? '2px solid var(--warning)' : 'none', borderRadius: focused ? 4 : 0, fontSize: '0.85rem' }}
     >
       <div className="inr-header-row">
         <button

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ModeratorTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ModeratorTab.css
@@ -6,7 +6,7 @@
   padding: 8px 10px;
   border-radius: 6px;
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .mod-tab-heading {
@@ -108,7 +108,7 @@
   padding: 4px 8px;
   border-radius: 4px;
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .mod-tab-commitment-name {
@@ -140,7 +140,7 @@
   padding: 1px 5px;
   border-radius: 3px;
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   cursor: default;
 }
 
@@ -222,7 +222,7 @@
   padding: 6px 8px;
   background: var(--bg-primary);
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .mod-tab-response-pre {
@@ -235,5 +235,5 @@
   padding: 6px 8px;
   background: var(--bg-primary);
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ModeratorTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ModeratorTab.tsx
@@ -70,7 +70,7 @@ function CandidateCard({ c, selected }: { c: Candidate; selected: ModeratorTrace
     // eslint-disable-next-line local/no-inline-style -- selected-state drives background, border, and fontWeight
     <div className="mod-tab-candidate-card" style={{
       background: c.debater === selected ? 'color-mix(in srgb, var(--color-acc) 12%, transparent)' : 'transparent',
-      border: `1px solid ${c.debater === selected ? 'var(--color-acc)' : 'var(--border)'}`,
+      border: `1px solid ${c.debater === selected ? 'var(--color-acc)' : 'var(--border-color)'}`,
       fontWeight: c.debater === selected ? 700 : 400,
     }}>
       <div>#{c.rank} {c.debater}</div>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ScoreBreakdown.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/ScoreBreakdown.tsx
@@ -71,7 +71,7 @@ export function ScoreBreakdown({ dims, processReward, judgeUsed }: {
       <DimensionScoreRow name="grounding"   pass={dims.grounding.pass}   weight={0.3} details={dims.grounding.issues ?? []} />
       <DimensionScoreRow name="advancement" pass={dims.advancement.pass} weight={0.2} details={dims.advancement.signals ?? []} />
       <DimensionScoreRow name="clarifies"   pass={dims.clarifies.pass}   weight={0.1} details={dims.clarifies.signals ?? []} />
-      <div style={{ borderTop: '1px solid var(--border)', margin: '4px 0', paddingTop: 4, display: 'flex', gap: 16 }}>
+      <div style={{ borderTop: '1px solid var(--border-color)', margin: '4px 0', paddingTop: 4, display: 'flex', gap: 16 }}>
         <span>Stage A: <strong style={mono}>{stageAScore.toFixed(2)}</strong> <span style={{ color: 'var(--text-muted)' }}>× 0.4 = {(0.4 * stageAScore).toFixed(2)}</span></span>
         <span>Judge: <strong style={mono}>{judgeQuality.toFixed(2)}</strong>{!judgeUsed && <span style={{ color: 'var(--text-muted)' }}> (default)</span>} <span style={{ color: 'var(--text-muted)' }}>× 0.6 = {(0.6 * judgeQuality).toFixed(2)}</span></span>
         <span>Total: <strong style={mono}>{processReward.toFixed(2)}</strong></span>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/TensionsListDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/TensionsListDetail.tsx
@@ -50,7 +50,7 @@ export function TensionsListDetail({ content }: { content: string }) {
   }, [content]);
 
   if (tensions.length === 0) {
-    return <pre style={{ fontSize: 'var(--text-2xs)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 300, overflow: 'auto', margin: '4px 0 8px', padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border)' }}>{content}</pre>;
+    return <pre style={{ fontSize: 'var(--text-2xs)', whiteSpace: 'pre-wrap', wordBreak: 'break-word', maxHeight: 300, overflow: 'auto', margin: '4px 0 8px', padding: '6px 8px', background: 'var(--bg-primary)', borderRadius: 4, border: '1px solid var(--border-color)' }}>{content}</pre>;
   }
 
   const sel = selected != null ? tensions[selected] : null;
@@ -62,13 +62,13 @@ export function TensionsListDetail({ content }: { content: string }) {
 
   return (
     <div style={{ display: 'flex', gap: 8, margin: '4px 0 8px' }}>
-      <div style={{ flex: '1 1 45%', maxHeight: 340, overflow: 'auto', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg-primary)' }}>
+      <div style={{ flex: '1 1 45%', maxHeight: 340, overflow: 'auto', borderRadius: 4, border: '1px solid var(--border-color)', background: 'var(--bg-primary)' }}>
         {tensions.map((t, i) => (
           <div key={i} onClick={() => { setSelected(i); setRationaleExpanded(false); }} style={{
             padding: '4px 8px', cursor: 'pointer', fontSize: 'var(--text-2xs)',
             background: selected === i ? 'color-mix(in srgb, var(--color-acc) 12%, transparent)' : 'transparent',
             borderLeft: selected === i ? '3px solid var(--color-acc)' : '3px solid transparent',
-            borderBottom: '1px solid var(--border)',
+            borderBottom: '1px solid var(--border-color)',
           }}>
             <span style={{ color: nodeIdColor(t.source), fontWeight: 600 }}>{t.source}</span>
             <span style={{ color: relationColor(t.relation), fontSize: 'var(--text-2xs)', fontWeight: 700, margin: '0 4px' }}>
@@ -79,10 +79,10 @@ export function TensionsListDetail({ content }: { content: string }) {
           </div>
         ))}
       </div>
-      <div style={{ flex: '1 1 55%', borderRadius: 4, border: '1px solid var(--border)', background: 'var(--bg-primary)', fontSize: '0.7rem', minHeight: 80, overflow: 'auto' }}>
+      <div style={{ flex: '1 1 55%', borderRadius: 4, border: '1px solid var(--border-color)', background: 'var(--bg-primary)', fontSize: '0.7rem', minHeight: 80, overflow: 'auto' }}>
         {sel ? (
           <>
-            <div style={{ padding: '8px 12px', borderBottom: '1px solid var(--border)', background: 'var(--bg-secondary)' }}>
+            <div style={{ padding: '8px 12px', borderBottom: '1px solid var(--border-color)', background: 'var(--bg-secondary)' }}>
               <span style={{ display: 'inline-block', padding: '2px 10px', borderRadius: 4, background: `${relationColor(sel.relation)}18`, color: relationColor(sel.relation), fontWeight: 700, fontSize: '0.72rem', textTransform: 'uppercase' }}>
                 {sel.relation.replace(/_/g, ' ')}
               </span>

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/TurnValidation.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/shared/TurnValidation.css
@@ -2,7 +2,7 @@
 /* Licensed under the MIT License. See LICENSE file in the project root. */
 
 .tv-attempt-row {
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   margin-bottom: 6px;
 }

--- a/taxonomy-editor/src/renderer/components/debate-workspace/ClaimsView.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/ClaimsView.css
@@ -4,7 +4,7 @@
 .claims-node-row {
   margin: 4px 0;
   padding-bottom: 4px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   font-size: 0.85rem;
 }
 
@@ -136,7 +136,7 @@
 
 .claims-style-toggle {
   background: none;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   padding: 1px 6px;
   font-size: var(--text-2xs);

--- a/taxonomy-editor/src/renderer/components/debate-workspace/ClarificationPanel.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/ClarificationPanel.css
@@ -224,9 +224,9 @@
   resize: vertical;
   padding: 8px;
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-input);
-  color: var(--text);
+  color: var(--text-primary);
   font-family: inherit;
   font-size: 0.85rem;
 }
@@ -257,7 +257,7 @@
   font-size: 0.8rem;
   color: var(--text-muted);
   padding: 4px 0;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .cp-tension-count {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -163,7 +163,7 @@ function ShareToCommunityButton({ debate }: { debate: { id: string; topic: strin
       {shareState === 'error' && shareError && (
         <span
           className="debate-toolbar-status"
-          style={{ color: 'var(--red, #ef4444)', marginLeft: 4, fontSize: '0.75rem' }}
+          style={{ color: 'var(--danger, #ef4444)', marginLeft: 4, fontSize: '0.75rem' }}
           title={shareError}
         >
           {'Failed: ' + shareError}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -85,7 +85,7 @@
   margin-left: 4px;
   background: var(--bg-tertiary);
   color: var(--text-muted);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   font-family: var(--font-mono);
 }
 

--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementProgressIndicator.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementProgressIndicator.css
@@ -42,11 +42,11 @@
   justify-content: center;
   font-size: 13px;
   line-height: 1;
-  color: var(--color-warning, #d97706);
+  color: var(--warning, #d97706);
 }
 
 .stmt-progress--error {
-  color: var(--color-warning, #d97706);
+  color: var(--warning, #d97706);
 }
 
 .stmt-progress-label {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TopicCritique/CritiqueColumn.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TopicCritique/CritiqueColumn.css
@@ -83,7 +83,7 @@
 }
 
 .critique-col-dim-max {
-  color: var(--text-tertiary, #777);
+  color: var(--text-muted, #777);
   font-size: 0.7rem;
 }
 

--- a/taxonomy-editor/src/renderer/components/debate/DebatePopoutWindow.css
+++ b/taxonomy-editor/src/renderer/components/debate/DebatePopoutWindow.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   background: var(--bg);
-  color: var(--text);
+  color: var(--text-primary);
   font-family: system-ui, sans-serif;
 }
 
@@ -15,7 +15,7 @@
   display: flex;
   flex-direction: column;
   background: var(--bg);
-  color: var(--text);
+  color: var(--text-primary);
   font-family: system-ui, sans-serif;
 }
 

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.css
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.css
@@ -65,7 +65,7 @@
   padding: 6px 10px;
   border-radius: 4px;
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   word-break: break-all;
   white-space: pre-wrap;
   display: block;
@@ -89,7 +89,7 @@
 }
 
 .debate-tab-speaker-thead-row {
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .debate-tab-speaker-th {
@@ -99,7 +99,7 @@
 }
 
 .debate-tab-speaker-tbody-row {
-  border-bottom: 1px solid var(--border-light, var(--border));
+  border-bottom: 1px solid var(--border-light, var(--border-color));
 }
 
 .debate-tab-speaker-td {

--- a/taxonomy-editor/src/renderer/components/debate/SituationDebatePanel.css
+++ b/taxonomy-editor/src/renderer/components/debate/SituationDebatePanel.css
@@ -9,7 +9,7 @@
 .sit-debate-label { display: block; font-size: var(--text-xs); font-weight: 600; color: var(--text-secondary); margin: 10px 0 4px; text-transform: uppercase; letter-spacing: 0.03em; }
 
 .sit-debate-debaters { display: flex; flex-wrap: wrap; gap: 6px; }
-.sit-debate-debater { display: flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: var(--radius-md); border: 1px solid var(--border-primary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; }
+.sit-debate-debater { display: flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: var(--radius-md); border: 1px solid var(--border-color); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; }
 .sit-debate-debater:hover { border-color: var(--color-sit); }
 .sit-debate-debater.active { background: color-mix(in srgb, var(--color-sit) 12%, var(--bg-secondary)); border-color: var(--color-sit); }
 .sit-debate-debater input { display: none; }
@@ -17,14 +17,14 @@
 .sit-debate-debater-pov { color: var(--text-muted); font-size: var(--text-2xs); }
 
 .sit-debate-format-row, .sit-debate-pacing-row { display: flex; gap: 6px; flex-wrap: wrap; }
-.sit-debate-format-opt, .sit-debate-pacing-opt { padding: 4px 10px; border-radius: var(--radius-md); border: 1px solid var(--border-primary); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; }
+.sit-debate-format-opt, .sit-debate-pacing-opt { padding: 4px 10px; border-radius: var(--radius-md); border: 1px solid var(--border-color); font-size: var(--text-sm); cursor: pointer; transition: all 0.15s; }
 .sit-debate-format-opt:hover, .sit-debate-pacing-opt:hover { border-color: var(--color-sit); }
 .sit-debate-format-opt.active, .sit-debate-pacing-opt.active { background: color-mix(in srgb, var(--color-sit) 12%, var(--bg-secondary)); border-color: var(--color-sit); font-weight: 600; }
 .sit-debate-format-opt input, .sit-debate-pacing-opt input { display: none; }
 
 .sit-debate-model { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .sit-debate-model-toggle { font-size: var(--text-sm); display: flex; align-items: center; gap: 4px; cursor: pointer; }
-.sit-debate-model-select { font-size: var(--text-sm); padding: 3px 6px; border-radius: var(--radius-sm); border: 1px solid var(--border-primary); background: var(--bg-secondary); color: var(--text-primary); max-width: 220px; }
+.sit-debate-model-select { font-size: var(--text-sm); padding: 3px 6px; border-radius: var(--radius-sm); border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary); max-width: 220px; }
 .sit-debate-model-current { font-size: var(--text-xs); color: var(--text-muted); }
 
 .sit-debate-adaptive { display: flex; align-items: center; gap: 6px; font-size: var(--text-sm); cursor: pointer; margin-top: 8px; }
@@ -34,12 +34,12 @@
 .sit-debate-advanced-toggle:hover { color: var(--text-primary); }
 .sit-debate-advanced { display: flex; flex-direction: column; gap: 6px; padding: 8px 0; }
 .sit-debate-advanced input[type="range"] { width: 100%; }
-.sit-debate-audience-select { font-size: var(--text-sm); padding: 3px 6px; border-radius: var(--radius-sm); border: 1px solid var(--border-primary); background: var(--bg-secondary); color: var(--text-primary); }
+.sit-debate-audience-select { font-size: var(--text-sm); padding: 3px 6px; border-radius: var(--radius-sm); border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary); }
 
 .sit-debate-launch { margin-top: 16px; width: 100%; }
 
-.sit-debate-history { margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid var(--border-primary); }
+.sit-debate-history { margin-bottom: 16px; padding-bottom: 12px; border-bottom: 1px solid var(--border-color); }
 .sit-debate-history-list { display: flex; flex-wrap: wrap; gap: 6px; }
-.sit-debate-history-item { background: var(--bg-secondary); border: 1px solid var(--border-primary); border-radius: var(--radius-sm); padding: 4px 8px; font-size: var(--text-xs); cursor: pointer; color: var(--text-primary); }
+.sit-debate-history-item { background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: var(--radius-sm); padding: 4px 8px; font-size: var(--text-xs); cursor: pointer; color: var(--text-primary); }
 .sit-debate-history-item:hover { border-color: var(--color-sit); background: color-mix(in srgb, var(--color-sit) 8%, var(--bg-secondary)); }
 .sit-debate-history-id { font-family: var(--font-mono, monospace); }

--- a/taxonomy-editor/src/renderer/components/debate/SituationDetail.css
+++ b/taxonomy-editor/src/renderer/components/debate/SituationDetail.css
@@ -18,7 +18,7 @@
 .situation-detail-divergence-bar {
   flex: 1;
   height: 8px;
-  background: var(--bg-tertiary, var(--border));
+  background: var(--bg-tertiary, var(--border-color));
   border-radius: 4px;
   overflow: hidden;
   max-width: 160px;

--- a/taxonomy-editor/src/renderer/components/debate/SituationsTab.css
+++ b/taxonomy-editor/src/renderer/components/debate/SituationsTab.css
@@ -5,7 +5,7 @@
 }
 
 .situations-standalone-divider {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   margin-top: 4px;
   padding-top: 4px;
 }

--- a/taxonomy-editor/src/renderer/components/edge-browser/SearchPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/edge-browser/SearchPanel.tsx
@@ -949,7 +949,7 @@ export function SearchPanel({ onAnalyze, onSelectResult }: SearchPanelProps) {
       case 'safetyist': return 'var(--color-saf)';
       case 'skeptic': return 'var(--color-skp)';
       case 'situations': return 'var(--color-sit)';
-      case 'conflicts': return 'var(--color-conflict, var(--text-muted))';
+      case 'conflicts': return 'var(--color-conflicts, var(--text-muted))';
       default: return 'var(--text-muted)';
     }
   };

--- a/taxonomy-editor/src/renderer/components/organizations/OrganizationDetail.css
+++ b/taxonomy-editor/src/renderer/components/organizations/OrganizationDetail.css
@@ -148,6 +148,6 @@
 }
 .od-tags-row { display: flex; flex-wrap: wrap; gap: 4px; }
 .od-tag-chip { padding: 1px 8px; border-radius: 10px; font-size: var(--text-2xs); background: var(--bg-tertiary, #1e293b); color: var(--text-muted); }
-.od-footer { border-top: 1px solid var(--border); padding-top: 8px; font-size: 0.7rem; color: var(--text-muted); }
+.od-footer { border-top: 1px solid var(--border-color); padding-top: 8px; font-size: 0.7rem; color: var(--text-muted); }
 .od-footer-id { font-family: monospace; user-select: all; }
 .od-footer-spaced { margin-left: 12px; }

--- a/taxonomy-editor/src/renderer/components/organizations/OrganizationsTab.css
+++ b/taxonomy-editor/src/renderer/components/organizations/OrganizationsTab.css
@@ -12,7 +12,7 @@
 .orgs-tab-pov-btn { font-size: var(--text-2xs); border-radius: 10px; }
 .orgs-tab-fs-2xs { font-size: var(--text-2xs); }
 .orgs-tab-empty-state { padding: 16px; text-align: center; }
-.orgs-tab-error-text { color: var(--color-error, #ef4444); margin-bottom: 8px; font-size: 0.8rem; }
+.orgs-tab-error-text { color: var(--danger, #ef4444); margin-bottom: 8px; font-size: 0.8rem; }
 .orgs-tab-item-header { display: flex; align-items: center; gap: 6px; }
 .orgs-tab-flex-1 { flex: 1; }
 .orgs-tab-type-badge {

--- a/taxonomy-editor/src/renderer/components/settings/GeminiOnboardingModal.css
+++ b/taxonomy-editor/src/renderer/components/settings/GeminiOnboardingModal.css
@@ -28,7 +28,7 @@
 }
 
 .gemini-onboarding-success {
-  color: var(--color-success, #22c55e);
+  color: var(--success, #22c55e);
   margin-bottom: 12px;
   font-weight: 500;
 }

--- a/taxonomy-editor/src/renderer/components/settings/HelpDialog.css
+++ b/taxonomy-editor/src/renderer/components/settings/HelpDialog.css
@@ -5,18 +5,18 @@
 .helpdialog-panel-count { color: var(--text-secondary); margin-bottom: 8px; }
 .helpdialog-filter-input {
   width: 100%; padding: 6px 10px; margin-bottom: 10px; border-radius: 6px;
-  border: 1px solid var(--border); background: var(--bg-secondary);
+  border: 1px solid var(--border-color); background: var(--bg-secondary);
   color: var(--text-primary); font-size: 0.85rem; box-sizing: border-box;
 }
 
-.helpdialog-table-wrap { overflow-y: auto; max-height: 320px; border: 1px solid var(--border); border-radius: 6px; }
+.helpdialog-table-wrap { overflow-y: auto; max-height: 320px; border: 1px solid var(--border-color); border-radius: 6px; }
 .helpdialog-sbom-table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
 .helpdialog-sbom-thead-row { position: sticky; top: 0; background: var(--bg-secondary); z-index: 1; }
-.helpdialog-sbom-th { text-align: left; padding: 6px 8px; cursor: pointer; user-select: none; border-bottom: 1px solid var(--border); font-weight: 700; }
+.helpdialog-sbom-th { text-align: left; padding: 6px 8px; cursor: pointer; user-select: none; border-bottom: 1px solid var(--border-color); font-weight: 700; }
 .helpdialog-sbom-th-nowrap { white-space: nowrap; }
 .helpdialog-sbom-row { cursor: pointer; }
-.helpdialog-sbom-td { padding: 3px 8px; font-family: monospace; font-size: 0.78rem; border-bottom: 1px solid var(--border); white-space: nowrap; }
-.helpdialog-sbom-td-license { padding: 3px 8px; border-bottom: 1px solid var(--border); max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.helpdialog-sbom-td { padding: 3px 8px; font-family: monospace; font-size: 0.78rem; border-bottom: 1px solid var(--border-color); white-space: nowrap; }
+.helpdialog-sbom-td-license { padding: 3px 8px; border-bottom: 1px solid var(--border-color); max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .helpdialog-sbom-empty { padding: 12px; text-align: center; color: var(--text-muted); }
 .helpdialog-toolbar { display: flex; align-items: center; gap: 8px; margin-top: 8px; }
 .helpdialog-note-muted { font-size: 0.78rem; color: var(--text-muted); }
@@ -28,7 +28,7 @@
 .helpdialog-license-type { color: var(--text-muted); margin-left: 8px; font-size: 0.8rem; }
 .helpdialog-license-detail {
   margin: 4px 0 8px 20px; padding: 10px; border-radius: 6px;
-  background: var(--bg-secondary); border: 1px solid var(--border);
+  background: var(--bg-secondary); border: 1px solid var(--border-color);
 }
 .helpdialog-license-table { font-size: 0.8rem; margin-bottom: 8px; border-collapse: collapse; }
 .helpdialog-license-pkg-name { padding-right: 12px; font-weight: 600; }
@@ -36,7 +36,7 @@
 .helpdialog-license-text {
   font-size: 0.72rem; white-space: pre-wrap; word-break: break-word;
   max-height: 300px; overflow-y: auto; margin: 0; padding: 8px; border-radius: 4px;
-  background: var(--bg-primary); border: 1px solid var(--border);
+  background: var(--bg-primary); border: 1px solid var(--border-color);
   color: var(--text-secondary);
 }
 .helpdialog-empty-note { color: var(--text-muted); padding: 8px; }
@@ -51,7 +51,7 @@
 }
 .helpdialog-title { margin: 0 0 12px; cursor: move; user-select: none; }
 .helpdialog-body { display: flex; gap: 0; flex: 1; min-height: 0; overflow: hidden; }
-.helpdialog-tabs { display: flex; flex-direction: column; gap: 2px; border-right: 1px solid var(--border); padding-right: 12px; margin-right: 12px; }
+.helpdialog-tabs { display: flex; flex-direction: column; gap: 2px; border-right: 1px solid var(--border-color); padding-right: 12px; margin-right: 12px; }
 .helpdialog-tab {
   padding: 6px 14px; font-size: 0.8rem; font-weight: 600;
   cursor: pointer; border: none;
@@ -59,7 +59,7 @@
 }
 .helpdialog-tab-badge {
   margin-left: 6px; padding: 0 5px; border-radius: 8px; font-size: var(--text-2xs);
-  font-weight: 700; background: var(--color-error, #ef4444); color: #fff;
+  font-weight: 700; background: var(--danger, #ef4444); color: #fff;
   line-height: 16px; display: inline-block; min-width: 16px; text-align: center;
 }
 .helpdialog-content { flex: 1; overflow-y: auto; min-height: 0; }
@@ -72,7 +72,7 @@
 .helpdialog-ref-link { color: var(--accent); font-size: 0.85em; }
 .helpdialog-shortcuts-h4 { margin-top: 0; }
 
-.helpdialog-tab-sep { height: 1px; background: var(--border); margin: 6px 0; }
+.helpdialog-tab-sep { height: 1px; background: var(--border-color); margin: 6px 0; }
 .helpdialog-tab-nav { border-left: 2px solid transparent; color: var(--text-secondary); }
 .helpdialog-tab-nav:hover { color: var(--text-primary); }
 

--- a/taxonomy-editor/src/renderer/components/settings/SupportAdminPanel.css
+++ b/taxonomy-editor/src/renderer/components/settings/SupportAdminPanel.css
@@ -17,7 +17,7 @@
   margin-bottom: 8px;
   border-radius: 6px;
   background: rgba(239, 68, 68, 0.1);
-  color: var(--color-error, #ef4444);
+  color: var(--danger, #ef4444);
   font-size: 0.8rem;
 }
 
@@ -46,7 +46,7 @@
 .support-admin-search {
   padding: 4px 8px;
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-size: 0.8rem;
@@ -56,7 +56,7 @@
 .support-admin-sort {
   padding: 4px 8px;
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-size: 0.78rem;
@@ -67,7 +67,7 @@
 }
 
 .support-admin-table-wrap {
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -86,7 +86,7 @@
   text-align: left;
   padding: 6px 8px;
   font-weight: 600;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   font-size: 0.75rem;
   white-space: nowrap;
 }
@@ -144,7 +144,7 @@
 
 .support-admin-expanded-cell {
   padding: 0;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .support-admin-detail-loading {
@@ -192,7 +192,7 @@
 .support-admin-status-select {
   padding: 3px 6px;
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-primary);
   color: var(--text-primary);
   font-size: 0.78rem;
@@ -236,7 +236,7 @@
 .support-admin-attach-item {
   padding: 6px;
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-primary);
 }
 
@@ -302,7 +302,7 @@
   flex: 1;
   padding: 6px 8px;
   border-radius: 4px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-primary);
   color: var(--text-primary);
   font-size: 0.8rem;

--- a/taxonomy-editor/src/renderer/components/settings/SupportAdminPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/SupportAdminPanel.tsx
@@ -11,8 +11,8 @@ import './SupportAdminPanel.css';
 const STATUS_OPTIONS = ['all', 'open', 'in-progress', 'resolved', 'closed'] as const;
 const STATUS_COLORS: Record<string, string> = {
   open: 'var(--color-info, #3b82f6)',
-  'in-progress': 'var(--color-warning, #f59e0b)',
-  resolved: 'var(--color-success, #22c55e)',
+  'in-progress': 'var(--warning, #f59e0b)',
+  resolved: 'var(--success, #22c55e)',
   closed: 'var(--text-muted, #94a3b8)',
 };
 const PRIORITY_ORDER: Record<string, number> = { high: 0, medium: 1, low: 2 };
@@ -353,7 +353,7 @@ function TableRow({
   statusChanging,
 }: TableRowProps) {
   const tdBorderStyle: React.CSSProperties = {
-    borderBottom: isExpanded ? 'none' : '1px solid var(--border)',
+    borderBottom: isExpanded ? 'none' : '1px solid var(--border-color)',
   };
 
   return (
@@ -591,7 +591,7 @@ function ExpandedDetail({
         <div
           className="support-admin-response-status"
           // eslint-disable-next-line local/no-inline-style -- text color reflects success vs failure state
-          style={{ color: responseSuccess.startsWith('Failed') ? 'var(--color-error, #ef4444)' : 'var(--color-success, #22c55e)' }}
+          style={{ color: responseSuccess.startsWith('Failed') ? 'var(--danger, #ef4444)' : 'var(--success, #22c55e)' }}
         >
           {responseSuccess}
         </div>

--- a/taxonomy-editor/src/renderer/components/settings/UsageBrowserTab.css
+++ b/taxonomy-editor/src/renderer/components/settings/UsageBrowserTab.css
@@ -17,7 +17,7 @@
   font-size: var(--text-sm);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  background: var(--bg-secondary, var(--input-bg, #fff));
+  background: var(--bg-secondary, var(--bg-input, #fff));
   color: var(--text-primary);
 }
 
@@ -26,7 +26,7 @@
   font-size: var(--text-sm);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
-  background: var(--bg-secondary, var(--input-bg, #fff));
+  background: var(--bg-secondary, var(--bg-input, #fff));
   color: var(--text-primary);
 }
 
@@ -71,11 +71,11 @@
 }
 
 .usage-browser-row:hover {
-  background: var(--hover-bg, rgba(0, 0, 0, 0.03));
+  background: var(--bg-hover, rgba(0, 0, 0, 0.03));
 }
 
 .usage-browser-row-expanded {
-  background: var(--hover-bg, rgba(0, 0, 0, 0.03));
+  background: var(--bg-hover, rgba(0, 0, 0, 0.03));
 }
 
 .usage-browser-id code {

--- a/taxonomy-editor/src/renderer/components/shared/ChatBubble.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/ChatBubble.tsx
@@ -50,7 +50,7 @@ export function MessageBubble({ role, children, footer, isError, className, styl
     color: 'var(--text-primary, var(--border-color))',
     border: role === 'user'
       ? '1px solid color-mix(in srgb, var(--warning) 30%, transparent)'
-      : '1px solid var(--border)',
+      : '1px solid var(--border-color)',
     userSelect: 'text',
     cursor: 'text',
   };
@@ -114,7 +114,7 @@ export function StreamingBubble({ content, mdClassName, className, style }: {
     lineHeight: 1.4,
     background: 'var(--bg-tertiary, rgba(255,255,255,0.05))',
     color: 'var(--text-primary, var(--border-color))',
-    border: '1px solid var(--border)',
+    border: '1px solid var(--border-color)',
     userSelect: 'text',
     cursor: 'text',
   };

--- a/taxonomy-editor/src/renderer/components/shared/CommunityShareBanner.css
+++ b/taxonomy-editor/src/renderer/components/shared/CommunityShareBanner.css
@@ -5,13 +5,13 @@
  */
 
 .community-share-banner-admin {
-  color: var(--green, #22c55e);
+  color: var(--success, #22c55e);
   font-size: 0.75rem;
 }
 
 .community-share-banner-compact {
   background: var(--bg-secondary, #f5f5f5);
-  border-left: 3px solid var(--green, #22c55e);
+  border-left: 3px solid var(--success, #22c55e);
   border-radius: 6px;
   padding: 6px 12px;
   margin-top: 6px;
@@ -22,7 +22,7 @@
 }
 
 .community-share-banner-compact-icon {
-  color: var(--green, #22c55e);
+  color: var(--success, #22c55e);
   flex-shrink: 0;
 }
 
@@ -39,7 +39,7 @@
 
 .community-share-banner {
   background: var(--bg-secondary, #f5f5f5);
-  border-left: 3px solid var(--green, #22c55e);
+  border-left: 3px solid var(--success, #22c55e);
   border-radius: 6px;
   padding: 8px 12px;
   margin-top: 6px;
@@ -52,7 +52,7 @@
 }
 
 .community-share-banner-icon {
-  color: var(--green, #22c55e);
+  color: var(--success, #22c55e);
   flex-shrink: 0;
 }
 

--- a/taxonomy-editor/src/renderer/components/shared/DetailPane.css
+++ b/taxonomy-editor/src/renderer/components/shared/DetailPane.css
@@ -8,7 +8,7 @@
   min-width: 280px;
   overflow: hidden;
   background: var(--bg-primary);
-  border-left: 1px solid var(--border);
+  border-left: 1px solid var(--border-color);
   /* User-resizable width; the host layout constrains the max. */
   resize: horizontal;
 }
@@ -18,7 +18,7 @@
   align-items: center;
   gap: 8px;
   padding: 10px 12px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);
   flex-shrink: 0;
 }
@@ -36,7 +36,7 @@
   margin-left: auto;
   flex-shrink: 0;
   background: transparent;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   color: var(--text-muted);
   cursor: pointer;
@@ -46,7 +46,7 @@
 
 .detail-pane-close:hover {
   color: var(--text-primary);
-  background: var(--bg-tertiary, var(--border));
+  background: var(--bg-tertiary, var(--border-color));
 }
 
 .detail-pane-body {
@@ -90,7 +90,7 @@
   border-radius: 4px;
   background: var(--bg-secondary);
   color: var(--text-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .detail-pane-policy-members {

--- a/taxonomy-editor/src/renderer/components/shared/DiffWindow.css
+++ b/taxonomy-editor/src/renderer/components/shared/DiffWindow.css
@@ -9,12 +9,12 @@
   display: flex;
   flex-direction: column;
   background: var(--bg, #1e1e1e);
-  color: var(--text, #d4d4d4);
+  color: var(--text-primary, #d4d4d4);
 }
 
 .diff-window-header {
   padding: 8px 16px;
-  border-bottom: 1px solid var(--border, #333);
+  border-bottom: 1px solid var(--border-color, #333);
   display: flex;
   align-items: center;
   gap: 12px;

--- a/taxonomy-editor/src/renderer/components/shared/DiffWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/DiffWindow.tsx
@@ -57,7 +57,7 @@ export function DiffWindow() {
           <pre className="diff-window-pre">
             {lines.map((line, i) => {
               let bg = 'transparent';
-              let color = 'var(--text, #d4d4d4)';
+              let color = 'var(--text-primary, #d4d4d4)';
               if (line.startsWith('+') && !line.startsWith('+++')) {
                 bg = 'rgba(78, 197, 105, 0.15)';
                 color = '#4ec569';

--- a/taxonomy-editor/src/renderer/components/shared/LineageDetailView.css
+++ b/taxonomy-editor/src/renderer/components/shared/LineageDetailView.css
@@ -37,7 +37,7 @@
   top: var(--ctx-y);
   z-index: 9999;
   background: var(--bg-primary, #1a1a2e);
-  border: 1px solid var(--border, #333);
+  border: 1px solid var(--border-color, #333);
   border-radius: 6px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   padding: 2px 0;

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.css
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.css
@@ -19,12 +19,12 @@
 }
 
 .toolbar-nav:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
   color: var(--text-secondary);
 }
 
 .toolbar-nav-active {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
   color: var(--text-primary);
 }
 

--- a/taxonomy-editor/src/renderer/components/support/CaseDetail.css
+++ b/taxonomy-editor/src/renderer/components/support/CaseDetail.css
@@ -72,7 +72,7 @@
 .support-case-detail-attachment-item {
   padding: 8px;
   border-radius: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-secondary);
 }
 

--- a/taxonomy-editor/src/renderer/components/support/CaseDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/support/CaseDetail.tsx
@@ -9,8 +9,8 @@ import './CaseDetail.css';
 
 const STATUS_COLORS: Record<string, string> = {
   open: 'var(--color-info, #3b82f6)',
-  'in-progress': 'var(--color-warning, #f59e0b)',
-  resolved: 'var(--color-success, #22c55e)',
+  'in-progress': 'var(--warning, #f59e0b)',
+  resolved: 'var(--success, #22c55e)',
   closed: 'var(--text-muted, #94a3b8)',
 };
 

--- a/taxonomy-editor/src/renderer/components/support/MyCases.css
+++ b/taxonomy-editor/src/renderer/components/support/MyCases.css
@@ -10,7 +10,7 @@
 }
 
 .support-mycases-error-text {
-  color: var(--color-error, #ef4444);
+  color: var(--danger, #ef4444);
   margin-bottom: 12px;
 }
 
@@ -43,7 +43,7 @@
 .support-mycases-detail-error {
   padding: 20px;
   text-align: center;
-  color: var(--color-error, #ef4444);
+  color: var(--danger, #ef4444);
 }
 
 .support-mycases-list {
@@ -72,7 +72,7 @@
 .support-mycases-row {
   padding: 8px 10px;
   border-radius: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   cursor: pointer;
   background: var(--bg-primary);
   transition: background 0.1s;

--- a/taxonomy-editor/src/renderer/components/support/MyCases.tsx
+++ b/taxonomy-editor/src/renderer/components/support/MyCases.tsx
@@ -8,8 +8,8 @@ import './MyCases.css';
 
 const STATUS_COLORS: Record<string, string> = {
   open: 'var(--color-info, #3b82f6)',
-  'in-progress': 'var(--color-warning, #f59e0b)',
-  resolved: 'var(--color-success, #22c55e)',
+  'in-progress': 'var(--warning, #f59e0b)',
+  resolved: 'var(--success, #22c55e)',
   closed: 'var(--text-muted, #94a3b8)',
 };
 

--- a/taxonomy-editor/src/renderer/components/support/SupportCaseForm.css
+++ b/taxonomy-editor/src/renderer/components/support/SupportCaseForm.css
@@ -50,7 +50,7 @@
   width: 100%;
   padding: 8px 10px;
   border-radius: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-size: 0.9rem;
@@ -62,7 +62,7 @@
   padding: 8px 10px;
   border-radius: 6px;
   resize: vertical;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-secondary);
   color: var(--text-primary);
   font-size: 0.85rem;
@@ -148,7 +148,7 @@
   padding: 6px 10px;
   border-radius: 6px;
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   font-size: 0.78rem;
   color: var(--text-secondary);
   font-family: monospace;

--- a/taxonomy-editor/src/renderer/components/sync/SyncDiagnosticsDialog.css
+++ b/taxonomy-editor/src/renderer/components/sync/SyncDiagnosticsDialog.css
@@ -17,7 +17,7 @@
   width: min(720px, 90vw);
   max-height: 85vh;
   background: var(--bg-primary, #fff);
-  border: 1px solid var(--border, #d0d7de);
+  border: 1px solid var(--border-color, #d0d7de);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-3);
   display: flex;
@@ -29,7 +29,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 14px 18px;
-  border-bottom: 1px solid var(--border, #d0d7de);
+  border-bottom: 1px solid var(--border-color, #d0d7de);
 }
 .sync-diag-header h2 {
   margin: 0;
@@ -129,7 +129,7 @@
   font-weight: 500;
   color: var(--text-muted);
   padding: 4px 8px;
-  border-bottom: 1px solid var(--border, #d0d7de);
+  border-bottom: 1px solid var(--border-color, #d0d7de);
 }
 .sync-diag-file-table td {
   padding: 3px 8px;

--- a/taxonomy-editor/src/renderer/components/sync/UnsyncedChangesDrawer.css
+++ b/taxonomy-editor/src/renderer/components/sync/UnsyncedChangesDrawer.css
@@ -13,8 +13,8 @@
 .unsynced-drawer {
   width: min(960px, 85vw);
   height: 100%;
-  background: var(--color-bg-default, #fff);
-  border-left: 1px solid var(--color-border, #d0d7de);
+  background: var(--bg-primary, #fff);
+  border-left: 1px solid var(--border-color, #d0d7de);
   display: flex;
   flex-direction: column;
   box-shadow: var(--shadow-3);
@@ -24,7 +24,7 @@
   justify-content: space-between;
   align-items: flex-start;
   padding: 14px 18px;
-  border-bottom: 1px solid var(--color-border, #d0d7de);
+  border-bottom: 1px solid var(--border-color, #d0d7de);
 }
 .unsynced-drawer-title {
   margin: 0;
@@ -32,7 +32,7 @@
 }
 .unsynced-drawer-subtitle {
   font-size: var(--text-xs);
-  color: var(--color-fg-muted, #656d76);
+  color: var(--text-muted, #656d76);
   margin-top: 2px;
 }
 .unsynced-drawer-subtitle code {
@@ -43,7 +43,7 @@
   display: flex;
   gap: 8px;
   padding: 10px 18px;
-  border-bottom: 1px solid var(--color-border, #d0d7de);
+  border-bottom: 1px solid var(--border-color, #d0d7de);
 }
 .unsynced-drawer-body {
   flex: 1;
@@ -52,7 +52,7 @@
   min-height: 0;
 }
 .unsynced-drawer-file-list {
-  border-right: 1px solid var(--color-border, #d0d7de);
+  border-right: 1px solid var(--border-color, #d0d7de);
   overflow-y: auto;
   padding: 6px 0;
 }
@@ -65,8 +65,8 @@
   cursor: pointer;
   font-size: var(--text-sm);
 }
-.unsynced-drawer-file:hover { background: var(--color-bg-subtle, #f6f8fa); }
-.unsynced-drawer-file.selected { background: var(--color-bg-emphasis, #e6effd); }
+.unsynced-drawer-file:hover { background: var(--bg-secondary, #f6f8fa); }
+.unsynced-drawer-file.selected { background: var(--bg-panel, #e6effd); }
 .unsynced-drawer-file-status {
   display: inline-block;
   width: 18px;
@@ -91,11 +91,11 @@
 }
 .unsynced-drawer-file-label {
   font-size: var(--text-2xs);
-  color: var(--color-fg-muted, #656d76);
+  color: var(--text-muted, #656d76);
 }
 .unsynced-drawer-diff-panel {
   overflow: auto;
-  background: var(--color-bg-subtle, #f6f8fa);
+  background: var(--bg-secondary, #f6f8fa);
   position: relative;
 }
 .unsynced-drawer-popout-btn {
@@ -126,7 +126,7 @@
 .unsynced-drawer-diff-line.diff-header { color: #656d76; }
 .unsynced-drawer-empty, .unsynced-drawer-diff-empty {
   padding: 18px;
-  color: var(--color-fg-muted, #656d76);
+  color: var(--text-muted, #656d76);
   font-size: var(--text-sm);
 }
 

--- a/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.tsx
@@ -155,9 +155,9 @@ function Badge({ field, value, onClick, onContextMenu }: {
 // ── Extracted sub-components for complexity reduction ──────────
 
 function confidenceColor(val: number): string {
-  if (val >= 0.7) return 'var(--color-success, #22c55e)';
+  if (val >= 0.7) return 'var(--success, #22c55e)';
   if (val >= 0.4) return 'var(--color-info, #3b82f6)';
-  return 'var(--color-warning, #f59e0b)';
+  return 'var(--warning, #f59e0b)';
 }
 
 export function ConfidenceCell({ value, readOnly, doctrinallyAnchored, evidentialConfidence, history, onUpdate }: {

--- a/taxonomy-editor/src/renderer/components/taxonomy/TaxonomyRefDetail.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/TaxonomyRefDetail.css
@@ -4,7 +4,7 @@
   margin-top: 12px;
   padding: 12px 16px 16px;
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-left: 3px solid var(--accent);
   border-radius: 4px;
   /* No own height cap (t/2414): grow to fit content (e.g. a long Steelman Vulnerability)
@@ -29,7 +29,7 @@
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .taxref-node-id {
@@ -41,7 +41,7 @@
 .taxref-close-btn {
   font-size: var(--text-2xs);
   padding: 2px 10px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   background: transparent;
   color: var(--text-muted);
@@ -106,7 +106,7 @@
   border-radius: 4px;
   background: var(--bg-secondary);
   color: var(--text-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   margin-right: 6px;
   margin-bottom: 4px;
 }
@@ -118,7 +118,7 @@
 
 .taxref-desc-box {
   padding: 10px 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   background: var(--bg-secondary);
   white-space: pre-wrap;
@@ -127,7 +127,7 @@
 
 .taxref-info-box {
   padding: 10px 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   background: var(--bg-secondary);
   font-size: 0.82rem;
@@ -159,7 +159,7 @@
 .taxref-divergence-track {
   flex: 1;
   height: 8px;
-  background: var(--bg-tertiary, var(--border));
+  background: var(--bg-tertiary, var(--border-color));
   border-radius: 4px;
   overflow: hidden;
 }
@@ -235,7 +235,7 @@
 /* borderLeft color is dynamic (per-POV color prop) — kept inline. */
 .taxref-pov-summary-box {
   padding: 10px 12px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   background: var(--bg-secondary);
   font-size: 0.82rem;
@@ -245,7 +245,7 @@
 /* Edge group rows */
 .taxref-edge-row {
   padding: 6px 10px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   font-size: 0.78rem;
   cursor: pointer;
   background: transparent;
@@ -296,14 +296,14 @@
 .taxref-edge-panel {
   margin-top: 12px;
   border-radius: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   background: var(--bg-primary);
   overflow: hidden;
 }
 
 .taxref-edge-banner {
   padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   background: var(--bg-secondary);
   display: flex;
   align-items: center;
@@ -446,7 +446,7 @@
   padding: 1px 8px;
   border-radius: 10px;
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .taxref-pov-filter-row {
@@ -489,7 +489,7 @@
 .taxref-interp-block {
   margin-top: 8px;
   padding-left: 12px;
-  border-left: 2px solid var(--border);
+  border-left: 2px solid var(--border-color);
 }
 
 .taxref-interp-block-line {
@@ -517,7 +517,7 @@
 .taxref-attr-block {
   margin-top: 6px;
   padding-left: 10px;
-  border-left: 2px solid var(--border);
+  border-left: 2px solid var(--border-color);
   font-size: 0.78rem;
 }
 

--- a/taxonomy-editor/src/renderer/components/taxonomy/ValidationTab.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/ValidationTab.tsx
@@ -41,9 +41,9 @@ function speakerColor(speaker: string): string {
 }
 
 function scoreColor(score: number): string {
-  if (score > 0.5) return 'var(--color-success, #22c55e)';
-  if (score >= 0.35) return 'var(--color-warning, #eab308)';
-  return 'var(--color-error, #ef4444)';
+  if (score > 0.5) return 'var(--success, #22c55e)';
+  if (score >= 0.35) return 'var(--warning, #eab308)';
+  return 'var(--danger, #ef4444)';
 }
 
 function truncate(text: string, max: number): string {

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -967,7 +967,7 @@ body {
 }
 
 .toolbar-more-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .toolbar-more-item.active {
@@ -1130,7 +1130,7 @@ body {
 }
 
 .toolbar-icon:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
   color: var(--text-primary);
 }
 
@@ -1609,7 +1609,7 @@ body {
   font-size: var(--text-sm);
   background: var(--bg-panel);
   cursor: pointer;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .hierarchy-chip:hover {
@@ -1852,7 +1852,7 @@ body {
   font-size: var(--text-2xs);
   font-weight: 500;
   color: var(--text-muted);
-  background: var(--bg-tertiary, var(--border));
+  background: var(--bg-tertiary, var(--border-color));
   padding: 1px 6px;
   border-radius: var(--radius-md);
   text-transform: uppercase;
@@ -1865,7 +1865,7 @@ body {
   line-height: 1.5;
   color: var(--text-secondary);
   background: var(--bg-secondary, var(--bg-tertiary, #f5f5f5));
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   opacity: 0.85;
   white-space: pre-wrap;
@@ -2676,7 +2676,7 @@ body {
 .save-bar-error-dismiss {
   flex: none;
   background: transparent;
-  border: 1px solid var(--border, rgba(127,127,127,0.3));
+  border: 1px solid var(--border-color, rgba(127,127,127,0.3));
   color: var(--text-secondary, inherit);
   width: 20px;
   height: 20px;
@@ -2773,14 +2773,14 @@ body {
   gap: 6px;
   padding: 3px 10px;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--color-border, #d0d7de);
-  background: var(--color-bg-subtle, #f6f8fa);
-  color: var(--color-fg-default, #1f2328);
+  border: 1px solid var(--border-color, #d0d7de);
+  background: var(--bg-secondary, #f6f8fa);
+  color: var(--text-primary, #1f2328);
   font-size: var(--text-xs);
   cursor: pointer;
 }
 .save-bar-unsynced:hover {
-  background: var(--color-bg-emphasis, #eaeef2);
+  background: var(--bg-panel, #eaeef2);
 }
 .save-bar-unsynced-dot {
   width: 7px;
@@ -2869,7 +2869,7 @@ body {
 .pr-form {
   margin-top: 12px;
   padding: 12px;
-  border: 1px solid var(--border, #d0d7de);
+  border: 1px solid var(--border-color, #d0d7de);
   border-radius: var(--radius-md);
   background: var(--bg-secondary, #f6f8fa);
 }
@@ -2905,10 +2905,10 @@ body {
   width: 100%;
   padding: 5px 8px;
   font-size: var(--text-sm);
-  border: 1px solid var(--border, #d0d7de);
+  border: 1px solid var(--border-color, #d0d7de);
   border-radius: var(--radius-sm);
   background: var(--bg, #fff);
-  color: var(--text, #1f2328);
+  color: var(--text-primary, #1f2328);
   box-sizing: border-box;
 }
 .pr-form-textarea {
@@ -2916,10 +2916,10 @@ body {
   padding: 5px 8px;
   font-size: var(--text-sm);
   font-family: var(--font-mono, monospace);
-  border: 1px solid var(--border, #d0d7de);
+  border: 1px solid var(--border-color, #d0d7de);
   border-radius: var(--radius-sm);
   background: var(--bg, #fff);
-  color: var(--text, #1f2328);
+  color: var(--text-primary, #1f2328);
   resize: vertical;
   box-sizing: border-box;
 }
@@ -4249,7 +4249,7 @@ body {
 }
 
 .tab-bar-menu-btn:hover {
-  background: var(--hover-bg);
+  background: var(--bg-hover);
   color: var(--text-primary);
 }
 
@@ -4381,7 +4381,7 @@ body {
 .settings-key-summary {
   width: 100%;
   margin-top: 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   padding: 6px 8px;
   font-size: var(--text-sm);
@@ -4391,7 +4391,7 @@ body {
   grid-template-columns: 140px 120px 1fr;
   gap: 8px;
   padding: 4px 0;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   align-items: baseline;
 }
 .settings-key-summary-row:last-child { border-bottom: none; }
@@ -5575,7 +5575,7 @@ body {
 }
 
 .analysis-retry-headline {
-  color: var(--warning-color, #e69500);
+  color: var(--warning, #e69500);
   font-weight: 600;
 }
 
@@ -6069,7 +6069,7 @@ body {
 .search-panel-pov-filter {
   font-size: var(--text-xs);
   padding: 2px 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-primary);
   color: var(--text-primary);
@@ -6086,7 +6086,7 @@ body {
   align-items: center;
   gap: 6px;
   padding: 4px 8px;
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
 }
@@ -6133,7 +6133,7 @@ body {
 }
 
 .search-panel-typeahead-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .search-panel-typeahead-id {
@@ -6179,7 +6179,7 @@ body {
 }
 
 .search-panel-result-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .search-panel-result-item.selected {
@@ -6270,7 +6270,7 @@ body {
   flex-direction: column;
   gap: 4px;
   padding: 4px 0;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
 }
 
 .search-panel-threshold-row {
@@ -6369,7 +6369,7 @@ body {
 }
 
 .lineage-panel-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .lineage-panel-item.selected {
@@ -6405,7 +6405,7 @@ body {
 }
 
 .lineage-l2-header:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .lineage-l2-label {
@@ -6436,7 +6436,7 @@ body {
 }
 
 .lineage-category-header:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .lineage-category-label {
@@ -6615,7 +6615,7 @@ body {
 }
 
 .prompts-panel-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .prompts-panel-item.selected {
@@ -6989,7 +6989,7 @@ body {
   flex: 1;
   font-size: var(--text-sm);
   padding: 6px 8px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -7397,8 +7397,8 @@ body {
   white-space: nowrap;
 }
 .ga-fallacy-type-missing {
-  color: var(--color-warning, #d97706);
-  border: 1px dashed var(--color-warning, #d97706);
+  color: var(--warning, #d97706);
+  border: 1px dashed var(--warning, #d97706);
   background: transparent;
 }
 .ga-fallacy-confidence {
@@ -8357,9 +8357,9 @@ body {
   letter-spacing: 0.04em;
 }
 
-.sit-bdi-label-belief { color: var(--color-beliefs, #3b82f6); }
-.sit-bdi-label-desire { color: var(--color-desires, #f59e0b); }
-.sit-bdi-label-intention { color: var(--color-intentions, #10b981); }
+.sit-bdi-label-belief { color: var(--cat-beliefs, #3b82f6); }
+.sit-bdi-label-desire { color: var(--cat-desires, #f59e0b); }
+.sit-bdi-label-intention { color: var(--cat-intentions, #10b981); }
 
 .sit-pov-evidence {
   flex: 1;
@@ -8499,7 +8499,7 @@ body {
   padding: 6px 12px;
   display: flex;
   align-items: center;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 .diagnostics-panel-header h3 {
   margin: 0;
@@ -8532,7 +8532,7 @@ body {
 }
 .diag-copy-btn {
   background: none;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   cursor: pointer;
@@ -8567,7 +8567,7 @@ body {
 }
 .diag-badge-move { background: color-mix(in srgb, var(--accent, #3b82f6) 20%, var(--bg-primary)); color: var(--accent, #3b82f6); }
 .diag-badge-type { background: color-mix(in srgb, var(--color-skp) 20%, var(--bg-primary)); color: var(--color-skp); }
-.diag-assumption { margin: 4px 0; padding: 4px; border-left: 2px solid var(--border); padding-left: 8px; }
+.diag-assumption { margin: 4px 0; padding: 4px; border-left: 2px solid var(--border-color); padding-left: 8px; }
 .diag-muted { color: var(--text-muted); font-size: var(--text-xs); }
 .diag-claim { display: flex; flex-wrap: wrap; gap: 4px; align-items: baseline; margin: 3px 0; font-size: var(--text-xs); }
 .diag-claim-accepted .diag-claim-status { color: var(--success); }
@@ -8578,7 +8578,7 @@ body {
 .diag-pre {
   font-size: var(--text-2xs);
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   padding: 6px 8px;
   white-space: pre-wrap;
@@ -8595,7 +8595,7 @@ body {
   font-size: var(--text-xs);
   background: var(--bg-primary);
   color: var(--text-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   padding: 6px 8px;
   white-space: pre-wrap;
@@ -8605,7 +8605,7 @@ body {
 .diag-ref-id { color: var(--accent); font-weight: 600; min-width: 100px; }
 .diag-ref-rel { color: var(--text-muted); }
 .diag-empty { padding: 16px; text-align: center; color: var(--text-muted); }
-.diag-an-node { margin: 6px 0; padding: 4px 0; border-bottom: 1px solid var(--border); }
+.diag-an-node { margin: 6px 0; padding: 4px 0; border-bottom: 1px solid var(--border-color); }
 .diag-an-claim { display: flex; gap: 4px; flex-wrap: wrap; }
 .diag-an-id { color: var(--accent); font-weight: 600; font-size: var(--text-xs); }
 .diag-an-speaker { color: var(--text-muted); font-size: var(--text-xs); }
@@ -8632,14 +8632,14 @@ body {
 .diag-verification-supported { background: color-mix(in srgb, var(--success) 15%, transparent); color: var(--success); font-size: var(--text-2xs); cursor: default; }
 .diag-verification-disputed { background: color-mix(in srgb, var(--danger) 15%, transparent); color: var(--danger); font-size: var(--text-2xs); cursor: default; }
 .diag-verification-unverifiable { background: color-mix(in srgb, var(--text-muted) 15%, transparent); color: var(--text-muted); font-size: var(--text-2xs); cursor: default; }
-.diag-ledger-entry { margin: 4px 0; padding: 4px 0; border-bottom: 1px solid var(--border); }
+.diag-ledger-entry { margin: 4px 0; padding: 4px 0; border-bottom: 1px solid var(--border-color); }
 .diag-ledger-addressed { opacity: 0.6; }
-.diag-missing-arg { margin: 6px 0; padding: 4px 0; border-bottom: 1px solid var(--border); }
+.diag-missing-arg { margin: 6px 0; padding: 4px 0; border-bottom: 1px solid var(--border-color); }
 .diag-drift-speaker { margin: 6px 0; }
 .diag-drift-warning { background: color-mix(in srgb, var(--danger) 15%, transparent); color: var(--danger); }
 
 /* Taxonomy suggestions */
-.diag-taxo-suggestion { margin: 8px 0; padding: 6px 0; border-bottom: 1px solid var(--border); }
+.diag-taxo-suggestion { margin: 8px 0; padding: 6px 0; border-bottom: 1px solid var(--border-color); }
 .diag-taxo-before, .diag-taxo-after { margin-top: 4px; }
 .diag-taxo-desc { font-size: var(--text-2xs); padding: 4px 6px; background: var(--bg-secondary); border-radius: var(--radius-sm); margin-top: 2px; line-height: 1.4; }
 .diag-taxo-desc-proposed { background: color-mix(in srgb, var(--success) 8%, transparent); border-left: 2px solid var(--success); }
@@ -8669,7 +8669,7 @@ body {
   font-size: var(--text-xs);
   padding: 2px 10px;
   border-radius: var(--radius-lg);
-  border: 1.5px solid var(--border);
+  border: 1.5px solid var(--border-color);
   background: transparent;
   cursor: pointer;
   transition: all 0.15s;
@@ -8748,7 +8748,7 @@ body {
 }
 .debate-entry-action-btn {
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   cursor: pointer;
@@ -8762,7 +8762,7 @@ body {
 }
 .debate-entry-delete-btn {
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   color: var(--text-muted);
   cursor: pointer;
@@ -9065,7 +9065,7 @@ a.vocab-term,
 .debate-diagnose-btn {
   margin-left: auto;
   background: none;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   color: var(--text-muted);
   font-size: var(--text-2xs);
   font-weight: 600;
@@ -9126,12 +9126,12 @@ a.vocab-term,
 }
 
 .debate-progress-retry {
-  color: var(--color-warning, #d97706);
+  color: var(--warning, #d97706);
   font-weight: 500;
 }
 
 .debate-progress-limit {
-  color: var(--color-warning, #d97706);
+  color: var(--warning, #d97706);
   font-size: var(--text-xs);
 }
 
@@ -9594,7 +9594,7 @@ a.vocab-term,
 .token-budget-bar {
   width: 60px;
   height: 4px;
-  background: var(--border);
+  background: var(--border-color);
   border-radius: var(--radius-sm);
   overflow: hidden;
 }
@@ -9737,7 +9737,7 @@ a.vocab-term,
 
 .debate-mention-item:hover,
 .debate-mention-item.selected {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .debate-length-select {
@@ -9766,7 +9766,7 @@ a.vocab-term,
   font-size: var(--text-xs);
   padding: 2px 10px;
   border-radius: var(--radius-lg);
-  border: 1.5px solid var(--border);
+  border: 1.5px solid var(--border-color);
   background: transparent;
   cursor: pointer;
   transition: all 0.15s;
@@ -9806,7 +9806,7 @@ a.vocab-term,
 /* ─── Adaptive Phase Progress Bar ──────────────────── */
 .adaptive-phase-bar {
   padding: 6px 16px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 .adaptive-phase-segments {
   display: flex;
@@ -9817,7 +9817,7 @@ a.vocab-term,
   flex: 1;
   position: relative;
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   overflow: hidden;
   display: flex;
@@ -9825,7 +9825,7 @@ a.vocab-term,
   justify-content: center;
 }
 .adaptive-phase-segment.active {
-  border-color: color-mix(in srgb, currentColor 40%, var(--border));
+  border-color: color-mix(in srgb, currentColor 40%, var(--border-color));
 }
 .adaptive-phase-segment.completed {
   opacity: 0.6;
@@ -9885,7 +9885,7 @@ a.vocab-term,
   display: flex;
   align-items: center;
   padding: 8px 16px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   gap: 0;
 }
 .session-step {
@@ -9898,7 +9898,7 @@ a.vocab-term,
   width: 22px;
   height: 22px;
   border-radius: 50%;
-  border: 2px solid var(--border);
+  border: 2px solid var(--border-color);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -9937,7 +9937,7 @@ a.vocab-term,
 .session-step-line {
   width: 24px;
   height: 2px;
-  background: var(--border);
+  background: var(--border-color);
   margin: 0 4px;
   flex-shrink: 0;
   transition: background 0.25s ease;
@@ -10033,7 +10033,7 @@ a.vocab-term,
   border-radius: var(--radius-sm);
 }
 .ndd-close-btn:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
   color: var(--text-primary);
 }
 
@@ -10877,7 +10877,7 @@ a.vocab-term,
 }
 
 .debate-source-similar-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .debate-source-similar-item.active {
@@ -11030,7 +11030,7 @@ a.vocab-term,
 }
 
 .claims-editor-text {
-  color: var(--text);
+  color: var(--text-primary);
   margin-bottom: 6px;
 }
 
@@ -11346,10 +11346,10 @@ a.vocab-term,
   font-size: var(--text-md);
   margin: 0 0 8px;
   padding-bottom: 4px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
 }
 .harvest-item {
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   margin-bottom: 6px;
   padding: 8px 10px;
@@ -11383,7 +11383,7 @@ a.vocab-term,
 .harvest-item-body {
   margin-top: 8px;
   padding-top: 6px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   font-size: var(--text-xs);
 }
 .harvest-position { margin: 2px 0; }
@@ -11392,7 +11392,7 @@ a.vocab-term,
 .harvest-generated input, .harvest-generated textarea {
   font-size: var(--text-xs);
   padding: 4px 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -11412,7 +11412,7 @@ a.vocab-term,
   width: 100%;
   font-size: var(--text-xs);
   padding: 4px 6px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -11429,7 +11429,7 @@ a.vocab-term,
   gap: 4px;
   font-size: var(--text-xs);
   padding: 3px 8px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   cursor: pointer;
 }
@@ -12257,7 +12257,7 @@ a.vocab-term,
   border-bottom: 1px solid var(--border-color);
 }
 .fallacy-panel-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 .fallacy-panel-item.selected {
   background: var(--focus-ring);
@@ -12380,7 +12380,7 @@ a.vocab-term,
   cursor: pointer;
 }
 .fallacy-detail-node.clickable:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
   border-color: var(--focus-ring);
 }
 .fallacy-detail-node-header {
@@ -12626,7 +12626,7 @@ a.vocab-term,
 .chat-session-item {
   padding: 8px 12px;
   cursor: pointer;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   position: relative;
 }
 
@@ -12767,7 +12767,7 @@ a.vocab-term,
   display: flex;
   flex-direction: column;
   height: 100%;
-  border-right: 1px solid var(--border);
+  border-right: 1px solid var(--border-color);
 }
 
 .chat-workspace:not(.has-detail-pane) .chat-main-column {
@@ -12791,7 +12791,7 @@ a.vocab-term,
   float: right;
   z-index: 10;
   background: var(--bg-secondary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   font-size: var(--text-lg);
@@ -12851,7 +12851,7 @@ a.vocab-term,
   align-items: center;
   gap: 12px;
   padding: 8px 12px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
 }
 
@@ -12931,7 +12931,7 @@ a.vocab-term,
   background: rgba(231, 76, 60, 0.1);
   color: var(--color-saf);
   font-size: var(--text-sm);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
 }
 
@@ -12957,7 +12957,7 @@ a.vocab-term,
 .chat-message-user {
   align-self: flex-end;
   background: var(--bg-hover);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
 }
 
 .chat-message-header {
@@ -13088,7 +13088,7 @@ a.vocab-term,
 .chat-generating-spinner {
   width: 32px;
   height: 32px;
-  border: 3px solid var(--border);
+  border: 3px solid var(--border-color);
   border-top-color: var(--accent);
   border-radius: 50%;
   animation: chat-spin 0.8s linear infinite;
@@ -13105,7 +13105,7 @@ a.vocab-term,
   align-items: flex-end;
   gap: 8px;
   padding: 8px 12px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border-color);
   flex-shrink: 0;
 }
 
@@ -13113,7 +13113,7 @@ a.vocab-term,
   flex: 1;
   resize: none;
   padding: 8px 10px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   background: var(--bg-input);
   color: var(--text-primary);
@@ -13160,7 +13160,7 @@ a.vocab-term,
   align-items: center;
   gap: 4px;
   padding: 12px 8px;
-  border: 2px solid var(--border);
+  border: 2px solid var(--border-color);
   border-radius: var(--radius-md);
   background: var(--bg-secondary);
   cursor: pointer;
@@ -13250,7 +13250,7 @@ a.vocab-term,
 .new-chat-topic {
   width: 100%;
   padding: 8px 10px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   background: var(--bg-input);
   color: var(--text-primary);
@@ -13279,7 +13279,7 @@ a.vocab-term,
 
 .new-chat-model-select {
   padding: 4px 8px;
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-input);
   color: var(--text-primary);
@@ -13551,14 +13551,14 @@ a.vocab-term,
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
-  color: var(--text-color);
+  color: var(--text-primary);
 }
 .pi-search-input:focus-visible { border-color: var(--accent-color); }
 .pi-search-clear {
   background: none; border: none; color: var(--text-muted); cursor: pointer;
   font-size: var(--text-lg); line-height: 1; padding: 0 4px;
 }
-.pi-search-clear:hover { color: var(--text-color); }
+.pi-search-clear:hover { color: var(--text-primary); }
 .pi-search-mode { display: flex; gap: 2px; margin-top: 4px; }
 .pi-mode-pill {
   flex: 1;
@@ -14042,13 +14042,13 @@ a.vocab-term,
   accent-color: var(--text-primary);
 }
 .qbaf-needs-score {
-  border: 1px dashed var(--color-warning, #d97706);
+  border: 1px dashed var(--warning, #d97706);
   border-radius: var(--radius-sm);
   padding: 1px 4px;
 }
 .qbaf-needs-score-label {
   font-size: var(--text-2xs);
-  color: var(--color-warning, #d97706);
+  color: var(--warning, #d97706);
   font-style: italic;
   white-space: nowrap;
 }
@@ -14074,7 +14074,7 @@ a.vocab-term,
 }
 .diag-qbaf-pending {
   border-style: dashed;
-  border-color: var(--color-warning, #d97706);
+  border-color: var(--warning, #d97706);
 }
 .diag-qbaf-card-header {
   display: flex;
@@ -14933,14 +14933,14 @@ th[data-tooltip]::after {
 .param-history-section h4 { margin: 0 0 8px; font-size: var(--text-sm); color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.5px; }
 
 .param-history-table { border-collapse: collapse; font-size: var(--text-xs); }
-.param-history-table th { text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--border); color: var(--text-muted); font-weight: 500; font-size: var(--text-2xs); text-transform: uppercase; white-space: nowrap; }
-.param-history-table td { padding: 4px 8px; border-bottom: 1px solid var(--border); }
+.param-history-table th { text-align: left; padding: 4px 8px; border-bottom: 1px solid var(--border-color); color: var(--text-muted); font-weight: 500; font-size: var(--text-2xs); text-transform: uppercase; white-space: nowrap; }
+.param-history-table td { padding: 4px 8px; border-bottom: 1px solid var(--border-color); }
 .param-name { font-weight: 500; white-space: nowrap; }
 .param-value { font-family: monospace; color: var(--accent); white-space: nowrap; }
 .param-sparkline { width: 90px; }
 
 .param-history-timeline { display: flex; flex-direction: column; gap: 4px; }
-.param-history-entry { border: 1px solid var(--border); border-radius: var(--radius-sm); overflow: hidden; }
+.param-history-entry { border: 1px solid var(--border-color); border-radius: var(--radius-sm); overflow: hidden; }
 .param-history-entry-header { display: flex; align-items: center; gap: 8px; padding: 6px 8px; font-size: var(--text-xs); }
 .param-history-entry-header:hover { background: var(--bg-secondary); }
 
@@ -14953,8 +14953,8 @@ th[data-tooltip]::after {
 .param-history-meta { color: var(--text-muted); font-size: var(--text-2xs); margin-left: auto; }
 .param-history-count { font-size: var(--text-2xs); color: var(--text-muted); }
 
-.param-history-changes { padding: 6px 8px 8px; border-top: 1px solid var(--border); background: var(--bg-secondary); }
-.param-history-change { margin: 6px 0; padding-bottom: 6px; border-bottom: 1px dashed var(--border); }
+.param-history-changes { padding: 6px 8px 8px; border-top: 1px solid var(--border-color); background: var(--bg-secondary); }
+.param-history-change { margin: 6px 0; padding-bottom: 6px; border-bottom: 1px dashed var(--border-color); }
 .param-history-change:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
 .param-change-header { display: flex; gap: 6px; align-items: baseline; font-size: var(--text-xs); }
 .param-confidence-badge { font-size: var(--text-2xs); font-weight: 600; text-transform: uppercase; }
@@ -14975,7 +14975,7 @@ th[data-tooltip]::after {
   margin-top: 2px;
   padding: 4px 0;
   background: var(--bg-primary);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-2);
 }
@@ -15004,7 +15004,7 @@ th[data-tooltip]::after {
 .diag-chat-markdown pre code { background: none; padding: 0; }
 .diag-chat-markdown strong { color: #f59e0b; }
 .diag-chat-markdown table { border-collapse: collapse; font-size: var(--text-2xs); margin: 4px 0; }
-.diag-chat-markdown th, .diag-chat-markdown td { border: 1px solid var(--border); padding: 2px 6px; }
+.diag-chat-markdown th, .diag-chat-markdown td { border: 1px solid var(--border-color); padding: 2px 6px; }
 .diag-chat-markdown th { background: rgba(255,255,255,0.05); }
 
 /* ── Vocabulary Panel ──────────────────────────── */
@@ -15014,17 +15014,17 @@ th[data-tooltip]::after {
 .vocab-header h3 { margin: 0; font-size: var(--text-md); }
 .vocab-stats { font-size: var(--text-xs); color: var(--text-muted); }
 .lint-badge { background: #ef4444; color: #fff; border-radius: var(--radius-md); padding: 1px 6px; margin-left: 6px; font-size: var(--text-2xs); font-weight: 600; }
-.vocab-tabs { display: flex; gap: 2px; margin-bottom: 8px; border-bottom: 1px solid var(--border); }
+.vocab-tabs { display: flex; gap: 2px; margin-bottom: 8px; border-bottom: 1px solid var(--border-color); }
 .vocab-tabs button { background: none; border: none; color: var(--text-muted); padding: 4px 10px; cursor: pointer; border-bottom: 2px solid transparent; font-size: var(--text-xs); }
-.vocab-tabs button.active { color: var(--text); border-bottom-color: var(--accent); }
-.vocab-tabs button:hover { color: var(--text); }
+.vocab-tabs button.active { color: var(--text-primary); border-bottom-color: var(--accent); }
+.vocab-tabs button:hover { color: var(--text-primary); }
 .vocab-filters { margin-bottom: 8px; }
-.vocab-search { width: 100%; padding: 4px 8px; background: var(--input-bg); border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--text); font-size: var(--text-xs); }
+.vocab-search { width: 100%; padding: 4px 8px; background: var(--bg-input); border: 1px solid var(--border-color); border-radius: var(--radius-sm); color: var(--text-primary); font-size: var(--text-xs); }
 .vocab-filter-row { display: flex; gap: 6px; margin-top: 4px; }
-.vocab-filter-row select { flex: 1; padding: 3px 6px; background: var(--input-bg); border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--text); font-size: var(--text-xs); }
+.vocab-filter-row select { flex: 1; padding: 3px 6px; background: var(--bg-input); border: 1px solid var(--border-color); border-radius: var(--radius-sm); color: var(--text-primary); font-size: var(--text-xs); }
 .vocab-content { flex: 1; }
 .vocab-list { display: flex; flex-direction: column; gap: 2px; }
-.vocab-entry { padding: 6px 8px; border: 1px solid var(--border); border-radius: var(--radius-sm); cursor: pointer; transition: background 0.1s; }
+.vocab-entry { padding: 6px 8px; border: 1px solid var(--border-color); border-radius: var(--radius-sm); cursor: pointer; transition: background 0.1s; }
 .vocab-entry:hover { background: rgba(255,255,255,0.03); }
 .vocab-entry.expanded { background: rgba(255,255,255,0.04); border-color: var(--accent); }
 .vocab-entry-header { display: flex; align-items: center; gap: 6px; font-size: var(--text-xs); }
@@ -15032,10 +15032,10 @@ th[data-tooltip]::after {
 .canonical { font-size: var(--text-xs); color: var(--accent); background: rgba(255,255,255,0.05); padding: 1px 4px; border-radius: var(--radius-sm); }
 .display-form { color: var(--text-muted); font-size: var(--text-xs); flex: 1; }
 .node-count { font-size: var(--text-2xs); color: var(--text-muted); background: rgba(255,255,255,0.05); padding: 1px 5px; border-radius: var(--radius-md); }
-.vocab-entry-detail { margin-top: 6px; padding-top: 6px; border-top: 1px solid var(--border); }
+.vocab-entry-detail { margin-top: 6px; padding-top: 6px; border-top: 1px solid var(--border-color); }
 .vocab-entry-detail .definition { margin: 0 0 6px; line-height: 1.4; }
 .detail-row { margin: 3px 0; font-size: var(--text-xs); }
-.detail-row strong { color: var(--text); margin-right: 4px; }
+.detail-row strong { color: var(--text-primary); margin-right: 4px; }
 .detail-row.meta { color: var(--text-muted); font-style: italic; }
 .phrase-tag { display: inline-block; background: rgba(245,158,11,0.12); color: #f59e0b; padding: 1px 5px; border-radius: var(--radius-sm); margin: 1px 2px; font-size: var(--text-2xs); }
 .see-also-link { cursor: pointer; color: var(--accent); text-decoration: underline; margin-right: 6px; }
@@ -15050,7 +15050,7 @@ th[data-tooltip]::after {
 .resolution .when { color: var(--text-muted); font-size: var(--text-2xs); }
 .camp-tag { font-size: var(--text-2xs); font-weight: 500; }
 .ambiguous-when { font-size: var(--text-2xs); color: var(--text-muted); margin-top: 4px; }
-.lint-list .lint-violation { padding: 6px 8px; border: 1px solid var(--border); border-radius: var(--radius-sm); margin-bottom: 2px; }
+.lint-list .lint-violation { padding: 6px 8px; border: 1px solid var(--border-color); border-radius: var(--radius-sm); margin-bottom: 2px; }
 .lint-violation.severity-error { border-left: 3px solid #ef4444; }
 .lint-violation.severity-warning { border-left: 3px solid #f59e0b; }
 .lint-violation.severity-info { border-left: 3px solid #3b82f6; }
@@ -15360,15 +15360,15 @@ th[data-tooltip]::after {
   flex: 1;
   padding: 4px 8px;
   font-size: var(--text-sm);
-  border: 1px solid var(--border, #d0d7de);
+  border: 1px solid var(--border-color, #d0d7de);
   border-radius: var(--radius-sm);
   background: var(--bg, #fff);
-  color: var(--text, #1f2328);
+  color: var(--text-primary, #1f2328);
 }
 .comment-filter-toggle {
   font-size: var(--text-xs);
   padding: 3px 8px;
-  border: 1px solid var(--border, #d0d7de);
+  border: 1px solid var(--border-color, #d0d7de);
   border-radius: var(--radius-sm);
   background: var(--bg, #fff);
   color: var(--text-muted, #636c76);
@@ -15415,7 +15415,7 @@ th[data-tooltip]::after {
 .comment-filter-pill {
   font-size: var(--text-2xs);
   padding: 2px 6px;
-  border: 1px solid var(--border, #d0d7de);
+  border: 1px solid var(--border-color, #d0d7de);
   border-radius: var(--radius-md);
   background: var(--bg, #fff);
   color: var(--text-muted, #636c76);
@@ -15434,7 +15434,7 @@ th[data-tooltip]::after {
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  color: var(--text, #1f2328);
+  color: var(--text-primary, #1f2328);
 }
 .comment-filter-checkbox input { margin: 0; }
 
@@ -15645,7 +15645,7 @@ th[data-tooltip]::after {
 }
 
 .mobile-header-hamburger:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .mobile-header-title {
@@ -15689,7 +15689,7 @@ th[data-tooltip]::after {
 }
 
 .bottom-nav-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
   color: var(--text-primary);
 }
 
@@ -15765,7 +15765,7 @@ th[data-tooltip]::after {
 }
 
 .hamburger-close:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
   color: var(--text-primary);
 }
 
@@ -15814,7 +15814,7 @@ th[data-tooltip]::after {
 }
 
 .hamburger-item:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .hamburger-item.active {
@@ -15910,7 +15910,7 @@ th[data-tooltip]::after {
   .help-dialog > div:nth-child(2) > div:first-child {
     flex-direction: row !important;
     border-right: none !important;
-    border-bottom: 1px solid var(--border) !important;
+    border-bottom: 1px solid var(--border-color) !important;
     padding-right: 0 !important;
     margin-right: 0 !important;
     padding-bottom: 8px !important;
@@ -15987,7 +15987,7 @@ th[data-tooltip]::after {
 }
 
 .phone-detail-back:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 .phone-detail-list-toggle {
@@ -16004,7 +16004,7 @@ th[data-tooltip]::after {
 }
 
 .phone-detail-list-toggle:hover {
-  background: var(--bg-hover, var(--hover-bg));
+  background: var(--bg-hover, var(--bg-hover));
 }
 
 /* ─── Touch-friendly resize handle (t/364) ────────────── */
@@ -16667,14 +16667,14 @@ th[data-tooltip]::after {
 .validation-sidebar {
   display: flex;
   flex-direction: column;
-  border-right: 1px solid var(--border, #e2e8f0);
+  border-right: 1px solid var(--border-color, #e2e8f0);
   position: relative;
   overflow: hidden;
 }
 
 .validation-sidebar-header {
   padding: 8px 10px;
-  border-bottom: 1px solid var(--border, #e2e8f0);
+  border-bottom: 1px solid var(--border-color, #e2e8f0);
   flex-shrink: 0;
 }
 
@@ -16689,7 +16689,7 @@ th[data-tooltip]::after {
 
 .validation-progress-fill {
   height: 100%;
-  background: var(--color-success, #22c55e);
+  background: var(--success, #22c55e);
   border-radius: var(--radius-sm);
   transition: width 0.3s ease;
 }
@@ -16715,7 +16715,7 @@ th[data-tooltip]::after {
   width: 100%;
   padding: 4px 6px;
   font-size: var(--text-sm);
-  border: 1px solid var(--border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-sm);
   background: var(--bg-primary, #fff);
   color: var(--text-primary, #1e293b);
@@ -16808,16 +16808,16 @@ th[data-tooltip]::after {
 
 .validation-verdict-dot.verdict-none { background: var(--text-muted, #ccc); }
 .validation-verdict-dot.verdict-correct {
-  background: var(--color-success, #22c55e);
-  box-shadow: 0 0 4px var(--color-success, #22c55e);
+  background: var(--success, #22c55e);
+  box-shadow: 0 0 4px var(--success, #22c55e);
 }
 .validation-verdict-dot.verdict-incorrect {
-  background: var(--color-error, #ef4444);
-  box-shadow: 0 0 4px var(--color-error, #ef4444);
+  background: var(--danger, #ef4444);
+  box-shadow: 0 0 4px var(--danger, #ef4444);
 }
 .validation-verdict-dot.verdict-uncertain {
-  background: var(--color-warning, #eab308);
-  box-shadow: 0 0 4px var(--color-warning, #eab308);
+  background: var(--warning, #eab308);
+  box-shadow: 0 0 4px var(--warning, #eab308);
 }
 .validation-verdict-dot.verdict-novel {
   background: #a855f7;
@@ -16869,7 +16869,7 @@ th[data-tooltip]::after {
   padding: 12px;
   background: var(--bg-secondary, #f8fafc);
   border-radius: var(--radius-md);
-  border-left: 3px solid var(--border, #e2e8f0);
+  border-left: 3px solid var(--border-color, #e2e8f0);
   user-select: text;
   -webkit-user-select: text;
   cursor: text;
@@ -16890,7 +16890,7 @@ th[data-tooltip]::after {
   transition: opacity 0.15s;
 }
 .validation-claim-full-text:hover .validation-copy-btn { opacity: 1; }
-.validation-copy-btn:hover { background: var(--border, #cbd5e1); }
+.validation-copy-btn:hover { background: var(--border-color, #cbd5e1); }
 
 .validation-context-row {
   display: flex;
@@ -16924,7 +16924,7 @@ th[data-tooltip]::after {
 
 .validation-verdict-btn {
   padding: 6px 14px;
-  border: 2px solid var(--border, #e2e8f0);
+  border: 2px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-md);
   background: var(--bg-primary, #fff);
   color: var(--text-primary, #1e293b);
@@ -16941,27 +16941,27 @@ th[data-tooltip]::after {
 .validation-verdict-btn kbd {
   font-size: var(--text-xs);
   padding: 1px 4px;
-  border: 1px solid var(--border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary, #f1f5f9);
   margin-left: 4px;
 }
 
 .validation-verdict-btn.verdict-correct.active {
-  background: var(--color-success, #22c55e);
-  border-color: var(--color-success, #22c55e);
+  background: var(--success, #22c55e);
+  border-color: var(--success, #22c55e);
   color: #fff;
 }
 
 .validation-verdict-btn.verdict-incorrect.active {
-  background: var(--color-error, #ef4444);
-  border-color: var(--color-error, #ef4444);
+  background: var(--danger, #ef4444);
+  border-color: var(--danger, #ef4444);
   color: #fff;
 }
 
 .validation-verdict-btn.verdict-uncertain.active {
-  background: var(--color-warning, #eab308);
-  border-color: var(--color-warning, #eab308);
+  background: var(--warning, #eab308);
+  border-color: var(--warning, #eab308);
   color: #fff;
 }
 
@@ -16975,7 +16975,7 @@ th[data-tooltip]::after {
   width: 100%;
   padding: 8px;
   font-size: var(--text-md);
-  border: 1px solid var(--border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-md);
   background: var(--bg-primary, #fff);
   color: var(--text-primary, #1e293b);
@@ -17008,7 +17008,7 @@ th[data-tooltip]::after {
 .validation-attribution {
   display: flex;
   flex-direction: column;
-  border-left: 1px solid var(--border, #e2e8f0);
+  border-left: 1px solid var(--border-color, #e2e8f0);
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   padding: 12px;
@@ -17030,23 +17030,23 @@ th[data-tooltip]::after {
 
 .validation-node-card {
   padding: 10px;
-  border: 1px solid var(--border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-md);
   background: var(--bg-secondary, #f8fafc);
 }
 
 .validation-node-card.incorrect {
-  border-color: var(--color-error, #ef4444);
-  background: color-mix(in srgb, var(--color-error, #ef4444) 5%, var(--bg-secondary, #f8fafc));
+  border-color: var(--danger, #ef4444);
+  background: color-mix(in srgb, var(--danger, #ef4444) 5%, var(--bg-secondary, #f8fafc));
 }
 
 .validation-node-card.corrected {
-  border-color: var(--color-success, #22c55e);
-  background: color-mix(in srgb, var(--color-success, #22c55e) 5%, var(--bg-secondary, #f8fafc));
+  border-color: var(--success, #22c55e);
+  background: color-mix(in srgb, var(--success, #22c55e) 5%, var(--bg-secondary, #f8fafc));
 }
 
 .validation-node-card.missing {
-  border-color: var(--color-warning, #eab308);
+  border-color: var(--warning, #eab308);
   opacity: 0.7;
 }
 
@@ -17110,7 +17110,7 @@ th[data-tooltip]::after {
   display: block;
   width: 100%;
   padding: 8px;
-  border: 1px solid var(--border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-sm);
   background: var(--bg-primary, #fff);
   color: var(--text-primary, #1e293b);
@@ -17159,7 +17159,7 @@ th[data-tooltip]::after {
   min-width: 0;
   padding: 6px 8px;
   font-size: var(--text-sm);
-  border: 1px solid var(--border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-sm);
   background: var(--bg-primary, #fff);
   color: var(--text-primary, #1e293b);
@@ -17168,7 +17168,7 @@ th[data-tooltip]::after {
 .validation-pov-select {
   padding: 4px 6px;
   font-size: var(--text-xs);
-  border: 1px solid var(--border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-sm);
   background: var(--bg-primary, #fff);
   color: var(--text-primary, #1e293b);
@@ -17207,7 +17207,7 @@ th[data-tooltip]::after {
 }
 
 .validation-search-item {
-  border: 1px solid var(--border, #e2e8f0);
+  border: 1px solid var(--border-color, #e2e8f0);
   border-radius: var(--radius-md);
   overflow: hidden;
 }
@@ -17223,7 +17223,7 @@ th[data-tooltip]::after {
 
 .validation-expanded-detail {
   padding: 8px 10px;
-  border-top: 1px solid var(--border, #e2e8f0);
+  border-top: 1px solid var(--border-color, #e2e8f0);
   background: var(--bg-secondary, #f8fafc);
   font-size: var(--text-sm);
   color: var(--text-primary, #1e293b);
@@ -17245,16 +17245,16 @@ th[data-tooltip]::after {
   padding: 4px 10px;
   font-size: var(--text-xs);
   font-weight: 600;
-  border: 1px solid var(--color-error, #ef4444);
+  border: 1px solid var(--danger, #ef4444);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--color-error, #ef4444) 8%, transparent);
-  color: var(--color-error, #ef4444);
+  background: color-mix(in srgb, var(--danger, #ef4444) 8%, transparent);
+  color: var(--danger, #ef4444);
   cursor: pointer;
   margin-top: 4px;
 }
 
 .validation-select-correction-btn:hover {
-  background: color-mix(in srgb, var(--color-error, #ef4444) 16%, transparent);
+  background: color-mix(in srgb, var(--danger, #ef4444) 16%, transparent);
 }
 
 /* Resize handles */

--- a/taxonomy-editor/src/renderer/theme-token-completeness.test.ts
+++ b/taxonomy-editor/src/renderer/theme-token-completeness.test.ts
@@ -39,16 +39,8 @@ const RENDERER_DIR = dirname(fileURLToPath(import.meta.url)); // this file lives
 // (b) undefined, need Design values → t/2569: genuinely-new tokens
 //     (e.g. --error-* family). Fix = Design blesses per-theme values, then define.
 const BASELINE_ALIAS_BUGS_T2568 = [
-  '--accent', '--accent-bg', '--accent-blue', '--accent-color', '--accent-hover',
-  '--accent-primary', '--accent-rgb', '--accent-strong', '--accent-text',
-  '--border', '--border-color-light', '--border-color-subtle', '--border-faint',
-  '--border-light', '--border-primary', '--border-subtle',
-  '--color-accent', '--color-beliefs', '--color-bg-default', '--color-bg-emphasis',
-  '--color-bg-subtle', '--color-border', '--color-conflict', '--color-desires',
-  '--color-error', '--color-fg-default', '--color-fg-muted', '--color-intentions',
-  '--color-moderator', '--color-success', '--color-warning',
-  '--hover-bg', '--input-bg', '--red', '--green',
-  '--text', '--text-color', '--text-tertiary', '--warning-color',
+  // Emptied by the t/2568 sweep: 23 wrong-name refs renamed to their real token;
+  // the other 16 were NOT wrong-names — reclassified to the (b) group below.
 ];
 const BASELINE_NEED_VALUES_T2569 = [
   '--active-definition-bg', '--bg-elevated', '--bg-selected', '--bg-subtle',
@@ -57,6 +49,15 @@ const BASELINE_NEED_VALUES_T2569 = [
   '--font-sans', '--font-serif', '--info', '--link', '--link-color',
   '--settings-warn-bg', '--surface-1', '--tag-bg', '--tag-color',
   '--warning-bg', '--warning-border',
+  // reclassified from class-(a) by t/2568 — these need REAL tokens, not renames:
+  //   accent family + --color-accent + --color-moderator = the unresolved t/2172 accent;
+  //   border-subtle variants need a real --border-subtle (collapsing to --border-color
+  //   would render heavier borders than the fallbacks — TL t/2568#3).
+  '--accent', '--accent-bg', '--accent-blue', '--accent-color', '--accent-hover',
+  '--accent-primary', '--accent-rgb', '--accent-strong', '--accent-text',
+  '--color-accent', '--color-moderator',
+  '--border-light', '--border-faint', '--border-subtle',
+  '--border-color-light', '--border-color-subtle',
 ];
 const BASELINE = new Set<string>([...BASELINE_ALIAS_BUGS_T2568, ...BASELINE_NEED_VALUES_T2569]);
 


### PR DESCRIPTION
## Summary
Class-(a) burn-down for the t/2567 gate: **23** CSS custom props were referenced by a **wrong name** while the intended token exists → they rendered hardcoded fallbacks in every theme. **Mechanical exact-token rename** (`var(--wrong)`→`var(--right)`, boundary-safe so `--border-color` etc. are untouched) across **85 renderer files**. TL-approved mapping (t/2568#1/#3); Sync-approved Primer subset.

**Renames:** `--border`/`--border-primary`→`--border-color` · `--text`/`--text-color`→`--text-primary` · `--text-tertiary`→`--text-muted` · `--color-beliefs/desires/intentions`→`--cat-*` · `--color-conflict`→`--color-conflicts` · `--color-border`→`--border-color` · `--color-success`→`--success` · `--color-warning`/`--warning-color`→`--warning` · `--color-error`→`--danger` · `--hover-bg`→`--bg-hover` · `--input-bg`→`--bg-input` · `--red`→`--danger` · `--green`→`--success` · Sync Primer `--color-fg/bg-*`→`--text-*`/`--bg-*`.

**Deferred (NOT in this PR):** the `--accent*` family + `--color-accent` + `--color-moderator` (→ t/2172) and the 5 subtle-border variants (→ new `--border-subtle`) are reclassified into the t/2567 gate's t/2569 group; their repoints + defs land in the **t/2569 Batch-1 PR** (Design-blessed, t/2569#1).

## Touched components — owners, please object in-window if a swap looks wrong (result = the token the author intended)
DebateDiagnostics (36), shared* + styles.css* (mine), DebateWorkspace (6), Analysis (6), Support (5), Settings (5), DebateUI (5), taxonomy (3), PovProgression (3), Sync (2), Organizations (2), Conflict (2), EdgeBrowser (1), Chat (1).

## Test plan
- [x] t/2567 gate 3/3 (baseline shrank by the 23; ratchet + stale-guard green)
- [x] renderer-tsc 0/0 · vite build clean
- [ ] CI green · 4-theme spot-check on border/text surfaces (highest-visibility)

Closes t/2568 · feeds t/2567 ratchet

🤖 Generated with [Claude Code](https://claude.com/claude-code)