### PR TITLE
feat(devops): add Azure Files volume mount to staging app (t/2612)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -586,6 +586,22 @@ resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
               failureThreshold: 10
             }
           ]
+          volumeMounts: [
+            // Mirror prod's Azure Files mount so staging is a faithful pre-prod
+            // proxy — grounding data (/mnt/shared) must be present for smoke
+            // tests to cover the full feature surface (t/2612 P1 gap).
+            {
+              volumeName: 'shared-data'
+              mountPath: '/mnt/shared'
+            }
+          ]
+        }
+      ]
+      volumes: [
+        {
+          name: 'shared-data'
+          storageType: 'AzureFile'
+          storageName: 'taxonomy-data'
         }
       ]
       scale: {


### PR DESCRIPTION
## Summary

- Adds `volumeMounts` + `volumes` to the staging Container App in `main.bicep`, mirroring the prod app's Azure Files mount (`/mnt/shared`, `taxonomy-data` share)
- Fixes P1 gap: staging had no volume mount, so smoke tests never exercised grounding-data paths and the t/2602 durability test was a false positive (hit in-process cache, not the real mount)
- Unblocks t/2642 (faithful scale-to-zero durability re-validation on staging)

**TL clearance (p/331#179):** CORS `allowedOrigins` and `allowedExternalRedirectUrls` Bicep expressions both resolve to `https://taxonomy-editor.yellowbush-aeda037d.eastus.azurecontainerapps.io` — matching live prod exactly. The prod delta in `what-if` is a no-op re-materialization of pre-existing ARM references, not a real config change.

After merge: dispatch `deploy-azure.yml` (user authorization required) to apply the Bicep change. Then ping TL to line up t/2642.

## Test plan

- [ ] CI green on this head before merge
- [ ] Pre-self-merge verification: base=main, head OID matches push, CI on exact OID
- [ ] After deploy: staging revision has `/mnt/shared` mounted (verify via `az containerapp revision show`)
- [ ] After deploy: t/2642 durability re-validation passes on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)