### PR TITLE
fix(edges): surface silent-blank rationales in Invoke-EdgeDiscovery (t/2674)

### DIFF
--- a/scripts/AITriad/Public/Invoke-EdgeDiscovery.ps1
+++ b/scripts/AITriad/Public/Invoke-EdgeDiscovery.ps1
@@ -183,6 +183,14 @@ function Invoke-EdgeDiscovery {
     Set-StrictMode -Version Latest
     $ErrorActionPreference = 'Stop'
 
+    # t/2674 — surface silent-blank rationales. When the LLM omits the
+    # schema-required `rationale`, the edge is still written with rationale=''
+    # (schema contract preserved). Count those so a run that quietly drops
+    # rationales is visible in the summary, not invisible (silent-failure class
+    # shared with t/2664/t/2669). Only one mode runs per call, so a single
+    # function-scoped counter never double-counts across modes.
+    $MissingRationaleCount = 0
+
     function Save-DiscoveryLog {
         param(
             [string]$Path,
@@ -689,6 +697,7 @@ Omit pairs with no relationship. No markdown fences.
                             discovered_at = (Get-Date).ToString('yyyy-MM-dd')
                         }
 
+                        if ([string]::IsNullOrWhiteSpace($NewEdge.rationale)) { $MissingRationaleCount++ }
                         $EdgesList.Add([PSCustomObject]$NewEdge)
                         $null = $ExistingEdgeKeys.Add($EdgeKey)
                         $BatchNewEdges++
@@ -742,6 +751,9 @@ Omit pairs with no relationship. No markdown fences.
         Write-Host "  Classification batches: $($ClassifyBatches.Count)"
         Write-Host "  New edges discovered: $NewEdgeCount" -ForegroundColor Green
         Write-Host "  Total edges: $($EdgesList.Count)"
+        if ($MissingRationaleCount -gt 0) {
+            Write-Warning "Edge discovery: $MissingRationaleCount proposed edge(s) had an empty/missing rationale (LLM omitted the schema-required field); stored rationale='' for these. Inspect the model output or re-run — silent-blank rationales are a tracked gap (t/2674)."
+        }
         return
     }
 
@@ -917,6 +929,7 @@ $BatchSchemaPrompt
 
                 if ($Edge.PSObject.Properties['bidirectional']) { $Bidir = [bool]$Edge.bidirectional } else { $Bidir = $false }
                 if ($Edge.PSObject.Properties['rationale'])    { $Rationale = $Edge.rationale }           else { $Rationale = '' }
+                if ([string]::IsNullOrWhiteSpace($Rationale)) { $MissingRationaleCount++ }
                 $EdgeObj = [ordered]@{
                     source        = $SourceId
                     target        = $TargetId
@@ -1246,6 +1259,7 @@ $SchemaPrompt
 
                 if ($Edge.PSObject.Properties['bidirectional']) { $Bidir = [bool]$Edge.bidirectional } else { $Bidir = $false }
                 if ($Edge.PSObject.Properties['rationale'])    { $Rationale = $Edge.rationale }           else { $Rationale = '' }
+                if ([string]::IsNullOrWhiteSpace($Rationale)) { $MissingRationaleCount++ }
                 $EdgeObj  = [ordered]@{
                     source        = $Disc.NodeId
                     target        = $Edge.target
@@ -1376,6 +1390,7 @@ $SchemaPrompt
 
                 if ($Edge.PSObject.Properties['bidirectional']) { $Bidir = [bool]$Edge.bidirectional } else { $Bidir = $false }
                 if ($Edge.PSObject.Properties['rationale'])    { $Rationale = $Edge.rationale }           else { $Rationale = '' }
+                if ([string]::IsNullOrWhiteSpace($Rationale)) { $MissingRationaleCount++ }
                 $EdgeObj  = [ordered]@{
                     source        = $Disc.NodeId
                     target        = $Edge.target
@@ -1469,6 +1484,9 @@ $SchemaPrompt
         Write-Host "  New edge types:   $($NewEdgeTypes.Count)" -ForegroundColor Yellow
     }
     Write-Host "  Total edges in store: $($EdgesList.Count)" -ForegroundColor Cyan
+    if ($MissingRationaleCount -gt 0) {
+        Write-Warning "Edge discovery: $MissingRationaleCount proposed edge(s) had an empty/missing rationale (LLM omitted the schema-required field); stored rationale='' for these. Inspect the model output or re-run — silent-blank rationales are a tracked gap (t/2674)."
+    }
     Write-Host ''
     Write-Host 'Proposed edges need human approval. Use Approve-Edge or Review-Edges to manage.' -ForegroundColor DarkGray
     Write-Host ''

--- a/tests/Invoke-EdgeDiscovery.Tests.ps1
+++ b/tests/Invoke-EdgeDiscovery.Tests.ps1
@@ -123,3 +123,80 @@ Describe 'Edge validation (gaps 7.1-7.4)' -Tag 'taxonomy' {
         }
     }
 }
+
+Describe 'Rationale silent-blank observability (t/2674)' -Tag 'taxonomy' {
+
+    BeforeEach {
+        InModuleScope AITriad {
+            $script:RatTempDir = Join-Path ([System.IO.Path]::GetTempPath()) "edge-rat-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $script:RatTempDir -Force | Out-Null
+            $TaxJson = @{
+                nodes = @(
+                    @{ id = 'acc-beliefs-001'; label = 'A'; description = 'A'; category = 'Beliefs' }
+                    @{ id = 'saf-beliefs-001'; label = 'B'; description = 'B'; category = 'Beliefs' }
+                )
+            } | ConvertTo-Json -Depth 5
+            Set-Content -Path (Join-Path $script:RatTempDir 'accelerationist.json') -Value $TaxJson
+            Set-Content -Path (Join-Path $script:RatTempDir 'safetyist.json') -Value '{"nodes":[]}'
+            Set-Content -Path (Join-Path $script:RatTempDir 'skeptic.json') -Value '{"nodes":[]}'
+            Set-Content -Path (Join-Path $script:RatTempDir 'situations.json') -Value '{"nodes":[]}'
+            Mock Get-TaxonomyDir { $script:RatTempDir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            Mock Write-Utf8NoBom { }
+        }
+    }
+
+    AfterEach {
+        InModuleScope AITriad {
+            Remove-Item -Path $script:RatTempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'FIRE ARM: warns when the LLM omits rationale (silent-blank surfaced, not swallowed)' {
+        InModuleScope AITriad {
+            # Two valid, distinct-type edges with NO rationale property — mirrors an
+            # LLM that omits the schema-required field (the real silent-blank cause).
+            Mock Invoke-NodeEdgeDiscovery {
+                [PSCustomObject]@{
+                    NodeId = $Node.id
+                    RawEdges = @(
+                        [PSCustomObject]@{ target = 'saf-beliefs-001'; type = 'SUPPORTS'; confidence = 0.8 }
+                        [PSCustomObject]@{ target = 'saf-beliefs-001'; type = 'WEAKENS';  confidence = 0.8 }
+                    )
+                    NewEdgeTypes = @(); Error = $null; ElapsedSec = 0.5
+                }
+            }
+
+            $warn = $null
+            $null = Invoke-EdgeDiscovery -NodeId 'acc-beliefs-001' -Force -MaxConcurrent 1 `
+                -RepoRoot $script:RatTempDir -WarningVariable warn -WarningAction SilentlyContinue 6>$null
+            $warnText = ($warn -join "`n")
+
+            $warnText | Should -Match 'rationale' -Because 'an omitted rationale must be surfaced, not silently blank'
+            $warnText | Should -Match 't/2674'
+            $warnText | Should -Match '2 proposed edge' -Because 'both rationale-less edges must be counted'
+        }
+    }
+
+    It 'CLEAN ARM: no rationale warning when every edge carries one (gate does not false-fire)' {
+        InModuleScope AITriad {
+            Mock Invoke-NodeEdgeDiscovery {
+                [PSCustomObject]@{
+                    NodeId = $Node.id
+                    RawEdges = @(
+                        [PSCustomObject]@{ target = 'saf-beliefs-001'; type = 'SUPPORTS'; confidence = 0.8; rationale = 'Because it supports' }
+                        [PSCustomObject]@{ target = 'saf-beliefs-001'; type = 'WEAKENS';  confidence = 0.8; rationale = 'Because it weakens' }
+                    )
+                    NewEdgeTypes = @(); Error = $null; ElapsedSec = 0.5
+                }
+            }
+
+            $warn = $null
+            $null = Invoke-EdgeDiscovery -NodeId 'acc-beliefs-001' -Force -MaxConcurrent 1 `
+                -RepoRoot $script:RatTempDir -WarningVariable warn -WarningAction SilentlyContinue 6>$null
+            $warnText = ($warn -join "`n")
+
+            $warnText | Should -Not -Match 't/2674' -Because 'a fully-populated run must not emit the silent-blank warning'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Observability arm of t/2674 (TL-approved p/360#65; self-cert /trivial-change). When the LLM omits the schema-required `rationale`, `Invoke-EdgeDiscovery` still writes the edge with `rationale=''` (schema contract preserved) — previously with **no signal**, the same silent-failure class as t/2664/t/2669. Now a function-scoped counter tallies empty/missing rationales across all four build sites (embedding-first, batch, per-node ×2) and a run-summary `Write-Warning` surfaces the count on both completion paths.

**No change to what is written** — purely additive observability.

## Investigation (t/2674#1)
The PI-reported blank rationales are a **DATA gap, not a render bug**: 33,456 of 33,621 edges (99.5%) have the `rationale` key **entirely absent** — historical schema drift (predates rationale being added to the writer), not swallowed blanks (zero empty-strings in the data). Backfilling those 33k is a **separate ticket, blocked on PI AI-spend sign-off** (TL to scope cost: all vs. UI-visible/high-degree subset; flash-lite free-tier vs. paid).

## Test plan
- [x] 2 gate-integrity arms in `Invoke-EdgeDiscovery.Tests.ps1`: **FIRE** (LLM omits rationale → warning fires with the count `2 proposed edge(s)`) and **CLEAN** (rationale present → no warning, no false-fire). Existing edge-validation tests unaffected.
- [x] Full `Invoke-Pester ./tests/` (keys unset, CI-faithful): **1201 passed, 0 failed**, 53 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
