### PR TITLE
feat(t2849): rename Op-Eds to Op-Ed Studies, default voices, render new fields

### DIFF
--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -146,13 +146,13 @@ function renderOpEdSetMarkdown(set: OpEdSet): string {
     if (member.byline) lines.push('', `_${member.byline}_`);
     if (member.disclosure) lines.push('', `> ${member.disclosure}`);
     lines.push('', member.body);
+    if (member.rhetorical_meta) lines.push('', '### What this op-ed did', '', member.rhetorical_meta);
     if (member.grounding?.length) {
       lines.push('', '**Grounding:**', '');
       for (const g of member.grounding) {
         lines.push(`- ${g.label} (${g.pov}): ${g.how_reflected}`);
       }
     }
-    if (member.rhetorical_meta) lines.push('', '### What this op-ed did', '', member.rhetorical_meta);
     lines.push('', '---', '');
   }
   return lines.join('\n');
@@ -341,7 +341,7 @@ export function registerOpEdHandlers(): void {
 
     const slug = set.topic.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').substring(0, 60);
     const result = await dialog.showSaveDialog(win, {
-      title: 'Export Op-Ed Studies Set',
+      title: 'Export Op-Ed Study',
       defaultPath: `oped-${slug}.md`,
       filters: [{ name: 'Markdown', extensions: ['md'] }],
     });

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -202,11 +202,9 @@ function OpEdArticle({ member, outlet }: { member: OpEdMember; outlet?: string }
           {member.subtitle && <p className="oped-article-subtitle">{member.subtitle}</p>}
           {member.byline && <p className="oped-byline">{member.byline}</p>}
           {member.disclosure && <p className="oped-disclosure" role="note">{member.disclosure}</p>}
-
           <div className="oped-reader-body">
             <Markdown remarkPlugins={[remarkGfm]}>{member.body}</Markdown>
           </div>
-
           <GroundingSection grounding={member.grounding} />
 
           {member.rhetorical_meta && (

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -49,7 +49,11 @@ function buildOpEdMarkdown(set: OpEdSet): string {
       lines.push(`_(This voice ${m.status === 'failed' ? 'failed to generate' : 'was cancelled'}.)_`);
       return;
     }
+    if (m.byline) lines.push(`\n*${m.byline}*`);
+    if (m.disclosure) lines.push(`\n> ${m.disclosure}`);
+    lines.push('');
     lines.push(m.body);
+    if (m.rhetorical_meta) lines.push(`\n---\n\n## What this op-ed did\n\n${m.rhetorical_meta}`);
     if (m.grounding.length > 0) {
       lines.push('\n---\n\n## Taxonomy grounding\n');
       lines.push('| Element | Type | Relevance | Reflected in the op-ed |');


### PR DESCRIPTION
## Summary
- Renames "Op-Eds" → "Op-Ed Studies" throughout UI: navConfig, Toolbar, OpEdTab, OpEdTable, opedHandlers save dialog
- Defaults all 3 camps selected when creating a new Op-Ed Study
- Renders byline after headline, disclosure above body, rhetorical_meta section after body in OpEdReader
- Updates buildOpEdMarkdown (web export) and renderOpEdSetMarkdown (Electron export) to include all three new fields
- Updates Toolbar.test.tsx and OpEdTable.test.tsx assertions

Closes t/2849 (child of t/2844)

Generated with Claude Code