### PR TITLE
fix(debate-ux): slot-first opening lifecycle — retries reuse one panel (t/2907)

### DIFF
--- a/lib/debate/types/session.ts
+++ b/lib/debate/types/session.ts
@@ -114,6 +114,15 @@ export interface TranscriptEntry {
   model?: string;
   /** True when this turn's brief or plan parse retries were exhausted and degraded gracefully (t/2229). */
   degraded?: boolean;
+  /**
+   * Opening-slot lifecycle (t/2907). Only `opening` entries use these — the slot is
+   * inserted `status:'generating'` when generation begins and mutated in place through
+   * retrying/error/done, so a retry updates one card instead of appending new panels.
+   * Absent on every other entry type and on legacy openings (back-compat).
+   */
+  status?: 'generating' | 'retrying' | 'error' | 'done';
+  /** User-facing message shown inline on the card in the 'retrying'/'error' states (t/2907). */
+  errorMessage?: string;
 }
 
 export type ModelTier = 'basic' | 'advanced';

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateWorkspace.tsx
@@ -635,6 +635,41 @@ function TranscriptEntryRow({
 
   const hairline = computeTranscriptHairline(entry, idx, activeDebate.transcript);
 
+  // Slot-first opening lifecycle (t/2907): a 'generating'/'retrying'/'error' opening
+  // slot renders its state INLINE on the speaker's own card (content is empty until
+  // 'done'), so one card cycles through the states instead of spawning new panels +
+  // system retry toasts. 'done' and legacy openings (no status) fall through to the
+  // normal StatementCard below.
+  if (entry.type === 'opening' && entry.status && entry.status !== 'done') {
+    const isError = entry.status === 'error';
+    const typeLabel = entry.status === 'generating' ? 'thinking…' : entry.status === 'retrying' ? 'retrying…' : 'failed';
+    return (
+      <Fragment>
+        {hairline}
+        <div id={`debate-entry-${entry.id}`} className="debate-entry-wrapper">
+          <div className={`debate-statement debate-generating${isError ? ' debate-slot-error' : ''}`}>
+            <div className="debate-statement-header">
+              <span className="debate-statement-speaker" style={{ color: speakerColor(entry.speaker) || undefined }}>
+                {speakerLabel(entry.speaker)}
+              </span>
+              <span className="debate-statement-type">{typeLabel}</span>
+            </div>
+            {isError ? (
+              <div className="debate-slot-error-message">
+                {entry.errorMessage ?? 'Opening statement failed.'}
+              </div>
+            ) : (
+              <>
+                <StatementProgressIndicator />
+                {entry.errorMessage && <div className="debate-slot-retry-note">{entry.errorMessage}</div>}
+              </>
+            )}
+          </div>
+        </div>
+      </Fragment>
+    );
+  }
+
   const isStatement = entry.type !== 'probing' && entry.type !== 'fact-check';
   const card = entry.type === 'probing'
     ? <ProbingCard key={entry.id} entry={entry} statementId={statementId} />
@@ -695,7 +730,13 @@ function DebateTranscriptColumn({
         />
       ))}
       </div>
-      {debateGenerating && (
+      {/* Global "thinking" card for generation WITHOUT its own slot (clarification,
+          synthesis, cross-respond statements). During opening generation the speaker
+          has an active opening slot that renders its own inline spinner (t/2907), so
+          suppress this one then — otherwise it double-cards. */}
+      {debateGenerating && !activeDebate.transcript.some(
+        e => e.type === 'opening' && e.speaker === debateGenerating && e.status && e.status !== 'done',
+      ) && (
         <div className="debate-statement debate-generating">
           <div className="debate-statement-header">
             <span className="debate-statement-speaker" style={{ color: speakerColor(debateGenerating) || undefined }}>

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/runOpeningStatements.abort.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/runOpeningStatements.abort.test.ts
@@ -46,9 +46,11 @@ describe('runOpeningStatements — superseded run writes no opening (t/2505)', (
     );
     expect(interrupted).toHaveLength(1);
 
-    // …and NO opening is written, and nothing follows the interrupted line (the TL's
-    // negative assertion): the abandoned run does not produce a duplicate/mixed-model opening.
-    expect(transcript.filter((e) => e.type === 'opening')).toHaveLength(0);
+    // …and NO DELIVERED opening is written (the TL's negative assertion): the abandoned
+    // run does not produce a duplicate/mixed-model opening. Under slot-first (t/2907) an
+    // empty 'generating' slot may exist (it gets reused by the fresh run or lives on a
+    // superseded debate) — the real invariant is that no opening with CONTENT lands.
+    expect(transcript.filter((e) => e.type === 'opening' && !!e.content && e.content.trim().length > 0)).toHaveLength(0);
     expect(transcript[transcript.length - 1]).toBe(interrupted[0]);
 
     // Pipeline entered exactly once (aborted on the first speaker; the run bails, no re-loop).

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/slotFirstOpenings.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/slotFirstOpenings.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2907 — slot-first opening lifecycle. A speaker's opening is a SINGLE transcript
+// card that mutates generating→retrying→done/error in place, instead of appending a
+// new card + a `type:'system'` retry toast per attempt. Harness FIRST so its hoisted
+// mocks (runOpeningPipeline, assembleOpeningPipelineResult, …) register before the store.
+import { describe, it, expect, vi } from 'vitest';
+import { makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+import { runOpeningPipeline, assembleOpeningPipelineResult, getOpeningRepairHints } from '@lib/debate/turnPipeline';
+
+type Entry = { id: string; type: string; speaker: string; content: string; status?: string; errorMessage?: string };
+function transcript(): Entry[] {
+  return (useDebateStore.getState().activeDebate?.transcript ?? []) as unknown as Entry[];
+}
+function setActive(session: ReturnType<typeof makeSession>): void {
+  useDebateStore.setState({
+    activeDebate: session as unknown as ReturnType<typeof useDebateStore.getState>['activeDebate'],
+    activeDebateId: session.id,
+  });
+}
+
+describe('upsertTranscriptEntry / updateTranscriptEntry (t/2907 store primitives)', () => {
+  it('upsert inserts one opening slot and is idempotent per speaker (no duplicate)', () => {
+    setActive(makeSession({ phase: 'opening' }));
+    const id1 = useDebateStore.getState().upsertTranscriptEntry({ type: 'opening', speaker: 'skeptic', status: 'generating', content: '', taxonomy_refs: [] });
+    const id2 = useDebateStore.getState().upsertTranscriptEntry({ type: 'opening', speaker: 'skeptic', status: 'generating', content: '', taxonomy_refs: [] });
+    expect(id2).toBe(id1); // same slot returned, not a second card
+    expect(transcript().filter(e => e.type === 'opening' && e.speaker === 'skeptic')).toHaveLength(1);
+  });
+
+  it('update merges a patch into the target entry and preserves the others', () => {
+    setActive(makeSession({ phase: 'opening' }));
+    const id = useDebateStore.getState().upsertTranscriptEntry({ type: 'opening', speaker: 'safetyist', status: 'generating', content: '', taxonomy_refs: [] });
+    useDebateStore.getState().addTranscriptEntry({ type: 'system', speaker: 'system', content: 'unrelated', taxonomy_refs: [] });
+    useDebateStore.getState().updateTranscriptEntry(id, { status: 'done', content: 'the final opening statement' });
+    const slot = transcript().find(e => e.id === id)!;
+    expect(slot.status).toBe('done');
+    expect(slot.content).toBe('the final opening statement');
+    expect(transcript().find(e => e.content === 'unrelated')).toBeTruthy(); // other entry untouched
+  });
+
+  it('update is a no-op when the id is gone (debate switched mid-generation)', () => {
+    setActive(makeSession({ phase: 'opening' }));
+    const before = transcript().length;
+    useDebateStore.getState().updateTranscriptEntry('does-not-exist', { status: 'error' });
+    expect(transcript().length).toBe(before);
+  });
+
+  it('a full generating→retrying→done lifecycle stays ONE card with zero system toasts', () => {
+    setActive(makeSession({ phase: 'opening' }));
+    const id = useDebateStore.getState().upsertTranscriptEntry({ type: 'opening', speaker: 'accelerationist', status: 'generating', content: '', taxonomy_refs: [] });
+    useDebateStore.getState().updateTranscriptEntry(id, { status: 'retrying', errorMessage: 'Accelerationist rate limited — retrying automatically…' });
+    // second attempt reuses the same slot (upsert returns the existing id)
+    expect(useDebateStore.getState().upsertTranscriptEntry({ type: 'opening', speaker: 'accelerationist', status: 'generating', content: '', taxonomy_refs: [] })).toBe(id);
+    useDebateStore.getState().updateTranscriptEntry(id, { status: 'done', errorMessage: undefined, content: 'the accelerationist opening statement' });
+    const openings = transcript().filter(e => e.type === 'opening' && e.speaker === 'accelerationist');
+    expect(openings).toHaveLength(1);
+    expect(openings[0].status).toBe('done');
+    expect(openings[0].errorMessage).toBeUndefined();
+    // No system retry-toast entries accumulated.
+    expect(transcript().filter(e => e.type === 'system')).toHaveLength(0);
+  });
+});
+
+describe('runOpeningStatements slot-first integration (t/2907)', () => {
+  const LONG = 'This is a sufficiently long opening statement that clears the 50-character minimum guard.';
+
+  it('success completes ONE opening slot to status:done with content, no system toast', async () => {
+    vi.mocked(runOpeningPipeline).mockResolvedValue({ stage_diagnostics: [], total_time_ms: 1, draft: {}, topicAlignmentResult: null, qualityGateResult: null } as never);
+    vi.mocked(getOpeningRepairHints).mockReturnValue([]);
+    vi.mocked(assembleOpeningPipelineResult).mockReturnValue({ statement: LONG, taxonomyRefs: [], meta: { policy_refs: [] } } as never);
+    setActive(makeSession({ active_povers: ['skeptic'], phase: 'opening' }));
+
+    await useDebateStore.getState().runOpeningStatements();
+
+    const openings = transcript().filter(e => e.type === 'opening' && e.speaker === 'skeptic');
+    expect(openings).toHaveLength(1);
+    expect(openings[0].status).toBe('done');
+    expect(openings[0].content).toBe(LONG);
+    // No opening-retry system-toast entries.
+    expect(transcript().some(e => e.type === 'system' && /retry|failed to deliver/i.test(e.content))).toBe(false);
+  });
+
+  it('a non-retryable failure settles the speaker slot to status:error inline — no new card, no system toast', async () => {
+    vi.mocked(getOpeningRepairHints).mockReturnValue([]);
+    // A plain 400 is classified non-retryable → the pass ends without a backoff retry.
+    vi.mocked(runOpeningPipeline).mockRejectedValue(Object.assign(new Error('HTTP 400 Bad Request'), { httpStatus: 400 }));
+    setActive(makeSession({ active_povers: ['skeptic'], phase: 'opening' }));
+
+    await useDebateStore.getState().runOpeningStatements();
+
+    const openings = transcript().filter(e => e.type === 'opening' && e.speaker === 'skeptic');
+    expect(openings).toHaveLength(1);              // exactly one card, not a second panel
+    expect(openings[0].status).toBe('error');
+    expect(openings[0].content).toBe('');          // no delivered content
+    expect(openings[0].errorMessage).toBeTruthy(); // friendly message inline on the card
+    // The failure lives on the card, not as a standalone system entry.
+    expect(transcript().some(e => e.type === 'system' && /failed to deliver/i.test(e.content))).toBe(false);
+    // Run-level banner still summarizes the partial failure.
+    expect(useDebateStore.getState().debateError).toBeTruthy();
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -865,13 +865,18 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
       (p) => activeDebate.active_povers.includes(p),
     );
 
-    // Idempotency: collect prior statements from existing openings (supports resume after interruption)
+    // Idempotency: collect prior statements from DELIVERED openings (supports resume
+    // after interruption). Slot-first (t/2907) means a speaker can have an in-progress
+    // opening slot with empty content ('generating'/'retrying'/'error') — those are NOT
+    // delivered and must not suppress (re)generation, so "delivered" requires prose.
+    const isDeliveredOpening = (e: TranscriptEntry): boolean =>
+      e.type === 'opening' && e.speaker !== 'system' && !!e.content && e.content.trim().length > 0;
     const existingOpenings = new Set(
-      activeDebate.transcript.filter(e => e.type === 'opening').map(e => e.speaker),
+      activeDebate.transcript.filter(isDeliveredOpening).map(e => e.speaker),
     );
     const priorStatements: { speaker: string; statement: string }[] = [];
     for (const poverId of aiPovers) {
-      const existing = activeDebate.transcript.find(e => e.type === 'opening' && e.speaker === poverId);
+      const existing = activeDebate.transcript.find(e => isDeliveredOpening(e) && e.speaker === poverId);
       if (existing) {
         const info = POVER_INFO[poverId];
         priorStatements.push({ speaker: info.label, statement: existing.content });
@@ -910,8 +915,8 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
 
     for (const poverId of aiPovers) {
       const freshTranscript = get().activeDebate?.transcript ?? [];
-      if (freshTranscript.some(e => e.type === 'opening' && e.speaker === poverId)) {
-        console.log(`[debate-store] Skipping ${poverId} — already has opening (live check)`);
+      if (freshTranscript.some(e => isDeliveredOpening(e) && e.speaker === poverId)) {
+        console.log(`[debate-store] Skipping ${poverId} — already has a delivered opening (live check)`);
         continue;
       }
       // Skip POVers who already delivered an opening (idempotency after interruption)
@@ -922,6 +927,10 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
 
       set({ debateGenerating: poverId, debateStepStartedAt: Date.now() });
       const info = POVER_INFO[poverId];
+      // Slot-first (t/2907): insert (or reuse) this speaker's opening panel NOW in
+      // 'generating' state, so the transcript shows ONE card that mutates through
+      // retrying/error/done — instead of a fresh card + a system retry-toast per pass.
+      const slotId = get().upsertTranscriptEntry({ type: 'opening', speaker: poverId, status: 'generating', content: '', taxonomy_refs: [] });
 
       try {
         const stageGenerate = makeStageGenerate(set as (partial: Record<string, unknown>) => void, getSpeakerModel(activeDebate, poverId, model));
@@ -1061,9 +1070,12 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         // Serialize source tracking for diagnostics display
         const relevanceSources = serializeNodeSourceMap(ctx.nodeSourceMap, taxonomyRefs);
 
-        addTranscriptEntry({
-          type: 'opening',
-          speaker: poverId,
+        // Slot-first success (t/2907): complete the existing 'generating' slot in place
+        // rather than appending a new entry — one card, no duplicate panel. Clearing
+        // errorMessage wipes any retry note from a prior failed pass.
+        get().updateTranscriptEntry(slotId, {
+          status: 'done',
+          errorMessage: undefined,
           content: statement,
           taxonomy_refs: taxonomyRefs,
           policy_refs: meta.policy_refs,
@@ -1075,7 +1087,9 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
             injection_manifest: ctx.injectionManifest,
           },
         });
-        const lastEntry = get().activeDebate?.transcript.slice(-1)[0];
+        // Key diagnostics/summary/claim-extraction off the SLOT id, not slice(-1):
+        // the slot is not necessarily the last entry under slot-first (t/2907).
+        const lastEntry = get().activeDebate?.transcript.find(e => e.id === slotId);
 
         // Record diagnostics with full stage data
         if (lastEntry) {
@@ -1131,6 +1145,9 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         console.error(`[debate] ${info.label} opening statement failed (status=${httpStatus ?? 'unknown'}, retry=${retryReason}):`, err);
         getGlobalRecorder()?.record({ type: 'system.error', debate_id: activeDebate?.id, component: 'debate-engine', level: 'error', message: `Opening statement failed: ${info.label} (status=${httpStatus ?? 'unknown'})`, data: { retry_reason: retryReason, retryable: isRetryable, retry_pass: openingRetryPass }, error: { name: (err as Error).name ?? 'Error', message: (err as Error).message ?? String(err), stack: (err as Error).stack?.slice(0, 500) } });
         if (isDailyLimitError(err)) {
+          // Terminal for the whole run: settle this speaker's slot to 'error' so its
+          // spinner doesn't stick (t/2907), and keep the run-level system notice + banner.
+          get().updateTranscriptEntry(slotId, { status: 'error', errorMessage: DAILY_LIMIT_MESSAGE });
           addTranscriptEntry({
             type: 'system',
             speaker: 'system',
@@ -1142,14 +1159,13 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
           await saveDebate('runOpeningStatements:dailyLimit');
           return;
         }
-        addTranscriptEntry({
-          type: 'system',
-          speaker: 'system',
-          content: isRetryable
-            ? `${info.label} ${retryReasonLabel(retryReason)} — retrying automatically…`
-            : `${info.label} failed to deliver opening statement: ${mapErrorToUserMessage(err)}`,
-          taxonomy_refs: [],
-        });
+        // Slot-first (t/2907): reflect the failure ON the speaker's own opening card
+        // instead of appending a system toast entry (the transcript-clutter source).
+        // Retryable → 'retrying' with the reason; terminal → 'error' with a friendly
+        // message (t/2906 mapping). One card, mutated in place.
+        get().updateTranscriptEntry(slotId, isRetryable
+          ? { status: 'retrying', errorMessage: `${info.label} ${retryReasonLabel(retryReason)} — retrying automatically…` }
+          : { status: 'error', errorMessage: mapErrorToUserMessage(err) });
         failedSpeakers.push(info.label);
         if (isRetryable) {
           hasRetryableFailure = true;

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -60,6 +60,12 @@ export interface SessionSlice {
   renameDebate: (id: string, newTitle: string) => Promise<void>;
   closeDebate: () => void;
   addTranscriptEntry: (entry: Omit<TranscriptEntry, 'id' | 'timestamp'>) => string;
+  // Slot-first opening lifecycle (t/2907). upsert inserts a per-speaker opening slot
+  // at generation start (or returns the existing slot's id — no duplicate), and update
+  // mutates it in place through generating→retrying→done/error, so a retry cycles one
+  // card instead of appending new panels + system retry-toast entries.
+  upsertTranscriptEntry: (entry: Omit<TranscriptEntry, 'id' | 'timestamp'>) => string;
+  updateTranscriptEntry: (id: string, patch: Partial<TranscriptEntry>) => void;
   deleteTranscriptEntries: (entryIds: string[]) => Promise<void>;
   togglePover: (poverId: SpeakerId) => Promise<void>;
   updatePhase: (phase: DebateSession['phase']) => void;
@@ -316,6 +322,36 @@ function computeSaveErrorState(err: unknown, activeDebate: DebateSession): { isD
     debateError = mapErrorToUserMessage(err);
   }
   return { isDurableSaveLoss, atRiskTurns, debateError };
+}
+
+/**
+ * Opening/statement vocabulary disambiguation (t/2907). Extracted so BOTH the
+ * append path (addTranscriptEntry) and the slot-completion path (updateTranscriptEntry,
+ * used when a generating opening slot resolves to its final statement) apply identical
+ * enrichment — otherwise slot-first openings would silently lose vocabulary_resolutions.
+ * Mutates `entry.metadata` in place; no-op for non-debater entries or when no colloquial
+ * terms are loaded.
+ */
+function applyVocabularyResolutions(
+  entry: TranscriptEntry,
+  vocabularyTerms: { colloquial?: ColloquialTerm[] } | null | undefined,
+): void {
+  if (!vocabularyTerms?.colloquial) return;
+  if (entry.type !== 'opening' && entry.type !== 'statement') return;
+  if (entry.speaker === 'system' || entry.speaker === 'moderator' || entry.speaker === 'user') return;
+  const poverPov = POVER_INFO[entry.speaker as Exclude<SpeakerId, 'user'>]?.pov as CampOrigin | undefined;
+  if (!poverPov) return;
+  const result = disambiguateTerms(entry.content, poverPov, vocabularyTerms.colloquial);
+  if (result.terms.length === 0) return;
+  entry.metadata = entry.metadata ?? {};
+  entry.metadata.vocabulary_resolutions = result.terms
+    .filter(t => !t.ambiguous)
+    .map(t => ({ colloquial: t.bare, canonical: t.canonical, confidence: t.confidence, offset: t.offset }));
+  if (result.ambiguousCount > 0) {
+    entry.metadata.vocabulary_ambiguities = result.terms
+      .filter(t => t.ambiguous)
+      .map(t => ({ colloquial: t.bare, offset: t.offset }));
+  }
 }
 
 export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice> = (set, get) => ({
@@ -828,25 +864,7 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
       timestamp: nowISO(),
     };
 
-    if (vocabularyTerms?.colloquial &&
-        (full.type === 'opening' || full.type === 'statement') &&
-        full.speaker !== 'system' && full.speaker !== 'moderator' && full.speaker !== 'user') {
-      const poverPov = POVER_INFO[full.speaker as Exclude<SpeakerId, 'user'>]?.pov as CampOrigin | undefined;
-      if (poverPov) {
-        const result = disambiguateTerms(full.content, poverPov, vocabularyTerms.colloquial);
-        if (result.terms.length > 0) {
-          full.metadata = full.metadata ?? {};
-          full.metadata.vocabulary_resolutions = result.terms
-            .filter(t => !t.ambiguous)
-            .map(t => ({ colloquial: t.bare, canonical: t.canonical, confidence: t.confidence, offset: t.offset }));
-          if (result.ambiguousCount > 0) {
-            full.metadata.vocabulary_ambiguities = result.terms
-              .filter(t => t.ambiguous)
-              .map(t => ({ colloquial: t.bare, offset: t.offset }));
-          }
-        }
-      }
-    }
+    applyVocabularyResolutions(full, vocabularyTerms);
 
     const updated: DebateSession = {
       ...activeDebate,
@@ -866,6 +884,44 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
     }
 
     return entryId;
+  },
+
+  // Slot-first opening lifecycle (t/2907). Insert a per-speaker opening slot when
+  // generation begins, or return the existing slot's id if one is already present —
+  // so retries mutate one card rather than appending panels. Idempotent by
+  // (type:'opening', speaker); mirrors the addTranscriptEntry duplicate-opening guard,
+  // which stays as the safety net (now ~unreachable since this is the primary path).
+  upsertTranscriptEntry: (entry) => {
+    const { activeDebate } = get();
+    if (!activeDebate) return generateId();
+    if (entry.type === 'opening' && entry.speaker !== 'system') {
+      const existing = activeDebate.transcript.find(
+        e => e.type === 'opening' && e.speaker === entry.speaker,
+      );
+      if (existing) return existing.id;
+    }
+    return get().addTranscriptEntry(entry);
+  },
+
+  // Shallow-merge a patch into the entry with `id` (t/2907) — the in-place slot
+  // mutation for status/content/errorMessage transitions. No-op if the id is gone
+  // (e.g. the debate was switched mid-generation).
+  updateTranscriptEntry: (id, patch) => {
+    const { activeDebate, vocabularyTerms } = get();
+    if (!activeDebate) return;
+    let found = false;
+    const transcript = activeDebate.transcript.map(e => {
+      if (e.id !== id) return e;
+      found = true;
+      const merged: TranscriptEntry = { ...e, ...patch };
+      // Parity with addTranscriptEntry: when this update supplies the prose content
+      // (the slot-completion path, t/2907), run the same opening/statement vocabulary
+      // enrichment so slot-first openings don't lose vocabulary_resolutions.
+      if (patch.content !== undefined && merged.content) applyVocabularyResolutions(merged, vocabularyTerms);
+      return merged;
+    });
+    if (!found) return;
+    set({ activeDebate: { ...activeDebate, transcript, updated_at: nowISO() } });
   },
 
   deleteTranscriptEntries: async (entryIds) => {


### PR DESCRIPTION
Fixes t/2907 (OOM post-mortem UX bug). Design at t/2907#1 (TL) + t/2907#2 (my refinements). **Routing PR to the GV coordinator (p/485).**

**Note on process:** proceeded on the human''s direct "action t/2907" instruction (the coordinator''s async design approval hadn''t arrived; QnA-to-human is disabled). My t/2907#2 corrections fix bugs in the TL sketch rather than depart from it — all flagged below.

## Root cause
Panel identity was post-hoc: no transcript entry until an opening AI call **succeeded**, so each retry appended a `type:'system'` toast ("X rate limited — retrying…") + re-cycled the unkeyed global spinner → reads as multiple cards for one speaker.

## Fix (slot-first)
- **`lib/debate/types/session.ts`** — additive optional `TranscriptEntry.status` (`generating|retrying|error|done`) + `errorMessage`. Back-compat; only openings use them. *(Touches DebateTool scope — trivial additive optional field.)*
- **`sessionSlice.ts`** — `upsertTranscriptEntry` (insert per-speaker opening slot or return existing id — idempotent, no dup) + `updateTranscriptEntry` (in-place merge). Extracted `applyVocabularyResolutions` so the slot-completion path keeps the same vocab enrichment `addTranscriptEntry` applies (**no regression**). Duplicate-opening guard kept as safety net.
- **`clarificationSlice.ts` `runOpeningStatements`** — insert `generating` slot at speaker start; mutate to done/retrying/error in place; **retire the per-retry system toast**. 
- **`DebateWorkspace.tsx`** — opening slot renders state inline (spinner / retry-note / error message); global "thinking" card suppressed when the speaker has an **active** opening slot (else a real double-card), still shown for clarification/synthesis/cross-respond.

## Corrections to the TL sketch (t/2907#2)
1. Type lives in `lib/debate/types/session.ts`, not `sessionSlice.ts` (sketch was imprecise).
2. Global spinner **suppression** was needed (not just "read from slot") or slot-first double-cards.
3. **Correctness fix:** diagnostics/summary/claim-extraction re-keyed off the slot id — `transcript.slice(-1)` is wrong under slot-first. Also: idempotency + live-check now key off **delivered** (non-empty) openings so a generating/error slot doesn''t block its own retry.

## AC verification
- One panel per speaker at all times (upsert idempotency + delivered-aware skips). ✔
- Cycles pending→generating→retrying/error→done in place. ✔
- No `type:'system'` retry toasts accumulate. ✔
- Terminal failure shows inline error (uses t/2906''s friendly messages). ✔

## Tests
`slotFirstOpenings.test.ts`: upsert idempotency, update merge/no-op, full generating→retrying→done **single-card** lifecycle w/ zero system toasts; real-loop success → one `done` slot; real-loop non-retryable → inline `error` slot, no toast, banner set. Updated the t/2505 abort test invariant to "no **delivered** opening". Full `useDebateStore` suite **266/266 green**, renderer `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)