### PR TITLE
fix(taxonomy): collapse all POV BDI hierarchies at session start (t/2720)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeTree.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeTree.test.tsx
@@ -11,7 +11,7 @@ vi.mock('../conflict/edit-conflicts', () => ({
   EditConflictBadge: () => null,
 }));
 
-const mockLocalStorage = (() => {
+function makeStorageMock() {
   let store: Record<string, string> = {};
   return {
     getItem: (key: string) => store[key] ?? null,
@@ -19,8 +19,14 @@ const mockLocalStorage = (() => {
     removeItem: (key: string) => { delete store[key]; },
     clear: () => { store = {}; },
   };
-})();
+}
+const mockLocalStorage = makeStorageMock();
 Object.defineProperty(window, 'localStorage', { value: mockLocalStorage });
+// NodeTree backs its collapse state on sessionStorage (t/2720): empty at session
+// start → all categories collapsed. Render suites below seed it with '[]' (nothing
+// collapsed) so node rows are visible; the session-start test leaves it empty.
+const mockSessionStorage = makeStorageMock();
+Object.defineProperty(window, 'sessionStorage', { value: mockSessionStorage });
 
 Element.prototype.scrollIntoView = vi.fn();
 HTMLElement.prototype.focus = vi.fn();
@@ -118,8 +124,9 @@ describe('getOrderedNodeIds', () => {
 describe('NodeTree', () => {
   beforeEach(() => {
     mockLocalStorage.clear();
-    mockLocalStorage.setItem('taxonomy-editor-collapsed-version', '2');
-    mockLocalStorage.setItem('taxonomy-editor-collapsed-categories', '[]');
+    // Seed sessionStorage with nothing-collapsed so category rows render for these suites.
+    mockSessionStorage.clear();
+    mockSessionStorage.setItem('taxonomy-editor-collapsed-categories', '[]');
   });
 
   it('renders category headers with counts', () => {
@@ -127,6 +134,20 @@ describe('NodeTree', () => {
     expect(screen.getByText(/Desires/)).toBeDefined();
     expect(screen.getByText(/Intentions/)).toBeDefined();
     expect(screen.getByText(/Beliefs/)).toBeDefined();
+  });
+
+  it('collapses all BDI categories at session start (empty sessionStorage) (t/2720)', () => {
+    // Fresh session: no stored collapse state at all.
+    mockSessionStorage.clear();
+    render(<NodeTree nodes={NODES} selectedNodeId={null} onSelect={vi.fn()} />);
+    // Category headers still render...
+    expect(screen.getByText(/Desires/)).toBeDefined();
+    expect(screen.getByText(/Intentions/)).toBeDefined();
+    expect(screen.getByText(/Beliefs/)).toBeDefined();
+    // ...but every category is collapsed, so no node rows are visible.
+    expect(screen.queryByText('Open dev is safe')).toBeNull();
+    expect(screen.queryByText('Maximize progress')).toBeNull();
+    expect(screen.queryByText('Fund research')).toBeNull();
   });
 
   it('calls onSelect when a node is clicked', () => {
@@ -185,8 +206,9 @@ describe('NodeTree', () => {
 describe('NodeTree debate-tested chip display gate (t/1661)', () => {
   beforeEach(() => {
     mockLocalStorage.clear();
-    mockLocalStorage.setItem('taxonomy-editor-collapsed-version', '2');
-    mockLocalStorage.setItem('taxonomy-editor-collapsed-categories', '[]');
+    // Seed sessionStorage with nothing-collapsed so category rows render for these suites.
+    mockSessionStorage.clear();
+    mockSessionStorage.setItem('taxonomy-editor-collapsed-categories', '[]');
   });
 
   // Hybrid gate: Beliefs always show the chip (legacy "Untested" when record-less);

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeTree.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeTree.tsx
@@ -97,28 +97,25 @@ export function getOrderedNodeIds(
   return ids;
 }
 
+// Collapse state is backed by sessionStorage (not localStorage) so every session
+// starts fully collapsed (t/2720): a fresh app launch / new tab has no stored state
+// → loadCollapsed() returns all categories collapsed. In-session toggles, POV switches,
+// and keyboard-nav auto-expand still persist for the life of the session.
 const COLLAPSE_STORAGE_KEY = 'taxonomy-editor-collapsed-categories';
-const COLLAPSE_VERSION_KEY = 'taxonomy-editor-collapsed-version';
-const COLLAPSE_VERSION = 2; // bump to reset all users to collapsed-by-default
 
 function loadCollapsed(): Set<string> {
   try {
-    const version = Number(localStorage.getItem(COLLAPSE_VERSION_KEY) || '0');
-    if (version >= COLLAPSE_VERSION) {
-      const raw = localStorage.getItem(COLLAPSE_STORAGE_KEY);
-      if (raw) return new Set(JSON.parse(raw));
-    }
-    // First run or version bump — default collapsed & store the version
-    localStorage.setItem(COLLAPSE_VERSION_KEY, String(COLLAPSE_VERSION));
+    const raw = sessionStorage.getItem(COLLAPSE_STORAGE_KEY);
+    if (raw) return new Set(JSON.parse(raw));
   } catch (err) {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'node-tree', level: 'warn', message: 'collapsed state load failed', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
   }
-  // Default: all categories collapsed
+  // Session start (or no stored state): all categories collapsed.
   return new Set(CATEGORY_ORDER);
 }
 
 function saveCollapsed(collapsed: Set<string>) {
-  localStorage.setItem(COLLAPSE_STORAGE_KEY, JSON.stringify([...collapsed]));
+  sessionStorage.setItem(COLLAPSE_STORAGE_KEY, JSON.stringify([...collapsed]));
 }
 
 function computeVisibleIds(


### PR DESCRIPTION
## What
Collapse all POV BDI hierarchies (Desires / Intentions / Beliefs) at the **start of every session** in the Taxonomy tree (t/2720, PI request).

## Why
`NodeTree` persisted the category collapse/expand state in `localStorage` and restored it across sessions, so once a user expanded a category it stayed expanded on the next app launch — the opposite of the requested behavior.

## Change
- Back the collapse state on **`sessionStorage`** instead of `localStorage` (`taxonomy-editor/src/renderer/components/taxonomy/NodeTree.tsx`). A fresh session (app launch / new tab) has no stored state → `loadCollapsed()` returns `new Set(CATEGORY_ORDER)` (all collapsed). In-session toggles, POV switches, and keyboard-nav auto-expand still persist for the life of the session.
- Drops the now-redundant collapse-version migration machinery (sessionStorage is empty at session start by construction).
- Test: mock `sessionStorage`; new assertion that all BDI categories render collapsed when `sessionStorage` is empty.

## Verification
- `NodeTree.test.tsx` — **20/20 pass** in the worktree (19 existing + 1 new session-start test).
- ESLint on changed files: **0 errors** (one *pre-existing* `computeVisibleIds` complexity warning, untouched, within the gate's `--max-warnings=4256` budget).
- Full local `npm run verify` was blocked before reaching the renderer step by a stale-root-`node_modules` resolution gap in `lib/sanitize` (missing `decode-named-character-reference` / `micromark-util-*` in the shared checkout's root modules) — unrelated to this one-file change; CI's clean install is the authoritative full-verify gate.

Both build targets: `sessionStorage` semantics apply in Electron (per-session renderer) and hosted web (per-tab).

Scope: `/trivial-change` self-cert — single-file, UI-only, no cross-role interface or data-model change. Taxonomy-editor has no dedicated role owner; actioned by Tech Lead as assignee.

Closes t/2720.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
