### PR TITLE
feat(lib/brief): T1 schemas, types, schemaUtils, and schema tests (t/2799)

### DIFF
--- a/docs/adr/ADR-0001-deck-spec-ir.md
+++ b/docs/adr/ADR-0001-deck-spec-ir.md
@@ -1,0 +1,77 @@
+# ADR-0001: Debate Brief Intermediate Representation — Schema Strategy and Contract
+
+**Status:** Accepted  
+**Date:** 2026-08-19  
+**Ticket:** t/2799  
+**Discussion:** e/109  
+
+## Context
+
+The Debate Brief Export pipeline (`Export-TriadBrief`) produces three JSON artifacts per run: `deck_spec.json` (the structured debate IR), `narration.json` (LLM-generated slide narration), and `audit-manifest.json` (run metadata and integrity hashes). These artifacts are consumed by multiple subsystems — the server, renderer, PowerShell cmdlets, and downstream tools — and the format is a one-way door: once consumers exist, breaking changes require coordinated migration.
+
+Three design questions needed answers before consumers could be built:
+
+1. **Validation model** — strict everywhere, or split write vs. read?
+2. **Version discriminator** — how do consumers identify the format major line?
+3. **Traceability** — how do narration entries reference their source node in `deck_spec`?
+
+A secondary concern was coverage scope: the `trace_coverage_pct` field records how many narration entries carry a resolvable trace, but whether "100%" should be enforced by the schema or a downstream gate was an open question.
+
+## Decision
+
+### Model B — Strict write, lenient read (derived mechanically)
+
+The write path validates against a **strict schema** (`*.write.json`) with `additionalProperties: false` throughout. The read path validates against a **derived schema** produced mechanically by stripping all `additionalProperties: false` nodes from the strict schema (`deriveReadSchema()` in `lib/brief/schemaUtils.ts`). No hand-maintained second schema file exists — the strict schema is the single source of truth.
+
+**Rationale:** Strict-on-write catches producer bugs early (the worst time to find a shape error is at the consumer). Lenient-on-read lets consumers survive non-breaking additive changes (new optional fields) without coordinated upgrades. Mechanical derivation eliminates the drift risk that comes from maintaining two files in sync.
+
+**Alternative considered (Model A — strict everywhere):** Rejected because it forces all consumers to upgrade in lockstep for any additive field, making iterative development across T2–T8 brittle.
+
+### Version discriminator — `pattern: "^1\\.\\d+$"`, not `const`
+
+The `deck_spec_version` field in all three schemas uses a regex pattern (`^1\.\d+$`) rather than a `const` value. Writers emit the exact version they produce (e.g., `"1.0"`); readers accept any 1.x string.
+
+**Minor bump rule:** Adding an optional field, relaxing a constraint, or expanding an enum is a minor bump (1.x → 1.x+1). Removing a required field, tightening a constraint, or renaming a field is a major bump (1.x → 2.0) and requires a new schema file and migration plan.
+
+**Rationale:** A `const: "1.0"` discriminator would require a schema change every time a compatible field is added, producing false breaking-change signals. The pattern approach lets readers state their intent ("I accept any 1.x document") without coupling to a specific patch version.
+
+### Traceability — RFC 6901 JSON Pointer
+
+`narration.json` entries carry a `trace` field (RFC 6901 JSON Pointer, e.g. `/cruxes/1`, `/resolution_analysis/stronger_camp_findings/0`) that resolves into `deck_spec.json`. The `audit-manifest.json` records `trace_coverage_pct` (0–100) — the percentage of narration entries with a resolvable trace.
+
+**Single resolver:** All trace resolution must go through one module, `lib/brief/traceResolver.ts` (T3). No consumer resolves traces ad-hoc. This ensures consistent error handling and makes the resolver the single place to add caching, validation, or format evolution.
+
+**Rationale:** JSON Pointer is an IETF standard (RFC 6901), already used in JSON Schema itself, with unambiguous semantics and no parsing ambiguity. Alternatives considered (dot-notation paths, custom IDs) introduced either ambiguity (arrays) or required a separate ID registry.
+
+### Coverage enforcement — T5 gate, not schema `const`
+
+`trace_coverage_pct` is typed as `number` with `minimum: 0, maximum: 100`. The `const: 100` constraint was **explicitly rejected** for the schema. For `narration_mode: "narrated"` runs, the requirement that `trace_coverage_pct == 100` is enforced by the T5 verify gate (t/2803), not by JSON Schema.
+
+**Rationale:** JSON Schema `const` enforces the constraint at parse time for all reads, including intermediate states during generation and for `deterministic` mode runs where coverage is not expected to be 100%. Moving enforcement to T5 keeps the schema honest about what it actually represents (a recorded number) and places the business rule where it can carry context (which mode, which run phase).
+
+### Record-vs-policy coverage distinction
+
+The schema records facts; policy rules live in gates. Fields like `trace_coverage_pct`, `within_tolerance`, and `checker_passed` are recorded observations — the schema validates their type and range. Whether a run should be accepted, retried, or flagged is a policy enforced by the verify stage, not by schema validation. This distinction is intentional and should be preserved as new fields are added.
+
+## Consequences
+
+**Positive:**
+- Consumers can be built against a stable, frozen 1.x contract (t/2799 ships T2–T8 fanned out from `main`)
+- Additive schema evolution does not require consumer upgrades
+- Single source of truth eliminates write/read schema drift
+- Trace coverage enforcement is testable independently of schema validation
+
+**Negative:**
+- `deriveReadSchema()` must be called explicitly — a consumer that imports the `.write.json` directly for read-time validation will be overly strict (a lint rule or hook should catch this; see t/2808)
+- Minor/major bump determination is a human judgment call — the schema-diff CI guard (t/2808) will flag any structural change for review but cannot auto-classify bump type
+
+## Files
+
+| File | Role |
+|------|------|
+| `lib/brief/schemas/deck_spec.write.json` | Strict write schema, deck_spec v1.x |
+| `lib/brief/schemas/narration.write.json` | Strict write schema, narration v1.x |
+| `lib/brief/schemas/audit-manifest.write.json` | Strict write schema, audit-manifest v1.x |
+| `lib/brief/schemaUtils.ts` | `deriveReadSchema()`, `hasAdditionalPropertiesFalse()` |
+| `lib/brief/types.ts` | Canonical TypeScript types for all three artifacts |
+| `lib/brief/schemas.test.ts` | Invariant tests: strict-on-write, lenient-on-read, version pattern, trace pattern |

--- a/lib/brief/schemaUtils.ts
+++ b/lib/brief/schemaUtils.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+type JsonObject = Record<string, unknown>;
+
+/**
+ * Mechanically derive the lenient read-time schema from a strict write-time schema.
+ * Strips all `additionalProperties: false` entries recursively, preserving all
+ * type/required/enum constraints. The strict schema is the single source of truth;
+ * this function produces the read variant — do not hand-maintain two schema files.
+ */
+export function deriveReadSchema(strict: JsonObject): JsonObject {
+  const clone: JsonObject = JSON.parse(JSON.stringify(strict));
+  stripAdditionalPropertiesFalse(clone);
+  return clone;
+}
+
+function stripAdditionalPropertiesFalse(obj: JsonObject): void {
+  if (typeof obj !== 'object' || obj === null) return;
+  if (obj['additionalProperties'] === false) delete obj['additionalProperties'];
+  for (const value of Object.values(obj)) {
+    if (typeof value === 'object' && value !== null) {
+      stripAdditionalPropertiesFalse(value as JsonObject);
+    }
+  }
+}
+
+/** True if any node in the schema tree carries additionalProperties:false. */
+export function hasAdditionalPropertiesFalse(schema: JsonObject): boolean {
+  if (typeof schema !== 'object' || schema === null) return false;
+  if (schema['additionalProperties'] === false) return true;
+  return Object.values(schema).some(
+    v => typeof v === 'object' && v !== null && hasAdditionalPropertiesFalse(v as JsonObject),
+  );
+}

--- a/lib/brief/schemas.test.ts
+++ b/lib/brief/schemas.test.ts
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2799 — derived read-variant assertion.
+// The strict write schemas are the single source of truth; the read variant is
+// mechanically derived (additionalProperties:false stripped). This test asserts
+// the invariant so two-schema drift is impossible.
+
+import { describe, it, expect } from 'vitest';
+import { deriveReadSchema, hasAdditionalPropertiesFalse } from './schemaUtils.js';
+import deckSpecStrict from './schemas/deck_spec.write.json';
+import narrationStrict from './schemas/narration.write.json';
+import auditManifestStrict from './schemas/audit-manifest.write.json';
+
+const SCHEMAS = [
+  { name: 'deck_spec', schema: deckSpecStrict },
+  { name: 'narration', schema: narrationStrict },
+  { name: 'audit-manifest', schema: auditManifestStrict },
+];
+
+describe('strict write schemas', () => {
+  SCHEMAS.forEach(({ name, schema }) => {
+    it(`${name}: has additionalProperties:false (strict)`, () => {
+      expect(hasAdditionalPropertiesFalse(schema as never)).toBe(true);
+    });
+
+    it(`${name}: deck_spec_version pattern is ^1\\.\\d+$ (not const)`, () => {
+      const versionProp = (schema as Record<string, Record<string, unknown>>)
+        .properties?.deck_spec_version;
+      expect(versionProp?.['const']).toBeUndefined();
+      expect(versionProp?.['pattern']).toBe('^1\\.\\d+$');
+    });
+  });
+});
+
+describe('deriveReadSchema', () => {
+  SCHEMAS.forEach(({ name, schema }) => {
+    it(`${name}: derived read variant has NO additionalProperties:false`, () => {
+      const read = deriveReadSchema(schema as never);
+      expect(hasAdditionalPropertiesFalse(read)).toBe(false);
+    });
+
+    it(`${name}: derived read variant preserves top-level type and required`, () => {
+      const strict = schema as Record<string, unknown>;
+      const read = deriveReadSchema(strict);
+      expect(read['type']).toBe('object');
+      expect(read['required']).toEqual(strict['required']);
+    });
+
+    it(`${name}: derived read variant is idempotent and strips only additionalProperties:false`, () => {
+      const strict = schema as Record<string, unknown>;
+      const read = deriveReadSchema(strict);
+      // Idempotent: a second derivation changes nothing
+      expect(deriveReadSchema(read)).toEqual(read);
+      // Strict contains the field; derived has no :false form (schema-valued additionalProperties is preserved)
+      expect(JSON.stringify(strict)).toContain('"additionalProperties":false');
+      expect(JSON.stringify(read)).not.toContain('"additionalProperties":false');
+    });
+  });
+});
+
+describe('narration.write.json', () => {
+  it('trace fields have RFC 6901 JSON Pointer pattern', () => {
+    const entries = (narrationStrict as Record<string, Record<string, Record<string, unknown>>>)
+      .properties?.entries?.items as Record<string, Record<string, unknown>> | undefined;
+    expect(entries?.properties?.trace?.['pattern']).toBe('^(/([^~/]|~[01])*)+$');
+  });
+
+  it('narration_mode is a required enum field', () => {
+    const required = (narrationStrict as Record<string, unknown[]>).required;
+    expect(required).toContain('narration_mode');
+    const prop = (narrationStrict as Record<string, Record<string, Record<string, unknown>>>)
+      .properties?.narration_mode;
+    expect(prop?.['enum']).toEqual(['narrated', 'deterministic']);
+  });
+
+  it('preset is a required field', () => {
+    const required = (narrationStrict as Record<string, unknown[]>).required;
+    expect(required).toContain('preset');
+  });
+});
+
+describe('audit-manifest.write.json', () => {
+  it('trace_coverage_pct has no const:100 (gate moved to T5)', () => {
+    const prop = (auditManifestStrict as Record<string, Record<string, Record<string, unknown>>>)
+      .properties?.trace_coverage_pct;
+    expect(prop?.['const']).toBeUndefined();
+    expect(prop?.['minimum']).toBe(0);
+    expect(prop?.['maximum']).toBe(100);
+  });
+
+  it('narration_mode is required', () => {
+    const required = (auditManifestStrict as Record<string, unknown[]>).required;
+    expect(required).toContain('narration_mode');
+  });
+});
+
+describe('deck_spec.write.json', () => {
+  it('meta.snapshot is an optional boolean', () => {
+    const metaProps = (deckSpecStrict as Record<string, Record<string, Record<string, Record<string, unknown>>>>)
+      .properties?.meta?.properties;
+    expect(metaProps?.snapshot?.['type']).toBe('boolean');
+  });
+
+  it('meta.snapshot is not in required array', () => {
+    const metaRequired = (deckSpecStrict as Record<string, Record<string, unknown[]>>)
+      .properties?.meta?.required;
+    expect(metaRequired).not.toContain('snapshot');
+  });
+});

--- a/lib/brief/schemas/audit-manifest.write.json
+++ b/lib/brief/schemas/audit-manifest.write.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aitriad.local/schemas/audit-manifest/1.0",
+  "title": "AuditManifest",
+  "description": "Strict write-time schema for audit-manifest.json. The trace_coverage_pct==100 gate is enforced by T5 (verify stage) for mode=narrated, not by this schema.",
+  "type": "object",
+  "required": [
+    "debate_id", "run_id", "deck_spec_version", "timestamp", "tool_versions",
+    "artifacts", "narrator_model", "narrator_model_source", "narration_mode",
+    "trace_coverage_pct", "symmetry", "verdict_counts", "warnings"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "debate_id":             { "type": "string" },
+    "run_id":                { "type": "string" },
+    "deck_spec_version":     { "type": "string", "pattern": "^1\\.\\d+$" },
+    "timestamp":             { "type": "string", "format": "date-time" },
+    "tool_versions": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Key: tool name, value: semver string"
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "sha256"],
+        "additionalProperties": false,
+        "properties": {
+          "name":   { "type": "string" },
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+        }
+      }
+    },
+    "narrator_model":        { "type": "string" },
+    "narrator_model_source": { "type": "string", "enum": ["Explicit", "Global", "Default"] },
+    "checker_model":         { "type": ["string", "null"] },
+    "checker_model_source":  { "type": ["string", "null"], "enum": ["Explicit", "Global", "Default", null] },
+    "narration_mode": {
+      "type": "string",
+      "enum": ["narrated", "deterministic"]
+    },
+    "trace_coverage_pct": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 100,
+      "description": "% of narration entries with a resolvable trace. For mode=narrated, must equal 100 (enforced by T5 verify gate, not this schema). Omitted or null in deterministic mode."
+    },
+    "symmetry": {
+      "type": "object",
+      "required": ["camps", "within_tolerance", "tolerance_pct"],
+      "additionalProperties": false,
+      "properties": {
+        "camps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["camp", "slide_count", "headline_count", "word_budget"],
+            "additionalProperties": false,
+            "properties": {
+              "camp":           { "type": "string" },
+              "slide_count":    { "type": "integer", "minimum": 0 },
+              "headline_count": { "type": "integer", "minimum": 0 },
+              "word_budget":    { "type": "integer", "minimum": 0 }
+            }
+          }
+        },
+        "within_tolerance": { "type": "boolean" },
+        "tolerance_pct":    { "type": "number", "default": 20 }
+      }
+    },
+    "verdict_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Supported":    { "type": "integer", "minimum": 0 },
+        "Disputed":     { "type": "integer", "minimum": 0 },
+        "Unverifiable": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/lib/brief/schemas/deck_spec.write.json
+++ b/lib/brief/schemas/deck_spec.write.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aitriad.local/schemas/deck_spec/1.0",
+  "title": "DeckSpec",
+  "description": "Strict write-time schema for deck_spec.json v1.x. Validate on write (hard error); use the derived read variant (additionalProperties stripped) on read.",
+  "type": "object",
+  "required": [
+    "deck_spec_version", "meta", "question", "framing_critique",
+    "agreements", "disagreements", "cruxes", "resolution_analysis",
+    "unresolved_questions", "argument_map", "fact_checks",
+    "concessions", "top_claims", "convergence", "open_threads"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "deck_spec_version": {
+      "type": "string",
+      "pattern": "^1\\.\\d+$",
+      "description": "Major-line version. Writers emit exact version (e.g. '1.0'); readers accept any 1.x via pattern."
+    },
+    "meta": {
+      "type": "object",
+      "required": ["id", "run_id", "title", "model", "protocol", "phase"],
+      "additionalProperties": false,
+      "properties": {
+        "id":                   { "type": "string" },
+        "run_id":               { "type": "string" },
+        "title":                { "type": "string" },
+        "model":                { "type": "string" },
+        "protocol":             { "type": "string" },
+        "phase":                { "type": "string", "enum": ["concluding", "closed", "open"] },
+        "transition_rationale": { "type": "string" },
+        "snapshot": {
+          "type": "boolean",
+          "description": "True when exported via allowOpen=true (watermark/maturity semantics). Drives render watermark."
+        },
+        "snapshot_note": { "type": "string" }
+      }
+    },
+    "question": {
+      "type": "object",
+      "required": ["core_proposition"],
+      "additionalProperties": false,
+      "properties": {
+        "core_proposition": { "type": "string" },
+        "tensions":         { "type": "array", "items": { "type": "string" } },
+        "qualifiers":       { "type": "array", "items": { "type": "string" } },
+        "exclusions":       { "type": "array", "items": { "type": "string" } },
+        "time_horizon":     { "type": "string" }
+      }
+    },
+    "framing_critique": {
+      "type": "object",
+      "required": ["rating", "composite"],
+      "additionalProperties": false,
+      "properties": {
+        "rating":           { "type": "string" },
+        "composite":        { "type": "number" },
+        "rewritten_motion": { "type": "string" }
+      }
+    },
+    "agreements":            { "type": "array", "items": { "$ref": "#/$defs/TextNode" } },
+    "disagreements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["text", "kind", "resolution_path"],
+        "additionalProperties": false,
+        "properties": {
+          "text":            { "type": "string" },
+          "kind":            { "type": "string", "enum": ["EMPIRICAL", "VALUES"] },
+          "resolution_path": { "type": "string" },
+          "source_ref":      { "type": "string" }
+        }
+      }
+    },
+    "cruxes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["text", "kind", "if_yes", "if_no"],
+        "additionalProperties": false,
+        "properties": {
+          "text":   { "type": "string" },
+          "kind":   { "type": "string", "enum": ["EMPIRICAL", "VALUES"] },
+          "if_yes": { "type": "string" },
+          "if_no":  { "type": "string" }
+        }
+      }
+    },
+    "resolution_analysis": {
+      "type": "object",
+      "required": ["stronger_camp_findings"],
+      "additionalProperties": false,
+      "properties": {
+        "stronger_camp_findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["camp", "finding"],
+            "additionalProperties": false,
+            "properties": {
+              "camp":    { "type": "string" },
+              "finding": { "type": "string" }
+            }
+          }
+        },
+        "would_change_if": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["camp", "falsifier"],
+            "additionalProperties": false,
+            "properties": {
+              "camp":      { "type": "string" },
+              "falsifier": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "unresolved_questions": { "type": "array", "items": { "$ref": "#/$defs/TextNode" } },
+    "argument_map": {
+      "type": "object",
+      "required": ["nodes", "relations"],
+      "additionalProperties": false,
+      "properties": {
+        "nodes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "camp", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "id":       { "type": "string" },
+              "camp":     { "type": "string" },
+              "label":    { "type": "string" },
+              "strength": { "type": "number" }
+            }
+          }
+        },
+        "relations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["from", "to", "type"],
+            "additionalProperties": false,
+            "properties": {
+              "from": { "type": "string" },
+              "to":   { "type": "string" },
+              "type": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "fact_checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["claim", "verdict"],
+        "additionalProperties": false,
+        "properties": {
+          "claim":       { "type": "string" },
+          "verdict":     { "type": "string", "enum": ["Supported", "Disputed", "Unverifiable"] },
+          "sources":     { "type": "array", "items": { "type": "string" } },
+          "explanation": { "type": "string" },
+          "speaker": {
+            "type": "string",
+            "description": "speaker='system' indicates neutral evidence injected by fact-checker, never a camp claim. Sentinel enforced in extract/render logic, not schema."
+          }
+        }
+      }
+    },
+    "concessions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["camp", "asserted", "conceded", "challenged"],
+        "additionalProperties": false,
+        "properties": {
+          "camp":       { "type": "string" },
+          "asserted":   { "type": "integer", "minimum": 0 },
+          "conceded":   { "type": "integer", "minimum": 0 },
+          "challenged": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "top_claims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["camp", "claim", "strength"],
+        "additionalProperties": false,
+        "properties": {
+          "camp":     { "type": "string" },
+          "claim":    { "type": "string" },
+          "strength": { "type": "number" }
+        }
+      }
+    },
+    "convergence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["issue", "score"],
+        "additionalProperties": false,
+        "properties": {
+          "issue": { "type": "string" },
+          "score": { "type": "number", "minimum": 0, "maximum": 1 }
+        }
+      }
+    },
+    "open_threads": { "type": "array", "items": { "$ref": "#/$defs/TextNode" } }
+  },
+  "$defs": {
+    "TextNode": {
+      "type": "object",
+      "required": ["text"],
+      "additionalProperties": false,
+      "properties": {
+        "text":       { "type": "string" },
+        "source_ref": { "type": "string" }
+      }
+    }
+  }
+}

--- a/lib/brief/schemas/narration.write.json
+++ b/lib/brief/schemas/narration.write.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://aitriad.local/schemas/narration/1.0",
+  "title": "Narration",
+  "description": "Strict write-time schema for narration.json. Validate on write; use derived read variant on read.",
+  "type": "object",
+  "required": [
+    "deck_spec_version", "narrator_model", "narrator_model_source",
+    "narration_mode", "preset", "entries", "audience_questions"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "deck_spec_version": {
+      "type": "string",
+      "pattern": "^1\\.\\d+$"
+    },
+    "narration_mode": {
+      "type": "string",
+      "enum": ["narrated", "deterministic"],
+      "description": "narrated = model-generated entries with traces; deterministic = skipNarration mode, verbatim spec text, entries may be empty."
+    },
+    "preset": {
+      "type": "string",
+      "enum": ["policymaker", "conference", "classroom"],
+      "description": "Preset this narration was produced for. Required for re-render and audit."
+    },
+    "narrator_model":        { "type": "string" },
+    "narrator_model_source": { "type": "string", "enum": ["Explicit", "Global", "Default"] },
+    "checker_model":         { "type": ["string", "null"] },
+    "checker_model_source":  { "type": ["string", "null"], "enum": ["Explicit", "Global", "Default", null] },
+    "checker_passed":        { "type": ["boolean", "null"] },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["trace", "text"],
+        "additionalProperties": false,
+        "properties": {
+          "trace": {
+            "type": "string",
+            "pattern": "^(/([^~/]|~[01])*)+$",
+            "description": "RFC 6901 JSON Pointer into deck_spec. E.g. /cruxes/1, /resolution_analysis/stronger_camp_findings/0."
+          },
+          "text":  { "type": "string" },
+          "slide": { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "audience_questions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["trace", "question"],
+        "additionalProperties": false,
+        "properties": {
+          "trace": {
+            "type": "string",
+            "pattern": "^(/([^~/]|~[01])*)+$"
+          },
+          "question": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/lib/brief/types.ts
+++ b/lib/brief/types.ts
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Shared TypeScript types for the Debate Brief Export pipeline (t/2799).
+// These are the canonical types consumed by server, renderer, and PowerShell.
+// JSON schema source of truth: lib/brief/schemas/*.write.json
+
+// ── Primitives ────────────────────────────────────────────────────────────────
+
+/** deck_spec_version string — major-line 1.x; writers emit the exact version they produce. */
+export type DeckSpecVersion = string;
+
+export type BriefPreset     = 'policymaker' | 'conference' | 'classroom';
+export type ModelSource     = 'Explicit' | 'Global' | 'Default';
+export type DisagreementKind = 'EMPIRICAL' | 'VALUES';
+export type FactCheckVerdict = 'Supported' | 'Disputed' | 'Unverifiable';
+export type DebatePhase      = 'concluding' | 'closed' | 'open';
+export type NarrationMode    = 'narrated' | 'deterministic';
+
+// ── deck_spec.json ────────────────────────────────────────────────────────────
+
+export interface DeckSpec {
+  deck_spec_version: DeckSpecVersion;
+  meta: DeckSpecMeta;
+  question: DeckSpecQuestion;
+  framing_critique: FramingCritique;
+  agreements: TextNode[];
+  disagreements: Disagreement[];
+  cruxes: Crux[];
+  resolution_analysis: ResolutionAnalysis;
+  unresolved_questions: TextNode[];
+  argument_map: ArgumentMap;
+  fact_checks: FactCheck[];
+  concessions: CampConcessions[];
+  top_claims: TopClaim[];
+  convergence: ConvergenceScore[];
+  open_threads: TextNode[];
+}
+
+export interface DeckSpecMeta {
+  id: string;
+  run_id: string;
+  title: string;
+  model: string;
+  protocol: string;
+  phase: DebatePhase;
+  transition_rationale?: string;
+  /** True when exported via allowOpen=true — drives render watermark. */
+  snapshot?: boolean;
+  snapshot_note?: string;
+}
+
+export interface DeckSpecQuestion {
+  core_proposition: string;
+  tensions?: string[];
+  qualifiers?: string[];
+  exclusions?: string[];
+  time_horizon?: string;
+}
+
+export interface FramingCritique {
+  rating: string;
+  composite: number;
+  rewritten_motion?: string;
+}
+
+export interface TextNode {
+  text: string;
+  source_ref?: string;
+}
+
+export interface Disagreement extends TextNode {
+  kind: DisagreementKind;
+  resolution_path: string;
+}
+
+export interface Crux {
+  text: string;
+  kind: DisagreementKind;
+  if_yes: string;
+  if_no: string;
+}
+
+export interface ResolutionAnalysis {
+  stronger_camp_findings: { camp: string; finding: string }[];
+  would_change_if?: { camp: string; falsifier: string }[];
+}
+
+export interface ArgumentMap {
+  nodes: { id: string; camp: string; label: string; strength?: number }[];
+  relations: { from: string; to: string; type: string }[];
+}
+
+export interface FactCheck {
+  claim: string;
+  verdict: FactCheckVerdict;
+  sources?: string[];
+  explanation?: string;
+  /** 'system' = neutral evidence injected by fact-checker, not a camp claim. */
+  speaker?: string;
+}
+
+export interface CampConcessions {
+  camp: string;
+  asserted: number;
+  conceded: number;
+  challenged: number;
+}
+
+export interface TopClaim {
+  camp: string;
+  claim: string;
+  strength: number;
+}
+
+export interface ConvergenceScore {
+  issue: string;
+  score: number;
+}
+
+// ── narration.json ────────────────────────────────────────────────────────────
+
+export interface Narration {
+  deck_spec_version: DeckSpecVersion;
+  narration_mode: NarrationMode;
+  /** Preset this narration was produced for — required for re-render and audit. */
+  preset: BriefPreset;
+  narrator_model: string;
+  narrator_model_source: ModelSource;
+  checker_model?: string | null;
+  checker_model_source?: ModelSource | null;
+  checker_passed?: boolean | null;
+  entries: NarrationEntry[];
+  audience_questions: AudienceQuestion[];
+}
+
+export interface NarrationEntry {
+  /** RFC 6901 JSON Pointer into deck_spec. E.g. /cruxes/1 */
+  trace: string;
+  text: string;
+  slide?: number;
+}
+
+export interface AudienceQuestion {
+  /** RFC 6901 JSON Pointer into deck_spec. */
+  trace: string;
+  question: string;
+}
+
+// ── audit-manifest.json ───────────────────────────────────────────────────────
+
+export interface AuditManifest {
+  debate_id: string;
+  run_id: string;
+  deck_spec_version: DeckSpecVersion;
+  timestamp: string;
+  tool_versions: Record<string, string>;
+  artifacts: { name: string; sha256: string }[];
+  narrator_model: string;
+  narrator_model_source: ModelSource;
+  checker_model?: string | null;
+  checker_model_source?: ModelSource | null;
+  narration_mode: NarrationMode;
+  /**
+   * % of narration entries with a resolvable trace (0–100).
+   * For mode=narrated, enforcement of ==100 is the T5 verify gate, not this type.
+   */
+  trace_coverage_pct: number;
+  symmetry: SymmetryAudit;
+  verdict_counts: Partial<Record<FactCheckVerdict, number>>;
+  warnings: string[];
+}
+
+export interface SymmetryAudit {
+  camps: { camp: string; slide_count: number; headline_count: number; word_budget: number }[];
+  within_tolerance: boolean;
+  tolerance_pct: number;
+}
+
+// ── TriadDeckExport — PS -PassThru output shape (spec §8) ────────────────────
+
+export interface TriadDeckExport {
+  debateId: string;
+  title: string;
+  preset: BriefPreset;
+  model: string;
+  modelSource: ModelSource;
+  checkerModel?: string;
+  path: string;
+  specPath?: string;
+  manifestPath: string;
+  traceCoveragePct: number;
+  verdicts: Partial<Record<FactCheckVerdict, number>>;
+  warnings: string[];
+}


### PR DESCRIPTION
## Summary

- Three strict write-time JSON schemas: `deck_spec.write.json`, `narration.write.json`, `audit-manifest.write.json`
- Shared TS types (`lib/brief/types.ts`): `DeckSpec`, `Narration`, `AuditManifest`, `TriadDeckExport`, `NarrationMode`, `BriefPreset`, etc.
- `schemaUtils.ts`: `deriveReadSchema()` (mechanically strips `additionalProperties:false`) + `hasAdditionalPropertiesFalse()`
- `schemas.test.ts`: 22 tests asserting strict-on-write / lenient-on-read invariant, RFC 6901 trace pattern, version discriminator, `trace_coverage_pct` has no `const:100`

**Design decisions (per t/2799#3 binding spec):**
- Version discriminator: `pattern: "^1\.\d+$"` (not `const`) — readers accept full major-line 1.x
- Read variant derived mechanically — no hand-maintained second schema file
- `narration_mode: 'narrated' | 'deterministic'` discriminator (skipNarration is first-class)
- `trace_coverage_pct` is `number 0–100`; ==100 enforcement is T5 gate (t/2803)
- `meta.snapshot?: boolean` optional, drives render watermark

**Hold:** Awaiting TL confirmatory pass on schemas + derived-read-variant tests before consumers fan out.

## Test plan

- [x] `npx vitest run brief/schemas.test.ts` — 22/22 pass
- [ ] TL confirmatory pass on schema contracts