### PR TITLE
feat(calibration): log per-category affect profile by phase (t/2676)

### DIFF
--- a/lib/debate/calibrationLogger/extract-metrics.ts
+++ b/lib/debate/calibrationLogger/extract-metrics.ts
@@ -17,7 +17,8 @@ import type { DebateSession, ArgumentNetworkNode, TrackedCrux } from '../types.j
 import type { CalibrationDataPoint } from './schema.js';
 import type { NeutralEvaluation } from '../neutralEvaluator.js';
 import { meanSentenceLength, lexicalDiversity, jargonDensity } from '../clarityMetrics.js';
-import { computeAffectIntensity, computeAffectProfile, computeAffectAppropriateness } from '../affectSignals.js';
+import { computeAffectIntensity, computeAffectProfile, computeAffectAppropriateness, AFFECT_CATEGORIES } from '../affectSignals.js';
+import type { AffectProfile } from '../affectSignals.js';
 import { computeCampInsularityRate } from '../schemeStagnation.js';
 
 type ArgNetwork = DebateSession['argument_network'];
@@ -401,6 +402,43 @@ export function computeAffectSignals(
     ? affectAppropScores.reduce((a, b) => a + b, 0) / affectAppropScores.length
     : null;
   return { affectIntensityMean, affectIntensityVariance, affectAppropMean };
+}
+
+/** Per-phase share-normalized affect profile aggregate (t/2676). Re-fit input for AFFECT_PHASE_BASELINES. */
+export function computeAffectProfileByPhase(
+  session: DebateSession,
+  rounds: number,
+): Partial<Record<'confrontation' | 'argumentation' | 'concluding', { profile_mean: AffectProfile; n_turns: number }>> | undefined {
+  type PhaseKey = 'confrontation' | 'argumentation' | 'concluding';
+  const PHASE_KEYS: PhaseKey[] = ['confrontation', 'argumentation', 'concluding'];
+  const sums = Object.fromEntries(PHASE_KEYS.map(ph => [ph, { urgency: 0, fear: 0, hope: 0, outrage: 0, empathy: 0 }])) as Record<PhaseKey, Record<string, number>>;
+  const counts = Object.fromEntries(PHASE_KEYS.map(ph => [ph, 0])) as Record<PhaseKey, number>;
+  for (const entry of session.transcript ?? []) {
+    if (entry.type !== 'opening' && entry.type !== 'statement') continue;
+    if (entry.speaker === 'system' || entry.speaker === 'moderator') continue;
+    if (!entry.content) continue;
+    const profile = computeAffectProfile(entry.content);
+    if (!profile) continue;
+    const total = AFFECT_CATEGORIES.reduce((s, c) => s + profile[c], 0);
+    if (total <= 0) continue; // mirror computeAffectAppropriateness: skip zero-affect turns
+    const entryRound = (entry.metadata as Record<string, unknown>)?.round as number ?? 1;
+    const phase = getDebatePhase(entryRound, rounds);
+    if (phase === 'terminated' || !(phase in sums)) continue;
+    const ph = phase as PhaseKey;
+    for (const cat of AFFECT_CATEGORIES) sums[ph][cat] += profile[cat] / total;
+    counts[ph]++;
+  }
+  const result: Partial<Record<PhaseKey, { profile_mean: AffectProfile; n_turns: number }>> = {};
+  for (const ph of PHASE_KEYS) {
+    const n = counts[ph];
+    if (n === 0) continue;
+    const profile_mean = {} as AffectProfile;
+    for (const cat of AFFECT_CATEGORIES) {
+      profile_mean[cat] = Math.round((sums[ph][cat] / n) * 10000) / 10000;
+    }
+    result[ph] = { profile_mean, n_turns: n };
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 /** Camp insularity (BEA: Reflective User Engagement, t/1117) — mean and max same-camp citation rate. */

--- a/lib/debate/calibrationLogger/extract-metrics.ts
+++ b/lib/debate/calibrationLogger/extract-metrics.ts
@@ -411,8 +411,9 @@ export function computeAffectProfileByPhase(
 ): Partial<Record<'confrontation' | 'argumentation' | 'concluding', { profile_mean: AffectProfile; n_turns: number }>> | undefined {
   type PhaseKey = 'confrontation' | 'argumentation' | 'concluding';
   const PHASE_KEYS: PhaseKey[] = ['confrontation', 'argumentation', 'concluding'];
-  const sums = Object.fromEntries(PHASE_KEYS.map(ph => [ph, { urgency: 0, fear: 0, hope: 0, outrage: 0, empathy: 0 }])) as Record<PhaseKey, Record<string, number>>;
-  const counts = Object.fromEntries(PHASE_KEYS.map(ph => [ph, 0])) as Record<PhaseKey, number>;
+  const zero = (): AffectProfile => ({ urgency: 0, fear: 0, hope: 0, outrage: 0, empathy: 0 });
+  const sums: Record<PhaseKey, AffectProfile> = { confrontation: zero(), argumentation: zero(), concluding: zero() };
+  const counts: Record<PhaseKey, number> = { confrontation: 0, argumentation: 0, concluding: 0 };
   for (const entry of session.transcript ?? []) {
     if (entry.type !== 'opening' && entry.type !== 'statement') continue;
     if (entry.speaker === 'system' || entry.speaker === 'moderator') continue;

--- a/lib/debate/calibrationLogger/extract.ts
+++ b/lib/debate/calibrationLogger/extract.ts
@@ -34,6 +34,7 @@ import {
   computeTopicCoherence,
   computeClarityMetrics,
   computeAffectSignals,
+  computeAffectProfileByPhase,
   computeCampInsularity,
   computePeerReferencing,
   computeLocalSufficiency,
@@ -366,6 +367,7 @@ export function extractCalibrationData(
 
   // ── Affect signals (Wachsmuth: Emotional Appeal, t/1121) ──
   const { affectIntensityMean, affectIntensityVariance, affectAppropMean } = computeAffectSignals(session, rounds);
+  const affectProfileByPhase = computeAffectProfileByPhase(session, rounds);
 
   // ── Source authority (Wachsmuth: Credibility, t/1122) ──
   // Fall back to session-stamped provenance (t/1769) when the caller didn't pass
@@ -802,6 +804,7 @@ export function extractCalibrationData(
     affect_intensity_mean: affectIntensityMean != null ? Math.round(affectIntensityMean * 1000) / 1000 : null,
     affect_intensity_variance: affectIntensityVariance != null ? Math.round(affectIntensityVariance * 1000) / 1000 : null,
     affect_appropriateness: affectAppropMean != null ? Math.round(affectAppropMean * 1000) / 1000 : null,
+    affect_profile_by_phase: affectProfileByPhase,
 
     // ── Source authority (Wachsmuth: Credibility, t/1122) ──
     source_authority_mean: srcAuth.source_authority_mean != null ? Math.round(srcAuth.source_authority_mean * 1000) / 1000 : null,

--- a/lib/debate/calibrationLogger/schema.ts
+++ b/lib/debate/calibrationLogger/schema.ts
@@ -13,6 +13,7 @@ import type { AgentUtility } from '../agentUtility.js';
 export type { AgentUtility } from '../agentUtility.js';
 import type { CruxMatchStats } from './extract-metrics.js';
 export type { CruxMatchStats } from './extract-metrics.js';
+import type { AffectProfile } from '../affectSignals.js';
 
 // ── Calibration data point schema ──────────────────────────
 
@@ -385,6 +386,18 @@ export interface CalibrationDataPoint {
   affect_intensity_variance: number | null;
   /** Mean affect appropriateness score (deviation from phase baseline). */
   affect_appropriateness: number | null;
+  /**
+   * Per-phase share-normalized affect profile aggregate (t/2676). Re-fit input for
+   * deriving AFFECT_PHASE_BASELINES from corpus data. Each phase entry holds the
+   * mean of per-turn share-normalized profiles (profile[cat]/total) for turns in
+   * that phase, plus n_turns (the weight for corpus aggregation). Absent on legacy
+   * rows and when no qualifying turns exist. Values at 4dp.
+   * Provenance: stipulated → derived once CL re-fits on ≥N post-t/2677 debates.
+   */
+  affect_profile_by_phase?: Partial<Record<'confrontation' | 'argumentation' | 'concluding', {
+    profile_mean: AffectProfile;
+    n_turns: number;
+  }>>;
 
   // ── Source authority (Wachsmuth: Credibility, t/1122) ──
   /** Mean venue tier score of cited sources [0,1]. */


### PR DESCRIPTION
## Summary

- Adds optional `affect_profile_by_phase` field to `CalibrationDataPoint` — per-phase share-normalized affect profiles, the sufficient statistic CL needs to derive `AFFECT_PHASE_BASELINES` from corpus data
- New `computeAffectProfileByPhase` in `extract-metrics.ts` mirrors `computeAffectAppropriateness` exactly: same turn selection, phase derivation, share normalization, zero-affect skip
- 4dp precision; per-phase `{ profile_mean: AffectProfile, n_turns: number }`; absent when no qualifying turns

**Draft gate:** CL schema shape review (per t/2676#1 spec). Un-draft when CL signs off.

## Test plan

- [ ] All 3003 existing tests pass (verified locally at 1fe648b0)
- [ ] CL reviews schema diff and approves shape
- [ ] CI green on head before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
