### PR TITLE
fix(debates): populate turns/model on index upsert + let TITLE fill width (t/2892)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.css
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.css
@@ -6,6 +6,7 @@
 ────────────────────────────────────────────── */
 .debate-table-wrap {
   flex: 1;
+  width: 100%; /* span the list panel so the 100%-wide table fills it — no empty gutter (t/2892) */
   overflow: auto;
   min-height: 0;
   padding-bottom: 1rem;
@@ -117,11 +118,14 @@
   font-size: 0.875rem;
 }
 
-/* Title cell wraps up to 3 lines */
+/* Title cell wraps up to 3 lines. min-width:0 lets the width:auto column (table-layout:fixed)
+   claim all width left by the fixed columns instead of pinning to the title's min-content,
+   so TITLE fills the row and truncates only when genuinely out of room (t/2892). */
 .debate-table td.col-title {
   white-space: normal;
   overflow-wrap: anywhere;
   vertical-align: top;
+  min-width: 0;
 }
 
 .debate-table-title-text {

--- a/taxonomy-editor/src/server/__tests__/debateStore.schemaStale.test.ts
+++ b/taxonomy-editor/src/server/__tests__/debateStore.schemaStale.test.ts
@@ -1,16 +1,19 @@
 // @vitest-environment node
 
 /**
- * t/2725 — the debate-index schema-drift guard. A cached index built before the
- * model/turn_count summary fields existed has the right ROW COUNT but fieldless rows,
- * so the count-only staleness check would keep serving them (Turns/Model render empty).
- * isDebateIndexSchemaStale detects the missing key so listDebateSessionsMeta rebuilds.
+ * t/2725 + t/2892 — the debate-index schema-drift guard. A cached index built before the
+ * model/turn_count summary fields existed (or written by the fieldless upsert path) has the
+ * right ROW COUNT but rows lacking turn_count, so the count-only staleness check would keep
+ * serving them (Turns/Model render "—"). isDebateIndexSchemaStale detects the missing key so
+ * listDebateSessionsMeta rebuilds. t/2892: key ONLY on turn_count (always a number after
+ * rebuild/upsert, so no false rebuild loop; `model` is legitimately optional), and scan EVERY
+ * row (a mixed index can have a fresh row at [0] and stale rows below it).
  */
 
 import { describe, it, expect } from 'vitest';
 import { isDebateIndexSchemaStale } from '../storage/debateStore';
 
-describe('isDebateIndexSchemaStale (t/2725)', () => {
+describe('isDebateIndexSchemaStale (t/2725, t/2892)', () => {
   it('empty index is not stale (nothing to rebuild)', () => {
     expect(isDebateIndexSchemaStale([])).toBe(false);
   });
@@ -19,18 +22,21 @@ describe('isDebateIndexSchemaStale (t/2725)', () => {
     expect(isDebateIndexSchemaStale([{ id: 'd1', title: 'T', phase: 'closed' }])).toBe(true);
   });
 
-  it('STALE: a row missing only model', () => {
-    expect(isDebateIndexSchemaStale([{ id: 'd1', turn_count: 3 }])).toBe(true);
-  });
-
-  it('STALE: a row missing only turn_count', () => {
+  it('STALE: a row missing turn_count (even if model is present)', () => {
     expect(isDebateIndexSchemaStale([{ id: 'd1', model: 'gemini-3.5-flash-lite' }])).toBe(true);
   });
 
-  it('FRESH: a row carrying both keys is not stale — even when their values are undefined', () => {
-    // Key presence (not value) signals the new schema: a debate with no model set still
-    // carries the key, so it must NOT force a perpetual rebuild.
+  it('FRESH: turn_count present, model absent — model is legitimately optional (t/2892)', () => {
+    // A debate with no model set still carries turn_count; keying rebuild on model would loop.
+    expect(isDebateIndexSchemaStale([{ id: 'd1', turn_count: 3 }])).toBe(false);
     expect(isDebateIndexSchemaStale([{ id: 'd1', model: undefined, turn_count: 0 }])).toBe(false);
     expect(isDebateIndexSchemaStale([{ id: 'd1', model: 'gemini-3.5-flash-lite', turn_count: 5 }])).toBe(false);
+  });
+
+  it('STALE: scans every row — a fieldless row below a fresh [0] is caught (t/2892)', () => {
+    expect(isDebateIndexSchemaStale([
+      { id: 'fresh', model: 'claude-fable-5', turn_count: 13 }, // new upsert
+      { id: 'stale', model: 'gemini', title: 'old' },          // fieldless upsert (no turn_count)
+    ])).toBe(true);
   });
 });

--- a/taxonomy-editor/src/server/storage/debateStore.ts
+++ b/taxonomy-editor/src/server/storage/debateStore.ts
@@ -39,8 +39,14 @@ function getDebatesDir(): string {
 
 const DEBATE_INDEX_FILE = '_index.json';
 
+/** One row of the lightweight debate index. `model`/`turn_count` are part of the schema
+ *  (t/2725) — the upsert path MUST populate them or the table renders "—" for those rows
+ *  while full-rebuild rows show real values (t/2892). `turn_count` is always a number
+ *  (0 when no transcript) so it doubles as the schema-drift sentinel. */
+type DebateIndexEntry = { id: string; title: string; created_at: string; updated_at: string; phase: string; model?: string; turn_count?: number };
+
 /** Read the lightweight debate index (one file read).  Returns null if the index doesn't exist. */
-async function readDebateIndex(): Promise<{ id: string; title: string; created_at: string; updated_at: string; phase: string }[] | null> {
+async function readDebateIndex(): Promise<DebateIndexEntry[] | null> {
   const backend = getUserContentBackend();
   const raw = await backend.readFile(path.join(getDebatesDir(), DEBATE_INDEX_FILE));
   if (raw === null) return null;
@@ -48,7 +54,7 @@ async function readDebateIndex(): Promise<{ id: string; title: string; created_a
 }
 
 /** Write the debate index to disk. */
-async function writeDebateIndex(entries: { id: string; title: string; created_at: string; updated_at: string; phase: string }[]): Promise<void> {
+async function writeDebateIndex(entries: DebateIndexEntry[]): Promise<void> {
   const backend = getUserContentBackend();
   await backend.writeFile(
     path.join(getDebatesDir(), DEBATE_INDEX_FILE),
@@ -57,7 +63,7 @@ async function writeDebateIndex(entries: { id: string; title: string; created_at
 }
 
 /** Upsert a single debate entry in the index. */
-async function upsertDebateIndex(summary: { id: string; title: string; created_at: string; updated_at: string; phase: string }): Promise<void> {
+async function upsertDebateIndex(summary: DebateIndexEntry): Promise<void> {
   const entries = (await readDebateIndex()) ?? [];
   const idx = entries.findIndex(e => e.id === summary.id);
   if (idx >= 0) entries[idx] = summary;
@@ -84,8 +90,11 @@ async function removeFromDebateIndex(id: string): Promise<void> {
  * is unchanged), so it would keep serving fieldless rows (Turns/Model render empty).
  */
 export function isDebateIndexSchemaStale(cached: unknown[]): boolean {
-  const first = cached[0] as Record<string, unknown> | undefined;
-  return first != null && (!('turn_count' in first) || !('model' in first));
+  // Scan EVERY row, not just cached[0] (t/2892): the upsert path historically wrote rows
+  // without turn_count, so an index can be mixed — new rows have it, older upsert rows don't.
+  // Key on turn_count only: it is always a number after rebuild/upsert (0 when no transcript),
+  // so it never false-triggers a rebuild loop the way an optional `model` would.
+  return cached.some(r => !('turn_count' in (r as Record<string, unknown>)));
 }
 
 export async function listDebateSessionsMeta(): Promise<unknown[]> {
@@ -217,13 +226,8 @@ export async function saveDebateSession(session: unknown, caller: string): Promi
   await backend.writeFile(debatePath, json);
   log.server.info({ caller, debateId: s.id, backendName: backend.backendName, blobKey: debatePath, bytes: json.length, writeAck: true }, 'Debate session saved');
   // Maintain the lightweight index
-  void upsertDebateIndex({
-    id: s.id,
-    title: s.title || s.topic?.final || s.topic?.original || 'Untitled',
-    created_at: s.created_at || '',
-    updated_at: s.updated_at || s.created_at || '',
-    phase: s.phase || 'unknown',
-  }).catch((err) => { log.server.warn({ err }, 'Debate index upsert failed (best-effort)'); });
+  void upsertDebateIndex(buildDebateIndexEntry(s.id, session as DebateSession))
+    .catch((err) => { log.server.warn({ err }, 'Debate index upsert failed (best-effort)'); });
 }
 
 /** Build the typed 409 version-conflict error carrying the server's current
@@ -268,14 +272,19 @@ async function applyDeltaAnon(delta: DebateDelta): Promise<{ newVersion: number 
   return { newVersion: merged._saveVersion ?? 0 };
 }
 
-function buildDebateIndexEntry(id: string, merged: DebateSession): { id: string; title: string; created_at: string; updated_at: string; phase: string } {
-  const m = merged as { title?: string; topic?: { final?: string; original?: string }; created_at?: string; updated_at?: string; phase?: string };
+function buildDebateIndexEntry(id: string, merged: DebateSession): DebateIndexEntry {
+  const m = merged as { title?: string; topic?: { final?: string; original?: string }; created_at?: string; updated_at?: string; phase?: string; debate_model?: string; transcript?: { type?: string }[] };
+  // model + turn_count mirror the full-rebuild path (listDebateSessions) so upsert-written
+  // rows carry the same fields — else Turns/Model render "—" for saved debates (t/2892).
+  const transcript = Array.isArray(m.transcript) ? m.transcript : [];
   return {
     id,
     title: m.title || m.topic?.final || m.topic?.original || 'Untitled',
     created_at: m.created_at || '',
     updated_at: m.updated_at || m.created_at || '',
     phase: m.phase || 'unknown',
+    model: m.debate_model,
+    turn_count: transcript.filter(t => t.type === 'statement' || t.type === 'opening').length,
   };
 }
 


### PR DESCRIPTION
Reported by @jpsnover / Diagnostics; two-part code fix, no design deliverable (Design pre-specified the CSS).

## Issue 1 — TURNS/MODEL "—" for some rows (data, the substantive fix)
**Root cause:** the debate `_index.json` carried `model`/`turn_count` only from the full **rebuild** path. The incremental **upsert** path (on every save/delta via `buildDebateIndexEntry` + the inline `saveDebateSession` call) wrote rows **without** them — the `DebateIndexEntry` type didn't even include the fields. Result: a *mixed* index — saved/updated debates render "—", rebuilt rows show real values.
**Fix:** carry `model`/`turn_count` through the index type; compute them in `buildDebateIndexEntry` (mirrors `listDebateSessions`); route the inline upsert through it. `isDebateIndexSchemaStale` now scans **every** row keyed on `turn_count` (always a number → no rebuild loop; `model` is legitimately optional), so existing mixed indexes rebuild once and self-heal. `turn_count` defaults to 0; "—" only when genuinely absent.

## Issue 2 — TITLE fills remaining width (CSS)
`.col-title` is `width:auto` under `table-layout:fixed` but was pinned to min-content → added `min-width:0` so it claims the space left by the fixed columns; `width:100%` on the wrap so the table spans the panel (no right gutter). 3-line clamp still applies when out of room.

## Verification
`tsc` (server) + `eslint` clean; `vitest debateStore.schemaStale` **5/5** incl. a new all-rows-scan case.
⚠️ **Issue-2 CSS is visual** — I couldn't render the web table; **Design, please eyeball the title-fill** (implements your specified `min-width:0`). Not gating the data fix on it.