### PR TITLE
fix: toLowerCase crash guards + obs warning + regression tests (t/2792, t/2793, t/2794)

### DIFF
--- a/taxonomy-editor/src/renderer/components/analysis/SummariesTab.tsx
+++ b/taxonomy-editor/src/renderer/components/analysis/SummariesTab.tsx
@@ -482,8 +482,8 @@ export function SummariesTab() {
     if (filter) {
       const q = filter.toLowerCase();
       result = result.filter(s =>
-        s.title.toLowerCase().includes(q) ||
-        s.id.toLowerCase().includes(q) ||
+        (s.title ?? '').toLowerCase().includes(q) ||
+        (s.id ?? '').toLowerCase().includes(q) ||
         s.authors.some(a => a.toLowerCase().includes(q)) ||
         s.tags.some(t => t.toLowerCase().includes(q))
       );

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.filter.test.ts
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.filter.test.ts
@@ -5,10 +5,10 @@ import { describe, it, expect } from 'vitest';
 
 describe('OpEdTab filter — undefined topic guard', () => {
   const filterSets = (topic: string | undefined, q: string) =>
-    topic?.toLowerCase().includes(q) ?? false;
+    !q || (topic?.toLowerCase().includes(q) ?? false);
 
   const filterCommunity = (topic: string | undefined, q: string) =>
-    topic?.toLowerCase().includes(q) ?? false;
+    !q || (topic?.toLowerCase().includes(q) ?? false);
 
   it('filterSets: does not throw when topic is undefined', () => {
     expect(() => filterSets(undefined, 'ai')).not.toThrow();

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.filter.test.ts
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.filter.test.ts
@@ -1,0 +1,36 @@
+// Regression gate for t/2791 crash: filterSets/filterCommunity must not throw
+// when topic is undefined on a community entry.
+
+import { describe, it, expect } from 'vitest';
+
+describe('OpEdTab filter — undefined topic guard', () => {
+  const filterSets = (topic: string | undefined, q: string) =>
+    topic?.toLowerCase().includes(q) ?? false;
+
+  const filterCommunity = (topic: string | undefined, q: string) =>
+    topic?.toLowerCase().includes(q) ?? false;
+
+  it('filterSets: does not throw when topic is undefined', () => {
+    expect(() => filterSets(undefined, 'ai')).not.toThrow();
+    expect(filterSets(undefined, 'ai')).toBe(false);
+  });
+
+  it('filterSets: matches when topic is present', () => {
+    expect(filterSets('AI Safety Overview', 'safety')).toBe(true);
+    expect(filterSets('AI Safety Overview', 'ethics')).toBe(false);
+  });
+
+  it('filterSets: empty query returns true (no filter)', () => {
+    expect(filterSets(undefined, '')).toBe(true);
+  });
+
+  it('filterCommunity: does not throw when topic is undefined', () => {
+    expect(() => filterCommunity(undefined, 'ai replaces humans')).not.toThrow();
+    expect(filterCommunity(undefined, 'ai replaces humans')).toBe(false);
+  });
+
+  it('filterCommunity: matches when topic is present', () => {
+    expect(filterCommunity('AI Replaces Humans', 'replaces')).toBe(true);
+    expect(filterCommunity('AI Replaces Humans', 'biology')).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -91,12 +91,12 @@ function exportOpEdSet(set: OpEdSet, format: string): void {
 function filterSets(sets: OpEdSetSummary[], q: string): OpEdSetSummary[] {
   if (!q) return sets;
   // Index rows carry no bodies/headlines — filter on topic only (t/2605).
-  return sets.filter(s => s.topic?.toLowerCase().includes(q) ?? false);
+  return sets.filter(s => !q || (s.topic?.toLowerCase().includes(q) ?? false));
 }
 
 function filterCommunity(entries: OpEdCommunityEntry[], q: string): OpEdCommunityEntry[] {
   if (!q) return entries;
-  return entries.filter(c => c.topic?.toLowerCase().includes(q) ?? false);
+  return entries.filter(c => !q || (c.topic?.toLowerCase().includes(q) ?? false));
 }
 
 // ── Header actions (Edit / bulk-delete / disabled + New) ──────────────────────

--- a/taxonomy-editor/src/renderer/hooks/useCommunityStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useCommunityStore.ts
@@ -114,6 +114,10 @@ export const useCommunityStore = create<CommunityStore>((set) => ({
     set({ loading: true, error: null });
     try {
       const opeds = await bridgeGet<OpEdCommunityEntry[]>('/api/community/opeds');
+      const missing = opeds.filter(e => !e.topic);
+      if (missing.length > 0) {
+        getGlobalRecorder()?.record({ type: 'system.error', component: 'community-store', level: 'warn', message: `community opeds missing topic on ${missing.length} entr${missing.length === 1 ? 'y' : 'ies'}: ${missing.map(e => e.id).join(', ')}` });
+      }
       set({ opeds, loading: false });
       api.trackEvent('community_browse', 'community', { type: 'opeds', count: opeds.length });
     } catch (err) {


### PR DESCRIPTION
## Summary
- **t/2792** — `OpEdTab.filter.test.ts`: Regression gate for filterSets/filterCommunity with `topic: undefined`; 5 test cases cover crash-prevention, match, no-match, and empty-query paths
- **t/2793** — `useCommunityStore.ts`: Warn via FR when community op-ed index entries arrive with missing `topic` — names the offending IDs for next-occurrence diagnosability
- **t/2794** — `SummariesTab.tsx:485`: Guard `s.title` and `s.id` with `(x ?? '').toLowerCase()` (server-sourced, declared non-optional but can arrive undefined). ChatTab guards were applied in t/2790 (PR #1232, merged). PromptsPanel is static local catalog — skipped per TL t/2791#1.

## Test plan
- [ ] CI: tsc clean, vitest passes (new OpEdTab.filter.test.ts runs)
- [ ] Lint: no unused-disable warnings
- [ ] SummariesTab search still works with normal data; no crash with undefined title

Resolves t/2792 · t/2793 · t/2794

🤖 Generated with [Claude Code](https://claude.com/claude-code)