### PR TITLE
feat(obs): warn on orphaned worktrees before npm run dev (t/2769)

### DIFF
--- a/scripts/AITriad/Private/Get-OrphanedWorktree.ps1
+++ b/scripts/AITriad/Private/Get-OrphanedWorktree.ps1
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-OrphanedWorktree {
+    <#
+    .SYNOPSIS
+        List directories under <RepoRoot>/.worktrees that are NOT registered git
+        worktrees (orphans).
+    .DESCRIPTION
+        A leftover directory in `.worktrees/` that `git worktree list` no longer knows
+        about (e.g. removed without `git worktree remove`, or pruned metadata) still
+        sits on disk and can pollute node_modules resolution for `npm run dev`, surfacing
+        as TS errors that look like source bugs (t/2768/t/2769). This returns the full
+        paths of such orphans so callers can warn (non-blocking).
+
+        Registered-worktree paths come from `git worktree list --porcelain`; both sides
+        are normalized via [IO.Path]::GetFullPath and compared case-insensitively so
+        the forward-slash paths git emits match the on-disk entries.
+    .PARAMETER RepoRoot
+        Repository root containing the `.worktrees/` directory.
+    .OUTPUTS
+        [string[]] full paths of orphaned worktree directories (empty when none / no
+        .worktrees dir / git unavailable).
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$RepoRoot
+    )
+
+    Set-StrictMode -Version Latest
+
+    $wtDir = Join-Path $RepoRoot '.worktrees'
+    if (-not (Test-Path $wtDir)) { return @() }
+    if (-not (Get-Command git -ErrorAction SilentlyContinue)) { return @() }
+
+    $norm = { param([string]$p) if ([string]::IsNullOrWhiteSpace($p)) { '' } else { ([System.IO.Path]::GetFullPath($p)).TrimEnd('\', '/') } }
+
+    $registered = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $listOut = & git -C $RepoRoot worktree list --porcelain 2>$null
+    foreach ($line in @($listOut)) {
+        if ("$line" -match '^worktree\s+(.+)$') {
+            [void]$registered.Add((& $norm $Matches[1]))
+        }
+    }
+
+    $orphans = [System.Collections.Generic.List[string]]::new()
+    foreach ($dir in @(Get-ChildItem -Path $wtDir -Directory -ErrorAction SilentlyContinue)) {
+        if (-not $registered.Contains((& $norm $dir.FullName))) {
+            $orphans.Add($dir.FullName)
+        }
+    }
+
+    return $orphans.ToArray()
+}

--- a/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
+++ b/scripts/AITriad/Public/Show-TaxonomyEditor.ps1
@@ -454,6 +454,16 @@ function Start-LegacyElectronMode {
         }
     }
 
+    # Warn on orphaned worktrees (t/2769). A leftover dir under .worktrees/ that git
+    # no longer tracks can pollute node_modules resolution for `npm run dev`, surfacing
+    # as TS errors that look like source bugs (t/2768). Non-blocking.
+    $Orphaned = @(Get-OrphanedWorktree -RepoRoot $CodeRoot)
+    if ($Orphaned.Count -gt 0) {
+        $OrphanRel = $Orphaned | ForEach-Object { [System.IO.Path]::GetRelativePath($CodeRoot, $_) }
+        Write-Warn "Orphaned worktrees detected (not registered): $($OrphanRel -join ', ')"
+        Write-Info '   These can pollute node_modules resolution. Run: git worktree prune'
+    }
+
     # Clear any stale process on port 5173 (vite dev server port) before launching
     $staleConn = Get-NetTCPConnection -LocalPort 5173 -State Listen -ErrorAction SilentlyContinue
     if ($staleConn) {

--- a/tests/Get-OrphanedWorktree.Tests.ps1
+++ b/tests/Get-OrphanedWorktree.Tests.ps1
@@ -1,0 +1,71 @@
+# Tag: health (t/2769)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Get-OrphanedWorktree — detect unregistered .worktrees/ dirs (t/2769).
+.DESCRIPTION
+    A leftover .worktrees/ directory git no longer tracks pollutes node_modules
+    resolution for `npm run dev` (t/2768). This helper lists such orphans so
+    Show-TaxonomyEditor can warn. Mocks `git worktree list --porcelain` in module
+    scope and uses real temp directories to exercise path normalization
+    (git emits forward-slash paths; on-disk entries use the OS separator).
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-OrphanedWorktree (t/2769)' -Tag 'health' {
+
+    BeforeEach {
+        $script:Root = Join-Path ([System.IO.Path]::GetTempPath()) "owt-$(New-Guid)"
+        $script:WtDir = Join-Path $script:Root '.worktrees'
+        New-Item -ItemType Directory -Path (Join-Path $script:WtDir 'reg-a') -Force | Out-Null
+        New-Item -ItemType Directory -Path (Join-Path $script:WtDir 'orphan-b') -Force | Out-Null
+    }
+
+    AfterEach {
+        Remove-Item -Path $script:Root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It 'returns unregistered .worktrees dirs (git lists only reg-a → orphan-b is flagged)' {
+        InModuleScope AITriad -Parameters @{ Root = $script:Root; WtDir = $script:WtDir } {
+            param($Root, $WtDir)
+            # git registers only reg-a (main repo + one worktree), forward-slash paths.
+            $regA = (Join-Path $WtDir 'reg-a').Replace('\', '/')
+            Mock git -MockWith {
+                @("worktree $($Root.Replace('\','/'))", '', "worktree $regA", '')
+            }
+            $orphans = @(Get-OrphanedWorktree -RepoRoot $Root)
+            $orphans.Count | Should -Be 1
+            (Split-Path $orphans[0] -Leaf) | Should -Be 'orphan-b'
+        }
+    }
+
+    It 'returns empty when every .worktrees dir is registered' {
+        InModuleScope AITriad -Parameters @{ Root = $script:Root; WtDir = $script:WtDir } {
+            param($Root, $WtDir)
+            $regA = (Join-Path $WtDir 'reg-a').Replace('\', '/')
+            $regB = (Join-Path $WtDir 'orphan-b').Replace('\', '/')
+            Mock git -MockWith { @("worktree $regA", '', "worktree $regB", '') }
+            @(Get-OrphanedWorktree -RepoRoot $Root).Count | Should -Be 0
+        }
+    }
+
+    It 'returns empty when there is no .worktrees directory' {
+        InModuleScope AITriad {
+            $bare = Join-Path ([System.IO.Path]::GetTempPath()) "owt-bare-$(New-Guid)"
+            New-Item -ItemType Directory -Path $bare -Force | Out-Null
+            try {
+                Mock git -MockWith { @() }
+                @(Get-OrphanedWorktree -RepoRoot $bare).Count | Should -Be 0
+                Should -Invoke git -Times 0 -Because 'no .worktrees dir → short-circuit before calling git'
+            } finally { Remove-Item $bare -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+}


### PR DESCRIPTION
## Observability gap (t/2769, post-t/2768)
A leftover directory under `.worktrees/` that `git worktree list` no longer tracks still sits on disk and pollutes `node_modules` resolution for `npm run dev` — surfacing as TS errors that look like source bugs (this was the root cause of the t/2768 qrcode/Azure TS errors). `Show-TaxonomyEditor` gave no signal.

## Change
- New Private helper **`Get-OrphanedWorktree`** — lists `.worktrees/` dirs not present in `git worktree list --porcelain`, normalizing both sides via `[IO.Path]::GetFullPath` (git emits forward-slash paths; on-disk entries use `\`). Returns empty when there's no `.worktrees/` dir or git is unavailable.
- `Start-LegacyElectronMode` warns **non-blocking** just before launch:
```
⚠ Orphaned worktrees detected (not registered): .worktrees/t2764-eslint-gate
   These can pollute node_modules resolution. Run: git worktree prune
```

## Tests — 3/3
orphan flagged · all-registered → empty · no-`.worktrees` short-circuits before git. `git` mocked; real temp dirs exercise path normalization. Module imports clean.

Self-cert (obs chore; single-scope, no new public API — the helper is Private). Closes t/2769.

🤖 Generated with [Claude Code](https://claude.com/claude-code)