### PR TITLE
fix(sigusr2): bound NDJSON dump to per-record framed writes under LOG_MAX_LINE_BYTES (t/2865)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/flightRecorderDumps.test.ts
+++ b/taxonomy-editor/src/server/__tests__/flightRecorderDumps.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../flightRecorderDumps.js';
 import { setGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import type { FlightRecorder, RecordInput } from '../../../../lib/flight-recorder/flightRecorder.js';
+import { writeFramedNdjson, LOG_MAX_LINE_BYTES } from '../logger.js';
 
 describe('isValidDumpId (t/908)', () => {
   it('accepts UUID-safe ids, rejects traversal/empty/oversized', () => {
@@ -262,5 +263,33 @@ describe('readMergedDump (t/939)', () => {
       { _type: 'event', _wall: '2026-01-01T00:00:01Z', type: 'api' },
     ));
     expect(await readMergedDump(root, 'srvonly', { includeServer: false })).toBeNull();
+  });
+});
+
+describe('writeFramedNdjson (t/2865 — SIGUSR2 dump line cap)', () => {
+  it('writes each record on its own line, all within LOG_MAX_LINE_BYTES', () => {
+    const lines: string[] = [];
+    const fakeOut = { write: (s: string) => { lines.push(s); } } as unknown as NodeJS.WritableStream;
+
+    const normal = JSON.stringify({ _type: 'event', msg: 'ok' });
+    const oversized = JSON.stringify({ _type: 'event', payload: 'x'.repeat(LOG_MAX_LINE_BYTES + 1000) });
+    writeFramedNdjson([normal, oversized, normal].join('\n'), fakeOut);
+
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      expect(Buffer.byteLength(line.replace(/\n$/, ''))).toBeLessThanOrEqual(LOG_MAX_LINE_BYTES);
+    }
+    // oversized record is truncated with a marker, not silently dropped
+    expect(lines[1]).toContain('[line truncated');
+    // normal records are written verbatim
+    expect(lines[0].trim()).toBe(normal);
+    expect(lines[2].trim()).toBe(normal);
+  });
+
+  it('skips empty lines and does not emit blank writes', () => {
+    const lines: string[] = [];
+    const fakeOut = { write: (s: string) => { lines.push(s); } } as unknown as NodeJS.WritableStream;
+    writeFramedNdjson('\n\n', fakeOut);
+    expect(lines).toHaveLength(0);
   });
 });

--- a/taxonomy-editor/src/server/logger.ts
+++ b/taxonomy-editor/src/server/logger.ts
@@ -189,6 +189,29 @@ function makeGuardedDestination(sink: (line: string) => void): Writable {
   });
 }
 
+// ── Framed NDJSON writer (t/2865) ──
+// The SIGUSR2 flight-recorder dump (githubAPIBackend) writes NDJSON straight to
+// stderr, bypassing pino and the destination guard above. This bounds each record
+// to the same ACA/Fluent Bit line limit so an oversized dump record can't slice.
+const FRAMED_TRUNCATION_MARKER = '...[line truncated: exceeded LOG_MAX_LINE_BYTES]';
+
+/** Write NDJSON line-by-line to `out`, bounding each line to LOG_MAX_LINE_BYTES.
+ *  Oversized records are character-sliced and suffixed with a truncation marker
+ *  so they stay under the ACA/Fluent Bit 16KB slice boundary. Never silently drops records. */
+export function writeFramedNdjson(ndjson: string, out: NodeJS.WritableStream): void {
+  const markerBytes = Buffer.byteLength(FRAMED_TRUNCATION_MARKER);
+  const limit = LOG_MAX_LINE_BYTES - markerBytes;
+  for (const line of ndjson.split('\n')) {
+    if (!line) continue;
+    if (Buffer.byteLength(line) <= LOG_MAX_LINE_BYTES) {
+      out.write(line + '\n');
+    } else {
+      // Slice by chars (≈ bytes for ASCII-dominant NDJSON) leaving room for the marker.
+      out.write(line.slice(0, limit) + FRAMED_TRUNCATION_MARKER + '\n');
+    }
+  }
+}
+
 const pinoOptions = {
   level: process.env.LOG_LEVEL || (isProduction ? 'info' : 'debug'),
   redact: {

--- a/taxonomy-editor/src/server/storage/githubAPIBackend.ts
+++ b/taxonomy-editor/src/server/storage/githubAPIBackend.ts
@@ -28,6 +28,7 @@ import type { FlightRecorder, RecordInput } from '../../../../lib/flight-recorde
 import { getCurrentUserId, getSessionBranchName } from '../security/userContext.js';
 import { GitHubRestClient, normalizeErrorForEvent, type CircuitState } from './githubRestClient.js';
 import { getDataRoot } from '../config.js';
+import { writeFramedNdjson } from '../logger.js';
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -1751,7 +1752,7 @@ export class GitHubAPIBackend implements StorageBackend {
     process.on('SIGUSR2', () => {
       if (!this.recorder) return;
       const dump = this.recorder.buildDump('manual', undefined, { trigger: 'SIGUSR2' });
-      process.stderr.write(dump.ndjson + '\n');
+      writeFramedNdjson(dump.ndjson, process.stderr);
     });
   }
 


### PR DESCRIPTION
## Summary
- Adds `writeFramedNdjson()` helper to `logger.ts` — splits NDJSON by record, writes each line within `LOG_MAX_LINE_BYTES`; oversized records are character-sliced + truncation marker appended (never silently dropped)
- `githubAPIBackend.registerSigHandler`: replaces bare `process.stderr.write(dump.ndjson + '\n')` with `writeFramedNdjson(dump.ndjson, process.stderr)` so no single stderr line exceeds the ACA/Fluent Bit 16 KB slice boundary
- Test suite added to `flightRecorderDumps.test.ts`: pathological large record emits only under-cap lines with marker; normal records verbatim; empty-line skip verified

Depends on t/2860 (Done). H3 sub-cause fix.

## Test plan
- [ ] `npx vitest run src/server/__tests__/flightRecorderDumps.test.ts` — all tests pass including 2 new `writeFramedNdjson` cases
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)