### PR TITLE
fix(calibration): use fileURLToPath so working_tree_state populates on Windows (t/2597)

### DIFF
--- a/lib/debate/calibrationLogger.test.ts
+++ b/lib/debate/calibrationLogger.test.ts
@@ -674,8 +674,8 @@ describe('appendCalibrationLog stamps runtime provenance (t/1672)', () => {
       // config_revision: 12-hex content hash of calibration-config.json, or '' if unreadable.
       expect(typeof entry.config_revision).toBe('string');
       expect(entry.config_revision).toMatch(/^([0-9a-f]{12})?$/);
-      // working_tree_state: real git state where a repo exists, 'unknown' where git is absent.
-      expect(['clean', 'dirty', 'unknown']).toContain(entry.working_tree_state);
+      // working_tree_state: must be clean or dirty in a git repo (t/2597: 'unknown' = bug).
+      expect(entry.working_tree_state).toMatch(/^(clean|dirty)$/);
     } finally {
       fs.rmSync(dataRoot, { recursive: true, force: true });
     }

--- a/lib/debate/calibrationLogger/io.ts
+++ b/lib/debate/calibrationLogger/io.ts
@@ -13,6 +13,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import type { CalibrationDataPoint } from './schema.js';
 
 // ── File I/O ────────────────────────────────────────────────
@@ -42,7 +43,7 @@ function captureRunProvenance(): { config_revision: string; working_tree_state: 
   // Resolve relative to this file — use import.meta.url for ESM compatibility (mirrors captureSnapshot).
   // This module lives in lib/debate/calibrationLogger/, so calibration-config.json (in lib/debate/)
   // is one directory up.
-  const thisDir = path.dirname(new URL(import.meta.url).pathname);
+  const thisDir = path.dirname(fileURLToPath(import.meta.url));
 
   let config_revision = '';
   try {


### PR DESCRIPTION
## Summary

- `captureRunProvenance()` in `calibrationLogger/io.ts` used `new URL(import.meta.url).pathname` to get the module directory, which returns `/C:/Users/...` on Windows — a URL path, not an OS path
- `fs.readFileSync` tolerates this; `execFileSync`'s `cwd` option passes it to the OS which rejects it → every local run caught and left `working_tree_state: 'unknown'`
- Fix: `fileURLToPath(import.meta.url)` yields the correct `C:\...` path on Windows (and is idiomatic ESM `__dirname`)
- Tightens the provenance test to assert `clean|dirty` (never `unknown`) in a git-repo test environment, locking out this failure class

## Test plan

- [ ] `npx vitest run calibrationLogger.test.ts` — 46/46 pass (verified locally)
- [ ] CI green
- [ ] Post-merge: CL can filter `calibration/core/calibration-log.jsonl` on `working_tree_state === 'clean'` and satisfy the R-1 replication gate (n≥10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)