### PR TITLE
fix(oped): warm ONNX at boot + bound the AI-response parse (t/2719 hardening)

### DIFF
--- a/lib/ai-client/retry.test.ts
+++ b/lib/ai-client/retry.test.ts
@@ -427,3 +427,53 @@ describe('retryableFetch — Retry-After header integration', () => {
     });
   });
 });
+
+describe('retryableFetch — response size cap (t/2719)', () => {
+  // Mirror MAX_RESPONSE_BYTES in retry.ts. A runaway provider/proxy response previously
+  // OOM-crashed the whole Node server in JsonParser::ParseJson (one bad response → server
+  // down for every user); the cap rejects it cleanly instead of buffering + parsing it.
+  const CAP = 25 * 1024 * 1024;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects an over-cap body by Content-Length WITHOUT reading it', async () => {
+    let textRead = false;
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      headers: new Headers({ 'content-length': String(CAP + 1) }),
+      text: () => { textRead = true; return Promise.resolve('unused'); },
+    });
+    await expect(retryableFetch({
+      label: 'test', url: 'https://example.com/api', init: { method: 'POST' },
+      timeoutMs: 5000, fetchFn, config: FAST_CONFIG,
+    })).rejects.toThrow(/safety cap/);
+    expect(textRead).toBe(false); // pre-check fires before the body is buffered
+  });
+
+  it('rejects an over-cap chunked body (no Content-Length) before parsing it', async () => {
+    const huge = 'x'.repeat(CAP + 1);
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true, status: 200, headers: new Headers(),
+      text: () => Promise.resolve(huge),
+    });
+    await expect(retryableFetch({
+      label: 'test', url: 'https://example.com/api', init: { method: 'POST' },
+      timeoutMs: 5000, fetchFn, config: FAST_CONFIG,
+    })).rejects.toThrow(/safety cap/);
+  });
+
+  it('returns the body for an under-cap response', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      headers: new Headers({ 'content-length': '15' }),
+      text: () => Promise.resolve('{"result":"ok"}'),
+    });
+    const result = await retryableFetch({
+      label: 'test', url: 'https://example.com/api', init: { method: 'POST' },
+      timeoutMs: 5000, fetchFn, config: FAST_CONFIG,
+    });
+    expect(result.bodyText).toBe('{"result":"ok"}');
+  });
+});

--- a/lib/ai-client/retry.ts
+++ b/lib/ai-client/retry.ts
@@ -4,6 +4,13 @@
 import { ActionableError } from '../debate/errors.js';
 import type { RateLimitType, RateLimitHeaders, RetryProgress, FetchFn } from './types.js';
 
+// t/2719: hard ceiling on a single AI-response body before we buffer + JSON.parse it.
+// This is the shared text-generation fetch path (op-ed voices, debate, NLI, chat);
+// embeddings run through a separate Python-subprocess path with its own maxBuffer, so
+// nothing legitimate here is more than KB-range. 25 MiB is far above any real response
+// yet well under what would OOM the process — a runaway payload is rejected, not parsed.
+const MAX_RESPONSE_BYTES = 25 * 1024 * 1024;
+
 export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return Promise.race([
     promise,
@@ -233,7 +240,29 @@ export async function retryableFetch(opts: {
       continue;
     }
 
+    // t/2719: reject an over-cap body BEFORE buffering it, using the declared
+    // Content-Length when the provider sends one — this avoids even reading a
+    // pathologically large payload into memory.
+    const contentLength = Number(response.headers.get('content-length'));
+    if (Number.isFinite(contentLength) && contentLength > MAX_RESPONSE_BYTES) {
+      throw new ActionableError({
+        goal: `Generate text via ${opts.label}`,
+        problem: `Response body is ${contentLength} bytes, over the ${MAX_RESPONSE_BYTES}-byte safety cap. Refusing to buffer it to avoid an out-of-memory crash.`,
+        location: `ai-client.retryableFetch(${opts.label})`,
+        nextSteps: ['Retry — an oversized/malformed response is usually transient', 'Switch to a different AI provider (Settings → AI Model)', 'If this recurs, the provider or proxy is returning an unexpected payload'],
+      });
+    }
     const bodyText = await withTimeout(response.text(), 30_000, `Reading ${opts.label} response`);
+    // t/2719: chunked / no-Content-Length responses slip past the pre-check, so cap the
+    // buffered string before it reaches JSON.parse — the OOM was in JsonParser::ParseJson.
+    if (bodyText.length > MAX_RESPONSE_BYTES) {
+      throw new ActionableError({
+        goal: `Generate text via ${opts.label}`,
+        problem: `Response body is ${bodyText.length} chars, over the ${MAX_RESPONSE_BYTES}-char safety cap. Refusing to parse it to avoid an out-of-memory crash.`,
+        location: `ai-client.retryableFetch(${opts.label})`,
+        nextSteps: ['Retry — an oversized/malformed response is usually transient', 'Switch to a different AI provider (Settings → AI Model)', 'If this recurs, the provider or proxy is returning an unexpected payload'],
+      });
+    }
     return { response, bodyText };
   }
   throw new ActionableError({

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import { spawn, execFile, ChildProcess } from 'child_process';
 import { getGlobalRecorder, setGlobalRecorder } from '../../../lib/flight-recorder/index.js';
+import { warmup as warmupEmbeddings } from '../../../lib/embeddings/onnxEmbedding.js';
 
 const require = createRequire(import.meta.url);
 
@@ -34,8 +35,7 @@ import {
 } from './config.js';
 import { GitHubAPIBackend } from './storage/githubAPIBackend.js';
 import { SessionBranchManager } from './storage/sessionBranchManager.js';
-import { runWithUser, getCurrentUserId, setSessionBranchName, deriveStorageUserId } from './security/userContext.js';
-import type { UserContext } from './security/userContext.js';
+import { runWithUser, getCurrentUserId, setSessionBranchName, deriveStorageUserId, type UserContext } from './security/userContext.js';
 import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, missingApiKeyError, resolveTestPersonaOverride } from './security/accessControl.js';
 import { sanitizeUserText } from './security/contentSanitizer.js';
 import { isFreeTierAiPath } from './anonAiRoutes.js';
@@ -81,8 +81,7 @@ import * as community from './community/community.js';
 import * as fileIO from './storage/fileIO.js';
 import { FEEDBACK_CATEGORIES, isFeedbackCategory, paginateFeedback } from './storage/feedbackStore.js';
 import { stampNodeAuthorship, diffNodes, changedFields } from './storage/editMeta.js';
-import { computeNodeConflicts } from './community/nodeConflicts.js';
-import type { TaxNode, NodeConflict } from './community/nodeConflicts.js';
+import { computeNodeConflicts, type TaxNode, type NodeConflict } from './community/nodeConflicts.js';
 import { getConfig, getConfigState, writeConfig, forceReload as reloadRuntimeConfig, diffFromDefaults } from './runtimeConfig.js';
 import { setRuntimeCredentials, clearRuntimeCredentials, getCredentials } from './security/githubAppAuth.js';
 import * as proxyTiers from './ai/proxyTiers.js';
@@ -1448,6 +1447,7 @@ server.listen(PORT, BIND_HOST, () => {
   serverRecorder.record({ type: 'lifecycle', component: 'server', level: 'info', message: 'Server started', data: { port: PORT, host: BIND_HOST, version: SERVER_VERSION, dataRoot: getDataRoot(), platform: process.platform, arch: process.arch, storageMode: STORAGE_MODE } });
   log.server.info({ port: PORT, host: BIND_HOST }, 'Taxonomy Editor running');
   log.server.info({ dataRoot: getDataRoot() }, 'Data root');
+  void warmupEmbeddings().catch((err: unknown) => log.server.warn({ err: String(err) }, 't/2719: ONNX embedding warmup failed at boot (non-fatal — first grounding request pays the cold-load)'));
 
   // t/924: surface the free-tier key pool + effective RPM so rate-limit
   // behavior is observable from startup logs (not inferred from 429 timing).


### PR DESCRIPTION
## What
Follow-on resilience for the web op-ed-create OOM (t/2719). The primary fix (aae8f840) serialized the voices; DevOps's ACA crash logs showed two remaining memory amplifiers this PR closes.

**A. Warm ONNX at server boot** (`taxonomy-editor/src/server/server.ts`) — fire `warmup()` best-effort in the `listen` callback so the one-time in-process embedding-model load happens off the request path, not during the first user's op-ed/debate grounding. Failure is non-fatal (logged); the first request then pays the cold-load as before.

**B. Bound the AI-response parse** (`lib/ai-client/retry.ts`) — reject a response body over a 25 MiB safety cap: by `Content-Length` before buffering when the provider declares one, and by string length before `JSON.parse` for chunked/no-header responses. A runaway provider/proxy payload now fails cleanly with an `ActionableError` instead of OOM-crashing the whole Node process (one bad response → server down for every user, the `JsonParser::ParseJson` FATAL in the logs).

## Why 25 MiB is safe
This is the shared **text-generation** fetch path (op-ed voices, debate, NLI, chat) — legit responses are KB-range. Embeddings run through a **separate** Python-subprocess path with its own `maxBuffer`, so nothing legitimate here approaches the cap.

## ADR-007 note
`server.ts` was at the 1500-line hard cap. Reclaimed the 2 lines the warmup import+call need by merging two split value+type imports — **no gate change**, file stays at 1500.

## Tests / gates (local)
- `retry.test.ts` +3 cases: over-cap-by-Content-Length rejects **without reading** the body; over-cap chunked body rejects before parsing; under-cap returns normally → **40/40**.
- `tsc` server + main: **0**. `eslint src/`: **0** (server.ts at 1500, floating-promise clean).

## Scope
`lib/ai-client` and `taxonomy-editor/src/server` are CLAUDE.md-owned; implemented by TL as the assigned owner of the t/2719 prod-resilience work (routed from DevOps). Flagging for owner awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
