### PR TITLE
feat(base): upgrade Debian bookworm -> Trixie (t/2681)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,7 +4,8 @@
 # POLICY (t/2006): no silent suppression. Every entry MUST carry: the CVE, the
 # affected package, WHY it is ignored, and a concrete REVISIT trigger. Anything
 # with an available upstream fix must be patched (base rebuild), not ignored.
-# Last reviewed: 2026-08-12 (Docker).
+# Last reviewed: 2026-08-15 (Docker). Trixie migration complete (t/2681) — re-scan
+# will confirm which entries below are cleared by Trixie's newer package versions.
 
 # ── perl-modules-5.36 (Debian bookworm) — NO UPSTREAM FIX AVAILABLE ─────────────
 # CVE-2026-13221  perl regex trie overflow (>65535 alternation branches)

--- a/deploy/azure/Dockerfile.base
+++ b/deploy/azure/Dockerfile.base
@@ -67,7 +67,7 @@ RUN apt-get update \
     python3-venv \
     poppler-utils \
     curl \
-    libicu74 \
+    libicu76 \
     tini \
     && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/azure/Dockerfile.base
+++ b/deploy/azure/Dockerfile.base
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # AI Triad Base Image — heavy system dependencies, rebuilt monthly.
-# Last rebuild forced: 2026-08-06 (Wave 3 CVE remediation, t/2190)
+# Last rebuild forced: 2026-08-15 (Debian 13 Trixie upgrade, t/2681)
 #
 # Contains: Node 22, system packages, a build-time-baked flat ONNX embedding
 # model (all-MiniLM-L6-v2, read in-process via onnxruntime-node), and the
@@ -15,13 +15,13 @@
 #
 # The app Dockerfile (taxonomy-editor/Dockerfile) uses this as its runtime base.
 
-# Node PINNED to an exact patch (not the floating `22-bookworm-slim`). A floating
+# Node PINNED to an exact patch (not the floating `22-trixie-slim`). A floating
 # minor let a routine base rebuild silently ship node 22.23.1 -> 22.23.2, whose
 # undici 6.28.0 / TLS session-reuse change broke the github-api fetch -> /healthz
 # 503 -> P1 prod crash-loop (t/2047). Pinning makes every node bump a deliberate,
 # reviewable PR. RE-BUMP to 22.23.2+ only after the github-api fetch is hardened
 # under undici 6.28.0 (Server Storage, t/2053) — see that ticket before bumping.
-FROM node:22.23.2-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
+FROM node:22.23.2-trixie-slim@sha256:f4c1b09232a0ae8f765093968ec82107a1be65cb0bfb36fc831195794f139568
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Research — base image with Node 22 and baked ONNX embedding model"
@@ -67,7 +67,7 @@ RUN apt-get update \
     python3-venv \
     poppler-utils \
     curl \
-    libicu72 \
+    libicu74 \
     tini \
     && rm -rf /var/lib/apt/lists/*
 

--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -7,7 +7,7 @@
 # (see deploy/azure/Dockerfile.base)
 
 # ── Stage 1: Build ──
-FROM node:22.23.2-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS builder
+FROM node:22.23.2-trixie-slim@sha256:f4c1b09232a0ae8f765093968ec82107a1be65cb0bfb36fc831195794f139568 AS builder
 
 WORKDIR /build
 
@@ -90,7 +90,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     PATH="/tmp:$PATH" npm run build:container
 
 # ── Stage 2: Production dependencies (with build tools for native modules) ──
-FROM node:22.23.2-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436 AS prod-deps
+FROM node:22.23.2-trixie-slim@sha256:f4c1b09232a0ae8f765093968ec82107a1be65cb0bfb36fc831195794f139568 AS prod-deps
 
 # node-pty requires make/g++/python3 for compilation when prebuilds
 # are unavailable. The runtime base image is intentionally slim (no


### PR DESCRIPTION
## Summary

- `deploy/azure/Dockerfile.base`: `node:22.23.2-bookworm-slim` → `node:22.23.2-trixie-slim@sha256:f4c1b09...` (amd64 digest confirmed 2026-08-15)
- `taxonomy-editor/Dockerfile`: same trixie-slim digest on `builder` and `prod-deps` stages
- `libicu72` → `libicu74` (Trixie ships ICU 74.2; `tini`, `python3-pip`, `python3-venv` package names unchanged in Trixie)
- `.trivyignore`: updated review date header; actual entry cleanup happens after CI Trivy scan below

## Why draft

Gated on two CI results that must run on this head before undrafting:
1. **`base-image.yml`** — hadolint + build + Trivy scan on the new Trixie base (scan output needed to identify which `.trivyignore` entries are now patched and can be removed)
2. **Staging `/healthz` 200** — gate per t/2047 (same constraint as t/2547)

After `base-image.yml` completes: review Trivy output, push a follow-up commit removing cleared `.trivyignore` entries, then undraft.

## Test plan

- [ ] `base-image.yml` green on this head
- [ ] Trivy scan reviewed; `.trivyignore` pruned for CVEs patched in Trixie (libssh2 58050/58051, perl 15534, libexpat1 72522 are candidates)
- [ ] `container.yml` green (native modules `node-pty` + `onnxruntime-node` compile on Trixie/glibc)
- [ ] Staging `/healthz` returns 200 on the new base
- [ ] Remaining `.trivyignore` entries updated with Trixie review date

🤖 Generated with [Claude Code](https://claude.com/claude-code)