### PR TITLE
test(preload): make .cts unit-testable + back-fill t/2694 buffer test (t/2698)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/preloadBuffer.test.ts
+++ b/taxonomy-editor/src/main/__tests__/preloadBuffer.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * t/2694 / t/2698 — regression coverage for the diagnostics-window "never
+ * displays" race. The main window pushes the cached state once on the popup's
+ * did-finish-load, but useDiagnosticsState subscribes only after React mounts; a
+ * push arriving first was silently dropped, leaving an idle debate stuck on
+ * "Loading debate…". preload.cts fixes it with createLatestValueBuffer (buffer the
+ * latest pre-registration value, flush on subscribe). These tests exercise that
+ * buffer state machine directly — now possible because t/2698 widened vite's
+ * esbuild.include to cover typed `.cts` modules.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createLatestValueBuffer } from '../preloadBuffer.cjs';
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('createLatestValueBuffer (t/2694 diagnostics-window race)', () => {
+  it('delivers a value buffered BEFORE subscribe (the race)', async () => {
+    const b = createLatestValueBuffer<string>();
+    b.onIpc('s1'); // push arrives before the component mounts + subscribes
+    const got: string[] = [];
+    b.onSubscribe(v => got.push(v));
+    await flush(); // buffered value is delivered on a microtask
+    expect(got).toEqual(['s1']);
+  });
+
+  it('keeps only the latest pre-subscribe value (full-state snapshots)', async () => {
+    const b = createLatestValueBuffer<string>();
+    b.onIpc('old');
+    b.onIpc('new');
+    const got: string[] = [];
+    b.onSubscribe(v => got.push(v));
+    await flush();
+    expect(got).toEqual(['new']);
+  });
+
+  it('delivers nothing when no push arrived before subscribe', async () => {
+    const b = createLatestValueBuffer<string>();
+    const got: string[] = [];
+    b.onSubscribe(v => got.push(v));
+    await flush();
+    expect(got).toEqual([]);
+  });
+
+  it('stops buffering once subscribed (live pushes go through the ipc listener, not the buffer)', async () => {
+    const b = createLatestValueBuffer<string>();
+    const got: string[] = [];
+    b.onSubscribe(v => got.push(v));
+    b.onIpc('after'); // arrives after subscribe → not re-delivered by the buffer
+    await flush();
+    expect(got).toEqual([]);
+  });
+
+  it('re-arms after unsubscribe so the next reload cycle is covered', async () => {
+    const b = createLatestValueBuffer<string>();
+    b.onSubscribe(() => {}); // first mount
+    b.onUnsubscribe(); // re-arm the buffer
+    b.onIpc('between'); // push arrives between reloads (nothing subscribed)
+    const got: string[] = [];
+    b.onSubscribe(v => got.push(v)); // second mount must still receive it
+    await flush();
+    expect(got).toEqual(['between']);
+  });
+});

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -3,6 +3,7 @@
 
 import { contextBridge, ipcRenderer } from 'electron';
 import type { OpEdSet, OpEdSetSummary } from '../../../lib/oped/types.js';
+import { createLatestValueBuffer } from './preloadBuffer.cjs';
 
 // Buffer debate-window-load IPC so it isn't lost if React mounts after did-finish-load
 // (happens with bootstrap.ts dynamic import indirection).
@@ -12,17 +13,16 @@ ipcRenderer.on('debate-window-load', (_event, debateId: string) => {
   if (_debateBufferActive) _bufferedDebateId = debateId;
 });
 
-// Buffer the diagnostics-state-update push the same way (t/2694). The main window
-// pushes the cached state once on the diagnostics popup's did-finish-load
-// (main.ts), but useDiagnosticsState registers its listener only after React
-// mounts — so a push arriving first was silently dropped, and for an idle debate
-// (no follow-up pushes) the window stayed on "Loading debate…" forever. Buffer the
-// latest pre-registration state (full-state snapshots, so only the newest matters)
-// and flush it on registration. Also covers the PovProgression window (same channel).
-let _bufferedDiagnosticsState: unknown = null;
-let _diagnosticsBufferActive = true;
+// Buffer the diagnostics-state-update push the same way (t/2694) — see
+// preloadBuffer.cts. The main window pushes the cached state once on the
+// diagnostics popup's did-finish-load, but useDiagnosticsState subscribes only
+// after React mounts; a push arriving first was silently dropped, and for an idle
+// debate (no follow-up pushes) the window stayed on "Loading debate…" forever.
+// Also covers the PovProgression window (same channel). Logic extracted to the
+// pure helper so it's unit-tested (preloadBuffer.test.ts, unblocked by t/2698).
+const _diagnosticsStateBuffer = createLatestValueBuffer<unknown>();
 ipcRenderer.on('diagnostics-state-update', (_event, state: unknown) => {
-  if (_diagnosticsBufferActive) _bufferedDiagnosticsState = state;
+  _diagnosticsStateBuffer.onIpc(state);
 });
 
 contextBridge.exposeInMainWorld('electronAPI', {
@@ -285,20 +285,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   sendDiagnosticsState: (state: unknown): void => ipcRenderer.send('diagnostics-state-update', state),
   onDiagnosticsStateUpdate: (callback: (state: unknown) => void) => {
-    // Stop buffering — the component is now listening directly.
-    _diagnosticsBufferActive = false;
-    // If the push arrived before the component mounted (race with the
-    // did-finish-load push), deliver the buffered state immediately (t/2694).
-    if (_bufferedDiagnosticsState !== null) {
-      const state = _bufferedDiagnosticsState;
-      _bufferedDiagnosticsState = null;
-      queueMicrotask(() => callback(state));
-    }
+    // Flush a push that arrived before the component mounted (t/2694), then the
+    // buffer stops; live pushes come through the listener registered below.
+    _diagnosticsStateBuffer.onSubscribe(callback);
     const listener = (_event: Electron.IpcRendererEvent, state: unknown) => callback(state);
     ipcRenderer.on('diagnostics-state-update', listener);
     return () => {
       ipcRenderer.removeListener('diagnostics-state-update', listener);
-      _diagnosticsBufferActive = true; // re-arm for the next reload cycle
+      _diagnosticsStateBuffer.onUnsubscribe(); // re-arm for the next reload cycle
     };
   },
   requestReExtractClaims: (entryId: string): void => ipcRenderer.send('request-re-extract-claims', entryId),

--- a/taxonomy-editor/src/main/preloadBuffer.cts
+++ b/taxonomy-editor/src/main/preloadBuffer.cts
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * "Latest-value" buffer for a preload IPC bridge (t/2694 / t/2698).
+ *
+ * Popup windows receive a one-shot state push from the main process on
+ * `did-finish-load`, but the React component registers its `ipcRenderer.on`
+ * listener only after it mounts. If the push arrives first it is silently
+ * dropped — and for an idle source (no follow-up pushes) the window never
+ * populates. This buffers the latest pre-registration value and flushes it when
+ * the component subscribes, so delivery no longer depends on IPC-vs-mount timing.
+ *
+ * A `.cts` (CommonJS) module so the sandboxed CommonJS preload can `require` it
+ * under `nodenext`. It is now unit-testable because vite's `esbuild.include` was
+ * widened to cover `.cts` (t/2698) — previously a typed `.cts` threw a parse error
+ * when imported by vitest. Only the newest value is kept: the diagnostics channel
+ * pushes full-state snapshots, so a superseded snapshot has no value.
+ */
+export interface LatestValueBuffer<T> {
+  /** Feed values in from the module-load `ipcRenderer.on` handler. */
+  onIpc(value: T): void;
+  /** Call when a component subscribes: stop buffering, flush any pending value. */
+  onSubscribe(deliver: (value: T) => void): void;
+  /** Call on unsubscribe: re-arm buffering for the next mount / reload cycle. */
+  onUnsubscribe(): void;
+}
+
+export function createLatestValueBuffer<T>(): LatestValueBuffer<T> {
+  let buffered: T | null = null;
+  let active = true;
+
+  return {
+    onIpc(value: T): void {
+      if (active) buffered = value;
+    },
+    onSubscribe(deliver: (value: T) => void): void {
+      // The component is now listening directly — stop buffering.
+      active = false;
+      if (buffered !== null) {
+        const value = buffered;
+        buffered = null;
+        // Deliver asynchronously so subscription setup finishes first, matching
+        // the ordering a live IPC push would have.
+        queueMicrotask(() => deliver(value));
+      }
+    },
+    onUnsubscribe(): void {
+      // Re-arm so a push arriving during the next reload cycle is captured.
+      active = true;
+    },
+  };
+}

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { defineConfig } from 'vite';
+import { defineConfig, transformWithEsbuild } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
 import { execSync } from 'child_process';
@@ -92,6 +92,21 @@ function getGitSha(): string {
 
 export default defineConfig({
   plugins: [
+    // t/2698: vite classifies `.cts` as CommonJS and routes it through a script
+    // transform that rejects TypeScript syntax, so a typed `.cts` (e.g. a preload
+    // helper) throws a parse error when imported by vitest. Run esbuild's TS
+    // transform on `.cts` first so such modules are importable + unit-testable.
+    // Renderer bundle imports no `.cts`, so this only affects test/dev resolution.
+    {
+      name: 'transform-cts-as-ts',
+      enforce: 'pre' as const,
+      async transform(code: string, id: string) {
+        if (id.split('?')[0].endsWith('.cts')) {
+          return transformWithEsbuild(code, id, { loader: 'ts', format: 'esm' });
+        }
+        return null;
+      },
+    },
     rendererNodeBuiltinGate(),
     react(),
     ...(isWeb ? [VitePWA({


### PR DESCRIPTION
Closes t/2698 and back-fills the t/2694 regression test that was previously impossible.

**Root cause:** vite classifies `.cts` as CommonJS and routes it through a script transform that rejects TS syntax, so a typed `.cts` helper throws a parse error under vitest — which is why `preload.cts`'s IPC-buffer race fixes (t/2694 diagnostics + the pre-existing debate-window buffer) shipped untested.

**Fix:** a `enforce:'pre'` plugin in `vite.config.ts` runs esbuild's TS transform on `.cts`. Renderer bundle imports no `.cts`, so this only affects test/dev resolution — **`vite build` verified unchanged**.

Then: extracted the diagnostics buffer to a typed `preloadBuffer.cts` (`createLatestValueBuffer`), wired `preload.cts` to use it (shipped code == tested code), and added `preloadBuffer.test.ts` (5 cases).

**Verify:** build:main tsc 0, renderer tsc 0, `vite build` OK, 7/7 tests, eslint clean.

Note: `transformWithEsbuild` is deprecated (→ `transformWithOxc`); kept esbuild (typed drop-in) — Oxc migration is a future follow-up.