### PR TITLE
fix(prefs): use @bridge alias so web persists view mode (not electron stub) (t/2651)

### DIFF
--- a/taxonomy-editor/src/renderer/store/preferencesStore.ts
+++ b/taxonomy-editor/src/renderer/store/preferencesStore.ts
@@ -18,7 +18,7 @@ export const usePreferencesStore = create<PreferencesState>()((set) => ({
   setViewMode: async (mode: ViewMode) => {
     set({ viewMode: mode });
     try {
-      const { api } = await import('../bridge/index');
+      const { api } = await import('@bridge'); // alias — resolves to web-bridge on web, electron-bridge on desktop (t/2651)
       await api.setPreferences({ viewMode: mode });
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'preferencesStore', level: 'error', message: 'Failed to persist view mode preference', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
@@ -27,7 +27,7 @@ export const usePreferencesStore = create<PreferencesState>()((set) => ({
 
   hydrate: async () => {
     try {
-      const { api } = await import('../bridge/index');
+      const { api } = await import('@bridge'); // alias — resolves to web-bridge on web, electron-bridge on desktop (t/2651)
       const prefs: UserPreferences | null = await api.getPreferences();
       if (prefs?.viewMode) {
         set({ viewMode: prefs.viewMode });


### PR DESCRIPTION
**Root cause of the web-container `setPreferences undefined` error** (Diagnostics t/2651). `preferencesStore.setViewMode` + `hydrate` did `await import('../bridge/index')` — a hardcoded relative path that **always** resolves to `bridge/index.ts` (the electron bridge). The vite web-alias (`@bridge` → `web-bridge.ts`) only swaps `@bridge` specifiers, so on web these imports loaded the **electron** bridge, whose `setPreferences` does `window.electronAPI.setPreferences?.(prefs)` — and `window.electronAPI` is undefined on web → `Cannot read properties of undefined (reading 'setPreferences')` ~3.4s after load. View-mode pref never persisted; `hydrate` silently failed to load it too.

Fix: import from `@bridge` in both call sites → web-bridge (PUT/GET `/api/preferences`) on web, electron-bridge on desktop. Verified `preferencesStore` was the **only** renderer file with a relative `bridge/index` import (not systemic).

Verify: renderer tsc clean · eslint 0 · **web build OK** (@bridge → web-bridge). Self-cert /trivial-change (2-line import correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)