### PR TITLE
ops(infra): repoint AI_TRIAD_DATA_ROOT + TAXONOMY_CACHE_DIR to /mnt/shared (t/2602)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -381,7 +381,12 @@ resource stagingAnalyticsContainer 'Microsoft.Storage/storageAccounts/blobServic
 // ── Container App ──
 
 var baseEnv = [
-  { name: 'AI_TRIAD_DATA_ROOT', value: '/tmp/taxonomy-cache' }
+  // t/2602: repoint data root from ephemeral /tmp to durable Azure Files mount.
+  // Fixes class-A durability (admin flags, runtime-config, calibration logs) and
+  // taxonomy reads (supersedes t/2612 startup.sh symlink). TAXONOMY_CACHE_DIR must
+  // stay in sync with AI_TRIAD_DATA_ROOT (t/2061 invariant; Dockerfile comment).
+  { name: 'AI_TRIAD_DATA_ROOT', value: '/mnt/shared' }
+  { name: 'TAXONOMY_CACHE_DIR', value: '/mnt/shared' }
   { name: 'ALLOWED_ORIGINS', value: 'https://taxonomy-editor.${containerAppEnv.properties.defaultDomain}' }
   { name: 'HOME', value: '/home/aitriad' }
   { name: 'NODE_ENV', value: 'production' }


### PR DESCRIPTION
## Summary

- `AI_TRIAD_DATA_ROOT` changed from `/tmp/taxonomy-cache` → `/mnt/shared` in `baseEnv` (deploy/azure/main.bicep)
- `TAXONOMY_CACHE_DIR` added explicitly to `baseEnv` as `/mnt/shared` — was previously absent (Dockerfile ENV default `/tmp/taxonomy-cache`); both vars must stay in sync per t/2061 invariant
- Fixes class-A durability: admin flags, runtime-config, calibration logs survive scale-to-zero
- Taxonomy reads (`loadTaxonomy`) now resolve from `/mnt/shared/taxonomy/` — supersedes the t/2612 startup.sh symlink stopgap

**Class-B note:** debates/op-eds/chats are unaffected — `AZURE_STORAGE_ACCOUNT_URL` is set so `getUserContentBackend()` routes to `AzureBlobBackend`, not the filesystem root. No regression.

**t/2600 / t/2623:** `loadDebateSession` 500 (requestId e5edb0fb) is a Blob miss for a pre-drift session, not an ephemerality bug. Separate investigation at t/2623.

## Test plan

- [ ] CI green on this head
- [ ] Staging deploy with class-A verification: change a runtime-config or feature-flag value → scale to zero → scale up → confirm value persisted on `/mnt/shared`
- [ ] Grounding call returns nodes (`Invoke-TaxEditorSmokeTest` or manual `/api/taxonomy/nodes`)
- [ ] Owner GO for prod
- [ ] Prod deploy via deploy-azure workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
