### PR TITLE
feat(cmdlet): Invoke-EdgeRationaleBackfill — AI backfill for missing edge rationales (t/2679)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -89,6 +89,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-IngestionPriority` | Score sources by ingestion value |
 | `Invoke-AttributeExtraction` | AI-extract attributes from a source |
 | `Invoke-EdgeDiscovery` | Discover candidate edges from text |
+| `Invoke-EdgeRationaleBackfill` | Backfill missing/empty edge `rationale` via AI — idempotent, resumable, `-DryRun`/`-Limit` for a costed pilot (t/2679) |
 
 ### AI Enrichment
 | Cmdlet | Use when |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -41,6 +41,7 @@
         'Get-Summary'
         'Invoke-AttributeExtraction'
         'Invoke-EdgeDiscovery'
+        'Invoke-EdgeRationaleBackfill'
         'Get-GraphNode'
         'Find-GraphPath'
         'Approve-Edge'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -760,6 +760,7 @@ Export-ModuleMember -Function @(
     'Get-Summary'
     'Invoke-AttributeExtraction'
     'Invoke-EdgeDiscovery'
+    'Invoke-EdgeRationaleBackfill'
     'Get-GraphNode'
     'Find-GraphPath'
     'Approve-Edge'
@@ -963,7 +964,7 @@ $_modelCompleter = {
 
 foreach ($_cmd in @(
     'Invoke-POVSummary', 'Invoke-BatchSummary', 'Invoke-AttributeExtraction',
-    'Invoke-EdgeDiscovery', 'Invoke-GraphQuery', 'Invoke-TaxonomyProposal',
+    'Invoke-EdgeDiscovery', 'Invoke-EdgeRationaleBackfill', 'Invoke-GraphQuery', 'Invoke-TaxonomyProposal',
     'Invoke-HierarchyProposal', 'Invoke-PolicyRefinement', 'Invoke-AITDebate',
     'Import-AITriadDocument', 'Find-PolicyAction', 'Find-PossibleFallacy',
     'Find-SituationCandidates', 'Get-ConflictEvolution', 'Get-Edge',

--- a/scripts/AITriad/Prompts/edge-rationale-backfill.prompt
+++ b/scripts/AITriad/Prompts/edge-rationale-backfill.prompt
@@ -1,0 +1,16 @@
+You are a research analyst for the AI Triad project (AI policy/safety taxonomy).
+
+Write ONE concise rationale (1-2 sentences, at most ~300 characters) explaining WHY the SOURCE node stands in a "{{EDGE_TYPE}}" relationship to the TARGET node. Ground the rationale in the substance of the two nodes; do not merely restate their labels. Be specific about the conceptual link the edge type asserts.
+
+Edge type "{{EDGE_TYPE}}" means: {{EDGE_TYPE_DEF}}
+
+SOURCE node ({{SOURCE_ID}})
+  Label: {{SOURCE_LABEL}}
+  Description: {{SOURCE_DESC}}
+
+TARGET node ({{TARGET_ID}})
+  Label: {{TARGET_LABEL}}
+  Description: {{TARGET_DESC}}
+
+Return ONLY JSON: {"rationale": "..."}
+No markdown fences, no extra keys, no commentary.

--- a/scripts/AITriad/Public/Invoke-EdgeRationaleBackfill.ps1
+++ b/scripts/AITriad/Public/Invoke-EdgeRationaleBackfill.ps1
@@ -1,0 +1,276 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Invoke-EdgeRationaleBackfill {
+    <#
+    .SYNOPSIS
+        Backfills missing/empty `rationale` on existing edges via AI (t/2679).
+    .DESCRIPTION
+        Historical edges in edges.json predate the `rationale` field (t/2674: 99.5%
+        absent). This cmdlet finds edges whose rationale is missing or empty, asks an
+        LLM to generate one from the source+target node text and the edge type, and
+        writes it back via Write-EdgesFile — WITHOUT changing any edge's status.
+
+        Idempotent: edges that already have a non-empty rationale are skipped unless
+        -Force. Resumable: writes a checkpoint every -CheckpointEvery successful
+        backfills, so an interrupted run can be re-run and picks up where it left off.
+        Silent-blank safe: if the LLM returns no rationale, the edge is left unchanged
+        and the omission is surfaced (a Write-Warning count), never written as ''
+        (the t/2674 observability contract).
+    .PARAMETER Scope
+        'UIVisible' (default) backfills only approved edges (those rendered in the
+        EdgeBrowser). 'All' backfills every rationale-less edge regardless of status.
+    .PARAMETER Limit
+        Cap the number of edges processed this run (0 = no cap). Use for a costed
+        pilot, e.g. -Limit 200.
+    .PARAMETER Model
+        AI model. Default 'gemini-3.5-flash-lite' (free tier).
+    .PARAMETER ApiKey
+        AI API key. If omitted, resolved via backend env var (GEMINI_API_KEY, etc).
+    .PARAMETER Temperature
+        Sampling temperature. Default 0.3.
+    .PARAMETER Force
+        Overwrite existing non-empty rationales too (default: skip already-populated).
+    .PARAMETER CheckpointEvery
+        Write edges.json after every N successful backfills (0 = only at the end).
+        Default 25.
+    .PARAMETER DryRun
+        Select target edges and render the first prompt, but make NO API calls and NO
+        writes. Reports how many edges WOULD be processed — use to size a pilot's cost.
+    .PARAMETER RepoRoot
+        Repository root. Defaults to the module-resolved root.
+    .OUTPUTS
+        [PSCustomObject] summary: Targeted, Backfilled, Failed, SkippedNoNodeText, DryRun.
+    .EXAMPLE
+        # Costed pilot preview — no spend, no writes
+        Invoke-EdgeRationaleBackfill -Scope UIVisible -Limit 200 -DryRun
+    .EXAMPLE
+        # Run the 200-edge pilot on the free tier
+        Invoke-EdgeRationaleBackfill -Scope UIVisible -Limit 200
+    .LINK
+        Invoke-EdgeDiscovery
+    .LINK
+        Approve-Edge
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [ValidateSet('UIVisible', 'All')]
+        [string]$Scope = 'UIVisible',
+
+        [Parameter()]
+        [ValidateRange(0, 100000)]
+        [int]$Limit = 0,
+
+        [Parameter()]
+        [ValidateScript({ Test-AIModelId $_ })]
+        [string]$Model = 'gemini-3.5-flash-lite',
+
+        [Parameter()]
+        [string]$ApiKey = '',
+
+        [Parameter()]
+        [ValidateRange(0.0, 1.0)]
+        [double]$Temperature = 0.3,
+
+        [Parameter()]
+        [switch]$Force,
+
+        [Parameter()]
+        [ValidateRange(0, 10000)]
+        [int]$CheckpointEvery = 25,
+
+        [Parameter()]
+        [switch]$DryRun,
+
+        [Parameter()]
+        [string]$RepoRoot
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    # ── Resolve backend + key (fail fast with a clear message) ────────────
+    $Backend = if ($Model -match '^gemini') { 'gemini' }
+        elseif ($Model -match '^claude') { 'claude' }
+        elseif ($Model -match '^groq')   { 'groq' }
+        elseif ($Model -match '^openai') { 'openai' }
+        else                             { 'gemini' }
+    if (-not $DryRun) {
+        $ResolvedKey = Resolve-AIApiKey -ExplicitKey $ApiKey -Backend $Backend
+    } else {
+        $ResolvedKey = ''
+    }
+
+    # ── Load edges.json ───────────────────────────────────────────────────
+    $TaxDir    = if ($RepoRoot) { Join-Path $RepoRoot 'taxonomy/Origin' } else { Get-TaxonomyDir }
+    $EdgesPath = Join-Path $TaxDir 'edges.json'
+    if (-not (Test-Path -LiteralPath $EdgesPath)) {
+        throw (New-ActionableError `
+            -Goal 'Backfill edge rationales' `
+            -Problem "edges.json not found at $EdgesPath" `
+            -Location 'Invoke-EdgeRationaleBackfill' `
+            -NextSteps 'Verify the data root (Get-TaxonomyDir) or pass -RepoRoot to the repo containing taxonomy/Origin/edges.json.')
+    }
+    $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+
+    # ── Build node id → {label, description} map from all node files ──────
+    $NodeText = @{}
+    foreach ($File in Get-ChildItem -Path $TaxDir -Filter '*.json' -File) {
+        if ($File.Name -in @('edges.json', 'embeddings.json', 'policy_actions.json')) { continue }
+        try { $Doc = Get-Content -Raw -Path $File.FullName | ConvertFrom-Json } catch { continue }
+        if (-not ($Doc.PSObject.Properties['nodes'])) { continue }
+        foreach ($N in @($Doc.nodes)) {
+            if ($N.PSObject.Properties['id']) {
+                $NodeText[$N.id] = [PSCustomObject]@{
+                    Label = if ($N.PSObject.Properties['label']) { [string]$N.label } else { '' }
+                    Desc  = if ($N.PSObject.Properties['description']) { [string]$N.description } else { '' }
+                }
+            }
+        }
+    }
+
+    # ── Edge-type definitions (for prompt context) ───────────────────────
+    $TypeDef = @{}
+    if ($EdgesData.PSObject.Properties['edge_types']) {
+        foreach ($T in @($EdgesData.edge_types)) {
+            if ($T.PSObject.Properties['type']) {
+                $TypeDef[$T.type] = if ($T.PSObject.Properties['definition']) { [string]$T.definition } else { '' }
+            }
+        }
+    }
+
+    # ── Select target edges ───────────────────────────────────────────────
+    $Targets = [System.Collections.Generic.List[object]]::new()
+    foreach ($E in @($EdgesData.edges)) {
+        $HasRationale = $E.PSObject.Properties['rationale'] -and -not [string]::IsNullOrWhiteSpace($E.rationale)
+        if ($HasRationale -and -not $Force) { continue }
+        if ($Scope -eq 'UIVisible') {
+            $Status = if ($E.PSObject.Properties['status']) { $E.status } else { '' }
+            if ($Status -ne 'approved') { continue }
+        }
+        $Targets.Add($E)
+    }
+    if ($Limit -gt 0 -and $Targets.Count -gt $Limit) {
+        $Targets = [System.Collections.Generic.List[object]]@($Targets[0..($Limit - 1)])
+    }
+
+    Write-Host "Edge rationale backfill: $($Targets.Count) target edge(s) [scope=$Scope, limit=$Limit, model=$Model]" -ForegroundColor Cyan
+
+    $Summary = {
+        param($t, $b, $f, $s, $dry)
+        [PSCustomObject]@{
+            Targeted          = $t
+            Backfilled        = $b
+            Failed            = $f
+            SkippedNoNodeText = $s
+            DryRun            = [bool]$dry
+            Model             = $Model
+            Scope             = $Scope
+        }
+    }
+
+    # Render the {{...}} replacement map for one edge.
+    $BuildReplacements = {
+        param($Edge)
+        $Src = if ($NodeText.ContainsKey($Edge.source)) { $NodeText[$Edge.source] } else { $null }
+        $Tgt = if ($NodeText.ContainsKey($Edge.target)) { $NodeText[$Edge.target] } else { $null }
+        if (-not $Src -or -not $Tgt) { return $null }
+        $Trunc = { param($s) if ($s.Length -gt 400) { $s.Substring(0, 400) } else { $s } }
+        @{
+            EDGE_TYPE     = [string]$Edge.type
+            EDGE_TYPE_DEF = if ($TypeDef.ContainsKey($Edge.type)) { $TypeDef[$Edge.type] } else { '(see taxonomy edge-type vocabulary)' }
+            SOURCE_ID     = [string]$Edge.source
+            SOURCE_LABEL  = $Src.Label
+            SOURCE_DESC   = & $Trunc $Src.Desc
+            TARGET_ID     = [string]$Edge.target
+            TARGET_LABEL  = $Tgt.Label
+            TARGET_DESC   = & $Trunc $Tgt.Desc
+        }
+    }
+
+    # ── Dry run: preview target count + first prompt, no API, no writes ───
+    if ($DryRun) {
+        if ($Targets.Count -gt 0) {
+            $R = & $BuildReplacements $Targets[0]
+            if ($R) {
+                Write-Host ''
+                Write-Host '--- Sample prompt (first target edge) ---' -ForegroundColor DarkGray
+                Write-Host (Get-Prompt -Name 'edge-rationale-backfill' -Replacements $R)
+            } else {
+                Write-Host '  (first target edge has no resolvable node text — it would be skipped)' -ForegroundColor DarkYellow
+            }
+        }
+        Write-Host ''
+        Write-Host "DRY RUN — no API calls, no writes. Would process $($Targets.Count) edge(s)." -ForegroundColor Yellow
+        return & $Summary $Targets.Count 0 0 0 $true
+    }
+
+    # ── Backfill loop ─────────────────────────────────────────────────────
+    $Schema = @{ type = 'object'; properties = @{ rationale = @{ type = 'string' } }; required = @('rationale') }
+    $Backfilled = 0; $Failed = 0; $SkippedNoText = 0
+
+    foreach ($Edge in $Targets) {
+        $EdgeKey = "$($Edge.source)->$($Edge.target) ($($Edge.type))"
+
+        $Repl = & $BuildReplacements $Edge
+        if (-not $Repl) {
+            Write-Warning "Skip $EdgeKey — source/target node text not found in taxonomy."
+            $SkippedNoText++
+            continue
+        }
+
+        if (-not $PSCmdlet.ShouldProcess($EdgeKey, 'Generate + write rationale')) { continue }
+
+        $Rationale = $null
+        try {
+            $Prompt   = Get-Prompt -Name 'edge-rationale-backfill' -Replacements $Repl
+            $Response = Invoke-AIApi -Prompt $Prompt -Model $Model -ApiKey $ResolvedKey `
+                -Temperature $Temperature -MaxTokens 512 -TimeoutSec 60 -JsonMode -ResponseSchema $Schema
+            $Text = ($Response.Text -replace '^```(json)?', '' -replace '```$', '').Trim()
+            $Parsed = $Text | ConvertFrom-Json
+            if ($Parsed.PSObject.Properties['rationale']) { $Rationale = [string]$Parsed.rationale }
+        } catch {
+            Write-Warning "Backfill failed for $EdgeKey — $($_.Exception.Message)"
+        }
+
+        if ([string]::IsNullOrWhiteSpace($Rationale)) {
+            # Silent-blank contract (t/2674): surface, do NOT write a blank.
+            Write-Warning "No rationale returned for $EdgeKey — leaving unchanged (not written blank)."
+            $Failed++
+            continue
+        }
+
+        if ($Edge.PSObject.Properties['rationale']) {
+            $Edge.rationale = $Rationale
+        } else {
+            Add-Member -InputObject $Edge -NotePropertyName 'rationale' -NotePropertyValue $Rationale -Force
+        }
+        $Backfilled++
+
+        if ($CheckpointEvery -gt 0 -and ($Backfilled % $CheckpointEvery) -eq 0) {
+            $EdgesData.last_modified = (Get-Date).ToString('yyyy-MM-dd')
+            Write-EdgesFile -EdgesData $EdgesData -Path $EdgesPath
+            Write-Host "  checkpoint: $Backfilled written" -ForegroundColor DarkGray
+        }
+    }
+
+    # ── Final write ───────────────────────────────────────────────────────
+    if ($Backfilled -gt 0) {
+        $EdgesData.last_modified = (Get-Date).ToString('yyyy-MM-dd')
+        Write-EdgesFile -EdgesData $EdgesData -Path $EdgesPath
+    }
+
+    Write-Host ''
+    Write-Host "=== Backfill complete ===" -ForegroundColor Cyan
+    Write-Host "  Backfilled:          $Backfilled" -ForegroundColor Green
+    Write-Host "  Failed (no output):  $Failed" -ForegroundColor $(if ($Failed -gt 0) { 'Yellow' } else { 'Green' })
+    Write-Host "  Skipped (no text):   $SkippedNoText" -ForegroundColor $(if ($SkippedNoText -gt 0) { 'Yellow' } else { 'Green' })
+
+    if ($Failed -gt 0) {
+        Write-Warning "$Failed edge(s) produced no rationale and were left unchanged (t/2674 silent-blank contract)."
+    }
+
+    return & $Summary $Targets.Count $Backfilled $Failed $SkippedNoText $false
+}

--- a/tests/Invoke-EdgeRationaleBackfill.Tests.ps1
+++ b/tests/Invoke-EdgeRationaleBackfill.Tests.ps1
@@ -1,0 +1,178 @@
+# Tag: taxonomy (t/2679)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Invoke-EdgeRationaleBackfill (t/2679) — AI edge-rationale backfill.
+.DESCRIPTION
+    The AI call (Invoke-AIApi) and the writer (Write-EdgesFile) are mocked, so NO
+    spend and NO disk writes occur. Each It is self-contained (fixture + mocks + call
+    in one InModuleScope) to avoid cross-file mock-carry flakiness.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Invoke-EdgeRationaleBackfill (t/2679)' -Tag 'taxonomy' {
+
+    It 'is exported from the AITriad module' {
+        Get-Command -Module AITriad -Name 'Invoke-EdgeRationaleBackfill' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'DryRun selects only UIVisible rationale-less edges — no API call, no write' {
+        InModuleScope AITriad {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            @{ nodes = @(
+                @{ id = 'acc-b-1'; label = 'A'; description = 'Desc A' }
+                @{ id = 'acc-b-2'; label = 'B'; description = 'Desc B' }
+            ) } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $dir 'accelerationist.json')
+            @{
+                _schema_version = '1.0.0'; _doc = 't'; last_modified = '2026-01-01'
+                edge_types = @(@{ type = 'SUPPORTS'; bidirectional = $false; definition = 'Source strengthens target.' })
+                edges = @(
+                    @{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'SUPPORTS'; confidence = 0.8; status = 'approved' }                          # rationale-less approved
+                    @{ source = 'acc-b-2'; target = 'acc-b-1'; type = 'SUPPORTS'; confidence = 0.7; status = 'approved'; rationale = 'already here' } # has rationale
+                    @{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'WEAKENS';  confidence = 0.6; status = 'proposed' }                          # proposed
+                )
+            } | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $dir 'edges.json')
+
+            Mock Get-TaxonomyDir { $dir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = '{"rationale":"nope"}' } }
+            Mock Write-EdgesFile { }
+
+            try {
+                $r = Invoke-EdgeRationaleBackfill -Scope UIVisible -DryRun 6>$null
+                $r.Targeted | Should -Be 1 -Because 'only the approved rationale-less edge qualifies (has-rationale + proposed excluded)'
+                $r.DryRun   | Should -BeTrue
+                $r.Backfilled | Should -Be 0
+                Should -Invoke Invoke-AIApi   -Times 0 -Exactly
+                Should -Invoke Write-EdgesFile -Times 0 -Exactly
+            } finally { Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'backfills an approved rationale-less edge and writes it back' {
+        InModuleScope AITriad {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            @{ nodes = @(
+                @{ id = 'acc-b-1'; label = 'A'; description = 'Desc A' }
+                @{ id = 'acc-b-2'; label = 'B'; description = 'Desc B' }
+            ) } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $dir 'accelerationist.json')
+            @{
+                _schema_version = '1.0.0'; _doc = 't'; last_modified = '2026-01-01'
+                edge_types = @(@{ type = 'SUPPORTS'; bidirectional = $false; definition = 'Source strengthens target.' })
+                edges = @(@{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'SUPPORTS'; confidence = 0.8; status = 'approved' })
+            } | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $dir 'edges.json')
+
+            Mock Get-TaxonomyDir { $dir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = '{"rationale":"Generated reason"}' } }
+            $script:Captured = $null
+            Mock Write-EdgesFile { $script:Captured = $EdgesData }
+
+            try {
+                $r = Invoke-EdgeRationaleBackfill -Scope UIVisible -CheckpointEvery 0 6>$null
+                $r.Backfilled | Should -Be 1
+                $r.Failed     | Should -Be 0
+                Should -Invoke Invoke-AIApi -Times 1 -Exactly
+                Should -Invoke Write-EdgesFile -Times 1 -Exactly
+                $script:Captured.edges[0].rationale | Should -Be 'Generated reason'
+            } finally { Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'is idempotent + scope-aware: -Scope All includes proposed, excludes already-populated' {
+        InModuleScope AITriad {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            @{ nodes = @(
+                @{ id = 'acc-b-1'; label = 'A'; description = 'Desc A' }
+                @{ id = 'acc-b-2'; label = 'B'; description = 'Desc B' }
+            ) } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $dir 'accelerationist.json')
+            @{
+                _schema_version = '1.0.0'; _doc = 't'; last_modified = '2026-01-01'
+                edge_types = @(@{ type = 'SUPPORTS'; bidirectional = $false; definition = 'x' })
+                edges = @(
+                    @{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'SUPPORTS'; confidence = 0.8; status = 'approved' }
+                    @{ source = 'acc-b-2'; target = 'acc-b-1'; type = 'SUPPORTS'; confidence = 0.7; status = 'approved'; rationale = 'already here' }
+                    @{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'WEAKENS';  confidence = 0.6; status = 'proposed' }
+                )
+            } | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $dir 'edges.json')
+
+            Mock Get-TaxonomyDir { $dir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = '{"rationale":"nope"}' } }
+            Mock Write-EdgesFile { }
+
+            try {
+                $r = Invoke-EdgeRationaleBackfill -Scope All -DryRun 6>$null
+                $r.Targeted | Should -Be 2 -Because 'All-scope targets both rationale-less edges (approved + proposed); the already-populated one is excluded'
+            } finally { Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'SILENT-BLANK: empty rationale from the LLM leaves the edge unchanged (Failed=1, never written blank)' {
+        InModuleScope AITriad {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            @{ nodes = @(
+                @{ id = 'acc-b-1'; label = 'A'; description = 'Desc A' }
+                @{ id = 'acc-b-2'; label = 'B'; description = 'Desc B' }
+            ) } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $dir 'accelerationist.json')
+            @{
+                _schema_version = '1.0.0'; _doc = 't'; last_modified = '2026-01-01'
+                edge_types = @(@{ type = 'SUPPORTS'; bidirectional = $false; definition = 'x' })
+                edges = @(@{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'SUPPORTS'; confidence = 0.8; status = 'approved' })
+            } | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $dir 'edges.json')
+
+            Mock Get-TaxonomyDir { $dir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = '{"rationale":""}' } }  # empty — the silent-blank case
+            Mock Write-EdgesFile { }
+
+            try {
+                $r = Invoke-EdgeRationaleBackfill -Scope UIVisible -CheckpointEvery 0 -WarningAction SilentlyContinue 6>$null
+                $r.Backfilled | Should -Be 0
+                $r.Failed     | Should -Be 1
+                Should -Invoke Write-EdgesFile -Times 0 -Exactly -Because 'a blank rationale must never be written (t/2674 contract)'
+            } finally { Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It '-Limit caps the number of edges processed' {
+        InModuleScope AITriad {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            @{ nodes = @(
+                @{ id = 'acc-b-1'; label = 'A'; description = 'Desc A' }
+                @{ id = 'acc-b-2'; label = 'B'; description = 'Desc B' }
+            ) } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $dir 'accelerationist.json')
+            @{
+                _schema_version = '1.0.0'; _doc = 't'; last_modified = '2026-01-01'
+                edge_types = @(@{ type = 'SUPPORTS'; bidirectional = $false; definition = 'x' })
+                edges = @(
+                    @{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'SUPPORTS'; confidence = 0.8; status = 'approved' }
+                    @{ source = 'acc-b-2'; target = 'acc-b-1'; type = 'SUPPORTS'; confidence = 0.7; status = 'approved' }
+                )
+            } | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $dir 'edges.json')
+
+            Mock Get-TaxonomyDir { $dir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = '{"rationale":"nope"}' } }
+            Mock Write-EdgesFile { }
+
+            try {
+                $r = Invoke-EdgeRationaleBackfill -Scope UIVisible -Limit 1 -DryRun 6>$null
+                $r.Targeted | Should -Be 1 -Because '-Limit 1 caps two eligible edges to one'
+            } finally { Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
New public cmdlet `Invoke-EdgeRationaleBackfill` (t/2679, follow-up to t/2674) that backfills missing/empty edge `rationale` via AI. t/2674 found 99.5% of edges lack a rationale (historical schema drift). This is the tool to close that gap.

- `-Scope UIVisible` (approved edges only, default) | `All`; `-Limit N` for a costed pilot
- `SupportsShouldProcess`; `-DryRun` previews the target count + a sample prompt (**no API call, no write**)
- **Idempotent** — skips edges that already have a non-empty rationale (unless `-Force`)
- **Resumable** — checkpoints every `-CheckpointEvery` successful writes
- **Silent-blank safe** — an empty LLM result leaves the edge unchanged and is surfaced (`Write-Warning` + `Failed` count), never written as `''` (the t/2674 contract)
- Prompt in `Prompts/edge-rationale-backfill.prompt` (`Get-Prompt`); reuses `Invoke-AIApi` / `Resolve-AIApiKey` / `Write-EdgesFile` — no new patterns; never mutates edge `status`

Self-cert **/add-ps-cmdlet** (writes via existing `Write-EdgesFile`, no direct taxonomy mutation). PI-approved pilot: 200 UI-visible edges on gemini-3.5-flash-lite free tier.

## Test plan
- [x] 6 Pester tests (`Invoke-AIApi` + `Write-EdgesFile` mocked — **no spend in CI**): exported; DryRun selects UIVisible-only + no API/write; backfills + writes back; scope/idempotency (All includes proposed, excludes already-populated); silent-blank leaves unchanged + never writes blank; `-Limit` caps.
- [x] Targeted regression: module load/exports (38), edge-discovery + edges-writer suites, `Test-ModuleManifest` — 42 passed, 0 failed. (CI runs the full ~1200-test sweep.)
- [x] **Validated on real data (DryRun, no spend):** 25,765 approved rationale-less edges (33,456 total).
- [x] **Live 3-edge free-tier sample on a scratch copy (real data untouched):** 3/3 backfilled, 0 failed, quality good/edge-type-aware.

The tool lands here; the real-data pilot run + data-repo landing is a separate step gated on PI direction (t/2679#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
