### PR TITLE
fix(debate): remove duplicate CLI cal-log write — engine is sole writer (t/2716)

### DIFF
--- a/lib/debate/cli.ts
+++ b/lib/debate/cli.ts
@@ -628,23 +628,8 @@ async function main(): Promise<void> {
     writeOutput(explorationDiagPath, JSON.stringify(buildDiagnosticsOutput(explorationSession), null, 2), 'exploration diagnostics');
   }
 
-  // Log calibration data point (non-blocking)
-  try {
-    const { extractCalibrationData, appendCalibrationLog } = await import('./calibrationLogger.js');
-    // When outputDir is explicitly configured, write the cal log inside it so
-    // experimental/isolated runs don't contaminate the main data-root log (t/2216).
-    // path.dirname(outputDir) would still land in the main data root when the
-    // scratch dir is a direct child of it (e.g. ../ai-triad-data/debates-t2192).
-    const calDataRoot = config.outputDir != null ? outputDir : dataRoot;
-    const dataPoint = extractCalibrationData(session, 'local', {
-      explorationSummary: engineConfig.explorationSummary,
-    });
-    appendCalibrationLog(dataPoint, calDataRoot);
-    log(`Calibration data logged to ${calDataRoot}/calibration/users/${dataPoint.origin || 'local'}/calibration-log.jsonl`);
-  } catch (err) {
-    getGlobalRecorder()?.record({ type: 'system.error', component: 'cli', level: 'warn', message: 'Calibration logging failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-    log(`Calibration logging failed (non-critical): ${err instanceof Error ? err.message : err}`);
-  }
+  // Calibration data is written by the engine (debateEngine.ts) using calibrationDataRoot.
+  // The CLI previously wrote a second identical copy here (t/2716); removed — one write per debate.
 
   // Dump flight recorder to output directory
   const recorderDump = recorder.dumpToFile(path.join(outputDir, `${slug}-flight-recorder.jsonl`));

--- a/lib/debate/debateEngine.calIsolation.test.ts
+++ b/lib/debate/debateEngine.calIsolation.test.ts
@@ -45,7 +45,7 @@ describe('DebateEngine calibrationDataRoot isolation (t/2219)', () => {
     await engine.run();
 
     const mockFn = vi.mocked(appendCalibrationLog);
-    expect(mockFn).toHaveBeenCalled();
+    expect(mockFn).toHaveBeenCalledTimes(1); // exactly one write per debate (t/2716)
     expect(mockFn.mock.calls[0][1]).toBe(calRoot);
   });
 
@@ -55,7 +55,7 @@ describe('DebateEngine calibrationDataRoot isolation (t/2219)', () => {
     await engine.run();
 
     const mockFn = vi.mocked(appendCalibrationLog);
-    expect(mockFn).toHaveBeenCalled();
+    expect(mockFn).toHaveBeenCalledTimes(1); // exactly one write per debate (t/2716)
     // Must be a non-empty filesystem path — not '/isolated/cal-root'
     const calledRoot = mockFn.mock.calls[0][1];
     expect(typeof calledRoot).toBe('string');


### PR DESCRIPTION
## Summary
- `cli.ts` was writing a second identical calibration row per debate after t/2219 made the engine also write — the t/2219 routing fix left both writers active
- Remove the CLI `appendCalibrationLog` block; `debateEngine.ts:658` is the sole authoritative writer
- Tighten `debateEngine.calIsolation.test.ts` to `toHaveBeenCalledTimes(1)` as regression guard

## Test plan
- [ ] `debateEngine.calIsolation.test.ts` passes (toHaveBeenCalledTimes(1) guard)
- [ ] CI vitest green
- [ ] Post-merge: 1-debate isolated run yields 1 row in core + users cal-log (AC1)

Closes t/2716.

🤖 Generated with [Claude Code](https://claude.com/claude-code)