### PR TITLE
fix(deploy): cap taxonomy-editor maxReplicas:1 to eliminate export-404 race (t/2885)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -671,8 +671,10 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
       ]
       scale: {
         // Scale-out restored after t/683 (ed489b9): AnonymousSessionStore is now
-        // file-backed on the shared /mnt/shared volume, so debate state is
-        // replica-independent — the single-replica stopgap is no longer needed.
+        // file-backed on the shared /mnt/shared volume — AnonymousSessionStore
+        // (debate/session state) IS replica-independent. HOWEVER: brief-export
+        // and oped job stores are still per-process in-memory Maps and are NOT
+        // replica-independent; see maxReplicas cap below (t/2885, 2026-08-20).
         // minReplicas reverted 1->0 (t/1354, 2026-07-07): prod was costing
         // ~$24 in its first 6 days of July alone (~$120+/mo projected) from
         // running 1 vCPU/2GiB continuously. Owner accepted the cold-start

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -679,7 +679,13 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         // latency tradeoff this reintroduces (previously fixed for the same
         // reason in e247ef75, 2026-05-05) in exchange for scale-to-zero savings.
         minReplicas: 0
-        maxReplicas: 5
+        // maxReplicas capped at 1 (t/2885, 2026-08-20): brief-export and oped job
+        // stores are per-process in-memory Maps. Running >1 replica means a POST
+        // that creates a job on replica A and a GET poll on replica B → 404.
+        // DO NOT raise this above 1 until the job store is backed by shared blob
+        // storage (t/2885 deferred). Raising it silently reintroduces the t/2884
+        // export-404 race with no error at startup.
+        maxReplicas: 1
         rules: [
           {
             name: 'http-scaler'


### PR DESCRIPTION
## Summary

- `maxReplicas: 5 → 1` in `deploy/azure/main.bicep` for the taxonomy-editor app
- Co-located comment at the line explains WHY (in-memory job store; raising >1 reinstates the t/2884 404 race — blob-store t/2885 is prerequisite to scaling out)

**Root cause:** brief-export and oped job stores are per-process in-memory Maps. With maxReplicas:5, POST creates a job on replica A and the GET poll may hit replica B → 404 "Export job not found" (observed prod, t/2884).

**Cost:** zero — minReplicas stays 0 (scale-to-zero preserved); current traffic never triggered scale-out to >1 replica.

## Hold — DRAFT until Second Opinion concurs

TL concurs (p/331#465); waiting on Second Opinion sign-off per shared-infra trigger before undrafting. Do not enable auto-merge.

## Test plan

- [ ] CI green (Bicep-env-drift gate, workflow-lint)
- [ ] After merge + deploy: run `Invoke-TaxEditorSmokeTest` to confirm app starts cleanly at maxReplicas:1
- [ ] Brief-export 404 no longer reproducible

🤖 Generated with [Claude Code](https://claude.com/claude-code)