### PR TITLE
fix(server): log.server.warn in 3 FR-only silent catches (t/2666)

### DIFF
--- a/taxonomy-editor/src/server/featureFlags.ts
+++ b/taxonomy-editor/src/server/featureFlags.ts
@@ -265,6 +265,7 @@ function appendAudit(entry: FlagAuditEntry): void {
     fs.mkdirSync(path.dirname(p), { recursive: true });
     fs.appendFileSync(p, JSON.stringify(entry) + '\n');
   } catch (err) {
+    log.server.warn({ err }, 'Failed to append feature-flag audit entry');
     getGlobalRecorder()?.record({
       type: 'system.error', component: 'feature-flags', level: 'warn',
       message: 'Failed to append feature-flag audit entry',

--- a/taxonomy-editor/src/server/organizations.ts
+++ b/taxonomy-editor/src/server/organizations.ts
@@ -7,6 +7,7 @@
 // the topic/policy reverse indexes, and the query helpers the REST routes call.
 
 import { readOrganizations, readOrganizationEdges } from './storage/fileIO.js';
+import { log } from './logger.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 
 export type { Pov, PovStance, TopicEngagement, PolicyEngagement, Organization, OrganizationEdgeType, OrganizationEdge } from '../../../lib/organizations/types.js';
@@ -82,6 +83,7 @@ async function load(): Promise<OrgIndexes> {
     const edges = Array.isArray(edgesRaw) ? edgesRaw.filter(e => e && typeof e.source === 'string') : [];
     cache = buildIndexes(orgs, edges);
   } catch (err) {
+    log.server.warn({ err }, 'Failed to load organizations.json; serving empty set');
     getGlobalRecorder()?.record({
       type: 'system.error', component: 'organizations', level: 'error',
       message: 'Failed to load organizations.json; serving empty set',

--- a/taxonomy-editor/src/server/support/supportStore.ts
+++ b/taxonomy-editor/src/server/support/supportStore.ts
@@ -9,6 +9,7 @@ import crypto from 'crypto';
 import path from 'path';
 import { resolveDataPath } from '../config.js';
 import { getUserContentBackend, assertSafeId } from '../storage/fileIO.js';
+import { log } from '../logger.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import type { SupportCase, CaseStatus, CaseResponse, SupportCaseSystemInfo, Attachment } from './types.js';
 import { isAllowedAttachmentMime, ATTACHMENT_MAX_BYTES, CASE_MAX_TOTAL_BYTES, CASE_MAX_ATTACHMENTS } from './types.js';
@@ -40,6 +41,7 @@ async function readCaseAt(userId: string, caseId: string): Promise<SupportCase |
   try {
     return JSON.parse(raw) as SupportCase;
   } catch (err) {
+    log.server.warn({ err }, 'Skipping unparseable support case');
     getGlobalRecorder()?.record({
       type: 'system.error', component: 'support', level: 'warn',
       message: 'Skipping unparseable support case',


### PR DESCRIPTION
ServerAPI-core half of the FR-only silent-catch audit (t/2666; Server Storage did the fileIO.ts half). Three catches recorded to the flight recorder only, with no Pino log — invisible in live server logs:

- `organizations.ts` load() — caches an empty index for the process lifetime on error
- `support/supportStore.ts` readCaseAt() — returns null (parse error indistinguishable from not-found)
- `featureFlags.ts` appendAudit() — admin audit-append failures swallowed

Fix: `log.server.warn({ err }, <same message>)` before each FR record. No rethrow — graceful fallbacks are intentional. Matches the fileIO.ts pattern.

**Verify:** `tsc -p tsconfig.server.json --noEmit` clean; eslint clean; the 4 affected suites (featureFlags, featureFlagsRmw, organizations, supportStore) 39/39 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)