### PR TITLE
feat(opeds): hide unused taxonomy-grounding rows behind a toggle (t/2703 Part 2)

### DIFF
--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
@@ -60,7 +60,7 @@ describe('OpEdReader — single voice', () => {
     expect(screen.getByText('Grounds the claim')).toBeTruthy();
   });
 
-  it('drops the Type column and sinks "not directly used" rows to the bottom', () => {
+  it('drops the Type column and hides "not directly used" rows behind a toggle (t/2703)', () => {
     render(<OpEdReader set={makeSet([member({
       grounding: [
         { node_id: 'acc-belief-001', label: 'Unused', category: 'Belief', pov: 'accelerationist', relevance: '0.15', how_reflected: 'not directly used' },
@@ -69,10 +69,22 @@ describe('OpEdReader — single voice', () => {
     })])} />);
     // Type column is gone (Element / Relevance / Reflected only).
     expect(screen.queryByRole('columnheader', { name: 'Type' })).toBeNull();
-    // The reflected row sorts ABOVE the 'not directly used' row despite lower list position.
-    const used = screen.getByRole('button', { name: 'saf-belief-014' });
-    const unused = screen.getByRole('button', { name: 'acc-belief-001' });
-    expect(used.compareDocumentPosition(unused) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // The used row shows; the 'not directly used' row is hidden by default.
+    expect(screen.getByRole('button', { name: 'saf-belief-014' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'acc-belief-001' })).toBeNull();
+    // The toggle reveals the hidden row…
+    fireEvent.click(screen.getByRole('button', { name: /show 1 unused element/i }));
+    expect(screen.getByRole('button', { name: 'acc-belief-001' })).toBeTruthy();
+    // …and toggling again re-hides it.
+    fireEvent.click(screen.getByRole('button', { name: /hide 1 unused element/i }));
+    expect(screen.queryByRole('button', { name: 'acc-belief-001' })).toBeNull();
+  });
+
+  it('shows no unused-toggle when every element is reflected (t/2703)', () => {
+    render(<OpEdReader set={makeSet([member({
+      grounding: [{ node_id: 'saf-belief-014', label: 'Used', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim' }],
+    })])} />);
+    expect(screen.queryByRole('button', { name: /unused element/i })).toBeNull();
   });
 });
 

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -90,6 +90,7 @@ function GroundingDetailCard({ ref, onClose }: { ref: OpEdGroundingRef; onClose:
 
 function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [showUnused, setShowUnused] = useState(false);
 
   useEffect(() => {
     if (!expandedId) return;
@@ -102,13 +103,14 @@ function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
     return <p className="oped-voice-only">Written from voice alone (no taxonomy grounding).</p>;
   }
 
-  const expandedRef = grounding.find(g => g.node_id === expandedId) ?? null;
+  // t/2703: elements the AI judged 'not directly used' are noise by default — partition
+  // them out and reveal on demand via the toggle below. Used rows keep their (relevance) order.
+  const used = grounding.filter(g => g.how_reflected !== 'not directly used');
+  const unused = grounding.filter(g => g.how_reflected === 'not directly used');
+  const visible = showUnused ? [...used, ...unused] : used;
 
-  // Elements the AI didn't reflect ('not directly used') sink to the bottom; everything
-  // else keeps its existing (relevance) order — a stable partition (Array.sort is stable).
-  const orderedGrounding = [...grounding].sort(
-    (a, b) => Number(a.how_reflected === 'not directly used') - Number(b.how_reflected === 'not directly used'),
-  );
+  // Only a visible row can stay expanded — hiding the unused set closes any card it owned.
+  const expandedRef = visible.find(g => g.node_id === expandedId) ?? null;
 
   return (
     <details className="oped-grounding" open>
@@ -124,7 +126,7 @@ function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
             </tr>
           </thead>
           <tbody>
-            {orderedGrounding.map(g => {
+            {visible.map(g => {
               const isOpen = g.node_id === expandedId;
               return (
                 <tr key={g.node_id} className={isOpen ? 'oped-grounding-row-active' : ''}>
@@ -147,6 +149,16 @@ function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
           </tbody>
         </table>
       </div>
+      {unused.length > 0 && (
+        <button
+          type="button"
+          className="oped-grounding-toggle-unused"
+          aria-expanded={showUnused}
+          onClick={() => setShowUnused(v => !v)}
+        >
+          {showUnused ? 'Hide' : 'Show'} {unused.length} unused element{unused.length !== 1 ? 's' : ''}
+        </button>
+      )}
       {expandedRef && <GroundingDetailCard ref={expandedRef} onClose={() => setExpandedId(null)} />}
     </details>
   );


### PR DESCRIPTION
Part 2 of t/2703. The Op-Ed Taxonomy Grounding table showed every grounded element (only sinking 'not directly used' ones to the bottom); now used elements render by default and unused ones hide behind a **Show N unused element(s)** toggle (re-hides on second click; no toggle when all reflected).

Renderer-only (`OpEdReader.tsx` GroundingSection): partition used vs 'not directly used', render `visible = showUnused ? all : used`, derive the expanded card from `visible` so hiding also closes any open card. Relevance/reflected columns + inline expand unchanged. Test updated (13/13); renderer tsc 0, eslint 0.

**Part 1 (sub-children linking each element to source claims) is deliberately NOT here** — the op-ed data model has no node→source-claims linkage and FromTopic op-eds have no source claims at all; it needs a generation-pipeline change gated on FromSource op-eds (t/2604 P2). Deferred with rationale + follow-up on t/2703.

Self-cert: UI-only, single-scope, no new API/schema/cross-role interface. Scope: renderer is CLAUDE.md-owned; TL-implemented, flagged for owner awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)