### PR TITLE
fix(debate): land v2 AFFECT_PHASE_BASELINES from t/2680 pruned-lexicon fit (t/2712)

### DIFF
--- a/lib/debate/affectSignals.ts
+++ b/lib/debate/affectSignals.ts
@@ -66,15 +66,14 @@ export const AFFECT_SATURATION_RATE: Record<AffectCategory, number> = {
   empathy: 4.0,
 };
 
-// Provisional fit from t/1771 + research/comp-linguist/analyses/t1771-affect/provisional-fit.md.
-// Replaces the pre-fit stipulated vector that made the 0.60 target unreachable (ceiling 0.580,
-// 100% of real turns below). Refit → median affect_appropriateness 0.40→0.63. Row stays
-// stipulated (provisional). Values from runs after this land are NOT comparable to the interim
-// post-t/1785 window. MAX_ACCEPTABLE_DEVIATION (0.35) is unchanged.
+// v2 fit from t/2680 + analyses/t1771-affect/provisional-fit-v2.md (66-debate pruned-lexicon corpus).
+// conf/arg re-fit on the pruned lexicon (t/2677); concluding unchanged — 0 concluding turns in corpus,
+// still provisional. Third non-comparability cutover for affect_appropriateness (post-t/2680).
+// Values stay provisional (not derived). MAX_ACCEPTABLE_DEVIATION (0.35) unchanged.
 export const AFFECT_PHASE_BASELINES: Record<Exclude<DebatePhase, 'terminated'>, AffectProfile> = {
-  confrontation: { urgency: 0.06, fear: 0.36, hope: 0.09, outrage: 0.10, empathy: 0.40 },
-  argumentation: { urgency: 0.07, fear: 0.39, hope: 0.09, outrage: 0.08, empathy: 0.37 },
-  concluding:    { urgency: 0.09, fear: 0.30, hope: 0.10, outrage: 0.11, empathy: 0.40 },
+  confrontation: { urgency: 0.18, fear: 0.39, hope: 0.16, outrage: 0.09, empathy: 0.18 },
+  argumentation: { urgency: 0.19, fear: 0.37, hope: 0.23, outrage: 0.06, empathy: 0.15 },
+  concluding:    { urgency: 0.09, fear: 0.30, hope: 0.10, outrage: 0.11, empathy: 0.40 }, // UNCHANGED — no corpus data (0 concluding turns); still provisional
 };
 
 const INTENSITY_WEIGHTS: Record<AffectCategory, number> = {


### PR DESCRIPTION
## Summary
- Update `confrontation` and `argumentation` vectors in `AFFECT_PHASE_BASELINES` to v2 fit values from 66-debate pruned-lexicon corpus (t/2680)
- `concluding` unchanged — 0 concluding turns in corpus, still provisional
- Block comment updated: v2 fit pointer, third non-comparability cutover note, provisional status
- No formula/threshold changes; pure value + comment edit

## Test plan
- [ ] CI vitest green
- [ ] Degeneracy re-check already passed (recorded in t/2680#7 / CL analysis)

Related: t/2712, parent t/2680, CL analysis PR #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)