### PR TITLE
fix(oped): allow -Topic in FromPrep parameter set (t/2588)

### DIFF
--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -131,6 +131,7 @@ function New-OpEd {
     param(
         [Parameter(Mandatory, Position = 0, ParameterSetName = 'FromTopic')]
         [Parameter(Position = 0, ParameterSetName = 'FromUrl')]
+        [Parameter(ParameterSetName = 'FromPrep')]
         [ValidateNotNullOrEmpty()]
         [string]$Topic,
 

--- a/tests/New-OpEd.ParamSet.Tests.ps1
+++ b/tests/New-OpEd.ParamSet.Tests.ps1
@@ -1,0 +1,50 @@
+# Tag: unit (t/2588)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# Regression guard for t/2588: New-OpEd FromPrep parameter set must accept -Topic.
+# Root cause: [Parameter(ParameterSetName='FromPrep')] was missing on -Topic, so passing
+# both -Topic and -SourcePrep caused "parameter set cannot be resolved" (exit 1 in shim).
+
+#Requires -Module Pester
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'New-OpEd parameter set: FromPrep' -Tag 'unit' {
+
+    It 'Is exported from the module' {
+        Get-Command New-OpEd -Module AITriad -ErrorAction Stop | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Has a FromPrep parameter set' {
+        $cmd = Get-Command New-OpEd -Module AITriad -ErrorAction Stop
+        $setNames = $cmd.ParameterSets | Select-Object -ExpandProperty Name
+        $setNames | Should -Contain 'FromPrep'
+    }
+
+    It 'FromPrep parameter set includes Topic (regression: was missing, caused exit 1 in invoke-oped.ps1 shim)' {
+        $cmd = Get-Command New-OpEd -Module AITriad -ErrorAction Stop
+        $fromPrep = $cmd.ParameterSets | Where-Object Name -eq 'FromPrep'
+        $fromPrep | Should -Not -BeNullOrEmpty
+        $topicParam = $fromPrep.Parameters | Where-Object Name -eq 'Topic'
+        $topicParam | Should -Not -BeNullOrEmpty -Because 'shim always passes -Topic alongside -SourcePrep; missing attribute causes parameter set resolution failure'
+    }
+
+    It 'FromPrep parameter set includes SourcePrep as mandatory' {
+        $cmd = Get-Command New-OpEd -Module AITriad -ErrorAction Stop
+        $fromPrep = $cmd.ParameterSets | Where-Object Name -eq 'FromPrep'
+        $sourcePrepParam = $fromPrep.Parameters | Where-Object Name -eq 'SourcePrep'
+        $sourcePrepParam | Should -Not -BeNullOrEmpty
+        $sourcePrepParam.IsMandatory | Should -Be $true
+    }
+
+    It 'Topic is not mandatory in FromPrep (optional — shim omits it when unset)' {
+        $cmd = Get-Command New-OpEd -Module AITriad -ErrorAction Stop
+        $fromPrep = $cmd.ParameterSets | Where-Object Name -eq 'FromPrep'
+        $topicParam = $fromPrep.Parameters | Where-Object Name -eq 'Topic'
+        $topicParam.IsMandatory | Should -Be $false
+    }
+}

--- a/tests/New-OpEd.Tests.ps1
+++ b/tests/New-OpEd.Tests.ps1
@@ -206,6 +206,45 @@ Describe 'New-OpEd' -Tag 'oped' {
         }
     }
 
+    Context 'FromPrep parameter set' {
+        BeforeEach {
+            $script:capturedSystem = $null
+            $script:capturedPrompt = $null
+            Mock Invoke-AIApi -MockWith $script:MockAI -ModuleName AITriad
+            Mock Get-RelevantTaxonomyNodes { @() } -ModuleName AITriad
+        }
+
+        # Regression: t/2588 — -Topic was missing [Parameter(ParameterSetName='FromPrep')]
+        # so passing both -SourcePrep and -Topic together threw "parameter set cannot be resolved".
+        It 'Resolves FromPrep without error when both -SourcePrep and -Topic are passed' {
+            $Prep = [PSCustomObject]@{
+                Url                  = 'https://example.com/doc.pdf'
+                SourceMarkdown       = 'Artificial intelligence policy requires oversight and accountability mechanisms.'
+                SourceFormat         = 'pdf'
+                SourceExtractionTool = 'ConvertFrom-Pdf'
+                ReadableWords        = 12
+                ReadableRatio        = 0.92
+                SourceBrief          = [PSCustomObject]@{ thesis = 'AI needs oversight.'; readable = 'true' }
+            }
+            { New-OpEd -SourcePrep $Prep -Topic 'Explicit topic override' -Pov safetyist } |
+                Should -Not -Throw
+        }
+
+        It 'Uses SourcePrep.SourceMarkdown as the source material in the prompt' {
+            $Prep = [PSCustomObject]@{
+                Url                  = 'https://example.com/doc.pdf'
+                SourceMarkdown       = 'Unique source content marker for test assertion.'
+                SourceFormat         = 'pdf'
+                SourceExtractionTool = 'ConvertFrom-Pdf'
+                ReadableWords        = 8
+                ReadableRatio        = 0.88
+                SourceBrief          = [PSCustomObject]@{ thesis = 'test'; readable = 'true' }
+            }
+            New-OpEd -SourcePrep $Prep -Topic 'Explicit topic' -Pov safetyist | Out-Null
+            $script:capturedPrompt | Should -Match 'Unique source content marker'
+        }
+    }
+
     Context 'Degradation and errors' {
         # These exercise response handling, not grounding — run voice-only so no
         # retrieval subprocess is attempted.


### PR DESCRIPTION
## Summary

- `New-OpEd`'s `FromPrep` parameter set was missing `[Parameter(ParameterSetName='FromPrep')]` on `-Topic`
- This caused "parameter set cannot be resolved" when the `invoke-oped.ps1` shim passed both `-Topic` and `-SourcePrep` together — all voices failed with exit 1
- The fallback at line 270 already handles absent Topic in `FromPrep` mode; adding the attribute makes the user's topic available when provided via the hoist path

## Root cause

The `FromPrep` path in `New-OpEd` was added as part of t/2588's Stage A hoist. The shim (`invoke-oped.ps1`) always includes `Topic` in the splat, but `FromPrep` only declared `SourcePrep` as its parameter — causing PowerShell to fail parameter set resolution on every voice spawn.

## Test plan

- [ ] Shim test: `pwsh -File invoke-oped.ps1` with SourcePrep JSON stdin → exits 0 with valid result JSON (verified locally before this PR)
- [ ] CI green on this head
- [ ] Live `createOpEdSet` DevTools run with ≥2 voices completes with stage sequence: `preparing-source` → `queued` × N → `complete` × N

🤖 Generated with [Claude Code](https://claude.com/claude-code)