### PR TITLE
fix(flags): RMW-with-precondition — stop the multi-replica lost-update clobber (t/2644)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/featureFlagsRmw.test.ts
+++ b/taxonomy-editor/src/server/__tests__/featureFlagsRmw.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+//
+// t/2644 — featureFlags lost-update race. Prod runs 2 replicas, each with its own 30s cache.
+// The old write path re-serialized a (possibly stale) whole cache, so a stale-cache replica's
+// write clobbered another replica's committed change at FILE granularity — the env-web-opeds
+// revert bounced back to true. Fix: read-modify-write against FRESH file state (merge only the
+// target flag) + a content-hash precondition with bounded retry + atomic temp→rename.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { setFlag, getFlagMetadata, _resetFlagCache } from '../featureFlags.js';
+
+let dataRoot: string;
+const SAVED: Record<string, string | undefined> = {};
+const flagsFile = () => path.join(dataRoot, 'admin', 'feature-flags.json');
+const auditFile = () => path.join(dataRoot, 'admin', 'feature-flags-audit.ndjson');
+const readDisk = () => JSON.parse(fs.readFileSync(flagsFile(), 'utf-8')) as { flags: Record<string, { enabled: boolean }> };
+
+beforeEach(() => {
+  dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ffrmw-'));
+  for (const k of ['AI_TRIAD_DATA_ROOT', 'AI_TRIAD_STATE_ROOT', 'ADMIN_USERS']) SAVED[k] = process.env[k];
+  delete process.env.AI_TRIAD_STATE_ROOT;
+  process.env.AI_TRIAD_DATA_ROOT = dataRoot; // getStateRoot() defaults to getDataRoot() when STATE_ROOT unset
+  process.env.ADMIN_USERS = 'jpsnover';
+  _resetFlagCache();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const k of ['AI_TRIAD_DATA_ROOT', 'AI_TRIAD_STATE_ROOT', 'ADMIN_USERS']) {
+    if (SAVED[k] === undefined) delete process.env[k]; else process.env[k] = SAVED[k];
+  }
+  fs.rmSync(dataRoot, { recursive: true, force: true });
+  _resetFlagCache();
+});
+
+describe('t/2644 — RMW anti-clobber', () => {
+  it('EXACT incident repro: a stale-cache write to flag Y does NOT clobber flag X\'s committed revert', () => {
+    // 1. This replica flips X=true → disk has X:true, and this process's _cache now holds X:true.
+    setFlag('env-web-opeds', { enabled: true, scope: 'env:web' });
+    expect(readDisk().flags['env-web-opeds'].enabled).toBe(true);
+
+    // 2. ANOTHER replica reverts X→false directly on disk. This process's _cache stays STALE (true) —
+    //    it never observed the revert (the exact multi-replica condition).
+    const disk = readDisk();
+    disk.flags['env-web-opeds'].enabled = false;
+    fs.writeFileSync(flagsFile(), JSON.stringify(disk, null, 2));
+
+    // 3. This (stale-cache) replica now writes an UNRELATED flag Y.
+    setFlag('some-other-flag', { enabled: true, scope: 'global' });
+
+    // 4. The RMW merged onto FRESH disk state → X's committed revert SURVIVES; Y is added.
+    const after = readDisk();
+    expect(after.flags['env-web-opeds'].enabled).toBe(false); // ← the revert is NOT bounced back to true
+    expect(after.flags['some-other-flag'].enabled).toBe(true);
+  });
+
+  it('a persistent concurrent writer surfaces a visible error after bounded retries (not a silent clobber)', () => {
+    // Seed a real file so the first fresh read parses.
+    setFlag('seed', { enabled: true, scope: 'global' });
+    _resetFlagCache();
+
+    // Simulate a writer that commits on EVERY read → the content-hash precondition can never match,
+    // so the RMW must exhaust its retries and throw (visible), never silently write a stale view.
+    let n = 0;
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      Buffer.from(JSON.stringify({ flags: { seed: { name: 'seed', enabled: true, scope: 'global', created_at: 'c', updated_at: 'u' } }, _race: n++ })),
+    );
+    expect(() => setFlag('x', { enabled: true, scope: 'global' })).toThrow(/could not commit|concurrent/i);
+  });
+
+  it('appends exactly one audit entry per successful RMW write', () => {
+    setFlag('a', { enabled: true, scope: 'global' }, 'jpsnover');
+    setFlag('b', { enabled: false, scope: 'global' }, 'jpsnover');
+    const audit = fs.readFileSync(auditFile(), 'utf-8').trim().split('\n').map(l => JSON.parse(l));
+    expect(audit.map(e => e.flag)).toEqual(['a', 'b']);
+    expect(audit[0]).toMatchObject({ action: 'set', flag: 'a', by: 'jpsnover' });
+    _resetFlagCache();
+    expect(getFlagMetadata('a')?.enabled).toBe(true); // committed + readable
+  });
+});

--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -188,10 +188,15 @@ function getConfig(): FlagsConfig {
 // bounced back to true). Fix: every write re-reads the file FRESH, merges ONLY the target flag,
 // and commits atomically — retrying if a concurrent writer changed the file since our read. A
 // content hash (not mtime) is the precondition, so it's independent of Azure Files mtime
-// resolution and detects a same-tick concurrent commit. Cross-flag writes never clobber; the
-// only residual is two writers hitting the SAME flag in the same instant (last-writer-wins on
-// that one flag — acceptable; not the cross-flag data-loss the incident was). Reads stay
-// 30s-cached, so cross-replica propagation of a committed change is bounded at ≤30s.
+// resolution and detects a same-tick concurrent commit. This makes the file-granularity clobber
+// (the incident) vanishingly unlikely — a stale replica writing flag Y re-reads and preserves
+// flag X's committed change. TWO residuals remain (both negligible at the human admin-flip rate):
+//   (1) DOMINANT: two writers hitting the SAME flag in the same instant → last-writer-wins on
+//       that one flag (acceptable; NOT the cross-flag file-granularity data-loss the incident was);
+//   (2) a sub-µs check-then-rename TOCTOU: two writers (even on different flags) can both pass the
+//       hash check before either renames → the earlier rename is dropped. The commit stages the
+//       temp file BEFORE the precondition check (below) so this window is only the rename itself.
+// Reads stay 30s-cached, so cross-replica propagation of a committed change is bounded at ≤30s.
 const MAX_RMW_ATTEMPTS = 5;
 
 /** sha256 of the current on-disk flags file, or '' if absent. Single-fd (t/2019 race-safe). */
@@ -235,12 +240,13 @@ function rmwFlags<T>(apply: (fresh: FlagsConfig) => RmwApply<T>): T {
     const { config: fresh, hash } = readFreshFlags();
     const applied = apply(fresh);
     if (applied.config === null) return applied.result; // no write needed
-    // Precondition: if the file changed since our fresh read, a concurrent writer committed →
-    // retry the full read-merge (so we merge onto their change, not clobber it).
-    if (currentFlagsHash() !== hash) continue;
-    // Atomic commit: temp in the SAME directory (same fs → no EXDEV) then rename.
+    // Stage the new file FIRST (the expensive step: write to a temp in the SAME directory — same
+    // fs, no EXDEV), THEN re-check the precondition immediately before the rename, so the
+    // check→commit TOCTOU window is only the rename call (t/2644 TL GV). If the file changed since
+    // our fresh read, a concurrent writer committed → drop the temp and retry the full read-merge.
     const tmp = `${p}.tmp-${process.pid}-${attempt}`;
     fs.writeFileSync(tmp, JSON.stringify(applied.config, null, 2));
+    if (currentFlagsHash() !== hash) { fs.rmSync(tmp, { force: true }); continue; }
     fs.renameSync(tmp, p);
     _cache = applied.config;
     _cacheMtime = -1; // force a fresh stat on next read (mtime changed)

--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -23,6 +23,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import crypto from 'crypto';
 import { getStateRoot } from './config.js';
 import { log } from './logger.js';
 import { getCurrentUser } from './security/userContext.js';
@@ -179,12 +180,77 @@ function getConfig(): FlagsConfig {
   return _cache ?? loadConfig();
 }
 
-function persist(config: FlagsConfig): void {
+// ── Writes: read-modify-write with a content-hash precondition (t/2644) ──
+//
+// Prod runs multiple replicas, each with its own 30s `_cache`. The old write path serialized
+// that (possibly stale) whole cache back to the file, so a stale-cache replica's write silently
+// clobbered another replica's committed change at FILE granularity (the env-web-opeds revert
+// bounced back to true). Fix: every write re-reads the file FRESH, merges ONLY the target flag,
+// and commits atomically — retrying if a concurrent writer changed the file since our read. A
+// content hash (not mtime) is the precondition, so it's independent of Azure Files mtime
+// resolution and detects a same-tick concurrent commit. Cross-flag writes never clobber; the
+// only residual is two writers hitting the SAME flag in the same instant (last-writer-wins on
+// that one flag — acceptable; not the cross-flag data-loss the incident was). Reads stay
+// 30s-cached, so cross-replica propagation of a committed change is bounded at ≤30s.
+const MAX_RMW_ATTEMPTS = 5;
+
+/** sha256 of the current on-disk flags file, or '' if absent. Single-fd (t/2019 race-safe). */
+function currentFlagsHash(): string {
+  try {
+    const fd = fs.openSync(flagsPath(), 'r');
+    try { return crypto.createHash('sha256').update(fs.readFileSync(fd)).digest('hex'); }
+    finally { fs.closeSync(fd); }
+  } catch (err) {
+    // ENOENT (no flags file yet) → '' hash; any other error re-throws to the recording caller. telemetry — silent by design for the ENOENT path.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return '';
+    throw err;
+  }
+}
+
+/** Read the current on-disk flags FRESH (bypassing the 30s cache) + its content hash. */
+function readFreshFlags(): { config: FlagsConfig; hash: string } {
+  try {
+    const fd = fs.openSync(flagsPath(), 'r');
+    try {
+      const buf = fs.readFileSync(fd);
+      const data = JSON.parse(buf.toString('utf-8')) as Partial<FlagsConfig>;
+      return { config: { flags: { ...SEED_FLAGS, ...(data.flags ?? {}) } }, hash: crypto.createHash('sha256').update(buf).digest('hex') };
+    } finally { fs.closeSync(fd); }
+  } catch (err) {
+    // ENOENT (no flags file yet) → seed baseline; any other error re-throws to the recording caller. telemetry — silent by design for the ENOENT path.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { config: { flags: { ...SEED_FLAGS } }, hash: '' };
+    throw err;
+  }
+}
+
+type RmwApply<T> =
+  | { config: FlagsConfig; audit: FlagAuditEntry; result: T }  // commit + audit
+  | { config: null; result: T };                                // no-op (e.g. delete of an absent flag)
+
+/** Apply a single-flag mutation against fresh file state, retrying on a concurrent write. */
+function rmwFlags<T>(apply: (fresh: FlagsConfig) => RmwApply<T>): T {
   const p = flagsPath();
   fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, JSON.stringify(config, null, 2));
-  _cache = config;
-  _cacheMtime = -1; // force a fresh stat on next read (mtime changed)
+  for (let attempt = 0; attempt < MAX_RMW_ATTEMPTS; attempt++) {
+    const { config: fresh, hash } = readFreshFlags();
+    const applied = apply(fresh);
+    if (applied.config === null) return applied.result; // no write needed
+    // Precondition: if the file changed since our fresh read, a concurrent writer committed →
+    // retry the full read-merge (so we merge onto their change, not clobber it).
+    if (currentFlagsHash() !== hash) continue;
+    // Atomic commit: temp in the SAME directory (same fs → no EXDEV) then rename.
+    const tmp = `${p}.tmp-${process.pid}-${attempt}`;
+    fs.writeFileSync(tmp, JSON.stringify(applied.config, null, 2));
+    fs.renameSync(tmp, p);
+    _cache = applied.config;
+    _cacheMtime = -1; // force a fresh stat on next read (mtime changed)
+    appendAudit(applied.audit);
+    return applied.result;
+  }
+  throw new Error(
+    `feature-flags: could not commit a flag change to ${p} after ${MAX_RMW_ATTEMPTS} retries — ` +
+    'another replica is writing concurrently. Retry the change.',
+  );
 }
 
 function appendAudit(entry: FlagAuditEntry): void {
@@ -291,25 +357,28 @@ function mergeFlagDef(name: string, patch: Partial<FlagDef>, before: FlagDef | n
 
 /** Create or update a flag (admin). Persists + appends audit. Returns the def. */
 export function setFlag(name: string, patch: Partial<FlagDef>, by = '_local'): FlagDef {
-  const config = { flags: { ...getConfig().flags } };
-  const before = config.flags[name] ?? null;
-  const now = new Date().toISOString();
-  const def = mergeFlagDef(name, patch, before, now, by);
-  config.flags[name] = def;
-  persist(config);
-  appendAudit({ timestamp: now, action: 'set', flag: name, by, before, after: def });
-  return def;
+  // t/2644: merge onto FRESH file state (not the stale in-process cache) so a concurrent
+  // change to a DIFFERENT flag on another replica survives; the RMW retries on a race.
+  return rmwFlags((fresh) => {
+    const config = { flags: { ...fresh.flags } };
+    const before = config.flags[name] ?? null;
+    const now = new Date().toISOString();
+    const def = mergeFlagDef(name, patch, before, now, by);
+    config.flags[name] = def;
+    return { config, audit: { timestamp: now, action: 'set', flag: name, by, before, after: def }, result: def };
+  });
 }
 
 /** Delete a flag (admin). No-op if absent. Persists + appends audit. */
 export function deleteFlag(name: string, by = '_local'): boolean {
-  const config = { flags: { ...getConfig().flags } };
-  const before = config.flags[name];
-  if (!before) return false;
-  delete config.flags[name];
-  persist(config);
-  appendAudit({ timestamp: new Date().toISOString(), action: 'delete', flag: name, by, before, after: null });
-  return true;
+  // t/2644: existence is checked against FRESH state; absent → no-op (no write, no clobber).
+  return rmwFlags<boolean>((fresh) => {
+    const before = fresh.flags[name];
+    if (!before) return { config: null, result: false };
+    const config = { flags: { ...fresh.flags } };
+    delete config.flags[name];
+    return { config, audit: { timestamp: new Date().toISOString(), action: 'delete', flag: name, by, before, after: null }, result: true };
+  });
 }
 
 /** Flags whose updated_at is older than `daysOld` and have no expiry set. */


### PR DESCRIPTION
**Fixes the featureFlags lost-update race** (TL-approved design t/2644#3-reply). Prod runs 2 replicas, each with its own 30s `_cache`; `setFlag`/`deleteFlag` serialized that (possibly stale) whole cache back to the file, so a stale-cache replica's write clobbered another replica's committed change at **file granularity** — the `env-web-opeds` revert bounced back to `true`.

**Fix (proportionate to the rare admin-flip rate — no lock/cache infra, per the SO lean):**
- **Field-granular RMW:** `setFlag`/`deleteFlag` re-read the file **FRESH** (bypass the cache), merge **only** the target flag, then commit. A stale replica writing flag Y now re-reads → flag X's committed change survives.
- **Content-hash precondition + bounded retry (5×):** re-hash right before commit; a mismatch = a concurrent writer committed since our read → retry the read-merge. **Content hash (not mtime)** → independent of Azure Files mtime resolution; detects a same-tick commit. Exhaustion **throws a visible error** (never a silent stale write).
- **Atomic commit:** temp in the same dir (same fs → no EXDEV) → `rename`.
- **Residual (documented):** same-flag-same-tick last-writer-wins (acceptable — one-flag last-write, not the cross-flag data loss the incident was). Reads stay 30s-cached → ≤30s cross-replica propagation.

**Tests:** `featureFlagsRmw.test.ts` (3) — **exact incident repro** (stale-cache write to Y preserves X's committed revert); persistent concurrent writer → visible error after retries; one audit per write. `featureFlags.test.ts` (17) unchanged = backward compat. tsc + eslint clean.

**Routed to Main (TL) for both-arms Gate Verification.** Relates t/2644, t/2643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)