### PR TITLE
fix(analysis): UsageHierarchy owns date preset — fixes Hierarchy tab empty-state (t/2655)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/AnalyticsDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/AnalyticsDashboard.tsx
@@ -559,7 +559,7 @@ export function AnalyticsDashboard() {
           onClick={() => setActiveTab('hierarchy')}>Hierarchy</button>
       </div>
 
-      {activeTab === 'hierarchy' && <UsageHierarchy range={{ from, to }} />}
+      {activeTab === 'hierarchy' && <UsageHierarchy />}
 
       {activeTab === 'overview' && loading && <div className="adash-loading">Loading analytics...</div>}
       {activeTab === 'overview' && error && <div className="adash-error">Failed to load analytics: {error}</div>}

--- a/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.css
+++ b/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.css
@@ -1,5 +1,36 @@
 /* UsageHierarchy — hierarchical analytics navigation (t/2561) */
 
+/* ── Preset bar (date range selector — t/2655) ──────────────────────────────── */
+
+.uh-preset-bar {
+  display: flex;
+  gap: 4px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.uh-preset-btn {
+  padding: 3px 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+
+.uh-preset-btn:hover {
+  color: var(--text-primary);
+}
+
+.uh-preset-btn--active {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+  font-weight: 500;
+}
+
 .uh-root {
   display: flex;
   flex-direction: column;

--- a/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.test.tsx
@@ -50,8 +50,6 @@ const FIXTURE_TREE: TreeNode = {
   },
 };
 
-const RANGE = { from: '2026-07-14', to: '2026-08-13' };
-
 const MOCK_LOAD_SUBJECT = vi.fn();
 
 function makeHookResult(overrides: Partial<UseAnalyticsResult> = {}): UseAnalyticsResult {
@@ -68,8 +66,6 @@ function makeHookResult(overrides: Partial<UseAnalyticsResult> = {}): UseAnalyti
     ...overrides,
   };
 }
-
-const RANGE_DEFAULT = RANGE;
 
 // ── Setup ──────────────────────────────────────────────────────────────────────
 
@@ -130,7 +126,7 @@ describe('UsageHierarchy states', () => {
     vi.mocked(useAnalytics).mockReturnValue(makeHookResult({
       engagement: { data: null, loading: true, error: null, isEmpty: false },
     }));
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     expect(document.querySelector('.uh-skeleton')).toBeTruthy();
   });
 
@@ -138,7 +134,7 @@ describe('UsageHierarchy states', () => {
     vi.mocked(useAnalytics).mockReturnValue(makeHookResult({
       engagement: { data: null, loading: false, error: 'Network error', isEmpty: true },
     }));
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     expect(screen.getByText(/network error/i)).toBeTruthy();
   });
 
@@ -149,7 +145,7 @@ describe('UsageHierarchy states', () => {
         loading: false, error: null, isEmpty: true,
       },
     }));
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     expect(screen.getByText(/no analytics data/i)).toBeTruthy();
   });
 
@@ -163,7 +159,7 @@ describe('UsageHierarchy states', () => {
     // Render with a user scope active (achieved by setting up the hook to reflect user scope)
     // We test the empty-under-scope branch via the `underScope` logic in HierarchyBody.
     // Simulate by checking that the no-scope message is NOT the scoped one when scope=all.
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     expect(screen.queryByText(/no activity in this branch/i)).toBeNull();
   });
 });
@@ -172,14 +168,14 @@ describe('UsageHierarchy states', () => {
 
 describe('drill-down navigation', () => {
   it('renders summary card and root-level drill table', () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     expect(document.querySelector('.uh-summary-card')).toBeTruthy();
     expect(screen.getByText('Taxonomy')).toBeTruthy();
     expect(screen.getByText('Chat')).toBeTruthy();
   });
 
   it('clicking a drill row descends into that child', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
     await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
     // Breadcrumb now shows Taxonomy segment
@@ -187,21 +183,21 @@ describe('drill-down navigation', () => {
   });
 
   it('Enter key on a drill row descends', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     const taxonomyRow = screen.getByRole('button', { name: /drill into taxonomy/i });
     fireEvent.keyDown(taxonomyRow, { key: 'Enter' });
     await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
   });
 
   it('Space key on a drill row descends', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     const taxonomyRow = screen.getByRole('button', { name: /drill into taxonomy/i });
     fireEvent.keyDown(taxonomyRow, { key: ' ' });
     await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
   });
 
   it('breadcrumb segment click navigates up', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     // Drill down
     fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
     await waitFor(() => expect(screen.getByText('Accelerationist')).toBeTruthy());
@@ -217,7 +213,7 @@ describe('drill-down navigation', () => {
 describe('scope-independence invariant', () => {
   it('scope change does NOT reset drillPath — position is preserved', async () => {
     // This is the critical invariant per spec §3 and TL ruling t/2561#2.
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
 
     // Drill down two levels: root → taxonomy → acc
     fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
@@ -237,7 +233,7 @@ describe('scope-independence invariant', () => {
   });
 
   it('drill change does NOT reset scope — WHO filter is preserved', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
 
     // Set user scope first
     fireEvent.click(screen.getByRole('button', { name: /everyone/i }));
@@ -254,7 +250,7 @@ describe('scope-independence invariant', () => {
   });
 
   it('clearing user scope also clears session scope', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
 
     // Set user scope
     fireEvent.click(screen.getByRole('button', { name: /everyone/i }));
@@ -275,7 +271,7 @@ describe('scope-independence invariant', () => {
 
 describe('leaf cross-axis panel', () => {
   it('calls loadSubjectBreakdown with groupBy=user at root scope when reaching a leaf', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     // Drill all the way to a leaf: root → taxonomy → acc → acc-bel → acc-bel-001
     fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
     await waitFor(() => screen.getByRole('button', { name: /drill into accelerationist/i }));
@@ -295,7 +291,7 @@ describe('leaf cross-axis panel', () => {
         loading: false, error: null, isEmpty: false,
       },
     }));
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     // Drill to a true leaf node (acc-bel-001 has no children)
     fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
     await waitFor(() => screen.getByRole('button', { name: /drill into accelerationist/i }));
@@ -329,13 +325,13 @@ describe('leaf cross-axis panel', () => {
 
 describe('summary card count-metric (spec §2.2)', () => {
   it('shows root count as "Items" using firstChild-kind fallback', () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     // Root firstChild = taxonomy (section kind, countUnit=''), falls back to root's countUnit='Items'
     expect(screen.getByText('Items')).toBeTruthy();
   });
 
   it('shows "Nodes" at a category node — child kind, not hidden', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     // Drill: root → taxonomy → acc → acc-bel (category with 2 node children)
     fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
     await waitFor(() => screen.getByRole('button', { name: /drill into accelerationist/i }));
@@ -351,7 +347,7 @@ describe('summary card count-metric (spec §2.2)', () => {
   });
 
   it('hides count metric at a leaf node (no spurious "0 Nodes")', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     // Drill to acc-bel-001 (true leaf, no children)
     fireEvent.click(screen.getByRole('button', { name: /drill into taxonomy/i }));
     await waitFor(() => screen.getByRole('button', { name: /drill into accelerationist/i }));
@@ -370,7 +366,7 @@ describe('summary card count-metric (spec §2.2)', () => {
 
 describe('view toggle', () => {
   it('switches to tree view and shows expand/collapse controls', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     const treeBtn = screen.getByRole('button', { name: /^tree$/i });
     fireEvent.click(treeBtn);
     await waitFor(() => expect(treeBtn.getAttribute('aria-pressed')).toBe('true'));
@@ -379,7 +375,7 @@ describe('view toggle', () => {
   });
 
   it('switching back to drill-down shows drill table', async () => {
-    render(<UsageHierarchy range={RANGE_DEFAULT} />);
+    render(<UsageHierarchy />);
     fireEvent.click(screen.getByRole('button', { name: /^tree$/i }));
     fireEvent.click(screen.getByRole('button', { name: /^drill-down$/i }));
     await waitFor(() => expect(document.querySelector('.uh-drill-table')).toBeTruthy());

--- a/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/UsageHierarchy.tsx
@@ -26,6 +26,19 @@ import type { TreeNode } from './engagementTree';
 
 interface ScopeUserRow { user: string; engagedMs: number; sessions?: number }
 
+type DatePreset = '7d' | '30d' | '90d';
+
+// ── Date helpers (local — component owns its own range) ───────────────────────
+
+const PRESET_DAYS: Record<DatePreset, number> = { '7d': 7, '30d': 30, '90d': 90 };
+
+function dateRange(preset: DatePreset): DateRange {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - (PRESET_DAYS[preset] - 1));
+  return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function walkPath(root: TreeNode, path: string[]): TreeNode | null {
@@ -451,7 +464,10 @@ function HierarchyBody({ engagement, currentNode, drillPath, viewMode, scope, su
 
 // ── Section 9: Main export ────────────────────────────────────────────────────
 
-export function UsageHierarchy({ range }: { range: DateRange }) {
+export function UsageHierarchy() {
+  // Date preset — component owns its own range (default 30d; fixes t/2655 date-range mismatch)
+  const [preset, setPreset] = useState<DatePreset>('30d');
+  const range = useMemo(() => dateRange(preset), [preset]);
   // WHAT axis — drill path (array of node ID keys from root)
   const [drillPath, setDrillPath] = useState<string[]>([]);
   // WHO axis — scope filter (fully independent of WHAT; see TL ruling t/2561#2)
@@ -497,6 +513,18 @@ export function UsageHierarchy({ range }: { range: DateRange }) {
 
   return (
     <div className="uh-root">
+      <div className="uh-preset-bar" role="group" aria-label="Date range">
+        {(['7d', '30d', '90d'] as DatePreset[]).map(p => (
+          <button
+            key={p}
+            className={`uh-preset-btn${preset === p ? ' uh-preset-btn--active' : ''}`}
+            onClick={() => setPreset(p)}
+            aria-pressed={preset === p}
+          >
+            {p === '7d' ? '7 days' : p === '30d' ? '30 days' : '90 days'}
+          </button>
+        ))}
+      </div>
       <ScopeBar
         scopeUser={scopeUser} scopeSession={scopeSession}
         users={users} sessions={sessionRows}


### PR DESCRIPTION
## Summary

- **Root cause:** `UsageHierarchy` inherited `range` from `AnalyticsDashboard` (7d default). If no engagement data exists in the 7d window, `isEmpty` fires with no date control in the Hierarchy tab — user sees "No analytics data available" even though EngagementDashboard shows 30d data.
- **Fix:** `UsageHierarchy` now owns its own `DatePreset` state (default `'30d'`), computes the range internally, and renders a compact `7d | 30d | 90d` preset bar above the scope bar. Callers pass no `range` prop.
- Covers t/2654 too: the upcoming EngagementDashboard Hierarchy tab will use `<UsageHierarchy />` with no prop.

## Changes

| File | Change |
|------|--------|
| `UsageHierarchy.tsx` | Drop `range` prop; add `DatePreset` type + `dateRange()` helper; add `preset` state (default `30d`); add preset bar JSX |
| `UsageHierarchy.css` | Add `.uh-preset-bar`, `.uh-preset-btn`, `.uh-preset-btn--active` |
| `AnalyticsDashboard.tsx` | `<UsageHierarchy />` — no range prop |
| `UsageHierarchy.test.tsx` | Remove `RANGE`/`RANGE_DEFAULT`; drop `range` prop from 18 render calls |

## Test plan

- [x] 24/24 `UsageHierarchy.test.tsx` vitest (all existing cases pass with no range prop)
- [x] `tsc --noEmit` clean
- [x] `vite build` clean
- [x] Self-cert: UI-only, single scope (analysis/), no new cross-role interfaces, no server change

🤖 Generated with [Claude Code](https://claude.com/claude-code)