### PR TITLE
fix(chat): NewChatDialog loads new chat in pane 2 instead of popup (t/2790 follow-up)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
@@ -650,7 +650,7 @@ export function ChatTab() {
         selectedCommunityChat={selectedCommunityChat}
       />}
 
-      {showNewDialog && <NewChatDialog onClose={() => setShowNewDialog(false)} />}
+      {showNewDialog && <NewChatDialog onClose={() => setShowNewDialog(false)} onCreated={(id) => { void loadChat(id); }} />}
     </div>
   );
 }

--- a/taxonomy-editor/src/renderer/components/chat/NewChatDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/NewChatDialog.tsx
@@ -18,6 +18,8 @@ import './NewChatDialog.css';
 
 interface NewChatDialogProps {
   onClose: () => void;
+  /** Called with the new chat ID instead of opening a popout window. */
+  onCreated?: (id: string) => void;
 }
 const MODES: ChatMode[] = ['brainstorm', 'inform', 'decide'];
 
@@ -27,7 +29,7 @@ const MODE_ICONS: Record<ChatMode, string> = {
   decide: '\u2696\uFE0F',  // scales
 };
 
-export function NewChatDialog({ onClose }: NewChatDialogProps) {
+export function NewChatDialog({ onClose, onCreated }: NewChatDialogProps) {
   const { createChat } = useChatStore();
   const [mode, setMode] = useState<ChatMode>('brainstorm');
   const [pover, setPover] = useState<Exclude<SpeakerId, 'user'>>('accelerationist');
@@ -68,7 +70,11 @@ export function NewChatDialog({ onClose }: NewChatDialogProps) {
     setCreating(true);
     const chatModelOverride = useCustomModel && customModel !== globalModel ? customModel : undefined;
     const id = await createChat(mode, pover, topic.trim(), chatModelOverride);
-    void api.openChatWindow(id, 'my');
+    if (onCreated) {
+      onCreated(id);
+    } else {
+      void api.openChatWindow(id, 'my');
+    }
     onClose();
   };
 


### PR DESCRIPTION
## Summary

- `NewChatDialog.handleStart` was calling `api.openChatWindow(id, 'my')` after creation, opening a blank popout — the missing piece from the t/2790 master-detail refactor (PR #1232)
- Added `onCreated?: (id: string) => void` to `NewChatDialogProps`; when provided, calls it instead of `openChatWindow`
- `ChatTab` passes `onCreated={(id) => void loadChat(id)}` so new chats load in pane 2

## Test plan

- [ ] Click `+ New` in the Chat tab, fill form, click Start → chat opens in pane 2 (right), no popup window
- [ ] tsc clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)