### PR TITLE
fix(ci): skip postinstall in lib-lint to prevent onnxruntime ETIMEDOUT (t/2640)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install lib dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Lint (errors gate; warnings advisory — see header)
         working-directory: lib


### PR DESCRIPTION
## Summary

t/2640 — skip onnxruntime-node postinstall in lib-lint (`--ignore-scripts`).
lib-lint only needs ESLint + TypeScript — no native binaries required.
Self-certifying under /trivial-change.
