### PR TITLE
fix(logger): guarantee emitted server-log line ≤ cap via destination guard (t/2860)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/loggerEmit.test.ts
+++ b/taxonomy-editor/src/server/__tests__/loggerEmit.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2860: regression test for the ACTUAL emitted server-log line (not capLogObject
+// in isolation — that was the t/1475 test gap that let prod keep slicing). Wires a
+// logger to an in-process capture sink (the production non-pretty emit path) and
+// asserts every emitted line stays <= LOG_MAX_LINE_BYTES for the escapes TL
+// enumerated: a large object field, a large `msg` string (H2), and a pathological
+// large URL path on a `Request completed`-shaped call.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+let buildLogger: (sink?: (chunk: string) => void) => { child: (b: Record<string, unknown>) => { info: (obj: Record<string, unknown>, msg: string) => void } };
+let LOG_MAX_LINE_BYTES: number;
+let prevNodeEnv: string | undefined;
+
+beforeAll(async () => {
+  // Force the non-pretty (ACA/stdout) emit path — usePretty is evaluated at module
+  // load, so NODE_ENV must be set before the dynamic import below.
+  prevNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'production';
+  const mod = await import('../logger.js');
+  buildLogger = mod.buildLogger as typeof buildLogger;
+  LOG_MAX_LINE_BYTES = mod.LOG_MAX_LINE_BYTES;
+});
+
+afterAll(() => {
+  // Restore NODE_ENV so we don't leak 'production' into sibling test files sharing this worker.
+  if (prevNodeEnv === undefined) delete process.env.NODE_ENV; else process.env.NODE_ENV = prevNodeEnv;
+});
+
+/** A logger whose emitted lines are captured (split on newline) instead of going to stdout. */
+function capture() {
+  const lines: string[] = [];
+  const logger = buildLogger((chunk) => {
+    for (const l of chunk.split('\n')) if (l.trim().length > 0) lines.push(l);
+  });
+  return { logger, lines };
+}
+
+const BIG = 200_000; // comfortably past the 16 KB ACA line limit
+
+describe('emitted server-log line stays under the cap (t/2860)', () => {
+  it('a large object field never emits a line over the cap', () => {
+    const { logger, lines } = capture();
+    logger.child({ component: 'server' }).info({ requestId: 'req-obj', blob: 'x'.repeat(BIG) }, 'huge object field');
+    expect(lines.length).toBeGreaterThan(0);
+    for (const l of lines) expect(Buffer.byteLength(l)).toBeLessThanOrEqual(LOG_MAX_LINE_BYTES);
+  });
+
+  it('a large msg string never emits a line over the cap (H2 — msg bypasses capLogObject)', () => {
+    const { logger, lines } = capture();
+    logger.child({ component: 'server' }).info({ requestId: 'req-msg' }, 'y'.repeat(BIG));
+    expect(lines.length).toBeGreaterThan(0);
+    for (const l of lines) expect(Buffer.byteLength(l)).toBeLessThanOrEqual(LOG_MAX_LINE_BYTES);
+  });
+
+  it('a pathological large URL path on a Request-completed line stays under the cap', () => {
+    const { logger, lines } = capture();
+    logger.child({ component: 'server' }).info(
+      { requestId: 'req-url', method: 'GET', path: '/' + 'p'.repeat(BIG), status: 200, duration_ms: 3 },
+      'Request completed',
+    );
+    expect(lines.length).toBeGreaterThan(0);
+    for (const l of lines) expect(Buffer.byteLength(l)).toBeLessThanOrEqual(LOG_MAX_LINE_BYTES);
+  });
+
+  it('a reduced (over-cap) line still carries requestId for correlation', () => {
+    const { logger, lines } = capture();
+    logger.child({ component: 'server' }).info({ requestId: 'req-keepme' }, 'z'.repeat(BIG));
+    expect(lines.some(l => l.includes('req-keepme'))).toBe(true);
+  });
+});

--- a/taxonomy-editor/src/server/logger.ts
+++ b/taxonomy-editor/src/server/logger.ts
@@ -171,7 +171,7 @@ export function capEmittedLine(line: string): string {
  *  line through capEmittedLine before the sink. Fail-safe: never throws, never drops. */
 function makeGuardedDestination(sink: (line: string) => void): Writable {
   let pending = '';
-  const emit = (raw: string) => { try { sink(capEmittedLine(raw)); } catch { /* never throw from logging */ } };
+  const emit = (raw: string) => { try { sink(capEmittedLine(raw)); } catch { /* telemetry — silent by design (logging must never throw) */ } };
   return new Writable({
     write(chunk: Buffer | string, _enc, cb) {
       try {
@@ -182,7 +182,7 @@ function makeGuardedDestination(sink: (line: string) => void): Writable {
           pending = pending.slice(nl + 1);
           if (line.length > 0) emit(line);
         }
-      } catch { /* never throw from logging */ }
+      } catch { /* telemetry — silent by design (logging must never throw) */ }
       cb();
     },
     final(cb) { if (pending.length > 0) { emit(pending); pending = ''; } cb(); },

--- a/taxonomy-editor/src/server/logger.ts
+++ b/taxonomy-editor/src/server/logger.ts
@@ -67,14 +67,6 @@ const usePretty = !isProduction && hasPinoPretty();
 // path (pretty mode runs a worker transport that bypasses an in-process
 // destination); opt out with FR_DUMP_INCLUDE_LOGS=0.
 const teeLogs = !usePretty && process.env.FR_DUMP_INCLUDE_LOGS !== '0';
-const teeStream = new Writable({
-  write(chunk: Buffer | string, _enc, cb) {
-    const s = chunk.toString();
-    process.stdout.write(s);
-    recordServerLog(s);
-    cb();
-  },
-});
 
 // ── Log-line size caps (t/1475) ──
 // Azure Container Apps captures stdout via Fluent Bit, which slices lines past a
@@ -128,6 +120,75 @@ export function capLogObject(obj: Record<string, unknown>): Record<string, unkno
   return reduced;
 }
 
+// ── Emitted-line guard (t/2860) ──
+// capLogObject (formatters.log) only sees the merged OBJECT — pino appends `msg`/
+// `level`/`time` afterwards — so an oversized `msg`, the object-cap + msg + meta
+// compose-overflow (15K + 4K + meta ≈ 19K > 16K), and any non-pino line routed
+// through the sink all escape it. The guard below runs on the FINAL serialized line
+// (real bytes) as the hard backstop, so the actually-emitted stdout line can never
+// exceed the ACA/Fluent Bit slice limit.
+
+/** Reduce a parsed, over-cap emitted line to triage keys + truncated `msg` + err/error
+ *  + marker. Always small and valid JSON; keeps `requestId` for Get-ServerLog
+ *  correlation. Unlike capLogObject this sees the serialized line's pino-added fields. */
+export function reduceEmittedLine(obj: Record<string, unknown>): Record<string, unknown> {
+  const reduced: Record<string, unknown> = {};
+  for (const k of [...LOG_TRIAGE_KEYS, 'level', 'time', 'name', 'pid', 'hostname']) {
+    if (k in obj) reduced[k] = truncateLogValue(obj[k]);
+  }
+  if (typeof obj.msg === 'string') reduced.msg = truncateLogString(obj.msg);
+  const err = obj.err as { type?: string; message?: string } | undefined;
+  if (err && typeof err === 'object') reduced.err = { type: err.type, message: truncateLogString(String(err.message ?? '')) };
+  const error = obj.error as { name?: string; message?: string } | undefined;
+  if (error && typeof error === 'object') reduced.error = { name: error.name, message: truncateLogString(String(error.message ?? '')) };
+  reduced._log_truncated = `emitted line exceeded ${LOG_MAX_LINE_BYTES}B — reduced for ACA/Fluent Bit; full detail in the flight recorder`;
+  return reduced;
+}
+
+/** Last-resort fail-safe: byte-truncate a line that isn't valid JSON (or is still
+ *  over-cap after reduction). The result may not be valid JSON, but a self-contained
+ *  truncated line is strictly better than one Fluent Bit slices — a slice corrupts
+ *  the ADJACENT record too (the t/2860 `completed"}` tails). */
+function byteTruncateLine(line: string): string {
+  const marker = '…[truncated oversized log line]';
+  const budget = Math.max(0, LOG_MAX_LINE_BYTES - Buffer.byteLength(marker));
+  return Buffer.from(line, 'utf8').subarray(0, budget).toString('utf8') + marker;
+}
+
+/** Guarantee an emitted line is ≤ LOG_MAX_LINE_BYTES bytes. Structured-reduce when
+ *  parseable (keeps triage + requestId), else byte-truncate. Never throws — logging
+ *  must never take the process down. */
+export function capEmittedLine(line: string): string {
+  try {
+    if (Buffer.byteLength(line) <= LOG_MAX_LINE_BYTES) return line;
+    const obj = JSON.parse(line) as Record<string, unknown>;
+    const s = JSON.stringify(reduceEmittedLine(obj));
+    return Buffer.byteLength(s) <= LOG_MAX_LINE_BYTES ? s : byteTruncateLine(s);
+  } catch { /* telemetry — silent by design */ return byteTruncateLine(line); }
+}
+
+/** Writable that buffers partial chunks, splits on newline, and passes every complete
+ *  line through capEmittedLine before the sink. Fail-safe: never throws, never drops. */
+function makeGuardedDestination(sink: (line: string) => void): Writable {
+  let pending = '';
+  const emit = (raw: string) => { try { sink(capEmittedLine(raw)); } catch { /* never throw from logging */ } };
+  return new Writable({
+    write(chunk: Buffer | string, _enc, cb) {
+      try {
+        pending += chunk.toString();
+        let nl: number;
+        while ((nl = pending.indexOf('\n')) !== -1) {
+          const line = pending.slice(0, nl);
+          pending = pending.slice(nl + 1);
+          if (line.length > 0) emit(line);
+        }
+      } catch { /* never throw from logging */ }
+      cb();
+    },
+    final(cb) { if (pending.length > 0) { emit(pending); pending = ''; } cb(); },
+  });
+}
+
 const pinoOptions = {
   level: process.env.LOG_LEVEL || (isProduction ? 'info' : 'debug'),
   redact: {
@@ -177,9 +238,23 @@ const pinoOptions = {
   },
 };
 
-// In pretty mode pino owns its output via a worker transport; otherwise route
-// through the tee so log lines also land in the server-log buffer for dumps.
-const logger = teeLogs ? pino(pinoOptions, teeStream) : pino(pinoOptions);
+/** Default line sink: write the (line-guarded) line to stdout and, when teeing is
+ *  enabled, into the bounded server-log buffer for flight-recorder dumps. */
+function defaultSink(line: string): void {
+  const withNl = line.endsWith('\n') ? line : line + '\n';
+  process.stdout.write(withNl);
+  if (teeLogs) recordServerLog(withNl);
+}
+
+/** Build a logger with the production options. `sink` overrides the line destination
+ *  (tests capture emitted lines); default → stdout + server-log tee. In pretty mode
+ *  (dev) pino owns output via a worker transport, so the in-process sink is bypassed. */
+export function buildLogger(sink: (line: string) => void = defaultSink) {
+  if (usePretty) return pino(pinoOptions);
+  return pino(pinoOptions, makeGuardedDestination(sink));
+}
+
+const logger = buildLogger();
 
 // ── Component child loggers ──
 


### PR DESCRIPTION
Server log lines were still sliced past 16 KB by ACA/Fluent Bit despite the t/1475 `capLogObject`, corrupting the adjacent record (the `completed"}` tails) and breaking `Get-ServerLog -RequestId` correlation.

**Root cause (TL-approved design, t/2860#2/#3):** `capLogObject` (`formatters.log`) only sees the merged **object** — pino appends `msg`/`level`/`time` afterwards — so an oversized `msg` (H2), the object-cap + msg + meta **compose-overflow** (15K + 4K + meta ≈ 19K > 16K), and non-pino lines all escaped it. Per-field caps can't compose to a bound; the guarantee must be on the **final serialized line**.

**Fix:** a fail-safe emitted-line guard at the pino **destination** (`capEmittedLine` + `makeGuardedDestination`). Every line is passed through before stdout + the server-log tee: structured-reduce when parseable (triage keys + truncated msg + err/error + marker, **keeps requestId**), else byte-truncate. Buffers partial chunks, never throws, never drops. `buildLogger` always wraps the sink, so both the tee and direct-stdout paths are covered.

**Red-first regression test** (`loggerEmit.test.ts`) exercises the real logger→sink path (not `capLogObject` in isolation — the t/1475 test gap):
- **RED** (before guard): large-msg case emitted **200120 B > 15000**
- **GREEN** (after): all 4 cases (large object field / large msg / pathological URL / requestId retained) ≤ cap

Existing `loggerTruncation` + serverLog buffer suites green; server `tsc` clean; `/review-ts` done (test env cleanup added; guard runs post-redaction on non-secret triage keys).

**Deviation** from the proposed design: dropped the redundant `msg` `hooks.logMethod` — the destination guard subsumes it (the hook alone can't stop the compose-overflow).

**Follow-ups filed:** H1 deploy-skew → **t/2864** (DevOps — likely the live cause; source fix won't touch a stale image); H3 githubAPIBackend stderr dump → **t/2865**.

Closes t/2860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)