### PR TITLE
fix(brief/narrate): retry + error on empty narration entries, not a downstream symmetry breach (t/2872)

### DIFF
--- a/lib/brief/narrate.test.ts
+++ b/lib/brief/narrate.test.ts
@@ -240,6 +240,17 @@ describe('narrate — narrated mode (mocked adapter)', () => {
     expect((adapter.generateText as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2); // 1 + repair retry
   });
 
+  it('retries then throws ActionableError on empty entries — not a silent symmetry breach (t/2872)', async () => {
+    // {entries:[]} is AJV-valid and has zero bad traces, so it slips past both the
+    // JSON and bad-trace gates. Without the presence gate it returned an empty
+    // narration that only failed far downstream at verify's symmetry check (0 slides
+    // per camp). The presence gate must retry once, then throw a narrate-level error.
+    const emptyResponse = { entries: [], audience_questions: [] };
+    const adapter = makeAdapter(emptyResponse);
+    await expect(narrate({ ...BASE_INPUT }, adapter)).rejects.toThrow(/zero narration entries/i);
+    expect((adapter.generateText as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2); // 1 + repair retry
+  });
+
   it('validates schema — rejects unknown property', async () => {
     // The model response is valid but the assembled Narration has extra fields
     // (tested by injecting a bad response that bypasses trace check)

--- a/lib/brief/narrate.ts
+++ b/lib/brief/narrate.ts
@@ -263,6 +263,31 @@ async function buildNarratedNarration(
       });
     }
 
+    // Presence gate (t/2872): an empty entries array is AJV-schema-valid and trips
+    // neither the JSON-parse nor the bad-trace gate, but yields a narration the model
+    // never actually produced — downstream verify() then hard-fails symmetry for EVERY
+    // camp (0 slides each), a confusing far-away error. Retry with a targeted repair
+    // message; throw an actionable narrate-level error if exhausted. Mirrors the
+    // badTrace gate above; a distinct FR `reason:'empty-entries'` lets the next
+    // diagnosis tell "empty" from "bad traces".
+    if ((parsed.entries ?? []).length === 0) {
+      const msg = 'Model returned zero narration entries — narration must cover the deck_spec';
+      if (attempt < MAX_REPAIR_RETRIES) {
+        priorErrors = `${msg}. Emit at least one entry per deck_spec section, each with a valid RFC 6901 trace into the provided JSON.`;
+        recorder?.record({ type: 'system.error' as const, component: 'brief-narrate', level: 'warn' as const, message: msg, data: { reason: 'empty-entries' } });
+        continue;
+      }
+      throw new ActionableError({
+        goal: 'Narrate deck_spec into narration.json',
+        problem: msg,
+        location: LOCATION,
+        nextSteps: [
+          'The model returned an empty entries array (AJV-valid but empty) on every attempt.',
+          'Use a model with stronger structured-output compliance for narration — lite/economy tiers may fail this complex prompt.',
+        ],
+      });
+    }
+
     return {
       deck_spec_version: DECK_SPEC_VERSION,
       narration_mode: 'narrated',


### PR DESCRIPTION
Diagnosis (Diagnostics) validated by TL (t/2872#1). `buildNarratedNarration`'s retry loop gated only on JSON-parse failure + unresolvable traces — both iterate `parsed.entries`, so an EMPTY entries array (AJV-valid, zero bad traces) slipped past both gates → empty narration → verify() symmetry hard-fail for every camp. Surfaced by `Export-TriadDebateBrief -Model gemini-3.5-flash-lite`.

**Fix (mirrors the adjacent badTrace gate — self-cert per TL, no design review):**
- Presence gate: `entries.length===0` → retry with a targeted repair message, then throw an actionable narrate-level error if exhausted.
- Distinct FR event (`data:{reason:'empty-entries'}`) so diagnosis can tell 'empty' from 'bad traces' (AC #2).
- narrate.test.ts: `{entries:[]}` → one retry then ActionableError (AC #3).

**Scope notes:** the 'all-non-camp traces' variant stays with verify's symmetry gate (per TL boundary note — strengthening narrate to it pulls verify's camp logic into narrate, not cheap). Consideration #2 (debateTiers.basic pre-flight) out of scope (spans PS cmdlet).

Gates: nodenext ✓, renderer-tsc 0/0 ✓, vitest 32/32 ✓. Closes t/2872.