### PR TITLE
fix(container): copy soul-docs/*.json to runtime image (t/2689)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -159,6 +159,10 @@ COPY --chown=aitriad:aitriad scripts/ ./scripts/
 # The op-ed create route resolves promptsDir = getProjectRoot()/lib/oped/prompts
 # (= /app/lib/oped/prompts here); tsc emits no .prompt assets, so copy the source.
 COPY --chown=aitriad:aitriad lib/oped/prompts/ ./lib/oped/prompts/
+# Soul-doc JSON data files for op-ed voice generation (t/2689).
+# soulDocLoader.ts reads these at runtime via fs.readFile from SOUL_DOCS_DIR
+# (= /app/lib/debate/soul-docs/); tsc does not emit .json data files, so copy explicitly.
+COPY --chown=aitriad:aitriad lib/debate/soul-docs/ ./lib/debate/soul-docs/
 
 # 3. Built artifacts (change on every code edit — LAST for fastest rebuilds)
 # tsc outputs to dist/server/{taxonomy-editor/src/server/,lib/} due to rootDir=../


### PR DESCRIPTION
## Summary
- `soulDocLoader.ts` reads soul-doc JSON files at runtime via `fs.readFile` from `/app/lib/debate/soul-docs/`
- The runtime stage copied compiled `.js` artifacts but not these data files — ENOENT on every op-ed voice generation request (100% broken on prod)
- Fix: add `COPY lib/debate/soul-docs/ ./lib/debate/soul-docs/` to the runtime stage, matching the existing `lib/oped/prompts/` pattern

## Test plan
- [ ] CI green
- [ ] Container build produces image with `/app/lib/debate/soul-docs/{accelerationist,safetyist,skeptic}.soul.json` present
- [ ] Deploy to prod, create-topic op-ed generates wordCount > 0 for each voice

Closes t/2689

Generated with Claude Code