### PR TITLE
feat(t2808): schema version-bump CI gate for lib/brief/schemas

### DIFF
--- a/lib/brief/schemas/check-version-bump.mjs
+++ b/lib/brief/schemas/check-version-bump.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief Export schema version-bump gate (t/2808).
+//
+// Under the forward-compatible IR (T1, Second Opinion e/109#2), the version-bump
+// discipline is a SOCIAL rule the schema can't self-enforce: a `properties` change
+// to any lib/brief/schemas/*.write.json with no version bump silently erodes the
+// provenance guarantee (on-disk manifests would misreport which contract they were
+// written under). This gate diffs the three write schemas against the PR base and
+// fails when a contract change lands without bumping the schema's `$id` version.
+//
+// The version marker is the trailing `/<major>.<minor>` of each schema's `$id`
+// (e.g. .../deck_spec/1.0). Additive-optional → bump minor; breaking → bump major.
+//
+// Config is co-located with the schemas (this file lives beside them). Pure logic
+// is exported for unit tests; the CLI runner drives it against `git`.
+//
+// Usage: node lib/brief/schemas/check-version-bump.mjs [--mode=warn|block]
+//   --mode=warn  (default) prints violations as GitHub warnings, exits 0.
+//   --mode=block prints errors, exits 1 on any violation (promote here after a
+//                green warn cycle — Gate Promotion, t/2808 AC).
+// Base ref: $BASE_REF, else origin/$GITHUB_BASE_REF, else origin/main.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ── Pure logic (unit-tested) ────────────────────────────────────────────────
+
+/** Non-contract keys stripped before comparing — editing these never needs a bump. */
+const NON_CONTRACT_KEYS = new Set(['description', 'title', '$id', '$schema', '$comment']);
+
+/** Extract `<major>.<minor>` from a schema's `$id`, or null if absent/malformed. */
+export function schemaVersion(schema) {
+  const id = schema && typeof schema['$id'] === 'string' ? schema['$id'] : '';
+  const m = /\/(\d+)\.(\d+)(?:\.\d+)?$/.exec(id);
+  return m ? `${m[1]}.${m[2]}` : null;
+}
+
+/** A stable, description-independent signature of the contract surface. */
+export function contractSignature(schema) {
+  return stableStringify(stripNonContract(schema));
+}
+
+function stripNonContract(value) {
+  if (Array.isArray(value)) return value.map(stripNonContract);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (NON_CONTRACT_KEYS.has(k)) continue;
+      out[k] = stripNonContract(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map(k => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * Decide whether a single schema's change is a violation.
+ * @returns {null | {file, baseVersion, headVersion, reason}} null = OK.
+ */
+export function detectViolation(file, baseSchema, headSchema) {
+  if (baseSchema == null) return null;          // new schema file — no prior contract
+  if (headSchema == null) return null;          // deleted schema — not this gate's concern
+  if (contractSignature(baseSchema) === contractSignature(headSchema)) return null; // no contract change
+  const baseVersion = schemaVersion(baseSchema);
+  const headVersion = schemaVersion(headSchema);
+  if (baseVersion !== null && baseVersion === headVersion) {
+    return {
+      file,
+      baseVersion,
+      headVersion,
+      reason: 'contract surface (properties/required/enum/pattern/type) changed without bumping the schema $id version',
+    };
+  }
+  return null; // contract changed AND version bumped (or version marker is new) → OK
+}
+
+// ── CLI runner ──────────────────────────────────────────────────────────────
+
+function parseSchema(text) {
+  try { return JSON.parse(text); } catch { return null; }
+}
+
+function baseRef() {
+  if (process.env.BASE_REF) return process.env.BASE_REF;
+  if (process.env.GITHUB_BASE_REF) return `origin/${process.env.GITHUB_BASE_REF}`;
+  return 'origin/main';
+}
+
+/** `git show <ref>:<path>` → text, or null if the path does not exist at that ref. */
+function gitShow(ref, repoRelPath) {
+  try {
+    return execFileSync('git', ['show', `${ref}:${repoRelPath}`], { encoding: 'utf8' });
+  } catch {
+    return null; // new file at head (absent from base)
+  }
+}
+
+function repoRoot() {
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+}
+
+function main() {
+  const mode = (process.argv.find(a => a.startsWith('--mode=')) ?? '--mode=warn').split('=')[1];
+  const here = dirname(fileURLToPath(import.meta.url));
+  const root = repoRoot();
+  const ref = baseRef();
+
+  const schemaFiles = readdirSync(here).filter(f => f.endsWith('.write.json')).sort();
+  const violations = [];
+
+  for (const name of schemaFiles) {
+    const abs = join(here, name);
+    const repoRel = relative(root, abs).split('\\').join('/');
+    const head = parseSchema(readFileSync(abs, 'utf8'));
+    const baseText = gitShow(ref, repoRel);
+    const base = baseText === null ? null : parseSchema(baseText);
+    const v = detectViolation(repoRel, base, head);
+    if (v) violations.push(v);
+  }
+
+  if (violations.length === 0) {
+    console.log(`schema version-bump gate: clean (${schemaFiles.length} schema(s) checked against ${ref}).`);
+    process.exit(0);
+  }
+
+  const level = mode === 'block' ? 'error' : 'warning';
+  for (const v of violations) {
+    console.log(
+      `::${level} file=${v.file}::${v.file} — ${v.reason}. ` +
+      `Version is still ${v.headVersion}; bump the $id (minor for additive-optional, major for breaking).`,
+    );
+  }
+  console.log(
+    `\nschema version-bump gate: ${violations.length} violation(s) [mode=${mode}]. ` +
+    (mode === 'block'
+      ? 'Failing the build.'
+      : 'Warn-only for now — promote to --mode=block after a green cycle (t/2808).'),
+  );
+  process.exit(mode === 'block' ? 1 : 0);
+}
+
+// Run only when invoked directly (not when imported by tests).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/lib/brief/schemas/check-version-bump.test.ts
+++ b/lib/brief/schemas/check-version-bump.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for the Brief Export schema version-bump gate (t/2808).
+// Exercises the pure comparison logic — the CLI's git plumbing is covered by the
+// both-arms Gate Verification (TL) against real PRs.
+
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — plain ESM module, no type declarations needed for a test import.
+import { schemaVersion, contractSignature, detectViolation } from './check-version-bump.mjs';
+
+function schema(version: string, extraProps: Record<string, unknown> = {}) {
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: `https://aitriad.local/schemas/deck_spec/${version}`,
+    title: 'DeckSpec',
+    type: 'object',
+    required: ['deck_spec_version'],
+    additionalProperties: false,
+    properties: {
+      deck_spec_version: { type: 'string', pattern: '^1\\.\\d+$' },
+      ...extraProps,
+    },
+  };
+}
+
+describe('schemaVersion', () => {
+  it('extracts major.minor from the $id', () => {
+    expect(schemaVersion(schema('1.0'))).toBe('1.0');
+    expect(schemaVersion(schema('1.7'))).toBe('1.7');
+    expect(schemaVersion(schema('2.0'))).toBe('2.0');
+  });
+  it('returns null for a missing/malformed $id', () => {
+    expect(schemaVersion({})).toBeNull();
+    expect(schemaVersion({ $id: 'no-version-here' })).toBeNull();
+  });
+});
+
+describe('contractSignature', () => {
+  it('is identical when only description/title differ', () => {
+    const a = schema('1.0', { foo: { type: 'string' } });
+    const b = schema('1.0', { foo: { type: 'string', description: 'a docstring' } });
+    (b as { title: string }).title = 'Renamed But Same Contract';
+    expect(contractSignature(a)).toBe(contractSignature(b));
+  });
+  it('is identical when only the $id version differs (version is not part of the surface)', () => {
+    expect(contractSignature(schema('1.0'))).toBe(contractSignature(schema('1.1')));
+  });
+  it('differs when a property is added', () => {
+    expect(contractSignature(schema('1.0'))).not.toBe(
+      contractSignature(schema('1.0', { newField: { type: 'number' } })),
+    );
+  });
+});
+
+describe('detectViolation', () => {
+  it('flags a property addition with no version bump', () => {
+    const base = schema('1.0');
+    const head = schema('1.0', { newField: { type: 'number' } });
+    const v = detectViolation('deck_spec.write.json', base, head);
+    expect(v).not.toBeNull();
+    expect(v.headVersion).toBe('1.0');
+  });
+
+  it('passes a property addition WITH a minor bump', () => {
+    const base = schema('1.0');
+    const head = schema('1.1', { newField: { type: 'number' } });
+    expect(detectViolation('deck_spec.write.json', base, head)).toBeNull();
+  });
+
+  it('passes a description-only edit with no bump', () => {
+    const base = schema('1.0', { foo: { type: 'string' } });
+    const head = schema('1.0', { foo: { type: 'string', description: 'now documented' } });
+    expect(detectViolation('deck_spec.write.json', base, head)).toBeNull();
+  });
+
+  it('passes a version-only bump with no contract change', () => {
+    expect(detectViolation('deck_spec.write.json', schema('1.0'), schema('1.1'))).toBeNull();
+  });
+
+  it('flags a required-list change with no bump', () => {
+    const base = schema('1.0', { foo: { type: 'string' } });
+    const head = schema('1.0', { foo: { type: 'string' } });
+    (head as { required: string[] }).required = ['deck_spec_version', 'foo'];
+    expect(detectViolation('deck_spec.write.json', base, head)).not.toBeNull();
+  });
+
+  it('flags an enum change with no bump', () => {
+    const base = schema('1.0', { mode: { type: 'string', enum: ['a', 'b'] } });
+    const head = schema('1.0', { mode: { type: 'string', enum: ['a', 'b', 'c'] } });
+    expect(detectViolation('deck_spec.write.json', base, head)).not.toBeNull();
+  });
+
+  it('ignores a brand-new schema file (no prior contract)', () => {
+    expect(detectViolation('new.write.json', null, schema('1.0'))).toBeNull();
+  });
+
+  it('ignores a deleted schema file', () => {
+    expect(detectViolation('gone.write.json', schema('1.0'), null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## t/2808 — schema version-bump gate

Diffs the three `lib/brief/schemas/*.write.json` write schemas against the PR base and flags any **contract-surface change** (properties/required/enum/pattern/type) that lands without bumping the schema's `$id` version — the version-bump discipline the forward-compatible IR (T1, Second Opinion e/109#2) cannot self-enforce (on-disk manifests would misreport their contract).

### Mechanics (self-cert per /trivial-change, as the ticket permits)
- `lib/brief/schemas/check-version-bump.mjs` — pure logic (`schemaVersion`, `contractSignature`, `detectViolation`) + a git-driven CLI. Config **co-located** with the schemas (AC).
- Description/title/`$id`/`$schema` are stripped before comparing, so doc-only edits and pure version bumps never trip it.
- `--mode=warn` (default: GH `::warning`, exit 0) / `--mode=block` (`::error`, exit 1). Promote to block after a green warn cycle (Gate Promotion).
- 13 unit tests (added-prop-no-bump → violation; added-prop-with-bump → clean; description-only → clean; version-only → clean; required/enum change → violation; new/deleted file → ignored).

### Both-arms Gate Verification evidence (local) — **TL runs the official GV**
- **Clean** (no schema change): `clean (3 schemas)`, exit 0.
- **Red / block** (property added, same version): `::error`, exit 1, "Failing the build".
- **Red / warn**: `::warning`, exit 0, "Warn-only for now".

### Remaining (coordination)
- **DevOps**: wire a `deckspec-version-bump` CI step (warn mode first) into `ci.yml` — `node lib/brief/schemas/check-version-bump.mjs` with the PR base fetched (`BASE_REF`/`GITHUB_BASE_REF`). ci.yml is DevOps-owned; draft step in the ticket.
- **TL**: both-arms Gate Verification, then promote warn→block after ≥1 green real-PR cycle.

lib eslint clean; 13 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)