### PR TITLE
feat(ai): add xAI (Grok 4.6) backend — OpenAI-compatible clone (t/2583)

### DIFF
--- a/ai-models.json
+++ b/ai-models.json
@@ -33,6 +33,10 @@
       "label": "Moonshot (Kimi)"
     },
     {
+      "id": "xai",
+      "label": "xAI (Grok)"
+    },
+    {
       "id": "ollama",
       "label": "Ollama (Local)",
       "local": true
@@ -75,6 +79,12 @@
       "label": "Kimi K3",
       "backend": "moonshot",
       "fixedTemperature": 1
+    },
+    {
+      "id": "xai-grok-4-6",
+      "apiModelId": "grok-4.6",
+      "label": "Grok 4.6",
+      "backend": "xai"
     },
     {
       "id": "gemini-3.7-flash",
@@ -751,7 +761,8 @@
     "azure": "azure-gpt-4o",
     "ollama": "ollama-gemma4-e4b-it-q4-k-m",
     "zai": "zai-glm-5-2",
-    "moonshot": "moonshot-kimi-k3"
+    "moonshot": "moonshot-kimi-k3",
+    "xai": "xai-grok-4-6"
   },
   "fallbackChains": {
     "gemini-3.1-pro-preview": [
@@ -806,6 +817,9 @@
     ],
     "moonshot-kimi-k3": [
       "groq-llama-3.3-70b-versatile"
+    ],
+    "xai-grok-4-6": [
+      "groq-llama-3.3-70b-versatile"
     ]
   },
   "contextWindows": {
@@ -817,7 +831,8 @@
     "deepseek": 65536,
     "ollama": 131072,
     "zai": 1000000,
-    "moonshot": 1000000
+    "moonshot": 1000000,
+    "xai": 500000
   },
   "capabilityDefaults": {
     "gemini": {
@@ -873,6 +888,12 @@
       "supportsVision": false,
       "supportsStreaming": true,
       "maxContextTokens": 1000000
+    },
+    "xai": {
+      "supportsTools": true,
+      "supportsVision": true,
+      "supportsStreaming": true,
+      "maxContextTokens": 500000
     }
   },
   "modelCapabilities": {
@@ -1100,6 +1121,11 @@
       "inputPer1M": 3,
       "outputPer1M": 15,
       "cachedInputPer1M": 0.3
+    },
+    "xai-grok-4-6": {
+      "inputPer1M": 2,
+      "outputPer1M": 6,
+      "cachedInputPer1M": 0.5
     }
   },
   "lastRefreshed": "2026-08-13T16:58:37.846Z"

--- a/lib/ai-client/allApiKeyBackends.test.ts
+++ b/lib/ai-client/allApiKeyBackends.test.ts
@@ -20,6 +20,7 @@ describe('ALL_API_KEY_BACKENDS', () => {
         'ollama',
         'openai',
         'tavily',
+        'xai',
         'zai',
       ].sort(),
     );

--- a/lib/ai-client/client.ts
+++ b/lib/ai-client/client.ts
@@ -15,6 +15,7 @@ import { generateViaOllama } from './providers/ollama.js';
 import { generateViaAzure } from './providers/azure.js';
 import { generateViaZai } from './providers/zai.js';
 import { generateViaMoonshot } from './providers/moonshot.js';
+import { generateViaXai } from './providers/xai.js';
 
 export interface AIClientDeps {
   fetch: FetchFn;
@@ -44,6 +45,7 @@ export function callProvider(
     case 'ollama': return generateViaOllama(fetchFn, prompt, apiModelId, apiKey, opts);
     case 'zai': return generateViaZai(fetchFn, prompt, apiModelId, apiKey, opts);
     case 'moonshot': return generateViaMoonshot(fetchFn, prompt, apiModelId, apiKey, opts);
+    case 'xai': return generateViaXai(fetchFn, prompt, apiModelId, apiKey, opts);
     default: return generateViaGemini(fetchFn, prompt, apiModelId, apiKey, opts);
   }
 }

--- a/lib/ai-client/index.ts
+++ b/lib/ai-client/index.ts
@@ -16,6 +16,7 @@ export { generateViaDeepSeek, generateViaDeepSeekStream } from './providers/deep
 export { generateViaOllama, isOllamaAvailable, OLLAMA_BASE } from './providers/ollama.js';
 export { generateViaZai } from './providers/zai.js';
 export { generateViaMoonshot } from './providers/moonshot.js';
+export { generateViaXai } from './providers/xai.js';
 export { TaskTier, resolveModelForPurpose, probeOllama, configureRouter, getRouterConfig, getTierForPurpose, PURPOSE_TIER_MAP, resolveMultiProviderModels } from './modelRouter.js';
 export type { TaskPurpose, RouterConfig, RoutedModel, ModelTier } from './modelRouter.js';
 export { callGeminiBatchEmbed } from './providers/gemini-embeddings.js';

--- a/lib/ai-client/providers/xai.ts
+++ b/lib/ai-client/providers/xai.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2583 — xAI (Grok) exposes an OpenAI-compatible /chat/completions endpoint at
+// https://api.x.ai/v1 (Bearer auth, system+user messages). Request/response shape
+// matches Groq/z.ai/Moonshot exactly; the model id (grok-4.6) flows from
+// ai-models.json via apiModelId.
+import { ActionableError } from '../../debate/errors.js';
+import { withTimeout, makeFetchSignal } from '../retry.js';
+import type { FetchFn, GenerateOptions, ProviderResult } from '../types.js';
+import { DEFAULT_TEMPERATURE } from '../defaults.js';
+
+const XAI_BASE = 'https://api.x.ai/v1';
+
+export async function generateViaXai(
+  fetchFn: FetchFn,
+  prompt: string,
+  apiModelId: string,
+  apiKey: string,
+  opts: GenerateOptions,
+): Promise<ProviderResult> {
+  const timeoutMs = opts.timeoutMs!;
+
+  const messages: { role: string; content: string }[] = [];
+  if (opts.systemMessage) messages.push({ role: 'system', content: opts.systemMessage });
+  messages.push({ role: 'user', content: prompt });
+
+  const response = await fetchFn(`${XAI_BASE}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: apiModelId,
+      messages,
+      temperature: opts.fixedTemperature ?? opts.temperature ?? DEFAULT_TEMPERATURE,
+      max_tokens: opts.maxTokens ?? 8192,
+      ...(opts.jsonMode ? {
+        response_format: { type: 'json_object' },
+      } : {}),
+    }),
+    signal: makeFetchSignal(timeoutMs, opts.signal),
+  });
+
+  const bodyText = await withTimeout(response.text(), 60_000, 'Reading xAI response');
+
+  if (response.status === 429 || response.status === 503) {
+    throw new ActionableError({
+      goal: 'Generate text via xAI',
+      problem: `xAI ${response.status}: ${bodyText.slice(0, 200)}`,
+      location: 'ai-client.generateViaXai',
+      nextSteps: ['Wait a minute and retry', 'Switch to a different AI provider (Settings → AI Model)', 'Check API quota'],
+    });
+  }
+  if (!response.ok) {
+    const isTemperatureError = /temperature/i.test(bodyText);
+    throw new ActionableError({
+      goal: 'Generate text via xAI',
+      problem: `xAI API error ${response.status}: ${bodyText.slice(0, 500)}`,
+      location: 'ai-client.generateViaXai',
+      nextSteps: isTemperatureError
+        ? [
+            'This model requires a fixed temperature — add `"fixedTemperature": 1` to its entry in ai-models.json',
+            'Or switch to a different model that accepts variable temperature',
+          ]
+        : ['Check your API key', 'Verify the model ID', 'Try a different model'],
+    });
+  }
+
+  let json: {
+    choices?: { message: { content: string } }[];
+    usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number; prompt_cache_hit_tokens?: number };
+  };
+  try {
+    json = JSON.parse(bodyText);
+  } catch {
+    throw new ActionableError({
+      goal: 'Parse xAI API response',
+      problem: `xAI API returned invalid JSON (${bodyText.length} bytes). First 200 chars: ${bodyText.slice(0, 200)}`,
+      location: 'ai-client.generateViaXai',
+      nextSteps: ['Retry the request', 'Check the API key and model ID'],
+    });
+  }
+  if (!json.choices?.length) {
+    throw new ActionableError({
+      goal: 'Generate text via xAI',
+      problem: `No choices in xAI response: ${bodyText.slice(0, 300)}`,
+      location: 'ai-client.generateViaXai',
+      nextSteps: ['Retry the request', 'Try a different model'],
+    });
+  }
+  const text = json.choices[0].message.content;
+  const u = json.usage;
+  const usage = u ? {
+    promptTokens: u.prompt_tokens,
+    completionTokens: u.completion_tokens,
+    cachedTokens: u.prompt_cache_hit_tokens,
+    totalTokens: u.total_tokens,
+  } : undefined;
+  return { text, usage, rawResponsePreview: text ? undefined : bodyText.slice(0, 200) };
+}

--- a/lib/ai-client/registry.ts
+++ b/lib/ai-client/registry.ts
@@ -43,6 +43,7 @@ export function resolveBackend(model: string): BackendId {
   if (model.startsWith('deepseek')) return 'deepseek';
   if (model.startsWith('zai')) return 'zai';
   if (model.startsWith('moonshot')) return 'moonshot';
+  if (model.startsWith('xai')) return 'xai';
   return 'gemini';
 }
 
@@ -58,6 +59,7 @@ export function resolveModel(registry: ModelRegistry, friendlyId: string): { api
   if (friendlyId.startsWith('deepseek')) return { apiModelId: friendlyId, backend: 'deepseek' };
   if (friendlyId.startsWith('zai')) return { apiModelId: friendlyId, backend: 'zai' };
   if (friendlyId.startsWith('moonshot')) return { apiModelId: friendlyId, backend: 'moonshot' };
+  if (friendlyId.startsWith('xai')) return { apiModelId: friendlyId, backend: 'xai' };
   return { apiModelId: friendlyId, backend: 'gemini' };
 }
 
@@ -71,6 +73,7 @@ function baseTimeout(backend: string): number {
     case 'groq':      return 120_000;
     case 'zai':       return 240_000;
     case 'moonshot':  return 240_000;
+    case 'xai':       return 240_000;
     case 'gemini':    return 120_000;
     default:          return 120_000;
   }

--- a/lib/ai-client/types.ts
+++ b/lib/ai-client/types.ts
@@ -102,7 +102,7 @@ export interface RetryProgress {
   rateLimitHeaders?: RateLimitHeaders;
 }
 
-export type BackendId = 'gemini' | 'claude' | 'groq' | 'openai' | 'azure' | 'ollama' | 'deepseek' | 'zai' | 'moonshot';
+export type BackendId = 'gemini' | 'claude' | 'groq' | 'openai' | 'azure' | 'ollama' | 'deepseek' | 'zai' | 'moonshot' | 'xai';
 
 /** Superset of BackendId that includes non-generation backends needing API key management (e.g. tavily for search). */
 export type ApiKeyBackend = BackendId | 'tavily';
@@ -123,6 +123,7 @@ const ALL_API_KEY_BACKENDS_MAP: Record<ApiKeyBackend, true> = {
   deepseek: true,
   zai: true,
   moonshot: true,
+  xai: true,
   tavily: true,
 };
 

--- a/lib/debate/aiAdapter.ts
+++ b/lib/debate/aiAdapter.ts
@@ -117,6 +117,7 @@ const BACKEND_ENV_KEYS: Record<string, string> = {
   deepseek: 'DEEPSEEK_API_KEY',
   moonshot: 'MOONSHOT_API_KEY',
   zai: 'ZAI_API_KEY',
+  xai: 'XAI_API_KEY',
   tavily: 'TAVILY_API_KEY',
 };
 

--- a/lib/debate/backendEnvKeys.test.ts
+++ b/lib/debate/backendEnvKeys.test.ts
@@ -37,6 +37,7 @@ const EXPECTED_BACKEND_ENV_KEYS: Record<string, string> = {
   deepseek: 'DEEPSEEK_API_KEY',
   moonshot: 'MOONSHOT_API_KEY',
   zai:      'ZAI_API_KEY',
+  xai:      'XAI_API_KEY',
 };
 
 // Backends that intentionally require no API key.

--- a/scripts/AIEnrich.psm1
+++ b/scripts/AIEnrich.psm1
@@ -18,7 +18,7 @@
 # ─────────────────────────────────────────────────────────────────────────────
 $script:ModelRegistry = @{}
 $script:FallbackChains = @{}
-$script:ContextWindows = @{ gemini = 1048576; claude = 200000; groq = 131072; openai = 131072; zai = 1000000; moonshot = 1000000; deepseek = 65536 }
+$script:ContextWindows = @{ gemini = 1048576; claude = 200000; groq = 131072; openai = 131072; zai = 1000000; moonshot = 1000000; xai = 500000; deepseek = 65536 }
 $script:DebateTiers = @{ basic = @{}; advanced = @{} }
 $script:LastApiKeySource = ''
 $script:AIApiLoggedThisSession = $false
@@ -189,6 +189,7 @@ function Resolve-AIApiKey {
         'azure'  = @('AZURE_OPENAI_API_KEY')
         'zai'    = @('ZAI_API_KEY')
         'moonshot' = @('MOONSHOT_API_KEY')
+        'xai'    = @('XAI_API_KEY')
         'deepseek' = @('DEEPSEEK_API_KEY')
     }
 
@@ -348,6 +349,7 @@ function Get-AIDefaultTimeoutSec {
         'deepseek*'  { 'deepseek';  break }
         'zai*'       { 'zai';       break }
         'moonshot*'  { 'moonshot';  break }
+        'xai*'       { 'xai';       break }
         default      { 'gemini' }
     }
 
@@ -360,6 +362,7 @@ function Get-AIDefaultTimeoutSec {
         'groq'      { 120 }
         'zai'       { 240 }
         'moonshot'  { 240 }
+        'xai'       { 240 }
         'gemini'    { 120 }
         default     { 120 }
     }
@@ -491,8 +494,9 @@ function Invoke-AIApi {
                 'ollama' { '(no env var — local, keyless)' }
                 'zai'    { 'ZAI_API_KEY' }
                 'moonshot' { 'MOONSHOT_API_KEY' }
+                'xai'    { 'XAI_API_KEY' }
                 'deepseek' { 'DEEPSEEK_API_KEY' }
-                default  { "(unknown backend '$Backend' — expected gemini/claude/groq/openai/azure/ollama/zai/moonshot/deepseek)" }
+                default  { "(unknown backend '$Backend' — expected gemini/claude/groq/openai/azure/ollama/zai/moonshot/xai/deepseek)" }
             }
             Write-Warning "No API key found for $Backend backend. Set $EnvHint or AI_API_KEY."
             return $null
@@ -720,6 +724,48 @@ function Invoke-AIApi {
             }
 
             $Body = $MoonshotBody | ConvertTo-Json -Depth 10
+        }
+
+        # t/2583 — xAI (Grok) exposes an OpenAI-compatible /chat/completions
+        # endpoint at https://api.x.ai/v1. Request shape matches Groq/z.ai/Moonshot
+        # exactly (Bearer auth, system+user messages); the model id (grok-4.6) flows
+        # from ai-models.json via $ApiModelId. 500K-token context
+        # ($script:ContextWindows.xai) so the pre-flight token check tolerates
+        # very large prompts sanely.
+        'xai' {
+            $Uri = 'https://api.x.ai/v1/chat/completions'
+            $Headers = @{
+                'Authorization' = "Bearer $ResolvedKey"
+            }
+
+            $XaiMessages = [System.Collections.Generic.List[object]]::new()
+            if ($SystemInstruction) {
+                $XaiMessages.Add(@{ role = 'system'; content = $SystemInstruction })
+            }
+            $XaiMessages.Add(@{ role = 'user'; content = $Prompt })
+
+            $XaiBody = @{
+                model       = $ApiModelId
+                messages    = @($XaiMessages)
+                temperature = $Temperature
+                max_tokens  = $MaxTokens
+            }
+            if ($JsonMode) {
+                if ($ResponseSchema) {
+                    $XaiBody['response_format'] = @{
+                        type        = 'json_schema'
+                        json_schema = @{
+                            name   = 'response'
+                            schema = $ResponseSchema
+                            strict = $true
+                        }
+                    }
+                } else {
+                    $XaiBody['response_format'] = @{ type = 'json_object' }
+                }
+            }
+
+            $Body = $XaiBody | ConvertTo-Json -Depth 10
         }
 
         # t/1938 — DeepSeek exposes an OpenAI-compatible /v1/chat/completions endpoint
@@ -1091,6 +1137,26 @@ function Invoke-AIApi {
             } catch {
                 $TopKeys = ($Response.PSObject.Properties.Name | Select-Object -First 5) -join ', '
                 Write-Warning "Moonshot: unexpected response shape (top-level keys: $TopKeys). Expected choices[].message.content"
+                return $null
+            }
+        }
+        # t/2583 — xAI (Grok) response shape mirrors Groq/z.ai/OpenAI.
+        'xai' {
+            try {
+                $Choice = $Response.choices[0]
+                $Text = $Choice.message.content
+                $Truncated = ($Choice.finish_reason -eq 'length')
+                $u = $Response.usage
+                if ($u) {
+                    $Usage = [PSCustomObject]@{
+                        InputTokens  = [int]($u.prompt_tokens)
+                        OutputTokens = [int]($u.completion_tokens)
+                        TotalTokens  = [int]($u.total_tokens)
+                    }
+                }
+            } catch {
+                $TopKeys = ($Response.PSObject.Properties.Name | Select-Object -First 5) -join ', '
+                Write-Warning "xAI: unexpected response shape (top-level keys: $TopKeys). Expected choices[].message.content"
                 return $null
             }
         }

--- a/scripts/AITriad/Public/Test-AIApiKey.ps1
+++ b/scripts/AITriad/Public/Test-AIApiKey.ps1
@@ -63,7 +63,7 @@ function Test-AIApiKey {
     [OutputType([PSCustomObject])]
     param(
         [Parameter(Mandatory, ParameterSetName = 'One', Position = 0)]
-        [ValidateSet('gemini', 'claude', 'groq', 'openai', 'azure', 'ollama', 'zai', 'moonshot', 'deepseek')]
+        [ValidateSet('gemini', 'claude', 'groq', 'openai', 'azure', 'ollama', 'zai', 'moonshot', 'xai', 'deepseek')]
         [string]$Backend,
 
         [Parameter(ParameterSetName = 'One')]
@@ -176,6 +176,11 @@ function Test-AIApiKey {
                 $Uri = 'https://api.moonshot.ai/v1/models'
                 $Headers['Authorization'] = "Bearer $Key"
             }
+            # t/2583 — xAI (Grok) is OpenAI-compatible and exposes a GET /v1/models list.
+            'xai' {
+                $Uri = 'https://api.x.ai/v1/models'
+                $Headers['Authorization'] = "Bearer $Key"
+            }
             # t/1938 — DeepSeek is OpenAI-compatible and exposes a GET /models list.
             'deepseek' {
                 $Uri = 'https://api.deepseek.com/models'
@@ -259,6 +264,8 @@ function Test-AIApiKey {
         # t/1437 — z.ai only if $env:ZAI_API_KEY is present (needs a real key).
         if ($env:ZAI_API_KEY) { $Backends += 'zai' }
         if ($env:MOONSHOT_API_KEY) { $Backends += 'moonshot' }
+        # t/2583 — xAI (Grok) only if $env:XAI_API_KEY is present (needs a real key).
+        if ($env:XAI_API_KEY) { $Backends += 'xai' }
         # t/1938 — DeepSeek only if $env:DEEPSEEK_API_KEY is present (needs a real key).
         if ($env:DEEPSEEK_API_KEY) { $Backends += 'deepseek' }
         foreach ($B in $Backends) {

--- a/scripts/AITriad/Public/Test-AIBackendHealth.ps1
+++ b/scripts/AITriad/Public/Test-AIBackendHealth.ps1
@@ -19,7 +19,7 @@
 
 .PARAMETER Backend
     Single backend to probe. One of: gemini, claude, groq, openai, deepseek, azure, zai,
-    moonshot, ollama.
+    moonshot, xai, ollama.
 
 .PARAMETER All
     Probe every backend that has a default model in ai-models.json.
@@ -48,7 +48,7 @@ function Test-AIBackendHealth {
     [OutputType([PSCustomObject])]
     param(
         [Parameter(Mandatory, ParameterSetName = 'One', Position = 0)]
-        [ValidateSet('gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama')]
+        [ValidateSet('gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'xai', 'ollama')]
         [string]$Backend,
 
         [Parameter(Mandatory, ParameterSetName = 'All')]

--- a/taxonomy-editor/src/main/__tests__/apiKeyStore.test.ts
+++ b/taxonomy-editor/src/main/__tests__/apiKeyStore.test.ts
@@ -178,7 +178,7 @@ describe('full-backend coverage (t/1957 — zai/moonshot were silently omitted)'
   // so deleteAllApiKeys left those keys on disk).
   const FAKE_KEYS: Record<ApiKeyBackend, string> = {
     gemini: 'k-gemini', claude: 'k-claude', groq: 'k-groq', openai: 'k-openai', azure: 'k-azure',
-    ollama: 'k-ollama', deepseek: 'k-deepseek', zai: 'k-zai', moonshot: 'k-moonshot', tavily: 'k-tavily',
+    ollama: 'k-ollama', deepseek: 'k-deepseek', zai: 'k-zai', moonshot: 'k-moonshot', xai: 'k-xai', tavily: 'k-tavily',
   };
   const ALL = Object.keys(FAKE_KEYS) as ApiKeyBackend[];
 

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/settingsSlice.ts
@@ -20,7 +20,7 @@ const DEFAULT_COMMUNITY_SERVER_URL = 'https://taxonomy-editor.yellowbush-aeda037
 
 export type ColorScheme = 'light' | 'dark' | 'bkc' | 'harvard' | 'system';
 
-export type AIBackend = 'gemini' | 'claude' | 'groq' | 'openai' | 'deepseek' | 'azure' | 'ollama' | 'zai' | 'moonshot';
+export type AIBackend = 'gemini' | 'claude' | 'groq' | 'openai' | 'deepseek' | 'azure' | 'ollama' | 'zai' | 'moonshot' | 'xai';
 
 export type GeminiModel =
   | typeof DEFAULT_MODEL
@@ -67,7 +67,10 @@ export type ZAIModel =
 export type MoonshotModel =
   | 'moonshot-kimi-k3';
 
-export type AIModel = GeminiModel | ClaudeModel | GroqModel | OpenAIModel | DeepSeekModel | AzureModel | OllamaModel | ZAIModel | MoonshotModel;
+export type XAIModel =
+  | 'xai-grok-4-6';
+
+export type AIModel = GeminiModel | ClaudeModel | GroqModel | OpenAIModel | DeepSeekModel | AzureModel | OllamaModel | ZAIModel | MoonshotModel | XAIModel;
 
 export interface AIModelEntry { value: AIModel; label: string }
 
@@ -83,6 +86,7 @@ export const AI_BACKENDS: { value: AIBackend; label: string }[] = [
   { value: 'ollama', label: 'Ollama (Local)' },
   { value: 'zai', label: 'Z.AI (GLM)' },
   { value: 'moonshot', label: 'Moonshot AI (Kimi)' },
+  { value: 'xai', label: 'xAI (Grok)' },
 ];
 
 export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
@@ -127,6 +131,9 @@ export const MODELS_BY_BACKEND: Record<AIBackend, AIModelEntry[]> = {
   moonshot: [
     { value: 'moonshot-kimi-k3', label: 'Kimi K3' },
   ],
+  xai: [
+    { value: 'xai-grok-4-6', label: 'Grok 4.6' },
+  ],
 };
 
 /** @deprecated Use MODELS_BY_BACKEND.gemini instead */
@@ -146,6 +153,7 @@ const DEFAULT_MODELS: Record<AIBackend, AIModel> = {
   ollama: 'ollama-gemma4-e4b-it-q4-k-m',
   zai: 'zai-glm-5-2',
   moonshot: 'moonshot-kimi-k3',
+  xai: 'xai-grok-4-6',
 };
 
 export let DEBATE_TIERS: Record<string, Record<string, string>> = {};
@@ -153,7 +161,7 @@ export let FALLBACK_CHAINS: Record<string, string[]> = {};
 
 // -- Module-level helpers --
 
-const KNOWN_BACKENDS: ReadonlySet<AIBackend> = new Set(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'ollama', 'zai', 'moonshot']);
+const KNOWN_BACKENDS: ReadonlySet<AIBackend> = new Set(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'ollama', 'zai', 'moonshot', 'xai']);
 
 export function isKnownBackend(id: string): id is AIBackend {
   return (KNOWN_BACKENDS as ReadonlySet<string>).has(id);
@@ -239,6 +247,7 @@ export function backendForModel(model: string): AIBackend | undefined {
   if (model.startsWith('ollama')) return 'ollama';
   if (model.startsWith('zai')) return 'zai';
   if (model.startsWith('moonshot')) return 'moonshot';
+  if (model.startsWith('xai')) return 'xai';
   return undefined;
 }
 

--- a/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
+++ b/taxonomy-editor/src/server/__tests__/runtimeConfig.test.ts
@@ -26,8 +26,8 @@ describe('getDefaults (t/926)', () => {
     expect(d.resilience.throttleEnterFactor).toBe(2.0);
     expect(d.tiers.free.pinnedModel).toBe('gemini-flash-lite-latest');
     // t/1513: platform/byok expose every system backend; key-presence gates real availability.
-    expect(d.tiers.platform.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama']);
-    expect(d.tiers.byok.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama']);
+    expect(d.tiers.platform.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'xai', 'ollama']);
+    expect(d.tiers.byok.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'xai', 'ollama']);
     expect(d.tiers.anonymous.allowedBackends).toEqual(['gemini', 'claude', 'groq']); // intentionally limited (no user keys)
     expect(d.flightRecorder.maxTotalDumpSizeBytes).toBe(52_428_800);
     expect(d.server.gitFetchTimeoutMs).toBe(600_000);
@@ -169,7 +169,7 @@ describe('validateAndMerge — allowedBackends', () => {
 
   it('falls back to default on an empty array', () => {
     const { config, errors } = validateAndMerge({ tiers: { byok: { allowedBackends: [] } } }, defaults());
-    expect(config.tiers.byok.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama']);
+    expect(config.tiers.byok.allowedBackends).toEqual(['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'xai', 'ollama']);
     expect(errors.some(e => e.includes('non-empty array'))).toBe(true);
   });
 

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -349,7 +349,7 @@ function buildGenerateOptions(
 
 // No key for any model in the chain — throw a backend-named ActionableError.
 function throwNoApiKeyError(backend: string, modelsToTry: string[]): never {
-  const names: Record<string, string> = { gemini: 'Gemini', claude: 'Claude', groq: 'Groq', openai: 'OpenAI', tavily: 'Tavily', deepseek: 'DeepSeek', moonshot: 'Moonshot (Kimi)' };
+  const names: Record<string, string> = { gemini: 'Gemini', claude: 'Claude', groq: 'Groq', openai: 'OpenAI', tavily: 'Tavily', deepseek: 'DeepSeek', moonshot: 'Moonshot (Kimi)', xai: 'xAI (Grok)' };
   const backendName = names[backend] ?? backend;
   throw new ActionableError({
     goal: `Generate text via ${backendName}`,

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -157,6 +157,7 @@ const ENV_KEY_NAMES: Record<AIBackend, string> = {
   azure: 'AZURE_OPENAI_API_KEY', // t/945 build-fix; actual Azure-backend wiring owned elsewhere
   zai: 'ZAI_API_KEY',
   moonshot: 'MOONSHOT_API_KEY', // t/1934 build-fix; matches lib/debate/aiAdapter.ts key map
+  xai: 'XAI_API_KEY', // t/2583; xAI Grok — matches lib/debate/aiAdapter.ts key map
 };
 
 // Imported after AIBackend is defined (keyStore depends on the type).

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -62,6 +62,7 @@ const BACKEND_DISPLAY: Record<AIBackend, string> = {
   gemini: 'Gemini', claude: 'Claude (Anthropic)', groq: 'Groq',
   openai: 'OpenAI', deepseek: 'DeepSeek', tavily: 'Tavily', ollama: 'Ollama',
   azure: 'Azure OpenAI', zai: 'Z.AI (GLM)', moonshot: 'Moonshot (Kimi)',
+  xai: 'xAI (Grok)',
 };
 
 // ── POST /api/ai/generate guard/step helpers (extracted from the handler, ADR-007)

--- a/taxonomy-editor/src/server/routes/keys.ts
+++ b/taxonomy-editor/src/server/routes/keys.ts
@@ -70,6 +70,7 @@ export const KEY_VALIDATION_PROBES: Record<string, KeyProbe> = {
   deepseek: key => fetch('https://api.deepseek.com/v1/models', { headers: { Authorization: `Bearer ${key}` } }),
   zai: key => fetch('https://api.z.ai/api/paas/v4/models', { headers: { Authorization: `Bearer ${key}` } }),
   moonshot: key => fetch('https://api.moonshot.ai/v1/models', { headers: { Authorization: `Bearer ${key}` } }),
+  xai: key => fetch('https://api.x.ai/v1/models', { headers: { Authorization: `Bearer ${key}` } }),
 };
 
 // t/1620 origin, t/1624 promotion: the provider-error decoders (extractProviderReason

--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -131,7 +131,7 @@ export interface RuntimeConfig {
 // Mirror of the backend ids in ai-models.json (t/1513). Used to validate admin
 // overrides of tier allowedBackends — must include every backend the system can
 // route to, or valid overrides get silently dropped by vBackends().
-export const KNOWN_BACKENDS = ['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'ollama'] as const;
+export const KNOWN_BACKENDS = ['gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'xai', 'ollama'] as const;
 
 // Range bounds (spec §3.2).
 const DURATION_MAX = 86_400_000; // 24h

--- a/tests/Invoke-AIApi.Xai.Tests.ps1
+++ b/tests/Invoke-AIApi.Xai.Tests.ps1
@@ -1,0 +1,117 @@
+# Tag: enrichment (t/2583)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    xAI (Grok) dispatch regression tests (t/2583).
+.DESCRIPTION
+    Pure-PS assertions (parameter surface, EnvVarMap wiring, context window,
+    Resolve-AIApiKey resolution) always run. Live round-trip tests self-skip
+    with an ALARMING reason when $env:XAI_API_KEY isn't set — mirroring the
+    t/1936 Moonshot / t/1437 z.ai pattern so a CI regression can't quietly
+    pass-by-skip.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+    $EnrichPath = Join-Path $PSScriptRoot '..' 'scripts' 'AIEnrich.psm1'
+    Import-Module $EnrichPath -Force -WarningAction SilentlyContinue
+
+    $script:HasXaiKey  = -not [string]::IsNullOrWhiteSpace($env:XAI_API_KEY)
+    $script:SkipReason = 'XAI_API_KEY not set — XAI LIVE GUARD NOT RUN (CI regression? owner-provisioned key needed)'
+}
+
+Describe 'xAI wiring — pure-PS shape checks (t/2583)' -Tag 'enrichment' {
+
+    It 'Test-AIApiKey ValidateSet includes xai' {
+        $cmd = Get-Command Test-AIApiKey -Module AITriad
+        $vs = $cmd.Parameters['Backend'].Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+        $vs.ValidValues | Should -Contain 'xai'
+    }
+
+    It 'AIEnrich ContextWindows registers xai at 500,000 tokens' {
+        InModuleScope AIEnrich {
+            $script:ContextWindows.ContainsKey('xai') | Should -Be $true
+            $script:ContextWindows['xai']             | Should -Be 500000
+        }
+    }
+
+    It 'Resolve-AIApiKey -Backend xai reads $env:XAI_API_KEY (or falls back to $env:AI_API_KEY)' {
+        InModuleScope AIEnrich {
+            $saved = @{
+                XAI = $env:XAI_API_KEY
+                AI  = $env:AI_API_KEY
+            }
+            try {
+                $env:XAI_API_KEY = 'xai-test-key-marker-t2583'
+                $env:AI_API_KEY  = $null
+                $r = Resolve-AIApiKey -Backend 'xai'
+                $r | Should -Be 'xai-test-key-marker-t2583'
+                $script:LastApiKeySource | Should -Be '$env:XAI_API_KEY'
+            } finally {
+                $env:XAI_API_KEY = $saved.XAI
+                $env:AI_API_KEY  = $saved.AI
+            }
+        }
+    }
+
+    It 'Resolve-AIApiKey -Backend xai returns $null when neither XAI_API_KEY nor AI_API_KEY set' {
+        InModuleScope AIEnrich {
+            $saved = @{
+                XAI = $env:XAI_API_KEY
+                AI  = $env:AI_API_KEY
+            }
+            try {
+                $env:XAI_API_KEY = $null
+                $env:AI_API_KEY  = $null
+                $r = Resolve-AIApiKey -Backend 'xai'
+                $r | Should -BeNullOrEmpty
+            } finally {
+                $env:XAI_API_KEY = $saved.XAI
+                $env:AI_API_KEY  = $saved.AI
+            }
+        }
+    }
+
+    It 'xai-grok-4-6 resolves to the xai backend in the model registry' {
+        InModuleScope AIEnrich {
+            $script:ModelRegistry.ContainsKey('xai-grok-4-6') | Should -Be $true
+            $script:ModelRegistry['xai-grok-4-6'].Backend     | Should -Be 'xai'
+        }
+    }
+}
+
+Describe 'xAI live round-trip — requires XAI_API_KEY (t/2583 AC)' -Tag 'enrichment' {
+
+    It 'Test-AIApiKey -Backend xai returns Functional=$true when the key authenticates' {
+        if (-not $script:HasXaiKey) {
+            Set-ItResult -Skipped -Because $script:SkipReason
+            return
+        }
+        $r = Test-AIApiKey -Backend xai -TimeoutSec 15
+        $r.Backend    | Should -Be 'xai'
+        $r.Functional | Should -Be $true
+        $r.StatusCode | Should -Be 200
+        $r.KeySource  | Should -Match 'XAI_API_KEY|AI_API_KEY'
+    }
+
+    It 'Invoke-AIApi -Model xai-grok-4-6 -Prompt returns non-empty Text + usage counters' {
+        if (-not $script:HasXaiKey) {
+            Set-ItResult -Skipped -Because $script:SkipReason
+            return
+        }
+        $r = Invoke-AIApi -Model 'xai-grok-4-6' -Prompt 'Say hi in one short word.' -MaxTokens 200 -Temperature 0.1
+        $r                    | Should -Not -BeNullOrEmpty
+        $r.Backend            | Should -Be 'xai'
+        $r.Text               | Should -Not -BeNullOrEmpty
+        $r.Text.Trim().Length | Should -BeGreaterThan 0
+        $r.Usage              | Should -Not -BeNullOrEmpty
+        $r.Usage.InputTokens  | Should -BeGreaterThan 0
+        $r.Usage.OutputTokens | Should -BeGreaterThan 0
+        $r.Usage.TotalTokens  | Should -Be ($r.Usage.InputTokens + $r.Usage.OutputTokens)
+    }
+}


### PR DESCRIPTION
## Summary
Adds the **xAI (Grok 4.6)** backend (t/2583). xAI is OpenAI-compatible (`/chat/completions`, base `https://api.x.ai/v1`, `XAI_API_KEY`), so this is a mechanical clone of the `moonshot` backend across every coupling site.

- backend `xai`, model `xai-grok-4-6` → `apiModelId: grok-4.6` (dot — resolvability gate)
- 500K context, pricing $2/$6/$0.50 per 1M (in/out/cached)
- **Self-certified against `/add-ai-backend`** — no TL design review needed (OpenAI-compatible, no novel auth).

## Tier placement (PI decision — TL confirmed p/360#41, q/48)
Paid only: **platform + BYOK**, **NOT** anonymous/free. Adding `xai` to `KNOWN_BACKENDS` is the *only* tier wiring needed — `platform`/`byok` `allowedBackends` derive from `[...KNOWN_BACKENDS]`; `anonymous`/`free` are hardcoded and correctly exclude xai. (Verified in `runtimeConfig.test.ts`.)

## Coupling sites
Config (`ai-models.json`, 7 sections, byte-identical round-trip) · TS lib (`types.ts`, `registry.ts`, new `providers/xai.ts`, `client.ts`, `index.ts`, `aiAdapter.ts`) · TS server (`keys.ts`, `config.ts`, `runtimeConfig.ts`, `aiBackends.ts`, `routes/ai.ts`) · renderer (`settingsSlice.ts`) · PowerShell (`AIEnrich.psm1`, `Test-AIApiKey.ps1`, `Test-AIBackendHealth.ps1`) · test fixtures + new `tests/Invoke-AIApi.Xai.Tests.ps1`.

**Playbook gaps found** (not listed in `/add-ai-backend`, folded in here; will flag to owner): renderer `settingsSlice.ts`, `routes/ai.ts` display map, `Test-AIBackendHealth.ps1`.

## Verification (local, keys unset — CI-faithful)
- `verify:config` — **7/7 green**
- `tsc` main / server / renderer / lib-debate — **all clean**
- PS module builds (180 fns, manifest valid); Pester xAI wiring **5 pass**, live guards self-skip
- Fixed vitest fixtures (`allApiKeyBackends`, `backendEnvKeys`, `runtimeConfig`, `apiKeyStore`) — pass
- Two pre-existing local failures (`githubApi`, `t2020Security`) are the **undici major-skew** local-Node artifact (local 7.x vs CI node 22.x; t/2053/t/2113/t/2281) — untouched by this diff, green in CI.

## ⚠️ Hold — live-call AC pending
AC requires a **live grok-4.6 generation call**. No `XAI_API_KEY` is provisioned in this environment, so the live guards self-skip (mirroring moonshot t/1936). **Do not self-merge as AC-complete until** either (a) a key is provisioned and the live call is run, or (b) PI authorizes landing with the live-call deferred. Awaiting PI direction (q/48 follow-up).

Closes t/2583 (pending the live-call resolution above).
