### PR TITLE
chore(storage): import OpEdSetSummary from lib/oped/types — kill duplicate (t/2596)

### DIFF
--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -33,7 +33,7 @@ import { serializeEdgesJson } from '../../../../lib/edges/serializeEdges.js';
 export * from './debateStore.js';
 export * from './calibrationStore.js';
 export * from './urlFetch.js';
-export type { OpEdSetSummary } from './opedStore.js';
+export type { OpEdSetSummary } from '../../../../lib/oped/types.js';
 export { listOpedSets, loadOpedSet, saveOpedSetInProgress, loadOpedSetInProgress, finalizeOpedSet, deleteOpedSet, getOpedSetsQuotaStatus } from './opedStore.js';
 // ── Backend injection ──
 

--- a/taxonomy-editor/src/server/storage/opedStore.ts
+++ b/taxonomy-editor/src/server/storage/opedStore.ts
@@ -12,23 +12,12 @@
 
 import path from 'path';
 import { resolveDataPath } from '../config.js';
-import type { OpEdSet } from '../../../../lib/oped/types.js';
+import type { OpEdSet, OpEdSetSummary, PovKey } from '../../../../lib/oped/types.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { log } from '../logger.js';
 import { getStorageUserId, isAnonymousUser } from '../security/userContext.js';
 import { checkQuota, type QuotaCheckResult } from '../security/quotas.js';
 import { getUserContentBackend, assertSafeId } from './fileIO.js';
-
-// ── Summary type (index entry — cheap list surface, no full-doc loads) ──
-
-export interface OpEdSetSummary {
-  set_id: string;
-  topic: string;
-  camps: string[];       // pov keys from all members
-  voice_count: number;
-  created_at: string;
-  updated_at: string;   // stamped at finalizeOpedSet time
-}
 
 // ── Dir helpers ──
 
@@ -195,7 +184,7 @@ export async function finalizeOpedSet(set: OpEdSet): Promise<void> {
   const summary: OpEdSetSummary = {
     set_id: set.set_id,
     topic: set.topic,
-    camps: [...new Set(set.opeds.map(m => m.pov))],
+    camps: [...new Set(set.opeds.map(m => m.pov))] as PovKey[],
     voice_count: set.opeds.length,
     created_at: set.created_at,
     updated_at: now,


### PR DESCRIPTION
## Summary

- Remove local `OpEdSetSummary` interface from `opedStore.ts`; import from `lib/oped/types.js` (canonicalized by t/2591, PR #987)
- Cast `camps` as `PovKey[]` at the summary construction site (povs are already valid keys)
- Update `fileIO.ts` barrel to re-export `OpEdSetSummary` from lib directly instead of through opedStore
- No behaviour change — wire contract and server list output unchanged

## Test plan

- [x] tsc clean (server tsconfig)
- [x] 13/13 opedStore tests pass
- [x] `OpEdSetSummary` is the single definition used by both builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
