### PR TITLE
fix(main): update PROMPTS_DIR to lib/oped/prompts post-t/2609 relocation (t/2611)

### DIFF
--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -23,9 +23,8 @@ import { generateOpEdSet } from '../../../../lib/oped/generate.js';
 import type { GenerateOpEdRequest, OpEdGeneratorDeps } from '../../../../lib/oped/generate.js';
 import { makeElectronAIAdapter } from '../electronAIAdapter.js';
 
-// Shared prompts dir: op-ed-*.prompt artifacts used by both PS and TS cores.
-// t/2609: when prompts relocate, update this constant to match the new path.
-const PROMPTS_DIR = path.join(PROJECT_ROOT, 'scripts', 'AITriad', 'Prompts');
+// Shared prompts dir: op-ed-*.prompt artifacts (relocated to lib/oped/prompts by t/2609).
+const PROMPTS_DIR = path.join(PROJECT_ROOT, 'lib', 'oped', 'prompts');
 
 // Stage-A fetch shim (FromUrl path only — stays PS, t/2604 P2 will migrate to TS).
 const PREP_SHIM_PATH = path.join(PROJECT_ROOT, 'taxonomy-editor', 'src', 'main', 'ps', 'invoke-get-oped-source.ps1');


### PR DESCRIPTION
## Summary

- PR #1011 annotated `PROMPTS_DIR` with a `// t/2609: when prompts relocate, update this constant` marker
- t/2609 landed as f43e988a, moving the four `op-ed-*.prompt` files to `lib/oped/prompts/`
- This PR applies the coordinated update: `scripts/AITriad/Prompts` → `lib/oped/prompts`
- Without this fix the `create-oped-set` IPC handler throws ENOENT on every Stage B run

Live smoke verified: `generateOpEdSet` correctly resolves all four prompts and produces a complete set (see t/2611#6 for canonical JSON with real `node_id`s and full `pov` names).

## Test plan

- [ ] CI green
- [ ] `taxonomy-editor/src/main/__tests__/opedHandlers.migration.test.ts` — 5 tests (generator wiring, temp-save, partial-finalize, STOPGAP helpers absent)
- [ ] `taxonomy-editor/src/main/__tests__/opedHandlers.create.test.ts` — 20 tests

Closes t/2611 (PROMPTS_DIR lockstep component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)