### PR TITLE
fix(contrast): defined fallback for --status-color badges — main back under ceiling (t/2817)

### DIFF
--- a/taxonomy-editor/src/renderer/components/support/CaseDetail.css
+++ b/taxonomy-editor/src/renderer/components/support/CaseDetail.css
@@ -21,7 +21,10 @@
   border-radius: 12px;
   font-size: 0.73rem;
   font-weight: 600;
-  background: var(--status-color);
+  /* --status-color is set inline per-status (CaseDetail.tsx). Defined dark fallback (t/2817):
+     resolves the contrast-gate "undefined token" finding and gives a visible slate default
+     with guaranteed contrast against the #fff text across all themes. */
+  background: var(--status-color, #4b5563);
   color: #fff;
 }
 

--- a/taxonomy-editor/src/renderer/components/support/MyCases.css
+++ b/taxonomy-editor/src/renderer/components/support/MyCases.css
@@ -98,7 +98,10 @@
   border-radius: 10px;
   font-size: 0.7rem;
   font-weight: 600;
-  background: var(--status-color);
+  /* --status-color is set inline per-status (MyCases.tsx). Defined dark fallback (t/2817):
+     resolves the contrast-gate "undefined token" finding and gives a visible slate default
+     with guaranteed contrast against the #fff text across all themes. */
+  background: var(--status-color, #4b5563);
   color: #fff;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary

**Gate-integrity fix.** The required `contrast-check` gate was RED on `main` itself (317 > 314 local; TL saw 321). It is electron-path-filtered and required, so it **blocked every taxonomy-editor PR** regardless of whether they touch CSS — first casualty PR #1249 (TL-approved, no CSS).

## Root cause
The support status badges (`CaseDetail.css`, `MyCases.css`) use `background: var(--status-color)` with the value set **inline per-status** via a `style` custom-property in `*.tsx`. The token is defined nowhere in CSS, so the static gate counts 8 "undefined token" findings (2 selectors × 4 themes). Introduced by the t/1849 inline→CSS migration (816d401d) with no fallback; a later downward ceiling ratchet to 314 exposed the latent findings (a ceiling-lower-vs-main race).

## Fix
`background: var(--status-color, #4b5563)` in both files — a defined dark-slate fallback that (a) resolves the undefined-token findings and (b) guarantees contrast against the `#fff` badge text across all four themes. **Ceiling NOT raised** (the ratchet only goes down).

## Verification
`bash taxonomy-editor/scripts/check-contrast.sh`: **317 → 309** (≤ 314, exit 0). Unblocks PR #1249 and other electron PRs on rebase.

## Prevention (for TL)
The latent findings predate the ceiling drop, so the immediate gap is the **ceiling-lowering step not re-verifying against post-merge main**. Flagging for a possible prevention ticket (re-run the gate on main after any ceiling ratchet) — your call on whether that routes to DevOps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)