### PR TITLE
fix(prompt-catalog): correct stale cmdlet attributions (t/2836)

### DIFF
--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -628,7 +628,7 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     source: 'AITriad/Prompts/fallacy-analysis.prompt',
     template: '(Loading from disk...)',
     group: 'powershell',
-    purpose: 'Used by Invoke-FallacyAnalysis. Identifies possible fallacies with tiered classification (formal, informal_structural, informal_contextual, cognitive_bias) and confidence levels.',
+    purpose: 'Used by Find-PossibleFallacy. Identifies possible fallacies with tiered classification (formal, informal_structural, informal_contextual, cognitive_bias) and confidence levels.',
     applicableDataSources: ['taxonomyNodes'],
     promptFiles: ['fallacy-analysis', 'fallacy-analysis-schema'],
     psParameters: [
@@ -659,7 +659,7 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     source: 'AITriad/Prompts/metadata-extraction.prompt',
     template: '(Loading from disk...)',
     group: 'powershell',
-    purpose: 'Used by Import-AITriadDocument. Extracts structured metadata from source documents during ingestion: title, authors, publication date, abstract, topic tags, POV tags.',
+    purpose: 'Runs during document ingestion via the enrichment.metadata-extraction usage (AIEnrich.psm1, Invoke-AIByUsage). Extracts structured metadata from source documents: title, authors, publication date, abstract, topic tags, POV tags.',
     applicableDataSources: ['sourceDocument'],
     promptFiles: ['metadata-extraction'],
     psParameters: [


### PR DESCRIPTION
## Summary
Content-correctness audit of the ~72 pre-#1266 `promptCatalog.ts` entries (t/2836). Fixes two stale `purpose` attributions found in the `ps-*` arm (verified against `origin/main`):

- **`ps-fallacy-analysis`** — "Used by Invoke-FallacyAnalysis" → **Find-PossibleFallacy** (no `Invoke-FallacyAnalysis` exists).
- **`ps-metadata-extraction`** — "Used by Import-AITriadDocument" → runs via the **`enrichment.metadata-extraction` usage** (`AIEnrich.psm1`, `Invoke-AIByUsage`).

String-only edits (tsc-safe).

## Audit result (full)
- **All 19 `ps-*` `promptFiles` lists verified correct** against each cmdlet's `Get-Prompt` concatenation on `origin/main`. (A `topic-frequency-label-schema` "omission" was a **false positive** from the shared checkout being behind `origin/main` — already correct upstream.)
- **TS-builder entries** (`debate-*`, `research`, `taxonomy`, `chat-*`) are compile-checked: each `template:` executes its builder at module load, so arg-count/rename drift is a `renderer-tsc` failure — impossible on green `main`. `(Template requires runtime context…)` entries are static/runtime-only, as designed.
- **1 orphan** — `ps-hierarchy-placement` describes `hierarchy-placement[.-single].prompt`, which has **no loader anywhere** in the repo. Tracked separately (deprecate-vs-wire decision + PS-owned prompt-file disposition).

## Provenance
No metric/threshold/lexicon change — documentation-accuracy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)