### PR TITLE
fix(t2873): Test-BriefNarrationStage — always pass --model (narrate-cli requires it)

### DIFF
--- a/scripts/AITriad/Public/Test-BriefNarrationStage.ps1
+++ b/scripts/AITriad/Public/Test-BriefNarrationStage.ps1
@@ -80,9 +80,14 @@ function Test-BriefNarrationStage {
         $ResolvedSpec = (Resolve-Path -LiteralPath $SpecPath).Path
         $Inv = Resolve-BriefNarrateCli
 
-        # Frozen flags (t/2873#2): --spec/--model + optional --preset/--checker-model/--skip-narration.
-        $CliArgs = @('--spec', $ResolvedSpec, '--preset', $Preset)
-        if ($SkipNarration) { $CliArgs += '--skip-narration' } else { $CliArgs += @('--model', $Model) }
+        # Frozen flags (t/2873#2): --spec/--model required + optional
+        # --preset/--checker-model/--skip-narration. The CLI requires --model on EVERY
+        # run (records it even in deterministic mode); -SkipNarration is additive, not a
+        # replacement — omitting --model makes the CLI exit non-zero (the t/2874 bug in
+        # the sibling Export cmdlet). Under skip without a model, pass the sentinel.
+        $resolvedModel = if ($Model) { $Model } elseif ($SkipNarration) { 'deterministic' } else { $Model }
+        $CliArgs = @('--spec', $ResolvedSpec, '--preset', $Preset, '--model', $resolvedModel)
+        if ($SkipNarration) { $CliArgs += '--skip-narration' }
         if ($CheckerModel)  { $CliArgs += @('--checker-model', $CheckerModel) }
         $AllArgs = @($Inv.ArgPrefix) + $CliArgs
 

--- a/tests/Test-BriefNarrationStage.Tests.ps1
+++ b/tests/Test-BriefNarrationStage.Tests.ps1
@@ -113,13 +113,14 @@ Describe 'Test-BriefNarrationStage' -Tag 'debate' {
             $sent | Should -Not -Match '--skip-narration'
         }
 
-        It 'passes --skip-narration and no --model under -SkipNarration' {
+        It 'passes --skip-narration AND --model (sentinel) under -SkipNarration (CLI requires --model always)' {
             $f = New-SpecFile
             $r = Test-BriefNarrationStage -SpecPath $f -SkipNarration
             $r.Model | Should -Match 'skipped'
             $sent = Get-Content -Raw -LiteralPath $script:ArgsFile
             $sent | Should -Match '--skip-narration'
-            $sent | Should -Not -Match '--model'
+            $sent | Should -Match '--model'
+            $sent | Should -Match 'deterministic'
         }
     }
 


### PR DESCRIPTION
## Follow-up to #1333 — fix the `--model`-under-skip bug

#1333 merged (14:56) with the narrate cmdlet + the empty-output guard, but **before** I fixed a `--model` bug that the sibling Export cmdlet's real E2E (t/2874) had just surfaced. So `main`'s `Test-BriefNarrationStage -SkipNarration` is broken the same way Export was.

**Bug:** the wrapper passed `--skip-narration` but **not `--model`**, yet **narrate-cli requires `--model` on every run** (records it even in deterministic mode) → CLI exits non-zero. Now `--model` is always passed (sentinel `deterministic` when skip + no `-Model`); `--skip-narration` is additive. The old unit test asserting "`--model` absent under skip" encoded the bug — corrected.

**Verified against the real landed narrate-cli** (`8056b061`): `--model deterministic --skip-narration` on a real `deck_spec` → exit 0, `{"entryCount":90,"audienceQuestionCount":4,"narration":{…}}` — the exact contract the cmdlet parses (and proof the `--model` sentinel is required; without it the CLI fails). 7 unit tests green.

Self-cert: scoped bug fix (mirror of t/2874 in the sibling cmdlet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)