### PR TITLE
fix(cmdlet): cap Get-ServerLog -Tail at az's 300 max (t/2765 follow-up)

### DIFF
--- a/scripts/AITriad/Public/Get-ServerLog.ps1
+++ b/scripts/AITriad/Public/Get-ServerLog.ps1
@@ -21,8 +21,11 @@ function Get-ServerLog {
     .PARAMETER Follow
         (Recent/Search) Stream logs live instead of a batch capture.
     .PARAMETER Tail
-        Number of log lines to request from ACA. 0 = per-set default
-        (Recent 100, ByRequestId 5000, ByTimeRange 10000, Search 1000).
+        Number of log lines to request from ACA (1-300 — `az containerapp logs show`
+        hard-caps `--tail` at 300). 0 = per-set default (Recent 100; ByRequestId,
+        ByTimeRange, and Search each request the 300 max). For history deeper than the
+        live-tail buffer, query Log Analytics directly — this cmdlet wraps the
+        `logs show` buffer only.
     .PARAMETER Component
         Filter to a single Pino `component`.
     .PARAMETER Level
@@ -77,7 +80,7 @@ function Get-ServerLog {
         [Parameter(ParameterSetName = 'ByRequestId')]
         [Parameter(ParameterSetName = 'ByTimeRange')]
         [Parameter(ParameterSetName = 'Search')]
-        [ValidateRange(1, 100000)]
+        [ValidateRange(1, 300)]
         [int]$Tail = 0,
 
         [Parameter(ParameterSetName = 'Recent')]
@@ -122,13 +125,18 @@ function Get-ServerLog {
             $EndTime = [datetime]::UtcNow
         }
 
+        # az containerapp logs show hard-caps --tail at 300; requesting more errors out
+        # (observed live: "--tail must be between 0 and 300"). Per-set defaults request
+        # the 300 max for the search-heavy sets; Recent tails 100.
+        $azTailMax = 300
         $effectiveTail = switch ($PSCmdlet.ParameterSetName) {
             'Recent'      { if ($Tail -gt 0) { $Tail } else { 100 } }
-            'ByRequestId' { if ($Tail -gt 0) { $Tail } else { 5000 } }
-            'ByTimeRange' { if ($Tail -gt 0) { $Tail } else { 10000 } }
-            'Search'      { if ($Tail -gt 0) { $Tail } else { 1000 } }
+            'ByRequestId' { if ($Tail -gt 0) { $Tail } else { $azTailMax } }
+            'ByTimeRange' { if ($Tail -gt 0) { $Tail } else { $azTailMax } }
+            'Search'      { if ($Tail -gt 0) { $Tail } else { $azTailMax } }
             default       { if ($Tail -gt 0) { $Tail } else { 100 } }
         }
+        if ($effectiveTail -gt $azTailMax) { $effectiveTail = $azTailMax }
 
         $levelNums = if ($Level) { [int[]]@($Level | ForEach-Object { $pinoLevelToNum[$_] }) } else { $null }
 

--- a/tests/Get-ServerLog.Tests.ps1
+++ b/tests/Get-ServerLog.Tests.ps1
@@ -82,4 +82,17 @@ Describe 'Get-ServerLog' -Tag 'diagnostics' {
     It 'Is exported and resolvable after import' {
         Get-Command Get-ServerLog -Module AITriad -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
     }
+
+    It 'Caps --tail at az''s 300 max for the ByRequestId default (regression: az rejects >300)' {
+        Mock az -ModuleName AITriad -MockWith { $global:AzArgs = $args; $global:LASTEXITCODE = 0; @() }
+        Get-ServerLog -RequestId 'abc' *> $null
+        $ti = [array]::IndexOf([object[]]$global:AzArgs, '--tail')
+        $ti | Should -BeGreaterThan -1 -Because '--tail must be passed to az'
+        [int]$global:AzArgs[$ti + 1] | Should -Be 300 -Because 'the ByRequestId default (was 5000) must clamp to az''s 300 cap'
+        Remove-Variable -Name AzArgs -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It 'Rejects -Tail greater than 300 at parameter binding (ValidateRange)' {
+        { Get-ServerLog -RequestId 'abc' -Tail 5000 } | Should -Throw -Because 'az caps --tail at 300; a clear PS validation error beats an opaque az failure'
+    }
 }


### PR DESCRIPTION
## Bug (found in live use)
`Get-ServerLog -RequestId <id>` failed: `az containerapp logs show --tail` hard-caps at **300** (`ERROR: --tail must be between 0 and 300`), but the per-set defaults (ByRequestId 5000, ByTimeRange 10000, Search 1000) and `ValidateRange(1,100000)` exceeded it — so the default call errored via the ActionableError path.

## Fix
- `ValidateRange(1, 300)` — a clear PS validation error instead of an opaque az failure.
- Per-set defaults now request the **300** max for the search-heavy sets (ByRequestId/ByTimeRange/Search); Recent stays 100. Belt-and-suspenders clamp on any computed value.
- Docstring documents the 300 cap and points to Log Analytics for deeper history.

## Tests (+2, 8/8)
`ByRequestId` default sends `--tail 300`; `-Tail 5000` rejected at parameter binding.

Self-cert `/add-ps-cmdlet` (correctness fix to the just-landed t/2765 cmdlet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)