### PR TITLE
fix(opeds): guard filterSets/filterCommunity against undefined topic + fix server field name (t/2791)

### DIFF
--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -91,12 +91,12 @@ function exportOpEdSet(set: OpEdSet, format: string): void {
 function filterSets(sets: OpEdSetSummary[], q: string): OpEdSetSummary[] {
   if (!q) return sets;
   // Index rows carry no bodies/headlines — filter on topic only (t/2605).
-  return sets.filter(s => s.topic.toLowerCase().includes(q));
+  return sets.filter(s => s.topic?.toLowerCase().includes(q) ?? false);
 }
 
 function filterCommunity(entries: OpEdCommunityEntry[], q: string): OpEdCommunityEntry[] {
   if (!q) return entries;
-  return entries.filter(c => c.topic.toLowerCase().includes(q));
+  return entries.filter(c => c.topic?.toLowerCase().includes(q) ?? false);
 }
 
 // ── Header actions (Edit / bulk-delete / disabled + New) ──────────────────────

--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -158,7 +158,7 @@ interface CommunityDebateEntry {
 }
 
 interface CommunityOpEdEntry {
-  id: unknown; title: string; created_at: string; updated_at: string;
+  id: unknown; topic: string; created_at: string; updated_at: string;
   community_metadata: unknown;
   camps: string[];
   voice_count: number;
@@ -213,7 +213,7 @@ export async function listCommunityOpEds(): Promise<unknown[]> {
     malformedMessage: 'Skipping malformed community op-ed file',
     toEntry: (parsed) => ({
       id: parsed.id,
-      title: typeof parsed.topic === 'string' ? parsed.topic || 'Untitled' : 'Untitled',
+      topic: typeof parsed.topic === 'string' ? parsed.topic || 'Untitled' : 'Untitled',
       created_at: parsed.created_at || '',
       updated_at: parsed.updated_at || parsed.created_at || '',
       community_metadata: stripOriginalId(parsed.community_metadata || null),


### PR DESCRIPTION
## Summary
- **OpEdTab.tsx**: `filterSets` (line 94) and `filterCommunity` (line 99) now use `?.toLowerCase().includes(q) ?? false` to guard against `topic: undefined` from server-fed community entries — same crash class as t/2791 FR dump
- **community.ts**: Root cause fixed — `CommunityOpEdEntry` internal interface and `listCommunityOpEds.toEntry` were emitting `title` instead of `topic`, so `OpEdCommunityEntry.topic` was always `undefined` at the client. Renamed field to `topic` to match `lib/oped/types.ts`

## Test plan
- [ ] CI: tsc clean, lint clean
- [ ] Typing a search in Op-Eds tab with community entries loaded does not throw or trigger error boundary
- [ ] Community op-ed rows now carry `topic` correctly (was always `undefined` before)

Resolves t/2791

🤖 Generated with [Claude Code](https://claude.com/claude-code)