### PR TITLE
fix(chat): community chat deep-link opens read-only detail, not blank window (t/2879, t/2880)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
@@ -808,7 +808,9 @@ function CommunityChatTranscript({ full }: { full: ChatSession | null }) {
   );
 }
 
-function CommunityChatDetail({ chat }: { chat: CommunityChat }) {
+// Exported so the community chat deep-link popout (ChatWindow, t/2879) can render the same
+// read-only detail view as the in-tab community browser — no duplicated transcript logic.
+export function CommunityChatDetail({ chat }: { chat: CommunityChat }) {
   const [full, setFull] = useState<ChatSession | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/taxonomy-editor/src/renderer/components/chat/ChatWindow.test.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWindow.test.tsx
@@ -11,6 +11,8 @@ const mockInitAIModels = vi.fn().mockResolvedValue(undefined);
 const mockInitDebateSessions = vi.fn();
 const mockLoadChat = vi.fn().mockResolvedValue(undefined);
 const mockOnChatWindowLoad = vi.fn().mockReturnValue(() => {});
+const mockFetchChats = vi.fn().mockResolvedValue(undefined);
+let mockCommunityChats: Array<{ id: string; title: string }> = [];
 
 vi.mock('../../hooks/useTaxonomyStore', () => ({
   useTaxonomyStore: Object.assign(
@@ -39,6 +41,20 @@ vi.mock('../../hooks/usePopoutTheme', () => ({
 // ChatWindow renders ChatWorkspace — mock it as a stub so we can assert "ready"
 vi.mock('./ChatWorkspace', () => ({
   ChatWorkspace: () => <div data-testid="chat-tab">ChatWorkspace</div>,
+}));
+
+// ChatWindow reuses ChatTab's CommunityChatDetail for the read-only community popout (t/2879).
+vi.mock('./ChatTab', () => ({
+  CommunityChatDetail: ({ chat }: { chat: { id: string } }) => (
+    <div data-testid="community-chat-detail">{chat.id}</div>
+  ),
+}));
+
+vi.mock('../../hooks/useCommunityStore', () => ({
+  useCommunityStore: Object.assign(
+    () => ({}),
+    { getState: () => ({ fetchChats: mockFetchChats, chats: mockCommunityChats }) },
+  ),
 }));
 
 vi.mock('@bridge', () => ({
@@ -76,6 +92,8 @@ describe('ChatWindow', () => {
     mockInitDebateSessions.mockClear();
     mockLoadChat.mockClear().mockResolvedValue(undefined);
     mockOnChatWindowLoad.mockClear().mockReturnValue(() => {});
+    mockFetchChats.mockClear().mockResolvedValue(undefined);
+    mockCommunityChats = [];
     window.location.hash = '';
   });
 
@@ -119,5 +137,18 @@ describe('ChatWindow', () => {
       expect(screen.getByTestId('chat-tab')).toBeInTheDocument();
     });
     expect(mockLoadChat).not.toHaveBeenCalled();
+  });
+
+  it('renders the read-only community detail (not the workspace) when source=community', async () => {
+    mockCommunityChats = [{ id: 'cc-1', title: 'Shared chat' }];
+    window.location.hash = '#chat-window?id=cc-1&source=community';
+    render(<ChatWindow />);
+    await waitFor(() => {
+      expect(screen.getByTestId('community-chat-detail')).toBeInTheDocument();
+    });
+    expect(mockFetchChats).toHaveBeenCalled();
+    // Community deep-link must NOT hit the personal load path or the editable workspace.
+    expect(mockLoadChat).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('chat-tab')).not.toBeInTheDocument();
   });
 });

--- a/taxonomy-editor/src/renderer/components/chat/ChatWindow.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatWindow.tsx
@@ -10,10 +10,18 @@ import { usePopoutTheme } from '../../hooks/usePopoutTheme';
 import { parseHashParams } from '../../lib/parseHash';
 import { api } from '@bridge';
 import { ChatWorkspace } from './ChatWorkspace';
+import { CommunityChatDetail } from './ChatTab';
+import { useCommunityStore, type CommunityChat } from '../../hooks/useCommunityStore';
 import './ChatWindow.css';
 
 export function ChatWindow() {
   const [ready, setReady] = useState(false);
+  // Community deep-link (?source=community): render the read-only detail view, not the
+  // editable workspace (t/2879). { active:false } = personal chat. Once the list is fetched,
+  // resolved flips true; chat is the matched row or null (removed / no longer shared).
+  const [community, setCommunity] = useState<
+    { active: false } | { active: true; resolved: boolean; chat: CommunityChat | null }
+  >({ active: false });
   usePopoutTheme();
 
   useEffect(() => {
@@ -26,14 +34,39 @@ export function ChatWindow() {
         if (!cancelled) {
           setReady(true);
 
-          // Dual delivery: hash param (always available) + IPC push (handles
-          // did-finish-load vs React-mount race via the preload buffer).
-          const chatId = parseHashParams(window.location.hash).get('id');
-          if (chatId) void useChatStore.getState().loadChat(chatId);
+          const params = parseHashParams(window.location.hash);
+          const chatId = params.get('id');
+          const source = params.get('source');
 
-          unsubChatLoad = api.onChatWindowLoad((id) => {
-            void useChatStore.getState().loadChat(id);
+          // t/2880 — record how the deep link resolved so a blank/empty popout is
+          // diagnosable from the flight recorder (which path did we take, and why).
+          getGlobalRecorder()?.record({
+            type: 'user.action',
+            component: 'chat-window',
+            level: 'info',
+            message: 'chat.deep-link.parse',
+            data: { source: source ?? null, id: chatId ?? null, resolved: source === 'community' ? 'community' : 'personal' },
           });
+
+          if (chatId && source === 'community') {
+            // Community chats are read-only content the viewer doesn't own — render the same
+            // read-only detail as the in-tab browser, not the editable workspace (t/2879, TL ruling a).
+            // Fetch the list for the row metadata; CommunityChatDetail self-loads the full transcript by id.
+            setCommunity({ active: true, resolved: false, chat: null });
+            void useCommunityStore.getState().fetchChats().then(() => {
+              if (cancelled) return;
+              const found = useCommunityStore.getState().chats.find(c => c.id === chatId) ?? null;
+              setCommunity({ active: true, resolved: true, chat: found });
+            });
+          } else {
+            // Personal chat — dual delivery: hash param (always available) + IPC push (handles
+            // did-finish-load vs React-mount race via the preload buffer). Community is web-only,
+            // so the Electron IPC push path is personal-only.
+            if (chatId) void useChatStore.getState().loadChat(chatId);
+            unsubChatLoad = api.onChatWindowLoad((id) => {
+              void useChatStore.getState().loadChat(id);
+            });
+          }
         }
       })
       .catch(err => {
@@ -53,6 +86,20 @@ export function ChatWindow() {
     return (
       <div className="chat-window-loading">
         Loading...
+      </div>
+    );
+  }
+
+  if (community.active) {
+    return (
+      <div className="chat-window-root">
+        {!community.resolved ? (
+          <div className="chat-window-loading">Loading community chat…</div>
+        ) : community.chat ? (
+          <CommunityChatDetail chat={community.chat} />
+        ) : (
+          <div className="chat-window-loading">This community chat is no longer available.</div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## What
A community chat deep-link (`#chat-window?id=<uuid>&source=community`) opened a blank popout showing "No chat selected". `ChatWindow` read only `?id=` and always called the **personal** `loadChat` → personal endpoint on a community id → nothing.

Reported by @jpsnover; diagnosed by Diagnostics (t/2879), rerouted to TL (unowned renderer).

## Fix (t/2879 — read-only detail, TL ruling (a))
`ChatWindow` now branches on `source`, mirroring the debate popout's `source=community` pattern:
- **Community:** fetch the community list for row metadata, render the **same read-only `CommunityChatDetail`** the in-tab browser uses (now `export`ed from `ChatTab` — no duplicated transcript logic). Community chats are content the viewer doesn't own → read-only detail, not the editable workspace.
- **Personal:** unchanged (hash `loadChat` + Electron IPC push, which stays personal-only since community is web-only).
- Three states handled: loading list → detail (found) → "no longer available" (removed).

## t/2880 (batched)
Emit a `chat.deep-link.parse` FR event (`source`, `id`, resolved path) so a blank/empty popout is diagnosable from the recorder.

## Verification
- `tsc --noEmit` clean · `eslint` 0 errors · `vitest ChatWindow.test.tsx` 6/6
- New test asserts `source=community` renders the read-only detail and does **not** call the personal `loadChat` or mount the workspace.