### PR TITLE
feat(flags): seed env-web-opeds (env:web, default OFF) — web Op-Eds reveal gate (t/2632)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/featureFlags.test.ts
+++ b/taxonomy-editor/src/server/__tests__/featureFlags.test.ts
@@ -88,6 +88,20 @@ describe('feature flag CRUD + resolution (t/899)', () => {
     expect(getFlag('custom-only')).toBe(true);
   });
 
+  it('env-web-opeds is seeded OFF with env:web scope; reveal = admin flip (t/2632)', () => {
+    // AC1: present in SEED, scope env:web, default disabled.
+    expect(getFlagMetadata('env-web-opeds')).toMatchObject({ enabled: false, scope: 'env:web' });
+    // AC2: resolves false by default (disabled short-circuits before scope).
+    expect(getFlag('env-web-opeds')).toBe(false);
+    expect(getFlag('release-qbaf-analysis')).toBe(true); // no regression to a sibling seed
+    // AC3: an admin flip → true, delivered on web only (env:web scope).
+    setFlag('env-web-opeds', { enabled: true, scope: 'env:web' }, 'jpsnover');
+    _resetFlagCache();
+    expect(getFlagMetadata('env-web-opeds')?.enabled).toBe(true);
+    expect(evaluateScope('env:web', ctx({ env: 'web' }))).toBe(true);
+    expect(evaluateScope('env:web', ctx({ env: 'electron' }))).toBe(false);
+  });
+
   it('file flags take precedence over seed flags with the same name', () => {
     setFlag('release-qbaf-analysis', { enabled: false, scope: 'global' });
     _resetFlagCache();

--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -90,6 +90,15 @@ const SEED_FLAGS: Record<string, FlagDef> = {
     created_at: '2026-06-24T00:00:00.000Z', updated_at: '2026-06-24T00:00:00.000Z',
     created_by: 'seed',
   },
+  'env-web-opeds': {
+    // t/2632: default OFF (deliberate deviation from the other enabled:true env-web-* seeds) —
+    // web Op-Eds is unverified until the t/2614 web-create smoke. Reveal = an admin flip to true
+    // (admin data.flags merges over SEED, no redeploy); pairs with the renderer nav gate (t/2633).
+    name: 'env-web-opeds', enabled: false, scope: 'env:web',
+    description: 'Show Op-Eds tab/route (web only) — OFF until the t/2614 web-create smoke verifies',
+    created_at: '2026-08-14T00:00:00.000Z', updated_at: '2026-08-14T00:00:00.000Z',
+    created_by: 'seed',
+  },
   'env-electron-summaries': {
     name: 'env-electron-summaries', enabled: true, scope: 'env:electron',
     description: 'Show summaries tab and menu items (electron only)',


### PR DESCRIPTION
Seeds the web-build counterpart flag so web users can reach Op-Eds once verified. Op-Eds is cross-build (t/2604) but the nav gated on `env-electron-opeds` (Electron-only, never delivered by the web `/api/flags`) → blocked t/2614.

**Change (self-certified — small seed add, follows the `env-web-*` pattern):**
- `featureFlags.ts` `SEED_FLAGS`: add `env-web-opeds { enabled: false, scope: 'env:web' }`. **Default OFF** is the deliberate TL-designed deviation from the `enabled:true` env-web-* seeds — web Op-Eds is unverified until the t/2614 smoke. Reveal = an **admin flip** to true (admin `data.flags` merges over SEED, no redeploy). Pairs with Rosetta's renderer nav gate (t/2633) — both must land before Op-Eds is reachable on web.
- `featureFlags.test.ts`: +1 test — seeded OFF w/ env:web scope, false by default, admin flip → true delivered web-only, no sibling-seed regression.

ACs met; tsc + eslint clean; featureFlags.test.ts 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)