### PR TITLE
gate(build): fail build:server on unemitted dynamic-import-only lib module (t/2626)

### DIFF
--- a/taxonomy-editor/package.json
+++ b/taxonomy-editor/package.json
@@ -31,7 +31,7 @@
     "dist:mac": "npm run build && electron-builder --mac",
     "dist:win": "npm run build && electron-builder --win",
     "dist:linux": "npm run build && electron-builder --linux",
-    "build:server": "node -e \"const fs=require('fs');fs.rmSync('dist/server',{recursive:true,force:true});fs.rmSync('.tsbuildinfo/server.tsbuildinfo',{force:true})\" && tsc -p tsconfig.server.json",
+    "build:server": "node -e \"const fs=require('fs');fs.rmSync('dist/server',{recursive:true,force:true});fs.rmSync('.tsbuildinfo/server.tsbuildinfo',{force:true})\" && tsc -p tsconfig.server.json && node scripts/check-server-lib-emits.mjs",
     "build:web": "cross-env VITE_TARGET=web vite build",
     "build:container": "npm run build:server && npm run build:web && npm run licenses",
     "start:server": "node dist/server/taxonomy-editor/src/server/server.js",

--- a/taxonomy-editor/scripts/check-server-lib-emits.mjs
+++ b/taxonomy-editor/scripts/check-server-lib-emits.mjs
@@ -13,6 +13,15 @@
 // Gate co-location (per TL condition 3): the scan target and the exemption list live HERE,
 // not in external config.
 //
+// Known limitations (TL GV note, p/333#132 — none occur in the current codebase; if one ever
+// does, add the module to EXEMPT with a why-comment, or extend the matcher):
+//   1. Multi-line import — a specifier split across lines (`import(\n  '...'\n)`) is not matched
+//      (the scan is line-oriented).
+//   2. Computed specifier — `import(someVar)` (non-literal) can't be statically resolved, so it
+//      is skipped (nothing to check).
+//   3. Bracket type-access — the type-query skip handles `import('...').T` (dot) but not the
+//      rarer `import('...')['T']` (bracket), which would be treated as a runtime import.
+//
 // Usage: node scripts/check-server-lib-emits.mjs   (exit 0 = all emitted; exit 1 = missing)
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';

--- a/taxonomy-editor/scripts/check-server-lib-emits.mjs
+++ b/taxonomy-editor/scripts/check-server-lib-emits.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// t/2626 — Build-artifact-completeness gate for the server's dynamic lib imports.
+//
+// A `dynamic import()` of a lib/ module does NOT add that module to the tsc program, so a
+// module reached ONLY via import() is silently never emitted to dist → 'Cannot find module'
+// → a 500 in the container the first time the route runs (newsReport, t/2626; the sibling
+// class of the moved-prompts and unemitted-newsReport build-artifact gaps).
+//
+// This gate runs AFTER build:server (on the real dist) and FAILS the build if any dynamic
+// import() of a lib module has no corresponding dist/server/lib/*.js. The fix it names is a
+// static `import type * as X from '<spec>'` in the importing file, which forces emission.
+//
+// Gate co-location (per TL condition 3): the scan target and the exemption list live HERE,
+// not in external config.
+//
+// Usage: node scripts/check-server-lib-emits.mjs   (exit 0 = all emitted; exit 1 = missing)
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TE = resolve(HERE, '..');                       // taxonomy-editor/
+const SERVER_SRC = join(TE, 'src', 'server');
+const DIST_LIB = join(TE, 'dist', 'server', 'lib');   // rootDir=../ + outDir=dist/server → lib lands here
+
+// Exemptions: lib modules intentionally not emitted (e.g. type-only surfaces the runtime
+// never import()s). Keep EMPTY unless a real case appears; each entry needs a why-comment.
+// Key = lib-relative path without extension, e.g. 'debate/someTypeOnly'.
+const EXEMPT = new Set([
+  // (none)
+]);
+
+/** Recursively collect .ts files under dir (skipping __tests__ and .d.ts). */
+function collectTsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      out.push(...collectTsFiles(full));
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// Map a lib import specifier → its lib-relative path (no extension), or null if not a lib module.
+//   relative:  ../../../../lib/debate/newsReport.js  → 'debate/newsReport'
+//   aliased:   @lib/debate/newsReport(.js)           → 'debate/newsReport'
+// Any ups-count is fine: lib always lands at dist/server/lib/<suffix> regardless of source depth.
+function toLibRel(spec) {
+  let m = spec.match(/(?:^|\/)lib\/(.+)$/);           // relative form: strip through '.../lib/'
+  if (!m) m = spec.match(/^@lib\/(.+)$/);             // aliased form: strip '@lib/'
+  if (!m) return null;
+  return m[1].replace(/\.js$/, '');                   // drop a trailing .js if present
+}
+
+const findings = [];
+let checked = 0;
+
+for (const file of collectTsFiles(SERVER_SRC)) {
+  const lines = readFileSync(file, 'utf-8').split(/\r?\n/);
+  lines.forEach((line, i) => {
+    // Match every `import('<spec>')` call on the line.
+    const re = /import\(\s*['"]([^'"]+)['"]\s*\)/g;
+    let mm;
+    while ((mm = re.exec(line)) !== null) {
+      // Skip TYPE queries `import('...').SomeType` — type-erased, no runtime emission needed.
+      const after = line.slice(mm.index + mm[0].length);
+      if (/^\s*\./.test(after)) continue;
+      const libRel = toLibRel(mm[1]);
+      if (!libRel || EXEMPT.has(libRel)) continue;
+      checked++;
+      const distPath = join(DIST_LIB, `${libRel}.js`);
+      if (!existsSync(distPath)) {
+        findings.push({ file: file.slice(TE.length + 1), line: i + 1, spec: mm[1], distPath: distPath.slice(TE.length + 1) });
+      }
+    }
+  });
+}
+
+if (findings.length > 0) {
+  console.error('\nBUILD-ARTIFACT GATE FAILED (t/2626) — dynamic import() of a lib module that never emitted to dist:\n');
+  for (const f of findings) {
+    console.error(`  ${f.file}:${f.line}`);
+    console.error(`    import('${f.spec}')`);
+    console.error(`    → missing: ${f.distPath}\n`);
+  }
+  console.error('Fix: add a static `import type * as X from \'<spec>\'` at the top of the importing file.');
+  console.error('A dynamic import() alone does NOT add the module to the tsc program, so it never emits.');
+  console.error(`\n${findings.length} unemitted dynamic-lib import(s). Run build:server first if dist is stale.\n`);
+  process.exit(1);
+}
+
+console.log(`check-server-lib-emits: ${checked} dynamic lib import(s) all emitted to dist. OK`);
+process.exit(0);


### PR DESCRIPTION
**Build-artifact-completeness gate — t/2626 class closure.** Prevents the news-report failure mode: a dynamic `import()` of a lib/ module doesn't add it to the tsc program, so a module reached ONLY via `import()` silently never emits to dist → `Cannot find module` 500 in the container on first use.

`scripts/check-server-lib-emits.mjs` runs after tsc in `build:server` (so it executes on the real dist in test-container):
- Scans `src/server` for runtime `import('<spec>')` of lib modules; **skips** type-query `import('...').T` forms.
- Maps each specifier — **relative** (`../../lib/X.js`) AND **`@lib`-aliased** — to `dist/server/lib/X.js`.
- **Fails** the build naming the offending import + the missing dist file + the fix (add a static `import type * as X`).
- Scan target + exemptions **co-located** in the script — no external config (TL condition 3).

**Both arms verified locally** (TL conditions p/333#130):
- Clean → `8 dynamic lib import(s) all emitted. OK` (exit 0).
- Fire (hide `dist/server/lib/debate/newsReport.js`) → names `debates.ts:341` + missing file + the fix (exit 1).

**Draft — pending TL Gate Verification** on the real dist. Touches `package.json` `build:server` (Rosetta scope) → flagged for scope review.

Relates t/2626, t/2600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)