### PR TITLE
feat(auth): deprecate per-user runtime credential override in hosted mode (t/2895)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/hostedModeCredentials.test.ts
+++ b/taxonomy-editor/src/server/__tests__/hostedModeCredentials.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+
+/**
+ * t/2895 — runtime per-user credential override is deprecated in hosted (non-filesystem) mode.
+ * App-install token is the canonical hosted auth path; per-user map is dead code in hosted.
+ *
+ * Covers:
+ *   - setRuntimeCredentials() throws ActionableError { statusCode: 409 } in hosted mode
+ *   - clearRuntimeCredentials() is a no-op (does not throw) in hosted mode
+ *   - getCredentials() returns App install token in hosted mode, never per-user map
+ *   - getCredentials() falls back to GITHUB_TOKEN env in hosted mode
+ *   - getCredentials() emits a FR system.error when all rungs exhausted (Condition 1, t/2895)
+ *   - getCredentials() emits FR error when GITHUB_REPO is unset
+ *   - getRepoSlug() returns env GITHUB_REPO in hosted mode, ignoring any map entry
+ *   - ALS isolation: set attempt throws, subsequent getCredentials() under any principal
+ *     returns the shared token, not the rejected value
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runWithUser, type UserContext } from '../security/userContext.js';
+
+// ── STORAGE_MODE mock (must be before the module under test is imported) ──
+vi.mock('../config.js', () => ({ STORAGE_MODE: 'blob', CACHE_DIR: '/tmp/test-cache' }));
+
+// ── Flight recorder mock ──
+const frRecord = vi.fn();
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: frRecord }),
+}));
+
+// ── getInstallationToken mock (module-internal; accessed via vi.mock of the module) ──
+// We mock the fetch used inside getInstallationToken instead of the function directly.
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import {
+  setRuntimeCredentials,
+  clearRuntimeCredentials,
+  getCredentials,
+  getRepoSlug,
+} from '../security/githubAppAuth.js';
+
+function asUser<T>(principalName: string, fn: () => T): T {
+  const ctx: UserContext = { principalName, idp: 'github', storageUserId: principalName, isAnonymous: false };
+  return runWithUser(ctx, fn);
+}
+
+const SAVED: Record<string, string | undefined> = {};
+const ENV_KEYS = ['GITHUB_REPO', 'GITHUB_TOKEN', 'GITHUB_APP_ID', 'GITHUB_APP_INSTALLATION_ID', 'GITHUB_APP_PRIVATE_KEY'];
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) { SAVED[k] = process.env[k]; delete process.env[k]; }
+  frRecord.mockClear();
+  mockFetch.mockReset();
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) { if (SAVED[k] === undefined) delete process.env[k]; else process.env[k] = SAVED[k]; }
+});
+
+describe('t/2895 hosted-mode credential gating (STORAGE_MODE !== filesystem)', () => {
+  it('setRuntimeCredentials() throws ActionableError { statusCode: 409 } in hosted mode', () => {
+    expect(() => asUser('alice', () => setRuntimeCredentials('alice/repo', 'tok-alice')))
+      .toThrow();
+    try {
+      asUser('alice', () => setRuntimeCredentials('alice/repo', 'tok-alice'));
+    } catch (err) {
+      expect((err as { statusCode?: number }).statusCode).toBe(409);
+      expect((err as { goal?: string }).goal).toBeDefined();
+      expect((err as { problem?: string }).problem).toBeDefined();
+      expect((err as { location?: string }).location).toBeDefined();
+      expect(Array.isArray((err as { nextSteps?: unknown[] }).nextSteps)).toBe(true);
+    }
+  });
+
+  it('clearRuntimeCredentials() is a no-op (does not throw) in hosted mode', () => {
+    expect(() => asUser('alice', () => clearRuntimeCredentials())).not.toThrow();
+  });
+
+  it('getRepoSlug() returns env GITHUB_REPO in hosted mode', () => {
+    process.env.GITHUB_REPO = 'owner/hosted-repo';
+    expect(getRepoSlug()).toBe('owner/hosted-repo');
+  });
+
+  it('getRepoSlug() returns null when GITHUB_REPO is unset in hosted mode', () => {
+    expect(getRepoSlug()).toBeNull();
+  });
+
+  it('getCredentials() returns GITHUB_TOKEN env when no App install token in hosted mode', async () => {
+    process.env.GITHUB_REPO = 'owner/repo';
+    process.env.GITHUB_TOKEN = 'pat-env-token';
+    // No GITHUB_APP_ID → getInstallationToken() returns null without network call
+    const creds = await getCredentials();
+    expect(creds).toEqual({ repo: 'owner/repo', token: 'pat-env-token', mode: 'pat' });
+  });
+
+  it('getCredentials() NEVER returns per-user map entry in hosted mode even if map were populated', async () => {
+    process.env.GITHUB_REPO = 'owner/repo';
+    process.env.GITHUB_TOKEN = 'shared-env-token';
+    // Attempt to set per-user creds — will throw; creds NOT stored
+    try { asUser('alice', () => setRuntimeCredentials('alice/repo', 'tok-alice')); } catch { /* expected */ }
+    // getCredentials() should return shared env token, not alice's rejected creds
+    const creds = await asUser('alice', () => getCredentials());
+    expect(creds?.token).toBe('shared-env-token');
+    expect(creds?.repo).toBe('owner/repo');
+  });
+
+  it('getCredentials() emits FR system.error when all credential rungs are exhausted', async () => {
+    process.env.GITHUB_REPO = 'owner/repo';
+    // No GITHUB_APP_ID, no GITHUB_TOKEN → both rungs fail
+    const creds = await getCredentials();
+    expect(creds).toBeNull();
+    expect(frRecord).toHaveBeenCalledOnce();
+    const call = frRecord.mock.calls[0][0] as { type: string; level: string; message: string };
+    expect(call.type).toBe('system.error');
+    expect(call.level).toBe('error');
+    expect(call.message).toMatch(/getCredentials\(\) resolved to null in hosted mode/);
+  });
+
+  it('getCredentials() emits FR system.error when GITHUB_REPO is unset', async () => {
+    process.env.GITHUB_TOKEN = 'pat-env-token';
+    // GITHUB_REPO not set → repo is invalid
+    const creds = await getCredentials();
+    expect(creds).toBeNull();
+    expect(frRecord).toHaveBeenCalledOnce();
+    const call = frRecord.mock.calls[0][0] as { message: string };
+    expect(call.message).toMatch(/GITHUB_REPO/);
+  });
+
+  it('ALS isolation: set fails in hosted, getCredentials under any principal returns shared token', async () => {
+    process.env.GITHUB_REPO = 'owner/repo';
+    process.env.GITHUB_TOKEN = 'shared-token';
+    // Both alice and bob try to set; both fail; both get the shared env token
+    for (const user of ['alice', 'bob']) {
+      try { asUser(user, () => setRuntimeCredentials(`${user}/repo`, `tok-${user}`)); } catch { /* expected */ }
+    }
+    const aliceCreds = await asUser('alice', () => getCredentials());
+    const bobCreds = await asUser('bob', () => getCredentials());
+    expect(aliceCreds?.token).toBe('shared-token');
+    expect(bobCreds?.token).toBe('shared-token');
+    expect(aliceCreds?.repo).toBe('owner/repo');
+    expect(bobCreds?.repo).toBe('owner/repo');
+  });
+});

--- a/taxonomy-editor/src/server/routes/sync.ts
+++ b/taxonomy-editor/src/server/routes/sync.ts
@@ -90,6 +90,14 @@ export function registerSyncRoutes(r: Router, ctx: ServerCtx): void {
     if (STORAGE_MODE !== 'filesystem' && isAnonymousUser()) {
       error(res, 'Authentication required to set sync credentials', 401); return;
     }
+    // t/2895: runtime per-user credential override is deprecated in hosted mode.
+    // Clear is a no-op (success); set is rejected 409.
+    if (STORAGE_MODE !== 'filesystem') {
+      const data = body as { clear?: boolean };
+      if (data.clear) { json(res, { ok: true, configured: false }); return; }
+      error(res, 'Runtime per-user credential override is not supported in hosted mode. Repository access uses the GitHub App installation token configured at deployment time.', 409);
+      return;
+    }
     try {
       const data = body as { repo?: string; token?: string; clear?: boolean };
       if (data.clear) {

--- a/taxonomy-editor/src/server/security/githubAppAuth.ts
+++ b/taxonomy-editor/src/server/security/githubAppAuth.ts
@@ -27,6 +27,8 @@ import { createRequire } from 'module';
 import { log } from '../logger.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { getCurrentUserId } from './userContext.js';
+import { STORAGE_MODE } from '../config.js';
+import { ActionableError } from '../../../../lib/debate/errors.js';
 
 const require = createRequire(import.meta.url);
 
@@ -193,11 +195,8 @@ async function getInstallationToken(): Promise<string | null> {
 // isolates each authenticated user's PAT.
 
 interface RuntimeCreds { repo: string | null; token: string | null }
-// @INMEMORY_JOB_STORE — per-user runtime GitHub creds (repo + PAT) live in a per-process Map,
-// NOT shared across replicas. Remove this marker when migrated to a shared store (t/2894). The
-// CI gate Test-InMemoryJobStoreScaleGuard.ps1 reads this marker and blocks maxReplicas > 1 while
-// it is present: at >1 replica a user's creds set on replica A are absent on replica B, so a
-// write routed to B silently loses auth (t/2884-class race, on the auth surface).
+// t/2895: per-user runtime creds deprecated in hosted mode (single-shared-repo; App-install token
+// is canonical). Scale-guard marker removed; map retained for filesystem/local-dev mode only.
 const runtimeCredsByUser = new Map<string, RuntimeCreds>();
 
 /**
@@ -206,6 +205,18 @@ const runtimeCredsByUser = new Map<string, RuntimeCreds>();
  * restarting the server.
  */
 export function setRuntimeCredentials(repo: string, token: string): void {
+  // t/2895: not supported in hosted mode — App-install token is canonical for single-shared-repo.
+  if (STORAGE_MODE !== 'filesystem') {
+    throw Object.assign(new ActionableError({
+      goal: 'Configure per-user GitHub credentials',
+      problem: 'Runtime per-user credential override is not supported in hosted mode. All hosted users share the repository configured at deployment time via the GitHub App installation token.',
+      location: 'security/githubAppAuth.ts → setRuntimeCredentials',
+      nextSteps: [
+        'In hosted mode, repository access is managed via the GitHub App installation token — no per-user override is needed.',
+        'Contact the deployment administrator to change the shared repository (GITHUB_REPO env var).',
+      ],
+    }), { statusCode: 409 });
+  }
   runtimeCredsByUser.set(getCurrentUserId(), {
     repo: repo && repo.includes('/') ? repo : null,
     token: token && token.trim() ? token.trim() : null,
@@ -213,6 +224,8 @@ export function setRuntimeCredentials(repo: string, token: string): void {
 }
 
 export function clearRuntimeCredentials(): void {
+  // t/2895: no-op in hosted mode — map is never populated there.
+  if (STORAGE_MODE !== 'filesystem') return;
   runtimeCredsByUser.delete(getCurrentUserId());
 }
 
@@ -220,6 +233,11 @@ export function clearRuntimeCredentials(): void {
 
 /** Repo in "owner/repo" form, or null when unset. */
 export function getRepoSlug(): string | null {
+  // t/2895: hosted mode is single-shared-repo — always use the deployment env var, never the per-user map.
+  if (STORAGE_MODE !== 'filesystem') {
+    const repo = process.env.GITHUB_REPO;
+    return repo && repo.includes('/') ? repo : null;
+  }
   const runtimeRepo = runtimeCredsByUser.get(getCurrentUserId())?.repo;
   if (runtimeRepo) return runtimeRepo;
   const repo = process.env.GITHUB_REPO;
@@ -239,8 +257,39 @@ export function getTokenExpiryMs(): number {
 /**
  * Returns a usable credential bundle, or null when no credentials are
  * configured. Callers should 503 (or render a disabled UI) on null.
+ *
+ * t/2895: in hosted (non-filesystem) mode the per-user runtime map is never
+ * consulted — App-install token → GITHUB_TOKEN env only. A FR error is emitted
+ * when all rungs are exhausted so auth failures are diagnosable.
  */
 export async function getCredentials(): Promise<SyncCredentials | null> {
+  if (STORAGE_MODE !== 'filesystem') {
+    // Hosted mode: single-shared-repo. Never consults per-user map (defense-in-depth, t/2895).
+    const repo = process.env.GITHUB_REPO ?? null;
+    const repoValid = repo != null && repo.includes('/');
+
+    const installToken = await getInstallationToken();
+    if (installToken && repoValid) return { repo: repo!, token: installToken, mode: 'app' };
+
+    const envPat = (process.env.GITHUB_TOKEN ?? '').trim() || null;
+    if (envPat && repoValid) return { repo: repo!, token: envPat, mode: 'pat' };
+
+    // All rungs exhausted — emit an observable signal so failures are diagnosable (t/2895 Condition 1).
+    const tried: string[] = [];
+    if (!installToken) tried.push('GitHub App installation token (GITHUB_APP_ID/INSTALLATION_ID/private key not configured or token mint failed)');
+    if (!envPat) tried.push('GITHUB_TOKEN env var (not set)');
+    if (!repoValid) tried.push(`GITHUB_REPO env var (${repo == null ? 'not set' : `"${repo}" is not in owner/repo form`})`);
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'github-auth',
+      level: 'error',
+      message: `getCredentials() resolved to null in hosted mode — credential rungs exhausted: ${tried.join('; ')}`,
+      error: { name: 'MissingCredentials', message: tried.join('; ') },
+    });
+    return null;
+  }
+
+  // Filesystem/single-user mode: existing priority order unchanged (t/847).
   const repo = getRepoSlug();
   if (!repo) return null;
 


### PR DESCRIPTION
## Summary

- **`githubAppAuth.ts`**: `setRuntimeCredentials()` throws `ActionableError {statusCode:409}` in hosted mode; `clearRuntimeCredentials()` is a no-op; `getRepoSlug()` reads `GITHUB_REPO` env directly (skips per-user map); `getCredentials()` hosted branch: App-install token → `GITHUB_TOKEN` env → emits `FR system.error` when all rungs exhausted (TL Condition 1). `@INMEMORY_JOB_STORE` marker removed — scale-guard both-arms re-verified locally.
- **`routes/sync.ts`**: `POST /api/sync/credentials` returns 409 in hosted mode (`clear: true` short-circuits to `{ok:true}` for stateless UI teardown).
- **`hostedModeCredentials.test.ts`** (new): 8 tests — 409 on set, no-op clear, env slug, FR emission on all-rungs-exhausted, ALS isolation.

## Review notes for TL

Auth/security surface — NOT self-cert per routing rules. Conditions from t/2895#6:

1. **FR observable signal** ✓ — `getCredentials()` emits `type:'system.error'` + `component:'github-auth'` with tried-rung list when all fail. Tested in cases 7 + 8 of hostedModeCredentials.test.ts.
2. **STORAGE_MODE at call time from same source** ✓ — imported from `'../config.js'` (same import as sync.ts:20). Read at every call site, not captured at module load.

Non-blocking notes from t/2895#6 addressed:
- `clear: true` in hosted mode returns `{ok:true, configured:false}` (stateless — no map to clear, no need to error)
- Filesystem priority order (t/847) unchanged: runtime PAT → App token → env PAT

## Scale guard verification

```
Arm 1 (pass): maxReplicas=1, markers present in briefExportJobs.ts + oped.ts → gate passes
Arm 2 (fail): maxReplicas=2, same markers → gate fires: "FAILED: maxReplicas=2 but @INMEMORY_JOB_STORE markers present"
```

## Test plan

- [ ] CI vitest suite includes hostedModeCredentials.test.ts and runtimeCredentials.test.ts (t/847 isolation)
- [ ] TL reviews auth surface before merge
- [ ] Pre-self-merge verification before merge: base=main, head=CI OID, CI on that OID, no open holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)