### PR TITLE
fix(summary): disable directional polarity gate by default (t/2896)

### DIFF
--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -68,7 +68,12 @@ function Invoke-DocumentSummary {
         [Parameter(Mandatory)][string]$SummariesDir,
         [Parameter(Mandatory)][string]$Now,
         [switch]$IterativeExtraction,
-        [switch]$AutoFire
+        [switch]$AutoFire,
+
+        # t/2896 — re-enable switch for the directional polarity gate. DEFAULT OFF
+        # (the gate is disabled; see the point-of-use comment at the gate call).
+        # Preserved as a one-flag re-arm for the durable LLM-judge fix (t/2900).
+        [switch]$EnablePolarityGate
     )
 
     Set-StrictMode -Version Latest
@@ -870,7 +875,20 @@ function Finalize-Summary {
         }
     }
     if ($PolarityKps.Count -gt 0) {
-        $PolarityCounts = Invoke-PolarityGatePass -KeyPoints $PolarityKps.ToArray()
+        # ── DIRECTIONAL POLARITY GATE — DISABLED BY DEFAULT (t/2896) ──────────────
+        # WHY OFF: the gate's safety invariant ("false-demote structurally ~0") is
+        # FALSIFIED. deberta-v3-small false-flips genuine aligned agreements to
+        # strongly_opposed at NLI margins 3.4–7.5 — an order of magnitude above the
+        # ~1.4 real-contradiction ceiling, so no τ_contra separates them (provably not
+        # tunable). Root cause is a model reasoning gap: it can't infer agency→loss
+        # (AI-gains-agency ⊨ humans-lose-oversight), which is the DOMINANT
+        # safetyist/skeptic claim shape — so the gate corrupts precisely where it
+        # fires most (CL diagnosis t/2896#1; TL [Decision] e/117#3).
+        # RE-ENABLE CONDITION: a model that does agency→loss entailment, wired behind
+        # the LLM-judge directional fix (t/2900). The code path is PRESERVED, not
+        # deleted — re-arm is a single flag: -EnablePolarityGate.
+        $PolarityCounts = Invoke-PolarityGatePass -KeyPoints $PolarityKps.ToArray() `
+            -SkipDirectionalGate:(-not $EnablePolarityGate)
         if ($PolarityCounts.opposes -gt 0) {
             Write-Warn ("Polarity gate: {0} inversion(s) flagged (opposes) — counts o={0} a={1} u={2} x={3} over {4} gated" -f `
                 $PolarityCounts.opposes, $PolarityCounts.agrees, $PolarityCounts.unrelated, $PolarityCounts.unresolved, $PolarityCounts.gated)

--- a/tests/Invoke-PolarityGatePass.Tests.ps1
+++ b/tests/Invoke-PolarityGatePass.Tests.ps1
@@ -225,3 +225,72 @@ Describe 'Invoke-PolarityGatePass (t/2739)' -Tag 'summary' {
         }
     }
 }
+
+# ── t/2896: disable Gate Verification (both arms of the -EnablePolarityGate switch) ──
+# The directional polarity flip is disabled by default (falsified safety invariant —
+# e/117#3). These prove the SWITCH works both ways so re-enabling behind the durable
+# LLM-judge fix (t/2900) is a one-flag flip. Test-DirectionalAgreement is mocked (no model).
+Describe 'Polarity-gate disable switch (t/2896)' -Tag 'summary' {
+
+    It 'ARM ON: gate active flips a genuine contradiction to strongly_opposed' {
+        InModuleScope AITriad {
+            Mock Test-DirectionalAgreement {
+                @($Pair) | ForEach-Object {
+                    [PSCustomObject]@{ Id = $_.Id; Direction = 'opposes'; Confidence = 5.0 }
+                }
+            }
+            $kp = [PSCustomObject]@{
+                stance                   = 'aligned'
+                taxonomy_node_id         = 'saf-beliefs-017'
+                retrieval_low_confidence = $false
+                verbatim                 = 'AI is delegated authority and acts non-deterministically.'
+            }
+            $counts = Invoke-PolarityGatePass -KeyPoints @(@{ KeyPoint = $kp; POV = 'safetyist' })
+
+            $kp.stance               | Should -Be 'strongly_opposed'
+            $kp.stance_polarity_flag | Should -BeTrue
+            $counts.opposes          | Should -BeGreaterThan 0
+        }
+    }
+
+    It 'ARM OFF: -SkipDirectionalGate makes the same verdict a no-op (the disable)' {
+        InModuleScope AITriad {
+            Mock Test-DirectionalAgreement {
+                @($Pair) | ForEach-Object {
+                    [PSCustomObject]@{ Id = $_.Id; Direction = 'opposes'; Confidence = 5.0 }
+                }
+            }
+            $kp = [PSCustomObject]@{
+                stance                   = 'aligned'
+                taxonomy_node_id         = 'saf-beliefs-017'
+                retrieval_low_confidence = $false
+                verbatim                 = 'AI is delegated authority and acts non-deterministically.'
+            }
+            $counts = Invoke-PolarityGatePass -KeyPoints @(@{ KeyPoint = $kp; POV = 'safetyist' }) -SkipDirectionalGate
+
+            $kp.stance                                      | Should -Be 'aligned'
+            $kp.PSObject.Properties['stance_polarity_flag'] | Should -BeNullOrEmpty
+            $counts.opposes                                 | Should -Be 0
+            $counts.gated                                   | Should -Be 0
+            Should -Invoke Test-DirectionalAgreement -Times 0 -Exactly -Because 'a skipped gate must not even call the engine'
+        }
+    }
+}
+
+Describe 'Invoke-DocumentSummary polarity wiring (t/2896)' -Tag 'summary' {
+
+    It 'exposes -EnablePolarityGate as a switch that defaults OFF (gate disabled by default)' {
+        InModuleScope AITriad {
+            $p = (Get-Command Invoke-DocumentSummary).Parameters['EnablePolarityGate']
+            $p                 | Should -Not -BeNullOrEmpty
+            $p.SwitchParameter | Should -BeTrue
+        }
+    }
+
+    It 'call-site contract: -EnablePolarityGate negates into -SkipDirectionalGate' {
+        $off = [switch]$false
+        (-not $off) | Should -BeTrue  -Because 'default-off routes -SkipDirectionalGate:$true (gate skipped)'
+        $on  = [switch]$true
+        (-not $on)  | Should -BeFalse -Because '-EnablePolarityGate routes -SkipDirectionalGate:$false (gate active)'
+    }
+}


### PR DESCRIPTION
## Summary
Disables the directional polarity flip in `Invoke-PolarityGatePass` **by default** — TL [Decision] APPROVED (e/117#3), routed here for the **condition-2 both-arms Gate Verification** before merge.

**Why (falsified safety invariant):** the gate false-flips genuine aligned agreements → `strongly_opposed` at NLI margins 3.4–7.5 (an order of magnitude above the ~1.4 real-contradiction ceiling → not tunable), on the dominant agency→loss safetyist/skeptic claim shape — corrupting precisely where it fires most (CL diagnosis t/2896#1).

**How (conditions #1/#4):** new `-EnablePolarityGate` (default **OFF**) on `Invoke-DocumentSummary`; the gate call now passes `-SkipDirectionalGate:(-not $EnablePolarityGate)`. Default-off = the disable. **Code path preserved, not deleted** — one-flag re-arm for the durable LLM-judge fix (**t/2900**). The point-of-use comment carries the *why* + the re-enable condition (a model that does agency→loss entailment).

## Gate Verification — both arms (condition #2)
- **ARM ON** (`-EnablePolarityGate`/gate active): a genuine 'opposes' verdict still flips to `strongly_opposed` — proves the path is intact for re-enable.
- **ARM OFF** (default / `-SkipDirectionalGate`): the SAME verdict is a **no-op** (no mutation) and the NLI engine is **never even called**.
- Plus: `-EnablePolarityGate` defaults OFF; the negation-into-`-SkipDirectionalGate` call-site contract.

`tests/Invoke-PolarityGatePass.Tests.ps1`: **13/13** — the 9 existing t/2739 tests preserved + 4 new t/2896 arms.

## Out of scope (separate lanes, per TL e/117#7)
- **Data revert** (9 `stance_polarity_flag` demotes → `aligned`, polarity fields cleared, node mapping/point/verbatim untouched) — CL's condition-#3 validation, a separate op done AFTER this lands.
- **Re-enable** (LLM-judge fix + persist `stance_pre_gate`) — tracked on **t/2900**, gated on future both-arms GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)