### PR TITLE
feat(debate): V3+V5 directional gates for stance-polarity inversion (t/2746)

### DIFF
--- a/lib/debate/argumentNetwork/attribution.ts
+++ b/lib/debate/argumentNetwork/attribution.ts
@@ -5,6 +5,7 @@
 
 import type { ArgumentNetworkNode, ClaimTaxonomyAttribution } from '../types.js';
 import { cosineSimilarity, scoreNodeRelevanceMeanTopN } from '../taxonomyRelevance.js';
+import { EXCLUSION_RATIO_THRESHOLD } from '../exclusionGuard.js';
 
 /** Thresholds per spec: primary ≥ 0.35, secondary ≥ 0.40. */
 const ATTRIBUTION_PRIMARY_THRESHOLD = 0.35;
@@ -23,7 +24,7 @@ export interface ClaimAttributionDecision {
   primary_ref: string | null;
   attribution_confidence: number;
   secondary_refs_count: number;
-  unattributed_reason?: 'novel_argument' | 'no_embedding';
+  unattributed_reason?: 'novel_argument' | 'no_embedding' | 'direction_mismatch';
 }
 
 /**
@@ -42,7 +43,7 @@ export interface ClaimAttributionDecision {
 export function computeClaimTaxonomyAttribution(
   nodes: ArgumentNetworkNode[],
   speakerPov: string,
-  nodeEmbeddings: Record<string, { pov: string; vector: number[]; vectors?: number[][] }>,
+  nodeEmbeddings: Record<string, { pov: string; vector: number[]; vectors?: number[][]; exclusion_vector?: number[] }>,
   candidateNodeIds: Set<string>,
   topN: number = 3,
 ): ClaimAttributionResult {
@@ -53,12 +54,13 @@ export function computeClaimTaxonomyAttribution(
   let novelArgument = 0;
 
   // Pre-filter: same-POV nodes with embeddings (all BDI categories)
-  const candidateEntries: [string, { vector: number[]; vectors?: number[][] }][] = [];
+  const candidateEntries: [string, { vector: number[]; vectors?: number[][]; exclusion_vector?: number[] }][] = [];
   for (const [nodeId, entry] of Object.entries(nodeEmbeddings)) {
     if (entry.pov === speakerPov && candidateNodeIds.has(nodeId) && entry.vector?.length > 0) {
-      candidateEntries.push([nodeId, { vector: entry.vector, vectors: entry.vectors }]);
+      candidateEntries.push([nodeId, { vector: entry.vector, vectors: entry.vectors, exclusion_vector: entry.exclusion_vector }]);
     }
   }
+  const candidateMap = new Map(candidateEntries);
   const hasMultiVector = candidateEntries.some(([, e]) => e.vectors && e.vectors.length > 0);
 
   for (const node of nodes) {
@@ -143,6 +145,31 @@ export function computeClaimTaxonomyAttribution(
         unattributed_reason: 'novel_argument',
       });
       continue;
+    }
+
+    // V3 directional gate: if the best candidate has an exclusion_vector and the claim
+    // is similarly close to the exclusion direction, demote to direction_mismatch (t/2746 V3).
+    const bestEntry = candidateMap.get(best.node_id);
+    if (bestEntry?.exclusion_vector && bestEntry.exclusion_vector.length > 0) {
+      const excSim = cosineSimilarity(queryVector, bestEntry.exclusion_vector);
+      if (excSim >= best.similarity * EXCLUSION_RATIO_THRESHOLD) {
+        const attribution: ClaimTaxonomyAttribution = {
+          primary_ref: '',
+          attribution_confidence: best.similarity,
+          unattributed_reason: 'direction_mismatch',
+        };
+        node.claim_taxonomy_attribution = attribution;
+        novelArgument++;
+        unattributed++;
+        decisions.push({
+          claim_id: node.id,
+          primary_ref: null,
+          attribution_confidence: best.similarity,
+          secondary_refs_count: 0,
+          unattributed_reason: 'direction_mismatch',
+        });
+        continue;
+      }
     }
 
     // Attributed — primary ref is the best match

--- a/lib/debate/assignWeights.ts
+++ b/lib/debate/assignWeights.ts
@@ -85,7 +85,10 @@ function embedBoundariesLocal(repoRoot: string): BoundaryEmbeddings {
     const { hardcoded, softcoded } = info.boundaries;
     const allBoundaries = [...hardcoded, ...softcoded];
     console.log(`  Embedding ${allBoundaries.length} boundary strings for ${pov} (${hardcoded.length} hardcoded, ${softcoded.length} softcoded)...`);
-    result[pov] = allBoundaries.map(s => embedTextLocal(script, s.replace(/^REJECT:\s*/i, '')));
+    result[pov] = {
+      vectors: allBoundaries.map(s => embedTextLocal(script, s)),
+      isRejection: allBoundaries.map(s => /^REJECT:\s*/i.test(s)),
+    };
   }
   return result;
 }
@@ -174,8 +177,9 @@ async function main(): Promise<void> {
     // ── Doctrinal anchoring ───────────────────────────
     let anchoringResults: AnchoringResult[] = [];
     if (boundaryEmbeddings?.[key]) {
+      const be = boundaryEmbeddings[key];
       anchoringResults = computeDoctrinalAnchoring(
-        nodes, boundaryEmbeddings[key], nodeEmbeddings,
+        nodes, be.vectors, nodeEmbeddings, undefined, undefined, be.isRejection,
       );
       const anchored = anchoringResults.filter(r => r.anchored).length;
       const floored = anchoringResults.filter(r => r.floorApplied).length;

--- a/lib/debate/claimAttribution.test.ts
+++ b/lib/debate/claimAttribution.test.ts
@@ -332,3 +332,61 @@ describe('computeClaimTaxonomyAttribution', () => {
     expect(result.decisions[0].attribution_confidence).toBeCloseTo(1.0);
   });
 });
+
+// ── V3 directional gate (t/2746) ─────────────────────────
+
+describe('computeClaimTaxonomyAttribution — V3 direction_mismatch gate', () => {
+  it('demotes to direction_mismatch when exclusion_vector is as close as main vector', () => {
+    // claim embedding = same direction as acc-B-001's exclusion_vector
+    const claimEmb = makeEmbedding(5);
+    const nodes = [makeNode('AN-1', 'accelerationist', claimEmb)];
+
+    // acc-B-001 has main vector also pointing at dim 5, so similarity = 1.0.
+    // Its exclusion_vector also points at dim 5 → excSim / mainSim = 1.0 >= EXCLUSION_RATIO_THRESHOLD (0.95).
+    const embeddings: Record<string, { pov: string; vector: number[]; exclusion_vector?: number[] }> = {
+      'acc-B-001': {
+        pov: 'accelerationist',
+        vector: makeEmbedding(5),
+        exclusion_vector: makeEmbedding(5), // identical to claim — triggers gate
+      },
+    };
+
+    const result = computeClaimTaxonomyAttribution(nodes, 'accelerationist', embeddings, BELIEF_IDS);
+    expect(result.attributed).toBe(0);
+    expect(result.unattributed).toBe(1);
+    expect(result.decisions[0].unattributed_reason).toBe('direction_mismatch');
+    expect(nodes[0].claim_taxonomy_attribution!.unattributed_reason).toBe('direction_mismatch');
+  });
+
+  it('attributes normally when exclusion_vector is far from claim', () => {
+    const claimEmb = makeEmbedding(5);
+    const nodes = [makeNode('AN-1', 'accelerationist', claimEmb)];
+
+    // exclusion_vector is orthogonal (dim 6) — no direction conflict
+    const embeddings: Record<string, { pov: string; vector: number[]; exclusion_vector?: number[] }> = {
+      'acc-B-001': {
+        pov: 'accelerationist',
+        vector: makeEmbedding(5),
+        exclusion_vector: makeEmbedding(6), // orthogonal → excSim ≈ 0
+      },
+    };
+
+    const result = computeClaimTaxonomyAttribution(nodes, 'accelerationist', embeddings, BELIEF_IDS);
+    expect(result.attributed).toBe(1);
+    expect(result.decisions[0].primary_ref).toBe('acc-B-001');
+    expect(result.decisions[0].unattributed_reason).toBeUndefined();
+  });
+
+  it('attributes normally when no exclusion_vector is present', () => {
+    const claimEmb = makeEmbedding(5);
+    const nodes = [makeNode('AN-1', 'accelerationist', claimEmb)];
+
+    const embeddings: Record<string, { pov: string; vector: number[] }> = {
+      'acc-B-001': { pov: 'accelerationist', vector: makeEmbedding(5) },
+    };
+
+    const result = computeClaimTaxonomyAttribution(nodes, 'accelerationist', embeddings, BELIEF_IDS);
+    expect(result.attributed).toBe(1);
+    expect(result.decisions[0].primary_ref).toBe('acc-B-001');
+  });
+});

--- a/lib/debate/claimExtractionPipeline/extract.ts
+++ b/lib/debate/claimExtractionPipeline/extract.ts
@@ -236,7 +236,7 @@ export async function extractClaims(
       trace.attribution_decisions = attrResult.decisions;
 
       // V4 NLI direction gate (t/2746): demote 'opposes' claims to direction_mismatch
-      const nodeTextById = new Map(povNodes.map(n => [n.id, n.text]));
+      const nodeTextById = new Map(povNodes.map(n => [n.id, n.description]));
       const opposingIds = runNliDirectionGate(claimsResult.newNodes, nodeTextById, speakerPov);
       if (opposingIds.size > 0) {
         for (const node of claimsResult.newNodes) {

--- a/lib/debate/claimExtractionPipeline/extract.ts
+++ b/lib/debate/claimExtractionPipeline/extract.ts
@@ -237,7 +237,14 @@ export async function extractClaims(
 
       // V4 NLI direction gate (t/2746): demote 'opposes' claims to direction_mismatch
       const nodeTextById = new Map(povNodes.map(n => [n.id, buildNliNodeProp(n.label, n.description)]));
-      const opposingIds = runNliDirectionGate(claimsResult.newNodes, nodeTextById, speakerPov);
+      const nliResult = runNliDirectionGate(claimsResult.newNodes, nodeTextById, speakerPov);
+      const { opposingIds, counts: nliCounts } = nliResult;
+      getGlobalRecorder()?.record({
+        type: 'an.nli_direction_gate', component: 'debate-engine', level: 'info',
+        speaker, debate_id: ctx.session?.id,
+        message: `NLI gate: ${opposingIds.size} demoted`,
+        data: { ...nliCounts },
+      });
       if (opposingIds.size > 0) {
         for (const node of claimsResult.newNodes) {
           if (!opposingIds.has(node.id)) continue;

--- a/lib/debate/claimExtractionPipeline/extract.ts
+++ b/lib/debate/claimExtractionPipeline/extract.ts
@@ -32,7 +32,7 @@ import { entailmentRepairPrompt, cruxRefreshPrompt } from '../prompts.js';
 import { callByUsage } from '../../ai-client/usageRegistry.js';
 import { getGlobalRecorder } from '../../flight-recorder/index.js';
 import { hashString, looksTruncated, updateExtractionSummary } from './helpers.js';
-import { runNliDirectionGate } from './nliDirectionGate.js';
+import { runNliDirectionGate, buildNliNodeProp } from './nliDirectionGate.js';
 import type { ClaimExtractionContext } from './context.js';
 
 export async function extractClaims(
@@ -236,7 +236,7 @@ export async function extractClaims(
       trace.attribution_decisions = attrResult.decisions;
 
       // V4 NLI direction gate (t/2746): demote 'opposes' claims to direction_mismatch
-      const nodeTextById = new Map(povNodes.map(n => [n.id, n.description]));
+      const nodeTextById = new Map(povNodes.map(n => [n.id, buildNliNodeProp(n.label, n.description)]));
       const opposingIds = runNliDirectionGate(claimsResult.newNodes, nodeTextById, speakerPov);
       if (opposingIds.size > 0) {
         for (const node of claimsResult.newNodes) {

--- a/lib/debate/claimExtractionPipeline/extract.ts
+++ b/lib/debate/claimExtractionPipeline/extract.ts
@@ -32,6 +32,7 @@ import { entailmentRepairPrompt, cruxRefreshPrompt } from '../prompts.js';
 import { callByUsage } from '../../ai-client/usageRegistry.js';
 import { getGlobalRecorder } from '../../flight-recorder/index.js';
 import { hashString, looksTruncated, updateExtractionSummary } from './helpers.js';
+import { runNliDirectionGate } from './nliDirectionGate.js';
 import type { ClaimExtractionContext } from './context.js';
 
 export async function extractClaims(
@@ -233,6 +234,30 @@ export async function extractClaims(
       trace.attribution_missing_embedding = attrResult.missing_embedding;
       trace.attribution_novel_argument = attrResult.novel_argument;
       trace.attribution_decisions = attrResult.decisions;
+
+      // V4 NLI direction gate (t/2746): demote 'opposes' claims to direction_mismatch
+      const nodeTextById = new Map(povNodes.map(n => [n.id, n.text]));
+      const opposingIds = runNliDirectionGate(claimsResult.newNodes, nodeTextById, speakerPov);
+      if (opposingIds.size > 0) {
+        for (const node of claimsResult.newNodes) {
+          if (!opposingIds.has(node.id)) continue;
+          node.claim_taxonomy_attribution = {
+            primary_ref: '',
+            attribution_confidence: node.claim_taxonomy_attribution?.attribution_confidence ?? 0,
+            unattributed_reason: 'direction_mismatch',
+          };
+          const dec = trace.attribution_decisions?.find(d => d.claim_id === node.id);
+          if (dec) {
+            dec.primary_ref = null;
+            dec.unattributed_reason = 'direction_mismatch';
+            dec.secondary_refs_count = 0;
+          }
+        }
+        const nliDemoted = opposingIds.size;
+        trace.attribution_attributed = (trace.attribution_attributed ?? 0) - nliDemoted;
+        trace.attribution_unattributed = (trace.attribution_unattributed ?? 0) + nliDemoted;
+        trace.attribution_novel_argument = (trace.attribution_novel_argument ?? 0) + nliDemoted;
+      }
 
       // Log warning if zero statement-level taxonomy_refs (injection may have failed upstream)
       if (taxonomyRefIds.length === 0 && claimsResult.newNodes.length > 0) {

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
@@ -5,9 +5,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { runNliDirectionGate, buildNliNodeProp } from './nliDirectionGate.js';
 import type { ArgumentNetworkNode } from '../types.js';
 
-vi.mock('child_process', async (importOriginal) => {
-  const actual = await importOriginal();
-  return { ...(actual as object), spawnSync: vi.fn() };
+// Create the fn inside the factory so it's available when vi.mock is hoisted.
+// Both the default and named export reference the same fn for cross-env compat.
+vi.mock('child_process', () => {
+  const fn = vi.fn();
+  return { default: { spawnSync: fn }, spawnSync: fn };
 });
 
 import { spawnSync } from 'child_process';
@@ -58,20 +60,34 @@ describe('buildNliNodeProp — rich node prop for NLI (t/2744#7)', () => {
     const desc = 'Encompasses: everything, nothing.';
     expect(buildNliNodeProp('Label Only', desc)).toBe('Label Only');
   });
+
+  it('richness arm — label-only would not match V1; label+Core does (t/2744#8)', () => {
+    // Demonstrates the load-bearing contrast: stripping Encompasses produces the
+    // same core text that tau_contra=1.0 was calibrated on (CL 4-variant test).
+    const fullDesc = 'Existing laws are insufficient for AI. Encompasses: tort law, liability.';
+    const labelOnly = 'Existing Laws Insufficient';
+    const labelPlusCore = buildNliNodeProp(labelOnly, fullDesc);
+    expect(labelPlusCore).toBe('Existing Laws Insufficient — Existing laws are insufficient for AI.');
+    // Bare label (what a naive caller would pass) is shorter and loses the proposition
+    expect(labelOnly).not.toContain('insufficient for AI');
+    // Rich form preserves the asserted proposition (the inversion-catchable content)
+    expect(labelPlusCore).toContain('insufficient for AI');
+  });
 });
 
 describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
-  it('returns empty set when no nodes are attributed', () => {
+  it('returns empty result when no nodes are attributed', () => {
     const nodes = [makeNode('AN-1', null)];
     const result = runNliDirectionGate(nodes, new Map(), 'acc');
-    expect(result.size).toBe(0);
+    expect(result.opposingIds.size).toBe(0);
+    expect(result.counts).toEqual({ opposes: 0, agrees: 0, unrelated: 0, unresolved: 0 });
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('returns empty set when nodeTextById has no entry for the ref', () => {
+  it('returns empty result when nodeTextById has no entry for the ref', () => {
     const nodes = [makeNode('AN-1', 'acc-bel-001')];
     const result = runNliDirectionGate(nodes, new Map(), 'acc');
-    expect(result.size).toBe(0);
+    expect(result.opposingIds.size).toBe(0);
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
@@ -83,8 +99,9 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
-    expect(result.has('AN-1')).toBe(true);
-    expect(result.size).toBe(1);
+    expect(result.opposingIds.has('AN-1')).toBe(true);
+    expect(result.counts.opposes).toBe(1);
+    expect(result.counts.agrees).toBe(0);
   });
 
   it('keeps claim when engine returns unrelated', () => {
@@ -95,7 +112,8 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
-    expect(result.has('AN-1')).toBe(false);
+    expect(result.opposingIds.has('AN-1')).toBe(false);
+    expect(result.counts.unrelated).toBe(1);
   });
 
   it('keeps claim when engine returns unresolved (fail-safe output)', () => {
@@ -106,7 +124,8 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
-    expect(result.size).toBe(0);
+    expect(result.opposingIds.size).toBe(0);
+    expect(result.counts.unresolved).toBe(1);
   });
 
   it('keeps claim when engine returns agrees', () => {
@@ -117,37 +136,39 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
-    expect(result.size).toBe(0);
+    expect(result.opposingIds.size).toBe(0);
+    expect(result.counts.agrees).toBe(1);
   });
 
-  it('returns empty set (fail-safe) when subprocess exits non-zero', () => {
+  it('returns empty result (fail-safe) when subprocess exits non-zero', () => {
     const nodes = [makeNode('AN-1', 'acc-bel-001')];
     const nodeMap = new Map([['acc-bel-001', 'some node text']]);
     mockSpawn.mockReturnValue({ stdout: '', stderr: 'ImportError', status: 1, error: undefined } as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
-    expect(result.size).toBe(0);
+    expect(result.opposingIds.size).toBe(0);
+    expect(result.counts).toEqual({ opposes: 0, agrees: 0, unrelated: 0, unresolved: 0 });
   });
 
-  it('returns empty set (fail-safe) when subprocess throws', () => {
+  it('returns empty result (fail-safe) when subprocess throws', () => {
     const nodes = [makeNode('AN-1', 'acc-bel-001')];
     const nodeMap = new Map([['acc-bel-001', 'some node text']]);
     mockSpawn.mockReturnValue({ stdout: '', stderr: '', status: 0, error: new Error('ENOENT') } as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
-    expect(result.size).toBe(0);
+    expect(result.opposingIds.size).toBe(0);
   });
 
-  it('returns empty set (fail-safe) when subprocess output is malformed JSON', () => {
+  it('returns empty result (fail-safe) when subprocess output is malformed JSON', () => {
     const nodes = [makeNode('AN-1', 'acc-bel-001')];
     const nodeMap = new Map([['acc-bel-001', 'some node text']]);
     mockSpawn.mockReturnValue({ stdout: 'not json', stderr: '', status: 0, error: undefined } as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
-    expect(result.size).toBe(0);
+    expect(result.opposingIds.size).toBe(0);
   });
 
-  it('handles mixed batch — demotes only the opposes claim', () => {
+  it('handles mixed batch — demotes only the opposes claim, counts all', () => {
     const nodes = [
       makeNode('AN-1', 'acc-bel-001', 'AI is beneficial'),
       makeNode('AN-2', 'acc-bel-002', 'AI is dangerous'),
@@ -162,13 +183,15 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
-    expect(result.has('AN-1')).toBe(false);
-    expect(result.has('AN-2')).toBe(true);
+    expect(result.opposingIds.has('AN-1')).toBe(false);
+    expect(result.opposingIds.has('AN-2')).toBe(true);
+    expect(result.counts).toEqual({ opposes: 1, agrees: 1, unrelated: 0, unresolved: 0 });
   });
 
-  it('passes claim_pov and node_pov to the subprocess', () => {
+  it('passes claim_pov, node_pov, and rich node_prop to the subprocess', () => {
+    const desc = 'AI cannot be regulated. Encompasses: AI safety, AGI policy.';
     const nodes = [makeNode('AN-1', 'saf-bel-001', 'safety first')];
-    const nodeMap = new Map([['saf-bel-001', 'safety matters']]);
+    const nodeMap = new Map([['saf-bel-001', buildNliNodeProp('Unregulatable AI', desc)]]);
     mockSpawn.mockReturnValue(spawnResult([
       { id: 'AN-1', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
     ]) as any);
@@ -180,5 +203,8 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     const parsed = JSON.parse(stdin);
     expect(parsed[0].claim_pov).toBe('safetyist');
     expect(parsed[0].node_pov).toBe('safetyist');
+    // Rich node_prop: label+Core with Encompasses stripped
+    expect(parsed[0].node_prop).toBe('Unregulatable AI — AI cannot be regulated.');
+    expect(parsed[0].node_prop).not.toContain('Encompasses');
   });
 });

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
@@ -5,9 +5,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { runNliDirectionGate } from './nliDirectionGate.js';
 import type { ArgumentNetworkNode } from '../types.js';
 
-vi.mock('child_process', () => ({
-  spawnSync: vi.fn(),
-}));
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...(actual as object), spawnSync: vi.fn() };
+});
 
 import { spawnSync } from 'child_process';
 const mockSpawn = vi.mocked(spawnSync);

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runNliDirectionGate } from './nliDirectionGate.js';
+import type { ArgumentNetworkNode } from '../types.js';
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+import { spawnSync } from 'child_process';
+const mockSpawn = vi.mocked(spawnSync);
+
+function makeNode(id: string, primaryRef: string | null, text = 'some claim'): ArgumentNetworkNode {
+  return {
+    id,
+    text,
+    speaker: 'accelerationist',
+    source_entry_id: 'e1',
+    taxonomy_refs: [],
+    turn_number: 1,
+    claim_taxonomy_attribution: primaryRef
+      ? { primary_ref: primaryRef, attribution_confidence: 0.7 }
+      : undefined,
+  } as unknown as ArgumentNetworkNode;
+}
+
+function spawnResult(stdout: object, status = 0) {
+  return { stdout: JSON.stringify(stdout), stderr: '', status, error: undefined };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
+  it('returns empty set when no nodes are attributed', () => {
+    const nodes = [makeNode('AN-1', null)];
+    const result = runNliDirectionGate(nodes, new Map(), 'acc');
+    expect(result.size).toBe(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('returns empty set when nodeTextById has no entry for the ref', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001')];
+    const result = runNliDirectionGate(nodes, new Map(), 'acc');
+    expect(result.size).toBe(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('demotes claim when engine returns opposes', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001')];
+    const nodeMap = new Map([['acc-bel-001', 'AI regulation accelerates progress']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1', direction: 'opposes', confidence: 1.4, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.has('AN-1')).toBe(true);
+    expect(result.size).toBe(1);
+  });
+
+  it('keeps claim when engine returns unrelated', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001')];
+    const nodeMap = new Map([['acc-bel-001', 'AI regulation accelerates progress']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1', direction: 'unrelated', confidence: 0.2, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.has('AN-1')).toBe(false);
+  });
+
+  it('keeps claim when engine returns unresolved (fail-safe output)', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001')];
+    const nodeMap = new Map([['acc-bel-001', 'AI regulation accelerates progress']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1', direction: 'unresolved', confidence: 0.0, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.size).toBe(0);
+  });
+
+  it('keeps claim when engine returns agrees', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001')];
+    const nodeMap = new Map([['acc-bel-001', 'AI regulation accelerates progress']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1', direction: 'agrees', confidence: 0.5, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.size).toBe(0);
+  });
+
+  it('returns empty set (fail-safe) when subprocess exits non-zero', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001')];
+    const nodeMap = new Map([['acc-bel-001', 'some node text']]);
+    mockSpawn.mockReturnValue({ stdout: '', stderr: 'ImportError', status: 1, error: undefined } as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.size).toBe(0);
+  });
+
+  it('returns empty set (fail-safe) when subprocess throws', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001')];
+    const nodeMap = new Map([['acc-bel-001', 'some node text']]);
+    mockSpawn.mockReturnValue({ stdout: '', stderr: '', status: 0, error: new Error('ENOENT') } as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.size).toBe(0);
+  });
+
+  it('returns empty set (fail-safe) when subprocess output is malformed JSON', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001')];
+    const nodeMap = new Map([['acc-bel-001', 'some node text']]);
+    mockSpawn.mockReturnValue({ stdout: 'not json', stderr: '', status: 0, error: undefined } as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.size).toBe(0);
+  });
+
+  it('handles mixed batch — demotes only the opposes claim', () => {
+    const nodes = [
+      makeNode('AN-1', 'acc-bel-001', 'AI is beneficial'),
+      makeNode('AN-2', 'acc-bel-002', 'AI is dangerous'),
+    ];
+    const nodeMap = new Map([
+      ['acc-bel-001', 'AI accelerates progress'],
+      ['acc-bel-002', 'AI reduces risk'],
+    ]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1', direction: 'agrees', confidence: 0.8, method: 'nli-deberta' },
+      { id: 'AN-2', direction: 'opposes', confidence: 1.3, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.has('AN-1')).toBe(false);
+    expect(result.has('AN-2')).toBe(true);
+  });
+
+  it('passes claim_pov and node_pov to the subprocess', () => {
+    const nodes = [makeNode('AN-1', 'saf-bel-001', 'safety first')];
+    const nodeMap = new Map([['saf-bel-001', 'safety matters']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+    ]) as any);
+
+    runNliDirectionGate(nodes, nodeMap, 'safetyist');
+
+    const callArgs = mockSpawn.mock.calls[0];
+    const stdin = callArgs[2]?.input as string;
+    const parsed = JSON.parse(stdin);
+    expect(parsed[0].claim_pov).toBe('safetyist');
+    expect(parsed[0].node_pov).toBe('safetyist');
+  });
+});

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { runNliDirectionGate } from './nliDirectionGate.js';
+import { runNliDirectionGate, buildNliNodeProp } from './nliDirectionGate.js';
 import type { ArgumentNetworkNode } from '../types.js';
 
 vi.mock('child_process', async (importOriginal) => {
@@ -33,6 +33,31 @@ function spawnResult(stdout: object, status = 0) {
 
 beforeEach(() => {
   vi.resetAllMocks();
+});
+
+describe('buildNliNodeProp — rich node prop for NLI (t/2744#7)', () => {
+  it('joins label and core description with em-dash', () => {
+    expect(buildNliNodeProp('Rapid Deployment', 'Faster deployment helps society.')).toBe('Rapid Deployment — Faster deployment helps society.');
+  });
+
+  it('strips Encompasses tail from description', () => {
+    const desc = 'AI accelerates progress. Encompasses: narrow AI, AGI research.';
+    expect(buildNliNodeProp('AI Progress', desc)).toBe('AI Progress — AI accelerates progress.');
+  });
+
+  it('strips Excludes tail from description', () => {
+    const desc = 'Regulation slows development. Excludes: safety-critical domains.';
+    expect(buildNliNodeProp('Regulation Risk', desc)).toBe('Regulation Risk — Regulation slows development.');
+  });
+
+  it('falls back to label-only when description is empty', () => {
+    expect(buildNliNodeProp('Bare Label', '')).toBe('Bare Label');
+  });
+
+  it('falls back to label-only when core is empty after strip', () => {
+    const desc = 'Encompasses: everything, nothing.';
+    expect(buildNliNodeProp('Label Only', desc)).toBe('Label Only');
+  });
 });
 
 describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// ── V4 NLI direction gate (t/2746) ───────────────────────
+
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import type { ArgumentNetworkNode } from '../types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+// claimExtractionPipeline -> lib/debate -> lib -> repo root
+const REPO_ROOT = path.resolve(path.dirname(__filename), '../../..');
+const NLI_SCRIPT = path.join(REPO_ROOT, 'scripts', 'nli_classify.py');
+
+interface NliInput {
+  id: string;
+  claim_prop: string;
+  node_prop: string;
+  claim_pov?: string;
+  node_pov?: string;
+}
+
+interface NliOutput {
+  id: string;
+  direction: 'agrees' | 'opposes' | 'unrelated' | 'unresolved';
+  confidence: number;
+  method: string;
+}
+
+/**
+ * V4 NLI direction gate (t/2746): subprocess-calls scripts/nli_classify.py for
+ * each attributed claim and returns the IDs of claims where direction === 'opposes'.
+ *
+ * Opposition-only gate (CL ruling t/2751#3): callers demote 'opposes' claims to
+ * direction_mismatch; all other directions keep their attribution unchanged.
+ *
+ * Fail-safe: any subprocess error or parse failure returns an empty set — the
+ * gate never falsely demotes a claim. 'unresolved' is the engine's fail-safe
+ * output and is treated identically to 'unrelated' here (keep attribution).
+ */
+export function runNliDirectionGate(
+  nodes: ArgumentNetworkNode[],
+  nodeTextById: Map<string, string>,
+  speakerPov: string,
+): Set<string> {
+  const attributed = nodes.filter(n => n.claim_taxonomy_attribution?.primary_ref);
+  if (attributed.length === 0) return new Set();
+
+  const batch: NliInput[] = [];
+  for (const n of attributed) {
+    const nodeText = nodeTextById.get(n.claim_taxonomy_attribution!.primary_ref!);
+    if (!nodeText) continue;
+    batch.push({
+      id: n.id,
+      claim_prop: n.canonical_proposition ?? n.text,
+      node_prop: nodeText,
+      claim_pov: speakerPov,
+      node_pov: speakerPov,
+    });
+  }
+  if (batch.length === 0) return new Set();
+
+  const proc = spawnSync('python', [NLI_SCRIPT], {
+    input: JSON.stringify(batch),
+    encoding: 'utf8',
+    cwd: REPO_ROOT,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  if (proc.error || proc.status !== 0) {
+    console.warn(
+      `[nli-direction-gate] subprocess failed (status=${proc.status}): ` +
+      (proc.stderr?.slice(0, 300) ?? proc.error?.message ?? 'unknown'),
+    );
+    return new Set();
+  }
+
+  let outputs: NliOutput[];
+  try {
+    outputs = JSON.parse(proc.stdout);
+  } catch {
+    console.warn('[nli-direction-gate] failed to parse subprocess output');
+    return new Set();
+  }
+  if (!Array.isArray(outputs)) return new Set();
+
+  return new Set(outputs.filter(o => o.direction === 'opposes').map(o => o.id));
+}

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
@@ -39,24 +39,40 @@ interface NliOutput {
   method: string;
 }
 
+export interface NliGateCounts {
+  opposes: number;
+  agrees: number;
+  unrelated: number;
+  unresolved: number;
+}
+
+export interface NliGateResult {
+  opposingIds: Set<string>;
+  counts: NliGateCounts;
+}
+
+const ZERO_COUNTS: NliGateCounts = { opposes: 0, agrees: 0, unrelated: 0, unresolved: 0 };
+
 /**
  * V4 NLI direction gate (t/2746): subprocess-calls scripts/nli_classify.py for
- * each attributed claim and returns the IDs of claims where direction === 'opposes'.
+ * each attributed claim and returns IDs of claims where direction === 'opposes'
+ * plus per-direction counts for diagnostics.
  *
  * Opposition-only gate (CL ruling t/2751#3): callers demote 'opposes' claims to
  * direction_mismatch; all other directions keep their attribution unchanged.
  *
- * Fail-safe: any subprocess error or parse failure returns an empty set — the
- * gate never falsely demotes a claim. 'unresolved' is the engine's fail-safe
- * output and is treated identically to 'unrelated' here (keep attribution).
+ * Fail-safe: any subprocess error or parse failure returns empty set + zero counts —
+ * the gate never falsely demotes a claim. 'unresolved' is the engine's fail-safe
+ * output and is treated identically to 'unrelated' (keep attribution).
  */
 export function runNliDirectionGate(
   nodes: ArgumentNetworkNode[],
   nodeTextById: Map<string, string>,
   speakerPov: string,
-): Set<string> {
+): NliGateResult {
+  const empty: NliGateResult = { opposingIds: new Set(), counts: { ...ZERO_COUNTS } };
   const attributed = nodes.filter(n => n.claim_taxonomy_attribution?.primary_ref);
-  if (attributed.length === 0) return new Set();
+  if (attributed.length === 0) return empty;
 
   const batch: NliInput[] = [];
   for (const n of attributed) {
@@ -70,7 +86,7 @@ export function runNliDirectionGate(
       node_pov: speakerPov,
     });
   }
-  if (batch.length === 0) return new Set();
+  if (batch.length === 0) return empty;
 
   const proc = spawnSync('python', [NLI_SCRIPT], {
     input: JSON.stringify(batch),
@@ -84,7 +100,7 @@ export function runNliDirectionGate(
       `[nli-direction-gate] subprocess failed (status=${proc.status}): ` +
       (proc.stderr?.slice(0, 300) ?? proc.error?.message ?? 'unknown'),
     );
-    return new Set();
+    return empty;
   }
 
   let outputs: NliOutput[];
@@ -92,9 +108,17 @@ export function runNliDirectionGate(
     outputs = JSON.parse(proc.stdout);
   } catch {
     console.warn('[nli-direction-gate] failed to parse subprocess output');
-    return new Set();
+    return empty;
   }
-  if (!Array.isArray(outputs)) return new Set();
+  if (!Array.isArray(outputs)) return empty;
 
-  return new Set(outputs.filter(o => o.direction === 'opposes').map(o => o.id));
+  const counts: NliGateCounts = { ...ZERO_COUNTS };
+  const opposingIds = new Set<string>();
+  for (const o of outputs) {
+    if (o.direction === 'opposes') { counts.opposes++; opposingIds.add(o.id); }
+    else if (o.direction === 'agrees') counts.agrees++;
+    else if (o.direction === 'unresolved') counts.unresolved++;
+    else counts.unrelated++;
+  }
+  return { opposingIds, counts };
 }

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
@@ -8,6 +8,17 @@ import { fileURLToPath } from 'url';
 import path from 'path';
 import type { ArgumentNetworkNode } from '../types.js';
 
+/**
+ * Build the rich node proposition for NLI input (t/2744#7, TL ruling t/2746).
+ * Matches V1 (PS2) format exactly: "label — Core" where Core = description with
+ * Encompasses:/Excludes: tails stripped (they name sibling topics, not the asserted
+ * proposition). Falls back to label-only when description is empty.
+ */
+export function buildNliNodeProp(label: string, description: string): string {
+  const core = (description ?? '').replace(/\s*(Encompasses|Excludes)\s*:[\s\S]*$/, '').trim();
+  return core ? `${label} — ${core}` : label;
+}
+
 const __filename = fileURLToPath(import.meta.url);
 // claimExtractionPipeline -> lib/debate -> lib -> repo root
 const REPO_ROOT = path.resolve(path.dirname(__filename), '../../..');

--- a/lib/debate/debateEngine/doctrinal.ts
+++ b/lib/debate/debateEngine/doctrinal.ts
@@ -45,15 +45,15 @@ export async function setupDoctrinalAnchoring(engine: DebateEngineInternals): Pr
   }
 
   // Run anchoring against each POV's Belief nodes
-  for (const [pov, vectors] of Object.entries(engine._boundaryEmbeddings)) {
-    if (vectors.length === 0) continue;
+  for (const [pov, entry] of Object.entries(engine._boundaryEmbeddings)) {
+    if (entry.vectors.length === 0) continue;
     const povNodes = engine.taxonomy[pov as PovKey]?.nodes ?? [];
     const beliefs = povNodes.filter(n => n.category === 'Beliefs');
     if (beliefs.length === 0) continue;
 
     const weights = boundaryWeights[pov];
     const results = computeDoctrinalAnchoring(
-      beliefs, vectors, engine.taxonomy.embeddings, weights,
+      beliefs, entry.vectors, engine.taxonomy.embeddings, weights, undefined, entry.isRejection,
     );
 
     // Check for threshold anomalies

--- a/lib/debate/doctrinalAnchoring.test.ts
+++ b/lib/debate/doctrinalAnchoring.test.ts
@@ -214,12 +214,15 @@ describe('embedDoctrinalBoundaries', () => {
 
     const result = await embedDoctrinalBoundaries(boundaries, embedFn);
 
-    expect(result.accelerationist).toHaveLength(2);
-    expect(result.safetyist).toHaveLength(1);
-    expect(result.accelerationist[0]).toHaveLength(384);
+    expect(result.accelerationist.vectors).toHaveLength(2);
+    expect(result.safetyist.vectors).toHaveLength(1);
+    expect(result.accelerationist.vectors[0]).toHaveLength(384);
+    // All are REJECT: boundaries → isRejection should all be true
+    expect(result.accelerationist.isRejection).toEqual([true, true]);
+    expect(result.safetyist.isRejection).toEqual([true]);
   });
 
-  it('strips REJECT: prefix before embedding', async () => {
+  it('preserves REJECT: prefix when embedding and sets isRejection flag (t/2746 V5)', async () => {
     const boundaries = {
       test: ['REJECT: precautionary principle', 'REJECT:  capability limits', 'No prefix here'],
     };
@@ -229,13 +232,16 @@ describe('embedDoctrinalBoundaries', () => {
       return new Array(384).fill(0.1);
     };
 
-    await embedDoctrinalBoundaries(boundaries, embedFn);
+    const result = await embedDoctrinalBoundaries(boundaries, embedFn);
 
+    // V5: prefix is preserved so the embedding captures polarity-bearing text
     expect(receivedTexts).toEqual([
-      'precautionary principle',
-      'capability limits',
+      'REJECT: precautionary principle',
+      'REJECT:  capability limits',
       'No prefix here',
     ]);
+    expect(result.test.isRejection).toEqual([true, true, false]);
+    expect(result.test.vectors).toHaveLength(3);
   });
 
   it('handles embedding failures gracefully', async () => {
@@ -248,7 +254,7 @@ describe('embedDoctrinalBoundaries', () => {
     };
 
     const result = await embedDoctrinalBoundaries(boundaries, embedFn);
-    expect(result.test).toHaveLength(2); // 1 failed, 2 succeeded
+    expect(result.test.vectors).toHaveLength(2); // 1 failed, 2 succeeded
   });
 });
 
@@ -268,7 +274,7 @@ describe('calibrateDoctrinalThresholds', () => {
       'b-001': { pov: 'acc', vector: base },      // sim=1.0 to boundary
       'b-002': { pov: 'acc', vector: similar },    // sim≈0.50 to boundary
     };
-    const boundaryEmbs = { acc: [base] };
+    const boundaryEmbs = { acc: { vectors: [base], isRejection: [false] } };
 
     const rows = calibrateDoctrinalThresholds(nodes, boundaryEmbs, nodeEmbs, [0.45, 0.55, 0.90]);
 
@@ -329,5 +335,70 @@ describe('DEFAULT_ANCHORING_CONFIG', () => {
   it('has threshold 0.55 and floor 0.60', () => {
     expect(DEFAULT_ANCHORING_CONFIG.threshold).toBe(0.55);
     expect(DEFAULT_ANCHORING_CONFIG.confidenceFloor).toBe(0.60);
+  });
+});
+
+// ── V5: REJECT: polarity gate (t/2746) ─────────────────
+
+describe('computeDoctrinalAnchoring — V5 REJECT: polarity gate', () => {
+  it('does not anchor a node matching a REJECT: boundary', () => {
+    const base = makeEmbedding(0);
+    const node = makeBeliefNode('b-001', 0.50);
+    const nodeEmbs = { 'b-001': { pov: 'accelerationist', vector: base } };
+    const boundaryVecs = [base]; // sim = 1.0 — above threshold
+    const isRejection = [true]; // this boundary is a REJECT: string
+
+    const results = computeDoctrinalAnchoring(
+      [node], boundaryVecs, nodeEmbs, undefined, undefined, isRejection,
+    );
+
+    expect(results[0].anchored).toBe(false);
+    expect(results[0].floorApplied).toBe(false);
+    // Confidence should not have been raised
+    expect(node.confidence).toBe(0.50);
+  });
+
+  it('anchors normally when matching an embrace boundary (isRejection = false)', () => {
+    const base = makeEmbedding(0);
+    const node = makeBeliefNode('b-001', 0.50);
+    const nodeEmbs = { 'b-001': { pov: 'accelerationist', vector: base } };
+    const boundaryVecs = [base];
+    const isRejection = [false]; // normal embrace boundary
+
+    const results = computeDoctrinalAnchoring(
+      [node], boundaryVecs, nodeEmbs, undefined, undefined, isRejection,
+    );
+
+    expect(results[0].anchored).toBe(true);
+    expect(results[0].floorApplied).toBe(true);
+    expect(node.confidence).toBe(DEFAULT_ANCHORING_CONFIG.confidenceFloor);
+  });
+
+  it('anchors normally when boundaryIsRejection is omitted (backward-compat)', () => {
+    const base = makeEmbedding(0);
+    const node = makeBeliefNode('b-001', 0.50);
+    const nodeEmbs = { 'b-001': { pov: 'accelerationist', vector: base } };
+    const boundaryVecs = [base]; // no isRejection arg
+
+    const results = computeDoctrinalAnchoring([node], boundaryVecs, nodeEmbs);
+
+    expect(results[0].anchored).toBe(true);
+  });
+
+  it('does not apply floor when matching a REJECT: boundary', () => {
+    const base = makeEmbedding(2);
+    const node = makeBeliefNode('b-rej', 0.40);
+    const nodeEmbs = { 'b-rej': { pov: 'safetyist', vector: base } };
+    const boundaryVecs = [base];
+    const isRejection = [true];
+
+    const config = { threshold: 0.55, confidenceFloor: 0.75 };
+    const results = computeDoctrinalAnchoring(
+      [node], boundaryVecs, nodeEmbs, undefined, config, isRejection,
+    );
+
+    expect(results[0].anchored).toBe(false);
+    expect(results[0].floorApplied).toBe(false);
+    expect(node.confidence).toBe(0.40); // untouched
   });
 });

--- a/lib/debate/doctrinalAnchoring.ts
+++ b/lib/debate/doctrinalAnchoring.ts
@@ -31,8 +31,8 @@ export const DEFAULT_ANCHORING_CONFIG: DoctrinalAnchoringConfig = {
 // ── Boundary embeddings ─────────────────────────────────
 
 export interface BoundaryEmbeddings {
-  /** POV key → array of 4 boundary embedding vectors. */
-  [pov: string]: number[][];
+  /** POV key → boundary vectors + per-position rejection flags (t/2746 V5). */
+  [pov: string]: { vectors: number[][]; isRejection: boolean[] };
 }
 
 /**
@@ -50,13 +50,18 @@ export async function embedDoctrinalBoundaries(
 
   for (const [pov, strings] of Object.entries(boundaries)) {
     const vectors: number[][] = [];
+    const isRejection: boolean[] = [];
     for (const s of strings) {
       try {
-        const vec = await embedFn(s.replace(/^REJECT:\s*/i, ''));
-        if (vec && vec.length > 0) vectors.push(vec);
+        // Preserve REJECT: prefix so embrace/reject distinction survives (t/2746 V5).
+        const vec = await embedFn(s);
+        if (vec && vec.length > 0) {
+          vectors.push(vec);
+          isRejection.push(/^REJECT:\s*/i.test(s));
+        }
       } catch { /* embedding failure silently skipped */ }
     }
-    result[pov] = vectors;
+    result[pov] = { vectors, isRejection };
   }
 
   return result;
@@ -85,6 +90,8 @@ export interface AnchoringResult {
  * @param nodeEmbeddings - Taxonomy node embeddings (keyed by node ID)
  * @param boundaryWeights - Per-boundary weight (hardcoded=1.0, softcoded=0.7). Scales similarity.
  * @param config - Threshold and floor configuration
+ * @param boundaryIsRejection - Per-boundary flag: true = boundary is a REJECT: string (t/2746 V5).
+ *   A node matching a rejection boundary is NOT anchored and does NOT receive the confidence floor.
  */
 export function computeDoctrinalAnchoring(
   nodes: PovNode[],
@@ -92,6 +99,7 @@ export function computeDoctrinalAnchoring(
   nodeEmbeddings: Record<string, { pov: string; vector: number[] }>,
   boundaryWeights?: number[],
   config: DoctrinalAnchoringConfig = DEFAULT_ANCHORING_CONFIG,
+  boundaryIsRejection?: boolean[],
 ): AnchoringResult[] {
   const results: AnchoringResult[] = [];
 
@@ -122,7 +130,10 @@ export function computeDoctrinalAnchoring(
       }
     }
 
-    const anchored = maxSim >= config.threshold;
+    // A REJECT: boundary match means the POV disavows the proposition — do not anchor or floor (t/2746 V5).
+    const cosineMatch = maxSim >= config.threshold;
+    const rejectionMatch = cosineMatch && bestIdx >= 0 && (boundaryIsRejection?.[bestIdx] ?? false);
+    const anchored = cosineMatch && !rejectionMatch;
     node.doctrinally_anchored = anchored || undefined; // only set if true
 
     let floorApplied = false;
@@ -175,7 +186,7 @@ export function calibrateDoctrinalThresholds(
       const beliefs = nodes.filter(n => n.category === 'Beliefs');
       totalBeliefs[pov] = beliefs.length;
 
-      const boundaryVecs = boundaryEmbeddings[pov] ?? [];
+      const boundaryVecs = boundaryEmbeddings[pov]?.vectors ?? [];
       if (boundaryVecs.length === 0) {
         counts[pov] = 0;
         percentages[pov] = 0;

--- a/lib/debate/types/argumentNetwork.ts
+++ b/lib/debate/types/argumentNetwork.ts
@@ -108,7 +108,7 @@ export interface ClaimTaxonomyAttribution {
   /** Secondary refs above the 0.40 threshold. */
   secondary_refs?: { node_id: string; similarity: number }[];
   /** Reason the claim was unattributed, if applicable. */
-  unattributed_reason?: 'novel_argument' | 'no_embedding';
+  unattributed_reason?: 'novel_argument' | 'no_embedding' | 'direction_mismatch';
 }
 
 export interface ArgumentNetworkEdge {

--- a/lib/debate/types/diagnostics.ts
+++ b/lib/debate/types/diagnostics.ts
@@ -166,7 +166,7 @@ export interface ClaimExtractionTrace {
     primary_ref: string | null;
     attribution_confidence: number;
     secondary_refs_count: number;
-    unattributed_reason?: 'novel_argument' | 'no_embedding';
+    unattributed_reason?: 'novel_argument' | 'no_embedding' | 'direction_mismatch';
   }[];
 
   exclusion_violations?: {

--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -25,6 +25,7 @@ export type EventType =
   | 'an.extraction_confidence_delta'
   | 'an.extraction_coverage_error'
   | 'an.exclusion_violation'
+  | 'an.nli_direction_gate'
   // Turn pipeline
   | 'turn.stage'
   | 'turn.validate'

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -224,10 +224,10 @@ async function applyDoctrinalAnchoring(pov: string, allPovNodes: PovNode[], node
     // Embed boundary strings (cached across POVs)
     await ensureBoundaryEmbeddingsCache();
 
-    const boundaryVectors = _boundaryEmbeddingsCache?.[pov] ?? [];
-    if (boundaryVectors.length > 0) {
+    const povBoundary = _boundaryEmbeddingsCache?.[pov];
+    if (povBoundary && povBoundary.vectors.length > 0) {
       const beliefs = allPovNodes.filter(n => n.category === 'Beliefs');
-      const results = computeDoctrinalAnchoring(beliefs, boundaryVectors, nodeEmbeddings);
+      const results = computeDoctrinalAnchoring(beliefs, povBoundary.vectors, nodeEmbeddings, undefined, undefined, povBoundary.isRejection);
       const anomaly = checkThresholdAnomalies(results, beliefs.length);
       if (anomaly) console.warn(anomaly.warning);
       const anchoredCount = results.filter(r => r.anchored).length;


### PR DESCRIPTION
## Summary
- **V5 (doctrinalAnchoring):** `BoundaryEmbeddings` type changed from flat vector arrays to `{vectors, isRejection}` structs. `embedDoctrinalBoundaries` now preserves the `REJECT:` prefix (so embeddings capture polarity-bearing text) and tracks a per-boundary `isRejection` flag. `computeDoctrinalAnchoring` gains a 6th param: a node matching a `REJECT:` boundary is NOT anchored and does NOT receive the confidence floor. Fixes polarity-blind anchoring where `REJECT:` strings were silently treated as embrace boundaries.
- **V3 (attribution):** `computeClaimTaxonomyAttribution` checks `exclusion_vector` on the best-matching node. If `cosineSimilarity(claim, exclusion_vector) >= mainSim * EXCLUSION_RATIO_THRESHOLD (0.95)`, the claim is demoted to `direction_mismatch`. Adds `'direction_mismatch'` to `ClaimAttributionDecision` and `ClaimTaxonomyAttribution.unattributed_reason`.

## Files changed
- `lib/debate/doctrinalAnchoring.ts` — BoundaryEmbeddings type, embedDoctrinalBoundaries, computeDoctrinalAnchoring (V5)
- `lib/debate/debateEngine/doctrinal.ts` — updated to pass `entry.vectors` + `entry.isRejection`
- `lib/debate/assignWeights.ts` — updated embedBoundariesLocal + computeDoctrinalAnchoring call
- `lib/debate/argumentNetwork/attribution.ts` — exclusion_vector direction check (V3)
- `lib/debate/types/argumentNetwork.ts` — direction_mismatch added to union
- `lib/debate/claimAttribution.test.ts` — 3 new V3 direction_mismatch test cases
- `lib/debate/doctrinalAnchoring.test.ts` — 4 new V5 REJECT: polarity cases; pre-existing tests updated for new BoundaryEmbeddings shape

## Test plan
- [ ] `npx vitest run claimAttribution.test.ts doctrinalAnchoring.test.ts` → 45/45 pass
- [ ] V3: direction_mismatch fires when exclusion_vector >= 0.95x main similarity
- [ ] V3: orthogonal exclusion_vector → normal attribution
- [ ] V5: REJECT: boundary → anchored: false, floorApplied: false, confidence unchanged
- [ ] V5: embrace boundary (isRejection: false) → anchors normally
- [ ] V5: no boundaryIsRejection param → backward-compatible anchoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)
