### PR TITLE
fix(quotas): wire defaultMaxOpEds knob (t/2578 follow-up)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/quotas.test.ts
+++ b/taxonomy-editor/src/server/__tests__/quotas.test.ts
@@ -29,12 +29,10 @@ vi.mock('../security/userContext.js', () => ({ getStorageUserId: vi.fn().mockRet
 vi.mock('../community/community.js', () => ({ isAdmin: vi.fn().mockReturnValue(false) }));
 vi.mock('../runtimeConfig.js', () => ({
   getConfig: vi.fn().mockReturnValue({
-    quotas: { defaultMaxChats: 25, defaultMaxDebates: 15 },
+    quotas: { defaultMaxChats: 25, defaultMaxDebates: 15, defaultMaxOpEds: 15 },
     cache: { defaultTtlMs: 5000 },
   }),
 }));
-// Note: runtimeConfig mock omits defaultMaxOpEds (t/2573 not yet landed);
-// quotas.ts uses the interim hardcoded default of 10 for maxOpEds.
 
 async function loadModule() {
   vi.resetModules();
@@ -128,7 +126,7 @@ describe('quotas config load — fd path (t/2023)', () => {
 
     expect(limits.maxChats).toBe(25);
     expect(limits.maxDebates).toBe(15);
-    expect(limits.maxOpEds).toBe(10);
+    expect(limits.maxOpEds).toBe(15);
     // fd was never opened → finally must not attempt to close it.
     expect(fsMock.closeSync).not.toHaveBeenCalled();
   });
@@ -138,7 +136,7 @@ describe('quotas config load — fd path (t/2023)', () => {
     const limits = getQuotaLimits();
     expect(limits.maxChats).toBe(25);
     expect(limits.maxDebates).toBe(15);
-    expect(limits.maxOpEds).toBe(10);
+    expect(limits.maxOpEds).toBe(15);
   });
 });
 
@@ -175,12 +173,12 @@ describe('checkQuota', () => {
   it('allows opeds under the limit', async () => {
     const { checkQuota } = await loadModule();
     const result = checkQuota('opeds', 5, 'testuser');
-    expect(result).toMatchObject({ allowed: true, current: 5, limit: 10, resource: 'opeds' });
+    expect(result).toMatchObject({ allowed: true, current: 5, limit: 15, resource: 'opeds' });
   });
 
   it('blocks when at the opeds limit', async () => {
     const { checkQuota } = await loadModule();
-    const result = checkQuota('opeds', 10, 'testuser');
-    expect(result).toMatchObject({ allowed: false, current: 10, limit: 10 });
+    const result = checkQuota('opeds', 15, 'testuser');
+    expect(result).toMatchObject({ allowed: false, current: 15, limit: 15 });
   });
 });

--- a/taxonomy-editor/src/server/security/quotas.ts
+++ b/taxonomy-editor/src/server/security/quotas.ts
@@ -33,9 +33,7 @@ interface QuotaConfig {
 // `defaults` override layered on top.
 function runtimeQuotaDefaults(): QuotaLimits {
   const q = getRuntimeConfig().quotas;
-  // t/2578: defaultMaxOpEds knob lands in t/2573 (runtimeConfig.ts); use interim
-  // hardcoded default until that PR merges, then replace 10 with q.defaultMaxOpEds.
-  return { maxChats: q.defaultMaxChats, maxDebates: q.defaultMaxDebates, maxOpEds: 10 };
+  return { maxChats: q.defaultMaxChats, maxDebates: q.defaultMaxDebates, maxOpEds: q.defaultMaxOpEds };
 }
 
 // ── Config loading with mtime cache (follows proxyTiers.ts pattern) ──


### PR DESCRIPTION
## Summary

- Swaps interim hardcoded `10` → `q.defaultMaxOpEds` now that t/2573 landed
- Project default is `15` (matches `defaultMaxDebates`), set by ServerAPI in runtimeConfig
- Updates test mock and assertions to use `15`

Completes t/2578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)