### PR TITLE
feat(workflow-app): restore embeddings.json on abort/quit (t/2753 Fix 2)

### DIFF
--- a/workflow-app/src/main/ipcHandlers.ts
+++ b/workflow-app/src/main/ipcHandlers.ts
@@ -8,6 +8,7 @@ import {
   listProposalFiles,
   readProposalFile,
   getDataRoot,
+  restoreEmbeddingsIfAbandoned,
 } from './pipeline';
 
 export function registerIpcHandlers(getWindow: () => BrowserWindow | null): void {
@@ -28,6 +29,10 @@ export function registerIpcHandlers(getWindow: () => BrowserWindow | null): void
 
   ipcMain.handle('cancel-step', () => {
     cancelStep();
+  });
+
+  ipcMain.handle('restore-embeddings-if-abandoned', () => {
+    return restoreEmbeddingsIfAbandoned();
   });
 
   ipcMain.handle('get-git-status', () => {

--- a/workflow-app/src/main/main.ts
+++ b/workflow-app/src/main/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, Menu } from 'electron';
 import path from 'path';
 import { registerIpcHandlers } from './ipcHandlers';
+import { restoreEmbeddingsIfAbandoned } from './pipeline';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -77,6 +78,10 @@ process.on('unhandledRejection', (reason) => {
 app.whenReady().then(() => {
   registerIpcHandlers(() => mainWindow);
   createWindow();
+});
+
+app.on('before-quit', () => {
+  restoreEmbeddingsIfAbandoned();
 });
 
 app.on('window-all-closed', () => {

--- a/workflow-app/src/main/pipeline.ts
+++ b/workflow-app/src/main/pipeline.ts
@@ -284,7 +284,7 @@ function buildPsCommand(stepId: string, config: Record<string, unknown>): string
     case 'backfill':
       return `${moduleImport}; Repair-ResolvedBackfill -Verbose`;
     case 'embeddings':
-      return `${moduleImport}; Update-TaxEmbeddings -Verbose`;
+      return `${moduleImport}; Update-TaxEmbeddings -AutoCommit:$false -Verbose`;
     case 'edges':
       return `${moduleImport}; Invoke-EdgeDiscovery -Verbose`;
     case 'attributes':
@@ -306,12 +306,56 @@ function buildPsCommand(stepId: string, config: Record<string, unknown>): string
 
 let activeProcess: ChildProcess | null = null;
 
+// Tracks whether embeddings.json was written this pipeline run without a
+// following git-commit. Used to auto-restore on abort/quit (t/2753 Fix 2).
+let embeddingsWritten = false;
+let gitCommitAttempted = false;
+let gitCommitDone = false;
+
+export function resetPipelineState(): void {
+  embeddingsWritten = false;
+  gitCommitAttempted = false;
+  gitCommitDone = false;
+}
+
+/**
+ * Restores embeddings.json to HEAD in the data repo if the embeddings step
+ * completed but git-commit was never attempted. Call on pipeline cancel/app quit.
+ * Does nothing if git-commit was attempted (user should retry commit, not lose data).
+ * Never throws.
+ */
+export function restoreEmbeddingsIfAbandoned(): boolean {
+  if (!embeddingsWritten || gitCommitAttempted) return false;
+  try {
+    const { execSync } = require('child_process') as typeof import('child_process');
+    const dataRoot = getDataRoot();
+    execSync('git restore taxonomy/Origin/embeddings.json', { cwd: dataRoot });
+    console.warn('[pipeline] restoreEmbeddingsIfAbandoned: restored embeddings.json to HEAD (embeddings ran, git-commit never attempted)');
+    embeddingsWritten = false;
+    return true;
+  } catch (err) {
+    console.warn('[pipeline] restoreEmbeddingsIfAbandoned: git restore failed (may already be clean):', err);
+    return false;
+  }
+}
+
 export function runStep(
   stepId: string,
   config: Record<string, unknown>,
   onData: (text: string) => void,
   onError: (text: string) => void,
 ): Promise<{ exitCode: number }> {
+  // Reset state at the start of a fresh embeddings run so prior abandoned state
+  // doesn't carry over when the user reruns embeddings without committing.
+  if (stepId === 'embeddings') {
+    embeddingsWritten = false;
+    gitCommitAttempted = false;
+    gitCommitDone = false;
+  }
+  if (stepId === 'git-commit') {
+    gitCommitAttempted = true;
+  }
+
   return new Promise((resolve, reject) => {
     try {
       const psCommand = buildPsCommand(stepId, config);
@@ -344,7 +388,10 @@ export function runStep(
 
       child.on('close', (code) => {
         activeProcess = null;
-        resolve({ exitCode: code ?? 1 });
+        const exitCode = code ?? 1;
+        if (stepId === 'embeddings' && exitCode === 0) embeddingsWritten = true;
+        if (stepId === 'git-commit' && exitCode === 0) gitCommitDone = true;
+        resolve({ exitCode });
       });
 
       child.on('error', (err) => {

--- a/workflow-app/src/main/preload.ts
+++ b/workflow-app/src/main/preload.ts
@@ -10,6 +10,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   cancelStep: (): Promise<void> =>
     ipcRenderer.invoke('cancel-step'),
 
+  restoreEmbeddingsIfAbandoned: (): Promise<boolean> =>
+    ipcRenderer.invoke('restore-embeddings-if-abandoned'),
+
   getGitStatus: (): Promise<{ summary: string; hasChanges: boolean }> =>
     ipcRenderer.invoke('get-git-status'),
 


### PR DESCRIPTION
## Summary

- Adds three-flag state machine (`embeddingsWritten`, `gitCommitAttempted`, `gitCommitDone`) to `pipeline.ts` to track progress across the embeddings → git-commit boundary
- `restoreEmbeddingsIfAbandoned()` runs `git restore taxonomy/Origin/embeddings.json` in the data repo when embeddings wrote but git-commit was never attempted — covering cancel, error, and app-quit cases
- Does NOT restore if git-commit was attempted (user should retry commit, not lose their run)
- Wired to `app.before-quit` in `main.ts` and exposed as `restore-embeddings-if-abandoned` IPC handle via `preload.ts` for renderer-triggered cleanup
- Adds `-AutoCommit:$false` to the pipeline's `Update-TaxEmbeddings` call so the pipeline's `git-commit` step retains ownership (standalone use defaults `$true` per Fix 1 / PR #1195)

Fix 2 of 2 for t/2753. Closes t/2753 when merged (Fix 1 already landed in PR #1195).

## Test plan

- [ ] Run pipeline through embeddings step, cancel before git-commit — confirm `git status` on data repo is clean after cancellation
- [ ] Run pipeline through embeddings + git-commit — confirm no spurious restore
- [ ] Close app window after embeddings step without committing — confirm embeddings.json restored to HEAD on next launch check
- [ ] Run embeddings standalone (outside pipeline) — confirm `-AutoCommit:$true` still fires (PS cmdlet default unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)