### PR TITLE
fix(deploy): walk back to CI-green ancestor for docs-only pushes (t/2784)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -105,12 +105,27 @@ jobs:
         run: |
           echo "Checking CI status for ${{ github.sha }}..."
 
-          # Get the latest CI run for this commit
-          RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${{ github.sha }}&per_page=1" \
-            --jq '.workflow_runs[0].id // empty' 2>/dev/null || echo "")
+          # Get the latest CI run for this commit (or its nearest ancestor).
+          # Docs-only pushes to main are intentionally skipped by ci.yml paths-ignore
+          # (**.md, docs/**, deploy/azure/runbooks/**), so HEAD may have no CI run.
+          # Walk back up to 10 commits to find the last green ancestor — safe because
+          # docs-only commits cannot affect the container image.
+          COMMITS=$(gh api "repos/${{ github.repository }}/commits?sha=${{ github.sha }}&per_page=10" \
+            --jq '.[].sha' 2>/dev/null || echo "")
+          RUN_ID=""
+          for COMMIT in $COMMITS; do
+            RUN_ID=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=${COMMIT}&per_page=1" \
+              --jq '.workflow_runs[0].id // empty' 2>/dev/null || echo "")
+            if [ -n "$RUN_ID" ]; then
+              if [ "$COMMIT" != "${{ github.sha }}" ]; then
+                echo "HEAD ${{ github.sha }} has no CI run (docs-only skip). Using ancestor ${COMMIT} (run ${RUN_ID})."
+              fi
+              break
+            fi
+          done
 
           if [ -z "$RUN_ID" ]; then
-            echo "::error::No CI run found for commit ${{ github.sha }}. CI must run before deploying."
+            echo "::error::No CI run found for commit ${{ github.sha }} or recent ancestors. CI must run before deploying."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Deploy preflight "Verify container-relevant CI" fails when HEAD is a docs-only commit (`**.md`, `docs/**`, `deploy/azure/runbooks/**`), because `ci.yml` intentionally skips those via `paths-ignore` — no CI run record is created for the commit SHA.
- Fix: walk back up to 10 ancestors via the GitHub API to find the nearest commit with a CI run. Docs-only commits cannot affect the container image, so using an ancestor's green CI is sound.

## Root cause

`ci.yml` paths-ignore skips workflow creation (not just jobs) for docs-only pushes. `deploy-azure.yml` preflight queries `head_sha={{ github.sha }}` — no run exists, preflight exits 1.

Triggered by the t/2731 docs PR merging between the t/2784 ONNX fix and its deploy, blocking the production restore.

## Test plan

- [ ] CI passes on this PR (workflow-lint covers the YAML)
- [ ] Post-merge: re-trigger `deploy-azure.yml` — preflight now walks back, finds `498618ca`/`389522b7` ancestor CI run, proceeds to deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)