### PR TITLE
ci(devops): Bicep baseEnv drift-detector gate (t/2631)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       container: ${{ steps.filter.outputs.container }}
       lockfile-sync: ${{ steps.filter.outputs.lockfile-sync }}
+      bicep-env: ${{ steps.filter.outputs.bicep-env }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         id: filter
@@ -153,6 +154,16 @@ jobs:
             lockfile-sync:
               - 'pnpm-workspace.yaml'
               - 'taxonomy-editor/pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+            # 'bicep-env' gates bicep-env-drift (t/2631). Triggers when either
+            # source-of-truth changes: main.bicep (Bicep definitions) or
+            # deploy-azure.yml (ExpectedEnvVars table). The parser script is
+            # also included so a change to parsing logic re-verifies the gate.
+            bicep-env:
+              - 'deploy/azure/main.bicep'
+              - '.github/workflows/deploy-azure.yml'
+              - 'operations/devops/Get-BicepBaseEnv.ps1'
+              - 'operations/devops/Test-BicepEnvDrift.ps1'
               - '.github/workflows/ci.yml'
 
   test-powershell:
@@ -938,6 +949,33 @@ jobs:
       - name: Lint workflow YAML files
         run: python3 .github/ci/workflow-lint.py
 
+  # ── bicep-env-drift: Bicep baseEnv ↔ ExpectedEnvVars sync gate (t/2631) ──
+  # Parses literal-string entries from the baseEnv block in deploy/azure/main.bicep
+  # and compares them against the ExpectedEnvVars table in deploy-azure.yml.
+  # Non-literal entries (interpolation / param refs) are skipped by the parser
+  # — only the 5 static-comparable keys are checked. Fails ::error:: if any value
+  # differs or a Bicep literal is missing from the table.
+  #
+  # This is the gate whose absence caused the step-14 false-red on 2026-08-13
+  # (t/2602): AI_TRIAD_DATA_ROOT was updated in Bicep by PR #1007 but the
+  # ExpectedEnvVars hardcode in deploy-azure.yml wasn't updated in the same PR,
+  # so the verify step failed in prod with a stale value.
+  #
+  # Path-filtered: runs only when main.bicep, deploy-azure.yml, or the parser
+  # scripts change. Skip = OK through ci-gate.
+  bicep-env-drift:
+    needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.bicep-env == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+
+      - name: Bicep baseEnv ↔ ExpectedEnvVars drift check
+        shell: pwsh
+        run: ./operations/devops/Test-BicepEnvDrift.ps1
+
   # ── ci-gate: the SINGLE required status context (t/1962) ──────────────────
   # Replaces the 6 individual code-check contexts in branch protection. Those get
   # SKIPPED by path-filtering on non-electron PRs (docs-only, PS-only); a skipped
@@ -965,9 +1003,11 @@ jobs:
   # startup health check + test suite; path-filtered to container changes, skip = OK.
   # workflow-lint (t/2529) is gated here: SHA-pinned actions, env-var indirection,
   # permissions block required; always runs, no path filter.
+  # bicep-env-drift (t/2631) is gated here: Bicep baseEnv ↔ deploy-azure.yml
+  # ExpectedEnvVars sync check; path-filtered to those two files + parser, skip = OK.
   ci-gate:
     name: ci-gate
-    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config, workflow-lint]
+    needs: [changes, test-powershell, test-electron, test-container, python-embed-smoke, dependency-coverage, lockfile-overrides-check, lib-lint, renderer-tsc, contrast-check, test-server-prod-config, workflow-lint, bicep-env-drift]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/operations/devops/Get-BicepBaseEnv.ps1
+++ b/operations/devops/Get-BicepBaseEnv.ps1
@@ -1,0 +1,73 @@
+<#
+.SYNOPSIS
+    Parses literal-string env entries from the baseEnv block in main.bicep.
+
+.DESCRIPTION
+    Extracts entries where the value is a pure single-quoted string literal —
+    no Bicep interpolation (`${...}`), no parameter/resource references.
+    These are the only entries that can be statically compared against the
+    ExpectedEnvVars table in deploy-azure.yml (t/2631).
+
+    Skipped by design (not static-comparable):
+      ALLOWED_ORIGINS             — Bicep string interpolation
+      AZURE_KEYVAULT_URL          — resource property reference
+      AZURE_STORAGE_ACCOUNT_URL   — resource property reference
+      AUTH_DISABLED / AUTH_OPTIONAL / ADMIN_USERS
+      GIT_SYNC_ENABLED / GITHUB_* — parameter references
+      APPLICATIONINSIGHTS_*       — resource property reference
+
+.PARAMETER BicepPath
+    Path to deploy/azure/main.bicep. Defaults to the canonical location
+    relative to this script's repo root.
+
+.OUTPUTS
+    [hashtable] mapping env-var name → literal string value.
+    Exits non-zero if the baseEnv block is not found.
+
+.EXAMPLE
+    $env = . ./operations/devops/Get-BicepBaseEnv.ps1
+    $env['NODE_ENV']   # 'production'
+#>
+[CmdletBinding()]
+param(
+    [string]$BicepPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $BicepPath) {
+    $repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $BicepPath = Join-Path $repoRoot 'deploy/azure/main.bicep'
+}
+
+if (-not (Test-Path $BicepPath)) {
+    throw "main.bicep not found at: $BicepPath"
+}
+
+$content = Get-Content $BicepPath -Raw
+
+# Locate the baseEnv block: var baseEnv = [ ... ]
+# Capture everything between the opening '[' and the matching ']'
+if ($content -notmatch '(?s)var baseEnv\s*=\s*\[(.*?)\]') {
+    Write-Error "baseEnv block not found in $BicepPath"
+    exit 1
+}
+$block = $Matches[1]
+
+# Match entries where the value is a pure single-quoted string literal.
+# Excludes: values with ${...} (interpolation), or values without quotes (param refs).
+$literalPattern = @"
+\{\s*name:\s*'([^']+)',\s*value:\s*'([^'\$\{\}]*)'\s*\}
+"@.Trim()
+
+$result = @{}
+$block | Select-String -Pattern $literalPattern -AllMatches | ForEach-Object {
+    foreach ($m in $_.Matches) {
+        $name  = $m.Groups[1].Value
+        $value = $m.Groups[2].Value
+        $result[$name] = $value
+    }
+}
+
+return $result

--- a/operations/devops/Test-BicepEnvDrift.ps1
+++ b/operations/devops/Test-BicepEnvDrift.ps1
@@ -1,0 +1,101 @@
+<#
+.SYNOPSIS
+    CI drift-detector: compares Bicep baseEnv literal entries against
+    deploy-azure.yml ExpectedEnvVars. Exits non-zero on any mismatch.
+
+.DESCRIPTION
+    Calls Get-BicepBaseEnv.ps1 to extract the literal-string env vars from
+    main.bicep, then parses the ExpectedEnvVars hashtable from deploy-azure.yml
+    for the same keys and compares. Non-literal Bicep entries (interpolation /
+    param refs) are skipped by the parser and never compared here (t/2631).
+
+    Gate proof arms expected by TL:
+      Fire: change a Bicep literal (e.g. NODE_ENV -> 'wrong') without updating
+            ExpectedEnvVars -> this script exits 1 with ::error:: annotations.
+      Pass: both files in sync -> exits 0 with "PASSED" line.
+
+.PARAMETER BicepPath
+    Path to deploy/azure/main.bicep. Defaults to repo-relative location.
+
+.PARAMETER DeployYmlPath
+    Path to .github/workflows/deploy-azure.yml. Defaults to repo-relative.
+#>
+[CmdletBinding()]
+param(
+    [string]$BicepPath,
+    [string]$DeployYmlPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+if (-not $BicepPath)     { $BicepPath     = Join-Path $repoRoot 'deploy/azure/main.bicep' }
+if (-not $DeployYmlPath) { $DeployYmlPath = Join-Path $repoRoot '.github/workflows/deploy-azure.yml' }
+
+# ── 1. Parse Bicep literal entries ──────────────────────────────────────────
+$parserScript  = Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1'
+$bicepLiterals = . $parserScript -BicepPath $BicepPath
+
+if ($bicepLiterals.Keys.Count -eq 0) {
+    Write-Host "::error::Get-BicepBaseEnv returned zero entries — check main.bicep baseEnv block"
+    exit 1
+}
+
+# ── 2. Parse ExpectedEnvVars block from deploy-azure.yml ────────────────────
+# Strategy: scan line-by-line; enter block on '-ExpectedEnvVars @{',
+# exit on a line whose only non-whitespace content is '}' (the closing brace).
+# Match only KEY = 'simple-literal-value' lines — GitHub expression values
+# (containing $, {, }) are skipped; we only compare the Bicep-literal keys.
+$yamlLines = Get-Content $DeployYmlPath
+$inBlock   = $false
+$yamlEnv   = @{}
+
+foreach ($line in $yamlLines) {
+    if (-not $inBlock) {
+        if ($line -match '-ExpectedEnvVars\s*@\{') { $inBlock = $true }
+        continue
+    }
+    if ($line -match '^\s*\}\s*$') { break }  # closing brace of the hashtable
+    # Simple literal: KEY = 'value'  (no $, {, } in value)
+    if ($line -match "^\s*(\w+)\s*=\s*'([^'{}\$]*)'\s*(?:#.*)?$") {
+        $yamlEnv[$Matches[1]] = $Matches[2]
+    }
+}
+
+if ($yamlEnv.Keys.Count -eq 0) {
+    Write-Host "::error::No simple-literal entries parsed from deploy-azure.yml ExpectedEnvVars — block missing or format changed"
+    exit 1
+}
+
+# ── 3. Compare ───────────────────────────────────────────────────────────────
+$pass = $true
+$rows = [System.Collections.Generic.List[PSCustomObject]]::new()
+
+foreach ($key in ($bicepLiterals.Keys | Sort-Object)) {
+    $bicepVal = $bicepLiterals[$key]
+    $yamlVal  = $yamlEnv[$key]
+
+    if ($null -eq $yamlVal) {
+        $rows.Add([PSCustomObject]@{ Key=$key; Bicep=$bicepVal; ExpectedEnvVars='(missing)'; Status='FAIL' })
+        Write-Host "::error file=.github/workflows/deploy-azure.yml::DRIFT: '$key' is in Bicep baseEnv ('$bicepVal') but missing from ExpectedEnvVars table"
+        $pass = $false
+    } elseif ($yamlVal -ne $bicepVal) {
+        $rows.Add([PSCustomObject]@{ Key=$key; Bicep=$bicepVal; ExpectedEnvVars=$yamlVal; Status='FAIL' })
+        Write-Host "::error file=.github/workflows/deploy-azure.yml::DRIFT: '$key' — Bicep='$bicepVal' vs ExpectedEnvVars='$yamlVal'"
+        $pass = $false
+    } else {
+        $rows.Add([PSCustomObject]@{ Key=$key; Bicep=$bicepVal; ExpectedEnvVars=$yamlVal; Status='OK' })
+    }
+}
+
+$rows | Format-Table Key, Bicep, ExpectedEnvVars, Status -AutoSize | Out-String | Write-Host
+
+if (-not $pass) {
+    Write-Host ''
+    Write-Host "::error::Bicep baseEnv is out of sync with deploy-azure.yml ExpectedEnvVars."
+    Write-Host "::error::Fix: update both files in the same PR. See t/2631."
+    exit 1
+}
+
+Write-Host "Drift check PASSED — $($bicepLiterals.Keys.Count) literal keys in sync."

--- a/tests/BicepEnvDrift.Tests.ps1
+++ b/tests/BicepEnvDrift.Tests.ps1
@@ -1,0 +1,62 @@
+#Requires -Modules Pester
+<#
+.SYNOPSIS
+    Standing both-arms gate test for the Bicep baseEnv drift-detector (t/2631).
+
+    Why two arms matter (TL Gate Verification requirement):
+      Pass arm alone cannot detect a rotted detector that silently always-passes.
+      The fire arm (exit 1 on drift) must be a permanent CI assertion, not a
+      one-time local claim.
+#>
+
+Describe 'Test-BicepEnvDrift' {
+    BeforeAll {
+        $scriptRoot = Split-Path $PSScriptRoot -Parent
+        $driftScript = Join-Path $scriptRoot 'operations/devops/Test-BicepEnvDrift.ps1'
+        $fixtureDir  = Join-Path $PSScriptRoot 'fixtures/bicep-env-drift'
+
+        $goodBicep   = Join-Path $fixtureDir 'good-main.bicep'
+        $goodYml     = Join-Path $fixtureDir 'good-deploy-azure.yml'
+        $driftedBicep = Join-Path $fixtureDir 'drifted-main.bicep'
+    }
+
+    It 'Pass arm: exits 0 when Bicep literals match ExpectedEnvVars' {
+        # good-main.bicep and good-deploy-azure.yml are in sync.
+        # Detector must exit 0 and emit no ::error:: annotations.
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $driftScript,
+                          '-BicepPath', $goodBicep,
+                          '-DeployYmlPath', $goodYml `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 0
+    }
+
+    It 'Fire arm: exits 1 when Bicep literal differs from ExpectedEnvVars' {
+        # drifted-main.bicep has NODE_ENV=staging vs good-deploy-azure.yml's
+        # NODE_ENV=production — detector must catch the mismatch and exit 1.
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $driftScript,
+                          '-BicepPath', $driftedBicep,
+                          '-DeployYmlPath', $goodYml `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 1
+    }
+
+    It 'Fire arm: exits 1 when a Bicep literal key is absent from ExpectedEnvVars' {
+        # Inline fixture: Bicep has a key that the YML table is missing entirely.
+        $tmpBicep = Join-Path $TestDrive 'missing-key.bicep'
+        Set-Content $tmpBicep @'
+var baseEnv = [
+  { name: 'NODE_ENV', value: 'production' }
+  { name: 'HOME', value: '/home/aitriad' }
+  { name: 'BRAND_NEW_KEY', value: '/new/path' }
+]
+'@
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $driftScript,
+                          '-BicepPath', $tmpBicep,
+                          '-DeployYmlPath', $goodYml `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 1
+    }
+}

--- a/tests/fixtures/bicep-env-drift/drifted-main.bicep
+++ b/tests/fixtures/bicep-env-drift/drifted-main.bicep
@@ -1,0 +1,13 @@
+// Minimal fixture for BicepEnvDrift.Tests.ps1 — drifted baseline.
+// NODE_ENV changed to 'staging' without updating deploy-azure.yml.
+
+var baseEnv = [
+  { name: 'AI_TRIAD_DATA_ROOT', value: '/mnt/shared' }
+  { name: 'TAXONOMY_CACHE_DIR', value: '/mnt/shared' }
+  { name: 'ALLOWED_ORIGINS', value: 'https://taxonomy-editor.${someResource.properties.domain}' }
+  { name: 'HOME', value: '/home/aitriad' }
+  { name: 'NODE_ENV', value: 'staging' }
+  { name: 'AZURE_KEYVAULT_URL', value: keyVault.properties.vaultUri }
+  { name: 'ADMIN_USERS', value: adminUsers }
+  { name: 'WEBSITE_AUTH_ENABLED', value: 'true' }
+]

--- a/tests/fixtures/bicep-env-drift/good-deploy-azure.yml
+++ b/tests/fixtures/bicep-env-drift/good-deploy-azure.yml
@@ -1,0 +1,13 @@
+# Minimal fixture for BicepEnvDrift.Tests.ps1 — in-sync baseline.
+# Contains only the ExpectedEnvVars block Test-BicepEnvDrift.ps1 reads.
+run: |
+  Test-AzureHealth `
+    -ExpectedEnvVars @{
+      NODE_ENV                           = 'production'
+      WEBSITE_AUTH_ENABLED               = 'true'
+      HOME                               = '/home/aitriad'
+      AI_TRIAD_DATA_ROOT                 = '/mnt/shared'
+      TAXONOMY_CACHE_DIR                 = '/mnt/shared'
+      AUTH_OPTIONAL                      = '${{ inputs.auth_mode }}'
+      AZURE_KEYVAULT_URL                 = '${{ steps.deploy.outputs.keyVaultUri }}'
+    }

--- a/tests/fixtures/bicep-env-drift/good-main.bicep
+++ b/tests/fixtures/bicep-env-drift/good-main.bicep
@@ -1,0 +1,13 @@
+// Minimal fixture for BicepEnvDrift.Tests.ps1 — in-sync baseline.
+// Contains only the baseEnv block the parser reads.
+
+var baseEnv = [
+  { name: 'AI_TRIAD_DATA_ROOT', value: '/mnt/shared' }
+  { name: 'TAXONOMY_CACHE_DIR', value: '/mnt/shared' }
+  { name: 'ALLOWED_ORIGINS', value: 'https://taxonomy-editor.${someResource.properties.domain}' }
+  { name: 'HOME', value: '/home/aitriad' }
+  { name: 'NODE_ENV', value: 'production' }
+  { name: 'AZURE_KEYVAULT_URL', value: keyVault.properties.vaultUri }
+  { name: 'ADMIN_USERS', value: adminUsers }
+  { name: 'WEBSITE_AUTH_ENABLED', value: 'true' }
+]


### PR DESCRIPTION
## Summary

- Adds `Get-BicepBaseEnv.ps1` — regex parser extracting literal-string env entries from `deploy/azure/main.bicep` baseEnv block
- Adds `Test-BicepEnvDrift.ps1` — CI drift comparator (calls parser, compares against deploy-azure.yml ExpectedEnvVars)
- Adds `bicep-env-drift` job to `ci.yml` — path-filtered to main.bicep + deploy-azure.yml + parser scripts; gated in ci-gate

## Root cause prevented

Step-14 false-red on 2026-08-13 (t/2602): PR #1007 updated Bicep env vars but did not update ExpectedEnvVars in deploy-azure.yml in the same PR. This gate enforces both-file sync by failing CI when they diverge.

## Gate Verification (both arms — run locally on this branch)

**Pass arm:** all 5 literal keys in sync — exit 0, table shows OK for all rows

**Fire arm:** NODE_ENV mutated to `wrong-value-gate-proof` in Bicep without updating deploy-azure.yml — exit 1 with `::error file=deploy-azure.yml::DRIFT: 'NODE_ENV'...`

## Routing

Routing to TL for Gate Verification per p/331#163 condition. Draft until TL clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
