### PR TITLE
feat(debate): Debate Setup drill-in dialog (t/2731)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateHeader.tsx
@@ -48,13 +48,14 @@ export function deriveHeaderTitle(topicFinal: string, sourceRef: string | null |
  *  resolved phase label are passed in to keep this component free of the toolbar/
  *  PHASE_TITLES dependency (no import cycle with DebateWorkspace.tsx). */
 export function DebateHeader({
-  activeDebate, coverageMap, strengthWeighted, phaseLabel, actions,
+  activeDebate, coverageMap, strengthWeighted, phaseLabel, actions, onShowSetup,
 }: {
   activeDebate: ActiveDebateSession;
   coverageMap: CoverageMap | null;
   strengthWeighted: StrengthWeightedCoverage | null;
   phaseLabel: string;
   actions: ReactNode;
+  onShowSetup?: () => void;
 }) {
   // POVs actually present, in canonical acc → saf → skp order; falls back to all three
   // if the session doesn't declare active_povers (spec §edge cases).
@@ -71,7 +72,22 @@ export function DebateHeader({
       <div className="debate-hdr-band debate-hdr-band1">
         <div className="debate-hdr-title-block">
           <div className="debate-hdr-title-row">
-            <h2 className="debate-hdr-title" title={activeDebate.topic.final}>{displayTitle}</h2>
+            {onShowSetup ? (
+              <h2
+                className="debate-hdr-title"
+                title={activeDebate.topic.final}
+                role="button"
+                tabIndex={0}
+                aria-label="Show full topic and setup"
+                style={{ cursor: 'pointer' }}
+                onClick={onShowSetup}
+                onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && onShowSetup()}
+              >
+                {displayTitle}
+              </h2>
+            ) : (
+              <h2 className="debate-hdr-title" title={activeDebate.topic.final}>{displayTitle}</h2>
+            )}
             <TheoryLink
               docPath="docs/debate-system-overview.md"
               label="Help: debate system overview"

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateSetupDialog.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateSetupDialog.css
@@ -1,0 +1,143 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+ * Licensed under the MIT License. See LICENSE file in the project root. */
+
+.dsd-dialog {
+  min-width: 520px;
+  max-width: 700px;
+  width: 90vw;
+  max-height: 85vh;
+  overflow-y: auto;
+}
+
+.dsd-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.dsd-section {
+  margin-bottom: 20px;
+}
+
+.dsd-section-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.dsd-topic-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.dsd-topic-text {
+  margin: 0;
+  flex: 1;
+  user-select: text;
+  line-height: 1.6;
+}
+
+.dsd-summary {
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.dsd-source-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.dsd-source-badge {
+  font-size: 0.72rem;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.dsd-source-url-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.9rem;
+  color: var(--link-color, #4a90e2);
+  cursor: pointer;
+  text-decoration: underline;
+  font-family: inherit;
+}
+
+.dsd-source-content-wrap {
+  margin-top: 8px;
+  max-height: 400px;
+  overflow: auto;
+}
+
+.dsd-scope-chips {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.dsd-scope-chip {
+  font-size: 0.78rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: var(--bg-tertiary, rgba(128, 128, 128, 0.15));
+  color: var(--text-secondary);
+}
+
+.dsd-setup-dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 5px 16px;
+  font-size: 0.9rem;
+  align-items: start;
+}
+
+.dsd-setup-dt {
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.dsd-setup-dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+.dsd-id-dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr max-content;
+  gap: 6px 12px;
+  font-size: 0.85rem;
+  align-items: center;
+}
+
+.dsd-id-dt {
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.dsd-id-code {
+  user-select: all;
+  font-size: 0.78rem;
+  word-break: break-all;
+}
+
+.dsd-live-region {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateSetupDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateSetupDialog.tsx
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useEffect, useRef, useState, Fragment } from 'react';
+import { api } from '@bridge';
+import { DEBATE_AUDIENCES } from '../../types/debate';
+import { DebateSourceViewer } from '../debate/DebateSourceViewer';
+import { useDebateStore } from '../../hooks/useDebateStore';
+import { humanizeUrl } from './DebateHeader';
+import './DebateSetupDialog.css';
+
+type DWStore = ReturnType<typeof useDebateStore.getState>;
+type ActiveDebateSession = NonNullable<DWStore['activeDebate']>;
+
+function CopyButton({ text, label }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+  return (
+    <button
+      className="btn btn-sm"
+      onClick={() => {
+        void api.clipboardWriteText(text);
+        setCopied(true);
+        if (timer.current) clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), 2000);
+      }}
+      aria-label={copied ? 'Copied' : (label ?? 'Copy')}
+    >
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+}
+
+export function DebateSetupDialog({
+  activeDebate,
+  onClose,
+}: {
+  activeDebate: ActiveDebateSession;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const [sourceEverOpened, setSourceEverOpened] = useState(false);
+
+  // Capture trigger for focus-return; move focus into dialog; trap Tab; Esc closes.
+  useEffect(() => {
+    const trigger = document.activeElement as HTMLElement | null;
+    closeRef.current?.focus();
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') { onClose(); return; }
+      if (e.key !== 'Tab' || !dialogRef.current) return;
+      const focusable = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(
+          'button:not([disabled]),a[href],[tabindex]:not([tabindex="-1"]),details > summary,input:not([disabled])'
+        )
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey ? document.activeElement === first : document.activeElement === last) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+      }
+    }
+
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      trigger?.focus();
+    };
+  }, [onClose]);
+
+  const audienceLabel = activeDebate.audience
+    ? (DEBATE_AUDIENCES.find(a => a.id === activeDebate.audience)?.label ?? activeDebate.audience)
+    : null;
+
+  const topicChanged =
+    (activeDebate.topic.original !== '' && activeDebate.topic.original !== activeDebate.topic.final) ||
+    (activeDebate.topic.refined != null && activeDebate.topic.refined !== activeDebate.topic.final);
+
+  const showSource = activeDebate.source_type !== 'topic';
+  const srcIsUrl = /^https?:\/\//i.test(activeDebate.source_ref);
+  const hasSourceContent = activeDebate.source_content !== '';
+
+  const created = new Date(activeDebate.created_at);
+  const createdStr =
+    created.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) +
+    ' · ' +
+    created.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+
+  const stageModels = activeDebate.stage_models;
+  const hasDistinctStageModels =
+    stageModels != null &&
+    Object.values(stageModels).some(v => v !== activeDebate.debate_model);
+
+  const scopeChips = activeDebate.topic.scope
+    ? [
+        activeDebate.topic.scope.domain || null,
+        activeDebate.topic.scope.risk_level ? `Risk: ${activeDebate.topic.scope.risk_level}` : null,
+        activeDebate.topic.scope.time_horizon || null,
+      ].filter((c): c is string => c != null)
+    : [];
+
+  return (
+    <div className="dialog-overlay" onClick={onClose} role="presentation">
+      <div
+        ref={dialogRef}
+        className="dialog dsd-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="dsd-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="dsd-header">
+          <h3 id="dsd-title" style={{ margin: 0 }}>Debate Setup</h3>
+          <button ref={closeRef} className="debate-inspect-close" onClick={onClose} aria-label="Close">
+            &times;
+          </button>
+        </div>
+
+        {/* TOPIC */}
+        <section className="dsd-section">
+          <div className="dsd-section-label">Topic</div>
+          <div className="dsd-topic-row">
+            <p className="dsd-topic-text">{activeDebate.topic.final}</p>
+            <CopyButton text={activeDebate.topic.final} label="Copy topic" />
+          </div>
+          {topicChanged && (
+            <details style={{ marginTop: 10 }}>
+              <summary className="dsd-summary">Topic evolution</summary>
+              <dl style={{ margin: '8px 0 0', display: 'grid', gap: 4 }}>
+                {activeDebate.topic.original !== activeDebate.topic.final && (
+                  <Fragment>
+                    <dt style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--text-secondary)' }}>Original</dt>
+                    <dd style={{ margin: 0 }}>{activeDebate.topic.original}</dd>
+                  </Fragment>
+                )}
+                {activeDebate.topic.refined != null && activeDebate.topic.refined !== activeDebate.topic.final && (
+                  <Fragment>
+                    <dt style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--text-secondary)' }}>Refined</dt>
+                    <dd style={{ margin: 0 }}>{activeDebate.topic.refined}</dd>
+                  </Fragment>
+                )}
+              </dl>
+            </details>
+          )}
+          {activeDebate.topic.clauses && activeDebate.topic.clauses.length > 0 && (
+            <details style={{ marginTop: 10 }}>
+              <summary className="dsd-summary">
+                Clauses ({activeDebate.topic.clauses.length})
+              </summary>
+              <ol style={{ margin: '8px 0 0', paddingLeft: 20 }}>
+                {activeDebate.topic.clauses.map((c, i) => (
+                  <li key={i} style={{ fontSize: '0.9rem', marginBottom: 4 }}>{c}</li>
+                ))}
+              </ol>
+            </details>
+          )}
+          {scopeChips.length > 0 && (
+            <details style={{ marginTop: 10 }}>
+              <summary className="dsd-summary">Scope</summary>
+              <div className="dsd-scope-chips">
+                {scopeChips.map((chip, i) => (
+                  <span key={i} className="dsd-scope-chip">{chip}</span>
+                ))}
+              </div>
+            </details>
+          )}
+        </section>
+
+        {/* SOURCE */}
+        {showSource && (
+          <section className="dsd-section">
+            <div className="dsd-section-label">Source</div>
+            <div className="dsd-source-row">
+              <span className="dsd-source-badge">{activeDebate.source_type}</span>
+              {activeDebate.source_ref !== '' && (
+                srcIsUrl ? (
+                  <button
+                    className="dsd-source-url-btn"
+                    onClick={() => void api.openExternal(activeDebate.source_ref)}
+                    aria-label={`Open source URL in browser: ${activeDebate.source_ref}`}
+                  >
+                    {humanizeUrl(activeDebate.source_ref)}
+                  </button>
+                ) : (
+                  <code style={{ fontSize: '0.85rem', wordBreak: 'break-all' }}>{activeDebate.source_ref}</code>
+                )
+              )}
+              {activeDebate.source_ref !== '' && (
+                <>
+                  {srcIsUrl && (
+                    <button
+                      className="btn btn-sm"
+                      onClick={() => void api.openExternal(activeDebate.source_ref)}
+                      aria-label="Open source URL in browser"
+                    >
+                      Open
+                    </button>
+                  )}
+                  <CopyButton text={activeDebate.source_ref} label="Copy source reference" />
+                </>
+              )}
+            </div>
+            {hasSourceContent && (
+              <details
+                style={{ marginTop: 10 }}
+                onToggle={(e) => {
+                  if ((e.target as HTMLDetailsElement).open) setSourceEverOpened(true);
+                }}
+              >
+                <summary className="dsd-summary">View source content</summary>
+                {sourceEverOpened && (
+                  <div className="dsd-source-content-wrap">
+                    <DebateSourceViewer
+                      content={activeDebate.source_content}
+                      sourceType={srcIsUrl ? 'url' : 'document'}
+                      sourceRef={activeDebate.source_ref}
+                    />
+                  </div>
+                )}
+              </details>
+            )}
+          </section>
+        )}
+
+        {/* BACKGROUND */}
+        {activeDebate.topic.background && (
+          <section className="dsd-section">
+            <div className="dsd-section-label">Background</div>
+            <p style={{ margin: 0, lineHeight: 1.6, fontSize: '0.9rem' }}>{activeDebate.topic.background}</p>
+          </section>
+        )}
+
+        {/* SETUP */}
+        <section className="dsd-section">
+          <div className="dsd-section-label">Setup</div>
+          <dl className="dsd-setup-dl">
+            {audienceLabel && (
+              <Fragment>
+                <dt className="dsd-setup-dt">Audience</dt>
+                <dd className="dsd-setup-dd">{audienceLabel}</dd>
+              </Fragment>
+            )}
+            {activeDebate.debate_model && (
+              <Fragment>
+                <dt className="dsd-setup-dt">Model</dt>
+                <dd className="dsd-setup-dd">{activeDebate.debate_model}</dd>
+              </Fragment>
+            )}
+            {activeDebate.evaluator_model && (
+              <Fragment>
+                <dt className="dsd-setup-dt">Evaluator</dt>
+                <dd className="dsd-setup-dd">{activeDebate.evaluator_model}</dd>
+              </Fragment>
+            )}
+            {activeDebate.protocol_id && (
+              <Fragment>
+                <dt className="dsd-setup-dt">Protocol</dt>
+                <dd className="dsd-setup-dd">
+                  {activeDebate.protocol_id}
+                  {activeDebate.moderator_mode ? ` · moderator: ${activeDebate.moderator_mode}` : ''}
+                </dd>
+              </Fragment>
+            )}
+            {activeDebate.debate_temperature !== undefined && (
+              <Fragment>
+                <dt className="dsd-setup-dt">Temp</dt>
+                <dd className="dsd-setup-dd">
+                  {activeDebate.debate_temperature}
+                  {activeDebate.model_tier ? ` · Tier ${activeDebate.model_tier}` : ''}
+                </dd>
+              </Fragment>
+            )}
+            <Fragment>
+              <dt className="dsd-setup-dt">Created</dt>
+              <dd className="dsd-setup-dd">{createdStr}</dd>
+            </Fragment>
+            {activeDebate.origin && (
+              <Fragment>
+                <dt className="dsd-setup-dt">Origin</dt>
+                <dd className="dsd-setup-dd">
+                  {activeDebate.origin.mode}
+                  {activeDebate.origin.command && (
+                    <code style={{ marginLeft: 6, fontSize: '0.8rem', wordBreak: 'break-all' }}>
+                      {activeDebate.origin.command}
+                    </code>
+                  )}
+                </dd>
+              </Fragment>
+            )}
+          </dl>
+          {hasDistinctStageModels && (
+            <details style={{ marginTop: 10 }}>
+              <summary className="dsd-summary">Per-stage models</summary>
+              <dl style={{ margin: '8px 0 0', display: 'grid', gridTemplateColumns: 'max-content 1fr', gap: '4px 12px', fontSize: '0.85rem' }}>
+                {Object.entries(stageModels!).map(([k, v]) => (
+                  <Fragment key={k}>
+                    <dt style={{ color: 'var(--text-secondary)' }}>{k}</dt>
+                    <dd style={{ margin: 0 }}>{v}</dd>
+                  </Fragment>
+                ))}
+              </dl>
+            </details>
+          )}
+        </section>
+
+        {/* IDENTIFIERS */}
+        <section>
+          <div className="dsd-section-label">Identifiers</div>
+          <dl className="dsd-id-dl">
+            <dt className="dsd-id-dt">id</dt>
+            <dd style={{ margin: 0 }}><code className="dsd-id-code">{activeDebate.id}</code></dd>
+            <dd style={{ margin: 0 }}><CopyButton text={activeDebate.id} label="Copy debate ID" /></dd>
+            {activeDebate.run_id && (
+              <Fragment>
+                <dt className="dsd-id-dt">run_id</dt>
+                <dd style={{ margin: 0 }}><code className="dsd-id-code">{activeDebate.run_id}</code></dd>
+                <dd style={{ margin: 0 }}><CopyButton text={activeDebate.run_id} label="Copy run ID" /></dd>
+              </Fragment>
+            )}
+          </dl>
+        </section>
+
+        <div className="dsd-live-region" aria-live="polite" aria-atomic="true" />
+      </div>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -7,7 +7,6 @@ import { useDebateStore } from '../../hooks/useDebateStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import type { SpeakerId } from '../../types/debate';
-import { DebateSourceViewer } from '../debate/DebateSourceViewer';
 import { NeutralEvaluationPanel } from '../analysis/NeutralEvaluationPanel';
 import { ParameterHistoryPanel } from '../analysis/ParameterHistoryPanel';
 import { computeCoverageMap, computeStrengthWeightedCoverage } from '@lib/debate/coverageTracker';
@@ -32,6 +31,7 @@ import { useCommunityStore } from '../../hooks/useCommunityStore';
 import { useUserProfile } from '../../hooks/useAuthStatus';
 import { CommunityShareBanner } from '../shared/CommunityShareBanner';
 import { DebateHeader } from './DebateHeader';
+import { DebateSetupDialog } from './DebateSetupDialog';
 import { StatementCard, ProbingCard, FactCheckCard, EntryDeleteControls, HighlightedText, PhaseHairline } from './StatementCard';
 import { DebaterToggles, DebateActions } from './DebateActionBar';
 import { DebatePhaseIndicators } from './DebatePhaseIndicators';
@@ -470,15 +470,14 @@ function GlobalModeControl({ defaultTier, setDefaultTier }: {
 }
 
 function DebateToolbar({
-  activeDebate, isExploration, isCrossCutting, onShowCCDetails,
+  activeDebate, isExploration, onShowSetup,
   commentSidebarOpen, toggleCommentSidebar, commentsFile,
   exportStatus, onExport, diagnosticsEnabled, toggleDiagnostics,
   defaultTier, setDefaultTier, headerVariant = false,
 }: {
   activeDebate: ActiveDebateSession;
   isExploration: boolean;
-  isCrossCutting: boolean;
-  onShowCCDetails: () => void;
+  onShowSetup: () => void;
   commentSidebarOpen: boolean;
   toggleCommentSidebar: () => void;
   commentsFile: CommentStoreState['commentsFile'];
@@ -505,15 +504,13 @@ function DebateToolbar({
           Exploration
         </span>
       )}
-      {isCrossCutting && (
-        <button
-          className="btn btn-sm debate-cc-details-btn"
-          onClick={onShowCCDetails}
-          title="View situation context used for this debate"
-        >
-          Details
-        </button>
-      )}
+      <button
+        className="btn btn-sm"
+        onClick={onShowSetup}
+        title="View full topic, source, and debate configuration"
+      >
+        Setup
+      </button>
       <button
         className={`btn btn-sm${commentSidebarOpen ? ' active' : ''}`}
         onClick={toggleCommentSidebar}
@@ -536,34 +533,6 @@ function DebateToolbar({
         {diagnosticsEnabled ? 'Diagnostics ON' : 'Diagnostics'}
       </button>
       <GlobalModeControl defaultTier={defaultTier} setDefaultTier={setDefaultTier} />
-    </div>
-  );
-}
-
-function CrossCuttingDialog({ activeDebate, show, onClose }: {
-  activeDebate: ActiveDebateSession;
-  show: boolean;
-  onClose: () => void;
-}) {
-  if (!show || !activeDebate.source_content) return null;
-  return (
-    <div className="dialog-overlay" onClick={onClose}>
-      <div className="dialog debate-cc-details-dialog" onClick={(e) => e.stopPropagation()}>
-        <div className="debate-cc-details-header">
-          <h3>Cross-Cutting Context</h3>
-          {activeDebate.source_ref && (
-            <span className="debate-source-ref">{activeDebate.source_ref}</span>
-          )}
-          <button className="debate-inspect-close" onClick={onClose} title="Close" aria-label="Close">&times;</button>
-        </div>
-        <div className="debate-cc-details-body">
-          <DebateSourceViewer
-            content={activeDebate.source_content}
-            sourceType="document"
-            sourceRef={activeDebate.source_ref}
-          />
-        </div>
-      </div>
     </div>
   );
 }
@@ -1244,7 +1213,7 @@ export function DebateWorkspace({ onExport, exportStatus }: {
   );
   const { runSemanticSearch, setFindQuery: setStoreFindQuery, setFindMode: setStoreFindMode, setToolbarPanel } = useTaxonomyStore();
   const transcriptEndRef = useRef<HTMLDivElement>(null);
-  const [showCCDetails, setShowCCDetails] = useState(false);
+  const [showSetup, setShowSetup] = useState(false);
   const [showParamHistory, setShowParamHistory] = useState(false);
   const [showEvaluation, setShowEvaluation] = useState(false);
   const [debateChatOpen, setDebateChatOpen] = useState(false);
@@ -1291,7 +1260,6 @@ export function DebateWorkspace({ onExport, exportStatus }: {
   const isDebatePhase = activeDebate.phase === 'debate'
     || activeDebate.phase === 'closed'
     || activeDebate.adaptive_staging?.phase_state?.current_phase != null;
-  const isCrossCutting = activeDebate.source_type === 'situations';
   const isExploration = activeDebate.protocol_id === 'exploration';
   const isExplorationClosed = isExploration && activeDebate.phase === 'closed';
   const showRemoteOverlay = driverIsRemote && !!activeDebate;
@@ -1300,8 +1268,7 @@ export function DebateWorkspace({ onExport, exportStatus }: {
     <div className="debate-workspace-row" data-phase={isClarificationPhase ? 'setup' : undefined}>
     {chatRedesign && <TranscriptOutline transcript={activeDebate.transcript} />}
     <div className="debate-workspace">
-      {/* Cross-cutting context dialog */}
-      <CrossCuttingDialog activeDebate={activeDebate} show={showCCDetails} onClose={() => setShowCCDetails(false)} />
+      {showSetup && <DebateSetupDialog activeDebate={activeDebate} onClose={() => setShowSetup(false)} />}
 
       {/* Find bar */}
       {findVisible && (
@@ -1328,13 +1295,13 @@ export function DebateWorkspace({ onExport, exportStatus }: {
           coverageMap={coverageMap}
           strengthWeighted={strengthWeighted}
           phaseLabel={PHASE_TITLES[activeDebate.phase] || activeDebate.phase}
+          onShowSetup={() => setShowSetup(true)}
           actions={
             <DebateToolbar
               activeDebate={activeDebate}
               headerVariant
               isExploration={isExploration}
-              isCrossCutting={isCrossCutting}
-              onShowCCDetails={() => setShowCCDetails(true)}
+              onShowSetup={() => setShowSetup(true)}
               commentSidebarOpen={commentSidebarOpen}
               toggleCommentSidebar={toggleCommentSidebar}
               commentsFile={commentsFile}


### PR DESCRIPTION
## Summary

- Adds `DebateSetupDialog` modal replacing the old `CrossCuttingDialog` + Details button
- New toolbar **Setup** button (always visible) and clickable header title both open the dialog
- Sections: Topic (with evolution/clauses/scope expand), Source (lazy `DebateSourceViewer`), Background, Setup (models/protocol/temp/origin), Identifiers with copy
- Full a11y: `role=dialog`, `aria-modal`, focus trap, Esc close, focus-return, native `<details>`, `aria-live` region
- Presentation-only — no backend/schema changes, no new bridge calls
- `CopyButton` timer cleaned up on unmount (review-ts finding)

## Test plan

- [ ] Open a debate, click **Setup** in toolbar → dialog opens
- [ ] Click the header title → dialog opens
- [ ] Esc key closes dialog and returns focus to trigger
- [ ] Tab cycles within dialog without escaping
- [ ] Source section lazy-loads `DebateSourceViewer` only on first expand
- [ ] URL source ref renders as clickable link (opens external browser)
- [ ] Debate with `source_type === 'topic'` shows no Source section
- [ ] Copy buttons copy text and reset label after 2 s
- [ ] Verify in Electron build and web build

🤖 Generated with [Claude Code](https://claude.com/claude-code)