### PR TITLE
fix(t2861): Get-ServerLog — strip az preamble + handle sliced (>16KB) log lines

### DIFF
--- a/scripts/AITriad/Public/Get-ServerLog.ps1
+++ b/scripts/AITriad/Public/Get-ServerLog.ps1
@@ -158,9 +158,14 @@ function Get-ServerLog {
             if ($p) { return $p.Value } else { return $null }
         }
 
+        # az writes connection chrome to the stream (captured via 2>&1). These are
+        # not container logs — strip them so -Raw and structured output stay clean.
+        $azNoiseRegex = '^(Connecting to the container|Successfully Connected to container|No log entries|Show logs)'
+
         $parseAndEmit = {
             param([string]$rawLine)
             if ([string]::IsNullOrWhiteSpace($rawLine)) { return }
+            if ($rawLine -match $azNoiseRegex) { return }   # az connection chrome, not a log
 
             # ACA wraps container stdout as {"Log":"<pino-json>","TimeStamp":"..."}.
             $pinoLine = $rawLine
@@ -175,7 +180,15 @@ function Get-ServerLog {
 
             $entry = $null
             try { $entry = $pinoLine | ConvertFrom-Json -ErrorAction Stop }
-            catch { if ($Raw) { Write-Output $pinoLine }; return }
+            catch {
+                # Unparseable: almost always a pino line sliced at ACA/Fluent Bit's
+                # ~16KB boundary (t/2860). A HEAD slice still starts with '{' and
+                # carries requestId — worth surfacing under -Raw; a TAIL slice (e.g.
+                # 'completed"}') is noise. Count either way so the run can warn.
+                $script:GslUnparsedCount++
+                if ($Raw -and $pinoLine.TrimStart().StartsWith('{')) { Write-Output $pinoLine }
+                return
+            }
 
             $entryLevel     = & $getField $entry 'level'
             $entryComponent = & $getField $entry 'component'
@@ -221,6 +234,7 @@ function Get-ServerLog {
 
     process {
         Set-StrictMode -Version Latest
+        $script:GslUnparsedCount = 0
 
         if ($isFollow) {
             & az @azArgs | ForEach-Object { & $parseAndEmit $_ }
@@ -243,6 +257,10 @@ function Get-ServerLog {
             foreach ($line in @($rawLines)) {
                 & $parseAndEmit ([string]$line)
             }
+        }
+
+        if ($script:GslUnparsedCount -gt 0) {
+            Write-Warning ("{0} log line(s) were unparseable — likely pino lines sliced at Azure's ~16KB Fluent Bit boundary (t/2860). requestId correlation may be incomplete; HEAD slices are shown under -Raw." -f $script:GslUnparsedCount)
         }
     }
 }

--- a/tests/Get-ServerLog.SliceRobustness.Tests.ps1
+++ b/tests/Get-ServerLog.SliceRobustness.Tests.ps1
@@ -1,0 +1,71 @@
+# Tag: azure (t/2861)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Get-ServerLog robustness to az connection chrome + sliced (>16KB) log lines (t/2861).
+.DESCRIPTION
+    ACA/Fluent Bit slices pino lines past ~16KB (t/2860); az also prints connection
+    chrome. Asserts Get-ServerLog strips the chrome, suppresses meaningless TAIL slice
+    fragments, still surfaces HEAD slices (with requestId) under -Raw, keeps parsing
+    intact lines, and warns with a count.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-ServerLog slice/preamble robustness (t/2861)' -Tag 'azure' {
+
+    BeforeEach {
+        # az emits: connection chrome, one intact envelope (req-1), a TAIL slice
+        # ('completed"}'), and a HEAD slice (starts with '{', carries req-2 but no
+        # closing brace). Envelopes are the ACA {TimeStamp,Log} wrapper.
+        Mock -ModuleName AITriad az {
+            $global:LASTEXITCODE = 0
+            @(
+                "Connecting to the container 'taxonomy-editor'...",
+                "Successfully Connected to container: 'taxonomy-editor--rev-xyz'",
+                (@{ TimeStamp = 't'; Log = (@{ level = 30; time = 1755648000000; requestId = 'req-1'; component = 'ai'; msg = 'ok' } | ConvertTo-Json -Compress) } | ConvertTo-Json -Compress),
+                (@{ TimeStamp = 't'; Log = 'completed"}' } | ConvertTo-Json -Compress),
+                (@{ TimeStamp = 't'; Log = '{"level":30,"requestId":"req-2","big":"aaaaaaaaaaaaaaaa' } | ConvertTo-Json -Compress)
+            )
+        }
+    }
+
+    It 'strips az connection chrome from -Raw output' {
+        $out = @(Get-ServerLog -Tail 5 -Raw -WarningAction SilentlyContinue)
+        ($out -join "`n") | Should -Not -Match 'Connecting to the container'
+        ($out -join "`n") | Should -Not -Match 'Successfully Connected'
+    }
+
+    It 'suppresses TAIL slice fragments but surfaces HEAD slices under -Raw' {
+        $out = @(Get-ServerLog -Tail 5 -Raw -WarningAction SilentlyContinue)
+        ($out -join "`n") | Should -Not -Match 'completed"\}'       # tail noise dropped
+        ($out -join "`n") | Should -Match 'req-2'                    # head slice kept (has requestId)
+        ($out -join "`n") | Should -Match 'req-1'                    # intact line kept
+    }
+
+    It 'warns with a count referencing t/2860 when slices are present' {
+        $w = $null
+        Get-ServerLog -Tail 5 -Raw -WarningVariable w -WarningAction SilentlyContinue | Out-Null
+        @($w) -join ';' | Should -Match 'unparseable'
+        @($w) -join ';' | Should -Match 't/2860'
+    }
+
+    It 'still parses intact lines into structured objects (slices excluded)' {
+        $objs = @(Get-ServerLog -Tail 5 -WarningAction SilentlyContinue)
+        $objs.Count | Should -Be 1
+        $objs[0].RequestId | Should -Be 'req-1'
+        $objs[0].Level | Should -Be 'info'
+    }
+
+    It 'does not emit chrome or tail slices even when they dominate the window' {
+        $objs = @(Get-ServerLog -Tail 5 -WarningAction SilentlyContinue)
+        ($objs | ForEach-Object { $_.Message }) | Should -Not -Contain 'completed"}'
+    }
+}


### PR DESCRIPTION
## t/2861 — `Get-ServerLog` robustness to az chrome + sliced log lines

Live triage (`Get-ServerLog -Tail 10 -Raw`) showed `az`'s connection chrome plus rows of `completed"}` — tail fragments of pino JSON lines sliced at Azure's ~16 KB Fluent Bit boundary. Two defects fixed:

1. **az connection chrome leaked into output.** `Connecting to the container…` / `Successfully Connected…` (captured via `2>&1`) fell through to `-Raw`. Now stripped in all modes via a regex guard.
2. **Sliced lines produced garbage / silent drops.** A pino line cut at 16 KB fails `ConvertFrom-Json`; under `-Raw` the raw fragment was dumped, else silently dropped. Now: count them, still surface **HEAD** slices (start with `{`, carry `requestId`) under `-Raw`, suppress meaningless **TAIL** fragments, and `Write-Warning` the count so the gap is visible. Intact lines parse unchanged.

### Scope
This makes the cmdlet robust to slices it **cannot prevent**. The **root cause** — the server's 15 KB `capLogObject` (t/1475) not being honored on some log path — is filed as **t/2860** (Tech Lead) and is where the slicing actually gets fixed.

### Tests
`tests/Get-ServerLog.SliceRobustness.Tests.ps1` — 5 tests (preamble-strip, HEAD-vs-TAIL slice handling under `-Raw`, warning with count+t/2860, intact-line structured parse), all green. Mocks `az` with chrome + one intact envelope + a tail slice + a head slice.

Self-cert: scoped bug fix in one cmdlet, no new public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)