### PR TITLE
fix(export): unclip chat Export dropdown + add JSON to op-ed export (t/2797)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.css
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.css
@@ -55,6 +55,13 @@
   white-space: nowrap;
 }
 
+/* The Export ▾ dropdown is position:absolute inside col-actions; the blanket
+   td overflow:hidden above would clip it invisible. Mirror DebateTable, which
+   scopes clipping to text columns and leaves col-actions unclipped (t/2797 A). */
+.chat-table td.col-actions {
+  overflow: visible;
+}
+
 /* col widths */
 .chat-table .col-created  { width: 110px; }
 .chat-table .col-updated  { width: 110px; }

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdExport.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdExport.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2797 Part B regression: exportOpEdSet(set, 'json') must download a valid,
+// parseable .json of the full op-ed set. Captures the Blob handed to the
+// download helper (via URL.createObjectURL) and round-trips it through JSON.parse.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { exportOpEdSet } from './OpEdTab';
+import type { OpEdSet } from '../../../../../lib/oped/types';
+
+function makeSet(): OpEdSet {
+  return {
+    schema_version: 1,
+    set_id: 'set-json-1',
+    topic: 'Export as JSON',
+    params: { povers: ['safetyist'] } as unknown as OpEdSet['params'],
+    created_at: '2026-08-19T10:00:00Z',
+    opeds: [
+      {
+        pov: 'safetyist' as OpEdSet['opeds'][number]['pov'],
+        status: 'complete',
+        headline: 'The case for audits',
+        subtitle: 'A subtitle',
+        body: 'Body text.',
+        wordCount: 2,
+        grounding: [],
+      },
+    ],
+  };
+}
+
+describe('exportOpEdSet — JSON path (t/2797)', () => {
+  let capturedBlob: Blob | null;
+  let clickSpy: ReturnType<typeof vi.spyOn>;
+  let lastDownloadName: string | undefined;
+
+  beforeEach(() => {
+    capturedBlob = null;
+    lastDownloadName = undefined;
+    // downloadFile() calls URL.createObjectURL(blob); capture the blob there.
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn((blob: Blob) => { capturedBlob = blob; return 'blob:mock'; }),
+      revokeObjectURL: vi.fn(),
+    });
+    // Suppress the anchor navigation and record the download filename.
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      lastDownloadName = this.download;
+    });
+  });
+
+  afterEach(() => {
+    clickSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it('produces a parseable .json blob round-tripping the set', async () => {
+    const set = makeSet();
+    exportOpEdSet(set, 'json');
+
+    expect(capturedBlob).not.toBeNull();
+    expect(capturedBlob!.type).toBe('application/json');
+    expect(lastDownloadName).toMatch(/\.json$/);
+
+    const text = await capturedBlob!.text();
+    const parsed = JSON.parse(text);
+    expect(parsed.set_id).toBe('set-json-1');
+    expect(parsed.topic).toBe('Export as JSON');
+    expect(parsed.opeds).toHaveLength(1);
+    expect(parsed.opeds[0].headline).toBe('The case for audits');
+  });
+});

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -83,8 +83,10 @@ function slugify(s: string): string {
   return (s || 'op-ed').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60) || 'op-ed';
 }
 
-function exportOpEdSet(set: OpEdSet, format: string): void {
-  if (format === 'text') downloadFile(`${slugify(set.topic)}.txt`, buildOpEdText(set), 'text/plain');
+// Exported for unit testing (t/2797 JSON regression).
+export function exportOpEdSet(set: OpEdSet, format: string): void {
+  if (format === 'json') downloadFile(`${slugify(set.topic)}.json`, JSON.stringify(set, null, 2), 'application/json');
+  else if (format === 'text') downloadFile(`${slugify(set.topic)}.txt`, buildOpEdText(set), 'text/plain');
   else downloadFile(`${slugify(set.topic)}.md`, buildOpEdMarkdown(set), 'text/markdown');
 }
 

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.test.tsx
@@ -149,6 +149,18 @@ describe('OpEdMyRow', () => {
     renderRow(makeSummary(), { editMode: true });
     expect(screen.getByRole('checkbox', { name: /select/i })).toBeTruthy();
   });
+
+  // t/2797 Part B: the export menu offers Markdown / Plain text / JSON; JSON is new.
+  it('export menu includes a JSON option that fires onExport with "json"', () => {
+    const onExport = vi.fn();
+    const set = makeSummary();
+    renderRow(set, { onExport });
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    const jsonItem = screen.getByRole('menuitem', { name: /^json$/i });
+    expect(jsonItem).toBeTruthy();
+    fireEvent.click(jsonItem);
+    expect(onExport).toHaveBeenCalledWith(set, 'json');
+  });
 });
 
 describe('OpEdCommunityRow', () => {

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
@@ -205,6 +205,7 @@ function OpEdExportMenu({ onExport }: { onExport: (format: string) => void }) {
         <span role="menu" className="oped-export-menu-list">
           <button type="button" role="menuitem" className="oped-export-menu-item" onClick={() => pick('markdown')}>Markdown</button>
           <button type="button" role="menuitem" className="oped-export-menu-item" onClick={() => pick('text')}>Plain text</button>
+          <button type="button" role="menuitem" className="oped-export-menu-item" onClick={() => pick('json')}>JSON</button>
         </span>
       )}
     </span>


### PR DESCRIPTION
## Summary

Two UAT export bugs, TL-diagnosed (t/2797). Both single-scope renderer, independent.

### Part A — chat Export ▾ showed no options
`ChatTable.css` blanket `.chat-table td { overflow: hidden }` clipped the `position:absolute` dropdown rendered inside `col-actions`. DebateTable leaves `col-actions` unclipped — the chat clone over-broadened. Fix: `.chat-table td.col-actions { overflow: visible }` (with a comment on why). Covers My + Community rows.

### Part B — op-ed export missing JSON
`OpEdExportMenu` offered only Markdown + Plain text; chat gained JSON in t/2782. Added a **JSON** menu item and a `format === 'json'` branch in `exportOpEdSet` → `downloadFile(...json, JSON.stringify(set, null, 2), 'application/json')`. The shared menu covers both My and Community.

## Tests
- `OpEdTable.test.tsx`: JSON menu item renders + click fires `onExport(set, 'json')`.
- `OpEdExport.test.tsx` (new): `exportOpEdSet(set, 'json')` produces a parseable `.json` blob round-tripping the set (captures the Blob via a `URL.createObjectURL` spy).

## Self-cert
Part A = 1-line CSS parity fix; Part B = trivial-scale + regression test. No deviations from the TL diagnosis.

## Verification
renderer tsc 0 errors · eslint 0 errors on changed files · op-ed tests 26 passing (2 new). Part A is a visual clip not observable in jsdom — guarded by the debate-parity CSS comment. CI authoritative for full vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)