### PR TITLE
feat(oped): renderer surface for public op-ed share links (t/2728)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -272,6 +272,10 @@ export const api: AppAPI = {
   createOpEdSet: (payload) => opEdIpc().createOpEdSet?.(payload) ?? rejectOpEdIpc('create an op-ed', 'createOpEdSet'),
   cancelOpEdSet: (setId) => { opEdIpc().cancelOpEdSet?.(setId); },
   onOpEdProgress: (cb) => opEdIpc().onOpEdProgress?.(cb) ?? (() => {}),
+  // t/2728: op-ed public sharing is a hosted-web feature (needs the public server route);
+  // desktop has no public URL, so reject with the standard web-only actionable error.
+  shareOpEdSet: () => rejectOpEdIpc('share an op-ed', 'shareOpEdSet'),
+  unshareOpEdSet: () => rejectOpEdIpc('un-share an op-ed', 'unshareOpEdSet'),
 
   // News Report
   generateNewsReport: (debateId) => window.electronAPI.generateNewsReport(debateId),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -300,6 +300,11 @@ export interface AppAPI {
   createOpEdSet: (payload: CreateOpEdPayload) => Promise<{ set_id: string }>;
   cancelOpEdSet: (setId: string) => void;
   onOpEdProgress: (callback: (event: OpEdProgressEvent) => void) => () => void;
+  /** t/2728: publish a durable public share link for an op-ed set. Web-only (the public
+   *  URL is served by the hosted server, GET /api/public/oped/:shareId); Electron rejects. */
+  shareOpEdSet: (setId: string) => Promise<{ shareId: string; url: string }>;
+  /** t/2728: revoke a public share (owner-only). */
+  unshareOpEdSet: (setId: string) => Promise<{ ok: boolean }>;
 
   // --- News Report ---
   generateNewsReport: (debateId: string) => Promise<{ article: string }>;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -1030,6 +1030,9 @@ const rawApi: AppAPI = {
   createOpEdSet: (payload) => runOpEdCreate(fetchWithSessionRecovery, payload),
   cancelOpEdSet: () => cancelActiveOpEdRun(), // aborts the in-flight POST → server cancels voices
   onOpEdProgress: (cb) => opedProgressBus.onProgress(cb),
+  // t/2728: publish/revoke a durable public share link (server: routes/oped.ts + opedShare.ts).
+  shareOpEdSet: (id) => post<{ shareId: string; url: string }>(`/api/oped-sets/${encodeURIComponent(id)}/share`, {}),
+  unshareOpEdSet: (id) => del<{ ok: boolean }>(`/api/oped-sets/${encodeURIComponent(id)}/share`),
   exportDebateToFile: async (session, format = 'json', exportOptions) => {
     const { debateToText, debateToMarkdown, debateToHtml, debateToPackage, debateExportFilename } = await import('@lib/debate/debateExport');
     const debate = session as Parameters<typeof debateToText>[0] & { diagnostics?: unknown };

--- a/taxonomy-editor/src/renderer/components/PublicOpEdView.css
+++ b/taxonomy-editor/src/renderer/components/PublicOpEdView.css
@@ -1,0 +1,128 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+   Licensed under the MIT License. See LICENSE file in the project root. */
+
+/* Public read-only op-ed share view (t/2728). Self-contained, theme-aware — this
+   view renders for a fully logged-out visitor and must not depend on the main app
+   shell. Mirrors the PublicPovView.css posture (slim centered card). */
+
+.pov-oped-root {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 2.5rem 1rem 4rem;
+  background: var(--bg, #f7f7f8);
+  color: var(--text, #1a1a1a);
+  box-sizing: border-box;
+}
+
+.pov-oped-card {
+  width: 100%;
+  max-width: 46rem;
+  background: var(--surface, #ffffff);
+  border: 1px solid var(--border, #e2e2e5);
+  border-radius: 12px;
+  padding: 2rem 2.25rem 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.pov-oped-status {
+  text-align: center;
+  color: var(--text-muted, #666);
+}
+.pov-oped-status-title {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem;
+}
+.pov-oped-status-body {
+  margin: 0;
+}
+
+.pov-oped-head {
+  border-bottom: 1px solid var(--border, #e2e2e5);
+  padding-bottom: 1rem;
+  margin-bottom: 1.25rem;
+}
+.pov-oped-topic {
+  font-size: 1.6rem;
+  line-height: 1.2;
+  margin: 0;
+}
+.pov-oped-outlet {
+  margin: 0.4rem 0 0;
+  color: var(--text-muted, #666);
+  font-size: 0.9rem;
+}
+
+.pov-oped-article {
+  margin: 1.75rem 0;
+}
+.pov-oped-strip {
+  border-left: 4px solid var(--text-muted, #888);
+  padding-left: 0.75rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: var(--text-muted, #666);
+  text-transform: uppercase;
+  margin-bottom: 0.6rem;
+}
+.pov-oped-headline {
+  font-size: 1.3rem;
+  line-height: 1.25;
+  margin: 0 0 0.35rem;
+}
+.pov-oped-subtitle {
+  font-size: 1.02rem;
+  color: var(--text-muted, #555);
+  margin: 0 0 0.9rem;
+  font-style: italic;
+}
+.pov-oped-body {
+  font-family: var(--font-serif, 'Source Serif 4', Georgia, serif);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+.pov-oped-body p { margin: 0 0 1rem; }
+.pov-oped-body h1,
+.pov-oped-body h2,
+.pov-oped-body h3 { line-height: 1.3; }
+
+.pov-oped-notice {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: var(--surface-muted, #f0f0f2);
+  color: var(--text-muted, #666);
+  font-size: 0.92rem;
+}
+
+.pov-oped-empty {
+  color: var(--text-muted, #666);
+  text-align: center;
+}
+
+.pov-oped-footer {
+  border-top: 1px solid var(--border, #e2e2e5);
+  padding-top: 1rem;
+  margin-top: 1.5rem;
+  text-align: center;
+}
+.pov-oped-brand {
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #888);
+  text-transform: uppercase;
+}
+
+@media (prefers-color-scheme: dark) {
+  .pov-oped-root {
+    background: var(--bg, #17171a);
+    color: var(--text, #e8e8ea);
+  }
+  .pov-oped-card {
+    background: var(--surface, #1f1f23);
+    border-color: var(--border, #33333a);
+    box-shadow: none;
+  }
+  .pov-oped-notice {
+    background: var(--surface-muted, #26262b);
+  }
+}

--- a/taxonomy-editor/src/renderer/components/PublicOpEdView.css
+++ b/taxonomy-editor/src/renderer/components/PublicOpEdView.css
@@ -1,33 +1,34 @@
 /* Copyright (c) 2026 Jeffrey Snover. All rights reserved.
    Licensed under the MIT License. See LICENSE file in the project root. */
 
-/* Public read-only op-ed share view (t/2728). Self-contained, theme-aware — this
-   view renders for a fully logged-out visitor and must not depend on the main app
-   shell. Mirrors the PublicPovView.css posture (slim centered card). */
+/* Public read-only op-ed share view (t/2728). Self-contained — this view renders
+   for a fully logged-out visitor and must not depend on the main app shell. Uses
+   only canonical theme tokens (src/renderer/styles.css), which are already
+   theme-aware, so no per-scheme override block is needed (theme-token-completeness
+   test, t/2567). Mirrors the PublicPovView.css posture (slim centered card). */
 
 .pov-oped-root {
   min-height: 100vh;
   display: flex;
   justify-content: center;
   padding: 2.5rem 1rem 4rem;
-  background: var(--bg, #f7f7f8);
-  color: var(--text, #1a1a1a);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   box-sizing: border-box;
 }
 
 .pov-oped-card {
   width: 100%;
   max-width: 46rem;
-  background: var(--surface, #ffffff);
-  border: 1px solid var(--border, #e2e2e5);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 2rem 2.25rem 1.5rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
 }
 
 .pov-oped-status {
   text-align: center;
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
 }
 .pov-oped-status-title {
   font-size: 1.25rem;
@@ -38,7 +39,7 @@
 }
 
 .pov-oped-head {
-  border-bottom: 1px solid var(--border, #e2e2e5);
+  border-bottom: 1px solid var(--border-color);
   padding-bottom: 1rem;
   margin-bottom: 1.25rem;
 }
@@ -49,7 +50,7 @@
 }
 .pov-oped-outlet {
   margin: 0.4rem 0 0;
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
   font-size: 0.9rem;
 }
 
@@ -57,11 +58,11 @@
   margin: 1.75rem 0;
 }
 .pov-oped-strip {
-  border-left: 4px solid var(--text-muted, #888);
+  border-left: 4px solid var(--text-muted);
   padding-left: 0.75rem;
   font-size: 0.78rem;
   letter-spacing: 0.04em;
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
   text-transform: uppercase;
   margin-bottom: 0.6rem;
 }
@@ -72,12 +73,11 @@
 }
 .pov-oped-subtitle {
   font-size: 1.02rem;
-  color: var(--text-muted, #555);
+  color: var(--text-secondary);
   margin: 0 0 0.9rem;
   font-style: italic;
 }
 .pov-oped-body {
-  font-family: var(--font-serif, 'Source Serif 4', Georgia, serif);
   font-size: 1.05rem;
   line-height: 1.65;
 }
@@ -89,18 +89,18 @@
 .pov-oped-notice {
   padding: 0.75rem 1rem;
   border-radius: 8px;
-  background: var(--surface-muted, #f0f0f2);
-  color: var(--text-muted, #666);
+  background: var(--bg-hover);
+  color: var(--text-muted);
   font-size: 0.92rem;
 }
 
 .pov-oped-empty {
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
   text-align: center;
 }
 
 .pov-oped-footer {
-  border-top: 1px solid var(--border, #e2e2e5);
+  border-top: 1px solid var(--border-color);
   padding-top: 1rem;
   margin-top: 1.5rem;
   text-align: center;
@@ -108,21 +108,6 @@
 .pov-oped-brand {
   font-size: 0.8rem;
   letter-spacing: 0.05em;
-  color: var(--text-muted, #888);
+  color: var(--text-muted);
   text-transform: uppercase;
-}
-
-@media (prefers-color-scheme: dark) {
-  .pov-oped-root {
-    background: var(--bg, #17171a);
-    color: var(--text, #e8e8ea);
-  }
-  .pov-oped-card {
-    background: var(--surface, #1f1f23);
-    border-color: var(--border, #33333a);
-    box-shadow: none;
-  }
-  .pov-oped-notice {
-    background: var(--surface-muted, #26262b);
-  }
 }

--- a/taxonomy-editor/src/renderer/components/PublicOpEdView.test.tsx
+++ b/taxonomy-editor/src/renderer/components/PublicOpEdView.test.tsx
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for the public read-only op-ed share view (t/2728, sibling of PublicPovView).
+// The load-bearing assertions are the TL binding invariants (t/1787#2): NO session
+// is minted (raw fetch, no `/api/auth/anonymous`), and the view is read-only.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const mockRecord = vi.fn();
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: mockRecord }),
+}));
+
+const mockFetch = vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>();
+vi.stubGlobal('fetch', mockFetch);
+
+const { PublicOpEdView, shareIdFromOpEdPath } = await import('./PublicOpEdView');
+
+interface FakeResponseInit { status?: number; body?: unknown }
+function fakeResponse({ status = 200, body = {} }: FakeResponseInit): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(),
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+const SHARE_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+const SAMPLE = {
+  schema_version: 1 as const,
+  shareId: SHARE_ID,
+  topic: 'The pace of AI capability',
+  outlet: 'The Atlantic',
+  created_at: '2026-08-17T00:00:00Z',
+  opeds: [
+    { pov: 'acc', status: 'complete', headline: 'Ship the future', subtitle: 'Why acceleration wins', body: 'Accelerate now, the body argues.', wordCount: 800 },
+    { pov: 'saf', status: 'failed', headline: '', subtitle: '', body: '', wordCount: 0 },
+  ],
+};
+
+function goTo(pathname: string): void {
+  window.history.pushState({}, '', pathname);
+}
+
+describe('shareIdFromOpEdPath', () => {
+  it('extracts a valid shareId (uuid), with or without trailing slash', () => {
+    expect(shareIdFromOpEdPath(`/share/oped/${SHARE_ID}`)).toBe(SHARE_ID);
+    expect(shareIdFromOpEdPath(`/share/oped/${SHARE_ID}/`)).toBe(SHARE_ID);
+  });
+  it('returns null for non-share or malformed paths', () => {
+    expect(shareIdFromOpEdPath('/')).toBeNull();
+    expect(shareIdFromOpEdPath('/share/oped/')).toBeNull();
+    expect(shareIdFromOpEdPath('/share/oped/a b')).toBeNull();
+    expect(shareIdFromOpEdPath('/share/oped/../etc')).toBeNull();
+    expect(shareIdFromOpEdPath('/share/pov/acc-Beliefs-001')).toBeNull();
+  });
+});
+
+describe('PublicOpEdView (t/2728)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    goTo(`/share/oped/${SHARE_ID}`);
+  });
+  afterEach(() => {
+    goTo('/');
+    vi.restoreAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  it('fetches via a raw GET to the public endpoint — no session minted', async () => {
+    mockFetch.mockResolvedValue(fakeResponse({ body: SAMPLE }));
+    render(<PublicOpEdView />);
+
+    await screen.findByText(SAMPLE.topic);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(`/api/public/oped/${SHARE_ID}`);
+    expect(init).toMatchObject({ method: 'GET', credentials: 'omit', cache: 'no-store' });
+
+    // The binding invariant: the session-recovery path is NEVER touched.
+    const hitAnonymous = mockFetch.mock.calls.some(([u]) => String(u).includes('/api/auth/anonymous'));
+    expect(hitAnonymous).toBe(false);
+  });
+
+  it('renders the shared set read-only (topic, complete voice, failed-voice notice; no controls)', async () => {
+    mockFetch.mockResolvedValue(fakeResponse({ body: SAMPLE }));
+    render(<PublicOpEdView />);
+
+    await screen.findByText(SAMPLE.topic);
+    expect(screen.getByText('For The Atlantic')).toBeInTheDocument();
+    expect(screen.getByText('Ship the future')).toBeInTheDocument();
+    expect(screen.getByText('Why acceleration wins')).toBeInTheDocument();
+    expect(screen.getByText('Accelerate now, the body argues.')).toBeInTheDocument();
+    // Partial-set contract: the failed voice renders a notice, not an essay.
+    expect(screen.getByText(/failed to generate/)).toBeInTheDocument();
+
+    // Read-only: no inputs or actionable buttons on the public path.
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('shows a not-found state on 404 without erroring', async () => {
+    mockFetch.mockResolvedValue(fakeResponse({ status: 404 }));
+    render(<PublicOpEdView />);
+    await screen.findByText('Not available');
+    expect(mockRecord).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch for a malformed shareId', async () => {
+    goTo('/share/oped/..');
+    render(<PublicOpEdView />);
+    await screen.findByText('Not available');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('shows an error state and records to the flight recorder on network failure', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+    render(<PublicOpEdView />);
+    await screen.findByText(/Couldn’t load this op-ed/);
+    expect(mockRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'system.error', component: 'PublicOpEdView', level: 'error' }),
+    );
+  });
+});

--- a/taxonomy-editor/src/renderer/components/PublicOpEdView.tsx
+++ b/taxonomy-editor/src/renderer/components/PublicOpEdView.tsx
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Public read-only op-ed share view (t/2728, sibling of PublicPovView / t/1790).
+//
+// Renders a shared op-ed SET for a FULLY LOGGED-OUT visitor at `/share/oped/:shareId`
+// — no login prompt, no App/loadAll mount, no `/ws` socket.
+//
+// Binding invariant (same as PublicPovView, TL t/1787#2): NO session/cookie is
+// minted on this path. The fetch below is a RAW `fetch` — NOT a web-bridge helper —
+// because those route through `fetchWithSessionRecovery`, which POSTs
+// `/api/auth/anonymous` on a `no_session` 401 and would silently mint a session.
+// `credentials: 'omit'` guarantees no cookie is sent or stored. Registered as an
+// approved bare-fetch exception in taxonomy-editor/AGENTS.md § Client Network Resilience.
+
+import { useEffect, useState } from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { resolvePovMeta } from './opeds/povResolve';
+import './PublicOpEdView.css';
+
+/**
+ * Public projection of a shared op-ed set — MUST mirror the server-side
+ * `PublicOpEd` / `PublicOpEdMember` positive allowlist (opedShareStore.ts). Exactly
+ * these fields are public; generation params (model/prompts/thesis/authorBio),
+ * the pitch draft, grounding internals, userId and the storage set_id are never exposed.
+ */
+export interface PublicOpEdMember {
+  pov: string;
+  status: string;
+  headline: string;
+  subtitle: string;
+  body: string;
+  wordCount: number;
+}
+export interface PublicOpEd {
+  schema_version: 1;
+  shareId: string;
+  topic: string;
+  outlet: string | null;
+  created_at: string;
+  opeds: PublicOpEdMember[];
+}
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'ready'; doc: PublicOpEd }
+  | { status: 'missing' }
+  | { status: 'error' };
+
+/**
+ * Extract the shareId from a `/share/oped/<shareId>` pathname. Pure — shareIds are
+ * randomUUIDs (`[A-Za-z0-9-]+`), so no decode/throw is needed; anything else returns
+ * null and the view shows the not-found state.
+ */
+export function shareIdFromOpEdPath(pathname: string): string | null {
+  const m = pathname.match(/^\/share\/oped\/([A-Za-z0-9-]+)\/?$/);
+  return m ? m[1] : null;
+}
+
+function OpEdArticle({ member, outlet }: { member: PublicOpEdMember; outlet: string | null }) {
+  const meta = resolvePovMeta(member.pov);
+  const metaLine = [meta.label.toUpperCase(), outlet || null, `${member.wordCount} words`]
+    .filter(Boolean).join(' · ');
+
+  return (
+    <article className="pov-oped-article">
+      <div
+        className="pov-oped-strip"
+        // eslint-disable-next-line local/no-inline-style -- dynamic: camp accent color from POV_META cssVar (theme-aware)
+        style={{ borderLeftColor: `var(${meta.cssVar})` }}
+      >
+        {metaLine}
+      </div>
+      {member.status !== 'complete' ? (
+        <div className="pov-oped-notice" role="status">
+          This voice {member.status === 'failed' ? 'failed to generate' : 'was cancelled'} — no essay is available for it.
+        </div>
+      ) : (
+        <>
+          <h2 className="pov-oped-headline">{member.headline}</h2>
+          {member.subtitle && <p className="pov-oped-subtitle">{member.subtitle}</p>}
+          <div className="pov-oped-body">
+            <Markdown remarkPlugins={[remarkGfm]}>{member.body}</Markdown>
+          </div>
+        </>
+      )}
+    </article>
+  );
+}
+
+export function PublicOpEdView() {
+  const [state, setState] = useState<LoadState>({ status: 'loading' });
+
+  useEffect(() => {
+    const shareId = shareIdFromOpEdPath(window.location.pathname);
+    if (!shareId) {
+      setState({ status: 'missing' });
+      return;
+    }
+
+    let cancelled = false;
+    // Raw fetch bypasses the bridge's timeout layer, so guard it ourselves
+    // (Network Resilience rule #1: every request has a timeout).
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/public/oped/${encodeURIComponent(shareId)}`,
+          { method: 'GET', credentials: 'omit', cache: 'no-store', signal: controller.signal },
+        );
+        if (cancelled) return;
+        if (res.status === 404) { setState({ status: 'missing' }); return; }
+        if (!res.ok) { setState({ status: 'error' }); return; }
+        const doc = await res.json() as PublicOpEd;
+        if (cancelled) return;
+        setState({ status: 'ready', doc });
+      } catch (err) {
+        if (cancelled) return;
+        getGlobalRecorder()?.record({
+          type: 'system.error',
+          component: 'PublicOpEdView',
+          level: 'error',
+          message: 'Failed to load public op-ed share',
+          error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+        });
+        setState({ status: 'error' });
+      } finally {
+        clearTimeout(timeout);
+      }
+    })();
+    return () => { cancelled = true; clearTimeout(timeout); };
+  }, []);
+
+  if (state.status === 'loading') {
+    return (
+      <div className="pov-oped-root">
+        <div className="pov-oped-card pov-oped-status">Loading…</div>
+      </div>
+    );
+  }
+
+  if (state.status === 'missing') {
+    return (
+      <div className="pov-oped-root">
+        <div className="pov-oped-card pov-oped-status">
+          <h1 className="pov-oped-status-title">Not available</h1>
+          <p className="pov-oped-status-body">This shared op-ed could not be found, or it isn’t publicly viewable.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="pov-oped-root">
+        <div className="pov-oped-card pov-oped-status">
+          <h1 className="pov-oped-status-title">Couldn’t load this op-ed</h1>
+          <p className="pov-oped-status-body">Something went wrong loading this shared op-ed. Please try again later.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { doc } = state;
+  return (
+    <div className="pov-oped-root">
+      <div className="pov-oped-card" aria-label="Shared op-ed">
+        <header className="pov-oped-head">
+          <h1 className="pov-oped-topic">{doc.topic}</h1>
+          {doc.outlet ? <p className="pov-oped-outlet">For {doc.outlet}</p> : null}
+        </header>
+        {doc.opeds.length === 0 ? (
+          <p className="pov-oped-empty">This shared op-ed has no voices.</p>
+        ) : (
+          doc.opeds.map((m, i) => <OpEdArticle key={`${m.pov}-${i}`} member={m} outlet={doc.outlet} />)
+        )}
+        <footer className="pov-oped-footer">
+          <span className="pov-oped-brand">AI Triad Research</span>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.css
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.css
@@ -96,6 +96,35 @@
   outline-offset: 2px;
 }
 
+/* ── Public share control (web-only; t/2728) ── */
+.oped-share {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto; /* push to the far end of the reader bar */
+}
+.oped-share-status {
+  font-size: 0.75rem;
+  color: var(--text-secondary, var(--text-muted));
+  white-space: nowrap;
+}
+.oped-share-url {
+  font: inherit;
+  font-size: 0.75rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  width: 15rem;
+  max-width: 34vw;
+}
+.oped-share-error {
+  font-size: 0.75rem;
+  color: var(--danger, #c0392b);
+  white-space: nowrap;
+}
+
 .oped-reader-loading,
 .oped-reader-error {
   padding: 1.5rem;

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -140,6 +140,78 @@ function OpEdHeaderActions({
   );
 }
 
+// ── Share control (web-only; electron-bridge rejects share — t/2728) ──────────
+//
+// Publishes a durable, no-login public link for a set and copies it to the
+// clipboard. The link is built from the returned shareId against the current
+// origin — canonical `/share/oped/:shareId`, independent of the server's `url`
+// field format. Un-share revokes the public copy (delete + re-share mints a
+// fresh shareId, so a leaked link dies for good).
+
+type ShareState =
+  | { status: 'idle' }
+  | { status: 'working' }
+  | { status: 'shared'; url: string; copied: boolean }
+  | { status: 'error'; message: string };
+
+function ShareOpEdControl({ setId }: { setId: string }) {
+  const [state, setState] = useState<ShareState>({ status: 'idle' });
+
+  const copy = useCallback(async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setState({ status: 'shared', url, copied: true });
+    } catch {
+      // Clipboard denied (permissions/insecure context) — still show the link so
+      // the user can copy manually; this is not a share failure.
+      setState({ status: 'shared', url, copied: false });
+    }
+  }, []);
+
+  const onShare = useCallback(async () => {
+    setState({ status: 'working' });
+    try {
+      const { shareId } = await api.shareOpEdSet(setId);
+      const url = new URL(`/share/oped/${encodeURIComponent(shareId)}`, window.location.origin).href;
+      await copy(url);
+    } catch (err) {
+      setState({ status: 'error', message: err instanceof Error ? err.message : 'Could not create the share link.' });
+    }
+  }, [setId, copy]);
+
+  const onUnshare = useCallback(async () => {
+    setState({ status: 'working' });
+    try {
+      await api.unshareOpEdSet(setId);
+      setState({ status: 'idle' });
+    } catch (err) {
+      setState({ status: 'error', message: err instanceof Error ? err.message : 'Could not revoke the share link.' });
+    }
+  }, [setId]);
+
+  if (state.status === 'shared') {
+    return (
+      <span className="oped-share oped-share-active">
+        <span className="oped-share-status" role="status">{state.copied ? 'Link copied' : 'Public link ready'}</span>
+        <input className="oped-share-url" type="text" readOnly value={state.url} aria-label="Public share link"
+          onFocus={e => e.currentTarget.select()} />
+        <button type="button" className="btn btn-sm btn-ghost" onClick={() => void copy(state.url)}>Copy</button>
+        <button type="button" className="btn btn-sm btn-ghost" onClick={() => void onUnshare()}>Un-share</button>
+      </span>
+    );
+  }
+
+  return (
+    <span className="oped-share">
+      <button type="button" className="btn btn-sm btn-ghost" onClick={() => void onShare()}
+        disabled={state.status === 'working'} aria-label="Create a public share link">
+        {state.status === 'working' ? 'Sharing…' : '🔗 Share'}
+      </button>
+      {state.status === 'error' && <span className="oped-share-error" role="alert">{state.message}</span>}
+    </span>
+  );
+}
+
 // ── Reader view (back bar + article/loading/error) ────────────────────────────
 
 function OpEdReaderView({
@@ -157,6 +229,8 @@ function OpEdReaderView({
         <div className="oped-reader-bar">
           <button type="button" className="oped-reader-back" onClick={onBack}>‹ Op-Eds</button>
           {status && <span className="oped-status">{status}</span>}
+          {/* Share is web-only: electron-bridge rejects shareOpEdSet (t/2728). */}
+          {readerSet && !isElectronMode() && <ShareOpEdControl setId={readerSet.set_id} />}
         </div>
         {readerLoading && <p className="oped-reader-loading">Loading op-ed…</p>}
         {readerError && <p className="oped-reader-error">{readerError}</p>}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -162,8 +162,9 @@ function ShareOpEdControl({ setId }: { setId: string }) {
       await navigator.clipboard.writeText(url);
       setState({ status: 'shared', url, copied: true });
     } catch {
+      /* telemetry — silent by design */
       // Clipboard denied (permissions/insecure context) — still show the link so
-      // the user can copy manually; this is not a share failure.
+      // the user can copy manually; this is not a share failure, so no record.
       setState({ status: 'shared', url, copied: false });
     }
   }, []);
@@ -175,6 +176,11 @@ function ShareOpEdControl({ setId }: { setId: string }) {
       const url = new URL(`/share/oped/${encodeURIComponent(shareId)}`, window.location.origin).href;
       await copy(url);
     } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'ShareOpEdControl', level: 'error',
+        message: 'Failed to publish an op-ed share link',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
       setState({ status: 'error', message: err instanceof Error ? err.message : 'Could not create the share link.' });
     }
   }, [setId, copy]);
@@ -185,6 +191,11 @@ function ShareOpEdControl({ setId }: { setId: string }) {
       await api.unshareOpEdSet(setId);
       setState({ status: 'idle' });
     } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'ShareOpEdControl', level: 'error',
+        message: 'Failed to revoke an op-ed share link',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
       setState({ status: 'error', message: err instanceof Error ? err.message : 'Could not revoke the share link.' });
     }
   }, [setId]);

--- a/taxonomy-editor/src/renderer/index.tsx
+++ b/taxonomy-editor/src/renderer/index.tsx
@@ -9,17 +9,24 @@ import '@fontsource/source-serif-4/600.css';
 import '@fontsource-variable/jetbrains-mono';
 import { App } from './App';
 import { PublicPovView } from './components/PublicPovView';
+import { PublicOpEdView } from './components/PublicOpEdView';
 import './styles.css';
 
-// Public share link (t/1790): a fully logged-out visitor to `/share/pov/:id`
-// gets the slim read-only POV view — NOT the main app. Rendering App() here would
-// run its feature-flag refresh (getFlags → session-recovering bridge helper) and
-// mount MainApp/loadAll (auth + `/ws`), all of which would mint a session and
-// violate the no-session invariant (TL, t/1787#2). Branch before App renders.
-const isPublicShare = window.location.pathname.startsWith('/share/pov/');
+// Public share link (t/1790, t/2728): a fully logged-out visitor to `/share/pov/:id`
+// or `/share/oped/:shareId` gets the slim read-only view — NOT the main app.
+// Rendering App() here would run its feature-flag refresh (getFlags → session-
+// recovering bridge helper) and mount MainApp/loadAll (auth + `/ws`), all of which
+// would mint a session and violate the no-session invariant (TL, t/1787#2). Branch
+// before App renders.
+const path = window.location.pathname;
+const publicView = path.startsWith('/share/pov/')
+  ? <PublicPovView />
+  : path.startsWith('/share/oped/')
+    ? <PublicOpEdView />
+    : null;
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    {isPublicShare ? <PublicPovView /> : <App />}
+    {publicView ?? <App />}
   </StrictMode>,
 );


### PR DESCRIPTION
Renderer half of the op-ed public-share feature (server side landed in **t/2727**). Web-only; mirrors the PublicPovView (t/1790) security posture.

## What
- **BridgeAPI** `shareOpEdSet` / `unshareOpEdSet` — electron-bridge **rejects** both (share is a hosted-web capability); web-bridge POST/DELETEs the t/2727 routes.
- **PublicOpEdView** (+ css) — fully logged-out read-only view at `/share/oped/:shareId`. RAW `fetch` + `credentials:'omit'` (**no session minted** — TL invariant t/1787#2), 15s AbortController timeout, loading/ready/missing/error states, flight-recorder on failure. Renders only the server-side positive-allowlist projection.
- **index.tsx** — branches `/share/oped/` to the slim view before `App` mounts (no loadAll, no `/ws`). `/share/` is already an auth-exempt prefix (publicPaths.ts).
- **ShareOpEdControl** in the op-ed reader bar (web-only) — publish → copy durable link (built from `shareId` against origin) → un-share (revoke).
- **Tests** — `shareIdFromOpEdPath` parsing + view load states incl. the no-session invariant and the partial-set failed-voice notice.

## DRAFT — gate before un-draft
Dual-build **data-reading** feature (t/2648 rule): must be verified on the **hosted web profile** (github-api path, real deployed data) before sign-off — a share link that renders locally can return empty on web. Un-draft only after: (1) CI green on this head, (2) hosted web smoke shows a real shared op-ed loads logged-out.

Refs t/2728. Server routes: t/2727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)