### PR TITLE
fix(oped): pass URL at payload root to reach Electron Stage A (t/2809)

### DIFF
--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -622,7 +622,7 @@ try {
     ipcRenderer.invoke('admin-remove-community-item', type, id, reason),
 
   // Op-Ed Studio (t/2575, t/2591)
-  createOpEdSet: (payload: { topic: string; params: unknown; voices: string[] }): Promise<{ set_id: string }> =>
+  createOpEdSet: (payload: { topic: string; url?: string; params: unknown; voices: string[] }): Promise<{ set_id: string }> =>
     ipcRenderer.invoke('create-oped-set', payload),
   cancelOpEdSet: (setId: string): void =>
     void ipcRenderer.invoke('cancel-oped-set', setId),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -100,7 +100,7 @@ export interface CreateOpEdParams {
   includePitch?: boolean;
   voiceOnly?: boolean;
 }
-export interface CreateOpEdPayload { topic: string; params: CreateOpEdParams; voices: PovKey[] }
+export interface CreateOpEdPayload { topic: string; url?: string; params: CreateOpEdParams; voices: PovKey[] }
 /** One 3-stage progress tick from the Electron generation IPC (t/2575 `oped-progress`). */
 export interface OpEdProgressEvent { set_id: string; voice: string; stage: string; error?: string }
 

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
@@ -775,7 +775,8 @@ export function NewOpEdDialog({ open, onClose, onCreated, allowUrlSource = true 
     if (wordCount != null) params.wordCount = wordCount;
     if (!ground) params.voiceOnly = true;
     else { params.maxGroundingNodes = maxGroundingNodes; params.maxSituations = maxSituations; }
-    return { topic: topic.trim(), params, voices: orderedVoices };
+    const sourceUrl = fromWebPage && url.trim() ? url.trim() : undefined;
+    return { topic: topic.trim(), url: sourceUrl, params, voices: orderedVoices };
   };
 
   const handleCancel = () => {


### PR DESCRIPTION
## Summary

- `buildPayload()` in `NewOpEdDialog.tsx` was putting `url` inside `params.url`, but the Electron IPC handler destructures `url` from the top-level payload (`{ topic, url?, params, voices }`)
- Result: `url` was always `undefined` in Stage A, `runGetOpEdSource` never ran, `sourceMaterial` stayed undefined, source-brief comprehension never ran, and `document_claims` was never populated on grounding refs
- Fix: extract URL at payload root in `buildPayload`; `params.url` kept for web/REST path

**Files changed (3 lines):**
- `taxonomy-editor/src/renderer/bridge/types.ts` — add `url?: string` to `CreateOpEdPayload`
- `taxonomy-editor/src/main/preload.cts` — add `url?: string` to IPC payload type annotation
- `taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx` — move url to payload root in `buildPayload`

## Test plan

- [ ] Generate an op-ed with a URL source → grounding refs have non-empty `document_claims`
- [ ] CI green (renderer TSC ceiling = 0, no new errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)