### PR TITLE
obs(data): self-diagnosable check-updates FR error — endpoint/command/dataRoot (t/2653)

### DIFF
--- a/taxonomy-editor/src/server/routes/data.ts
+++ b/taxonomy-editor/src/server/routes/data.ts
@@ -143,6 +143,9 @@ export function registerDataRoutes(r: Router, ctx: ServerCtx): void {
         component: 'server',
         level: 'error',
         message: 'Operation failed',
+        // t/2653: name the endpoint + git command + data root so the FR event is self-diagnosable
+        // without grepping the source (this only fires in filesystem mode — github-api skips git).
+        data: { endpoint: '/api/data/check-updates', command: 'git fetch', dataRoot: getDataRoot() },
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       json(res, { available: false, error: String(err) });


### PR DESCRIPTION
The `system.error` from `POST /api/data/check-updates` on git failure recorded only `message:'Operation failed'` with no structured data — during the ccebf210 triage, 14 identical errors had to be traced to `data.ts` by reading the source to find git was being called and on what path.

Adds `data: { endpoint: '/api/data/check-updates', command: 'git fetch', dataRoot }` to the recorder call so the FR event is self-diagnosable without a source cross-reference.

**Note:** post-#1046 (t/2649) this error only fires in **filesystem mode** — github-api mode skips the git path entirely — so the enrichment now helps the local/dev diagnosability path.

Self-certified chore (single-file, additive-only observability, no behavior change, no new API). tsc + eslint clean.

Relates t/2653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)