### PR TITLE
fix(storage): extract RestError.code in readLines/listDates warn for diagnostic parity (t/2663)

### DIFF
--- a/taxonomy-editor/src/server/storage/analyticsBlob.ts
+++ b/taxonomy-editor/src/server/storage/analyticsBlob.ts
@@ -76,7 +76,8 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
       return text.split('\n').filter(Boolean);
     } catch (err) {
       if (isNotFound(err)) return [];
-      log.analytics.warn({ err, date }, 'analytics blob readLines failed');
+      const code = err instanceof RestError ? (err.code ?? String(err.statusCode)) : undefined;
+      log.analytics.warn({ err, date, code }, 'analytics blob readLines failed');
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'analytics-blob', level: 'error',
         message: 'analytics blob readLines failed',
@@ -94,7 +95,8 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
         if (match) dates.push(match[1]);
       }
     } catch (err) {
-      log.analytics.warn({ err }, 'analytics blob listDates failed');
+      const code = err instanceof RestError ? (err.code ?? String(err.statusCode)) : undefined;
+      log.analytics.warn({ err, code }, 'analytics blob listDates failed');
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'analytics-blob', level: 'error',
         message: 'analytics blob listDates failed',


### PR DESCRIPTION
## Summary

- `readLines` and `listDates` catch blocks in `BlobAnalyticsBackend` now extract `const code = err instanceof RestError ? (err.code ?? String(err.statusCode)) : undefined` and include it in the `log.analytics.warn` call
- Matches the `append` block's existing shape (t/2665 reference pattern)
- Without this, `pino.stdSerializers.err` omits `RestError.code` as a structured field — `AuthorizationPermissionMismatch`, `ContainerNotFound`, and `BlobNotFound` all look identical from `err.message` alone; each routes to a different fix
- No behavioral change; warn/swallow pattern unchanged

## Test plan

- [x] Existing 2 `analyticsBlob.test.ts` tests pass (no rethrow, warn fires)
- [x] Self-cert /trivial-change: 4 lines added, no interface change, no new imports (`RestError` already imported at top of file)
- [ ] Rides next deploy → Diagnostics greps `component:analytics` + `analytics blob readLines failed` for the `code` field to route the actual read fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)