### PR TITLE
fix(oped): accept url as alternative source in create-guard (t/2908)

### DIFF
--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -169,12 +169,13 @@ export function registerOpEdHandlers(): void {
   }) => {
     const { topic, url, params, voices } = payload;
 
-    if (!topic?.trim() || !voices?.length) {
+    // FromUrl mode sends url with an empty topic — accept url as an alternative source (t/2908).
+    if ((!topic?.trim() && !url?.trim()) || !voices?.length) {
       throw new ActionableError({
         goal: 'Create op-ed set',
-        problem: 'topic and at least one voice are required',
+        problem: 'a topic or a web-page URL, and at least one voice, are required',
         location: 'opedHandlers create-oped-set',
-        nextSteps: ['Provide a topic and select at least one voice'],
+        nextSteps: ['Provide a topic or a web-page URL', 'Select at least one voice'],
       });
     }
 


### PR DESCRIPTION
## Summary
Urgent regression fix. `create-oped-set` at `opedHandlers.ts:172` guarded on `!topic?.trim()`, but in FromUrl mode `topic` is empty and `url` carries the source — so every From-web-page create threw `"topic and at least one voice are required"` before any AI work. t/2899 added `url` to the payload but never updated this guard.

FromUrl is the only claims-extracting path, so this blocked the entire t/2897 verification chain (4th-recurrence claims verification).

## Fix
Guard now throws only when **both** topic and url are empty (or no voices); error message/next-steps updated to reflect url as a valid source.

```ts
if ((!topic?.trim() && !url?.trim()) || !voices?.length) {
```

## Verification
- `tsc -p tsconfig.main.json` clean (exit 0)
- oped main-process tests pass (exit 0)
- Full `npm run verify`: 7795 passed; the 80 failures are the **local-only** undici major-version skew (local Node 7.x vs required Node 22.x — CI runs node:22.23.2 where they pass), all in unrelated GitHubAPIBackend storage tests. CI on Node 22 is the authoritative full-verify here.

Parent: t/2897. Fixes t/2908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)