### PR TITLE
feat(analytics-blob): structured Pino warn logging in all catch blocks (t/2665)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/analyticsBlob.test.ts
+++ b/taxonomy-editor/src/server/__tests__/analyticsBlob.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment node
 //
-// t/2664 — BlobAnalyticsBackend.append failure signaling.
-// Verifies that a write failure emits a greppable console.error and resolves
+// t/2664/t/2665 — BlobAnalyticsBackend.append failure signaling.
+// Verifies that a write failure emits a structured Pino warn log and resolves
 // (best-effort, no rethrow) so analytics failures don't 5xx the caller route.
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type { BlobServiceClient } from '@azure/storage-blob';
 import { BlobAnalyticsBackend } from '../storage/analyticsBlob.js';
+import { log } from '../logger.js';
 
 function makeFakeServiceClient(appendError: Error): BlobServiceClient {
   const fakeAppendBlobClient = {
@@ -21,34 +22,33 @@ function makeFakeServiceClient(appendError: Error): BlobServiceClient {
   } as unknown as BlobServiceClient;
 }
 
-describe('BlobAnalyticsBackend.append failure signaling (t/2664)', () => {
+describe('BlobAnalyticsBackend.append failure signaling (t/2664, t/2665)', () => {
   afterEach(() => { vi.restoreAllMocks(); });
 
-  it('emits console.error with greppable tag on write failure', async () => {
+  it('emits log.analytics.warn on write failure (t/2665)', async () => {
     const error = new Error('403 AuthorizationFailure');
     const backend = new BlobAnalyticsBackend({
       accountUrl: 'https://test.blob.core.windows.net',
       container: 'analytics',
       serviceClient: makeFakeServiceClient(error),
     });
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => { /* suppress output */ });
+    const spy = vi.spyOn(log.analytics, 'warn').mockImplementation(() => { /* suppress output */ });
     await backend.append('2026-08-15', ['{"event":1}']); // resolves (best-effort, no throw)
     expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('analytics-blob-append-failed'),
-      expect.anything(),
+      expect.objectContaining({ date: '2026-08-15' }),
+      'analytics blob append failed',
     );
   });
 
   it('resolves (does not rethrow) on write failure — safe during backend outage', async () => {
     // Best-effort: a failing append must not 5xx the caller's route.
-    // The failure is visible via console.error (greppable log) without propagating.
     const error = new Error('503 ServiceUnavailable');
     const backend = new BlobAnalyticsBackend({
       accountUrl: 'https://test.blob.core.windows.net',
       container: 'analytics',
       serviceClient: makeFakeServiceClient(error),
     });
-    vi.spyOn(console, 'error').mockImplementation(() => { /* suppress output */ });
+    vi.spyOn(log.analytics, 'warn').mockImplementation(() => { /* suppress output */ });
     await expect(backend.append('2026-08-15', ['{"event":1}'])).resolves.toBeUndefined();
   });
 });

--- a/taxonomy-editor/src/server/storage/analyticsBlob.ts
+++ b/taxonomy-editor/src/server/storage/analyticsBlob.ts
@@ -13,6 +13,7 @@
 import { BlobServiceClient, type ContainerClient, RestError } from '@azure/storage-blob';
 import { DefaultAzureCredential } from '@azure/identity';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+import { log } from '../logger.js';
 import type { AnalyticsBackend } from '../community/analytics.js';
 
 export interface AnalyticsBlobOptions {
@@ -56,11 +57,9 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
       await appendClient.appendBlock(content, Buffer.byteLength(content, 'utf-8'));
     } catch (err) {
       const code = err instanceof RestError ? (err.code ?? String(err.statusCode)) : undefined;
-      // Greppable via `az containerapp logs` without a flight-recorder dump (t/2664).
-      // Best-effort: log loudly but do not rethrow — analytics is non-critical telemetry
-      // and a rethrow would 5xx every event during a backend outage. Add rethrow +
-      // route-layer catch (Server Community appendEvents) when the catch is co-landed.
-      console.error('[analytics-blob-append-failed]', { component: 'analytics-blob', date, code, error: String(err) });
+      // Best-effort: log but do not rethrow — analytics is non-critical telemetry and a
+      // rethrow would 5xx every event during a backend outage (t/2664).
+      log.analytics.warn({ err, date, code }, 'analytics blob append failed');
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'analytics-blob', level: 'error',
         message: 'analytics blob append failed',
@@ -77,6 +76,7 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
       return text.split('\n').filter(Boolean);
     } catch (err) {
       if (isNotFound(err)) return [];
+      log.analytics.warn({ err, date }, 'analytics blob readLines failed');
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'analytics-blob', level: 'error',
         message: 'analytics blob readLines failed',
@@ -94,6 +94,7 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
         if (match) dates.push(match[1]);
       }
     } catch (err) {
+      log.analytics.warn({ err }, 'analytics blob listDates failed');
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'analytics-blob', level: 'error',
         message: 'analytics blob listDates failed',
@@ -111,15 +112,19 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
           try {
             await this.client.getBlobClient(`${date}.ndjson`).delete();
           } catch (err) {
-            if (!isNotFound(err)) getGlobalRecorder()?.record({
-              type: 'system.error', component: 'analytics-blob', level: 'warn',
-              message: 'analytics blob prune delete failed',
-              error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-            });
+            if (!isNotFound(err)) {
+              log.analytics.warn({ err, date }, 'analytics blob prune delete failed');
+              getGlobalRecorder()?.record({
+                type: 'system.error', component: 'analytics-blob', level: 'warn',
+                message: 'analytics blob prune delete failed',
+                error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+              });
+            }
           }
         }
       }
     } catch (err) {
+      log.analytics.warn({ err, cutoffDate }, 'analytics blob prune failed');
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'analytics-blob', level: 'warn',
         message: 'analytics blob prune failed',


### PR DESCRIPTION
## Summary

- Replaces `console.error` workaround (t/2664) with `log.analytics.warn({ err, ... }, msg)` in all four `BlobAnalyticsBackend` catch blocks: `append`, `readLines`, `listDates`, `prune` (outer + per-date inner)
- Errors now appear in `az containerapp logs` as structured JSON (component=analytics, greppable, parseable in Log Analytics) alongside the flight recorder record
- No behavior change — still best-effort, no rethrow

## Test plan

- [x] `npx vitest run src/server/__tests__/analyticsBlob.test.ts` — 2 passed
- [x] Test 1: `log.analytics.warn` spy fires with `{ date }` merge object on append failure
- [x] Test 2: `append` resolves (does not rethrow) on write failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)