### PR TITLE
feat(ps): add Test-AnalyticsBackend round-trip diagnostic cmdlet (t/2668)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -111,6 +111,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Test-PersonaEndpoints` | Auth-gate regression matrix across anonymous/authenticated/admin personas |
 | `Test-ServiceWorkerHealth` | Parse deployed /sw.js for skipWaiting mode, denylist coverage, precache stats |
 | `Get-FreeTierStatus` | Live free-tier budget/usage report (live config + token consumption) |
+| `Test-AnalyticsBackend` | Analytics storage round-trip probe — POST synthetic event, wait, GET query, verify event appears; confirms write failures in <60s (t/2668) |
 | `Test-AzureHealth` | Azure infra status |
 | `Test-GitHubHealth` | GitHub platform + CI status |
 | `Test-AIApiKey` | Probe AI backend auth endpoints (no tokens consumed) — confirm a key is present and accepted before running jobs |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -132,6 +132,7 @@
         'Invoke-DebateBatch'
         'Get-FreeTierStatus'
         'Invoke-TaxEditorSmokeTest'
+        'Test-AnalyticsBackend'
         'Test-AzureHealth'
         'Test-GitHubHealth'
         'Get-TaxEditorRevision'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -849,6 +849,8 @@ Export-ModuleMember -Function @(
     'Invoke-DebateBatch'
     'Get-FreeTierStatus'
     'Invoke-TaxEditorSmokeTest'
+    # t/2668 — analytics storage round-trip diagnosis
+    'Test-AnalyticsBackend'
     'Test-AzureHealth'
     'Test-GitHubHealth'
     'Get-TaxEditorRevision'

--- a/scripts/AITriad/Public/Test-AnalyticsBackend.ps1
+++ b/scripts/AITriad/Public/Test-AnalyticsBackend.ps1
@@ -1,0 +1,161 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-AnalyticsBackend {
+    <#
+    .SYNOPSIS
+        Tests the analytics storage round-trip: POST a synthetic event, then GET
+        and verify it appears in the query result.
+    .DESCRIPTION
+        Confirms analytics write/read path health in under 60 seconds.
+        Useful after deploys or config changes to catch silent Blob write failures
+        (the server always returns 200 regardless of whether the backend stored
+        the event).
+
+        Two checks are performed:
+          1. Write — POST to /api/analytics/event; pass if ok=true and count=1.
+             count=0 means the event was silently dropped by the server sanitizer
+             (missing required fields) — indicates a test-payload bug, not a
+             backend failure.
+          2. Read  — GET /api/analytics/query; pass if summary.totalEvents >= 1
+             and the synthetic event_type appears in eventTypes.
+    .PARAMETER BaseUrl
+        The Taxonomy Editor base URL. Default: production URL from Get-TaxEditorBaseUrl.
+    .PARAMETER TimeoutSec
+        HTTP request timeout per call. Default: 10.
+    .PARAMETER WaitSec
+        Seconds to wait between POST and GET to allow the async append to settle.
+        Default: 2.
+    .EXAMPLE
+        Test-AnalyticsBackend
+    .EXAMPLE
+        Test-AnalyticsBackend -BaseUrl 'https://staging.example.io'
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Test-AzureHealth
+    .LINK
+        Invoke-TaxEditorSmokeTest
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Position = 0)]
+        [string]$BaseUrl = (Get-TaxEditorBaseUrl),
+
+        [Parameter()]
+        [ValidateRange(1, 120)]
+        [int]$TimeoutSec = 10,
+
+        [Parameter()]
+        [ValidateRange(0, 30)]
+        [int]$WaitSec = 2
+    )
+
+    Set-StrictMode -Version Latest
+    $BaseUrl = if (-not [string]::IsNullOrWhiteSpace($BaseUrl)) { $BaseUrl.TrimEnd('/') } else { '' }
+    $Checks = [System.Collections.Generic.List[PSObject]]::new()
+
+    # Unique probe marker so the read probe can confirm this specific event appears.
+    $ProbeId   = [System.Guid]::NewGuid().ToString('N')
+    $ProbeType = "diag.probe-$ProbeId"
+    $ProbeTs   = (Get-Date).ToUniversalTime().ToString('o')
+
+    # ── Write probe ─────────────────────────────────────────────────────────
+    $WritePayload = @{
+        events = @(
+            @{
+                user       = 'Test-AnalyticsBackend'
+                session_id = $ProbeId
+                timestamp  = $ProbeTs
+                event_type = $ProbeType
+                category   = 'diagnostics'
+                detail     = @{ probe = $true }
+            }
+        )
+    }
+
+    $WriteResult = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/api/analytics/event' `
+        -Method POST -Body $WritePayload -TimeoutSec $TimeoutSec -ExpectJson
+
+    $WriteOk    = $WriteResult.Body -and $WriteResult.Body.PSObject.Properties['ok'] -and [bool]$WriteResult.Body.ok
+    $WriteCount = if ($WriteResult.Body -and $WriteResult.Body.PSObject.Properties['count']) { [int]$WriteResult.Body.count } else { -1 }
+    $WritePass  = $WriteResult.Success -and $WriteOk -and $WriteCount -eq 1
+
+    $WriteDetail = if ($WriteResult.Success -and $WriteResult.Body) {
+        $OkVal    = if ($WriteResult.Body.PSObject.Properties['ok'])    { $WriteResult.Body.ok    } else { 'missing' }
+        $CountVal = if ($WriteResult.Body.PSObject.Properties['count']) { $WriteResult.Body.count } else { 'missing' }
+        "ok=$OkVal count=$CountVal$(if ($WriteCount -eq 0) { ' (event dropped by sanitizer — check payload fields)' })"
+    }
+    else {
+        if ($WriteResult.Error) { $WriteResult.Error } else { "HTTP $($WriteResult.StatusCode)" }
+    }
+
+    $Checks.Add([PSCustomObject]@{
+        Check      = 'Analytics Write (POST /api/analytics/event)'
+        Pass       = $WritePass
+        ResponseMs = $WriteResult.ResponseMs
+        Detail     = $WriteDetail
+    })
+
+    # ── Wait for async append ────────────────────────────────────────────────
+    if ($WaitSec -gt 0) {
+        Write-Verbose "Waiting ${WaitSec}s for analytics append to settle..."
+        Start-Sleep -Seconds $WaitSec
+    }
+
+    # ── Read probe ───────────────────────────────────────────────────────────
+    $Today      = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+    $ReadResult = Invoke-RemoteCheck -BaseUrl $BaseUrl `
+        -Path "/api/analytics/query?from=$Today&to=$Today" `
+        -TimeoutSec $TimeoutSec -ExpectJson
+
+    $ReadPass   = $false
+    $ReadDetail = ''
+
+    if ($ReadResult.Success -and $ReadResult.Body) {
+        $Body = $ReadResult.Body
+        $HasSummary = $Body.PSObject.Properties['summary']
+        $TotalEvents = if ($HasSummary -and $Body.summary.PSObject.Properties['totalEvents']) {
+            [int]$Body.summary.totalEvents
+        } else { 0 }
+
+        $ProbeVisible = $Body.PSObject.Properties['eventTypes'] -and
+                        $Body.eventTypes.PSObject.Properties[$ProbeType]
+
+        if ($ProbeVisible) {
+            $ReadPass   = $true
+            $ReadDetail = "probe event_type confirmed in eventTypes (totalEvents=$TotalEvents)"
+        }
+        elseif ($HasSummary) {
+            $ReadDetail = "query succeeded but probe event_type '$ProbeType' absent from eventTypes (totalEvents=$TotalEvents) — write may have failed silently"
+        }
+        else {
+            $ReadDetail = "unexpected response shape: summary field missing"
+        }
+    }
+    else {
+        $ReadDetail = if ($ReadResult.Error) { $ReadResult.Error }
+                      elseif ($ReadResult.StatusCode -in @(302, 401, 403)) {
+                          "Auth required (HTTP $($ReadResult.StatusCode)) — run as authenticated user or use -SkipRead"
+                      }
+                      else { "HTTP $($ReadResult.StatusCode)" }
+    }
+
+    $Checks.Add([PSCustomObject]@{
+        Check      = 'Analytics Read (GET /api/analytics/query)'
+        Pass       = $ReadPass
+        ResponseMs = $ReadResult.ResponseMs
+        Detail     = $ReadDetail
+    })
+
+    # ── Summary ──────────────────────────────────────────────────────────────
+    $AllPass = @($Checks | Where-Object { -not $_.Pass }).Count -eq 0
+
+    [PSCustomObject]@{
+        Backend   = $BaseUrl
+        Healthy   = $AllPass
+        Checks    = @($Checks)
+        Timestamp = (Get-Date).ToString('o')
+    }
+}

--- a/tests/Test-AnalyticsBackend.Tests.ps1
+++ b/tests/Test-AnalyticsBackend.Tests.ps1
@@ -1,0 +1,194 @@
+# Tag: analytics (t/2668)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-AnalyticsBackend' -Tag 'analytics' {
+
+    Context 'Write probe passes and event confirmed in eventTypes' {
+        BeforeAll {
+            # Capture the dynamic probe event_type from the POST body so the GET
+            # mock can reflect it back — mirrors the real server round-trip.
+            $script:CapturedProbeType = $null
+
+            InModuleScope AITriad {
+                function script:Invoke-RemoteCheck {
+                    param($BaseUrl, $Path, $Method, $Body, $TimeoutSec, [switch]$ExpectJson)
+                    if ($Method -eq 'POST') {
+                        # Capture probe event_type from the payload hashtable
+                        $script:CapturedProbeType = $Body.events[0].event_type
+                        return [PSCustomObject]@{
+                            Success = $true; StatusCode = 200; ResponseMs = 12; Error = $null
+                            Body = [PSCustomObject]@{ ok = $true; count = 1 }
+                            ContentType = 'application/json'; RawBody = ''
+                        }
+                    }
+                    # GET — echo the captured probe type back in eventTypes
+                    $eventTypes = [PSCustomObject]@{}
+                    if ($script:CapturedProbeType) {
+                        $eventTypes | Add-Member -NotePropertyName $script:CapturedProbeType -NotePropertyValue 1
+                    }
+                    return [PSCustomObject]@{
+                        Success = $true; StatusCode = 200; ResponseMs = 20; Error = $null
+                        Body = [PSCustomObject]@{
+                            summary    = [PSCustomObject]@{ totalEvents = 1 }
+                            eventTypes = $eventTypes
+                        }
+                        ContentType = 'application/json'; RawBody = ''
+                    }
+                }
+            }
+        }
+
+        It 'Returns Healthy=$true when both probes pass' {
+            InModuleScope AITriad {
+                $r = Test-AnalyticsBackend -BaseUrl 'http://fake' -WaitSec 0
+                $r.Healthy | Should -Be $true
+                @($r.Checks).Count | Should -Be 2
+            }
+        }
+
+        It 'Write check passes with ok=true count=1' {
+            InModuleScope AITriad {
+                $r = Test-AnalyticsBackend -BaseUrl 'http://fake' -WaitSec 0
+                $writeCheck = @($r.Checks | Where-Object { $_.Check -match 'Write' })
+                $writeCheck.Count | Should -Be 1
+                $writeCheck[0].Pass | Should -Be $true
+                $writeCheck[0].Detail | Should -Match 'ok=True'
+                $writeCheck[0].Detail | Should -Match 'count=1'
+            }
+        }
+
+        It 'Read check passes with probe event_type confirmed in eventTypes' {
+            InModuleScope AITriad {
+                $r = Test-AnalyticsBackend -BaseUrl 'http://fake' -WaitSec 0
+                $readCheck = @($r.Checks | Where-Object { $_.Check -match 'Read' })
+                $readCheck[0].Pass | Should -Be $true
+                $readCheck[0].Detail | Should -Match 'confirmed'
+            }
+        }
+    }
+
+    Context 'Write probe fails when server returns count=0 (silent drop)' {
+        BeforeAll {
+            InModuleScope AITriad {
+                function script:Invoke-RemoteCheck {
+                    param($BaseUrl, $Path, $Method, $Body, $TimeoutSec, [switch]$ExpectJson)
+                    if ($Method -eq 'POST') {
+                        return [PSCustomObject]@{
+                            Success = $true; StatusCode = 200; ResponseMs = 8; Error = $null
+                            Body = [PSCustomObject]@{ ok = $true; count = 0 }
+                            ContentType = 'application/json'; RawBody = ''
+                        }
+                    }
+                    return [PSCustomObject]@{
+                        Success = $false; StatusCode = 0; ResponseMs = 0
+                        Error = 'skipped'; Body = $null; ContentType = ''; RawBody = ''
+                    }
+                }
+            }
+        }
+
+        It 'Write check fails and Detail mentions dropped event' {
+            InModuleScope AITriad {
+                $r = Test-AnalyticsBackend -BaseUrl 'http://fake' -WaitSec 0
+                $writeCheck = @($r.Checks | Where-Object { $_.Check -match 'Write' })
+                $writeCheck[0].Pass | Should -Be $false
+                $writeCheck[0].Detail | Should -Match 'dropped'
+            }
+        }
+
+        It 'Healthy=$false when write probe fails' {
+            InModuleScope AITriad {
+                $r = Test-AnalyticsBackend -BaseUrl 'http://fake' -WaitSec 0
+                $r.Healthy | Should -Be $false
+            }
+        }
+    }
+
+    Context 'Read probe fails when event absent from eventTypes' {
+        BeforeAll {
+            InModuleScope AITriad {
+                function script:Invoke-RemoteCheck {
+                    param($BaseUrl, $Path, $Method, $Body, $TimeoutSec, [switch]$ExpectJson)
+                    if ($Method -eq 'POST') {
+                        return [PSCustomObject]@{
+                            Success = $true; StatusCode = 200; ResponseMs = 10; Error = $null
+                            Body = [PSCustomObject]@{ ok = $true; count = 1 }
+                            ContentType = 'application/json'; RawBody = ''
+                        }
+                    }
+                    return [PSCustomObject]@{
+                        Success = $true; StatusCode = 200; ResponseMs = 15; Error = $null
+                        Body = [PSCustomObject]@{
+                            summary    = [PSCustomObject]@{ totalEvents = 3 }
+                            eventTypes = [PSCustomObject]@{ 'some.other.event' = 3 }
+                        }
+                        ContentType = 'application/json'; RawBody = ''
+                    }
+                }
+            }
+        }
+
+        It 'Read check fails and Detail mentions absent event_type' {
+            InModuleScope AITriad {
+                $r = Test-AnalyticsBackend -BaseUrl 'http://fake' -WaitSec 0
+                $readCheck = @($r.Checks | Where-Object { $_.Check -match 'Read' })
+                $readCheck[0].Pass | Should -Be $false
+                $readCheck[0].Detail | Should -Match 'absent'
+            }
+        }
+    }
+
+    Context 'Read probe soft-fails on auth redirect' {
+        BeforeAll {
+            InModuleScope AITriad {
+                function script:Invoke-RemoteCheck {
+                    param($BaseUrl, $Path, $Method, $Body, $TimeoutSec, [switch]$ExpectJson)
+                    if ($Method -eq 'POST') {
+                        return [PSCustomObject]@{
+                            Success = $true; StatusCode = 200; ResponseMs = 9; Error = $null
+                            Body = [PSCustomObject]@{ ok = $true; count = 1 }
+                            ContentType = 'application/json'; RawBody = ''
+                        }
+                    }
+                    return [PSCustomObject]@{
+                        Success = $false; StatusCode = 302; ResponseMs = 5
+                        Error = $null; Body = $null; ContentType = 'text/html'; RawBody = ''
+                    }
+                }
+            }
+        }
+
+        It 'Read check Detail mentions auth when HTTP 302' {
+            InModuleScope AITriad {
+                $r = Test-AnalyticsBackend -BaseUrl 'http://fake' -WaitSec 0
+                $readCheck = @($r.Checks | Where-Object { $_.Check -match 'Read' })
+                $readCheck[0].Detail | Should -Match 'Auth required'
+            }
+        }
+    }
+
+    It 'Output object has Backend, Healthy, Checks, Timestamp properties' {
+        InModuleScope AITriad {
+            function script:Invoke-RemoteCheck {
+                param($BaseUrl, $Path, $Method, $Body, $TimeoutSec, [switch]$ExpectJson)
+                return [PSCustomObject]@{
+                    Success = $false; StatusCode = 503; ResponseMs = 1
+                    Error = 'timeout'; Body = $null; ContentType = ''; RawBody = ''
+                }
+            }
+            $r = Test-AnalyticsBackend -BaseUrl 'http://fake' -WaitSec 0
+            $r.PSObject.Properties.Name | Should -Contain 'Backend'
+            $r.PSObject.Properties.Name | Should -Contain 'Healthy'
+            $r.PSObject.Properties.Name | Should -Contain 'Checks'
+            $r.PSObject.Properties.Name | Should -Contain 'Timestamp'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `Test-AnalyticsBackend` cmdlet: POST synthetic event -> wait 2s -> GET `/api/analytics/query` -> verify `event_type` appears in `eventTypes` aggregate
- Catches silent Blob write failures (server always 200; this probe confirms the event actually stored) in <60s
- Added to `Export-ModuleMember` + `FunctionsToExport`; cmdlet-reference.md updated

## Self-certification
Follows `/add-ps-cmdlet` playbook — no deviations.

## Test plan
- [x] 8/8 Pester tests pass (`-Tag analytics`)
- [x] `Get-Command Test-AnalyticsBackend` succeeds after `Import-Module`
- [x] `Test-ModuleManifest` passes
- [x] Happy path, count=0 silent-drop, absent-event-type, auth-redirect cases all covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)