### PR TITLE
feat(chat): always-visible New button + auto-select most-recent chat on open (t/2760)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
@@ -299,11 +299,9 @@ function SessionListPanel({
       <div className="list-panel-header">
         <h2>Chats</h2>
         <div className="list-panel-header-actions">
-          {listView === 'my' && (
-            <button className="btn btn-sm" onClick={() => setShowNewDialog(true)}>
-              + New
-            </button>
-          )}
+          <button className="btn btn-sm" onClick={() => { setShowNewDialog(true); setListView('my'); }}>
+            + New
+          </button>
           <button className="pane-collapse-btn" onClick={() => setListCollapsed(true)} title="Collapse" aria-label="Collapse panel">&lsaquo;</button>
         </div>
       </div>
@@ -455,6 +453,25 @@ export function ChatTab() {
     if (sessionsLoading) return;
     setListView(sessions.length > 0 ? 'my' : 'community');
   }, [listView, sessionsLoading, sessions.length]);
+
+  // Auto-select the most-recent chat into pane 2 on first open (t/2760).
+  // Suppressed on phone: the phone layout is list-first and the user initiates detail view by tapping.
+  useEffect(() => {
+    if (isPhone) return;
+    if (activeChatId || selectedCommunityChat) return;
+    if (sessionsLoading || communityLoading) return;
+    if (sessions.length > 0) {
+      const newest = [...sessions].sort((a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      )[0];
+      void loadChat(newest.id);
+    } else if (communityChats.length > 0) {
+      const newest = [...communityChats].sort((a, b) =>
+        new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      )[0];
+      setSelectedCommunityChat(newest);
+    }
+  }, [isPhone, activeChatId, selectedCommunityChat, sessionsLoading, communityLoading, sessions, communityChats, loadChat]);
 
   const handleSelect = (session: ChatSessionSummary) => {
     if (session.id !== activeChatId) {

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
@@ -272,6 +272,24 @@
   color: var(--text-primary);
 }
 
+.oped-grounding-card-claims {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.6rem;
+}
+
+.oped-grounding-card-claims-label {
+  font-weight: 600;
+  color: var(--text-primary);
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.oped-grounding-card-claims-list {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
 .oped-grounding-card-empty {
   color: var(--text-muted);
   font-size: 0.85rem;

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { OpEdReader } from './OpEdReader';
 import type { OpEdSet, OpEdMember } from '../../../../../lib/oped/types';
@@ -32,6 +32,10 @@ function makeSet(members: OpEdMember[], overrides: Partial<OpEdSet> = {}): OpEdS
 }
 
 describe('OpEdReader — single voice', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
   it('renders no tab strip and the headline as the sole h1', () => {
     render(<OpEdReader set={makeSet([member()])} />);
     expect(screen.queryByRole('tablist')).toBeNull();
@@ -85,6 +89,24 @@ describe('OpEdReader — single voice', () => {
       grounding: [{ node_id: 'saf-belief-014', label: 'Used', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim' }],
     })])} />);
     expect(screen.queryByRole('button', { name: /unused element/i })).toBeNull();
+  });
+
+  it('renders document_claims list in the detail card when present (t/2717)', () => {
+    render(<OpEdReader set={makeSet([member({
+      grounding: [{ node_id: 'saf-belief-014', label: 'A belief', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim', document_claims: ['Safety incidents doubled last year', 'Only 3 labs share proactively'] }],
+    })])} />);
+    fireEvent.click(screen.getByRole('button', { name: 'saf-belief-014' }));
+    expect(screen.getByText('Addresses these source claims:')).toBeTruthy();
+    expect(screen.getByText('Safety incidents doubled last year')).toBeTruthy();
+    expect(screen.getByText('Only 3 labs share proactively')).toBeTruthy();
+  });
+
+  it('renders nothing for document_claims when absent (t/2717)', () => {
+    render(<OpEdReader set={makeSet([member({
+      grounding: [{ node_id: 'saf-belief-014', label: 'A belief', category: 'Belief', pov: 'safetyist', relevance: '0.82', how_reflected: 'Grounds the claim' }],
+    })])} />);
+    fireEvent.click(screen.getByRole('button', { name: 'saf-belief-014' }));
+    expect(screen.queryByText('Addresses these source claims:')).toBeNull();
   });
 });
 

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -79,6 +79,14 @@ function GroundingDetailCard({ ref, onClose }: { ref: OpEdGroundingRef; onClose:
           <span className="oped-grounding-card-reflected-label">Reflected in this op-ed:</span> {ref.how_reflected}
         </div>
       )}
+      {ref.document_claims && ref.document_claims.length > 0 && (
+        <div className="oped-grounding-card-claims">
+          <span className="oped-grounding-card-claims-label">Addresses these source claims:</span>
+          <ul className="oped-grounding-card-claims-list">
+            {ref.document_claims.map((c, i) => <li key={i}>{c}</li>)}
+          </ul>
+        </div>
+      )}
       {body}
     </div>
   );


### PR DESCRIPTION
## Summary

- **Fix 1**: Removes the `listView === 'my'` guard on `+ New` so the button appears on both My and Community tabs. Click also calls `setListView('my')` so the created chat lands in a visible list.
- **Fix 2**: One-shot `useEffect` after loading completes auto-selects the most-recent chat (by `updated_at` desc) into pane 2. Prefers most-recent My chat; falls back to most-recent Community chat. Guards against: `isPhone`, `activeChatId` already set, `selectedCommunityChat` set, either loading flag true.
- **Phone gating**: auto-select suppressed on `isPhone` — mobile is list-first and the user initiates detail view by tapping (deviation noted in t/2760#1).

## Test plan

- [ ] CI green on this head before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)