### PR TITLE
docs(taxonomy): richness correction — engine test-arm swap + docstring + recall boundary (t/2751)

### DIFF
--- a/scripts/AITriad/Private/Test-DirectionalAgreement.ps1
+++ b/scripts/AITriad/Private/Test-DirectionalAgreement.ps1
@@ -15,11 +15,13 @@ function Test-DirectionalAgreement {
         of that is single-sourced in the engine so the two runtimes can never
         drift. It only marshals pairs to the engine and returns its verdicts.
 
-        ASYMMETRIC OPPOSITION DETECTOR (CL ruling t/2751#3): under POV framing the
-        NLI model reliably recovers *contradiction* but suppresses *entailment*, so
-        `opposes` is the only actionable verdict. Callers demote/flip ONLY on
-        `opposes`; `agrees` / `unrelated` / `unresolved` all mean "no opposition
-        detected → keep your edge." The gate never confirms agreement.
+        ASYMMETRIC OPPOSITION DETECTOR (CL ruling t/2751#3): the NLI model reliably
+        recovers *contradiction* but rates a genuine agreement `neutral`, not
+        `entailment`, so `opposes` is the only actionable verdict. Callers
+        demote/flip ONLY on `opposes`; `agrees` / `unrelated` / `unresolved` all
+        mean "no opposition detected → keep your edge." The gate never confirms
+        agreement. Recall depends on rich node text — pass the fullest label+Core
+        (t/2744#7); a bare label can miss an inversion (engine RECALL BOUNDARY).
 
         FAIL-SAFE: any subprocess failure resolves every pair to `unresolved`
         (method `none`) — NEVER `opposes`. A missed inversion beats a false demote.

--- a/scripts/AITriad/Public/Invoke-OrgClaimMatching.ps1
+++ b/scripts/AITriad/Public/Invoke-OrgClaimMatching.ps1
@@ -371,8 +371,8 @@ function Invoke-OrgClaimMatching {
     # ¬(node), so the provisional edge type (derived from the org's OWN polarity)
     # is FLIPPED (ADVOCATES_FOR<->OPPOSES). 'agrees'/'unrelated'/'unresolved' all
     # mean "no opposition detected" → the provisional edge stands (no drop —
-    # framing suppresses entailment so genuine agreement reads 'unrelated', and
-    # dropping it would nuke recall). Off only under -SkipDirectionalGate.
+    # the gate rates a genuine agreement 'unrelated', not 'agrees', so dropping on
+    # anything but 'opposes' would nuke recall). Off only under -SkipDirectionalGate.
     $directionalFlipped = 0
     if (-not $SkipDirectionalGate -and $proposals.Count -gt 0) {
         $povByPrefix = @{ acc = 'accelerationist'; saf = 'safetyist'; skp = 'skeptic' }

--- a/scripts/AITriad/Public/Invoke-QbafConflictAnalysis.ps1
+++ b/scripts/AITriad/Public/Invoke-QbafConflictAnalysis.ps1
@@ -278,8 +278,8 @@ function Invoke-QbafConflictAnalysis {
     # engine. Only 'opposes' is actionable — the two claims genuinely contradict,
     # so emit an ATTACK instead of the (bogus) support. Everything else
     # ('agrees'/'unrelated'/'unresolved') keeps the provisional supports edge:
-    # framing suppresses entailment so a true agreement reads 'unrelated', and the
-    # gate's job is to catch the inversion, not to confirm support.
+    # the gate rates a true agreement 'unrelated', not 'agrees', and its job is to
+    # catch the inversion, not to confirm support.
     $StageADirCounts = [ordered]@{ opposes = 0; agrees = 0; unrelated = 0; unresolved = 0 }
     if (-not $SkipDirectionalGate -and $SupportCandidates.Count -gt 0) {
         $dirPairs = [System.Collections.Generic.List[PSObject]]::new()

--- a/scripts/nli_classify.py
+++ b/scripts/nli_classify.py
@@ -9,14 +9,18 @@ per-runtime NLI, framing, or thresholds. It exists to keep every runtime's
 directional verdict *identical*, which is the whole point of a gate that fights
 a cross-cutting inversion class.
 
-WHY AN ENGINE, NOT WRAPPER LOGIC (t/2744#2, empirically reproduced):
-The deberta NLI model reproduces the polarity-blindness bug on RAW propositions
-(false `entailment` +4.09 on the t/2737 origin case) and only recovers the true
-direction when each side is framed as a *stated position*
-(`"The <pov> position is: <prop>"` -> `contradiction`, entail -1.23 / contra
-+1.44). Framing is the fragile, bug-determining step, so it MUST live here and
-nowhere else — a wrapper that frames (or forgets to) is exactly how one runtime
-regresses unnoticed.
+WHY AN ENGINE, NOT WRAPPER LOGIC (t/2744#7, controlled 2x2):
+The load-bearing lever is node-proposition RICHNESS, not framing. Feeding the
+matched node's bare label recovers a false `entailment` on an inversion (the model
+latches onto the shared topic); feeding the full `label + Core description` — whose
+explicit contrast ("Not Adapted Old Ones … rather than adapted existing laws") the
+bare label drops — recovers `contradiction` and catches the inversion. (An earlier
+"framing-sensitivity" claim, t/2744#2, was confounded: those two probes differed in
+BOTH framing and node richness. A clean 2x2 shows framing is INERT.) The mapping,
+thresholds, and node-text expectation therefore live here and nowhere else — a
+wrapper that passes a terser node_prop is exactly how one runtime regresses
+unnoticed, so all wrappers MUST pass the fullest `label + Core` (see RECALL BOUNDARY).
+POV framing is retained (harmless, and it normalizes both sides) but is not the lever.
 
 Reuses embed_taxonomy.py's deberta driver (`_load_nli_model`,
 `_classify_pairs_nli`) so the raw model + margin gate are single-sourced too;
@@ -29,12 +33,23 @@ SUBPROCESS CONTRACT
   direction in {agrees, opposes, unrelated, unresolved}
   confidence = NLI top-1 vs top-2 logit margin (best - second).
 
-ASYMMETRIC OPPOSITION DETECTOR (CL ruling t/2751#3): under POV framing the deberta
-model reliably recovers *contradiction* but SUPPRESSES *entailment* — a genuine
-agreement reads `neutral`, not `entailment` (a label fact, not a threshold to
-tune). So this gate's load-bearing signal is `opposes`; callers demote/flip ONLY
-on `opposes`. `agrees` / `unrelated` / `unresolved` all mean "no opposition
-detected" and the caller KEEPS its edge. The gate never confirms agreement.
+ASYMMETRIC OPPOSITION DETECTOR (CL ruling t/2751#3): on this two-position task the
+deberta model reliably recovers *contradiction* but rates a genuine agreement
+`neutral`, not `entailment` (a label fact, not a threshold to tune). So this gate's
+load-bearing signal is `opposes`; callers demote/flip ONLY on `opposes`. `agrees` /
+`unrelated` / `unresolved` all mean "no opposition detected" and the caller KEEPS
+its edge. The gate never confirms agreement.
+
+RECALL BOUNDARY (t/2744#7): the gate UNDER-catches — it can only return `opposes`
+when the node_prop is rich enough to carry the asserted proposition's contrast.
+Concrete floor: a node with an empty Core description falls back to label-only,
+which is the guaranteed-MISS case (an inversion reads `agrees`/`entailment`, e.g.
++4.76 on the origin claim, so the wrong edge is KEPT). Claim-proposition specificity
+matters too (a terse canonical proposition can read `neutral` where a fuller
+attribution phrasing reads `opposes`). This is acceptable under the opposes-only
+fail-safe (a miss never fabricates opposition), and it is OBSERVABLE: an all-`agrees`
+/ all-`unresolved` run over rich inputs signals a degraded feed. Mitigation is on
+the caller: pass the fullest `label + Core` node text (Encompasses/Excludes stripped).
 
 FAIL-SAFE (load-bearing, t/2751#3 arm 3): any error, an empty proposition, or a
 below-threshold margin resolves to `unresolved` — NEVER `opposes`. Because callers
@@ -51,9 +66,9 @@ Flags:
   --tau-entail FLOAT   Margin floor to emit `agrees`. Default 0.0 = RESERVED/unused
                        (CL t/2751#3): `agrees` is informational only — no caller
                        acts on it — so it carries no floor.
-  --no-framing         Bypass POV framing (feed raw props). Exists ONLY so the
-                       framing-regression guard fixture can show raw->entailment
-                       (wrong) vs framed->contradiction (right) through THIS engine.
+  --no-framing         Bypass POV framing (feed raw props). Diagnostic only —
+                       framing is inert on the verdict (t/2744#7), so this lets the
+                       2x2 confirm framed vs unframed give identical results.
 """
 
 import argparse

--- a/scripts/test_nli_classify.py
+++ b/scripts/test_nli_classify.py
@@ -5,11 +5,12 @@
 
 """Unit tests for nli_classify.py — the shared directional-agreement engine (t/2751).
 
-Exercises the engine's OWN logic (POV framing, label->direction mapping, the
+Exercises the engine's OWN logic (framing plumbing, label->direction mapping, the
 tau_contra floor, and the fail-safe) WITHOUT the deberta model by monkeypatching
-the classifier embed_taxonomy exposes. The real-model arms (exact scores on the
-t/2742 fixture) are proven separately and recorded on t/2751; this suite is the
-CI-runnable guard so framing/mapping/fail-safe can never regress unnoticed.
+the classifier embed_taxonomy exposes. `test_richness_guard_real_model` adds the
+GV richness arm on the actual model (skips offline): node-proposition richness —
+NOT framing — is what catches an inversion (CL 2x2, t/2744#7). Together they guard
+mapping/fail-safe/richness so the gate can never regress unnoticed.
 
 Runnable under pytest or standalone: `python test_nli_classify.py`.
 """
@@ -34,6 +35,11 @@ def _load(name):
 embed_taxonomy = _load("embed_taxonomy")
 sys.modules["embed_taxonomy"] = embed_taxonomy
 nli_classify = _load("nli_classify")
+
+# Real deberta driver, saved before any monkeypatch — the richness guard restores
+# these to run against the actual model (it skips if the model can't load).
+_REAL_LOAD = embed_taxonomy._load_nli_model
+_REAL_CLASSIFY = embed_taxonomy._classify_pairs_nli
 
 
 def _stub_classifier(result_for):
@@ -103,6 +109,10 @@ def test_empty_proposition_is_unresolved_without_calling_model():
 
 
 def test_no_framing_passes_raw_text():
+    # Plumbing only: --no-framing must feed the raw prop (no "The <pov> position
+    # is:" prefix) to the classifier. NOTE: framing is INERT on the verdict
+    # (CL t/2744#7 2x2) — the semantic lever is node richness, guarded by
+    # test_richness_guard_real_model below. This test just pins the flag's wiring.
     captured = {}
 
     def fake(model, pairs):
@@ -116,6 +126,43 @@ def test_no_framing_passes_raw_text():
           "node_prop": "raw node"}], no_framing=True)
     assert captured["pairs"][0] == ("raw claim", "raw node")  # no prefix
     assert out[0]["direction"] == "agrees"
+
+
+def test_richness_guard_real_model():
+    """The GV richness arm (TL bless t/2744#8, replaces the moot framing arm).
+
+    node-proposition RICHNESS — not framing — is what catches an inversion
+    (CL 2x2, t/2744#7). Same origin claim, vary the node_prop:
+      bare  (label only)     -> agrees   (MISSES the inversion)
+      rich  (label + Core)   -> opposes  (CATCHES it)
+    Real deberta; skips when the model can't load (offline CI). The margins are
+    the tau_contra calibration anchor (rich ~1.3, matching CL's ~1.42).
+    """
+    # Restore the real driver (earlier tests monkeypatched it).
+    embed_taxonomy._load_nli_model = _REAL_LOAD
+    embed_taxonomy._classify_pairs_nli = _REAL_CLASSIFY
+    try:
+        _REAL_LOAD()
+    except Exception as exc:  # noqa: BLE001 — model unavailable => skip, not fail
+        print("SKIP test_richness_guard_real_model — model unavailable:", exc)
+        return
+
+    claim = ("rejecting AI exceptionalism ensures existing privacy principles "
+             "remain the baseline for technological deployment without requiring "
+             "novel regulatory regimes.")
+    label = "Argue That AI Requires Entirely New Laws, Not Adapted Old Ones"
+    core = ("asserts emerging technologies are so transformative they require "
+            "entirely new legal frameworks rather than adapted existing laws.")
+    out = nli_classify.judge_direction([
+        {"id": "bare", "claim_prop": claim, "claim_pov": "accelerationist",
+         "node_prop": label, "node_pov": "accelerationist"},
+        {"id": "rich", "claim_prop": claim, "claim_pov": "accelerationist",
+         "node_prop": "{} — {}".format(label, core), "node_pov": "accelerationist"},
+    ])
+    by = {r["id"]: r for r in out}
+    assert by["bare"]["direction"] == "agrees", by["bare"]     # bare node MISSES
+    assert by["rich"]["direction"] == "opposes", by["rich"]    # rich node CATCHES
+    assert by["rich"]["confidence"] >= 1.0                     # >= tau_contra
 
 
 def test_ids_and_order_preserved():


### PR DESCRIPTION
## Richness correction to the shared NLI engine (t/2751 follow-up)

Per CL's controlled 2×2 (t/2744#7): the directional gate's real lever is **node-proposition richness**, not POV framing (framing is inert). No production bug — the engine + V1/V2 already pass rich `label + Core` node text — this is the test-arm swap + doc corrections TL blessed (t/2744#8).

### Changes
- **`scripts/test_nli_classify.py`** — replace the moot framing-regression proxy with **`test_richness_guard_real_model`** (TL's spec): same origin claim, **label-only node → `agrees` (MISS)** vs **label+Core → `opposes`@≥1.0 (CATCH)**. Real deberta; skips offline. (8→9 tests; all pass, guard ran green against the real model here.)
- **`scripts/nli_classify.py`** docstring — correct the causal story (framing→richness; framing retained but inert) and add a **RECALL BOUNDARY** section: empty Core → label-only fallback → guaranteed miss (`agrees`, +4.76 on the origin claim); acceptable under opposes-only (a miss never fabricates opposition); observable in the counts; mitigation = callers pass fullest `label + Core`.
- **V1/V2 + `Test-DirectionalAgreement`** — correct the "framing suppresses entailment" comments to "the gate rates a genuine agreement `unrelated`" and note the rich-node recall dependency. Comment-only; 22 PS tests unchanged & green.

### Recall observation flagged to CL (not fixed here)
With the **canonical** proposition (what V1 feeds), the origin inversion reads `unrelated` (neutral@3.43) — only the **attribution** phrasing reads `opposes` (@1.27). Documented in the recall-boundary as claim-proposition specificity; raised with CL (t/2744) as a possible contract question (which claim text to feed). Under opposes-only this is a recall miss, never a false demote.

### Review
TL to **eyeball the reworked arm** (not a full re-GV, per t/2744#8). CL owns the t/2742 fixture nli_probe causal note.

Refs t/2751, t/2744, t/2745

🤖 Generated with [Claude Code](https://claude.com/claude-code)
