### PR TITLE
feat(debate): land provisional AFFECT_PHASE_BASELINES refit (t/2675)

### DIFF
--- a/lib/debate/affectSignals.test.ts
+++ b/lib/debate/affectSignals.test.ts
@@ -118,7 +118,7 @@ describe('computeAffectAppropriateness (share-normalized, t/1785)', () => {
   });
 
   it('distinguishes different balances at the same magnitude (AC3)', () => {
-    // Concluding baseline is hope-dominant (0.39) and outrage-minimal (0.04).
+    // Concluding baseline is empathy-dominant (0.40) and urgency-minimal (0.09) after t/1771 refit.
     const hopeDominant: AffectProfile = { urgency: 0.10, fear: 0.03, hope: 0.40, outrage: 0.02, empathy: 0.25 };
     const outrageDominant: AffectProfile = { urgency: 0.10, fear: 0.10, hope: 0.05, outrage: 0.60, empathy: 0.05 };
     const sHope = computeAffectAppropriateness(hopeDominant, 'concluding')!;
@@ -127,7 +127,7 @@ describe('computeAffectAppropriateness (share-normalized, t/1785)', () => {
   });
 
   it('scores ~0 for a balance far from the phase baseline', () => {
-    // All mass in outrage; concluding rates outrage lowest (0.04) → maximal share deviation.
+    // All mass in outrage; concluding baseline outrage share is 0.11 → large deviation, scores near 0.
     const allOutrage: AffectProfile = { urgency: 0, fear: 0, hope: 0, outrage: 1, empathy: 0 };
     const score = computeAffectAppropriateness(allOutrage, 'concluding')!;
     expect(score).toBeLessThanOrEqual(0.05);

--- a/lib/debate/affectSignals.ts
+++ b/lib/debate/affectSignals.ts
@@ -62,10 +62,15 @@ export const AFFECT_SATURATION_RATE: Record<AffectCategory, number> = {
   empathy: 4.0,
 };
 
+// Provisional fit from t/1771 + research/comp-linguist/analyses/t1771-affect/provisional-fit.md.
+// Replaces the pre-fit stipulated vector that made the 0.60 target unreachable (ceiling 0.580,
+// 100% of real turns below). Refit → median affect_appropriateness 0.40→0.63. Row stays
+// stipulated (provisional). Values from runs after this land are NOT comparable to the interim
+// post-t/1785 window. MAX_ACCEPTABLE_DEVIATION (0.35) is unchanged.
 export const AFFECT_PHASE_BASELINES: Record<Exclude<DebatePhase, 'terminated'>, AffectProfile> = {
-  confrontation: { urgency: 0.30, fear: 0.20, hope: 0.17, outrage: 0.17, empathy: 0.14 },
-  argumentation: { urgency: 0.20, fear: 0.12, hope: 0.30, outrage: 0.09, empathy: 0.24 },
-  concluding:    { urgency: 0.25, fear: 0.08, hope: 0.39, outrage: 0.04, empathy: 0.29 },
+  confrontation: { urgency: 0.06, fear: 0.36, hope: 0.09, outrage: 0.10, empathy: 0.40 },
+  argumentation: { urgency: 0.07, fear: 0.39, hope: 0.09, outrage: 0.08, empathy: 0.37 },
+  concluding:    { urgency: 0.09, fear: 0.30, hope: 0.10, outrage: 0.11, empathy: 0.40 },
 };
 
 const INTENSITY_WEIGHTS: Record<AffectCategory, number> = {


### PR DESCRIPTION
## Summary
- Replaces the pre-fit `AFFECT_PHASE_BASELINES` constant in `affectSignals.ts` with CL-fitted vectors from t/1771 provisional analysis
- Old baselines made the 0.60 appropriateness target unreachable (ceiling 0.580); refit → median 0.40→0.63
- `MAX_ACCEPTABLE_DEVIATION` (0.35) and all lexicon/saturation values unchanged
- Row stays `stipulated` (provisional); values post-land are not comparable to interim post-t/1785 window
- Updated two stale test comments that referenced old baseline shape

## Test plan
- [x] `affectSignals.test.ts` — 23/23 passing
- [x] Full debate suite — 3003/3003 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)