### PR TITLE
fix(opeds): grounding table — drop Type column, sink "not directly used" to bottom

### DIFF
--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
@@ -59,6 +59,21 @@ describe('OpEdReader — single voice', () => {
     expect(screen.getByRole('button', { name: 'saf-belief-014' })).toBeTruthy();
     expect(screen.getByText('Grounds the claim')).toBeTruthy();
   });
+
+  it('drops the Type column and sinks "not directly used" rows to the bottom', () => {
+    render(<OpEdReader set={makeSet([member({
+      grounding: [
+        { node_id: 'acc-belief-001', label: 'Unused', category: 'Belief', pov: 'accelerationist', relevance: '0.15', how_reflected: 'not directly used' },
+        { node_id: 'saf-belief-014', label: 'Used', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim' },
+      ],
+    })])} />);
+    // Type column is gone (Element / Relevance / Reflected only).
+    expect(screen.queryByRole('columnheader', { name: 'Type' })).toBeNull();
+    // The reflected row sorts ABOVE the 'not directly used' row despite lower list position.
+    const used = screen.getByRole('button', { name: 'saf-belief-014' });
+    const unused = screen.getByRole('button', { name: 'acc-belief-001' });
+    expect(used.compareDocumentPosition(unused) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
 });
 
 describe('OpEdReader — failed / cancelled member', () => {

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -24,12 +24,6 @@ function prefersReducedMotion(): boolean {
     && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-function groundingType(nodeId: string | undefined): string {
-  // Legacy/foreign grounding rows may lack node_id (persisted PascalCase shape) — don't
-  // crash the reader; classify a missing id as BDI (t/2605 follow-up: real-data smoke).
-  return nodeId?.startsWith('sit-') ? 'Situation' : 'BDI';
-}
-
 // ──────────────────────────────────────────────
 // Inline grounding-element detail card (§6 clickable grounding)
 // ──────────────────────────────────────────────
@@ -110,6 +104,12 @@ function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
 
   const expandedRef = grounding.find(g => g.node_id === expandedId) ?? null;
 
+  // Elements the AI didn't reflect ('not directly used') sink to the bottom; everything
+  // else keeps its existing (relevance) order — a stable partition (Array.sort is stable).
+  const orderedGrounding = [...grounding].sort(
+    (a, b) => Number(a.how_reflected === 'not directly used') - Number(b.how_reflected === 'not directly used'),
+  );
+
   return (
     <details className="oped-grounding" open>
       <summary className="oped-grounding-summary">Taxonomy grounding ({grounding.length} element{grounding.length !== 1 ? 's' : ''})</summary>
@@ -119,13 +119,12 @@ function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
           <thead>
             <tr>
               <th scope="col">Element</th>
-              <th scope="col">Type</th>
               <th scope="col">Relevance</th>
               <th scope="col">Reflected in the op-ed</th>
             </tr>
           </thead>
           <tbody>
-            {grounding.map(g => {
+            {orderedGrounding.map(g => {
               const isOpen = g.node_id === expandedId;
               return (
                 <tr key={g.node_id} className={isOpen ? 'oped-grounding-row-active' : ''}>
@@ -140,7 +139,6 @@ function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
                       {g.node_id}
                     </button>
                   </td>
-                  <td>{groundingType(g.node_id)}</td>
                   <td>{g.relevance || '—'}</td>
                   <td>{g.how_reflected || '(not reported)'}</td>
                 </tr>


### PR DESCRIPTION
Per user request on the op-ed reader's taxonomy-grounding table:
- **Remove the `Type` column** (Situation/BDI) → Element / Relevance / Reflected only.
- Rows whose `how_reflected` is **"not directly used"** sort to the **bottom**; every other row keeps its existing (relevance) order — a stable partition.
- Drop the now-unused `groundingType()` helper.

Scope: the reader table (`GroundingSection` in `OpEdReader.tsx`). The export-markdown grounding table (`OpEdTab.buildOpEdMarkdown`) still has a Type column — left as-is pending confirmation whether to align it.

Verify: `OpEdReader.test.tsx` 12/12 (new case asserts no Type header + the reflected row sorts above the "not directly used" row) · renderer tsc clean · eslint 0. **UI-only + test → self-cert /trivial-change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)