### PR TITLE
feat(storage): emit greppable warn on absent-file branch in graceful-empty readers (t/2672)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/entityStore.test.ts
+++ b/taxonomy-editor/src/server/__tests__/entityStore.test.ts
@@ -6,7 +6,8 @@
 // t/1793 caching discipline (repeated reads don't re-parse), absent-store null,
 // and cache reset on backend swap.
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { log } from '../logger.js';
 import type { StorageBackend } from '../storage/storageBackend.js';
 import type { Entity } from '../../../../lib/entities/types.js';
 import * as fileIO from '../storage/fileIO.js';
@@ -166,5 +167,89 @@ describe('static registry readers pin ref:main (t/2662)', () => {
     const call = calls.find(c => c.path.replace(/\\/g, '/').endsWith('organization_edges.json'));
     expect(call).toBeDefined();
     expect(call!.opts?.ref).toBe('main');
+  });
+});
+
+// t/2672: absent-file branches must emit a greppable log.server.warn so ops can
+// detect "silently empty" loads via az logs without requiring a flight-recorder dump.
+// Must NOT fire on a legitimately-empty-but-successful read (an empty array is valid data).
+describe('graceful-empty readers emit warn on absent file (t/2672)', () => {
+  function makeNullBackend(): StorageBackend {
+    return {
+      async readFile(): Promise<string | null> { return null; },
+      async writeFile(): Promise<void> { /* stub */ },
+      async listDirectory(): Promise<string[]> { return []; },
+      async deleteFile(): Promise<void> { /* stub */ },
+      async fileExists(): Promise<boolean> { return false; },
+      async readBinaryFile(): Promise<Buffer | null> { return null; },
+      async writeBinaryFile(): Promise<void> { /* stub */ },
+    };
+  }
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('readOrganizations: emits warn with path+ref on absent file, returns null', async () => {
+    fileIO.setTaxonomyBackend(makeNullBackend());
+    const spy = vi.spyOn(log.server, 'warn').mockImplementation(() => { /* suppress */ });
+    const result = await fileIO.readOrganizations();
+    expect(result).toBeNull();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'main' }),
+      'readOrganizations: file absent',
+    );
+  });
+
+  it('readOrganizationEdges: emits warn with path+ref on absent file, returns null', async () => {
+    fileIO.setTaxonomyBackend(makeNullBackend());
+    const spy = vi.spyOn(log.server, 'warn').mockImplementation(() => { /* suppress */ });
+    const result = await fileIO.readOrganizationEdges();
+    expect(result).toBeNull();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'main' }),
+      'readOrganizationEdges: file absent',
+    );
+  });
+
+  it('readEntities: emits warn with path+ref on absent file, returns null', async () => {
+    fileIO.setTaxonomyBackend(makeNullBackend());
+    const spy = vi.spyOn(log.server, 'warn').mockImplementation(() => { /* suppress */ });
+    const result = await fileIO.readEntities();
+    expect(result).toBeNull();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'main' }),
+      'readEntities: file absent',
+    );
+  });
+
+  it('readEntityRegistry: emits warn on absent entity store, returns null', async () => {
+    fileIO.setTaxonomyBackend(makeNullBackend());
+    const spy = vi.spyOn(log.server, 'warn').mockImplementation(() => { /* suppress */ });
+    const result = await fileIO.readEntityRegistry();
+    expect(result).toBeNull();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: 'main' }),
+      'readEntityRegistry: entity store absent',
+    );
+  });
+
+  it('readEntities: does NOT warn on a successful empty-array read (no false noise)', async () => {
+    const emptyBackend: StorageBackend = {
+      async readFile(p): Promise<string | null> {
+        if (p.replace(/\\/g, '/').endsWith('entities.json')) return JSON.stringify({ entities: [] });
+        return null;
+      },
+      async writeFile(): Promise<void> { /* stub */ },
+      async listDirectory(): Promise<string[]> { return []; },
+      async deleteFile(): Promise<void> { /* stub */ },
+      async fileExists(): Promise<boolean> { return false; },
+      async readBinaryFile(): Promise<Buffer | null> { return null; },
+      async writeBinaryFile(): Promise<void> { /* stub */ },
+    };
+    fileIO.setTaxonomyBackend(emptyBackend);
+    const spy = vi.spyOn(log.server, 'warn').mockImplementation(() => { /* suppress */ });
+    const result = await fileIO.readEntities();
+    expect(result).toEqual([]);
+    const absentCalls = spy.mock.calls.filter(([, msg]) => String(msg).includes('absent'));
+    expect(absentCalls).toHaveLength(0);
   });
 });

--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -509,7 +509,10 @@ export async function readOrganizations(): Promise<unknown | null> {
   try {
     const p = path.join(getTaxonomyDir(), 'organizations.json');
     const raw = await backend.readFile(p, { ref: 'main' });
-    if (raw === null) return null;
+    if (raw === null) {
+      log.server.warn({ path: p, ref: 'main' }, 'readOrganizations: file absent');
+      return null;
+    }
     return JSON.parse(raw);
   } catch (err) {
     log.server.warn({ err }, 'readOrganizations failed');
@@ -528,7 +531,10 @@ export async function readOrganizationEdges(): Promise<OrganizationEdge[] | null
   try {
     const p = path.join(getTaxonomyDir(), 'organization_edges.json');
     const raw = await backend.readFile(p, { ref: 'main' });
-    if (raw === null) return null;
+    if (raw === null) {
+      log.server.warn({ path: p, ref: 'main' }, 'readOrganizationEdges: file absent');
+      return null;
+    }
     const data = JSON.parse(raw);
     return (data as { edges?: OrganizationEdge[] })?.edges ?? [];
   } catch (err) {
@@ -586,7 +592,10 @@ export async function readEntities(): Promise<Entity[] | null> {
   try {
     const p = path.join(getTaxonomyDir(), 'entities.json');
     const raw = await backend.readFile(p, { ref: 'main' });
-    if (raw === null) return null;
+    if (raw === null) {
+      log.server.warn({ path: p, ref: 'main' }, 'readEntities: file absent');
+      return null;
+    }
     const data = JSON.parse(raw) as { entities?: Entity[] };
     const entities = data.entities ?? [];
     entitiesCache = { at: Date.now(), entities };
@@ -613,7 +622,11 @@ export async function readEntities(): Promise<Entity[] | null> {
  */
 export async function readEntityRegistry(): Promise<Map<string, Entity> | null> {
   const entities = await readEntities();
-  return entities ? new Map(entities.map(e => [e.id, e])) : null;
+  if (entities === null) {
+    log.server.warn({ ref: 'main' }, 'readEntityRegistry: entity store absent');
+    return null;
+  }
+  return new Map(entities.map(e => [e.id, e]));
 }
 
 // ── Entity Mentions (derived artifact) ──


### PR DESCRIPTION
## Summary

- `readOrganizations`, `readOrganizationEdges`, `readEntities`, `readEntityRegistry` all had a silent `if (raw === null) return null` branch — a total load failure looked identical to 'no data', invisible in az logs without a dump (root cause of the t/2662 incident taking extra time to diagnose)
- Each now calls `log.server.warn({ path, ref: 'main' }, '<reader>: file absent')` on the null branch
- `readEntityRegistry` emits an additional `'readEntityRegistry: entity store absent'` warn since it's the callers' entry point
- Warn fires only on the absent/null branch — a successful empty-array parse emits no warn (no noise)

## Test plan

- [x] 5 new assertions in `entityStore.test.ts`:
  - `readOrganizations` / `readOrganizationEdges` / `readEntities` / `readEntityRegistry` each: spy backend returns null → warn fires with expected message and `ref:'main'`
  - No-noise guard: empty-array successful parse emits zero 'absent' warns
- [x] All 13 entityStore tests pass (`npx vitest run src/server/__tests__/entityStore.test.ts`)
- [x] Pairs with t/2662 ref-pinning fix — same readers now observable end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)