### PR TITLE
feat(prompt-tool): registry lint gate for PROMPT_CATALOG drift (t/2834)

### DIFF
--- a/taxonomy-editor/src/renderer/data/promptCatalog.excluded.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.excluded.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * Prompt-catalog exclusion allowlist (t/2834).
+ *
+ * The registry lint (`__tests__/promptCatalog.lint.test.ts`) fails when a discovered
+ * prompt-builder (`lib/debate/prompts/*`, `renderer/prompts/*`) or `.prompt` file is neither
+ * referenced by `PROMPT_CATALOG` nor listed here. This file is the single, greppable place an
+ * intentional exclusion lives — co-located with the catalog + gate (Gate Co-Location).
+ *
+ * **Every entry needs a `reason`** — an exemption without a reason is how allowlists rot.
+ * Seeded from CL's curation ruling (t/2835#1): the 14 INTERNAL debate builders that are
+ * opening/version variants, repair micro-prompts, or classifier/gate helpers — conceptually
+ * covered by an already-exposed prompt, so they carry the marker instead of a catalog entry.
+ */
+
+export interface PromptExclusion {
+  /** Exported builder fn name (or `.prompt` basename) that is intentionally NOT catalogued. */
+  name: string;
+  /** Why it's excluded — required. Keeps the allowlist auditable. */
+  reason: string;
+}
+
+export const PROMPT_CATALOG_EXCLUDED: PromptExclusion[] = [
+  // ── CL INTERNAL (t/2835#1): opening-stage variants — the opening is already represented
+  //    top-level by the catalogued `openingStatementPrompt`; these are its per-stage specializations.
+  { name: 'planOpeningStagePrompt', reason: 'Opening-stage variant of planStagePrompt; opening is represented by the catalogued openingStatementPrompt (CL t/2835#1).' },
+  { name: 'briefOpeningStagePrompt', reason: 'Opening-stage variant of briefStagePrompt; opening is represented by the catalogued openingStatementPrompt (CL t/2835#1).' },
+  { name: 'draftOpeningStagePrompt', reason: 'Opening-stage variant of draftStagePrompt; opening is represented by the catalogued openingStatementPrompt (CL t/2835#1).' },
+  { name: 'citeOpeningStagePrompt', reason: 'Opening-stage variant of citeStagePrompt; opening is represented by the catalogued openingStatementPrompt (CL t/2835#1).' },
+  // ── CL INTERNAL: version / user-seed variants of an already-exposed stage.
+  { name: 'briefStagePromptV2', reason: 'A/B version variant of the catalogued briefStagePrompt (CL t/2835#1).' },
+  { name: 'draftFromSelectedClaimsPrompt', reason: 'User-seeded-claims variant of the catalogued draftStagePrompt (CL t/2835#1).' },
+  // ── CL INTERNAL: repair / classifier / gate helpers — not user-inspected turn prompts.
+  { name: 'dolceComplianceRetryPrompt', reason: 'DOLCE-compliance repair micro-prompt (CL t/2835#1).' },
+  { name: 'entailmentRepairPrompt', reason: 'Entailment repair micro-prompt (CL t/2835#1).' },
+  { name: 'classifyCounterfactualTypePrompt', reason: 'Classifier helper, not a user-facing turn prompt (CL t/2835#1).' },
+  { name: 'coverageCheckPrompt', reason: 'Coverage gate helper, not a user-facing turn prompt (CL t/2835#1).' },
+  { name: 'elementDecompositionPrompt', reason: 'Statement→information-elements helper (CL t/2835#1).' },
+  { name: 'cruxRefreshPrompt', reason: 'Mid-debate crux-maintenance micro-prompt (CL t/2835#1).' },
+  { name: 'consensusSituationPrompt', reason: 'Niche convergence→enrichment sub-prompt (CL t/2835#1).' },
+  { name: 'crossCuttingNodePrompt', reason: 'Niche convergence→enrichment sub-prompt (CL t/2835#1).' },
+
+  // ── PROVISIONAL (t/2859): renderer-prompt builders outside CL's t/2835 debate-builder scope.
+  //    Excluded to keep the gate green now; CL disposition tracked by t/2859 (TL ruling C, t/2834#5) —
+  //    time-bound, not silent-forever. Re-evaluate when t/2859 rules expose-vs-internal.
+  { name: 'vernacularPrompt', reason: 'Provisional: pending CL disposition, outside t/2835 scope — t/2859.' },
+  { name: 'aphorismPrompt', reason: 'Provisional: pending CL disposition, outside t/2835 scope — t/2859.' },
+  { name: 'generateDebateTitlePrompt', reason: 'Provisional: pending CL disposition, outside t/2835 scope — t/2859.' },
+];

--- a/taxonomy-editor/src/renderer/data/promptCatalog.lint.test.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.lint.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Prompt-catalog registry lint (t/2834). Anti-drift gate: fails when a prompt-builder or
+// `.prompt` file exists but is neither catalogued in PROMPT_CATALOG nor allowlisted in
+// promptCatalog.excluded.ts — the failure class t/2822 found (14+ silent misses). Runs inside
+// the existing `test-electron (taxonomy-editor)` vitest job — no new ci.yml step (TL t/2834#3).
+//
+// Signal (TL-ruled A/B, t/2834#5):
+//   • .prompt files  → referenced ⟺ basename ∈ some entry.promptFiles[]
+//   • TS builders    → referenced ⟺ imported-and-used in promptCatalog.ts ∪ some entry.builders[]
+//   • plus a no-dead-import arm (every imported *Prompt is actually used) and bidirectional
+//     reverse checks (every promptFiles/source/builders reference resolves to a real file/export).
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PROMPT_CATALOG } from './promptCatalog';
+import { PROMPT_CATALOG_EXCLUDED } from './promptCatalog.excluded';
+
+// ── Resolve the repo root deterministically (dir that holds both the .prompt and builder trees),
+//    so the lint is independent of vitest's cwd. ──
+function findRepoRoot(start: string): string {
+  let dir = start;
+  for (let i = 0; i < 12; i++) {
+    if (
+      fs.existsSync(path.join(dir, 'lib', 'debate', 'prompts')) &&
+      fs.existsSync(path.join(dir, 'scripts', 'AITriad', 'Prompts'))
+    ) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`promptCatalog.lint: could not locate repo root walking up from ${start}`);
+}
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = findRepoRoot(HERE);
+const CATALOG_PATH = 'taxonomy-editor/src/renderer/data/promptCatalog.ts';
+
+// Discovered universe (TL-approved mechanism, t/2834#1): the two `.prompt` dirs + the two
+// builder-fn trees. `.prompt` basenames drop the extension; builders are declaration-site exports.
+const PROMPT_DIRS = ['scripts/AITriad/Prompts', 'lib/oped/prompts'];
+const BUILDER_DIRS = ['lib/debate/prompts', 'taxonomy-editor/src/renderer/prompts'];
+const BUILDER_EXPORT_RE = /export\s+(?:async\s+)?(?:function|const)\s+(\w+Prompt)\b/g;
+
+function discoveredPromptFiles(): string[] {
+  const out: string[] = [];
+  for (const d of PROMPT_DIRS) {
+    const abs = path.join(ROOT, d);
+    if (!fs.existsSync(abs)) continue;
+    for (const f of fs.readdirSync(abs)) {
+      if (f.endsWith('.prompt')) out.push(f.replace(/\.prompt$/, ''));
+    }
+  }
+  return out;
+}
+
+function discoveredBuilders(): Set<string> {
+  const set = new Set<string>();
+  for (const d of BUILDER_DIRS) {
+    const abs = path.join(ROOT, d);
+    if (!fs.existsSync(abs)) continue;
+    for (const f of fs.readdirSync(abs)) {
+      if (!f.endsWith('.ts') || f.endsWith('.test.ts')) continue;
+      const src = fs.readFileSync(path.join(abs, f), 'utf8');
+      for (const m of src.matchAll(BUILDER_EXPORT_RE)) set.add(m[1]);
+    }
+  }
+  return set;
+}
+
+// ── promptCatalog.ts source-text analysis: imported *Prompt identifiers + a body with the
+//    import statements stripped (so "is this import used?" is a search over the rest of the file). ──
+const CATALOG_SRC = fs.readFileSync(path.join(ROOT, CATALOG_PATH), 'utf8');
+const IMPORT_BLOCK_RE = /import\s*(?:type\s*)?\{([^}]*)\}\s*from\s*['"][^'"]*['"];?/g;
+
+function importedBuilders(): string[] {
+  const names = new Set<string>();
+  for (const block of CATALOG_SRC.matchAll(IMPORT_BLOCK_RE)) {
+    for (const raw of block[1].split(',')) {
+      const name = raw.trim().split(/\s+as\s+/)[0].trim();
+      if (/^\w+Prompt$/.test(name)) names.add(name);
+    }
+  }
+  return [...names];
+}
+const CATALOG_BODY_NO_IMPORTS = CATALOG_SRC.replace(IMPORT_BLOCK_RE, '');
+
+function sourceResolves(src: string): boolean {
+  // `source` is a display path with one of three roots: repo-root-relative (`lib/...`,
+  // `lib/oped/prompts/*.prompt`), renderer-src-relative (`prompts/...`, `data/...`), or the
+  // PS-prompt label form (`AITriad/Prompts/*.prompt`, which lives under `scripts/`). Accept a hit
+  // against any of the three.
+  return [
+    path.join(ROOT, src),
+    path.join(ROOT, 'taxonomy-editor', 'src', 'renderer', src),
+    path.join(ROOT, 'scripts', src),
+  ].some((c) => fs.existsSync(c));
+}
+
+// ── Derived reference sets ──
+const referencedPromptFiles = new Set(PROMPT_CATALOG.flatMap((e) => e.promptFiles ?? []));
+const declaredBuilders = new Set(PROMPT_CATALOG.flatMap((e) => e.builders ?? []));
+const excludedNames = new Set(PROMPT_CATALOG_EXCLUDED.map((e) => e.name));
+
+describe('promptCatalog registry lint (t/2834)', () => {
+  const discovered = discoveredBuilders();
+  const imported = importedBuilders();
+  const referencedBuilders = new Set([...imported, ...declaredBuilders]);
+
+  it('forward (builders): every discovered *Prompt builder is catalogued or allowlisted', () => {
+    const orphans = [...discovered]
+      .filter((b) => !referencedBuilders.has(b) && !excludedNames.has(b))
+      .sort();
+    expect(
+      orphans,
+      `Uncatalogued prompt builders — add a catalog entry (with builders:['name'] or a template call) ` +
+        `or an exclusion in promptCatalog.excluded.ts:\n  ${orphans.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('forward (.prompt): every discovered .prompt file is catalogued or allowlisted', () => {
+    const orphans = discoveredPromptFiles()
+      .filter((p) => !referencedPromptFiles.has(p) && !excludedNames.has(p))
+      .sort();
+    expect(
+      orphans,
+      `Uncatalogued .prompt files — add promptFiles:[...] to an entry or an exclusion:\n  ${orphans.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('reverse (promptFiles): every catalog promptFiles basename resolves to a real .prompt', () => {
+    const present = new Set(discoveredPromptFiles());
+    const dangling = [...referencedPromptFiles].filter((p) => !present.has(p)).sort();
+    expect(dangling, `Catalog promptFiles referencing a missing .prompt:\n  ${dangling.join('\n  ')}`).toEqual([]);
+  });
+
+  it('reverse (builders): every declared builders[] name resolves to a real exported builder', () => {
+    const dangling = [...declaredBuilders].filter((b) => !discovered.has(b)).sort();
+    expect(dangling, `builders[] names with no exported builder in the discovered trees:\n  ${dangling.join('\n  ')}`).toEqual([]);
+  });
+
+  it('reverse (source): every catalog entry.source resolves to a real file', () => {
+    const bad = PROMPT_CATALOG.filter((e) => !sourceResolves(e.source))
+      .map((e) => `${e.id} → ${e.source}`)
+      .sort();
+    expect(bad, `Catalog entries whose source path does not resolve:\n  ${bad.join('\n  ')}`).toEqual([]);
+  });
+
+  it('no dead prompt imports: every imported *Prompt is used in promptCatalog.ts', () => {
+    const dead = imported.filter((name) => !new RegExp(`\\b${name}\\b`).test(CATALOG_BODY_NO_IMPORTS)).sort();
+    expect(dead, `Imported but never used — remove the import or reference it (dead imports):\n  ${dead.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every exclusion carries a non-empty reason (allowlist hygiene)', () => {
+    const noReason = PROMPT_CATALOG_EXCLUDED.filter((e) => !e.reason?.trim()).map((e) => e.name);
+    expect(noReason, `Exclusions missing a reason:\n  ${noReason.join('\n  ')}`).toEqual([]);
+  });
+});

--- a/taxonomy-editor/src/renderer/data/promptCatalog.lint.test.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.lint.test.ts
@@ -112,6 +112,17 @@ describe('promptCatalog registry lint (t/2834)', () => {
   const imported = importedBuilders();
   const referencedBuilders = new Set([...imported, ...declaredBuilders]);
 
+  it('coverage integrity: every discovery dir exists (no vacuous forward arm) — TL t/2834#7', () => {
+    // findRepoRoot anchors lib/debate/prompts + scripts/AITriad/Prompts, but lib/oped/prompts and
+    // renderer/prompts are otherwise unanchored — if one is renamed/moved, its forward arm would
+    // pass vacuously and coverage would shrink silently (the silent-degradation class). Fail loud.
+    const missing = [...PROMPT_DIRS, ...BUILDER_DIRS].filter((d) => !fs.existsSync(path.join(ROOT, d)));
+    expect(
+      missing,
+      `Discovery dir(s) missing — a moved/renamed dir makes that arm pass vacuously. Update the dir list:\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
   it('forward (builders): every discovered *Prompt builder is catalogued or allowlisted', () => {
     const orphans = [...discovered]
       .filter((b) => !referencedBuilders.has(b) && !excludedNames.has(b))

--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -51,15 +51,9 @@ import {
   newsReportPrompt,
   citeRetryPrompt,
   draftQualityCheckPrompt,
-  consensusSituationPrompt,
-  dolceComplianceRetryPrompt,
   decomposeResolutionPrompt,
 } from '@lib/debate/prompts';
-import { extractClaimsPrompt, classifyClaimsPrompt } from '@lib/debate/argumentNetwork';
-import { classifyConcessionsPrompt } from '@lib/debate/concessionTracker';
-import { documentAnalysisPrompt } from '@lib/debate/documentAnalysis';
 import { critiqueTopicPrompt } from '@lib/debate/topicCritique';
-import { buildRepairPrompt } from '@lib/debate/turnValidator';
 
 export type PromptGroup = 'debate-setup' | 'debate-turns' | 'debate-analysis' | 'moderator' | 'chat' | 'taxonomy' | 'research' | 'powershell' | 'oped';
 export type DataSourceId = 'taxonomyNodes' | 'situationNodes' | 'vulnerabilities' | 'fallacies' | 'policyRegistry' | 'sourceDocument' | 'commitments' | 'argumentNetwork' | 'establishedPoints';
@@ -86,6 +80,12 @@ export interface PromptCatalogEntry {
   promptDir?: 'ps' | 'oped';
   /** PS cmdlet parameters that configure this prompt at runtime */
   psParameters?: { name: string; type: string; default: string; description: string }[];
+  /** Prompt-builder fn names (exported from `lib/debate/prompts/*` or `renderer/prompts/*`)
+   *  this entry exposes. The registry lint (`__tests__/promptCatalog.lint.test.ts`, t/2834)
+   *  treats these as the machine-link for builders that aren't invoked in a `template` call
+   *  at build time (e.g. the StagePromptInput turn stages). Every name must resolve to a real
+   *  exported builder. Simple entries that call `builder('{x}')` in `template` need no entry here. */
+  builders?: string[];
 }
 
 export const PROMPT_CATALOG: PromptCatalogEntry[] = [
@@ -1142,5 +1142,139 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     purpose: 'Pre-generation step. Reads {{SOURCE_MATERIAL}} and returns a structured JSON brief (key claims, evidence, positions) that grounds the subsequent op-ed. Returns JSON.',
     applicableDataSources: ['sourceDocument'],
     promptFiles: ['op-ed-source-brief'],
+  },
+
+  // === Debate turn pipeline (non-opening stages) + analytical builders (t/2834 / CL EXPOSE t/2835#1) ===
+  // These builders take runtime StagePromptInput and can't be invoked in a `template` at build time,
+  // so they declare `builders: [...]` as the registry-lint machine-link instead of a template call.
+  {
+    id: 'debate-plan-stage',
+    title: 'Debate: Plan (turn stage)',
+    description: 'Core turn-pipeline plan stage — the debater plans argument structure for a non-opening turn.',
+    source: 'lib/debate/prompts/turn-pipeline.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-turns',
+    purpose: 'Fires as the plan stage of each non-opening debater turn. The debater (in character) plans strategic goal, thesis, and argument structure before drafting. Feeds the Draft stage.',
+    phase: 'response',
+    applicableDataSources: ['taxonomyNodes', 'situationNodes'],
+    builders: ['planStagePrompt'],
+  },
+  {
+    id: 'debate-brief-stage',
+    title: 'Debate: Brief (turn stage)',
+    description: 'Core turn-pipeline brief stage — analytical situation brief identifying the strongest framing for a non-opening turn.',
+    source: 'lib/debate/prompts/turn-pipeline.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-turns',
+    purpose: 'Fires as the first stage of each non-opening debater turn. An analytical assistant assesses the current state and strongest angles; output feeds the Plan stage.',
+    phase: 'response',
+    applicableDataSources: ['taxonomyNodes', 'situationNodes', 'sourceDocument'],
+    builders: ['briefStagePrompt'],
+  },
+  {
+    id: 'debate-draft-stage',
+    title: 'Debate: Draft (turn stage)',
+    description: 'Core turn-pipeline draft stage — the debater writes their turn statement (phase-aware directives).',
+    source: 'lib/debate/prompts/turn-pipeline.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-turns',
+    purpose: 'Fires after the Plan stage. The debater (in character) writes the full turn statement grounded in taxonomy nodes, with phase-aware directives. Produces the statement text, claim sketches, and key assumptions.',
+    phase: 'response',
+    applicableDataSources: ['taxonomyNodes', 'situationNodes', 'sourceDocument', 'policyRegistry'],
+    builders: ['draftStagePrompt'],
+  },
+  {
+    id: 'debate-cite-stage',
+    title: 'Debate: Cite (turn stage)',
+    description: 'Core turn-pipeline cite stage — post-hoc grounding that maps a turn\'s claims to taxonomy nodes.',
+    source: 'lib/debate/prompts/turn-pipeline.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-turns',
+    purpose: 'Fires after the Draft stage. Verifies grounding by mapping the drafted claims to taxonomy/situation nodes; unresolved pointers surface as gaps.',
+    phase: 'response',
+    applicableDataSources: ['taxonomyNodes', 'situationNodes'],
+    builders: ['citeStagePrompt'],
+  },
+  {
+    id: 'debate-assumptions-extraction',
+    title: 'Debate: Assumptions Extraction',
+    description: 'Surfaces the implicit assumptions underlying a debate statement.',
+    source: 'lib/debate/prompts/turn-pipeline.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-analysis',
+    purpose: 'A distinct analytical prompt that reads a statement and extracts the assumptions it rests on — used to make hidden premises inspectable.',
+    applicableDataSources: [],
+    builders: ['assumptionsExtractionPrompt'],
+  },
+  {
+    id: 'debate-reflection',
+    title: 'Debate: Post-Debate Reflection',
+    description: 'Generates the post-debate reflection over the concluded transcript.',
+    source: 'lib/debate/prompts/reflection.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-analysis',
+    purpose: 'Fires after a debate concludes. Produces the reflection surfaced in the Post-Debate Reflections panel (cf. docs/debate-reflections.md) — proposed edits, new POV items, and convergence notes.',
+    phase: 'reflection',
+    applicableDataSources: ['taxonomyNodes'],
+    builders: ['reflectionPrompt'],
+  },
+  {
+    id: 'debate-taxonomy-refinement',
+    title: 'Debate: Taxonomy Refinement',
+    description: 'Post-debate synthesis prompt that proposes taxonomy refinements from the concluded debate.',
+    source: 'lib/debate/prompts/synthesis.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-analysis',
+    purpose: 'Fires during post-debate synthesis. Reads the concluded debate and proposes concrete taxonomy refinements (node edits/additions) grounded in what was argued.',
+    phase: 'synthesis',
+    applicableDataSources: ['taxonomyNodes'],
+    builders: ['taxonomyRefinementPrompt'],
+  },
+  {
+    id: 'debate-improve-topic',
+    title: 'Debate: Improve Topic',
+    description: 'User-facing topic sharpening — rewrites a debate topic to be crisper and more debatable.',
+    source: 'lib/debate/prompts/topic-crux.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-setup',
+    purpose: 'Fires from the debate-topic editor when the user asks to sharpen their topic. Rewrites the topic into a crisper, more debatable statement without changing its intent.',
+    phase: 'clarification',
+    applicableDataSources: [],
+    builders: ['improveDebateTopicPrompt'],
+  },
+  {
+    id: 'debate-extract-topic-structure',
+    title: 'Debate: Extract Topic Structure',
+    description: 'Debate setup — extracts the structured shape (dimensions, sub-claims) of a debate topic.',
+    source: 'lib/debate/prompts/topic-crux.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-setup',
+    purpose: 'Fires during debate setup. Parses the topic into its structural dimensions and sub-claims so the debate can be scoped and grounded.',
+    phase: 'clarification',
+    applicableDataSources: [],
+    builders: ['extractTopicStructurePrompt'],
+  },
+  {
+    id: 'debate-decontextualize-crux',
+    title: 'Debate: Decontextualize Crux',
+    description: 'Rewrites a crux into a self-contained, context-independent statement (CL calibration surface).',
+    source: 'lib/debate/prompts/topic-crux.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-setup',
+    purpose: 'Takes a crux that references debate-local context and rewrites it as a standalone claim, so cruxes can be compared and reused across debates.',
+    applicableDataSources: [],
+    builders: ['decontextualizeCruxPrompt'],
+  },
+  {
+    id: 'debate-topic-scope-extraction',
+    title: 'Debate: Topic Scope Extraction',
+    description: 'Debate setup — extracts the scope boundaries of a debate topic.',
+    source: 'lib/debate/prompts/topic-crux.ts',
+    template: '(Template requires runtime context — view in Prompt Inspector or Full Prompt tab)',
+    group: 'debate-setup',
+    purpose: 'Fires during debate setup. Identifies what is in- and out-of-scope for the topic so debaters stay bounded and the grounding stays relevant.',
+    phase: 'clarification',
+    applicableDataSources: [],
+    builders: ['topicScopeExtractionPrompt'],
   },
 ];


### PR DESCRIPTION
**Draft** pending TL Gate-Verification sign-off (a hard vitest assertion that will block every renderer PR once merged — TL confirms the GV before it lands, t/2834#5).

Anti-drift gate for the t/2822 failure class (14+ silent prompt misses). A vitest lint in the existing `test-electron (taxonomy-editor)` job — **no new ci.yml step**.

## Signal (TL-ruled A/B/D, t/2834#5)
- **.prompt**: referenced ⟺ basename ∈ some `entry.promptFiles[]`.
- **builders**: referenced ⟺ imported-and-used in `promptCatalog.ts` ∪ some `entry.builders[]` (new optional field — the machine-link for StagePromptInput stages that can't be invoked in a `template` at build time).
- **no-dead-import arm** + bidirectional reverse checks (every `promptFiles`/`source`/`builders` reference resolves to a real file/export).

## Seeded to green
- 11 CL EXPOSE builders → catalog entries (via `builders[]`).
- 14 CL INTERNAL + 3 provisional renderer builders (t/2859) → new co-located `promptCatalog.excluded.ts` (`reason` required; provisional entries inline-reference t/2859 per ruling C).
- Removed **7 dead prompt imports**: the 3 flagged in design (consensus/dolce/buildRepair) + **4 the no-dead-import arm surfaced** (extractClaims/classifyClaims/classifyConcessions/documentAnalysis — imported, never used).
- Op-ed `.prompt` files already catalogued via #1277 → verify-only (ruling D).

## Both-arms GV (all 4 cases — evidence in t/2834)
1. forward drift → RED naming the orphan ✓
2. reverse missing-file → RED naming the entry ✓
3. allowlisted → PASS (exclusion suppresses) ✓
4. clean tree → PASS silent, zero noise (7/7) ✓

tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)