### PR TITLE
chore(models): retire gemini-3.6-flash — repoint New-OpEd + test literals to 3.7 (t/2582)

### DIFF
--- a/ai-models.json
+++ b/ai-models.json
@@ -83,12 +83,6 @@
       "backend": "gemini"
     },
     {
-      "id": "gemini-3.6-flash",
-      "apiModelId": "gemini-3.6-flash",
-      "label": "Gemini 3.6 Flash",
-      "backend": "gemini"
-    },
-    {
       "id": "gemini-3.1-pro-preview",
       "apiModelId": "gemini-3.1-pro-preview",
       "label": "Gemini 3.1 Pro Preview",
@@ -760,10 +754,6 @@
     "moonshot": "moonshot-kimi-k3"
   },
   "fallbackChains": {
-    "gemini-3.6-flash": [
-      "gemini-3.5-flash-lite",
-      "groq-llama-3.3-70b-versatile"
-    ],
     "gemini-3.1-pro-preview": [
       "gemini-3.1-pro-preview"
     ],

--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -73,7 +73,7 @@ function New-OpEd {
         If supplied, writes the headline, body, and any pitch to a Markdown file
         at this path (UTF-8, no BOM).
     .PARAMETER Model
-        AI model to use. Defaults to gemini-3.6-flash — a deliberate step up from
+        AI model to use. Defaults to gemini-3.7-flash — a deliberate step up from
         the flash-lite enrichment default because long-form persuasive prose needs
         a stronger tier; a GA model is preferred over a preview as a default. For
         maximum polish, pass -Model gemini-3.1-pro-preview.
@@ -155,7 +155,7 @@ function New-OpEd {
         [string]$OutputPath,
 
         [ValidateScript({ Test-AIModelId $_ })]
-        [string]$Model = 'gemini-3.6-flash',
+        [string]$Model = 'gemini-3.7-flash',
 
         [ValidateRange(0.0, 2.0)]
         [double]$Temperature = 0.8,

--- a/tests/AITriad.Module.Tests.ps1
+++ b/tests/AITriad.Module.Tests.ps1
@@ -115,7 +115,7 @@ Describe 'AI Model Configuration' {
 
     It 'Model validation should work for known models' -Skip:(-not $HasDataRepo) {
         # Test via parameter validation on a real cmdlet (requires taxonomy data)
-        { Find-PolicyAction -Model 'gemini-3.6-flash' -DryRun -POV accelerationist -ErrorAction Stop } | Should -Not -Throw
+        { Find-PolicyAction -Model 'gemini-3.7-flash' -DryRun -POV accelerationist -ErrorAction Stop } | Should -Not -Throw
     }
 
     It 'Model validation should reject invalid models' {

--- a/tests/Invoke-EntityExtraction.Tests.ps1
+++ b/tests/Invoke-EntityExtraction.Tests.ps1
@@ -89,10 +89,10 @@ Describe 'Invoke-EntityExtraction (t/1806 Phase 1)' -Tag 'unit' {
                     [PSCustomObject]@{ Text = '{"proposals":[],"org_mentions":[]}'; Model = 'stub' }
                 }
 
-                Invoke-EntityExtraction -NodeId 'node-a' -Model 'gemini-3.6-flash' -Concurrency 1 `
+                Invoke-EntityExtraction -NodeId 'node-a' -Model 'gemini-3.7-flash' -Concurrency 1 `
                     -EntitiesPath $EntPath -EmbeddingsPath $EmbPath -SourceEvidenceIndexPath $SeiPath -OutputPath $LogPath -Confirm:$false | Out-Null
 
-                $script:capturedModel | Should -Be 'gemini-3.6-flash'
+                $script:capturedModel | Should -Be 'gemini-3.7-flash'
             }
         }
 

--- a/tests/Test-AIBackendHealth.Tests.ps1
+++ b/tests/Test-AIBackendHealth.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'Test-AIBackendHealth' -Tag 'enrichment' {
     Context 'Single backend — ok' {
         BeforeEach {
             Mock Invoke-AIApi -ModuleName AITriad {
-                [PSCustomObject]@{ Text = 'pong'; Backend = 'gemini'; Model = 'gemini-3.6-flash'; Truncated = $false; Usage = $null; RawResponse = $null }
+                [PSCustomObject]@{ Text = 'pong'; Backend = 'gemini'; Model = 'gemini-3.7-flash'; Truncated = $false; Usage = $null; RawResponse = $null }
             }
         }
 


### PR DESCRIPTION
## Summary
- Removes `gemini-3.6-flash` from `ai-models.json` (model entry + its own fallback chain key)
- Repoints `New-OpEd.ps1` default `-Model` to `gemini-3.7-flash` (doc comment + parameter default)
- Repoints three test literals that would fail ModelLiteralLint: `AITriad.Module.Tests.ps1:118`, `Invoke-EntityExtraction.Tests.ps1:92/95`, `Test-AIBackendHealth.Tests.ps1:25`
- Historical data artifacts (`tests/fixtures/edges-format/`, `ai-usages.json`, `research/comp-linguist/`) left untouched

## Test plan
- [ ] `verify:config` 7/7 green (confirmed locally before push)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)