### PR TITLE
feat(scripts): centralize dirty-tree-sweep guard at data-write sinks + detection gate (t/2902 Part 2)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -156,3 +156,10 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | Cmdlet | Use when |
 |--------|----------|
 | `Assert-CleanDataTree` | Before a whole-file rewrite of a data-repo JSON, assert the target has no uncommitted changes — so a `ConvertFrom-Json \| ConvertTo-Json` (or Python `json.load`→`json.dump`) round-trip can't sweep concurrent working-tree state into the commit (t/2902; `-Force` downgrades the block to a warning). Also exposed as the opt-in `Write-Utf8NoBom -RequireCleanTree` switch. |
+
+**Centralized data-write guard (t/2902 Part 2).** Every data-of-record write in the module funnels through a guarded sink, so individual cmdlets need no per-callsite wiring:
+
+- **Content-string writes** go through `Write-Utf8NoBom`, which calls the internal `Assert-DataWriteAllowed` guard automatically. Writers using atomic `[IO.File]::WriteAllText`/`Move` sinks call the guard directly at the sink; Python re-writers call `assert_clean_data_tree` (`scripts/data_tree_guard.py`).
+- The guard fires **only** for a target **under the data root** (`Get-DataRoot`) that is **already dirty** — it is per-file, never a whole-tree assertion (the data tree is perpetually dirty).
+- **Mode** via `$env:AI_TRIAD_DATA_WRITE_GUARD` = `Warn` (default; surfaces a warning and proceeds) · `Block` (throws) · `Off`. Pass `-AllowDirty` on a sink call to opt a legitimate sequential rewriter out.
+- A detection test (`tests/DataWriteSinkGuard.Tests.ps1`) fails CI if any new data writer reaches disk bypassing the guarded sink — so coverage tracks growth.

--- a/scripts/AITriad/Private/Assert-DataWriteAllowed.ps1
+++ b/scripts/AITriad/Private/Assert-DataWriteAllowed.ps1
@@ -9,6 +9,11 @@
 # perpetually dirty; a whole-tree gate would false-block at scale). Delegates the
 # actual git check to Assert-CleanDataTree (Part 1).
 #
+# SCOPE (CL, t/2902#16): this guards the SAME-FILE sweep (t/2896 — a whole-file
+# rewrite bundling concurrent edits to that file). It does NOT cover the CROSS-FILE
+# `git add -A` sweep (the license-drift sibling) — that is the explicit-paths
+# staging rule's job (root AGENTS.md junk-file-hygiene), not this per-file guard.
+#
 # Gate promotion (t/2902 condition 4): default mode is WARN (surface, don't block)
 # so a ≥1-cycle warn-first period can flush any false-fire on legitimate sequential
 # dirty-target rewrites before promotion to BLOCK. Override with the env var

--- a/scripts/AITriad/Private/Assert-DataWriteAllowed.ps1
+++ b/scripts/AITriad/Private/Assert-DataWriteAllowed.ps1
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# ── Centralized dirty-tree-sweep guard for data-repo writes (t/2902 Part 2) ──
+# The single chokepoint every data-of-record write funnels through. It asserts the
+# SPECIFIC target file is clean vs HEAD before a whole-file rewrite, so concurrent
+# uncommitted working-tree state can't be swept into the commit (t/2896: 128ce8f4
+# swept sit-477). Per-FILE-dirty — NOT a whole-tree assertion (the data tree is
+# perpetually dirty; a whole-tree gate would false-block at scale). Delegates the
+# actual git check to Assert-CleanDataTree (Part 1).
+#
+# Gate promotion (t/2902 condition 4): default mode is WARN (surface, don't block)
+# so a ≥1-cycle warn-first period can flush any false-fire on legitimate sequential
+# dirty-target rewrites before promotion to BLOCK. Override with the env var
+# AI_TRIAD_DATA_WRITE_GUARD = Warn | Block | Off.
+
+$script:DataWriteGuardMode = $null   # in-process override (tests / callers); env wins if set
+
+function Get-DataWriteGuardMode {
+    <#
+    .SYNOPSIS
+        Resolve the active guard mode: Block | Warn | Off. Priority:
+        $env:AI_TRIAD_DATA_WRITE_GUARD > $script:DataWriteGuardMode > 'Warn' (default).
+    #>
+    [OutputType([string])]
+    param()
+    $envMode = [Environment]::GetEnvironmentVariable('AI_TRIAD_DATA_WRITE_GUARD')
+    if (-not [string]::IsNullOrWhiteSpace($envMode)) {
+        switch -Regex ($envMode.Trim()) {
+            '^(?i)block$' { return 'Block' }
+            '^(?i)warn$'  { return 'Warn' }
+            '^(?i)off$'   { return 'Off' }
+            default {
+                Write-Warning "AI_TRIAD_DATA_WRITE_GUARD='$envMode' is not Block/Warn/Off — defaulting to Warn."
+                return 'Warn'
+            }
+        }
+    }
+    if ($script:DataWriteGuardMode) { return $script:DataWriteGuardMode }
+    return 'Warn'   # warn-first default
+}
+
+function Test-IsUnderDataRoot {
+    <#
+    .SYNOPSIS
+        True when $Path resolves to a location under the shared data root. The guard
+        only fires for data-of-record writes; non-data outputs (reports, PDFs, config,
+        flight-recorder dumps) are never sweep-prone and must not be guarded.
+    #>
+    [OutputType([bool])]
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
+    try { $root = Get-DataRoot } catch { return $false }
+    if ([string]::IsNullOrWhiteSpace($root)) { return $false }
+    try {
+        $full = [System.IO.Path]::GetFullPath($Path)
+        $rootFull = [System.IO.Path]::GetFullPath($root)
+    } catch { return $false }
+    $sep = [System.IO.Path]::DirectorySeparatorChar
+    if (-not $rootFull.EndsWith($sep)) { $rootFull += $sep }
+    return $full.StartsWith($rootFull, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Assert-DataWriteAllowed {
+    <#
+    .SYNOPSIS
+        Sink-level dirty-tree-sweep guard. Call immediately before any whole-file
+        rewrite of a data-repo file. No-op unless the target is under the data root
+        AND already carries uncommitted changes.
+    .PARAMETER Path
+        The target file about to be overwritten.
+    .PARAMETER AllowDirty
+        Opt-out for a writer that legitimately rewrites a target left dirty by a
+        prior pass in the same sequence (t/2902 condition 4). Bypasses the guard.
+    .OUTPUTS
+        None. In Block mode a dirty data-target throws (New-ActionableError via
+        Assert-CleanDataTree); in Warn mode it warns and proceeds.
+    #>
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [switch]$AllowDirty
+    )
+    if ($AllowDirty) { return }
+    $mode = Get-DataWriteGuardMode
+    if ($mode -eq 'Off') { return }
+    if (-not (Test-IsUnderDataRoot -Path $Path)) { return }
+
+    if ($mode -eq 'Block') {
+        Assert-CleanDataTree -Path $Path            # dirty data-target -> throw
+    }
+    else {
+        Assert-CleanDataTree -Path $Path -Force     # Warn: dirty -> warn, proceed
+    }
+}

--- a/scripts/AITriad/Private/EntitiesStore.ps1
+++ b/scripts/AITriad/Private/EntitiesStore.ps1
@@ -221,6 +221,7 @@ function Write-EntityStoreAtomic {
         }
     }
 
+    Assert-DataWriteAllowed -Path $Path  # t/2902
     $temp = "$Path.tmp"
     $json = $Store | ConvertTo-Json -Depth 12
     try {

--- a/scripts/AITriad/Private/Write-Utf8NoBom.ps1
+++ b/scripts/AITriad/Private/Write-Utf8NoBom.ps1
@@ -55,10 +55,15 @@ function Write-Utf8NoBom {
         # a target UNDER the data root that is ALREADY dirty (Warn-first by default,
         # Block after promotion). -RequireCleanTree forces a hard block regardless of
         # mode/scope (Part 1); -AllowDirty opts a legit sequential rewriter out.
+        # Best-effort: skip cleanly if the guard functions aren't loaded — Build-Module.ps1
+        # dot-sources THIS file standalone (without the guard chain) to write .aitriad.json,
+        # a build artifact under the module dir, never a data-of-record write (t/2902).
         if ($RequireCleanTree) {
-            if (-not $AllowDirty) { Assert-CleanDataTree -Path $Path }
+            if (-not $AllowDirty -and (Get-Command Assert-CleanDataTree -ErrorAction SilentlyContinue)) {
+                Assert-CleanDataTree -Path $Path
+            }
         }
-        else {
+        elseif (Get-Command Assert-DataWriteAllowed -ErrorAction SilentlyContinue) {
             Assert-DataWriteAllowed -Path $Path -AllowDirty:$AllowDirty
         }
         Set-Content -Path $Path -Value $text -Encoding utf8NoBOM -NoNewline

--- a/scripts/AITriad/Private/Write-Utf8NoBom.ps1
+++ b/scripts/AITriad/Private/Write-Utf8NoBom.ps1
@@ -14,11 +14,14 @@ function Write-Utf8NoBom {
         [switch]$NoNewline,
         [switch]$Force,
 
-        # t/2902 — opt-in dirty-tree-sweep guard. When set, assert the target file
-        # has no uncommitted changes before overwriting it, so a whole-file rewrite
-        # cannot merge concurrent working-tree state into a later commit. Default
-        # OFF keeps every other writer's clean path zero-cost and zero-noise.
-        [switch]$RequireCleanTree
+        # t/2902 — force a HARD block regardless of guard mode/scope (Part 1
+        # semantics): assert the target is clean and throw on dirty. Prefer letting
+        # the centralized guard (below) decide; this is the explicit caller opt-in.
+        [switch]$RequireCleanTree,
+
+        # t/2902 — opt a legitimate sequential rewriter out of the dirty-tree guard
+        # (a target intentionally left dirty by a prior pass in the same run).
+        [switch]$AllowDirty
     )
     begin {
         $parts = New-Object System.Collections.Generic.List[string]
@@ -46,11 +49,17 @@ function Write-Utf8NoBom {
             Write-Warning "Write-Utf8NoBom: BLOCKED write to $fileName — content is $([math]::Round($text.Length / 1MB, 1)) MB (likely corrupted). This prevents a runaway encoding bug."
             return
         }
-        # t/2902 — opt-in: refuse to overwrite a target that already carries
-        # uncommitted changes (throws New-ActionableError), so a whole-file rewrite
-        # cannot sweep concurrent working-tree state into a later commit.
+        # t/2902 — centralized dirty-tree-sweep guard. Every content-string data
+        # write funnels through here, so guarding this sink covers all such callers
+        # (current and future) without per-callsite wiring. The guard fires only for
+        # a target UNDER the data root that is ALREADY dirty (Warn-first by default,
+        # Block after promotion). -RequireCleanTree forces a hard block regardless of
+        # mode/scope (Part 1); -AllowDirty opts a legit sequential rewriter out.
         if ($RequireCleanTree) {
-            Assert-CleanDataTree -Path $Path
+            if (-not $AllowDirty) { Assert-CleanDataTree -Path $Path }
+        }
+        else {
+            Assert-DataWriteAllowed -Path $Path -AllowDirty:$AllowDirty
         }
         Set-Content -Path $Path -Value $text -Encoding utf8NoBOM -NoNewline
     }

--- a/scripts/AITriad/Public/Get-DebateIndexHealth.ps1
+++ b/scripts/AITriad/Public/Get-DebateIndexHealth.ps1
@@ -183,6 +183,7 @@ function Get-DebateIndexHealth {
             # Match the app's compact serialization (JSON.stringify — no pretty,
             # no BOM, no trailing newline; saveIndex in debateIO.ts).
             $Json = $Index | ConvertTo-Json -Depth 20 -Compress
+            Assert-DataWriteAllowed -Path $IndexPath  # t/2902
             [System.IO.File]::WriteAllText($IndexPath, $Json, [System.Text.UTF8Encoding]::new($false))
         }
     }

--- a/scripts/AITriad/Public/Import-Organization.ps1
+++ b/scripts/AITriad/Public/Import-Organization.ps1
@@ -166,6 +166,7 @@ function Import-Organization {
     }
 
     # Atomic write: temp + File.Move
+    Assert-DataWriteAllowed -Path $path  # t/2902
     $temp = "$path.tmp"
     $json = $store | ConvertTo-Json -Depth 12
     try {

--- a/scripts/AITriad/Public/Import-OrganizationEdge.ps1
+++ b/scripts/AITriad/Public/Import-OrganizationEdge.ps1
@@ -191,6 +191,7 @@ function Import-OrganizationEdge {
     }
 
     # Atomic write: temp + File.Move
+    Assert-DataWriteAllowed -Path $path  # t/2902
     $temp = "$path.tmp"
     $json = $store | ConvertTo-Json -Depth 8
     try {

--- a/scripts/AITriad/Public/Invoke-AphorismBatch.ps1
+++ b/scripts/AITriad/Public/Invoke-AphorismBatch.ps1
@@ -306,6 +306,7 @@ function Invoke-AphorismBatch {
         }
 
         if ($PSCmdlet.ShouldProcess($FilePath, 'Save aphorisms')) {
+            Assert-DataWriteAllowed -Path $FilePath  # t/2902
             $TaxData | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
             $FileName = Split-Path $FilePath -Leaf
             Write-Verbose "Updated $($FileResults.Count) nodes in $FileName"

--- a/scripts/AITriad/Public/Invoke-BDIWeightAssignment.ps1
+++ b/scripts/AITriad/Public/Invoke-BDIWeightAssignment.ps1
@@ -304,6 +304,7 @@ function Invoke-BDIWeightAssignment {
 
         # Write back
         if (-not $DryRun -and $PSCmdlet.ShouldProcess("$PovName.json", 'Write confidence + priority + operationality')) {
+            Assert-DataWriteAllowed -Path $FilePath  # t/2902
             $Data | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
             Write-Host "  Saved $PovName.json" -ForegroundColor Green
         }

--- a/scripts/AITriad/Public/Invoke-CcToSitMigration.ps1
+++ b/scripts/AITriad/Public/Invoke-CcToSitMigration.ps1
@@ -319,6 +319,7 @@ function Invoke-CcToSitMigration {
             $orig = Get-Content -Raw -Path $s.Path -Encoding utf8
             $new  = $Pattern.Replace($orig, $Callback)
             if ($new -ne $orig) {
+                Assert-DataWriteAllowed -Path $s.Path  # t/2902
                 $tmp = $s.Path + '.tmp'
                 Set-Content -Path $tmp -Value $new -Encoding utf8NoBOM -NoNewline
                 [System.IO.File]::Move($tmp, $s.Path, $true)
@@ -355,6 +356,7 @@ function Invoke-CcToSitMigration {
         }
         foreach ($k in $Mapping.Keys) { $mappingObj.mapping[$k] = $Mapping[$k] }
         $json = ($mappingObj | ConvertTo-Json -Depth 8)
+        Assert-DataWriteAllowed -Path $MappingOut  # t/2902
         $tmp = $MappingOut + '.tmp'
         Set-Content -Path $tmp -Value $json -Encoding utf8NoBOM -NoNewline
         [System.IO.File]::Move($tmp, $MappingOut, $true)

--- a/scripts/AITriad/Public/Invoke-EntityExtraction.ps1
+++ b/scripts/AITriad/Public/Invoke-EntityExtraction.ps1
@@ -880,6 +880,7 @@ function Invoke-EntityExtraction {
             node_count      = @($ExistingLogNodes).Count
             nodes           = @($ExistingLogNodes)
         }
+        Assert-DataWriteAllowed -Path $OutputPath  # t/2902
         $Temp = "$OutputPath.tmp"
         $Json = $LogStore | ConvertTo-Json -Depth 8
         Set-Content -Path $Temp -Value $Json -Encoding utf8NoBOM

--- a/scripts/AITriad/Public/Invoke-OrgStanceExtraction.ps1
+++ b/scripts/AITriad/Public/Invoke-OrgStanceExtraction.ps1
@@ -441,6 +441,7 @@ function Invoke-OrgStanceExtraction {
     }
 
     if ($writtenNew -gt 0) {
+        Assert-DataWriteAllowed -Path $OutputPath  # t/2902
         $temp = "$OutputPath.tmp"
         $json = $store | ConvertTo-Json -Depth 8
         Set-Content -Path $temp -Value $json -Encoding utf8NoBOM

--- a/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
+++ b/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
@@ -257,6 +257,7 @@ Rules:
             }
         }
 
+        Assert-DataWriteAllowed -Path $FilePath  # t/2902
         $TaxData | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
         $FileName = Split-Path $FilePath -Leaf
         Write-Verbose "Updated $($FileResults.Count) nodes in $FileName" # Changed to verbose

--- a/scripts/AITriad/Public/Repair-PovAttributes.ps1
+++ b/scripts/AITriad/Public/Repair-PovAttributes.ps1
@@ -273,6 +273,7 @@ No markdown fences, no explanation.
     if ($TotalFixed -gt 0 -and -not $WhatIfPreference) {
         foreach ($PovName in $TaxData.Keys) {
             $FilePath = Join-Path $TaxDir "$PovName.json"
+            Assert-DataWriteAllowed -Path $FilePath  # t/2902
             $TaxData[$PovName] | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
         }
         Write-Host "`nSaved taxonomy files" -ForegroundColor Green

--- a/scripts/AITriad/Public/Repair-PovDescriptions.ps1
+++ b/scripts/AITriad/Public/Repair-PovDescriptions.ps1
@@ -225,6 +225,7 @@ Rules:
 
         # Write back if modified
         if ($Modified -and -not $WhatIfPreference) {
+            Assert-DataWriteAllowed -Path $FilePath  # t/2902
             $Data | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
             Write-Host "  Saved $FilePath" -ForegroundColor Green
         }

--- a/scripts/AITriad/Public/Repair-PovLineage.ps1
+++ b/scripts/AITriad/Public/Repair-PovLineage.ps1
@@ -235,6 +235,7 @@ function Repair-PovLineage {
                 }
             }
             if ($PovMod) {
+                Assert-DataWriteAllowed -Path $FilePath  # t/2902
                 $TaxFileData | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
                 Write-Host "  Saved $PovName.json" -ForegroundColor Green
             }
@@ -461,6 +462,7 @@ Return a JSON object mapping node_id to an array of updated lineage entries:
                 }
             }
 
+            Assert-DataWriteAllowed -Path $FilePath  # t/2902
             $Data | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
             Write-Host "  Saved $PovName.json" -ForegroundColor Green
         }
@@ -667,6 +669,7 @@ Return a JSON object mapping node_id to an array of updated lineage entries:
                     }
                     if ($PovModified) {
                         $FilePath = Join-Path $TaxDir "$PovName.json"
+                        Assert-DataWriteAllowed -Path $FilePath  # t/2902
                         $Data | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
                     }
                 }
@@ -974,6 +977,7 @@ Example: [{"name":"Effective Altruism","description":"A philosophical movement..
 
         if ($Modified) {
             $FilePath = Join-Path $TaxDir "$PovName.json"
+            Assert-DataWriteAllowed -Path $FilePath  # t/2902
             $Data | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
             Write-Host "  Saved $PovName.json" -ForegroundColor Green
         }

--- a/scripts/AITriad/Public/Set-TaxonomyHierarchy.ps1
+++ b/scripts/AITriad/Public/Set-TaxonomyHierarchy.ps1
@@ -402,6 +402,7 @@ function Set-TaxonomyHierarchy {
         }
         if ($PSCmdlet.ShouldProcess($FileEntry.Path, 'Write updated taxonomy file')) {
             try {
+                Assert-DataWriteAllowed -Path $FileEntry.Path  # t/2902
                 Set-Content -Path $FileEntry.Path -Value ($Json -replace "`r`n", "`n") -Encoding utf8NoBOM -NoNewline
                 Write-OK "Saved $PovKey ($($FileEntry.Path))"
             }

--- a/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
+++ b/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
@@ -363,6 +363,7 @@ function Update-EntityMentionIndex {
 
     if ($PSCmdlet.ShouldProcess($OutPath, "Write entity_mentions.json ($($result.ContainerCount) containers, $TotalMentions mentions)")) {
         $json = ConvertTo-Json $file -Depth 8
+        Assert-DataWriteAllowed -Path $OutPath  # t/2902
         $tmp = "$OutPath.tmp"
         try {
             Set-Content -LiteralPath $tmp -Value $json -Encoding utf8NoBOM

--- a/scripts/AITriad/Public/Update-NodeTestingRecord.ps1
+++ b/scripts/AITriad/Public/Update-NodeTestingRecord.ps1
@@ -138,6 +138,7 @@ function Update-NodeTestingRecord {
     if ($dirtyFiles.Count -gt 0 -and -not $WhatIfPreference) {
         foreach ($povName in $dirtyFiles.Keys) {
             $filePath = Join-Path $taxDir "$povName.json"
+            Assert-DataWriteAllowed -Path $filePath  # t/2902
             $dirtyFiles[$povName] | ConvertTo-Json -Depth 20 | Set-Content -Path $filePath -Encoding utf8NoBOM
             Write-Verbose "Update-NodeTestingRecord: wrote $filePath"
         }

--- a/scripts/AITriad/Public/Update-SyntheticCorpus.ps1
+++ b/scripts/AITriad/Public/Update-SyntheticCorpus.ps1
@@ -133,6 +133,7 @@ function Update-SyntheticCorpus {
             $Cleaned = @($Corpus.entries | Where-Object { -not $OrphanedNodes.Contains($_.node_id) })
             $Corpus.entries = $Cleaned
             $Corpus.entry_count = $Cleaned.Count
+            Assert-DataWriteAllowed -Path $CorpusPath  # t/2902
             $Corpus | ConvertTo-Json -Depth 10 -Compress | Set-Content -Path $CorpusPath -Encoding UTF8
         }
         Write-Host "  Removed $($OrphanedNodes.Count) orphaned node entries." -ForegroundColor Yellow

--- a/scripts/Invoke-DisagreementTypeBackfill.ps1
+++ b/scripts/Invoke-DisagreementTypeBackfill.ps1
@@ -34,6 +34,9 @@ $PSNativeCommandUseErrorActionPreference = $false
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 Import-Module (Join-Path $PSScriptRoot 'AIEnrich.psm1') -Force -WarningAction SilentlyContinue
+# t/2902 — standalone script: import AITriad for the dirty-tree-sweep guard
+# (Assert-CleanDataTree) used before the whole-file situations.json write below.
+Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
 
 # ── Resolve situations.json path ─────────────────────────────────────────────
 if (-not $SituationsPath) {
@@ -325,6 +328,9 @@ if ($DryRun) {
 Write-Host ''
 Write-Host 'Writing situations.json...' -ForegroundColor Cyan
 $json = $Raw | ConvertTo-Json -Depth 20
+# t/2902 — guard against sweeping concurrent uncommitted situations.json edits into
+# this whole-file rewrite. Warn-first (-Force warns and proceeds); drop -Force to block.
+Assert-CleanDataTree -Path $SituationsPath -Force
 [System.IO.File]::WriteAllText($SituationsPath, $json, (New-Object System.Text.UTF8Encoding $false))
 Write-Host 'Done.' -ForegroundColor Green
 

--- a/scripts/backfill_taxonomy_mappings.py
+++ b/scripts/backfill_taxonomy_mappings.py
@@ -23,6 +23,8 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from data_tree_guard import assert_clean_data_tree  # t/2902
+
 import numpy as np
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -320,6 +322,7 @@ def main():
         }
 
     for fpath, data in files_to_update.items():
+        assert_clean_data_tree(fpath)  # t/2902
         Path(fpath).write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8", newline="\n")
 
     print(f"  Updated {len(files_to_update)} summary files.", file=sys.stderr)

--- a/scripts/build_sense_embeddings.py
+++ b/scripts/build_sense_embeddings.py
@@ -21,6 +21,8 @@ import sys
 import time
 from pathlib import Path
 
+from data_tree_guard import assert_clean_data_tree  # t/2902
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_MODEL = "all-MiniLM-L6-v2"
 
@@ -175,6 +177,7 @@ def main():
         "entries": new_entries,
     }
 
+    assert_clean_data_tree(embeddings_path)  # t/2902
     embeddings_path.write_text(json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8")
     print(
         f"Wrote {len(new_entries)} entries to {embeddings_path.relative_to(data_root)}",

--- a/scripts/consolidate_conflicts.py
+++ b/scripts/consolidate_conflicts.py
@@ -34,6 +34,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from data_tree_guard import assert_clean_data_tree  # t/2902
+
 import numpy as np
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
@@ -429,6 +431,7 @@ def write_consolidated(consolidated, source_map, output_dir, replace=False):
     }
 
     conflicts_path = output_dir / "conflicts.json"
+    assert_clean_data_tree(conflicts_path)  # t/2902
     conflicts_path.write_text(
         json.dumps(wrapper, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8", newline="\n",

--- a/scripts/data_tree_guard.py
+++ b/scripts/data_tree_guard.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+"""Dirty-tree-sweep guard for Python data-repo writers (t/2902).
+
+A whole-file rewrite (``json.load`` -> mutate -> ``json.dump``/``write_text``)
+re-reads a file's CURRENT on-disk content -- including any concurrent
+uncommitted edits -- and a later ``git add`` commits that state under a
+misleading message (t/2896: commit 128ce8f4 swept an unrelated
+``resolved_node_id: sit-477`` into a "stance-only" commit).
+
+The collision is INTRA-FILE, so a path-level ``git add <file>`` gate cannot
+catch it -- staging the file still captures the pre-existing WIP. The durable
+guard is to assert the target file is clean vs HEAD *before* the rewrite. This
+is the Python mirror of the PowerShell ``Assert-CleanDataTree`` cmdlet; keep the
+two in sync.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+class DirtyTreeError(RuntimeError):
+    """Raised when a whole-file write target already carries uncommitted changes."""
+
+
+def is_data_tree_clean(path) -> bool:
+    """Return True when ``path`` is safe to whole-file rewrite.
+
+    Clean (True) means: no tracked-modified changes, OR the file does not exist
+    yet (a brand-new file carries nothing to sweep), OR it is not under a git
+    work tree / git is unavailable (the guard defends tracked state only).
+    Untracked files are ignored (``--untracked-files=no``).
+    """
+    path = os.fspath(path)
+    if not os.path.exists(path):
+        return True
+    directory = os.path.dirname(os.path.abspath(path)) or "."
+    leaf = os.path.basename(path)
+    # Run with cwd = the file's directory and a bare-leaf pathspec so no absolute
+    # path reaches git's pathspec parser (avoids MSYS path-conversion quirks --
+    # see "Git Forensics" in root AGENTS.md).
+    try:
+        proc = subprocess.run(
+            ["git", "-C", directory, "status", "--porcelain",
+             "--untracked-files=no", "--", leaf],
+            capture_output=True, text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return True  # git unavailable -> nothing to assert against
+    if proc.returncode != 0:
+        return True  # not a git work tree
+    return proc.stdout.strip() == ""
+
+
+def assert_clean_data_tree(path, force: bool = False) -> None:
+    """Raise ``DirtyTreeError`` if ``path`` already carries uncommitted changes.
+
+    Stops a whole-file rewrite from sweeping concurrent working-tree state into
+    the commit (t/2902). ``force=True`` downgrades the block to a stderr warning
+    and returns.
+    """
+    if is_data_tree_clean(path):
+        return
+    msg = (
+        f"{path} already has uncommitted changes; a whole-file rewrite would sweep "
+        f"that concurrent state into your commit (t/2902). Commit/stash it first, or "
+        f"write only the fields you mean to change."
+    )
+    if force:
+        print(f"WARNING: {msg} (proceeding, force=True)", file=sys.stderr)
+        return
+    raise DirtyTreeError(msg)

--- a/scripts/data_tree_guard.py
+++ b/scripts/data_tree_guard.py
@@ -54,13 +54,38 @@ def is_data_tree_clean(path) -> bool:
     return proc.stdout.strip() == ""
 
 
-def assert_clean_data_tree(path, force: bool = False) -> None:
-    """Raise ``DirtyTreeError`` if ``path`` already carries uncommitted changes.
+def _data_write_guard_mode() -> str:
+    """Resolve the guard mode from ``$AI_TRIAD_DATA_WRITE_GUARD``: ``block`` |
+    ``warn`` | ``off`` (default ``warn``). Mirrors the PowerShell
+    ``Get-DataWriteGuardMode`` so both languages promote together (t/2902 cond. 4:
+    warn-first, then Block after a clean cycle)."""
+    raw = (os.environ.get("AI_TRIAD_DATA_WRITE_GUARD") or "").strip().lower()
+    if raw in ("block", "warn", "off"):
+        return raw
+    if raw:
+        print(f"WARNING: AI_TRIAD_DATA_WRITE_GUARD='{raw}' is not block/warn/off "
+              f"— defaulting to warn.", file=sys.stderr)
+    return "warn"
 
-    Stops a whole-file rewrite from sweeping concurrent working-tree state into
-    the commit (t/2902). ``force=True`` downgrades the block to a stderr warning
-    and returns.
+
+def assert_clean_data_tree(path, force: bool = False) -> None:
+    """Guard a whole-file data-repo rewrite against a dirty-tree sweep (t/2902).
+
+    Warn-first by default; the mode comes from ``$AI_TRIAD_DATA_WRITE_GUARD``
+    (mirrors the PowerShell guard so both languages promote in lockstep):
+      - ``off``                       -> no-op.
+      - clean target (any mode)       -> no-op.
+      - dirty + ``warn`` (default)    -> stderr warning, return (does NOT raise).
+      - dirty + ``block``             -> raise ``DirtyTreeError``.
+
+    ``force=True`` opts out entirely (mirrors PowerShell ``-AllowDirty``) — for a
+    writer that legitimately rewrites a target left dirty by a prior pass.
     """
+    if force:
+        return
+    mode = _data_write_guard_mode()
+    if mode == "off":
+        return
     if is_data_tree_clean(path):
         return
     msg = (
@@ -68,7 +93,6 @@ def assert_clean_data_tree(path, force: bool = False) -> None:
         f"that concurrent state into your commit (t/2902). Commit/stash it first, or "
         f"write only the fields you mean to change."
     )
-    if force:
-        print(f"WARNING: {msg} (proceeding, force=True)", file=sys.stderr)
-        return
-    raise DirtyTreeError(msg)
+    if mode == "block":
+        raise DirtyTreeError(msg)
+    print(f"WARNING: {msg}", file=sys.stderr)  # warn-first: surface, don't block

--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -27,6 +27,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from data_tree_guard import assert_clean_data_tree  # t/2902
+
 import numpy as np
 
 _SCRIPT_DIR = Path(__file__).resolve().parent
@@ -520,6 +522,7 @@ def main():
         from datetime import timezone
         wrapper["last_modified"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         wrapper["conflict_count"] = len(wrapper.get("conflicts", []))
+        assert_clean_data_tree(conflicts_file)  # t/2902
         conflicts_file.write_text(
             json.dumps(wrapper, indent=2, ensure_ascii=False) + "\n",
             encoding="utf-8", newline="\n",

--- a/scripts/reprocess_taxonomy_vocabulary.py
+++ b/scripts/reprocess_taxonomy_vocabulary.py
@@ -24,6 +24,8 @@ from copy import deepcopy
 from datetime import date
 from pathlib import Path
 
+from data_tree_guard import assert_clean_data_tree  # t/2902
+
 _SCRIPT_DIR = Path(__file__).resolve().parent
 TODAY = date.today().isoformat()
 
@@ -452,6 +454,7 @@ def main():
         if not args.dry_run:
             data["nodes"] = new_nodes
             data["last_modified"] = TODAY
+            assert_clean_data_tree(fpath)  # t/2902
             fpath.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
             print(f"  Wrote {fpath.name}", file=sys.stderr)
 

--- a/scripts/test_data_tree_guard.py
+++ b/scripts/test_data_tree_guard.py
@@ -12,11 +12,32 @@ working-tree state into the commit. Tested against a REAL temporary git repo
 pytest or standalone: `python test_data_tree_guard.py`.
 """
 
+import contextlib
 import importlib.util
+import io
 import os
 import subprocess
 import tempfile
 from pathlib import Path
+
+
+@contextlib.contextmanager
+def _guard_mode(mode):
+    """Set $AI_TRIAD_DATA_WRITE_GUARD for the block, restoring the prior value
+    afterward (pytest runs every test in one process — do not clobber)."""
+    key = "AI_TRIAD_DATA_WRITE_GUARD"
+    prev = os.environ.get(key)
+    if mode is None:
+        os.environ.pop(key, None)
+    else:
+        os.environ[key] = mode
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prev
 
 _SPEC = importlib.util.spec_from_file_location(
     "data_tree_guard", Path(__file__).resolve().parent / "data_tree_guard.py"
@@ -54,25 +75,51 @@ def test_clean_arm_committed_file_is_clean():
         assert_clean_data_tree(f)  # must not raise
 
 
-def test_dirty_arm_uncommitted_change_blocks():
+def test_block_mode_dirty_raises():
     with tempfile.TemporaryDirectory() as tmp:
-        f = _make_repo(Path(tmp) / "dirty")
+        f = _make_repo(Path(tmp) / "block")
         f.write_text('{ "stance": "strongly_opposed", "sit-477": true }\n', encoding="utf-8")
         assert is_data_tree_clean(f) is False
         raised = False
-        try:
-            assert_clean_data_tree(f)
-        except DirtyTreeError as exc:
-            raised = True
-            assert "uncommitted changes" in str(exc)
-        assert raised, "expected DirtyTreeError on a dirty target"
+        with _guard_mode("Block"):
+            try:
+                assert_clean_data_tree(f)
+            except DirtyTreeError as exc:
+                raised = True
+                assert "uncommitted changes" in str(exc)
+        assert raised, "Block mode must raise DirtyTreeError on a dirty target"
 
 
-def test_force_downgrades_to_warning():
+def test_warn_mode_default_dirty_warns_without_raising():
+    # Default (no env var) is warn-first: surface a stderr warning, do NOT raise —
+    # mirrors the PowerShell guard so Python doesn't hard-block from day one (t/2902 GV).
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "warn")
+        f.write_text("mutated\n", encoding="utf-8")
+        with _guard_mode(None):  # unset -> default warn
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                assert_clean_data_tree(f)  # must NOT raise
+            assert "uncommitted changes" in err.getvalue()
+
+
+def test_off_mode_dirty_noop():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "off")
+        f.write_text("mutated\n", encoding="utf-8")
+        with _guard_mode("Off"):
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err):
+                assert_clean_data_tree(f)  # no raise
+            assert err.getvalue() == ""  # and no noise
+
+
+def test_force_opts_out_even_in_block_mode():
     with tempfile.TemporaryDirectory() as tmp:
         f = _make_repo(Path(tmp) / "force")
         f.write_text("mutated\n", encoding="utf-8")
-        assert_clean_data_tree(f, force=True)  # must not raise
+        with _guard_mode("Block"):
+            assert_clean_data_tree(f, force=True)  # -AllowDirty equivalent: must not raise
 
 
 def test_not_yet_existent_is_clean():

--- a/scripts/test_data_tree_guard.py
+++ b/scripts/test_data_tree_guard.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+"""Both-arms tests for the t/2902 dirty-tree-sweep guard (Python side).
+
+`assert_clean_data_tree` refuses a whole-file rewrite whose target already
+carries uncommitted changes, so a `json.dump` round-trip can't sweep concurrent
+working-tree state into the commit. Tested against a REAL temporary git repo
+(no git mocking — the guard's whole job is reading real `git status`). Runs under
+pytest or standalone: `python test_data_tree_guard.py`.
+"""
+
+import importlib.util
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "data_tree_guard", Path(__file__).resolve().parent / "data_tree_guard.py"
+)
+data_tree_guard = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(data_tree_guard)
+
+assert_clean_data_tree = data_tree_guard.assert_clean_data_tree
+is_data_tree_clean = data_tree_guard.is_data_tree_clean
+DirtyTreeError = data_tree_guard.DirtyTreeError
+
+
+def _make_repo(root: Path) -> Path:
+    """Init a throwaway git repo with one committed, clean file; return its path.
+
+    Identity + signing are set LOCAL to this fixture repo only (CI has no signing
+    key) — it is a disposable fixture, not a project repo.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(root), "init", "--quiet"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.email", "fixture@example.com"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "Fixture"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "commit.gpgsign", "false"], check=True)
+    f = root / "data.json"
+    f.write_text('{ "stance": "aligned" }\n', encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "data.json"], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "--quiet", "-m", "seed"], check=True)
+    return f
+
+
+def test_clean_arm_committed_file_is_clean():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "clean")
+        assert is_data_tree_clean(f) is True
+        assert_clean_data_tree(f)  # must not raise
+
+
+def test_dirty_arm_uncommitted_change_blocks():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "dirty")
+        f.write_text('{ "stance": "strongly_opposed", "sit-477": true }\n', encoding="utf-8")
+        assert is_data_tree_clean(f) is False
+        raised = False
+        try:
+            assert_clean_data_tree(f)
+        except DirtyTreeError as exc:
+            raised = True
+            assert "uncommitted changes" in str(exc)
+        assert raised, "expected DirtyTreeError on a dirty target"
+
+
+def test_force_downgrades_to_warning():
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "force")
+        f.write_text("mutated\n", encoding="utf-8")
+        assert_clean_data_tree(f, force=True)  # must not raise
+
+
+def test_not_yet_existent_is_clean():
+    with tempfile.TemporaryDirectory() as tmp:
+        ghost = Path(tmp) / "does-not-exist.json"
+        assert is_data_tree_clean(ghost) is True
+        assert_clean_data_tree(ghost)  # must not raise
+
+
+def test_non_git_path_does_not_block():
+    with tempfile.TemporaryDirectory() as tmp:
+        loose = Path(tmp) / "loose.json"
+        loose.write_text("x\n", encoding="utf-8")  # tmp is not a git work tree
+        assert is_data_tree_clean(loose) is True
+        assert_clean_data_tree(loose)  # must not raise
+
+
+if __name__ == "__main__":
+    _tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in _tests:
+        try:
+            t()
+            print(f"[+] {t.__name__}")
+        except Exception as exc:  # noqa: BLE001 — standalone runner surfaces all
+            failed += 1
+            print(f"[-] {t.__name__}: {exc}")
+    print(f"\n{len(_tests) - failed}/{len(_tests)} passed")
+    raise SystemExit(1 if failed else 0)

--- a/tests/Assert-DataWriteAllowed.Tests.ps1
+++ b/tests/Assert-DataWriteAllowed.Tests.ps1
@@ -148,3 +148,24 @@ Describe 'Assert-DataWriteAllowed — centralized data-write guard (t/2902)' -Ta
         }
     }
 }
+
+Describe 'Write-Utf8NoBom Build-Module contract (t/2902 regression)' -Tag 'summary' {
+    # Build-Module.ps1 dot-sources Private/Write-Utf8NoBom.ps1 STANDALONE (without the
+    # guard chain) to write .aitriad.json. The centralized guard must therefore be
+    # best-effort: a standalone dot-source must still write, not fail on a missing
+    # Assert-DataWriteAllowed. Verified in a FRESH pwsh process (real isolation — the
+    # in-process module would otherwise make the guard resolvable and mask the break).
+    It 'a standalone dot-source writes without requiring the guard chain' {
+        $writer = (Resolve-Path (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'Private' 'Write-Utf8NoBom.ps1')).Path
+        $out    = Join-Path $TestDrive 'standalone-build.json'
+        $mini   = Join-Path $TestDrive 'mini-build.ps1'
+        # Write the harness to a file (avoids -Command quoting hazards, Shell Quoting Rule).
+        Set-Content -Path $mini -Encoding utf8NoBOM -Value @(
+            ". `"$writer`""
+            "'hello-build' | Write-Utf8NoBom -Path `"$out`""
+        )
+        $p = Start-Process -FilePath 'pwsh' -ArgumentList '-NoProfile', '-File', $mini -Wait -PassThru -NoNewWindow
+        $p.ExitCode | Should -Be 0
+        (Get-Content -Raw -Path $out).Trim() | Should -Be 'hello-build'
+    }
+}

--- a/tests/Assert-DataWriteAllowed.Tests.ps1
+++ b/tests/Assert-DataWriteAllowed.Tests.ps1
@@ -1,0 +1,150 @@
+# Tag: summary (t/2902)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Centralized data-write dirty-tree guard (t/2902 Part 2) — both arms + mode +
+    data-root scoping, against a REAL temp git repo used as the data root.
+.DESCRIPTION
+    Assert-DataWriteAllowed is the sink chokepoint. It must:
+      - Block mode + dirty data-target   -> throw (sweep blocked).
+      - Warn  mode + dirty data-target   -> warn, no throw (warn-first promotion).
+      - Off   mode                       -> no-op.
+      - clean data-target (any mode)     -> no-op, silent.
+      - target OUTSIDE the data root      -> no-op even in Block (per-file, data-scoped;
+                                            NOT a whole-tree gate — the false-block trap).
+      - -AllowDirty                       -> bypass even in Block (sequential-rewriter opt-out).
+    Also proves Write-Utf8NoBom routes through the guard (Block + dirty -> throw).
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    # Capture pre-existing env so AfterEach can RESTORE (not clobber) it — the full
+    # suite runs every test file in one process, and CI sets AI_TRIAD_DATA_ROOT.
+    $script:OrigDataRoot  = [Environment]::GetEnvironmentVariable('AI_TRIAD_DATA_ROOT')
+    $script:OrigGuardMode = [Environment]::GetEnvironmentVariable('AI_TRIAD_DATA_WRITE_GUARD')
+
+    function New-DataRepo {
+        param([string]$Root)
+        New-Item -ItemType Directory -Path $Root -Force | Out-Null
+        & git -C $Root init --quiet
+        & git -C $Root config user.email 'fixture@example.com'
+        & git -C $Root config user.name 'Fixture'
+        & git -C $Root config commit.gpgsign false
+        $sub = Join-Path $Root 'summaries'
+        New-Item -ItemType Directory -Path $sub -Force | Out-Null
+        $file = Join-Path $sub 'doc.json'
+        '{ "stance": "aligned" }' | Set-Content -Path $file -Encoding utf8NoBOM
+        & git -C $Root add -A
+        & git -C $Root commit --quiet -m 'seed'
+        return $file
+    }
+}
+
+Describe 'Assert-DataWriteAllowed — centralized data-write guard (t/2902)' -Tag 'summary' {
+
+    AfterEach {
+        # Restore the pre-existing values (do NOT blanket-remove — would clobber a
+        # CI-set AI_TRIAD_DATA_ROOT for every later test file in the shared process).
+        if ($null -eq $script:OrigDataRoot) { Remove-Item Env:\AI_TRIAD_DATA_ROOT -ErrorAction SilentlyContinue }
+        else { $env:AI_TRIAD_DATA_ROOT = $script:OrigDataRoot }
+        if ($null -eq $script:OrigGuardMode) { Remove-Item Env:\AI_TRIAD_DATA_WRITE_GUARD -ErrorAction SilentlyContinue }
+        else { $env:AI_TRIAD_DATA_WRITE_GUARD = $script:OrigGuardMode }
+    }
+
+    It 'Block mode + dirty data-target throws' {
+        $repo = Join-Path $TestDrive 'block-dirty'
+        $file = New-DataRepo -Root $repo
+        'mutated' | Set-Content -Path $file -Encoding utf8NoBOM   # make it dirty
+        $env:AI_TRIAD_DATA_ROOT = $repo
+        $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+        InModuleScope AITriad -Parameters @{ F = $file } {
+            param($F)
+            { Assert-DataWriteAllowed -Path $F } | Should -Throw -ExpectedMessage '*uncommitted changes*'
+        }
+    }
+
+    It 'Warn mode + dirty data-target warns but does not throw' {
+        $repo = Join-Path $TestDrive 'warn-dirty'
+        $file = New-DataRepo -Root $repo
+        'mutated' | Set-Content -Path $file -Encoding utf8NoBOM
+        $env:AI_TRIAD_DATA_ROOT = $repo
+        $env:AI_TRIAD_DATA_WRITE_GUARD = 'Warn'
+        InModuleScope AITriad -Parameters @{ F = $file } {
+            param($F)
+            $emitted = Assert-DataWriteAllowed -Path $F 3>&1
+            @($emitted).Count | Should -BeGreaterThan 0
+            "$emitted" | Should -BeLike '*uncommitted changes*'
+        }
+    }
+
+    It 'Off mode is a no-op even on a dirty data-target' {
+        $repo = Join-Path $TestDrive 'off-dirty'
+        $file = New-DataRepo -Root $repo
+        'mutated' | Set-Content -Path $file -Encoding utf8NoBOM
+        $env:AI_TRIAD_DATA_ROOT = $repo
+        $env:AI_TRIAD_DATA_WRITE_GUARD = 'Off'
+        InModuleScope AITriad -Parameters @{ F = $file } {
+            param($F)
+            $emitted = Assert-DataWriteAllowed -Path $F 3>&1
+            @($emitted).Count | Should -Be 0
+        }
+    }
+
+    It 'clean data-target is a silent no-op (Block mode)' {
+        $repo = Join-Path $TestDrive 'block-clean'
+        $file = New-DataRepo -Root $repo
+        $env:AI_TRIAD_DATA_ROOT = $repo
+        $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+        InModuleScope AITriad -Parameters @{ F = $file } {
+            param($F)
+            $emitted = Assert-DataWriteAllowed -Path $F 3>&1
+            @($emitted).Count | Should -Be 0
+        }
+    }
+
+    It 'target OUTSIDE the data root is not guarded even in Block mode' {
+        $repo = Join-Path $TestDrive 'scope-repo'
+        $null = New-DataRepo -Root $repo
+        # A dirty tracked file in a DIFFERENT git repo, not under the data root.
+        $other = Join-Path $TestDrive 'other'
+        $outsideFile = New-DataRepo -Root $other   # its own repo
+        'mutated' | Set-Content -Path $outsideFile -Encoding utf8NoBOM
+        $env:AI_TRIAD_DATA_ROOT = $repo            # data root is the FIRST repo
+        $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+        InModuleScope AITriad -Parameters @{ F = $outsideFile } {
+            param($F)
+            # Not under data root -> guard must not fire, even dirty + Block.
+            { Assert-DataWriteAllowed -Path $F } | Should -Not -Throw
+        }
+    }
+
+    It '-AllowDirty bypasses the guard even in Block mode' {
+        $repo = Join-Path $TestDrive 'allowdirty'
+        $file = New-DataRepo -Root $repo
+        'mutated' | Set-Content -Path $file -Encoding utf8NoBOM
+        $env:AI_TRIAD_DATA_ROOT = $repo
+        $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+        InModuleScope AITriad -Parameters @{ F = $file } {
+            param($F)
+            { Assert-DataWriteAllowed -Path $F -AllowDirty } | Should -Not -Throw
+        }
+    }
+
+    It 'Write-Utf8NoBom routes through the guard (Block + dirty data-target throws)' {
+        $repo = Join-Path $TestDrive 'wired'
+        $file = New-DataRepo -Root $repo
+        'mutated' | Set-Content -Path $file -Encoding utf8NoBOM
+        $env:AI_TRIAD_DATA_ROOT = $repo
+        $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+        InModuleScope AITriad -Parameters @{ F = $file } {
+            param($F)
+            { 'new' | Write-Utf8NoBom -Path $F } | Should -Throw -ExpectedMessage '*uncommitted changes*'
+        }
+    }
+}

--- a/tests/DataWriteGuard.IncidentFixture.Tests.ps1
+++ b/tests/DataWriteGuard.IncidentFixture.Tests.ps1
@@ -1,0 +1,170 @@
+# Tag: summary (t/2902)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Canonical dirty-situations incident fixture for the data-write guard (t/2902,
+    CL fixture shape t/2902#13) — encodes commit 128ce8f4.
+.DESCRIPTION
+    The t/2896 sweep (commit 128ce8f4) whole-file round-tripped a summary that the
+    working tree had left dirty, carrying TWO sweep signatures into a "stance-only"
+    commit:
+      (1) a SEMANTIC ride-along — `resolved_node_id` added to an unmapped_concepts
+          entry, and
+      (2) the WHOLE-FILE ROUND-TRIP TELL — cosmetic float->int churn (`3.0 -> 3`) on
+          untargeted graph_attributes.
+
+    Signature (2) is load-bearing: it fires even when NO semantic field rides along,
+    so it catches the MECHANISM (ConvertFrom-Json | ConvertTo-Json re-serialize), not
+    just the symptom. This guard checks `git status` (not field content), so it fires
+    on ANY uncommitted change to the target — proven here for the semantic arm, the
+    numeric-churn-ONLY arm, and mirrored on taxonomy/Origin/situations.json.
+
+    Fixture edits are SURGICAL (string splice / value swap) so each signature is
+    isolated in the diff — a whole-file reformat would blur them together.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    $script:OrigDataRoot  = [Environment]::GetEnvironmentVariable('AI_TRIAD_DATA_ROOT')
+    $script:OrigGuardMode = [Environment]::GetEnvironmentVariable('AI_TRIAD_DATA_WRITE_GUARD')
+
+    # A committed-clean summary carrying float graph_attributes (3.0) + an
+    # unmapped_concepts entry WITHOUT resolved_node_id. LF, stable layout so the
+    # surgical edits below produce isolated diffs.
+    $script:CleanSummary = @'
+{
+  "pov_summaries": {
+    "safetyist": {
+      "key_points": [
+        { "stance": "aligned", "taxonomy_node_id": "saf-beliefs-017" }
+      ]
+    }
+  },
+  "graph_attributes": { "in_count": 3.0, "out_count": 5.0, "ratio": 3.0 },
+  "unmapped_concepts": [
+    { "concept": "digital sovereignty", "suggested_pov": "situations" }
+  ]
+}
+'@ -replace "`r`n", "`n"
+
+    function New-IncidentRepo {
+        param([string]$Root, [string]$RelPath = 'summaries/democracy.json', [string]$Content = $script:CleanSummary)
+        New-Item -ItemType Directory -Path $Root -Force | Out-Null
+        & git -C $Root init --quiet
+        & git -C $Root config user.email 'fixture@example.com'
+        & git -C $Root config user.name 'Fixture'
+        & git -C $Root config commit.gpgsign false
+        $file = Join-Path $Root $RelPath
+        New-Item -ItemType Directory -Path (Split-Path $file -Parent) -Force | Out-Null
+        [System.IO.File]::WriteAllText($file, $Content, (New-Object System.Text.UTF8Encoding $false))
+        & git -C $Root add -A
+        & git -C $Root commit --quiet -m 'seed clean summary'
+        return $file
+    }
+
+    function Get-Diff { param([string]$Root) (& git -C $Root --no-pager diff) -join "`n" }
+}
+
+Describe 'Dirty-situations sweep guard — incident 128ce8f4 fixture (t/2902 / CL)' -Tag 'summary' {
+
+    AfterEach {
+        if ($null -eq $script:OrigDataRoot) { Remove-Item Env:\AI_TRIAD_DATA_ROOT -ErrorAction SilentlyContinue }
+        else { $env:AI_TRIAD_DATA_ROOT = $script:OrigDataRoot }
+        if ($null -eq $script:OrigGuardMode) { Remove-Item Env:\AI_TRIAD_DATA_WRITE_GUARD -ErrorAction SilentlyContinue }
+        else { $env:AI_TRIAD_DATA_WRITE_GUARD = $script:OrigGuardMode }
+    }
+
+    Context 'DIRTY arm — both sweep signatures present (the actual incident)' {
+        It 'guard FIRES on a tree carrying a semantic ride-along AND numeric round-trip churn' {
+            $repo = Join-Path $TestDrive 'both'
+            $file = New-IncidentRepo -Root $repo
+            $env:AI_TRIAD_DATA_ROOT = $repo
+            $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+
+            # Concurrent uncommitted state, spliced surgically:
+            $raw = [System.IO.File]::ReadAllText($file)
+            $raw = $raw -replace '"concept": "digital sovereignty"', '"resolved_node_id": "sit-477", "concept": "digital sovereignty"'  # signature 1
+            $raw = $raw -replace '3\.0', '3'                                                                                            # signature 2
+            [System.IO.File]::WriteAllText($file, $raw, (New-Object System.Text.UTF8Encoding $false))
+
+            InModuleScope AITriad -Parameters @{ F = $file } {
+                param($F)
+                { Assert-DataWriteAllowed -Path $F } | Should -Throw -ExpectedMessage '*uncommitted changes*'
+            }
+
+            $diff = Get-Diff -Root $repo
+            $diff | Should -Match 'resolved_node_id'        # signature 1 is in the swept-away dirtiness
+            $diff | Should -Match '3\.0'                    # signature 2 (a 3.0 churned away)
+        }
+    }
+
+    Context 'DIRTY arm — numeric round-trip tell ALONE (load-bearing)' {
+        It 'guard FIRES on cosmetic 3.0->3 churn with NO semantic field added' {
+            $repo = Join-Path $TestDrive 'numeric-only'
+            $file = New-IncidentRepo -Root $repo
+            $env:AI_TRIAD_DATA_ROOT = $repo
+            $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+
+            # ONLY the whole-file round-trip tell — untargeted graph_attributes churn.
+            $raw = [System.IO.File]::ReadAllText($file) -replace '3\.0', '3'
+            [System.IO.File]::WriteAllText($file, $raw, (New-Object System.Text.UTF8Encoding $false))
+
+            InModuleScope AITriad -Parameters @{ F = $file } {
+                param($F)
+                { Assert-DataWriteAllowed -Path $F } | Should -Throw -ExpectedMessage '*uncommitted changes*'
+            }
+
+            $diff = Get-Diff -Root $repo
+            $diff | Should -Not -Match 'resolved_node_id'   # no semantic ride-along this time
+            $diff | Should -Match '3\.0'                    # the mechanism-tell is the only change — still caught
+        }
+    }
+
+    Context 'CLEAN arm — no concurrent state (no false block)' {
+        It 'committed-clean target is a silent no-op' {
+            $repo = Join-Path $TestDrive 'clean'
+            $file = New-IncidentRepo -Root $repo
+            $env:AI_TRIAD_DATA_ROOT = $repo
+            $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+
+            InModuleScope AITriad -Parameters @{ F = $file } {
+                param($F)
+                $emitted = Assert-DataWriteAllowed -Path $F 3>&1
+                @($emitted).Count | Should -Be 0
+            }
+        }
+    }
+
+    Context 'mirror — taxonomy/Origin/situations.json writer' {
+        It 'guard FIRES when a concurrent situation-node add is left uncommitted' {
+            $sit = @'
+{
+  "nodes": [
+    { "id": "sit-001", "label": "Seed", "graph_attributes": { "ratio": 3.0 } }
+  ]
+}
+'@ -replace "`r`n", "`n"
+            $repo = Join-Path $TestDrive 'situations'
+            $file = New-IncidentRepo -Root $repo -RelPath 'taxonomy/Origin/situations.json' -Content $sit
+            $env:AI_TRIAD_DATA_ROOT = $repo
+            $env:AI_TRIAD_DATA_WRITE_GUARD = 'Block'
+
+            # Concurrent uncommitted node add (grouped replacement — build it first).
+            $insert = '"nodes": [' + "`n    { `"id`": `"sit-477`", `"label`": `"Concurrent`" },"
+            $raw = [System.IO.File]::ReadAllText($file).Replace('"nodes": [', $insert)
+            [System.IO.File]::WriteAllText($file, $raw, (New-Object System.Text.UTF8Encoding $false))
+
+            InModuleScope AITriad -Parameters @{ F = $file } {
+                param($F)
+                { Assert-DataWriteAllowed -Path $F } | Should -Throw -ExpectedMessage '*uncommitted changes*'
+            }
+            (Get-Diff -Root $repo) | Should -Match 'sit-477'
+        }
+    }
+}

--- a/tests/DataWriteSinkGuard.Tests.ps1
+++ b/tests/DataWriteSinkGuard.Tests.ps1
@@ -1,0 +1,162 @@
+# Tag: summary (t/2902)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Data-write sink guard (t/2902 Part 2) — the load-bearing gate that keeps the
+    dirty-tree-sweep class CLOSED as the system grows.
+.DESCRIPTION
+    Modeled on lib/edges/edgesWriterGuard.test.ts. Every whole-file write of an
+    ai-triad-data file MUST funnel through a guarded sink so the dirty-tree-sweep
+    guard (Assert-DataWriteAllowed / Assert-CleanDataTree, or Python
+    assert_clean_data_tree) runs before disk. This gate scans scripts/ and FAILS
+    when a source file writes a data path with a RAW sink
+    ([IO.File]::WriteAllText/Move, Move-Item, Set-Content/Add-Content, Out-File;
+    Python write_text/json.dump) WITHOUT referencing a sanctioned guard/sink —
+    catching a NEW writer that reintroduces the sweep, even one every per-writer
+    test would miss (the coverage-tracks-growth property per-callsite wiring can't give).
+
+    Noisy-over-silent: a legitimate non-data raw writer that trips the heuristic is
+    silenced with an EXEMPT_FILES entry + a one-line reason (co-located here so the
+    exemption travels with the gate).
+#>
+
+BeforeAll {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+    # Trees that can contain data-repo writers.
+    $script:ScanDirs   = @('scripts')
+    $script:SourceExts = @('.ps1', '.psm1', '.py')
+    $script:SkipDirs   = @('archive', '.worktrees', 'dist', 'node_modules', '.git',
+                           '.claude', 'Project-Template', 'TalmudicDebate', 'CuiTests', 'en-US')
+
+    # Files allowed to call a raw sink while touching data — each with its reason.
+    # Paths are repo-relative, forward slashes.
+    $script:ExemptFiles = @{
+        # The guarded sinks THEMSELVES (they implement the write + call the guard).
+        'scripts/AITriad/Private/Write-Utf8NoBom.ps1'      = 'the content-string sink (calls the guard, then Set-Content)'
+        'scripts/AITriad/Private/Write-EdgesFile.ps1'      = 'the edges serializer (delegates to Write-Utf8NoBom)'
+        'scripts/AITriad/Private/Assert-DataWriteAllowed.ps1' = 'the guard itself'
+        'scripts/AITriad/Public/Assert-CleanDataTree.ps1'  = 'the guard itself'
+        'scripts/data_tree_guard.py'                       = 'the Python guard itself'
+
+        # Legitimate NON-data / regenerate-fresh / new-output writers that reference a
+        # data token (so they read data) but do NOT rewrite a data-of-record file in
+        # place — verified during t/2902 Part 2. Each is a genuine exception, not a
+        # sweep risk.
+        'scripts/embed_taxonomy.py'                        = 'regenerates embeddings.json fresh from taxonomy nodes + writes a similarity cache + stdout dumps (not a read-mutate round-trip of the same file)'
+        'scripts/evaluate_embeddings.py'                   = 'json.dump to stdout / report only — no data-file write-back'
+        'scripts/generate_corpus.py'                       = 'stdout dumps + NEW corpus/index/embedding exports (fresh generation, not read-mutate)'
+        'scripts/migrate-t1583-tier-conversion.ps1'        = 'one-shot migration script'
+        'scripts/AITriad/Public/Compare-Taxonomy.ps1'      = 'writes an HTML diff report to a temp path (non-data output)'
+        'scripts/AITriad/Public/Export-AggregatedCruxes.ps1' = 'writes a NEW aggregated-cruxes export file (not an in-place rewrite)'
+        'scripts/AITriad/Public/Get-TaxonomySnapshot.ps1'  = 'writes a NEW snapshot-meta.json in the snapshot output dir'
+        'scripts/AITriad/Public/Invoke-AITDebate.ps1'      = 'writes debate config to a GetTempFileName() temp (non-data)'
+        'scripts/AITriad/Public/New-OpEd.ps1'              = 'writes op-ed Markdown output (new file, non-data-of-record)'
+        'scripts/AITriad/Public/New-SyntheticCorpus.ps1'   = 'append-checkpoint + fresh corpus generation + NEW metadata (not a whole-file data rewrite)'
+        'scripts/AITriad/Public/Test-DebatePersistence.ps1' = 'writes a random persist-probe .tmp (test probe, non-data)'
+    }
+
+    # A data-of-record path token (basename or data-dir accessor). Kept specific so
+    # non-data outputs (reports/PDF/config/snapshots) do not trip the gate.
+    $script:DataToken = '(?<![\w-])(?:situations|edges|policy_actions|embeddings|entities|organizations|organization_edges|conflicts)\.json|\.debate-index\.json|\.summarise-queue\.json|Get-(?:Summaries|Taxonomy|Situations|Conflicts|Debates|Sources|Data)(?:Dir|Root)\b|\bsumm_dir\b|\btax_dir\b|taxonomy[\\/]Origin'
+
+    # Raw write sinks by language.
+    $script:PsSink = '\[(?:System\.)?IO\.File\]::(?:WriteAllText|WriteAllLines|AppendAllText|Move)\b|\bMove-Item\b|\bSet-Content\b|\bAdd-Content\b|\bOut-File\b'
+    $script:PySink = '\.write_text\s*\(|\bjson\.dump\s*\('
+
+    # Sanctioned funnels — a file that references one routes its data writes through the guard.
+    $script:PsSanctioned = 'Write-Utf8NoBom|Write-EdgesFile|Assert-DataWriteAllowed|Assert-CleanDataTree'
+    $script:PySanctioned = 'assert_clean_data_tree|is_data_tree_clean'
+
+    function Test-SourceContent {
+        <# Returns the sink line numbers that are VIOLATIONS for one file's content. #>
+        param([string]$Content, [bool]$IsPython)
+        $sink       = if ($IsPython) { $script:PySink } else { $script:PsSink }
+        $sanctioned = if ($IsPython) { $script:PySanctioned } else { $script:PsSanctioned }
+
+        if ($Content -notmatch $script:DataToken) { return @() }   # not a data writer
+        if ($Content -match $sanctioned) { return @() }            # funnels through the guard
+        $violations = @()
+        $lines = $Content -split "`n"
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match $sink) { $violations += ($i + 1) }
+        }
+        return $violations
+    }
+
+    function Get-DataWriteViolations {
+        $viol = @()
+        $reached = @()
+        foreach ($d in $script:ScanDirs) {
+            $root = Join-Path $RepoRoot $d
+            if (-not (Test-Path $root)) { continue }
+            $files = Get-ChildItem -Path $root -Recurse -File | Where-Object {
+                $ext = $_.Extension.ToLower()
+                if ($script:SourceExts -notcontains $ext) { return $false }
+                if ($_.Name -match '\.Tests\.ps1$') { return $false }
+                if ($_.Name -match '^test_.*\.py$') { return $false }
+                $rel = $_.FullName.Substring($RepoRoot.Length + 1) -replace '\\', '/'
+                foreach ($sd in $script:SkipDirs) { if ($rel -match "(^|/)$([regex]::Escape($sd))(/|$)") { return $false } }
+                return $true
+            }
+            foreach ($f in $files) {
+                $rel = $f.FullName.Substring($RepoRoot.Length + 1) -replace '\\', '/'
+                if ($script:ExemptFiles.ContainsKey($rel)) { continue }
+                $content = Get-Content -Raw -Path $f.FullName
+                if (-not $content) { continue }
+                $isPy = $f.Extension -ieq '.py'
+                # positive control: a file that funnels a data write through the guard
+                $san = if ($isPy) { $script:PySanctioned } else { $script:PsSanctioned }
+                if (($content -match $script:DataToken) -and ($content -match $san)) { $reached += $rel }
+                $bad = Test-SourceContent -Content $content -IsPython $isPy
+                foreach ($ln in $bad) { $viol += [PSCustomObject]@{ File = $rel; Line = $ln } }
+            }
+        }
+        return [PSCustomObject]@{ Violations = $viol; Reached = $reached }
+    }
+}
+
+Describe 'Data-write sink guard (t/2902)' -Tag 'summary' {
+
+    It 'no source file writes a data path with a raw sink outside the guarded funnel' {
+        $result = Get-DataWriteViolations
+        $report = ($result.Violations | ForEach-Object { "  $($_.File):$($_.Line)" }) -join "`n"
+        $result.Violations | Should -BeNullOrEmpty -Because @"
+Found data-repo write(s) that bypass the guarded sink:
+$report
+
+Every whole-file write of an ai-triad-data file MUST funnel through the dirty-tree-sweep
+guard. Fix: route the write through Write-Utf8NoBom / Write-EdgesFile (PowerShell) or call
+Assert-DataWriteAllowed (PS) / assert_clean_data_tree (Python) immediately before the raw
+sink. If this is a genuine NON-data write, add the file to `ExemptFiles` in this test with a
+one-line reason. (t/2902; mirrors lib/edges/edgesWriterGuard.test.ts.)
+"@
+    }
+
+    It 'reaches known guarded data writers (guards against a vacuous pass)' {
+        $result = Get-DataWriteViolations
+        @($result.Reached).Count | Should -BeGreaterThan 0
+    }
+
+    It 'the detector fires on a bypassing writer and passes a compliant one (both arms)' {
+        # Bypassing: data token + raw sink, no sanctioned funnel.
+        $bypassPs = '$p = Get-SummariesDir; [System.IO.File]::WriteAllText($p, $json)'
+        (Test-SourceContent -Content $bypassPs -IsPython $false) | Should -Not -BeNullOrEmpty
+        $bypassPy = "data = json.loads(open(summ_dir).read())`njson.dump(data, open(fpath,'w'))"
+        (Test-SourceContent -Content $bypassPy -IsPython $true) | Should -Not -BeNullOrEmpty
+
+        # Compliant: same write, but the file references the guard.
+        $okPs = 'Assert-DataWriteAllowed -Path $p; $p = Get-SummariesDir; [System.IO.File]::WriteAllText($p, $json)'
+        (Test-SourceContent -Content $okPs -IsPython $false) | Should -BeNullOrEmpty
+        $okPy = "from data_tree_guard import assert_clean_data_tree`nassert_clean_data_tree(fpath)`njson.dump(data, open(fpath,'w'))"
+        (Test-SourceContent -Content $okPy -IsPython $true) | Should -BeNullOrEmpty
+
+        # Non-data raw write is ignored (no data token).
+        $nonData = 'Set-Content -Path $reportPath -Value $html'
+        (Test-SourceContent -Content $nonData -IsPython $false) | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## t/2902 Part 2 — centralize the dirty-tree-sweep guard at the write sinks + detection gate

**DRAFT — gated on Main (TL) Gate Verification** (t/2902#10 conditions). Part 1 (guard cmdlet) merged as #1366; this realizes the prevention.

### Approach (TL's centralize decision, t/2902#10)
Guard the **shared write sinks**, not 40 callsites. Per-**file**-dirty semantic (never whole-tree — the data tree is perpetually dirty). Warn-first promotion. A **detection gate** keeps the class closed as the system grows.

### What's guarded
- **Guard core** `Private/Assert-DataWriteAllowed.ps1` — per-file clean-vs-HEAD (delegates to Part-1 `Assert-CleanDataTree`), **data-root-scoped** via `Get-DataRoot` (non-data outputs — reports/PDF/config/snapshots — never guarded), modes `Warn|Block|Off` via `$env:AI_TRIAD_DATA_WRITE_GUARD` (**default Warn**), `-AllowDirty` sequential-rewriter opt-out.
- **Content-string sink** `Write-Utf8NoBom` funnels every write through the guard → auto-covers ~28 writers incl. the sit-477 `Repair-*` path + edges (via `Write-EdgesFile`). Part-1 `-RequireCleanTree` kept as an explicit hard-block.
- **Atomic/`WriteAllText`+`Move` sinks & raw `Set-Content` data writers** call the guard at the sink: situations.json (`Invoke-DisagreementTypeBackfill`, `Invoke-CcToSitMigration`), stance (`Invoke-OrgStanceExtraction`), entities, organizations, POV taxonomy (`Repair-Pov*`, `Invoke-{Aphorism,Vernacular,BDIWeight}Batch`, `Set-TaxonomyHierarchy`), node-testing record, debate index, synthetic corpus.
- **Python re-writers** call `assert_clean_data_tree` (new `scripts/data_tree_guard.py`): `reprocess_taxonomy_vocabulary`, `backfill_taxonomy_mappings`, `enrich_conflicts_qbaf`, `consolidate_conflicts`, `build_sense_embeddings`.

### Detection gate (the load-bearing deliverable)
`tests/DataWriteSinkGuard.Tests.ps1` — mirrors `lib/edges/edgesWriterGuard.test.ts`. FAILS if any source writes a data path with a raw sink outside the guarded funnel, so writer #43 can't silently reintroduce the sweep. Documented EXEMPT list (non-data/regenerate-fresh writers) + positive control + synthetic both-arms self-check. It already earned its keep — surfaced 12 unwired data-writers using raw `Set-Content` that the initial atomic-sink sweep missed.

### Verification
- Guard both-arms (Warn/Block/Off/AllowDirty/data-scoping + `Write-Utf8NoBom` routing) — 7/7.
- Detection gate — 3/3 (real-tree scan clean + positive control + synthetic both-arms).
- Python both-arms — 5/5; all wired `.py` compile.
- Full suite (real data root): **1386 passed, 2 failed** — the 2 are pre-existing & env-gated, identical to Part 1's pattern and outside this diff (`Invoke-AIApi` xai-grok-4-6 *live* round-trip needs `XAI_API_KEY`; `situations` live-data-count baseline — both green/skipped in CI).

### Gate promotion (t/2902 cond. 4)
Ships **Warn-first**. After ≥1 clean cycle with no false-fire on legitimate sequential/dirty-target rewrites, promote `$env:AI_TRIAD_DATA_WRITE_GUARD` to `Block`. `-AllowDirty` is the documented opt-out for a writer that intentionally rewrites a target left dirty by a prior pass.

CL: looping you for the situation/stance/taxonomy sink fixtures. AGENTS.md discipline line → PI (separate).

Ticket: t/2902. Design: t/2902#10 (TL centralize decision), realization t/2902#11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
