### PR TITLE
feat(oped): wire FABRICATED_LEDE_GUARD to production + guard-regression tests

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -13,6 +13,8 @@ import { computeEmbedding } from '../embeddings/onnxEmbedding.js';
 import type { OpEdMember, OpEdParams, OpEdSet, OpEdGroundingRef } from './types.js';
 import { resolveOutletBand } from './outletBands.js';
 import { loadAndAssemblePrompt, assembleReflectionPrompt, type SourceBrief } from './promptLoader.js';
+import { FABRICATED_LEDE_GUARD } from './opedGuards.js';
+import { getGlobalRecorder } from '../flight-recorder/index.js';
 
 // ── Public request / deps types ───────────────────────────────────────────────
 
@@ -274,6 +276,17 @@ async function runVoiceGeneration(
     }
   }
 
+  // Guard scan: when newsHook was empty, check the lede (first 500 chars) for
+  // fabricated dated-event markers. Flag without mutating the body (t/2730).
+  const emptyHook = !request.params.newsHook?.trim();
+  const fabricatedLede = emptyHook && FABRICATED_LEDE_GUARD.test(body.slice(0, 500));
+  if (fabricatedLede) {
+    getGlobalRecorder()?.record({
+      type: 'system.warning', component: 'opedGenerate', level: 'warn',
+      message: `FABRICATED_LEDE_GUARD matched for pov=${pov} set=${request.set_id} — empty-hook lede may contain invented dated event`,
+    });
+  }
+
   return {
     pov,
     status: 'complete',
@@ -283,6 +296,7 @@ async function runVoiceGeneration(
     pitch: parsed.pitch_email || undefined,
     wordCount: actualWordCount,
     grounding: allGroundingRefs,
+    ...(fabricatedLede && { fabricated_lede: true as const }),
   };
 }
 

--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -14,7 +14,6 @@ import type { OpEdMember, OpEdParams, OpEdSet, OpEdGroundingRef } from './types.
 import { resolveOutletBand } from './outletBands.js';
 import { loadAndAssemblePrompt, assembleReflectionPrompt, type SourceBrief } from './promptLoader.js';
 import { FABRICATED_LEDE_GUARD } from './opedGuards.js';
-import { getGlobalRecorder } from '../flight-recorder/index.js';
 
 // ── Public request / deps types ───────────────────────────────────────────────
 
@@ -34,6 +33,8 @@ export interface OpEdGeneratorDeps {
   promptsDir: string;
   /** Repo root — locates soul-docs/ and taxonomy/embeddings data. */
   repoRoot: string;
+  /** Optional recorder for guard warnings — pass getGlobalRecorder() from the host. */
+  recorder?: { record: (event: Record<string, unknown>) => void } | null;
 }
 
 // ── Progress event union ──────────────────────────────────────────────────────
@@ -281,7 +282,7 @@ async function runVoiceGeneration(
   const emptyHook = !request.params.newsHook?.trim();
   const fabricatedLede = emptyHook && FABRICATED_LEDE_GUARD.test(body.slice(0, 500));
   if (fabricatedLede) {
-    getGlobalRecorder()?.record({
+    deps.recorder?.record({
       type: 'system.warning', component: 'opedGenerate', level: 'warn',
       message: `FABRICATED_LEDE_GUARD matched for pov=${pov} set=${request.set_id} — empty-hook lede may contain invented dated event`,
     });

--- a/lib/oped/opedGuards.test.ts
+++ b/lib/oped/opedGuards.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { FABRICATED_LEDE_GUARD } from './opedGuards.js';
+
+// ── Positive arm: guard fires on known fabricated dated-event phrases ─────────
+
+describe('FABRICATED_LEDE_GUARD — positive arm (fabrication detected)', () => {
+  const FABRICATED_CASES = [
+    'This week, as federal regulators draft new rules requiring multi-month pre-clearance audits…',
+    'Next week, the Senate will take a pending vote on the newly proposed AI regulation.',
+    'Yesterday, the agency released a newly drafted rule on frontier model oversight.',
+    'The pending ruling from the appeals court has shaken the industry.',
+    'The newly proposed regulation would require pre-clearance from an independent board.',
+    'Pre-clearance requirements are now under discussion in Brussels.',
+    'Regulators are drafting new regulations that would require pre-clearance for every model release.',
+    'A newly drafted rule from the FTC landed this week, catching developers off guard.',
+    "Next week's pending vote in the Senate threatens to reshape the field overnight.",
+    "Yesterday's announcement of a pre-clearance mandate sent shockwaves through Silicon Valley.",
+    'The pending ruling, expected this week, would mandate pre-clearance of any frontier system.',
+    'Newly proposed rules would require developers to seek pre-clearance 90 days before release.',
+  ];
+
+  FABRICATED_CASES.forEach((text, i) => {
+    it(`case ${i + 1}: detects fabricated dated-event marker`, () => {
+      expect(FABRICATED_LEDE_GUARD.test(text)).toBe(true);
+    });
+  });
+});
+
+// ── Negative arm (N≥10): guard fires 0 times on timeless stakes framing ──────
+
+describe('FABRICATED_LEDE_GUARD — guard-regression (mock): 0 fires on timeless empty-hook ledes', () => {
+  const TIMELESS_LEDES = [
+    'The question of who controls artificial intelligence has never been more consequential.',
+    'A structural tension at the heart of the field — speed versus safety — demands a clear answer.',
+    'Machines now write code, diagnose disease, and advise judges. The field has never moved faster.',
+    'Every technology that reshaped civilization arrived before the rules to govern it. AI is no different.',
+    'The last time a single technology threatened to compress decades of change into years, we called it the internet.',
+    'For decades, the promise of artificial general intelligence lived in science fiction. It is no longer fiction.',
+    'The real risk of advanced AI is not a robot rebellion. It is a slow, invisible transfer of power.',
+    'Acceleration is not a policy. It is a bet — and right now, the house always wins.',
+    'Safety and speed are not opposites. The engineers who believe otherwise have never shipped a bridge.',
+    'We have been here before: a technology too powerful to ignore, too complex to regulate, and too profitable to slow.',
+    'When a single model can pass the bar exam, write legislation, and simulate a pandemic, governance cannot wait.',
+    'The optimists say the risks are theoretical. The pessimists say they are already here. Both are right.',
+  ];
+
+  TIMELESS_LEDES.forEach((text, i) => {
+    it(`case ${i + 1}: does not flag timeless framing`, () => {
+      expect(FABRICATED_LEDE_GUARD.test(text)).toBe(false);
+    });
+  });
+});

--- a/lib/oped/opedGuards.ts
+++ b/lib/oped/opedGuards.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Detects fabricated dated-event markers in op-ed ledes produced when newsHook
+ * was empty. The empty-hook fallback (t/2721) tells the model not to invent
+ * events; this guard is the runtime enforcement layer — it scans the first
+ * paragraph of generated output and flags any slip-through.
+ *
+ * Canonical form — stipulated in metric-provenance-register §5 (t/2726).
+ */
+export const FABRICATED_LEDE_GUARD =
+  /\b(this week|next week|yesterday|pending (vote|ruling)|newly? (proposed|drafted) (rule|regulation)|pre-?clearance)\b/i;

--- a/lib/oped/promptAssembly.test.ts
+++ b/lib/oped/promptAssembly.test.ts
@@ -6,6 +6,7 @@ import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { loadAndAssemblePrompt, assembleReflectionPrompt, type PromptContext } from './promptLoader.js';
+import { FABRICATED_LEDE_GUARD } from './opedGuards.js';
 
 // Fixture prompt templates — minimal placeholders that cover every interpolation key
 const SYSTEM_TEMPLATE =
@@ -97,10 +98,6 @@ describe('loadAndAssemblePrompt', () => {
     expect(user).toContain('enduring stakes');
   });
 
-  // Guard pattern for fabricated dated-event markers (stipulated lexicon — t/2721)
-  // Provenance: CL to register in metric-provenance-register once pattern is final.
-  const FABRICATED_LEDE_GUARD =
-    /\b(this week|next week|yesterday|pending (vote|ruling)|newly? (proposed|drafted) (rule|regulation)|pre-?clearance)\b/i;
 
   it('FABRICATED_LEDE_GUARD matches known fabricated regulatory text', () => {
     const fabricated =

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -30,6 +30,7 @@ vi.mock('./promptLoader.js', () => ({
   loadAndAssemblePrompt: () => ({ system: 'sys', user: 'user' }),
   assembleReflectionPrompt: () => 'refl',
 }));
+vi.mock('../flight-recorder/index.js', () => ({ getGlobalRecorder: () => null }));
 
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -108,5 +109,44 @@ describe('generateOpEdSet — document_claims propagation (t/2722)', () => {
     // Empty document_claims array → field stays absent (only set when length > 0)
     const sitRef = member!.grounding.find(r => r.node_id === 'sit-001');
     expect(sitRef?.document_claims).toBeUndefined();
+  });
+});
+
+describe('generateOpEdSet — FABRICATED_LEDE_GUARD integration (t/2730)', () => {
+  const makeAdapter = (body: string) => ({
+    generateText: async () => JSON.stringify({ headline: 'H', subtitle: '', body_markdown: body, word_count: body.split(/\s+/).length }),
+  });
+  const makeReq = (newsHook: string) => ({
+    set_id: 'g1', topic: 'AI policy',
+    params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook, thesis: '' } as never,
+    povs: ['accelerationist'] as PovKey[],
+  });
+  const DEPS = { adapter: null as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT };
+
+  it('fabricated_lede is absent when body is timeless and newsHook is empty', async () => {
+    const deps = { ...DEPS, adapter: makeAdapter('The question of who controls AI has never been more consequential.') as never };
+    let member: { fabricated_lede?: true } | undefined;
+    for await (const ev of generateOpEdSet(makeReq(''), deps) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_complete') member = ev.member as typeof member;
+    }
+    expect(member?.fabricated_lede).toBeUndefined();
+  });
+
+  it('fabricated_lede is true when body contains a guard phrase and newsHook is empty', async () => {
+    const deps = { ...DEPS, adapter: makeAdapter('This week regulators released a newly proposed pre-clearance rule for AI.') as never };
+    let member: { fabricated_lede?: true } | undefined;
+    for await (const ev of generateOpEdSet(makeReq(''), deps) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_complete') member = ev.member as typeof member;
+    }
+    expect(member?.fabricated_lede).toBe(true);
+  });
+
+  it('fabricated_lede is absent even when body has guard phrase if newsHook is non-empty', async () => {
+    const deps = { ...DEPS, adapter: makeAdapter('This week regulators released a newly proposed pre-clearance rule for AI.') as never };
+    let member: { fabricated_lede?: true } | undefined;
+    for await (const ev of generateOpEdSet(makeReq('EU AI Act passed committee') , deps) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_complete') member = ev.member as typeof member;
+    }
+    expect(member?.fabricated_lede).toBeUndefined();
   });
 });

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -30,7 +30,6 @@ vi.mock('./promptLoader.js', () => ({
   loadAndAssemblePrompt: () => ({ system: 'sys', user: 'user' }),
   assembleReflectionPrompt: () => 'refl',
 }));
-vi.mock('../flight-recorder/index.js', () => ({ getGlobalRecorder: () => null }));
 
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';

--- a/lib/oped/types.ts
+++ b/lib/oped/types.ts
@@ -45,6 +45,8 @@ export interface OpEdMember {
   pitch?: string;
   wordCount: number;
   grounding: OpEdGroundingRef[];
+  /** Set when FABRICATED_LEDE_GUARD matched the lede on an empty-newsHook run (t/2730). */
+  fabricated_lede?: true;
 }
 
 // ── Set wrapper (e/91#2 conditions 2 & 4) ────────────────────────────────────


### PR DESCRIPTION
## Summary

- `lib/oped/opedGuards.ts` — exports `FABRICATED_LEDE_GUARD` as single source of truth (canonical form, stipulated in metric-provenance-register §5 / t/2726)
- `lib/oped/types.ts` — adds `fabricated_lede?: true` to `OpEdMember`
- `lib/oped/generate.ts` — scans first 500 chars of generated body against guard when `newsHook` was empty; sets `fabricated_lede: true` + flight-recorder warning on match (no body mutation — flag+warn, CL-approved)
- `lib/oped/promptAssembly.test.ts` — imports guard from `opedGuards.ts`, removes inline copy
- `lib/oped/opedGuards.test.ts` — 12 positive cases + 12 timeless-framing negative cases (guard-regression mock, N≥10 per AC#3)
- `lib/oped/serialGeneration.test.ts` — 3 guard integration cases (clean/empty-hook, fabricated/empty-hook, fabricated/non-empty-hook)

40/40 tests pass.

## Test plan

- [ ] CI green on head
- [ ] CL reviews + signs off; graduates register row §8→§5

🤖 Generated with [Claude Code](https://claude.ai/claude-code)