### PR TITLE
feat(view): gate TheoryLink doc/help icons to Advanced view (t/2867)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { DebateWorkspace } from './DebateWorkspace';
+import { usePreferencesStore } from '../../store/preferencesStore';
 
 // ── Store mocks ───────────────────────────────────────────────
 
@@ -346,6 +347,8 @@ describe('phase routing', () => {
   beforeEach(() => {
     mockStore.debateLoading = false;
     mockStore.debateGenerating = null;
+    // t/2867: the header TheoryLink now gates on viewMode; advanced view renders it.
+    usePreferencesStore.setState({ viewMode: 'advanced' });
   });
 
   it('shows "Topic Refinement" phase title for clarification phase', () => {

--- a/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.planDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/TaxonomyRefs.planDetail.test.tsx
@@ -50,6 +50,7 @@ vi.mock('../taxonomy/TaxonomyRefDetail', () => ({
 }));
 
 import { TaxonomyRefsSection } from './TaxonomyRefs';
+import { usePreferencesStore } from '../../store/preferencesStore';
 
 const ANCHOR = 'acc-B-001';
 
@@ -70,7 +71,8 @@ function renderPlan() {
 }
 
 describe('TaxonomyRefsSection — PLAN anchor → inline POV detail (t/1724)', () => {
-  beforeEach(() => { vi.clearAllMocks(); });
+  // t/2867: TheoryLink now gates on viewMode; advanced view shows the help icons these tests assert.
+  beforeEach(() => { vi.clearAllMocks(); usePreferencesStore.setState({ viewMode: 'advanced' }); });
 
   it('renders the anchor as a keyboard-accessible button, no detail until clicked', () => {
     renderPlan();

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.test.tsx
@@ -9,6 +9,12 @@ const openExternal = vi.fn().mockResolvedValue(undefined);
 vi.mock('@bridge', () => ({ api: { openExternal: (url: string) => openExternal(url) } }));
 const { recorderRecord } = vi.hoisted(() => ({ recorderRecord: vi.fn() }));
 vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: recorderRecord }) }));
+// t/2867: TheoryLink now gates on viewMode. Default 'advanced' keeps the existing render
+// assertions valid; the gate tests below flip it to 'simple'.
+const { viewModeRef } = vi.hoisted(() => ({ viewModeRef: { current: 'advanced' as 'simple' | 'advanced' } }));
+vi.mock('../../store/preferencesStore', () => ({
+  usePreferencesStore: (sel: (s: { viewMode: 'simple' | 'advanced' }) => unknown) => sel({ viewMode: viewModeRef.current }),
+}));
 
 import { TheoryLink, DocLink, buildDocUrl, humanizeDocName, type TheoryLinkProps } from './TheoryLink';
 
@@ -33,7 +39,7 @@ describe('humanizeDocName', () => {
 });
 
 describe('TheoryLink', () => {
-  beforeEach(() => { openExternal.mockClear(); recorderRecord.mockClear(); });
+  beforeEach(() => { openExternal.mockClear(); recorderRecord.mockClear(); viewModeRef.current = 'advanced'; });
 
   it('DocLink is an alias of TheoryLink', () => {
     expect(DocLink).toBe(TheoryLink);
@@ -117,5 +123,28 @@ describe('TheoryLink', () => {
     const { container } = render(<TheoryLink {...({ url: URL, docPath: 'docs/x.md' } as unknown as TheoryLinkProps)} />);
     expect(container).toBeEmptyDOMElement();
     expect(recorderRecord).toHaveBeenCalledWith(expect.objectContaining({ type: 'system.error', component: 'theory-link' }));
+  });
+
+  // ── viewMode gate (t/2867): Simple view hides all doc/help links, single-point ──
+  it('renders nothing in Simple view', () => {
+    viewModeRef.current = 'simple';
+    const { container } = render(<TheoryLink url={URL} label="Help" />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders the link in Advanced view', () => {
+    viewModeRef.current = 'advanced';
+    render(<TheoryLink url={URL} label="Help" />);
+    expect(screen.getByRole('button', { name: 'Help' })).toHaveAttribute('data-theory-link');
+  });
+
+  it('toggling Advanced→Simple hides it live (store subscription, no reload)', () => {
+    viewModeRef.current = 'advanced';
+    const { rerender, container } = render(<TheoryLink url={URL} label="Help" />);
+    expect(screen.getByRole('button', { name: 'Help' })).toBeTruthy();
+    viewModeRef.current = 'simple';
+    rerender(<TheoryLink url={URL} label="Help" />);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/taxonomy-editor/src/renderer/components/shared/TheoryLink.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TheoryLink.tsx
@@ -22,6 +22,7 @@
 
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
+import { usePreferencesStore } from '../../store/preferencesStore';
 import './TheoryLink.css';
 
 /** Canonical GitHub repo for doc links — single source of truth (t/2410, TL-confirmed org). */
@@ -67,6 +68,13 @@ export type TheoryLinkProps =
 
 export function TheoryLink(props: TheoryLinkProps) {
   const { label, tooltip, size = 15, className } = props;
+
+  // t/2867: Simple view hides ALL doc/help links app-wide — a single-point gate here
+  // (mirrors PinnedPanel, t/2826) instead of ~40 per-site conditionals, which removes the
+  // missed-surface risk. Store subscription ⇒ Simple↔Advanced toggles live with no reload.
+  // (Redundant-but-harmless on the diagnostics surfaces that are already Advanced-only.)
+  const viewMode = usePreferencesStore((s) => s.viewMode);
+  if (viewMode !== 'advanced') return null;
 
   // Runtime guard (t/2410): exactly one of `url` / `docPath`. The discriminated union
   // catches static callers; this catches spread / `as any` / JS-caller bypasses — record a

--- a/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.test.tsx
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { RankedSelectCell, ConfidenceCell } from './GraphAttributesPanel';
+import { usePreferencesStore } from '../../store/preferencesStore';
 
 const openExternal = vi.fn().mockResolvedValue(undefined);
 vi.mock('@bridge', () => ({ api: { openExternal: (...args: unknown[]) => openExternal(...args) } }));
@@ -16,7 +17,8 @@ vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }))
 const BDI_DOC_URL = 'https://github.com/jpsnover/ai-triad-research/blob/main/docs/bdi-scales.md';
 
 describe('GraphAttributesPanel — BDI scale doc-links (t/2448)', () => {
-  beforeEach(() => { openExternal.mockClear(); cleanup(); });
+  // t/2867: TheoryLink now gates on viewMode; advanced view shows the doc-links these tests assert.
+  beforeEach(() => { openExternal.mockClear(); cleanup(); usePreferencesStore.setState({ viewMode: 'advanced' }); });
 
   it('renders the doc link beside a RankedSelectCell label and opens docs/bdi-scales.md', () => {
     render(<RankedSelectCell label="Priority" value={3} options={[{ value: 3, label: '3 — Important' }]} />);

--- a/taxonomy-editor/src/renderer/hooks/useTheoryLinkHotkey.test.tsx
+++ b/taxonomy-editor/src/renderer/hooks/useTheoryLinkHotkey.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ recor
 
 import { TheoryLink } from '../components/shared/TheoryLink';
 import { useTheoryLinkHotkey } from './useTheoryLinkHotkey';
+import { usePreferencesStore } from '../store/preferencesStore';
 
 // jsdom does no layout: offsetParent is null and getClientRects() is empty, so the
 // hook's visibility filter would drop every link. Make attached elements report visible.
@@ -33,7 +34,8 @@ function stubRect(el: Element, left: number, top: number) {
 }
 
 describe('useTheoryLinkHotkey', () => {
-  beforeEach(() => { openExternal.mockClear(); });
+  // t/2867: TheoryLink now gates on viewMode; the hotkey targets links, so advanced view must render them.
+  beforeEach(() => { openExternal.mockClear(); usePreferencesStore.setState({ viewMode: 'advanced' }); });
   afterEach(() => { document.body.innerHTML = ''; });
 
   it('F1 activates the TheoryLink in the focused element\'s enclosing section', () => {


### PR DESCRIPTION
UAT follow-up to t/2826 (human-confirmed): "bookmarks" also means the open-book **TheoryLink** doc/help icons (node-badge books, PovTab top-right, SaveBar pink book, ~40 sites) — which t/2826 never scoped. Hide them in Simple view too.

**Single-point gate** inside the shared `TheoryLink` component (mirrors the PinnedPanel gate from t/2826) instead of ~40 per-site conditionals — removes the missed-surface risk:
```ts
const viewMode = usePreferencesStore(s => s.viewMode);
if (viewMode !== 'advanced') return null;
```
Store subscription ⇒ Simple↔Advanced toggles live, no reload. Returning `null` removes the node entirely (no empty flex slot at inline sites like `EdgeDetailPanel`/`OverviewTabRouter`).

**Test:** `TheoryLink.test.tsx` — `preferencesStore` mocked (default `advanced` keeps the existing 15 assertions valid); adds Simple→null, Advanced→renders, and a live Advanced→Simple toggle. **18/18** green; renderer `tsc` + `eslint` clean.

**Self-cert:** /trivial-change + this ticket (TL-specced, single-scope renderer, existing viewMode pattern).

**One AC I couldn't fully verify headlessly:** the live visual "no layout regression / both build targets" spot-check — CI covers renderer-tsc + test-electron(taxonomy-editor); the null-return makes inline layout safe by construction, but a Simple-view visual pass (NodeDetail badge, PovTab, SaveBar) is advisable at review. Flagging per the deviation rule; no per-site link needed to stay visible was found.

Closes t/2867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)