### PR TITLE
fix(situations): fail closed on unlabeled NLI pairs in Find-SituationCandidates (t/2747)

### DIFF
--- a/scripts/AITriad/Private/Resolve-NliLabelOrDefault.ps1
+++ b/scripts/AITriad/Private/Resolve-NliLabelOrDefault.ps1
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Resolve-NliLabelOrDefault {
+    <#
+    .SYNOPSIS
+        Return a similar pair's NLI label, failing CLOSED to 'neutral' when absent.
+    .DESCRIPTION
+        Used by Find-SituationCandidates when labeling shared-concept clusters. NLI
+        classification can be skipped (-NoNLI) or fail at runtime, leaving a pair with
+        no NliLabel. Such a pair must NOT be assumed to be verified agreement: it is
+        embedding-similar but its directional relationship is unverified. Defaulting to
+        'entailment' (the prior behavior) asserted shared-concept agreement we never
+        confirmed — a fail-OPEN bug (t/2747). This resolves to 'neutral' instead, so an
+        unverified pair is surfaced as a candidate without claiming entailment.
+    .PARAMETER Pair
+        A similar-pair object that may carry an 'NliLabel' note property.
+    .OUTPUTS
+        [string] the pair's NliLabel when present and non-empty, otherwise 'neutral'.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)]
+        [PSObject]$Pair
+    )
+
+    Set-StrictMode -Version Latest
+
+    if ($Pair.PSObject.Properties['NliLabel'] -and $Pair.NliLabel) {
+        return [string]$Pair.NliLabel
+    }
+    return 'neutral'
+}

--- a/scripts/AITriad/Public/Find-SituationCandidates.ps1
+++ b/scripts/AITriad/Public/Find-SituationCandidates.ps1
@@ -407,7 +407,10 @@ function Find-SituationCandidates {
         $Members = @($Pair.IdA, $Pair.IdB)
         $PovsRepresented = @($Members | ForEach-Object { $NodeIndex[$_].POV } | Select-Object -Unique)
         if ($PovsRepresented.Count -lt 2) { continue }
-        if ($Pair.PSObject.Properties['NliLabel'] -and $Pair.NliLabel) { $NliLabel = $Pair.NliLabel } else { $NliLabel = 'entailment' }
+        # Fail CLOSED: an unlabeled / NLI-failed pair is unverified, not agreement.
+        # Defaulting to 'entailment' here asserted shared-concept agreement we never
+        # confirmed (fail-open, t/2747); resolve to 'neutral' instead.
+        $NliLabel = Resolve-NliLabelOrDefault -Pair $Pair
         $NliCounts = @{ entailment = 0; neutral = 0; contradiction = 0 }
         $NliCounts[$NliLabel]++
         $AllScoredGroups.Add([PSCustomObject]@{

--- a/tests/Resolve-NliLabelOrDefault.Tests.ps1
+++ b/tests/Resolve-NliLabelOrDefault.Tests.ps1
@@ -1,0 +1,51 @@
+# Tag: situations (t/2747)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Resolve-NliLabelOrDefault fail-closed regression (t/2747).
+.DESCRIPTION
+    Find-SituationCandidates previously defaulted an unlabeled / NLI-failed similar
+    pair to 'entailment' (fail-OPEN: asserting shared-concept agreement it never
+    verified). This helper is the fail-closed seam — an absent/empty NliLabel must
+    resolve to 'neutral', never 'entailment'. Mirrors the TS exclusionGuard fix
+    (PR #1171).
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Resolve-NliLabelOrDefault (t/2747 fail-closed)' -Tag 'situations' {
+
+    It 'returns the real label when NliLabel is present' {
+        InModuleScope AITriad {
+            foreach ($label in 'entailment', 'neutral', 'contradiction') {
+                $pair = [PSCustomObject]@{ IdA = 'a'; IdB = 'b'; NliLabel = $label }
+                Resolve-NliLabelOrDefault -Pair $pair | Should -Be $label
+            }
+        }
+    }
+
+    It 'fails closed to neutral (NOT entailment) when NliLabel property is absent' {
+        InModuleScope AITriad {
+            $pair = [PSCustomObject]@{ IdA = 'a'; IdB = 'b'; Similarity = 0.65 }
+            $result = Resolve-NliLabelOrDefault -Pair $pair
+            $result | Should -Be 'neutral'
+            $result | Should -Not -Be 'entailment' -Because 'an unverified pair must never be assumed agreement (t/2747)'
+        }
+    }
+
+    It 'fails closed to neutral when NliLabel is present but null or empty' {
+        InModuleScope AITriad {
+            foreach ($empty in $null, '') {
+                $pair = [PSCustomObject]@{ IdA = 'a'; IdB = 'b'; NliLabel = $empty }
+                Resolve-NliLabelOrDefault -Pair $pair | Should -Be 'neutral'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What (spec §9 PARTIAL — PS half of t/2747)
`Find-SituationCandidates` labeled shared-concept clusters. In the loose-agreement-pair path (~line 410), an unlabeled / NLI-failed similar pair defaulted to `NliLabel='entailment'` — asserting **verified shared-concept agreement it never confirmed** (fail-OPEN). Under `-NoNLI`, or on any NLI runtime failure, embedding-similar pairs were surfaced as entailment.

## Fix
Extract the default into a named Private helper `Resolve-NliLabelOrDefault` that **fails CLOSED to `neutral`** (unverified, not agreement), and route the loose-pair path through it. The pair still surfaces as a candidate but is no longer labeled entailment. Mirrors the TS half (exclusionGuard fail-closed, PR #1171).

## Tests
`tests/Resolve-NliLabelOrDefault.Tests.ps1`: real label passes through; absent `NliLabel` → `neutral` (never `entailment`); null/empty → `neutral`. 3/3 green. Module import + manifest OK.

Self-certified (single-scope bug fix mirroring the landed TS half).

**Note:** required `test-server-prod-config` is currently red on `main` (Actions infra "Set up job" failure, DevOps aware) — will merge on green once it clears.

Closes t/2747 (PS half). 🤖 Generated with [Claude Code](https://claude.com/claude-code)