### PR TITLE
chore: rename app title to AI Rosetta Stone

### DIFF
--- a/taxonomy-editor/src/main/main.ts
+++ b/taxonomy-editor/src/main/main.ts
@@ -138,7 +138,7 @@ function createWindow(): void {
     height: 800,
     minWidth: 900,
     minHeight: 600,
-    title: 'Taxonomy Editor',
+    title: 'AI Rosetta Stone',
     webPreferences: {
       preload: preloadPath,
       contextIsolation: true,

--- a/taxonomy-editor/src/renderer/index.html
+++ b/taxonomy-editor/src/renderer/index.html
@@ -7,7 +7,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    <title>Taxonomy Editor</title>
+    <title>Rosetta Stone</title>
   </head>
   <body>
     <div id="root"></div>

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -138,8 +138,8 @@ export default defineConfig({
         ],
       },
       manifest: {
-        name: 'Taxonomy Editor',
-        short_name: 'Taxonomy',
+        name: 'AI Rosetta Stone',
+        short_name: 'Rosetta Stone',
         description: 'Multi-perspective research platform for AI policy taxonomy',
         start_url: '/',
         display: 'standalone',


### PR DESCRIPTION
Renames the visible app titles across all three surfaces:

- **BrowserWindow title** (\main.ts\): Taxonomy Editor → AI Rosetta Stone
- **Browser \<title>\** (\src/renderer/index.html\): Taxonomy Editor → Rosetta Stone  
- **PWA manifest** (\ite.config.ts\): name → AI Rosetta Stone, short_name → Rosetta Stone