### PR TITLE
feat(storage): personal oped-set store — atomic finalize, partial-set, orphan sweep (t/2572)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/opedStore.test.ts
+++ b/taxonomy-editor/src/server/__tests__/opedStore.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+// Tests for opedStore.ts — t/2572
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Inline mock backend ──────────────────────────────────────────────────────
+
+type Blob = { content: string } | null;
+const _store = new Map<string, string>();
+
+const mockBackend = {
+  readFile: vi.fn(async (p: string) => _store.get(p) ?? null),
+  writeFile: vi.fn(async (p: string, c: string) => { _store.set(p, c); }),
+  deleteFile: vi.fn(async (p: string) => { _store.delete(p); }),
+  listDirectory: vi.fn(async (dir: string) => {
+    const prefix = dir.endsWith('/') ? dir : dir + '/';
+    return [..._store.keys()]
+      .filter(k => k.startsWith(prefix))
+      .map(k => k.slice(prefix.length).split('/')[0])
+      .filter((v, i, a) => a.indexOf(v) === i);
+  }),
+  fileExists: vi.fn(async (p: string) => _store.has(p)),
+  readBinaryFile: vi.fn(),
+  writeBinaryFile: vi.fn(),
+};
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('../config.js', () => ({
+  resolveDataPath: (rel: string) => `/data/${rel}`,
+  getDataRoot: () => '/data',
+}));
+
+vi.mock('../logger.js', () => ({
+  log: { server: { info: vi.fn(), warn: vi.fn() } },
+}));
+
+vi.mock('../security/userContext.js', () => ({
+  getStorageUserId: vi.fn(() => 'user-abc'),
+  isAnonymousUser: vi.fn(() => false),
+}));
+
+vi.mock('./fileIO.js', () => ({
+  getUserContentBackend: () => mockBackend,
+  assertSafeId: (value: string, label: string) => {
+    if (!value || !/^[a-zA-Z0-9_-]+$/.test(value))
+      throw Object.assign(new Error(`Invalid ${label}: "${value}"`), { statusCode: 400 });
+  },
+}));
+
+import {
+  listOpedSets,
+  loadOpedSet,
+  saveOpedSetInProgress,
+  loadOpedSetInProgress,
+  finalizeOpedSet,
+  deleteOpedSet,
+} from '../storage/opedStore.js';
+import type { OpEdSet } from '../../../../lib/oped/types.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSet(id: string, overrides: Partial<OpEdSet> = {}): OpEdSet {
+  return {
+    schema_version: 1,
+    set_id: id,
+    topic: 'AI Safety policy',
+    params: { wordCount: 800, model: 'claude-sonnet-5' },
+    created_at: '2026-08-13T10:00:00.000Z',
+    opeds: [
+      { pov: 'accelerationist', status: 'complete', headline: 'H1', subtitle: 'S1', body: 'B1', wordCount: 800, grounding: [] },
+      { pov: 'safetyist', status: 'complete', headline: 'H2', subtitle: 'S2', body: 'B2', wordCount: 800, grounding: [] },
+    ],
+    ...overrides,
+  };
+}
+
+const DIR = '/data/users/user-abc/oped-sets';
+const indexPath = `${DIR}/_index.json`;
+
+beforeEach(() => {
+  _store.clear();
+  vi.clearAllMocks();
+  // Reset the _sweptUsers set between tests by re-importing isn't possible with vi.mock,
+  // so we rely on mock.calls tracking for sweep assertions instead.
+});
+
+// ── 1. Round-trip ─────────────────────────────────────────────────────────────
+
+describe('round-trip (t/2572)', () => {
+  it('finalizeOpedSet then loadOpedSet returns deep-equal doc', async () => {
+    const set = makeSet('set-001');
+    await finalizeOpedSet(set);
+    const loaded = await loadOpedSet('set-001');
+    expect(loaded).toEqual(set);
+  });
+});
+
+// ── 2. Partial-set persists ───────────────────────────────────────────────────
+
+describe('partial-set (t/2572)', () => {
+  it('finalizes a set with failed/cancelled members and lists it correctly', async () => {
+    const set = makeSet('set-002', {
+      opeds: [
+        { pov: 'accelerationist', status: 'complete', headline: 'H', subtitle: 'S', body: 'B', wordCount: 700, grounding: [] },
+        { pov: 'safetyist', status: 'failed', headline: '', subtitle: '', body: '', wordCount: 0, grounding: [] },
+        { pov: 'skeptic', status: 'cancelled', headline: '', subtitle: '', body: '', wordCount: 0, grounding: [] },
+      ],
+    });
+    await finalizeOpedSet(set);
+    const list = await listOpedSets();
+    const entry = list.find(e => e.set_id === 'set-002');
+    expect(entry).toBeDefined();
+    expect(entry!.voice_count).toBe(3);
+    expect(entry!.camps).toContain('accelerationist');
+    expect(entry!.camps).toContain('safetyist');
+    expect(entry!.camps).toContain('skeptic');
+  });
+});
+
+// ── 3. List does not load individual docs ─────────────────────────────────────
+
+describe('list without full-doc load (t/2572)', () => {
+  it('listOpedSets succeeds even when individual set-doc reads would throw', async () => {
+    const set = makeSet('set-003');
+    await finalizeOpedSet(set);
+
+    // Poison individual set-doc reads; index reads still work
+    const setDocPath = `${DIR}/oped-set-set-003.json`;
+    mockBackend.readFile.mockImplementation(async (p: string) => {
+      if (p === setDocPath) throw new Error('Should not read individual set doc');
+      return _store.get(p) ?? null;
+    });
+
+    const list = await listOpedSets();
+    const entry = list.find(e => e.set_id === 'set-003');
+    expect(entry).toBeDefined();
+    expect(entry!.topic).toBe('AI Safety policy');
+
+    // Restore default implementation
+    mockBackend.readFile.mockImplementation(async (p: string) => _store.get(p) ?? null);
+  });
+});
+
+// ── 4. In-progress lifecycle ──────────────────────────────────────────────────
+
+describe('in-progress lifecycle (t/2572)', () => {
+  it('saveOpedSetInProgress → loadOpedSetInProgress → finalizeOpedSet → null', async () => {
+    const partial = { set_id: 'set-004', opeds: [{ pov: 'accelerationist', status: 'complete' }] };
+    await saveOpedSetInProgress('set-004', partial);
+    const loaded = await loadOpedSetInProgress('set-004');
+    expect(loaded).toEqual(partial);
+
+    const set = makeSet('set-004');
+    await finalizeOpedSet(set);
+    // Allow the best-effort delete to settle
+    await new Promise(r => setTimeout(r, 10));
+
+    const inprogPath = `${DIR}/oped-set-set-004.json.inprogress`;
+    expect(_store.has(inprogPath)).toBe(false);
+  });
+});
+
+// ── 5. assertSafeId at entry points ──────────────────────────────────────────
+
+describe('assertSafeId guards (t/2572)', () => {
+  const badIds = ['../evil', 'bad/path', '', 'a b'];
+  const ops: Array<[string, () => Promise<unknown>]> = [
+    ['loadOpedSet', () => loadOpedSet('../evil')],
+    ['saveOpedSetInProgress', () => saveOpedSetInProgress('../evil', {})],
+    ['loadOpedSetInProgress', () => loadOpedSetInProgress('../evil')],
+    ['finalizeOpedSet', () => finalizeOpedSet(makeSet('../evil'))],
+    ['deleteOpedSet', () => deleteOpedSet('../evil')],
+  ];
+
+  for (const [name, op] of ops) {
+    it(`${name} rejects unsafe setId`, async () => {
+      await expect(op()).rejects.toMatchObject({ statusCode: 400 });
+    });
+  }
+});
+
+// ── 6. Delete round-trip ──────────────────────────────────────────────────────
+
+describe('delete round-trip (t/2572)', () => {
+  it('deleteOpedSet removes doc from load and list; no throw if .inprogress absent', async () => {
+    const set = makeSet('set-006');
+    await finalizeOpedSet(set);
+    await deleteOpedSet('set-006');
+    // Allow best-effort operations to settle
+    await new Promise(r => setTimeout(r, 10));
+
+    expect(await loadOpedSet('set-006')).toBeNull();
+    const list = await listOpedSets();
+    expect(list.find(e => e.set_id === 'set-006')).toBeUndefined();
+    // .inprogress delete on absent file must not throw (deleteFile is best-effort)
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/opedStore.test.ts
+++ b/taxonomy-editor/src/server/__tests__/opedStore.test.ts
@@ -40,7 +40,7 @@ vi.mock('../security/userContext.js', () => ({
   isAnonymousUser: vi.fn(() => false),
 }));
 
-vi.mock('./fileIO.js', () => ({
+vi.mock('../storage/fileIO.js', () => ({
   getUserContentBackend: () => mockBackend,
   assertSafeId: (value: string, label: string) => {
     if (!value || !/^[a-zA-Z0-9_-]+$/.test(value))

--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -33,6 +33,7 @@ import { serializeEdgesJson } from '../../../../lib/edges/serializeEdges.js';
 export * from './debateStore.js';
 export * from './calibrationStore.js';
 export * from './urlFetch.js';
+export * from './opedStore.js';
 // ── Backend injection ──
 
 // Taxonomy / conflicts / calibration / summaries / sources use `backend`.

--- a/taxonomy-editor/src/server/storage/opedStore.ts
+++ b/taxonomy-editor/src/server/storage/opedStore.ts
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Op-ed set persistence — atomic finalize, partial-set semantics, .inprogress tier.
+ * Parallel to debateStore.ts (ADR-007, t/2572). Re-exported from fileIO.ts.
+ *
+ * Visibility contract: .inprogress blobs are NEVER surfaced by listOpedSets or
+ * loadOpedSet. Only finalizeOpedSet promotes a set to the visible final state.
+ * Orphaned .inprogress blobs are swept once per user per server lifetime.
+ */
+
+import path from 'path';
+import { resolveDataPath } from '../config.js';
+import type { OpEdSet } from '../../../../lib/oped/types.js';
+import { log } from '../logger.js';
+import { getStorageUserId, isAnonymousUser } from '../security/userContext.js';
+import { getUserContentBackend, assertSafeId } from './fileIO.js';
+
+// ── Summary type (index entry — cheap list surface, no full-doc loads) ──
+
+export interface OpEdSetSummary {
+  set_id: string;
+  topic: string;
+  camps: string[];       // pov keys from all members
+  voice_count: number;
+  created_at: string;
+  updated_at: string;   // stamped at finalizeOpedSet time
+}
+
+// ── Dir helpers ──
+
+function getOpedSetsDir(): string {
+  const userId = getStorageUserId();
+  if (userId === '_local') return resolveDataPath('oped-sets');
+  return resolveDataPath(`users/${userId}/oped-sets`);
+}
+
+const OPED_INDEX_FILE = '_index.json';
+
+// ── Index helpers ──
+
+async function readOpedSetIndex(): Promise<OpEdSetSummary[] | null> {
+  const backend = getUserContentBackend();
+  const raw = await backend.readFile(path.join(getOpedSetsDir(), OPED_INDEX_FILE));
+  if (raw === null) return null;
+  try { return JSON.parse(raw); } catch { /* telemetry — silent by design */ return null; }
+}
+
+async function writeOpedSetIndex(entries: OpEdSetSummary[]): Promise<void> {
+  const backend = getUserContentBackend();
+  await backend.writeFile(
+    path.join(getOpedSetsDir(), OPED_INDEX_FILE),
+    JSON.stringify(entries, null, 2),
+  );
+}
+
+async function upsertOpedSetIndex(summary: OpEdSetSummary): Promise<void> {
+  const entries = (await readOpedSetIndex()) ?? [];
+  const idx = entries.findIndex(e => e.set_id === summary.set_id);
+  if (idx >= 0) entries[idx] = summary;
+  else entries.push(summary);
+  await writeOpedSetIndex(entries);
+}
+
+async function removeFromOpedSetIndex(setId: string): Promise<void> {
+  const entries = await readOpedSetIndex();
+  if (!entries) return;
+  const filtered = entries.filter(e => e.set_id !== setId);
+  if (filtered.length !== entries.length) await writeOpedSetIndex(filtered);
+}
+
+// ── Startup orphan sweep ──
+
+// Tracks which users have been swept this server lifetime — ensures once-only semantics.
+const _sweptUsers = new Set<string>();
+
+/** Sweep all orphaned .inprogress blobs for the current user. Best-effort: errors logged,
+ *  not thrown. Runs once per user per server lifetime (guarded by _sweptUsers). */
+async function sweepOrphanedOpedSetInProgress(): Promise<void> {
+  if (isAnonymousUser()) return;
+  const userId = getStorageUserId();
+  if (_sweptUsers.has(userId)) return;
+  _sweptUsers.add(userId);
+
+  const backend = getUserContentBackend();
+  const dir = getOpedSetsDir();
+  try {
+    const files = await backend.listDirectory(dir);
+    const orphans = files.filter(f => f.endsWith('.inprogress'));
+    await Promise.all(orphans.map(async f => {
+      try {
+        await backend.deleteFile(path.join(dir, f));
+        log.server.info({ file: f }, 'Swept orphaned oped-set .inprogress blob');
+      } catch (err) {
+        log.server.warn({ err, file: f }, 'Failed to sweep orphaned oped-set .inprogress blob (best-effort)');
+      }
+    }));
+  } catch (err) {
+    log.server.warn({ err }, 'oped-set orphan sweep failed (best-effort)');
+  }
+}
+
+// ── Public API ──
+
+/** List oped-sets for the current user — reads _index.json only, never individual docs.
+ *  .inprogress blobs are invisible. Triggers orphan sweep on first call per user. */
+export async function listOpedSets(): Promise<OpEdSetSummary[]> {
+  if (isAnonymousUser()) return [];
+  void sweepOrphanedOpedSetInProgress();
+  const cached = await readOpedSetIndex();
+  return cached ?? [];
+}
+
+/** Load a finalized oped-set doc by setId; returns null if not found.
+ *  Never surfaces .inprogress blobs. */
+export async function loadOpedSet(setId: string): Promise<unknown> {
+  assertSafeId(setId, 'oped-set id');
+  if (isAnonymousUser()) return null;
+  const backend = getUserContentBackend();
+  const raw = await backend.readFile(path.join(getOpedSetsDir(), `oped-set-${setId}.json`));
+  if (raw === null) return null;
+  try { return JSON.parse(raw); } catch { /* telemetry — silent by design */ return null; }
+}
+
+/** Write a partial snapshot during generation. Invisible to list/load paths. */
+export async function saveOpedSetInProgress(setId: string, partial: unknown): Promise<void> {
+  assertSafeId(setId, 'oped-set id');
+  if (isAnonymousUser()) return;
+  const backend = getUserContentBackend();
+  await backend.writeFile(
+    path.join(getOpedSetsDir(), `oped-set-${setId}.json.inprogress`),
+    JSON.stringify(partial, null, 2),
+  );
+}
+
+/** Load the in-progress snapshot; returns null if not found. */
+export async function loadOpedSetInProgress(setId: string): Promise<unknown> {
+  assertSafeId(setId, 'oped-set id');
+  if (isAnonymousUser()) return null;
+  const backend = getUserContentBackend();
+  const raw = await backend.readFile(
+    path.join(getOpedSetsDir(), `oped-set-${setId}.json.inprogress`),
+  );
+  if (raw === null) return null;
+  try { return JSON.parse(raw); } catch { /* telemetry — silent by design */ return null; }
+}
+
+/**
+ * Atomic finalize: write final doc → upsert index → delete .inprogress (best-effort).
+ *
+ * Accepts any mix of member statuses (partial-set contract, e/91#2 condition 1).
+ * Step (a) is atomic on blob — backend.writeFile either completes or fails; no
+ * partial write is possible. Steps (b) and (c) are best-effort.
+ */
+export async function finalizeOpedSet(set: OpEdSet): Promise<void> {
+  assertSafeId(set.set_id, 'oped-set id');
+  if (isAnonymousUser()) return;
+  const backend = getUserContentBackend();
+  const dir = getOpedSetsDir();
+  const now = new Date().toISOString();
+
+  // (a) Write final doc — single write, atomic on blob
+  await backend.writeFile(
+    path.join(dir, `oped-set-${set.set_id}.json`),
+    JSON.stringify(set, null, 2),
+  );
+
+  // (b) Upsert index
+  const summary: OpEdSetSummary = {
+    set_id: set.set_id,
+    topic: set.topic,
+    camps: [...new Set(set.opeds.map(m => m.pov))],
+    voice_count: set.opeds.length,
+    created_at: set.created_at,
+    updated_at: now,
+  };
+  await upsertOpedSetIndex(summary).catch((err) => {
+    log.server.warn({ err, setId: set.set_id }, 'Oped-set index upsert failed (best-effort)');
+  });
+
+  // (c) Delete .inprogress — best-effort, never throws
+  void backend.deleteFile(path.join(dir, `oped-set-${set.set_id}.json.inprogress`))
+    .catch((err) => { log.server.warn({ err, setId: set.set_id }, 'Oped-set .inprogress cleanup failed (best-effort)'); });
+}
+
+/** Delete a finalized oped-set + remove from index. Cleans up .inprogress if present. */
+export async function deleteOpedSet(setId: string): Promise<void> {
+  assertSafeId(setId, 'oped-set id');
+  if (isAnonymousUser()) return;
+  const backend = getUserContentBackend();
+  const dir = getOpedSetsDir();
+  await backend.deleteFile(path.join(dir, `oped-set-${setId}.json`));
+  void removeFromOpedSetIndex(setId).catch((err) => {
+    log.server.warn({ err, setId }, 'Oped-set index removal failed (best-effort)');
+  });
+  void backend.deleteFile(path.join(dir, `oped-set-${setId}.json.inprogress`))
+    .catch(() => { /* best-effort — .inprogress may not exist */ });
+}


### PR DESCRIPTION
## Summary

- New `opedStore.ts` parallel to `debateStore.ts`: `listOpedSets`, `loadOpedSet`, `saveOpedSetInProgress`, `loadOpedSetInProgress`, `finalizeOpedSet`, `deleteOpedSet`
- `.inprogress` blobs invisible to all list/load paths — only `finalizeOpedSet` promotes to visible state
- `sweepOrphanedOpedSetInProgress` runs once per user per server lifetime (guarded by module-level Set), triggered from `listOpedSets`
- `assertSafeId` at every `setId` entry point (M5-class path-traversal guard)
- Re-exported from `fileIO.ts` barrel alongside `debateStore`
- Design approved by Quality (Tech Lead) at t/2572#3; TL pre-ruling at t/2572#2

## Test plan

- [x] Round-trip: `finalizeOpedSet` → `loadOpedSet` deep-equal
- [x] Partial-set: failed/cancelled members persist and list correctly
- [x] No full-doc load: list succeeds even when individual set-doc reads throw
- [x] In-progress lifecycle: save → load → finalize → inprogress null
- [x] `assertSafeId` guards at 5 entry points (rejects `../evil`, empty, slash paths)
- [x] Delete round-trip: doc gone, index entry gone, no throw on absent inprogress
- [x] ESLint clean, tsc clean on server tsconfig

🤖 Generated with [Claude Code](https://claude.com/claude-code)
