### PR TITLE
ci: schema version-bump warn gate (t/2808)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,31 @@ jobs:
         working-directory: lib
         run: pnpm exec tsc --noEmit -p debate/tsconfig.json
 
+  # ── Schema version-bump gate — warn mode (t/2808) ───────────────────────
+  # Diffs lib/brief/schemas/*.write.json against the PR base; warns when the
+  # contract surface changes without a $id version bump. Warn-only (exit 0
+  # always) until a green warn cycle confirms signal quality — then promote to
+  # --mode=block + add to ci-gate (Gate Promotion per AGENTS.md, requires TL
+  # sign-off per DevOps AGENTS.md Gate Promotion Discipline).
+  schema-version-bump:
+    needs: [changes]
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name != 'pull_request' || needs.changes.outputs.lib == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
+        with:
+          node-version: '22'
+
+      - name: Schema version-bump check — warn mode (t/2808)
+        continue-on-error: true
+        run: node lib/brief/schemas/check-version-bump.mjs --mode=warn
+
   # ── Commit hygiene: flags anonymous / undersized commit subjects (t/1319) ──
   # Annotation-only by design — never flips (t/1319). Visibility, not friction.
   commit-hygiene:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,6 +539,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+        with:
+          fetch-depth: 0  # required: script runs `git show origin/<base>:<file>` (t/2808 GV)
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:


### PR DESCRIPTION
## Summary
- Adds `schema-version-bump` job to `ci.yml` (warn mode, `continue-on-error: true`)
- Runs `node lib/brief/schemas/check-version-bump.mjs --mode=warn` on PRs touching `lib/**`
- Exits 0 always — GitHub warning annotations only, no CI gate breakage
- Script file lands in PR #1262 (t/2808); without it the step fails gracefully (file not found, continue-on-error catches it)

## Gate Promotion path (NOT in this PR)
When promoted to `--mode=block`: remove `continue-on-error`, add `schema-version-bump` to `ci-gate needs`, open as a separate draft PR + TL sign-off per Gate Promotion Discipline.

## Test plan (TL GV)
- [ ] Arm 1 (violation): PR that changes `*.write.json` contract without bumping `$id` → step prints `::warning::` annotation, exits 0, job passes
- [ ] Arm 2 (clean): PR with no schema changes (or bumped version) → step prints "clean", exits 0

Blocked on TL GV before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
