### PR TITLE
obs(analytics): FR event for DwellTracker init outcome (t/2705)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/dwellTracker.ts
+++ b/taxonomy-editor/src/renderer/lib/dwellTracker.ts
@@ -341,6 +341,19 @@ const PULSE_EVENTS = ['pointermove', 'keydown', 'scroll', 'wheel', 'click'] as c
 
 /** Initialize dwell tracking. Call once, before `initAnalytics()`. No-op in Electron. */
 export async function initDwellTracker(): Promise<void> {
+  // t/2705: record the init lifecycle outcome so a session's dwell-tracking state is
+  // diagnosable from the FR. During t/2699 there was no signal for whether the tracker
+  // activated, was an Electron no-op, or was a redundant re-init — the emptiness could
+  // not be distinguished from "tracking on but no events". `view.dwell` (what feeds the
+  // engagement dashboard) exists only when outcome === 'activated'.
+  const outcome = !isWeb ? 'skipped_electron' : initialized ? 'skipped_already_initialized' : 'activated';
+  getGlobalRecorder()?.record({
+    type: 'lifecycle',
+    component: 'dwellTracker',
+    level: 'info',
+    message: 'dwell_tracker_init',
+    data: { outcome, target: isWeb ? 'web' : 'electron' },
+  });
   if (!isWeb || initialized) return;
   initialized = true;
   tracker = new DwellTracker(() => getClientConfig().analytics);

--- a/taxonomy-editor/src/renderer/lib/dwellTrackerInit.test.ts
+++ b/taxonomy-editor/src/renderer/lib/dwellTrackerInit.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// @vitest-environment jsdom
+
+// t/2705 — initDwellTracker emits a lifecycle FR event recording its init outcome so a
+// session's dwell-tracking state is diagnosable from the flight recorder (t/2699 had no
+// signal to distinguish "tracker skipped" from "tracking on but no events"). `view.dwell`
+// — what feeds the engagement dashboard — exists only when outcome === 'activated'.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({ record: vi.fn() }));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: h.record }) }));
+// Stub the store so the activated path's dynamic import stays light and deterministic.
+vi.mock('../hooks/useTaxonomyStore', () => ({
+  useTaxonomyStore: {
+    getState: () => ({ activeTab: 'skeptic', selectedNodeId: null, toolbarPanel: null }),
+    subscribe: () => () => {},
+  },
+}));
+
+function initEvent(): { outcome: string; target: string } | undefined {
+  const call = h.record.mock.calls.map(c => c[0]).find(e => e.message === 'dwell_tracker_init');
+  return call?.data as { outcome: string; target: string } | undefined;
+}
+
+beforeEach(() => { h.record.mockClear(); vi.resetModules(); });
+afterEach(() => { vi.unstubAllEnvs(); });
+
+describe('initDwellTracker init-outcome FR event (t/2705)', () => {
+  it('records skipped_electron when the target is not web (no-op path)', async () => {
+    vi.stubEnv('VITE_TARGET', 'electron');
+    const mod = await import('./dwellTracker');
+    await mod.initDwellTracker();
+    const ev = h.record.mock.calls.map(c => c[0]).find(e => e.message === 'dwell_tracker_init');
+    expect(ev?.type).toBe('lifecycle');
+    expect(ev?.level).toBe('info');
+    expect(initEvent()).toEqual({ outcome: 'skipped_electron', target: 'electron' });
+  });
+
+  it('records activated on the first web init, then skipped_already_initialized on re-init', async () => {
+    vi.stubEnv('VITE_TARGET', 'web');
+    const mod = await import('./dwellTracker');
+
+    await mod.initDwellTracker();
+    expect(initEvent()).toEqual({ outcome: 'activated', target: 'web' });
+
+    h.record.mockClear();
+    await mod.initDwellTracker();
+    expect(initEvent()).toEqual({ outcome: 'skipped_already_initialized', target: 'web' });
+
+    mod.stopDwellTracker();
+  });
+});


### PR DESCRIPTION
Closes t/2705. `initDwellTracker` now emits a lifecycle FR event `dwell_tracker_init` at info with `data:{outcome, target}` — `activated` (web first call; the only case that emits `view.dwell`), `skipped_electron` (no-op), or `skipped_already_initialized` (redundant re-init). Recorded before the early return so every call is captured; makes an empty engagement dashboard immediately attributable to init state (the signal t/2699 lacked).

**Deviation:** ticket asked for `path: normal|copy_complete|first_run`, but t/2707 unified all four App.tsx init paths through one `initAnalyticsSession()→initDwellTracker()`, so per-caller path is no longer distinguishable inside initDwellTracker — the activated/skipped **outcome** is the diagnostic signal instead. Dropped the extra `log.analytics.debug` console line (no-console lint; the FR event is the structured log).

New test `dwellTrackerInit.test.ts` stubs VITE_TARGET + mocks recorder/store, pins all three outcomes (2/2). renderer tsc 0, eslint 0. Self-cert: additive observability, no behavior/API/schema change. Scope: renderer is CLAUDE.md-owned; TL-implemented, flagged for owner awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)