### PR TITLE
chore(dependabot): hold undici major bumps (CVE-2026-58040 invariant) (#1091)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,16 @@ updates:
       minor-and-patch:
         update-types: [minor, patch]
     open-pull-requests-limit: 5
+    ignore:
+      # undici MAJOR is HELD (t/2053/t/2113/t/2281; #1091). The GitHub REST client passes an
+      # undici.Agent as `dispatcher:` to Node's built-in fetch; per assertUndiciMajorInvariant,
+      # userland undici major MUST equal Node's bundled undici major (node:22.23.2 → undici 6.x),
+      # or fetch silently ignores the dispatcher and falls back to TLS session caching
+      # (CVE-2026-58040). A userland-only major bump (e.g. 6→8) reintroduces that condition and
+      # reds githubApi.test.ts. minor/patch within the pinned major still flow (security patches).
+      # REVISIT when the pinned Node runtime bundles a newer undici major, then bump both together.
+      - dependency-name: undici
+        update-types: [version-update:semver-major]
 
   - package-ecosystem: npm
     directory: /workflow-app


### PR DESCRIPTION
## Why
Dependabot #1091 proposed undici **6→8**, which reds `githubApi.test.ts` (74) + `test-electron`/`test-container`. Investigation (PM p/344): these are **not broken mocks** — they're the `assertUndiciMajorInvariant` security guard firing correctly.

The GitHub REST client passes an `undici.Agent` as `dispatcher:` to Node's built-in fetch. Per the invariant (t/2053/t/2113/t/2281), **userland undici major MUST equal Node's bundled undici major** — `node:22.23.2` (CI+prod) bundles undici **6.x**, so userland stays pinned at 6.x. A userland-only major bump makes fetch silently ignore the dispatcher and fall back to TLS session caching — the **CVE-2026-58040** condition.

## Change
Add a dependabot `ignore` for `undici` `version-update:semver-major` in the `/taxonomy-editor` npm ecosystem (the only direct undici pin). **Minor/patch within 6.x still flow** for security patches. Same pattern/precedent as the existing `node` docker major-ignores in this file.

#1091 is closed. Revisit when the pinned Node runtime bundles a newer undici major (then bump Node + undici together).
🤖 Generated with [Claude Code](https://claude.com/claude-code)