### PR TITLE
feat(taxonomy): shared directional-agreement engine scripts/nli_classify.py (t/2751)

### DIFF
--- a/scripts/nli_classify.py
+++ b/scripts/nli_classify.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+"""Shared directional-agreement engine (t/2743 / t/2744 / t/2751).
+
+ONE engine for the directional-agreement gate. The PowerShell and TypeScript
+gates are thin subprocess wrappers over this file (TL ruling t/2744#3) — no
+per-runtime NLI, framing, or thresholds. It exists to keep every runtime's
+directional verdict *identical*, which is the whole point of a gate that fights
+a cross-cutting inversion class.
+
+WHY AN ENGINE, NOT WRAPPER LOGIC (t/2744#2, empirically reproduced):
+The deberta NLI model reproduces the polarity-blindness bug on RAW propositions
+(false `entailment` +4.09 on the t/2737 origin case) and only recovers the true
+direction when each side is framed as a *stated position*
+(`"The <pov> position is: <prop>"` -> `contradiction`, entail -1.23 / contra
++1.44). Framing is the fragile, bug-determining step, so it MUST live here and
+nowhere else — a wrapper that frames (or forgets to) is exactly how one runtime
+regresses unnoticed.
+
+Reuses embed_taxonomy.py's deberta driver (`_load_nli_model`,
+`_classify_pairs_nli`) so the raw model + margin gate are single-sourced too;
+the `nli-classify` subcommand there is left untouched for Find-SituationCandidates.
+
+SUBPROCESS CONTRACT
+  stdin  JSON: [{"id"?, "claim_prop", "node_prop", "claim_pov"?, "node_pov"?}]
+  stdout JSON: [{"id", "direction", "confidence", "method",
+                 "nli_label", "framed_a", "framed_b"}]
+  direction in {agrees, opposes, unrelated, unresolved}
+  confidence = NLI top-1 vs top-2 logit margin (best - second).
+
+FAIL-SAFE (load-bearing, t/2744#3 arm 3): any error, an empty proposition, or a
+below-threshold margin resolves to `unresolved` — NEVER `agrees`. Callers treat
+`unresolved`/`unrelated` as flag/neutral/drop and must never assert alignment.
+
+Flags:
+  --min-margin FLOAT   Margin floor (best-second) required to emit agrees/opposes;
+                       below it -> unresolved. Default 1.0 (stipulated v0; same
+                       units as embed_taxonomy NLI_CONFIDENCE_MARGIN). Provenance
+                       owned by CL (docs/metric-provenance-register.md), calibrated
+                       against the t/2742 fixture + an agreement control.
+  --no-framing         Bypass POV framing (feed raw props). Exists ONLY so the
+                       framing-regression guard fixture can show raw->entailment
+                       (wrong) vs framed->contradiction (right) through THIS engine.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# Reuse the single deberta driver from embed_taxonomy (import-safe: it guards
+# execution behind `if __name__ == "__main__"`).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+_MAX_STDIN_BYTES = 50 * 1024 * 1024
+
+# Stipulated v0 (t/2744, CL). Margin floor on the (best - second) logit scale.
+# v0 == the base margin gate, i.e. "trust the margin-gated label". CL calibrates
+# and registers the final value; do NOT raise tau_contra past ~1.4 (the t/2744#2
+# true-contradiction margin was ~1.44 — a higher floor rejects real opposition).
+MARGIN_FLOOR_DEFAULT = 1.0
+
+
+def frame_position(prop, pov):
+    """Frame a proposition as an attributed *stated position* (t/2744#2).
+
+    Empty/whitespace proposition -> '' so the caller resolves it to `unresolved`
+    rather than feeding the model a degenerate hypothesis.
+    """
+    prop = (prop or "").strip()
+    if not prop:
+        return ""
+    pov = (pov or "").strip()
+    if pov:
+        return "The {} position is: {}".format(pov, prop)
+    return "The stated position is: {}".format(prop)
+
+
+def _direction_for(label, margin, min_margin):
+    """Map an NLI label + margin to a directional verdict. Fail-safe by default."""
+    if label == "entailment" and margin >= min_margin:
+        return "agrees"
+    if label == "contradiction" and margin >= min_margin:
+        return "opposes"
+    if label == "neutral":
+        return "unrelated"
+    # entailment/contradiction below the margin floor, or anything unexpected.
+    return "unresolved"
+
+
+def judge_direction(items, min_margin=MARGIN_FLOOR_DEFAULT, no_framing=False):
+    """Judge each {claim_prop, node_prop, pov} item. Returns aligned result dicts."""
+    n = len(items)
+    results = [None] * n
+    pending = []  # (index, framed_a, framed_b)
+
+    for i, it in enumerate(items):
+        claim = it.get("claim_prop", "")
+        node = it.get("node_prop", "")
+        if no_framing:
+            a = (claim or "").strip()
+            b = (node or "").strip()
+        else:
+            a = frame_position(claim, it.get("claim_pov"))
+            b = frame_position(node, it.get("node_pov"))
+        if not a or not b:
+            results[i] = {
+                "direction": "unresolved", "confidence": 0.0, "method": "none",
+                "nli_label": None, "framed_a": a, "framed_b": b,
+            }
+        else:
+            pending.append((i, a, b))
+
+    if pending:
+        try:
+            from embed_taxonomy import _load_nli_model, _classify_pairs_nli
+            model = _load_nli_model()
+            classified = _classify_pairs_nli(model, [(a, b) for (_i, a, b) in pending])
+        except Exception as exc:  # noqa: BLE001 — fail-safe: never assert agreement
+            print("nli_classify: engine unavailable ({}) — all pending unresolved"
+                  .format(exc), file=sys.stderr)
+            classified = None
+
+        if classified is None:
+            for (i, a, b) in pending:
+                results[i] = {
+                    "direction": "unresolved", "confidence": 0.0, "method": "none",
+                    "nli_label": None, "framed_a": a, "framed_b": b,
+                }
+        else:
+            for (i, a, b), res in zip(pending, classified):
+                label = res.get("label")
+                margin = float(res.get("margin", 0.0))
+                results[i] = {
+                    "direction": _direction_for(label, margin, min_margin),
+                    "confidence": round(margin, 4),
+                    "method": "nli",
+                    "nli_label": label,
+                    "framed_a": a, "framed_b": b,
+                }
+
+    out = []
+    for i, it in enumerate(items):
+        r = results[i]
+        r_id = it["id"] if "id" in it else i
+        entry = {"id": r_id}
+        entry.update(r)
+        out.append(entry)
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Shared directional-agreement engine (POV-framed NLI).")
+    parser.add_argument("--min-margin", type=float, default=MARGIN_FLOOR_DEFAULT,
+                        help="Margin floor for agrees/opposes (default 1.0).")
+    parser.add_argument("--no-framing", action="store_true",
+                        help="Bypass POV framing (regression-guard fixture only).")
+    args = parser.parse_args()
+
+    raw = sys.stdin.read(_MAX_STDIN_BYTES)
+    if not raw.strip():
+        json.dump([], sys.stdout)
+        return
+    items = json.loads(raw)
+    if not isinstance(items, list):
+        items = [items]
+
+    out = judge_direction(items, min_margin=args.min_margin, no_framing=args.no_framing)
+    json.dump(out, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nli_classify.py
+++ b/scripts/nli_classify.py
@@ -29,16 +29,28 @@ SUBPROCESS CONTRACT
   direction in {agrees, opposes, unrelated, unresolved}
   confidence = NLI top-1 vs top-2 logit margin (best - second).
 
-FAIL-SAFE (load-bearing, t/2744#3 arm 3): any error, an empty proposition, or a
-below-threshold margin resolves to `unresolved` — NEVER `agrees`. Callers treat
-`unresolved`/`unrelated` as flag/neutral/drop and must never assert alignment.
+ASYMMETRIC OPPOSITION DETECTOR (CL ruling t/2751#3): under POV framing the deberta
+model reliably recovers *contradiction* but SUPPRESSES *entailment* — a genuine
+agreement reads `neutral`, not `entailment` (a label fact, not a threshold to
+tune). So this gate's load-bearing signal is `opposes`; callers demote/flip ONLY
+on `opposes`. `agrees` / `unrelated` / `unresolved` all mean "no opposition
+detected" and the caller KEEPS its edge. The gate never confirms agreement.
+
+FAIL-SAFE (load-bearing, t/2751#3 arm 3): any error, an empty proposition, or a
+below-threshold margin resolves to `unresolved` — NEVER `opposes`. Because callers
+only act on `opposes`, `unresolved` is safe (a missed inversion beats dropping
+every edge). The gate must never FALSELY oppose.
 
 Flags:
-  --min-margin FLOAT   Margin floor (best-second) required to emit agrees/opposes;
-                       below it -> unresolved. Default 1.0 (stipulated v0; same
-                       units as embed_taxonomy NLI_CONFIDENCE_MARGIN). Provenance
-                       owned by CL (docs/metric-provenance-register.md), calibrated
-                       against the t/2742 fixture + an agreement control.
+  --tau-contra FLOAT   Margin floor (best-second) to emit `opposes`; below it ->
+                       unresolved. Default 1.0 (FINAL, CL t/2751#3 — catches the
+                       t/2742 inversion at margin 1.2746; genuine agreements are
+                       `neutral` so the false-oppose rate is structurally ~0). Do
+                       not exceed ~1.4 (the real contradiction margin). Provenance
+                       registered by CL in docs/metric-provenance-register.md.
+  --tau-entail FLOAT   Margin floor to emit `agrees`. Default 0.0 = RESERVED/unused
+                       (CL t/2751#3): `agrees` is informational only — no caller
+                       acts on it — so it carries no floor.
   --no-framing         Bypass POV framing (feed raw props). Exists ONLY so the
                        framing-regression guard fixture can show raw->entailment
                        (wrong) vs framed->contradiction (right) through THIS engine.
@@ -55,11 +67,14 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 _MAX_STDIN_BYTES = 50 * 1024 * 1024
 
-# Stipulated v0 (t/2744, CL). Margin floor on the (best - second) logit scale.
-# v0 == the base margin gate, i.e. "trust the margin-gated label". CL calibrates
-# and registers the final value; do NOT raise tau_contra past ~1.4 (the t/2744#2
-# true-contradiction margin was ~1.44 — a higher floor rejects real opposition).
-MARGIN_FLOOR_DEFAULT = 1.0
+# FINAL thresholds (CL ruling t/2751#3). Margin = (best - second) logit gap.
+# tau_contra 1.0 catches the t/2742 inversion (margin 1.2746) while genuine
+# agreements read `neutral`, so the false-oppose rate is structurally ~0. Do NOT
+# raise past ~1.4 (the real contradiction margin). Registered by CL in the
+# metric-provenance-register. tau_entail is reserved/unused — `agrees` is
+# informational only (no caller acts on it), so it carries no floor.
+TAU_CONTRA_DEFAULT = 1.0
+TAU_ENTAIL_DEFAULT = 0.0
 
 
 def frame_position(prop, pov):
@@ -77,19 +92,25 @@ def frame_position(prop, pov):
     return "The stated position is: {}".format(prop)
 
 
-def _direction_for(label, margin, min_margin):
-    """Map an NLI label + margin to a directional verdict. Fail-safe by default."""
-    if label == "entailment" and margin >= min_margin:
-        return "agrees"
-    if label == "contradiction" and margin >= min_margin:
+def _direction_for(label, margin, tau_contra, tau_entail):
+    """Map an NLI label + margin to a directional verdict (opposition detector).
+
+    `opposes` is the only load-bearing verdict (callers act on it); it requires a
+    contradiction label AND margin >= tau_contra. `agrees` is informational
+    (tau_entail default 0.0 = no floor). Anything below the contradiction floor,
+    or an unexpected label, is `unresolved` — never a false `opposes`.
+    """
+    if label == "contradiction" and margin >= tau_contra:
         return "opposes"
+    if label == "entailment" and margin >= tau_entail:
+        return "agrees"
     if label == "neutral":
         return "unrelated"
-    # entailment/contradiction below the margin floor, or anything unexpected.
     return "unresolved"
 
 
-def judge_direction(items, min_margin=MARGIN_FLOOR_DEFAULT, no_framing=False):
+def judge_direction(items, tau_contra=TAU_CONTRA_DEFAULT,
+                    tau_entail=TAU_ENTAIL_DEFAULT, no_framing=False):
     """Judge each {claim_prop, node_prop, pov} item. Returns aligned result dicts."""
     n = len(items)
     results = [None] * n
@@ -133,7 +154,7 @@ def judge_direction(items, min_margin=MARGIN_FLOOR_DEFAULT, no_framing=False):
                 label = res.get("label")
                 margin = float(res.get("margin", 0.0))
                 results[i] = {
-                    "direction": _direction_for(label, margin, min_margin),
+                    "direction": _direction_for(label, margin, tau_contra, tau_entail),
                     "confidence": round(margin, 4),
                     "method": "nli",
                     "nli_label": label,
@@ -153,8 +174,10 @@ def judge_direction(items, min_margin=MARGIN_FLOOR_DEFAULT, no_framing=False):
 def main():
     parser = argparse.ArgumentParser(
         description="Shared directional-agreement engine (POV-framed NLI).")
-    parser.add_argument("--min-margin", type=float, default=MARGIN_FLOOR_DEFAULT,
-                        help="Margin floor for agrees/opposes (default 1.0).")
+    parser.add_argument("--tau-contra", type=float, default=TAU_CONTRA_DEFAULT,
+                        help="Margin floor to emit 'opposes' (default 1.0, final).")
+    parser.add_argument("--tau-entail", type=float, default=TAU_ENTAIL_DEFAULT,
+                        help="Margin floor to emit 'agrees' (default 0.0, reserved).")
     parser.add_argument("--no-framing", action="store_true",
                         help="Bypass POV framing (regression-guard fixture only).")
     args = parser.parse_args()
@@ -167,7 +190,8 @@ def main():
     if not isinstance(items, list):
         items = [items]
 
-    out = judge_direction(items, min_margin=args.min_margin, no_framing=args.no_framing)
+    out = judge_direction(items, tau_contra=args.tau_contra,
+                          tau_entail=args.tau_entail, no_framing=args.no_framing)
     json.dump(out, sys.stdout)
 
 

--- a/scripts/test_nli_classify.py
+++ b/scripts/test_nli_classify.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+"""Unit tests for nli_classify.py — the shared directional-agreement engine (t/2751).
+
+Exercises the engine's OWN logic (POV framing, label->direction mapping, the
+tau_contra floor, and the fail-safe) WITHOUT the deberta model by monkeypatching
+the classifier embed_taxonomy exposes. The real-model arms (exact scores on the
+t/2742 fixture) are proven separately and recorded on t/2751; this suite is the
+CI-runnable guard so framing/mapping/fail-safe can never regress unnoticed.
+
+Runnable under pytest or standalone: `python test_nli_classify.py`.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_DIR = Path(__file__).resolve().parent
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, _DIR / (name + ".py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Register embed_taxonomy in sys.modules BEFORE loading nli_classify, so the
+# deferred `from embed_taxonomy import ...` inside judge_direction resolves to
+# THIS instance — the one the tests monkeypatch — not a fresh real import.
+embed_taxonomy = _load("embed_taxonomy")
+sys.modules["embed_taxonomy"] = embed_taxonomy
+nli_classify = _load("nli_classify")
+
+
+def _stub_classifier(result_for):
+    """Install a fake deberta driver keyed by a marker in the hypothesis text."""
+    embed_taxonomy._load_nli_model = lambda: object()
+
+    def fake(model, pairs):
+        out = []
+        for (_a, b) in pairs:
+            out.append(result_for(b))
+        return out
+
+    embed_taxonomy._classify_pairs_nli = fake
+
+
+def _res(label, margin):
+    return {"label": label, "entailment": 0.0, "neutral": 0.0,
+            "contradiction": 0.0, "margin": margin}
+
+
+def test_framing_is_applied_and_single_sourced():
+    _stub_classifier(lambda b: _res("contradiction", 1.3))
+    out = nli_classify.judge_direction(
+        [{"id": "p", "claim_prop": "ordinary law applies",
+          "claim_pov": "accelerationist", "node_prop": "AI needs new laws",
+          "node_pov": "accelerationist"}])
+    assert out[0]["framed_a"] == "The accelerationist position is: ordinary law applies"
+    assert out[0]["framed_b"] == "The accelerationist position is: AI needs new laws"
+    assert out[0]["direction"] == "opposes"
+
+
+def test_label_to_direction_mapping():
+    cases = [("contradiction", 1.3, "opposes"),
+             ("entailment", 5.0, "agrees"),
+             ("neutral", 4.0, "unrelated")]
+    for label, margin, expected in cases:
+        _stub_classifier(lambda b, _l=label, _m=margin: _res(_l, _m))
+        out = nli_classify.judge_direction(
+            [{"claim_prop": "a", "node_prop": "b"}])
+        assert out[0]["direction"] == expected, (label, out[0]["direction"])
+
+
+def test_tau_contra_floor_downgrades_weak_contradiction_to_unresolved():
+    # A contradiction below tau_contra must NOT emit a (false) opposes.
+    _stub_classifier(lambda b: _res("contradiction", 0.5))
+    out = nli_classify.judge_direction(
+        [{"claim_prop": "a", "node_prop": "b"}], tau_contra=1.0)
+    assert out[0]["direction"] == "unresolved"
+
+
+def test_failsafe_on_engine_error_is_unresolved_never_opposes():
+    def boom():
+        raise RuntimeError("model unavailable")
+    embed_taxonomy._load_nli_model = boom
+    out = nli_classify.judge_direction([{"claim_prop": "a", "node_prop": "b"}])
+    assert out[0]["direction"] == "unresolved"
+    assert out[0]["method"] == "none"
+
+
+def test_empty_proposition_is_unresolved_without_calling_model():
+    def boom(*_a, **_k):
+        raise AssertionError("model must not be called for an empty proposition")
+    embed_taxonomy._load_nli_model = boom
+    out = nli_classify.judge_direction([{"claim_prop": "a", "node_prop": ""}])
+    assert out[0]["direction"] == "unresolved"
+    assert out[0]["method"] == "none"
+
+
+def test_no_framing_passes_raw_text():
+    captured = {}
+
+    def fake(model, pairs):
+        captured["pairs"] = pairs
+        return [_res("entailment", 5.0) for _ in pairs]
+    embed_taxonomy._load_nli_model = lambda: object()
+    embed_taxonomy._classify_pairs_nli = fake
+
+    out = nli_classify.judge_direction(
+        [{"claim_prop": "raw claim", "claim_pov": "accelerationist",
+          "node_prop": "raw node"}], no_framing=True)
+    assert captured["pairs"][0] == ("raw claim", "raw node")  # no prefix
+    assert out[0]["direction"] == "agrees"
+
+
+def test_ids_and_order_preserved():
+    _stub_classifier(lambda b: _res("neutral", 2.0))
+    items = [{"id": "first", "claim_prop": "a", "node_prop": "b"},
+             {"claim_prop": "c", "node_prop": "d"}]  # second: no id -> index
+    out = nli_classify.judge_direction(items)
+    assert out[0]["id"] == "first"
+    assert out[1]["id"] == 1
+
+
+def test_empty_input_returns_empty():
+    assert nli_classify.judge_direction([]) == []
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print("ok", fn.__name__)
+    print("\nAll {} tests passed.".format(len(fns)))


### PR DESCRIPTION
## Shared directional-agreement engine — `scripts/nli_classify.py` (t/2751)

The single engine that every directional gate consumes (TL ruling t/2744#3). PS (t/2745) and TS (t/2746) are thin subprocess wrappers; the summary gate (t/2739) too. **Blocks all three.**

### Design (per t/2744#3 + t/2751#3)
- **Single-sourced POV framing** — `"The <pov> position is: <prop>"` on both sides. This is the bug-determining step: raw text yields a *false entailment*; framing recovers direction. It lives here so a wrapper can never forget it.
- **Reuses `embed_taxonomy.py`'s deberta driver** (`_load_nli_model` / `_classify_pairs_nli`) — raw model + margin gate single-sourced too; the `nli-classify` subcommand is untouched.
- **Asymmetric opposition detector (CL t/2751#3):** under framing deberta reliably recovers *contradiction* but *suppresses entailment* — genuine agreements read `neutral` (a label fact, not a τ to tune). So `opposes` is the only load-bearing verdict; `agrees`/`unrelated`/`unresolved` all mean "no opposition → caller keeps its edge." The gate never confirms agreement.
- **τ FINAL:** `tau_contra=1.0` (catches the t/2742 inversion at margin 1.2746; genuine agreements are neutral so false-oppose ≈ 0), `tau_entail` reserved/unused. Provenance registered by CL.
- **Fail-safe:** any error / empty prop / below-margin → `unresolved`, **never `opposes`** — a missed inversion beats a false demotion.

### Contract
```
stdin  [{"id"?, "claim_prop", "node_prop", "claim_pov"?, "node_pov"?}]
stdout [{"id", "direction", "confidence", "method", "nli_label", "framed_a", "framed_b"}]
direction ∈ agrees | opposes | unrelated | unresolved
```

### GV — four arms
Real deberta on CL's `t/2742` fixture (`stance-polarity-repro.json`), matching CL's recorded scores exactly:

| Arm | Input | Verdict | margin |
|---|---|---|---|
| 1 inversion (POV-framed) | attribution ↔ acc-047 | **opposes** | 1.2746 |
| 2 genuine agreement (POV-framed) | case_2 ↔ acc-047 | **unrelated** (not opposes) | 0.117 |
| 3 fail-safe | empty / engine error | **unresolved** (method none) | — |
| 4 framing-regression | RAW `--no-framing` | **agrees** (the bug) vs framed **opposes** | 4.85 / 1.27 |

`scripts/test_nli_classify.py` — 8 model-free unit tests (framing, mapping, τ floor, fail-safe, no-framing, id/order) so framing can't silently regress in CI where the model may be absent.

### DRAFT — routes to Main (TL) for GV
Arm-2 was redefined (agreement → *not opposes*) after empirical evidence overturned the "agrees" assumption; CL routes that re-bless to TL. Merges first; then V-surfaces (t/2745, t/2746, t/2739) rework onto it.

Refs t/2751, t/2744, t/2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)
