### PR TITLE
fix(community): swallow appendEvents blob errors to preserve fire-and-forget contract

### DIFF
--- a/taxonomy-editor/src/server/community/analytics.ts
+++ b/taxonomy-editor/src/server/community/analytics.ts
@@ -14,6 +14,7 @@
 import fs from 'fs';
 import path from 'path';
 import { getConfig } from '../runtimeConfig.js';
+import { log } from '../logger.js';
 
 // ── Types ──
 
@@ -165,7 +166,11 @@ export async function appendEvents(events: AnalyticsEvent[]): Promise<void> {
   }
 
   for (const [date, lines] of byDate) {
-    await backend.append(date, lines);
+    try {
+      await backend.append(date, lines);
+    } catch (err) {
+      log.error({ err, date, count: lines.length }, 'analytics: append failed, events dropped');
+    }
   }
 }
 

--- a/taxonomy-editor/src/server/community/analytics.ts
+++ b/taxonomy-editor/src/server/community/analytics.ts
@@ -169,7 +169,7 @@ export async function appendEvents(events: AnalyticsEvent[]): Promise<void> {
     try {
       await backend.append(date, lines);
     } catch (err) {
-      log.error({ err, date, count: lines.length }, 'analytics: append failed, events dropped');
+      log.analytics.error({ err, date, count: lines.length }, 'analytics: append failed, events dropped');
     }
   }
 }


### PR DESCRIPTION
## Summary
- `BlobAnalyticsBackend.append` now rethrows on write failure (PR #1061 from Server Storage)
- Wrap the `backend.append` loop in try/catch so errors are logged via `log.error` and dropped rather than propagating to the route as a 5xx
- Restores the documented contract: Fire-and-forget safe — errors are recorded, not thrown

## Test plan
- [ ] CI type-check passes
- [ ] CI server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)