### PR TITLE
feat(arg-strength): collapsible POV sections + per-POV Top 5 (t/2686)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.css
@@ -49,6 +49,52 @@
   color: var(--text-muted);
 }
 
+/* t/2686: per-POV collapse toggle (whole label is the click target) */
+.ast-pov-toggle {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.ast-pov-caret {
+  font-size: var(--text-2xs);
+  color: var(--text-secondary);
+  align-self: center;
+}
+
+/* t/2686: per-POV Top-5 filter toggle */
+.ast-top5-btn {
+  margin-left: auto;
+  font-size: var(--text-2xs);
+  padding: 1px 8px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.ast-top5-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.ast-top5-btn.active {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.ast-top5-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 .ast-node-wrap {
   position: relative;
 }

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ArgStrengthTab } from './ArgStrengthTab';
+
+// ---------------------------------------------------------------------------
+// Mocks — isolate the tab from qbaf math, INodeRow detail, and POV metadata.
+// ---------------------------------------------------------------------------
+vi.mock('@lib/debate/qbaf', () => ({ computeQbafStrengths: () => ({ strengths: new Map() }) }));
+vi.mock('../shared/INodeRow', () => ({
+  INodeRow: (props: { node?: { id?: string } }) => <div data-testid={`inode-${props.node?.id}`} />,
+}));
+vi.mock('../helpers', () => ({ speakerLabel: (s: string) => s }));
+vi.mock('@lib/electron-shared/povMeta', () => ({
+  POV_META: {
+    accelerationist: { cssVar: '--color-acc' },
+    safetyist: { cssVar: '--color-saf' },
+    skeptic: { cssVar: '--color-skp' },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------------
+function node(id: string, speaker: string, base: number) {
+  return { id, speaker, base_strength: base, source_entry_id: 'e1' } as never;
+}
+
+function makeProps(nodes: unknown[]) {
+  return {
+    debate: { transcript: [{ id: 'e1' }] } as never,
+    an: { nodes: nodes as never[], edges: [] as never[] },
+    handleUpdateSubScore: vi.fn(),
+    setOverviewTab: vi.fn(),
+    setSelectedEntry: vi.fn(),
+    setLocalOverride: vi.fn(),
+    nodeLabels: new Map<string, string>(),
+  };
+}
+
+// accelerationist has 7 args (to exercise Top 5); saf/skp have 2 each.
+const NODES = [
+  ...Array.from({ length: 7 }, (_, i) => node(`a${i}`, 'accelerationist', (i + 1) / 10)),
+  node('s0', 'safetyist', 0.4), node('s1', 'safetyist', 0.2),
+  node('k0', 'skeptic', 0.5), node('k1', 'skeptic', 0.3),
+];
+
+describe('ArgStrengthTab — t/2686 POV sections, collapse, Top 5', () => {
+  it('renders a section for every POV present (not just Accelerationist)', () => {
+    render(<ArgStrengthTab {...makeProps(NODES)} />);
+    // One collapse toggle per POV section.
+    expect(screen.getByRole('button', { name: /accelerationist/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /safetyist/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /skeptic/i })).toBeTruthy();
+    // All 7 accelerationist rows render by default (expanded, no Top-5 filter).
+    expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(7);
+  });
+
+  it('collapsing a POV section hides its argument rows', () => {
+    render(<ArgStrengthTab {...makeProps(NODES)} />);
+    const toggle = screen.getByRole('button', { name: /accelerationist/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryAllByTestId(/^inode-a/)).toHaveLength(0);
+    // Other sections stay expanded.
+    expect(screen.getAllByTestId(/^inode-s/)).toHaveLength(2);
+  });
+
+  it('Top 5 filters a POV to its 5 strongest, and toggles back', () => {
+    render(<ArgStrengthTab {...makeProps(NODES)} />);
+    // Only accelerationist has >5 args, so exactly one Top 5 button exists.
+    const top5 = screen.getByRole('button', { name: 'Top 5' });
+    fireEvent.click(top5);
+    expect(top5.getAttribute('aria-pressed')).toBe('true');
+    const shown = screen.getAllByTestId(/^inode-a/);
+    expect(shown).toHaveLength(5);
+    // The 5 strongest are a6..a2 (base 0.7..0.3); a1/a0 are dropped.
+    const ids = shown.map(el => el.getAttribute('data-testid'));
+    expect(ids).toContain('inode-a6');
+    expect(ids).not.toContain('inode-a0');
+    fireEvent.click(top5);
+    expect(screen.getAllByTestId(/^inode-a/)).toHaveLength(7);
+  });
+
+  it('Collapse All hides every section; Expand All restores them', () => {
+    render(<ArgStrengthTab {...makeProps(NODES)} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse All' }));
+    expect(screen.queryAllByTestId(/^inode-/)).toHaveLength(0);
+    fireEvent.click(screen.getByRole('button', { name: 'Expand All' }));
+    expect(screen.getAllByTestId(/^inode-/).length).toBeGreaterThan(0);
+  });
+
+  it('shows the empty state when there is no argument network', () => {
+    render(<ArgStrengthTab {...makeProps([])} />);
+    expect(screen.getByText(/No argument network data/i)).toBeTruthy();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-diagnostics/window/overview-tabs/ArgStrengthTab.tsx
@@ -27,6 +27,15 @@ export function ArgStrengthTab({
   debate, an, handleUpdateSubScore, setOverviewTab, setSelectedEntry, setLocalOverride, nodeLabels,
 }: ArgStrengthTabProps) {
   const [allExpanded, setAllExpanded] = useState(false);
+  // t/2686: per-POV-section collapse + per-POV Top-5 filter. Default: all sections expanded.
+  const [collapsedPovs, setCollapsedPovs] = useState<Set<string>>(new Set());
+  const [top5Povs, setTop5Povs] = useState<Set<string>>(new Set());
+  const togglePov = (pov: string, setter: React.Dispatch<React.SetStateAction<Set<string>>>) =>
+    setter(prev => {
+      const next = new Set(prev);
+      if (next.has(pov)) next.delete(pov); else next.add(pov);
+      return next;
+    });
   const edges = an.edges ?? [];
 
   const stmtIdByEntry = useMemo(() => {
@@ -71,12 +80,21 @@ export function ArgStrengthTab({
     ...POV_ORDER.filter(p => nodesByPov.has(p)),
     ...[...nodesByPov.keys()].filter(p => !(POV_ORDER as readonly string[]).includes(p)),
   ];
+  const anyCollapsed = orderedPovs.some(p => collapsedPovs.has(p));
 
   return (
     <div className="ast-root">
       <div className="ast-toolbar">
-        <button onClick={() => setAllExpanded(!allExpanded)} className="ast-expand-btn">
-          {allExpanded ? 'Collapse All' : 'Expand All'}
+        <button
+          type="button"
+          className="ast-expand-btn"
+          // t/2686: operates on POV SECTIONS. Expand All also expands argument-row detail.
+          onClick={() => {
+            if (anyCollapsed) { setCollapsedPovs(new Set()); setAllExpanded(true); }
+            else { setCollapsedPovs(new Set(orderedPovs)); }
+          }}
+        >
+          {anyCollapsed ? 'Expand All' : 'Collapse All'}
         </button>
       </div>
       {orderedPovs.map(pov => {
@@ -87,19 +105,43 @@ export function ArgStrengthTab({
               nodes.length
             : 0;
         const cssVar = POV_META[pov as PovMetaKey]?.cssVar ?? '--text-primary';
+        const isCollapsed = collapsedPovs.has(pov);
+        const isTop5 = top5Povs.has(pov);
+        const displayNodes = isTop5 ? nodes.slice(0, 5) : nodes;
         return (
           <div key={pov} className="ast-pov-section">
             <div className="ast-pov-header">
-              {/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}
-              <span className="ast-pov-label" style={{ color: `var(${cssVar})` }}>
-                {speakerLabel(pov)}
-              </span>
+              <button
+                type="button"
+                className="ast-pov-toggle"
+                onClick={() => togglePov(pov, setCollapsedPovs)}
+                aria-expanded={!isCollapsed}
+                title={isCollapsed ? 'Expand section' : 'Collapse section'}
+              >
+                <span className="ast-pov-caret" aria-hidden="true">{isCollapsed ? '▶' : '▼'}</span>
+                {/* eslint-disable-next-line local/no-inline-style -- color is per-camp, derived from POV_META.cssVar */}
+                <span className="ast-pov-label" style={{ color: `var(${cssVar})` }}>
+                  {speakerLabel(pov)}
+                </span>
+              </button>
               <span className="ast-pov-stats">
                 {nodes.length} argument{nodes.length !== 1 ? 's' : ''} · avg{' '}
                 {avgStrength.toFixed(2)}
               </span>
+              {nodes.length > 5 && (
+                <button
+                  type="button"
+                  className={`ast-top5-btn${isTop5 ? ' active' : ''}`}
+                  onClick={() => togglePov(pov, setTop5Povs)}
+                  aria-pressed={isTop5}
+                  disabled={isCollapsed}
+                  title={isTop5 ? 'Show all arguments' : 'Show only the 5 strongest'}
+                >
+                  Top 5
+                </button>
+              )}
             </div>
-            {nodes.map((n, idx) => {
+            {!isCollapsed && displayNodes.map((n, idx) => {
               const attacks = edges.filter(e => e.target === n.id && e.type === 'attacks');
               const supports = edges.filter(e => e.target === n.id && e.type === 'supports');
               const isSource = edges.some(e => e.source === n.id);


### PR DESCRIPTION
## What (t/2686)
Adds the requested interactions to the Arg Strength tab (Debate Diagnostics):
- **Collapsible POV sections** — each POV header is a collapse/expand toggle (default expanded, AC2).
- **Per-POV "Top 5"** — filters to the 5 highest-strength arguments; shown only when a section has >5; toggling off restores the full list (AC3).
- **Expand All / Collapse All** now operates on POV **sections** (AC5); Expand All also expands argument-row detail so there's no row-expand regression.

## TL review correction (see t/2686#1)
The ticket premise was partly inaccurate — verified against the code:
- **All POVs already rendered** (`ArgStrengthTab.tsx` maps `orderedPovs`); the screenshot just showed the first section above the fold. AC1 "only Accelerationist" was not true.
- **Debates are a 3-agent system** (acc/saf/skp) — **Concerned Citizen is a taxonomy camp, not a debate speaker**, so AC1's "all four camps" is N/A. Asked PM to correct AC1 to the 3 debate POVs.

Per-argument display (strength bar, node ref, category, rank badges #1–#3) unchanged (AC4).

## Tests
`ArgStrengthTab.test.tsx`: every POV renders, section collapse hides its rows (others stay), Top 5 shows the 5 strongest and toggles back, Collapse/Expand All, empty state.

## Verification
Local run not performed (worktree has no node_modules; local TS tests hit the Node-24 undici skew per t/2670#1) → **CI Node 22 is the gate**. Self-reviewed vs the TS guide (UI-only; no IPC/credential surface; `fireEvent` matches sibling tests in this dir).

Ticket: t/2686
🤖 Generated with [Claude Code](https://claude.com/claude-code)