### PR TITLE
feat(brief): shared runBriefPipeline + full-pipeline CLI (t/2837)

### DIFF
--- a/lib/brief/cli.test.ts
+++ b/lib/brief/cli.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for the full-pipeline CLI (t/2837). runBriefPipeline + the adapter/repo
+// resolvers are mocked — this asserts the CLI's own contract: arg parsing,
+// error-code mapping, the one-line TriadDeckExport stdout, WARN-on-stderr, artifact
+// writes (incl. on gate failure), and the --skip-narration adapter guard.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { mkdtemp, writeFile, rm, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('./pipeline.js', () => ({ runBriefPipeline: vi.fn() }));
+vi.mock('../debate/aiAdapter.js', () => ({ createCLIAdapter: vi.fn(() => ({ generateText: vi.fn() })) }));
+vi.mock('../debate/taxonomyLoader.js', () => ({ resolveRepoRoot: vi.fn(() => '/repo') }));
+
+import { runBriefPipeline } from './pipeline.js';
+import { createCLIAdapter } from '../debate/aiAdapter.js';
+import { runCli, parseArgs } from './cli.js';
+
+function okResult(over: Record<string, unknown> = {}) {
+  return {
+    spec: { meta: { id: 'sess-1', title: 'My Title' } },
+    narration: {},
+    pptxBytes: new Uint8Array([1]),
+    htmlDoc: '<html>',
+    manifest: { debate_id: 'sess-1', trace_coverage_pct: 100, verdict_counts: { Supported: 2 }, warnings: [] },
+    artifacts: [
+      { name: 'deck_spec.json', text: '{}' },
+      { name: 'narration.json', text: '{}' },
+      { name: 'brief.pptx', bytes: new Uint8Array([1]) },
+      { name: 'brief.html', text: '<html>' },
+      { name: 'audit-manifest.json', text: '{}' },
+    ],
+    hardFailures: [] as string[],
+    warnings: [] as string[],
+    ...over,
+  };
+}
+
+let dir: string;
+let outSpy: Mock;
+let errSpy: Mock;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  dir = await mkdtemp(join(tmpdir(), 'brief-cli-'));
+  await writeFile(join(dir, 'debate.json'), JSON.stringify({ id: 'sess-1', phase: 'closed' }));
+  outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true) as unknown as Mock;
+  errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true) as unknown as Mock;
+});
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(dir, { recursive: true, force: true });
+});
+
+const stdout = () => outSpy.mock.calls.map(c => String(c[0])).join('');
+const stderr = () => errSpy.mock.calls.map(c => String(c[0])).join('');
+
+describe('parseArgs', () => {
+  it('requires --path, --model, --out', () => {
+    expect(() => parseArgs(['--model', 'm', '--out', 'o'])).toThrow(/required/);
+    expect(() => parseArgs(['--path', 'p', '--out', 'o'])).toThrow(/required/);
+    expect(() => parseArgs(['--path', 'p', '--model', 'm'])).toThrow(/required/);
+  });
+  it('rejects an unknown preset', () => {
+    expect(() => parseArgs(['--path', 'p', '--model', 'm', '--out', 'o', '--preset', 'nope'])).toThrow(/preset/);
+  });
+  it('parses boolean flags', () => {
+    const a = parseArgs(['--path', 'p', '--model', 'm', '--out', 'o', '--skip-narration', '--allow-open', '--no-framing-meta']);
+    expect(a.skipNarration).toBe(true);
+    expect(a.allowOpen).toBe(true);
+    expect(a.framingMeta).toBe(false);
+  });
+});
+
+describe('runCli', () => {
+  it('success → exit 0, one line of TriadDeckExport JSON on stdout, artifacts written', async () => {
+    (runBriefPipeline as Mock).mockResolvedValue(okResult());
+    const out = join(dir, 'out');
+    const r = await runCli(['--path', join(dir, 'debate.json'), '--model', 'gemini', '--out', out]);
+    expect(r.exitCode).toBe(0);
+
+    const lines = stdout().trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.debateId).toBe('sess-1');
+    expect(parsed.title).toBe('My Title');
+    expect(parsed.path).toMatch(/brief\.pptx$/);
+    expect(parsed.manifestPath).toMatch(/audit-manifest\.json$/);
+    expect(parsed.verdicts).toEqual({ Supported: 2 });
+
+    const written = await readdir(out);
+    expect(written.sort()).toEqual(
+      ['audit-manifest.json', 'brief.html', 'brief.pptx', 'deck_spec.json', 'narration.json'],
+    );
+  });
+
+  it('verify-gate failure → exit 1, error code on stderr, artifacts still written', async () => {
+    (runBriefPipeline as Mock).mockResolvedValue(okResult({ hardFailures: ['symmetry breach'], warnings: ['thin camp'] }));
+    const out = join(dir, 'out');
+    const r = await runCli(['--path', join(dir, 'debate.json'), '--model', 'gemini', '--out', out]);
+    expect(r.exitCode).toBe(1);
+    expect(stdout()).toBe(''); // stdout stays clean on failure
+    expect(stderr()).toContain('WARN: thin camp');
+    const errLine = stderr().trim().split('\n').find(l => l.startsWith('{'))!;
+    expect(JSON.parse(errLine).errorCode).toBe('SymmetryFailure');
+    const written = await readdir(out);
+    expect(written).toContain('audit-manifest.json');
+  });
+
+  it('bad --path → DebateFileInvalid, exit 1', async () => {
+    const r = await runCli(['--path', join(dir, 'nope.json'), '--model', 'gemini', '--out', join(dir, 'out')]);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(stderr().trim()).errorCode).toBe('DebateFileInvalid');
+    expect(runBriefPipeline).not.toHaveBeenCalled();
+  });
+
+  it('stage throw with "closed" message → DebateNotClosed', async () => {
+    (runBriefPipeline as Mock).mockRejectedValue(new Error('Debate is not closed; pass allowOpen'));
+    const r = await runCli(['--path', join(dir, 'debate.json'), '--model', 'gemini', '--out', join(dir, 'out')]);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(stderr().trim()).errorCode).toBe('DebateNotClosed');
+  });
+
+  it('--skip-narration does NOT build a model adapter', async () => {
+    (runBriefPipeline as Mock).mockResolvedValue(okResult());
+    await runCli(['--path', join(dir, 'debate.json'), '--model', 'gemini', '--out', join(dir, 'out'), '--skip-narration']);
+    expect(createCLIAdapter).not.toHaveBeenCalled();
+  });
+
+  it('builds the model adapter when narration is NOT skipped', async () => {
+    (runBriefPipeline as Mock).mockResolvedValue(okResult());
+    await runCli(['--path', join(dir, 'debate.json'), '--model', 'gemini', '--out', join(dir, 'out')]);
+    expect(createCLIAdapter).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/brief/cli.ts
+++ b/lib/brief/cli.ts
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief Export full-pipeline CLI (t/2837). Takes a RAW exported debate JSON
+// through all four stages — extract → narrate → render → verify — and writes the
+// same artifacts + audit-manifest.json as the T6 server path, with no server and
+// (optionally) no model call. Consumed by PowerShell T8 local mode (-Path) and
+// CI/offline. The render-only sibling `render/cli.ts` stays for --spec/--narration
+// re-render; this is the whole pipeline from a debate session.
+//
+//   node lib/brief/cli.js --path debate.json --model gemini-2.5-flash \
+//     --preset conference --out ./out [--checker-model ...] [--skip-narration] \
+//     [--allow-open] [--template deck.potx] [--no-framing-meta]
+//
+// Output contract (t/2837#3, confirming PS t/2806#6):
+//   success → exit 0; stdout = EXACTLY one line of JSON = TriadDeckExport; nothing
+//             else on stdout, so the T8 parse is robust. Artifacts written under --out.
+//   failure → exit ≠0; stderr = one line of JSON { errorCode, message }.
+//   warnings → `WARN: <msg>` lines on stderr; stdout stays clean.
+// A verify-GATE failure still writes ALL artifacts (incl. audit-manifest.json)
+// before exiting ≠0 (diagnosable, mirrors T6 persist-on-failure). Stage throws
+// (bad --path, non-closed debate, model unreachable, render fault) may leave
+// partial/no artifacts.
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { ActionableError, errorMessage } from '../debate/errors.js';
+import { createCLIAdapter } from '../debate/aiAdapter.js';
+import { resolveRepoRoot } from '../debate/taxonomyLoader.js';
+import type { AIAdapter } from '../debate/aiAdapter.js';
+import type { DebateSession } from '../debate/types.js';
+import { runBriefPipeline, type BriefPipelineResult } from './pipeline.js';
+import { BRIEF_ARTIFACTS } from './types.js';
+import type {
+  BriefPreset, ModelSource, ExportErrorCode, ExportJobState, TriadDeckExport,
+} from './types.js';
+
+const LOCATION = 'lib/brief/cli.ts';
+const PRESETS: readonly BriefPreset[] = ['policymaker', 'conference', 'classroom'];
+const MODEL_SOURCES: readonly ModelSource[] = ['Explicit', 'Global', 'Default'];
+
+/** CLI error codes = the frozen wire ExportErrorCode PLUS one CLI-local code for a
+ *  bad/unparseable --path (T6 never reads a file, so it is not a wire code). */
+export type CliErrorCode = ExportErrorCode | 'DebateFileInvalid';
+
+export interface CliArgs {
+  path: string;
+  model: string;
+  modelSource: ModelSource;
+  preset: BriefPreset;
+  checkerModel?: string;
+  checkerModelSource?: ModelSource;
+  skipNarration: boolean;
+  allowOpen: boolean;
+  template?: string;
+  framingMeta?: boolean;
+  out: string;
+}
+
+function fail(problem: string, nextSteps: string[]): never {
+  throw new ActionableError({
+    goal: 'Run the Brief Export pipeline offline from a debate JSON',
+    problem,
+    location: LOCATION,
+    nextSteps,
+  });
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const map = new Map<string, string>();
+  let skipNarration = false;
+  let allowOpen = false;
+  let framingMeta: boolean | undefined;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--skip-narration') { skipNarration = true; continue; }
+    if (a === '--allow-open') { allowOpen = true; continue; }
+    if (a === '--no-framing-meta') { framingMeta = false; continue; }
+    if (a.startsWith('--')) { map.set(a.slice(2), argv[++i]); }
+  }
+
+  const inPath = map.get('path');
+  const model = map.get('model');
+  const out = map.get('out');
+  if (!inPath || !model || !out) {
+    fail('--path, --model, and --out are required', [
+      'node lib/brief/cli.js --path <debate.json> --model <id> --preset <p> --out <dir>',
+      'Optional: --checker-model, --skip-narration, --allow-open, --template <potx>, --no-framing-meta',
+    ]);
+  }
+
+  const preset = (map.get('preset') ?? 'conference') as BriefPreset;
+  if (!PRESETS.includes(preset)) fail(`Unknown preset "${preset}"`, [`Use one of: ${PRESETS.join(', ')}`]);
+
+  const modelSource = (map.get('model-source') ?? 'Explicit') as ModelSource;
+  if (!MODEL_SOURCES.includes(modelSource)) {
+    fail(`Unknown model-source "${modelSource}"`, [`Use one of: ${MODEL_SOURCES.join(', ')}`]);
+  }
+  const checkerModelSource = map.get('checker-model-source') as ModelSource | undefined;
+  if (checkerModelSource && !MODEL_SOURCES.includes(checkerModelSource)) {
+    fail(`Unknown checker-model-source "${checkerModelSource}"`, [`Use one of: ${MODEL_SOURCES.join(', ')}`]);
+  }
+
+  return {
+    path: inPath!,
+    model: model!,
+    modelSource,
+    preset,
+    checkerModel: map.get('checker-model'),
+    checkerModelSource,
+    skipNarration,
+    allowOpen,
+    template: map.get('template'),
+    framingMeta,
+    out: out!,
+  };
+}
+
+// ── Error-code mapping (CLI owns this — wire/host-specific, per the pipeline split) ──
+
+/** Map a verify() hardFailure string to its stable code. Order matters — schema
+ *  before trace (a schema failure can cascade into trace strings). Mirrors T6. */
+function codeForHardFailures(hardFailures: string[]): ExportErrorCode {
+  const joined = hardFailures.join(' | ').toLowerCase();
+  if (joined.includes('schema')) return 'SpecSchemaFailure';
+  if (joined.includes('trace')) return 'TraceGateFailure';
+  if (joined.includes('symmetry')) return 'SymmetryFailure';
+  if (joined.includes('ooxml') || joined.includes('pptx') || joined.includes('lint')) return 'PptxLintFailure';
+  return 'PptxLintFailure'; // default within the verify-gate family
+}
+
+/** Map a thrown stage fault to a code, keyed off the stage that was running. */
+function codeForThrow(err: unknown, stage: ExportJobState | 'reading'): CliErrorCode {
+  const msg = errorMessage(err).toLowerCase();
+  if (stage === 'reading') return 'DebateFileInvalid';
+  if (msg.includes('closed')) return 'DebateNotClosed'; // extract's non-closed guard
+  if (stage === 'narrating' || stage === 'checking') return 'ModelUnavailable';
+  return 'RenderFailure';
+}
+
+function emitError(code: CliErrorCode, message: string): void {
+  process.stderr.write(JSON.stringify({ errorCode: code, message }) + '\n');
+}
+
+/** A guard adapter used under --skip-narration: no model is contacted, so an
+ *  actual call is a bug, not a silent no-op. */
+const skipNarrationGuardAdapter: AIAdapter = {
+  generateText: async () => {
+    throw new ActionableError({
+      goal: 'Produce narration text',
+      problem: 'The model adapter was invoked under --skip-narration (deterministic mode)',
+      location: LOCATION,
+      nextSteps: ['Remove --skip-narration to narrate with a model, or report this as a bug'],
+    });
+  },
+};
+
+/** Tool versions recorded in the manifest. Best-effort; the gate records, not validates. */
+function toolVersions(repoRoot: string): Record<string, string> {
+  let appVersion = 'unknown';
+  try {
+    const pkg = JSON.parse(
+      readFileSync(path.resolve(repoRoot, 'taxonomy-editor/package.json'), 'utf8'),
+    ) as { version?: string };
+    if (pkg.version) appVersion = pkg.version;
+  } catch { /* fall back to 'unknown' */ }
+  return { 'brief-cli': appVersion, node: process.version };
+}
+
+export interface RunResult { exitCode: number }
+
+export async function runCli(argv: string[]): Promise<RunResult> {
+  let args: CliArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    // Arg errors are user errors, not a wire code — surface the actionable message.
+    process.stderr.write((err instanceof ActionableError ? err.message : String(err)) + '\n');
+    return { exitCode: 2 };
+  }
+
+  // ── read + parse the debate JSON (bad/unparseable → DebateFileInvalid) ──
+  let session: DebateSession;
+  try {
+    const raw = await readFile(args.path, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object') throw new Error('debate JSON is not an object');
+    session = parsed as DebateSession;
+  } catch (err) {
+    emitError('DebateFileInvalid', `Cannot read/parse debate JSON at ${args.path}: ${errorMessage(err)}`);
+    return { exitCode: 1 };
+  }
+
+  let template: Uint8Array | undefined;
+  if (args.template) {
+    try {
+      template = await readFile(args.template);
+    } catch (err) {
+      emitError('RenderFailure', `Cannot read --template ${args.template}: ${errorMessage(err)}`);
+      return { exitCode: 1 };
+    }
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = resolveRepoRoot(__dirname);
+  const adapter = args.skipNarration ? skipNarrationGuardAdapter : createCLIAdapter(repoRoot);
+
+  // ── run the shared pipeline; track the stage for precise throw-mapping ──
+  let stage: ExportJobState = 'extracting';
+  let result: BriefPipelineResult;
+  try {
+    result = await runBriefPipeline(
+      {
+        session,
+        preset: args.preset,
+        modelId: args.model,
+        modelSource: args.modelSource,
+        checkerModelId: args.checkerModel,
+        checkerModelSource: args.checkerModelSource,
+        skipNarration: args.skipNarration,
+        template,
+        framingMeta: args.framingMeta,
+        allowOpen: args.allowOpen,
+        toolVersions: toolVersions(repoRoot),
+        timestamp: new Date().toISOString(),
+      },
+      adapter,
+      s => { stage = s; },
+    );
+  } catch (err) {
+    emitError(codeForThrow(err, stage), errorMessage(err));
+    return { exitCode: 1 };
+  }
+
+  // ── write all artifacts under --out (incl. manifest, even on gate failure) ──
+  await mkdir(args.out, { recursive: true });
+  for (const a of result.artifacts) {
+    const dest = join(args.out, a.name);
+    if (a.bytes !== undefined) await writeFile(dest, a.bytes);
+    else await writeFile(dest, a.text ?? '');
+  }
+
+  // ── warnings → stderr WARN lines; stdout stays clean ──
+  for (const w of result.warnings) process.stderr.write(`WARN: ${w}\n`);
+
+  // ── verify-gate failure: artifacts written, exit ≠0 with the mapped code ──
+  if (result.hardFailures.length > 0) {
+    emitError(
+      codeForHardFailures(result.hardFailures),
+      `Export verify gate failed: ${result.hardFailures.join('; ')}`,
+    );
+    return { exitCode: 1 };
+  }
+
+  // ── success: one line of TriadDeckExport JSON on stdout ──
+  const passthru: TriadDeckExport = {
+    debateId: result.manifest.debate_id,
+    title: result.spec.meta.title,
+    preset: args.preset,
+    model: args.model,
+    modelSource: args.modelSource,
+    checkerModel: args.checkerModel,
+    path: join(args.out, BRIEF_ARTIFACTS.pptx),
+    specPath: join(args.out, BRIEF_ARTIFACTS.deckSpec),
+    manifestPath: join(args.out, BRIEF_ARTIFACTS.manifest),
+    traceCoveragePct: result.manifest.trace_coverage_pct,
+    verdicts: result.manifest.verdict_counts,
+    warnings: result.warnings,
+  };
+  process.stdout.write(JSON.stringify(passthru) + '\n');
+  return { exitCode: 0 };
+}
+
+// Executed directly (not imported): run over process.argv and set the exit code.
+const invokedDirectly = process.argv[1] !== undefined
+  && import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}`;
+if (invokedDirectly) {
+  runCli(process.argv.slice(2))
+    .then(r => { process.exitCode = r.exitCode; })
+    .catch((e: unknown) => {
+      // Last-resort: an unmapped fault. Emit a generic wire-shaped error line.
+      process.stderr.write(JSON.stringify({ errorCode: 'RenderFailure', message: String(e) }) + '\n');
+      process.exitCode = 1;
+    });
+}

--- a/lib/brief/pipeline.test.ts
+++ b/lib/brief/pipeline.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for the shared Brief Export pipeline (t/2837). The four stages are mocked
+// — this asserts the ORCHESTRATION the pipeline owns: stage order, the `checking`
+// sub-phase, allowOpen threading, artifact assembly (manifest last, as output
+// record), warnings aggregation, and hardFailures passthrough (no throw on gate-fail).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+
+vi.mock('./extract.js', () => ({ extractDeckSpec: vi.fn() }));
+vi.mock('./narrate.js', () => ({ narrate: vi.fn() }));
+vi.mock('./render/index.js', () => ({ render: vi.fn() }));
+vi.mock('./verify.js', () => ({ verify: vi.fn() }));
+
+import { extractDeckSpec } from './extract.js';
+import { narrate } from './narrate.js';
+import { render } from './render/index.js';
+import { verify } from './verify.js';
+import { runBriefPipeline } from './pipeline.js';
+import type { BriefPipelineInput } from './pipeline.js';
+import type { DeckSpec, Narration, AuditManifest } from './types.js';
+import type { DebateSession } from '../debate/types.js';
+import type { AIAdapter } from '../debate/aiAdapter.js';
+
+const adapter = { generateText: async () => '' } as AIAdapter;
+
+const specFixture = { meta: { id: 'sess-1', title: 'T' } } as unknown as DeckSpec;
+const narrationFixture = { narration_mode: 'deterministic' } as unknown as Narration;
+const manifestFixture = (over: Partial<AuditManifest> = {}): AuditManifest =>
+  ({ warnings: ['mw1'], trace_coverage_pct: 100, verdict_counts: {}, debate_id: 'sess-1', ...over } as AuditManifest);
+
+function baseInput(over: Partial<BriefPipelineInput> = {}): BriefPipelineInput {
+  return {
+    session: { id: 'sess-1', phase: 'closed' } as unknown as DebateSession,
+    preset: 'conference',
+    modelId: 'gemini-2.5-flash',
+    modelSource: 'Explicit',
+    skipNarration: false,
+    toolVersions: { 'brief-cli': '1.0' },
+    timestamp: '2026-08-19T00:00:00.000Z',
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (extractDeckSpec as Mock).mockReturnValue(specFixture);
+  (narrate as Mock).mockResolvedValue({ narration: narrationFixture });
+  (render as Mock).mockResolvedValue({
+    pptxBytes: new Uint8Array([1, 2, 3]), htmlDoc: '<html></html>',
+    warnings: ['rw1'], slideModels: [],
+  });
+  (verify as Mock).mockResolvedValue({ manifest: manifestFixture(), hardFailures: [] });
+});
+
+describe('runBriefPipeline', () => {
+  it('emits the four stages in order (no checking when no checker)', async () => {
+    const stages: string[] = [];
+    await runBriefPipeline(baseInput(), adapter, s => stages.push(s));
+    expect(stages).toEqual(['extracting', 'narrating', 'rendering', 'verifying']);
+  });
+
+  it('emits checking after narrating when a checker ran', async () => {
+    const stages: string[] = [];
+    await runBriefPipeline(baseInput({ checkerModelId: 'checker-x' }), adapter, s => stages.push(s));
+    expect(stages).toEqual(['extracting', 'narrating', 'checking', 'rendering', 'verifying']);
+  });
+
+  it('does NOT emit checking under skipNarration even with a checker set', async () => {
+    const stages: string[] = [];
+    await runBriefPipeline(baseInput({ checkerModelId: 'checker-x', skipNarration: true }), adapter, s => stages.push(s));
+    expect(stages).not.toContain('checking');
+  });
+
+  it('threads allowOpen to extractDeckSpec', async () => {
+    await runBriefPipeline(baseInput({ allowOpen: true }), adapter);
+    expect(extractDeckSpec).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'sess-1' }),
+      { allowOpen: true },
+    );
+  });
+
+  it('assembles artifacts in production order with the manifest last', async () => {
+    const result = await runBriefPipeline(baseInput(), adapter);
+    expect(result.artifacts.map(a => a.name)).toEqual([
+      'deck_spec.json', 'narration.json', 'brief.pptx', 'brief.html', 'audit-manifest.json',
+    ]);
+    // pptx is the only bytes artifact; the rest carry text.
+    const pptx = result.artifacts.find(a => a.name === 'brief.pptx');
+    expect(pptx?.bytes).toBeInstanceOf(Uint8Array);
+    expect(pptx?.text).toBeUndefined();
+  });
+
+  it('aggregates render + manifest warnings', async () => {
+    const result = await runBriefPipeline(baseInput(), adapter);
+    expect(result.warnings).toEqual(['rw1', 'mw1']);
+  });
+
+  it('passes hardFailures through without throwing (verify gate failure)', async () => {
+    (verify as Mock).mockResolvedValue({ manifest: manifestFixture(), hardFailures: ['schema invalid'] });
+    const result = await runBriefPipeline(baseInput(), adapter);
+    expect(result.hardFailures).toEqual(['schema invalid']);
+    // manifest artifact still produced on gate failure
+    expect(result.artifacts.some(a => a.name === 'audit-manifest.json')).toBe(true);
+  });
+
+  it('forwards narration + verify inputs from the pipeline input', async () => {
+    await runBriefPipeline(baseInput({ skipNarration: true, checkerModelId: 'c1' }), adapter);
+    expect(narrate).toHaveBeenCalledWith(
+      expect.objectContaining({ preset: 'conference', modelId: 'gemini-2.5-flash', skipNarration: true, checkerModelId: 'c1' }),
+      adapter,
+    );
+    expect(verify).toHaveBeenCalledWith(expect.objectContaining({
+      meta: { toolVersions: { 'brief-cli': '1.0' }, timestamp: '2026-08-19T00:00:00.000Z' },
+    }));
+  });
+});

--- a/lib/brief/pipeline.ts
+++ b/lib/brief/pipeline.ts
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief Export shared pipeline (t/2837). The ONE orchestration of the four
+// stages — extract → narrate(+checker) → render → verify — that BOTH the T6 REST
+// server (briefExportJobs.runExportJob) and the offline CLI (lib/brief/cli.ts)
+// call, so there is no second copy of the stage sequence to drift.
+//
+// The split (approved TL t/2837#2): runBriefPipeline owns the four stages and
+// returns the artifacts + verify outcome; the CALLER owns everything
+// wire/host-specific — job lifecycle (queued/done/failed), storage, idempotency,
+// TTL, error-code mapping. This preserves T6's exact invariants:
+//   • the manifest is the OUTPUT record, not a hashed input artifact — it is added
+//     here after verify(), never inside verify();
+//   • verify() NEVER throws on a gate failure — a failed gate comes back as a
+//     non-empty `hardFailures`; only an unexpected stage fault throws;
+//   • the `checking` sub-phase is surfaced post-hoc, only when a checker ran.
+
+import { extractDeckSpec } from './extract.js';
+import { narrate } from './narrate.js';
+import { render } from './render/index.js';
+import { verify } from './verify.js';
+import { BRIEF_ARTIFACTS } from './types.js';
+import type {
+  DeckSpec, Narration, AuditManifest, BriefPreset, ModelSource,
+  ExportJobState, BriefArtifactName,
+} from './types.js';
+import type { DebateSession } from '../debate/types.js';
+import type { AIAdapter } from '../debate/aiAdapter.js';
+
+/** Everything the four stages need. Mirrors T6's CreateJobArgs minus the
+ *  host-specific fields (userId, idempotencyKey, debateId) the caller owns. */
+export interface BriefPipelineInput {
+  session: DebateSession;
+  preset: BriefPreset;
+  modelId: string;
+  modelSource: ModelSource;
+  checkerModelId?: string;
+  checkerModelSource?: ModelSource;
+  skipNarration?: boolean;
+  template?: Uint8Array;
+  /** When explicitly false, drops the framing_meta slide from classroom (t/2838). */
+  framingMeta?: boolean;
+  /** Export a non-closed (in-progress) debate as a watermarked snapshot (t/2816).
+   *  Absent/false → extractDeckSpec throws on a non-closed session. */
+  allowOpen?: boolean;
+  /** Tool name → semver, recorded in the manifest. */
+  toolVersions: Record<string, string>;
+  /** ISO-8601; caller supplies it so the pipeline stays deterministic. */
+  timestamp: string;
+}
+
+/** One emitted artifact — exactly one of text/bytes is set. */
+export interface BriefArtifact {
+  name: BriefArtifactName;
+  text?: string;
+  bytes?: Uint8Array;
+}
+
+export interface BriefPipelineResult {
+  spec: DeckSpec;
+  narration: Narration;
+  pptxBytes: Uint8Array;
+  htmlDoc: string;
+  manifest: AuditManifest;
+  /** deck_spec.json, narration.json, brief.pptx, brief.html, audit-manifest.json —
+   *  in production order. The manifest is included (output record). */
+  artifacts: BriefArtifact[];
+  /** Empty ⇒ the verify gate passed. Non-empty ⇒ the caller must fail. */
+  hardFailures: string[];
+  /** Aggregated non-fatal render warnings + manifest warnings. */
+  warnings: string[];
+}
+
+/**
+ * Run the four Brief Export stages. Stage faults propagate (the caller maps them
+ * to its own error codes); a verify GATE failure does NOT throw — it returns via
+ * `hardFailures` with the manifest still produced, so the failure is diagnosable.
+ *
+ * @param onStage optional progress sink — emits extracting|narrating|checking|
+ *   rendering|verifying as each stage begins (`checking` only when a checker ran).
+ *   The caller owns queued/done/failed.
+ */
+export async function runBriefPipeline(
+  input: BriefPipelineInput,
+  adapter: AIAdapter,
+  onStage?: (stage: ExportJobState) => void,
+): Promise<BriefPipelineResult> {
+  const artifacts: BriefArtifact[] = [];
+
+  // ── extract ──
+  onStage?.('extracting');
+  const spec = extractDeckSpec(input.session, { allowOpen: input.allowOpen });
+  artifacts.push({ name: BRIEF_ARTIFACTS.deckSpec, text: JSON.stringify(spec, null, 2) });
+
+  // ── narrate (+ optional maker-checker) ──
+  onStage?.('narrating');
+  const { narration } = await narrate({
+    spec,
+    preset: input.preset,
+    modelId: input.modelId,
+    modelSource: input.modelSource,
+    checkerModelId: input.checkerModelId,
+    checkerModelSource: input.checkerModelSource,
+    skipNarration: input.skipNarration,
+  }, adapter);
+  // `checking` is a sub-phase inside narrate(); surface it only when a checker ran.
+  if (input.checkerModelId && !input.skipNarration) onStage?.('checking');
+  artifacts.push({ name: BRIEF_ARTIFACTS.narration, text: JSON.stringify(narration, null, 2) });
+
+  // ── render (pptx + htmlDoc; PDF is Electron-only, never here) ──
+  onStage?.('rendering');
+  const { pptxBytes, htmlDoc, warnings: renderWarnings } = await render({
+    spec,
+    narration,
+    preset: input.preset,
+    template: input.template,
+    framingMeta: input.framingMeta,
+  });
+  artifacts.push({ name: BRIEF_ARTIFACTS.pptx, bytes: pptxBytes });
+  artifacts.push({ name: BRIEF_ARTIFACTS.htmlDoc, text: htmlDoc });
+
+  // ── verify (build-fails-not-warns; manifest ALWAYS produced) ──
+  onStage?.('verifying');
+  const { manifest, hardFailures } = await verify({
+    spec,
+    narration,
+    pptxBytes,
+    meta: { toolVersions: input.toolVersions, timestamp: input.timestamp },
+  });
+  // Manifest is the output record, NOT a hashed input artifact — added here, not in verify().
+  artifacts.push({ name: BRIEF_ARTIFACTS.manifest, text: JSON.stringify(manifest, null, 2) });
+
+  return {
+    spec,
+    narration,
+    pptxBytes,
+    htmlDoc,
+    manifest,
+    artifacts,
+    hardFailures,
+    warnings: [...renderWarnings, ...manifest.warnings],
+  };
+}


### PR DESCRIPTION
## t/2837 — Brief Export full-pipeline CLI + shared `runBriefPipeline`

Design approved by TL (t/2837#2). **Draft** pending two design confirmations (below).

### What
- **`lib/brief/pipeline.ts`** — `runBriefPipeline(input, adapter, onStage?)`: the ONE orchestration of extract → narrate(+checker) → render → verify, called by BOTH the offline CLI (here) and the T6 REST server (adoption is an approved root-Main fast-follow). Returns `{ spec, narration, pptxBytes, htmlDoc, manifest, artifacts, hardFailures, warnings }`.
- **`lib/brief/cli.ts`** — full-pipeline CLI: `--path <debate.json> --model --preset --out [--checker-model] [--skip-narration] [--allow-open] [--template] [--no-framing-meta]`. Consumed by PowerShell T8 `-Path` local mode (t/2806) and CI/offline.
- Tests: `pipeline.test.ts` (orchestration — stage order, `checking` sub-phase, `allowOpen` threading, artifact order, warnings aggregation, `hardFailures` passthrough), `cli.test.ts` (arg parsing, output contract, error-code mapping, artifact writes, skip-narration guard).

### Preserves T6 invariants
- Manifest is the **output record** — added after `verify()`, never inside it (not a hashed input artifact).
- `verify()` returns `hardFailures` rather than throwing on a gate failure; only unexpected stage faults throw (caller maps them).
- `checking` sub-phase emitted only when a checker ran.
- The split: pipeline owns the four stages; the **caller** owns job lifecycle / storage / error-code mapping (wire-specific).

### CLI output contract (t/2837#3)
- success → exit 0; stdout = **exactly one line** of `TriadDeckExport` JSON; nothing else on stdout (robust T8 parse).
- failure → exit ≠0; stderr = one line `{ errorCode, message }`.
- warnings → `WARN: <msg>` on stderr; stdout stays clean.
- A **verify-gate** failure still writes all artifacts (incl. `audit-manifest.json`) before exiting ≠0 (diagnosable). Stage throws may leave partial/no artifacts.

### Design decisions for TL confirmation (were open at t/2837#3/#4)
1. **`DebateFileInvalid`** (bad/unparseable `--path`) implemented as **CLI-local** (`CliErrorCode = ExportErrorCode | 'DebateFileInvalid'`) — T6 never reads a file, so it's not added to the frozen wire `ExportErrorCode`. Confirm keep CLI-local vs. promote to the wire type.
2. **`--allow-open`** (t/2816) threaded to `extractDeckSpec(session, { allowOpen })` — folds T8 `-AllowOpenDebate` into the CLI.
3. **Adapter reuse:** used the canonical `lib/debate` `createCLIAdapter` (env keys, per-call model routing) instead of adding a new `lib/ai-client` factory — a clean helper already exists (TL's #2 allowed reuse "if a clean helper already exists"). `--skip-narration` uses a guard adapter; no model contacted.

### Local verification
- `typecheck:brief-nodenext` ✓ · renderer-tsc `0/0` ✓ · vitest `17/17` ✓
- No new runtime dependency (imports existing modules only) → no lockfile changes.

Closes t/2837.
