### PR TITLE
fix(storage): toRepoPath strips getDataRoot() not cacheDir (t/2670)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/githubApi.test.ts
+++ b/taxonomy-editor/src/server/__tests__/githubApi.test.ts
@@ -107,6 +107,9 @@ const originalFetch = globalThis.fetch;
 beforeEach(() => {
   fetchCalls.length = 0;
   apiHandlers = [];
+  // Align getDataRoot() with createBackend()'s cacheDir so toRepoPath() strips the
+  // right prefix. Tests that need a divergent dataRoot override this in their own beforeEach.
+  vi.stubEnv('AI_TRIAD_DATA_ROOT', '/var/cache/taxonomy-test');
 
   globalThis.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;

--- a/taxonomy-editor/src/server/__tests__/githubApi.test.ts
+++ b/taxonomy-editor/src/server/__tests__/githubApi.test.ts
@@ -1758,6 +1758,38 @@ describe('GitHubAPIBackend — undici dispatcher (t/2053)', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// t/2670: toRepoPath must strip getDataRoot(), not cacheDir — separate cache
+// mount must not 404 all github-api reads.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('toRepoPath strips getDataRoot() not cacheDir (t/2670)', () => {
+  // Simulate a staging deployment where TAXONOMY_CACHE_DIR != AI_TRIAD_DATA_ROOT.
+  // cacheDir comes from createBackend() = '/var/cache/taxonomy-test'.
+  // getDataRoot() reads AI_TRIAD_DATA_ROOT; stub it to a distinct value.
+  const FAKE_DATA_ROOT = '/mnt/shared-data';
+
+  beforeEach(() => { vi.stubEnv('AI_TRIAD_DATA_ROOT', FAKE_DATA_ROOT); });
+  afterEach(() => { vi.unstubAllEnvs(); });
+
+  it('resolves a getDataRoot()-prefixed absolute path to a repo-relative path when cacheDir differs', async () => {
+    const backend = await createBackend(); // cacheDir = /var/cache/taxonomy-test
+
+    // File path as fileIO.ts constructs it: absolute, rooted at getDataRoot().
+    await backend.readFile(`${FAKE_DATA_ROOT}/taxonomy/nodes.json`);
+
+    // The GitHub Contents API call must use the repo-relative path.
+    // With the bug (strip cacheDir): prefix not stripped → URL gets 'mnt/shared-data/taxonomy/...'
+    // With the fix (strip dataRoot): prefix stripped → URL gets 'taxonomy/nodes.json'
+    const contentCall = fetchCalls.find(c => c.method === 'GET' && c.url.includes('/contents/'));
+    expect(contentCall).toBeDefined();
+    expect(contentCall!.url).toContain('/contents/taxonomy/nodes.json');
+    expect(contentCall!.url).not.toContain('mnt/shared-data');
+
+    backend.shutdown();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // t/2113: undici major-version invariant — gate fires from both directions
 // ═══════════════════════════════════════════════════════════════════════════
 

--- a/taxonomy-editor/src/server/storage/githubAPIBackend.ts
+++ b/taxonomy-editor/src/server/storage/githubAPIBackend.ts
@@ -27,6 +27,7 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import type { FlightRecorder, RecordInput } from '../../../../lib/flight-recorder/index.js';
 import { getCurrentUserId, getSessionBranchName } from '../security/userContext.js';
 import { GitHubRestClient, normalizeErrorForEvent, type CircuitState } from './githubRestClient.js';
+import { getDataRoot } from '../config.js';
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -1155,9 +1156,14 @@ export class GitHubAPIBackend implements StorageBackend {
   private toRepoPath(filePath: string): string {
     let p = filePath;
 
-    // If the path is absolute and starts with the cache dir, strip it
-    if (p.startsWith(this.cacheDir)) {
-      p = p.slice(this.cacheDir.length);
+    // Strip the data-root prefix to get the repo-relative path. Use getDataRoot()
+    // (the actual source of incoming absolute paths from fileIO.ts) rather than
+    // this.cacheDir (the disk-cache write location) — they can diverge when the
+    // cache is on a separate mount (e.g. TAXONOMY_CACHE_DIR != AI_TRIAD_DATA_ROOT),
+    // which caused staging github-api reads to 404 (t/2670).
+    const dataRoot = getDataRoot();
+    if (p.startsWith(dataRoot)) {
+      p = p.slice(dataRoot.length);
     }
 
     // Strip leading slashes


### PR DESCRIPTION
## Summary

- `GitHubAPIBackend.toRepoPath()` was stripping `this.cacheDir` to convert absolute paths to repo-relative paths, but incoming paths from `fileIO.ts` are rooted at `getDataRoot()` — these diverge when `TAXONOMY_CACHE_DIR` is set to a different mount than `AI_TRIAD_DATA_ROOT` (the staging Azure Files scenario)
- With the bug, a path like `/mnt/shared-data/taxonomy/nodes.json` had nothing stripped, becoming `/contents/mnt/shared-data/taxonomy/nodes.json` → 404 on every GitHub Contents API call
- Fix: strip `getDataRoot()` instead of `this.cacheDir` in `toRepoPath()`
- Regression test stubs `AI_TRIAD_DATA_ROOT=/mnt/shared-data` with `cacheDir=/var/cache/taxonomy-test` and asserts the fetched URL resolves to `/contents/taxonomy/nodes.json`

## Test plan

- [ ] `npx vitest run src/server/__tests__/githubApi.test.ts` green on CI (Node 22.x — local Node 24.x hits undici skew guard, same as all 74 pre-existing tests)
- [ ] No other tests affected (storage-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)