### PR TITLE
feat(brief): Brief Export T7 — web-first GUI (dialog + progress + exports list) (t/2805)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -76,6 +76,22 @@ function rejectOpEdIpc(goal: string, method: string): Promise<never> {
   }));
 }
 
+// Brief Export (t/2805, T7) is web-only for v1. Desktop parity is tracked as a follow-up:
+// the Electron IPC handler will call the shared `runBriefPipeline` in-process (blocked by
+// t/2837), NOT a reimplementation. Until then, reject LOUDLY (never a silent empty) so a
+// desktop user is told exactly where to go — the UI also gates the menu item (see DebateTab).
+function rejectBriefWebOnly(goal: string, method: string): Promise<never> {
+  return Promise.reject(new ActionableError({
+    goal: `Brief Export: ${goal}`,
+    problem: `Brief export runs in the AITriad web app; the desktop backend (${method}) is not available in this build yet.`,
+    location: 'electron-bridge · Brief Export',
+    nextSteps: [
+      'Open this debate in the AITriad web app to export a brief.',
+      'Desktop parity is tracked (blocked by the shared runBriefPipeline, t/2837).',
+    ],
+  }));
+}
+
 // Same-window diagnostics callbacks for the in-app drawer (mobile/narrow).
 // When a popout BrowserWindow is open, IPC delivers state to it directly.
 // When the drawer is used instead, we also deliver to local callbacks.
@@ -289,6 +305,13 @@ export const api: AppAPI = {
   exportDebateToFile: (s, format, exportOptions) => window.electronAPI.exportDebateToFile(s, format, exportOptions),
   loadDebateComments: (id) => window.electronAPI.loadDebateComments(id),
   saveDebateComments: (id, data) => window.electronAPI.saveDebateComments(id, data),
+
+  // Brief Export (t/2805, T7) — web-only v1; desktop parity tracked (blocked by t/2837 runBriefPipeline).
+  createBriefExport: () => rejectBriefWebOnly('start a brief export', 'createBriefExport'),
+  getBriefExportJob: () => rejectBriefWebOnly('check a brief export job', 'getBriefExportJob'),
+  listBriefExports: () => rejectBriefWebOnly('list brief exports', 'listBriefExports'),
+  downloadBriefArtifact: () => rejectBriefWebOnly('download a brief export artifact', 'downloadBriefArtifact'),
+  deleteBriefExport: () => rejectBriefWebOnly('delete a brief export', 'deleteBriefExport'),
 
   // Op-Ed Studio (t/2576) — feature-detected IPC (lands with t/2575); see opEdIpc above.
   listOpEdSets: () => opEdIpc().listOpEdSets?.() ?? rejectOpEdIpc('list op-eds', 'listOpEdSets'),

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -83,6 +83,7 @@ import type { DebateDelta as _DebateDelta } from '@lib/debate/types';
 export type DebateDelta = _DebateDelta;
 
 import type { OpEdSet, OpEdSetSummary, PovKey } from '../../../../lib/oped/types';
+import type { BriefPreset, ExportJobState, ExportErrorCode, BriefArtifactName } from '../../../../lib/brief/types';
 
 /** Op-Ed generation params (PR#2) — maps to New-OpEd cmdlet params; topic + voices
  *  travel separately in the payload (one New-OpEd call per selected voice). */
@@ -103,6 +104,43 @@ export interface CreateOpEdParams {
 export interface CreateOpEdPayload { topic: string; url?: string; params: CreateOpEdParams; voices: PovKey[] }
 /** One 3-stage progress tick from the Electron generation IPC (t/2575 `oped-progress`). */
 export interface OpEdProgressEvent { set_id: string; voice: string; stage: string; error?: string }
+
+// Brief Export (t/2805, T7) — client shapes of the T6 REST API (server: routes/briefExports.ts).
+// Consumes T6's frozen job-state names, artifact names, and error taxonomy verbatim.
+export interface BriefExportRequest {
+  preset: BriefPreset;
+  /** Resolved model id; omit to let the server use its default. */
+  model?: string;
+  /** Provenance hint for the server's §6 resolution — 'global' = "Use current model". */
+  modelSource?: 'global' | 'explicit';
+  /** Optional maker-checker model (independently resolved server-side). */
+  checkerModel?: string;
+  options?: { skipNarration?: boolean };
+}
+export interface BriefExportJobView {
+  status: ExportJobState;
+  progressPct: number;
+  warnings: string[];
+  error: string | null;
+  errorCode: ExportErrorCode | null;
+  exportId: string | null;
+}
+export interface BriefExportRecord {
+  exportId: string;
+  debateId: string;
+  title: string;
+  preset: BriefPreset;
+  status: 'done' | 'failed';
+  errorCode?: ExportErrorCode;
+  narratorModel: string;
+  narratorModelSource: string;
+  checkerModel?: string | null;
+  formats: string[];
+  artifacts: BriefArtifactName[];
+  traceCoveragePct: number;
+  warnings: string[];
+  createdAt: string;
+}
 
 import type { EdgesFile as _EdgesFile } from '@lib/debate/taxonomyTypes';
 export type EdgesFile = _EdgesFile;
@@ -290,6 +328,13 @@ export interface AppAPI {
   exportDebateToFile: (session: unknown, format?: 'json' | 'markdown' | 'text' | 'pdf' | 'package', exportOptions?: { includeTaxonomyRefs?: boolean; includeReasoning?: boolean }) => Promise<{ cancelled: boolean; filePath?: string }>;
   loadDebateComments: (debateId: string) => Promise<unknown>;
   saveDebateComments: (debateId: string, data: unknown) => Promise<void>;
+
+  // --- Brief Export (t/2805, T7 — client of the T6 REST API; web-only v1, Electron parity tracked) ---
+  createBriefExport: (debateId: string, body: BriefExportRequest) => Promise<{ jobId: string }>;
+  getBriefExportJob: (jobId: string) => Promise<BriefExportJobView>;
+  listBriefExports: (debateId: string) => Promise<BriefExportRecord[]>;
+  downloadBriefArtifact: (exportId: string, name: BriefArtifactName) => Promise<Blob>;
+  deleteBriefExport: (exportId: string) => Promise<void>;
 
   // --- Op-Ed Studio (t/2576; personal library — submit/copy route via community store) ---
   listOpEdSets: () => Promise<OpEdSetSummary[]>;

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -5,7 +5,7 @@
  * Web bridge — implements AppAPI via REST and WebSocket calls to the server.
  * Used when the app runs in a browser served by the container.
  */
-import type { AppAPI, SourceDocumentResolution, DebateDelta, UserPreferences } from './types';
+import type { AppAPI, SourceDocumentResolution, DebateDelta, UserPreferences, BriefExportJobView, BriefExportRecord } from './types';
 import { instrumentBridge } from './instrumentBridge';
 import { makeCancellationError } from './cancellation';
 import { ActionableError } from '@lib/debate/errors';
@@ -1016,6 +1016,22 @@ const rawApi: AppAPI = {
   deleteDebateSession: (id) => del(`/api/debates/${encodeURIComponent(id)}`).then(() => {}),
   loadDebateComments: (id) => get(`/api/debates/${encodeURIComponent(id)}/comments`),
   saveDebateComments: (id, data) => put(`/api/debates/${encodeURIComponent(id)}/comments`, data).then(() => {}),
+
+  // Brief Export (t/2805, T7) — client of the T6 REST API (server: routes/briefExports.ts).
+  createBriefExport: (debateId, body) => post<{ jobId: string }>(`/api/debates/${encodeURIComponent(debateId)}/exports`, body),
+  getBriefExportJob: (jobId) => get<BriefExportJobView>(`/api/export-jobs/${encodeURIComponent(jobId)}`),
+  listBriefExports: (debateId) => get<BriefExportRecord[]>(`/api/debates/${encodeURIComponent(debateId)}/exports`),
+  downloadBriefArtifact: async (exportId, name) => {
+    // Binary-capable read (pptx is bytes; json artifacts also come back as a Blob) — mirrors
+    // downloadCaseAttachment. The route validates the artifact name; we encode defensively.
+    const res = await resilientFetch(
+      `/api/exports/${encodeURIComponent(exportId)}/artifacts/${encodeURIComponent(name)}`,
+      {}, { timeoutMs: 30_000, maxRetries: 1, critical: true, category: 'read' as EndpointCategory },
+    );
+    if (!res.ok) throw new Error(`Artifact download failed: ${res.status}`);
+    return res.blob();
+  },
+  deleteBriefExport: (exportId) => del(`/api/exports/${encodeURIComponent(exportId)}`).then(() => {}),
 
   // Op-Ed Studio (t/2576) — real routes against t/2573's server API (on main). The
   // personal-library path is /api/oped-sets (t/2599 live-smoke found the bridge had

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.css
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.css
@@ -1,0 +1,88 @@
+/* Brief Export dialog (t/2805, T7). Co-located per the styles.css-frozen rule.
+   All colors use var(--token, fallback) so the contrast gate never hits an undefined token. */
+
+.bx-overlay {
+  position: fixed; inset: 0; z-index: 1000;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--overlay-bg, rgba(0, 0, 0, 0.5));
+}
+.bx-dialog {
+  width: min(560px, 92vw); max-height: 88vh; overflow-y: auto;
+  background: var(--panel-bg, #ffffff);
+  color: var(--text-color, #1a1a1a);
+  border: 1px solid var(--border-color, #d0d0d0);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px var(--shadow-color, rgba(0, 0, 0, 0.25));
+  padding: 20px;
+}
+.bx-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+.bx-title { font-size: 1.1rem; margin: 0; }
+.bx-close {
+  background: none; border: none; font-size: 1.5rem; line-height: 1; cursor: pointer;
+  color: var(--text-muted, #6b7280);
+}
+.bx-close:hover { color: var(--text-color, #1a1a1a); }
+
+.bx-notice {
+  background: var(--warning-bg, #fff7ed);
+  color: var(--warning-text, #9a3412);
+  border: 1px solid var(--warning-border, #fed7aa);
+  border-radius: 6px; padding: 10px 12px; margin-bottom: 12px; font-size: 0.9rem;
+}
+.bx-notice-sub { color: var(--text-muted, #6b7280); }
+
+.bx-form { display: flex; flex-direction: column; gap: 14px; }
+.bx-fieldset { border: 1px solid var(--border-color, #d0d0d0); border-radius: 6px; padding: 10px 12px; margin: 0; }
+.bx-fieldset legend { font-weight: 600; padding: 0 6px; }
+.bx-radio { display: grid; grid-template-columns: auto 1fr; align-items: baseline; gap: 6px 8px; padding: 4px 0; }
+.bx-radio-label { font-weight: 500; }
+.bx-hint { grid-column: 2; color: var(--text-muted, #6b7280); font-size: 0.82rem; }
+
+.bx-field { display: flex; flex-direction: column; gap: 4px; }
+.bx-field label { font-weight: 500; font-size: 0.9rem; }
+.bx-field select {
+  padding: 6px 8px; border-radius: 6px;
+  border: 1px solid var(--border-color, #d0d0d0);
+  background: var(--input-bg, #ffffff); color: var(--text-color, #1a1a1a);
+}
+.bx-indent { margin-left: 22px; }
+.bx-check { display: flex; align-items: center; gap: 8px; font-size: 0.9rem; }
+.bx-formats { font-size: 0.82rem; color: var(--text-muted, #6b7280); margin: 0; }
+
+.bx-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
+.bx-btn-primary {
+  padding: 7px 16px; border-radius: 6px; border: none; cursor: pointer; font-weight: 600;
+  background: var(--accent-color, #2563eb); color: var(--accent-text, #ffffff);
+}
+.bx-btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.bx-btn-ghost {
+  padding: 7px 14px; border-radius: 6px; cursor: pointer;
+  background: transparent; color: var(--text-color, #1a1a1a);
+  border: 1px solid var(--border-color, #d0d0d0);
+}
+
+.bx-error, .bx-failed-msg {
+  background: var(--error-bg, #fef2f2); color: var(--error-text, #991b1b);
+  border: 1px solid var(--error-border, #fecaca);
+  border-radius: 6px; padding: 8px 10px; font-size: 0.85rem;
+  white-space: pre-wrap; word-break: break-word; margin: 0;
+}
+
+.bx-progress { display: flex; flex-direction: column; gap: 10px; padding: 16px 0; }
+.bx-phase { font-weight: 600; }
+.bx-bar { height: 8px; border-radius: 4px; background: var(--track-bg, #e5e7eb); overflow: hidden; }
+.bx-bar-fill { height: 100%; background: var(--accent-color, #2563eb); transition: width 0.3s ease; }
+
+.bx-warnings { margin: 4px 0; padding-left: 18px; color: var(--warning-text, #9a3412); font-size: 0.85rem; }
+
+.bx-done-head, .bx-failed-head { font-weight: 700; margin-bottom: 10px; }
+.bx-done-head { color: var(--success-text, #15803d); }
+.bx-failed-head { color: var(--error-text, #991b1b); }
+.bx-artifacts { list-style: none; margin: 0 0 10px; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.bx-artifacts li {
+  display: flex; align-items: center; justify-content: space-between;
+  border: 1px solid var(--border-color, #d0d0d0); border-radius: 6px; padding: 8px 10px;
+}
+.bx-artifact-name { font-size: 0.9rem; }
+.bx-dl { padding: 4px 12px; }
+.bx-meta { color: var(--text-muted, #6b7280); font-size: 0.82rem; margin-bottom: 10px; }

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.css
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.css
@@ -1,88 +1,90 @@
 /* Brief Export dialog (t/2805, T7). Co-located per the styles.css-frozen rule.
-   All colors use var(--token, fallback) so the contrast gate never hits an undefined token. */
+   Uses only DEFINED theme tokens (theme-token-completeness gate t/2567 — an undefined
+   custom property with a CSS fallback would render that fallback in every theme, i.e.
+   not theme-aware). */
 
 .bx-overlay {
   position: fixed; inset: 0; z-index: 1000;
   display: flex; align-items: center; justify-content: center;
-  background: var(--overlay-bg, rgba(0, 0, 0, 0.5));
+  background: rgba(0, 0, 0, 0.5);
 }
 .bx-dialog {
   width: min(560px, 92vw); max-height: 88vh; overflow-y: auto;
-  background: var(--panel-bg, #ffffff);
-  color: var(--text-color, #1a1a1a);
-  border: 1px solid var(--border-color, #d0d0d0);
-  border-radius: 8px;
-  box-shadow: 0 8px 32px var(--shadow-color, rgba(0, 0, 0, 0.25));
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--dialog-shadow);
   padding: 20px;
 }
 .bx-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
-.bx-title { font-size: 1.1rem; margin: 0; }
+.bx-title { font-size: var(--text-lg); margin: 0; }
 .bx-close {
   background: none; border: none; font-size: 1.5rem; line-height: 1; cursor: pointer;
-  color: var(--text-muted, #6b7280);
+  color: var(--text-muted);
 }
-.bx-close:hover { color: var(--text-color, #1a1a1a); }
+.bx-close:hover { color: var(--text-primary); }
 
 .bx-notice {
-  background: var(--warning-bg, #fff7ed);
-  color: var(--warning-text, #9a3412);
-  border: 1px solid var(--warning-border, #fed7aa);
-  border-radius: 6px; padding: 10px 12px; margin-bottom: 12px; font-size: 0.9rem;
+  background: var(--settings-warn-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm); padding: 10px 12px; margin-bottom: 12px; font-size: var(--text-sm);
 }
-.bx-notice-sub { color: var(--text-muted, #6b7280); }
+.bx-notice-sub { color: var(--text-muted); }
 
 .bx-form { display: flex; flex-direction: column; gap: 14px; }
-.bx-fieldset { border: 1px solid var(--border-color, #d0d0d0); border-radius: 6px; padding: 10px 12px; margin: 0; }
+.bx-fieldset { border: 1px solid var(--border-color); border-radius: var(--radius-sm); padding: 10px 12px; margin: 0; }
 .bx-fieldset legend { font-weight: 600; padding: 0 6px; }
 .bx-radio { display: grid; grid-template-columns: auto 1fr; align-items: baseline; gap: 6px 8px; padding: 4px 0; }
 .bx-radio-label { font-weight: 500; }
-.bx-hint { grid-column: 2; color: var(--text-muted, #6b7280); font-size: 0.82rem; }
+.bx-hint { grid-column: 2; color: var(--text-muted); font-size: var(--text-xs); }
 
 .bx-field { display: flex; flex-direction: column; gap: 4px; }
-.bx-field label { font-weight: 500; font-size: 0.9rem; }
+.bx-field label { font-weight: 500; font-size: var(--text-sm); }
 .bx-field select {
-  padding: 6px 8px; border-radius: 6px;
-  border: 1px solid var(--border-color, #d0d0d0);
-  background: var(--input-bg, #ffffff); color: var(--text-color, #1a1a1a);
+  padding: 6px 8px; border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  background: var(--bg-input); color: var(--text-primary);
 }
 .bx-indent { margin-left: 22px; }
-.bx-check { display: flex; align-items: center; gap: 8px; font-size: 0.9rem; }
-.bx-formats { font-size: 0.82rem; color: var(--text-muted, #6b7280); margin: 0; }
+.bx-check { display: flex; align-items: center; gap: 8px; font-size: var(--text-sm); }
+.bx-formats { font-size: var(--text-xs); color: var(--text-muted); margin: 0; }
 
 .bx-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
 .bx-btn-primary {
-  padding: 7px 16px; border-radius: 6px; border: none; cursor: pointer; font-weight: 600;
-  background: var(--accent-color, #2563eb); color: var(--accent-text, #ffffff);
+  padding: 7px 16px; border-radius: var(--radius-sm); border: none; cursor: pointer; font-weight: 600;
+  background: var(--accent-bg); color: var(--accent-text);
 }
 .bx-btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 .bx-btn-ghost {
-  padding: 7px 14px; border-radius: 6px; cursor: pointer;
-  background: transparent; color: var(--text-color, #1a1a1a);
-  border: 1px solid var(--border-color, #d0d0d0);
+  padding: 7px 14px; border-radius: var(--radius-sm); cursor: pointer;
+  background: transparent; color: var(--text-primary);
+  border: 1px solid var(--border-color);
 }
 
 .bx-error, .bx-failed-msg {
-  background: var(--error-bg, #fef2f2); color: var(--error-text, #991b1b);
-  border: 1px solid var(--error-border, #fecaca);
-  border-radius: 6px; padding: 8px 10px; font-size: 0.85rem;
+  background: var(--error-bg); color: var(--error-text);
+  border: 1px solid var(--error-border);
+  border-radius: var(--radius-sm); padding: 8px 10px; font-size: var(--text-sm);
   white-space: pre-wrap; word-break: break-word; margin: 0;
 }
 
 .bx-progress { display: flex; flex-direction: column; gap: 10px; padding: 16px 0; }
 .bx-phase { font-weight: 600; }
-.bx-bar { height: 8px; border-radius: 4px; background: var(--track-bg, #e5e7eb); overflow: hidden; }
-.bx-bar-fill { height: 100%; background: var(--accent-color, #2563eb); transition: width 0.3s ease; }
+.bx-bar { height: 8px; border-radius: 4px; background: var(--bg-secondary); overflow: hidden; }
+.bx-bar-fill { height: 100%; background: var(--accent-bg); transition: width 0.3s ease; }
 
-.bx-warnings { margin: 4px 0; padding-left: 18px; color: var(--warning-text, #9a3412); font-size: 0.85rem; }
+.bx-warnings { margin: 4px 0; padding-left: 18px; color: var(--text-secondary); font-size: var(--text-sm); }
 
 .bx-done-head, .bx-failed-head { font-weight: 700; margin-bottom: 10px; }
-.bx-done-head { color: var(--success-text, #15803d); }
-.bx-failed-head { color: var(--error-text, #991b1b); }
+.bx-done-head { color: var(--success); }
+.bx-failed-head { color: var(--danger); }
 .bx-artifacts { list-style: none; margin: 0 0 10px; padding: 0; display: flex; flex-direction: column; gap: 6px; }
 .bx-artifacts li {
   display: flex; align-items: center; justify-content: space-between;
-  border: 1px solid var(--border-color, #d0d0d0); border-radius: 6px; padding: 8px 10px;
+  border: 1px solid var(--border-color); border-radius: var(--radius-sm); padding: 8px 10px;
 }
-.bx-artifact-name { font-size: 0.9rem; }
+.bx-artifact-name { font-size: var(--text-sm); }
 .bx-dl { padding: 4px 12px; }
-.bx-meta { color: var(--text-muted, #6b7280); font-size: 0.82rem; margin-bottom: 10px; }
+.bx-meta { color: var(--text-muted); font-size: var(--text-xs); margin-bottom: 10px; }

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T7 dialog tests (t/2805): closed-gate, model-provenance mapping (global vs explicit),
+// poll→progress→artifacts, and verbatim failure. The T6 API is mocked via @bridge.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const { createBriefExport, getBriefExportJob, listBriefExports, downloadBriefArtifact } = vi.hoisted(() => ({
+  createBriefExport: vi.fn(), getBriefExportJob: vi.fn(), listBriefExports: vi.fn(), downloadBriefArtifact: vi.fn(),
+}));
+vi.mock('@bridge', () => ({
+  api: { createBriefExport, getBriefExportJob, listBriefExports, downloadBriefArtifact },
+  isElectronMode: () => false,
+}));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+vi.mock('../../hooks/useTaxonomyStore', () => ({
+  AI_BACKENDS: [{ value: 'gemini', label: 'Google Gemini' }],
+  MODELS_BY_BACKEND: { gemini: [{ value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' }, { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' }] },
+  useTaxonomyStore: () => ({ geminiModel: 'gemini-2.5-flash' }),
+}));
+
+import { BriefExportDialog } from './BriefExportDialog';
+
+const baseProps = { debateId: 'deb-1', debateTitle: 'Should AI pause?', onClose: vi.fn() };
+
+function renderClosed(extra = {}) {
+  return render(<BriefExportDialog {...baseProps} debatePhase="closed" {...extra} />);
+}
+
+describe('BriefExportDialog (t/2805)', () => {
+  beforeEach(() => {
+    createBriefExport.mockReset().mockResolvedValue({ jobId: 'job-1' });
+    getBriefExportJob.mockReset();
+    listBriefExports.mockReset().mockResolvedValue([]);
+    downloadBriefArtifact.mockReset();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('open debate: shows the closed-only notice and disables Export', () => {
+    render(<BriefExportDialog {...baseProps} debatePhase="open" />);
+    expect(screen.getByText(/debates only/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Export' })).toBeDisabled();
+    expect(createBriefExport).not.toHaveBeenCalled();
+  });
+
+  it('closed + "Use current model": submits model=global provenance', async () => {
+    getBriefExportJob.mockResolvedValue({ status: 'narrating', progressPct: 30, warnings: [], error: null, errorCode: null, exportId: null });
+    renderClosed();
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    await waitFor(() => expect(createBriefExport).toHaveBeenCalled());
+    expect(createBriefExport).toHaveBeenCalledWith('deb-1', expect.objectContaining({
+      preset: 'conference', model: 'gemini-2.5-flash', modelSource: 'global',
+    }));
+  });
+
+  it('closed + explicit model pick: submits model=explicit provenance', async () => {
+    getBriefExportJob.mockResolvedValue({ status: 'narrating', progressPct: 30, warnings: [], error: null, errorCode: null, exportId: null });
+    renderClosed();
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gemini-2.5-pro' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    await waitFor(() => expect(createBriefExport).toHaveBeenCalled());
+    expect(createBriefExport).toHaveBeenCalledWith('deb-1', expect.objectContaining({
+      model: 'gemini-2.5-pro', modelSource: 'explicit',
+    }));
+  });
+
+  it('polls to done and lists downloadable artifacts', async () => {
+    vi.useFakeTimers();
+    getBriefExportJob.mockResolvedValue({ status: 'done', progressPct: 100, warnings: [], error: null, errorCode: null, exportId: 'exp-1' });
+    listBriefExports.mockResolvedValue([{
+      exportId: 'exp-1', debateId: 'deb-1', title: 'Should AI pause?', preset: 'conference', status: 'done',
+      narratorModel: 'gemini-2.5-flash', narratorModelSource: 'Global', formats: ['pptx'],
+      artifacts: ['deck_spec.json', 'narration.json', 'audit-manifest.json', 'brief.pptx'],
+      traceCoveragePct: 100, warnings: [], createdAt: '2026-08-19T00:00:00Z',
+    }]);
+    renderClosed();
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    await vi.advanceTimersByTimeAsync(1600); // fire the first poll
+    await vi.waitFor(() => expect(screen.getByText(/export complete/i)).toBeInTheDocument());
+    expect(screen.getByText('Slides (PPTX)')).toBeInTheDocument();
+    expect(screen.getByText('Audit manifest (JSON)')).toBeInTheDocument();
+  });
+
+  it('failed job: shows the gate message verbatim', async () => {
+    vi.useFakeTimers();
+    getBriefExportJob.mockResolvedValue({ status: 'failed', progressPct: 100, warnings: [], error: 'Export verify gate failed: trace coverage 60% < 80%', errorCode: 'TraceGateFailure', exportId: null });
+    renderClosed();
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    await vi.advanceTimersByTimeAsync(1600);
+    await vi.waitFor(() => expect(screen.getByText(/TraceGateFailure/)).toBeInTheDocument());
+    expect(screen.getByText(/trace coverage 60% < 80%/)).toBeInTheDocument();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.tsx
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief Export dialog (t/2805, T7 — spec §7). Client of the T6 REST API: kicks off an
+// async export job, polls phase-level progress, and on completion lists the artifacts
+// with download buttons. Web-first v1 (pptx + json); PDF/template/framing-meta deferred
+// to t/2838; closed-debate only (open shows an explanatory notice — TL ruling A, t/2805#5).
+//
+// Consumes T6's frozen contract verbatim: job-state names, artifact names (BRIEF_ARTIFACTS),
+// and the error taxonomy (shown as the verbatim gate message on failure).
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { api } from '@bridge';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { AI_BACKENDS, MODELS_BY_BACKEND } from '../../hooks/useTaxonomyStore';
+import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
+import { BRIEF_ARTIFACTS, type BriefPreset, type BriefArtifactName } from '../../../../../lib/brief/types';
+import type { BriefExportJobView, BriefExportRecord } from '../../bridge/types';
+import './BriefExportDialog.css';
+
+const PRESETS: { value: BriefPreset; label: string; hint: string }[] = [
+  { value: 'policymaker', label: 'Policymaker', hint: 'Tight, decision-oriented brief.' },
+  { value: 'conference', label: 'Conference', hint: 'Balanced talk-style deck.' },
+  { value: 'classroom', label: 'Classroom', hint: 'Teaching deck with framing.' },
+];
+
+/** Human labels for the frozen T6 job states (spec §5). */
+const PHASE_LABEL: Record<string, string> = {
+  queued: 'Queued', extracting: 'Extracting deck spec', narrating: 'Narrating',
+  checking: 'Maker-checker review', rendering: 'Rendering slides', verifying: 'Verifying',
+  done: 'Done', failed: 'Failed',
+};
+
+const ARTIFACT_LABEL: Record<BriefArtifactName, string> = {
+  [BRIEF_ARTIFACTS.deckSpec]: 'Deck spec (JSON)',
+  [BRIEF_ARTIFACTS.narration]: 'Narration (JSON)',
+  [BRIEF_ARTIFACTS.manifest]: 'Audit manifest (JSON)',
+  [BRIEF_ARTIFACTS.pptx]: 'Slides (PPTX)',
+};
+
+const POLL_MS = 1500;
+const CURRENT = '__current__';
+
+type Phase = 'form' | 'running' | 'done' | 'failed';
+
+interface Props {
+  debateId: string;
+  debateTitle: string;
+  /** Debate phase; export is closed-only for v1 (TL ruling A). */
+  debatePhase: string;
+  onClose: () => void;
+  /** Fired after a successful export so the parent can refresh its Exports list. */
+  onExported?: () => void;
+}
+
+export function BriefExportDialog({ debateId, debateTitle, debatePhase, onClose, onExported }: Props) {
+  const { geminiModel } = useTaxonomyStore();
+  const isClosed = debatePhase === 'closed';
+
+  const [preset, setPreset] = useState<BriefPreset>('conference');
+  const [modelChoice, setModelChoice] = useState<string>(CURRENT);
+  const [makerChecker, setMakerChecker] = useState(false);
+  const [checkerModel, setCheckerModel] = useState<string>(geminiModel || '');
+  const [skipNarration, setSkipNarration] = useState(false);
+
+  const [phase, setPhase] = useState<Phase>('form');
+  const [job, setJob] = useState<BriefExportJobView | null>(null);
+  const [record, setRecord] = useState<BriefExportRecord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stopPoll = useCallback(() => { if (pollRef.current) { clearTimeout(pollRef.current); pollRef.current = null; } }, []);
+  useEffect(() => stopPoll, [stopPoll]);
+
+  const finishFromRecord = useCallback(async (exportId: string) => {
+    // Terminal: pull the durable record (source of truth once the in-memory job expires).
+    try {
+      const list = await api.listBriefExports(debateId);
+      const rec = list.find(r => r.exportId === exportId) ?? null;
+      setRecord(rec);
+      if (rec?.status === 'failed') { setError(`Export failed: ${rec.errorCode ?? 'unknown gate'}`); setPhase('failed'); }
+      else { setPhase('done'); onExported?.(); }
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'brief-export-ui', level: 'error', message: 'Failed to load export record', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+      // Job said done but the list read failed — still show done (artifacts are addressable by id).
+      setPhase('done'); onExported?.();
+    }
+  }, [debateId, onExported]);
+
+  const poll = useCallback(async (jobId: string) => {
+    let view: BriefExportJobView;
+    try {
+      view = await api.getBriefExportJob(jobId);
+    } catch {
+      // 404 (per-replica registry TTL, T6 §5): the job view is gone — fall back to the
+      // durable exports list rather than treating expiry as an error.
+      try {
+        const list = await api.listBriefExports(debateId);
+        const rec = list[0];
+        if (rec) { setRecord(rec); setPhase(rec.status === 'failed' ? 'failed' : 'done'); if (rec.status !== 'failed') onExported?.(); return; }
+      } catch { /* fall through to a generic error */ }
+      setError('Lost track of the export job (it may have expired). Check the Exports list.');
+      setPhase('failed');
+      return;
+    }
+    setJob(view);
+    if (view.status === 'done' && view.exportId) { await finishFromRecord(view.exportId); return; }
+    if (view.status === 'failed') { setError(view.error ?? `Export failed: ${view.errorCode ?? 'unknown gate'}`); setPhase('failed'); return; }
+    pollRef.current = setTimeout(() => void poll(jobId), POLL_MS);
+  }, [debateId, finishFromRecord, onExported]);
+
+  const submit = useCallback(async () => {
+    setError(null); setJob(null); setRecord(null); setPhase('running');
+    try {
+      const body = {
+        preset,
+        model: modelChoice === CURRENT ? (geminiModel || undefined) : modelChoice,
+        modelSource: (modelChoice === CURRENT ? 'global' : 'explicit') as 'global' | 'explicit',
+        ...(makerChecker && checkerModel ? { checkerModel } : {}),
+        options: { skipNarration },
+      };
+      const { jobId } = await api.createBriefExport(debateId, body);
+      pollRef.current = setTimeout(() => void poll(jobId), POLL_MS);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setPhase('failed');
+    }
+  }, [preset, modelChoice, geminiModel, makerChecker, checkerModel, skipNarration, debateId, poll]);
+
+  const download = useCallback(async (name: BriefArtifactName) => {
+    if (!record) return;
+    try {
+      const blob = await api.downloadBriefArtifact(record.exportId, name);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = name; document.body.appendChild(a); a.click(); a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'brief-export-ui', level: 'error', message: 'Artifact download failed', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+      setError(`Could not download ${name}.`);
+    }
+  }, [record]);
+
+  const modelOptions = (
+    <>
+      {AI_BACKENDS.map(b => (
+        <optgroup key={b.value} label={b.label}>
+          {(MODELS_BY_BACKEND[b.value] ?? []).map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
+        </optgroup>
+      ))}
+    </>
+  );
+
+  return (
+    <div className="bx-overlay" role="dialog" aria-modal="true" aria-label="Export debate brief" onClick={onClose}>
+      <div className="bx-dialog" onClick={e => e.stopPropagation()}>
+        <div className="bx-header">
+          <h2 className="bx-title">Export brief — {debateTitle}</h2>
+          <button className="bx-close" onClick={onClose} aria-label="Close">×</button>
+        </div>
+
+        {!isClosed && (
+          <div className="bx-notice" role="note">
+            Brief export is available for <strong>closed</strong> debates only. Close this debate to export a brief.
+            <span className="bx-notice-sub"> (Live-snapshot export is planned — t/2816.)</span>
+          </div>
+        )}
+
+        {phase === 'form' && (
+          <div className="bx-form">
+            <fieldset className="bx-fieldset">
+              <legend>Preset</legend>
+              {PRESETS.map(p => (
+                <label key={p.value} className="bx-radio">
+                  <input type="radio" name="bx-preset" value={p.value} checked={preset === p.value} onChange={() => setPreset(p.value)} disabled={!isClosed} />
+                  <span className="bx-radio-label">{p.label}</span>
+                  <span className="bx-hint">{p.hint}</span>
+                </label>
+              ))}
+            </fieldset>
+
+            <div className="bx-field">
+              <label htmlFor="bx-model">Model</label>
+              <select id="bx-model" value={modelChoice} onChange={e => setModelChoice(e.target.value)} disabled={!isClosed}>
+                <option value={CURRENT}>Use current model ({geminiModel || 'default'})</option>
+                {modelOptions}
+              </select>
+            </div>
+
+            <label className="bx-check">
+              <input type="checkbox" checked={makerChecker} onChange={e => setMakerChecker(e.target.checked)} disabled={!isClosed || skipNarration} />
+              Enable maker-checker review
+            </label>
+            {makerChecker && !skipNarration && (
+              <div className="bx-field bx-indent">
+                <label htmlFor="bx-checker">Checker model</label>
+                <select id="bx-checker" value={checkerModel} onChange={e => setCheckerModel(e.target.value)} disabled={!isClosed}>
+                  {modelOptions}
+                </select>
+              </div>
+            )}
+
+            <label className="bx-check">
+              <input type="checkbox" checked={skipNarration} onChange={e => setSkipNarration(e.target.checked)} disabled={!isClosed} />
+              Skip narration (deterministic, no model calls)
+            </label>
+
+            <p className="bx-formats">Produces: <strong>PPTX</strong> + deck spec, narration & audit manifest (JSON). PDF & templates are desktop-only (t/2838).</p>
+
+            {error && <div className="bx-error" role="alert">{error}</div>}
+            <div className="bx-actions">
+              <button className="bx-btn-ghost" onClick={onClose}>Cancel</button>
+              <button className="bx-btn-primary" onClick={() => void submit()} disabled={!isClosed}>Export</button>
+            </div>
+          </div>
+        )}
+
+        {phase === 'running' && (
+          <div className="bx-progress" aria-live="polite">
+            <div className="bx-phase">{PHASE_LABEL[job?.status ?? 'queued'] ?? 'Working…'}</div>
+            <div className="bx-bar"><div className="bx-bar-fill" style={{ width: `${job?.progressPct ?? 5}%` }} /></div>
+            {(job?.warnings.length ?? 0) > 0 && (
+              <ul className="bx-warnings">{job!.warnings.map((w, i) => <li key={i}>{w}</li>)}</ul>
+            )}
+          </div>
+        )}
+
+        {phase === 'done' && (
+          <div className="bx-done">
+            <div className="bx-done-head">✓ Export complete</div>
+            {record && (
+              <>
+                {record.warnings.length > 0 && (
+                  <ul className="bx-warnings">{record.warnings.map((w, i) => <li key={i}>{w}</li>)}</ul>
+                )}
+                <ul className="bx-artifacts">
+                  {record.artifacts.map(name => (
+                    <li key={name}>
+                      <span className="bx-artifact-name">{ARTIFACT_LABEL[name] ?? name}</span>
+                      <button className="bx-btn-ghost bx-dl" onClick={() => void download(name)}>Download</button>
+                    </li>
+                  ))}
+                </ul>
+                <div className="bx-meta">Trace coverage {record.traceCoveragePct}% · model {record.narratorModel}</div>
+              </>
+            )}
+            <div className="bx-actions"><button className="bx-btn-primary" onClick={onClose}>Done</button></div>
+          </div>
+        )}
+
+        {phase === 'failed' && (
+          <div className="bx-failed" role="alert">
+            <div className="bx-failed-head">Export failed{job?.errorCode ? ` — ${job.errorCode}` : ''}</div>
+            <pre className="bx-failed-msg">{error ?? job?.error ?? 'Unknown failure.'}</pre>
+            <div className="bx-actions">
+              <button className="bx-btn-ghost" onClick={onClose}>Close</button>
+              <button className="bx-btn-primary" onClick={() => setPhase('form')}>Back</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.tsx
@@ -92,13 +92,14 @@ export function BriefExportDialog({ debateId, debateTitle, debatePhase, onClose,
     try {
       view = await api.getBriefExportJob(jobId);
     } catch {
+      /* telemetry — silent by design */
       // 404 (per-replica registry TTL, T6 §5): the job view is gone — fall back to the
       // durable exports list rather than treating expiry as an error.
       try {
         const list = await api.listBriefExports(debateId);
         const rec = list[0];
         if (rec) { setRecord(rec); setPhase(rec.status === 'failed' ? 'failed' : 'done'); if (rec.status !== 'failed') onExported?.(); return; }
-      } catch { /* fall through to a generic error */ }
+      } catch { /* telemetry — silent by design */ }
       setError('Lost track of the export job (it may have expired). Check the Exports list.');
       setPhase('failed');
       return;
@@ -122,6 +123,7 @@ export function BriefExportDialog({ debateId, debateTitle, debatePhase, onClose,
       const { jobId } = await api.createBriefExport(debateId, body);
       pollRef.current = setTimeout(() => void poll(jobId), POLL_MS);
     } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'brief-export-ui', level: 'error', message: 'Failed to start brief export', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
       setError(err instanceof Error ? err.message : String(err));
       setPhase('failed');
     }
@@ -218,7 +220,10 @@ export function BriefExportDialog({ debateId, debateTitle, debatePhase, onClose,
         {phase === 'running' && (
           <div className="bx-progress" aria-live="polite">
             <div className="bx-phase">{PHASE_LABEL[job?.status ?? 'queued'] ?? 'Working…'}</div>
-            <div className="bx-bar"><div className="bx-bar-fill" style={{ width: `${job?.progressPct ?? 5}%` }} /></div>
+            <div className="bx-bar">
+              {/* eslint-disable-next-line local/no-inline-style -- dynamic: progress width % */}
+              <div className="bx-bar-fill" style={{ width: `${job?.progressPct ?? 5}%` }} />
+            </div>
             {(job?.warnings.length ?? 0) > 0 && (
               <ul className="bx-warnings">{job!.warnings.map((w, i) => <li key={i}>{w}</li>)}</ul>
             )}

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportsList.css
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportsList.css
@@ -1,0 +1,27 @@
+/* Brief Exports section (t/2805, T7). Co-located; var(--token, fallback) for contrast safety. */
+
+.bxl-section { margin-top: 12px; }
+.bxl-head { font-weight: 600; font-size: 0.9rem; margin-bottom: 6px; color: var(--text-color, #1a1a1a); }
+.bxl-loading, .bxl-empty { color: var(--text-muted, #6b7280); font-size: 0.85rem; }
+.bxl-error {
+  color: var(--error-text, #991b1b); background: var(--error-bg, #fef2f2);
+  border: 1px solid var(--error-border, #fecaca); border-radius: 6px; padding: 6px 8px; font-size: 0.85rem;
+}
+.bxl-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
+.bxl-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  border: 1px solid var(--border-color, #d0d0d0); border-radius: 6px; padding: 6px 10px;
+}
+.bxl-row-failed { border-color: var(--error-border, #fecaca); }
+.bxl-row-main { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.bxl-preset { font-weight: 600; text-transform: capitalize; }
+.bxl-model { color: var(--text-muted, #6b7280); font-size: 0.82rem; }
+.bxl-date { color: var(--text-muted, #6b7280); font-size: 0.82rem; }
+.bxl-failed { color: var(--error-text, #991b1b); font-size: 0.82rem; }
+.bxl-dls { display: flex; gap: 6px; }
+.bxl-dl {
+  padding: 4px 10px; border-radius: 6px; cursor: pointer; font-size: 0.82rem;
+  background: transparent; color: var(--text-color, #1a1a1a);
+  border: 1px solid var(--border-color, #d0d0d0);
+}
+.bxl-dl:hover { background: var(--hover-bg, #f3f4f6); }

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportsList.css
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportsList.css
@@ -1,27 +1,27 @@
-/* Brief Exports section (t/2805, T7). Co-located; var(--token, fallback) for contrast safety. */
+/* Brief Exports section (t/2805, T7). Co-located; only DEFINED theme tokens (gate t/2567). */
 
 .bxl-section { margin-top: 12px; }
-.bxl-head { font-weight: 600; font-size: 0.9rem; margin-bottom: 6px; color: var(--text-color, #1a1a1a); }
-.bxl-loading, .bxl-empty { color: var(--text-muted, #6b7280); font-size: 0.85rem; }
+.bxl-head { font-weight: 600; font-size: var(--text-sm); margin-bottom: 6px; color: var(--text-primary); }
+.bxl-loading, .bxl-empty { color: var(--text-muted); font-size: var(--text-sm); }
 .bxl-error {
-  color: var(--error-text, #991b1b); background: var(--error-bg, #fef2f2);
-  border: 1px solid var(--error-border, #fecaca); border-radius: 6px; padding: 6px 8px; font-size: 0.85rem;
+  color: var(--error-text); background: var(--error-bg);
+  border: 1px solid var(--error-border); border-radius: var(--radius-sm); padding: 6px 8px; font-size: var(--text-sm);
 }
 .bxl-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 6px; }
 .bxl-row {
   display: flex; align-items: center; justify-content: space-between; gap: 10px;
-  border: 1px solid var(--border-color, #d0d0d0); border-radius: 6px; padding: 6px 10px;
+  border: 1px solid var(--border-color); border-radius: var(--radius-sm); padding: 6px 10px;
 }
-.bxl-row-failed { border-color: var(--error-border, #fecaca); }
+.bxl-row-failed { border-color: var(--error-border); }
 .bxl-row-main { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
 .bxl-preset { font-weight: 600; text-transform: capitalize; }
-.bxl-model { color: var(--text-muted, #6b7280); font-size: 0.82rem; }
-.bxl-date { color: var(--text-muted, #6b7280); font-size: 0.82rem; }
-.bxl-failed { color: var(--error-text, #991b1b); font-size: 0.82rem; }
+.bxl-model { color: var(--text-muted); font-size: var(--text-xs); }
+.bxl-date { color: var(--text-muted); font-size: var(--text-xs); }
+.bxl-failed { color: var(--danger); font-size: var(--text-xs); }
 .bxl-dls { display: flex; gap: 6px; }
 .bxl-dl {
-  padding: 4px 10px; border-radius: 6px; cursor: pointer; font-size: 0.82rem;
-  background: transparent; color: var(--text-color, #1a1a1a);
-  border: 1px solid var(--border-color, #d0d0d0);
+  padding: 4px 10px; border-radius: var(--radius-sm); cursor: pointer; font-size: var(--text-xs);
+  background: transparent; color: var(--text-primary);
+  border: 1px solid var(--border-color);
 }
-.bxl-dl:hover { background: var(--hover-bg, #f3f4f6); }
+.bxl-dl:hover { background: var(--bg-hover); }

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportsList.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportsList.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief Exports section (t/2805, T7 — spec §7). Lists completed exports for a debate
+// (date / preset / model / manifest) with per-artifact download. Web-only v1 — the caller
+// gates on isElectronMode(); the list read itself asserts presence, not just "renders"
+// (ADR-001 graceful-empty: an empty list is shown explicitly, never a silent blank).
+
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '@bridge';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { BRIEF_ARTIFACTS, type BriefArtifactName } from '../../../../../lib/brief/types';
+import type { BriefExportRecord } from '../../bridge/types';
+import './BriefExportsList.css';
+
+export function BriefExportsList({ debateId, refreshKey }: { debateId: string; refreshKey: number }) {
+  const [rows, setRows] = useState<BriefExportRecord[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const list = await api.listBriefExports(debateId);
+        if (!cancelled) { setRows(list); setError(null); }
+      } catch (err) {
+        if (cancelled) return;
+        getGlobalRecorder()?.record({ type: 'system.error', component: 'brief-exports-list', level: 'error', message: 'Failed to load brief exports', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+        setError('Could not load exports.');
+        setRows([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [debateId, refreshKey]);
+
+  const download = useCallback(async (exportId: string, name: BriefArtifactName) => {
+    try {
+      const blob = await api.downloadBriefArtifact(exportId, name);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url; a.download = name; document.body.appendChild(a); a.click(); a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'brief-exports-list', level: 'error', message: 'Artifact download failed', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+    }
+  }, []);
+
+  if (rows === null) return <div className="bxl-section"><div className="bxl-loading">Loading exports…</div></div>;
+
+  return (
+    <div className="bxl-section">
+      <div className="bxl-head">Brief exports {rows.length > 0 ? `(${rows.length})` : ''}</div>
+      {error && <div className="bxl-error" role="alert">{error}</div>}
+      {rows.length === 0 && !error && <div className="bxl-empty">No briefs exported yet.</div>}
+      {rows.length > 0 && (
+        <ul className="bxl-list">
+          {rows.map(r => (
+            <li key={r.exportId} className={`bxl-row bxl-row-${r.status}`}>
+              <div className="bxl-row-main">
+                <span className="bxl-preset">{r.preset}</span>
+                <span className="bxl-model">{r.narratorModel}</span>
+                <span className="bxl-date">{r.createdAt.slice(0, 10)}</span>
+                {r.status === 'failed' && <span className="bxl-failed">failed{r.errorCode ? ` · ${r.errorCode}` : ''}</span>}
+              </div>
+              {r.status === 'done' && (
+                <div className="bxl-dls">
+                  {r.artifacts.includes(BRIEF_ARTIFACTS.pptx) && (
+                    <button className="bxl-dl" onClick={() => void download(r.exportId, BRIEF_ARTIFACTS.pptx)}>PPTX</button>
+                  )}
+                  {r.artifacts.includes(BRIEF_ARTIFACTS.manifest) && (
+                    <button className="bxl-dl" onClick={() => void download(r.exportId, BRIEF_ARTIFACTS.manifest)}>Manifest</button>
+                  )}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/taxonomy-editor/src/renderer/components/debate/DebateBriefExports.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateBriefExports.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief Export wiring for the debate detail view (t/2805, T7). Extracted as a hook so the
+// dialog + exports-list state stays out of DebateTab (ADR-007 file-size ceiling). Web-only
+// v1: the exports list renders for closed debates on the web build; the dialog opens on
+// demand from the ExportDropdown "Brief…" item.
+
+import { useState } from 'react';
+import { BriefExportDialog } from './BriefExportDialog';
+import { BriefExportsList } from './BriefExportsList';
+
+export function useDebateBriefExports(
+  debate: { id: string; title: string; phase: string },
+  isElectron: boolean,
+): { openBrief: () => void; node: JSX.Element } {
+  const [showBrief, setShowBrief] = useState(false);
+  const [refresh, setRefresh] = useState(0);
+
+  const node = (
+    <>
+      {!isElectron && debate.phase === 'closed' && (
+        <BriefExportsList debateId={debate.id} refreshKey={refresh} />
+      )}
+      {showBrief && (
+        <BriefExportDialog
+          debateId={debate.id}
+          debateTitle={debate.title}
+          debatePhase={debate.phase}
+          onClose={() => setShowBrief(false)}
+          onExported={() => setRefresh(k => k + 1)}
+        />
+      )}
+    </>
+  );
+
+  return { openBrief: () => setShowBrief(true), node };
+}

--- a/taxonomy-editor/src/renderer/components/debate/DebateBriefExports.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateBriefExports.tsx
@@ -6,14 +6,14 @@
 // v1: the exports list renders for closed debates on the web build; the dialog opens on
 // demand from the ExportDropdown "Brief…" item.
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { BriefExportDialog } from './BriefExportDialog';
 import { BriefExportsList } from './BriefExportsList';
 
 export function useDebateBriefExports(
   debate: { id: string; title: string; phase: string },
   isElectron: boolean,
-): { openBrief: () => void; node: JSX.Element } {
+): { openBrief: () => void; node: ReactNode } {
   const [showBrief, setShowBrief] = useState(false);
   const [refresh, setRefresh] = useState(0);
 

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -16,6 +16,7 @@ import { NewDebateDialog } from './NewDebateDialog';
 import { DebateWorkspace } from '../debate-workspace';
 import { filterCommunityDebates } from './communityFilter';
 import { ExportDropdown } from './ExportDropdown';
+import { useDebateBriefExports } from './DebateBriefExports';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { useAuthStatus } from '../../hooks/useAuthStatus';
 import { SearchPreview } from '../edge-browser/SearchPreview';
@@ -939,6 +940,8 @@ function DebateDetailSummary({
 }) {
   const [showCalibration, setShowCalibration] = useState(false);
   const [shareStatus, setShareStatus] = useState<string | null>(null);
+  // Brief Export (t/2805, T7) — web-only v1; the menu item signals web-only on desktop.
+  const brief = useDebateBriefExports(debate, isElectronMode());
   // Calibration is an admin/power-user tool — show only for admins (t/1036).
   // Desktop (Electron) owners are admin-equivalent; web requires the admin flag.
   // useFlag is a hook — call it unconditionally, never inside the `||` short-circuit
@@ -996,7 +999,7 @@ function DebateDetailSummary({
           })}
         </div>
         <div className="debate-tab-spacer" />
-        <ExportDropdown onExport={onExport} />
+        <ExportDropdown onExport={onExport} onBrief={brief.openBrief} briefWebOnly={isElectronMode()} />
         {showAdminControls && viewMode !== 'simple' && (
           <button className="btn" onClick={() => setShowCalibration(!showCalibration)}>
             Calibration
@@ -1007,6 +1010,8 @@ function DebateDetailSummary({
         </button>
         {exportStatus && <span className="debate-detail-export-status">{exportStatus}</span>}
       </div>
+
+      {brief.node}
 
       {showCalibration && viewMode !== 'simple' && (
         <ParameterHistoryPanel onClose={() => setShowCalibration(false)} />

--- a/taxonomy-editor/src/renderer/components/debate/ExportDropdown.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/ExportDropdown.tsx
@@ -14,7 +14,14 @@ const EXPORT_OPTIONS: { format: string; label: string }[] = [
  * Single "Export" toolbar button that reveals a PDF / JSON / Markdown menu (t/1031),
  * replacing three separate export buttons. Closes on outside-click or Escape.
  */
-export function ExportDropdown({ onExport }: { onExport: (format: string) => void }) {
+export function ExportDropdown({ onExport, onBrief, briefWebOnly }: {
+  onExport: (format: string) => void;
+  /** Optional async "Brief…" export (t/2805, T7) — opens a dialog rather than a file download. */
+  onBrief?: () => void;
+  /** Desktop build: brief export is web-only for v1 — show the item disabled with a reason
+   *  (TL condition, p/455#97) so desktop users see it exists and where to go, not a dead end. */
+  briefWebOnly?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -61,6 +68,20 @@ export function ExportDropdown({ onExport }: { onExport: (format: string) => voi
               {label}
             </button>
           ))}
+          {onBrief && (
+            <button
+              type="button"
+              role="menuitem"
+              className="btn export-dropdown-item"
+              onClick={() => { if (!briefWebOnly) { setOpen(false); onBrief(); } }}
+              disabled={briefWebOnly}
+              title={briefWebOnly
+                ? 'Brief export is available in the AITriad web app (desktop coming)'
+                : 'Generate a slide brief from this debate'}
+            >
+              {briefWebOnly ? 'Brief… (web app)' : 'Brief…'}
+            </button>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Brief Export T7 — GUI (web-first v1) · t/2805

Client of the T6 REST API (I authored T6, so this consumes its frozen job-states, artifact names, and error taxonomy verbatim). **TL-approved** design of record (t/2805#4, rulings p/455#97).

### What's in
- **Bridge** (dual-build): 5 T6 client methods on `AppAPI` (createBriefExport / getBriefExportJob / listBriefExports / downloadBriefArtifact / deleteBriefExport) + client shapes. web-bridge implements them (billable POST → **0 retries**, no duplicate jobs; binary artifact download via resilientFetch). **electron-bridge rejects LOUDLY** with an ActionableError (TL condition 1).
- **BriefExportDialog**: preset radios (default Conference); model select with **"Use current model (<resolved>)"** first → `modelSource` global vs explicit (T6 §6); maker-checker reveal; skip-narration. POST → **poll** `getBriefExportJob` (~1.5s) → phase-level progress from the frozen states → artifact list with downloads. Failure shows the gate message **verbatim** + errorCode. **Closed-only** (open → explanatory notice, ruling A — no silent downgrade). 404-job (per-replica TTL) → durable exports-list fallback.
- **Exports section** (`BriefExportsList`) in the debate detail view: closed debate's exports (preset/model/date) + PPTX/manifest download; explicit empty state (ADR-001 presence, not silent-blank). Web-only.
- **Menu**: `ExportDropdown` gains a "Brief…" item; **on desktop it's disabled with a web-only tooltip** (TL condition 1 part 2 — no dead end). State lives in a `useDebateBriefExports` hook so DebateTab stays under the ADR-007 1500-line ceiling (1491).

### Rulings baked in (p/455#97)
- **A** closed-only v1 · **B** PDF deferred (T6 doesn't serve htmlDoc) · **C** template + framing-meta deferred → **t/2838**.

### Verification
tsc clean; eslint **0 errors**; **5 vitest** pass (closed-gate, model-provenance global/explicit, poll→done→artifacts, failed→verbatim message).

### Follow-ups (tracked, out of scope here)
- **Electron parity** (TL filing): IPC handler calling shared `runBriefPipeline` in-process, blocked by **t/2837** — not a reimpl.
- **Hosted-web PS parity**: extend `Invoke-ListLoadContractTest.ps1` for `/api/debates/:id/exports`→`/api/exports/:id` (PowerShell/DevOps scope). Component-level presence is asserted by the empty-state vitest.
- PDF/template/framing-meta → **t/2838**.
