### PR TITLE
feat(summary): promote polarity gate to default-on (t/2912)

### DIFF
--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -70,10 +70,12 @@ function Invoke-DocumentSummary {
         [switch]$IterativeExtraction,
         [switch]$AutoFire,
 
-        # t/2896 — re-enable switch for the directional polarity gate. DEFAULT OFF
-        # (the gate is disabled; see the point-of-use comment at the gate call).
-        # Preserved as a one-flag re-arm for the durable LLM-judge fix (t/2900).
-        [switch]$EnablePolarityGate
+        # Directional polarity gate. DEFAULT ON as of t/2912 — promoted after the
+        # durable two-stage LLM-judge fix (t/2900) cleared both-arms GV + a clean
+        # observe cycle (121 deberta false-positives caught, 0 bad flips on a real
+        # sample). It was default-OFF under t/2896 while deberta over-flagged solo.
+        # Kill switch: pass -EnablePolarityGate:$false to disable.
+        [bool]$EnablePolarityGate = $true
     )
 
     Set-StrictMode -Version Latest

--- a/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
+++ b/scripts/AITriad/Private/Invoke-DocumentSummary.ps1
@@ -886,24 +886,31 @@ function Finalize-Summary {
         # (AI-gains-agency ⊨ humans-lose-oversight), which is the DOMINANT
         # safetyist/skeptic claim shape — so the gate corrupts precisely where it
         # fires most (CL diagnosis t/2896#1; TL [Decision] e/117#3).
-        # RE-ENABLE CONDITION: a model that does agency→loss entailment, wired behind
-        # the LLM-judge directional fix (t/2900). The code path is PRESERVED, not
-        # deleted — re-arm is a single flag: -EnablePolarityGate.
+        # STATUS (t/2912): the gate is ACTIVE BY DEFAULT. The durable two-stage
+        # LLM-judge fix (t/2900) resolved the agency→loss false-demote — deberta
+        # proposes 'opposes' candidates, the gemini-3.1-pro-preview judge disposes
+        # (unanimous-opposes-to-flip @ temp 0.3; fail-safe unresolved/error → KEEP) —
+        # promoted after both-arms GV + a clean observe cycle (121 deberta FPs the
+        # judge rejected, 0 bad flips). Kill switch: -EnablePolarityGate:$false.
         $PolarityCounts = Invoke-PolarityGatePass -KeyPoints $PolarityKps.ToArray() `
             -SkipDirectionalGate:(-not $EnablePolarityGate)
-        if ($PolarityCounts.opposes -gt 0) {
-            Write-Warn ("Polarity gate: {0} inversion(s) flagged (opposes) — counts o={0} a={1} u={2} x={3} over {4} gated" -f `
-                $PolarityCounts.opposes, $PolarityCounts.agrees, $PolarityCounts.unrelated, $PolarityCounts.unresolved, $PolarityCounts.gated)
-        } elseif ($PolarityCounts.reps -gt 0 -and $PolarityCounts.unresolved -eq $PolarityCounts.reps) {
+        if ($EnablePolarityGate -and $PolarityCounts.gated -gt 0) {
+            # t/2900/t/2912 two-stage telemetry — emitted EVERY run so the judge's
+            # flip / false-positive-kept / self-heal rates are observable in prod
+            # (TL GV condition t/2912#3). judge_kept = deberta false-positives the
+            # judge rejected (the payoff); judge_flipped = confirmed demotes;
+            # self_healed = prior false-flips auto-reverted.
+            $polLine = "Polarity gate (two-stage): judge_flipped={0} judge_kept={1} self_healed={2} over {3} gated key_point(s), {4} deberta rep-pair(s)" -f `
+                $PolarityCounts.judge_flipped, $PolarityCounts.judge_kept, $PolarityCounts.self_healed, $PolarityCounts.gated, $PolarityCounts.reps
+            if ($PolarityCounts.judge_flipped -gt 0) { Write-Warn $polLine } else { Write-Info $polLine }
             # Silent-degradation detector: every claim-rep pair unresolved ⇒ the
             # directional engine likely failed for the whole run (fail-safe kept all
             # mappings). Surface by default so a dead engine does not pass unnoticed
             # (TL GV t/2739#6).
-            Write-Warn ("Polarity gate: all {0} claim-rep pair(s) over {1} gated key_point(s) unresolved — directional engine may be down (no inversion detection this run)" -f `
-                $PolarityCounts.reps, $PolarityCounts.gated)
-        } else {
-            Write-Verbose ("Polarity gate: no inversions — counts o=0 a={0} u={1} x={2} over {3} gated" -f `
-                $PolarityCounts.agrees, $PolarityCounts.unrelated, $PolarityCounts.unresolved, $PolarityCounts.gated)
+            if ($PolarityCounts.reps -gt 0 -and $PolarityCounts.unresolved -eq $PolarityCounts.reps) {
+                Write-Warn ("Polarity gate: all {0} claim-rep pair(s) over {1} gated key_point(s) unresolved — directional engine may be down (no inversion detection this run)" -f `
+                    $PolarityCounts.reps, $PolarityCounts.gated)
+            }
         }
     }
 

--- a/tests/Invoke-PolarityGatePass.Tests.ps1
+++ b/tests/Invoke-PolarityGatePass.Tests.ps1
@@ -279,18 +279,21 @@ Describe 'Polarity-gate disable switch (t/2896)' -Tag 'summary' {
 
 Describe 'Invoke-DocumentSummary polarity wiring (t/2896)' -Tag 'summary' {
 
-    It 'exposes -EnablePolarityGate as a switch that defaults OFF (gate disabled by default)' {
+    It 'exposes -EnablePolarityGate as [bool] defaulting ON (t/2912 promotion; kill switch -EnablePolarityGate:$false)' {
         InModuleScope AITriad {
-            $p = (Get-Command Invoke-DocumentSummary).Parameters['EnablePolarityGate']
-            $p                 | Should -Not -BeNullOrEmpty
-            $p.SwitchParameter | Should -BeTrue
+            $ast = (Get-Command Invoke-DocumentSummary).ScriptBlock.Ast
+            $param = $ast.FindAll({
+                $args[0] -is [System.Management.Automation.Language.ParameterAst] -and
+                $args[0].Name.VariablePath.UserPath -eq 'EnablePolarityGate'
+            }, $true) | Select-Object -First 1
+            $param | Should -Not -BeNullOrEmpty
+            $param.StaticType.Name | Should -Be 'Boolean'            # promoted from [switch] to [bool]
+            $param.DefaultValue.Extent.Text | Should -Be '$true'     # gate ACTIVE by default
         }
     }
 
-    It 'call-site contract: -EnablePolarityGate negates into -SkipDirectionalGate' {
-        $off = [switch]$false
-        (-not $off) | Should -BeTrue  -Because 'default-off routes -SkipDirectionalGate:$true (gate skipped)'
-        $on  = [switch]$true
-        (-not $on)  | Should -BeFalse -Because '-EnablePolarityGate routes -SkipDirectionalGate:$false (gate active)'
+    It 'call-site contract: default-ON routes the gate active; -EnablePolarityGate:$false disables' {
+        (-not $true)  | Should -BeFalse -Because 'default -EnablePolarityGate=$true routes -SkipDirectionalGate:$false (gate ACTIVE)'
+        (-not $false) | Should -BeTrue  -Because '-EnablePolarityGate:$false routes -SkipDirectionalGate:$true (gate skipped)'
     }
 }


### PR DESCRIPTION
## t/2912 — promote polarity gate to default-ON

**DRAFT — gated on Main (TL) both-arms PROMOTION GV.** This is the flag flip that turns the two-stage LLM-judge gate on in production. Distinct from the t/2900 mechanism GV (which predated the golden-set correction #1377).

### Change
`-EnablePolarityGate` default **OFF→ON**: `[switch]` → `[bool]$EnablePolarityGate = $true`. Kill switch: `-EnablePolarityGate:$false`. No production caller passes the flag, so the default flip is the whole change; call site `-SkipDirectionalGate:(-not $EnablePolarityGate)` unchanged.

### Pre-flip verification
- **Live acceptance re-run:** UNANIMOUS **4/4 @ temp 0.3** on the corrected golden set (case_4 + case_5a KEEP; case_5b + case_1 FLIP).
- **Observe cycle** (8 real summaries / 163 gated key_points, gate active): **judge_kept=121** (deberta false-positives the judge caught — the OLD single-stage gate would have false-demoted all 121 on this sample), **judge_flipped=0** (no bad demotes), **self_healed=0**. Clean.
- **Unit 18/18** (t/2896 wiring tests updated to assert default-ON via AST + [bool]).

### Rollback
Instant + config-only: `-EnablePolarityGate:$false` at the call, or revert this one-line default.

TL: requesting the both-arms promotion GV. On your approval + CI green I un-draft + self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
