### PR TITLE
fix(ai): shared backend-entitlement gate for the 2 bypass endpoints (t/2625)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/entitlementGate.test.ts
+++ b/taxonomy-editor/src/server/__tests__/entitlementGate.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment node
+//
+// t/2625 — the shared backend-entitlement gate + its wiring into the two routes that
+// previously bypassed it. A free/restricted tier must not be able to select a premium
+// backend via body.model: resolveGenerationContext pins the free tier's model and
+// enforceBackendAllowed 403s a disallowed backend BEFORE any generation.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import http from 'http';
+
+const h = vi.hoisted(() => ({
+  tier: null as unknown,
+}));
+const FREE = { level: 'free', allowedBackends: ['gemini'], pinnedModel: 'gemini-2.5-flash', limits: { requestsPerMinute: 10, tokensPerDay: 1000 }, serverProvidedKey: true };
+const PLATFORM = { level: 'platform', allowedBackends: ['gemini', 'claude'], pinnedModel: undefined, limits: { requestsPerMinute: 100, tokensPerDay: 1_000_000 }, serverProvidedKey: false };
+
+vi.mock('../ai/proxyTiers.js', () => ({
+  resolveTier: () => h.tier,
+  isBackendAllowed: (tier: { allowedBackends: string[] }, b: string) => tier.allowedBackends.includes(b),
+}));
+vi.mock('../ai/aiBackends.js', () => ({
+  resolveBackend: (m: string | undefined) => (m && m.includes('claude') ? 'claude' : 'gemini'),
+  generateTextWithSearchByUsage: vi.fn(), generateText: vi.fn(),
+  isContextTooLongError: () => false, is429Error: () => false, retryAfterMs: () => 0,
+  computeAvailableBackends: vi.fn(),
+}));
+vi.mock('../security/accessControl.js', () => ({ callerTierIdentity: () => ({ principalName: '', idp: '' }), clientSafeMessage: (m: string) => m }));
+vi.mock('../security/userContext.js', () => ({ getCurrentUser: () => null, getStorageUserId: () => 'u', isAnonymousUser: () => true, getAnonymousSessionId: () => 'anon' }));
+vi.mock('../../../../lib/ai-client/index.js', () => ({ DEFAULT_MODEL: 'gemini-2.5-flash' }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+
+import { resolveGenerationContext, enforceBackendAllowed } from '../routes/generationContext.js';
+import { createRouter } from '../httpKit.js';
+import { registerSourcesRoutes } from '../routes/sources.js';
+import { registerAiRoutes } from '../routes/ai.js';
+import * as aiMock from '../ai/aiBackends.js';
+
+// A non-free tier HONOURS the requested model (no pinning) but restricts backends — the
+// path where a disallowed backend produces a 403 rather than a silent free-tier downgrade.
+const RESTRICTED = { level: 'platform', allowedBackends: ['gemini'], pinnedModel: undefined, limits: { requestsPerMinute: 100, tokensPerDay: 1_000_000 }, serverProvidedKey: false };
+
+function mockReq(): http.IncomingMessage {
+  return { headers: {}, socket: { remoteAddress: '127.0.0.1' } } as unknown as http.IncomingMessage;
+}
+function mockRes() {
+  const r = {
+    statusCode: 0, body: '', headers: {} as Record<string, string>, writableEnded: false,
+    writeHead(code: number, hdrs?: Record<string, string>) { r.statusCode = code; if (hdrs) Object.assign(r.headers, hdrs); return r; },
+    setHeader(k: string, v: string) { r.headers[k] = v; },
+    end(b?: string) { r.body = b ?? ''; r.writableEnded = true; return r; },
+    write() { return true; },
+  };
+  return r;
+}
+function handlerFor(register: (r: never, ctx: never) => void, method: string, path: string) {
+  const routes: Array<{ method: string; path: string; handler: (req: unknown, res: unknown, body: unknown) => unknown }> = [];
+  register(createRouter(routes as never) as never, {} as never);
+  return routes.find(r => r.method === method && r.path === path)!.handler;
+}
+
+describe('t/2625 — shared backend-entitlement gate', () => {
+  beforeEach(() => { h.tier = FREE; });
+
+  it('resolveGenerationContext pins the free tier model over a user-supplied premium model', () => {
+    const { effectiveModel, backend, isFree } = resolveGenerationContext(mockReq(), 'claude-opus-4');
+    expect(isFree).toBe(true);
+    expect(effectiveModel).toBe('gemini-2.5-flash'); // pinned — NOT the requested claude model
+    expect(backend).toBe('gemini');
+  });
+
+  it('resolveGenerationContext honours the requested model for a non-free tier', () => {
+    h.tier = PLATFORM;
+    const { effectiveModel, backend } = resolveGenerationContext(mockReq(), 'claude-opus-4');
+    expect(effectiveModel).toBe('claude-opus-4');
+    expect(backend).toBe('claude');
+  });
+
+  it('enforceBackendAllowed 403s a backend the tier cannot use', () => {
+    const res = mockRes();
+    expect(enforceBackendAllowed(res as never, FREE as never, 'claude')).toBe(true);
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).requested_backend).toBe('claude');
+  });
+
+  it('enforceBackendAllowed passes an allowed backend without responding', () => {
+    const res = mockRes();
+    expect(enforceBackendAllowed(res as never, FREE as never, 'gemini')).toBe(false);
+    expect(res.statusCode).toBe(0);
+  });
+});
+
+describe('t/2625 — the two formerly-bypassing routes now route through the gate', () => {
+  beforeEach(() => { h.tier = FREE; vi.mocked(aiMock.generateTextWithSearchByUsage).mockClear(); });
+
+  it('POST /api/evidence-qbaf → 403 when a restricted tier requests a disallowed backend', async () => {
+    h.tier = RESTRICTED;
+    const handler = handlerFor(registerSourcesRoutes as never, 'POST', '/api/evidence-qbaf');
+    const res = mockRes();
+    await handler(mockReq(), res, { claimText: 'x', claimId: 'c1', model: 'claude-opus-4' });
+    expect(res.statusCode).toBe(403); // gated BEFORE any evidence retrieval / generation
+  });
+
+  it('POST /api/ai/search → 403 when a restricted tier requests a disallowed backend', async () => {
+    h.tier = RESTRICTED;
+    const handler = handlerFor(registerAiRoutes as never, 'POST', '/api/ai/search');
+    const res = mockRes();
+    await handler(mockReq(), res, { prompt: 'hi', model: 'claude-opus-4' });
+    expect(res.statusCode).toBe(403); // gated BEFORE the search-generation call
+  });
+
+  it('POST /api/ai/search → a free user\'s premium model is DOWNGRADED to the pinned backend, not passed through', async () => {
+    h.tier = FREE;
+    const handler = handlerFor(registerAiRoutes as never, 'POST', '/api/ai/search');
+    const res = mockRes();
+    await handler(mockReq(), res, { prompt: 'hi', model: 'claude-opus-4' });
+    expect(res.statusCode).toBe(200); // free tier pins → runs on the allowed backend
+    // The provider was invoked with the PINNED model, never the requested premium one.
+    const call = vi.mocked(aiMock.generateTextWithSearchByUsage).mock.calls[0];
+    expect(call?.[2]).toEqual({ model: 'gemini-2.5-flash' });
+  });
+});

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -446,6 +446,8 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
         data: { model: model ?? 'default', promptLength: prompt?.length, source: ai.isContextTooLongError(err) ? 'context_overflow' : ai.is429Error(err) ? 'upstream' : 'error' },
       });
+      if (ai.isContextTooLongError(err)) log.server.warn({ component: 'ai-search', model: model ?? 'default' }, 'AI search input exceeds model context window');
+      else if (ai.is429Error(err)) log.server.warn({ component: 'ai-search', model: model ?? 'default', retryAfterMs: ai.retryAfterMs(err) }, 'AI search upstream rate-limited — returning 429');
       respondAiSearchError(res, err);
     }
   });

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -27,6 +27,7 @@ import { hasApiKey, getPaidGeminiFallbackKey, type AIBackend } from '../config.j
 import * as proxyTiers from '../ai/proxyTiers.js';
 import * as rateLimiter from '../security/rateLimiter.js';
 import * as ai from '../ai/aiBackends.js';
+import { resolveGenerationContext, enforceBackendAllowed } from './generationContext.js';
 import * as fileIO from '../storage/fileIO.js';
 
 // Pure mirror of the server.ts parseCookies helper (used by the logout /
@@ -68,21 +69,6 @@ const BACKEND_DISPLAY: Record<AIBackend, string> = {
 // ── POST /api/ai/generate guard/step helpers (extracted from the handler, ADR-007)
 // Each guard returns true when it has already sent a response (caller must return).
 type ResolvedTier = ReturnType<typeof proxyTiers.resolveTier>;
-
-/** 403 + record when the resolved backend isn't allowed on the caller's tier. */
-function enforceBackendAllowed(res: http.ServerResponse, tier: ResolvedTier, backend: AIBackend): boolean {
-  if (proxyTiers.isBackendAllowed(tier, backend)) return false;
-  // t/1463: record the tier context so a tier-restriction 403 is a one-line FR read
-  // instead of a server.ts → proxyTiers → runtimeConfig code trace.
-  getGlobalRecorder()?.record({
-    type: 'ai.error', component: 'ai-generate', level: 'warn',
-    message: `Backend '${backend}' not available on '${tier.level}' tier`,
-    data: { tier_level: tier.level, requested_backend: backend, allowed_backends: tier.allowedBackends },
-  });
-  res.writeHead(403);
-  res.end(JSON.stringify({ error: `Backend '${backend}' not available on your tier`, tier_level: tier.level, requested_backend: backend }));
-  return true;
-}
 
 /** Per-IP (free) / per-user RPM + daily-token limits. 429 + log/record on breach. */
 function enforceAiRateLimits(res: http.ServerResponse, isFree: boolean, limitKey: string, tier: ResolvedTier, backend: AIBackend): boolean {
@@ -273,20 +259,22 @@ function respondIfUpstream429(res: http.ServerResponse, err: unknown, modelLabel
   return true;
 }
 
-/** Resolve the caller's tier + rate-limit key + effective (pinned-for-free) model +
- *  target backend from the request. Pure setup — sends no response. */
-function resolveGenerationContext(req: http.IncomingMessage, model: string | undefined): {
-  tier: ResolvedTier; isFree: boolean; limitKey: string; effectiveModel: string | undefined; backend: AIBackend;
-} {
-  const { principalName, idp } = callerIdentity(); // t/848: verified context, not raw headers
-  const tier = proxyTiers.resolveTier(principalName, idp);
-  const isFree = tier.level === 'free';
-  // Free tier (t/793): keyed per-IP (all keyless users would otherwise share one
-  // bucket), with the model pinned. Other tiers key by user and honour the request model.
-  const limitKey = isFree ? `free:${getClientIp(req)}` : (principalName || '_anonymous');
-  const effectiveModel = isFree ? (tier.pinnedModel ?? model) : model;
-  const backend = ai.resolveBackend(effectiveModel || DEFAULT_MODEL);
-  return { tier, isFree, limitKey, effectiveModel, backend };
+/** Map an /api/ai/search generation error to its HTTP response (t/2625 — the non-recording
+ *  tail extracted from the handler catch per ADR-003; the catch records, this only responds). */
+function respondAiSearchError(res: http.ServerResponse, err: unknown): void {
+  if (ai.isContextTooLongError(err)) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'context_too_long', message: 'Input exceeds the model context window — try a shorter prompt or a model with a larger context window' }));
+    return;
+  }
+  if (ai.is429Error(err)) {
+    const retry = ai.retryAfterMs(err);
+    res.setHeader('Retry-After', String(Math.max(1, Math.ceil(retry / 1000))));
+    res.writeHead(429, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Upstream AI provider rate limit — retry shortly', limitType: 'upstream_rate_limit', retryAfterMs: retry, retryable: true }));
+    return;
+  }
+  error(res, String(err), 500, err);
 }
 
 export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
@@ -442,42 +430,23 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
     }
   });
 
-  post('/api/ai/search', async (_req, res, body) => {
+  post('/api/ai/search', async (req, res, body) => {
     const { prompt, model } = body as { prompt: string; model?: string };
     try {
-      json(res, await ai.generateTextWithSearchByUsage('server.search', { prompt }, model ? { model } : undefined));
+      // t/2625: gate the user-supplied model through the shared entitlement path (pins free tier).
+      const { tier, effectiveModel, backend } = resolveGenerationContext(req, model);
+      if (enforceBackendAllowed(res, tier, backend)) return;
+      json(res, await ai.generateTextWithSearchByUsage('server.search', { prompt }, effectiveModel ? { model: effectiveModel } : undefined));
     } catch (err) {
-      if (ai.isContextTooLongError(err)) {
-        log.server.warn({ component: 'ai-search', model: model ?? 'default' }, 'AI search input exceeds model context window');
-        getGlobalRecorder()?.record({
-          type: 'ai.error', component: 'ai-search', level: 'warn',
-          message: 'AI search input too long for model context window',
-          data: { model: model ?? 'default', source: 'context_overflow' },
-        });
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'context_too_long', message: 'Input exceeds the model context window — try a shorter prompt or a model with a larger context window' }));
-        return;
-      }
-      if (ai.is429Error(err)) {
-        const retry = ai.retryAfterMs(err);
-        log.server.warn({ component: 'ai-search', model: model ?? 'default', retryAfterMs: retry }, 'AI search upstream rate-limited — returning 429');
-        getGlobalRecorder()?.record({
-          type: 'ai.error', component: 'ai-search', level: 'warn',
-          message: 'AI search upstream rate-limited',
-          data: { model: model ?? 'default', retryAfterMs: retry, source: 'upstream' },
-        });
-        res.setHeader('Retry-After', String(Math.max(1, Math.ceil(retry / 1000))));
-        res.writeHead(429, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Upstream AI provider rate limit — retry shortly', limitType: 'upstream_rate_limit', retryAfterMs: retry, retryable: true }));
-        return;
-      }
+      // ADR-003: record literally in the catch; the (non-recording) err→HTTP mapping is extracted.
+      const expected = ai.isContextTooLongError(err) || ai.is429Error(err);
       getGlobalRecorder()?.record({
-        type: 'system.error', component: 'ai-search', level: 'error',
+        type: 'ai.error', component: 'ai-search', level: expected ? 'warn' : 'error',
         message: `AI search failed: ${String(err)}`,
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-        data: { model: model ?? 'default', promptLength: prompt?.length },
+        data: { model: model ?? 'default', promptLength: prompt?.length, source: ai.isContextTooLongError(err) ? 'context_overflow' : ai.is429Error(err) ? 'upstream' : 'error' },
       });
-      error(res, String(err), 500, err);
+      respondAiSearchError(res, err);
     }
   });
 

--- a/taxonomy-editor/src/server/routes/chat.ts
+++ b/taxonomy-editor/src/server/routes/chat.ts
@@ -21,6 +21,7 @@ import type { UrlFetchOptions, UrlFetchResult } from '../../../../lib/url-fetch/
 import * as proxyTiers from '../ai/proxyTiers.js';
 import * as rateLimiter from '../security/rateLimiter.js';
 import * as ai from '../ai/aiBackends.js';
+import { resolveGenerationContext } from './generationContext.js';
 import { getApiKeys, hasApiKey, type AIBackend } from '../config.js';
 
 type ResolvedTier = ReturnType<typeof proxyTiers.resolveTier>;
@@ -149,11 +150,6 @@ export async function buildUrlInjectedPrompt(
   return { combinedPrompt, urlMeta };
 }
 
-/** Pure mirror of routes/ai.ts callerIdentity — ALS-verified context, not raw headers (t/848). */
-function callerIdentity(): { principalName: string; idp: string } {
-  return callerTierIdentity(getCurrentUser());
-}
-
 /** Coarse caller auth class for the ai.request flight-recorder event (t/2494 —
  *  observability only, never an auth decision): local single-user, cookie-only
  *  anonymous, or a signed-in principal. Derived from the ALS user context. */
@@ -168,19 +164,6 @@ export function authUserType(): 'local' | 'anonymous' | 'authenticated' {
  *  clients + guard against a malicious oversize value bloating the recorder). */
 export function boundedId(v: unknown): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v.slice(0, 128) : undefined;
-}
-
-/** Pure mirror of routes/ai.ts resolveGenerationContext. */
-function resolveGenerationContext(req: http.IncomingMessage, model: string | undefined): {
-  tier: ResolvedTier; isFree: boolean; limitKey: string; effectiveModel: string | undefined; backend: AIBackend;
-} {
-  const { principalName, idp } = callerIdentity();
-  const tier = proxyTiers.resolveTier(principalName, idp);
-  const isFree = tier.level === 'free';
-  const limitKey = isFree ? `free:${getClientIp(req)}` : (principalName || '_anonymous');
-  const effectiveModel = isFree ? (tier.pinnedModel ?? model) : model;
-  const backend = ai.resolveBackend(effectiveModel || DEFAULT_MODEL);
-  return { tier, isFree, limitKey, effectiveModel, backend };
 }
 
 /** Pure mirror of routes/ai.ts resolveExplicitAiKey. */

--- a/taxonomy-editor/src/server/routes/generationContext.ts
+++ b/taxonomy-editor/src/server/routes/generationContext.ts
@@ -54,7 +54,7 @@ export function enforceBackendAllowed(res: http.ServerResponse, tier: ResolvedTi
     message: `Backend '${backend}' not available on '${tier.level}' tier`,
     data: { tier_level: tier.level, requested_backend: backend, allowed_backends: tier.allowedBackends },
   });
-  res.writeHead(403);
+  res.writeHead(403, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify({ error: `Backend '${backend}' not available on your tier`, tier_level: tier.level, requested_backend: backend }));
   return true;
 }

--- a/taxonomy-editor/src/server/routes/generationContext.ts
+++ b/taxonomy-editor/src/server/routes/generationContext.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+//
+// Shared generation-context resolution + backend-entitlement gate (t/2625).
+//
+// INVARIANT: every route that runs server-side AI generation from a user-supplied model
+// MUST resolve through `resolveGenerationContext` (which pins the free tier's model and
+// derives the target backend) and gate with `enforceBackendAllowed` BEFORE calling the
+// provider. Otherwise a free/restricted-tier caller can select a premium backend via
+// `body.model` (the class this closes: /api/evidence-qbaf + /api/ai/search bypassed it;
+// chat-stream + /api/ai/generate already routed through this). Extracted from the verbatim
+// copies previously duplicated in routes/ai.ts and routes/chat.ts.
+
+import http from 'http';
+import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+import { DEFAULT_MODEL } from '../../../../lib/ai-client/index.js';
+import * as proxyTiers from '../ai/proxyTiers.js';
+import * as ai from '../ai/aiBackends.js';
+import { type AIBackend } from '../config.js';
+import { getClientIp } from '../httpKit.js';
+import { callerTierIdentity } from '../security/accessControl.js';
+import { getCurrentUser } from '../security/userContext.js';
+
+export type ResolvedTier = ReturnType<typeof proxyTiers.resolveTier>;
+
+/** ALS-verified request identity, not raw headers (t/848). */
+function callerIdentity(): { principalName: string; idp: string } {
+  return callerTierIdentity(getCurrentUser());
+}
+
+/** Resolve the caller's tier + rate-limit key + effective (pinned-for-free) model +
+ *  target backend from the request. Pure setup — sends no response. */
+export function resolveGenerationContext(req: http.IncomingMessage, model: string | undefined): {
+  tier: ResolvedTier; isFree: boolean; limitKey: string; effectiveModel: string | undefined; backend: AIBackend;
+} {
+  const { principalName, idp } = callerIdentity(); // t/848: verified context, not raw headers
+  const tier = proxyTiers.resolveTier(principalName, idp);
+  const isFree = tier.level === 'free';
+  // Free tier (t/793): keyed per-IP (all keyless users would otherwise share one
+  // bucket), with the model pinned. Other tiers key by user and honour the request model.
+  const limitKey = isFree ? `free:${getClientIp(req)}` : (principalName || '_anonymous');
+  const effectiveModel = isFree ? (tier.pinnedModel ?? model) : model;
+  const backend = ai.resolveBackend(effectiveModel || DEFAULT_MODEL);
+  return { tier, isFree, limitKey, effectiveModel, backend };
+}
+
+/** 403 + record when the resolved backend isn't allowed on the caller's tier.
+ *  Returns true when it has already sent a response (caller must return). */
+export function enforceBackendAllowed(res: http.ServerResponse, tier: ResolvedTier, backend: AIBackend): boolean {
+  if (proxyTiers.isBackendAllowed(tier, backend)) return false;
+  // t/1463: record the tier context so a tier-restriction 403 is a one-line FR read
+  // instead of a server.ts → proxyTiers → runtimeConfig code trace.
+  getGlobalRecorder()?.record({
+    type: 'ai.error', component: 'ai-generate', level: 'warn',
+    message: `Backend '${backend}' not available on '${tier.level}' tier`,
+    data: { tier_level: tier.level, requested_backend: backend, allowed_backends: tier.allowedBackends },
+  });
+  res.writeHead(403);
+  res.end(JSON.stringify({ error: `Backend '${backend}' not available on your tier`, tier_level: tier.level, requested_backend: backend }));
+  return true;
+}

--- a/taxonomy-editor/src/server/routes/sources.ts
+++ b/taxonomy-editor/src/server/routes/sources.ts
@@ -31,6 +31,7 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { DEFAULT_MODEL } from '../../../../lib/ai-client/index.js';
 import { log } from '../logger.js';
 import * as ai from '../ai/aiBackends.js';
+import { resolveGenerationContext, enforceBackendAllowed } from './generationContext.js';
 import { getDataRoot } from '../config.js';
 import { greatestHitsPath } from '../../../../lib/debate/corpusCoverage.js';
 import * as fileIO from '../storage/fileIO.js';
@@ -254,9 +255,14 @@ export function registerSourcesRoutes(r: Router, _ctx: ServerCtx): void {
 
   // ── Evidence QBAF (runs full pipeline server-side) ──
 
-  post('/api/evidence-qbaf', async (_req, res, body) => {
+  post('/api/evidence-qbaf', async (req, res, body) => {
     const { claimText, claimId, model } = body as { claimText: string; claimId: string; model?: string };
     if (!claimText || !claimId) { error(res, 'claimText and claimId are required', 400); return; }
+
+    // t/2625: gate the user-supplied model through the shared entitlement path — a
+    // free/restricted tier can't select a premium backend via body.model. Pins free tier.
+    const { tier, effectiveModel, backend } = resolveGenerationContext(req, model);
+    if (enforceBackendAllowed(res, tier, backend)) return;
 
     const sourcesDir = fileIO.getSourcesDir();
     if (!sourcesDir || !fs.existsSync(sourcesDir)) { json(res, null); return; }
@@ -276,7 +282,7 @@ export function registerSourcesRoutes(r: Router, _ctx: ServerCtx): void {
         },
       };
 
-      const evalModel = model || DEFAULT_MODEL;
+      const evalModel = effectiveModel || DEFAULT_MODEL;
       const result = await buildEvidenceQbaf(claimText, evidenceItems, adapter, evalModel, {
         claimBaseStrength: 0.5,
       });


### PR DESCRIPTION
**Closes the backend-entitlement class (t/2625).** `/api/evidence-qbaf` + `/api/ai/search` passed a user-supplied `model` straight to server-side generation with **no tier check** — a free/restricted caller could reach a premium backend via `body.model`. chat-stream + `/api/ai/generate` already gated.

**Genus fix (route through the gate, don't bolt a check on each):**
- New `routes/generationContext.ts` — shared `resolveGenerationContext` (pins the free tier's model, derives the backend) + `enforceBackendAllowed` (403 pre-generation). Extracted **verbatim** from the identical copies previously duplicated in `routes/ai.ts` + `routes/chat.ts` (deduped, zero behaviour change there).
- `/api/evidence-qbaf` (sources.ts) + `/api/ai/search` (ai.ts) now resolve through it before generating, using the effective (pinned-for-free) model.
- ai.ts search: extracted the non-recording catch tail (`respondAiSearchError`) to stay under the complexity ceiling (ADR-003: record stays literal in the catch).

**Behaviour** matches the SAFE reference routes: free tier → premium request **downgraded** to the pinned backend (safe, 200); a non-free tier that honours the model but disallows the backend → **403**.

**Tests:** `entitlementGate.test.ts` (7) — pin/honour, enforceBackendAllowed 403/pass, both routes gate (restricted→403, free→downgraded). tsc + eslint clean (no new complexity warnings); server suite green (75 local fails = Node-7.x undici-skew guard, CI node22 green).

**Draft — routed to Main (TL) for auth-surface review** (Server Auth convention). Follow-ups for your call: AGENTS.md prevention rule (via ogit), a CI heuristic gate (route through you for Gate Verification), and folding op-ed's `resolveOpEdModel` onto the shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)