### PR TITLE
fix(container): bake ONNX all-MiniLM-L6-v2 model into image (t/2784)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -89,6 +89,24 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     chmod +x /tmp/pnpm && \
     PATH="/tmp:$PATH" npm run build:container
 
+# ── Stage 1b: ONNX model download ──
+# Bakes all-MiniLM-L6-v2 (fp32, equivalence-anchored at t/1651) into the image
+# so onnxEmbedding.ts runs fully offline. Without this, each cold-start downloads
+# from HuggingFace at runtime, hitting the 50s route timeout (t/2784).
+# fp32 is required — quantized output diverges from the stored embeddings.json corpus.
+FROM node:22.23.2-trixie-slim@sha256:db8a96a63e5264607ada2d206758876ebbed6a12be2ada7517793cbfb0c2a29c AS onnx-model
+# hadolint ignore=DL3008
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends curl ca-certificates
+RUN mkdir -p /onnx/all-MiniLM-L6-v2 \
+ && curl -fsSL "https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx" \
+         -o /onnx/all-MiniLM-L6-v2/model.onnx \
+ && curl -fsSL "https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/tokenizer.json" \
+         -o /onnx/all-MiniLM-L6-v2/tokenizer.json \
+ && curl -fsSL "https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/tokenizer_config.json" \
+         -o /onnx/all-MiniLM-L6-v2/tokenizer_config.json
+
 # ── Stage 2: Production dependencies (with build tools for native modules) ──
 FROM node:22.23.2-trixie-slim@sha256:db8a96a63e5264607ada2d206758876ebbed6a12be2ada7517793cbfb0c2a29c AS prod-deps
 
@@ -137,6 +155,8 @@ ENV TAXONOMY_CACHE_DIR=/tmp/taxonomy-cache
 ENV PORT=7862
 ENV NODE_ENV=production
 ENV PYTHONUNBUFFERED=1
+# Baked ONNX model dir — makes onnxEmbedding.ts run fully offline (t/2784, t/1641).
+ENV AI_TRIAD_ONNX_MODEL_DIR=/app/onnx-models/all-MiniLM-L6-v2
 # PYTHONUTF8=1: PEP 540 UTF-8 Mode — forces UTF-8 for stdio AND open() on all platforms.
 # Prevents UnicodeEncodeError/DecodeError on non-ASCII from pty-broker.py (t/2046).
 ENV PYTHONUTF8=1
@@ -163,6 +183,9 @@ COPY --chown=aitriad:aitriad lib/oped/prompts/ ./lib/oped/prompts/
 # soulDocLoader.ts reads these at runtime via fs.readFile from SOUL_DOCS_DIR
 # (= /app/lib/debate/soul-docs/); tsc does not emit .json data files, so copy explicitly.
 COPY --chown=aitriad:aitriad lib/debate/soul-docs/ ./lib/debate/soul-docs/
+
+# 2b. ONNX model files (baked offline; change only when model contract changes — t/2784)
+COPY --from=onnx-model --chown=aitriad:aitriad /onnx/all-MiniLM-L6-v2/ ./onnx-models/all-MiniLM-L6-v2/
 
 # 3. Built artifacts (change on every code edit — LAST for fastest rebuilds)
 # tsc outputs to dist/server/{taxonomy-editor/src/server/,lib/} due to rootDir=../


### PR DESCRIPTION
## Summary

- Adds `onnx-model` build stage that downloads the fp32 `all-MiniLM-L6-v2` ONNX model files from HuggingFace **at image build time**
- COPYs them into the runtime stage at `/app/onnx-models/all-MiniLM-L6-v2/`
- Sets `ENV AI_TRIAD_ONNX_MODEL_DIR=/app/onnx-models/all-MiniLM-L6-v2` so `onnxEmbedding.ts` runs fully offline

## Root cause (confirmed via production logs, t/2784)

All 3 `POST /api/embeddings/compute` 500s on 2026-08-18: `"No local embedding encoder available after ~50s — the Python sentence-transformers venv is absent and the in-process ONNX all-MiniLM-L6-v2 fallback failed to initialize"`. Without `AI_TRIAD_ONNX_MODEL_DIR`, the code attempted a HuggingFace download at request time, timing out at the 50s route timeout. Semantic search broken for all hosted-web users.

## Notes

- fp32 model required (quantized output diverges from stored `embeddings.json` corpus — t/1651)
- `test-container` CI job validates the image builds and the server starts cleanly
- Post-merge: trigger container build + deploy to restore semantic search

## Test plan

- [ ] `test-container` CI passes (image builds with model files baked in, liveness smoke passes)
- [ ] Post-merge: container build + smoke test confirms `/api/embeddings/compute` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)