### PR TITLE
feat(infra): staging Easy Auth — add authConfigStaging Bicep resource (t/2695 Part 1)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -853,6 +853,75 @@ resource authConfig 'Microsoft.App/containerApps/authConfigs@2024-10-02-preview'
   }
 }
 
+// ── Authentication — Staging (Easy Auth for containerAppStaging) ──
+// Mirrors the prod authConfig above. Identical identity-provider wiring so
+// staging is a faithful pre-prod OAuth proxy.
+//
+// Part 2 (human gate, t/2695): Before deploying this resource, register the
+// staging callback URIs with each provider:
+//   Google:  https://<staging-fqdn>/.auth/login/google/callback
+//   GitHub:  https://<staging-fqdn>/.auth/login/github/callback
+//   AAD:     https://<staging-fqdn>/.auth/login/aad/callback
+// The FQDN can be read from containerAppStaging.properties.configuration.ingress.fqdn
+// after a deploy or via: az containerapp show -n taxonomy-editor-staging -g ai-triad --query properties.configuration.ingress.fqdn
+//
+// The authConfig can land and CI-green independently of Part 2; the deploy step
+// waits for the URIs to be registered (unauthenticated staging remains accessible
+// since unauthenticatedClientAction='AllowAnonymous').
+
+resource authConfigStaging 'Microsoft.App/containerApps/authConfigs@2024-10-02-preview' = {
+  parent: containerAppStaging
+  name: 'current'
+  properties: {
+    platform: {
+      enabled: true
+    }
+    globalValidation: {
+      unauthenticatedClientAction: 'AllowAnonymous'
+    }
+    identityProviders: {
+      google: {
+        enabled: googleEnabled
+        registration: {
+          clientId: googleClientId
+          clientSecretSettingName: googleClientSecretName
+        }
+        validation: {
+          allowedAudiences: []
+        }
+      }
+      gitHub: {
+        enabled: githubEnabled
+        registration: {
+          clientId: githubClientId
+          clientSecretSettingName: githubClientSecretName
+        }
+      }
+      azureActiveDirectory: {
+        enabled: aadEnabled
+        registration: {
+          clientId: aadClientId
+          clientSecretSettingName: aadClientSecretName
+          #disable-next-line no-hardcoded-env-urls
+          openIdIssuer: 'https://login.microsoftonline.com/${aadIssuer}/v2.0'
+        }
+      }
+    }
+    login: {
+      routes: {
+        logoutEndpoint: '/.auth/logout'
+      }
+      allowedExternalRedirectUrls: [
+        'https://${containerAppStaging.properties.configuration.ingress.fqdn}'
+      ]
+      preserveUrlFragmentsForLogins: false
+      tokenStore: {
+        enabled: true
+      }
+    }
+  }
+}
+
 // ── Budget Alert ──
 // Alerts at 80% and 100% of $5/month to catch cost overruns early.
 


### PR DESCRIPTION
## Summary

Adds `authConfigStaging` — the Easy Auth `authConfigs` resource for `containerAppStaging` — mirroring the prod `authConfig` already in Bicep. Without this resource, staging has no OAuth providers registered (idp:''), leaving it permanently anonymous.

**Root cause (t/2695):** Prod Easy Auth was configured manually via `az containerapp auth` CLI and captured in Bicep later. Staging was never caught up — `authConfigs` for `containerAppStaging` was never added to IaC.

## What this adds

- `authConfigStaging` resource (`Microsoft.App/containerApps/authConfigs@2024-10-02-preview`)
- Parent: `containerAppStaging` (same API version, same name `'current'`)
- Identical identity providers: Google, GitHub, AAD — all parameterised via the same `googleEnabled`/`githubEnabled`/`aadEnabled` conditionals and secret-setting-name vars as prod
- `allowedExternalRedirectUrls`: staging FQDN (`containerAppStaging.properties.configuration.ingress.fqdn`)
- `AllowAnonymous` — staging stays accessible while Part 2 URI registration is pending

## Part 2 gate (human / Jeffrey)

**Do not deploy** until the staging callback URIs are registered with each OAuth provider:
```
Google:  https://<staging-fqdn>/.auth/login/google/callback
GitHub:  https://<staging-fqdn>/.auth/login/github/callback
AAD:     https://<staging-fqdn>/.auth/login/aad/callback
```
Get the FQDN: `az containerapp show -n taxonomy-editor-staging -g ai-triad --query properties.configuration.ingress.fqdn`

This PR can land and CI-green independently of Part 2. The deploy waits.

## Review request

Auth-surface change — routing to Main (TL) per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)