### PR TITLE
fix(catalog): register directional-judge.prompt — green the promptCatalog lint on main (t/2900)

### DIFF
--- a/taxonomy-editor/src/renderer/data/promptCatalog.ts
+++ b/taxonomy-editor/src/renderer/data/promptCatalog.ts
@@ -799,6 +799,22 @@ export const PROMPT_CATALOG: PromptCatalogEntry[] = [
     ],
   },
   {
+    id: 'ps-directional-judge',
+    title: 'Directional Agreement Judge',
+    description: 'Stage-2 LLM judge for the aligned-family polarity gate — decides whether a claim opposes, agrees with, or is unrelated to a taxonomy node proposition (t/2900).',
+    source: 'AITriad/Prompts/directional-judge.prompt',
+    template: '(Loading from disk...)',
+    group: 'powershell',
+    purpose: 'Used by Invoke-DirectionalJudge (stage 2 of the polarity gate). Confirms deberta\'s opposes candidates before a stance flip — unanimous opposes required across N draws, fail-safe KEEP (t/2900).',
+    applicableDataSources: ['taxonomyNodes'],
+    promptFiles: ['directional-judge'],
+    psParameters: [
+      { name: '-Model', type: 'string', default: DEFAULT_MODEL, description: 'Judge model (gemini-3.1-pro-preview)' },
+      { name: '-Temperature', type: 'number', default: '0.3', description: 'Sampling temperature (draw variance for the unanimity bar)' },
+      { name: '-Draws', type: 'number', default: '3', description: 'Independent draws; unanimity required to confirm opposes' },
+    ],
+  },
+  {
     id: 'ps-direction-check',
     title: 'Edge Direction Check',
     description: 'Verifies the correct direction of edges in the taxonomy knowledge graph.',


### PR DESCRIPTION
## Broken-main incident fix
`test-electron (taxonomy-editor)` is RED on main → blocks all PRs (Shared Lib t/2907 reported it).

**Root cause:** t/2900 (#1374) added `scripts/AITriad/Prompts/directional-judge.prompt` but never registered it in `PROMPT_CATALOG`. The `promptCatalog.lint` forward(.prompt) arm ("every discovered .prompt is catalogued or allowlisted") fails.

**Fix:** add the `ps-directional-judge` catalog entry (`promptFiles: ['directional-judge']`), matching the sibling `ps-direction-check` shape. Verified `directional-judge` is the ONLY orphan (47 .prompt files; every other catalogued/excluded).

This PR touches `taxonomy-editor/**`, so its CI runs the lint → validates the fix (the arm that's red on main goes green here).

**Self-cert `/trivial-change`** — single-file catalog registration, no behavioral change.

**Prevention (separate → DevOps):** the CI `changes`-filter let a `scripts/`-only prompt add skip `test-electron (taxonomy-editor)` (where the lint lives), so the drift merged undetected. The lint must trigger whenever ANY prompt dir it validates changes (`scripts/AITriad/Prompts`, `lib/oped/prompts`, `lib/debate/prompts`, `taxonomy-editor/src/renderer/prompts`), not just `taxonomy-editor/**`.

Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>