### PR TITLE
feat(main): hoist Get-OpEdSource once per create-oped-set, thread -SourcePrep (t/2588)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/opedHandlers.create.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedHandlers.create.test.ts
@@ -1,9 +1,10 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-// Unit tests for create-oped-set / cancel-oped-set IPC handlers (t/2575).
-// Verifies: N-voice fan-out, per-voice progress, partial-set finalization,
-// cancel mid-run, and 2-window event targeting (events reach only sender).
+// Unit tests for create-oped-set / cancel-oped-set IPC handlers (t/2575, t/2588).
+// Verifies: Stage-A source prep hoist, N-voice fan-out, per-voice progress,
+// partial-set finalization, cancel mid-run, 2-window event targeting, and
+// fail-fast on unreadable source (TL cond 3).
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'events';
@@ -306,5 +307,163 @@ describe('create-oped-set — event targeting', () => {
 
     expect(sent1.length).toBeGreaterThan(0);
     expect(sender2.send).not.toHaveBeenCalled();
+  });
+});
+
+// ── Stage-A source hoist (t/2588) ─────────────────────────────────────────────
+
+// Identify spawned shims by filename (avoids path-separator differences on Windows).
+const PREP_SHIM_FILE  = 'invoke-get-oped-source.ps1';
+const VOICE_SHIM_FILE = 'invoke-oped.ps1';
+
+const FAKE_SOURCE_PREP = {
+  Url: 'https://example.com/article',
+  SourceMarkdown: '# Article\n\nSome content.',
+  SourceFormat: 'markdown',
+  ReadableWords: 500,
+  ReadableRatio: 0.85,
+  ContentHash: 'abc123',
+};
+
+function makeSpawnRouter(prepChild: FakeChild, voiceChildren: FakeChild[]): (_cmd: string, args: string[]) => FakeChild {
+  let voiceIdx = 0;
+  return (_cmd: string, args: string[]) => {
+    const file = args[3] ?? '';
+    if (file.includes('invoke-get-oped-source')) return prepChild;
+    return voiceChildren[voiceIdx++] as FakeChild;
+  };
+}
+
+function emitPrepResult(child: FakeChild, data: Record<string, unknown>): void {
+  const line = JSON.stringify({ type: 'result', data }) + '\n';
+  child.stdout.emit('data', Buffer.from(line));
+  child.emit('close', 0);
+}
+
+describe('create-oped-set — Stage-A source hoist', () => {
+  it('spawns prep shim first, then one voice shim per voice', async () => {
+    const prepChild = makeChild();
+    const voiceChildren = [makeChild(), makeChild()];
+    mockSpawn.mockImplementation(makeSpawnRouter(prepChild, voiceChildren));
+
+    const { sender } = makeSender();
+    const handler = getHandler('create-oped-set');
+
+    const resultP = handler(
+      { sender },
+      { topic: 'AI safety', url: 'https://example.com', params: baseParams, voices: ['accelerationist', 'safetyist'] },
+    ) as Promise<{ set_id: string }>;
+
+    await Promise.resolve();
+    emitPrepResult(prepChild, FAKE_SOURCE_PREP);
+    await Promise.resolve();
+
+    emitResult(voiceChildren[0], { Headline: 'H1', Subtitle: 'S1', Body: 'B1', WordCount: 600, Grounding: [] });
+    emitResult(voiceChildren[1], { Headline: 'H2', Subtitle: 'S2', Body: 'B2', WordCount: 600, Grounding: [] });
+    await resultP;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(3); // 1 prep + 2 voices
+    expect((mockSpawn.mock.calls[0] as [string, string[]])[1][3]).toContain(PREP_SHIM_FILE);
+    expect((mockSpawn.mock.calls[1] as [string, string[]])[1][3]).toContain(VOICE_SHIM_FILE);
+    expect((mockSpawn.mock.calls[2] as [string, string[]])[1][3]).toContain(VOICE_SHIM_FILE);
+  });
+
+  it('emits preparing-source set-phase event (no voice field) before queued events', async () => {
+    const prepChild = makeChild();
+    const voiceChild = makeChild();
+    mockSpawn.mockImplementation(makeSpawnRouter(prepChild, [voiceChild]));
+
+    const { sender, sent } = makeSender();
+    const handler = getHandler('create-oped-set');
+
+    const resultP = handler(
+      { sender },
+      { topic: 'topic', url: 'https://example.com', params: baseParams, voices: ['accelerationist'] },
+    ) as Promise<unknown>;
+
+    await Promise.resolve();
+    emitPrepResult(prepChild, FAKE_SOURCE_PREP);
+    await Promise.resolve();
+
+    emitResult(voiceChild, { Headline: 'H', Subtitle: 'S', Body: 'B', WordCount: 600, Grounding: [] });
+    await resultP;
+
+    const events = sent as Array<{ stage: string; voice?: string }>;
+    const prepIdx   = events.findIndex(e => e.stage === 'preparing-source');
+    const queuedIdx = events.findIndex(e => e.stage === 'queued');
+    expect(prepIdx).toBeGreaterThanOrEqual(0);
+    expect(events[prepIdx].voice).toBeUndefined();
+    expect(prepIdx).toBeLessThan(queuedIdx);
+  });
+
+  it('threads SourcePrep into each voice spawn stdin', async () => {
+    const prepChild = makeChild();
+    const voiceChildren = [makeChild(), makeChild()];
+    mockSpawn.mockImplementation(makeSpawnRouter(prepChild, voiceChildren));
+
+    const { sender } = makeSender();
+    const handler = getHandler('create-oped-set');
+
+    const resultP = handler(
+      { sender },
+      { topic: 'topic', url: 'https://example.com', params: baseParams, voices: ['accelerationist', 'safetyist'] },
+    ) as Promise<unknown>;
+
+    await Promise.resolve();
+    emitPrepResult(prepChild, FAKE_SOURCE_PREP);
+    await Promise.resolve();
+
+    emitResult(voiceChildren[0], { Headline: 'H', Subtitle: 'S', Body: 'B', WordCount: 600, Grounding: [] });
+    emitResult(voiceChildren[1], { Headline: 'H', Subtitle: 'S', Body: 'B', WordCount: 600, Grounding: [] });
+    await resultP;
+
+    // Both voice spawns must receive SourcePrep in stdin
+    for (const voiceChild of voiceChildren) {
+      const writtenArg = (voiceChild.stdin.write as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      const parsed = JSON.parse(writtenArg) as Record<string, unknown>;
+      expect(parsed).toHaveProperty('SourcePrep');
+      expect((parsed.SourcePrep as Record<string, unknown>).ContentHash).toBe('abc123');
+    }
+  });
+
+  it('fail-fast: unreadable source throws ActionableError, no voice spawns, no finalize', async () => {
+    const prepChild = makeChild();
+    mockSpawn.mockImplementation(makeSpawnRouter(prepChild, []));
+
+    const { sender } = makeSender();
+    const handler = getHandler('create-oped-set');
+
+    const resultP = handler(
+      { sender },
+      { topic: 'topic', url: 'https://example.com', params: baseParams, voices: ['accelerationist'] },
+    ) as Promise<unknown>;
+
+    await Promise.resolve();
+    // Prep shim exits non-zero (readability gate trip)
+    prepChild.emit('close', 1);
+
+    await expect(resultP).rejects.toThrow();
+    expect(mockFinalize).not.toHaveBeenCalled();
+    // Only the prep shim was spawned — no voice shims
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect((mockSpawn.mock.calls[0] as [string, string[]])[1][3]).toContain(PREP_SHIM_FILE);
+  });
+
+  it('no prep shim when url is absent (topic-only path unchanged)', async () => {
+    const voiceChild = makeChild();
+    mockSpawn.mockReturnValue(voiceChild);
+
+    const { sender } = makeSender();
+    const resultP = getHandler('create-oped-set')(
+      { sender },
+      { topic: 'topic', params: baseParams, voices: ['accelerationist'] },
+    ) as Promise<unknown>;
+
+    await Promise.resolve();
+    emitResult(voiceChild, { Headline: 'H', Subtitle: 'S', Body: 'B', WordCount: 600, Grounding: [] });
+    await resultP;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect((mockSpawn.mock.calls[0] as [string, string[]])[1][3]).toContain(VOICE_SHIM_FILE);
   });
 });

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -322,6 +322,11 @@ export function registerOpEdHandlers(): void {
         sourcePrep = await runGetOpEdSource(url, controller.signal);
       } catch (err) {
         activeOpEdRuns.delete(setId);
+        getGlobalRecorder()?.record({
+          type: 'system.error', component: 'opedHandlers', level: 'error',
+          message: `Stage A Get-OpEdSource failed for set ${setId}: ${(err as Error).message}`,
+          error: { name: (err as Error).name ?? 'Error', message: String((err as Error).message ?? err), stack: (err as Error).stack },
+        });
         throw new ActionableError({
           goal: 'Prepare source material for op-ed set',
           problem: `Get-OpEdSource failed: ${(err as Error).message}`,

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -1,9 +1,10 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-// Op-ed create/cancel/export IPC handlers (t/2575).
-// N× New-OpEd fan-out via ElectronMain-owned PS shim, 3-stage progress,
-// temp→atomic finalize (partial-set contract), whole-set Markdown export.
+// Op-ed create/cancel/export IPC handlers (t/2575, t/2588).
+// Stage A: Get-OpEdSource hoisted once per create call, SourcePrep threaded into each voice.
+// Stage B: N× New-OpEd fan-out via ElectronMain-owned PS shim, per-voice progress + cancel.
+// Partial-set contract: failed/cancelled members; whole-set Markdown export.
 
 import { ipcMain, dialog, BrowserWindow } from 'electron';
 import { spawn } from 'child_process';
@@ -19,10 +20,11 @@ import { saveOpEdSetTemp, finalizeOpEdSet, loadOpEdSet } from '../opedIO.js';
 import type { OpEdSet, OpEdMember, OpEdParams } from '../../../../lib/oped/types.js';
 import type { PovKey } from '../../../../lib/oped/types.js';
 
-// PS shim lives in source tree alongside its TypeScript callers. PROJECT_ROOT resolves
+// PS shims live in source tree alongside their TypeScript callers. PROJECT_ROOT resolves
 // via resolveRepoRootForApp (walks .aitriad.json), stable in both dev and packaged builds —
 // build:main is tsc-only and does not copy .ps1 to dist/.
-const SHIM_PATH = path.join(PROJECT_ROOT, 'taxonomy-editor', 'src', 'main', 'ps', 'invoke-oped.ps1');
+const SHIM_PATH      = path.join(PROJECT_ROOT, 'taxonomy-editor', 'src', 'main', 'ps', 'invoke-oped.ps1');
+const PREP_SHIM_PATH = path.join(PROJECT_ROOT, 'taxonomy-editor', 'src', 'main', 'ps', 'invoke-get-oped-source.ps1');
 
 // Read generation.opedVoiceTimeoutMs from {dataRoot}/admin/runtime-config.json on each run
 // so it's tunable without restart. Falls back to 360s (New-OpEd = grounding + full-essay LLM;
@@ -44,11 +46,11 @@ const activeOpEdRuns = new Map<string, AbortController>();
 
 // ── Progress event shape ──────────────────────────────────────────────────────
 
-type OpEdStage = 'queued' | 'fetching' | 'grounding' | 'generating' | 'finalizing' | 'complete' | 'failed' | 'cancelled';
+type OpEdStage = 'queued' | 'preparing-source' | 'fetching' | 'grounding' | 'generating' | 'finalizing' | 'complete' | 'failed' | 'cancelled';
 
 interface OpEdProgressEvent {
   set_id: string;
-  voice: PovKey;
+  voice?: PovKey;  // absent for set-phase events (e.g. preparing-source)
   stage: OpEdStage;
   error?: string;
 }
@@ -59,23 +61,94 @@ interface ShimStageLine { type: 'stage'; stage: string }
 interface ShimResultLine { type: 'result'; data: Record<string, unknown> }
 type ShimLine = ShimStageLine | ShimResultLine;
 
-// ── Single-voice runner ───────────────────────────────────────────────────────
+// ── Stage-A: source prep runner ───────────────────────────────────────────────
+
+function runGetOpEdSource(url: string, signal: AbortSignal): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('pwsh', ['-NoProfile', '-NonInteractive', '-File', PREP_SHIM_PATH], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let settled = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+    function onAbort(): void {
+      settle(() => { child.kill('SIGTERM'); reject(Object.assign(new Error('cancelled'), { name: 'AbortError' })); });
+    }
+
+    function settle(fn: () => void): void {
+      if (settled) return;
+      settled = true;
+      if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+      signal.removeEventListener('abort', onAbort);
+      fn();
+    }
+
+    if (signal.aborted) { onAbort(); return; }
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    timeoutHandle = setTimeout(() => {
+      settle(() => { child.kill('SIGTERM'); reject(new Error('Get-OpEdSource timed out')); });
+    }, getVoiceTimeoutMs());
+
+    child.stdin.write(JSON.stringify({ Url: url }), 'utf-8');
+    child.stdin.end();
+
+    let stdoutBuf = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutBuf += chunk.toString('utf-8');
+      const lines = stdoutBuf.split('\n');
+      stdoutBuf = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        let msg: ShimLine;
+        try { msg = JSON.parse(trimmed) as ShimLine; } catch { /* telemetry — silent by design */ continue; }
+        if (msg.type === 'result') {
+          settle(() => resolve((msg as ShimResultLine).data ?? {}));
+        }
+      }
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'opedHandlers', level: 'warn',
+        message: `Get-OpEdSource stderr: ${chunk.toString('utf-8').slice(0, 500)}`,
+      });
+    });
+
+    child.on('error', (err) => settle(() => reject(err)));
+    child.on('close', (code) => settle(() => {
+      if (code !== 0) reject(new Error(`Get-OpEdSource exited with code ${code}`));
+      else reject(new Error('No result received from Get-OpEdSource'));
+    }));
+  });
+}
+
+// ── Stage-B: single-voice runner ─────────────────────────────────────────────
 
 interface VoiceRunOpts {
   topic: string;
   pov: PovKey;
   params: OpEdParams;
+  sourcePrep?: Record<string, unknown>;  // hoisted Stage-A result; if absent, Url falls through
   signal: AbortSignal;
   onProgress: (stage: OpEdStage, error?: string) => void;
 }
 
-function runVoice({ topic, pov, params, signal, onProgress }: VoiceRunOpts): Promise<OpEdMember> {
+function runVoice({ topic, pov, params, sourcePrep, signal, onProgress }: VoiceRunOpts): Promise<OpEdMember> {
   return new Promise<OpEdMember>((resolve, reject) => {
     const stdinPayload = JSON.stringify({
       Topic: topic,
       Pov: pov,
       WordCount: params.wordCount,
       Model: params.model,
+      // SourcePrep (FromPrep path) and Url (FromUrl path) are mutually exclusive parameter sets.
+      // The orchestrator passes SourcePrep when it has hoisted Stage A; otherwise falls through
+      // to Url for single-voice direct callers (not currently wired — future use).
+      ...(sourcePrep
+        ? { SourcePrep: sourcePrep }
+        : {}),
       ...(params.outlet    ? { Outlet:    params.outlet }    : {}),
       ...(params.newsHook  ? { NewsHook:  params.newsHook }  : {}),
       ...(params.thesis    ? { Thesis:    params.thesis }    : {}),
@@ -216,10 +289,11 @@ function renderOpEdSetMarkdown(set: OpEdSet): string {
 export function registerOpEdHandlers(): void {
   ipcMain.handle('create-oped-set', async (event, payload: {
     topic: string;
+    url?: string;   // if provided, Get-OpEdSource is hoisted once (Stage A) before voice fan-out
     params: OpEdParams;
     voices: PovKey[];
   }) => {
-    const { topic, params, voices } = payload;
+    const { topic, url, params, voices } = payload;
 
     if (!topic?.trim() || !voices?.length) {
       throw new ActionableError({
@@ -239,7 +313,28 @@ export function registerOpEdHandlers(): void {
       if (!event.sender.isDestroyed()) event.sender.send('oped-progress', data);
     };
 
-    // Fire queued for each voice immediately — renderer stores set_id for cancellation
+    // Stage A: hoist Get-OpEdSource once before spawning voices.
+    // Fail fast if readability gate trips — don't fan out to draft on garbage (TL cond 3).
+    let sourcePrep: Record<string, unknown> | undefined;
+    if (url) {
+      send({ set_id: setId, stage: 'preparing-source' });
+      try {
+        sourcePrep = await runGetOpEdSource(url, controller.signal);
+      } catch (err) {
+        activeOpEdRuns.delete(setId);
+        throw new ActionableError({
+          goal: 'Prepare source material for op-ed set',
+          problem: `Get-OpEdSource failed: ${(err as Error).message}`,
+          location: 'opedHandlers create-oped-set Stage A',
+          nextSteps: [
+            'Check that the URL is publicly accessible',
+            'Verify the page contains sufficient readable text (minimum word count required)',
+          ],
+        });
+      }
+    }
+
+    // Fire queued for each voice — renderer stores set_id for cancellation
     for (const voice of voices) {
       send({ set_id: setId, voice, stage: 'queued' });
     }
@@ -248,7 +343,7 @@ export function registerOpEdHandlers(): void {
 
     const voicePromises = voices.map(async (voice): Promise<OpEdMember> => {
       const member = await runVoice({
-        topic, pov: voice, params,
+        topic, pov: voice, params, sourcePrep,
         signal: controller.signal,
         onProgress: (stage, error) => send({ set_id: setId, voice, stage, error }),
       }).catch((err): OpEdMember => {

--- a/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
+++ b/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
@@ -1,0 +1,23 @@
+#Requires -Version 7
+# Stage-A shim: fetch + convert + readability gate for one URL.
+# Called once per create-oped-set; SourcePrep is threaded into each voice spawn.
+# Reads JSON stdin: { "Url": "<url>" }
+# Writes JSON lines to stdout:
+#   {"type":"result","data":{...SourcePrep fields...}}
+# Throws (exit 1) if Get-OpEdSource's readability gate trips or any error occurs.
+param()
+$ErrorActionPreference = 'Stop'
+
+$raw = [Console]::In.ReadToEnd()
+$p   = $raw | ConvertFrom-Json
+
+$repoRoot = $PSScriptRoot
+for ($i = 0; $i -lt 4; $i++) { $repoRoot = Split-Path -Parent $repoRoot }
+$modulePath = Join-Path $repoRoot 'scripts' 'AITriad' 'AITriad.psd1'
+Import-Module $modulePath -Force -ErrorAction Stop
+
+$prep = Get-OpEdSource -Url ([string]$p.Url)
+
+$resultLine = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
+[Console]::Out.WriteLine($resultLine)
+[Console]::Out.Flush()

--- a/taxonomy-editor/src/main/ps/invoke-oped.ps1
+++ b/taxonomy-editor/src/main/ps/invoke-oped.ps1
@@ -28,10 +28,18 @@ $stagePatterns = [ordered]@{
 
 # Splat only recognized New-OpEd params (no -ParamsFile; avoids cross-scope cmdlet change)
 $splat = [ordered]@{ Topic = [string]$p.Topic; Pov = [string]$p.Pov }
-foreach ($key in @('Outlet', 'NewsHook', 'Thesis', 'AuthorBio', 'Url', 'Model')) {
+foreach ($key in @('Outlet', 'NewsHook', 'Thesis', 'AuthorBio', 'Model')) {
     if ($null -ne $p.PSObject.Properties[$key] -and $null -ne $p.$key) {
         $splat[$key] = [string]$p.$key
     }
+}
+# SourcePrep (FromPrep path) and Url (FromUrl path) are mutually exclusive parameter sets.
+# The orchestrator hoists Get-OpEdSource once and passes SourcePrep as plain JSON data;
+# ConvertFrom-Json yields a PSCustomObject, which is exactly what New-OpEd -SourcePrep expects.
+if ($null -ne $p.PSObject.Properties['SourcePrep'] -and $null -ne $p.SourcePrep) {
+    $splat['SourcePrep'] = $p.SourcePrep
+} elseif ($null -ne $p.PSObject.Properties['Url'] -and $null -ne $p.Url) {
+    $splat['Url'] = [string]$p.Url
 }
 if ($null -ne $p.PSObject.Properties['WordCount'] -and $null -ne $p.WordCount) {
     $splat['WordCount'] = [int]$p.WordCount


### PR DESCRIPTION
## Summary
- Stage A: new `invoke-get-oped-source.ps1` shim calls `Get-OpEdSource -Url` once before the voice fan-out; emits `preparing-source` progress event (no voice field)
- Stage B: `invoke-oped.ps1` accepts either `-SourcePrep` (PSObject from ConvertFrom-Json) or `-Url` (mutually exclusive); `runVoice` threads `SourcePrep` in stdin payload
- `runGetOpEdSource()` in `opedHandlers.ts` mirrors `runVoice` settle/timeout/abort pattern
- Fail-fast: `ActionableError` on unreadable source before any voice is spawned
- `OpEdStage` and `OpEdProgressEvent.voice` made optional (preparing-source fires set-level)

## Test plan
- [ ] `npx vitest run src/main/__tests__/opedHandlers.create.test.ts` — all pass (incl. 5 new Stage-A tests)
- [ ] `npx tsc --noEmit -p tsconfig.main.json` — clean
- [ ] CI green on head commit
- [ ] ONE live `create-oped-set` run with a URL recorded on t/2588 (merge gate per TL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)