### PR TITLE
ci: lib/brief NodeNext typecheck step in lib-lint (t/2832)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,10 @@ jobs:
         working-directory: lib
         run: pnpm exec tsc --noEmit -p debate/tsconfig.json
 
+      - name: TypeScript — lib/brief NodeNext module check (t/2832)
+        working-directory: lib
+        run: pnpm run typecheck:brief-nodenext
+
   # ── Schema version-bump gate — warn mode (t/2808) ───────────────────────
   # Diffs lib/brief/schemas/*.write.json against the PR base; warns when the
   # contract surface changes without a $id version bump. Warn-only (exit 0


### PR DESCRIPTION
## Summary
- Adds `pnpm run typecheck:brief-nodenext` step to the existing `lib-lint` job
- Script: `tsc -p brief/tsconfig.nodenext.json` (from PR #1265, t/2832)
- Path-filtered to `lib/**` via existing `lib` filter — runs on any lib change
- Step is blocking (no `continue-on-error`) — deterministic typecheck, no flake surface
- Prevents the #1259 break shape: NodeNext module resolution errors that pass standard tsc

## Dependencies
- Requires PR #1265 to merge first (adds `typecheck:brief-nodenext` script to `lib/package.json`)

## Test plan (TL GV)
- [ ] Arm 1 (violation): PR with a lib/brief NodeNext incompatibility → step fails, lib-lint red
- [ ] Arm 2 (clean): normal PR touching lib/** → step passes, no noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
