### PR TITLE
fix(main): emit newsReport.js + prompts.js in Electron main build (t/2628)

### DIFF
--- a/taxonomy-editor/src/main/ipc/debateHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/debateHandlers.ts
@@ -26,6 +26,12 @@ import { renameSyncWithRetry } from '../../../../lib/debate/persistence.js';
 import { recordLockHolder } from '../../../../lib/debate/lockHolder.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { DEFAULT_MODEL } from '../../../../lib/ai-client/index.js';
+// t/2628: static import type forces tsc to emit newsReport.js + prompts.js into
+// dist/main (rootDir=../ → dist/main/lib/debate/). Both files are reached ONLY by
+// dynamic import() in the news-report handler and never enter the tsc program otherwise
+// → 'Cannot find module' in the packaged Electron build. Mirrors cf4b735e (server-side fix).
+import type * as NewsReportModule from '../../../../lib/debate/newsReport.js';
+import type * as PromptsModule from '../../../../lib/debate/prompts.js';
 import { VALID_POV, NodeId } from '../ipcSchemas.js';
 import { assertSafeId } from '../../../../lib/electron-shared/safeId.js';
 
@@ -68,8 +74,10 @@ export function registerDebateHandlers(): void {
       });
     }
 
-    const { extractTranscriptHighlights, summarizeArgumentNetwork } = await import('../../../../lib/debate/newsReport.js');
-    const { newsReportPrompt } = await import('../../../../lib/debate/prompts.js');
+    const { extractTranscriptHighlights, summarizeArgumentNetwork }: typeof NewsReportModule =
+      await import('../../../../lib/debate/newsReport.js');
+    const { newsReportPrompt }: typeof PromptsModule =
+      await import('../../../../lib/debate/prompts.js');
 
     const anNodes = ((session.argument_network as Record<string, unknown>)?.nodes ?? []) as unknown[];
     const anEdges = ((session.argument_network as Record<string, unknown>)?.edges ?? []) as unknown[];


### PR DESCRIPTION
## Summary

- `lib/debate/newsReport.ts` and `lib/debate/prompts.ts` were reached ONLY via `await import()` in `debateHandlers.ts:71` — tsc never added them to the compilation program, so neither emitted to `dist/main/lib/debate/`
- At runtime in the packaged Electron build, every `generate-news-report` IPC call throws `Cannot find module .../lib/debate/newsReport.js`
- Fix: add `import type * as NewsReportModule` and `import type * as PromptsModule` static imports — forces tsc emission and annotates the dynamic destructuring with the namespace types
- Mirrors the server-side fix in cf4b735e

## Verification

- `npm run build:main` exits 0
- `dist/main/lib/debate/newsReport.js` (8.6 KB) confirmed emitted
- `dist/main/lib/debate/prompts.js` confirmed emitted
- 4-ups path already correct: compiled `debateHandlers.js` at `dist/main/taxonomy-editor/src/main/ipc/` → `../../../../lib/debate/` = `dist/main/lib/debate/`

## Test plan

- [ ] CI green on this head
- [ ] Pre-self-merge verify: base=main, head OID matches push, CI ran on that OID

🤖 Generated with [Claude Code](https://claude.com/claude-code)