### PR TITLE
feat(cmdlet): Get-AnalyticsEventTypes — read-side per-event-type counts (t/2708)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -115,6 +115,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Test-AnalyticsBackend` | Analytics storage round-trip probe — POST synthetic event, wait, GET query, verify event appears; confirms write failures in <60s (t/2668) |
 | `Test-AzureHealth` | Azure infra status |
 | `Test-AnalyticsBlobHealth` | Verify the analytics blob container exists, is accessible, and has recent data (daily NDJSON blobs, event counts, stale-write threshold) |
+| `Get-AnalyticsEventTypes` | Read-side analytics check — per-event-type counts from `GET /api/analytics/query` (surfaces instrumentation gaps like `view.dwell: 0`); `-Days`/`-Env prod\|staging` |
 | `Test-GitHubHealth` | GitHub platform + CI status |
 | `Test-AIApiKey` | Probe AI backend auth endpoints (no tokens consumed) — confirm a key is present and accepted before running jobs |
 | `Test-AIBackendHealth` | Full completion round-trip probe per backend — use before a debate run to surface degraded/unreachable models (t/2212) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -135,6 +135,7 @@
         'Invoke-TaxEditorSmokeTest'
         'Test-AnalyticsBackend'
         'Test-AnalyticsBlobHealth'
+        'Get-AnalyticsEventTypes'
         'Test-AzureHealth'
         'Test-GitHubHealth'
         'Get-TaxEditorRevision'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -854,6 +854,8 @@ Export-ModuleMember -Function @(
     'Test-AnalyticsBackend'
     # t/2702 — analytics blob container health (exists/accessible/recent data)
     'Test-AnalyticsBlobHealth'
+    # t/2708 — analytics read-side: per-event-type counts from the query endpoint
+    'Get-AnalyticsEventTypes'
     'Test-AzureHealth'
     'Test-GitHubHealth'
     'Get-TaxEditorRevision'

--- a/scripts/AITriad/Public/Get-AnalyticsEventTypes.ps1
+++ b/scripts/AITriad/Public/Get-AnalyticsEventTypes.ps1
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-AnalyticsEventTypes {
+    <#
+    .SYNOPSIS
+        Show per-event-type counts from the deployed analytics query endpoint.
+    .DESCRIPTION
+        Read-side analytics diagnostic. Calls GET /api/analytics/query on a deployed
+        taxonomy-editor and returns the aggregated per-event-type counts (the
+        `eventTypes` map — analytics.ts). This is the discriminator that resolved
+        t/2699: it immediately shows, e.g., `tab.switch: 42, view.dwell: 0`, exposing
+        a client instrumentation gap (DwellTracker emitting no view.dwell events)
+        without server-log triage.
+
+        Complements Test-AnalyticsBlobHealth (write path: container reachable, blobs
+        landing) with the read path (what the query endpoint actually aggregates).
+
+        The endpoint is anon-allowed (GET), but in AUTH_OPTIONAL a cookie-less request
+        returns a 200 Sign-In interstitial (t/2683/t/2684), so this establishes an
+        anonymous session first and threads it through the request.
+
+        No AI calls are made — this is a purely offline diagnostic against a deployment.
+    .PARAMETER Days
+        Look-back window in days (maps to the endpoint's from/to range). Default: 7.
+        The server caps aggregation history independently; large windows are fine.
+    .PARAMETER Env
+        Target environment: 'prod' (default) resolves to Get-TaxEditorBaseUrl;
+        'staging' resolves to $env:TAXEDITOR_STAGING_URL. Ignored when -BaseUrl is
+        given explicitly.
+    .PARAMETER BaseUrl
+        Explicit base URL. Overrides -Env. Default: resolved from -Env.
+    .PARAMETER TimeoutSec
+        Per-request timeout. Default: 30.
+    .OUTPUTS
+        [PSCustomObject] rows with EventType and Count (descending by Count).
+    .EXAMPLE
+        Get-AnalyticsEventTypes
+    .EXAMPLE
+        Get-AnalyticsEventTypes -Days 14 -Env staging
+    .EXAMPLE
+        Get-AnalyticsEventTypes | Where-Object Count -eq 0   # instrumentation gaps
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Test-AnalyticsBlobHealth
+    .LINK
+        Test-TaxEditorHealth
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [ValidateRange(1, 365)]
+        [int]$Days = 7,
+
+        [Parameter()]
+        [ValidateSet('prod', 'staging')]
+        [string]$Env = 'prod',
+
+        [Parameter()]
+        [string]$BaseUrl,
+
+        [Parameter()]
+        [ValidateRange(1, 600)]
+        [int]$TimeoutSec = 30
+    )
+
+    Set-StrictMode -Version Latest
+    $CallerName = 'Get-AnalyticsEventTypes'
+
+    # ── Resolve base URL ─────────────────────────────────────────────────
+    if (-not $BaseUrl) {
+        if ($Env -eq 'staging') {
+            $BaseUrl = $env:TAXEDITOR_STAGING_URL
+            if (-not $BaseUrl) {
+                throw (New-ActionableError `
+                    -Goal 'Query analytics event types on staging' `
+                    -Problem 'No staging URL configured (-Env staging)' `
+                    -Location $CallerName `
+                    -NextSteps @('Set $env:TAXEDITOR_STAGING_URL to the staging base URL',
+                                 'Or pass -BaseUrl explicitly'))
+            }
+        }
+        else {
+            $BaseUrl = Get-TaxEditorBaseUrl
+        }
+    }
+    $BaseUrl = $BaseUrl.TrimEnd('/')
+
+    # ── Establish anon session (avoid the AUTH_OPTIONAL interstitial, t/2684) ──
+    $Session = New-AnonymousWebSession -BaseUrl $BaseUrl -TimeoutSec $TimeoutSec
+    if (-not $Session) {
+        Write-Host '  (anonymous session not established — the query may return the auth interstitial)' -ForegroundColor DarkYellow
+    }
+
+    # ── Query the aggregated endpoint ────────────────────────────────────
+    $From = (Get-Date).ToUniversalTime().AddDays(-$Days).ToString('yyyy-MM-dd')
+    $To   = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
+    $Path = "/api/analytics/query?from=$From&to=$To"
+
+    $Params = @{ BaseUrl = $BaseUrl; Path = $Path; Method = 'GET'; TimeoutSec = $TimeoutSec; AcceptableStatusCodes = @(200) }
+    if ($Session) { $Params.Session = $Session }
+    $Check = Invoke-RemoteCheck @Params
+
+    if (-not $Check.Success) {
+        throw (New-ActionableError `
+            -Goal 'Query analytics event types' `
+            -Problem "GET /api/analytics/query failed (status=$($Check.StatusCode))$(if ($Check.Error) { ": $($Check.Error)" })" `
+            -Location $CallerName `
+            -NextSteps @("Verify the deployment is reachable: $BaseUrl",
+                         'Check Test-TaxEditorHealth for liveness/readiness'))
+    }
+
+    if (-not ($Check.Body -and $Check.Body.PSObject.Properties['eventTypes'])) {
+        # A 200 with no eventTypes is the auth interstitial or an unexpected shape.
+        throw (New-ActionableError `
+            -Goal 'Query analytics event types' `
+            -Problem 'Response had no eventTypes field (likely the auth Sign-In interstitial or an unexpected payload)' `
+            -Location $CallerName `
+            -NextSteps @('Confirm the anonymous session was established (re-run; watch for the warning above)',
+                         'Verify /api/analytics/query is anon-allowed on this deployment'))
+    }
+
+    # ── Emit per-event-type rows (descending by count) ───────────────────
+    $Total = 0
+    if ($Check.Body.PSObject.Properties['summary'] -and $Check.Body.summary -and
+        $Check.Body.summary.PSObject.Properties['totalEvents']) {
+        $Total = [int]$Check.Body.summary.totalEvents
+    }
+
+    $Rows = [System.Collections.Generic.List[PSCustomObject]]::new()
+    foreach ($Prop in $Check.Body.eventTypes.PSObject.Properties) {
+        $Rows.Add([PSCustomObject]@{
+            EventType = $Prop.Name
+            Count     = [int]$Prop.Value
+        })
+    }
+    $Sorted = @($Rows | Sort-Object -Property @{ Expression = 'Count'; Descending = $true }, EventType)
+
+    Write-Host "`nAnalytics event types — $BaseUrl ($From..$To)" -ForegroundColor Cyan
+    Write-Host "  $($Sorted.Count) event type(s), $Total event(s) total" -ForegroundColor Gray
+    if ($Sorted.Count -eq 0) {
+        Write-Host '  (no events aggregated in this window)' -ForegroundColor Yellow
+    }
+    Write-Host ''
+
+    $Sorted
+}

--- a/tests/Get-AnalyticsEventTypes.Tests.ps1
+++ b/tests/Get-AnalyticsEventTypes.Tests.ps1
@@ -1,0 +1,115 @@
+# Tag: health (t/2708)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Get-AnalyticsEventTypes (t/2708) — read-side analytics diagnostics.
+.DESCRIPTION
+    Mocks the module-internal Invoke-RemoteCheck and New-AnonymousWebSession so the
+    cmdlet runs offline. Covers the happy path (per-type rows sorted desc, including
+    the zero-count instrumentation-gap discriminator), empty aggregation, a failed
+    query, the auth-interstitial shape (no eventTypes), and staging URL resolution.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-AnalyticsEventTypes' -Tag 'health' {
+
+    BeforeEach {
+        InModuleScope AITriad {
+            Mock New-AnonymousWebSession -MockWith { [Microsoft.PowerShell.Commands.WebRequestSession]::new() }
+            Mock Get-TaxEditorBaseUrl -MockWith { 'https://prod.example' }
+
+            function script:New-RCResult ($Success, $Status, $Body) {
+                [PSCustomObject]@{
+                    Success = $Success; StatusCode = $Status; ResponseMs = 5
+                    Body = $Body; ContentType = 'application/json'; RawBody = ''
+                    Error = $(if (-not $Success) { "HTTP $Status" } else { $null })
+                }
+            }
+        }
+    }
+
+    It 'Returns per-event-type rows sorted by count desc (incl. zero-count gap)' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                New-RCResult $true 200 ([PSCustomObject]@{
+                    summary    = [PSCustomObject]@{ totalEvents = 42 }
+                    eventTypes = [PSCustomObject]@{ 'tab.switch' = 42; 'view.dwell' = 0 }
+                })
+            }
+
+            $rows = @(Get-AnalyticsEventTypes 6>$null)
+
+            $rows.Count | Should -Be 2
+            $rows[0].EventType | Should -Be 'tab.switch'
+            $rows[0].Count     | Should -Be 42
+            ($rows | Where-Object EventType -eq 'view.dwell').Count | Should -Be 0 -Because 'the zero-count discriminator must surface, not be dropped'
+        }
+    }
+
+    It 'Threads an anon session and the from/to window into the query' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                New-RCResult $true 200 ([PSCustomObject]@{
+                    summary    = [PSCustomObject]@{ totalEvents = 1 }
+                    eventTypes = [PSCustomObject]@{ 'tab.switch' = 1 }
+                })
+            }
+
+            Get-AnalyticsEventTypes -Days 14 6>$null | Out-Null
+
+            Should -Invoke New-AnonymousWebSession -Times 1 -Exactly
+            Should -Invoke Invoke-RemoteCheck -Times 1 -Exactly -ParameterFilter {
+                $Path -like '/api/analytics/query?from=*&to=*' -and $null -ne $Session
+            }
+        }
+    }
+
+    It 'Empty aggregation → no rows, does not throw' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                New-RCResult $true 200 ([PSCustomObject]@{
+                    summary    = [PSCustomObject]@{ totalEvents = 0 }
+                    eventTypes = [PSCustomObject]@{}
+                })
+            }
+
+            $rows = @(Get-AnalyticsEventTypes 6>$null)
+            $rows.Count | Should -Be 0
+        }
+    }
+
+    It 'Failed query → throws ActionableError' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith { New-RCResult $false 502 $null }
+            { Get-AnalyticsEventTypes 6>$null } | Should -Throw
+        }
+    }
+
+    It 'Auth interstitial (200, no eventTypes) → throws ActionableError' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith { New-RCResult $true 200 ([PSCustomObject]@{ note = 'sign-in' }) }
+            { Get-AnalyticsEventTypes 6>$null } | Should -Throw
+        }
+    }
+
+    It '-Env staging without a configured URL → throws ActionableError' {
+        InModuleScope AITriad {
+            $saved = $env:TAXEDITOR_STAGING_URL
+            Remove-Item Env:\TAXEDITOR_STAGING_URL -ErrorAction SilentlyContinue
+            try {
+                { Get-AnalyticsEventTypes -Env staging 6>$null } | Should -Throw
+            }
+            finally {
+                if ($null -ne $saved) { $env:TAXEDITOR_STAGING_URL = $saved }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What
New public cmdlet `Get-AnalyticsEventTypes [-Days <int>] [-Env prod|staging] [-BaseUrl <url>]` (t/2708). Calls `GET /api/analytics/query` on a deployed taxonomy-editor and returns aggregated per-event-type counts (the `eventTypes` map) as rows sorted by count desc.

## Why
This is the t/2699 discriminator — it immediately shows e.g. `tab.switch: 42, view.dwell: 0`, exposing a client instrumentation gap (DwellTracker emitting no `view.dwell`) without server-log triage. Completes the diagnostic pair with `Test-AnalyticsBlobHealth` (write path) that Diagnostics called out.

## Design
- Establishes an anon session first (t/2684: cookie-less GET hits the AUTH_OPTIONAL Sign-In interstitial) and threads it + a `from`/`to` window (`-Days`) through the request.
- `-Env prod` → `Get-TaxEditorBaseUrl`; `-Env staging` → `$env:TAXEDITOR_STAGING_URL`; `-BaseUrl` overrides. Never guesses a staging URL — errors actionably if unconfigured.
- Actionable errors on failed query, missing `eventTypes` (interstitial/unexpected shape), and unconfigured staging URL.

## Playbook
Followed `/add-ps-cmdlet` — **no deviations**. Registered in both `AITriad.psd1` + `AITriad.psm1`; `New-ActionableError`; StrictMode-safe; added to `docs/cmdlet-reference.md`.

## Tests
`tests/Get-AnalyticsEventTypes.Tests.ps1` (anon session + Invoke-RemoteCheck mocked): sorted rows incl. the zero-count gap, session+window threading, empty aggregation, failed query, interstitial shape, staging-URL-unconfigured. 6/6 green. Export-sync + manifest green.

Closes t/2708. 🤖 Generated with [Claude Code](https://claude.com/claude-code)