### PR TITLE
fix(opeds): re-gate desktop reveal + render-tolerate legacy pov/grounding (t/2603)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -458,15 +458,15 @@ export const api: AppAPI = {
   // DEBATE_CHAT_REDESIGN defaults ON for the local/Electron build (t/2257); opt out with
   // VITE_DEBATE_CHAT_REDESIGN=false. Web/server default is separate (Azure ticket, t/2243).
   //
-  // env-electron-opeds: GA reveal (t/2603, PI decision) — now defaults ON on desktop
-  // (create is Electron-only; unblocked once New-OpEd FromPrep -Topic landed, t/2588 #996).
-  // Opt OUT with VITE_ELECTRON_OPEDS=false (mirrors DEBATE_CHAT_REDESIGN). GA contract: t/2570#5.
-  // NOTE: `env-electron-summaries` has the SAME stub omission — NOT delivered on desktop, so
-  // Summaries is web-only in practice on the Electron build. Flagged on t/2601 for a separate
-  // decision (intended web-only vs. the same latent gap → follow-up); left as-is here.
+  // env-electron-opeds: GA reveal (t/2603) RE-GATED to opt-in (default OFF) — a real-data
+  // desktop smoke found three create-vs-render contract crashes the sign-off missed (t/2605
+  // set.opeds; pov short-code vs POV_META; grounding persisted PascalCase vs OpEdGroundingRef).
+  // Render-side resolvers/guards (povResolve, groundingType) are legacy-data TOLERANCE, not the
+  // fix; the reveal stays dark until create-side persists the canonical TS contract (ElectronMain
+  // migration) and a real-data READER smoke passes on a DRAFT re-reveal PR. Opt IN: VITE_ELECTRON_OPEDS=true.
   getFlags: () => Promise.resolve({
     DEBATE_CHAT_REDESIGN: import.meta.env.VITE_DEBATE_CHAT_REDESIGN !== 'false',
-    'env-electron-opeds': import.meta.env.VITE_ELECTRON_OPEDS !== 'false',
+    'env-electron-opeds': import.meta.env.VITE_ELECTRON_OPEDS === 'true',
   }),
 
   // UsageID registry — stub (desktop has no server-side usage registry)

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -11,7 +11,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { OpEdSet, OpEdMember, OpEdGroundingRef, PovKey } from '../../../../../lib/oped/types';
-import { POV_META } from '@lib/electron-shared/povMeta';
+import { resolvePovMeta } from './povResolve';
 import { POV_KEYS } from '@lib/debate/types';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { NodeDetail } from '../taxonomy/NodeDetail';
@@ -24,8 +24,10 @@ function prefersReducedMotion(): boolean {
     && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-function groundingType(nodeId: string): string {
-  return nodeId.startsWith('sit-') ? 'Situation' : 'BDI';
+function groundingType(nodeId: string | undefined): string {
+  // Legacy/foreign grounding rows may lack node_id (persisted PascalCase shape) — don't
+  // crash the reader; classify a missing id as BDI (t/2605 follow-up: real-data smoke).
+  return nodeId?.startsWith('sit-') ? 'Situation' : 'BDI';
 }
 
 // ──────────────────────────────────────────────
@@ -50,7 +52,7 @@ function GroundingDetailCard({ ref, onClose }: { ref: OpEdGroundingRef; onClose:
   let body: React.ReactNode = <div className="oped-grounding-card-empty">Element not found in the loaded taxonomy.</div>;
   let openTab: string | null = null;
 
-  if (ref.node_id.startsWith('sit-')) {
+  if (ref.node_id?.startsWith('sit-')) {
     const node = state.situations?.nodes.find(n => n.id === ref.node_id);
     if (node) { body = <SituationDetail node={node} readOnly chipDepth={0} />; openTab = 'situations'; }
   } else {
@@ -157,7 +159,7 @@ function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
 // ──────────────────────────────────────────────
 
 function OpEdArticle({ member, outlet }: { member: OpEdMember; outlet?: string }) {
-  const meta = POV_META[member.pov];
+  const meta = resolvePovMeta(member.pov);
   const metaLine = [meta.label.toUpperCase(), outlet || null, `${member.wordCount} words`]
     .filter(Boolean).join(' · ');
 
@@ -241,7 +243,7 @@ export function OpEdReader({ set }: { set: OpEdSet }) {
     <div className="oped-reader">
       <div className="oped-tabstrip" role="tablist" aria-label="Op-ed voices">
         {members.map((m, i) => {
-          const meta = POV_META[m.pov];
+          const meta = resolvePovMeta(m.pov);
           const isActive = i === activeIdx;
           return (
             <button

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
@@ -219,10 +219,17 @@ describe('OpEdTable — My variant', () => {
   // camp chips + voice counts for every row without throwing. A prior version iterated
   // `set.opeds` on the summary and crashed on the first non-empty list; an empty-rows
   // test never exercised the row-render path and gave false confidence.
-  it('renders a non-empty My list with per-row camp chips + voice tags (no crash)', () => {
+  //
+  // t/2605 follow-up: camps here carry the SHORT camp codes ('acc'/'saf'/'skp') that the
+  // create flow actually persists in OpEdMember.pov — NOT the full-name PovKeys POV_META
+  // is keyed by. Using full names before hid a second crash (POV_META['acc'].label =
+  // undefined.label), caught only by a live smoke on real data. `as unknown as PovKey[]`
+  // documents that these values violate the nominal PovKey type — that drift is the bug.
+  const short = (...c: string[]) => c as unknown as PovKey[];
+  it('renders a non-empty My list with SHORT-code camp chips + voice tags (no crash)', () => {
     const rows = [
-      makeSummary({ set_id: 'multi', topic: 'Frontier model licensing', camps: ['safetyist', 'skeptic'], voice_count: 2 }),
-      makeSummary({ set_id: 'single', topic: 'Compute governance', camps: ['accelerationist'], voice_count: 1 }),
+      makeSummary({ set_id: 'multi', topic: 'Frontier model licensing', camps: short('saf', 'skp'), voice_count: 2 }),
+      makeSummary({ set_id: 'single', topic: 'Compute governance', camps: short('acc'), voice_count: 1 }),
     ];
     render(<OpEdTable {...noopMyProps} rows={rows} totalCount={rows.length} />);
 
@@ -230,14 +237,25 @@ describe('OpEdTable — My variant', () => {
     expect(screen.getByText('Frontier model licensing')).toBeTruthy();
     expect(screen.getByText('Compute governance')).toBeTruthy();
 
-    // The multi-voice row shows its camp chips and the voices tag.
+    // Short codes normalize to their POV_META short labels — proving the resolver ran.
     const multiRow = screen.getByText('Frontier model licensing').closest('tr')!;
     expect(within(multiRow).getByText('Saf')).toBeTruthy();
     expect(within(multiRow).getByText('Skp')).toBeTruthy();
     expect(within(multiRow).getByText('▸ 2 voices')).toBeTruthy();
+    const singleRow = screen.getByText('Compute governance').closest('tr')!;
+    expect(within(singleRow).getByText('Acc')).toBeTruthy();
 
     // Every row exposes an Open action — proves the full row body rendered.
     expect(screen.getAllByRole('button', { name: /open/i })).toHaveLength(2);
+  });
+
+  it('renders a neutral chip for an unknown/legacy camp code instead of crashing', () => {
+    const rows = [makeSummary({ set_id: 'x', topic: 'Legacy voice', camps: short('bogus'), voice_count: 1 })];
+    render(<OpEdTable {...noopMyProps} rows={rows} totalCount={1} />);
+    const row = screen.getByText('Legacy voice').closest('tr')!;
+    // Fallback short label is an em dash — the row still renders, no error boundary.
+    expect(within(row).getByText('—')).toBeTruthy();
+    expect(within(row).getByRole('button', { name: /open/i })).toBeTruthy();
   });
 });
 

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
@@ -10,8 +10,8 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { OpEdSetSummary, OpEdCommunityEntry, PovKey } from '../../../../../lib/oped/types';
-import { CampGlyph, povToCamp } from '../shared/CampGlyph';
-import { POV_META } from '@lib/electron-shared/povMeta';
+import { CampGlyph } from '../shared/CampGlyph';
+import { resolvePovMeta, resolveCampKey } from './povResolve';
 import './OpEdTable.css';
 
 // ──────────────────────────────────────────────
@@ -121,17 +121,20 @@ function CampChips({ camps }: { camps: PovKey[] }) {
   return (
     <span className="oped-camp-chips">
       {camps.map(pov => {
-        const camp = povToCamp(pov);
+        // pov may be a short camp code ('acc') or full PovKey — normalize both, and
+        // fall back to a neutral chip for unknown/legacy codes (t/2605 follow-up).
+        const meta = resolvePovMeta(pov);
+        const camp = resolveCampKey(pov);
         return (
           <span
             key={pov}
             className="oped-camp-chip"
-            title={POV_META[pov].label}
+            title={meta.label}
             // eslint-disable-next-line local/no-inline-style -- dynamic: camp accent color from POV_META cssVar (theme-aware)
-            style={{ color: `var(${POV_META[pov].cssVar})` }}
+            style={{ color: `var(${meta.cssVar})` }}
           >
             {camp && <CampGlyph camp={camp} size={13} />}
-            <span className="oped-camp-chip-label">{POV_META[pov].shortLabel}</span>
+            <span className="oped-camp-chip-label">{meta.shortLabel}</span>
           </span>
         );
       })}

--- a/taxonomy-editor/src/renderer/components/opeds/povResolve.test.ts
+++ b/taxonomy-editor/src/renderer/components/opeds/povResolve.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { resolvePovMeta, resolvePovMetaKey, resolveCampKey } from './povResolve';
+
+// Guards the pov-key drift that crashed the revealed Op-Ed My tab (t/2605 follow-up):
+// persisted OpEdMember.pov carries the SHORT camp code ('acc'), but POV_META is keyed by
+// the full PovKey ('accelerationist'). These resolvers accept both and never throw.
+
+describe('resolvePovMetaKey', () => {
+  it('maps short camp codes to the full POV_META key', () => {
+    expect(resolvePovMetaKey('acc')).toBe('accelerationist');
+    expect(resolvePovMetaKey('saf')).toBe('safetyist');
+    expect(resolvePovMetaKey('skp')).toBe('skeptic');
+  });
+
+  it('passes full PovKeys through unchanged', () => {
+    expect(resolvePovMetaKey('accelerationist')).toBe('accelerationist');
+    expect(resolvePovMetaKey('skeptic')).toBe('skeptic');
+  });
+
+  it('returns undefined for an unknown code', () => {
+    expect(resolvePovMetaKey('bogus')).toBeUndefined();
+  });
+});
+
+describe('resolvePovMeta', () => {
+  it('resolves a short code to its POV_META entry', () => {
+    const meta = resolvePovMeta('acc');
+    expect(meta.label).toBe('Accelerationist');
+    expect(meta.shortLabel).toBe('Acc');
+  });
+
+  it('never throws on an unknown code — returns a neutral fallback', () => {
+    const meta = resolvePovMeta('bogus');
+    expect(meta.shortLabel).toBe('—');
+    expect(meta.label).toBe('Unknown');
+  });
+});
+
+describe('resolveCampKey', () => {
+  it('yields the short camp key for both forms', () => {
+    expect(resolveCampKey('acc')).toBe('acc');
+    expect(resolveCampKey('accelerationist')).toBe('acc');
+  });
+
+  it('returns undefined for an unknown code', () => {
+    expect(resolveCampKey('bogus')).toBeUndefined();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/opeds/povResolve.ts
+++ b/taxonomy-editor/src/renderer/components/opeds/povResolve.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { POV_META, type PovMeta, type PovMetaKey } from '@lib/electron-shared/povMeta';
+import { type CampKey, povToCamp } from '../shared/CampGlyph';
+
+// Persisted op-ed voices carry the SHORT camp code in `OpEdMember.pov` — the create
+// flow writes `'acc'`/`'saf'`/`'skp'`, not the full PovKey (`'accelerationist'`…) that
+// POV_META is keyed by. `pov` is *typed* PovKey, so tsc never flagged the drift; it was
+// masked at runtime by the t/2605 `set.opeds` crash until that landed. A live desktop
+// smoke of the t/2603 reveal then hit `POV_META[pov].label` → `undefined.label` on the
+// first real set. These resolvers accept BOTH forms and fall back safely so a legacy or
+// unknown code renders a neutral chip instead of crashing the whole tab (t/2605 follow-up).
+
+const CAMP_TO_POV: Record<string, PovMetaKey> = {
+  acc: 'accelerationist',
+  saf: 'safetyist',
+  skp: 'skeptic',
+  sit: 'situations',
+};
+
+// Neutral chip for an unrecognized code — never throws, keeps the row/reader rendering.
+const FALLBACK_META: PovMeta = {
+  label: 'Unknown',
+  shortLabel: '—',
+  color: 'var(--text-muted)',
+  cssVar: '--text-muted',
+  prefix: '',
+};
+
+/** Normalize a persisted pov value (short camp code OR full PovKey) to a POV_META key. */
+export function resolvePovMetaKey(pov: string): PovMetaKey | undefined {
+  if (pov in POV_META) return pov as PovMetaKey;
+  return CAMP_TO_POV[pov];
+}
+
+/** POV_META entry for a persisted pov value, with a neutral fallback (never undefined). */
+export function resolvePovMeta(pov: string): PovMeta {
+  const key = resolvePovMetaKey(pov);
+  return (key && POV_META[key]) || FALLBACK_META;
+}
+
+/** Short camp key (for the glyph) from a persisted pov value, or undefined if unknown. */
+export function resolveCampKey(pov: string): CampKey | undefined {
+  const key = resolvePovMetaKey(pov);
+  return key ? povToCamp(key) : undefined;
+}


### PR DESCRIPTION
**Re-gates the Op-Ed Studio desktop reveal to opt-in (default OFF)** after a live desktop smoke on REAL persisted sets found two more create-vs-render contract crashes the sign-off missed (beyond t/2605's `set.opeds`). The reveal (#997) shipped an Op-Eds tab that blanks the whole app on any real set. Re-gate authorized by TL (p/336#159); reveal stays dark until create-side persists the canonical TS contract (ElectronMain migration) + a real-data reader smoke passes on a draft re-reveal PR.

### Crashes found on real data
1. **pov short-code** — `OpEdMember.pov` persisted as short camp code (`'acc'`) but `POV_META` keyed by full `PovKey` (`'accelerationist'`) → `POV_META[pov].label` = `undefined.label`. Typed `pov: PovKey` so tsc never flagged it; masked by t/2605 until that landed.
2. **grounding shape** — grounding refs persisted PascalCase (`Id/Type/POV/Category/Label/RelevanceScore/Reflection`), not `OpEdGroundingRef` (`node_id/…`) → `groundingType(ref.node_id).startsWith` → reader crash on open.

### Changes (render-side LEGACY-DATA TOLERANCE — not the canonical fix)
- `povResolve.ts` — normalize short codes AND full PovKeys, neutral fallback for unknown. Wired into CampChips + both OpEdReader sites.
- OpEdReader `node_id` guards (optional chaining) — missing/foreign id classifies BDI instead of throwing.
- `electron-bridge` getFlags: `env-electron-opeds` default flipped back OFF (`=== 'true'` opt-in).

### Tests
- `povResolve.test.ts` — short→full, passthrough, unknown→fallback.
- `OpEdTable.test.tsx` — non-empty My-list regression now feeds **SHORT** camp codes (the real-data shape full-name fixtures missed) + unknown-code neutral-chip case.

### Verified live
Built desktop app on real on-disk sets renders the My table (3 sets, Acc/Saf chips) **and** the reader (article + voice tabs + 14 grounding rows) with **no error boundary**. renderer/main/server tsc clean · eslint 0 errors · opeds vitest 48/48.

Canonical create-side fix (map PS output → TS contract at persist) routed to ElectronMain via the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)