### PR TITLE
feat(opeds): Op-Ed Studio PR#1 — library + reader + bridge trio behind env-electron-opeds (t/2576)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -48,6 +48,7 @@ const SituationsTab = recordingLazy(() => import('./components/debate/Situations
 const ConflictsTab = recordingLazy(() => import('./components/conflict/ConflictsTab').then(m => ({ default: m.ConflictsTab })));
 const DebateTab = recordingLazy(() => import('./components/debate/DebateTab').then(m => ({ default: m.DebateTab })));
 const ChatTab = recordingLazy(() => import('./components/chat/ChatTab').then(m => ({ default: m.ChatTab })));
+const OpEdTab = recordingLazy(() => import('./components/opeds/OpEdTab').then(m => ({ default: m.OpEdTab })));
 const SummariesTab = recordingLazy(() => import('./components/analysis/SummariesTab').then(m => ({ default: m.SummariesTab })));
 const CruxesTab = recordingLazy(() => import('./components/debate/CruxesTab').then(m => ({ default: m.CruxesTab })));
 const ValidationTab = recordingLazy(() => import('./components/taxonomy/ValidationTab').then(m => ({ default: m.ValidationTab })));
@@ -248,6 +249,7 @@ function AppRouter() {
 function MainApp() {
   const { activeTab, loading, backgroundLoading, loadingProgress, loadAll, colorScheme, paneSpacing, zoomLevel, zoomIn, zoomOut, zoomReset, toolbarPanel } = useTaxonomyStore();
   const summariesFlag = useFlag('env-electron-summaries');
+  const opedsFlag = useFlag('env-electron-opeds');
   const breakpoint = useBreakpoint();
   const isTouch = useIsTouchDevice();
   const isMobile = breakpoint === 'phone' || breakpoint === 'phone-lg' || breakpoint === 'tablet';
@@ -667,7 +669,7 @@ function MainApp() {
         </button>
         <span className="mobile-header-title">Taxonomy Editor</span>
       </div>
-      {toolbarPanel === null && !['situations', 'conflicts', 'cruxes', 'debate', 'chat', 'summaries', 'validation', 'organizations'].includes(activeTab) && <TabBar />}
+      {toolbarPanel === null && !['situations', 'conflicts', 'cruxes', 'debate', 'chat', 'opeds', 'summaries', 'validation', 'organizations'].includes(activeTab) && <TabBar />}
       <div className="app-body">
         <Toolbar />
         <div className="tab-content">
@@ -679,6 +681,7 @@ function MainApp() {
             {activeTab === 'conflicts' && <ConflictsTab />}
             {activeTab === 'cruxes' && <CruxesTab />}
             {activeTab === 'debate' && <DebateTab />}
+            {activeTab === 'opeds' && opedsFlag && <OpEdTab />}
             {activeTab === 'summaries' && summariesFlag && <SummariesTab />}
             {activeTab === 'validation' && <ValidationTab />}
             {activeTab === 'organizations' && <OrganizationsTab />}

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -16,11 +16,36 @@ import {
   localComputeEmbedding,
   localComputeEmbeddings,
 } from '../utils/localEmbedding';
+import { ActionableError } from '@lib/debate/errors';
+import type { OpEdSet } from '../../../../lib/oped/types';
 
 // Fire-and-forget: start local embedding init on module load.
 // Bridge is always available in Electron, so WASM-init-failed is harmless noise.
 notifyBridgeFallback();
 void tryInitLocalEmbedding();
+
+// Op-Ed Studio (t/2576) — the op-ed persistence IPC surface is added to the preload
+// API by t/2575. Until that lands, the methods are absent from window.electronAPI, so
+// we feature-detect (optional-chained cast) and reject with an honest ActionableError.
+// No stub to swap out: when t/2575 installs the real methods, these calls light up.
+type OpEdIpc = {
+  listOpEdSets?: () => Promise<OpEdSet[]>;
+  loadOpEdSet?: (id: string) => Promise<OpEdSet>;
+  saveOpEdSet?: (set: OpEdSet) => Promise<void>;
+  deleteOpEdSet?: (id: string) => Promise<void>;
+};
+const opEdIpc = (): OpEdIpc => window.electronAPI as unknown as OpEdIpc;
+function rejectOpEdIpc(goal: string, method: string): Promise<never> {
+  return Promise.reject(new ActionableError({
+    goal: `Op-Ed Studio: ${goal}`,
+    problem: `The desktop op-ed backend (${method}) is not installed in this build.`,
+    location: 'electron-bridge · Op-Ed Studio',
+    nextSteps: [
+      'Update to a desktop build that includes the op-ed backend (t/2575).',
+      'Until then, browse the community op-ed library in the web app.',
+    ],
+  }));
+}
 
 // Same-window diagnostics callbacks for the in-app drawer (mobile/narrow).
 // When a popout BrowserWindow is open, IPC delivers state to it directly.
@@ -236,6 +261,12 @@ export const api: AppAPI = {
   loadDebateComments: (id) => window.electronAPI.loadDebateComments(id),
   saveDebateComments: (id, data) => window.electronAPI.saveDebateComments(id, data),
 
+  // Op-Ed Studio (t/2576) — feature-detected IPC (lands with t/2575); see opEdIpc above.
+  listOpEdSets: () => opEdIpc().listOpEdSets?.() ?? rejectOpEdIpc('list op-eds', 'listOpEdSets'),
+  loadOpEdSet: (id) => opEdIpc().loadOpEdSet?.(id) ?? rejectOpEdIpc('load an op-ed', 'loadOpEdSet'),
+  saveOpEdSet: (set) => opEdIpc().saveOpEdSet?.(set) ?? rejectOpEdIpc('save an op-ed', 'saveOpEdSet'),
+  deleteOpEdSet: (id) => opEdIpc().deleteOpEdSet?.(id) ?? rejectOpEdIpc('delete an op-ed', 'deleteOpEdSet'),
+
   // News Report
   generateNewsReport: (debateId) => window.electronAPI.generateNewsReport(debateId),
 
@@ -292,6 +323,7 @@ export const api: AppAPI = {
   },
   copyFromCommunity: async () => { throw new Error('Community Library is only available in the web app'); },
   loadCommunityDebateSession: async () => { throw new Error('Community Library is only available in the web app'); },
+  loadCommunityOpEd: async () => { throw new Error('Community Library is only available in the web app'); },
   loadCommunityChatSession: async () => { throw new Error('Community Library is only available in the web app'); },
   // Proxy through the main process so the cross-origin POST is not blocked by browser CORS.
   communitySubmit: (baseUrl, payload) => window.electronAPI.communitySubmit(baseUrl, payload),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -82,6 +82,8 @@ export type DebateTestedEntry = _DebateTestedEntry;
 import type { DebateDelta as _DebateDelta } from '@lib/debate/types';
 export type DebateDelta = _DebateDelta;
 
+import type { OpEdSet } from '../../../../lib/oped/types';
+
 import type { EdgesFile as _EdgesFile } from '@lib/debate/taxonomyTypes';
 export type EdgesFile = _EdgesFile;
 
@@ -269,6 +271,12 @@ export interface AppAPI {
   loadDebateComments: (debateId: string) => Promise<unknown>;
   saveDebateComments: (debateId: string, data: unknown) => Promise<void>;
 
+  // --- Op-Ed Studio (t/2576; personal library — submit/copy route via community store) ---
+  listOpEdSets: () => Promise<OpEdSet[]>;
+  loadOpEdSet: (id: string) => Promise<OpEdSet>;
+  saveOpEdSet: (set: OpEdSet) => Promise<void>;
+  deleteOpEdSet: (id: string) => Promise<void>;
+
   // --- News Report ---
   generateNewsReport: (debateId: string) => Promise<{ article: string }>;
 
@@ -324,10 +332,11 @@ export interface AppAPI {
   submitToCommunity: (type: 'chat' | 'debate', itemData: unknown, note?: string) => Promise<{ submissionId: string }>;
   copyFromCommunity: (type: 'chats' | 'debates', communityId: string) => Promise<{ newId: string }>;
   loadCommunityDebateSession: (id: string) => Promise<unknown>;
+  loadCommunityOpEd: (id: string) => Promise<OpEdSet>;
   loadCommunityChatSession: (id: string) => Promise<unknown>;
   // Submit to a remote community server. In Electron this is proxied through the main
   // process (net.fetch) so it is not blocked by browser CORS; baseUrl is the server origin.
-  communitySubmit: (baseUrl: string, payload: { type: 'chat' | 'debate'; data: unknown; note?: string }) => Promise<{ submissionId: string }>;
+  communitySubmit: (baseUrl: string, payload: { type: 'chat' | 'debate' | 'oped'; data: unknown; note?: string }) => Promise<{ submissionId: string }>;
 
   // --- Support cases ---
   createSupportCase: (payload: SupportCaseCreatePayload) => Promise<{ id: string }>;
@@ -483,5 +492,5 @@ export interface AppAPI {
   adminReviewStats: () => Promise<{ total: number; byDomain: Record<string, number> }>;
   adminReviewDetail: (groupId: string) => Promise<unknown>;
   adminReviewAction: (action: { domain: string; groupId: string; action: string; itemIds: string[]; reason?: string; edits?: Record<string, unknown> }) => Promise<void>;
-  adminRemoveCommunityItem: (type: 'chats' | 'debates', id: string, reason?: string) => Promise<void>;
+  adminRemoveCommunityItem: (type: 'chats' | 'debates' | 'opeds', id: string, reason?: string) => Promise<void>;
 }

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -11,6 +11,7 @@ import { makeCancellationError } from './cancellation';
 import { ActionableError } from '@lib/debate/errors';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
+import type { OpEdSet } from '../../../../lib/oped/types';
 import { encryptKeysForSharing, decryptKeysFromSharing } from '../utils/keyShareCrypto';
 import { resilientFetch, categorizeEndpoint, registerConnectionPoolProvider, type EndpointCategory } from './resilience';
 import { nextStepsForStatus } from './httpErrorSteps';
@@ -1014,6 +1015,14 @@ const rawApi: AppAPI = {
   deleteDebateSession: (id) => del(`/api/debates/${encodeURIComponent(id)}`).then(() => {}),
   loadDebateComments: (id) => get(`/api/debates/${encodeURIComponent(id)}/comments`),
   saveDebateComments: (id, data) => put(`/api/debates/${encodeURIComponent(id)}/comments`, data).then(() => {}),
+
+  // Op-Ed Studio (t/2576) — real routes against t/2573's server API. Those routes
+  // are not merged yet, so these calls surface an honest normalized 404 until they
+  // land (no stub module to swap out — the wiring lights up when t/2573 ships).
+  listOpEdSets: () => get<OpEdSet[]>('/api/opeds'),
+  loadOpEdSet: (id) => get<OpEdSet>(`/api/opeds/${encodeURIComponent(id)}`),
+  saveOpEdSet: (set) => put('/api/opeds', set).then(() => {}),
+  deleteOpEdSet: (id) => del(`/api/opeds/${encodeURIComponent(id)}`).then(() => {}),
   exportDebateToFile: async (session, format = 'json', exportOptions) => {
     const { debateToText, debateToMarkdown, debateToHtml, debateToPackage, debateExportFilename } = await import('@lib/debate/debateExport');
     const debate = session as Parameters<typeof debateToText>[0] & { diagnostics?: unknown };
@@ -1161,6 +1170,7 @@ const rawApi: AppAPI = {
   submitToCommunity: (type, itemData, note) => post('/api/community/submit', { type, data: itemData, note }),
   copyFromCommunity: (type, communityId) => post('/api/community/copy', { type, communityId }),
   loadCommunityDebateSession: (id) => get(`/api/community/debates/${encodeURIComponent(id)}`),
+  loadCommunityOpEd: (id) => get<OpEdSet>(`/api/community/opeds/${encodeURIComponent(id)}`),
   loadCommunityChatSession: (id) => get(`/api/community/chats/${encodeURIComponent(id)}`),
   // Web mode is same-origin; baseUrl is ignored and the relative path is used.
   communitySubmit: (_baseUrl, payload) => post('/api/community/submit', payload),

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
@@ -1,0 +1,283 @@
+/* OpEdReader.css — essay reader (t/2576 PR#1, §6). Tokens only — no hard-coded colors. */
+
+.oped-reader {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.oped-reader-empty {
+  padding: 2rem;
+  color: var(--text-muted);
+}
+
+/* Camp-tab strip (multi-voice sets only) */
+.oped-tabstrip {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border-color);
+  padding: 0 0.75rem;
+}
+
+.oped-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  padding: 0.5rem 0.75rem;
+  margin-bottom: -1px;
+}
+
+.oped-tab:hover { color: var(--text-primary); }
+
+.oped-tab:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.oped-tab-active { font-weight: 700; }
+
+/* Article */
+.oped-article {
+  padding: 1.25rem 1.5rem 2.5rem;
+}
+
+/* Camp-accent strip — colored left border + label text */
+.oped-article-strip {
+  border-left: 4px solid var(--border-color);
+  padding: 0.35rem 0.75rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: var(--bg-secondary, transparent);
+}
+
+.oped-article-notice {
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  background: var(--bg-secondary, transparent);
+}
+
+.oped-article-headline {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.5rem;
+  max-width: 34ch;
+}
+
+.oped-article-subtitle {
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--text-muted);
+  margin: 0 0 1.5rem;
+  max-width: 60ch;
+}
+
+/* Body — comfortable reading measure (~68ch) */
+.oped-reader-body {
+  max-width: 68ch;
+  font-size: 1rem;
+  line-height: 1.65;
+  color: var(--text-primary);
+}
+
+.oped-reader-body p { margin: 0 0 1rem; }
+
+.oped-reader-body h1,
+.oped-reader-body h2,
+.oped-reader-body h3 {
+  line-height: 1.3;
+  margin: 1.5rem 0 0.6rem;
+  color: var(--text-primary);
+}
+
+.oped-reader-body a { color: var(--focus-ring); }
+
+.oped-reader-body blockquote {
+  border-left: 3px solid var(--border-color);
+  margin: 1rem 0;
+  padding-left: 1rem;
+  color: var(--text-secondary);
+}
+
+.oped-reader-body ul,
+.oped-reader-body ol { margin: 0 0 1rem 1.25rem; }
+
+/* Pitch (collapsible) */
+.oped-pitch {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+  padding-top: 1rem;
+}
+
+.oped-pitch-summary,
+.oped-grounding-summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  user-select: none;
+}
+
+.oped-pitch-summary:hover,
+.oped-grounding-summary:hover { color: var(--text-primary); }
+
+.oped-pitch-body { margin-top: 0.75rem; }
+
+/* Voice-only notice (empty grounding) */
+.oped-voice-only {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+/* Grounding table */
+.oped-grounding {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+  padding-top: 1rem;
+}
+
+.oped-grounding-table-wrap {
+  overflow-x: auto;
+  margin-top: 0.75rem;
+}
+
+.oped-grounding-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+}
+
+.oped-grounding-table th {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+  white-space: nowrap;
+}
+
+.oped-grounding-table td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+  vertical-align: top;
+}
+
+.oped-grounding-row-active {
+  background: var(--bg-hover);
+}
+
+.oped-grounding-id-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-family: var(--font-mono, monospace);
+  color: var(--focus-ring);
+  text-align: left;
+}
+
+.oped-grounding-id-btn:hover { text-decoration: underline; }
+
+.oped-grounding-id-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Inline element detail card */
+.oped-grounding-card {
+  margin-top: 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 0.75rem;
+  background: var(--bg-secondary, transparent);
+}
+
+.oped-grounding-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.oped-grounding-card-id {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.oped-grounding-card-head-actions {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.oped-grounding-card-open {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.2rem 0.55rem;
+}
+
+.oped-grounding-card-open:hover { background: var(--bg-hover); }
+
+.oped-grounding-card-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0 0.3rem;
+}
+
+.oped-grounding-card-close:hover { color: var(--text-primary); }
+
+.oped-grounding-card-reflected {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.6rem;
+}
+
+.oped-grounding-card-reflected-label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.oped-grounding-card-empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding: 0.5rem 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .oped-tab { transition: none; }
+}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { OpEdReader } from './OpEdReader';
+import type { OpEdSet, OpEdMember } from '../../../../../lib/oped/types';
+
+function member(overrides: Partial<OpEdMember> = {}): OpEdMember {
+  return {
+    pov: 'safetyist',
+    status: 'complete',
+    headline: 'Mandatory Audits Are the Floor',
+    subtitle: 'Why the oversight bill must go further',
+    body: 'The lede opens on the news hook.\n\nA second paragraph.',
+    wordCount: 812,
+    grounding: [],
+    ...overrides,
+  };
+}
+
+function makeSet(members: OpEdMember[], overrides: Partial<OpEdSet> = {}): OpEdSet {
+  return {
+    schema_version: 1,
+    set_id: 'set-1',
+    topic: 'Audits',
+    params: { wordCount: 800, model: 'gemini-3.6-flash', outlet: 'The Washington Post' },
+    created_at: '2026-08-08T12:00:00Z',
+    opeds: members,
+    ...overrides,
+  };
+}
+
+describe('OpEdReader — single voice', () => {
+  it('renders no tab strip and the headline as the sole h1', () => {
+    render(<OpEdReader set={makeSet([member()])} />);
+    expect(screen.queryByRole('tablist')).toBeNull();
+    const h1s = screen.getAllByRole('heading', { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe('Mandatory Audits Are the Floor');
+  });
+
+  it('renders the subtitle and camp label in the accent strip', () => {
+    render(<OpEdReader set={makeSet([member()])} />);
+    expect(screen.getByText('Why the oversight bill must go further')).toBeTruthy();
+    expect(screen.getByText(/SAFETYIST/)).toBeTruthy();
+  });
+
+  it('shows the voice-only notice when grounding is empty', () => {
+    render(<OpEdReader set={makeSet([member({ grounding: [] })])} />);
+    expect(screen.getByText(/Written from voice alone/i)).toBeTruthy();
+  });
+
+  it('renders a grounding table (not the voice-only notice) when grounding is present', () => {
+    render(<OpEdReader set={makeSet([member({
+      grounding: [{ node_id: 'saf-belief-014', label: 'A belief', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim' }],
+    })])} />);
+    expect(screen.queryByText(/Written from voice alone/i)).toBeNull();
+    expect(screen.getByRole('button', { name: 'saf-belief-014' })).toBeTruthy();
+    expect(screen.getByText('Grounds the claim')).toBeTruthy();
+  });
+});
+
+describe('OpEdReader — failed / cancelled member', () => {
+  it('renders an honest notice instead of a body for a failed voice', () => {
+    render(<OpEdReader set={makeSet([member({ status: 'failed' })])} />);
+    expect(screen.getByText(/This voice failed to generate/i)).toBeTruthy();
+    expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+  });
+
+  it('renders a cancelled notice for a cancelled voice', () => {
+    render(<OpEdReader set={makeSet([member({ status: 'cancelled' })])} />);
+    expect(screen.getByText(/was cancelled/i)).toBeTruthy();
+  });
+});
+
+describe('OpEdReader — multi-voice set', () => {
+  const set = makeSet([
+    member({ pov: 'skeptic', headline: 'Skeptic headline' }),
+    member({ pov: 'safetyist', headline: 'Safetyist headline' }),
+  ]);
+
+  it('renders a tablist with one tab per voice', () => {
+    render(<OpEdReader set={set} />);
+    expect(screen.getByRole('tablist')).toBeTruthy();
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+  });
+
+  it('shows the first voice active by default', () => {
+    render(<OpEdReader set={set} />);
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true');
+    expect(tabs[1].getAttribute('aria-selected')).toBe('false');
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Skeptic headline');
+  });
+
+  it('clicking a tab swaps the article', () => {
+    render(<OpEdReader set={set} />);
+    fireEvent.click(screen.getAllByRole('tab')[1]);
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Safetyist headline');
+  });
+
+  it('ArrowRight moves the active tab (roving)', () => {
+    render(<OpEdReader set={set} />);
+    const tabs = screen.getAllByRole('tab');
+    fireEvent.keyDown(tabs[0], { key: 'ArrowRight' });
+    expect(screen.getAllByRole('tab')[1].getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Safetyist headline');
+  });
+
+  it('only one h1 is present at a time (sole-h1 invariant)', () => {
+    render(<OpEdReader set={set} />);
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -1,0 +1,271 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// OpEdReader — renders one op-ed SET as an article (t/2576 PR#1, §6). A multi-voice
+// set gets a camp-tab strip (roving-tabindex tablist); a single-voice set renders the
+// one article directly with no tab strip (TL ruling t/2576#3). Each article is a
+// landmark <article> whose headline is the region's sole <h1>. Grounding ids are real
+// <button aria-expanded> disclosures that expand an inline taxonomy-element card.
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { OpEdSet, OpEdMember, OpEdGroundingRef, PovKey } from '../../../../../lib/oped/types';
+import { POV_META } from '@lib/electron-shared/povMeta';
+import { POV_KEYS } from '@lib/debate/types';
+import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
+import { NodeDetail } from '../taxonomy/NodeDetail';
+import { SituationDetail } from '../debate/SituationDetail';
+import './OpEdReader.css';
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function groundingType(nodeId: string): string {
+  return nodeId.startsWith('sit-') ? 'Situation' : 'BDI';
+}
+
+// ──────────────────────────────────────────────
+// Inline grounding-element detail card (§6 clickable grounding)
+// ──────────────────────────────────────────────
+
+function GroundingDetailCard({ ref, onClose }: { ref: OpEdGroundingRef; onClose: () => void }) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const state = useTaxonomyStore.getState();
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (el) el.scrollIntoView({ block: 'nearest', behavior: prefersReducedMotion() ? 'auto' : 'smooth' });
+  }, []);
+
+  const openInTaxonomy = useCallback((tab: string, id: string) => {
+    // navigateToNode swaps the app to the taxonomy tab and selects the node.
+    (useTaxonomyStore.getState().navigateToNode as (t: string, id: string) => void)(tab, id);
+  }, []);
+
+  // Resolve the node exactly like SearchPreview: situations first, then each POV set.
+  let body: React.ReactNode = <div className="oped-grounding-card-empty">Element not found in the loaded taxonomy.</div>;
+  let openTab: string | null = null;
+
+  if (ref.node_id.startsWith('sit-')) {
+    const node = state.situations?.nodes.find(n => n.id === ref.node_id);
+    if (node) { body = <SituationDetail node={node} readOnly chipDepth={0} />; openTab = 'situations'; }
+  } else {
+    for (const p of POV_KEYS) {
+      const node = state[p]?.nodes.find(n => n.id === ref.node_id);
+      if (node) { body = <NodeDetail pov={p} node={node} readOnly chipDepth={0} />; openTab = p; break; }
+    }
+  }
+
+  return (
+    <div ref={cardRef} className="oped-grounding-card">
+      <div className="oped-grounding-card-head">
+        <span className="oped-grounding-card-id">{ref.node_id}</span>
+        <div className="oped-grounding-card-head-actions">
+          {openTab && (
+            <button
+              type="button"
+              className="oped-grounding-card-open"
+              onClick={() => openInTaxonomy(openTab!, ref.node_id)}
+              title="Open this element in the taxonomy tree"
+            >
+              Open in Taxonomy →
+            </button>
+          )}
+          <button type="button" className="oped-grounding-card-close" onClick={onClose} aria-label="Close element detail" title="Close">×</button>
+        </div>
+      </div>
+      {ref.how_reflected && (
+        <div className="oped-grounding-card-reflected">
+          <span className="oped-grounding-card-reflected-label">Reflected in this op-ed:</span> {ref.how_reflected}
+        </div>
+      )}
+      {body}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Grounding section (collapsible table + inline expand)
+// ──────────────────────────────────────────────
+
+function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!expandedId) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setExpandedId(null); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [expandedId]);
+
+  if (grounding.length === 0) {
+    return <p className="oped-voice-only">Written from voice alone (no taxonomy grounding).</p>;
+  }
+
+  const expandedRef = grounding.find(g => g.node_id === expandedId) ?? null;
+
+  return (
+    <details className="oped-grounding" open>
+      <summary className="oped-grounding-summary">Taxonomy grounding ({grounding.length} element{grounding.length !== 1 ? 's' : ''})</summary>
+      <div className="oped-grounding-table-wrap">
+        <table className="oped-grounding-table">
+          <caption className="sr-only">Taxonomy grounding for this op-ed</caption>
+          <thead>
+            <tr>
+              <th scope="col">Element</th>
+              <th scope="col">Type</th>
+              <th scope="col">Relevance</th>
+              <th scope="col">Reflected in the op-ed</th>
+            </tr>
+          </thead>
+          <tbody>
+            {grounding.map(g => {
+              const isOpen = g.node_id === expandedId;
+              return (
+                <tr key={g.node_id} className={isOpen ? 'oped-grounding-row-active' : ''}>
+                  <td>
+                    <button
+                      type="button"
+                      className="oped-grounding-id-btn"
+                      aria-expanded={isOpen}
+                      title={g.label}
+                      onClick={() => setExpandedId(isOpen ? null : g.node_id)}
+                    >
+                      {g.node_id}
+                    </button>
+                  </td>
+                  <td>{groundingType(g.node_id)}</td>
+                  <td>{g.relevance || '—'}</td>
+                  <td>{g.how_reflected || '(not reported)'}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      {expandedRef && <GroundingDetailCard ref={expandedRef} onClose={() => setExpandedId(null)} />}
+    </details>
+  );
+}
+
+// ──────────────────────────────────────────────
+// One article (a single voice)
+// ──────────────────────────────────────────────
+
+function OpEdArticle({ member, outlet }: { member: OpEdMember; outlet?: string }) {
+  const meta = POV_META[member.pov];
+  const metaLine = [meta.label.toUpperCase(), outlet || null, `${member.wordCount} words`]
+    .filter(Boolean).join(' · ');
+
+  return (
+    <article className="oped-article">
+      {/* Camp-accent strip — label text carries the identity, never color alone */}
+      <div
+        className="oped-article-strip"
+        // eslint-disable-next-line local/no-inline-style -- dynamic: camp accent color from POV_META cssVar (theme-aware)
+        style={{ borderLeftColor: `var(${meta.cssVar})` }}
+      >
+        {metaLine}
+      </div>
+
+      {member.status !== 'complete' ? (
+        <div className="oped-article-notice" role="status">
+          This voice {member.status === 'failed' ? 'failed to generate' : 'was cancelled'} — no essay is available for it.
+        </div>
+      ) : (
+        <>
+          <h1 className="oped-article-headline">{member.headline}</h1>
+          {member.subtitle && <p className="oped-article-subtitle">{member.subtitle}</p>}
+
+          <div className="oped-reader-body">
+            <Markdown remarkPlugins={[remarkGfm]}>{member.body}</Markdown>
+          </div>
+
+          {member.pitch && (
+            <details className="oped-pitch">
+              <summary className="oped-pitch-summary">Pitch cover email</summary>
+              <div className="oped-reader-body oped-pitch-body">
+                <Markdown remarkPlugins={[remarkGfm]}>{member.pitch}</Markdown>
+              </div>
+            </details>
+          )}
+
+          <GroundingSection grounding={member.grounding} />
+        </>
+      )}
+    </article>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Reader (tab strip for multi-voice sets)
+// ──────────────────────────────────────────────
+
+export function OpEdReader({ set }: { set: OpEdSet }) {
+  const members = set.opeds;
+  const [activeIdx, setActiveIdx] = useState(0);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const active = members[Math.min(activeIdx, members.length - 1)];
+
+  const onTabKeyDown = useCallback((e: React.KeyboardEvent, idx: number) => {
+    let next = idx;
+    if (e.key === 'ArrowRight') next = (idx + 1) % members.length;
+    else if (e.key === 'ArrowLeft') next = (idx - 1 + members.length) % members.length;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = members.length - 1;
+    else return;
+    e.preventDefault();
+    setActiveIdx(next);
+    tabRefs.current[next]?.focus();
+  }, [members.length]);
+
+  if (members.length === 0) {
+    return <div className="oped-reader oped-reader-empty">This op-ed set has no voices.</div>;
+  }
+
+  // Single-voice set: no tab strip, render the article directly (TL ruling t/2576#3).
+  if (members.length === 1) {
+    return (
+      <div className="oped-reader">
+        <OpEdArticle member={members[0]} outlet={set.params.outlet} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="oped-reader">
+      <div className="oped-tabstrip" role="tablist" aria-label="Op-ed voices">
+        {members.map((m, i) => {
+          const meta = POV_META[m.pov];
+          const isActive = i === activeIdx;
+          return (
+            <button
+              key={`${m.pov}-${i}`}
+              ref={el => { tabRefs.current[i] = el; }}
+              role="tab"
+              id={`oped-tab-${i}`}
+              aria-selected={isActive}
+              aria-controls={`oped-panel-${i}`}
+              tabIndex={isActive ? 0 : -1}
+              className={`oped-tab${isActive ? ' oped-tab-active' : ''}`}
+              // eslint-disable-next-line local/no-inline-style -- dynamic: active underline uses the camp's theme color
+              style={isActive ? { borderBottomColor: `var(${meta.cssVar})`, color: `var(${meta.cssVar})` } : undefined}
+              onClick={() => setActiveIdx(i)}
+              onKeyDown={e => onTabKeyDown(e, i)}
+            >
+              {meta.label}
+            </button>
+          );
+        })}
+      </div>
+      <div role="tabpanel" id={`oped-panel-${activeIdx}`} aria-labelledby={`oped-tab-${activeIdx}`}>
+        <OpEdArticle member={active} outlet={set.params.outlet} />
+      </div>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.css
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.css
@@ -1,0 +1,117 @@
+/* OpEdTab.css — Op-Ed Studio shell (t/2576 PR#1). Tokens only — no hard-coded colors. */
+
+/* Full-width list panel in table mode (mirrors .debate-tab-table-mode). */
+.oped-tab-table-mode .list-panel {
+  width: 100% !important;
+  max-width: 100%;
+}
+
+.oped-tab-table-mode .list-panel.oped-list-panel {
+  flex: 1;
+}
+
+.two-column.tablet-mode.oped-tab-table-mode .list-panel.oped-list-panel {
+  width: auto !important;
+  min-width: 0 !important;
+  max-width: none !important;
+  flex: 1;
+}
+
+.oped-list-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* Search box */
+.oped-search-wrap {
+  padding: 0.5rem 0.75rem;
+}
+
+.oped-search-input {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  font: inherit;
+  font-size: 0.875rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary, transparent);
+  color: var(--text-primary);
+}
+
+.oped-search-input:focus {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 0;
+}
+
+/* Status flash */
+.oped-status {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.oped-status-inline {
+  padding: 0 0.75rem 0.4rem;
+}
+
+/* Reader shell */
+.oped-reader-shell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+  width: 100%;
+}
+
+.oped-reader-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  position: sticky;
+  top: 0;
+  background: var(--bg-primary, var(--bg-secondary));
+  z-index: 1;
+}
+
+.oped-reader-back {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  padding: 0.25rem 0.7rem;
+}
+
+.oped-reader-back:hover {
+  background: var(--bg-hover);
+}
+
+.oped-reader-back:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.oped-reader-loading,
+.oped-reader-error {
+  padding: 1.5rem;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+.oped-reader-error {
+  color: var(--danger, var(--warning));
+}
+
+/* Empty state (community-in-Electron notice) */
+.oped-session-empty {
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -1,0 +1,404 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// OpEdTab — Op-Ed Studio shell (t/2576 PR#1). Mirrors DebateTab's two-column →
+// table-mode information architecture: a My / Community split, a full-width table,
+// and per-row Open / Export / Share (My) or Open / Export / Copy (Community). An
+// op-ed is static text, so "Open" reads it inline (no popout) — selecting a set
+// swaps the workspace to OpEdReader with a back control.
+//
+// Create is PR#2 — the "+ New Op-Ed" button is present but DISABLED here (t/2570#3).
+
+import { useEffect, useState, useCallback } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { api, isElectronMode } from '@bridge';
+import { useBreakpoint } from '../../hooks/useBreakpoint';
+import { useAuthStatus } from '../../hooks/useAuthStatus';
+import { useOpEdStore } from '../../hooks/useOpEdStore';
+import { useCommunityStore } from '../../hooks/useCommunityStore';
+import type { OpEdSet, OpEdCommunityEntry } from '../../../../../lib/oped/types';
+import { OpEdTable } from './OpEdTable';
+import { OpEdReader } from './OpEdReader';
+import './OpEdTab.css';
+
+function recordError(component: string, message: string, err: unknown): void {
+  getGlobalRecorder()?.record({
+    type: 'system.error',
+    component,
+    level: 'error',
+    message,
+    error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+  });
+}
+
+// ── Client-side export (PR#1 has no export bridge — assemble the set as text) ──
+
+function buildOpEdMarkdown(set: OpEdSet): string {
+  const lines: string[] = [];
+  set.opeds.forEach((m, i) => {
+    if (i > 0) lines.push('\n---\n');
+    lines.push(`# ${m.headline}`);
+    if (m.subtitle) lines.push(`\n*${m.subtitle}*`);
+    lines.push('');
+    if (m.status !== 'complete') {
+      lines.push(`_(This voice ${m.status === 'failed' ? 'failed to generate' : 'was cancelled'}.)_`);
+      return;
+    }
+    lines.push(m.body);
+    if (m.pitch) { lines.push('\n---\n\n## Pitch cover email\n'); lines.push(m.pitch); }
+    if (m.grounding.length > 0) {
+      lines.push('\n---\n\n## Taxonomy grounding\n');
+      lines.push('| Element | Type | Relevance | Reflected in the op-ed |');
+      lines.push('|---|---|---|---|');
+      for (const g of m.grounding) {
+        const type = g.node_id.startsWith('sit-') ? 'Situation' : 'BDI';
+        lines.push(`| ${g.node_id} | ${type} | ${g.relevance || '—'} | ${g.how_reflected || '(not reported)'} |`);
+      }
+    }
+  });
+  return lines.join('\n');
+}
+
+function buildOpEdText(set: OpEdSet): string {
+  // Strip the lightest Markdown syntax for a plain-text rendering.
+  return buildOpEdMarkdown(set).replace(/^#+\s*/gm, '').replace(/[*_`]/g, '');
+}
+
+function downloadFile(filename: string, content: string, mime: string): void {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+function slugify(s: string): string {
+  return (s || 'op-ed').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60) || 'op-ed';
+}
+
+function exportOpEdSet(set: OpEdSet, format: string): void {
+  if (format === 'text') downloadFile(`${slugify(set.topic)}.txt`, buildOpEdText(set), 'text/plain');
+  else downloadFile(`${slugify(set.topic)}.md`, buildOpEdMarkdown(set), 'text/markdown');
+}
+
+function filterSets(sets: OpEdSet[], q: string): OpEdSet[] {
+  if (!q) return sets;
+  return sets.filter(s => s.topic.toLowerCase().includes(q) || s.opeds.some(m => m.headline.toLowerCase().includes(q)));
+}
+
+function filterCommunity(entries: OpEdCommunityEntry[], q: string): OpEdCommunityEntry[] {
+  if (!q) return entries;
+  return entries.filter(c => c.topic.toLowerCase().includes(q));
+}
+
+// ── Header actions (Edit / bulk-delete / disabled + New) ──────────────────────
+
+function OpEdHeaderActions({
+  listView, editMode, hasSets, selectedCount, isElectron,
+  onBulkDelete, onClearSelected, onExitEdit, onEnterEdit,
+}: {
+  listView: 'my' | 'community';
+  editMode: boolean;
+  hasSets: boolean;
+  selectedCount: number;
+  isElectron: boolean;
+  onBulkDelete: () => void;
+  onClearSelected: () => void;
+  onExitEdit: () => void;
+  onEnterEdit: () => void;
+}) {
+  if (listView !== 'my') return null;
+  if (editMode) {
+    return (
+      <div className="list-panel-header-actions">
+        {selectedCount > 0 && (
+          <button className="btn btn-sm btn-danger" onClick={onBulkDelete}>Delete {selectedCount}</button>
+        )}
+        <button className="btn btn-sm btn-ghost" onClick={onClearSelected}>None</button>
+        <button className="btn btn-sm btn-ghost" onClick={onExitEdit}>Done</button>
+      </div>
+    );
+  }
+  return (
+    <div className="list-panel-header-actions">
+      {hasSets && (
+        <button className="btn btn-sm btn-ghost" onClick={onEnterEdit} title="Rename or delete op-eds">Edit</button>
+      )}
+      {/* Create is PR#2 — the button is present but disabled (t/2570#3). */}
+      <button
+        className="btn btn-sm"
+        disabled
+        title={isElectron ? 'Create coming soon' : 'Available in the desktop app'}
+        aria-label="New op-ed (coming soon)"
+      >
+        + New Op-Ed
+      </button>
+    </div>
+  );
+}
+
+// ── Reader view (back bar + article/loading/error) ────────────────────────────
+
+function OpEdReaderView({
+  readerSet, readerLoading, readerError, status, onBack,
+}: {
+  readerSet: OpEdSet | null;
+  readerLoading: boolean;
+  readerError: string | null;
+  status: string | null;
+  onBack: () => void;
+}) {
+  return (
+    <div className="two-column oped-tab-table-mode">
+      <div className="oped-reader-shell">
+        <div className="oped-reader-bar">
+          <button type="button" className="oped-reader-back" onClick={onBack}>‹ Op-Eds</button>
+          {status && <span className="oped-status">{status}</span>}
+        </div>
+        {readerLoading && <p className="oped-reader-loading">Loading op-ed…</p>}
+        {readerError && <p className="oped-reader-error">{readerError}</p>}
+        {readerSet && !readerLoading && <OpEdReader set={readerSet} />}
+      </div>
+    </div>
+  );
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function OpEdTab() {
+  const {
+    sets, loading, editMode, selectedIds, selectedSetId,
+    loadSets, selectSet, renameSet, setEditMode, toggleSelected, clearSelected, deleteSelected,
+  } = useOpEdStore(useShallow(s => ({
+    sets: s.sets, loading: s.loading, editMode: s.editMode, selectedIds: s.selectedIds, selectedSetId: s.selectedSetId,
+    loadSets: s.loadSets, selectSet: s.selectSet, renameSet: s.renameSet, setEditMode: s.setEditMode,
+    toggleSelected: s.toggleSelected, clearSelected: s.clearSelected, deleteSelected: s.deleteSelected,
+  })));
+  const { opeds: communityOpeds, communityLoading, fetchOpeds, submitItem, copyItem } = useCommunityStore(useShallow(s => ({
+    opeds: s.opeds, communityLoading: s.loading, fetchOpeds: s.fetchOpeds, submitItem: s.submitItem, copyItem: s.copyItem,
+  })));
+
+  const auth = useAuthStatus();
+  const breakpoint = useBreakpoint();
+  const isPhone = breakpoint === 'phone' || breakpoint === 'phone-lg';
+  const isElectron = isElectronMode();
+
+  const [listView, setListView] = useState<'my' | 'community'>('my');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [copyingId, setCopyingId] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  // The set currently open in the reader — may come from the personal store (My)
+  // or a community load (Community). null = table view.
+  const [readerSet, setReaderSet] = useState<OpEdSet | null>(null);
+  const [readerLoading, setReaderLoading] = useState(false);
+  const [readerError, setReaderError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void loadSets();
+    void fetchOpeds();
+  }, [loadSets, fetchOpeds]);
+
+  const flash = useCallback((msg: string) => {
+    setStatus(msg);
+    setTimeout(() => setStatus(null), 4000);
+  }, []);
+
+  const exitEditMode = useCallback(() => { setEditMode(false); setRenamingId(null); }, [setEditMode]);
+
+  // ── Reader open/close ──
+
+  const openMy = useCallback((id: string) => {
+    const found = sets.find(s => s.set_id === id) ?? null;
+    if (!found) return;
+    selectSet(id);
+    setReaderError(null);
+    setReaderSet(found);
+  }, [sets, selectSet]);
+
+  const openCommunity = useCallback((id: string) => {
+    selectSet(id);
+    setReaderError(null);
+    setReaderLoading(true);
+    api.loadCommunityOpEd(id).then(set => {
+      setReaderSet(set);
+    }).catch(err => {
+      recordError('oped-tab', 'Failed to load community op-ed', err);
+      setReaderError('Could not load this op-ed — it may have been removed.');
+    }).finally(() => setReaderLoading(false));
+  }, [selectSet]);
+
+  const closeReader = useCallback(() => {
+    selectSet(null);
+    setReaderSet(null);
+    setReaderError(null);
+  }, [selectSet]);
+
+  // ── Row actions ──
+
+  const handleRename = useCallback((id: string, topic: string) => {
+    renameSet(id, topic).catch(err => {
+      recordError('oped-tab', 'Failed to rename op-ed', err);
+      flash(`Rename failed: ${err}`);
+    });
+  }, [renameSet, flash]);
+
+  const handleShare = useCallback((set: OpEdSet) => {
+    submitItem('oped', set).then(() => flash('Shared to community.')).catch(err => {
+      recordError('oped-tab', 'Failed to share op-ed to community', err);
+      flash(`Share failed: ${err}`);
+    });
+  }, [submitItem, flash]);
+
+  const handleExportMy = useCallback((set: OpEdSet, format: string) => {
+    try {
+      exportOpEdSet(set, format);
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'oped-tab', level: 'error', message: 'Failed to export op-ed',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      flash(`Export failed: ${err}`);
+    }
+  }, [flash]);
+
+  const handleExportCommunity = useCallback((entry: OpEdCommunityEntry, format: string) => {
+    // The community index entry lacks the full body — load, then export.
+    api.loadCommunityOpEd(entry.id).then(set => exportOpEdSet(set, format)).catch(err => {
+      recordError('oped-tab', 'Failed to export community op-ed', err);
+      flash(`Export failed: ${err}`);
+    });
+  }, [flash]);
+
+  const handleCopy = useCallback((entry: OpEdCommunityEntry) => {
+    setCopyingId(entry.id);
+    copyItem('opeds', entry.id).then(() => { void loadSets(); flash('Copied to My op-eds.'); }).catch(err => {
+      recordError('oped-tab', 'Failed to copy community op-ed', err);
+      flash(`Copy failed: ${err}`);
+    }).finally(() => setCopyingId(null));
+  }, [copyItem, loadSets, flash]);
+
+  const handleBulkDelete = useCallback(() => {
+    deleteSelected().catch(err => {
+      recordError('oped-tab', 'Failed to delete selected op-eds', err);
+      flash(`Delete failed: ${err}`);
+    });
+  }, [deleteSelected, flash]);
+
+  // ── Filtering ──
+
+  const q = searchQuery.trim().toLowerCase();
+  const filteredSets = filterSets(sets, q);
+  const filteredCommunity = filterCommunity(communityOpeds, q);
+
+  const isTableMode = !isPhone;
+
+  // ── Reader view ──
+
+  if (selectedSetId && (readerSet || readerLoading || readerError)) {
+    return (
+      <OpEdReaderView
+        readerSet={readerSet}
+        readerLoading={readerLoading}
+        readerError={readerError}
+        status={status}
+        onBack={closeReader}
+      />
+    );
+  }
+
+  // ── Table view ──
+
+  return (
+    <div className={['two-column', isTableMode ? 'oped-tab-table-mode' : ''].filter(Boolean).join(' ')}>
+      <div className="list-panel oped-list-panel">
+        <div className="list-panel-header">
+          <h2>Op-Eds</h2>
+          <OpEdHeaderActions
+            listView={listView}
+            editMode={editMode}
+            hasSets={sets.length > 0}
+            selectedCount={selectedIds.size}
+            isElectron={isElectron}
+            onBulkDelete={handleBulkDelete}
+            onClearSelected={clearSelected}
+            onExitEdit={exitEditMode}
+            onEnterEdit={() => setEditMode(true)}
+          />
+        </div>
+
+        <div className="list-view-tabs">
+          <button
+            className={`list-view-tab${listView === 'my' ? ' active' : ''}`}
+            onClick={() => { setListView('my'); exitEditMode(); }}
+          >
+            My ({sets.length})
+          </button>
+          <button
+            className={`list-view-tab${listView === 'community' ? ' active' : ''}`}
+            onClick={() => { setListView('community'); exitEditMode(); }}
+          >
+            Community ({communityOpeds.length})
+          </button>
+        </div>
+
+        <div className="oped-search-wrap">
+          <input
+            type="text"
+            className="oped-search-input"
+            placeholder={listView === 'my' ? 'Search op-eds…' : 'Search community op-eds…'}
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+          />
+        </div>
+
+        {status && listView && <div className="oped-status oped-status-inline">{status}</div>}
+
+        {listView === 'my' ? (
+          <OpEdTable
+            variant="my"
+            rows={filteredSets}
+            loading={loading}
+            searchQuery={searchQuery}
+            editMode={editMode}
+            selectedIds={selectedIds}
+            onToggleSelect={toggleSelected}
+            renamingId={renamingId}
+            setRenamingId={setRenamingId}
+            renameValue={renameValue}
+            setRenameValue={setRenameValue}
+            onRename={handleRename}
+            onOpen={openMy}
+            onExport={handleExportMy}
+            onShare={handleShare}
+            onNew={() => { /* create is PR#2 */ }}
+            selectedSetId={selectedSetId}
+            totalCount={sets.length}
+          />
+        ) : (
+          <OpEdTable
+            variant="community"
+            rows={filteredCommunity}
+            loading={communityLoading}
+            searchQuery={searchQuery}
+            onOpen={openCommunity}
+            onExport={handleExportCommunity}
+            onCopy={handleCopy}
+            copyingId={copyingId}
+            auth={auth}
+            isElectron={isElectron}
+            selectedId={selectedSetId}
+            totalCount={communityOpeds.length}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.css
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.css
@@ -1,0 +1,332 @@
+/* OpEdTable.css — full-width op-ed library table (t/2576 PR#1). Tokens only. */
+
+.oped-table-wrap {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+  padding-bottom: 1rem;
+}
+
+.oped-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+/* Column sizing — Headline takes the flex; everything else sizes to content. */
+.oped-table colgroup .col-headline { width: auto; }
+.oped-table colgroup .col-camp     { width: 8rem; }
+.oped-table colgroup .col-outlet   { width: 8rem; }
+.oped-table colgroup .col-words    { width: 5rem; }
+.oped-table colgroup .col-date     { width: 7.5rem; }
+.oped-table colgroup .col-actions  { width: 13rem; }
+.oped-table colgroup .col-cb       { width: 2rem; }
+
+/* Header */
+.oped-table thead th {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-color);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.oped-table thead th.col-words {
+  text-align: right;
+}
+
+.oped-table-sort-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+}
+
+.oped-table-sort-btn:hover { color: var(--text-primary); }
+
+.oped-table-sort-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.oped-table-sort-indicator {
+  font-size: 0.65em;
+  opacity: 0.7;
+}
+
+/* Rows */
+.oped-table tbody tr {
+  border-bottom: 1px solid var(--border-color);
+  transition: background 0.1s;
+}
+
+.oped-table tbody tr:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
+}
+
+.oped-table tbody tr:hover { background: var(--bg-hover); }
+
+.oped-table tbody tr.selected,
+.oped-table tbody tr[aria-current="true"] {
+  background: var(--bg-hover);
+  box-shadow: inset 3px 0 0 var(--focus-ring);
+}
+
+.oped-table tbody tr.bulk-selected { background: var(--bg-hover); }
+
+/* Cells */
+.oped-table tbody td {
+  padding: 0.55rem 0.75rem;
+  vertical-align: top;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+
+.oped-table td.col-headline {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.oped-table-headline-text {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  line-height: 1.4;
+}
+
+.oped-table-headline-secondary {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.oped-table-rename-input {
+  width: 100%;
+  font: inherit;
+  font-size: 0.875rem;
+  padding: 0.15rem 0.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-primary);
+}
+
+.oped-table-rename-input:focus {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 0;
+}
+
+.oped-table td.col-camp { white-space: nowrap; }
+
+.oped-table td.col-outlet,
+.oped-table td.col-date {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+.oped-table td.col-words {
+  white-space: nowrap;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.oped-table td.col-actions { white-space: nowrap; }
+.oped-table td.col-cb { text-align: center; }
+
+/* Camp chips — glyph + short label, colored per camp (label text carries identity) */
+.oped-camp-chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.oped-camp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2em;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.oped-camp-chip-label { color: var(--text-secondary); }
+
+/* Action buttons */
+.oped-table-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  position: relative;
+}
+
+.oped-table-action-btn {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  transition: color 0.1s, border-color 0.1s, background 0.1s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+}
+
+.oped-table-action-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--border-color);
+  background: var(--bg-hover);
+}
+
+.oped-table-action-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.oped-table-action-btn.primary {
+  color: var(--text-primary);
+  border-color: var(--border-color);
+}
+
+.oped-table-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Export mini-menu */
+.oped-export-menu { position: relative; display: inline-flex; }
+
+.oped-export-menu-list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 2px;
+  display: flex;
+  flex-direction: column;
+  min-width: 8rem;
+  background: var(--bg-secondary, var(--bg-primary));
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 10;
+}
+
+.oped-export-menu-item {
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 0.4rem 0.7rem;
+  font: inherit;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.oped-export-menu-item:hover { background: var(--bg-hover); }
+
+/* Empty / loading */
+.oped-table-empty-cell {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  padding: 2.5rem 1rem;
+}
+
+.oped-table-empty-action {
+  margin-top: 0.75rem;
+}
+
+/* Responsive: tablet — collapse Outlet into the headline secondary line */
+@media (max-width: 960px) {
+  .oped-table .col-outlet,
+  .oped-table td.col-outlet,
+  .oped-table th.col-outlet {
+    display: none;
+  }
+}
+
+/* Phone — stacked card fallback */
+@media (max-width: 600px) {
+  .oped-table,
+  .oped-table thead,
+  .oped-table tbody,
+  .oped-table tr,
+  .oped-table th,
+  .oped-table td {
+    display: block;
+  }
+
+  .oped-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  .oped-table tbody tr {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    margin-bottom: 0.75rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .oped-table td.col-headline { order: -1; }
+
+  .oped-table tbody tr.selected {
+    box-shadow: 0 0 0 2px var(--focus-ring);
+  }
+
+  .oped-table tbody td {
+    padding: 0.2rem 0;
+    border: none;
+  }
+
+  .oped-table td.col-camp,
+  .oped-table td.col-words,
+  .oped-table td.col-date {
+    display: inline;
+    padding-right: 0.5rem;
+  }
+
+  .oped-table td.col-actions {
+    text-align: left;
+    padding-top: 0.4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .oped-table tbody tr,
+  .oped-table-action-btn {
+    transition: none;
+  }
+}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
@@ -1,0 +1,263 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { OpEdTable, OpEdMyRow, OpEdCommunityRow, opEdCamps, opEdWordCount, applySortMy, applySortCommunity } from './OpEdTable';
+import type { OpEdSet, OpEdMember, OpEdCommunityEntry, PovKey } from '../../../../../lib/oped/types';
+
+function member(overrides: Partial<OpEdMember> = {}): OpEdMember {
+  return {
+    pov: 'safetyist',
+    status: 'complete',
+    headline: 'A headline',
+    subtitle: 'A subtitle',
+    body: 'Body text.',
+    wordCount: 800,
+    grounding: [],
+    ...overrides,
+  };
+}
+
+function makeSet(overrides: Partial<OpEdSet> = {}): OpEdSet {
+  return {
+    schema_version: 1,
+    set_id: 'set-1',
+    topic: 'Mandatory pre-deployment audits',
+    params: { wordCount: 800, model: 'gemini-3.6-flash', outlet: 'The Washington Post' },
+    created_at: '2026-08-08T12:00:00Z',
+    opeds: [member()],
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<OpEdCommunityEntry> = {}): OpEdCommunityEntry {
+  return {
+    id: 'c-1',
+    topic: 'Open-weight models',
+    created_at: '2026-08-07T12:00:00Z',
+    updated_at: '2026-08-07T12:00:00Z',
+    camps: ['skeptic'],
+    voice_count: 1,
+    community_metadata: null,
+    ...overrides,
+  };
+}
+
+const noopMyProps = {
+  variant: 'my' as const,
+  loading: false,
+  searchQuery: '',
+  editMode: false,
+  selectedIds: new Set<string>(),
+  onToggleSelect: vi.fn(),
+  renamingId: null,
+  setRenamingId: vi.fn(),
+  renameValue: '',
+  setRenameValue: vi.fn(),
+  onRename: vi.fn(),
+  onOpen: vi.fn(),
+  onExport: vi.fn(),
+  onShare: vi.fn(),
+  onNew: vi.fn(),
+  selectedSetId: null,
+  totalCount: 0,
+};
+
+describe('opEdCamps / opEdWordCount helpers', () => {
+  it('returns distinct camps in member order', () => {
+    const set = makeSet({ opeds: [member({ pov: 'skeptic' }), member({ pov: 'safetyist' }), member({ pov: 'skeptic' })] });
+    expect(opEdCamps(set)).toEqual<PovKey[]>(['skeptic', 'safetyist']);
+  });
+
+  it('sums word counts across members', () => {
+    const set = makeSet({ opeds: [member({ wordCount: 800 }), member({ pov: 'skeptic', wordCount: 655 })] });
+    expect(opEdWordCount(set)).toBe(1455);
+  });
+});
+
+describe('applySort — My / Community', () => {
+  it('sorts My rows by date descending', () => {
+    const rows = [
+      makeSet({ set_id: 'a', created_at: '2026-08-01T00:00:00Z' }),
+      makeSet({ set_id: 'b', created_at: '2026-08-09T00:00:00Z' }),
+    ];
+    const sorted = applySortMy(rows, { col: 'date', dir: 'desc' });
+    expect(sorted[0].set_id).toBe('b');
+  });
+
+  it('sorts My rows by words ascending', () => {
+    const rows = [
+      makeSet({ set_id: 'big', opeds: [member({ wordCount: 900 })] }),
+      makeSet({ set_id: 'small', opeds: [member({ wordCount: 300 })] }),
+    ];
+    const sorted = applySortMy(rows, { col: 'words', dir: 'asc' });
+    expect(sorted[0].set_id).toBe('small');
+  });
+
+  it('returns rows unchanged when sort is none', () => {
+    const rows = [makeSet({ set_id: 'a' }), makeSet({ set_id: 'b' })];
+    expect(applySortMy(rows, { col: null, dir: 'none' })).toBe(rows);
+  });
+
+  it('sorts Community rows by date descending', () => {
+    const rows = [
+      makeEntry({ id: 'a', updated_at: '2026-08-01T00:00:00Z' }),
+      makeEntry({ id: 'b', updated_at: '2026-08-09T00:00:00Z' }),
+    ];
+    const sorted = applySortCommunity(rows, { col: 'date', dir: 'desc' });
+    expect(sorted[0].id).toBe('b');
+  });
+});
+
+describe('OpEdMyRow', () => {
+  function renderRow(set: OpEdSet, extra: Record<string, unknown> = {}) {
+    return render(
+      <table><tbody>
+        <OpEdMyRow
+          set={set}
+          isActive={false}
+          editMode={false}
+          isSelected={false}
+          onToggleSelect={vi.fn()}
+          renamingId={null}
+          setRenamingId={vi.fn()}
+          renameValue=""
+          setRenameValue={vi.fn()}
+          onRename={vi.fn()}
+          onOpen={vi.fn()}
+          onExport={vi.fn()}
+          onShare={vi.fn()}
+          {...extra}
+        />
+      </tbody></table>,
+    );
+  }
+
+  it('renders topic as the headline and the outlet + word count', () => {
+    renderRow(makeSet());
+    expect(screen.getByText('Mandatory pre-deployment audits')).toBeTruthy();
+    expect(screen.getByText('The Washington Post')).toBeTruthy();
+    expect(screen.getByText('800')).toBeTruthy();
+  });
+
+  it('shows "— " for a missing outlet', () => {
+    renderRow(makeSet({ params: { wordCount: 800, model: 'm' } }));
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+
+  it('shows a "▸ N voices" tag for multi-voice sets', () => {
+    renderRow(makeSet({ opeds: [member({ pov: 'skeptic' }), member({ pov: 'safetyist' })] }));
+    expect(screen.getByText('▸ 2 voices')).toBeTruthy();
+  });
+
+  it('Open button fires onOpen with the set id', () => {
+    const onOpen = vi.fn();
+    renderRow(makeSet(), { onOpen });
+    fireEvent.click(screen.getByRole('button', { name: /open/i }));
+    expect(onOpen).toHaveBeenCalledWith('set-1');
+  });
+
+  it('Share button fires onShare', () => {
+    const onShare = vi.fn();
+    renderRow(makeSet(), { onShare });
+    fireEvent.click(screen.getByRole('button', { name: /share/i }));
+    expect(onShare).toHaveBeenCalled();
+  });
+
+  it('renders a select checkbox in edit mode', () => {
+    renderRow(makeSet(), { editMode: true });
+    expect(screen.getByRole('checkbox', { name: /select/i })).toBeTruthy();
+  });
+});
+
+describe('OpEdCommunityRow', () => {
+  function renderRow(entry: OpEdCommunityEntry, extra: Record<string, unknown> = {}) {
+    return render(
+      <table><tbody>
+        <OpEdCommunityRow
+          entry={entry}
+          isSelected={false}
+          onOpen={vi.fn()}
+          onExport={vi.fn()}
+          onCopy={vi.fn()}
+          copyingId={null}
+          showCopy
+          {...extra}
+        />
+      </tbody></table>,
+    );
+  }
+
+  it('renders topic and camp chip', () => {
+    renderRow(makeEntry());
+    expect(screen.getByText('Open-weight models')).toBeTruthy();
+    expect(screen.getByText('Skp')).toBeTruthy();
+  });
+
+  it('shows Copy when showCopy is true and hides it when false', () => {
+    const { rerender } = renderRow(makeEntry());
+    expect(screen.queryByRole('button', { name: /copy/i })).toBeTruthy();
+    rerender(
+      <table><tbody>
+        <OpEdCommunityRow
+          entry={makeEntry()}
+          isSelected={false}
+          onOpen={vi.fn()}
+          onExport={vi.fn()}
+          onCopy={vi.fn()}
+          copyingId={null}
+          showCopy={false}
+        />
+      </tbody></table>,
+    );
+    expect(screen.queryByRole('button', { name: /copy/i })).toBeNull();
+  });
+
+  it('Enter on the row fires onOpen', () => {
+    const onOpen = vi.fn();
+    const { container } = renderRow(makeEntry({ id: 'c-42' }), { onOpen });
+    fireEvent.keyDown(container.querySelector('tr')!, { key: 'Enter' });
+    expect(onOpen).toHaveBeenCalledWith('c-42');
+  });
+});
+
+describe('OpEdTable — My variant', () => {
+  it('renders the empty state with a + New Op-Ed action', () => {
+    render(<OpEdTable {...noopMyProps} rows={[]} />);
+    expect(screen.getByText(/No op-eds yet/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /New Op-Ed/i })).toBeTruthy();
+  });
+
+  it('renders a semantic table with an sr-only caption and sortable headers', () => {
+    render(<OpEdTable {...noopMyProps} rows={[makeSet()]} />);
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('My Op-Eds')).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: /headline/i })).toBeTruthy();
+  });
+});
+
+describe('OpEdTable — Community variant', () => {
+  const base = {
+    variant: 'community' as const,
+    loading: false,
+    searchQuery: '',
+    onOpen: vi.fn(),
+    onExport: vi.fn(),
+    onCopy: vi.fn(),
+    copyingId: null,
+    auth: null,
+    selectedId: null,
+    totalCount: 0,
+  };
+
+  it('shows the web-only notice in Electron with no rows', () => {
+    render(<OpEdTable {...base} rows={[]} isElectron />);
+    expect(screen.getByText(/only available in the web app/i)).toBeTruthy();
+  });
+
+  it('hides Copy for anonymous users', () => {
+    render(<OpEdTable {...base} rows={[makeEntry()]} isElectron={false} auth={{ anonymous: true }} />);
+    expect(screen.queryByRole('button', { name: /copy/i })).toBeNull();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
@@ -1,0 +1,617 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// OpEdTable — full-width semantic table for the My / Community op-ed libraries
+// (t/2576 PR#1). Mirrors DebateTable's construction and a11y contract: semantic
+// <table> + <th scope> + sr-only caption, a sort state machine, edit-mode
+// checkbox column, and full-width colSpan empty/loading rows. One row per SET —
+// a single-voice run is a set of 1; a multi-voice set shows N camp chips and a
+// "▸ N voices" tag on the headline.
+
+import { useState, useCallback } from 'react';
+import type { OpEdSet, OpEdCommunityEntry, PovKey } from '../../../../../lib/oped/types';
+import { CampGlyph, povToCamp } from '../shared/CampGlyph';
+import { POV_META } from '@lib/electron-shared/povMeta';
+import './OpEdTable.css';
+
+// ──────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────
+
+export type AuthStatus = { anonymous?: boolean } | null | undefined;
+
+type SortColumn = 'headline' | 'camp' | 'outlet' | 'words' | 'date';
+type SortDir = 'asc' | 'desc' | 'none';
+
+interface SortState {
+  col: SortColumn | null;
+  dir: SortDir;
+}
+
+export interface OpEdTableMyProps {
+  variant: 'my';
+  rows: OpEdSet[];
+  loading: boolean;
+  searchQuery: string;
+  editMode: boolean;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string) => void;
+  renamingId: string | null;
+  setRenamingId: (id: string | null) => void;
+  renameValue: string;
+  setRenameValue: (v: string) => void;
+  onRename: (id: string, topic: string) => void;
+  onOpen: (id: string) => void;
+  onExport: (set: OpEdSet, format: string) => void;
+  onShare: (set: OpEdSet) => void;
+  onNew: () => void;
+  selectedSetId: string | null;
+  totalCount: number;
+}
+
+export interface OpEdTableCommunityProps {
+  variant: 'community';
+  rows: OpEdCommunityEntry[];
+  loading: boolean;
+  searchQuery: string;
+  onOpen: (id: string) => void;
+  onExport: (entry: OpEdCommunityEntry, format: string) => void;
+  onCopy: (entry: OpEdCommunityEntry) => void;
+  copyingId: string | null;
+  auth: AuthStatus;
+  /** Electron has no community library — render the web-only notice as empty state. */
+  isElectron: boolean;
+  selectedId: string | null;
+  totalCount: number;
+}
+
+export type OpEdTableProps = OpEdTableMyProps | OpEdTableCommunityProps;
+
+// ──────────────────────────────────────────────
+// Helpers (exported for unit testing)
+// ──────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+/** Distinct camps in a set, in first-seen member order. */
+export function opEdCamps(set: OpEdSet): PovKey[] {
+  const seen = new Set<PovKey>();
+  const out: PovKey[] = [];
+  for (const m of set.opeds) {
+    if (!seen.has(m.pov)) { seen.add(m.pov); out.push(m.pov); }
+  }
+  return out;
+}
+
+/** Total words across a set (single-voice = the one member's count). */
+export function opEdWordCount(set: OpEdSet): number {
+  return set.opeds.reduce((sum, m) => sum + (m.wordCount ?? 0), 0);
+}
+
+export function applySortMy(rows: OpEdSet[], sort: SortState): OpEdSet[] {
+  if (!sort.col || sort.dir === 'none') return rows;
+  const mul = sort.dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    switch (sort.col) {
+      case 'headline': return mul * (a.topic ?? '').localeCompare(b.topic ?? '');
+      case 'camp':     return mul * opEdCamps(a).join(',').localeCompare(opEdCamps(b).join(','));
+      case 'outlet':   return mul * (a.params.outlet ?? '').localeCompare(b.params.outlet ?? '');
+      case 'words':    return mul * (opEdWordCount(a) - opEdWordCount(b));
+      case 'date':     return mul * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+      default:         return 0;
+    }
+  });
+}
+
+export function applySortCommunity(rows: OpEdCommunityEntry[], sort: SortState): OpEdCommunityEntry[] {
+  if (!sort.col || sort.dir === 'none') return rows;
+  const mul = sort.dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    switch (sort.col) {
+      case 'headline': return mul * (a.topic ?? '').localeCompare(b.topic ?? '');
+      case 'camp':     return mul * (a.camps ?? []).join(',').localeCompare((b.camps ?? []).join(','));
+      case 'date':     return mul * (new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime());
+      default:         return 0; // outlet/words not carried on the community index entry
+    }
+  });
+}
+
+// ──────────────────────────────────────────────
+// Camp chips
+// ──────────────────────────────────────────────
+
+function CampChips({ camps }: { camps: PovKey[] }) {
+  return (
+    <span className="oped-camp-chips">
+      {camps.map(pov => {
+        const camp = povToCamp(pov);
+        return (
+          <span
+            key={pov}
+            className="oped-camp-chip"
+            title={POV_META[pov].label}
+            // eslint-disable-next-line local/no-inline-style -- dynamic: camp accent color from POV_META cssVar (theme-aware)
+            style={{ color: `var(${POV_META[pov].cssVar})` }}
+          >
+            {camp && <CampGlyph camp={camp} size={13} />}
+            <span className="oped-camp-chip-label">{POV_META[pov].shortLabel}</span>
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Sort header
+// ──────────────────────────────────────────────
+
+function getSortAttr(col: SortColumn, sort: SortState): 'ascending' | 'descending' | 'none' {
+  if (sort.col !== col) return 'none';
+  return sort.dir === 'asc' ? 'ascending' : 'descending';
+}
+
+function SortHeader({ label, col, sort, onSort }: {
+  label: string; col: SortColumn; sort: SortState; onSort: (col: SortColumn) => void;
+}) {
+  const active = sort.col === col;
+  const indicator = active ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '';
+  return (
+    <button type="button" className="oped-table-sort-btn" onClick={() => onSort(col)}>
+      {label}
+      {indicator && <span className="oped-table-sort-indicator" aria-hidden="true">{indicator}</span>}
+    </button>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Export menu (Markdown / Plain text — client-side, no bridge in PR#1)
+// ──────────────────────────────────────────────
+
+function OpEdExportMenu({ onExport }: { onExport: (format: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const pick = (format: string) => { setOpen(false); onExport(format); };
+  return (
+    <span className="oped-export-menu">
+      <button
+        type="button"
+        className="oped-table-action-btn"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Export"
+        onClick={() => setOpen(o => !o)}
+      >
+        Export ▾
+      </button>
+      {open && (
+        <span role="menu" className="oped-export-menu-list">
+          <button type="button" role="menuitem" className="oped-export-menu-item" onClick={() => pick('markdown')}>Markdown</button>
+          <button type="button" role="menuitem" className="oped-export-menu-item" onClick={() => pick('text')}>Plain text</button>
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ──────────────────────────────────────────────
+// My row
+// ──────────────────────────────────────────────
+
+/** Headline cell — rename input while renaming, else clamped text + a secondary line. */
+function OpEdHeadlineCell({
+  headline, subtitle, voiceCount, isRenaming, editMode,
+  renameValue, setRenameValue, onCommit, onCancel, onStartRename,
+}: {
+  headline: string;
+  subtitle: string;
+  voiceCount: number;
+  isRenaming: boolean;
+  editMode: boolean;
+  renameValue: string;
+  setRenameValue: (v: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+  onStartRename: () => void;
+}) {
+  if (isRenaming) {
+    return (
+      <input
+        className="oped-table-rename-input"
+        value={renameValue}
+        autoFocus
+        onClick={e => e.stopPropagation()}
+        onChange={e => setRenameValue(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter' && renameValue.trim()) { e.stopPropagation(); onCommit(); }
+          else if (e.key === 'Escape') onCancel();
+        }}
+        onBlur={onCommit}
+      />
+    );
+  }
+  const secondary = voiceCount > 1 ? `▸ ${voiceCount} voices` : subtitle;
+  return (
+    <>
+      <div
+        className="oped-table-headline-text"
+        title={headline}
+        onDoubleClick={!editMode ? (e) => { e.stopPropagation(); onStartRename(); } : undefined}
+      >
+        {headline}
+      </div>
+      {secondary && <div className="oped-table-headline-secondary">{secondary}</div>}
+    </>
+  );
+}
+
+export function OpEdMyRow({
+  set, isActive, editMode, isSelected, onToggleSelect,
+  renamingId, setRenamingId, renameValue, setRenameValue, onRename,
+  onOpen, onExport, onShare,
+}: {
+  set: OpEdSet;
+  isActive: boolean;
+  editMode: boolean;
+  isSelected: boolean;
+  onToggleSelect: (id: string) => void;
+  renamingId: string | null;
+  setRenamingId: (id: string | null) => void;
+  renameValue: string;
+  setRenameValue: (v: string) => void;
+  onRename: (id: string, topic: string) => void;
+  onOpen: (id: string) => void;
+  onExport: (set: OpEdSet, format: string) => void;
+  onShare: (set: OpEdSet) => void;
+}) {
+  const camps = opEdCamps(set);
+  const words = opEdWordCount(set);
+  const voiceCount = set.opeds.length;
+  const isRenaming = renamingId === set.set_id;
+  const headline = set.topic || 'Untitled op-ed';
+  const subtitle = voiceCount === 1 ? (set.opeds[0]?.subtitle ?? '') : '';
+
+  const handleRowClick = useCallback(() => {
+    if (editMode) onToggleSelect(set.set_id);
+    // Desktop non-edit: row click is inert; the Open button drives the reader.
+  }, [editMode, onToggleSelect, set.set_id]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTableRowElement>) => {
+    if (e.key === 'Enter' && !editMode) {
+      e.preventDefault();
+      onOpen(set.set_id);
+    }
+  }, [editMode, onOpen, set.set_id]);
+
+  const commitRename = useCallback(() => {
+    const v = renameValue.trim();
+    if (v && v !== headline) onRename(set.set_id, v);
+    setRenamingId(null);
+  }, [renameValue, headline, onRename, set.set_id, setRenamingId]);
+
+  return (
+    <tr
+      className={[isActive ? 'selected' : '', editMode && isSelected ? 'bulk-selected' : ''].filter(Boolean).join(' ')}
+      aria-current={isActive ? 'true' : undefined}
+      tabIndex={0}
+      onClick={handleRowClick}
+      onKeyDown={handleKeyDown}
+    >
+      {editMode && (
+        <td className="col-cb" onClick={e => e.stopPropagation()}>
+          <input
+            type="checkbox"
+            aria-label={`Select ${headline}`}
+            checked={isSelected}
+            onChange={() => onToggleSelect(set.set_id)}
+          />
+        </td>
+      )}
+
+      {/* Headline — flexible column, wraps then clamps */}
+      <td className="col-headline">
+        <OpEdHeadlineCell
+          headline={headline}
+          subtitle={subtitle}
+          voiceCount={voiceCount}
+          isRenaming={isRenaming}
+          editMode={editMode}
+          renameValue={renameValue}
+          setRenameValue={setRenameValue}
+          onCommit={commitRename}
+          onCancel={() => setRenamingId(null)}
+          onStartRename={() => { setRenamingId(set.set_id); setRenameValue(headline); }}
+        />
+      </td>
+
+      {/* Camp */}
+      <td className="col-camp"><CampChips camps={camps} /></td>
+
+      {/* Outlet */}
+      <td className="col-outlet" title={set.params.outlet ?? undefined}>{set.params.outlet || '—'}</td>
+
+      {/* Words */}
+      <td className="col-words">{words > 0 ? words : '—'}</td>
+
+      {/* Date */}
+      <td className="col-date" title={set.created_at}>{formatDate(set.created_at)}</td>
+
+      {/* Actions */}
+      <td className="col-actions" onClick={e => e.stopPropagation()}>
+        <div className="oped-table-actions">
+          <button
+            type="button"
+            className="oped-table-action-btn primary"
+            title="Open op-ed"
+            aria-label={`Open "${headline}"`}
+            onClick={() => onOpen(set.set_id)}
+          >
+            Open
+          </button>
+          <OpEdExportMenu onExport={fmt => onExport(set, fmt)} />
+          <button
+            type="button"
+            className="oped-table-action-btn"
+            title="Share to community"
+            aria-label={`Share "${headline}" to community`}
+            onClick={() => onShare(set)}
+          >
+            Share
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Community row
+// ──────────────────────────────────────────────
+
+export function OpEdCommunityRow({
+  entry, isSelected, onOpen, onExport, onCopy, copyingId, showCopy,
+}: {
+  entry: OpEdCommunityEntry;
+  isSelected: boolean;
+  onOpen: (id: string) => void;
+  onExport: (entry: OpEdCommunityEntry, format: string) => void;
+  onCopy: (entry: OpEdCommunityEntry) => void;
+  copyingId: string | null;
+  showCopy: boolean;
+}) {
+  const isCopying = copyingId === entry.id;
+  const headline = entry.topic || 'Untitled op-ed';
+  const voiceCount = entry.voice_count ?? entry.camps.length;
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTableRowElement>) => {
+    if (e.key === 'Enter') { e.preventDefault(); onOpen(entry.id); }
+  }, [onOpen, entry.id]);
+
+  return (
+    <tr
+      className={isSelected ? 'selected' : ''}
+      aria-current={isSelected ? 'true' : undefined}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+    >
+      <td className="col-headline">
+        <div className="oped-table-headline-text" title={headline}>{headline}</div>
+        {voiceCount > 1 && <div className="oped-table-headline-secondary">▸ {voiceCount} voices</div>}
+      </td>
+      <td className="col-camp"><CampChips camps={entry.camps} /></td>
+      <td className="col-outlet">—</td>
+      <td className="col-words">—</td>
+      <td className="col-date" title={entry.updated_at}>{formatDate(entry.updated_at)}</td>
+      <td className="col-actions" onClick={e => e.stopPropagation()}>
+        <div className="oped-table-actions">
+          <button
+            type="button"
+            className="oped-table-action-btn primary"
+            title="Open op-ed"
+            aria-label={`Open "${headline}"`}
+            onClick={() => onOpen(entry.id)}
+          >
+            Open
+          </button>
+          <OpEdExportMenu onExport={fmt => onExport(entry, fmt)} />
+          {showCopy && (
+            <button
+              type="button"
+              className="oped-table-action-btn"
+              title="Copy to My op-eds"
+              aria-label={`Copy "${headline}" to My op-eds`}
+              disabled={isCopying}
+              onClick={() => onCopy(entry)}
+            >
+              {isCopying ? 'Copying…' : 'Copy'}
+            </button>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+// ──────────────────────────────────────────────
+// Table shell
+// ──────────────────────────────────────────────
+
+function useSort(): [SortState, (col: SortColumn) => void] {
+  const [sort, setSort] = useState<SortState>({ col: 'date', dir: 'desc' });
+  const onSort = useCallback((col: SortColumn) => {
+    setSort(prev => {
+      if (prev.col !== col) return { col, dir: 'asc' };
+      if (prev.dir === 'asc') return { col, dir: 'desc' };
+      if (prev.dir === 'desc') return { col: null, dir: 'none' };
+      return { col, dir: 'asc' };
+    });
+  }, []);
+  return [sort, onSort];
+}
+
+export function OpEdTable(props: OpEdTableProps) {
+  if (props.variant === 'my') return <MyTable {...props} />;
+  return <CommunityTable {...props} />;
+}
+
+function MyTable(props: OpEdTableMyProps) {
+  const {
+    rows, loading, searchQuery, editMode, selectedIds, onToggleSelect,
+    renamingId, setRenamingId, renameValue, setRenameValue, onRename,
+    onOpen, onExport, onShare, onNew, selectedSetId,
+  } = props;
+  const [sort, onSort] = useSort();
+  const sortedRows = applySortMy(rows, sort);
+  const colSpan = editMode ? 7 : 6;
+
+  return (
+    <div className="oped-table-wrap" role="region" aria-label="My op-eds table">
+      <table className="oped-table">
+        <caption className="sr-only">My Op-Eds</caption>
+        <colgroup>
+          {editMode && <col className="col-cb" />}
+          <col className="col-headline" />
+          <col className="col-camp" />
+          <col className="col-outlet" />
+          <col className="col-words" />
+          <col className="col-date" />
+          <col className="col-actions" />
+        </colgroup>
+        <thead>
+          <tr>
+            {editMode && <th scope="col" className="col-cb" aria-label="Select row" />}
+            <th scope="col" className="col-headline" aria-sort={getSortAttr('headline', sort)}>
+              <SortHeader label="Headline" col="headline" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-camp" aria-sort={getSortAttr('camp', sort)}>
+              <SortHeader label="Camp" col="camp" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-outlet" aria-sort={getSortAttr('outlet', sort)}>
+              <SortHeader label="Outlet" col="outlet" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-words" aria-sort={getSortAttr('words', sort)}>
+              <SortHeader label="Words" col="words" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-date" aria-sort={getSortAttr('date', sort)}>
+              <SortHeader label="Date" col="date" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading && rows.length === 0 && (
+            <tr><td colSpan={colSpan} className="oped-table-empty-cell">Loading…</td></tr>
+          )}
+          {!loading && rows.length === 0 && (
+            <tr>
+              <td colSpan={colSpan} className="oped-table-empty-cell">
+                No op-eds yet. Create one to draft a guest essay in a camp voice.
+                <div className="oped-table-empty-action">
+                  <button type="button" className="btn btn-sm" onClick={onNew}>+ New Op-Ed</button>
+                </div>
+              </td>
+            </tr>
+          )}
+          {searchQuery && sortedRows.length === 0 && rows.length > 0 && (
+            <tr><td colSpan={colSpan} className="oped-table-empty-cell">No op-eds match &ldquo;{searchQuery}&rdquo;</td></tr>
+          )}
+          {sortedRows.map(set => (
+            <OpEdMyRow
+              key={set.set_id}
+              set={set}
+              isActive={set.set_id === selectedSetId}
+              editMode={editMode}
+              isSelected={selectedIds.has(set.set_id)}
+              onToggleSelect={onToggleSelect}
+              renamingId={renamingId}
+              setRenamingId={setRenamingId}
+              renameValue={renameValue}
+              setRenameValue={setRenameValue}
+              onRename={onRename}
+              onOpen={onOpen}
+              onExport={onExport}
+              onShare={onShare}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CommunityTable(props: OpEdTableCommunityProps) {
+  const { rows, loading, searchQuery, onOpen, onExport, onCopy, copyingId, auth, isElectron, selectedId } = props;
+  const [sort, onSort] = useSort();
+  const showCopy = !auth?.anonymous;
+
+  // Electron has no community library — show the web-only notice as the empty state.
+  if (!loading && rows.length === 0 && isElectron) {
+    return (
+      <div className="oped-session-empty">
+        Community op-eds are only available in the web app — open it in your browser to browse and search shared op-eds.
+      </div>
+    );
+  }
+
+  const sortedRows = applySortCommunity(rows, sort);
+
+  return (
+    <div className="oped-table-wrap" role="region" aria-label="Community op-eds table">
+      <table className="oped-table">
+        <caption className="sr-only">Community Op-Eds</caption>
+        <colgroup>
+          <col className="col-headline" />
+          <col className="col-camp" />
+          <col className="col-outlet" />
+          <col className="col-words" />
+          <col className="col-date" />
+          <col className="col-actions" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th scope="col" className="col-headline" aria-sort={getSortAttr('headline', sort)}>
+              <SortHeader label="Headline" col="headline" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-camp" aria-sort={getSortAttr('camp', sort)}>
+              <SortHeader label="Camp" col="camp" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-outlet">Outlet</th>
+            <th scope="col" className="col-words">Words</th>
+            <th scope="col" className="col-date" aria-sort={getSortAttr('date', sort)}>
+              <SortHeader label="Date" col="date" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading && rows.length === 0 && (
+            <tr><td colSpan={6} className="oped-table-empty-cell">Loading community op-eds…</td></tr>
+          )}
+          {!loading && rows.length === 0 && (
+            <tr><td colSpan={6} className="oped-table-empty-cell">No community op-eds available yet.</td></tr>
+          )}
+          {searchQuery && sortedRows.length === 0 && rows.length > 0 && (
+            <tr><td colSpan={6} className="oped-table-empty-cell">No community op-eds match &ldquo;{searchQuery}&rdquo;</td></tr>
+          )}
+          {sortedRows.map(entry => (
+            <OpEdCommunityRow
+              key={entry.id}
+              entry={entry}
+              isSelected={selectedId === entry.id}
+              onOpen={onOpen}
+              onExport={onExport}
+              onCopy={onCopy}
+              copyingId={copyingId}
+              showCopy={showCopy}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
@@ -188,7 +188,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
       if (action.id === 'taxonomy') {
         clearCurrentPanel();
         setToolbarPanel(null);
-        if (['situations', 'conflicts', 'debate', 'chat', 'summaries', 'validation'].includes(activeTab)) setActiveTab('accelerationist');
+        if (['situations', 'conflicts', 'debate', 'chat', 'opeds', 'summaries', 'validation'].includes(activeTab)) setActiveTab('accelerationist');
       } else if (action.id === 'chat') {
         void api.openChatWindow();
       } else if (action.id === 'feedback') {

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef, Fragment } from 'react';
 import {
   Search, LayoutGrid, MessageSquare, MessageCircle, ArrowLeft,
   Ellipsis, CircleHelp, Star, Layers,
-  RefreshCw, Settings, User, Users, Shield, LogOut,
+  RefreshCw, Settings, User, Users, Shield, LogOut, Newspaper,
 } from 'lucide-react';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { api, isElectronMode } from '@bridge';
@@ -216,6 +216,7 @@ export function Toolbar() {
 
   const adminFeatures = useFlag('permission-admin-features');
   const summariesFlag = useFlag('env-electron-summaries');
+  const opedsFlag = useFlag('env-electron-opeds');
   const navCtx = { flags: { 'env-electron-summaries': summariesFlag }, isAdmin: adminFeatures };
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const secondaryGroups = getSecondaryByGroup(visibleItems);
@@ -249,7 +250,7 @@ export function Toolbar() {
     else if (toolbarPanel === 'attrInfo') clearAttributeInfo();
   };
 
-  const switchTab = (tab: 'situations' | 'conflicts' | 'cruxes' | 'debate' | 'chat' | 'summaries' | 'validation') => {
+  const switchTab = (tab: 'situations' | 'conflicts' | 'cruxes' | 'debate' | 'chat' | 'opeds' | 'summaries' | 'validation') => {
     clearCurrentPanel();
     useTaxonomyStore.setState({ relatedNodeId: null, selectedEdge: null });
     setToolbarPanel(null);
@@ -278,7 +279,7 @@ export function Toolbar() {
     else if (action.type === 'togglePanel') toggle(action.target as ToolbarPanel);
   };
 
-  const isTaxonomyActive = toolbarPanel === null && !['situations', 'conflicts', 'cruxes', 'debate', 'chat', 'summaries', 'validation'].includes(activeTab);
+  const isTaxonomyActive = toolbarPanel === null && !['situations', 'conflicts', 'cruxes', 'debate', 'chat', 'opeds', 'summaries', 'validation'].includes(activeTab);
 
   return (
     <nav className="toolbar" aria-label="Primary">
@@ -310,7 +311,7 @@ export function Toolbar() {
           onClick={() => {
             clearCurrentPanel();
             setToolbarPanel(null);
-            if (['situations', 'conflicts', 'debate', 'chat', 'summaries', 'validation'].includes(activeTab)) {
+            if (['situations', 'conflicts', 'debate', 'chat', 'opeds', 'summaries', 'validation'].includes(activeTab)) {
               setActiveTab('accelerationist');
             }
           }}
@@ -335,6 +336,16 @@ export function Toolbar() {
           <MessageCircle size="1.25em" />
           <span className="toolbar-nav-label">Chat</span>
         </button>
+        {opedsFlag && (
+          <button
+            className={`toolbar-nav${activeTab === 'opeds' && toolbarPanel === null ? ' toolbar-nav-active' : ''}`}
+            onClick={() => switchTab('opeds')}
+            aria-label="Op-Eds"
+          >
+            <Newspaper size="1.25em" />
+            <span className="toolbar-nav-label">Op-Eds</span>
+          </button>
+        )}
       </div>
       <div className="toolbar-bottom">
         <button

--- a/taxonomy-editor/src/renderer/data/navConfig.ts
+++ b/taxonomy-editor/src/renderer/data/navConfig.ts
@@ -7,7 +7,7 @@ import {
   Crosshair, TriangleAlert, CirclePlus, BookText,
   CircleCheck, GitFork, Link, Layers, BarChart3, ShieldAlert,
   BookOpen, LineChart, Terminal, FileText, CircleHelp, Star,
-  RefreshCw, Settings, Building2, Boxes,
+  RefreshCw, Settings, Building2, Boxes, Newspaper,
 } from 'lucide-react';
 
 export type NavAction =
@@ -34,6 +34,7 @@ export const NAV_ITEMS: readonly NavItem[] = [
   { id: 'taxonomy', label: 'Taxonomy', icon: LayoutGrid, tier: 'primary', action: { type: 'custom', id: 'taxonomy' } },
   { id: 'debate', label: 'Debate', icon: MessageSquare, tier: 'primary', action: { type: 'switchTab', target: 'debate' } },
   { id: 'chat', label: 'Chat', icon: MessageCircle, tier: 'primary', action: { type: 'custom', id: 'chat' } },
+  { id: 'opeds', label: 'Op-Eds', icon: Newspaper, tier: 'primary', action: { type: 'switchTab', target: 'opeds' }, gate: { flag: 'env-electron-opeds' } },
 
   // ── Secondary tier — browse group ──
   { id: 'situations', label: 'Situations', icon: Crosshair, tier: 'secondary', group: 'browse', action: { type: 'switchTab', target: 'situations' } },

--- a/taxonomy-editor/src/renderer/hooks/useCommunityStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useCommunityStore.ts
@@ -6,6 +6,7 @@ import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { bridgeGet, bridgePost } from '../bridge/web-bridge';
 import { useTaxonomyStore } from './useTaxonomyStore';
+import type { OpEdCommunityEntry } from '../../../../lib/oped/types';
 
 export interface CommunityItem {
   id: string;
@@ -35,7 +36,7 @@ export interface CommunityDebate extends CommunityItem {
 
 export interface Submission {
   id: string;
-  type: 'chat' | 'debate';
+  type: 'chat' | 'debate' | 'oped';
   originalId: string;
   submittedBy: string;
   submittedAt: string;
@@ -46,16 +47,18 @@ export interface Submission {
 interface CommunityStore {
   chats: CommunityChat[];
   debates: CommunityDebate[];
+  opeds: OpEdCommunityEntry[];
   submissions: Submission[];
   loading: boolean;
   error: string | null;
 
   fetchChats: () => Promise<void>;
   fetchDebates: () => Promise<void>;
+  fetchOpeds: () => Promise<void>;
   fetchSubmissions: (status?: string) => Promise<void>;
-  submitItem: (type: 'chat' | 'debate', data: unknown, note?: string) => Promise<string>;
-  copyItem: (type: 'chats' | 'debates', communityId: string) => Promise<string>;
-  removeItem: (type: 'chats' | 'debates', id: string, reason?: string) => Promise<void>;
+  submitItem: (type: 'chat' | 'debate' | 'oped', data: unknown, note?: string) => Promise<string>;
+  copyItem: (type: 'chats' | 'debates' | 'opeds', communityId: string) => Promise<string>;
+  removeItem: (type: 'chats' | 'debates' | 'opeds', id: string, reason?: string) => Promise<void>;
   approveSubmission: (id: string) => Promise<void>;
   rejectSubmission: (id: string) => Promise<void>;
 }
@@ -73,6 +76,7 @@ function getCommunityBaseUrl(): string {
 export const useCommunityStore = create<CommunityStore>((set) => ({
   chats: [],
   debates: [],
+  opeds: [],
   submissions: [],
   loading: false,
   error: null,
@@ -99,6 +103,19 @@ export const useCommunityStore = create<CommunityStore>((set) => ({
       api.trackEvent('community_browse', 'community', { type: 'debates', count: debates.length });
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'community-store', level: 'error', message: 'Failed to fetch community debates', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+      set({ error: String(err), loading: false });
+    }
+  },
+
+  fetchOpeds: async () => {
+    if (isElectronMode()) { set({ opeds: [], loading: false }); return; }
+    set({ loading: true, error: null });
+    try {
+      const opeds = await bridgeGet<OpEdCommunityEntry[]>('/api/community/opeds');
+      set({ opeds, loading: false });
+      api.trackEvent('community_browse', 'community', { type: 'opeds', count: opeds.length });
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'community-store', level: 'error', message: 'Failed to fetch community op-eds', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
       set({ error: String(err), loading: false });
     }
   },
@@ -140,7 +157,7 @@ export const useCommunityStore = create<CommunityStore>((set) => ({
   },
 
   removeItem: async (type, id, reason) => {
-    const listKey = type === 'chats' ? 'chats' : 'debates';
+    const listKey = type;
     const prev = useCommunityStore.getState()[listKey];
     set({ [listKey]: prev.filter(item => item.id !== id) });
     try {

--- a/taxonomy-editor/src/renderer/hooks/useOpEdStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useOpEdStore.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { create } from 'zustand';
+import { api } from '@bridge';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import type { OpEdSet } from '../../../../lib/oped/types';
+
+// Personal Op-Ed library store (t/2576). A lean list/load/delete/rename surface over
+// the bridge trio — deliberately NOT a mirror of useDebateStore's state machine: an
+// op-ed set is static text, so there is no live-generation loop to model here. The
+// PR#2 create flow adds the generation actions; PR#1 is the library + reader only.
+//
+// Personal op-eds come through `api.*OpEd*` (Electron: local fs via t/2575 IPC; web:
+// t/2573 routes). Community op-eds live in useCommunityStore alongside debates/chats.
+
+interface OpEdStore {
+  /** Personal op-ed sets (each set = one create run; single-voice is a set of 1). */
+  sets: OpEdSet[];
+  /** set_id of the row open in the reader, or null for the table view. */
+  selectedSetId: string | null;
+  loading: boolean;
+  error: string | null;
+  /** Edit mode enables the bulk-select checkbox column + inline rename (My only). */
+  editMode: boolean;
+  selectedIds: Set<string>;
+
+  loadSets: () => Promise<void>;
+  selectSet: (id: string | null) => void;
+  deleteSet: (id: string) => Promise<void>;
+  renameSet: (id: string, topic: string) => Promise<void>;
+  setEditMode: (on: boolean) => void;
+  toggleSelected: (id: string) => void;
+  clearSelected: () => void;
+  deleteSelected: () => Promise<void>;
+}
+
+export const useOpEdStore = create<OpEdStore>((set, get) => ({
+  sets: [],
+  selectedSetId: null,
+  loading: false,
+  error: null,
+  editMode: false,
+  selectedIds: new Set<string>(),
+
+  loadSets: async () => {
+    set({ loading: true, error: null });
+    try {
+      const sets = await api.listOpEdSets();
+      set({ sets, loading: false });
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'oped-store', level: 'error', message: 'Failed to load op-ed sets',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      set({ error: String(err), loading: false });
+    }
+  },
+
+  selectSet: (id) => set({ selectedSetId: id }),
+
+  deleteSet: async (id) => {
+    const prev = get().sets;
+    // Optimistic removal; roll back on failure. Mutations never auto-retry — the
+    // error is re-thrown so the caller surfaces user-visible feedback (toast/inline).
+    set({
+      sets: prev.filter(s => s.set_id !== id),
+      selectedSetId: get().selectedSetId === id ? null : get().selectedSetId,
+    });
+    try {
+      await api.deleteOpEdSet(id);
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'oped-store', level: 'error', message: 'Failed to delete op-ed set',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      set({ sets: prev, error: String(err) });
+      throw err;
+    }
+  },
+
+  renameSet: async (id, topic) => {
+    const prev = get().sets;
+    const target = prev.find(s => s.set_id === id);
+    if (!target) return;
+    const updated: OpEdSet = { ...target, topic };
+    set({ sets: prev.map(s => (s.set_id === id ? updated : s)) });
+    try {
+      await api.saveOpEdSet(updated);
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'oped-store', level: 'error', message: 'Failed to rename op-ed set',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      set({ sets: prev, error: String(err) });
+      throw err;
+    }
+  },
+
+  setEditMode: (on) => set({ editMode: on, selectedIds: on ? get().selectedIds : new Set<string>() }),
+
+  toggleSelected: (id) => {
+    const next = new Set(get().selectedIds);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    set({ selectedIds: next });
+  },
+
+  clearSelected: () => set({ selectedIds: new Set<string>() }),
+
+  deleteSelected: async () => {
+    const ids = Array.from(get().selectedIds);
+    // Sequential, not parallel: mutations must not race, and a mid-batch failure
+    // should stop rather than fire the rest blind. deleteSet re-throws on failure.
+    for (const id of ids) {
+      await get().deleteSet(id);
+    }
+    set({ selectedIds: new Set<string>(), editMode: false });
+  },
+}));

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -243,7 +243,7 @@ export interface ElectronAPI {
   captureScreenshot: (opts?: { width?: number; height?: number; defaultName?: string }) => Promise<{ cancelled: boolean; filePath?: string }>;
 
   // Community
-  communitySubmit: (baseUrl: string, payload: { type: 'chat' | 'debate'; data: unknown; note?: string }) => Promise<{ submissionId: string }>;
+  communitySubmit: (baseUrl: string, payload: { type: 'chat' | 'debate' | 'oped'; data: unknown; note?: string }) => Promise<{ submissionId: string }>;
 
   // Admin Review
   adminReviewConfigured: () => Promise<boolean>;

--- a/taxonomy-editor/src/renderer/types/taxonomy.ts
+++ b/taxonomy-editor/src/renderer/types/taxonomy.ts
@@ -151,4 +151,4 @@ export interface ConflictFile {
   verdict?: ConflictVerdict;
 }
 
-export type TabId = 'accelerationist' | 'safetyist' | 'skeptic' | 'situations' | 'conflicts' | 'cruxes' | 'debate' | 'chat' | 'summaries' | 'validation' | 'organizations';
+export type TabId = 'accelerationist' | 'safetyist' | 'skeptic' | 'situations' | 'conflicts' | 'cruxes' | 'debate' | 'chat' | 'opeds' | 'summaries' | 'validation' | 'organizations';


### PR DESCRIPTION
## Op-Ed Studio — PR#1 (library + reader + bridge trio) · t/2576

Renderer half of the Op-Ed Studio epic (t/2570), phase 1. **Ships dark** behind the `env-electron-opeds` flag (off by default) — nothing user-visible lands until the backend is ready, so this merges safely ahead of t/2573/t/2575.

### What's in
- **Nav**: `opeds` primary item below Chat → inline `OpEdTab` workspace (mirrors Debate's table-mode shell).
- **Store**: `useOpEdStore` (lean library CRUD — list/select/delete/rename/bulk); `useCommunityStore` `opeds` extension.
- **Bridge trio** (types + web + electron): `list/load/save/delete` + `loadCommunityOpEd`. Web hits real `/api/opeds` (honest normalized 404 until **t/2573**); electron **feature-detects** the IPC surface — lights up when **t/2575** installs it, no stub module to swap (the t/2561 lesson, engineered out).
- **Components**: `OpEdTab` / `OpEdTable` (one row per **set**, camp chips + `▸ N voices`) / `OpEdReader` (single-voice → no tab strip; multi-voice → camp tabs with roving tabindex; grounding table with **clickable inline `NodeDetail` cards**, one open at a time, Esc-dismiss, reduced-motion). Reuses the shared taxonomy ref-detail renderer.
- **Contract**: `lib/oped/types` (t/2571) imported directly — no stubs.
- **Tests**: 30 vitest (OpEdTable set-grouping/chips/empty; OpEdReader single vs multi-voice, partial-set `failed`/`cancelled`, grounding-expand a11y).

### Verify
Full deterministic gate green locally: main/server/renderer tsc `0/0`, eslint clean, depcruise, scoped vitest (opeds + bridge), `vite build`.

### Deviations from the approved design (t/2576#2)
1. **Nav mechanism `custom` → `switchTab`.** The `custom` action (chat/taxonomy) can't mount an inline workspace; `switchTab` is Debate's mechanism for exactly the full-width workspace the spec wants. Touches `Toolbar`/`HamburgerMenu` nav wiring (both in scope). Same user-visible outcome.
2. **`+ New Op-Ed` rendered DISABLED** in PR#1 (create = PR#2). Web shows "Available in the desktop app" (t/2570#3); Electron "Create coming soon."

### Deferred to PR#2 / follow-up
- `NewOpEdDialog` + 3-stage generation progress (create flow).
- Export is client-side Markdown/Plain-text Blob for now; PDF/JSON need the `New-OpEd.ps1` formatter bridge.

### Ticket stays OPEN after merge (per t/2576#3)
Close gates are the **post-t/2573 web live-smoke** (real 200 → library renders) + Electron list/load check after t/2575, and **Design `/design-review-workflow`** (4 themes, keyboard, camp tabs, grounding a11y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
