### PR TITLE
fix(oped): repoint web create promptsDir → lib/oped/prompts (t/2627, t/2609 miss)

### DIFF
--- a/taxonomy-editor/src/server/routes/oped.ts
+++ b/taxonomy-editor/src/server/routes/oped.ts
@@ -128,7 +128,11 @@ async function driveOpEdRun(
     const { generateOpEdSet } = await import('../../../../lib/oped/generate.js');
     const deps: OpEdGeneratorDeps = {
       adapter: createWebOpEdAdapter(),
-      promptsDir: path.join(getProjectRoot(), 'scripts', 'AITriad', 'Prompts'),
+      // t/2609 relocated the op-ed .prompt files from scripts/AITriad/Prompts to
+      // lib/oped/prompts; New-OpEd (PS), the parity gate, and Electron main (#1015) already
+      // read the new location. The container ships them at /app/lib/oped/prompts via the
+      // companion Dockerfile COPY (Rosetta, repo-root-anchored). Repo-root anchor matches.
+      promptsDir: path.join(getProjectRoot(), 'lib', 'oped', 'prompts'),
       repoRoot: getProjectRoot(),
     };
     for await (const event of generateOpEdSet(request, deps) as AsyncGenerator<OpEdProgressEvent>) {


### PR DESCRIPTION
t/2609 relocated the op-ed `.prompt` files from `scripts/AITriad/Prompts` to `lib/oped/prompts`, but `routes/oped.ts:131` (web create, #1013) still injected the old dir → ENOENT on op-ed create. New-OpEd (PS), the parity gate, and Electron main (#1015/t/2611) already read the new location.

**Fix:** `promptsDir: path.join(getProjectRoot(), 'lib', 'oped', 'prompts')` — getProjectRoot-based (not dist-relative), so it composes with Rosetta's companion runtime-stage `COPY lib/oped/prompts/ ./lib/oped/prompts/` (DevOps p/331#123, TL p/333#124): both resolve to `/app/lib/oped/prompts`. Both must be on main before DevOps's t/2602 staging smoke.

Op-ed is dark → no live impact; unblocks web create + the staging smoke.

Verified: tsc-server + eslint clean.

Relates t/2610, t/2609, t/2611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)