### PR TITLE
feat(t2873): Test-BriefNarrationStage — run only the brief narrate stage [DRAFT: narrate-cli]

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -73,6 +73,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Show-DebateDiagnostics` | Inspect debate internals |
 | `Repair-DebateOutput` | Fix malformed debate JSON |
 | `Export-TriadDebateBrief` | Export a closed debate to a presentation brief (.pptx). Local mode (`-Path`) runs the offline lib/brief pipeline; server mode (`-DebateId`) is deferred pending AAD auth (t/2839) |
+| `Test-BriefNarrationStage` | Run ONLY the brief narrate stage on a deck_spec + model to debug zero-entry/bad-trace failures without the full pipeline; returns entry count + validation errors (t/2873) |
 
 ### Op-Ed Generation
 | Cmdlet | Use when |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -39,6 +39,7 @@
         'Repair-PovAttributes'
         'Export-AggregatedCruxes'
         'Export-TriadDebateBrief'
+        'Test-BriefNarrationStage'
         'Get-Summary'
         'Invoke-AttributeExtraction'
         'Invoke-EdgeDiscovery'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -779,6 +779,7 @@ Export-ModuleMember -Function @(
     'Repair-PovAttributes'
     'Export-AggregatedCruxes'
     'Export-TriadDebateBrief'
+    'Test-BriefNarrationStage'
     'Get-Summary'
     'Invoke-AttributeExtraction'
     'Invoke-EdgeDiscovery'

--- a/scripts/AITriad/Private/Resolve-BriefNarrateCli.ps1
+++ b/scripts/AITriad/Private/Resolve-BriefNarrateCli.ps1
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Resolve-BriefNarrateCli {
+    <#
+    .SYNOPSIS
+        Resolve the invocation for the shared lib/brief narrate-stage CLI (t/2873).
+    .DESCRIPTION
+        Returns @{ Exe = <string>; ArgPrefix = <string[]> } so the caller invokes:
+            & $inv.Exe @($inv.ArgPrefix + $flagArgs)
+        Isolates the tsx entrypoint decision (owned by lib/brief) from
+        Test-BriefNarrationStage, which only knows the flag interface
+        (--spec/--model + optional --preset/--checker-model/--skip-narration).
+
+        Sibling of Resolve-BriefExportCli: lib/brief's tsconfig is noEmit (no committed
+        .js, no npm bin), and Shared Lib froze the canonical entrypoint as
+        `tsx lib/brief/<cli>.ts` from repo root (t/2837#7). We run the source via
+        `npx tsx lib/brief/narrate-cli.ts` (npx keeps it portable; tsx is a root
+        devDependency). If the entrypoint ever changes, only this function changes.
+        Tests mock this.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    Set-StrictMode -Version Latest
+
+    # Repo root = two levels up from the module (scripts/AITriad → repo root).
+    $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $script:ModuleRoot '..' '..'))
+    $cliPath = Join-Path $repoRoot 'lib' 'brief' 'narrate-cli.ts'
+
+    if (-not (Test-Path -LiteralPath $cliPath -PathType Leaf)) {
+        throw (New-ActionableError `
+                -Goal     'Run the offline brief narrate stage' `
+                -Problem  "The brief narrate-stage CLI was not found at '$cliPath'. It is provided by lib/brief (t/2873) and needs the lib/brief sources in the repo checkout." `
+                -Location 'Resolve-BriefNarrateCli' `
+                -NextSteps @(
+                    'Run from a full repo checkout (where lib/brief lives)',
+                    'Install dependencies (npm ci) — the stage needs tsx AND its runtime packages',
+                    'If lib/brief/narrate-cli.ts has not landed yet, track t/2873'
+                ))
+    }
+
+    return @{ Exe = 'npx'; ArgPrefix = @('--yes', 'tsx', $cliPath) }
+}

--- a/scripts/AITriad/Public/Test-BriefNarrationStage.ps1
+++ b/scripts/AITriad/Public/Test-BriefNarrationStage.ps1
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-BriefNarrationStage {
+    <#
+    .SYNOPSIS
+        Run ONLY the Brief Export narrate stage against a deck_spec, for debugging
+        zero-entry / bad-trace model failures without the full pipeline (t/2873).
+    .DESCRIPTION
+        Wraps the lib/brief narrate-stage CLI (tsx). Loads a deck_spec JSON, runs the
+        single narrate() model call, and reports what came back — entry count, audience
+        questions, checker pass/fail, and any schema/trace validation errors — WITHOUT
+        running extract → render → verify.
+
+        Narration failure is DATA, not an exception: a zero-entry or bad-trace result
+        returns normally with Errors populated and EntryCount 0 (that IS the diagnostic).
+        Only infrastructure faults (missing spec file, CLI crash) raise a non-terminating
+        error, so a pipeline of specs survives one bad input.
+    .PARAMETER SpecPath
+        Path to a deck_spec JSON. Binds FullName from the pipeline.
+    .PARAMETER Model
+        Narrator model id. Required unless -SkipNarration.
+    .PARAMETER Preset
+        policymaker | conference (default) | classroom — drives compression.
+    .PARAMETER CheckerModel
+        Optional maker-checker model; when set, CheckerPassed reflects its verdict.
+    .PARAMETER SkipNarration
+        Deterministic (verbatim) narration with zero model calls — the control case.
+    .OUTPUTS
+        [PSCustomObject] with SpecPath, Model, Preset, EntryCount, AudienceQuestionCount,
+        Errors (string[]), CheckerPassed (nullable), Narration (raw parsed object).
+    .EXAMPLE
+        Test-BriefNarrationStage -SpecPath .\deck_spec.json -Model gemini-3.5-flash-lite
+    .EXAMPLE
+        Get-ChildItem *deck_spec.json | Test-BriefNarrationStage -SkipNarration
+    .LINK
+        Export-TriadDebateBrief
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName, Position = 0)]
+        [Alias('FullName')]
+        [string]$SpecPath,
+
+        [Parameter()]
+        [string]$Model,
+
+        [Parameter()]
+        [ValidateSet('policymaker', 'conference', 'classroom')]
+        [string]$Preset = 'conference',
+
+        [Parameter()]
+        [string]$CheckerModel,
+
+        [Parameter()]
+        [switch]$SkipNarration
+    )
+
+    begin {
+        Set-StrictMode -Version Latest
+
+        $WriteStageError = {
+            param([string]$Id, [string]$Message, $TargetObject)
+            $rec = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new($Message), $Id,
+                [System.Management.Automation.ErrorCategory]::InvalidOperation, $TargetObject)
+            $PSCmdlet.WriteError($rec)   # non-terminating; honors -ErrorAction Stop
+        }
+    }
+
+    process {
+        if (-not (Test-Path -LiteralPath $SpecPath -PathType Leaf)) {
+            & $WriteStageError 'SpecFileInvalid' "deck_spec file not found: $SpecPath" $SpecPath; return
+        }
+        if (-not $SkipNarration -and -not $Model) {
+            & $WriteStageError 'ModelUnavailable' 'Narration requires -Model unless -SkipNarration.' $SpecPath; return
+        }
+
+        $ResolvedSpec = (Resolve-Path -LiteralPath $SpecPath).Path
+        $Inv = Resolve-BriefNarrateCli
+
+        # Frozen flags (t/2873#2): --spec/--model + optional --preset/--checker-model/--skip-narration.
+        $CliArgs = @('--spec', $ResolvedSpec, '--preset', $Preset)
+        if ($SkipNarration) { $CliArgs += '--skip-narration' } else { $CliArgs += @('--model', $Model) }
+        if ($CheckerModel)  { $CliArgs += @('--checker-model', $CheckerModel) }
+        $AllArgs = @($Inv.ArgPrefix) + $CliArgs
+
+        $StderrFile = [System.IO.Path]::GetTempFileName()
+        try {
+            $Stdout = & $Inv.Exe @AllArgs 2> $StderrFile
+            $Exit = $LASTEXITCODE
+            $Stderr = if (Test-Path $StderrFile) { Get-Content -Raw -Path $StderrFile } else { '' }
+        }
+        finally {
+            Remove-Item -Path $StderrFile -Force -ErrorAction SilentlyContinue
+        }
+
+        # exit != 0 = infra/arg fault (spec unreadable, CLI crash), NOT a narration
+        # failure. Surface the CLI's {errorCode,message} as a non-terminating error.
+        if ($Exit -ne 0) {
+            $errObj = $null
+            try {
+                $errLine = @(($Stderr -split "`n") | Where-Object { $_ -match '"errorCode"' }) | Select-Object -First 1
+                if ($errLine) { $errObj = $errLine | ConvertFrom-Json }
+            } catch { }
+            $id  = if ($errObj -and $errObj.PSObject.Properties['errorCode']) { [string]$errObj.errorCode } else { 'NarrateCliFailure' }
+            $msg = if ($errObj -and $errObj.PSObject.Properties['message'])   { [string]$errObj.message }   else { "narrate CLI exited with code $Exit" }
+            & $WriteStageError $id $msg $ResolvedSpec; return
+        }
+
+        $result = $null
+        try { $result = @($Stdout) -join "`n" | ConvertFrom-Json }
+        catch { & $WriteStageError 'NarrateCliFailure' 'Could not parse the narrate CLI output as JSON.' $ResolvedSpec; return }
+
+        $get = { param($n) if ($result -and $result.PSObject.Properties[$n]) { $result.$n } else { $null } }
+
+        $checkerPassed = $null
+        $checker = & $get 'checkerReport'
+        if ($checker -and $checker.PSObject.Properties['passed']) { $checkerPassed = [bool]$checker.passed }
+
+        [PSCustomObject]@{
+            SpecPath              = $ResolvedSpec
+            Model                 = if ($SkipNarration) { '(none — narration skipped)' } else { $Model }
+            Preset                = $Preset
+            EntryCount            = [int](& { $v = & $get 'entryCount'; if ($null -ne $v) { $v } else { 0 } })
+            AudienceQuestionCount = [int](& { $v = & $get 'audienceQuestionCount'; if ($null -ne $v) { $v } else { 0 } })
+            Errors                = @(& { $e = & $get 'errors'; if ($e) { $e } else { @() } })
+            CheckerPassed         = $checkerPassed
+            Narration             = & $get 'narration'
+        }
+    }
+}

--- a/scripts/AITriad/Public/Test-BriefNarrationStage.ps1
+++ b/scripts/AITriad/Public/Test-BriefNarrationStage.ps1
@@ -109,9 +109,16 @@ function Test-BriefNarrationStage {
             & $WriteStageError $id $msg $ResolvedSpec; return
         }
 
+        # Assert OUTPUT, not just exit 0 (t/2874): a broken entrypoint can exit 0 with
+        # NO stdout — never let that parse into a fake zero-entry result.
+        if ([string]::IsNullOrWhiteSpace((@($Stdout) -join ''))) {
+            & $WriteStageError 'NarrateCliFailure' 'The narrate CLI exited 0 but produced no output — treat as failure, not an empty result (broken entrypoint / t/2868).' $ResolvedSpec; return
+        }
+
         $result = $null
         try { $result = @($Stdout) -join "`n" | ConvertFrom-Json }
         catch { & $WriteStageError 'NarrateCliFailure' 'Could not parse the narrate CLI output as JSON.' $ResolvedSpec; return }
+        if ($null -eq $result) { & $WriteStageError 'NarrateCliFailure' 'The narrate CLI output parsed to null — no result emitted.' $ResolvedSpec; return }
 
         $get = { param($n) if ($result -and $result.PSObject.Properties[$n]) { $result.$n } else { $null } }
 

--- a/tests/Test-BriefNarrationStage.Tests.ps1
+++ b/tests/Test-BriefNarrationStage.Tests.ps1
@@ -1,0 +1,149 @@
+# Tag: debate (t/2873)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Test-BriefNarrationStage (t/2873) — narrate-stage debug wrapper.
+.DESCRIPTION
+    Covers flag pass-through, the happy path, narration-failure-as-DATA (errors[] +
+    EntryCount 0 returned, not thrown), -SkipNarration, checker verdict, and the
+    input guards + infra-fault path — all against pwsh stubs for the narrate CLI
+    (mocked via Resolve-BriefNarrateCli).
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    $script:StubDir = Join-Path ([System.IO.Path]::GetTempPath()) "narr-stub-$(New-Guid)"
+    New-Item -ItemType Directory -Path $script:StubDir -Force | Out-Null
+    $script:ArgsFile = Join-Path $script:StubDir 'last-args.txt'
+    $script:PwshExe = (Get-Process -Id $PID).Path
+
+    # Success: 3 entries, 2 audience questions, checker passed, no errors.
+    $script:OkStub = Join-Path $script:StubDir 'ok.ps1'
+    Set-Content -LiteralPath $script:OkStub -Encoding UTF8 -Value @'
+$args -join "`n" | Set-Content -LiteralPath (Join-Path $PSScriptRoot 'last-args.txt') -Encoding UTF8
+$o = @{
+    entryCount = 3; audienceQuestionCount = 2
+    narration = @{ narration_mode = 'narrated'; entries = @(1, 2, 3) }
+    checkerReport = @{ passed = $true }
+    errors = @()
+}
+Write-Output ($o | ConvertTo-Json -Compress -Depth 6)
+exit 0
+'@
+
+    # Completed run but the model produced a bad result: zero entries + errors[]. This
+    # is DATA (exit 0), not an exception — the whole point of the diagnostic.
+    $script:DataFailStub = Join-Path $script:StubDir 'datafail.ps1'
+    Set-Content -LiteralPath $script:DataFailStub -Encoding UTF8 -Value @'
+$o = @{
+    entryCount = 0; audienceQuestionCount = 0; narration = $null
+    errors = @("narration/entries: must NOT have fewer than 1 items", "trace /cruxes/9 unresolvable")
+}
+Write-Output ($o | ConvertTo-Json -Compress -Depth 6)
+exit 0
+'@
+
+    # Infra fault: bad spec file etc. → exit != 0 + {errorCode,message} on stderr.
+    $script:InfraFailStub = Join-Path $script:StubDir 'infrafail.ps1'
+    Set-Content -LiteralPath $script:InfraFailStub -Encoding UTF8 -Value @'
+[Console]::Error.WriteLine((@{ errorCode = "SpecSchemaFailure"; message = "deck_spec did not match schema" } | ConvertTo-Json -Compress))
+exit 1
+'@
+
+    function New-SpecFile {
+        $f = Join-Path $script:StubDir "spec-$(New-Guid).json"
+        Set-Content -LiteralPath $f -Value '{"deck_spec_version":"1.0"}' -Encoding UTF8
+        $f
+    }
+}
+
+AfterAll {
+    Remove-Item -LiteralPath $script:StubDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Test-BriefNarrationStage' -Tag 'debate' {
+
+    Context 'Input guards (non-terminating)' {
+        It 'emits SpecFileInvalid for a missing -SpecPath' {
+            $err = $null
+            Test-BriefNarrationStage -SpecPath (Join-Path $script:StubDir 'nope.json') -Model m -ErrorVariable err -ErrorAction SilentlyContinue
+            $err[0].FullyQualifiedErrorId | Should -Match 'SpecFileInvalid'
+        }
+
+        It 'emits ModelUnavailable when neither -Model nor -SkipNarration is given' {
+            $f = New-SpecFile
+            $err = $null
+            Test-BriefNarrationStage -SpecPath $f -ErrorVariable err -ErrorAction SilentlyContinue
+            $err[0].FullyQualifiedErrorId | Should -Match 'ModelUnavailable'
+        }
+    }
+
+    Context 'Happy path' {
+        BeforeEach {
+            Mock -ModuleName AITriad Resolve-BriefNarrateCli {
+                @{ Exe = $script:PwshExe; ArgPrefix = @('-NoProfile', '-File', $script:OkStub) }
+            }
+        }
+
+        It 'returns entry/audience counts, checker verdict, and raw narration; passes --spec/--model/--preset' {
+            $f = New-SpecFile
+            $r = Test-BriefNarrationStage -SpecPath $f -Model gemini-3.5-flash-lite -Preset classroom
+            $r | Should -BeOfType ([pscustomobject])
+            $r.EntryCount | Should -Be 3
+            $r.AudienceQuestionCount | Should -Be 2
+            $r.CheckerPassed | Should -BeTrue
+            $r.Errors.Count | Should -Be 0
+            $r.Narration.narration_mode | Should -Be 'narrated'
+            $r.Preset | Should -Be 'classroom'
+
+            $sent = Get-Content -Raw -LiteralPath $script:ArgsFile
+            $sent | Should -Match '--spec'
+            $sent | Should -Match '--model'
+            $sent | Should -Match 'classroom'
+            $sent | Should -Not -Match '--skip-narration'
+        }
+
+        It 'passes --skip-narration and no --model under -SkipNarration' {
+            $f = New-SpecFile
+            $r = Test-BriefNarrationStage -SpecPath $f -SkipNarration
+            $r.Model | Should -Match 'skipped'
+            $sent = Get-Content -Raw -LiteralPath $script:ArgsFile
+            $sent | Should -Match '--skip-narration'
+            $sent | Should -Not -Match '--model'
+        }
+    }
+
+    Context 'Narration failure is DATA, not an exception' {
+        It 'returns EntryCount 0 + populated Errors without throwing or writing an error' {
+            Mock -ModuleName AITriad Resolve-BriefNarrateCli {
+                @{ Exe = $script:PwshExe; ArgPrefix = @('-NoProfile', '-File', $script:DataFailStub) }
+            }
+            $f = New-SpecFile
+            $err = $null
+            $r = Test-BriefNarrationStage -SpecPath $f -Model m -ErrorVariable err
+            @($err).Count | Should -Be 0
+            $r.EntryCount | Should -Be 0
+            $r.Errors.Count | Should -Be 2
+            ($r.Errors -join ';') | Should -Match 'unresolvable'
+            $r.Narration | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Infra fault (exit != 0) maps the CLI errorCode' {
+        It 'surfaces the CLI {errorCode} as a non-terminating error' {
+            Mock -ModuleName AITriad Resolve-BriefNarrateCli {
+                @{ Exe = $script:PwshExe; ArgPrefix = @('-NoProfile', '-File', $script:InfraFailStub) }
+            }
+            $f = New-SpecFile
+            $err = $null
+            Test-BriefNarrationStage -SpecPath $f -Model m -ErrorVariable err -ErrorAction SilentlyContinue
+            $err[0].FullyQualifiedErrorId | Should -Match 'SpecSchemaFailure'
+        }
+    }
+}

--- a/tests/Test-BriefNarrationStage.Tests.ps1
+++ b/tests/Test-BriefNarrationStage.Tests.ps1
@@ -56,6 +56,10 @@ exit 0
 exit 1
 '@
 
+    # False-green (t/2874): a broken entrypoint exits 0 with NO stdout.
+    $script:EmptyStub = Join-Path $script:StubDir 'empty.ps1'
+    Set-Content -LiteralPath $script:EmptyStub -Encoding UTF8 -Value 'exit 0'
+
     function New-SpecFile {
         $f = Join-Path $script:StubDir "spec-$(New-Guid).json"
         Set-Content -LiteralPath $f -Value '{"deck_spec_version":"1.0"}' -Encoding UTF8
@@ -132,6 +136,20 @@ Describe 'Test-BriefNarrationStage' -Tag 'debate' {
             $r.Errors.Count | Should -Be 2
             ($r.Errors -join ';') | Should -Match 'unresolvable'
             $r.Narration | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'False-green guard: exit 0 with no output' {
+        It 'raises an error instead of returning an empty zero-entry result' {
+            Mock -ModuleName AITriad Resolve-BriefNarrateCli {
+                @{ Exe = $script:PwshExe; ArgPrefix = @('-NoProfile', '-File', $script:EmptyStub) }
+            }
+            $f = New-SpecFile
+            $err = $null
+            $out = Test-BriefNarrationStage -SpecPath $f -Model m -ErrorVariable err -ErrorAction SilentlyContinue
+            $out | Should -BeNullOrEmpty
+            $err[0].FullyQualifiedErrorId | Should -Match 'NarrateCliFailure'
+            $err[0].Exception.Message | Should -Match 'no output'
         }
     }
 


### PR DESCRIPTION
## t/2873 — `Test-BriefNarrationStage` (Diagnostics request)

Debug zero-entry / bad-trace narration model failures by running **only** the narrate stage on a `deck_spec`, without extract→narrate→render→verify.

**Draft** — gated on Shared Lib's `lib/brief/narrate-cli.ts` (they own it; accepted the t/2873#2 contract, building after t/2872). `Resolve-BriefNarrateCli` throws until it lands; un-draft + wire once they hand over the frozen invocation (same flow as Export/t/2837).

### Cmdlet
- Params: `-SpecPath` (deck_spec, pipeline `FullName`), `-Model`, `-Preset` (default `conference`), `-CheckerModel`, `-SkipNarration`.
- Returns `[PSCustomObject]`: `SpecPath, Model, Preset, EntryCount, AudienceQuestionCount, Errors[], CheckerPassed, Narration`.
- **Narration failure is DATA, not an exception** — a zero-entry / bad-trace result returns with `Errors` populated + `EntryCount 0` (the diagnostic). Only infra faults (missing spec, CLI crash) raise a non-terminating error, so a pipeline of specs survives one.
- Invocation mirrors `Export-TriadDebateBrief`: `npx tsx <narrate-cli>` via `Resolve-BriefNarrateCli`.

### Verification
6 Pester tests green (input guards, happy path with `--spec/--model/--preset` pass-through, `-SkipNarration`, failure-as-data, infra errorCode mapping) + module-parity suite (38) + `Test-ModuleManifest`. `Get-Command Test-BriefNarrationStage` succeeds.

Self-cert: **/add-ps-cmdlet**, no PS-side deviations. The lib/brief entrypoint is Shared Lib's scope (consistent with t/2837).

🤖 Generated with [Claude Code](https://claude.com/claude-code)