### PR TITLE
feat(analysis): EngagementDashboard Overview | Hierarchy tab bar (t/2654)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.css
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.css
@@ -79,6 +79,35 @@
 
 .eng-admin-badge--header { margin-left: 0.25rem; }
 
+/* ── Tab bar ────────────────────────────────────────────────────────────────── */
+
+.eng-tab-bar {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 0;
+}
+
+.eng-tab {
+  padding: 0.4rem 1rem;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  cursor: pointer;
+  margin-bottom: -1px;
+  transition: color 0.1s;
+}
+
+.eng-tab:hover { color: var(--text-primary); }
+
+.eng-tab--active {
+  color: var(--text-primary);
+  border-bottom-color: var(--color-acc, #3b82f6);
+  font-weight: 500;
+}
+
 /* ── Controls ───────────────────────────────────────────────────────────────── */
 
 .eng-preset-group {

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
@@ -28,6 +28,10 @@ vi.mock('./chartTooltip', () => ({
   ChartTooltipLayer: () => null,
 }));
 
+vi.mock('./UsageHierarchy', () => ({
+  UsageHierarchy: () => <div data-testid="usage-hierarchy-stub">UsageHierarchy</div>,
+}));
+
 import { bridgeGet } from '../../bridge/web-bridge';
 import { useFlag } from '../../hooks/useFeatureFlags';
 
@@ -232,5 +236,57 @@ describe('EngagementDashboard', () => {
     render(<EngagementDashboard />);
     // aggregate: visits=100, engagedVisits=80 → 80.0%
     await waitFor(() => expect(screen.getByText('80.0%')).toBeTruthy());
+  });
+});
+
+// ── Tab bar ───────────────────────────────────────────────────────────────────
+
+describe('EngagementDashboard tab bar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAdmin(false);
+    mockBridgeGet(FIXTURE_RESULT);
+  });
+
+  it('renders Overview and Hierarchy tab buttons', async () => {
+    render(<EngagementDashboard />);
+    expect(screen.getByRole('tab', { name: /overview/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /hierarchy/i })).toBeTruthy();
+  });
+
+  it('Overview tab is selected by default', () => {
+    render(<EngagementDashboard />);
+    expect(screen.getByRole('tab', { name: /overview/i }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: /hierarchy/i }).getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('Overview content visible on default tab', async () => {
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/loading engagement/i)).toBeTruthy());
+    expect(screen.queryByTestId('usage-hierarchy-stub')).toBeNull();
+  });
+
+  it('clicking Hierarchy tab shows UsageHierarchy and hides Overview content', async () => {
+    render(<EngagementDashboard />);
+    fireEvent.click(screen.getByRole('tab', { name: /hierarchy/i }));
+    await waitFor(() => expect(screen.getByTestId('usage-hierarchy-stub')).toBeTruthy());
+    expect(screen.queryByText(/loading engagement/i)).toBeNull();
+  });
+
+  it('clicking Overview tab after Hierarchy restores Overview content', async () => {
+    render(<EngagementDashboard />);
+    await waitFor(() => expect(screen.getByText(/camp distribution/i)).toBeTruthy());
+    fireEvent.click(screen.getByRole('tab', { name: /hierarchy/i }));
+    await waitFor(() => expect(screen.getByTestId('usage-hierarchy-stub')).toBeTruthy());
+    fireEvent.click(screen.getByRole('tab', { name: /overview/i }));
+    expect(screen.queryByTestId('usage-hierarchy-stub')).toBeNull();
+    expect(screen.getByText(/camp distribution/i)).toBeTruthy();
+  });
+
+  it('date preset buttons remain visible when switching tabs', async () => {
+    render(<EngagementDashboard />);
+    expect(screen.getByText('30 days')).toBeTruthy();
+    fireEvent.click(screen.getByRole('tab', { name: /hierarchy/i }));
+    expect(screen.getByText('30 days')).toBeTruthy();
   });
 });

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
@@ -14,6 +14,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { bridgeGet } from '../../bridge/web-bridge';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { useChartTooltip, ChartTooltipLayer } from './chartTooltip';
+import { UsageHierarchy } from './UsageHierarchy';
 import {
   type TreeNode,
   CAMP_COLORS, CAMP_LABELS,
@@ -322,6 +323,7 @@ function HealthStrip({ aggregate }: { aggregate: TreeNode }) {
 export function EngagementDashboard() {
   const isAdmin = useFlag('permission-admin-features');
 
+  const [activeTab, setActiveTab] = useState<'overview' | 'hierarchy'>('overview');
   const [preset, setPreset] = useState<DatePreset>('7d');
   // userFilter: live input value; committedFilter: triggers fetch on Enter
   const [userFilter, setUserFilter] = useState('');
@@ -399,10 +401,21 @@ export function EngagementDashboard() {
         </div>
       </div>
 
-      {loading && <div className="eng-loading">Loading engagement data…</div>}
-      {error && <div className="eng-error">Failed to load: {error}</div>}
+      <div className="eng-tab-bar" role="tablist">
+        <button role="tab" aria-selected={activeTab === 'overview'}
+          className={`eng-tab${activeTab === 'overview' ? ' eng-tab--active' : ''}`}
+          onClick={() => setActiveTab('overview')}>Overview</button>
+        <button role="tab" aria-selected={activeTab === 'hierarchy'}
+          className={`eng-tab${activeTab === 'hierarchy' ? ' eng-tab--active' : ''}`}
+          onClick={() => setActiveTab('hierarchy')}>Hierarchy</button>
+      </div>
 
-      {data && !loading && (
+      {activeTab === 'hierarchy' && <UsageHierarchy />}
+
+      {activeTab === 'overview' && loading && <div className="eng-loading">Loading engagement data…</div>}
+      {activeTab === 'overview' && error && <div className="eng-error">Failed to load: {error}</div>}
+
+      {activeTab === 'overview' && data && !loading && (
         <>
           {data.aggregate.visits === 0 ? (
             <div className="eng-empty-state">


### PR DESCRIPTION
## Summary

- Adds a two-tab bar (**Overview** | **Hierarchy**) to `EngagementDashboard`, matching the `AnalyticsDashboard` pattern.
- **Overview** tab: existing engagement analytics panels (no change to behaviour).
- **Hierarchy** tab: renders `<UsageHierarchy />` — self-contained component that manages its own date preset (landed in t/2655, PR #1048).
- Default tab is Overview; switching preserves the date preset selection.

**Deviation from ticket spec:** ticket said to pass `range={{ from, to }}` to `UsageHierarchy`, but t/2655 made the component self-contained (no range prop).

## Changes

| File | Change |
|------|--------|
| `EngagementDashboard.tsx` | `activeTab` state; tab bar JSX; overview conditional; `<UsageHierarchy />` on Hierarchy tab; import |
| `EngagementDashboard.css` | `.eng-tab-bar`, `.eng-tab`, `.eng-tab--active` |
| `EngagementDashboard.test.tsx` | `UsageHierarchy` stub mock; 6 new tab bar tests |

## Test plan

- [x] 21/21 `EngagementDashboard.test.tsx` vitest (all prior tests + 6 new tab bar tests)
- [x] `tsc --noEmit` clean
- [x] `vite build` clean
- [x] Self-cert: UI-only, single scope (analysis/), no cross-role interfaces, no server changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)