### PR TITLE
fix(bridge): waitForElectronAPI guard + preload-ready FR event (t/2767, t/2766)

### DIFF
--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -31,6 +31,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   osRelease: process.getSystemVersion?.() ?? process.platform,
   osPlatform: process.platform,
   osArch: process.arch,
+  // t/2766: stamp when contextBridge.exposeInMainWorld ran — lets renderer compute
+  // the preload→bridge-available delta for the bridge-available FR lifecycle event.
+  preloadTimestamp: performance.now(),
   getEmbeddingInfo: (): Promise<{ backend: string; execution_provider?: string; calibration_version?: number }> =>
     ipcRenderer.invoke('get-embedding-info'),
 

--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -184,6 +184,45 @@ export function App() {
   // covers the main app and every window mode App renders (t/2343).
   useTheoryLinkHotkey();
 
+  // t/2767: defer all child mounts until window.electronAPI is ready.
+  // In web mode bridgeReady starts true (no preload exists), so the gate is transparent.
+  // Inline polling (not imported waitForElectronAPI) to avoid bundling electron-bridge into
+  // the web build. clearInterval in cleanup handles StrictMode's discarded first mount.
+  const [bridgeReady, setBridgeReady] = useState(import.meta.env.VITE_TARGET === 'web');
+  const [bridgeError, setBridgeError] = useState<string | null>(null);
+  useEffect(() => {
+    if (import.meta.env.VITE_TARGET === 'web') return;
+    if (window.electronAPI) { setBridgeReady(true); return; }
+    const TIMEOUT_MS = 2000;
+    const start = performance.now();
+    let done = false;
+    const id = setInterval(() => {
+      if (window.electronAPI) {
+        clearInterval(id);
+        if (done) return; done = true;
+        getGlobalRecorder()?.record({
+          type: 'lifecycle', component: 'electron-bridge', level: 'info',
+          message: `bridge-available after ${Math.round(performance.now() - start)}ms`,
+          data: { preloadTimestamp: window.electronAPI.preloadTimestamp },
+        });
+        setBridgeReady(true);
+      } else if (performance.now() - start > TIMEOUT_MS) {
+        clearInterval(id);
+        if (done) return; done = true;
+        getGlobalRecorder()?.record({
+          type: 'system.error', component: 'electron-bridge', level: 'error',
+          message: `window.electronAPI not available after ${TIMEOUT_MS}ms — preload may have failed`,
+          error: { name: 'BridgeInitError', message: 'Preload did not run in time' },
+        });
+        setBridgeError('Desktop bridge unavailable — restart the app');
+      }
+    }, 5);
+    return () => { clearInterval(id); done = true; };
+  }, []);
+
+  if (!bridgeReady) return null;
+  if (bridgeError) return <div className="app-bridge-error">{bridgeError}</div>;
+
   // If this window was opened as a diagnostics popout, render only that
   if (hash === '#diagnostics-window') {
     return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><DiagnosticsWindow /></Suspense></ErrorBoundary>;

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -24,6 +24,32 @@ import type { OpEdSet, OpEdSetSummary } from '../../../../lib/oped/types';
 notifyBridgeFallback();
 void tryInitLocalEmbedding();
 
+// t/2767: exported for App.tsx's mount gate — resolves once window.electronAPI is set.
+// Timeout default is 2000ms so a cold-start machine with slow preload still succeeds.
+export function waitForElectronAPI(timeoutMs = 2000): Promise<void> {
+  if (window.electronAPI) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const start = performance.now();
+    const id = setInterval(() => {
+      if (window.electronAPI) {
+        clearInterval(id);
+        resolve();
+      } else if (performance.now() - start > timeoutMs) {
+        clearInterval(id);
+        reject(new ActionableError({
+          goal: 'Initialize Electron bridge',
+          problem: `window.electronAPI not available after ${timeoutMs}ms — preload may have failed`,
+          location: 'electron-bridge.waitForElectronAPI',
+          nextSteps: [
+            'Launch via npm run electron:dev',
+            'Check preload.cts for errors in DevTools console',
+          ],
+        }));
+      }
+    }, 5);
+  });
+}
+
 // Op-Ed Studio (t/2576) — the op-ed persistence IPC surface is added to the preload
 // API by t/2575. Until that lands, the methods are absent from window.electronAPI, so
 // we feature-detect (optional-chained cast) and reject with an honest ActionableError.

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -10,6 +10,8 @@ import type { UserPreferences } from '../bridge/types';
 export interface ElectronAPI {
   processVersions: Record<string, string | undefined>;
   osRelease: string;
+  /** t/2766: performance.now() stamp from when contextBridge.exposeInMainWorld ran. */
+  preloadTimestamp: number;
   getEmbeddingInfo: () => Promise<{ backend: string; execution_provider?: string; calibration_version?: number }>;
 
   // User preferences (t/2118) — optional until handler confirmed present


### PR DESCRIPTION
## Summary
- **t/2767 (HIGH)**: `window.electronAPI` undefined crash — gate-at-mount pattern: `App()` defers all child renders until `window.electronAPI` is set. Closes the class (AppRouter:239 + FileViewerApp:111 both deferred). Web build: gate transparent (`bridgeReady` starts true). StrictMode: `clearInterval` cleanup prevents dangling poller.
- **t/2766 (LOW)**: `preloadTimestamp: performance.now()` added to preload contextBridge object; `bridge-available` lifecycle FR event records elapsed time when gate resolves.
- `waitForElectronAPI(timeoutMs=2000)` exported from `electron-bridge.ts` as standalone utility (2s timeout per TL refinement #1).

## Test plan
- [ ] `Invoke-TaxEditorSmokeTest` passes — no ErrorBoundary on fresh `npm run electron:dev` launch
- [ ] Flight recorder dump shows `bridge-available` lifecycle event with `preloadTimestamp` delta
- [ ] Web build unaffected (bridgeReady starts true, no poller runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)