### PR TITLE
feat(cmdlet): Get-CIFailureSummary — one-call CI failure triage (t/2882)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -134,6 +134,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Disable-ContainerAppRevision` | Deactivate an ACA revision (stale cleanup or rollback tail); non-fatal on failure — matches deploy YAML's `\|\| true` semantics (t/1500 Phase 3) |
 | `Get-ContainerAppDiagnostics` | Combined revision-show + console + system logs for failure triage; polls 30s for logs to appear before declaring unavailable (t/1500 Phase 3) |
 | `Get-GitHubWorkflowRun` | Fetch a workflow run + per-job conclusions for a commit SHA or run ID (t/1499) |
+| `Get-CIFailureSummary` | One-call CI triage — pull failing Pester tests + real infra errors from a gh run log (t/2882) |
 | `Remove-StaleContainerImages` | GHCR cleanup — paginate → filter → delete untagged image versions with `-WhatIf` (t/1492) |
 | `Get-TaxonomySnapshot` | Fetch the 11-file taxonomy + conflict snapshot from ai-triad-data with commit-SHA stamping (t/1493) |
 | `Test-TaxonomyDirContents` | Pre-embedding TAXONOMY_DIR validation — flags files whose `nodes` field would crash `Update-TaxEmbeddings` (dict/null instead of a list of objects); mirrors embed_taxonomy.py skip logic (t/1654) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -192,6 +192,7 @@
         'Get-ContainerAppRevision'
         # t/1499 — GH workflow run queries
         'Get-GitHubWorkflowRun'
+        'Get-CIFailureSummary'
         # t/1550 — POV aphorism backfill
         'Invoke-AphorismBatch'
         # t/1553 Stage 0 — org PUBLISHED edge seeding

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -936,6 +936,7 @@ Export-ModuleMember -Function @(
     'Get-ContainerAppRevision'
     # t/1499 — GH workflow run queries
     'Get-GitHubWorkflowRun'
+    'Get-CIFailureSummary'
     # t/1550 — POV aphorism backfill
     'Invoke-AphorismBatch'
     # t/1553 Stage 0 — org PUBLISHED edge seeding

--- a/scripts/AITriad/Private/ConvertFrom-CILog.ps1
+++ b/scripts/AITriad/Private/ConvertFrom-CILog.ps1
@@ -1,0 +1,94 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function ConvertFrom-CILog {
+    <#
+    .SYNOPSIS
+        Pure parser (t/2882): extract Pester failures and error lines from a gh run log.
+    .DESCRIPTION
+        Takes the raw text of a `gh run view --log`/`--log-failed` capture and returns a
+        structured summary: the failing Pester test names, the raw `[-]` failure lines
+        plus their assertion detail (test-emitted), and the remaining `##[error]` lines
+        (real infrastructure errors — a failed step, a module-load error, etc.).
+
+        Pure by design (no gh call) so it is unit-testable against synthetic log text.
+    .PARAMETER LogText
+        The captured CI log text.
+    .PARAMETER FailedJobs
+        Optional list of failed job names (from `gh run view --json jobs`), echoed through.
+    .OUTPUTS
+        [PSCustomObject] with FailedJobs, FailingTests, PesterFailureLines, InfraErrorLines,
+        FailedCount.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$LogText,
+
+        [Parameter()]
+        [string[]]$FailedJobs = @()
+    )
+
+    Set-StrictMode -Version Latest
+
+    $FailingTests       = [System.Collections.Generic.List[string]]::new()
+    $PesterFailureLines = [System.Collections.Generic.List[string]]::new()
+    $InfraErrorLines    = [System.Collections.Generic.List[string]]::new()
+    $FailedCount        = $null
+
+    # gh prefixes each line with "job<TAB>step<TAB>timestamp "; strip a leading
+    # "<stuff>##[error]" and any leading timestamp so matching is prefix-agnostic.
+    $Lines = $LogText -split "\r?\n"
+    $InAssertionBlock = $false
+
+    foreach ($Raw in $Lines) {
+        # `gh run view --log` prefixes each line with "job<TAB>step<TAB>ISO-timestamp ".
+        # Strip up to and including that timestamp so content matches cleanly (no-op when
+        # the caller pipes an already-clean log).
+        $Line = ($Raw -replace '^.*?\d{4}-\d{2}-\d{2}T[0-9:.]+Z\s+', '').Trim()
+        if ([string]::IsNullOrWhiteSpace($Line)) { continue }
+
+        # A Pester FAILING test line: "[-] <name> <ms>", optionally prefixed with ##[error].
+        if ($Line -match '\[-\]\s+(.+?)(?:\s+\d+(?:\.\d+)?\s*ms)?\s*$') {
+            $Name = ($Matches[1] -replace '^.*##\[error\]', '').Trim()
+            $FailingTests.Add($Name)
+            $PesterFailureLines.Add(($Line -replace '^.*##\[error\]', '').Trim())
+            $InAssertionBlock = $true
+            continue
+        }
+
+        # Assertion detail that belongs to the failing test just above it.
+        if ($InAssertionBlock -and
+            $Line -match 'Expected|But was|but got|Should\s|##\[group\]Message|at .+:\d+') {
+            $PesterFailureLines.Add(($Line -replace '^.*##\[error\]', '').Trim())
+            continue
+        }
+        $InAssertionBlock = $false
+
+        # Pester's own run summary — pull the failed count if present.
+        if ($Line -match 'Tests? (?:Passed|completed).*Failed:\s*(\d+)' -or
+            $Line -match 'Failed:\s*(\d+)\b') {
+            $FailedCount = [int]$Matches[1]
+            continue
+        }
+
+        # Everything else carrying ##[error] that is NOT a test failure/assertion and NOT
+        # the generic step-wrapper marker is a real infrastructure error.
+        if ($Line -match '##\[error\]' -and
+            $Line -notmatch '\[-\]' -and
+            $Line -notmatch 'Process completed with exit code') {
+            $Msg = ($Line -replace '^.*##\[error\]', '').Trim()
+            if ($Msg) { $InfraErrorLines.Add($Msg) }
+        }
+    }
+
+    return [PSCustomObject]@{
+        FailedJobs         = @($FailedJobs)
+        FailingTests       = @($FailingTests)
+        PesterFailureLines = @($PesterFailureLines)
+        InfraErrorLines    = @($InfraErrorLines)
+        FailedCount        = $FailedCount
+    }
+}

--- a/scripts/AITriad/Public/Get-CIFailureSummary.ps1
+++ b/scripts/AITriad/Public/Get-CIFailureSummary.ps1
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-CIFailureSummary {
+    <#
+    .SYNOPSIS
+        Extract Pester failures and error lines from a GitHub Actions run log (t/2882).
+    .DESCRIPTION
+        One call to surface why a CI run failed instead of several
+        `gh run view --log | Select-String` passes. Resolves a run (explicit -RunId,
+        latest failed run for -WorkflowFile, or the latest failed run), pulls the
+        failed-step log via `gh run view --log-failed`, and returns a structured
+        summary: failed job names, failing Pester test names, the `[-]` failure lines
+        with their assertion detail (test-emitted), and the remaining `##[error]`
+        lines (real infrastructure errors).
+    .PARAMETER RunId
+        The GitHub Actions run id. If omitted, the latest failed run is used
+        (optionally filtered by -WorkflowFile).
+    .PARAMETER WorkflowFile
+        Workflow file name (e.g. 'ci.yml') to scope the latest-failed-run lookup.
+    .OUTPUTS
+        [PSCustomObject] with RunId, FailedJobs, FailingTests, PesterFailureLines,
+        InfraErrorLines, FailedCount.
+    .EXAMPLE
+        Get-CIFailureSummary
+    .EXAMPLE
+        Get-CIFailureSummary -RunId 31614727103
+    .EXAMPLE
+        Get-CIFailureSummary -WorkflowFile ci.yml | Select-Object -ExpandProperty FailingTests
+    .LINK
+        Show-AITriadHelp
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Position = 0)]
+        [string]$RunId,
+
+        [Parameter()]
+        [string]$WorkflowFile
+    )
+
+    Set-StrictMode -Version Latest
+
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        throw (New-ActionableError `
+            -Goal 'Summarize a CI failure' `
+            -Problem 'GitHub CLI (gh) was not found on PATH.' `
+            -Location 'Get-CIFailureSummary' `
+            -NextSteps 'Install the GitHub CLI and authenticate (gh auth login), then retry.')
+    }
+
+    # ── Resolve the run id ────────────────────────────────────────────────
+    if (-not $RunId) {
+        $ListArgs = @('run', 'list', '--status', 'failure', '--limit', '1', '--json', 'databaseId,name,workflowName')
+        if ($WorkflowFile) { $ListArgs += @('--workflow', $WorkflowFile) }
+        $ListRaw = & gh @ListArgs 2>$null
+        $Runs = if ($ListRaw) { @($ListRaw | ConvertFrom-Json) } else { @() }
+        if ($Runs.Count -eq 0) {
+            throw (New-ActionableError `
+                -Goal 'Summarize a CI failure' `
+                -Problem "No failed run found$(if ($WorkflowFile) { " for workflow '$WorkflowFile'" })." `
+                -Location 'Get-CIFailureSummary' `
+                -NextSteps 'Pass -RunId explicitly, or verify with: gh run list --status failure.')
+        }
+        $RunId = [string]$Runs[0].databaseId
+    }
+
+    # ── Failed job names ──────────────────────────────────────────────────
+    $FailedJobs = @()
+    $JobsRaw = & gh run view $RunId --json jobs 2>$null
+    if ($JobsRaw) {
+        try {
+            $JobsObj = $JobsRaw | ConvertFrom-Json
+            if ($JobsObj.PSObject.Properties['jobs']) {
+                $FailedJobs = @($JobsObj.jobs |
+                    Where-Object { $_.conclusion -eq 'failure' } |
+                    ForEach-Object { $_.name })
+            }
+        } catch {
+            Write-Warning "Get-CIFailureSummary: could not parse jobs for run $RunId — $($_.Exception.Message)"
+        }
+    }
+
+    # ── Failed-step log (fall back to full log if empty) ─────────────────
+    $Log = (& gh run view $RunId --log-failed 2>$null) -join "`n"
+    if ([string]::IsNullOrWhiteSpace($Log)) {
+        $Log = (& gh run view $RunId --log 2>$null) -join "`n"
+    }
+    if ([string]::IsNullOrWhiteSpace($Log)) {
+        throw (New-ActionableError `
+            -Goal 'Summarize a CI failure' `
+            -Problem "Could not retrieve any log for run $RunId (empty output from gh run view)." `
+            -Location 'Get-CIFailureSummary' `
+            -NextSteps "Verify the run id and access: gh run view $RunId --log-failed.")
+    }
+
+    $Summary = ConvertFrom-CILog -LogText $Log -FailedJobs $FailedJobs
+    return ($Summary | Add-Member -NotePropertyName RunId -NotePropertyValue $RunId -PassThru)
+}

--- a/tests/Get-CIFailureSummary.Tests.ps1
+++ b/tests/Get-CIFailureSummary.Tests.ps1
@@ -1,0 +1,91 @@
+# Tag: ci (t/2882)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Get-CIFailureSummary (t/2882) and its pure parser ConvertFrom-CILog.
+    The parser is exercised with synthetic gh-log text — no network / no gh call.
+#>
+
+BeforeAll {
+    Import-Module "$PSScriptRoot/../scripts/AITriad/AITriad.psm1" -Force -WarningAction SilentlyContinue
+
+    # Realistic gh `run view --log` shape: "job<TAB>step<TAB>ISO-timestamp <content>".
+    $script:SampleLog = @(
+        "test-powershell`tRun tests`t2026-08-12T15:57:47.4Z Describing Register-AIBackend auth hardening",
+        "test-powershell`tRun tests`t2026-08-12T15:57:47.4Z   [+] GET / without token returns 401 26ms",
+        "test-powershell`tRun tests`t2026-08-12T15:57:47.4Z ##[error][-] GET /api/reveal with spoofed Host header returns 403 17ms",
+        "test-powershell`tRun tests`t2026-08-12T15:57:47.4Z ##[group]Message",
+        "test-powershell`tRun tests`t2026-08-12T15:57:47.4Z Expected 403, but got 404.",
+        "test-powershell`tRun tests`t2026-08-12T15:57:47.4Z at `$status | Should -Be 403, Register-AIBackend.Auth.Tests.ps1:144",
+        "test-powershell`tRun tests`t2026-08-12T15:57:50.0Z Tests Passed: 42, Failed: 1, Skipped: 0",
+        "test-powershell`tRun tests`t2026-08-12T15:57:50.1Z ##[error]Import-Module: Could not load module 'Foo'",
+        "build`tCompile`t2026-08-12T15:58:00.0Z ##[error]Process completed with exit code 1"
+    ) -join "`n"
+}
+
+Describe 'Get-CIFailureSummary (t/2882)' -Tag 'ci' {
+
+    It 'is exported from the AITriad module' {
+        Get-Command -Module AITriad -Name 'Get-CIFailureSummary' | Should -Not -BeNullOrEmpty
+    }
+
+    Context 'ConvertFrom-CILog parser' {
+
+        It 'extracts the failing Pester test name (from the [-] line, timestamp/prefix stripped)' {
+            InModuleScope AITriad -Parameters @{ Log = $script:SampleLog } {
+                param($Log)
+                $r = ConvertFrom-CILog -LogText $Log
+                $r.FailingTests | Should -Contain 'GET /api/reveal with spoofed Host header returns 403'
+                @($r.FailingTests).Count | Should -Be 1
+            }
+        }
+
+        It 'captures the assertion detail into PesterFailureLines (clean, no gh prefix)' {
+            InModuleScope AITriad -Parameters @{ Log = $script:SampleLog } {
+                param($Log)
+                $r = ConvertFrom-CILog -LogText $Log
+                ($r.PesterFailureLines -join "`n") | Should -Match 'Expected 403, but got 404\.'
+                # The prefix/timestamp must be stripped.
+                ($r.PesterFailureLines -join "`n") | Should -Not -Match 'test-powershell'
+            }
+        }
+
+        It 'classifies a real infra error as infra, not a test failure' {
+            InModuleScope AITriad -Parameters @{ Log = $script:SampleLog } {
+                param($Log)
+                $r = ConvertFrom-CILog -LogText $Log
+                ($r.InfraErrorLines -join "`n") | Should -Match "Could not load module 'Foo'"
+                # The [-] test failure must NOT be in the infra bucket.
+                ($r.InfraErrorLines -join "`n") | Should -Not -Match 'spoofed Host'
+            }
+        }
+
+        It 'ignores the generic "Process completed with exit code" step-wrapper noise' {
+            InModuleScope AITriad -Parameters @{ Log = $script:SampleLog } {
+                param($Log)
+                $r = ConvertFrom-CILog -LogText $Log
+                ($r.InfraErrorLines -join "`n") | Should -Not -Match 'Process completed with exit code'
+            }
+        }
+
+        It 'extracts the Pester failed count' {
+            InModuleScope AITriad -Parameters @{ Log = $script:SampleLog } {
+                param($Log)
+                $r = ConvertFrom-CILog -LogText $Log
+                $r.FailedCount | Should -Be 1
+            }
+        }
+
+        It 'returns empty structures (no throw) for an empty log' {
+            InModuleScope AITriad {
+                $r = ConvertFrom-CILog -LogText ''
+                @($r.FailingTests).Count    | Should -Be 0
+                @($r.InfraErrorLines).Count | Should -Be 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`Get-CIFailureSummary [-RunId] [-WorkflowFile]` (t/2882) — cuts CI-failure diagnosis from several `gh run view --log | Select-String` passes to one call. Resolves a run (explicit `-RunId`, latest failed for `-WorkflowFile`, or latest failed), pulls the failed-step log, and returns a structured summary:
- `FailedJobs`, `FailingTests` (Pester names), `PesterFailureLines` (the `[-]` lines + assertion detail — test-emitted), `InfraErrorLines` (real `##[error]` infra errors), `FailedCount`.

The parsing lives in a **pure** Private helper `ConvertFrom-CILog` (no gh call) so it is unit-testable on synthetic log text. It strips the gh `job/step/timestamp` prefix, distinguishes **test-emitted** errors (a `[-]` failure + its assertion block) from **infra** errors, and ignores the generic `Process completed with exit code` step-wrapper noise.

Self-cert **/add-ps-cmdlet** (new public cmdlet, standard conventions).

## Test plan
- [x] 7 Pester tests (`tests/Get-CIFailureSummary.Tests.ps1`): export check + parser — failing-test extraction, assertion-detail capture (prefix stripped), infra-vs-test classification, exit-code-noise ignored, failed-count, empty-log-no-throw. All green locally.
- [x] `Test-ModuleManifest` clean; cmdlet loads.

**Hold note:** `test-powershell` on this branch is red from the pre-existing #1344/#1345 SKIP_FILES-vs-fixture race (fix in flight as #1347). Will rebase onto green main and land after #1347 — same as #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)