### PR TITLE
feat(devops): deterministic in-memory job store scale guard (t/2885)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,11 @@ jobs:
             powershell:
               - 'scripts/**'
               - 'tests/**'
+              - 'operations/devops/**'
               - 'lib/**'
               - 'ai-models.json'
+              - 'deploy/azure/main.bicep'
+              - 'taxonomy-editor/src/server/briefExportJobs.ts'
               - '.github/workflows/ci.yml'
             electron:
               - 'taxonomy-editor/**'

--- a/operations/devops/Test-InMemoryJobStoreScaleGuard.ps1
+++ b/operations/devops/Test-InMemoryJobStoreScaleGuard.ps1
@@ -1,0 +1,55 @@
+#Requires -Version 7.0
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    CI gate: fails if maxReplicas > 1 while an in-memory job store is still in use.
+.DESCRIPTION
+    Reads deploy/azure/main.bicep and checks the taxonomy-editor maxReplicas value.
+    Greps taxonomy-editor/src/server/briefExportJobs.ts for the @INMEMORY_JOB_STORE
+    marker. If the marker is present and maxReplicas > 1, the gate fails — raising the
+    replica count while the job store is per-process in-memory reinstates the t/2884
+    cross-replica 404 race. When the store is migrated to shared blob storage (t/2885),
+    remove the @INMEMORY_JOB_STORE marker and this gate passes unconditionally.
+.PARAMETER BicepPath
+    Path to deploy/azure/main.bicep. Defaults to the canonical repo location.
+.PARAMETER JobStorePath
+    Path to briefExportJobs.ts. Defaults to the canonical repo location.
+#>
+[CmdletBinding()]
+param(
+    [string] $BicepPath    = "$PSScriptRoot/../../deploy/azure/main.bicep",
+    [string] $JobStorePath = "$PSScriptRoot/../../taxonomy-editor/src/server/briefExportJobs.ts"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── 1. Check for in-memory store marker ───────────────────────────────────────
+$markerPresent = (Select-String -Path $JobStorePath -Pattern '@INMEMORY_JOB_STORE' -Quiet) -eq $true
+
+if (-not $markerPresent) {
+    Write-Host "InMemoryJobStore scale guard: @INMEMORY_JOB_STORE marker absent — store has been migrated to shared storage. Gate passes unconditionally."
+    return
+}
+
+# ── 2. Extract taxonomy-editor maxReplicas from main.bicep ────────────────────
+$bicepContent = Get-Content -Path $BicepPath -Raw
+
+# The t/2885 cap comment immediately precedes the maxReplicas line — match across newlines.
+$match = [regex]::Match($bicepContent, 'maxReplicas capped at 1[\s\S]*?maxReplicas:\s*(\d+)')
+if (-not $match.Success) {
+    throw "InMemoryJobStore scale guard: could not parse taxonomy-editor maxReplicas from $BicepPath. Ensure the t/2885 cap comment and maxReplicas line are present and intact."
+}
+$maxReplicas = [int]$match.Groups[1].Value
+
+# ── 3. Enforce the invariant ──────────────────────────────────────────────────
+if ($maxReplicas -gt 1) {
+    Write-Host "::error::InMemoryJobStore scale guard FAILED: maxReplicas=$maxReplicas but @INMEMORY_JOB_STORE marker is present in briefExportJobs.ts."
+    Write-Host "::error::Raising maxReplicas above 1 while the job store is per-process in-memory reinstates the t/2884 cross-replica 404 race (POST on replica A, GET poll on replica B → 404)."
+    Write-Host "::error::Implement the blob-backed shared job store (t/2885) and remove @INMEMORY_JOB_STORE before scaling out."
+    throw "InMemoryJobStore scale guard FAILED: maxReplicas=$maxReplicas with in-memory job store still in use."
+}
+
+Write-Host "InMemoryJobStore scale guard: maxReplicas=$maxReplicas, @INMEMORY_JOB_STORE present — invariant holds. Gate passes."

--- a/taxonomy-editor/src/server/briefExportJobs.ts
+++ b/taxonomy-editor/src/server/briefExportJobs.ts
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
+// @INMEMORY_JOB_STORE — job registry is a per-process in-memory Map (not shared across replicas).
+// Remove this marker when migrated to blob-backed shared store (t/2885). The CI gate
+// Test-InMemoryJobStoreScaleGuard.ps1 reads this marker and blocks if maxReplicas > 1.
 // Brief Export async job runner + registry (t/2804, T6). Mirrors the oped run-registry
 // pattern (in-memory Map, per-user concurrency cap, TTL sweep) but exposes the
 // POST-202-jobId + GET-poll shape (not SSE). Durable truth is the exports list +

--- a/tests/Test-InMemoryJobStoreScaleGuard.Tests.ps1
+++ b/tests/Test-InMemoryJobStoreScaleGuard.Tests.ps1
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Gate-verification tests for Test-InMemoryJobStoreScaleGuard (t/2885 SO condition 2).
+.DESCRIPTION
+    Proves BOTH arms required by TL gate-verification:
+      Fire arm:   marker present + maxReplicas > 1  → gate throws (blocks CI).
+      Pass arm:   marker present + maxReplicas = 1  → gate passes silently.
+    Also proves two safe-pass conditions:
+      No marker:  store migrated, any maxReplicas   → gate passes unconditionally.
+      Parse fail: malformed Bicep                   → gate throws with a clear message.
+#>
+
+Describe 'Test-InMemoryJobStoreScaleGuard — both arms (t/2885)' {
+
+    BeforeAll {
+        $script:GateScript = "$PSScriptRoot/../operations/devops/Test-InMemoryJobStoreScaleGuard.ps1"
+
+        # Helpers to create temp fixture files
+        function script:New-BicepFixture ([int]$MaxReplicas) {
+            $f = [System.IO.Path]::GetTempFileName()
+            Set-Content -Path $f -Value @"
+// maxReplicas capped at 1 (t/2885, 2026-08-20): brief-export and oped job
+// stores are per-process in-memory Maps. Running >1 replica means POST on
+// replica A and GET poll on replica B → 404. DO NOT raise above 1 until
+// blob-backed store lands (t/2885 deferred).
+maxReplicas: $MaxReplicas
+"@
+            return $f
+        }
+
+        function script:New-JobStoreFixture ([bool]$WithMarker) {
+            $f = [System.IO.Path]::GetTempFileName()
+            $content = if ($WithMarker) {
+                '// @INMEMORY_JOB_STORE — remove when migrated to blob-backed shared store (t/2885)'
+            } else {
+                '// job store migrated to shared blob storage'
+            }
+            Set-Content -Path $f -Value $content
+            return $f
+        }
+    }
+
+    # ── Fire arm: maxReplicas > 1 + marker present ────────────────────────────
+    Context 'FIRE ARM — maxReplicas=2, marker present (must block)' {
+        It 'throws and blocks CI' {
+            $bicep = script:New-BicepFixture -MaxReplicas 2
+            $store = script:New-JobStoreFixture -WithMarker $true
+            try {
+                { & $script:GateScript -BicepPath $bicep -JobStorePath $store } |
+                    Should -Throw -ExpectedMessage '*scale guard FAILED*'
+            } finally {
+                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'emits ::error:: lines mentioning maxReplicas and the race' {
+            $bicep = script:New-BicepFixture -MaxReplicas 2
+            $store = script:New-JobStoreFixture -WithMarker $true
+            $output = & { try { & $script:GateScript -BicepPath $bicep -JobStorePath $store } catch {} } 6>&1 | Out-String
+            try {
+                $output | Should -Match '::error::.*maxReplicas=2'
+                $output | Should -Match '::error::.*cross-replica 404'
+            } finally {
+                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Pass arm: maxReplicas = 1 + marker present ───────────────────────────
+    Context 'PASS ARM — maxReplicas=1, marker present (must pass)' {
+        It 'does not throw' {
+            $bicep = script:New-BicepFixture -MaxReplicas 1
+            $store = script:New-JobStoreFixture -WithMarker $true
+            try {
+                { & $script:GateScript -BicepPath $bicep -JobStorePath $store } | Should -Not -Throw
+            } finally {
+                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Safe pass: marker absent (store migrated) ────────────────────────────
+    Context 'No marker — store migrated, any maxReplicas (must pass)' {
+        It 'passes even when maxReplicas=5' {
+            $bicep = script:New-BicepFixture -MaxReplicas 5
+            $store = script:New-JobStoreFixture -WithMarker $false
+            try {
+                { & $script:GateScript -BicepPath $bicep -JobStorePath $store } | Should -Not -Throw
+            } finally {
+                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Parse guard: malformed Bicep ─────────────────────────────────────────
+    Context 'Malformed Bicep — cap comment missing (must throw with clear message)' {
+        It 'throws mentioning parse failure' {
+            $bicep = [System.IO.Path]::GetTempFileName()
+            Set-Content -Path $bicep -Value 'maxReplicas: 1'  # no cap comment — regex won't match
+            $store = script:New-JobStoreFixture -WithMarker $true
+            try {
+                { & $script:GateScript -BicepPath $bicep -JobStorePath $store } |
+                    Should -Throw -ExpectedMessage '*could not parse*'
+            } finally {
+                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

SO condition 2 from t/2885#3: CI gate that blocks if \maxReplicas > 1\ while \@INMEMORY_JOB_STORE\ marker is present in \riefExportJobs.ts\.

**Files changed:**
- \operations/devops/Test-InMemoryJobStoreScaleGuard.ps1\ — gate script (reads Bicep + greps TS marker)
- \	ests/Test-InMemoryJobStoreScaleGuard.Tests.ps1\ — Pester tests: fire arm, pass arm, no-marker, parse-fail
- \	axonomy-editor/src/server/briefExportJobs.ts\ — adds \@INMEMORY_JOB_STORE\ grep-able marker
- \.github/workflows/ci.yml\ — powershell filter extended to cover \main.bicep\, \operations/devops/**\, \riefExportJobs.ts\

**How it works:** If marker absent (store migrated to blob) → unconditional pass. If marker present + maxReplicas=1 → pass. If marker present + maxReplicas>1 → \::error::\ + throw.

**Remove \@INMEMORY_JOB_STORE\** when blob-backed shared store lands (t/2885 deferred).

## Gate verification (TL required before un-drafting)
- [ ] Fire arm: set maxReplicas=2 in Bicep → gate throws in Pester
- [ ] Pass arm: maxReplicas=1 + marker present → Pester passes, zero noise
- [ ] CI green on this PR

Stays **draft** until TL gate-verification sign-off (t/2885#3, p/338).