### PR TITLE
fix(oped): supply SOURCE_CLAIMS to PS grounding-reflection render (t/2911)

### DIFF
--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -505,6 +505,13 @@ function New-OpEd {
             $ReflPrompt = Get-Prompt -Name 'op-ed-grounding-reflection' -PromptsDir $OPedPromptsDir -Replacements @{
                 OPED_BODY      = $Body
                 GROUNDING_LIST = $glb.ToString().TrimEnd()
+                # Mirror generate.ts:291-293 reflection pass: numbered key_claims list,
+                # "(none)" fallback when absent. Without this the shared prompt's
+                # {{SOURCE_CLAIMS}} slot (t/2890) rendered literally on the PS path (t/2911).
+                SOURCE_CLAIMS  = if ($null -ne $SBrief -and $SBrief.PSObject.Properties.Name -contains 'key_claims' -and $null -ne $SBrief.key_claims -and @($SBrief.key_claims).Count -gt 0) {
+                    $ReflClaims = @($SBrief.key_claims)
+                    (0..($ReflClaims.Count - 1) | ForEach-Object { "  $($_ + 1). $($ReflClaims[$_])" }) -join "`n"
+                } else { '(none)' }
             }
             $ReflSchema = @{
                 type       = 'object'

--- a/tests/New-OpEdParity.Tests.ps1
+++ b/tests/New-OpEdParity.Tests.ps1
@@ -207,6 +207,55 @@ process.stdout.write(out);
             Should -Be ($TsUser -replace '\r\n', "`n").TrimEnd()
     }
 
+    # t/2911 regression: the shared grounding-reflection prompt gained a
+    # {{SOURCE_CLAIMS}} slot (t/2890) wired into the TS loader but not the PS
+    # New-OpEd render, so PS shipped the literal placeholder to the model.
+    It 'PS and TS assemble byte-identical grounding-reflection prompt (t/2911)' {
+        if (-not $script:TsxAvailable) { Set-ItResult -Skipped -Because 'tsx not available'; return }
+
+        # PS side — mirror New-OpEd's reflection render keys exactly.
+        $PsRefl = InModuleScope AITriad -Parameters @{ PromptsDir = $script:OPedPromptsDir } {
+            param([string]$PromptsDir)
+            Get-Prompt -Name 'op-ed-grounding-reflection' -PromptsDir $PromptsDir -AllowUnresolved `
+                -Replacements @{
+                    OPED_BODY     = 'PARITY_FIXTURE_BODY paragraph one.'
+                    GROUNDING_LIST = '- [saf-bel-001] (bdi/Belief) AI is dangerous'
+                    SOURCE_CLAIMS = "  1. Audits catch failures early`n  2. Voluntary compliance is insufficient"
+                }
+        }
+
+        $TsCode = @"
+import { readFileSync } from 'fs';
+import { join } from 'path';
+const dir = "$($script:PromptsDirFwd)";
+const tpl = readFileSync(join(dir, 'op-ed-grounding-reflection.prompt'), 'utf-8').trimEnd();
+const vars = {"OPED_BODY":"PARITY_FIXTURE_BODY paragraph one.","GROUNDING_LIST":"- [saf-bel-001] (bdi/Belief) AI is dangerous","SOURCE_CLAIMS":"  1. Audits catch failures early\n  2. Voluntary compliance is insufficient"};
+const out = tpl.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? '');
+process.stdout.write(out);
+"@
+        $TsRefl = & $script:TsxHelper $TsCode
+
+        ($PsRefl -replace '\r\n', "`n").TrimEnd() |
+            Should -Be ($TsRefl -replace '\r\n', "`n").TrimEnd()
+    }
+
+    # Direct symptom guard (no tsx): rendering with the exact keys New-OpEd
+    # supplies must leave ZERO unresolved {{…}} placeholders. Catches a future
+    # shared-prompt placeholder the PS render forgets to fill (the t/2911 class).
+    It 'PS grounding-reflection render leaves no unresolved placeholders (t/2911)' {
+        $Rendered = InModuleScope AITriad -Parameters @{ PromptsDir = $script:OPedPromptsDir } {
+            param([string]$PromptsDir)
+            Get-Prompt -Name 'op-ed-grounding-reflection' -PromptsDir $PromptsDir -AllowUnresolved `
+                -Replacements @{
+                    OPED_BODY      = 'body'
+                    GROUNDING_LIST = '- [saf-bel-001] (bdi/Belief) x'
+                    SOURCE_CLAIMS  = '(none)'
+                }
+        }
+        $Rendered | Should -Not -Match '\{\{[A-Za-z0-9_-]+\}\}' `
+            -Because 'every placeholder in the shared reflection prompt must be supplied by the PS render (t/2911)'
+    }
+
     # Deliberate-divergence proof: confirms the gate is sensitive to PS-side changes.
     It 'Gate fires when PS uses a different POV_LABEL (divergence sensitivity)' {
         $Aligned = InModuleScope AITriad -Parameters @{ PromptsDir = $script:OPedPromptsDir } {


### PR DESCRIPTION
## Summary
`New-OpEd` (the PowerShell op-ed CLI) was sending a **literal `{{SOURCE_CLAIMS}}`** string to the model. t/2890 added a `{{SOURCE_CLAIMS}}` slot to the shared prompt `lib/oped/prompts/op-ed-grounding-reflection.prompt` and wired its substitution into the **TS** loader (`promptLoader.ts`), but the **PowerShell** reflection render was never updated — a cross-path shared-prompt/loader drift.

## Fix
- `New-OpEd.ps1`: supply `SOURCE_CLAIMS` to the reflection `Get-Prompt` render, formatted from `SourceUnderstanding.key_claims` (numbered list, `"(none)"` fallback), mirroring `generate.ts:291-293`.

## Prevention (test)
Added to `New-OpEdParity.Tests.ps1`:
- **Byte-identical PS↔TS reflection-prompt arm** — catches PS/TS divergence on this prompt.
- **No-unresolved-placeholder guard** (no tsx needed) — rendering with the keys `New-OpEd` supplies must leave zero `{{…}}`, catching the whole drift class going forward.

## Verification
- `New-OpEdParity.Tests.ps1`: 8/8 pass.
- OpEd/prompt-touching suites (`New-OpEd`, `New-OpEd.ParamSet`, `New-OpEdParity`, `Get-Prompt`): 39/39 pass.
- `Test-ModuleManifest`: OK (AITriad v0.8.6).

Self-certified under `/trivial-change` + `/add-test` (single-file behavioral fix mirroring an existing proven pattern; no new public API / schema).

Fixes t/2911.

🤖 Generated with [Claude Code](https://claude.com/claude-code)