### PR TITLE
fix(debate): populate Turns + Model on the hosted-web debate list (t/2725)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/anonymousSessionStore.test.ts
+++ b/taxonomy-editor/src/server/__tests__/anonymousSessionStore.test.ts
@@ -88,6 +88,22 @@ describe('AnonymousSessionStore (file-backed, t/683)', () => {
       expect((list[0] as { id: string }).id).toBe('d2');
     });
 
+    it('projects model + turn_count into the summary (t/2725 — was empty on web)', async () => {
+      await store.saveDebate('s1', {
+        id: 'd1', title: 'T', created_at: '2026-01-01', updated_at: '2026-01-01',
+        debate_model: 'gemini-3.5-flash-lite',
+        transcript: [
+          { type: 'opening', speaker: 'acc' },
+          { type: 'statement', speaker: 'saf' },
+          { type: 'statement', speaker: 'skp' },
+          { type: 'system', speaker: 'x' }, // not a turn — excluded from the count
+        ],
+      });
+      const [row] = (await store.listDebates('s1')) as { model?: string; turn_count?: number }[];
+      expect(row.model).toBe('gemini-3.5-flash-lite');
+      expect(row.turn_count).toBe(3); // opening + 2 statements; 'system' excluded
+    });
+
     it('deletes debate and its comments', async () => {
       await store.saveDebate('s1', { id: 'd1', title: 'Test' });
       await store.saveDebateComments('s1', 'd1', { comments: ['a'] });

--- a/taxonomy-editor/src/server/__tests__/debateStore.schemaStale.test.ts
+++ b/taxonomy-editor/src/server/__tests__/debateStore.schemaStale.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+
+/**
+ * t/2725 — the debate-index schema-drift guard. A cached index built before the
+ * model/turn_count summary fields existed has the right ROW COUNT but fieldless rows,
+ * so the count-only staleness check would keep serving them (Turns/Model render empty).
+ * isDebateIndexSchemaStale detects the missing key so listDebateSessionsMeta rebuilds.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isDebateIndexSchemaStale } from '../storage/debateStore';
+
+describe('isDebateIndexSchemaStale (t/2725)', () => {
+  it('empty index is not stale (nothing to rebuild)', () => {
+    expect(isDebateIndexSchemaStale([])).toBe(false);
+  });
+
+  it('STALE: a row missing both model and turn_count', () => {
+    expect(isDebateIndexSchemaStale([{ id: 'd1', title: 'T', phase: 'closed' }])).toBe(true);
+  });
+
+  it('STALE: a row missing only model', () => {
+    expect(isDebateIndexSchemaStale([{ id: 'd1', turn_count: 3 }])).toBe(true);
+  });
+
+  it('STALE: a row missing only turn_count', () => {
+    expect(isDebateIndexSchemaStale([{ id: 'd1', model: 'gemini-3.5-flash-lite' }])).toBe(true);
+  });
+
+  it('FRESH: a row carrying both keys is not stale — even when their values are undefined', () => {
+    // Key presence (not value) signals the new schema: a debate with no model set still
+    // carries the key, so it must NOT force a perpetual rebuild.
+    expect(isDebateIndexSchemaStale([{ id: 'd1', model: undefined, turn_count: 0 }])).toBe(false);
+    expect(isDebateIndexSchemaStale([{ id: 'd1', model: 'gemini-3.5-flash-lite', turn_count: 5 }])).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/server/storage/anonymousSessionStore.ts
+++ b/taxonomy-editor/src/server/storage/anonymousSessionStore.ts
@@ -319,13 +319,21 @@ export class AnonymousSessionStore {
 
   async listDebates(sessionId: string): Promise<unknown[]> {
     const debates = await this.listKind(sessionId, 'debates');
-    return debates.map(d => ({
-      id: d.id,
-      title: d.title || d.topic || 'Untitled Debate',
-      created_at: d.created_at || '',
-      updated_at: d.updated_at || d.created_at || '',
-      phase: d.phase || 'unknown',
-    })).sort((a, b) => String(b.updated_at || '').localeCompare(String(a.updated_at || '')));
+    return debates.map(d => {
+      // t/2725: project model + turn_count so the debate table's Turns/Model columns populate
+      // for anon hosted-web users. Mirrors debateStore.listDebateSessions / main/debateIO.ts —
+      // this producer previously dropped both, leaving both columns empty ("—") on web.
+      const transcript = Array.isArray(d.transcript) ? (d.transcript as { type?: string }[]) : [];
+      return {
+        id: d.id,
+        title: d.title || d.topic || 'Untitled Debate',
+        created_at: d.created_at || '',
+        updated_at: d.updated_at || d.created_at || '',
+        phase: d.phase || 'unknown',
+        model: d.debate_model,
+        turn_count: transcript.filter(t => t.type === 'statement' || t.type === 'opening').length,
+      };
+    }).sort((a, b) => String(b.updated_at || '').localeCompare(String(a.updated_at || '')));
   }
 
   async listDebatesMeta(sessionId: string): Promise<unknown[]> {

--- a/taxonomy-editor/src/server/storage/debateStore.ts
+++ b/taxonomy-editor/src/server/storage/debateStore.ts
@@ -78,12 +78,24 @@ async function removeFromDebateIndex(id: string): Promise<void> {
  * Falls back to full scan (listDebateSessions) and rebuilds the index on first call
  * or when the file count in the tree doesn't match the index (staleness check).
  */
+/**
+ * t/2725: a cached index whose rows predate the model/turn_count summary fields must be
+ * rebuilt — the count-only staleness check below can't detect a schema ADDITION (row count
+ * is unchanged), so it would keep serving fieldless rows (Turns/Model render empty).
+ */
+export function isDebateIndexSchemaStale(cached: unknown[]): boolean {
+  const first = cached[0] as Record<string, unknown> | undefined;
+  return first != null && (!('turn_count' in first) || !('model' in first));
+}
+
 export async function listDebateSessionsMeta(): Promise<unknown[]> {
   if (isAnonymousUser()) { const a = getAnonStore(); return a ? await a.store.listDebatesMeta(a.sessionId) : []; }
   const backend = getUserContentBackend();
   const dir = getDebatesDir();
   const cached = await readDebateIndex();
   if (cached !== null && cached.length > 0) {
+    // t/2725: rebuild synchronously on schema drift so this request returns populated fields.
+    if (isDebateIndexSchemaStale(cached)) return rebuildDebateIndex();
     // Lightweight staleness check: compare file count from tree with index size.
     // listDirectory() uses the in-memory repoTree — zero API calls.
     try {


### PR DESCRIPTION
## Bug (t/2725)
The debate table's **Turns** and **Model** columns render empty ("—") for every row on the hosted web app (screenshot t3.png). STATUS/DATE/TITLE populate fine.

## Root cause — producer-parity gap
The consumer is correct (`DebateTable.tsx` reads `s.turn_count`/`s.model`, shows "—" when null). The rows arrive without those fields:
- **Anon hosted-web users** → `anonymousSessionStore.listDebates` projected only `id/title/created_at/updated_at/phase`, **dropping `model` + `turn_count`**. `listKind` reads the full debate JSON (so `debate_model` + `transcript` were available) — the map just didn't project them. The desktop/main producers (`debateStore.listDebateSessions`, `main/debateIO.ts:89-90`) both include them. Classic dual-build producer divergence (t/2709 class).
- **Authed users** → cached debate index with a **count-only** staleness check (`debateStore.ts`) that can't detect a schema *addition* (row count unchanged) → a pre-field index keeps serving fieldless rows.

## Fix
1. `anonymousSessionStore.listDebates` — project `model: d.debate_model` + derived `turn_count` (statement+opening count), mirroring `listDebateSessions`.
2. `isDebateIndexSchemaStale()` — detect a cached-index row missing `model`/`turn_count` and rebuild synchronously (self-heals authed users on a pre-field index).

## Tests
- `anonymousSessionStore.test.ts`: asserts `model` + `turn_count` are projected (fails under old code).
- `debateStore.schemaStale.test.ts`: pure both-arm coverage of the schema-drift predicate (stale when a key is missing; fresh when keys present even with undefined values).

## Verification
Local run skipped (worktree/undici skew, t/2670#1) → **CI Node 22 is the gate**. Per the **t/2669 data-read-parity** rule, final sign-off is a hosted-web check that the columns populate for an anon session.

Ticket: t/2725
🤖 Generated with [Claude Code](https://claude.com/claude-code)