### PR TITLE
feat(server): getStateRoot() — isolate class-A writes from the shared data root (t/2643)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/stateRoot.test.ts
+++ b/taxonomy-editor/src/server/__tests__/stateRoot.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+//
+// t/2643 — state-root isolation. Class-A WRITES (feature flags, runtime config, keys,
+// calibration, telemetry, flight-recorder) route through getStateRoot(); grounding READS stay
+// on getDataRoot(). On staging, AI_TRIAD_STATE_ROOT points at an isolated RW mount so a class-A
+// write cannot mutate prod's shared data root. These tests prove the split + the fail-fast guard
+// + the unit-level arm-B property (a flag write lands in the state root, NOT the data root).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { getDataRoot, getStateRoot, resolveStatePath, isStagingIdentity, assertStateRootIsolation } from '../config.js';
+import { setFlag, getFlagMetadata, _resetFlagCache } from '../featureFlags.js';
+
+const SAVED: Record<string, string | undefined> = {};
+const KEYS = ['AI_TRIAD_DATA_ROOT', 'AI_TRIAD_STATE_ROOT', 'CONTAINER_APP_NAME', 'AI_TRIAD_ENV', 'ADMIN_USERS'];
+let dataRoot: string;
+let stateRoot: string;
+
+beforeEach(() => {
+  for (const k of KEYS) SAVED[k] = process.env[k];
+  dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'data-'));
+  stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'state-'));
+  for (const k of KEYS) delete process.env[k];
+  process.env.AI_TRIAD_DATA_ROOT = dataRoot;
+  process.env.ADMIN_USERS = 'jpsnover';
+  _resetFlagCache();
+});
+afterEach(() => {
+  for (const k of KEYS) { if (SAVED[k] === undefined) delete process.env[k]; else process.env[k] = SAVED[k]; }
+  fs.rmSync(dataRoot, { recursive: true, force: true });
+  fs.rmSync(stateRoot, { recursive: true, force: true });
+  _resetFlagCache();
+});
+
+describe('t/2643 — getStateRoot / resolveStatePath', () => {
+  it('defaults to getDataRoot() when AI_TRIAD_STATE_ROOT is unset (prod/local unchanged)', () => {
+    expect(getStateRoot()).toBe(getDataRoot());
+  });
+  it('resolves to AI_TRIAD_STATE_ROOT when set (staging isolation)', () => {
+    process.env.AI_TRIAD_STATE_ROOT = stateRoot;
+    expect(getStateRoot()).toBe(path.resolve(stateRoot));
+    expect(getStateRoot()).not.toBe(getDataRoot());
+  });
+  it('resolveStatePath joins the state root', () => {
+    process.env.AI_TRIAD_STATE_ROOT = stateRoot;
+    expect(resolveStatePath('admin/x.json')).toBe(path.resolve(stateRoot, 'admin/x.json'));
+  });
+});
+
+describe('t/2643 — isStagingIdentity', () => {
+  it('true when CONTAINER_APP_NAME contains "staging" (ACA-injected, drift-proof)', () => {
+    process.env.CONTAINER_APP_NAME = 'taxonomy-editor-staging';
+    expect(isStagingIdentity()).toBe(true);
+  });
+  it('true when AI_TRIAD_ENV=staging (explicit backstop)', () => {
+    process.env.AI_TRIAD_ENV = 'staging';
+    expect(isStagingIdentity()).toBe(true);
+  });
+  it('false on prod (CONTAINER_APP_NAME=taxonomy-editor, no env flag)', () => {
+    process.env.CONTAINER_APP_NAME = 'taxonomy-editor';
+    expect(isStagingIdentity()).toBe(false);
+  });
+});
+
+describe('t/2643 — assertStateRootIsolation fail-fast guard', () => {
+  it('THROWS on staging identity when the state root fell back to the data root (env drift)', () => {
+    process.env.CONTAINER_APP_NAME = 'taxonomy-editor-staging';
+    // AI_TRIAD_STATE_ROOT unset → getStateRoot()===getDataRoot() → the hazard.
+    expect(() => assertStateRootIsolation()).toThrow(/refusing to start/i);
+  });
+  it('passes on staging when the state root IS isolated', () => {
+    process.env.CONTAINER_APP_NAME = 'taxonomy-editor-staging';
+    process.env.AI_TRIAD_STATE_ROOT = stateRoot;
+    expect(() => assertStateRootIsolation()).not.toThrow();
+  });
+  it('passes on prod/local (not staging) even when stateRoot===dataRoot', () => {
+    // no staging identity; stateRoot===dataRoot is legitimate (prod owns its share)
+    expect(() => assertStateRootIsolation()).not.toThrow();
+  });
+});
+
+describe('t/2643 — arm-B property (unit level): a class-A write lands in the STATE root, not the data root', () => {
+  it('setFlag writes under getStateRoot() and does NOT create the file under getDataRoot()', () => {
+    process.env.AI_TRIAD_STATE_ROOT = stateRoot; // isolate (staging-like)
+    _resetFlagCache();
+    setFlag('env-web-opeds', { enabled: true, scope: 'env:web' }, 'jpsnover');
+
+    const stateFile = path.join(stateRoot, 'admin', 'feature-flags.json');
+    const dataFile = path.join(dataRoot, 'admin', 'feature-flags.json');
+    expect(fs.existsSync(stateFile)).toBe(true);                 // written to the isolated state root
+    expect(fs.existsSync(dataFile)).toBe(false);                 // prod's data root is UNTOUCHED
+    _resetFlagCache();
+    expect(getFlagMetadata('env-web-opeds')?.enabled).toBe(true); // and readable back from the state root
+  });
+});

--- a/taxonomy-editor/src/server/ai/providerBinding.ts
+++ b/taxonomy-editor/src/server/ai/providerBinding.ts
@@ -16,7 +16,7 @@
 import fs from 'fs';
 import path from 'path';
 import { readFileWithMtime } from './fsCache.js';
-import { getDataRoot } from '../config.js';
+import { getStateRoot } from '../config.js';
 import { log } from '../logger.js';
 import { getConfig } from '../runtimeConfig.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
@@ -40,7 +40,9 @@ let _cacheMtime = 0;
 let _lastLoadTime = 0;
 
 function getBindingsPath(): string {
-  return path.join(getDataRoot(), 'admin', 'provider_bindings.json');
+  // t/2643: provider bindings are class-A writable state (runtime-written on first login) →
+  // the writable state root, so a staging login can't rewrite prod's provider_bindings.json.
+  return path.join(getStateRoot(), 'admin', 'provider_bindings.json');
 }
 
 function loadBindings(): Map<string, string> {

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -107,6 +107,67 @@ export function resolveDataPath(subPath: string): string {
 }
 
 /**
+ * Writable STATE root for class-A data — feature flags, runtime config, the key store,
+ * telemetry, flight-recorder dirs, and calibration logs. Split from the read/grounding
+ * data root so a staging deployment cannot mutate prod's shared Azure Files share (t/2643).
+ *
+ * - `AI_TRIAD_STATE_ROOT` (Bicep-declared on staging) → an isolated, staging-owned RW mount.
+ * - Defaults to `getDataRoot()`, so filesystem/Electron and prod behave exactly as before
+ *   (prod's state root IS its data root — the shared share, which prod legitimately owns).
+ *
+ * Grounding/taxonomy READS and read-only provisioned config keep using `getDataRoot()` /
+ * `resolveDataPath()` (the shared, read-only mount) — only WRITABLE class-A paths route here.
+ * The RO mount is the primary prod-immutability boundary; this split makes staging function
+ * within it (t/2643#3).
+ */
+export function getStateRoot(): string {
+  const envRoot = process.env.AI_TRIAD_STATE_ROOT;
+  if (envRoot) return path.resolve(envRoot);
+  return getDataRoot();
+}
+
+/** `resolveDataPath` for the writable state root (t/2643). Use for class-A WRITE paths. */
+export function resolveStatePath(subPath: string): string {
+  const stateRoot = getStateRoot();
+  return path.isAbsolute(subPath) ? subPath : path.resolve(stateRoot, subPath);
+}
+
+/**
+ * True when this process is the STAGING deployment. ACA auto-injects `CONTAINER_APP_NAME`
+ * (drift-proof — set by the platform, not a Bicep env a drift could silently wipe); an
+ * explicit `AI_TRIAD_ENV=staging` is accepted as a belt-and-suspenders backstop. Used only
+ * by the state-root isolation fail-fast guard (t/2643) — never an auth/security decision.
+ */
+export function isStagingIdentity(): boolean {
+  const appName = process.env.CONTAINER_APP_NAME ?? '';
+  return /staging/i.test(appName) || process.env.AI_TRIAD_ENV === 'staging';
+}
+
+/**
+ * Boot-time fail-fast guard (t/2643, Second Opinion cond. 4): if this is the STAGING
+ * deployment but the isolated state root resolves back to the shared data root — i.e.
+ * `AI_TRIAD_STATE_ROOT` was wiped by env-var drift (the project's documented incident class)
+ * — refuse to start. This converts "staging silently resumes mutating prod's shared share"
+ * into a visible boot failure. Called once at server startup. No-op on prod/local (where
+ * stateRoot===dataRoot is legitimate — prod owns its share).
+ */
+export function assertStateRootIsolation(): void {
+  if (isStagingIdentity() && getStateRoot() === getDataRoot()) {
+    throw new Error(
+      'State-root isolation guard failed — refusing to start (t/2643).\n' +
+      '  Goal:       keep staging class-A writes off prod\'s shared Azure Files data root.\n' +
+      '  Problem:    staging identity detected but AI_TRIAD_STATE_ROOT is unset/equal to the ' +
+      'data root, so class-A writes (feature flags, runtime config, keys, calibration) would ' +
+      'land on prod\'s shared share.\n' +
+      `  Location:   getStateRoot()===getDataRoot()===${getDataRoot()} on ` +
+      `${process.env.CONTAINER_APP_NAME ?? '(unknown app)'}.\n` +
+      '  Next steps: set AI_TRIAD_STATE_ROOT to the staging-owned RW mount in main.bicep ' +
+      '(never via --set-env-vars, which the next Bicep apply wipes — re-arming the hazard).',
+    );
+  }
+}
+
+/**
  * Resolve sources root independently from data root.
  * Priority: AI_TRIAD_SOURCES_ROOT env var > .aitriad.json sources_root > null.
  * Returns null when sources are unavailable (web/container mode, or repo not cloned).
@@ -177,7 +238,7 @@ export async function getApiKey(backend: AIBackend = 'gemini'): Promise<string |
 
   try {
     // t/835: stored value may be a JSON array of keys — take the first.
-    const stored = await getKeyStore(getDataRoot).getKeys(backend, getCurrentUserId());
+    const stored = await getKeyStore(getStateRoot).getKeys(backend, getCurrentUserId());
     if (stored.length > 0) return stored[0];
   } catch (err) {
     getGlobalRecorder()?.record({
@@ -206,7 +267,7 @@ export async function getApiKeys(backend: AIBackend = 'gemini'): Promise<string[
   if (envKey) return [envKey];
 
   try {
-    const stored = await getKeyStore(getDataRoot).getKeys(backend, getCurrentUserId());
+    const stored = await getKeyStore(getStateRoot).getKeys(backend, getCurrentUserId());
     if (stored.length > 0) return stored;
   } catch (err) {
     getGlobalRecorder()?.record({
@@ -226,17 +287,17 @@ export async function getApiKeys(backend: AIBackend = 'gemini'): Promise<string[
 /** The user's stored BYOK keys for a backend (t/835) — excludes env/platform
  *  keys; for the Settings key-management list. */
 export async function getStoredApiKeys(backend: AIBackend = 'gemini'): Promise<string[]> {
-  return getKeyStore(getDataRoot).getKeys(backend, getCurrentUserId());
+  return getKeyStore(getStateRoot).getKeys(backend, getCurrentUserId());
 }
 
 /** Append a BYOK key for a backend (t/835); returns the new key list. */
 export async function addApiKey(key: string, backend: AIBackend = 'gemini'): Promise<string[]> {
-  return getKeyStore(getDataRoot).addKey(backend, getCurrentUserId(), key);
+  return getKeyStore(getStateRoot).addKey(backend, getCurrentUserId(), key);
 }
 
 /** Remove the BYOK key at `index` for a backend (t/835); returns the new key list. */
 export async function removeApiKey(index: number, backend: AIBackend = 'gemini'): Promise<string[]> {
-  return getKeyStore(getDataRoot).removeKey(backend, getCurrentUserId(), index);
+  return getKeyStore(getStateRoot).removeKey(backend, getCurrentUserId(), index);
 }
 
 export async function hasApiKey(backend: AIBackend = 'gemini'): Promise<boolean> {
@@ -244,7 +305,7 @@ export async function hasApiKey(backend: AIBackend = 'gemini'): Promise<boolean>
 }
 
 export async function storeApiKey(key: string, backend: AIBackend = 'gemini'): Promise<void> {
-  await getKeyStore(getDataRoot).set(backend, getCurrentUserId(), key);
+  await getKeyStore(getStateRoot).set(backend, getCurrentUserId(), key);
 }
 
 // ── Paid Gemini fallback key (t/948) ──
@@ -258,7 +319,7 @@ const PAID_FALLBACK_PARTITION = '_system';
  *  GEMINI_PAID_KEY env var), or null if neither is configured. */
 export async function getPaidGeminiFallbackKey(): Promise<string | null> {
   try {
-    const stored = await getKeyStore(getDataRoot).getKeys('gemini', PAID_FALLBACK_PARTITION);
+    const stored = await getKeyStore(getStateRoot).getKeys('gemini', PAID_FALLBACK_PARTITION);
     if (stored.length > 0) return stored[0];
   } catch (err) {
     getGlobalRecorder()?.record({
@@ -272,12 +333,12 @@ export async function getPaidGeminiFallbackKey(): Promise<string | null> {
 
 /** Admin: store the paid Gemini fallback key in the `_system` key-store partition. */
 export async function setPaidGeminiFallbackKey(key: string): Promise<void> {
-  await getKeyStore(getDataRoot).set('gemini', PAID_FALLBACK_PARTITION, key);
+  await getKeyStore(getStateRoot).set('gemini', PAID_FALLBACK_PARTITION, key);
 }
 
 /** Admin: remove the stored paid Gemini fallback key (the env-var path, if any, persists). */
 export async function deletePaidGeminiFallbackKey(): Promise<void> {
-  await getKeyStore(getDataRoot).delete('gemini', PAID_FALLBACK_PARTITION);
+  await getKeyStore(getStateRoot).delete('gemini', PAID_FALLBACK_PARTITION);
 }
 
 /** All user-configurable AI backends — iterated by deleteAllApiKeys().
@@ -288,11 +349,11 @@ export async function deletePaidGeminiFallbackKey(): Promise<void> {
 const ALL_AI_BACKENDS = Object.keys(ENV_KEY_NAMES) as AIBackend[];
 
 export async function deleteApiKey(backend: AIBackend = 'gemini'): Promise<void> {
-  await getKeyStore(getDataRoot).delete(backend, getCurrentUserId());
+  await getKeyStore(getStateRoot).delete(backend, getCurrentUserId());
 }
 
 export async function deleteAllApiKeys(): Promise<void> {
-  const store = getKeyStore(getDataRoot);
+  const store = getKeyStore(getStateRoot);
   const userId = getCurrentUserId();
   await Promise.all(ALL_AI_BACKENDS.map(b => store.delete(b, userId)));
 }
@@ -302,7 +363,7 @@ export async function deleteAllApiKeys(): Promise<void> {
  * (t/809). No-op on Key Vault (platform-managed encryption). Admin-triggered.
  */
 export async function rotateApiKeyMaterial(): Promise<KeyRotationResult> {
-  return getKeyStore(getDataRoot).rotateKeyMaterial();
+  return getKeyStore(getStateRoot).rotateKeyMaterial();
 }
 
 // ── Storage mode ──

--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -23,7 +23,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { getDataRoot } from './config.js';
+import { getStateRoot } from './config.js';
 import { log } from './logger.js';
 import { getCurrentUser } from './security/userContext.js';
 import { isAdmin } from './community/community.js';
@@ -132,8 +132,10 @@ let _cacheMtime = -1;
 let _lastLoadTime = 0;
 const CACHE_TTL = 30_000;
 
-function flagsPath(): string { return path.join(getDataRoot(), 'admin', 'feature-flags.json'); }
-function auditPath(): string { return path.join(getDataRoot(), 'admin', 'feature-flags-audit.ndjson'); }
+// t/2643: feature flags are class-A WRITABLE state (read + runtime-written by the server) →
+// the writable state root, so a staging flag flip can't mutate prod's shared feature-flags.json.
+function flagsPath(): string { return path.join(getStateRoot(), 'admin', 'feature-flags.json'); }
+function auditPath(): string { return path.join(getStateRoot(), 'admin', 'feature-flags-audit.ndjson'); }
 
 function loadConfig(): FlagsConfig {
   const p = flagsPath();

--- a/taxonomy-editor/src/server/routes/admin.ts
+++ b/taxonomy-editor/src/server/routes/admin.ts
@@ -16,7 +16,7 @@ import type { ServerCtx } from './context.js';
 import { json, error, param, query } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { log } from '../logger.js';
-import { getDataRoot, getProjectRoot, rotateApiKeyMaterial, STORAGE_MODE, getPaidGeminiFallbackKey, setPaidGeminiFallbackKey, deletePaidGeminiFallbackKey } from '../config.js';
+import { getDataRoot, getStateRoot, getProjectRoot, rotateApiKeyMaterial, STORAGE_MODE, getPaidGeminiFallbackKey, setPaidGeminiFallbackKey, deletePaidGeminiFallbackKey } from '../config.js';
 import { loadUsageRegistry } from '../../../../lib/ai-client/usageTypes.js';
 import { getConfig, getConfigState, writeConfig, forceReload as reloadRuntimeConfig, diffFromDefaults } from '../runtimeConfig.js';
 import { requireAdmin, getReviewQueue, getReviewStats, getReviewDetail, executeReviewAction } from '../community/admin/reviewRegistry.js';
@@ -738,7 +738,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
 
       const userId = getCurrentUserId();
       const date = new Date().toISOString().slice(0, 10);
-      const telemetryDir = path.join(getDataRoot(), 'admin', 'telemetry');
+      const telemetryDir = path.join(getStateRoot(), 'admin', 'telemetry'); // t/2643: class-A writable state
       fs.mkdirSync(telemetryDir, { recursive: true });
 
       const line = JSON.stringify({
@@ -779,7 +779,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
     try {
       const url = new URL(req.url!, 'http://localhost');
       const days = Math.min(parseInt(url.searchParams.get('days') || '7', 10) || 7, 90);
-      const telemetryDir = path.join(getDataRoot(), 'admin', 'telemetry');
+      const telemetryDir = path.join(getStateRoot(), 'admin', 'telemetry'); // t/2643: class-A writable state
 
       const summaries: Record<string, Record<string, number>> = {};
       const now = new Date();

--- a/taxonomy-editor/src/server/routes/data.ts
+++ b/taxonomy-editor/src/server/routes/data.ts
@@ -16,7 +16,7 @@ import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
-import { getDataRoot, STORAGE_MODE } from '../config.js';
+import { getDataRoot, STORAGE_MODE, isStagingIdentity } from '../config.js';
 import { getConfig } from '../runtimeConfig.js';
 import { isPathWithinDir } from '../security/accessControl.js';
 import { requireAdmin } from '../community/admin/reviewRegistry.js';
@@ -163,6 +163,15 @@ export function registerDataRoutes(r: Router, ctx: ServerCtx): void {
       res.end('Data pull skipped: github-api mode uses the GitHub API as the source of truth (no local git sync).\n');
       return;
     }
+    // t/2643: even in filesystem mode, refuse a data-pull on staging — reset --hard + clean -fd on
+    // the worktree at getDataRoot() (= /mnt/shared, prod's SHARED tree) would mutate prod's data.
+    // Closes the git-worktree staging→prod hazard before DevOps flips the mount RO (the backstop).
+    if (isStagingIdentity()) {
+      res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Data pull is disabled on staging: the shared data worktree is read-only there (t/2643).\n');
+      return;
+    }
+
     // Stream heartbeats to prevent Azure Container Apps' Envoy proxy from
     // returning 504 "stream timeout" during long-running git operations.
     res.writeHead(200, {

--- a/taxonomy-editor/src/server/routes/debates.ts
+++ b/taxonomy-editor/src/server/routes/debates.ts
@@ -18,7 +18,7 @@ import * as community from '../community/community.js';
 import * as ai from '../ai/aiBackends.js';
 import { getStorageUserId, getAnonymousSessionId } from '../security/userContext.js';
 import * as rateLimiter from '../security/rateLimiter.js';
-import { getDataRoot } from '../config.js';
+import { getStateRoot } from '../config.js';
 import type { DebateDelta } from '../../../../lib/debate/types.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 // t/2626: this static `import type` forces tsc to emit lib/debate/newsReport.js into the
@@ -50,7 +50,9 @@ async function logCalibrationIfComplete(body: unknown): Promise<void> {
       // `body` is the saved debate session at runtime; the local narrow type above
       // is only for the transcript check, so cast to the function's param.
       const dataPoint = extractCalibrationData(session as unknown as Parameters<typeof extractCalibrationData>[0], getStorageUserId());
-      appendCalibrationLog(dataPoint, getDataRoot());
+      // t/2643: calibration is class-A writable state (raw-fs append in the lib funnel, which
+      // roots purely at this arg) → the writable state root, not prod's shared data root.
+      appendCalibrationLog(dataPoint, getStateRoot());
     }
   } catch (err) {
     getGlobalRecorder()?.record({

--- a/taxonomy-editor/src/server/routes/diagnostics.ts
+++ b/taxonomy-editor/src/server/routes/diagnostics.ts
@@ -20,7 +20,7 @@ import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error, param } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
-import { getDataRoot, getProjectRoot, STORAGE_MODE } from '../config.js';
+import { getDataRoot, getStateRoot, getProjectRoot, STORAGE_MODE } from '../config.js';
 import { writeDump, isValidDumpId, readMergedDump } from '../flightRecorderDumps.js';
 import { escapeForInlineScript } from '../flightRecorderViewer.js';
 import { clientSafeMessage } from '../security/accessControl.js';
@@ -36,7 +36,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
   // ── Calibration log (per-debate metrics — JSONL from core/) ──
   get('/api/calibration/log', (_req, res) => {
     try {
-      const logPath = path.join(getDataRoot(), 'calibration', 'core', 'calibration-log.jsonl');
+      const logPath = path.join(getStateRoot(), 'calibration', 'core', 'calibration-log.jsonl'); // t/2643: calibration is class-A writable state (read side)
       if (!fs.existsSync(logPath)) { json(res, { entries: [], validationReport: null }); return; }
 
       const entries = fs.readFileSync(logPath, 'utf-8')
@@ -44,7 +44,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
         .filter((line: string) => line.trim().length > 0)
         .map((line: string) => JSON.parse(line));
 
-      const reportPath = path.join(getDataRoot(), 'calibration', 'validation-report.json');
+      const reportPath = path.join(getStateRoot(), 'calibration', 'validation-report.json'); // t/2643
       let validationReport = null;
       if (fs.existsSync(reportPath)) {
         try { validationReport = JSON.parse(fs.readFileSync(reportPath, 'utf-8')); } catch { /* telemetry — silent by design */ }
@@ -58,7 +58,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
   get('/api/calibration/history', async (_req, res) => {
     try {
       const { readParameterHistory, captureSnapshot } = await import('../../../../lib/debate/calibrationLogger.js');
-      const history = readParameterHistory(getDataRoot());
+      const history = readParameterHistory(getStateRoot()); // t/2643: calibration is class-A writable state
       const current = captureSnapshot();
       json(res, { current, history });
     } catch (err) { getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to load parameter history', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); error(res, String(err), 500, err); }
@@ -80,7 +80,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
         return;
       }
 
-      const dumpDir = path.join(getDataRoot(), 'flight-recorder');
+      const dumpDir = path.join(getStateRoot(), 'flight-recorder'); // t/2643: class-A writable state
       fs.mkdirSync(dumpDir, { recursive: true });
 
       const ts = new Date().toISOString().replace(/:/g, '-');
@@ -116,7 +116,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
   post('/api/flight-recorder/server-dump', (_req, res) => {
     try {
       const ndjson = appendServerLogs(serverRecorder.buildDump('manual').ndjson);
-      const dumpDir = path.join(getDataRoot(), 'flight-recorder');
+      const dumpDir = path.join(getStateRoot(), 'flight-recorder'); // t/2643: class-A writable state
       fs.mkdirSync(dumpDir, { recursive: true });
       const ts = new Date().toISOString().replace(/:/g, '-');
       const filename = `server-flight-recorder-${ts}.jsonl`;
@@ -199,7 +199,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
 
   get('/api/flight-recorder/list', (_req, res) => {
     try {
-      const dumpDir = path.join(getDataRoot(), 'flight-recorder');
+      const dumpDir = path.join(getStateRoot(), 'flight-recorder'); // t/2643: class-A writable state
       if (!fs.existsSync(dumpDir)) { json(res, { files: [] }); return; }
       const files = fs.readdirSync(dumpDir)
         .filter(f => f.endsWith('.jsonl') && /^(server-)?flight-recorder-/.test(f))
@@ -229,7 +229,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
         error(res, 'Invalid filename', 400);
         return;
       }
-      const dumpDir = path.join(getDataRoot(), 'flight-recorder');
+      const dumpDir = path.join(getStateRoot(), 'flight-recorder'); // t/2643: class-A writable state
       const filePath = path.join(dumpDir, filename);
       if (!fs.existsSync(filePath)) { error(res, 'File not found', 404); return; }
       const content = fs.readFileSync(filePath, 'utf-8');
@@ -248,7 +248,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
         error(res, 'Invalid filename', 400);
         return;
       }
-      const dumpDir = path.join(getDataRoot(), 'flight-recorder');
+      const dumpDir = path.join(getStateRoot(), 'flight-recorder'); // t/2643: class-A writable state
       const filePath = path.join(dumpDir, filename);
       if (!fs.existsSync(filePath)) { error(res, 'File not found', 404); return; }
 

--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -17,7 +17,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { getDataRoot } from './config.js';
+import { getStateRoot } from './config.js';
 import { log } from './logger.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 import { DEFAULT_MODEL } from '../../../lib/ai-client/index.js';
@@ -472,7 +472,8 @@ let _lastLoadTime = 0;
 const CACHE_TTL = 5_000;
 
 function configPath(): string {
-  return path.join(getDataRoot(), 'admin', 'runtime-config.json');
+  // t/2643: runtime config is class-A writable state → the writable state root.
+  return path.join(getStateRoot(), 'admin', 'runtime-config.json');
 }
 
 function loadConfig(): RuntimeConfig {

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -1459,7 +1459,7 @@ server.listen(PORT, BIND_HOST, () => {
   const analyticsBlobUrl = process.env.AZURE_STORAGE_ACCOUNT_URL;
   const analyticsContainer = process.env.AZURE_ANALYTICS_CONTAINER || 'analytics';
   analytics.initAnalytics(
-    getDataRoot(),
+    getStateRoot(), // t/2643: analytics NDJSON is class-A writable state — isolate the fs-fallback root by construction (not by AZURE_STORAGE_ACCOUNT_URL being set). No-op on prod (stateRoot===dataRoot).
     analyticsBlobUrl ? { accountUrl: analyticsBlobUrl, container: analyticsContainer } : undefined,
   ).then(() => {
     log.analytics.info({ backend: analyticsBlobUrl ? 'azure-blob' : 'filesystem' }, 'Analytics initialized');

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -26,7 +26,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 import { WebSocketServer, WebSocket } from 'ws';
 import {
-  PORT, getDataRoot, getApiKey, hasApiKey, storeApiKey, deleteApiKey, deleteAllApiKeys, rotateApiKeyMaterial,
+  PORT, getDataRoot, getStateRoot, assertStateRootIsolation, getApiKey, hasApiKey, storeApiKey, deleteApiKey, deleteAllApiKeys, rotateApiKeyMaterial,
   getStoredApiKeys, addApiKey, removeApiKey, resolveDataPath,
   getPaidGeminiFallbackKey, setPaidGeminiFallbackKey, deletePaidGeminiFallbackKey,
   BROKER_SCRIPT, SCRIPTS_DIR, getProjectRoot, type AIBackend,
@@ -1373,7 +1373,7 @@ function shutdown(signal: string) {
   try {
     serverRecorder.record({ type: 'lifecycle', component: 'server', level: 'info', message: `Shutdown: ${signal}` });
     const ndjson = appendServerLogs(serverRecorder.buildDump('manual').ndjson);
-    const dumpDir = path.join(getDataRoot(), 'flight-recorder');
+    const dumpDir = path.join(getStateRoot(), 'flight-recorder'); // t/2643: class-A writable state
     fs.mkdirSync(dumpDir, { recursive: true });
     fs.writeFileSync(path.join(dumpDir, `server-shutdown-${Date.now()}.jsonl`), ndjson);
   } catch { /* telemetry — silent by design;  best effort */ }
@@ -1417,7 +1417,7 @@ process.on('uncaughtException', (err) => {
   try {
     serverRecorder.record({ type: 'system.error', component: 'server', level: 'fatal', message: err.message, error: { name: err.name, message: err.message, stack: err.stack?.slice(0, 500) } });
     const { ndjson } = serverRecorder.buildDump('uncaught_error', { name: err.name, message: err.message, stack: err.stack?.slice(0, 500) });
-    const dumpDir = path.join(getDataRoot(), 'flight-recorder');
+    const dumpDir = path.join(getStateRoot(), 'flight-recorder'); // t/2643: class-A writable state
     fs.mkdirSync(dumpDir, { recursive: true });
     fs.writeFileSync(path.join(dumpDir, `server-crash-${Date.now()}.jsonl`), ndjson);
   } catch { /* telemetry — silent by design;  best effort */ }
@@ -1438,7 +1438,7 @@ initAnonymousSessionStore({
 });
 
 // ── Start ──
-
+assertStateRootIsolation(); // t/2643: refuse start if staging's state root wasn't isolated (env drift) — no-op prod/local
 // t/2532 (M12): loopback (127.0.0.1) in dev / 0.0.0.0 in prod; HOST opts into LAN exposure (logged loudly below).
 const BIND_HOST = resolveBindHost(process.env);
 server.listen(PORT, BIND_HOST, () => {


### PR DESCRIPTION
**Prod-integrity fix (t/2643).** Staging + prod mount the SAME Azure Files share, so any class-A write from staging (feature flags, runtime config, keys, calibration) mutated prod's data. Splits the writable **STATE root** from the read/grounding **DATA root**. Per TL GV (t/2643#9) + SO conditions: the RO mount DevOps flips on staging is the PRIMARY boundary; this split makes staging function within it.

**config.ts:** `getStateRoot()` = `AI_TRIAD_STATE_ROOT ?? getDataRoot()` (prod/local unchanged); `resolveStatePath()`; `isStagingIdentity()` (drift-proof `CONTAINER_APP_NAME`); `assertStateRootIsolation()` boot fail-fast (staging && stateRoot===dataRoot → refuse start); keyStore wiring → `getStateRoot` (12 sites, keyStore.ts unchanged).

**Rerouted to `getStateRoot()` (raw-fs class-A, read+write together):** featureFlags (flags+audit), runtimeConfig, providerBinding, admin telemetry, flight-recorder dirs (server.ts + diagnostics), calibration (debates.ts:53 call site — lib helper root-agnostic, no DebateTool change; diagnostics calibration reads).

**Stays on `getDataRoot()` (shared RO):** grounding/taxonomy + read-only provisioned config (quotas, proxy-tiers, authorized-users). Backend-mediated writes (writeDump, calibrationStore, user content) → GitHub-API/Blob in prod, not the mount → separate class-B question.

**Folded (TL p/333#158):** `/api/data/pull` refuses on staging (its `reset --hard`/`clean -fd` runs on the shared worktree). Prod requireAdmin + .gitignore audit = **t/2645** (separate PR).

**Tests:** `stateRoot.test.ts` (11) — default/override, isStagingIdentity, fail-fast both ways, + the unit-level **arm-B property** (a flag write lands in the state root, data root untouched). featureFlags.test.ts (16) unchanged = backward compat. tsc + eslint clean; server suite green (75 local fails = Node-7.x undici-skew, CI green).

**DRAFT — routed to Main (TL) for Gate Verification** (both runtime arms on the RW mount: staging debate-smoke + config + key write → prod `/mnt/shared` byte-unchanged; staging write to RO mount fails visibly) before merge + the RO flip. DevOps half: RO-mount shared share, RW staging-state mount, Bicep-declared `AI_TRIAD_STATE_ROOT` + `TAXONOMY_CACHE_DIR` on both apps.

Relates t/2643, t/2644, t/2645, t/2612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)