### PR TITLE
feat(oped): Claims section + per-element claim linkage (t/2890)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -182,6 +182,17 @@ const REFLECTION_SCHEMA = {
         required: ['id', 'reflection'],
       },
     },
+    claims: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          text: { type: 'string' },
+          paragraph: { type: 'integer' },
+        },
+        required: ['text', 'paragraph'],
+      },
+    },
   },
   required: ['grounding_usage'],
 } as const;
@@ -199,6 +210,7 @@ interface EssayResponse {
 
 interface ReflectionResponse {
   grounding_usage: { id: string; reflection: string; document_claims?: string[] }[];
+  claims?: { text: string; paragraph: number }[];
 }
 
 async function runVoiceGeneration(
@@ -269,6 +281,7 @@ async function runVoiceGeneration(
   ];
 
   // Reflection pass — best-effort, maps grounding elements to where they appear
+  let reflClaims: { text: string; paragraph: number }[] | undefined;
   if (allGroundingRefs.length > 0 && body) {
     try {
       const groundingList = buildGroundingList(groundingNodes, sitNodes);
@@ -292,6 +305,7 @@ async function runVoiceGeneration(
           if (usage.document_claims?.length) ref.document_claims = usage.document_claims;
         }
       }
+      if (reflParsed.claims?.length) reflClaims = reflParsed.claims;
     } catch {
       // Reflection failure is non-fatal — how_reflected stays '(not reported)'
     }
@@ -319,6 +333,7 @@ async function runVoiceGeneration(
     rhetorical_meta: parsed.rhetorical_meta ?? '',
     wordCount: actualWordCount,
     grounding: allGroundingRefs,
+    ...(reflClaims && { claims: reflClaims }),
     ...(fabricatedLede && { fabricated_lede: true as const }),
   };
 }

--- a/lib/oped/prompts/op-ed-grounding-reflection.prompt
+++ b/lib/oped/prompts/op-ed-grounding-reflection.prompt
@@ -13,4 +13,6 @@ For EACH element id above, judge against the actual essay text and write one sen
 
 Also, when SOURCE DOCUMENT KEY CLAIMS are provided above, list in "document_claims" the specific claims (copied verbatim from the numbered list) that THIS element engages, supports, or rebuts in the essay. Include a claim only if the essay actually connects this element to it. Use an empty array if the element engages no source claim, or if no source claims were provided.
 
-Return ONLY a JSON object: { "grounding_usage": [ { "id": "<the [id]>", "reflection": "<one sentence>", "document_claims": ["<verbatim claim>", ...] }, ... ] } with exactly one entry per element id shown above. No commentary outside the JSON.
+Additionally, when SOURCE DOCUMENT KEY CLAIMS are provided (not "(none)"), extract a top-level "claims" array: one entry per claim from the numbered list, with the claim text verbatim and the paragraph number (1-indexed) of the op-ed body where that claim is most directly engaged or addressed. If a claim is not addressed anywhere in the op-ed, use paragraph 0. If no source claims were provided, return "claims" as an empty array.
+
+Return ONLY a JSON object: { "grounding_usage": [ { "id": "<the [id]>", "reflection": "<one sentence>", "document_claims": ["<verbatim claim>", ...] }, ... ], "claims": [ { "text": "<verbatim claim text>", "paragraph": <integer> }, ... ] } with exactly one entry per element id shown above in grounding_usage. No commentary outside the JSON.

--- a/lib/oped/schemas.ts
+++ b/lib/oped/schemas.ts
@@ -26,6 +26,7 @@ export const OpEdGroundingRefSchema = z.object({
   pov: PovKeySchema,         // full PovKey — rejects PS short-code "acc"/"saf"/"skp"
   relevance: z.string(),     // snake_case — rejects PS "Relevance"
   how_reflected: z.string(), // snake_case — rejects PS "HowReflected"
+  document_claims: z.array(z.string()).optional(),
 });
 
 export const OpEdMemberSchema = z.object({
@@ -42,6 +43,7 @@ export const OpEdMemberSchema = z.object({
   rhetorical_meta: z.string().optional().default(''),
   wordCount: z.number().int().optional().default(0),
   grounding: z.array(OpEdGroundingRefSchema),
+  claims: z.array(z.object({ text: z.string(), paragraph: z.number().int() })).optional(),
 });
 
 export const OpEdSetSchema = z.object({

--- a/lib/oped/types.ts
+++ b/lib/oped/types.ts
@@ -47,6 +47,8 @@ export interface OpEdMember {
   rhetorical_meta: string;
   wordCount: number;
   grounding: OpEdGroundingRef[];
+  /** Source claims extracted by the reflection pass (t/2890) — absent when no source brief or claims list is empty. */
+  claims?: { text: string; paragraph: number }[];
   /** Set when FABRICATED_LEDE_GUARD matched the lede on an empty-newsHook run (t/2730). */
   fabricated_lede?: true;
 }

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.css
@@ -314,6 +314,49 @@
   color: var(--text-primary);
 }
 
+/* Claims section (t/2890) — mirrors .oped-grounding spacing/tokens; no hard-coded colors */
+.oped-claims {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+  padding-top: 1rem;
+}
+
+.oped-claims-summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  user-select: none;
+}
+
+.oped-claims-summary:hover { color: var(--text-primary); }
+
+.oped-claims-list {
+  margin: 0.75rem 0 0 1.25rem;
+  padding: 0;
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.oped-claim-item {
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.oped-claim-para {
+  flex-shrink: 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm, 3px);
+  padding: 0.1rem 0.35rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .oped-tab { transition: none; }
 }

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -28,7 +28,7 @@ function prefersReducedMotion(): boolean {
 // Inline grounding-element detail card (§6 clickable grounding)
 // ──────────────────────────────────────────────
 
-function GroundingDetailCard({ ref, onClose }: { ref: OpEdGroundingRef; onClose: () => void }) {
+function GroundingDetailCard({ ref, onClose, claims }: { ref: OpEdGroundingRef; onClose: () => void; claims?: { text: string; paragraph: number }[] }) {
   const cardRef = useRef<HTMLDivElement>(null);
   const state = useTaxonomyStore.getState();
 
@@ -83,7 +83,20 @@ function GroundingDetailCard({ ref, onClose }: { ref: OpEdGroundingRef; onClose:
         <div className="oped-grounding-card-claims">
           <span className="oped-grounding-card-claims-label">Addresses these source claims:</span>
           <ul className="oped-grounding-card-claims-list">
-            {ref.document_claims.map((c, i) => <li key={i}>{c}</li>)}
+            {ref.document_claims.map((c, i) => {
+              const matchIdx = claims?.findIndex(cl => cl.text === c) ?? -1;
+              const claimNum = matchIdx >= 0 ? matchIdx + 1 : null;
+              const para = matchIdx >= 0 ? claims![matchIdx].paragraph : null;
+              return (
+                <li key={i}>
+                  {claimNum != null && <strong>Claim #{claimNum} · </strong>}
+                  {c}
+                  {para != null && para > 0 && (
+                    <span className="oped-claim-para" title={`Paragraph ${para}`} aria-label={`Paragraph ${para}`}>¶{para}</span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}
@@ -125,7 +138,7 @@ function ClaimsSection({ claims }: { claims: { text: string; paragraph: number }
 // Grounding section (collapsible table + inline expand)
 // ──────────────────────────────────────────────
 
-function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
+function GroundingSection({ grounding, claims }: { grounding: OpEdGroundingRef[]; claims?: { text: string; paragraph: number }[] }) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [showUnused, setShowUnused] = useState(false);
 
@@ -196,7 +209,7 @@ function GroundingSection({ grounding }: { grounding: OpEdGroundingRef[] }) {
           {showUnused ? 'Hide' : 'Show'} {unused.length} unused element{unused.length !== 1 ? 's' : ''}
         </button>
       )}
-      {expandedRef && <GroundingDetailCard ref={expandedRef} onClose={() => setExpandedId(null)} />}
+      {expandedRef && <GroundingDetailCard ref={expandedRef} onClose={() => setExpandedId(null)} claims={claims} />}
     </details>
   );
 }
@@ -235,7 +248,7 @@ function OpEdArticle({ member, outlet }: { member: OpEdMember; outlet?: string }
             <Markdown remarkPlugins={[remarkGfm]}>{member.body}</Markdown>
           </div>
           {member.claims && member.claims.length > 0 && <ClaimsSection claims={member.claims} />}
-          <GroundingSection grounding={member.grounding} />
+          <GroundingSection grounding={member.grounding} claims={member.claims} />
 
           {member.rhetorical_meta && (
             <section className="oped-rhetorical-meta" aria-label="What this op-ed did">

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx
@@ -93,6 +93,35 @@ function GroundingDetailCard({ ref, onClose }: { ref: OpEdGroundingRef; onClose:
 }
 
 // ──────────────────────────────────────────────
+// Claims section (t/2890) — source claims above taxonomy grounding
+// ──────────────────────────────────────────────
+
+function ClaimsSection({ claims }: { claims: { text: string; paragraph: number }[] }) {
+  if (claims.length === 0) return null;
+  return (
+    <details className="oped-claims" open>
+      <summary className="oped-claims-summary">Claims ({claims.length})</summary>
+      <ol className="oped-claims-list">
+        {claims.map((c, i) => (
+          <li key={i} className="oped-claim-item">
+            {c.text}
+            {c.paragraph > 0 && (
+              <span
+                className="oped-claim-para"
+                title={`Paragraph ${c.paragraph}`}
+                aria-label={`Paragraph ${c.paragraph}`}
+              >
+                ¶{c.paragraph}
+              </span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
+// ──────────────────────────────────────────────
 // Grounding section (collapsible table + inline expand)
 // ──────────────────────────────────────────────
 
@@ -205,6 +234,7 @@ function OpEdArticle({ member, outlet }: { member: OpEdMember; outlet?: string }
           <div className="oped-reader-body">
             <Markdown remarkPlugins={[remarkGfm]}>{member.body}</Markdown>
           </div>
+          {member.claims && member.claims.length > 0 && <ClaimsSection claims={member.claims} />}
           <GroundingSection grounding={member.grounding} />
 
           {member.rhetorical_meta && (


### PR DESCRIPTION
## Summary

- Extends op-ed grounding reflection to co-return a top-level `claims: [{text, paragraph}]` array — source claims paired with the op-ed paragraph where each is engaged
- Adds `ClaimsSection` UI component (collapsible `<details open>`) above Taxonomy grounding, per Design spec at t/2890#3
- Fixes `OpEdGroundingRefSchema` Zod gap: `document_claims` was being stripped on re-parse (field present at runtime, absent after Zod validation)
- All additions are backward-compatible: absent/empty `claims` → section omitted, no regression on existing grounding display

**Files changed:**
- `lib/oped/types.ts` — `claims?` added to `OpEdMember`
- `lib/oped/schemas.ts` — `document_claims` fixed in `OpEdGroundingRefSchema`; `claims` added to `OpEdMemberSchema`
- `lib/oped/generate.ts` — `REFLECTION_SCHEMA` + `ReflectionResponse` extended; claims extracted and threaded into returned member
- `lib/oped/prompts/op-ed-grounding-reflection.prompt` — instructs AI to also return top-level claims with paragraph refs
- `taxonomy-editor/src/renderer/components/opeds/OpEdReader.tsx` — `ClaimsSection` component + call site in `OpEdArticle`
- `taxonomy-editor/src/renderer/components/opeds/OpEdReader.css` — `.oped-claims*` + `.oped-claim-para` classes; tokens only, no hard-coded hex

## Test plan

- [ ] tsc --noEmit passes (verified locally at 11920152)
- [ ] ESLint passes on changed lib/oped/ files (verified locally)
- [ ] CI green on head
- [ ] Design `/design-review-workflow` sign-off before merge

**Draft gate:** Design `/design-review-workflow` (per t/2890#3 acceptance criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)