### PR TITLE
feat(devops): promote blob container gate to blocking (t/2701)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -307,6 +307,7 @@ jobs:
         run: |
           $StorageAccount = '${{ steps.deploy.outputs.storageAccountName }}'
           $Containers = @('analytics', 'staging-analytics', 'user-content', 'staging-user-content', 'community', 'staging-community')
+          if ($Containers.Count -ne 6) { throw "Container list sync error: expected 6, got $($Containers.Count). Update workflow and main.bicep together." }
           $Failed = @()
           foreach ($c in $Containers) {
             $null = az storage container show --account-name $StorageAccount --name $c --auth-mode login --output none 2>&1

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -299,36 +299,26 @@ jobs:
       # target below — and, with the pin, that revision holds 100% throughout the
       # deploy, so it can never drop to 0% / go stale / be GC'd mid-deploy (t/2047).
 
-      # t/2701: WARN-ONLY (Gate Promotion cycle). This step runs non-blocking for ≥1
-      # real-env green deploy to prove: (a) --auth-mode login works for the CI SP
-      # (data-plane RBAC check), (b) gate fires correctly on absence (Arm-A), and
-      # (c) gate is silent on a clean deploy (Arm-B). A follow-up PR flips it to
-      # blocking once all three are confirmed. Keep in sync with the container
-      # resources in deploy/azure/main.bicep (6 containers: analytics,
-      # staging-analytics, user-content, staging-user-content, community,
-      # staging-community). Adding a container there requires adding it here.
-      - name: Verify blob containers exist post-deploy (warn-only)
+      # SYNC WITH main.bicep: analyticsContainer, stagingAnalyticsContainer,
+      # userContentContainer, stagingUserContentContainer, communityContainer,
+      # stagingCommunityContainer. Update both if a container is added or removed.
+      - name: Verify blob containers exist post-deploy
         shell: pwsh
-        continue-on-error: true
         run: |
           $StorageAccount = '${{ steps.deploy.outputs.storageAccountName }}'
-          # SYNC WITH main.bicep: analyticsContainer, stagingAnalyticsContainer,
-          # userContentContainer, stagingUserContentContainer, communityContainer,
-          # stagingCommunityContainer. Update both if a container is added or removed.
           $Containers = @('analytics', 'staging-analytics', 'user-content', 'staging-user-content', 'community', 'staging-community')
           $Failed = @()
           foreach ($c in $Containers) {
             $null = az storage container show --account-name $StorageAccount --name $c --auth-mode login --output none 2>&1
             if ($LASTEXITCODE -ne 0) {
-              Write-Host "::warning::Blob container '$c' missing or inaccessible after Bicep deploy (storageAccount=$StorageAccount) — warn-only (t/2701 Gate Promotion)"
+              Write-Host "::error::Blob container '$c' missing or inaccessible after Bicep deploy (storageAccount=$StorageAccount)"
               $Failed += $c
             } else {
               Write-Host "  [OK] $c"
             }
           }
           if ($Failed.Count -gt 0) {
-            Write-Host "::warning::Post-deploy blob container check: $($Failed.Count) container(s) missing — $($Failed -join ', ') (warn-only; will block after Gate Promotion)"
-            exit 1
+            throw "Post-deploy blob container check FAILED: $($Failed.Count) container(s) missing — $($Failed -join ', ')"
           }
           Write-Host "All $($Containers.Count) blob containers verified."
 


### PR DESCRIPTION
## Summary

Promotes the post-deploy blob container verification gate from warn-only to blocking, completing the Gate Promotion cycle for t/2701.

**Gate Promotion evidence (e/105#6):**
- **Arm-A** (run 31968721919): `::warning::` fired correctly for `does-not-exist-gatecheck`, all 6 real containers `[OK]`, pipeline stayed green (`continue-on-error` worked)
- **Arm-B** (run 31972328065): zero warnings, `All 6 blob containers verified.`, clean deploy

**Changes:**
- `continue-on-error: true` removed (gate now blocks on failure)
- `::warning::` → `::error::` + `throw` (hard failure)
- Step name: `Verify blob containers exist post-deploy (warn-only)` → `Verify blob containers exist post-deploy`
- Gate Promotion comment block removed (fulfilled)
- SYNC comment moved to step header

## Test plan

- [ ] CI green
- [ ] TL Gate Verification (both arms documented in e/105#6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)