### PR TITLE
fix(analysis): pin EngagementDashboard header with sticky positioning (t/2636)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.css
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.css
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1rem 1.5rem;
+  padding: 0 1.5rem 1rem;
   max-width: 1200px;
   margin: 0 auto;
   min-height: 100vh;
@@ -24,8 +24,13 @@
   justify-content: space-between;
   gap: 1rem;
   flex-wrap: wrap;
+  padding-top: 1rem;
   padding-bottom: 0.75rem;
   border-bottom: 1px solid var(--border-color);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg-primary);
 }
 
 .eng-header-left {


### PR DESCRIPTION
## Summary

- Moves `.eng-root` top padding (1rem) onto `.eng-header` as `padding-top` so the header starts flush at `top: 0` and latches without a positional jump when scrolling begins.
- Adds `position: sticky; top: 0; z-index: 10; background: var(--bg-primary)` to `.eng-header` — header stays pinned, panels scroll underneath it, opaque background prevents bleed-through.
- CSS-only, single file (`EngagementDashboard.css`). Shared renderer → applies to both Electron and web builds.

## Test plan

- [x] 142/142 analysis vitest (scoped run)
- [x] `tsc --noEmit` clean
- [x] `vite build` clean
- [x] Self-cert trivial-change (CSS-only, no new cross-role interfaces, no TSX changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
