### PR TITLE
fix(oped): wordCount optional on web create + clamp word-count on blur (t/2685)

### DIFF
--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.test.tsx
@@ -127,6 +127,36 @@ describe('NewOpEdDialog — settings drawer', () => {
     // Back on Screen A the modified badge reflects one changed section
     expect(screen.getByLabelText(/1 setting changed/)).toBeTruthy();
   });
+
+  it('word count clamps on blur, not on keystroke — intermediate values are typeable (t/2685)', () => {
+    open();
+    fireEvent.click(screen.getByRole('button', { name: /More options/ }));
+    // 'Length & outlet' is the default section, so the override input is visible.
+    const input = screen.getByLabelText('Word count override') as HTMLInputElement;
+
+    // Regression: the old clamp ran on every change, so a below-min keystroke was collapsed to
+    // 300 immediately — making only 300/2000 reachable. Now typing is preserved; clamp is on blur.
+    fireEvent.change(input, { target: { value: '50' } });
+    expect(input.value).toBe('50');
+    fireEvent.blur(input);
+    expect(input.value).toBe('300');
+
+    // Above-max: typeable while editing, clamped to 2000 on blur.
+    fireEvent.change(input, { target: { value: '9000' } });
+    expect(input.value).toBe('9000');
+    fireEvent.blur(input);
+    expect(input.value).toBe('2000');
+
+    // A mid-band value survives untouched.
+    fireEvent.change(input, { target: { value: '800' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('800');
+
+    // Empty ⇒ null ⇒ use the outlet band (no override sent).
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('');
+  });
 });
 
 describe('NewOpEdDialog — draft + progress + cancel', () => {

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
@@ -219,11 +219,16 @@ function OpEdSettingsDrawer({
     setFamily(backendForModelWithFallback(globalModel));
   };
 
-  const clampWordCount = (raw: string): number | null => {
+  // While typing, keep the raw parsed value (no clamp) so intermediate digits — e.g. "80" on the
+  // way to "800" — aren't collapsed to the 300 floor, which made only 300/2000 reachable (t/2685).
+  // Clamp to [300,2000] on blur; empty ⇒ null ⇒ use the outlet band.
+  const parseWordCount = (raw: string): number | null => {
     if (raw.trim() === '') return null;
     const n = parseInt(raw, 10);
-    if (Number.isNaN(n)) return null;
-    return Math.min(2000, Math.max(300, n));
+    return Number.isNaN(n) ? null : n;
+  };
+  const clampWordCountOnBlur = () => {
+    setWordCount(prev => (prev == null ? null : Math.min(2000, Math.max(300, prev))));
   };
 
   return (
@@ -277,7 +282,8 @@ function OpEdSettingsDrawer({
                     max={2000}
                     placeholder="Use outlet band"
                     value={wordCount ?? ''}
-                    onChange={e => setWordCount(clampWordCount(e.target.value))}
+                    onChange={e => setWordCount(parseWordCount(e.target.value))}
+                    onBlur={clampWordCountOnBlur}
                   />
                   <p className="oped-field-hint">300–2000. Overrides the outlet's target length.</p>
                 </div>

--- a/taxonomy-editor/src/server/__tests__/opedRoutes.test.ts
+++ b/taxonomy-editor/src/server/__tests__/opedRoutes.test.ts
@@ -260,10 +260,21 @@ describe('POST /api/oped-sets create pre-start gate (t/2610)', () => {
     expect(res._status).toBe(400);
   });
 
-  it('400 when params.model / wordCount are missing', async () => {
+  it('400 when params.model is missing', async () => {
     const res = fakeRes();
-    await handlers['POST /api/oped-sets'](fakeReq('/api/oped-sets'), res, { topic: 'x', povs: ['acc'] });
+    await handlers['POST /api/oped-sets'](fakeReq('/api/oped-sets'), res, { topic: 'x', povs: ['acc'], params: { wordCount: 800 } });
     expect(res._status).toBe(400);
+  });
+
+  it('wordCount is OPTIONAL — a default create (no wordCount ⇒ outlet band) passes validation, not a 400 (t/2685)', async () => {
+    // Regression for the UAT bug: the default create ("Use outlet band") sends no wordCount and
+    // was wrongly 400'd. Prove it now passes validation by advancing to the quota gate (429) —
+    // if wordCount were still required this would 400 BEFORE quota is ever checked.
+    getOpedSetsQuotaStatus.mockResolvedValue({ allowed: false, resource: 'opeds', current: 15, limit: 15 });
+    const res = fakeRes();
+    await handlers['POST /api/oped-sets'](fakeReq('/api/oped-sets'), res, { topic: 'x', povs: ['acc'], params: { model: 'gemini-2.5-flash' } });
+    expect(res._status).toBe(429);
+    expect(JSON.parse(res._body!).error).toBe('quota_exceeded');
   });
 
   it('429 quota_exceeded when the op-ed quota is full — BEFORE any generation', async () => {

--- a/taxonomy-editor/src/server/routes/oped.ts
+++ b/taxonomy-editor/src/server/routes/oped.ts
@@ -83,8 +83,13 @@ function parseOpEdCreate(body: unknown): { ok: true; value: ParsedOpEdCreate } |
   const params = b.params;
   if (!topic || topic.length > MAX_TOPIC_LEN) return { ok: false, status: 400, message: 'topic is required (non-empty, ≤2000 chars)' };
   if (povs.length === 0) return { ok: false, status: 400, message: 'at least one voice (pov) is required' };
-  if (!params || typeof params.model !== 'string' || typeof params.wordCount !== 'number') return { ok: false, status: 400, message: 'params.model and params.wordCount are required' };
-  return { ok: true, value: { topic, povs, params } };
+  if (!params || typeof params.model !== 'string') return { ok: false, status: 400, message: 'params.model is required' };
+  // wordCount is OPTIONAL — the outlet band supplies the default (lib/oped/generate.ts resolveOutletBand;
+  // New-OpEd.ps1 derives length from the outlet). A default create ("Use outlet band") sends no wordCount,
+  // so requiring it 400'd every default web op-ed (t/2685). Coerce absent/invalid/≤0 to the band sentinel 0
+  // (mirrors schemas.ts .optional().default(0); generate.ts treats `wordCount > 0 ? … : band.words`).
+  const wordCount = typeof params.wordCount === 'number' && params.wordCount > 0 ? params.wordCount : 0;
+  return { ok: true, value: { topic, povs, params: { ...params, wordCount } } };
 }
 
 /** Tier-backend entitlement (mirrors chat.ts resolveGenerationContext, t/2610#11): a free


### PR DESCRIPTION
## What
Fixes two coupled UAT bugs in **web op-ed create** (Azure app), diagnosed in t/2685 from flight recorder `merged-83ad5beb` (build 2026-08-15T14:13Z).

### BUG 1 — default create 400'd ("params.model and params.wordCount are required")
`routes/oped.ts` required `params.wordCount` as a number, but `wordCount` is **optional by design** — the outlet band supplies the default (`lib/oped/generate.ts` `resolveOutletBand`; `New-OpEd.ps1` derives length from the outlet; `schemas.ts` `.optional().default(0)`). A default create ("Use outlet band") sends no `wordCount` → **400**. This is what forced users to manually set Outlet/Length.
- **Fix:** require only `model`; coerce absent/invalid/≤0 `wordCount` to the band sentinel `0`. No type churn (downstream already treats `wordCount > 0 ? … : band.words`).

### BUG 2 — word-count field only allowed 300 or 2000
`clampWordCount` ran `Math.min(2000, Math.max(300, n))` inside **onChange**, clamping every keystroke — typing "800" collapsed digit-by-digit to the 300 floor.
- **Fix:** parse (no clamp) on change, **clamp on blur**; empty ⇒ null ⇒ use outlet band.

## Tests (regression)
- `opedRoutes.test.ts`: model-missing → 400; **wordCount omitted passes validation** (advances to the quota gate 429, not a 400).
- `NewOpEdDialog.test.tsx`: below-min keystroke preserved ('50'), clamped to 300 **on blur**; above-max → 2000 on blur; mid-band survives; empty → blank.

## Not included (split)
The separate "**voice failed to generate — 0 words**" on a *successful* (200) create (screenshot t2.png) — no server-side generation error was captured in the dump. Needs a live repro + observability; tracked as a follow-up under t/2685.

## Verification
Local test run not performed — worktree has no `node_modules` and local TS tests hit the known Node-24 undici skew (t/2670#1); **CI (Node 22) is the gate.** Self-review + Quality (TL) review requested before merge.

Ticket: t/2685
🤖 Generated with [Claude Code](https://claude.com/claude-code)