### PR TITLE
fix(obs): abort fetch on unmount + FR crash enrichment (t/2755, t/2732)

### DIFF
--- a/taxonomy-editor/src/renderer/components/PublicPovView.test.tsx
+++ b/taxonomy-editor/src/renderer/components/PublicPovView.test.tsx
@@ -113,16 +113,16 @@ describe('PublicPovView (t/1790)', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it(‘shows an error state and records to the flight recorder on network failure’, async () => {
-    mockFetch.mockRejectedValue(new Error(‘network down’));
+  it('shows an error state and records to the flight recorder on network failure', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
     render(<PublicPovView />);
-    await screen.findByText(/Couldn’t load this item/);
+    await screen.findByText(/Couldn't load this item/);
     expect(mockRecord).toHaveBeenCalledWith(
-      expect.objectContaining({ type: ‘system.error’, component: ‘PublicPovView’, level: ‘error’ }),
+      expect.objectContaining({ type: 'system.error', component: 'PublicPovView', level: 'error' }),
     );
   });
 
-  it(‘aborts the in-flight fetch on unmount (t/2755)’, async () => {
+  it('aborts the in-flight fetch on unmount (t/2755)', async () => {
     const abortSpy = vi.fn();
     const origAbortController = globalThis.AbortController;
     globalThis.AbortController = class extends origAbortController {

--- a/taxonomy-editor/src/renderer/components/PublicPovView.test.tsx
+++ b/taxonomy-editor/src/renderer/components/PublicPovView.test.tsx
@@ -113,12 +113,31 @@ describe('PublicPovView (t/1790)', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('shows an error state and records to the flight recorder on network failure', async () => {
-    mockFetch.mockRejectedValue(new Error('network down'));
+  it(‘shows an error state and records to the flight recorder on network failure’, async () => {
+    mockFetch.mockRejectedValue(new Error(‘network down’));
     render(<PublicPovView />);
     await screen.findByText(/Couldn’t load this item/);
     expect(mockRecord).toHaveBeenCalledWith(
-      expect.objectContaining({ type: 'system.error', component: 'PublicPovView', level: 'error' }),
+      expect.objectContaining({ type: ‘system.error’, component: ‘PublicPovView’, level: ‘error’ }),
     );
+  });
+
+  it(‘aborts the in-flight fetch on unmount (t/2755)’, async () => {
+    const abortSpy = vi.fn();
+    const origAbortController = globalThis.AbortController;
+    globalThis.AbortController = class extends origAbortController {
+      abort(...args: unknown[]) { abortSpy(); super.abort(...(args as [])); }
+    } as typeof AbortController;
+
+    let resolveFetch!: (r: Response) => void;
+    mockFetch.mockReturnValue(new Promise<Response>(res => { resolveFetch = res; }));
+
+    const { unmount } = render(<PublicPovView />);
+    unmount();
+
+    expect(abortSpy).toHaveBeenCalled();
+    // Resolve to avoid unhandled-rejection noise in test output
+    resolveFetch(fakeResponse({ status: 200, body: SAMPLE }));
+    globalThis.AbortController = origAbortController;
   });
 });

--- a/taxonomy-editor/src/renderer/components/PublicPovView.tsx
+++ b/taxonomy-editor/src/renderer/components/PublicPovView.tsx
@@ -94,7 +94,7 @@ export function PublicPovView() {
         clearTimeout(timeout);
       }
     })();
-    return () => { cancelled = true; clearTimeout(timeout); };
+    return () => { cancelled = true; clearTimeout(timeout); controller.abort(); };
   }, []);
 
   if (state.status === 'loading') {

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -980,6 +980,13 @@ function snapshotStoresForCrash(): Record<string, unknown> | undefined {
       debate_phase: debate?.phase ?? null,
       debate_generating: !!debateState.debateGenerating,
       dirty_files: [...((taxState.dirty as Set<string>) ?? [])],
+      // t/2732: surface sessions with non-string titles so index-shape bugs name the
+      // offending session IDs immediately rather than after reading the full call path.
+      debate_sessions_non_string_title_ids: (() => {
+        const sessions = debateState.sessions as Array<{ id: string; title: unknown }> | undefined;
+        const bad = (sessions ?? []).filter(s => typeof s.title !== 'string').map(s => s.id);
+        return bad.length > 0 ? bad : undefined;
+      })(),
     };
   } catch {
     /* flight recorder init — silent by design (store may be corrupted) */
@@ -997,6 +1004,15 @@ function snapshotStoresForCrash(): Record<string, unknown> | undefined {
  * a human repro (t/2551 observability arm; the vite.config.ts build gate is the
  * prevention arm). Returns undefined for ordinary errors.
  */
+/**
+ * Parse the React "Objects are not valid as a React child" error message to extract
+ * the offending object's key names (t/2732). Returns undefined for unrelated errors.
+ */
+function extractInvalidReactChildKeys(error: Error): string[] | undefined {
+  const m = /found: object with keys \{([^}]+)\}/.exec(error.message);
+  return m ? m[1].split(',').map(k => k.trim()) : undefined;
+}
+
 function extractExternalizedModule(error: Error): { module: string; accessed?: string } | undefined {
   const msg = String(error?.message ?? '');
   const mod = /Module "([^"]+)" has been externalized for browser compatibility/.exec(msg);
@@ -1021,10 +1037,12 @@ export function dumpOnReactError(
   const stateSnapshot = snapshotStoresForCrash();
   const externalizedModule = extractExternalizedModule(error);
 
+  const invalidReactChildKeys = extractInvalidReactChildKeys(error);
   const baseData: Record<string, unknown> = {
     ...(componentStack ? { component_stack: componentStack.slice(0, 1000) } : {}),
     ...(stateSnapshot ? { state_snapshot: stateSnapshot } : {}),
     ...(externalizedModule ? { externalized_module: externalizedModule } : {}),
+    ...(invalidReactChildKeys ? { invalid_react_child_keys: invalidReactChildKeys } : {}),
   };
 
   // Record the crash SYNCHRONOUSLY, before any async work (t/2297). This guarantees

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -1014,15 +1014,6 @@ function snapshotStoresForCrash(): Record<string, unknown> | undefined {
  * a human repro (t/2551 observability arm; the vite.config.ts build gate is the
  * prevention arm). Returns undefined for ordinary errors.
  */
-/**
- * Parse the React "Objects are not valid as a React child" error message to extract
- * the offending object's key names (t/2732). Returns undefined for unrelated errors.
- */
-function extractInvalidReactChildKeys(error: Error): string[] | undefined {
-  const m = /found: object with keys \{([^}]+)\}/.exec(error.message);
-  return m ? m[1].split(',').map(k => k.trim()) : undefined;
-}
-
 function extractExternalizedModule(error: Error): { module: string; accessed?: string } | undefined {
   const msg = String(error?.message ?? '');
   const mod = /Module "([^"]+)" has been externalized for browser compatibility/.exec(msg);
@@ -1060,8 +1051,6 @@ export function dumpOnReactError(
 
   const stateSnapshot = snapshotStoresForCrash();
   const externalizedModule = extractExternalizedModule(error);
-  const invalidReactChildKeys = extractInvalidReactChildKeys(error);
-
   const invalidReactChildKeys = extractInvalidReactChildKeys(error);
   const baseData: Record<string, unknown> = {
     ...(componentStack ? { component_stack: componentStack.slice(0, 1000) } : {}),


### PR DESCRIPTION
## Summary

- **t/2755** `PublicPovView.tsx`: missing `controller.abort()` in `useEffect` cleanup — fetch ran until TCP close even after unmount. One-liner fix + unmount-abort test (same shape as the t/2728 fix in `PublicOpEdView`).
- **t/2732** `flightRecorderInit.ts`: two crash-diagnosis additions:
  - `invalid_react_child_keys` — parsed from React's "object with keys {…}" message, surfaces the offending type's key shape inline in the FR dump
  - `debate_sessions_non_string_title_ids` — scans the sessions index in `snapshotStoresForCrash`, lists IDs whose `title` is not a string. Would have named the bad session in the t/2729 BulkDeleteDialog crash immediately.

## Test plan

- [ ] `PublicPovView.test.tsx` unmount-abort test passes
- [ ] Manual: open a shared POV node, navigate away quickly — no in-flight fetch errors in console
- [ ] FR dump after a BulkDeleteDialog-style crash contains `invalid_react_child_keys` and `debate_sessions_non_string_title_ids` where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)