### PR TITLE
ci(deploy): wire -AssertDataPresence into staging + prod smoke gates (t/2671)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -391,7 +391,7 @@ jobs:
           # Invoke-TaxEditorSmokeTest covers all 6 endpoint categories + health +
           # Azure + GitHub checks against the zero-traffic revision before any traffic
           # is shifted — mandatory pre-promotion gate (t/2376).
-          $SmokeResult = Invoke-TaxEditorSmokeTest -BaseUrl $BaseUrl -Detailed
+          $SmokeResult = Invoke-TaxEditorSmokeTest -BaseUrl $BaseUrl -Detailed -AssertDataPresence
           Write-Host ""
           Write-Host "=== Smoke: $($SmokeResult.EndpointsPassed)/$($SmokeResult.EndpointsTotal) endpoints passed ==="
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -140,7 +140,8 @@ jobs:
           # Full smoke: all 6 endpoint categories (mandatory pre-traffic gate, t/2376).
           Write-Host "=== Full smoke test against 0%-traffic revision: $BaseUrl ==="
           $SmokeResult = Invoke-TaxEditorSmokeTest -BaseUrl $BaseUrl -Detailed `
-            -DeployedSha '${{ github.event.workflow_run.head_sha }}'
+            -DeployedSha '${{ github.event.workflow_run.head_sha }}' `
+            -AssertDataPresence
           if (-not $SmokeResult.OverallPass) {
             Write-Host "::error::Smoke test failed on new staging revision — NOT promoting traffic"
             Write-Host "  Health: $(if ($SmokeResult.HealthOk) { 'OK' } else { 'FAIL' })"


### PR DESCRIPTION
## Summary
- Adds \-AssertDataPresence\ to \Invoke-TaxEditorSmokeTest\ in \deploy-staging.yml\ and \deploy-azure.yml\
- DataPresence gated in \OverallPass\ (blocks promotion on failure); \GitHubOk\ excluded per TL design (p/346)
- PS-side implementation: PR #1098

## Merge order
Land #1098 (PS) first, then this PR.

## Test plan
- [ ] CI green
- [ ] TL gate-verification: deliberate data-absence triggers gate; happy path passes