### PR TITLE
feat(brief): Electron desktop parity for brief export (t/2840)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/briefExportHandlers.test.ts
+++ b/taxonomy-editor/src/main/__tests__/briefExportHandlers.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief Export — Electron main-process handler tests (t/2840). Mocks the shared runBriefPipeline
+// and drives the 5 IPC handlers against a real temp userData dir, so the persistence assertions
+// (brief.html present, manifest-always, partial-persist-on-throw) are real file round-trips.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const TMP = path.join(os.tmpdir(), `brief-export-test-${process.pid}`);
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: vi.fn(() => TMP) },
+}));
+
+const runBriefPipeline = vi.hoisted(() => vi.fn());
+vi.mock('../../../../lib/brief/pipeline.js', () => ({ runBriefPipeline }));
+vi.mock('../../../../lib/brief/errorMapping.js', () => ({ codeForHardFailures: vi.fn(() => 'TraceGateFailure') }));
+vi.mock('../electronAIAdapter.js', () => ({ makeElectronAIAdapter: vi.fn(() => ({ generateText: vi.fn() })) }));
+
+const loadDebateSession = vi.hoisted(() => vi.fn());
+vi.mock('../debateIO.js', () => ({ loadDebateSession }));
+
+vi.mock('../../../../lib/debate/errors.js', () => ({
+  ActionableError: class extends Error { constructor(o: { problem: string }) { super(o.problem); } },
+  errorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
+}));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: vi.fn(() => null) }));
+vi.mock('../../../../lib/ai-client/index.js', () => ({ DEFAULT_MODEL: 'gemini-2.5-flash' }));
+
+import { ipcMain } from 'electron';
+import { BRIEF_ARTIFACTS } from '../../../../lib/brief/types.js';
+import { registerBriefExportHandlers } from '../ipc/briefExportHandlers.js';
+
+type Handler = (...args: unknown[]) => unknown;
+function handlers(): Record<string, Handler> {
+  const map: Record<string, Handler> = {};
+  for (const [ch, fn] of (ipcMain.handle as unknown as { mock: { calls: [string, Handler][] } }).mock.calls) map[ch] = fn;
+  return map;
+}
+
+const SPEC = { meta: { title: 'Should AI be paused?', snapshot: false } };
+const MANIFEST = { trace_coverage_pct: 100, warnings: [] as string[] };
+const ALL_ARTIFACTS = [
+  { name: BRIEF_ARTIFACTS.deckSpec, text: '{"deck":true}' },
+  { name: BRIEF_ARTIFACTS.narration, text: '{"narr":true}' },
+  { name: BRIEF_ARTIFACTS.pptx, bytes: new Uint8Array([1, 2, 3, 4]) },
+  { name: BRIEF_ARTIFACTS.htmlDoc, text: '<html>brief</html>' },
+  { name: BRIEF_ARTIFACTS.manifest, text: '{"manifest":true}' },
+];
+function result(over: Record<string, unknown> = {}) {
+  return { spec: SPEC, narration: {}, pptxBytes: new Uint8Array([1, 2, 3, 4]), htmlDoc: '<html>brief</html>', manifest: MANIFEST, artifacts: ALL_ARTIFACTS, hardFailures: [] as string[], warnings: [] as string[], ...over };
+}
+
+async function createAndWait(h: Record<string, Handler>, body: Record<string, unknown> = { preset: 'policymaker' }) {
+  const { jobId } = (await h['create-brief-export'](null, 'deb-1', body)) as { jobId: string };
+  for (let i = 0; i < 100; i++) {
+    const job = (await h['get-brief-export-job'](null, jobId)) as { status: string; exportId: string | null };
+    if (job.status === 'done' || job.status === 'failed') return { jobId, job };
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error('job did not terminate');
+}
+
+describe('briefExportHandlers — Electron parity (t/2840)', () => {
+  beforeEach(() => {
+    (ipcMain.handle as unknown as { mockReset: () => void }).mockReset();
+    runBriefPipeline.mockReset();
+    loadDebateSession.mockReset().mockResolvedValue({ phase: 'closed' });
+    fs.rmSync(TMP, { recursive: true, force: true });
+    registerBriefExportHandlers();
+  });
+  afterEach(() => { fs.rmSync(TMP, { recursive: true, force: true }); });
+
+  it('create → done persists all 5 artifacts incl brief.html; list=1; download non-empty', async () => {
+    runBriefPipeline.mockImplementation(async (_i: unknown, _a: unknown, onStage: (s: string) => void, onArtifact: (x: unknown) => void) => {
+      onStage('extracting'); for (const art of ALL_ARTIFACTS) onArtifact(art); onStage('verifying');
+      return result();
+    });
+    const h = handlers();
+    const { job } = await createAndWait(h);
+    expect(job.status).toBe('done');
+    expect(job.exportId).toBeTruthy();
+    const list = (await h['list-brief-exports'](null, 'deb-1')) as { artifacts: string[]; status: string }[];
+    expect(list).toHaveLength(1);
+    // brief.html must be persisted so the desktop "Save as PDF" button is never invisible (TL plus).
+    expect(list[0].artifacts).toContain(BRIEF_ARTIFACTS.htmlDoc);
+    expect(list[0].artifacts).toContain(BRIEF_ARTIFACTS.manifest);
+    const bytes = (await h['download-brief-artifact'](null, job.exportId, BRIEF_ARTIFACTS.pptx)) as Uint8Array | null;
+    expect(bytes && bytes.length).toBeGreaterThan(0);
+  });
+
+  it('verify hardFailures → failed + manifest still persisted (diagnosable)', async () => {
+    runBriefPipeline.mockImplementation(async (_i: unknown, _a: unknown, _s: (s: string) => void, onArtifact: (x: unknown) => void) => {
+      for (const art of ALL_ARTIFACTS) onArtifact(art);
+      return result({ hardFailures: ['trace coverage 60% < 80% threshold'] });
+    });
+    const h = handlers();
+    const { job } = await createAndWait(h);
+    expect(job.status).toBe('failed');
+    expect(job.exportId).toBeNull();
+    const list = (await h['list-brief-exports'](null, 'deb-1')) as { artifacts: string[]; status: string }[];
+    expect(list[0].status).toBe('failed');
+    expect(list[0].artifacts).toContain(BRIEF_ARTIFACTS.manifest);
+  });
+
+  it('stage throw after extract → failed, deck_spec partial-persisted via onArtifact', async () => {
+    runBriefPipeline.mockImplementation(async (_i: unknown, _a: unknown, onStage: (s: string) => void, onArtifact: (x: unknown) => void) => {
+      onStage('extracting'); onArtifact({ name: BRIEF_ARTIFACTS.deckSpec, text: '{"deck":true}' });
+      onStage('narrating'); throw new Error('provider 503');
+    });
+    const h = handlers();
+    const { job } = await createAndWait(h);
+    expect(job.status).toBe('failed');
+    const list = (await h['list-brief-exports'](null, 'deb-1')) as { artifacts: string[] }[];
+    expect(list[0].artifacts).toEqual([BRIEF_ARTIFACTS.deckSpec]);
+  });
+
+  it('delete removes the export from the store', async () => {
+    runBriefPipeline.mockImplementation(async (_i: unknown, _a: unknown, _s: (s: string) => void, onArtifact: (x: unknown) => void) => {
+      for (const art of ALL_ARTIFACTS) onArtifact(art); return result();
+    });
+    const h = handlers();
+    const { job } = await createAndWait(h);
+    await h['delete-brief-export'](null, job.exportId);
+    const list = (await h['list-brief-exports'](null, 'deb-1')) as unknown[];
+    expect(list).toHaveLength(0);
+  });
+
+  it('missing debate → job fails (loud, not silent)', async () => {
+    loadDebateSession.mockResolvedValue(null);
+    const h = handlers();
+    const { job } = await createAndWait(h);
+    expect(job.status).toBe('failed');
+  });
+});

--- a/taxonomy-editor/src/main/ipc/briefExportHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/briefExportHandlers.ts
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief Export — Electron main-process parity (t/2840). Desktop backend for the 5 brief-export
+// AppAPI methods (create / get-job / list / download-artifact / delete). Runs the SHARED
+// lib/brief `runBriefPipeline` (t/2837) in-process — the 3rd caller (web REST + PS CLI + this),
+// never a reimplementation. Mirrors T6's briefExportJobs *shell* (job map + async runner) MINUS
+// the server-only concerns: desktop is single-user, so there is no anon-auth, no entitlement
+// gate, no per-user quota, no concurrency cap. Storage is the local filesystem under userData.
+//
+// Download returns raw bytes (the renderer/electron-bridge wraps them into a Blob) — the
+// downloadBriefArtifact AppAPI stays Blob-returning in BOTH builds (TL t/2840 ruling #2), so the
+// renderer's "Save as PDF" path (#1305) stays reachable on desktop. brief.html is always among the
+// persisted artifacts so the PDF button is never invisible.
+
+import { ipcMain, app } from 'electron';
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { runBriefPipeline, type BriefArtifact } from '../../../../lib/brief/pipeline.js';
+import { codeForHardFailures } from '../../../../lib/brief/errorMapping.js';
+import {
+  BRIEF_ARTIFACTS,
+  type BriefArtifactName,
+  type BriefPreset,
+  type ExportJobState,
+  type ExportErrorCode,
+  type ModelSource,
+} from '../../../../lib/brief/types.js';
+import { DEFAULT_MODEL } from '../../../../lib/ai-client/index.js';
+import type { DebateSession } from '../../../../lib/debate/types.js';
+import { ActionableError, errorMessage } from '../../../../lib/debate/errors.js';
+import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+import { makeElectronAIAdapter } from '../electronAIAdapter.js';
+import { loadDebateSession } from '../debateIO.js';
+
+// Mirrors the server's constant — recorded in the audit manifest.
+const TOOL_VERSIONS: Record<string, string> = { node: process.version, brief: '1.0' };
+const JOB_TTL_MS = 10 * 60_000;
+
+interface BriefExportRequestBody {
+  preset: BriefPreset;
+  model?: string;
+  /** Provenance hint from the renderer (matches the web AppAPI request). */
+  modelSource?: 'global' | 'explicit';
+  checkerModel?: string;
+  framingMeta?: boolean;
+  options?: { skipNarration?: boolean };
+}
+
+interface BriefRecord {
+  exportId: string;
+  debateId: string;
+  title: string;
+  preset: BriefPreset;
+  status: 'done' | 'failed';
+  errorCode?: ExportErrorCode;
+  formats: string[];
+  artifacts: BriefArtifactName[];
+  traceCoveragePct: number;
+  warnings: string[];
+  createdAt: string;
+}
+
+// ── Job registry (in-process, single-user) ──
+
+interface BriefJob {
+  jobId: string;
+  debateId: string;
+  status: ExportJobState;
+  progressPct: number;
+  warnings: string[];
+  error: string | null;
+  errorCode: ExportErrorCode | null;
+  exportId: string | null;
+  startedAt: number;
+}
+
+const jobs = new Map<string, BriefJob>();
+
+const PROGRESS: Record<ExportJobState, number> = {
+  queued: 0, extracting: 10, narrating: 30, checking: 50,
+  rendering: 70, verifying: 90, done: 100, failed: 100,
+};
+
+function setState(job: BriefJob, status: ExportJobState): void {
+  job.status = status;
+  job.progressPct = PROGRESS[status];
+}
+
+function sweepJobs(): void {
+  const now = Date.now();
+  for (const [id, j] of jobs) {
+    if ((j.status === 'done' || j.status === 'failed') && now - j.startedAt > JOB_TTL_MS) jobs.delete(id);
+  }
+}
+
+// codeForThrow stays caller-local by design (Shared Lib p/18#25): it maps a *stage throw* to a
+// stable code — a shell concern, not a pipeline output. Mirrors the T6 server copy.
+function codeForThrow(err: unknown, stage: ExportJobState): ExportErrorCode {
+  const msg = errorMessage(err).toLowerCase();
+  if (msg.includes('closed')) return 'DebateNotClosed';
+  if (stage === 'narrating' || stage === 'checking') return 'ModelUnavailable';
+  return 'RenderFailure';
+}
+
+// ── Filesystem store (single-user; userData/brief-exports) ──
+
+function exportsDir(): string { return path.join(app.getPath('userData'), 'brief-exports'); }
+function exportDir(exportId: string): string { return path.join(exportsDir(), `export-${exportId}`); }
+const INDEX_FILE = '_index.json';
+
+function readIndex(): BriefRecord[] {
+  try { return JSON.parse(fs.readFileSync(path.join(exportsDir(), INDEX_FILE), 'utf-8')) as BriefRecord[]; }
+  catch { /* no index yet / unreadable → empty list — silent by design (ADR-003) */ return []; }
+}
+function writeIndex(recs: BriefRecord[]): void {
+  fs.mkdirSync(exportsDir(), { recursive: true });
+  fs.writeFileSync(path.join(exportsDir(), INDEX_FILE), JSON.stringify(recs, null, 2), 'utf-8');
+}
+function upsertIndex(rec: BriefRecord): void {
+  const recs = readIndex();
+  const i = recs.findIndex(r => r.exportId === rec.exportId);
+  if (i >= 0) recs[i] = rec; else recs.push(rec);
+  writeIndex(recs);
+}
+
+/** Persist an export: write each artifact under export-<id>/, then upsert the index. Called for
+ *  BOTH done and failed jobs — a failed export still stores its manifest + record (diagnosable). */
+function saveExport(rec: BriefRecord, artifacts: BriefArtifact[]): void {
+  const dir = exportDir(rec.exportId);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const a of artifacts) {
+    const p = path.join(dir, a.name);
+    if (a.bytes !== undefined) fs.writeFileSync(p, Buffer.from(a.bytes));
+    else fs.writeFileSync(p, a.text ?? '', 'utf-8');
+  }
+  fs.writeFileSync(path.join(dir, 'record.json'), JSON.stringify(rec, null, 2), 'utf-8');
+  upsertIndex(rec);
+}
+
+function listExports(debateId?: string): BriefRecord[] {
+  const recs = readIndex();
+  return debateId ? recs.filter(r => r.debateId === debateId) : recs;
+}
+
+function loadArtifact(exportId: string, name: BriefArtifactName): Uint8Array | null {
+  const p = path.join(exportDir(exportId), name);
+  try { return fs.readFileSync(p); } catch { /* artifact absent → null (route surfaces not-found) — silent by design (ADR-003) */ return null; }
+}
+
+function deleteExport(exportId: string): void {
+  fs.rmSync(exportDir(exportId), { recursive: true, force: true });
+  const recs = readIndex().filter(r => r.exportId !== exportId);
+  writeIndex(recs);
+}
+
+// ── Runner ──
+
+function startJob(debateId: string, body: BriefExportRequestBody): BriefJob {
+  sweepJobs();
+  const job: BriefJob = {
+    jobId: randomUUID(),
+    debateId,
+    status: 'queued',
+    progressPct: 0,
+    warnings: [],
+    error: null,
+    errorCode: null,
+    exportId: null,
+    startedAt: Date.now(),
+  };
+  jobs.set(job.jobId, job);
+  void runJob(job, body);
+  return job;
+}
+
+async function runJob(job: BriefJob, body: BriefExportRequestBody): Promise<void> {
+  const exportId = randomUUID();
+  const artifacts: BriefArtifact[] = [];
+  let title = job.debateId;
+  let traceCoveragePct = 0;
+  let stage: ExportJobState = 'extracting';
+  try {
+    const session = (await loadDebateSession(job.debateId)) as DebateSession | null;
+    if (!session) {
+      throw new ActionableError({
+        goal: 'Export a debate brief (desktop)',
+        problem: `Debate "${job.debateId}" was not found`,
+        location: 'briefExportHandlers runJob',
+        nextSteps: ['Open the debate in the app and try again'],
+      });
+    }
+
+    // Desktop has no entitlement gate — use the requested model directly (or the app default).
+    const result = await runBriefPipeline(
+      {
+        session,
+        preset: body.preset,
+        skipNarration: body.options?.skipNarration === true,
+        modelId: body.model || DEFAULT_MODEL,
+        // Map the request hint → resolved provenance (mirrors the web route's resolveExportModel):
+        // no model asked → Default; explicit ask → Global (use-current) or Explicit.
+        modelSource: (!body.model ? 'Default' : body.modelSource === 'global' ? 'Global' : 'Explicit') as ModelSource,
+        checkerModelId: body.checkerModel || undefined,
+        checkerModelSource: body.checkerModel ? ('Explicit' as ModelSource) : undefined,
+        framingMeta: body.framingMeta === false ? false : undefined,
+        // No allowOpen on desktop v1 — parity is closed-debate export (the GUI gates to closed).
+        toolVersions: TOOL_VERSIONS,
+        timestamp: new Date().toISOString(),
+      },
+      makeElectronAIAdapter(),
+      (s) => { setState(job, s); stage = s; },
+      (a: BriefArtifact) => { artifacts.push(a); },
+    );
+
+    title = result.spec.meta.title;
+    job.warnings.push(...result.warnings);
+    traceCoveragePct = result.manifest.trace_coverage_pct;
+
+    const hardFailures = result.hardFailures;
+    const status: 'done' | 'failed' = hardFailures.length > 0 ? 'failed' : 'done';
+    const errorCode = hardFailures.length > 0 ? codeForHardFailures(hardFailures) : undefined;
+
+    persistRecord(exportId, job, status, title, body.preset, traceCoveragePct, errorCode, artifacts);
+
+    if (status === 'failed') {
+      job.error = `Export verify gate failed: ${hardFailures.join('; ')}`;
+      job.errorCode = errorCode ?? null;
+      setState(job, 'failed');
+    } else {
+      job.exportId = exportId;
+      setState(job, 'done');
+    }
+  } catch (err) {
+    // A stage threw — persist whatever artifacts were captured (onArtifact) so the failure is
+    // diagnosable, then mark failed with the mapped code.
+    const errorCode = codeForThrow(err, stage);
+    job.error = errorMessage(err);
+    job.errorCode = errorCode;
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'brief-export-desktop', level: 'error',
+      message: `Desktop brief export failed at ${stage}`,
+      error: { name: (err as Error).name ?? 'Error', message: job.error, stack: (err as Error).stack },
+    });
+    try {
+      persistRecord(exportId, job, 'failed', title, body.preset, traceCoveragePct, errorCode, artifacts);
+    } catch (perr) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'brief-export-desktop', level: 'error',
+        message: 'Desktop brief export failure-record persist also failed',
+        error: { name: (perr as Error).name ?? 'Error', message: errorMessage(perr) },
+      });
+    }
+    setState(job, 'failed');
+  }
+}
+
+function persistRecord(
+  exportId: string, job: BriefJob, status: 'done' | 'failed', title: string, preset: BriefPreset,
+  traceCoveragePct: number, errorCode: ExportErrorCode | undefined, artifacts: BriefArtifact[],
+): void {
+  const names = artifacts.map(a => a.name);
+  const rec: BriefRecord = {
+    exportId, debateId: job.debateId, title, preset, status, errorCode,
+    formats: [
+      ...(names.includes(BRIEF_ARTIFACTS.pptx) ? ['pptx'] : []),
+      ...(names.includes(BRIEF_ARTIFACTS.htmlDoc) ? ['html'] : []),
+    ],
+    artifacts: names,
+    traceCoveragePct,
+    warnings: job.warnings,
+    createdAt: new Date().toISOString(),
+  };
+  saveExport(rec, artifacts);
+}
+
+// ── IPC registration ──
+
+export function registerBriefExportHandlers(): void {
+  ipcMain.handle('create-brief-export', (_event, debateId: string, body: BriefExportRequestBody) => {
+    if (!body?.preset) {
+      throw new ActionableError({
+        goal: 'Start a brief export (desktop)',
+        problem: 'A preset is required',
+        location: 'briefExportHandlers create-brief-export',
+        nextSteps: ['Pick a preset (policymaker / conference / classroom) and retry'],
+      });
+    }
+    const job = startJob(debateId, body);
+    return { jobId: job.jobId };
+  });
+
+  ipcMain.handle('get-brief-export-job', (_event, jobId: string) => {
+    const job = jobs.get(jobId);
+    if (!job) {
+      throw new ActionableError({
+        goal: 'Check a brief export job (desktop)',
+        problem: `Export job "${jobId}" not found (it may have expired)`,
+        location: 'briefExportHandlers get-brief-export-job',
+        nextSteps: ['Re-check the debate exports list', 'Start the export again'],
+      });
+    }
+    return {
+      status: job.status,
+      progressPct: job.progressPct,
+      warnings: job.warnings,
+      error: job.error,
+      errorCode: job.errorCode,
+      exportId: job.exportId,
+    };
+  });
+
+  ipcMain.handle('list-brief-exports', (_event, debateId: string) => listExports(debateId));
+
+  ipcMain.handle('download-brief-artifact', (_event, exportId: string, name: BriefArtifactName) => {
+    // Returns raw bytes; the renderer/electron-bridge wraps them into a Blob (Blob-returning AppAPI
+    // in both builds — TL ruling #2). null → the bridge surfaces a not-found error.
+    return loadArtifact(exportId, name);
+  });
+
+  ipcMain.handle('delete-brief-export', (_event, exportId: string) => {
+    deleteExport(exportId);
+  });
+}

--- a/taxonomy-editor/src/main/ipcHandlers.ts
+++ b/taxonomy-editor/src/main/ipcHandlers.ts
@@ -26,6 +26,7 @@ import { registerCommunityHandlers } from './ipc/communityHandlers.js';
 import { registerSystemHandlers } from './ipc/systemHandlers.js';
 import { registerPrefsHandlers } from './ipc/prefsHandlers.js';
 import { registerOpEdHandlers } from './ipc/opedHandlers.js';
+import { registerBriefExportHandlers } from './ipc/briefExportHandlers.js';
 
 export function registerIpcHandlers(): void {
   registerPrefsHandlers();
@@ -43,4 +44,5 @@ export function registerIpcHandlers(): void {
   registerCommunityHandlers();
   registerSystemHandlers();
   registerOpEdHandlers();
+  registerBriefExportHandlers();
 }

--- a/taxonomy-editor/src/main/preload.cts
+++ b/taxonomy-editor/src/main/preload.cts
@@ -644,6 +644,19 @@ try {
     ipcRenderer.invoke('delete-oped-set', setId),
   saveOpEdSet: (set: OpEdSet): Promise<void> =>
     ipcRenderer.invoke('save-oped-set', set),
+
+  // Brief Export — desktop parity (t/2840). Mirrors the web AppAPI; download returns raw bytes
+  // that the electron-bridge wraps into a Blob (Blob-returning AppAPI in both builds).
+  createBriefExport: (debateId: string, body: unknown): Promise<{ jobId: string }> =>
+    ipcRenderer.invoke('create-brief-export', debateId, body),
+  getBriefExportJob: (jobId: string): Promise<unknown> =>
+    ipcRenderer.invoke('get-brief-export-job', jobId),
+  listBriefExports: (debateId: string): Promise<unknown[]> =>
+    ipcRenderer.invoke('list-brief-exports', debateId),
+  downloadBriefArtifact: (exportId: string, name: string): Promise<Uint8Array | null> =>
+    ipcRenderer.invoke('download-brief-artifact', exportId, name),
+  deleteBriefExport: (exportId: string): Promise<void> =>
+    ipcRenderer.invoke('delete-brief-export', exportId),
   });
   console.log('[preload] electronAPI exposed');
   ipcRenderer.send('forward-flight-event', {

--- a/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/electron-bridge.ts
@@ -76,21 +76,8 @@ function rejectOpEdIpc(goal: string, method: string): Promise<never> {
   }));
 }
 
-// Brief Export (t/2805, T7) is web-only for v1. Desktop parity is tracked as a follow-up:
-// the Electron IPC handler will call the shared `runBriefPipeline` in-process (blocked by
-// t/2837), NOT a reimplementation. Until then, reject LOUDLY (never a silent empty) so a
-// desktop user is told exactly where to go — the UI also gates the menu item (see DebateTab).
-function rejectBriefWebOnly(goal: string, method: string): Promise<never> {
-  return Promise.reject(new ActionableError({
-    goal: `Brief Export: ${goal}`,
-    problem: `Brief export runs in the AITriad web app; the desktop backend (${method}) is not available in this build yet.`,
-    location: 'electron-bridge · Brief Export',
-    nextSteps: [
-      'Open this debate in the AITriad web app to export a brief.',
-      'Desktop parity is tracked (blocked by the shared runBriefPipeline, t/2837).',
-    ],
-  }));
-}
+// Brief Export desktop parity landed in t/2840 — the 5 methods now delegate to the main-process
+// IPC handlers (which run the shared runBriefPipeline in-process). See the AppAPI block below.
 
 // Same-window diagnostics callbacks for the in-app drawer (mobile/narrow).
 // When a popout BrowserWindow is open, IPC delivers state to it directly.
@@ -306,12 +293,24 @@ export const api: AppAPI = {
   loadDebateComments: (id) => window.electronAPI.loadDebateComments(id),
   saveDebateComments: (id, data) => window.electronAPI.saveDebateComments(id, data),
 
-  // Brief Export (t/2805, T7) — web-only v1; desktop parity tracked (blocked by t/2837 runBriefPipeline).
-  createBriefExport: () => rejectBriefWebOnly('start a brief export', 'createBriefExport'),
-  getBriefExportJob: () => rejectBriefWebOnly('check a brief export job', 'getBriefExportJob'),
-  listBriefExports: () => rejectBriefWebOnly('list brief exports', 'listBriefExports'),
-  downloadBriefArtifact: () => rejectBriefWebOnly('download a brief export artifact', 'downloadBriefArtifact'),
-  deleteBriefExport: () => rejectBriefWebOnly('delete a brief export', 'deleteBriefExport'),
+  // Brief Export — desktop parity via main-process IPC (t/2840). Calls the shared runBriefPipeline
+  // in-process; download returns raw bytes wrapped into a Blob (Blob-returning AppAPI in both builds).
+  createBriefExport: (debateId, body) => window.electronAPI.createBriefExport(debateId, body),
+  getBriefExportJob: (jobId) => window.electronAPI.getBriefExportJob(jobId),
+  listBriefExports: (debateId) => window.electronAPI.listBriefExports(debateId),
+  downloadBriefArtifact: async (exportId, name) => {
+    const bytes = await window.electronAPI.downloadBriefArtifact(exportId, name);
+    if (bytes == null) {
+      throw new ActionableError({
+        goal: 'Download a brief export artifact',
+        problem: `Artifact "${name}" was not found for export "${exportId}"`,
+        location: 'electron-bridge · downloadBriefArtifact',
+        nextSteps: ['Re-check the export still exists in the debate exports list', 'Regenerate the export'],
+      });
+    }
+    return new Blob([bytes as BlobPart]);   // Uint8Array is a valid BlobPart at runtime (strict-generic cast)
+  },
+  deleteBriefExport: (exportId) => window.electronAPI.deleteBriefExport(exportId),
   // printBriefToPdf is available independently of the full brief export pipeline (t/2852).
   printBriefToPdf: (html) => window.electronAPI.printBriefToPdf(html),
 

--- a/taxonomy-editor/src/renderer/types/electron.d.ts
+++ b/taxonomy-editor/src/renderer/types/electron.d.ts
@@ -5,9 +5,16 @@ import type { Organization, OrganizationEdge } from '@lib/organizations/types';
 import type { EntityDetail, EntitySummary, EntityListQuery } from '@lib/entities/types';
 import type { ContainerMentions } from '@lib/entities/mentionTypes';
 import type { EdgesFile } from '@lib/debate/taxonomyTypes';
-import type { UserPreferences } from '../bridge/types';
+import type { UserPreferences, BriefExportRequest, BriefExportJobView, BriefExportRecord } from '../bridge/types';
+import type { BriefArtifactName } from '@lib/brief/types';
 
 export interface ElectronAPI {
+  // Brief Export — desktop parity (t/2840). download returns raw bytes (the bridge wraps a Blob).
+  createBriefExport: (debateId: string, body: BriefExportRequest) => Promise<{ jobId: string }>;
+  getBriefExportJob: (jobId: string) => Promise<BriefExportJobView>;
+  listBriefExports: (debateId: string) => Promise<BriefExportRecord[]>;
+  downloadBriefArtifact: (exportId: string, name: BriefArtifactName) => Promise<Uint8Array | null>;
+  deleteBriefExport: (exportId: string) => Promise<void>;
   processVersions: Record<string, string | undefined>;
   osRelease: string;
   /** t/2766: performance.now() stamp from when contextBridge.exposeInMainWorld ran. */


### PR DESCRIPTION
Desktop backend for the 5 brief-export AppAPI methods — the **3rd caller** of the shared `runBriefPipeline` (t/2837), never a reimplementation. Built on TL's 3 rulings (t/2840#2), consuming #1308.

## Files
- **NEW `main/ipc/briefExportHandlers.ts`** — in-process job map + async runner calling `runBriefPipeline(input, makeElectronAIAdapter(), onStage, onArtifact)` + a filesystem store under `userData/brief-exports`. Mirrors T6's shell **minus** server-only concerns (desktop single-user: no anon-auth / entitlement / per-user-quota / concurrency). Shared `codeForHardFailures`; `codeForThrow` caller-local (by design). `onArtifact` wires **partial-persist-on-throw**; manifest always persisted; **brief.html always among artifacts** so the desktop PDF button is never invisible (TL's plus).
- **`preload.cts` + `electron.d.ts`** — expose/type the 5.
- **`electron-bridge.ts`** — the 5 methods now **delegate** to `window.electronAPI` (were `rejectBriefWebOnly`); `downloadBriefArtifact` wraps returned bytes in a Blob — the AppAPI stays **Blob-returning in both builds** (ruling #2), so #1305's savePdf stays reachable. Removed the unused reject helper.
- Model: `body.model || DEFAULT_MODEL`, **no entitlement gate** (desktop, ruling #3); modelSource mapped request-hint → resolved provenance (mirrors web `resolveExportModel`).

## Tests
`briefExportHandlers.test.ts` (5, against a real temp userData dir): create→done persists all 5 incl **brief.html + manifest**, list=1, download non-empty; verify-fail→failed+manifest; **stage-throw→deck_spec partial-persist**; delete; missing-debate fails loud. renderer+main tsc clean, eslint 0 errors.

## Deviation flagged
No runtime electron-bridge delegation test — no bridge-test harness exists to extend, and the 5 delegations are trivial passthroughs on the `AppAPI`-typed bridge object, so **tsc verifies the signatures structurally**. Handler behavior is covered by the 5 tests. (Also: `runJob` carries a complexity=19 lint *warning* — non-blocking, quality-gates is errors-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)