### PR TITLE
obs(storage): log resolved backend+key on debate write-ack and not-found read (t/2624)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/debateStoreObs.test.ts
+++ b/taxonomy-editor/src/server/__tests__/debateStoreObs.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+// Observability tests for debateStore.ts (t/2624):
+// - not-found read logs backendName + blobKey + result='not-found'
+// - write-ack log carries backendName + blobKey + bytes + writeAck=true
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { _store, mockBackend } = vi.hoisted(() => {
+  const _store = new Map<string, string>();
+  const mockBackend = {
+    backendName: 'test-mock',
+    readFile: vi.fn(async (p: string) => _store.get(p) ?? null),
+    writeFile: vi.fn(async (p: string, c: string) => { _store.set(p, c); }),
+    deleteFile: vi.fn(async (p: string) => { _store.delete(p); }),
+    listDirectory: vi.fn(async () => [..._store.keys()].map(k => k.split('/').pop()!)),
+    fileExists: vi.fn(async (p: string) => _store.has(p)),
+    readBinaryFile: vi.fn(),
+    writeBinaryFile: vi.fn(),
+  };
+  return { _store, mockBackend };
+});
+
+const mockLogInfo = vi.hoisted(() => vi.fn());
+
+vi.mock('../config.js', () => ({
+  resolveDataPath: (rel: string) => `/data/${rel}`,
+  getDataRoot: () => '/data',
+}));
+
+vi.mock('../logger.js', () => ({
+  log: { server: { info: mockLogInfo, warn: vi.fn() } },
+}));
+
+vi.mock('../security/userContext.js', () => ({
+  getStorageUserId: vi.fn(() => 'user-obs'),
+  isAnonymousUser: vi.fn(() => false),
+  getCurrentUserId: vi.fn(() => 'user-obs'),
+}));
+
+vi.mock('../security/quotas.js', () => ({
+  checkQuota: vi.fn(() => ({ allowed: true, resource: 'debates', current: 0, limit: 10 })),
+}));
+
+vi.mock('../storage/fileIO.js', () => ({
+  getUserContentBackend: () => mockBackend,
+  assertSafeId: (value: string, label: string) => {
+    if (!value || !/^[a-zA-Z0-9_-]+$/.test(value))
+      throw Object.assign(new Error(`Invalid ${label}: "${value}"`), { statusCode: 400 });
+  },
+  getAnonStore: vi.fn(() => null),
+}));
+
+import { loadDebateSession, saveDebateSession } from '../storage/debateStore.js';
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  _store.clear();
+  vi.clearAllMocks();
+  mockBackend.readFile.mockImplementation(async (p: string) => _store.get(p) ?? null);
+  mockBackend.writeFile.mockImplementation(async (p: string, c: string) => { _store.set(p, c); });
+  mockBackend.listDirectory.mockImplementation(async (dir: string) => {
+    const prefix = dir.endsWith('/') ? dir : dir + '/';
+    return [..._store.keys()]
+      .filter(k => k.startsWith(prefix))
+      .map(k => k.slice(prefix.length).split('/')[0])
+      .filter((v, i, a) => a.indexOf(v) === i);
+  });
+  mockLogInfo.mockClear();
+});
+
+describe('loadDebateSession observability (t/2624)', () => {
+  it('logs backendName + blobKey + result=not-found when debate is absent', async () => {
+    await expect(loadDebateSession('debate-missing-123')).rejects.toThrow();
+
+    const notFoundCall = mockLogInfo.mock.calls.find(
+      ([fields]) => fields?.result === 'not-found',
+    );
+    expect(notFoundCall).toBeDefined();
+    const [fields, msg] = notFoundCall!;
+    expect(fields.backendName).toBe('test-mock');
+    expect(fields.blobKey).toContain('debate-debate-missing-123.json');
+    expect(fields.debateId).toBe('debate-missing-123');
+    expect(msg).toMatch(/not found/i);
+  });
+});
+
+describe('saveDebateSession observability (t/2624)', () => {
+  it('logs backendName + blobKey + bytes + writeAck=true after write', async () => {
+    const session = {
+      id: 'obs-save-001',
+      title: 'Obs test',
+      created_at: '2026-08-14T00:00:00Z',
+      updated_at: '2026-08-14T00:00:00Z',
+      phase: 'opening',
+    };
+    await saveDebateSession(session, 'test-caller');
+
+    const writeAckCall = mockLogInfo.mock.calls.find(
+      ([fields]) => fields?.writeAck === true,
+    );
+    expect(writeAckCall).toBeDefined();
+    const [fields] = writeAckCall!;
+    expect(fields.backendName).toBe('test-mock');
+    expect(fields.blobKey).toContain('debate-obs-save-001.json');
+    expect(fields.debateId).toBe('obs-save-001');
+    expect(typeof fields.bytes).toBe('number');
+    expect(fields.bytes).toBeGreaterThan(0);
+  });
+});

--- a/taxonomy-editor/src/server/storage/azureBlobBackend.ts
+++ b/taxonomy-editor/src/server/storage/azureBlobBackend.ts
@@ -90,6 +90,8 @@ function wrapBlobError(err: unknown, op: string, blob: string): ActionableError 
 const DEFAULT_BLOB_UPLOAD_TIMEOUT_MS = 60_000;
 
 export class AzureBlobBackend implements StorageBackend {
+  readonly backendName = 'azure-blob';
+
   private readonly userContentClient: ContainerClient;
   private readonly communityClient: ContainerClient;
   private readonly uploadTimeoutMs: number;

--- a/taxonomy-editor/src/server/storage/debateStore.ts
+++ b/taxonomy-editor/src/server/storage/debateStore.ts
@@ -163,12 +163,15 @@ export async function loadDebateSession(id: string): Promise<unknown> {
   const backend = getUserContentBackend();
   const filePath = path.join(getDebatesDir(), `debate-${id}.json`);
   const raw = await backend.readFile(filePath);
-  if (raw === null) throw new ActionableError({
-    goal: 'Load debate session',
-    problem: `Debate session not found: ${id}`,
-    location: 'server/fileIO.ts → loadDebateSession',
-    nextSteps: ['Verify the debate ID exists via listDebateSessions()'],
-  });
+  if (raw === null) {
+    log.server.info({ backendName: backend.backendName, debateId: id, blobKey: filePath, result: 'not-found' }, 'Debate session not found on backend');
+    throw new ActionableError({
+      goal: 'Load debate session',
+      problem: `Debate session not found: ${id}`,
+      location: 'server/fileIO.ts → loadDebateSession',
+      nextSteps: ['Verify the debate ID exists via listDebateSessions()'],
+    });
+  }
   return JSON.parse(raw);
 }
 
@@ -200,7 +203,7 @@ export async function saveDebateSession(session: unknown, caller: string): Promi
     log.server.warn({ debateId: s.id, errorMessage }, 'Debate session serialized with sanitizing replacer — non-serializable fields stripped');
   }
   await backend.writeFile(debatePath, json);
-  log.server.info({ caller, debateId: s.id }, 'Debate session saved');
+  log.server.info({ caller, debateId: s.id, backendName: backend.backendName, blobKey: debatePath, bytes: json.length, writeAck: true }, 'Debate session saved');
   // Maintain the lightweight index
   void upsertDebateIndex({
     id: s.id,

--- a/taxonomy-editor/src/server/storage/filesystemBackend.ts
+++ b/taxonomy-editor/src/server/storage/filesystemBackend.ts
@@ -14,6 +14,8 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
  * gracefully (no throws for ENOENT).
  */
 export class FilesystemBackend implements StorageBackend {
+  readonly backendName = 'filesystem';
+
   private async renameWithRetry(oldPath: string, newPath: string): Promise<void> {
     const maxRetries = 5;
     for (let i = 0; i <= maxRetries; i++) {

--- a/taxonomy-editor/src/server/storage/githubAPIBackend.ts
+++ b/taxonomy-editor/src/server/storage/githubAPIBackend.ts
@@ -89,6 +89,8 @@ const MANIFEST_FILE = 'manifest.json';
 // ── GitHubAPIBackend ─────────────────────────────────────────────────────
 
 export class GitHubAPIBackend implements StorageBackend {
+  readonly backendName = 'github-api';
+
   private readonly cacheDir: string;
   private readonly recorder: FlightRecorder | null;
   private readonly pollIntervalMs: number;

--- a/taxonomy-editor/src/server/storage/storageBackend.ts
+++ b/taxonomy-editor/src/server/storage/storageBackend.ts
@@ -19,6 +19,9 @@
  */
 
 export interface StorageBackend {
+  /** Short identity string for structured logs (e.g. 'filesystem', 'azure-blob', 'github-api'). */
+  readonly backendName: string;
+
   /** Read a file as UTF-8. Returns null if the file does not exist.
    *  `opts.ref` pins the read to a specific ref (e.g. 'main') for shared data
    *  that lives on main rather than a per-user session branch (community


### PR DESCRIPTION
## Summary

- `StorageBackend`: add `readonly backendName: string` accessor
- `FilesystemBackend` / `GitHubAPIBackend` / `AzureBlobBackend`: implement `backendName` (`'filesystem'` / `'github-api'` / `'azure-blob'`)
- `debateStore.saveDebateSession`: enhance write-ack log with `backendName`, `blobKey`, `bytes`, `writeAck: true` — proves the success path landed on the correct backend at the correct key
- `debateStore.loadDebateSession`: log `backendName + blobKey + result='not-found'` before the `ActionableError` throw — makes a future Blob 404 diagnosable from logs alone (which backend, which key)
- `debateStoreObs.test.ts`: 2 tests pinning both log shapes (not-found + write-ack)

Closes t/2624 (obs arm of t/2623).

## Test plan

- [x] `loadDebateSession` on absent debate logs `{ backendName: 'test-mock', debateId, blobKey, result: 'not-found' }`
- [x] `saveDebateSession` logs `{ backendName: 'test-mock', debateId, blobKey, bytes: N, writeAck: true }` after write
- [x] tsc clean (server tsconfig)
- [x] 2/2 observability tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
