### PR TITLE
feat(t2846): remove pitch email UI and output from Op-Ed tool

### DIFF
--- a/taxonomy-editor/src/main/__tests__/opedHandlers.migration.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedHandlers.migration.test.ts
@@ -86,7 +86,6 @@ const FAKE_MEMBER: OpEdMember = {
   status: 'complete',
   headline: 'Test Headline',
   subtitle: 'Test Subtitle',
-  pitch: 'Test Pitch',
   body: 'Body text.',
   wordCount: 2,
   grounding: [{ node_id: 'acc-bel-001', label: 'Node A', category: 'Beliefs', pov: 'accelerationist', relevance: 'High', how_reflected: 'Directly cited' }],

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -144,7 +144,6 @@ function renderOpEdSetMarkdown(set: OpEdSet): string {
     lines.push(`## ${member.pov}`, '', `### ${member.headline}`);
     if (member.subtitle) lines.push('', `*${member.subtitle}*`);
     lines.push('', member.body);
-    if (member.pitch) lines.push('', '**Pitch:**', '', member.pitch);
     if (member.grounding?.length) {
       lines.push('', '**Grounding:**', '');
       for (const g of member.grounding) {

--- a/taxonomy-editor/src/main/ps/invoke-oped.ps1
+++ b/taxonomy-editor/src/main/ps/invoke-oped.ps1
@@ -44,9 +44,6 @@ if ($null -ne $p.PSObject.Properties['SourcePrep'] -and $null -ne $p.SourcePrep)
 if ($null -ne $p.PSObject.Properties['WordCount'] -and $null -ne $p.WordCount) {
     $splat['WordCount'] = [int]$p.WordCount
 }
-if ($null -ne $p.PSObject.Properties['IncludePitch'] -and $null -ne $p.IncludePitch) {
-    $splat['IncludePitch'] = [bool]$p.IncludePitch
-}
 
 # Run New-OpEd, intercepting the verbose stream (4>&1) to emit stage events
 $lastResult = $null

--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -98,7 +98,6 @@ export interface CreateOpEdParams {
   temperature?: number;
   maxGroundingNodes?: number;
   maxSituations?: number;
-  includePitch?: boolean;
   voiceOnly?: boolean;
 }
 export interface CreateOpEdPayload { topic: string; url?: string; params: CreateOpEdParams; voices: PovKey[] }

--- a/taxonomy-editor/src/renderer/components/PublicOpEdView.tsx
+++ b/taxonomy-editor/src/renderer/components/PublicOpEdView.tsx
@@ -24,7 +24,7 @@ import './PublicOpEdView.css';
  * Public projection of a shared op-ed set — MUST mirror the server-side
  * `PublicOpEd` / `PublicOpEdMember` positive allowlist (opedShareStore.ts). Exactly
  * these fields are public; generation params (model/prompts/thesis/authorBio),
- * the pitch draft, grounding internals, userId and the storage set_id are never exposed.
+ * grounding internals, userId and the storage set_id are never exposed.
  */
 export interface PublicOpEdMember {
   pov: string;

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.css
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.css
@@ -166,7 +166,7 @@
   margin-top: 0.3rem;
 }
 
-/* ── More options / pitch footer ───────────────────────────────────────────── */
+/* ── More options footer ───────────────────────────────────────────────────── */
 
 .oped-more-options-btn {
   background: none;
@@ -197,14 +197,6 @@
   color: var(--bg-primary, #fff);
   font-size: 0.7rem;
   font-weight: 700;
-}
-
-.oped-pitch-row {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-size: 0.8125rem;
-  color: var(--text-primary);
 }
 
 /* ── Footer ────────────────────────────────────────────────────────────────── */

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
@@ -3,7 +3,7 @@
 
 // NewOpEdDialog — Op-Ed Studio create flow (t/2576 PR#2, §5). Two screens mirroring
 // NewDebateDialog: Screen A is the essential form (topic/url, multi-select voices,
-// outlet, news hook, pitch); Screen B is the "More options" settings drawer. On Draft
+// outlet, news hook); Screen B is the "More options" settings drawer. On Draft
 // the dialog shows a live progress panel (not a spinner) fed by api.onOpEdProgress and
 // finalizes by opening the created set in the reader. The bridge trio (createOpEdSet /
 // cancelOpEdSet / onOpEdProgress) is Electron-only; web keeps the disabled affordance.
@@ -488,8 +488,6 @@ interface CreateFormProps {
   setOutlet: (v: string) => void;
   newsHook: string;
   setNewsHook: (v: string) => void;
-  includePitch: boolean;
-  setIncludePitch: (v: boolean) => void;
   settingsDiffCount: number;
   onOpenSettings: () => void;
   startError: ActionableShape | null;
@@ -623,10 +621,6 @@ function OpEdCreateForm(p: CreateFormProps) {
           </div>
         )}
         <div className="oped-footer-actions">
-          <label className="oped-pitch-row">
-            <input type="checkbox" checked={p.includePitch} onChange={e => p.setIncludePitch(e.target.checked)} />
-            Pitch email too
-          </label>
           <div className="oped-footer-right">
             <button type="button" className="btn" onClick={p.onClose}>Cancel</button>
             <button
@@ -661,7 +655,7 @@ export function NewOpEdDialog({ open, onClose, onCreated, allowUrlSource = true 
   const [voices, setVoices] = useState<Set<PovKey>>(new Set());
   const [outlet, setOutlet] = useState(DEFAULTS.outlet);
   const [newsHook, setNewsHook] = useState('');
-  const [includePitch, setIncludePitch] = useState(false);
+
 
   // Screen B–owned
   const [wordCount, setWordCount] = useState<number | null>(DEFAULTS.wordCount);
@@ -769,7 +763,6 @@ export function NewOpEdDialog({ open, onClose, onCreated, allowUrlSource = true 
       authorBio: authorBio.trim() || undefined,
       model: activeModel,
       temperature,
-      includePitch: includePitch || undefined,
     };
     if (fromWebPage && url.trim()) params.url = url.trim();
     if (wordCount != null) params.wordCount = wordCount;
@@ -860,8 +853,6 @@ export function NewOpEdDialog({ open, onClose, onCreated, allowUrlSource = true 
             setOutlet={setOutlet}
             newsHook={newsHook}
             setNewsHook={setNewsHook}
-            includePitch={includePitch}
-            setIncludePitch={setIncludePitch}
             settingsDiffCount={settingsDiffCount}
             onOpenSettings={() => setShowSettings(true)}
             startError={startError}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
@@ -116,14 +116,6 @@
 .oped-reader-body ul,
 .oped-reader-body ol { margin: 0 0 1rem 1.25rem; }
 
-/* Pitch (collapsible) */
-.oped-pitch {
-  margin-top: 1.5rem;
-  border-top: 1px solid var(--border-color);
-  padding-top: 1rem;
-}
-
-.oped-pitch-summary,
 .oped-grounding-summary {
   cursor: pointer;
   font-size: 0.85rem;
@@ -132,10 +124,7 @@
   user-select: none;
 }
 
-.oped-pitch-summary:hover,
 .oped-grounding-summary:hover { color: var(--text-primary); }
-
-.oped-pitch-body { margin-top: 0.75rem; }
 
 /* Voice-only notice (empty grounding) */
 .oped-voice-only {

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -205,15 +205,6 @@ function OpEdArticle({ member, outlet }: { member: OpEdMember; outlet?: string }
             <Markdown remarkPlugins={[remarkGfm]}>{member.body}</Markdown>
           </div>
 
-          {member.pitch && (
-            <details className="oped-pitch">
-              <summary className="oped-pitch-summary">Pitch cover email</summary>
-              <div className="oped-reader-body oped-pitch-body">
-                <Markdown remarkPlugins={[remarkGfm]}>{member.pitch}</Markdown>
-              </div>
-            </details>
-          )}
-
           <GroundingSection grounding={member.grounding} />
         </>
       )}

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -48,7 +48,6 @@ function buildOpEdMarkdown(set: OpEdSet): string {
       return;
     }
     lines.push(m.body);
-    if (m.pitch) { lines.push('\n---\n\n## Pitch cover email\n'); lines.push(m.pitch); }
     if (m.grounding.length > 0) {
       lines.push('\n---\n\n## Taxonomy grounding\n');
       lines.push('| Element | Type | Relevance | Reflected in the op-ed |');

--- a/taxonomy-editor/src/server/__tests__/opedShareStore.test.ts
+++ b/taxonomy-editor/src/server/__tests__/opedShareStore.test.ts
@@ -2,9 +2,9 @@
 //
 // t/2727 — op-ed public-share projection (the info-leak control). projectPublicOpEd
 // is a POSITIVE field allowlist: an OpEdSet laden with generation params (model,
-// prompts, thesis, authorBio, newsHook), per-voice pitch-email drafts, and grounding
-// internals must project to EXACTLY the public wire shape and nothing more. This is
-// what guarantees no private field is ever written to the public copy at rest.
+// prompts, thesis, authorBio, newsHook) and grounding internals must project to
+// EXACTLY the public wire shape and nothing more. This is what guarantees no private
+// field is ever written to the public copy at rest.
 
 import { describe, it, expect } from 'vitest';
 import { projectPublicOpEd } from '../storage/opedShareStore.js';
@@ -31,7 +31,6 @@ const ladenSet = {
       headline: 'The case for speed',
       subtitle: 'Why caution costs lives',
       body: 'Full essay body text.',
-      pitch: 'PRIVATE pitch email draft to the editor',
       wordCount: 812,
       grounding: [
         { node_id: 'acc-beliefs-095', label: 'internal', category: 'beliefs', pov: 'accelerationist', relevance: '0.9', how_reflected: 'internal note' },
@@ -52,7 +51,7 @@ describe('projectPublicOpEd — positive allowlist (info-leak guard, t/2727)', (
     expect(pub).not.toHaveProperty('params');
   });
 
-  it('per-voice members carry EXACTLY the public fields — no pitch, no grounding', () => {
+  it('per-voice members carry EXACTLY the public fields — no grounding', () => {
     const pub = projectPublicOpEd(ladenSet, 'share-xyz');
     expect(pub.opeds).toHaveLength(1);
     expect(Object.keys(pub.opeds[0]).sort()).toEqual(
@@ -67,7 +66,6 @@ describe('projectPublicOpEd — positive allowlist (info-leak guard, t/2727)', (
       'PRIVATE thesis',                // params.thesis
       'PRIVATE author bio',            // params.authorBio
       'PRIVATE news hook',             // params.newsHook
-      'PRIVATE pitch email',           // member.pitch
       'gemini-3.5-flash-lite',         // params.model
       'how_reflected', 'node_id',      // grounding internals
       'acc-beliefs-095',

--- a/taxonomy-editor/src/server/storage/opedShareStore.ts
+++ b/taxonomy-editor/src/server/storage/opedShareStore.ts
@@ -34,7 +34,7 @@ function shareRegistryPath(): string {
 
 // ── Public wire shape — POSITIVE allowlist, the info-leak control ─────────────
 // Only these fields ever reach the public copy at rest. Generation params (model,
-// prompts, thesis, authorBio, newsHook), the pitch-email draft, grounding internals,
+// prompts, thesis, authorBio, newsHook), grounding internals,
 // userId, and the storage set_id are all STRIPPED — never a spread/denylist.
 export interface PublicOpEdMember {
   pov: string;


### PR DESCRIPTION
## Summary
- Removes all `IncludePitch` controls from `NewOpEdDialog` (checkbox, state, prop, payload)
- Removes pitch output from `OpEdReader` (collapsible block), `OpEdTab` (Markdown export), `opedHandlers.ts` (Markdown renderer), and `invoke-oped.ps1` (PS pass-through)
- Removes `includePitch?: boolean` from `CreateOpEdParams` bridge type
- Removes all pitch CSS rules from `NewOpEdDialog.css` and `OpEdReader.css`
- Cleans up pitch fixtures and assertions from `opedShareStore.test.ts` and `opedHandlers.migration.test.ts`
- Updates `opedShareStore.ts` and `PublicOpEdView.tsx` comments to remove pitch references

## Test plan
- [ ] `opedShareStore.test.ts` — 5 tests pass (positive allowlist guard + public-safe fields)
- [ ] `opedHandlers.migration.test.ts` — all tests pass
- [ ] `npm run verify` clean (tsc + vitest)

Closes t/2846

🤖 Generated with [Claude Code](https://claude.com/claude-code)