### PR TITLE
feat(ui): gate bookmark (Pin-for-comparison) controls to Advanced view (t/2826)

### DIFF
--- a/taxonomy-editor/src/renderer/components/conflict/ConflictDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/conflict/ConflictDetail.tsx
@@ -7,6 +7,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import type { ConflictFile, ConflictInstance, ConflictQbaf, ConflictStance, DialecticTrace, DialecticTraceStep, TabId } from '../../types/taxonomy';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import { useFeatureFlagStore } from '../../hooks/useFeatureFlags';
+import { usePreferencesStore } from '../../store/preferencesStore';
 import { DeleteConfirmDialog } from '../shared/DeleteConfirmDialog';
 import { OverflowMenu } from '../shared/OverflowMenu';
 import { newEmptyInstance } from './ConflictInstanceForm';
@@ -62,6 +63,8 @@ function tabForNodeId(id: string): TabId {
 }
 
 export function ConflictDetail({ conflict, readOnly, onPin, chipDepth = 0 }: ConflictDetailProps) {
+  // Bookmark (Pin-for-comparison) controls are Advanced-view only (t/2826).
+  const viewMode = usePreferencesStore(s => s.viewMode);
   const {
     updateConflict,
     deleteConflict,
@@ -193,7 +196,7 @@ export function ConflictDetail({ conflict, readOnly, onPin, chipDepth = 0 }: Con
         onResearch={handleResearchPrompt}
         onDebate={handleDebate}
         debateCreating={debateCreating}
-        onPin={onPin}
+        onPin={viewMode === 'advanced' ? onPin : undefined}
         readOnly={readOnly}
         onDelete={() => setShowDelete(true)}
       />

--- a/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
@@ -7,6 +7,7 @@ import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import type { SituationNode } from '../../types/taxonomy';
 import { interpretationText } from '../../types/taxonomy';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
+import { usePreferencesStore } from '../../store/preferencesStore';
 import { DeleteConfirmDialog } from '../shared/DeleteConfirmDialog';
 import { HighlightedTextarea } from '../shared/HighlightedField';
 import { TypeaheadSelect } from '../shared/TypeaheadSelect';
@@ -592,6 +593,8 @@ function SitPovTab({
 
 export function SituationDetail({ node, readOnly, onPin, onRelated, onDebate, chipDepth = 0 }: SituationDetailProps) {
   const { updateSituationNode, deleteSituationNode, validationErrors, getAllNodeIds, getAllConflictIds, runAttributeFilter, showAttributeInfo, getLabelForId } = useTaxonomyStore();
+  // Bookmark (Pin-for-comparison) controls are Advanced-view only (t/2826).
+  const viewMode = usePreferencesStore(s => s.viewMode);
   const [descMode, setDescMode] = useDescriptionMode();
   const [showDelete, setShowDelete] = useState(false);
   const [activeTab, setActiveTab] = useState<SitTab>('overview');
@@ -689,7 +692,7 @@ export function SituationDetail({ node, readOnly, onPin, onRelated, onDebate, ch
         node={node}
         readOnly={readOnly}
         onDebate={onDebate}
-        onPin={onPin}
+        onPin={viewMode === 'advanced' ? onPin : undefined}
         err={err}
         hasErrors={hasErrors}
         update={update}

--- a/taxonomy-editor/src/renderer/components/shared/PinnedPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/PinnedPanel.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from 'react';
 import { useTaxonomyStore, type PinnedData } from '../../hooks/useTaxonomyStore';
+import { usePreferencesStore } from '../../store/preferencesStore';
 import { NodeDetail } from '../taxonomy/NodeDetail';
 import { SituationDetail } from '../debate/SituationDetail';
 import { ConflictDetail } from '../conflict/ConflictDetail';
@@ -50,7 +51,11 @@ function PinnedPanelEntry({ data, depth, onClose }: {
 
 export function PinnedPanel() {
   const { pinnedStack, closePinnedFromDepth } = useTaxonomyStore();
+  // Bookmark (Pin-for-comparison) surface is Advanced-view only — the shared gate for all
+  // three tabs that render it. Subscribing here re-renders on view toggle (no reload, t/2826).
+  const viewMode = usePreferencesStore(s => s.viewMode);
 
+  if (viewMode !== 'advanced') return null;
   if (pinnedStack.length === 0) return null;
 
   return (

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
@@ -6,7 +6,7 @@
 // fix holds. Also asserts Simple/Advanced tab visibility gate works correctly.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import type { PovNode } from '../../types/taxonomy';
 
 // ── Store mocks ──────────────────────────────────────────────────────────────
@@ -198,5 +198,23 @@ describe('NodeDetail — Zustand scalar selector regression (t/2142)', () => {
     expect(screen.getByRole('button', { name: /related/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /attributes/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /research/i })).toBeInTheDocument();
+  });
+
+  // t/2826 — the Pin-for-comparison ("bookmark") control is Advanced-view only.
+  it('omits Pin for Comparison from the actions menu in simple mode', () => {
+    render(
+      <NodeDetail pov="acc" node={mockNode} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTitle('More actions'));
+    expect(screen.queryByRole('menuitem', { name: /pin for comparison/i })).not.toBeInTheDocument();
+  });
+
+  it('includes Pin for Comparison in the actions menu in advanced mode', () => {
+    mockPrefsState.viewMode = 'advanced';
+    render(
+      <NodeDetail pov="acc" node={mockNode} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTitle('More actions'));
+    expect(screen.getByRole('menuitem', { name: /pin for comparison/i })).toBeInTheDocument();
   });
 });

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -388,7 +388,7 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
           update={update}
           maybeRegenAphorism={maybeRegenAphorism}
           onSimilarSearch={onSimilarSearch}
-          onPin={onPin}
+          onPin={viewMode === 'advanced' ? onPin : undefined}
           moveTargets={moveTargets}
           setShowDelete={setShowDelete}
           labelContent={labelContent}


### PR DESCRIPTION
## Bookmarks: Advanced-view only across all surfaces (t/2826)

Bookmark controls (the Pin-for-comparison buttons + the shared `PinnedPanel`) are now hidden in **Simple** view and shown in **Advanced** view, across every surface the TL enumerated in t/2826#1: POV/node, conflicts, debate situations.

### Gating (mirrors the existing `viewMode` pattern, e.g. `NodeDescriptionSection`)
- **Pin trigger buttons** — gated at the `onPin` prop boundary in each detail component (`onPin={viewMode === 'advanced' ? onPin : undefined}`), so each site's existing `{onPin && …}` guard hides it. Covers NodeDetail (header button **and** overflow "Pin for Comparison" entry), ConflictDetail (`ConflictToolbar`), SituationDetail (`SitHeader`).
- **PinnedPanel** — gated **once** inside the shared component (returns `null` unless advanced), covering all three tabs (PovTab / ConflictsTab / SituationsTab) that render it. This is the DRY-once point the TL flagged.

`viewMode` is a store subscription → toggling Simple↔Advanced re-renders and shows/hides bookmarks with **no reload** (AC #3).

### Tests
`NodeDetail.test.tsx` gains two cases: the "Pin for Comparison" actions-menu entry is absent in simple mode, present in advanced. Full file 6/6 green; eslint 0 errors.

### Self-cert
Per the TL's t/2826#1 clearance — single-scope renderer, existing pattern → self-certified, no design review. No deviations.
