### PR TITLE
fix(share): abort in-flight fetch on unmount in PublicOpEdView (t/2755 sibling)

### DIFF
--- a/taxonomy-editor/src/renderer/components/PublicOpEdView.test.tsx
+++ b/taxonomy-editor/src/renderer/components/PublicOpEdView.test.tsx
@@ -125,4 +125,24 @@ describe('PublicOpEdView (t/2728)', () => {
       expect.objectContaining({ type: 'system.error', component: 'PublicOpEdView', level: 'error' }),
     );
   });
+
+  it('aborts the in-flight fetch when the component unmounts (t/2755)', async () => {
+    let resolveResponse!: (r: Response) => void;
+    mockFetch.mockReturnValue(new Promise(res => { resolveResponse = res; }));
+
+    const { unmount } = render(<PublicOpEdView />);
+    await Promise.resolve();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const signal = mockFetch.mock.calls[0][1]?.signal as AbortSignal;
+    expect(signal).toBeDefined();
+    expect(signal.aborted).toBe(false);
+
+    // Regression guard: cleanup must call controller.abort(), not merely
+    // clearTimeout (which would suppress the timer-driven abort).
+    unmount();
+    expect(signal.aborted).toBe(true);
+
+    resolveResponse(fakeResponse({ body: SAMPLE }));
+  });
 });

--- a/taxonomy-editor/src/renderer/components/PublicOpEdView.tsx
+++ b/taxonomy-editor/src/renderer/components/PublicOpEdView.tsx
@@ -131,7 +131,11 @@ export function PublicOpEdView() {
         clearTimeout(timeout);
       }
     })();
-    return () => { cancelled = true; clearTimeout(timeout); };
+    // Abort the in-flight fetch on unmount, not just clear the timer — clearing
+    // the timeout alone suppresses the timer-driven abort, so the request would
+    // otherwise run to completion after the component is gone. The sibling
+    // PublicPovView fix (t/2755) missed this view; same one-line cleanup here.
+    return () => { cancelled = true; clearTimeout(timeout); controller.abort(); };
   }, []);
 
   if (state.status === 'loading') {


### PR DESCRIPTION
## What
The landed t/2755 fix (`5008ace1`) fixed **PublicPovView** but missed its sibling **PublicOpEdView**, which carried the identical bug: the `useEffect` cleanup cleared the timeout but never called `controller.abort()`, so the raw `fetch` runs to completion after unmount (the timer-driven abort is suppressed by the `clearTimeout`; `setState` is already guarded by `cancelled`).

This PR (rebased onto current `main`) adds **only** the one-line cleanup abort to `PublicOpEdView.tsx` plus an unmount-abort regression test mirroring the one now on `main` for PublicPovView.

## Why narrowed
Originally opened covering both views; a parallel effort landed the PublicPovView fix + test on `main` while this was in flight (Claim-Before-Implement miss on my side). Rebased down to the non-duplicate sibling fix.

## Tests
`vitest run src/renderer/components/PublicOpEdView.test.tsx` → **8 passed** (incl. new unmount-abort guard).

Completes t/2755 (sibling coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)