### PR TITLE
feat(debate): V5 NLI gate — 3-slot OR rule for claim-text assembly (t/2746)

### DIFF
--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
@@ -15,10 +15,18 @@ vi.mock('child_process', () => {
 import { spawnSync } from 'child_process';
 const mockSpawn = vi.mocked(spawnSync);
 
-function makeNode(id: string, primaryRef: string | null, text = 'some claim'): ArgumentNetworkNode {
+function makeNode(
+  id: string,
+  primaryRef: string | null,
+  text = 'some claim',
+  canonical?: string,
+  attribution?: string,
+): ArgumentNetworkNode {
   return {
     id,
     text,
+    ...(canonical !== undefined && { canonical_proposition: canonical }),
+    ...(attribution !== undefined && { attribution_text_genus: attribution }),
     speaker: 'accelerationist',
     source_entry_id: 'e1',
     taxonomy_refs: [],
@@ -75,7 +83,10 @@ describe('buildNliNodeProp — rich node prop for NLI (t/2744#7)', () => {
   });
 });
 
-describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
+describe('runNliDirectionGate — V5 direction gate, multi-field OR (t/2746, t/2744#10)', () => {
+  // V5 sends up to 3 slots per claim (id__v / id__c / id__a) and applies opposes-if-ANY.
+  // Default makeNode has only text set → one slot (__v). Tests with all fields use makeNode overloads.
+
   it('returns empty result when no nodes are attributed', () => {
     const nodes = [makeNode('AN-1', null)];
     const result = runNliDirectionGate(nodes, new Map(), 'acc');
@@ -91,11 +102,11 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
-  it('demotes claim when engine returns opposes', () => {
+  it('demotes claim when verbatim slot returns opposes', () => {
     const nodes = [makeNode('AN-1', 'acc-bel-001')];
     const nodeMap = new Map([['acc-bel-001', 'AI regulation accelerates progress']]);
     mockSpawn.mockReturnValue(spawnResult([
-      { id: 'AN-1', direction: 'opposes', confidence: 1.4, method: 'nli-deberta' },
+      { id: 'AN-1__v', direction: 'opposes', confidence: 1.4, method: 'nli-deberta' },
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
@@ -104,11 +115,11 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     expect(result.counts.agrees).toBe(0);
   });
 
-  it('keeps claim when engine returns unrelated', () => {
+  it('keeps claim when verbatim slot returns unrelated', () => {
     const nodes = [makeNode('AN-1', 'acc-bel-001')];
     const nodeMap = new Map([['acc-bel-001', 'AI regulation accelerates progress']]);
     mockSpawn.mockReturnValue(spawnResult([
-      { id: 'AN-1', direction: 'unrelated', confidence: 0.2, method: 'nli-deberta' },
+      { id: 'AN-1__v', direction: 'unrelated', confidence: 0.2, method: 'nli-deberta' },
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
@@ -116,11 +127,11 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     expect(result.counts.unrelated).toBe(1);
   });
 
-  it('keeps claim when engine returns unresolved (fail-safe output)', () => {
+  it('keeps claim when verbatim slot returns unresolved (fail-safe output)', () => {
     const nodes = [makeNode('AN-1', 'acc-bel-001')];
     const nodeMap = new Map([['acc-bel-001', 'AI regulation accelerates progress']]);
     mockSpawn.mockReturnValue(spawnResult([
-      { id: 'AN-1', direction: 'unresolved', confidence: 0.0, method: 'nli-deberta' },
+      { id: 'AN-1__v', direction: 'unresolved', confidence: 0.0, method: 'nli-deberta' },
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
@@ -128,17 +139,121 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     expect(result.counts.unresolved).toBe(1);
   });
 
-  it('keeps claim when engine returns agrees', () => {
-    const nodes = [makeNode('AN-1', 'acc-bel-001')];
-    const nodeMap = new Map([['acc-bel-001', 'AI regulation accelerates progress']]);
+  it('keeps claim when all slots return agrees (arm-2 genuine-agreement control: no false demote)', () => {
+    // GV arm-2: genuine agreement across all three fields must never manufacture a false opposes.
+    const nodes = [makeNode('AN-1', 'acc-bel-001', 'AI helps everyone', 'AI is beneficial', 'AI improves welfare')];
+    const nodeMap = new Map([['acc-bel-001', 'AI accelerates progress']]);
     mockSpawn.mockReturnValue(spawnResult([
-      { id: 'AN-1', direction: 'agrees', confidence: 0.5, method: 'nli-deberta' },
+      { id: 'AN-1__v', direction: 'agrees', confidence: 0.9, method: 'nli-deberta' },
+      { id: 'AN-1__c', direction: 'agrees', confidence: 0.8, method: 'nli-deberta' },
+      { id: 'AN-1__a', direction: 'agrees', confidence: 0.7, method: 'nli-deberta' },
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
     expect(result.opposingIds.size).toBe(0);
     expect(result.counts.agrees).toBe(1);
+    expect(result.counts.opposes).toBe(0);
   });
+
+  // ── OR rule tests (t/2744#10–#11) ──────────────────────────────────────────
+
+  it('OR rule: verbatim→opposes fires even when canonical→unrelated', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001', 'verbatim text', 'canonical text')];
+    const nodeMap = new Map([['acc-bel-001', 'node prop']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1__v', direction: 'opposes', confidence: 1.2, method: 'nli-deberta' },
+      { id: 'AN-1__c', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.opposingIds.has('AN-1')).toBe(true);
+    expect(result.counts.opposes).toBe(1);
+  });
+
+  it('OR rule: attribution→agrees (false entailment) blocked by verbatim→opposes (t/2744#11 case)', () => {
+    // The empirical origin case: attribution_text over-abstracts to false entailment,
+    // but verbatim/canonical both fire opposes — the OR rule catches the inversion.
+    const nodes = [makeNode('AN-1', 'acc-int-047', 'verbatim contradicts node', 'canonical also contradicts', 'attribution entails — false')];
+    const nodeMap = new Map([['acc-int-047', 'Existing laws are insufficient for AI']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1__v', direction: 'opposes', confidence: 4.71, method: 'nli-deberta' },
+      { id: 'AN-1__c', direction: 'opposes', confidence: 1.42, method: 'nli-deberta' },
+      { id: 'AN-1__a', direction: 'agrees',  confidence: 6.84, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.opposingIds.has('AN-1')).toBe(true);
+    expect(result.counts.opposes).toBe(1);
+    expect(result.counts.agrees).toBe(0);
+  });
+
+  it('OR rule: all three slots→unrelated → claim not opposing, counts as unrelated', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001', 'v text', 'c text', 'a text')];
+    const nodeMap = new Map([['acc-bel-001', 'node prop']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1__v', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+      { id: 'AN-1__c', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+      { id: 'AN-1__a', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.opposingIds.size).toBe(0);
+    expect(result.counts.unrelated).toBe(1);
+    expect(result.counts.opposes).toBe(0);
+  });
+
+  it('OR rule: all three slots→unresolved → counts as unresolved (fail-safe)', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001', 'v text', 'c text', 'a text')];
+    const nodeMap = new Map([['acc-bel-001', 'node prop']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1__v', direction: 'unresolved', confidence: 0.0, method: 'nli-deberta' },
+      { id: 'AN-1__c', direction: 'unresolved', confidence: 0.0, method: 'nli-deberta' },
+      { id: 'AN-1__a', direction: 'unresolved', confidence: 0.0, method: 'nli-deberta' },
+    ]) as any);
+
+    const result = runNliDirectionGate(nodes, nodeMap, 'acc');
+    expect(result.opposingIds.size).toBe(0);
+    expect(result.counts.unresolved).toBe(1);
+  });
+
+  it('sends only available fields — skips undefined canonical and attribution', () => {
+    // Node with only text → batch should have exactly 1 slot (__v).
+    const nodes = [makeNode('AN-1', 'acc-bel-001', 'just verbatim')];
+    const nodeMap = new Map([['acc-bel-001', 'node prop']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1__v', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+    ]) as any);
+
+    runNliDirectionGate(nodes, nodeMap, 'acc');
+    const stdin = JSON.parse(mockSpawn.mock.calls[0][2]?.input as string);
+    expect(stdin).toHaveLength(1);
+    expect(stdin[0].id).toBe('AN-1__v');
+    expect(stdin[0].claim_prop).toBe('just verbatim');
+  });
+
+  it('sends all three slots when all fields are populated', () => {
+    const nodes = [makeNode('AN-1', 'acc-bel-001', 'verbatim', 'canonical', 'attribution')];
+    const nodeMap = new Map([['acc-bel-001', 'node prop']]);
+    mockSpawn.mockReturnValue(spawnResult([
+      { id: 'AN-1__v', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+      { id: 'AN-1__c', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+      { id: 'AN-1__a', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+    ]) as any);
+
+    runNliDirectionGate(nodes, nodeMap, 'acc');
+    const stdin = JSON.parse(mockSpawn.mock.calls[0][2]?.input as string);
+    expect(stdin).toHaveLength(3);
+    const ids = stdin.map((s: { id: string }) => s.id);
+    expect(ids).toContain('AN-1__v');
+    expect(ids).toContain('AN-1__c');
+    expect(ids).toContain('AN-1__a');
+    const byId = Object.fromEntries(stdin.map((s: { id: string; claim_prop: string }) => [s.id, s.claim_prop]));
+    expect(byId['AN-1__v']).toBe('verbatim');
+    expect(byId['AN-1__c']).toBe('canonical');
+    expect(byId['AN-1__a']).toBe('attribution');
+  });
+
+  // ── Fail-safe tests ────────────────────────────────────────────────────────
 
   it('returns empty result (fail-safe) when subprocess exits non-zero', () => {
     const nodes = [makeNode('AN-1', 'acc-bel-001')];
@@ -168,7 +283,7 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     expect(result.opposingIds.size).toBe(0);
   });
 
-  it('handles mixed batch — demotes only the opposes claim, counts all', () => {
+  it('handles mixed batch — demotes only the opposes claim, counts all (claim-level)', () => {
     const nodes = [
       makeNode('AN-1', 'acc-bel-001', 'AI is beneficial'),
       makeNode('AN-2', 'acc-bel-002', 'AI is dangerous'),
@@ -178,8 +293,8 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
       ['acc-bel-002', 'AI reduces risk'],
     ]);
     mockSpawn.mockReturnValue(spawnResult([
-      { id: 'AN-1', direction: 'agrees', confidence: 0.8, method: 'nli-deberta' },
-      { id: 'AN-2', direction: 'opposes', confidence: 1.3, method: 'nli-deberta' },
+      { id: 'AN-1__v', direction: 'agrees',  confidence: 0.8, method: 'nli-deberta' },
+      { id: 'AN-2__v', direction: 'opposes', confidence: 1.3, method: 'nli-deberta' },
     ]) as any);
 
     const result = runNliDirectionGate(nodes, nodeMap, 'acc');
@@ -188,12 +303,12 @@ describe('runNliDirectionGate — V4 direction gate (t/2746)', () => {
     expect(result.counts).toEqual({ opposes: 1, agrees: 1, unrelated: 0, unresolved: 0 });
   });
 
-  it('passes claim_pov, node_pov, and rich node_prop to the subprocess', () => {
+  it('passes claim_pov, node_pov, and rich node_prop to each slot', () => {
     const desc = 'AI cannot be regulated. Encompasses: AI safety, AGI policy.';
     const nodes = [makeNode('AN-1', 'saf-bel-001', 'safety first')];
     const nodeMap = new Map([['saf-bel-001', buildNliNodeProp('Unregulatable AI', desc)]]);
     mockSpawn.mockReturnValue(spawnResult([
-      { id: 'AN-1', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
+      { id: 'AN-1__v', direction: 'unrelated', confidence: 0.1, method: 'nli-deberta' },
     ]) as any);
 
     runNliDirectionGate(nodes, nodeMap, 'safetyist');

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.test.ts
@@ -83,7 +83,7 @@ describe('buildNliNodeProp — rich node prop for NLI (t/2744#7)', () => {
   });
 });
 
-describe('runNliDirectionGate — V5 direction gate, multi-field OR (t/2746, t/2744#10)', () => {
+describe('runNliDirectionGate — V4 direction gate, multi-field OR (t/2746, t/2744#10)', () => {
   // V5 sends up to 3 slots per claim (id__v / id__c / id__a) and applies opposes-if-ANY.
   // Default makeNode has only text set → one slot (__v). Tests with all fields use makeNode overloads.
 

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-// ── V4 NLI direction gate (t/2746) ───────────────────────
+// ── V5 NLI direction gate (t/2746, t/2744#10) ────────────
 
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -53,17 +53,35 @@ export interface NliGateResult {
 
 const ZERO_COUNTS: NliGateCounts = { opposes: 0, agrees: 0, unrelated: 0, unresolved: 0 };
 
+// Slot suffixes for the three claim-text fields (t/2744#10: run-all, opposes-if-ANY).
+// Using short suffix strings that cannot collide with real claim IDs (which never end in __v/__c/__a).
+const SLOT_V = '__v';
+const SLOT_C = '__c';
+const SLOT_A = '__a';
+const SLOT_SUFFIXES = [SLOT_V, SLOT_C, SLOT_A] as const;
+
+function baseClaimId(slotId: string): string {
+  for (const s of SLOT_SUFFIXES) {
+    if (slotId.endsWith(s)) return slotId.slice(0, -s.length);
+  }
+  return slotId;
+}
+
 /**
- * V4 NLI direction gate (t/2746): subprocess-calls scripts/nli_classify.py for
- * each attributed claim and returns IDs of claims where direction === 'opposes'
- * plus per-direction counts for diagnostics.
+ * V5 NLI direction gate (t/2746, t/2744#10): subprocess-calls scripts/nli_classify.py with
+ * up to THREE slots per claim — verbatim (text), canonical_proposition, attribution_text_genus —
+ * and returns IDs of claims where ANY slot direction === 'opposes' (recall-safe OR rule).
+ *
+ * Rationale (t/2744#10–#11): no single claim field wins across cases. verbatim/canonical
+ * catch the origin key-point inversion; attribution catches the #1184 org-stance case.
+ * The OR rule never false-demotes under opposes-only + fail-safe: extra neutral/entailment
+ * slots don't fire. Counts are claim-level (not slot-level).
  *
  * Opposition-only gate (CL ruling t/2751#3): callers demote 'opposes' claims to
  * direction_mismatch; all other directions keep their attribution unchanged.
  *
  * Fail-safe: any subprocess error or parse failure returns empty set + zero counts —
- * the gate never falsely demotes a claim. 'unresolved' is the engine's fail-safe
- * output and is treated identically to 'unrelated' (keep attribution).
+ * the gate never falsely demotes a claim.
  */
 export function runNliDirectionGate(
   nodes: ArgumentNetworkNode[],
@@ -74,17 +92,24 @@ export function runNliDirectionGate(
   const attributed = nodes.filter(n => n.claim_taxonomy_attribution?.primary_ref);
   if (attributed.length === 0) return empty;
 
+  // Build up to 3 slots per claim — skip unavailable fields.
   const batch: NliInput[] = [];
+  const claimIds = new Set<string>(); // track which claims have at least one slot
   for (const n of attributed) {
     const nodeText = nodeTextById.get(n.claim_taxonomy_attribution!.primary_ref!);
     if (!nodeText) continue;
-    batch.push({
-      id: n.id,
-      claim_prop: n.canonical_proposition ?? n.text,
-      node_prop: nodeText,
-      claim_pov: speakerPov,
-      node_pov: speakerPov,
-    });
+    const fields: Array<[string, string | undefined]> = [
+      [SLOT_V, n.text],
+      [SLOT_C, n.canonical_proposition],
+      [SLOT_A, n.attribution_text_genus],
+    ];
+    let added = false;
+    for (const [suffix, claimText] of fields) {
+      if (!claimText) continue;
+      batch.push({ id: `${n.id}${suffix}`, claim_prop: claimText, node_prop: nodeText, claim_pov: speakerPov, node_pov: speakerPov });
+      added = true;
+    }
+    if (added) claimIds.add(n.id);
   }
   if (batch.length === 0) return empty;
 
@@ -112,13 +137,28 @@ export function runNliDirectionGate(
   }
   if (!Array.isArray(outputs)) return empty;
 
+  // Group slot outputs by claim ID, then apply OR rule at claim level.
+  const slotsByClaimId = new Map<string, NliOutput[]>();
+  for (const o of outputs) {
+    const cid = baseClaimId(o.id);
+    const arr = slotsByClaimId.get(cid);
+    if (arr) arr.push(o); else slotsByClaimId.set(cid, [o]);
+  }
+
   const counts: NliGateCounts = { ...ZERO_COUNTS };
   const opposingIds = new Set<string>();
-  for (const o of outputs) {
-    if (o.direction === 'opposes') { counts.opposes++; opposingIds.add(o.id); }
-    else if (o.direction === 'agrees') counts.agrees++;
-    else if (o.direction === 'unresolved') counts.unresolved++;
-    else counts.unrelated++;
+  for (const [claimId, slots] of slotsByClaimId) {
+    const dirs = slots.map(s => s.direction);
+    if (dirs.some(d => d === 'opposes')) {
+      counts.opposes++;
+      opposingIds.add(claimId);
+    } else if (dirs.some(d => d === 'agrees')) {
+      counts.agrees++;
+    } else if (dirs.every(d => d === 'unresolved')) {
+      counts.unresolved++;
+    } else {
+      counts.unrelated++;
+    }
   }
   return { opposingIds, counts };
 }

--- a/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
+++ b/lib/debate/claimExtractionPipeline/nliDirectionGate.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-// ── V5 NLI direction gate (t/2746, t/2744#10) ────────────
+// ── V4 NLI direction gate (t/2746, t/2744#10) ────────────
 
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -68,7 +68,7 @@ function baseClaimId(slotId: string): string {
 }
 
 /**
- * V5 NLI direction gate (t/2746, t/2744#10): subprocess-calls scripts/nli_classify.py with
+ * V4 NLI direction gate (t/2746, t/2744#10): subprocess-calls scripts/nli_classify.py with
  * up to THREE slots per claim — verbatim (text), canonical_proposition, attribution_text_genus —
  * and returns IDs of claims where ANY slot direction === 'opposes' (recall-safe OR rule).
  *


### PR DESCRIPTION
## Summary

- **What**: Upgrades the NLI direction gate in `nliDirectionGate.ts` from single-field (`canonical_proposition ?? text`) to the 3-slot OR rule specified in t/2744#10.
- **How**: For each attributed claim, sends up to three NLI slots — `id__v` (text), `id__c` (canonical_proposition), `id__a` (attribution_text_genus) — then emits `opposes` if ANY slot returns contradiction. Counts are claim-level.
- **Why**: No single claim field wins across cases (t/2744#11). Verbatim/canonical catch the origin inversion; attribution catches the #1184 org-stance case. OR rule is recall-safe: extra neutral/entailment slots never cause a false demote.
- **Scope**: Debate-engine NLI gate only. V3 (exclusion-vector) and V5 (embedding/doctrinal) unaffected.

## Test plan

- [x] 23/23 vitest pass (6 `buildNliNodeProp` + 17 `runNliDirectionGate`)
- [x] New OR-rule tests: verbatim fires when canonical neutral; attribution false-entailment blocked by verbatim/canonical opposes (t/2744#11 empirical case)
- [x] Arm-2 genuine-agreement control: all three fields→agrees → zero false demotes
- [x] Slot-count test: 3 slots sent when all fields present; 1 slot when only verbatim
- [x] All existing fail-safe tests updated to slot-suffixed mock IDs

Routes to TL for quick GV (t/2746).

🤖 Generated with [Claude Code](https://claude.com/claude-code)