### PR TITLE
feat(t2832): standalone nodenext typecheck gate for all of lib/brief

### DIFF
--- a/lib/brief/tsconfig.nodenext.json
+++ b/lib/brief/tsconfig.nodenext.json
@@ -1,0 +1,16 @@
+{
+  "//": "Standalone nodenext typecheck for the WHOLE brief pipeline (t/2832). lib/brief is a three-config surface (bundler + nodenext + renderer-tsc); this asserts every module is nodenext-clean independent of any consumer, so latent server-build (build:server, nodenext) errors are caught at authoring time — not one-consumer-at-a-time (the #1259/#1261 failure mode). Bundler-over-lib is already gated by renderer-tsc.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/lib/package.json
+++ b/lib/package.json
@@ -20,6 +20,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:brief-nodenext": "tsc -p brief/tsconfig.nodenext.json"
   }
 }


### PR DESCRIPTION
## t/2832 — three-config prevention (TL request, p/458#1)

Prevention for the #1259/#1261 nodenext break. `lib/brief` is a **three-config surface** (bundler + nodenext + renderer-tsc), but nodenext coverage was **consumer-triggered** — errors only surfaced when a server consumer first imported a module (T6's REST route surfaced 9 latent errors at once). This asserts **every** brief module compiles clean under nodenext, independent of any consumer.

### Change
- `lib/brief/tsconfig.nodenext.json` — `module`/`moduleResolution: nodenext`, strict, `include: brief/**`, excludes tests (not shipped; they run under vitest/bundler).
- lib npm script `typecheck:brief-nodenext`.

Bundler-over-lib is already gated by **renderer-tsc** (taxonomy-editor/tsconfig includes `../lib/**`); this closes the **nodenext** leg so all three configs are covered.

### Both-arms verification (local)
- **Clean** (current main): `pnpm run typecheck:brief-nodenext` → exit 0.
- **Red** (ajv default import — a nodenext-only regression bundler accepts): `error TS2351: not constructable` + implicit-any → exit 2. Reverted → clean.

### Routing
- **DevOps**: wire a CI step (extend lib-lint or a new job): `pnpm --dir lib run typecheck:brief-nodenext`, path-filtered to lib/brief changes. ci.yml is your scope.
- **TL**: both-arms Gate Verification, then it can go blocking immediately (deterministic typecheck, no flake surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)