### PR TITLE
feat(scripts): add Test-TaxonomyDir to pre-validate taxonomy JSON before embedding (t/2876)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -22,6 +22,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-TaxonomyHealth` | Check node/edge counts, orphans, structural issues |
 | `Compare-Taxonomy` | Diff two taxonomy states |
 | `Test-TaxonomyIntegrity` | Validate referential integrity — dangling refs, edge source/target resolution, and self-loop edges (source == target); `-Repair` strips bad/self-loop edges (see `Test-OrganizationIntegrity` for the Organization slice) |
+| `Test-TaxonomyDir` | Pre-validate the taxonomy dir against the embed_taxonomy.py loader contract before `Update-TaxEmbeddings` — reports which files would be ingested vs skipped and flags any ingested file whose `nodes` lack `id` (the shape that crashes the embed run, t/2875) |
 | `Test-OntologyCompliance` | Check nodes against ontology rules |
 | `Get-NodeTestingRecord` | Debate-Tested Phase 2 research surface — filter/sort POV nodes by tier, stale-hash, or importance×deficit (t/1579) |
 | `Update-NodeTestingRecord -RecomputeOnly` | Recompute tier + sort_key across all nodes after a constant change; historical record[] never touched; idempotent (t/1579) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -70,6 +70,7 @@
         'Update-PolicyRegistry'
         'Show-FallacyInfo'
         'Test-TaxonomyIntegrity'
+        'Test-TaxonomyDir'
         'Invoke-HierarchyProposal'
         'Set-TaxonomyHierarchy'
         'Invoke-SchemaMigration'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -810,6 +810,8 @@ Export-ModuleMember -Function @(
     'Update-PolicyRegistry'
     'Show-FallacyInfo'
     'Test-TaxonomyIntegrity'
+    # t/2876 — pre-validate taxonomy dir against embed_taxonomy.py loader contract
+    'Test-TaxonomyDir'
     'Invoke-HierarchyProposal'
     'Set-TaxonomyHierarchy'
     'Invoke-SchemaMigration'

--- a/scripts/AITriad/Public/Show-AITriadHelp.ps1
+++ b/scripts/AITriad/Public/Show-AITriadHelp.ps1
@@ -90,6 +90,7 @@ function Show-AITriadHelp {
         'Update-PolicyRegistry' = 'Taxonomy Data'; 'Invoke-PolicyRefinement' = 'Taxonomy Data'
         'Get-TaxonomyHealth' = 'Taxonomy Data'; 'Compare-Taxonomy' = 'Taxonomy Data'
         'Test-TaxonomyIntegrity' = 'Taxonomy Data'; 'Test-OntologyCompliance' = 'Taxonomy Data'
+        'Test-TaxonomyDir' = 'Taxonomy Data'
         'Get-RelevantTaxonomyNodes' = 'Taxonomy Data'; 'Measure-TaxonomyBaseline' = 'Taxonomy Data'
         'Get-TaxonomyProcess' = 'Taxonomy Data'; 'Update-TaxEmbeddings' = 'Taxonomy Data'
         'Set-TaxonomyHierarchy' = 'Taxonomy Data'; 'Approve-TaxonomyProposal' = 'Taxonomy Data'

--- a/scripts/AITriad/Public/Test-TaxonomyDir.ps1
+++ b/scripts/AITriad/Public/Test-TaxonomyDir.ps1
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-TaxonomyDir {
+    <#
+    .SYNOPSIS
+        Pre-validate the taxonomy directory against the embed_taxonomy.py loader
+        contract before running Update-TaxEmbeddings.
+    .DESCRIPTION
+        Predicts exactly which files embed_taxonomy.py's _load_taxonomy_nodes()
+        would ingest, and flags any ingested file that would crash the embedding
+        run. This answers the question "which taxonomy file is malformed?" in
+        seconds instead of a bespoke diagnostic script (motivating incident: t/2875,
+        where a stray entity_extraction_log.json with nodes keyed 'node_id' instead
+        of 'id' crashed all three embed subcommands with KeyError: 'id').
+
+        For each *.json file in the taxonomy directory it reports one of:
+          - Skip    — in SKIP_FILES or an 'embeddings-*' index artifact (never ingested)
+          - Ingest  — would be loaded as POV nodes; OK when every 'nodes' entry is a
+                      dict containing an 'id'
+          - Error   — would be ingested but is malformed (invalid JSON, 'nodes' is not
+                      an array, or 'nodes' entries lack 'id') — this is the shape that
+                      crashes the loader downstream
+
+        The SKIP_FILES set is parsed from embed_taxonomy.py at runtime so this check
+        stays in sync with the loader (the single source of truth) rather than
+        drifting from a hardcoded copy. If the source cannot be parsed it falls back
+        to a documented default and warns.
+    .PARAMETER Path
+        Taxonomy directory to scan. Defaults to Get-TaxonomyDir (the configured
+        taxonomy/Origin directory).
+    .PARAMETER PassThru
+        Return a summary object (Ok, FileCount, IngestCount, SkipCount, Problems,
+        Details) instead of only writing the human-readable report.
+    .EXAMPLE
+        Test-TaxonomyDir
+        Scan the configured taxonomy directory and print a per-file report.
+    .EXAMPLE
+        if (-not (Test-TaxonomyDir -PassThru).Ok) { throw 'Fix taxonomy before embedding' }
+        Gate a pipeline on a clean taxonomy directory.
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Update-TaxEmbeddings
+    .LINK
+        Test-TaxonomyIntegrity
+    .LINK
+        Get-TaxonomyHealth
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [string]$Path,
+
+        [switch]$PassThru
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $Path) { $Path = Get-TaxonomyDir }
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw (New-ActionableError `
+            -Goal 'Pre-validate the taxonomy directory before embedding' `
+            -Problem "Taxonomy directory not found: $Path" `
+            -Location 'Test-TaxonomyDir' `
+            -NextSteps @(
+                'Verify the data root is configured (.aitriad.json or $env:AI_TRIAD_DATA_ROOT).',
+                'Pass an explicit -Path to the taxonomy directory.'
+            ))
+    }
+
+    # ── Resolve the loader's SKIP_FILES from embed_taxonomy.py (single source of truth) ──
+    # Parsing keeps this check in sync with the loader instead of drifting from a
+    # hardcoded copy — the exact drift that let entity_extraction_log.json through (t/2875).
+    $DefaultSkip = @(
+        'embeddings.json', 'edges.json', 'policy_actions.json', 'lineage_categories.json',
+        '_archived_edges.json', 'interpretation_embeddings.json'
+    )
+    $EmbedScript = Join-Path (Join-Path $script:RepoRoot 'scripts') 'embed_taxonomy.py'
+    if (-not (Test-Path -LiteralPath $EmbedScript)) { $EmbedScript = Join-Path $script:ModuleRoot 'embed_taxonomy.py' }
+
+    $SkipFiles = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $ParsedSkip = $false
+    if (Test-Path -LiteralPath $EmbedScript) {
+        $Match = Select-String -LiteralPath $EmbedScript -Pattern '^\s*SKIP_FILES\s*=\s*\{(.+)\}' | Select-Object -First 1
+        if ($Match) {
+            foreach ($Q in [regex]::Matches($Match.Matches[0].Groups[1].Value, '"([^"]+)"')) {
+                [void]$SkipFiles.Add($Q.Groups[1].Value)
+            }
+            if ($SkipFiles.Count -gt 0) { $ParsedSkip = $true }
+        }
+    }
+    if (-not $ParsedSkip) {
+        Write-Warning "Test-TaxonomyDir: could not parse SKIP_FILES from '$EmbedScript' — using the built-in default. If the loader's skip list has changed, results may be stale."
+        foreach ($S in $DefaultSkip) { [void]$SkipFiles.Add($S) }
+    }
+
+    # ── Scan every *.json file, classifying against the loader contract ──
+    $Details  = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $Problems = 0
+    $IngestCount = 0
+    $SkipCount = 0
+
+    foreach ($File in (Get-ChildItem -LiteralPath $Path -Filter '*.json' -File | Sort-Object Name)) {
+        $Name = $File.Name
+        $Stem = [System.IO.Path]::GetFileNameWithoutExtension($Name)
+
+        # Loader skip rules (embed_taxonomy.py:_load_taxonomy_nodes) ────────────
+        if ($SkipFiles.Contains($Name)) {
+            $Details.Add([PSCustomObject]@{ File = $Name; Action = 'Skip'; Severity = 'Info'; NodeCount = $null; Reason = 'in SKIP_FILES' })
+            $SkipCount++
+            continue
+        }
+        if ($Stem.StartsWith('embeddings-', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $Details.Add([PSCustomObject]@{ File = $Name; Action = 'Skip'; Severity = 'Info'; NodeCount = $null; Reason = "embedding-index artifact ('embeddings-*')" })
+            $SkipCount++
+            continue
+        }
+
+        # File would be ingested — validate the node shape the loader requires ──
+        try {
+            $Raw = Get-Content -Raw -LiteralPath $File.FullName -Encoding UTF8
+            $Data = $Raw | ConvertFrom-Json
+        }
+        catch {
+            $Details.Add([PSCustomObject]@{ File = $Name; Action = 'Ingest'; Severity = 'Error'; NodeCount = $null; Reason = "invalid JSON: $($_.Exception.Message)" })
+            $Problems++
+            $IngestCount++
+            continue
+        }
+
+        # No 'nodes' array → loader's data.get('nodes', []) yields nothing; harmless
+        # but unexpected for a file the loader treats as POV data.
+        if (-not ($Data.PSObject.Properties['nodes'])) {
+            $Details.Add([PSCustomObject]@{ File = $Name; Action = 'Ingest'; Severity = 'Warning'; NodeCount = 0; Reason = "no 'nodes' array (ingested but contributes 0 nodes)" })
+            $IngestCount++
+            continue
+        }
+
+        $Nodes = $Data.nodes
+        # 'nodes' present but not an array of node objects (e.g. a dict keyed by ID,
+        # as in embedding-index files). Iterating this crashes the loader.
+        if ($Nodes -is [System.Management.Automation.PSCustomObject]) {
+            $Details.Add([PSCustomObject]@{ File = $Name; Action = 'Ingest'; Severity = 'Error'; NodeCount = $null; Reason = "'nodes' is an object, not an array of node dicts" })
+            $Problems++
+            $IngestCount++
+            continue
+        }
+
+        $NodeList = @($Nodes)
+        $BadCount = 0
+        $AltKeys = [System.Collections.Generic.HashSet[string]]::new()
+        foreach ($Node in $NodeList) {
+            if ($Node -isnot [System.Management.Automation.PSCustomObject] -or -not $Node.PSObject.Properties['id']) {
+                $BadCount++
+                if ($Node -is [System.Management.Automation.PSCustomObject]) {
+                    foreach ($Prop in $Node.PSObject.Properties) {
+                        if ($Prop.Name -match 'id') { [void]$AltKeys.Add($Prop.Name) }
+                    }
+                }
+            }
+        }
+
+        if ($BadCount -gt 0) {
+            $Hint = if ($AltKeys.Count -gt 0) { " (entries carry '$([string]::Join("', '", $AltKeys))' instead of 'id')" } else { '' }
+            $Details.Add([PSCustomObject]@{ File = $Name; Action = 'Ingest'; Severity = 'Error'; NodeCount = $NodeList.Count; Reason = "$BadCount of $($NodeList.Count) 'nodes' entries lack an 'id' field$Hint — this crashes the embedding run" })
+            $Problems++
+        }
+        else {
+            $Details.Add([PSCustomObject]@{ File = $Name; Action = 'Ingest'; Severity = 'Ok'; NodeCount = $NodeList.Count; Reason = 'valid POV nodes' })
+        }
+        $IngestCount++
+    }
+
+    $FileCount = $Details.Count
+    $Ok = ($Problems -eq 0)
+
+    # ── Report ──
+    Write-Host ''
+    Write-Host '=== Taxonomy Directory Pre-Validation ===' -ForegroundColor Cyan
+    Write-Host "  Directory:   $Path" -ForegroundColor White
+    Write-Host "  JSON files:  $FileCount" -ForegroundColor White
+    Write-Host "  Would ingest: $IngestCount    Would skip: $SkipCount" -ForegroundColor White
+    Write-Host "  Problems:    $Problems" -ForegroundColor $(if ($Problems -gt 0) { 'Red' } else { 'Green' })
+    Write-Host ''
+
+    foreach ($D in $Details) {
+        $Color = switch ($D.Severity) {
+            'Error'   { 'Red' }
+            'Warning' { 'Yellow' }
+            'Ok'      { 'Green' }
+            default   { 'DarkGray' }
+        }
+        $Label = if ($D.Action -eq 'Skip') { 'SKIP  ' } else { 'INGEST' }
+        Write-Host "  [$Label] $($D.File): $($D.Reason)" -ForegroundColor $Color
+    }
+    Write-Host ''
+    if ($Ok) {
+        Write-Host '  No ingest-blocking problems found — safe to run Update-TaxEmbeddings.' -ForegroundColor Green
+    }
+    else {
+        Write-Host "  $Problems file(s) would crash or degrade the embedding run. Fix or add to SKIP_FILES in embed_taxonomy.py before embedding." -ForegroundColor Red
+    }
+    Write-Host ''
+
+    if ($PassThru) {
+        [PSCustomObject]@{
+            Ok          = $Ok
+            Directory   = $Path
+            FileCount   = $FileCount
+            IngestCount = $IngestCount
+            SkipCount   = $SkipCount
+            Problems    = $Problems
+            Details     = @($Details)
+        }
+    }
+}

--- a/tests/Test-TaxonomyDir.Tests.ps1
+++ b/tests/Test-TaxonomyDir.Tests.ps1
@@ -1,0 +1,112 @@
+# Tag: taxonomy (t/2876)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Test-TaxonomyDir — the pre-embedding taxonomy directory validator.
+.DESCRIPTION
+    Covers the motivating incident (t/2875): a stray entity_extraction_log.json
+    whose 'nodes' entries are keyed 'node_id' instead of 'id' crashed the embed
+    run with KeyError: 'id'. Test-TaxonomyDir must flag exactly that file as a
+    problem, while passing a clean POV directory and correctly classifying the
+    loader's skip rules (SKIP_FILES + 'embeddings-*').
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    function New-TaxTempDir {
+        $Dir = Join-Path ([System.IO.Path]::GetTempPath()) "taxdir-test-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        New-Item -ItemType Directory -Path $Dir -Force | Out-Null
+        return $Dir
+    }
+}
+
+Describe 'Test-TaxonomyDir' -Tag 'taxonomy' {
+
+    It 'Is exported and callable after Import-Module' {
+        Get-Command Test-TaxonomyDir -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Reports Ok for a directory of valid POV files' {
+        $Dir = New-TaxTempDir
+        try {
+            Set-Content -Path (Join-Path $Dir 'accelerationist.json') -Value '{"nodes":[{"id":"acc-beliefs-001"}]}'
+            Set-Content -Path (Join-Path $Dir 'safetyist.json')       -Value '{"nodes":[{"id":"saf-desires-001"}]}'
+
+            $result = Test-TaxonomyDir -Path $Dir -PassThru 6>$null
+            $result.Ok          | Should -BeTrue
+            $result.Problems    | Should -Be 0
+            $result.IngestCount | Should -Be 2
+        }
+        finally { Remove-Item -Path $Dir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'Flags entity_extraction_log.json (nodes keyed node_id, not id) as a problem — t/2875' {
+        $Dir = New-TaxTempDir
+        try {
+            Set-Content -Path (Join-Path $Dir 'accelerationist.json') -Value '{"nodes":[{"id":"acc-beliefs-001"}]}'
+            # The exact incident shape: a top-level nodes[] whose entries are keyed
+            # 'node_id'. Not in SKIP_FILES, not 'embeddings-*' → the loader ingests
+            # it and crashes on node["id"].
+            Set-Content -Path (Join-Path $Dir 'entity_extraction_log.json') `
+                -Value '{"node_count":1,"nodes":[{"node_id":"acc-beliefs-003","model":"claude-sonnet-4-6"}]}'
+
+            $result = Test-TaxonomyDir -Path $Dir -PassThru 6>$null
+            $result.Ok       | Should -BeFalse
+            $result.Problems | Should -Be 1
+
+            $bad = @($result.Details | Where-Object { $_.File -eq 'entity_extraction_log.json' })
+            $bad.Count       | Should -Be 1
+            $bad[0].Severity | Should -Be 'Error'
+            $bad[0].Reason   | Should -Match "lack an 'id'"
+            # The alt-key hint should name the offending key so a human can act on it.
+            $bad[0].Reason   | Should -Match 'node_id'
+        }
+        finally { Remove-Item -Path $Dir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'Classifies SKIP_FILES and embeddings-* index artifacts as Skip (not ingested)' {
+        $Dir = New-TaxTempDir
+        try {
+            Set-Content -Path (Join-Path $Dir 'accelerationist.json')      -Value '{"nodes":[{"id":"acc-beliefs-001"}]}'
+            Set-Content -Path (Join-Path $Dir 'embeddings.json')           -Value '{"nodes":{}}'
+            Set-Content -Path (Join-Path $Dir 'policy_actions.json')       -Value '{"policies":[]}'
+            # embeddings-* index artifact: 'nodes' is a dict keyed by ID. Must be
+            # skipped by the prefix rule, never validated as POV data.
+            Set-Content -Path (Join-Path $Dir 'embeddings-orgstance-6733.json') -Value '{"nodes":{"acc-1":[0.1,0.2]}}'
+
+            $result = Test-TaxonomyDir -Path $Dir -PassThru 6>$null
+            $result.Ok        | Should -BeTrue
+            $result.SkipCount | Should -Be 3
+
+            $skipped = @($result.Details | Where-Object { $_.Action -eq 'Skip' } | ForEach-Object { $_.File })
+            $skipped | Should -Contain 'embeddings.json'
+            $skipped | Should -Contain 'policy_actions.json'
+            $skipped | Should -Contain 'embeddings-orgstance-6733.json'
+        }
+        finally { Remove-Item -Path $Dir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'Flags invalid JSON in an ingested file as a problem' {
+        $Dir = New-TaxTempDir
+        try {
+            Set-Content -Path (Join-Path $Dir 'skeptic.json') -Value '{"nodes":[{"id":"skp-1"} ] '  # truncated / invalid
+
+            $result = Test-TaxonomyDir -Path $Dir -PassThru 6>$null
+            $result.Ok       | Should -BeFalse
+            $result.Problems | Should -Be 1
+            @($result.Details | Where-Object { $_.Reason -match 'invalid JSON' }).Count | Should -Be 1
+        }
+        finally { Remove-Item -Path $Dir -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'Throws an ActionableError when the directory does not exist' {
+        $Missing = Join-Path ([System.IO.Path]::GetTempPath()) "taxdir-nope-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        { Test-TaxonomyDir -Path $Missing 6>$null } | Should -Throw
+    }
+}


### PR DESCRIPTION
## Summary
Adds `Test-TaxonomyDir` — a pre-embedding validator that predicts exactly which files `embed_taxonomy.py`'s `_load_taxonomy_nodes()` would ingest and flags any ingested file whose `nodes` entries lack an `id`. That is the shape that crashed all three embed subcommands with `KeyError: 'id'` (t/2875, the motivating incident). It answers "which taxonomy file is malformed?" in seconds instead of requiring a bespoke diagnostic script.

Closes t/2876.

## Behavior
For each `*.json` in the taxonomy dir it reports one of:
- **Skip** — in `SKIP_FILES` or an `embeddings-*` index artifact (never ingested)
- **Ingest / Ok** — valid POV nodes (every `nodes` entry a dict with `id`)
- **Ingest / Error** — invalid JSON, `nodes` is an object not an array, or entries lack `id` (names the offending key, e.g. `node_id`)

`-PassThru` returns `{ Ok, Directory, FileCount, IngestCount, SkipCount, Problems, Details }` for pipeline gating.

## Drift resistance
`SKIP_FILES` is **parsed from `embed_taxonomy.py` at runtime** (the single source of truth) rather than hardcoded — avoiding the exact copy-drift that let the stray file through in the first place. Falls back to a documented default with a warning if the source can't be parsed.

## Coupling sites updated
- `AITriad.psd1` `FunctionsToExport` + `AITriad.psm1` `Export-ModuleMember`
- `Show-AITriadHelp` category map
- `docs/cmdlet-reference.md` catalog

## Tests
`tests/Test-TaxonomyDir.Tests.ps1` (6 tests, all green): clean POV dir, the t/2875 `node_id`-keyed log, SKIP_FILES + `embeddings-*` classification, invalid JSON, and missing-dir `ActionableError`. `AITriad.Module.Tests.ps1` (export/manifest consistency) passes with the new export; `Test-ModuleManifest` clean.

Followed `/add-ps-cmdlet` (design-review exempt). Typed output is `PSCustomObject` to match the sibling `Test-TaxonomyIntegrity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)