### PR TITLE
feat(server): instrument embedding-compute load — event-loop delay + heap + in-flight (t/2904)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2904 — embedding-load instrumentation. Unit tests for the in-flight counter
+// and the load snapshot. The counter is the same one the t/2905 concurrency cap
+// will read, so its increment/decrement/floor invariants are load-bearing.
+
+import { describe, it, expect } from 'vitest';
+import {
+  beginEmbeddingCompute,
+  endEmbeddingCompute,
+  inFlightEmbeddingComputes,
+  embeddingLoadSnapshot,
+} from '../embeddingsLoad.js';
+
+describe('embeddingsLoad (t/2904)', () => {
+  it('in-flight counter increments and decrements relative to its base', () => {
+    const base = inFlightEmbeddingComputes();
+    beginEmbeddingCompute();
+    beginEmbeddingCompute();
+    expect(inFlightEmbeddingComputes()).toBe(base + 2);
+    endEmbeddingCompute();
+    expect(inFlightEmbeddingComputes()).toBe(base + 1);
+    endEmbeddingCompute();
+    expect(inFlightEmbeddingComputes()).toBe(base);
+  });
+
+  it('endEmbeddingCompute never drops the counter below zero', () => {
+    while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
+    endEmbeddingCompute();
+    endEmbeddingCompute();
+    expect(inFlightEmbeddingComputes()).toBe(0);
+  });
+
+  it('snapshot returns a finite, non-negative number for every field', () => {
+    const snap = embeddingLoadSnapshot();
+    for (const [key, value] of Object.entries(snap)) {
+      expect(Number.isFinite(value), `${key} must be finite`).toBe(true);
+      expect(value, `${key} must be >= 0`).toBeGreaterThanOrEqual(0);
+    }
+    // heap_size_limit is always a positive V8 constant.
+    expect(snap.heap_limit_mb).toBeGreaterThan(0);
+  });
+
+  it('snapshot reflects the current in-flight count', () => {
+    while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
+    beginEmbeddingCompute();
+    try {
+      expect(embeddingLoadSnapshot().in_flight_embedding_computes).toBe(1);
+    } finally {
+      endEmbeddingCompute();
+    }
+  });
+});

--- a/taxonomy-editor/src/server/embeddingsLoad.ts
+++ b/taxonomy-editor/src/server/embeddingsLoad.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2904 / t/2905 — embedding-compute load instrumentation.
+//
+// The 2026-08-21 prod crash was NOT an OOM. Three concurrent 702-item embedding
+// computes drove V8 into GC mark-compact thrash that froze the Node event loop
+// long enough to miss ACA's liveness-probe deadline → the container was SIGKILL'd
+// and restarted (RSS never hit the limit; no FATAL ERROR in stderr). See t/2905.
+//
+// This module exposes the pre-freeze signals — event-loop delay (the DIRECT
+// predictor of a liveness miss), heap/rss, and the in-flight embedding-compute
+// count (the trigger was concurrency) — plus the in-flight counter that the
+// t/2905 concurrency cap builds on. Per-process by design (maxReplicas: 1).
+
+import v8 from 'v8';
+import { monitorEventLoopDelay, type IntervalHistogram } from 'perf_hooks';
+
+const BYTES_PER_MB = 1024 * 1024;
+const NS_PER_MS = 1e6;
+
+// Event-loop delay histogram, enabled once on first use. `.mean`/`.max` are in
+// NANOSECONDS since process start; a sustained high value means the loop is
+// starved — the state that precedes a liveness-probe miss under embedding load.
+let loopDelay: IntervalHistogram | undefined;
+function getLoopDelay(): IntervalHistogram {
+  if (!loopDelay) {
+    loopDelay = monitorEventLoopDelay({ resolution: 20 });
+    loopDelay.enable();
+  }
+  return loopDelay;
+}
+
+let inFlight = 0;
+
+/** Increment the in-flight embedding-compute counter (call before the compute). */
+export function beginEmbeddingCompute(): void { inFlight++; }
+/** Decrement it (call in a `finally` after the compute). Never drops below 0. */
+export function endEmbeddingCompute(): void { inFlight = Math.max(0, inFlight - 1); }
+/** Current number of in-flight embedding computes on this replica. */
+export function inFlightEmbeddingComputes(): number { return inFlight; }
+
+export interface EmbeddingLoadSnapshot {
+  heap_used_mb: number;
+  heap_total_mb: number;
+  heap_limit_mb: number;
+  rss_mb: number;
+  event_loop_delay_mean_ms: number;
+  event_loop_delay_max_ms: number;
+  in_flight_embedding_computes: number;
+}
+
+/**
+ * Point-in-time snapshot of the signals that precede an embedding-load
+ * liveness-probe kill. Cheap; safe to call per request.
+ */
+export function embeddingLoadSnapshot(): EmbeddingLoadSnapshot {
+  const mem = process.memoryUsage();
+  const heapLimit = v8.getHeapStatistics().heap_size_limit;
+  const d = getLoopDelay();
+  // `.mean`/`.max` can be NaN before the first sampling interval elapses.
+  const toMs = (ns: number): number => (Number.isFinite(ns) ? Math.round((ns / NS_PER_MS) * 10) / 10 : 0);
+  return {
+    heap_used_mb: Math.round(mem.heapUsed / BYTES_PER_MB),
+    heap_total_mb: Math.round(mem.heapTotal / BYTES_PER_MB),
+    heap_limit_mb: Math.round(heapLimit / BYTES_PER_MB),
+    rss_mb: Math.round(mem.rss / BYTES_PER_MB),
+    event_loop_delay_mean_ms: toMs(d.mean),
+    event_loop_delay_max_ms: toMs(d.max),
+    in_flight_embedding_computes: inFlight,
+  };
+}

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -29,6 +29,7 @@ import * as rateLimiter from '../security/rateLimiter.js';
 import * as ai from '../ai/aiBackends.js';
 import { resolveGenerationContext, enforceBackendAllowed } from './generationContext.js';
 import * as fileIO from '../storage/fileIO.js';
+import { beginEmbeddingCompute, endEmbeddingCompute, embeddingLoadSnapshot } from '../embeddingsLoad.js';
 
 // Pure mirror of the server.ts parseCookies helper (used by the logout /
 // fresh-login handlers). Depends only on the request headers; holds no state.
@@ -535,8 +536,20 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
     try {
       const gate = freeTierEmbeddingGate(req, res);
       if (gate.blocked) return;
-      const vectors = await ai.computeEmbeddings(texts, ids, gate.key);
-      json(res, { vectors });
+      // t/2904: emit the pre-freeze load signals (event-loop delay + heap + rss +
+      // in-flight count) at INFO so a liveness-probe kill under concurrent embedding
+      // load is diagnosable in the ACA container logs — the 2026-08-21 crash had none.
+      log.api.info(
+        { ...embeddingLoadSnapshot(), item_count: Array.isArray(texts) ? texts.length : 0 },
+        'embeddings.compute: entry',
+      );
+      beginEmbeddingCompute();
+      try {
+        const vectors = await ai.computeEmbeddings(texts, ids, gate.key);
+        json(res, { vectors });
+      } finally {
+        endEmbeddingCompute();
+      }
     } catch (err) { getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to compute embeddings', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); error(res, String(err), 500, err); }
   }));
 


### PR DESCRIPTION
## What
Instruments `/api/embeddings/compute` with the pre-freeze load signals (t/2904).

## Why
The 2026-08-21 prod crash was a **liveness-probe SIGKILL**, not an OOM: 3 concurrent 702-item embedding computes drove V8 into GC event-loop freeze that missed ACA's liveness deadline (RSS was ~53% of the container limit; no FATAL ERROR). It was undiagnosable — no server-side load signal was logged and the flight-recorder server dump also 500'd during the freeze. Full RCA: t/2905#4.

## Change
- New `embeddingsLoad.ts`: an event-loop-delay monitor (`perf_hooks` — the DIRECT pre-liveness-miss predictor), a per-replica **in-flight embedding-compute counter** (the **t/2905 concurrency cap** builds on it), and a heap/rss/loop snapshot.
- `/api/embeddings/compute` logs the snapshot at **INFO** on entry (INFO not debug, so it survives prod Pino filtering) + brackets the compute with the in-flight counter (`try/finally`).
- Unit tests: counter increment/decrement/floor invariants + snapshot shape.

## Scope
**Observability only** — no behavioral change to the compute path. First step of the t/2905 event-loop-starvation fix (obs → concurrency cap → load-shed backstop → worker-thread offload).

**Self-cert:** obs-only (one log line + a counter), single-scope, no new public API / schema / behavioral change. TL's own t/2904 design; RCA converged with Diagnostics + DevOps. Merges on green after pre-self-merge verification.

Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
Co-Authored-By: Diagnostics (Orca) <main.operations-diagnostics@ai-triad-research.orca.local>
Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>