### PR TITLE
chore(oped): extract create-payload validation to a pure, testable helper (t/2910)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/opedValidation.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedValidation.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression coverage for the create-oped-set guard (t/2908 / t/2910). The handler is
+// electron-coupled, so the validation lives in a pure helper that this test exercises
+// directly. The load-bearing case is url-only: FromUrl mode sends an empty topic, and
+// the pre-t/2908 guard rejected it, blocking all From-web-page creates.
+
+import { describe, it, expect } from 'vitest';
+import { ActionableError } from '../../../../lib/debate/errors.js';
+import { validateCreateOpEdPayload } from '../ipc/opedValidation.js';
+
+const voices = ['accelerationist'];
+
+describe('validateCreateOpEdPayload (t/2908/t/2910)', () => {
+  it('accepts a topic-only payload', () => {
+    expect(validateCreateOpEdPayload({ topic: 'Mandatory audits', voices })).toBeNull();
+  });
+
+  it('accepts a url-only payload (empty topic — the FromUrl regression case)', () => {
+    expect(validateCreateOpEdPayload({ topic: '', url: 'https://example.com/piece', voices })).toBeNull();
+  });
+
+  it('rejects when both topic and url are blank', () => {
+    const err = validateCreateOpEdPayload({ topic: '   ', url: '', voices });
+    expect(err).toBeInstanceOf(ActionableError);
+  });
+
+  it('rejects when no voices are selected even with a topic', () => {
+    expect(validateCreateOpEdPayload({ topic: 'Mandatory audits', voices: [] })).toBeInstanceOf(ActionableError);
+  });
+
+  it('rejects a whitespace-only topic with no url', () => {
+    expect(validateCreateOpEdPayload({ topic: '   ', voices })).toBeInstanceOf(ActionableError);
+  });
+
+  it('treats a whitespace-only url as no source', () => {
+    expect(validateCreateOpEdPayload({ topic: '', url: '   ', voices })).toBeInstanceOf(ActionableError);
+  });
+
+  it('returns an actionable error with next steps', () => {
+    const err = validateCreateOpEdPayload({ voices: [] });
+    expect(err?.nextSteps.length).toBeGreaterThan(0);
+    expect(err?.problem).toMatch(/topic or a web-page URL/i);
+  });
+});

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -22,6 +22,7 @@ import type { PovKey } from '../../../../lib/oped/types.js';
 import { generateOpEdSet } from '../../../../lib/oped/generate.js';
 import type { GenerateOpEdRequest, OpEdGeneratorDeps } from '../../../../lib/oped/generate.js';
 import { makeElectronAIAdapter } from '../electronAIAdapter.js';
+import { validateCreateOpEdPayload } from './opedValidation.js';
 
 // Shared prompts dir: op-ed-*.prompt artifacts (relocated to lib/oped/prompts by t/2609).
 const PROMPTS_DIR = path.join(PROJECT_ROOT, 'lib', 'oped', 'prompts');
@@ -169,15 +170,10 @@ export function registerOpEdHandlers(): void {
   }) => {
     const { topic, url, params, voices } = payload;
 
-    // FromUrl mode sends url with an empty topic — accept url as an alternative source (t/2908).
-    if ((!topic?.trim() && !url?.trim()) || !voices?.length) {
-      throw new ActionableError({
-        goal: 'Create op-ed set',
-        problem: 'a topic or a web-page URL, and at least one voice, are required',
-        location: 'opedHandlers create-oped-set',
-        nextSteps: ['Provide a topic or a web-page URL', 'Select at least one voice'],
-      });
-    }
+    // A create needs a source (topic OR url — FromUrl sends an empty topic) plus a voice.
+    // Guard extracted to a pure, unit-tested validator (t/2910; regression fixed in t/2908).
+    const validationError = validateCreateOpEdPayload({ topic, url, voices });
+    if (validationError) throw validationError;
 
     const setId = crypto.randomUUID();
     const createdAt = new Date().toISOString();

--- a/taxonomy-editor/src/main/ipc/opedValidation.ts
+++ b/taxonomy-editor/src/main/ipc/opedValidation.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Pure validation for the create-oped-set payload, extracted from opedHandlers so it
+// can be unit-tested without the electron coupling of the IPC handler (t/2910).
+// Root cause it guards against: a create needs a *source* — a topic OR a web-page URL
+// (FromUrl mode sends an empty topic) — plus at least one voice. The inline guard once
+// checked topic only, which rejected every FromUrl create (t/2908 regression).
+
+import { ActionableError } from '../../../../lib/debate/errors.js';
+
+export interface CreateOpEdValidationInput {
+  topic?: string;
+  url?: string;
+  voices?: readonly unknown[];
+}
+
+/**
+ * Validate a create-oped-set payload. Returns an {@link ActionableError} to throw when
+ * invalid, or `null` when the payload is acceptable. Valid iff a non-blank source
+ * (topic or url) is present AND at least one voice is selected.
+ */
+export function validateCreateOpEdPayload(input: CreateOpEdValidationInput): ActionableError | null {
+  const { topic, url, voices } = input;
+  if ((!topic?.trim() && !url?.trim()) || !voices?.length) {
+    return new ActionableError({
+      goal: 'Create op-ed set',
+      problem: 'a topic or a web-page URL, and at least one voice, are required',
+      location: 'opedHandlers create-oped-set',
+      nextSteps: ['Provide a topic or a web-page URL', 'Select at least one voice'],
+    });
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
Prevention follow-up for the t/2908 FromUrl regression. The `create-oped-set` guard lived inline in the electron-coupled IPC handler, so it had no unit test — which is how the regression shipped uncaught.

- New `taxonomy-editor/src/main/ipc/opedValidation.ts` — pure `validateCreateOpEdPayload({topic,url,voices})` returning an `ActionableError` or `null`. No electron import.
- `opedHandlers.ts` now delegates to it (identical logic; no behavioral change).
- New `opedValidation.test.ts` (7 cases): url-only passes (the regression case), topic-only passes, both-blank fails, no-voices fails, whitespace-only source fails, error is actionable.

Self-cert: `/add-test` + `/trivial-change` (single-scope, pure extraction, no new cross-role interface or schema).

## Verification
- `tsc -p tsconfig.main.json` clean (exit 0)
- new test 7/7 pass
- (Full `npm run verify` is authoritative on CI Node 22 — local Node 7.x hits the known undici-skew in unrelated storage tests only.)

Parent: t/2897. Relates: t/2908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)