### PR TITLE
feat(chat): thread chatId through openChatWindow for per-session dedup (t/2780)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/chatWindow.multiWindow.test.ts
+++ b/taxonomy-editor/src/main/__tests__/chatWindow.multiWindow.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-// Unit tests for multi-window chat registry (t/2564).
-// Verifies: cap enforcement, MRU focus-at-cap, cascade offset,
+// Unit tests for multi-window chat registry (t/2564, t/2780).
+// Verifies: per-chatId dedup, cap enforcement, MRU focus-at-cap, cascade offset,
 // closed-event cleanup, main-window notification, and destroyed-window pruning.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -27,7 +27,7 @@ function makeMockWin(overrides: Record<string, unknown> = {}): Record<string, un
     loadURL: vi.fn(async () => undefined),
     loadFile: vi.fn(async () => undefined),
     on: vi.fn(),
-    webContents: { send: vi.fn() },
+    webContents: { send: vi.fn(), on: vi.fn() },
     ...overrides,
   };
 }
@@ -63,16 +63,19 @@ import { registerChatWindowHandlers, chatWindows, MAX_CHAT_WINDOWS } from '../ip
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getHandler(): (...args: unknown[]) => Promise<unknown> {
+function getHandler(): (event: unknown, chatId: string, source?: string) => Promise<unknown> {
   const calls = (mockHandle as ReturnType<typeof vi.fn>).mock.calls;
   const entry = calls.find((c: unknown[]) => c[0] === 'open-chat-window');
   if (!entry) throw new Error('open-chat-window handler not registered');
-  return entry[1] as (...args: unknown[]) => Promise<unknown>;
+  return entry[1] as (event: unknown, chatId: string, source?: string) => Promise<unknown>;
 }
 
 function makeMainWindow(destroyed = false) {
   return { isDestroyed: () => destroyed, webContents: { send: vi.fn() } };
 }
+
+// Stub event object (handler ignores it)
+const EVENT = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -94,7 +97,7 @@ describe('registerChatWindowHandlers — open-chat-window', () => {
   it('creates a new window and adds it to chatWindows', async () => {
     const hardenWindow = vi.fn();
     registerChatWindowHandlers('/fake/preload.cjs', () => makeMainWindow() as never, hardenWindow);
-    await getHandler()();
+    await getHandler()(EVENT, 'chat-abc');
 
     expect(MockBrowserWindow).toHaveBeenCalledTimes(1);
     expect(chatWindows.size).toBe(1);
@@ -103,25 +106,47 @@ describe('registerChatWindowHandlers — open-chat-window', () => {
 
   it('passes preloadPath into BrowserWindow webPreferences', async () => {
     registerChatWindowHandlers('/my/preload.cjs', () => null, vi.fn());
-    await getHandler()();
+    await getHandler()(EVENT, 'chat-abc');
 
     const opts = (MockBrowserWindow as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
     expect(opts?.webPreferences?.preload).toBe('/my/preload.cjs');
+  });
+
+  it('focuses existing window for same chatId (per-session dedup)', async () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
+    const handler = getHandler();
+
+    await handler(EVENT, 'chat-dup');
+    expect(MockBrowserWindow).toHaveBeenCalledTimes(1);
+    expect(chatWindows.size).toBe(1);
+
+    // Second call with same chatId — must focus, not create
+    await handler(EVENT, 'chat-dup');
+    expect(MockBrowserWindow).toHaveBeenCalledTimes(1); // no new window
+    const win = mockWins[0]!;
+    expect((win.focus as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    expect((win.show as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+
+  it('opens a new window for different chatIds', async () => {
+    registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
+    const handler = getHandler();
+
+    await handler(EVENT, 'chat-1');
+    await handler(EVENT, 'chat-2');
+    expect(MockBrowserWindow).toHaveBeenCalledTimes(2);
+    expect(chatWindows.size).toBe(2);
   });
 
   it('applies cascade offset on second window', async () => {
     registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
     const handler = getHandler();
 
-    // First window: size was 0 → offset 0 → x/y undefined
-    await handler();
+    await handler(EVENT, 'chat-1');
     const firstOpts = (MockBrowserWindow as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
     expect(firstOpts?.x).toBeUndefined();
 
-    // Manually register first win so chatWindows.size === 1 before second call
-    chatWindows.set(mockWins[0]!.id as number, mockWins[0] as never);
-
-    await handler();
+    await handler(EVENT, 'chat-2');
     const secondOpts = (MockBrowserWindow as ReturnType<typeof vi.fn>).mock.calls[1]?.[0];
     expect(secondOpts?.x).toBe(30);
     expect(secondOpts?.y).toBe(30);
@@ -133,13 +158,14 @@ describe('registerChatWindowHandlers — open-chat-window', () => {
 
     for (let i = 0; i < MAX_CHAT_WINDOWS; i++) {
       const win = makeMockWin();
-      chatWindows.set(win.id as number, win as never);
+      chatWindows.set(`chat-${i}`, win as never);
     }
     const mruWin = [...chatWindows.values()].at(-1) as unknown as Record<string, unknown>;
 
-    await handler();
+    const result = await handler(EVENT, 'chat-new');
 
     expect(MockBrowserWindow).not.toHaveBeenCalled();
+    expect(result).toEqual({ atCap: true });
     expect((mruWin.show as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
     expect((mruWin.focus as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
   });
@@ -150,11 +176,11 @@ describe('registerChatWindowHandlers — open-chat-window', () => {
 
     for (let i = 0; i < MAX_CHAT_WINDOWS; i++) {
       const win = makeMockWin({ isMinimized: vi.fn(() => true) });
-      chatWindows.set(win.id as number, win as never);
+      chatWindows.set(`chat-${i}`, win as never);
     }
     const mruWin = [...chatWindows.values()].at(-1) as unknown as Record<string, unknown>;
 
-    await handler();
+    await handler(EVENT, 'chat-new');
     expect((mruWin.restore as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
   });
 
@@ -164,10 +190,10 @@ describe('registerChatWindowHandlers — open-chat-window', () => {
 
     for (let i = 0; i < MAX_CHAT_WINDOWS; i++) {
       const win = makeMockWin({ isDestroyed: vi.fn(() => true) });
-      chatWindows.set(win.id as number, win as never);
+      chatWindows.set(`chat-${i}`, win as never);
     }
 
-    await handler();
+    await handler(EVENT, 'chat-new');
 
     expect(MockBrowserWindow).toHaveBeenCalledTimes(1);
     expect(chatWindows.size).toBe(1);
@@ -175,7 +201,7 @@ describe('registerChatWindowHandlers — open-chat-window', () => {
 
   it('removes window from chatWindows on closed event', async () => {
     registerChatWindowHandlers('/fake/preload.cjs', () => makeMainWindow() as never, vi.fn());
-    await getHandler()();
+    await getHandler()(EVENT, 'chat-abc');
 
     const win = mockWins[0]!;
     const closedCb = (win.on as ReturnType<typeof vi.fn>).mock.calls
@@ -186,22 +212,22 @@ describe('registerChatWindowHandlers — open-chat-window', () => {
     expect(chatWindows.size).toBe(0);
   });
 
-  it('sends chat-popout-closed to main window on chat close', async () => {
+  it('sends chat-popout-closed with chatId to main window on chat close', async () => {
     const mainWin = makeMainWindow();
     registerChatWindowHandlers('/fake/preload.cjs', () => mainWin as never, vi.fn());
-    await getHandler()();
+    await getHandler()(EVENT, 'chat-xyz');
 
     const win = mockWins[0]!;
     const closedCb = (win.on as ReturnType<typeof vi.fn>).mock.calls
       .find((c: unknown[]) => c[0] === 'closed')?.[1] as () => void;
 
     closedCb();
-    expect(mainWin.webContents.send).toHaveBeenCalledWith('chat-popout-closed');
+    expect(mainWin.webContents.send).toHaveBeenCalledWith('chat-popout-closed', 'chat-xyz');
   });
 
   it('does not crash when main window is null on closed', async () => {
     registerChatWindowHandlers('/fake/preload.cjs', () => null, vi.fn());
-    await getHandler()();
+    await getHandler()(EVENT, 'chat-abc');
 
     const win = mockWins[0]!;
     const closedCb = (win.on as ReturnType<typeof vi.fn>).mock.calls
@@ -213,7 +239,7 @@ describe('registerChatWindowHandlers — open-chat-window', () => {
   it('does not crash when main window is destroyed on closed', async () => {
     const mainWin = makeMainWindow(true);
     registerChatWindowHandlers('/fake/preload.cjs', () => mainWin as never, vi.fn());
-    await getHandler()();
+    await getHandler()(EVENT, 'chat-abc');
 
     const win = mockWins[0]!;
     const closedCb = (win.on as ReturnType<typeof vi.fn>).mock.calls

--- a/taxonomy-editor/src/main/ipc/chatWindowHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/chatWindowHandlers.ts
@@ -1,13 +1,13 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-// Chat popout window management (t/2564): up to MAX_CHAT_WINDOWS concurrent
-// independent sessions. Each window's chat-stream events target only its own
-// webContents — no cross-stream contamination (aiHandlers uses event.sender.send).
+// Chat popout window management (t/2564, t/2780): up to MAX_CHAT_WINDOWS concurrent
+// sessions, deduped per chatId (same chatId → focus existing window, no duplicate).
+// Each window's chat-stream events target only its own webContents — no cross-stream
+// contamination (aiHandlers uses event.sender.send).
 //
 // Web build: openChatWindow opens a new browser tab on every click; no cap is
-// enforced there — the browser handles tab management natively. This Electron
-// cap is intentionally not mirrored in web-bridge.ts.
+// enforced there — the browser handles tab management natively.
 
 import { ipcMain, BrowserWindow, screen, app } from 'electron';
 import path from 'path';
@@ -15,19 +15,28 @@ import { PROJECT_ROOT } from '../fileIO.js';
 
 export const MAX_CHAT_WINDOWS = 5;
 
-// Module-level registry: window id → BrowserWindow.
+// Module-level registry: chatId → BrowserWindow.
 // Exported so tests can reset state between runs.
-export const chatWindows = new Map<number, BrowserWindow>();
+export const chatWindows = new Map<string, BrowserWindow>();
 
 export function registerChatWindowHandlers(
   preloadPath: string,
   getMainWindow: () => BrowserWindow | null,
   hardenWindow: (win: BrowserWindow) => void,
 ): void {
-  ipcMain.handle('open-chat-window', () => {
+  ipcMain.handle('open-chat-window', (_event, chatId: string, source?: 'my' | 'community') => {
     // Prune any windows destroyed without firing 'closed' (defensive).
     for (const [id, win] of chatWindows) {
       if (win.isDestroyed()) chatWindows.delete(id);
+    }
+
+    // Per-chat dedup: if a window for this chatId already exists, focus it.
+    const existing = chatWindows.get(chatId);
+    if (existing && !existing.isDestroyed()) {
+      if (existing.isMinimized()) existing.restore();
+      existing.show();
+      existing.focus();
+      return;
     }
 
     if (chatWindows.size >= MAX_CHAT_WINDOWS) {
@@ -36,7 +45,7 @@ export function registerChatWindowHandlers(
       if (mruWin.isMinimized()) mruWin.restore();
       mruWin.show();
       mruWin.focus();
-      return;
+      return { atCap: true as const };
     }
 
     const { width: screenW, height: screenH } = screen.getPrimaryDisplay().workAreaSize;
@@ -61,20 +70,27 @@ export function registerChatWindowHandlers(
 
     hardenWindow(win);
 
+    const hashParams = `chat-window?id=${encodeURIComponent(chatId)}${source ? `&source=${encodeURIComponent(source)}` : ''}`;
     const isDev = !app.isPackaged;
     if (isDev) {
-      void win.loadURL('http://localhost:5173#chat-window');
+      void win.loadURL(`http://localhost:5173#${hashParams}`);
     } else {
-      void win.loadFile(path.join(PROJECT_ROOT, 'taxonomy-editor/dist/renderer/index.html'), { hash: 'chat-window' });
+      void win.loadFile(path.join(PROJECT_ROOT, 'taxonomy-editor/dist/renderer/index.html'), { hash: hashParams });
     }
 
-    chatWindows.set(win.id, win);
+    chatWindows.set(chatId, win);
+
+    win.webContents.on('did-finish-load', () => {
+      if (!win.isDestroyed()) {
+        win.webContents.send('chat-window-load', chatId);
+      }
+    });
 
     win.on('closed', () => {
-      chatWindows.delete(win.id);
+      chatWindows.delete(chatId);
       const mainWindow = getMainWindow();
       if (mainWindow && !mainWindow.isDestroyed()) {
-        mainWindow.webContents.send('chat-popout-closed');
+        mainWindow.webContents.send('chat-popout-closed', chatId);
       }
     });
   });

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -36,6 +36,8 @@ console.log('[preload] starting...');
 // (happens with bootstrap.ts dynamic import indirection).
 let _bufferedDebateId: string | null = null;
 let _debateBufferActive = true;
+let _bufferedChatId: string | null = null;
+let _chatBufferActive = true;
 
 // Buffer the diagnostics-state-update push the same way (t/2694) — see
 // preloadBuffer.cts. The main window pushes the cached state once on the
@@ -264,11 +266,25 @@ try {
   closeDiagnosticsWindow: (): Promise<void> => ipcRenderer.invoke('close-diagnostics-window'),
 
   // Chat popout window
-  openChatWindow: (): Promise<void> => ipcRenderer.invoke('open-chat-window'),
-  onChatPopoutClosed: (callback: () => void) => {
-    const listener = () => callback();
+  openChatWindow: (chatId: string, source?: 'my' | 'community'): Promise<{ atCap: true } | void> => ipcRenderer.invoke('open-chat-window', chatId, source),
+  onChatPopoutClosed: (callback: (chatId: string) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, chatId: string) => callback(chatId);
     ipcRenderer.on('chat-popout-closed', listener);
     return () => { ipcRenderer.removeListener('chat-popout-closed', listener); };
+  },
+  onChatWindowLoad: (callback: (chatId: string) => void) => {
+    _chatBufferActive = false;
+    if (_bufferedChatId) {
+      const id = _bufferedChatId;
+      _bufferedChatId = null;
+      queueMicrotask(() => callback(id));
+    }
+    const listener = (_event: Electron.IpcRendererEvent, chatId: string) => callback(chatId);
+    ipcRenderer.on('chat-window-load', listener);
+    return () => {
+      ipcRenderer.removeListener('chat-window-load', listener);
+      _chatBufferActive = true;
+    };
   },
 
   // Data file diff window
@@ -645,6 +661,9 @@ try {
 try {
   ipcRenderer.on('debate-window-load', (_event, debateId: string) => {
     if (_debateBufferActive) _bufferedDebateId = debateId;
+  });
+  ipcRenderer.on('chat-window-load', (_event, chatId: string) => {
+    if (_chatBufferActive) _bufferedChatId = chatId;
   });
   ipcRenderer.on('diagnostics-state-update', (_event, state: unknown) => {
     _diagnosticsStateBuffer.onIpc(state);

--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -239,7 +239,7 @@ export function App() {
   if (hash.startsWith('#diff-window')) {
     return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><DiffWindow /></Suspense></ErrorBoundary>;
   }
-  if (hash === '#chat-window') {
+  if (hash.startsWith('#chat-window')) {
     return <ErrorBoundary buildInfo={BUILD_FINGERPRINT}><Suspense fallback={null}><ChatWindow /></Suspense></ErrorBoundary>;
   }
   if (hash === '#analytics' && analyticsFlag) {

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -483,8 +483,9 @@ export const api: AppAPI = {
     return () => { localDiagCallbacks.delete(cb); unsub(); };
   },
   onDiagnosticsPopoutClosed: (cb) => window.electronAPI.onDiagnosticsPopoutClosed(cb),
-  openChatWindow: () => window.electronAPI.openChatWindow(),
+  openChatWindow: (chatId, source) => window.electronAPI.openChatWindow(chatId, source),
   onChatPopoutClosed: (cb) => window.electronAPI.onChatPopoutClosed(cb),
+  onChatWindowLoad: (cb) => window.electronAPI.onChatWindowLoad(cb),
   requestReExtractClaims: (entryId) => window.electronAPI.requestReExtractClaims(entryId),
   onReExtractClaims: (cb) => window.electronAPI.onReExtractClaims(cb),
   onDebateWindowLoad: (cb) => window.electronAPI.onDebateWindowLoad(cb),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -463,8 +463,9 @@ export interface AppAPI {
   // --- Event listeners (return unsubscribe function) ---
   onDiagnosticsStateUpdate: (callback: (state: unknown) => void) => () => void;
   onDiagnosticsPopoutClosed: (callback: () => void) => () => void;
-  openChatWindow: () => Promise<void>;
-  onChatPopoutClosed: (callback: () => void) => () => void;
+  openChatWindow: (chatId: string, source?: 'my' | 'community') => Promise<{ atCap: true } | void>;
+  onChatPopoutClosed: (callback: (chatId: string) => void) => () => void;
+  onChatWindowLoad: (callback: (chatId: string) => void) => () => void;
   requestReExtractClaims: (entryId: string) => void;
   onReExtractClaims: (callback: (entryId: string) => void) => () => void;
   onDebateWindowLoad: (callback: (debateId: string) => void) => () => void;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -1375,10 +1375,11 @@ const rawApi: AppAPI = {
     diagClosedCallbacks.add(cb);
     return () => { diagClosedCallbacks.delete(cb); };
   },
-  openChatWindow: async () => {
-    openAppWindow('chat-window');
+  openChatWindow: async (chatId, source) => {
+    openAppWindow(`chat-window?id=${encodeURIComponent(chatId)}${source ? `&source=${encodeURIComponent(source)}` : ''}`);
   },
   onChatPopoutClosed: () => () => {},
+  onChatWindowLoad: () => () => {},
   requestReExtractClaims: (entryId) => {
     diagChannel?.postMessage({ type: 're-extract-claims', entryId });
   },

--- a/taxonomy-editor/src/renderer/components/chat/ChatWindow.test.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWindow.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../hooks/useTaxonomyStore', () => ({
     { getState: () => ({ loadAll: mockLoadAll }) },
   ),
   initAIModels: (...args: unknown[]) => mockInitAIModels(...args),
+  MODELS_BY_BACKEND: {} as Record<string, unknown[]>,
 }));
 
 vi.mock('../../hooks/useChatStore', () => ({

--- a/taxonomy-editor/src/renderer/components/chat/ChatWindow.test.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWindow.test.tsx
@@ -10,6 +10,7 @@ const mockLoadAll = vi.fn().mockResolvedValue(undefined);
 const mockInitAIModels = vi.fn().mockResolvedValue(undefined);
 const mockInitDebateSessions = vi.fn();
 const mockLoadChat = vi.fn().mockResolvedValue(undefined);
+const mockOnChatWindowLoad = vi.fn().mockReturnValue(() => {});
 
 vi.mock('../../hooks/useTaxonomyStore', () => ({
   useTaxonomyStore: Object.assign(
@@ -31,8 +32,19 @@ vi.mock('../../hooks/useDebateStore', () => ({
   initDebateSessions: () => mockInitDebateSessions(),
 }));
 
-vi.mock('./ChatTab', () => ({
-  ChatTab: () => <div data-testid="chat-tab">ChatTab</div>,
+vi.mock('../../hooks/usePopoutTheme', () => ({
+  usePopoutTheme: () => {},
+}));
+
+// ChatWindow renders ChatWorkspace — mock it as a stub so we can assert "ready"
+vi.mock('./ChatWorkspace', () => ({
+  ChatWorkspace: () => <div data-testid="chat-tab">ChatWorkspace</div>,
+}));
+
+vi.mock('@bridge', () => ({
+  api: {
+    onChatWindowLoad: (...args: unknown[]) => mockOnChatWindowLoad(...args),
+  },
 }));
 
 vi.mock('@lib/flight-recorder/index', () => ({
@@ -63,6 +75,7 @@ describe('ChatWindow', () => {
     mockLoadAll.mockClear().mockResolvedValue(undefined);
     mockInitDebateSessions.mockClear();
     mockLoadChat.mockClear().mockResolvedValue(undefined);
+    mockOnChatWindowLoad.mockClear().mockReturnValue(() => {});
     window.location.hash = '';
   });
 

--- a/taxonomy-editor/src/renderer/components/chat/ChatWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWindow.tsx
@@ -8,7 +8,8 @@ import { useChatStore } from '../../hooks/useChatStore';
 import { initDebateSessions } from '../../hooks/useDebateStore';
 import { usePopoutTheme } from '../../hooks/usePopoutTheme';
 import { parseHashParams } from '../../lib/parseHash';
-import { ChatTab } from './ChatTab';
+import { api } from '@bridge';
+import { ChatWorkspace } from './ChatWorkspace';
 import './ChatWindow.css';
 
 export function ChatWindow() {
@@ -17,14 +18,22 @@ export function ChatWindow() {
 
   useEffect(() => {
     let cancelled = false;
+    let unsubChatLoad: (() => void) | undefined;
     initAIModels()
       .then(() => useTaxonomyStore.getState().loadAll())
       .then(() => {
         initDebateSessions();
         if (!cancelled) {
           setReady(true);
+
+          // Dual delivery: hash param (always available) + IPC push (handles
+          // did-finish-load vs React-mount race via the preload buffer).
           const chatId = parseHashParams(window.location.hash).get('id');
           if (chatId) void useChatStore.getState().loadChat(chatId);
+
+          unsubChatLoad = api.onChatWindowLoad((id) => {
+            void useChatStore.getState().loadChat(id);
+          });
         }
       })
       .catch(err => {
@@ -37,7 +46,7 @@ export function ChatWindow() {
         });
         if (!cancelled) setReady(true);
       });
-    return () => { cancelled = true; };
+    return () => { cancelled = true; unsubChatLoad?.(); };
   }, []);
 
   if (!ready) {
@@ -50,7 +59,7 @@ export function ChatWindow() {
 
   return (
     <div className="chat-window-root">
-      <ChatTab />
+      <ChatWorkspace />
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/shared/BottomNav.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/BottomNav.tsx
@@ -76,7 +76,7 @@ export function BottomNav({ onOpenMore }: BottomNavProps) {
             </button>
             <button
               className="bottom-nav-item"
-              onClick={() => void api.openChatWindow()}
+              onClick={() => void api.openChatWindow(crypto.randomUUID())}
             >
               {navIcon('chat')}
               <span className="bottom-nav-label">Chat</span>

--- a/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/HamburgerMenu.tsx
@@ -190,7 +190,7 @@ export function HamburgerMenu({ isOpen, onClose }: HamburgerMenuProps) {
         setToolbarPanel(null);
         if (['situations', 'conflicts', 'debate', 'chat', 'opeds', 'summaries', 'validation'].includes(activeTab)) setActiveTab('accelerationist');
       } else if (action.id === 'chat') {
-        void api.openChatWindow();
+        void api.openChatWindow(crypto.randomUUID());
       } else if (action.id === 'feedback') {
         setShowFeedback(true);
       } else if (action.id === 'help') {

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -332,7 +332,7 @@ export function Toolbar() {
         </button>
         <button
           className="toolbar-nav"
-          onClick={() => void api.openChatWindow()}
+          onClick={() => void api.openChatWindow(crypto.randomUUID())}
           aria-label="Chat"
         >
           <MessageCircle size="1.25em" />

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -207,8 +207,9 @@ export interface ElectronAPI {
   openPromptDiffWindow: (debateId: string, entryId: string) => Promise<void>;
 
   // Chat popout
-  openChatWindow: () => Promise<void>;
-  onChatPopoutClosed: (callback: () => void) => () => void;
+  openChatWindow: (chatId: string, source?: 'my' | 'community') => Promise<{ atCap: true } | void>;
+  onChatPopoutClosed: (callback: (chatId: string) => void) => () => void;
+  onChatWindowLoad: (callback: (chatId: string) => void) => () => void;
 
   // Flight recorder
   dumpFlightRecorder: (ndjson: string, dumpId?: string) => Promise<{ filePath: string; filename: string }>;


### PR DESCRIPTION
## Summary
- `openChatWindow(chatId, source?)` threaded through all bridge layers (types, electron-bridge, web-bridge, preload, electron.d.ts)
- `chatWindowHandlers`: `Map<string,BrowserWindow>` keyed by chatId — same chatId focuses existing window; cap-5 returns `{atCap:true}`; hash includes `?id=…&source=…`; `did-finish-load` pushes `chat-window-load chatId`; closed event carries chatId
- Preload: `onChatWindowLoad` with latest-value buffer (mirrors debate pattern for did-finish-load vs React-mount race)
- `App.tsx`: `startsWith('#chat-window')` so query params don't break routing
- `ChatWindow`: dual delivery (hash param + IPC buffer); renders `ChatWorkspace` instead of `ChatTab`
- Toolbar/BottomNav/HamburgerMenu generic "open chat" buttons use `crypto.randomUUID()` (preserves one-window-per-click behavior)

## Test plan
- [ ] tsc clean (excluding pre-existing lib/sanitize transitive-dep errors)
- [ ] Open chat from toolbar — new window loads correct chat workspace
- [ ] Open same chatId twice — second click focuses existing window
- [ ] Open 5 windows — 6th click returns `{atCap:true}`, focuses MRU
- [ ] Close chat window — main window receives `chat-popout-closed` with chatId

🤖 Generated with [Claude Code](https://claude.com/claude-code)
