### PR TITLE
fix(brief): surface the real brief-export failure reason (t/2888, t/2889)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/types.ts
+++ b/taxonomy-editor/src/renderer/bridge/types.ts
@@ -143,6 +143,9 @@ export interface BriefExportRecord {
   preset: BriefPreset;
   status: 'done' | 'failed';
   errorCode?: ExportErrorCode;
+  /** Human-readable failure reason (verify message / thrown error) — shown by the export
+   *  dialog's list fallback so a failed export explains WHY, not just a code (t/2888). */
+  reason?: string;
   narratorModel: string;
   narratorModelSource: string;
   checkerModel?: string | null;

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.test.tsx
@@ -89,6 +89,24 @@ describe('BriefExportDialog (t/2805)', () => {
     expect(screen.getByText('Audit manifest (JSON)')).toBeInTheDocument();
   });
 
+  it('poll 404 + persisted failed record: shows the real reason, not "lost track" (t/2888/t/2889)', async () => {
+    vi.useFakeTimers();
+    getBriefExportJob.mockRejectedValue(new Error('404 not found')); // per-replica registry miss
+    listBriefExports.mockResolvedValue([{
+      exportId: 'exp-1', debateId: 'deb-1', title: 'Should AI pause?', preset: 'conference',
+      status: 'failed', errorCode: 'symmetry_fail',
+      reason: 'Export verify gate failed: accelerationist camp produced 0 slides',
+      narratorModel: 'gemini-2.5-flash', narratorModelSource: 'Global', formats: [], artifacts: [],
+      traceCoveragePct: 0, warnings: [], createdAt: '2026-08-19T00:00:00Z',
+    }]);
+    renderClosed();
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }));
+    await vi.advanceTimersByTimeAsync(1600); // first poll → 404 → durable-list fallback
+    // The fallback must surface the persisted reason, and must NOT show the old "lost track" copy.
+    await vi.waitFor(() => expect(screen.getByText(/accelerationist camp produced 0 slides/i)).toBeInTheDocument());
+    expect(screen.queryByText(/lost track/i)).not.toBeInTheDocument();
+  });
+
   it('web mode: offers "Save as PDF" when an htmlDoc artifact is present and routes it through the bridge', async () => {
     // Regression (t/2852): the PDF action was gated isElectronMode(), but the brief
     // pipeline runs web-only — so the button was unreachable in both profiles. It must

--- a/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/BriefExportDialog.tsx
@@ -126,7 +126,7 @@ export function BriefExportDialog({ debateId, debateTitle, debatePhase, onClose,
       const list = await api.listBriefExports(debateId);
       const rec = list.find(r => r.exportId === exportId) ?? null;
       setRecord(rec);
-      if (rec?.status === 'failed') { setError(`Export failed: ${rec.errorCode ?? 'unknown gate'}`); setPhase('failed'); }
+      if (rec?.status === 'failed') { setError(`Export failed: ${rec.reason ?? rec.errorCode ?? 'unknown gate'}`); setPhase('failed'); }
       else { setPhase('done'); onExported?.(); }
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'brief-export-ui', level: 'error', message: 'Failed to load export record', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
@@ -146,9 +146,19 @@ export function BriefExportDialog({ debateId, debateTitle, debatePhase, onClose,
       try {
         const list = await api.listBriefExports(debateId);
         const rec = list[0];
-        if (rec) { setRecord(rec); setPhase(rec.status === 'failed' ? 'failed' : 'done'); if (rec.status !== 'failed') onExported?.(); return; }
+        if (rec) {
+          setRecord(rec);
+          // A durable record exists — surface the REAL reason for a failure (t/2888/t/2889),
+          // not a generic "lost track". reason (verify message) ?? errorCode (the gate).
+          if (rec.status === 'failed') { setError(`Export failed: ${rec.reason ?? rec.errorCode ?? 'unknown gate'}`); setPhase('failed'); }
+          else { setPhase('done'); onExported?.(); }
+          return;
+        }
       } catch { /* telemetry — silent by design */ }
-      setError('Lost track of the export job (it may have expired). Check the Exports list.');
+      // No durable record either: the in-memory job view is gone (per-replica TTL / cross-replica)
+      // AND nothing was persisted. Don't imply expiry — it may still be finishing on another
+      // replica; point at the Exports list rather than asserting a cause we don't know (t/2889).
+      setError('Could not retrieve this export’s status — it may still be finishing on the server. Check the Exports list in a moment.');
       setPhase('failed');
       return;
     }

--- a/taxonomy-editor/src/server/briefExportJobs.ts
+++ b/taxonomy-editor/src/server/briefExportJobs.ts
@@ -205,7 +205,9 @@ async function runExportJob(job: ExportJob, args: CreateJobArgs): Promise<void> 
     const errorCode = hardFailures.length > 0 ? codeForHardFailures(hardFailures) : undefined;
 
     await persist(job, args, exportId, status, artifacts, {
-      narrator: models, traceCoveragePct, warnings: job.warnings, errorCode, title,
+      narrator: models, traceCoveragePct, warnings: job.warnings, errorCode,
+      reason: status === 'failed' ? `Export verify gate failed: ${hardFailures.join('; ')}` : undefined,
+      title,
     });
 
     if (status === 'failed') {
@@ -229,7 +231,9 @@ async function runExportJob(job: ExportJob, args: CreateJobArgs): Promise<void> 
     });
     try {
       await persist(job, args, exportId, 'failed', artifacts, {
-        narrator: models, traceCoveragePct, warnings: job.warnings, errorCode, title,
+        narrator: models, traceCoveragePct, warnings: job.warnings, errorCode,
+        reason: job.error, // the thrown-stage message (set above)
+        title,
       });
     } catch (perr) {
       getGlobalRecorder()?.record({
@@ -247,7 +251,7 @@ async function runExportJob(job: ExportJob, args: CreateJobArgs): Promise<void> 
 async function persist(
   job: ExportJob, args: CreateJobArgs, exportId: string,
   status: 'done' | 'failed', artifacts: ArtifactBlob[],
-  extra: { narrator: ResolvedModels; traceCoveragePct: number; warnings: string[]; errorCode?: ExportErrorCode; title: string },
+  extra: { narrator: ResolvedModels; traceCoveragePct: number; warnings: string[]; errorCode?: ExportErrorCode; reason?: string; title: string },
 ): Promise<void> {
   const rec: BriefExportRecord = {
     exportId,
@@ -256,6 +260,7 @@ async function persist(
     preset: args.request.preset,
     status,
     errorCode: extra.errorCode,
+    reason: extra.reason,
     narratorModel: extra.narrator.modelId,
     narratorModelSource: extra.narrator.modelSource,
     checkerModel: extra.narrator.checkerModelId ?? null,

--- a/taxonomy-editor/src/server/storage/briefExportStore.ts
+++ b/taxonomy-editor/src/server/storage/briefExportStore.ts
@@ -30,6 +30,9 @@ export interface BriefExportRecord {
   preset: BriefPreset;
   status: 'done' | 'failed';
   errorCode?: ExportErrorCode;
+  /** Human-readable failure reason (the verify message / thrown error) — durable copy of
+   *  job.error so the exports-list fallback can show WHY it failed, not just the code (t/2888). */
+  reason?: string;
   narratorModel: string;
   narratorModelSource: ModelSource;
   checkerModel?: string | null;


### PR DESCRIPTION
## Code-reality note (both ticket premises were partly stale)
Failed export records are **already persisted** — `briefExportJobs.persist` runs for `status:'failed'` → `saveBriefExport`, for both the verify-hard-failure and thrown-stage paths. So this isn't "add persistence"; the real gaps were narrower.

## t/2888 — store the verbose reason, not just the code
The record stored only `errorCode` (a gate code like `symmetry_fail`), never the human-readable `job.error` ("accelerationist camp produced 0 slides"). Added `reason?: string` to `BriefExportRecord` (server `briefExportStore.ts` + renderer `types.ts`) and populate it in `persist` for both failure paths.

## t/2889 — surface it + honest copy
The poll-404 fallback **found** the failed record but only `setPhase('failed')` without setting the message → the panel showed **"Unknown failure"**; the truly-not-found path claimed **"may have expired"** (a cause we don't know). Now:
- record found + failed → shows `reason ?? errorCode`
- no record → "Could not retrieve this export's status — it may still be finishing on the server" (no false expiry claim)

## Verification
- `tsc` (server + renderer) clean · `eslint` 0 errors · `vitest BriefExportDialog` **8/8**
- New regression test: poll 404 + persisted failed record → shows the real reason; asserts no "lost track" copy.