### PR TITLE
feat(taxonomy): Soul Documents Analysis TheoryLink + bump ontology-guide link size (p/344)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -403,7 +403,13 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
           <TheoryLink
             docPath="docs/taxonomy-ontology-guide.md"
             label="Help: taxonomy ontology guide"
-            size={14}
+            size={16}
+          />
+          <TheoryLink
+            docPath="research/comp-linguist/docs/soul-documents-analysis.md"
+            label="Soul documents analysis"
+            tooltip="Open Soul Documents Analysis in GitHub"
+            size={15}
           />
           <EditConflictBadge conflict={conflict} resolveUrl={resolveUrl} />
         </div>


### PR DESCRIPTION
Two small UI changes in `NodeDetail.tsx` `nd-header-meta` (requested by PM, p/344#90):

1. Enlarge the existing taxonomy-ontology-guide `TheoryLink` 14 → **16**.
2. Add a second `TheoryLink` → `research/comp-linguist/docs/soul-documents-analysis.md` (label "Soul documents analysis", size 15).

**Note:** PM asked size **18** for link 1, but `TheoryLink` clamps `size` to 12–16 (t/2416 em-scaling), so 16 is the effective max. Set to 16 and flagged to PM — if 18 is truly wanted, the clamp in the shared `TheoryLink` component must be raised (separate change).

Referenced doc verified present. Owner: root Main (renderer). Trivial change routed by PM via PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)