### PR TITLE
fix(brief): repair broken-main renderer-tsc (ARTIFACT_LABEL) + relocate soul-doc bookmark (t/2827)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.tsx
@@ -36,6 +36,9 @@ const ARTIFACT_LABEL: Record<BriefArtifactName, string> = {
   [BRIEF_ARTIFACTS.narration]: 'Narration (JSON)',
   [BRIEF_ARTIFACTS.manifest]: 'Audit manifest (JSON)',
   [BRIEF_ARTIFACTS.pptx]: 'Slides (PPTX)',
+  // brief.html is the printToPDF source (Electron-only, t/2838); label kept so the
+  // Record<BriefArtifactName> stays exhaustive after htmlDoc was added to BRIEF_ARTIFACTS.
+  [BRIEF_ARTIFACTS.htmlDoc]: 'HTML (PDF source)',
 };
 
 const POLL_MS = 1500;

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -81,6 +81,8 @@ interface NodeDetailProps {
   onPin?: () => void;
   onSimilarSearch?: () => void;
   onRelated?: () => void;
+  /** Opens the camp Soul Document dialog (t/2827) — rendered in the header icon row, Advanced-view only. */
+  onOpenSoulDoc?: () => void;
   chipDepth?: number;
   conflict?: NodeConflict;
   resolveUrl?: string | null;
@@ -115,7 +117,7 @@ function getNodeAphorism(node: PovNode): string | undefined {
   return node.graph_attributes?.aphorism;
 }
 
-export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRelated, chipDepth = 0, conflict, resolveUrl }: NodeDetailProps) {
+export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRelated, onOpenSoulDoc, chipDepth = 0, conflict, resolveUrl }: NodeDetailProps) {
   const { updatePovNode, deletePovNode, movePovNodeCategory, movePovNode, validationErrors, getAllNodeIds, getAllConflictIds, runAttributeFilter, showAttributeInfo, navigateToLineage, setToolbarPanel, selectedEdge, relatedNodeId, loadEdges, edgesFile, setSelectedNodeId, getLabelForId, aggregatedCruxes, showCruxDetail, conflicts } = useTaxonomyStore();
   const viewMode = usePreferencesStore(state => state.viewMode);
   const [descMode, setDescMode] = useDescriptionMode();
@@ -410,6 +412,11 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
             tooltip="Open Soul Documents Analysis in GitHub"
             size={15}
           />
+          {/* Soul-doc bookmark relocated here (t/2827), right of the soul-doc icon; Advanced-view
+              only (same bookmark-control gate as t/2826 — not an always-visible control). */}
+          {viewMode === 'advanced' && onOpenSoulDoc && (
+            <button className="nd-header-btn" onClick={onOpenSoulDoc} title="Soul document" aria-label="Soul document">&#x1f4dc;</button>
+          )}
           <EditConflictBadge conflict={conflict} resolveUrl={resolveUrl} />
         </div>
 

--- a/taxonomy-editor/src/renderer/components/taxonomy/PovTab.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/PovTab.tsx
@@ -808,9 +808,9 @@ export function PovTab({ pov }: PovTabProps) {
         // eslint-disable-next-line local/no-inline-style -- width is a user-resized panel size from useResizablePanel
         <div className="list-panel" ref={listPanelRef} style={{ width }}>
           <div className="list-panel-header">
-            <div className="list-panel-header-title">
-              <button className="btn btn-sm btn-ghost" onClick={() => setShowSoulDoc(true)} title="Soul document" aria-label="Soul document">&#x1f4dc;</button>
-            </div>
+            {/* t/2827: the Soul-document control moved into the POV detail header icon row
+                (NodeDetail nd-header-meta, right of the soul-doc icon). Title kept for layout. */}
+            <div className="list-panel-header-title"></div>
             <div className="list-panel-header-actions">
               {/* t/2813: Search entry point relocated from the nav rail into the Taxonomy panel header. */}
               <button className="btn btn-sm btn-ghost" onClick={() => setToolbarPanel('search')} title="Search taxonomy" aria-label="Search taxonomy">
@@ -944,7 +944,7 @@ export function PovTab({ pov }: PovTabProps) {
                 </div>
               )}
               {selectedNode ? (
-                <NodeDetail pov={pov} node={selectedNode} onPin={handlePin} onSimilarSearch={handleSimilarSearch} onRelated={handleRelated} conflict={nodeConflicts.conflicts.get(selectedNode.id)} resolveUrl={syncStatus.pr_url} />
+                <NodeDetail pov={pov} node={selectedNode} onPin={handlePin} onSimilarSearch={handleSimilarSearch} onRelated={handleRelated} onOpenSoulDoc={() => setShowSoulDoc(true)} conflict={nodeConflicts.conflicts.get(selectedNode.id)} resolveUrl={syncStatus.pr_url} />
               ) : (
                 <div className="detail-panel-empty">Select a node to edit</div>
               )}


### PR DESCRIPTION
## ⚠ Contains a broken-main fix — please expedite

**main renderer-tsc is currently RED** (blocks every renderer PR): t/2838 added `htmlDoc: 'brief.html'` to `BRIEF_ARTIFACTS`, so `BriefArtifactName` gained a member, but `BriefExportDialog`'s `ARTIFACT_LABEL: Record<BriefArtifactName, string>` wasn't updated → **TS2741**. This PR adds the missing `htmlDoc` label. (Cross-ticket coupling miss between t/2838 and my merged T7 #1273.)

## t/2827 (self-cert, layout)
Moved the Soul-document control from the taxonomy-panel list header into the **POV detail header icon row** (`NodeDetail` `nd-header-meta`, right of the soul-doc icon) via a new `onOpenSoulDoc` prop. Gated **Advanced-view only** (same bookmark-control gate as t/2826 — not reintroduced as always-visible, per TL t/2827#1). PovTab keeps the `showSoulDoc` state + `SoulDocDialog`; only the trigger moved.

### Verify
renderer tsc clean (both fixes), eslint 0 errors. Layout-only for the relocation; no behavior/data change.