### PR TITLE
fix(deploy): update blob container gate check from 6 to 8 containers

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -326,7 +326,8 @@ jobs:
 
       # SYNC WITH main.bicep: analyticsContainer, stagingAnalyticsContainer,
       # userContentContainer, stagingUserContentContainer, communityContainer,
-      # stagingCommunityContainer. Update both if a container is added or removed.
+      # stagingCommunityContainer, briefExportsContainer, stagingBriefExportsContainer.
+      # Update both if a container is added or removed.
       # Discriminates ContainerNotFound (404) from RBAC failures (403) — t/2718.
       - name: Verify blob containers exist post-deploy
         shell: pwsh

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -363,10 +363,10 @@ resource analyticsContainer 'Microsoft.Storage/storageAccounts/blobServices/cont
 // use these container names (BLOB_CONTAINER_PREFIX=staging-).
 //
 // SYNC WITH deploy-azure.yml: the "Verify blob containers exist post-deploy"
-// step (t/2701 gate) holds a hard-coded list of these 6 container names
+// step (t/2701 gate) holds a hard-coded list of these 8 container names
 // (analytics, staging-analytics, user-content, staging-user-content, community,
-// staging-community). Adding or removing a container resource here requires
-// updating that list in the workflow.
+// staging-community, brief-exports, staging-brief-exports). Adding or removing
+// a container resource here requires updating that list in the workflow.
 
 resource stagingUserContentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobService

--- a/operations/devops/Invoke-BlobContainerGateCheck.ps1
+++ b/operations/devops/Invoke-BlobContainerGateCheck.ps1
@@ -39,8 +39,8 @@ function Get-AzContainerErrorClass ([string] $AzStderr) {
     return 'unknown'
 }
 
-if ($Containers.Count -ne 6) {
-    throw "Container list sync error: expected 6, got $($Containers.Count). Update deploy-azure.yml and main.bicep together."
+if ($Containers.Count -ne 8) {
+    throw "Container list sync error: expected 8, got $($Containers.Count). Update deploy-azure.yml and main.bicep together."
 }
 
 $Failed = @()


### PR DESCRIPTION
## Summary
- `Invoke-BlobContainerGateCheck.ps1`: guard `Count -ne 6` → `Count -ne 8`
- `deploy-azure.yml`: SYNC comment updated to include `briefExportsContainer` and `stagingBriefExportsContainer`
- `deploy/azure/main.bicep`: comment updated from "6 container names" to "8 container names"

## Root cause
`briefExportsContainer` and `stagingBriefExportsContainer` were added to `main.bicep` (t/2821) but the expected-count guard in `Invoke-BlobContainerGateCheck.ps1` (line 42) was not updated. Blocked deploy run [32389106424](https://github.com/jpsnover/ai-triad-research/actions/runs/32389106424) with "expected 6, got 8".

## Test plan
- [ ] CI passes (no container-relevant file changes — `test-container` skipped; gate check runs in deploy)
- [ ] Re-trigger deploy after merge to confirm blob gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)