### PR TITLE
feat(debate-diagnostics): add Arg Strength tab (t/2658)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/DiagnosticsWindow.tsx
@@ -247,6 +247,7 @@ function buildDebateSection(debate: DebateSession, hasAn: boolean, hasCommitment
   return { header: 'DEBATE', tabs: [
     { id: 'topic-scope', label: 'Topic Scope', visible: !!debate.topic?.scope },
     { id: 'argument-network', label: 'Arg Net', visible: hasAn },
+    { id: 'arg-strength', label: 'Arg Strength', visible: hasAn },
     { id: 'commitments', label: 'Commitments', visible: hasCommitments },
     { id: 'transcript', label: `Transcript (${debate.transcript.filter(e => e.type === 'statement' || e.type === 'opening').length} stmts / ${debate.transcript.length} total)`, visible: true },
     { id: 'convergence', label: `Convergence (${debate.convergence_signals?.length ?? 0})`, visible: !!(debate.convergence_signals && debate.convergence_signals.length > 0) },

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/OverviewTabRouter.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/OverviewTabRouter.tsx
@@ -13,6 +13,7 @@ import type { OverviewTab, UtilitySnapshot } from './types';
 import { UTILITY_WEIGHTS } from './types';
 
 import { ArgumentNetworkTab } from './overview-tabs';
+import { ArgStrengthTab } from './overview-tabs';
 import { AdaptiveStagingTab } from './overview-tabs';
 import { ReflectionsTab } from './overview-tabs';
 import { UtilityTab } from './overview-tabs';
@@ -459,6 +460,35 @@ function ArgumentNetworkSection({
       setAnFilterMode={setAnFilterMode}
       setAnFilterNodeId={setAnFilterNodeId}
       focusedNodeId={focusedNodeId}
+      handleUpdateSubScore={handleUpdateSubScore}
+      setOverviewTab={setOverviewTab}
+      setSelectedEntry={setSelectedEntry}
+      setLocalOverride={setLocalOverride}
+      nodeLabels={nodeLabels}
+    />
+  );
+}
+
+interface ArgStrengthSectionProps {
+  debate: DebateSession;
+  an: { nodes: ArgumentNetworkNode[]; edges: ArgumentNetworkEdge[] } | undefined;
+  effectiveOverviewTab: OverviewTab;
+  handleUpdateSubScore: (nodeId: string, key: string, value: number) => void;
+  setOverviewTab: (tab: OverviewTab) => void;
+  setSelectedEntry: (id: string | null) => void;
+  setLocalOverride: (v: boolean) => void;
+  nodeLabels: Map<string, string>;
+}
+
+function ArgStrengthSection({
+  debate, an, effectiveOverviewTab, handleUpdateSubScore, setOverviewTab, setSelectedEntry,
+  setLocalOverride, nodeLabels,
+}: ArgStrengthSectionProps) {
+  if (effectiveOverviewTab !== 'arg-strength' || !an || an.nodes.length === 0) return null;
+  return (
+    <ArgStrengthTab
+      debate={debate}
+      an={an}
       handleUpdateSubScore={handleUpdateSubScore}
       setOverviewTab={setOverviewTab}
       setSelectedEntry={setSelectedEntry}
@@ -1039,6 +1069,18 @@ export function OverviewTabRouter({
         setAnFilterMode={setAnFilterMode}
         setAnFilterNodeId={setAnFilterNodeId}
         focusedNodeId={focusedNodeId}
+        handleUpdateSubScore={handleUpdateSubScore}
+        setOverviewTab={setOverviewTab}
+        setSelectedEntry={setSelectedEntry}
+        setLocalOverride={setLocalOverride}
+        nodeLabels={nodeLabels}
+      />
+
+      {/* Arg Strength — AN reorganized by POV, sorted by QBAF score */}
+      <ArgStrengthSection
+        debate={debate}
+        an={an}
+        effectiveOverviewTab={effectiveOverviewTab}
         handleUpdateSubScore={handleUpdateSubScore}
         setOverviewTab={setOverviewTab}
         setSelectedEntry={setSelectedEntry}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
@@ -1,0 +1,75 @@
+/* ArgStrengthTab — ast-* prefix (t/2658) */
+
+.ast-root {
+  padding: 12px;
+}
+
+.ast-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+}
+
+.ast-expand-btn {
+  font-size: var(--text-xs);
+  padding: 2px 8px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.ast-expand-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.ast-pov-section {
+  margin-bottom: 20px;
+}
+
+.ast-pov-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 6px 0 4px;
+  border-bottom: 2px solid var(--border-color);
+  margin-bottom: 4px;
+}
+
+.ast-pov-label {
+  font-weight: 700;
+  font-size: var(--text-sm);
+  letter-spacing: 0.02em;
+}
+
+.ast-pov-stats {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.ast-node-wrap {
+  position: relative;
+}
+
+.ast-rank-badge {
+  position: absolute;
+  right: 0;
+  top: 8px;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  padding: 1px 5px;
+  border: 1px solid;
+  border-radius: 3px;
+  opacity: 0.75;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.ast-empty {
+  padding: 24px;
+  color: var(--text-muted);
+  font-style: italic;
+  text-align: center;
+}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import React, { useState, useMemo } from 'react';
+import './ArgStrengthTab.css';
+import type { DebateSession, ArgumentNetworkNode, ArgumentNetworkEdge } from '../../../../types/debate';
+import { computeQbafStrengths } from '@lib/debate/qbaf';
+import type { QbafNode, QbafEdge } from '@lib/debate/qbaf';
+import { INodeRow } from '../shared/INodeRow';
+import { speakerLabel } from '../helpers';
+import type { OverviewTab } from '../types';
+import { POV_META, type PovMetaKey } from '@lib/electron-shared/povMeta';
+
+interface ArgStrengthTabProps {
+  debate: DebateSession;
+  an: { nodes: ArgumentNetworkNode[]; edges: ArgumentNetworkEdge[] };
+  handleUpdateSubScore: (nodeId: string, key: string, value: number) => void;
+  setOverviewTab: (tab: OverviewTab) => void;
+  setSelectedEntry: (id: string | null) => void;
+  setLocalOverride: (v: boolean) => void;
+  nodeLabels: Map<string, string>;
+}
+
+const POV_ORDER = ['accelerationist', 'safetyist', 'skeptic'] as const;
+
+export function ArgStrengthTab({
+  debate, an, handleUpdateSubScore, setOverviewTab, setSelectedEntry, setLocalOverride, nodeLabels,
+}: ArgStrengthTabProps) {
+  const [allExpanded, setAllExpanded] = useState(false);
+  const edges = an.edges ?? [];
+
+  const stmtIdByEntry = useMemo(() => {
+    const m = new Map<string, string>();
+    debate.transcript.forEach((e, i) => m.set(e.id, `S${i + 1}`));
+    return m;
+  }, [debate.transcript]);
+
+  const strengthMap = useMemo(() => {
+    const qbafNodes: QbafNode[] = an.nodes.map(n => ({ id: n.id, base_strength: n.base_strength ?? 0.5 }));
+    const qbafEdges: QbafEdge[] = edges.map(e => ({
+      source: e.source,
+      target: e.target,
+      type: e.type as 'attacks' | 'supports',
+      weight: e.weight ?? 0.5,
+      attack_type: e.attack_type,
+    }));
+    return computeQbafStrengths(qbafNodes, qbafEdges).strengths;
+  }, [an.nodes, edges]);
+
+  const nodesByPov = useMemo(() => {
+    const map = new Map<string, ArgumentNetworkNode[]>();
+    for (const n of an.nodes) {
+      if (!map.has(n.speaker)) map.set(n.speaker, []);
+      map.get(n.speaker)!.push(n);
+    }
+    for (const [, nodes] of map) {
+      nodes.sort(
+        (a, b) =>
+          (strengthMap.get(b.id) ?? b.base_strength ?? 0.5) -
+          (strengthMap.get(a.id) ?? a.base_strength ?? 0.5),
+      );
+    }
+    return map;
+  }, [an.nodes, strengthMap]);
+
+  if (an.nodes.length === 0) {
+    return <div className="ast-empty">No argument network data for this debate.</div>;
+  }
+
+  const orderedPovs = [
+    ...POV_ORDER.filter(p => nodesByPov.has(p)),
+    ...[...nodesByPov.keys()].filter(p => !(POV_ORDER as readonly string[]).includes(p)),
+  ];
+
+  return (
+    <div className="ast-root">
+      <div className="ast-toolbar">
+        <button onClick={() => setAllExpanded(!allExpanded)} className="ast-expand-btn">
+          {allExpanded ? 'Collapse All' : 'Expand All'}
+        </button>
+      </div>
+      {orderedPovs.map(pov => {
+        const nodes = nodesByPov.get(pov) ?? [];
+        const avgStrength =
+          nodes.length > 0
+            ? nodes.reduce((s, n) => s + (strengthMap.get(n.id) ?? n.base_strength ?? 0.5), 0) /
+              nodes.length
+            : 0;
+        const cssVar = POV_META[pov as PovMetaKey]?.cssVar ?? '--text-primary';
+        return (
+          <div key={pov} className="ast-pov-section">
+            <div className="ast-pov-header">
+              {/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}
+              <span className="ast-pov-label" style={{ color: `var(${cssVar})` }}>
+                {speakerLabel(pov)}
+              </span>
+              <span className="ast-pov-stats">
+                {nodes.length} argument{nodes.length !== 1 ? 's' : ''} · avg{' '}
+                {avgStrength.toFixed(2)}
+              </span>
+            </div>
+            {nodes.map((n, idx) => {
+              const attacks = edges.filter(e => e.target === n.id && e.type === 'attacks');
+              const supports = edges.filter(e => e.target === n.id && e.type === 'supports');
+              const isSource = edges.some(e => e.source === n.id);
+              const rank = idx < 3 ? idx + 1 : null;
+              return (
+                <div key={n.id} className="ast-node-wrap">
+                  {rank != null && (
+                    <span
+                      className="ast-rank-badge"
+                      title={`#${rank} strongest ${speakerLabel(pov)} argument`}
+                      // eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar
+                      style={{ color: `var(${cssVar})`, borderColor: `var(${cssVar})` }}
+                    >
+                      #{rank}
+                    </span>
+                  )}
+                  <INodeRow
+                    node={n}
+                    attacks={attacks}
+                    supports={supports}
+                    allNodes={an.nodes}
+                    allEdges={edges}
+                    isSource={isSource}
+                    computedStrength={strengthMap.get(n.id)}
+                    strengthMap={strengthMap}
+                    statementId={stmtIdByEntry.get(n.source_entry_id)}
+                    onGotoEntry={(eid) => {
+                      setOverviewTab('transcript');
+                      setSelectedEntry(eid);
+                      setLocalOverride(true);
+                    }}
+                    stmtIdByEntry={stmtIdByEntry}
+                    focused={false}
+                    onUpdateSubScore={handleUpdateSubScore}
+                    nodeLabels={nodeLabels}
+                    defaultExpanded={allExpanded}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/index.ts
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/index.ts
@@ -4,5 +4,6 @@
 export { AdaptiveStagingTab } from './AdaptiveStagingTab';
 export { ReflectionsTab } from './ReflectionsTab';
 export { ArgumentNetworkTab } from './ArgumentNetworkTab';
+export { ArgStrengthTab } from './ArgStrengthTab';
 export { UtilityTab } from './UtilityTab';
 export { EmotionalRegisterTab } from './EmotionalRegisterTab';

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/types.ts
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/types.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-export type OverviewTab = 'topic-scope' | 'extraction' | 'argument-network' | 'commitments' | 'transcript' | 'convergence' | 'reflections' | 'gaps' | 'grounding' | 'lineage' | 'adaptive' | 'pov-progression' | 'fr-context' | 'prompt-diff' | 'utility' | 'exclusion-overview' | 'emotional-register';
+export type OverviewTab = 'topic-scope' | 'extraction' | 'argument-network' | 'arg-strength' | 'commitments' | 'transcript' | 'convergence' | 'reflections' | 'gaps' | 'grounding' | 'lineage' | 'adaptive' | 'pov-progression' | 'fr-context' | 'prompt-diff' | 'utility' | 'exclusion-overview' | 'emotional-register';
 
 export type EntryTab = 'tax-refs' | 'details' | 'claims' | 'evidence' | 'citations' | 'brief' | 'plan' | 'draft' | 'lookahead' | 'cite' | 'moderator' | 'exclusion' | 'affect';
 

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/useDiagnosticsState.ts
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/useDiagnosticsState.ts
@@ -580,6 +580,7 @@ export function useDiagnosticsState(initialData?: Record<string, unknown>) {
     const tabVisibility: Record<OverviewTab, boolean> = {
       'topic-scope': !!debate.topic?.scope,
       'argument-network': hasAn,
+      'arg-strength': hasAn,
       'commitments': hasCommitments,
       'transcript': true,
       'extraction': true,


### PR DESCRIPTION
## Summary
- Adds **Arg Strength** sidebar tab immediately below **Arg Net** in the diagnostics window
- Groups argument network nodes by POV (accelerationist → safetyist → skeptic), sorted descending by QBAF computed strength score
- Top-3 nodes per POV display a `#1`/`#2`/`#3` rank badge
- Reuses `INodeRow` for full expandable ATTACK/SUPPORT drilldown per argument

## Files changed
- `ArgStrengthTab.tsx` + `ArgStrengthTab.css` — new component (`ast-*` CSS prefix)
- `types.ts` — added `'arg-strength'` to `OverviewTab` union
- `overview-tabs/index.ts` — re-exports `ArgStrengthTab`
- `DiagnosticsWindow.tsx` — sidebar entry after `argument-network`
- `OverviewTabRouter.tsx` — `ArgStrengthSection` render path
- `useDiagnosticsState.ts` — `'arg-strength': hasAn` in `tabVisibility`

## Test plan
- [ ] Renderer TSC: 0 errors (`check-renderer-tsc.sh`)
- [ ] ESLint: under 4256 warning ceiling
- [ ] Open diagnostics window on a debate with argument network data → **Arg Strength** appears in sidebar after **Arg Net**
- [ ] Nodes grouped by POV, each section sorted by QBAF strength descending
- [ ] Top 3 per POV show `#1`/`#2`/`#3` badges
- [ ] Expand All / Collapse All toggles drilldown rows
- [ ] Clicking "go to statement" navigates to transcript entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)