### PR TITLE
fix(debate-ux): friendly HTTP-error messages in debate failure states (t/2906)

### DIFF
--- a/taxonomy-editor/src/renderer/utils/errorMessages.test.ts
+++ b/taxonomy-editor/src/renderer/utils/errorMessages.test.ts
@@ -39,3 +39,50 @@ describe('mapErrorToUserMessage — ActionableError surfaces .problem, not the r
     expect(typeof mapErrorToUserMessage('something went wrong')).toBe('string');
   });
 });
+
+describe('mapErrorToUserMessage — HTTP status → friendly text (t/2906)', () => {
+  it('HTTP 500 maps to the friendly server-problem string, not raw', () => {
+    const shown = mapErrorToUserMessage(new Error('HTTP 500 Internal Server Error'));
+    expect(shown).toBe('The AI service ran into a problem. Retrying automatically — hang tight.');
+    expect(shown).not.toMatch(/HTTP 500|Internal Server Error/);
+  });
+
+  it('a bare "Internal Server Error" (no code) also maps to the 500 string', () => {
+    expect(mapErrorToUserMessage(new Error('Internal Server Error'))).toBe(
+      'The AI service ran into a problem. Retrying automatically — hang tight.',
+    );
+  });
+
+  it('HTTP 502 / 504 gateway errors map to the gateway string', () => {
+    expect(mapErrorToUserMessage(new Error('HTTP 502 Bad Gateway'))).toBe('A gateway error occurred. Retrying shortly.');
+    expect(mapErrorToUserMessage(new Error('HTTP 504 Gateway Timeout'))).toBe('A gateway error occurred. Retrying shortly.');
+  });
+
+  it('an AbortError maps to the connection-interrupted string', () => {
+    const err = new Error('The operation was aborted');
+    err.name = 'AbortError';
+    expect(mapErrorToUserMessage(err)).toBe('Connection interrupted. Retrying…');
+  });
+
+  it('a circuit-breaker-open error maps to the paused string', () => {
+    expect(mapErrorToUserMessage(new Error('Circuit breaker is OPEN for gemini'))).toBe(
+      'The service is temporarily unavailable. Your debate is paused — it will resume automatically.',
+    );
+  });
+
+  it('a generic HTTP 401/422 hits the friendly catch-all, not raw leak', () => {
+    expect(mapErrorToUserMessage(new Error('HTTP 401 Unauthorized'))).toBe('An unexpected error occurred. If this persists, try reloading.');
+    expect(mapErrorToUserMessage(new Error('Request failed with HTTP 422'))).toBe('An unexpected error occurred. If this persists, try reloading.');
+  });
+
+  it('no regression: 429 and 503 still return their existing strings (specific guards win)', () => {
+    expect(mapErrorToUserMessage(new Error('HTTP 429 Too Many Requests'))).toMatch(/rate limited/i);
+    expect(mapErrorToUserMessage(new Error('HTTP 503 Service Unavailable'))).toMatch(/temporarily overloaded/i);
+  });
+
+  it('an unrecognised error still hits the safe default (non-empty), not an empty string', () => {
+    const shown = mapErrorToUserMessage(new Error('some totally novel failure mode'));
+    expect(shown).toBe('some totally novel failure mode');
+    expect(shown.length).toBeGreaterThan(0);
+  });
+});

--- a/taxonomy-editor/src/renderer/utils/errorMessages.ts
+++ b/taxonomy-editor/src/renderer/utils/errorMessages.ts
@@ -76,6 +76,33 @@ export function mapErrorToUserMessage(err: unknown): string {
     return 'Operation timed out. The AI service may be slow — try again or switch to a faster model.';
   }
 
+  // HTTP 500 / bare 5xx server error (t/2906). Above the generic HTTP guard so it wins.
+  if (msg.includes('500') || msg.toLowerCase().includes('internal server error')) {
+    return 'The AI service ran into a problem. Retrying automatically — hang tight.';
+  }
+
+  // HTTP 502 / 504 gateway errors (t/2906)
+  if (msg.includes('502') || msg.includes('504') || msg.toLowerCase().includes('bad gateway') || msg.toLowerCase().includes('gateway timeout')) {
+    return 'A gateway error occurred. Retrying shortly.';
+  }
+
+  // AbortError / network interruption not caught by the timeout guard above (t/2906).
+  // Genuine aborts only — user-cancel is intercepted by isCancellationError before this maps.
+  if (err instanceof Error && err.name === 'AbortError') {
+    return 'Connection interrupted. Retrying…';
+  }
+
+  // Circuit breaker open — the sentinel string emitted by the breaker (t/2906)
+  if (msg.toLowerCase().includes('circuit') && msg.toLowerCase().includes('open')) {
+    return 'The service is temporarily unavailable. Your debate is paused — it will resume automatically.';
+  }
+
+  // Generic HTTP 4xx/5xx not caught above (400, 401, 422, etc.) — last, so specific
+  // guards (429, 500, 502/504, 503) always win over this catch-all (t/2906).
+  if (/HTTP [4-5]\d{2}/.test(msg)) {
+    return 'An unexpected error occurred. If this persists, try reloading.';
+  }
+
   // Default: truncate the raw message
   return msg.length > 200 ? msg.slice(0, 200) + '...' : msg;
 }


### PR DESCRIPTION
Fixes t/2906 (single-file, per TL design t/2906#1). **Routing PR to the GV coordinator (p/486).** Dependency for t/2907''s inline error display.

## Problem
Post-mortem of FR `merged-4aca633d`: debate failure panels leaked raw `HTTP 500` strings. `mapErrorToUserMessage` already fronts every `debateError` write — the gap was coverage holes; 500/4xx/gateway/AbortError/circuit-open fell through to the raw-message default.

## Fix (`errorMessages.ts` only)
Five guards added immediately before the default fallback:
- HTTP 500 / `internal server error` → "The AI service ran into a problem. Retrying automatically — hang tight."
- HTTP 502/504 / bad gateway / gateway timeout → "A gateway error occurred. Retrying shortly."
- `AbortError` (name-based) → "Connection interrupted. Retrying…"
- Circuit breaker open → "The service is temporarily unavailable. Your debate is paused — it will resume automatically."
- Generic `HTTP [4-5]xx` catch-all → placed **last**, so specific 429/500/502/504/503 guards always win.

Existing 429 / 503 / timeout / context guards unchanged. `sessionSlice.ts:312` deliberate HTTP-code save message left as-is (per design).

## GV confirmations (all covered by tests, 12/12 green)
1. `"HTTP 500 Internal Server Error"` → friendly string ✔
2. synthetic `AbortError` → maps correctly ✔
3. existing 429/503 → unchanged strings (no regression) ✔
4. unrecognised error → safe non-empty default (not empty string) ✔

Local: `errorMessages.test.ts` 12/12 pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)