### PR TITLE
feat(smoke): SHA-specific CI query in staging smoke gate (t/2639)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -139,7 +139,8 @@ jobs:
 
           # Full smoke: all 6 endpoint categories (mandatory pre-traffic gate, t/2376).
           Write-Host "=== Full smoke test against 0%-traffic revision: $BaseUrl ==="
-          $SmokeResult = Invoke-TaxEditorSmokeTest -BaseUrl $BaseUrl -Detailed
+          $SmokeResult = Invoke-TaxEditorSmokeTest -BaseUrl $BaseUrl -Detailed `
+            -DeployedSha '${{ github.event.workflow_run.head_sha }}'
           if (-not $SmokeResult.OverallPass) {
             Write-Host "::error::Smoke test failed on new staging revision — NOT promoting traffic"
             Write-Host "  Health: $(if ($SmokeResult.HealthOk) { 'OK' } else { 'FAIL' })"

--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -23,6 +23,11 @@ function Invoke-TaxEditorSmokeTest {
     .PARAMETER HealthRetryIntervalSec
         Seconds to sleep between health-probe attempts when HealthMaxAttempts > 1.
         Default: 10.
+    .PARAMETER DeployedSha
+        When provided, passes the commit SHA to Test-GitHubHealth so the ci.yml
+        check queries by exact SHA instead of branch=main. Fail-closed: no
+        completed CI run for the SHA → GitHub check fails. Intended for use in
+        the deploy workflow immediately after a push (t/2639).
     .PARAMETER Detailed
         Show per-endpoint results in addition to the summary.
     .EXAMPLE
@@ -62,6 +67,9 @@ function Invoke-TaxEditorSmokeTest {
         [Parameter()]
         [ValidateRange(1, 300)]
         [int]$HealthRetryIntervalSec = 10,
+
+        [Parameter()]
+        [string]$DeployedSha = '',
 
         [Parameter()]
         [switch]$Detailed
@@ -137,7 +145,9 @@ function Invoke-TaxEditorSmokeTest {
 
     # ── Phase 4: GitHub services ─────────────────────────────────────────
     Write-Host '=== GitHub Services ===' -ForegroundColor Cyan
-    $GitHub = Test-GitHubHealth -TimeoutSec $TimeoutSec
+    $GitHubSplatArgs = @{ TimeoutSec = $TimeoutSec }
+    if ($DeployedSha) { $GitHubSplatArgs['DeployedSha'] = $DeployedSha }
+    $GitHub = Test-GitHubHealth @GitHubSplatArgs
 
     foreach ($Check in $GitHub.Checks) {
         $Icon = if ($Check.Pass) { '[PASS]' } else { '[FAIL]' }

--- a/scripts/AITriad/Public/Test-GitHubHealth.ps1
+++ b/scripts/AITriad/Public/Test-GitHubHealth.ps1
@@ -17,6 +17,11 @@ function Test-GitHubHealth {
         Branch to scope the workflow-runs status check to. Default: main (the
         deployed line) — so a red PR/branch run does not false-FAIL the CI-health
         category in a prod smoke (t/1975).
+    .PARAMETER DeployedSha
+        When provided, the ci.yml check queries by exact commit SHA instead of
+        branch=main. Fail-closed: zero completed runs for the SHA → check fails
+        (never silently passes or falls back to branch). Fixes the gh-run-rerun
+        created_at displacement false-negative (t/2639).
     .EXAMPLE
         Test-GitHubHealth
     .EXAMPLE
@@ -36,7 +41,10 @@ function Test-GitHubHealth {
         [int]$TimeoutSec = 10,
 
         [Parameter()]
-        [string]$Branch = 'main'
+        [string]$Branch = 'main',
+
+        [Parameter()]
+        [string]$DeployedSha = ''
     )
 
     Set-StrictMode -Version Latest
@@ -133,28 +141,50 @@ function Test-GitHubHealth {
     # so a red PR/branch run doesn't false-FAIL the CI-health category in a prod
     # smoke. GitHub filters by head_branch via the `branch` param; escape guards
     # branch names containing '/'.
+    # t/2639 — when DeployedSha is provided, ci.yml uses head_sha= instead of
+    # branch= so a gh-run-rerun (which preserves original created_at) is not
+    # displaced by a newer branch run. Fail-closed: zero runs for the SHA → FAIL.
     $BranchQ = [uri]::EscapeDataString($Branch)
     foreach ($Wf in $KeyWorkflows) {
+        $UseSha = $DeployedSha -and $Wf -eq 'ci.yml'
+        $CheckLabel = if ($UseSha) { "Workflow: $Wf @$DeployedSha" } else { "Workflow: $Wf @$Branch" }
+        $RunsUri = if ($UseSha) {
+            "https://api.github.com/repos/$Repo/actions/workflows/$Wf/runs?head_sha=$DeployedSha&status=completed&per_page=1"
+        } else {
+            "https://api.github.com/repos/$Repo/actions/workflows/$Wf/runs?per_page=1&status=completed&branch=$BranchQ"
+        }
         try {
-            $RunsResp = Invoke-RestMethod `
-                -Uri "https://api.github.com/repos/$Repo/actions/workflows/$Wf/runs?per_page=1&status=completed&branch=$BranchQ" `
+            $RunsResp = Invoke-RestMethod -Uri $RunsUri `
                 -Headers $Headers -TimeoutSec $TimeoutSec -ErrorAction Stop
 
             if ($RunsResp.total_count -gt 0) {
                 $Run = $RunsResp.workflow_runs[0]
                 $Conclusion = $Run.conclusion
                 $RunDate = ([datetime]$Run.updated_at).ToString('yyyy-MM-dd HH:mm')
+                if ($UseSha) {
+                    Write-Verbose "Checking CI for sha=$DeployedSha, run #$($Run.run_number)"
+                }
 
                 $Checks.Add([PSCustomObject]@{
-                    Check      = "Workflow: $Wf @$Branch"
+                    Check      = $CheckLabel
                     Pass       = $Conclusion -eq 'success'
                     ResponseMs = 0
                     Detail     = "conclusion=$Conclusion | $RunDate | #$($Run.run_number)"
                 })
             }
+            elseif ($UseSha) {
+                # Fail-closed: a SHA with no completed runs must not silently pass
+                Write-Verbose "sha=$DeployedSha — no CI run found → failing closed"
+                $Checks.Add([PSCustomObject]@{
+                    Check      = $CheckLabel
+                    Pass       = $false
+                    ResponseMs = 0
+                    Detail     = "sha=$DeployedSha — no CI run found → failing closed"
+                })
+            }
             else {
                 $Checks.Add([PSCustomObject]@{
-                    Check      = "Workflow: $Wf @$Branch"
+                    Check      = $CheckLabel
                     Pass       = $true
                     ResponseMs = 0
                     Detail     = 'No completed runs found'
@@ -167,7 +197,7 @@ function Test-GitHubHealth {
                 $StatusCode = [int]$_.Exception.Response.StatusCode
             }
             $Checks.Add([PSCustomObject]@{
-                Check      = "Workflow: $Wf @$Branch"
+                Check      = $CheckLabel
                 Pass       = $false
                 ResponseMs = 0
                 Detail     = if ($StatusCode -eq 404) { 'Workflow not found' }

--- a/tests/Test-GitHubHealth.DeployedSha.Tests.ps1
+++ b/tests/Test-GitHubHealth.DeployedSha.Tests.ps1
@@ -1,0 +1,108 @@
+# Tag: health (t/2639)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    SHA-scoped CI check in Test-GitHubHealth (t/2639).
+.DESCRIPTION
+    When -DeployedSha is provided, the ci.yml check must query by exact commit
+    SHA (head_sha=) rather than branch=main, so a gh-run-rerun (which preserves
+    original created_at) cannot be displaced by a newer branch run that makes the
+    per_page=1 branch query return the wrong run. health-monitor.yml is unaffected.
+    Fail-closed: zero completed runs for the SHA must FAIL, never silently pass.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-GitHubHealth -DeployedSha SHA-scoped CI check (t/2639)' -Tag 'health' {
+
+    It 'uses head_sha= for ci.yml when DeployedSha is provided and passes on success' {
+        InModuleScope AITriad {
+            $script:CiUri = $null
+            $script:HmUri = $null
+            Mock Invoke-RestMethod -MockWith {
+                if ($Uri -like '*githubstatus.com*') {
+                    return [PSCustomObject]@{ status = [PSCustomObject]@{ indicator = 'none'; description = 'All Systems Operational' } }
+                }
+                if ($Uri -like '*/actions/workflows/ci.yml*') {
+                    $script:CiUri = $Uri
+                    return [PSCustomObject]@{ total_count = 1; workflow_runs = @([PSCustomObject]@{ conclusion = 'success'; updated_at = '2026-08-14T10:00:00Z'; run_number = 200 }) }
+                }
+                if ($Uri -like '*/actions/workflows/health-monitor.yml*') {
+                    $script:HmUri = $Uri
+                    return [PSCustomObject]@{ total_count = 1; workflow_runs = @([PSCustomObject]@{ conclusion = 'success'; updated_at = '2026-08-14T09:00:00Z'; run_number = 50 }) }
+                }
+                if ($Uri -like '*/rate_limit*') {
+                    return [PSCustomObject]@{ resources = [PSCustomObject]@{ core = [PSCustomObject]@{ remaining = 5000; limit = 5000; reset = 9999999999 } } }
+                }
+                return [PSCustomObject]@{ visibility = 'public'; default_branch = 'main' }
+            }
+
+            $result = Test-GitHubHealth -DeployedSha 'abc1234' 6>$null
+
+            $script:CiUri | Should -Match 'head_sha=abc1234' -Because 'the ci.yml query must use the exact SHA (t/2639 fix)'
+            $script:CiUri | Should -Not -Match 'branch=' -Because 'SHA mode must not also filter by branch'
+            $script:HmUri | Should -Match 'branch=main' -Because 'health-monitor.yml is unaffected by DeployedSha'
+
+            $ciCheck = $result.Checks | Where-Object { $_.Check -like 'Workflow: ci.yml*' }
+            $ciCheck.Pass | Should -BeTrue -Because 'a successful run for the SHA must pass'
+            $ciCheck.Check | Should -Match 'abc1234' -Because 'the check label reflects the SHA not the branch'
+        }
+    }
+
+    It 'fails closed when zero completed runs exist for the SHA (gate integrity)' {
+        InModuleScope AITriad {
+            Mock Invoke-RestMethod -MockWith {
+                if ($Uri -like '*githubstatus.com*') {
+                    return [PSCustomObject]@{ status = [PSCustomObject]@{ indicator = 'none'; description = 'All Systems Operational' } }
+                }
+                if ($Uri -like '*/actions/workflows/ci.yml*') {
+                    return [PSCustomObject]@{ total_count = 0; workflow_runs = @() }
+                }
+                if ($Uri -like '*/rate_limit*') {
+                    return [PSCustomObject]@{ resources = [PSCustomObject]@{ core = [PSCustomObject]@{ remaining = 5000; limit = 5000; reset = 9999999999 } } }
+                }
+                return [PSCustomObject]@{ visibility = 'public'; default_branch = 'main'; total_count = 1;
+                    workflow_runs = @([PSCustomObject]@{ conclusion = 'success'; updated_at = '2026-08-14T09:00:00Z'; run_number = 50 }) }
+            }
+
+            $result = Test-GitHubHealth -DeployedSha 'deadbeef' 6>$null
+
+            $ciCheck = $result.Checks | Where-Object { $_.Check -like 'Workflow: ci.yml*' }
+            $ciCheck.Pass   | Should -BeFalse -Because 'no CI run for the SHA must fail closed, not silently pass (t/2639 requirement)'
+            $ciCheck.Detail | Should -Match 'failing closed' -Because 'the detail must name the fail-closed reason for operator visibility'
+            $result.Healthy | Should -BeFalse -Because 'a fail-closed ci.yml check must sink overall health'
+        }
+    }
+
+    It 'legacy path (no DeployedSha) still uses branch=main for ci.yml' {
+        InModuleScope AITriad {
+            $script:LegacyCiUri = $null
+            Mock Invoke-RestMethod -MockWith {
+                if ($Uri -like '*githubstatus.com*') {
+                    return [PSCustomObject]@{ status = [PSCustomObject]@{ indicator = 'none'; description = 'All Systems Operational' } }
+                }
+                if ($Uri -like '*/actions/workflows/ci.yml*') {
+                    $script:LegacyCiUri = $Uri
+                    return [PSCustomObject]@{ total_count = 1; workflow_runs = @([PSCustomObject]@{ conclusion = 'success'; updated_at = '2026-08-14T10:00:00Z'; run_number = 201 }) }
+                }
+                if ($Uri -like '*/rate_limit*') {
+                    return [PSCustomObject]@{ resources = [PSCustomObject]@{ core = [PSCustomObject]@{ remaining = 5000; limit = 5000; reset = 9999999999 } } }
+                }
+                return [PSCustomObject]@{ visibility = 'public'; default_branch = 'main'; total_count = 1;
+                    workflow_runs = @([PSCustomObject]@{ conclusion = 'success'; updated_at = '2026-08-14T09:00:00Z'; run_number = 50 }) }
+            }
+
+            $null = Test-GitHubHealth 6>$null
+
+            $script:LegacyCiUri | Should -Match 'branch=main' -Because 'omitting DeployedSha must preserve the existing branch=main behavior'
+            $script:LegacyCiUri | Should -Not -Match 'head_sha' -Because 'legacy path must not use SHA querying'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `-DeployedSha` param to `Test-GitHubHealth` / `Invoke-TaxEditorSmokeTest` so the staging smoke gate queries CI by the exact deployed SHA (`head_sha=<sha>`) rather than `branch=main&per_page=1`
- Fails closed when zero CI runs found for that SHA (logs `sha=<sha> — no CI run found → failing closed`)
- Wires `${{ github.event.workflow_run.head_sha }}` into the smoke step in `deploy-staging.yml`

Fixes the stale-head gap: a staging deploy that raced a faster-landing sibling could previously pass smoke by accidentally matching the sibling's green CI run.

Combined PR covering both the PS cmdlet change and the CI workflow wiring (approved design — e/100#2).

## Test plan

- [ ] Pester: 3 new tests in `tests/GitHubHealth.Tests.ps1` covering `-DeployedSha` param, `head_sha=` query, and fail-closed-on-zero-runs (pass at `53185738`)
- [ ] CI green on this head before merge
- [ ] Pre-self-merge verification: base=main, head OID matches push, CI on exact OID

🤖 Generated with [Claude Code](https://claude.com/claude-code)