### PR TITLE
fix(embed): don't crash on stray nodes-files in _load_taxonomy_nodes (t/2875)

### DIFF
--- a/scripts/embed_taxonomy.py
+++ b/scripts/embed_taxonomy.py
@@ -132,7 +132,7 @@ def _classify_pairs_nli(nli_model, pairs):
     return results
 
 
-SKIP_FILES = {"embeddings.json", "edges.json", "policy_actions.json", "lineage_categories.json", "_archived_edges.json", "interpretation_embeddings.json"}
+SKIP_FILES = {"embeddings.json", "edges.json", "policy_actions.json", "lineage_categories.json", "_archived_edges.json", "interpretation_embeddings.json", "entity_extraction_log.json"}
 
 # Resolved at runtime from .aitriad.json
 CONFLICTS_DIR: Optional[Path] = None  # set in _resolve_taxonomy_dir
@@ -321,7 +321,18 @@ def _load_taxonomy_nodes():
             continue
 
         pov = path.stem.lower()
-        for node in data.get("nodes", []):
+        # Durable class guard (t/2875, a t/1652-class recurrence): a stray
+        # `nodes`-bearing file whose entries aren't POV nodes (e.g. log entries
+        # keyed `node_id`, not `id`) must be a logged skip, not a downstream
+        # KeyError that takes the whole pipeline down. Validate shape before ingest.
+        file_nodes = data.get("nodes", [])
+        if file_nodes and not all(isinstance(n, dict) and "id" in n for n in file_nodes):
+            print(
+                f"Warning: skipping {path.name}: 'nodes' entries lack 'id' (not a POV file)",
+                file=sys.stderr,
+            )
+            continue
+        for node in file_nodes:
             nodes.append((pov, node))
     return nodes
 

--- a/scripts/test_load_taxonomy_nodes.py
+++ b/scripts/test_load_taxonomy_nodes.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+"""Regression tests for embed_taxonomy._load_taxonomy_nodes (t/2875).
+
+A stray `nodes`-bearing file whose entries are not POV nodes (e.g.
+entity_extraction_log.json — log entries keyed `node_id`, not `id`) must NOT
+take the embeddings pipeline down with a KeyError. Two arms:
+
+  1. entity_extraction_log.json is name-skipped via SKIP_FILES (this incident).
+  2. any OTHER stray nodes-file whose entries lack `id` is shape-skipped with a
+     stderr warning (the durable, t/1652-class fix).
+
+Both cases fail on the pre-fix loader (the bogus nodes are ingested → the test's
+`id` read raises / count mismatch) and pass after the fix.
+
+Runnable under pytest or standalone: `python test_load_taxonomy_nodes.py`.
+"""
+
+import contextlib
+import importlib.util
+import io
+import json
+import tempfile
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "embed_taxonomy", Path(__file__).resolve().parent / "embed_taxonomy.py"
+)
+embed_taxonomy = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(embed_taxonomy)
+
+
+def _write(dir_path: Path, name: str, obj) -> None:
+    (dir_path / name).write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _valid_pov_file(dir_path: Path) -> None:
+    _write(dir_path, "accelerationist.json", {
+        "nodes": [
+            {"id": "acc-beliefs-001", "label": "A", "description": "Desc A"},
+            {"id": "acc-beliefs-002", "label": "B", "description": "Desc B"},
+        ]
+    })
+
+
+def _run_loader(dir_path: Path):
+    """Point the module at dir_path, capture stderr, return (nodes, stderr)."""
+    saved = embed_taxonomy.TAXONOMY_DIR
+    embed_taxonomy.TAXONOMY_DIR = Path(dir_path)
+    try:
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            nodes = embed_taxonomy._load_taxonomy_nodes()
+        return nodes, buf.getvalue()
+    finally:
+        embed_taxonomy.TAXONOMY_DIR = saved
+
+
+def test_entity_extraction_log_is_name_skipped():
+    """Arm 1: entity_extraction_log.json is skipped by name — no crash, no bogus nodes."""
+    with tempfile.TemporaryDirectory() as d:
+        dp = Path(d)
+        _valid_pov_file(dp)
+        # The t/2875 shape: log entries keyed node_id, not id.
+        _write(dp, "entity_extraction_log.json", {
+            "nodes": [
+                {"node_id": "acc-beliefs-001", "ts": "2026-07-28T00:00:00Z"},
+                {"node_id": "acc-beliefs-002", "ts": "2026-07-28T00:00:01Z"},
+            ]
+        })
+        nodes, _ = _run_loader(dp)
+
+    assert len(nodes) == 2, f"expected only the 2 POV nodes, got {len(nodes)}"
+    assert sorted(n["id"] for _, n in nodes) == ["acc-beliefs-001", "acc-beliefs-002"]
+    assert all(pov == "accelerationist" for pov, _ in nodes)
+
+
+def test_stray_nodes_file_is_shape_skipped_with_warning():
+    """Arm 2: a differently-named stray nodes-file (entries lack id) is skipped with a warning."""
+    with tempfile.TemporaryDirectory() as d:
+        dp = Path(d)
+        _valid_pov_file(dp)
+        _write(dp, "stray_nodes.json", {
+            "nodes": [{"node_id": "x-1"}, {"node_id": "x-2"}]
+        })
+        nodes, stderr = _run_loader(dp)
+
+    assert len(nodes) == 2, f"expected only the 2 POV nodes, got {len(nodes)}"
+    assert sorted(n["id"] for _, n in nodes) == ["acc-beliefs-001", "acc-beliefs-002"]
+    # The skip must be observable (ADR-001 silent-degradation rule).
+    assert "stray_nodes.json" in stderr
+    assert "lack 'id'" in stderr
+
+
+def test_empty_nodes_file_does_not_warn():
+    """A file with an empty `nodes` list is legal — no false shape-guard warning."""
+    with tempfile.TemporaryDirectory() as d:
+        dp = Path(d)
+        _valid_pov_file(dp)
+        _write(dp, "safetyist.json", {"nodes": []})
+        nodes, stderr = _run_loader(dp)
+
+    assert len(nodes) == 2
+    assert "lack 'id'" not in stderr
+
+
+if __name__ == "__main__":
+    test_entity_extraction_log_is_name_skipped()
+    test_stray_nodes_file_is_shape_skipped_with_warning()
+    test_empty_nodes_file_does_not_warn()
+    print("OK: all _load_taxonomy_nodes regression tests passed")


### PR DESCRIPTION
## Summary
Incident fix (t/2875): all \mbed_taxonomy.py\ subcommands crashed \KeyError: 'id'\ — \_load_taxonomy_nodes\ ingested \ntity_extraction_log.json\ (a new data file whose \
odes\ are log entries keyed \
ode_id\, not \id\) as POV nodes. Embeddings were stale until fixed. TL-authored two-arm fix.

- **Arm 1:** add \ntity_extraction_log.json\ to \SKIP_FILES\.
- **Arm 2 (durable, t/1652-class):** \_load_taxonomy_nodes\ skips-with-stderr-warning any file whose \
odes\ entries aren't all dicts containing \id\, instead of crashing downstream. A future stray \
odes\-file is now a logged skip, not a pipeline outage (ADR-001 silent-degradation: the skip is observable).

## Test plan
- [x] New \scripts/test_load_taxonomy_nodes.py\: (1) entity_extraction_log.json name-skipped; (2) differently-named stray file shape-skipped **with warning**; (3) empty-nodes file → no false warning. Standalone-runnable + pytest.
- [x] Verified genuine regression: pre-fix loader returns 4 nodes + \KeyError: 'id'\; post-fix returns 2 clean.
- [x] Embeddings regenerated with the fixed code; \generate\/\query\/\similarity-matrix\ recovery confirmed (provenance in t/2875).

Note: one test-spec refinement vs the ticket — two cases instead of one, because Arm 1 name-skips \ntity_extraction_log.json\ silently (no warning), so the warning assertion lands on the Arm-2 shape-guard path with a non-SKIP_FILES filename (t/2875#1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)