### PR TITLE
feat(devops): add stagingSharedReadOnly dispatch input to deploy-azure.yml (t/2643)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -36,6 +36,14 @@ on:
           - optional
           - required
           - disabled
+      staging_shared_read_only:
+        description: 'Mount staging shared volume read-only (true = RO flip for arm-A verification, t/2643)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
       # enable_git_sync removed — GitHub API-first mode is always on (STORAGE_MODE=github-api)
 
 permissions:
@@ -247,6 +255,7 @@ jobs:
               freeTierGeminiKey=${{ secrets.FREE_TIER_GEMINI_KEY }} \
               geminiPaidKey=${{ secrets.GEMINI_PAID_KEY }} \
               budgetAlertEmail=${{ vars.ALERT_EMAIL }} \
+              stagingSharedReadOnly=${{ inputs.staging_shared_read_only == 'true' && 'true' || 'false' }} \
             --no-pretty-print 2>&1) || true
           echo "$RESULT"
 
@@ -292,6 +301,7 @@ jobs:
             budgetAlertEmail=${{ vars.ALERT_EMAIL }}
             trafficPinRevisionName=${{ steps.current_revision.outputs.revision }}
             trafficPinRevisionNameStaging=${{ steps.current_revision.outputs.staging_revision }}
+            stagingSharedReadOnly=${{ inputs.staging_shared_read_only == 'true' && 'true' || 'false' }}
 
       # NOTE: the current active revision is now captured BEFORE the Bicep apply
       # (see "Capture current active revisions" above) so it can be passed as the


### PR DESCRIPTION
## Summary
- Adds `staging_shared_read_only` workflow_dispatch input (default `false`) to `deploy-azure.yml`
- Passes `stagingSharedReadOnly` to both the Bicep what-if preview step and the `azure/arm-deploy` parameters block
- Enables dispatching the RO flip for t/2643 arm-A verification without a direct `az deployment group create` invocation

## Test plan
- [ ] CI green on this PR
- [ ] After merge, dispatch `deploy-azure.yml` with `staging_shared_read_only=true` to flip staging shared volume to RO
- [ ] Run arm-A: attempt write to `/mnt/shared` → expect EACCES/EPERM
- [ ] Report arm-A result to TL for both-arms GV sign-off → unfreeze t/2614

🤖 Generated with [Claude Code](https://claude.com/claude-code)
