### PR TITLE
fix(opeds): repoint web-bridge to /api/oped-sets + rename PUT (t/2576 live-smoke fix, t/2592)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -1016,11 +1016,13 @@ const rawApi: AppAPI = {
   loadDebateComments: (id) => get(`/api/debates/${encodeURIComponent(id)}/comments`),
   saveDebateComments: (id, data) => put(`/api/debates/${encodeURIComponent(id)}/comments`, data).then(() => {}),
 
-  // Op-Ed Studio (t/2576) — real routes against t/2573's server API (now on main).
-  listOpEdSets: () => get<OpEdSet[]>('/api/opeds'),
-  loadOpEdSet: (id) => get<OpEdSet>(`/api/opeds/${encodeURIComponent(id)}`),
-  saveOpEdSet: (set) => put('/api/opeds', set).then(() => {}),
-  deleteOpEdSet: (id) => del(`/api/opeds/${encodeURIComponent(id)}`).then(() => {}),
+  // Op-Ed Studio (t/2576) — real routes against t/2573's server API (on main). The
+  // personal-library path is /api/oped-sets (t/2599 live-smoke found the bridge had
+  // assumed /api/opeds). Rename persists topic-only via PUT /api/oped-sets/:id (t/2594).
+  listOpEdSets: () => get<OpEdSet[]>('/api/oped-sets'),
+  loadOpEdSet: (id) => get<OpEdSet>(`/api/oped-sets/${encodeURIComponent(id)}`),
+  saveOpEdSet: (set) => put(`/api/oped-sets/${encodeURIComponent(set.set_id)}`, set).then(() => {}),
+  deleteOpEdSet: (id) => del(`/api/oped-sets/${encodeURIComponent(id)}`).then(() => {}),
   // PR#2 create flow is Electron-only (New-OpEd is PowerShell; v1 has no web generation
   // route — server confirms). Web rejects honestly; the UI shows a "desktop app" affordance.
   createOpEdSet: () => Promise.reject(new ActionableError({


### PR DESCRIPTION
## Op-Ed bridge-fix: repoint to `/api/oped-sets` + rename PUT · t/2576 (live-smoke fix) + t/2592

The t/2576 **live-smoke** (t/2576#10) found the op-ed bridge assumed `/api/opeds`, but t/2573 registered the personal-library routes at **`/api/oped-sets`**. This is the one fix PR TL gated on t/2591 — now unblocked (t/2591 #987 + t/2594 both on main).

### Changes (web-bridge.ts)
- `listOpEdSets` / `loadOpEdSet` / `deleteOpEdSet`: `/api/opeds` → **`/api/oped-sets`**.
- `saveOpEdSet`: **`PUT /api/oped-sets/<set_id>`** (t/2594; full `OpEdSet` body, server whitelists `topic`).
- Community routes (`/api/community/opeds`) already correct — untouched.

### Electron path — no change needed (verified)
`electron-bridge` already feature-detects `listOpEdSets`/`loadOpEdSet`/`saveOpEdSet`/`deleteOpEdSet` — I confirmed these **exactly match t/2591's preload names** (ElectronMain built to the t/2576#13 contract). No re-drift.

### t/2592 rename write-path (folded in per TL p/336#147)
`saveOpEdSet` PUT + PR#1's edit-mode inline rename (set-level `topic`, Design-confirmed) now round-trip on both builds. **Date column already tolerates absent `updated_at`**: My rows are `OpEdSet[]` (only `created_at`); Community uses its guaranteed `updated_at`.

**Verify:** renderer-tsc 0/0, bridge `appapi-completeness` test, vite build.

**Close gate:** on merge I re-run the live-smoke both builds (web `/api/oped-sets` 200 + rename PUT persists `topic`; Electron list/load/save IPC) → closes t/2576 + t/2592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
