### PR TITLE
feat(taxonomy): V1 feeds verbatim as directional-gate claimProp (t/2752)

### DIFF
--- a/scripts/AITriad/Public/Invoke-OrgClaimMatching.ps1
+++ b/scripts/AITriad/Public/Invoke-OrgClaimMatching.ps1
@@ -249,12 +249,20 @@ function Invoke-OrgClaimMatching {
 
         $sourceId = [string]$claim.source_id
         $family = $sourceId -replace $familyKeyPattern, ''
+        # Verbatim = the raw org sentence. The directional gate feeds this (not the
+        # canonical_proposition) as claimProp per CL's contract amendment t/2744#9:
+        # canonical over-abstracts and neutralizes the polarity signal the gate
+        # exists to detect (origin inversion reads unrelated on canonical vs opposes
+        # on the verbatim phrasing). Org claims carry no attribution_text, so `text`
+        # is the verbatim fallback. Embedding/node-selection still use canonical.
+        $verbatim = if ($claim.PSObject.Properties['text']) { [string]$claim.text } else { '' }
         $matchPerClaim.Add([PSCustomObject]@{
             OrgId       = [string]$claim.org_id
             SourceId    = $sourceId
             Family      = $family
             Polarity    = [string]$claim.polarity
             Proposition = [string]$claim.canonical_proposition
+            Verbatim    = $verbatim
             Top         = @($top)
             Best        = $top[0]
         })
@@ -333,8 +341,11 @@ function Invoke-OrgClaimMatching {
         #  because a flip changes the (org, node, type) tuple it keys on.)
 
         # Representative claim proposition = the highest-cosine item in the
-        # bucket (the pair the directional gate judges for this proposal).
-        $repProp = (@($items | Sort-Object -Property { $_.Best.Score } -Descending)[0]).Proposition
+        # bucket (the pair the directional gate judges for this proposal). Use its
+        # VERBATIM text (t/2744#9), falling back to the canonical proposition only
+        # when verbatim is empty.
+        $repItem = @($items | Sort-Object -Property { $_.Best.Score } -Descending)[0]
+        $repProp = if ([string]::IsNullOrWhiteSpace($repItem.Verbatim)) { $repItem.Proposition } else { $repItem.Verbatim }
 
         # Rationale + source_refs bundle
         $reason = if ($meetsA -and $meetsB) { 'multi-claim-agreement+high-cosine' }

--- a/tests/Invoke-OrgClaimMatching.Tests.ps1
+++ b/tests/Invoke-OrgClaimMatching.Tests.ps1
@@ -520,5 +520,57 @@ Describe 'Invoke-OrgClaimMatching (t/1553 Stages 2+3)' -Tag 'taxonomy' {
                 $script:TaxonomyData.Remove('invtest-pov')
             }
         }
+
+        It 'CLAIM TEXT: the gate is fed the VERBATIM text (claim.text), not the canonical proposition (t/2744#9)' {
+            InModuleScope AITriad -Parameters @{
+                ClaimsPath = $script:claimsPath
+                EmbPath    = $script:invEmbPath
+                VecA       = [double[]]$script:vecA
+            } {
+                param($ClaimsPath, $EmbPath, $VecA)
+
+                # Distinct text vs canonical, so we can tell which one reached the gate.
+                @{ claims = @(
+                    [PSCustomObject]@{ org_id='org-014'; source_id='src-vb'; polarity='asserts'
+                        text='VERBATIM org sentence with the full polarity-bearing phrasing'
+                        canonical_proposition='over-abstracted canonical'
+                        extraction_confidence=0.9 }
+                ) } | ConvertTo-Json -Depth 5 | Set-Content -Path $ClaimsPath -Encoding utf8NoBOM
+
+                $script:TaxonomyData['invtest-pov'] = [PSCustomObject]@{ nodes = @(
+                    [PSCustomObject]@{ id='acc-intentions-999'; label='N'; description='node text' }
+                )}
+
+                $script:capturedClaimProp = $null
+                $vecAref = $VecA
+                function python {
+                    process {
+                        $payload = @($input | Out-String | ConvertFrom-Json)
+                        if ($payload.Count -gt 0 -and $payload[0].PSObject.Properties['claim_prop']) {
+                            $script:capturedClaimProp = [string]$payload[0].claim_prop
+                            # Genuine-agreement-style control fed via verbatim → not opposes.
+                            $out = foreach ($it in $payload) {
+                                [pscustomobject]@{ id=$it.id; direction='unrelated'; confidence=0.1; method='nli' }
+                            }
+                            ConvertTo-Json -InputObject @($out) -Depth 5
+                        } else {
+                            $o = [ordered]@{}
+                            foreach ($it in $payload) { $o[$it.id] = $vecAref }
+                            $o | ConvertTo-Json -Depth 5 -Compress
+                        }
+                    }
+                }
+                Mock Get-OrganizationEdgesStore { [PSCustomObject]@{ edges = @() } }
+
+                $r = Invoke-OrgClaimMatching -ClaimsPath $ClaimsPath -EmbeddingsPath $EmbPath `
+                    -MatchThreshold 0.60 -Verbose:$false 6>$null
+
+                $script:capturedClaimProp | Should -Be 'VERBATIM org sentence with the full polarity-bearing phrasing' -Because 'the gate feeds claim.text (verbatim), not canonical_proposition (t/2744#9)'
+                $r.Proposals[0].Direction | Should -Be 'unrelated'
+                $r.DirectionalCounts.opposes | Should -Be 0 -Because 'no false-opposes on the verbatim-fed control'
+
+                $script:TaxonomyData.Remove('invtest-pov')
+            }
+        }
     }
 }


### PR DESCRIPTION
Per CL contract amendment t/2744#9: V1's directional gate feeds the verbatim org sentence (claim.text), not the over-abstracted canonical_proposition, which neutralizes the polarity signal (origin inversion reads unrelated@3.43 on canonical vs opposes@1.27 on verbatim; convergent with t/2357, SAF-167). Org claims carry no attribution_text, so text is the verbatim fallback; embedding/node-selection/reporting keep canonical.

Pure recall improvement — opposes-only + fail-safe means a wrong claim-text choice is a recall miss, never a false demote. CL-sanctioned without TL re-bless (t/2744#9). Self-cert: single-file behavior change + test, no new API/interface.

Test asserts the gate receives the verbatim text (not canonical) and the verbatim-fed control yields zero false-opposes. 10 OrgClaimMatching tests green.

Refs t/2752, t/2744, t/2745

🤖 Generated with [Claude Code](https://claude.com/claude-code)