### PR TITLE
fix(container): wait for in-progress CI run before checking job status

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -90,6 +90,18 @@ jobs:
             }
           fi
 
+          # If the run is still in progress (found via fast path, not dispatched here),
+          # wait for it to complete before checking individual job conclusions.
+          RUN_STATUS=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}" \
+            --jq '.status' 2>/dev/null || echo "")
+          if [ "$RUN_STATUS" = "in_progress" ] || [ "$RUN_STATUS" = "queued" ]; then
+            echo "CI run ${RUN_ID} is still ${RUN_STATUS} — waiting for completion..."
+            gh run watch "${RUN_ID}" --exit-status || {
+              echo "::error::CI run ${RUN_ID} failed. Container build blocked until CI passes."
+              exit 1
+            }
+          fi
+
           # Check only test-container — it needs: [test-powershell, test-electron]
           # so if it passed, all upstream jobs passed too. Checking test-electron
           # by name fails because the matrix creates per-app jobs (e.g. "test-electron (taxonomy-editor)").


### PR DESCRIPTION
## Summary
- Add a `gh run watch` in the ci-gate fast path (when a CI run already exists for the SHA)

## Problem
The ci-gate fast path found an existing CI run but immediately queried job conclusions without waiting. If the run was still `in_progress`, it exited with an error requiring a manual redispatch. The dispatch/fallback path already had a `gh run watch` — the fast path did not.

## Fix
Before the job-status loop, check the run's status and call `gh run watch --exit-status` if it's `in_progress` or `queued`. This makes both paths (fresh dispatch and existing run) wait for completion.

## Test plan
- [ ] CI passes on this PR (workflow-lint)
- [ ] After merge, re-dispatch `container.yml` — ci-gate should now wait if the CI run is in progress rather than failing immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
