### PR TITLE
feat(nav): OR-of-flags gate; reveal Op-Eds per-build (t/2633)

### DIFF
--- a/taxonomy-editor/src/renderer/data/navConfig.test.ts
+++ b/taxonomy-editor/src/renderer/data/navConfig.test.ts
@@ -33,3 +33,24 @@ describe('navConfig — env-electron-opeds gate (t/2599)', () => {
     expect(hasOpeds({ 'env-electron-summaries': true, 'env-electron-opeds': false })).toBe(false);
   });
 });
+
+describe('navConfig — Op-Eds OR-of-flags per-build reveal (t/2633)', () => {
+  // Op-Eds is gated on anyFlag ['env-electron-opeds','env-web-opeds'] so each build reveals
+  // it via its OWN flag: Electron delivers env-electron-opeds, web delivers env-web-opeds.
+  it('shows Op-Eds when only the WEB flag is on (web reveal; electron flag absent)', () => {
+    expect(hasOpeds({ 'env-web-opeds': true })).toBe(true);
+  });
+
+  it('shows Op-Eds when only the ELECTRON flag is on (desktop reveal; web flag absent)', () => {
+    expect(hasOpeds({ 'env-electron-opeds': true })).toBe(true);
+  });
+
+  it('hides Op-Eds when BOTH build flags are off/absent', () => {
+    expect(hasOpeds({ 'env-electron-opeds': false, 'env-web-opeds': false })).toBe(false);
+    expect(hasOpeds({})).toBe(false);
+  });
+
+  it('shows Op-Eds when both flags are on', () => {
+    expect(hasOpeds({ 'env-electron-opeds': true, 'env-web-opeds': true })).toBe(true);
+  });
+});

--- a/taxonomy-editor/src/renderer/data/navConfig.ts
+++ b/taxonomy-editor/src/renderer/data/navConfig.ts
@@ -25,7 +25,10 @@ export interface NavItem {
   tier: NavTier;
   group?: NavGroup;
   action: NavAction;
-  gate?: { flag?: string; adminOnly?: boolean };
+  // `flag`: single required flag. `anyFlag`: OR-of-flags — the item shows when ANY listed
+  // flag is truthy (per-build reveal, e.g. Op-Eds shows in whichever build delivers its own
+  // build flag). `adminOnly`: admin-gated. Multiple keys AND together (t/2633).
+  gate?: { flag?: string; anyFlag?: string[]; adminOnly?: boolean };
 }
 
 export const NAV_ITEMS: readonly NavItem[] = [
@@ -34,7 +37,7 @@ export const NAV_ITEMS: readonly NavItem[] = [
   { id: 'taxonomy', label: 'Taxonomy', icon: LayoutGrid, tier: 'primary', action: { type: 'custom', id: 'taxonomy' } },
   { id: 'debate', label: 'Debate', icon: MessageSquare, tier: 'primary', action: { type: 'switchTab', target: 'debate' } },
   { id: 'chat', label: 'Chat', icon: MessageCircle, tier: 'primary', action: { type: 'custom', id: 'chat' } },
-  { id: 'opeds', label: 'Op-Eds', icon: Newspaper, tier: 'primary', action: { type: 'switchTab', target: 'opeds' }, gate: { flag: 'env-electron-opeds' } },
+  { id: 'opeds', label: 'Op-Eds', icon: Newspaper, tier: 'primary', action: { type: 'switchTab', target: 'opeds' }, gate: { anyFlag: ['env-electron-opeds', 'env-web-opeds'] } },
 
   // ── Secondary tier — browse group ──
   { id: 'situations', label: 'Situations', icon: Crosshair, tier: 'secondary', group: 'browse', action: { type: 'switchTab', target: 'situations' } },
@@ -78,6 +81,8 @@ export function getVisibleNavItems(
     if (!item.gate) return true;
     if (item.gate.adminOnly && !ctx.isAdmin) return false;
     if (item.gate.flag && !ctx.flags[item.gate.flag]) return false;
+    // OR-of-flags: hide unless at least one listed flag is truthy (t/2633).
+    if (item.gate.anyFlag && !item.gate.anyFlag.some(f => ctx.flags[f])) return false;
     return true;
   });
 }


### PR DESCRIPTION
Unblocks the t/2614 web-create smoke (**TL Option A**, per-build flags). The Op-Eds nav item gated on the single `env-electron-opeds` flag — delivered only by the Electron bridge — so the tab was unreachable on web (confirmed live: prod `/api/flags` omits it).

- `NavItem.gate`: add `anyFlag?: string[]` (OR-of-flags; keys AND together).
- `getVisibleNavItems`: hide an `anyFlag` item unless ≥1 listed flag is truthy.
- Op-Eds gate → `{ anyFlag: ['env-electron-opeds', 'env-web-opeds'] }`.

Each build reveals Op-Eds via its OWN flag: Electron delivers `env-electron-opeds` (unchanged); web delivers `env-web-opeds` (paired ServerAPI **t/2632**, seeds OFF → web stays dark until an admin flip post-smoke). Independent per-build rollout preserved.

Unit test: web-only → shown, electron-only → shown, both off/absent → hidden, both on → shown; existing single-flag + t/2599 regression unchanged.

Verify: navConfig.test.ts 8/8 · renderer tsc clean · eslint 0. **UI-only + test → self-cert.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)