### PR TITLE
feat(smoke): data-presence assertion phase for staging/prod smoke (t/2671)

### DIFF
--- a/scripts/AITriad/Private/Test-DataPresenceAssertion.ps1
+++ b/scripts/AITriad/Private/Test-DataPresenceAssertion.ps1
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-DataPresenceAssertion {
+    <#
+    .SYNOPSIS
+        Pure assertion helper (t/2671): decides whether a parsed API response
+        actually carries data rows (> 0), independent of HTTP status.
+    .DESCRIPTION
+        The hosted deploy smoke passed 26/26 green while Entities/Organizations
+        were empty on web, because it asserted endpoints RESPOND, not that data
+        POPULATES — and worse, an auth Sign-In interstitial is served as 200
+        text/html, which a status-only check reads as PASS. This helper is the
+        authoritative presence check: it fails a non-JSON body (the interstitial),
+        a null/unparseable body, a missing/null count field, and an empty
+        collection — and it NEVER throws on malformed input (returns Pass=$false).
+
+        Pure by design (no HTTP): takes an already-parsed body + content-type so
+        it is unit-testable against synthetic bodies with no live server.
+    .PARAMETER Body
+        The parsed response body (e.g. Invoke-RemoteCheck's .Body), or $null when
+        the response was not valid JSON.
+    .PARAMETER ContentType
+        The response Content-Type. A non-JSON type (e.g. text/html) fails the
+        assertion — this is the auth-interstitial catch. Empty string skips the
+        content-type check (for pure unit tests that pass a body directly).
+    .PARAMETER CountField
+        Name of the field holding the row collection (e.g. 'nodes' for taxonomy).
+        Empty string means the body itself is the array (entities, organizations).
+    .PARAMETER Label
+        Human label for the data kind, used in the Reason text.
+    .OUTPUTS
+        [PSCustomObject] with Count (int), Pass (bool), Reason (string).
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [object]$Body,
+
+        [Parameter()]
+        [string]$ContentType = '',
+
+        [Parameter()]
+        [string]$CountField = '',
+
+        [Parameter()]
+        [string]$Label = 'data'
+    )
+
+    Set-StrictMode -Version Latest
+
+    $Result = { param($c, $p, $r) [PSCustomObject]@{ Count = $c; Pass = $p; Reason = $r } }
+
+    # 1. Must be JSON. An AUTH_OPTIONAL Sign-In interstitial is 200 text/html —
+    #    the exact escape that made the endpoint smoke falsely green.
+    if ($ContentType -and $ContentType -notmatch 'application/json') {
+        return & $Result 0 $false "Expected application/json but got '$ContentType' (likely the auth Sign-In interstitial, not data)"
+    }
+
+    # 2. Null / unparseable body.
+    if ($null -eq $Body) {
+        return & $Result 0 $false 'Response body was null or not valid JSON'
+    }
+
+    # 3. Resolve the collection to count.
+    if ($CountField) {
+        if (($Body -is [string]) -or ($Body -is [ValueType]) -or -not ($Body.PSObject.Properties[$CountField])) {
+            return & $Result 0 $false "Field '$CountField' absent from response body"
+        }
+        $Coll = $Body.$CountField
+        $What = "Field '$CountField'"
+    } else {
+        $Coll = $Body
+        $What = 'Response body'
+    }
+
+    # 4. Null collection (e.g. {"nodes":null}) — fail, never throw.
+    #    (@($null).Count is 1, so this MUST be guarded before the @() wrap below.)
+    if ($null -eq $Coll) {
+        return & $Result 0 $false "$What is null (expected a non-empty array)"
+    }
+
+    # 5. Count rows. Array/list → length; a bare object → 1 row if it has any
+    #    properties, 0 for an empty object {}; a scalar/string is not a collection.
+    if (($Coll -is [string]) -or ($Coll -is [ValueType])) {
+        return & $Result 0 $false "$What is not an array (got $($Coll.GetType().Name))"
+    }
+    if ($Coll -is [System.Collections.IEnumerable]) {
+        $Count = @($Coll).Count
+    } else {
+        $Count = if (@($Coll.PSObject.Properties).Count -gt 0) { 1 } else { 0 }
+    }
+
+    $Pass = $Count -gt 0
+    $Reason = if ($Pass) { "$Count $Label row(s)" } else { "Empty — $What present but 0 rows" }
+    return & $Result $Count $Pass $Reason
+}

--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -12,7 +12,9 @@ function Invoke-TaxEditorSmokeTest {
         counts, response time stats, and per-category breakdowns. The analytics
         probe reads aggregated totalEvents, POSTs a synthetic event, and re-reads
         to confirm the count increased — catching silent blob-storage drops that
-        still return HTTP 200.
+        still return HTTP 200. With -AssertDataPresence, an additional phase (t/2671)
+        asserts entities/organizations/taxonomy-nodes return JSON with > 0 rows over
+        an anonymous session — catching empty data and auth-interstitial false-greens.
     .PARAMETER BaseUrl
         The base URL of the deployed Taxonomy Editor site.
     .PARAMETER TimeoutSec
@@ -33,6 +35,14 @@ function Invoke-TaxEditorSmokeTest {
         the deploy workflow immediately after a push (t/2639).
     .PARAMETER Detailed
         Show per-endpoint results in addition to the summary.
+    .PARAMETER AssertDataPresence
+        Run the data-presence phase (t/2671): establish an anonymous session, then
+        assert /api/entities, /api/organizations, and /api/taxonomy/<pov> return
+        JSON with > 0 rows — not just HTTP 200. Off by default so local runs (which
+        may not point at a data-populated instance) are unaffected; the deploy
+        workflow passes it. Catches the escape where the endpoint smoke went 26/26
+        green while data was empty on web, and where an auth Sign-In interstitial
+        (200 text/html) is mistaken for real data.
     .EXAMPLE
         Invoke-TaxEditorSmokeTest
     .EXAMPLE
@@ -75,7 +85,10 @@ function Invoke-TaxEditorSmokeTest {
         [string]$DeployedSha = '',
 
         [Parameter()]
-        [switch]$Detailed
+        [switch]$Detailed,
+
+        [Parameter()]
+        [switch]$AssertDataPresence
     )
 
     Set-StrictMode -Version Latest
@@ -283,8 +296,62 @@ function Invoke-TaxEditorSmokeTest {
     }
     Write-Host ''
 
+    # ── Phase 6: Data presence (t/2671) — opt-in via -AssertDataPresence ──
+    # The endpoint smoke passed 26/26 green while Entities/Organizations were empty
+    # on web (t/2648/t/2661): it asserts endpoints RESPOND, not that data POPULATES.
+    # Worse, in AUTH_OPTIONAL a cookie-less GET returns a 200 text/html Sign-In
+    # interstitial that a status-only check reads as PASS. This phase establishes an
+    # anonymous session (so the app serves real JSON, not the interstitial —
+    # accessControl.ts:335 anon-allows GETs; no admin token needed) and asserts each
+    # data route returns application/json with > 0 rows. Failures flow into
+    # FailedEndpoints → OverallPass. Off by default; the deploy workflow passes the switch.
+    $DataPresence = @()
+    if ($AssertDataPresence) {
+        Write-Host '=== Data Presence ===' -ForegroundColor Cyan
+        $DataSession = New-AnonymousWebSession -BaseUrl $BaseUrl -TimeoutSec $TimeoutSec
+        if (-not $DataSession) {
+            Write-Host '  (anonymous session not established — data GETs may return the auth interstitial)' -ForegroundColor DarkYellow
+        }
+
+        $DataRoutes = @(
+            @{ Path = '/api/entities';                 Field = '';      Label = 'entities' }
+            @{ Path = '/api/organizations';            Field = '';      Label = 'organizations' }
+            @{ Path = '/api/taxonomy/accelerationist'; Field = 'nodes'; Label = 'taxonomy nodes' }
+        )
+        foreach ($R in $DataRoutes) {
+            $Params = @{ BaseUrl = $BaseUrl; Path = $R.Path; Method = 'GET'; TimeoutSec = $TimeoutSec; ExpectJson = $true }
+            if ($DataSession) { $Params.Session = $DataSession }
+            $Check  = Invoke-RemoteCheck @Params
+            $Assert = Test-DataPresenceAssertion -Body $Check.Body -ContentType $Check.ContentType `
+                -CountField $R.Field -Label $R.Label
+
+            $Res = [EndpointTestResult]::new()
+            $Res.Endpoint    = "GET $($R.Path)"
+            $Res.Category    = 'DataPresence'
+            $Res.Description = "Data presence: $($R.Label) > 0"
+            $Res.Status      = $Check.StatusCode
+            $Res.Pass        = $Assert.Pass
+            $Res.Ms          = $Check.ResponseMs
+            $Res.NodeCount   = $Assert.Count
+            if (-not $Assert.Pass) {
+                $Res.Error = "$($R.Label): $($Assert.Reason)$(if ($Check.Error) { " (http: $($Check.Error))" })"
+            }
+            $DataPresence += $Res
+        }
+
+        foreach ($Ep in $DataPresence) {
+            $Icon = if ($Ep.Pass) { '[PASS]' } else { '[FAIL]' }
+            $Color = if ($Ep.Pass) { 'Green' } else { 'Red' }
+            Write-Host "  $Icon $($Ep.Endpoint) — $($Ep.Status) ($($Ep.NodeCount) rows) $($Ep.Ms)ms" -ForegroundColor $Color
+            if (-not $Ep.Pass -and $Ep.Error) {
+                Write-Host "        $($Ep.Error)" -ForegroundColor DarkRed
+            }
+        }
+        Write-Host ''
+    }
+
     # ── Summary ──────────────────────────────────────────────────────────
-    $AllResults = @($Endpoints) + @($AnonEndpoints) + @($Analytics)
+    $AllResults = @($Endpoints) + @($AnonEndpoints) + @($Analytics) + @($DataPresence)
     $Passed = @($AllResults | Where-Object { $_.Pass }).Count
     $Failed = @($AllResults | Where-Object { -not $_.Pass }).Count
     $Total = $AllResults.Count

--- a/tests/Test-DataPresenceAssertion.Tests.ps1
+++ b/tests/Test-DataPresenceAssertion.Tests.ps1
@@ -1,0 +1,98 @@
+# Tag: health (t/2671)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Pure-assertion tests for Test-DataPresenceAssertion (t/2671) — the data-presence
+    gate used by Invoke-TaxEditorSmokeTest -AssertDataPresence.
+.DESCRIPTION
+    Gate integrity, proven on synthetic bodies with NO live server:
+      PASS arms  — a populated array / {nodes:[...]} resolves Pass=$true.
+      FIRE arms  — empty array, empty nodes, the auth INTERSTITIAL (200 text/html),
+                   and malformed/null/{nodes:null}/garbage bodies resolve Pass=$false
+                   and NEVER throw.
+    The interstitial arm is the load-bearing one: it proves the gate catches
+    "200-but-not-JSON", not merely empty arrays.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-DataPresenceAssertion (t/2671)' -Tag 'health' {
+
+    Context 'PASS arms — real data resolves Pass=$true' {
+        It 'top-level array with rows (entities/organizations shape)' {
+            InModuleScope AITriad {
+                $rows = @([PSCustomObject]@{ id = 'e1' }, [PSCustomObject]@{ id = 'e2' })
+                $r = Test-DataPresenceAssertion -Body $rows -ContentType 'application/json' -CountField '' -Label 'entities'
+                $r.Pass  | Should -BeTrue
+                $r.Count | Should -Be 2
+            }
+        }
+
+        It 'object with a populated nodes field (taxonomy shape)' {
+            InModuleScope AITriad {
+                $body = [PSCustomObject]@{ nodes = @([PSCustomObject]@{ id = 'n1' }, [PSCustomObject]@{ id = 'n2' }, [PSCustomObject]@{ id = 'n3' }) }
+                $r = Test-DataPresenceAssertion -Body $body -ContentType 'application/json; charset=utf-8' -CountField 'nodes' -Label 'taxonomy nodes'
+                $r.Pass  | Should -BeTrue
+                $r.Count | Should -Be 3
+            }
+        }
+    }
+
+    Context 'FIRE arms — the gate must FAIL (Pass=$false), never throw' {
+        It 'EMPTY nodes array → Pass=$false, count 0 (the empty-data escape)' {
+            InModuleScope AITriad {
+                $body = [PSCustomObject]@{ nodes = @() }
+                $r = Test-DataPresenceAssertion -Body $body -ContentType 'application/json' -CountField 'nodes' -Label 'taxonomy nodes'
+                $r.Pass  | Should -BeFalse
+                $r.Count | Should -Be 0
+            }
+        }
+
+        It 'EMPTY object {} for an array route → Pass=$false, count 0' {
+            InModuleScope AITriad {
+                $r = Test-DataPresenceAssertion -Body ([PSCustomObject]@{}) -ContentType 'application/json' -CountField '' -Label 'entities'
+                $r.Pass  | Should -BeFalse
+                $r.Count | Should -Be 0
+            }
+        }
+
+        It 'STAR: auth Sign-In interstitial (200 text/html) → Pass=$false (200-but-not-JSON)' {
+            InModuleScope AITriad {
+                # The real escape: cookie-less GET returns the interstitial as text/html.
+                $r = Test-DataPresenceAssertion -Body $null -ContentType 'text/html; charset=utf-8' -CountField '' -Label 'entities'
+                $r.Pass   | Should -BeFalse
+                $r.Reason | Should -Match 'interstitial'
+            }
+        }
+
+        It 'NULL body with JSON content-type → Pass=$false, no throw' {
+            InModuleScope AITriad {
+                $r = $null
+                { $script:__x = Test-DataPresenceAssertion -Body $null -ContentType 'application/json' -CountField 'nodes' -Label 'taxonomy nodes' } | Should -Not -Throw
+                $script:__x.Pass | Should -BeFalse
+            }
+        }
+
+        It 'MALFORMED {nodes:null} → Pass=$false, no throw' {
+            InModuleScope AITriad {
+                $body = [PSCustomObject]@{ nodes = $null }
+                { $script:__y = Test-DataPresenceAssertion -Body $body -ContentType 'application/json' -CountField 'nodes' -Label 'taxonomy nodes' } | Should -Not -Throw
+                $script:__y.Pass | Should -BeFalse
+            }
+        }
+
+        It 'GARBAGE non-object body (string) → Pass=$false, no throw' {
+            InModuleScope AITriad {
+                { $script:__z = Test-DataPresenceAssertion -Body '<html>not json</html>' -ContentType 'application/json' -CountField '' -Label 'entities' } | Should -Not -Throw
+                $script:__z.Pass | Should -BeFalse
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds an opt-in \-AssertDataPresence\ phase to \Invoke-TaxEditorSmokeTest\ (t/2671, TL-approved t/2671#4). The endpoint smoke passed 26/26 green while Entities/Organizations were empty on web (t/2648/t/2661) — it asserts endpoints RESPOND, not that data POPULATES, and in AUTH_OPTIONAL a cookie-less GET returns a 200 text/html Sign-In interstitial that a status-only check reads as PASS.

- Establishes an anonymous session (no admin token needed — \ccessControl.ts:335\ anon-allows GETs) and asserts \/api/entities\, \/api/organizations\, \/api/taxonomy/<pov>\ each return **application/json with > 0 rows**. Failures flow into \FailedEndpoints\ → \OverallPass\.
- Off by default (local runs unaffected); the deploy workflow passes the switch.
- New pure Private helper \Test-DataPresenceAssertion\ (parsed body + content-type + count field → {Count, Pass, Reason}) — unit-testable with no live server, never throws on malformed input.

Rebased on main so it composes with t/2673 (#1071): DataPresence is gated in \OverallPass\; GitHubOk is excluded — exactly the split TL described.

## Test plan
- [x] 8 helper tests: 2 PASS arms + 4 FIRE arms — empty array, empty {nodes:[]}, the STAR auth-interstitial (200 text/html → Pass=\False), and malformed/null/{nodes:null}/garbage (Pass=\False, no throw).
- [x] Post-rebase smoke suites green: ColdStart (3) + Analytics (4) + DataPresence (8) + GitHubGate (5) = 20/0.

**DevOps to add** the \-AssertDataPresence\ wiring in deploy-staging.yml + deploy-azure.yml (combined PR to TL for gate-verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)