### PR TITLE
fix(scripts): dirty-tree-sweep guard for whole-file data-repo writes (t/2902)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -151,3 +151,8 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Register-AIBackend` | Configure AI backend credentials |
 | `Test-AIApiKey` | Verify an AI provider API key authenticates (auth-only probe of gemini/claude/groq/openai/azure; no token cost). Use `-All` to sweep every backend with a resolvable key. |
 | `Test-AIModelsConfig` | Validate `ai-models.json` — BOM, JSON parse, orphaned model refs in defaults/debateTiers/fallbackChains, incomplete `models[]` entries, and friendly-id-in-`apiModelId` (t/1705). Returns `{Pass; Issues}`; run in a Pester test / CI. |
+
+### Data-Write Safety
+| Cmdlet | Use when |
+|--------|----------|
+| `Assert-CleanDataTree` | Before a whole-file rewrite of a data-repo JSON, assert the target has no uncommitted changes — so a `ConvertFrom-Json \| ConvertTo-Json` (or Python `json.load`→`json.dump`) round-trip can't sweep concurrent working-tree state into the commit (t/2902; `-Force` downgrades the block to a warning). Also exposed as the opt-in `Write-Utf8NoBom -RequireCleanTree` switch. |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -72,6 +72,7 @@
         'Show-FallacyInfo'
         'Test-TaxonomyIntegrity'
         'Test-TaxonomyDir'
+        'Assert-CleanDataTree'
         'Invoke-HierarchyProposal'
         'Set-TaxonomyHierarchy'
         'Invoke-SchemaMigration'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -813,6 +813,8 @@ Export-ModuleMember -Function @(
     'Test-TaxonomyIntegrity'
     # t/2876 — pre-validate taxonomy dir against embed_taxonomy.py loader contract
     'Test-TaxonomyDir'
+    # t/2902 — dirty-tree-sweep guard for whole-file data-repo writes
+    'Assert-CleanDataTree'
     'Invoke-HierarchyProposal'
     'Set-TaxonomyHierarchy'
     'Invoke-SchemaMigration'

--- a/scripts/AITriad/Private/Write-Utf8NoBom.ps1
+++ b/scripts/AITriad/Private/Write-Utf8NoBom.ps1
@@ -12,7 +12,13 @@ function Write-Utf8NoBom {
         $Value,
 
         [switch]$NoNewline,
-        [switch]$Force
+        [switch]$Force,
+
+        # t/2902 — opt-in dirty-tree-sweep guard. When set, assert the target file
+        # has no uncommitted changes before overwriting it, so a whole-file rewrite
+        # cannot merge concurrent working-tree state into a later commit. Default
+        # OFF keeps every other writer's clean path zero-cost and zero-noise.
+        [switch]$RequireCleanTree
     )
     begin {
         $parts = New-Object System.Collections.Generic.List[string]
@@ -39,6 +45,12 @@ function Write-Utf8NoBom {
         if ($fileName -match '^(accelerationist|safetyist|skeptic|situations)\.json$' -and $text.Length -gt 10MB) {
             Write-Warning "Write-Utf8NoBom: BLOCKED write to $fileName — content is $([math]::Round($text.Length / 1MB, 1)) MB (likely corrupted). This prevents a runaway encoding bug."
             return
+        }
+        # t/2902 — opt-in: refuse to overwrite a target that already carries
+        # uncommitted changes (throws New-ActionableError), so a whole-file rewrite
+        # cannot sweep concurrent working-tree state into a later commit.
+        if ($RequireCleanTree) {
+            Assert-CleanDataTree -Path $Path
         }
         Set-Content -Path $Path -Value $text -Encoding utf8NoBOM -NoNewline
     }

--- a/scripts/AITriad/Public/Assert-CleanDataTree.ps1
+++ b/scripts/AITriad/Public/Assert-CleanDataTree.ps1
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Assert-CleanDataTree {
+    <#
+    .SYNOPSIS
+        Guard against dirty-tree sweeps: assert a file has no uncommitted changes
+        before a whole-file rewrite (t/2902).
+
+    .DESCRIPTION
+        A whole-file JSON round-trip (ConvertFrom-Json | ConvertTo-Json, or Python
+        json.load -> json.dump) re-reads the file's CURRENT on-disk content — which
+        includes any concurrent uncommitted edits — and rewrites the whole file.
+        On a shared / perpetually-dirty data tree (ai-triad-data), a later
+        `git add <file>` then commits that concurrent state under a misleading
+        message. This is the dirty-tree sweep failure class (t/2896 collateral:
+        commit 128ce8f4 swept an unrelated `resolved_node_id: sit-477` into a
+        "stance-only" commit).
+
+        The collision is INTRA-FILE, so a path-level `git add <file>` gate cannot
+        catch it — staging the file still captures the pre-existing WIP. The
+        durable guard is to assert the target file is clean vs HEAD *before* the
+        rewrite, so a whole-file write can never merge concurrent state.
+
+        Behavior:
+        - Target is tracked-modified (dirty)  -> throw New-ActionableError (or, with
+          -Force, Write-Warning and proceed).
+        - Target is clean                     -> return silently (no output, no
+          warning — safe for the zero-noise clean path).
+        - Target does not exist yet           -> clean (a brand-new file carries no
+          concurrent state to sweep).
+        - Target is not under a git work tree -> clean (guard only defends tracked
+          state; -Verbose records the skip). Untracked files are ignored
+          (`--untracked-files=no`) — a not-yet-tracked file cannot be swept.
+
+    .PARAMETER Path
+        One or more file paths about to be whole-file rewritten. Accepts pipeline
+        input and the FullName property (so `Get-Item x.json | Assert-CleanDataTree`
+        works).
+
+    .PARAMETER Force
+        Downgrade a dirty-target block to a warning and proceed. Use only when you
+        own the pending changes and intend to include them.
+
+    .EXAMPLE
+        Assert-CleanDataTree -Path $summaryFile
+        $data | ConvertTo-Json -Depth 20 | Write-Utf8NoBom -Path $summaryFile
+
+    .EXAMPLE
+        # Wired through the module's write chokepoint:
+        $json | Write-Utf8NoBom -Path $file -RequireCleanTree
+    #>
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('FullName', 'PSPath')]
+        [string[]]$Path,
+
+        [switch]$Force
+    )
+    begin {
+        $dirty = [System.Collections.Generic.List[string]]::new()
+    }
+    process {
+        foreach ($p in $Path) {
+            # A not-yet-existent target carries no concurrent state to sweep.
+            $resolved = Resolve-Path -LiteralPath $p -ErrorAction SilentlyContinue
+            if (-not $resolved) {
+                Write-Verbose "Assert-CleanDataTree: '$p' does not exist yet — nothing to sweep."
+                continue
+            }
+            $full = $resolved.Path
+            $dir = Split-Path -Parent $full
+            $leaf = Split-Path -Leaf $full
+
+            # Run with cwd = the file's directory and a bare-leaf pathspec so no
+            # absolute Windows path reaches git's pathspec parser (avoids MSYS
+            # path-conversion quirks — see "Git Forensics" in root AGENTS.md).
+            # `--untracked-files=no`: an untracked (brand-new) file cannot be swept
+            # by a rewrite of an existing file; we only defend tracked-modified state.
+            $status = & git -C $dir status --porcelain --untracked-files=no -- $leaf 2>$null
+            $exit = $LASTEXITCODE
+            if ($exit -ne 0) {
+                # Not a git work tree (or git unavailable). The guard defends tracked
+                # state only; a target outside git has nothing to sweep — do not block.
+                Write-Verbose "Assert-CleanDataTree: '$full' is not under a git work tree (git exit $exit) — skipping clean-tree check."
+                continue
+            }
+            $lines = @($status | Where-Object { $_ -and $_.Trim() })
+            if ($lines.Count -gt 0) {
+                $dirty.Add($full)
+            }
+        }
+    }
+    end {
+        if ($dirty.Count -eq 0) { return }
+
+        $fileList = ($dirty | ForEach-Object { "     - $_" }) -join "`n"
+        $problem = "Target file(s) already carry uncommitted changes; a whole-file rewrite would sweep that concurrent state into your commit:`n$fileList"
+
+        if ($Force) {
+            Write-Warning "Assert-CleanDataTree: $problem`n(Proceeding anyway — -Force specified.)"
+            return
+        }
+
+        New-ActionableError `
+            -Goal 'Write a data-repo file without sweeping concurrent uncommitted state into the commit' `
+            -Problem $problem `
+            -Location 'Assert-CleanDataTree' `
+            -NextSteps @(
+                'Commit or stash the pre-existing changes to these file(s) first, then re-run.'
+                'Or change only the targeted fields surgically instead of re-serializing the whole file.'
+                'If you own those pending changes and intend to include them, re-run with -Force.'
+            ) `
+            -Throw
+    }
+}

--- a/tests/Assert-CleanDataTree.Tests.ps1
+++ b/tests/Assert-CleanDataTree.Tests.ps1
@@ -1,0 +1,124 @@
+# Tag: summary (t/2902)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Assert-CleanDataTree — dirty-tree-sweep guard (t/2902).
+.DESCRIPTION
+    Both-arms Gate Verification against a REAL temporary git repo (no native-git
+    mocking — the guard's whole job is to read real `git status`):
+
+      DIRTY arm  — target file has uncommitted changes  -> throws (sweep blocked).
+      CLEAN arm  — target file matches HEAD             -> returns silently, no
+                                                            warning (zero-noise).
+
+    Plus the edge contracts: not-yet-existent target (clean), non-git target
+    (clean, no block), -Force downgrades a dirty block to a warning, and the
+    opt-in `Write-Utf8NoBom -RequireCleanTree` wiring blocks a dirty overwrite.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    # Build a throwaway git repo with one committed, clean file. Signing/identity
+    # are set LOCAL to this fixture repo only (CI has no signing key) — this is a
+    # disposable fixture, not a project repo, so it does not touch the fleet's
+    # commit-signing discipline.
+    function New-FixtureRepo {
+        param([string]$Root)
+        New-Item -ItemType Directory -Path $Root -Force | Out-Null
+        & git -C $Root init --quiet
+        & git -C $Root config user.email 'fixture@example.com'
+        & git -C $Root config user.name 'Fixture'
+        & git -C $Root config commit.gpgsign false
+        $file = Join-Path $Root 'data.json'
+        '{ "stance": "aligned" }' | Set-Content -Path $file -Encoding utf8NoBOM
+        & git -C $Root add data.json
+        & git -C $Root commit --quiet -m 'seed'
+        return $file
+    }
+}
+
+Describe 'Assert-CleanDataTree (t/2902)' -Tag 'summary' {
+
+    Context 'CLEAN arm — committed file matches HEAD' {
+        It 'returns silently and emits no warning' {
+            $repo = Join-Path $TestDrive 'clean-repo'
+            $file = New-FixtureRepo -Root $repo
+
+            # 3>&1 merges the warning stream into output so we can assert on it
+            # directly; a void return means a clean pass emits nothing at all.
+            $emitted = Assert-CleanDataTree -Path $file 3>&1
+            @($emitted).Count | Should -Be 0
+        }
+    }
+
+    Context 'DIRTY arm — file has uncommitted changes' {
+        It 'throws to block the sweep, naming the file' {
+            $repo = Join-Path $TestDrive 'dirty-repo'
+            $file = New-FixtureRepo -Root $repo
+            '{ "stance": "strongly_opposed", "sit-477": true }' | Set-Content -Path $file -Encoding utf8NoBOM
+
+            { Assert-CleanDataTree -Path $file } | Should -Throw -ExpectedMessage '*uncommitted changes*'
+        }
+    }
+
+    Context '-Force downgrades a dirty block to a warning' {
+        It 'warns but does not throw' {
+            $repo = Join-Path $TestDrive 'force-repo'
+            $file = New-FixtureRepo -Root $repo
+            'mutated' | Set-Content -Path $file -Encoding utf8NoBOM
+
+            # A -Force block downgrades to a warning and returns (no throw).
+            $emitted = Assert-CleanDataTree -Path $file -Force 3>&1
+            @($emitted).Count | Should -BeGreaterThan 0
+            "$emitted" | Should -BeLike '*uncommitted changes*'
+        }
+    }
+
+    Context 'not-yet-existent target' {
+        It 'is treated as clean (no throw)' {
+            $ghost = Join-Path $TestDrive 'does-not-exist.json'
+            { Assert-CleanDataTree -Path $ghost } | Should -Not -Throw
+        }
+    }
+
+    Context 'target outside any git work tree' {
+        It 'does not block (guard defends tracked state only)' {
+            # $TestDrive itself is not a git repo.
+            $loose = Join-Path $TestDrive 'loose.json'
+            'x' | Set-Content -Path $loose -Encoding utf8NoBOM
+            { Assert-CleanDataTree -Path $loose } | Should -Not -Throw
+        }
+    }
+
+    Context 'Write-Utf8NoBom -RequireCleanTree wiring' {
+        It 'blocks an overwrite of a dirty target' {
+            $repo = Join-Path $TestDrive 'wired-dirty'
+            $file = New-FixtureRepo -Root $repo
+            'pending edit' | Set-Content -Path $file -Encoding utf8NoBOM
+
+            InModuleScope AITriad -Parameters @{ File = $file } {
+                param($File)
+                { 'new content' | Write-Utf8NoBom -Path $File -RequireCleanTree } |
+                    Should -Throw -ExpectedMessage '*uncommitted changes*'
+            }
+        }
+
+        It 'writes normally to a clean target with no warning' {
+            $repo = Join-Path $TestDrive 'wired-clean'
+            $file = New-FixtureRepo -Root $repo
+
+            InModuleScope AITriad -Parameters @{ File = $file } {
+                param($File)
+                $emitted = 'fresh' | Write-Utf8NoBom -Path $File -RequireCleanTree 3>&1
+                @($emitted).Count | Should -Be 0
+            }
+            (Get-Content -Path $file -Raw).TrimEnd("`n") | Should -Be 'fresh'
+        }
+    }
+}


### PR DESCRIPTION
## t/2902 — dirty-tree-sweep guard for whole-file data-repo writes

**DRAFT — gated on Main (TL) Gate Verification.** The ticket AC routes a blocking guard to TL for GV; un-drafting only after that.

### Problem
A whole-file JSON round-trip re-reads a file's current on-disk content — including concurrent uncommitted edits — and a later `git add` commits that state under a misleading message. In t/2896, commit `128ce8f4` swept an unrelated `resolved_node_id: sit-477` into a "stance-only" commit. The collision is **intra-file**, so a path-level `git add <file>` gate can't catch it.

### Fix
- **`Assert-CleanDataTree`** (new public cmdlet) — `git status --porcelain` on the target; throws `New-ActionableError` if tracked-modified. `-Force` downgrades to a warning. Not-yet-existent / non-git targets → clean (no false block).
- **`Write-Utf8NoBom -RequireCleanTree`** — opt-in switch on the module's single write chokepoint; **default OFF** ⇒ zero cost / zero noise for every existing writer.
- Exports + `docs/cmdlet-reference.md` catalog entry.

### Both-arms verification (`tests/Assert-CleanDataTree.Tests.ps1`, real temp git repo)
- DIRTY target → throws (sweep blocked); CLEAN target → writes with **zero warnings**; non-git path → no block; `-Force` on dirty → warning, no throw; `Write-Utf8NoBom -RequireCleanTree` wiring blocks dirty / writes clean. **7/7 pass.**

### Regression
Full local suite: **1376 passed, 2 failed** — both pre-existing & env-gated and outside this diff (`Invoke-AIApi` xai-grok-4-6 live round-trip; `situations` live-data baseline). This change is additive + opt-in; no path to either.

### Design note (deliberate)
Guard kept **opt-in**, not retrofitted into production `Repair-*` writers — those legitimately run against a dirty data tree, so a forced clean-tree precondition would be a false-block (the "flaky blocking gate = next incident" risk). The real failure surface was an ad-hoc scratchpad rewrite; the durable prevention is the callable guard + the AGENTS.md discipline (routed to PI separately).

Ticket: t/2902. Design/self-cert: t/2902#2 (`/add-ps-cmdlet`, one deviation noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
