### PR TITLE
feat(oped): web URL-source op-eds via the hardened fetchUrlContent (t/2807)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -350,7 +350,17 @@ export async function* generateOpEdSet(
         signal: request.signal,
       });
       const parsed = JSON.parse(stripCodeFences(briefRaw)) as SourceBrief;
-      if (parsed.readable !== false) sourceBrief = parsed;
+      if (parsed.readable !== false) {
+        sourceBrief = parsed;
+      } else {
+        // t/2807: Step-0 judged the supplied source unreadable — voices then generate
+        // from topic only, silently ignoring the source the caller provided. Record it
+        // so "source supplied but not represented" is diagnosable (via the host recorder).
+        deps.recorder?.record({
+          type: 'system.error', component: 'oped-generate', level: 'warn',
+          message: 'Op-ed source brief marked unreadable — generating from topic only despite a supplied source',
+        });
+      }
       yield { type: 'source_brief_done' };
     } catch (err) {
       yield { type: 'source_brief_failed', error: String(err) };

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -192,6 +192,39 @@ describe('generateOpEdSet — Step 0 source-brief comprehension (t/2722)', () =>
     expect(briefIdx).toBeLessThan(groundingIdx);
   });
 
+  it('records a warning when the source brief comes back readable:false (t/2807)', async () => {
+    const UNREADABLE_JSON = JSON.stringify({
+      thesis: '', author: '', actor_type: '', stance: '',
+      primary_recommendations: [], key_claims: [], readable: false,
+    });
+    const adapter = {
+      generateText: async (prompt: string) => {
+        if (prompt === 'source-brief-prompt') return UNREADABLE_JSON;
+        if (prompt === 'refl') return REFL_JSON;
+        return ESSAY_JSON;
+      },
+    };
+    const req = {
+      set_id: 's-unreadable', topic: 'AI safety',
+      params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' } as never,
+      povs: ['accelerationist'] as PovKey[],
+      sourceMaterial: 'Unparseable gibberish',
+    };
+    const record = vi.fn();
+    const deps = { adapter: adapter as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT, recorder: { record } };
+
+    const events: string[] = [];
+    for await (const ev of generateOpEdSet(req, deps) as AsyncGenerator<OpEdProgressEvent>) {
+      events.push(ev.type);
+    }
+
+    // Non-fatal: Step 0 still completes and the set generates (from topic only)…
+    expect(events).toContain('source_brief_done');
+    expect(events).toContain('complete');
+    // …but the supplied-but-unreadable source is recorded so it's diagnosable.
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({ level: 'warn', component: 'oped-generate' }));
+  });
+
   it('yields source_brief_failed but still completes when comprehension throws', async () => {
     const adapter = {
       generateText: async (prompt: string) => {

--- a/taxonomy-editor/src/server/__tests__/opedRoutes.test.ts
+++ b/taxonomy-editor/src/server/__tests__/opedRoutes.test.ts
@@ -44,9 +44,18 @@ vi.mock('../ai/opedAdapter.js', () => ({ createWebOpEdAdapter: () => ({ generate
 
 // isSafeId comes from fileIO; mock it to the SAME whitelist as fileIO's SAFE_ID_RE
 // (/^[a-zA-Z0-9_-]+$/) so this test never pulls the heavy fileIO backend chain.
+// fetchUrlContent (t/2807) is also mocked here so the URL-source path is controllable
+// without the real network/SSRF stack (that stack is covered by t720Security.test.ts).
+const { fetchUrlContent } = vi.hoisted(() => ({ fetchUrlContent: vi.fn() }));
 vi.mock('../storage/fileIO.js', () => ({
   isSafeId: (v: string) => !!v && /^[a-zA-Z0-9_-]+$/.test(v),
+  fetchUrlContent,
 }));
+
+// t/2807: controllable generator so the URL happy-path can assert the request handed to
+// the core carries sourceMaterial, without driving real AI generation.
+const { generateOpEdSet } = vi.hoisted(() => ({ generateOpEdSet: vi.fn() }));
+vi.mock('../../../../lib/oped/generate.js', () => ({ generateOpEdSet }));
 
 import { registerOpedRoutes } from '../routes/oped.js';
 
@@ -67,6 +76,9 @@ function fakeRes(): ServerResponse & { _status?: number; _body?: string } {
     writeHead: vi.fn((s: number) => { res._status = s; }),
     end: vi.fn((b?: string) => { res._body = b; }),
     setHeader: vi.fn(),
+    // SSE path (t/2807 URL happy-path drives the stream): write/on must exist.
+    write: vi.fn(),
+    on: vi.fn(),
   } as unknown as ServerResponse & { _status?: number; _body?: string };
   return res;
 }
@@ -222,6 +234,8 @@ describe('POST /api/oped-sets create pre-start gate (t/2610)', () => {
     resolveTier.mockReset().mockReturnValue({ level: 'platform', allowedBackends: ['gemini', 'claude', 'groq'], pinnedModel: undefined });
     resolveBackend.mockReset().mockReturnValue('gemini');
     isRegisteredModel.mockReset().mockReturnValue(true);
+    fetchUrlContent.mockReset();
+    generateOpEdSet.mockReset();
     const r = makeRouter();
     registerOpedRoutes(r.router as never, {} as never);
     handlers = r.handlers;
@@ -273,10 +287,49 @@ describe('POST /api/oped-sets create pre-start gate (t/2610)', () => {
     expect(getOpedSetsQuotaStatus).not.toHaveBeenCalled(); // gated before quota + any generation
   });
 
-  it('400 on a URL/source path — P1 is FromTopic only', async () => {
+  it('400 on a file/PDF/DOCX `source` upload — still desktop-only (t/2807 keeps this blocked)', async () => {
+    const res = fakeRes();
+    await handlers['POST /api/oped-sets'](fakeReq('/api/oped-sets'), res, { ...validBody, source: { name: 'doc.pdf' } });
+    expect(res._status).toBe(400);
+    expect(fetchUrlContent).not.toHaveBeenCalled();
+  });
+
+  // t/2807 Part 1: URL source is fetched via the hardened fileIO.fetchUrlContent and
+  // flows into the generator as sourceMaterial.
+  it('URL source: fetches via fetchUrlContent and hands sourceMaterial to the generator', async () => {
+    fetchUrlContent.mockResolvedValue({ content: '# Fetched article\nBody.' });
+    let capturedReq: { sourceMaterial?: string } | undefined;
+    generateOpEdSet.mockImplementation(async function* (req: { set_id: string; topic: string; params: unknown; sourceMaterial?: string }) {
+      capturedReq = req;
+      yield { type: 'complete', set: { schema_version: 1, set_id: req.set_id, topic: req.topic, params: req.params, created_at: 'c', opeds: [] } };
+    });
+    finalizeOpedSet.mockResolvedValue(undefined);
     const res = fakeRes();
     await handlers['POST /api/oped-sets'](fakeReq('/api/oped-sets'), res, { ...validBody, url: 'https://example.com/article' });
-    expect(res._status).toBe(400);
+    // Fetch happened AFTER the gate (quota was checked) and BEFORE generation.
+    expect(getOpedSetsQuotaStatus).toHaveBeenCalled();
+    expect(fetchUrlContent).toHaveBeenCalledWith('https://example.com/article');
+    expect(res._status).toBe(200); // SSE committed → generation ran
+    expect(capturedReq?.sourceMaterial).toBe('# Fetched article\nBody.');
+  });
+
+  // t/2807 MUST: a fetch failure returns a clean HTTP error and NEVER proceeds with
+  // empty sourceMaterial (the t/2722 empty-source regression). No SSE, no generation.
+  it('URL source: a fetch failure returns 502 and does NOT start generation', async () => {
+    fetchUrlContent.mockResolvedValue({ content: '', error: 'blocked host' });
+    const res = fakeRes();
+    await handlers['POST /api/oped-sets'](fakeReq('/api/oped-sets'), res, { ...validBody, url: 'https://169.254.169.254/latest/meta-data' });
+    expect(res._status).toBe(502);
+    expect(generateOpEdSet).not.toHaveBeenCalled();
+    expect(finalizeOpedSet).not.toHaveBeenCalled();
+  });
+
+  it('URL source: fetch runs only AFTER the quota gate — an over-quota caller never triggers a fetch', async () => {
+    getOpedSetsQuotaStatus.mockResolvedValue({ allowed: false, resource: 'opeds', current: 15, limit: 15 });
+    const res = fakeRes();
+    await handlers['POST /api/oped-sets'](fakeReq('/api/oped-sets'), res, { ...validBody, url: 'https://example.com/article' });
+    expect(res._status).toBe(429);
+    expect(fetchUrlContent).not.toHaveBeenCalled();
   });
 
   it('400 when topic is missing/blank', async () => {

--- a/taxonomy-editor/src/server/routes/oped.ts
+++ b/taxonomy-editor/src/server/routes/oped.ts
@@ -22,7 +22,7 @@ import { json, error, param } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { clientSafeMessage } from '../security/accessControl.js';
-import { isSafeId } from '../storage/fileIO.js';
+import { isSafeId, fetchUrlContent } from '../storage/fileIO.js';
 import { listOpedSets, loadOpedSet, deleteOpedSet, getOpedSetsQuotaStatus, finalizeOpedSet } from '../storage/opedStore.js';
 import type { OpEdSet, OpEdMember, OpEdParams, PovKey } from '../../../../lib/oped/types.js';
 import type { GenerateOpEdRequest, OpEdGeneratorDeps, OpEdProgressEvent } from '../../../../lib/oped/generate.js';
@@ -75,12 +75,16 @@ function countRunningOpedRuns(userId: string): number {
   return n;
 }
 
-// ── create-request parsing (P1 FromTopic only) ──
-interface ParsedOpEdCreate { topic: string; povs: string[]; params: OpEdParams }
+// ── create-request parsing (FromTopic + FromSource-URL) ──
+interface ParsedOpEdCreate { topic: string; povs: string[]; params: OpEdParams; url?: string }
 function parseOpEdCreate(body: unknown): { ok: true; value: ParsedOpEdCreate } | { ok: false; status: number; message: string } {
   const b = (body ?? {}) as { topic?: unknown; params?: OpEdParams; povs?: unknown; url?: unknown; source?: unknown };
-  // P1 is FromTopic only (TL) — never present a submit path the server can't run.
-  if (b.url != null || b.source != null) return { ok: false, status: 400, message: 'URL sources require the desktop app — open the desktop app to generate an op-ed from a URL' };
+  // t/2807: `url` sources are now supported on web — fetched via the SSRF-hardened
+  // fileIO.fetchUrlContent (the same path debates use). `source` (file/PDF/DOCX
+  // uploads) still requires the desktop DocConverters path — keep blocking it here
+  // (remaining gap tracked as a follow-up; t/2604 P2/P3).
+  if (b.source != null) return { ok: false, status: 400, message: 'File/PDF/DOCX sources require the desktop app — paste a URL, or use the desktop app for document uploads' };
+  const url = typeof b.url === 'string' && b.url.trim() ? b.url.trim() : undefined;
   const topic = typeof b.topic === 'string' ? b.topic.trim() : '';
   const povs = Array.isArray(b.povs) ? b.povs.filter((p): p is string => typeof p === 'string') : [];
   const params = b.params;
@@ -92,7 +96,16 @@ function parseOpEdCreate(body: unknown): { ok: true; value: ParsedOpEdCreate } |
   // so requiring it 400'd every default web op-ed (t/2685). Coerce absent/invalid/≤0 to the band sentinel 0
   // (mirrors schemas.ts .optional().default(0); generate.ts treats `wordCount > 0 ? … : band.words`).
   const wordCount = typeof params.wordCount === 'number' && params.wordCount > 0 ? params.wordCount : 0;
-  return { ok: true, value: { topic, povs, params: { ...params, wordCount } } };
+  return { ok: true, value: { topic, povs, params: { ...params, wordCount }, url } };
+}
+
+/** Adapt the global FlightRecorder to OpEdGeneratorDeps.recorder's looser param type
+ *  (t/2807). deps.recorder takes Record<string,unknown>; FlightRecorder.record takes the
+ *  stricter RecordInput. generate.ts always passes a valid RecordInput shape, so the
+ *  forward is safe. Module-level so it doesn't add branch-complexity to driveOpEdRun. */
+function toOpEdRecorder(): OpEdGeneratorDeps['recorder'] {
+  const r = getGlobalRecorder();
+  return r ? { record: (e: Record<string, unknown>) => r.record(e as never) } : null;
 }
 
 function applyEventToRun(run: OpEdRun, event: OpEdProgressEvent, completed: OpEdMember[]): void {
@@ -128,6 +141,9 @@ async function driveOpEdRun(
       // companion Dockerfile COPY (Rosetta, repo-root-anchored). Repo-root anchor matches.
       promptsDir: path.join(getProjectRoot(), 'lib', 'oped', 'prompts'),
       repoRoot: getProjectRoot(),
+      // t/2807: give the core a recorder so Step-0 can flag a supplied-but-unreadable
+      // URL source (otherwise it silently degrades to a topic-only op-ed).
+      recorder: toOpEdRecorder(),
     };
     for await (const event of generateOpEdSet(request, deps) as AsyncGenerator<OpEdProgressEvent>) {
       applyEventToRun(run, event, completed);
@@ -193,7 +209,7 @@ export function registerOpedRoutes(r: Router, _ctx: ServerCtx): void {
     if (isAnonymousUser()) { error(res, 'Sign in to create op-eds', 403); return; }
     const parsed = parseOpEdCreate(body);
     if (!parsed.ok) { error(res, parsed.message, parsed.status); return; }
-    const { topic, povs, params } = parsed.value;
+    const { topic, povs, params, url } = parsed.value;
     // Tier-backend entitlement via the shared helper (t/2635 — folds op-ed onto the ONE
     // entitlement path in routes/generationContext.ts, replacing the local resolveOpEdModel
     // mirror). Free tier's model is pinned; a free/restricted caller can't reach a premium
@@ -213,6 +229,24 @@ export function registerOpedRoutes(r: Router, _ctx: ServerCtx): void {
     if (!quota.allowed) { json(res, { error: 'quota_exceeded', resource: quota.resource, current: quota.current, limit: quota.limit }, 429); return; }
     if (countRunningOpedRuns(userId) >= MAX_CONCURRENT_OPED_RUNS) {
       json(res, { error: 'concurrency_limit', message: 'You already have an op-ed generating; wait for it to finish.', limit: MAX_CONCURRENT_OPED_RUNS }, 429); return;
+    }
+
+    // ── URL source fetch (t/2807) ──
+    // Reuse the SSRF-hardened fileIO.fetchUrlContent — the SAME path debates use
+    // (t/720-hardened: HTTPS-only, no creds-in-URL, blocks IP-literals/localhost/
+    // .local/.internal/.corp, timeout + size-cap + content-type + redirect re-validation).
+    // NO second fetch path. Placed AFTER the auth/tier/quota/concurrency gate so an
+    // unentitled or over-quota caller can never use this endpoint as a fetch trigger,
+    // and BEFORE the SSE stream commits so a fetch failure returns a clean HTTP error
+    // instead of a mid-stream frame — never proceed with empty sourceMaterial (t/2722). (TL MUST)
+    let sourceMaterial: string | undefined;
+    if (url) {
+      const fetched = await fetchUrlContent(url);
+      if (fetched.error || !fetched.content) {
+        error(res, `Could not fetch that URL: ${fetched.error || 'no readable content returned'}`, 502);
+        return;
+      }
+      sourceMaterial = fetched.content;
     }
 
     // ── Commit SSE — no JSON error responses after this point ──
@@ -238,7 +272,7 @@ export function registerOpedRoutes(r: Router, _ctx: ServerCtx): void {
 
     writeFrame({ type: 'run_started', runId });
     // Generate with the entitlement-resolved (free-tier-pinned) model, not the raw request.
-    const request: GenerateOpEdRequest = { set_id: setId, topic, params: { ...params, model }, povs: povs as PovKey[], signal: ac.signal };
+    const request: GenerateOpEdRequest = { set_id: setId, topic, params: { ...params, model }, povs: povs as PovKey[], sourceMaterial, signal: ac.signal };
     await driveOpEdRun(res, run, request, writeFrame, heartbeat, () => clientGone);
   });
 


### PR DESCRIPTION
## Summary

Unblocks **FromSource op-eds for URL sources on the hosted web build** by reusing the SSRF-hardened debate fetcher (`fileIO.fetchUrlContent`) instead of the desktop-only PowerShell shim. TL design-approved at t/2807#2.

## Changes

**`server/routes/oped.ts`** (the only production surface):
- `parseOpEdCreate` accepts `url`; still blocks `source` (file/PDF/DOCX → desktop DocConverters, follow-up).
- Fetch via `fileIO.fetchUrlContent` — the **same** t/720-hardened path debates use (HTTPS-only, no creds-in-URL, blocks IP-literals/localhost/.local/.internal/.corp, timeout + size-cap + content-type + redirect re-validation). **No second fetch path.**
- **(TL MUST)** Fetch placed **after** auth/tier/quota/concurrency and **before** the SSE stream commits — an unentitled/over-quota caller can never trigger a fetch, and a fetch failure returns a clean HTTP error, never proceeding with empty `sourceMaterial` (t/2722 regression).
- Fetched markdown flows into `generateOpEdSet` as `sourceMaterial`; Step-0 comprehension runs → `document_claims` populate (unblocks t/2717 on web).

**Observability (TL SHOULD):** when Step-0 marks a supplied source `readable:false`, the core records a warning via `deps.recorder` (route passes the global recorder). Otherwise a supplied-but-unreadable URL silently degrades to a topic-only op-ed.

## Tests
- URL happy-path hands `sourceMaterial` to the generator; fetch-failure → 502 + no generation; fetch runs only after the quota gate; `source` still 400s (all in `opedRoutes.test.ts`).
- `readable:false` → recorder warning (`serialGeneration.test.ts`).
- SSRF unchanged → covered by existing `t720Security.test.ts` (no new fetch path).

## ⚠️ Deviations from approved design (t/2807#1)
1. **Design said "no lib change"** — added a ~5-line FR at the `readable:false` branch in `lib/oped/generate.ts` (+ lib test). That state is only observable inside the core and the TL SHOULD asked for the FR there; it reuses the existing `deps.recorder` hook. **Cross-scope touch (Shared Lib)** — flagging for review; happy to move to a Shared-Lib child ticket if preferred.
2. **Collapsed the 400/502 split to a single 502** for all fetch failures (matches the debate sibling route; avoids fragile error-string parsing).

Note: `topic` remains required alongside `url` (mirrors the desktop FromSource path, which passes both).

## Verification
server tsc 0 errors · eslint 0 new warnings (the one `driveOpEdRun` complexity warning is pre-existing on main — no added branches inside it) · op-ed route + lib + entitlement + route-table suites green (45 tests). Hosted-web fidelity smoke (fetch a known URL → op-ed represents the doc + `document_claims` render) per the AC to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)