### PR TITLE
feat(console): pwsh console imports AITriad on launch via pty-broker (t/2830)

### DIFF
--- a/taxonomy-editor/src/main/pty-broker.py
+++ b/taxonomy-editor/src/main/pty-broker.py
@@ -45,7 +45,17 @@ def set_winsize(fd, cols, rows):
 
 def main():
     shell = find_shell()
-    shell_args = [shell, "-NoLogo"] if "pwsh" in shell else [shell]
+    if "pwsh" in shell:
+        shell_args = [shell, "-NoLogo"]
+        # Import the AITriad module on launch so cmdlets are available in the console (t/2830).
+        # The path comes from the server (AITRIAD_MODULE env), resolved the same way the app
+        # resolves scripts/ (config.ts SCRIPTS_DIR) — never hardcoded. -NoExit keeps the session
+        # interactive after the import; a missing module degrades gracefully to a plain pwsh shell.
+        module = os.environ.get("AITRIAD_MODULE")
+        if module and os.path.isfile(module):
+            shell_args += ["-NoExit", "-Command", "Import-Module '{}' -Force".format(module)]
+    else:
+        shell_args = [shell]
 
     pid = -1
     master_fd = -1

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -1192,7 +1192,10 @@ function handleTerminalConnection(ws: WebSocket) {
   const pythonCmd = process.platform === 'win32' ? 'python' : 'python3';
   terminalProcess = spawn(pythonCmd, [BROKER_SCRIPT], {
     cwd: getProjectRoot(),
-    env: { ...safeEnv, TERM: 'xterm-256color', PTY_COLS: '120', PTY_ROWS: '30' },
+    // AITRIAD_MODULE (t/2830): the broker imports this into the pwsh console on launch.
+    // Resolved via the server's SCRIPTS_DIR (config.ts, .aitriad.json-anchored) so it works
+    // in the container (/app/scripts) and dev alike — never a hardcoded path.
+    env: { ...safeEnv, TERM: 'xterm-256color', PTY_COLS: '120', PTY_ROWS: '30', AITRIAD_MODULE: path.join(SCRIPTS_DIR, 'AITriad', 'AITriad.psd1') },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 


### PR DESCRIPTION
## t/2830 — web console: pwsh + AITriad on launch

Spin-off from t/2824. Diagnosis: the web-console **pty-broker** (`src/main/pty-broker.py`, not the Electron `terminal.ts` which was already pwsh) is the launcher in scope. `find_shell()` already **prefers pwsh** (first in its candidate list), so **AC1 is satisfied now that t/2824 installed pwsh in the container** — the bash fallback was the pre-pwsh state. The real gap was **AC2**: the broker never imported AITriad.

### Change (2 files, self-cert)
- **server.ts** — pass `AITRIAD_MODULE` to the broker env, resolved via `SCRIPTS_DIR` (config.ts, `.aitriad.json`-anchored → `/app/scripts` in the container, correct in dev too). Not hardcoded.
- **pty-broker.py** — pwsh launches with `-NoExit -Command "Import-Module <m> -Force"`; a missing module **degrades gracefully** to a plain pwsh shell (no hard fail).

### Verify
server tsc clean; broker `py_compile` OK. **No Python unit test** — the broker has no pytest harness in this repo (deviation from the self-cert 'add a test' note; flagged).

### AC3 → DevOps
"Verified against the deployed container" (pwsh session opens + AITriad cmdlets available) needs a **deployed-container check** — coordinating with DevOps post-merge.