### PR TITLE
fix: wire Brief export to table-row ExportDropdown (t/2805 follow-up)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateBriefExports.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateBriefExports.tsx
@@ -9,6 +9,7 @@
 import { useState, type ReactNode } from 'react';
 import { BriefExportDialog } from './BriefExportDialog';
 import { BriefExportsList } from './BriefExportsList';
+import type { SessionRowData } from './DebateTable';
 
 export function useDebateBriefExports(
   debate: { id: string; title: string; phase: string },
@@ -35,4 +36,21 @@ export function useDebateBriefExports(
   );
 
   return { openBrief: () => setShowBrief(true), node };
+}
+
+/** Row-level brief export: manages session selection + dialog mount (t/2805 follow-up). */
+export function useRowBriefExport(
+  isElectron: boolean,
+): { openRowBrief: (s: SessionRowData) => void; rowBriefNode: ReactNode } {
+  const [session, setSession] = useState<SessionRowData | null>(null);
+  const rowBriefNode = session && !isElectron ? (
+    <BriefExportDialog
+      debateId={session.id}
+      debateTitle={session.title}
+      debatePhase={session.phase}
+      onClose={() => setSession(null)}
+      onExported={() => setSession(null)}
+    />
+  ) : null;
+  return { openRowBrief: (s) => setSession(s), rowBriefNode };
 }

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -16,8 +16,7 @@ import { NewDebateDialog } from './NewDebateDialog';
 import { DebateWorkspace } from '../debate-workspace';
 import { filterCommunityDebates } from './communityFilter';
 import { ExportDropdown } from './ExportDropdown';
-import { useDebateBriefExports } from './DebateBriefExports';
-import { BriefExportDialog } from './BriefExportDialog';
+import { useDebateBriefExports, useRowBriefExport } from './DebateBriefExports';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { useAuthStatus } from '../../hooks/useAuthStatus';
 import { SearchPreview } from '../edge-browser/SearchPreview';
@@ -454,9 +453,7 @@ export function DebateTab() {
     }
   }, [runExport]);
 
-  // Brief export triggered from a table row (t/2805 follow-up — wire row ExportDropdown).
-  const [briefRowSession, setBriefRowSession] = useState<SessionRowData | null>(null);
-  const handleRowBrief = useCallback((s: SessionRowData) => setBriefRowSession(s), []);
+  const rowBrief = useRowBriefExport(isElectronMode());
 
   const listProps: DebateListProps = {
     width, listView, setListView, editMode, setEditMode, sessions, sessionsLoading,
@@ -471,7 +468,7 @@ export function DebateTab() {
     onRowExport: (s, fmt) => { void handleRowExport(s, fmt); },
     onRowShare: handleRowShare,
     onRowCommunityExport: (cd, fmt) => { void handleRowCommunityExport(cd, fmt); },
-    onRowBrief: handleRowBrief,
+    onRowBrief: rowBrief.openRowBrief,
   };
 
   const rightPaneProps: DebateRightPaneProps = {
@@ -554,15 +551,7 @@ export function DebateTab() {
           }}
         />
       )}
-      {briefRowSession && !isElectronMode() && (
-        <BriefExportDialog
-          debateId={briefRowSession.id}
-          debateTitle={briefRowSession.title}
-          debatePhase={briefRowSession.phase}
-          onClose={() => setBriefRowSession(null)}
-          onExported={() => setBriefRowSession(null)}
-        />
-      )}
+      {rowBrief.rowBriefNode}
       {showBulkDeleteConfirm && (
         <BulkDeleteDialog
           sessions={sessions}

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -17,6 +17,7 @@ import { DebateWorkspace } from '../debate-workspace';
 import { filterCommunityDebates } from './communityFilter';
 import { ExportDropdown } from './ExportDropdown';
 import { useDebateBriefExports } from './DebateBriefExports';
+import { BriefExportDialog } from './BriefExportDialog';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { useAuthStatus } from '../../hooks/useAuthStatus';
 import { SearchPreview } from '../edge-browser/SearchPreview';
@@ -95,6 +96,7 @@ interface DebateListProps {
   onRowExport: (session: SessionRowData, format: string) => void;
   onRowShare: (session: SessionRowData) => Promise<void>;
   onRowCommunityExport: (cd: CommunityDebate, format: string) => void;
+  onRowBrief: (session: SessionRowData) => void;
 }
 
 // Shared prop bag for the right (detail) pane subtree.
@@ -452,6 +454,10 @@ export function DebateTab() {
     }
   }, [runExport]);
 
+  // Brief export triggered from a table row (t/2805 follow-up — wire row ExportDropdown).
+  const [briefRowSession, setBriefRowSession] = useState<SessionRowData | null>(null);
+  const handleRowBrief = useCallback((s: SessionRowData) => setBriefRowSession(s), []);
+
   const listProps: DebateListProps = {
     width, listView, setListView, editMode, setEditMode, sessions, sessionsLoading,
     selectedIds, setSelectedIds, setShowBulkDeleteConfirm, customOrder, saveCustomOrder,
@@ -465,6 +471,7 @@ export function DebateTab() {
     onRowExport: (s, fmt) => { void handleRowExport(s, fmt); },
     onRowShare: handleRowShare,
     onRowCommunityExport: (cd, fmt) => { void handleRowCommunityExport(cd, fmt); },
+    onRowBrief: handleRowBrief,
   };
 
   const rightPaneProps: DebateRightPaneProps = {
@@ -545,6 +552,15 @@ export function DebateTab() {
               void runExport(fmt, opts);
             }
           }}
+        />
+      )}
+      {briefRowSession && !isElectronMode() && (
+        <BriefExportDialog
+          debateId={briefRowSession.id}
+          debateTitle={briefRowSession.title}
+          debatePhase={briefRowSession.phase}
+          onClose={() => setBriefRowSession(null)}
+          onExported={() => setBriefRowSession(null)}
         />
       )}
       {showBulkDeleteConfirm && (
@@ -668,7 +684,7 @@ function DebateMyList(props: DebateListProps) {
     filteredSessions, activeDebateId, selectedIds, setSelectedIds,
     renamingId, setRenamingId, renameValue, setRenameValue, renameDebate,
     moveSession, handleSelect, nav,
-    onRowOpen, onRowExport, onRowShare,
+    onRowOpen, onRowExport, onRowShare, onRowBrief,
   } = props;
   const isPhone = nav.isActive;
   return (
@@ -705,6 +721,8 @@ function DebateMyList(props: DebateListProps) {
         onOpen={onRowOpen}
         onExport={onRowExport}
         onShare={onRowShare}
+        onBrief={onRowBrief}
+        briefWebOnly={isElectronMode()}
         onPhoneSelect={handleSelect}
         isPhone={isPhone}
         activeDebateId={activeDebateId}

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -59,6 +59,9 @@ export interface DebateTableMyProps {
   onOpen: (id: string) => void;
   onExport: (session: SessionRowData, format: string) => void;
   onShare: (session: SessionRowData) => void;
+  /** Brief export from a table row (t/2805 follow-up). Undefined = item hidden. */
+  onBrief?: (session: SessionRowData) => void;
+  briefWebOnly?: boolean;
   /** Phone nav: row click pushes mobile navigation (desktop: noop). */
   onPhoneSelect: (session: SessionRowData) => void;
   isPhone: boolean;
@@ -243,6 +246,8 @@ interface DebateTableRowProps {
   onOpen: (id: string) => void;
   onExport: (session: SessionRowData, format: string) => void;
   onShare: (session: SessionRowData) => void;
+  onBrief?: (session: SessionRowData) => void;
+  briefWebOnly?: boolean;
   onPhoneSelect: (session: SessionRowData) => void;
   isPhone: boolean;
 }
@@ -250,7 +255,7 @@ interface DebateTableRowProps {
 export function DebateTableRow({
   s, idx, totalRows, isActive, editMode, isSelected,
   onToggleSelect, renamingId, setRenamingId, renameValue, setRenameValue,
-  onRename, onMoveSession, onOpen, onExport, onShare, onPhoneSelect, isPhone,
+  onRename, onMoveSession, onOpen, onExport, onShare, onBrief, briefWebOnly, onPhoneSelect, isPhone,
 }: DebateTableRowProps) {
   const isRenaming = renamingId === s.id;
   const colSpan = editMode ? 7 : 6;
@@ -384,7 +389,7 @@ export function DebateTableRow({
             >
               Open
             </button>
-            <ExportDropdown onExport={fmt => onExport(s, fmt)} />
+            <ExportDropdown onExport={fmt => onExport(s, fmt)} onBrief={onBrief ? () => onBrief(s) : undefined} briefWebOnly={briefWebOnly} />
             <button
               type="button"
               className="debate-table-action-btn"
@@ -602,7 +607,7 @@ function MyTable(props: DebateTableMyProps & { sort: SortState; onSort: (col: So
   const {
     rows, loading, searchQuery, editMode, selectedIds, onToggleSelect,
     renamingId, setRenamingId, renameValue, setRenameValue, onRename,
-    onMoveSession, onOpen, onExport, onShare, onPhoneSelect, isPhone,
+    onMoveSession, onOpen, onExport, onShare, onBrief, briefWebOnly, onPhoneSelect, isPhone,
     activeDebateId, sort, onSort,
   } = props;
 
@@ -678,6 +683,8 @@ function MyTable(props: DebateTableMyProps & { sort: SortState; onSort: (col: So
               onOpen={onOpen}
               onExport={onExport}
               onShare={onShare}
+              onBrief={onBrief}
+              briefWebOnly={briefWebOnly}
               onPhoneSelect={onPhoneSelect}
               isPhone={isPhone}
             />


### PR DESCRIPTION
t/2805 wired the "Brief..." ExportDropdown item only to the detail view (opened debate). The table-row dropdowns had no onBrief prop, so the item never appeared.

Root cause: DebateTable.tsx renders ExportDropdown without onBrief.

Fix: add onBrief/briefWebOnly through the prop chain (DebateTableMyProps to DebateTableRowProps to ExportDropdown) and wire a briefRowSession state + BriefExportDialog mount in the main DebateTab component. On Electron the item shows disabled (web-only v1; electron parity tracked in t/2837).