### PR TITLE
feat(deploy): wire Test-EmbeddingHealth into pre-traffic-shift acceptance gate (t/2786)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -438,7 +438,17 @@ jobs:
             Write-Host "  GitHub: $(if ($SmokeResult.GitHubOk) { 'OK' } else { 'FAIL' })"
             foreach ($F in $SmokeResult.FailedEndpoints) { Write-Host "  FAIL  $($F.Endpoint): $($F.Error)" }
           } else {
-            Add-Content -Path $env:GITHUB_OUTPUT -Value 'accepted=true'
+            # Embedding health check — blocks traffic shift if ONNX encoder is down (t/2786).
+            # Must assert a real 384-dim vector, not just HTTP 200 — silent-degradation guard.
+            Write-Host ""
+            Write-Host "=== Embedding health check (pre-traffic shift) ==="
+            $EmbedHealth = Test-EmbeddingHealth -BaseUrl $BaseUrl
+            if (-not $EmbedHealth.Healthy) {
+              Add-Content -Path $env:GITHUB_OUTPUT -Value 'accepted=false'
+              Write-Host "::error::Embedding health FAILED ($($EmbedHealth.Error)) — NOT shifting traffic. Trace: Get-ServerLog -RequestId $($EmbedHealth.RequestId)"
+            } else {
+              Add-Content -Path $env:GITHUB_OUTPUT -Value 'accepted=true'
+            }
           }
 
       - name: Persona matrix (pre-traffic shift)


### PR DESCRIPTION
## Summary

- Adds `Test-EmbeddingHealth` call in the acceptance step **after** `Invoke-TaxEditorSmokeTest` passes but **before** traffic shifts to the new revision
- If the ONNX encoder is down → `Healthy=False` → sets `accepted=false` → blocks traffic shift → triggers existing rollback path
- Asserts a real 384-dim vector (not just HTTP 200) — the silent-degradation guard: a container returning 200 with no vectors would pass a naive status check but fail here

## Blocking gate

**Hold: awaiting TL sign-off (p/331#424 / t/2786)** — both-arms evidence already provided (success: prod dims=384; failure: Pester unhealthy-on-500 + unhealthy-on-200-with-no-vectors). Staying draft until sign-off lands.

## Test plan

- [ ] CI green (workflow-lint covers the YAML change)
- [ ] TL sign-off on t/2786 gate-verification
- [ ] Post-merge: next deploy will exercise the embedding check pre-traffic-shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)