### PR TITLE
fix(debate): coerce object title in DebateTab search + BulkDeleteDialog (t/2729, t/2734)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -265,7 +265,7 @@ export function DebateTab() {
     const q = searchQuery.trim().toLowerCase();
     if (!q) return orderedSessions;
     return orderedSessions.filter(s =>
-      (s.title ?? '').toLowerCase().includes(q) ||
+      (typeof s.title === 'string' ? s.title : '').toLowerCase().includes(q) ||
       (s.topic_text && s.topic_text.toLowerCase().includes(q))
     );
   }, [orderedSessions, searchQuery]);
@@ -895,7 +895,7 @@ function BulkDeleteDialog({
         <div className="bulk-delete-list">
           {sessions.filter(s => selectedIds.has(s.id)).map(s => (
             <div key={s.id} className="bulk-delete-item">
-              <span className="bulk-delete-item-title">{s.title}</span>
+              <span className="bulk-delete-item-title">{typeof s.title === 'string' ? s.title : (s.title as any)?.final ?? (s.title as any)?.original ?? '(Untitled)'}</span>
               <span className="bulk-delete-item-meta">{s.phase} &middot; {formatDate(s.updated_at)}</span>
             </div>
           ))}


### PR DESCRIPTION
## Summary

Fixes two crash surfaces caused by stale index entries where `title` is `{final, original}` instead of a string.

- **t/2734** `DebateTab.tsx:268` — `(s.title ?? '').toLowerCase()` throws TypeError when title is an object. Fixed with `typeof` guard.
- **t/2729** `DebateTab.tsx:898` — `{s.title}` in BulkDeleteDialog throws React "Objects are not valid as a React child". Fixed: extract `.final ?? .original ?? "(Untitled)"`.

`debateIndex.ts:165` already has the cache-invalidation guard (`typeof cached.title === 'string'`) — no change needed there.

## Test plan

- [ ] CI green
- [ ] BulkDeleteDialog with stale object-title session: no crash, title shown
- [ ] Search with stale-title session: no TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)