### PR TITLE
fix(nodedetail): hide empty steelman POV blocks in edit mode too (t/2656)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -881,7 +881,10 @@ function SteelmanVulnerabilitySection({ node, readOnly, update }: SteelmanVulner
             const vuln = node.graph_attributes!.steelman_vulnerability as Record<string, string | undefined>;
             const povKey = key.replace('from_', '') as 'accelerationist' | 'safetyist' | 'skeptic';
             const meta = POV_META[povKey];
-            if (!vuln[key] && readOnly) return null;
+            // Hide a POV with no vulnerability text in BOTH modes — an empty POV rendered a
+            // blank textarea in edit mode (noise). These are AI-populated (POV-node regen), not
+            // manually seeded, so hiding an empty one loses nothing; regen repopulates it.
+            if (!vuln[key]) return null;
             return (
               <div key={key} className="vulnerability-subsection">
                 {/* eslint-disable-next-line local/no-inline-style -- color is per-POV, computed from meta.cssVar */}


### PR DESCRIPTION
Diagnostics p/1#95: object-form `steelman_vulnerability` (from_accelerationist/safetyist/skeptic) rendered a **blank textarea** for any POV with no content in **edit** mode. The guard at NodeDetail.tsx:884 hid empty POVs only in read-only (`!vuln[key] && readOnly`). Fix: drop the `readOnly` condition → `if (!vuln[key]) return null`, hiding empty POVs in both modes.

Safe: these POVs are AI-populated via POV-node regeneration (`triggerPovNodeRegeneration`), not manually seeded into empty blocks — hiding an empty one loses nothing; regen repopulates it.

Verify: renderer tsc clean · eslint 0 errors. Self-cert /trivial-change (1-line guard, user-requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)