### PR TITLE
ops(drift-check): suppress OS-locked fail-open from SuspiciousPaths alarm

### DIFF
--- a/operations/devops/check-shared-drift.ps1
+++ b/operations/devops/check-shared-drift.ps1
@@ -85,6 +85,11 @@ try {
     #                     (shell-quoting debris like src/server/community/22)
     $untracked = @(Invoke-Git @('-C', $RepoRoot, 'ls-files', '--others', '--exclude-standard') | Where-Object { $_ })
     $sourceDirs = @('taxonomy-editor/src/', 'taxonomy-editor/lib/', 'lib/', 'engineering/', 'operations/', 'research/')
+    # OS-locked files confirmed as junk but un-deletable until host restart.
+    # Entries here suppress SuspiciousPaths alarm. Remove when the file clears.
+    $knownOsLocked = @(
+        'engineering/tech-lead/fail-open'   # vim TUI artifact, OS handle lock — clears on host restart
+    )
     $junkPaths = @()
     $suspiciousPaths = @()
     foreach ($f in $untracked) {
@@ -100,7 +105,7 @@ try {
                 $normalizedF = $f -replace '\\', '/'
                 $inSourceDir = @($sourceDirs | Where-Object { $normalizedF.StartsWith($_) })
                 $hasNoExtension = [System.IO.Path]::GetExtension($item.Name) -eq ''
-                if ($inSourceDir.Count -gt 0 -and $hasNoExtension) { $suspiciousPaths += $f }
+                if ($inSourceDir.Count -gt 0 -and $hasNoExtension -and ($normalizedF -notin $knownOsLocked)) { $suspiciousPaths += $f }
             }
         } catch { continue }
     }


### PR DESCRIPTION
## Summary
- Adds `$knownOsLocked` array to `check-shared-drift.ps1` to suppress hourly r/11 alarm for OS-handle-locked junk files that can't be deleted until host restart
- Filters `engineering/tech-lead/fail-open` (confirmed vim TUI artifact, ~18h old, OS lock with no visible handle per Sysinternals) from `SuspiciousPaths`
- Entry is self-documenting and removable once file clears on host restart

## Test plan
- [ ] CI green
- [ ] Run drift check script — confirm Alarm=false with fail-open present

🤖 Generated with [Claude Code](https://claude.com/claude-code)