### PR TITLE
fix(affect): prune ubiquitous tokens from fear/empathy lexicons (t/2677)

### DIFF
--- a/lib/debate/affectSignals.test.ts
+++ b/lib/debate/affectSignals.test.ts
@@ -185,10 +185,11 @@ describe('computeAffectEvidence', () => {
     expect(ev.fear).not.toContain('dire');
   });
 
-  it('keeps inflected forms (risk→"risks")', () => {
-    const text = pad('The risks of this approach are significant and the threats multiply as benefits decrease.');
+  it('keeps inflected forms (danger→"dangers")', () => {
+    // 'risk' removed from fear lexicon (t/2677 — neutral noun); inflection tested via 'danger'/'dangers'.
+    const text = pad('The dangers of this approach are significant and the threats multiply as benefits decrease.');
     const ev = computeAffectEvidence(text);
-    expect(ev.fear).toContain('risk');
+    expect(ev.fear).toContain('danger');
     expect(ev.fear).toContain('threat');
   });
 });

--- a/lib/debate/affectSignals.ts
+++ b/lib/debate/affectSignals.ts
@@ -17,14 +17,15 @@ export const AFFECT_LEXICONS: Record<AffectCategory, string[]> = {
     'overdue', 'at once', 'no time to waste', 'act now', 'accelerating',
     'vital', 'essential', 'necessity', 'demands immediate',
   ],
+  // Dropped (t/2677): 'risk' (neutral noun), 'undermine'/'could lead to'/'may result in' (causal connectives),
+  // 'unpredictable' (neutral ML descriptor). Keep 'risky', 'severe' (genuine charge).
   fear: [
-    'danger', 'dangerous', 'threat', 'threaten', 'risk', 'risky',
+    'danger', 'dangerous', 'threat', 'threaten', 'risky',
     'harmful', 'catastrophic', 'catastrophe', 'devastating', 'disastrous',
     'disaster', 'alarming', 'alarm', 'worried', 'peril', 'perilous',
     'hazard', 'hazardous', 'menace', 'menacing', 'dire', 'existential',
-    'nightmare', 'irreversible', 'uncontrollable', 'unpredictable',
-    'jeopardize', 'endanger', 'undermine', 'could lead to',
-    'may result in', 'fallout', 'frightening', 'terrifying', 'severe',
+    'nightmare', 'irreversible', 'uncontrollable',
+    'jeopardize', 'endanger', 'fallout', 'frightening', 'terrifying', 'severe',
   ],
   hope: [
     'hope', 'hopeful', 'promising', 'potential', 'opportunity',
@@ -44,12 +45,15 @@ export const AFFECT_LEXICONS: Record<AffectCategory, string[]> = {
     'unconscionable', 'reprehensible', 'deplorable', 'at the expense of',
     'willfully ignore', 'deliberately disregard', 'contemptible',
   ],
+  // Dropped (t/2677): 'people'/'human'/'individual'/'individuals' (units of analysis),
+  // 'community'/'communities'/'workers' (neutral collective nouns),
+  // 'in practice'/'impact on' (analytic connectives — ubiquitous in AI-policy prose).
   empathy: [
-    'people', 'human', 'community', 'communities', 'victim', 'victims',
-    'suffer', 'suffering', 'pain', 'impact on', 'lived experience',
-    'families', 'workers', 'vulnerable', 'dignity', 'welfare', 'wellbeing',
+    'victim', 'victims',
+    'suffer', 'suffering', 'pain', 'lived experience',
+    'families', 'vulnerable', 'dignity', 'welfare', 'wellbeing',
     'affected by', 'those who', 'real people', 'ordinary', 'day to day',
-    'in practice', 'individual', 'individuals', 'struggle', 'burden',
+    'struggle', 'burden',
     'harm to', 'care', 'compassion',
   ],
 };


### PR DESCRIPTION
## Summary
- **FEAR drops (5):** `risk` (neutral noun), `undermine`/`could lead to`/`may result in` (causal connectives), `unpredictable` (neutral ML descriptor). Keep `risky`, `severe`.
- **EMPATHY drops (9):** `people`/`human`/`individual`/`individuals` (units of analysis), `community`/`communities`/`workers` (neutral collectives), `in practice`/`impact on` (analytic connectives).
- Test: pivot inflection fixture from `risk→risks` to `danger→dangers`.

## Why draft
Routing to CL for neutral-sentence probe before merge — this gates the t/2676 re-fit and the stipulated→derived promotion (t/1771). Will un-draft once CL confirms the probe no longer maxes fear/empathy.

Fixes t/2677 | Precondition for t/2676

🤖 Generated with Claude Code