### PR TITLE
docs(debate): ActionableError innerError-chaining and UI display JSDoc conventions (t/2762)

### DIFF
--- a/lib/debate/errors.ts
+++ b/lib/debate/errors.ts
@@ -4,6 +4,17 @@
 /**
  * Standardized actionable error for humans and AI agents.
  * Every error must state: goal, problem, location, and next steps.
+ *
+ * ## Convention: re-wrapping a caught error
+ * Pass the original as `innerError`; never copy a caught error's `.message`
+ * into `problem`. Write a fresh one-line `problem` for this layer's context.
+ * When you need the inner text inline:
+ *   `err instanceof ActionableError ? err.problem : errorMessage(err)`
+ * Never use `.message` directly — it is the multi-line formatted block.
+ *
+ * ## Convention: user-facing display
+ * UI code never renders `.message`. Use `mapErrorToUserMessage(err)`
+ * (renderer/utils/errorMessages.ts), which already prefers `.problem`.
  */
 export class ActionableError extends Error {
   public readonly goal: string;


### PR DESCRIPTION
## Summary
- Adds a JSDoc convention block to `ActionableError` in `lib/debate/errors.ts`
- Documents two rules: (1) re-wrap caught errors via `innerError`, never nest `.message` in `problem`; (2) UI uses `mapErrorToUserMessage()`, never `.message`
- No behavior change; comments only

## Test plan
- [ ] `npx vitest run` in `lib/debate` — no regressions in debate test suite
- [ ] CI green

Self-certified under /trivial-change (JSDoc-only, single file in scope, no exports changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)