### PR TITLE
feat(ui): animated loading indicator for disk-backed prompts (t/2823)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/PromptInspector.css
+++ b/taxonomy-editor/src/renderer/components/chat/PromptInspector.css
@@ -13,7 +13,7 @@
 }
 
 .pi-load-timeout {
-  color: var(--color-danger, #dc2626);
+  color: var(--danger);
   font-style: italic;
   font-size: var(--text-sm, 0.875rem);
 }

--- a/taxonomy-editor/src/renderer/components/chat/PromptInspector.css
+++ b/taxonomy-editor/src/renderer/components/chat/PromptInspector.css
@@ -1,0 +1,19 @@
+/* PromptInspector — disk-load activity indicator (t/2823) */
+
+@keyframes pi-load-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.pi-load-live {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: var(--text-sm, 0.875rem);
+  animation: pi-load-pulse 1.4s ease-in-out infinite;
+}
+
+.pi-load-timeout {
+  color: var(--color-danger, #dc2626);
+  font-style: italic;
+  font-size: var(--text-sm, 0.875rem);
+}

--- a/taxonomy-editor/src/renderer/components/chat/PromptInspector.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/PromptInspector.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import './PromptInspector.css';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { PROMPT_CATALOG, type PromptCatalogEntry, type PromptGroup, type DataSourceId } from '../../data/promptCatalog';
 import { useDebateStore } from '../../hooks/useDebateStore';
@@ -245,6 +246,27 @@ function PromptSelectorPane({
   );
 }
 
+function DiskLoadingIndicator() {
+  const [elapsed, setElapsed] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setElapsed(s => s + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (elapsed >= 30) {
+    return (
+      <span className="pi-load-timeout">
+        Load timed out after 30s — check that the project path is accessible
+      </span>
+    );
+  }
+  return (
+    <span className="pi-load-live">
+      {elapsed > 0 ? `Loading from disk… ${elapsed}s` : 'Loading from disk…'}
+    </span>
+  );
+}
+
 function TemplateSection({
   selected, showTemplate, setShowTemplate, psPromptContent, psPromptLoading,
 }: {
@@ -269,7 +291,7 @@ function TemplateSection({
                 ~{estimateTokens(selected.promptFiles.map(f => psPromptContent[f] ?? '').join('\n')).toLocaleString()} tokens
               </span>
             )}
-            {psPromptLoading && <span className="pi-template-tokens">loading...</span>}
+            {psPromptLoading && <span className="pi-load-live pi-template-tokens">loading…</span>}
           </button>
           {showTemplate && selected.promptFiles.map(fileName => (
             <div key={fileName} className="pi-prompt-file">
@@ -282,7 +304,7 @@ function TemplateSection({
               <pre className="pi-template">
                 {psPromptContent[fileName]
                   ? highlightPsPlaceholders(psPromptContent[fileName])
-                  : 'Loading...'}
+                  : <DiskLoadingIndicator />}
               </pre>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Replaces the static `Loading...` string in the PS prompt file `<pre>` with a `DiskLoadingIndicator` component
- Shows elapsed seconds while loading (e.g. "Loading from disk… 3s") with a CSS pulse animation, making it visually distinct from a static/frozen state
- After 30s shows a timeout error message so a hung load is distinguishable from an active one
- New `PromptInspector.css` for the animation (styles.css is frozen per AGENTS.md)

## Self-cert
Self-certifying under /trivial-change.
Change: UI-only — animated disk-load indicator in PromptInspector
Files: `PromptInspector.tsx` (+24/-2), `PromptInspector.css` (+19/0)
Lines changed: 43 additions, 2 deletions
Verify gate: PromptInspector.test.tsx — 11/11 passed at 9251723c; pre-existing lib/brief TS errors unrelated to this change (reproduced on main HEAD)
Deviations: none

## Test plan
- [ ] Select a PowerShell-backed prompt (POV Summary, Attribute Extraction, etc.) in the Prompt Inspector — content pane should show the pulsing "Loading from disk…" text while the file loads, then the file content once loaded
- [ ] Verify that if a load stalls for 30s, the timeout message appears
- [ ] All 11 existing PromptInspector unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)