### PR TITLE
fix(container): add --repo to gh workflow run in ci-gate fallback

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -70,7 +70,7 @@ jobs:
             # Dispatch CI manually and wait for it rather than failing with an
             # unhelpful "push to main" instruction that no longer applies.
             echo "No CI run found for ${TARGET_SHA} (docs-only tip skipped by paths-ignore). Dispatching CI..."
-            gh workflow run ci.yml --ref main
+            gh workflow run ci.yml --repo "${{ github.repository }}" --ref main
             # Allow ~20s for the dispatched run to register in GitHub's API
             sleep 20
             for i in $(seq 1 18); do


### PR DESCRIPTION
## Summary
- Add `--repo "${{ github.repository }}"` to the `gh workflow run ci.yml` call in container.yml's ci-gate fallback path

## Problem
The ci-gate fallback (triggered when no CI run exists for the target SHA) calls `gh workflow run ci.yml --ref main` without `--repo`. The `gh` CLI resolves the repo from the git remote when `--repo` is absent, but the ci-gate job has no `actions/checkout` step — so there's no `.git` directory and the command crashes with `fatal: not a git repository`. This blocked run 32368206955 before the CI dispatch could fire.

## Fix
One-line addition of `--repo "${{ github.repository }}"`. All other logic (dispatch, poll, watch, job-status check) is unchanged.

## Test plan
- [ ] CI passes on this PR (workflow-lint will catch YAML issues)
- [ ] After merge, redispatch `container.yml` without a `sha` input to exercise the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
