### PR TITLE
docs(brief): guard-comments keeping image-size CVEs unreachable (t/2866)

### DIFF
--- a/lib/brief/render/potxHonor.ts
+++ b/lib/brief/render/potxHonor.ts
@@ -9,6 +9,12 @@
 // No new deps: JSZip is already in lib/package.json (used by verify.ts).
 // This is intentionally the ONLY place that reads .potx bytes; pptxRenderer.ts
 // stays the only pptxgenjs surface (TL build condition 1 preserved).
+//
+// SECURITY (t/2866): this is the ONLY reader of user-supplied .potx bytes, and it does so
+// via pure JSZip/OOXML text surgery — it never decodes embedded images. That keeps
+// pptxgenjs's transitive `image-size` (CVE-2025-71329 / CVE-2025-71330 — ICNS/JXL/HEIF DoS,
+// no patched release) unreachable, the basis for the Dependabot dismissal. Do NOT add
+// image-byte parsing of .potx content here without re-triaging t/2866.
 
 import JSZip from 'jszip';
 import type { DeckTheme } from './deckTheme.js';

--- a/lib/brief/render/pptxRenderer.ts
+++ b/lib/brief/render/pptxRenderer.ts
@@ -19,6 +19,13 @@ import { campColor } from './deckTheme.js';
 // at runtime: the CJS main's `module.exports` IS the class) to the exact API this
 // renderer uses, so it type-checks under BOTH bundler (vitest/renderer) and nodenext
 // (server build). A pptxgenjs swap or a types fix touches only this block.
+//
+// SECURITY (t/2866): this surface deliberately exposes NO addImage/addMedia. pptxgenjs
+// invokes its transitive `image-size` dep (CVE-2025-71329 / CVE-2025-71330 — ICNS/JXL/HEIF
+// parser infinite-loop DoS, no patched release exists) ONLY when measuring an embedded
+// image. Keeping image embedding out of this bounded surface keeps those parsers
+// unreachable — the basis on which the 4 Dependabot alerts were dismissed. Do NOT add
+// addImage/addMedia here without re-triaging t/2866 first.
 type Hex = string;
 interface PptxLine { color: Hex; width?: number; pt?: number }
 interface PptxTextOpts {


### PR DESCRIPTION
TL-required precondition (p/455#131) before dismissing the 4 high Dependabot alerts — all `image-size` (CVE-2025-71329 ICNS + CVE-2025-71330 JXL/HEIF parser DoS; no patched release; transitive via pptxgenjs).

The dismissal rests on **"no `addImage` anywhere → image-size parsers unreachable"**, so this guards the two sites a future dev could silently break that invariant:

- **`pptxRenderer.ts`** (the bounded pptxgenjs surface) — notes it deliberately exposes no `addImage`/`addMedia`; image-size only runs when measuring embedded images.
- **`potxHonor.ts`** (the ONLY reader of user-supplied `.potx` bytes) — notes it is pure JSZip/OOXML surgery, never decodes embedded images.

Both point at t/2866 for re-triage before adding image handling.

Comment-only; `eslint` clean; brief render suite **18/18** green. After merge I'll dismiss all 4 alerts ("vulnerable code not used") and keep t/2866 open as the patched-image-size tracking item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)