### PR TITLE
feat(server): embedding load-shed — concurrency cap + event-loop-delay backstop, warn-first (t/2905)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
@@ -6,12 +6,14 @@
 // and the load snapshot. The counter is the same one the t/2905 concurrency cap
 // will read, so its increment/decrement/floor invariants are load-bearing.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   beginEmbeddingCompute,
   endEmbeddingCompute,
   inFlightEmbeddingComputes,
   embeddingLoadSnapshot,
+  embeddingLoadShedMode,
+  evaluateEmbeddingLoadShed,
 } from '../embeddingsLoad.js';
 
 describe('embeddingsLoad (t/2904)', () => {
@@ -51,5 +53,67 @@ describe('embeddingsLoad (t/2904)', () => {
     } finally {
       endEmbeddingCompute();
     }
+  });
+});
+
+describe('embeddingsLoad load-shed (t/2905)', () => {
+  const ENV_KEYS = ['EMBEDDINGS_LOAD_SHED_MODE', 'EMBEDDINGS_MAX_CONCURRENT', 'EMBEDDINGS_LOOP_SHED_MS', 'EMBEDDINGS_RETRY_AFTER_MS'];
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+    while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
+  });
+
+  it('mode defaults to warn (warn-first Gate Promotion)', () => {
+    expect(embeddingLoadShedMode()).toBe('warn');
+  });
+
+  it('mode reads EMBEDDINGS_LOAD_SHED_MODE (block|off, case-insensitive), else warn', () => {
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'block';    expect(embeddingLoadShedMode()).toBe('block');
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'OFF';      expect(embeddingLoadShedMode()).toBe('off');
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'nonsense'; expect(embeddingLoadShedMode()).toBe('warn');
+  });
+
+  it('BLOCK arm: at the concurrency cap → shed, mode=block, reason=concurrency', () => {
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'block';
+    process.env.EMBEDDINGS_MAX_CONCURRENT = '2';
+    while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
+    beginEmbeddingCompute();
+    beginEmbeddingCompute(); // in-flight = 2 = cap
+    const d = evaluateEmbeddingLoadShed();
+    expect(d.shed).toBe(true);
+    expect(d.mode).toBe('block');
+    expect(d.reason).toBe('concurrency');
+    expect(d.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('WARN arm: at the cap → shed=true but mode=warn (route warns + proceeds)', () => {
+    process.env.EMBEDDINGS_MAX_CONCURRENT = '2'; // mode defaults warn
+    while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
+    beginEmbeddingCompute();
+    beginEmbeddingCompute();
+    const d = evaluateEmbeddingLoadShed();
+    expect(d.shed).toBe(true);
+    expect(d.mode).toBe('warn');
+  });
+
+  it('PASS arm: under the cap (loop signal disabled) → no shed, no reason', () => {
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'block';
+    process.env.EMBEDDINGS_MAX_CONCURRENT = '3';
+    process.env.EMBEDDINGS_LOOP_SHED_MS = '100000'; // rule out an incidental loop-delay trip
+    while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
+    beginEmbeddingCompute(); // in-flight = 1 < cap 3
+    const d = evaluateEmbeddingLoadShed();
+    expect(d.shed).toBe(false);
+    expect(d.reason).toBeUndefined();
+  });
+
+  it('OFF mode never sheds even over the cap', () => {
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'off';
+    process.env.EMBEDDINGS_MAX_CONCURRENT = '1';
+    while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
+    beginEmbeddingCompute();
+    beginEmbeddingCompute(); // in-flight = 2 > cap 1
+    expect(evaluateEmbeddingLoadShed().shed).toBe(false);
   });
 });

--- a/taxonomy-editor/src/server/embeddingsLoad.ts
+++ b/taxonomy-editor/src/server/embeddingsLoad.ts
@@ -70,3 +70,86 @@ export function embeddingLoadSnapshot(): EmbeddingLoadSnapshot {
     in_flight_embedding_computes: inFlight,
   };
 }
+
+// ── t/2905: load-shed decision (concurrency cap + event-loop-delay backstop) ──
+//
+// The primary fix for the liveness-probe SIGKILL: bound the peak SIMULTANEOUS
+// embedding load so V8 GC can't thrash the event loop into a missed health check.
+// Two signals, either trips the shed:
+//   - in-flight embedding-compute count >= a concurrency cap (the trigger was 3
+//     parallel 702-item computes), OR
+//   - mean event-loop delay > a threshold (the DIRECT pre-liveness-miss signal,
+//     robust regardless of count — the mechanism this incident actually hit).
+//
+// Gate promotion (warn-first): ships in WARN mode — the route LOGS "would shed"
+// but proceeds, so the real concurrency + loop-delay distribution can be observed
+// (via the t/2904 snapshot logs) and the cap/threshold tuned from data BEFORE
+// promotion to BLOCK (503). Mode via EMBEDDINGS_LOAD_SHED_MODE = warn|block|off.
+
+export type LoadShedMode = 'warn' | 'block' | 'off';
+
+function intFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Resolve the load-shed mode: EMBEDDINGS_LOAD_SHED_MODE = warn|block|off (default warn). */
+export function embeddingLoadShedMode(): LoadShedMode {
+  const raw = (process.env.EMBEDDINGS_LOAD_SHED_MODE ?? '').trim().toLowerCase();
+  if (raw === 'block') return 'block';
+  if (raw === 'off') return 'off';
+  return 'warn'; // warn-first default (Gate Promotion)
+}
+
+export interface LoadShedDecision {
+  /** True when the current load exceeds a shed threshold. */
+  shed: boolean;
+  /** Active mode. In 'warn' the caller logs and proceeds; in 'block' it 503s. */
+  mode: LoadShedMode;
+  /** Which signal tripped (for the log / response). */
+  reason?: 'concurrency' | 'event_loop_delay';
+  /** Suggested Retry-After for a 503, in ms. */
+  retryAfterMs: number;
+  /** Signals at decision time (for the log). */
+  in_flight: number;
+  event_loop_delay_mean_ms: number;
+}
+
+/**
+ * Decide whether to shed a NEW embedding compute. Call at route entry BEFORE
+ * accepting the compute (so `in_flight` is the count of OTHER computes running).
+ * Env-tunable (warn-first):
+ *   EMBEDDINGS_MAX_CONCURRENT  (default 2)   — shed when in-flight >= this.
+ *   EMBEDDINGS_LOOP_SHED_MS    (default 250) — shed when mean loop delay > this.
+ *   EMBEDDINGS_RETRY_AFTER_MS  (default 2000)
+ *   EMBEDDINGS_LOAD_SHED_MODE  (default warn)
+ * Defaults are conservative starting points; tune from the t/2904 curve before
+ * promoting to block.
+ */
+export function evaluateEmbeddingLoadShed(): LoadShedDecision {
+  const mode = embeddingLoadShedMode();
+  const cap = intFromEnv('EMBEDDINGS_MAX_CONCURRENT', 2);
+  const loopShedMs = intFromEnv('EMBEDDINGS_LOOP_SHED_MS', 250);
+  const retryAfterMs = intFromEnv('EMBEDDINGS_RETRY_AFTER_MS', 2000);
+
+  const d = getLoopDelay();
+  const loopMeanMs = Number.isFinite(d.mean) ? d.mean / NS_PER_MS : 0;
+
+  let shed = false;
+  let reason: LoadShedDecision['reason'];
+  if (mode !== 'off') {
+    if (inFlight >= cap) { shed = true; reason = 'concurrency'; }
+    else if (loopMeanMs > loopShedMs) { shed = true; reason = 'event_loop_delay'; }
+  }
+
+  return {
+    shed,
+    mode,
+    reason,
+    retryAfterMs,
+    in_flight: inFlight,
+    event_loop_delay_mean_ms: Math.round(loopMeanMs * 10) / 10,
+  };
+}

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -29,7 +29,7 @@ import * as rateLimiter from '../security/rateLimiter.js';
 import * as ai from '../ai/aiBackends.js';
 import { resolveGenerationContext, enforceBackendAllowed } from './generationContext.js';
 import * as fileIO from '../storage/fileIO.js';
-import { beginEmbeddingCompute, endEmbeddingCompute, embeddingLoadSnapshot } from '../embeddingsLoad.js';
+import { beginEmbeddingCompute, endEmbeddingCompute, embeddingLoadSnapshot, evaluateEmbeddingLoadShed } from '../embeddingsLoad.js';
 
 // Pure mirror of the server.ts parseCookies helper (used by the logout /
 // fresh-login handlers). Depends only on the request headers; holds no state.
@@ -543,6 +543,21 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
         { ...embeddingLoadSnapshot(), item_count: Array.isArray(texts) ? texts.length : 0 },
         'embeddings.compute: entry',
       );
+      // t/2905: load-shed to prevent the GC event-loop freeze that SIGKILL'd the
+      // container. Sheds when in-flight computes hit the concurrency cap OR the
+      // event-loop delay is already high. Warn-first by default (logs + proceeds);
+      // EMBEDDINGS_LOAD_SHED_MODE=block returns a typed 503 so the client circuit
+      // breaker retries instead of tripping on an opaque crash.
+      const shedDecision = evaluateEmbeddingLoadShed();
+      if (shedDecision.shed) {
+        if (shedDecision.mode === 'block') {
+          log.api.warn({ ...embeddingLoadSnapshot(), reason: shedDecision.reason }, 'embeddings.compute: load-shed 503');
+          res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': String(Math.ceil(shedDecision.retryAfterMs / 1000)) });
+          res.end(JSON.stringify({ error: 'Embedding service is at capacity; retry shortly.', retryable: true, reason: shedDecision.reason, retryAfterMs: shedDecision.retryAfterMs }));
+          return;
+        }
+        log.api.warn({ ...embeddingLoadSnapshot(), reason: shedDecision.reason }, 'embeddings.compute: WOULD load-shed (warn-first; not blocking)');
+      }
       beginEmbeddingCompute();
       try {
         const vectors = await ai.computeEmbeddings(texts, ids, gate.key);


### PR DESCRIPTION
## What
The **primary fix** for the 2026-08-21 embeddings crash (t/2905): a load-shed on `/api/embeddings/compute` that bounds peak simultaneous embedding load.

## Why
The crash was a **liveness-probe SIGKILL** — 3 concurrent 702-item computes drove V8 GC to freeze the event loop past ACA's liveness deadline (not an OOM; RSS ~53% of limit). RCA: t/2905#4.

## Change
- `embeddingsLoad.ts` → `evaluateEmbeddingLoadShed()`: sheds a new compute when **in-flight computes ≥ a concurrency cap** (the trigger) OR **mean event-loop delay > a threshold** (the direct pre-liveness-miss signal). Built on the t/2904 in-flight counter + event-loop monitor.
- `/api/embeddings/compute`: applies the decision. **Warn-first** default (`EMBEDDINGS_LOAD_SHED_MODE=warn` logs "would shed" + proceeds — zero behavioral change); `=block` returns a **typed 503 + Retry-After** so the client circuit breaker retries instead of tripping on an opaque crash. Env-tunable cap/threshold (`EMBEDDINGS_MAX_CONCURRENT`=2, `EMBEDDINGS_LOOP_SHED_MS`=250, `EMBEDDINGS_RETRY_AFTER_MS`=2000).
- Both-arms tests on the decision: block→shed(reason=concurrency), warn→shed-but-mode-warn, under-cap→pass, off→never.

## Ships safe
**Warn-first** → no behavioral change on merge (observe the real cap/loop-delay distribution via the t/2904 logs, then tune + promote to block per Gate Promotion).

## Follow-ups (t/2905#4, separate)
Chunk-and-yield inside a single large compute; worker-thread offload (phase 2).

## Review routing
**Draft — routed to Quality (Technical Lead) for the both-arms GV.** This is TL's own ticket + design (t/2905#4), so I'm the implementer and can't self-GV a gate; Quality reviews the shed logic + tests before merge. Un-draft on Quality approval + CI green.

Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>
Co-Authored-By: Diagnostics (Orca) <main.operations-diagnostics@ai-triad-research.orca.local>