### PR TITLE
fix(fileIO): add ref:main to readEntities/readOrganizations/readOrganizationEdges (t/2662)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/entityStore.test.ts
+++ b/taxonomy-editor/src/server/__tests__/entityStore.test.ts
@@ -101,3 +101,70 @@ describe('entity store read path (t/1807)', () => {
     expect(mem2.readCount).toBe(1);
   });
 });
+
+// t/2662 regression: static registries must pin { ref: 'main' } so a cache miss
+// fetches from the base branch, not the caller's session branch (where these files
+// don't exist → 404 → empty panels).
+describe('static registry readers pin ref:main (t/2662)', () => {
+  type ReadCall = { path: string; opts: { ref?: string; optional?: boolean } | undefined };
+
+  function makeSpyBackend(
+    readCalls: ReadCall[],
+    responseFor: (p: string) => string | null,
+  ): StorageBackend {
+    return {
+      async readFile(filePath, opts) {
+        readCalls.push({ path: filePath, opts });
+        return responseFor(filePath);
+      },
+      async writeFile(): Promise<void> { /* stub */ },
+      async listDirectory(): Promise<string[]> { return []; },
+      async deleteFile(): Promise<void> { /* stub */ },
+      async fileExists(): Promise<boolean> { return false; },
+      async readBinaryFile(): Promise<Buffer | null> { return null; },
+      async writeBinaryFile(): Promise<void> { /* stub */ },
+    };
+  }
+
+  it('readEntities passes { ref: "main" } to readFile', async () => {
+    const calls: ReadCall[] = [];
+    const spy = makeSpyBackend(calls, p =>
+      p.replace(/\\/g, '/').endsWith('entities.json')
+        ? JSON.stringify({ entities: [] })
+        : null,
+    );
+    fileIO.setTaxonomyBackend(spy);
+    await fileIO.readEntities();
+    const call = calls.find(c => c.path.replace(/\\/g, '/').endsWith('entities.json'));
+    expect(call).toBeDefined();
+    expect(call!.opts?.ref).toBe('main');
+  });
+
+  it('readOrganizations passes { ref: "main" } to readFile', async () => {
+    const calls: ReadCall[] = [];
+    const spy = makeSpyBackend(calls, p =>
+      p.replace(/\\/g, '/').endsWith('organizations.json')
+        ? JSON.stringify([])
+        : null,
+    );
+    fileIO.setTaxonomyBackend(spy);
+    await fileIO.readOrganizations();
+    const call = calls.find(c => c.path.replace(/\\/g, '/').endsWith('organizations.json'));
+    expect(call).toBeDefined();
+    expect(call!.opts?.ref).toBe('main');
+  });
+
+  it('readOrganizationEdges passes { ref: "main" } to readFile', async () => {
+    const calls: ReadCall[] = [];
+    const spy = makeSpyBackend(calls, p =>
+      p.replace(/\\/g, '/').endsWith('organization_edges.json')
+        ? JSON.stringify({ edges: [] })
+        : null,
+    );
+    fileIO.setTaxonomyBackend(spy);
+    await fileIO.readOrganizationEdges();
+    const call = calls.find(c => c.path.replace(/\\/g, '/').endsWith('organization_edges.json'));
+    expect(call).toBeDefined();
+    expect(call!.opts?.ref).toBe('main');
+  });
+});

--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -508,7 +508,7 @@ export async function readLineageEnrichments(): Promise<Record<string, unknown>>
 export async function readOrganizations(): Promise<unknown | null> {
   try {
     const p = path.join(getTaxonomyDir(), 'organizations.json');
-    const raw = await backend.readFile(p);
+    const raw = await backend.readFile(p, { ref: 'main' });
     if (raw === null) return null;
     return JSON.parse(raw);
   } catch (err) {
@@ -526,7 +526,7 @@ export async function readOrganizations(): Promise<unknown | null> {
 export async function readOrganizationEdges(): Promise<OrganizationEdge[] | null> {
   try {
     const p = path.join(getTaxonomyDir(), 'organization_edges.json');
-    const raw = await backend.readFile(p);
+    const raw = await backend.readFile(p, { ref: 'main' });
     if (raw === null) return null;
     const data = JSON.parse(raw);
     return (data as { edges?: OrganizationEdge[] })?.edges ?? [];
@@ -583,7 +583,7 @@ export async function readEntities(): Promise<Entity[] | null> {
   }
   try {
     const p = path.join(getTaxonomyDir(), 'entities.json');
-    const raw = await backend.readFile(p);
+    const raw = await backend.readFile(p, { ref: 'main' });
     if (raw === null) return null;
     const data = JSON.parse(raw) as { entities?: Entity[] };
     const entities = data.entities ?? [];


### PR DESCRIPTION
## Summary

- `readEntities`, `readOrganizations`, `readOrganizationEdges` were calling `backend.readFile(p)` with no `opts.ref`, so a cache miss fetched at `getEffectiveRef()` = the caller's session branch → GitHub 404 → empty Entities/Organizations panels on prod
- Fix: add `{ ref: 'main' }` to all three, matching the existing pattern at `fileIO.ts:234` (`loadSyntheticCorpus`) and per `githubAPIBackend.ts:281-285` (t/684)
- Safe: all three files are static pipeline-curated data with no server write path; the session overlay (consulted first regardless of `ref`) is a no-op for them

FR-confirmed root cause (Diagnostics p/111#33). Self-certified /trivial-change (3 calls matching existing :234 pattern).

## Test plan

- [ ] CI green
- [ ] Prod re-check: Entities/Organizations panels populated after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)