### PR TITLE
feat(brief): flip allowOpen 400→snapshot pipeline + maturity warning (t/2851)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/briefExportJobs.test.ts
+++ b/taxonomy-editor/src/server/__tests__/briefExportJobs.test.ts
@@ -128,6 +128,23 @@ describe('brief export runner (t/2804)', () => {
     expect(narrate).toHaveBeenCalledWith(expect.objectContaining({ skipNarration: true }), expect.anything());
   });
 
+  it('allowOpen: extracts a watermarked snapshot and surfaces the in-progress maturity warning (t/2851)', async () => {
+    extractDeckSpec.mockReturnValue({ ...SPEC, meta: { ...SPEC.meta, snapshot: true, snapshot_note: 'IN PROGRESS' } });
+    const job = startExportJob(baseArgs({ session: { phase: 'open' } as never, request: { preset: 'policymaker', skipNarration: false, allowOpen: true } }));
+    await waitTerminal(job);
+    // extract was asked for the snapshot (allowOpen threaded through)
+    expect(extractDeckSpec).toHaveBeenCalledWith(expect.objectContaining({ phase: 'open' }), { allowOpen: true });
+    // an explicit maturity warning — a snapshot never masquerades as a final export
+    expect(job.warnings.some(w => w.startsWith('in_progress_snapshot:'))).toBe(true);
+  });
+
+  it('allowOpen unset: a closed export passes no snapshot opts and adds no maturity warning (t/2851)', async () => {
+    const job = startExportJob(baseArgs());
+    await waitTerminal(job);
+    expect(extractDeckSpec).toHaveBeenCalledWith(expect.objectContaining({ phase: 'closed' }), undefined);
+    expect(job.warnings.some(w => w.startsWith('in_progress_snapshot:'))).toBe(false);
+  });
+
   it('registry: getExportJob is user-scoped (another user cannot read the job)', async () => {
     const job = startExportJob(baseArgs());
     await waitTerminal(job);

--- a/taxonomy-editor/src/server/__tests__/briefExports.test.ts
+++ b/taxonomy-editor/src/server/__tests__/briefExports.test.ts
@@ -125,10 +125,15 @@ describe('Brief Export routes (t/2804)', () => {
     expect(startExportJob).not.toHaveBeenCalled();
   });
 
-  it('400 on ?allowOpen=true — live-snapshot export is not available yet (t/2816)', async () => {
+  it('?allowOpen=true on a non-closed debate runs the pipeline (202) with request.allowOpen (t/2851)', async () => {
+    loadDebateSession.mockResolvedValue({ phase: 'open' });
     await post(validBody, '/api/debates/deb-1/exports?allowOpen=true');
-    expect(lastRes._status).toBe(400);
-    expect(lastRes._body).toMatch(/t\/2816/);
+    expect(lastRes._status).toBe(202);
+    expect(JSON.parse(lastRes._body!)).toEqual({ jobId: 'job-1' });
+    // allowOpen is threaded into the job so extractDeckSpec produces the watermarked snapshot.
+    expect(startExportJob).toHaveBeenCalledWith(expect.objectContaining({
+      request: expect.objectContaining({ allowOpen: true }),
+    }));
   });
 
   it('404 when the debate does not exist', async () => {

--- a/taxonomy-editor/src/server/briefExportJobs.ts
+++ b/taxonomy-editor/src/server/briefExportJobs.ts
@@ -34,6 +34,9 @@ export interface ExportJobRequest {
   template?: Uint8Array;
   /** When false, removes the framing_meta slide from classroom exports (t/2838). */
   framingMeta?: boolean;
+  /** When true, export a non-closed (in-progress) debate as a watermarked snapshot
+   *  (t/2851 / t/2816). Passed through to extractDeckSpec; a closed debate ignores it. */
+  allowOpen?: boolean;
 }
 export interface ExportJob {
   jobId: string;
@@ -157,8 +160,16 @@ async function runExportJob(job: ExportJob, args: CreateJobArgs): Promise<void> 
   try {
     // ── extract ──
     setState(job, 'extracting'); stage = 'extracting';
-    const spec = extractDeckSpec(session);
+    const spec = extractDeckSpec(session, request.allowOpen ? { allowOpen: true } : undefined);
     title = spec.meta.title;
+    // Maturity warning (t/2851): a live-snapshot export is partial, not a final export.
+    // Keyed on the actual snapshot flag (a closed debate + allowOpen still extracts normally),
+    // so the response never lets an in-progress snapshot masquerade as a concluded brief.
+    if (spec.meta.snapshot) {
+      job.warnings.push(
+        'in_progress_snapshot: exported from a non-closed debate — this is a partial, watermarked live snapshot (meta.snapshot=true), not a final export.',
+      );
+    }
     artifacts.push({ name: BRIEF_ARTIFACTS.deckSpec, text: JSON.stringify(spec, null, 2) });
 
     // ── narrate (+ optional maker-checker) ──

--- a/taxonomy-editor/src/server/routes/briefExports.ts
+++ b/taxonomy-editor/src/server/routes/briefExports.ts
@@ -42,7 +42,7 @@ interface ExportPostBody {
  *  complexity ceiling; the I/O gates (debate load, model resolution) remain inline. */
 type ExportPrecheck =
   | { ok: false; status: number; message: string }
-  | { ok: true; preset: BriefPreset; skipNarration: boolean };
+  | { ok: true; preset: BriefPreset; skipNarration: boolean; allowOpen: boolean };
 
 function precheckExportRequest(req: Parameters<Parameters<Router['post']>[1]>[0], b: ExportPostBody): ExportPrecheck {
   // Auth MUST (#5): export is billable — never anon.
@@ -57,13 +57,13 @@ function precheckExportRequest(req: Parameters<Parameters<Router['post']>[1]>[0]
     return { ok: false, status: 400, message: 'PDF requires the desktop app: the server renders .pptx (and spec). Open the AITriad desktop app to export a PDF (printToPDF is Electron-only).' };
   }
 
-  // allowOpen depends on snapshot extract (t/2816) — closed-only for v1; never silently downgrade.
+  // allowOpen (t/2851): snapshot extract is supported now (lib #1269, snapshot-aware verify t/2841).
+  // A non-closed debate exports a watermarked in-progress snapshot (meta.snapshot=true) with a
+  // maturity warning; the closed-phase gate below only fails closed when allowOpen is NOT set.
   const url = new URL(req.url ?? '', 'http://localhost');
-  if (url.searchParams.get('allowOpen') === 'true') {
-    return { ok: false, status: 400, message: 'Snapshot export of a live debate is not available yet (tracked in t/2816). Close the debate to export.' };
-  }
+  const allowOpen = url.searchParams.get('allowOpen') === 'true';
 
-  return { ok: true, preset, skipNarration: b.options?.skipNarration === true };
+  return { ok: true, preset, skipNarration: b.options?.skipNarration === true, allowOpen };
 }
 
 /** Resolve narrator + optional checker with the billable entitlement gate (MUST #5). Writes
@@ -108,7 +108,7 @@ export function registerBriefExportsRoutes(r: Router, _ctx: ServerCtx): void {
     const b = (body ?? {}) as ExportPostBody;
     const pre = precheckExportRequest(req, b);
     if (!pre.ok) { error(res, pre.message, pre.status); return; }
-    const { preset, skipNarration } = pre;
+    const { preset, skipNarration, allowOpen } = pre;
     const debateId = param(req, 'debateId', '/api/debates/:debateId/exports');
 
     // Load debate + closed-phase gate.
@@ -119,8 +119,8 @@ export function registerBriefExportsRoutes(r: Router, _ctx: ServerCtx): void {
       error(res, 'Debate not found', 404); return;
     }
     if (!session) { error(res, 'Debate not found', 404); return; }
-    if (session.phase !== 'closed') {
-      error(res, 'Only closed debates can be exported. Close the debate first (live-snapshot export is tracked in t/2816).', 409);
+    if (session.phase !== 'closed' && !allowOpen) {
+      error(res, 'Only closed debates can be exported. Close the debate first, or pass ?allowOpen=true to export a watermarked in-progress snapshot.', 409);
       return;
     }
 
@@ -149,7 +149,7 @@ export function registerBriefExportsRoutes(r: Router, _ctx: ServerCtx): void {
     const framingMeta = b.framingMeta === false ? false : undefined;
     const job = startExportJob({
       userId, session, debateId, models,
-      request: { preset, skipNarration, framingMeta },
+      request: { preset, skipNarration, framingMeta, allowOpen },
       toolVersions: TOOL_VERSIONS, timestamp: new Date().toISOString(),
       idempotencyKey, adapter: createWebOpEdAdapter(),
     });


### PR DESCRIPTION
T6 (server) half of t/2816 — now that lib snapshot extract (#1269) and snapshot-aware verify (t/2841) are on main.

## Change
- **`routes/briefExports.ts`**: `?allowOpen=true` no longer returns 400. The precheck returns `allowOpen`; the closed-phase gate only 409s when `!closed && !allowOpen`. A non-closed debate with `allowOpen` now exports a **watermarked in-progress snapshot**. Closed path and `!closed && !allowOpen` → 409 unchanged.
- **`briefExportJobs.ts`**: threads `allowOpen` into `extractDeckSpec(session, { allowOpen })`; when the extracted spec is a snapshot (`meta.snapshot`), pushes an explicit `in_progress_snapshot:` **maturity warning** so a live snapshot never presents as a final export.
- **Tests**: replaced the "400 on allowOpen" route assertion with allowOpen→202 + `request.allowOpen`; added **both-arms** job tests (snapshot → maturity warning present; closed → no warning + `extractDeckSpec(session, undefined)`).

## Billable-surface note
Gate unchanged — still auth-gated (403 anon), entitlement-gated, count-quota + concurrency=1. `allowOpen` only changes *which* debates are exportable (adds in-progress), not the metering. No unmetered spend.

## Self-cert
`/add-rest-endpoint`. **Deviation**: this is a response-**contract** modification (accepts `?allowOpen`, adds a `warnings` entry), not a brand-new endpoint — flagged per the ticket's review-routing note. Server+renderer tsc clean, eslint 0 errors, 31 brief tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)