### PR TITLE
fix(smoke): Phase 7 oped-files false-warn — parse Body explicitly, drop -ExpectJson flag

### DIFF
--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -372,24 +372,33 @@ function Invoke-TaxEditorSmokeTest {
     # Warn-only: NOT gating OverallPass until TL Gate Verification (both arms +
     # ≥1 real-env cycle) is complete. See t/2689 AC3.
     Write-Host '=== Oped Files Health ===' -ForegroundColor Cyan
+    # Accept both 200 (ok) and 500 (missing files) so Invoke-WebRequest doesn't throw on the
+    # failure arm; we discriminate via ok:true/false in the body, not the HTTP status.
     $OpedFilesCheck = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/api/health/oped-files' `
-        -Method 'GET' -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200) -ExpectJson $true
-    # Require JSON content-type + ok:true — status-200-only passes the Sign-In interstitial
-    # (200 text/html) which is what any unknown GET returns before the endpoint is deployed.
+        -Method 'GET' -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200, 500)
+    # Parse body explicitly — Invoke-RemoteCheck.Body may arrive as a raw string or as a
+    # PSCustomObject depending on how ConvertFrom-Json behaved for this response. Parse
+    # defensively so the ok/missing checks always operate on a structured object.
+    # (t/2689: smoke false-warned on a valid {ok:true} response — body not parsed as object)
+    $OpedFilesJson = if ($OpedFilesCheck.Body -is [string]) {
+        try { $OpedFilesCheck.Body | ConvertFrom-Json -ErrorAction SilentlyContinue } catch { $null }
+    } else { $OpedFilesCheck.Body }
+    # Require JSON content-type + ok:true — a 200 text/html response is the Sign-In
+    # interstitial (any unknown GET before the endpoint is in PUBLIC_EXACT_PATHS).
     $OpedFilesJsonOk  = $OpedFilesCheck.ContentType -and ($OpedFilesCheck.ContentType -like '*json*')
-    $OpedFilesBodyOk  = $OpedFilesCheck.Body -and
-        $OpedFilesCheck.Body.PSObject.Properties['ok'] -and [bool]$OpedFilesCheck.Body.ok
+    $OpedFilesBodyOk  = $OpedFilesJson -and
+        $OpedFilesJson.PSObject.Properties['ok'] -and [bool]$OpedFilesJson.ok
     $OpedFilesPass = $OpedFilesCheck.Success -and $OpedFilesJsonOk -and $OpedFilesBodyOk
     $OpedFilesDetail = if ($OpedFilesPass) {
-        $count = if ($OpedFilesCheck.Body -and $OpedFilesCheck.Body.PSObject.Properties['assets']) {
-            @($OpedFilesCheck.Body.assets).Count
+        $count = if ($OpedFilesJson -and $OpedFilesJson.PSObject.Properties['assets']) {
+            @($OpedFilesJson.assets).Count
         } else { 0 }
         "all assets present ($count files)"
     } elseif (-not $OpedFilesJsonOk) {
         "non-JSON response (content-type=$($OpedFilesCheck.ContentType), status=$($OpedFilesCheck.StatusCode)) — endpoint unreachable or returned interstitial"
     } elseif (-not $OpedFilesBodyOk) {
-        $missing = if ($OpedFilesCheck.Body -and $OpedFilesCheck.Body.PSObject.Properties['missing']) {
-            ($OpedFilesCheck.Body.missing -join ', ')
+        $missing = if ($OpedFilesJson -and $OpedFilesJson.PSObject.Properties['missing']) {
+            ($OpedFilesJson.missing -join ', ')
         } else { 'ok:false (no missing list)' }
         "MISSING: $missing (status=$($OpedFilesCheck.StatusCode))"
     } else {


### PR DESCRIPTION
## Summary

- Phase 7 (`/api/health/oped-files`) warned on a healthy `{ok:true}` response on first deploy. TL confirmed live cookie-less GET returns `application/json {ok:true}` with all 7 assets — the endpoint was correct; the smoke check was wrong.
- Root cause: `-ExpectJson $true` (explicit value form) behaves differently from bare `-ExpectJson`, producing `Success=$false` even for a valid response. Additionally, `Body` may arrive as a raw string instead of PSCustomObject in some PS7/WebRequest contexts, making `Body.PSObject.Properties['ok']` return `$null`.
- Fix: removed `-ExpectJson` flag; use `AcceptableStatusCodes @(200, 500)` so `Invoke-WebRequest` doesn't throw on the 500-missing arm; parse `Body` via `ConvertFrom-Json` if it's a string; rely on our explicit `$OpedFilesJsonOk` content-type check for the HTML-interstitial guard.
- Searched for other `-ExpectJson $true` occurrences — this was the only one; other callers use bare `-ExpectJson` and are unaffected.

## Test plan

- [x] 9/9 Pester tests pass (`Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1` + `ColdStart.Tests.ps1`) — mocks return PSCustomObject, taking the else branch of the string guard, unaffected
- [ ] CI green
- [ ] Post-merge: re-run `Invoke-TaxEditorSmokeTest -Detailed` against prod — Phase 7 should show `[PASS]` with "all assets present (7 files)"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)