### PR TITLE
fix(opeds): My-Library renders OpEdSetSummary rows (fatal crash) (t/2605)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -17,7 +17,7 @@ import {
   localComputeEmbeddings,
 } from '../utils/localEmbedding';
 import { ActionableError } from '@lib/debate/errors';
-import type { OpEdSet } from '../../../../lib/oped/types';
+import type { OpEdSet, OpEdSetSummary } from '../../../../lib/oped/types';
 
 // Fire-and-forget: start local embedding init on module load.
 // Bridge is always available in Electron, so WASM-init-failed is harmless noise.
@@ -29,7 +29,7 @@ void tryInitLocalEmbedding();
 // we feature-detect (optional-chained cast) and reject with an honest ActionableError.
 // No stub to swap out: when t/2575 installs the real methods, these calls light up.
 type OpEdIpc = {
-  listOpEdSets?: () => Promise<OpEdSet[]>;
+  listOpEdSets?: () => Promise<OpEdSetSummary[]>;
   loadOpEdSet?: (id: string) => Promise<OpEdSet>;
   saveOpEdSet?: (set: OpEdSet) => Promise<void>;
   deleteOpEdSet?: (id: string) => Promise<void>;

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -82,7 +82,7 @@ export type DebateTestedEntry = _DebateTestedEntry;
 import type { DebateDelta as _DebateDelta } from '@lib/debate/types';
 export type DebateDelta = _DebateDelta;
 
-import type { OpEdSet, PovKey } from '../../../../lib/oped/types';
+import type { OpEdSet, OpEdSetSummary, PovKey } from '../../../../lib/oped/types';
 
 /** Op-Ed generation params (PR#2) — maps to New-OpEd cmdlet params; topic + voices
  *  travel separately in the payload (one New-OpEd call per selected voice). */
@@ -292,7 +292,7 @@ export interface AppAPI {
   saveDebateComments: (debateId: string, data: unknown) => Promise<void>;
 
   // --- Op-Ed Studio (t/2576; personal library — submit/copy route via community store) ---
-  listOpEdSets: () => Promise<OpEdSet[]>;
+  listOpEdSets: () => Promise<OpEdSetSummary[]>;
   loadOpEdSet: (id: string) => Promise<OpEdSet>;
   saveOpEdSet: (set: OpEdSet) => Promise<void>;
   deleteOpEdSet: (id: string) => Promise<void>;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -11,7 +11,7 @@ import { makeCancellationError } from './cancellation';
 import { ActionableError } from '@lib/debate/errors';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { ALL_API_KEY_BACKENDS } from '@lib/ai-client/types';
-import type { OpEdSet } from '../../../../lib/oped/types';
+import type { OpEdSet, OpEdSetSummary } from '../../../../lib/oped/types';
 import { encryptKeysForSharing, decryptKeysFromSharing } from '../utils/keyShareCrypto';
 import { resilientFetch, categorizeEndpoint, registerConnectionPoolProvider, type EndpointCategory } from './resilience';
 import { nextStepsForStatus } from './httpErrorSteps';
@@ -1019,7 +1019,7 @@ const rawApi: AppAPI = {
   // Op-Ed Studio (t/2576) — real routes against t/2573's server API (on main). The
   // personal-library path is /api/oped-sets (t/2599 live-smoke found the bridge had
   // assumed /api/opeds). Rename persists topic-only via PUT /api/oped-sets/:id (t/2594).
-  listOpEdSets: () => get<OpEdSet[]>('/api/oped-sets'),
+  listOpEdSets: () => get<OpEdSetSummary[]>('/api/oped-sets'),
   loadOpEdSet: (id) => get<OpEdSet>(`/api/oped-sets/${encodeURIComponent(id)}`),
   saveOpEdSet: (set) => put(`/api/oped-sets/${encodeURIComponent(set.set_id)}`, set).then(() => {}),
   deleteOpEdSet: (id) => del(`/api/oped-sets/${encodeURIComponent(id)}`).then(() => {}),

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -17,7 +17,7 @@ import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { useAuthStatus } from '../../hooks/useAuthStatus';
 import { useOpEdStore } from '../../hooks/useOpEdStore';
 import { useCommunityStore } from '../../hooks/useCommunityStore';
-import type { OpEdSet, OpEdCommunityEntry } from '../../../../../lib/oped/types';
+import type { OpEdSet, OpEdSetSummary, OpEdCommunityEntry } from '../../../../../lib/oped/types';
 import { OpEdTable } from './OpEdTable';
 import { OpEdReader } from './OpEdReader';
 import { NewOpEdDialog } from './NewOpEdDialog';
@@ -87,9 +87,10 @@ function exportOpEdSet(set: OpEdSet, format: string): void {
   else downloadFile(`${slugify(set.topic)}.md`, buildOpEdMarkdown(set), 'text/markdown');
 }
 
-function filterSets(sets: OpEdSet[], q: string): OpEdSet[] {
+function filterSets(sets: OpEdSetSummary[], q: string): OpEdSetSummary[] {
   if (!q) return sets;
-  return sets.filter(s => s.topic.toLowerCase().includes(q) || s.opeds.some(m => m.headline.toLowerCase().includes(q)));
+  // Index rows carry no bodies/headlines — filter on topic only (t/2605).
+  return sets.filter(s => s.topic.toLowerCase().includes(q));
 }
 
 function filterCommunity(entries: OpEdCommunityEntry[], q: string): OpEdCommunityEntry[] {
@@ -225,12 +226,18 @@ export function OpEdTab() {
   // ── Reader open/close ──
 
   const openMy = useCallback((id: string) => {
-    const found = sets.find(s => s.set_id === id) ?? null;
-    if (!found) return;
+    // The My list holds index summaries (no body) — load the full doc for the reader.
     selectSet(id);
     setReaderError(null);
-    setReaderSet(found);
-  }, [sets, selectSet]);
+    setReaderSet(null);
+    setReaderLoading(true);
+    api.loadOpEdSet(id).then(set => {
+      setReaderSet(set);
+    }).catch(err => {
+      recordError('oped-tab', 'Failed to load op-ed', err);
+      setReaderError('Could not load this op-ed — it may have been removed.');
+    }).finally(() => setReaderLoading(false));
+  }, [selectSet]);
 
   const openCommunity = useCallback((id: string) => {
     selectSet(id);
@@ -254,10 +261,17 @@ export function OpEdTab() {
   const handleCreated = useCallback(async (setId: string) => {
     setListView('my');
     await loadSets();
-    const found = useOpEdStore.getState().sets.find(s => s.set_id === setId) ?? null;
+    // loadSets returns index summaries (no body) — load the full doc for the reader.
     selectSet(setId);
     setReaderError(null);
-    setReaderSet(found);
+    setReaderSet(null);
+    setReaderLoading(true);
+    return api.loadOpEdSet(setId).then(set => {
+      setReaderSet(set);
+    }).catch(err => {
+      recordError('oped-tab', 'Failed to load new op-ed', err);
+      setReaderError('Could not load this op-ed.');
+    }).finally(() => setReaderLoading(false));
   }, [loadSets, selectSet]);
 
   // ── Row actions ──
@@ -269,23 +283,25 @@ export function OpEdTab() {
     });
   }, [renameSet, flash]);
 
-  const handleShare = useCallback((set: OpEdSet) => {
-    submitItem('oped', set).then(() => flash('Shared to community.')).catch(err => {
-      recordError('oped-tab', 'Failed to share op-ed to community', err);
-      flash(`Share failed: ${err}`);
-    });
+  const handleShare = useCallback((summary: OpEdSetSummary) => {
+    // The My row is an index summary — load the full doc before submitting.
+    api.loadOpEdSet(summary.set_id)
+      .then(set => submitItem('oped', set))
+      .then(() => flash('Shared to community.'))
+      .catch(err => {
+        recordError('oped-tab', 'Failed to share op-ed to community', err);
+        flash(`Share failed: ${err}`);
+      });
   }, [submitItem, flash]);
 
-  const handleExportMy = useCallback((set: OpEdSet, format: string) => {
-    try {
-      exportOpEdSet(set, format);
-    } catch (err) {
-      getGlobalRecorder()?.record({
-        type: 'system.error', component: 'oped-tab', level: 'error', message: 'Failed to export op-ed',
-        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+  const handleExportMy = useCallback((summary: OpEdSetSummary, format: string) => {
+    // buildOpEd* iterate set.opeds — the index row has none, so load the full doc.
+    api.loadOpEdSet(summary.set_id)
+      .then(set => exportOpEdSet(set, format))
+      .catch(err => {
+        recordError('oped-tab', 'Failed to export op-ed', err);
+        flash(`Export failed: ${err}`);
       });
-      flash(`Export failed: ${err}`);
-    }
   }, [flash]);
 
   const handleExportCommunity = useCallback((entry: OpEdCommunityEntry, format: string) => {

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
@@ -3,30 +3,18 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { OpEdTable, OpEdMyRow, OpEdCommunityRow, opEdCamps, opEdWordCount, applySortMy, applySortCommunity } from './OpEdTable';
-import type { OpEdSet, OpEdMember, OpEdCommunityEntry, PovKey } from '../../../../../lib/oped/types';
+import { OpEdTable, OpEdMyRow, OpEdCommunityRow, opEdCamps, applySortMy, applySortCommunity } from './OpEdTable';
+import type { OpEdSetSummary, OpEdCommunityEntry, PovKey } from '../../../../../lib/oped/types';
 
-function member(overrides: Partial<OpEdMember> = {}): OpEdMember {
+// The My list renders OpEdSetSummary index rows (no `opeds`/`params` body) — the
+// t/2605 crash was code that assumed the full OpEdSet here (`set.opeds` iteration).
+function makeSummary(overrides: Partial<OpEdSetSummary> = {}): OpEdSetSummary {
   return {
-    pov: 'safetyist',
-    status: 'complete',
-    headline: 'A headline',
-    subtitle: 'A subtitle',
-    body: 'Body text.',
-    wordCount: 800,
-    grounding: [],
-    ...overrides,
-  };
-}
-
-function makeSet(overrides: Partial<OpEdSet> = {}): OpEdSet {
-  return {
-    schema_version: 1,
     set_id: 'set-1',
     topic: 'Mandatory pre-deployment audits',
-    params: { wordCount: 800, model: 'gemini-3.6-flash', outlet: 'The Washington Post' },
     created_at: '2026-08-08T12:00:00Z',
-    opeds: [member()],
+    camps: ['safetyist'],
+    voice_count: 1,
     ...overrides,
   };
 }
@@ -64,39 +52,34 @@ const noopMyProps = {
   totalCount: 0,
 };
 
-describe('opEdCamps / opEdWordCount helpers', () => {
-  it('returns distinct camps in member order', () => {
-    const set = makeSet({ opeds: [member({ pov: 'skeptic' }), member({ pov: 'safetyist' }), member({ pov: 'skeptic' })] });
+describe('opEdCamps helper', () => {
+  it('returns the summary camps directly (no opeds iteration)', () => {
+    const set = makeSummary({ camps: ['skeptic', 'safetyist'] });
     expect(opEdCamps(set)).toEqual<PovKey[]>(['skeptic', 'safetyist']);
-  });
-
-  it('sums word counts across members', () => {
-    const set = makeSet({ opeds: [member({ wordCount: 800 }), member({ pov: 'skeptic', wordCount: 655 })] });
-    expect(opEdWordCount(set)).toBe(1455);
   });
 });
 
 describe('applySort — My / Community', () => {
   it('sorts My rows by date descending', () => {
     const rows = [
-      makeSet({ set_id: 'a', created_at: '2026-08-01T00:00:00Z' }),
-      makeSet({ set_id: 'b', created_at: '2026-08-09T00:00:00Z' }),
+      makeSummary({ set_id: 'a', created_at: '2026-08-01T00:00:00Z' }),
+      makeSummary({ set_id: 'b', created_at: '2026-08-09T00:00:00Z' }),
     ];
     const sorted = applySortMy(rows, { col: 'date', dir: 'desc' });
     expect(sorted[0].set_id).toBe('b');
   });
 
-  it('sorts My rows by words ascending', () => {
+  it('sorts My rows by camp ascending', () => {
     const rows = [
-      makeSet({ set_id: 'big', opeds: [member({ wordCount: 900 })] }),
-      makeSet({ set_id: 'small', opeds: [member({ wordCount: 300 })] }),
+      makeSummary({ set_id: 'skp', camps: ['skeptic'] }),
+      makeSummary({ set_id: 'acc', camps: ['accelerationist'] }),
     ];
-    const sorted = applySortMy(rows, { col: 'words', dir: 'asc' });
-    expect(sorted[0].set_id).toBe('small');
+    const sorted = applySortMy(rows, { col: 'camp', dir: 'asc' });
+    expect(sorted[0].set_id).toBe('acc');
   });
 
   it('returns rows unchanged when sort is none', () => {
-    const rows = [makeSet({ set_id: 'a' }), makeSet({ set_id: 'b' })];
+    const rows = [makeSummary({ set_id: 'a' }), makeSummary({ set_id: 'b' })];
     expect(applySortMy(rows, { col: null, dir: 'none' })).toBe(rows);
   });
 
@@ -111,7 +94,7 @@ describe('applySort — My / Community', () => {
 });
 
 describe('OpEdMyRow', () => {
-  function renderRow(set: OpEdSet, extra: Record<string, unknown> = {}) {
+  function renderRow(set: OpEdSetSummary, extra: Record<string, unknown> = {}) {
     return render(
       <table><tbody>
         <OpEdMyRow
@@ -134,39 +117,35 @@ describe('OpEdMyRow', () => {
     );
   }
 
-  it('renders topic as the headline and the outlet + word count', () => {
-    renderRow(makeSet());
+  it('renders the topic as the headline and the camp chip', () => {
+    const { container } = renderRow(makeSummary());
     expect(screen.getByText('Mandatory pre-deployment audits')).toBeTruthy();
-    expect(screen.getByText('The Washington Post')).toBeTruthy();
-    expect(screen.getByText('800')).toBeTruthy();
-  });
-
-  it('shows "— " for a missing outlet', () => {
-    renderRow(makeSet({ params: { wordCount: 800, model: 'm' } }));
-    expect(screen.getByText('—')).toBeTruthy();
+    // Camp chip renders the short label for safetyist.
+    expect(within(container.querySelector('.col-camp')!).getByText('Saf')).toBeTruthy();
   });
 
   it('shows a "▸ N voices" tag for multi-voice sets', () => {
-    renderRow(makeSet({ opeds: [member({ pov: 'skeptic' }), member({ pov: 'safetyist' })] }));
+    renderRow(makeSummary({ camps: ['skeptic', 'safetyist'], voice_count: 2 }));
     expect(screen.getByText('▸ 2 voices')).toBeTruthy();
   });
 
   it('Open button fires onOpen with the set id', () => {
     const onOpen = vi.fn();
-    renderRow(makeSet(), { onOpen });
+    renderRow(makeSummary(), { onOpen });
     fireEvent.click(screen.getByRole('button', { name: /open/i }));
     expect(onOpen).toHaveBeenCalledWith('set-1');
   });
 
-  it('Share button fires onShare', () => {
+  it('Share button fires onShare with the summary', () => {
     const onShare = vi.fn();
-    renderRow(makeSet(), { onShare });
+    const set = makeSummary();
+    renderRow(set, { onShare });
     fireEvent.click(screen.getByRole('button', { name: /share/i }));
-    expect(onShare).toHaveBeenCalled();
+    expect(onShare).toHaveBeenCalledWith(set);
   });
 
   it('renders a select checkbox in edit mode', () => {
-    renderRow(makeSet(), { editMode: true });
+    renderRow(makeSummary(), { editMode: true });
     expect(screen.getByRole('checkbox', { name: /select/i })).toBeTruthy();
   });
 });
@@ -230,10 +209,35 @@ describe('OpEdTable — My variant', () => {
   });
 
   it('renders a semantic table with an sr-only caption and sortable headers', () => {
-    render(<OpEdTable {...noopMyProps} rows={[makeSet()]} />);
+    render(<OpEdTable {...noopMyProps} rows={[makeSummary()]} />);
     const table = screen.getByRole('table');
     expect(within(table).getByText('My Op-Eds')).toBeTruthy();
     expect(screen.getByRole('columnheader', { name: /headline/i })).toBeTruthy();
+  });
+
+  // t/2605 regression: the full My table over a NON-EMPTY OpEdSetSummary[] must render
+  // camp chips + voice counts for every row without throwing. A prior version iterated
+  // `set.opeds` on the summary and crashed on the first non-empty list; an empty-rows
+  // test never exercised the row-render path and gave false confidence.
+  it('renders a non-empty My list with per-row camp chips + voice tags (no crash)', () => {
+    const rows = [
+      makeSummary({ set_id: 'multi', topic: 'Frontier model licensing', camps: ['safetyist', 'skeptic'], voice_count: 2 }),
+      makeSummary({ set_id: 'single', topic: 'Compute governance', camps: ['accelerationist'], voice_count: 1 }),
+    ];
+    render(<OpEdTable {...noopMyProps} rows={rows} totalCount={rows.length} />);
+
+    // Both topics render as headlines.
+    expect(screen.getByText('Frontier model licensing')).toBeTruthy();
+    expect(screen.getByText('Compute governance')).toBeTruthy();
+
+    // The multi-voice row shows its camp chips and the voices tag.
+    const multiRow = screen.getByText('Frontier model licensing').closest('tr')!;
+    expect(within(multiRow).getByText('Saf')).toBeTruthy();
+    expect(within(multiRow).getByText('Skp')).toBeTruthy();
+    expect(within(multiRow).getByText('▸ 2 voices')).toBeTruthy();
+
+    // Every row exposes an Open action — proves the full row body rendered.
+    expect(screen.getAllByRole('button', { name: /open/i })).toHaveLength(2);
   });
 });
 

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
@@ -9,7 +9,7 @@
 // "▸ N voices" tag on the headline.
 
 import { useState, useCallback, useEffect, useRef } from 'react';
-import type { OpEdSet, OpEdCommunityEntry, PovKey } from '../../../../../lib/oped/types';
+import type { OpEdSetSummary, OpEdCommunityEntry, PovKey } from '../../../../../lib/oped/types';
 import { CampGlyph, povToCamp } from '../shared/CampGlyph';
 import { POV_META } from '@lib/electron-shared/povMeta';
 import './OpEdTable.css';
@@ -30,7 +30,7 @@ interface SortState {
 
 export interface OpEdTableMyProps {
   variant: 'my';
-  rows: OpEdSet[];
+  rows: OpEdSetSummary[];
   loading: boolean;
   searchQuery: string;
   editMode: boolean;
@@ -42,8 +42,8 @@ export interface OpEdTableMyProps {
   setRenameValue: (v: string) => void;
   onRename: (id: string, topic: string) => void;
   onOpen: (id: string) => void;
-  onExport: (set: OpEdSet, format: string) => void;
-  onShare: (set: OpEdSet) => void;
+  onExport: (set: OpEdSetSummary, format: string) => void;
+  onShare: (set: OpEdSetSummary) => void;
   onNew: () => void;
   selectedSetId: string | null;
   totalCount: number;
@@ -79,30 +79,21 @@ function formatDate(iso: string): string {
   });
 }
 
-/** Distinct camps in a set, in first-seen member order. */
-export function opEdCamps(set: OpEdSet): PovKey[] {
-  const seen = new Set<PovKey>();
-  const out: PovKey[] = [];
-  for (const m of set.opeds) {
-    if (!seen.has(m.pov)) { seen.add(m.pov); out.push(m.pov); }
-  }
-  return out;
+/** Distinct camps in a set. The list API returns OpEdSetSummary, whose `camps` is
+ *  already deduped at the producer (t/2591) — the summary carries no `opeds` array,
+ *  so we read `camps` directly (the t/2605 crash was iterating `set.opeds` here). */
+export function opEdCamps(set: OpEdSetSummary): PovKey[] {
+  return set.camps;
 }
 
-/** Total words across a set (single-voice = the one member's count). */
-export function opEdWordCount(set: OpEdSet): number {
-  return set.opeds.reduce((sum, m) => sum + (m.wordCount ?? 0), 0);
-}
-
-export function applySortMy(rows: OpEdSet[], sort: SortState): OpEdSet[] {
+export function applySortMy(rows: OpEdSetSummary[], sort: SortState): OpEdSetSummary[] {
   if (!sort.col || sort.dir === 'none') return rows;
   const mul = sort.dir === 'asc' ? 1 : -1;
   return [...rows].sort((a, b) => {
     switch (sort.col) {
       case 'headline': return mul * (a.topic ?? '').localeCompare(b.topic ?? '');
       case 'camp':     return mul * opEdCamps(a).join(',').localeCompare(opEdCamps(b).join(','));
-      case 'outlet':   return mul * (a.params.outlet ?? '').localeCompare(b.params.outlet ?? '');
-      case 'words':    return mul * (opEdWordCount(a) - opEdWordCount(b));
+      // outlet/words are NOT on OpEdSetSummary — those columns are dropped from My (t/2605).
       case 'date':     return mul * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
       default:         return 0;
     }
@@ -272,7 +263,7 @@ export function OpEdMyRow({
   renamingId, setRenamingId, renameValue, setRenameValue, onRename,
   onOpen, onExport, onShare,
 }: {
-  set: OpEdSet;
+  set: OpEdSetSummary;
   isActive: boolean;
   editMode: boolean;
   isSelected: boolean;
@@ -283,15 +274,16 @@ export function OpEdMyRow({
   setRenameValue: (v: string) => void;
   onRename: (id: string, topic: string) => void;
   onOpen: (id: string) => void;
-  onExport: (set: OpEdSet, format: string) => void;
-  onShare: (set: OpEdSet) => void;
+  onExport: (set: OpEdSetSummary, format: string) => void;
+  onShare: (set: OpEdSetSummary) => void;
 }) {
   const camps = opEdCamps(set);
-  const words = opEdWordCount(set);
-  const voiceCount = set.opeds.length;
+  const voiceCount = set.voice_count;
   const isRenaming = renamingId === set.set_id;
   const headline = set.topic || 'Untitled op-ed';
-  const subtitle = voiceCount === 1 ? (set.opeds[0]?.subtitle ?? '') : '';
+  // OpEdSetSummary carries no per-member subtitle — the secondary line is the
+  // "▸ N voices" tag for multi-voice sets (OpEdHeadlineCell falls back to '' here).
+  const subtitle = '';
 
   const handleRowClick = useCallback(() => {
     if (editMode) onToggleSelect(set.set_id);
@@ -349,11 +341,7 @@ export function OpEdMyRow({
       {/* Camp */}
       <td className="col-camp"><CampChips camps={camps} /></td>
 
-      {/* Outlet */}
-      <td className="col-outlet" title={set.params.outlet ?? undefined}>{set.params.outlet || '—'}</td>
-
-      {/* Words */}
-      <td className="col-words">{words > 0 ? words : '—'}</td>
+      {/* Outlet + Words dropped (t/2605): OpEdSetSummary carries neither. */}
 
       {/* Date */}
       <td className="col-date" title={set.created_at}>{formatDate(set.created_at)}</td>
@@ -484,7 +472,9 @@ function MyTable(props: OpEdTableMyProps) {
   } = props;
   const [sort, onSort] = useSort();
   const sortedRows = applySortMy(rows, sort);
-  const colSpan = editMode ? 7 : 6;
+  // Columns: [cb?] headline · camp · date · actions — Outlet/Words dropped (t/2605,
+  // not on OpEdSetSummary).
+  const colSpan = editMode ? 5 : 4;
 
   return (
     <div className="oped-table-wrap" role="region" aria-label="My op-eds table">
@@ -494,8 +484,6 @@ function MyTable(props: OpEdTableMyProps) {
           {editMode && <col className="col-cb" />}
           <col className="col-headline" />
           <col className="col-camp" />
-          <col className="col-outlet" />
-          <col className="col-words" />
           <col className="col-date" />
           <col className="col-actions" />
         </colgroup>
@@ -507,12 +495,6 @@ function MyTable(props: OpEdTableMyProps) {
             </th>
             <th scope="col" className="col-camp" aria-sort={getSortAttr('camp', sort)}>
               <SortHeader label="Camp" col="camp" sort={sort} onSort={onSort} />
-            </th>
-            <th scope="col" className="col-outlet" aria-sort={getSortAttr('outlet', sort)}>
-              <SortHeader label="Outlet" col="outlet" sort={sort} onSort={onSort} />
-            </th>
-            <th scope="col" className="col-words" aria-sort={getSortAttr('words', sort)}>
-              <SortHeader label="Words" col="words" sort={sort} onSort={onSort} />
             </th>
             <th scope="col" className="col-date" aria-sort={getSortAttr('date', sort)}>
               <SortHeader label="Date" col="date" sort={sort} onSort={onSort} />

--- a/taxonomy-editor/src/renderer/hooks/useOpEdStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useOpEdStore.ts
@@ -4,7 +4,7 @@
 import { create } from 'zustand';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
-import type { OpEdSet } from '../../../../lib/oped/types';
+import type { OpEdSetSummary } from '../../../../lib/oped/types';
 
 // Personal Op-Ed library store (t/2576). A lean list/load/delete/rename surface over
 // the bridge trio — deliberately NOT a mirror of useDebateStore's state machine: an
@@ -15,8 +15,8 @@ import type { OpEdSet } from '../../../../lib/oped/types';
 // t/2573 routes). Community op-eds live in useCommunityStore alongside debates/chats.
 
 interface OpEdStore {
-  /** Personal op-ed sets (each set = one create run; single-voice is a set of 1). */
-  sets: OpEdSet[];
+  /** Personal op-ed sets as lightweight index rows (no body/params — load on open). */
+  sets: OpEdSetSummary[];
   /** set_id of the row open in the reader, or null for the table view. */
   selectedSetId: string | null;
   loading: boolean;
@@ -83,10 +83,13 @@ export const useOpEdStore = create<OpEdStore>((set, get) => ({
     const prev = get().sets;
     const target = prev.find(s => s.set_id === id);
     if (!target) return;
-    const updated: OpEdSet = { ...target, topic };
-    set({ sets: prev.map(s => (s.set_id === id ? updated : s)) });
+    // Optimistically patch the visible index row (topic is on the summary), but the
+    // persisted doc is the FULL set — the index carries no body, so we load-then-save
+    // the whole doc (a summary-only save would truncate opeds/params). t/2605.
+    set({ sets: prev.map(s => (s.set_id === id ? { ...s, topic } : s)) });
     try {
-      await api.saveOpEdSet(updated);
+      const full = await api.loadOpEdSet(id);
+      await api.saveOpEdSet({ ...full, topic });
     } catch (err) {
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'oped-store', level: 'error', message: 'Failed to rename op-ed set',


### PR DESCRIPTION
Fixes the fatal crash blanking the Op-Eds **My** tab on a non-empty library (blocks the t/2603 GA reveal).

**Root cause:** the My list holds `OpEdSetSummary` index rows (set_id/topic/camps/voice_count — no `opeds`/`params` body), but OpEdTable/useOpEdStore/OpEdTab still assumed the full `OpEdSet`. `opEdCamps` iterated `set.opeds` → `TypeError: set.opeds is not iterable` on the first non-empty render.

**Fix:**
- Retype the `listOpEdSets` chain end-to-end to `OpEdSetSummary[]` (bridge/types, web-bridge, electron-bridge, useOpEdStore).
- `opEdCamps` reads `set.camps`; drop `opEdWordCount` + the Words/Outlet columns (absent on the summary).
- Load the full doc on demand where a body is needed: reader open, export, share, rename (load-then-save — a summary-only write would truncate opeds/params).
- `filterSets` matches on topic only.

**Regression (the gap TL flagged):** OpEdTable.test.tsx now renders a **non-empty** My list (multi-camp + single-camp `OpEdSetSummary` rows), asserting camp chips, voice tags, and a per-row Open action. The prior suite mocked full `OpEdSet` rows + an empty-list render, so it never exercised the crashing row path.

**Verify:** renderer/main/server tsc clean · eslint 0 errors · OpEdTable.test.tsx 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)