### PR TITLE
ci: renderer-tsc also runs on lib/** changes (t/2854)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,12 +316,15 @@ jobs:
   # imported a not-yet-landed lib/bandColor path; CI went green and the PR merged.
   # check-renderer-tsc.sh calls `tsc -p tsconfig.json --noEmit` and compares
   # error count against quality-gates.json tsc_error_ceilings (ceiling currently 0).
-  # Path-filtered to `electron` changes — docs/PS-only PRs skip (OK in ci-gate).
+  # Path-filtered to `electron` OR `lib` changes — lib types are renderer-consumed
+  # (e.g. BriefArtifactName) and a lib type widening must trigger renderer-tsc so
+  # exhaustive-map mismatches don't land on main silently (t/2854). PS/docs/analytics
+  # PRs still skip. Gate Verification required before relying on this to block (t/2854 AC).
   renderer-tsc:
     needs: [changes]
     if: >-
       always() && !cancelled() &&
-      (github.event_name != 'pull_request' || needs.changes.outputs.electron == 'true')
+      (github.event_name != 'pull_request' || needs.changes.outputs.electron == 'true' || needs.changes.outputs.lib == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6

--- a/lib/brief/types.ts
+++ b/lib/brief/types.ts
@@ -220,7 +220,5 @@ export const BRIEF_ARTIFACTS = {
   pptx: 'brief.pptx',
   /** Self-contained HTML for Electron printToPDF (t/2838, T7-v2). */
   htmlDoc: 'brief.html',
-  /** GV Arm-1 throwaway — revert after red run confirms renderer-tsc triggers (t/2854). */
-  gvTestArtifact: 'gv-test.json',
 } as const;
 export type BriefArtifactName = typeof BRIEF_ARTIFACTS[keyof typeof BRIEF_ARTIFACTS];

--- a/lib/brief/types.ts
+++ b/lib/brief/types.ts
@@ -220,5 +220,7 @@ export const BRIEF_ARTIFACTS = {
   pptx: 'brief.pptx',
   /** Self-contained HTML for Electron printToPDF (t/2838, T7-v2). */
   htmlDoc: 'brief.html',
+  /** GV Arm-1 throwaway — revert after red run confirms renderer-tsc triggers (t/2854). */
+  gvTestArtifact: 'gv-test.json',
 } as const;
 export type BriefArtifactName = typeof BRIEF_ARTIFACTS[keyof typeof BRIEF_ARTIFACTS];


### PR DESCRIPTION
## Summary
- Adds `|| needs.changes.outputs.lib == 'true'` to the `renderer-tsc` job `if` condition
- Uses the existing `lib` filter from the `changes` job (`lib/**`) — no new filter logic needed
- lib types are renderer-consumed: a `BriefArtifactName` union widening that misses an exhaustive renderer map now triggers renderer-tsc red instead of landing silently on main
- PS/docs/analytics-only PRs still skip renderer-tsc (no added noise)

## Prevention target
Closes the renderer-tsc leg of the "consumer-triggered coverage gap" failure class (same genus as t/2832 nodenext leg). Root incident: t/2838 widened `BriefArtifactName`; renderer-tsc didn't run; next renderer PR broke main.

## Gate Verification (required — DRAFT until TL sign-off)
- [ ] Arm 1 (violation): lib-only PR adding a member to a lib union without updating a renderer exhaustive map → renderer-tsc now runs and goes RED
- [ ] Arm 2 (clean): PS-only or docs-only PR → `needs.changes.outputs.lib == 'false'` → renderer-tsc still skips, zero added noise

**This PR is DRAFT pending TL (Main) Gate Verification sign-off per t/2854 AC.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
