### PR TITLE
fix(debates): emit newsReport.js + 4-ups paths — news-report 500 in container (t/2626)

### DIFF
--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -21,6 +21,14 @@ import * as rateLimiter from '../security/rateLimiter.js';
 import { getDataRoot } from '../config.js';
 import type { DebateDelta } from '../../../../lib/debate/types.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
+// t/2626: this static `import type` forces tsc to emit lib/debate/newsReport.js into the
+// build (rootDir=../ → dist/server/lib/debate/newsReport.js). newsReport is otherwise
+// reached ONLY by the dynamic import() in the news-report handler, so it never enters the
+// tsc program and never emits → 'Cannot find module' → a 500 on every container
+// news-report request (a distinct t/2600 cause). The namespace type also annotates the
+// dynamic result below. (prompts.js already emits via static importers — only its path
+// needed the 3-ups→4-ups fix.)
+import type * as NewsReportModule from '../../../../lib/debate/newsReport.js';
 
 // t/1461: per-{userId,debateId} in-flight guard against the concurrent debate-save
 // cascade — an actively-used debate fires saveDebate from many store transitions,
@@ -326,10 +334,12 @@ export function registerDebatesRoutes(r: Router, _ctx: ServerCtx): void {
       // t/2553: breadcrumb immediately before the dynamic imports — the import()
       // calls are the most likely fast-failure site (module resolution / runtime).
       getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debates', level: 'info', message: 'news-report: importing', data: { debateId, phase: 'importing' } });
-      // @ts-expect-error — lib/debate uses bundler moduleResolution; dynamic import resolves at runtime
-      const { extractTranscriptHighlights, summarizeArgumentNetwork } = await import('../../../lib/debate/newsReport.js');
-      // @ts-expect-error — lib/debate uses bundler moduleResolution; dynamic import resolves at runtime
-      const { newsReportPrompt } = await import('../../../lib/debate/prompts.js');
+      // 4-ups matches tsconfig.server rootDir=../ + outDir=dist/server (compiled route at
+      // dist/server/taxonomy-editor/src/server/routes/, lib at dist/server/lib/); the prior
+      // 3-ups path resolved in no environment (t/2626).
+      const { extractTranscriptHighlights, summarizeArgumentNetwork }: typeof NewsReportModule =
+        await import('../../../../lib/debate/newsReport.js');
+      const { newsReportPrompt } = await import('../../../../lib/debate/prompts.js');
 
       // t/2600: breadcrumb between the imports and the AI call so the FR's last
       // event separates an extract/summarize throw (this phase) from an import


### PR DESCRIPTION
Fixes the live container news-report 500 (t/2626): every hosted news-report throws `Cannot find module .../lib/debate/newsReport.js`.

**Two defects in `routes/debates.ts`, verified against a real `build:server`:**
1. **Not emitted.** `newsReport.js` was reached only via a dynamic `import()`, which tsc doesn't add to the program → never compiled into `dist/server/lib/debate/`. A static `import type * as NewsReportModule` forces emission — proven: `build:server` now writes `dist/server/lib/debate/newsReport.js` (8.6KB). Same mechanism that emits `lib/oped/generate.js` (t/2610).
2. **Wrong path.** Both `newsReport` + `prompts` dynamic imports used a **3-ups** path that resolves in no environment (tsc/vitest/dist). Fixed to **4-ups** per tsconfig.server rootDir=../ + outDir=dist/server; `@ts-expect-error` suppressions dropped.

`calibrationLogger` (line 41) was already 4-ups + emitted — unchanged.

Verified: tsc-server + eslint clean; `build:server` emits newsReport.js at the 4-ups path.

Flagged separately: `debateHandlers.ts:71` (Electron main, tsconfig.main) has the same dynamic-only pattern → ElectronMain to verify.

Relates t/2600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)