### PR TITLE
docs(t2828): debate reflections theory-of-operations doc

### DIFF
--- a/docs/debate-reflections.md
+++ b/docs/debate-reflections.md
@@ -46,7 +46,7 @@ Line 3: "Excludes: [2-3 neighboring concepts named neutrally]."
 
 The differentia states *what* the position is, not why it is correct. Causal connectors (`rendering`, `thereby`, `thus`, `therefore`, `contingent on`) are not allowed in line 1. Each description carries exactly one concept in the differentia. Packing mechanism, target, and caveats into one clause is a compliance failure.
 
-After the model returns its proposals, the engine checks each proposed description against these rules. If any description fails, the engine sends a targeted retry prompt with the specific violations listed. It retries up to three times per edit. A description that still fails after three attempts is excluded from the reflection set.
+After the model returns its proposals, the engine checks each proposed description against these rules. If any description fails, the engine sends a targeted retry prompt with the specific violations listed. It retries up to three times per edit. A description that still fails after three attempts is surfaced to the human as-is.
 
 ## Approval flow
 


### PR DESCRIPTION
## Summary
- Adds `docs/debate-reflections.md`: theory-of-operations doc for Post-Debate Reflections
- Covers all six ACs: camp ordering, cross-camp visibility, proposal generation (Revise/Qualify/Deprecate/propose_new), DOLCE compliance + retry behavior, evidence citation, and the Approve & Apply / Dismiss / Approve All / Dismiss All approval flow
- Fixes one factual error from prior session: DOLCE retry failure surfaces the description as-is (not excluded)

## Test plan
- [ ] CI green
- [ ] Docs-only change — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: DebateTool (Orca) <main.lib-debate@ai-triad-research.orca.local>