### PR TITLE
ci(gate): wire Test-PreloadHealth into test-electron after build (t/2776)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,14 @@ jobs:
         working-directory: ${{ matrix.app }}
         run: pnpm run build
 
+      - name: Preload self-contained gate (t/2776)
+        if: matrix.app == 'taxonomy-editor'
+        shell: pwsh
+        run: |
+          Import-Module ./scripts/AITriad/AITriad.psd1 -Force
+          $r = Test-PreloadHealth -CheckSyntax
+          if (-not $r.Healthy) { $r.Checks | Where-Object { -not $_.Pass } | ForEach-Object { Write-Error $_.Detail }; exit 1 }
+
   # ── renderer-tsc: renderer type-check gate (t/2252) ──
   # CI ran `tsc --noEmit -p tsconfig.main.json` for main-process code but NEVER
   # ran renderer tsc — a renderer import error / unresolved module passes all CI


### PR DESCRIPTION
## Summary

- Adds a `pwsh` step in `test-electron (taxonomy-editor)` immediately after `pnpm run build`
- Imports `AITriad.psd1` and runs `Test-PreloadHealth -CheckSyntax`; fails CI if any check is not Healthy
- Catches re-introduction of a relative sibling `require()` in the emitted preload — the class that silently broke `window.electronAPI` for ~2 days (t/2772)
- Path-filtered via the job-level `electron` filter (same as `renderer-tsc`); docs/PS-only PRs skip automatically
- `ubuntu-latest` has `pwsh` preinstalled; no extra setup step needed

## Test plan

- [ ] CI green on this PR (success arm: current self-contained preload passes)
- [ ] TL gate-verification: both arms — sibling require → red; clean preload → green
- [ ] TL sign-off in t/2776

🤖 Generated with [Claude Code](https://claude.com/claude-code)