### PR TITLE
feat(container): install PowerShell Core in runtime image (t/2824)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -208,6 +208,17 @@ COPY --chown=aitriad:aitriad taxonomy-editor/src/main/pty-broker.py ./src/main/p
 #    For local builds: mkdir -p taxonomy-snapshot && echo '{}' > taxonomy-snapshot/snapshot-meta.json
 COPY --chown=aitriad:aitriad taxonomy-snapshot/ ./fallback-data/
 
+# 7. PowerShell Core — required for the web console ("Console (pwsh + AITriad)") (t/2824)
+# hadolint ignore=DL3008
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    curl -fsSL "https://packages.microsoft.com/config/debian/13/packages-microsoft-prod.deb" \
+      -o /tmp/ms-prod.deb \
+    && dpkg -i /tmp/ms-prod.deb \
+    && rm /tmp/ms-prod.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends powershell
+
 USER aitriad
 
 EXPOSE 7862


### PR DESCRIPTION
## Summary
- Adds `pwsh` (PowerShell Core) to the container runtime stage via Microsoft's Debian 13 package feed
- Placed before `USER aitriad` so installation runs as root; `pwsh` is then available to the `aitriad` user
- `scripts/` is already COPY'd to `/app/scripts/`, so `Import-Module '/app/scripts/AITriad/AITriad.psd1' -Force` (AC2) follows once `pwsh` is present (AC1)

## AC3 note
Making the console *start in* pwsh (vs dropping to bash) requires a change in the pty-broker/console launcher — Taxonomy Editor scope. Routing separately after this lands.

## Test plan
- [ ] `test-container` CI job builds the image — `apt-get install powershell` must succeed (AC1 proof)
- [ ] Post-deploy: `Invoke-TaxEditorSmokeTest` + manual console open + `pwsh --version`

Closes t/2824 (AC1 + AC2; AC3 routed to Taxonomy Editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
