### PR TITLE
refactor(oped): fold op-ed entitlement onto shared resolveGenerationContext (t/2635)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/opedRoutes.test.ts
+++ b/taxonomy-editor/src/server/__tests__/opedRoutes.test.ts
@@ -233,7 +233,26 @@ describe('POST /api/oped-sets create pre-start gate (t/2610)', () => {
     const res = fakeRes();
     await handlers['POST /api/oped-sets'](fakeReq('/api/oped-sets'), res, { ...validBody, params: { model: 'claude-opus-4', wordCount: 800 } });
     expect(res._status).toBe(403);
+    // t/2635: entitlement now flows through the shared enforceBackendAllowed
+    // (routes/generationContext.ts), whose 403 carries the tier context — asserting the
+    // body shape locks the op-ed route onto the ONE consolidated gate, not the old mirror.
+    expect(JSON.parse(res._body ?? '{}')).toMatchObject({ tier_level: 'platform', requested_backend: 'claude' });
     expect(getOpedSetsQuotaStatus).not.toHaveBeenCalled(); // gated before quota + any generation
+  });
+
+  it('free tier is PINNED — a premium request is not 403’d, it proceeds on the pinned backend (t/2635)', async () => {
+    // The consolidation's core behaviour via resolveGenerationContext: a free user asking for a
+    // premium model is served the tier's pinned model (an allowed backend), NOT rejected. We stop
+    // at the quota gate (429) to prove entitlement passed without kicking off real generation.
+    resolveTier.mockReturnValue({ level: 'free', allowedBackends: ['gemini'], pinnedModel: 'gemini-2.5-flash' });
+    resolveBackend.mockReturnValue('gemini'); // effectiveModel = pinned gemini-2.5-flash → gemini backend
+    getOpedSetsQuotaStatus.mockResolvedValue({ allowed: false, resource: 'opeds', current: 15, limit: 15 });
+    // Free-tier limit-keying calls getClientIp, so this req needs headers + socket (bare fakeReq doesn't).
+    const freeReq = { url: '/api/oped-sets', headers: {}, socket: { remoteAddress: '127.0.0.1' } } as unknown as IncomingMessage;
+    const res = fakeRes();
+    await handlers['POST /api/oped-sets'](freeReq, res, { ...validBody, params: { model: 'claude-opus-4', wordCount: 800 } });
+    expect(res._status).toBe(429); // reached quota ⇒ entitlement did NOT 403 the pinned free user
+    expect(getOpedSetsQuotaStatus).toHaveBeenCalled();
   });
 
   it('403 for anonymous users (no anonymous op-ed tier)', async () => {

--- a/taxonomy-editor/src/server/routes/oped.ts
+++ b/taxonomy-editor/src/server/routes/oped.ts
@@ -24,9 +24,8 @@ import { isSafeId } from '../storage/fileIO.js';
 import { listOpedSets, loadOpedSet, deleteOpedSet, getOpedSetsQuotaStatus, finalizeOpedSet } from '../storage/opedStore.js';
 import type { OpEdSet, OpEdMember, OpEdParams, PovKey } from '../../../../lib/oped/types.js';
 import type { GenerateOpEdRequest, OpEdGeneratorDeps, OpEdProgressEvent } from '../../../../lib/oped/generate.js';
-import { getStorageUserId, isAnonymousUser, getCurrentUser } from '../security/userContext.js';
-import { callerTierIdentity } from '../security/accessControl.js';
-import * as proxyTiers from '../ai/proxyTiers.js';
+import { getStorageUserId, isAnonymousUser } from '../security/userContext.js';
+import { resolveGenerationContext, enforceBackendAllowed } from './generationContext.js';
 import { resolveBackend, isRegisteredModel } from '../ai/aiBackends.js';
 import { DEFAULT_MODEL } from '../../../../lib/ai-client/index.js';
 import { getProjectRoot } from '../config.js';
@@ -90,27 +89,6 @@ function parseOpEdCreate(body: unknown): { ok: true; value: ParsedOpEdCreate } |
   // (mirrors schemas.ts .optional().default(0); generate.ts treats `wordCount > 0 ? … : band.words`).
   const wordCount = typeof params.wordCount === 'number' && params.wordCount > 0 ? params.wordCount : 0;
   return { ok: true, value: { topic, povs, params: { ...params, wordCount } } };
-}
-
-/** Tier-backend entitlement (mirrors chat.ts resolveGenerationContext, t/2610#11): a free
- *  user must not invoke a premium backend via `params.model`, and the free tier's model is
- *  pinned. Returns the EFFECTIVE model to generate with (pinned for free). */
-function resolveOpEdModel(params: OpEdParams): { ok: true; model: string } | { ok: false; status: number; message: string } {
-  const { principalName, idp } = callerTierIdentity(getCurrentUser());
-  const tier = proxyTiers.resolveTier(principalName, idp);
-  const model = (tier.level === 'free' ? (tier.pinnedModel ?? params.model) : params.model) || DEFAULT_MODEL;
-  // t/2687: reject an UNREGISTERED model before committing the SSE stream. resolveBackend only
-  // prefix-guesses (unknown → 'gemini'), so without this an unregistered id reaches the provider
-  // and fails silently mid-generation ("voice failed — 0 words"). Free tier is pinned to a
-  // registered model, so this only rejects a caller-chosen unregistered id.
-  if (!isRegisteredModel(model)) {
-    return { ok: false, status: 400, message: `Model '${model}' is not available — choose another model in Settings.` };
-  }
-  const backend = resolveBackend(model);
-  if (!proxyTiers.isBackendAllowed(tier, backend)) {
-    return { ok: false, status: 403, message: `Your plan can't use the ${backend} backend — choose an allowed model` };
-  }
-  return { ok: true, model };
 }
 
 function applyEventToRun(run: OpEdRun, event: OpEdProgressEvent, completed: OpEdMember[]): void {
@@ -205,10 +183,18 @@ export function registerOpedRoutes(r: Router, _ctx: ServerCtx): void {
     const parsed = parseOpEdCreate(body);
     if (!parsed.ok) { error(res, parsed.message, parsed.status); return; }
     const { topic, povs, params } = parsed.value;
-    // Tier-backend entitlement — a free user can't pick a premium backend via params.model
-    // (mirrors chat.ts:236); free tier's model is pinned. Must precede any generation.
-    const ent = resolveOpEdModel(params);
-    if (!ent.ok) { error(res, ent.message, ent.status); return; }
+    // Tier-backend entitlement via the shared helper (t/2635 — folds op-ed onto the ONE
+    // entitlement path in routes/generationContext.ts, replacing the local resolveOpEdModel
+    // mirror). Free tier's model is pinned; a free/restricted caller can't reach a premium
+    // backend via params.model. Must precede any generation (JSON errors before the SSE headers).
+    const { tier, effectiveModel, backend } = resolveGenerationContext(req, params.model);
+    const model = effectiveModel || DEFAULT_MODEL;
+    // t/2687: reject an UNREGISTERED model before committing the SSE stream — the shared helper
+    // doesn't (resolveBackend only prefix-guesses unknown → 'gemini', so an unregistered id would
+    // reach the provider and fail silently mid-generation, "voice failed — 0 words"). Free tier is
+    // pinned to a registered model, so this only rejects a caller-chosen unregistered id.
+    if (!isRegisteredModel(model)) { error(res, `Model '${model}' is not available — choose another model in Settings.`, 400); return; }
+    if (enforceBackendAllowed(res, tier, backend)) return;
 
     const userId = getStorageUserId();
     sweepOpedRuns();
@@ -241,7 +227,7 @@ export function registerOpedRoutes(r: Router, _ctx: ServerCtx): void {
 
     writeFrame({ type: 'run_started', runId });
     // Generate with the entitlement-resolved (free-tier-pinned) model, not the raw request.
-    const request: GenerateOpEdRequest = { set_id: setId, topic, params: { ...params, model: ent.model }, povs: povs as PovKey[], signal: ac.signal };
+    const request: GenerateOpEdRequest = { set_id: setId, topic, params: { ...params, model }, povs: povs as PovKey[], signal: ac.signal };
     await driveOpEdRun(res, run, request, writeFrame, heartbeat, () => clientGone);
   });
 


### PR DESCRIPTION
## What
Behaviour-neutral consolidation (t/2635): fold the op-ed create route's local `resolveOpEdModel` — the 4th mirror of tier-backend entitlement — onto the shared `routes/generationContext.ts` (`resolveGenerationContext` + `enforceBackendAllowed`, t/2625). One entitlement path now.

## Changes (`routes/oped.ts`)
- Replace `resolveOpEdModel` with `resolveGenerationContext(req, params.model)` + `enforceBackendAllowed`; generate with `effectiveModel` (free-tier pinning preserved).
- **KEEP the t/2687 unregistered-model 400** as an explicit check — the shared helper does *not* reject unregistered ids (`resolveBackend` only prefix-guesses), so dropping it would regress t/2687 (unregistered id → silent mid-generation "voice failed — 0 words"). Ordering preserved: 400 (unregistered) → 403 (disallowed backend) → both before quota + SSE headers.
- Drop now-unused imports (`proxyTiers`, `callerTierIdentity`, `getCurrentUser`).

## Tests (`opedRoutes.test.ts`)
- Strengthen the 403 test to assert the shared `enforceBackendAllowed` body shape (`{ tier_level, requested_backend }`) — locks op-ed onto the consolidated gate, not the old mirror.
- Add a free-tier pinning test: a free user requesting a premium model is pinned to its allowed backend (not 403'd) and proceeds to the quota gate → exercises the free-tier branch through the shared helper. **23/23.**

## Behaviour-neutrality
Same three behaviours preserved: (1) unregistered → 400, (2) disallowed backend → 403, (3) free-tier model pinned for generation. The only observable delta is the 403 body is now the shared helper's richer shape (asserted).

## Gates
tsc server + main: **0**. `eslint src/`: **0 errors** (pre-existing `driveOpEdRun` complexity warning untouched; CI lint gates errors only). opedRoutes **23/23**, opedCreateAbort integration **2/2**.

## Scope
`taxonomy-editor/src/server` is CLAUDE.md-owned; implemented by TL (assigned t/2635, routed from PM). Behaviour-neutral consolidation onto an already-reviewed shared helper — self-certified with the analysis above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
