### PR TITLE
feat(devops): sync Bicep baseEnv to staging on every deploy (t/2630)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -78,6 +78,13 @@ jobs:
             Write-Host "Prior revision (rollback target): '$($Top.Name)'"
           }
 
+      - name: Sync Bicep baseEnv to staging template (t/2630)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Import-Module ./scripts/AITriad/AITriad.psm1 -Force
+          ./operations/devops/Sync-StagingEnv.ps1
+
       - name: Deploy new revision to staging (0% traffic)
         id: new_revision
         shell: pwsh
@@ -160,6 +167,36 @@ jobs:
             -MaxAttempts 3 `
             -RetryIntervalSec 10
           Write-Host "Staging traffic promoted to ${{ steps.new_revision.outputs.revision }}"
+
+      - name: Verify Bicep baseEnv on staging serving revision (t/2630)
+        if: steps.smoke.outputs.passed == 'true'
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $BicepEnv = & ./operations/devops/Get-BicepBaseEnv.ps1 -BicepPath deploy/azure/main.bicep
+          $RevEnvJson = az containerapp revision show `
+            --name '${{ env.CONTAINER_APP_NAME }}' `
+            -g '${{ env.RESOURCE_GROUP }}' `
+            --revision '${{ steps.new_revision.outputs.revision }}' `
+            --query 'properties.template.containers[0].env' -o json
+          $RevEnv = $RevEnvJson | ConvertFrom-Json
+          $RevMap = @{}
+          foreach ($e in @($RevEnv)) {
+            $valProp = $e.PSObject.Properties['value']
+            if ($null -ne $valProp) { $RevMap[$e.name] = $valProp.Value }
+          }
+          $Mismatches = @()
+          foreach ($key in $BicepEnv.Keys) {
+            if ($RevMap[$key] -ne $BicepEnv[$key]) {
+              $Mismatches += "${key}: expected='$($BicepEnv[$key])' actual='$($RevMap[$key])'"
+            }
+          }
+          if ($Mismatches.Count -gt 0) {
+            Write-Error "Staging serving revision baseEnv mismatch:`n$($Mismatches -join "`n")"
+            exit 1
+          }
+          Write-Host "Staging serving revision '${{ steps.new_revision.outputs.revision }}' baseEnv verified OK"
 
       - name: Re-authenticate before rollback
         if: always() && failure() && steps.current_revision.outputs.revision != ''

--- a/operations/devops/Sync-StagingEnv.ps1
+++ b/operations/devops/Sync-StagingEnv.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+    Syncs main.bicep baseEnv literal entries to the staging Container App
+    env template. Idempotent — exits 0 with no-op if already in sync. (t/2630)
+
+.PARAMETER MockCurrentEnvPath
+    Testing only: path to a JSON file whose content replaces the az containerapp
+    show query. Eliminates the real Azure call so tests run without credentials.
+
+.PARAMETER DryRun
+    Testing only: skip the az containerapp update call. Exits 2 if drift
+    detected, 0 if in sync. Proves the drift-detection path without touching Azure.
+#>
+[CmdletBinding()]
+Param(
+    [string] $BicepPath,
+    [string] $AppName         = 'taxonomy-editor-staging',
+    [string] $ResourceGroup   = 'ai-triad',
+    [string] $MockCurrentEnvPath,
+    [switch] $DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $BicepPath) {
+    $BicepPath = Join-Path $PSScriptRoot '../../deploy/azure/main.bicep'
+}
+
+$BicepEnv = & (Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1') -BicepPath $BicepPath
+if ($BicepEnv.Count -eq 0) {
+    Write-Error "Get-BicepBaseEnv.ps1 returned 0 entries — Bicep parse failed or baseEnv block is empty"
+    exit 1
+}
+
+# Get current staging env vars from the active template
+if ($MockCurrentEnvPath) {
+    $CurrentEnvJson = Get-Content $MockCurrentEnvPath | ConvertFrom-Json
+} else {
+    $CurrentEnvJson = az containerapp show --name $AppName -g $ResourceGroup `
+        --query 'properties.template.containers[0].env' -o json | ConvertFrom-Json
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "az containerapp show failed (exit $LASTEXITCODE)"
+        exit 1
+    }
+}
+
+$CurrentMap = @{}
+foreach ($e in @($CurrentEnvJson)) {
+    $valProp = $e.PSObject.Properties['value']
+    if ($null -ne $valProp) { $CurrentMap[$e.name] = $valProp.Value }
+}
+
+# Idempotency check — skip update if all literal keys already match
+$Drifted = [System.Collections.Generic.List[string]]::new()
+foreach ($key in $BicepEnv.Keys) {
+    if ($CurrentMap[$key] -ne $BicepEnv[$key]) {
+        $Drifted.Add("$key (was='$($CurrentMap[$key])', expected='$($BicepEnv[$key])')")
+    }
+}
+
+if ($Drifted.Count -eq 0) {
+    Write-Host "Staging baseEnv matches Bicep — no update needed"
+    exit 0
+}
+
+Write-Host "Drift detected in $($Drifted.Count) key(s):"
+$Drifted | ForEach-Object { Write-Host "  $_" }
+
+if ($DryRun) {
+    Write-Host "[DryRun] Would call: az containerapp update --set-env-vars ..."
+    exit 2
+}
+
+# Synchronous (no --no-wait) so failures surface immediately and the following
+# New-ContainerAppRevision inherits the updated template (t/2630 TL condition)
+$EnvArgs = @($BicepEnv.GetEnumerator() | ForEach-Object { "$($_.Key)=$($_.Value)" })
+Write-Host "Syncing to Azure..."
+az containerapp update --name $AppName -g $ResourceGroup --set-env-vars @EnvArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "az containerapp update failed (exit $LASTEXITCODE)"
+    exit 1
+}
+Write-Host "Staging baseEnv synced successfully"

--- a/tests/StagingEnvSync.Tests.ps1
+++ b/tests/StagingEnvSync.Tests.ps1
@@ -1,0 +1,46 @@
+#Requires -Modules Pester
+<#
+.SYNOPSIS
+    Standing both-arms gate for Sync-StagingEnv.ps1 (t/2630).
+
+    Uses -MockCurrentEnvPath + -DryRun to avoid real Azure calls.
+    Deploy-time condition (a) — that the synced value actually lands on the
+    staging serving revision — is proved by the az containerapp revision show
+    verify step in deploy-staging.yml, not here.
+#>
+
+Describe 'Sync-StagingEnv' {
+    BeforeAll {
+        $scriptRoot   = Split-Path $PSScriptRoot -Parent
+        $syncScript   = Join-Path $scriptRoot 'operations/devops/Sync-StagingEnv.ps1'
+        $fixtureDir   = Join-Path $PSScriptRoot 'fixtures/staging-env-sync'
+        $bicepFixture = Join-Path $PSScriptRoot 'fixtures/bicep-env-drift/good-main.bicep'
+
+        $matchingEnv = Join-Path $fixtureDir 'matching-env.json'
+        $driftedEnv  = Join-Path $fixtureDir 'drifted-env.json'
+    }
+
+    It 'Pass arm: exits 0 (no-op) when staging env already matches Bicep baseEnv' {
+        # matching-env.json has the same literal values as good-main.bicep.
+        # The script must detect no drift and exit 0 without calling az.
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $matchingEnv,
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 0
+    }
+
+    It 'Fire arm: exits 2 (-DryRun, drift) when staging env differs from Bicep' {
+        # drifted-env.json has NODE_ENV=staging and stale data paths.
+        # The script must detect drift and exit 2 (-DryRun sentinel for "would update").
+        $proc = Start-Process pwsh `
+            -ArgumentList '-NonInteractive', '-File', $syncScript,
+                          '-BicepPath',           $bicepFixture,
+                          '-MockCurrentEnvPath',  $driftedEnv,
+                          '-DryRun' `
+            -PassThru -Wait -NoNewWindow
+        $proc.ExitCode | Should -Be 2
+    }
+}

--- a/tests/fixtures/staging-env-sync/drifted-env.json
+++ b/tests/fixtures/staging-env-sync/drifted-env.json
@@ -1,0 +1,8 @@
+[
+  { "name": "AI_TRIAD_DATA_ROOT",   "value": "/tmp/old-path" },
+  { "name": "TAXONOMY_CACHE_DIR",   "value": "/tmp/old-path" },
+  { "name": "HOME",                 "value": "/home/aitriad" },
+  { "name": "NODE_ENV",             "value": "staging" },
+  { "name": "WEBSITE_AUTH_ENABLED", "value": "true" },
+  { "name": "AZURE_KEYVAULT_URL",   "secretRef": "kv-url" }
+]

--- a/tests/fixtures/staging-env-sync/matching-env.json
+++ b/tests/fixtures/staging-env-sync/matching-env.json
@@ -1,0 +1,8 @@
+[
+  { "name": "AI_TRIAD_DATA_ROOT",   "value": "/mnt/shared" },
+  { "name": "TAXONOMY_CACHE_DIR",   "value": "/mnt/shared" },
+  { "name": "HOME",                 "value": "/home/aitriad" },
+  { "name": "NODE_ENV",             "value": "production" },
+  { "name": "WEBSITE_AUTH_ENABLED", "value": "true" },
+  { "name": "AZURE_KEYVAULT_URL",   "secretRef": "kv-url" }
+]


### PR DESCRIPTION
## Summary
- Adds `Sync-StagingEnv.ps1` — idempotent: reads Bicep `baseEnv` literal keys via `Get-BicepBaseEnv.ps1`, compares against staging Container App template, calls `az containerapp update --set-env-vars` only when drift detected. Synchronous (no `--no-wait`) per TL condition.
- `deploy-staging.yml`: adds **Sync** step before `New-ContainerAppRevision` (template is updated before new revision is created) and **Verify** step after promote (`az containerapp revision show` confirms synced keys landed on the serving revision — proves TL condition (a)).
- `tests/StagingEnvSync.Tests.ps1`: standing both-arms Pester gate — pass arm exits 0 (no-op), fire arm exits 2 (`-DryRun` sentinel for drift-would-update).

## Test plan
- [ ] Both Pester arms pass locally: `Invoke-Pester tests/StagingEnvSync.Tests.ps1` (2/2 green at 62a67af4)
- [ ] CI green on this PR head
- [ ] TL Gate Verification: both-arms Pester + deploy-time verify step design

🤖 Generated with [Claude Code](https://claude.com/claude-code)