### PR TITLE
feat(flight-recorder): add shim flag to config and dump header (t/2691)

### DIFF
--- a/lib/flight-recorder/flightRecorder.test.ts
+++ b/lib/flight-recorder/flightRecorder.test.ts
@@ -592,6 +592,19 @@ describe('FlightRecorder', () => {
 
     expect(eventLine.component).toBe('argument-network');
   });
+
+  it('shim:true is emitted in dump header when config.shim is set', () => {
+    const shim = new FlightRecorder({ capacity: 1, dumpOnError: false, shim: true });
+    const { ndjson } = shim.buildDump('manual');
+    const header = JSON.parse(ndjson.split('\n')[0]);
+    expect(header.shim).toBe(true);
+  });
+
+  it('shim field is absent from dump header when config.shim is not set', () => {
+    const { ndjson } = recorder.buildDump('manual');
+    const header = JSON.parse(ndjson.split('\n')[0]);
+    expect(header.shim).toBeUndefined();
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════

--- a/lib/flight-recorder/flightRecorder.ts
+++ b/lib/flight-recorder/flightRecorder.ts
@@ -305,6 +305,7 @@ export class FlightRecorder {
       ring_buffer_events_total: this.buffer.count,
       ring_buffer_events_retained: this.buffer.retained,
       events_lost: Math.max(0, this.buffer.count - this.buffer.capacity),
+      ...(this.config.shim && { shim: true }),
     };
   }
 }

--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -225,6 +225,7 @@ export interface FlightRecorderConfig {
   maxDumpFiles: number;          // Retain last N dumps (default: 10)
   maxDumpBytes: number;          // Total disk budget in bytes (default: 50 MB)
   includeSystemContext: boolean;  // Include OS/app info in dump header (default: true)
+  shim?: boolean;                // Marks this as an intentional capacity-1 popup shim recorder
 }
 
 export const DEFAULT_CONFIG: FlightRecorderConfig = {


### PR DESCRIPTION
## Summary

- Adds `shim?: boolean` to `FlightRecorderConfig` — an optional marker for intentional capacity-1 popup-shim recorders
- `buildDump()` emits `shim: true` in the `_type: "header"` line when the flag is set
- Two tests added: presence and absence of the field in the dump header

## Motivation

Diagnosing t/2690 required several investigative steps because a shim recorder dump (`ring_buffer_capacity: 1, ring_buffer_events_total: 0`) was indistinguishable from a broken/misconfigured one. This field removes that ambiguity at a glance.

The renderer side (`createPopupShim`/`createWebPopupShim` passing `{ shim: true }`) is a one-liner TL will wire in a follow-up.

## Test plan
- [x] `vitest run` on `lib/flight-recorder/flightRecorder.test.ts` — 69/69 pass
- [x] New: `shim:true emitted when config.shim set`
- [x] New: `shim absent from header when config.shim not set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)