### PR TITLE
feat(smoke): analytics write/read round-trip probe in staging smoke test (t/2667)

### DIFF
--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -7,9 +7,12 @@ function Invoke-TaxEditorSmokeTest {
         Runs a comprehensive remote smoke test against the deployed Taxonomy Editor.
     .DESCRIPTION
         Orchestrates Test-TaxEditorHealth, Test-TaxEditorEndpoints,
-        Test-AzureHealth, and Test-GitHubHealth, then produces a summary
-        report with pass/fail counts, response time stats, and per-category
-        breakdowns.
+        Test-AzureHealth, and Test-GitHubHealth, plus an analytics write/read
+        round-trip probe (t/2667), then produces a summary report with pass/fail
+        counts, response time stats, and per-category breakdowns. The analytics
+        probe reads aggregated totalEvents, POSTs a synthetic event, and re-reads
+        to confirm the count increased — catching silent blob-storage drops that
+        still return HTTP 200.
     .PARAMETER BaseUrl
         The base URL of the deployed Taxonomy Editor site.
     .PARAMETER TimeoutSec
@@ -156,8 +159,123 @@ function Invoke-TaxEditorSmokeTest {
     }
     Write-Host ''
 
+    # ── Phase 5: Analytics write/read round-trip (t/2667) ────────────────
+    # Q3b prevention (failure Class 3): the blob analytics backend silently drops
+    # events when misconfigured while the server still returns 200. The POST
+    # response's `count` reflects sanitized REQUEST events (session.ts:179), and the
+    # blob append is fire-and-forget (session.ts:172) — so the write alone can NEVER
+    # confirm persistence. The authoritative detector is a DELTA READ-BACK: read the
+    # aggregated totalEvents (read straight from blob storage — analytics.ts:301),
+    # POST a synthetic event, wait for the async append, read again, and require the
+    # count to increase. A silent drop leaves the count flat. (Design option A,
+    # approved t/2667#6. GET /api/analytics/query is anon-allowed — accessControl.ts:335
+    # — so this runs without a session token. Concurrent staging traffic between the
+    # two reads is an accepted low-risk masking window on quiet staging.)
+    Write-Host '=== Analytics Round-Trip ===' -ForegroundColor Cyan
+    $Analytics = @()
+
+    # Guarded extractor: pull summary.totalEvents from an Invoke-RemoteCheck result,
+    # or $null when the read failed / the field is absent (StrictMode-safe).
+    $GetTotalEvents = {
+        param($Check)
+        if ($Check.Success -and $Check.Body -and
+            $Check.Body.PSObject.Properties['summary'] -and $Check.Body.summary -and
+            $Check.Body.summary.PSObject.Properties['totalEvents']) {
+            return [int]$Check.Body.summary.totalEvents
+        }
+        return $null
+    }
+
+    # Baseline read BEFORE the write.
+    $BaselineCheck = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/api/analytics/query' `
+        -Method GET -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200)
+    $Before = & $GetTotalEvents $BaselineCheck
+
+    # Write probe — reachability only (200 + ok:true). NOT a drop detector.
+    # Build the body as an explicit JSON string so the single-element `events`
+    # array is never unwrapped to an object (the server requires an array — 400 otherwise).
+    $ProbeStamp   = [DateTimeOffset]::UtcNow.ToString('o')
+    $ProbeSession = "smoke-$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())"
+    $ProbeEvent   = @{
+        user       = 'smoke-probe'
+        session_id = $ProbeSession
+        timestamp  = $ProbeStamp
+        event_type = 'smoke-probe'
+        category   = 'system'
+        detail     = @{}
+    }
+    $EventJson = '{"events":[' + ($ProbeEvent | ConvertTo-Json -Depth 6 -Compress) + ']}'
+
+    $WriteCheck = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/api/analytics/event' `
+        -Method POST -Body $EventJson -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200)
+    $WriteOk = $false
+    if ($WriteCheck.Success -and $WriteCheck.Body -and $WriteCheck.Body.PSObject.Properties['ok']) {
+        $WriteOk = [bool]$WriteCheck.Body.ok
+    }
+    $WritePass = $WriteCheck.Success -and $WriteOk
+
+    $WriteResult = [EndpointTestResult]::new()
+    $WriteResult.Endpoint    = 'POST /api/analytics/event'
+    $WriteResult.Category    = 'Analytics'
+    $WriteResult.Description = 'Analytics write reachability (200 + ok:true)'
+    $WriteResult.Status      = $WriteCheck.StatusCode
+    $WriteResult.Pass        = $WritePass
+    $WriteResult.Ms          = $WriteCheck.ResponseMs
+    $WriteResult.NodeCount   = $null
+    if (-not $WritePass) {
+        $WriteResult.Error = if ($WriteCheck.Error) {
+            $WriteCheck.Error
+        } else {
+            "Unexpected write response (status=$($WriteCheck.StatusCode), ok=$WriteOk)"
+        }
+    }
+    $Analytics += $WriteResult
+
+    # Async blob append — give the write time to land before the read-back.
+    Start-Sleep -Seconds 2
+
+    # Read-back AFTER the write — the delta is the detector.
+    $AfterCheck = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/api/analytics/query' `
+        -Method GET -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200)
+    $After = & $GetTotalEvents $AfterCheck
+
+    $DeltaPass = $false
+    $DeltaErr  = $null
+    if ($null -eq $Before) {
+        $DeltaErr = "Baseline read failed (status=$($BaselineCheck.StatusCode)) — cannot compute delta$(if ($BaselineCheck.Error) { ": $($BaselineCheck.Error)" })"
+    } elseif ($null -eq $After) {
+        $DeltaErr = "Read-back failed (status=$($AfterCheck.StatusCode)) — cannot confirm write landed$(if ($AfterCheck.Error) { ": $($AfterCheck.Error)" })"
+    } else {
+        $Delta = $After - $Before
+        $DeltaPass = ($Delta -ge 1)
+        if (-not $DeltaPass) {
+            $DeltaErr = "Silent drop: totalEvents did not increase after write (before=$Before, after=$After, delta=$Delta) — event accepted but not persisted (blob backend misconfigured?)"
+        }
+    }
+
+    $DeltaResult = [EndpointTestResult]::new()
+    $DeltaResult.Endpoint    = 'GET /api/analytics/query (delta read-back)'
+    $DeltaResult.Category    = 'Analytics'
+    $DeltaResult.Description = 'Analytics storage round-trip (totalEvents increased)'
+    $DeltaResult.Status      = $AfterCheck.StatusCode
+    $DeltaResult.Pass        = $DeltaPass
+    $DeltaResult.Ms          = $BaselineCheck.ResponseMs + $AfterCheck.ResponseMs
+    $DeltaResult.NodeCount   = $After
+    $DeltaResult.Error       = $DeltaErr
+    $Analytics += $DeltaResult
+
+    foreach ($Ep in $Analytics) {
+        $Icon = if ($Ep.Pass) { '[PASS]' } else { '[FAIL]' }
+        $Color = if ($Ep.Pass) { 'Green' } else { 'Red' }
+        Write-Host "  $Icon $($Ep.Endpoint) — $($Ep.Status) $($Ep.Ms)ms" -ForegroundColor $Color
+        if (-not $Ep.Pass -and $Ep.Error) {
+            Write-Host "        $($Ep.Error)" -ForegroundColor DarkRed
+        }
+    }
+    Write-Host ''
+
     # ── Summary ──────────────────────────────────────────────────────────
-    $AllResults = @($Endpoints) + @($AnonEndpoints)
+    $AllResults = @($Endpoints) + @($AnonEndpoints) + @($Analytics)
     $Passed = @($AllResults | Where-Object { $_.Pass }).Count
     $Failed = @($AllResults | Where-Object { -not $_.Pass }).Count
     $Total = $AllResults.Count

--- a/tests/Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1
@@ -1,0 +1,143 @@
+# Tag: health (t/2667)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Regression tests for the t/2667 analytics write/read round-trip probe added to
+    Invoke-TaxEditorSmokeTest (Phase 5).
+.DESCRIPTION
+    Q3b prevention (failure Class 3): the blob analytics backend silently drops
+    events when misconfigured while the server still returns 200. The probe's
+    authoritative detector is a DELTA READ-BACK — read aggregated totalEvents,
+    POST a synthetic event, read again, require the count to increase.
+
+    These tests mock the Private Invoke-RemoteCheck (the analytics phase's HTTP
+    helper) inside the module and stub the other four phases so the orchestration
+    runs offline. Gate integrity is proven both ways: a clean round-trip passes,
+    and each failure mode (silent drop / write unreachable / read path broken)
+    sinks OverallPass and surfaces in FailedEndpoints.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Invoke-TaxEditorSmokeTest analytics round-trip probe (t/2667)' -Tag 'health' {
+
+    BeforeEach {
+        InModuleScope AITriad {
+            # Stub the four non-analytics phases so OverallPass hinges on analytics.
+            Mock Test-TaxEditorHealth -MockWith {
+                $r = [TaxEditorHealthResult]::new()
+                $r.BaseUrl = 'https://stub'; $r.Healthy = $true
+                $r.Checks = @(); $r.AverageMs = 0; $r.FreeTierKeyPoolSize = 0
+                $r.Timestamp = (Get-Date).ToString('o'); $r
+            }
+            Mock Test-TaxEditorEndpoints -MockWith {
+                @([PSCustomObject]@{
+                    Endpoint = '/api/models'; Category = 'Core'; Description = 'stub'
+                    Status = 200; Pass = $true; Ms = 42; NodeCount = 0; Error = $null
+                })
+            }
+            Mock Test-AzureHealth  -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
+            Mock Test-GitHubHealth -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
+            Mock Start-Sleep -MockWith { }
+
+            # Helper builds an Invoke-RemoteCheck-shaped result.
+            function script:New-RCResult ($Success, $Status, $Body) {
+                [PSCustomObject]@{
+                    Success = $Success; StatusCode = $Status; ResponseMs = 10
+                    Body = $Body; ContentType = 'application/json'; RawBody = ''; Error = $(if (-not $Success) { "HTTP $Status" } else { $null })
+                }
+            }
+        }
+    }
+
+    It 'clean round-trip: totalEvents increases → Analytics PASS, OverallPass true' {
+        InModuleScope AITriad {
+            $script:QueryCall = 0
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
+                $script:QueryCall++
+                $total = if ($script:QueryCall -eq 1) { 5 } else { 6 }   # +1 after write
+                New-RCResult $true 200 ([PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } })
+            }
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
+                New-RCResult $true 200 ([PSCustomObject]@{ ok = $true; count = 1 })
+            }
+
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' 6>$null
+
+            $result.OverallPass | Should -BeTrue -Because 'a clean analytics round-trip with all other phases green must pass'
+            @($result.FailedEndpoints | Where-Object { $_.Category -eq 'Analytics' }).Count |
+                Should -Be 0 -Because 'neither analytics probe should fail on a healthy round-trip'
+            @($result.Categories | Where-Object { $_.Category -eq 'Analytics' }).Count |
+                Should -Be 1 -Because 'the Analytics category must appear in the per-category breakdown'
+        }
+    }
+
+    It 'SILENT DROP: totalEvents flat after a 200 write → delta FAILS, OverallPass false (the critical catch)' {
+        InModuleScope AITriad {
+            $script:QueryCall = 0
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
+                $script:QueryCall++
+                New-RCResult $true 200 ([PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = 5 } })  # never increases
+            }
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
+                New-RCResult $true 200 ([PSCustomObject]@{ ok = $true; count = 1 })  # server reports success — the trap
+            }
+
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' 6>$null
+
+            $result.OverallPass | Should -BeFalse -Because 'a silent drop (write 200 but nothing stored) must sink the gate'
+            $delta = $result.FailedEndpoints | Where-Object { $_.Endpoint -like '*delta read-back*' }
+            $delta | Should -Not -BeNullOrEmpty -Because 'the delta read-back is the authoritative silent-drop detector'
+            $delta.Error | Should -Match 'Silent drop'
+            # The write probe alone reports 200+ok:true — proving it can NOT be the detector.
+            $write = $result.FailedEndpoints | Where-Object { $_.Endpoint -eq 'POST /api/analytics/event' }
+            $write | Should -BeNullOrEmpty -Because 'the write is reachability-only; it passes on the silent drop, which is exactly why the delta is needed'
+        }
+    }
+
+    It 'WRITE UNREACHABLE: POST non-200 → write probe FAILS, OverallPass false' {
+        InModuleScope AITriad {
+            $script:QueryCall = 0
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
+                $script:QueryCall++
+                New-RCResult $true 200 ([PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = 5 } })
+            }
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
+                New-RCResult $false 502 $null
+            }
+
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' 6>$null
+
+            $result.OverallPass | Should -BeFalse
+            $write = $result.FailedEndpoints | Where-Object { $_.Endpoint -eq 'POST /api/analytics/event' }
+            $write | Should -Not -BeNullOrEmpty -Because 'an unreachable write endpoint must fail the gate'
+        }
+    }
+
+    It 'READ PATH BROKEN: baseline query non-200 → delta FAILS "Baseline read failed", OverallPass false' {
+        InModuleScope AITriad {
+            $script:QueryCall = 0
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
+                $script:QueryCall++
+                New-RCResult $false 302 $null   # e.g. auth redirect / read path down
+            }
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
+                New-RCResult $true 200 ([PSCustomObject]@{ ok = $true; count = 1 })
+            }
+
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' 6>$null
+
+            $result.OverallPass | Should -BeFalse
+            $delta = $result.FailedEndpoints | Where-Object { $_.Endpoint -like '*delta read-back*' }
+            $delta | Should -Not -BeNullOrEmpty
+            $delta.Error | Should -Match 'Baseline read failed'
+        }
+    }
+}

--- a/tests/Invoke-TaxEditorSmokeTest.ColdStart.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.ColdStart.Tests.ps1
@@ -42,6 +42,29 @@ Describe 'Invoke-TaxEditorSmokeTest Health-phase cold-start tolerance (t/1696)' 
             Mock Test-AzureHealth  -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
             Mock Test-GitHubHealth -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
             Mock Start-Sleep -MockWith { }
+
+            # t/2667 — the Analytics phase (Phase 5) calls the Private Invoke-RemoteCheck
+            # for a delta read-back. Stub it to a clean round-trip (totalEvents 0 → 1)
+            # so the analytics phase passes and OverallPass hinges solely on the health
+            # phase under test. Without this stub the real HTTP calls to the stub URL
+            # would fail and sink OverallPass, masking the health-phase assertions.
+            $script:CsQuery = 0
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
+                $script:CsQuery++
+                $total = if ($script:CsQuery -eq 1) { 0 } else { 1 }
+                [PSCustomObject]@{
+                    Success = $true; StatusCode = 200; ResponseMs = 5
+                    Body = [PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } }
+                    ContentType = 'application/json'; RawBody = ''; Error = $null
+                }
+            }
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
+                [PSCustomObject]@{
+                    Success = $true; StatusCode = 200; ResponseMs = 5
+                    Body = [PSCustomObject]@{ ok = $true; count = 1 }
+                    ContentType = 'application/json'; RawBody = ''; Error = $null
+                }
+            }
         }
     }
 
@@ -85,7 +108,9 @@ Describe 'Invoke-TaxEditorSmokeTest Health-phase cold-start tolerance (t/1696)' 
             $result.HealthOk    | Should -BeFalse -Because 'an app that never returns healthy within the budget must still fail (no falsely-green gate)'
             $result.OverallPass | Should -BeFalse -Because 'a down health phase must sink OverallPass even with other phases green'
             $script:Probe       | Should -Be 4 -Because 'it must exhaust exactly HealthMaxAttempts probes before giving up'
-            Should -Invoke Start-Sleep -Times 3 -Exactly -Because '4 attempts → 3 inter-attempt sleeps (none after the last)'
+            # Scope to the health-phase retry sleep (interval=1s); the t/2667 analytics
+            # phase adds one -Seconds 2 wait that must not be counted here.
+            Should -Invoke Start-Sleep -Times 3 -Exactly -ParameterFilter { $Seconds -ne 2 } -Because '4 attempts → 3 inter-attempt sleeps (none after the last)'
         }
     }
 
@@ -106,7 +131,8 @@ Describe 'Invoke-TaxEditorSmokeTest Health-phase cold-start tolerance (t/1696)' 
 
             $result.HealthOk | Should -BeFalse
             $script:Probe    | Should -Be 1 -Because 'HealthMaxAttempts=1 preserves the prior single-shot behavior'
-            Should -Invoke Start-Sleep -Times 0 -Exactly
+            # Health-phase sleeps only; the t/2667 analytics -Seconds 2 wait is excluded.
+            Should -Invoke Start-Sleep -Times 0 -Exactly -ParameterFilter { $Seconds -ne 2 }
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds a Phase 5 analytics write/read round-trip probe to `Invoke-TaxEditorSmokeTest` (t/2667, Q3b prevention — failure Class 3). The blob analytics backend silently drops events when misconfigured while still returning HTTP 200; this catches it at staging deploy time. **No pipeline wiring** — `deploy-staging.yml` already calls the smoke test.

## Design correction (approved t/2667#6, option A)
Reading the handlers before coding surfaced that the originally-approved mechanism could not detect the drop:
- `POST /api/analytics/event` returns `count: events.length` from the **request** (session.ts:179); the blob append is **fire-and-forget** (session.ts:172). A valid POST always returns `count:1`, drop or no drop — so the write alone can never confirm persistence.
- `GET /api/analytics/query` is **anon-allowed** (accessControl.ts:335) and returns `summary.totalEvents` read **from blob storage** (analytics.ts:301) — the real storage-confirmation signal, no token needed.

**Corrected probe (option A — delta read-back):** read aggregated `totalEvents` → POST a synthetic event → wait 2s for the async append → read again → require the count to **increase**. The POST is demoted to a reachability-only check (200 + `ok:true`). Results flow into `FailedEndpoints`/`Categories` as `[EndpointTestResult]`, so a silent drop sinks `OverallPass`.

Accepted caveat (per reviewer): concurrent staging traffic between the two reads is a low-risk masking window on quiet staging.

## Test plan
- [x] 4 gate-integrity tests (`Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1`): clean round-trip passes; **silent drop** (200 write, flat totalEvents) fails; write-unreachable fails; read-path-broken fails — proves the gate both passes clean and bites.
- [x] Updated the t/1696 cold-start tests to stub the new phase and scope their `Start-Sleep` assertions to the health interval.
- [x] Full `Invoke-Pester ./tests/` (keys unset, CI-faithful): **1199 passed, 0 failed**, 53 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
