### PR TITLE
feat(devops): staging Azure Files write isolation — steps 1-2 (t/2643)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -175,7 +175,7 @@ jobs:
         run: |
           Set-StrictMode -Version Latest
           $ErrorActionPreference = 'Stop'
-          $BicepEnv = & ./operations/devops/Get-BicepBaseEnv.ps1 -BicepPath deploy/azure/main.bicep
+          $BicepEnv = & ./operations/devops/Get-BicepBaseEnv.ps1 -BicepPath deploy/azure/main.bicep -ForStaging
           $RevEnvJson = az containerapp revision show `
             --name '${{ env.CONTAINER_APP_NAME }}' `
             -g '${{ env.RESOURCE_GROUP }}' `

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -469,8 +469,10 @@ var stagingEnvOverrides = [
   { name: 'TAXONOMY_CACHE_DIR',  value: '/mnt/staging-state/cache' }
   // Routes all class-A writes (flags, config, calibration, keys) to isolated mount
   { name: 'AI_TRIAD_STATE_ROOT', value: '/mnt/staging-state' }
+  // github-api writes go to the staging branch, not main (t/2650 class-B isolation)
+  { name: 'GITHUB_BRANCH',       value: 'staging' }
 ]
-// stagingBaseEnv = baseEnv with the 3 isolation overrides applied.
+// stagingBaseEnv = baseEnv with the 4 isolation overrides applied.
 // filter() removes the baseEnv entries that stagingEnvOverrides supersedes.
 var stagingBaseEnv = concat(
   filter(baseEnv, e => e.name != 'TAXONOMY_CACHE_DIR' && e.name != 'GIT_SYNC_ENABLED'),

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -378,6 +378,30 @@ resource stagingAnalyticsContainer 'Microsoft.Storage/storageAccounts/blobServic
   }
 }
 
+// ── Staging Azure Files — writable state share (t/2643) ──
+// Class-A writes (flags, config, calibration, keys) from staging route here.
+// Prod's 'taxonomy-data' share is NOT declared here (managed externally) — it
+// will be flipped to ReadOnly in a follow-up deploy once getStateRoot() is live.
+
+resource stagingStateShare 'Microsoft.Storage/storageAccounts/fileServices/shares@2023-05-01' = {
+  name: '${storageAccount.name}/default/taxonomy-data-staging'
+  properties: { shareQuota: 100 }
+}
+
+resource envStorageStagingState 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
+  parent: containerAppEnv
+  name: 'taxonomy-data-staging'
+  properties: {
+    azureFile: {
+      accountName: storageAccount.name
+      accountKey: storageAccount.listKeys().keys[0].value
+      shareName: 'taxonomy-data-staging'
+      accessMode: 'ReadWrite'
+    }
+  }
+  dependsOn: [stagingStateShare]
+}
+
 // ── Container App ──
 
 var baseEnv = [
@@ -432,6 +456,40 @@ var envWithFreeTier = freeTierEnabled
 var containerEnv = paidTierEnabled
   ? concat(envWithFreeTier, [ { name: 'GEMINI_PAID_KEY', secretRef: paidTierSecretName } ])
   : envWithFreeTier
+
+// ── Staging env isolation (t/2643) ──
+// Override 2 baseEnv keys and add 1 new key for staging class-A write isolation.
+// ALL three must be Bicep-declared (never --set-env-vars — wiped by next apply).
+// Get-BicepBaseEnv.ps1 -ForStaging also parses stagingEnvOverrides so
+// Sync-StagingEnv.ps1 keeps staging's template in sync on every deploy.
+var stagingEnvOverrides = [
+  // Force off: staging must not sync to prod's git backend (t/2643 git-worktree hazard)
+  { name: 'GIT_SYNC_ENABLED',    value: '0' }
+  // Cache must not write to the (soon-to-be) RO /mnt/shared; route to state mount
+  { name: 'TAXONOMY_CACHE_DIR',  value: '/mnt/staging-state/cache' }
+  // Routes all class-A writes (flags, config, calibration, keys) to isolated mount
+  { name: 'AI_TRIAD_STATE_ROOT', value: '/mnt/staging-state' }
+]
+// stagingBaseEnv = baseEnv with the 3 isolation overrides applied.
+// filter() removes the baseEnv entries that stagingEnvOverrides supersedes.
+var stagingBaseEnv = concat(
+  filter(baseEnv, e => e.name != 'TAXONOMY_CACHE_DIR' && e.name != 'GIT_SYNC_ENABLED'),
+  stagingEnvOverrides
+)
+// Rebuild the secret chain for staging — mirrors the prod chain so staging
+// is a faithful pre-prod proxy (same oauth/ai secrets, different write path).
+var stagingEnvWithToken = githubTokenProvided
+  ? concat(stagingBaseEnv, [ { name: 'GITHUB_TOKEN', secretRef: githubTokenSecretName } ])
+  : stagingBaseEnv
+var stagingEnvWithWebhook = githubWebhookSecretProvided
+  ? concat(stagingEnvWithToken, [ { name: 'GITHUB_WEBHOOK_SECRET', secretRef: githubWebhookSecretName } ])
+  : stagingEnvWithToken
+var stagingEnvWithFreeTier = freeTierEnabled
+  ? concat(stagingEnvWithWebhook, [ { name: 'FREE_TIER_GEMINI_KEY', secretRef: freeTierSecretName } ])
+  : stagingEnvWithWebhook
+var stagingContainerEnv = paidTierEnabled
+  ? concat(stagingEnvWithFreeTier, [ { name: 'GEMINI_PAID_KEY', secretRef: paidTierSecretName } ])
+  : stagingEnvWithFreeTier
 
 resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
   name: 'taxonomy-editor'
@@ -577,7 +635,7 @@ resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
             cpu: json('0.25')
             memory: '0.5Gi'
           }
-          env: containerEnv
+          env: stagingContainerEnv
           probes: [
             {
               type: 'Startup'
@@ -587,12 +645,17 @@ resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
             }
           ]
           volumeMounts: [
-            // Mirror prod's Azure Files mount so staging is a faithful pre-prod
-            // proxy — grounding data (/mnt/shared) must be present for smoke
-            // tests to cover the full feature surface (t/2612 P1 gap).
+            // Shared grounding data (taxonomy, embeddings) — read-only after
+            // getStateRoot() is live (t/2643 step 3; RO flip is a follow-up deploy).
             {
               volumeName: 'shared-data'
               mountPath: '/mnt/shared'
+            }
+            // Staging-isolated writable state: class-A writes (flags, config,
+            // calibration, keys) land here, never on the shared /mnt/shared (t/2643).
+            {
+              volumeName: 'staging-state'
+              mountPath: '/mnt/staging-state'
             }
           ]
         }
@@ -602,6 +665,12 @@ resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'shared-data'
           storageType: 'AzureFile'
           storageName: 'taxonomy-data'
+        }
+        {
+          // Staging-isolated RW share for class-A state (t/2643).
+          name: 'staging-state'
+          storageType: 'AzureFile'
+          storageName: 'taxonomy-data-staging'
         }
       ]
       scale: {

--- a/operations/devops/Get-BicepBaseEnv.ps1
+++ b/operations/devops/Get-BicepBaseEnv.ps1
@@ -13,12 +13,16 @@
       AZURE_KEYVAULT_URL          — resource property reference
       AZURE_STORAGE_ACCOUNT_URL   — resource property reference
       AUTH_DISABLED / AUTH_OPTIONAL / ADMIN_USERS
-      GIT_SYNC_ENABLED / GITHUB_* — parameter references
+      GIT_SYNC_ENABLED / GITHUB_* — parameter references (overridden by -ForStaging)
       APPLICATIONINSIGHTS_*       — resource property reference
 
 .PARAMETER BicepPath
     Path to deploy/azure/main.bicep. Defaults to the canonical location
     relative to this script's repo root.
+
+.PARAMETER ForStaging
+    Also parse var stagingEnvOverrides and merge into the result (staging values
+    win over baseEnv). Use when syncing or verifying the staging container app.
 
 .OUTPUTS
     [hashtable] mapping env-var name → literal string value.
@@ -27,10 +31,15 @@
 .EXAMPLE
     $env = . ./operations/devops/Get-BicepBaseEnv.ps1
     $env['NODE_ENV']   # 'production'
+
+.EXAMPLE
+    $env = . ./operations/devops/Get-BicepBaseEnv.ps1 -ForStaging
+    $env['TAXONOMY_CACHE_DIR']   # '/mnt/staging-state/cache'
 #>
 [CmdletBinding()]
 param(
-    [string]$BicepPath
+    [string]$BicepPath,
+    [switch]$ForStaging
 )
 
 Set-StrictMode -Version Latest
@@ -67,6 +76,19 @@ $block | Select-String -Pattern $literalPattern -AllMatches | ForEach-Object {
         $name  = $m.Groups[1].Value
         $value = $m.Groups[2].Value
         $result[$name] = $value
+    }
+}
+
+if ($ForStaging) {
+    if ($content -match '(?s)var stagingEnvOverrides\s*=\s*\[(.*?)\]') {
+        $stagingBlock = $Matches[1]
+        $stagingBlock | Select-String -Pattern $literalPattern -AllMatches | ForEach-Object {
+            foreach ($m in $_.Matches) {
+                $result[$m.Groups[1].Value] = $m.Groups[2].Value
+            }
+        }
+    } else {
+        Write-Warning "stagingEnvOverrides block not found in $BicepPath — only baseEnv entries returned"
     }
 }
 

--- a/operations/devops/Sync-StagingEnv.ps1
+++ b/operations/devops/Sync-StagingEnv.ps1
@@ -27,7 +27,8 @@ if (-not $BicepPath) {
     $BicepPath = Join-Path $PSScriptRoot '../../deploy/azure/main.bicep'
 }
 
-$BicepEnv = & (Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1') -BicepPath $BicepPath
+$isStaging = $AppName -like '*-staging*'
+$BicepEnv = & (Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1') -BicepPath $BicepPath $(if ($isStaging) { '-ForStaging' })
 if ($BicepEnv.Count -eq 0) {
     Write-Error "Get-BicepBaseEnv.ps1 returned 0 entries — Bicep parse failed or baseEnv block is empty"
     exit 1


### PR DESCRIPTION
## Summary

- New `taxonomy-data-staging` Azure Files share + ACA managed env storage
- `stagingEnvOverrides`: `GIT_SYNC_ENABLED=0`, `TAXONOMY_CACHE_DIR=/mnt/staging-state/cache`, `AI_TRIAD_STATE_ROOT=/mnt/staging-state`
- `stagingContainerEnv` Bicep chain replaces `containerEnv` on `containerAppStaging`
- `staging-state` RW volume mount at `/mnt/staging-state` added to staging app
- `/mnt/shared` stays ReadWrite — RO flip is step 3 (separate PR, gated on ServerAPI `getStateRoot()` + arm-B GV)
- `Get-BicepBaseEnv.ps1`: `-ForStaging` switch merges `stagingEnvOverrides` over `baseEnv`
- `Sync-StagingEnv.ps1`: auto-detects `*-staging*` AppName and passes `-ForStaging`
- `deploy-staging.yml`: baseEnv verify step uses `-ForStaging`

## Deployment gate

**DO NOT deploy until all of the following clear:**
1. ServerAPI `getStateRoot()` PR lands and TL verifies both arms (t/2643#5)
2. t/2650 (staging `GITHUB_REPO` isolation) lands — added to unfreeze gate at t/2643#15

## Test plan

- [ ] Bicep lints (`az bicep build`)
- [ ] CI green on this branch
- [ ] Arm-A: post-ServerAPI merge, staging write to `/mnt/staging-state` succeeds, `/mnt/shared` untouched
- [ ] Arm-B: staging flag flip → prod `feature-flags.json` byte-identical (mount read-only verification)
- [ ] `Sync-StagingEnv.ps1` dry-run with `-ForStaging` confirms `TAXONOMY_CACHE_DIR` and `GIT_SYNC_ENABLED` overrides present
- [ ] Deploy-staging baseEnv verify step passes with `-ForStaging`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Implements: t/2643
Design approval: t/2643#5 (TL binding, 2026-08-14)
