### PR TITLE
fix(prompts): catalog directional-judge.prompt to unblock main (t/2834)

### DIFF
--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -814,6 +814,21 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     ],
   },
   {
+    id: 'ps-directional-judge',
+    title: 'Directional Agreement Judge',
+    description: 'Judges whether a claim OPPOSES, AGREES with, or is UNRELATED to a same-camp taxonomy node proposition — the polarity gate\'s directional pass (t/2900).',
+    source: 'AITriad/Prompts/directional-judge.prompt',
+    template: '(Loading from disk...)',
+    group: 'powershell',
+    purpose: 'Used by Invoke-DirectionalJudge (two-stage LLM-judge polarity gate, t/2900). Given a camp, a claim attributed to it, and a same-camp node proposition, decides propositional stance (opposes/agrees/unrelated) — judging propositional content, not topical overlap.',
+    applicableDataSources: ['taxonomyNodes'],
+    promptFiles: ['directional-judge'],
+    psParameters: [
+      { name: '-Model', type: 'string', default: DEFAULT_MODEL, description: 'AI model' },
+      { name: '-Temperature', type: 'number', default: '0.1', description: 'Sampling temperature' },
+    ],
+  },
+  {
     id: 'ps-edge-weight-evaluation',
     title: 'Edge Weight Evaluation',
     description: 'Scores the strength/weight of edges between taxonomy nodes on a normalized scale.',


### PR DESCRIPTION
**Unblocks broken main** (PM-authorized, p/15#107). `data/promptCatalog.lint.test.ts` (t/2834, forward `.prompt` arm) is failing on `main` — red for **every open PR** — because `scripts/AITriad/Prompts/directional-judge.prompt` (landed via t/2900 / t/2911) was never catalogued or excluded.

## Fix
It''s a first-class PS content prompt — a directional-agreement judge for the polarity gate, invoked by `Invoke-DirectionalJudge.ps1` (t/2900) — so it gets a **catalog entry** (`ps-directional-judge`) mirroring its sibling `scripts/AITriad/Prompts` entries (e.g. `ps-direction-check`), not an exclusion.

## Verify
- `promptCatalog.lint.test.ts` **8/8 green** (was 1 failing), `tsc` clean.

Single-file, data-only. Landing this first unblocks the fleet; my t/2907 PR (#1376) merges right after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)