### PR TITLE
feat(brief): narrate-stage debug CLI — lib/brief/narrate-cli.ts (t/2873)

### DIFF
--- a/lib/brief/narrate-cli.test.ts
+++ b/lib/brief/narrate-cli.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Tests for the narrate-stage debug CLI (t/2873). narrate() + the adapter/repo
+// resolvers are mocked — this asserts the CLI's contract: arg parsing, the one-line
+// JSON output, and the KEY behavior — a narrate() throw is CAPTURED into errors[]
+// (exit 0, narration=null), not propagated; only spec-file/arg faults exit ≠0.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('./narrate.js', () => ({ narrate: vi.fn() }));
+vi.mock('../debate/aiAdapter.js', () => ({ createCLIAdapter: vi.fn(() => ({ generateText: vi.fn() })) }));
+vi.mock('../debate/taxonomyLoader.js', () => ({ resolveRepoRoot: vi.fn(() => '/repo') }));
+
+import { narrate } from './narrate.js';
+import { createCLIAdapter } from '../debate/aiAdapter.js';
+import { runCli, parseArgs } from './narrate-cli.js';
+
+const narration = {
+  deck_spec_version: '1.0', narration_mode: 'narrated', preset: 'conference',
+  narrator_model: 'm', narrator_model_source: 'Explicit', checker_model: null,
+  checker_model_source: null, checker_passed: null,
+  entries: [{ trace: '/cruxes/0', text: 'x' }],
+  audience_questions: [{ trace: '/cruxes/0', question: 'q?' }],
+};
+
+let dir: string;
+let specPath: string;
+let outSpy: Mock;
+let errSpy: Mock;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  dir = await mkdtemp(join(tmpdir(), 'narrate-cli-'));
+  specPath = join(dir, 'deck_spec.json');
+  await writeFile(specPath, JSON.stringify({ meta: { id: 's1', title: 'T' }, cruxes: [{ text: 'c' }] }));
+  outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true) as unknown as Mock;
+  errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true) as unknown as Mock;
+});
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await rm(dir, { recursive: true, force: true });
+});
+
+const stdout = () => outSpy.mock.calls.map(c => String(c[0])).join('');
+const stderr = () => errSpy.mock.calls.map(c => String(c[0])).join('');
+
+describe('parseArgs', () => {
+  it('requires --spec and --model', () => {
+    expect(() => parseArgs(['--model', 'm'])).toThrow(/required/);
+    expect(() => parseArgs(['--spec', 's'])).toThrow(/required/);
+  });
+  it('rejects an unknown preset', () => {
+    expect(() => parseArgs(['--spec', 's', '--model', 'm', '--preset', 'nope'])).toThrow(/preset/);
+  });
+});
+
+describe('runCli', () => {
+  it('success → exit 0, one JSON line with entry/question counts + narration', async () => {
+    (narrate as Mock).mockResolvedValue({ narration });
+    const r = await runCli(['--spec', specPath, '--model', 'gemini']);
+    expect(r.exitCode).toBe(0);
+    const lines = stdout().trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.entryCount).toBe(1);
+    expect(parsed.audienceQuestionCount).toBe(1);
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.narration.entries).toHaveLength(1);
+  });
+
+  it('CAPTURES a narrate() throw into errors[] — exit 0, narration null, entryCount 0', async () => {
+    (narrate as Mock).mockRejectedValue(new Error('Model returned zero narration entries — narration must cover the deck_spec'));
+    const r = await runCli(['--spec', specPath, '--model', 'gemini-3.5-flash-lite']);
+    expect(r.exitCode).toBe(0); // a completed-but-failed narrate is DATA, not an error
+    expect(stderr()).toBe('');
+    const parsed = JSON.parse(stdout().trim());
+    expect(parsed.entryCount).toBe(0);
+    expect(parsed.narration).toBeNull();
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors[0]).toMatch(/zero narration entries/);
+  });
+
+  it('includes checkerReport when narrate returns one', async () => {
+    (narrate as Mock).mockResolvedValue({ narration, checkerReport: { passed: true, fidelity_failures: [], symmetry: {} } });
+    await runCli(['--spec', specPath, '--model', 'gemini', '--checker-model', 'c1']);
+    const parsed = JSON.parse(stdout().trim());
+    expect(parsed.checkerReport.passed).toBe(true);
+  });
+
+  it('bad spec file → SpecFileInvalid on stderr, exit 1, narrate not called', async () => {
+    const r = await runCli(['--spec', join(dir, 'missing.json'), '--model', 'gemini']);
+    expect(r.exitCode).toBe(1);
+    expect(JSON.parse(stderr().trim()).errorCode).toBe('SpecFileInvalid');
+    expect(narrate).not.toHaveBeenCalled();
+  });
+
+  it('--skip-narration does NOT build a model adapter', async () => {
+    (narrate as Mock).mockResolvedValue({ narration });
+    await runCli(['--spec', specPath, '--model', 'gemini', '--skip-narration']);
+    expect(createCLIAdapter).not.toHaveBeenCalled();
+  });
+});

--- a/lib/brief/narrate-cli.ts
+++ b/lib/brief/narrate-cli.ts
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Brief NARRATE-stage debug CLI (t/2873). Runs ONLY narrate() on a loaded deck_spec —
+// no extract/render/verify — so a model's narration output can be inspected in
+// isolation while diagnosing zero-entry / bad-trace failures (the t/2872 class).
+// Consumed by PowerShell's Test-BriefNarrationStage (contract: t/2873#2), wrapped
+// via tsx the same way Export-TriadDebateBrief wraps the full-pipeline cli.ts.
+//
+//   tsx lib/brief/narrate-cli.ts --spec <deck_spec.json> --model <id> \
+//     [--preset conference] [--checker-model <id>] [--skip-narration]
+//
+// Output contract (t/2873#2):
+//   A COMPLETED narrate run — success OR failure — is DATA, not an error: stdout gets
+//   exactly one JSON line { entryCount, audienceQuestionCount, narration, checkerReport?,
+//   errors } and the process exits 0. A narrate() throw (schema/trace/model) is CAPTURED
+//   into errors[] with narration=null/entryCount=0 — the diagnostic wants to see the
+//   failed output, not a stack trace. Only arg / spec-file / infra faults exit ≠0 with a
+//   { errorCode, message } line on stderr (same shape as cli.ts).
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { ActionableError, errorMessage } from '../debate/errors.js';
+import { createCLIAdapter } from '../debate/aiAdapter.js';
+import { resolveRepoRoot } from '../debate/taxonomyLoader.js';
+import type { AIAdapter } from '../debate/aiAdapter.js';
+import { narrate } from './narrate.js';
+import type { CheckerReport } from './narrate.js';
+import type { DeckSpec, Narration, BriefPreset, ModelSource } from './types.js';
+
+const LOCATION = 'lib/brief/narrate-cli.ts';
+const PRESETS: readonly BriefPreset[] = ['policymaker', 'conference', 'classroom'];
+const MODEL_SOURCES: readonly ModelSource[] = ['Explicit', 'Global', 'Default'];
+
+/** exit≠0 codes — infra/arg/spec-file faults ONLY (a narrate failure is DATA, not this). */
+export type NarrateCliErrorCode = 'SpecFileInvalid';
+
+export interface NarrateCliArgs {
+  spec: string;
+  model: string;
+  modelSource: ModelSource;
+  preset: BriefPreset;
+  checkerModel?: string;
+  checkerModelSource?: ModelSource;
+  skipNarration: boolean;
+}
+
+/** One JSON line on stdout for a completed run. */
+export interface NarrateCliOutput {
+  entryCount: number;
+  audienceQuestionCount: number;
+  narration: Narration | null;
+  checkerReport?: CheckerReport;
+  errors: string[];
+}
+
+function fail(problem: string, nextSteps: string[]): never {
+  throw new ActionableError({
+    goal: 'Run the Brief narrate stage in isolation on a deck_spec',
+    problem,
+    location: LOCATION,
+    nextSteps,
+  });
+}
+
+export function parseArgs(argv: string[]): NarrateCliArgs {
+  const map = new Map<string, string>();
+  let skipNarration = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--skip-narration') { skipNarration = true; continue; }
+    if (a.startsWith('--')) { map.set(a.slice(2), argv[++i]); }
+  }
+
+  const spec = map.get('spec');
+  const model = map.get('model');
+  if (!spec || !model) {
+    fail('--spec and --model are required', [
+      'tsx lib/brief/narrate-cli.ts --spec <deck_spec.json> --model <id> [--preset conference] [--checker-model <id>] [--skip-narration]',
+    ]);
+  }
+
+  const preset = (map.get('preset') ?? 'conference') as BriefPreset;
+  if (!PRESETS.includes(preset)) fail(`Unknown preset "${preset}"`, [`Use one of: ${PRESETS.join(', ')}`]);
+
+  const modelSource = (map.get('model-source') ?? 'Explicit') as ModelSource;
+  if (!MODEL_SOURCES.includes(modelSource)) fail(`Unknown model-source "${modelSource}"`, [`Use one of: ${MODEL_SOURCES.join(', ')}`]);
+  const checkerModelSource = map.get('checker-model-source') as ModelSource | undefined;
+  if (checkerModelSource && !MODEL_SOURCES.includes(checkerModelSource)) {
+    fail(`Unknown checker-model-source "${checkerModelSource}"`, [`Use one of: ${MODEL_SOURCES.join(', ')}`]);
+  }
+
+  return {
+    spec: spec!,
+    model: model!,
+    modelSource,
+    preset,
+    checkerModel: map.get('checker-model'),
+    checkerModelSource,
+    skipNarration,
+  };
+}
+
+function emitError(code: NarrateCliErrorCode, message: string): void {
+  process.stderr.write(JSON.stringify({ errorCode: code, message }) + '\n');
+}
+
+/** Guard adapter for --skip-narration: narrate() builds deterministic narration
+ *  without a model, so an actual call is a bug, not a silent no-op. */
+const skipNarrationGuardAdapter: AIAdapter = {
+  generateText: async () => {
+    throw new ActionableError({
+      goal: 'Produce narration text',
+      problem: 'The model adapter was invoked under --skip-narration (deterministic mode)',
+      location: LOCATION,
+      nextSteps: ['Remove --skip-narration to narrate with a model, or report this as a bug'],
+    });
+  },
+};
+
+export interface RunResult { exitCode: number }
+
+export async function runCli(argv: string[]): Promise<RunResult> {
+  let args: NarrateCliArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    process.stderr.write((err instanceof ActionableError ? err.message : String(err)) + '\n');
+    return { exitCode: 2 };
+  }
+
+  // ── read + parse the deck_spec (a bad/unreadable spec file is an infra fault → exit≠0) ──
+  let spec: DeckSpec;
+  try {
+    const parsed = JSON.parse(await readFile(args.spec, 'utf8')) as unknown;
+    if (!parsed || typeof parsed !== 'object') throw new Error('deck_spec is not a JSON object');
+    spec = parsed as DeckSpec;
+  } catch (err) {
+    emitError('SpecFileInvalid', `Cannot read/parse deck_spec at ${args.spec}: ${errorMessage(err)}`);
+    return { exitCode: 1 };
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = resolveRepoRoot(__dirname);
+  const adapter = args.skipNarration ? skipNarrationGuardAdapter : createCLIAdapter(repoRoot);
+
+  // ── run ONLY narrate; CAPTURE a throw into errors[] (it is the diagnostic, not a fault) ──
+  const out: NarrateCliOutput = { entryCount: 0, audienceQuestionCount: 0, narration: null, errors: [] };
+  try {
+    const { narration, checkerReport } = await narrate({
+      spec,
+      preset: args.preset,
+      modelId: args.model,
+      modelSource: args.modelSource,
+      checkerModelId: args.checkerModel,
+      checkerModelSource: args.checkerModelSource,
+      skipNarration: args.skipNarration,
+    }, adapter);
+    out.narration = narration;
+    out.entryCount = narration.entries.length;
+    out.audienceQuestionCount = narration.audience_questions.length;
+    if (checkerReport) out.checkerReport = checkerReport;
+  } catch (err) {
+    out.errors.push(errorMessage(err));
+  }
+
+  process.stdout.write(JSON.stringify(out) + '\n');
+  return { exitCode: 0 };
+}
+
+// Executed directly (not imported): run over process.argv and set the exit code.
+// Resolved-path guard (compare fileURLToPath === path.resolve(argv[1])) — a hand-built
+// file:// string compare silently fails on Windows (t/2868).
+const invokedDirectly = process.argv[1] !== undefined
+  && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (invokedDirectly) {
+  runCli(process.argv.slice(2))
+    .then(r => { process.exitCode = r.exitCode; })
+    .catch((e: unknown) => {
+      // Last-resort infra fault (e.g. adapter/registry construction) — wire-shaped error line.
+      process.stderr.write(JSON.stringify({ errorCode: 'SpecFileInvalid', message: String(e) }) + '\n');
+      process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
The Shared Lib half of t/2873 — the narrate-only entrypoint PowerShell's `Test-BriefNarrationStage` (#1333, draft) wraps. Runs ONLY `narrate()` on a loaded deck_spec; no extract/render/verify.

**Frozen invocation:** `tsx lib/brief/narrate-cli.ts --spec <deck_spec.json> --model <id> [--preset conference] [--checker-model <id>] [--checker-model-source <s>] [--model-source <s>] [--skip-narration]`

**Output contract (t/2873#2):**
- A COMPLETED run (success OR failure) is DATA → stdout = one JSON line `{ entryCount, audienceQuestionCount, narration, checkerReport?, errors }`, **exit 0**.
- A `narrate()` throw (schema/trace/model — incl. the t/2872 empty-entries error) is **CAPTURED** into `errors[]` (narration=null, entryCount=0) — the diagnostic sees the failed output, not a stack trace.
- Only arg / spec-file / infra faults exit ≠0 with `{errorCode,message}` on stderr. Resolved-path invokedDirectly guard (Windows-safe, t/2868).

Thin entrypoint mirroring cli.ts (t/2837 precedent) over existing `narrate()` — no new shared module/API; self-cert. PowerShell owns the consuming contract.

Verify: 7 unit tests (capture-throw→errors[]/exit0, success, checkerReport, bad-spec→exit1, skip-narration guard). Live smoke: `--skip-narration` → entryCount 10, exit 0, clean stderr. nodenext ✓, renderer-tsc 0/0 ✓, no new dep. Unblocks #1333.