### PR TITLE
feat(oped): source provenance on OpEdSet + reflection observability (t/2898)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -24,6 +24,9 @@ export interface GenerateOpEdRequest {
   povs: PovKey[];
   /** Raw source markdown (pre-fetched from URL). Omit for topic-only requests. */
   sourceMaterial?: string;
+  /** The URL `sourceMaterial` was fetched from — persisted as OpEdSet.source_url for
+   *  provenance (t/2898). The app-half handler passes it; absent for topic runs. */
+  sourceUrl?: string;
   signal?: AbortSignal;
 }
 
@@ -40,7 +43,7 @@ export interface OpEdGeneratorDeps {
 // ── Progress event union ──────────────────────────────────────────────────────
 
 export type OpEdProgressEvent =
-  | { type: 'source_brief_done' }
+  | { type: 'source_brief_done'; keyClaimsCount: number }
   | { type: 'source_brief_failed'; error: string }
   | { type: 'grounding_done'; nodeCount: number }
   | { type: 'grounding_failed'; error: string }
@@ -306,10 +309,29 @@ async function runVoiceGeneration(
         }
       }
       if (reflParsed.claims?.length) reflClaims = reflParsed.claims;
-    } catch {
-      // Reflection failure is non-fatal — how_reflected stays '(not reported)'
+    } catch (err) {
+      // Reflection failure is non-fatal — how_reflected stays '(not reported)' and
+      // claims are absent. The bare swallow here is why four claims-extraction
+      // failures were undiagnosable (t/2897); record it so it's visible. Uses
+      // 'system.error'+level:'warn' — the file's valid-EventType warn convention
+      // ('system.warning' is not in the union; TL confirmed the mapping, p/342#133).
+      deps.recorder?.record({
+        type: 'system.error', component: 'opedGenerate', level: 'warn',
+        message: `Op-ed reflection pass failed for pov=${pov} set=${request.set_id}: ${String(err)} — grounding how_reflected + claims will be absent`,
+      });
     }
   }
+
+  // Claims-extraction observability (t/2898): record a per-member count — including
+  // the 0 case — so "zero claims extracted" is a visible recorded fact, not an
+  // inference from an absent field. document_claims_refs = grounding refs the
+  // reflection pass tied back to a source claim.
+  const documentClaimsRefs = allGroundingRefs.filter(r => r.document_claims?.length).length;
+  deps.recorder?.record({
+    type: 'system.info', component: 'opedGenerate', level: 'info',
+    message: `Op-ed claims extracted for pov=${pov} set=${request.set_id}: claims=${reflClaims?.length ?? 0} document_claims_refs=${documentClaimsRefs}`,
+    data: { pov, set_id: request.set_id, claims_extracted: reflClaims?.length ?? 0, document_claims_refs: documentClaimsRefs },
+  });
 
   // Guard scan: when newsHook was empty, check the lede (first 500 chars) for
   // fabricated dated-event markers. Flag without mutating the body (t/2730).
@@ -317,7 +339,9 @@ async function runVoiceGeneration(
   const fabricatedLede = emptyHook && FABRICATED_LEDE_GUARD.test(body.slice(0, 500));
   if (fabricatedLede) {
     deps.recorder?.record({
-      type: 'system.warning', component: 'opedGenerate', level: 'warn',
+      // 'system.error'+level:'warn' — 'system.warning' is not in the EventType union
+      // (fixed in-scope, t/2898; TL-confirmed p/342#133).
+      type: 'system.error', component: 'opedGenerate', level: 'warn',
       message: `FABRICATED_LEDE_GUARD matched for pov=${pov} set=${request.set_id} — empty-hook lede may contain invented dated event`,
     });
   }
@@ -378,7 +402,9 @@ export async function* generateOpEdSet(
           message: 'Op-ed source brief marked unreadable — generating from topic only despite a supplied source',
         });
       }
-      yield { type: 'source_brief_done' };
+      // keyClaimsCount surfaces the comprehension result in-stream (t/2898) — 0 when
+      // the brief was unreadable/absent so the handler sees "source present, 0 claims".
+      yield { type: 'source_brief_done', keyClaimsCount: sourceBrief?.key_claims?.length ?? 0 };
     } catch (err) {
       yield { type: 'source_brief_failed', error: String(err) };
     }
@@ -488,6 +514,11 @@ export async function* generateOpEdSet(
   const memberMap = new Map(members.map(({ pov, member }) => [pov, member]));
   const orderedMembers = request.povs.map(pov => memberMap.get(pov)!).filter(Boolean);
 
+  // Source provenance (t/2897/t/2898): source_mode is ALWAYS set on new sets so a
+  // topic run (a URL pasted into the topic box → no source fetched → no claims) is
+  // distinguishable from the file alone. url mode also carries the fetched URL and the
+  // comprehension-pass claim count (0 = brief failed/unreadable/empty).
+  const isUrlMode = !!request.sourceMaterial;
   const set: OpEdSet = {
     schema_version: 1,
     set_id: request.set_id,
@@ -495,6 +526,9 @@ export async function* generateOpEdSet(
     params: request.params,
     created_at: new Date().toISOString(),
     opeds: orderedMembers,
+    source_mode: isUrlMode ? 'url' : 'topic',
+    ...(isUrlMode && request.sourceUrl ? { source_url: request.sourceUrl } : {}),
+    ...(isUrlMode ? { source_key_claims_count: sourceBrief?.key_claims?.length ?? 0 } : {}),
   };
 
   yield { type: 'complete', set };

--- a/lib/oped/schemas.ts
+++ b/lib/oped/schemas.ts
@@ -53,6 +53,11 @@ export const OpEdSetSchema = z.object({
   params: OpEdParamsSchema,
   created_at: z.string(),
   opeds: z.array(OpEdMemberSchema),
+  // Source provenance (t/2898) — optional/additive so re-parse doesn't strip them
+  // (same strip-gap class fixed for document_claims in t/2890). Absent on legacy sets.
+  source_mode: z.enum(['topic', 'url']).optional(),
+  source_url: z.string().optional(),
+  source_key_claims_count: z.number().int().optional(),
 });
 
 /**

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -35,7 +35,9 @@ vi.mock('./promptLoader.js', () => ({
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { generateOpEdSet, type OpEdProgressEvent } from './generate.js';
+import { parseOpEdSet } from './schemas.js';
 import type { PovKey } from '../debate/types.js';
+import type { OpEdSet } from './types.js';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -274,5 +276,133 @@ describe('generateOpEdSet — Step 0 source-brief comprehension (t/2722)', () =>
     expect(events).not.toContain('source_brief_done');
     expect(events).not.toContain('source_brief_failed');
     expect(events).toContain('complete');
+  });
+});
+
+describe('generateOpEdSet — source provenance + reflection observability (t/2898)', () => {
+  const ESSAY_JSON = JSON.stringify({ headline: 'H', subtitle: '', body_markdown: 'Body.', word_count: 1 });
+  const REFL_JSON = JSON.stringify({ grounding_usage: [] });
+  const BRIEF_JSON = JSON.stringify({
+    thesis: 'AI labs must share safety research', author: 'Test Org', actor_type: 'think tank',
+    stance: 'FOR', primary_recommendations: ['Mandate sharing'],
+    key_claims: ['Incidents doubled', 'Only 3 labs share'], readable: true,
+  });
+  const PROMPTS = join(REPO_ROOT, 'lib', 'oped', 'prompts');
+
+  async function collect(req: Record<string, unknown>, deps: Record<string, unknown>): Promise<OpEdSet> {
+    let set: OpEdSet | undefined;
+    for await (const ev of generateOpEdSet(req as never, deps as never) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'complete') set = ev.set;
+    }
+    if (!set) throw new Error('no complete event');
+    return set;
+  }
+
+  it('topic-mode set reads source_mode:"topic" with no url/count — distinguishable from the file alone', async () => {
+    const adapter = { generateText: async (p: string) => (p === 'refl' ? REFL_JSON : ESSAY_JSON) };
+    const set = await collect(
+      { set_id: 't-topic', topic: 'AI policy', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' }, povs: ['accelerationist'] },
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT },
+    );
+    expect(set.source_mode).toBe('topic');
+    expect(set.source_url).toBeUndefined();
+    expect(set.source_key_claims_count).toBeUndefined();
+  });
+
+  it('url-mode set reads source_mode:"url", source_url, and the key-claims count', async () => {
+    const adapter = {
+      generateText: async (p: string) => (p === 'source-brief-prompt' ? BRIEF_JSON : p === 'refl' ? REFL_JSON : ESSAY_JSON),
+    };
+    const set = await collect(
+      { set_id: 't-url', topic: 'AI safety', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' }, povs: ['accelerationist'], sourceMaterial: 'Doc text', sourceUrl: 'https://example.org/report' },
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT },
+    );
+    expect(set.source_mode).toBe('url');
+    expect(set.source_url).toBe('https://example.org/report');
+    expect(set.source_key_claims_count).toBe(2);
+  });
+
+  it('url-mode count is 0 when the source brief is unreadable (brief failed/empty)', async () => {
+    const UNREADABLE = JSON.stringify({ thesis: '', author: '', actor_type: '', stance: '', primary_recommendations: [], key_claims: [], readable: false });
+    const adapter = {
+      generateText: async (p: string) => (p === 'source-brief-prompt' ? UNREADABLE : p === 'refl' ? REFL_JSON : ESSAY_JSON),
+    };
+    const set = await collect(
+      { set_id: 't-url0', topic: 'AI safety', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' }, povs: ['accelerationist'], sourceMaterial: 'gibberish', sourceUrl: 'https://example.org/x' },
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT },
+    );
+    expect(set.source_mode).toBe('url');
+    expect(set.source_key_claims_count).toBe(0);
+  });
+
+  it('source_brief_done carries keyClaimsCount', async () => {
+    const adapter = {
+      generateText: async (p: string) => (p === 'source-brief-prompt' ? BRIEF_JSON : p === 'refl' ? REFL_JSON : ESSAY_JSON),
+    };
+    let count: number | undefined;
+    for await (const ev of generateOpEdSet(
+      { set_id: 't-evt', topic: 'AI', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' }, povs: ['accelerationist'], sourceMaterial: 'Doc' } as never,
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT } as never,
+    ) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'source_brief_done') count = ev.keyClaimsCount;
+    }
+    expect(count).toBe(2);
+  });
+
+  it('reflection-pass failure emits a recorder warning naming the pov — no longer silent', async () => {
+    const adapter = {
+      // 'refl' returns non-JSON → JSON.parse throws inside the reflection block.
+      generateText: async (p: string) => (p === 'refl' ? 'not json at all' : ESSAY_JSON),
+    };
+    const record = vi.fn();
+    let member: { pov: string } | undefined;
+    for await (const ev of generateOpEdSet(
+      { set_id: 't-refl', topic: 'AI', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: 'hook', thesis: '' }, povs: ['accelerationist'] } as never,
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT, recorder: { record } } as never,
+    ) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_complete') member = ev.member;
+    }
+    // Non-fatal: the voice still completes …
+    expect(member?.pov).toBe('accelerationist');
+    // … but the reflection failure is now recorded (valid EventType, names the pov).
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'system.error', level: 'warn', component: 'opedGenerate',
+      message: expect.stringContaining('reflection pass failed for pov=accelerationist'),
+    }));
+  });
+
+  it('records a per-member claims_extracted count — including the zero case', async () => {
+    const adapter = { generateText: async (p: string) => (p === 'refl' ? REFL_JSON : ESSAY_JSON) };
+    const record = vi.fn();
+    for await (const _ev of generateOpEdSet(
+      { set_id: 't-count', topic: 'AI', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: 'hook', thesis: '' }, povs: ['accelerationist'] } as never,
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT, recorder: { record } } as never,
+    ) as AsyncGenerator<OpEdProgressEvent>) { /* drain */ }
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'system.info', component: 'opedGenerate',
+      data: expect.objectContaining({ claims_extracted: 0, pov: 'accelerationist' }),
+    }));
+  });
+
+  it('schema round-trip retains the three new provenance fields (no strip)', () => {
+    const raw: OpEdSet = {
+      schema_version: 1, set_id: 's', topic: 't',
+      params: { model: 'm', wordCount: 800 }, created_at: '2026-08-21T00:00:00Z',
+      opeds: [],
+      source_mode: 'url', source_url: 'https://example.org/a', source_key_claims_count: 4,
+    };
+    const round = parseOpEdSet(JSON.parse(JSON.stringify(raw)));
+    expect(round.source_mode).toBe('url');
+    expect(round.source_url).toBe('https://example.org/a');
+    expect(round.source_key_claims_count).toBe(4);
+  });
+
+  it('legacy set without provenance fields still parses (no migration)', () => {
+    const legacy = {
+      schema_version: 1, set_id: 's', topic: 't',
+      params: { model: 'm', wordCount: 800 }, created_at: '2026-08-21T00:00:00Z', opeds: [],
+    };
+    const round = parseOpEdSet(legacy);
+    expect(round.source_mode).toBeUndefined();
   });
 });

--- a/lib/oped/types.ts
+++ b/lib/oped/types.ts
@@ -66,6 +66,12 @@ export interface OpEdSet {
   params: OpEdParams;
   created_at: string;
   opeds: OpEdMember[];
+  /** Source provenance (t/2897): how this set was created. Absent on pre-existing sets. */
+  source_mode?: 'topic' | 'url';
+  /** The fetched source URL — url mode only. */
+  source_url?: string;
+  /** key_claims extracted by the comprehension pass (0 = brief failed/empty). url mode only. */
+  source_key_claims_count?: number;
 }
 
 // ── Local library listing summary (t/2591) ───────────────────────────────────


### PR DESCRIPTION
Fixes t/2898 (interface-first half of t/2897). Design + TL sign-off at t/2898#1; self-cert per the ticket routing note. **Land first — t/2899 (handler) is blocked on these types.**

## What & why
Root cause of t/2897: a set was created with a URL pasted into the topic box → topic mode → no source brief → no claims, **silently**. Now answerable *from the file alone*.

- **`types.ts`** — additive optional `OpEdSet` fields: `source_mode: ''topic''|''url''`, `source_url`, `source_key_claims_count`. `schema_version` stays `1`; legacy sets (fields absent) still parse.
- **`schemas.ts`** — mirror the three on `OpEdSetSchema` so store re-parse doesn''t strip them (same strip-gap class as t/2890 `document_claims`).
- **`generate.ts`** —
  - `source_mode` set on **every** new set (topic runs distinguishable from the file); url mode also carries `source_url` + the comprehension-pass `key_claims` count (0 = brief failed/unreadable/empty).
  - New optional `GenerateOpEdRequest.sourceUrl` — the app-half handler (t/2899) passes it.
  - `source_brief_done` now carries `keyClaimsCount` for in-stream consumption.
  - Reflection-pass bare `catch {}` → recorder warn naming pov+set_id (the swallow hid four failures); per-member `claims_extracted` count recorded (incl. the 0 case).
  - **EventType fix:** reflection warn + the pre-existing fabricated-lede guard use `system.error`+`level:''warn''` — `system.warning` is not in the `EventType` union (TL-confirmed, p/342#133).

## Consumer contract (for t/2899)
Authoritative: `OpEdSet.source_key_claims_count?: number` (url mode; 0 on brief failure; absent in topic mode) + `source_mode`, `source_url`. In-stream convenience: `{ type: ''source_brief_done'', keyClaimsCount }`.

## Tests
`serialGeneration.test.ts` extended: topic vs url provenance; 0-count on unreadable brief; `source_brief_done` count; reflection-failure recorder warn (no longer silent); `claims_extracted` count; schema round-trip retains the new fields; legacy set still parses. Full `lib/oped` suite green (72), `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)