### PR TITLE
feat(smoke): promote Phase 7 oped-files health to blocking (t/2689 AC3)

### DIFF
--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -367,10 +367,9 @@ function Invoke-TaxEditorSmokeTest {
         Write-Host ''
     }
 
-    # ── Phase 7: Oped-files runtime asset health (t/2689 AC3) — warn-only ─────
+    # ── Phase 7: Oped-files runtime asset health (t/2689 AC3) ──────────────────
     # Asserts soul-docs + lib/oped/prompts are present in the container image.
-    # Warn-only: NOT gating OverallPass until TL Gate Verification (both arms +
-    # ≥1 real-env cycle) is complete. See t/2689 AC3.
+    # Both-arms gate verified (#1124) + clean real-env cycle (#1122) — now blocking.
     Write-Host '=== Oped Files Health ===' -ForegroundColor Cyan
     # Accept both 200 (ok) and 500 (missing files) so Invoke-WebRequest doesn't throw on the
     # failure arm; we discriminate via ok:true/false in the body, not the HTTP status.
@@ -404,17 +403,28 @@ function Invoke-TaxEditorSmokeTest {
     } else {
         "failed (status=$($OpedFilesCheck.StatusCode))"
     }
-    $OFIcon  = if ($OpedFilesPass) { '[PASS]' } else { '[WARN]' }
-    $OFColor = if ($OpedFilesPass) { 'Green' } else { 'Yellow' }
+    $OFIcon  = if ($OpedFilesPass) { '[PASS]' } else { '[FAIL]' }
+    $OFColor = if ($OpedFilesPass) { 'Green' } else { 'Red' }
     Write-Host "  $OFIcon GET /api/health/oped-files — $($OpedFilesCheck.StatusCode) $($OpedFilesCheck.ResponseMs)ms — $OpedFilesDetail" -ForegroundColor $OFColor
     if (-not $OpedFilesPass) {
-        Write-Host "  (warn-only: not gating OverallPass — see t/2689 AC3)" -ForegroundColor DarkYellow
-        Write-Host "::warning::Oped-files health check failed: $OpedFilesDetail"
+        Write-Host "::error::Oped-files health check failed: $OpedFilesDetail"
     }
     Write-Host ''
 
+    $OpedFilesResult = [EndpointTestResult]::new()
+    $OpedFilesResult.Endpoint    = 'GET /api/health/oped-files'
+    $OpedFilesResult.Category    = 'OpedFiles'
+    $OpedFilesResult.Description = 'Soul-docs + oped prompts present in container image'
+    $OpedFilesResult.Status      = $OpedFilesCheck.StatusCode
+    $OpedFilesResult.Pass        = $OpedFilesPass
+    $OpedFilesResult.Ms          = $OpedFilesCheck.ResponseMs
+    $OpedFilesResult.NodeCount   = $null
+    if (-not $OpedFilesPass) {
+        $OpedFilesResult.Error = $OpedFilesDetail
+    }
+
     # ── Summary ──────────────────────────────────────────────────────────
-    $AllResults = @($Endpoints) + @($AnonEndpoints) + @($Analytics) + @($DataPresence)
+    $AllResults = @($Endpoints) + @($AnonEndpoints) + @($Analytics) + @($DataPresence) + @($OpedFilesResult)
     $Passed = @($AllResults | Where-Object { $_.Pass }).Count
     $Failed = @($AllResults | Where-Object { -not $_.Pass }).Count
     $Total = $AllResults.Count

--- a/tests/Invoke-TaxEditorSmokeTest.GitHubGate.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.GitHubGate.Tests.ps1
@@ -95,6 +95,13 @@ Describe 'Invoke-TaxEditorSmokeTest GitHub-flap gate exclusion (t/2673)' -Tag 'h
                     ContentType = 'application/json'; RawBody = ''; Error = $null
                 }
             }
+            Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/health/oped-files' } -MockWith {
+                [PSCustomObject]@{
+                    Success = $true; StatusCode = 200; ResponseMs = 10
+                    Body = [PSCustomObject]@{ ok = $true; assets = @('a','b','c') }
+                    ContentType = 'application/json'; RawBody = ''; Error = $null
+                }
+            }
             Mock Test-AzureHealth  -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
             Mock Test-GitHubHealth -MockWith {
                 [PSCustomObject]@{


### PR DESCRIPTION
## Summary

- Promotes `GET /api/health/oped-files` Phase 7 from warn-only to blocking in `Invoke-TaxEditorSmokeTest.ps1`
- `[WARN]`/Yellow/warn-only note → `[FAIL]`/Red/`::error::` annotation
- Adds `$OpedFilesResult` (`EndpointTestResult`) to `$AllResults` so failures gate `$OverallPass`

## Prerequisites (both satisfied)

- ✅ #1122 — smoke bug fixed + clean real-env PASS cycle confirmed (`[PASS] all assets present (7 files)`)
- ✅ #1124 — both-arms unit test (`opedFilesHealth.test.ts`: 200-all-present / 500-missing-soul-doc / 500-empty-prompts, 3/3 green), merged 2026-08-16T14:38:33Z

## Test plan

- [x] `Invoke-Pester` — 9/9 passing (Analytics + ColdStart suites)
- [x] No tests assert `EndpointsTotal`; total increases 28→29 harmlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)