### PR TITLE
fix(devops): generalize in-memory scale guard to glob all server files (t/2885)

### DIFF
--- a/operations/devops/Test-InMemoryJobStoreScaleGuard.ps1
+++ b/operations/devops/Test-InMemoryJobStoreScaleGuard.ps1
@@ -4,40 +4,43 @@
 
 <#
 .SYNOPSIS
-    CI gate: fails if maxReplicas > 1 while an in-memory job store is still in use.
+    CI gate: fails if maxReplicas > 1 while any in-memory job store is still in use.
 .DESCRIPTION
     Reads deploy/azure/main.bicep and checks the taxonomy-editor maxReplicas value.
-    Greps taxonomy-editor/src/server/briefExportJobs.ts for the @INMEMORY_JOB_STORE
-    marker. If the marker is present and maxReplicas > 1, the gate fails — raising the
-    replica count while the job store is per-process in-memory reinstates the t/2884
-    cross-replica 404 race. When the store is migrated to shared blob storage (t/2885),
-    remove the @INMEMORY_JOB_STORE marker and this gate passes unconditionally.
+    Greps all *.ts files under taxonomy-editor/src/server/** for the @INMEMORY_JOB_STORE
+    marker. If ANY file carries the marker and maxReplicas > 1, the gate fails — raising
+    the replica count while any job store is per-process in-memory reinstates the t/2884
+    cross-replica 404 race. When ALL marked stores are migrated to shared blob storage
+    (t/2885), remove their @INMEMORY_JOB_STORE markers and this gate passes unconditionally.
 .PARAMETER BicepPath
     Path to deploy/azure/main.bicep. Defaults to the canonical repo location.
-.PARAMETER JobStorePath
-    Path to briefExportJobs.ts. Defaults to the canonical repo location.
+.PARAMETER ServerDir
+    Directory to search for @INMEMORY_JOB_STORE markers. Defaults to
+    taxonomy-editor/src/server. All *.ts files are checked recursively.
 #>
 [CmdletBinding()]
 param(
-    [string] $BicepPath    = "$PSScriptRoot/../../deploy/azure/main.bicep",
-    [string] $JobStorePath = "$PSScriptRoot/../../taxonomy-editor/src/server/briefExportJobs.ts"
+    [string] $BicepPath = "$PSScriptRoot/../../deploy/azure/main.bicep",
+    [string] $ServerDir = "$PSScriptRoot/../../taxonomy-editor/src/server"
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# ── 1. Check for in-memory store marker ───────────────────────────────────────
-$markerPresent = (Select-String -Path $JobStorePath -Pattern '@INMEMORY_JOB_STORE' -Quiet) -eq $true
+# ── 1. Check for in-memory store markers across all server files ───────────────
+$markedFiles = @(Get-ChildItem -Path $ServerDir -Recurse -Filter '*.ts' |
+    Where-Object { Select-String -Path $_.FullName -Pattern '@INMEMORY_JOB_STORE' -Quiet })
 
-if (-not $markerPresent) {
-    Write-Host "InMemoryJobStore scale guard: @INMEMORY_JOB_STORE marker absent — store has been migrated to shared storage. Gate passes unconditionally."
+if ($markedFiles.Count -eq 0) {
+    Write-Host "InMemoryJobStore scale guard: no @INMEMORY_JOB_STORE markers found in $ServerDir — all stores migrated. Gate passes unconditionally."
     return
 }
 
 # ── 2. Extract taxonomy-editor maxReplicas from main.bicep ────────────────────
+# NOTE: the regex anchors on the literal string 'maxReplicas capped at 1' — that
+# string is load-bearing for this gate (Gate Co-Location, t/2885). Rewording the
+# cap comment in main.bicep requires updating the regex here.
 $bicepContent = Get-Content -Path $BicepPath -Raw
-
-# The t/2885 cap comment immediately precedes the maxReplicas line — match across newlines.
 $match = [regex]::Match($bicepContent, 'maxReplicas capped at 1[\s\S]*?maxReplicas:\s*(\d+)')
 if (-not $match.Success) {
     throw "InMemoryJobStore scale guard: could not parse taxonomy-editor maxReplicas from $BicepPath. Ensure the t/2885 cap comment and maxReplicas line are present and intact."
@@ -46,10 +49,11 @@ $maxReplicas = [int]$match.Groups[1].Value
 
 # ── 3. Enforce the invariant ──────────────────────────────────────────────────
 if ($maxReplicas -gt 1) {
-    Write-Host "::error::InMemoryJobStore scale guard FAILED: maxReplicas=$maxReplicas but @INMEMORY_JOB_STORE marker is present in briefExportJobs.ts."
-    Write-Host "::error::Raising maxReplicas above 1 while the job store is per-process in-memory reinstates the t/2884 cross-replica 404 race (POST on replica A, GET poll on replica B → 404)."
-    Write-Host "::error::Implement the blob-backed shared job store (t/2885) and remove @INMEMORY_JOB_STORE before scaling out."
-    throw "InMemoryJobStore scale guard FAILED: maxReplicas=$maxReplicas with in-memory job store still in use."
+    $fileList = ($markedFiles | Select-Object -ExpandProperty Name) -join ', '
+    Write-Host "::error::InMemoryJobStore scale guard FAILED: maxReplicas=$maxReplicas but @INMEMORY_JOB_STORE markers present in: $fileList"
+    Write-Host "::error::Raising maxReplicas above 1 while any job store is per-process in-memory reinstates the cross-replica 404 race (POST on replica A, GET poll on replica B → 404)."
+    Write-Host "::error::Migrate ALL marked stores to shared blob storage and remove their @INMEMORY_JOB_STORE markers before scaling out. See t/2885."
+    throw "InMemoryJobStore scale guard FAILED: maxReplicas=$maxReplicas with in-memory stores still in use: $fileList"
 }
 
-Write-Host "InMemoryJobStore scale guard: maxReplicas=$maxReplicas, @INMEMORY_JOB_STORE present — invariant holds. Gate passes."
+Write-Host "InMemoryJobStore scale guard: maxReplicas=$maxReplicas, @INMEMORY_JOB_STORE present in $($markedFiles.Count) file(s) ($($markedFiles.Name -join ', ')) — invariant holds. Gate passes."

--- a/taxonomy-editor/src/server/routes/oped.ts
+++ b/taxonomy-editor/src/server/routes/oped.ts
@@ -61,6 +61,11 @@ interface OpEdRun {
   perVoice: Record<string, VoiceState>;
   startedAt: number;
 }
+// @INMEMORY_JOB_STORE — active op-ed generation runs (status, SSE progress, cancel signal,
+// per-voice state) live in a per-process Map, NOT shared across replicas. Remove this marker
+// when migrated to a shared/blob store (t/2893). The CI gate Test-InMemoryJobStoreScaleGuard.ps1
+// reads this marker and blocks maxReplicas > 1 while it is present (t/2884-class race: an SSE
+// stream or cancel routed to a different replica than the one running the job 404s silently).
 const opedRuns = new Map<string, OpEdRun>();
 
 function sweepOpedRuns(): void {

--- a/taxonomy-editor/src/server/security/githubAppAuth.ts
+++ b/taxonomy-editor/src/server/security/githubAppAuth.ts
@@ -193,6 +193,11 @@ async function getInstallationToken(): Promise<string | null> {
 // isolates each authenticated user's PAT.
 
 interface RuntimeCreds { repo: string | null; token: string | null }
+// @INMEMORY_JOB_STORE — per-user runtime GitHub creds (repo + PAT) live in a per-process Map,
+// NOT shared across replicas. Remove this marker when migrated to a shared store (t/2894). The
+// CI gate Test-InMemoryJobStoreScaleGuard.ps1 reads this marker and blocks maxReplicas > 1 while
+// it is present: at >1 replica a user's creds set on replica A are absent on replica B, so a
+// write routed to B silently loses auth (t/2884-class race, on the auth surface).
 const runtimeCredsByUser = new Map<string, RuntimeCreds>();
 
 /**

--- a/tests/Test-InMemoryJobStoreScaleGuard.Tests.ps1
+++ b/tests/Test-InMemoryJobStoreScaleGuard.Tests.ps1
@@ -8,11 +8,12 @@
     Gate-verification tests for Test-InMemoryJobStoreScaleGuard (t/2885 SO condition 2).
 .DESCRIPTION
     Proves BOTH arms required by TL gate-verification:
-      Fire arm:   marker present + maxReplicas > 1  → gate throws (blocks CI).
-      Pass arm:   marker present + maxReplicas = 1  → gate passes silently.
+      Fire arm:   marker present in ANY server file + maxReplicas > 1  → gate throws (blocks CI).
+      Pass arm:   marker present + maxReplicas = 1                     → gate passes silently.
     Also proves two safe-pass conditions:
-      No marker:  store migrated, any maxReplicas   → gate passes unconditionally.
-      Parse fail: malformed Bicep                   → gate throws with a clear message.
+      No marker:  all stores migrated, any maxReplicas → gate passes unconditionally.
+      Parse fail: malformed Bicep                      → gate throws with a clear message.
+    Multi-file arm: marker in a second file fires the gate alongside the first.
 #>
 
 Describe 'Test-InMemoryJobStoreScaleGuard — both arms (t/2885)' {
@@ -20,7 +21,6 @@ Describe 'Test-InMemoryJobStoreScaleGuard — both arms (t/2885)' {
     BeforeAll {
         $script:GateScript = "$PSScriptRoot/../operations/devops/Test-InMemoryJobStoreScaleGuard.ps1"
 
-        # Helpers to create temp fixture files
         function script:New-BicepFixture ([int]$MaxReplicas) {
             $f = [System.IO.Path]::GetTempFileName()
             Set-Content -Path $f -Value @"
@@ -33,40 +33,65 @@ maxReplicas: $MaxReplicas
             return $f
         }
 
-        function script:New-JobStoreFixture ([bool]$WithMarker) {
-            $f = [System.IO.Path]::GetTempFileName()
-            $content = if ($WithMarker) {
-                '// @INMEMORY_JOB_STORE — remove when migrated to blob-backed shared store (t/2885)'
-            } else {
-                '// job store migrated to shared blob storage'
+        # Creates a temp directory containing one or more .ts files.
+        # markerFiles: list of filenames that should carry @INMEMORY_JOB_STORE.
+        # cleanFiles:  list of filenames that should NOT carry the marker.
+        function script:New-ServerDirFixture ([string[]]$MarkerFiles = @(), [string[]]$CleanFiles = @()) {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
+            New-Item -ItemType Directory -Path $dir | Out-Null
+            foreach ($name in $MarkerFiles) {
+                $full = Join-Path $dir $name
+                New-Item -ItemType Directory -Path (Split-Path $full -Parent) -Force | Out-Null
+                Set-Content -Path $full -Value '// @INMEMORY_JOB_STORE — remove when migrated to blob-backed shared store (t/2885)'
             }
-            Set-Content -Path $f -Value $content
-            return $f
+            foreach ($name in $CleanFiles) {
+                $full = Join-Path $dir $name
+                New-Item -ItemType Directory -Path (Split-Path $full -Parent) -Force | Out-Null
+                Set-Content -Path $full -Value '// job store migrated to shared blob storage'
+            }
+            return $dir
         }
     }
 
-    # ── Fire arm: maxReplicas > 1 + marker present ────────────────────────────
-    Context 'FIRE ARM — maxReplicas=2, marker present (must block)' {
+    # ── Fire arm: maxReplicas > 1 + marker in one file ───────────────────────
+    Context 'FIRE ARM — maxReplicas=2, one marked file (must block)' {
         It 'throws and blocks CI' {
             $bicep = script:New-BicepFixture -MaxReplicas 2
-            $store = script:New-JobStoreFixture -WithMarker $true
+            $dir   = script:New-ServerDirFixture -MarkerFiles @('briefExportJobs.ts')
             try {
-                { & $script:GateScript -BicepPath $bicep -JobStorePath $store } |
+                { & $script:GateScript -BicepPath $bicep -ServerDir $dir } |
                     Should -Throw -ExpectedMessage '*scale guard FAILED*'
             } finally {
-                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+                Remove-Item $bicep -ErrorAction SilentlyContinue
+                Remove-Item $dir -Recurse -ErrorAction SilentlyContinue
             }
         }
 
         It 'emits ::error:: lines mentioning maxReplicas and the race' {
             $bicep = script:New-BicepFixture -MaxReplicas 2
-            $store = script:New-JobStoreFixture -WithMarker $true
-            $output = & { try { & $script:GateScript -BicepPath $bicep -JobStorePath $store } catch {} } 6>&1 | Out-String
+            $dir   = script:New-ServerDirFixture -MarkerFiles @('briefExportJobs.ts')
+            $output = & { try { & $script:GateScript -BicepPath $bicep -ServerDir $dir } catch {} } 6>&1 | Out-String
             try {
                 $output | Should -Match '::error::.*maxReplicas=2'
                 $output | Should -Match '::error::.*cross-replica 404'
             } finally {
-                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+                Remove-Item $bicep -ErrorAction SilentlyContinue
+                Remove-Item $dir -Recurse -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    # ── Fire arm: maxReplicas > 1 + markers in multiple files ────────────────
+    Context 'FIRE ARM — maxReplicas=2, multiple marked files (must block and name all)' {
+        It 'throws and lists all marked files' {
+            $bicep = script:New-BicepFixture -MaxReplicas 2
+            $dir   = script:New-ServerDirFixture -MarkerFiles @('briefExportJobs.ts', 'routes/oped.ts', 'security/githubAppAuth.ts')
+            $output = & { try { & $script:GateScript -BicepPath $bicep -ServerDir $dir } catch {} } 6>&1 | Out-String
+            try {
+                $output | Should -Match 'briefExportJobs.ts'
+            } finally {
+                Remove-Item $bicep -ErrorAction SilentlyContinue
+                Remove-Item $dir -Recurse -ErrorAction SilentlyContinue
             }
         }
     }
@@ -75,24 +100,26 @@ maxReplicas: $MaxReplicas
     Context 'PASS ARM — maxReplicas=1, marker present (must pass)' {
         It 'does not throw' {
             $bicep = script:New-BicepFixture -MaxReplicas 1
-            $store = script:New-JobStoreFixture -WithMarker $true
+            $dir   = script:New-ServerDirFixture -MarkerFiles @('briefExportJobs.ts')
             try {
-                { & $script:GateScript -BicepPath $bicep -JobStorePath $store } | Should -Not -Throw
+                { & $script:GateScript -BicepPath $bicep -ServerDir $dir } | Should -Not -Throw
             } finally {
-                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+                Remove-Item $bicep -ErrorAction SilentlyContinue
+                Remove-Item $dir -Recurse -ErrorAction SilentlyContinue
             }
         }
     }
 
-    # ── Safe pass: marker absent (store migrated) ────────────────────────────
-    Context 'No marker — store migrated, any maxReplicas (must pass)' {
+    # ── Safe pass: no markers anywhere (all stores migrated) ─────────────────
+    Context 'No markers — all stores migrated, any maxReplicas (must pass)' {
         It 'passes even when maxReplicas=5' {
             $bicep = script:New-BicepFixture -MaxReplicas 5
-            $store = script:New-JobStoreFixture -WithMarker $false
+            $dir   = script:New-ServerDirFixture -CleanFiles @('briefExportJobs.ts', 'routes/oped.ts')
             try {
-                { & $script:GateScript -BicepPath $bicep -JobStorePath $store } | Should -Not -Throw
+                { & $script:GateScript -BicepPath $bicep -ServerDir $dir } | Should -Not -Throw
             } finally {
-                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+                Remove-Item $bicep -ErrorAction SilentlyContinue
+                Remove-Item $dir -Recurse -ErrorAction SilentlyContinue
             }
         }
     }
@@ -102,12 +129,13 @@ maxReplicas: $MaxReplicas
         It 'throws mentioning parse failure' {
             $bicep = [System.IO.Path]::GetTempFileName()
             Set-Content -Path $bicep -Value 'maxReplicas: 1'  # no cap comment — regex won't match
-            $store = script:New-JobStoreFixture -WithMarker $true
+            $dir   = script:New-ServerDirFixture -MarkerFiles @('briefExportJobs.ts')
             try {
-                { & $script:GateScript -BicepPath $bicep -JobStorePath $store } |
+                { & $script:GateScript -BicepPath $bicep -ServerDir $dir } |
                     Should -Throw -ExpectedMessage '*could not parse*'
             } finally {
-                Remove-Item $bicep, $store -ErrorAction SilentlyContinue
+                Remove-Item $bicep -ErrorAction SilentlyContinue
+                Remove-Item $dir -Recurse -ErrorAction SilentlyContinue
             }
         }
     }


### PR DESCRIPTION
## Summary

Extends `Test-InMemoryJobStoreScaleGuard.ps1` (SO condition 2, t/2885) from a
hardcoded single-file check to a recursive glob over `taxonomy-editor/src/server/**/*.ts`.

**Problem with the previous implementation (p/331#471 from TL):** the gate only checked
`briefExportJobs.ts`. A partial migration that migrated brief-export but left oped.ts or
githubAppAuth.ts marked would silently pass at maxReplicas > 1, reintroducing the t/2884
cross-replica race for those stores.

**Change:** replace `-JobStorePath` parameter with `-ServerDir` (defaults to
`taxonomy-editor/src/server`). Any `.ts` file in the tree carrying `@INMEMORY_JOB_STORE`
fires the gate — not just brief-export. Error output names all marked files.

**Pester tests updated:**
- `New-JobStoreFixture` (single file) → `New-ServerDirFixture` (temp dir with subdirectory support)
- Added multi-file fire arm: markers in `briefExportJobs.ts`, `routes/oped.ts`, `security/githubAppAuth.ts` all fire the gate
- 6/6 passing locally

**Landing condition:** TL is adding `@INMEMORY_JOB_STORE` to `routes/oped.ts` (t/2893) and
`security/githubAppAuth.ts` (t/2894) and will run TL Gate Verification (both arms) against
this PR before sign-off. Keeping draft until TL confirms both arms in context of real repo.

## Test plan
- [x] Local Pester: 6/6 pass (all fire/pass/no-marker/parse-fail arms)
- [ ] TL gate verification: fire arm (real `maxReplicas: 2` edit) triggers; pass arm (maxReplicas: 1) clean
- [ ] CI green on this branch with TL's marker additions landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)