### PR TITLE
feat(debate): wire Brief export into the Community debates dropdown (t/2805 follow-up)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateBriefExports.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateBriefExports.tsx
@@ -9,7 +9,13 @@
 import { useState, type ReactNode } from 'react';
 import { BriefExportDialog } from './BriefExportDialog';
 import { BriefExportsList } from './BriefExportsList';
-import type { SessionRowData } from './DebateTable';
+
+/** Minimal shape a row must supply to open a brief export — satisfied by both a My-debate
+ *  SessionRowData and a Community CommunityDebate, so either list can trigger the dialog.
+ *  `phase` is required here; community rows carry an optional phase, so DebateTab coerces a
+ *  missing one to '' (⇒ not-'closed' ⇒ the dialog's closed-only explanation — brief is
+ *  closed-only for v1 per BriefExportDialog TL ruling A). */
+export type BriefTarget = { id: string; title: string; phase: string };
 
 export function useDebateBriefExports(
   debate: { id: string; title: string; phase: string },
@@ -41,8 +47,8 @@ export function useDebateBriefExports(
 /** Row-level brief export: manages session selection + dialog mount (t/2805 follow-up). */
 export function useRowBriefExport(
   isElectron: boolean,
-): { openRowBrief: (s: SessionRowData) => void; rowBriefNode: ReactNode } {
-  const [session, setSession] = useState<SessionRowData | null>(null);
+): { openRowBrief: (s: BriefTarget) => void; rowBriefNode: ReactNode } {
+  const [session, setSession] = useState<BriefTarget | null>(null);
   const rowBriefNode = session && !isElectron ? (
     <BriefExportDialog
       debateId={session.id}

--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -16,7 +16,7 @@ import { NewDebateDialog } from './NewDebateDialog';
 import { DebateWorkspace } from '../debate-workspace';
 import { filterCommunityDebates } from './communityFilter';
 import { ExportDropdown } from './ExportDropdown';
-import { useDebateBriefExports, useRowBriefExport } from './DebateBriefExports';
+import { useDebateBriefExports, useRowBriefExport, type BriefTarget } from './DebateBriefExports';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { useAuthStatus } from '../../hooks/useAuthStatus';
 import { SearchPreview } from '../edge-browser/SearchPreview';
@@ -95,7 +95,7 @@ interface DebateListProps {
   onRowExport: (session: SessionRowData, format: string) => void;
   onRowShare: (session: SessionRowData) => Promise<void>;
   onRowCommunityExport: (cd: CommunityDebate, format: string) => void;
-  onRowBrief: (session: SessionRowData) => void;
+  onRowBrief: (target: BriefTarget) => void;
 }
 
 // Shared prop bag for the right (detail) pane subtree.
@@ -726,7 +726,7 @@ function DebateCommunityList(props: DebateListProps) {
     communityDebates, communityLoading, searchQuery, setSearchQuery,
     filteredCommunityDebates, selectedCommunityDebate, setSelectedCommunityDebate,
     copyingId, setCopyingId, copyItem, loadSessions, auth, nav,
-    onCommunityRowOpen, onRowCommunityExport,
+    onCommunityRowOpen, onRowCommunityExport, onRowBrief,
   } = props;
   const isPhone = nav.isActive;
 
@@ -778,6 +778,8 @@ function DebateCommunityList(props: DebateListProps) {
         selectedId={selectedCommunityDebate?.id ?? null}
         onOpen={onCommunityRowOpen}
         onExport={onRowCommunityExport}
+        onBrief={(cd) => onRowBrief({ id: cd.id, title: cd.title, phase: cd.phase ?? '' })}
+        briefWebOnly={isElectronMode()}
         onCopy={handleCopy}
         copyingId={copyingId}
         auth={auth}

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -82,6 +82,9 @@ export interface DebateTableCommunityProps {
   selectedId: string | null;
   onOpen: (id: string) => void;
   onExport: (cd: CommunityDebate, format: string) => void;
+  /** Brief export from a community row (t/2805 follow-up). Undefined = item hidden. */
+  onBrief?: (cd: CommunityDebate) => void;
+  briefWebOnly?: boolean;
   onCopy: (cd: CommunityDebate) => Promise<void>;
   copyingId: string | null;
   auth: AuthStatus;
@@ -451,6 +454,8 @@ interface CommunityTableRowProps {
   isSelected: boolean;
   onOpen: (id: string) => void;
   onExport: (cd: CommunityDebate, format: string) => void;
+  onBrief?: (cd: CommunityDebate) => void;
+  briefWebOnly?: boolean;
   onCopy: (cd: CommunityDebate) => Promise<void>;
   copyingId: string | null;
   showCopy: boolean;
@@ -459,7 +464,7 @@ interface CommunityTableRowProps {
 }
 
 export function CommunityTableRow({
-  cd, isSelected, onOpen, onExport, onCopy, copyingId, showCopy,
+  cd, isSelected, onOpen, onExport, onBrief, briefWebOnly, onCopy, copyingId, showCopy,
   onPhoneSelect, isPhone,
 }: CommunityTableRowProps) {
   const isCopying = copyingId === cd.id;
@@ -522,7 +527,7 @@ export function CommunityTableRow({
           >
             Open
           </button>
-          <ExportDropdown onExport={fmt => onExport(cd, fmt)} />
+          <ExportDropdown onExport={fmt => onExport(cd, fmt)} onBrief={onBrief ? () => onBrief(cd) : undefined} briefWebOnly={briefWebOnly} />
           {showCopy && (
             <button
               type="button"
@@ -703,7 +708,7 @@ function CommunityTable(
   props: DebateTableCommunityProps & { sort: SortState; onSort: (col: SortColumn) => void },
 ) {
   const {
-    rows, loading, searchQuery, selectedId, onOpen, onExport, onCopy,
+    rows, loading, searchQuery, selectedId, onOpen, onExport, onBrief, briefWebOnly, onCopy,
     copyingId, auth, onPhoneSelect, isPhone, sort, onSort,
   } = props;
 
@@ -766,6 +771,8 @@ function CommunityTable(
               isSelected={selectedId === cd.id}
               onOpen={onOpen}
               onExport={onExport}
+              onBrief={onBrief}
+              briefWebOnly={briefWebOnly}
               onCopy={onCopy}
               copyingId={copyingId}
               showCopy={showCopy}

--- a/taxonomy-editor/src/renderer/components/debate/ExportDropdown.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/ExportDropdown.test.tsx
@@ -29,4 +29,33 @@ describe('ExportDropdown', () => {
     expect(onExport).toHaveBeenCalledWith('markdown');
     expect(screen.queryByRole('menu')).toBeNull();
   });
+
+  // Brief… item — shared by the My and Community debate rows (t/2805 follow-up). No onBrief
+  // ⇒ no item; provided ⇒ enabled and fires; briefWebOnly ⇒ disabled dead-end on desktop.
+  it('omits the Brief… item when onBrief is not provided', () => {
+    render(<ExportDropdown onExport={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    expect(screen.queryByRole('menuitem', { name: /brief/i })).toBeNull();
+  });
+
+  it('renders an enabled Brief… item that fires onBrief and closes the menu', () => {
+    const onBrief = vi.fn();
+    render(<ExportDropdown onExport={() => {}} onBrief={onBrief} />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    const item = screen.getByRole('menuitem', { name: 'Brief…' });
+    expect((item as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(item);
+    expect(onBrief).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  it('disables the Brief… item (web-app only) and does not fire onBrief when briefWebOnly', () => {
+    const onBrief = vi.fn();
+    render(<ExportDropdown onExport={() => {}} onBrief={onBrief} briefWebOnly />);
+    fireEvent.click(screen.getByRole('button', { name: /export/i }));
+    const item = screen.getByRole('menuitem', { name: /brief.*web app/i });
+    expect((item as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(item);
+    expect(onBrief).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What
The Community debates Export dropdown only offered PDF / JSON / Markdown. The "Brief…" item was wired for **My** debates only (#1332). This threads `onBrief`/`briefWebOnly` through the community `DebateTable` path so shared/community debates can export a brief too.

Reported by @jpsnover (screenshot: Community list Export ▾ missing Brief).

## Changes
- `DebateBriefExports.tsx` — broaden the row-brief target to a minimal `BriefTarget {id,title,phase}` so both `SessionRowData` (My) and `CommunityDebate` (Community) satisfy it.
- `DebateTab.tsx` — pass `onBrief`/`briefWebOnly` to the community `DebateTable`; coerce `CommunityDebate.phase` (optional) → `''` (dialog is closed-only for v1, so non-closed shows the closed-only notice). Net +2 lines; file stays at the 1500-line ADR-007 ceiling.
- `DebateTable.tsx` — thread `onBrief`/`briefWebOnly` through community props → `CommunityTableRow` → `ExportDropdown`.
- `ExportDropdown.test.tsx` — add coverage for the Brief… item (absent when no `onBrief`; enabled fires; `briefWebOnly` disabled dead-end). Closes a test gap left by #1332; protects both My + Community.

## Verification
- `tsc --noEmit` clean
- `eslint` clean (0 errors)
- `vitest ExportDropdown.test.tsx` 6/6 green

## Follow-up (not in this PR)
`DebateTab.tsx` is at exactly 1500 lines (ADR-007 ceiling) — chronically bumped by brief wiring. Filing a ticket to extract it below the ceiling with margin.