### PR TITLE
obs(analytics): startup probe of analytics store + FR event on failure (t/2704)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/analytics.probe.test.ts
+++ b/taxonomy-editor/src/server/__tests__/analytics.probe.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+//
+// t/2704 — startup analytics store probe. BlobAnalyticsBackend.probe() surfaces an
+// inaccessible or missing container by THROWING (unlike listDates, which swallows and
+// returns [] — indistinguishable from "empty"). reportStartupProbe() runs at boot: it
+// logs init, probes, and on failure logs error + emits a flight-recorder system.error —
+// so a broken or empty analytics pipeline is observable immediately instead of surfacing
+// later as a silent empty dashboard (t/2699).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlobServiceClient } from '@azure/storage-blob';
+import { BlobAnalyticsBackend } from '../storage/analyticsBlob.js';
+import { initAnalytics, reportStartupProbe } from '../community/analytics.js';
+import { log } from '../logger.js';
+
+const rec = vi.hoisted(() => ({ record: vi.fn() }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: rec.record }),
+}));
+
+interface FakeOpts {
+  exists?: boolean | (() => Promise<boolean>);
+  blobs?: string[];
+}
+function makeFakeServiceClient(opts: FakeOpts = {}): BlobServiceClient {
+  const blobs = opts.blobs ?? [];
+  const fakeContainerClient = {
+    containerName: 'analytics',
+    exists: vi.fn(() => (typeof opts.exists === 'function' ? opts.exists() : Promise.resolve(opts.exists ?? true))),
+    async *listBlobsFlat() { for (const name of blobs) yield { name }; },
+    getAppendBlobClient: vi.fn(),
+    getBlobClient: vi.fn().mockReturnValue({ delete: vi.fn().mockResolvedValue({}) }),
+  };
+  return { getContainerClient: vi.fn().mockReturnValue(fakeContainerClient) } as unknown as BlobServiceClient;
+}
+
+const blobCfg = (svc: BlobServiceClient) => ({
+  accountUrl: 'https://test.blob.core.windows.net',
+  container: 'analytics',
+  serviceClient: svc,
+});
+
+describe('BlobAnalyticsBackend.probe (t/2704)', () => {
+  it('resolves when the container exists', async () => {
+    const backend = new BlobAnalyticsBackend(blobCfg(makeFakeServiceClient({ exists: true })));
+    await expect(backend.probe()).resolves.toBeUndefined();
+  });
+
+  it('throws when the container is missing (exists=false)', async () => {
+    const backend = new BlobAnalyticsBackend(blobCfg(makeFakeServiceClient({ exists: false })));
+    await expect(backend.probe()).rejects.toThrow(/container not found/);
+  });
+
+  it('propagates an auth/network failure (exists rejects — the case listDates would swallow)', async () => {
+    const svc = makeFakeServiceClient({ exists: () => Promise.reject(new Error('403 AuthorizationFailure')) });
+    const backend = new BlobAnalyticsBackend(blobCfg(svc));
+    await expect(backend.probe()).rejects.toThrow(/AuthorizationFailure/);
+  });
+});
+
+describe('reportStartupProbe (t/2704)', () => {
+  beforeEach(() => { rec.record.mockClear(); vi.restoreAllMocks(); });
+
+  it('logs "probe OK" and emits no error when the store is reachable with data', async () => {
+    const infoSpy = vi.spyOn(log.analytics, 'info').mockImplementation(() => log.analytics);
+    const errSpy = vi.spyOn(log.analytics, 'error').mockImplementation(() => log.analytics);
+    await initAnalytics('/unused', blobCfg(makeFakeServiceClient({ exists: true, blobs: ['2026-08-15.ndjson'] })));
+    await reportStartupProbe('azure-blob', 'analytics');
+    expect(infoSpy).toHaveBeenCalledWith(expect.objectContaining({ dateCount: 1 }), 'Analytics store probe OK');
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(rec.record).not.toHaveBeenCalled();
+  });
+
+  it('warns (not errors) when the store is reachable but empty', async () => {
+    const warnSpy = vi.spyOn(log.analytics, 'warn').mockImplementation(() => log.analytics);
+    vi.spyOn(log.analytics, 'info').mockImplementation(() => log.analytics);
+    const errSpy = vi.spyOn(log.analytics, 'error').mockImplementation(() => log.analytics);
+    await initAnalytics('/unused', blobCfg(makeFakeServiceClient({ exists: true, blobs: [] })));
+    await reportStartupProbe('azure-blob', 'analytics');
+    expect(warnSpy).toHaveBeenCalledWith(expect.objectContaining({ dateCount: 0 }), 'Analytics store reachable but contains no data');
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(rec.record).not.toHaveBeenCalled();
+  });
+
+  it('logs error + emits a system.error FR when the container is inaccessible', async () => {
+    vi.spyOn(log.analytics, 'info').mockImplementation(() => log.analytics);
+    const errSpy = vi.spyOn(log.analytics, 'error').mockImplementation(() => log.analytics);
+    await initAnalytics('/unused', blobCfg(makeFakeServiceClient({ exists: false })));
+    await reportStartupProbe('azure-blob', 'analytics');
+    expect(errSpy).toHaveBeenCalledWith(expect.objectContaining({ container: 'analytics' }), expect.stringMatching(/probe failed/));
+    expect(rec.record).toHaveBeenCalledWith(expect.objectContaining({ message: 'Analytics store startup probe failed' }));
+  });
+});

--- a/taxonomy-editor/src/server/community/analytics.ts
+++ b/taxonomy-editor/src/server/community/analytics.ts
@@ -15,6 +15,7 @@ import fs from 'fs';
 import path from 'path';
 import { getConfig } from '../runtimeConfig.js';
 import { log } from '../logger.js';
+import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 
 // ── Types ──
 
@@ -79,6 +80,12 @@ export interface AnalyticsBackend {
   readLines(date: string): Promise<string[]>;
   listDates(): Promise<string[]>;
   prune(cutoffDate: string): Promise<void>;
+  /**
+   * t/2704: startup health probe. Surfaces backend inaccessibility by THROWING —
+   * unlike listDates()/readLines(), which swallow errors and return [] (so they can't
+   * distinguish "broken" from "empty"). Resolves when the store is reachable.
+   */
+  probe(): Promise<void>;
 }
 
 export interface AnalyticsBlobConfig {
@@ -125,6 +132,12 @@ class FsAnalyticsBackend implements AnalyticsBackend {
       }
     } catch { /* telemetry — silent by design;  best-effort cleanup */ }
   }
+
+  async probe(): Promise<void> {
+    // The constructor already mkdir -p'd the dir; a readdir confirms it is accessible.
+    // Unlike listDates() this does NOT swallow — an inaccessible dir throws.
+    await fs.promises.readdir(this.dir);
+  }
 }
 
 // ── Module state ──
@@ -151,6 +164,45 @@ export async function initAnalytics(dataRoot: string, blobConfig?: AnalyticsBlob
     backend = new FsAnalyticsBackend(path.join(dataRoot, 'analytics'));
   }
   await backend.prune(cutoffStr());
+}
+
+/**
+ * Startup health report (t/2704). Exercises the analytics backend so a broken or empty
+ * pipeline is observable at startup instead of surfacing later as a silently empty
+ * dashboard (t/2699). `backend.probe()` throws on inaccessibility (auth/network/missing
+ * container) → logged at error + a flight-recorder `system.error`. A reachable store then
+ * reports its partition count, so "reachable but empty" — the state that masquerades as
+ * broken — is a distinct warn, not an error. Called once, right after initAnalytics.
+ */
+export async function reportStartupProbe(backendKind: string, container: string): Promise<void> {
+  log.analytics.info({ backend: backendKind }, 'Analytics initialized');
+  if (!backend) {
+    log.analytics.error({ backend: backendKind, container }, 'Analytics store startup probe: backend not initialized');
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'analytics', level: 'error',
+      message: 'Analytics store not initialized at startup probe',
+      data: { backend: backendKind, container },
+    });
+    return;
+  }
+  try {
+    await backend.probe();
+  } catch (err) {
+    log.analytics.error({ backend: backendKind, container, err }, 'Analytics store startup probe failed — pipeline may be broken');
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'analytics', level: 'error',
+      message: 'Analytics store startup probe failed',
+      data: { backend: backendKind, container },
+      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+    });
+    return;
+  }
+  const dates = await backend.listDates();
+  if (dates.length === 0) {
+    log.analytics.warn({ backend: backendKind, dateCount: 0 }, 'Analytics store reachable but contains no data');
+  } else {
+    log.analytics.info({ backend: backendKind, dateCount: dates.length }, 'Analytics store probe OK');
+  }
 }
 
 /** Append a batch of events. Fire-and-forget safe — errors are recorded, not thrown. */

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -1461,9 +1461,9 @@ server.listen(PORT, BIND_HOST, () => {
   analytics.initAnalytics(
     getStateRoot(), // t/2643: analytics NDJSON is class-A writable state — isolate the fs-fallback root by construction (not by AZURE_STORAGE_ACCOUNT_URL being set). No-op on prod (stateRoot===dataRoot).
     analyticsBlobUrl ? { accountUrl: analyticsBlobUrl, container: analyticsContainer } : undefined,
-  ).then(() => {
-    log.analytics.info({ backend: analyticsBlobUrl ? 'azure-blob' : 'filesystem' }, 'Analytics initialized');
-  }).catch((e) => { /* telemetry — silent by design */ log.analytics.warn({ err: e }, 'Analytics init failed'); });
+    // t/2704: reportStartupProbe logs "initialized" then probes the store, so a broken/empty pipeline is observable at boot (would have surfaced t/2699) instead of as a silent empty dashboard.
+  ).then(() => analytics.reportStartupProbe(analyticsBlobUrl ? 'azure-blob' : 'filesystem', analyticsContainer))
+    .catch((e) => { /* telemetry — silent by design */ log.analytics.warn({ err: e }, 'Analytics init failed'); });
 
   if (githubBackend) {
     // Initialize GitHubAPIBackend (token + cache check) AFTER health check is

--- a/taxonomy-editor/src/server/storage/analyticsBlob.ts
+++ b/taxonomy-editor/src/server/storage/analyticsBlob.ts
@@ -106,6 +106,16 @@ export class BlobAnalyticsBackend implements AnalyticsBackend {
     return dates;
   }
 
+  async probe(): Promise<void> {
+    // t/2704: container `exists()` surfaces auth/network failures by THROWING (unlike
+    // listDates, which swallows). A reachable-but-missing container returns false —
+    // also fatal to the analytics pipeline — so treat it as an error too.
+    const exists = await this.client.exists();
+    if (!exists) {
+      throw new Error(`analytics container not found: ${this.client.containerName}`);
+    }
+  }
+
   async prune(cutoffDate: string): Promise<void> {
     try {
       const dates = await this.listDates();


### PR DESCRIPTION
Closes t/2704. Non-swallowing startup probe so a broken/empty analytics pipeline is observable at boot (t/2699 had no such signal).

- `AnalyticsBackend.probe()` throws on inaccessibility. Fs: readdir. Blob: container `exists()` (surfaces auth/network by throwing; missing container = error). Deliberately unlike `listDates()`, which swallows → returns [] (can't tell broken from empty).
- `reportStartupProbe(backend, container)` runs after initAnalytics: logs init, probes, and on failure logs error + emits a flight-recorder `system.error` (recorded in-catch). Reachable-but-empty is a distinct **warn**, not an error.
- server.ts wires it in the existing `initAnalytics().then()` — **net-zero lines** (server.ts is at the ADR-007 1500 cap; reporting lives in analytics.ts).

Test (6/6): probe() resolves/throws/propagates-auth-failure; reportStartupProbe logs OK-with-data, warns-on-empty, errors+FR on inaccessible. server tsc 0, eslint 0 errors. Complementary to DevOps's on-demand `Test-AnalyticsBlobHealth` (t/2702). Self-cert: additive observability. Scope: server is CLAUDE.md-owned; TL-implemented, flagged for owner awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)