### PR TITLE
feat(cmdlet): Get-ServerLog — ACA server log retrieval by requestId (t/2765)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -123,6 +123,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-DebateIndexHealth` | Scan the aggregated `.debate-index.json` for type-invalid entries (object-as-title etc.); `-Repair` deletes bad entries for re-extraction on next launch (t/2735) |
 | `Test-DebatePersistence` | Pre-flight atomic write+rename probe for the debates output dir — call before AI generation to surface LOCKED/NO_PERMISSION early (t/2545) |
 | `Get-ContainerAppRevision` | Query ACA revisions by mode (Active/Stale/Fqdn) — replaces raw `az containerapp revision` calls (t/1498) |
+| `Get-ServerLog` | Retrieve + filter ACA server logs, correlate by Pino requestId — `-RequestId`/`-Recent`/`-StartTime`/`-Pattern` sets, `-Level`/`-Component`/`-Follow`/`-Raw` (t/2765) |
 | `New-ContainerAppRevision` | Blue-green: deploy a new ACA revision at 0% traffic; returns real `RevisionName` for the promotion chain (t/1500 Phase 3) |
 | `Set-ContainerAppTraffic` | Shift traffic to a named revision with retry — call BEFORE `Disable-ContainerAppRevision` in rollback (t/1500 Phase 3) |
 | `Disable-ContainerAppRevision` | Deactivate an ACA revision (stale cleanup or rollback tail); non-fatal on failure — matches deploy YAML's `\|\| true` semantics (t/1500 Phase 3) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -224,6 +224,8 @@
         'Test-DebateSession'
         # t/2545 — Pre-flight atomic write+rename probe for debate output dir
         'Test-DebatePersistence'
+        # t/2765 — ACA server log retrieval with requestId correlation
+        'Get-ServerLog'
     )
 
     # Aliases exported from this module

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -948,6 +948,8 @@ Export-ModuleMember -Function @(
     'New-OpEd'
     # Fetch + convert + validate a source URL for op-ed generation (once per URL)
     'Get-OpEdSource'
+    # t/2765 — ACA server log retrieval with requestId correlation
+    'Get-ServerLog'
 ) -Alias @(
     'Import-Document'
     'TaxonomyEditor'

--- a/scripts/AITriad/Public/Get-ServerLog.ps1
+++ b/scripts/AITriad/Public/Get-ServerLog.ps1
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-ServerLog {
+    <#
+    .SYNOPSIS
+        Retrieve and filter Azure Container App server logs by Pino requestId.
+    .DESCRIPTION
+        Pulls container-app logs via `az containerapp logs show`, unwraps the ACA
+        `{Log,TimeStamp}` envelope, parses the Pino JSON, and filters/correlates by
+        requestId, component, level, pattern, or time. The primary use is tracing a
+        single request end-to-end from a flight-recorder requestId (t/2761/t/2763).
+
+        Requires the az CLI logged in with access to the container app. No AI calls.
+    .PARAMETER RequestId
+        (ByRequestId) Trace one request end-to-end. Default -Tail 5000.
+    .PARAMETER StartTime
+        (ByTimeRange) Lower bound of the post-mortem window (UTC-compared).
+    .PARAMETER EndTime
+        (ByTimeRange) Upper bound. Defaults to now (UTC) when omitted.
+    .PARAMETER Follow
+        (Recent/Search) Stream logs live instead of a batch capture.
+    .PARAMETER Tail
+        Number of log lines to request from ACA. 0 = per-set default
+        (Recent 100, ByRequestId 5000, ByTimeRange 10000, Search 1000).
+    .PARAMETER Component
+        Filter to a single Pino `component`.
+    .PARAMETER Level
+        Filter to one or more Pino levels (trace/debug/info/warn/error/fatal).
+    .PARAMETER Pattern
+        (Search: mandatory; other sets: optional) Regex matched against the Pino line.
+    .PARAMETER ResourceGroup
+        Azure resource group. Default 'ai-triad'.
+    .PARAMETER AppName
+        Container app name. Default 'taxonomy-editor'.
+    .PARAMETER Revision
+        Restrict to a specific revision.
+    .PARAMETER Raw
+        Emit the raw Pino JSON string per line instead of a structured object.
+    .OUTPUTS
+        [PSCustomObject] with Time, Level, Component, RequestId, Message, Raw
+        (or raw JSON strings with -Raw).
+    .EXAMPLE
+        Get-ServerLog -RequestId a2451012-e019-426c-8541-17e541a594bc
+    .EXAMPLE
+        Get-ServerLog -Level error -Tail 500
+    .EXAMPLE
+        Get-ServerLog -StartTime (Get-Date).AddHours(-2) -Component ai
+    .EXAMPLE
+        Get-ServerLog -Pattern 'GEMINI|quota' -Level warn,error
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Test-AzureHealth
+    .LINK
+        Get-ContainerAppRevision
+    .LINK
+        Get-AzureFlightRecorder
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Recent')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'ByRequestId', Position = 0)]
+        [string]$RequestId,
+
+        [Parameter(Mandatory, ParameterSetName = 'ByTimeRange')]
+        [datetime]$StartTime,
+
+        [Parameter(ParameterSetName = 'ByTimeRange')]
+        [datetime]$EndTime,
+
+        [Parameter(ParameterSetName = 'Recent')]
+        [Parameter(ParameterSetName = 'Search')]
+        [switch]$Follow,
+
+        [Parameter(ParameterSetName = 'Recent')]
+        [Parameter(ParameterSetName = 'ByRequestId')]
+        [Parameter(ParameterSetName = 'ByTimeRange')]
+        [Parameter(ParameterSetName = 'Search')]
+        [ValidateRange(1, 100000)]
+        [int]$Tail = 0,
+
+        [Parameter(ParameterSetName = 'Recent')]
+        [Parameter(ParameterSetName = 'ByRequestId')]
+        [Parameter(ParameterSetName = 'ByTimeRange')]
+        [Parameter(ParameterSetName = 'Search')]
+        [string]$Component,
+
+        [Parameter(ParameterSetName = 'Recent')]
+        [Parameter(ParameterSetName = 'ByRequestId')]
+        [Parameter(ParameterSetName = 'ByTimeRange')]
+        [Parameter(ParameterSetName = 'Search')]
+        [ValidateSet('trace', 'debug', 'info', 'warn', 'error', 'fatal')]
+        [string[]]$Level,
+
+        [Parameter(Mandatory, ParameterSetName = 'Search')]
+        [Parameter(ParameterSetName = 'Recent')]
+        [Parameter(ParameterSetName = 'ByRequestId')]
+        [Parameter(ParameterSetName = 'ByTimeRange')]
+        [string]$Pattern,
+
+        [Parameter()]
+        [string]$ResourceGroup = 'ai-triad',
+
+        [Parameter()]
+        [string]$AppName = 'taxonomy-editor',
+
+        [Parameter()]
+        [string]$Revision,
+
+        [Parameter()]
+        [switch]$Raw
+    )
+
+    begin {
+        Set-StrictMode -Version Latest
+
+        $pinoLevelMap   = @{ 10 = 'trace'; 20 = 'debug'; 30 = 'info'; 40 = 'warn'; 50 = 'error'; 60 = 'fatal' }
+        $pinoLevelToNum = @{ 'trace' = 10; 'debug' = 20; 'info' = 30; 'warn' = 40; 'error' = 50; 'fatal' = 60 }
+
+        if ($PSCmdlet.ParameterSetName -eq 'ByTimeRange' -and -not $PSBoundParameters.ContainsKey('EndTime')) {
+            $EndTime = [datetime]::UtcNow
+        }
+
+        $effectiveTail = switch ($PSCmdlet.ParameterSetName) {
+            'Recent'      { if ($Tail -gt 0) { $Tail } else { 100 } }
+            'ByRequestId' { if ($Tail -gt 0) { $Tail } else { 5000 } }
+            'ByTimeRange' { if ($Tail -gt 0) { $Tail } else { 10000 } }
+            'Search'      { if ($Tail -gt 0) { $Tail } else { 1000 } }
+            default       { if ($Tail -gt 0) { $Tail } else { 100 } }
+        }
+
+        $levelNums = if ($Level) { [int[]]@($Level | ForEach-Object { $pinoLevelToNum[$_] }) } else { $null }
+
+        $azArgs = @('containerapp', 'logs', 'show', '--name', $AppName, '--resource-group', $ResourceGroup, '--format', 'json')
+        if ($Revision) { $azArgs += @('--revision', $Revision) }
+
+        $isFollow = $Follow.IsPresent -and $PSCmdlet.ParameterSetName -in @('Recent', 'Search')
+        if ($isFollow) { $azArgs += @('--follow', '--tail', $effectiveTail) }
+        else           { $azArgs += @('--tail', $effectiveTail) }
+
+        Write-Verbose "az $($azArgs -join ' ')"
+
+        # StrictMode-safe field read from a ConvertFrom-Json object: absent property
+        # returns $null instead of throwing (project convention — powershell-strict-mode.md).
+        $getField = {
+            param($obj, [string]$name)
+            if ($null -eq $obj) { return $null }
+            $p = $obj.PSObject.Properties[$name]
+            if ($p) { return $p.Value } else { return $null }
+        }
+
+        $parseAndEmit = {
+            param([string]$rawLine)
+            if ([string]::IsNullOrWhiteSpace($rawLine)) { return }
+
+            # ACA wraps container stdout as {"Log":"<pino-json>","TimeStamp":"..."}.
+            $pinoLine = $rawLine
+            try {
+                $envelope = $rawLine | ConvertFrom-Json -ErrorAction Stop
+                $logField = (& $getField $envelope 'Log')
+                if ($null -eq $logField) { $logField = (& $getField $envelope 'log') }
+                if ($null -ne $logField) { $pinoLine = [string]$logField }
+            } catch { }
+
+            if ([string]::IsNullOrWhiteSpace($pinoLine)) { return }
+
+            $entry = $null
+            try { $entry = $pinoLine | ConvertFrom-Json -ErrorAction Stop }
+            catch { if ($Raw) { Write-Output $pinoLine }; return }
+
+            $entryLevel     = & $getField $entry 'level'
+            $entryComponent = & $getField $entry 'component'
+            $entryRequestId = & $getField $entry 'requestId'
+            $entryTime      = & $getField $entry 'time'
+            $entryMsg       = & $getField $entry 'msg'
+
+            if ($levelNums -and ($null -eq $entryLevel -or [int]$entryLevel -notin $levelNums)) { return }
+            if ($Component -and $entryComponent -ne $Component) { return }
+            if ($PSCmdlet.ParameterSetName -eq 'ByRequestId' -and $entryRequestId -ne $RequestId) { return }
+
+            if ($PSCmdlet.ParameterSetName -eq 'ByTimeRange' -and $entryTime) {
+                try {
+                    $ts = [System.DateTimeOffset]::FromUnixTimeMilliseconds([long]$entryTime).UtcDateTime
+                    if ($ts -lt $StartTime.ToUniversalTime() -or $ts -gt $EndTime.ToUniversalTime()) { return }
+                } catch { return }
+            }
+
+            if ($Pattern -and $pinoLine -notmatch $Pattern) { return }
+
+            if ($Raw) { Write-Output $pinoLine; return }
+
+            $levelName = if ($null -ne $entryLevel -and $pinoLevelMap.ContainsKey([int]$entryLevel)) {
+                $pinoLevelMap[[int]$entryLevel]
+            } else { "$entryLevel" }
+
+            $timestamp = $null
+            if ($entryTime) {
+                try { $timestamp = [System.DateTimeOffset]::FromUnixTimeMilliseconds([long]$entryTime).UtcDateTime }
+                catch { $timestamp = $entryTime }
+            }
+
+            [PSCustomObject]@{
+                Time      = $timestamp
+                Level     = $levelName
+                Component = $entryComponent
+                RequestId = $entryRequestId
+                Message   = $entryMsg
+                Raw       = $entry
+            }
+        }
+    }
+
+    process {
+        Set-StrictMode -Version Latest
+
+        if ($isFollow) {
+            & az @azArgs | ForEach-Object { & $parseAndEmit $_ }
+        }
+        else {
+            $rawLines = & az @azArgs 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                $tailText = @($rawLines) | Select-Object -Last 3 | Out-String -Width 200
+                throw (New-ActionableError `
+                        -Goal     "Retrieve server logs from '$AppName' in '$ResourceGroup'" `
+                        -Problem  "az containerapp logs show exited $LASTEXITCODE. $($tailText.TrimEnd())" `
+                        -Location 'Get-ServerLog' `
+                        -NextSteps @(
+                            'Verify Azure CLI login: az account show',
+                            "Check ResourceGroup='$ResourceGroup', AppName='$AppName'",
+                            'Confirm the app is running: Test-AzureHealth',
+                            'Verify the revision exists: Get-ContainerAppRevision'
+                        ))
+            }
+            foreach ($line in @($rawLines)) {
+                & $parseAndEmit ([string]$line)
+            }
+        }
+    }
+}

--- a/tests/Get-ServerLog.Tests.ps1
+++ b/tests/Get-ServerLog.Tests.ps1
@@ -1,0 +1,85 @@
+# Tag: diagnostics (t/2765)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Get-ServerLog — ACA server-log retrieval + Pino requestId correlation (t/2765).
+.DESCRIPTION
+    Mocks the az CLI inside the module scope (-ModuleName AITriad, since Get-ServerLog
+    invokes `& az` in module scope) and sets $LASTEXITCODE so the exit-code guard sees
+    success. Covers: envelope unwrap + level mapping, level/requestId filtering, -Raw
+    passthrough, StrictMode safety on a field-sparse line, and the az-failure
+    ActionableError.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-ServerLog' -Tag 'diagnostics' {
+
+    It 'Unwraps the ACA envelope, maps level, and filters by -RequestId' {
+        Mock az -ModuleName AITriad -MockWith {
+            $global:LASTEXITCODE = 0
+            @(
+                '{"Log":"{\"level\":30,\"time\":1787048352160,\"requestId\":\"abc\",\"component\":\"ai\",\"msg\":\"ok\"}"}',
+                '{"Log":"{\"level\":30,\"time\":1787048352160,\"requestId\":\"zzz\",\"msg\":\"other\"}"}'
+            )
+        }
+        $r = @(Get-ServerLog -RequestId 'abc')
+        $r.Count      | Should -Be 1 -Because 'only the matching requestId is emitted'
+        $r[0].RequestId | Should -Be 'abc'
+        $r[0].Level     | Should -Be 'info'
+        $r[0].Component  | Should -Be 'ai'
+        $r[0].Message    | Should -Be 'ok'
+    }
+
+    It 'Filters by -Level' {
+        Mock az -ModuleName AITriad -MockWith {
+            $global:LASTEXITCODE = 0
+            @(
+                '{"Log":"{\"level\":30,\"time\":1787048352160,\"msg\":\"info line\"}"}',
+                '{"Log":"{\"level\":50,\"time\":1787048352160,\"msg\":\"error line\"}"}'
+            )
+        }
+        $r = @(Get-ServerLog -Level error)
+        $r.Count | Should -Be 1
+        $r[0].Level | Should -Be 'error'
+    }
+
+    It 'Returns raw Pino strings with -Raw' {
+        $raw = '{"level":30,"time":1787048352160,"msg":"hello"}'
+        Mock az -ModuleName AITriad -MockWith {
+            $global:LASTEXITCODE = 0
+            @("{`"Log`":`"$($raw -replace '"','\"')`"}")
+        }
+        $r = @(Get-ServerLog -Raw)
+        $r[0] | Should -Be $raw
+    }
+
+    It 'Is StrictMode-safe on a line missing requestId/component (no crash)' {
+        Mock az -ModuleName AITriad -MockWith {
+            $global:LASTEXITCODE = 0
+            @('{"Log":"{\"level\":40,\"time\":1787048352160,\"msg\":\"sparse\"}"}')
+        }
+        # A StrictMode crash on the absent field would throw here and fail the test.
+        $r = @(Get-ServerLog)
+        $r.Count | Should -Be 1
+        $r[0].Level     | Should -Be 'warn'
+        $r[0].RequestId | Should -BeNullOrEmpty
+        $r[0].Component | Should -BeNullOrEmpty
+    }
+
+    It 'Throws an ActionableError when az fails' {
+        Mock az -ModuleName AITriad -MockWith { Write-Error 'not logged in'; $global:LASTEXITCODE = 1 }
+        { Get-ServerLog *> $null } | Should -Throw
+    }
+
+    It 'Is exported and resolvable after import' {
+        Get-Command Get-ServerLog -Module AITriad -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## What (e/107, Diagnostics)
New `Get-ServerLog` cmdlet: retrieves container-app logs via `az containerapp logs show`, unwraps the ACA `{Log,TimeStamp}` envelope, parses Pino JSON, and filters/correlates by requestId/component/level/pattern/time.

Four parameter sets — **ByRequestId** (trace one request from the FR), **Recent** (default; tail + `-Follow`), **ByTimeRange** (post-mortem window), **Search** (regex). Cross-set: `-Component`, `-Level`, `-Pattern`, `-ResourceGroup`, `-AppName`, `-Revision`, `-Raw`. Pino levels 10..60 → trace..fatal.

Immediate need: tracing requestId `a2451012-e019-426c-8541-17e541a594bc` (Gemini failure in an FR dump). Retrieval half of the t/2761 observability incident (pairs with t/2763 server-side capture).

## Playbook + deviations
Followed `/add-ps-cmdlet` (self-cert; assessed **within** the playbook — az CLI already used, no new deps/schema/cross-module). **Two correctness deviations from the e/107 reference impl** (asked X, did Y, because Z):
1. Added the module header + `Set-StrictMode -Version Latest` and routed **all** `ConvertFrom-Json` field access through a `PSObject.Properties` guard — the reference read `$entry.requestId/.level/.component` directly, which **throws under StrictMode** (the project convention) on field-sparse log lines.
2. Tests mock `az` with **`-ModuleName AITriad`** (module-scope call site) and set `$LASTEXITCODE` — the skeleton's plain `Mock az` wouldn't intercept the module-internal call.

## Tests — 6/6
envelope unwrap + level map · `-RequestId`/`-Level` filters · `-Raw` · **StrictMode-sparse line (no crash)** · az-failure ActionableError · export resolves. Export-sync + module 42/42; `Test-ModuleManifest` OK.

Registered in `AITriad.psd1` + `AITriad.psm1`; added to `docs/cmdlet-reference.md`. Closes t/2765. CC @Diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)