### PR TITLE
feat(opeds): Op-Ed Studio PR#2 — create flow (NewOpEdDialog + 3-stage progress) (t/2576)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -5,7 +5,7 @@
  * Electron bridge — delegates every AppAPI method to window.electronAPI (IPC).
  * Used when the app runs inside Electron (desktop mode).
  */
-import type { AppAPI, UserPreferences } from './types';
+import type { AppAPI, UserPreferences, CreateOpEdPayload, OpEdProgressEvent } from './types';
 import { makeCancellationError } from './cancellation';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
@@ -33,6 +33,9 @@ type OpEdIpc = {
   loadOpEdSet?: (id: string) => Promise<OpEdSet>;
   saveOpEdSet?: (set: OpEdSet) => Promise<void>;
   deleteOpEdSet?: (id: string) => Promise<void>;
+  createOpEdSet?: (payload: CreateOpEdPayload) => Promise<{ set_id: string }>;
+  cancelOpEdSet?: (setId: string) => void;
+  onOpEdProgress?: (cb: (e: OpEdProgressEvent) => void) => () => void;
 };
 const opEdIpc = (): OpEdIpc => window.electronAPI as unknown as OpEdIpc;
 function rejectOpEdIpc(goal: string, method: string): Promise<never> {
@@ -266,6 +269,9 @@ export const api: AppAPI = {
   loadOpEdSet: (id) => opEdIpc().loadOpEdSet?.(id) ?? rejectOpEdIpc('load an op-ed', 'loadOpEdSet'),
   saveOpEdSet: (set) => opEdIpc().saveOpEdSet?.(set) ?? rejectOpEdIpc('save an op-ed', 'saveOpEdSet'),
   deleteOpEdSet: (id) => opEdIpc().deleteOpEdSet?.(id) ?? rejectOpEdIpc('delete an op-ed', 'deleteOpEdSet'),
+  createOpEdSet: (payload) => opEdIpc().createOpEdSet?.(payload) ?? rejectOpEdIpc('create an op-ed', 'createOpEdSet'),
+  cancelOpEdSet: (setId) => { opEdIpc().cancelOpEdSet?.(setId); },
+  onOpEdProgress: (cb) => opEdIpc().onOpEdProgress?.(cb) ?? (() => {}),
 
   // News Report
   generateNewsReport: (debateId) => window.electronAPI.generateNewsReport(debateId),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -82,7 +82,27 @@ export type DebateTestedEntry = _DebateTestedEntry;
 import type { DebateDelta as _DebateDelta } from '@lib/debate/types';
 export type DebateDelta = _DebateDelta;
 
-import type { OpEdSet } from '../../../../lib/oped/types';
+import type { OpEdSet, PovKey } from '../../../../lib/oped/types';
+
+/** Op-Ed generation params (PR#2) — maps to New-OpEd cmdlet params; topic + voices
+ *  travel separately in the payload (one New-OpEd call per selected voice). */
+export interface CreateOpEdParams {
+  url?: string;
+  outlet?: string;
+  wordCount?: number;
+  newsHook?: string;
+  thesis?: string;
+  authorBio?: string;
+  model?: string;
+  temperature?: number;
+  maxGroundingNodes?: number;
+  maxSituations?: number;
+  includePitch?: boolean;
+  voiceOnly?: boolean;
+}
+export interface CreateOpEdPayload { topic: string; params: CreateOpEdParams; voices: PovKey[] }
+/** One 3-stage progress tick from the Electron generation IPC (t/2575 `oped-progress`). */
+export interface OpEdProgressEvent { set_id: string; voice: string; stage: string; error?: string }
 
 import type { EdgesFile as _EdgesFile } from '@lib/debate/taxonomyTypes';
 export type EdgesFile = _EdgesFile;
@@ -276,6 +296,10 @@ export interface AppAPI {
   loadOpEdSet: (id: string) => Promise<OpEdSet>;
   saveOpEdSet: (set: OpEdSet) => Promise<void>;
   deleteOpEdSet: (id: string) => Promise<void>;
+  // PR#2 create flow — Electron-only (New-OpEd is PowerShell); web rejects with a desktop-only error.
+  createOpEdSet: (payload: CreateOpEdPayload) => Promise<{ set_id: string }>;
+  cancelOpEdSet: (setId: string) => void;
+  onOpEdProgress: (callback: (event: OpEdProgressEvent) => void) => () => void;
 
   // --- News Report ---
   generateNewsReport: (debateId: string) => Promise<{ article: string }>;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -1016,13 +1016,21 @@ const rawApi: AppAPI = {
   loadDebateComments: (id) => get(`/api/debates/${encodeURIComponent(id)}/comments`),
   saveDebateComments: (id, data) => put(`/api/debates/${encodeURIComponent(id)}/comments`, data).then(() => {}),
 
-  // Op-Ed Studio (t/2576) — real routes against t/2573's server API. Those routes
-  // are not merged yet, so these calls surface an honest normalized 404 until they
-  // land (no stub module to swap out — the wiring lights up when t/2573 ships).
+  // Op-Ed Studio (t/2576) — real routes against t/2573's server API (now on main).
   listOpEdSets: () => get<OpEdSet[]>('/api/opeds'),
   loadOpEdSet: (id) => get<OpEdSet>(`/api/opeds/${encodeURIComponent(id)}`),
   saveOpEdSet: (set) => put('/api/opeds', set).then(() => {}),
   deleteOpEdSet: (id) => del(`/api/opeds/${encodeURIComponent(id)}`).then(() => {}),
+  // PR#2 create flow is Electron-only (New-OpEd is PowerShell; v1 has no web generation
+  // route — server confirms). Web rejects honestly; the UI shows a "desktop app" affordance.
+  createOpEdSet: () => Promise.reject(new ActionableError({
+    goal: 'Op-Ed Studio: create an op-ed',
+    problem: 'Op-ed generation runs the New-OpEd PowerShell cmdlet, available only in the desktop app.',
+    location: 'web-bridge · Op-Ed Studio',
+    nextSteps: ['Open the desktop app to draft op-eds.', 'You can still browse, share, and copy community op-eds here.'],
+  })),
+  cancelOpEdSet: () => { /* no-op: web has no in-flight generation to cancel */ },
+  onOpEdProgress: () => () => {}, // web has no generation progress stream
   exportDebateToFile: async (session, format = 'json', exportOptions) => {
     const { debateToText, debateToMarkdown, debateToHtml, debateToPackage, debateExportFilename } = await import('@lib/debate/debateExport');
     const debate = session as Parameters<typeof debateToText>[0] & { diagnostics?: unknown };

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.css
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.css
@@ -1,0 +1,421 @@
+/* NewOpEdDialog.css — Op-Ed Studio create flow (t/2576 PR#2, §5). Tokens only —
+   no hard-coded colors; theme-aware across light / dark / bkc / harvard. Mirrors
+   NewDebateDialog's two-screen chrome with an `oped-` prefix (styles.css frozen). */
+
+/* ── Screen A dialog shell ─────────────────────────────────────────────────── */
+
+.oped-dialog {
+  background: var(--bg-primary, var(--bg-secondary));
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  width: 560px;
+  max-width: calc(100vw - 2rem);
+  max-height: calc(100vh - 3rem);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.oped-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.9rem 1.1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.oped-dialog-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.oped-close-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 1.4rem;
+  line-height: 1;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
+.oped-close-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+.oped-close-btn:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
+
+.oped-dialog-body {
+  padding: 1rem 1.1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+/* ── Fields ────────────────────────────────────────────────────────────────── */
+
+.oped-field-label {
+  display: block;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+  color: var(--text-primary);
+}
+
+.oped-required-mark { color: var(--danger, var(--warning)); }
+
+.oped-inline-hint { font-weight: 400; font-size: 0.75rem; color: var(--text-muted); }
+
+.oped-field-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 0.3rem 0 0;
+  line-height: 1.4;
+}
+
+.oped-input,
+.oped-textarea,
+.oped-select {
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  font: inherit;
+  font-size: 0.875rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary, transparent);
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+
+.oped-textarea { resize: none; line-height: 1.45; }
+
+.oped-input:focus,
+.oped-textarea:focus,
+.oped-select:focus {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 0;
+  border-color: var(--focus-ring);
+}
+
+/* Topic / URL toggle */
+.oped-source-toggle {
+  background: none;
+  border: none;
+  color: var(--link-color, var(--text-secondary));
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 0.15rem 0;
+  text-align: left;
+  align-self: flex-start;
+}
+.oped-source-toggle:hover { text-decoration: underline; }
+.oped-source-toggle:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
+
+.oped-signin-note {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 0.3rem 0 0;
+}
+
+/* ── Voice chips (multi-select) ────────────────────────────────────────────── */
+
+.oped-voice-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.oped-voice-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--bg-secondary, transparent);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+}
+
+.oped-voice-chip:hover { background: var(--bg-hover); }
+.oped-voice-chip:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
+
+.oped-voice-chip[aria-pressed="true"] {
+  border-color: currentColor;
+  color: var(--text-primary);
+  background: var(--bg-hover);
+  font-weight: 600;
+}
+
+.oped-voice-chip-glyph { display: inline-flex; }
+
+.oped-voice-count {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 0.4rem 0 0;
+  line-height: 1.4;
+}
+
+.oped-hint-error {
+  font-size: 0.75rem;
+  color: var(--danger, var(--warning));
+  margin-top: 0.3rem;
+}
+
+/* ── More options / pitch footer ───────────────────────────────────────────── */
+
+.oped-more-options-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  padding: 0.2rem 0;
+  text-align: left;
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.oped-more-options-btn:hover { color: var(--text-primary); }
+.oped-more-options-btn:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
+
+.oped-change-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.1rem;
+  height: 1.1rem;
+  padding: 0 0.3rem;
+  border-radius: 999px;
+  background: var(--focus-ring, var(--text-secondary));
+  color: var(--bg-primary, #fff);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.oped-pitch-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+}
+
+/* ── Footer ────────────────────────────────────────────────────────────────── */
+
+.oped-dialog-footer {
+  border-top: 1px solid var(--border-color);
+  padding: 0.75rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.oped-footer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.oped-footer-right { display: flex; gap: 0.5rem; }
+
+.oped-start-error {
+  border: 1px solid var(--danger, var(--warning));
+  border-radius: 4px;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  background: var(--bg-secondary, transparent);
+}
+
+.oped-start-error-problem { font-weight: 600; }
+
+.oped-start-error-steps {
+  margin: 0.35rem 0 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+/* ── Settings drawer (Screen B) ────────────────────────────────────────────── */
+
+.oped-settings-dialog {
+  background: var(--bg-primary, var(--bg-secondary));
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  width: 680px;
+  max-width: calc(100vw - 2rem);
+  max-height: calc(100vh - 3rem);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+
+.oped-settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.9rem 1.1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.oped-settings-title { margin: 0; font-size: 1.05rem; font-weight: 600; }
+
+.oped-settings-layout {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+}
+
+.oped-settings-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 0.6rem;
+  gap: 0.15rem;
+  border-right: 1px solid var(--border-color);
+  min-width: 160px;
+}
+
+.oped-settings-nav-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8125rem;
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+}
+
+.oped-settings-nav-item:hover { background: var(--bg-hover); }
+.oped-settings-nav-item.active { background: var(--bg-hover); color: var(--text-primary); font-weight: 600; }
+.oped-settings-nav-item:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: -2px; }
+
+.oped-nav-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--focus-ring, var(--text-secondary));
+  flex-shrink: 0;
+}
+
+.oped-settings-body {
+  flex: 1;
+  padding: 1rem 1.1rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  min-width: 0;
+}
+
+.oped-settings-section-title { margin: 0 0 0.2rem; font-size: 0.95rem; font-weight: 600; }
+
+.oped-settings-field { display: flex; flex-direction: column; }
+
+.oped-settings-toggle-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+.oped-toggle-name { display: block; font-weight: 600; }
+.oped-toggle-help { display: block; font-size: 0.75rem; color: var(--text-muted); margin-top: 0.1rem; }
+
+.oped-model-row { display: flex; gap: 0.5rem; align-items: flex-end; }
+.oped-model-field { flex: 1; }
+
+.oped-refresh-btn {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  padding: 0.4rem 0.6rem;
+  white-space: nowrap;
+}
+.oped-refresh-btn:hover:not(:disabled) { background: var(--bg-hover); color: var(--text-primary); }
+.oped-refresh-btn:disabled { opacity: 0.6; cursor: default; }
+
+.oped-settings-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-top: 1px solid var(--border-color);
+  padding: 0.75rem 1.1rem;
+}
+
+.oped-settings-footer-right { display: flex; gap: 0.5rem; }
+
+/* ── Generating / progress panel (§5.2) ────────────────────────────────────── */
+
+.oped-progress-panel {
+  padding: 1.25rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.oped-progress-heading { margin: 0; font-size: 0.95rem; font-weight: 600; }
+
+.oped-progress-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.oped-progress-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.oped-progress-voice {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  min-width: 7.5rem;
+}
+
+.oped-progress-stage { color: var(--text-secondary); }
+
+.oped-progress-item[data-state="failed"] { border-color: var(--danger, var(--warning)); }
+.oped-progress-item[data-state="failed"] .oped-progress-stage { color: var(--danger, var(--warning)); }
+.oped-progress-item[data-state="complete"] .oped-progress-stage { color: var(--success, var(--color-acc, var(--text-primary))); }
+
+.oped-progress-notice {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.oped-progress-actions { display: flex; justify-content: flex-end; }
+
+/* Reduced-motion: no animated spinner is used; the panel is static text updates. */

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.test.tsx
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { NewOpEdDialog } from './NewOpEdDialog';
+
+// ── Bridge / hook mocks ───────────────────────────────────────────────────────
+
+type ProgressEvent = { set_id: string; voice: string; stage: string; error?: string };
+
+const h = vi.hoisted(() => {
+  const state: { cb: ((e: ProgressEvent) => void) | null } = { cb: null };
+  return {
+    state,
+    hasApiKey: vi.fn().mockResolvedValue(true),
+    createOpEdSet: vi.fn(),
+    cancelOpEdSet: vi.fn(),
+    refreshAIModels: vi.fn().mockResolvedValue(undefined),
+    onOpEdProgress: vi.fn((cb: (e: ProgressEvent) => void) => {
+      state.cb = cb;
+      return () => { state.cb = null; };
+    }),
+  };
+});
+
+const { hasApiKey, createOpEdSet, cancelOpEdSet, onOpEdProgress } = h;
+const fireProgress = (e: ProgressEvent) => h.state.cb?.(e);
+
+vi.mock('@bridge', () => ({
+  api: {
+    hasApiKey: h.hasApiKey,
+    createOpEdSet: h.createOpEdSet,
+    cancelOpEdSet: h.cancelOpEdSet,
+    refreshAIModels: h.refreshAIModels,
+    onOpEdProgress: h.onOpEdProgress,
+  },
+  isElectronMode: () => true,
+}));
+
+vi.mock('../../hooks/useAuthStatus', () => ({
+  useAuthStatus: () => ({ user: 'u', anonymous: false, idp: 'github' }),
+}));
+
+function open(props: Partial<Parameters<typeof NewOpEdDialog>[0]> = {}) {
+  return render(
+    <NewOpEdDialog open onClose={vi.fn()} onCreated={vi.fn()} {...props} />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hasApiKey.mockResolvedValue(true);
+  h.state.cb = null;
+});
+
+describe('NewOpEdDialog — visibility', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(<NewOpEdDialog open={false} onClose={vi.fn()} onCreated={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the create dialog when open', () => {
+    open();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('New op-ed')).toBeTruthy();
+  });
+});
+
+describe('NewOpEdDialog — voices + live count', () => {
+  it('shows the empty prompt then the 1-op-ed line', () => {
+    open();
+    expect(screen.getByText('Select at least one voice.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Safetyist' }));
+    expect(screen.getByText('Will create 1 op-ed — Safetyist.')).toBeTruthy();
+  });
+
+  it('shows the multi-voice line and relabels the submit button', () => {
+    open();
+    fireEvent.click(screen.getByRole('button', { name: 'Safetyist' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skeptic' }));
+    expect(screen.getByText(/Will create 2 op-eds on the same topic/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Draft 2 op-eds' })).toBeTruthy();
+  });
+
+  it('marks a selected chip aria-pressed', () => {
+    open();
+    const chip = screen.getByRole('button', { name: 'Skeptic' });
+    expect(chip.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(chip);
+    expect(chip.getAttribute('aria-pressed')).toBe('true');
+  });
+});
+
+describe('NewOpEdDialog — Draft enablement', () => {
+  it('disables Draft without a topic or voice, enables it with both', () => {
+    open();
+    const draft = () => screen.getByRole('button', { name: /Draft/ });
+    expect((draft() as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText(/Topic/), { target: { value: 'Mandatory audits' } });
+    expect((draft() as HTMLButtonElement).disabled).toBe(true); // still no voice
+    fireEvent.click(screen.getByRole('button', { name: 'Safetyist' }));
+    expect((draft() as HTMLButtonElement).disabled).toBe(false);
+  });
+});
+
+describe('NewOpEdDialog — topic / URL toggle', () => {
+  it('swaps the topic textarea for a URL input and back', () => {
+    open();
+    expect(screen.getByLabelText(/Topic/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /From a web page instead/ }));
+    expect(screen.getByLabelText(/Web page URL/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Use a topic instead/ }));
+    expect(screen.getByLabelText(/Topic/)).toBeTruthy();
+  });
+});
+
+describe('NewOpEdDialog — settings drawer', () => {
+  it('opens the More options drawer and applies changes', () => {
+    open();
+    fireEvent.click(screen.getByRole('button', { name: /More options/ }));
+    expect(screen.getByRole('dialog', { name: 'More options' })).toBeTruthy();
+    // Angle section is reachable
+    fireEvent.click(screen.getByRole('button', { name: 'Angle' }));
+    fireEvent.change(screen.getByLabelText('Thesis'), { target: { value: 'Audits are the floor' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+    // Back on Screen A the modified badge reflects one changed section
+    expect(screen.getByLabelText(/1 setting changed/)).toBeTruthy();
+  });
+});
+
+describe('NewOpEdDialog — draft + progress + cancel', () => {
+  it('creates, subscribes to progress, and reports the new set id', async () => {
+    let resolveCreate!: (v: { set_id: string }) => void;
+    createOpEdSet.mockReturnValue(new Promise<{ set_id: string }>(res => { resolveCreate = res; }));
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    open({ onCreated, onClose });
+
+    fireEvent.change(screen.getByLabelText(/Topic/), { target: { value: 'Mandatory audits' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Safetyist' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft op-ed' }));
+
+    // Progress panel appears and the subscription is active.
+    expect(screen.getByText('Drafting your op-ed…')).toBeTruthy();
+    expect(onOpEdProgress).toHaveBeenCalledTimes(1);
+
+    // A progress tick renders the voice's stage.
+    act(() => { fireProgress({ set_id: 'set-9', voice: 'safetyist', stage: 'generating' }); });
+    expect(screen.getByText('Writing the Safetyist op-ed')).toBeTruthy();
+
+    await act(async () => { resolveCreate({ set_id: 'set-9' }); });
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith('set-9'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Cancel aborts the run with the id from the first progress event', async () => {
+    createOpEdSet.mockReturnValue(new Promise<{ set_id: string }>(() => { /* never resolves */ }));
+    open();
+
+    fireEvent.change(screen.getByLabelText(/Topic/), { target: { value: 'Mandatory audits' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Safetyist' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft op-ed' }));
+
+    act(() => { fireProgress({ set_id: 'set-42', voice: 'safetyist', stage: 'queued' }); });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(cancelOpEdSet).toHaveBeenCalledWith('set-42');
+  });
+
+  it('surfaces an ActionableError Next Steps list on failure', async () => {
+    createOpEdSet.mockRejectedValue(Object.assign(new Error('boom'), {
+      problem: 'The generator could not be reached.',
+      nextSteps: ['Check that PowerShell is installed', 'Retry in a moment'],
+    }));
+    open();
+
+    fireEvent.change(screen.getByLabelText(/Topic/), { target: { value: 'Mandatory audits' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Safetyist' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft op-ed' }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(screen.getByText('The generator could not be reached.')).toBeTruthy();
+    expect(screen.getByText('Check that PowerShell is installed')).toBeTruthy();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
@@ -1,0 +1,873 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// NewOpEdDialog — Op-Ed Studio create flow (t/2576 PR#2, §5). Two screens mirroring
+// NewDebateDialog: Screen A is the essential form (topic/url, multi-select voices,
+// outlet, news hook, pitch); Screen B is the "More options" settings drawer. On Draft
+// the dialog shows a live progress panel (not a spinner) fed by api.onOpEdProgress and
+// finalizes by opening the created set in the reader. The bridge trio (createOpEdSet /
+// cancelOpEdSet / onOpEdProgress) is Electron-only; web keeps the disabled affordance.
+
+import { useState, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
+import type { TextareaHTMLAttributes, RefObject } from 'react';
+import { api } from '@bridge';
+import type { CreateOpEdParams, CreateOpEdPayload, OpEdProgressEvent } from '../../bridge/types';
+import type { PovKey } from '../../../../../lib/oped/types';
+import { POV_META } from '@lib/electron-shared/povMeta';
+import { POV_KEYS } from '@lib/debate/types';
+import { CampGlyph, povToCamp } from '../shared/CampGlyph';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import {
+  AI_BACKENDS, MODELS_BY_BACKEND, backendForModelWithFallback, initAIModels, useTaxonomyStore, type AIBackend,
+} from '../../hooks/useTaxonomyStore';
+import { useTierInfo, isFreeTier, type TierInfo } from '../../hooks/useTierInfo';
+import { useAuthStatus } from '../../hooks/useAuthStatus';
+import './NewOpEdDialog.css';
+
+// ── Outlets (mirror New-OpEd.ps1 ValidateSet + band hints) ────────────────────
+
+const OUTLETS: { value: string; label: string; band: string }[] = [
+  { value: 'WashingtonPost',    label: 'The Washington Post',   band: '~800 words, strong news hook' },
+  { value: 'NYTimes',           label: 'The New York Times',    band: '~800 words, sharp thesis' },
+  { value: 'WallStreetJournal', label: 'The Wall Street Journal', band: '600–1200 words, business/policy framing' },
+  { value: 'USAToday',          label: 'USA Today',             band: '550–750 words, plain and direct' },
+  { value: 'ForeignAffairs',    label: 'Foreign Affairs',       band: '800–1500 words, structural analysis' },
+  { value: 'Politico',          label: 'Politico',              band: '~1000 words, policy-mechanics focus' },
+  { value: 'Regional',          label: 'Regional / local daily', band: '500–800 words, local relevance' },
+  { value: 'Generic',           label: 'Generic',               band: '~800 words, strong news hook' },
+];
+
+// ── Screen-B defaults (must equal New-OpEd's parameter defaults) ──────────────
+
+const DEFAULTS = {
+  outlet: 'Generic',
+  wordCount: null as number | null, // null ⇒ use the outlet band (cmdlet default)
+  thesis: '',
+  authorBio: '',
+  ground: true,                     // off ⇒ params.voiceOnly = true
+  maxGroundingNodes: 12,
+  maxSituations: 3,
+  temperature: 0.8,
+};
+
+const OPED_EXCLUDED_BACKENDS = new Set(['ollama']);
+
+// ── Focus trap (mirror of NewDebateDialog's local useFocusTrap) ───────────────
+
+function useFocusTrap(ref: RefObject<HTMLElement | null>, active: boolean) {
+  useEffect(() => {
+    if (!active || !ref.current) return;
+    const el = ref.current;
+    const getFocusable = () => Array.from(
+      el.querySelectorAll<HTMLElement>(
+        'button:not([disabled]),[href],input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusable();
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+      } else {
+        if (document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    };
+    el.addEventListener('keydown', onKeyDown);
+    return () => el.removeEventListener('keydown', onKeyDown);
+  }, [active, ref]);
+}
+
+function AutoGrowTextarea({
+  value, maxHeight = 200, ...props
+}: TextareaHTMLAttributes<HTMLTextAreaElement> & { maxHeight?: number }) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+    el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }, [value, maxHeight]);
+  return <textarea ref={ref} value={value} {...props} />;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function computeActiveModel(freeTier: boolean, tierInfo: TierInfo | null, model: string): string {
+  return freeTier && tierInfo?.pinnedModel ? tierInfo.pinnedModel : model;
+}
+
+function computeModelHasKey(hasApiKey: Record<string, boolean>, backend: string, freeTier: boolean, tierInfo: TierInfo | null): boolean {
+  if (OPED_EXCLUDED_BACKENDS.has(backend)) return false;
+  return hasApiKey[backend] !== false || (freeTier && !!tierInfo && tierInfo.allowedBackends.includes(backend));
+}
+
+function voiceLabels(voices: PovKey[]): string {
+  return voices.map(v => POV_META[v].label).join(', ');
+}
+
+function voiceCountLine(voices: PovKey[]): string {
+  if (voices.length === 0) return 'Select at least one voice.';
+  if (voices.length === 1) return `Will create 1 op-ed — ${voiceLabels(voices)}.`;
+  return `Will create ${voices.length} op-eds on the same topic — ${voiceLabels(voices)} — shown in tabs.`;
+}
+
+/** Normalize a thrown error to the ActionableError shape (Goal/Problem/Location/Next Steps). */
+interface ActionableShape { goal?: string; problem: string; location?: string; nextSteps: string[]; }
+function toActionable(err: unknown): ActionableShape {
+  const e = err as { goal?: string; problem?: string; location?: string; nextSteps?: unknown; message?: string };
+  if (e && Array.isArray(e.nextSteps)) {
+    return { goal: e.goal, problem: e.problem ?? e.message ?? 'The op-ed could not be created.', location: e.location, nextSteps: e.nextSteps as string[] };
+  }
+  return { problem: err instanceof Error ? err.message : String(err), nextSteps: [] };
+}
+
+const STAGE_LABELS: Record<string, string> = {
+  queued: 'Queued',
+  fetching: 'Fetching the web page',
+  grounding: 'Retrieving grounding',
+  generating: 'Writing the op-ed',
+  finalizing: 'Mapping grounding across drafts',
+  complete: 'Done',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+};
+
+function stageLabel(pov: PovKey, stage: string, error?: string): string {
+  if (stage === 'generating') return `Writing the ${POV_META[pov]?.label ?? pov} op-ed`;
+  if (stage === 'failed') return error ? `Failed — ${error}` : 'Failed';
+  return STAGE_LABELS[stage] ?? stage;
+}
+
+// ── Screen B — settings drawer (mirror DebateSettingsDialog) ──────────────────
+
+export interface OpEdSettingsValues {
+  outlet: string;
+  wordCount: number | null;
+  thesis: string;
+  authorBio: string;
+  ground: boolean;
+  maxGroundingNodes: number;
+  maxSituations: number;
+  model: string;
+  temperature: number;
+}
+
+type SettingsSection = 'length' | 'angle' | 'grounding' | 'model';
+
+const SETTINGS_SECTIONS: { id: SettingsSection; label: string }[] = [
+  { id: 'length',    label: 'Length & outlet' },
+  { id: 'angle',     label: 'Angle' },
+  { id: 'grounding', label: 'Grounding' },
+  { id: 'model',     label: 'Model' },
+];
+
+function sectionHasDiff(section: SettingsSection, s: OpEdSettingsValues, globalModel: string): boolean {
+  switch (section) {
+    case 'length':    return s.outlet !== DEFAULTS.outlet || s.wordCount !== DEFAULTS.wordCount;
+    case 'angle':     return s.thesis !== DEFAULTS.thesis || s.authorBio !== DEFAULTS.authorBio;
+    case 'grounding': return s.ground !== DEFAULTS.ground || s.maxGroundingNodes !== DEFAULTS.maxGroundingNodes || s.maxSituations !== DEFAULTS.maxSituations;
+    case 'model':     return s.model !== globalModel || s.temperature !== DEFAULTS.temperature;
+  }
+}
+
+function OpEdSettingsDrawer({
+  initial, globalModel, onApply, onClose,
+}: {
+  initial: OpEdSettingsValues;
+  globalModel: string;
+  onApply: (v: OpEdSettingsValues) => void;
+  onClose: () => void;
+}) {
+  const [activeSection, setActiveSection] = useState<SettingsSection>('length');
+  const [outlet, setOutlet] = useState(initial.outlet);
+  const [wordCount, setWordCount] = useState<number | null>(initial.wordCount);
+  const [thesis, setThesis] = useState(initial.thesis);
+  const [authorBio, setAuthorBio] = useState(initial.authorBio);
+  const [ground, setGround] = useState(initial.ground);
+  const [maxGroundingNodes, setMaxGroundingNodes] = useState(initial.maxGroundingNodes);
+  const [maxSituations, setMaxSituations] = useState(initial.maxSituations);
+  const [model, setModel] = useState(initial.model);
+  const [temperature, setTemperature] = useState(initial.temperature);
+  const [family, setFamily] = useState<AIBackend>(() => backendForModelWithFallback(initial.model));
+  const [refreshing, setRefreshing] = useState(false);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, true);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const current: OpEdSettingsValues = { outlet, wordCount, thesis, authorBio, ground, maxGroundingNodes, maxSituations, model, temperature };
+
+  const handleReset = () => {
+    setOutlet(DEFAULTS.outlet);
+    setWordCount(DEFAULTS.wordCount);
+    setThesis(DEFAULTS.thesis);
+    setAuthorBio(DEFAULTS.authorBio);
+    setGround(DEFAULTS.ground);
+    setMaxGroundingNodes(DEFAULTS.maxGroundingNodes);
+    setMaxSituations(DEFAULTS.maxSituations);
+    setModel(globalModel);
+    setTemperature(DEFAULTS.temperature);
+    setFamily(backendForModelWithFallback(globalModel));
+  };
+
+  const clampWordCount = (raw: string): number | null => {
+    if (raw.trim() === '') return null;
+    const n = parseInt(raw, 10);
+    if (Number.isNaN(n)) return null;
+    return Math.min(2000, Math.max(300, n));
+  };
+
+  return (
+    <div className="dialog-overlay" onClick={onClose}>
+      <div
+        ref={dialogRef}
+        className="oped-settings-dialog"
+        role="dialog"
+        aria-modal
+        aria-labelledby="oped-settings-title"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="oped-settings-header">
+          <h2 className="oped-settings-title" id="oped-settings-title">More options</h2>
+          <button type="button" className="oped-close-btn" onClick={onClose} aria-label="Close settings">&times;</button>
+        </div>
+
+        <div className="oped-settings-layout">
+          <nav className="oped-settings-nav" aria-label="Settings sections">
+            {SETTINGS_SECTIONS.map(s => (
+              <button
+                key={s.id}
+                type="button"
+                className={`oped-settings-nav-item${activeSection === s.id ? ' active' : ''}`}
+                onClick={() => setActiveSection(s.id)}
+              >
+                {s.label}
+                {sectionHasDiff(s.id, current, globalModel) && <span className="oped-nav-dot" aria-label="modified" />}
+              </button>
+            ))}
+          </nav>
+
+          <div className="oped-settings-body">
+            {activeSection === 'length' && (
+              <>
+                <h3 className="oped-settings-section-title">Length &amp; outlet</h3>
+                <div className="oped-settings-field">
+                  <label className="oped-field-label" htmlFor="oped-s-outlet">Outlet</label>
+                  <select id="oped-s-outlet" className="oped-select" value={outlet} onChange={e => setOutlet(e.target.value)}>
+                    {OUTLETS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                  </select>
+                  <p className="oped-field-hint">{OUTLETS.find(o => o.value === outlet)?.band}</p>
+                </div>
+                <div className="oped-settings-field">
+                  <label className="oped-field-label" htmlFor="oped-s-wordcount">Word count override</label>
+                  <input
+                    id="oped-s-wordcount"
+                    type="number"
+                    className="oped-input"
+                    min={300}
+                    max={2000}
+                    placeholder="Use outlet band"
+                    value={wordCount ?? ''}
+                    onChange={e => setWordCount(clampWordCount(e.target.value))}
+                  />
+                  <p className="oped-field-hint">300–2000. Overrides the outlet's target length.</p>
+                </div>
+              </>
+            )}
+
+            {activeSection === 'angle' && (
+              <>
+                <h3 className="oped-settings-section-title">Angle</h3>
+                <div className="oped-settings-field">
+                  <label className="oped-field-label" htmlFor="oped-s-thesis">Thesis</label>
+                  <AutoGrowTextarea
+                    id="oped-s-thesis"
+                    className="oped-textarea"
+                    rows={3}
+                    placeholder="Leave blank to let the camp's values derive one"
+                    value={thesis}
+                    onChange={e => setThesis(e.target.value)}
+                  />
+                </div>
+                <div className="oped-settings-field">
+                  <label className="oped-field-label" htmlFor="oped-s-bio">Author bio</label>
+                  <input
+                    id="oped-s-bio"
+                    type="text"
+                    className="oped-input"
+                    placeholder="Credentials for the byline"
+                    value={authorBio}
+                    onChange={e => setAuthorBio(e.target.value)}
+                  />
+                </div>
+              </>
+            )}
+
+            {activeSection === 'grounding' && (
+              <>
+                <h3 className="oped-settings-section-title">Grounding</h3>
+                <label className="oped-settings-toggle-row">
+                  <input type="checkbox" checked={ground} onChange={e => setGround(e.target.checked)} />
+                  <span>
+                    <span className="oped-toggle-name">Ground in taxonomy</span>
+                    <span className="oped-toggle-help">
+                      Injects this camp's most relevant registered beliefs/desires/intentions and situation stress-cases as the positions the essay must argue from. Off writes from voice alone.
+                    </span>
+                  </span>
+                </label>
+                <div className="oped-settings-field">
+                  <label className="oped-field-label" htmlFor="oped-s-maxnodes">Max BDI nodes</label>
+                  <input
+                    id="oped-s-maxnodes"
+                    type="number"
+                    className="oped-input"
+                    min={0}
+                    max={40}
+                    disabled={!ground}
+                    value={maxGroundingNodes}
+                    onChange={e => setMaxGroundingNodes(Math.min(40, Math.max(0, parseInt(e.target.value, 10) || 0)))}
+                  />
+                </div>
+                <div className="oped-settings-field">
+                  <label className="oped-field-label" htmlFor="oped-s-maxsit">Max situations</label>
+                  <input
+                    id="oped-s-maxsit"
+                    type="number"
+                    className="oped-input"
+                    min={0}
+                    max={15}
+                    disabled={!ground}
+                    value={maxSituations}
+                    onChange={e => setMaxSituations(Math.min(15, Math.max(0, parseInt(e.target.value, 10) || 0)))}
+                  />
+                </div>
+              </>
+            )}
+
+            {activeSection === 'model' && (
+              <>
+                <h3 className="oped-settings-section-title">Model</h3>
+                <div className="oped-model-row">
+                  <div className="oped-model-field">
+                    <label className="oped-field-label" htmlFor="oped-s-family">Model family</label>
+                    <select
+                      id="oped-s-family"
+                      className="oped-select"
+                      value={family}
+                      onChange={e => {
+                        const fam = e.target.value as AIBackend;
+                        setFamily(fam);
+                        setModel(MODELS_BY_BACKEND[fam]?.[0]?.value ?? model);
+                      }}
+                    >
+                      {AI_BACKENDS.map(b => <option key={b.value} value={b.value}>{b.label}</option>)}
+                    </select>
+                  </div>
+                  <button
+                    type="button"
+                    className="oped-refresh-btn"
+                    disabled={refreshing}
+                    onClick={async () => {
+                      setRefreshing(true);
+                      try { await api.refreshAIModels(); await initAIModels(); } catch { /* telemetry — silent by design */ }
+                      setRefreshing(false);
+                    }}
+                  >{refreshing ? 'Refreshing…' : 'Refresh models'}</button>
+                </div>
+                <div className="oped-settings-field">
+                  <label className="oped-field-label" htmlFor="oped-s-model">Model</label>
+                  <select id="oped-s-model" className="oped-select" value={model} onChange={e => setModel(e.target.value)}>
+                    {(MODELS_BY_BACKEND[family] ?? []).map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
+                  </select>
+                </div>
+                <div className="oped-settings-field">
+                  <label className="oped-field-label" htmlFor="oped-s-temp">Temperature: {temperature.toFixed(1)}</label>
+                  <input
+                    id="oped-s-temp"
+                    type="range"
+                    min={0}
+                    max={2}
+                    step={0.1}
+                    value={temperature}
+                    onChange={e => setTemperature(parseFloat(e.target.value))}
+                  />
+                  <p className="oped-field-hint">0 = deterministic, 2 = most varied. Default 0.8.</p>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="oped-settings-footer">
+          <button type="button" className="btn" onClick={handleReset}>Reset to defaults</button>
+          <div className="oped-settings-footer-right">
+            <button type="button" className="btn" onClick={onClose}>Cancel</button>
+            <button type="button" className="btn btn-primary" onClick={() => onApply(current)}>Apply</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Progress panel (§5.2) ──────────────────────────────────────────────────────
+
+function OpEdProgressPanel({
+  voices, progress, onCancel,
+}: {
+  voices: PovKey[];
+  progress: Record<string, { stage: string; error?: string }>;
+  onCancel: () => void;
+}) {
+  const heading = voices.length === 1 ? 'Drafting your op-ed…' : `Drafting ${voices.length} op-eds…`;
+  const hasGraceful = Object.values(progress).some(p => p.stage === 'failed');
+
+  return (
+    <div className="oped-progress-panel">
+      <h3 className="oped-progress-heading">{heading}</h3>
+      <ul className="oped-progress-list" aria-live="polite">
+        {voices.map(pov => {
+          const p = progress[pov] ?? { stage: 'queued' };
+          const camp = povToCamp(pov);
+          const state = p.stage === 'failed' || p.stage === 'cancelled' ? 'failed' : (p.stage === 'complete' ? 'complete' : 'active');
+          return (
+            <li key={pov} className="oped-progress-item" data-state={state}>
+              <span className="oped-progress-voice">
+                {camp && <span className="oped-voice-chip-glyph" aria-hidden="true"><CampGlyph camp={camp} size={12} /></span>}
+                {POV_META[pov].label}
+              </span>
+              <span className="oped-progress-stage">{stageLabel(pov, p.stage, p.error)}</span>
+            </li>
+          );
+        })}
+      </ul>
+      {hasGraceful && (
+        <p className="oped-progress-notice">
+          Some voices could not finish — the drafts that succeeded will still open. Failed voices are marked in the reader.
+        </p>
+      )}
+      <div className="oped-progress-actions">
+        <button type="button" className="btn" onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+// ── Screen A form (extracted to keep the dialog's complexity in check) ────────
+
+interface CreateFormProps {
+  fromWebPage: boolean;
+  setFromWebPage: (v: boolean) => void;
+  topic: string;
+  setTopic: (v: string) => void;
+  url: string;
+  setUrl: (v: string) => void;
+  isAnonymous: boolean;
+  voices: Set<PovKey>;
+  toggleVoice: (pov: PovKey) => void;
+  orderedVoices: PovKey[];
+  outlet: string;
+  setOutlet: (v: string) => void;
+  newsHook: string;
+  setNewsHook: (v: string) => void;
+  includePitch: boolean;
+  setIncludePitch: (v: boolean) => void;
+  settingsDiffCount: number;
+  onOpenSettings: () => void;
+  startError: ActionableShape | null;
+  onClose: () => void;
+  onDraft: () => void;
+  canStart: boolean;
+  hasSource: boolean;
+  modelHasKey: boolean;
+  submitLabel: string;
+}
+
+function OpEdCreateForm(p: CreateFormProps) {
+  return (
+    <>
+      <div className="oped-dialog-body">
+        {/* Topic OR URL — mutually exclusive */}
+        {!p.fromWebPage ? (
+          <div>
+            <label className="oped-field-label" htmlFor="oped-topic">
+              Topic <span className="oped-required-mark" aria-hidden="true">*</span>
+            </label>
+            <AutoGrowTextarea
+              id="oped-topic"
+              className="oped-textarea"
+              rows={2}
+              value={p.topic}
+              onChange={e => p.setTopic(e.target.value)}
+              placeholder="e.g. Mandatory pre-deployment audits for frontier AI models"
+              autoFocus
+              aria-required="true"
+            />
+            <button type="button" className="oped-source-toggle" onClick={() => p.setFromWebPage(true)}>
+              ⌥ From a web page instead →
+            </button>
+          </div>
+        ) : (
+          <div>
+            <label className="oped-field-label" htmlFor="oped-url">
+              Web page URL <span className="oped-required-mark" aria-hidden="true">*</span>
+            </label>
+            <input
+              id="oped-url"
+              type="url"
+              className="oped-input"
+              value={p.url}
+              onChange={e => p.setUrl(e.target.value)}
+              placeholder="https://…"
+              disabled={p.isAnonymous}
+              autoFocus
+            />
+            {p.isAnonymous && <p className="oped-signin-note">Sign in to use URL sources.</p>}
+            <button type="button" className="oped-source-toggle" onClick={() => { p.setFromWebPage(false); p.setUrl(''); }}>
+              ← Use a topic instead
+            </button>
+          </div>
+        )}
+
+        {/* Voices — multi-select camp chips */}
+        <div>
+          <label className="oped-field-label" id="oped-voices-label">
+            Voices — one op-ed each <span className="oped-required-mark" aria-hidden="true">*</span>
+          </label>
+          <div className="oped-voice-chips" role="group" aria-labelledby="oped-voices-label">
+            {POV_KEYS.map(pov => {
+              const camp = povToCamp(pov);
+              const selected = p.voices.has(pov);
+              return (
+                <button
+                  key={pov}
+                  type="button"
+                  className="oped-voice-chip"
+                  aria-pressed={selected}
+                  // eslint-disable-next-line local/no-inline-style -- dynamic: camp accent when selected (theme-aware)
+                  style={selected ? { color: `var(${POV_META[pov].cssVar})` } : undefined}
+                  onClick={() => p.toggleVoice(pov)}
+                >
+                  {camp && <span className="oped-voice-chip-glyph" aria-hidden="true"><CampGlyph camp={camp} size={13} /></span>}
+                  {POV_META[pov].label}
+                </button>
+              );
+            })}
+          </div>
+          <p className="oped-voice-count" aria-live="polite">{voiceCountLine(p.orderedVoices)}</p>
+        </div>
+
+        {/* Outlet */}
+        <div>
+          <label className="oped-field-label" htmlFor="oped-outlet">Outlet</label>
+          <select id="oped-outlet" className="oped-select" value={p.outlet} onChange={e => p.setOutlet(e.target.value)}>
+            {OUTLETS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+          </select>
+          <p className="oped-field-hint">{OUTLETS.find(o => o.value === p.outlet)?.band}</p>
+        </div>
+
+        {/* News hook */}
+        <div>
+          <label className="oped-field-label" htmlFor="oped-newshook">News hook <span className="oped-inline-hint">(strongly recommended)</span></label>
+          <input
+            id="oped-newshook"
+            type="text"
+            className="oped-input"
+            value={p.newsHook}
+            onChange={e => p.setNewsHook(e.target.value)}
+            placeholder="e.g. the Senate AI oversight bill up for a floor vote next week"
+          />
+          {!p.newsHook.trim() && (
+            <p className="oped-field-hint">Without a hook the model will invent a plausible one — verify it before submitting.</p>
+          )}
+        </div>
+
+        {/* More options */}
+        <button type="button" className="oped-more-options-btn" onClick={p.onOpenSettings}>
+          ▸ More options (thesis, author bio, word count, grounding, model)
+          {p.settingsDiffCount > 0 && (
+            <span className="oped-change-badge" aria-label={`${p.settingsDiffCount} setting${p.settingsDiffCount > 1 ? 's' : ''} changed`}>{p.settingsDiffCount}</span>
+          )}
+        </button>
+      </div>
+
+      <div className="oped-dialog-footer">
+        {p.startError && (
+          <div className="oped-start-error" role="alert">
+            <div className="oped-start-error-problem">{p.startError.problem}</div>
+            {p.startError.nextSteps.length > 0 && (
+              <ul className="oped-start-error-steps">
+                {p.startError.nextSteps.map((s, i) => <li key={i}>{s}</li>)}
+              </ul>
+            )}
+          </div>
+        )}
+        <div className="oped-footer-actions">
+          <label className="oped-pitch-row">
+            <input type="checkbox" checked={p.includePitch} onChange={e => p.setIncludePitch(e.target.checked)} />
+            Pitch email too
+          </label>
+          <div className="oped-footer-right">
+            <button type="button" className="btn" onClick={p.onClose}>Cancel</button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              onClick={p.onDraft}
+              disabled={!p.canStart}
+              title={!p.hasSource ? 'Enter a topic or URL' : p.orderedVoices.length < 1 ? 'Select at least one voice' : !p.modelHasKey ? 'No API key configured for the selected model' : undefined}
+            >
+              {p.submitLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Main dialog ────────────────────────────────────────────────────────────────
+
+export function NewOpEdDialog({ open, onClose, onCreated }: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (setId: string) => void;
+}) {
+  // Screen A
+  const [fromWebPage, setFromWebPage] = useState(false);
+  const [topic, setTopic] = useState('');
+  const [url, setUrl] = useState('');
+  const [voices, setVoices] = useState<Set<PovKey>>(new Set());
+  const [outlet, setOutlet] = useState(DEFAULTS.outlet);
+  const [newsHook, setNewsHook] = useState('');
+  const [includePitch, setIncludePitch] = useState(false);
+
+  // Screen B–owned
+  const [wordCount, setWordCount] = useState<number | null>(DEFAULTS.wordCount);
+  const [thesis, setThesis] = useState(DEFAULTS.thesis);
+  const [authorBio, setAuthorBio] = useState(DEFAULTS.authorBio);
+  const [ground, setGround] = useState(DEFAULTS.ground);
+  const [maxGroundingNodes, setMaxGroundingNodes] = useState(DEFAULTS.maxGroundingNodes);
+  const [maxSituations, setMaxSituations] = useState(DEFAULTS.maxSituations);
+  const [temperature, setTemperature] = useState(DEFAULTS.temperature);
+
+  const { geminiModel } = useTaxonomyStore();
+  const globalModel: string = geminiModel;
+  const [model, setModel] = useState<string>(globalModel);
+
+  // Key / tier
+  const [hasApiKey, setHasApiKey] = useState<Record<string, boolean>>({});
+  const { tier: tierInfo } = useTierInfo();
+  const freeTier = isFreeTier(tierInfo);
+  const auth = useAuthStatus();
+  const isAnonymous = auth?.anonymous === true;
+
+  // UI
+  const [showSettings, setShowSettings] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [progress, setProgress] = useState<Record<string, { stage: string; error?: string }>>({});
+  const [startError, setStartError] = useState<ActionableShape | null>(null);
+
+  const runSetIdRef = useRef<string | null>(null);
+  const cancelledRef = useRef(false);
+  const unsubRef = useRef<(() => void) | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, open && !showSettings);
+
+  // Restore focus to the triggering element on close
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.activeElement as HTMLElement | null;
+    return () => { prev?.focus(); };
+  }, [open]);
+
+  // Escape closes (Screen A only; drawer handles its own)
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape' && !showSettings && !creating) onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, showSettings, creating, onClose]);
+
+  // Keep the model default tracking the global default until the user overrides it.
+  useEffect(() => { setModel(m => (m === '' ? globalModel : m)); }, [globalModel]);
+
+  // Load API-key availability for the key-check.
+  useEffect(() => {
+    if (!open) return;
+    void Promise.all(
+      AI_BACKENDS.map(async (b) => [b.value, await api.hasApiKey(b.value)] as [string, boolean]),
+    ).then(results => setHasApiKey(Object.fromEntries(results)))
+      .catch((err) => {
+        getGlobalRecorder()?.record({ type: 'system.error', component: 'oped-new-dialog', level: 'warn', message: 'hasApiKey check failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+      });
+  }, [open]);
+
+  // Cleanup the progress subscription on unmount.
+  useEffect(() => () => { unsubRef.current?.(); unsubRef.current = null; }, []);
+
+  const activeModel = computeActiveModel(freeTier, tierInfo, model);
+  const activeModelBackend = backendForModelWithFallback(activeModel);
+  const modelHasKey = computeModelHasKey(hasApiKey, activeModelBackend, freeTier, tierInfo);
+
+  const orderedVoices = useMemo(() => POV_KEYS.filter(v => voices.has(v)), [voices]);
+
+  const hasSource = fromWebPage ? url.trim().length > 0 : topic.trim().length > 0;
+  const canStart = hasSource && orderedVoices.length >= 1 && modelHasKey;
+
+  const settingsDiffCount = SETTINGS_SECTIONS.filter(s =>
+    sectionHasDiff(s.id, { outlet, wordCount, thesis, authorBio, ground, maxGroundingNodes, maxSituations, model, temperature }, globalModel),
+  ).length;
+
+  const toggleVoice = (pov: PovKey) => {
+    setVoices(prev => {
+      const next = new Set(prev);
+      if (next.has(pov)) next.delete(pov); else next.add(pov);
+      return next;
+    });
+  };
+
+  const handleApplySettings = (v: OpEdSettingsValues) => {
+    setOutlet(v.outlet);
+    setWordCount(v.wordCount);
+    setThesis(v.thesis);
+    setAuthorBio(v.authorBio);
+    setGround(v.ground);
+    setMaxGroundingNodes(v.maxGroundingNodes);
+    setMaxSituations(v.maxSituations);
+    setModel(v.model);
+    setTemperature(v.temperature);
+    setShowSettings(false);
+  };
+
+  const buildPayload = (): CreateOpEdPayload => {
+    const params: CreateOpEdParams = {
+      outlet,
+      newsHook: newsHook.trim() || undefined,
+      thesis: thesis.trim() || undefined,
+      authorBio: authorBio.trim() || undefined,
+      model: activeModel,
+      temperature,
+      includePitch: includePitch || undefined,
+    };
+    if (fromWebPage && url.trim()) params.url = url.trim();
+    if (wordCount != null) params.wordCount = wordCount;
+    if (!ground) params.voiceOnly = true;
+    else { params.maxGroundingNodes = maxGroundingNodes; params.maxSituations = maxSituations; }
+    return { topic: topic.trim(), params, voices: orderedVoices };
+  };
+
+  const handleCancel = () => {
+    cancelledRef.current = true;
+    const id = runSetIdRef.current;
+    if (id) api.cancelOpEdSet(id);
+  };
+
+  const handleDraft = async () => {
+    if (!canStart || creating) return;
+    if (fromWebPage && isAnonymous) {
+      setStartError({ problem: 'URL sources require sign-in.', nextSteps: ['Sign in with GitHub or Google', 'Or switch to a topic instead of a web page'] });
+      return;
+    }
+    setCreating(true);
+    setStartError(null);
+    setProgress({});
+    runSetIdRef.current = null;
+    cancelledRef.current = false;
+
+    // Subscribe BEFORE createOpEdSet — queued events carry the set_id so Cancel can
+    // abort a run whose create promise has not yet resolved.
+    const unsub = api.onOpEdProgress((e: OpEdProgressEvent) => {
+      if (!runSetIdRef.current) runSetIdRef.current = e.set_id;
+      setProgress(prev => ({ ...prev, [e.voice]: { stage: e.stage, error: e.error } }));
+    });
+    unsubRef.current = unsub;
+
+    try {
+      const { set_id } = await api.createOpEdSet(buildPayload());
+      if (cancelledRef.current) { onClose(); return; }
+      onCreated(set_id);
+      onClose();
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'oped-new-dialog', level: 'error', message: 'Failed to create op-ed set', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+      setStartError(toActionable(err));
+      setCreating(false);
+    } finally {
+      unsub();
+      unsubRef.current = null;
+    }
+  };
+
+  if (!open) return null;
+
+  const submitLabel = orderedVoices.length > 1 ? `Draft ${orderedVoices.length} op-eds` : 'Draft op-ed';
+
+  return (
+    <div className="dialog-overlay" onClick={() => { if (!creating) onClose(); }}>
+      <div
+        ref={dialogRef}
+        className="oped-dialog"
+        role="dialog"
+        aria-modal
+        aria-labelledby="oped-dialog-title"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="oped-dialog-header">
+          <h2 className="oped-dialog-title" id="oped-dialog-title">New op-ed</h2>
+          {!creating && (
+            <button type="button" className="oped-close-btn" onClick={onClose} aria-label="Close">&times;</button>
+          )}
+        </div>
+
+        {creating ? (
+          <OpEdProgressPanel voices={orderedVoices} progress={progress} onCancel={handleCancel} />
+        ) : (
+          <OpEdCreateForm
+            fromWebPage={fromWebPage}
+            setFromWebPage={setFromWebPage}
+            topic={topic}
+            setTopic={setTopic}
+            url={url}
+            setUrl={setUrl}
+            isAnonymous={isAnonymous}
+            voices={voices}
+            toggleVoice={toggleVoice}
+            orderedVoices={orderedVoices}
+            outlet={outlet}
+            setOutlet={setOutlet}
+            newsHook={newsHook}
+            setNewsHook={setNewsHook}
+            includePitch={includePitch}
+            setIncludePitch={setIncludePitch}
+            settingsDiffCount={settingsDiffCount}
+            onOpenSettings={() => setShowSettings(true)}
+            startError={startError}
+            onClose={onClose}
+            onDraft={handleDraft}
+            canStart={canStart}
+            hasSource={hasSource}
+            modelHasKey={modelHasKey}
+            submitLabel={submitLabel}
+          />
+        )}
+      </div>
+
+      {showSettings && (
+        <OpEdSettingsDrawer
+          initial={{ outlet, wordCount, thesis, authorBio, ground, maxGroundingNodes, maxSituations, model, temperature }}
+          globalModel={globalModel}
+          onApply={handleApplySettings}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -250,7 +250,7 @@ export function OpEdReader({ set }: { set: OpEdSet }) {
               role="tab"
               id={`oped-tab-${i}`}
               aria-selected={isActive}
-              aria-controls={`oped-panel-${i}`}
+              aria-controls="oped-panel"
               tabIndex={isActive ? 0 : -1}
               className={`oped-tab${isActive ? ' oped-tab-active' : ''}`}
               // eslint-disable-next-line local/no-inline-style -- dynamic: active underline uses the camp's theme color
@@ -263,7 +263,7 @@ export function OpEdReader({ set }: { set: OpEdSet }) {
           );
         })}
       </div>
-      <div role="tabpanel" id={`oped-panel-${activeIdx}`} aria-labelledby={`oped-tab-${activeIdx}`}>
+      <div role="tabpanel" id="oped-panel" aria-labelledby={`oped-tab-${activeIdx}`}>
         <OpEdArticle member={active} outlet={set.params.outlet} />
       </div>
     </div>

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -20,6 +20,7 @@ import { useCommunityStore } from '../../hooks/useCommunityStore';
 import type { OpEdSet, OpEdCommunityEntry } from '../../../../../lib/oped/types';
 import { OpEdTable } from './OpEdTable';
 import { OpEdReader } from './OpEdReader';
+import { NewOpEdDialog } from './NewOpEdDialog';
 import './OpEdTab.css';
 
 function recordError(component: string, message: string, err: unknown): void {
@@ -100,7 +101,7 @@ function filterCommunity(entries: OpEdCommunityEntry[], q: string): OpEdCommunit
 
 function OpEdHeaderActions({
   listView, editMode, hasSets, selectedCount, isElectron,
-  onBulkDelete, onClearSelected, onExitEdit, onEnterEdit,
+  onBulkDelete, onClearSelected, onExitEdit, onEnterEdit, onNew,
 }: {
   listView: 'my' | 'community';
   editMode: boolean;
@@ -111,6 +112,7 @@ function OpEdHeaderActions({
   onClearSelected: () => void;
   onExitEdit: () => void;
   onEnterEdit: () => void;
+  onNew: () => void;
 }) {
   if (listView !== 'my') return null;
   if (editMode) {
@@ -129,15 +131,21 @@ function OpEdHeaderActions({
       {hasSets && (
         <button className="btn btn-sm btn-ghost" onClick={onEnterEdit} title="Rename or delete op-eds">Edit</button>
       )}
-      {/* Create is PR#2 — the button is present but disabled (t/2570#3). */}
-      <button
-        className="btn btn-sm"
-        disabled
-        title={isElectron ? 'Create coming soon' : 'Available in the desktop app'}
-        aria-label="New op-ed (coming soon)"
-      >
-        + New Op-Ed
-      </button>
+      {/* Create (PR#2) — Electron only; web keeps the disabled desktop-app affordance. */}
+      {isElectron ? (
+        <button className="btn btn-sm" onClick={onNew} aria-label="New op-ed">
+          + New Op-Ed
+        </button>
+      ) : (
+        <button
+          className="btn btn-sm"
+          disabled
+          title="Available in the desktop app"
+          aria-label="New op-ed (available in the desktop app)"
+        >
+          + New Op-Ed
+        </button>
+      )}
     </div>
   );
 }
@@ -194,6 +202,7 @@ export function OpEdTab() {
   const [renameValue, setRenameValue] = useState('');
   const [copyingId, setCopyingId] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  const [showNewDialog, setShowNewDialog] = useState(false);
 
   // The set currently open in the reader — may come from the personal store (My)
   // or a community load (Community). null = table view.
@@ -240,6 +249,16 @@ export function OpEdTab() {
     setReaderSet(null);
     setReaderError(null);
   }, [selectSet]);
+
+  // A fresh create (PR#2) — reload the library, then open the new set in the reader.
+  const handleCreated = useCallback(async (setId: string) => {
+    setListView('my');
+    await loadSets();
+    const found = useOpEdStore.getState().sets.find(s => s.set_id === setId) ?? null;
+    selectSet(setId);
+    setReaderError(null);
+    setReaderSet(found);
+  }, [loadSets, selectSet]);
 
   // ── Row actions ──
 
@@ -331,6 +350,7 @@ export function OpEdTab() {
             onClearSelected={clearSelected}
             onExitEdit={exitEditMode}
             onEnterEdit={() => setEditMode(true)}
+            onNew={() => setShowNewDialog(true)}
           />
         </div>
 
@@ -378,7 +398,7 @@ export function OpEdTab() {
             onOpen={openMy}
             onExport={handleExportMy}
             onShare={handleShare}
-            onNew={() => { /* create is PR#2 */ }}
+            onNew={() => setShowNewDialog(true)}
             selectedSetId={selectedSetId}
             totalCount={sets.length}
           />
@@ -399,6 +419,14 @@ export function OpEdTab() {
           />
         )}
       </div>
+
+      {isElectron && (
+        <NewOpEdDialog
+          open={showNewDialog}
+          onClose={() => setShowNewDialog(false)}
+          onCreated={setId => { void handleCreated(setId); }}
+        />
+      )}
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
@@ -8,7 +8,7 @@
 // a single-voice run is a set of 1; a multi-voice set shows N camp chips and a
 // "▸ N voices" tag on the headline.
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { OpEdSet, OpEdCommunityEntry, PovKey } from '../../../../../lib/oped/types';
 import { CampGlyph, povToCamp } from '../shared/CampGlyph';
 import { POV_META } from '@lib/electron-shared/povMeta';
@@ -176,9 +176,26 @@ function SortHeader({ label, col, sort, onSort }: {
 
 function OpEdExportMenu({ onExport }: { onExport: (format: string) => void }) {
   const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLSpanElement>(null);
   const pick = (format: string) => { setOpen(false); onExport(format); };
+
+  // Escape + click-outside dismiss (t/2576#6 polish).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    const onDocClick = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onDocClick);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onDocClick);
+    };
+  }, [open]);
+
   return (
-    <span className="oped-export-menu">
+    <span className="oped-export-menu" ref={wrapRef}>
       <button
         type="button"
         className="oped-table-action-btn"


### PR DESCRIPTION
## Op-Ed Studio — PR#2 (create flow) · t/2576

Second half of the Op-Ed Studio epic (t/2570), behind `env-electron-opeds`. Adds the **Electron-only** create flow on top of PR#1's library + reader. Web keeps the disabled "Available in the desktop app" affordance (t/2570#3 PI ruling).

### What's in
- **Bridge**: `createOpEdSet({topic, params, voices}) → {set_id}`, `cancelOpEdSet`, `onOpEdProgress` across types/web/electron. Electron delegates to t/2575's IPC (feature-detected cast); web rejects with a desktop-only `ActionableError`.
- **`NewOpEdDialog`** (two-screen, mirrors `NewDebateDialog`/`DebateSettingsDialog`): Screen A (topic/URL toggle · multi-select voices with live count + submit relabel · outlet + word-band hints · news hook · pitch) + Screen B settings drawer (word count · thesis · author bio · grounding toggle/`maxGroundingNodes`/`maxSituations` · model · temperature). Every field maps to a `New-OpEd` param; defaults match the cmdlet. `useFocusTrap` + free-tier model pinning reused.
- **Generating state (§5.2)**: subscribes `onOpEdProgress` before create (queued event → `set_id` for early cancel), maps the real `oped-progress` IPC stages to per-voice labels, `aria-live` polite, Cancel → `cancelOpEdSet`, **partial-set honest** (failed/cancelled voices shown), `ActionableError` Next Steps as a list. On success reloads + opens the reader.
- Wired the PR#1 disabled **"+ New Op-Ed"** button (Electron-enabled).
- **Design polish (t/2576#6)**: stable `oped-panel` aria-controls id on the reader camp tabs; export mini-menu Esc + click-outside dismiss.

### Verify
Full deterministic gate green: main/server/renderer tsc 0/0, eslint clean, depcruise, `vite build`. **41 renderer tests** (11 new + PR#1's 30 intact).

Self-cert per t/2576#3 (approved epic phasing — second half of the confirmed split).

### Note
Model default follows the app's global model + free-tier pinning (the established Debate-dialog pattern), the one spot an untouched form differs from the cmdlet's literal default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
