### PR TITLE
ci(test-electron): cache onnxruntime postinstall via --side-effects-cache (t/2580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --side-effects-cache
 
       # NOTE: dependency audit + provenance moved OUT of this job into the
       # standalone `dependency-audit` job below (t/1800). They used to sit here


### PR DESCRIPTION
## Summary
- Adds `--side-effects-cache` to `pnpm install --frozen-lockfile` in the `test-electron` job
- onnxruntime-node's postinstall downloads a platform-specific GPU `.nupkg` from nuget.org on every run — not covered by the existing `cache: pnpm` step (which caches tarballs, not postinstall artifacts)
- `--side-effects-cache` stores postinstall outputs in the pnpm store, which IS already cached by `actions/setup-node`. Cache hits skip the nuget.org download entirely.

## Incident
PR #970 was blocked by 4 consecutive `test-electron` failures: `api.nuget.org → ETIMEDOUT` downloading the onnxruntime GPU nupkg (2026-08-13). Green runs existed 40 min prior — confirmed transient nuget.org flake on GitHub runners.

## Test plan
- [ ] CI green on this PR (confirms `--side-effects-cache` flag is accepted by pnpm v11)
- [ ] Second CI run on any subsequent PR shows "Restored cache" for the pnpm store (side-effects included)

Self-cert: /trivial-change — 1 line changed, DevOps-owned file, no API/interface/auth changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)