### PR TITLE
fix(debate): opus 300s timeout floor + t/1075 experiment ceiling fix

### DIFF
--- a/lib/debate/aiAdapter.ts
+++ b/lib/debate/aiAdapter.ts
@@ -294,7 +294,10 @@ export function createCLIAdapter(repoRoot: string, explicitApiKey?: string): Ext
   async function doGenerateText(prompt: string, model: string, options?: GenerateOptions): Promise<string> {
     const { apiModelId, backend, fixedTemperature } = resolveModel(registry, model);
     const apiKey = resolveApiKey(backend, explicitApiKey);
-    const timeoutMs = options?.timeoutMs ?? getDefaultTimeout(model, registry);
+    // Opus models require extended per-call time on complex structured topics (t/1075, t/1069#6).
+    // Apply a 300s floor for any model whose ID contains 'opus'; other models use the registry default.
+    const baseTimeoutMs = options?.timeoutMs ?? getDefaultTimeout(model, registry);
+    const timeoutMs = model.includes('opus') ? Math.max(baseTimeoutMs, 300_000) : baseTimeoutMs;
     const opts = { ...options, timeoutMs, fixedTemperature };
 
     const t0 = performance.now();

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-liability-regime.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-liability-regime.json
@@ -9,5 +9,6 @@
   "pacing": "moderate",
   "outputFormat": "all",
   "throttleMs": 2000,
+  "maxTotalRounds": 20,
   "outputDir": "C:/tmp/exp1075-out"
 }

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-safety-sharing.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-safety-sharing.json
@@ -9,5 +9,6 @@
   "pacing": "moderate",
   "outputFormat": "all",
   "throttleMs": 2000,
+  "maxTotalRounds": 20,
   "outputDir": "C:/tmp/exp1075-out"
 }

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-siloed-datasets.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-ctrl-siloed-datasets.json
@@ -9,5 +9,6 @@
   "pacing": "moderate",
   "outputFormat": "all",
   "throttleMs": 2000,
+  "maxTotalRounds": 20,
   "outputDir": "C:/tmp/exp1075-out"
 }

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-liability-regime.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-liability-regime.json
@@ -9,5 +9,6 @@
   "pacing": "moderate",
   "outputFormat": "all",
   "throttleMs": 2000,
+  "maxTotalRounds": 20,
   "outputDir": "C:/tmp/exp1075-out"
 }

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-safety-sharing.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-safety-sharing.json
@@ -9,5 +9,6 @@
   "pacing": "moderate",
   "outputFormat": "all",
   "throttleMs": 2000,
+  "maxTotalRounds": 20,
   "outputDir": "C:/tmp/exp1075-out"
 }

--- a/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-siloed-datasets.json
+++ b/research/comp-linguist/analyses/t1069-phaseA/exp1075-treat-siloed-datasets.json
@@ -9,5 +9,6 @@
   "pacing": "moderate",
   "outputFormat": "all",
   "throttleMs": 2000,
+  "maxTotalRounds": 20,
   "outputDir": "C:/tmp/exp1075-out"
 }


### PR DESCRIPTION
## Summary
- `lib/debate/aiAdapter.ts`: adds 300s minimum timeout floor for models containing 'opus' — 180s base is insufficient for complex structured topics (same failure class as t/1069#6, fired on treat-liability-regime and treat-siloed-datasets in the t/1075 Phase A run)
- All 6 `research/comp-linguist/analyses/t1069-phaseA/` experiment configs: `maxTotalRounds: 10 → 20`, raising the API hard ceiling from 150 → 300 API calls — all 4 completed debates terminated at `api_ceiling`, making `convergence_score` uninterpretable per CL's R-4 censoring gate (t/1075#6)

## Test plan
- [ ] CI passes (tsc + vitest)
- [ ] Verify `aiAdapter.ts` change: type-safe (string.includes → boolean, Math.max(number, number) → number)
- [ ] Post-merge: re-run 2 failed treatment debates with updated engine + configs

Generated with Claude Code