### PR TITLE
chore(obs): add invalid-child keys + bad-session-title ids to FR crash dump (t/2732)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/__tests__/flightRecorderReactError.test.ts
+++ b/taxonomy-editor/src/renderer/lib/__tests__/flightRecorderReactError.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { RecordInput } from '@lib/flight-recorder/types';
 
 /**
@@ -140,5 +140,76 @@ describe('dumpOnReactError — externalized-module attribution (t/2551 observabi
     expect(h.fakeRecorder.record).toHaveBeenCalledTimes(1);
     const data = (h.recordCalls[0].data ?? {}) as Record<string, unknown>;
     expect(data.externalized_module).toBeUndefined();
+  });
+});
+
+/**
+ * Observability arm for t/2732: an "invalid React child" crash (rendering a
+ * non-primitive, e.g. a bad session-index entry — the t/2729 BulkDeleteDialog crash)
+ * must name the offending object's keys in `invalid_react_child_keys`, and the store
+ * snapshot must surface the ids of any debate session whose `title` is non-string
+ * (the index-shape defect class) in `debate_sessions_non_string_title_ids`.
+ */
+describe('dumpOnReactError — invalid-child + bad-session attribution (t/2732 observability)', () => {
+  beforeEach(() => {
+    h.recordCalls.length = 0;
+    h.fakeRecorder.record.mockClear();
+    h.dumpFlightRecorder.mockClear();
+    h.reportError.mockClear();
+  });
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__ZUSTAND_STORES__;
+  });
+
+  it('records invalid_react_child_keys parsed from the React error message', async () => {
+    const { dumpOnReactError } = await import('../flightRecorderInit');
+
+    // The exact message React throws when a non-primitive is rendered as a child —
+    // the shape t/2729's BulkDeleteDialog crash produced ({final, original}).
+    const err = new Error(
+      'Objects are not valid as a React child (found: object with keys {final, original}). ' +
+      'If you meant to render a collection of children, use an array instead.',
+    );
+
+    dumpOnReactError(err, '\n    at BulkDeleteDialog\n    at DebateTab');
+
+    expect(h.fakeRecorder.record).toHaveBeenCalledTimes(1);
+    const data = h.recordCalls[0].data as Record<string, unknown>;
+    expect(data.invalid_react_child_keys).toEqual(['final', 'original']);
+  });
+
+  it('omits invalid_react_child_keys for an ordinary crash', async () => {
+    const { dumpOnReactError } = await import('../flightRecorderInit');
+
+    dumpOnReactError(new Error('boom'), undefined);
+
+    expect(h.fakeRecorder.record).toHaveBeenCalledTimes(1);
+    const data = (h.recordCalls[0].data ?? {}) as Record<string, unknown>;
+    expect(data.invalid_react_child_keys).toBeUndefined();
+  });
+
+  it('surfaces non-string-title session ids in the crash state snapshot', async () => {
+    // Stub the zustand stores getStores() reads, with one well-typed and one
+    // malformed session title (the bad index-entry class).
+    (window as unknown as Record<string, unknown>).__ZUSTAND_STORES__ = {
+      debate: {
+        getState: () => ({
+          sessions: [
+            { id: 'good-1', title: 'A normal debate' },
+            { id: 'bad-1', title: { final: 'x', original: 'y' } },
+            { id: 'bad-2', title: 42 },
+          ],
+        }),
+      },
+      taxonomy: { getState: () => ({}) },
+    };
+
+    const { dumpOnReactError } = await import('../flightRecorderInit');
+    dumpOnReactError(new Error('boom'), undefined);
+
+    expect(h.fakeRecorder.record).toHaveBeenCalledTimes(1);
+    const data = h.recordCalls[0].data as Record<string, unknown>;
+    const snapshot = data.state_snapshot as Record<string, unknown>;
+    expect(snapshot.debate_sessions_non_string_title_ids).toEqual(['bad-1', 'bad-2']);
   });
 });

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -971,6 +971,16 @@ function snapshotStoresForCrash(): Record<string, unknown> | undefined {
     const taxState = (stores.useTaxonomyStore as { getState: () => Record<string, unknown> }).getState();
     const debateState = (stores.useDebateStore as { getState: () => Record<string, unknown> }).getState();
     const debate = debateState.activeDebate as Record<string, unknown> | null;
+    // Session index-shape audit (t/2732): a session whose `title` is not a string
+    // is the class of bad index entry that crashed BulkDeleteDialog (t/2729 —
+    // rendered `{final, original}` as a React child). Surfacing the offending
+    // session ids here cuts diagnosis from reading `listDebateSessionsIndexed`
+    // end-to-end to a glance at the dump. Empty when every title is well-typed.
+    const sessions = debateState.sessions as Array<{ id?: string; title?: unknown }> | undefined;
+    const badSessionTitleIds = (sessions ?? [])
+      .filter(s => typeof s?.title !== 'string')
+      .map(s => s?.id)
+      .filter((id): id is string => typeof id === 'string');
     return {
       active_tab: taxState.activeTab ?? null,
       toolbar_panel: taxState.toolbarPanel ?? null,
@@ -980,6 +990,7 @@ function snapshotStoresForCrash(): Record<string, unknown> | undefined {
       debate_phase: debate?.phase ?? null,
       debate_generating: !!debateState.debateGenerating,
       dirty_files: [...((taxState.dirty as Set<string>) ?? [])],
+      ...(badSessionTitleIds.length > 0 ? { debate_sessions_non_string_title_ids: badSessionTitleIds } : {}),
     };
   } catch {
     /* flight recorder init — silent by design (store may be corrupted) */
@@ -1006,6 +1017,20 @@ function extractExternalizedModule(error: Error): { module: string; accessed?: s
 }
 
 /**
+ * A React "invalid child" crash — rendering a non-primitive where a child is
+ * expected — throws with a message like `Objects are not valid as a React child
+ * (found: object with keys {final, original})`. Surface those keys as a first-class
+ * dump field so the NEXT such crash names the offending shape instead of requiring a
+ * human to read the producing code path (t/2732; the BulkDeleteDialog index-shape
+ * crash, t/2729). Mirrors the extractExternalizedModule pattern above. Returns
+ * undefined for ordinary errors.
+ */
+function extractInvalidReactChildKeys(error: Error): string[] | undefined {
+  const m = /found: object with keys \{([^}]+)\}/.exec(String(error?.message ?? ''));
+  return m ? m[1].split(',').map(k => k.trim()).filter(Boolean) : undefined;
+}
+
+/**
  * Called from ErrorBoundary.componentDidCatch to dump on React render errors.
  */
 export function dumpOnReactError(
@@ -1020,11 +1045,13 @@ export function dumpOnReactError(
 
   const stateSnapshot = snapshotStoresForCrash();
   const externalizedModule = extractExternalizedModule(error);
+  const invalidReactChildKeys = extractInvalidReactChildKeys(error);
 
   const baseData: Record<string, unknown> = {
     ...(componentStack ? { component_stack: componentStack.slice(0, 1000) } : {}),
     ...(stateSnapshot ? { state_snapshot: stateSnapshot } : {}),
     ...(externalizedModule ? { externalized_module: externalizedModule } : {}),
+    ...(invalidReactChildKeys ? { invalid_react_child_keys: invalidReactChildKeys } : {}),
   };
 
   // Record the crash SYNCHRONOUSLY, before any async work (t/2297). This guarantees


### PR DESCRIPTION
## What
Two observability fields added to the `react-error-boundary` `system.error` flight-recorder event so the next index-shape crash (class of t/2729 BulkDeleteDialog) is diagnosable at a glance instead of requiring an end-to-end read of `listDebateSessionsIndexed`:

- **`invalid_react_child_keys`** — parsed from React's `Objects are not valid as a React child (found: object with keys {…})` message. Mirrors the existing `extractExternalizedModule` helper pattern.
- **`debate_sessions_non_string_title_ids`** — store-snapshot audit of debate sessions whose `title` is non-string (the bad index-entry class). Added to `snapshotStoresForCrash`.

Both fields are **omitted when absent** — no behavioral change, no new dump noise on ordinary crashes.

## Design provenance
Per Diagnostics' corrected design review (t/2732#1): the original ticket proposed `offending_session_ids` from `selectedIds`, but `selectedIds` is component-local `useState` in `BulkDeleteDialog`, not store state — unreachable from `snapshotStoresForCrash`. The audit therefore keys on **session title-type** in the store snapshot, which is what actually crashed.

## Tests (`/add-test`)
Extended `flightRecorderReactError.test.ts` with a t/2732 observability block:
- `invalid_react_child_keys` populated for an invalid-child crash; omitted for an ordinary crash.
- `debate_sessions_non_string_title_ids` surfaces the bad session ids from a stubbed store snapshot.
- `vitest run`: **7 passed**. Changed files type-clean (the only tsc errors are pre-existing missing-type-decls in `lib/sanitize`, untouched here); `eslint` 0 errors.

Closes t/2732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)