### PR TITLE
docs(quotas): mark brief-export cap 25/user as product-confirmed (t/2831)

### DIFF
--- a/taxonomy-editor/src/server/runtimeConfig.ts
+++ b/taxonomy-editor/src/server/runtimeConfig.ts
@@ -170,7 +170,7 @@ const DEFAULTS: RuntimeConfig = {
     defaultMaxChats: 25,
     defaultMaxDebates: 15,
     defaultMaxOpEds: 15,
-    defaultMaxBriefExports: 25, // t/2831: TL/product to confirm limit; 25 matches maxChats as a conservative starting point
+    defaultMaxBriefExports: 25, // t/2831: product-confirmed (25/user) — billable-spend cap for any signed-in identity incl. headless AAD principals (entitlement: t/2862); matches maxChats
   },
   sessions: {
     anonymousTtlMs: 14_400_000,


### PR DESCRIPTION
Final item on t/2831: the per-user **brief-export count-quota** is **product-confirmed at 25/user** (Jeff, via t/2862 entitlement decision — applies to any signed-in identity, including headless AAD-bearer principals). Matches `maxChats`.

**Comment-only marker flip** — the value is unchanged (was already 25 from PR #1268's provisional). Flips `// t/2831: TL/product to confirm limit` → product-confirmed. No behavioral change; the other 3 ACs (resource, 429 gate, quota-status endpoint) landed in #1268.

Supersedes the closed #1312 (which incorrectly proposed 15).

Closes t/2831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)