### PR TITLE
fix(storage): validate OpEdSet against Zod schema at persist boundary (t/2617)

### DIFF
--- a/taxonomy-editor/src/server/storage/opedStore.ts
+++ b/taxonomy-editor/src/server/storage/opedStore.ts
@@ -13,6 +13,7 @@
 import path from 'path';
 import { resolveDataPath } from '../config.js';
 import type { OpEdSet, OpEdSetSummary, PovKey } from '../../../../lib/oped/types.js';
+import { parseOpEdSet } from '../../../../lib/oped/schemas.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { log } from '../logger.js';
 import { getStorageUserId, isAnonymousUser } from '../security/userContext.js';
@@ -174,10 +175,13 @@ export async function finalizeOpedSet(set: OpEdSet): Promise<void> {
     }
   }
 
+  // Validate shape before writing — rejects PS short-code pov / PascalCase grounding fields
+  const validated = parseOpEdSet(set);
+
   // (a) Write final doc — single write, atomic on blob
   await backend.writeFile(
     path.join(dir, `oped-set-${set.set_id}.json`),
-    JSON.stringify(set, null, 2),
+    JSON.stringify(validated, null, 2),
   );
 
   // (b) Upsert index


### PR DESCRIPTION
## Summary

- Add \parseOpEdSet(set)\ call in \inalizeOpedSet\ before the blob write
- Rejects PS short-code pov (\cc\/\saf\/\skp\) and PascalCase grounding fields at write time
- Uses the canonical schema from \lib/oped/schemas.js\ (landed in PR #1005)
- tsc clean (server tsconfig)

Closes server-side call site required by t/2617 (Quality review t/2617#2).

## Test plan

- [x] tsc clean
- [x] Valid \OpEdSet\ (canonical shape) passes \parseOpEdSet\ and writes
- [x] Malformed shape (PS short-code pov / PascalCase grounding) throws \ActionableError\ naming the field — covered by \lib/oped/schemas.test.ts\ (PR #1005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)