### PR TITLE
fix(opeds): per-POV BDI grounding — each voice grounds in its own camp (t/2637)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -294,8 +294,14 @@ export async function* generateOpEdSet(
   request: GenerateOpEdRequest,
   deps: OpEdGeneratorDeps,
 ): AsyncGenerator<OpEdProgressEvent> {
-  // ── Step 1: grounding (once, shared across voices) ────────────────────────
-  let groundingNodes: ScoredPovNode[] = [];
+  // ── Step 1: grounding ─────────────────────────────────────────────────────
+  // BDI grounding is selected PER POV — the taxonomy is camp-partitioned
+  // (`taxonomy[pov].nodes`, ids `{pov}-{category}-{NNN}`), so a camp's grounding IS
+  // its own belief/desire/intention nodes. Selecting once from `povs[0]` grounded
+  // every voice in the first camp's nodes, making all voices display identical
+  // grounding tables (a Safetyist essay grounded in `acc-*` nodes). Situations are
+  // camp-agnostic, so `sitNodes` is legitimately selected once and shared.
+  const groundingByPov = new Map<PovKey, ScoredPovNode[]>();
   let sitNodes: ScoredSituationNode[] = [];
 
   try {
@@ -305,17 +311,14 @@ export async function* generateOpEdSet(
     const vec = await computeEmbedding(query);
     const scores = scoreNodeRelevance(vec, taxonomy.embeddings);
 
-    // Use first pov to select BDI nodes — all voices get the same grounding set
-    // (semantically appropriate: the topic is shared; voice differences are in voice block)
-    const firstPov = request.povs[0];
-    if (firstPov) {
-      groundingNodes = selectRelevantNodes(
-        taxonomy[firstPov]?.nodes ?? [],
+    for (const pov of request.povs) {
+      groundingByPov.set(pov, selectRelevantNodes(
+        taxonomy[pov]?.nodes ?? [],
         scores,
         undefined, // use default threshold
         2,         // minPerCategory
         12,        // maxTotal — mirrors PS MaxGroundingNodes default
-      );
+      ));
     }
     sitNodes = selectRelevantSituationNodes(
       taxonomy.situations?.nodes ?? [],
@@ -324,7 +327,13 @@ export async function* generateOpEdSet(
       1,
       3,
     );
-    yield { type: 'grounding_done', nodeCount: groundingNodes.length + sitNodes.length };
+    // Count distinct grounding elements across the whole set (per-POV BDI node ids
+    // are disjoint by camp; situations counted once) — a truthful set-level total.
+    const distinctBdi = new Set<string>();
+    for (const nodes of groundingByPov.values()) {
+      for (const { node } of nodes) distinctBdi.add(node.id);
+    }
+    yield { type: 'grounding_done', nodeCount: distinctBdi.size + sitNodes.length };
   } catch (err) {
     yield { type: 'grounding_failed', error: String(err) };
     // continue voice-only
@@ -350,7 +359,7 @@ export async function* generateOpEdSet(
     } else {
       enqueue({ type: 'voice_start', pov });
       try {
-        const member = await runVoiceGeneration(pov, groundingNodes, sitNodes, request, deps);
+        const member = await runVoiceGeneration(pov, groundingByPov.get(pov) ?? [], sitNodes, request, deps);
         members.push({ pov, member });
         enqueue({ type: 'voice_complete', pov, member });
       } catch (err) {

--- a/lib/oped/perPovGrounding.test.ts
+++ b/lib/oped/perPovGrounding.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression: per-POV BDI grounding in generateOpEdSet.
+//
+// The taxonomy is camp-partitioned (`taxonomy[pov].nodes`, node ids `{pov}-{cat}-{NNN}`),
+// so each camp's grounding IS its own belief/desire/intention nodes. A prior version
+// selected grounding ONCE from `request.povs[0]` and reused that array for every voice,
+// so all voices displayed identical grounding tables (a Safetyist essay grounded in
+// `acc-*` nodes). This locks the fix: each voice's grounding must come from its OWN camp;
+// only situations (camp-agnostic) are legitimately shared.
+
+import { describe, it, expect, vi } from 'vitest';
+
+// ── Heavy-dep mocks (embedding model, taxonomy IO, relevance scoring, prompts, fs) ──
+
+vi.mock('../embeddings/onnxEmbedding.js', () => ({
+  computeEmbedding: async () => [1, 0, 0],
+}));
+
+vi.mock('../debate/taxonomyLoader.js', () => ({
+  loadTaxonomy: () => ({
+    accelerationist: { nodes: [
+      { id: 'acc-bel-001', category: 'Belief', label: 'Acceleration compounds', description: 'd', parent_id: null, children: [] },
+      { id: 'acc-des-001', category: 'Desire', label: 'Deploy fast', description: 'd', parent_id: null, children: [] },
+    ] },
+    safetyist: { nodes: [
+      { id: 'saf-bel-001', category: 'Belief', label: 'Unaligned AI is existential', description: 'd', parent_id: null, children: [] },
+      { id: 'saf-des-001', category: 'Desire', label: 'Slow deployment', description: 'd', parent_id: null, children: [] },
+    ] },
+    skeptic: { nodes: [
+      { id: 'skp-bel-001', category: 'Belief', label: 'Capabilities are overstated', description: 'd', parent_id: null, children: [] },
+      { id: 'skp-des-001', category: 'Desire', label: 'Demand evidence', description: 'd', parent_id: null, children: [] },
+    ] },
+    situations: { nodes: [
+      { id: 'sit-001', label: 'Open-weight misuse', description: 'd', parent_id: null },
+    ] },
+    embeddings: {},
+  }),
+}));
+
+// Echo the nodes each call receives back as scored refs — so a voice's grounding reflects
+// EXACTLY the camp-partitioned node array that generateOpEdSet passed to it.
+vi.mock('../debate/taxonomyRelevance.js', () => ({
+  scoreNodeRelevance: () => new Map(),
+  selectRelevantNodes: (nodes: { id: string }[]) => nodes.map(node => ({ node, score: 0.9 })),
+  selectRelevantSituationNodes: (nodes: { id: string }[]) => nodes.map(node => ({ node, score: 0.8 })),
+}));
+
+vi.mock('./outletBands.js', () => ({
+  resolveOutletBand: () => ({ words: 800, guidance: 'guidance' }),
+}));
+
+vi.mock('./promptLoader.js', () => ({
+  loadAndAssemblePrompt: () => ({ system: 'sys', user: 'user' }),
+  assembleReflectionPrompt: () => 'refl',
+}));
+
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { generateOpEdSet, type OpEdProgressEvent } from './generate.js';
+import type { PovKey } from '../debate/types.js';
+
+// Real repo root, so loadSoulDoc reads the actual lib/debate/soul-docs/*.soul.json
+// (taxonomy + embeddings + prompts are mocked; only the soul docs load for real).
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// Adapter returns a valid essay JSON for the essay pass; the best-effort reflection pass
+// then re-parses it, finds no `grounding_usage`, and is swallowed (how_reflected stays default).
+const adapter = {
+  generateText: async () => JSON.stringify({ headline: 'H', subtitle: 'S', body_markdown: 'Body words here.', word_count: 3 }),
+};
+
+async function drain(povs: PovKey[]): Promise<Map<PovKey, string[]>> {
+  const req = {
+    set_id: 's1', topic: 'AI policy',
+    params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' } as never,
+    povs,
+  };
+  const deps = { adapter: adapter as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT };
+  const byPov = new Map<PovKey, string[]>();
+  for await (const ev of generateOpEdSet(req, deps) as AsyncGenerator<OpEdProgressEvent>) {
+    if (ev.type === 'voice_complete') {
+      byPov.set(ev.pov, ev.member.grounding.map(g => g.node_id));
+    }
+  }
+  return byPov;
+}
+
+describe('generateOpEdSet — per-POV grounding (regression)', () => {
+  it('grounds each voice in its OWN camp BDI nodes, not the first POV\'s', async () => {
+    const byPov = await drain(['accelerationist', 'safetyist', 'skeptic']);
+
+    const acc = byPov.get('accelerationist')!;
+    const saf = byPov.get('safetyist')!;
+    const skp = byPov.get('skeptic')!;
+
+    // Each voice's BDI grounding carries only its own camp prefix.
+    expect(acc.filter(id => id.startsWith('acc-')).length).toBeGreaterThan(0);
+    expect(acc.some(id => id.startsWith('saf-') || id.startsWith('skp-'))).toBe(false);
+    expect(saf.some(id => id.startsWith('saf-'))).toBe(true);
+    expect(saf.some(id => id.startsWith('acc-') || id.startsWith('skp-'))).toBe(false);
+    expect(skp.some(id => id.startsWith('skp-'))).toBe(true);
+    expect(skp.some(id => id.startsWith('acc-') || id.startsWith('saf-'))).toBe(false);
+  });
+
+  it('shares the camp-agnostic situation grounding across all voices', async () => {
+    const byPov = await drain(['accelerationist', 'safetyist', 'skeptic']);
+    for (const pov of ['accelerationist', 'safetyist', 'skeptic'] as PovKey[]) {
+      expect(byPov.get(pov)!).toContain('sit-001');
+    }
+  });
+
+  it('does NOT give every voice the identical grounding set (the original bug)', async () => {
+    const byPov = await drain(['accelerationist', 'safetyist', 'skeptic']);
+    const acc = [...byPov.get('accelerationist')!].sort().join(',');
+    const saf = [...byPov.get('safetyist')!].sort().join(',');
+    expect(acc).not.toEqual(saf);
+  });
+});


### PR DESCRIPTION
## Bug (t/2637)
A 3-voice Op-Ed showed the **same** taxonomy grounding elements under every voice. Grounding should be per-POV.

## Root cause — logic, not display
`lib/oped/generate.ts` `generateOpEdSet` Step 1 selected BDI grounding **once** from `request.povs[0]` and reused that single array for every voice. The taxonomy is camp-partitioned (`taxonomy[pov].nodes`, ids `{pov}-{cat}-{NNN}`), so every voice was grounded in the first camp's nodes (e.g. a Safetyist essay grounded in `acc-*` nodes). Each member's refs got their own `pov` stamped, but the underlying node_ids were identical. `OpEdReader.tsx` renders per-member `member.grounding` correctly — display was innocent.

## Fix
- Select BDI grounding **per POV** into `Map<PovKey, ScoredPovNode[]>`; each voice grounds in `taxonomy[pov].nodes`.
- Situations (camp-agnostic) stay shared — unchanged.
- `grounding_done.nodeCount` now reports distinct grounding elements across the set.

## Test
`lib/oped/perPovGrounding.test.ts` — both arms proven: **red** against the old shared-from-`povs[0]` behavior, **green** with the fix. The "shared situations" arm stays green (situations were always shared).

## Verification
63 tests pass (lib/oped + server oped); `tsc -p tsconfig.server.json` clean; eslint clean.

## Ownership
`lib/oped/` is **Shared Lib** scope; drafted by the Computational Linguist (mandatory grounding-compliance review). **Draft — held for Shared Lib review before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)