### PR TITLE
fix(devops): update blob container gate count 6→8 (t/2821 regression)

### DIFF
--- a/operations/devops/Invoke-BlobContainerGateCheck.ps1
+++ b/operations/devops/Invoke-BlobContainerGateCheck.ps1
@@ -39,8 +39,8 @@ function Get-AzContainerErrorClass ([string] $AzStderr) {
     return 'unknown'
 }
 
-if ($Containers.Count -ne 6) {
-    throw "Container list sync error: expected 6, got $($Containers.Count). Update deploy-azure.yml and main.bicep together."
+if ($Containers.Count -ne 8) {
+    throw "Container list sync error: expected 8, got $($Containers.Count). Update deploy-azure.yml and main.bicep together."
 }
 
 $Failed = @()


### PR DESCRIPTION
## Summary
- Fix blob container count guard: 6 → 8 to match the 8-entry list (6 original + brief-exports + staging-brief-exports added in t/2821)

## Problem
PR #1280 added `brief-exports` and `staging-brief-exports` to Bicep and to the `\` list in `Invoke-BlobContainerGateCheck.ps1`, but the `Count -ne 6` guard was not updated. Every deploy since t/2821 merged fails post-deploy verification with `expected 6, got 8`.

## Test plan
- [ ] CI passes
- [ ] After merge, redeploy — blob container gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)