### PR TITLE
feat(opeds): reorder in Edit mode — mirror debate custom-order (t/2796)

### DIFF
--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -9,7 +9,7 @@
 //
 // Create is PR#2 — the "+ New Op-Ed" button is present but DISABLED here (t/2570#3).
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { api, isElectronMode } from '@bridge';
@@ -102,15 +102,17 @@ function filterCommunity(entries: OpEdCommunityEntry[], q: string): OpEdCommunit
 // ── Header actions (Edit / bulk-delete / disabled + New) ──────────────────────
 
 function OpEdHeaderActions({
-  listView, editMode, hasSets, selectedCount,
-  onBulkDelete, onClearSelected, onExitEdit, onEnterEdit, onNew,
+  listView, editMode, hasSets, selectedCount, hasCustomOrder,
+  onBulkDelete, onClearSelected, onResetOrder, onExitEdit, onEnterEdit, onNew,
 }: {
   listView: 'my' | 'community';
   editMode: boolean;
   hasSets: boolean;
   selectedCount: number;
+  hasCustomOrder: boolean;
   onBulkDelete: () => void;
   onClearSelected: () => void;
+  onResetOrder: () => void;
   onExitEdit: () => void;
   onEnterEdit: () => void;
   onNew: () => void;
@@ -123,6 +125,9 @@ function OpEdHeaderActions({
           <button className="btn btn-sm btn-danger" onClick={onBulkDelete}>Delete {selectedCount}</button>
         )}
         <button className="btn btn-sm btn-ghost" onClick={onClearSelected}>None</button>
+        {hasCustomOrder && (
+          <button className="btn btn-sm btn-ghost" onClick={onResetOrder} title="Reset to default sort order">Reset Order</button>
+        )}
         <button className="btn btn-sm btn-ghost" onClick={onExitEdit}>Done</button>
       </div>
     );
@@ -130,7 +135,7 @@ function OpEdHeaderActions({
   return (
     <div className="list-panel-header-actions">
       {hasSets && (
-        <button className="btn btn-sm btn-ghost" onClick={onEnterEdit} title="Rename or delete op-eds">Edit</button>
+        <button className="btn btn-sm btn-ghost" onClick={onEnterEdit} title="Rename, reorder, or delete op-eds">Edit</button>
       )}
       {/* Create — both builds (t/2614). Desktop runs the in-process core; web streams the
           shared lib/oped core via POST /api/oped-sets (topic-only; URL toggle hidden on web). */}
@@ -296,6 +301,52 @@ export function OpEdTab() {
 
   const exitEditMode = useCallback(() => { setEditMode(false); setRenamingId(null); }, [setEditMode]);
 
+  // ── Custom sort order (persisted to localStorage) — mirrors DebateTab (t/2796). ──
+  const [customOrder, setCustomOrder] = useState<string[]>(() => {
+    try {
+      const saved = localStorage.getItem('oped-custom-order');
+      return saved ? JSON.parse(saved) : [];
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'oped-tab', level: 'warn',
+        message: 'Failed to load custom op-ed order from localStorage',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      return [];
+    }
+  });
+
+  const saveCustomOrder = useCallback((order: string[]) => {
+    setCustomOrder(order);
+    localStorage.setItem('oped-custom-order', JSON.stringify(order));
+  }, []);
+
+  // Apply custom ordering: sets not yet in the custom order (e.g. newly created)
+  // float to the top in server order (newest-first), followed by manually-ordered
+  // sets in their saved order. Mirrors DebateTab.orderedSessions.
+  const orderedSets = useMemo(() => {
+    if (customOrder.length === 0) return sets;
+    const orderMap = new Map(customOrder.map((id, i) => [id, i]));
+    return [...sets].sort((a, b) => {
+      const ai = orderMap.get(a.set_id);
+      const bi = orderMap.get(b.set_id);
+      if (ai !== undefined && bi !== undefined) return ai - bi;
+      if (ai !== undefined) return 1;  // a pinned, b new — new (b) first
+      if (bi !== undefined) return -1; // b pinned, a new — new (a) first
+      return 0;                        // both unordered — keep server order
+    });
+  }, [sets, customOrder]);
+
+  const moveSet = useCallback((id: string, direction: 'up' | 'down') => {
+    const ids = orderedSets.map(s => s.set_id);
+    const idx = ids.indexOf(id);
+    if (idx < 0) return;
+    const targetIdx = direction === 'up' ? idx - 1 : idx + 1;
+    if (targetIdx < 0 || targetIdx >= ids.length) return;
+    [ids[idx], ids[targetIdx]] = [ids[targetIdx], ids[idx]];
+    saveCustomOrder(ids);
+  }, [orderedSets, saveCustomOrder]);
+
   // ── Reader open/close ──
 
   const openMy = useCallback((id: string) => {
@@ -403,7 +454,7 @@ export function OpEdTab() {
   // ── Filtering ──
 
   const q = searchQuery.trim().toLowerCase();
-  const filteredSets = filterSets(sets, q);
+  const filteredSets = filterSets(orderedSets, q);
   const filteredCommunity = filterCommunity(communityOpeds, q);
 
   const isTableMode = !isPhone;
@@ -434,8 +485,10 @@ export function OpEdTab() {
             editMode={editMode}
             hasSets={sets.length > 0}
             selectedCount={selectedIds.size}
+            hasCustomOrder={customOrder.length > 0}
             onBulkDelete={handleBulkDelete}
             onClearSelected={clearSelected}
+            onResetOrder={() => saveCustomOrder([])}
             onExitEdit={exitEditMode}
             onEnterEdit={() => setEditMode(true)}
             onNew={() => setShowNewDialog(true)}
@@ -483,6 +536,7 @@ export function OpEdTab() {
             renameValue={renameValue}
             setRenameValue={setRenameValue}
             onRename={handleRename}
+            onMoveSet={moveSet}
             onOpen={openMy}
             onExport={handleExportMy}
             onShare={handleShare}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
@@ -44,6 +44,7 @@ const noopMyProps = {
   renameValue: '',
   setRenameValue: vi.fn(),
   onRename: vi.fn(),
+  onMoveSet: vi.fn(),
   onOpen: vi.fn(),
   onExport: vi.fn(),
   onShare: vi.fn(),
@@ -270,6 +271,31 @@ describe('OpEdTable — My variant', () => {
     render(<OpEdTable {...noopMyProps} rows={[makeSummary()]} totalCount={1} />);
     const heads = screen.getAllByRole('columnheader').map(th => (th.textContent || '').replace(/[^A-Za-z]/g, ''));
     expect(heads).toEqual(['Camp', 'Date', 'Outlet', 'Actions', 'Headline']);
+  });
+
+  // t/2796: reorder controls appear only in edit mode; ends are disabled; onMoveSet fires.
+  it('edit mode: shows move up/down per row, disables at the ends, fires onMoveSet', () => {
+    const onMoveSet = vi.fn();
+    const rows = [
+      makeSummary({ set_id: 'a', topic: 'First' }),
+      makeSummary({ set_id: 'b', topic: 'Second' }),
+    ];
+    render(<OpEdTable {...noopMyProps} rows={rows} totalCount={2} editMode onMoveSet={onMoveSet} />);
+    const firstRow = screen.getByText('First').closest('tr')!;
+    const secondRow = screen.getByText('Second').closest('tr')!;
+    // Top row: Up disabled, Down enabled. Bottom row: the reverse.
+    expect(within(firstRow).getByRole('button', { name: /move "first" up/i })).toBeDisabled();
+    const firstDown = within(firstRow).getByRole('button', { name: /move "first" down/i });
+    expect(firstDown).toBeEnabled();
+    expect(within(secondRow).getByRole('button', { name: /move "second" down/i })).toBeDisabled();
+    fireEvent.click(firstDown);
+    expect(onMoveSet).toHaveBeenCalledWith('a', 'down');
+  });
+
+  it('non-edit mode: no move controls are rendered', () => {
+    render(<OpEdTable {...noopMyProps} rows={[makeSummary({ topic: 'Solo' })]} totalCount={1} />);
+    expect(screen.queryByRole('button', { name: /move .* up/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /move .* down/i })).toBeNull();
   });
 });
 

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
@@ -41,6 +41,7 @@ export interface OpEdTableMyProps {
   renameValue: string;
   setRenameValue: (v: string) => void;
   onRename: (id: string, topic: string) => void;
+  onMoveSet: (id: string, dir: 'up' | 'down') => void;
   onOpen: (id: string) => void;
   onExport: (set: OpEdSetSummary, format: string) => void;
   onShare: (set: OpEdSetSummary) => void;
@@ -262,11 +263,13 @@ function OpEdHeadlineCell({
 }
 
 export function OpEdMyRow({
-  set, isActive, editMode, isSelected, onToggleSelect,
-  renamingId, setRenamingId, renameValue, setRenameValue, onRename,
+  set, idx, totalRows, isActive, editMode, isSelected, onToggleSelect,
+  renamingId, setRenamingId, renameValue, setRenameValue, onRename, onMoveSet,
   onOpen, onExport, onShare,
 }: {
   set: OpEdSetSummary;
+  idx: number;
+  totalRows: number;
   isActive: boolean;
   editMode: boolean;
   isSelected: boolean;
@@ -276,6 +279,7 @@ export function OpEdMyRow({
   renameValue: string;
   setRenameValue: (v: string) => void;
   onRename: (id: string, topic: string) => void;
+  onMoveSet: (id: string, dir: 'up' | 'down') => void;
   onOpen: (id: string) => void;
   onExport: (set: OpEdSetSummary, format: string) => void;
   onShare: (set: OpEdSetSummary) => void;
@@ -340,6 +344,30 @@ export function OpEdMyRow({
       {/* Actions */}
       <td className="col-actions" onClick={e => e.stopPropagation()}>
         <div className="oped-table-actions">
+          {editMode && (
+            <>
+              <button
+                type="button"
+                className="oped-table-action-btn"
+                title="Move up"
+                aria-label={`Move "${headline}" up`}
+                disabled={idx === 0}
+                onClick={() => onMoveSet(set.set_id, 'up')}
+              >
+                &#9650;
+              </button>
+              <button
+                type="button"
+                className="oped-table-action-btn"
+                title="Move down"
+                aria-label={`Move "${headline}" down`}
+                disabled={idx === totalRows - 1}
+                onClick={() => onMoveSet(set.set_id, 'down')}
+              >
+                &#9660;
+              </button>
+            </>
+          )}
           <button
             type="button"
             className="oped-table-action-btn primary"
@@ -456,8 +484,8 @@ export function OpEdCommunityRow({
 // Table shell
 // ──────────────────────────────────────────────
 
-function useSort(): [SortState, (col: SortColumn) => void] {
-  const [sort, setSort] = useState<SortState>({ col: 'date', dir: 'desc' });
+function useSort(defaultCol: SortColumn | null = 'date'): [SortState, (col: SortColumn) => void] {
+  const [sort, setSort] = useState<SortState>({ col: defaultCol, dir: defaultCol ? 'desc' : 'none' });
   const onSort = useCallback((col: SortColumn) => {
     setSort(prev => {
       if (prev.col !== col) return { col, dir: 'asc' };
@@ -477,10 +505,12 @@ export function OpEdTable(props: OpEdTableProps) {
 function MyTable(props: OpEdTableMyProps) {
   const {
     rows, loading, searchQuery, editMode, selectedIds, onToggleSelect,
-    renamingId, setRenamingId, renameValue, setRenameValue, onRename,
+    renamingId, setRenamingId, renameValue, setRenameValue, onRename, onMoveSet,
     onOpen, onExport, onShare, onNew, selectedSetId,
   } = props;
-  const [sort, onSort] = useSort();
+  // Default to no internal sort (col: null) so the caller's custom order (t/2796)
+  // shows through; clicking a sort header still overrides it, matching DebateTable.
+  const [sort, onSort] = useSort(null);
   const sortedRows = applySortMy(rows, sort);
   // Columns (t/2724): [cb?] camp · date · outlet · actions · headline. Headline is
   // rightmost so it expands with window width; Outlet is always shown (placeholder
@@ -532,10 +562,12 @@ function MyTable(props: OpEdTableMyProps) {
           {searchQuery && sortedRows.length === 0 && rows.length > 0 && (
             <tr><td colSpan={colSpan} className="oped-table-empty-cell">No op-eds match &ldquo;{searchQuery}&rdquo;</td></tr>
           )}
-          {sortedRows.map(set => (
+          {sortedRows.map((set, idx) => (
             <OpEdMyRow
               key={set.set_id}
               set={set}
+              idx={idx}
+              totalRows={sortedRows.length}
               isActive={set.set_id === selectedSetId}
               editMode={editMode}
               isSelected={selectedIds.has(set.set_id)}
@@ -545,6 +577,7 @@ function MyTable(props: OpEdTableMyProps) {
               renameValue={renameValue}
               setRenameValue={setRenameValue}
               onRename={onRename}
+              onMoveSet={onMoveSet}
               onOpen={onOpen}
               onExport={onExport}
               onShare={onShare}


### PR DESCRIPTION
## Summary

Adds **reorder in Edit mode** to Op-Eds — the one genuine feature gap from the t/2795 triage (PM-confirmed). Mirrors the debate custom-order pattern; purely client-side, no server/data-model change.

## Changes

- **OpEdTab.tsx:** `customOrder` state persisted to localStorage `oped-custom-order`; `orderedSets` memo (new sets float to top in server order, pinned sets keep saved order — mirrors `orderedSessions`); `moveSet` swaps neighbours in the full ordered id list; search filter now applies to the ordered list; **Reset Order** button in the Edit-mode header; Edit tooltip → "Rename, reorder, or delete op-eds".
- **OpEdTable.tsx:** My variant defaults to no internal sort (`col: null`) so custom order shows through — clicking a sort header still overrides it, matching DebateTable; per-row **move up/down** controls in Edit mode, disabled at the ends.
- **Tests:** reorder controls appear only in Edit mode, ends disabled, `onMoveSet` fires with (id, dir); `onMoveSet` added to shared test props.

## Self-cert

Self-certified against the debate custom-order pattern (t/2796#1). Search+order interaction matches debate exactly (order first, then filter; moves operate on the full ordered list). No deviations.

## Verification

- renderer tsc: 0 errors · eslint (changed files): 0 errors · OpEdTable tests: 24 passing (incl. 2 new reorder tests)
- CI authoritative for the full vitest suite (local undici skew t/2281)

🤖 Generated with [Claude Code](https://claude.com/claude-code)