### PR TITLE
feat(oped): render document_claims sub-children in GroundingDetailCard (t/2717)

### DIFF
--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
@@ -272,6 +272,24 @@
   color: var(--text-primary);
 }
 
+.oped-grounding-card-claims {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.6rem;
+}
+
+.oped-grounding-card-claims-label {
+  font-weight: 600;
+  color: var(--text-primary);
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.oped-grounding-card-claims-list {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
 .oped-grounding-card-empty {
   color: var(--text-muted);
   font-size: 0.85rem;

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { OpEdReader } from './OpEdReader';
 import type { OpEdSet, OpEdMember } from '../../../../../lib/oped/types';
@@ -32,6 +32,10 @@ function makeSet(members: OpEdMember[], overrides: Partial<OpEdSet> = {}): OpEdS
 }
 
 describe('OpEdReader — single voice', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
   it('renders no tab strip and the headline as the sole h1', () => {
     render(<OpEdReader set={makeSet([member()])} />);
     expect(screen.queryByRole('tablist')).toBeNull();
@@ -85,6 +89,24 @@ describe('OpEdReader — single voice', () => {
       grounding: [{ node_id: 'saf-belief-014', label: 'Used', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim' }],
     })])} />);
     expect(screen.queryByRole('button', { name: /unused element/i })).toBeNull();
+  });
+
+  it('renders document_claims list in the detail card when present (t/2717)', () => {
+    render(<OpEdReader set={makeSet([member({
+      grounding: [{ node_id: 'saf-belief-014', label: 'A belief', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim', document_claims: ['Safety incidents doubled last year', 'Only 3 labs share proactively'] }],
+    })])} />);
+    fireEvent.click(screen.getByRole('button', { name: 'saf-belief-014' }));
+    expect(screen.getByText('Addresses these source claims:')).toBeTruthy();
+    expect(screen.getByText('Safety incidents doubled last year')).toBeTruthy();
+    expect(screen.getByText('Only 3 labs share proactively')).toBeTruthy();
+  });
+
+  it('renders nothing for document_claims when absent (t/2717)', () => {
+    render(<OpEdReader set={makeSet([member({
+      grounding: [{ node_id: 'saf-belief-014', label: 'A belief', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim' }],
+    })])} />);
+    fireEvent.click(screen.getByRole('button', { name: 'saf-belief-014' }));
+    expect(screen.queryByText('Addresses these source claims:')).toBeNull();
   });
 });
 

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -79,6 +79,14 @@ function GroundingDetailCard({ ref, onClose }: { ref: OpEdGroundingRef; onClose:
           <span className="oped-grounding-card-reflected-label">Reflected in this op-ed:</span> {ref.how_reflected}
         </div>
       )}
+      {ref.document_claims && ref.document_claims.length > 0 && (
+        <div className="oped-grounding-card-claims">
+          <span className="oped-grounding-card-claims-label">Addresses these source claims:</span>
+          <ul className="oped-grounding-card-claims-list">
+            {ref.document_claims.map((c, i) => <li key={i}>{c}</li>)}
+          </ul>
+        </div>
+      )}
       {body}
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds source-claim sub-children to `GroundingDetailCard` in `OpEdReader.tsx`: when a grounding ref has `document_claims[]`, an "Addresses these source claims:" label and bulleted list appear after the `how_reflected` block
- Adds three CSS classes to `OpEdReader.css` mirroring the existing `oped-grounding-card-reflected` token style
- Adds two vitest cases (claims list renders; absent → nothing rendered); stubs `scrollIntoView` for jsdom

## Test plan

- [ ] 15/15 OpEdReader tests pass locally
- [ ] CI green on this head before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)