### PR TITLE
fix(nav): Op-Eds reveal honors both build flags; drift-proof navCtx (t/2641)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
@@ -10,7 +10,7 @@ import { SettingsDialog } from '../settings/SettingsDialog';
 import { FeedbackPopover } from './FeedbackPopover';
 import { useAuthStatus } from '../../hooks/useAuthStatus';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
-import { useFlag } from '../../hooks/useFeatureFlags';
+import { useFlag, useFeatureFlagStore } from '../../hooks/useFeatureFlags';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import {
   NAV_ITEMS, getVisibleNavItems, getSecondaryByGroup,
@@ -77,9 +77,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
   } = useTaxonomyStore();
   const breakpoint = useBreakpoint();
   const adminFeatures = useFlag('permission-admin-features');
-  const summariesFlag = useFlag('env-electron-summaries');
-  const opedsFlag = useFlag('env-electron-opeds');
-  const webOpedsFlag = useFlag('env-web-opeds'); // web reveal — Op-Eds gate ORs both build flags (t/2633)
+  // Whole flag record → navCtx (drift-proof; see Toolbar/t/2641). Below at navCtx.
   const [showHelp, setShowHelp] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
@@ -168,7 +166,8 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
   }
 
   // NavConfig-driven items
-  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag, 'env-web-opeds': webOpedsFlag }, isAdmin: adminFeatures };
+  const allFlags = useFeatureFlagStore(s => s.flags); // whole record → no nav-gate flag can drift (t/2641)
+  const navCtx = { flags: allFlags, isAdmin: adminFeatures };
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const primaryNavItems = visibleItems.filter(i => i.tier === 'primary' && !bottomNavIds.has(i.id));
   const secondaryGroups = getSecondaryByGroup(visibleItems);

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.test.tsx
@@ -62,8 +62,13 @@ vi.mock('../../hooks/useAuthStatus', () => ({
   useUserProfile: () => null,
 }));
 
+// Configurable feature flags (t/2641). Both useFlag and the whole-record store selector
+// read the same source, so a test can reveal Op-Eds via EITHER build flag and prove the
+// component threads it (the drift that hid Op-Eds on web — t/2599, t/2633).
+const { mockFlags } = vi.hoisted(() => ({ mockFlags: { value: {} as Record<string, boolean> } }));
 vi.mock('../../hooks/useFeatureFlags', () => ({
-  useFlag: () => false,
+  useFlag: (name: string) => mockFlags.value[name] ?? false,
+  useFeatureFlagStore: (selector: (s: { flags: Record<string, boolean> }) => unknown) => selector({ flags: mockFlags.value }),
 }));
 
 vi.mock('../../hooks/useTierInfo', () => ({
@@ -127,5 +132,28 @@ describe('Toolbar — Zustand scalar selector regression (t/2142)', () => {
       screen.getByRole('button', { name: /switch to simple view/i }),
     );
     expect(mockPrefsState.setViewMode).toHaveBeenCalledWith('simple');
+  });
+});
+
+describe('Toolbar — Op-Eds reveal honors both build flags (t/2641)', () => {
+  beforeEach(() => { mockFlags.value = {}; mockPrefsState.viewMode = 'simple'; });
+
+  it('hides the Op-Eds button when neither build flag is set', () => {
+    render(<Toolbar />);
+    expect(screen.queryByRole('button', { name: 'Op-Eds' })).toBeNull();
+  });
+
+  // The web-reveal case that the hardcoded env-electron-opeds gate (Toolbar line 340) missed:
+  // env-web-opeds ON, env-electron-opeds absent → the primary Op-Eds button MUST appear.
+  it('shows the Op-Eds button when only env-web-opeds is on (web reveal)', () => {
+    mockFlags.value = { 'env-web-opeds': true };
+    render(<Toolbar />);
+    expect(screen.getByRole('button', { name: 'Op-Eds' })).toBeInTheDocument();
+  });
+
+  it('shows the Op-Eds button when only env-electron-opeds is on (desktop, unchanged)', () => {
+    mockFlags.value = { 'env-electron-opeds': true };
+    render(<Toolbar />);
+    expect(screen.getByRole('button', { name: 'Op-Eds' })).toBeInTheDocument();
   });
 });

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -13,7 +13,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { HelpDialog } from '../settings/HelpDialog';
 import { SettingsDialog } from '../settings/SettingsDialog';
 import { useAuthStatus, useUserProfile } from '../../hooks/useAuthStatus';
-import { useFlag } from '../../hooks/useFeatureFlags';
+import { useFlag, useFeatureFlagStore } from '../../hooks/useFeatureFlags';
 import { useTierInfo } from '../../hooks/useTierInfo';
 import { FeedbackPopover } from './FeedbackPopover';
 import { NAV_ITEMS, getVisibleNavItems, getSecondaryByGroup, type NavItem, type NavAction } from '../../data/navConfig';
@@ -215,12 +215,15 @@ export function Toolbar() {
   }, [showMore]);
 
   const adminFeatures = useFlag('permission-admin-features');
-  const summariesFlag = useFlag('env-electron-summaries');
-  const opedsFlag = useFlag('env-electron-opeds');
-  const webOpedsFlag = useFlag('env-web-opeds'); // web reveal — Op-Eds gate ORs both build flags (t/2633)
-  const navCtx = { flags: { 'env-electron-summaries': summariesFlag, 'env-electron-opeds': opedsFlag, 'env-web-opeds': webOpedsFlag }, isAdmin: adminFeatures };
+  // Thread the WHOLE flag record into navCtx so a nav gate can never reference a flag the
+  // component forgot to include — the drift that hid Op-Eds twice (t/2599, t/2633). t/2641.
+  const allFlags = useFeatureFlagStore(s => s.flags);
+  const navCtx = { flags: allFlags, isAdmin: adminFeatures };
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const secondaryGroups = getSecondaryByGroup(visibleItems);
+  // The hardcoded primary Op-Eds button honors the SAME navConfig gate (not a re-derived
+  // flag check) so its visibility can't diverge from the gate — the line-340 drift (t/2641).
+  const opedsVisible = visibleItems.some(i => i.id === 'opeds');
   const isNavItemActive = (item: NavItem): boolean => {
     if (item.action.type === 'switchTab') return activeTab === item.action.target && toolbarPanel === null;
     if (item.action.type === 'togglePanel') return toolbarPanel === item.action.target;
@@ -337,7 +340,7 @@ export function Toolbar() {
           <MessageCircle size="1.25em" />
           <span className="toolbar-nav-label">Chat</span>
         </button>
-        {opedsFlag && (
+        {opedsVisible && (
           <button
             className={`toolbar-nav${activeTab === 'opeds' && toolbarPanel === null ? ' toolbar-nav-active' : ''}`}
             onClick={() => switchTab('opeds')}


### PR DESCRIPTION
**Hardening + the REAL remaining web-reveal fix.** A live smoke showed the web Op-Eds reveal was still broken after #1033. Two drift sites:

1. **navCtx hardcoded flag subset** (Toolbar + HamburgerMenu) — a gate referencing an omitted flag is silently never satisfied (hid Op-Eds in t/2599 + t/2633). Fix: thread the WHOLE flag record (`useFeatureFlagStore(s => s.flags)`) into navCtx. Stable store ref, no t/2142 loop risk.

2. **The real remaining web blocker:** the Toolbar PRIMARY Op-Eds button (line 340) was hardcoded on `env-electron-opeds` ONLY and never used navCtx. #1033 fixed the navCtx path — but in the Toolbar that only feeds the secondary/overflow menu, not the primary button. `App.tsx` always renders `<Toolbar/>` (HamburgerMenu is mobile-only), so **desktop-width web still hid Op-Eds**. Fix: gate the button on `visibleItems.some(i => i.id === 'opeds')` — the same navConfig gate.

Guard test: asserts the Op-Eds button hides with no flag, and shows when ONLY `env-web-opeds` is on (the case line 340 missed) + when only `env-electron-opeds` is on. Fails against pre-fix code.

⚠️ **Deploy note:** this — not #1033 alone — makes the web reveal work on desktop-width web. **The t/2614 smoke needs a redeploy that includes this commit.**

Verify: Toolbar.test.tsx 9/9 · renderer tsc clean · eslint 0 errors. Self-cert (UI-only + guard test); flagging the scope/impact to TL as it's the failure-class prevention area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)