### PR TITLE
fix(oped): harden web route 400 for URL sources (t/2722)

### DIFF
--- a/taxonomy-editor/src/server/routes/oped.ts
+++ b/taxonomy-editor/src/server/routes/oped.ts
@@ -76,7 +76,7 @@ interface ParsedOpEdCreate { topic: string; povs: string[]; params: OpEdParams }
 function parseOpEdCreate(body: unknown): { ok: true; value: ParsedOpEdCreate } | { ok: false; status: number; message: string } {
   const b = (body ?? {}) as { topic?: unknown; params?: OpEdParams; povs?: unknown; url?: unknown; source?: unknown };
   // P1 is FromTopic only (TL) — never present a submit path the server can't run.
-  if (b.url != null || b.source != null) return { ok: false, status: 400, message: 'URL/source op-eds are desktop-only in v1 — use a topic' };
+  if (b.url != null || b.source != null) return { ok: false, status: 400, message: 'URL sources require the desktop app — open the desktop app to generate an op-ed from a URL' };
   const topic = typeof b.topic === 'string' ? b.topic.trim() : '';
   const povs = Array.isArray(b.povs) ? b.povs.filter((p): p is string => typeof p === 'string') : [];
   const params = b.params;


### PR DESCRIPTION
## Summary
- Updates the web route 400 response for URL/source op-ed attempts from the internal v1 note to a user-actionable message: *"URL sources require the desktop app — open the desktop app to generate an op-ed from a URL"*

## Context
Part of t/2722 (op-ed URL source grounding). This is PR A (trivial, immediate) of a two-PR plan. PR B (Step 0 source-brief comprehension + claim-reflection wiring in `lib/oped/generate.ts`) is blocked on the Computational Linguist's schema PR.

Self-certifying under /trivial-change: 1-line string change in `oped.ts`, no interface/type/behavioral changes.

## Test plan
- [ ] CI verify gate passes
- [ ] Web UI: submitting a URL-source request returns a clear 400 with the desktop-app message

🤖 Generated with [Claude Code](https://claude.com/claude-code)