### PR TITLE
fix(build): exclude src/main/__tests__ from tsconfig.main.json + tsconfig.debate-check.json (t/2768, t/2770)

### DIFF
--- a/taxonomy-editor/tsconfig.debate-check.json
+++ b/taxonomy-editor/tsconfig.debate-check.json
@@ -9,7 +9,7 @@
     "../lib/flight-recorder/**/*"
   ],
   "exclude": [
-    "../lib/debate/**/*.test.ts",
+    "../lib/**/*.test.ts",
     "../lib/debate/__tests__/**/*",
     "../lib/debate/_*.ts",
     "src/main/__tests__/**",

--- a/taxonomy-editor/tsconfig.debate-check.json
+++ b/taxonomy-editor/tsconfig.debate-check.json
@@ -11,6 +11,8 @@
   "exclude": [
     "../lib/debate/**/*.test.ts",
     "../lib/debate/__tests__/**/*",
-    "../lib/debate/_*.ts"
+    "../lib/debate/_*.ts",
+    "src/main/__tests__/**",
+    "**/*.test.ts"
   ]
 }

--- a/taxonomy-editor/tsconfig.main.json
+++ b/taxonomy-editor/tsconfig.main.json
@@ -31,6 +31,8 @@
     "../lib/flight-recorder/**/*"
   ],
   "exclude": [
-    "../lib/**/*.test.ts"
+    "../lib/**/*.test.ts",
+    "src/main/__tests__/**",
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `src/main/__tests__/**` and `**/*.test.ts` to `exclude` in both `tsconfig.main.json` and `tsconfig.debate-check.json`
- Fixes 26 implicit-any TS errors from `__tests__` files being swept into the main-process and debate-check builds without vitest types (t/2768 + t/2770)
- `tsconfig.server.json` is already clean — no change needed there
- Self-certifying under /trivial-change: config-only additions, no new API, no interface changes

## Test plan
- [ ] CI `check-renderer-tsc` passes (26 errors → 0)
- [ ] `show-taxonomyEditor -dev` launches without TS build errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)