### PR TITLE
feat(taxonomy): V1 gates over {verbatim,canonical} claim reps, opposes-if-any (t/2759)

### DIFF
--- a/scripts/AITriad/Public/Invoke-OrgClaimMatching.ps1
+++ b/scripts/AITriad/Public/Invoke-OrgClaimMatching.ps1
@@ -70,8 +70,9 @@ function Invoke-OrgClaimMatching {
         with a manual delete — this only overrides the has-any-status skip.
     .PARAMETER SkipDirectionalGate
         Disable the directional-agreement gate (t/2745, shared engine t/2751). By
-        default every surviving proposal's claim proposition is checked against
-        the matched node via the POV-framed NLI engine: on `opposes` (the claim
+        default every surviving proposal is checked against the matched node via
+        the POV-framed NLI engine over EACH available claim representation
+        (verbatim + canonical, t/2744#10) — opposes-if-ANY: on `opposes` (a rep
         asserts ¬node) the edge type is FLIPPED ADVOCATES_FOR↔OPPOSES; otherwise
         the edge is kept unchanged. Use this switch only where the NLI engine is
         unavailable, or to isolate the aggregation logic in tests — it restores
@@ -347,6 +348,23 @@ function Invoke-OrgClaimMatching {
         $repItem = @($items | Sort-Object -Property { $_.Best.Score } -Descending)[0]
         $repProp = if ([string]::IsNullOrWhiteSpace($repItem.Verbatim)) { $repItem.Proposition } else { $repItem.Verbatim }
 
+        # Claim REPRESENTATIONS for the directional gate (CL t/2744#10 / TL t/2756#2):
+        # no single claim field wins across cases, so gate EVERY available rep and
+        # take opposes-if-ANY. Org claims carry two reps — verbatim (text) + canonical.
+        # Verbatim first so the primary rep leads; dedup identical texts to avoid a
+        # redundant NLI call. Recall-safe under opposes-only (a rep that reads
+        # neutral/entailment simply doesn't fire; each opposes is still τ_contra-gated).
+        $repSeen = @{}
+        $repReps = [System.Collections.Generic.List[PSObject]]::new()
+        foreach ($cand in @(
+                @{ Kind = 'verbatim';  Text = [string]$repItem.Verbatim },
+                @{ Kind = 'canonical'; Text = [string]$repItem.Proposition })) {
+            if ([string]::IsNullOrWhiteSpace($cand.Text)) { continue }
+            if ($repSeen.ContainsKey($cand.Text)) { continue }
+            $repSeen[$cand.Text] = $true
+            $repReps.Add([PSCustomObject]@{ Kind = $cand.Kind; Text = $cand.Text })
+        }
+
         # Rationale + source_refs bundle
         $reason = if ($meetsA -and $meetsB) { 'multi-claim-agreement+high-cosine' }
                   elseif ($meetsA) { 'multi-claim-agreement' }
@@ -361,6 +379,7 @@ function Invoke-OrgClaimMatching {
             EdgeType    = $edgeType
             Polarity    = $polarity
             RepProp     = [string]$repProp
+            RepReps     = @($repReps)
             Direction   = 'skipped'
             DirConfidence = $null
             DirMethod   = 'skipped'
@@ -403,6 +422,7 @@ function Invoke-OrgClaimMatching {
             }
         }
 
+        # One gate pair per claim REP (verbatim, canonical) — id "propIdx:repIdx".
         $gatePairs = [System.Collections.Generic.List[PSObject]]::new()
         for ($pi = 0; $pi -lt $proposals.Count; $pi++) {
             $prop = $proposals[$pi]
@@ -410,29 +430,52 @@ function Invoke-OrgClaimMatching {
             $nodeText = if ($nodeTextById.ContainsKey($nid)) { $nodeTextById[$nid] } else { '' }
             $prefix = if ($nid -match '^(acc|saf|skp)-') { $Matches[1] } else { '' }
             $nodePov = if ($prefix -and $povByPrefix.ContainsKey($prefix)) { $povByPrefix[$prefix] } else { '' }
-            $gatePairs.Add([PSCustomObject]@{ Id = $pi; ClaimProp = $prop.RepProp; NodeProp = $nodeText; NodePov = $nodePov })
+            $reps = @($prop.RepReps)
+            for ($ri = 0; $ri -lt $reps.Count; $ri++) {
+                $gatePairs.Add([PSCustomObject]@{ Id = "$($pi):$($ri)"; ClaimProp = [string]$reps[$ri].Text; NodeProp = $nodeText; NodePov = $nodePov })
+            }
         }
 
         $verdicts = Test-DirectionalAgreement -Pair @($gatePairs) -TauContra $DirectionalTauContra
-        $verdictByIdx = @{}
-        foreach ($v in @($verdicts)) { $verdictByIdx[[int]$v.Id] = $v }
+        # Group each proposal's per-rep verdicts by the proposal index.
+        $verdictsByProp = @{}
+        foreach ($v in @($verdicts)) {
+            $pidx = [int]((([string]$v.Id) -split ':')[0])
+            if (-not $verdictsByProp.ContainsKey($pidx)) { $verdictsByProp[$pidx] = [System.Collections.Generic.List[PSObject]]::new() }
+            $verdictsByProp[$pidx].Add($v)
+        }
 
         for ($pi = 0; $pi -lt $proposals.Count; $pi++) {
             $prop = $proposals[$pi]
-            $v = if ($verdictByIdx.ContainsKey($pi)) { $verdictByIdx[$pi] } else { $null }
-            $direction = if ($v) { [string]$v.Direction } else { 'unresolved' }
+            $repVerdicts = if ($verdictsByProp.ContainsKey($pi)) { @($verdictsByProp[$pi]) } else { @() }
+
+            # opposes-if-ANY (CL t/2744#10 / TL t/2756#2): the proposal opposes iff
+            # any claim rep contradicts the node. Otherwise summarize the survivors
+            # (agrees > unrelated > unresolved) for the counts metric. Recall-safe:
+            # each 'opposes' is still τ_contra-gated, so extra reps never false-demote.
+            $opp = @($repVerdicts | Where-Object { $_.Direction -eq 'opposes' })
+            if ($opp.Count -gt 0) {
+                $direction = 'opposes'
+                $decV = @($opp | Sort-Object -Property Confidence -Descending)[0]
+            } elseif (@($repVerdicts | Where-Object { $_.Direction -eq 'agrees' }).Count -gt 0) {
+                $direction = 'agrees';    $decV = @($repVerdicts | Where-Object { $_.Direction -eq 'agrees' })[0]
+            } elseif (@($repVerdicts | Where-Object { $_.Direction -eq 'unrelated' }).Count -gt 0) {
+                $direction = 'unrelated'; $decV = @($repVerdicts | Where-Object { $_.Direction -eq 'unrelated' })[0]
+            } else {
+                $direction = 'unresolved'; $decV = if ($repVerdicts.Count -gt 0) { $repVerdicts[0] } else { $null }
+            }
             $prop.Direction     = $direction
-            $prop.DirConfidence = if ($v) { $v.Confidence } else { 0.0 }
-            $prop.DirMethod     = if ($v) { [string]$v.Method } else { 'none' }
+            $prop.DirConfidence = if ($decV) { $decV.Confidence } else { 0.0 }
+            $prop.DirMethod     = if ($decV) { [string]$decV.Method } else { 'none' }
 
             if ($direction -eq 'opposes') {
                 # Claim asserts ¬(node) → flip the provisional polarity-derived edge.
                 $finalType = if ($prop.EdgeType -eq 'ADVOCATES_FOR') { 'OPPOSES' } else { 'ADVOCATES_FOR' }
                 $directionalFlipped++
-                $prop.Rationale = "$($prop.Rationale) directional_flip=$($prop.EdgeType)->$finalType nli_dir=opposes"
+                $prop.Rationale = "$($prop.Rationale) directional_flip=$($prop.EdgeType)->$finalType nli_dir=opposes reps=$($repVerdicts.Count)"
                 $prop.EdgeType = $finalType
             } else {
-                $prop.Rationale = "$($prop.Rationale) directional_ok nli_dir=$direction"
+                $prop.Rationale = "$($prop.Rationale) directional_ok nli_dir=$direction reps=$($repVerdicts.Count)"
             }
         }
     }

--- a/tests/Invoke-OrgClaimMatching.Tests.ps1
+++ b/tests/Invoke-OrgClaimMatching.Tests.ps1
@@ -572,5 +572,107 @@ Describe 'Invoke-OrgClaimMatching (t/1553 Stages 2+3)' -Tag 'taxonomy' {
                 $script:TaxonomyData.Remove('invtest-pov')
             }
         }
+
+        It 'MULTI-REP OR: an inversion caught by ONLY the canonical rep still flips the edge (opposes-if-any, t/2744#10)' {
+            InModuleScope AITriad -Parameters @{
+                ClaimsPath = $script:claimsPath
+                EmbPath    = $script:invEmbPath
+                VecA       = [double[]]$script:vecA
+            } {
+                param($ClaimsPath, $EmbPath, $VecA)
+
+                @{ claims = @(
+                    [PSCustomObject]@{ org_id='org-014'; source_id='src-mr'; polarity='asserts'
+                        text='VERBATIM rep that reads neutral to the model'
+                        canonical_proposition='CANONICAL rep that contradicts the node'
+                        extraction_confidence=0.9 }
+                ) } | ConvertTo-Json -Depth 5 | Set-Content -Path $ClaimsPath -Encoding utf8NoBOM
+
+                $script:TaxonomyData['invtest-pov'] = [PSCustomObject]@{ nodes = @(
+                    [PSCustomObject]@{ id='acc-intentions-999'; label='N'; description='node text' }
+                )}
+
+                $vecAref = $VecA
+                function python {
+                    process {
+                        $payload = @($input | Out-String | ConvertFrom-Json)
+                        if ($payload.Count -gt 0 -and $payload[0].PSObject.Properties['claim_prop']) {
+                            # verbatim rep → unrelated; canonical rep → opposes. OR must fire.
+                            $out = foreach ($it in $payload) {
+                                $dir = if ([string]$it.claim_prop -match 'CANONICAL') { 'opposes' } else { 'unrelated' }
+                                [pscustomobject]@{ id=$it.id; direction=$dir; confidence=1.4; method='nli' }
+                            }
+                            ConvertTo-Json -InputObject @($out) -Depth 5
+                        } else {
+                            $o = [ordered]@{}
+                            foreach ($it in $payload) { $o[$it.id] = $vecAref }
+                            $o | ConvertTo-Json -Depth 5 -Compress
+                        }
+                    }
+                }
+                Mock Get-OrganizationEdgesStore { [PSCustomObject]@{ edges = @() } }
+
+                $r = Invoke-OrgClaimMatching -ClaimsPath $ClaimsPath -EmbeddingsPath $EmbPath `
+                    -MatchThreshold 0.60 -Verbose:$false 6>$null
+
+                $r.ProposalsWouldEmit        | Should -Be 1
+                $r.Proposals[0].Direction    | Should -Be 'opposes' -Because 'opposes-if-ANY: the canonical rep fires'
+                $r.Proposals[0].EdgeType     | Should -Be 'OPPOSES'
+                $r.DirectionalFlipped        | Should -Be 1
+                $r.DirectionalCounts.opposes | Should -Be 1
+
+                $script:TaxonomyData.Remove('invtest-pov')
+            }
+        }
+
+        It 'MULTI-REP arm-2: genuine agreement across BOTH reps keeps the edge with zero false-opposes (TL binding condition)' {
+            InModuleScope AITriad -Parameters @{
+                ClaimsPath = $script:claimsPath
+                EmbPath    = $script:invEmbPath
+                VecA       = [double[]]$script:vecA
+            } {
+                param($ClaimsPath, $EmbPath, $VecA)
+
+                @{ claims = @(
+                    [PSCustomObject]@{ org_id='org-014'; source_id='src-agree2'; polarity='asserts'
+                        text='VERBATIM rep, genuinely aligned'
+                        canonical_proposition='CANONICAL rep, genuinely aligned'
+                        extraction_confidence=0.9 }
+                ) } | ConvertTo-Json -Depth 5 | Set-Content -Path $ClaimsPath -Encoding utf8NoBOM
+
+                $script:TaxonomyData['invtest-pov'] = [PSCustomObject]@{ nodes = @(
+                    [PSCustomObject]@{ id='acc-intentions-999'; label='N'; description='node text' }
+                )}
+
+                $vecAref = $VecA
+                function python {
+                    process {
+                        $payload = @($input | Out-String | ConvertFrom-Json)
+                        if ($payload.Count -gt 0 -and $payload[0].PSObject.Properties['claim_prop']) {
+                            # Both reps read unrelated (genuine agreement reads 'unrelated' under the gate).
+                            $out = foreach ($it in $payload) {
+                                [pscustomobject]@{ id=$it.id; direction='unrelated'; confidence=0.2; method='nli' }
+                            }
+                            ConvertTo-Json -InputObject @($out) -Depth 5
+                        } else {
+                            $o = [ordered]@{}
+                            foreach ($it in $payload) { $o[$it.id] = $vecAref }
+                            $o | ConvertTo-Json -Depth 5 -Compress
+                        }
+                    }
+                }
+                Mock Get-OrganizationEdgesStore { [PSCustomObject]@{ edges = @() } }
+
+                $r = Invoke-OrgClaimMatching -ClaimsPath $ClaimsPath -EmbeddingsPath $EmbPath `
+                    -MatchThreshold 0.60 -Verbose:$false 6>$null
+
+                $r.ProposalsWouldEmit        | Should -Be 1
+                $r.Proposals[0].EdgeType     | Should -Be 'ADVOCATES_FOR' -Because 'no rep opposes → edge kept'
+                $r.DirectionalFlipped        | Should -Be 0
+                $r.DirectionalCounts.opposes | Should -Be 0 -Because 'zero false-opposes across both reps (TL binding condition)'
+
+                $script:TaxonomyData.Remove('invtest-pov')
+            }
+        }
     }
 }


### PR DESCRIPTION
Inherits the ratified claim-text rule (CL t/2744#10, TL t/2756#2): no single claim field wins across cases, so the consumer runs the gate over EVERY available claim rep and emits opposes-if-ANY. Supersedes t/2752's single-field (verbatim) choice for V1 — org claims carry verbatim (text) + canonical, so V1 now gates each rep (deduped) and flips if any contradicts the node.

Consumer-side OR; engine unchanged (one-pair->one-verdict, per TL). Recall-safe under opposes-only + fail-safe — each opposes is still tau_contra-gated, so extra reps never false-demote.

Both-arms tests: (a) inversion caught by ONLY the canonical rep still flips the edge; (b) TL binding condition — genuine agreement across BOTH reps keeps the edge, zero false-opposes. 12 OrgClaimMatching tests green. Self-cert (single-file consumer change, ratified rule).

Refs t/2759, t/2744, t/2745

🤖 Generated with [Claude Code](https://claude.com/claude-code)