### PR TITLE
fix(ci): add scripts/AITriad/Prompts to electron changes filter (t/2915)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
               - 'lib/**'
               - 'ai-models.json'
               - '.github/workflows/ci.yml'
+              - 'scripts/AITriad/Prompts/**'  # promptCatalog.lint validates this dir; must re-run when prompts change here (t/2915)
             debate:
               - 'lib/debate/**'
               - 'evals/**'


### PR DESCRIPTION
## Summary

- Adds `scripts/AITriad/Prompts/**` to the `electron` changes filter so `test-electron (taxonomy-editor)` — and the `promptCatalog.lint` it contains — fires whenever a prompt is added/changed in that directory, even with no `taxonomy-editor/**` changes.
- `lib/oped/prompts` and `lib/debate/prompts` were already covered by `lib/**`; `taxonomy-editor/src/renderer/prompts` by `taxonomy-editor/**`. Only `scripts/AITriad/Prompts/**` was missing.
- Root cause of broken-main from t/2900 (#1374 → uncatalogued prompt merged → #1380 fixed); this closes the trigger-scope gap.

## Gate-verification (both arms — per t/2915)

Fire arm: a PR that adds an uncatalogued prompt in `scripts/AITriad/Prompts/` with NO `taxonomy-editor/**` change must fail `test-electron (taxonomy-editor)` (promptCatalog.lint fires). Clean arm: a catalogued prompt add passes. Both to Main (TL).

## Test plan
- [ ] TL GV: fire arm (uncatalogued scripts/ prompt, no taxonomy-editor change → lint red)
- [ ] TL GV: clean arm (catalogued prompt add → CI green)

Closes t/2915

🤖 Generated with [Claude Code](https://claude.com/claude-code)