### PR TITLE
feat(container): bump runtime base to ai-triad-base:2026-08-15 (t/2681)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -117,10 +117,10 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --prod 
 # ── Stage 3: Runtime ──
 # CI smoke = liveness-only (any HTTP status passes; t/2067). Data-readiness proven at staging
 # (deploy-staging.yml Test-TaxEditorHealth /healthz). :2026-07-30 was exonerated in t/2047 —
-# root cause was t/2061 (isDataAvailable path mismatch, app-side). Bumped to :2026-08-13 to
-# clear DLA-4726-1 (ca-certificates fix) + 6 no-fix CVE .trivyignore entries (t/2547).
+# root cause was t/2061 (isDataAvailable path mismatch, app-side). Bumped to :2026-08-15 for
+# Debian 13 Trixie upgrade + .trivyignore cleanup (t/2681).
 # Gate base bumps on staging /healthz, not CI green.
-FROM ghcr.io/jpsnover/ai-triad-base:2026-08-13@sha256:ec5159a9e466adf5af0f5f762b6fe7877e437fbee93748bd6ab209d378b7a963 AS runtime
+FROM ghcr.io/jpsnover/ai-triad-base:2026-08-15@sha256:60a955b4523340536e9ed3e20a737304b58b56fe3a150fe643fb61699a58ca63 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Taxonomy Editor"


### PR DESCRIPTION
## Summary
- Bumps taxonomy-editor runtime base from `ai-triad-base:2026-08-13` (bookworm) to `ai-triad-base:2026-08-15` (Trixie, sha256:60a955b4)
- The new base was built in #1101 (Debian 13 Trixie upgrade) and its .trivyignore entries were cleaned up in #1106

## Hold
Draft until staging /healthz confirms the Trixie base starts cleanly. Per Dockerfile comment: "Gate base bumps on staging /healthz, not CI green."

To undraft: run `Invoke-TaxEditorSmokeTest -BaseUrl <staging-url>` and verify /healthz returns 200, then un-draft and merge.

## Test plan
- [ ] Staging /healthz returns 200 on the Trixie base (manual gate — un-draft when confirmed)
- [ ] CI green (container build + Trivy scan)

Generated with [Claude Code](https://claude.com/claude-code)
