### PR TITLE
fix(brief/render): normalize ppt/presentation.xml to canonical order — verify OOXML gate (t/2871)

### DIFF
--- a/lib/brief/render/index.ts
+++ b/lib/brief/render/index.ts
@@ -13,6 +13,7 @@ import type { SlideKind } from './slideModel.js';
 import { resolveTheme } from './deckTheme.js';
 import { renderPptx } from './pptxRenderer.js';
 import { renderHtml } from './htmlRenderer.js';
+import { normalizePresentationOrder } from './normalizeOoxml.js';
 
 export interface RenderInput {
   spec: DeckSpec;
@@ -66,6 +67,13 @@ export async function render(input: RenderInput): Promise<RenderResult> {
       allWarnings.push(`template_masters_not_merged: slide-master injection failed — ${msg}`);
     }
   }
+
+  // FINAL byte step: normalize ppt/presentation.xml child order to ECMA-376 canonical
+  // (pptxgenjs emits notesMasterIdLst after sldIdLst on any deck with speaker notes,
+  // which the T5 OOXML lint rejects — t/2871). After the optional .potx merge so it
+  // also corrects any reordering that introduced. No-op (bytes unchanged) if already
+  // canonical.
+  pptxBytes = await normalizePresentationOrder(pptxBytes);
 
   const htmlDoc = renderHtml(slides, theme);
 

--- a/lib/brief/render/normalizeOoxml.test.ts
+++ b/lib/brief/render/normalizeOoxml.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for the ppt/presentation.xml canonical-order fix (t/2871).
+//   1. Pure unit tests of the reorder logic.
+//   2. Red-first render→verify-WITH-notes integration test — the exact #1256 gate
+//      gap (no test ever rendered a deck with speaker notes through verify), which
+//      is why the pptxgenjs ordering bug stayed latent.
+
+import { describe, it, expect } from 'vitest';
+import { reorderPresentationChildren } from './normalizeOoxml.js';
+import { runBriefPipeline } from '../pipeline.js';
+import type { DebateSession } from '../../debate/types.js';
+import type { AIAdapter } from '../../debate/aiAdapter.js';
+
+// pptxgenjs's buggy shape: <p:sldIdLst> BEFORE <p:notesMasterIdLst>.
+const OUT_OF_ORDER = [
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+  '<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" saveSubsetFonts="1">',
+  '<p:sldMasterIdLst><p:sldMasterId id="2147483648" r:id="rId1"/></p:sldMasterIdLst>',
+  '<p:sldIdLst><p:sldId id="256" r:id="rId2"/><p:sldId id="257" r:id="rId3"/></p:sldIdLst>',
+  '<p:notesMasterIdLst><p:notesMasterId r:id="rId4"/></p:notesMasterIdLst>',
+  '<p:sldSz cx="9144000" cy="6858000" type="screen4x3"/>',
+  '<p:notesSz cx="6858000" cy="9144000"/>',
+  '<p:defaultTextStyle><a:lvl1pPr/></p:defaultTextStyle>',
+  '</p:presentation>',
+].join('');
+
+const CANONICAL_TAGS = ['sldMasterIdLst', 'notesMasterIdLst', 'handoutMasterIdLst', 'sldIdLst', 'sldSz', 'notesSz'];
+function orderedPositions(xml: string): string[] {
+  return CANONICAL_TAGS
+    .map(t => ({ t, at: xml.indexOf(`<p:${t}`) }))
+    .filter(p => p.at >= 0)
+    .sort((a, b) => a.at - b.at)
+    .map(p => p.t);
+}
+
+describe('reorderPresentationChildren', () => {
+  it('moves notesMasterIdLst before sldIdLst (the pptxgenjs defect)', () => {
+    const out = reorderPresentationChildren(OUT_OF_ORDER);
+    expect(orderedPositions(out)).toEqual(['sldMasterIdLst', 'notesMasterIdLst', 'sldIdLst', 'sldSz', 'notesSz']);
+    // notesMasterIdLst now precedes sldIdLst
+    expect(out.indexOf('<p:notesMasterIdLst')).toBeLessThan(out.indexOf('<p:sldIdLst'));
+  });
+
+  it('preserves each element\'s children and any trailing non-canonical elements', () => {
+    const out = reorderPresentationChildren(OUT_OF_ORDER);
+    expect(out).toContain('<p:sldId id="256" r:id="rId2"/>');
+    expect(out).toContain('<p:sldId id="257" r:id="rId3"/>');
+    expect(out).toContain('<p:notesMasterId r:id="rId4"/>');
+    // defaultTextStyle stays after the id-lists/sizes
+    expect(out.indexOf('<p:defaultTextStyle')).toBeGreaterThan(out.indexOf('<p:notesSz'));
+    // no element dropped or duplicated
+    for (const tag of ['sldMasterIdLst', 'notesMasterIdLst', 'sldIdLst', 'sldSz', 'notesSz', 'defaultTextStyle']) {
+      expect(out.split(`<p:${tag}`).length - 1, `${tag} count`).toBe(1);
+    }
+  });
+
+  it('is a no-op (returns the same string) when already canonical', () => {
+    const already = reorderPresentationChildren(OUT_OF_ORDER);
+    expect(reorderPresentationChildren(already)).toBe(already);
+  });
+
+  it('leaves XML with fewer than two canonical children untouched', () => {
+    const one = '<p:presentation><p:sldIdLst><p:sldId id="256"/></p:sldIdLst></p:presentation>';
+    expect(reorderPresentationChildren(one)).toBe(one);
+  });
+});
+
+// ── Red-first render→verify-WITH-notes (the #1256 gate gap) ───────────────────
+
+const guardAdapter = { generateText: async () => { throw new Error('adapter must not be called under skipNarration'); } } as AIAdapter;
+
+// Minimal valid CLOSED session — the deterministic pipeline attaches speaker notes to
+// every slide, which is what triggers pptxgenjs's notesMaster ordering bug.
+function makeSession(): DebateSession {
+  return {
+    id: 'sess-ooxml-001', run_id: 'run-ooxml-001', title: 'Should AI safety be legally mandated?',
+    debate_model: 'claude-sonnet-5', protocol_id: 'structured', phase: 'closed',
+    topic: {
+      final: 'AI safety requirements should be legally mandated',
+      scope: { key_tensions: ['innovation vs. safety'], explicit_qualifiers: ['frontier models'], excluded_scenarios: ['research prototypes'], time_horizon: '2026-2030' },
+      critique: { rating: 'fair', composite_score: 12, reframing_suggestion: 'Should frontier AI training require certified safety audits?' },
+    },
+    transcript: [{
+      type: 'concluding',
+      metadata: { synthesis: {
+        areas_of_agreement: [{ point: 'AI risks are real', povers: ['acc', 'saf'] }],
+        areas_of_disagreement: [{ point: 'Mandatory thresholds are harmful', bdi_layer: 'belief', resolvability: 'empirically_testable' }],
+        unresolved_questions: ['What metrics define sufficient safety?'],
+        cruxes: [{ question: 'Will mandates stifle innovation?', type: 'EMPIRICAL', if_yes: 'Acc wins', if_no: 'Saf wins', resolution_status: 'active' }],
+        preferences: [{ conflict: 'speed vs. safety', prevails: 'saf', criterion: 'public harm', rationale: 'irreversible harms outweigh delay costs', what_would_change_this: 'proof mandates cut investment >30%' }],
+        argument_map: [{ claim_id: 'a1', claim: 'Regulation reduces innovation', claimant: 'acc', supported_by: ['a2'], attacked_by: [{ claim_id: 'a3' }] }],
+      } },
+    }],
+    argument_network: { nodes: [
+      { id: 'a1', text: 'Regulation reduces innovation', speaker: 'acc', scoring_method: 'bdi_criteria', computed_strength: 0.72 },
+      { id: 'fc1', text: 'Frontier models doubled in 12 months', speaker: 'system', scoring_method: 'fact_check', verification_status: 'supported', verification_evidence: 'Epoch AI 2025' },
+    ] },
+    commitments: { acc: { asserted: ['c1', 'c2'], conceded: ['c3'], challenged: ['c4'] }, saf: { asserted: ['c6'], conceded: [], challenged: ['c7'] } },
+    convergence_tracker: { issues: [{ taxonomy_ref: 'ai-safety-mandate', convergence: 0.4, qbaf_strength: 0.45 }] },
+    crux_tracker: [{ id: 'cx1', description: 'Will mandates stifle innovation?', state: 'engaged', identified_turn: 2, history: [], attacking_claim_ids: [], speakers_involved: ['acc', 'saf'], last_computed_strength: 0.5, support_polarity: 0 }],
+  } as unknown as DebateSession;
+}
+
+describe('render→verify with speaker notes (t/2871 regression)', () => {
+  it('a real deck WITH notes passes the verify OOXML canonical-order gate', async () => {
+    const result = await runBriefPipeline(
+      {
+        session: makeSession(), preset: 'policymaker', modelId: 'gemini-2.5-flash', modelSource: 'Explicit',
+        skipNarration: true, toolVersions: { 'brief-test': '1.0' }, timestamp: '2026-08-20T00:00:00.000Z',
+      },
+      guardAdapter,
+    );
+    // Red-first: on unfixed render this array contains
+    //   "ooxml: p:presentation children out of canonical order … <p:sldIdLst> precedes <p:notesMasterIdLst>"
+    const canonicalFailures = result.hardFailures.filter(f => /canonical order/i.test(f));
+    expect(canonicalFailures, `verify OOXML canonical-order gate failed:\n${result.hardFailures.join('\n')}`).toEqual([]);
+    // And the export is fully clean (no other hard failures) → the CLI/server success path works.
+    expect(result.hardFailures).toEqual([]);
+  }, 60_000);
+});

--- a/lib/brief/render/normalizeOoxml.ts
+++ b/lib/brief/render/normalizeOoxml.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// T4 Render — canonical-order normalization of ppt/presentation.xml (t/2871).
+//
+// pptxgenjs 3.12.0 emits <p:sldIdLst> BEFORE <p:notesMasterIdLst> whenever the deck
+// has speaker notes (every real deck does — assemble.ts attaches speakerNotes). That
+// violates the ECMA-376 CT_Presentation sequence, which the T5 verify OOXML lint
+// (verify.ts CANONICAL_PRESENTATION_ORDER) correctly rejects — so EVERY export with
+// notes hard-failed the gate (CLI and the T6 server, which share runBriefPipeline →
+// render → verify). This post-process reorders the id-list/size children of
+// <p:presentation> into canonical order.
+//
+// Pure JSZip/OOXML text surgery — mirrors potxHonor.ts. No new dep, no pptxgenjs
+// surface change, and NO image decoding (t/2866: keeps pptxgenjs's transitive
+// image-size parsers unreachable). Runs as the FINAL render step so it also
+// normalizes any reordering introduced by the optional .potx master merge.
+
+import JSZip from 'jszip';
+
+// MUST match verify.ts CANONICAL_PRESENTATION_ORDER — the exact tags/order the lint checks.
+const CANONICAL_PRESENTATION_ORDER = [
+  'sldMasterIdLst', 'notesMasterIdLst', 'handoutMasterIdLst',
+  'sldIdLst', 'sldSz', 'notesSz',
+] as const;
+
+/** Match one <p:TAG …/> (self-closing) or <p:TAG …>…</p:TAG> (container) element. */
+function elementRegex(tag: string): RegExp {
+  return new RegExp(`<p:${tag}\\b[^>]*?(?:/>|>[\\s\\S]*?</p:${tag}>)`);
+}
+
+interface FoundElement { tag: string; text: string; index: number }
+
+/**
+ * Reorder the canonical id-list/size children of <p:presentation> into ECMA-376
+ * order. Returns the XML unchanged (===) when already canonical or when fewer than
+ * two canonical children are present, so callers can skip a needless re-zip.
+ */
+export function reorderPresentationChildren(xml: string): string {
+  const present: FoundElement[] = [];
+  for (const tag of CANONICAL_PRESENTATION_ORDER) {
+    const m = elementRegex(tag).exec(xml);
+    if (m) present.push({ tag, text: m[0], index: m.index });
+  }
+  if (present.length < 2) return xml;
+
+  const canonical = present.slice().sort(
+    (a, b) => CANONICAL_PRESENTATION_ORDER.indexOf(a.tag as typeof CANONICAL_PRESENTATION_ORDER[number])
+            - CANONICAL_PRESENTATION_ORDER.indexOf(b.tag as typeof CANONICAL_PRESENTATION_ORDER[number]),
+  );
+  // Already canonical iff document order (by index) already equals canonical order.
+  const alreadyCanonical = canonical.every((el, i) => i === 0 || el.index > canonical[i - 1].index);
+  if (alreadyCanonical) return xml;
+
+  // Strip every canonical element from its current position, then reinsert the whole
+  // block — in canonical order — immediately after the <p:presentation …> open tag.
+  // Per CT_Presentation these id-lists/sizes are the first children, so this is the
+  // correct anchor and cannot displace legitimately-earlier content (there is none).
+  let stripped = xml;
+  for (const el of present) stripped = stripped.replace(el.text, '');
+
+  const open = /<p:presentation\b[^>]*>/.exec(stripped);
+  if (!open) return xml; // unexpected shape — leave untouched rather than corrupt
+  const at = open.index + open[0].length;
+  const block = canonical.map(el => el.text).join('');
+  return stripped.slice(0, at) + block + stripped.slice(at);
+}
+
+/**
+ * Rewrite ppt/presentation.xml inside a .pptx zip so its <p:presentation> children
+ * are in ECMA-376 canonical order. Returns the input bytes unchanged when no
+ * reordering is needed (no re-zip).
+ */
+export async function normalizePresentationOrder(pptxBytes: Uint8Array): Promise<Uint8Array> {
+  const zip = await JSZip.loadAsync(pptxBytes);
+  const presName = Object.keys(zip.files).find(n => /(^|\/)presentation\.xml$/.test(n) && n.includes('ppt/'));
+  if (!presName) return pptxBytes;
+
+  const xml = await zip.files[presName].async('string');
+  const reordered = reorderPresentationChildren(xml);
+  if (reordered === xml) return pptxBytes;
+
+  zip.file(presName, reordered);
+  return zip.generateAsync({ type: 'uint8array', compression: 'DEFLATE' });
+}


### PR DESCRIPTION
## t/2871 — normalize ppt/presentation.xml to canonical order (T6 release-blocker)

**T6 release-blocker** (TL p/342#116): every real brief export — offline CLI **and** T6 server — hard-fails the verify OOXML gate, because pptxgenjs 3.12.0 emits `<p:sldIdLst>` before `<p:notesMasterIdLst>` on any deck with speaker notes (assemble.ts attaches `speakerNotes` to every slide), violating ECMA-376 `CT_Presentation`. Latent since verify shipped (#1256): no test ever rendered notes through verify.

### Fix — shared render path (covers CLI + server in one shot)
- **`lib/brief/render/normalizeOoxml.ts`** — reorders the `<p:presentation>` id-list/size children into canonical order via pure JSZip/OOXML text surgery (mirrors `potxHonor.ts`). No new dep, no pptxgenjs-surface change, **no image decoding** (t/2866 safe). Returns the bytes unchanged (no re-zip) when already canonical.
- **`render/index.ts`** — applied as the FINAL byte step, after the optional `.potx` merge. Since both CLI (`runBriefPipeline`) and T6 (`briefExportJobs.ts` → same `runBriefPipeline`) go through `render()`, one fix covers both.

### Tests — red-first proven
- `reorderPresentationChildren` unit tests: out-of-order → canonical; already-canonical → unchanged (no re-zip); <2 canonical children → untouched; children + trailing non-canonical elements preserved, none dropped/duplicated.
- **render→verify-WITH-notes integration test** — the exact #1256 gate gap. **Red** on unfixed render (`PptxLintFailure: … <p:sldIdLst> precedes <p:notesMasterIdLst>`); **green** after: the full export is verify-clean (`hardFailures` empty).

### ⚠ Design note (deviation flag)
TL said "fix in shared **pptxRenderer**". I homed the logic in a sibling **`normalizeOoxml.ts`** rather than in `pptxRenderer.ts`, because it is **post-processing (JSZip), not pptxgenjs API** — keeping `pptxRenderer.ts` the *sole* pptxgenjs surface (the same reason `potxHonor.ts` is separate). Wired into the shared `render()` so CLI + server are both covered exactly as intended. Happy to inline into pptxRenderer if you'd prefer.

### Gates
nodenext ✓ · renderer-tsc 0/0 ✓ · vitest 57/57 (normalizeOoxml + render + verify + pipeline; existing suites unaffected) ✓ · `/review-ts` clean. No new runtime dep.

### Follow-up (t/2871 AC)
Once this lands, tighten the t/2868 CLI E2E (`cli.entrypoint.test.ts`) from the anti-silent-no-op contract to the **success-only** assertion (per TL p/342#117).

Routing to **Main (TL)** for review — release-blocker + render-byte-contract change. Not self-merging.

Closes t/2871.
