### PR TITLE
feat(devops): GITHUB_BRANCH=staging in stagingEnvOverrides — class-B write isolation (t/2650)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -469,8 +469,10 @@ var stagingEnvOverrides = [
   { name: 'TAXONOMY_CACHE_DIR',  value: '/mnt/staging-state/cache' }
   // Routes all class-A writes (flags, config, calibration, keys) to isolated mount
   { name: 'AI_TRIAD_STATE_ROOT', value: '/mnt/staging-state' }
+  // github-api writes go to the staging branch, not main (t/2650 class-B isolation)
+  { name: 'GITHUB_BRANCH',       value: 'staging' }
 ]
-// stagingBaseEnv = baseEnv with the 3 isolation overrides applied.
+// stagingBaseEnv = baseEnv with the 4 isolation overrides applied.
 // filter() removes the baseEnv entries that stagingEnvOverrides supersedes.
 var stagingBaseEnv = concat(
   filter(baseEnv, e => e.name != 'TAXONOMY_CACHE_DIR' && e.name != 'GIT_SYNC_ENABLED'),


### PR DESCRIPTION
## Summary

Adds `GITHUB_BRANCH=staging` to `stagingEnvOverrides` in `main.bicep`, isolating staging's github-api writes (saveProposal, saveEdge, etc.) to the `staging` branch of `jpsnover/ai-triad-data` rather than `main`.

**One-time prerequisite done:** `staging` branch created off `main` in `jpsnover/ai-triad-data`.

**Stacks on:** #1044 (t/2643 — RW staging-state mount + env chain). This PR targets that branch; retarget to `main` after #1044 merges.

## Deployment gate — DO NOT deploy until

1. #1044 (t/2643) merges
2. ServerAPI confirms `GITHUB_BRANCH` env var is actually read for **write** targets (not hardcoded to `main`) — if hardcoded, this env change is inert and a ServerAPI code fix is required first
3. Both-arms AC verified:
   - Arm A: a staging proposal-save appears on `ai-triad-data/staging`, NOT on `ai-triad-data/main`
   - Arm B: prod data repo (`main`) is byte-identical before/after the staging write

## Test plan

- [ ] Bicep lints cleanly after merge with #1044
- [ ] CI green
- [ ] ServerAPI co-req confirmed (GITHUB_BRANCH is read for writes)
- [ ] Arm-A verified: staging write → staging branch only
- [ ] Arm-B verified: prod main unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Implements: t/2650
Design approval: t/2650#2 (TL binding, 2026-08-14)
