### PR TITLE
feat(prompts): CL disposition — catalog vernacular/aphorism, INTERNAL generateDebateTitle (t/2859)

### DIFF
--- a/taxonomy-editor/src/renderer/data/promptCatalog.excluded.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.excluded.ts
@@ -42,10 +42,8 @@ export const PROMPT_CATALOG_EXCLUDED: PromptExclusion[] = [
   { name: 'consensusSituationPrompt', reason: 'Niche convergence→enrichment sub-prompt (CL t/2835#1).' },
   { name: 'crossCuttingNodePrompt', reason: 'Niche convergence→enrichment sub-prompt (CL t/2835#1).' },
 
-  // ── PROVISIONAL (t/2859): renderer-prompt builders outside CL's t/2835 debate-builder scope.
-  //    Excluded to keep the gate green now; CL disposition tracked by t/2859 (TL ruling C, t/2834#5) —
-  //    time-bound, not silent-forever. Re-evaluate when t/2859 rules expose-vs-internal.
-  { name: 'vernacularPrompt', reason: 'Provisional: pending CL disposition, outside t/2835 scope — t/2859.' },
-  { name: 'aphorismPrompt', reason: 'Provisional: pending CL disposition, outside t/2835 scope — t/2859.' },
-  { name: 'generateDebateTitlePrompt', reason: 'Provisional: pending CL disposition, outside t/2835 scope — t/2859.' },
+  // ── CL INTERNAL (t/2859): trivial UI utility, not a user-inspected content prompt.
+  //    vernacularPrompt + aphorismPrompt ruled EXPOSE (now catalogued); this is the one
+  //    permanent INTERNAL exclusion replacing the provisional t/2859 block.
+  { name: 'generateDebateTitlePrompt', reason: 'Trivial UI utility — distils a debate topic into a <60-char title; no tunable substance, no data sources, no version. Utility micro-prompt class (CL ruling t/2859).' },
 ];

--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -14,6 +14,8 @@
 
 import { DEFAULT_MODEL } from '@lib/ai-client/defaults';
 import { researchPrompt, conflictResearchPrompt } from '../prompts/research';
+import { vernacularPrompt } from '../prompts/vernacular';
+import { aphorismPrompt } from '../prompts/aphorism';
 import {
   distinctionAnalysisPrompt,
   clusterLabelPrompt,
@@ -147,6 +149,26 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     group: 'taxonomy',
     purpose: 'Fires when the user requests a critique of a specific taxonomy node. Produces a structured analysis of systemic integration quality with proposed refinements in genus-differentia format.',
     applicableDataSources: ['taxonomyNodes', 'situationNodes', 'policyRegistry'],
+  },
+  {
+    id: 'vernacular-description',
+    title: 'Vernacular Description',
+    description: 'Rewrites an academic ontological node description into plain ~10th-grade language for display.',
+    source: 'prompts/vernacular.ts',
+    template: vernacularPrompt('{description}'),
+    group: 'taxonomy',
+    purpose: 'Fires when a user regenerates the plain-language ("vernacular") description of a taxonomy node (regeneratePlainDescription). Rewrites the genus-differentia academic description at ~10th-grade reading level, preserving the core claim and nuances while dropping ontological boundary markers.',
+    applicableDataSources: ['taxonomyNodes'],
+  },
+  {
+    id: 'aphorism',
+    title: 'Aphorism',
+    description: 'Generates one short camp-voiced aphorism (3-8 words) faithful to a node’s BDI register and differentia.',
+    source: 'prompts/aphorism.ts',
+    template: aphorismPrompt('{pov}', '{category}', '{label}', '{description}'),
+    group: 'taxonomy',
+    purpose: 'Fires when a user regenerates a node’s aphorism (regenerateAphorism). Produces a single sober maxim stated in the camp’s own voice, matched to the BDI register (Belief asserts how the world is / Desire what ought to be / Intention how to act), faithful to the node’s differentia.',
+    applicableDataSources: ['taxonomyNodes'],
   },
 
   // === Debate setup ===


### PR DESCRIPTION
Applies the Computational Linguist's disposition (t/2859#1) for the 3 renderer prompt builders the t/2834 prompt-catalog gate surfaced outside t/2835's debate-builder scope.

| builder | ruling | change |
|---|---|---|
| `vernacularPrompt` | **EXPOSE** | Catalogued as **Vernacular Description** (taxonomy group), real `template:` call |
| `aphorismPrompt` | **EXPOSE** | Catalogued as **Aphorism** (taxonomy group), real `template:` call |
| `generateDebateTitlePrompt` | **INTERNAL** | Permanent allowlist entry (trivial UI title utility) |

Drops the provisional `── PROVISIONAL (t/2859)` exclusion block; the two EXPOSE builders become imported-and-used template calls (forward-builder arm), the one INTERNAL entry replaces the block.

**Verification (worktree):**
- `promptCatalog.lint.test.ts` — 8/8 pass
- renderer `tsc -p tsconfig.json --noEmit` — clean (exit 0)

Closes t/2859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)