### PR TITLE
test(cl): commit t/1075 Phase A debate configs (durable)

### DIFF
--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-liability-regime.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-liability-regime.json
@@ -1,0 +1,13 @@
+{
+  "topic": "Should liability for AI-caused harms follow strict liability or negligence standards?",
+  "name": "exp1075-ctrl-liability-regime",
+  "model": "claude-opus-4-8",
+  "stageModels": {
+    "evaluator": "claude-opus-4-8"
+  },
+  "useAdaptiveStaging": true,
+  "pacing": "moderate",
+  "outputFormat": "all",
+  "throttleMs": 2000,
+  "outputDir": "C:/tmp/exp1075-out"
+}

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-safety-sharing.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-safety-sharing.json
@@ -1,0 +1,13 @@
+{
+  "topic": "Should frontier AI labs be required to share safety research?",
+  "name": "exp1075-ctrl-safety-sharing",
+  "model": "claude-opus-4-8",
+  "stageModels": {
+    "evaluator": "claude-opus-4-8"
+  },
+  "useAdaptiveStaging": true,
+  "pacing": "moderate",
+  "outputFormat": "all",
+  "throttleMs": 2000,
+  "outputDir": "C:/tmp/exp1075-out"
+}

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-siloed-datasets.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-siloed-datasets.json
@@ -1,0 +1,13 @@
+{
+  "topic": "To what extent and under what specific regulatory and technological conditions would a Congressional mandate, targeting large language model providers like OpenAI and Google and enforced by agencies such as the FTC or NIST, for the utilization of siloed datasets\u2014defined as restricted access tiers where models train on specific information without cross-referencing external user data\u2014effectively mitigate unauthorized data exfiltration and corporate surveillance?",
+  "name": "exp1075-ctrl-siloed-datasets",
+  "model": "claude-opus-4-8",
+  "stageModels": {
+    "evaluator": "claude-opus-4-8"
+  },
+  "useAdaptiveStaging": true,
+  "pacing": "moderate",
+  "outputFormat": "all",
+  "throttleMs": 2000,
+  "outputDir": "C:/tmp/exp1075-out"
+}

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-liability-regime.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-liability-regime.json
@@ -1,0 +1,13 @@
+{
+  "topic": "Should liability for AI-caused harms follow strict liability or negligence standards?",
+  "name": "exp1075-treat-liability-regime",
+  "model": "claude-opus-4-8",
+  "stageModels": {
+    "evaluator": "gemini-3.5-flash-lite"
+  },
+  "useAdaptiveStaging": true,
+  "pacing": "moderate",
+  "outputFormat": "all",
+  "throttleMs": 2000,
+  "outputDir": "C:/tmp/exp1075-out"
+}

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-safety-sharing.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-safety-sharing.json
@@ -1,0 +1,13 @@
+{
+  "topic": "Should frontier AI labs be required to share safety research?",
+  "name": "exp1075-treat-safety-sharing",
+  "model": "claude-opus-4-8",
+  "stageModels": {
+    "evaluator": "gemini-3.5-flash-lite"
+  },
+  "useAdaptiveStaging": true,
+  "pacing": "moderate",
+  "outputFormat": "all",
+  "throttleMs": 2000,
+  "outputDir": "C:/tmp/exp1075-out"
+}

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-siloed-datasets.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-siloed-datasets.json
@@ -1,0 +1,13 @@
+{
+  "topic": "To what extent and under what specific regulatory and technological conditions would a Congressional mandate, targeting large language model providers like OpenAI and Google and enforced by agencies such as the FTC or NIST, for the utilization of siloed datasets\u2014defined as restricted access tiers where models train on specific information without cross-referencing external user data\u2014effectively mitigate unauthorized data exfiltration and corporate surveillance?",
+  "name": "exp1075-treat-siloed-datasets",
+  "model": "claude-opus-4-8",
+  "stageModels": {
+    "evaluator": "gemini-3.5-flash-lite"
+  },
+  "useAdaptiveStaging": true,
+  "pacing": "moderate",
+  "outputFormat": "all",
+  "throttleMs": 2000,
+  "outputDir": "C:/tmp/exp1075-out"
+}


### PR DESCRIPTION
The 6 evaluatorModel-substitution configs for t/1075 Phase A (3 control + 3 treatment, Opus-4.8 main) were left **untracked** in the shared checkout and got git-cleaned mid-run — debate 1 read them, then debates 2–6 failed because the dir was gone. Committing them so the experiment is reproducible and the ~6-hr Opus run can't be wiped again.

No code; data-only. Refs t/1075 (parent t/1069).

🤖 Generated with [Claude Code](https://claude.com/claude-code)