### PR TITLE
feat(main): list/load/delete/save-oped-set IPC handlers (t/2591)

### DIFF
--- a/lib/oped/types.ts
+++ b/lib/oped/types.ts
@@ -61,6 +61,19 @@ export interface OpEdSet {
   opeds: OpEdMember[];
 }
 
+// ── Local library listing summary (t/2591) ───────────────────────────────────
+//
+// Returned by list-oped-sets IPC so OpEdTable renders camp chips + voice count
+// without loading the full set doc. Derived from OpEdSet at list time.
+
+export interface OpEdSetSummary {
+  set_id: string;
+  topic: string;
+  created_at: string;
+  camps: PovKey[];
+  voice_count: number;
+}
+
 // ── Community index entry (e/91#2 condition 5) ────────────────────────────────
 //
 // Carried in the listing index so list rows render camp chips without loading

--- a/lib/oped/types.ts
+++ b/lib/oped/types.ts
@@ -70,6 +70,7 @@ export interface OpEdSetSummary {
   set_id: string;
   topic: string;
   created_at: string;
+  updated_at?: string;
   camps: PovKey[];
   voice_count: number;
 }

--- a/taxonomy-editor/src/main/__tests__/opedHandlers.readPath.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedHandlers.readPath.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Unit tests for list/load/delete/save-oped-set IPC handlers (t/2591).
+// Mirrors debate-session read-path coverage: safeId rejection + happy path.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ipcMain } from 'electron';
+
+vi.mock('child_process', () => ({ default: { spawn: vi.fn() }, spawn: vi.fn() }));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  dialog: { showSaveDialog: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+  app: { getPath: vi.fn(() => '/tmp') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false) },
+}));
+
+const mockListOpEdSets  = vi.hoisted(() => vi.fn());
+const mockLoadOpEdSet   = vi.hoisted(() => vi.fn());
+const mockDeleteOpEdSet = vi.hoisted(() => vi.fn());
+const mockSaveOpEdSet   = vi.hoisted(() => vi.fn());
+
+vi.mock('../opedIO.js', () => ({
+  saveOpEdSetTemp: vi.fn(),
+  finalizeOpEdSet: vi.fn(),
+  loadOpEdSet:     mockLoadOpEdSet,
+  deleteOpEdSet:   mockDeleteOpEdSet,
+  listOpEdSets:    mockListOpEdSets,
+  saveOpEdSet:     mockSaveOpEdSet,
+}));
+
+vi.mock('../fileIO.js', () => ({
+  PROJECT_ROOT: '/fake/root',
+  getDataRootPath: vi.fn(() => '/fake/data'),
+  resolveDataPath: vi.fn((p: string) => `/fake/data/${p}`),
+}));
+
+const mockAssertSafeId = vi.hoisted(() => vi.fn());
+vi.mock('../../../../lib/electron-shared/safeId.js', () => ({ assertSafeId: mockAssertSafeId }));
+vi.mock('../../../../lib/debate/errors.js', () => ({
+  ActionableError: class extends Error {
+    constructor(o: { goal: string; problem: string; location: string; nextSteps: string[] }) { super(o.problem); }
+  },
+}));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+
+import { registerOpEdHandlers } from '../ipc/opedHandlers.js';
+
+function getHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const calls = (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls;
+  const entry = calls.find((c: unknown[]) => c[0] === channel);
+  if (!entry) throw new Error(`${channel} not registered`);
+  return entry[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+const FAKE_SET = {
+  schema_version: 1 as const,
+  set_id: 'aaaabbbb-0000-0000-0000-000000000001',
+  topic: 'AI policy',
+  params: { wordCount: 600, model: 'test' },
+  created_at: '2026-08-13T00:00:00.000Z',
+  opeds: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  registerOpEdHandlers();
+});
+
+describe('list-oped-sets', () => {
+  it('returns all sets from opedIO', async () => {
+    mockListOpEdSets.mockReturnValue([FAKE_SET]);
+    const result = await getHandler('list-oped-sets')({}, undefined);
+    expect(result).toEqual([FAKE_SET]);
+    expect(mockListOpEdSets).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty array when no sets exist', async () => {
+    mockListOpEdSets.mockReturnValue([]);
+    const result = await getHandler('list-oped-sets')({}, undefined);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('load-oped-set', () => {
+  it('asserts safeId and returns set', async () => {
+    mockLoadOpEdSet.mockReturnValue(FAKE_SET);
+    const result = await getHandler('load-oped-set')({}, FAKE_SET.set_id);
+    expect(mockAssertSafeId).toHaveBeenCalledWith(FAKE_SET.set_id, 'oped set id');
+    expect(result).toEqual(FAKE_SET);
+  });
+
+  it('propagates safeId rejection', () => {
+    mockAssertSafeId.mockImplementationOnce(() => { throw new Error('unsafe id'); });
+    expect(() => getHandler('load-oped-set')({}, '../evil')).toThrow('unsafe id');
+    expect(mockLoadOpEdSet).not.toHaveBeenCalled();
+  });
+});
+
+describe('delete-oped-set', () => {
+  it('asserts safeId and deletes', async () => {
+    await getHandler('delete-oped-set')({}, FAKE_SET.set_id);
+    expect(mockAssertSafeId).toHaveBeenCalledWith(FAKE_SET.set_id, 'oped set id');
+    expect(mockDeleteOpEdSet).toHaveBeenCalledWith(FAKE_SET.set_id);
+  });
+
+  it('propagates safeId rejection', () => {
+    mockAssertSafeId.mockImplementationOnce(() => { throw new Error('unsafe id'); });
+    expect(() => getHandler('delete-oped-set')({}, '../evil')).toThrow('unsafe id');
+    expect(mockDeleteOpEdSet).not.toHaveBeenCalled();
+  });
+});
+
+describe('save-oped-set', () => {
+  it('asserts safeId on set_id and saves', async () => {
+    await getHandler('save-oped-set')({}, FAKE_SET);
+    expect(mockAssertSafeId).toHaveBeenCalledWith(FAKE_SET.set_id, 'oped set id');
+    expect(mockSaveOpEdSet).toHaveBeenCalledWith(FAKE_SET);
+  });
+
+  it('propagates safeId rejection', () => {
+    mockAssertSafeId.mockImplementationOnce(() => { throw new Error('unsafe id'); });
+    expect(() => getHandler('save-oped-set')({}, { ...FAKE_SET, set_id: '../evil' })).toThrow('unsafe id');
+    expect(mockSaveOpEdSet).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/main/__tests__/opedIO.list.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedIO.list.test.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Direct unit tests for opedIO.listOpEdSets (t/2591 TL-required).
+// Tests the real filter/sort/summary-derive logic against a temp dir —
+// guards against .wip/.tmp/.inprogress leaking into the listing.
+//
+// OPED_DIR is a module-level constant in opedIO.ts, so we reset modules and
+// re-import before each test to force re-evaluation with the fresh tempDir.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  safeStorage: { isEncryptionAvailable: vi.fn(() => false) },
+}));
+
+// Mutable ref — updated in beforeEach before module re-import.
+const dataDirs = { root: '' };
+
+vi.mock('../fileIO.js', () => ({
+  PROJECT_ROOT: '/fake/root',
+  getDataRootPath: vi.fn(() => dataDirs.root),
+  resolveDataPath: vi.fn((p: string) => path.join(dataDirs.root, p)),
+}));
+
+vi.mock('../../../../lib/electron-shared/safeId.js', () => ({ assertSafeId: vi.fn() }));
+vi.mock('../../../../lib/debate/errors.js', () => ({
+  ActionableError: class extends Error {
+    constructor(o: { problem: string; goal: string; location: string; nextSteps: string[] }) { super(o.problem); }
+  },
+}));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+vi.mock('../../../../lib/debate/persistence.js', () => ({
+  atomicWriteSync: vi.fn(),
+  renameSyncWithRetry: vi.fn(),
+}));
+vi.mock('../../../../lib/debate/lockHolder.js', () => ({ recordLockHolder: vi.fn() }));
+
+type ListOpEdSets = () => ReturnType<typeof import('../opedIO.js')['listOpEdSets']>;
+
+let listOpEdSets: ListOpEdSets;
+
+beforeEach(async () => {
+  dataDirs.root = fs.mkdtempSync(path.join(os.tmpdir(), 'oped-list-test-'));
+  fs.mkdirSync(path.join(dataDirs.root, 'oped-sets'), { recursive: true });
+  vi.resetModules();
+  const mod = await import('../opedIO.js');
+  listOpEdSets = mod.listOpEdSets as ListOpEdSets;
+});
+
+afterEach(() => {
+  fs.rmSync(dataDirs.root, { recursive: true, force: true });
+});
+
+function makeSet(setId: string, topic: string, createdAt: string, povs: string[]): object {
+  return {
+    schema_version: 1,
+    set_id: setId,
+    topic,
+    params: { wordCount: 600, model: 'test' },
+    created_at: createdAt,
+    opeds: povs.map(pov => ({ pov, status: 'complete', headline: '', subtitle: '', body: '', wordCount: 0, grounding: [] })),
+  };
+}
+
+function write(filename: string, content: object): void {
+  fs.writeFileSync(path.join(dataDirs.root, 'oped-sets', filename), JSON.stringify(content), 'utf-8');
+}
+
+describe('listOpEdSets', () => {
+  it('returns empty array when only wip and junk files are present', () => {
+    write('oped-aaa-wip.json', makeSet('aaa', 'WIP topic', '2026-08-13T00:00:00.000Z', ['acc']));
+    fs.writeFileSync(path.join(dataDirs.root, 'oped-sets', 'oped-bbb.json.tmp'), '{}');
+    fs.writeFileSync(path.join(dataDirs.root, 'oped-sets', 'unrelated.txt'), 'noise');
+    expect(listOpEdSets()).toEqual([]);
+  });
+
+  it('excludes -wip.json, .tmp, and non-oped files; includes only final oped-*.json', () => {
+    write('oped-set-a.json', makeSet('set-a', 'Topic A', '2026-08-12T00:00:00.000Z', ['acc', 'saf']));
+    write('oped-set-b.json', makeSet('set-b', 'Topic B', '2026-08-13T00:00:00.000Z', ['skp']));
+    write('oped-set-c-wip.json', makeSet('set-c', 'WIP', '2026-08-14T00:00:00.000Z', ['acc']));
+    fs.writeFileSync(path.join(dataDirs.root, 'oped-sets', 'oped-set-d.json.tmp'), '{}');
+    fs.writeFileSync(path.join(dataDirs.root, 'oped-sets', 'debug.inprogress'), 'noise');
+
+    const result = listOpEdSets();
+    expect(result).toHaveLength(2);
+    // Sorted newest-first
+    expect(result[0].set_id).toBe('set-b');
+    expect(result[1].set_id).toBe('set-a');
+  });
+
+  it('derives summary fields correctly from OpEdSet', () => {
+    write('oped-xyz.json', makeSet('xyz', 'AI policy', '2026-08-13T00:00:00.000Z', ['acc', 'saf', 'skp']));
+    const [summary] = listOpEdSets();
+    expect(summary).toEqual({
+      set_id: 'xyz',
+      topic: 'AI policy',
+      created_at: '2026-08-13T00:00:00.000Z',
+      camps: ['acc', 'saf', 'skp'],
+      voice_count: 3,
+    });
+  });
+
+  it('silently skips corrupt/unreadable JSON entries', () => {
+    fs.writeFileSync(path.join(dataDirs.root, 'oped-sets', 'oped-corrupt.json'), '{not valid json}');
+    write('oped-valid.json', makeSet('valid', 'Good set', '2026-08-13T00:00:00.000Z', ['acc']));
+    const result = listOpEdSets();
+    expect(result).toHaveLength(1);
+    expect(result[0].set_id).toBe('valid');
+  });
+});

--- a/taxonomy-editor/src/main/__tests__/opedIO.list.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedIO.list.test.ts
@@ -93,15 +93,16 @@ describe('listOpEdSets', () => {
     expect(result[1].set_id).toBe('set-a');
   });
 
-  it('derives summary fields correctly from OpEdSet', () => {
-    write('oped-xyz.json', makeSet('xyz', 'AI policy', '2026-08-13T00:00:00.000Z', ['acc', 'saf', 'skp']));
+  it('derives summary fields correctly from OpEdSet and deduplicates camps', () => {
+    // Two 'acc' opeds (e.g. retry) should produce one 'acc' in camps
+    write('oped-xyz.json', makeSet('xyz', 'AI policy', '2026-08-13T00:00:00.000Z', ['acc', 'saf', 'skp', 'acc']));
     const [summary] = listOpEdSets();
     expect(summary).toEqual({
       set_id: 'xyz',
       topic: 'AI policy',
       created_at: '2026-08-13T00:00:00.000Z',
       camps: ['acc', 'saf', 'skp'],
-      voice_count: 3,
+      voice_count: 4,
     });
   });
 

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -15,7 +15,7 @@ import { ActionableError } from '../../../../lib/debate/errors.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { assertSafeId } from '../../../../lib/electron-shared/safeId.js';
 import { PROJECT_ROOT, getDataRootPath } from '../fileIO.js';
-import { saveOpEdSetTemp, finalizeOpEdSet, loadOpEdSet } from '../opedIO.js';
+import { saveOpEdSetTemp, finalizeOpEdSet, loadOpEdSet, deleteOpEdSet, listOpEdSets, saveOpEdSet } from '../opedIO.js';
 import type { OpEdSet, OpEdMember, OpEdParams } from '../../../../lib/oped/types.js';
 import type { PovKey } from '../../../../lib/oped/types.js';
 
@@ -277,6 +277,23 @@ export function registerOpEdHandlers(): void {
 
   ipcMain.handle('cancel-oped-set', (_event, setId: string) => {
     activeOpEdRuns.get(setId)?.abort();
+  });
+
+  ipcMain.handle('list-oped-sets', () => listOpEdSets());
+
+  ipcMain.handle('load-oped-set', (_event, setId: string) => {
+    assertSafeId(setId, 'oped set id');
+    return loadOpEdSet(setId);
+  });
+
+  ipcMain.handle('delete-oped-set', (_event, setId: string) => {
+    assertSafeId(setId, 'oped set id');
+    deleteOpEdSet(setId);
+  });
+
+  ipcMain.handle('save-oped-set', (_event, set: OpEdSet) => {
+    assertSafeId(set.set_id, 'oped set id');
+    saveOpEdSet(set);
   });
 
   ipcMain.handle('export-oped-set', async (event, setId: string) => {

--- a/taxonomy-editor/src/main/opedIO.ts
+++ b/taxonomy-editor/src/main/opedIO.ts
@@ -10,7 +10,7 @@ import { atomicWriteSync, renameSyncWithRetry } from '../../../lib/debate/persis
 import { recordLockHolder } from '../../../lib/debate/lockHolder.js';
 import { ActionableError } from '../../../lib/debate/errors.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
-import type { OpEdSet } from '../../../lib/oped/types.js';
+import type { OpEdSet, OpEdSetSummary } from '../../../lib/oped/types.js';
 
 const OPED_DIR = resolveDataPath('oped-sets');
 
@@ -98,16 +98,23 @@ export function deleteOpEdSet(setId: string): void {
   fs.unlinkSync(filePath);
 }
 
-export function listOpEdSets(): OpEdSet[] {
+export function listOpEdSets(): OpEdSetSummary[] {
   ensureOpEdDir();
-  const sets: OpEdSet[] = [];
+  const summaries: OpEdSetSummary[] = [];
   for (const entry of fs.readdirSync(OPED_DIR)) {
     if (!entry.startsWith('oped-') || !entry.endsWith('.json') || entry.endsWith('-wip.json')) continue;
     try {
-      sets.push(JSON.parse(fs.readFileSync(path.join(OPED_DIR, entry), 'utf-8')) as OpEdSet);
+      const set = JSON.parse(fs.readFileSync(path.join(OPED_DIR, entry), 'utf-8')) as OpEdSet;
+      summaries.push({
+        set_id: set.set_id,
+        topic: set.topic,
+        created_at: set.created_at,
+        camps: set.opeds.map(o => o.pov),
+        voice_count: set.opeds.length,
+      });
     } catch { /* telemetry — silent by design; skip unreadable/corrupt entries */ }
   }
-  return sets.sort((a, b) => b.created_at.localeCompare(a.created_at));
+  return summaries.sort((a, b) => b.created_at.localeCompare(a.created_at));
 }
 
 export function saveOpEdSet(set: OpEdSet): void {

--- a/taxonomy-editor/src/main/opedIO.ts
+++ b/taxonomy-editor/src/main/opedIO.ts
@@ -109,7 +109,7 @@ export function listOpEdSets(): OpEdSetSummary[] {
         set_id: set.set_id,
         topic: set.topic,
         created_at: set.created_at,
-        camps: set.opeds.map(o => o.pov),
+        camps: [...new Set(set.opeds.map(o => o.pov))],
         voice_count: set.opeds.length,
       });
     } catch { /* telemetry — silent by design; skip unreadable/corrupt entries */ }

--- a/taxonomy-editor/src/main/opedIO.ts
+++ b/taxonomy-editor/src/main/opedIO.ts
@@ -97,3 +97,20 @@ export function deleteOpEdSet(setId: string): void {
   }
   fs.unlinkSync(filePath);
 }
+
+export function listOpEdSets(): OpEdSet[] {
+  ensureOpEdDir();
+  const sets: OpEdSet[] = [];
+  for (const entry of fs.readdirSync(OPED_DIR)) {
+    if (!entry.startsWith('oped-') || !entry.endsWith('.json') || entry.endsWith('-wip.json')) continue;
+    try {
+      sets.push(JSON.parse(fs.readFileSync(path.join(OPED_DIR, entry), 'utf-8')) as OpEdSet);
+    } catch { /* telemetry — silent by design; skip unreadable/corrupt entries */ }
+  }
+  return sets.sort((a, b) => b.created_at.localeCompare(a.created_at));
+}
+
+export function saveOpEdSet(set: OpEdSet): void {
+  // Atomic whole-set write (rename edits topic in-place) — mirrors saveDebateSession.
+  finalizeOpEdSet(set);
+}

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -560,7 +560,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   adminRemoveCommunityItem: (type: string, id: string, reason?: string): Promise<void> =>
     ipcRenderer.invoke('admin-remove-community-item', type, id, reason),
 
-  // Op-Ed Studio (t/2575)
+  // Op-Ed Studio (t/2575, t/2591)
   createOpEdSet: (payload: { topic: string; params: unknown; voices: string[] }): Promise<{ set_id: string }> =>
     ipcRenderer.invoke('create-oped-set', payload),
   cancelOpEdSet: (setId: string): void =>
@@ -572,4 +572,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('oped-progress', listener);
     return () => { ipcRenderer.removeListener('oped-progress', listener); };
   },
+  listOpEdSets: (): Promise<unknown[]> =>
+    ipcRenderer.invoke('list-oped-sets'),
+  loadOpEdSet: (setId: string): Promise<unknown> =>
+    ipcRenderer.invoke('load-oped-set', setId),
+  deleteOpEdSet: (setId: string): Promise<void> =>
+    ipcRenderer.invoke('delete-oped-set', setId),
+  saveOpEdSet: (set: unknown): Promise<void> =>
+    ipcRenderer.invoke('save-oped-set', set),
 });


### PR DESCRIPTION
## Summary
- Add `list-oped-sets`, `load-oped-set`, `delete-oped-set`, `save-oped-set` IPC handlers mirroring debate-session read-path
- Add `listOpEdSets()` and `saveOpEdSet()` to `opedIO.ts` (atomic whole-set write via `finalizeOpEdSet`)
- Expose all four in `preload.cts` with names matching Rosetta's `electron-bridge` feature-detect contract
- 8 unit tests: happy path + safeId rejection per handler

## Test plan
- [ ] `npx vitest run src/main/__tests__/opedHandlers.readPath.test.ts` — 8/8 pass
- [ ] `npx tsc --noEmit -p tsconfig.main.json` — clean
- [ ] CI green on head commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)