### PR TITLE
fix(devops): discriminate 403 RBAC from 404 absent in blob container gate (t/2718)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -312,26 +312,12 @@ jobs:
       # SYNC WITH main.bicep: analyticsContainer, stagingAnalyticsContainer,
       # userContentContainer, stagingUserContentContainer, communityContainer,
       # stagingCommunityContainer. Update both if a container is added or removed.
+      # Discriminates ContainerNotFound (404) from RBAC failures (403) — t/2718.
       - name: Verify blob containers exist post-deploy
         shell: pwsh
         run: |
-          $StorageAccount = '${{ steps.deploy.outputs.storageAccountName }}'
-          $Containers = @('analytics', 'staging-analytics', 'user-content', 'staging-user-content', 'community', 'staging-community')
-          if ($Containers.Count -ne 6) { throw "Container list sync error: expected 6, got $($Containers.Count). Update workflow and main.bicep together." }
-          $Failed = @()
-          foreach ($c in $Containers) {
-            $null = az storage container show --account-name $StorageAccount --name $c --auth-mode login --output none 2>&1
-            if ($LASTEXITCODE -ne 0) {
-              Write-Host "::error::Blob container '$c' missing or inaccessible after Bicep deploy (storageAccount=$StorageAccount)"
-              $Failed += $c
-            } else {
-              Write-Host "  [OK] $c"
-            }
-          }
-          if ($Failed.Count -gt 0) {
-            throw "Post-deploy blob container check FAILED: $($Failed.Count) container(s) missing — $($Failed -join ', ')"
-          }
-          Write-Host "All $($Containers.Count) blob containers verified."
+          ./operations/devops/Invoke-BlobContainerGateCheck.ps1 `
+            -StorageAccount '${{ steps.deploy.outputs.storageAccountName }}'
 
       - name: Cleanup stale revisions
         shell: pwsh

--- a/operations/devops/Invoke-BlobContainerGateCheck.ps1
+++ b/operations/devops/Invoke-BlobContainerGateCheck.ps1
@@ -1,0 +1,69 @@
+#Requires -Version 7.0
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Post-deploy gate: verify all 6 blob containers exist and are accessible.
+.DESCRIPTION
+    Called by deploy-azure.yml after the Bicep deploy, before traffic switch.
+    Discriminates ContainerNotFound (404) from RBAC failures (403) so on-call
+    gets an actionable error rather than "container missing" for an auth regression.
+    Every non-zero az exit code blocks — classification is diagnostic-only. (t/2718)
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $StorageAccount,
+    # SYNC WITH main.bicep: analyticsContainer, stagingAnalyticsContainer,
+    # userContentContainer, stagingUserContentContainer, communityContainer,
+    # stagingCommunityContainer. Update both if a container is added or removed.
+    [string[]] $Containers = @(
+        'analytics', 'staging-analytics',
+        'user-content', 'staging-user-content',
+        'community', 'staging-community'
+    )
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-AzContainerErrorClass ([string] $AzStderr) {
+    if ($AzStderr -match 'ContainerNotFound|The specified container does not exist') {
+        return 'missing'
+    }
+    if ($AzStderr -match 'AuthorizationPermissionMismatch|AuthenticationFailed|does not have .+permission') {
+        return 'rbac'
+    }
+    return 'unknown'
+}
+
+if ($Containers.Count -ne 6) {
+    throw "Container list sync error: expected 6, got $($Containers.Count). Update deploy-azure.yml and main.bicep together."
+}
+
+$Failed = @()
+foreach ($c in $Containers) {
+    $azOutput = az storage container show --account-name $StorageAccount --name $c --auth-mode login --output none 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $azStderr = ($azOutput | Out-String).Trim()
+        switch (Get-AzContainerErrorClass $azStderr) {
+            'missing' {
+                Write-Host "::error::Blob container '$c' does not exist after Bicep deploy (storageAccount=$StorageAccount)"
+            }
+            'rbac' {
+                Write-Host "::error::RBAC failure checking blob container '$c' — SP may lack Storage Blob Data Reader on $StorageAccount. Diagnose: az role assignment list --scope .../storageAccounts/$StorageAccount"
+            }
+            default {
+                Write-Host "::error::Blob container '$c' check failed — unexpected az error (storageAccount=$StorageAccount): $azStderr"
+            }
+        }
+        $Failed += $c  # Always: categorization is diagnostic-only — every non-zero exit blocks
+    } else {
+        Write-Host "  [OK] $c"
+    }
+}
+
+if ($Failed.Count -gt 0) {
+    throw "Post-deploy blob container check FAILED: $($Failed.Count) container(s) missing or inaccessible — $($Failed -join ', ')"
+}
+Write-Host "All $($Containers.Count) blob containers verified."

--- a/tests/BlobContainerGateCheck.Tests.ps1
+++ b/tests/BlobContainerGateCheck.Tests.ps1
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Covers Invoke-BlobContainerGateCheck — t/2718 error-class discrimination.
+.DESCRIPTION
+    az storage container show exits non-zero for both ContainerNotFound (404)
+    and RBAC failures (AuthorizationPermissionMismatch / AuthenticationFailed, 403).
+    The gate must emit distinct ::error:: messages so on-call can distinguish a
+    missing container from an auth regression. Critically, EVERY non-zero az exit
+    must still throw and block the deploy — categorization is diagnostic-only.
+
+    Tests shadow `az` as a PowerShell function to inject captured stderr fixtures.
+    The final test proves the unknown/unmatched case still throws (TL requirement,
+    e/105#9, t/2718).
+#>
+
+Describe 'Invoke-BlobContainerGateCheck — error-class discrimination (t/2718)' {
+
+    BeforeAll {
+        $script:GateScript = "$PSScriptRoot/../operations/devops/Invoke-BlobContainerGateCheck.ps1"
+        $script:AllContainers = @('analytics', 'staging-analytics', 'user-content', 'staging-user-content', 'community', 'staging-community')
+
+        function script:Invoke-Gate ([string]$StorageAccount, [string[]]$Containers = $script:AllContainers) {
+            & $script:GateScript -StorageAccount $StorageAccount -Containers $Containers
+        }
+
+        # Captures Write-Host (stream 6) output even when gate throws
+        function script:Capture-GateOutput ([string]$StorageAccount, [string[]]$Containers = $script:AllContainers) {
+            & { try { & $script:GateScript -StorageAccount $StorageAccount -Containers $Containers } catch {} } 6>&1 | Out-String
+        }
+    }
+
+    Context 'All containers present' {
+        BeforeEach {
+            function global:az {
+                param([Parameter(ValueFromRemainingArguments)][object[]]$azArgs)
+                $global:LASTEXITCODE = 0
+            }
+        }
+        AfterEach { Remove-Item Function:global:az -ErrorAction SilentlyContinue }
+
+        It 'succeeds without throwing' {
+            { script:Invoke-Gate -StorageAccount 'myaccount' } | Should -Not -Throw
+        }
+
+        It 'prints verified count for all 6 containers' {
+            $output = script:Capture-GateOutput -StorageAccount 'myaccount'
+            $output | Should -Match 'All 6 blob containers verified'
+        }
+    }
+
+    Context 'ContainerNotFound (404 — container absent)' {
+        BeforeEach {
+            function global:az {
+                param([Parameter(ValueFromRemainingArguments)][object[]]$azArgs)
+                Write-Error 'ERROR: (ContainerNotFound) The specified container does not exist.' -ErrorAction Continue
+                $global:LASTEXITCODE = 1
+            }
+        }
+        AfterEach { Remove-Item Function:global:az -ErrorAction SilentlyContinue }
+
+        It 'throws and blocks the deploy' {
+            { script:Invoke-Gate -StorageAccount 'sa' } | Should -Throw -ExpectedMessage '*check FAILED*'
+        }
+
+        It 'emits ::error:: message mentioning "does not exist"' {
+            $output = script:Capture-GateOutput -StorageAccount 'sa'
+            $output | Should -Match '::error::.*does not exist'
+        }
+    }
+
+    Context 'AuthorizationPermissionMismatch (403 — RBAC missing)' {
+        BeforeEach {
+            function global:az {
+                param([Parameter(ValueFromRemainingArguments)][object[]]$azArgs)
+                Write-Error 'ERROR: (AuthorizationPermissionMismatch) This request is not authorized to perform this operation using this permission.' -ErrorAction Continue
+                $global:LASTEXITCODE = 1
+            }
+        }
+        AfterEach { Remove-Item Function:global:az -ErrorAction SilentlyContinue }
+
+        It 'throws and blocks the deploy' {
+            { script:Invoke-Gate -StorageAccount 'sa' } | Should -Throw
+        }
+
+        It 'emits ::error:: message mentioning RBAC' {
+            $output = script:Capture-GateOutput -StorageAccount 'sa'
+            $output | Should -Match '::error::.*RBAC'
+        }
+    }
+
+    Context 'AuthenticationFailed (403 — auth failure)' {
+        BeforeEach {
+            function global:az {
+                param([Parameter(ValueFromRemainingArguments)][object[]]$azArgs)
+                Write-Error 'ERROR: (AuthenticationFailed) Server failed to authenticate the request.' -ErrorAction Continue
+                $global:LASTEXITCODE = 1
+            }
+        }
+        AfterEach { Remove-Item Function:global:az -ErrorAction SilentlyContinue }
+
+        It 'throws and blocks the deploy' {
+            { script:Invoke-Gate -StorageAccount 'sa' } | Should -Throw
+        }
+
+        It 'emits ::error:: message mentioning RBAC (AuthenticationFailed maps to rbac class)' {
+            $output = script:Capture-GateOutput -StorageAccount 'sa'
+            $output | Should -Match '::error::.*RBAC'
+        }
+    }
+
+    Context 'Unknown/unmatched az error — must still block (t/2718 must-hold)' {
+        BeforeEach {
+            function global:az {
+                param([Parameter(ValueFromRemainingArguments)][object[]]$azArgs)
+                Write-Error 'ERROR: (InternalServerError) An unexpected internal server error occurred.' -ErrorAction Continue
+                $global:LASTEXITCODE = 1
+            }
+        }
+        AfterEach { Remove-Item Function:global:az -ErrorAction SilentlyContinue }
+
+        It 'throws even when the az error string matches no known class' {
+            { script:Invoke-Gate -StorageAccount 'sa' } | Should -Throw -ExpectedMessage '*check FAILED*'
+        }
+
+        It 'emits ::error:: with "unexpected az error" for unknown class' {
+            $output = script:Capture-GateOutput -StorageAccount 'sa'
+            $output | Should -Match '::error::.*unexpected az error'
+        }
+    }
+
+    Context 'Count guard' {
+        It 'throws sync error when container list is not exactly 6' {
+            function global:az { $global:LASTEXITCODE = 0 }
+            try {
+                { script:Invoke-Gate -StorageAccount 'sa' -Containers @('analytics', 'staging-analytics') } |
+                    Should -Throw -ExpectedMessage '*sync error*'
+            } finally {
+                Remove-Item Function:global:az -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- \`az storage container show\` exits non-zero for both **ContainerNotFound** (404) and **AuthorizationPermissionMismatch / AuthenticationFailed** (403). The previous gate discarded stderr and emitted the same \`"Blob container 'X' missing"\` error for both — on an RBAC regression, on-call would hunt a container that was never deleted (t/2683 genus).
- Extracts gate logic to \`operations/devops/Invoke-BlobContainerGateCheck.ps1\`, which captures stderr, classifies it (\`missing\` / \`rbac\` / \`unknown\`), and emits a distinct \`::error::\` message per class.
- **Every non-zero exit still throws and blocks** — classification is diagnostic-only. \`\$Failed += \$c\` is unconditional; the final \`throw\` fires whenever \`\$Failed.Count > 0\`.

## Test plan

- [x] 11 Pester cases in \`tests/BlobContainerGateCheck.Tests.ps1\` — 11/11 passing locally
- [x] Includes "unknown/unmatched error class still blocks" case (TL must-hold, e/105#9)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)