### PR TITLE
fix(container): set GH_REPO env so gh CLI resolves repo without git checkout

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Verify container-relevant CI passed for this commit
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TARGET_SHA: ${{ inputs.sha || github.sha }}
         run: |
           echo "Checking CI status for ${TARGET_SHA}..."


### PR DESCRIPTION
## Summary
- Add `GH_REPO` to the ci-gate step env so the `gh` CLI resolves the repo without a git checkout

## Problem
The ci-gate job has no `actions/checkout` step. Every `gh` subcommand that auto-detects the target repo by reading the git remote fails with `fatal: not a git repository`. PR #1329 patched `gh workflow run` and PR #1337 patched `gh run watch` individually — but `GH_REPO` is the environment variable `gh` reads for exactly this purpose, and it fixes all current and future `gh` calls in the step in one place.

## Test plan
- [ ] CI passes (workflow-lint)
- [ ] After merge, redispatch container.yml — ci-gate finds the CI run and waits for completion successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
