### PR TITLE
fix(conflict): guard getNodeConflicts() against electron-prod (t/2620)

### DIFF
--- a/taxonomy-editor/src/renderer/components/conflict/edit-conflicts/editConflicts.test.tsx
+++ b/taxonomy-editor/src/renderer/components/conflict/edit-conflicts/editConflicts.test.tsx
@@ -30,6 +30,42 @@ const CONFLICT: NodeConflict = SAMPLE.conflicts[0];
 
 afterEach(() => { vi.restoreAllMocks(); mockBridgeGet.mockReset(); });
 
+// Capture baseline env so each describe can restore cleanly.
+const _origTarget = import.meta.env.VITE_TARGET;
+const _origDev = import.meta.env.DEV;
+
+describe('getNodeConflicts — electron-prod guard (t/2620)', () => {
+  afterEach(() => {
+    import.meta.env.VITE_TARGET = _origTarget;
+    (import.meta.env as Record<string, unknown>).DEV = _origDev;
+    mockBridgeGet.mockReset();
+  });
+
+  it('returns DISABLED immediately without touching bridgeGet in electron-prod', async () => {
+    import.meta.env.VITE_TARGET = 'electron';
+    (import.meta.env as Record<string, unknown>).DEV = false;
+    // No server: if bridgeGet were called it would reject and open the read circuit.
+    expect(await getNodeConflicts()).toEqual({ enabled: false, session_branch: null, behind_by: 0, conflicts: [] });
+    expect(mockBridgeGet).not.toHaveBeenCalled();
+  });
+
+  it('calls bridgeGet in web-container mode (guard off)', async () => {
+    import.meta.env.VITE_TARGET = 'web';
+    (import.meta.env as Record<string, unknown>).DEV = false;
+    mockBridgeGet.mockResolvedValue(SAMPLE);
+    expect(await getNodeConflicts()).toEqual(SAMPLE);
+    expect(mockBridgeGet).toHaveBeenCalledWith('/api/sync/node-conflicts');
+  });
+
+  it('calls bridgeGet in electron-dev mode (dev server is running)', async () => {
+    import.meta.env.VITE_TARGET = 'electron';
+    (import.meta.env as Record<string, unknown>).DEV = true;
+    mockBridgeGet.mockResolvedValue(SAMPLE);
+    expect(await getNodeConflicts()).toEqual(SAMPLE);
+    expect(mockBridgeGet).toHaveBeenCalledWith('/api/sync/node-conflicts');
+  });
+});
+
 describe('getNodeConflicts', () => {
   it('returns the disabled response on HTTP error', async () => {
     mockBridgeGet.mockRejectedValue(new Error('HTTP 500'));

--- a/taxonomy-editor/src/renderer/components/conflict/edit-conflicts/nodeConflictsApi.ts
+++ b/taxonomy-editor/src/renderer/components/conflict/edit-conflicts/nodeConflictsApi.ts
@@ -56,6 +56,13 @@ export const DISABLED_NODE_CONFLICTS: NodeConflictsResponse = {
  * rather than throwing into the render/save path.
  */
 export async function getNodeConflicts(): Promise<NodeConflictsResponse> {
+  // Node-conflicts is a web-container-only feature. In the packaged Electron
+  // build (no Express backend), repeated failures here would open the read
+  // circuit and block Engagement Analytics / Leaderboards / Heuristic Health
+  // for 60 s (t/2620). electron-dev is excluded: the dev server is running.
+  if (import.meta.env.VITE_TARGET !== 'web' && !import.meta.env.DEV) {
+    return DISABLED_NODE_CONFLICTS;
+  }
   try {
     return await bridgeGet<NodeConflictsResponse>('/api/sync/node-conflicts');
   } catch (err) {


### PR DESCRIPTION
## Summary
- In electron-prod, `getNodeConflicts()` now returns `DISABLED_NODE_CONFLICTS` immediately without calling `bridgeGet` — prevents 4× retry cascade that opened the read circuit and blocked Engagement Analytics / Leaderboards / Heuristic Health for 60 s
- Guard condition: `VITE_TARGET !== 'web' && !DEV` — electron-dev excluded (dev server is running)
- 3 new integration tests: electron-prod skips bridgeGet, web-container calls bridgeGet, electron-dev calls bridgeGet

## Test plan
- [x] Scoped vitest: 13/13 pass (`src/renderer/components/conflict/edit-conflicts/`)
- [x] renderer-tsc: 0/0 errors
- [x] ESLint: 576 warnings (ceiling 4256)
- [ ] CI green on head `962fcbf2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)