### PR TITLE
feat(cmdlet): Test-PreloadHealth — validate built preload.cjs before launch (t/2775)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -124,6 +124,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Test-DebatePersistence` | Pre-flight atomic write+rename probe for the debates output dir — call before AI generation to surface LOCKED/NO_PERMISSION early (t/2545) |
 | `Get-ContainerAppRevision` | Query ACA revisions by mode (Active/Stale/Fqdn) — replaces raw `az containerapp revision` calls (t/1498) |
 | `Get-ServerLog` | Retrieve + filter ACA server logs, correlate by Pino requestId — `-RequestId`/`-Recent`/`-StartTime`/`-Pattern` sets, `-Level`/`-Component`/`-Follow`/`-Raw` (t/2765) |
+| `Test-PreloadHealth` | Validate the built `preload.cjs` before launch — exists, calls `contextBridge.exposeInMainWorld`, `preloadBuffer.cjs` alongside, optional `node --check` (t/2775) |
 | `New-ContainerAppRevision` | Blue-green: deploy a new ACA revision at 0% traffic; returns real `RevisionName` for the promotion chain (t/1500 Phase 3) |
 | `Set-ContainerAppTraffic` | Shift traffic to a named revision with retry — call BEFORE `Disable-ContainerAppRevision` in rollback (t/1500 Phase 3) |
 | `Disable-ContainerAppRevision` | Deactivate an ACA revision (stale cleanup or rollback tail); non-fatal on failure — matches deploy YAML's `\|\| true` semantics (t/1500 Phase 3) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -133,6 +133,7 @@
         'Invoke-DebateBatch'
         'Get-FreeTierStatus'
         'Invoke-TaxEditorSmokeTest'
+        'Test-PreloadHealth'
         'Test-AnalyticsBackend'
         'Test-AnalyticsBlobHealth'
         'Get-AnalyticsEventTypes'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -851,6 +851,8 @@ Export-ModuleMember -Function @(
     'Get-FreeTierStatus'
     'Invoke-TaxEditorSmokeTest'
     # t/2668 — analytics storage round-trip diagnosis
+    # t/2775 — validate the built preload.cjs artifact before launch
+    'Test-PreloadHealth'
     'Test-AnalyticsBackend'
     # t/2702 — analytics blob container health (exists/accessible/recent data)
     'Test-AnalyticsBlobHealth'

--- a/scripts/AITriad/Public/Test-PreloadHealth.ps1
+++ b/scripts/AITriad/Public/Test-PreloadHealth.ps1
@@ -1,0 +1,132 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-PreloadHealth {
+    <#
+    .SYNOPSIS
+        Validate the built taxonomy-editor preload.cjs artifact before launch.
+    .DESCRIPTION
+        Diagnosing a missing `window.electronAPI` (t/2772) required launching the app,
+        attaching CDP, and polling for seconds. This verifies the preload BUILD ARTIFACT
+        offline in well under a second:
+          - preload.cjs exists under taxonomy-editor/dist/main
+          - it calls contextBridge.exposeInMainWorld (the bridge that sets electronAPI)
+          - preloadBuffer.cjs is present alongside it
+          - (optional) `node --check` syntax-validates it
+
+        Emits a structured Healthy/Checks object matching the diagnostic-cmdlet family
+        (Test-AnalyticsBlobHealth, Test-AzureHealth). Suitable as an Invoke-TaxEditorSmokeTest
+        pre-launch gate. No AI calls.
+    .PARAMETER CodeRoot
+        Repo root containing taxonomy-editor/. Default: module-resolved code root.
+    .PARAMETER CheckSyntax
+        Also run `node --check` on preload.cjs to catch a corrupt/partial build.
+    .OUTPUTS
+        [PSCustomObject] with Healthy, PreloadPath, Checks (Name/Pass/Detail), Timestamp.
+    .EXAMPLE
+        Test-PreloadHealth
+    .EXAMPLE
+        Test-PreloadHealth -CheckSyntax
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Invoke-TaxEditorSmokeTest
+    .LINK
+        Test-TaxEditorHealth
+    .LINK
+        Show-TaxonomyEditor
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [string]$CodeRoot,
+
+        [Parameter()]
+        [switch]$CheckSyntax
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $CodeRoot) {
+        $CodeRoot = Get-CodeRoot
+        if (-not $CodeRoot) {
+            throw (New-ActionableError `
+                    -Goal     'Validate the taxonomy-editor preload artifact' `
+                    -Problem  'Cannot resolve the ai-triad-research code root' `
+                    -Location 'Test-PreloadHealth' `
+                    -NextSteps @(
+                        'Set $env:AI_TRIAD_CODE_ROOT to the repo path',
+                        'Or cd into the ai-triad-research directory',
+                        'Or pass -CodeRoot explicitly'
+                    ))
+        }
+    }
+
+    $DistMain = Join-Path $CodeRoot 'taxonomy-editor/dist/main'
+    $Checks   = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $AddCheck = {
+        param($Name, $Pass, $Detail)
+        $Checks.Add([PSCustomObject]@{ Name = $Name; Pass = [bool]$Pass; Detail = $Detail })
+    }
+
+    # ── Check 1: preload.cjs exists (nesting under dist/main varies, so recurse) ──
+    $Preload = $null
+    if (Test-Path $DistMain) {
+        $Preload = @(Get-ChildItem -Path $DistMain -Recurse -Filter 'preload.cjs' -File -ErrorAction SilentlyContinue) |
+            Select-Object -First 1
+    }
+    $PreloadExists = $null -ne $Preload
+    & $AddCheck 'preload.cjs built' $PreloadExists $(if ($PreloadExists) { $Preload.FullName } else { "not found under $DistMain — build first (npm run build in taxonomy-editor/)" })
+
+    # ── Check 2: contextBridge.exposeInMainWorld present ─────────────────────────
+    $HasBridge = $false
+    if ($PreloadExists) {
+        $Content = Get-Content -Raw -Path $Preload.FullName
+        $HasBridge = $Content -match 'contextBridge\.exposeInMainWorld'
+    }
+    & $AddCheck 'exposes electronAPI (contextBridge.exposeInMainWorld)' $HasBridge $(if ($HasBridge) { 'bridge call present' } elseif ($PreloadExists) { 'bridge call MISSING — preload will not set window.electronAPI (t/2772)' } else { 'skipped (no preload.cjs)' })
+
+    # ── Check 3: preloadBuffer.cjs alongside ─────────────────────────────────────
+    $BufferExists = $false
+    $BufferPath = $null
+    if ($PreloadExists) {
+        $BufferPath = Join-Path $Preload.Directory.FullName 'preloadBuffer.cjs'
+        $BufferExists = Test-Path $BufferPath
+    }
+    & $AddCheck 'preloadBuffer.cjs present' $BufferExists $(if ($BufferExists) { $BufferPath } elseif ($PreloadExists) { "missing alongside preload.cjs ($($Preload.Directory.FullName))" } else { 'skipped (no preload.cjs)' })
+
+    # ── Check 4 (optional): node --check syntax validation ───────────────────────
+    if ($CheckSyntax) {
+        if (-not $PreloadExists) {
+            & $AddCheck 'node --check syntax' $false 'skipped (no preload.cjs)'
+        }
+        elseif (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+            & $AddCheck 'node --check syntax' $false 'node not found on PATH'
+        }
+        else {
+            & node --check $Preload.FullName 2>$null
+            $SyntaxOk = ($LASTEXITCODE -eq 0)
+            & $AddCheck 'node --check syntax' $SyntaxOk $(if ($SyntaxOk) { 'valid CommonJS' } else { "node --check exited $LASTEXITCODE — corrupt/partial build?" })
+        }
+    }
+
+    $Healthy = @($Checks | Where-Object { -not $_.Pass }).Count -eq 0
+
+    # ── Report ───────────────────────────────────────────────────────────────────
+    Write-Host "`nPreload Health — taxonomy-editor/dist/main" -ForegroundColor Cyan
+    foreach ($C in $Checks) {
+        $Icon  = if ($C.Pass) { '[PASS]' } else { '[FAIL]' }
+        $Color = if ($C.Pass) { 'Green' } else { 'Red' }
+        Write-Host "  $Icon $($C.Name) — $($C.Detail)" -ForegroundColor $Color
+    }
+    Write-Host ''
+
+    [PSCustomObject]@{
+        Healthy     = $Healthy
+        PreloadPath = if ($PreloadExists) { $Preload.FullName } else { $null }
+        Checks      = @($Checks)
+        Timestamp   = (Get-Date).ToUniversalTime().ToString('o')
+    }
+}

--- a/tests/Test-PreloadHealth.Tests.ps1
+++ b/tests/Test-PreloadHealth.Tests.ps1
@@ -1,0 +1,92 @@
+# Tag: health (t/2775)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Test-PreloadHealth — validate the built preload.cjs artifact (t/2775).
+.DESCRIPTION
+    Filesystem-based (no mocking): each case builds a temp code root with a nested
+    taxonomy-editor/dist/main/.../preload.cjs to exercise the recursive glob, then
+    asserts the Healthy verdict + per-check results. Covers happy path, missing
+    preload, missing bridge call, missing preloadBuffer, and -CheckSyntax.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-PreloadHealth (t/2775)' -Tag 'health' {
+
+    BeforeEach {
+        $script:Root  = Join-Path ([System.IO.Path]::GetTempPath()) "tph-$(New-Guid)"
+        # Nested to match the real dist/main/taxonomy-editor/src/main/ layout.
+        $script:MainDir = Join-Path $script:Root 'taxonomy-editor/dist/main/taxonomy-editor/src/main'
+        New-Item -ItemType Directory -Path $script:MainDir -Force | Out-Null
+    }
+
+    AfterEach {
+        Remove-Item -Path $script:Root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    function script:Get-Check ($result, $name) { $result.Checks | Where-Object { $_.Name -like "$name*" } }
+
+    It 'Healthy when preload.cjs (with bridge) + preloadBuffer.cjs are present' {
+        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
+        Set-Content -Path (Join-Path $script:MainDir 'preloadBuffer.cjs') -Value 'module.exports = {};' -Encoding utf8
+
+        $r = Test-PreloadHealth -CodeRoot $script:Root 6>$null
+        $r.Healthy | Should -BeTrue
+        $r.PreloadPath | Should -BeLike '*preload.cjs'
+        @($r.Checks | Where-Object { -not $_.Pass }).Count | Should -Be 0
+    }
+
+    It 'Unhealthy + flags the built check when preload.cjs is absent' {
+        # dist/main exists but no preload.cjs.
+        $r = Test-PreloadHealth -CodeRoot $script:Root 6>$null
+        $r.Healthy | Should -BeFalse
+        $r.PreloadPath | Should -BeNullOrEmpty
+        (Get-Check $r 'preload.cjs built').Pass | Should -BeFalse
+    }
+
+    It 'Flags the missing contextBridge.exposeInMainWorld call' {
+        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'console.log("no bridge here");' -Encoding utf8
+        Set-Content -Path (Join-Path $script:MainDir 'preloadBuffer.cjs') -Value 'module.exports = {};' -Encoding utf8
+
+        $r = Test-PreloadHealth -CodeRoot $script:Root 6>$null
+        $r.Healthy | Should -BeFalse
+        (Get-Check $r 'exposes electronAPI').Pass | Should -BeFalse
+    }
+
+    It 'Flags a missing preloadBuffer.cjs' {
+        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
+
+        $r = Test-PreloadHealth -CodeRoot $script:Root 6>$null
+        $r.Healthy | Should -BeFalse
+        (Get-Check $r 'preloadBuffer.cjs present').Pass | Should -BeFalse
+    }
+
+    It '-CheckSyntax passes on a valid preload and fails on a corrupt one' {
+        if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because 'node not on PATH — syntax arm not run'
+            return
+        }
+        Set-Content -Path (Join-Path $script:MainDir 'preloadBuffer.cjs') -Value 'module.exports = {};' -Encoding utf8
+
+        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
+        $ok = Test-PreloadHealth -CodeRoot $script:Root -CheckSyntax 6>$null
+        (Get-Check $ok 'node --check syntax').Pass | Should -BeTrue
+
+        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'contextBridge.exposeInMainWorld("electronAPI", {' -Encoding utf8  # unbalanced
+        $bad = Test-PreloadHealth -CodeRoot $script:Root -CheckSyntax 6>$null
+        (Get-Check $bad 'node --check syntax').Pass | Should -BeFalse
+        $bad.Healthy | Should -BeFalse
+    }
+
+    It 'Is exported and resolvable after import' {
+        Get-Command Test-PreloadHealth -Module AITriad -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## What (Diagnostics, post-t/2772)
New `Test-PreloadHealth` — verifies the built preload **artifact** offline in <1s instead of launch + CDP + multi-second polling:
- `preload.cjs` exists under `taxonomy-editor/dist/main` (recursive glob — the built path is deeply nested, `.../dist/main/taxonomy-editor/src/main/preload.cjs`)
- it calls `contextBridge.exposeInMainWorld` (the bridge that sets `window.electronAPI`)
- `preloadBuffer.cjs` sits alongside it
- optional `-CheckSyntax` runs `node --check` to catch a corrupt/partial build

Emits a `Healthy` / `Checks` (Name/Pass/Detail) object matching the diagnostic-cmdlet family (`Test-AnalyticsBlobHealth`/`Test-AzureHealth`). Usable as an `Invoke-TaxEditorSmokeTest` pre-launch gate — integration left as an **optional follow-up** per the ticket ("Could be integrated"), scope kept tight.

## Playbook
Followed `/add-ps-cmdlet` (self-cert). Registered in both `AITriad.psd1` + `AITriad.psm1`, `New-ActionableError`, StrictMode-safe, added to `docs/cmdlet-reference.md`.

## Tests — 6/6
healthy · missing preload · missing bridge call · missing preloadBuffer · `-CheckSyntax` pass+fail · export resolves. Real temp fixtures, nested to exercise the recursive glob. Export-sync + module 42/42; `Test-ModuleManifest` OK.

Closes t/2775.

🤖 Generated with [Claude Code](https://claude.com/claude-code)