### PR TITLE
fix(chat): full-width table (max-width cap) + Edit-mode rename parity (t/2790)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
@@ -447,6 +447,8 @@ export function ChatTab() {
   const [mySearchQuery, setMySearchQuery] = useState('');
   const [communitySearchQuery, setCommunitySearchQuery] = useState('');
   const [capNotice, setCapNotice] = useState<string | null>(null);
+  // t/2790#6: Edit-mode parity with Debates/Op-Eds — discoverable rename affordance.
+  const [editMode, setEditMode] = useState(false);
 
   // t/2790 UAT: tables fill the tab; opening a chat launches a popout window
   // (max 5 concurrent, deduped per chatId in chatWindowHandlers).
@@ -540,12 +542,17 @@ export function ChatTab() {
           <div className="list-panel-header">
             <h2>Chats</h2>
             <div className="list-panel-header-actions">
+              {listView === 'my' && (editMode ? (
+                <button className="btn btn-sm btn-ghost" onClick={() => setEditMode(false)}>Done</button>
+              ) : (
+                <button className="btn btn-sm btn-ghost" title="Rename chats" onClick={() => setEditMode(true)}>Edit</button>
+              ))}
               <button className="btn btn-sm" onClick={() => { setShowNewDialog(true); setListView('my'); }}>+ New</button>
             </div>
           </div>
           <div className="list-view-tabs">
             <button className={`list-view-tab${listView === 'my' ? ' active' : ''}`} onClick={() => setListView('my')}>My ({sessions.length})</button>
-            <button className={`list-view-tab${listView === 'community' ? ' active' : ''}`} onClick={() => setListView('community')}>Community ({communityChats.length})</button>
+            <button className={`list-view-tab${listView === 'community' ? ' active' : ''}`} onClick={() => { setListView('community'); setEditMode(false); }}>Community ({communityChats.length})</button>
           </div>
           {capNotice && <div className="chat-tab-cap-notice" role="status">{capNotice}</div>}
           {listView === 'my' ? (
@@ -569,6 +576,7 @@ export function ChatTab() {
                 setRenameValue={setRenameValue}
                 onRename={renameChat}
                 selectedId={activeChatId ?? undefined}
+                editMode={editMode}
                 onOpen={id => openChatPopout(id, 'my')}
                 onExport={handleExportChat}
                 onShare={handleShareChat}

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.css
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.css
@@ -166,9 +166,12 @@
   border-color: var(--focus-ring);
 }
 
-/* Table mode: list panel fills full width */
+/* Table mode: list panel fills full width.
+   max-width: none overrides the global .list-panel 600px cap (styles.css) —
+   without it the table stops at 600px and leaves an empty pane (t/2790 UAT). */
 .chat-tab-table-mode .list-panel {
   width: 100% !important;
+  max-width: none;
   flex: 1;
   display: flex;
   flex-direction: column;

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.editmode.test.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.editmode.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2790#9 review condition: Edit-mode regression coverage for ChatTable (My variant).
+// Locks the edit-mode contract from PR #1239: in edit mode each row swaps its
+// actions for a Rename affordance, and row-click no longer opens a popout.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChatTable } from './ChatTable';
+import type { ChatSessionSummary } from '../../types/chat';
+
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+vi.mock('./ChatExportDropdown', () => ({ ChatExportDropdown: () => <button type="button">Export</button> }));
+
+const session = {
+  id: 'chat-1',
+  title: 'Alpha',
+  created_at: '2026-08-01T10:00:00Z',
+  updated_at: '2026-08-02T10:00:00Z',
+  mode: 'brainstorm',
+  pover: 'accelerationist',
+  chat_model: 'model-x',
+} as ChatSessionSummary;
+
+function renderMy(editMode: boolean) {
+  const onOpen = vi.fn();
+  render(
+    <ChatTable
+      variant="my"
+      rows={[session]}
+      loading={false}
+      searchQuery=""
+      renamingId={null}
+      setRenamingId={vi.fn()}
+      renameValue=""
+      setRenameValue={vi.fn()}
+      onRename={vi.fn()}
+      onOpen={onOpen}
+      onExport={vi.fn()}
+      onShare={vi.fn()}
+      editMode={editMode}
+    />,
+  );
+  return onOpen;
+}
+
+describe('ChatTable edit mode (t/2790#9)', () => {
+  it('edit mode: Rename shown; Open and Share hidden', () => {
+    renderMy(true);
+    expect(screen.getByRole('button', { name: /rename "alpha"/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /open "alpha"/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /share "alpha"/i })).not.toBeInTheDocument();
+  });
+
+  it('edit mode: row-click does not open a popout', () => {
+    const onOpen = renderMy(true);
+    fireEvent.click(screen.getByText('Alpha').closest('tr')!);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('normal mode: Open shown and row-click opens the chat', () => {
+    const onOpen = renderMy(false);
+    expect(screen.getByRole('button', { name: /open "alpha"/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Alpha').closest('tr')!);
+    expect(onOpen).toHaveBeenCalledWith('chat-1');
+  });
+});

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
@@ -30,6 +30,8 @@ export interface ChatTableMyProps {
   loading: boolean;
   searchQuery: string;
   selectedId?: string;
+  /** Edit mode swaps row actions for a Rename affordance (t/2790#6 parity with Debates/Op-Eds). */
+  editMode?: boolean;
   renamingId: string | null;
   setRenamingId: (id: string | null) => void;
   renameValue: string;
@@ -130,6 +132,7 @@ function SortHeader({
 interface ChatTableRowMyProps {
   s: ChatSessionSummary;
   selectedId?: string;
+  editMode?: boolean;
   renamingId: string | null;
   setRenamingId: (id: string | null) => void;
   renameValue: string;
@@ -141,7 +144,7 @@ interface ChatTableRowMyProps {
 }
 
 function ChatTableRowMy({
-  s, selectedId, renamingId, setRenamingId, renameValue, setRenameValue,
+  s, selectedId, editMode, renamingId, setRenamingId, renameValue, setRenameValue,
   onRename, onOpen, onExport, onShare,
 }: ChatTableRowMyProps) {
   const isRenaming = renamingId === s.id;
@@ -164,8 +167,8 @@ function ChatTableRowMy({
   return (
     <tr
       className={selectedId === s.id ? 'selected' : ''}
-      onClick={() => onOpen(s.id)}
-      style={{ cursor: 'pointer' }}
+      onClick={editMode ? undefined : () => onOpen(s.id)}
+      style={{ cursor: editMode ? 'default' : 'pointer' }}
     >
       <td className="col-created" title={s.created_at}>{formatDate(s.created_at)}</td>
       <td className="col-updated" title={s.updated_at}>{formatDate(s.updated_at)}</td>
@@ -174,25 +177,39 @@ function ChatTableRowMy({
       <td className="col-model" title={s.chat_model}>{s.chat_model || '—'}</td>
       <td className="col-actions" onClick={e => e.stopPropagation()}>
         <div className="chat-table-actions">
-          <button
-            type="button"
-            className="chat-table-action-btn"
-            title="Open in a chat window"
-            aria-label={`Open "${safeTitle}" in a chat window`}
-            onClick={() => onOpen(s.id)}
-          >
-            Open
-          </button>
-          <ChatExportDropdown onExport={fmt => onExport(s.id, fmt)} />
-          <button
-            type="button"
-            className="chat-table-action-btn"
-            title="Share to community"
-            aria-label={`Share "${safeTitle}" to community`}
-            onClick={() => onShare(s)}
-          >
-            Share
-          </button>
+          {editMode ? (
+            <button
+              type="button"
+              className="chat-table-action-btn"
+              title="Rename"
+              aria-label={`Rename "${safeTitle}"`}
+              onClick={() => { setRenamingId(s.id); setRenameValue(safeTitle); }}
+            >
+              Rename
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="chat-table-action-btn"
+                title="Open in a chat window"
+                aria-label={`Open "${safeTitle}" in a chat window`}
+                onClick={() => onOpen(s.id)}
+              >
+                Open
+              </button>
+              <ChatExportDropdown onExport={fmt => onExport(s.id, fmt)} />
+              <button
+                type="button"
+                className="chat-table-action-btn"
+                title="Share to community"
+                aria-label={`Share "${safeTitle}" to community`}
+                onClick={() => onShare(s)}
+              >
+                Share
+              </button>
+            </>
+          )}
         </div>
       </td>
       <td className="col-title">
@@ -336,7 +353,7 @@ export function ChatTable(props: ChatTableProps) {
 
 function MyTable(props: ChatTableMyProps & { sort: SortState; onSort: (col: SortColumn) => void }) {
   const {
-    rows, loading, searchQuery, selectedId, renamingId, setRenamingId, renameValue, setRenameValue,
+    rows, loading, searchQuery, selectedId, editMode, renamingId, setRenamingId, renameValue, setRenameValue,
     onRename, onOpen, onExport, onShare, sort, onSort,
   } = props;
   const sorted = applySortMy(rows, sort);
@@ -392,6 +409,7 @@ function MyTable(props: ChatTableMyProps & { sort: SortState; onSort: (col: Sort
               key={s.id}
               s={s}
               selectedId={selectedId}
+              editMode={editMode}
               renamingId={renamingId}
               setRenamingId={setRenamingId}
               renameValue={renameValue}


### PR DESCRIPTION
## Summary

1. **UAT fix (user screenshot t2.png):** the chat table capped at 600px, leaving an empty right pane. Root cause: the global `.list-panel { max-width: 600px }` in styles.css survived the `chat-tab-table-mode` full-width override. Fix: `max-width: none` on the table-mode rule.

2. **Edit-mode parity (t/2790#6, PM-confirmed):** Edit/Done toggle in the Chats header (My view, mirrors `DebateTab`); edit mode swaps row actions for a **Rename** button using the existing `renamingId` flow and suspends row-click open. Double-click rename unchanged. Bulk-delete deferred (optional per TL).

## Verification

- renderer tsc: 0 errors; eslint: 0 errors (3 pre-existing warnings, within budget)
- CI authoritative for vitest (local undici skew t/2281)

🤖 Generated with [Claude Code](https://claude.com/claude-code)