### PR TITLE
fix(opeds): render OpEdTab on web — App.tsx guard ORs both build flags (t/2646)

### DIFF
--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -249,7 +249,12 @@ function AppRouter() {
 function MainApp() {
   const { activeTab, loading, backgroundLoading, loadingProgress, loadAll, colorScheme, paneSpacing, zoomLevel, zoomIn, zoomOut, zoomReset, toolbarPanel } = useTaxonomyStore();
   const summariesFlag = useFlag('env-electron-summaries');
-  const opedsFlag = useFlag('env-electron-opeds');
+  // OR both build flags — mirrors the navConfig Op-Eds gate (anyFlag: electron||web). Gates
+  // BOTH the tab render below and must stay in sync with the nav gate, else the button shows
+  // (via env-web-opeds) but the panel never mounts on web → blank content area (t/2646).
+  const opedsElectronFlag = useFlag('env-electron-opeds');
+  const opedsWebFlag = useFlag('env-web-opeds');
+  const opedsFlag = opedsElectronFlag || opedsWebFlag;
   const breakpoint = useBreakpoint();
   const isTouch = useIsTouchDevice();
   const isMobile = breakpoint === 'phone' || breakpoint === 'phone-lg' || breakpoint === 'tablet';


### PR DESCRIPTION
**Blank Op-Eds content area on web** (Diagnostics p/1#90/#91). The navConfig gate + Toolbar primary button (#1041) OR `['env-electron-opeds','env-web-opeds']`, so with `env-web-opeds` ON the tab **button** appears — but `App.tsx:686` renders `<OpEdTab/>` gated on `opedsFlag`, bound at `:252` to `env-electron-opeds` **alone**. Button shows, panel never mounts on web → blank.

**Third instance of the OR-gate drift class** (t/2599 navCtx; #1041 Toolbar button; now the App content render). Fix: OR both build flags at App.tsx:252, mirroring the anyFlag gate.

A **code fix, not a flag write** — unblocks the t/2614 web-create smoke independent of the t/2643 storage-isolation freeze. (An identical uncommitted fix was found orphaned in the shared main checkout — never committed, so invisible to CI/deploy; landing it properly here.)

**Prevention note:** 3rd recurrence — argues for a single "is nav item X enabled" source of truth (relates t/2641).

Verify: renderer tsc clean · eslint 0 errors · web build OK. Self-cert /trivial-change (3-line OR matching the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)