### PR TITLE
obs(bridge): loadOpEdSet grounding + circuit_open attribution FR fields (t/2621, t/2622)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
@@ -64,6 +64,35 @@ describe('instrumentBridge — listOpEdSets result shape (t/2606)', () => {
   });
 });
 
+describe('instrumentBridge — loadOpEdSet grounding presence (t/2621)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('records has_grounding=true + grounded_member_count when some members are grounded', async () => {
+    const set = { set_id: 'a', topic: 'T', opeds: [
+      { pov: 'acc', grounding: [{ node_id: 'acc-b-001' }, { node_id: 'acc-b-002' }] },
+      { pov: 'saf', grounding: [] },
+    ] };
+    const api = instrumentBridge({ loadOpEdSet: () => Promise.resolve(set) } as unknown as AppAPI);
+    await (api as unknown as { loadOpEdSet: (id: string) => Promise<unknown> }).loadOpEdSet('a');
+
+    const ok = okRecord('loadOpEdSet');
+    expect(ok?.data?.member_count).toBe(2);
+    expect(ok?.data?.has_grounding).toBe(true);
+    expect(ok?.data?.grounded_member_count).toBe(1);
+  });
+
+  it('records has_grounding=false when no member carries grounding', async () => {
+    const set = { set_id: 'a', topic: 'T', opeds: [{ pov: 'acc', grounding: [] }, { pov: 'saf' }] };
+    const api = instrumentBridge({ loadOpEdSet: () => Promise.resolve(set) } as unknown as AppAPI);
+    await (api as unknown as { loadOpEdSet: (id: string) => Promise<unknown> }).loadOpEdSet('a');
+
+    const ok = okRecord('loadOpEdSet');
+    expect(ok?.data?.member_count).toBe(2);
+    expect(ok?.data?.has_grounding).toBe(false);
+    expect(ok?.data?.grounded_member_count).toBe(0);
+  });
+});
+
 describe('instrumentBridge — expected-status downgrade (t/2395)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/taxonomy-editor/src/renderer/bridge/__tests__/resilience.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/resilience.test.ts
@@ -472,6 +472,39 @@ describe('resilience', () => {
         lastFailure: 'HTTP 503',
       });
     });
+
+    it('attributes the triggering endpoint/method/component on threshold-open (t/2622)', async () => {
+      // A node-id-shaped path segment (acc-b-001) exercises the component normalization.
+      for (let i = 0; i < 5; i++) {
+        fetchSpy.mockResolvedValueOnce(mockFetchResponse(500));
+        await resilientFetch('/api/nodes/acc-b-001/conflicts', { method: 'GET' }, defaultOpts());
+      }
+      const event = findRecordCall('network.circuit_open')![0] as { data: Record<string, unknown> };
+      expect(event.data).toMatchObject({
+        triggering_endpoint: '/api/nodes/acc-b-001/conflicts',
+        triggering_method: 'GET',
+        triggering_component: '/api/nodes/:id/conflicts',
+      });
+    });
+
+    it('attributes the triggering endpoint/component on half-open re-open (t/2622)', async () => {
+      for (let i = 0; i < 5; i++) {
+        fetchSpy.mockResolvedValueOnce(mockFetchResponse(500));
+        await resilientFetch('/api/oped-sets/42', { method: 'GET' }, defaultOpts());
+      }
+      mockRecord.mockClear();
+
+      vi.advanceTimersByTime(60_001);
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse(503));
+      await resilientFetch('/api/oped-sets/42', { method: 'GET' }, defaultOpts());
+
+      const event = findRecordCall('network.circuit_open')![0] as { data: Record<string, unknown> };
+      expect(event.data).toMatchObject({
+        trigger: 'half_open_probe_failed',
+        triggering_endpoint: '/api/oped-sets/42',
+        triggering_component: '/api/oped-sets/:id',
+      });
+    });
   });
 
   describe('adaptive throttle', () => {

--- a/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
@@ -87,6 +87,14 @@ function extractResultMeta(method: string, args: unknown[], value: unknown): Rec
     const has_opeds = !!first && 'opeds' in first;
     return { count: (v as unknown[]).length, result_type: has_opeds ? 'full' : 'summary', has_opeds };
   }
+  if (method === 'loadOpEdSet') {
+    // Record grounding presence on the loaded set so a "grounding No data" report is
+    // diagnosable from the dump alone — distinguishes "grounding absent in the payload"
+    // from "present but not rendering" (which previously needed the on-disk JSON). t/2621.
+    const opeds = Array.isArray(v.opeds) ? (v.opeds as Array<{ grounding?: unknown[] }>) : [];
+    const grounded_member_count = opeds.filter(m => (m.grounding?.length ?? 0) > 0).length;
+    return { member_count: opeds.length, has_grounding: grounded_member_count > 0, grounded_member_count };
+  }
   if (method === 'generateText' || method === 'generateTextWithSearch') {
     const text = v.text;
     const meta: Record<string, unknown> = {};

--- a/taxonomy-editor/src/renderer/bridge/resilience.ts
+++ b/taxonomy-editor/src/renderer/bridge/resilience.ts
@@ -63,11 +63,35 @@ export function categorizeEndpoint(path: string, method: string): EndpointCatego
 
 const RECENT_FAILURES_CAP = 5;
 
+/** A single circuit failure with call attribution (t/2622). `reason` is the failure
+ *  class (`HTTP 500`, `timeout`, `TypeError`); `endpoint`/`method` identify the failing
+ *  request; `component` is a best-effort call-site label derived from the endpoint. */
+interface FailureRecord {
+  reason: string;
+  endpoint?: string;
+  method?: string;
+  component?: string;
+}
+
 interface CircuitEntry {
   state: CircuitState;
   consecutiveFailures: number;
   lastFailureTime: number;
-  recentFailures: string[];
+  recentFailures: FailureRecord[];
+}
+
+/** Best-effort call-site label from an endpoint: normalize id-like path segments to
+ *  `:id` so `/api/nodes/acc-b-001/conflicts` → `/api/nodes/:id/conflicts` — a stable
+ *  route pattern that distinguishes call-sites without a caller-supplied tag (t/2622). */
+function deriveComponent(endpoint: string): string {
+  const pathOnly = endpoint.split('?')[0];
+  return pathOnly.split('/').map((seg) => {
+    if (!seg) return seg;
+    if (/^\d+$/.test(seg)) return ':id';                        // numeric id
+    if (/^[0-9a-f]{8,}$/i.test(seg)) return ':id';              // uuid/hash
+    if (seg.includes('-') && /\d/.test(seg) && /[a-z]/i.test(seg)) return ':id'; // node-id shape (acc-b-001)
+    return seg;
+  }).join('/');
 }
 
 const circuits = new Map<EndpointCategory, CircuitEntry>();
@@ -106,7 +130,7 @@ function checkCircuit(cat: EndpointCategory, path: string): void {
       return;
     }
     const remaining = Math.ceil((cfg().circuitCooldownMs - elapsed) / 1000);
-    const failureSummary = summarizeFailures(c.recentFailures);
+    const failureSummary = summarizeFailures(c.recentFailures.map(f => f.reason));
     const detail = failureSummary ? `\nLast failures: ${failureSummary}` : '';
     throw new ActionableError({
       goal: `Make request to ${path}`,
@@ -132,24 +156,37 @@ function onCircuitSuccess(cat: EndpointCategory): void {
   if (wasNotClosed) notifyListeners();
 }
 
-function onCircuitFailure(cat: EndpointCategory, reason: string): void {
+function onCircuitFailure(cat: EndpointCategory, reason: string, endpoint?: string, method?: string): void {
   const c = getCircuit(cat);
   const prevState = c.state;
   c.consecutiveFailures++;
   c.lastFailureTime = Date.now();
-  c.recentFailures.push(reason);
+  // The failing call's attribution travels with the failure so the OPEN event can name
+  // the triggering endpoint/call-site without walking preceding events (t/2622).
+  const failure: FailureRecord = {
+    reason,
+    ...(endpoint !== undefined && { endpoint, component: deriveComponent(endpoint) }),
+    ...(method !== undefined && { method }),
+  };
+  c.recentFailures.push(failure);
   if (c.recentFailures.length > RECENT_FAILURES_CAP) c.recentFailures.shift();
+  // The just-pushed failure is the trigger (the latest / threshold-tripping entry).
+  const trig = {
+    triggering_endpoint: failure.endpoint,
+    triggering_method: failure.method,
+    triggering_component: failure.component,
+  };
   if (c.state === 'HALF_OPEN') {
     c.state = 'OPEN';
     recordEvent('network.circuit_open', 'warn',
       `Circuit '${cat}' re-OPEN after failed probe (${reason})`,
-      { category: cat, state: 'OPEN', trigger: 'half_open_probe_failed', consecutiveFailures: c.consecutiveFailures, cooldownMs: cfg().circuitCooldownMs, lastFailure: reason });
+      { category: cat, state: 'OPEN', trigger: 'half_open_probe_failed', consecutiveFailures: c.consecutiveFailures, cooldownMs: cfg().circuitCooldownMs, lastFailure: reason, ...trig });
   } else if (c.consecutiveFailures >= cfg().circuitThreshold && c.state === 'CLOSED') {
     c.state = 'OPEN';
-    const summary = summarizeFailures(c.recentFailures);
+    const summary = summarizeFailures(c.recentFailures.map(f => f.reason));
     recordEvent('network.circuit_open', 'error',
       `Circuit '${cat}' → OPEN after ${c.consecutiveFailures} consecutive failures. Last: ${summary}`,
-      { category: cat, state: 'OPEN', trigger: 'threshold_exceeded', consecutiveFailures: c.consecutiveFailures, cooldownMs: cfg().circuitCooldownMs, recentFailures: [...c.recentFailures] });
+      { category: cat, state: 'OPEN', trigger: 'threshold_exceeded', consecutiveFailures: c.consecutiveFailures, cooldownMs: cfg().circuitCooldownMs, recentFailures: c.recentFailures.map(f => f.reason), ...trig });
   }
   if (c.state !== prevState) notifyListeners();
 }
@@ -281,7 +318,7 @@ export async function resilientFetch(
       if (res.status === 429) {
         onCircuitSuccess(category);
       } else {
-        onCircuitFailure(category, `HTTP ${res.status}`);
+        onCircuitFailure(category, `HTTP ${res.status}`, path, init.method);
       }
 
       if (attempt < maxRetries) {
@@ -305,7 +342,7 @@ export async function resilientFetch(
       // Deliberate caller cancel (t/2508): not a server failure — don't trip the circuit,
       // don't retry, don't log an error. Re-throw so the bridge can tag it as a cancellation.
       if (opts.signal?.aborted) throw err;
-      onCircuitFailure(category, (err as Error).name === 'AbortError' ? 'timeout' : (err as Error).name);
+      onCircuitFailure(category, (err as Error).name === 'AbortError' ? 'timeout' : (err as Error).name, path, init.method);
 
       if (attempt < maxRetries && isRetryableError(err)) {
         const backoff = computeBackoff(attempt);
@@ -354,7 +391,7 @@ export function getResilienceState(): ResilienceStatus {
   const ts = {} as ResilienceStatus['throttles'];
   for (const cat of ALL_CATEGORIES) {
     const c = getCircuit(cat);
-    cs[cat] = { state: c.state, consecutiveFailures: c.consecutiveFailures, recentFailures: [...c.recentFailures] };
+    cs[cat] = { state: c.state, consecutiveFailures: c.consecutiveFailures, recentFailures: c.recentFailures.map(f => f.reason) };
     const t = getThrottle(cat);
     ts[cat] = {
       state: t.state,


### PR DESCRIPTION
Two renderer FR-observability additions, batched per TL (same family as the merged t/2606).

**t/2621** — `loadOpEdSet` ok event: add `has_grounding` + `member_count` + `grounded_member_count` (in `instrumentBridge.extractResultMeta`). Distinguishes "grounding absent in the payload" from "present but not rendering" — the diagnosis that previously needed on-disk JSON. Both bridges route through instrumentBridge, so desktop + hosted dumps match.

**t/2622** — `network.circuit_open` event: identify the triggering call. `onCircuitFailure` now takes `endpoint`/`method`; `recentFailures` carries a `FailureRecord` instead of a bare string; both OPEN emissions surface `triggering_endpoint`/`triggering_method`/`triggering_component`. `component` is a best-effort endpoint-derived call-site label (id-like segments → `:id`, e.g. `/api/nodes/acc-b-001/conflicts` → `/api/nodes/:id/conflicts`) — no new caller-tag convention. Public `ResilienceStatus.recentFailures` stays `string[]`.

**Self-cert /add-test.** No behavior change beyond the added event fields. renderer tsc clean · eslint 0 errors · instrumentBridge + resilience suites 50/50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)