### PR TITLE
feat(oped): wire Step 0 source-brief comprehension pass (t/2722)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -12,7 +12,7 @@ import { loadTaxonomy } from '../debate/taxonomyLoader.js';
 import { computeEmbedding } from '../embeddings/onnxEmbedding.js';
 import type { OpEdMember, OpEdParams, OpEdSet, OpEdGroundingRef } from './types.js';
 import { resolveOutletBand } from './outletBands.js';
-import { loadAndAssemblePrompt, assembleReflectionPrompt, type SourceBrief } from './promptLoader.js';
+import { loadAndAssemblePrompt, assembleReflectionPrompt, assembleSourceBriefPrompt, type SourceBrief } from './promptLoader.js';
 
 // ── Public request / deps types ───────────────────────────────────────────────
 
@@ -37,6 +37,8 @@ export interface OpEdGeneratorDeps {
 // ── Progress event union ──────────────────────────────────────────────────────
 
 export type OpEdProgressEvent =
+  | { type: 'source_brief_done' }
+  | { type: 'source_brief_failed'; error: string }
   | { type: 'grounding_done'; nodeCount: number }
   | { type: 'grounding_failed'; error: string }
   | { type: 'voice_start'; pov: PovKey }
@@ -135,6 +137,20 @@ function buildGroundingList(nodes: ScoredPovNode[], sitNodes: ScoredSituationNod
 
 // ── Essay response schema ─────────────────────────────────────────────────────
 
+const SOURCE_BRIEF_SCHEMA = {
+  type: 'object',
+  properties: {
+    thesis: { type: 'string' },
+    author: { type: 'string' },
+    actor_type: { type: 'string' },
+    stance: { type: 'string' },
+    primary_recommendations: { type: 'array', items: { type: 'string' } },
+    key_claims: { type: 'array', items: { type: 'string' } },
+    readable: { type: 'boolean' },
+  },
+  required: ['thesis', 'author', 'actor_type', 'stance', 'primary_recommendations', 'key_claims', 'readable'],
+} as const;
+
 const ESSAY_SCHEMA = {
   type: 'object',
   properties: {
@@ -188,6 +204,7 @@ async function runVoiceGeneration(
   sitNodes: ScoredSituationNode[],
   request: GenerateOpEdRequest,
   deps: OpEdGeneratorDeps,
+  sourceBrief: SourceBrief | undefined,
 ): Promise<OpEdMember> {
   const soul = loadSoulDoc(deps.repoRoot, pov);
   const band = resolveOutletBand(request.params.outlet);
@@ -203,6 +220,7 @@ async function runVoiceGeneration(
     groundingNodes: formatGroundingNodes(groundingNodes),
     situations: formatSituationNodes(sitNodes),
     sourceMaterial: request.sourceMaterial ?? '(no external source supplied — argue from the topic and general knowledge)',
+    sourceBrief,
     outletGuidance: band.guidance,
     targetWords,
   });
@@ -251,8 +269,10 @@ async function runVoiceGeneration(
   if (allGroundingRefs.length > 0 && body) {
     try {
       const groundingList = buildGroundingList(groundingNodes, sitNodes);
-      // sourceClaims stays '(none)' for P1 — key_claims require the comprehension pass in Step-0 (TL)
-      const reflPrompt = assembleReflectionPrompt(deps.promptsDir, body, groundingList, '(none)');
+      const sourceClaims = sourceBrief?.key_claims?.length
+        ? sourceBrief.key_claims.map((c, i) => `  ${i + 1}. ${c}`).join('\n')
+        : '(none)';
+      const reflPrompt = assembleReflectionPrompt(deps.promptsDir, body, groundingList, sourceClaims);
       const reflMaxTokens = Math.max(4000, allGroundingRefs.length * 150 + 3000);
       const reflRaw = await deps.adapter.generateText(reflPrompt, request.params.model, {
         maxTokens: reflMaxTokens,
@@ -299,6 +319,29 @@ export async function* generateOpEdSet(
   request: GenerateOpEdRequest,
   deps: OpEdGeneratorDeps,
 ): AsyncGenerator<OpEdProgressEvent> {
+  // ── Step 0: source-brief comprehension (when URL source present) ─────────
+  // Extracts structured SourceBrief (thesis/author/stance/key_claims) from raw
+  // markdown so {{SOURCE_AUTHOR/THESIS/STANCE/RECOMMENDATIONS/KEY_CLAIMS}} are
+  // populated in the generation prompt. Non-fatal — falls through with undefined
+  // so voices still generate from raw {{SOURCE_MATERIAL}} text on failure.
+  let sourceBrief: SourceBrief | undefined;
+  if (request.sourceMaterial) {
+    try {
+      const briefPrompt = assembleSourceBriefPrompt(deps.promptsDir, request.sourceMaterial);
+      const briefRaw = await deps.adapter.generateText(briefPrompt, request.params.model, {
+        maxTokens: 2000,
+        temperature: 0.1,
+        responseSchema: SOURCE_BRIEF_SCHEMA as Record<string, unknown>,
+        signal: request.signal,
+      });
+      const parsed = JSON.parse(stripCodeFences(briefRaw)) as SourceBrief;
+      if (parsed.readable !== false) sourceBrief = parsed;
+      yield { type: 'source_brief_done' };
+    } catch (err) {
+      yield { type: 'source_brief_failed', error: String(err) };
+    }
+  }
+
   // ── Step 1: grounding ─────────────────────────────────────────────────────
   // BDI grounding is selected PER POV — the taxonomy is camp-partitioned
   // (`taxonomy[pov].nodes`, ids `{pov}-{category}-{NNN}`), so a camp's grounding IS
@@ -364,7 +407,7 @@ export async function* generateOpEdSet(
     } else {
       enqueue({ type: 'voice_start', pov });
       try {
-        const member = await runVoiceGeneration(pov, groundingByPov.get(pov) ?? [], sitNodes, request, deps);
+        const member = await runVoiceGeneration(pov, groundingByPov.get(pov) ?? [], sitNodes, request, deps, sourceBrief);
         members.push({ pov, member });
         enqueue({ type: 'voice_complete', pov, member });
       } catch (err) {

--- a/lib/oped/promptLoader.ts
+++ b/lib/oped/promptLoader.ts
@@ -13,7 +13,7 @@ export interface SourceBrief {
   stance?: string;
   primary_recommendations?: string[];
   key_claims?: string[];
-  readable?: string;
+  readable?: boolean;
 }
 
 export interface PromptContext {
@@ -88,6 +88,12 @@ export function loadAndAssemblePrompt(promptsDir: string, ctx: PromptContext): A
   });
 
   return { system, user };
+}
+
+export function assembleSourceBriefPrompt(promptsDir: string, sourceMaterial: string): string {
+  return interpolate(loadPromptTemplate(promptsDir, 'op-ed-source-brief'), {
+    SOURCE_MATERIAL: sourceMaterial,
+  });
 }
 
 export function assembleReflectionPrompt(

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -29,6 +29,7 @@ vi.mock('./outletBands.js', () => ({ resolveOutletBand: () => ({ words: 800, gui
 vi.mock('./promptLoader.js', () => ({
   loadAndAssemblePrompt: () => ({ system: 'sys', user: 'user' }),
   assembleReflectionPrompt: () => 'refl',
+  assembleSourceBriefPrompt: () => 'source-brief-prompt',
 }));
 
 import { fileURLToPath } from 'url';
@@ -108,5 +109,98 @@ describe('generateOpEdSet — document_claims propagation (t/2722)', () => {
     // Empty document_claims array → field stays absent (only set when length > 0)
     const sitRef = member!.grounding.find(r => r.node_id === 'sit-001');
     expect(sitRef?.document_claims).toBeUndefined();
+  });
+});
+
+describe('generateOpEdSet — Step 0 source-brief comprehension (t/2722)', () => {
+  const ESSAY_JSON = JSON.stringify({ headline: 'H', subtitle: '', body_markdown: 'Body.', word_count: 1 });
+  const REFL_JSON = JSON.stringify({ grounding_usage: [] });
+
+  it('yields source_brief_done before grounding_done when comprehension succeeds', async () => {
+    const BRIEF_JSON = JSON.stringify({
+      thesis: 'AI labs must share safety research',
+      author: 'Test Org', actor_type: 'think tank',
+      stance: 'FOR mandatory sharing',
+      primary_recommendations: ['Mandate sharing within 30 days'],
+      key_claims: ['Safety incidents doubled last year', 'Only 3 labs share proactively'],
+      readable: true,
+    });
+    const adapter = {
+      generateText: async (prompt: string) => {
+        if (prompt === 'source-brief-prompt') return BRIEF_JSON;
+        if (prompt === 'refl') return REFL_JSON;
+        return ESSAY_JSON;
+      },
+    };
+    const req = {
+      set_id: 's3', topic: 'AI safety sharing',
+      params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' } as never,
+      povs: ['accelerationist'] as PovKey[],
+      sourceMaterial: 'Full document text...',
+    };
+    const deps = { adapter: adapter as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT };
+
+    const events: string[] = [];
+    for await (const ev of generateOpEdSet(req, deps) as AsyncGenerator<OpEdProgressEvent>) {
+      events.push(ev.type);
+    }
+
+    expect(events).toContain('source_brief_done');
+    const briefIdx = events.indexOf('source_brief_done');
+    const groundingIdx = events.indexOf('grounding_done');
+    expect(briefIdx).toBeGreaterThanOrEqual(0);
+    expect(groundingIdx).toBeGreaterThanOrEqual(0);
+    expect(briefIdx).toBeLessThan(groundingIdx);
+  });
+
+  it('yields source_brief_failed but still completes when comprehension throws', async () => {
+    const adapter = {
+      generateText: async (prompt: string) => {
+        if (prompt === 'source-brief-prompt') throw new Error('network error');
+        if (prompt === 'refl') return REFL_JSON;
+        return ESSAY_JSON;
+      },
+    };
+    const req = {
+      set_id: 's4', topic: 'AI safety',
+      params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' } as never,
+      povs: ['accelerationist'] as PovKey[],
+      sourceMaterial: 'Some text',
+    };
+    const deps = { adapter: adapter as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT };
+
+    const events: string[] = [];
+    for await (const ev of generateOpEdSet(req, deps) as AsyncGenerator<OpEdProgressEvent>) {
+      events.push(ev.type);
+    }
+
+    expect(events).toContain('source_brief_failed');
+    expect(events).toContain('complete'); // non-fatal
+    expect(events).not.toContain('source_brief_done');
+  });
+
+  it('skips Step 0 entirely when no sourceMaterial is provided', async () => {
+    const adapter = {
+      generateText: async (prompt: string) => {
+        if (prompt === 'source-brief-prompt') throw new Error('should not be called');
+        if (prompt === 'refl') return REFL_JSON;
+        return ESSAY_JSON;
+      },
+    };
+    const req = {
+      set_id: 's5', topic: 'AI policy',
+      params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' } as never,
+      povs: ['accelerationist'] as PovKey[],
+    };
+    const deps = { adapter: adapter as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT };
+
+    const events: string[] = [];
+    for await (const ev of generateOpEdSet(req, deps) as AsyncGenerator<OpEdProgressEvent>) {
+      events.push(ev.type);
+    }
+
+    expect(events).not.toContain('source_brief_done');
+    expect(events).not.toContain('source_brief_failed');
+    expect(events).toContain('complete');
   });
 });


### PR DESCRIPTION
## Summary
- Wires the missing source-brief comprehension pass (Step 0) into `generateOpEdSet` — when `sourceMaterial` is present, runs `op-ed-source-brief.prompt` via the AI adapter before grounding, producing a structured `SourceBrief`
- `SourceBrief.key_claims` now flows into `assembleReflectionPrompt` as `sourceClaims`, so the reflection pass maps document claims to BDI grounding refs
- `SourceBrief` structured fields (thesis/author/stance/recommendations/key_claims) now populate the generation prompt placeholders via `loadAndAssemblePrompt`
- Fixes `SourceBrief.readable` type: `string` → `boolean` (matching the prompt contract)
- Adds `assembleSourceBriefPrompt` to `promptLoader.ts`
- 3 new test cases: Step 0 success (yields `source_brief_done` before grounding), Step 0 failure (yields `source_brief_failed`, still completes), no sourceMaterial (Step 0 skipped entirely)

## Context
PR B of t/2722. PR A (#1159, web route 400) already landed. This PR closes the remaining acceptance criteria — all four ACs should be satisfied once merged.

Tested: 5/5 tests pass (`serialGeneration.test.ts` — 2 pre-existing + 3 new Step 0 cases).

## Test plan
- [ ] CI verify gate passes
- [ ] Manual: URL-source op-ed in desktop app — BDI grounding renders with document-claim subchildren; SOURCE_AUTHOR/THESIS/RECOMMENDATIONS are populated (not blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)