### PR TITLE
feat(config): mirror generation.opedVoiceTimeoutMs in renderer store + admin UI (t/2577)

### DIFF
--- a/taxonomy-editor/src/renderer/components/settings/RuntimeConfigPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/RuntimeConfigPanel.test.tsx
@@ -45,6 +45,7 @@ function makeConfig(overrides?: Partial<RuntimeConfig>): RuntimeConfig {
       gitDefaultTimeoutMs: 30000, gitBufferLimitBytes: 52428800, apiKeyMaskLength: 8,
     },
     cache: { defaultTtlMs: 300000 },
+    generation: { opedVoiceTimeoutMs: 360000 },
     ...overrides,
   };
 }

--- a/taxonomy-editor/src/renderer/components/settings/RuntimeConfigPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/RuntimeConfigPanel.tsx
@@ -117,6 +117,12 @@ const SECTIONS: SectionDef[] = [
       { key: 'defaultTtlMs', label: 'Default TTL', type: 'number', unit: 'ms' },
     ],
   },
+  {
+    key: 'generation', label: 'Generation',
+    fields: [
+      { key: 'opedVoiceTimeoutMs', label: 'Op-Ed Voice Timeout', type: 'number', unit: 'ms' },
+    ],
+  },
 ];
 
 const TIER_KEYS = ['platform', 'byok', 'anonymous', 'free'] as const;

--- a/taxonomy-editor/src/renderer/hooks/useRuntimeConfigStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useRuntimeConfigStore.ts
@@ -84,6 +84,9 @@ export interface RuntimeConfig {
   cache: {
     defaultTtlMs: number;
   };
+  generation: {
+    opedVoiceTimeoutMs: number;
+  };
 }
 
 export interface ConfigState {


### PR DESCRIPTION
Follow-up to t/2575, which added the `generation.opedVoiceTimeoutMs` knob (default 360s, range 60s–1h) to the **server** RuntimeConfig. This mirrors it in the **renderer** so it's visible and editable via the admin-config UI.

## Changes
- `useRuntimeConfigStore.ts` — add `generation: { opedVoiceTimeoutMs: number }` to the client-side `RuntimeConfig` mirror
- `RuntimeConfigPanel.tsx` — add a **Generation** section to `SECTIONS` (number field, ms unit) so operators can adjust the op-ed voice timeout without a deploy
- `RuntimeConfigPanel.test.tsx` — add `generation` to the test mock to satisfy the type

## Notes
- Renderer-only. The server's `writeConfig` deep-merges partial PUT bodies over the live config, so the existing partial-mirror pattern holds.
- Gates: renderer `tsc` clean, eslint clean, RuntimeConfigPanel test 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)