### PR TITLE
feat(opeds): enable web op-ed create — SSE client + topic-only dialog (t/2614)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/opedStream.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/opedStream.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@lib/debate/errors', () => ({
+  ActionableError: class ActionableError extends Error {
+    goal: string; problem: string; location: string; nextSteps: string[];
+    constructor(o: { goal: string; problem: string; location: string; nextSteps: string[] }) {
+      super(o.problem); this.name = 'ActionableError';
+      this.goal = o.goal; this.problem = o.problem; this.location = o.location; this.nextSteps = o.nextSteps;
+    }
+  },
+}));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn(), intern: vi.fn() }) }));
+
+import { runOpEdCreate, opedProgressBus } from '../opedStream';
+import type { CreateOpEdPayload, OpEdProgressEvent } from '../types';
+
+/** A fake SSE Response whose body streams the given frame strings, one per read(). */
+function sseResponse(frames: string[]): Response {
+  let i = 0;
+  const encoder = new TextEncoder();
+  return {
+    ok: true, status: 200,
+    body: { getReader: () => ({ read: () => i < frames.length ? Promise.resolve({ done: false, value: encoder.encode(frames[i++]) }) : Promise.resolve({ done: true, value: undefined }) }) },
+  } as unknown as Response;
+}
+function jsonResponse(status: number, body: unknown): Response {
+  return { ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) } as unknown as Response;
+}
+/** Wrap a lib/oped generator event as a server SSE data frame ({runId, seq, event}). */
+function frame(event: Record<string, unknown>): string {
+  return `data: ${JSON.stringify({ runId: 'run-1', seq: 0, event })}\n\n`;
+}
+
+const PAYLOAD: CreateOpEdPayload = { topic: 'Frontier audits', params: { model: 'm', wordCount: 800 }, voices: ['acc', 'saf'] as CreateOpEdPayload['voices'] };
+
+describe('opedStream.runOpEdCreate', () => {
+  let progress: OpEdProgressEvent[];
+  let unsub: () => void;
+  beforeEach(() => {
+    progress = [];
+    unsub = opedProgressBus.onProgress((e) => progress.push(e));
+  });
+
+  it('maps per-voice events to onProgress and resolves set_id on complete', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(sseResponse([
+      frame({ type: 'run_started', runId: 'run-1' }),
+      frame({ type: 'voice_start', pov: 'acc' }),
+      frame({ type: 'voice_complete', pov: 'acc', member: {} }),
+      frame({ type: 'voice_failed', pov: 'saf', error: 'boom' }),
+      frame({ type: 'complete', set: { set_id: 's1' } }),
+    ]));
+    const result = await runOpEdCreate(fetchFn, PAYLOAD);
+    unsub();
+    expect(result).toEqual({ set_id: 's1' });
+    expect(progress).toEqual([
+      { set_id: '', voice: 'acc', stage: 'generating' },
+      { set_id: '', voice: 'acc', stage: 'complete' },
+      { set_id: '', voice: 'saf', stage: 'failed', error: 'boom' },
+    ]);
+  });
+
+  it('maps bridge voices → server povs in the POST body', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(sseResponse([frame({ type: 'complete', set: { set_id: 's1' } })]));
+    await runOpEdCreate(fetchFn, PAYLOAD);
+    unsub();
+    const body = JSON.parse(fetchFn.mock.calls[0][1].body as string);
+    expect(body).toMatchObject({ topic: 'Frontier audits', povs: ['acc', 'saf'] });
+    expect(body.voices).toBeUndefined();
+  });
+
+  it('does not dispatch set-level grounding events to onProgress', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(sseResponse([
+      frame({ type: 'grounding_done', nodeCount: 5 }),
+      frame({ type: 'voice_start', pov: 'acc' }),
+      frame({ type: 'complete', set: { set_id: 's1' } }),
+    ]));
+    await runOpEdCreate(fetchFn, PAYLOAD);
+    unsub();
+    expect(progress).toEqual([{ set_id: '', voice: 'acc', stage: 'generating' }]);
+  });
+
+  it('rejects a pre-SSE 429 concurrency error with a user-readable message', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(429, { error: 'concurrency_limit', message: 'You already have an op-ed generating; wait for it to finish.' }));
+    await expect(runOpEdCreate(fetchFn, PAYLOAD)).rejects.toThrow(/already have an op-ed generating/);
+    unsub();
+  });
+
+  it('recovers via run-status GET when the stream ends without a complete frame', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(sseResponse([frame({ type: 'run_started', runId: 'run-1' }), frame({ type: 'voice_start', pov: 'acc' })]))
+      .mockResolvedValueOnce(jsonResponse(200, { runId: 'run-1', setId: 's2', status: 'complete', perVoice: {} }));
+    const result = await runOpEdCreate(fetchFn, PAYLOAD);
+    unsub();
+    expect(result).toEqual({ set_id: 's2' });
+    // Second call is the run-status recovery GET.
+    expect(fetchFn.mock.calls[1][0]).toBe('/api/oped-runs/run-1');
+    expect(fetchFn.mock.calls[1][1].method).toBe('GET');
+  });
+
+  it('rejects when the recovery run-status reports error', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(sseResponse([frame({ type: 'run_started', runId: 'run-1' })]))
+      .mockResolvedValueOnce(jsonResponse(200, { runId: 'run-1', setId: 's3', status: 'error', perVoice: {} }));
+    await expect(runOpEdCreate(fetchFn, PAYLOAD)).rejects.toThrow(/failed on the server|interrupted/i);
+    unsub();
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/opedStream.ts
+++ b/taxonomy-editor/src/renderer/bridge/opedStream.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Op-Ed create streaming (SSE) transport for the web bridge (t/2614). Extracted as a leaf
+ * module (like chatStream.ts) so web-bridge.ts stays under the max-lines cap and the SSE
+ * parse/dispatch is unit-testable in isolation.
+ *
+ * Shape-identical to the Electron IPC (opedHandlers.ts): createOpEdSet resolves `{set_id}`
+ * or rejects with an ActionableError; onOpEdProgress callbacks fire per voice as the run
+ * streams. The per-voice stage mapping matches Electron EXACTLY so desktop and web render
+ * the same live panel.
+ *
+ * Server contract (POST /api/oped-sets, t/2610 — SSE):
+ *   200 text/event-stream, each frame: data: {runId, seq, event}
+ *     event {type:'run_started', runId}
+ *     event {type:'voice_start'|'voice_complete'|'voice_failed'|'voice_cancelled', pov, ...}
+ *     event {type:'grounding_done'|'grounding_failed', ...}   (set-level — not per-voice)
+ *     event {type:'complete', set}                            → resolve {set_id: set.set_id}
+ *     event {type:'error', message}                           → reject
+ *   Pre-SSE failures (403 anon / 429 quota|concurrency / 400 / 403 entitlement) arrive
+ *   instead as a non-200 JSON body BEFORE the stream headers.
+ * Recovery (t/2610): a dropped stream re-fetches GET /api/oped-runs/:runId — a terminal
+ * status resolves with the durable set_id (the set is finalized server-side); the run never
+ * orphans the UI.
+ */
+
+import { ActionableError } from '@lib/debate/errors';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { categorizeEndpoint, type ResilientFetchOptions } from './resilience';
+import type { CreateOpEdPayload, OpEdProgressEvent } from './types';
+
+type OpEdProgressCb = (event: OpEdProgressEvent) => void;
+const progressCbs = new Set<OpEdProgressCb>();
+
+/** Subscription surface exposed via the bridge's onOpEdProgress method. */
+export const opedProgressBus = {
+  onProgress: (cb: OpEdProgressCb): (() => void) => { progressCbs.add(cb); return () => { progressCbs.delete(cb); }; },
+};
+
+// A web build runs at most one create at a time (mirrors the server's per-user concurrency
+// cap of 1). Cancel = abort the in-flight POST → the server's res.on('close') cancels the
+// in-flight voices and still finalizes the partial set (t/2610 gap 1).
+let activeAbort: AbortController | null = null;
+
+/** Abort the in-flight web op-ed run, if any (bridge cancelOpEdSet on web). */
+export function cancelActiveOpEdRun(): void {
+  activeAbort?.abort();
+}
+
+const OPED_STREAM_TIMEOUT_MS = 300_000; // multi-voice generation: 30s–2min per voice × N
+
+function errShape(err: unknown): { name: string; message: string; stack?: string } {
+  return { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack };
+}
+
+function emitProgress(event: OpEdProgressEvent): void {
+  for (const cb of progressCbs) {
+    try { cb(event); } catch { /* telemetry — silent by design */ }
+  }
+}
+
+/** Parse an SSE byte stream, invoking `onEvent` once per `data:` JSON payload. */
+async function consumeSse(res: Response, onEvent: (evt: Record<string, unknown>) => void): Promise<void> {
+  const reader = res.body?.getReader();
+  if (!reader) return;
+  const decoder = new TextDecoder();
+  let buffer = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let sep: number;
+    while ((sep = buffer.indexOf('\n\n')) !== -1) {
+      const frame = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      const data = frame.split('\n').filter((l) => l.startsWith('data:')).map((l) => l.replace(/^data:\s?/, '')).join('\n');
+      if (!data) continue; // heartbeat ': ping' comment or blank
+      try { onEvent(JSON.parse(data) as Record<string, unknown>); }
+      catch (err) { getGlobalRecorder()?.record({ type: 'system.error', component: 'web-bridge', level: 'warn', message: 'oped-stream: malformed SSE data frame', error: errShape(err) }); }
+    }
+  }
+}
+
+/** Build a user-readable ActionableError from a non-200 create response (JSON error emitted
+ *  before the SSE headers: 403 anon, 400 bad request, 403 entitlement, 429 quota/concurrency). */
+async function buildHttpError(res: Response): Promise<ActionableError> {
+  const data = await res.json().catch(() => ({})) as Record<string, unknown>;
+  const goal = 'Op-Ed Studio: create an op-ed';
+  if (res.status === 429) {
+    const problem = data.error === 'concurrency_limit'
+      ? (data.message as string) || 'You already have an op-ed generating — wait for it to finish.'
+      : 'You have reached your op-ed limit. Delete an op-ed or try again later.';
+    const err = new ActionableError({ goal, problem, location: 'opedStream.runOpEdCreate', nextSteps: data.error === 'concurrency_limit' ? ['Wait for the current op-ed to finish, then try again'] : ['Delete an existing op-ed to free a slot', 'Try again later'] });
+    (err as ActionableError & { httpStatus: number }).httpStatus = 429;
+    return err;
+  }
+  const problem = (typeof data.error === 'string' && data.error) || (typeof data.message === 'string' && data.message) || `Create failed with HTTP ${res.status}`;
+  const nextSteps = res.status === 403
+    ? ['Sign in with GitHub or Google to create op-eds']
+    : ['Check your topic and selected voices, then try again'];
+  const err = new ActionableError({ goal, problem, location: 'opedStream.runOpEdCreate', nextSteps });
+  (err as ActionableError & { httpStatus: number }).httpStatus = res.status;
+  return err;
+}
+
+/** Map a lib/oped generator event → the bridge's per-voice {set_id, voice, stage, error}
+ *  shape, matching Electron opedHandlers exactly. Returns null for non-per-voice events
+ *  (grounding breadcrumbs / run_started / complete are handled by the caller). */
+function toProgress(event: Record<string, unknown>): OpEdProgressEvent | null {
+  const pov = typeof event.pov === 'string' ? event.pov : '';
+  switch (event.type) {
+    case 'voice_start': return { set_id: '', voice: pov, stage: 'generating' };
+    case 'voice_complete': return { set_id: '', voice: pov, stage: 'complete' };
+    case 'voice_failed': return { set_id: '', voice: pov, stage: 'failed', error: typeof event.error === 'string' ? event.error : undefined };
+    case 'voice_cancelled': return { set_id: '', voice: pov, stage: 'cancelled' };
+    default: return null; // grounding_done/failed (set-level) + run_started/complete
+  }
+}
+
+/** The web bridge's session-recovering fetch (injected to avoid a circular import). */
+type OpEdFetch = (path: string, init: RequestInit, opts: ResilientFetchOptions) => Promise<Response>;
+
+/** Recover a dropped stream: a terminal run resolves with the durable set_id; still-running
+ *  or missing → surface as an interruption the user can retry (the set may exist in My Library). */
+async function recoverFromRunStatus(fetchFn: OpEdFetch, runId: string): Promise<{ set_id: string }> {
+  const path = `/api/oped-runs/${encodeURIComponent(runId)}`;
+  const res = await fetchFn(path, { method: 'GET' }, { timeoutMs: 30_000, maxRetries: 1, critical: false, category: categorizeEndpoint(path, 'GET') });
+  if (!res.ok) throw new ActionableError({ goal: 'Op-Ed Studio: create an op-ed', problem: 'The op-ed stream was interrupted and its run could not be recovered.', location: 'opedStream.recoverFromRunStatus', nextSteps: ['Check My Op-Eds — it may have finished', 'Try creating it again'] });
+  const run = await res.json() as { setId?: string; status?: string };
+  if ((run.status === 'complete' || run.status === 'cancelled') && typeof run.setId === 'string') return { set_id: run.setId };
+  throw new ActionableError({ goal: 'Op-Ed Studio: create an op-ed', problem: run.status === 'error' ? 'Op-ed generation failed on the server.' : 'The op-ed stream was interrupted before it finished.', location: 'opedStream.recoverFromRunStatus', nextSteps: ['Check My Op-Eds — it may have finished', 'Try creating it again'] });
+}
+
+/** Drive one web op-ed create: POST → read SSE → map per-voice events to onOpEdProgress →
+ *  resolve {set_id} on 'complete'. Rejects with an ActionableError (pre-SSE JSON error, a
+ *  server 'error' frame, or an unrecoverable stream drop). */
+export async function runOpEdCreate(fetchFn: OpEdFetch, payload: CreateOpEdPayload): Promise<{ set_id: string }> {
+  const body = { topic: payload.topic, povs: payload.voices, params: payload.params };
+  const controller = new AbortController();
+  activeAbort = controller;
+  getGlobalRecorder()?.record({ type: 'ai.request', component: 'web-bridge', level: 'info', message: 'oped-create request', data: { voiceCount: payload.voices.length, model: payload.params.model } });
+
+  const path = '/api/oped-sets';
+  let res: Response;
+  try {
+    res = await fetchFn(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
+      { timeoutMs: OPED_STREAM_TIMEOUT_MS, maxRetries: 0, critical: true, category: categorizeEndpoint(path, 'POST'), signal: controller.signal });
+  } catch (err) {
+    activeAbort = null;
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'web-bridge', level: 'error', message: 'oped-create network error', error: errShape(err) });
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      throw new ActionableError({ goal: 'Op-Ed Studio: create an op-ed', problem: 'Op-ed creation was cancelled.', location: 'opedStream.runOpEdCreate', nextSteps: ['Start a new op-ed when you are ready'] });
+    }
+    throw err;
+  }
+
+  if (!res.ok) { activeAbort = null; throw await buildHttpError(res); }
+
+  let runId = '';
+  let resolvedSetId: string | null = null;
+  let streamError: ActionableError | null = null;
+  try {
+    await consumeSse(res, (frame) => {
+      const event = (frame.event ?? frame) as Record<string, unknown>; // frames wrap: {runId, seq, event}
+      if (typeof frame.runId === 'string' && frame.runId) runId = frame.runId;
+      if (event.type === 'run_started') { if (typeof event.runId === 'string') runId = event.runId; return; }
+      if (event.type === 'complete') {
+        const set = event.set as { set_id?: unknown } | undefined;
+        if (set && typeof set.set_id === 'string') resolvedSetId = set.set_id;
+        return;
+      }
+      if (event.type === 'error') {
+        streamError = new ActionableError({ goal: 'Op-Ed Studio: create an op-ed', problem: typeof event.message === 'string' ? event.message : 'Op-ed generation failed on the server.', location: 'opedStream.runOpEdCreate', nextSteps: ['Try creating it again', 'Check My Op-Eds — a partial op-ed may have been saved'] });
+        return;
+      }
+      const progress = toProgress(event);
+      if (progress) emitProgress(progress);
+    });
+  } catch (err) {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'web-bridge', level: 'error', message: 'oped-create: reading the SSE body failed', error: errShape(err) });
+    activeAbort = null;
+    // Stream dropped mid-run — recover via the run-status GET rather than orphaning the UI.
+    // recoverFromRunStatus throws its own ActionableError on failure, which propagates to the caller.
+    if (runId) return recoverFromRunStatus(fetchFn, runId);
+    throw new ActionableError({ goal: 'Op-Ed Studio: create an op-ed', problem: `The op-ed stream was interrupted: ${String(err)}`, location: 'opedStream.runOpEdCreate', nextSteps: ['Check your network connection and try again'] });
+  }
+
+  activeAbort = null;
+  if (streamError) throw streamError as ActionableError;
+  if (resolvedSetId) return { set_id: resolvedSetId };
+  // Stream ended cleanly but with no 'complete' frame (rare) — recover the terminal state.
+  if (runId) return recoverFromRunStatus(fetchFn, runId);
+  throw new ActionableError({ goal: 'Op-Ed Studio: create an op-ed', problem: 'The op-ed finished but no result was returned.', location: 'opedStream.runOpEdCreate', nextSteps: ['Check My Op-Eds — it may have been saved', 'Try creating it again'] });
+}

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -16,6 +16,7 @@ import { encryptKeysForSharing, decryptKeysFromSharing } from '../utils/keyShare
 import { resilientFetch, categorizeEndpoint, registerConnectionPoolProvider, type EndpointCategory } from './resilience';
 import { nextStepsForStatus } from './httpErrorSteps';
 import { runChatStream, chatStreamBus } from './chatStream';
+import { runOpEdCreate, cancelActiveOpEdRun, opedProgressBus } from './opedStream';
 import { onQuotaMilestone } from '../hooks/useQuotaWarning';
 export { getResilienceState, subscribeResilience, resetResilience } from './resilience';
 export type { ResilienceStatus, CircuitState, ThrottleState, EndpointCategory } from './resilience';
@@ -1023,16 +1024,12 @@ const rawApi: AppAPI = {
   loadOpEdSet: (id) => get<OpEdSet>(`/api/oped-sets/${encodeURIComponent(id)}`),
   saveOpEdSet: (set) => put(`/api/oped-sets/${encodeURIComponent(set.set_id)}`, set).then(() => {}),
   deleteOpEdSet: (id) => del(`/api/oped-sets/${encodeURIComponent(id)}`).then(() => {}),
-  // PR#2 create flow is Electron-only (New-OpEd is PowerShell; v1 has no web generation
-  // route — server confirms). Web rejects honestly; the UI shows a "desktop app" affordance.
-  createOpEdSet: () => Promise.reject(new ActionableError({
-    goal: 'Op-Ed Studio: create an op-ed',
-    problem: 'Op-ed generation runs the New-OpEd PowerShell cmdlet, available only in the desktop app.',
-    location: 'web-bridge · Op-Ed Studio',
-    nextSteps: ['Open the desktop app to draft op-eds.', 'You can still browse, share, and copy community op-eds here.'],
-  })),
-  cancelOpEdSet: () => { /* no-op: web has no in-flight generation to cancel */ },
-  onOpEdProgress: () => () => {}, // web has no generation progress stream
+  // Web op-ed create (t/2614) — POST /api/oped-sets opens an SSE run driven by the shared
+  // lib/oped core server-side (t/2610). Topic-only on web (the URL toggle is hidden). The
+  // SSE parse/dispatch + run-status recovery live in opedStream.ts (leaf, like chatStream).
+  createOpEdSet: (payload) => runOpEdCreate(fetchWithSessionRecovery, payload),
+  cancelOpEdSet: () => cancelActiveOpEdRun(), // aborts the in-flight POST → server cancels voices
+  onOpEdProgress: (cb) => opedProgressBus.onProgress(cb),
   exportDebateToFile: async (session, format = 'json', exportOptions) => {
     const { debateToText, debateToMarkdown, debateToHtml, debateToPackage, debateExportFilename } = await import('@lib/debate/debateExport');
     const debate = session as Parameters<typeof debateToText>[0] & { diagnostics?: unknown };

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
@@ -465,6 +465,9 @@ function OpEdProgressPanel({
 // ── Screen A form (extracted to keep the dialog's complexity in check) ────────
 
 interface CreateFormProps {
+  /** Whether the URL/source create path is offered. False on web (v1 topic-only) — the
+   *  server rejects URL create, so we never present a submit path it can't run (t/2614). */
+  allowUrlSource: boolean;
   fromWebPage: boolean;
   setFromWebPage: (v: boolean) => void;
   topic: string;
@@ -512,9 +515,11 @@ function OpEdCreateForm(p: CreateFormProps) {
               autoFocus
               aria-required="true"
             />
-            <button type="button" className="oped-source-toggle" onClick={() => p.setFromWebPage(true)}>
-              ⌥ From a web page instead →
-            </button>
+            {p.allowUrlSource && (
+              <button type="button" className="oped-source-toggle" onClick={() => p.setFromWebPage(true)}>
+                ⌥ From a web page instead →
+              </button>
+            )}
           </div>
         ) : (
           <div>
@@ -636,10 +641,12 @@ function OpEdCreateForm(p: CreateFormProps) {
 
 // ── Main dialog ────────────────────────────────────────────────────────────────
 
-export function NewOpEdDialog({ open, onClose, onCreated }: {
+export function NewOpEdDialog({ open, onClose, onCreated, allowUrlSource = true }: {
   open: boolean;
   onClose: () => void;
   onCreated: (setId: string) => void;
+  /** Offer the URL/source create path. Default true (desktop); false on web — v1 topic-only. */
+  allowUrlSource?: boolean;
 }) {
   // Screen A
   const [fromWebPage, setFromWebPage] = useState(false);
@@ -831,6 +838,7 @@ export function NewOpEdDialog({ open, onClose, onCreated }: {
           <OpEdProgressPanel voices={orderedVoices} progress={progress} onCancel={handleCancel} />
         ) : (
           <OpEdCreateForm
+            allowUrlSource={allowUrlSource}
             fromWebPage={fromWebPage}
             setFromWebPage={setFromWebPage}
             topic={topic}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -101,14 +101,13 @@ function filterCommunity(entries: OpEdCommunityEntry[], q: string): OpEdCommunit
 // ── Header actions (Edit / bulk-delete / disabled + New) ──────────────────────
 
 function OpEdHeaderActions({
-  listView, editMode, hasSets, selectedCount, isElectron,
+  listView, editMode, hasSets, selectedCount,
   onBulkDelete, onClearSelected, onExitEdit, onEnterEdit, onNew,
 }: {
   listView: 'my' | 'community';
   editMode: boolean;
   hasSets: boolean;
   selectedCount: number;
-  isElectron: boolean;
   onBulkDelete: () => void;
   onClearSelected: () => void;
   onExitEdit: () => void;
@@ -132,21 +131,11 @@ function OpEdHeaderActions({
       {hasSets && (
         <button className="btn btn-sm btn-ghost" onClick={onEnterEdit} title="Rename or delete op-eds">Edit</button>
       )}
-      {/* Create (PR#2) — Electron only; web keeps the disabled desktop-app affordance. */}
-      {isElectron ? (
-        <button className="btn btn-sm" onClick={onNew} aria-label="New op-ed">
-          + New Op-Ed
-        </button>
-      ) : (
-        <button
-          className="btn btn-sm"
-          disabled
-          title="Available in the desktop app"
-          aria-label="New op-ed (available in the desktop app)"
-        >
-          + New Op-Ed
-        </button>
-      )}
+      {/* Create — both builds (t/2614). Desktop runs the in-process core; web streams the
+          shared lib/oped core via POST /api/oped-sets (topic-only; URL toggle hidden on web). */}
+      <button className="btn btn-sm" onClick={onNew} aria-label="New op-ed">
+        + New Op-Ed
+      </button>
     </div>
   );
 }
@@ -361,7 +350,6 @@ export function OpEdTab() {
             editMode={editMode}
             hasSets={sets.length > 0}
             selectedCount={selectedIds.size}
-            isElectron={isElectron}
             onBulkDelete={handleBulkDelete}
             onClearSelected={clearSelected}
             onExitEdit={exitEditMode}
@@ -436,13 +424,14 @@ export function OpEdTab() {
         )}
       </div>
 
-      {isElectron && (
-        <NewOpEdDialog
-          open={showNewDialog}
-          onClose={() => setShowNewDialog(false)}
-          onCreated={setId => { void handleCreated(setId); }}
-        />
-      )}
+      {/* Create dialog — both builds (t/2614). URL/source create is desktop-only in v1
+          (server rejects it), so the web build hides the URL toggle → topic-only. */}
+      <NewOpEdDialog
+        open={showNewDialog}
+        onClose={() => setShowNewDialog(false)}
+        onCreated={setId => { void handleCreated(setId); }}
+        allowUrlSource={isElectron}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Wires the web build's create path to t/2610's `POST /api/oped-sets` SSE route — op-ed generation now works on web (was desktop-only; the bridge hard-rejected).

### Changes
- **NEW `bridge/opedStream.ts`** — leaf SSE client mirroring `chatStream.ts`: an `onProgress` bus + `runOpEdCreate`. POSTs `{topic, povs, params}` (maps bridge `voices`→server `povs`), reads the SSE, maps lib events → the bridge `{set_id, voice, stage, error}` shape **matching electron opedHandlers exactly**, resolves `{set_id}` on `complete`. Pre-SSE non-200 → ActionableError (403 anon / 429 quota+concurrency). Stream-drop → `GET /api/oped-runs/:runId` recovery (never orphans the UI). Cancel aborts the POST → server cancels voices + finalizes the partial set.
- **`web-bridge.ts`** — the create trio now routes through opedStream (was reject/no-op stubs).
- **`OpEdTab.tsx`** — enable the web New-Op-Ed button + render the dialog on both builds.
- **`NewOpEdDialog.tsx`** — `allowUrlSource` prop; web passes `false` → URL toggle hidden → **topic-only** (server rejects URL create in v1).

### Deviations (self-cert /add-bridge-method, per t/2614#2)
SSE-client leaf module (mirrors chatStream.ts); cross-build UI gating; web omits set-level grounding breadcrumbs (not per-voice, zero UI impact; per-voice stages match desktop); **no progress-contract change** (reuses t/2610 frames verbatim).

### Verify
renderer tsc clean · eslint 0 errors · depcruise clean · **web build OK** · `opedStream.test.ts` 6/6 (SSE parse + stage map, voices→povs, grounding-skip, 429 reject, stream-drop→run-status recovery) · opeds+bridge suites 184/184. **Desktop create path unchanged.**

⚠️ AC's both-build **live smoke** (web create topic end-to-end) needs this code + the route on the same deploy — completes on DevOps's t/2602 staging. Keeping t/2614 In Progress until that passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)