### PR TITLE
fix(nav): thread env-web-opeds into Toolbar/HamburgerMenu navCtx (t/2633 → unblocks t/2614)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
@@ -79,6 +79,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
   const adminFeatures = useFlag('permission-admin-features');
   const summariesFlag = useFlag('env-electron-summaries');
   const opedsFlag = useFlag('env-electron-opeds');
+  const webOpedsFlag = useFlag('env-web-opeds'); // web reveal — Op-Eds gate ORs both build flags (t/2633)
   const [showHelp, setShowHelp] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
@@ -167,7 +168,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
   }
 
   // NavConfig-driven items
-  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag }, isAdmin: adminFeatures };
+  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag, 'env-web-opeds': webOpedsFlag }, isAdmin: adminFeatures };
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const primaryNavItems = visibleItems.filter(i => i.tier === 'primary' && !bottomNavIds.has(i.id));
   const secondaryGroups = getSecondaryByGroup(visibleItems);

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -217,7 +217,8 @@ export function Toolbar() {
   const adminFeatures = useFlag('permission-admin-features');
   const summariesFlag = useFlag('env-electron-summaries');
   const opedsFlag = useFlag('env-electron-opeds');
-  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag }, isAdmin: adminFeatures };
+  const webOpedsFlag = useFlag('env-web-opeds'); // web reveal — Op-Eds gate ORs both build flags (t/2633)
+  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag, 'env-web-opeds': webOpedsFlag }, isAdmin: adminFeatures };
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const secondaryGroups = getSecondaryByGroup(visibleItems);
   const isNavItemActive = (item: NavItem): boolean => {


### PR DESCRIPTION
**Live-smoke follow-up to t/2633.** The nav gate ORs `['env-electron-opeds','env-web-opeds']`, but `Toolbar.tsx:220` + `HamburgerMenu.tsx:170` build `navCtx.flags` from a **hardcoded subset** (only `env-electron-summaries` + `env-electron-opeds`) — so the gate never saw `env-web-opeds`. A live prod smoke confirmed it: server `/api/flags` returns `env-web-opeds:true` but the Op-Eds nav stayed hidden on web.

This is the exact **t/2599 failure class** (flag delivered but not threaded into navCtx) that `navConfig.test.ts` documents — and my t/2633 unit test was a false witness (passed the flag straight to `getVisibleNavItems`, bypassing the broken plumbing).

Fix: read + include `env-web-opeds` in `navCtx.flags` in both components.

**Follow-up (routing to TL):** thread the WHOLE flag record (`useFeatureFlagStore` exposes it) so a hardcoded subset can't drift again — this class has now bitten twice.

Verify: renderer tsc clean · eslint 0 errors · navConfig.test.ts 8/8. Re-running the live web reveal + create smoke after this deploys. **Self-cert /trivial-change** (2-line flag threading, no logic change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)