### PR TITLE
obs(debates): news-report extracting+generating breadcrumbs to pin 500 phase (t/2600)

### DIFF
--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -327,10 +327,18 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
       // @ts-expect-error — lib/debate uses bundler moduleResolution; dynamic import resolves at runtime
       const { newsReportPrompt } = await import('../../../lib/debate/prompts.js');
 
+      // t/2600: breadcrumb between the imports and the AI call so the FR's last
+      // event separates an extract/summarize throw (this phase) from an import
+      // throw (prior 'importing') and from the AI call (next 'generating').
+      getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debates', level: 'info', message: 'news-report: extracting', data: { debateId, phase: 'extracting' } });
       const { anNodes, anEdges, synthesisJson, docAnalysis, topic, audience } = extractNewsReportFields(session, transcript);
       const highlights = extractTranscriptHighlights(transcript as never[], anNodes as never[]);
       const argSummary = summarizeArgumentNetwork(anNodes as never[], anEdges as never[]);
       const prompt = newsReportPrompt(topic, synthesisJson, argSummary, highlights, docAnalysis, undefined, audience as import('../../../../lib/debate/types.js').DebateAudience | undefined);
+      // t/2600: breadcrumb immediately before the AI call — the top-ranked site for
+      // an intermittent prod 500 (backend/key/quota/timeout). If the FR's last
+      // event is 'generating', the throw is generateTextByUsage, not extract/import.
+      getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debates', level: 'info', message: 'news-report: generating', data: { debateId, phase: 'generating' } });
       const result = await ai.generateTextByUsage('server.news-report', { prompt });
       json(res, { article: result.text });
     } catch (err) {

--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -300,6 +300,10 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
       try {
         session = await fileIO.loadDebateSession(debateId) as Record<string, unknown>;
       } catch (loadErr) {
+        // t/2600: this instanceof discriminates not-found (404) from real faults (500).
+        // It is reliable ONLY because the server is a no-bundler tsc/nodenext build —
+        // one ActionableError module identity across storage + route. Revisit (switch to
+        // a duck-typed marker) if we ever adopt a bundler that could duplicate the class.
         if (loadErr instanceof ActionableError) {
           const notFound = new ActionableError({
             goal: 'Generate a news report for this debate',


### PR DESCRIPTION
Observability arm of **t/2600** (prod News Report 500, requestId e5edb0fb). The news-report handler's flight-recorder breadcrumbs stopped at `importing`, so triage can't separate an **import** vs **extract/summarize** vs **AI-call** throw without the full stack.

Adds two lifecycle breadcrumbs so the FR's last event pins the phase unambiguously:
`started → importing → extracting` (after the dynamic imports, before `extractNewsReportFields`) `→ generating` (immediately before `generateTextByUsage`).

Observability-only, behavior-neutral — self-cert `/trivial-change`. No route/behavior change (routeTable unaffected); server tsc + eslint green.

The **root-cause fix + regression test** follow once DevOps retrieves the e5edb0fb log/FR to pin the throw site (t/2600 stays In Progress). Analysis in t/2600#1 corroborates the TL ranking: candidate 1 (the AI call) is most likely for an intermittent prod 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)