### PR TITLE
feat(t2816): allowOpen / meta.snapshot support in extractDeckSpec

### DIFF
--- a/lib/brief/extract.test.ts
+++ b/lib/brief/extract.test.ts
@@ -122,6 +122,46 @@ describe('extractDeckSpec phase guard', () => {
   });
 });
 
+// ── allowOpen / meta.snapshot (t/2816) ────────────────────────────────────────
+
+describe('extractDeckSpec allowOpen snapshot', () => {
+  it('non-closed still throws by default (allowOpen omitted)', () => {
+    const session = makeSession({ phase: 'debate' });
+    expect(() => extractDeckSpec(session as never)).toThrow("must be 'closed'");
+  });
+
+  it('non-closed + allowOpen exports a snapshot with meta.snapshot + note + phase open', () => {
+    const session = makeSession({ phase: 'debate' });
+    const spec = extractDeckSpec(session as never, { allowOpen: true });
+    expect(spec.meta.snapshot).toBe(true);
+    expect(spec.meta.snapshot_note).toContain('snapshot');
+    expect(spec.meta.snapshot_note).toContain('debate'); // the real session phase
+    expect(spec.meta.phase).toBe('open');
+  });
+
+  it('allowOpen tolerates a missing concluding entry (in-progress snapshot)', () => {
+    const session = makeSession({ phase: 'opening', transcript: [] });
+    const spec = extractDeckSpec(session as never, { allowOpen: true });
+    expect(spec.meta.snapshot).toBe(true);
+    // synthesis-derived sections are legitimately empty before the debate concludes
+    expect(spec.agreements).toEqual([]);
+    expect(spec.cruxes).toEqual([]);
+  });
+
+  it('closed export sets no snapshot flag (unchanged)', () => {
+    const spec = extractDeckSpec(makeSession() as never);
+    expect(spec.meta.snapshot).toBeUndefined();
+    expect(spec.meta.snapshot_note).toBeUndefined();
+    expect(spec.meta.phase).toBe('closed');
+  });
+
+  it('closed + allowOpen is a no-op (not treated as a snapshot)', () => {
+    const spec = extractDeckSpec(makeSession() as never, { allowOpen: true });
+    expect(spec.meta.snapshot).toBeUndefined();
+    expect(spec.meta.phase).toBe('closed');
+  });
+});
+
 // ── Happy path: version + meta ────────────────────────────────────────────────
 
 describe('extractDeckSpec meta', () => {

--- a/lib/brief/extract.ts
+++ b/lib/brief/extract.ts
@@ -56,23 +56,42 @@ const STRIP_LIST = new Set([
 
 const KNOWN_FIELDS = new Set([...MAPPED_FIELDS, ...STRIP_LIST]);
 
+/** Options for {@link extractDeckSpec}. */
+export interface ExtractOptions {
+  /**
+   * Export a non-closed (in-progress) debate as a WATERMARKED snapshot (spec §5).
+   * Sets `meta.snapshot=true` + `meta.snapshot_note`; T4 renders the "IN PROGRESS"
+   * watermark + maturity note. Sections derived from the concluding synthesis may be
+   * empty because the debate has not concluded. Default false → non-closed throws.
+   */
+  allowOpen?: boolean;
+}
+
 /**
- * Extract a `deck_spec.json` IR from a closed debate session.
- * All 14 sections are deterministically derived — no model calls.
+ * Extract a `deck_spec.json` IR from a debate session.
+ * Closed debates export directly. A non-closed debate throws unless `allowOpen` is set
+ * (spec §5), in which case it exports a watermarked in-progress snapshot.
+ * All sections are deterministically derived — no model calls.
  * Validates output against the strict write schema; throws ActionableError on failure.
  */
-export function extractDeckSpec(session: DebateSession): DeckSpec {
-  if (session.phase !== 'closed') {
+export function extractDeckSpec(session: DebateSession, opts: ExtractOptions = {}): DeckSpec {
+  const isSnapshot = session.phase !== 'closed';
+  if (isSnapshot && !opts.allowOpen) {
     throw new ActionableError({
       goal: 'Extract deck_spec from debate session',
       problem: `Session phase is '${session.phase}' — must be 'closed'`,
       location: LOCATION,
-      nextSteps: ['Close the debate before exporting (run the synthesis phase first).'],
+      nextSteps: [
+        'Close the debate before exporting (run the synthesis phase first),',
+        'or pass allowOpen=true to export a watermarked in-progress snapshot.',
+      ],
     });
   }
 
+  // The concluding synthesis only exists once the debate concludes; a snapshot of an
+  // in-progress debate legitimately has none — its synthesis-derived sections are empty.
   const concludingEntry = session.transcript.find(e => e.type === 'concluding');
-  if (!concludingEntry) {
+  if (!concludingEntry && !isSnapshot) {
     throw new ActionableError({
       goal: 'Extract deck_spec from debate session',
       problem: 'No concluding transcript entry found',
@@ -81,7 +100,7 @@ export function extractDeckSpec(session: DebateSession): DeckSpec {
     });
   }
 
-  const synthesis = (concludingEntry.metadata?.['synthesis'] ?? {}) as Partial<SynthesisResult>;
+  const synthesis = (concludingEntry?.metadata?.['synthesis'] ?? {}) as Partial<SynthesisResult>;
   const recorder = getGlobalRecorder();
 
   // Warn on unmapped non-strip fields (silent-degradation guard, t/2800#1)
@@ -99,7 +118,7 @@ export function extractDeckSpec(session: DebateSession): DeckSpec {
 
   const spec: DeckSpec = {
     deck_spec_version: DECK_SPEC_VERSION,
-    meta: buildMeta(session),
+    meta: buildMeta(session, isSnapshot),
     question: buildQuestion(session),
     framing_critique: buildFramingCritique(session),
     agreements: buildAgreements(synthesis),
@@ -121,15 +140,24 @@ export function extractDeckSpec(session: DebateSession): DeckSpec {
 
 // ── Section builders ──────────────────────────────────────────────────────────
 
-function buildMeta(session: DebateSession): DeckSpec['meta'] {
-  return {
+function buildMeta(session: DebateSession, isSnapshot: boolean): DeckSpec['meta'] {
+  const meta: DeckSpec['meta'] = {
     id: session.id,
     run_id: session.run_id ?? session.id,
     title: session.title,
     model: session.debate_model ?? (session.stage_models?.['draft'] as string | undefined) ?? 'unknown',
     protocol: session.protocol_id ?? 'structured',
-    phase: 'closed',
+    // Session lifecycle (setup|…|closed|cancelled) → deck_spec phase enum (closed|open).
+    // 'concluding' has no session-lifecycle equivalent, so any non-closed → 'open'.
+    phase: session.phase === 'closed' ? 'closed' : 'open',
   };
+  if (isSnapshot) {
+    meta.snapshot = true;
+    meta.snapshot_note =
+      `Exported from an in-progress debate (session phase: '${session.phase}') via allowOpen; ` +
+      'this is a snapshot and may be incomplete.';
+  }
+  return meta;
 }
 
 function buildQuestion(session: DebateSession): DeckSpec['question'] {


### PR DESCRIPTION
## t/2816 — end the allowOpen deferral (lib part)

`extractDeckSpec(session, opts?: { allowOpen?: boolean })`. A non-closed debate still throws **by default** (unchanged); with `allowOpen` it exports a **watermarked in-progress snapshot** — sets `meta.snapshot=true` + `meta.snapshot_note`. T4 already renders the "IN PROGRESS" watermark + maturity note on `meta.snapshot`, so this makes the snapshot path reachable end-to-end on the lib side. Additive + backward-compatible (optional param; snapshot fields already optional in the schema; closed path byte-identical).

### Design decisions (for review)
- **Concluding-entry guard relaxed for snapshots:** an in-progress debate legitimately has no concluding synthesis → synthesis-derived sections are empty rather than a throw (the "content may be incomplete" reality). Closed still requires it.
- **meta.phase mapping:** `DebateSession.phase` is a session lifecycle enum (`setup|clarification|edit-claims|opening|debate|closed|cancelled`), distinct from the deck_spec `concluding|closed|open`. Map `closed→closed`, any non-closed→`open` ('concluding' has no lifecycle equivalent). Previously hard-coded 'closed' (only reachable when closed).
- **`cancelled` is not special-cased** — a cancelled debate + allowOpen would still snapshot. Flagging in case you want to exclude it; easy to add.

### Tests (5 new, 42/42 pass)
default non-closed still throws; snapshot sets flag+note+phase=open; missing-concluding tolerated under allowOpen; closed unchanged (no snapshot flag); closed+allowOpen is a no-op. Clean under nodenext (the new t/2832 gate) + bundler; lint clean.

### Fast-follows (other scopes — flagging, not in this PR)
- **T6 (root Main):** flip `routes/briefExports.ts` `?allowOpen=true` 400 → run the pipeline (extract now accepts it), surface the maturity warning.
- **T8 (PowerShell):** `-AllowOpenDebate` format gate.

→ Main-TL: contract change to extract (you reviewed it for T2) — routing for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)