### PR TITLE
fix(oped): serialize voice generation to bound peak memory (t/2719)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -285,8 +285,8 @@ async function runVoiceGeneration(
 
 /**
  * Generate a multi-voice op-ed set, yielding progress events.
- * Voices run in parallel (Promise.all fan-out). Grounding failure degrades to
- * voice-only rather than throwing. Signal is threaded into every AI call.
+ * Voices run SEQUENTIALLY (one at a time) to bound peak memory (t/2719) — grounding
+ * failure degrades to voice-only rather than throwing. Signal is threaded into every AI call.
  * Always yields `{ type: 'complete', set }` last — set.opeds carries all
  * members including failed/cancelled (partial-set contract, e/91#2 cond. 1).
  */
@@ -339,7 +339,7 @@ export async function* generateOpEdSet(
     // continue voice-only
   }
 
-  // ── Step 2: parallel voice fan-out ────────────────────────────────────────
+  // ── Step 2: sequential voice generation (memory-bounded, t/2719) ──────────
   const queue: OpEdProgressEvent[] = [];
   let wakeResolve: (() => void) | null = null;
   let remaining = request.povs.length;
@@ -378,7 +378,12 @@ export async function* generateOpEdSet(
     r?.();
   }
 
-  void Promise.all(request.povs.map(pov => runVoice(pov)));
+  // t/2719: run voices SEQUENTIALLY (concurrency 1), not Promise.all. Parallel fan-out
+  // kept every voice's AI response + JSON.parse resident at once which, on top of the
+  // in-process ONNX model + embeddings + taxonomy, OOM-crashed the Node process mid-stream
+  // (a single create took the whole server down). Sequential caps peak at one voice; the
+  // queue/drain loop below still streams per-voice progress in order.
+  void (async () => { for (const pov of request.povs) await runVoice(pov); })();
 
   while (remaining > 0 || queue.length > 0) {
     while (queue.length > 0) {

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2719 — voices must generate SEQUENTIALLY (concurrency 1), not in a Promise.all
+// fan-out. Parallel fan-out kept every voice's AI response + JSON.parse resident at once
+// which, on top of the in-process ONNX model + embeddings + taxonomy, OOM-crashed the Node
+// server mid-stream (a single create took the whole process down). This test locks the
+// serialization: an instrumented adapter records the max number of concurrent generateText
+// calls; sequential generation ⇒ 1, the old parallel fan-out ⇒ N (one per voice).
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../embeddings/onnxEmbedding.js', () => ({ computeEmbedding: async () => [1, 0, 0] }));
+vi.mock('../debate/taxonomyLoader.js', () => ({
+  loadTaxonomy: () => ({
+    accelerationist: { nodes: [{ id: 'acc-bel-001', category: 'Belief', label: 'l', description: 'd', parent_id: null, children: [] }] },
+    safetyist: { nodes: [{ id: 'saf-bel-001', category: 'Belief', label: 'l', description: 'd', parent_id: null, children: [] }] },
+    skeptic: { nodes: [{ id: 'skp-bel-001', category: 'Belief', label: 'l', description: 'd', parent_id: null, children: [] }] },
+    situations: { nodes: [{ id: 'sit-001', label: 'l', description: 'd', parent_id: null }] },
+    embeddings: {},
+  }),
+}));
+vi.mock('../debate/taxonomyRelevance.js', () => ({
+  scoreNodeRelevance: () => new Map(),
+  selectRelevantNodes: (nodes: { id: string }[]) => nodes.map(node => ({ node, score: 0.9 })),
+  selectRelevantSituationNodes: (nodes: { id: string }[]) => nodes.map(node => ({ node, score: 0.8 })),
+}));
+vi.mock('./outletBands.js', () => ({ resolveOutletBand: () => ({ words: 800, guidance: 'g' }) }));
+vi.mock('./promptLoader.js', () => ({
+  loadAndAssemblePrompt: () => ({ system: 'sys', user: 'user' }),
+  assembleReflectionPrompt: () => 'refl',
+}));
+
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { generateOpEdSet, type OpEdProgressEvent } from './generate.js';
+import type { PovKey } from '../debate/types.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('generateOpEdSet — sequential voice generation (t/2719 OOM regression)', () => {
+  it('never runs more than one voice generation concurrently', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const adapter = {
+      generateText: async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        // Yield so that, if voices were fanned out in parallel, their calls would overlap here.
+        await new Promise(r => setTimeout(r, 5));
+        inFlight--;
+        return JSON.stringify({ headline: 'H', subtitle: 'S', body_markdown: 'Body.', word_count: 1 });
+      },
+    };
+    const req = {
+      set_id: 's1', topic: 'AI policy',
+      params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' } as never,
+      povs: ['accelerationist', 'safetyist', 'skeptic'] as PovKey[],
+    };
+    const deps = { adapter: adapter as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT };
+
+    const completed: PovKey[] = [];
+    for await (const ev of generateOpEdSet(req, deps) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_complete') completed.push(ev.pov);
+    }
+
+    // All three voices still produced (sequential doesn't drop any) …
+    expect(completed.sort()).toEqual(['accelerationist', 'safetyist', 'skeptic']);
+    // … but never more than one AI generation was in flight at once.
+    expect(maxInFlight).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes the OOM that failed the t/2614 web-create smoke (t/2719). DevOps ACA logs: FATAL JS-heap OOM in `JsonParser::ParseJson` + a cold ONNX-load spike → Node crashed mid-stream → client 'signal is aborted without reason'. Root cause: `generate.ts` fanned voices out in **parallel** (Promise.all), so every voice's AI response + JSON.parse stayed resident at once on top of in-process ONNX + embeddings + taxonomy — a single create could exhaust the heap and take the whole process down.

**Fix:** serialize the fan-out (concurrency 1) — voices run one at a time, peak = one voice's footprint. Queue/wake/drain loop unchanged → per-voice SSE progress + partial-set/abort contract preserved; only change is sequential completion (higher latency, bounded memory).

**Test:** `serialGeneration.test.ts` asserts max concurrent `generateText` === 1 while all voices complete; perPovGrounding regression unaffected. server+main tsc 0, eslint 0, lib/oped 29/29.

Primary fix. Follow-on hardening on t/2719: bound the AI-response parse + warm/cache ONNX. Pairs with DevOps's staging bump (0.5→1 GiB) for the re-run smoke. Scope: lib/oped CLAUDE.md-owned; TL-implemented (routed from DevOps), flagged for owner awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)