### PR TITLE
feat(search): relocate Search from nav rail to Taxonomy panel + POV detail header (t/2813)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useEffect, useRef, Fragment } from 'react';
 import {
-  Search, LayoutGrid, MessageSquare, MessageCircle, ArrowLeft,
+  LayoutGrid, MessageSquare, MessageCircle, ArrowLeft,
   Ellipsis, CircleHelp, MessageSquareText, Layers,
   RefreshCw, Settings, User, Users, Shield, LogOut, Newspaper,
 } from 'lucide-react';
@@ -301,14 +301,8 @@ export function Toolbar() {
           </>
         )}
         {/* Primary nav — icon-over-label stacks */}
-        <button
-          className={`toolbar-nav${toolbarPanel === 'search' ? ' toolbar-nav-active' : ''}`}
-          onClick={() => toggle('search')}
-          aria-label="Search"
-        >
-          <Search size="1.25em" />
-          <span className="toolbar-nav-label">Search</span>
-        </button>
+        {/* t/2813: Search removed from the nav rail; entry points now live in the
+            Taxonomy panel header + POV detail header. toggle('search') still works. */}
         <button
           className={`toolbar-nav${isTaxonomyActive ? ' toolbar-nav-active' : ''}`}
           onClick={() => {

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -592,6 +592,10 @@ function NodeDetailHeaderTop({ pov, node, readOnly, err, update, maybeRegenAphor
       </div>
       <div className="nd-header-actions">
         {/* doc-link book relocated to the detail panel top-right (collapse-row / phone header) in PovTab — t/2412 */}
+        {/* t/2813: Search entry point in the POV detail header — opens the search panel (previousView captured for Back). */}
+        <button className="nd-header-btn" onClick={() => useTaxonomyStore.getState().setToolbarPanel('search')} title="Search taxonomy" aria-label="Search taxonomy">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        </button>
         {nodeTypeFromId(node.id) === 'pov' && (
           <CopyLinkButton hash={publicPovSharePath(node.id)} title="Copy public link" />
         )}

--- a/taxonomy-editor/src/renderer/components/taxonomy/PovTab.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/PovTab.tsx
@@ -428,7 +428,7 @@ export function PovTab({ pov }: PovTabProps) {
     attributeFilter, attributeInfo,
     clusterView, clusterLoading, clusterError, runClusterView, clearClusterView,
     relatedNodeId, showRelatedEdges, selectedEdge,
-    toolbarPanel, setActiveTab,
+    toolbarPanel, setActiveTab, setToolbarPanel,
     cruxDetailId, showCruxDetail,
   } = useTaxonomyStore();
   const file = useTaxonomyStore((s) => s[pov]);
@@ -812,6 +812,10 @@ export function PovTab({ pov }: PovTabProps) {
               <button className="btn btn-sm btn-ghost" onClick={() => setShowSoulDoc(true)} title="Soul document" aria-label="Soul document">&#x1f4dc;</button>
             </div>
             <div className="list-panel-header-actions">
+              {/* t/2813: Search entry point relocated from the nav rail into the Taxonomy panel header. */}
+              <button className="btn btn-sm btn-ghost" onClick={() => setToolbarPanel('search')} title="Search taxonomy" aria-label="Search taxonomy">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              </button>
               <select
                 className="sort-select"
                 value={sortMode}


### PR DESCRIPTION
## Summary

Relocates the Search entry points (t/2813, TL design-approved t/2813#3/#4): removed from the left nav rail; added to the Taxonomy panel header and the POV detail header. The search experience itself is unchanged.

## Changes
- **Toolbar.tsx** — remove the nav-rail Search `<button>` (and the now-unused `Search` lucide import). `toggle`/`setToolbarPanel` + the Back affordance are untouched.
- **PovTab.tsx** — add a Search magnifier button in the Taxonomy `list-panel` header → `setToolbarPanel('search')`.
- **NodeDetail.tsx** — add a Search magnifier button in the POV detail header → `setToolbarPanel('search')`.

## Design notes (per TL)
- **Mount point unchanged:** search still renders off `toolbarPanel === 'search'` (SearchPanel in the list-panel + `SearchPreview` in pane 2). New buttons just call the same store action.
- **Back:** `setToolbarPanel` captures `previousView` on open, so the existing Back affordance restores the prior Taxonomy view. No store/history changes.

## Self-cert
/trivial-change — single-scope renderer nav refactor, mechanical, no shared-type/API change.

## Verification
renderer tsc 0 errors · eslint 0 new warnings (pre-existing NodeDetail/PovTab complexity warnings only; my additions add no branches). Verify web + Electron (shared components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)