### PR TITLE
fix(nav): thread whole flag record into navCtx so nav gates can't drift (t/2641)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
@@ -11,6 +11,7 @@ import { FeedbackPopover } from './FeedbackPopover';
 import { useAuthStatus } from '../../hooks/useAuthStatus';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { useFlag } from '../../hooks/useFeatureFlags';
+import { useNavVisibilityContext } from '../../hooks/useNavVisibilityContext';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import {
   NAV_ITEMS, getVisibleNavItems, getSecondaryByGroup,
@@ -77,9 +78,6 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
   } = useTaxonomyStore();
   const breakpoint = useBreakpoint();
   const adminFeatures = useFlag('permission-admin-features');
-  const summariesFlag = useFlag('env-electron-summaries');
-  const opedsFlag = useFlag('env-electron-opeds');
-  const webOpedsFlag = useFlag('env-web-opeds'); // web reveal — Op-Eds gate ORs both build flags (t/2633)
   const [showHelp, setShowHelp] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
@@ -168,7 +166,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
   }
 
   // NavConfig-driven items
-  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag, 'env-web-opeds': webOpedsFlag }, isAdmin: adminFeatures };
+  const navCtx = useNavVisibilityContext(); // whole flag record — no subset to drift (t/2641)
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const primaryNavItems = visibleItems.filter(i => i.tier === 'primary' && !bottomNavIds.has(i.id));
   const secondaryGroups = getSecondaryByGroup(visibleItems);

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.test.tsx
@@ -64,6 +64,9 @@ vi.mock('../../hooks/useAuthStatus', () => ({
 
 vi.mock('../../hooks/useFeatureFlags', () => ({
   useFlag: () => false,
+  // Toolbar threads the whole flag record via useNavVisibilityContext (t/2641).
+  useFeatureFlagStore: (selector: (s: { flags: Record<string, boolean> }) => unknown) =>
+    selector({ flags: {} }),
 }));
 
 vi.mock('../../hooks/useTierInfo', () => ({

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -14,6 +14,7 @@ import { HelpDialog } from '../settings/HelpDialog';
 import { SettingsDialog } from '../settings/SettingsDialog';
 import { useAuthStatus, useUserProfile } from '../../hooks/useAuthStatus';
 import { useFlag } from '../../hooks/useFeatureFlags';
+import { useNavVisibilityContext } from '../../hooks/useNavVisibilityContext';
 import { useTierInfo } from '../../hooks/useTierInfo';
 import { FeedbackPopover } from './FeedbackPopover';
 import { NAV_ITEMS, getVisibleNavItems, getSecondaryByGroup, type NavItem, type NavAction } from '../../data/navConfig';
@@ -214,11 +215,8 @@ export function Toolbar() {
     return () => window.removeEventListener('mousedown', handler);
   }, [showMore]);
 
-  const adminFeatures = useFlag('permission-admin-features');
-  const summariesFlag = useFlag('env-electron-summaries');
-  const opedsFlag = useFlag('env-electron-opeds');
-  const webOpedsFlag = useFlag('env-web-opeds'); // web reveal — Op-Eds gate ORs both build flags (t/2633)
-  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag, 'env-web-opeds': webOpedsFlag }, isAdmin: adminFeatures };
+  const opedsFlag = useFlag('env-electron-opeds'); // gates the primary Op-Eds button below (desktop reveal)
+  const navCtx = useNavVisibilityContext(); // whole flag record — no subset to drift (t/2641)
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const secondaryGroups = getSecondaryByGroup(visibleItems);
   const isNavItemActive = (item: NavItem): boolean => {

--- a/taxonomy-editor/src/renderer/data/navConfig.ts
+++ b/taxonomy-editor/src/renderer/data/navConfig.ts
@@ -68,6 +68,28 @@ export const NAV_ITEMS: readonly NavItem[] = [
   { id: 'settings', label: 'Settings', icon: Settings, tier: 'system', action: { type: 'custom', id: 'settings' } },
 ];
 
+/**
+ * Every feature flag referenced by any NAV_ITEMS gate (`flag` + `anyFlag`), deduped.
+ * Derived from NAV_ITEMS so a newly-added gate flag is covered automatically. The nav
+ * visibility context MUST thread all of these: `getVisibleNavItems` treats an absent
+ * flag as falsy, so a gate flag missing from `navCtx.flags` silently hides its item even
+ * with the flag ON — the class of bug that bit twice (t/2599, t/2633). Threading the
+ * whole flag record (see `useNavVisibilityContext`) makes that drift impossible; this
+ * export exists so a regression test can assert every gate flag is actually threaded.
+ */
+export const NAV_GATE_FLAGS: readonly string[] = Array.from(
+  new Set(
+    NAV_ITEMS.flatMap(item => {
+      const g = item.gate;
+      if (!g) return [];
+      const flags: string[] = [];
+      if (g.flag) flags.push(g.flag);
+      if (g.anyFlag) flags.push(...g.anyFlag);
+      return flags;
+    }),
+  ),
+);
+
 export interface NavVisibilityContext {
   flags: Record<string, boolean>;
   isAdmin: boolean;

--- a/taxonomy-editor/src/renderer/hooks/useNavVisibilityContext.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useNavVisibilityContext.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression guard for t/2641 (prevention for t/2599 + t/2633).
+//
+// Toolbar and HamburgerMenu used to build `navCtx.flags` from a HARDCODED subset of
+// `useFlag()` calls. `getVisibleNavItems` treats an absent flag as falsy, so any nav
+// gate referencing a flag missing from that subset silently hid its item even with the
+// flag ON — twice (t/2599 env-electron-opeds; t/2633 env-web-opeds, caught by a live
+// prod smoke, not a test, because the existing unit tests fed getVisibleNavItems a
+// hand-built flag map and never exercised the broken plumbing).
+//
+// Both components now build navCtx through the single `useNavVisibilityContext` hook,
+// which threads the WHOLE flag record. This test drives that hook — the actual navCtx
+// constructor — and fails if any nav-gate flag fails to reach navCtx.flags. If a future
+// change reintroduces a subset that omits a gate flag, the per-flag assertion below
+// turns red.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+let mockFlags: Record<string, boolean> = {};
+
+vi.mock('./useFeatureFlags', () => ({
+  useFeatureFlagStore: (selector: (s: { flags: Record<string, boolean> }) => unknown) =>
+    selector({ flags: mockFlags }),
+  useFlag: (name: string) => mockFlags[name] ?? false,
+}));
+
+import { useNavVisibilityContext } from './useNavVisibilityContext';
+import { NAV_ITEMS, NAV_GATE_FLAGS, getVisibleNavItems } from '../data/navConfig';
+
+const ctxFor = (flags: Record<string, boolean>) => {
+  mockFlags = flags;
+  return renderHook(() => useNavVisibilityContext()).result.current;
+};
+
+describe('useNavVisibilityContext — whole-record threading (t/2641)', () => {
+  beforeEach(() => {
+    mockFlags = {};
+  });
+
+  it('has at least the two historically-dropped gate flags', () => {
+    // Sanity: the flags whose omission caused t/2599 and t/2633 are gate flags.
+    expect(NAV_GATE_FLAGS).toContain('env-electron-opeds');
+    expect(NAV_GATE_FLAGS).toContain('env-web-opeds');
+  });
+
+  it('threads EVERY nav-gate flag into navCtx.flags — the t/2599 + t/2633 class', () => {
+    // A subset that forgets any gate flag would leave it absent here (undefined),
+    // which getVisibleNavItems reads as falsy → the item is hidden with the flag ON.
+    const allOn = Object.fromEntries(NAV_GATE_FLAGS.map(f => [f, true]));
+    const ctx = ctxFor(allOn);
+    for (const flag of NAV_GATE_FLAGS) {
+      expect(ctx.flags[flag], `gate flag "${flag}" was not threaded into navCtx`).toBe(true);
+    }
+  });
+
+  it('each gate flag, alone, reveals its gated item end-to-end', () => {
+    // Drives the full path: hook builds navCtx → getVisibleNavItems filters. Would have
+    // caught t/2633: env-web-opeds ON must reveal Op-Eds even with env-electron-opeds off.
+    for (const flag of NAV_GATE_FLAGS) {
+      const before = getVisibleNavItems(NAV_ITEMS, ctxFor({})).map(i => i.id);
+      const after = getVisibleNavItems(NAV_ITEMS, ctxFor({ [flag]: true })).map(i => i.id);
+      const revealed = after.filter(id => !before.includes(id));
+      expect(revealed.length, `flag "${flag}" revealed no nav item`).toBeGreaterThan(0);
+    }
+  });
+
+  it('passes the store record through by reference (no per-flag copy to drift)', () => {
+    const flags = { 'env-web-opeds': true };
+    expect(ctxFor(flags).flags).toBe(flags);
+  });
+
+  it('wires isAdmin to the permission-admin-features flag', () => {
+    expect(ctxFor({}).isAdmin).toBe(false);
+    expect(ctxFor({ 'permission-admin-features': true }).isAdmin).toBe(true);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useNavVisibilityContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useNavVisibilityContext.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useFeatureFlagStore, useFlag } from './useFeatureFlags';
+import type { NavVisibilityContext } from '../data/navConfig';
+
+/**
+ * Single source of truth for the nav visibility context consumed by
+ * `getVisibleNavItems`. Threads the WHOLE feature-flag record — not a hardcoded
+ * subset — so a nav gate can never reference a flag the context forgot to pass.
+ *
+ * History: Toolbar and HamburgerMenu each built `navCtx.flags` from a handful of
+ * explicit `useFlag()` calls. `getVisibleNavItems` treats an absent flag as falsy,
+ * so any gate flag omitted from that subset silently hid its item even with the
+ * flag ON — twice (t/2599 env-electron-opeds; t/2633 env-web-opeds). Passing the
+ * store's full record makes the subset (and its drift) disappear; behavior is
+ * unchanged because each gate still only reads its own flags. See NAV_GATE_FLAGS.
+ */
+export function useNavVisibilityContext(): NavVisibilityContext {
+  const flags = useFeatureFlagStore((s) => s.flags);
+  const isAdmin = useFlag('permission-admin-features');
+  return { flags, isAdmin };
+}


### PR DESCRIPTION
## What
Eliminates the hardcoded feature-flag subset in `Toolbar` and `HamburgerMenu` that built `navCtx.flags` for `getVisibleNavItems`. Both now delegate to a new shared `useNavVisibilityContext()` hook that threads the **whole** flag record.

## Why (prevention — bit twice)
`getVisibleNavItems` treats an absent flag as falsy, so a nav gate referencing a flag the component forgot to thread stays hidden even with the flag ON:
- **t/2599** — `env-electron-opeds` read but not threaded.
- **t/2633** — Op-Eds gained an `env-web-opeds` gate flag but components still threaded only `env-electron-opeds`; the web reveal did nothing until #1033 patched the subset. Found by a live prod smoke — the existing unit tests fed `getVisibleNavItems` a hand-built map and never exercised the broken plumbing.

## How
- New `useNavVisibilityContext()` hook — single navCtx constructor, whole-record threading. Behavior-equivalent (each gate reads only its own flags).
- `NAV_GATE_FLAGS` derived from `NAV_ITEMS` so a new gate flag is covered automatically.
- Regression test drives the hook (the real navCtx constructor) and fails if any nav-gate flag is not threaded — verified it fires when the hook is regressed to a subset. Would have caught t/2599 + t/2633.

## Acceptance criteria
- [x] Toolbar + HamburgerMenu no longer use a hardcoded flag subset for `navCtx.flags`.
- [x] Regression test fails if a nav-gate flag is not threaded into navCtx.
- [x] No behavior change (desktop `env-electron-opeds` still reveals Op-Eds; primary Op-Eds button keeps its own gate).

## Verification
- Renderer tsc: 0 errors. Affected vitest suites: 19 passed. Negative arm: subset regression → 3 failures.

Chose **Option A** (whole record) over Option B (assert-coverage of NAV_GATE_FLAGS) — drift becomes structurally impossible rather than test-enforced. Aligns with the approach Main favored on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)