### PR TITLE
ci(devops): deactivate stale staging revisions after traffic promotion (t/2660)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -169,6 +169,26 @@ jobs:
             -RetryIntervalSec 10
           Write-Host "Staging traffic promoted to ${{ steps.new_revision.outputs.revision }}"
 
+      - name: Deactivate stale revisions (keep serving + prior rollback) (t/2660)
+        if: steps.smoke.outputs.passed == 'true'
+        continue-on-error: true  # cosmetic GC — must not red a successful deploy
+        shell: pwsh
+        run: |
+          # 30s drain window: prior revision may still be draining long-lived connections
+          Start-Sleep -Seconds 30
+          $serving = '${{ steps.new_revision.outputs.revision }}'
+          $prior   = '${{ steps.current_revision.outputs.revision }}'
+          $stale = az containerapp revision list `
+            --name '${{ env.CONTAINER_APP_NAME }}' -g '${{ env.RESOURCE_GROUP }}' `
+            --query '[?properties.trafficWeight==`0` && properties.active==`true`].name' `
+            -o json | ConvertFrom-Json | Where-Object { $_ -ne $prior }
+          foreach ($rev in $stale) {
+            az containerapp revision deactivate `
+              --name '${{ env.CONTAINER_APP_NAME }}' -g '${{ env.RESOURCE_GROUP }}' --revision $rev
+            Write-Host "Deactivated: $rev"
+          }
+          Write-Host "Active: $serving (serving)$(if ($prior) { ', ' + $prior + ' (rollback)' })"
+
       - name: Verify Bicep baseEnv on staging serving revision (t/2630)
         if: steps.smoke.outputs.passed == 'true'
         shell: pwsh


### PR DESCRIPTION
## Summary

- Adds a GC step to `deploy-staging.yml` that deactivates all 0%-traffic active revisions after a successful traffic promotion
- Keeps the serving revision + prior revision (rollback target) active; deactivates everything else
- 30s drain window before deactivation — prior revision may still be draining long-lived connections
- `continue-on-error: true` — cleanup failure must not red a successful deploy (TL requirement; also guards az-stderr false-red trap)

**Root cause this fixes**: ~50 stale active revisions accumulated over time (from Sync-StagingEnv drift-sync runs + image-swap deploys). When t/2643 Bicep storage changes propagated, ACA health-checked all active revisions — old incompatible `staging-151d3e7` entered a restart loop (2026-08-15 00:07-00:09Z).

## Test plan

- [ ] CI green
- [ ] First real deploy-staging run after merge: confirm serving + prior active, all others deactivated
- [ ] Confirm `continue-on-error` is respected if az list fails (cosmetic, deploy stays green)

Self-certified under /trivial-change: single file, DevOps scope, no new public API.
TL-approved at t/2660#1 (required fix: `continue-on-error: true` — applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Implements: t/2660
Design approval: t/2660#1 (TL, 2026-08-15)