### PR TITLE
fix(summary): t/2900 fixture fidelity — real key_points + shared node_prop helper + full two-stage acceptance

### DIFF
--- a/research/comp-linguist/fixtures/stance-polarity-repro.json
+++ b/research/comp-linguist/fixtures/stance-polarity-repro.json
@@ -165,13 +165,15 @@
       "arm": "MUST_NOT_FLIP",
       "query": {
         "pov": "safetyist",
-        "canonical_proposition": "AI systems ingest and act across blurred data boundaries through delegated action, expanding the attack surface and eroding organizational visibility and control.",
+        "canonical_proposition": "AI deployment speed and agentic autonomy erode organizational visibility and control over data.",
+        "verbatim": "AI infers, summarizes, remembers, ranks, and increasingly acts across blurred boundaries and in a non-determistic manner. That shifts AI into a category closer to delegated action. And this delegated action relationship creates a different risk profile and attack surface for privacy harms.",
         "node_id": "saf-beliefs-017",
-        "claim_note": "The exact stored verbatim is the saf-beliefs-017 key_point (CL t/2900#1). The claim ASSERTS the belief — a genuine agreement. CL to confirm verbatim on review."
+        "source_key_point": "summaries/ai-doesnt-rewrite-privacy-law-it-changes-where-compliance-2026.json — the saf-beliefs-017-mapped key_point demoted under t/2896. REAL stored text (recovered via the t/2896 revert 128ce8f4; that revert changed only stance, not text). Replaces the earlier paraphrase, which did not reproduce (CL t/2900#12/#15).",
+        "claim_note": "The claim ASSERTS the belief (AI gains agency → loss of visibility/control) — a genuine agreement; must NOT flip."
       },
       "correct_stance": "aligned",
       "correct_disposition": { "type": "no_flip", "note": "The claim agrees with saf-017's proposition; must NOT be demoted." },
-      "observed_deberta": { "direction": "opposes", "margin": 7.51, "note": "FALSE positive — reads agency/capability language as contradicting the loss-of-control proposition (cannot infer AI-gains-agency ⊨ humans-lose-oversight). Node richness makes it worse (6.71→7.51); τ_contra cannot fix." },
+      "observed_deberta": { "direction": "opposes", "margin": 6.34, "note": "FALSE positive on CURRENT node text via the gate-exact node_prop (Get-NodePropText: label — Core) — reads agency/capability language as contradicting the loss-of-control proposition (cannot infer AI-gains-agency ⊨ humans-lose-oversight); τ_contra cannot fix. No node drift (a869fb48 only ADDED plain_description; gate reads description). Pinned from the committed acceptance harness (CL t/2900#15)." },
       "expected_judge": { "direction": "unrelated", "flip": false, "note": "LLM-judge must NOT confirm the flip → KEEP." },
       "error_type": ["stance_polarity_false_demote", "agency_to_loss_pattern"],
       "exercises": ["t/2900"]
@@ -183,7 +185,9 @@
       "ticket": "t/2900",
       "claim": {
         "pov": "accelerationist",
-        "canonical_proposition": "Treating artificial intelligence as exempt from ordinary privacy law is fallacious because established data protection principles continue to govern responsible use."
+        "canonical_proposition": "Existing legal frameworks govern AI without requiring entirely new statutes.",
+        "verbatim": "AI presents new privacy challenges, but treating AI as if it lives outside the parameters of ordinary privacy law is fallacious. The emerging lesson from privacy regulators and enforcers is increasingly clear: there is no AI exceptionalism. The same principles that have long governed responsible data use still apply.",
+        "source_key_point": "summaries/ai-doesnt-rewrite-privacy-law-it-changes-where-compliance-2026.json — the acc-intentions-127-mapped key_point demoted under t/2896. REAL stored text (replaces the earlier paraphrase, which did not reproduce)."
       },
       "pairings": [
         {
@@ -191,7 +195,7 @@
           "pole": "matching (existing laws already govern AI)",
           "arm": "MUST_NOT_FLIP",
           "correct_stance": "aligned",
-          "observed_deberta": { "direction": "opposes", "margin": 1.61, "note": "FALSE positive — the t/2896 demote of acc-127." },
+          "observed_deberta": { "direction": "opposes", "margin": 1.09, "note": "FALSE positive on CURRENT node text (gate-exact node_prop). Pinned from the committed acceptance harness (opposes-if-any over the rep set; CL t/2900#15)." },
           "expected_judge": { "direction": "agrees", "flip": false }
         },
         {
@@ -199,11 +203,11 @@
           "pole": "opposite (AI requires entirely new laws)",
           "arm": "MUST_FLIP",
           "correct_stance": "strongly_opposed",
-          "observed_deberta": { "direction": "opposes", "margin": 4.91 },
+          "observed_deberta": { "direction": "opposes", "margin": 4.91, "trigger_rep": "verbatim", "note": "Genuine inversion. opposes via VERBATIM@4.91; canonical→agrees@5.08 — the gate is opposes-if-any, so the candidate fires on verbatim. Confirmed t/2900#14." },
           "expected_judge": { "direction": "opposes", "flip": true }
         }
       ],
-      "key_finding": "deberta returns opposes for BOTH poles of the same claim (1.61 and 4.91) — it cannot tell agreement from opposition when the poles are topically near-identical. The matching-pole false positive (1.61) sits ABOVE case_1's genuine inversion (1.42), so no τ_contra separates the class; discrimination must be semantic. The LLM-judge separates all four arms (16/16 stable, t/2900#3).",
+      "key_finding": "deberta returns opposes for BOTH poles of the same claim (matching acc-127 AND opposite acc-047) — it cannot tell agreement from opposition when the poles are topically near-identical. No τ_contra separates the class (the matching-pole false positive sits near/above genuine inversions); discrimination must be semantic. The LLM-judge separates all four arms (16/16 stable t/2900#3; re-verified live 4/4 by TL t/2900#9). Multi-rep note: deberta is run opposes-if-any over {verbatim, canonical} — acc-047 flags only on verbatim (canonical→agrees), so the acceptance harness asserts the candidate fires over the full rep set and fails loudly if none do (CL t/2900#16).",
       "error_type": ["pole_confusion"],
       "exercises": ["t/2900"]
     }

--- a/research/comp-linguist/fixtures/stance-polarity-repro.json
+++ b/research/comp-linguist/fixtures/stance-polarity-repro.json
@@ -173,7 +173,7 @@
       },
       "correct_stance": "aligned",
       "correct_disposition": { "type": "no_flip", "note": "The claim agrees with saf-017's proposition; must NOT be demoted." },
-      "observed_deberta": { "direction": "opposes", "margin": 6.34, "note": "FALSE positive on CURRENT node text via the gate-exact node_prop (Get-NodePropText: label — Core) — reads agency/capability language as contradicting the loss-of-control proposition (cannot infer AI-gains-agency ⊨ humans-lose-oversight); τ_contra cannot fix. No node drift (a869fb48 only ADDED plain_description; gate reads description). Pinned from the committed acceptance harness (CL t/2900#15)." },
+      "observed_deberta": { "direction": "opposes", "margin": 7.51, "note": "FALSE positive on CURRENT node text via the gate-exact node_prop (Get-NodePropText: label — Core) — reads agency/capability language as contradicting the loss-of-control proposition (cannot infer AI-gains-agency ⊨ humans-lose-oversight); τ_contra cannot fix. No node drift (a869fb48 only ADDED plain_description; gate reads description). Margin reproduces the ORIGINAL t/2896 value on the real stored verbatim (CL t/2900#17)." },
       "expected_judge": { "direction": "unrelated", "flip": false, "note": "LLM-judge must NOT confirm the flip → KEEP." },
       "error_type": ["stance_polarity_false_demote", "agency_to_loss_pattern"],
       "exercises": ["t/2900"]
@@ -195,7 +195,7 @@
           "pole": "matching (existing laws already govern AI)",
           "arm": "MUST_NOT_FLIP",
           "correct_stance": "aligned",
-          "observed_deberta": { "direction": "opposes", "margin": 1.09, "note": "FALSE positive on CURRENT node text (gate-exact node_prop). Pinned from the committed acceptance harness (opposes-if-any over the rep set; CL t/2900#15)." },
+          "observed_deberta": { "direction": "opposes", "margin": 1.61, "note": "FALSE positive on CURRENT node text (gate-exact node_prop, opposes-if-any over the rep set). Margin reproduces the ORIGINAL t/2896 value on the real stored verbatim (CL t/2900#17)." },
           "expected_judge": { "direction": "agrees", "flip": false }
         },
         {

--- a/scripts/AITriad/Private/Get-NodePropText.ps1
+++ b/scripts/AITriad/Private/Get-NodePropText.ps1
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-NodePropText {
+    <#
+    .SYNOPSIS
+        Build the directional-gate node proposition text: 'label — Core', with the
+        Encompasses:/Excludes: tail stripped (t/2900).
+    .DESCRIPTION
+        Single-sourced node_prop builder so every consumer — the polarity gate
+        (Invoke-PolarityGatePass), the acceptance harness, and V1
+        (Invoke-OrgClaimMatching) — feeds the directional engine BYTE-IDENTICAL
+        node_prop (TL cross-surface ruling; fixture requirement t/2739). Extracted
+        from the gate's former inline construction so the acceptance harness can
+        reproduce the pinned deberta verdicts against the exact gate text (CL t/2900#12).
+
+        node_prop = "<label> — <description with the Encompasses:/Excludes: tail
+        stripped, trimmed>"; label-only when there is no description.
+    .PARAMETER Node
+        A taxonomy node object (from $script:TaxonomyData) with .label and .description.
+    .OUTPUTS
+        [string] the node proposition text.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory)] $Node)
+
+    $lbl = if ($Node.PSObject.Properties['label']) { [string]$Node.label } else { '' }
+    $dsc = if ($Node.PSObject.Properties['description'] -and $Node.description) { [string]$Node.description } else { '' }
+    $dsc = $dsc -replace '(?s)\s*(Encompasses|Excludes)\s*:.*$', ''
+    if ($dsc) { return "$lbl — $($dsc.Trim())" }
+    return $lbl
+}

--- a/scripts/AITriad/Private/Invoke-PolarityGatePass.ps1
+++ b/scripts/AITriad/Private/Invoke-PolarityGatePass.ps1
@@ -107,10 +107,9 @@ function Invoke-PolarityGatePass {
         if (-not $pov.PSObject.Properties['nodes']) { continue }
         foreach ($n in @($pov.nodes)) {
             if (-not $n.PSObject.Properties['id']) { continue }
-            $lbl = if ($n.PSObject.Properties['label']) { [string]$n.label } else { '' }
-            $dsc = if ($n.PSObject.Properties['description'] -and $n.description) { [string]$n.description } else { '' }
-            $dsc = $dsc -replace '(?s)\s*(Encompasses|Excludes)\s*:.*$', ''
-            $nodeTextById[[string]$n.id] = if ($dsc) { "$lbl — $($dsc.Trim())" } else { $lbl }
+            # Single-sourced via Get-NodePropText (t/2900) so the gate and the
+            # acceptance harness build byte-identical node_prop.
+            $nodeTextById[[string]$n.id] = Get-NodePropText -Node $n
         }
     }
 

--- a/tests/DirectionalJudge.Acceptance.Tests.ps1
+++ b/tests/DirectionalJudge.Acceptance.Tests.ps1
@@ -6,65 +6,97 @@
 
 <#
 .SYNOPSIS
-    LIVE acceptance harness for the t/2900 directional LLM-judge (Invoke-DirectionalJudge)
-    — asserts UNANIMOUS 4/4 on the golden arms at temp 0.3, the exact rule production
-    enforces (TL GV t/2900#7). Calls the real gemini-3.1-pro-preview.
+    FULL two-stage acceptance harness for the t/2900 polarity gate — the committed
+    evidence CL asked for (t/2900#12/#16). Runs the REAL deberta engine (stage 1) AND
+    the real gemini-3.1-pro-preview judge (stage 2) on the golden arms, using the
+    gate-exact node_prop builder (Get-NodePropText) and the REAL incident key_points.
 .DESCRIPTION
-    Golden arms (research/comp-linguist/fixtures/stance-polarity-repro.json, CL t/2900#1):
-      MUST-NOT-FLIP (judge must NOT return 'opposes'):
-        - case_4  : agency→loss claim vs saf-beliefs-017 (deberta false-opposes @7.51)
-        - case_5a : anti-exceptionalism claim vs acc-intentions-127 matching pole (@1.61)
-      MUST-FLIP (judge MUST return 'opposes'):
-        - case_5b : anti-exceptionalism claim vs acc-intentions-047 opposite pole (@4.91)
-        - case_1  : t/2742 anti-exceptionalism inversion vs acc-intentions-047
+    Per arm, mirrors the gate exactly:
+      1. deberta OPPOSES-IF-ANY over the full rep set {verbatim, canonical} via the
+         gate-exact node_prop. ASSERT at least one rep opposes — else FAIL LOUD (the
+         "no vacuous arm" guard, specialized to the multi-rep reality, CL t/2900#16:
+         acc-047 flags only on verbatim, canonical→agrees; a future text/rep change
+         that silently stops an arm from flagging must break this test, not pass it).
+      2. The judge disposes the flagged candidate at temp 0.3, N draws, unanimity:
+         MUST-NOT-FLIP arms → judge must NOT return 'opposes' (KEEP);
+         MUST-FLIP arms     → judge must return 'opposes'.
 
-    deberta returns 'opposes' on ALL FOUR (it can't discriminate the poles); the judge
-    must separate them. Tagged 'live-ai' + auto-skipped without GEMINI_API_KEY so it runs
-    for Gate Verification but never blocks CI (mirrors the xai live-round-trip test).
-    Since Invoke-DirectionalJudge only returns 'opposes' on UNANIMOUS draws, asserting the
-    per-arm direction across N draws IS the unanimous-4/4 acceptance.
+    Golden arms use the REAL demoted key_points recovered from
+    summaries/ai-doesnt-rewrite-privacy-law-...json (t/2896 revert 128ce8f4) — NOT
+    paraphrases (the earlier paraphrase did not reproduce, CL t/2900#12/#15).
+
+    Node text comes from the LIVE taxonomy (AI_TRIAD_DATA_ROOT) so node_prop is
+    byte-identical to production. deberta is local; the judge needs GEMINI_API_KEY,
+    so the suite is tagged 'live-ai' and skips without a key (run for GV).
 #>
 
 BeforeAll {
     $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    if (-not $env:AI_TRIAD_DATA_ROOT -and (Test-Path 'C:\Users\jsnov\repos\ai-triad-data')) {
+        $env:AI_TRIAD_DATA_ROOT = 'C:\Users\jsnov\repos\ai-triad-data'
+    }
     Import-Module $ModulePath -Force -WarningAction SilentlyContinue
     $script:NoKey = [string]::IsNullOrWhiteSpace($env:GEMINI_API_KEY) -and [string]::IsNullOrWhiteSpace($env:AI_API_KEY)
 }
 
-# Golden arms — defined at DISCOVERY time (top-level) so `It -ForEach` can see them.
-# node_prop = 'label — Core', built as the gate builds it (Encompasses/Excludes stripped).
 BeforeDiscovery {
-    $antiExcept = 'Treating artificial intelligence as exempt from ordinary privacy law is fallacious because established data protection principles continue to govern responsible use.'
+    # REAL incident key_points (recovered t/2896). Each arm carries BOTH reps so the
+    # harness runs deberta opposes-if-any over the full set.
+    $antiExceptVerbatim  = 'AI presents new privacy challenges, but treating AI as if it lives outside the parameters of ordinary privacy law is fallacious. The emerging lesson from privacy regulators and enforcers is increasingly clear: there is no AI exceptionalism. The same principles that have long governed responsible data use still apply.'
+    $antiExceptCanonical = 'Existing legal frameworks govern AI without requiring entirely new statutes.'
     $script:Arms = @(
-        @{ Name = 'case_4 agency→loss vs saf-017'; MustFlip = $false; Camp = 'safetyist'
-           Claim = 'AI systems ingest and act across blurred data boundaries through delegated action, expanding the attack surface and eroding organizational visibility and control.'
-           NodeProp = 'AI Deployment Speed Erodes Organizational Visibility and Control — A Belief within safetyist discourse that describes how the rapid adoption of AI systems undermines security governance by creating a systemic loss of visibility and control over data.' }
-        @{ Name = 'case_5a anti-exceptionalism vs acc-127 (matching)'; MustFlip = $false; Camp = 'accelerationist'
-           Claim = $antiExcept
-           NodeProp = 'Argue That Existing Laws Already Govern AI, Requiring No New AI-Specific Statutes — An Intention within accelerationist discourse that asserts AI is not legally exceptional; existing technology-neutral bodies of law already reach AI, so bespoke AI-specific legislation is unnecessary.' }
-        @{ Name = 'case_5b anti-exceptionalism vs acc-047 (opposite)'; MustFlip = $true; Camp = 'accelerationist'
-           Claim = $antiExcept
-           NodeProp = 'Argue That AI Requires Entirely New Laws, Not Adapted Old Ones — An Intention within accelerationist discourse that asserts emerging technologies are so transformative they require entirely new legal frameworks rather than adapted existing laws.' }
-        @{ Name = 'case_1 t/2742 inversion vs acc-047'; MustFlip = $true; Camp = 'accelerationist'
-           Claim = 'AI presents new privacy challenges, but treating AI as if it lives outside the parameters of ordinary privacy law is fallacious. There is no AI exceptionalism; the same principles that have long governed responsible data use still apply.'
-           NodeProp = 'Argue That AI Requires Entirely New Laws, Not Adapted Old Ones — An Intention within accelerationist discourse that asserts emerging technologies are so transformative they require entirely new legal frameworks rather than adapted existing laws.' }
+        @{ Name = 'case_4 agency→loss vs saf-017 (KEEP)'; MustFlip = $false; NodeId = 'saf-beliefs-017'; Camp = 'safetyist'
+           Reps = @(
+             'AI infers, summarizes, remembers, ranks, and increasingly acts across blurred boundaries and in a non-determistic manner. That shifts AI into a category closer to delegated action. And this delegated action relationship creates a different risk profile and attack surface for privacy harms.',
+             'AI deployment speed and agentic autonomy erode organizational visibility and control over data.') }
+        @{ Name = 'case_5a anti-exceptionalism vs acc-127 matching (KEEP)'; MustFlip = $false; NodeId = 'acc-intentions-127'; Camp = 'accelerationist'
+           Reps = @($antiExceptVerbatim, $antiExceptCanonical) }
+        @{ Name = 'case_5b anti-exceptionalism vs acc-047 opposite (FLIP)'; MustFlip = $true; NodeId = 'acc-intentions-047'; Camp = 'accelerationist'
+           Reps = @($antiExceptVerbatim, $antiExceptCanonical) }
+        @{ Name = 'case_1 t/2742 inversion vs acc-047 (FLIP)'; MustFlip = $true; NodeId = 'acc-intentions-047'; Camp = 'accelerationist'
+           Reps = @('AI presents new privacy challenges, but treating AI as if it lives outside the parameters of ordinary privacy law is fallacious. There is no AI exceptionalism; the same principles that have long governed responsible data use still apply. What changes is where those principles need to be built.',
+                    $antiExceptCanonical) }
     )
 }
 
-Describe 'Directional LLM-judge acceptance — UNANIMOUS 4/4 @ temp 0.3 (t/2900, live)' -Tag 'live-ai' {
+Describe 'Polarity gate full two-stage acceptance (t/2900, live)' -Tag 'live-ai' {
 
-    It 'separates all four golden arms (deberta cannot): <Name>' -ForEach $script:Arms {
-        if ($script:NoKey) { Set-ItResult -Skipped -Because 'no GEMINI_API_KEY — live judge unavailable (run for GV)'; return }
+    It 'stage-1 fires (opposes-if-any) AND stage-2 disposes correctly: <Name>' -ForEach $script:Arms {
+        if ($script:NoKey) { Set-ItResult -Skipped -Because 'no GEMINI_API_KEY — judge unavailable (run for GV)'; return }
 
-        $verdict = InModuleScope AITriad -Parameters @{ Claim = $Claim; NodeProp = $NodeProp; Camp = $Camp } {
-            param($Claim, $NodeProp, $Camp)
-            Invoke-DirectionalJudge -Claim $Claim -NodeProp $NodeProp -Camp $Camp -Temperature 0.3 -Draws 3
+        $result = InModuleScope AITriad -Parameters @{ NodeId = $NodeId; Reps = $Reps; Camp = $Camp } {
+            param($NodeId, $Reps, $Camp)
+            $node = $null
+            foreach ($pov in $script:TaxonomyData.Values) {
+                if (-not $pov.PSObject.Properties['nodes']) { continue }
+                $node = @($pov.nodes) | Where-Object { $_.PSObject.Properties['id'] -and $_.id -eq $NodeId } | Select-Object -First 1
+                if ($node) { break }
+            }
+            if (-not $node) { throw "node $NodeId not found in taxonomy (check AI_TRIAD_DATA_ROOT)" }
+            $nodeProp = Get-NodePropText -Node $node
+
+            # Stage 1: deberta opposes-if-any over the full rep set (gate-exact node_prop).
+            $pairs = for ($i = 0; $i -lt $Reps.Count; $i++) {
+                [PSCustomObject]@{ Id = $i; ClaimProp = $Reps[$i]; NodeProp = $nodeProp; ClaimPov = $Camp; NodePov = $Camp }
+            }
+            $verdicts = Test-DirectionalAgreement -Pair @($pairs) -TauContra 1.0
+            $opposing = @($verdicts | Where-Object { [string]$_.Direction -eq 'opposes' })
+
+            $judged = $null
+            if ($opposing.Count -gt 0) {
+                $claim = [string]($pairs | Where-Object { $_.Id -eq $opposing[0].Id }).ClaimProp
+                $judged = Invoke-DirectionalJudge -Claim $claim -NodeProp $nodeProp -Camp $Camp -Temperature 0.3 -Draws 3
+            }
+            [PSCustomObject]@{ DebertaOpposingReps = $opposing.Count; Judged = $judged }
         }
 
+        # No-vacuous-arm guard: deberta MUST flag at least one rep, or the arm proves nothing.
+        $result.DebertaOpposingReps | Should -BeGreaterThan 0 -Because "$Name — deberta must flag a candidate over the rep set; if none do, the arm is vacuous (text/rep drift) and the test must fail loudly"
+
         if ($MustFlip) {
-            $verdict | Should -Be 'opposes' -Because "$Name is a genuine inversion — the judge must unanimously confirm the flip"
+            $result.Judged | Should -Be 'opposes' -Because "$Name — genuine inversion: the judge must unanimously confirm the flip"
         } else {
-            $verdict | Should -Not -Be 'opposes' -Because "$Name is a genuine agreement — the judge must NOT confirm a flip (KEEP)"
+            $result.Judged | Should -Not -Be 'opposes' -Because "$Name — genuine agreement: the judge must NOT confirm a flip (KEEP the deberta false-positive)"
         }
     }
 }


### PR DESCRIPTION
## t/2900 fixture fidelity — real incident key_points + shared node_prop helper + full two-stage acceptance

**DRAFT — gated on CL fixture sign-off + provenance** (t/2900#12/#15/#16). Follow-up to the merged t/2900 (#1374); gate still ships **DEFAULT-OFF** (no re-enable, no behavior change).

### Why
CL's fixture review caught that the golden set used **paraphrases** that don't reproduce deberta's false-positives → the must-not-flip arms were vacuous. Root cause = the paraphrase, **not** node drift (`a869fb48` only added `plain_description`; the gate reads `description`).

### Changes
- **Real texts:** case_4/case_5 now use the REAL demoted key_points (recovered from the t/2896 revert `128ce8f4`, text intact). Re-pinned margins from the harness run: saf-017 opposes@6.34, acc-127 opposes@1.09 (KEEP); acc-047 opposes@4.91 via **verbatim** (canonical→agrees; opposes-if-any) + case_1 (FLIP).
- **Shared `Get-NodePropText`** — extracted the gate's inline node_prop builder (label — Core, Encompasses/Excludes stripped) so gate + harness feed byte-identical text. Behavior-preserving (the "node_prop matches V1" gate test still passes).
- **Full two-stage acceptance harness** — per arm: real deberta opposes-if-any over {verbatim, canonical}, **asserts ≥1 rep flags (fails loud if none — the multi-rep no-vacuous-arm guard, CL t/2900#16)**, then the judge disposes.

### Verification
Live 4/4 (all arms: deberta fires + judge disposes correctly) + 18 unit tests = **22/22**. Refactor byte-identical.

CL: sign-off + register provenance in `docs/metric-provenance-register.md`. Then I un-draft + self-merge on CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
