### PR TITLE
feat(smoke): view.dwell event_type assertion in analytics round-trip (t/2706)

### DIFF
--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -231,6 +231,8 @@ function Invoke-TaxEditorSmokeTest {
     # Write probe — reachability only (200 + ok:true). NOT a drop detector.
     # Build the body as an explicit JSON string so the single-element `events`
     # array is never unwrapped to an object (the server requires an array — 400 otherwise).
+    # Two events in one batch: smoke-probe (system category) + view.dwell (engagement)
+    # so the after-read can assert eventTypes['view.dwell'] >= 1 (t/2706 AC).
     $ProbeStamp   = [DateTimeOffset]::UtcNow.ToString('o')
     $ProbeSession = "smoke-$([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds())"
     $ProbeEvent   = @{
@@ -241,7 +243,15 @@ function Invoke-TaxEditorSmokeTest {
         category   = 'system'
         detail     = @{}
     }
-    $EventJson = '{"events":[' + ($ProbeEvent | ConvertTo-Json -Depth 6 -Compress) + ']}'
+    $DwellEvent   = @{
+        user       = 'smoke-probe'
+        session_id = $ProbeSession
+        timestamp  = $ProbeStamp
+        event_type = 'view.dwell'
+        category   = 'engagement'
+        detail     = @{ duration_ms = 100 }
+    }
+    $EventJson = '{"events":[' + ($ProbeEvent | ConvertTo-Json -Depth 6 -Compress) + ',' + ($DwellEvent | ConvertTo-Json -Depth 6 -Compress) + ']}'
 
     $WriteParams = @{ BaseUrl = $BaseUrl; Path = '/api/analytics/event'; Method = 'POST'; Body = $EventJson; TimeoutSec = $TimeoutSec; AcceptableStatusCodes = @(200) }
     if ($AnalyticsSession) { $WriteParams.Session = $AnalyticsSession }
@@ -302,6 +312,38 @@ function Invoke-TaxEditorSmokeTest {
     $DeltaResult.NodeCount   = $After
     $DeltaResult.Error       = $DeltaErr
     $Analytics += $DeltaResult
+
+    # t/2706 — assert view.dwell event_type is recorded in eventTypes.
+    # The write batch above includes a view.dwell event; the after-read's
+    # eventTypes map (QueryResult.eventTypes: Record<string,number>) must
+    # contain 'view.dwell' >= 1. This catches a class of routing bug where
+    # the event is accepted (200 ok) but silently discarded or mis-typed.
+    $DwellPass = $false
+    $DwellErr  = $null
+    if (-not $AfterCheck.Success) {
+        $DwellErr = "after-read failed (status=$($AfterCheck.StatusCode)) — cannot check eventTypes"
+    } elseif (-not $AfterCheck.Body -or -not $AfterCheck.Body.PSObject.Properties['eventTypes']) {
+        $DwellErr = "eventTypes field missing from /api/analytics/query response"
+    } else {
+        $EventTypes  = $AfterCheck.Body.eventTypes
+        $DwellProp   = $EventTypes.PSObject.Properties['view.dwell']
+        $DwellCount  = if ($DwellProp) { [int]$DwellProp.Value } else { 0 }
+        $DwellPass   = ($DwellCount -ge 1)
+        if (-not $DwellPass) {
+            $DwellErr = "view.dwell absent or zero in eventTypes after probe write (count=$DwellCount) — event not persisted or event_type mis-routed"
+        }
+    }
+
+    $DwellResult = [EndpointTestResult]::new()
+    $DwellResult.Endpoint    = 'GET /api/analytics/query (view.dwell eventType)'
+    $DwellResult.Category    = 'Analytics'
+    $DwellResult.Description = 'view.dwell event_type present in analytics after write (t/2706)'
+    $DwellResult.Status      = $AfterCheck.StatusCode
+    $DwellResult.Pass        = $DwellPass
+    $DwellResult.Ms          = $AfterCheck.ResponseMs
+    $DwellResult.NodeCount   = $null
+    $DwellResult.Error       = $DwellErr
+    $Analytics += $DwellResult
 
     foreach ($Ep in $Analytics) {
         $Icon = if ($Ep.Pass) { '[PASS]' } else { '[FAIL]' }

--- a/tests/Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1
@@ -78,7 +78,10 @@ Describe 'Invoke-TaxEditorSmokeTest analytics round-trip probe (t/2667)' -Tag 'h
             Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
                 $script:QueryCall++
                 $total = if ($script:QueryCall -eq 1) { 5 } else { 6 }   # +1 after write
-                New-RCResult $true 200 ([PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } })
+                New-RCResult $true 200 ([PSCustomObject]@{
+                    summary    = [PSCustomObject]@{ totalEvents = $total }
+                    eventTypes = [PSCustomObject]@{ 'view.dwell' = if ($script:QueryCall -ge 2) { 1 } else { 0 } }
+                })
             }
             Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
                 New-RCResult $true 200 ([PSCustomObject]@{ ok = $true; count = 1 })
@@ -162,7 +165,10 @@ Describe 'Invoke-TaxEditorSmokeTest analytics round-trip probe (t/2667)' -Tag 'h
             Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
                 $script:QueryCall++
                 $total = if ($script:QueryCall -eq 1) { 5 } else { 6 }
-                New-RCResult $true 200 ([PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } })
+                New-RCResult $true 200 ([PSCustomObject]@{
+                    summary    = [PSCustomObject]@{ totalEvents = $total }
+                    eventTypes = [PSCustomObject]@{ 'view.dwell' = if ($script:QueryCall -ge 2) { 1 } else { 0 } }
+                })
             }
             Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
                 New-RCResult $true 200 ([PSCustomObject]@{ ok = $true; count = 1 })
@@ -188,7 +194,10 @@ Describe 'Invoke-TaxEditorSmokeTest analytics round-trip probe (t/2667)' -Tag 'h
             Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
                 $script:QueryCall++
                 $total = if ($script:QueryCall -eq 1) { 5 } else { 6 }
-                New-RCResult $true 200 ([PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } })
+                New-RCResult $true 200 ([PSCustomObject]@{
+                    summary    = [PSCustomObject]@{ totalEvents = $total }
+                    eventTypes = [PSCustomObject]@{ 'view.dwell' = if ($script:QueryCall -ge 2) { 1 } else { 0 } }
+                })
             }
             Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/event' } -MockWith {
                 New-RCResult $true 200 ([PSCustomObject]@{ ok = $true; count = 1 })

--- a/tests/Invoke-TaxEditorSmokeTest.ColdStart.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.ColdStart.Tests.ps1
@@ -51,10 +51,14 @@ Describe 'Invoke-TaxEditorSmokeTest Health-phase cold-start tolerance (t/1696)' 
             $script:CsQuery = 0
             Mock Invoke-RemoteCheck -ParameterFilter { $Path -eq '/api/analytics/query' } -MockWith {
                 $script:CsQuery++
-                $total = if ($script:CsQuery -eq 1) { 0 } else { 1 }
+                $total      = if ($script:CsQuery -eq 1) { 0 } else { 1 }
+                $dwellCount = if ($script:CsQuery -eq 1) { 0 } else { 1 }
                 [PSCustomObject]@{
                     Success = $true; StatusCode = 200; ResponseMs = 5
-                    Body = [PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } }
+                    Body = [PSCustomObject]@{
+                        summary    = [PSCustomObject]@{ totalEvents = $total }
+                        eventTypes = [PSCustomObject]@{ 'view.dwell' = $dwellCount }
+                    }
                     ContentType = 'application/json'; RawBody = ''; Error = $null
                 }
             }

--- a/tests/Invoke-TaxEditorSmokeTest.GitHubGate.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.GitHubGate.Tests.ps1
@@ -84,7 +84,10 @@ Describe 'Invoke-TaxEditorSmokeTest GitHub-flap gate exclusion (t/2673)' -Tag 'h
                 $total = if ($script:AnalyticsQ -eq 1) { 5 } else { 6 }
                 [PSCustomObject]@{
                     Success = $true; StatusCode = 200; ResponseMs = 10
-                    Body = [PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } }
+                    Body = [PSCustomObject]@{
+                        summary    = [PSCustomObject]@{ totalEvents = $total }
+                        eventTypes = [PSCustomObject]@{ 'view.dwell' = if ($script:AnalyticsQ -ge 2) { 1 } else { 0 } }
+                    }
                     ContentType = 'application/json'; RawBody = ''; Error = $null
                 }
             }
@@ -147,7 +150,10 @@ Describe 'Invoke-TaxEditorSmokeTest GitHub-flap gate exclusion (t/2673)' -Tag 'h
                 $total = if ($script:AnalyticsQ -eq 1) { 5 } else { 6 }
                 [PSCustomObject]@{
                     Success = $true; StatusCode = 200; ResponseMs = 10
-                    Body = [PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } }
+                    Body = [PSCustomObject]@{
+                        summary    = [PSCustomObject]@{ totalEvents = $total }
+                        eventTypes = [PSCustomObject]@{ 'view.dwell' = if ($script:AnalyticsQ -ge 2) { 1 } else { 0 } }
+                    }
                     ContentType = 'application/json'; RawBody = ''; Error = $null
                 }
             }
@@ -194,7 +200,10 @@ Describe 'Invoke-TaxEditorSmokeTest GitHub-flap gate exclusion (t/2673)' -Tag 'h
                 $total = if ($script:AnalyticsQ -eq 1) { 5 } else { 6 }
                 [PSCustomObject]@{
                     Success = $true; StatusCode = 200; ResponseMs = 10
-                    Body = [PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } }
+                    Body = [PSCustomObject]@{
+                        summary    = [PSCustomObject]@{ totalEvents = $total }
+                        eventTypes = [PSCustomObject]@{ 'view.dwell' = if ($script:AnalyticsQ -ge 2) { 1 } else { 0 } }
+                    }
                     ContentType = 'application/json'; RawBody = ''; Error = $null
                 }
             }
@@ -270,7 +279,10 @@ Describe 'Invoke-TaxEditorSmokeTest GitHub-flap gate exclusion (t/2673)' -Tag 'h
                 $total = if ($script:AnalyticsQ -eq 1) { 5 } else { 6 }
                 [PSCustomObject]@{
                     Success = $true; StatusCode = 200; ResponseMs = 10
-                    Body = [PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total } }
+                    Body = [PSCustomObject]@{
+                        summary    = [PSCustomObject]@{ totalEvents = $total }
+                        eventTypes = [PSCustomObject]@{ 'view.dwell' = if ($script:AnalyticsQ -ge 2) { 1 } else { 0 } }
+                    }
                     ContentType = 'application/json'; RawBody = ''; Error = $null
                 }
             }


### PR DESCRIPTION
## Summary

- Adds a `view.dwell` engagement event to the existing analytics write batch in `Invoke-TaxEditorSmokeTest`
- After the async blob append, asserts `eventTypes['view.dwell'] >= 1` from `/api/analytics/query` — catches the class of bug where an event is accepted (200 ok) but silently discarded or mis-typed
- Updates ColdStart test mock to return `eventTypes` with `view.dwell` so existing health-phase tests stay green (3/3 pass locally)

## Test plan

- [x] `Invoke-Pester -Path tests/Invoke-TaxEditorSmokeTest.ColdStart.Tests.ps1` — 3/3 pass
- [ ] CI Pester suite green
- [ ] `Invoke-TaxEditorSmokeTest` against staging confirms `[PASS] GET /api/analytics/query (view.dwell eventType)`

Closes t/2706. Also satisfies t/2689 AC3 (smoke gate covers view.dwell analytics path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)