### PR TITLE
fix(security): route /api/fetch-url through the hardened SSRF fetcher (t/720 -> t/2482)

### DIFF
--- a/lib/url-fetch/fetchUrlForPrompt.test.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
+// @vitest-environment node
+// Binds real loopback HTTP servers and drives node:http/node:dns — the suite's
+// default jsdom environment cannot host either.
+
 import * as http from 'node:http';
+import { promises as dnsPromises } from 'node:dns';
 import { AddressInfo } from 'node:net';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -112,10 +117,61 @@ describe('fetchUrlForPrompt', () => {
   let baseUrl: string;
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     if (server) {
       await stopServer(server);
       server = undefined;
     }
+  });
+
+  // ── IP pinning / DNS-rebind defense (TL change #2) ────────────────────
+
+  it('connects to the validated IP instead of re-resolving the hostname', async () => {
+    ({ url: baseUrl, server } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(`host=${req.headers.host}`);
+    }));
+    const { port } = new URL(baseUrl);
+
+    // `.invalid` is reserved by RFC 2606 and never resolves. The only way this
+    // request can succeed is if the transport connects to the address returned
+    // by the pre-flight lookup rather than resolving the hostname again at
+    // connect time — which is exactly what closes the rebind TOCTOU window.
+    vi.spyOn(dnsPromises, 'lookup').mockResolvedValue(
+      [{ address: '127.0.0.1', family: 4 }] as never,
+    );
+
+    const result = await fetchUrlForPrompt(`http://pinned.invalid:${port}/`, { checkAddress: ALLOW_ALL });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Host header carries the original hostname AND the non-default port.
+    expect(result.text).toContain(`host=pinned.invalid:${port}`);
+  });
+
+  // ── rawBody passthrough (server markitdown path, t/720) ───────────────
+
+  it('returns the body verbatim when rawBody is set', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<html><head><title>Raw</title></head><body><p>Hello <b>world</b></p></body></html>');
+    }));
+
+    const result = await fetchUrlForPrompt(baseUrl, { checkAddress: ALLOW_ALL, rawBody: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.text).toContain('<b>world</b>'); // markup preserved for the converter
+    expect(result.title).toBe('Raw');
+  });
+
+  it('still applies the SSRF block when rawBody is set', async () => {
+    ({ url: baseUrl, server } = await startServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('should not reach');
+    }));
+    const result = await fetchUrlForPrompt(baseUrl, { rawBody: true }); // default checkAddress
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('ssrf-blocked');
   });
 
   // ── Happy path ────────────────────────────────────────────────────────
@@ -218,6 +274,7 @@ describe('fetchUrlForPrompt', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.reason).toBe('http-error');
+    expect(result.status).toBe(404); // carried so callers can surface `HTTP 404`
   });
 
   it('returns unsupported-content for non-text content-type', async () => {

--- a/lib/url-fetch/fetchUrlForPrompt.ts
+++ b/lib/url-fetch/fetchUrlForPrompt.ts
@@ -110,6 +110,9 @@ function makeRequest(
 ): Promise<http.IncomingMessage> {
   return new Promise((resolve, reject) => {
     let timedOut = false;
+    // RFC 9110 §7.2: the Host header carries the port whenever it is not the
+    // scheme default, or a virtual host on a non-standard port misroutes.
+    const hostHeader = port === (isHttps ? 443 : 80) ? hostname : `${hostname}:${port}`;
     const options: http.RequestOptions & https.RequestOptions = {
       method: 'GET',
       host: resolvedIp,       // connect to the pre-validated IP — closes rebind TOCTOU
@@ -117,7 +120,7 @@ function makeRequest(
       port,
       path,
       headers: {
-        'Host': hostname,     // correct HTTP/1.1 virtual-host routing
+        'Host': hostHeader,   // correct HTTP/1.1 virtual-host routing
         'User-Agent': 'AI-Triad-Research/1.0 (url-fetch)',
         'Accept': 'text/html, text/plain;q=0.9, */*;q=0.1',
         'Accept-Encoding': 'identity', // avoid gzip complications
@@ -176,9 +179,13 @@ function decodeBasicEntities(s: string): string {
     .replace(/&amp;/gi, '&');
 }
 
-function htmlToText(html: string): { text: string; title: string | undefined } {
+function extractTitle(html: string): string | undefined {
   const titleMatch = /<title[^>]*>([^<]*)<\/title>/i.exec(html);
-  const title = titleMatch ? decodeBasicEntities(titleMatch[1].trim()) : undefined;
+  return titleMatch ? decodeBasicEntities(titleMatch[1].trim()) : undefined;
+}
+
+function htmlToText(html: string): { text: string; title: string | undefined } {
+  const title = extractTitle(html);
 
   let text = html
     .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, '')
@@ -264,10 +271,11 @@ export async function fetchUrlForPrompt(
       continue;
     }
 
-    // HTTP errors
+    // HTTP errors — carry the status so callers can surface `HTTP <code>`
     if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+      const status = res.statusCode;
       res.destroy();
-      return { ok: false, reason: 'http-error' };
+      return { ok: false, reason: 'http-error', status };
     }
 
     // Content-Type gate — only fetch text (HTML or plain)
@@ -290,12 +298,21 @@ export async function fetchUrlForPrompt(
     const raw = await readBody(res, maxBytes);
     if (raw === null) return { ok: false, reason: 'too-large' };
 
-    // HTML → text, then XSS safety pass via shared core
-    const { text: extracted, title } = isHtml ? htmlToText(raw) : { text: raw, title: undefined };
-    const safe = sanitizeText(extracted);
+    // HTML → text, then XSS safety pass via shared core. rawBody callers run
+    // their own converter over the markup, so both steps are skipped for them
+    // (the transport-level SSRF guarantees above still applied).
+    let text: string;
+    let title: string | undefined;
+    if (opts.rawBody) {
+      text = raw;
+      title = isHtml ? extractTitle(raw) : undefined;
+    } else {
+      const extracted = isHtml ? htmlToText(raw) : { text: raw, title: undefined };
+      title = extracted.title;
+      text = sanitizeText(extracted.text);
+    }
 
     // Soft token-budget truncation
-    let text = safe;
     let truncated = false;
     if (opts.tokenBudget !== undefined && text.length > opts.tokenBudget) {
       text = text.slice(0, opts.tokenBudget);

--- a/lib/url-fetch/types.ts
+++ b/lib/url-fetch/types.ts
@@ -18,7 +18,7 @@ export type UrlFetchFailureReason =
 
 export type UrlFetchResult =
   | { ok: true; text: string; title: string | undefined; finalUrl: string; truncated: boolean }
-  | { ok: false; reason: UrlFetchFailureReason };
+  | { ok: false; reason: UrlFetchFailureReason; status?: number };
 
 export interface UrlFetchOptions {
   /** Max response body size in bytes before abort. Default: 1.5 MB. */
@@ -29,6 +29,18 @@ export interface UrlFetchOptions {
   maxRedirects?: number;
   /** Soft character budget: truncates extracted text to this length when set. */
   tokenBudget?: number;
+  /**
+   * Return the response body verbatim instead of the tag-stripped, sanitized
+   * extraction. For callers that run their own converter over the raw markup
+   * (the server's markitdown HTML→Markdown pass, t/720). Default: false.
+   *
+   * The SSRF transport guarantees — IP pinning, private-range blocking, size
+   * cap, timeout, content-type gate — are unaffected; only the post-processing
+   * of an already-fetched body changes. Raw output is NOT XSS-sanitized, so a
+   * caller using this must treat the result as untrusted markup and never
+   * re-render it as HTML.
+   */
+  rawBody?: boolean;
   /**
    * Predicate that returns true when an IP address should be blocked (private/SSRF).
    * Default: internal isPrivateIp (blocks RFC-1918, loopback, link-local, CGNAT, etc.).

--- a/taxonomy-editor/src/server/__tests__/t720Security.test.ts
+++ b/taxonomy-editor/src/server/__tests__/t720Security.test.ts
@@ -133,4 +133,25 @@ describe('L5: SSRF / DNS-rebinding guard', () => {
     expect(creds.error).toMatch(/credentials/);
     expect(lookup).not.toHaveBeenCalled();
   });
+
+  it('rejects a bracketed IPv6 literal before any DNS lookup', async () => {
+    const lookup = vi.spyOn(dns.promises, 'lookup');
+    const res = await fileIO.fetchUrlContent('https://[::1]/page');
+    expect(res.content).toBe('');
+    expect(res.error).toMatch(/private\/internal/);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a domain name as an IPv6 literal (fd*/ff* hostnames)', async () => {
+    // Regression guard: isPrivateIp classifies IPv6 by string prefix, so an
+    // ungated literal check would reject every host starting fc/fd (ULA) or ff
+    // (multicast) — fdsa.com, ffmpeg.org. Reaching DNS at all is the assertion;
+    // the request is then blocked on the *resolved* address, as it should be.
+    const lookup = vi.spyOn(dns.promises, 'lookup').mockResolvedValue(
+      [{ address: '127.0.0.1', family: 4 }] as never,
+    );
+    const res = await fileIO.fetchUrlContent('https://fdsa.com/page');
+    expect(lookup).toHaveBeenCalled();
+    expect(res.error).toMatch(/private\/internal/);
+  });
 });

--- a/taxonomy-editor/src/server/storage/urlFetch.ts
+++ b/taxonomy-editor/src/server/storage/urlFetch.ts
@@ -5,80 +5,63 @@
  * URL content fetching with SSRF defenses — extracted from fileIO.ts (ADR-007).
  *
  * Fetches a remote HTTPS page and converts it to Markdown (markitdown, with an
- * HTML-strip fallback). All requests are vetted against private/internal address
- * ranges both at the hostname literal and at the DNS-resolved IP (t/720 L5,
- * DNS-rebinding / SSRF defense). Re-exported from fileIO.ts for a stable surface.
+ * HTML-strip fallback). Re-exported from fileIO.ts for a stable surface.
+ *
+ * TRANSPORT IS NOT IMPLEMENTED HERE. Every request goes through
+ * `lib/url-fetch/fetchUrlForPrompt` — the single hardened fetcher (t/2482).
+ * This module contributes only the two things that are specific to the server's
+ * `POST /api/fetch-url` route:
+ *
+ *   1. A STRICTER pre-flight than the shared fetcher applies (HTTPS-only, no
+ *      credentials in the URL, no local/internal hostname suffixes). The shared
+ *      fetcher permits http: for the debate path; this route must not.
+ *   2. markitdown HTML→Markdown conversion of the fetched body, which is why it
+ *      asks for `rawBody` rather than the fetcher's tag-stripped extraction.
+ *
+ * WHY THE DELEGATION (t/720 → t/2482 consolidation): this module previously ran
+ * its own DNS pre-check and then called `fetch(url)`, which re-resolved the
+ * hostname at connect time — a DNS-rebinding TOCTOU window. `fetchUrlForPrompt`
+ * closes it by connecting to the IP it just validated (with SNI/Host preserved),
+ * and additionally brings a request timeout, a response size cap with mid-stream
+ * abort, a content-type gate, and per-hop redirect re-validation, none of which
+ * existed here. Keeping two implementations is what let the weaker one end up on
+ * the internet-facing route; do not reintroduce a local transport.
  */
 
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import dns from 'dns';
 import { execFile } from 'child_process';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
-
-function isPrivateIP(hostname: string): boolean {
-  const parts = hostname.split('.').map(Number);
-  if (parts.length !== 4 || parts.some(n => isNaN(n))) return false;
-  // RFC 1918
-  if (parts[0] === 10) return true;
-  if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
-  if (parts[0] === 192 && parts[1] === 168) return true;
-  // Loopback
-  if (parts[0] === 127) return true;
-  // Link-local (includes Azure IMDS 169.254.169.254)
-  if (parts[0] === 169 && parts[1] === 254) return true;
-  // CGNAT
-  if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true;
-  return false;
-}
+import { fetchUrlForPrompt, isPrivateIp } from '../../../../lib/url-fetch/fetchUrlForPrompt.js';
+import type { UrlFetchResult } from '../../../../lib/url-fetch/types.js';
 
 /**
- * L5 (t/720): classify a resolved IP literal (IPv4 or IPv6) as private/internal.
- * Extends isPrivateIP with IPv6 loopback/ULA/link-local + IPv4-mapped handling,
- * for vetting addresses DNS returns (rebinding / SSRF defense).
+ * L5 (t/720): classify an IP literal (IPv4 or IPv6) as private/internal.
+ *
+ * Thin adapter over the shared `isPrivateIp` — it normalizes the address forms
+ * DNS and URL parsing produce (surrounding whitespace, IPv6 zone ids like
+ * `fe80::1%eth0`, bracketed literals like `[::1]`) and then applies the single
+ * shared range table. Kept exported because `fileIO` re-exports it and the t/720
+ * suite asserts against it directly.
  */
 export function isBlockedAddress(addr: string): boolean {
-  let ip = addr.trim().toLowerCase().split('%')[0]; // drop IPv6 zone id (fe80::1%eth0)
-  const mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/); // IPv4-mapped IPv6
-  if (mapped) ip = mapped[1];
-
-  if (ip.includes(':')) { // IPv6
-    if (ip === '::1' || ip === '::') return true;                 // loopback / unspecified
-    if (ip.startsWith('fc') || ip.startsWith('fd')) return true;  // fc00::/7 unique-local
-    if (/^fe[89ab]/.test(ip)) return true;                        // fe80::/10 link-local
-    return false;
-  }
-  // IPv4 — reuse isPrivateIP, plus the 0.0.0.0/8 "this-network" block.
-  if (Number(ip.split('.')[0]) === 0) return true;
-  return isPrivateIP(ip);
+  const ip = addr.trim().toLowerCase()
+    .replace(/^\[|\]$/g, '')  // bracketed IPv6 literal from URL.hostname
+    .split('%')[0];            // IPv6 zone id
+  return isPrivateIp(ip);
 }
 
 /**
- * L5: resolve `hostname` and reject if ANY resolved address is private/internal.
- * Defends against DNS rebinding where a public-looking host resolves to an
- * internal IP (e.g. cloud metadata 169.254.169.254). Residual TOCTOU is
- * minimized by checking immediately before the fetch.
+ * True when `host` is an IP literal rather than a domain name. Gating the
+ * literal check on this is load-bearing: `isPrivateIp` classifies IPv6 by
+ * string prefix, so feeding it a domain name would block every host beginning
+ * `fc`/`fd` (ULA) or `ff` (multicast) — `fdsa.com`, `ffmpeg.org`. URL parsing
+ * brackets IPv6 literals and normalizes every numeric IPv4 form (decimal,
+ * octal, hex) to dotted-quad, so these two shapes are exhaustive.
  */
-async function assertHostnameResolvesPublic(hostname: string): Promise<string | null> {
-  let addresses: { address: string }[];
-  try {
-    addresses = await dns.promises.lookup(hostname, { all: true });
-  } catch (err) {
-    getGlobalRecorder()?.record({
-      type: 'system.error',
-      component: 'file-io',
-      level: 'warn',
-      message: `DNS resolution failed for fetch host "${hostname}"`,
-      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-    });
-    return 'DNS resolution failed';
-  }
-  if (addresses.length === 0) return 'DNS resolution returned no addresses';
-  for (const a of addresses) {
-    if (isBlockedAddress(a.address)) return 'URL resolves to a private/internal address';
-  }
-  return null;
+function isIpLiteral(host: string): boolean {
+  return host.startsWith('[') || /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
 }
 
 function validateFetchUrl(url: string): string | null {
@@ -88,7 +71,11 @@ function validateFetchUrl(url: string): string | null {
   if (parsed.protocol !== 'https:') return 'Only HTTPS URLs are allowed';
   if (parsed.username || parsed.password) return 'URLs with credentials are not allowed';
 
-  if (isPrivateIP(parsed.hostname)) return 'URLs targeting private/internal addresses are not allowed';
+  // Hostname-literal check. The authoritative check is the resolved-IP one
+  // inside fetchUrlForPrompt; this one fails fast with a precise message and
+  // catches bracketed IPv6 literals before they reach DNS.
+  if (isIpLiteral(parsed.hostname) && isBlockedAddress(parsed.hostname))
+    return 'URLs targeting private/internal addresses are not allowed';
   if (parsed.hostname === 'localhost' || parsed.hostname.endsWith('.local'))
     return 'URLs targeting local addresses are not allowed';
   if (parsed.hostname.endsWith('.internal') || parsed.hostname.endsWith('.corp'))
@@ -97,31 +84,44 @@ function validateFetchUrl(url: string): string | null {
   return null;
 }
 
+/** Map a shared-fetcher failure onto this route's user-facing error string. */
+function describeFailure(result: Extract<UrlFetchResult, { ok: false }>): string {
+  switch (result.reason) {
+    // Wording preserved from the pre-consolidation implementation — the t/720
+    // suite matches on /private\/internal/.
+    case 'ssrf-blocked': return 'URL resolves to a private/internal address';
+    case 'http-error': return result.status ? `HTTP ${result.status}` : 'HTTP request failed';
+    case 'timeout': return 'Request timed out';
+    case 'too-large': return 'Response exceeded the maximum allowed size';
+    case 'unsupported-content': return 'Only HTML and plain-text URLs can be fetched';
+    case 'too-many-redirects': return 'Too many redirects';
+    case 'network': return 'Network request failed (DNS, TLS, or connection error)';
+  }
+}
+
 export async function fetchUrlContent(url: string): Promise<{ content: string; error?: string }> {
   const validationError = validateFetchUrl(url);
   if (validationError) return { content: '', error: validationError };
-  // L5 (t/720): vet the resolved IP, not just the hostname literal (DNS rebinding / SSRF).
-  const dnsError = await assertHostnameResolvesPublic(new URL(url).hostname);
-  if (dnsError) return { content: '', error: dnsError };
 
   try {
-    const resp = await fetch(url, { redirect: 'manual' });
-    if (resp.status >= 300 && resp.status < 400) {
-      const location = resp.headers.get('location') || '';
-      const redirectError = validateFetchUrl(location);
-      if (redirectError) return { content: '', error: `Redirect blocked: ${redirectError}` };
-      const redirectDnsError = await assertHostnameResolvesPublic(new URL(location).hostname);
-      if (redirectDnsError) return { content: '', error: `Redirect blocked: ${redirectDnsError}` };
-      const resp2 = await fetch(location, { redirect: 'manual' });
-      if (!resp2.ok) return { content: '', error: `HTTP ${resp2.status}` };
-      const html = await resp2.text();
-      const markdown = await htmlToMarkdown(html);
-      return { content: markdown };
+    // rawBody: markitdown converts the original markup; the fetcher's own
+    // tag-stripped extraction would defeat the conversion.
+    const result = await fetchUrlForPrompt(url, { rawBody: true });
+    if (!result.ok) {
+      const error = describeFailure(result);
+      // Keep failed fetches diagnosable — the pre-consolidation code recorded
+      // DNS failures here, and an ssrf-blocked result is a signal worth seeing
+      // in the recorder rather than only in the caller's response body.
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'file-io',
+        level: result.reason === 'ssrf-blocked' ? 'warn' : 'info',
+        message: `URL fetch rejected (${result.reason})`,
+        data: { url, reason: result.reason, status: result.status },
+      });
+      return { content: '', error };
     }
-    if (!resp.ok) return { content: '', error: `HTTP ${resp.status}` };
-    const html = await resp.text();
-    const markdown = await htmlToMarkdown(html);
-    return { content: markdown };
+    return { content: await htmlToMarkdown(result.text) };
   } catch (err) {
     getGlobalRecorder()?.record({
       type: 'system.error',

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -222,6 +222,9 @@ export default defineConfig({
       '../../../lib/search/**/*.test.ts',
       '../../../lib/entities/**/*.test.ts',
       '../../../lib/sanitize/**/*.test.ts',
+      // t/720 consolidation: the shared SSRF-guarded fetcher backs POST /api/fetch-url,
+      // so its suite must gate CI. It was absent from this list since t/2482 landed.
+      '../../../lib/url-fetch/**/*.test.ts',
       '../../../lib/ai-config/**/*.test.ts',
       '../../../lib/embeddings/**/*.test.ts', // t/2060 — mock-based (fake onnxruntime-node), no native addon/model needed
       '../../../lib/*.test.ts',


### PR DESCRIPTION
## Problem

The repo has **two** SSRF-guarded URL fetchers, and the internet-facing Azure route used the weaker one.

- **Strong (t/2482):** `lib/url-fetch/fetchUrlForPrompt.ts` — IP-pinned connect, size cap, timeout, content-type gate, per-hop redirect re-validation. Backs the debate source path.
- **Weak (t/720):** `taxonomy-editor/src/server/storage/urlFetch.ts` — reached by `POST /api/fetch-url` via `fileIO`. **This is what runs on Azure.**

`urlFetch.ts` pre-checked DNS and then called `fetch(url)`, which re-resolves the hostname at connect time — a DNS-rebinding TOCTOU window. Its own comment called this "residual… minimized", accurate when written, but t/2482 has since demonstrated the real fix (connect to the validated IP, preserving SNI + `Host`). The route returns the response body to the caller, so a bypass is a full read primitive.

**Exposure:** authenticated-only (`/api/fetch-url` is in neither `PUBLIC_EXACT_PATHS` nor `ANON_SAFE_POST_PATHS`), but prod runs `AUTH_OPTIONAL='1'` and `enforceOptionalAuthGate` never consults the allowlist — so the bar is "holds a Google/GitHub/Microsoft account", not "is on the allowlist".

**Blast radius, scoped honestly:** this is *not* a managed-identity credential path. Container Apps doesn't serve IMDS at `169.254.169.254`; tokens come from a `127.0.0.1` `IDENTITY_ENDPOINT` over http with a required `X-IDENTITY-HEADER`. The HTTPS-only check and the 127/8 block each independently prevent it. What a rebind reaches is private HTTPS endpoints inside the ACA environment — internal probing/scanning. The environment declares no VNet, so egress is unrestricted and app-layer validation is the only control.

## Change

`urlFetch.ts` no longer implements transport. It keeps only what is specific to this route and delegates the fetch:

1. A **stricter** pre-flight than the shared fetcher applies — HTTPS-only, no credentials, no local/internal suffixes. (The shared fetcher permits `http:` for the debate path; this route must not, so the pre-flight stays.)
2. markitdown HTML→Markdown conversion, preserved via a new `rawBody` option on the shared fetcher.

`rawBody` skips the tag-strip/sanitize pass and returns the body verbatim so markitdown converts the original markup. Transport-level guarantees are unaffected — there is a test asserting the SSRF block still fires under `rawBody`.

The route inherits, all previously absent: **10s timeout**, **1.5 MB cap with mid-stream abort**, **content-type gate**, **per-hop redirect re-validation** (was 1 hop).

### Also in this PR

- **`lib/url-fetch/**/*.test.ts` was absent from the vitest `include` list** — the hardened fetcher's suite has never gated CI since t/2482 landed. Added, with a `node` environment pragma (it binds real loopback servers; the suite defaults to jsdom). Worth noting independently of this change: that module was already in production on the debate path, untested in CI.
- `Host` header now carries a non-default port (RFC 9110 §7.2) — it was being dropped.
- `http-error` results carry the status, so callers still surface `HTTP 404` rather than a generic string.
- Failed fetches record to the flight recorder; the pre-consolidation code recorded DNS failures and that hook would otherwise have been lost.

## Behavior change worth reviewing

The content-type gate now rejects non-text URLs with a clear error. Previously a PDF link was `resp.text()`-ed into mojibake, written to `input.html`, and handed to markitdown as HTML — garbage either way, so **not a functional regression**, but users pasting arXiv PDF links now get an explicit refusal instead of nonsense. Making that path actually work (markitdown does handle PDFs) is a reasonable follow-up.

## Tests

New coverage:
- **IP-pinning proof** — a `.invalid` hostname (RFC 2606, never resolves) reachable *only* if the transport connects to the address from the pre-flight lookup. Also asserts the Host header + port fix. This is the rebind regression test; it lives at the lib level because once the IP is pinned a rebind is structurally unobservable at the server level — there is no second resolution to intercept.
- `rawBody` passthrough, and SSRF-still-blocks-under-`rawBody`.
- `http-error` carries status.
- Server-level: bracketed IPv6 literal rejected pre-DNS; and a guard that domain names starting `fc`/`fd`/`ff` are **not** misread as IPv6 literals — `isPrivateIp` classifies IPv6 by string prefix, so an ungated literal check would have blocked `fdsa.com`, `ffmpeg.org`.

Results (rebased onto `origin/main` @ 78f5c4a8, deps reinstalled):
- `t720Security.test.ts` + `lib/url-fetch/` — **40 passed, 0 failed**
- `npm run build:server` (incl. `check-server-lib-emits`) — clean, 8 dynamic lib imports emitted
- `depcruise` — no violations across 1596 modules (the new server→`lib/url-fetch` edge is legal)
- `eslint` on changed files — clean

**Full server suite locally: 1091 passed, 76 failed.** All 76 are in `githubApi.test.ts` and `t2020Security.test.ts`, from the undici major-skew guard firing on local Node (bundled undici 7.x vs the required Node 22 / undici 6.x). The identical 76 fail on unmodified `main`, so they are pre-existing and environmental — this branch adds exactly +2 passing tests. CI pins node:22.23.2 and should be green; that is the one claim I could not verify locally.

## Notes

No ticket key: the Orca MCP server rejected `create_ticket` in the authoring session (`Cannot determine caller agent identity` — `ORCA_AGENT_ID` unset), so the commit references `t/720 → t/2482`. Happy to amend the message if a ticket is filed.

Routing: the `taxonomy-editor` sub-roles (ServerAPI / Server Storage) are not registered in the Orca workspace — `resolve_owner` on `urlFetch.ts` falls back to the root project role. Per AGENTS.md, security-surface work is TL-reviewed by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
