### PR TITLE
fix(analyticsBlob): warn + rethrow on append failure (t/2664)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/analyticsBlob.test.ts
+++ b/taxonomy-editor/src/server/__tests__/analyticsBlob.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+//
+// t/2664 — BlobAnalyticsBackend.append failure signaling.
+// Verifies that a write failure is surfaced (console.error + rethrow) rather
+// than swallowed into a silent 200.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { BlobServiceClient } from '@azure/storage-blob';
+import { BlobAnalyticsBackend } from '../storage/analyticsBlob.js';
+
+function makeFakeServiceClient(appendError: Error): BlobServiceClient {
+  const fakeAppendBlobClient = {
+    createIfNotExists: vi.fn().mockResolvedValue({}),
+    appendBlock: vi.fn().mockRejectedValue(appendError),
+  };
+  const fakeContainerClient = {
+    getAppendBlobClient: vi.fn().mockReturnValue(fakeAppendBlobClient),
+  };
+  return {
+    getContainerClient: vi.fn().mockReturnValue(fakeContainerClient),
+  } as unknown as BlobServiceClient;
+}
+
+describe('BlobAnalyticsBackend.append failure signaling (t/2664)', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('emits console.error with greppable tag on write failure', async () => {
+    const error = new Error('403 AuthorizationFailure');
+    const backend = new BlobAnalyticsBackend({
+      accountUrl: 'https://test.blob.core.windows.net',
+      container: 'analytics',
+      serviceClient: makeFakeServiceClient(error),
+    });
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => { /* suppress output */ });
+    await expect(backend.append('2026-08-15', ['{"event":1}'])).rejects.toThrow();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('analytics-blob-append-failed'),
+      expect.anything(),
+    );
+  });
+
+  it('rethrows on write failure — does not swallow into silent success', async () => {
+    const error = new Error('503 ServiceUnavailable');
+    const backend = new BlobAnalyticsBackend({
+      accountUrl: 'https://test.blob.core.windows.net',
+      container: 'analytics',
+      serviceClient: makeFakeServiceClient(error),
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => { /* suppress output */ });
+    await expect(backend.append('2026-08-15', ['{"event":1}'])).rejects.toThrow('503 ServiceUnavailable');
+  });
+});

--- a/taxonomy-editor/src/server/storage/analyticsBlob.ts
+++ b/taxonomy-editor/src/server/storage/analyticsBlob.ts
@@ -55,11 +55,15 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
       const content = lines.join('\n') + '\n';
       await appendClient.appendBlock(content, Buffer.byteLength(content, 'utf-8'));
     } catch (err) {
+      const code = err instanceof RestError ? (err.code ?? String(err.statusCode)) : undefined;
+      // Greppable via `az containerapp logs` without a flight-recorder dump (t/2664)
+      console.error('[analytics-blob-append-failed]', { component: 'analytics-blob', date, code, error: String(err) });
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'analytics-blob', level: 'error',
         message: 'analytics blob append failed',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary
- `analyticsBlob.ts`: add `console.error('[analytics-blob-append-failed]', ...)` in the catch block — greppable via `az containerapp logs` without a flight-recorder dump
- Rethrow the error so the caller receives a failure signal instead of apparent success (silent void = silent 200)
- New `analyticsBlob.test.ts`: two regression tests verifying the tag is emitted and the error rethrows

## Cross-scope note
`analytics.ts:appendEvents` (Server Community) has docstring "Fire-and-forget safe — errors are recorded, not thrown." With this change, a blob backend failure now propagates through `appendEvents` to the route handler. Server Community should wrap `backend.append` in try/catch to maintain fire-and-forget at the route layer — or accept that a total infrastructure failure now surfaces as a 5xx. Flagging via ticket comment.

## Test plan
- [x] `npx vitest run src/server/__tests__/analyticsBlob.test.ts` — 2 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)