### PR TITLE
fix(data): no git-pull on github-api mode — requireAdmin + skip git (t/2645, t/2649)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/dataPullAdminGate.test.ts
+++ b/taxonomy-editor/src/server/__tests__/dataPullAdminGate.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+//
+// t/2645 + t/2649 — the "no git-pull on github-api mode" story for the data-mutation routes.
+// /api/data/pull + /api/data/check-updates run destructive git ops (reset --hard, clean -fd,
+// fetch) on the shared data worktree at getDataRoot(). Two guards, tested here:
+//   t/2645 — requireAdmin: they were the data routes left ungated (siblings set-root/clone gate).
+//   t/2649 — on STORAGE_MODE=github-api the GitHub API is authoritative, so the /mnt/shared git
+//            path is vestigial + hazardous → skipped entirely (also moots the dubious-ownership
+//            false-healthy 200 that check-updates was returning ~every 30s on ACA).
+//
+// STORAGE_MODE is a module-load const, so config is mocked to 'github-api' (the prod mode).
+// requireAdmin runs first, so the non-admin 403 tests are unaffected by the mode.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import http from 'http';
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return { ...actual, STORAGE_MODE: 'github-api' };
+});
+
+import { runWithUser, type UserContext } from '../security/userContext.js';
+import { createRouter } from '../httpKit.js';
+import { registerDataRoutes } from '../routes/data.js';
+
+const ADMIN_ID = 'admin-user';
+let prevAdminUsers: string | undefined;
+
+function mockRes(): http.ServerResponse & { statusCode: number; body: string } {
+  const r = {
+    statusCode: 0, body: '', writableEnded: false, headersSent: false,
+    writeHead(code: number) { r.statusCode = code; return r; },
+    setHeader() {}, write() { return true; },
+    end(b?: string) { r.body = b ?? ''; r.writableEnded = true; return r; },
+    on() { return r; },
+  };
+  return r as unknown as http.ServerResponse & { statusCode: number; body: string };
+}
+function asUser<T>(storageUserId: string, fn: () => T): T {
+  const c: UserContext = { principalName: storageUserId, idp: 'github', storageUserId, isAnonymous: false };
+  return runWithUser(c, fn);
+}
+function handlerFor(method: string, path: string): (req: unknown, res: unknown, body: unknown) => Promise<void> {
+  const routes: Array<{ method: string; path: string; handler: (req: unknown, res: unknown, body: unknown) => Promise<void> }> = [];
+  registerDataRoutes(createRouter(routes as never), { serverRecorder: null } as never);
+  return routes.find(r => r.method === method && r.path === path)!.handler;
+}
+
+beforeEach(() => { prevAdminUsers = process.env.ADMIN_USERS; process.env.ADMIN_USERS = ADMIN_ID; });
+afterEach(() => { if (prevAdminUsers === undefined) delete process.env.ADMIN_USERS; else process.env.ADMIN_USERS = prevAdminUsers; });
+
+describe('t/2645 — data mutation routes require admin (before any git op)', () => {
+  it('POST /api/data/pull → 403 for a non-admin', async () => {
+    const res = mockRes();
+    await asUser('someone-else', () => handlerFor('POST', '/api/data/pull')({}, res, {}));
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('Forbidden');
+  });
+  it('POST /api/data/check-updates → 403 for a non-admin', async () => {
+    const res = mockRes();
+    await asUser('someone-else', () => handlerFor('POST', '/api/data/check-updates')({}, res, {}));
+    expect(res.statusCode).toBe(403);
+  });
+  it('no-context (_local) is also rejected', async () => {
+    const res = mockRes();
+    await handlerFor('POST', '/api/data/pull')({}, res, {});
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('t/2649 — github-api mode skips git entirely (no reset --hard / clean -fd / fetch)', () => {
+  it('admin POST /api/data/pull → 200 "skipped", never runs git', async () => {
+    const res = mockRes();
+    await asUser(ADMIN_ID, () => handlerFor('POST', '/api/data/pull')({}, res, {}));
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatch(/skipped|github-api|source of truth/i);
+  });
+  it('admin POST /api/data/check-updates → honest {available:false} (not a swallowed-error false 200)', async () => {
+    const res = mockRes();
+    await asUser(ADMIN_ID, () => handlerFor('POST', '/api/data/check-updates')({}, res, {}));
+    const body = JSON.parse(res.body);
+    expect(body.available).toBe(false);
+    expect(body.reason).toMatch(/github-api/i);
+  });
+});

--- a/taxonomy-editor/src/server/routes/data.ts
+++ b/taxonomy-editor/src/server/routes/data.ts
@@ -16,7 +16,7 @@ import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
-import { getDataRoot } from '../config.js';
+import { getDataRoot, STORAGE_MODE } from '../config.js';
 import { getConfig } from '../runtimeConfig.js';
 import { isPathWithinDir } from '../security/accessControl.js';
 import { requireAdmin } from '../community/admin/reviewRegistry.js';
@@ -102,6 +102,14 @@ export function registerDataRoutes(r: Router, ctx: ServerCtx): void {
   });
 
   post('/api/data/check-updates', async (_req, res) => {
+    if (!requireAdmin(res)) return; // t/2645: git fetch mutates the shared data root's .git — admin-only, mirroring set-root/clone
+    if (STORAGE_MODE === 'github-api') {
+      // t/2649: on github-api the GitHub API is authoritative and the /mnt/shared git cache is
+      // vestigial. Running git here only trips dubious-ownership on the Azure Files mount, whose
+      // swallowed error returned a false-healthy 200 (~every 30s). Skip with an honest response.
+      json(res, { available: false, reason: 'github-api mode: git sync disabled (GitHub API is the source of truth)' });
+      return;
+    }
     try {
       const dataRoot = getDataRoot();
       const gitDir = path.join(dataRoot, '.git');
@@ -142,6 +150,19 @@ export function registerDataRoutes(r: Router, ctx: ServerCtx): void {
   });
 
   post('/api/data/pull', async (_req, res) => {
+    // t/2645: a data-pull runs `git reset --hard` + `clean -fd` on the shared data worktree —
+    // a destructive admin operation. Gate it like its siblings set-root (:43)/clone (:66); it was
+    // the one data route left ungated. requireAdmin limits WHO; the data-repo .gitignore covering
+    // admin/ is the actual data-loss fix (an admin pull still clean -fd's untracked class-A files).
+    if (!requireAdmin(res)) return;
+    if (STORAGE_MODE === 'github-api') {
+      // t/2649: git pull is vestigial AND destructive (reset --hard + clean -fd on the shared
+      // /mnt/shared worktree) in github-api mode — the GitHub API is the persistence layer. Skip
+      // it entirely: this removes the worktree-mutation hazard in prod and moots dubious-ownership.
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Data pull skipped: github-api mode uses the GitHub API as the source of truth (no local git sync).\n');
+      return;
+    }
     // Stream heartbeats to prevent Azure Container Apps' Envoy proxy from
     // returning 504 "stream timeout" during long-running git operations.
     res.writeHead(200, {


### PR DESCRIPTION
The /api/data mutation routes run destructive git on the shared /mnt/shared worktree (`reset --hard` + `clean -fd` + fetch). Two coherent guards on the same handlers (TL p/333#167), one "no git-pull on github-api mode" story:

**t/2645 — requireAdmin** on `/api/data/pull` + `/api/data/check-updates`. They were the data routes left ungated while siblings set-root (:43) + clone (:66) already gate — a non-admin could trigger `reset --hard`/`clean -fd`. requireAdmin limits WHO; the data-repo `.gitignore` covering `admin/` is the actual data-loss fix (t/2645 — DevOps commits, lines proposed there). `/api/data/pull` is a WEB route (web-bridge.ts:813); Electron uses IPC, so local git-sync is unaffected (mirrors clone).

**t/2649 — skip git when `STORAGE_MODE=github-api`** (prod). The GitHub API is authoritative; the local `/mnt/shared` git cache is vestigial and only trips dubious-ownership, whose swallowed error returned a false-healthy 200 (~every 30s on ACA). Skip entirely: pull → 200 "skipped"; check-updates → honest `{available:false, reason:'github-api'}`. Removes the worktree-mutation hazard in prod + moots the false-200 spam. **Rejected `safe.directory`** (re-enables git on the mount → re-arms the hazard t/2645 guards).

Coexists with the t/2643 staging guard (#1043, `isStagingIdentity`→403 on pull) — three layered guards; whoever lands 2nd rebases.

**Tests:** `dataPullAdminGate.test.ts` (5) — non-admin/no-context → 403 both routes; admin in github-api mode → pull skipped (200, no git), check-updates honest `{available:false}`. tsc + eslint clean.

Relates t/2643, t/2645, t/2649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)