### PR TITLE
fix(analytics): adapt server EngagementTree → TreeNode at fetch boundary (t/2709)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.test.tsx
@@ -37,41 +37,40 @@ import { useFlag } from '../../hooks/useFeatureFlags';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-const LEAF_NODE = (id: string) => ({
-  id, visits: 10, engagedVisits: 8, engagedMs: 30_000, cappedRate: 0.05,
-});
+const LEAF_NODE = () => ({ visits: 10, engagedVisits: 8, engagedMs: 30_000, cappedRate: 0.05 });
 
+// Server wire EngagementTree ({tool,camps,tabs}) — the dashboard adapts this into the
+// hierarchical TreeNode at the fetch boundary (engagementTreeToTreeNode, t/2709). The
+// prior fixture was already-adapted TreeNode, which never exercised the wire→TreeNode
+// conversion and so was blind to the mismatch that shipped an empty dashboard. Metrics
+// mirror the old fixture, so the rendered camps/categories/leaderboards are unchanged.
 const FIXTURE_TREE = {
-  id: 'root', visits: 100, engagedVisits: 80, engagedMs: 240_000, cappedRate: 0.05, uniqueUsers: 5,
-  children: {
-    taxonomy: {
-      id: 'taxonomy', visits: 100, engagedVisits: 80, engagedMs: 240_000,
-      children: {
-        acc: {
-          id: 'acc', visits: 40, engagedVisits: 32, engagedMs: 90_000,
-          children: {
-            'acc-bel': {
-              id: 'acc-bel', visits: 20, engagedVisits: 16, engagedMs: 50_000,
-              children: { 'acc-bel-001': LEAF_NODE('acc-bel-001'), 'acc-bel-002': LEAF_NODE('acc-bel-002') },
-            },
-            'acc-des': {
-              id: 'acc-des', visits: 20, engagedVisits: 16, engagedMs: 40_000,
-              children: { 'acc-des-001': LEAF_NODE('acc-des-001') },
-            },
-          },
+  tool: { visits: 100, engagedVisits: 80, engagedMs: 240_000, cappedRate: 0.05, uniqueUsers: 5 },
+  camps: {
+    acc: {
+      visits: 40, engagedVisits: 32, engagedMs: 90_000, cappedRate: 0.05,
+      categories: {
+        'acc-bel': {
+          visits: 20, engagedVisits: 16, engagedMs: 50_000, cappedRate: 0.05,
+          nodes: { 'acc-bel-001': LEAF_NODE(), 'acc-bel-002': LEAF_NODE() },
         },
-        saf: {
-          id: 'saf', visits: 60, engagedVisits: 48, engagedMs: 150_000,
-          children: {
-            'saf-bel': {
-              id: 'saf-bel', visits: 60, engagedVisits: 48, engagedMs: 150_000,
-              children: { 'saf-bel-001': LEAF_NODE('saf-bel-001') },
-            },
-          },
+        'acc-des': {
+          visits: 20, engagedVisits: 16, engagedMs: 40_000, cappedRate: 0.05,
+          nodes: { 'acc-des-001': LEAF_NODE() },
+        },
+      },
+    },
+    saf: {
+      visits: 60, engagedVisits: 48, engagedMs: 150_000, cappedRate: 0.05,
+      categories: {
+        'saf-bel': {
+          visits: 60, engagedVisits: 48, engagedMs: 150_000, cappedRate: 0.05,
+          nodes: { 'saf-bel-001': LEAF_NODE() },
         },
       },
     },
   },
+  tabs: {},
 };
 
 const FIXTURE_USERS = [
@@ -91,7 +90,7 @@ const FIXTURE_RESULT = {
 };
 
 const EMPTY_RESULT = {
-  aggregate: { id: 'root', visits: 0, engagedVisits: 0, engagedMs: 0 },
+  aggregate: { tool: { visits: 0, engagedVisits: 0, engagedMs: 0, cappedRate: 0 }, camps: {}, tabs: {} },
   subtree: null,
   daily: [],
   users: [],

--- a/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/EngagementDashboard.tsx
@@ -17,6 +17,8 @@ import { useChartTooltip, ChartTooltipLayer } from './chartTooltip';
 import { UsageHierarchy } from './UsageHierarchy';
 import {
   type TreeNode,
+  type WireEngagementTree,
+  engagementTreeToTreeNode,
   CAMP_COLORS, CAMP_LABELS,
   fmtDuration, fmtNumber, relativeTime, categoryLabel,
   sumByCamp, sumByCategoryForCamp, collectLeafNodes,
@@ -33,6 +35,23 @@ interface EngagementResult {
   user?: TreeNode;    // per-user subtree when ?user= given (t/2467#2)
   daily: DailyPoint[];
   users?: UserRow[];  // admin-only; stripped server-side for non-admins
+}
+
+// Server wire shape: aggregate/user are EngagementTree ({tool,camps,tabs}), converted
+// to TreeNode by engagementTreeToTreeNode at the fetch boundary (t/2709).
+type WireEngagementResult = Omit<EngagementResult, 'aggregate' | 'user'> & {
+  aggregate: WireEngagementTree;
+  user?: WireEngagementTree;
+};
+
+/** Adapt the server wire result to the TreeNode-based contract the panels consume (t/2709). */
+function adaptEngagement(raw: WireEngagementResult): EngagementResult {
+  const { aggregate, user, ...rest } = raw;
+  return {
+    ...rest,
+    aggregate: engagementTreeToTreeNode(aggregate),
+    ...(user ? { user: engagementTreeToTreeNode(user) } : {}),
+  };
 }
 
 type DatePreset = '7d' | '30d' | '90d';
@@ -341,8 +360,8 @@ export function EngagementDashboard() {
     const qs = committedFilter
       ? `/api/analytics/engagement?from=${from}&to=${to}&user=${encodeURIComponent(committedFilter)}`
       : `/api/analytics/engagement?from=${from}&to=${to}`;
-    bridgeGet<EngagementResult>(qs)
-      .then(d => { setData(d); setLoading(false); })
+    bridgeGet<WireEngagementResult>(qs)
+      .then(raw => { setData(adaptEngagement(raw)); setLoading(false); })
       .catch(err => {
         getGlobalRecorder()?.record({
           type: 'system.error',

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.test.tsx
@@ -26,41 +26,38 @@ import { useUserProfile } from '../../hooks/useAuthStatus';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-const LEAF_NODE = (id: string) => ({
-  id, visits: 10, engagedVisits: 8, engagedMs: 30_000,
-});
+const LEAF_NODE = () => ({ visits: 10, engagedVisits: 8, engagedMs: 30_000, cappedRate: 0 });
 
+// Server wire EngagementTree ({tool,camps,tabs}) — the panel adapts `.user` into the
+// hierarchical TreeNode at the fetch boundary (engagementTreeToTreeNode, t/2709). The
+// prior fixture was already-adapted TreeNode and never exercised that conversion.
 const FIXTURE_TREE = {
-  id: 'root', visits: 80, engagedVisits: 64, engagedMs: 200_000,
-  children: {
-    taxonomy: {
-      id: 'taxonomy', visits: 80, engagedVisits: 64, engagedMs: 200_000,
-      children: {
-        acc: {
-          id: 'acc', visits: 40, engagedVisits: 32, engagedMs: 100_000,
-          children: {
-            'acc-bel': {
-              id: 'acc-bel', visits: 20, engagedVisits: 16, engagedMs: 60_000,
-              children: { 'acc-bel-001': LEAF_NODE('acc-bel-001') },
-            },
-            'acc-des': {
-              id: 'acc-des', visits: 20, engagedVisits: 16, engagedMs: 40_000,
-              children: { 'acc-des-001': LEAF_NODE('acc-des-001') },
-            },
-          },
+  tool: { visits: 80, engagedVisits: 64, engagedMs: 200_000, cappedRate: 0 },
+  camps: {
+    acc: {
+      visits: 40, engagedVisits: 32, engagedMs: 100_000, cappedRate: 0,
+      categories: {
+        'acc-bel': {
+          visits: 20, engagedVisits: 16, engagedMs: 60_000, cappedRate: 0,
+          nodes: { 'acc-bel-001': LEAF_NODE() },
         },
-        saf: {
-          id: 'saf', visits: 40, engagedVisits: 32, engagedMs: 100_000,
-          children: {
-            'saf-bel': {
-              id: 'saf-bel', visits: 40, engagedVisits: 32, engagedMs: 100_000,
-              children: { 'saf-bel-001': LEAF_NODE('saf-bel-001') },
-            },
-          },
+        'acc-des': {
+          visits: 20, engagedVisits: 16, engagedMs: 40_000, cappedRate: 0,
+          nodes: { 'acc-des-001': LEAF_NODE() },
+        },
+      },
+    },
+    saf: {
+      visits: 40, engagedVisits: 32, engagedMs: 100_000, cappedRate: 0,
+      categories: {
+        'saf-bel': {
+          visits: 40, engagedVisits: 32, engagedMs: 100_000, cappedRate: 0,
+          nodes: { 'saf-bel-001': LEAF_NODE() },
         },
       },
     },
   },
+  tabs: {},
 };
 
 const SIGNED_IN_PROFILE = {
@@ -129,7 +126,7 @@ describe('YourActivityPanel', () => {
   it('shows empty state when user tree has no visits', async () => {
     mockProfile(SIGNED_IN_PROFILE);
     vi.mocked(bridgeGet).mockResolvedValue({
-      user: { id: 'root', visits: 0, engagedVisits: 0, engagedMs: 0 },
+      user: { tool: { visits: 0, engagedVisits: 0, engagedMs: 0, cappedRate: 0 }, camps: {}, tabs: {} },
     });
     render(<YourActivityPanel />);
     await waitFor(() => expect(screen.getByText(/no activity recorded/i)).toBeTruthy());

--- a/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/YourActivityPanel.tsx
@@ -16,6 +16,8 @@ import { bridgeGet } from '../../bridge/web-bridge';
 import { useUserProfile } from '../../hooks/useAuthStatus';
 import {
   type TreeNode,
+  type WireEngagementTree,
+  engagementTreeToTreeNode,
   CAMP_COLORS, CAMP_LABELS,
   fmtDuration, fmtNumber, categoryLabel,
   sumByCamp, sumByCategoryForCamp, collectLeafNodes,
@@ -25,7 +27,9 @@ import './YourActivityPanel.css';
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 interface ActivityResult {
-  user?: TreeNode;  // caller's own subtree (t/2467#2); absent if no events yet
+  // Server wire shape: `.user` is an EngagementTree, converted to TreeNode at the
+  // fetch boundary via engagementTreeToTreeNode (t/2709).
+  user?: WireEngagementTree;  // caller's own subtree (t/2467#2); absent if no events yet
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -176,7 +180,7 @@ function useFetchUserActivity(userId: string | null, isAnonymous: boolean): Fetc
     // Non-admin path: server returns .user for the caller's own userId and strips
     // all other-user data server-side. (verified seam: t/2469#3)
     bridgeGet<ActivityResult>(`/api/analytics/engagement?user=${encodeURIComponent(userId)}&from=${from}&to=${to}`)
-      .then(d => { setUserTree(d.user ?? null); setLoading(false); })
+      .then(d => { setUserTree(engagementTreeToTreeNode(d.user)); setLoading(false); })
       .catch(err => {
         getGlobalRecorder()?.record({
           type: 'system.error',

--- a/taxonomy-editor/src/renderer/components/analysis/engagementTree.test.ts
+++ b/taxonomy-editor/src/renderer/components/analysis/engagementTree.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * t/2709 — the server's GET /api/analytics/engagement returns an EngagementTree
+ * ({tool,camps,tabs}), but every panel consumes the hierarchical TreeNode
+ * ({id,…metrics,children}) via sumByCamp / sumByCategoryForCamp / collectLeafNodes.
+ * `bridgeGet<T>` cast the wire JSON straight to TreeNode, so the shape mismatch
+ * compiled and shipped an empty dashboard. These tests pin engagementTreeToTreeNode:
+ * they assert the adapter output is exactly what the traversal utilities expect, so
+ * the two contracts can never silently diverge again.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  engagementTreeToTreeNode,
+  sumByCamp,
+  sumByCategoryForCamp,
+  collectLeafNodes,
+  type WireEngagementTree,
+} from './engagementTree';
+
+// A realistic wire tree: tool root, two camps (acc has a category+nodes, saf is bare),
+// and a non-taxonomy tab that must NOT surface as a camp.
+const WIRE: WireEngagementTree = {
+  tool: { visits: 100, engagedVisits: 60, engagedMs: 50_000, cappedRate: 0.1, uniqueUsers: 5 },
+  camps: {
+    acc: {
+      visits: 40, engagedVisits: 25, engagedMs: 20_000, cappedRate: 0,
+      categories: {
+        'acc-bel': {
+          visits: 30, engagedVisits: 20, engagedMs: 15_000, cappedRate: 0,
+          nodes: {
+            'acc-bel-001': { visits: 20, engagedVisits: 12, engagedMs: 9_000, cappedRate: 0 },
+            'acc-bel-002': { visits: 10, engagedVisits: 8, engagedMs: 6_000, cappedRate: 0 },
+          },
+        },
+      },
+    },
+    saf: { visits: 25, engagedVisits: 15, engagedMs: 12_000, cappedRate: 0, categories: {} },
+  },
+  tabs: {
+    summaries: { visits: 35, engagedVisits: 20, engagedMs: 18_000, cappedRate: 0 },
+  },
+};
+
+describe('engagementTreeToTreeNode (t/2709)', () => {
+  it('maps tool metrics onto the root node (what HealthStrip / isEmpty read)', () => {
+    const root = engagementTreeToTreeNode(WIRE);
+    expect(root.id).toBe('root');
+    expect(root.visits).toBe(100);
+    expect(root.engagedVisits).toBe(60);
+    expect(root.engagedMs).toBe(50_000);
+    expect(root.cappedRate).toBe(0.1);
+    expect(root.uniqueUsers).toBe(5);
+  });
+
+  it('nests root → single tool → camps (the two levels sumByCamp walks)', () => {
+    const root = engagementTreeToTreeNode(WIRE);
+    expect(Object.keys(root.children ?? {})).toEqual(['tool']);
+    const tool = root.children!.tool;
+    // camps present; the `summaries` tab is intentionally excluded (non-taxonomy).
+    expect(Object.keys(tool.children ?? {}).sort()).toEqual(['acc', 'saf']);
+    expect(tool.children!.summaries).toBeUndefined();
+  });
+
+  it('feeds sumByCamp correctly (per-camp engagedMs/visits, sorted desc)', () => {
+    const root = engagementTreeToTreeNode(WIRE);
+    expect(sumByCamp(root)).toEqual([
+      { key: 'acc', engagedMs: 20_000, visits: 40 },
+      { key: 'saf', engagedMs: 12_000, visits: 25 },
+    ]);
+  });
+
+  it('feeds sumByCategoryForCamp correctly for a camp with categories', () => {
+    const root = engagementTreeToTreeNode(WIRE);
+    expect(sumByCategoryForCamp(root, 'acc')).toEqual([
+      { key: 'acc-bel', engagedMs: 15_000, visits: 30 },
+    ]);
+    // A camp with no categories yields no rows (not a throw).
+    expect(sumByCategoryForCamp(root, 'saf')).toEqual([]);
+  });
+
+  it('feeds collectLeafNodes only the taxonomy nodes (depth ≥ 3), not camps/categories', () => {
+    const root = engagementTreeToTreeNode(WIRE);
+    const leaves: Array<{ id: string; engagedMs: number; visits: number }> = [];
+    collectLeafNodes(root, 0, leaves);
+    expect(leaves.map(l => l.id).sort()).toEqual(['acc-bel-001', 'acc-bel-002']);
+    expect(leaves.find(l => l.id === 'acc-bel-001')).toEqual({ id: 'acc-bel-001', engagedMs: 9_000, visits: 20 });
+  });
+
+  it('returns null for a missing tree so callers keep their empty-state handling', () => {
+    expect(engagementTreeToTreeNode(null)).toBeNull();
+    expect(engagementTreeToTreeNode(undefined)).toBeNull();
+  });
+
+  it('tolerates a partial tree (server omits empty camps/categories/nodes)', () => {
+    const bare: WireEngagementTree = {
+      tool: { visits: 0, engagedVisits: 0, engagedMs: 0, cappedRate: 0 },
+      camps: {},
+      tabs: {},
+    };
+    const root = engagementTreeToTreeNode(bare);
+    expect(root.visits).toBe(0);                       // isEmpty → true
+    expect(Object.keys(root.children!.tool.children ?? {})).toEqual([]);
+    expect(sumByCamp(root)).toEqual([]);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/analysis/engagementTree.ts
+++ b/taxonomy-editor/src/renderer/components/analysis/engagementTree.ts
@@ -18,6 +18,91 @@ export interface TreeNode {
   children?: Record<string, TreeNode>;
 }
 
+// ── Server wire shape → TreeNode adapter (t/2709) ─────────────────────────────
+//
+// GET /api/analytics/engagement returns an *EngagementTree*, NOT a TreeNode:
+//   { tool, camps: { campId: { …metrics, categories: { catKey: { …metrics,
+//     nodes: { nodeId: …metrics } } } } }, tabs: { tabId: …metrics } }   (analytics.ts)
+// Every panel here instead consumes the hierarchical `TreeNode` ({id,…metrics,children})
+// via sumByCamp / sumByCategoryForCamp / collectLeafNodes. The renderer's frozen
+// contract types the field as TreeNode, but `bridgeGet<T>` is an unchecked cast over
+// JSON — so the shape mismatch compiled and shipped an empty dashboard (t/2709). This
+// is the single conversion point; every fetch boundary (useAnalytics,
+// EngagementDashboard, YourActivityPanel) runs its aggregate/user tree through it.
+//
+// Structure mapping — the traversal expects root → tool → camps → categories → nodes:
+//   root            = tool metrics, one child keyed 'tool'  (HealthStrip/isEmpty read root.visits)
+//   tool.children   = camps      (keyed acc|saf|skp|cc)
+//   camp.children   = categories (keyed `${camp}-${cat}`)
+//   category.children = taxonomy nodes (leaves, depth 4 → collectLeafNodes' depth≥3)
+// `tabs` are non-taxonomy views (Summaries, Lineage, …) whose ids are not camps; the
+// camp-based dashboard (CampBars is keyed to the 4 camps) has no place for them, so
+// they are intentionally excluded from the camp hierarchy. root.visits still counts
+// them — the server's `tool` rollup aggregates every view — so the totals stay
+// complete while the camp breakdown stays taxonomy-only. (Surfacing tabs is a separate
+// feature, not a silent loss.)
+
+export interface WireEngagementNode {
+  visits: number;
+  engagedVisits: number;
+  engagedMs: number;
+  cappedRate: number;
+  uniqueUsers?: number;
+}
+export interface WireEngagementCategory extends WireEngagementNode {
+  nodes: Record<string, WireEngagementNode>;
+}
+export interface WireEngagementCamp extends WireEngagementNode {
+  categories: Record<string, WireEngagementCategory>;
+}
+export interface WireEngagementTree {
+  tool: WireEngagementNode;
+  camps: Record<string, WireEngagementCamp>;
+  tabs: Record<string, WireEngagementNode>;
+}
+
+function wireToNode(id: string, n: WireEngagementNode, children?: Record<string, TreeNode>): TreeNode {
+  const node: TreeNode = {
+    id,
+    visits: n.visits,
+    engagedVisits: n.engagedVisits,
+    engagedMs: n.engagedMs,
+    cappedRate: n.cappedRate,
+  };
+  if (n.uniqueUsers !== undefined) node.uniqueUsers = n.uniqueUsers;
+  if (children) node.children = children;
+  return node;
+}
+
+/**
+ * Convert a server EngagementTree into the hierarchical TreeNode the panels traverse.
+ * A missing tree (the server omits `.user` when a caller has no events) maps to null,
+ * so callers keep their existing `?? null` / `=== null` empty-state handling.
+ */
+export function engagementTreeToTreeNode(tree: WireEngagementTree): TreeNode;
+export function engagementTreeToTreeNode(tree: WireEngagementTree | null | undefined): TreeNode | null;
+export function engagementTreeToTreeNode(tree: WireEngagementTree | null | undefined): TreeNode | null {
+  if (!tree) return null;
+  const camps: Record<string, TreeNode> = {};
+  // Maps default to {} — the server may omit an empty camps/categories/nodes level,
+  // and a defensive walk keeps a partial tree from throwing (returns a valid subtree).
+  for (const [campId, camp] of Object.entries(tree.camps ?? {})) {
+    const categories: Record<string, TreeNode> = {};
+    for (const [catKey, cat] of Object.entries(camp.categories ?? {})) {
+      const nodes: Record<string, TreeNode> = {};
+      for (const [nodeId, node] of Object.entries(cat.nodes ?? {})) {
+        nodes[nodeId] = wireToNode(nodeId, node);
+      }
+      categories[catKey] = wireToNode(catKey, cat, nodes);
+    }
+    camps[campId] = wireToNode(campId, camp, categories);
+  }
+  const toolNode = wireToNode('tool', tree.tool, camps);
+  // root carries tool metrics (HealthStrip/isEmpty read root.visits) and wraps the
+  // single tool node whose children are the camps — the two levels sumByCamp expects.
+  return wireToNode('root', tree.tool, { tool: toolNode });
+}
+
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 export const CAMP_COLORS: Record<string, string> = {

--- a/taxonomy-editor/src/renderer/hooks/useAnalytics.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useAnalytics.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useAnalytics } from './useAnalytics';
-import type { EngagementResult, SubjectBreakdownRow, SessionRow, DateRange } from './useAnalytics';
+import type { SubjectBreakdownRow, SessionRow, DateRange } from './useAnalytics';
 
 vi.mock('@lib/flight-recorder/index', () => ({
   getGlobalRecorder: () => ({ record: vi.fn() }),
@@ -27,8 +27,12 @@ const mockGet = vi.mocked(bridgeGet);
 
 const RANGE: DateRange = { from: '2026-08-06', to: '2026-08-13' };
 
-function leaf(visits: number, engagedMs = 1000): import('../components/analysis/engagementTree').TreeNode {
-  return { id: 'root', visits, engagedVisits: visits, engagedMs };
+// Server wire aggregate/user shape (t/2709): an EngagementTree whose `tool` carries
+// the root metrics the hook exposes as aggregate.{visits,engagedMs}. The hook adapts
+// this wire tree → the contract TreeNode at the boundary (engagementTreeToTreeNode);
+// these fixtures pin that mapping alongside the sessions/subject wire adapters.
+function wireTree(visits: number, engagedMs = 1000): import('../components/analysis/engagementTree').WireEngagementTree {
+  return { tool: { visits, engagedVisits: visits, engagedMs, cappedRate: 0 }, camps: {}, tabs: {} };
 }
 
 // Public contract shape (id) — what the hook must EXPOSE to consumers.
@@ -49,26 +53,29 @@ afterEach(() => { vi.restoreAllMocks(); mockGet.mockReset(); });
 
 describe('useAnalytics — engagement scope (§7.1)', () => {
   it('fetches the whole-population aggregate for scope "all" and reports non-empty', async () => {
-    const result: EngagementResult = { aggregate: leaf(42), daily: [] };
+    const result = { aggregate: wireTree(42), daily: [] };
     mockGet.mockResolvedValue(result);
 
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
 
     expect(mockGet).toHaveBeenCalledWith('/api/analytics/engagement?from=2026-08-06&to=2026-08-13');
-    expect(hook.current.engagement.data).toEqual(result);
+    // aggregate is adapted wire→TreeNode at the boundary: root carries the tool metrics.
+    expect(hook.current.engagement.data?.aggregate.id).toBe('root');
+    expect(hook.current.engagement.data?.aggregate.visits).toBe(42);
+    expect(hook.current.engagement.data?.daily).toEqual([]);
     expect(hook.current.engagement.isEmpty).toBe(false);
   });
 
   it('threads &user= for user scope', async () => {
-    mockGet.mockResolvedValue({ aggregate: leaf(5), daily: [] });
+    mockGet.mockResolvedValue({ aggregate: wireTree(5), daily: [] });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'user', user: 'alice@x.com' } }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
     expect(mockGet).toHaveBeenCalledWith('/api/analytics/engagement?from=2026-08-06&to=2026-08-13&user=alice%40x.com');
   });
 
   it('threads &session= for session scope and returns the recomputed aggregate', async () => {
-    const scoped: EngagementResult = { aggregate: leaf(9, 7777), daily: [] };
+    const scoped = { aggregate: wireTree(9, 7777), daily: [] };
     mockGet.mockResolvedValue(scoped);
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'session', session: 's1' } }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
@@ -77,7 +84,7 @@ describe('useAnalytics — engagement scope (§7.1)', () => {
   });
 
   it('reports isEmpty when the aggregate has zero visits', async () => {
-    mockGet.mockResolvedValue({ aggregate: leaf(0), daily: [] });
+    mockGet.mockResolvedValue({ aggregate: wireTree(0), daily: [] });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
     expect(hook.current.engagement.isEmpty).toBe(true);
@@ -94,7 +101,7 @@ describe('useAnalytics — engagement scope (§7.1)', () => {
 
 describe('useAnalytics — sessions list (§7.2)', () => {
   it('exposes sessions riding the user-scope response, with no second round-trip', async () => {
-    mockGet.mockResolvedValue({ aggregate: leaf(5), daily: [], sessions: WIRE_SESSIONS });
+    mockGet.mockResolvedValue({ aggregate: wireTree(5), daily: [], sessions: WIRE_SESSIONS });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'user', user: 'alice' } }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
 
@@ -105,7 +112,7 @@ describe('useAnalytics — sessions list (§7.2)', () => {
   });
 
   it('is empty under non-user scope even if the payload carried sessions', async () => {
-    mockGet.mockResolvedValue({ aggregate: leaf(5), daily: [], sessions: WIRE_SESSIONS });
+    mockGet.mockResolvedValue({ aggregate: wireTree(5), daily: [], sessions: WIRE_SESSIONS });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'all' } }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
     expect(hook.current.sessions.isEmpty).toBe(true);
@@ -114,7 +121,7 @@ describe('useAnalytics — sessions list (§7.2)', () => {
 
 describe('useAnalytics — subject WHO breakdown (§7.3)', () => {
   it('fetches ?subject=&groupBy=user on demand', async () => {
-    mockGet.mockResolvedValueOnce({ aggregate: leaf(5), daily: [] }); // initial engagement
+    mockGet.mockResolvedValueOnce({ aggregate: wireTree(5), daily: [] }); // initial engagement
     // Wire: {rows:[{user,…}]} envelope (groupBy=user). Hook unwraps + maps user→key.
     const wire = { rows: [
       { user: 'alice', engagedMs: 3000, visits: 4 },
@@ -137,7 +144,7 @@ describe('useAnalytics — subject WHO breakdown (§7.3)', () => {
   });
 
   it('reports isEmpty for a subject with no rows, and groupBy=session in the query', async () => {
-    mockGet.mockResolvedValueOnce({ aggregate: leaf(5), daily: [] });
+    mockGet.mockResolvedValueOnce({ aggregate: wireTree(5), daily: [] });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
 
@@ -152,7 +159,7 @@ describe('useAnalytics — subject WHO breakdown (§7.3)', () => {
   // Contract v2 (t/2560#2, t/2562#2): under user scope the WHO query threads &user=
   // so the user-scoped leaf panel gets by-session rows for that user only.
   it('threads &user= when the active scope is a user (v2)', async () => {
-    mockGet.mockResolvedValueOnce({ aggregate: leaf(5), daily: [] });
+    mockGet.mockResolvedValueOnce({ aggregate: wireTree(5), daily: [] });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'user', user: 'alice@x.com' } }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
 
@@ -164,7 +171,7 @@ describe('useAnalytics — subject WHO breakdown (§7.3)', () => {
   });
 
   it('omits &user= under non-user scope (all / session)', async () => {
-    mockGet.mockResolvedValueOnce({ aggregate: leaf(5), daily: [] });
+    mockGet.mockResolvedValueOnce({ aggregate: wireTree(5), daily: [] });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'session', session: 's9' } }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
 
@@ -180,7 +187,7 @@ describe('useAnalytics — subject WHO breakdown (§7.3)', () => {
 // the mock-blindness that hid the t/2560#6 drift cannot recur. Field-level assertions.
 describe('useAnalytics — server wire shape → frozen contract (regression, t/2560#6/#7)', () => {
   it('maps the sessions wire field `session` → contract `id` (never undefined)', async () => {
-    mockGet.mockResolvedValue({ aggregate: leaf(3), daily: [], sessions: WIRE_SESSIONS });
+    mockGet.mockResolvedValue({ aggregate: wireTree(3), daily: [], sessions: WIRE_SESSIONS });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE, scope: { kind: 'user', user: 'alice' } }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
     // The wire carries no `id`; the adapter must supply it from `session`.
@@ -189,7 +196,7 @@ describe('useAnalytics — server wire shape → frozen contract (regression, t/
   });
 
   it('unwraps the subject `{rows}` envelope and maps `user`/`session` → `key`', async () => {
-    mockGet.mockResolvedValueOnce({ aggregate: leaf(3), daily: [] });
+    mockGet.mockResolvedValueOnce({ aggregate: wireTree(3), daily: [] });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
 
@@ -205,7 +212,7 @@ describe('useAnalytics — server wire shape → frozen contract (regression, t/
 
 describe('useAnalytics — refetch + stale-response guard', () => {
   it('re-runs the engagement fetch on refetch()', async () => {
-    mockGet.mockResolvedValue({ aggregate: leaf(1), daily: [] });
+    mockGet.mockResolvedValue({ aggregate: wireTree(1), daily: [] });
     const { result: hook } = renderHook(() => useAnalytics({ range: RANGE }));
     await waitFor(() => expect(hook.current.engagement.loading).toBe(false));
     expect(mockGet).toHaveBeenCalledTimes(1);
@@ -218,7 +225,7 @@ describe('useAnalytics — refetch + stale-response guard', () => {
     // First (user=alice) resolves slowly; the rerender to session=s1 resolves first.
     let resolveAlice!: (v: EngagementResult) => void;
     mockGet.mockImplementationOnce(() => new Promise<EngagementResult>(r => { resolveAlice = r; }));
-    mockGet.mockResolvedValueOnce({ aggregate: leaf(2, 222), daily: [] }); // session=s1
+    mockGet.mockResolvedValueOnce({ aggregate: wireTree(2, 222), daily: [] }); // session=s1
 
     const { result: hook, rerender } = renderHook(
       (props: { scope: import('./useAnalytics').AnalyticsScope }) => useAnalytics({ range: RANGE, scope: props.scope }),
@@ -229,7 +236,7 @@ describe('useAnalytics — refetch + stale-response guard', () => {
     await waitFor(() => expect(hook.current.engagement.data?.aggregate.engagedMs).toBe(222));
 
     // The late alice response must be ignored (stale request id).
-    act(() => { resolveAlice({ aggregate: leaf(999, 999), daily: [] }); });
+    act(() => { resolveAlice({ aggregate: wireTree(999, 999), daily: [] }); });
     await Promise.resolve();
     expect(hook.current.engagement.data?.aggregate.engagedMs).toBe(222);
   });

--- a/taxonomy-editor/src/renderer/hooks/useAnalytics.ts
+++ b/taxonomy-editor/src/renderer/hooks/useAnalytics.ts
@@ -20,7 +20,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { bridgeGet } from '../bridge/web-bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
-import type { TreeNode } from '../components/analysis/engagementTree';
+import type { TreeNode, WireEngagementTree } from '../components/analysis/engagementTree';
+import { engagementTreeToTreeNode } from '../components/analysis/engagementTree';
 
 // ── Contract types (frozen; published at t/2560#1) ───────────────────────────
 
@@ -102,7 +103,15 @@ export interface UseAnalyticsResult {
 // below simply become identity passthroughs.
 
 interface WireSessionRow { session: string; startTime: string; engagedMs: number; nodeCount: number }
-type WireEngagementResult = Omit<EngagementResult, 'sessions'> & { sessions?: WireSessionRow[] };
+// aggregate/user arrive as the server's EngagementTree ({tool,camps,tabs}), NOT the
+// frozen-contract TreeNode — the boundary adapter (below) converts them via
+// engagementTreeToTreeNode. Typing them honestly here is what makes the conversion
+// mandatory instead of an unchecked cast (the t/2709 empty-dashboard bug).
+type WireEngagementResult = Omit<EngagementResult, 'sessions' | 'aggregate' | 'user'> & {
+  aggregate: WireEngagementTree;
+  user?: WireEngagementTree;
+  sessions?: WireSessionRow[];
+};
 type WireSubjectRow =
   | { user: string; engagedMs: number; visits: number }
   | { session: string; engagedMs: number; visits: number };
@@ -171,10 +180,14 @@ export function useAnalytics({ range, scope = { kind: 'all' } }: UseAnalyticsOpt
     bridgeGet<WireEngagementResult>(engagementQuery(from, to, scope))
       .then(raw => {
         if (id !== engReq.current) return;
-        // Adapt §7.2 sessions: server row field `session` → frozen contract `id` (t/2560#6/#7).
-        const { sessions: wireSessions, ...rest } = raw;
+        // Adapt the server wire shape to the frozen contract (t/2560#6/#7, t/2709):
+        //   • aggregate/user: EngagementTree {tool,camps,tabs} → hierarchical TreeNode
+        //   • §7.2 sessions: server row field `session` → contract `id`
+        const { sessions: wireSessions, aggregate: wireAggregate, user: wireUser, ...rest } = raw;
         const d: EngagementResult = {
           ...rest,
+          aggregate: engagementTreeToTreeNode(wireAggregate),
+          ...(wireUser ? { user: engagementTreeToTreeNode(wireUser) } : {}),
           ...(wireSessions
             ? { sessions: wireSessions.map(s => ({ id: s.session, startTime: s.startTime, engagedMs: s.engagedMs, nodeCount: s.nodeCount })) }
             : {}),


### PR DESCRIPTION
## t/2709 — empty engagement dashboard: adapt server EngagementTree → TreeNode

**Root cause.** `GET /api/analytics/engagement` returns an `EngagementTree`
(`{tool, camps:{…categories:{…nodes}}, tabs}`), but every engagement panel consumes
the hierarchical `TreeNode` (`{id,…metrics,children}`) via `sumByCamp` /
`sumByCategoryForCamp` / `collectLeafNodes`. The renderer's frozen contract typed the
field as `TreeNode`, yet `bridgeGet<T>` is an **unchecked cast over JSON** — so the
shape mismatch compiled and shipped: the dashboard read `.visits`/`.children` off a
tree that has neither at its root, rendering **empty** while 300+ `view.dwell` events
existed. (Distinct from t/2707, which fixed a *minority* init path; this is the
empty-dashboard root cause.)

**Fix — one shared boundary adapter.** `engagementTreeToTreeNode()` in
`engagementTree.ts`, applied at all three fetch sites that cast the wire tree to
`TreeNode`:

| Site | Field(s) | Consumer |
|------|----------|----------|
| `hooks/useAnalytics.ts` | `raw.aggregate`, `raw.user` | UsageHierarchy |
| `EngagementDashboard.tsx` | `d.aggregate`, `d.user` | admin dashboard |
| `YourActivityPanel.tsx` | `d.user` | self-view |

The wire types (`WireEngagementTree`/`Camp`/`Category`/`Node`) are declared honestly so
the conversion is **mandatory, not an unchecked cast** — the type-level lie that hid the
bug can no longer typecheck.

**Mapping.** `root` carries the `tool` metrics (HealthStrip/isEmpty read `root.visits`)
and wraps a single tool node whose children are the camps — the two levels `sumByCamp`
walks — then categories → taxonomy nodes (depth-4 leaves). Non-taxonomy **`tabs` are
intentionally excluded** from the camp hierarchy (`CampBars` is keyed to the 4 camps);
`root.visits` still counts them via the server's `tool` rollup, so totals stay complete
while the camp breakdown stays taxonomy-only. Adapter is null-tolerant (server omits
`.user` when a caller has no events) and defensive against omitted empty maps.

**Tests.**
- **New** `engagementTree.test.ts` pins the adapter output against the actual traversal
  utilities (`sumByCamp` / `sumByCategoryForCamp` / `collectLeafNodes`) — the contract
  the bug violated — plus null/partial-tree handling and tab exclusion.
- The three consumers' fixtures are converted from already-adapted `TreeNode` to the
  **real server wire shape**. The old `TreeNode` fixtures never exercised the
  wire→`TreeNode` conversion, so they were blind to the mismatch that shipped — the same
  single-context blindness called out in the tech-lead AGENTS.md.

**Verify.** renderer `tsc` 0 · eslint 0 errors · 721/721 renderer tests pass. The
pre-existing complexity-18 warning on `EngagementDashboard` is unchanged (verified
against `origin/main`; this change is complexity-neutral).

**Scope note.** Renderer files are CLAUDE.md-profile-owned; implemented directly by TL
as the assigned owner of this urgent prod-blocker (architecture decided in t/2709#1).
Flagging to the renderer owner for post-merge awareness.

Fixes t/2709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Diagnostics (Orca) &lt;main.operations-diagnostics@ai-triad-research.orca.local&gt;
