### PR TITLE
feat(t2806/t2816): wire Export-TriadDebateBrief local mode to landed CLI + -AllowOpenDebate [DRAFT: p/470]

### DIFF
--- a/scripts/AITriad/Private/Resolve-BriefExportCli.ps1
+++ b/scripts/AITriad/Private/Resolve-BriefExportCli.ps1
@@ -8,12 +8,17 @@ function Resolve-BriefExportCli {
     .DESCRIPTION
         Returns @{ Exe = <string>; ArgPrefix = <string[]> } so the caller invokes:
             & $inv.Exe @($inv.ArgPrefix + $flagArgs)
-        This isolates the tsx-vs-compiled-bin entrypoint decision (owned by lib/brief,
-        pending TL freeze on t/2837) from Export-TriadDebateBrief, which only knows the
-        frozen flag interface (--path/--model/--preset/--skip-narration/--out).
+        This isolates the tsx-vs-compiled-bin entrypoint decision (owned by lib/brief)
+        from Export-TriadDebateBrief, which only knows the flag interface
+        (--path/--model/--preset/--out + optional --skip-narration/--checker-model/--allow-open).
 
-        Until the CLI lands and its entrypoint is frozen, this throws an actionable error
-        rather than guessing a path. Tests mock this function.
+        The CLI (lib/brief/cli.ts) is a TypeScript module; lib/brief's tsconfig is noEmit,
+        so there is no committed cli.js. The repo's convention for running lib/*.ts without
+        a build is `tsx` (a root devDependency, used by the parity tests). We therefore run
+        the source via `npx tsx lib/brief/cli.ts`. (PROVISIONAL — confirming the canonical
+        invocation with Shared Lib on p/470 before un-drafting; if they prefer the
+        build:server output `dist/server/lib/brief/cli.js` or a dedicated npm script, only
+        this function changes.) Tests mock this function.
     #>
     [CmdletBinding()]
     [OutputType([hashtable])]
@@ -21,15 +26,20 @@ function Resolve-BriefExportCli {
 
     Set-StrictMode -Version Latest
 
-    # The entrypoint (tsx vs compiled bin) and its on-disk location are still being
-    # frozen by the Tech Lead on t/2837; Shared Lib will hand over the exact invocation.
-    # Deliberately not guessed here — resolve once, in one place, when it lands.
-    throw (New-ActionableError `
-            -Goal     'Run the offline brief-export pipeline (local mode)' `
-            -Problem  'The shared lib/brief full-pipeline CLI (t/2837) has not landed yet, so local-mode export cannot run. Its entrypoint is being frozen by the Tech Lead.' `
-            -Location 'Resolve-BriefExportCli' `
-            -NextSteps @(
-                'Track t/2837 (Shared Lib brief full-pipeline CLI) — local mode activates when it lands',
-                'Once frozen, wire the invocation here: @{ Exe = ''node''|''npx''; ArgPrefix = @(...) }'
-            ))
+    # Repo root = two levels up from the module (scripts/AITriad → repo root).
+    $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $script:ModuleRoot '..' '..'))
+    $cliPath = Join-Path $repoRoot 'lib' 'brief' 'cli.ts'
+
+    if (-not (Test-Path -LiteralPath $cliPath -PathType Leaf)) {
+        throw (New-ActionableError `
+                -Goal     'Run the offline brief-export pipeline (local mode)' `
+                -Problem  "The brief full-pipeline CLI was not found at '$cliPath'. Local-mode export needs the lib/brief sources in the repo checkout." `
+                -Location 'Resolve-BriefExportCli' `
+                -NextSteps @(
+                    'Run from a full repo checkout (where lib/brief lives)',
+                    'Install dependencies (npm ci) — the pipeline needs tsx AND its runtime packages'
+                ))
+    }
+
+    return @{ Exe = 'npx'; ArgPrefix = @('--yes', 'tsx', $cliPath) }
 }

--- a/scripts/AITriad/Public/Export-TriadDebateBrief.ps1
+++ b/scripts/AITriad/Public/Export-TriadDebateBrief.ps1
@@ -32,8 +32,13 @@ function Export-TriadDebateBrief {
         Optional fact-check model.
     .PARAMETER SkipNarration
         Deterministic brief with zero model calls.
-    .PARAMETER OutputPath
-        Output .pptx path (local mode). Default: the debate file name with .pptx.
+    .PARAMETER OutputDirectory
+        (Local) Output DIRECTORY for the artifacts (brief.pptx, deck_spec.json,
+        narration.json, audit-manifest.json). Default: a "<debate>-brief" folder
+        beside the debate JSON. Alias -OutDir / -OutputPath.
+    .PARAMETER AllowOpenDebate
+        (Local) Export a not-yet-closed debate as a watermarked snapshot
+        (meta.snapshot). Without it, a non-closed debate fails with DebateNotClosed.
     .PARAMETER AccessToken
         (Server) AAD bearer token → `Authorization: Bearer`. The cmdlet never spoofs
         identity or sets principal headers. Alias -Token.
@@ -84,7 +89,11 @@ function Export-TriadDebateBrief {
         [switch]$SkipNarration,
 
         [Parameter(ParameterSetName = 'Local')]
-        [string]$OutputPath,
+        [Alias('OutDir', 'OutputPath')]
+        [string]$OutputDirectory,
+
+        [Parameter(ParameterSetName = 'Local')]
+        [switch]$AllowOpenDebate,
 
         [Parameter(ParameterSetName = 'Server')]
         [Alias('Token')]
@@ -146,23 +155,36 @@ function Export-TriadDebateBrief {
             & $WriteExportError 'ModelUnavailable' 'Local mode requires -Model unless -SkipNarration (no global model to inherit offline).' $Path; return
         }
 
-        $Out = if ($OutputPath) { $OutputPath } else { [System.IO.Path]::ChangeExtension((Resolve-Path -LiteralPath $Path).Path, '.pptx') }
-        if ((Test-Path -LiteralPath $Out) -and -not $Force) {
-            & $WriteExportError 'RenderFailure' "Output already exists: $Out — use -Force to overwrite." $Out; return
+        # --out is a DIRECTORY: the CLI writes brief.pptx + deck_spec.json +
+        # narration.json + audit-manifest.json under it (paths come back in the
+        # TriadDeckExport). Default: a "<debate>-brief" dir beside the debate JSON.
+        $ResolvedPath = (Resolve-Path -LiteralPath $Path).Path
+        $OutDir = if ($OutputDirectory) {
+            $OutputDirectory
+        }
+        else {
+            $base = [System.IO.Path]::GetFileNameWithoutExtension($ResolvedPath)
+            Join-Path (Split-Path -Parent $ResolvedPath) "$base-brief"
+        }
+        if ((Test-Path -LiteralPath $OutDir) -and
+            @(Get-ChildItem -LiteralPath $OutDir -Force -ErrorAction SilentlyContinue).Count -gt 0 -and
+            -not $Force) {
+            & $WriteExportError 'RenderFailure' "Output directory is not empty: $OutDir — use -Force to overwrite." $OutDir; return
         }
 
         $resolvedModel = if ($SkipNarration) { '(none — narration skipped)' } else { $Model }
-        if (-not $PSCmdlet.ShouldProcess($Path, "export brief (preset=$Preset, model=$resolvedModel)")) { return }
+        if (-not $PSCmdlet.ShouldProcess($ResolvedPath, "export brief (preset=$Preset, model=$resolvedModel) → $OutDir")) { return }
 
         # Resolve the t/2837 CLI invocation. Returns @{ Exe; ArgPrefix } so the
-        # tsx-vs-compiled-bin decision (pending TL, t/2837) is abstracted away here;
-        # throws an actionable error until the CLI lands. Never hard-coded above.
+        # tsx-vs-compiled-bin entrypoint decision is abstracted to one place.
         $Inv = Resolve-BriefExportCli
 
-        # Frozen input flags (TL p/360#95): --path/--model/--preset/--skip-narration/--out.
-        $CliArgs = @('--path', $Path, '--preset', $Preset, '--out', $Out)
-        if ($SkipNarration) { $CliArgs += '--skip-narration' } else { $CliArgs += @('--model', $Model) }
-        if ($CheckerModel)  { $CliArgs += @('--checker-model', $CheckerModel) }
+        # Frozen CLI flags (lib/brief/cli.ts): --path/--model/--preset/--out (dir),
+        # optional --skip-narration/--checker-model/--allow-open.
+        $CliArgs = @('--path', $ResolvedPath, '--preset', $Preset, '--out', $OutDir)
+        if ($SkipNarration)   { $CliArgs += '--skip-narration' } else { $CliArgs += @('--model', $Model) }
+        if ($CheckerModel)    { $CliArgs += @('--checker-model', $CheckerModel) }
+        if ($AllowOpenDebate) { $CliArgs += '--allow-open' }
         $AllArgs = @($Inv.ArgPrefix) + $CliArgs
 
         $progressId = 2806

--- a/tests/Export-TriadDebateBrief.Tests.ps1
+++ b/tests/Export-TriadDebateBrief.Tests.ps1
@@ -28,8 +28,12 @@ BeforeAll {
     $script:StubDir = Join-Path ([System.IO.Path]::GetTempPath()) "brief-stub-$(New-Guid)"
     New-Item -ItemType Directory -Path $script:StubDir -Force | Out-Null
 
+    # ok stub: records the exact CLI flags it received (so tests can assert flag
+    # pass-through) then emits a TriadDeckExport JSON line + a WARN: line.
+    $script:ArgsFile = Join-Path $script:StubDir 'last-args.txt'
     $script:OkStub = Join-Path $script:StubDir 'ok.ps1'
     Set-Content -LiteralPath $script:OkStub -Encoding UTF8 -Value @'
+$args -join "`n" | Set-Content -LiteralPath (Join-Path $PSScriptRoot 'last-args.txt') -Encoding UTF8
 [Console]::Error.WriteLine("WARN: symmetry tolerance 12% (soft)")
 $deck = @{
     debateId = "deb-123"; title = "Should we pause?"; preset = "policymaker"
@@ -104,25 +108,47 @@ Describe 'Export-TriadDebateBrief' -Tag 'debate' {
     }
 
     Context 'Local mode — happy path' {
-        It 'returns a [TriadDeckExport] parsed from CLI stdout and streams WARN: lines' {
+        BeforeEach {
             Mock -ModuleName AITriad Resolve-BriefExportCli {
                 @{ Exe = $script:PwshExe; ArgPrefix = @('-NoProfile', '-File', $script:OkStub) }
             }
+        }
+
+        It 'returns a [TriadDeckExport] parsed from CLI stdout, streams WARN:, passes --out as a directory' {
             $f = New-DebateFile
-            $out = Join-Path $script:StubDir 'out.pptx'
+            $out = Join-Path $script:StubDir 'out-happy'
             $warn = $null
-            $res = Export-TriadDebateBrief -Path $f -Model gemini-3.5-flash-lite -OutputPath $out -PassThru -WarningVariable warn -WarningAction SilentlyContinue
+            $res = Export-TriadDebateBrief -Path $f -Model gemini-3.5-flash-lite -OutputDirectory $out -PassThru -WarningVariable warn -WarningAction SilentlyContinue
             $res | Should -BeOfType ([TriadDeckExport])
             $res.DebateId | Should -Be 'deb-123'
             $res.TraceCoveragePct | Should -Be 100
             $res.Verdicts['Supported'] | Should -Be 3
             @($warn) -join ';' | Should -Match 'symmetry tolerance'
+
+            $sent = Get-Content -Raw -LiteralPath $script:ArgsFile
+            $sent | Should -Match '--out'
+            $sent | Should -Match ([regex]::Escape($out))
+            $sent | Should -Not -Match '--allow-open'
+        }
+
+        It 'passes --allow-open only when -AllowOpenDebate is set' {
+            $f = New-DebateFile
+            Export-TriadDebateBrief -Path $f -Model m -OutputDirectory (Join-Path $script:StubDir 'out-open') -AllowOpenDebate -WarningAction SilentlyContinue | Out-Null
+            (Get-Content -Raw -LiteralPath $script:ArgsFile) | Should -Match '--allow-open'
+        }
+
+        It 'passes --skip-narration (and no --model) under -SkipNarration' {
+            $f = New-DebateFile
+            Export-TriadDebateBrief -Path $f -SkipNarration -OutputDirectory (Join-Path $script:StubDir 'out-skip') -WarningAction SilentlyContinue | Out-Null
+            $sent = Get-Content -Raw -LiteralPath $script:ArgsFile
+            $sent | Should -Match '--skip-narration'
+            $sent | Should -Not -Match '--model'
         }
 
         It 'does not invoke the CLI under -WhatIf' {
             Mock -ModuleName AITriad Resolve-BriefExportCli { throw 'must not run under -WhatIf' }
             $f = New-DebateFile
-            { Export-TriadDebateBrief -Path $f -Model m -OutputPath (Join-Path $script:StubDir 'wi.pptx') -WhatIf } | Should -Not -Throw
+            { Export-TriadDebateBrief -Path $f -Model m -OutputDirectory (Join-Path $script:StubDir 'wi') -WhatIf } | Should -Not -Throw
             Should -Invoke -ModuleName AITriad Resolve-BriefExportCli -Times 0
         }
     }
@@ -134,7 +160,7 @@ Describe 'Export-TriadDebateBrief' -Tag 'debate' {
             }
             $f = New-DebateFile
             $err = $null
-            Export-TriadDebateBrief -Path $f -Model m -OutputPath (Join-Path $script:StubDir 'f.pptx') -ErrorVariable err -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+            Export-TriadDebateBrief -Path $f -Model m -OutputDirectory (Join-Path $script:StubDir 'out-fail') -ErrorVariable err -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
             $err[0].FullyQualifiedErrorId | Should -Match 'TraceGateFailure'
         }
     }


### PR DESCRIPTION
## Follow-up to #1270 — wire local mode to the now-landed `lib/brief` CLI + add `-AllowOpenDebate`

**Context:** #1270 was merged (21:00Z) while still the **draft stub** — `Resolve-BriefExportCli` throws "CLI has not landed yet". Since then **t/2837 landed** (`lib/brief/cli.ts`, #1292), so `main` currently has a **broken local mode** (errors even though the CLI now exists). This PR fixes that and folds in the T8 allow-open gate (t/2816).

### Changes
- **`Resolve-BriefExportCli`** now returns a real invocation: `npx tsx lib/brief/cli.ts` (lib/brief is `noEmit` — no committed `cli.js`; `tsx` runs the source, matching the repo convention used by the parity tests). **Provisional** pending Shared Lib's canonical answer (p/470: tsx-source vs `build:server` dist js vs a dedicated npm script) — isolated to this one function.
- **`--out` is a directory** (the CLI writes `brief.pptx` + `deck_spec.json` + `narration.json` + `audit-manifest.json` under it): `-OutputPath` → **`-OutputDirectory`** (alias `-OutDir`/`-OutputPath`), default `<debate>-brief` beside the JSON, `-Force` guards a non-empty dir.
- **`-AllowOpenDebate`** switch → `--allow-open` (watermarked snapshot of a non-closed debate; absent → `DebateNotClosed`). Snapshot `WARN:` lines flow through the existing warning streaming.

### Verification
- **9 Pester tests green** — parity, server-defer, input guards, happy-path with flag-passthrough assertions (`--out`-dir / `--allow-open` / `--skip-narration`), `-WhatIf` no-op, failure errorCode mapping.
- **Entrypoint smoke:** `npx tsx lib/brief/cli.ts` executes the real CLI (loads the import graph); full E2E needs an `npm ci`'d checkout (a documented local-mode runtime prerequisite).
- CLI output contract read directly from `lib/brief/cli.ts` — matches the parsed `TriadDeckExport` exactly.

### Un-draft criteria
1. Shared Lib confirms the canonical CLI invocation (p/470) → adjust `Resolve-BriefExportCli` if needed.
2. `/review-ps` + full Pester green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)