### PR TITLE
fix(nav): primary Op-Eds button honors the navConfig gate (t/2641)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.test.tsx
@@ -62,11 +62,15 @@ vi.mock('../../hooks/useAuthStatus', () => ({
   useUserProfile: () => null,
 }));
 
+// Configurable flags (t/2641): both useFlag and the whole-record store read the same
+// source, so a test can reveal Op-Eds via EITHER build flag and prove the primary button
+// honors the gate (it was hardcoded on env-electron-opeds → hidden on web).
+const { mockFlags } = vi.hoisted(() => ({ mockFlags: { value: {} as Record<string, boolean> } }));
 vi.mock('../../hooks/useFeatureFlags', () => ({
-  useFlag: () => false,
+  useFlag: (name: string) => mockFlags.value[name] ?? false,
   // Toolbar threads the whole flag record via useNavVisibilityContext (t/2641).
   useFeatureFlagStore: (selector: (s: { flags: Record<string, boolean> }) => unknown) =>
-    selector({ flags: {} }),
+    selector({ flags: mockFlags.value }),
 }));
 
 vi.mock('../../hooks/useTierInfo', () => ({
@@ -130,5 +134,29 @@ describe('Toolbar — Zustand scalar selector regression (t/2142)', () => {
       screen.getByRole('button', { name: /switch to simple view/i }),
     );
     expect(mockPrefsState.setViewMode).toHaveBeenCalledWith('simple');
+  });
+});
+
+describe('Toolbar — primary Op-Eds button honors both build flags (t/2641)', () => {
+  beforeEach(() => { mockFlags.value = {}; mockPrefsState.viewMode = 'simple'; });
+
+  it('hides the Op-Eds button when neither build flag is set', () => {
+    render(<Toolbar />);
+    expect(screen.queryByRole('button', { name: 'Op-Eds' })).toBeNull();
+  });
+
+  // The web-reveal case the hardcoded env-electron-opeds gate missed: env-web-opeds ON,
+  // env-electron-opeds absent → the primary Op-Eds button MUST appear (the Toolbar is
+  // what renders on desktop-width web).
+  it('shows the Op-Eds button when only env-web-opeds is on (web reveal)', () => {
+    mockFlags.value = { 'env-web-opeds': true };
+    render(<Toolbar />);
+    expect(screen.getByRole('button', { name: 'Op-Eds' })).toBeInTheDocument();
+  });
+
+  it('shows the Op-Eds button when only env-electron-opeds is on (desktop, unchanged)', () => {
+    mockFlags.value = { 'env-electron-opeds': true };
+    render(<Toolbar />);
+    expect(screen.getByRole('button', { name: 'Op-Eds' })).toBeInTheDocument();
   });
 });

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -215,10 +215,13 @@ export function Toolbar() {
     return () => window.removeEventListener('mousedown', handler);
   }, [showMore]);
 
-  const opedsFlag = useFlag('env-electron-opeds'); // gates the primary Op-Eds button below (desktop reveal)
   const navCtx = useNavVisibilityContext(); // whole flag record — no subset to drift (t/2641)
   const visibleItems = getVisibleNavItems(NAV_ITEMS, navCtx);
   const secondaryGroups = getSecondaryByGroup(visibleItems);
+  // The hardcoded primary Op-Eds button honors the SAME navConfig gate as the data-driven
+  // items — it was gated on env-electron-opeds ALONE, so it stayed hidden on web even with
+  // env-web-opeds ON (the Toolbar is what renders on desktop-width web). t/2641.
+  const opedsVisible = visibleItems.some(i => i.id === 'opeds');
   const isNavItemActive = (item: NavItem): boolean => {
     if (item.action.type === 'switchTab') return activeTab === item.action.target && toolbarPanel === null;
     if (item.action.type === 'togglePanel') return toolbarPanel === item.action.target;
@@ -335,7 +338,7 @@ export function Toolbar() {
           <MessageCircle size="1.25em" />
           <span className="toolbar-nav-label">Chat</span>
         </button>
-        {opedsFlag && (
+        {opedsVisible && (
           <button
             className={`toolbar-nav${activeTab === 'opeds' && toolbarPanel === null ? ' toolbar-nav-active' : ''}`}
             onClick={() => switchTab('opeds')}


### PR DESCRIPTION
**The remaining half of the web Op-Eds reveal** (complements #1035). #1035 threaded the whole flag record into navCtx — but that fixes the Toolbar's secondary/overflow menu, not its PRIMARY Op-Eds button, which was hardcoded on `env-electron-opeds` alone. `App.tsx` always renders `<Toolbar/>` on desktop-width web (HamburgerMenu is mobile-only), so flipping `env-web-opeds` still left Op-Eds hidden on web — the real remaining blocker for the t/2614 smoke, found by live prod inspection.

Fix: gate the primary button on `visibleItems.some(i => i.id === 'opeds')` — the same navConfig gate as the data-driven items, so it can't diverge again. Drop the now-unused `opedsFlag` decl.

Guard test: Op-Eds button hides with no flag; shows when ONLY `env-web-opeds` is on (the case the old gate missed); shows when only `env-electron-opeds` is on (desktop, unchanged). Fails against pre-fix code.

⚠️ **Deploy:** together with #1035, this is what makes the web reveal actually work. The t/2614 smoke needs a staging redeploy that includes this commit.

Verify: Toolbar.test.tsx 9/9 · renderer tsc clean · eslint 0 errors. Self-cert (UI-only + guard test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)