### PR TITLE
obs(bridge): listOpEdSets ok FR event carries result_type/has_opeds (t/2606)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
@@ -23,6 +23,47 @@ function lastRecord(): { level: string; message: string; data?: { http_status?: 
   return mockRecord.mock.calls.at(-1)?.[0] as { level: string; message: string; data?: { http_status?: number } };
 }
 
+/** Find the ok-completion event for a bridge method (its enriched result meta). */
+function okRecord(method: string): { message: string; data?: Record<string, unknown> } | undefined {
+  return mockRecord.mock.calls
+    .map((c) => c[0] as { message: string; data?: Record<string, unknown> })
+    .find((e) => e.message === `bridge.${method} ok`);
+}
+
+describe('instrumentBridge — listOpEdSets result shape (t/2606)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('records result_type=summary + has_opeds=false for the summary index', async () => {
+    const rows = [{ set_id: 'a', topic: 'T', camps: ['acc'], voice_count: 1 }];
+    const api = instrumentBridge({ listOpEdSets: () => Promise.resolve(rows) } as unknown as AppAPI);
+    await (api as unknown as { listOpEdSets: () => Promise<unknown> }).listOpEdSets();
+
+    const ok = okRecord('listOpEdSets');
+    expect(ok?.data?.count).toBe(1);
+    expect(ok?.data?.result_type).toBe('summary');
+    expect(ok?.data?.has_opeds).toBe(false);
+  });
+
+  it('records result_type=full + has_opeds=true if full OpEdSets leak through (the t/2605 shape)', async () => {
+    const full = [{ set_id: 'a', topic: 'T', opeds: [{ pov: 'acc' }] }];
+    const api = instrumentBridge({ listOpEdSets: () => Promise.resolve(full) } as unknown as AppAPI);
+    await (api as unknown as { listOpEdSets: () => Promise<unknown> }).listOpEdSets();
+
+    const ok = okRecord('listOpEdSets');
+    expect(ok?.data?.result_type).toBe('full');
+    expect(ok?.data?.has_opeds).toBe(true);
+  });
+
+  it('records result_type=summary for an empty list (expected default)', async () => {
+    const api = instrumentBridge({ listOpEdSets: () => Promise.resolve([]) } as unknown as AppAPI);
+    await (api as unknown as { listOpEdSets: () => Promise<unknown> }).listOpEdSets();
+
+    const ok = okRecord('listOpEdSets');
+    expect(ok?.data?.count).toBe(0);
+    expect(ok?.data?.result_type).toBe('summary');
+  });
+});
+
 describe('instrumentBridge — expected-status downgrade (t/2395)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
@@ -76,6 +76,17 @@ function extractResultMeta(method: string, args: unknown[], value: unknown): Rec
       .filter((id): id is string => typeof id === 'string');
     return { count: v.length, ids: ids.slice(0, 20) };
   }
+  if (method === 'listOpEdSets') {
+    // Record the RESULT SHAPE, not just the count, so a summary-vs-full regression is
+    // visible in the dump alone (t/2606). The t/2605 crash was listOpEdSets returning a
+    // full OpEdSet[] where the caller expected OpEdSetSummary[] (no `opeds`); result_type
+    // makes a repeat diagnosable without re-reading source. Empty list → 'summary' (the
+    // expected default). `has_opeds` is the same signal at the per-row level.
+    if (!Array.isArray(v)) return undefined;
+    const first = (v as unknown[])[0] as Record<string, unknown> | undefined;
+    const has_opeds = !!first && 'opeds' in first;
+    return { count: (v as unknown[]).length, result_type: has_opeds ? 'full' : 'summary', has_opeds };
+  }
   if (method === 'generateText' || method === 'generateTextWithSearch') {
     const text = v.text;
     const meta: Record<string, unknown> = {};


### PR DESCRIPTION
Observability arm of the t/2605 crash. The `bridge.listOpEdSets` ok flight-recorder event carried no shape info, so a summary-vs-full mismatch (the t/2605 crash: `listOpEdSets` returned full `OpEdSet[]` where `OpEdSetSummary[]` was expected) was invisible in a dump — diagnosing it required reading source.

`instrumentBridge.extractResultMeta` now enriches the `listOpEdSets` ok event with `count` + `result_type` ('summary' | 'full') + `has_opeds`, derived from whether the first row carries an `opeds` array. A future shape regression is visible in the dump alone. Empty list → 'summary' (expected default).

**Pure observability, no behavior change — self-cert /trivial-change.**

Tests: 3 cases assert the ok event data (summary index, full-set leak = t/2605 shape, empty list). renderer tsc clean · eslint 0 errors · instrumentBridge.test.ts 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)