### PR TITLE
feat(cmdlet): Test-EmbeddingHealth — smoke-test /api/embeddings/compute (t/2787)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -107,6 +107,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | Cmdlet | Use when |
 |--------|----------|
 | `Test-TaxEditorHealth` | Production liveness/readiness check (supports `-MaxAttempts` polling for post-deploy waits, t/1491) |
+| `Test-EmbeddingHealth` | Smoke-test `POST /api/embeddings/compute` in prod (anon session + x-request-id) — reports Healthy/status/duration/vector dims + a `Get-ServerLog`-traceable requestId on failure (t/2787) |
 | `Test-TaxEditorEndpoints` | Smoke-test 16 endpoints |
 | `Test-AnonymousDebateFlow` | End-to-end smoke test of the anonymous/free-tier user journey |
 | `Test-PersonaEndpoints` | Auth-gate regression matrix across anonymous/authenticated/admin personas |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -125,6 +125,7 @@
         'Get-ImportReport'
         'Get-CalibrationTrend'
         'Test-TaxEditorHealth'
+        'Test-EmbeddingHealth'
         'Test-TaxEditorEndpoints'
         'Test-AnonymousDebateFlow'
         'Test-PersonaEndpoints'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -842,6 +842,8 @@ Export-ModuleMember -Function @(
     'Get-ImportReport'
     'Get-CalibrationTrend'
     'Test-TaxEditorHealth'
+    # t/2787 — smoke-test /api/embeddings/compute in production
+    'Test-EmbeddingHealth'
     'Test-TaxEditorEndpoints'
     'Test-AnonymousDebateFlow'
     'Test-PersonaEndpoints'

--- a/scripts/AITriad/Public/Test-EmbeddingHealth.ps1
+++ b/scripts/AITriad/Public/Test-EmbeddingHealth.ps1
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-EmbeddingHealth {
+    <#
+    .SYNOPSIS
+        Smoke-test POST /api/embeddings/compute on a deployed taxonomy-editor.
+    .DESCRIPTION
+        Diagnosing a semantic-search HTTP 500 (t/2784) needed a user to trigger search
+        and capture a dump. This proactively probes the embedding endpoint: it establishes
+        an anonymous session (AUTH_OPTIONAL cookie-less requests get the Sign-In
+        interstitial — t/2684), POSTs a minimal `{ texts: [...] }` payload with an
+        x-request-id it generates, and reports success/failure, HTTP status, duration, the
+        returned vector dimensionality, and the requestId (usable with
+        `Get-ServerLog -RequestId` to trace a failure server-side).
+
+        Suitable for the session-start health suite alongside Test-TaxEditorHealth.
+        No AI calls are made client-side (the server computes the embedding).
+    .PARAMETER BaseUrl
+        Deployed base URL. Default: module-resolved (Get-TaxEditorBaseUrl).
+    .PARAMETER Backend
+        ADVISORY. Forwarded as a `?backend=` hint. The /compute endpoint currently selects
+        the embedding backend from server config, not per-request, so this does not change
+        which backend runs today — it is reserved for forward-compat and echoed in output.
+    .PARAMETER TimeoutSec
+        Per-request timeout. Default 30 (the server caps compute at 50s).
+    .OUTPUTS
+        [PSCustomObject] Healthy, BaseUrl, Backend, StatusCode, DurationMs, VectorDims,
+        RequestId, Error, Timestamp.
+    .EXAMPLE
+        Test-EmbeddingHealth
+    .EXAMPLE
+        $h = Test-EmbeddingHealth; if (-not $h.Healthy) { Get-ServerLog -RequestId $h.RequestId }
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Test-TaxEditorHealth
+    .LINK
+        Get-ServerLog
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [string]$BaseUrl,
+
+        [Parameter()]
+        [string]$Backend,
+
+        [Parameter()]
+        [ValidateRange(1, 600)]
+        [int]$TimeoutSec = 30
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $BaseUrl) { $BaseUrl = Get-TaxEditorBaseUrl }
+    $BaseUrl = $BaseUrl.TrimEnd('/')
+
+    # Anon session so the cookie-less POST reaches the handler (not the interstitial).
+    $Session = New-AnonymousWebSession -BaseUrl $BaseUrl -TimeoutSec $TimeoutSec
+    if (-not $Session) {
+        Write-Host '  (anonymous session not established — the probe may hit the auth interstitial)' -ForegroundColor DarkYellow
+    }
+
+    $RequestId = [guid]::NewGuid().ToString()
+    $Path = '/api/embeddings/compute'
+    if ($Backend) { $Path += "?backend=$([uri]::EscapeDataString($Backend))" }
+    $BodyJson = '{"texts":["embedding health check"]}'
+
+    $Params = @{
+        BaseUrl               = $BaseUrl
+        Path                  = $Path
+        Method                = 'POST'
+        Body                  = $BodyJson
+        TimeoutSec            = $TimeoutSec
+        AcceptableStatusCodes = @(200)
+        ExtraHeaders          = @{ 'x-request-id' = $RequestId; 'Content-Type' = 'application/json' }
+    }
+    if ($Session) { $Params.Session = $Session }
+
+    $Check = Invoke-RemoteCheck @Params
+
+    # Success = 200 AND a non-empty vector came back (proves the compute path ran).
+    $VectorDims = $null
+    $HasVector  = $false
+    if ($Check.Success -and $Check.Body -and $Check.Body.PSObject.Properties['vectors']) {
+        $Vectors = @($Check.Body.vectors)
+        if ($Vectors.Count -gt 0 -and $null -ne $Vectors[0]) {
+            $VectorDims = @($Vectors[0]).Count
+            $HasVector  = $VectorDims -gt 0
+        }
+    }
+    $Healthy = [bool]($Check.Success -and $HasVector)
+
+    $ErrText = $null
+    if (-not $Healthy) {
+        $ErrText = if ($Check.Error) { $Check.Error }
+                   elseif (-not $Check.Success) { "HTTP $($Check.StatusCode)" }
+                   else { 'no vectors in response' }
+    }
+
+    # ── Report ───────────────────────────────────────────────────────────────────
+    $Icon  = if ($Healthy) { '[PASS]' } else { '[FAIL]' }
+    $Color = if ($Healthy) { 'Green' } else { 'Red' }
+    Write-Host "`nEmbedding Health — $BaseUrl" -ForegroundColor Cyan
+    Write-Host "  $Icon POST /api/embeddings/compute — $($Check.StatusCode) $($Check.ResponseMs)ms$(if ($HasVector) { " (dims=$VectorDims)" })" -ForegroundColor $Color
+    if (-not $Healthy) {
+        Write-Host "        $ErrText" -ForegroundColor DarkRed
+        Write-Host "        Trace: Get-ServerLog -RequestId $RequestId" -ForegroundColor DarkYellow
+    }
+    Write-Host ''
+
+    [PSCustomObject]@{
+        Healthy    = $Healthy
+        BaseUrl    = $BaseUrl
+        Backend    = if ($Backend) { $Backend } else { $null }
+        StatusCode = $Check.StatusCode
+        DurationMs = $Check.ResponseMs
+        VectorDims = $VectorDims
+        RequestId  = $RequestId
+        Error      = $ErrText
+        Timestamp  = (Get-Date).ToUniversalTime().ToString('o')
+    }
+}

--- a/tests/Test-EmbeddingHealth.Tests.ps1
+++ b/tests/Test-EmbeddingHealth.Tests.ps1
@@ -1,0 +1,97 @@
+# Tag: health (t/2787)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Test-EmbeddingHealth — /api/embeddings/compute smoke test (t/2787).
+.DESCRIPTION
+    Mocks the module-internal Invoke-RemoteCheck + New-AnonymousWebSession +
+    Get-TaxEditorBaseUrl so the probe runs offline. Covers a healthy compute
+    (200 + vectors), the t/2784 failure (500), a 200-with-no-vectors degenerate
+    case, and asserts the anon session + x-request-id header are threaded so a
+    failure is traceable with Get-ServerLog.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-EmbeddingHealth (t/2787)' -Tag 'health' {
+
+    BeforeEach {
+        InModuleScope AITriad {
+            Mock New-AnonymousWebSession -MockWith { [Microsoft.PowerShell.Commands.WebRequestSession]::new() }
+            Mock Get-TaxEditorBaseUrl -MockWith { 'https://prod.example' }
+            function script:New-RC ($Success, $Status, $Body) {
+                [PSCustomObject]@{
+                    Success = $Success; StatusCode = $Status; ResponseMs = 42
+                    Body = $Body; ContentType = 'application/json'; RawBody = ''
+                    Error = $(if (-not $Success) { "HTTP $Status" } else { $null })
+                }
+            }
+        }
+    }
+
+    It 'Healthy when compute returns 200 + a non-empty vector' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                New-RC $true 200 ([PSCustomObject]@{ vectors = @(, @(0.1, 0.2, 0.3, 0.4)) })
+            }
+            $h = Test-EmbeddingHealth 6>$null
+            $h.Healthy    | Should -BeTrue
+            $h.StatusCode | Should -Be 200
+            $h.VectorDims | Should -Be 4
+            $h.RequestId  | Should -Not -BeNullOrEmpty
+            $h.Error      | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Unhealthy on a 500 (the t/2784 failure) — surfaces status + a traceable requestId' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith { New-RC $false 500 $null }
+            $h = Test-EmbeddingHealth 6>$null
+            $h.Healthy    | Should -BeFalse
+            $h.StatusCode | Should -Be 500
+            $h.Error      | Should -Match '500'
+            $h.RequestId  | Should -Not -BeNullOrEmpty -Because 'the requestId must be reported for Get-ServerLog correlation'
+        }
+    }
+
+    It 'Unhealthy when 200 carries no vectors' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith { New-RC $true 200 ([PSCustomObject]@{ vectors = @() }) }
+            $h = Test-EmbeddingHealth 6>$null
+            $h.Healthy | Should -BeFalse
+            $h.Error   | Should -Match 'no vectors'
+        }
+    }
+
+    It 'Threads anon session + x-request-id header + JSON body to the compute endpoint' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith { New-RC $true 200 ([PSCustomObject]@{ vectors = @(, @(1.0)) }) }
+            $h = Test-EmbeddingHealth 6>$null
+            Should -Invoke Invoke-RemoteCheck -Times 1 -Exactly -ParameterFilter {
+                $Path -like '/api/embeddings/compute*' -and $Method -eq 'POST' -and
+                $null -ne $Session -and
+                $ExtraHeaders['x-request-id'] -eq $h.RequestId
+            }
+        }
+    }
+
+    It '-Backend is forwarded as a ?backend= query hint and echoed in output' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith { New-RC $true 200 ([PSCustomObject]@{ vectors = @(, @(1.0)) }) }
+            $h = Test-EmbeddingHealth -Backend 'gemini' 6>$null
+            $h.Backend | Should -Be 'gemini'
+            Should -Invoke Invoke-RemoteCheck -Times 1 -Exactly -ParameterFilter { $Path -like '*backend=gemini*' }
+        }
+    }
+
+    It 'Is exported and resolvable after import' {
+        Get-Command Test-EmbeddingHealth -Module AITriad -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## What (Diagnostics, from the t/2784 semantic-search 500)
New `Test-EmbeddingHealth [-BaseUrl] [-Backend] [-TimeoutSec]` — proactively probes the embedding endpoint so a broken `/compute` is caught before a user hits it:
- Establishes an anon session (AUTH_OPTIONAL cookie-less → Sign-In interstitial, t/2684)
- POSTs a minimal `{ texts: ["embedding health check"] }` with a generated `x-request-id`
- Reports **Healthy**, HTTP status, duration, returned **vector dims**, and the **requestId** — so a failure is traceable with `Get-ServerLog -RequestId`

Fits the session-start health suite alongside `Test-TaxEditorHealth`.

## Deviation from the requested signature (flagged)
The `/compute` body is `{ texts, ids }`; it selects the embedding backend from **server config, not per-request**. So `-Backend` is kept in the signature but forwarded only as an **advisory `?backend=` hint** (ignored server-side today) and echoed in output — documented as reserved for forward-compat. Flagged to Diagnostics.

## Playbook
`/add-ps-cmdlet` self-cert. Registered in both `AITriad.psd1` + `AITriad.psm1`; StrictMode-safe (guarded JSON access); added to `docs/cmdlet-reference.md`.

## Tests — 6/6
healthy (200+vector) · **500 failure surfaces a traceable requestId** · 200-no-vectors · anon-session + `x-request-id` + JSON body threading · `-Backend` forwarding · export. `Invoke-RemoteCheck` + anon session mocked. Export-sync + `Test-ModuleManifest` OK.

Closes t/2787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)