### PR TITLE
prevent(debate): fail-closed on missing exclusion_vector in filter functions (t/2747)

### DIFF
--- a/lib/debate/exclusionGuard.test.ts
+++ b/lib/debate/exclusionGuard.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   checkClaimExclusionBoundary,
   checkDraftScopeBoundary,
+  filterByExclusionAbsolute,
+  filterByExclusionRatio,
   EXCLUSION_RATIO_THRESHOLD,
   SCOPE_BOUNDARY_THRESHOLD,
 } from './exclusionGuard.js';
@@ -207,5 +209,99 @@ describe('checkDraftScopeBoundary', () => {
     );
     expect(result.length).toBe(1);
     expect(result[0].node_id).toBe('n1');
+  });
+});
+
+describe('filterByExclusionAbsolute — fail-closed on missing exclusion_vector', () => {
+  function makeVec(seed: number, dim = 384): number[] {
+    const v = new Array(dim).fill(0);
+    v[0] = Math.cos(seed);
+    v[1] = Math.sin(seed);
+    return v;
+  }
+
+  it('does not pass a node when exclusion_vector is absent', () => {
+    const embeddings = {
+      'n1': { pov: 'acc', vector: makeVec(0) }, // no exclusion_vector
+    };
+    const result = filterByExclusionAbsolute(['n1'], makeVec(0), embeddings);
+    expect(result.passed).not.toContain('n1');
+  });
+
+  it('places missing-vector node in flagged_no_vector', () => {
+    const embeddings = {
+      'n1': { pov: 'acc', vector: makeVec(0) },
+    };
+    const result = filterByExclusionAbsolute(['n1'], makeVec(0), embeddings);
+    expect(result.flagged_no_vector).toContain('n1');
+  });
+
+  it('passes node normally when exclusion_vector is present and below threshold', () => {
+    const embeddings = {
+      'n1': { pov: 'acc', vector: makeVec(0), exclusion_vector: makeVec(Math.PI) },
+    };
+    const result = filterByExclusionAbsolute(['n1'], makeVec(0), embeddings);
+    expect(result.passed).toContain('n1');
+    expect(result.flagged_no_vector).toHaveLength(0);
+  });
+
+  it('mixes correctly: missing-vector goes to flagged, checked nodes route normally', () => {
+    const embeddings = {
+      'safe': { pov: 'acc', vector: makeVec(0), exclusion_vector: makeVec(Math.PI) },
+      'excluded': { pov: 'acc', vector: makeVec(0), exclusion_vector: makeVec(0.1) },
+      'unverifiable': { pov: 'acc', vector: makeVec(0) },
+    };
+    const result = filterByExclusionAbsolute(['safe', 'excluded', 'unverifiable'], makeVec(0.1), embeddings);
+    expect(result.passed).toContain('safe');
+    expect(result.skipped.map(s => s.node_id)).toContain('excluded');
+    expect(result.flagged_no_vector).toContain('unverifiable');
+    expect(result.passed).not.toContain('unverifiable');
+  });
+});
+
+describe('filterByExclusionRatio — fail-closed on missing exclusion_vector', () => {
+  function makeVec(seed: number, dim = 384): number[] {
+    const v = new Array(dim).fill(0);
+    v[0] = Math.cos(seed);
+    v[1] = Math.sin(seed);
+    return v;
+  }
+
+  it('does not pass a node when exclusion_vector is absent', () => {
+    const embeddings = {
+      'n1': { pov: 'acc', vector: makeVec(0) },
+    };
+    const result = filterByExclusionRatio(['n1'], makeVec(0), embeddings);
+    expect(result.passed).not.toContain('n1');
+  });
+
+  it('places missing-vector node in flagged_no_vector', () => {
+    const embeddings = {
+      'n1': { pov: 'acc', vector: makeVec(0) },
+    };
+    const result = filterByExclusionRatio(['n1'], makeVec(0), embeddings);
+    expect(result.flagged_no_vector).toContain('n1');
+  });
+
+  it('passes node normally when exclusion_vector is present and ratio is safe', () => {
+    const embeddings = {
+      'n1': { pov: 'acc', vector: makeVec(0.1), exclusion_vector: makeVec(Math.PI) },
+    };
+    const result = filterByExclusionRatio(['n1'], makeVec(0.1), embeddings);
+    expect(result.passed).toContain('n1');
+    expect(result.flagged_no_vector).toHaveLength(0);
+  });
+
+  it('mixes correctly: missing-vector flagged, checked nodes route normally', () => {
+    const embeddings = {
+      'safe': { pov: 'acc', vector: makeVec(0.1), exclusion_vector: makeVec(Math.PI) },
+      'demoted': { pov: 'acc', vector: makeVec(2.0), exclusion_vector: makeVec(0.1) },
+      'unverifiable': { pov: 'acc', vector: makeVec(0) },
+    };
+    const result = filterByExclusionRatio(['safe', 'demoted', 'unverifiable'], makeVec(0.1), embeddings);
+    expect(result.passed).toContain('safe');
+    expect(result.demoted.map(d => d.node_id)).toContain('demoted');
+    expect(result.flagged_no_vector).toContain('unverifiable');
+    expect(result.passed).not.toContain('unverifiable');
   });
 });

--- a/lib/debate/exclusionGuard.ts
+++ b/lib/debate/exclusionGuard.ts
@@ -14,6 +14,8 @@ export interface ExclusionDemotion {
 export interface ExclusionFilterResult {
   passed: string[];
   demoted: ExclusionDemotion[];
+  /** Nodes held back because no exclusion_vector was available — never asserted as aligned. */
+  flagged_no_vector: string[];
 }
 
 export interface ExclusionViolation {
@@ -96,6 +98,8 @@ export function checkDraftScopeBoundary(
 export interface SituationExclusionResult {
   passed: string[];
   skipped: { node_id: string; similarity_exclusion: number }[];
+  /** Nodes held back because no exclusion_vector was available — never asserted as aligned. */
+  flagged_no_vector: string[];
 }
 
 export function filterByExclusionAbsolute(
@@ -106,11 +110,12 @@ export function filterByExclusionAbsolute(
 ): SituationExclusionResult {
   const passed: string[] = [];
   const skipped: { node_id: string; similarity_exclusion: number }[] = [];
+  const flagged_no_vector: string[] = [];
 
   for (const nodeId of candidateNodeIds) {
     const entry = nodeEmbeddings[nodeId];
     if (!entry?.exclusion_vector) {
-      passed.push(nodeId);
+      flagged_no_vector.push(nodeId);
       continue;
     }
 
@@ -122,7 +127,7 @@ export function filterByExclusionAbsolute(
     }
   }
 
-  return { passed, skipped };
+  return { passed, skipped, flagged_no_vector };
 }
 
 export function filterByExclusionRatio(
@@ -133,11 +138,12 @@ export function filterByExclusionRatio(
 ): ExclusionFilterResult {
   const passed: string[] = [];
   const demoted: ExclusionDemotion[] = [];
+  const flagged_no_vector: string[] = [];
 
   for (const nodeId of candidateNodeIds) {
     const entry = nodeEmbeddings[nodeId];
     if (!entry?.exclusion_vector) {
-      passed.push(nodeId);
+      flagged_no_vector.push(nodeId);
       continue;
     }
 
@@ -151,5 +157,5 @@ export function filterByExclusionRatio(
     }
   }
 
-  return { passed, demoted };
+  return { passed, demoted, flagged_no_vector };
 }


### PR DESCRIPTION
## Summary
- `filterByExclusionAbsolute` and `filterByExclusionRatio` previously passed nodes through when `exclusion_vector` was absent, implicitly asserting alignment with no directional signal
- Now: nodes with no `exclusion_vector` go to `flagged_no_vector` (new additive field on both result types) instead of `passed`
- Callers using only `passed` automatically get fail-closed behavior — unverifiable nodes are not asserted as aligned
- 8 new regression tests: missing-vector path for both functions, including mixed fixtures with safe / demoted / unverifiable nodes

## Out of scope (PS half)
`Find-SituationCandidates.ps1` NLI default-to-entailment (t/2747 item 1) is being routed to the scripts owner separately.

## Test plan
- [ ] 21/21 `exclusionGuard.test.ts` tests pass (verified locally)
- [ ] TypeScript: no new errors introduced (`contentSanitizerCore.ts` errors are pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)