### PR TITLE
fix(diagnostics): buffer diagnostics-state-update so the popup can't miss it (t/2694)

### DIFF
--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -12,6 +12,19 @@ ipcRenderer.on('debate-window-load', (_event, debateId: string) => {
   if (_debateBufferActive) _bufferedDebateId = debateId;
 });
 
+// Buffer the diagnostics-state-update push the same way (t/2694). The main window
+// pushes the cached state once on the diagnostics popup's did-finish-load
+// (main.ts), but useDiagnosticsState registers its listener only after React
+// mounts — so a push arriving first was silently dropped, and for an idle debate
+// (no follow-up pushes) the window stayed on "Loading debate…" forever. Buffer the
+// latest pre-registration state (full-state snapshots, so only the newest matters)
+// and flush it on registration. Also covers the PovProgression window (same channel).
+let _bufferedDiagnosticsState: unknown = null;
+let _diagnosticsBufferActive = true;
+ipcRenderer.on('diagnostics-state-update', (_event, state: unknown) => {
+  if (_diagnosticsBufferActive) _bufferedDiagnosticsState = state;
+});
+
 contextBridge.exposeInMainWorld('electronAPI', {
   // Synchronous system info — available without IPC round-trip
   processVersions: { ...process.versions },
@@ -272,9 +285,21 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   sendDiagnosticsState: (state: unknown): void => ipcRenderer.send('diagnostics-state-update', state),
   onDiagnosticsStateUpdate: (callback: (state: unknown) => void) => {
+    // Stop buffering — the component is now listening directly.
+    _diagnosticsBufferActive = false;
+    // If the push arrived before the component mounted (race with the
+    // did-finish-load push), deliver the buffered state immediately (t/2694).
+    if (_bufferedDiagnosticsState !== null) {
+      const state = _bufferedDiagnosticsState;
+      _bufferedDiagnosticsState = null;
+      queueMicrotask(() => callback(state));
+    }
     const listener = (_event: Electron.IpcRendererEvent, state: unknown) => callback(state);
     ipcRenderer.on('diagnostics-state-update', listener);
-    return () => { ipcRenderer.removeListener('diagnostics-state-update', listener); };
+    return () => {
+      ipcRenderer.removeListener('diagnostics-state-update', listener);
+      _diagnosticsBufferActive = true; // re-arm for the next reload cycle
+    };
   },
   requestReExtractClaims: (entryId: string): void => ipcRenderer.send('request-re-extract-claims', entryId),
   onReExtractClaims: (callback: (entryId: string) => void) => {


### PR DESCRIPTION
## Summary

Fixes **t/2694**: the debate Diagnostics popup could **"never display"**. The main window pushes the cached diagnostics state **once** on the popup's `did-finish-load`, but `useDiagnosticsState` registers its `onDiagnosticsStateUpdate` listener only **after React mounts**. A push arriving first was silently dropped — and for an **idle** debate (no follow-up pushes) the window stayed on "Loading debate…" forever.

## Fix

Buffer the latest pre-registration `diagnostics-state-update` in `preload.cts` and flush it on subscribe — a **direct mirror of the existing `debate-window-load` buffer** in the same file (which fixes the identical race for the debate window). Preserves the live in-memory state source; also covers the PovProgression window (same channel). **`preload.cts` only** — no `main.ts` / renderer changes.

## ⚠️ Two deviations — please review

**1. Reversed the ticket's proposed approach (hash `debateId` deep-link).**
The deep-link path loads a **persisted** session via `loadDebateSession(debateId)`, which returns null for a fresh **in-progress debate not yet persisted** → `setDeepLinkError('Debate not found')` → still broken, and it changes the data source (persisted vs live). The preload buffer keeps the live source and works whether or not the debate is persisted. Full analysis in **t/2694#1** (flagged to Diagnostics; proceeding per PI direction to action the ticket). **Diagnostics: please confirm you're OK with this approach.**

**2. No unit test — against "every fix has a regression test".**
`preload.cts` is a sandboxed **CommonJS** module that is **not unit-testable in this stack**, demonstrated during implementation:
- vite's SSR transform rejects TS syntax in a `.cts` (`interface`/annotations → parse error);
- `tsc` ignores JSDoc in a `.cts` (it's a TS file) → can't type a plain-JS `.cts` helper;
- a CJS preload can't `require` an ESM `.ts` helper (`"type":"module"`, `nodenext`, Electron `sandbox:true`);
- `allowJs` is off, so a `.cjs` helper wouldn't emit to `dist/main`.

The mirrored `debate-window-load` buffer is likewise shipped **without** a unit test. Filed **t/2698** (tech debt) to add a preload test harness. Open to a reviewer's idea for a viable test.

## Verification
- `build:main` tsc: **clean**
- renderer tsc: **0 errors**
- eslint: `.cts` is config-ignored (no lint), 0 errors

## Draft
Kept as **draft** pending (a) Diagnostics' ack of the approach reversal and (b) reviewer sign-off on the test deviation. Un-draft + merge once both are cleared.

Refs t/2694, t/2698.
