### PR TITLE
feat(reflections): theory-of-operations doc bookmark in panel header (t/2829)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/ReflectionsPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/ReflectionsPanel.tsx
@@ -12,6 +12,7 @@ import { POVER_INFO } from '../../types/debate';
 import type { SpeakerId } from '../../types/debate';
 import { checkDolceCompliance, type ComplianceViolation } from '../../utils/dolceCompliance';
 import { DescriptionToggle, resolveDescription, useDescriptionMode } from './DescriptionToggle';
+import { TheoryLink } from './TheoryLink';
 import { generatePlainPreview } from '../../utils/regeneratePlainDescription';
 import './ReflectionsPanel.css';
 
@@ -1148,6 +1149,12 @@ export function ReflectionsPanel({ onClose }: { onClose: () => void }) {
           style={{ cursor: dragRef.current ? 'grabbing' : 'grab' }}
         >
           <h3 className="rp-modal-title">Post-Debate Reflections</h3>
+          <TheoryLink
+            docPath="docs/debate-reflections.md"
+            label="Post-Debate Reflections — how it works"
+            tooltip="Open the Reflections theory-of-operations doc"
+            size={15}
+          />
           {reflections.length > 0 && totalPending > 0 && (
             <>
               <button className="btn btn-primary rp-btn-sm" onClick={approveAll}>


### PR DESCRIPTION
## What
Adds a `TheoryLink` open-book glyph next to the **Post-Debate Reflections** panel title, opening `docs/debate-reflections.md` on GitHub via `api.openExternal` (works in both Electron + web builds).

Part 2 of t/2825; the doc (t/2828) is already on `main`, so the link resolves.

## How
- `ReflectionsPanel.tsx`: import `TheoryLink`; render `<TheoryLink docPath="docs/debate-reflections.md" size={15} … />` after the `<h3>` title.
- Single file, reuses the existing TheoryLink pattern. `size=15` within the 12–16 clamp.

## Verification
- `tsc -p tsconfig.json --noEmit` — clean (exit 0)
- `eslint ReflectionsPanel.tsx` — clean (exit 0)
- No new CSS/tokens → theme-token-completeness unaffected.

Self-certified under the TheoryLink pattern (TL authorized self-cert on t/2829; route-to-me only on deviation — none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)