### PR TITLE
feat(t2802): T4 Render stage (deck_spec + narration → pptx/HTML)

### DIFF
--- a/lib/brief/render/assemble.ts
+++ b/lib/brief/render/assemble.ts
@@ -1,0 +1,341 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — assemble the target-neutral SlideModel[] from deck_spec + narration.
+// Runs ONCE; both renderers consume the result so pptx and HTML-for-PDF cannot
+// drift. Deterministic, no model.
+//
+// Gate integrity (TL e/113#2): content is budgeted by a FAIR uniform per-entry cap
+// for readability, NOT trimmed to satisfy T5's ±20% parity. Real camp asymmetry
+// surfaces to T5. Any trim is sentence-boundary-aware and warns when traced
+// content is dropped, preserving the "every sentence traces to a node" invariant.
+
+import type { DeckSpec, Narration, BriefPreset, FactCheckVerdict } from '../types.js';
+import { buildTrace } from '../traceResolver.js';
+import type { SlideModel, SlideBlock, CampCard, TraceRef, SlideKind } from './slideModel.js';
+import { campColor } from './deckTheme.js';
+import { profileFor } from './presets.js';
+
+export interface AssembleResult {
+  slides: SlideModel[];
+  warnings: string[];
+}
+
+const REQUIRED_SLIDES: ReadonlySet<SlideKind> = new Set<SlideKind>([
+  'title', 'question', 'provenance',
+]);
+
+export function assemble(spec: DeckSpec, narration: Narration, preset: BriefPreset): AssembleResult {
+  const ctx = new AssembleCtx(spec, narration, preset);
+  const profile = profileFor(preset);
+  const slides: SlideModel[] = [];
+
+  for (const kind of profile.slides) {
+    const slide = ctx.buildSlide(kind);
+    if (slide === null) continue; // graceful-omit: no content and not required
+    slides.push(slide);
+  }
+
+  return { slides, warnings: ctx.warnings };
+}
+
+/** Word-count helper (shared with T5's definition of word budget). */
+function countWords(text: string): number {
+  const t = text.trim();
+  return t === '' ? 0 : t.split(/\s+/).length;
+}
+
+class AssembleCtx {
+  readonly warnings: string[] = [];
+  /** trace → narrated text, for compressing spec copy to slide length. */
+  private readonly narratedByTrace: Map<string, string>;
+  private readonly snapshot: boolean;
+
+  constructor(
+    private readonly spec: DeckSpec,
+    private readonly narration: Narration,
+    private readonly preset: BriefPreset,
+  ) {
+    this.narratedByTrace = new Map();
+    for (const e of narration.entries) this.narratedByTrace.set(e.trace, e.text);
+    this.snapshot = spec.meta.snapshot === true;
+  }
+
+  private watermark(): string | undefined {
+    return this.snapshot ? 'IN PROGRESS' : undefined;
+  }
+
+  /**
+   * Display copy for a spec node: the narrated (compressed) text when the model
+   * produced one for this exact trace, else the verbatim spec text. Applies the
+   * preset's uniform readability cap with sentence-boundary trimming; warns if
+   * traced content is dropped.
+   */
+  private display(trace: string, verbatim: string): string {
+    const narrated = this.narratedByTrace.get(trace) ?? verbatim;
+    return this.capToSentences(narrated, trace);
+  }
+
+  private capToSentences(text: string, trace: string): string {
+    const cap = profileFor(this.preset).perEntryWordCap;
+    if (countWords(text) <= cap) return text;
+    const sentences = text.match(/[^.!?]+[.!?]+(\s|$)|[^.!?]+$/g) ?? [text];
+    const kept: string[] = [];
+    let words = 0;
+    for (const s of sentences) {
+      const w = countWords(s);
+      if (words + w > cap && kept.length > 0) break;
+      kept.push(s.trim());
+      words += w;
+    }
+    const result = kept.join(' ').trim();
+    if (countWords(result) < countWords(text)) {
+      this.warnings.push(
+        `content_trimmed: slide copy for trace "${trace}" exceeded the ${cap}-word ` +
+        `cap and was trimmed at a sentence boundary (full text is in the audit trail).`,
+      );
+    }
+    return result;
+  }
+
+  /** A speaker note carries the VERBATIM spec text + the node's own trace (never fabricated). */
+  private note(trace: string, verbatim: string): TraceRef {
+    return { text: verbatim, trace };
+  }
+
+  /** Finish a slide; graceful-empty per ADR-001: omit contentless optional slides, warn on required. */
+  private finish(kind: SlideKind, title: string, blocks: SlideBlock[], notes: TraceRef[]): SlideModel | null {
+    const hasContent = blocks.some(b => blockHasContent(b));
+    if (!hasContent) {
+      if (REQUIRED_SLIDES.has(kind)) {
+        this.warnings.push(`empty_required_slide: "${kind}" has no content but is a required slide`);
+      } else {
+        return null; // graceful omit
+      }
+    }
+    return { kind, title, blocks, speakerNotes: notes, watermark: this.watermark() };
+  }
+
+  buildSlide(kind: SlideKind): SlideModel | null {
+    switch (kind) {
+      case 'title': return this.title();
+      case 'question': return this.question();
+      case 'how_to_read': return this.howToRead();
+      case 'agreements': return this.agreements();
+      case 'positions': return this.positions();
+      case 'empirical_cruxes': return this.cruxes('EMPIRICAL', 'Empirical Cruxes');
+      case 'values_cruxes': return this.cruxes('VALUES', 'Values Crux(es)');
+      case 'audience_questions': return this.audienceQuestions();
+      case 'change_minds': return this.changeMinds();
+      case 'evidence_shelf': return this.evidenceShelf();
+      case 'provenance': return this.provenance();
+      case 'framing_meta': return this.framingMeta();
+      case 'glossary': return this.glossary();
+      case 'open_threads_appendix': return this.openThreadsAppendix();
+    }
+  }
+
+  // ── Slide builders ───────────────────────────────────────────────────────────
+
+  private title(): SlideModel | null {
+    const m = this.spec.meta;
+    const blocks: SlideBlock[] = [
+      { type: 'text', text: m.title },
+      { type: 'note', text: `Narrated by ${this.narration.narrator_model} · ${this.preset} brief` },
+    ];
+    return this.finish('title', m.title, blocks, []);
+  }
+
+  private question(): SlideModel | null {
+    const q = this.spec.question;
+    const trace = buildTrace(['question', 'core_proposition']);
+    const blocks: SlideBlock[] = [{ type: 'text', text: this.display(trace, q.core_proposition) }];
+    if (q.time_horizon) blocks.push({ type: 'note', text: `Time horizon: ${q.time_horizon}` });
+    if (q.tensions && q.tensions.length > 0) blocks.push({ type: 'bullets', items: q.tensions });
+    return this.finish('question', 'The Question', blocks, [this.note(buildTrace(['question']), q.core_proposition)]);
+  }
+
+  private howToRead(): SlideModel | null {
+    const camps = distinctCamps(this.spec.top_claims.map(c => c.camp));
+    const legend: SlideBlock = {
+      type: 'badge_row',
+      badges: camps.map(c => ({ label: c, value: `#${campColor(c)}` })),
+    };
+    const kinds: SlideBlock = {
+      type: 'bullets',
+      items: [
+        'EMPIRICAL — resolvable by evidence',
+        'VALUES — a values choice, not settled by evidence',
+        'Verdict badges: Supported / Disputed / Unverifiable',
+      ],
+    };
+    return this.finish('how_to_read', 'How to Read This Debate', [legend, kinds], []);
+  }
+
+  private agreements(): SlideModel | null {
+    const items: string[] = [];
+    const notes: TraceRef[] = [];
+    this.spec.agreements.forEach((a, i) => {
+      const trace = buildTrace(['agreements', i]);
+      items.push(this.display(trace, a.text));
+      notes.push(this.note(trace, a.text));
+    });
+    return this.finish('agreements', 'Where All Camps Agree', [{ type: 'bullets', items }], notes);
+  }
+
+  private positions(): SlideModel | null {
+    const camps = distinctCamps(this.spec.top_claims.map(c => c.camp));
+    const notes: TraceRef[] = [];
+    const cards: CampCard[] = camps.map(camp => {
+      const lines: string[] = [];
+      this.spec.top_claims.forEach((c, i) => {
+        if (c.camp !== camp) return;
+        const trace = buildTrace(['top_claims', i]);
+        lines.push(this.display(trace, c.claim));
+        notes.push(this.note(trace, c.claim));
+      });
+      return { camp, title: camp.toUpperCase(), lines };
+    });
+    return this.finish('positions', 'The Positions', [{ type: 'card_row', cards }], notes);
+  }
+
+  private cruxes(kind: 'EMPIRICAL' | 'VALUES', title: string): SlideModel | null {
+    const blocks: SlideBlock[] = [];
+    const notes: TraceRef[] = [];
+    this.spec.cruxes.forEach((c, i) => {
+      if (c.kind !== kind) return;
+      const trace = buildTrace(['cruxes', i]);
+      blocks.push({ type: 'fork', prompt: this.display(trace, c.text), ifYes: c.if_yes, ifNo: c.if_no });
+      notes.push(this.note(trace, c.text));
+    });
+    if (kind === 'VALUES' && blocks.length > 0) {
+      blocks.push({ type: 'note', text: 'These are values choices — not resolvable by evidence.' });
+    }
+    return this.finish(kind === 'EMPIRICAL' ? 'empirical_cruxes' : 'values_cruxes', title, blocks, notes);
+  }
+
+  private audienceQuestions(): SlideModel | null {
+    const items: string[] = [];
+    const notes: TraceRef[] = [];
+    for (const q of this.narration.audience_questions) {
+      items.push(q.question);
+      notes.push(this.note(q.trace, q.question));
+    }
+    return this.finish('audience_questions', 'Questions to Ask Yourself', [{ type: 'bullets', items }], notes);
+  }
+
+  private changeMinds(): SlideModel | null {
+    const blocks: SlideBlock[] = [];
+    const notes: TraceRef[] = [];
+    const falsifiers = this.spec.resolution_analysis.would_change_if ?? [];
+    if (falsifiers.length > 0) {
+      blocks.push({ type: 'bullets', items: falsifiers.map(f => `${f.camp.toUpperCase()}: ${f.falsifier}`) });
+      falsifiers.forEach((f, i) =>
+        notes.push(this.note(buildTrace(['resolution_analysis', 'would_change_if', i]), f.falsifier)));
+    }
+    if (this.spec.concessions.length > 0) {
+      blocks.push({
+        type: 'table',
+        headers: ['Camp', 'Asserted', 'Conceded', 'Challenged'],
+        rows: this.spec.concessions.map(c => [c.camp.toUpperCase(), String(c.asserted), String(c.conceded), String(c.challenged)]),
+      });
+      const zero = this.spec.concessions.filter(c => c.conceded === 0).map(c => c.camp.toUpperCase());
+      if (zero.length > 0) blocks.push({ type: 'note', text: `Conceded nothing: ${zero.join(', ')}` });
+    }
+    return this.finish('change_minds', 'What Would Change Their Minds', blocks, notes);
+  }
+
+  private evidenceShelf(): SlideModel | null {
+    const counts: Partial<Record<FactCheckVerdict, number>> = {};
+    for (const fc of this.spec.fact_checks) counts[fc.verdict] = (counts[fc.verdict] ?? 0) + 1;
+    const blocks: SlideBlock[] = [{
+      type: 'badge_row',
+      badges: (['Supported', 'Disputed', 'Unverifiable'] as FactCheckVerdict[])
+        .filter(v => counts[v]).map(v => ({ label: v, value: String(counts[v]) })),
+    }];
+    const notes: TraceRef[] = [];
+    // Disputed verdicts are ALWAYS surfaced, never dropped (spec §2.1 hygiene).
+    const disputed = this.spec.fact_checks
+      .map((fc, i) => ({ fc, i }))
+      .filter(({ fc }) => fc.verdict === 'Disputed');
+    if (disputed.length > 0) {
+      blocks.push({
+        type: 'bullets',
+        items: disputed.map(({ fc }) => `${fc.claim}${fc.explanation ? ` — ${fc.explanation}` : ''}`),
+      });
+      disputed.forEach(({ fc, i }) => notes.push(this.note(buildTrace(['fact_checks', i]), fc.claim)));
+    }
+    return this.finish('evidence_shelf', 'The Evidence Shelf', blocks, notes);
+  }
+
+  private provenance(): SlideModel | null {
+    const m = this.spec.meta;
+    const fc = this.spec.framing_critique;
+    const blocks: SlideBlock[] = [
+      { type: 'bullets', items: [
+        `Debate phase: ${m.phase}`,
+        `Framing critique: ${fc.rating} (composite ${fc.composite})`,
+        `Pipeline: Extract → Narrate (${this.narration.narrator_model}) → Render → Verify`,
+      ] },
+    ];
+    if (this.spec.open_threads.length > 0) {
+      blocks.push({ type: 'note', text: `Open threads: ${this.spec.open_threads.map(t => t.text).join('; ')}` });
+    }
+    // Live-URL disclosure (spec §10): the debate links out; warn when not in community.
+    blocks.push({ type: 'note', text: 'Source debate is linked; sign-in may be required if it is not a community debate.' });
+    if (this.snapshot) {
+      blocks.push({ type: 'note', text: `Snapshot of an in-progress debate${m.snapshot_note ? ` — ${m.snapshot_note}` : ''}.` });
+    }
+    return this.finish('provenance', 'Provenance', blocks, []);
+  }
+
+  private framingMeta(): SlideModel | null {
+    const fc = this.spec.framing_critique;
+    const blocks: SlideBlock[] = [
+      { type: 'text', text: `Motion rated: ${fc.rating} (composite ${fc.composite})` },
+    ];
+    if (fc.rewritten_motion) {
+      blocks.push({ type: 'note', text: `Reframed motion: ${fc.rewritten_motion}` });
+    }
+    return this.finish('framing_meta', 'Framing Critique', blocks,
+      [this.note(buildTrace(['framing_critique']), fc.rewritten_motion ?? fc.rating)]);
+  }
+
+  private glossary(): SlideModel | null {
+    // deck_spec carries no glossary payload; this is a static divider pointing at
+    // the Taxonomy Vocabulary System (spec §3). Not fabricated content.
+    const blocks: SlideBlock[] = [
+      { type: 'note', text: 'Key terms are defined in the Taxonomy Vocabulary System.' },
+    ];
+    return this.finish('glossary', 'Glossary', blocks, []);
+  }
+
+  private openThreadsAppendix(): SlideModel | null {
+    const items: string[] = [];
+    const notes: TraceRef[] = [];
+    this.spec.open_threads.forEach((t, i) => {
+      const trace = buildTrace(['open_threads', i]);
+      items.push(t.text);
+      notes.push(this.note(trace, t.text));
+    });
+    return this.finish('open_threads_appendix', 'Appendix: Open Threads', [{ type: 'bullets', items }], notes);
+  }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function distinctCamps(camps: string[]): string[] {
+  return [...new Set(camps)].sort();
+}
+
+function blockHasContent(b: SlideBlock): boolean {
+  switch (b.type) {
+    case 'text': return b.text.trim() !== '';
+    case 'note': return b.text.trim() !== '';
+    case 'bullets': return b.items.length > 0;
+    case 'card_row': return b.cards.some(c => c.lines.length > 0);
+    case 'fork': return b.prompt.trim() !== '';
+    case 'badge_row': return b.badges.length > 0;
+    case 'table': return b.rows.length > 0;
+  }
+}

--- a/lib/brief/render/cli.ts
+++ b/lib/brief/render/cli.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — node CLI entrypoint for the offline pipeline (consumed by T8 PS
+// local mode). Runs the deterministic render with no server and no model call.
+// PDF is NOT produced here (Electron-only); the CLI reports that actionably
+// rather than silently omitting the format (TL t/2802#2).
+//
+//   node render/cli.js --spec deck_spec.json --narration narration.json \
+//     --preset conference --out ./brief.pptx [--pdf]
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { ActionableError } from '../../debate/errors.js';
+import type { DeckSpec, Narration, BriefPreset } from '../types.js';
+import { render } from './index.js';
+
+const LOCATION = 'lib/brief/render/cli.ts';
+const PRESETS: readonly BriefPreset[] = ['policymaker', 'conference', 'classroom'];
+
+interface CliArgs {
+  spec: string;
+  narration: string;
+  preset: BriefPreset;
+  out: string;
+  pdf: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const map = new Map<string, string>();
+  let pdf = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--pdf') { pdf = true; continue; }
+    if (a.startsWith('--')) { map.set(a.slice(2), argv[++i]); }
+  }
+  const spec = map.get('spec');
+  const narration = map.get('narration');
+  const preset = (map.get('preset') ?? 'conference') as BriefPreset;
+  const out = map.get('out') ?? './brief.pptx';
+  if (!spec || !narration) {
+    throw new ActionableError({
+      goal: 'Render a debate brief offline',
+      problem: '--spec and --narration are required',
+      location: LOCATION,
+      nextSteps: ['Pass --spec <deck_spec.json> --narration <narration.json> --preset <p> --out <file.pptx>'],
+    });
+  }
+  if (!PRESETS.includes(preset)) {
+    throw new ActionableError({
+      goal: 'Render a debate brief offline',
+      problem: `Unknown preset "${preset}"`,
+      location: LOCATION,
+      nextSteps: [`Use one of: ${PRESETS.join(', ')}`],
+    });
+  }
+  return { spec, narration, preset, out, pdf };
+}
+
+export async function runCli(argv: string[], log: (m: string) => void = console.log): Promise<void> {
+  const args = parseArgs(argv);
+  const spec = JSON.parse(await readFile(args.spec, 'utf8')) as DeckSpec;
+  const narration = JSON.parse(await readFile(args.narration, 'utf8')) as Narration;
+
+  const result = await render({ spec, narration, preset: args.preset });
+  await writeFile(args.out, result.pptxBytes);
+  log(`Wrote ${args.out} (${result.slideModels.length} slides, preset=${args.preset})`);
+  for (const w of result.warnings) log(`  warning: ${w}`);
+
+  if (args.pdf) {
+    log('PDF requires the desktop app: the offline CLI renders .pptx only. ' +
+        'Open the brief in the AITriad desktop app to export a PDF (printToPDF is Electron-only).');
+  }
+}
+
+// Executed directly (not imported): run the CLI over process.argv.
+const invokedDirectly = process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}`;
+if (invokedDirectly) {
+  runCli(process.argv.slice(2)).catch((e: unknown) => {
+    console.error(e instanceof ActionableError ? e.message : String(e));
+    process.exitCode = 1;
+  });
+}

--- a/lib/brief/render/deckTheme.ts
+++ b/lib/brief/render/deckTheme.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — deck theme (colors / fonts / logo), kept SEPARATE from the
+// JSON→slide logic (TL build condition 2). Camp colors are fixed constants
+// shared across every brief (spec §2.3).
+
+/** Camp id → hex color. Fixed constants; the four taxonomy camps + neutral. */
+export const CAMP_COLORS: Record<string, string> = {
+  acc: '2E7D32', // Accelerationist — green
+  saf: '1565C0', // Safetyist — blue
+  skp: '6A1B9A', // Skeptic — purple
+  cc:  '424242', // Common Concerns / cross-camp — neutral grey
+};
+
+/** Fallback color for a camp id not in the fixed map. */
+export const CAMP_COLOR_FALLBACK = '37474F';
+
+export function campColor(camp: string): string {
+  return CAMP_COLORS[camp] ?? CAMP_COLOR_FALLBACK;
+}
+
+export interface DeckTheme {
+  name: string;
+  colors: {
+    background: string;
+    text: string;
+    subtle: string;
+    accent: string;
+    /** Verdict badge colors keyed by FactCheckVerdict. */
+    verdict: { Supported: string; Disputed: string; Unverifiable: string };
+  };
+  fonts: { heading: string; body: string };
+  /** Optional data-URI logo (embedded, never a network reference). */
+  logoDataUri?: string;
+}
+
+/** The built-in AITriad house style — used whenever no template is honored. */
+export const HOUSE_THEME: DeckTheme = {
+  name: 'AITriad House',
+  colors: {
+    background: 'FFFFFF',
+    text: '1A1A1A',
+    subtle: '5F6B7A',
+    accent: '1565C0',
+    verdict: { Supported: '2E7D32', Disputed: 'C62828', Unverifiable: 'F9A825' },
+  },
+  fonts: { heading: 'Georgia', body: 'Calibri' },
+};
+
+/**
+ * Resolve the theme for a render. v1 applies the AITriad house style; a supplied
+ * `.potx` template is acknowledged but its colors/fonts/masters are NOT yet
+ * honored (full template theming + slide-master honoring is the t/2820 v2 item).
+ * Returns a disclosure warning so the partial application is never silent
+ * (silent-degradation rule; TL e/113#2 condition 2a).
+ */
+export function resolveTheme(hasTemplate: boolean): { theme: DeckTheme; warning?: string } {
+  if (hasTemplate) {
+    return {
+      theme: HOUSE_THEME,
+      warning:
+        'template_not_honored: a .potx template was supplied but v1 renders in the ' +
+        'AITriad house style — template colors/fonts and slide masters are not applied ' +
+        '(tracked as t/2820).',
+    };
+  }
+  return { theme: HOUSE_THEME };
+}

--- a/lib/brief/render/htmlRenderer.ts
+++ b/lib/brief/render/htmlRenderer.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — SlideModel[] → a fully self-contained HTML document for Electron
+// webContents.printToPDF (PDF is Electron-only; lib only GENERATES the HTML).
+// TL condition (e/113#2): the HTML MUST be self-contained — inline CSS, embedded
+// logo as a data URI, NO external network references — so printToPDF is
+// deterministic and works offline. All dynamic text is HTML-escaped.
+
+import type { SlideModel, SlideBlock } from './slideModel.js';
+import type { DeckTheme } from './deckTheme.js';
+import { campColor } from './deckTheme.js';
+
+export function renderHtml(slides: SlideModel[], theme: DeckTheme): string {
+  const style = buildStyle(theme);
+  const body = slides.map(s => renderSlide(s, theme)).join('\n');
+  const logo = theme.logoDataUri
+    ? `<img class="logo" alt="" src="${escapeAttr(theme.logoDataUri)}"/>`
+    : '';
+  return [
+    '<!DOCTYPE html>',
+    '<html lang="en"><head><meta charset="utf-8"/>',
+    '<meta name="viewport" content="width=device-width, initial-scale=1"/>',
+    `<title>Debate Brief</title>`,
+    `<style>${style}</style>`,
+    '</head><body>',
+    logo,
+    body,
+    '</body></html>',
+  ].join('\n');
+}
+
+function buildStyle(theme: DeckTheme): string {
+  // No @import, no url() to remote hosts, no <link> — everything inline.
+  return [
+    `*{box-sizing:border-box;margin:0;padding:0}`,
+    `body{font-family:${cssFont(theme.fonts.body)};color:#${theme.colors.text};background:#${theme.colors.background}}`,
+    `.slide{page-break-after:always;padding:48px 56px;min-height:100vh;position:relative}`,
+    `.slide h2{font-family:${cssFont(theme.fonts.heading)};font-size:32px;margin-bottom:20px;color:#${theme.colors.text}}`,
+    `.text{font-size:20px;margin:10px 0}`,
+    `.note{font-size:14px;font-style:italic;color:#${theme.colors.subtle};margin:8px 0}`,
+    `ul{margin:10px 0 10px 26px}li{font-size:18px;margin:6px 0}`,
+    `.cards{display:flex;gap:16px;margin-top:12px}`,
+    `.card{flex:1;border:2px solid #ccc;border-radius:8px;padding:12px}`,
+    `.card h3{font-size:18px;margin-bottom:8px}`,
+    `.badges{font-size:16px;color:#${theme.colors.accent};margin:10px 0}`,
+    `.fork{margin:12px 0}.fork .prompt{font-weight:bold;font-size:18px}`,
+    `table{border-collapse:collapse;margin:12px 0;width:100%}`,
+    `th,td{border:1px solid #${theme.colors.subtle};padding:6px 10px;font-size:14px;text-align:left}`,
+    `th{background:#${theme.colors.accent};color:#fff}`,
+    `.watermark{position:absolute;top:40%;left:0;right:0;text-align:center;font-size:72px;font-weight:bold;color:#${theme.colors.verdict.Disputed};opacity:0.15;transform:rotate(-20deg)}`,
+    `.logo{position:fixed;top:12px;right:12px;height:36px}`,
+  ].join('');
+}
+
+function renderSlide(model: SlideModel, theme: DeckTheme): string {
+  const blocks = model.blocks.map(b => renderBlock(b, theme)).join('\n');
+  const watermark = model.watermark ? `<div class="watermark">${escapeHtml(model.watermark)}</div>` : '';
+  return `<section class="slide">${watermark}<h2>${escapeHtml(model.title)}</h2>${blocks}</section>`;
+}
+
+function renderBlock(block: SlideBlock, theme: DeckTheme): string {
+  switch (block.type) {
+    case 'text':
+      return `<p class="text">${escapeHtml(block.text)}</p>`;
+    case 'note':
+      return `<p class="note">${escapeHtml(block.text)}</p>`;
+    case 'bullets':
+      return `<ul>${block.items.map(i => `<li>${escapeHtml(i)}</li>`).join('')}</ul>`;
+    case 'card_row':
+      return `<div class="cards">${block.cards.map(c =>
+        `<div class="card" style="border-color:#${campColor(c.camp)}">` +
+        `<h3 style="color:#${campColor(c.camp)}">${escapeHtml(c.title)}</h3>` +
+        `<ul>${c.lines.map(l => `<li>${escapeHtml(l)}</li>`).join('')}</ul></div>`).join('')}</div>`;
+    case 'fork':
+      return `<div class="fork"><div class="prompt">${escapeHtml(block.prompt)}</div>` +
+        `<ul><li>If yes → ${escapeHtml(block.ifYes)}</li><li>If no → ${escapeHtml(block.ifNo)}</li></ul></div>`;
+    case 'badge_row':
+      return `<div class="badges">${block.badges.map(b => `${escapeHtml(b.label)}: ${escapeHtml(b.value)}`).join(' &nbsp; ')}</div>`;
+    case 'table':
+      return `<table><thead><tr>${block.headers.map(h => `<th>${escapeHtml(h)}</th>`).join('')}</tr></thead>` +
+        `<tbody>${block.rows.map(r => `<tr>${r.map(c => `<td>${escapeHtml(c)}</td>`).join('')}</tr>`).join('')}</tbody></table>`;
+  }
+  void theme;
+}
+
+/** Quote a font-family name for CSS, with a generic fallback (no remote fonts). */
+function cssFont(name: string): string {
+  const generic = /serif|georgia|times/i.test(name) ? 'serif' : 'sans-serif';
+  return `'${name.replace(/'/g, '')}', ${generic}`;
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/"/g, '&quot;');
+}

--- a/lib/brief/render/index.ts
+++ b/lib/brief/render/index.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — public entry (t/2802). deck_spec + narration + preset → artifacts.
+// Deterministic, no model, node-pure. Produces the .pptx bytes (always) and a
+// self-contained HTML doc for Electron printToPDF; the actual PDF conversion is
+// Electron-only and lives in the surface layer (T7), never here.
+
+import type { DeckSpec, Narration, BriefPreset } from '../types.js';
+import type { SlideModel } from './slideModel.js';
+import { assemble } from './assemble.js';
+import { resolveTheme } from './deckTheme.js';
+import { renderPptx } from './pptxRenderer.js';
+import { renderHtml } from './htmlRenderer.js';
+
+export interface RenderInput {
+  spec: DeckSpec;
+  narration: Narration;
+  preset: BriefPreset;
+  /** Optional .potx bytes. v1 records a disclosure warning; theming is not yet applied. */
+  template?: Uint8Array;
+}
+
+export interface RenderResult {
+  /** ALWAYS — the primary deliverable, the real OOXML bytes handed to T5 verify(). */
+  pptxBytes: Uint8Array;
+  /** Self-contained HTML for Electron printToPDF (PDF is Electron-only). */
+  htmlDoc: string;
+  /** The assembled slide IR — exposed for tests/debugging. */
+  slideModels: SlideModel[];
+  /** Non-fatal render warnings (trimmed content, template-not-honored, empty slides). */
+  warnings: string[];
+}
+
+export async function render(input: RenderInput): Promise<RenderResult> {
+  const { theme, warning } = resolveTheme(input.template !== undefined);
+  const { slides, warnings } = assemble(input.spec, input.narration, input.preset);
+  const allWarnings = warning ? [warning, ...warnings] : warnings;
+
+  const pptxBytes = await renderPptx(slides, theme);
+  const htmlDoc = renderHtml(slides, theme);
+
+  return { pptxBytes, htmlDoc, slideModels: slides, warnings: allWarnings };
+}
+
+export type { SlideModel } from './slideModel.js';
+export { HOUSE_THEME, CAMP_COLORS } from './deckTheme.js';

--- a/lib/brief/render/pptxRenderer.ts
+++ b/lib/brief/render/pptxRenderer.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — the ONE bounded surface over pptxgenjs (TL build condition 1).
+// Nothing else in lib/brief imports pptxgenjs; a future library swap rewrites
+// only this file. Input is the target-neutral SlideModel[]; output is the real
+// serialized .pptx bytes handed to T5 verify().
+
+import PptxGenJS from 'pptxgenjs';
+import type { SlideModel, SlideBlock } from './slideModel.js';
+import type { DeckTheme } from './deckTheme.js';
+import { campColor } from './deckTheme.js';
+
+const MARGIN = 0.5;
+const CONTENT_W = 9.0; // 10in slide width minus margins
+const TITLE_Y = 0.4;
+const BODY_Y = 1.4;
+
+export async function renderPptx(slides: SlideModel[], theme: DeckTheme): Promise<Uint8Array> {
+  const pptx = new PptxGenJS();
+  pptx.defineLayout({ name: 'BRIEF', width: 10, height: 7.5 });
+  pptx.layout = 'BRIEF';
+  pptx.theme = { headFontFace: theme.fonts.heading, bodyFontFace: theme.fonts.body };
+
+  for (const model of slides) {
+    const slide = pptx.addSlide();
+    slide.background = { color: theme.colors.background };
+
+    slide.addText(model.title, {
+      x: MARGIN, y: TITLE_Y, w: CONTENT_W, h: 0.8,
+      fontSize: 28, bold: true, color: theme.colors.text, fontFace: theme.fonts.heading,
+    });
+
+    layoutBlocks(slide, model.blocks, theme);
+
+    if (model.watermark) {
+      slide.addText(model.watermark, {
+        x: MARGIN, y: 3.2, w: CONTENT_W, h: 1.0,
+        fontSize: 54, bold: true, color: theme.colors.verdict.Disputed,
+        align: 'center', rotate: 315, transparency: 80,
+      });
+    }
+
+    if (model.speakerNotes.length > 0) {
+      const notes = model.speakerNotes.map(n => `[${n.trace}] ${n.text}`).join('\n');
+      slide.addNotes(notes);
+    }
+  }
+
+  // pptxgenjs emits valid OOXML (positive offsets, canonical p:presentation order),
+  // so the render output passes T5's OOXML lint by construction.
+  const out = await pptx.write({ outputType: 'uint8array' });
+  return out as Uint8Array;
+}
+
+function layoutBlocks(slide: PptxGenJS.Slide, blocks: SlideBlock[], theme: DeckTheme): void {
+  let y = BODY_Y;
+  for (const block of blocks) {
+    y = layoutBlock(slide, block, theme, y);
+    y += 0.2;
+  }
+}
+
+function layoutBlock(slide: PptxGenJS.Slide, block: SlideBlock, theme: DeckTheme, y: number): number {
+  switch (block.type) {
+    case 'text':
+      slide.addText(block.text, {
+        x: MARGIN, y, w: CONTENT_W, h: 0.8, fontSize: 18, color: theme.colors.text, fontFace: theme.fonts.body,
+      });
+      return y + 0.8;
+
+    case 'note':
+      slide.addText(block.text, {
+        x: MARGIN, y, w: CONTENT_W, h: 0.5, fontSize: 12, italic: true, color: theme.colors.subtle, fontFace: theme.fonts.body,
+      });
+      return y + 0.5;
+
+    case 'bullets':
+      slide.addText(block.items.map(t => ({ text: t, options: { bullet: true } })), {
+        x: MARGIN, y, w: CONTENT_W, h: Math.min(4, 0.4 * block.items.length + 0.3),
+        fontSize: 16, color: theme.colors.text, fontFace: theme.fonts.body,
+      });
+      return y + Math.min(4, 0.4 * block.items.length + 0.3);
+
+    case 'card_row': {
+      const n = Math.max(1, block.cards.length);
+      const gap = 0.3;
+      const cardW = (CONTENT_W - gap * (n - 1)) / n;
+      block.cards.forEach((card, i) => {
+        const cx = MARGIN + i * (cardW + gap);
+        slide.addText(
+          [
+            { text: card.title, options: { bold: true, fontSize: 16, color: campColor(card.camp) } },
+            ...card.lines.map(l => ({ text: l, options: { bullet: true, fontSize: 13, color: theme.colors.text } })),
+          ],
+          { x: cx, y, w: cardW, h: 3.0, valign: 'top', fontFace: theme.fonts.body,
+            line: { color: campColor(card.camp), width: 1 }, margin: 6 },
+        );
+      });
+      return y + 3.0;
+    }
+
+    case 'fork':
+      slide.addText(
+        [
+          { text: block.prompt, options: { bold: true, fontSize: 16, color: theme.colors.text } },
+          { text: `If yes → ${block.ifYes}`, options: { bullet: true, fontSize: 13, color: theme.colors.text } },
+          { text: `If no → ${block.ifNo}`, options: { bullet: true, fontSize: 13, color: theme.colors.text } },
+        ],
+        { x: MARGIN, y, w: CONTENT_W, h: 1.4, valign: 'top', fontFace: theme.fonts.body },
+      );
+      return y + 1.5;
+
+    case 'badge_row': {
+      const text = block.badges.map(b => `${b.label}: ${b.value}`).join('    ');
+      slide.addText(text, { x: MARGIN, y, w: CONTENT_W, h: 0.6, fontSize: 15, color: theme.colors.accent, fontFace: theme.fonts.body });
+      return y + 0.6;
+    }
+
+    case 'table': {
+      const header = block.headers.map(h => ({ text: h, options: { bold: true, color: 'FFFFFF', fill: { color: theme.colors.accent } } }));
+      const rows = block.rows.map(r => r.map(cell => ({ text: cell, options: { color: theme.colors.text } })));
+      slide.addTable([header, ...rows], {
+        x: MARGIN, y, w: CONTENT_W, fontSize: 13, border: { type: 'solid', color: theme.colors.subtle, pt: 1 }, fontFace: theme.fonts.body,
+      });
+      return y + 0.4 * (rows.length + 1) + 0.2;
+    }
+  }
+}

--- a/lib/brief/render/presets.ts
+++ b/lib/brief/render/presets.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — presets as selection/compression MASKS over the same deck_spec
+// (spec §3). Presets never change extraction; they pick which slides appear and
+// a per-slide readability word cap. The cap is a FAIR, uniform readability
+// budget — NOT a truncate-to-beat-T5 device (TL e/113#2 gate-integrity MUST):
+// genuine content asymmetry must surface to the T5 symmetry gate, not be trimmed.
+
+import type { BriefPreset } from '../types.js';
+import type { SlideKind } from './slideModel.js';
+
+export interface PresetProfile {
+  /** Ordered slide kinds included for this preset. */
+  slides: SlideKind[];
+  /**
+   * Uniform per-card / per-entry readability cap (words). Applied identically to
+   * every camp — a slide simply cannot hold unbounded copy. Over-cap copy is
+   * trimmed at SENTENCE boundaries and a warning is emitted when traced content
+   * is dropped (assemble.ts). Same cap for all camps ⇒ no gate-gaming.
+   */
+  perEntryWordCap: number;
+  /** Classroom: derive extra discussion-prompt audience questions from cruxes. */
+  discussionPrompts: boolean;
+}
+
+const CONFERENCE_SLIDES: SlideKind[] = [
+  'title', 'question', 'how_to_read', 'agreements', 'positions',
+  'empirical_cruxes', 'values_cruxes', 'audience_questions',
+  'change_minds', 'evidence_shelf', 'provenance',
+];
+
+// Policymaker (~6): terse executive cut — the question, the cruxes + their asks,
+// what to ask yourself, and provenance. Drops legend/agreements/positions-map/
+// change-minds/evidence per the approved design (e/113).
+const POLICYMAKER_SLIDES: SlideKind[] = [
+  'title', 'question', 'empirical_cruxes', 'values_cruxes', 'audience_questions', 'provenance',
+];
+
+// Classroom (~16): full grammar + framing-meta, glossary, open-threads appendix,
+// and discussion prompts per crux.
+const CLASSROOM_SLIDES: SlideKind[] = [
+  ...CONFERENCE_SLIDES,
+  'framing_meta', 'glossary', 'open_threads_appendix',
+];
+
+export const PRESET_PROFILES: Record<BriefPreset, PresetProfile> = {
+  policymaker: { slides: POLICYMAKER_SLIDES, perEntryWordCap: 40, discussionPrompts: false },
+  conference:  { slides: CONFERENCE_SLIDES,  perEntryWordCap: 90, discussionPrompts: false },
+  classroom:   { slides: CLASSROOM_SLIDES,   perEntryWordCap: 110, discussionPrompts: true },
+};
+
+export function profileFor(preset: BriefPreset): PresetProfile {
+  return PRESET_PROFILES[preset];
+}

--- a/lib/brief/render/render.test.ts
+++ b/lib/brief/render/render.test.ts
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for T4 Render (t/2802): assemble + pptx + HTML targets, presets, parity,
+// gate-integrity (no truncate-to-parity), self-contained HTML, CLI arg parsing.
+
+import { describe, it, expect } from 'vitest';
+import { render } from './index.js';
+import { assemble } from './assemble.js';
+import { renderHtml } from './htmlRenderer.js';
+import { resolveTheme } from './deckTheme.js';
+import { parseArgs } from './cli.js';
+import type { DeckSpec, Narration } from '../types.js';
+
+function makeSpec(overrides: Partial<DeckSpec> = {}): DeckSpec {
+  return {
+    deck_spec_version: '1.0',
+    meta: { id: 'sess-1', run_id: 'run-1', title: 'AI Safety Debate', model: 'gemini-pro', protocol: 'structured', phase: 'closed' },
+    question: { core_proposition: 'Should AI development be paused?', tensions: ['Safety vs. speed'], time_horizon: '2030' },
+    framing_critique: { rating: 'good', composite: 0.8, rewritten_motion: 'Should frontier AI training be paused?' },
+    agreements: [{ text: 'Both agree risks are real' }],
+    disagreements: [{ text: 'Dispute on imminence', kind: 'EMPIRICAL', resolution_path: 'research' }],
+    cruxes: [
+      { text: 'Will scaling produce AGI?', kind: 'EMPIRICAL', if_yes: 'pause needed', if_no: 'no pause' },
+      { text: 'Is autonomy intrinsically valuable?', kind: 'VALUES', if_yes: 'permit', if_no: 'restrict' },
+    ],
+    resolution_analysis: {
+      stronger_camp_findings: [{ camp: 'saf', finding: 'Evidence favors caution' }],
+      would_change_if: [{ camp: 'acc', falsifier: 'A capability plateau is demonstrated' }],
+    },
+    unresolved_questions: [{ text: 'Timeline uncertainty' }],
+    argument_map: { nodes: [], relations: [] },
+    fact_checks: [
+      { claim: 'AI development is accelerating', verdict: 'Supported', speaker: 'acc' },
+      { claim: 'Scaling laws hold indefinitely', verdict: 'Disputed', speaker: 'acc', explanation: 'contested by recent results' },
+    ],
+    concessions: [
+      { camp: 'saf', asserted: 2, conceded: 1, challenged: 0 },
+      { camp: 'acc', asserted: 2, conceded: 0, challenged: 1 },
+    ],
+    top_claims: [
+      { camp: 'saf', claim: 'Pause reduces catastrophic risk substantially', strength: 0.9 },
+      { camp: 'acc', claim: 'Pause forfeits enormous economic upside', strength: 0.8 },
+    ],
+    convergence: [{ issue: 'safety', score: 0.6 }],
+    open_threads: [{ text: 'Regulatory pathways' }],
+    ...overrides,
+  };
+}
+
+function makeNarration(overrides: Partial<Narration> = {}): Narration {
+  return {
+    deck_spec_version: '1.0',
+    narration_mode: 'narrated',
+    preset: 'conference',
+    narrator_model: 'gemini-2.0-flash',
+    narrator_model_source: 'Explicit',
+    checker_model: null, checker_model_source: null, checker_passed: null,
+    entries: [
+      { trace: '/question/core_proposition', text: 'Should we pause frontier AI?', slide: 2 },
+      { trace: '/top_claims/0', text: 'Pausing sharply lowers tail risk', slide: 5 },
+      { trace: '/top_claims/1', text: 'Pausing forfeits large economic gains', slide: 5 },
+    ],
+    audience_questions: [
+      { trace: '/cruxes/0', question: 'Do you think scaling yields AGI?' },
+      { trace: '/question/tensions/0', question: 'How do you weigh safety vs speed?' },
+    ],
+    ...overrides,
+  };
+}
+
+describe('render — outputs', () => {
+  it('produces pptx bytes (a real zip), HTML, and slide models', async () => {
+    const r = await render({ spec: makeSpec(), narration: makeNarration(), preset: 'conference' });
+    expect(r.pptxBytes.byteLength).toBeGreaterThan(1000);
+    // ZIP local-file magic "PK\x03\x04"
+    expect(r.pptxBytes[0]).toBe(0x50);
+    expect(r.pptxBytes[1]).toBe(0x4b);
+    expect(typeof r.htmlDoc).toBe('string');
+    expect(r.slideModels.length).toBeGreaterThan(0);
+  });
+});
+
+describe('render — presets as masks', () => {
+  it('conference renders the full 11-slide grammar', async () => {
+    const { slides } = assemble(makeSpec(), makeNarration(), 'conference');
+    expect(slides.length).toBe(11);
+    expect(slides.map(s => s.kind)).toContain('positions');
+    expect(slides.map(s => s.kind)).toContain('evidence_shelf');
+  });
+
+  it('policymaker is a compressed subset (~6, no legend/positions)', async () => {
+    const { slides } = assemble(makeSpec(), makeNarration(), 'policymaker');
+    expect(slides.length).toBeLessThanOrEqual(6);
+    expect(slides.map(s => s.kind)).not.toContain('how_to_read');
+  });
+
+  it('classroom adds framing_meta, glossary, and the open-threads appendix', async () => {
+    const kinds = assemble(makeSpec(), makeNarration(), 'classroom').slides.map(s => s.kind);
+    expect(kinds).toContain('framing_meta');
+    expect(kinds).toContain('glossary');
+    expect(kinds).toContain('open_threads_appendix');
+  });
+});
+
+describe('render — per-camp parity', () => {
+  it('the Positions slide has one card per camp', () => {
+    const { slides } = assemble(makeSpec(), makeNarration(), 'conference');
+    const positions = slides.find(s => s.kind === 'positions')!;
+    const cardRow = positions.blocks.find(b => b.type === 'card_row');
+    expect(cardRow?.type).toBe('card_row');
+    if (cardRow?.type === 'card_row') {
+      expect(cardRow.cards.map(c => c.camp).sort()).toEqual(['acc', 'saf']);
+    }
+  });
+});
+
+describe('render — gate integrity (no truncate-to-parity)', () => {
+  it('does NOT equalize genuinely asymmetric camp content', () => {
+    // saf has a very long claim; acc a short one. Assemble must preserve the
+    // asymmetry (so T5 can still fail on real imbalance), not trim saf to match.
+    const spec = makeSpec({
+      top_claims: [
+        { camp: 'saf', claim: 'Pause reduces catastrophic risk because alignment research lags capability by a wide and growing margin across every measured axis', strength: 0.9 },
+        { camp: 'acc', claim: 'Pause is costly', strength: 0.8 },
+      ],
+    });
+    // No narrated override for these traces → verbatim spec text flows through.
+    const narration = makeNarration({ entries: [] });
+    const { slides } = assemble(spec, narration, 'conference');
+    const positions = slides.find(s => s.kind === 'positions')!;
+    const cardRow = positions.blocks.find(b => b.type === 'card_row');
+    if (cardRow?.type === 'card_row') {
+      const saf = cardRow.cards.find(c => c.camp === 'saf')!.lines.join(' ');
+      const acc = cardRow.cards.find(c => c.camp === 'acc')!.lines.join(' ');
+      expect(saf.split(/\s+/).length).toBeGreaterThan(acc.split(/\s+/).length * 2);
+    }
+  });
+});
+
+describe('render — speaker notes reuse the narration trace', () => {
+  it('carries the entry’s own resolvable pointer, not a fabricated one', () => {
+    const { slides } = assemble(makeSpec(), makeNarration(), 'conference');
+    const positions = slides.find(s => s.kind === 'positions')!;
+    const traces = positions.speakerNotes.map(n => n.trace);
+    expect(traces).toContain('/top_claims/0');
+    expect(traces).toContain('/top_claims/1');
+  });
+});
+
+describe('render — self-contained HTML', () => {
+  it('has inline styles and no external network references', () => {
+    const { slides } = assemble(makeSpec(), makeNarration(), 'conference');
+    const { theme } = resolveTheme(false);
+    const html = renderHtml(slides, theme);
+    expect(html).toContain('<style>');
+    expect(html).not.toMatch(/https?:\/\//);
+    expect(html).not.toContain('<link');
+    expect(html).not.toMatch(/@import/);
+  });
+
+  it('escapes HTML in dynamic content (XSS-safe, deterministic)', () => {
+    const spec = makeSpec({ question: { core_proposition: 'Pause <script>alert(1)</script>?' } });
+    const { slides } = assemble(spec, makeNarration({ entries: [] }), 'conference');
+    const { theme } = resolveTheme(false);
+    const html = renderHtml(slides, theme);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('render — snapshot watermark + template disclosure', () => {
+  it('marks slides with the IN PROGRESS watermark when meta.snapshot is set', () => {
+    const spec = makeSpec({ meta: { id: 'x', run_id: 'r', title: 't', model: 'm', protocol: 'p', phase: 'open', snapshot: true } });
+    const { slides } = assemble(spec, makeNarration(), 'conference');
+    expect(slides.every(s => s.watermark === 'IN PROGRESS')).toBe(true);
+  });
+
+  it('records a template-not-honored disclosure warning when a template is supplied', async () => {
+    const r = await render({ spec: makeSpec(), narration: makeNarration(), preset: 'conference', template: new Uint8Array([1, 2, 3]) });
+    expect(r.warnings.some(w => w.startsWith('template_not_honored'))).toBe(true);
+  });
+});
+
+describe('render — graceful empty (ADR-001)', () => {
+  it('omits the change_minds falsifier sub-block when would_change_if is empty but still renders concessions', () => {
+    const spec = makeSpec({ resolution_analysis: { stronger_camp_findings: [{ camp: 'saf', finding: 'x' }] } });
+    const { slides } = assemble(spec, makeNarration(), 'conference');
+    const cm = slides.find(s => s.kind === 'change_minds');
+    expect(cm).toBeDefined();
+    expect(cm!.blocks.some(b => b.type === 'table')).toBe(true);
+  });
+});
+
+describe('render — CLI arg parsing', () => {
+  it('parses spec/narration/preset/out and the --pdf flag', () => {
+    const args = parseArgs(['--spec', 'a.json', '--narration', 'b.json', '--preset', 'classroom', '--out', 'x.pptx', '--pdf']);
+    expect(args).toEqual({ spec: 'a.json', narration: 'b.json', preset: 'classroom', out: 'x.pptx', pdf: true });
+  });
+
+  it('defaults preset to conference and out to ./brief.pptx', () => {
+    const args = parseArgs(['--spec', 'a.json', '--narration', 'b.json']);
+    expect(args.preset).toBe('conference');
+    expect(args.out).toBe('./brief.pptx');
+    expect(args.pdf).toBe(false);
+  });
+
+  it('throws on unknown preset', () => {
+    expect(() => parseArgs(['--spec', 'a.json', '--narration', 'b.json', '--preset', 'bogus'])).toThrow();
+  });
+});

--- a/lib/brief/render/slideModel.ts
+++ b/lib/brief/render/slideModel.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — the target-neutral slide IR (t/2802).
+// assemble.ts builds SlideModel[] ONCE from deck_spec + narration; both the
+// pptx renderer and the HTML-for-PDF renderer consume the SAME SlideModel[] so
+// the two output targets cannot drift in content (only in medium).
+
+/** Every slide kind in the grammar (spec §2.3) plus the classroom-preset extras. */
+export type SlideKind =
+  | 'title'
+  | 'question'
+  | 'how_to_read'
+  | 'agreements'
+  | 'positions'
+  | 'empirical_cruxes'
+  | 'values_cruxes'
+  | 'audience_questions'
+  | 'change_minds'
+  | 'evidence_shelf'
+  | 'provenance'
+  | 'framing_meta'          // classroom
+  | 'glossary'             // classroom
+  | 'open_threads_appendix'; // classroom
+
+/** A line of slide copy paired with the RFC 6901 trace it came from (speaker notes). */
+export interface TraceRef {
+  text: string;
+  /** The narration entry's own resolvable pointer — never fabricated here. */
+  trace: string;
+}
+
+/** One camp's card on the Positions slide — carries `camp` for parity/attribution. */
+export interface CampCard {
+  camp: string;
+  title: string;
+  lines: string[];
+}
+
+export type SlideBlock =
+  | { type: 'text'; text: string }
+  | { type: 'bullets'; items: string[] }
+  | { type: 'card_row'; cards: CampCard[] }
+  | { type: 'fork'; prompt: string; ifYes: string; ifNo: string }
+  | { type: 'badge_row'; badges: { label: string; value: string }[] }
+  | { type: 'table'; headers: string[]; rows: string[][] }
+  | { type: 'note'; text: string };
+
+export interface SlideModel {
+  kind: SlideKind;
+  title: string;
+  blocks: SlideBlock[];
+  /** Verbatim spec text + trace refs; drives PowerPoint speaker notes (spec §2.3). */
+  speakerNotes: TraceRef[];
+  /** Set on single-camp slides; per-camp cards carry their own `camp` in card_row. */
+  camp?: string;
+  /** "IN PROGRESS" when meta.snapshot — the allowOpen watermark. */
+  watermark?: string;
+}

--- a/lib/package.json
+++ b/lib/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "ajv": "8.20.0",
     "decode-named-character-reference": "^1.3.0",
-    "micromark-util-decode-numeric-character-reference": "^2.0.2"
+    "micromark-util-decode-numeric-character-reference": "^2.0.2",
+    "pptxgenjs": "3.12.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       micromark-util-decode-numeric-character-reference:
         specifier: ^2.0.2
         version: 2.0.2
+      pptxgenjs:
+        specifier: 3.12.0
+        version: 3.12.0
     devDependencies:
       '@types/node':
         specifier: ^26.1.2
@@ -255,6 +258,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      pptxgenjs:
+        specifier: 3.12.0
+        version: 3.12.0
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -2203,6 +2209,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -3662,6 +3671,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  https@1.0.0:
+    resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3687,6 +3699,11 @@ packages:
   ignore@7.0.6:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
+
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -4784,6 +4801,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  pptxgenjs@3.12.0:
+    resolution: {integrity: sha512-ZozkYKWb1MoPR4ucw3/aFYlHkVIJxo9czikEclcUVnS4Iw/M+r+TEwdlB3fyAWO9JY1USxJDt0Y0/r15IR/RUA==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4866,6 +4886,9 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -5616,6 +5639,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -7971,6 +7997,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
@@ -9834,6 +9864,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https@1.0.0: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -9853,6 +9885,10 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
+
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
 
   immediate@3.0.6: {}
 
@@ -11104,6 +11140,13 @@ snapshots:
       commander: 9.5.0
     optional: true
 
+  pptxgenjs@3.12.0:
+    dependencies:
+      '@types/node': 18.19.130
+      https: 1.0.0
+      image-size: 1.2.1
+      jszip: 3.10.1
+
   prelude-ls@1.2.1: {}
 
   pretty-bytes@5.6.0: {}
@@ -11188,6 +11231,10 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 
@@ -12112,6 +12159,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@5.26.5: {}
 
   undici-types@7.18.2: {}
 

--- a/taxonomy-editor/package.json
+++ b/taxonomy-editor/package.json
@@ -68,6 +68,7 @@
     "node-pty": "^1.1.0",
     "onnxruntime-node": "^1.27.0",
     "pino": "^10.3.1",
+    "pptxgenjs": "3.12.0",
     "qrcode": "^1.5.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/taxonomy-editor/pnpm-lock.yaml
+++ b/taxonomy-editor/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      pptxgenjs:
+        specifier: 3.12.0
+        version: 3.12.0
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1738,6 +1741,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
@@ -3088,6 +3094,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  https@1.0.0:
+    resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3113,6 +3122,11 @@ packages:
   ignore@7.0.6:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
+
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -4145,6 +4159,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  pptxgenjs@3.12.0:
+    resolution: {integrity: sha512-ZozkYKWb1MoPR4ucw3/aFYlHkVIJxo9czikEclcUVnS4Iw/M+r+TEwdlB3fyAWO9JY1USxJDt0Y0/r15IR/RUA==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4227,6 +4244,9 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -4948,6 +4968,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -7083,6 +7106,8 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+    optionalDependencies:
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.2.1(@types/node@24.12.0)(jiti@2.6.1)(terser@5.48.0))
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -7159,6 +7184,10 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@24.12.0':
     dependencies:
@@ -8845,6 +8874,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https@1.0.0: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -8864,6 +8895,10 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
+
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
 
   immediate@3.0.6: {}
 
@@ -10065,6 +10100,13 @@ snapshots:
       commander: 9.5.0
     optional: true
 
+  pptxgenjs@3.12.0:
+    dependencies:
+      '@types/node': 18.19.130
+      https: 1.0.0
+      image-size: 1.2.1
+      jszip: 3.10.1
+
   prelude-ls@1.2.1: {}
 
   pretty-bytes@5.6.0: {}
@@ -10148,6 +10190,10 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 
@@ -11019,6 +11065,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@5.26.5: {}
 
   undici-types@7.16.0: {}
 


### PR DESCRIPTION
## T4 — Render stage (t/2802)

Deterministic, node-pure render for the Brief Export pipeline. Design approved e/113 (Main-TL). **Draft — gated on one DevOps-owned lockfile step (below).**

### Architecture (`lib/brief/render/`)
- `slideModel.ts` — target-neutral IR
- `assemble.ts` — deck_spec + narration + preset → `SlideModel[]` (built ONCE, shared by both targets → no drift)
- `deckTheme.ts` — colors/fonts/logo, separate from JSON→slide logic; camp colors fixed
- `presets.ts` — selection/compression masks (policymaker ~6 / conference 11 / classroom +extras)
- `pptxRenderer.ts` — **the one bounded pptxgenjs surface**; emits the real .pptx bytes handed to T5
- `htmlRenderer.ts` — self-contained HTML for Electron printToPDF (inline CSS/fonts, no network refs, HTML-escaped)
- `index.ts` — `render(input) → { pptxBytes, htmlDoc, slideModels, warnings }`
- `cli.ts` — offline node CLI for T8; PDF unavailable → actionable "requires the desktop app"

### Conditions honored (e/113#2)
- **Gate integrity:** fair uniform readability budget, NOT truncate-to-parity; real camp asymmetry surfaces to T5; sentence-boundary trims warn on dropped traced content.
- Self-contained HTML (no external refs). Speaker notes reuse the narration entry's own trace (no fabricated pointers). Graceful-empty (ADR-001). Snapshot watermark. Live-URL sign-in disclosure on Provenance.

### ⚠️ Deviation flagged for review
Condition 2 (.potx theme-only) is implemented as **house-style + a disclosure warning** rather than extracting template colors/fonts — extracting them needs an unzip dep in T4, which I avoided. Full template theming is tracked as **t/2820** (v2). Asked X (theme-only), did Y (house-style + disclosure), because Z (no unzip dep in T4; BKC template theming is the v2 concern already filed). Flagging per the deviation rule — happy to add extraction if you'd rather.

### 🚧 Draft gate — DevOps-owned standalone lockfile
pptxgenjs 3.12.0 (MIT, pinned) is a new direct dep. It is declared in `lib/package.json`, the root `pnpm-lock.yaml`, and `taxonomy-editor/package.json` (dependency-coverage). The Docker `prod-deps` stage uses the **standalone** `taxonomy-editor/pnpm-lock.yaml`, which still needs the pptxgenjs entry (+ its `https`/`image-size` subtree; jszip already present). Regenerating it with `pnpm install --ignore-workspace --lockfile-only` drifts **185 lines** of unrelated deps (sharp/uuid/js-yaml/adm-zip re-resolve to current registry state — the standalone lock is a point-in-time snapshot and the workspace overrides aren't cleanly reapplied). I did not ship that drift. **DevOps: what's the canonical procedure to add a single new dep to `taxonomy-editor/pnpm-lock.yaml` without the registry-drift?** Once that lands, `test-container` goes green and this un-drafts.

### Local verification
15 render tests pass (incl. a real pptxgenjs byte-stream, per-camp parity, gate-integrity asymmetry, self-contained/XSS-safe HTML, CLI parsing). lib eslint clean (0 errors); render typechecks clean under lib tsconfig.

→ Main-TL: review `assemble.ts` (anti-drift seam) + `pptxRenderer.ts` (bounded surface) + the parity-truncation MUST.