### PR TITLE
feat(oped): lib/oped generation core — parallel voice fan-out + grounding (t/2608)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -1,0 +1,396 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { AIAdapter } from '../debate/aiAdapter.js';
+import type { PovKey } from '../debate/types.js';
+import type { ScoredPovNode, ScoredSituationNode } from '../debate/taxonomyRelevance.js';
+import { scoreNodeRelevance, selectRelevantNodes, selectRelevantSituationNodes } from '../debate/taxonomyRelevance.js';
+import { loadTaxonomy } from '../debate/taxonomyLoader.js';
+import { computeEmbedding } from '../embeddings/onnxEmbedding.js';
+import type { OpEdMember, OpEdParams, OpEdSet, OpEdGroundingRef } from './types.js';
+import { resolveOutletBand } from './outletBands.js';
+import { loadAndAssemblePrompt, assembleReflectionPrompt, type SourceBrief } from './promptLoader.js';
+
+// ── Public request / deps types ───────────────────────────────────────────────
+
+export interface GenerateOpEdRequest {
+  set_id: string;
+  topic: string;
+  params: OpEdParams;
+  povs: PovKey[];
+  /** P2 slot: pre-fetched source brief text (FromUrl). Omit for P1 FromTopic. */
+  sourceBrief?: string;
+  signal?: AbortSignal;
+}
+
+export interface OpEdGeneratorDeps {
+  adapter: AIAdapter;
+  /** Absolute path to dir containing op-ed-*.prompt files (shared PS+TS artifacts). */
+  promptsDir: string;
+  /** Repo root — locates soul-docs/ and taxonomy/embeddings data. */
+  repoRoot: string;
+}
+
+// ── Progress event union ──────────────────────────────────────────────────────
+
+export type OpEdProgressEvent =
+  | { type: 'grounding_done'; nodeCount: number }
+  | { type: 'grounding_failed'; error: string }
+  | { type: 'voice_start'; pov: PovKey }
+  | { type: 'voice_complete'; pov: PovKey; member: OpEdMember }
+  | { type: 'voice_failed'; pov: PovKey; error: string }
+  | { type: 'voice_cancelled'; pov: PovKey }
+  | { type: 'complete'; set: OpEdSet };
+
+// ── Soul doc (internal) ───────────────────────────────────────────────────────
+
+interface SoulVoice {
+  disposition: string;
+  style: string;
+  reasoning: string;
+  evidence: string;
+  signature: string;
+  prose_style: string;
+  voice_hygiene: string;
+}
+
+interface SoulDoc {
+  label: string;
+  personality: string;
+  voice: SoulVoice;
+  value_hierarchy: string[];
+  epistemic_stance: string[];
+  anti_patterns: string[];
+}
+
+// ── Soul doc helpers ──────────────────────────────────────────────────────────
+
+function loadSoulDoc(repoRoot: string, pov: PovKey): SoulDoc {
+  const soulPath = join(repoRoot, 'lib', 'debate', 'soul-docs', `${pov}.soul.json`);
+  return JSON.parse(readFileSync(soulPath, 'utf-8')) as SoulDoc;
+}
+
+function buildVoiceBlock(soul: SoulDoc): string {
+  const lines: string[] = [
+    `PERSONALITY: ${soul.personality}`,
+    `DISPOSITION: ${soul.voice.disposition}`,
+    `RHETORICAL STYLE: ${soul.voice.style}`,
+    `REASONING MODE: ${soul.voice.reasoning}`,
+    `PREFERRED EVIDENCE: ${soul.voice.evidence}`,
+    `SIGNATURE MOVE: ${soul.voice.signature}`,
+    '',
+    soul.voice.prose_style,
+    '',
+    soul.voice.voice_hygiene,
+    '',
+    'VALUE HIERARCHY (in priority order):',
+    ...soul.value_hierarchy.map((v, i) => `  ${i + 1}. ${v}`),
+    '',
+    'EPISTEMIC STANCE:',
+    ...soul.epistemic_stance.map(e => `  - ${e}`),
+    '',
+    'ANTI-PATTERNS (never do these):',
+    ...soul.anti_patterns.map(a => `  - ${a}`),
+  ];
+  return lines.join('\n');
+}
+
+// ── Grounding text formatting ─────────────────────────────────────────────────
+
+const VOICE_ONLY_GROUNDING = '(none — argue from your camp voice and general knowledge)';
+const VOICE_ONLY_SITUATIONS = '(none supplied)';
+
+function formatGroundingNodes(nodes: ScoredPovNode[]): string {
+  if (nodes.length === 0) return VOICE_ONLY_GROUNDING;
+  return nodes
+    .map(({ node, score: _score }) => {
+      const desc = node.description.length > 240 ? node.description.slice(0, 240) + '…' : node.description;
+      return `- [${node.id}] [${node.category}] ${node.label}: ${desc}`;
+    })
+    .join('\n');
+}
+
+function formatSituationNodes(nodes: ScoredSituationNode[]): string {
+  if (nodes.length === 0) return VOICE_ONLY_SITUATIONS;
+  return nodes
+    .map(({ node, score: _score }) => {
+      const desc = node.description.length > 300 ? node.description.slice(0, 300) + '…' : node.description;
+      return `- [${node.id}] ${node.label}: ${desc}`;
+    })
+    .join('\n');
+}
+
+function buildGroundingList(nodes: ScoredPovNode[], sitNodes: ScoredSituationNode[]): string {
+  const bdiLines = nodes.map(
+    ({ node }) => `- [${node.id}] (bdi/${node.category}) ${node.label}`,
+  );
+  const sitLines = sitNodes.map(
+    ({ node }) => `- [${node.id}] (situation/Situation) ${node.label}`,
+  );
+  return [...bdiLines, ...sitLines].join('\n');
+}
+
+// ── Essay response schema ─────────────────────────────────────────────────────
+
+const ESSAY_SCHEMA = {
+  type: 'object',
+  properties: {
+    headline: { type: 'string' },
+    subtitle: { type: 'string' },
+    body_markdown: { type: 'string' },
+    word_count: { type: 'integer' },
+    pitch_email: { type: 'string' },
+    stance: { type: 'string', description: 'How the camp engages the source: agree/extend/rebut (or empty if no source)' },
+  },
+  required: ['headline', 'body_markdown', 'word_count'],
+} as const;
+
+const REFLECTION_SCHEMA = {
+  type: 'object',
+  properties: {
+    grounding_usage: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          reflection: { type: 'string' },
+        },
+        required: ['id', 'reflection'],
+      },
+    },
+  },
+  required: ['grounding_usage'],
+} as const;
+
+// ── Per-voice generation ──────────────────────────────────────────────────────
+
+interface EssayResponse {
+  headline: string;
+  subtitle?: string;
+  body_markdown: string;
+  word_count?: number;
+  pitch_email?: string;
+  stance?: string;
+}
+
+interface ReflectionResponse {
+  grounding_usage: { id: string; reflection: string }[];
+}
+
+async function runVoiceGeneration(
+  pov: PovKey,
+  groundingNodes: ScoredPovNode[],
+  sitNodes: ScoredSituationNode[],
+  request: GenerateOpEdRequest,
+  deps: OpEdGeneratorDeps,
+): Promise<OpEdMember> {
+  const soul = loadSoulDoc(deps.repoRoot, pov);
+  const band = resolveOutletBand(request.params.outlet);
+  const targetWords = request.params.wordCount > 0 ? request.params.wordCount : band.words;
+  const maxTokens = Math.ceil(targetWords * 3) + 5000;
+
+  const { system, user } = loadAndAssemblePrompt(deps.promptsDir, {
+    topic: request.topic,
+    params: request.params,
+    pov,
+    povLabel: soul.label,
+    voiceBlock: buildVoiceBlock(soul),
+    groundingNodes: formatGroundingNodes(groundingNodes),
+    situations: formatSituationNodes(sitNodes),
+    sourceMaterial: request.sourceBrief ?? '(no external source supplied — argue from the topic and general knowledge)',
+    outletGuidance: band.guidance,
+    targetWords,
+  });
+
+  // Prepend system to prompt — generateText has no separate system channel;
+  // adapters that support adapter.generate() can be wired later for native system messages.
+  const fullPrompt = `${system}\n\n---\n\n${user}`;
+  const rawText = await deps.adapter.generateText(fullPrompt, request.params.model, {
+    maxTokens,
+    temperature: 0.8,
+    responseSchema: ESSAY_SCHEMA as Record<string, unknown>,
+    signal: request.signal,
+  });
+
+  let parsed: EssayResponse;
+  try {
+    parsed = JSON.parse(rawText) as EssayResponse;
+  } catch {
+    parsed = { headline: '', body_markdown: rawText, word_count: undefined };
+  }
+
+  const body = parsed.body_markdown ?? '';
+  const actualWordCount = body.trim() ? body.trim().split(/\s+/).length : 0;
+
+  // Build initial grounding refs (reflection populated below if grounding was used)
+  const allGroundingRefs: OpEdGroundingRef[] = [
+    ...groundingNodes.map(({ node, score }) => ({
+      node_id: node.id,
+      label: node.label,
+      category: String(node.category),
+      pov,
+      relevance: score.toFixed(4),
+      how_reflected: '(not reported)',
+    })),
+    ...sitNodes.map(({ node, score }) => ({
+      node_id: node.id,
+      label: node.label,
+      category: 'Situation',
+      pov,
+      relevance: score.toFixed(4),
+      how_reflected: '(not reported)',
+    })),
+  ];
+
+  // Reflection pass — best-effort, maps grounding elements to where they appear
+  if (allGroundingRefs.length > 0 && body) {
+    try {
+      const groundingList = buildGroundingList(groundingNodes, sitNodes);
+      const reflPrompt = assembleReflectionPrompt(deps.promptsDir, body, groundingList);
+      const reflMaxTokens = Math.max(4000, allGroundingRefs.length * 150 + 3000);
+      const reflRaw = await deps.adapter.generateText(reflPrompt, request.params.model, {
+        maxTokens: reflMaxTokens,
+        temperature: 0.2,
+        responseSchema: REFLECTION_SCHEMA as Record<string, unknown>,
+        signal: request.signal,
+      });
+      const reflParsed = JSON.parse(reflRaw) as ReflectionResponse;
+      const usageMap = new Map(reflParsed.grounding_usage.map(u => [u.id, u.reflection]));
+      for (const ref of allGroundingRefs) {
+        const refl = usageMap.get(ref.node_id);
+        if (refl) ref.how_reflected = refl;
+      }
+    } catch {
+      // Reflection failure is non-fatal — how_reflected stays '(not reported)'
+    }
+  }
+
+  return {
+    pov,
+    status: 'complete',
+    headline: parsed.headline ?? '',
+    subtitle: parsed.subtitle ?? '',
+    body,
+    pitch: parsed.pitch_email || undefined,
+    wordCount: actualWordCount,
+    grounding: allGroundingRefs,
+  };
+}
+
+// ── Main exported generator ───────────────────────────────────────────────────
+
+/**
+ * Generate a multi-voice op-ed set, yielding progress events.
+ * Voices run in parallel (Promise.all fan-out). Grounding failure degrades to
+ * voice-only rather than throwing. Signal is threaded into every AI call.
+ * Always yields `{ type: 'complete', set }` last — set.opeds carries all
+ * members including failed/cancelled (partial-set contract, e/91#2 cond. 1).
+ */
+export async function* generateOpEdSet(
+  request: GenerateOpEdRequest,
+  deps: OpEdGeneratorDeps,
+): AsyncGenerator<OpEdProgressEvent> {
+  // ── Step 1: grounding (once, shared across voices) ────────────────────────
+  let groundingNodes: ScoredPovNode[] = [];
+  let sitNodes: ScoredSituationNode[] = [];
+
+  try {
+    const taxonomy = loadTaxonomy(deps.repoRoot);
+    const queryParts = [request.topic, request.params.newsHook, request.params.thesis].filter(Boolean);
+    const query = queryParts.join('. ');
+    const vec = await computeEmbedding(query);
+    const scores = scoreNodeRelevance(vec, taxonomy.embeddings);
+
+    // Use first pov to select BDI nodes — all voices get the same grounding set
+    // (semantically appropriate: the topic is shared; voice differences are in voice block)
+    const firstPov = request.povs[0];
+    if (firstPov) {
+      groundingNodes = selectRelevantNodes(
+        taxonomy[firstPov]?.nodes ?? [],
+        scores,
+        undefined, // use default threshold
+        2,         // minPerCategory
+        12,        // maxTotal — mirrors PS MaxGroundingNodes default
+      );
+    }
+    sitNodes = selectRelevantSituationNodes(
+      taxonomy.situations?.nodes ?? [],
+      scores,
+      undefined,
+      1,
+      3,
+    );
+    yield { type: 'grounding_done', nodeCount: groundingNodes.length + sitNodes.length };
+  } catch (err) {
+    yield { type: 'grounding_failed', error: String(err) };
+    // continue voice-only
+  }
+
+  // ── Step 2: parallel voice fan-out ────────────────────────────────────────
+  const queue: OpEdProgressEvent[] = [];
+  let wakeResolve: (() => void) | null = null;
+  let remaining = request.povs.length;
+  const members: { pov: PovKey; member: OpEdMember }[] = [];
+
+  function enqueue(ev: OpEdProgressEvent): void {
+    queue.push(ev);
+    const r = wakeResolve;
+    wakeResolve = null;
+    r?.();
+  }
+
+  async function runVoice(pov: PovKey): Promise<void> {
+    if (request.signal?.aborted) {
+      members.push({ pov, member: { pov, status: 'cancelled', headline: '', subtitle: '', body: '', wordCount: 0, grounding: [] } });
+      enqueue({ type: 'voice_cancelled', pov });
+    } else {
+      enqueue({ type: 'voice_start', pov });
+      try {
+        const member = await runVoiceGeneration(pov, groundingNodes, sitNodes, request, deps);
+        members.push({ pov, member });
+        enqueue({ type: 'voice_complete', pov, member });
+      } catch (err) {
+        const cancelled = request.signal?.aborted;
+        members.push({ pov, member: { pov, status: cancelled ? 'cancelled' : 'failed', headline: '', subtitle: '', body: '', wordCount: 0, grounding: [] } });
+        if (cancelled) {
+          enqueue({ type: 'voice_cancelled', pov });
+        } else {
+          enqueue({ type: 'voice_failed', pov, error: String(err) });
+        }
+      }
+    }
+    remaining--;
+    const r = wakeResolve;
+    wakeResolve = null;
+    r?.();
+  }
+
+  void Promise.all(request.povs.map(pov => runVoice(pov)));
+
+  while (remaining > 0 || queue.length > 0) {
+    while (queue.length > 0) {
+      yield queue.shift()!;
+    }
+    if (remaining > 0 && queue.length === 0) {
+      await new Promise<void>(r => { wakeResolve = r; });
+    }
+  }
+
+  // ── Step 3: assemble set (preserve request.povs order) ───────────────────
+  const memberMap = new Map(members.map(({ pov, member }) => [pov, member]));
+  const orderedMembers = request.povs.map(pov => memberMap.get(pov)!).filter(Boolean);
+
+  const set: OpEdSet = {
+    schema_version: 1,
+    set_id: request.set_id,
+    topic: request.topic,
+    params: request.params,
+    created_at: new Date().toISOString(),
+    opeds: orderedMembers,
+  };
+
+  yield { type: 'complete', set };
+}

--- a/lib/oped/groundingSelection.test.ts
+++ b/lib/oped/groundingSelection.test.ts
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import {
+  selectRelevantNodes,
+  selectRelevantSituationNodes,
+  scoreNodeRelevance,
+} from '../debate/taxonomyRelevance.js';
+import type { PovNode, SituationNode } from '../debate/taxonomyTypes.js';
+
+// ── Fixture nodes ─────────────────────────────────────────────────────────────
+
+function makePovNode(id: string, category: 'Belief' | 'Desire' | 'Intention', label: string): PovNode {
+  return {
+    id,
+    category,
+    label,
+    description: `Description for ${label}`,
+    parent_id: null,
+    children: [],
+  };
+}
+
+function makeSitNode(id: string, label: string): SituationNode {
+  return {
+    id,
+    label,
+    description: `Situation: ${label}`,
+    parent_id: null,
+    interpretations: {
+      accelerationist: { summary: '' },
+      safetyist: { summary: '' },
+      skeptic: { summary: '' },
+    },
+  };
+}
+
+const POV_NODES: PovNode[] = [
+  makePovNode('saf-bel-001', 'Belief', 'AI systems are dangerous'),
+  makePovNode('saf-bel-002', 'Belief', 'Unaligned AI is existential'),
+  makePovNode('saf-des-001', 'Desire', 'Slow AI deployment'),
+  makePovNode('saf-des-002', 'Desire', 'Enforce safety standards'),
+  makePovNode('saf-int-001', 'Intention', 'Advocate for regulation'),
+  makePovNode('saf-int-002', 'Intention', 'Support interpretability research'),
+];
+
+const SIT_NODES: SituationNode[] = [
+  makeSitNode('sit-001', 'Misuse of open-weight models'),
+  makeSitNode('sit-002', 'Runaway autonomous agent'),
+  makeSitNode('sit-003', 'Regulatory capture'),
+];
+
+// ── Fixture embeddings (deterministic — no actual model calls) ────────────────
+
+// Simple unit vectors for cosine similarity: higher dot product = higher score
+const EMBEDDINGS: Record<string, { pov: string; vector: number[] }> = {
+  'saf-bel-001': { pov: 'safetyist', vector: [0.9, 0.1, 0.0] },  // highest
+  'saf-bel-002': { pov: 'safetyist', vector: [0.8, 0.2, 0.0] },
+  'saf-des-001': { pov: 'safetyist', vector: [0.5, 0.5, 0.0] },
+  'saf-des-002': { pov: 'safetyist', vector: [0.4, 0.6, 0.0] },
+  'saf-int-001': { pov: 'safetyist', vector: [0.3, 0.3, 0.1] },
+  'saf-int-002': { pov: 'safetyist', vector: [0.2, 0.2, 0.1] },  // lowest
+  'sit-001': { pov: 'situations', vector: [0.85, 0.15, 0.0] },
+  'sit-002': { pov: 'situations', vector: [0.6,  0.4,  0.0] },
+  'sit-003': { pov: 'situations', vector: [0.1,  0.1,  0.0] },   // lowest
+};
+
+// Query vector aligned with saf-bel-001 direction
+const QUERY_VECTOR = [1.0, 0.0, 0.0];
+
+describe('scoreNodeRelevance', () => {
+  it('returns a score for every node in the embeddings map', () => {
+    const scores = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    expect(scores.size).toBe(Object.keys(EMBEDDINGS).length);
+  });
+
+  it('produces the same Map on repeated calls with the same inputs', () => {
+    const first = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    const second = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    for (const [id, score] of first) {
+      expect(second.get(id)).toBe(score);
+    }
+  });
+
+  it('scores saf-bel-001 higher than saf-int-002 for a query aligned with belief', () => {
+    const scores = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    expect(scores.get('saf-bel-001')!).toBeGreaterThan(scores.get('saf-int-002')!);
+  });
+});
+
+describe('selectRelevantNodes', () => {
+  it('returns the same node ids in the same order on repeated calls', () => {
+    const scores = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    const first = selectRelevantNodes(POV_NODES, scores, 0.0, 1, 6);
+    const second = selectRelevantNodes(POV_NODES, scores, 0.0, 1, 6);
+    const firstIds = first.map(n => n.node.id);
+    const secondIds = second.map(n => n.node.id);
+    expect(firstIds).toEqual(secondIds);
+  });
+
+  it('respects maxTotal — never returns more nodes than the cap', () => {
+    const scores = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    const result = selectRelevantNodes(POV_NODES, scores, 0.0, 1, 3);
+    expect(result.length).toBeLessThanOrEqual(3);
+  });
+
+  it('ranks saf-bel-001 before saf-int-002 when both pass threshold', () => {
+    const scores = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    const result = selectRelevantNodes(POV_NODES, scores, 0.0, 1, 6);
+    const ids = result.map(n => n.node.id);
+    const bel001Idx = ids.indexOf('saf-bel-001');
+    const int002Idx = ids.indexOf('saf-int-002');
+    if (bel001Idx !== -1 && int002Idx !== -1) {
+      expect(bel001Idx).toBeLessThan(int002Idx);
+    }
+  });
+});
+
+describe('selectRelevantSituationNodes', () => {
+  it('returns the same situation ids in the same order on repeated calls', () => {
+    const scores = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    const first = selectRelevantSituationNodes(SIT_NODES, scores, 0.0, 1, 3);
+    const second = selectRelevantSituationNodes(SIT_NODES, scores, 0.0, 1, 3);
+    expect(first.map(n => n.node.id)).toEqual(second.map(n => n.node.id));
+  });
+
+  it('ranks sit-001 above sit-003 for the fixture query', () => {
+    const scores = scoreNodeRelevance(QUERY_VECTOR, EMBEDDINGS);
+    const result = selectRelevantSituationNodes(SIT_NODES, scores, 0.0, 1, 3);
+    const ids = result.map(n => n.node.id);
+    const sit001Idx = ids.indexOf('sit-001');
+    const sit003Idx = ids.indexOf('sit-003');
+    if (sit001Idx !== -1 && sit003Idx !== -1) {
+      expect(sit001Idx).toBeLessThan(sit003Idx);
+    }
+  });
+});

--- a/lib/oped/outletBands.ts
+++ b/lib/oped/outletBands.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+export interface OutletBand {
+  words: number;
+  guidance: string;
+}
+
+export const OUTLET_BANDS: Readonly<Record<string, OutletBand>> = {
+  WashingtonPost: {
+    words: 800,
+    guidance: 'The Washington Post: max 800 words, strong news hook, hyperlink-able sources, zero jargon; national public audience.',
+  },
+  NYTimes: {
+    words: 800,
+    guidance: 'The New York Times Guest Essay: ~800 words, sharp thesis, general national readership.',
+  },
+  WallStreetJournal: {
+    words: 900,
+    guidance: 'The Wall Street Journal: 600-1200 words, rapid thesis, business/policy relevance, market and regulatory framing, zero jargon; executives, investors, policymakers.',
+  },
+  USAToday: {
+    words: 650,
+    guidance: 'USA Today: 550-750 words, embed verifiable source references, plain and direct; broad national audience.',
+  },
+  ForeignAffairs: {
+    words: 1200,
+    guidance: 'Foreign Affairs / policy platform: 800-1500 words, deeper structural analysis permitted; subject specialists, Hill staff, agency officials.',
+  },
+  Politico: {
+    words: 1000,
+    guidance: 'Politico: ~1000 words, policy-mechanics focus, timely; Hill and agency audience.',
+  },
+  Regional: {
+    words: 650,
+    guidance: 'Regional / local daily: 500-800 words, direct regional relevance, local anecdotes, state-level calls to action; municipal voters and state legislators.',
+  },
+  Generic: {
+    words: 800,
+    guidance: 'General-interest opinion desk: ~800 words, strong news hook, plain language, broad public audience.',
+  },
+};
+
+export function resolveOutletBand(outlet: string | undefined): OutletBand {
+  return OUTLET_BANDS[outlet ?? 'Generic'] ?? OUTLET_BANDS['Generic']!;
+}

--- a/lib/oped/promptAssembly.test.ts
+++ b/lib/oped/promptAssembly.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadAndAssemblePrompt, assembleReflectionPrompt, type PromptContext } from './promptLoader.js';
+
+// Fixture prompt templates — minimal placeholders that cover every interpolation key
+const SYSTEM_TEMPLATE =
+  'SYSTEM|{{POV_LABEL}}|{{VOICE_BLOCK}}|{{WORD_COUNT}}|{{OUTLET_GUIDANCE}}';
+const USER_TEMPLATE =
+  'USER|{{TOPIC}}|{{WORD_COUNT}}|{{OUTLET_GUIDANCE}}|{{NEWS_HOOK}}|{{THESIS}}|{{AUTHOR_BIO}}' +
+  '|{{SOURCE_MATERIAL}}|{{GROUNDING_NODES}}|{{SITUATIONS}}|{{PITCH_INSTRUCTION}}' +
+  '|{{SOURCE_AUTHOR}}|{{SOURCE_ACTOR_TYPE}}|{{SOURCE_THESIS}}|{{SOURCE_STANCE}}' +
+  '|{{SOURCE_RECOMMENDATIONS}}';
+const REFLECTION_TEMPLATE = 'REFL|{{OPED_BODY}}|{{GROUNDING_LIST}}';
+
+let promptsDir: string;
+
+beforeAll(() => {
+  promptsDir = mkdtempSync(join(tmpdir(), 'oped-prompts-test-'));
+  writeFileSync(join(promptsDir, 'op-ed-generation-system.prompt'), SYSTEM_TEMPLATE, 'utf-8');
+  writeFileSync(join(promptsDir, 'op-ed-generation-user.prompt'), USER_TEMPLATE, 'utf-8');
+  writeFileSync(join(promptsDir, 'op-ed-grounding-reflection.prompt'), REFLECTION_TEMPLATE, 'utf-8');
+});
+
+afterAll(() => {
+  rmSync(promptsDir, { recursive: true, force: true });
+});
+
+const FIXTURE_CTX: PromptContext = {
+  topic: 'Mandatory AI audits',
+  params: {
+    wordCount: 800,
+    outlet: 'Generic',
+    newsHook: 'Senate AI bill next week',
+    thesis: 'Audits prevent catastrophic failures',
+    authorBio: 'A researcher at MIT',
+    model: 'gemini-3.7-flash',
+  },
+  pov: 'safetyist',
+  povLabel: 'The Safetyist',
+  voiceBlock: 'VOICE: cautious and evidence-driven',
+  groundingNodes: '- [saf-bel-001] [Belief] AI is dangerous: It really is.',
+  situations: '- [sit-001] Runaway model: Bad outcome.',
+  sourceMaterial: '(no external source supplied — argue from the topic and general knowledge)',
+  outletGuidance: 'Generic: ~800 words',
+  targetWords: 800,
+};
+
+describe('loadAndAssemblePrompt', () => {
+  it('produces byte-identical output on repeated calls with the same inputs', () => {
+    const first = loadAndAssemblePrompt(promptsDir, FIXTURE_CTX);
+    const second = loadAndAssemblePrompt(promptsDir, FIXTURE_CTX);
+    expect(first.system).toBe(second.system);
+    expect(first.user).toBe(second.user);
+  });
+
+  it('interpolates POV_LABEL and VOICE_BLOCK into system prompt', () => {
+    const { system } = loadAndAssemblePrompt(promptsDir, FIXTURE_CTX);
+    expect(system).toContain('The Safetyist');
+    expect(system).toContain('VOICE: cautious and evidence-driven');
+    expect(system).toContain('800');
+    expect(system).toContain('Generic: ~800 words');
+  });
+
+  it('interpolates topic, news hook, thesis, and grounding into user prompt', () => {
+    const { user } = loadAndAssemblePrompt(promptsDir, FIXTURE_CTX);
+    expect(user).toContain('Mandatory AI audits');
+    expect(user).toContain('Senate AI bill next week');
+    expect(user).toContain('Audits prevent catastrophic failures');
+    expect(user).toContain('saf-bel-001');
+    expect(user).toContain('sit-001');
+  });
+
+  it('fills missing optional fields with descriptive fallbacks', () => {
+    const ctx: PromptContext = {
+      ...FIXTURE_CTX,
+      params: { ...FIXTURE_CTX.params, newsHook: undefined, thesis: undefined, authorBio: undefined },
+    };
+    const { user } = loadAndAssemblePrompt(promptsDir, ctx);
+    expect(user).toContain('none supplied');
+  });
+
+  it('interpolates sourceBrief fields when present', () => {
+    const ctx: PromptContext = {
+      ...FIXTURE_CTX,
+      sourceBrief: {
+        author: 'Jane Doe',
+        thesis: 'AI is risky',
+        stance: 'cautionary',
+        primary_recommendations: ['Audit', 'Regulate'],
+      },
+    };
+    const { user } = loadAndAssemblePrompt(promptsDir, ctx);
+    expect(user).toContain('Jane Doe');
+    expect(user).toContain('AI is risky');
+    expect(user).toContain('Audit; Regulate');
+  });
+
+  it('leaves no unresolved {{PLACEHOLDER}} tokens', () => {
+    const { system, user } = loadAndAssemblePrompt(promptsDir, FIXTURE_CTX);
+    expect(system).not.toMatch(/\{\{\w+\}\}/);
+    expect(user).not.toMatch(/\{\{\w+\}\}/);
+  });
+});
+
+describe('assembleReflectionPrompt', () => {
+  it('produces byte-identical output on repeated calls', () => {
+    const body = 'The essay body text.';
+    const list = '- [saf-bel-001] (bdi/Belief) AI is dangerous';
+    const first = assembleReflectionPrompt(promptsDir, body, list);
+    const second = assembleReflectionPrompt(promptsDir, body, list);
+    expect(first).toBe(second);
+  });
+
+  it('interpolates OPED_BODY and GROUNDING_LIST', () => {
+    const result = assembleReflectionPrompt(
+      promptsDir,
+      'Essay body here.',
+      '- [saf-bel-001] label',
+    );
+    expect(result).toContain('Essay body here.');
+    expect(result).toContain('saf-bel-001');
+  });
+});

--- a/lib/oped/promptLoader.ts
+++ b/lib/oped/promptLoader.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import type { OpEdParams } from './types.js';
+import type { PovKey } from '../debate/types.js';
+
+export interface SourceBrief {
+  author?: string;
+  actor_type?: string;
+  thesis?: string;
+  stance?: string;
+  primary_recommendations?: string[];
+  key_claims?: string[];
+  readable?: string;
+}
+
+export interface PromptContext {
+  topic: string;
+  params: OpEdParams;
+  pov: PovKey;
+  povLabel: string;
+  voiceBlock: string;
+  groundingNodes: string;
+  situations: string;
+  sourceMaterial: string;
+  sourceBrief?: SourceBrief;
+  outletGuidance: string;
+  targetWords: number;
+}
+
+export interface AssembledPrompt {
+  system: string;
+  user: string;
+}
+
+function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => vars[key] ?? '');
+}
+
+export function loadPromptTemplate(promptsDir: string, name: string): string {
+  return readFileSync(join(promptsDir, `${name}.prompt`), 'utf-8');
+}
+
+export function loadAndAssemblePrompt(promptsDir: string, ctx: PromptContext): AssembledPrompt {
+  const newsHookText = ctx.params.newsHook?.trim()
+    ? ctx.params.newsHook
+    : '(none supplied — invent a plausible current news hook and make clear in the lede what timely event it assumes, so the author can verify it against real events before submitting)';
+  const thesisText = ctx.params.thesis?.trim()
+    ? ctx.params.thesis
+    : '(none supplied — derive a clear, arguable thesis that follows from your camp value hierarchy)';
+  const authorBioText = ctx.params.authorBio?.trim()
+    ? ctx.params.authorBio
+    : '(none supplied — write a generic authority line the author can replace, e.g. "[Author], [affiliation]")';
+
+  const system = interpolate(loadPromptTemplate(promptsDir, 'op-ed-generation-system'), {
+    POV_LABEL: ctx.povLabel,
+    VOICE_BLOCK: ctx.voiceBlock,
+    WORD_COUNT: String(ctx.targetWords),
+    OUTLET_GUIDANCE: ctx.outletGuidance,
+  });
+
+  const user = interpolate(loadPromptTemplate(promptsDir, 'op-ed-generation-user'), {
+    TOPIC: ctx.topic,
+    WORD_COUNT: String(ctx.targetWords),
+    OUTLET_GUIDANCE: ctx.outletGuidance,
+    NEWS_HOOK: newsHookText,
+    THESIS: thesisText,
+    AUTHOR_BIO: authorBioText,
+    SOURCE_MATERIAL: ctx.sourceMaterial,
+    GROUNDING_NODES: ctx.groundingNodes,
+    SITUATIONS: ctx.situations,
+    PITCH_INSTRUCTION:
+      'ALSO write a pitch cover email in "pitch_email". Use this layout: a subject line "Op-Ed Submission: [Headline]"; one or two sentences opening with the news hook and summarizing the thesis and proposed solution; one sentence of author credentials; and a closing note that the full draft is pasted below. Keep it under 150 words and do not paste the essay itself into the pitch.',
+    SOURCE_AUTHOR: ctx.sourceBrief?.author ?? '',
+    SOURCE_ACTOR_TYPE: ctx.sourceBrief?.actor_type ?? '',
+    SOURCE_THESIS: ctx.sourceBrief?.thesis ?? '',
+    SOURCE_STANCE: ctx.sourceBrief?.stance ?? '',
+    SOURCE_RECOMMENDATIONS: ctx.sourceBrief?.primary_recommendations?.join('; ') ?? '',
+  });
+
+  return { system, user };
+}
+
+export function assembleReflectionPrompt(
+  promptsDir: string,
+  opedBody: string,
+  groundingList: string,
+): string {
+  return interpolate(loadPromptTemplate(promptsDir, 'op-ed-grounding-reflection'), {
+    OPED_BODY: opedBody,
+    GROUNDING_LIST: groundingList,
+  });
+}

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -214,6 +214,7 @@ export default defineConfig({
       '../../../lib/chat/**/*.test.ts',
       '../../../lib/electron-shared/**/*.test.ts',
       '../../../lib/debate/**/*.test.ts',
+      '../../../lib/oped/**/*.test.ts',
       // dictionary lint tests excluded — data consistency checks owned by data team
       '../../../lib/diff/**/*.test.ts',
       '../../../lib/edges/**/*.test.ts',


### PR DESCRIPTION
## Summary

- Adds `lib/oped/generate.ts` — `generateOpEdSet` async generator with parallel voice fan-out, grounding degradation, reflection pass, and partial-set contract (failed/cancelled members included in final `OpEdSet`)
- Adds `lib/oped/outletBands.ts` — outlet word-band lookup (8 outlets)
- Adds `lib/oped/promptLoader.ts` — `{{KEY}}` template interpolation for shared PS+TS prompt artifacts
- Adds `lib/oped/promptAssembly.test.ts` + `lib/oped/groundingSelection.test.ts` — deterministic unit tests (no AI calls)
- Registers `lib/oped/**/*.test.ts` in `taxonomy-editor/vite.config.ts` test include list

Architecture: Option 1 approved by Second Opinion (e/96). Interface posted at t/2608#3 before implementation per TL design-review requirement (e/96#2).

Five conditions from t/2604#2:
1. Parity gate — PS port map in t/2604#1; core logic matches `New-OpEd.ps1`
2. Electron migrates in-epic (t/2611, ElectronMain)
3. SSE `res.on('close')` — ServerAPI (t/2610)
4. Quota pre-start — ServerAPI (t/2610)
5. Grounding data on server — ServerAPI (t/2610)

## Test plan

- [ ] CI green (vitest + tsc)
- [ ] `promptAssembly.test.ts`: byte-identical output, all placeholders resolved, sourceBrief interpolation, optional-field fallbacks
- [ ] `groundingSelection.test.ts`: deterministic ordering, score ranking, maxTotal cap

Co-Authored-By: Shared Lib (Orca) <main.lib@ai-triad-research.orca.local>