### PR TITLE
feat(brief): T7-v2 htmlDoc artifact storage + framingMeta flag (t/2838)

### DIFF
--- a/lib/brief/render/assemble.ts
+++ b/lib/brief/render/assemble.ts
@@ -21,16 +21,25 @@ export interface AssembleResult {
   warnings: string[];
 }
 
+/** Options for overriding the preset's default slide selection (t/2838, T7-v2). */
+export interface AssembleOptions {
+  /** Slide kinds to drop from the preset's ordered list. Required slides are never dropped. */
+  excludeSlides?: ReadonlySet<SlideKind>;
+}
+
 const REQUIRED_SLIDES: ReadonlySet<SlideKind> = new Set<SlideKind>([
   'title', 'question', 'provenance',
 ]);
 
-export function assemble(spec: DeckSpec, narration: Narration, preset: BriefPreset): AssembleResult {
+export function assemble(spec: DeckSpec, narration: Narration, preset: BriefPreset, options?: AssembleOptions): AssembleResult {
   const ctx = new AssembleCtx(spec, narration, preset);
   const profile = profileFor(preset);
+  const kindList = options?.excludeSlides
+    ? profile.slides.filter(k => REQUIRED_SLIDES.has(k) || !options.excludeSlides!.has(k))
+    : profile.slides;
   const slides: SlideModel[] = [];
 
-  for (const kind of profile.slides) {
+  for (const kind of kindList) {
     const slide = ctx.buildSlide(kind);
     if (slide === null) continue; // graceful-omit: no content and not required
     slides.push(slide);

--- a/lib/brief/render/index.ts
+++ b/lib/brief/render/index.ts
@@ -9,6 +9,7 @@
 import type { DeckSpec, Narration, BriefPreset } from '../types.js';
 import type { SlideModel } from './slideModel.js';
 import { assemble } from './assemble.js';
+import type { SlideKind } from './slideModel.js';
 import { resolveTheme } from './deckTheme.js';
 import { renderPptx } from './pptxRenderer.js';
 import { renderHtml } from './htmlRenderer.js';
@@ -23,6 +24,12 @@ export interface RenderInput {
    * `template_parse_error` warning is emitted if the bytes are not a valid zip.
    */
   template?: Uint8Array;
+  /**
+   * When explicitly false, removes the `framing_meta` slide from classroom exports (t/2838, T7-v2).
+   * Undefined / true → include it (preset default). Has no effect on policymaker/conference
+   * (neither preset includes `framing_meta`).
+   */
+  framingMeta?: boolean;
 }
 
 export interface RenderResult {
@@ -38,7 +45,10 @@ export interface RenderResult {
 
 export async function render(input: RenderInput): Promise<RenderResult> {
   const { theme, warning } = await resolveTheme(input.template);
-  const { slides, warnings } = assemble(input.spec, input.narration, input.preset);
+  const excludeSlides = input.framingMeta === false
+    ? new Set<SlideKind>(['framing_meta'])
+    : undefined;
+  const { slides, warnings } = assemble(input.spec, input.narration, input.preset, excludeSlides ? { excludeSlides } : undefined);
   const allWarnings: string[] = warning ? [warning, ...warnings] : [...warnings];
 
   let pptxBytes = await renderPptx(slides, theme);

--- a/lib/brief/render/render.test.ts
+++ b/lib/brief/render/render.test.ts
@@ -77,6 +77,7 @@ describe('render — outputs', () => {
     expect(r.pptxBytes[0]).toBe(0x50);
     expect(r.pptxBytes[1]).toBe(0x4b);
     expect(typeof r.htmlDoc).toBe('string');
+    expect(r.htmlDoc).toContain('<!DOCTYPE html');
     expect(r.slideModels.length).toBeGreaterThan(0);
   });
 });
@@ -100,6 +101,23 @@ describe('render — presets as masks', () => {
     expect(kinds).toContain('framing_meta');
     expect(kinds).toContain('glossary');
     expect(kinds).toContain('open_threads_appendix');
+  });
+
+  it('framingMeta:false removes framing_meta from classroom (t/2838)', async () => {
+    const r = await render({ spec: makeSpec(), narration: makeNarration(), preset: 'classroom', framingMeta: false });
+    expect(r.slideModels.map(s => s.kind)).not.toContain('framing_meta');
+    expect(r.slideModels.map(s => s.kind)).toContain('glossary'); // other classroom-only slides survive
+  });
+
+  it('framingMeta:true (explicit) keeps framing_meta for classroom', async () => {
+    const r = await render({ spec: makeSpec(), narration: makeNarration(), preset: 'classroom', framingMeta: true });
+    expect(r.slideModels.map(s => s.kind)).toContain('framing_meta');
+  });
+
+  it('framingMeta:false on conference/policymaker is a no-op (they never had the slide)', async () => {
+    const conf = await render({ spec: makeSpec(), narration: makeNarration(), preset: 'conference', framingMeta: false });
+    expect(conf.slideModels.map(s => s.kind)).not.toContain('framing_meta');
+    expect(conf.slideModels.length).toBe(11); // count unchanged
   });
 });
 

--- a/lib/brief/types.ts
+++ b/lib/brief/types.ts
@@ -218,5 +218,7 @@ export const BRIEF_ARTIFACTS = {
   narration: 'narration.json',
   manifest: 'audit-manifest.json',
   pptx: 'brief.pptx',
+  /** Self-contained HTML for Electron printToPDF (t/2838, T7-v2). */
+  htmlDoc: 'brief.html',
 } as const;
 export type BriefArtifactName = typeof BRIEF_ARTIFACTS[keyof typeof BRIEF_ARTIFACTS];

--- a/taxonomy-editor/src/server/__tests__/briefExports.test.ts
+++ b/taxonomy-editor/src/server/__tests__/briefExports.test.ts
@@ -227,6 +227,15 @@ describe('Brief Export routes (t/2804)', () => {
     expect(res._headers?.['Content-Disposition']).toMatch(/attachment/);
   });
 
+  it('GET artifact: brief.html ⇒ text/html content-type (t/2838)', async () => {
+    loadBriefArtifact.mockResolvedValue({ text: '<!DOCTYPE html><html></html>' });
+    const res = fakeRes();
+    await handlers['GET /api/exports/:exportId/artifacts/:name'](fakeReq(`/api/exports/e1/artifacts/${BRIEF_ARTIFACTS.htmlDoc}`), res, undefined);
+    expect(res._status).toBe(200);
+    expect(res._headers?.['Content-Type']).toMatch(/text\/html/);
+    expect(res._body).toBe('<!DOCTYPE html><html></html>');
+  });
+
   it('GET artifact: json ⇒ text/json body, 404 when absent', async () => {
     loadBriefArtifact.mockResolvedValue({ text: '{"a":1}' });
     const res = fakeRes();

--- a/taxonomy-editor/src/server/briefExportJobs.ts
+++ b/taxonomy-editor/src/server/briefExportJobs.ts
@@ -32,6 +32,8 @@ export interface ExportJobRequest {
   preset: BriefPreset;
   skipNarration: boolean;
   template?: Uint8Array;
+  /** When false, removes the framing_meta slide from classroom exports (t/2838). */
+  framingMeta?: boolean;
 }
 export interface ExportJob {
   jobId: string;
@@ -171,13 +173,15 @@ async function runExportJob(job: ExportJob, args: CreateJobArgs): Promise<void> 
     if (models.checkerModelId && !request.skipNarration) { setState(job, 'checking'); stage = 'checking'; }
     artifacts.push({ name: BRIEF_ARTIFACTS.narration, text: JSON.stringify(narration, null, 2) });
 
-    // ── render (pptx bytes; PDF is Electron-only, never here) ──
+    // ── render (pptx + htmlDoc; PDF is Electron-only, never here) ──
     setState(job, 'rendering'); stage = 'rendering';
-    const { pptxBytes, warnings: renderWarnings } = await render({
+    const { pptxBytes, htmlDoc, warnings: renderWarnings } = await render({
       spec, narration, preset: request.preset, template: request.template,
+      framingMeta: request.framingMeta,
     });
     job.warnings.push(...renderWarnings);
     artifacts.push({ name: BRIEF_ARTIFACTS.pptx, bytes: pptxBytes });
+    artifacts.push({ name: BRIEF_ARTIFACTS.htmlDoc, text: htmlDoc });
 
     // ── verify (build-fails-not-warns; manifest ALWAYS produced) ──
     setState(job, 'verifying'); stage = 'verifying';
@@ -250,7 +254,10 @@ async function persist(
     narratorModel: extra.narrator.modelId,
     narratorModelSource: extra.narrator.modelSource,
     checkerModel: extra.narrator.checkerModelId ?? null,
-    formats: artifacts.some(a => a.name === BRIEF_ARTIFACTS.pptx) ? ['pptx'] : [],
+    formats: [
+      ...(artifacts.some(a => a.name === BRIEF_ARTIFACTS.pptx) ? ['pptx'] : []),
+      ...(artifacts.some(a => a.name === BRIEF_ARTIFACTS.htmlDoc) ? ['html'] : []),
+    ],
     artifacts: artifacts.map(a => a.name),
     traceCoveragePct: extra.traceCoveragePct,
     warnings: extra.warnings,

--- a/taxonomy-editor/src/server/routes/briefExports.ts
+++ b/taxonomy-editor/src/server/routes/briefExports.ts
@@ -33,7 +33,8 @@ const TOOL_VERSIONS: Record<string, string> = { node: process.version, brief: '1
 
 interface ExportPostBody {
   preset?: unknown; format?: unknown; model?: unknown; checkerModel?: unknown;
-  template?: unknown; modelSource?: unknown; options?: { skipNarration?: unknown };
+  template?: unknown; modelSource?: unknown; framingMeta?: unknown;
+  options?: { skipNarration?: unknown };
 }
 
 /** The static, request-shape gates that need no I/O — auth, preset, PDF-is-desktop-only,
@@ -145,9 +146,10 @@ export function registerBriefExportsRoutes(r: Router, _ctx: ServerCtx): void {
       return;
     }
 
+    const framingMeta = b.framingMeta === false ? false : undefined;
     const job = startExportJob({
       userId, session, debateId, models,
-      request: { preset, skipNarration },
+      request: { preset, skipNarration, framingMeta },
       toolVersions: TOOL_VERSIONS, timestamp: new Date().toISOString(),
       idempotencyKey, adapter: createWebOpEdAdapter(),
     });
@@ -184,7 +186,8 @@ export function registerBriefExportsRoutes(r: Router, _ctx: ServerCtx): void {
         res.writeHead(200, { 'Content-Type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation', 'Content-Disposition': `attachment; filename="${name}"` });
         res.end(artifact.bytes);
       } else {
-        res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Disposition': `attachment; filename="${name}"` });
+        const ct = name === BRIEF_ARTIFACTS.htmlDoc ? 'text/html; charset=utf-8' : 'application/json';
+        res.writeHead(200, { 'Content-Type': ct, 'Content-Disposition': `attachment; filename="${name}"` });
         res.end(artifact.text);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- **htmlDoc artifact**: `render()` already produced a self-contained HTML doc for Electron `printToPDF`, but it was never stored. The job runner now captures it and saves it as `brief.html` alongside `.pptx` and manifest. The artifact download endpoint serves it as `text/html; charset=utf-8`. Adds `BRIEF_ARTIFACTS.htmlDoc = 'brief.html'` to the canonical registry.
- **framingMeta flag**: `POST /api/debates/:debateId/exports` now accepts `framingMeta:false` to suppress the `framing_meta` slide in classroom exports. Omitted/`true` → include (preset default). No effect on conference or policymaker (neither preset includes that slide). Implemented via `AssembleOptions.excludeSlides`; required slides (`title`/`question`/`provenance`) are never removed.
- **Sub-feature 3 (template theming)** deferred to child ticket.

## Files changed
- `lib/brief/types.ts` — adds `BRIEF_ARTIFACTS.htmlDoc`
- `lib/brief/render/assemble.ts` — adds `AssembleOptions.excludeSlides`
- `lib/brief/render/index.ts` — adds `framingMeta?: boolean` to `RenderInput`
- `lib/brief/render/render.test.ts` — 4 new framingMeta tests + DOCTYPE check
- `taxonomy-editor/src/server/briefExportJobs.ts` — captures htmlDoc, threads framingMeta, stores html artifact
- `taxonomy-editor/src/server/routes/briefExports.ts` — framingMeta in body, html content-type fix
- `taxonomy-editor/src/server/__tests__/briefExports.test.ts` — html content-type test (21 tests total)

## Test plan
- [ ] `pnpm vitest run "../lib/brief/render/render.test.ts"` from taxonomy-editor — 18 tests pass
- [ ] `pnpm vitest run "src/server/__tests__/briefExports.test.ts"` — 21 tests pass
- [ ] CI green on this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)