### PR TITLE
docs(review): add Class 6 - silent degradation under single-context validation (t/2669)

### DIFF
--- a/docs/CodeReview/failure-classes.md
+++ b/docs/CodeReview/failure-classes.md
@@ -1,10 +1,10 @@
 # Failure-Class Taxonomy — Prospective Review Checklist
 
-**Last updated:** 2026-08-09
+**Last updated:** 2026-08-15
 **Owner:** Diagnostics (source analysis) / Tech Lead (review checklist)
-**Source:** e/84 systemic quality analysis of the 2026-08-09 Azure production bug sweep.
+**Source:** e/84 systemic quality analysis of the 2026-08-09 Azure production bug sweep; Class 6 added from the 2026-08-15 dual-build / staging-isolation sweep (t/2669).
 
-Purpose: turn post-incident hindsight into foresight. Before landing a change — especially at a producer/consumer seam, on a deploy path, or touching config — ask **"which of these classes could this change introduce?"** and require the corresponding test or gate. Each incident maps to one of five structural classes.
+Purpose: turn post-incident hindsight into foresight. Before landing a change — especially at a producer/consumer seam, on a deploy path, or touching config — ask **"which of these classes could this change introduce?"** and require the corresponding test or gate. Each incident maps to one of six structural classes.
 
 ## The Core Gap
 
@@ -44,6 +44,21 @@ A gate that was sufficient when written, outgrown as the system added surfaces.
 
 - **Examples:** renderer type errors invisible to the server `tsconfig`; the shell-quoting junk-spray guard condition was too narrow (t/2222).
 - **Prevention:** gate-coverage review after every incident (the Prevention-per-incident rule); cross-project `tsc` in CI.
+
+## Class 6 — Silent degradation under single-context validation
+
+A change is validated in **one** context (local, one build target, one env, one identity), and when it fails in an **un**-validated context a graceful-degradation path — empty result, swallowed error, success-return — **hides** the failure. The failure is invisible, not loud. This is the amplifier class: it usually rides on a Class 2 (identity) or Class 3 (environment) gap, but what makes it pernicious is the second half — **single-context validation misses it, AND silent degradation hides it in prod**, so it passes every green check while visibly broken.
+
+- **Examples (2026-08-15 dual-build / staging-isolation sweep):**
+  - **Dual-build read parity** — Entities/Organizations rendered locally (Electron/filesystem) but returned empty on hosted web: the github-api read fetched the session branch, not `main` (missing `{ ref: 'main' }`), and ADR-001 graceful-empty rendered zero **silently**. The deploy smoke went **26/26 green** because it asserted "endpoints respond," not "data populates" (t/2648/t/2661).
+  - **Swallow-and-continue** — analytics `appendEvents` swallowed a blob error and returned success → events dropped invisibly (t/2664); a route-layer `log.error` that never fired because `log` was a child-logger map (PR #1065).
+  - **Deploy/env false-greens** — AUTH_OPTIONAL smoke reclassified the cookie-less Sign-In **HTML interstitial** as a PASS for JSON endpoints; a durability "revision restart" validated a warm pod instead of scale-to-zero (t/2642); a staging `AI_TRIAD_DATA_ROOT` pointed at the empty cache mount so reads were silently empty (t/2670).
+  - **Concurrency swallow** — a multi-replica stale-cache clobber overwrote a prod feature flag and returned success (t/2644).
+- **Prevention (the three moves, always together — any one alone leaves the hole):**
+  1. **Verify in the deployed context** — the hosted web / github-api path against **real deployed data**, and the prod identity (anonymous session), not just local + authenticated. "Works on my machine" is not sign-off for a dual-build or multi-env feature.
+  2. **Assert the positive outcome** — smokes assert **data presence** (count > 0 / expected shape), not "renders / responds without error." A liveness-only smoke passes while the feature is broken.
+  3. **Make degradation observable** — graceful-empty (ADR-001) and any swallow-and-continue must emit a detectable signal (log/metric: "loaded 0 / write failed") so a zero/failed result is **detectable, not invisible**.
+- **Tickets:** t/2669 (process-gap epic), t/2671 (hosted data-presence smoke), t/2672 (graceful-empty observability), t/2664 (analytics swallow signal). Process rule landed in the tech-lead `AGENTS.md` **Cross-Profile Impact** ("Data-read parity").
 
 ## How to use this
 


### PR DESCRIPTION
## What

Adds **Class 6 — Silent degradation under single-context validation** to the failure-class taxonomy (`docs/CodeReview/failure-classes.md`). Completes **t/2669 AC4**.

## Why

The 2026-08-15 dual-build / staging-isolation sweep surfaced a recurring class the existing five didn't name. It's the amplifier class: a change validated in **one** context (local / one build target / one env / one identity) fails in an un-validated context, and a graceful-degradation path — empty result, swallowed error, success-return — **hides** the failure in prod. It passes every green check while visibly broken.

## The prevention (three moves, always together)

1. Verify in the **deployed** context (hosted web / github-api path, real deployed data, anon identity) — not just local + authenticated.
2. Assert the **positive outcome** — data presence (count > 0 / expected shape), not "renders / responds without error."
3. Make degradation **observable** — graceful-empty (ADR-001) and swallow-and-continue must emit a log/metric signal.

## Evidence cited (this session)

- Dual-build read parity — 26/26-green smoke while Entities/Orgs empty on web (t/2648/t/2661)
- Swallow-and-continue — analytics append (t/2664), route-layer log-map bug (#1065)
- Deploy/env false-greens — durability warm-pod (t/2642), staging data-root at empty cache mount (t/2670)
- Concurrency swallow — feature-flag clobber returning success (t/2644)

Docs-only. The companion process rule (AC2) already landed in the tech-lead `AGENTS.md` **Cross-Profile Impact**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
