### PR TITLE
feat(flight-recorder): mark popup-shim dumps with shim:true (t/2691)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -226,7 +226,7 @@ async function persistDump(
  */
 function createPopupShim(origin: string): FlightRecorder {
   // Create a minimal recorder (capacity 1 — we don't buffer locally)
-  const shim = new FlightRecorder({ capacity: 1, dumpOnError: false });
+  const shim = new FlightRecorder({ capacity: 1, dumpOnError: false, shim: true }); // t/2691: mark dumps as popup-shim in the FR header
 
   const electronAPI = (window as unknown as { electronAPI: { forwardFlightEvent: (event: RecordInput) => void } }).electronAPI;
 
@@ -280,7 +280,7 @@ function createPopupShim(origin: string): FlightRecorder {
  * Mirrors createPopupShim but uses BroadcastChannel instead of Electron IPC.
  */
 function createWebPopupShim(origin: string): FlightRecorder {
-  const shim = new FlightRecorder({ capacity: 1, dumpOnError: false });
+  const shim = new FlightRecorder({ capacity: 1, dumpOnError: false, shim: true }); // t/2691: mark dumps as popup-shim in the FR header
   const channel = new BroadcastChannel('aitriad-flight-recorder');
 
   shim.record = (input: RecordInput) => {


### PR DESCRIPTION
Renderer one-liner pairing #1119 (lib side). Passes `shim: true` to the FlightRecorder config in `createPopupShim`/`createWebPopupShim` so `buildDump` emits `shim: true` in the dump header — so a popup dump (capacity 1 / 0 events) reads as an intentional shim, not a broken recorder (the misdiagnosis that cost time in t/2690).

Self-cert /trivial-change. Verify: renderer tsc 0 errors, flightRecorderPopupDump.test 2/2, eslint 0 errors. Closes t/2691.