### PR TITLE
obs(infra): staging + prod ContainerBackOff alert rules (t/2659)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -1181,6 +1181,85 @@ resource branchDivergence 'Microsoft.Insights/scheduledQueryRules@2023-03-15-pre
   }
 }
 
+// ── Staging ContainerBackOff Alert (t/2659) ──
+// Fires within 2 min on any ContainerBackOff or ContainerCrashing event on
+// taxonomy-editor-staging. Staging-specific so it can be distinguished from
+// the generic restartLoopAlert (all apps, 5+ threshold, 5-min eval).
+// Historical proof: staging-151d3e7 incident produced ContainerBackOff rows
+// in LA at 2026-08-15T00:13-00:23; query returned matching rows on a P7D
+// look-back (verified 2026-08-15). ContainerBackOff is the correct Reason_s —
+// ACA never emits the raw Kubernetes string "ImagePullBackOff" (see imagePullFailureAlert).
+
+resource stagingBackoffAlert 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
+  name: 'alert-staging-container-backoff'
+  location: location
+  tags: tags
+  properties: {
+    displayName: 'taxonomy-editor-staging — ContainerBackOff'
+    description: 'Staging container entered a restart loop. No direct user impact; investigate before next isolation deploy. (t/2659)'
+    severity: 1
+    enabled: true
+    scopes: [ logAnalytics.id ]
+    evaluationFrequency: 'PT1M'
+    windowSize: 'PT5M'
+    criteria: {
+      allOf: [
+        {
+          query: '''
+            ContainerAppSystemLogs_CL
+            | where ContainerAppName_s == "taxonomy-editor-staging"
+            | where Reason_s in ("ContainerBackOff", "ContainerCrashing")
+          '''
+          timeAggregation: 'Count'
+          operator: 'GreaterThan'
+          threshold: 0
+        }
+      ]
+    }
+    actions: {
+      actionGroups: budgetAlertConfigured ? [ restartAlertActionGroup.id ] : []
+    }
+  }
+}
+
+// ── Prod ContainerBackOff Alert (t/2659 — severity 0, direct user impact) ──
+// Same query as staging alert but scoped to taxonomy-editor (prod).
+// Severity 0 (Critical) because a prod restart loop means users cannot load the app.
+// Complements the generic restartLoopAlert (all apps, 5-restart threshold)
+// with faster per-minute detection and no restart-count threshold.
+
+resource prodBackoffAlert 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
+  name: 'alert-prod-container-backoff'
+  location: location
+  tags: tags
+  properties: {
+    displayName: 'taxonomy-editor PROD — ContainerBackOff (Critical)'
+    description: 'Production container entered a restart loop — direct user impact. Investigate immediately. (t/2659)'
+    severity: 0
+    enabled: true
+    scopes: [ logAnalytics.id ]
+    evaluationFrequency: 'PT1M'
+    windowSize: 'PT5M'
+    criteria: {
+      allOf: [
+        {
+          query: '''
+            ContainerAppSystemLogs_CL
+            | where ContainerAppName_s == "taxonomy-editor"
+            | where Reason_s in ("ContainerBackOff", "ContainerCrashing")
+          '''
+          timeAggregation: 'Count'
+          operator: 'GreaterThan'
+          threshold: 0
+        }
+      ]
+    }
+    actions: {
+      actionGroups: budgetAlertConfigured ? [ restartAlertActionGroup.id ] : []
+    }
+  }
+}
+
 // ── Ephemeral Runner Module ──
 module ephemeralRunner 'runner/runner.bicep' = {
   name: 'ephemeral-runner'


### PR DESCRIPTION
## Summary

- `alert-staging-container-backoff` (severity 1, PT1M eval, PT5M window): staging-specific ContainerBackOff/ContainerCrashing alert — distinguishable from the generic `restartLoopAlert` (all apps, 5+ threshold, 5-min eval)
- `alert-prod-container-backoff` (severity 0/Critical, PT1M eval, PT5M window): prod-specific, immediate threshold — faster detection than the generic alert

## Fire proof (historical)

Queried LA workspace `b5528873-0847-4864-a724-cb6f7b1cfdd8` with P7D look-back (2026-08-15):
- **Arm A (fires):** staging-151d3e7 incident produced 5+ `ContainerBackOff` rows at 2026-08-15T00:13-00:23 — query matched. Alert would have fired within 2 min of the first event.
- **Arm B (no noise):** staging-6afa5be-r2 (healthy, 30-min look-back) returned 0 rows.

## Design notes

- No new params — reuses `restartAlertActionGroup` (already uses `budgetAlertEmail`)
- Diagnostic settings already wired via `containerAppEnv.appLogsConfiguration` (no `diagnosticSettings` resource needed)
- `ContainerBackOff` is the correct ACA `Reason_s` — ACA never emits the raw Kubernetes string `ImagePullBackOff` (see `imagePullFailureAlert` comment)

## Self-cert

Self-certifying under TL's t/2659#2 explicit authorization (query logic and severity thresholds non-ambiguous; no TL GV routing required).
- Bicep builds cleanly (`az bicep build`) — warnings are pre-existing in `runner/runner.bicep`, zero in `main.bicep`
- Historical fire proof confirmed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Implements: t/2659