### PR TITLE
fix(brief): backfill dropped camps in narrated mode (t/2883)

### DIFF
--- a/lib/brief/campBackfill.test.ts
+++ b/lib/brief/campBackfill.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2883 — end-to-end regression for the narrated-mode camp-completeness fix (B1).
+// A narrator that drops a whole camp used to hard-fail verify's presence-symmetry
+// arm ("camp X … 0 slides in the narration"), failing the user's export at the
+// far-away verify stage. B1: repair re-prompt first, then deterministic backfill
+// from the camp's REAL top_claim, surfaced in BOTH an FR event and the export-record
+// warnings so the narrator drop signal survives (block→repair-and-warn).
+//
+// These run the REAL pipeline (extract → narrate → render → verify) with a stub
+// adapter, so they exercise the full data path a community-copied debate hits.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runBriefPipeline } from './pipeline.js';
+import type { AIAdapter } from '../debate/aiAdapter.js';
+import { setGlobalRecorder, clearGlobalRecorder } from '../flight-recorder/index.js';
+
+// Full-form camp labels ('accelerationist' …) as seen in the FR (t/2883). Three
+// camps, each with a top_claim, mirroring a real closed debate (and a community
+// copy, which — proven in the diagnosis — is shape-identical after extract).
+function makeSession(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const camps = ['accelerationist', 'safetyist', 'skeptic'];
+  const strength: Record<string, number> = { accelerationist: 0.72, safetyist: 0.71, skeptic: 0.70 };
+  return {
+    id: 'sess-cc', run_id: 'run-cc', title: 'Should AI safety be legally mandated?',
+    debate_model: 'gemini-2.5-flash', protocol_id: 'structured', phase: 'closed',
+    topic: {
+      final: 'AI safety requirements should be legally mandated',
+      scope: { key_tensions: ['innovation vs. safety'] },
+      critique: { rating: 'fair', composite_score: 12 },
+    },
+    transcript: [{
+      type: 'concluding',
+      metadata: {
+        synthesis: {
+          areas_of_agreement: [{ point: 'AI risks are real and worth addressing' }],
+          areas_of_disagreement: [{ point: 'Mandatory thresholds are net harmful', bdi_layer: 'belief' }],
+          unresolved_questions: ['What metrics define sufficient safety?'],
+          cruxes: [{ question: 'Will mandates stifle innovation?', type: 'EMPIRICAL', if_yes: 'x', if_no: 'y' }],
+          preferences: [],
+          argument_map: camps.map(c => ({ claim_id: `am-${c}`, claim: `${c} core argument`, claimant: c, supported_by: [], attacked_by: [] })),
+        },
+      },
+    }],
+    argument_network: {
+      nodes: camps.map(c => ({
+        id: `n-${c}`,
+        // Comparable length across camps so the ratio arms stay in tolerance after backfill.
+        text: `The ${c} camp position on mandate policy scope`,
+        speaker: c,
+        scoring_method: 'bdi_criteria',
+        computed_strength: strength[c],
+      })),
+    },
+    commitments: Object.fromEntries(camps.map(c => [c, { asserted: ['a'], conceded: [], challenged: [] }])),
+    convergence_tracker: { issues: [{ taxonomy_ref: 'ref', convergence: 0.5, qbaf_strength: 0.5 }] },
+    crux_tracker: [{ id: 'cx1', description: 'Will mandates stifle innovation?', state: 'engaged' }],
+    ...overrides,
+  };
+}
+
+const META = { toolVersions: { brief: '1.0.0' }, timestamp: '2026-08-20T00:00:00.000Z' };
+
+// Records FR events for the observability assertion (the FR arm of the fix).
+interface CapturedEvent { message?: string; data?: Record<string, unknown> }
+let events: CapturedEvent[];
+
+beforeEach(() => {
+  events = [];
+  setGlobalRecorder({ record: (e: CapturedEvent) => events.push(e) } as never);
+});
+afterEach(() => clearGlobalRecorder());
+
+/** A narrator that covers safetyist + skeptic top_claims but ALWAYS omits
+ *  accelerationist — even on the repair retry — so backfill must engage. */
+function omitAccelerationistAdapter(): AIAdapter {
+  return {
+    generateText: vi.fn().mockResolvedValue(JSON.stringify({
+      entries: [
+        { trace: '/top_claims/1', text: 'The safetyist camp position on mandate policy scope', slide: 1 },
+        { trace: '/top_claims/2', text: 'The skeptic camp position on mandate policy scope', slide: 2 },
+        { trace: '/agreements/0', text: 'Both sides agree AI risks are real', slide: 3 },
+      ],
+      audience_questions: [],
+    })),
+  } as unknown as AIAdapter;
+}
+
+describe('t2883 camp backfill — narrated mode drops a camp', () => {
+  it('repairs, then backfills the dropped camp from its top_claim → export SUCCEEDS with a warning', async () => {
+    const adapter = omitAccelerationistAdapter();
+    const res = await runBriefPipeline(
+      { session: makeSession() as never, preset: 'conference', modelId: 'gemini-2.5-flash', modelSource: 'Explicit', toolVersions: META.toolVersions, timestamp: META.timestamp },
+      adapter,
+    );
+
+    // Pass-post: the gate no longer hard-fails (pre-fix this held the symmetry error).
+    expect(res.hardFailures).toEqual([]);
+
+    // Presence: accelerationist now has ≥1 slide via the backfill.
+    const acc = res.manifest.symmetry.camps.find(c => c.camp === 'accelerationist');
+    expect(acc?.slide_count).toBeGreaterThanOrEqual(1);
+
+    // Export-record observability arm: a camp_backfill warning naming the camp.
+    expect(res.warnings.some(w => /camp_backfill.*accelerationist/.test(w))).toBe(true);
+
+    // Repair-first: the narrator was re-prompted before backfill kicked in.
+    expect((adapter.generateText as ReturnType<typeof vi.fn>)).toHaveBeenCalledTimes(2);
+
+    // FR observability arm: a repair event, then the backfill event naming the camp.
+    expect(events.some(e => e.data?.reason === 'missing-camp')).toBe(true);
+    const bf = events.find(e => e.data?.reason === 'camp-backfill');
+    expect(bf).toBeTruthy();
+    expect(bf?.data?.backfilledCamps).toContain('accelerationist');
+  });
+
+  it('backfill entry traces to the REAL top_claim (never fabricated text)', async () => {
+    const res = await runBriefPipeline(
+      { session: makeSession() as never, preset: 'conference', modelId: 'gemini-2.5-flash', modelSource: 'Explicit', toolVersions: META.toolVersions, timestamp: META.timestamp },
+      omitAccelerationistAdapter(),
+    );
+    const accClaim = res.spec.top_claims.find(t => t.camp === 'accelerationist')!.claim;
+    const backfilled = res.narration.entries.find(e => e.text === accClaim);
+    expect(backfilled).toBeTruthy();
+    expect(backfilled!.trace).toBe('/top_claims/0'); // accelerationist sorts first by strength
+  });
+});
+
+describe('t2883 camp backfill — clean narration does not trigger it', () => {
+  it('deterministic narration covers every camp → no backfill, no warning, verify passes', async () => {
+    const stub = { generateText: vi.fn().mockResolvedValue('{}') } as unknown as AIAdapter;
+    const res = await runBriefPipeline(
+      { session: makeSession() as never, preset: 'conference', modelId: 'm', modelSource: 'Default', skipNarration: true, toolVersions: META.toolVersions, timestamp: META.timestamp },
+      stub,
+    );
+    expect(res.hardFailures).toEqual([]);
+    expect(res.warnings.some(w => /camp_backfill/.test(w))).toBe(false);
+    for (const camp of ['accelerationist', 'safetyist', 'skeptic']) {
+      expect(res.manifest.symmetry.camps.find(c => c.camp === camp)?.slide_count).toBeGreaterThanOrEqual(1);
+    }
+    expect(events.some(e => e.data?.reason === 'camp-backfill')).toBe(false);
+    // Deterministic mode makes no model call for narration.
+    expect((stub.generateText as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+});

--- a/lib/brief/campCoverage.test.ts
+++ b/lib/brief/campCoverage.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2883 — unit tests for the shared camp-coverage helpers used by BOTH the
+// narrate completeness gate and the verify presence arm (they must not drift).
+
+import { describe, it, expect } from 'vitest';
+import type { DeckSpec } from './types.js';
+import { expectedCamps, campOfTrace, campsCovered, missingCamps } from './campCoverage.js';
+
+function makeSpec(): DeckSpec {
+  return {
+    deck_spec_version: '1.0',
+    meta: { id: 's', run_id: 'r', title: 'T', model: 'm', protocol: 'structured', phase: 'closed' },
+    question: { core_proposition: 'Q?' },
+    framing_critique: { rating: 'fair', composite: 1 },
+    agreements: [{ text: 'agree' }],
+    disagreements: [],
+    cruxes: [],
+    resolution_analysis: { stronger_camp_findings: [] },
+    unresolved_questions: [],
+    argument_map: { nodes: [], relations: [] },
+    fact_checks: [],
+    concessions: [],
+    top_claims: [
+      { camp: 'skeptic', claim: 'skp claim', strength: 0.6 },
+      { camp: 'accelerationist', claim: 'acc claim', strength: 0.8 },
+    ],
+    convergence: [],
+    open_threads: [],
+  } as unknown as DeckSpec;
+}
+
+describe('expectedCamps', () => {
+  it('returns the sorted unique top_claims camps', () => {
+    expect(expectedCamps(makeSpec())).toEqual(['accelerationist', 'skeptic']);
+  });
+});
+
+describe('campOfTrace', () => {
+  const spec = makeSpec();
+  it('reads the camp of a camp-bearing node', () => {
+    expect(campOfTrace(spec, '/top_claims/1')).toBe('accelerationist');
+  });
+  it('returns null for a camp-less section', () => {
+    expect(campOfTrace(spec, '/agreements/0')).toBeNull();
+  });
+  it('returns null for an unresolvable trace', () => {
+    expect(campOfTrace(spec, '/nope/9')).toBeNull();
+  });
+});
+
+describe('campsCovered / missingCamps', () => {
+  const spec = makeSpec();
+  it('covers only the camps whose nodes are traced', () => {
+    expect([...campsCovered(spec, ['/top_claims/1'])]).toEqual(['accelerationist']);
+  });
+  it('flags the uncovered expected camp', () => {
+    expect(missingCamps(spec, ['/top_claims/1', '/agreements/0'])).toEqual(['skeptic']);
+  });
+  it('reports no missing camps when all are traced', () => {
+    expect(missingCamps(spec, ['/top_claims/0', '/top_claims/1'])).toEqual([]);
+  });
+});

--- a/lib/brief/campCoverage.ts
+++ b/lib/brief/campCoverage.ts
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Shared camp-coverage helpers (t/2883). Extracted so the narrate stage's
+// completeness check (repair + backfill) and the verify stage's presence-symmetry
+// arm read camp membership through the SAME logic — a divergence between "which
+// camps must be covered" and "which camps a narration entry covers" would let a
+// backfill target a camp the gate doesn't check (or vice-versa), reopening the
+// exact 0-slides gap this ticket closes.
+
+import type { DeckSpec } from './types.js';
+import { resolveTrace } from './traceResolver.js';
+
+/**
+ * The camps that MUST have per-camp coverage — the debate's "positions" (spec §2.3
+ * slide 5, one card per camp). Derived from `top_claims` camps: those are the
+ * canonical camp positions the deck renders. Deliberately NOT the union of every
+ * camp-bearing node type (argument_map/concessions can carry incidental or
+ * cross-camp labels that don't warrant a slide) — a broader set would false-fire
+ * the symmetry gate, which TL flagged as the next-incident risk (e/112#4).
+ * Entry→camp ATTRIBUTION ({@link campOfTrace}) still reads all camp-bearing node
+ * types per MUST 3; only the EXPECTED set is narrowed here.
+ */
+export function expectedCamps(spec: DeckSpec): string[] {
+  const camps = new Set<string>();
+  for (const c of spec.top_claims) camps.add(c.camp);
+  return [...camps].sort();
+}
+
+/**
+ * Attribute a narration entry to a camp by resolving its trace to the spec node and
+ * reading that node's `camp`. Camp-less sections (question, agreements, cruxes, framing)
+ * resolve to nodes without a `camp` and are excluded (TL, e/112 MUST 3).
+ */
+export function campOfTrace(spec: DeckSpec, trace: string): string | null {
+  let node: unknown;
+  try {
+    node = resolveTrace(spec, trace);
+  } catch {
+    return null;
+  }
+  if (node && typeof node === 'object' && 'camp' in node) {
+    const camp = (node as { camp: unknown }).camp;
+    if (typeof camp === 'string' && camp.length > 0) return camp;
+  }
+  return null;
+}
+
+/** Set of camps covered by ≥1 of the given narration traces. */
+export function campsCovered(spec: DeckSpec, traces: string[]): Set<string> {
+  const covered = new Set<string>();
+  for (const t of traces) {
+    const camp = campOfTrace(spec, t);
+    if (camp !== null) covered.add(camp);
+  }
+  return covered;
+}
+
+/** Expected camps with zero covering narration entries — the drop the narrator made. */
+export function missingCamps(spec: DeckSpec, traces: string[]): string[] {
+  const covered = campsCovered(spec, traces);
+  return expectedCamps(spec).filter(c => !covered.has(c));
+}

--- a/lib/brief/extract.ts
+++ b/lib/brief/extract.ts
@@ -52,6 +52,10 @@ const STRIP_LIST = new Set([
   'gap_injections', 'origin', 'perturbation_result', 'lookahead_filter_weak',
   'topic_structure', 'exploration_summary', 'exploration_source_id',
   'doc_meta', 'position_drift', 'per_claim_drift', 'run_id',
+  // Community-provenance bookkeeping added on submit/copy (t/2883): not deck content.
+  // Explicitly stripped so a community-copied debate doesn't emit misleading
+  // "unmapped field" warnings (which misdirected the t/2883 diagnosis).
+  'community_metadata', 'copied_from_community',
 ]);
 
 const KNOWN_FIELDS = new Set([...MAPPED_FIELDS, ...STRIP_LIST]);

--- a/lib/brief/narrate.test.ts
+++ b/lib/brief/narrate.test.ts
@@ -190,6 +190,9 @@ describe('narrate — narrated mode (mocked adapter)', () => {
       entries: [
         { trace: '/question', text: 'Should AI be paused?', slide: 1 },
         { trace: '/cruxes/0', text: 'Key crux: scaling', slide: 2 },
+        // Cover the single top_claims camp ('saf') so the t/2883 completeness gate
+        // is satisfied — a realistic narration slides every camp's position.
+        { trace: '/top_claims/0', text: 'Pause reduces risk', slide: 3 },
       ],
       audience_questions: [
         { trace: '/cruxes/0', question: 'Will scaling cause AGI?' },
@@ -255,7 +258,10 @@ describe('narrate — narrated mode (mocked adapter)', () => {
     // The model response is valid but the assembled Narration has extra fields
     // (tested by injecting a bad response that bypasses trace check)
     const goodResponse = {
-      entries: [{ trace: '/question', text: 'ok', slide: 1 }],
+      entries: [
+        { trace: '/question', text: 'ok', slide: 1 },
+        { trace: '/top_claims/0', text: 'ok claim', slide: 2 }, // cover camp 'saf' (t/2883 gate)
+      ],
       audience_questions: [{ trace: '/cruxes/0', question: 'ok?' }],
     };
     const adapter = makeAdapter(goodResponse);
@@ -268,7 +274,11 @@ describe('narrate — narrated mode (mocked adapter)', () => {
 describe('narrate — Maker-Checker', () => {
   const spec = makeSpec();
   const goodNarratedResponse = {
-    entries: [{ trace: '/question', text: 'Pause debate', slide: 1 }],
+    entries: [
+      { trace: '/question', text: 'Pause debate', slide: 1 },
+      // Cover the single top_claims camp ('saf') — the t/2883 completeness gate.
+      { trace: '/top_claims/0', text: 'Pause reduces risk', slide: 2 },
+    ],
     audience_questions: [{ trace: '/cruxes/0', question: 'Will scaling cause AGI?' }],
   };
   const checkerPass = {

--- a/lib/brief/narrate.ts
+++ b/lib/brief/narrate.ts
@@ -15,6 +15,7 @@ import type {
   NarrationEntry, AudienceQuestion, SymmetryAudit,
 } from './types.js';
 import { buildTrace, isResolvable, resolveTrace } from './traceResolver.js';
+import { missingCamps } from './campCoverage.js';
 import narrationWriteSchema from './schemas/narration.write.json' with { type: 'json' };
 
 const LOCATION = 'lib/brief/narrate.ts:narrate';
@@ -45,6 +46,13 @@ export interface CheckerReport {
 export interface NarrationResult {
   narration: Narration;
   checkerReport?: CheckerReport;
+  /**
+   * Camps the narrator dropped that were deterministically backfilled from their
+   * real top_claim (t/2883). Empty/absent when the narrator covered every camp (or
+   * in deterministic mode, which narrates all top_claims). The pipeline forwards
+   * this to verify() so each backfilled camp surfaces as an export-record warning.
+   */
+  backfilledCamps?: string[];
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────
@@ -56,10 +64,13 @@ export async function narrate(
   const { spec, preset, modelId, modelSource, checkerModelId, checkerModelSource, skipNarration } = input;
 
   let narration: Narration;
+  let backfilledCamps: string[] = [];
   if (skipNarration) {
+    // Deterministic mode narrates every top_claim, so every camp is covered by
+    // construction — no completeness repair/backfill is possible or needed.
     narration = buildDeterministicNarration(spec, preset, modelId, modelSource);
   } else {
-    narration = await buildNarratedNarration(spec, preset, modelId, modelSource, adapter);
+    ({ narration, backfilledCamps } = await buildNarratedNarration(spec, preset, modelId, modelSource, adapter));
   }
 
   // Self-validate: AJV schema + trace resolvability (the T2 lesson)
@@ -78,7 +89,7 @@ export async function narrate(
     validateNarration(narration, spec);
   }
 
-  return { narration, checkerReport };
+  return { narration, checkerReport, backfilledCamps: backfilledCamps.length ? backfilledCamps : undefined };
 }
 
 // ── skipNarration: deterministic mode ─────────────────────────────────────────
@@ -200,13 +211,38 @@ function buildNarrationPrompt(spec: DeckSpec, preset: BriefPreset, priorErrors?:
   ].join('\n');
 }
 
+/**
+ * Build one narration entry per dropped camp, tracing to that camp's REAL top_claim
+ * (t/2883 B1 backfill). Slides continue after the highest slide the narrator used.
+ * A camp whose top_claim has empty text is skipped (nothing real to show) — it stays
+ * missing and verify's presence arm correctly hard-fails on it, since we never
+ * fabricate narration. Every expected camp derives from `top_claims`, so a missing
+ * camp always has an index; the guard is defensive only.
+ */
+function buildCampBackfillEntries(
+  spec: DeckSpec,
+  existing: NarrationEntry[],
+  missing: string[],
+): { entries: NarrationEntry[]; camps: string[] } {
+  let nextSlide = existing.reduce((m, e) => Math.max(m, e.slide ?? 0), 0) + 1;
+  const entries: NarrationEntry[] = [];
+  const camps: string[] = [];
+  for (const camp of missing) {
+    const idx = spec.top_claims.findIndex(t => t.camp === camp);
+    if (idx < 0 || !spec.top_claims[idx].claim) continue;
+    entries.push({ trace: buildTrace(['top_claims', idx]), text: spec.top_claims[idx].claim, slide: nextSlide++ });
+    camps.push(camp);
+  }
+  return { entries, camps };
+}
+
 async function buildNarratedNarration(
   spec: DeckSpec,
   preset: BriefPreset,
   modelId: string,
   modelSource: ModelSource,
   adapter: AIAdapter,
-): Promise<Narration> {
+): Promise<{ narration: Narration; backfilledCamps: string[] }> {
   const recorder = getGlobalRecorder();
   let priorErrors: string | undefined;
 
@@ -288,17 +324,51 @@ async function buildNarratedNarration(
       });
     }
 
+    // Camp-completeness gate (t/2883): the narrator can silently drop a whole camp —
+    // its top_claim is in the deck_spec (so verify's presence-symmetry arm expects a
+    // slide) but the narrator emitted 0 entries covering it, hard-failing the export
+    // at the far-away verify stage. Mirror the presence gates above: one targeted
+    // REPAIR re-prompt naming the dropped camp(s); if still missing after repair,
+    // BACKFILL one entry per camp from its REAL top_claim (never fabricated text) so
+    // the deck keeps every camp's position and the export succeeds (B1, TL t/2883#2).
+    // The backfill is surfaced (FR event here + export-record warning in verify) so
+    // the narrator drop signal survives the block→repair-and-warn conversion.
+    let backfilledCamps: string[] = [];
+    const missing = missingCamps(spec, (parsed.entries ?? []).map(e => e.trace));
+    if (missing.length > 0) {
+      const msg = `Narrator omitted camp(s): ${missing.join(', ')} — every debate camp with a top_claim must appear on ≥1 slide`;
+      if (attempt < MAX_REPAIR_RETRIES) {
+        priorErrors = `${msg}. Emit at least one entry for each omitted camp, traced to that camp's /top_claims/<i> in the provided deck_spec.`;
+        recorder?.record({ type: 'system.error' as const, component: 'brief-narrate', level: 'warn' as const, message: msg, data: { reason: 'missing-camp', missing } });
+        continue;
+      }
+      // Repair exhausted → deterministic backfill from the real top_claim (B1).
+      const backfill = buildCampBackfillEntries(spec, parsed.entries ?? [], missing);
+      parsed.entries = [...(parsed.entries ?? []), ...backfill.entries];
+      backfilledCamps = backfill.camps;
+      if (backfilledCamps.length > 0) {
+        recorder?.record({
+          type: 'system.error' as const, component: 'brief-narrate', level: 'warn' as const,
+          message: `Narrator omitted camp(s) ${backfilledCamps.join(', ')}; backfilled from their top_claim (B1, t/2883)`,
+          data: { reason: 'camp-backfill', backfilledCamps },
+        });
+      }
+    }
+
     return {
-      deck_spec_version: DECK_SPEC_VERSION,
-      narration_mode: 'narrated',
-      preset,
-      narrator_model: modelId,
-      narrator_model_source: modelSource,
-      checker_model: null,
-      checker_model_source: null,
-      checker_passed: null,
-      entries: parsed.entries ?? [],
-      audience_questions: parsed.audience_questions ?? [],
+      narration: {
+        deck_spec_version: DECK_SPEC_VERSION,
+        narration_mode: 'narrated',
+        preset,
+        narrator_model: modelId,
+        narrator_model_source: modelSource,
+        checker_model: null,
+        checker_model_source: null,
+        checker_passed: null,
+        entries: parsed.entries ?? [],
+        audience_questions: parsed.audience_questions ?? [],
+      },
+      backfilledCamps,
     };
   }
 

--- a/lib/brief/pipeline.ts
+++ b/lib/brief/pipeline.ts
@@ -109,7 +109,7 @@ export async function runBriefPipeline(
 
   // ── narrate (+ optional maker-checker) ──
   onStage?.('narrating');
-  const { narration } = await narrate({
+  const { narration, backfilledCamps } = await narrate({
     spec,
     preset: input.preset,
     modelId: input.modelId,
@@ -141,6 +141,7 @@ export async function runBriefPipeline(
     narration,
     pptxBytes,
     meta: { toolVersions: input.toolVersions, timestamp: input.timestamp },
+    backfilledCamps,
   });
   // Manifest is the output record, NOT a hashed input artifact — added here, not in verify().
   emit({ name: BRIEF_ARTIFACTS.manifest, text: JSON.stringify(manifest, null, 2) });

--- a/lib/brief/verify.ts
+++ b/lib/brief/verify.ts
@@ -22,7 +22,8 @@ import type {
   FactCheckVerdict, ModelSource,
 } from './types.js';
 import { BRIEF_ARTIFACTS } from './types.js';
-import { isResolvable, resolveTrace } from './traceResolver.js';
+import { isResolvable } from './traceResolver.js';
+import { expectedCamps, campOfTrace } from './campCoverage.js';
 import deckSpecSchema from './schemas/deck_spec.write.json' with { type: 'json' };
 import narrationSchema from './schemas/narration.write.json' with { type: 'json' };
 import auditManifestSchema from './schemas/audit-manifest.write.json' with { type: 'json' };
@@ -51,6 +52,14 @@ export interface VerifyInput {
   };
   /** Symmetry tolerance (percent). Defaults to 20. */
   tolerancePct?: number;
+  /**
+   * Camps the narrate stage backfilled from their real top_claim because the
+   * narrator model dropped them (t/2883). The presence-symmetry arm passes for
+   * these (the backfill gives them a slide), so the drop signal MUST NOT vanish:
+   * each is surfaced as a manifest `camp_backfill` warning here — the export-record
+   * half of the required observability (the FR event is emitted in narrate.ts).
+   */
+  backfilledCamps?: string[];
 }
 
 export interface VerifyResult {
@@ -92,7 +101,11 @@ export async function verify(input: VerifyInput): Promise<VerifyResult> {
   for (const msg of await lintOoxml(pptxBytes)) hardFailures.push(msg);
 
   // Warnings (recorded, never fail the build)
-  const warnings = [...computeWarnings(spec, symmetry, isSnapshot), ...snapshotSymmetryWarnings];
+  const warnings = [
+    ...computeWarnings(spec, symmetry, isSnapshot),
+    ...snapshotSymmetryWarnings,
+    ...backfillWarnings(input.backfilledCamps),
+  ];
 
   // Assemble the manifest — records reality regardless of pass/fail
   const manifest: AuditManifest = {
@@ -188,41 +201,10 @@ function checkTraceCoverage(
 }
 
 // ── Per-camp symmetry ─────────────────────────────────────────────────────────
-
-/**
- * Attribute a narration entry to a camp by resolving its trace to the spec node and
- * reading that node's `camp`. Camp-less sections (question, agreements, cruxes, framing)
- * resolve to nodes without a `camp` and are excluded (TL, e/112 MUST 3).
- */
-function campOfTrace(spec: DeckSpec, trace: string): string | null {
-  let node: unknown;
-  try {
-    node = resolveTrace(spec, trace);
-  } catch {
-    return null;
-  }
-  if (node && typeof node === 'object' && 'camp' in node) {
-    const camp = (node as { camp: unknown }).camp;
-    if (typeof camp === 'string' && camp.length > 0) return camp;
-  }
-  return null;
-}
-
-/**
- * The camps that MUST have per-camp parity — the debate's "positions" (spec §2.3
- * slide 5, one card per camp). Derived from `top_claims` camps: those are the
- * canonical camp positions the deck renders. Deliberately NOT the union of every
- * camp-bearing node type (argument_map/concessions can carry incidental or
- * cross-camp labels that don't warrant a slide) — a broader set would false-fire
- * the symmetry gate, which TL flagged as the next-incident risk (e/112#4).
- * Entry→camp ATTRIBUTION (campOfTrace) still reads all four node types per MUST 3;
- * only the EXPECTED set is narrowed here.
- */
-function expectedCamps(spec: DeckSpec): string[] {
-  const camps = new Set<string>();
-  for (const c of spec.top_claims) camps.add(c.camp);
-  return [...camps].sort();
-}
+//
+// `expectedCamps` (which camps must be covered) and `campOfTrace` (which camp an
+// entry covers) live in ./campCoverage.js so the narrate stage's completeness
+// check (repair + backfill, t/2883) and this presence arm can never drift.
 
 function countWords(text: string): number {
   const t = text.trim();
@@ -383,6 +365,19 @@ async function lintOoxml(pptxBytes: Uint8Array): Promise<string[]> {
 }
 
 // ── Warnings (recorded, never fail) ───────────────────────────────────────────
+
+/**
+ * Surface each narrate-stage camp backfill (t/2883) as a manifest warning naming
+ * the dropped camp. This is the export-record half of the required observability:
+ * B1 lets the presence arm pass on a backfilled camp, so without this the narrator
+ * drop-rate would be invisible in the export record (silent-degradation). The FR
+ * event is the other half, emitted in narrate.ts where the drop is detected.
+ */
+function backfillWarnings(backfilledCamps: string[] | undefined): string[] {
+  return (backfilledCamps ?? []).map(camp =>
+    `camp_backfill: narrator omitted camp "${camp}"; backfilled from its top_claim so the deck retains the camp's position`,
+  );
+}
 
 function computeWarnings(spec: DeckSpec, symmetry: SymmetryAudit, isSnapshot: boolean): string[] {
   const warnings: string[] = [];


### PR DESCRIPTION
Fixes t/2883. TL-approved design + B1 policy at t/2883#1 / t/2883#2. Single-scope (lib/brief), self-certified.

## Root cause (reproduced)
brief-extract handles community-copied debates correctly — all camps survive the community sanitize transform and **deterministic narration passes symmetry**. The failure is in the **narrate stage**: a narrator MODEL drops a whole camp, then verify''s presence-symmetry arm hard-fails (`camp "X" ... 0 slides in the narration`). deck_spec is shape-identical for community vs personal debates, so this hits personal debates too. The Diagnostics "extract turn→camp break for community metadata" hypothesis is **disproven**.

## Fix (B1)
- **Camp-completeness gate** in `narrate.ts` (mirrors the t/2872 empty-entries gate): one targeted **repair re-prompt** naming the dropped camp(s); if still missing, **deterministic backfill from the camp''s REAL top_claim** (never fabricated).
- **Observability (both arms)** — the block→repair-and-**warn** conversion keeps the narrator drop signal visible: an **FR event** (`reason: camp-backfill`) in narrate + an **export-record warning** (`camp_backfill: …`) in verify. Neither vanishes.
- **Ratio arms unchanged** (word_budget/headline still enforce).
- `expectedCamps`/`campOfTrace` extracted to **`campCoverage.ts`** so the narrate gate and verify arm can''t drift.
- `community_metadata` + `copied_from_community` added to `extract.ts` STRIP_LIST → the misleading unmapped-field warnings stop firing.

## Tests
- `campBackfill.test.ts` — real pipeline (extract→narrate→render→verify): narrator omits accelerationist → repair attempted → backfill → **export succeeds**, warning present (both arms), verify passes; **fails pre-fix** (hard-fail), passes post. Plus clean-deterministic no-op.
- `campCoverage.test.ts` — unit coverage of the shared helpers.
- Full `lib/brief` suite green (201), `tsc -p brief/tsconfig.nodenext.json` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)