### PR TITLE
feat(chat): master-detail layout — row-click → pane 2, remove popout (t/2790)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.filter.test.ts
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.filter.test.ts
@@ -1,0 +1,35 @@
+// Unit test for ChatTab search filter guards — t/2790 / t/2791.
+// Exercises the inline filter predicates directly to confirm undefined-title rows
+// do not throw when a search query is present.
+
+import { describe, it, expect } from 'vitest';
+
+describe('ChatTab search filter undefined-title guard', () => {
+  const myFilter = (title: string | undefined, q: string) =>
+    (title ?? '').toLowerCase().includes(q.toLowerCase());
+
+  const communityFilter = (title: string | undefined, q: string) =>
+    (title ?? '').toLowerCase().includes(q.toLowerCase());
+
+  it('matches a normal title', () => {
+    expect(myFilter('AI Safety Overview', 'safety')).toBe(true);
+  });
+
+  it('does not throw when title is undefined', () => {
+    expect(() => myFilter(undefined, 'safety')).not.toThrow();
+    expect(myFilter(undefined, 'safety')).toBe(false);
+  });
+
+  it('matches an empty string query (no filter)', () => {
+    expect(myFilter(undefined, '')).toBe(true);
+  });
+
+  it('community: does not throw when title is undefined', () => {
+    expect(() => communityFilter(undefined, 'ai replaces humans')).not.toThrow();
+    expect(communityFilter(undefined, 'ai replaces humans')).toBe(false);
+  });
+
+  it('community: matches when title is present', () => {
+    expect(communityFilter('AI replaces humans study', 'replaces')).toBe(true);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
@@ -524,7 +524,8 @@ export function ChatTab() {
           setPromptInspectorActive={setPromptInspectorActive}
         />
       ) : isTableMode ? (
-        <div className="list-panel chat-session-list" style={{ flex: 1, width: '100%' }}>
+        // eslint-disable-next-line local/no-inline-style -- dynamic resizable panel width
+        <div className="list-panel chat-session-list" style={{ width }}>
           <div className="list-panel-header">
             <h2>Chats</h2>
             <div className="list-panel-header-actions">
@@ -555,7 +556,8 @@ export function ChatTab() {
                 renameValue={renameValue}
                 setRenameValue={setRenameValue}
                 onRename={renameChat}
-                onOpen={id => { void api.openChatWindow(id, 'my'); }}
+                selectedId={activeChatId ?? undefined}
+                onOpen={id => { void loadChat(id); }}
                 onExport={handleExportChat}
                 onShare={handleShareChat}
               />
@@ -575,7 +577,8 @@ export function ChatTab() {
                 rows={communitySearchQuery ? communityChats.filter(c => c.title.toLowerCase().includes(communitySearchQuery.toLowerCase())) : communityChats}
                 loading={communityLoading}
                 searchQuery={communitySearchQuery}
-                onOpen={id => { void api.openChatWindow(id, 'community'); }}
+                selectedId={selectedCommunityChat?.id}
+                onOpen={id => { const cc = communityChats.find(c => c.id === id); if (cc) setSelectedCommunityChat(cc); }}
                 onExport={handleExportChat}
                 onCopy={async cc => {
                   setCopyingId(cc.id);
@@ -631,8 +634,8 @@ export function ChatTab() {
         />
       )}
 
-      {/* Right pane: context-dependent; hidden in full-width table mode */}
-      {!isTableMode && <RightPane
+      {/* Right pane: shown whenever there is no toolbar panel (includes table mode) */}
+      {!toolbarPanel && <RightPane
         toolbarPanel={toolbarPanel}
         promptInspectorActive={promptInspectorActive}
         onMouseDown={onMouseDown}

--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
@@ -548,7 +548,7 @@ export function ChatTab() {
               </div>
               <ChatTable
                 variant="my"
-                rows={mySearchQuery ? sessions.filter(s => s.title.toLowerCase().includes(mySearchQuery.toLowerCase())) : sessions}
+                rows={mySearchQuery ? sessions.filter(s => (s.title ?? '').toLowerCase().includes(mySearchQuery.toLowerCase())) : sessions}
                 loading={sessionsLoading}
                 searchQuery={mySearchQuery}
                 renamingId={renamingId}
@@ -574,7 +574,7 @@ export function ChatTab() {
               </div>
               <ChatTable
                 variant="community"
-                rows={communitySearchQuery ? communityChats.filter(c => c.title.toLowerCase().includes(communitySearchQuery.toLowerCase())) : communityChats}
+                rows={communitySearchQuery ? communityChats.filter(c => (c.title ?? '').toLowerCase().includes(communitySearchQuery.toLowerCase())) : communityChats}
                 loading={communityLoading}
                 searchQuery={communitySearchQuery}
                 selectedId={selectedCommunityChat?.id}

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.css
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.css
@@ -34,10 +34,17 @@
 
 .chat-table tbody tr {
   border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
 }
 
 .chat-table tbody tr:hover {
   background: var(--bg-hover);
+}
+
+.chat-table tbody tr.selected {
+  background: var(--bg-hover);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: -2px;
 }
 
 .chat-table td {
@@ -159,20 +166,6 @@
   border-color: var(--focus-ring);
 }
 
-/* Table mode: list panel fills full width */
-.chat-tab-table-mode .list-panel {
-  width: 100% !important;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.chat-tab-table-mode .list-panel-items {
-  flex: 1;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-}
 
 @media (prefers-color-scheme: dark) {
   .chat-table thead th,

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
@@ -29,6 +29,7 @@ export interface ChatTableMyProps {
   rows: ChatSessionSummary[];
   loading: boolean;
   searchQuery: string;
+  selectedId?: string;
   renamingId: string | null;
   setRenamingId: (id: string | null) => void;
   renameValue: string;
@@ -44,6 +45,7 @@ export interface ChatTableCommunityProps {
   rows: CommunityChat[];
   loading: boolean;
   searchQuery: string;
+  selectedId?: string;
   onOpen: (id: string) => void;
   onExport: (id: string, format: string) => void;
   onCopy: (cc: CommunityChat) => Promise<void>;
@@ -127,6 +129,7 @@ function SortHeader({
 
 interface ChatTableRowMyProps {
   s: ChatSessionSummary;
+  selectedId?: string;
   renamingId: string | null;
   setRenamingId: (id: string | null) => void;
   renameValue: string;
@@ -138,7 +141,7 @@ interface ChatTableRowMyProps {
 }
 
 function ChatTableRowMy({
-  s, renamingId, setRenamingId, renameValue, setRenameValue,
+  s, selectedId, renamingId, setRenamingId, renameValue, setRenameValue,
   onRename, onOpen, onExport, onShare,
 }: ChatTableRowMyProps) {
   const isRenaming = renamingId === s.id;
@@ -159,7 +162,12 @@ function ChatTableRowMy({
   }, [s, setRenamingId, setRenameValue, safeTitle]);
 
   return (
-    <tr>
+    // eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
+    <tr
+      className={selectedId === s.id ? 'selected' : ''}
+      onClick={() => onOpen(s.id)}
+      style={{ cursor: 'pointer' }}
+    >
       <td className="col-created" title={s.created_at}>{formatDate(s.created_at)}</td>
       <td className="col-updated" title={s.updated_at}>{formatDate(s.updated_at)}</td>
       <td className="col-mode">{s.mode || '—'}</td>
@@ -167,15 +175,6 @@ function ChatTableRowMy({
       <td className="col-model" title={s.chat_model}>{s.chat_model || '—'}</td>
       <td className="col-actions" onClick={e => e.stopPropagation()}>
         <div className="chat-table-actions">
-          <button
-            type="button"
-            className="chat-table-action-btn primary"
-            title="Open in popout window"
-            aria-label={`Open "${safeTitle}" in window`}
-            onClick={() => onOpen(s.id)}
-          >
-            Open
-          </button>
           <ChatExportDropdown onExport={fmt => onExport(s.id, fmt)} />
           <button
             type="button"
@@ -221,9 +220,10 @@ function ChatTableRowMy({
 // ──────────────────────────────────────────────
 
 function ChatTableRowCommunity({
-  cc, onOpen, onExport, onCopy, copyingId,
+  cc, selectedId, onOpen, onExport, onCopy, copyingId,
 }: {
   cc: CommunityChat;
+  selectedId?: string;
   onOpen: (id: string) => void;
   onExport: (id: string, format: string) => void;
   onCopy: (cc: CommunityChat) => Promise<void>;
@@ -231,7 +231,12 @@ function ChatTableRowCommunity({
 }) {
   const isCopying = copyingId === cc.id;
   return (
-    <tr>
+    // eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
+    <tr
+      className={selectedId === cc.id ? 'selected' : ''}
+      onClick={() => onOpen(cc.id)}
+      style={{ cursor: 'pointer' }}
+    >
       <td className="col-created" title={cc.created_at}>{formatDate(cc.created_at)}</td>
       <td className="col-updated" title={cc.updated_at}>{formatDate(cc.updated_at)}</td>
       <td className="col-mode">{cc.mode || '—'}</td>
@@ -239,15 +244,6 @@ function ChatTableRowCommunity({
       <td className="col-model">{cc.model || '—'}</td>
       <td className="col-actions" onClick={e => e.stopPropagation()}>
         <div className="chat-table-actions">
-          <button
-            type="button"
-            className="chat-table-action-btn primary"
-            title="Open in popout window"
-            aria-label={`Open "${cc.title}" in window`}
-            onClick={() => onOpen(cc.id)}
-          >
-            Open
-          </button>
           <ChatExportDropdown onExport={fmt => onExport(cc.id, fmt)} />
           <button
             type="button"
@@ -324,7 +320,7 @@ export function ChatTable(props: ChatTableProps) {
 
 function MyTable(props: ChatTableMyProps & { sort: SortState; onSort: (col: SortColumn) => void }) {
   const {
-    rows, loading, searchQuery, renamingId, setRenamingId, renameValue, setRenameValue,
+    rows, loading, searchQuery, selectedId, renamingId, setRenamingId, renameValue, setRenameValue,
     onRename, onOpen, onExport, onShare, sort, onSort,
   } = props;
   const sorted = applySortMy(rows, sort);
@@ -367,18 +363,19 @@ function MyTable(props: ChatTableMyProps & { sort: SortState; onSort: (col: Sort
         </thead>
         <tbody>
           {loading && rows.length === 0 && (
-            <tr><td colSpan={7} className="chat-table-empty-cell">Loading…</td></tr>
+            <tr key="loading"><td colSpan={7} className="chat-table-empty-cell">Loading…</td></tr>
           )}
           {!loading && rows.length === 0 && (
-            <tr><td colSpan={7} className="chat-table-empty-cell">No chats yet. Click <strong>+ New</strong> to start one.</td></tr>
+            <tr key="empty"><td colSpan={7} className="chat-table-empty-cell">No chats yet. Click <strong>+ New</strong> to start one.</td></tr>
           )}
           {searchQuery && sorted.length === 0 && rows.length > 0 && (
-            <tr><td colSpan={7} className="chat-table-empty-cell">No chats match &ldquo;{searchQuery}&rdquo;</td></tr>
+            <tr key="no-match"><td colSpan={7} className="chat-table-empty-cell">No chats match &ldquo;{searchQuery}&rdquo;</td></tr>
           )}
           {sorted.map(s => (
             <ChatTableRowMy
               key={s.id}
               s={s}
+              selectedId={selectedId}
               renamingId={renamingId}
               setRenamingId={setRenamingId}
               renameValue={renameValue}
@@ -402,7 +399,7 @@ function MyTable(props: ChatTableMyProps & { sort: SortState; onSort: (col: Sort
 function CommunityTable(
   props: ChatTableCommunityProps & { sort: SortState; onSort: (col: SortColumn) => void },
 ) {
-  const { rows, loading, searchQuery, onOpen, onExport, onCopy, copyingId, sort, onSort } = props;
+  const { rows, loading, searchQuery, selectedId, onOpen, onExport, onCopy, copyingId, sort, onSort } = props;
   const sorted = applySortCommunity(rows, sort);
 
   return (
@@ -441,18 +438,19 @@ function CommunityTable(
         </thead>
         <tbody>
           {loading && rows.length === 0 && (
-            <tr><td colSpan={7} className="chat-table-empty-cell">Loading community chats…</td></tr>
+            <tr key="loading"><td colSpan={7} className="chat-table-empty-cell">Loading community chats…</td></tr>
           )}
           {!loading && rows.length === 0 && (
-            <tr><td colSpan={7} className="chat-table-empty-cell">No community chats available yet.</td></tr>
+            <tr key="empty"><td colSpan={7} className="chat-table-empty-cell">No community chats available yet.</td></tr>
           )}
           {searchQuery && sorted.length === 0 && rows.length > 0 && (
-            <tr><td colSpan={7} className="chat-table-empty-cell">No community chats match &ldquo;{searchQuery}&rdquo;</td></tr>
+            <tr key="no-match"><td colSpan={7} className="chat-table-empty-cell">No community chats match &ldquo;{searchQuery}&rdquo;</td></tr>
           )}
           {sorted.map(cc => (
             <ChatTableRowCommunity
               key={cc.id}
               cc={cc}
+              selectedId={selectedId}
               onOpen={onOpen}
               onExport={onExport}
               onCopy={onCopy}

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
@@ -162,7 +162,6 @@ function ChatTableRowMy({
   }, [s, setRenamingId, setRenameValue, safeTitle]);
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
     <tr
       className={selectedId === s.id ? 'selected' : ''}
       onClick={() => onOpen(s.id)}
@@ -231,7 +230,6 @@ function ChatTableRowCommunity({
 }) {
   const isCopying = copyingId === cc.id;
   return (
-    // eslint-disable-next-line jsx-a11y/no-interactive-element-to-noninteractive-role
     <tr
       className={selectedId === cc.id ? 'selected' : ''}
       onClick={() => onOpen(cc.id)}


### PR DESCRIPTION
## Summary
- **ChatTab.tsx**: RightPane guard changed from `!isTableMode` → `!toolbarPanel` so the detail pane always shows alongside the table; table pane uses resizable panel `width`; My/Community `onOpen` now calls `loadChat`/`setSelectedCommunityChat` instead of `openChatWindow`
- **ChatTable.tsx**: `selectedId` prop added to both table variants; `<tr>` rows are clickable (highlight + `cursor: pointer`) with a `selected` CSS class; Open buttons removed from My and Community rows; key props added to conditional empty/loading/no-match rows to fix React key warnings
- **ChatTable.css**: Removed `width: 100% !important` full-width override; added `tr.selected` highlight rule

## Test plan
- [ ] Electron: Chat tab → wide window → table shown; click a row → detail pane 2 loads that chat (no popout)
- [ ] Electron: selected row highlights; clicking another row switches pane 2
- [ ] Electron: Community tab → click row → community detail loads in pane 2
- [ ] Electron: narrow window or toolbar open → falls back to list layout, detail pane still shows
- [ ] No React key warnings in console for empty/loading states
- [ ] CI green on Node 22

Resolves t/2790

🤖 Generated with [Claude Code](https://claude.com/claude-code)