### PR TITLE
fix(brief): make lib/brief nodenext-clean for the T6 server build

### DIFF
--- a/lib/brief/extract.ts
+++ b/lib/brief/extract.ts
@@ -5,7 +5,7 @@
 // Deterministic, no model. Maps a closed DebateSession → deck_spec.json IR.
 // Validates output against the strict write schema before returning.
 
-import Ajv from 'ajv';
+import { Ajv } from 'ajv';
 import type { DebateSession } from '../debate/types.js';
 import type { SynthesisResult, SynthesisCrux, PreferenceEntry } from '../debate/types/synthesis.js';
 import type { ArgumentNetworkNode, CommitmentStore } from '../debate/types/argumentNetwork.js';

--- a/lib/brief/narrate.ts
+++ b/lib/brief/narrate.ts
@@ -6,7 +6,7 @@
 // Validates output against the strict write schema and checks trace resolvability
 // before returning (the T2 lesson: structured-output requests are NOT self-validating).
 
-import Ajv from 'ajv';
+import { Ajv } from 'ajv';
 import type { AIAdapter } from '../debate/aiAdapter.js';
 import { ActionableError } from '../debate/errors.js';
 import { getGlobalRecorder } from '../flight-recorder/index.js';

--- a/lib/brief/render/pptxRenderer.ts
+++ b/lib/brief/render/pptxRenderer.ts
@@ -6,10 +6,50 @@
 // only this file. Input is the target-neutral SlideModel[]; output is the real
 // serialized .pptx bytes handed to T5 verify().
 
-import PptxGenJS from 'pptxgenjs';
+import PptxGenJSImport from 'pptxgenjs';
 import type { SlideModel, SlideBlock } from './slideModel.js';
 import type { DeckTheme } from './deckTheme.js';
 import { campColor } from './deckTheme.js';
+
+// ── Bounded pptxgenjs surface ────────────────────────────────────────────────
+// pptxgenjs ships ESM-`export default` types over a CJS main; under the server's
+// nodenext build its default export is typed as the module namespace, not a
+// constructor (and `PptxGenJS.Slide` etc. become unreachable). This local surface —
+// the ONLY pptxgenjs coupling in lib/brief — pins the runtime constructor (correct
+// at runtime: the CJS main's `module.exports` IS the class) to the exact API this
+// renderer uses, so it type-checks under BOTH bundler (vitest/renderer) and nodenext
+// (server build). A pptxgenjs swap or a types fix touches only this block.
+type Hex = string;
+interface PptxLine { color: Hex; width?: number; pt?: number }
+interface PptxTextOpts {
+  x?: number; y?: number; w?: number; h?: number;
+  fontSize?: number; color?: Hex; bold?: boolean; italic?: boolean;
+  align?: 'left' | 'center' | 'right'; valign?: 'top' | 'middle' | 'bottom';
+  rotate?: number; transparency?: number; bullet?: boolean;
+  fontFace?: string; fill?: { color: Hex }; margin?: number; line?: PptxLine;
+}
+interface PptxTextRun { text: string; options?: PptxTextOpts }
+type PptxTextInput = string | PptxTextRun[];
+interface PptxTableCell { text: string; options?: Record<string, unknown> }
+interface PptxTableOpts {
+  x?: number; y?: number; w?: number; fontSize?: number; fontFace?: string;
+  border?: { type?: string; color?: Hex; pt?: number };
+}
+interface PptxSlide {
+  background: { color: Hex };
+  addText(text: PptxTextInput, opts: PptxTextOpts): void;
+  addTable(rows: PptxTableCell[][], opts: PptxTableOpts): void;
+  addNotes(notes: string): void;
+}
+interface PptxDeck {
+  defineLayout(opts: { name: string; width: number; height: number }): void;
+  layout: string;
+  theme: { headFontFace?: string; bodyFontFace?: string };
+  addSlide(): PptxSlide;
+  write(opts: { outputType: 'uint8array' }): Promise<Uint8Array>;
+}
+type PptxDeckCtor = new () => PptxDeck;
+const PptxGenJS = PptxGenJSImport as unknown as PptxDeckCtor;
 
 const MARGIN = 0.5;
 const CONTENT_W = 9.0; // 10in slide width minus margins
@@ -49,11 +89,10 @@ export async function renderPptx(slides: SlideModel[], theme: DeckTheme): Promis
 
   // pptxgenjs emits valid OOXML (positive offsets, canonical p:presentation order),
   // so the render output passes T5's OOXML lint by construction.
-  const out = await pptx.write({ outputType: 'uint8array' });
-  return out as Uint8Array;
+  return pptx.write({ outputType: 'uint8array' });
 }
 
-function layoutBlocks(slide: PptxGenJS.Slide, blocks: SlideBlock[], theme: DeckTheme): void {
+function layoutBlocks(slide: PptxSlide, blocks: SlideBlock[], theme: DeckTheme): void {
   let y = BODY_Y;
   for (const block of blocks) {
     y = layoutBlock(slide, block, theme, y);
@@ -61,7 +100,7 @@ function layoutBlocks(slide: PptxGenJS.Slide, blocks: SlideBlock[], theme: DeckT
   }
 }
 
-function layoutBlock(slide: PptxGenJS.Slide, block: SlideBlock, theme: DeckTheme, y: number): number {
+function layoutBlock(slide: PptxSlide, block: SlideBlock, theme: DeckTheme, y: number): number {
   switch (block.type) {
     case 'text':
       slide.addText(block.text, {

--- a/lib/brief/verify.test.ts
+++ b/lib/brief/verify.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import JSZip from 'jszip';
-import Ajv from 'ajv';
+import { Ajv } from 'ajv';
 import { verify } from './verify.js';
 import type { VerifyInput } from './verify.js';
 import type { DeckSpec, Narration } from './types.js';

--- a/lib/brief/verify.ts
+++ b/lib/brief/verify.ts
@@ -13,7 +13,7 @@
 // before returning (the T2 self-validation lesson — the manifest is itself an artifact).
 
 import { createHash } from 'node:crypto';
-import Ajv from 'ajv';
+import { Ajv } from 'ajv';
 import JSZip from 'jszip';
 import { ActionableError } from '../debate/errors.js';
 import { getGlobalRecorder } from '../flight-recorder/index.js';


### PR DESCRIPTION
## Problem
T6's REST route (#1259) imports the brief pipeline, so `build:server` (tsc, **nodenext**) now compiles `lib/brief` for the first time — it previously only ever built under `bundler`. That surfaced 9 type errors (Root Main, p/18#14).

## Fixes (both config-independent — clean under bundler AND nodenext)
- **ajv** (`extract.ts`, `narrate.ts`, `verify.ts`, `verify.test.ts`): `import { Ajv } from 'ajv'` (named class export) instead of the default import, which nodenext types as the module namespace (not constructable). This also clears the 3 cascaded implicit-`any e` in the `.errors.map()` sites.
- **pptxgenjs** (`pptxRenderer.ts`): its shipped types are ESM-`export default` over a CJS main, so under nodenext the default is the namespace (not constructable) and `PptxGenJS.Slide` is unreachable. Bound the exact API this renderer uses behind a small local surface (already the ONLY pptxgenjs coupling in lib/brief, per TL's T4 design) and pin the runtime constructor through it — runtime-correct (CJS `module.exports` IS the class) and type-safe under both configs.

## Verification
- `tsc` **nodenext**: 0 brief errors (server-build simulation)
- `tsc` **bundler** (lib tsconfig): 0 brief errors
- 63 brief tests pass (narrate + verify + render); lib eslint clean (0 errors)

## Coordination
Root Main: rebase #1259 on this once it lands and the server build goes green. Deterministic type-only change — no behavior change, no GV needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)