### PR TITLE
feat(oped): persist source provenance in handler + steer URL-in-topic-box (t/2899)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/opedHandlers.migration.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedHandlers.migration.test.ts
@@ -9,11 +9,16 @@
 //   (d) STOPGAP helpers (normalizePov / normalizeGrounding) are gone
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
 import type { IpcMainInvokeEvent } from 'electron';
 import type { OpEdMember } from '../../../../lib/oped/types.js';
 import type { OpEdProgressEvent as LibEvent } from '../../../../lib/oped/generate.js';
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
+
+// Stage-A source prep spawns Get-OpEdSource — mock it so url-mode tests can drive it.
+const mockSpawn = vi.hoisted(() => vi.fn());
+vi.mock('child_process', () => ({ default: { spawn: mockSpawn }, spawn: mockSpawn }));
 
 vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
@@ -98,6 +103,7 @@ beforeEach(() => {
   vi.mocked(finalizeOpEdSet).mockClear();
   vi.mocked(saveOpEdSetTemp).mockClear();
   mockGenerateOpEdSet.mockClear();
+  mockSpawn.mockClear();
   registerOpEdHandlers();
 });
 
@@ -233,5 +239,126 @@ describe('t/2611 migration: create-oped-set uses lib/oped in-process', () => {
     const mod = await import('../ipc/opedHandlers.js');
     expect((mod as Record<string, unknown>).normalizePov).toBeUndefined();
     expect((mod as Record<string, unknown>).normalizeGrounding).toBeUndefined();
+  });
+});
+
+// ── Source provenance persistence (t/2899) ───────────────────────────────────
+// A URL pasted into the topic box silently produced a claim-less set (t/2897). These
+// prove a persisted set is distinguishable topic-vs-url from the JSON alone, and that
+// the count is present in url mode and ABSENT (not 0) in topic mode.
+
+interface PrepChild extends EventEmitter {
+  stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> };
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function makePrepChild(): PrepChild {
+  const child = new EventEmitter() as PrepChild;
+  child.stdin  = { write: vi.fn(), end: vi.fn() };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill   = vi.fn();
+  return child;
+}
+
+const FAKE_SOURCE_PREP = {
+  Url: 'https://example.com/article',
+  SourceMarkdown: '# Article\n\nSome content.',
+  SourceFormat: 'markdown',
+  ReadableWords: 500,
+  ReadableRatio: 0.85,
+  ContentHash: 'abc123',
+};
+
+function emitPrepResult(child: PrepChild, data: Record<string, unknown>): void {
+  child.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'result', data }) + '\n'));
+  child.emit('close', 0);
+}
+
+const SET_ID_ANY = 'x';
+function completeSet(opeds: OpEdMember[]) {
+  return { schema_version: 1 as const, set_id: SET_ID_ANY, topic: 'topic', params: {}, created_at: '2026-08-13T00:00:00.000Z', opeds };
+}
+
+describe('t/2899: source provenance persisted on the set', () => {
+  it('topic mode: temp-save records source_mode "topic" and omits url + count', async () => {
+    mockGenerateOpEdSet.mockImplementation(() => makeGenerator([
+      { type: 'voice_start', pov: 'accelerationist' },
+      { type: 'voice_complete', pov: 'accelerationist', member: FAKE_MEMBER },
+      { type: 'complete', set: completeSet([FAKE_MEMBER]) },
+    ] as LibEvent[]));
+
+    const handler = captureHandler('create-oped-set');
+    await handler(fakeEvent(makeSender()), { topic: 'topic', params: {}, voices: ['accelerationist'] });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    const tempSet = vi.mocked(saveOpEdSetTemp).mock.calls[0][0];
+    expect(tempSet.source_mode).toBe('topic');
+    expect(tempSet.source_url).toBeUndefined();
+    expect(tempSet.source_key_claims_count).toBeUndefined();
+  });
+
+  it('topic mode: partial-finalize on abort records source_mode "topic", no url/count', async () => {
+    mockGenerateOpEdSet.mockImplementation(async function* () {
+      yield { type: 'voice_complete', pov: 'accelerationist', member: FAKE_MEMBER } as LibEvent;
+      throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+    });
+
+    const handler = captureHandler('create-oped-set');
+    try { await handler(fakeEvent(makeSender()), { topic: 'topic', params: {}, voices: ['accelerationist'] }); } catch { /* abort */ }
+
+    const partial = vi.mocked(finalizeOpEdSet).mock.calls[0][0];
+    expect(partial.source_mode).toBe('topic');
+    expect(partial.source_url).toBeUndefined();
+    expect(partial.source_key_claims_count).toBeUndefined();
+  });
+
+  it('url mode: temp-save records source_mode "url" + source_url + key-claims count, and sourceUrl is wired to the lib', async () => {
+    const prep = makePrepChild();
+    mockSpawn.mockReturnValue(prep);
+    mockGenerateOpEdSet.mockImplementation(() => makeGenerator([
+      { type: 'source_brief_done', keyClaimsCount: 3 },
+      { type: 'voice_start', pov: 'accelerationist' },
+      { type: 'voice_complete', pov: 'accelerationist', member: FAKE_MEMBER },
+      { type: 'complete', set: completeSet([FAKE_MEMBER]) },
+    ] as LibEvent[]));
+
+    const handler = captureHandler('create-oped-set');
+    const p = handler(fakeEvent(makeSender()), { topic: 'topic', url: 'https://example.com/article', params: {}, voices: ['accelerationist'] });
+    await Promise.resolve();
+    emitPrepResult(prep, FAKE_SOURCE_PREP);
+    await p;
+
+    const tempSet = vi.mocked(saveOpEdSetTemp).mock.calls[0][0];
+    expect(tempSet.source_mode).toBe('url');
+    expect(tempSet.source_url).toBe('https://example.com/article');
+    expect(tempSet.source_key_claims_count).toBe(3);
+
+    // The lib gets sourceUrl so its authoritative `complete` set also carries source_url.
+    const [request] = mockGenerateOpEdSet.mock.calls[0] as [{ sourceUrl?: string }];
+    expect(request.sourceUrl).toBe('https://example.com/article');
+  });
+
+  it('url mode: partial-finalize on abort carries full provenance (mode + url + count)', async () => {
+    const prep = makePrepChild();
+    mockSpawn.mockReturnValue(prep);
+    mockGenerateOpEdSet.mockImplementation(async function* () {
+      yield { type: 'source_brief_done', keyClaimsCount: 5 } as LibEvent;
+      yield { type: 'voice_complete', pov: 'accelerationist', member: FAKE_MEMBER } as LibEvent;
+      throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+    });
+
+    const handler = captureHandler('create-oped-set');
+    const p = handler(fakeEvent(makeSender()), { topic: 'topic', url: 'https://example.com/article', params: {}, voices: ['accelerationist'] });
+    await Promise.resolve();
+    emitPrepResult(prep, FAKE_SOURCE_PREP);
+    try { await p; } catch { /* abort */ }
+
+    const partial = vi.mocked(finalizeOpEdSet).mock.calls[0][0];
+    expect(partial.source_mode).toBe('url');
+    expect(partial.source_url).toBe('https://example.com/article');
+    expect(partial.source_key_claims_count).toBe(5);
   });
 });

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -218,6 +218,24 @@ export function registerOpEdHandlers(): void {
       }
     }
 
+    // Source provenance (t/2897/t/2899): url mode ⟺ a source brief was fetched — mirror
+    // the lib's own `request.sourceMaterial ? 'url':'topic'` test so the handler-built temp/
+    // partial literals below never disagree with the lib's authoritative `complete` set.
+    const isUrlMode = Boolean(sourceBrief);
+    // key_claims count from the comprehension pass, captured in-stream (url mode only).
+    let sourceKeyClaimsCount: number | undefined;
+    // Provenance for the handler-built literals (temp-save + abort partial-finalize). The
+    // lib writes these itself on the `complete` set; these two paths bypass the lib, so they
+    // carry provenance explicitly. Read at call time — the count is captured mid-stream.
+    // Topic mode omits url + count entirely (absent, not 0) per the t/2898 contract.
+    const provenanceFields = (): {
+      source_mode: 'topic' | 'url'; source_url?: string; source_key_claims_count?: number;
+    } => ({
+      source_mode: isUrlMode ? 'url' : 'topic',
+      ...(isUrlMode && url ? { source_url: url } : {}),
+      ...(isUrlMode ? { source_key_claims_count: sourceKeyClaimsCount ?? 0 } : {}),
+    });
+
     // Fire queued for each voice — renderer stores set_id for cancellation
     for (const voice of voices) {
       send({ set_id: setId, voice, stage: 'queued' });
@@ -229,6 +247,7 @@ export function registerOpEdHandlers(): void {
       params,
       povs: voices,
       sourceMaterial: sourceBrief,
+      sourceUrl: url,   // persisted as OpEdSet.source_url by the lib on the `complete` set (url mode)
       signal: controller.signal,
     };
 
@@ -244,6 +263,10 @@ export function registerOpEdHandlers(): void {
     try {
       for await (const evt of generateOpEdSet(request, deps)) {
         switch (evt.type) {
+          case 'source_brief_done':
+            // url mode only — capture for the handler-built temp/partial literals below.
+            sourceKeyClaimsCount = evt.keyClaimsCount;
+            break;
           case 'grounding_done':
             send({ set_id: setId, stage: 'grounding' });
             break;
@@ -259,7 +282,7 @@ export function registerOpEdHandlers(): void {
           case 'voice_complete': {
             completedMembers.push(evt.member);
             try {
-              saveOpEdSetTemp({ schema_version: 1, set_id: setId, topic, params, created_at: createdAt, opeds: [...completedMembers] });
+              saveOpEdSetTemp({ schema_version: 1, set_id: setId, topic, params, created_at: createdAt, opeds: [...completedMembers], ...provenanceFields() });
             } catch { /* telemetry — silent by design; temp save is best-effort */ }
             send({ set_id: setId, voice: evt.pov, stage: 'complete' });
             break;
@@ -287,7 +310,7 @@ export function registerOpEdHandlers(): void {
       // Abort before complete: persist partial set so completed voices aren't lost.
       if (!finalized && completedMembers.length > 0) {
         try {
-          finalizeOpEdSet({ schema_version: 1, set_id: setId, topic, params, created_at: createdAt, opeds: completedMembers });
+          finalizeOpEdSet({ schema_version: 1, set_id: setId, topic, params, created_at: createdAt, opeds: completedMembers, ...provenanceFields() });
         } catch { /* telemetry — silent by design */ }
       }
     }

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.css
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.css
@@ -119,6 +119,36 @@
   margin: 0.3rem 0 0;
 }
 
+/* URL-in-topic-box steer (t/2899): a pasted URL silently produces a claim-less set,
+   so nudge desktop users to the web-page path that extracts and links claims. */
+.oped-url-steer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.5rem;
+  margin: 0.4rem 0 0;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--surface-muted, var(--surface-secondary, transparent));
+}
+.oped-url-steer-text {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+.oped-url-steer-action {
+  background: none;
+  border: none;
+  color: var(--link-color, var(--text-secondary));
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  padding: 0;
+}
+.oped-url-steer-action:hover { text-decoration: underline; }
+.oped-url-steer-action:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
+
 /* ── Voice chips (multi-select) ────────────────────────────────────────────── */
 
 .oped-voice-chips {

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.css
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.css
@@ -130,7 +130,7 @@
   padding: 0.4rem 0.55rem;
   border: 1px solid var(--border-color);
   border-radius: 4px;
-  background: var(--surface-muted, var(--surface-secondary, transparent));
+  background: var(--bg-secondary);
 }
 .oped-url-steer-text {
   font-size: 0.78rem;

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.test.tsx
@@ -130,6 +130,48 @@ describe('NewOpEdDialog — topic / URL toggle', () => {
   });
 });
 
+describe('NewOpEdDialog — URL-in-topic steer (t/2899)', () => {
+  const STEER = /This looks like a web page/;
+
+  it('shows the steer hint when the topic box holds a URL (desktop)', () => {
+    open();
+    expect(screen.queryByText(STEER)).toBeNull();
+    fireEvent.change(screen.getByLabelText(/Topic/), { target: { value: 'https://example.com/post' } });
+    expect(screen.getByText(STEER)).toBeTruthy();
+  });
+
+  it('is absent for a plain-text topic', () => {
+    open();
+    fireEvent.change(screen.getByLabelText(/Topic/), { target: { value: 'Mandatory pre-deployment audits' } });
+    expect(screen.queryByText(STEER)).toBeNull();
+  });
+
+  it('migrates the URL into the web-page field and switches modes on click', () => {
+    open();
+    fireEvent.change(screen.getByLabelText(/Topic/), { target: { value: 'https://example.com/post' } });
+    fireEvent.click(screen.getByRole('button', { name: /Use as web page/ }));
+    // now in URL mode: the URL input carries the value, the topic box is gone
+    const urlInput = screen.getByLabelText(/Web page URL/) as HTMLInputElement;
+    expect(urlInput.value).toBe('https://example.com/post');
+    expect(screen.queryByLabelText(/^Topic/)).toBeNull();
+    // the steer hint no longer applies in URL mode
+    expect(screen.queryByText(STEER)).toBeNull();
+  });
+
+  it('is absent in URL mode even if the topic previously looked like a URL', () => {
+    open();
+    fireEvent.click(screen.getByRole('button', { name: /From a web page instead/ }));
+    fireEvent.change(screen.getByLabelText(/Web page URL/), { target: { value: 'https://example.com/post' } });
+    expect(screen.queryByText(STEER)).toBeNull();
+  });
+
+  it('is absent on web (allowUrlSource=false), where there is no URL path to steer to', () => {
+    open({ allowUrlSource: false });
+    fireEvent.change(screen.getByLabelText(/Topic/), { target: { value: 'https://example.com/post' } });
+    expect(screen.queryByText(STEER)).toBeNull();
+  });
+});
+
 describe('NewOpEdDialog — settings drawer', () => {
   it('opens the More options drawer and applies changes', () => {
     open();

--- a/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/NewOpEdDialog.tsx
@@ -480,6 +480,10 @@ interface CreateFormProps {
   setTopic: (v: string) => void;
   url: string;
   setUrl: (v: string) => void;
+  /** Topic-box content looks like a web page URL (matches ^https?://) — only meaningful in topic mode. */
+  topicLooksLikeUrl: boolean;
+  /** Move the URL-shaped topic value into the URL field and switch to web-page mode. */
+  onMigrateTopicToUrl: () => void;
   isAnonymous: boolean;
   voices: Set<PovKey>;
   toggleVoice: (pov: PovKey) => void;
@@ -523,6 +527,16 @@ function OpEdCreateForm(p: CreateFormProps) {
               <button type="button" className="oped-source-toggle" onClick={() => p.setFromWebPage(true)}>
                 ⌥ From a web page instead →
               </button>
+            )}
+            {p.allowUrlSource && p.topicLooksLikeUrl && (
+              <div className="oped-url-steer" role="status">
+                <span className="oped-url-steer-text">
+                  This looks like a web page. Switch to “From web page” to extract and link its claims.
+                </span>
+                <button type="button" className="oped-url-steer-action" onClick={p.onMigrateTopicToUrl}>
+                  Use as web page →
+                </button>
+              </div>
             )}
           </div>
         ) : (
@@ -731,6 +745,15 @@ export function NewOpEdDialog({ open, onClose, onCreated, allowUrlSource = true 
   const hasSource = fromWebPage ? url.trim().length > 0 : topic.trim().length > 0;
   const canStart = hasSource && orderedVoices.length >= 1 && modelHasKey;
 
+  // A URL pasted into the topic box → FromTopic → no source brief → no claims, silently (t/2899).
+  // Detect it so we can steer the user to the web-page path (desktop only; web has no URL path).
+  const topicLooksLikeUrl = !fromWebPage && /^https?:\/\//i.test(topic.trim());
+  const handleMigrateTopicToUrl = () => {
+    setFromWebPage(true);
+    setUrl(topic.trim());
+    setTopic('');
+  };
+
   const settingsDiffCount = SETTINGS_SECTIONS.filter(s =>
     sectionHasDiff(s.id, { outlet, wordCount, thesis, authorBio, ground, maxGroundingNodes, maxSituations, model, temperature }, globalModel),
   ).length;
@@ -846,6 +869,8 @@ export function NewOpEdDialog({ open, onClose, onCreated, allowUrlSource = true 
             setTopic={setTopic}
             url={url}
             setUrl={setUrl}
+            topicLooksLikeUrl={topicLooksLikeUrl}
+            onMigrateTopicToUrl={handleMigrateTopicToUrl}
             isAnonymous={isAnonymous}
             voices={voices}
             toggleVoice={toggleVoice}


### PR DESCRIPTION
Closes t/2899 (child of t/2897, the op-ed claim-less-set incident). Builds on t/2898 (#1362, landed) — consumes the `OpEdSet.source_mode/source_url/source_key_claims_count` fields.

## Part 1 — `opedHandlers.ts`: persist provenance
The create handler knew topic-vs-url mode + the source URL but dropped them, so a claim-less URL-in-topic set was indistinguishable from a real topic set in the JSON.
- Pass `request.sourceUrl = url` so the lib writes provenance authoritatively on the `complete` set.
- The two handler-built literals (temp-save + abort partial-finalize) bypass the lib, so carry provenance explicitly via a `provenanceFields()` closure keyed off `sourceBrief` presence (mirrors the lib's own url-mode test — temp and final files never disagree). Count captured in-stream from `source_brief_done`.
- Topic mode omits `source_url` + `source_key_claims_count` entirely (absent, not 0) per the t/2898 contract.

## Part 2 — `NewOpEdDialog.tsx`: URL-in-topic steer
A URL pasted into the topic box was the incident's root cause. Detect `^https?://` in topic mode and, on desktop, show an inline hint + one-click **"Use as web page →"** that moves the value into the URL field and switches mode. Web/anonymous: no steer, submission stays legal (steer, don't forbid). Tokens-only CSS (styles.css frozen).

## Tests
- `NewOpEdDialog.test.tsx` +5: hint appears for URL-like topic; click migrates value + switches mode; absent for plain topics, in URL mode, and on web.
- `opedHandlers.migration.test.ts` +4: topic mode → `source_mode:'topic'` no url/count; url mode → full provenance on both temp-save and partial-finalize; `sourceUrl` wired to the lib.
- Full `npm run verify` green **except** the known local-only undici Node-version invariant (`githubApi`/`t2020Security`; local node 24, CI node 22 passes — t/2053/t/2113/t/2281). tsc clean.

## Status: DRAFT — review hold
Routing to **Quality (TL)** async review before merge (incident-driven change, per t/2899#1). Un-draft only after approval + CI green on the pushed head.