### PR TITLE
feat(scripts): field-surgical JSON writer + adversarial anti-sweep test (t/2916 Phase 1)

### DIFF
--- a/scripts/AITriad/Private/Update-JsonNodeField.ps1
+++ b/scripts/AITriad/Private/Update-JsonNodeField.ps1
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# ── Field-surgical JSON writer (t/2916, TL ruling t/2916#3) ───────────────────
+# Changes ONE field on ONE node[] entry by splicing only that field's bytes in the
+# raw text — every other byte is preserved, so concurrent uncommitted WIP elsewhere
+# in the file cannot ride into the write (the sit-477 sweep). This is the durable fix
+# for the WARN-tier writers the dirty-tree guard can't Block (t/2909).
+#
+# Safety = parse-LOCATE + minimal-SPLICE + re-parse-VERIFY: after splicing we re-parse
+# the result and assert (order-insensitively) that it equals the original with EXACTLY
+# the intended field change — anything else throws New-ActionableError and writes
+# nothing. That invariant is what makes byte-surgery safe regardless of splice edge cases.
+
+function ConvertTo-CanonicalForm {
+    # Recursively normalize a ConvertFrom-Json value into order-insensitive canonical
+    # form (sorted hashtable keys) so the verify compares DATA, not key order/formatting.
+    param([Parameter(Mandatory)][AllowNull()]$Value)
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [System.Management.Automation.PSCustomObject]) {
+        $out = [ordered]@{}
+        foreach ($p in ($Value.PSObject.Properties | Sort-Object Name)) {
+            $out[$p.Name] = ConvertTo-CanonicalForm -Value $p.Value
+        }
+        return $out
+    }
+    if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+        return @($Value | ForEach-Object { ConvertTo-CanonicalForm -Value $_ })
+    }
+    return $Value
+}
+
+function Test-JsonSemanticEqual {
+    param([Parameter(Mandatory)][AllowNull()]$A, [Parameter(Mandatory)][AllowNull()]$B)
+    $ca = ConvertTo-CanonicalForm -Value $A | ConvertTo-Json -Depth 100 -Compress
+    $cb = ConvertTo-CanonicalForm -Value $B | ConvertTo-Json -Depth 100 -Compress
+    return $ca -eq $cb
+}
+
+function Find-JsonObjectSpan {
+    # Single-pass, string/escape-aware forward scan: given a char index KNOWN to be
+    # inside a { } object, return @{ Start; End } for the INNERMOST enclosing object
+    # (indices of its '{' and matching '}'). A brace stack tracks nesting; at the inner
+    # index we capture the innermost open '{', then return when its matching '}' pops.
+    param([Parameter(Mandatory)][string]$Text, [Parameter(Mandatory)][int]$InnerIndex)
+
+    $stack = New-Object System.Collections.Generic.Stack[int]
+    $inStr = $false; $esc = $false; $targetOpen = -1
+    for ($i = 0; $i -lt $Text.Length; $i++) {
+        $c = $Text[$i]
+        if ($inStr) {
+            if ($esc) { $esc = $false }
+            elseif ($c -eq '\') { $esc = $true }
+            elseif ($c -eq '"') { $inStr = $false }
+        }
+        else {
+            if ($c -eq '"') { $inStr = $true }
+            elseif ($c -eq '{') { $stack.Push($i) }
+            elseif ($c -eq '}') {
+                if ($stack.Count -eq 0) { return $null }
+                $popped = $stack.Pop()
+                if ($targetOpen -ge 0 -and $popped -eq $targetOpen) { return @{ Start = $targetOpen; End = $i } }
+            }
+        }
+        # Once we reach the inner index, the innermost currently-open '{' is our object.
+        if ($i -eq $InnerIndex -and $targetOpen -lt 0) {
+            if ($stack.Count -eq 0) { return $null }
+            $targetOpen = $stack.Peek()
+        }
+    }
+    return $null
+}
+
+function Update-JsonNodeField {
+    <#
+    .SYNOPSIS
+        Field-surgical update of ONE field on ONE nodes[] entry (t/2916). Byte-preserving
+        everywhere except the target field; re-parse-verified before returning.
+    .OUTPUTS
+        [string] the patched raw JSON. Throws New-ActionableError (writes nothing) if the
+        node is absent, the splice can't be located, the result isn't valid JSON, or the
+        re-parse-verify detects any change beyond the intended field.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string]$RawText,
+        [Parameter(Mandatory)][string]$NodeId,
+        [Parameter(Mandatory)][string]$Field,
+        [Parameter(Mandatory)][AllowNull()]$Value
+    )
+    Set-StrictMode -Version Latest
+
+    $fail = {
+        param($problem, $steps)
+        throw (New-ActionableError -Goal "Field-surgical update of '$Field' on node '$NodeId'" `
+            -Problem $problem -Location 'Update-JsonNodeField' -NextSteps $steps -PassThru)
+    }
+
+    # --- Parse (locate + verification baseline) ---
+    try { $original = $RawText | ConvertFrom-Json } catch { & $fail "Input is not valid JSON: $($_.Exception.Message)" @('Pass well-formed JSON text') }
+    if (-not $original.PSObject.Properties['nodes']) { & $fail "No nodes[] array in the JSON" @('Expected a top-level nodes[] array') }
+    $match = @($original.nodes | Where-Object { $_.PSObject.Properties['id'] -and $_.id -eq $NodeId })
+    if ($match.Count -eq 0) { & $fail "Node id '$NodeId' not found in nodes[]" @("Verify the node id exists in the file") }
+
+    # --- Locate the node object's span (parse-guided, string-aware) ---
+    $idToken = [regex]::Match($RawText, '"id"\s*:\s*"' + [regex]::Escape($NodeId) + '"')
+    if (-not $idToken.Success) { & $fail "id token for '$NodeId' not found in raw text" @('File text may not match the parsed structure') }
+    $span = Find-JsonObjectSpan -Text $RawText -InnerIndex $idToken.Index
+    if ($null -eq $span) { & $fail "could not locate the enclosing object span for '$NodeId'" @('Check the JSON is well-formed') }
+    $objText = $RawText.Substring($span.Start, $span.End - $span.Start + 1)
+
+    # --- Encode the new value as a JSON literal ---
+    $encoded = $Value | ConvertTo-Json -Depth 100 -Compress
+
+    # --- Splice: replace the field value if present within THIS object, else insert ---
+    $fieldRx = '("' + [regex]::Escape($Field) + '"\s*:\s*)(' +
+               '"(?:[^"\\]|\\.)*"|-?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?|true|false|null' + ')'
+    $fm = [regex]::Match($objText, $fieldRx)
+    if ($fm.Success) {
+        $newObjText = $objText.Substring(0, $fm.Index) + $fm.Groups[1].Value + $encoded +
+                      $objText.Substring($fm.Index + $fm.Length)
+    } else {
+        # Absent-key insert at a parse-located point: right after the opening '{'.
+        $insertAt = 1   # just past '{'
+        $newObjText = $objText.Substring(0, $insertAt) + " `"$Field`": $encoded," + $objText.Substring($insertAt)
+    }
+    $patched = $RawText.Substring(0, $span.Start) + $newObjText + $RawText.Substring($span.End + 1)
+
+    # --- Re-parse-VERIFY invariant (the safety net) ---
+    try { $actual = $patched | ConvertFrom-Json } catch { & $fail "patched text is not valid JSON — writing nothing: $($_.Exception.Message)" @('Splice produced invalid JSON; this is a bug in Update-JsonNodeField') }
+    $expected = $RawText | ConvertFrom-Json
+    $expNode = @($expected.nodes | Where-Object { $_.PSObject.Properties['id'] -and $_.id -eq $NodeId })[0]
+    if ($expNode.PSObject.Properties[$Field]) { $expNode.$Field = $Value }
+    else { $expNode | Add-Member -NotePropertyName $Field -NotePropertyValue $Value -Force }
+    if (-not (Test-JsonSemanticEqual -A $expected -B $actual)) {
+        & $fail "re-parse-verify FAILED: the splice changed more than the intended field '$Field' on '$NodeId' — writing nothing" `
+            @('This is a splice bug; the guard refused a corrupting write', 'Report with the input file + node id')
+    }
+    return $patched
+}

--- a/scripts/AITriad/Private/Update-JsonNodeField.ps1
+++ b/scripts/AITriad/Private/Update-JsonNodeField.ps1
@@ -11,6 +11,15 @@
 # the result and assert (order-insensitively) that it equals the original with EXACTLY
 # the intended field change — anything else throws New-ActionableError and writes
 # nothing. That invariant is what makes byte-surgery safe regardless of splice edge cases.
+#
+# LIMITATION (scalar-only field values): the in-place splice locates the field's value
+# token via a regex that matches only JSON SCALARS (string / number / bool / null). If
+# the target field currently holds an OBJECT or ARRAY, the value token is not matched and
+# the code falls to the absent-key insert branch — producing a DUPLICATE key. That is a
+# safe failure, not a corrupting one: the re-parse-VERIFY step rejects it (PS7
+# ConvertFrom-Json throws on duplicate keys) so the helper throws New-ActionableError and
+# writes nothing. Callers needing to rewrite object/array-valued fields must use a
+# different mechanism; this helper is for the scalar node-field backfills (t/2916 scope).
 
 function ConvertTo-CanonicalForm {
     # Recursively normalize a ConvertFrom-Json value into order-insensitive canonical

--- a/tests/Update-JsonNodeField.Tests.ps1
+++ b/tests/Update-JsonNodeField.Tests.ps1
@@ -1,0 +1,107 @@
+# Tag: summary (t/2916)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Adversarial anti-sweep suite for the field-surgical writer Update-JsonNodeField
+    (t/2916, TL ruling t/2916#3). Written FIRST (TDD). The helper must:
+      - parse-LOCATE the target node + field (not naive string-search),
+      - minimal-SPLICE only that field's value (or insert an absent key at a
+        parse-located point),
+      - re-parse-VERIFY: the deep-diff vs the intended change must be EXACTLY the one
+        field, else throw New-ActionableError and return nothing (write nothing).
+    The written text must be byte-preserving everywhere except the target field, so
+    concurrent WIP elsewhere in the file cannot ride into the write (the sit-477 sweep).
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    # A situations-like fixture. Deliberately adversarial:
+    #  - sit-001 has both "type" and "disagreement_type" (substring collision) AND a
+    #    "note" whose TEXT contains the literal string "disagreement_type".
+    #  - sit-002 LACKS disagreement_type (absent-key insert case).
+    #  - sit-003 carries unrelated concurrent WIP (resolved_node_id: sit-477, ratio: 3.0)
+    #    AND the SAME field+value ("disagreement_type": "empirical") as sit-001 — proving
+    #    the locate is node-scoped, not a global value replace.
+    $script:Fixture = @'
+{
+  "nodes": [
+    { "id": "sit-001", "type": "situation", "disagreement_type": "empirical", "note": "mentions disagreement_type in prose" },
+    { "id": "sit-002", "label": "no dtype yet" },
+    { "id": "sit-003", "disagreement_type": "empirical", "resolved_node_id": "sit-477", "ratio": 3.0 }
+  ]
+}
+'@ -replace "`r`n", "`n"
+}
+
+Describe 'Update-JsonNodeField — adversarial anti-sweep (t/2916)' -Tag 'summary' {
+
+    It '1. basic value replace: only the target node/field changes' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodeField -RawText $Raw -NodeId 'sit-001' -Field 'disagreement_type' -Value 'normative'
+            $o = $out | ConvertFrom-Json
+            (@($o.nodes) | Where-Object { $_.id -eq 'sit-001' }).disagreement_type | Should -Be 'normative'
+            (@($o.nodes) | Where-Object { $_.id -eq 'sit-003' }).disagreement_type | Should -Be 'empirical'  # untouched
+        }
+    }
+
+    It '2. field-name-substring collision: "type" vs "disagreement_type" + prose mention are not confused' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodeField -RawText $Raw -NodeId 'sit-001' -Field 'type' -Value 'crux'
+            $o = @($out | ConvertFrom-Json | Select-Object -ExpandProperty nodes | Where-Object { $_.id -eq 'sit-001' })[0]
+            $o.type              | Should -Be 'crux'
+            $o.disagreement_type | Should -Be 'empirical'                    # collider untouched
+            $o.note              | Should -Be 'mentions disagreement_type in prose'  # prose untouched
+        }
+    }
+
+    It '3. absent-key insert (parse-located): adds the field, stays valid JSON' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodeField -RawText $Raw -NodeId 'sit-002' -Field 'disagreement_type' -Value 'insufficient'
+            $o = @($out | ConvertFrom-Json | Select-Object -ExpandProperty nodes | Where-Object { $_.id -eq 'sit-002' })[0]
+            $o.disagreement_type | Should -Be 'insufficient'
+            $o.label             | Should -Be 'no dtype yet'   # existing field preserved
+        }
+    }
+
+    It '4. escaping: quotes / backslash / newline round-trip exactly' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $tricky = 'He said "hi"' + "`n" + 'C:\path\to'
+            $out = Update-JsonNodeField -RawText $Raw -NodeId 'sit-001' -Field 'disagreement_type' -Value $tricky
+            (@($out | ConvertFrom-Json | Select-Object -ExpandProperty nodes | Where-Object { $_.id -eq 'sit-001' })[0]).disagreement_type | Should -Be $tricky
+        }
+    }
+
+    It '5. anti-sweep: concurrent foreign WIP survives BYTE-IDENTICAL' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodeField -RawText $Raw -NodeId 'sit-001' -Field 'disagreement_type' -Value 'normative'
+            # sit-003's foreign WIP (the sit-477 add + the 3.0 float) must be untouched, byte-for-byte.
+            $out | Should -BeLike '*"resolved_node_id": "sit-477"*'
+            $out | Should -BeLike '*"ratio": 3.0*'   # NOT churned to 3
+            # And ONLY the sit-001 disagreement_type line differs from the original.
+            $origLines = @($Raw    -split "`n")
+            $newLines  = @($out    -split "`n")
+            $newLines.Count | Should -Be $origLines.Count
+            $diff = for ($i = 0; $i -lt $origLines.Count; $i++) { if ($origLines[$i] -ne $newLines[$i]) { $i } }
+            @($diff).Count | Should -Be 1   # exactly one changed line
+        }
+    }
+
+    It '6. safety: unknown node id throws New-ActionableError and returns nothing' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            { Update-JsonNodeField -RawText $Raw -NodeId 'sit-999' -Field 'disagreement_type' -Value 'x' } |
+                Should -Throw
+        }
+    }
+}

--- a/tests/Update-JsonNodeField.Tests.ps1
+++ b/tests/Update-JsonNodeField.Tests.ps1
@@ -104,4 +104,47 @@ Describe 'Update-JsonNodeField — adversarial anti-sweep (t/2916)' -Tag 'summar
                 Should -Throw
         }
     }
+
+    It '7. multi-node sequential composition: chained edits all land AND foreign WIP survives byte-identical' {
+        # The actual batch-writer pattern (TL GV t/2916#5): feed each call's output as the
+        # next call's RawText. Each call re-parses from scratch, so there is no cross-call
+        # offset state — but an offset bug would hide HERE, so prove it end-to-end.
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out1 = Update-JsonNodeField -RawText $Raw  -NodeId 'sit-001' -Field 'disagreement_type' -Value 'normative'
+            $out2 = Update-JsonNodeField -RawText $out1 -NodeId 'sit-002' -Field 'disagreement_type' -Value 'insufficient'
+
+            $o = @($out2 | ConvertFrom-Json | Select-Object -ExpandProperty nodes)
+            (@($o | Where-Object { $_.id -eq 'sit-001' })[0]).disagreement_type | Should -Be 'normative'    # first edit persisted
+            (@($o | Where-Object { $_.id -eq 'sit-002' })[0]).disagreement_type | Should -Be 'insufficient' # second edit landed
+            (@($o | Where-Object { $_.id -eq 'sit-002' })[0]).label             | Should -Be 'no dtype yet'  # existing field preserved
+
+            # Foreign WIP on the untouched node survives byte-identical across BOTH edits.
+            $out2 | Should -BeLike '*"resolved_node_id": "sit-477"*'
+            $out2 | Should -BeLike '*"ratio": 3.0*'
+            # Exactly two lines differ from the original (one per edit); no churn, no line drift.
+            $origLines = @($Raw  -split "`n")
+            $newLines  = @($out2 -split "`n")
+            $newLines.Count | Should -Be $origLines.Count
+            $diff = for ($i = 0; $i -lt $origLines.Count; $i++) { if ($origLines[$i] -ne $newLines[$i]) { $i } }
+            @($diff).Count | Should -Be 2
+        }
+    }
+
+    It '8. scalar-only limitation: an object/array-valued field is a SAFE THROW, not corruption (writes nothing)' {
+        # Documented limitation (see helper header): the in-place splice matches only scalar
+        # value tokens. An object/array-valued field falls to the insert branch → duplicate
+        # key → re-parse-VERIFY rejects it. Prove it fails safe rather than corrupting.
+        InModuleScope AITriad {
+            $objFixture = @'
+{
+  "nodes": [
+    { "id": "sit-obj", "meta": { "a": 1 }, "note": "has an object-valued field" }
+  ]
+}
+'@ -replace "`r`n", "`n"
+            { Update-JsonNodeField -RawText $objFixture -NodeId 'sit-obj' -Field 'meta' -Value 'scalar' } |
+                Should -Throw
+        }
+    }
 }


### PR DESCRIPTION
## t/2916 Phase 1 — field-surgical JSON writer `Update-JsonNodeField` + adversarial anti-sweep test

**DRAFT — for Main (TL) GV.** The sweep-proof primitive for the WARN-tier durable fix (ruling t/2916#3). Inert on merge (no writer wired yet) → safe to land on GV + green; writer wiring follows on top.

### Mechanism (per your ruling)
- **parse-LOCATE:** single-pass, string/escape-aware brace-stack scan finds the target node's object span (not naive string-search).
- **minimal-SPLICE:** replace only the field's value token, or insert an absent key at the parse-located object start.
- **re-parse-VERIFY invariant (the safety net):** re-parse the patched text; canonical order-insensitive deep-equal vs (original + intended change). ANY delta beyond the one field → `New-ActionableError`, **writes nothing**. This makes byte-surgery safe regardless of splice edge cases.

### Adversarial anti-sweep test (TDD, written first) — 6/6
1. basic value replace (only target changes) · 2. field-name substring collision (`type` vs `disagreement_type` + a prose mention of the field name) · 3. parse-located absent-key insert · 4. quote/backslash/newline escaping round-trips · 5. **byte-identical foreign-WIP survival** (a `sit-477` add + a `3.0` float untouched — the anti-sweep proof) · 6. unknown-node safety (throws, writes nothing).

### Next (on top of this GV'd primitive)
Wire the situations writers via **read-fresh-then-splice** (`Invoke-DisagreementTypeBackfill` POC first, then `Invoke-CcToSitMigration`) + a Python mirror for `reprocess_taxonomy_vocabulary`. Pairs with explicit-path staging (never `git add -A`). Phase 2 = Repair-Pov*/batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
