### PR TITLE
feat(cmdlet): Test-AnalyticsBlobHealth — analytics blob container diagnostics (t/2702)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -114,6 +114,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-FreeTierStatus` | Live free-tier budget/usage report (live config + token consumption) |
 | `Test-AnalyticsBackend` | Analytics storage round-trip probe — POST synthetic event, wait, GET query, verify event appears; confirms write failures in <60s (t/2668) |
 | `Test-AzureHealth` | Azure infra status |
+| `Test-AnalyticsBlobHealth` | Verify the analytics blob container exists, is accessible, and has recent data (daily NDJSON blobs, event counts, stale-write threshold) |
 | `Test-GitHubHealth` | GitHub platform + CI status |
 | `Test-AIApiKey` | Probe AI backend auth endpoints (no tokens consumed) — confirm a key is present and accepted before running jobs |
 | `Test-AIBackendHealth` | Full completion round-trip probe per backend — use before a debate run to surface degraded/unreachable models (t/2212) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -134,6 +134,7 @@
         'Get-FreeTierStatus'
         'Invoke-TaxEditorSmokeTest'
         'Test-AnalyticsBackend'
+        'Test-AnalyticsBlobHealth'
         'Test-AzureHealth'
         'Test-GitHubHealth'
         'Get-TaxEditorRevision'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -852,6 +852,8 @@ Export-ModuleMember -Function @(
     'Invoke-TaxEditorSmokeTest'
     # t/2668 — analytics storage round-trip diagnosis
     'Test-AnalyticsBackend'
+    # t/2702 — analytics blob container health (exists/accessible/recent data)
+    'Test-AnalyticsBlobHealth'
     'Test-AzureHealth'
     'Test-GitHubHealth'
     'Get-TaxEditorRevision'

--- a/scripts/AITriad/Public/Test-AnalyticsBlobHealth.ps1
+++ b/scripts/AITriad/Public/Test-AnalyticsBlobHealth.ps1
@@ -1,0 +1,241 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-AnalyticsBlobHealth {
+    <#
+    .SYNOPSIS
+        Verify the analytics blob container exists, is accessible, and has recent data.
+    .DESCRIPTION
+        Remote diagnostics for the community analytics pipeline. Analytics events are
+        written by the taxonomy-editor server as daily NDJSON append blobs named
+        `YYYY-MM-DD.ndjson` in the `analytics` container (analyticsBlob.ts). This
+        cmdlet confirms the container is reachable, lists the recent daily blobs,
+        counts the events they hold (one NDJSON line per event), and flags a stale
+        pipeline when the most recent write is older than a configurable threshold.
+
+        Would have confirmed the t/2699 root cause in seconds rather than requiring
+        server log triage. Pairs with Test-TaxEditorHealth. Requires the az CLI
+        logged in with data-plane access to the storage account (--auth-mode login).
+
+        No AI calls are made — this is a purely offline diagnostic against Azure.
+    .PARAMETER StorageAccount
+        Storage account name. Default: auto-detected from the resource group
+        (first account matching `staitriad*`).
+    .PARAMETER Container
+        Analytics container name. Default: 'analytics'.
+    .PARAMETER ResourceGroup
+        Azure resource group name. Default: 'ai-triad'.
+    .PARAMETER Days
+        Look-back window (days) for listing recent daily blobs. Default: 7.
+    .PARAMETER StaleThresholdHours
+        Flag the pipeline stale (and unhealthy) when the most recent write is older
+        than this many hours. Default: 24.
+    .OUTPUTS
+        [PSCustomObject] with Healthy, ContainerExists, Accessible, RecentBlobs,
+        TotalRecentEvents, LastWrite, HoursSinceLastWrite, Stale, and Checks.
+    .EXAMPLE
+        Test-AnalyticsBlobHealth
+    .EXAMPLE
+        Test-AnalyticsBlobHealth -Days 14 -StaleThresholdHours 6
+    .EXAMPLE
+        $h = Test-AnalyticsBlobHealth; $h.RecentBlobs | Format-Table Date, EventCount, LastModified
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Test-TaxEditorHealth
+    .LINK
+        Test-AzureHealth
+    .LINK
+        Get-TaxEditorBlob
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [string]$StorageAccount,
+
+        [Parameter()]
+        [string]$Container = 'analytics',
+
+        [Parameter()]
+        [string]$ResourceGroup = 'ai-triad',
+
+        [Parameter()]
+        [ValidateRange(1, 365)]
+        [int]$Days = 7,
+
+        [Parameter()]
+        [ValidateRange(1, 8760)]
+        [int]$StaleThresholdHours = 24
+    )
+
+    Set-StrictMode -Version Latest
+    $CallerName = 'Test-AnalyticsBlobHealth'
+
+    # ── Validate az CLI ──────────────────────────────────────────────────
+    $AzCmd = Get-Command az -ErrorAction SilentlyContinue
+    if (-not $AzCmd) {
+        throw (New-ActionableError `
+            -Goal 'Check analytics blob health' `
+            -Problem 'Azure CLI (az) not found on PATH' `
+            -Location $CallerName `
+            -NextSteps @('Install Azure CLI: https://aka.ms/installazurecli'))
+    }
+
+    $AccountJson = & az account show --output json 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $AccountJson) {
+        throw (New-ActionableError `
+            -Goal 'Check analytics blob health' `
+            -Problem 'Azure CLI is not logged in' `
+            -Location $CallerName `
+            -NextSteps @('Run: az login', 'Verify subscription: az account show'))
+    }
+
+    # ── Resolve storage account ──────────────────────────────────────────
+    if (-not $StorageAccount) {
+        $AccountListJson = & az storage account list -g $ResourceGroup --query "[?starts_with(name,'staitriad')].name" -o json 2>$null
+        # Explicit array assign — `$x = if(){@()}` unwraps to a scalar under StrictMode.
+        $Accounts = @()
+        if ($LASTEXITCODE -eq 0 -and $AccountListJson) { $Accounts = @($AccountListJson | ConvertFrom-Json) }
+        if ($Accounts.Count -eq 0) {
+            throw (New-ActionableError `
+                -Goal 'Resolve storage account' `
+                -Problem "No 'staitriad*' storage accounts found in resource group '$ResourceGroup'" `
+                -Location $CallerName `
+                -NextSteps @('Pass -StorageAccount explicitly',
+                             "Check resource group: az storage account list -g $ResourceGroup"))
+        }
+        $StorageAccount = $Accounts[0]
+    }
+
+    $Checks = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $AddCheck = {
+        param($Name, $Pass, $Detail)
+        $Checks.Add([PSCustomObject]@{ Name = $Name; Pass = [bool]$Pass; Detail = $Detail })
+    }
+
+    # ── Check 1: Container exists / accessible ───────────────────────────
+    $ContainerExists = $false
+    $Accessible      = $false
+    $ExistsJson = & az storage container exists --account-name $StorageAccount --name $Container --auth-mode login -o json 2>$null
+    if ($LASTEXITCODE -eq 0 -and $ExistsJson) {
+        $Accessible = $true
+        try {
+            $Parsed = $ExistsJson | ConvertFrom-Json
+            if ($Parsed.PSObject.Properties['exists']) { $ContainerExists = [bool]$Parsed.exists }
+        } catch {
+            $Accessible = $false
+        }
+    }
+    & $AddCheck 'Container accessible' $Accessible $(if ($Accessible) { "Queried '$Container' on '$StorageAccount'" } else { "Could not query container '$Container' (auth/network/RBAC?)" })
+    & $AddCheck 'Container exists' $ContainerExists $(if ($ContainerExists) { "'$Container' present" } else { "'$Container' not found on '$StorageAccount'" })
+
+    # ── Check 2: List recent daily blobs + count events ──────────────────
+    $CutoffDate = (Get-Date).ToUniversalTime().AddDays(-$Days).ToString('yyyy-MM-dd')
+    $RecentBlobs = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $TotalEvents = 0
+
+    if ($ContainerExists -and $Accessible) {
+        $BlobJson = & az storage blob list --account-name $StorageAccount --container-name $Container --auth-mode login -o json 2>$null
+        # Explicit array assign — `$x = if(){@()}` unwraps to a scalar under StrictMode.
+        $Blobs = @()
+        if ($LASTEXITCODE -eq 0 -and $BlobJson) { $Blobs = @($BlobJson | ConvertFrom-Json) }
+
+        foreach ($Blob in $Blobs) {
+            if (-not $Blob.PSObject.Properties['name']) { continue }
+            # Daily analytics blobs are named YYYY-MM-DD.ndjson (analyticsBlob.ts).
+            $M = [regex]::Match([string]$Blob.name, '^(\d{4}-\d{2}-\d{2})\.ndjson$')
+            if (-not $M.Success) { continue }
+            $BlobDate = $M.Groups[1].Value
+            if ($BlobDate -lt $CutoffDate) { continue }
+
+            $Size = 0
+            $LastModified = ''
+            if ($Blob.PSObject.Properties['properties']) {
+                if ($Blob.properties.PSObject.Properties['contentLength']) { $Size = [long]$Blob.properties.contentLength }
+                if ($Blob.properties.PSObject.Properties['lastModified']) {
+                    $Raw = $Blob.properties.lastModified
+                    $LastModified = if ($Raw -is [datetime]) { $Raw.ToUniversalTime().ToString('o') } else { [string]$Raw }
+                }
+            }
+
+            # Event count = non-blank NDJSON lines. Download to a temp file and count;
+            # $null when the download fails so we never report a false zero.
+            $EventCount = $null
+            $Tmp = [System.IO.Path]::GetTempFileName()
+            try {
+                & az storage blob download --account-name $StorageAccount --container-name $Container `
+                    --name $Blob.name --file $Tmp --auth-mode login --no-progress --output none 2>$null
+                if ($LASTEXITCODE -eq 0 -and (Test-Path $Tmp)) {
+                    $EventCount = @(Get-Content -Path $Tmp | Where-Object { $_.Trim().Length -gt 0 }).Count
+                    $TotalEvents += $EventCount
+                }
+            }
+            finally {
+                if (Test-Path $Tmp) { Remove-Item -Path $Tmp -Force -ErrorAction SilentlyContinue }
+            }
+
+            $RecentBlobs.Add([PSCustomObject]@{
+                Date         = $BlobDate
+                Name         = [string]$Blob.name
+                SizeBytes    = $Size
+                EventCount   = $EventCount
+                LastModified = $LastModified
+            })
+        }
+    }
+
+    $SortedBlobs = @($RecentBlobs | Sort-Object Date)
+    & $AddCheck 'Recent blobs present' ($SortedBlobs.Count -gt 0) "$($SortedBlobs.Count) daily blob(s) in the last $Days day(s), $TotalEvents event(s) total"
+
+    # ── Check 3: Freshness (last write vs threshold) ─────────────────────
+    $LastWrite = $null
+    $HoursSince = $null
+    $Stale = $true
+    $WithMod = @($SortedBlobs | Where-Object { $_.LastModified })
+    if ($WithMod.Count -gt 0) {
+        $Latest = ($WithMod | Sort-Object LastModified)[-1]
+        $LastWrite = $Latest.LastModified
+        try {
+            $LastDt = [datetimeoffset]::Parse($LastWrite).UtcDateTime
+            $HoursSince = [math]::Round(((Get-Date).ToUniversalTime() - $LastDt).TotalHours, 2)
+            $Stale = $HoursSince -gt $StaleThresholdHours
+        } catch {
+            $HoursSince = $null
+            $Stale = $true
+        }
+    }
+    $FreshDetail = if ($null -eq $HoursSince) {
+        'No dated blob with a lastModified timestamp in the window'
+    } else {
+        "Last write ${HoursSince}h ago (threshold ${StaleThresholdHours}h)"
+    }
+    & $AddCheck 'Pipeline fresh' (-not $Stale) $FreshDetail
+
+    # ── Overall verdict + report ─────────────────────────────────────────
+    $Healthy = $ContainerExists -and $Accessible -and (-not $Stale)
+
+    Write-Host "`nAnalytics Blob Health — $StorageAccount/$Container" -ForegroundColor Cyan
+    foreach ($C in $Checks) {
+        $Icon  = if ($C.Pass) { '[PASS]' } else { '[FAIL]' }
+        $Color = if ($C.Pass) { 'Green' } else { 'Red' }
+        Write-Host "  $Icon $($C.Name) — $($C.Detail)" -ForegroundColor $Color
+    }
+    Write-Host ''
+
+    [PSCustomObject]@{
+        StorageAccount      = $StorageAccount
+        Container           = $Container
+        ContainerExists     = $ContainerExists
+        Accessible          = $Accessible
+        RecentBlobs         = $SortedBlobs
+        TotalRecentEvents   = $TotalEvents
+        LastWrite           = $LastWrite
+        HoursSinceLastWrite = $HoursSince
+        StaleThresholdHours = $StaleThresholdHours
+        Stale               = $Stale
+        Healthy             = $Healthy
+        Checks              = @($Checks)
+        Timestamp           = (Get-Date).ToUniversalTime().ToString('o')
+    }
+}

--- a/tests/Test-AnalyticsBlobHealth.Tests.ps1
+++ b/tests/Test-AnalyticsBlobHealth.Tests.ps1
@@ -1,0 +1,144 @@
+# Tag: health (t/2702)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Test-AnalyticsBlobHealth (t/2702) — analytics blob container diagnostics.
+.DESCRIPTION
+    Mocks the az CLI (mirroring TaxEditorBlob.Tests.ps1). The blob-download branch
+    writes NDJSON to the --file path so event counting (one line per event) is
+    exercised end-to-end. Covers: az missing / not-logged-in guards, a healthy
+    round-trip (container present + fresh write + event count), a stale pipeline,
+    and a missing container.
+
+    Dynamic dates/timestamps are passed to the module-scoped mock via $global:
+    variables (a Pester -MockWith body does not close over It-scope locals and
+    does not honor $using:).
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-AnalyticsBlobHealth' -Tag 'health' {
+
+    AfterEach {
+        Remove-Variable -Name AbhDate, AbhMod -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It 'Throws when az CLI is not found' {
+        Mock Get-Command { $null } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        { Test-AnalyticsBlobHealth 2>$null } | Should -Throw
+    }
+
+    It 'Throws when az CLI is not logged in' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith { $global:LASTEXITCODE = 1; return $null } -ModuleName AITriad
+        { Test-AnalyticsBlobHealth 2>$null } | Should -Throw
+    }
+
+    It 'Healthy: container present, fresh write, event count from NDJSON lines' {
+        $global:AbhDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+        $global:AbhMod  = (Get-Date).ToUniversalTime().AddHours(-1).ToString('o')
+
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'account' -and $args -contains 'list') { return '["staitriadtest"]' }
+            if ($args -contains 'container' -and $args -contains 'exists') { return '{"exists": true}' }
+            if ($args -contains 'blob' -and $args -contains 'list') {
+                return "[{`"name`":`"$($global:AbhDate).ndjson`",`"properties`":{`"contentLength`":128,`"lastModified`":`"$($global:AbhMod)`"}}]"
+            }
+            if ($args -contains 'blob' -and $args -contains 'download') {
+                $fi = [array]::IndexOf($args, '--file')
+                if ($fi -ge 0) { Set-Content -Path $args[$fi + 1] -Value @('{"event":1}', '{"event":2}', '{"event":3}') }
+                return $null
+            }
+            return '{"id":"sub-123"}'
+        } -ModuleName AITriad
+
+        $h = Test-AnalyticsBlobHealth -StorageAccount 'staitriadtest' 6>$null
+
+        $h.ContainerExists   | Should -BeTrue
+        $h.Accessible        | Should -BeTrue
+        $h.Stale             | Should -BeFalse
+        $h.Healthy           | Should -BeTrue
+        @($h.RecentBlobs).Count | Should -Be 1
+        $h.RecentBlobs[0].EventCount | Should -Be 3 -Because 'the downloaded blob has 3 NDJSON lines'
+        $h.TotalRecentEvents | Should -Be 3
+    }
+
+    It 'Stale: recent blob but last write older than threshold → unhealthy' {
+        $global:AbhDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+        $global:AbhMod  = (Get-Date).ToUniversalTime().AddHours(-48).ToString('o')
+
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'container' -and $args -contains 'exists') { return '{"exists": true}' }
+            if ($args -contains 'blob' -and $args -contains 'list') {
+                return "[{`"name`":`"$($global:AbhDate).ndjson`",`"properties`":{`"contentLength`":64,`"lastModified`":`"$($global:AbhMod)`"}}]"
+            }
+            if ($args -contains 'blob' -and $args -contains 'download') {
+                $fi = [array]::IndexOf($args, '--file')
+                if ($fi -ge 0) { Set-Content -Path $args[$fi + 1] -Value @('{"event":1}') }
+                return $null
+            }
+            return '{"id":"sub-123"}'
+        } -ModuleName AITriad
+
+        $h = Test-AnalyticsBlobHealth -StorageAccount 'staitriadtest' -StaleThresholdHours 24 6>$null
+
+        $h.Stale   | Should -BeTrue
+        $h.Healthy | Should -BeFalse
+        $h.HoursSinceLastWrite | Should -BeGreaterThan 24
+        ($h.Checks | Where-Object { $_.Name -eq 'Pipeline fresh' }).Pass | Should -BeFalse
+    }
+
+    It 'Missing container → ContainerExists false, unhealthy' {
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'container' -and $args -contains 'exists') { return '{"exists": false}' }
+            return '{"id":"sub-123"}'
+        } -ModuleName AITriad
+
+        $h = Test-AnalyticsBlobHealth -StorageAccount 'staitriadtest' 6>$null
+
+        $h.ContainerExists | Should -BeFalse
+        $h.Healthy         | Should -BeFalse
+        @($h.RecentBlobs).Count | Should -Be 0 -Because 'no blob listing runs when the container is absent'
+    }
+
+    It 'Auto-detects storage account from resource group' {
+        $global:AbhDate = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+        $global:AbhMod  = (Get-Date).ToUniversalTime().AddHours(-1).ToString('o')
+
+        Mock Get-Command { @{ Name = 'az' } } -ParameterFilter { $Name -eq 'az' } -ModuleName AITriad
+        Mock -CommandName 'az' -MockWith {
+            param()
+            $global:LASTEXITCODE = 0
+            if ($args -contains 'account' -and $args -contains 'list' -and $args -contains '-g') { return '["staitriadauto"]' }
+            if ($args -contains 'container' -and $args -contains 'exists') { return '{"exists": true}' }
+            if ($args -contains 'blob' -and $args -contains 'list') {
+                return "[{`"name`":`"$($global:AbhDate).ndjson`",`"properties`":{`"contentLength`":32,`"lastModified`":`"$($global:AbhMod)`"}}]"
+            }
+            if ($args -contains 'blob' -and $args -contains 'download') {
+                $fi = [array]::IndexOf($args, '--file')
+                if ($fi -ge 0) { Set-Content -Path $args[$fi + 1] -Value @('{"event":1}') }
+                return $null
+            }
+            return '{"id":"sub-123"}'
+        } -ModuleName AITriad
+
+        $h = Test-AnalyticsBlobHealth 6>$null
+        $h.StorageAccount | Should -Be 'staitriadauto'
+    }
+}


### PR DESCRIPTION
## What
New public cmdlet `Test-AnalyticsBlobHealth` (t/2702) for remote analytics diagnostics:
1. Confirms the `analytics` blob container is reachable (`az storage container exists`, `--auth-mode login`)
2. Lists recent daily NDJSON blobs (`YYYY-MM-DD.ndjson`, configurable `-Days`, default 7)
3. Reports per-blob event counts (one NDJSON line = one event) and a total
4. Flags a stale pipeline when the last write is older than `-StaleThresholdHours` (default 24)

Returns a structured object: `Healthy / ContainerExists / Accessible / RecentBlobs / TotalRecentEvents / LastWrite / HoursSinceLastWrite / Stale / Checks`.

## Why
Would have confirmed the t/2699 root cause in seconds instead of server-log triage. Pairs with `Test-TaxEditorHealth`.

## Design
Mirrors the az-CLI access + storage-account auto-detect pattern of `Get-TaxEditorBlob`, and the check-list health shape of `Test-AzureHealth`. Blob layout (`analytics` container, daily append blobs) matches `analyticsBlob.ts`.

## Playbook
Followed `/add-ps-cmdlet` — **no deviations**. Registered in both `AITriad.psd1` FunctionsToExport and `AITriad.psm1` Export-ModuleMember; `New-ActionableError` for unrecoverable errors; StrictMode-safe; added to `docs/cmdlet-reference.md`.

## Tests
`tests/Test-AnalyticsBlobHealth.Tests.ps1` (az mocked; download branch writes NDJSON to the `--file` path): az-missing / not-logged-in guards, healthy round-trip with event count, stale pipeline, missing container, account auto-detect. 6/6 green. Export-sync + module tests green.

Closes t/2702. 🤖 Generated with [Claude Code](https://claude.com/claude-code)