### PR TITLE
style(theme): define error family per-theme — t/2567 class-(b) baseline → zero (t/2569)

### DIFF
--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -61,6 +61,11 @@
   --accent-text: #1A56DB;
   --accent-rgb: 59,130,246; /* MUST equal --focus-ring RGB — for rgba(var(--accent-rgb),α) accent tints */
   --color-moderator: #8B5CF6;
+  /* t/2569 error family — Design-blessed (t/2569#6); final class-(b) batch → baseline zero */
+  --error-color: var(--danger); /* generic error red — alias, single source like --error */
+  --error-text: #B42318; /* foreground; AA on --bg-primary (paired w/ --success-text) AND on --error-bg */
+  --error-bg: #FDECEC;
+  --error-border: #F3C0C0;
   --bar: #3b82f6; /* data-blue share-bar fill; was undefined → hardcoded fallback (t/2565) */
 
   /* Scrollbar */
@@ -134,6 +139,11 @@
   --accent-text: #93C5FD;
   --accent-rgb: 96,165,250;
   --color-moderator: #A78BFA;
+  /* t/2569 error family — Design-blessed (t/2569#6); final class-(b) batch → baseline zero */
+  --error-color: var(--danger);
+  --error-text: #FCA5A5; /* foreground; AA on --bg-primary AND on --error-bg */
+  --error-bg: #2A1616;
+  --error-border: #4D2424;
   --bar: #60a5fa; /* data-blue share-bar fill (t/2565) */
 
   /* Scrollbar */
@@ -207,6 +217,11 @@
   --accent-text: #8FB8C8;
   --accent-rgb: 77,122,139;
   --color-moderator: #B794D4;
+  /* t/2569 error family — Design-blessed (t/2569#6); final class-(b) batch → baseline zero */
+  --error-color: var(--danger);
+  --error-text: #FF9B9B; /* foreground; AA on --bg-primary AND on --error-bg */
+  --error-bg: #2E1A1C;
+  --error-border: #4D2428;
   --bar: #6a9fd4; /* data-blue share-bar fill (t/2565) */
 
   /* Scrollbar */
@@ -278,6 +293,11 @@
   --accent-text: #A51C30;
   --accent-rgb: 165,28,48;
   --color-moderator: #7A5299;
+  /* t/2569 error family — Design-blessed (t/2569#6); final class-(b) batch → baseline zero */
+  --error-color: var(--danger);
+  --error-text: #A5182A; /* foreground; AA on --bg-primary AND on --error-bg */
+  --error-bg: #F5E2E2;
+  --error-border: #D9A5A5;
   --bar: #3f6fae; /* data-blue share-bar fill (t/2565) */
 
   /* Scrollbar */

--- a/taxonomy-editor/src/renderer/theme-token-completeness.test.ts
+++ b/taxonomy-editor/src/renderer/theme-token-completeness.test.ts
@@ -43,15 +43,11 @@ const BASELINE_ALIAS_BUGS_T2568 = [
   // the other 16 were NOT wrong-names — reclassified to the (b) group below.
 ];
 const BASELINE_NEED_VALUES_T2569 = [
-  // Error family → owned by the t/2566 thread (don't double-define here).
-  '--error-bg', '--error-border', '--error-color', '--error-text',
-  // --color-accent repointed to --focus-ring (Design p/29#114) — cleared, class-(b) baseline
-  // is now the error family only (t/2566).
-  // Everything else here (Batch 1 + Batch 3: --info, --link-color, --warning-bg/-border,
-  // --bg-selected, --border-subtle, --accent-hover/-bg/-text/-rgb, --color-moderator,
-  // reuse/font tokens) is now DEFINED, and --accent/-color/-primary/-strong/-blue,
-  // --bg-subtle, --surface-1, --bg-elevated, --link, --color-info, --border-* variants,
-  // --active-definition-bg are REPOINTED to existing tokens — all removed from the ratchet.
+  // EMPTY → class-(b) baseline is ZERO (t/2569 complete). The error family
+  // (--error-bg/-border/-color/-text) was the final batch — Design-blessed per-theme at
+  // t/2569#6 (correcting the earlier mis-deferral to t/2566, which only covered singular
+  // --error) and now DEFINED in styles.css. Everything else was defined (Batch 1+3) or
+  // repointed to existing tokens (accent family → --focus-ring, etc.) in prior landings.
 ];
 const BASELINE = new Set<string>([...BASELINE_ALIAS_BUGS_T2568, ...BASELINE_NEED_VALUES_T2569]);
 


### PR DESCRIPTION
Final class-(b) batch for t/2569. Design blessed the error family per-theme at t/2569#6 (correcting the earlier mis-deferral to t/2566, which covered only the singular `--error`).

Defines across all four themes (light/dark/bkc/harvard) via the t/2261 token pattern:
- `--error-color: var(--danger)` — alias, single source (like `--error`)
- `--error-text` — foreground red; AA on `--bg-primary` **and** on `--error-bg`
- `--error-bg` / `--error-border` — error-banner surface + border

Clears the 4 entries from `BASELINE_NEED_VALUES_T2569` in `theme-token-completeness.test.ts` — the shrink-only ratchet now holds an **empty class-(b) baseline** (t/2567 goal met).

**Verified:** theme-token-completeness 3/3, contrast-check 309/314 (`--error-text` AA pairs pass), renderer tsc clean, eslint 0 errors.

Design owns closing t/2569. Self-cert /trivial-change (Design-blessed token defs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)