### PR TITLE
fix(analytics-blob): remove rethrow — log-and-swallow during RBAC outage (t/2664)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/analyticsBlob.test.ts
+++ b/taxonomy-editor/src/server/__tests__/analyticsBlob.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 //
 // t/2664 — BlobAnalyticsBackend.append failure signaling.
-// Verifies that a write failure is surfaced (console.error + rethrow) rather
-// than swallowed into a silent 200.
+// Verifies that a write failure emits a greppable console.error and resolves
+// (best-effort, no rethrow) so analytics failures don't 5xx the caller route.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { BlobServiceClient } from '@azure/storage-blob';
@@ -32,14 +32,16 @@ describe('BlobAnalyticsBackend.append failure signaling (t/2664)', () => {
       serviceClient: makeFakeServiceClient(error),
     });
     const spy = vi.spyOn(console, 'error').mockImplementation(() => { /* suppress output */ });
-    await expect(backend.append('2026-08-15', ['{"event":1}'])).rejects.toThrow();
+    await backend.append('2026-08-15', ['{"event":1}']); // resolves (best-effort, no throw)
     expect(spy).toHaveBeenCalledWith(
       expect.stringContaining('analytics-blob-append-failed'),
       expect.anything(),
     );
   });
 
-  it('rethrows on write failure — does not swallow into silent success', async () => {
+  it('resolves (does not rethrow) on write failure — safe during backend outage', async () => {
+    // Best-effort: a failing append must not 5xx the caller's route.
+    // The failure is visible via console.error (greppable log) without propagating.
     const error = new Error('503 ServiceUnavailable');
     const backend = new BlobAnalyticsBackend({
       accountUrl: 'https://test.blob.core.windows.net',
@@ -47,6 +49,6 @@ describe('BlobAnalyticsBackend.append failure signaling (t/2664)', () => {
       serviceClient: makeFakeServiceClient(error),
     });
     vi.spyOn(console, 'error').mockImplementation(() => { /* suppress output */ });
-    await expect(backend.append('2026-08-15', ['{"event":1}'])).rejects.toThrow('503 ServiceUnavailable');
+    await expect(backend.append('2026-08-15', ['{"event":1}'])).resolves.toBeUndefined();
   });
 });

--- a/taxonomy-editor/src/server/storage/analyticsBlob.ts
+++ b/taxonomy-editor/src/server/storage/analyticsBlob.ts
@@ -56,14 +56,16 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
       await appendClient.appendBlock(content, Buffer.byteLength(content, 'utf-8'));
     } catch (err) {
       const code = err instanceof RestError ? (err.code ?? String(err.statusCode)) : undefined;
-      // Greppable via `az containerapp logs` without a flight-recorder dump (t/2664)
+      // Greppable via `az containerapp logs` without a flight-recorder dump (t/2664).
+      // Best-effort: log loudly but do not rethrow — analytics is non-critical telemetry
+      // and a rethrow would 5xx every event during a backend outage. Add rethrow +
+      // route-layer catch (Server Community appendEvents) when the catch is co-landed.
       console.error('[analytics-blob-append-failed]', { component: 'analytics-blob', date, code, error: String(err) });
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'analytics-blob', level: 'error',
         message: 'analytics blob append failed',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary

- Removes `throw err` that auto-merged in PR #1061 before TL flagged the sequencing hazard (p/408#16)
- Analytics is ~100% failing right now (RBAC outage) — a lone rethrow would 5xx every analytics event route
- Keeps greppable `console.error('[analytics-blob-append-failed]', ...)` for visibility in `az containerapp logs`
- Updates test assertions to match log-and-swallow: `resolves.toBeUndefined()` + separate `console.error` spy check

## Test plan

- [x] `npx vitest run src/server/__tests__/analyticsBlob.test.ts` — 2 passed
- [x] Test 1: console.error spy fires with greppable tag on write failure
- [x] Test 2: append resolves (does not rethrow) on write failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)