### PR TITLE
fix(layout): full-height nav rail — POV tab header into content column (t/2857)

### DIFF
--- a/taxonomy-editor/src/renderer/App.css
+++ b/taxonomy-editor/src/renderer/App.css
@@ -10,3 +10,19 @@
 .app-viewer-pre { font-size: 0.7rem; margin-top: 8px; }
 .app-files-count { font-size: 0.75rem; font-weight: 600; margin-bottom: 4px; }
 .app-files-scroll { max-height: 200px; overflow-y: auto; }
+
+/* POV/Taxonomy tab header inside the content column (t/2857) so the nav rail spans full
+   height. .pov-tab-shell fills .tab-content (row-flex child) and stacks TabBar over the body;
+   .pov-tab-shell-body replicates the old .tab-content row-flex parent so PovTab is unchanged. */
+.pov-tab-shell {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.pov-tab-shell-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}

--- a/taxonomy-editor/src/renderer/App.tsx
+++ b/taxonomy-editor/src/renderer/App.tsx
@@ -606,6 +606,30 @@ function MainApp() {
     );
   }
 
+  // POV/Taxonomy tab header (Accelerationist/Safetyist/Skeptic) renders inside the content
+  // column (t/2857) so the left nav rail spans full window height, matching Debate/Chat/Op-Eds.
+  // showPovHeader mirrors the original TabBar visibility condition exactly. Layout-only.
+  const showPovHeader = toolbarPanel === null &&
+    !['situations', 'conflicts', 'cruxes', 'debate', 'chat', 'opeds', 'summaries', 'validation', 'organizations'].includes(activeTab);
+  const tabContent = (
+    <>
+      {activeTab === 'accelerationist' && <PovTab pov="accelerationist" />}
+      {activeTab === 'safetyist' && <PovTab pov="safetyist" />}
+      {activeTab === 'skeptic' && <PovTab pov="skeptic" />}
+      <Suspense fallback={<div className="loading"><div className="loading-title">Loading...</div></div>}>
+        {activeTab === 'situations' && <SituationsTab />}
+        {activeTab === 'conflicts' && <ConflictsTab />}
+        {activeTab === 'cruxes' && <CruxesTab />}
+        {activeTab === 'debate' && <DebateTab />}
+        {activeTab === 'chat' && <ChatTab />}
+        {activeTab === 'opeds' && opedsFlag && <OpEdTab />}
+        {activeTab === 'summaries' && summariesFlag && <SummariesTab />}
+        {activeTab === 'validation' && <ValidationTab />}
+        {activeTab === 'organizations' && <OrganizationsTab />}
+      </Suspense>
+    </>
+  );
+
   return (
     <div className="app">
       {/* Background loading indicator for remaining POVs */}
@@ -712,24 +736,17 @@ function MainApp() {
         </button>
         <span className="mobile-header-title">Taxonomy Editor</span>
       </div>
-      {toolbarPanel === null && !['situations', 'conflicts', 'cruxes', 'debate', 'chat', 'opeds', 'summaries', 'validation', 'organizations'].includes(activeTab) && <TabBar />}
       <div className="app-body">
         <Toolbar />
         <div className="tab-content">
-          {activeTab === 'accelerationist' && <PovTab pov="accelerationist" />}
-          {activeTab === 'safetyist' && <PovTab pov="safetyist" />}
-          {activeTab === 'skeptic' && <PovTab pov="skeptic" />}
-          <Suspense fallback={<div className="loading"><div className="loading-title">Loading...</div></div>}>
-            {activeTab === 'situations' && <SituationsTab />}
-            {activeTab === 'conflicts' && <ConflictsTab />}
-            {activeTab === 'cruxes' && <CruxesTab />}
-            {activeTab === 'debate' && <DebateTab />}
-            {activeTab === 'chat' && <ChatTab />}
-            {activeTab === 'opeds' && opedsFlag && <OpEdTab />}
-            {activeTab === 'summaries' && summariesFlag && <SummariesTab />}
-            {activeTab === 'validation' && <ValidationTab />}
-            {activeTab === 'organizations' && <OrganizationsTab />}
-          </Suspense>
+          {showPovHeader ? (
+            <div className="pov-tab-shell">
+              <TabBar />
+              <div className="pov-tab-shell-body">{tabContent}</div>
+            </div>
+          ) : (
+            tabContent
+          )}
         </div>
         {/* One app-level ref → DetailPane host for every main tab in this shell (t/1987).
             A ref-link click in PovTab/Situations/Conflicts/Cruxes/Debate sets the global


### PR DESCRIPTION
**Draft** pending Design `/design-review-workflow` visual sign-off (layout change — draft enforces the hold so it isn't merged before visual verification).

Design bug t/2857: in the Taxonomy/POV view the left nav rail was pushed down because `TabBar` rendered as a full-width sibling above `.app-body`.

## Fix (presentation-only, per Design's spec + TL self-cert ruling t/2857#1)
- **`App.tsx`**: `TabBar` is no longer a sibling of `.app-body`. When `showPovHeader` (mirrors the original visibility condition exactly: `toolbarPanel===null && POV tab`), the POV content is wrapped in `.pov-tab-shell` (column flex) with `TabBar` stacked over `.pov-tab-shell-body`. `.pov-tab-shell-body` replicates the old `.tab-content` row-flex parent, so **PovTab is unchanged**. Non-POV tabs render flat as before (untouched).
- **`App.css`**: two co-located classes (styles.css is frozen to new selectors).

## Result
POV tab header (Accel/Safety/Skeptic) now sits inside the content column, to the right of the rail; the rail spans full window height like Debate/Chat/Op-Eds.

## Guarantees
No change to `TabBar` semantics (`role=tablist`/keyboard order), `activeTab` routing, or `GlobalDetailPaneHost`. tsc + eslint clean; TabBar/Toolbar/navConfig tests green (22).

**Design:** please run `/design-review-workflow` on this branch — I'll un-draft on your visual sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)