### PR TITLE
infra: brief-exports blob containers + 30-day lifecycle policy (t/2821)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -392,6 +392,63 @@ resource stagingAnalyticsContainer 'Microsoft.Storage/storageAccounts/blobServic
   }
 }
 
+// ── Brief Export artifact containers (t/2821) ──
+// Dedicated containers isolate brief export blobs so the lifecycle policy
+// (managementPolicies below) can target them without touching user-content.
+// SYNC WITH Invoke-BlobContainerGateCheck.ps1: update the container list there too.
+
+resource briefExportsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'brief-exports'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource stagingBriefExportsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'staging-brief-exports'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+// ── Brief Export artifact lifecycle policy (t/2821) ──
+// 30-day flat delete on brief-exports and staging-brief-exports.
+// Zero runtime cost; runs even when the app is scaled to 0.
+// Count-quota (t/2831) handles live hygiene; this rule handles stale cleanup.
+resource briefExportsLifecyclePolicy 'Microsoft.Storage/storageAccounts/managementPolicies@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+  properties: {
+    policy: {
+      rules: [
+        {
+          name: 'delete-stale-brief-exports'
+          enabled: true
+          type: 'Lifecycle'
+          definition: {
+            actions: {
+              baseBlob: {
+                delete: {
+                  daysAfterModificationGreaterThan: 30
+                }
+              }
+            }
+            filters: {
+              blobTypes: ['blockBlob']
+              prefixMatch: [
+                'brief-exports/'
+                'staging-brief-exports/'
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
 // ── Staging Azure Files — writable state share (t/2643) ──
 // Class-A writes (flags, config, calibration, keys) from staging route here.
 // Prod's 'taxonomy-data' share is NOT declared here (managed externally) — it

--- a/operations/devops/Invoke-BlobContainerGateCheck.ps1
+++ b/operations/devops/Invoke-BlobContainerGateCheck.ps1
@@ -4,7 +4,7 @@
 
 <#
 .SYNOPSIS
-    Post-deploy gate: verify all 6 blob containers exist and are accessible.
+    Post-deploy gate: verify all 8 blob containers exist and are accessible.
 .DESCRIPTION
     Called by deploy-azure.yml after the Bicep deploy, before traffic switch.
     Discriminates ContainerNotFound (404) from RBAC failures (403) so on-call
@@ -16,11 +16,13 @@ param(
     [Parameter(Mandatory)] [string] $StorageAccount,
     # SYNC WITH main.bicep: analyticsContainer, stagingAnalyticsContainer,
     # userContentContainer, stagingUserContentContainer, communityContainer,
-    # stagingCommunityContainer. Update both if a container is added or removed.
+    # stagingCommunityContainer, briefExportsContainer, stagingBriefExportsContainer.
+    # Update both if a container is added or removed.
     [string[]] $Containers = @(
         'analytics', 'staging-analytics',
         'user-content', 'staging-user-content',
-        'community', 'staging-community'
+        'community', 'staging-community',
+        'brief-exports', 'staging-brief-exports'
     )
 )
 


### PR DESCRIPTION
## Summary
- Adds dedicated `brief-exports` and `staging-brief-exports` blob containers
- Adds `managementPolicies` lifecycle rule: delete blobs in those containers after 30 days of no modification (flat delete, no Cool-tier intermediate step)
- Updates `Invoke-BlobContainerGateCheck.ps1` from 6 → 8 expected containers so the post-deploy gate catches a missing `brief-exports` container before traffic cutover

## Why dedicated containers
Brief exports currently write to `user-content` under `users/<userId>/brief-exports/`. A lifecycle rule can't safely prefix-filter `users/` (would delete all user content). Dedicated containers let the rule target `brief-exports/` cleanly with no bleed.

## Engineering dependency
`briefExportStore.ts` must write to the `brief-exports` container (not `user-content`) for the lifecycle policy to take effect. Pinging owner in t/2821 comment.

## Policy rationale (t/2821#1)
- 30-day TTL, flat delete — stale artifact cleanup, not a cost driver
- ~$0.06/month at current scale; count-quota (t/2831) handles live hygiene

## Test plan
- [ ] `test-container` CI job green (Bicep linting/validation)
- [ ] Post-deploy: `az storage container show --name brief-exports` exists in prod storage account
- [ ] `Invoke-BlobContainerGateCheck.ps1` passes with all 8 containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
