### PR TITLE
feat(infra): add staging-state isolation mount + RO flip param (t/2643)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -51,6 +51,14 @@ param trafficPinRevisionName string = ''
 @description('Full name of the revision to hold 100% STAGING ingress traffic on during a Bicep apply. Empty = first/only staging deploy (latest gets 100%).')
 param trafficPinRevisionNameStaging string = ''
 
+// ── Staging write-isolation (t/2643) ──
+// Set stagingSharedReadOnly=true as the FINAL step of the isolation deployment,
+// AFTER arm-B verification confirms class-A writes route to /mnt/staging-state.
+// The RO flip makes the hard boundary live: missed write sites EROFS instead of
+// silently mutating prod. Deploy order matters — see t/2643#5/#6.
+@description('Flip /mnt/shared to read-only on staging (ARM step 3 of t/2643 isolation). Apply ONLY after arm-B verification passes with /mnt/shared still RW.')
+param stagingSharedReadOnly bool = false
+
 // ── Resource Tags ──
 var tags = {
   project: 'ai-triad-research'
@@ -402,6 +410,24 @@ resource envStorageStagingState 'Microsoft.App/managedEnvironments/storages@2024
   dependsOn: [stagingStateShare]
 }
 
+// Read-only registration of the shared taxonomy-data share.
+// Always provisioned so the RO flip (stagingSharedReadOnly=true) is a
+// single-param redeploy — no resource creation race at flip time.
+// Arm A verification: with staging referencing this, a write to /mnt/shared
+// must fail with EACCES/EPERM (Azure Files surfaces RO writes as EACCES).
+resource envStorageSharedRO 'Microsoft.App/managedEnvironments/storages@2024-03-01' = {
+  parent: containerAppEnv
+  name: 'taxonomy-data-ro'
+  properties: {
+    azureFile: {
+      accountName: storageAccount.name
+      accountKey: storageAccount.listKeys().keys[0].value
+      shareName: 'taxonomy-data'
+      accessMode: 'ReadOnly'
+    }
+  }
+}
+
 // ── Container App ──
 
 var baseEnv = [
@@ -609,6 +635,9 @@ resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
   identity: {
     type: 'SystemAssigned'
   }
+  // storageName strings create no implicit dependency — explicit dependsOn ensures
+  // both managed env storage registrations exist before the container app is deployed.
+  dependsOn: [envStorageStagingState, envStorageSharedRO]
   properties: {
     managedEnvironmentId: containerAppEnv.id
     configuration: {
@@ -666,7 +695,12 @@ resource containerAppStaging 'Microsoft.App/containerApps@2024-03-01' = {
         {
           name: 'shared-data'
           storageType: 'AzureFile'
-          storageName: 'taxonomy-data'
+          // RO flip (step 3): deploy with stagingSharedReadOnly=true AFTER arm-B
+          // confirms class-A writes route to /mnt/staging-state. The -ro registration
+          // (ReadOnly accessMode) makes the hard boundary live: any missed write site
+          // fails with EACCES rather than silently mutating prod (t/2643#3 cond 3,
+          // t/2643#5 binding correction — RO must come last, never before getStateRoot).
+          storageName: stagingSharedReadOnly ? 'taxonomy-data-ro' : 'taxonomy-data'
         }
         {
           // Staging-isolated RW share for class-A state (t/2643).


### PR DESCRIPTION
## Summary

**Paired with PR #1043 (ServerAPI `getStateRoot()` code) — both must merge together. Neither merges before TL GV + runtime both-arms pass.**

Completes the DevOps half of t/2643 staging→prod Azure Files write isolation. Adds the RO flip mechanism on top of steps 1-2 (already on main via PR #1044 MERGED).

### What this adds

- **`envStorageSharedRO`** — ReadOnly managed-env-storage for `taxonomy-data` share. Always provisioned (not conditional) so the RO flip is a single-param redeploy with no resource-creation race.
- **`stagingSharedReadOnly` param** (bool, default `false`) — the step-3 RO flip switch. Set `true` ONLY after arm-B passes with `/mnt/shared` still RW (t/2643#5/#6 binding constraint).
- **Staging `shared-data` volume ternary**: `storageName: stagingSharedReadOnly ? 'taxonomy-data-ro' : 'taxonomy-data'`
- **`dependsOn: [envStorageStagingState, envStorageSharedRO]`** on staging container app — string `storageName` references carry no implicit Bicep dependency.

### Already on main (not changed here)
`stagingStateShare`, `envStorageStagingState`, `stagingContainerEnv` (with `AI_TRIAD_STATE_ROOT`, `TAXONOMY_CACHE_DIR=/mnt/staging-state/cache`, `GIT_SYNC_ENABLED=0`, `GITHUB_BRANCH=staging`), and the `staging-state` volume mount (all via #1044/#1047).

### Prod diff
Zero — prod container app untouched at both `stagingSharedReadOnly=false` and `stagingSharedReadOnly=true`.

## Deployment sequence (t/2643#5/#6 — write freeze stays ON through steps 1-2)

1. Merge #1054 + #1043. Deploy with `stagingSharedReadOnly=false` (default). `/mnt/shared` stays RW.
2. **Arm-B (while RW):** all class-A write triggers on staging (flag flip + runtime-config + key write + debate smoke + proposal save). Confirm `/mnt/shared/admin/feature-flags.json` byte-identical on prod. Any write on `/mnt/shared` = stop-the-line.
3. **RO flip:** redeploy with `stagingSharedReadOnly=true`. Smoke-boot. **Arm-A:** staging write to `/mnt/shared` → must fail EACCES/EPERM.
4. Both-arms GV → unfreeze (also requires t/2650 closed — all code already landed).

## Open confirmations before RO flip (t/2643#14)
- Staging runs `STORAGE_MODE=github-api` (gates backend-writer severity split)
- `AZURE_STORAGE_ACCOUNT_URL` set on staging (analytics fs-fallback stays in Blob)

## Test plan
- [ ] CI green
- [ ] `az deployment group what-if` → zero diff on `taxonomy-editor` prod app (at both param values)
- [ ] Arm-B: all class-A write triggers leave `/mnt/shared` byte-unchanged
- [ ] Arm-A: staging write to `/mnt/shared` fails EACCES/EPERM post-RO-flip

Implements: t/2643
Paired PR: #1043 (ServerAPI `getStateRoot()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)