### PR TITLE
feat(embed): fail loud on silent conflict/class drop in generate (t/2877)

### DIFF
--- a/scripts/embed_taxonomy.py
+++ b/scripts/embed_taxonomy.py
@@ -50,32 +50,47 @@ TAXONOMY_DIR: Path = _FALLBACK_TAXONOMY_DIR
 EMBEDDINGS_FILE: Path = _FALLBACK_TAXONOMY_DIR / "embeddings.json"
 
 
-def _resolve_taxonomy_dir(override=None):
-    """Resolve the taxonomy directory from override, .aitriad.json, or default."""
+def _resolve_taxonomy_dir(override=None, conflicts_override=None):
+    """Resolve the taxonomy + conflicts directories from override, .aitriad.json, or default.
+
+    t/2877: `.aitriad.json` is consulted for the conflicts dir even when
+    `--taxonomy-dir` overrides the taxonomy location. Previously an override left
+    CONFLICTS_DIR on the script-parent fallback, which silently dropped conflicts
+    when generate ran from an unusual cwd/worktree. Precedence for conflicts:
+    explicit `conflicts_override` (--conflicts-dir) > .aitriad.json > fallback.
+    """
     global TAXONOMY_DIR, EMBEDDINGS_FILE, CONFLICTS_DIR
 
     data_base = _SCRIPT_DIR.parent  # fallback
+    cfg_conflicts = None
+
+    # Always read config (independent of --taxonomy-dir) so conflicts resolve
+    # against the configured data root, not the script-parent fallback.
+    config_path = _SCRIPT_DIR.parent / ".aitriad.json"
+    if config_path.exists():
+        try:
+            cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            data_root = cfg.get("data_root", ".")
+            tax_dir = cfg.get("taxonomy_dir", "taxonomy/Origin")
+            conflicts_dir = cfg.get("conflicts_dir", "conflicts")
+            base = Path(data_root) if Path(data_root).is_absolute() else (_SCRIPT_DIR.parent / data_root)
+            data_base = base.resolve()
+            cfg_conflicts = (base / conflicts_dir).resolve()
+            if not override:
+                TAXONOMY_DIR = (base / tax_dir).resolve()
+        except (json.JSONDecodeError, OSError):
+            pass  # fall through to default
 
     if override:
         TAXONOMY_DIR = Path(override).resolve()
-    else:
-        # Try .aitriad.json
-        config_path = _SCRIPT_DIR.parent / ".aitriad.json"
-        if config_path.exists():
-            try:
-                cfg = json.loads(config_path.read_text(encoding="utf-8"))
-                data_root = cfg.get("data_root", ".")
-                tax_dir = cfg.get("taxonomy_dir", "taxonomy/Origin")
-                conflicts_dir = cfg.get("conflicts_dir", "conflicts")
-                base = Path(data_root) if Path(data_root).is_absolute() else (_SCRIPT_DIR.parent / data_root)
-                data_base = base.resolve()
-                TAXONOMY_DIR = (base / tax_dir).resolve()
-                CONFLICTS_DIR = (base / conflicts_dir).resolve()
-            except (json.JSONDecodeError, OSError):
-                pass  # fall through to default
 
     EMBEDDINGS_FILE = TAXONOMY_DIR / "embeddings.json"
-    if CONFLICTS_DIR is None or not CONFLICTS_DIR.exists():
+
+    if conflicts_override:
+        CONFLICTS_DIR = Path(conflicts_override).resolve()
+    elif cfg_conflicts is not None:
+        CONFLICTS_DIR = cfg_conflicts
+    else:
         CONFLICTS_DIR = data_base / "conflicts"
     return TAXONOMY_DIR
 
@@ -381,6 +396,60 @@ def _load_conflict_nodes():
         return []
 
 
+def _assert_corpus_complete(node_count, conflict_count, conflicts_dir, allow_missing_conflicts):
+    """Fail loud if the regenerated corpus is missing a node class the source contains (t/2877).
+
+    Prevents the silent-degradation class (ADR-001): a path/cwd quirk that drops a whole
+    class (e.g. conflicts) while `generate` still exits 0 with a truncated corpus. Raises
+    ValueError (→ non-zero exit) with an actionable Goal/Problem/Next-Steps message; returns
+    None on success. Pure (no model encode) so it is unit-testable.
+
+    The crux (why not just "corpus conflicts > 0"): the incident's mis-resolution made the
+    SOURCE look empty, so a >0 check would not fire. This asserts the conflicts source
+    RESOLVED to a real conflicts.json and that the corpus count EXACTLY matches its entries —
+    catching total AND partial drops regardless of cause.
+    """
+    def _err(problem, next_steps):
+        return ValueError(
+            "Goal: Regenerate a complete embeddings.json (all node classes the source contains)\n"
+            f"Problem: {problem}\n"
+            "Location: embed_taxonomy.py cmd_generate / _assert_corpus_complete\n"
+            f"Next Steps: {next_steps}"
+        )
+
+    if node_count == 0:
+        raise _err(
+            f"0 taxonomy POV nodes loaded — source empty or TAXONOMY_DIR mis-resolved ({TAXONOMY_DIR}).",
+            "Check --taxonomy-dir / cwd / .aitriad.json so the POV JSON files are found.",
+        )
+
+    conflicts_file = (Path(conflicts_dir) / "conflicts.json") if conflicts_dir else None
+    if conflicts_file is None or not conflicts_file.exists():
+        if allow_missing_conflicts:
+            return
+        raise _err(
+            f"CONFLICTS_DIR did not resolve to an existing conflicts.json (looked at {conflicts_file}); "
+            "conflicts would be silently dropped from the corpus.",
+            "Pass --conflicts-dir <dir>, fix cwd/.aitriad.json so conflicts resolve, "
+            "or pass --allow-missing-conflicts if this run is intentionally conflict-free.",
+        )
+
+    try:
+        expected = len(json.loads(conflicts_file.read_text(encoding="utf-8")).get("conflicts", []))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise _err(
+            f"could not read conflicts source {conflicts_file}: {exc}",
+            "Verify the conflicts.json file is valid JSON and readable.",
+        )
+
+    if conflict_count != expected:
+        raise _err(
+            f"conflict count mismatch: corpus has {conflict_count} but source {conflicts_file} "
+            f"has {expected} — a partial or total conflict drop.",
+            "Check CONFLICTS_DIR resolution and the conflict load path; do not ship a truncated corpus.",
+        )
+
+
 def cmd_generate(args):
     """Rebuild embeddings.json from all taxonomy JSON files and policy registry.
 
@@ -406,6 +475,17 @@ def cmd_generate(args):
 
     if not nodes and not policies and not conflicts:
         print("Error: no taxonomy nodes, policies, or conflicts found.", file=sys.stderr)
+        sys.exit(1)
+
+    # t/2877 — fail loud BEFORE the expensive encode if a whole node class was silently
+    # dropped (e.g. conflicts, via a path/cwd mis-resolution). Never ship a truncated corpus.
+    try:
+        _assert_corpus_complete(
+            len(nodes), len(conflicts), CONFLICTS_DIR,
+            getattr(args, "allow_missing_conflicts", False),
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
     # Parse weights
@@ -983,6 +1063,24 @@ def main():
             "production embeddings (t/1553 Stage 2 needs a 0.67/0.33 variant per t/524)."
         ),
     )
+    gen.add_argument(
+        "--conflicts-dir",
+        default=None,
+        help=(
+            "Override the conflicts directory (default: resolved from .aitriad.json). "
+            "Use when running from an unusual cwd/worktree where the relative data_root "
+            "does not resolve, so conflicts are not silently dropped (t/2877)."
+        ),
+    )
+    gen.add_argument(
+        "--allow-missing-conflicts",
+        action="store_true",
+        help=(
+            "Permit a run whose conflicts source does not resolve (intentionally "
+            "conflict-free data). Without this, generate aborts rather than silently "
+            "shipping a corpus with no conflicts (t/2877)."
+        ),
+    )
 
     # query
     q = sub.add_parser("query", help="Semantic search over taxonomy nodes")
@@ -1062,7 +1160,7 @@ def main():
     sm.add_argument("--include-policies", action="store_true", help="Include pol-* nodes in matrix")
 
     args = parser.parse_args()
-    _resolve_taxonomy_dir(args.taxonomy_dir)
+    _resolve_taxonomy_dir(args.taxonomy_dir, getattr(args, "conflicts_dir", None))
 
     if args.command == "generate":
         cmd_generate(args)

--- a/scripts/test_generate_guard.py
+++ b/scripts/test_generate_guard.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+"""Regression tests for the t/2877 generate corpus-completeness guard.
+
+`_assert_corpus_complete` fails loud when `generate` would ship a corpus missing a
+node class the source contains (the silent-degradation class from the t/2875 recovery).
+Pure — no model encode — so both arms run fast under pytest or standalone:
+  `python test_generate_guard.py`.
+"""
+
+import importlib.util
+import json
+import tempfile
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "embed_taxonomy", Path(__file__).resolve().parent / "embed_taxonomy.py"
+)
+embed_taxonomy = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(embed_taxonomy)
+
+
+def _make_conflicts_dir(tmp: Path, n: int) -> Path:
+    (tmp / "conflicts.json").write_text(
+        json.dumps({"conflicts": [{"claim_id": f"c{i}"} for i in range(n)]}),
+        encoding="utf-8",
+    )
+    return tmp
+
+
+def test_passes_when_counts_match():
+    """PASS arm: conflicts source resolves and corpus count == source entries."""
+    with tempfile.TemporaryDirectory() as d:
+        cdir = _make_conflicts_dir(Path(d), 5)
+        embed_taxonomy._assert_corpus_complete(10, 5, cdir, False)  # must not raise
+
+
+def test_fires_on_unresolved_conflicts_dir():
+    """FIRE arm (the incident): conflicts_dir does not resolve → abort, name the fix."""
+    with tempfile.TemporaryDirectory() as d:
+        missing = Path(d) / "does-not-exist"
+        try:
+            embed_taxonomy._assert_corpus_complete(10, 0, missing, False)
+        except ValueError as e:
+            assert "did not resolve" in str(e)
+            assert "--conflicts-dir" in str(e)
+        else:
+            raise AssertionError("expected ValueError for unresolved conflicts dir")
+
+
+def test_allow_missing_conflicts_opt_out():
+    """A legitimately conflict-free run passes with the explicit opt-out."""
+    with tempfile.TemporaryDirectory() as d:
+        missing = Path(d) / "does-not-exist"
+        embed_taxonomy._assert_corpus_complete(10, 0, missing, True)  # must not raise
+
+
+def test_fires_on_partial_drop():
+    """FIRE arm (TL condition 1): exact-count — a PARTIAL drop must also abort."""
+    with tempfile.TemporaryDirectory() as d:
+        cdir = _make_conflicts_dir(Path(d), 5)
+        try:
+            embed_taxonomy._assert_corpus_complete(10, 4, cdir, False)  # 4 != 5
+        except ValueError as e:
+            assert "count mismatch" in str(e)
+            assert "4" in str(e) and "5" in str(e)
+        else:
+            raise AssertionError("expected ValueError for a partial conflict drop")
+
+
+def test_fires_on_zero_nodes():
+    """FIRE arm: an empty POV node set is always an error."""
+    with tempfile.TemporaryDirectory() as d:
+        cdir = _make_conflicts_dir(Path(d), 5)
+        try:
+            embed_taxonomy._assert_corpus_complete(0, 5, cdir, False)
+        except ValueError as e:
+            assert "0 taxonomy POV nodes" in str(e)
+        else:
+            raise AssertionError("expected ValueError for 0 nodes")
+
+
+def test_conflicts_dir_override_resolves():
+    """Root-cause fix: --conflicts-dir wins over config/fallback resolution."""
+    saved = (embed_taxonomy.TAXONOMY_DIR, embed_taxonomy.EMBEDDINGS_FILE, embed_taxonomy.CONFLICTS_DIR)
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            cdir = Path(d) / "myconflicts"
+            cdir.mkdir()
+            embed_taxonomy._resolve_taxonomy_dir(
+                override=str(Path(d) / "taxonomy"), conflicts_override=str(cdir)
+            )
+            assert embed_taxonomy.CONFLICTS_DIR == cdir.resolve()
+    finally:
+        embed_taxonomy.TAXONOMY_DIR, embed_taxonomy.EMBEDDINGS_FILE, embed_taxonomy.CONFLICTS_DIR = saved
+
+
+if __name__ == "__main__":
+    test_passes_when_counts_match()
+    test_fires_on_unresolved_conflicts_dir()
+    test_allow_missing_conflicts_opt_out()
+    test_fires_on_partial_drop()
+    test_fires_on_zero_nodes()
+    test_conflicts_dir_override_resolves()
+    print("OK: all t/2877 generate-guard tests passed")


### PR DESCRIPTION
## Summary
Durable prevention for the t/2875 silent-degradation near-miss — a path/cwd quirk produced an `embeddings.json` missing all 1,240 conflicts while `generate` still exited 0. TL-approved design (t/2877#2), Quality-lane review.

**Part 1 — the guard (`_assert_corpus_complete`, pure/unit-testable).** Before writing, `generate` aborts non-zero with an actionable Goal/Problem/Next-Steps message if:
- POV nodes == 0 (empty/mis-resolved taxonomy);
- the conflicts source did **not** resolve to a real `conflicts.json` (the exact incident — a naive "corpus conflicts > 0" check wouldn't fire, because mis-resolution makes the source *look* empty);
- the corpus conflict count does **not exactly match** the source entries (catches **partial** drops too — TL condition 1).
`--allow-missing-conflicts` opts out for intentionally conflict-free runs.

**Part 2 — root cause.** New `--conflicts-dir` flag, and `_resolve_taxonomy_dir` now resolves `CONFLICTS_DIR` from `.aitriad.json` even under `--taxonomy-dir` override (it previously fell back to the script parent → the drop).

## Gate Verification — caller audit
The only `cmd_generate` caller is `Update-TaxEmbeddings` (runs against real data *with* conflicts → guard passes; no flag change). `check_composition_drift.py` imports `embed_taxonomy` but uses `_load_taxonomy_nodes`/field helpers, **not** `cmd_generate`. No CI job or test runs `generate` on a conflict-free source ⇒ **abort-by-default reds no clean pipeline.**

## Both-arms evidence
**FIRE** (the incident, real CLI) — `generate --conflicts-dir C:\nonexistent\conflicts` against real taxonomy:
```
Error: Goal: Regenerate a complete embeddings.json ...
Problem: CONFLICTS_DIR did not resolve to an existing conflicts.json (looked at C:\nonexistent\conflicts\conflicts.json); conflicts would be silently dropped from the corpus.
Next Steps: Pass --conflicts-dir <dir>, fix cwd/.aitriad.json ..., or --allow-missing-conflicts ...
cli_exit=1
```
(aborts *before* the model load — fast.)

**PASS** — `scripts/test_generate_guard.py` 6/6 (counts-match, unresolved-dir fire, opt-out, **partial-drop** fire, zero-nodes fire, `--conflicts-dir` override); existing `test_load_taxonomy_nodes.py` + `test_embed_envelope.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)