### PR TITLE
obs(diagnostics): instrument sendDiagnosticsState + diag-window load (t/2692)

### DIFF
--- a/taxonomy-editor/src/main/main.ts
+++ b/taxonomy-editor/src/main/main.ts
@@ -419,6 +419,17 @@ void app.whenReady().then(() => {
       void diagWindow.loadFile(path.join(PROJECT_ROOT, 'taxonomy-editor/dist/renderer/index.html'), { hash: 'diagnostics-window' });
     }
     diagWindow.webContents.on('did-finish-load', () => {
+      // t/2692: record whether the buffered state existed the moment the diag window
+      // finished loading. This is the seam where an IPC-after-load race would strand the
+      // popout (Issue 2): lastStateAvailable=false at load, with no later push, is the
+      // failure signature — previously only assessable as PLAUSIBLE, now CONFIRMABLE.
+      getGlobalRecorder()?.record({
+        type: 'lifecycle',
+        component: 'diagnostics-window',
+        level: 'info',
+        message: 'diagnostics-window did-finish-load',
+        data: { lastStateAvailable: !!_lastDiagnosticsState },
+      });
       if (_lastDiagnosticsState && diagWindow && !diagWindow.isDestroyed()) {
         diagWindow.webContents.send('diagnostics-state-update', _lastDiagnosticsState);
       }

--- a/taxonomy-editor/src/renderer/bridge/__tests__/diagnosticsStateInstrumentation.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/diagnosticsStateInstrumentation.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2692 — `sendDiagnosticsState` is a sync ipcRenderer.send, so instrumentBridge
+// (which wraps only async methods) skips it. The electron-bridge impl records a manual
+// flight-recorder event so the IPC state push is confirmable from the FR. This test
+// pins that instrumentation: the delegation still happens, and the record carries the
+// minimal debate_id / transcript_length / selected_entry payload at debug level.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({ record: vi.fn() }));
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: h.record, intern: (_ns: string, v: string) => v }),
+}));
+
+const origWindow = (globalThis as Record<string, unknown>).window;
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).window = origWindow;
+  h.record.mockReset();
+  vi.resetModules();
+});
+
+describe('electron-bridge sendDiagnosticsState instrumentation (t/2692)', () => {
+  it('delegates to window.electronAPI and records the IPC push with a minimal payload', async () => {
+    const sendDiagnosticsState = vi.fn();
+    (globalThis as Record<string, unknown>).window = { electronAPI: { sendDiagnosticsState } };
+    const state = { debate: { id: 'debate-1', transcript: [{ id: 'e0' }, { id: 'e1' }, { id: 'e2' }] }, selectedEntry: 'e2' };
+
+    const mod = await import('../electron-bridge');
+    mod.api.sendDiagnosticsState(state as never);
+
+    expect(sendDiagnosticsState).toHaveBeenCalledWith(state);
+    expect(h.record).toHaveBeenCalledTimes(1);
+    const rec = h.record.mock.calls[0][0];
+    expect(rec.message).toBe('bridge.sendDiagnosticsState');
+    expect(rec.level).toBe('debug');
+    expect(rec.data).toEqual({ debate_id: 'debate-1', transcript_length: 3, selected_entry: 'e2' });
+  });
+
+  it('tolerates a null/partial state (no throw; null fields)', async () => {
+    const sendDiagnosticsState = vi.fn();
+    (globalThis as Record<string, unknown>).window = { electronAPI: { sendDiagnosticsState } };
+
+    const mod = await import('../electron-bridge');
+    mod.api.sendDiagnosticsState({ debate: null, selectedEntry: null } as never);
+
+    expect(sendDiagnosticsState).toHaveBeenCalledTimes(1);
+    expect(h.record.mock.calls[0][0].data).toEqual({ debate_id: null, transcript_length: null, selected_entry: null });
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -399,6 +399,23 @@ export const api: AppAPI = {
   sendDiagnosticsState: (s) => {
     for (const cb of localDiagCallbacks) cb(s);
     window.electronAPI.sendDiagnosticsState(s);
+    // t/2692: sendDiagnosticsState is a sync `ipcRenderer.send`, so instrumentBridge
+    // (which only wraps async methods) skips it — record manually here to confirm the
+    // IPC state push actually left the sender. Fires on every debate state change
+    // (high-frequency), so debug level + minimal payload to avoid evicting useful
+    // events (the concern the instrumentBridge SKIP list already guards).
+    const st = s as { debate?: { id?: string; transcript?: unknown[] }; selectedEntry?: unknown } | null;
+    getGlobalRecorder()?.record({
+      type: 'lifecycle',
+      component: 'electron-bridge',
+      level: 'debug',
+      message: 'bridge.sendDiagnosticsState',
+      data: {
+        debate_id: st?.debate?.id ?? null,
+        transcript_length: Array.isArray(st?.debate?.transcript) ? st.debate.transcript.length : null,
+        selected_entry: st?.selectedEntry ?? null,
+      },
+    });
   },
 
   // Data file diff popout


### PR DESCRIPTION
Closes t/2692. Two additive flight-recorder records to make the diagnostics IPC path confirmable (the 2026-08-16 'diag never displayed' race could only be assessed PLAUSIBLE):

1. **electron-bridge `sendDiagnosticsState`** — sync `ipcRenderer.send`, so instrumentBridge (async-only) skips it. Manual record mirroring the instrumentBridge shape at **debug** level, minimal payload `{debate_id, transcript_length, selected_entry}` (fires per debate state change → keep cheap).
2. **main.ts diag-window `did-finish-load`** — record `{lastStateAvailable}` at **info**; false-at-load with no later push is the race's failure signature.

Purely additive, no behavior change. Unit test pins the bridge record (delegation + payload + null tolerance). Verify: renderer tsc 0, main tsc 0, eslint 0 errors, test 2/2.

Design t/2692#1 (hold lifted — t/2694 landed, so this instruments the final path). Self-cert: additive observability, no new API/schema/cross-role interface. Scope: renderer+main are CLAUDE.md-owned; TL-implemented, flagged for owner awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)