### PR TITLE
feat(chat): add JSON export format (t/2782)

### DIFF
--- a/lib/chat/__tests__/chatExportFormatters.test.ts
+++ b/lib/chat/__tests__/chatExportFormatters.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import {
+  chatToMarkdown,
+  chatToText,
+  chatToJson,
+  chatExportFilename,
+  type ChatExportEntry,
+  type ChatExportOptions,
+} from '../chatExportFormatters.js';
+
+const OPTS: ChatExportOptions = {
+  title: 'Test Chat',
+  mode: 'brainstorm',
+  pov: 'safetyist',
+};
+
+const ENTRIES: ChatExportEntry[] = [
+  {
+    id: 'e1',
+    timestamp: '2026-01-01T10:00:00.000Z',
+    speaker: 'user',
+    content: 'Hello world',
+    taxonomy_refs: [],
+  },
+  {
+    id: 'e2',
+    timestamp: '2026-01-01T10:01:00.000Z',
+    speaker: 'safetyist',
+    content: 'AI safety matters.',
+    taxonomy_refs: [{ node_id: 'saf-bel-001', label: 'Risk', relevance: 'high' }],
+  },
+];
+
+describe('chatToMarkdown', () => {
+  it('includes title and perspective', () => {
+    const out = chatToMarkdown(ENTRIES, OPTS);
+    expect(out).toContain('# Test Chat');
+    expect(out).toContain('Safetyist');
+    expect(out).toContain('Brainstorm');
+  });
+
+  it('includes speaker content', () => {
+    const out = chatToMarkdown(ENTRIES, OPTS);
+    expect(out).toContain('Hello world');
+    expect(out).toContain('AI safety matters.');
+  });
+
+  it('includes taxonomy refs', () => {
+    const out = chatToMarkdown(ENTRIES, OPTS);
+    expect(out).toContain('saf-bel-001');
+  });
+});
+
+describe('chatToText', () => {
+  it('includes title and perspective', () => {
+    const out = chatToText(ENTRIES, OPTS);
+    expect(out).toContain('Test Chat');
+    expect(out).toContain('Safetyist');
+  });
+
+  it('includes speaker content', () => {
+    const out = chatToText(ENTRIES, OPTS);
+    expect(out).toContain('Hello world');
+    expect(out).toContain('AI safety matters.');
+  });
+});
+
+describe('chatToJson', () => {
+  it('produces valid JSON', () => {
+    const out = chatToJson(ENTRIES, OPTS);
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
+
+  it('includes schema version', () => {
+    const parsed = JSON.parse(chatToJson(ENTRIES, OPTS));
+    expect(parsed.schema).toBe('ai-triad-chat-export/1');
+  });
+
+  it('preserves title, pov, mode', () => {
+    const parsed = JSON.parse(chatToJson(ENTRIES, OPTS));
+    expect(parsed.title).toBe('Test Chat');
+    expect(parsed.pov).toBe('safetyist');
+    expect(parsed.mode).toBe('brainstorm');
+  });
+
+  it('includes exportedAt ISO timestamp', () => {
+    const parsed = JSON.parse(chatToJson(ENTRIES, OPTS));
+    expect(typeof parsed.exportedAt).toBe('string');
+    expect(() => new Date(parsed.exportedAt)).not.toThrow();
+  });
+
+  it('preserves all message fields', () => {
+    const parsed = JSON.parse(chatToJson(ENTRIES, OPTS));
+    expect(parsed.messages).toHaveLength(2);
+    const [m1, m2] = parsed.messages;
+    expect(m1.id).toBe('e1');
+    expect(m1.content).toBe('Hello world');
+    expect(m2.taxonomy_refs).toHaveLength(1);
+    expect(m2.taxonomy_refs[0].node_id).toBe('saf-bel-001');
+  });
+
+  it('produces pretty-printed output (indented)', () => {
+    const out = chatToJson(ENTRIES, OPTS);
+    expect(out).toContain('\n  ');
+  });
+});
+
+describe('chatExportFilename', () => {
+  it('slugifies title and appends extension', () => {
+    const name = chatExportFilename('My Chat Title', 'json');
+    expect(name).toMatch(/^chat-my-chat-title-\d{8}\.json$/);
+  });
+
+  it('handles empty title', () => {
+    const name = chatExportFilename('', 'md');
+    expect(name).toMatch(/^chat-untitled-\d{8}\.md$/);
+  });
+});

--- a/lib/chat/chatExportFormatters.ts
+++ b/lib/chat/chatExportFormatters.ts
@@ -217,6 +217,21 @@ ${entriesHtml}
 </html>`;
 }
 
+export function chatToJson(entries: ChatExportEntry[], options: ChatExportOptions): string {
+  return JSON.stringify(
+    {
+      schema: 'ai-triad-chat-export/1',
+      title: options.title,
+      pov: options.pov,
+      mode: options.mode,
+      exportedAt: new Date().toISOString(),
+      messages: entries,
+    },
+    null,
+    2,
+  );
+}
+
 export function chatExportFilename(title: string, ext: string): string {
   const slug = slugify(title);
   const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');

--- a/taxonomy-editor/src/main/ipc/chatHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/chatHandlers.ts
@@ -12,7 +12,7 @@ import {
   saveChatSession,
   deleteChatSession,
 } from '../chatIO.js';
-import { chatToMarkdown, chatToText, chatToPrintHtml, chatExportFilename, type ChatExportEntry, type ChatExportOptions } from '../../../../lib/chat/chatExportFormatters.js';
+import { chatToMarkdown, chatToText, chatToPrintHtml, chatToJson, chatExportFilename, type ChatExportEntry, type ChatExportOptions } from '../../../../lib/chat/chatExportFormatters.js';
 
 export function registerChatHandlers(): void {
   ipcMain.handle('list-chat-sessions', () => {
@@ -33,17 +33,18 @@ export function registerChatHandlers(): void {
 
   // Chat export (t/1485) — mirrors export-debate-to-file. Formatters live in lib/chat
   // (main-safe, like lib/debate); PDF is print-to-PDF via an offscreen window like debateToPdf.
-  ipcMain.handle('export-chat-to-file', async (event, entries: ChatExportEntry[], format: 'markdown' | 'text' | 'pdf', options: ChatExportOptions) => {
+  ipcMain.handle('export-chat-to-file', async (event, entries: ChatExportEntry[], format: 'markdown' | 'text' | 'pdf' | 'json', options: ChatExportOptions) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (!win) return { cancelled: true };
 
     // Map requested format to a default extension and put it first in the filter list.
-    const formatExtMap: Record<string, string> = { markdown: 'md', text: 'txt', pdf: 'pdf' };
+    const formatExtMap: Record<string, string> = { markdown: 'md', text: 'txt', pdf: 'pdf', json: 'json' };
     const defaultExt = formatExtMap[format] || 'md';
     const allFilters = [
       { name: 'Markdown', extensions: ['md'] },
       { name: 'Plain Text', extensions: ['txt'] },
       { name: 'PDF', extensions: ['pdf'] },
+      { name: 'JSON', extensions: ['json'] },
     ];
     const selectedIdx = allFilters.findIndex(f => f.extensions[0] === defaultExt);
     const filters = selectedIdx > 0
@@ -80,6 +81,10 @@ export function registerChatHandlers(): void {
         } finally {
           pdfWindow.destroy();
         }
+        break;
+      }
+      case 'json': {
+        fs.writeFileSync(filePath, chatToJson(entries, options), 'utf-8');
         break;
       }
       case 'md':

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -316,7 +316,7 @@ export interface AppAPI {
   deleteChatSession: (id: string) => Promise<void>;
   exportChatToFile: (
     entries: { id: string; timestamp: string; speaker: string; content: string; taxonomy_refs: { node_id: string; label?: string; relevance: string }[] }[],
-    format: 'markdown' | 'text' | 'pdf',
+    format: 'markdown' | 'text' | 'pdf' | 'json',
     options: { title: string; mode: 'brainstorm' | 'inform' | 'decide'; pov: 'accelerationist' | 'safetyist' | 'skeptic' },
   ) => Promise<{ cancelled: boolean; filePath?: string }>;
 

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -1100,7 +1100,7 @@ const rawApi: AppAPI = {
   saveChatSession: (session) => put('/api/chats', session).then(() => {}),
   deleteChatSession: (id) => del(`/api/chats/${encodeURIComponent(id)}`).then(() => {}),
   exportChatToFile: async (entries, format, options) => {
-    const { chatToMarkdown, chatToText, chatToPrintHtml, chatExportFilename } = await import('@lib/chat/chatExportFormatters');
+    const { chatToMarkdown, chatToText, chatToPrintHtml, chatToJson, chatExportFilename } = await import('@lib/chat/chatExportFormatters');
     const exportOpts = { title: options.title, mode: options.mode, pov: options.pov };
 
     switch (format) {
@@ -1129,6 +1129,17 @@ const rawApi: AppAPI = {
         const content = chatToText(entries, exportOpts);
         const filename = chatExportFilename(options.title, 'txt');
         const blob = new Blob([content], { type: 'text/plain' });
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(a.href);
+        return { cancelled: false, filePath: filename };
+      }
+      case 'json': {
+        const content = chatToJson(entries, exportOpts);
+        const filename = chatExportFilename(options.title, 'json');
+        const blob = new Blob([content], { type: 'application/json' });
         const a = document.createElement('a');
         a.href = URL.createObjectURL(blob);
         a.download = filename;


### PR DESCRIPTION
## Summary
- Adds `chatToJson(entries, options)` to `lib/chat/chatExportFormatters.ts` — schema-versioned pretty JSON (`schema: 'ai-triad-chat-export/1'`) with `title`, `pov`, `mode`, `exportedAt`, and `messages[]`
- Widens format union from `'markdown' | 'text' | 'pdf'` to `+ 'json'` in `bridge/types.ts`, `chatHandlers.ts` (Electron main + dialog filter), and `web-bridge.ts` (browser blob download)
- Adds `lib/chat/__tests__/chatExportFormatters.test.ts` covering all four formatters including JSON structure, schema field, pretty-printing, and filename generation
- `package` format omitted — chat has no embedded assets to bundle (per TL guidance)

## Test plan
- [ ] CI green (formatter tests in lib/chat/__tests__)
- [ ] Export chat as JSON in Electron — dialog shows JSON option, file is valid pretty-printed JSON with schema field
- [ ] Export chat as JSON in web build — blob download triggers with `.json` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)
