### PR TITLE
fix(nav): thread env-electron-opeds into navCtx so the Op-Eds item can appear (t/2599)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
@@ -78,6 +78,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
   const breakpoint = useBreakpoint();
   const adminFeatures = useFlag('permission-admin-features');
   const summariesFlag = useFlag('env-electron-summaries');
+  const opedsFlag = useFlag('env-electron-opeds');
   const [showHelp, setShowHelp] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
@@ -166,7 +167,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
   }
 
   // NavConfig-driven items
-  const navCtx = { flags: { 'env-electron-summaries': summariesFlag }, isAdmin: adminFeatures };
+  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag }, isAdmin: adminFeatures };
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const primaryNavItems = visibleItems.filter(i => i.tier === 'primary' && !bottomNavIds.has(i.id));
   const secondaryGroups = getSecondaryByGroup(visibleItems);

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -217,7 +217,7 @@ export function Toolbar() {
   const adminFeatures = useFlag('permission-admin-features');
   const summariesFlag = useFlag('env-electron-summaries');
   const opedsFlag = useFlag('env-electron-opeds');
-  const navCtx = { flags: { 'env-electron-summaries': summariesFlag }, isAdmin: adminFeatures };
+  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag }, isAdmin: adminFeatures };
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const secondaryGroups = getSecondaryByGroup(visibleItems);
   const isNavItemActive = (item: NavItem): boolean => {

--- a/taxonomy-editor/src/renderer/data/navConfig.test.ts
+++ b/taxonomy-editor/src/renderer/data/navConfig.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression for t/2599: the Op-Eds nav item is gated on `env-electron-opeds`. The bug
+// was that Toolbar/HamburgerMenu READ the flag but omitted it from the `navCtx.flags`
+// passed to getVisibleNavItems — and getVisibleNavItems treats an absent flag as falsy
+// (`!ctx.flags[item.gate.flag]`), so the gate could never pass, hiding the tool even
+// with the flag ON. These assert the gate BOTH ways plus the omitted-flag case, which
+// is the class of miss that hid this (flag read but not threaded into the nav context).
+
+import { describe, it, expect } from 'vitest';
+import { NAV_ITEMS, getVisibleNavItems } from './navConfig';
+
+const hasOpeds = (flags: Record<string, boolean>): boolean =>
+  getVisibleNavItems(NAV_ITEMS, { flags, isAdmin: false }).some(i => i.id === 'opeds');
+
+describe('navConfig — env-electron-opeds gate (t/2599)', () => {
+  it('shows the Op-Eds item when the flag is present and true', () => {
+    expect(hasOpeds({ 'env-electron-opeds': true })).toBe(true);
+  });
+
+  it('hides the Op-Eds item when the flag is present and false', () => {
+    expect(hasOpeds({ 'env-electron-opeds': false })).toBe(false);
+  });
+
+  it('hides the Op-Eds item when the flag is OMITTED from navCtx — the t/2599 bug', () => {
+    // Toolbar/HamburgerMenu built navCtx.flags without env-electron-opeds; an absent
+    // flag is falsy, so the item was always filtered out even with the flag on.
+    expect(hasOpeds({ 'env-electron-summaries': true })).toBe(false);
+  });
+
+  it('gate is independent — the summaries flag does not reveal Op-Eds', () => {
+    expect(hasOpeds({ 'env-electron-summaries': true, 'env-electron-opeds': false })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Fix: Op-Eds nav item never appears even with `env-electron-opeds` ON · t/2599

**Bug:** the Op-Eds nav item (`gate: env-electron-opeds`) never rendered even with the flag enabled. `getVisibleNavItems` treats an absent flag as falsy (`!ctx.flags[item.gate.flag]`), and the `navCtx.flags` built in Toolbar/HamburgerMenu **omitted** `env-electron-opeds` (only `env-electron-summaries` was threaded) — so the gate could never pass. Dark-ship reveal was broken.

### Fix
- **`Toolbar.tsx`** — add `'env-electron-opeds': opedsFlag` to `navCtx.flags` (TL's cited line).
- **`HamburgerMenu.tsx`** — **same omission**; read `opedsFlag` + thread it in. This is the data-driven nav surface (renders primary items from `getVisibleNavItems`), so it's where the item was actually filtered. The Toolbar renders Op-Eds via a bespoke primary button (its `visibleItems` only feeds *secondary* groups), so it had a backstop — but the fix is correct hygiene there too.
- **`navConfig.test.ts`** (new) — both-arms + omitted-flag regression: visible iff the flag is present **and** true; an **absent** flag hides it (the exact miss class); plus a gate-independence control.

### Deviation from the ticket
Ticket specified a 1-line Toolbar fix; I also fixed `HamburgerMenu.tsx` (identical bug, and the real data-driven filter). Self-cert (UI-only change + `/add-test`).

**Verify:** renderer-tsc 0/0, eslint 0 errors, navConfig test 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
