### PR TITLE
feat(t2850): route brief-export writes to dedicated brief-exports container

### DIFF
--- a/taxonomy-editor/src/server/__tests__/briefExportBackend.test.ts
+++ b/taxonomy-editor/src/server/__tests__/briefExportBackend.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+//
+// t/2850 — brief-export container-selection regression. getBriefExportBackend()
+// must return the dedicated brief-export backend when wired, independently of the
+// user-content backend. This gate ensures the lifecycle-rule container routing is
+// never silently un-wired.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fileIO from '../storage/fileIO.js';
+import type { StorageBackend } from '../storage/storageBackend.js';
+
+function makeStub(name: string): StorageBackend {
+  return { backendName: name } as unknown as StorageBackend;
+}
+
+const originalUserContent = fileIO.getUserContentBackend();
+const originalBriefExport = fileIO.getBriefExportBackend();
+
+afterEach(() => {
+  fileIO.setUserContentBackend(originalUserContent);
+  fileIO.setBriefExportBackend(originalBriefExport);
+});
+
+describe('getBriefExportBackend — container-selection (t/2850)', () => {
+  it('returns the dedicated brief-export backend when wired', () => {
+    const dedicated = makeStub('brief-exports');
+    fileIO.setBriefExportBackend(dedicated);
+    expect(fileIO.getBriefExportBackend()).toBe(dedicated);
+  });
+
+  it('brief-export and user-content backends are distinct when both wired', () => {
+    const uc = makeStub('user-content');
+    const be = makeStub('brief-exports');
+    fileIO.setUserContentBackend(uc);
+    fileIO.setBriefExportBackend(be);
+    expect(fileIO.getBriefExportBackend()).toBe(be);
+    expect(fileIO.getUserContentBackend()).toBe(uc);
+    expect(fileIO.getBriefExportBackend()).not.toBe(fileIO.getUserContentBackend());
+  });
+
+  it('changing the user-content backend does not change the brief-export backend', () => {
+    const be = makeStub('brief-exports-stable');
+    fileIO.setBriefExportBackend(be);
+    fileIO.setUserContentBackend(makeStub('new-user-content'));
+    expect(fileIO.getBriefExportBackend()).toBe(be);
+  });
+});

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -235,6 +235,12 @@ if (STORAGE_MODE === 'github-api') {
       userContentContainer: process.env.AZURE_USER_CONTENT_CONTAINER || 'user-content',
       communityContainer: process.env.AZURE_COMMUNITY_CONTAINER || 'community',
     }));
+    const briefExportsContainer = process.env.AZURE_BRIEF_EXPORTS_CONTAINER || 'brief-exports';
+    fileIO.setBriefExportBackend(new AzureBlobBackend({
+      accountUrl: blobAccountUrl,
+      userContentContainer: briefExportsContainer,
+      communityContainer: briefExportsContainer,
+    }));
     serverRecorder.record({
       type: 'storage.mode', component: 'storage', level: 'info',
       message: 'User content storage: azure-blob',

--- a/taxonomy-editor/src/server/storage/briefExportStore.ts
+++ b/taxonomy-editor/src/server/storage/briefExportStore.ts
@@ -16,7 +16,7 @@ import { resolveDataPath } from '../config.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { log } from '../logger.js';
 import { getStorageUserId, isAnonymousUser } from '../security/userContext.js';
-import { getUserContentBackend, assertSafeId } from './fileIO.js';
+import { getBriefExportBackend, assertSafeId } from './fileIO.js';
 import { checkQuota, type QuotaCheckResult } from '../security/quotas.js';
 import { BRIEF_ARTIFACTS, type BriefArtifactName, type BriefPreset, type ModelSource, type ExportErrorCode } from '../../../../lib/brief/types.js';
 
@@ -60,12 +60,12 @@ const INDEX_FILE = '_index.json';
 // ── Index helpers ──
 
 async function readIndex(): Promise<BriefExportRecord[]> {
-  const raw = await getUserContentBackend().readFile(path.join(getExportsDir(), INDEX_FILE));
+  const raw = await getBriefExportBackend().readFile(path.join(getExportsDir(), INDEX_FILE));
   if (raw === null) return [];
   try { return JSON.parse(raw) as BriefExportRecord[]; } catch { /* telemetry — silent by design */ return []; }
 }
 async function writeIndex(entries: BriefExportRecord[]): Promise<void> {
-  await getUserContentBackend().writeFile(path.join(getExportsDir(), INDEX_FILE), JSON.stringify(entries, null, 2));
+  await getBriefExportBackend().writeFile(path.join(getExportsDir(), INDEX_FILE), JSON.stringify(entries, null, 2));
 }
 async function upsertIndex(rec: BriefExportRecord): Promise<void> {
   const entries = await readIndex();
@@ -95,7 +95,7 @@ export async function saveBriefExport(rec: BriefExportRecord, artifacts: Artifac
       nextSteps: ['Sign in to export debate briefs'],
     });
   }
-  const backend = getUserContentBackend();
+  const backend = getBriefExportBackend();
   const dir = getExportDir(rec.exportId);
   for (const a of artifacts) {
     const p = path.join(dir, a.name);
@@ -127,7 +127,7 @@ export async function listBriefExports(debateId?: string): Promise<BriefExportRe
 export async function loadBriefExportRecord(exportId: string): Promise<BriefExportRecord | null> {
   assertSafeId(exportId, 'export id');
   if (isAnonymousUser()) return null;
-  const raw = await getUserContentBackend().readFile(path.join(getExportDir(exportId), 'record.json'));
+  const raw = await getBriefExportBackend().readFile(path.join(getExportDir(exportId), 'record.json'));
   if (raw === null) return null;
   try { return JSON.parse(raw) as BriefExportRecord; } catch { /* telemetry — silent by design */ return null; }
 }
@@ -137,7 +137,7 @@ export async function loadBriefExportRecord(exportId: string): Promise<BriefExpo
 export async function loadBriefArtifact(exportId: string, name: BriefArtifactName): Promise<{ bytes: Buffer } | { text: string } | null> {
   assertSafeId(exportId, 'export id');
   if (isAnonymousUser()) return null;
-  const backend = getUserContentBackend();
+  const backend = getBriefExportBackend();
   const p = path.join(getExportDir(exportId), name);
   if (name === BRIEF_ARTIFACTS.pptx) {
     const bytes = await backend.readBinaryFile(p);
@@ -152,7 +152,7 @@ export async function loadBriefArtifact(exportId: string, name: BriefArtifactNam
 export async function deleteBriefExport(exportId: string): Promise<void> {
   assertSafeId(exportId, 'export id');
   if (isAnonymousUser()) return;
-  const backend = getUserContentBackend();
+  const backend = getBriefExportBackend();
   const dir = getExportDir(exportId);
   const names: string[] = [...Object.values(BRIEF_ARTIFACTS), 'record.json'];
   await Promise.all(names.map(n => backend.deleteFile(path.join(dir, n)).catch(() => { /* best-effort — file may be absent */ })));

--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -44,6 +44,7 @@ export { listOpedSets, loadOpedSet, saveOpedSetInProgress, loadOpedSetInProgress
 // while `backend` stays on GitHubAPIBackend.
 let backend: StorageBackend = new FilesystemBackend();
 let userContentBackend: StorageBackend | null = null;
+let briefExportBackend: StorageBackend | null = null;
 
 // Parsed-entities cache — memoizes entities.json so repeated public getEntity
 // (t/1786) hits, an UNAUTHENTICATED read tier, never re-parse the file per request
@@ -74,6 +75,10 @@ export function setTaxonomyBackend(b: StorageBackend): void { backend = b; entit
 export function setUserContentBackend(b: StorageBackend): void { userContentBackend = b; }
 /** User-content backend; falls back to the taxonomy backend when unset. */
 export function getUserContentBackend(): StorageBackend { return userContentBackend ?? backend; }
+/** Set the backend for brief-export artifacts (t/2850 — dedicated container for lifecycle rule). */
+export function setBriefExportBackend(b: StorageBackend): void { briefExportBackend = b; }
+/** Brief-export backend; falls back to user-content backend when unset. */
+export function getBriefExportBackend(): StorageBackend { return briefExportBackend ?? getUserContentBackend(); }
 
 // ── Path safety ──
 


### PR DESCRIPTION
## Summary
- Adds `setBriefExportBackend` / `getBriefExportBackend` to `fileIO.ts` — mirrors the `userContentBackend` pattern, falls back to `getUserContentBackend()` when unset (filesystem/Electron mode unaffected)
- Wires a dedicated `AzureBlobBackend` in `server.ts` targeting `AZURE_BRIEF_EXPORTS_CONTAINER` (default: `brief-exports`; operators set `staging-brief-exports` in staging)
- `briefExportStore` switches from `getUserContentBackend` to `getBriefExportBackend` so all artifact writes land in the correct container, making the 30-day lifecycle rule from PR #1280 effective
- Regression test (`briefExportBackend.test.ts`) pins container-selection independence — dedicated backend is distinct from user-content, and changing user-content doesn't affect brief-export routing

## Sequencing note
**Must NOT be deployed until PR #1280 (Bicep lifecycle rule) has deployed** and the `brief-exports` / `staging-brief-exports` containers exist. If deployed first, writes 404 against a nonexistent container (per ticket description).

## Test plan
- [ ] `npm run briefExportBackend.test.ts` — 3 container-selection tests pass
- [ ] `npm run verify` (tsc + vitest) clean
- [ ] AC3 (post-deploy): an export lands in `brief-exports` container and is subject to the 30-day lifecycle rule

Closes t/2850

🤖 Generated with [Claude Code](https://claude.com/claude-code)