### PR TITLE
fix(devops): remove Arm-A probe container from deploy-azure.yml (t/2701)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -315,7 +315,7 @@ jobs:
           # SYNC WITH main.bicep: analyticsContainer, stagingAnalyticsContainer,
           # userContentContainer, stagingUserContentContainer, communityContainer,
           # stagingCommunityContainer. Update both if a container is added or removed.
-          $Containers = @('analytics', 'staging-analytics', 'user-content', 'staging-user-content', 'community', 'staging-community', 'does-not-exist-gatecheck')
+          $Containers = @('analytics', 'staging-analytics', 'user-content', 'staging-user-content', 'community', 'staging-community')
           $Failed = @()
           foreach ($c in $Containers) {
             $null = az storage container show --account-name $StorageAccount --name $c --auth-mode login --output none 2>&1


### PR DESCRIPTION
## Summary

- Removes `does-not-exist-gatecheck` from `$Containers` in the blob gate step — this was a temporary test entry merged via PR #1140 as the Arm-A warn-cycle probe
- Arm-A evidence already captured (run 31968721919): all 6 real containers `[OK]`, warning fired correctly for the bogus name, pipeline stayed green with `continue-on-error: true`
- This cleanup restores main to the production-correct 6-container list

## Test plan

- [ ] CI green
- [ ] Deploy from this branch (Arm-B): confirms zero blob gate warnings on clean container list

🤖 Generated with [Claude Code](https://claude.com/claude-code)