### PR TITLE
feat(summary): polarity/contradiction gate (t/2739 P1) — draft, routes to TL for GV

### DIFF
--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -854,6 +854,32 @@ function Finalize-Summary {
         }
     }
 
+    # -- Polarity/contradiction gate (t/2739 P1) -------------------------------
+    # Runs after the confidence pass (retrieval_low_confidence populated). Asks the
+    # shared directional engine whether each aligned, high-topical-band key_point
+    # OPPOSES its ASSIGNED node's proposition; flips to strongly_opposed +
+    # stance_polarity_flag on 'opposes' (opposition-only; unresolved keeps). The
+    # residual that similarity + the prompt (t/2738) cannot catch.
+    $PolarityKps = [System.Collections.Generic.List[object]]::new()
+    foreach ($Camp in $Camps) {
+        $CampDataPol = $SummaryObject.pov_summaries.$Camp
+        if (-not $CampDataPol -or -not (Has-Field $CampDataPol 'key_points')) { continue }
+        $kpListPol = Get-Field $CampDataPol 'key_points'
+        if ($kpListPol) {
+            foreach ($kp in @($kpListPol)) { [void]$PolarityKps.Add(@{ KeyPoint = $kp; POV = $Camp }) }
+        }
+    }
+    if ($PolarityKps.Count -gt 0) {
+        $PolarityCounts = Invoke-PolarityGatePass -KeyPoints $PolarityKps.ToArray()
+        if ($PolarityCounts.opposes -gt 0) {
+            Write-Warn ("Polarity gate: {0} inversion(s) flagged (opposes) — counts o={0} a={1} u={2} x={3} over {4} gated" -f `
+                $PolarityCounts.opposes, $PolarityCounts.agrees, $PolarityCounts.unrelated, $PolarityCounts.unresolved, $PolarityCounts.gated)
+        } else {
+            Write-Verbose ("Polarity gate: no inversions — counts o=0 a={0} u={1} x={2} over {3} gated" -f `
+                $PolarityCounts.agrees, $PolarityCounts.unrelated, $PolarityCounts.unresolved, $PolarityCounts.gated)
+        }
+    }
+
     # -- Mechanism #5 per-key_point re-retrieval pass (t/2357) -----------------
     # Runs after the confidence pass so retrieval_low_confidence is populated.
     # Flags key_points whose assigned node is retrieval_low_confidence OR absent

--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -874,6 +874,11 @@ function Finalize-Summary {
         if ($PolarityCounts.opposes -gt 0) {
             Write-Warn ("Polarity gate: {0} inversion(s) flagged (opposes) — counts o={0} a={1} u={2} x={3} over {4} gated" -f `
                 $PolarityCounts.opposes, $PolarityCounts.agrees, $PolarityCounts.unrelated, $PolarityCounts.unresolved, $PolarityCounts.gated)
+        } elseif ($PolarityCounts.gated -gt 0 -and $PolarityCounts.unresolved -eq $PolarityCounts.gated) {
+            # Silent-degradation detector: every gated pair unresolved ⇒ the directional
+            # engine likely failed for the whole run (fail-safe kept all mappings). Surface
+            # by default so a dead engine does not pass unnoticed (TL GV t/2739#6).
+            Write-Warn ("Polarity gate: all {0} gated key_point(s) unresolved — directional engine may be down (no inversion detection this run)" -f $PolarityCounts.gated)
         } else {
             Write-Verbose ("Polarity gate: no inversions — counts o=0 a={0} u={1} x={2} over {3} gated" -f `
                 $PolarityCounts.agrees, $PolarityCounts.unrelated, $PolarityCounts.unresolved, $PolarityCounts.gated)

--- a/scripts/AITriad/Private/Invoke-PolarityGatePass.ps1
+++ b/scripts/AITriad/Private/Invoke-PolarityGatePass.ps1
@@ -1,0 +1,156 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Invoke-PolarityGatePass {
+    <#
+    .SYNOPSIS
+        Polarity/contradiction gate for the summary finalize stage (t/2739 P1).
+    .DESCRIPTION
+        Runs AFTER Invoke-RetrievalConfidencePass. For each key_point whose claimed
+        stance is aligned-family, whose assigned taxonomy_node_id is non-null, and
+        whose topical match is in the HIGH band (NOT retrieval_low_confidence), it
+        asks the shared directional-agreement engine whether the claim OPPOSES the
+        ASSIGNED node's proposition — the residual that similarity + the LLM prompt
+        cannot catch (t/2737/t/2738; run-B acc-074 mismap, CL t/2739#1).
+
+        BINDINGS (TL design review t/2739#3):
+        1. Consumes the shared Private wrapper Test-DirectionalAgreement (PS2 #1175)
+           over the merged engine scripts/nli_classify.py (#1180). This pass does NOT
+           frame, call NLI, or threshold — framing is single-sourced in the engine
+           (t/2744#3). node_prop is built label + Core with Encompasses:/Excludes:
+           tails stripped, IDENTICAL to V1 (Invoke-OrgClaimMatching) per condition #3.
+        2. Opposition-only contract (t/2751#2): the engine reliably recovers
+           contradiction but rates genuine agreement 'unrelated', not 'entailment'.
+           So this fires ONLY on 'opposes'. 'agrees' / 'unrelated' / 'unresolved' all
+           KEEP the LLM's mapping. FAIL-SAFE: 'unresolved' KEEPS (never demote) — a
+           missed inversion beats a false demote that nukes recall and flakes a
+           blocking gate.
+        3. Emits per-run counts {opposes, agrees, unrelated, unresolved} over the
+           gated key_points — also the silent-degradation detector (all-'unresolved'
+           = engine down).
+
+        On 'opposes': sets stance = 'strongly_opposed' (opposed-family) and
+        stance_polarity_flag = $true on the key_point — surfaced, never silent. The
+        node mapping is preserved (the source disputes THAT node's proposition);
+        this is the opposed-family branch of the spec disposition (opposed-family OR
+        unmap), chosen over unmap to preserve the node association and avoid
+        synthesizing an unmapped_concept post-hoc.
+    .PARAMETER KeyPoints
+        Array of items shaped @{ KeyPoint = <kp object>; POV = <camp> } (mirrors the
+        Mechanism-5 pass collection). Empty is a no-op.
+    .PARAMETER DirectionalTauContra
+        Contradiction margin floor forwarded to the engine. Default 1.0 (FINAL, the
+        engine's τ; CL t/2751#3). Introduces NO new threshold of its own.
+    .PARAMETER SkipDirectionalGate
+        Bypass the gate entirely (returns zeroed counts, mutates nothing).
+    .OUTPUTS
+        [hashtable] per-run counts { opposes; agrees; unrelated; unresolved; gated }.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$KeyPoints,
+
+        [Parameter()]
+        [ValidateRange(0.0, 1000.0)]
+        [double]$DirectionalTauContra = 1.0,
+
+        [Parameter()]
+        [switch]$SkipDirectionalGate
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    $counts = @{ opposes = 0; agrees = 0; unrelated = 0; unresolved = 0; gated = 0 }
+    $items = @($KeyPoints)
+    if ($SkipDirectionalGate -or $items.Count -eq 0) { return $counts }
+
+    # ── node_prop lookup: label + Core, Encompasses:/Excludes: tails stripped ──
+    # IDENTICAL construction to V1 (Invoke-OrgClaimMatching) — TL GV condition #3.
+    $povByPrefix  = @{ acc = 'accelerationist'; saf = 'safetyist'; skp = 'skeptic' }
+    $nodeTextById = @{}
+    foreach ($pov in $script:TaxonomyData.Values) {
+        if (-not $pov.PSObject.Properties['nodes']) { continue }
+        foreach ($n in @($pov.nodes)) {
+            if (-not $n.PSObject.Properties['id']) { continue }
+            $lbl = if ($n.PSObject.Properties['label']) { [string]$n.label } else { '' }
+            $dsc = if ($n.PSObject.Properties['description'] -and $n.description) { [string]$n.description } else { '' }
+            $dsc = $dsc -replace '(?s)\s*(Encompasses|Excludes)\s*:.*$', ''
+            $nodeTextById[[string]$n.id] = if ($dsc) { "$lbl — $($dsc.Trim())" } else { $lbl }
+        }
+    }
+
+    # ── Select gated key_points ────────────────────────────────────────────────
+    # aligned-family stance + non-null assigned node + HIGH topical band.
+    $alignedFamily = @('aligned', 'strongly_aligned')
+    $gated = [System.Collections.Generic.List[PSObject]]::new()
+    foreach ($item in $items) {
+        $kp = & { if ($item -is [System.Collections.IDictionary]) { $item['KeyPoint'] } else { $item.KeyPoint } }
+        $pov = & { if ($item -is [System.Collections.IDictionary]) { $item['POV'] } else { $item.POV } }
+        if ($null -eq $kp) { continue }
+
+        $nodeId = if ($kp.PSObject.Properties['taxonomy_node_id']) { $kp.taxonomy_node_id } else { $null }
+        if ([string]::IsNullOrWhiteSpace([string]$nodeId)) { continue }
+
+        $stance = if ($kp.PSObject.Properties['stance']) { [string]$kp.stance } else { '' }
+        if ($stance -notin $alignedFamily) { continue }
+
+        # HIGH topical band: reuse the existing retrieval-confidence band — gate only
+        # where the assigned node is NOT retrieval_low_confidence (no new threshold).
+        $low = if ($kp.PSObject.Properties['retrieval_low_confidence']) { [bool]$kp.retrieval_low_confidence } else { $false }
+        if ($low) { continue }
+
+        $gated.Add([PSCustomObject]@{ KeyPoint = $kp; POV = $pov; NodeId = [string]$nodeId })
+    }
+    $counts.gated = $gated.Count
+    if ($gated.Count -eq 0) { return $counts }
+
+    # ── Build directional pairs (claim vs ASSIGNED node) ───────────────────────
+    $pairs = [System.Collections.Generic.List[PSObject]]::new()
+    for ($i = 0; $i -lt $gated.Count; $i++) {
+        $kp = $gated[$i].KeyPoint
+        $claimProp = if ($kp.PSObject.Properties['canonical_proposition'] -and $kp.canonical_proposition) {
+            [string]$kp.canonical_proposition
+        } elseif ($kp.PSObject.Properties['attribution_text'] -and $kp.attribution_text) {
+            [string]$kp.attribution_text
+        } else { '' }
+
+        $nid      = $gated[$i].NodeId
+        $nodeText = if ($nodeTextById.ContainsKey($nid)) { $nodeTextById[$nid] } else { '' }
+        $prefix   = if ($nid -match '^(acc|saf|skp)-') { $Matches[1] } else { '' }
+        $nodePov  = if ($prefix -and $povByPrefix.ContainsKey($prefix)) { $povByPrefix[$prefix] } else { '' }
+        $claimPov = [string]$gated[$i].POV
+
+        $pairs.Add([PSCustomObject]@{
+            Id = $i; ClaimProp = $claimProp; NodeProp = $nodeText; ClaimPov = $claimPov; NodePov = $nodePov
+        })
+    }
+
+    # ── Directional verdicts via the shared wrapper ────────────────────────────
+    $verdicts = Test-DirectionalAgreement -Pair @($pairs) -TauContra $DirectionalTauContra
+    $byIdx = @{}
+    foreach ($v in @($verdicts)) { $byIdx[[int]$v.Id] = $v }
+
+    for ($i = 0; $i -lt $gated.Count; $i++) {
+        $kp = $gated[$i].KeyPoint
+        $v  = if ($byIdx.ContainsKey($i)) { $byIdx[$i] } else { $null }
+        $direction = if ($v) { [string]$v.Direction } else { 'unresolved' }
+        if ($counts.ContainsKey($direction)) { $counts[$direction]++ } else { $counts['unresolved']++ }
+
+        if ($direction -eq 'opposes') {
+            # Claim asserts ¬(node proposition): surface the inversion + flip to
+            # opposed-family. Node mapping preserved (it disputes THAT node).
+            $kp | Add-Member -NotePropertyName 'stance'               -NotePropertyValue 'strongly_opposed' -Force
+            $kp | Add-Member -NotePropertyName 'stance_polarity_flag' -NotePropertyValue $true              -Force
+            $conf = if ($v -and $v.PSObject.Properties['Confidence']) { $v.Confidence } else { 0.0 }
+            $kp | Add-Member -NotePropertyName 'stance_polarity_confidence' -NotePropertyValue $conf -Force
+        }
+        # agrees / unrelated / unresolved → KEEP the LLM's mapping (opposition-only,
+        # fail-safe = do not demote).
+    }
+
+    return $counts
+}

--- a/tests/Invoke-PolarityGatePass.Tests.ps1
+++ b/tests/Invoke-PolarityGatePass.Tests.ps1
@@ -1,0 +1,147 @@
+# Tag: summary (t/2739)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Invoke-PolarityGatePass — polarity/contradiction gate (t/2739 P1).
+.DESCRIPTION
+    Both-arm + fail-safe Gate Verification with count assertions, mirroring the
+    V1/V2 test Contexts (INVERSION fires / non-opposes KEEPS / unresolved KEEPS).
+    The shared wrapper Test-DirectionalAgreement is MOCKED for determinism in CI;
+    the real-deberta arm is recorded on the ticket (same standard as the engine +
+    V1/V2). Opposition-only contract (t/2751#2): fire ONLY on 'opposes'; 'agrees' /
+    'unrelated' / 'unresolved' all KEEP the mapping.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Invoke-PolarityGatePass (t/2739)' -Tag 'summary' {
+
+    BeforeEach {
+        InModuleScope AITriad {
+            # Minimal taxonomy for node_prop construction (label + Core; Encompasses tail present to prove stripping).
+            $script:TaxonomyData = @{
+                accelerationist = [PSCustomObject]@{ nodes = @(
+                    [PSCustomObject]@{ id = 'acc-intentions-047'; label = 'Argue AI Requires Entirely New Laws'; description = 'An Intention that new legal frameworks are required rather than adapted existing laws. Encompasses: bespoke AI legislation, regulatory sandboxes.' }
+                ) }
+            }
+        }
+    }
+
+    # A gated aligned key_point on acc-intentions-047 (high band).
+    function script:New-Kp ($stance = 'aligned', $node = 'acc-intentions-047', $low = $false) {
+        [PSCustomObject]@{
+            canonical_proposition   = 'Existing privacy law already governs AI; no new frameworks are needed.'
+            taxonomy_node_id        = $node
+            stance                  = $stance
+            retrieval_low_confidence = $low
+        }
+    }
+
+    It 'INVERSION fires: opposes → strongly_opposed + stance_polarity_flag, counts.opposes=1' {
+        InModuleScope AITriad {
+            Mock Test-DirectionalAgreement -MockWith {
+                $r = [System.Collections.Generic.List[PSObject]]::new()
+                foreach ($p in @($Pair)) { $r.Add([PSCustomObject]@{ Id = $p.Id; Direction = 'opposes'; Confidence = 1.44; Method = 'nli' }) }
+                $r
+            }
+            $kp = New-Kp
+            $counts = Invoke-PolarityGatePass -KeyPoints @(@{ KeyPoint = $kp; POV = 'accelerationist' })
+
+            $kp.stance | Should -Be 'strongly_opposed'
+            $kp.stance_polarity_flag | Should -BeTrue
+            $counts.opposes | Should -Be 1
+            $counts.gated   | Should -Be 1
+        }
+    }
+
+    It 'node_prop matches V1: label + Core with Encompasses/Excludes stripped' {
+        InModuleScope AITriad {
+            $script:CapturedPairs = $null
+            Mock Test-DirectionalAgreement -MockWith {
+                $script:CapturedPairs = @($Pair)
+                $r = [System.Collections.Generic.List[PSObject]]::new()
+                foreach ($p in @($Pair)) { $r.Add([PSCustomObject]@{ Id = $p.Id; Direction = 'unrelated'; Confidence = 0.0; Method = 'nli' }) }
+                $r
+            }
+            Invoke-PolarityGatePass -KeyPoints @(@{ KeyPoint = (New-Kp); POV = 'accelerationist' }) | Out-Null
+
+            $np = $script:CapturedPairs[0].NodeProp
+            $np | Should -BeLike 'Argue AI Requires Entirely New Laws — *'
+            $np | Should -Not -Match 'Encompasses' -Because 'Encompasses:/Excludes: tails must be stripped (condition #3)'
+            $script:CapturedPairs[0].NodePov | Should -Be 'accelerationist'
+        }
+    }
+
+    It 'GENUINE AGREEMENT arm: unrelated → KEEP (no flag), counts.unrelated=1' {
+        InModuleScope AITriad {
+            Mock Test-DirectionalAgreement -MockWith {
+                $r = [System.Collections.Generic.List[PSObject]]::new()
+                foreach ($p in @($Pair)) { $r.Add([PSCustomObject]@{ Id = $p.Id; Direction = 'unrelated'; Confidence = 0.0; Method = 'nli' }) }
+                $r
+            }
+            $kp = New-Kp 'aligned'
+            $counts = Invoke-PolarityGatePass -KeyPoints @(@{ KeyPoint = $kp; POV = 'accelerationist' })
+
+            $kp.stance | Should -Be 'aligned' -Because 'genuine agreement reads unrelated (not entailment) and must KEEP'
+            ($kp.PSObject.Properties['stance_polarity_flag']) | Should -BeNullOrEmpty
+            $counts.unrelated | Should -Be 1
+            $counts.opposes   | Should -Be 0
+        }
+    }
+
+    It 'FAIL-SAFE: unresolved → KEEP the mapping (never demote), counts.unresolved=1' {
+        InModuleScope AITriad {
+            Mock Test-DirectionalAgreement -MockWith {
+                $r = [System.Collections.Generic.List[PSObject]]::new()
+                foreach ($p in @($Pair)) { $r.Add([PSCustomObject]@{ Id = $p.Id; Direction = 'unresolved'; Confidence = 0.0; Method = 'none' }) }
+                $r
+            }
+            $kp = New-Kp 'strongly_aligned'
+            $counts = Invoke-PolarityGatePass -KeyPoints @(@{ KeyPoint = $kp; POV = 'accelerationist' })
+
+            $kp.stance | Should -Be 'strongly_aligned' -Because 'a demotion gate fails safe by NOT demoting (t/2751#2)'
+            ($kp.PSObject.Properties['stance_polarity_flag']) | Should -BeNullOrEmpty
+            $counts.unresolved | Should -Be 1
+        }
+    }
+
+    It 'SCOPING: opposed-stance, null-node, and low-band key_points are NOT gated' {
+        InModuleScope AITriad {
+            $script:GatedSeen = 0
+            Mock Test-DirectionalAgreement -MockWith {
+                $script:GatedSeen = @($Pair).Count
+                $r = [System.Collections.Generic.List[PSObject]]::new()
+                foreach ($p in @($Pair)) { $r.Add([PSCustomObject]@{ Id = $p.Id; Direction = 'unrelated'; Confidence = 0; Method = 'nli' }) }
+                $r
+            }
+            $items = @(
+                @{ KeyPoint = (New-Kp 'opposed');                 POV = 'accelerationist' }  # already opposed → skip
+                @{ KeyPoint = (New-Kp 'aligned' $null);           POV = 'accelerationist' }  # null node → skip
+                @{ KeyPoint = (New-Kp 'aligned' 'acc-intentions-047' $true); POV = 'accelerationist' }  # low band → skip
+                @{ KeyPoint = (New-Kp 'aligned');                 POV = 'accelerationist' }  # gated
+            )
+            $counts = Invoke-PolarityGatePass -KeyPoints $items
+            $counts.gated | Should -Be 1
+            $script:GatedSeen | Should -Be 1
+        }
+    }
+
+    It '-SkipDirectionalGate is a no-op (zeroed counts, no engine call)' {
+        InModuleScope AITriad {
+            Mock Test-DirectionalAgreement -MockWith { throw 'should not be called' }
+            $kp = New-Kp
+            $counts = Invoke-PolarityGatePass -KeyPoints @(@{ KeyPoint = $kp; POV = 'accelerationist' }) -SkipDirectionalGate
+            $counts.gated   | Should -Be 0
+            $counts.opposes | Should -Be 0
+            $kp.stance | Should -Be 'aligned'
+            Should -Invoke Test-DirectionalAgreement -Times 0
+        }
+    }
+}


### PR DESCRIPTION
**DRAFT — routes to Main (TL) for per-surface Gate Verification** (t/2739#3 disposition). Do not merge until GV signs off.

## What
New Private `Invoke-PolarityGatePass`, wired into `Invoke-DocumentSummary` right after `Invoke-RetrievalConfidencePass`. Implements all 3 TL bindings (t/2739#3):
- **B1:** consumes the shared `Test-DirectionalAgreement` wrapper (#1175) over `nli_classify.py` (#1180). `node_prop` = label + Core, Encompasses/Excludes stripped, **identical to V1** (Invoke-OrgClaimMatching).
- **B2:** opposition-only — fires **only** on `opposes` (→ `strongly_opposed` + `stance_polarity_flag`, node mapping preserved); `agrees`/`unrelated`/`unresolved` **keep**; `unresolved`→keep fail-safe (never demote).
- **B3:** per-run counts `{opposes,agrees,unrelated,unresolved,gated}`; runs on the **assigned** node; no new threshold (τ=1.0 forwarded).

Scope: aligned-family + non-null node + high topical band. `-SkipDirectionalGate` bypass.

## Mocked GV arms — 6/6 green
INVERSION fires · node_prop matches V1 (Encompasses stripped) · genuine-agreement (`unrelated`)→KEEP · `unresolved`→KEEP · scoping (opposed/null-node/low-band skipped) · skip no-op. Adjacent M5/OrgClaimMatching/Module suites 55/55, no regression.

## ⚠️ Real-deberta arm — MATERIAL FINDING FOR GV
I ran the **live** engine on fixture case_1 (the origin inversion). With the stored claim text (`canonical_proposition`, and also tried `attribution_text`) vs the acc-047 `label+Core` node_prop, the engine returns **`unrelated` (neutral), NOT `opposes`** (conf ~1.6–3.4). So end-to-end on the real model, **case_1 is NOT caught** — the gate keeps the (wrong) aligned mapping. This is the documented **recall boundary** (t/2744#7, wrapper docstring): the fixture's recorded contradiction (+1.44) used a hand-authored `pov_attributed_framing` text_a that differs from any stored key_point field.

**GV decision needed (TL):** is the mock-verified opposition-only gate acceptable to land now — it fires correctly *when the engine says opposes*, and case_1's live miss is an engine/text recall-boundary issue shared with V1/V2 — with case_1 live recall tracked separately? Or should claim/node text construction be enriched first (and if so, that likely belongs in the shared engine/wrapper, not this consumer, to preserve cross-surface consistency)? I did **not** tune framing unilaterally — that's a single-source (engine) concern per your t/2744#3 ruling.

Consumes #1175 (shared wrapper). Routes to you for GV. 🤖 Generated with [Claude Code](https://claude.com/claude-code)