### PR TITLE
chore: wrap Op-Ed Studies sidebar label onto two lines

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -340,7 +340,7 @@ export function Toolbar() {
             aria-label="Op-Ed Studies"
           >
             <Newspaper size="1.25em" />
-            <span className="toolbar-nav-label">Op-Ed Studies</span>
+            <span className="toolbar-nav-label">Op-Ed<br />Studies</span>
           </button>
         )}
       </div>


### PR DESCRIPTION
Splits the toolbar nav label `<span>` so "Op-Ed" and "Studies" render on separate lines — consistent with the visual weight of the other nav items. The `aria-label` attribute is unchanged ("Op-Ed Studies").