### PR TITLE
fix(cmdlet): Test-PreloadHealth Check 3 → self-contained invariant (t/2777)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -124,7 +124,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Test-DebatePersistence` | Pre-flight atomic write+rename probe for the debates output dir — call before AI generation to surface LOCKED/NO_PERMISSION early (t/2545) |
 | `Get-ContainerAppRevision` | Query ACA revisions by mode (Active/Stale/Fqdn) — replaces raw `az containerapp revision` calls (t/1498) |
 | `Get-ServerLog` | Retrieve + filter ACA server logs, correlate by Pino requestId — `-RequestId`/`-Recent`/`-StartTime`/`-Pattern` sets, `-Level`/`-Component`/`-Follow`/`-Raw` (t/2765) |
-| `Test-PreloadHealth` | Validate the built `preload.cjs` before launch — exists, calls `contextBridge.exposeInMainWorld`, `preloadBuffer.cjs` alongside, optional `node --check` (t/2775) |
+| `Test-PreloadHealth` | Validate the built `preload.cjs` before launch — exists, calls `contextBridge.exposeInMainWorld`, self-contained (no relative `require('./…')`), optional `node --check` (t/2775, t/2777) |
 | `New-ContainerAppRevision` | Blue-green: deploy a new ACA revision at 0% traffic; returns real `RevisionName` for the promotion chain (t/1500 Phase 3) |
 | `Set-ContainerAppTraffic` | Shift traffic to a named revision with retry — call BEFORE `Disable-ContainerAppRevision` in rollback (t/1500 Phase 3) |
 | `Disable-ContainerAppRevision` | Deactivate an ACA revision (stale cleanup or rollback tail); non-fatal on failure — matches deploy YAML's `\|\| true` semantics (t/1500 Phase 3) |

--- a/scripts/AITriad/Public/Test-PreloadHealth.ps1
+++ b/scripts/AITriad/Public/Test-PreloadHealth.ps1
@@ -11,7 +11,9 @@ function Test-PreloadHealth {
         offline in well under a second:
           - preload.cjs exists under taxonomy-editor/dist/main
           - it calls contextBridge.exposeInMainWorld (the bridge that sets electronAPI)
-          - preloadBuffer.cjs is present alongside it
+          - it is self-contained: NO relative sibling require('./…') (a relative
+            sibling require breaks under the Electron sandbox — that was the t/2772 bug;
+            the fix inlines it and deletes preloadBuffer.cjs)
           - (optional) `node --check` syntax-validates it
 
         Emits a structured Healthy/Checks object matching the diagnostic-cmdlet family
@@ -88,14 +90,20 @@ function Test-PreloadHealth {
     }
     & $AddCheck 'exposes electronAPI (contextBridge.exposeInMainWorld)' $HasBridge $(if ($HasBridge) { 'bridge call present' } elseif ($PreloadExists) { 'bridge call MISSING — preload will not set window.electronAPI (t/2772)' } else { 'skipped (no preload.cjs)' })
 
-    # ── Check 3: preloadBuffer.cjs alongside ─────────────────────────────────────
-    $BufferExists = $false
-    $BufferPath = $null
+    # ── Check 3: preload.cjs is self-contained (no relative sibling require) ──────
+    # A preload that require()s a relative sibling (e.g. ./preloadBuffer) breaks under
+    # the Electron sandbox — THAT sibling require was the t/2772 bug. The fix (#1214)
+    # inlines the dependency and deletes preloadBuffer.cjs, so a healthy preload has NO
+    # relative require. Bare module requires like require('electron') are fine.
+    $SelfContained = $false
+    $RelRequire    = $null
     if ($PreloadExists) {
-        $BufferPath = Join-Path $Preload.Directory.FullName 'preloadBuffer.cjs'
-        $BufferExists = Test-Path $BufferPath
+        if ($null -eq $Content) { $Content = Get-Content -Raw -Path $Preload.FullName }
+        $RelMatch = [regex]::Match($Content, 'require\(\s*[''"]\.{1,2}/')
+        $SelfContained = -not $RelMatch.Success
+        if ($RelMatch.Success) { $RelRequire = $RelMatch.Value }
     }
-    & $AddCheck 'preloadBuffer.cjs present' $BufferExists $(if ($BufferExists) { $BufferPath } elseif ($PreloadExists) { "missing alongside preload.cjs ($($Preload.Directory.FullName))" } else { 'skipped (no preload.cjs)' })
+    & $AddCheck 'preload.cjs self-contained (no relative require)' $SelfContained $(if ($SelfContained -and $PreloadExists) { 'no relative sibling require — sandbox-safe' } elseif ($PreloadExists) { "relative require present (`"$RelRequire`"...) — breaks under the Electron sandbox (t/2772)" } else { 'skipped (no preload.cjs)' })
 
     # ── Check 4 (optional): node --check syntax validation ───────────────────────
     if ($CheckSyntax) {

--- a/tests/Test-PreloadHealth.Tests.ps1
+++ b/tests/Test-PreloadHealth.Tests.ps1
@@ -34,13 +34,14 @@ Describe 'Test-PreloadHealth (t/2775)' -Tag 'health' {
 
     function script:Get-Check ($result, $name) { $result.Checks | Where-Object { $_.Name -like "$name*" } }
 
-    It 'Healthy when preload.cjs (with bridge) + preloadBuffer.cjs are present' {
-        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
-        Set-Content -Path (Join-Path $script:MainDir 'preloadBuffer.cjs') -Value 'module.exports = {};' -Encoding utf8
+    It 'Healthy for a self-contained preload with the bridge (no relative require, no preloadBuffer needed)' {
+        # The correctly-fixed build (#1214) inlines the buffer — no preloadBuffer.cjs sibling.
+        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'const { contextBridge } = require("electron"); contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
 
         $r = Test-PreloadHealth -CodeRoot $script:Root 6>$null
-        $r.Healthy | Should -BeTrue
+        $r.Healthy | Should -BeTrue -Because 'a self-contained preload with the bridge is healthy — the buffer sibling is inlined, not required'
         $r.PreloadPath | Should -BeLike '*preload.cjs'
+        (Get-Check $r 'preload.cjs self-contained').Pass | Should -BeTrue
         @($r.Checks | Where-Object { -not $_.Pass }).Count | Should -Be 0
     }
 
@@ -54,19 +55,28 @@ Describe 'Test-PreloadHealth (t/2775)' -Tag 'health' {
 
     It 'Flags the missing contextBridge.exposeInMainWorld call' {
         Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'console.log("no bridge here");' -Encoding utf8
-        Set-Content -Path (Join-Path $script:MainDir 'preloadBuffer.cjs') -Value 'module.exports = {};' -Encoding utf8
 
         $r = Test-PreloadHealth -CodeRoot $script:Root 6>$null
         $r.Healthy | Should -BeFalse
         (Get-Check $r 'exposes electronAPI').Pass | Should -BeFalse
     }
 
-    It 'Flags a missing preloadBuffer.cjs' {
-        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
+    It 'Flags a relative sibling require — NOT self-contained (the t/2772 anti-pattern)' {
+        # A preload that require()s ./preloadBuffer is the sandbox-breaking bug the fix removed.
+        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'const buf = require("./preloadBuffer"); contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
 
         $r = Test-PreloadHealth -CodeRoot $script:Root 6>$null
         $r.Healthy | Should -BeFalse
-        (Get-Check $r 'preloadBuffer.cjs present').Pass | Should -BeFalse
+        $selfCheck = Get-Check $r 'preload.cjs self-contained'
+        $selfCheck.Pass   | Should -BeFalse
+        $selfCheck.Detail | Should -Match 'relative require'
+    }
+
+    It 'A bare module require (electron) does NOT trip the self-contained check' {
+        Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'const { contextBridge } = require("electron"); contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
+
+        $r = Test-PreloadHealth -CodeRoot $script:Root 6>$null
+        (Get-Check $r 'preload.cjs self-contained').Pass | Should -BeTrue -Because 'only relative (./ ../) requires are the sandbox risk; bare module requires are fine'
     }
 
     It '-CheckSyntax passes on a valid preload and fails on a corrupt one' {
@@ -74,8 +84,6 @@ Describe 'Test-PreloadHealth (t/2775)' -Tag 'health' {
             Set-ItResult -Skipped -Because 'node not on PATH — syntax arm not run'
             return
         }
-        Set-Content -Path (Join-Path $script:MainDir 'preloadBuffer.cjs') -Value 'module.exports = {};' -Encoding utf8
-
         Set-Content -Path (Join-Path $script:MainDir 'preload.cjs') -Value 'contextBridge.exposeInMainWorld("electronAPI", {});' -Encoding utf8
         $ok = Test-PreloadHealth -CodeRoot $script:Root -CheckSyntax 6>$null
         (Get-Check $ok 'node --check syntax').Pass | Should -BeTrue


### PR DESCRIPTION
## Bug (TL p/360#88)
`Test-PreloadHealth` Check 3 asserted `preloadBuffer.cjs` is present alongside `preload.cjs`. That's backwards: the t/2772 fix (#1214) **inlines** the buffer and **deletes** `preloadBuffer.cjs`, and the sibling `require('./…')` that pulled it in **was the sandbox bug**. So the old check (a) false-fails the correctly-fixed build post-#1214, and (b) encodes the sibling-require anti-pattern as a health requirement.

## Fix
Replace Check 3 with the correct invariant: **preload.cjs is self-contained — no relative `require('./…')`/`require('../…')`** (`require\(\s*['"]\.{1,2}/`). Bare module requires like `require('electron')` are fine. This is the exact check TL's **t/2776** CI gate will run — `Test-PreloadHealth` is its single home (**blocks t/2776**).

## Tests — 7/7 (inverted)
self-contained preload (bridge, no relative require, no preloadBuffer) → Healthy · `require('./preloadBuffer')` → self-contained check FAILS · bare `require('electron')` does NOT trip it · plus the existing built/bridge/syntax/export arms. Docstring + `docs/cmdlet-reference.md` updated.

Self-cert `/add-ps-cmdlet` (single-scope check modification; TL-directed invariant). Closes t/2777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)