### PR TITLE
feat(brief): onArtifact pipeline hook + shared codeForHardFailures (t/2858, t/2840)

### DIFF
--- a/lib/brief/cli.ts
+++ b/lib/brief/cli.ts
@@ -33,6 +33,7 @@ import { resolveRepoRoot } from '../debate/taxonomyLoader.js';
 import type { AIAdapter } from '../debate/aiAdapter.js';
 import type { DebateSession } from '../debate/types.js';
 import { runBriefPipeline, type BriefPipelineResult } from './pipeline.js';
+import { codeForHardFailures } from './errorMapping.js';
 import { BRIEF_ARTIFACTS } from './types.js';
 import type {
   BriefPreset, ModelSource, ExportErrorCode, ExportJobState, TriadDeckExport,
@@ -120,17 +121,9 @@ export function parseArgs(argv: string[]): CliArgs {
 }
 
 // ── Error-code mapping (CLI owns this — wire/host-specific, per the pipeline split) ──
-
-/** Map a verify() hardFailure string to its stable code. Order matters — schema
- *  before trace (a schema failure can cascade into trace strings). Mirrors T6. */
-function codeForHardFailures(hardFailures: string[]): ExportErrorCode {
-  const joined = hardFailures.join(' | ').toLowerCase();
-  if (joined.includes('schema')) return 'SpecSchemaFailure';
-  if (joined.includes('trace')) return 'TraceGateFailure';
-  if (joined.includes('symmetry')) return 'SymmetryFailure';
-  if (joined.includes('ooxml') || joined.includes('pptx') || joined.includes('lint')) return 'PptxLintFailure';
-  return 'PptxLintFailure'; // default within the verify-gate family
-}
+// codeForHardFailures is shared (lib/brief/errorMapping) — identical across T6, CLI,
+// and Electron (t/2840). codeForThrow stays CLI-local (its 'reading' stage +
+// DebateFileInvalid are CLI-only concerns).
 
 /** Map a thrown stage fault to a code, keyed off the stage that was running. */
 function codeForThrow(err: unknown, stage: ExportJobState | 'reading'): CliErrorCode {

--- a/lib/brief/errorMapping.test.ts
+++ b/lib/brief/errorMapping.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for the shared verify-hardFailure → ExportErrorCode mapping (t/2840).
+
+import { describe, it, expect } from 'vitest';
+import { codeForHardFailures } from './errorMapping.js';
+
+describe('codeForHardFailures', () => {
+  it('maps each verify-gate family by substring', () => {
+    expect(codeForHardFailures(['deck_spec schema invalid'])).toBe('SpecSchemaFailure');
+    expect(codeForHardFailures(['trace coverage 80% < 100%'])).toBe('TraceGateFailure');
+    expect(codeForHardFailures(['symmetry: acc word_budget off by 40%'])).toBe('SymmetryFailure');
+    expect(codeForHardFailures(['OOXML lint: bad relationship'])).toBe('PptxLintFailure');
+    expect(codeForHardFailures(['pptx corrupt'])).toBe('PptxLintFailure');
+  });
+
+  it('is order-sensitive: schema wins over a cascaded trace string', () => {
+    // A schema failure can cascade into trace strings; schema must win.
+    expect(codeForHardFailures(['schema invalid', 'trace unresolvable'])).toBe('SpecSchemaFailure');
+  });
+
+  it('is case-insensitive', () => {
+    expect(codeForHardFailures(['SCHEMA broken'])).toBe('SpecSchemaFailure');
+    expect(codeForHardFailures(['SYMMETRY breach'])).toBe('SymmetryFailure');
+  });
+
+  it('defaults to PptxLintFailure within the verify-gate family for unrecognized text', () => {
+    expect(codeForHardFailures(['something unexpected'])).toBe('PptxLintFailure');
+    expect(codeForHardFailures([])).toBe('PptxLintFailure');
+  });
+});

--- a/lib/brief/errorMapping.ts
+++ b/lib/brief/errorMapping.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Shared Brief Export error-code mapping (t/2840). The verify()-hardFailure → stable
+// ExportErrorCode mapping is caller-side (the pipeline itself never maps errors — the
+// caller owns wire/host-specific error codes), but it is IDENTICAL across every caller
+// — the T6 REST job runner, the offline CLI, and the Electron handler (t/2840). Homing
+// it here makes each consumer the Nth adopter without an Nth byte-identical copy.
+
+import type { ExportErrorCode } from './types.js';
+
+/**
+ * Map a verify() hardFailure string to its stable ExportErrorCode. Order matters —
+ * schema before trace (a schema failure can cascade into trace strings). The default
+ * stays within the verify-gate family (PptxLintFailure).
+ */
+export function codeForHardFailures(hardFailures: string[]): ExportErrorCode {
+  const joined = hardFailures.join(' | ').toLowerCase();
+  if (joined.includes('schema')) return 'SpecSchemaFailure';
+  if (joined.includes('trace')) return 'TraceGateFailure';
+  if (joined.includes('symmetry')) return 'SymmetryFailure';
+  if (joined.includes('ooxml') || joined.includes('pptx') || joined.includes('lint')) return 'PptxLintFailure';
+  return 'PptxLintFailure'; // default within the verify-gate family
+}

--- a/lib/brief/pipeline.test.ts
+++ b/lib/brief/pipeline.test.ts
@@ -117,3 +117,47 @@ describe('runBriefPipeline', () => {
     }));
   });
 });
+
+describe('runBriefPipeline onArtifact', () => {
+  it('emits each artifact once, in production order, as produced', async () => {
+    const emitted: string[] = [];
+    await runBriefPipeline(baseInput(), adapter, undefined, a => emitted.push(a.name));
+    expect(emitted).toEqual([
+      'deck_spec.json', 'narration.json', 'brief.pptx', 'brief.html', 'audit-manifest.json',
+    ]);
+  });
+
+  it('byte-identity: the emitted stream equals the returned artifacts, each object exactly once', async () => {
+    const emitted: unknown[] = [];
+    const result = await runBriefPipeline(baseInput(), adapter, undefined, a => emitted.push(a));
+    // Same values, same order …
+    expect(emitted).toEqual(result.artifacts);
+    // … and the SAME object references (push-and-emit share one object) — no divergence possible.
+    expect(emitted.length).toBe(result.artifacts.length);
+    expect(emitted.every((a, i) => a === result.artifacts[i])).toBe(true);
+  });
+
+  it('still emits the manifest on a verify-gate failure (partial-persist path)', async () => {
+    (verify as Mock).mockResolvedValue({ manifest: manifestFixture(), hardFailures: ['symmetry breach'] });
+    const emitted: string[] = [];
+    await runBriefPipeline(baseInput(), adapter, undefined, a => emitted.push(a.name));
+    expect(emitted).toContain('audit-manifest.json');
+  });
+
+  it('emits produced artifacts before a later-stage throw (T6 partial-persist-on-throw)', async () => {
+    (render as Mock).mockRejectedValue(new Error('render blew up'));
+    const emitted: string[] = [];
+    await expect(
+      runBriefPipeline(baseInput(), adapter, undefined, a => emitted.push(a.name)),
+    ).rejects.toThrow('render blew up');
+    // deck_spec + narration were emitted before render threw; pptx/manifest were not.
+    expect(emitted).toEqual(['deck_spec.json', 'narration.json']);
+  });
+
+  it('is optional — omitting onArtifact still returns the full artifact set', async () => {
+    const result = await runBriefPipeline(baseInput(), adapter);
+    expect(result.artifacts.map(a => a.name)).toEqual([
+      'deck_spec.json', 'narration.json', 'brief.pptx', 'brief.html', 'audit-manifest.json',
+    ]);
+  });
+});

--- a/lib/brief/pipeline.ts
+++ b/lib/brief/pipeline.ts
@@ -80,18 +80,32 @@ export interface BriefPipelineResult {
  * @param onStage optional progress sink — emits extracting|narrating|checking|
  *   rendering|verifying as each stage begins (`checking` only when a checker ran).
  *   The caller owns queued/done/failed.
+ * @param onArtifact optional per-artifact sink — invoked ONCE for each artifact the
+ *   moment it is produced (deck_spec after extract … audit-manifest after verify),
+ *   with the SAME object that lands in the returned `artifacts`. Lets a caller
+ *   persist incrementally — so a later stage throw still leaves the earlier
+ *   artifacts captured (T6 partial-persist-on-throw, t/2858; Electron parity,
+ *   t/2840) — built once here rather than re-derived per caller. On success the
+ *   returned `artifacts` equal the union of emitted artifacts, each exactly once.
  */
 export async function runBriefPipeline(
   input: BriefPipelineInput,
   adapter: AIAdapter,
   onStage?: (stage: ExportJobState) => void,
+  onArtifact?: (artifact: BriefArtifact) => void,
 ): Promise<BriefPipelineResult> {
   const artifacts: BriefArtifact[] = [];
+  // Single sink: push and emit the SAME object, so returned `artifacts` and the
+  // onArtifact stream can never diverge (each artifact appears in both, exactly once).
+  const emit = (artifact: BriefArtifact): void => {
+    artifacts.push(artifact);
+    onArtifact?.(artifact);
+  };
 
   // ── extract ──
   onStage?.('extracting');
   const spec = extractDeckSpec(input.session, { allowOpen: input.allowOpen });
-  artifacts.push({ name: BRIEF_ARTIFACTS.deckSpec, text: JSON.stringify(spec, null, 2) });
+  emit({ name: BRIEF_ARTIFACTS.deckSpec, text: JSON.stringify(spec, null, 2) });
 
   // ── narrate (+ optional maker-checker) ──
   onStage?.('narrating');
@@ -106,7 +120,7 @@ export async function runBriefPipeline(
   }, adapter);
   // `checking` is a sub-phase inside narrate(); surface it only when a checker ran.
   if (input.checkerModelId && !input.skipNarration) onStage?.('checking');
-  artifacts.push({ name: BRIEF_ARTIFACTS.narration, text: JSON.stringify(narration, null, 2) });
+  emit({ name: BRIEF_ARTIFACTS.narration, text: JSON.stringify(narration, null, 2) });
 
   // ── render (pptx + htmlDoc; PDF is Electron-only, never here) ──
   onStage?.('rendering');
@@ -117,8 +131,8 @@ export async function runBriefPipeline(
     template: input.template,
     framingMeta: input.framingMeta,
   });
-  artifacts.push({ name: BRIEF_ARTIFACTS.pptx, bytes: pptxBytes });
-  artifacts.push({ name: BRIEF_ARTIFACTS.htmlDoc, text: htmlDoc });
+  emit({ name: BRIEF_ARTIFACTS.pptx, bytes: pptxBytes });
+  emit({ name: BRIEF_ARTIFACTS.htmlDoc, text: htmlDoc });
 
   // ── verify (build-fails-not-warns; manifest ALWAYS produced) ──
   onStage?.('verifying');
@@ -129,7 +143,7 @@ export async function runBriefPipeline(
     meta: { toolVersions: input.toolVersions, timestamp: input.timestamp },
   });
   // Manifest is the output record, NOT a hashed input artifact — added here, not in verify().
-  artifacts.push({ name: BRIEF_ARTIFACTS.manifest, text: JSON.stringify(manifest, null, 2) });
+  emit({ name: BRIEF_ARTIFACTS.manifest, text: JSON.stringify(manifest, null, 2) });
 
   return {
     spec,


### PR DESCRIPTION
## lib/brief: `onArtifact` pipeline hook + shared `codeForHardFailures` (t/2858, t/2840)

Two pre-approved, additive lib/brief changes that unblock root Main's t/2858 (T6 partial-persist) and t/2840 (Electron parity) — built once here so downstream consumers adopt without re-deriving.

### 1. `onArtifact` on `runBriefPipeline` (t/2858#4)
- New optional **4th positional** `onArtifact?: (a: BriefArtifact) => void`, invoked once per artifact the moment it's produced (deck_spec after extract … audit-manifest after verify). Kept `onStage` as the 3rd positional (TL-approved shape, t/2837#2) — additive, no caller churn.
- **Byte-identity guaranteed structurally:** a single `emit()` helper does `artifacts.push(a); onArtifact?.(a)` with the *same object*, so the returned `artifacts` and the emitted stream can never diverge. Asserted in a test (emitted `toEqual` returned **and** reference-identical element-wise).
- Enables partial-persist-on-throw: a later-stage throw still leaves earlier artifacts captured (test: render throws → `deck_spec` + `narration` already emitted).

### 2. Shared `lib/brief/errorMapping.ts` `codeForHardFailures` (t/2840 #1)
- Extracted the byte-identical verify-hardFailure → `ExportErrorCode` mapping (was duplicated in `briefExportJobs.ts` + `cli.ts`) into a shared export. `cli.ts` now imports it (local copy removed). Electron (t/2840) becomes the 3rd consumer without a 3rd copy.
- `codeForThrow` stays CLI-local (its `'reading'` stage + `DebateFileInvalid` are CLI-only).
- **Root Main adopts** `briefExportJobs.ts` → import from `lib/brief/errorMapping` during the t/2858/t2840 build (their scope; I left their file untouched to avoid colliding with their in-flight edits).

### Verification
- nodenext typecheck · renderer-tsc · vitest (pipeline + errorMapping) — results in the PR checks.
- No new runtime dependency.

Unblocks t/2858 + t/2840. cc root Main.
