### PR TITLE
fix(devops): use splatting to pass -ForStaging switch in Sync-StagingEnv (t/2630)

### DIFF
--- a/operations/devops/Sync-StagingEnv.ps1
+++ b/operations/devops/Sync-StagingEnv.ps1
@@ -28,7 +28,9 @@ if (-not $BicepPath) {
 }
 
 $isStaging = $AppName -like '*-staging*'
-$BicepEnv = & (Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1') -BicepPath $BicepPath $(if ($isStaging) { '-ForStaging' })
+$getEnvArgs = @{ BicepPath = $BicepPath }
+if ($isStaging) { $getEnvArgs['ForStaging'] = $true }
+$BicepEnv = & (Join-Path $PSScriptRoot 'Get-BicepBaseEnv.ps1') @getEnvArgs
 if ($BicepEnv.Count -eq 0) {
     Write-Error "Get-BicepBaseEnv.ps1 returned 0 entries — Bicep parse failed or baseEnv block is empty"
     exit 1


### PR DESCRIPTION
## Summary

- Sync-StagingEnv.ps1 used \ as an argument, which expands to the literal string '-ForStaging'. PowerShell tried to bind it positionally, but [switch]\ has no positional binding.
- Root cause: both StagingEnvSync test arms were failing with 'A positional parameter cannot be found that accepts argument -ForStaging', exiting 1 instead of 0/2.
- Fix: splat a hashtable (\ = @{ BicepPath = \ }; if (\) { \['ForStaging'] = \True }) so the switch is properly bound.

## Test plan

- [ ] CI 	est-powershell passes (both StagingEnvSync arms: pass exits 0, fire exits 2)
- [ ] BicepEnvDrift tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)