### PR TITLE
fix(auth): absorb getInstallationToken() throw in hosted getCredentials() (t/2895)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/hostedModeCredentials.test.ts
+++ b/taxonomy-editor/src/server/__tests__/hostedModeCredentials.test.ts
@@ -116,6 +116,36 @@ describe('t/2895 hosted-mode credential gating (STORAGE_MODE !== filesystem)', (
     expect(call.message).toMatch(/getCredentials\(\) resolved to null in hosted mode/);
   });
 
+  it('getCredentials() absorbs getInstallationToken() throw and falls back to GITHUB_TOKEN env', async () => {
+    // App configured but network blips — fetch throws inside getInstallationToken().
+    // Must NOT propagate; must fall through to GITHUB_TOKEN and return it.
+    process.env.GITHUB_REPO = 'owner/repo';
+    process.env.GITHUB_TOKEN = 'pat-fallback';
+    process.env.GITHUB_APP_ID = 'app-123';
+    process.env.GITHUB_APP_INSTALLATION_ID = 'inst-456';
+    process.env.GITHUB_APP_PRIVATE_KEY = 'dummy-key-triggers-fetch';
+    mockFetch.mockRejectedValueOnce(new Error('network failure'));
+    const creds = await getCredentials();
+    // Must not throw; must return the PAT fallback
+    expect(creds).toEqual({ repo: 'owner/repo', token: 'pat-fallback', mode: 'pat' });
+    expect(frRecord).not.toHaveBeenCalled();
+  });
+
+  it('getCredentials() absorbs getInstallationToken() throw and emits FR error when no fallback', async () => {
+    // App configured, network blips, and no GITHUB_TOKEN → all rungs exhausted → null + FR error.
+    process.env.GITHUB_REPO = 'owner/repo';
+    process.env.GITHUB_APP_ID = 'app-123';
+    process.env.GITHUB_APP_INSTALLATION_ID = 'inst-456';
+    process.env.GITHUB_APP_PRIVATE_KEY = 'dummy-key-triggers-fetch';
+    mockFetch.mockRejectedValueOnce(new Error('network failure'));
+    const creds = await getCredentials();
+    expect(creds).toBeNull();
+    expect(frRecord).toHaveBeenCalledOnce();
+    const call = frRecord.mock.calls[0][0] as { type: string; level: string; message: string };
+    expect(call.type).toBe('system.error');
+    expect(call.message).toMatch(/getCredentials\(\) resolved to null in hosted mode/);
+  });
+
   it('getCredentials() emits FR system.error when GITHUB_REPO is unset', async () => {
     process.env.GITHUB_TOKEN = 'pat-env-token';
     // GITHUB_REPO not set → repo is invalid

--- a/taxonomy-editor/src/server/security/githubAppAuth.ts
+++ b/taxonomy-editor/src/server/security/githubAppAuth.ts
@@ -268,7 +268,10 @@ export async function getCredentials(): Promise<SyncCredentials | null> {
     const repo = process.env.GITHUB_REPO ?? null;
     const repoValid = repo != null && repo.includes('/');
 
-    const installToken = await getInstallationToken();
+    // t/2895: .catch(() => null) — a network blip or JSON parse error in getInstallationToken()
+    // must NOT throw out of getCredentials(), bypassing the GITHUB_TOKEN fallback and the
+    // Condition-1 FR-error/graceful-null path. Absorb the throw; treat mint failure as null.
+    const installToken = await getInstallationToken().catch(() => null);
     if (installToken && repoValid) return { repo: repo!, token: installToken, mode: 'app' };
 
     const envPat = (process.env.GITHUB_TOKEN ?? '').trim() || null;


### PR DESCRIPTION
## Summary

Follow-up to #1363 (t/2895). The hosted `getCredentials()` branch called `await getInstallationToken()` without `.catch()` — a network blip or JSON parse error inside that function throws out of `getCredentials()` entirely, bypassing both the `GITHUB_TOKEN` env fallback and the Condition-1 FR-error/graceful-null path (the exact diagnosability TL required).

Fix: `await getInstallationToken().catch(() => null)` — any throw is absorbed and treated as token-unavailable, letting the fallback rungs proceed.

**Two new tests:**
- App configured + mint throws (bad private key / network error) → falls back to `GITHUB_TOKEN` env ✓
- App configured + mint throws + no `GITHUB_TOKEN` → `null` + `FR system.error` emitted (Condition 1) ✓

## Pre-self-merge checklist
- [ ] CI green on pushed head
- [ ] base=main, head=CI OID, no open holds

TL approved the fix design at t/2895#8 / p/343#35. Self-merge on green per TL instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)