### PR TITLE
fix(smoke): establish anon session for Phase 5 analytics round-trip (t/2684)

### DIFF
--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -208,9 +208,24 @@ function Invoke-TaxEditorSmokeTest {
         return $null
     }
 
+    # Establish an anonymous session first. Both /api/analytics/event (POST) and
+    # /api/analytics/query (GET) are anon-allowed, BUT in AUTH_OPTIONAL a cookie-less
+    # request receives a 200 text/html Sign-In interstitial (see Phase 6 note below,
+    # and lines 302-303) — so a session-less round-trip POSTs into the interstitial
+    # (event never reaches the handler) and reads the interstitial back as delta 0,
+    # a false "silent drop" that blocked prod+staging deploys (t/2683 → t/2684).
+    # Mirror the t/2671 data-presence phase: get the anon cookies, thread them
+    # through all three calls. If the session can't be established, warn explicitly
+    # so a resulting read failure is not mistaken for a persistence drop.
+    $AnalyticsSession = New-AnonymousWebSession -BaseUrl $BaseUrl -TimeoutSec $TimeoutSec
+    if (-not $AnalyticsSession) {
+        Write-Host '  (anonymous session not established — analytics round-trip may hit the auth interstitial; delta cannot be trusted)' -ForegroundColor DarkYellow
+    }
+
     # Baseline read BEFORE the write.
-    $BaselineCheck = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/api/analytics/query' `
-        -Method GET -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200)
+    $BaselineParams = @{ BaseUrl = $BaseUrl; Path = '/api/analytics/query'; Method = 'GET'; TimeoutSec = $TimeoutSec; AcceptableStatusCodes = @(200) }
+    if ($AnalyticsSession) { $BaselineParams.Session = $AnalyticsSession }
+    $BaselineCheck = Invoke-RemoteCheck @BaselineParams
     $Before = & $GetTotalEvents $BaselineCheck
 
     # Write probe — reachability only (200 + ok:true). NOT a drop detector.
@@ -228,8 +243,9 @@ function Invoke-TaxEditorSmokeTest {
     }
     $EventJson = '{"events":[' + ($ProbeEvent | ConvertTo-Json -Depth 6 -Compress) + ']}'
 
-    $WriteCheck = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/api/analytics/event' `
-        -Method POST -Body $EventJson -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200)
+    $WriteParams = @{ BaseUrl = $BaseUrl; Path = '/api/analytics/event'; Method = 'POST'; Body = $EventJson; TimeoutSec = $TimeoutSec; AcceptableStatusCodes = @(200) }
+    if ($AnalyticsSession) { $WriteParams.Session = $AnalyticsSession }
+    $WriteCheck = Invoke-RemoteCheck @WriteParams
     $WriteOk = $false
     if ($WriteCheck.Success -and $WriteCheck.Body -and $WriteCheck.Body.PSObject.Properties['ok']) {
         $WriteOk = [bool]$WriteCheck.Body.ok
@@ -257,8 +273,9 @@ function Invoke-TaxEditorSmokeTest {
     Start-Sleep -Seconds 2
 
     # Read-back AFTER the write — the delta is the detector.
-    $AfterCheck = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/api/analytics/query' `
-        -Method GET -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200)
+    $AfterParams = @{ BaseUrl = $BaseUrl; Path = '/api/analytics/query'; Method = 'GET'; TimeoutSec = $TimeoutSec; AcceptableStatusCodes = @(200) }
+    if ($AnalyticsSession) { $AfterParams.Session = $AnalyticsSession }
+    $AfterCheck = Invoke-RemoteCheck @AfterParams
     $After = & $GetTotalEvents $AfterCheck
 
     $DeltaPass = $false

--- a/tests/Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1
@@ -47,6 +47,12 @@ Describe 'Invoke-TaxEditorSmokeTest analytics round-trip probe (t/2667)' -Tag 'h
             Mock Test-GitHubHealth -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
             Mock Start-Sleep -MockWith { }
 
+            # Phase 5 now establishes an anon session (t/2684) before the round-trip —
+            # stub it so the tests stay offline and fast. Default: a real session so
+            # the -Session param is threaded through the three calls; individual tests
+            # override to $null to exercise the unavailable path.
+            Mock New-AnonymousWebSession -MockWith { [Microsoft.PowerShell.Commands.WebRequestSession]::new() }
+
             # Helper builds an Invoke-RemoteCheck-shaped result.
             function script:New-RCResult ($Success, $Status, $Body) {
                 [PSCustomObject]@{
@@ -138,6 +144,52 @@ Describe 'Invoke-TaxEditorSmokeTest analytics round-trip probe (t/2667)' -Tag 'h
             $delta = $result.FailedEndpoints | Where-Object { $_.Endpoint -like '*delta read-back*' }
             $delta | Should -Not -BeNullOrEmpty
             $delta.Error | Should -Match 'Baseline read failed'
+        }
+    }
+
+    It 'ANON SESSION: establishes one and threads it through all three Phase-5 calls (t/2684)' {
+        InModuleScope AITriad {
+            $script:QueryCall = 0
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
+                $script:QueryCall++
+                $total = if ($script:QueryCall -eq 1) { 5 } else { 6 }
+                New-RCResult $true 200 ([PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } })
+            }
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
+                New-RCResult $true 200 ([PSCustomObject]@{ ok = $true; count = 1 })
+            }
+
+            Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' 6>$null | Out-Null
+
+            # The anon session is established exactly once for the phase.
+            Should -Invoke New-AnonymousWebSession -Times 1 -Exactly
+
+            # …and threaded to all three analytics calls (baseline GET, POST event,
+            # read-back GET) — the fix for the cookie-less interstitial false-positive.
+            Should -Invoke Invoke-RemoteCheck -Times 3 -Exactly -ParameterFilter {
+                ($Path -eq '/api/analytics/query' -or $Path -eq '/api/analytics/event') -and $null -ne $Session
+            }
+        }
+    }
+
+    It 'ANON SESSION UNAVAILABLE: warns and proceeds session-less, does not throw (t/2684)' {
+        InModuleScope AITriad {
+            Mock New-AnonymousWebSession -MockWith { $null }
+            $script:QueryCall = 0
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
+                $script:QueryCall++
+                $total = if ($script:QueryCall -eq 1) { 5 } else { 6 }
+                New-RCResult $true 200 ([PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } })
+            }
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
+                New-RCResult $true 200 ([PSCustomObject]@{ ok = $true; count = 1 })
+            }
+
+            # No -Session flows through when the session could not be established.
+            { Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' 6>$null } | Should -Not -Throw
+            Should -Invoke Invoke-RemoteCheck -Times 3 -Exactly -ParameterFilter {
+                ($Path -eq '/api/analytics/query' -or $Path -eq '/api/analytics/event') -and $null -eq $Session
+            }
         }
     }
 }


### PR DESCRIPTION
## Incident
Phase 5 (t/2667) analytics round-trip in `Invoke-TaxEditorSmokeTest.ps1` POSTed `/api/analytics/event` and read `/api/analytics/query` **cookie-less**. In AUTH_OPTIONAL a cookie-less request gets a **200 text/html Sign-In interstitial**, so the POST never reached the handler and the read-back delta was 0 — a false "silent drop" that **blocked prod+staging deploys of 690ea4e0** (incident t/2683, diagnosis t/2683#2).

## Fix
Establish an anonymous web session (`New-AnonymousWebSession`) and thread `-Session` through all three Phase-5 calls (baseline GET, POST event, read-back GET) — mirroring the t/2671 data-presence phase already in the same file. If the session can't be established, warn explicitly so a read failure isn't misread as a persistence drop.

## Gate integrity (both arms, offline)
- **Arm 1 (clean case):** `clean round-trip: totalEvents increases → PASS` — now runs with the anon session threaded.
- **Arm 2 (failure still fires):** `SILENT DROP: totalEvents flat → delta FAILS` — detector not neutered.
- New tests: session established once + threaded to all three calls; session-unavailable path proceeds session-less without throwing.

Full smoke suite (Analytics/ColdStart/GitHubGate) + anon-auth suite green (18/18 local).

Pattern-following (self-cert eligible per owner note); the both-arm Gate Verification evidence is routed to Main (TL) before DevOps re-runs the deploy.

Fixes t/2684. 🤖 Generated with [Claude Code](https://claude.com/claude-code)