### PR TITLE
chore(t2845): drop the now-unused OpEd pitch type field

### DIFF
--- a/lib/oped/types.ts
+++ b/lib/oped/types.ts
@@ -42,7 +42,6 @@ export interface OpEdMember {
   headline: string;
   subtitle: string;
   body: string;
-  pitch?: string;
   wordCount: number;
   grounding: OpEdGroundingRef[];
   /** Set when FABRICATED_LEDE_GUARD matched the lede on an empty-newsHook run (t/2730). */


### PR DESCRIPTION
## t/2845 — final part: remove the OpEd `pitch?` type field

Completes t/2845 (part of t/2843). Removes `pitch?: string` from the OpEd member interface (`lib/oped/types.ts:45`) — the last pitch reference. Deferred until now as the cross-scope compile linchpin; **t/2846 (#1284)** removed all `member.pitch` renderer/main consumers (grep-clean confirmed), so it's safe.

15 oped tests pass; 0 oped tsc errors (bundler); lint clean.

### 🚧 Draft — held on a pre-existing broken-main (NOT this change)
`renderer-tsc` is currently **red on main** from **t/2838** (T7-v2): it added `htmlDoc: 'brief.html'` to `BRIEF_ARTIFACTS`, so `BriefArtifactName` now includes `'brief.html'`, but `BriefExportDialog.tsx:34` builds an exhaustive `Record<BriefArtifactName, string>` missing that key → TS2741 (ceiling 0). Surfaced to root Main + TL (p/468). This PR is unrelated to that break — un-drafting + merging once main's renderer-tsc is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)