### PR TITLE
fix(search): remove false AI-backend attribution from embedding error (t/2788)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts
@@ -185,7 +185,7 @@ export const createSearchSlice: StateCreator<TaxonomyStore, [], [], SearchSlice>
       set({
         semanticResults: [],
         embeddingLoading: false,
-        embeddingError: `Semantic search failed while computing embeddings for "${query}" using ${aiBackend}/${geminiModel}. ${detail}`,
+        embeddingError: `Semantic search failed while computing embeddings for "${query}". ${detail}`,
       });
     }
   },


### PR DESCRIPTION
## Summary
One-line fix: remove `using ${aiBackend}/${geminiModel}` from the embedding failure error string in `searchSlice.ts:188`. Embeddings are computed locally (ONNX/Python) — the generation backend is irrelevant to embedding failures. The `detail` string from `ActionableError` already carries the real cause.

Self-certifying under /trivial-change. 1 line changed, single file, no new API, no interface change.

## Test plan
- [ ] CI green
- [ ] Trigger an embedding failure — error message no longer mentions Gemini/backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
