### PR TITLE
feat(t2806): Export-TriadDebateBrief cmdlet (Brief Export T8) — local mode [DRAFT: gated on t/2837]

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -72,6 +72,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Watch-DebateProgress` | Live-updating table of a running batch's per-debate status (hung detection) |
 | `Show-DebateDiagnostics` | Inspect debate internals |
 | `Repair-DebateOutput` | Fix malformed debate JSON |
+| `Export-TriadDebateBrief` | Export a closed debate to a presentation brief (.pptx). Local mode (`-Path`) runs the offline lib/brief pipeline; server mode (`-DebateId`) is deferred pending AAD auth (t/2839) |
 
 ### Op-Ed Generation
 | Cmdlet | Use when |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -38,6 +38,7 @@
         'Repair-PovLineage'
         'Repair-PovAttributes'
         'Export-AggregatedCruxes'
+        'Export-TriadDebateBrief'
         'Get-Summary'
         'Invoke-AttributeExtraction'
         'Invoke-EdgeDiscovery'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -226,6 +226,27 @@ class GhcrImage {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# TriadDeckExport — typed -PassThru result from Export-TriadDebateBrief (T8).
+# Cross-surface wire contract; field parity with lib/brief/types.ts:182
+# (TriadDeckExport) is enforced by a Pester parity test. Optional TS fields
+# (checkerModel, specPath) map to nullable PS properties.
+# ─────────────────────────────────────────────────────────────────────────────
+class TriadDeckExport {
+    [string]    $DebateId
+    [string]    $Title
+    [string]    $Preset
+    [string]    $Model
+    [string]    $ModelSource
+    [string]    $CheckerModel
+    [string]    $Path
+    [string]    $SpecPath
+    [string]    $ManifestPath
+    [double]    $TraceCoveragePct
+    [hashtable] $Verdicts
+    [string[]]  $Warnings
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # DataCommit — typed result from Get-TaxEditorDataCommit
 # ─────────────────────────────────────────────────────────────────────────────
 class DataCommit {
@@ -757,6 +778,7 @@ Export-ModuleMember -Function @(
     'Repair-PovLineage'
     'Repair-PovAttributes'
     'Export-AggregatedCruxes'
+    'Export-TriadDebateBrief'
     'Get-Summary'
     'Invoke-AttributeExtraction'
     'Invoke-EdgeDiscovery'

--- a/scripts/AITriad/Private/Resolve-BriefExportCli.ps1
+++ b/scripts/AITriad/Private/Resolve-BriefExportCli.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Resolve-BriefExportCli {
+    <#
+    .SYNOPSIS
+        Resolve the invocation for the shared lib/brief full-pipeline export CLI (t/2837).
+    .DESCRIPTION
+        Returns @{ Exe = <string>; ArgPrefix = <string[]> } so the caller invokes:
+            & $inv.Exe @($inv.ArgPrefix + $flagArgs)
+        This isolates the tsx-vs-compiled-bin entrypoint decision (owned by lib/brief,
+        pending TL freeze on t/2837) from Export-TriadDebateBrief, which only knows the
+        frozen flag interface (--path/--model/--preset/--skip-narration/--out).
+
+        Until the CLI lands and its entrypoint is frozen, this throws an actionable error
+        rather than guessing a path. Tests mock this function.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    Set-StrictMode -Version Latest
+
+    # The entrypoint (tsx vs compiled bin) and its on-disk location are still being
+    # frozen by the Tech Lead on t/2837; Shared Lib will hand over the exact invocation.
+    # Deliberately not guessed here — resolve once, in one place, when it lands.
+    throw (New-ActionableError `
+            -Goal     'Run the offline brief-export pipeline (local mode)' `
+            -Problem  'The shared lib/brief full-pipeline CLI (t/2837) has not landed yet, so local-mode export cannot run. Its entrypoint is being frozen by the Tech Lead.' `
+            -Location 'Resolve-BriefExportCli' `
+            -NextSteps @(
+                'Track t/2837 (Shared Lib brief full-pipeline CLI) — local mode activates when it lands',
+                'Once frozen, wire the invocation here: @{ Exe = ''node''|''npx''; ArgPrefix = @(...) }'
+            ))
+}

--- a/scripts/AITriad/Public/Export-TriadDebateBrief.ps1
+++ b/scripts/AITriad/Public/Export-TriadDebateBrief.ps1
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Export-TriadDebateBrief {
+    <#
+    .SYNOPSIS
+        Export a closed Triad debate to a presentation brief (Brief Export T8, spec §8).
+    .DESCRIPTION
+        Two modes:
+          - LOCAL (-Path): runs the brief pipeline OFFLINE against an exported debate JSON
+            via the shared lib/brief full-pipeline CLI (t/2837). No server, no auth, no
+            billing — the CI/offline path. -Model is required unless -SkipNarration.
+          - SERVER (-DebateId): REST client of the T6 export API. DEFERRED — the billable
+            export endpoint 403s anonymous and needs an AAD bearer token, gated on DevOps
+            enabling AAD Easy Auth (t/2839) + an entitlement policy (t/2814/t/2831). The
+            flow is designed (t/2806#3) and lands when those clear; today it errors with
+            that guidance.
+
+        Emits the artifact path as verbose; -PassThru returns a [TriadDeckExport] (field
+        parity with lib/brief/types.ts). Per-item errors are NON-TERMINATING (a pipeline of
+        many debates survives one failure); -ErrorAction Stop behaves normally. Error ids
+        are the frozen ExportErrorCode taxonomy shared with T6/T7.
+    .PARAMETER Path
+        (Local) Path to an exported debate JSON. Binds `FullName` from the pipeline.
+    .PARAMETER DebateId
+        (Server) Debate id. Binds Id/DebateId from `Get-TriadDebate -Phase Closed | ...`.
+    .PARAMETER Preset
+        policymaker (default) | conference | classroom.
+    .PARAMETER Model
+        Narrator model. Local mode: required unless -SkipNarration.
+    .PARAMETER CheckerModel
+        Optional fact-check model.
+    .PARAMETER SkipNarration
+        Deterministic brief with zero model calls.
+    .PARAMETER OutputPath
+        Output .pptx path (local mode). Default: the debate file name with .pptx.
+    .PARAMETER AccessToken
+        (Server) AAD bearer token → `Authorization: Bearer`. The cmdlet never spoofs
+        identity or sets principal headers. Alias -Token.
+    .PARAMETER BaseUrl
+        (Server) deployed base URL. Default: Get-TaxEditorBaseUrl.
+    .PARAMETER Force
+        Overwrite existing output files. NEVER bypasses the verify/lint gates.
+    .PARAMETER PassThru
+        Emit the [TriadDeckExport] object.
+    .PARAMETER TimeoutSec
+        Pipeline timeout. Default 300.
+    .OUTPUTS
+        [TriadDeckExport] (with -PassThru).
+    .EXAMPLE
+        Export-TriadDebateBrief -Path .\debate-abc.json -Model gemini-3.5-flash-lite -Preset conference
+    .EXAMPLE
+        Get-ChildItem *.json | Export-TriadDebateBrief -SkipNarration -PassThru
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Get-AITDebate
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Local', SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    # String form: module-scope classes aren't resolvable in a per-file-parsed
+    # [OutputType([...])] attribute (see Test-TaxEditorHealth). The body still emits
+    # a real [TriadDeckExport], resolved at runtime in module scope.
+    [OutputType('TriadDeckExport')]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'Local', ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [Alias('FullName')]
+        [string]$Path,
+
+        [Parameter(Mandatory, ParameterSetName = 'Server', ValueFromPipelineByPropertyName)]
+        [Alias('Id')]
+        [string]$DebateId,
+
+        [Parameter()]
+        [ValidateSet('policymaker', 'conference', 'classroom')]
+        [string]$Preset = 'policymaker',
+
+        [Parameter()]
+        [string]$Model,
+
+        [Parameter()]
+        [string]$CheckerModel,
+
+        [Parameter()]
+        [switch]$SkipNarration,
+
+        [Parameter(ParameterSetName = 'Local')]
+        [string]$OutputPath,
+
+        [Parameter(ParameterSetName = 'Server')]
+        [Alias('Token')]
+        [string]$AccessToken,
+
+        [Parameter(ParameterSetName = 'Server')]
+        [string]$BaseUrl,
+
+        [Parameter()]
+        [switch]$Force,
+
+        [Parameter()]
+        [switch]$PassThru,
+
+        [Parameter()]
+        [ValidateRange(1, 3600)]
+        [int]$TimeoutSec = 300
+    )
+
+    begin {
+        Set-StrictMode -Version Latest
+
+        # ExportErrorCode (lib/brief/types.ts) + local DebateFileInvalid → PS category.
+        $script:ExportErrorCategory = @{
+            DebateNotFound    = 'ObjectNotFound';    DebateNotClosed = 'InvalidOperation'
+            AuthFailure       = 'PermissionDenied';  ModelUnavailable = 'ResourceUnavailable'
+            SpecSchemaFailure = 'InvalidData';       TraceGateFailure = 'InvalidData'
+            SymmetryFailure   = 'InvalidData';       PptxLintFailure  = 'InvalidData'
+            RenderFailure     = 'InvalidData';       DebateFileInvalid = 'InvalidData'
+        }
+        $WriteExportError = {
+            param([string]$Id, [string]$Message, $TargetObject)
+            $cat = if ($ExportErrorCategory.ContainsKey($Id)) { $ExportErrorCategory[$Id] } else { 'NotSpecified' }
+            $rec = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new($Message), $Id,
+                [System.Management.Automation.ErrorCategory]$cat, $TargetObject)
+            $PSCmdlet.WriteError($rec)   # non-terminating; honors -ErrorAction Stop
+        }
+    }
+
+    process {
+        # ── Server mode: deferred pending AAD auth infra (t/2839) + policy ──────────
+        if ($PSCmdlet.ParameterSetName -eq 'Server') {
+            throw (New-ActionableError `
+                    -Goal     "Export debate '$DebateId' via the server" `
+                    -Problem  'Server-mode export is not yet available: the billable endpoint 403s anonymous and requires an AAD bearer token, gated on DevOps enabling AAD Easy Auth (t/2839) and an entitlement policy (t/2814/t/2831).' `
+                    -Location 'Export-TriadDebateBrief' `
+                    -NextSteps @(
+                        'Use local mode: Export-TriadDebateBrief -Path <exported debate JSON> ...',
+                        'Track t/2839 (AAD Easy Auth) for server-mode auth'
+                    ))
+        }
+
+        # ── Local mode (t/2837 full-pipeline CLI) ───────────────────────────────────
+        if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+            & $WriteExportError 'DebateFileInvalid' "Debate file not found: $Path" $Path; return
+        }
+        if (-not $SkipNarration -and -not $Model) {
+            & $WriteExportError 'ModelUnavailable' 'Local mode requires -Model unless -SkipNarration (no global model to inherit offline).' $Path; return
+        }
+
+        $Out = if ($OutputPath) { $OutputPath } else { [System.IO.Path]::ChangeExtension((Resolve-Path -LiteralPath $Path).Path, '.pptx') }
+        if ((Test-Path -LiteralPath $Out) -and -not $Force) {
+            & $WriteExportError 'RenderFailure' "Output already exists: $Out — use -Force to overwrite." $Out; return
+        }
+
+        $resolvedModel = if ($SkipNarration) { '(none — narration skipped)' } else { $Model }
+        if (-not $PSCmdlet.ShouldProcess($Path, "export brief (preset=$Preset, model=$resolvedModel)")) { return }
+
+        # Resolve the t/2837 CLI invocation. Returns @{ Exe; ArgPrefix } so the
+        # tsx-vs-compiled-bin decision (pending TL, t/2837) is abstracted away here;
+        # throws an actionable error until the CLI lands. Never hard-coded above.
+        $Inv = Resolve-BriefExportCli
+
+        # Frozen input flags (TL p/360#95): --path/--model/--preset/--skip-narration/--out.
+        $CliArgs = @('--path', $Path, '--preset', $Preset, '--out', $Out)
+        if ($SkipNarration) { $CliArgs += '--skip-narration' } else { $CliArgs += @('--model', $Model) }
+        if ($CheckerModel)  { $CliArgs += @('--checker-model', $CheckerModel) }
+        $AllArgs = @($Inv.ArgPrefix) + $CliArgs
+
+        $progressId = 2806
+        Write-Progress -Id $progressId -Activity "Exporting brief: $([System.IO.Path]::GetFileName($Path))" -Status 'Running pipeline' -PercentComplete 10
+        $StderrFile = [System.IO.Path]::GetTempFileName()
+        try {
+            $Stdout = & $Inv.Exe @AllArgs 2> $StderrFile
+            $Exit = $LASTEXITCODE
+            $Stderr = if (Test-Path $StderrFile) { Get-Content -Raw -Path $StderrFile } else { '' }
+        }
+        finally {
+            Remove-Item -Path $StderrFile -Force -ErrorAction SilentlyContinue
+            Write-Progress -Id $progressId -Activity "Exporting brief: $([System.IO.Path]::GetFileName($Path))" -Completed
+        }
+
+        # Stream WARN: lines (proposed output contract, t/2806#6 — pending Shared Lib confirm).
+        foreach ($Line in @(($Stderr -split "`n"))) {
+            if ($Line -match '^\s*WARN:\s*(.+)$') { Write-Warning $Matches[1].Trim() }
+        }
+
+        if ($Exit -ne 0) {
+            $ErrObj = $null
+            try {
+                $ErrLine = @(($Stderr -split "`n") | Where-Object { $_ -match '"errorCode"' }) | Select-Object -First 1
+                if ($ErrLine) { $ErrObj = $ErrLine | ConvertFrom-Json }
+            } catch { }
+            $Id  = if ($ErrObj -and $ErrObj.PSObject.Properties['errorCode']) { [string]$ErrObj.errorCode } else { 'RenderFailure' }
+            $Msg = if ($ErrObj -and $ErrObj.PSObject.Properties['message'])   { [string]$ErrObj.message }   else { "brief CLI exited with code $Exit" }
+            & $WriteExportError $Id $Msg $Path; return
+        }
+
+        $Deck = $null
+        try { $Deck = @($Stdout) -join "`n" | ConvertFrom-Json }
+        catch { & $WriteExportError 'SpecSchemaFailure' 'Could not parse the brief CLI output as TriadDeckExport JSON.' $Path; return }
+
+        $get = { param($n) if ($Deck -and $Deck.PSObject.Properties[$n]) { $Deck.$n } else { $null } }
+        $verdicts = @{}
+        $rawVerdicts = & $get 'verdicts'
+        if ($rawVerdicts) { foreach ($p in $rawVerdicts.PSObject.Properties) { $verdicts[$p.Name] = [int]$p.Value } }
+
+        $Export = [TriadDeckExport]@{
+            DebateId         = [string](& $get 'debateId')
+            Title            = [string](& $get 'title')
+            Preset           = [string](& $get 'preset')
+            Model            = [string](& $get 'model')
+            ModelSource      = [string](& $get 'modelSource')
+            CheckerModel     = [string](& $get 'checkerModel')
+            Path             = [string](& $get 'path')
+            SpecPath         = [string](& $get 'specPath')
+            ManifestPath     = [string](& $get 'manifestPath')
+            TraceCoveragePct = [double](& { $v = & $get 'traceCoveragePct'; if ($null -ne $v) { $v } else { 0.0 } })
+            Verdicts         = $verdicts
+            Warnings         = @(& { $w = & $get 'warnings'; if ($w) { $w } else { @() } })
+        }
+
+        Write-Verbose "Exported brief: $($Export.Path)"
+        if ($PassThru) { $Export }
+    }
+}

--- a/tests/Export-TriadDebateBrief.Tests.ps1
+++ b/tests/Export-TriadDebateBrief.Tests.ps1
@@ -1,0 +1,141 @@
+# Tag: debate (t/2806)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+# `using module` makes the module-scope [TriadDeckExport] class visible in this test
+# scope (Import-Module alone does not export classes). Must precede other statements.
+using module ..\scripts\AITriad\AITriad.psm1
+
+<#
+.SYNOPSIS
+    Export-TriadDebateBrief (Brief Export T8) — local mode + [TriadDeckExport] parity.
+.DESCRIPTION
+    Covers the frozen wire contract (field parity with lib/brief/types.ts), server-mode
+    deferral (t/2839), the local-mode error taxonomy, and the happy/failure paths against
+    a pwsh stub standing in for the t/2837 CLI (mocked via Resolve-BriefExportCli).
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    $script:TypesPath = Join-Path $PSScriptRoot '..' 'lib' 'brief' 'types.ts'
+
+    # A pwsh stub that impersonates the t/2837 CLI: emits a TriadDeckExport JSON line on
+    # stdout, WARN: lines + (on failure) a {errorCode,message} line on stderr.
+    $script:StubDir = Join-Path ([System.IO.Path]::GetTempPath()) "brief-stub-$(New-Guid)"
+    New-Item -ItemType Directory -Path $script:StubDir -Force | Out-Null
+
+    $script:OkStub = Join-Path $script:StubDir 'ok.ps1'
+    Set-Content -LiteralPath $script:OkStub -Encoding UTF8 -Value @'
+[Console]::Error.WriteLine("WARN: symmetry tolerance 12% (soft)")
+$deck = @{
+    debateId = "deb-123"; title = "Should we pause?"; preset = "policymaker"
+    model = "gemini-3.5-flash-lite"; modelSource = "Explicit"; checkerModel = $null
+    path = "C:\out\brief.pptx"; specPath = "C:\out\deck_spec.json"
+    manifestPath = "C:\out\audit-manifest.json"; traceCoveragePct = 100
+    verdicts = @{ Supported = 3; Disputed = 1 }; warnings = @("symmetry tolerance 12% (soft)")
+}
+Write-Output ($deck | ConvertTo-Json -Compress -Depth 6)
+exit 0
+'@
+
+    $script:FailStub = Join-Path $script:StubDir 'fail.ps1'
+    Set-Content -LiteralPath $script:FailStub -Encoding UTF8 -Value @'
+[Console]::Error.WriteLine("WARN: partial extraction")
+[Console]::Error.WriteLine((@{ errorCode = "TraceGateFailure"; message = "trace coverage 87% < 100%" } | ConvertTo-Json -Compress))
+exit 3
+'@
+
+    $script:PwshExe = (Get-Process -Id $PID).Path
+
+    function New-DebateFile {
+        $f = Join-Path $script:StubDir "debate-$(New-Guid).json"
+        Set-Content -LiteralPath $f -Value '{"id":"deb-123","phase":"closed"}' -Encoding UTF8
+        $f
+    }
+}
+
+AfterAll {
+    Remove-Item -LiteralPath $script:StubDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Export-TriadDebateBrief' -Tag 'debate' {
+
+    Context '[TriadDeckExport] wire-contract parity with lib/brief/types.ts' {
+        It 'has exactly the fields of the TS TriadDeckExport interface (case-insensitive)' {
+            $ts = Get-Content -Raw -LiteralPath $script:TypesPath
+            $m = [regex]::Match($ts, 'export interface TriadDeckExport \{(?<body>[^}]*)\}')
+            $m.Success | Should -BeTrue -Because 'the TS interface must exist to compare against'
+            $tsFields = [regex]::Matches($m.Groups['body'].Value, '(?m)^\s*(?<name>\w+)\??:') |
+                ForEach-Object { $_.Groups['name'].Value.ToLowerInvariant() } | Sort-Object
+
+            $psFields = ([TriadDeckExport].GetProperties() | ForEach-Object { $_.Name.ToLowerInvariant() }) | Sort-Object
+
+            ($psFields -join ',') | Should -Be ($tsFields -join ',') -Because 'PS class and TS interface are one wire contract'
+        }
+    }
+
+    Context 'Server mode (deferred, t/2839)' {
+        It 'throws an actionable error naming the auth gate and NOT touching the CLI' {
+            Mock -ModuleName AITriad Resolve-BriefExportCli { throw 'CLI must not be resolved in server mode' }
+            { Export-TriadDebateBrief -DebateId 'deb-123' -Preset policymaker -ErrorAction Stop } |
+                Should -Throw -ExpectedMessage '*t/2839*'
+            Should -Invoke -ModuleName AITriad Resolve-BriefExportCli -Times 0
+        }
+    }
+
+    Context 'Local mode — input guards (non-terminating error taxonomy)' {
+        It 'emits DebateFileInvalid for a missing -Path' {
+            $err = $null
+            Export-TriadDebateBrief -Path (Join-Path $script:StubDir 'nope.json') -Model m -ErrorVariable err -ErrorAction SilentlyContinue
+            @($err).Count | Should -BeGreaterThan 0
+            $err[0].FullyQualifiedErrorId | Should -Match 'DebateFileInvalid'
+        }
+
+        It 'emits ModelUnavailable when neither -Model nor -SkipNarration is given' {
+            $f = New-DebateFile
+            $err = $null
+            Export-TriadDebateBrief -Path $f -ErrorVariable err -ErrorAction SilentlyContinue
+            $err[0].FullyQualifiedErrorId | Should -Match 'ModelUnavailable'
+        }
+    }
+
+    Context 'Local mode — happy path' {
+        It 'returns a [TriadDeckExport] parsed from CLI stdout and streams WARN: lines' {
+            Mock -ModuleName AITriad Resolve-BriefExportCli {
+                @{ Exe = $script:PwshExe; ArgPrefix = @('-NoProfile', '-File', $script:OkStub) }
+            }
+            $f = New-DebateFile
+            $out = Join-Path $script:StubDir 'out.pptx'
+            $warn = $null
+            $res = Export-TriadDebateBrief -Path $f -Model gemini-3.5-flash-lite -OutputPath $out -PassThru -WarningVariable warn -WarningAction SilentlyContinue
+            $res | Should -BeOfType ([TriadDeckExport])
+            $res.DebateId | Should -Be 'deb-123'
+            $res.TraceCoveragePct | Should -Be 100
+            $res.Verdicts['Supported'] | Should -Be 3
+            @($warn) -join ';' | Should -Match 'symmetry tolerance'
+        }
+
+        It 'does not invoke the CLI under -WhatIf' {
+            Mock -ModuleName AITriad Resolve-BriefExportCli { throw 'must not run under -WhatIf' }
+            $f = New-DebateFile
+            { Export-TriadDebateBrief -Path $f -Model m -OutputPath (Join-Path $script:StubDir 'wi.pptx') -WhatIf } | Should -Not -Throw
+            Should -Invoke -ModuleName AITriad Resolve-BriefExportCli -Times 0
+        }
+    }
+
+    Context 'Local mode — CLI failure maps the wire errorCode' {
+        It 'surfaces the CLI {errorCode} as the non-terminating error id' {
+            Mock -ModuleName AITriad Resolve-BriefExportCli {
+                @{ Exe = $script:PwshExe; ArgPrefix = @('-NoProfile', '-File', $script:FailStub) }
+            }
+            $f = New-DebateFile
+            $err = $null
+            Export-TriadDebateBrief -Path $f -Model m -OutputPath (Join-Path $script:StubDir 'f.pptx') -ErrorVariable err -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+            $err[0].FullyQualifiedErrorId | Should -Match 'TraceGateFailure'
+        }
+    }
+}


### PR DESCRIPTION
## Brief Export T8 — PowerShell surface (Surface C) for `Export-TriadDebateBrief`

Closes the PS half of t/2806. **Draft** — gated on the t/2837 full-pipeline CLI landing + its entrypoint freeze (Shared Lib is building it; output contract confirmed in t/2837#3).

### What lands here
- **`[TriadDeckExport]` class** (`AITriad.psm1`) — wire-contract parity with `lib/brief/types.ts` (12 fields), enforced by a Pester parity gate.
- **`Export-TriadDebateBrief`** (`Public/`) with two param sets:
  - **Local (`-Path`)** — runs the offline `lib/brief` pipeline via the t/2837 CLI. Frozen input flags (TL): `--path/--model/--preset/--skip-narration/--out`. The tsx-vs-bin entrypoint is isolated behind private **`Resolve-BriefExportCli`**, which throws an actionable error until t/2837 lands (never hard-coded).
  - **Server (`-DebateId`)** — present but **deferred**: the billable T6 endpoint 403s anonymous and needs an AAD bearer token, gated on AAD Easy Auth (**t/2839**) + entitlement policy (t/2814/t/2831). Errors with that guidance. **Never spoofs identity or injects `x-ms-client-principal`.** PDF omitted (Electron-only).
- Non-terminating per-item errors keyed to the frozen `ExportErrorCode` taxonomy (+ CLI-local `DebateFileInvalid`), so a pipeline of debates survives one failure. `SupportsShouldProcess`, `-PassThru/-Force/-SkipNarration`, `WARN:` streaming to `Write-Warning`.
- Registered in `AITriad.psd1` + `AITriad.psm1`; `docs/cmdlet-reference.md` entry.

### Tests
`tests/Export-TriadDebateBrief.Tests.ps1` — 7 tests, all green (parity gate, server-deferral, both input guards, happy path with `[TriadDeckExport]` typing + WARN streaming, `-WhatIf` no-op, CLI-failure errorCode mapping). Module-parity suite (`AITriad.Module.Tests.ps1`, 38) still green with the new function. `Test-ModuleManifest` passes.

### Gating / un-draft criteria
1. t/2837 CLI lands and its entrypoint is frozen → wire `Resolve-BriefExportCli` to the real invocation.
2. (Server mode, separate follow-up) t/2839 + entitlement policy clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)