### PR TITLE
feat(brief): FR-instrument export-job poll 404 for cross-replica diagnosis (t/2887)

### DIFF
--- a/taxonomy-editor/src/server/briefExportJobs.ts
+++ b/taxonomy-editor/src/server/briefExportJobs.ts
@@ -75,6 +75,13 @@ export function getExportJob(jobId: string, userId: string): ExportJob | null {
   return job && job.userId === userId ? job : null;
 }
 
+/** Raw registry membership (any user) — lets the GET handler distinguish "not in this
+ *  process's Map at all" (the cross-replica-404 signal, t/2887) from "present but wrong
+ *  user" (an auth/scoping issue). Does NOT leak the job; boolean only. */
+export function hasExportJob(jobId: string): boolean {
+  return jobs.has(jobId);
+}
+
 export function countRunningExportJobs(userId: string): number {
   let n = 0;
   for (const j of jobs.values()) {

--- a/taxonomy-editor/src/server/routes/briefExports.ts
+++ b/taxonomy-editor/src/server/routes/briefExports.ts
@@ -20,7 +20,7 @@ import { createWebOpEdAdapter } from '../ai/opedAdapter.js';
 import { resolveExportModel, type ClientModelSource } from './exportModel.js';
 import { enforceBackendAllowed } from './generationContext.js';
 import {
-  startExportJob, getExportJob, sweepExportJobs, countRunningExportJobs,
+  startExportJob, getExportJob, hasExportJob, sweepExportJobs, countRunningExportJobs,
   findIdempotentJob, MAX_CONCURRENT_EXPORT_JOBS, type ResolvedModels,
 } from '../briefExportJobs.js';
 import { listBriefExports, loadBriefExportRecord, loadBriefArtifact, deleteBriefExport, getBriefExportsQuotaStatus } from '../storage/briefExportStore.js';
@@ -161,7 +161,19 @@ export function registerBriefExportsRoutes(r: Router, _ctx: ServerCtx): void {
   get('/api/export-jobs/:jobId', (req, res) => {
     const jobId = param(req, 'jobId', '/api/export-jobs/:jobId');
     const job = getExportJob(jobId, getStorageUserId());
-    if (!job) { error(res, 'Export job not found (it may have expired — check the debate exports list).', 404); return; }
+    if (!job) {
+      // t/2887: record the miss so a poll 404 is diagnosable in server FR (was invisible, t/2884).
+      // `inMap` distinguishes "not in THIS process's registry at all" — the cross-replica-404
+      // signal (job created on another replica; see t/2885 cap) — from "present but wrong user".
+      // We log the 404 (the failure) but NOT the frequent 200 polls, which would flood the FR
+      // ring and evict this very event (deliberate deviation from the ticket's "every GET").
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'brief-export', level: 'warn',
+        message: 'export-job poll 404',
+        data: { jobId, status: 404, found: false, inMap: hasExportJob(jobId) },
+      });
+      error(res, 'Export job not found (it may have expired — check the debate exports list).', 404); return;
+    }
     json(res, { status: job.status, progressPct: job.progressPct, warnings: job.warnings, error: job.error, errorCode: job.errorCode ?? null, exportId: job.exportId });
   });
 


### PR DESCRIPTION
## What (Mitigation A from t/2884)
`GET /api/export-jobs/:jobId` had **zero FR instrumentation**, so a poll 404 was invisible server-side — the t/2884 incident literally had "no server FR log for the 404." Now the 404 records `jobId` + `inMap`, where `inMap` distinguishes:
- **not in this process's registry at all** → the cross-replica-404 signal (job created on another replica; the t/2885 `maxReplicas:1` cap now prevents this, but the signal stays for any recurrence), vs
- **present but wrong user** → an auth/scoping issue.

New `hasExportJob()` accessor exposes raw Map membership (boolean; no job leak).

## Deviations (flagged per the rule)
- Logs the **404 only**, not every 200 poll — per-poll logging would flood the FR ring buffer and evict the very 404 event we need. The 404 is the diagnostic signal.
- `requestId` not recorded (not available at this handler layer); `jobId` is the correlation key.

## Verification
`tsc -p tsconfig.server.json` clean · `eslint` 0 errors.