### PR TITLE
fix(docker): ship lib/oped/prompts in the runtime image (t/2609, t/2602)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -155,6 +155,10 @@ COPY --chown=aitriad:aitriad ai-usages.json ./
 COPY --chown=aitriad:aitriad .aitriad.json ./
 COPY --chown=aitriad:aitriad taxonomy/schemas/ ./taxonomy/schemas/
 COPY --chown=aitriad:aitriad scripts/ ./scripts/
+# Op-ed prompt templates (t/2609 relocated them out of scripts/AITriad/Prompts).
+# The op-ed create route resolves promptsDir = getProjectRoot()/lib/oped/prompts
+# (= /app/lib/oped/prompts here); tsc emits no .prompt assets, so copy the source.
+COPY --chown=aitriad:aitriad lib/oped/prompts/ ./lib/oped/prompts/
 
 # 3. Built artifacts (change on every code edit — LAST for fastest rebuilds)
 # tsc outputs to dist/server/{taxonomy-editor/src/server/,lib/} due to rootDir=../


### PR DESCRIPTION
**P1 — blocks t/2602 staging smoke.** t/2609 relocated the op-ed prompt templates out of `scripts/AITriad/Prompts/` into `lib/oped/prompts/`. The runtime stage COPYs `scripts/` (line 157) but not `lib/` source, and tsc emits no `.prompt` assets into `dist/`, so the op-ed prompts are absent from the image → op-ed create ENOENTs in prod.

Adds `COPY --chown=aitriad:aitriad lib/oped/prompts/ ./lib/oped/prompts/` to the runtime stage → lands the files at `/app/lib/oped/prompts`, matching the create route's `getProjectRoot()/lib/oped/prompts` resolution (`getProjectRoot()` = `/app` in the container). `lib/` + `*.prompt` are not `.dockerignore`'d.

⚠️ **Insufficient alone:** `routes/oped.ts:131` (ServerAPI) still injects `promptsDir = getProjectRoot()/scripts/AITriad/Prompts` (the emptied old path). That resolver must be repointed to `lib/oped/prompts` for the smoke to pass — flagged to ServerAPI as the t/2609 coupling site that was missed. **Both land before the smoke.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)