### PR TITLE
fix(main): concrete preload types for op-ed read methods (t/2607)

### DIFF
--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { contextBridge, ipcRenderer } from 'electron';
+import type { OpEdSet, OpEdSetSummary } from '../../../lib/oped/types.js';
 
 // Buffer debate-window-load IPC so it isn't lost if React mounts after did-finish-load
 // (happens with bootstrap.ts dynamic import indirection).
@@ -572,12 +573,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('oped-progress', listener);
     return () => { ipcRenderer.removeListener('oped-progress', listener); };
   },
-  listOpEdSets: (): Promise<unknown[]> =>
+  listOpEdSets: (): Promise<OpEdSetSummary[]> =>
     ipcRenderer.invoke('list-oped-sets'),
-  loadOpEdSet: (setId: string): Promise<unknown> =>
+  loadOpEdSet: (setId: string): Promise<OpEdSet> =>
     ipcRenderer.invoke('load-oped-set', setId),
   deleteOpEdSet: (setId: string): Promise<void> =>
     ipcRenderer.invoke('delete-oped-set', setId),
-  saveOpEdSet: (set: unknown): Promise<void> =>
+  saveOpEdSet: (set: OpEdSet): Promise<void> =>
     ipcRenderer.invoke('save-oped-set', set),
 });


### PR DESCRIPTION
## Summary
- Tightens `listOpEdSets` return type from `Promise<unknown[]>` → `Promise<OpEdSetSummary[]>`
- Tightens `loadOpEdSet` return type from `Promise<unknown>` → `Promise<OpEdSet>`
- Tightens `saveOpEdSet` parameter from `unknown` → `OpEdSet`
- Imports `OpEdSet` and `OpEdSetSummary` from `lib/oped/types.js` via `import type`

## Why
The loose `unknown` types allowed the renderer to cast freely, hiding the `OpEdSet[]` vs `OpEdSetSummary[]` mismatch that caused the t/2605 crash. With concrete types, a wrong cast is a compile error at the IPC boundary, not a runtime crash.

## Coordination
**Must land jointly with Rosetta t/2605.** This change alone correctly fails `tsc` if `OpEdTable` still casts `listOpEdSets` result to `OpEdSet[]` (the guard is working as intended). Rosetta lands their renderer fix; this lands simultaneously or immediately after.

## Test plan
- [ ] `tsc -p tsconfig.main.json` clean after Rosetta's t/2605 renderer fix lands
- [ ] CI green on this head

🤖 Generated with [Claude Code](https://claude.com/claude-code)