### PR TITLE
obs(embeddings): log chainMembers on ai.request + ai.fallback FR events (t/2785)

### DIFF
--- a/lib/embeddings/embeddingResolver.ts
+++ b/lib/embeddings/embeddingResolver.ts
@@ -35,6 +35,14 @@ export async function resolveEmbeddings(
     const missingIds = ids ? missingIndices.map(i => ids[i]) : undefined;
     let computed: number[][] | null = null;
 
+    getGlobalRecorder()?.record({
+      type: 'ai.request',
+      component: 'embedding-resolver',
+      level: 'info',
+      message: 'computing embeddings',
+      data: { chainMembers: fallbackChain.map(f => f.name) },
+    });
+
     for (const fallback of fallbackChain) {
       try {
         computed = await fallback.compute(missingTexts, missingIds);
@@ -45,6 +53,7 @@ export async function resolveEmbeddings(
           component: 'embedding-resolver',
           level: 'warn',
           message: `Embedding fallback "${fallback.name}" failed, trying next`,
+          data: { chainMembers: fallbackChain.map(f => f.name) },
           error: { name: (err as Error).name ?? 'Error', message: String(err) },
         });
       }


### PR DESCRIPTION
## Summary

- Adds `ai.request` FR event at entry to the fallback chain with `data.chainMembers` listing all available chain members
- Adds `chainMembers` to the existing `ai.fallback` event so dumps show the full chain alongside the step that failed
- Single-file change in `lib/embeddings/embeddingResolver.ts` — no API or type changes

Fixes the t/2784 diagnosis gap where chain availability had to be inferred from logs rather than read directly from a FR dump.

Self-certifying under /trivial-change: 9 insertions, single file in lib/, no new exports, no interface changes. Typecheck errors are pre-existing environment issues in electron-shared/sanitize, not introduced by this change.

## Test plan
- [ ] CI green (renderer-tsc + test-powershell)
- [ ] Spot-check: flight-recorder dump from an embeddings call shows `ai.request` event with `chainMembers` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)