### PR TITLE
fix(flight-recorder): popup Dump Log delegates to main recorder, not empty shim (t/2690)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/__tests__/flightRecorderPopupDump.test.ts
+++ b/taxonomy-editor/src/renderer/lib/__tests__/flightRecorderPopupDump.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Regression tests for t/2690: "Dump Log" clicked inside a diagnostics *popup*
+ * window must write the MAIN window's recorder (capacity 5000) via IPC — not the
+ * popup's capacity-1 forwarding shim.
+ *
+ * The bug: DiagnosticsWindow.tsx / OverviewTabRouter.tsx import `triggerManualDump`
+ * directly from this module. In a popup, `getGlobalRecorder()` returns the shim, so
+ * `persistDump(shim, …)` wrote a useless 1-capacity buffer (0 events). The popup's
+ * real dump path (IPC → main window) lived only on `globalThis.__triggerManualDump`
+ * and was never invoked by the buttons.
+ *
+ * The fix: a module-level `_popupDumpHandler`, set in the popup init path and checked
+ * at the top of `triggerManualDump()`, so the direct-import callers delegate to the
+ * IPC forwarder instead of persisting the empty shim.
+ */
+
+const h = vi.hoisted(() => {
+  let current: unknown = null;
+  return {
+    getCurrent: () => current,
+    setCurrent: (r: unknown) => { current = r; },
+    dumpFlightRecorder: vi.fn().mockResolvedValue({ filePath: '/tmp/main-dump.ndjson', filename: 'main-dump.ndjson' }),
+    clipboardWriteText: vi.fn(),
+    openFlightRecorderViewer: vi.fn(),
+    reportError: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('@lib/flight-recorder/index', () => ({
+  // Minimal recorder: the popup shim reassigns .record/.intern; the main path calls
+  // .intern (dictionary seeding) and .buildDump (dump). All backed by vi.fn spies.
+  FlightRecorder: class {
+    record = vi.fn();
+    intern = vi.fn((_category: string, value: string) => ({ id: value }));
+    buildDump = vi.fn(() => ({ ndjson: '{"event":1}', droppedByCategory: {}, meta: {} }));
+  },
+  getGlobalRecorder: () => h.getCurrent(),
+  setGlobalRecorder: (r: unknown) => { h.setCurrent(r); },
+}));
+
+vi.mock('@bridge', () => ({
+  api: {
+    dumpFlightRecorder: h.dumpFlightRecorder,
+    clipboardWriteText: h.clipboardWriteText,
+    openFlightRecorderViewer: h.openFlightRecorderViewer,
+    reportError: h.reportError,
+  },
+}));
+
+vi.mock('../dumpToast', () => ({
+  showDumpToast: vi.fn(),
+  showDumpErrorToast: vi.fn(),
+  showDumpPendingToast: vi.fn(() => () => { /* dismiss */ }),
+}));
+
+describe('triggerManualDump — popup delegates to main recorder, not the local shim (t/2690)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    h.setCurrent(null);
+    h.dumpFlightRecorder.mockClear();
+    h.clipboardWriteText.mockClear();
+  });
+
+  it('in a diagnostics popup, "Dump Log" triggers the MAIN window dump via IPC and never persists the shim', async () => {
+    window.location.hash = '#diagnostics-window';
+    const triggerMainDump = vi.fn().mockResolvedValue({ filePath: '/tmp/main-dump.ndjson' });
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      forwardFlightEvent: vi.fn(),
+      triggerMainDump,
+      // onTriggerDump omitted — main-window relay hook is not registered in a popup
+    };
+
+    const mod = await import('../flightRecorderInit');
+    mod.initFlightRecorder();
+
+    await mod.triggerManualDump();
+
+    // Delegated to the popup's IPC forwarder → main window writes its full recorder.
+    expect(triggerMainDump).toHaveBeenCalledTimes(1);
+    // The empty capacity-1 shim is NEVER persisted (the t/2690 bug).
+    expect(h.dumpFlightRecorder).not.toHaveBeenCalled();
+  });
+
+  it('in the main window (no popup handler), "Dump Log" persists the real recorder as before', async () => {
+    window.location.hash = '';
+    // electronAPI present but NOT a popup (hash is main) → isWeb=false.
+    (window as unknown as { electronAPI: unknown }).electronAPI = { forwardFlightEvent: vi.fn() };
+
+    const mod = await import('../flightRecorderInit');
+    // Fresh module → _popupDumpHandler is null (popup init never ran). Register a
+    // normal main-window recorder as the global, mirroring what initFlightRecorder
+    // does on the main path, and confirm triggerManualDump persists IT.
+    h.setCurrent({
+      record: vi.fn(),
+      buildDump: vi.fn(() => ({ ndjson: '{"event":1}', droppedByCategory: {}, meta: {} })),
+    });
+
+    await mod.triggerManualDump();
+
+    // Main window persists its own recorder directly (no popup delegation).
+    expect(h.dumpFlightRecorder).toHaveBeenCalledTimes(1);
+  });
+});

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -332,6 +332,14 @@ function createWebPopupShim(origin: string): FlightRecorder {
 
 let initialized = false;
 
+// In a popup window, the real (capacity-5000) recorder lives in the MAIN window;
+// this window holds only a capacity-1 forwarding shim. Set in the popup init path
+// below to the popup's dump handler (IPC / BroadcastChannel → main window) so that
+// triggerManualDump() — imported directly by the "Dump Log" UI buttons — delegates
+// to it instead of persisting the empty local shim buffer (t/2690). null in the
+// main window, where triggerManualDump persists the real recorder directly.
+let _popupDumpHandler: (() => void) | null = null;
+
 // Defer store import to avoid circular dependency — resolved on first context/dump call.
 // Module-scoped so both initFlightRecorder and dumpOnReactError can access it.
 let _stores: { useDebateStore: unknown; useTaxonomyStore: unknown } | null = null;
@@ -469,8 +477,12 @@ export function initFlightRecorder(): FlightRecorder {
         }
       };
 
-      // Set up manual dump trigger for popup — request main window to dump
-      (globalThis as unknown as { __triggerManualDump: () => Promise<void> | void }).__triggerManualDump = () => {
+      // Set up manual dump trigger for popup — request main window to dump.
+      // Stored in module-level _popupDumpHandler AND on globalThis so both the
+      // error-boundary hook (globalThis) and the "Dump Log" UI buttons (which
+      // import triggerManualDump directly) route through this IPC/BroadcastChannel
+      // forwarder instead of persisting the empty local shim buffer (t/2690).
+      const popupDumpHandler = () => {
         shim.record({ type: 'lifecycle', component: 'flight-recorder', level: 'info', message: 'Manual dump requested from popup' });
         if (hasElectronIPC) {
           try {
@@ -488,6 +500,8 @@ export function initFlightRecorder(): FlightRecorder {
           ch.close();
         }
       };
+      _popupDumpHandler = popupDumpHandler;
+      (globalThis as unknown as { __triggerManualDump: () => Promise<void> | void }).__triggerManualDump = popupDumpHandler;
 
       return shim;
     }
@@ -924,6 +938,15 @@ export function isDumpInProgress(): boolean { return _dumpInFlight; }
  * Shows an immediate pending toast, guards against overlapping dumps.
  */
 export async function triggerManualDump(): Promise<void> {
+  // In a popup window the real recorder lives in the MAIN window; the local
+  // recorder is a capacity-1 forwarding shim. Delegate to the popup's dump handler
+  // (IPC / BroadcastChannel → main window) instead of persisting the empty shim.
+  // The "Dump Log" buttons import this function directly, bypassing the
+  // globalThis.__triggerManualDump hook, so the popup check must live here (t/2690).
+  if (_popupDumpHandler) {
+    _popupDumpHandler();
+    return;
+  }
   const recorder = getGlobalRecorder();
   if (!recorder || _dumpInFlight) return;
   _dumpInFlight = true;


### PR DESCRIPTION
## Summary

Fixes **t/2690**: clicking "Dump Log" inside a debate Diagnostics **popup** window wrote the popup's capacity-1 forwarding shim (0 events) instead of the main window's full 5000-event recorder — producing a useless 334-byte dump.

## Root cause

`DiagnosticsWindow.tsx:315` and `OverviewTabRouter.tsx:663` import `triggerManualDump` **directly** from `flightRecorderInit`. In a popup, `getGlobalRecorder()` returns the shim, so `persistDump(shim, …)` wrote the empty local buffer. The popup's real dump path (IPC → main window's recorder) lived only on `globalThis.__triggerManualDump` and was never invoked by those buttons.

## Fix

- Module-level `_popupDumpHandler`, set in the popup init path to the same IPC/BroadcastChannel forwarder already assigned to `globalThis.__triggerManualDump`.
- `triggerManualDump()` checks it first and delegates when in a popup — so both the direct-import UI buttons and the error-boundary `globalThis` hook route through the forwarder.
- Main-window and error-boundary dump paths are unchanged.

Diagnosis by Diagnostics; net change is +27 lines in `flightRecorderInit.ts` (a rename of the existing popup closure into a named handler + the delegation guard).

## Test

New `flightRecorderPopupDump.test.ts`:
- **popup** → `triggerManualDump` calls `electronAPI.triggerMainDump` (main window dumps) and **never** persists the shim.
- **main window** → still persists its own recorder.

## Verification (local)

- `flightRecorderPopupDump.test.ts` + existing `flightRecorderReactError.test.ts`: **6/6 pass**
- renderer tsc: **0 errors**
- eslint (changed files): **0 errors** (7 pre-existing warnings only)

Full `npm run verify` runs in CI.

Closes t/2690.
