### PR TITLE
feat(server): embedding health endpoint + loud warmup error (t/2789 Part 2)

### DIFF
--- a/lib/embeddings/onnxEmbedding.ts
+++ b/lib/embeddings/onnxEmbedding.ts
@@ -86,6 +86,8 @@ let _ort: OrtModule | null = null;
 let _session: OrtSession | null = null;
 let _tokenizer: WordPieceTokenizer | null = null;
 let _initPromise: Promise<void> | null = null;
+let _warmupResult: boolean | null = null;
+let _warmupError: string | undefined;
 let _modelDir: string | null = null;
 let _offline = false; // true when the model dir came from MODEL_DIR_ENV — authoritative, never fetch
 let _selectedEP: string = 'none';
@@ -481,10 +483,15 @@ export async function warmup(): Promise<void> {
  * Consumers can use this to decide whether to fall back to Python subprocess.
  */
 export async function tryWarmup(): Promise<boolean> {
+  if (_warmupResult !== null) return _warmupResult;
   try {
     await ensureReady();
+    _warmupResult = true;
+    _warmupError = undefined;
     return true;
   } catch (err) {
+    _warmupResult = false;
+    _warmupError = String(err);
     console.warn(`[onnxEmbedding] Initialization failed, Python fallback recommended: ${err}`);
     return false;
   }
@@ -493,6 +500,12 @@ export async function tryWarmup(): Promise<boolean> {
 /** Check if the model is loaded and ready for inference. */
 export function isReady(): boolean {
   return _session != null && _tokenizer != null;
+}
+
+/** Report cached warmup status for health endpoints. */
+export function getWarmupStatus(): { ready: boolean; error?: string } {
+  if (_warmupResult === null) return { ready: false, error: 'warmup not yet attempted' };
+  return _warmupResult ? { ready: true } : { ready: false, error: _warmupError };
 }
 
 /** Return the active execution provider ('openvino', 'dml', 'cpu', or 'none' if not initialized). */

--- a/taxonomy-editor/src/server/__tests__/embeddingHealth.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingHealth.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Unit tests for GET /api/health/embeddings (t/2789 Part 2).
+// Covers: publicPaths inclusion, 200 on ready, 503 on not-ready, error passthrough.
+
+import { describe, it, expect } from 'vitest';
+import { PUBLIC_EXACT_PATHS, computeIsPublicPath } from '../publicPaths.js';
+
+// ── publicPaths ──────────────────────────────────────────────────────────────
+
+describe('publicPaths — /api/health/embeddings', () => {
+  it('is in PUBLIC_EXACT_PATHS', () => {
+    expect(PUBLIC_EXACT_PATHS.has('/api/health/embeddings')).toBe(true);
+  });
+
+  it('computeIsPublicPath returns true for the endpoint', () => {
+    expect(computeIsPublicPath('/api/health/embeddings')).toBe(true);
+  });
+
+  it('does not treat it as a prefix (trailing path must not match)', () => {
+    expect(computeIsPublicPath('/api/health/embeddings/extra')).toBe(false);
+  });
+});
+
+// ── handler response shape (inline simulation) ───────────────────────────────
+// The route handler is a thin conditional over getWarmupStatus(); we test the
+// output shape that the conditional produces rather than importing the full
+// diagnostics route module (which pulls in heavy server deps).
+
+type WarmupStatus = { ready: boolean; error?: string };
+
+function simulateHandler(status: WarmupStatus): { statusCode: number; body: Record<string, unknown> } {
+  if (status.ready) {
+    return { statusCode: 200, body: { ok: true, ready: true } };
+  }
+  return { statusCode: 503, body: { ok: false, ready: false, error: status.error ?? 'not ready' } };
+}
+
+describe('GET /api/health/embeddings — response shape', () => {
+  it('returns 200 { ok, ready: true } when embedding is warm', () => {
+    const { statusCode, body } = simulateHandler({ ready: true });
+    expect(statusCode).toBe(200);
+    expect(body).toEqual({ ok: true, ready: true });
+  });
+
+  it('returns 503 { ok: false, ready: false, error } when warmup failed', () => {
+    const { statusCode, body } = simulateHandler({ ready: false, error: 'ONNX model load failed' });
+    expect(statusCode).toBe(503);
+    expect(body).toEqual({ ok: false, ready: false, error: 'ONNX model load failed' });
+  });
+
+  it('uses "not ready" fallback when error field absent', () => {
+    const { statusCode, body } = simulateHandler({ ready: false });
+    expect(statusCode).toBe(503);
+    expect(body.error).toBe('not ready');
+  });
+});

--- a/taxonomy-editor/src/server/publicPaths.ts
+++ b/taxonomy-editor/src/server/publicPaths.ts
@@ -32,6 +32,7 @@ export const PUBLIC_EXACT_PATHS: ReadonlySet<string> = new Set<string>([
   '/manifest.webmanifest',
   '/sw.js',                 // EXACT — contrast the '/workbox-' PREFIX below
   '/api/health/oped-files', // t/2689: runtime-asset health check — no secrets, deterministic; cookie-less smoke must get JSON not interstitial
+  '/api/health/embeddings', // t/2789: embedding readiness — reflects cached warmup result; no secrets
 ]);
 
 /** Prefix public paths (were `urlPath.startsWith(X)`). */

--- a/taxonomy-editor/src/server/routes/diagnostics.ts
+++ b/taxonomy-editor/src/server/routes/diagnostics.ts
@@ -28,6 +28,7 @@ import { getRequestId } from '../logger.js';
 import { log } from '../logger.js';
 import * as community from '../community/community.js';
 import * as fileIO from '../storage/fileIO.js';
+import { getWarmupStatus } from '../../../../lib/embeddings/onnxEmbedding.js';
 
 export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
   const { get, post, put, del } = r;
@@ -311,6 +312,19 @@ document.addEventListener('DOMContentLoaded', function() {
         json(res, { ok: false, missing, present }, 500);
       }
     } catch (err) { getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to check oped runtime assets', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); error(res, String(err), 500, err); }
+  });
+
+  // ── Embedding health (t/2789 Part 2) ──
+  // No-auth endpoint: reflects the cached warmup result from onnxEmbedding.ts.
+  // 200 { ok, ready } when warm; 503 { ok, ready, error } when warmup failed.
+  // Does NOT gate /healthz — embedding warm-up failure is non-fatal.
+  get('/api/health/embeddings', (_req, res) => {
+    const status = getWarmupStatus();
+    if (status.ready) {
+      json(res, { ok: true, ready: true });
+    } else {
+      json(res, { ok: false, ready: false, error: status.error ?? 'not ready' }, 503);
+    }
   });
 
   // ── Chat sessions ──

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -1326,7 +1326,10 @@ server.listen(PORT, BIND_HOST, () => {
   serverRecorder.record({ type: 'lifecycle', component: 'server', level: 'info', message: 'Server started', data: { port: PORT, host: BIND_HOST, version: SERVER_VERSION, dataRoot: getDataRoot(), platform: process.platform, arch: process.arch, storageMode: STORAGE_MODE } });
   log.server.info({ port: PORT, host: BIND_HOST }, 'Taxonomy Editor running');
   log.server.info({ dataRoot: getDataRoot() }, 'Data root');
-  void warmupEmbeddings().catch((err: unknown) => log.server.warn({ err: String(err) }, 't/2719: ONNX embedding warmup failed at boot (non-fatal — first grounding request pays the cold-load)'));
+  void warmupEmbeddings().catch((err: unknown) => {
+    log.server.error({ err: String(err) }, 'ONNX embedding warmup failed at boot');
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'ONNX embedding warmup failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });
+  });
 
   // t/924: surface the free-tier key pool + effective RPM so rate-limit
   // behavior is observable from startup logs (not inferred from 429 timing).


### PR DESCRIPTION
**Depends on PR #1225** (`feat/t2789-onnx-warmup-cache`) — base will be rebased to `main` once that merges.

## Summary
- `GET /api/health/embeddings`: no-auth public endpoint reflecting the cached ONNX warmup result. Returns `200 { ok, ready: true }` when warm, `503 { ok: false, ready: false, error }` when warmup failed. Does not gate `/healthz`.
- `publicPaths.ts`: adds `/api/health/embeddings` to `PUBLIC_EXACT_PATHS` (exact match — not a prefix)
- `server.ts:1329`: upgrades warmup failure from `log.warn` to `log.error` + FR `system.error` record so startup failures are visible in the diagnostics dump
- `server/__tests__/embeddingHealth.test.ts`: covers publicPaths inclusion, 200/503 response shapes, and fallback error message

## Test plan
- [ ] CI green on this branch (compiles against Part 1's `getWarmupStatus()`)
- [ ] `GET /api/health/embeddings` returns 200 when ONNX is warm
- [ ] Returns 503 when ONNX warmup failed (simulate by blocking model load)
- [ ] Startup warmup failure now shows as ERROR in server logs and appears in FR dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
