### PR TITLE
feat(quotas): add 'opeds' resource — mirror of maxDebates (t/2578)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/quotas.test.ts
+++ b/taxonomy-editor/src/server/__tests__/quotas.test.ts
@@ -33,6 +33,8 @@ vi.mock('../runtimeConfig.js', () => ({
     cache: { defaultTtlMs: 5000 },
   }),
 }));
+// Note: runtimeConfig mock omits defaultMaxOpEds (t/2573 not yet landed);
+// quotas.ts uses the interim hardcoded default of 10 for maxOpEds.
 
 async function loadModule() {
   vi.resetModules();
@@ -126,6 +128,7 @@ describe('quotas config load — fd path (t/2023)', () => {
 
     expect(limits.maxChats).toBe(25);
     expect(limits.maxDebates).toBe(15);
+    expect(limits.maxOpEds).toBe(10);
     // fd was never opened → finally must not attempt to close it.
     expect(fsMock.closeSync).not.toHaveBeenCalled();
   });
@@ -135,6 +138,7 @@ describe('quotas config load — fd path (t/2023)', () => {
     const limits = getQuotaLimits();
     expect(limits.maxChats).toBe(25);
     expect(limits.maxDebates).toBe(15);
+    expect(limits.maxOpEds).toBe(10);
   });
 });
 
@@ -166,5 +170,17 @@ describe('checkQuota', () => {
     const { checkQuota } = await loadModule();
     const result = checkQuota('debates', 5, 'testuser');
     expect(result).toMatchObject({ allowed: true, current: 5, limit: 15 });
+  });
+
+  it('allows opeds under the limit', async () => {
+    const { checkQuota } = await loadModule();
+    const result = checkQuota('opeds', 5, 'testuser');
+    expect(result).toMatchObject({ allowed: true, current: 5, limit: 10, resource: 'opeds' });
+  });
+
+  it('blocks when at the opeds limit', async () => {
+    const { checkQuota } = await loadModule();
+    const result = checkQuota('opeds', 10, 'testuser');
+    expect(result).toMatchObject({ allowed: false, current: 10, limit: 10 });
   });
 });

--- a/taxonomy-editor/src/server/security/quotas.ts
+++ b/taxonomy-editor/src/server/security/quotas.ts
@@ -13,12 +13,14 @@ import { isAdmin } from '../community/community.js';
 export interface QuotaLimits {
   maxChats: number;
   maxDebates: number;
+  maxOpEds: number;
 }
 
 interface ElevatedEntry {
   userId: string;
   maxChats?: number;
   maxDebates?: number;
+  maxOpEds?: number;
 }
 
 interface QuotaConfig {
@@ -31,7 +33,9 @@ interface QuotaConfig {
 // `defaults` override layered on top.
 function runtimeQuotaDefaults(): QuotaLimits {
   const q = getRuntimeConfig().quotas;
-  return { maxChats: q.defaultMaxChats, maxDebates: q.defaultMaxDebates };
+  // t/2578: defaultMaxOpEds knob lands in t/2573 (runtimeConfig.ts); use interim
+  // hardcoded default until that PR merges, then replace 10 with q.defaultMaxOpEds.
+  return { maxChats: q.defaultMaxChats, maxDebates: q.defaultMaxDebates, maxOpEds: 10 };
 }
 
 // ── Config loading with mtime cache (follows proxyTiers.ts pattern) ──
@@ -85,25 +89,26 @@ function getConfig(): QuotaConfig {
 
 export function getQuotaLimits(userId?: string): QuotaLimits {
   const uid = userId ?? getStorageUserId();
-  if (isAdmin(uid)) return { maxChats: Infinity, maxDebates: Infinity };
+  if (isAdmin(uid)) return { maxChats: Infinity, maxDebates: Infinity, maxOpEds: Infinity };
   const config = getConfig();
   const entry = config.elevated.find(e => e.userId === uid);
   return {
     maxChats: entry?.maxChats ?? config.defaults.maxChats,
     maxDebates: entry?.maxDebates ?? config.defaults.maxDebates,
+    maxOpEds: entry?.maxOpEds ?? config.defaults.maxOpEds,
   };
 }
 
 export interface QuotaCheckResult {
   allowed: boolean;
-  resource: 'chats' | 'debates';
+  resource: 'chats' | 'debates' | 'opeds';
   current: number;
   limit: number;
 }
 
-export function checkQuota(resource: 'chats' | 'debates', currentCount: number, userId?: string): QuotaCheckResult {
+export function checkQuota(resource: 'chats' | 'debates' | 'opeds', currentCount: number, userId?: string): QuotaCheckResult {
   const limits = getQuotaLimits(userId);
-  const limit = resource === 'chats' ? limits.maxChats : limits.maxDebates;
+  const limit = resource === 'chats' ? limits.maxChats : resource === 'debates' ? limits.maxDebates : limits.maxOpEds;
   return {
     allowed: currentCount < limit,
     resource,


### PR DESCRIPTION
## Summary

- Adds `maxOpEds` to `QuotaLimits`, `ElevatedEntry`, `getQuotaLimits`, `checkQuota`, and `QuotaCheckResult` — exact structural mirror of the `maxDebates` branch
- Admin users get `Infinity`; elevated overrides respected; default falls through from config
- Interim hardcoded default: `10` (conservative; swaps to `runtimeConfig.quotas.defaultMaxOpEds` in a 1-line follow-up once t/2573 lands)
- Unblocks t/2579 (Storage)

## Test plan

- [x] 13 tests pass in `quotas.test.ts` (all existing + 2 new opeds cases)
- [x] `maxOpEds: 10` in fallback-defaults and ALS-user tests
- [x] `checkQuota('opeds', ...)` allow (5/10) and block (10/10) cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)