### PR TITLE
feat(embed): -AutoCommit on Update-TaxEmbeddings (t/2753 Fix 1)

### DIFF
--- a/scripts/AITriad/Public/Update-TaxEmbeddings.ps1
+++ b/scripts/AITriad/Public/Update-TaxEmbeddings.ps1
@@ -8,8 +8,16 @@ function Update-TaxEmbeddings {
     .DESCRIPTION
         Calls embed_taxonomy.py generate to rebuild the semantic embeddings
         used by Get-Tax -Similar. Requires Python with sentence-transformers.
+    .PARAMETER AutoCommit
+        On success, git-add + commit taxonomy/Origin/embeddings.json to the DATA repo
+        with a machine-attributed message, so a run never leaves unattributed churn in
+        the shared data checkout (t/2753). Default $true. Pipeline callers that own the
+        broader commit pass -AutoCommit:$false. No-op when the file is unchanged, git is
+        absent, or the data root is not a git work tree (warns, never throws).
     .EXAMPLE
         Update-TaxEmbeddings
+    .EXAMPLE
+        Update-TaxEmbeddings -AutoCommit:$false   # pipeline owns the commit
     .LINK
         Show-AITriadHelp
     .LINK
@@ -26,7 +34,9 @@ function Update-TaxEmbeddings {
         Test-OntologyCompliance
     #>
     [CmdletBinding()]
-    param()
+    param(
+        [switch]$AutoCommit = $true
+    )
 
     Set-StrictMode -Version Latest
     $ErrorActionPreference = 'Stop'
@@ -78,4 +88,43 @@ function Update-TaxEmbeddings {
         return
     }
     Write-Host "Embeddings updated successfully." -ForegroundColor Green
+
+    # ── Auto-commit to the DATA repo (t/2753) ────────────────────────────────
+    # Prevent shared-data-checkout drift: a regen must never leave unattributed
+    # embeddings.json churn in the shared data tree (the t/2750 incident). Commit it
+    # here with machine attribution unless the pipeline owns the broader commit
+    # (-AutoCommit:$false). Narrow staging (embeddings.json only), no-change guard,
+    # and graceful degradation (warn, never throw — the embeddings are already written).
+    if ($AutoCommit) {
+        $DataRoot = Get-DataRoot
+        $EmbFile  = Join-Path (Get-TaxonomyDir) 'embeddings.json'
+        $GitCmd   = Get-Command git -ErrorAction SilentlyContinue
+
+        if (-not $GitCmd) {
+            Write-Warning "Update-TaxEmbeddings: -AutoCommit skipped — git not found on PATH. Commit embeddings.json manually to avoid shared-checkout drift (t/2753)."
+        }
+        elseif (-not $DataRoot -or ((& git -C $DataRoot rev-parse --is-inside-work-tree 2>$null) -ne 'true')) {
+            Write-Warning "Update-TaxEmbeddings: -AutoCommit skipped — data root '$DataRoot' is not a git work tree. Commit embeddings.json manually (t/2753)."
+        }
+        elseif (-not (Test-Path $EmbFile)) {
+            Write-Warning "Update-TaxEmbeddings: -AutoCommit skipped — embeddings.json not found at '$EmbFile'."
+        }
+        else {
+            $Status = (& git -C $DataRoot status --porcelain -- $EmbFile 2>$null) -join "`n"
+            if ([string]::IsNullOrWhiteSpace($Status)) {
+                Write-Host "AutoCommit: embeddings.json unchanged — nothing to commit." -ForegroundColor DarkGray
+            }
+            else {
+                & git -C $DataRoot add -- $EmbFile 2>&1 | Out-Null
+                $CommitMsg = "chore(embed): auto-commit embeddings [Update-TaxEmbeddings]`n`nCo-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>"
+                & git -C $DataRoot commit -m $CommitMsg 2>&1 | Out-Null
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "AutoCommit: committed embeddings.json to '$DataRoot'." -ForegroundColor Green
+                }
+                else {
+                    Write-Warning "Update-TaxEmbeddings: -AutoCommit commit failed (git exit $LASTEXITCODE) — embeddings.json is staged but uncommitted. Finish manually: git -C `"$DataRoot`" commit (t/2753)."
+                }
+            }
+        }
+    }
 }

--- a/tests/Update-TaxEmbeddings.AutoCommit.Tests.ps1
+++ b/tests/Update-TaxEmbeddings.AutoCommit.Tests.ps1
@@ -1,0 +1,114 @@
+# Tag: enrichment (t/2753)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Update-TaxEmbeddings -AutoCommit prevents shared-data-checkout drift (t/2753).
+.DESCRIPTION
+    After a successful regen, -AutoCommit (default $true) git-adds + commits
+    embeddings.json to the DATA repo with machine attribution, so a run never leaves
+    unattributed churn in the shared data tree (t/2750 incident). Uses a real fake
+    embed_taxonomy.py (exit 0) like the t/1653 test, and mocks git / Get-DataRoot /
+    Get-TaxonomyDir to assert the commit logic without touching a real data repo.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Update-TaxEmbeddings -AutoCommit (t/2753)' -Tag 'enrichment' {
+
+    BeforeEach {
+        $py = if (Get-Command python -ErrorAction SilentlyContinue) { 'python' }
+              elseif (Get-Command python3 -ErrorAction SilentlyContinue) { 'python3' } else { $null }
+        $script:HavePython = [bool]$py
+
+        $script:TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("aitriad-t2753-" + [System.Guid]::NewGuid().ToString('N'))
+        $script:CodeScripts = Join-Path $script:TempRoot 'code\scripts'
+        $script:TaxDir      = Join-Path $script:TempRoot 'data\taxonomy\Origin'
+        New-Item -ItemType Directory -Path $script:CodeScripts -Force | Out-Null
+        New-Item -ItemType Directory -Path $script:TaxDir -Force | Out-Null
+        # Success no-op embed script + a real embeddings.json for the Test-Path guard.
+        Set-Content -Path (Join-Path $script:CodeScripts 'embed_taxonomy.py') -Value 'import sys; sys.exit(0)' -Encoding utf8
+        Set-Content -Path (Join-Path $script:TaxDir 'embeddings.json') -Value '{"nodes":{}}' -Encoding utf8
+    }
+
+    AfterEach {
+        Remove-Item -Path $script:TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'commits embeddings.json to the data repo when it changed (default AutoCommit)' {
+        if (-not $script:HavePython) { Set-ItResult -Skipped -Because 'python missing on PATH — AutoCommit guard NOT RUN'; return }
+        InModuleScope AITriad -Parameters @{ Code = (Join-Path $script:TempRoot 'code'); Tax = $script:TaxDir; Data = (Join-Path $script:TempRoot 'data') } {
+            param($Code, $Tax, $Data)
+            $orig = $script:RepoRoot; $script:RepoRoot = $Code
+            try {
+                Mock Get-DataRoot    { $Data }
+                Mock Get-TaxonomyDir { $Tax }
+                # git: repo present, file changed, add/commit succeed.
+                Mock git -MockWith {
+                    $global:LASTEXITCODE = 0
+                    if ($args -contains 'rev-parse') { return 'true' }
+                    if ($args -contains 'status')   { return ' M taxonomy/Origin/embeddings.json' }
+                    return $null
+                }
+                Update-TaxEmbeddings *> $null
+                Should -Invoke git -ParameterFilter { $args -contains 'commit' } -Times 1
+            } finally { $script:RepoRoot = $orig }
+        }
+    }
+
+    It 'does NOT commit when embeddings.json is unchanged (no-change guard)' {
+        if (-not $script:HavePython) { Set-ItResult -Skipped -Because 'python missing'; return }
+        InModuleScope AITriad -Parameters @{ Code = (Join-Path $script:TempRoot 'code'); Tax = $script:TaxDir; Data = (Join-Path $script:TempRoot 'data') } {
+            param($Code, $Tax, $Data)
+            $orig = $script:RepoRoot; $script:RepoRoot = $Code
+            try {
+                Mock Get-DataRoot    { $Data }
+                Mock Get-TaxonomyDir { $Tax }
+                Mock git -MockWith {
+                    $global:LASTEXITCODE = 0
+                    if ($args -contains 'rev-parse') { return 'true' }
+                    if ($args -contains 'status')   { return '' }   # clean → no change
+                    return $null
+                }
+                Update-TaxEmbeddings *> $null
+                Should -Invoke git -ParameterFilter { $args -contains 'commit' } -Times 0 -Because 'a no-op regen must not create an empty commit'
+            } finally { $script:RepoRoot = $orig }
+        }
+    }
+
+    It '-AutoCommit:$false performs no git operations (pipeline owns the commit)' {
+        if (-not $script:HavePython) { Set-ItResult -Skipped -Because 'python missing'; return }
+        InModuleScope AITriad -Parameters @{ Code = (Join-Path $script:TempRoot 'code'); Tax = $script:TaxDir; Data = (Join-Path $script:TempRoot 'data') } {
+            param($Code, $Tax, $Data)
+            $orig = $script:RepoRoot; $script:RepoRoot = $Code
+            try {
+                Mock Get-DataRoot    { $Data }
+                Mock Get-TaxonomyDir { $Tax }
+                Mock git -MockWith { $global:LASTEXITCODE = 0; return 'true' }
+                Update-TaxEmbeddings -AutoCommit:$false *> $null
+                Should -Invoke git -Times 0 -Because 'AutoCommit:$false leaves all git work to the caller'
+            } finally { $script:RepoRoot = $orig }
+        }
+    }
+
+    It 'warns and does not throw when the data root is not a git work tree' {
+        if (-not $script:HavePython) { Set-ItResult -Skipped -Because 'python missing'; return }
+        InModuleScope AITriad -Parameters @{ Code = (Join-Path $script:TempRoot 'code'); Tax = $script:TaxDir; Data = (Join-Path $script:TempRoot 'data') } {
+            param($Code, $Tax, $Data)
+            $orig = $script:RepoRoot; $script:RepoRoot = $Code
+            try {
+                Mock Get-DataRoot    { $Data }
+                Mock Get-TaxonomyDir { $Tax }
+                Mock git -MockWith { $global:LASTEXITCODE = 128; return $null }   # rev-parse fails → not a work tree
+                { Update-TaxEmbeddings *> $null } | Should -Not -Throw
+                Should -Invoke git -ParameterFilter { $args -contains 'commit' } -Times 0
+            } finally { $script:RepoRoot = $orig }
+        }
+    }
+}


### PR DESCRIPTION
## t/2753 Fix 1 (PowerShell scope) — per DevOps design t/2753#1
`Update-TaxEmbeddings` wrote `embeddings.json` and exited with no git op → an abandoned/standalone run left unattributed churn in the shared data checkout (t/2750 incident).

Adds **`-AutoCommit`** (default `$true`): after a successful regen, git-add + commit `taxonomy/Origin/embeddings.json` to the **DATA repo** (resolved via `Get-DataRoot` / `$env:AI_TRIAD_DATA_ROOT`) with `chore(embed): auto-commit embeddings [Update-TaxEmbeddings]` + Orca co-author trailer. Pipeline callers pass `-AutoCommit:$false` (pipeline owns its commit).

**Safety:** narrow staging (embeddings.json only, never `-A`); no-change guard (no empty-commit error); graceful degradation (warn, never throw, when git is absent or the data root isn't a work tree — embeddings are already written).

## Tests — 4/4
commit-on-change · no-change guard · `-AutoCommit:$false` no-op · not-a-git-repo warn. StderrSurface + module suites unaffected. Self-certified (follows t/2753#1; existing-cmdlet switch + tests).

**Scope note:** this is Fix 1 only. **Fix 2** (`workflow-app/src/main/pipeline.ts` restore-on-abort) is DevOps/owner-TBD per the design — not in this PR. t/2753 (DevOps-owned) closes when both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)