### PR TITLE
feat(quotas): confirm brief-export cap at 15, matching op-eds (t/2831)

### DIFF
--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -170,7 +170,7 @@ const DEFAULTS: RuntimeConfig = {
     defaultMaxChats: 25,
     defaultMaxDebates: 15,
     defaultMaxOpEds: 15,
-    defaultMaxBriefExports: 25, // t/2831: TL/product to confirm limit; 25 matches maxChats as a conservative starting point
+    defaultMaxBriefExports: 15, // t/2831: product-confirmed limit — matches maxOpEds (15) for a uniform per-artifact billable cap
   },
   sessions: {
     anonymousTtlMs: 14_400_000,


### PR DESCRIPTION
Closes the final open item on t/2831: product-confirmed the per-user **brief-export count-quota** (a billable-spend cap — each export runs a narrate call + optional checker call) at **15**, matching the op-ed quota (`defaultMaxOpEds`) for a uniform per-artifact cap. Replaces the provisional **25** shipped in PR #1268.

Single-line change to `runtimeConfig.ts` quota defaults; the per-user `elevated` override path and admin-Infinity path are unchanged.

**Verification (worktree):**
- `quotas.test.ts` + `briefExports.test.ts` — 36/36 pass
- `tsc -p tsconfig.server.json --noEmit` — clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)