### PR TITLE
fix(preload): guard performance.now + expose-first + error fallback order (t/2772)

### DIFF
--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -9,9 +9,6 @@ import { createLatestValueBuffer } from './preloadBuffer.cjs';
 // (happens with bootstrap.ts dynamic import indirection).
 let _bufferedDebateId: string | null = null;
 let _debateBufferActive = true;
-ipcRenderer.on('debate-window-load', (_event, debateId: string) => {
-  if (_debateBufferActive) _bufferedDebateId = debateId;
-});
 
 // Buffer the diagnostics-state-update push the same way (t/2694) — see
 // preloadBuffer.cts. The main window pushes the cached state once on the
@@ -21,9 +18,6 @@ ipcRenderer.on('debate-window-load', (_event, debateId: string) => {
 // Also covers the PovProgression window (same channel). Logic extracted to the
 // pure helper so it's unit-tested (preloadBuffer.test.ts, unblocked by t/2698).
 const _diagnosticsStateBuffer = createLatestValueBuffer<unknown>();
-ipcRenderer.on('diagnostics-state-update', (_event, state: unknown) => {
-  _diagnosticsStateBuffer.onIpc(state);
-});
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // Synchronous system info — available without IPC round-trip
@@ -33,7 +27,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   osArch: process.arch,
   // t/2766: stamp when contextBridge.exposeInMainWorld ran — lets renderer compute
   // the preload→bridge-available delta for the bridge-available FR lifecycle event.
-  preloadTimestamp: performance.now(),
+  preloadTimestamp: (typeof performance !== 'undefined' && typeof performance.now === 'function') ? performance.now() : Date.now(),
   getEmbeddingInfo: (): Promise<{ backend: string; execution_provider?: string; calibration_version?: number }> =>
     ipcRenderer.invoke('get-embedding-info'),
 
@@ -604,3 +598,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   saveOpEdSet: (set: OpEdSet): Promise<void> =>
     ipcRenderer.invoke('save-oped-set', set),
 });
+
+// Wire IPC listeners AFTER exposeInMainWorld so window.electronAPI is always set
+// even if a listener registration throws (t/2772).
+try {
+  ipcRenderer.on('debate-window-load', (_event, debateId: string) => {
+    if (_debateBufferActive) _bufferedDebateId = debateId;
+  });
+  ipcRenderer.on('diagnostics-state-update', (_event, state: unknown) => {
+    _diagnosticsStateBuffer.onIpc(state);
+  });
+} catch (e) {
+  console.error('[preload] listener wiring failed', e);
+}

--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -220,8 +220,8 @@ export function App() {
     return () => { clearInterval(id); done = true; };
   }, []);
 
-  if (!bridgeReady) return null;
   if (bridgeError) return <div className="app-bridge-error">{bridgeError}</div>;
+  if (!bridgeReady) return null;
 
   // If this window was opened as a diagnostics popout, render only that
   if (hash === '#diagnostics-window') {


### PR DESCRIPTION
## Summary
- **Bug 1 (root cause)** `preload.cts`: `performance.now()` throws in the EL43 sandbox, aborting `exposeInMainWorld` before `window.electronAPI` is set — three fixes:
  - Guard `preloadTimestamp` with `typeof` check; fall back to `Date.now()`
  - Move `contextBridge.exposeInMainWorld` ahead of `ipcRenderer.on` calls so the API is always set even if listener wiring throws
  - Wrap listener wiring in `try/catch` with `console.error('[preload] listener wiring failed')`
- **Bug 2 (TL review miss)** `App.tsx`: `bridgeError` check was after `!bridgeReady` return, so the reject path rendered blank forever — swapped order

## Test plan
- [ ] `show-taxonomyEditor -dev` launches and renders past the blank screen
- [ ] tsc exit 0 (verified locally at `be6878c8`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)