### PR TITLE
fix(oped): raise source-brief MaxTokens 2000->4000 (t/2589)

### DIFF
--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -367,7 +367,7 @@ function New-OpEd {
                     SOURCE_MATERIAL = [string]$Prep.SourceMarkdown
                 }
                 $BriefResult = Invoke-AIApi -Prompt $BriefPrompt -Model $Model -Temperature 0.2 `
-                    -MaxTokens 2000 -JsonMode -ResponseSchema $BriefSchema
+                    -MaxTokens 4000 -JsonMode -ResponseSchema $BriefSchema
                 if ($null -ne $BriefResult -and -not [string]::IsNullOrWhiteSpace($BriefResult.Text)) {
                     $SBrief = $BriefResult.Text | ConvertFrom-Json
                     $Prep.SourceBrief = $SBrief


### PR DESCRIPTION
## Summary
- ARI PDF produces 4231 readable words; at 2000 tokens the JSON response truncates, ConvertFrom-Json throws, SourceBrief is silently nulled, and SOURCE_* placeholders are empty in the op-ed prompt
- At 4000 tokens the response is clean; stance correctly resolves to pro-mandatory-federal-regulation
- One-line fix: New-OpEd.ps1:370 -MaxTokens 2000 to -MaxTokens 4000

## Test plan
- [ ] CI green
- [ ] CL.Investigate1 re-runs ARI PDF end-to-end and confirms SourceBrief.stance is populated

Fixes t/2589. Unblocks t/2584 live re-fact-check.

Co-Authored-By: Claude Code