### PR TITLE
feat(t2841): make the verify gate snapshot-aware

### DIFF
--- a/lib/brief/verify.test.ts
+++ b/lib/brief/verify.test.ts
@@ -215,6 +215,59 @@ describe('verify — symmetry', () => {
   });
 });
 
+// ── Snapshot-aware symmetry (t/2841) ──────────────────────────────────────────
+
+const SNAPSHOT_META = {
+  id: 'sess-1', run_id: 'run-1', title: 'AI Safety Debate',
+  model: 'gemini-pro', protocol: 'structured', phase: 'open' as const, snapshot: true,
+};
+
+describe('verify — snapshot-aware symmetry (t/2841)', () => {
+  it('word_budget imbalance is a WARNING, not a hard-fail, when meta.snapshot', async () => {
+    const spec = makeSpec({ meta: SNAPSHOT_META });
+    const skewed = makeBalancedNarration({
+      entries: [
+        { trace: '/top_claims/0', text: 'one two three four five six seven eight nine ten eleven twelve', slide: 5 },
+        { trace: '/top_claims/1', text: 'short', slide: 5 },
+      ],
+    });
+    const result = await verify(await makeInput({ spec, narration: skewed }));
+    expect(result.hardFailures.filter(f => f.includes('word_budget'))).toEqual([]);
+    expect(result.hardFailures).toEqual([]); // no gate failures at all for the snapshot
+    expect(result.manifest.warnings.some(w => w.startsWith('snapshot_symmetry'))).toBe(true);
+  });
+
+  it('a camp with zero slides is a WARNING, not a hard-fail, when meta.snapshot', async () => {
+    const spec = makeSpec({ meta: SNAPSHOT_META });
+    const oneCamp = makeBalancedNarration({
+      entries: [{ trace: '/top_claims/0', text: 'only saf has spoken so far', slide: 5 }],
+    });
+    const result = await verify(await makeInput({ spec, narration: oneCamp }));
+    expect(result.hardFailures.some(f => f.includes('has 0 slides'))).toBe(false);
+    expect(result.manifest.warnings.some(w => w.includes('snapshot_symmetry'))).toBe(true);
+  });
+
+  it('correctness checks stay HARD even for a snapshot (unresolvable trace)', async () => {
+    const spec = makeSpec({ meta: SNAPSHOT_META });
+    const bad = makeBalancedNarration({
+      entries: [{ trace: '/nonexistent/path', text: 'hallucinated', slide: 1 }],
+    });
+    const result = await verify(await makeInput({ spec, narration: bad }));
+    expect(result.hardFailures.some(f => f.startsWith('trace resolution'))).toBe(true);
+  });
+
+  it('closed (non-snapshot) imbalance still hard-fails — no regression', async () => {
+    const skewed = makeBalancedNarration({
+      entries: [
+        { trace: '/top_claims/0', text: 'one two three four five six seven eight nine ten eleven twelve', slide: 5 },
+        { trace: '/top_claims/1', text: 'short', slide: 5 },
+      ],
+    });
+    const result = await verify(await makeInput({ narration: skewed }));
+    expect(result.hardFailures.some(f => f.includes('word_budget'))).toBe(true);
+  });
+});
+
 // ── Red arm: OOXML lint ────────────────────────────────────────────────────────
 
 describe('verify — OOXML lint', () => {

--- a/lib/brief/verify.ts
+++ b/lib/brief/verify.ts
@@ -76,15 +76,23 @@ export async function verify(input: VerifyInput): Promise<VerifyResult> {
   const { coveragePct, coverageFailures } = checkTraceCoverage(spec, narration);
   for (const msg of coverageFailures) hardFailures.push(msg);
 
-  // 5 — per-camp symmetry
+  // 5 — per-camp symmetry. For an in-progress snapshot (meta.snapshot=true) the deck is
+  // inherently incomplete/imbalanced (the debate hasn't concluded), so symmetry breaches
+  // are recorded as warnings, NOT gate failures (t/2841) — else every snapshot errors.
+  // Correctness checks (schema/trace/coverage/OOXML) stay HARD even for snapshots.
+  const isSnapshot = spec.meta.snapshot === true;
   const { symmetry, symmetryFailures } = computeSymmetry(spec, narration, tolerancePct);
-  for (const msg of symmetryFailures) hardFailures.push(msg);
+  const snapshotSymmetryWarnings: string[] = [];
+  for (const msg of symmetryFailures) {
+    if (isSnapshot) snapshotSymmetryWarnings.push(`snapshot_symmetry: ${msg}`);
+    else hardFailures.push(msg);
+  }
 
   // 6 — OOXML lint on the shipped bytes
   for (const msg of await lintOoxml(pptxBytes)) hardFailures.push(msg);
 
   // Warnings (recorded, never fail the build)
-  const warnings = computeWarnings(spec, symmetry);
+  const warnings = [...computeWarnings(spec, symmetry, isSnapshot), ...snapshotSymmetryWarnings];
 
   // Assemble the manifest — records reality regardless of pass/fail
   const manifest: AuditManifest = {
@@ -376,7 +384,7 @@ async function lintOoxml(pptxBytes: Uint8Array): Promise<string[]> {
 
 // ── Warnings (recorded, never fail) ───────────────────────────────────────────
 
-function computeWarnings(spec: DeckSpec, symmetry: SymmetryAudit): string[] {
+function computeWarnings(spec: DeckSpec, symmetry: SymmetryAudit, isSnapshot: boolean): string[] {
   const warnings: string[] = [];
   if (spec.convergence.some(c => c.score < 0.3)) {
     warnings.push('low_convergence: one or more issues have a convergence score below 0.3');
@@ -393,7 +401,9 @@ function computeWarnings(spec: DeckSpec, symmetry: SymmetryAudit): string[] {
   }
   // A symmetry breach also surfaces as a manifest warning (the hard-fail is separate).
   if (!symmetry.within_tolerance) {
-    warnings.push('symmetry_breach: per-camp parity is outside tolerance (see hard-failures)');
+    warnings.push(isSnapshot
+      ? 'symmetry_breach: per-camp parity is outside tolerance (allowed — in-progress snapshot)'
+      : 'symmetry_breach: per-camp parity is outside tolerance (see hard-failures)');
   }
   return warnings;
 }


### PR DESCRIPTION
## t/2841 — snapshot-aware verify (prerequisite for the T6 allowOpen flip)

Follow-up to t/2816 allowOpen (TL flag p/342#89). An in-progress snapshot (`spec.meta.snapshot === true`, from extract's allowOpen path) is inherently incomplete/imbalanced — the debate hasn't concluded. Today the **symmetry** gate would hard-fail such a deck (partial/imbalanced per-camp content), so *every* snapshot export would error.

### Change (verify.ts)
- When `meta.snapshot === true`: per-camp **symmetry** breaches (presence / word_budget / headline) are recorded as `snapshot_symmetry:` **warnings** in the manifest, NOT gate hard-failures.
- **Correctness stays HARD for snapshots:** deck_spec/narration schema, trace resolvability + coverage, OOXML lint (a snapshot's traces/bytes must still be valid).
- Closed (non-snapshot) exports: **unchanged** — real imbalance still hard-fails.

### Both-arms GV evidence (4 new tests, 21/21 pass)
- Snapshot word_budget imbalance → `hardFailures == []`, `snapshot_symmetry` warning present.
- Snapshot 0-slide camp → not a hard-fail (warned).
- **Snapshot + unresolvable trace → still hard** (correctness unchanged).
- **Closed imbalance → still hard** (no regression).

Clean under nodenext (t/2832 gate) + bundler; lint clean.

→ Main-TL: gate-touching → both-arms Gate Verification. Sequenced **before** the T6 `?allowOpen=true` flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)