### PR TITLE
feat(brief): full .potx slide-master honoring in render v2 (t/2820)

### DIFF
--- a/lib/brief/render/deckTheme.ts
+++ b/lib/brief/render/deckTheme.ts
@@ -49,21 +49,27 @@ export const HOUSE_THEME: DeckTheme = {
 };
 
 /**
- * Resolve the theme for a render. v1 applies the AITriad house style; a supplied
- * `.potx` template is acknowledged but its colors/fonts/masters are NOT yet
- * honored (full template theming + slide-master honoring is the t/2820 v2 item).
- * Returns a disclosure warning so the partial application is never silent
- * (silent-degradation rule; TL e/113#2 condition 2a).
+ * Resolve the theme for a render. When `.potx` bytes are supplied the template's
+ * theme colors and fonts are extracted and applied (v2, t/2820); slide-master
+ * honoring is handled as a post-process step in render() via mergePotxMasters().
+ * Falls back to HOUSE_THEME with a `template_parse_error` warning if the bytes
+ * cannot be read as a valid .potx zip (silent-degradation rule, TL e/113#2 §2a).
  */
-export function resolveTheme(hasTemplate: boolean): { theme: DeckTheme; warning?: string } {
-  if (hasTemplate) {
+export async function resolveTheme(
+  template?: Uint8Array,
+): Promise<{ theme: DeckTheme; warning?: string }> {
+  if (!template) return { theme: HOUSE_THEME };
+
+  try {
+    const { extractPotxTheme } = await import('./potxHonor.js');
+    const theme = await extractPotxTheme(template);
+    return { theme };
+  } catch {
     return {
       theme: HOUSE_THEME,
       warning:
-        'template_not_honored: a .potx template was supplied but v1 renders in the ' +
-        'AITriad house style — template colors/fonts and slide masters are not applied ' +
-        '(tracked as t/2820).',
+        'template_parse_error: the supplied .potx could not be read as a valid ' +
+        'Office Open XML zip — house style applied, slide masters not merged.',
     };
   }
-  return { theme: HOUSE_THEME };
 }

--- a/lib/brief/render/index.ts
+++ b/lib/brief/render/index.ts
@@ -17,7 +17,11 @@ export interface RenderInput {
   spec: DeckSpec;
   narration: Narration;
   preset: BriefPreset;
-  /** Optional .potx bytes. v1 records a disclosure warning; theming is not yet applied. */
+  /**
+   * Optional .potx bytes. When supplied, v2 (t/2820) extracts theme colors/fonts
+   * and injects the .potx slide masters into the rendered output. A
+   * `template_parse_error` warning is emitted if the bytes are not a valid zip.
+   */
   template?: Uint8Array;
 }
 
@@ -28,16 +32,29 @@ export interface RenderResult {
   htmlDoc: string;
   /** The assembled slide IR — exposed for tests/debugging. */
   slideModels: SlideModel[];
-  /** Non-fatal render warnings (trimmed content, template-not-honored, empty slides). */
+  /** Non-fatal render warnings (trimmed content, template_parse_error, empty slides). */
   warnings: string[];
 }
 
 export async function render(input: RenderInput): Promise<RenderResult> {
-  const { theme, warning } = resolveTheme(input.template !== undefined);
+  const { theme, warning } = await resolveTheme(input.template);
   const { slides, warnings } = assemble(input.spec, input.narration, input.preset);
-  const allWarnings = warning ? [warning, ...warnings] : warnings;
+  const allWarnings: string[] = warning ? [warning, ...warnings] : [...warnings];
 
-  const pptxBytes = await renderPptx(slides, theme);
+  let pptxBytes = await renderPptx(slides, theme);
+
+  if (input.template && !warning) {
+    // Template was parsed successfully — inject its slide masters as a post-process.
+    // Falls back to the unmerged bytes on failure (never silent: warning is appended).
+    try {
+      const { mergePotxMasters } = await import('./potxHonor.js');
+      pptxBytes = await mergePotxMasters(pptxBytes, input.template);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      allWarnings.push(`template_masters_not_merged: slide-master injection failed — ${msg}`);
+    }
+  }
+
   const htmlDoc = renderHtml(slides, theme);
 
   return { pptxBytes, htmlDoc, slideModels: slides, warnings: allWarnings };

--- a/lib/brief/render/potxHonor.ts
+++ b/lib/brief/render/potxHonor.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — .potx theme extraction and slide-master merge (t/2820).
+// Two exports:
+//   extractPotxTheme  — parse theme colors/fonts from .potx bytes → DeckTheme
+//   mergePotxMasters  — post-process: inject .potx slide masters into pptxgenjs output
+//
+// No new deps: JSZip is already in lib/package.json (used by verify.ts).
+// This is intentionally the ONLY place that reads .potx bytes; pptxRenderer.ts
+// stays the only pptxgenjs surface (TL build condition 1 preserved).
+
+import JSZip from 'jszip';
+import type { DeckTheme } from './deckTheme.js';
+import { HOUSE_THEME } from './deckTheme.js';
+
+// ── Theme extraction ─────────────────────────────────────────────────────────
+
+function parseColorBlock(themeXml: string, role: string): string | undefined {
+  const block = themeXml.match(new RegExp(`<a:${role}>[\\s\\S]*?</a:${role}>`));
+  if (!block) return undefined;
+  // srgbClr val="RRGGBB" (most themes)
+  const srgb = block[0].match(/val="([0-9A-Fa-f]{6})"/);
+  if (srgb) return srgb[1].toUpperCase();
+  // sysClr lastClr="RRGGBB" (system-color themes)
+  const sys = block[0].match(/lastClr="([0-9A-Fa-f]{6})"/);
+  return sys ? sys[1].toUpperCase() : undefined;
+}
+
+function parseFontFace(themeXml: string, which: 'majorFont' | 'minorFont'): string | undefined {
+  const block = themeXml.match(new RegExp(`<a:${which}>[\\s\\S]*?</a:${which}>`));
+  if (!block) return undefined;
+  const m = block[0].match(/<a:latin typeface="([^"]+)"/);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Parse a DeckTheme from .potx bytes by reading ppt/theme/theme1.xml.
+ * Falls back to HOUSE_THEME for any color/font not found in the template.
+ * Verdict colors are always kept from HOUSE_THEME — no .potx equivalent exists
+ * for the Supported/Disputed/Unverifiable semantic roles.
+ */
+export async function extractPotxTheme(potxBytes: Uint8Array): Promise<DeckTheme> {
+  const zip = await JSZip.loadAsync(potxBytes);
+  const themeFile = zip.file('ppt/theme/theme1.xml');
+  if (!themeFile) return HOUSE_THEME;
+
+  const xml = await themeFile.async('string');
+  return {
+    name: 'Template',
+    colors: {
+      background: parseColorBlock(xml, 'lt1')     ?? HOUSE_THEME.colors.background,
+      text:       parseColorBlock(xml, 'dk1')     ?? HOUSE_THEME.colors.text,
+      subtle:     parseColorBlock(xml, 'dk2')     ?? HOUSE_THEME.colors.subtle,
+      accent:     parseColorBlock(xml, 'accent1') ?? HOUSE_THEME.colors.accent,
+      verdict: HOUSE_THEME.colors.verdict,
+    },
+    fonts: {
+      heading: parseFontFace(xml, 'majorFont') ?? HOUSE_THEME.fonts.heading,
+      body:    parseFontFace(xml, 'minorFont') ?? HOUSE_THEME.fonts.body,
+    },
+  };
+}
+
+// ── Slide master merge ───────────────────────────────────────────────────────
+
+const MASTER_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster';
+
+/**
+ * rId base for injected masters. pptxgenjs emits rId1 (sole master) then rId2,
+ * rId3, … for slides. Starting injected master rIds at 100 avoids any collision
+ * with those generated IDs without requiring a full renumber of the rels.
+ */
+const MASTER_RID_BASE = 100;
+
+const TEMPLATE_PREFIXES = ['ppt/slideMasters/', 'ppt/slideLayouts/', 'ppt/theme/'];
+
+function countFiles(zip: JSZip, pattern: RegExp): number {
+  let n = 0;
+  zip.forEach(path => { if (pattern.test(path)) n++; });
+  return n;
+}
+
+/** Collect ppt/media/* paths referenced from template master/layout _rels. */
+async function collectTemplateMedia(potxZip: JSZip): Promise<string[]> {
+  const media = new Set<string>();
+  const relPrefixes = ['ppt/slideMasters/_rels/', 'ppt/slideLayouts/_rels/'];
+  for (const prefix of relPrefixes) {
+    const relFiles: string[] = [];
+    potxZip.forEach(path => {
+      if (path.startsWith(prefix) && path.endsWith('.rels')) relFiles.push(path);
+    });
+    for (const rf of relFiles) {
+      const xml = await potxZip.file(rf)!.async('string');
+      for (const m of xml.matchAll(/Target="\.\.\/media\/([^"]+)"/g)) {
+        media.add(`ppt/media/${m[1]}`);
+      }
+    }
+  }
+  return [...media];
+}
+
+/** Replace slideMaster relationships in ppt/_rels/presentation.xml.rels. */
+async function injectMasterRels(pptxZip: JSZip, masterCount: number): Promise<void> {
+  const relsFile = pptxZip.file('ppt/_rels/presentation.xml.rels');
+  let xml = relsFile ? await relsFile.async('string') : '';
+
+  // Remove existing slideMaster entries (pptxgenjs always emits exactly one)
+  xml = xml.replace(/<Relationship\s[^>]*Type="[^"]*\/slideMaster"[^>]*\/>/g, '');
+
+  const newRels = Array.from({ length: masterCount }, (_, i) =>
+    `  <Relationship Id="rId${MASTER_RID_BASE + i}" Type="${MASTER_TYPE}" Target="slideMasters/slideMaster${i + 1}.xml"/>`,
+  ).join('\n');
+
+  xml = xml.replace('</Relationships>', `${newRels}\n</Relationships>`);
+  pptxZip.file('ppt/_rels/presentation.xml.rels', xml);
+}
+
+/** Rewrite <p:sldMasterIdLst> in ppt/presentation.xml to reference injected masters. */
+async function updateSldMasterIdLst(pptxZip: JSZip, masterCount: number): Promise<void> {
+  const presFile = pptxZip.file('ppt/presentation.xml');
+  if (!presFile) return;
+  let xml = await presFile.async('string');
+
+  const entries = Array.from({ length: masterCount }, (_, i) =>
+    `<p:sldMasterId id="${2147483648 + i}" r:id="rId${MASTER_RID_BASE + i}"/>`,
+  ).join('');
+
+  xml = xml.replace(
+    /<p:sldMasterIdLst>[\s\S]*?<\/p:sldMasterIdLst>/,
+    `<p:sldMasterIdLst>${entries}</p:sldMasterIdLst>`,
+  );
+  pptxZip.file('ppt/presentation.xml', xml);
+}
+
+/** Swap Override entries for template-managed parts in [Content_Types].xml. */
+async function updateContentTypes(pptxZip: JSZip, potxZip: JSZip): Promise<void> {
+  const ctFile = pptxZip.file('[Content_Types].xml');
+  if (!ctFile) return;
+  let xml = await ctFile.async('string');
+
+  // Remove existing overrides for parts we are replacing
+  xml = xml.replace(
+    /<Override PartName="\/ppt\/(slideMasters|slideLayouts|theme)\/[^"]*"[^/]*\/>/g,
+    '',
+  );
+
+  const potxCt = potxZip.file('[Content_Types].xml');
+  if (potxCt) {
+    const potxXml = await potxCt.async('string');
+    const overrides = [
+      ...potxXml.matchAll(
+        /<Override PartName="\/ppt\/(slideMasters|slideLayouts|theme)\/[^"]*"[^/]*\/>/g,
+      ),
+    ].map(m => m[0]).join('\n');
+
+    xml = xml.replace('</Types>', `${overrides}\n</Types>`);
+  }
+
+  pptxZip.file('[Content_Types].xml', xml);
+}
+
+/**
+ * Post-process a pptxgenjs-generated .pptx to inject slide masters and layouts
+ * from the supplied .potx template. Slide content is unchanged; only the
+ * master/layout/theme parts are replaced so the org's branded master layouts
+ * are preserved in the rendered brief.
+ *
+ * The T4→T5 byte contract is maintained: verify() receives valid OOXML bytes
+ * and its lint checks (negative-offset scan, canonical presentation.xml order)
+ * still apply to the final shipped content.
+ */
+export async function mergePotxMasters(
+  pptxBytes: Uint8Array,
+  potxBytes: Uint8Array,
+): Promise<Uint8Array> {
+  const [pptxZip, potxZip] = await Promise.all([
+    JSZip.loadAsync(pptxBytes),
+    JSZip.loadAsync(potxBytes),
+  ]);
+
+  // Remove template-managed parts from the generated output
+  const toRemove: string[] = [];
+  pptxZip.forEach(path => {
+    if (TEMPLATE_PREFIXES.some(p => path.startsWith(p))) toRemove.push(path);
+  });
+  toRemove.forEach(p => pptxZip.remove(p));
+
+  // Copy all template parts (masters, layouts, theme, their _rels) from .potx
+  const potxFilePaths: string[] = [];
+  potxZip.forEach((path, file) => {
+    if (!file.dir && TEMPLATE_PREFIXES.some(p => path.startsWith(p))) {
+      potxFilePaths.push(path);
+    }
+  });
+  for (const path of potxFilePaths) {
+    pptxZip.file(path, await potxZip.file(path)!.async('uint8array'));
+  }
+
+  // Copy media assets referenced by the template's masters/layouts
+  for (const mediaPath of await collectTemplateMedia(potxZip)) {
+    const f = potxZip.file(mediaPath);
+    if (f) pptxZip.file(mediaPath, await f.async('uint8array'));
+  }
+
+  const masterCount = countFiles(
+    potxZip,
+    /^ppt\/slideMasters\/slideMaster\d+\.xml$/,
+  );
+
+  await injectMasterRels(pptxZip, masterCount);
+  await updateSldMasterIdLst(pptxZip, masterCount);
+  await updateContentTypes(pptxZip, potxZip);
+
+  return pptxZip.generateAsync({ type: 'uint8array', compression: 'DEFLATE' });
+}

--- a/lib/brief/render/render.test.ts
+++ b/lib/brief/render/render.test.ts
@@ -149,9 +149,9 @@ describe('render — speaker notes reuse the narration trace', () => {
 });
 
 describe('render — self-contained HTML', () => {
-  it('has inline styles and no external network references', () => {
+  it('has inline styles and no external network references', async () => {
     const { slides } = assemble(makeSpec(), makeNarration(), 'conference');
-    const { theme } = resolveTheme(false);
+    const { theme } = await resolveTheme();
     const html = renderHtml(slides, theme);
     expect(html).toContain('<style>');
     expect(html).not.toMatch(/https?:\/\//);
@@ -159,10 +159,10 @@ describe('render — self-contained HTML', () => {
     expect(html).not.toMatch(/@import/);
   });
 
-  it('escapes HTML in dynamic content (XSS-safe, deterministic)', () => {
+  it('escapes HTML in dynamic content (XSS-safe, deterministic)', async () => {
     const spec = makeSpec({ question: { core_proposition: 'Pause <script>alert(1)</script>?' } });
     const { slides } = assemble(spec, makeNarration({ entries: [] }), 'conference');
-    const { theme } = resolveTheme(false);
+    const { theme } = await resolveTheme();
     const html = renderHtml(slides, theme);
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).toContain('&lt;script&gt;');
@@ -176,9 +176,9 @@ describe('render — snapshot watermark + template disclosure', () => {
     expect(slides.every(s => s.watermark === 'IN PROGRESS')).toBe(true);
   });
 
-  it('records a template-not-honored disclosure warning when a template is supplied', async () => {
+  it('records a template_parse_error warning when invalid .potx bytes are supplied', async () => {
     const r = await render({ spec: makeSpec(), narration: makeNarration(), preset: 'conference', template: new Uint8Array([1, 2, 3]) });
-    expect(r.warnings.some(w => w.startsWith('template_not_honored'))).toBe(true);
+    expect(r.warnings.some(w => w.startsWith('template_parse_error'))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- New `potxHonor.ts` module: `extractPotxTheme` (colors/fonts from `ppt/theme/theme1.xml`) and `mergePotxMasters` (JSZip post-process that injects .potx slide master/layout/theme parts into the pptxgenjs output, rewires `presentation.xml.rels` and `[Content_Types].xml`)
- `resolveTheme()` now async; accepts `Uint8Array | undefined`; extracts real theme colors/fonts from .potx when valid bytes supplied
- `render()` awaits `resolveTheme`, runs `mergePotxMasters` as a post-process; falls back with `template_masters_not_merged` warning on failure (never silent)
- v1 `template_not_honored` warning retired; invalid .potx bytes emit `template_parse_error`
- T4→T5 byte contract intact: `verify()` still lints the final merged bytes (negative-offset scan, canonical `presentation.xml` order)
- No new deps — uses JSZip already in `lib/package.json`

## Test plan
- [x] 15/15 render tests pass including updated `template_parse_error` test
- [x] `typecheck:brief-nodenext` clean (the new CI gate from #1267)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)