### PR TITLE
feat(chat): ChatTable + full-width table mode + search + New to popout (t/2783)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatExportDropdown.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatExportDropdown.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { useState, useRef, useEffect } from 'react';
+import '../debate/ExportDropdown.css';
+
+// Chat export formats: json + md + text + pdf (t/2782 parity; no package — chats have no assets).
+const CHAT_EXPORT_OPTIONS: { format: string; label: string }[] = [
+  { format: 'pdf', label: 'PDF' },
+  { format: 'json', label: 'JSON' },
+  { format: 'markdown', label: 'Markdown' },
+  { format: 'text', label: 'Text' },
+];
+
+export function ChatExportDropdown({ onExport }: { onExport: (format: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDocMouseDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onDocMouseDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  const pick = (format: string) => { setOpen(false); onExport(format); };
+
+  return (
+    <div ref={ref} className="export-dropdown">
+      <button
+        type="button"
+        className="btn"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+      >
+        Export ▾
+      </button>
+      {open && (
+        <div role="menu" className="export-dropdown-menu">
+          {CHAT_EXPORT_OPTIONS.map(({ format, label }) => (
+            <button
+              key={format}
+              type="button"
+              role="menuitem"
+              className="btn export-dropdown-item"
+              onClick={() => pick(format)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useChatStore } from '../../hooks/useChatStore';
@@ -11,6 +11,7 @@ import type { CommunityChat } from '../../hooks/useCommunityStore';
 import { useResizablePanel } from '../../hooks/useResizablePanel';
 import { useBreakpoint } from '../../hooks/useBreakpoint';
 import { NewChatDialog } from './NewChatDialog';
+import { ChatTable } from './ChatTable';
 import { ChatWorkspace } from './ChatWorkspace';
 import { SearchPreview } from '../edge-browser/SearchPreview';
 import { PromptDetailPanel } from './PromptsPanel';
@@ -442,6 +443,30 @@ export function ChatTab() {
   const { chats: communityChats, loading: communityLoading, fetchChats: fetchCommunityChats, copyItem } = useCommunityStore();
   const [copyingId, setCopyingId] = useState<string | null>(null);
   const [selectedCommunityChat, setSelectedCommunityChat] = useState<CommunityChat | null>(null);
+  const isTableMode = !toolbarPanel && !isPhone;
+  const [mySearchQuery, setMySearchQuery] = useState('');
+  const [communitySearchQuery, setCommunitySearchQuery] = useState('');
+
+  const handleExportChat = useCallback((id: string, format: string) => {
+    void api.loadChatSession(id).then((raw) => {
+      const session = raw as ChatSession;
+      return api.exportChatToFile(
+        session.transcript,
+        format as 'markdown' | 'text' | 'pdf' | 'json',
+        { title: session.topic, mode: session.mode, pov: session.pover },
+      );
+    }).catch((err: unknown) => {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-tab', level: 'error', message: 'Export failed', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+    });
+  }, []);
+
+  const handleShareChat = useCallback((session: ChatSessionSummary) => {
+    void api.loadChatSession(session.id).then((full) => {
+      return api.submitToCommunity('chat', full as unknown);
+    }).catch((err: unknown) => {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-tab', level: 'error', message: 'Share failed', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+    });
+  }, []);
 
   useEffect(() => {
     void loadSessions();
@@ -485,7 +510,7 @@ export function ChatTab() {
   };
 
   return (
-    <div className={`two-column${isPhone ? ' phone-mode' : ''}${(isPhone && activeChatId && !toolbarPanel) ? ' has-selection' : ''}`}>
+    <div className={`two-column${isPhone ? ' phone-mode' : ''}${(isPhone && activeChatId && !toolbarPanel) ? ' has-selection' : ''}${isTableMode ? ' chat-tab-table-mode' : ''}`}>
       {/* Left pane: Session list OR toolbar panel */}
       {toolbarPanel ? (
         <ToolbarLeftPanel
@@ -498,6 +523,76 @@ export function ChatTab() {
           setSelectedPromptEntry={setSelectedPromptEntry}
           setPromptInspectorActive={setPromptInspectorActive}
         />
+      ) : isTableMode ? (
+        <div className="list-panel chat-session-list" style={{ flex: 1, width: '100%' }}>
+          <div className="list-panel-header">
+            <h2>Chats</h2>
+            <div className="list-panel-header-actions">
+              <button className="btn btn-sm" onClick={() => { setShowNewDialog(true); setListView('my'); }}>+ New</button>
+            </div>
+          </div>
+          <div className="list-view-tabs">
+            <button className={`list-view-tab${listView === 'my' ? ' active' : ''}`} onClick={() => setListView('my')}>My ({sessions.length})</button>
+            <button className={`list-view-tab${listView === 'community' ? ' active' : ''}`} onClick={() => setListView('community')}>Community ({communityChats.length})</button>
+          </div>
+          {listView === 'my' ? (
+            <>
+              <div className="chat-tab-search-wrap">
+                <input
+                  className="chat-tab-search-input"
+                  placeholder="Search chats…"
+                  value={mySearchQuery}
+                  onChange={e => setMySearchQuery(e.target.value)}
+                />
+              </div>
+              <ChatTable
+                variant="my"
+                rows={mySearchQuery ? sessions.filter(s => s.title.toLowerCase().includes(mySearchQuery.toLowerCase())) : sessions}
+                loading={sessionsLoading}
+                searchQuery={mySearchQuery}
+                renamingId={renamingId}
+                setRenamingId={setRenamingId}
+                renameValue={renameValue}
+                setRenameValue={setRenameValue}
+                onRename={renameChat}
+                onOpen={id => { void api.openChatWindow(id, 'my'); }}
+                onExport={handleExportChat}
+                onShare={handleShareChat}
+              />
+            </>
+          ) : (
+            <>
+              <div className="chat-tab-search-wrap">
+                <input
+                  className="chat-tab-search-input"
+                  placeholder="Search community chats…"
+                  value={communitySearchQuery}
+                  onChange={e => setCommunitySearchQuery(e.target.value)}
+                />
+              </div>
+              <ChatTable
+                variant="community"
+                rows={communitySearchQuery ? communityChats.filter(c => c.title.toLowerCase().includes(communitySearchQuery.toLowerCase())) : communityChats}
+                loading={communityLoading}
+                searchQuery={communitySearchQuery}
+                onOpen={id => { void api.openChatWindow(id, 'community'); }}
+                onExport={handleExportChat}
+                onCopy={async cc => {
+                  setCopyingId(cc.id);
+                  try {
+                    await copyItem('chats', cc.id);
+                    void loadSessions();
+                  } catch (err) {
+                    getGlobalRecorder()?.record({ type: 'system.error', component: 'chat-tab', level: 'error', message: 'Failed to copy community chat', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+                  } finally {
+                    setCopyingId(null);
+                  }
+                }}
+                copyingId={copyingId}
+              />
+            </>
+          )}
+        </div>
       ) : listCollapsed ? (
         <div className="pane-collapsed pane-collapsed-list" onClick={() => setListCollapsed(false)} title="Expand list">
           <span className="pane-collapsed-label">Chats</span>
@@ -536,8 +631,8 @@ export function ChatTab() {
         />
       )}
 
-      {/* Right pane: context-dependent */}
-      <RightPane
+      {/* Right pane: context-dependent; hidden in full-width table mode */}
+      {!isTableMode && <RightPane
         toolbarPanel={toolbarPanel}
         promptInspectorActive={promptInspectorActive}
         onMouseDown={onMouseDown}
@@ -550,7 +645,7 @@ export function ChatTab() {
         activeChatId={activeChatId}
         listView={listView}
         selectedCommunityChat={selectedCommunityChat}
-      />
+      />}
 
       {showNewDialog && <NewChatDialog onClose={() => setShowNewDialog(false)} />}
     </div>

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.css
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.css
@@ -23,8 +23,8 @@
 .chat-table thead th {
   position: sticky;
   top: 0;
-  background: var(--color-surface, #fff);
-  border-bottom: 1px solid var(--color-border, #ddd);
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
   padding: 6px 8px;
   text-align: left;
   font-weight: 600;
@@ -33,11 +33,11 @@
 }
 
 .chat-table tbody tr {
-  border-bottom: 1px solid var(--color-border-subtle, #eee);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .chat-table tbody tr:hover {
-  background: var(--color-surface-hover, rgba(0,0,0,.03));
+  background: var(--bg-hover);
 }
 
 .chat-table td {
@@ -86,19 +86,19 @@
 .chat-table-action-btn {
   padding: 2px 8px;
   font-size: 0.8rem;
-  border: 1px solid var(--color-border, #ccc);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--color-surface, #fff);
+  background: var(--bg-primary);
   cursor: pointer;
   white-space: nowrap;
 }
 
 .chat-table-action-btn:hover {
-  background: var(--color-surface-hover, #f0f0f0);
+  background: var(--bg-hover);
 }
 
 .chat-table-action-btn.primary {
-  background: var(--color-primary, #0060df);
+  background: var(--focus-ring);
   color: #fff;
   border-color: transparent;
 }
@@ -111,9 +111,9 @@
   width: 100%;
   font: inherit;
   padding: 2px 4px;
-  border: 1px solid var(--color-primary, #0060df);
+  border: 1px solid var(--focus-ring);
   border-radius: 3px;
-  background: var(--color-surface, #fff);
+  background: var(--bg-primary);
 }
 
 .chat-table-title-text {
@@ -125,7 +125,7 @@
 
 .chat-table-title-secondary {
   font-size: 0.75rem;
-  color: var(--color-text-secondary, #666);
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -134,29 +134,29 @@
 .chat-table-empty-cell {
   padding: 24px 8px;
   text-align: center;
-  color: var(--color-text-secondary, #666);
+  color: var(--text-secondary);
 }
 
 /* Search bar above table */
 .chat-tab-search-wrap {
   padding: 6px 8px;
-  border-bottom: 1px solid var(--color-border-subtle, #eee);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .chat-tab-search-input {
   width: 100%;
   padding: 5px 10px;
   font-size: 0.875rem;
-  border: 1px solid var(--color-border, #ccc);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--color-surface, #fff);
+  background: var(--bg-primary);
   color: inherit;
   box-sizing: border-box;
 }
 
 .chat-tab-search-input:focus {
   outline: none;
-  border-color: var(--color-primary, #0060df);
+  border-color: var(--focus-ring);
 }
 
 /* Table mode: list panel fills full width */
@@ -177,6 +177,6 @@
 @media (prefers-color-scheme: dark) {
   .chat-table thead th,
   .chat-table-rename-input {
-    background: var(--color-surface, #1a1a1a);
+    background: var(--bg-primary);
   }
 }

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.css
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.css
@@ -1,0 +1,182 @@
+/* ChatTable — structural clone of DebateTable.css, chat-scoped class names (t/2783). */
+
+.chat-table-wrap {
+  overflow-x: auto;
+  flex: 1;
+}
+
+.chat-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  table-layout: fixed;
+}
+
+.chat-table caption {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.chat-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--color-surface, #fff);
+  border-bottom: 1px solid var(--color-border, #ddd);
+  padding: 6px 8px;
+  text-align: left;
+  font-weight: 600;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.chat-table tbody tr {
+  border-bottom: 1px solid var(--color-border-subtle, #eee);
+}
+
+.chat-table tbody tr:hover {
+  background: var(--color-surface-hover, rgba(0,0,0,.03));
+}
+
+.chat-table td {
+  padding: 6px 8px;
+  vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* col widths */
+.chat-table .col-created  { width: 110px; }
+.chat-table .col-updated  { width: 110px; }
+.chat-table .col-mode     { width: 80px; }
+.chat-table .col-pov      { width: 110px; }
+.chat-table .col-model    { width: 120px; }
+.chat-table .col-actions  { width: 200px; }
+.chat-table .col-title    { /* absorbs remaining width */ }
+
+.chat-table-sort-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
+  color: inherit;
+  white-space: nowrap;
+}
+
+.chat-table-sort-btn:hover {
+  text-decoration: underline;
+}
+
+.chat-table-sort-indicator {
+  font-size: 0.7em;
+}
+
+.chat-table-actions {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
+.chat-table-action-btn {
+  padding: 2px 8px;
+  font-size: 0.8rem;
+  border: 1px solid var(--color-border, #ccc);
+  border-radius: 4px;
+  background: var(--color-surface, #fff);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.chat-table-action-btn:hover {
+  background: var(--color-surface-hover, #f0f0f0);
+}
+
+.chat-table-action-btn.primary {
+  background: var(--color-primary, #0060df);
+  color: #fff;
+  border-color: transparent;
+}
+
+.chat-table-action-btn.primary:hover {
+  opacity: 0.9;
+}
+
+.chat-table-rename-input {
+  width: 100%;
+  font: inherit;
+  padding: 2px 4px;
+  border: 1px solid var(--color-primary, #0060df);
+  border-radius: 3px;
+  background: var(--color-surface, #fff);
+}
+
+.chat-table-title-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.chat-table-title-secondary {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary, #666);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-table-empty-cell {
+  padding: 24px 8px;
+  text-align: center;
+  color: var(--color-text-secondary, #666);
+}
+
+/* Search bar above table */
+.chat-tab-search-wrap {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--color-border-subtle, #eee);
+}
+
+.chat-tab-search-input {
+  width: 100%;
+  padding: 5px 10px;
+  font-size: 0.875rem;
+  border: 1px solid var(--color-border, #ccc);
+  border-radius: 4px;
+  background: var(--color-surface, #fff);
+  color: inherit;
+  box-sizing: border-box;
+}
+
+.chat-tab-search-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #0060df);
+}
+
+/* Table mode: list panel fills full width */
+.chat-tab-table-mode .list-panel {
+  width: 100% !important;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-tab-table-mode .list-panel-items {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (prefers-color-scheme: dark) {
+  .chat-table thead th,
+  .chat-table-rename-input {
+    background: var(--color-surface, #1a1a1a);
+  }
+}

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
@@ -1,0 +1,466 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// ChatTable — sortable My/Community table for the chat tool (t/2783).
+// Mirrors DebateTable.tsx structure; columns differ (Created/Updated/Mode/POV/Model/Actions/Title).
+
+import { useState, useCallback, useEffect } from 'react';
+import type { CommunityChat } from '../../hooks/useCommunityStore';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { POVER_INFO } from '../../types/debate';
+import type { ChatSessionSummary } from '../../types/chat';
+import { ChatExportDropdown } from './ChatExportDropdown';
+import './ChatTable.css';
+
+// ──────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────
+
+type SortColumn = 'created' | 'updated' | 'mode' | 'pov' | 'model' | 'title';
+type SortDir = 'asc' | 'desc' | 'none';
+
+interface SortState {
+  col: SortColumn | null;
+  dir: SortDir;
+}
+
+export interface ChatTableMyProps {
+  variant: 'my';
+  rows: ChatSessionSummary[];
+  loading: boolean;
+  searchQuery: string;
+  renamingId: string | null;
+  setRenamingId: (id: string | null) => void;
+  renameValue: string;
+  setRenameValue: (v: string) => void;
+  onRename: (id: string, newTitle: string) => Promise<void>;
+  onOpen: (id: string) => void;
+  onExport: (id: string, format: string) => void;
+  onShare: (session: ChatSessionSummary) => void;
+}
+
+export interface ChatTableCommunityProps {
+  variant: 'community';
+  rows: CommunityChat[];
+  loading: boolean;
+  searchQuery: string;
+  onOpen: (id: string) => void;
+  onExport: (id: string, format: string) => void;
+  onCopy: (cc: CommunityChat) => Promise<void>;
+  copyingId: string | null;
+}
+
+export type ChatTableProps = ChatTableMyProps | ChatTableCommunityProps;
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: 'short', day: 'numeric',
+    hour: '2-digit', minute: '2-digit',
+  });
+}
+
+function applySortMy(rows: ChatSessionSummary[], sort: SortState): ChatSessionSummary[] {
+  if (!sort.col || sort.dir === 'none') return rows;
+  const mul = sort.dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    switch (sort.col) {
+      case 'created': return mul * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+      case 'updated': return mul * (new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime());
+      case 'mode':    return mul * (a.mode ?? '').localeCompare(b.mode ?? '');
+      case 'pov':     return mul * (a.pover ?? '').localeCompare(b.pover ?? '');
+      case 'model':   return mul * (a.chat_model ?? '').localeCompare(b.chat_model ?? '');
+      case 'title':   return mul * (a.title ?? '').localeCompare(b.title ?? '');
+      default:        return 0;
+    }
+  });
+}
+
+function applySortCommunity(rows: CommunityChat[], sort: SortState): CommunityChat[] {
+  if (!sort.col || sort.dir === 'none') return rows;
+  const mul = sort.dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    switch (sort.col) {
+      case 'created': return mul * (new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+      case 'updated': return mul * (new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime());
+      case 'mode':    return mul * (a.mode ?? '').localeCompare(b.mode ?? '');
+      case 'model':   return mul * (a.model ?? '').localeCompare(b.model ?? '');
+      case 'title':   return mul * (a.title ?? '').localeCompare(b.title ?? '');
+      default:        return 0;
+    }
+  });
+}
+
+// ──────────────────────────────────────────────
+// SortHeader
+// ──────────────────────────────────────────────
+
+function getSortAttr(col: SortColumn, sort: SortState): 'ascending' | 'descending' | 'none' {
+  if (sort.col !== col) return 'none';
+  return sort.dir === 'asc' ? 'ascending' : 'descending';
+}
+
+function SortHeader({
+  label, col, sort, onSort,
+}: {
+  label: string;
+  col: SortColumn;
+  sort: SortState;
+  onSort: (col: SortColumn) => void;
+}) {
+  const active = sort.col === col;
+  const indicator = active ? (sort.dir === 'asc' ? ' ▲' : ' ▼') : '';
+  return (
+    <button type="button" className="chat-table-sort-btn" onClick={() => onSort(col)}>
+      {label}
+      {indicator && <span className="chat-table-sort-indicator" aria-hidden="true">{indicator}</span>}
+    </button>
+  );
+}
+
+// ──────────────────────────────────────────────
+// ChatTableRow — My variant
+// ──────────────────────────────────────────────
+
+interface ChatTableRowMyProps {
+  s: ChatSessionSummary;
+  renamingId: string | null;
+  setRenamingId: (id: string | null) => void;
+  renameValue: string;
+  setRenameValue: (v: string) => void;
+  onRename: (id: string, newTitle: string) => Promise<void>;
+  onOpen: (id: string) => void;
+  onExport: (id: string, format: string) => void;
+  onShare: (session: ChatSessionSummary) => void;
+}
+
+function ChatTableRowMy({
+  s, renamingId, setRenamingId, renameValue, setRenameValue,
+  onRename, onOpen, onExport, onShare,
+}: ChatTableRowMyProps) {
+  const isRenaming = renamingId === s.id;
+  const safeTitle = s.title || 'Untitled';
+  const poverLabel = POVER_INFO[s.pover as keyof typeof POVER_INFO]?.label || s.pover || '—';
+
+  const commitRename = useCallback(() => {
+    if (renameValue.trim() && renameValue.trim() !== safeTitle) {
+      void onRename(s.id, renameValue.trim());
+    }
+    setRenamingId(null);
+  }, [renameValue, s, onRename, setRenamingId, safeTitle]);
+
+  const handleDoubleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRenamingId(s.id);
+    setRenameValue(safeTitle);
+  }, [s, setRenamingId, setRenameValue, safeTitle]);
+
+  return (
+    <tr>
+      <td className="col-created" title={s.created_at}>{formatDate(s.created_at)}</td>
+      <td className="col-updated" title={s.updated_at}>{formatDate(s.updated_at)}</td>
+      <td className="col-mode">{s.mode || '—'}</td>
+      <td className="col-pov">{poverLabel}</td>
+      <td className="col-model" title={s.chat_model}>{s.chat_model || '—'}</td>
+      <td className="col-actions" onClick={e => e.stopPropagation()}>
+        <div className="chat-table-actions">
+          <button
+            type="button"
+            className="chat-table-action-btn primary"
+            title="Open in popout window"
+            aria-label={`Open "${safeTitle}" in window`}
+            onClick={() => onOpen(s.id)}
+          >
+            Open
+          </button>
+          <ChatExportDropdown onExport={fmt => onExport(s.id, fmt)} />
+          <button
+            type="button"
+            className="chat-table-action-btn"
+            title="Share to community"
+            aria-label={`Share "${safeTitle}" to community`}
+            onClick={() => onShare(s)}
+          >
+            Share
+          </button>
+        </div>
+      </td>
+      <td className="col-title">
+        {isRenaming ? (
+          <input
+            className="chat-table-rename-input"
+            value={renameValue}
+            autoFocus
+            onClick={e => e.stopPropagation()}
+            onChange={e => setRenameValue(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && renameValue.trim()) { e.stopPropagation(); commitRename(); }
+              else if (e.key === 'Escape') setRenamingId(null);
+            }}
+            onBlur={commitRename}
+          />
+        ) : (
+          <div
+            className="chat-table-title-text"
+            title={safeTitle}
+            onDoubleClick={handleDoubleClick}
+          >
+            {safeTitle}
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ──────────────────────────────────────────────
+// CommunityTableRow
+// ──────────────────────────────────────────────
+
+function ChatTableRowCommunity({
+  cc, onOpen, onExport, onCopy, copyingId,
+}: {
+  cc: CommunityChat;
+  onOpen: (id: string) => void;
+  onExport: (id: string, format: string) => void;
+  onCopy: (cc: CommunityChat) => Promise<void>;
+  copyingId: string | null;
+}) {
+  const isCopying = copyingId === cc.id;
+  return (
+    <tr>
+      <td className="col-created" title={cc.created_at}>{formatDate(cc.created_at)}</td>
+      <td className="col-updated" title={cc.updated_at}>{formatDate(cc.updated_at)}</td>
+      <td className="col-mode">{cc.mode || '—'}</td>
+      <td className="col-pov">—</td>
+      <td className="col-model">{cc.model || '—'}</td>
+      <td className="col-actions" onClick={e => e.stopPropagation()}>
+        <div className="chat-table-actions">
+          <button
+            type="button"
+            className="chat-table-action-btn primary"
+            title="Open in popout window"
+            aria-label={`Open "${cc.title}" in window`}
+            onClick={() => onOpen(cc.id)}
+          >
+            Open
+          </button>
+          <ChatExportDropdown onExport={fmt => onExport(cc.id, fmt)} />
+          <button
+            type="button"
+            className="chat-table-action-btn"
+            title="Copy to My chats"
+            aria-label={`Copy "${cc.title}" to My chats`}
+            disabled={isCopying}
+            onClick={() => { void onCopy(cc); }}
+          >
+            {isCopying ? 'Copying…' : 'Copy'}
+          </button>
+        </div>
+      </td>
+      <td className="col-title">
+        <div className="chat-table-title-text" title={cc.title}>{cc.title}</div>
+        {cc.community_metadata?.submitted_by_display && (
+          <div className="chat-table-title-secondary">
+            by {cc.community_metadata.submitted_by_display}
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ──────────────────────────────────────────────
+// ChatTable — main export
+// ──────────────────────────────────────────────
+
+export function ChatTable(props: ChatTableProps) {
+  const defaultDir: SortDir = props.variant === 'community' ? 'desc' : 'none';
+  const defaultCol: SortColumn | null = props.variant === 'community' ? 'updated' : null;
+  const [sort, setSort] = useState<SortState>({ col: defaultCol, dir: defaultDir });
+
+  useEffect(() => {
+    if (defaultCol) {
+      getGlobalRecorder()?.record({
+        type: 'user.action',
+        component: 'ChatTable',
+        level: 'info',
+        message: 'sort-default',
+        data: { col: defaultCol, dir: defaultDir, variant: props.variant },
+      });
+    }
+  }, []); // mount-only
+
+  const handleSort = useCallback((col: SortColumn) => {
+    setSort(prev => {
+      let next: SortState;
+      if (prev.col !== col) next = { col, dir: 'asc' };
+      else if (prev.dir === 'asc') next = { col, dir: 'desc' };
+      else if (prev.dir === 'desc') next = { col: null, dir: 'none' };
+      else next = { col, dir: 'asc' };
+      getGlobalRecorder()?.record({
+        type: 'user.action',
+        component: 'ChatTable',
+        level: 'info',
+        message: 'sort-click',
+        data: { col: next.col, dir: next.dir, variant: props.variant },
+      });
+      return next;
+    });
+  }, [props.variant]);
+
+  if (props.variant === 'my') {
+    return <MyTable {...props} sort={sort} onSort={handleSort} />;
+  }
+  return <CommunityTable {...props} sort={sort} onSort={handleSort} />;
+}
+
+// ──────────────────────────────────────────────
+// MyTable
+// ──────────────────────────────────────────────
+
+function MyTable(props: ChatTableMyProps & { sort: SortState; onSort: (col: SortColumn) => void }) {
+  const {
+    rows, loading, searchQuery, renamingId, setRenamingId, renameValue, setRenameValue,
+    onRename, onOpen, onExport, onShare, sort, onSort,
+  } = props;
+  const sorted = applySortMy(rows, sort);
+
+  return (
+    <div className="chat-table-wrap" role="region" aria-label="My chats table">
+      <table className="chat-table" role="grid">
+        <caption className="sr-only">My Chats</caption>
+        <colgroup>
+          <col className="col-created" />
+          <col className="col-updated" />
+          <col className="col-mode" />
+          <col className="col-pov" />
+          <col className="col-model" />
+          <col className="col-actions" />
+          <col className="col-title" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th scope="col" className="col-created" aria-sort={getSortAttr('created', sort)}>
+              <SortHeader label="Created" col="created" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-updated" aria-sort={getSortAttr('updated', sort)}>
+              <SortHeader label="Updated" col="updated" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-mode" aria-sort={getSortAttr('mode', sort)}>
+              <SortHeader label="Mode" col="mode" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-pov" aria-sort={getSortAttr('pov', sort)}>
+              <SortHeader label="POV" col="pov" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-model" aria-sort={getSortAttr('model', sort)}>
+              <SortHeader label="Model" col="model" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-actions">Actions</th>
+            <th scope="col" className="col-title" aria-sort={getSortAttr('title', sort)}>
+              <SortHeader label="Title" col="title" sort={sort} onSort={onSort} />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading && rows.length === 0 && (
+            <tr><td colSpan={7} className="chat-table-empty-cell">Loading…</td></tr>
+          )}
+          {!loading && rows.length === 0 && (
+            <tr><td colSpan={7} className="chat-table-empty-cell">No chats yet. Click <strong>+ New</strong> to start one.</td></tr>
+          )}
+          {searchQuery && sorted.length === 0 && rows.length > 0 && (
+            <tr><td colSpan={7} className="chat-table-empty-cell">No chats match &ldquo;{searchQuery}&rdquo;</td></tr>
+          )}
+          {sorted.map(s => (
+            <ChatTableRowMy
+              key={s.id}
+              s={s}
+              renamingId={renamingId}
+              setRenamingId={setRenamingId}
+              renameValue={renameValue}
+              setRenameValue={setRenameValue}
+              onRename={onRename}
+              onOpen={onOpen}
+              onExport={onExport}
+              onShare={onShare}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────
+// CommunityTable
+// ──────────────────────────────────────────────
+
+function CommunityTable(
+  props: ChatTableCommunityProps & { sort: SortState; onSort: (col: SortColumn) => void },
+) {
+  const { rows, loading, searchQuery, onOpen, onExport, onCopy, copyingId, sort, onSort } = props;
+  const sorted = applySortCommunity(rows, sort);
+
+  return (
+    <div className="chat-table-wrap" role="region" aria-label="Community chats table">
+      <table className="chat-table" role="grid">
+        <caption className="sr-only">Community Chats</caption>
+        <colgroup>
+          <col className="col-created" />
+          <col className="col-updated" />
+          <col className="col-mode" />
+          <col className="col-pov" />
+          <col className="col-model" />
+          <col className="col-actions" />
+          <col className="col-title" />
+        </colgroup>
+        <thead>
+          <tr>
+            <th scope="col" className="col-created" aria-sort={getSortAttr('created', sort)}>
+              <SortHeader label="Created" col="created" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-updated" aria-sort={getSortAttr('updated', sort)}>
+              <SortHeader label="Updated" col="updated" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-mode" aria-sort={getSortAttr('mode', sort)}>
+              <SortHeader label="Mode" col="mode" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-pov">POV</th>
+            <th scope="col" className="col-model" aria-sort={getSortAttr('model', sort)}>
+              <SortHeader label="Model" col="model" sort={sort} onSort={onSort} />
+            </th>
+            <th scope="col" className="col-actions">Actions</th>
+            <th scope="col" className="col-title" aria-sort={getSortAttr('title', sort)}>
+              <SortHeader label="Title" col="title" sort={sort} onSort={onSort} />
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading && rows.length === 0 && (
+            <tr><td colSpan={7} className="chat-table-empty-cell">Loading community chats…</td></tr>
+          )}
+          {!loading && rows.length === 0 && (
+            <tr><td colSpan={7} className="chat-table-empty-cell">No community chats available yet.</td></tr>
+          )}
+          {searchQuery && sorted.length === 0 && rows.length > 0 && (
+            <tr><td colSpan={7} className="chat-table-empty-cell">No community chats match &ldquo;{searchQuery}&rdquo;</td></tr>
+          )}
+          {sorted.map(cc => (
+            <ChatTableRowCommunity
+              key={cc.id}
+              cc={cc}
+              onOpen={onOpen}
+              onExport={onExport}
+              onCopy={onCopy}
+              copyingId={copyingId}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/chat/NewChatDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/NewChatDialog.tsx
@@ -28,7 +28,7 @@ const MODE_ICONS: Record<ChatMode, string> = {
 };
 
 export function NewChatDialog({ onClose }: NewChatDialogProps) {
-  const { createChat, loadChat } = useChatStore();
+  const { createChat } = useChatStore();
   const [mode, setMode] = useState<ChatMode>('brainstorm');
   const [pover, setPover] = useState<Exclude<SpeakerId, 'user'>>('accelerationist');
   const [topic, setTopic] = useState('');
@@ -68,7 +68,7 @@ export function NewChatDialog({ onClose }: NewChatDialogProps) {
     setCreating(true);
     const chatModelOverride = useCustomModel && customModel !== globalModel ? customModel : undefined;
     const id = await createChat(mode, pover, topic.trim(), chatModelOverride);
-    await loadChat(id);
+    void api.openChatWindow(id, 'my');
     onClose();
   };
 


### PR DESCRIPTION
## Summary
- **ChatTable.tsx**: Sortable table view mirroring DebateTable pattern — columns Created/Updated/Mode/POV/Model/Actions/Title. My variant actions: Open/Export/Share (+ double-click rename); Community actions: Open/Export/Copy.
- **ChatExportDropdown.tsx**: PDF/JSON/Markdown/Text export picker reusing `ExportDropdown.css`.
- **ChatTab.tsx**: `isTableMode = !toolbarPanel && !isPhone` wires full-width table with per-tab search bars; `RightPane` hidden in table mode — exact pattern from DebateTab.
- **NewChatDialog.tsx**: Post-create calls `openChatWindow(id, 'my')` instead of `loadChat` so new chats open as a popout (TL approval: t/2783#2).

## Test plan
- [ ] Electron: widen window → Chat tab shows table layout with sort, search, Open/Export/Share/Rename
- [ ] Electron: narrow window or open toolbar → falls back to list layout
- [ ] New Chat dialog → fills form → Start Chat → popout window opens (not inline load)
- [ ] Community tab: Copy button present, Share absent
- [ ] Export dropdown: PDF/JSON/Markdown/Text options render
- [ ] CI green on Node 22

Resolves t/2783

🤖 Generated with [Claude Code](https://claude.com/claude-code)
