### PR TITLE
feat(scripts): surgical-write orchestrator + BLOCK-tier exemption + wire backfill (t/2916)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -156,6 +156,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | Cmdlet | Use when |
 |--------|----------|
 | `Assert-CleanDataTree` | Before a whole-file rewrite of a data-repo JSON, assert the target has no uncommitted changes — so a `ConvertFrom-Json \| ConvertTo-Json` (or Python `json.load`→`json.dump`) round-trip can't sweep concurrent working-tree state into the commit (t/2902; `-Force` downgrades the block to a warning). Also exposed as the opt-in `Write-Utf8NoBom -RequireCleanTree` switch. |
+| `Save-JsonNodeFieldEdits` | Use when a writer needs to set scalar `nodes[]` fields in a data-repo JSON without a whole-file round-trip. Reads fresh, splices ONLY the target fields via a re-parse-verified byte-preserving primitive, writes once through the guarded sink — so it cannot sweep concurrent WIP and is safe even on the perpetually-dirty BLOCK-tier `situations.json` (t/2916). Returns a summary (Applied + NotFound). Pair with explicit-path staging at commit. |
 
 **Centralized data-write guard (t/2902 Part 2).** Every data-of-record write in the module funnels through a guarded sink, so individual cmdlets need no per-callsite wiring:
 

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -73,6 +73,7 @@
         'Test-TaxonomyIntegrity'
         'Test-TaxonomyDir'
         'Assert-CleanDataTree'
+        'Save-JsonNodeFieldEdits'
         'Invoke-HierarchyProposal'
         'Set-TaxonomyHierarchy'
         'Invoke-SchemaMigration'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -815,6 +815,8 @@ Export-ModuleMember -Function @(
     'Test-TaxonomyDir'
     # t/2902 — dirty-tree-sweep guard for whole-file data-repo writes
     'Assert-CleanDataTree'
+    # t/2916 — durable batch writer: field-surgical node-field edits (sweep-proof)
+    'Save-JsonNodeFieldEdits'
     'Invoke-HierarchyProposal'
     'Set-TaxonomyHierarchy'
     'Invoke-SchemaMigration'

--- a/scripts/AITriad/Private/Assert-DataWriteAllowed.ps1
+++ b/scripts/AITriad/Private/Assert-DataWriteAllowed.ps1
@@ -103,6 +103,20 @@ function Assert-DataWriteAllowed {
     .PARAMETER AllowDirty
         Opt-out for a writer that legitimately rewrites a target left dirty by a
         prior pass in the same sequence (t/2902 condition 4). Bypasses the guard.
+        Semantics: "the tree is dirty and I am choosing to ignore that" — a blanket
+        override. Do NOT use it for surgical writes; use -SurgicalWrite (below).
+    .PARAMETER SurgicalWrite
+        Distinct, semantically-honest exemption for a FIELD-SURGICAL write (t/2916,
+        TL ruling t/2916#8). Its claim is NOT "ignore the dirty tree" but "this write
+        is sweep-proof BY CONSTRUCTION, so the dirty-tree check is N/A." Earned only by
+        Save-JsonNodeFieldEdits, whose every write goes through Update-JsonNodeField's
+        re-parse-verify invariant + byte-identical foreign-WIP preservation (proven in
+        Update-JsonNodeField tests 5/7 and SurgicalWriteExemption.Tests.ps1). Kept
+        SEPARATE from -AllowDirty on purpose: the two carry different risk profiles, and
+        overloading one flag would make a `grep -AllowDirty` unable to tell "provably
+        safe surgical" from "blanket override — scrutinize." Reachable only via the
+        orchestrator (enforced by the detection gate in SurgicalWriteExemption.Tests.ps1),
+        so a whole-file writer cannot claim it and bypass the BLOCK tier.
     .OUTPUTS
         None. In Block mode a dirty data-target throws (New-ActionableError via
         Assert-CleanDataTree); in Warn mode it warns and proceeds.
@@ -113,8 +127,16 @@ function Assert-DataWriteAllowed {
         [Parameter(Mandatory)]
         [string]$Path,
 
-        [switch]$AllowDirty
+        [switch]$AllowDirty,
+
+        [switch]$SurgicalWrite
     )
+    # t/2916 Fork 2 (TL t/2916#8) — surgical-write exemption. A field-surgical write is
+    # sweep-proof by construction (re-parse-verify + byte-identical preservation), so the
+    # dirty-tree check is N/A: return BEFORE consulting the tier or the tree. This is the
+    # one write that is SAFE on a dirty BLOCK-tier file; blocking it would defeat t/2916.
+    # Kept distinct from -AllowDirty (blanket override) so the audit trail stays honest.
+    if ($SurgicalWrite) { return }
     if ($AllowDirty) { return }
     $mode = Get-DataWriteGuardMode -Path $Path   # per-target tier (t/2909)
     if ($mode -eq 'Off') { return }

--- a/scripts/AITriad/Private/Write-Utf8NoBom.ps1
+++ b/scripts/AITriad/Private/Write-Utf8NoBom.ps1
@@ -21,7 +21,14 @@ function Write-Utf8NoBom {
 
         # t/2902 — opt a legitimate sequential rewriter out of the dirty-tree guard
         # (a target intentionally left dirty by a prior pass in the same run).
-        [switch]$AllowDirty
+        [switch]$AllowDirty,
+
+        # t/2916 Fork 2 (TL t/2916#8) — forward the FIELD-SURGICAL exemption to the guard.
+        # A surgical write is sweep-proof by construction, so the dirty-tree check is N/A.
+        # This is a PASS-THROUGH conduit only: it must be set solely by Save-JsonNodeFieldEdits
+        # (enforced by the detection gate in SurgicalWriteExemption.Tests.ps1). A whole-file
+        # writer must never set it — that would let it bypass the BLOCK tier.
+        [switch]$SurgicalWrite
     )
     begin {
         $parts = New-Object System.Collections.Generic.List[string]
@@ -64,7 +71,8 @@ function Write-Utf8NoBom {
             }
         }
         elseif (Get-Command Assert-DataWriteAllowed -ErrorAction SilentlyContinue) {
-            Assert-DataWriteAllowed -Path $Path -AllowDirty:$AllowDirty
+            # t/2916 — forward the surgical exemption (set only by Save-JsonNodeFieldEdits).
+            Assert-DataWriteAllowed -Path $Path -AllowDirty:$AllowDirty -SurgicalWrite:$SurgicalWrite
         }
         Set-Content -Path $Path -Value $text -Encoding utf8NoBOM -NoNewline
     }

--- a/scripts/AITriad/Public/Save-JsonNodeFieldEdits.ps1
+++ b/scripts/AITriad/Public/Save-JsonNodeFieldEdits.ps1
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Save-JsonNodeFieldEdits {
+    <#
+    .SYNOPSIS
+        Durable batch writer for scalar node-field edits (t/2916, TL ruling t/2916#8).
+        The single public entry every WARN/BLOCK-tier field-backfill writer calls instead
+        of a whole-file `ConvertFrom-Json | ConvertTo-Json` round-trip.
+    .DESCRIPTION
+        Reads the target FRESH from disk (so any WIP that landed during a long, AI-bound
+        pass is preserved), applies each edit via the Private field-surgical primitive
+        Update-JsonNodeField — chaining each call's output as the next call's RawText — then
+        writes ONCE through the guarded sink (Write-Utf8NoBom) with the surgical exemption.
+        Because every splice preserves untouched bytes, a write cannot sweep concurrent WIP
+        elsewhere in the file regardless of tree state (the sit-477 sweep, t/2896).
+
+        SWEEP PREVENTION IS TWO HALVES (TL t/2916#3): this keeps foreign WIP separable
+        (a minimal per-field diff vs distinct WIP hunks); the OTHER half is explicit-path /
+        hunk staging at commit — NEVER `git add -A`, or a stray `git add <file>` re-sweeps
+        the WIP into the commit.
+
+        The surgical exemption to the BLOCK-tier dirty-tree guard is claimed ONLY here
+        (Assert-DataWriteAllowed -SurgicalWrite, forwarded via Write-Utf8NoBom). It is
+        earned because every write through this path is verified surgical by
+        Update-JsonNodeField's re-parse-verify invariant + byte-identical preservation
+        (proven in Update-JsonNodeField tests 5/7 and SurgicalWriteExemption.Tests.ps1).
+
+    .PARAMETER Path
+        The target JSON file (a nodes[] document) to edit in place.
+    .PARAMETER Edits
+        One or more edit hashtables, each @{ NodeId=<id>; Field=<name>; Value=<scalar> }.
+        Applied in order; each is a single scalar field on a single node. Object/array
+        values are unsupported and safe-abort via Update-JsonNodeField's verify.
+    .OUTPUTS
+        [pscustomobject] result summary: Applied (int), NotFound (string[] — NodeIds not
+        present in the file, surfaced not silently dropped), Path. Throws New-ActionableError
+        (writing NOTHING) if the file is missing, an edit is malformed, or any surgical
+        splice fails its re-parse-verify (the batch is atomic on unexpected failure).
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [hashtable[]]$Edits
+    )
+    Set-StrictMode -Version Latest
+
+    $fail = {
+        param($problem, $steps)
+        throw (New-ActionableError -Goal "Apply $(@($Edits).Count) field-surgical edit(s) to '$Path'" `
+            -Problem $problem -Location 'Save-JsonNodeFieldEdits' -NextSteps $steps -PassThru)
+    }
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        & $fail "Target file not found: $Path" @('Verify the path exists before calling Save-JsonNodeFieldEdits')
+    }
+
+    # --- Read FRESH (read-fresh-at-write timing, TL t/2916#8) ---
+    $raw = Get-Content -Raw -LiteralPath $Path
+    try { $parsed = $raw | ConvertFrom-Json } catch {
+        & $fail "Target is not valid JSON: $($_.Exception.Message)" @('The file must be a well-formed nodes[] document')
+    }
+    if (-not $parsed.PSObject.Properties['nodes']) {
+        & $fail 'Target has no top-level nodes[] array' @('Expected a { "nodes": [ ... ] } document')
+    }
+    # Stable id set: surgical edits change field VALUES / insert absent keys — never add or
+    # remove nodes — so the id membership computed from the fresh read holds for the batch.
+    $existingIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($n in @($parsed.nodes)) {
+        if ($n.PSObject.Properties['id']) { [void]$existingIds.Add([string]$n.id) }
+    }
+
+    $applied  = 0
+    $notFound = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($edit in @($Edits)) {
+        foreach ($key in @('NodeId', 'Field', 'Value')) {
+            if (-not $edit.ContainsKey($key)) {
+                & $fail "An edit hashtable is missing required key '$key'" @('Each edit must be @{ NodeId=..; Field=..; Value=.. }')
+            }
+        }
+        $nodeId = [string]$edit['NodeId']
+        if (-not $existingIds.Contains($nodeId)) {
+            # Surface, never silently drop (the observability half of the sweep-class lesson).
+            $notFound.Add($nodeId)
+            Write-Warning "Save-JsonNodeFieldEdits: node '$nodeId' not found in $Path — skipped (not written)."
+            continue
+        }
+        # Chain: each surgical splice consumes the prior result. A verify failure THROWS
+        # (writes nothing yet) → the whole batch aborts atomically, leaving the file untouched.
+        $raw = Update-JsonNodeField -RawText $raw -NodeId $nodeId -Field $edit['Field'] -Value $edit['Value']
+        $applied++
+    }
+
+    if ($applied -gt 0) {
+        if ($PSCmdlet.ShouldProcess($Path, "Apply $applied field-surgical edit(s)")) {
+            # Surgical exemption claimed HERE ONLY (t/2916#8): sweep-proof by construction,
+            # so it proceeds even on a dirty BLOCK-tier target. Forwarded through the sink.
+            Write-Utf8NoBom -Path $Path -Value $raw -NoNewline -SurgicalWrite
+        }
+    }
+
+    return [pscustomobject]@{
+        Applied  = $applied
+        NotFound = $notFound.ToArray()
+        Path     = $Path
+    }
+}

--- a/scripts/Invoke-DisagreementTypeBackfill.ps1
+++ b/scripts/Invoke-DisagreementTypeBackfill.ps1
@@ -34,8 +34,9 @@ $PSNativeCommandUseErrorActionPreference = $false
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 Import-Module (Join-Path $PSScriptRoot 'AIEnrich.psm1') -Force -WarningAction SilentlyContinue
-# t/2902 — standalone script: import AITriad for the dirty-tree-sweep guard
-# (Assert-CleanDataTree) used before the whole-file situations.json write below.
+# t/2916 — standalone script: import AITriad for the field-surgical durable writer
+# (Save-JsonNodeFieldEdits) used for the situations.json write below (t/2902 whole-file
+# guard superseded by byte-preserving surgical writes).
 Import-Module (Join-Path $PSScriptRoot 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
 
 # ── Resolve situations.json path ─────────────────────────────────────────────
@@ -256,6 +257,9 @@ $counts = @{ definitional = 0; interpretive = 0; structural = 0; insufficient = 
 $written = 0
 $skipped = 0
 $errors  = 0
+# t/2916 — collect field-surgical edits; apply them via Save-JsonNodeFieldEdits at the end
+# instead of a whole-file round-trip (which would sweep concurrent situations.json WIP).
+$edits = [System.Collections.Generic.List[hashtable]]::new()
 
 for ($i = 0; $i -lt $toClassify.Count; $i++) {
     $node   = $toClassify[$i]
@@ -296,13 +300,10 @@ for ($i = 0; $i -lt $toClassify.Count; $i++) {
 
     $counts[$label]++
 
-    # Mutate the live node object (same reference as in $Raw.nodes)
-    $liveNode = @($Raw.nodes | Where-Object { $_.id -eq $nodeId })[0]
-    if ($liveNode.PSObject.Properties['disagreement_type']) {
-        $liveNode.disagreement_type = $label
-    } else {
-        $liveNode | Add-Member -NotePropertyName 'disagreement_type' -NotePropertyValue $label -Force
-    }
+    # t/2916 — record a field-surgical edit (scalar disagreement_type on this node).
+    # The byte-preserving splice happens at write time via Save-JsonNodeFieldEdits, which
+    # re-reads situations.json fresh; no live whole-file object is mutated here.
+    $edits.Add(@{ NodeId = $nodeId; Field = 'disagreement_type'; Value = $label })
     $written++
 }
 
@@ -323,15 +324,21 @@ if ($DryRun) {
     exit 0
 }
 
-# Serialize and write using the situations.json writer contract:
-# ConvertTo-Json -Depth 20, UTF-8 without BOM.
+# ── Write results — field-surgical (t/2916), NOT a whole-file round-trip ─────────
+# Save-JsonNodeFieldEdits re-reads situations.json FRESH, splices ONLY disagreement_type
+# on each classified node (every other byte preserved), and writes once through the guarded
+# sink with the surgical exemption. Sweep-proof by construction: it cannot bundle concurrent
+# situation-node WIP into the write regardless of tree state (the sit-477 sweep, t/2896) —
+# which also lets it proceed on the perpetually-dirty BLOCK-tier situations.json. PAIR WITH
+# EXPLICIT-PATH STAGING at commit — never `git add -A` — the other half of sweep prevention
+# (TL t/2916#3, #8).
 Write-Host ''
-Write-Host 'Writing situations.json...' -ForegroundColor Cyan
-$json = $Raw | ConvertTo-Json -Depth 20
-# t/2902 — guard against sweeping concurrent uncommitted situations.json edits into
-# this whole-file rewrite. Warn-first (-Force warns and proceeds); drop -Force to block.
-Assert-CleanDataTree -Path $SituationsPath -Force
-[System.IO.File]::WriteAllText($SituationsPath, $json, (New-Object System.Text.UTF8Encoding $false))
+Write-Host 'Writing situations.json (field-surgical)...' -ForegroundColor Cyan
+$saveResult = Save-JsonNodeFieldEdits -Path $SituationsPath -Edits $edits.ToArray()
+Write-Host "  Applied $($saveResult.Applied) surgical edit(s)." -ForegroundColor Green
+if (@($saveResult.NotFound).Count -gt 0) {
+    Write-Warning "situations.json: $(@($saveResult.NotFound).Count) classified node(s) not found at write time (skipped): $($saveResult.NotFound -join ', ')"
+}
 Write-Host 'Done.' -ForegroundColor Green
 
 # ── Summary for t/2170 comment ────────────────────────────────────────────────

--- a/tests/Save-JsonNodeFieldEdits.Tests.ps1
+++ b/tests/Save-JsonNodeFieldEdits.Tests.ps1
@@ -1,0 +1,104 @@
+# Tag: summary (t/2916)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Save-JsonNodeFieldEdits — the Public durable batch writer (t/2916 Fork 1,
+    TL ruling t/2916#8). It reads the target fresh, applies each edit via the Private
+    Update-JsonNodeField (chaining RawText->next), writes once via the guarded sink with
+    the surgical exemption, and returns a result summary (Applied + NotFound) so a
+    not-found node never vanishes silently. TestDrive targets are outside the data root,
+    so the dirty-tree guard no-ops here — the exemption itself is proved in
+    SurgicalWriteExemption.Tests.ps1.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Save-JsonNodeFieldEdits — durable batch writer (t/2916)' -Tag 'summary' {
+
+    BeforeEach {
+        $script:fixture = @'
+{
+  "nodes": [
+    { "id": "sit-001", "type": "situation", "disagreement_type": "empirical" },
+    { "id": "sit-002", "label": "no dtype yet" },
+    { "id": "sit-003", "disagreement_type": "empirical", "resolved_node_id": "sit-477", "ratio": 3.0 }
+  ]
+}
+'@ -replace "`r`n", "`n"
+        $script:path = Join-Path $TestDrive 'situations-fixture.json'
+        [System.IO.File]::WriteAllText($script:path, $script:fixture, (New-Object System.Text.UTF8Encoding $false))
+    }
+
+    It 'applies multiple edits (read-fresh + chained splice) and preserves foreign WIP byte-identical' {
+        $edits = @(
+            @{ NodeId = 'sit-001'; Field = 'disagreement_type'; Value = 'normative' }
+            @{ NodeId = 'sit-002'; Field = 'disagreement_type'; Value = 'interpretive' }
+        )
+        $result = Save-JsonNodeFieldEdits -Path $script:path -Edits $edits
+        $result.Applied | Should -Be 2
+
+        $after = Get-Content -Raw -Path $script:path
+        $o = @(($after | ConvertFrom-Json).nodes)
+        (@($o | Where-Object { $_.id -eq 'sit-001' })[0]).disagreement_type | Should -Be 'normative'
+        (@($o | Where-Object { $_.id -eq 'sit-002' })[0]).disagreement_type | Should -Be 'interpretive'
+        (@($o | Where-Object { $_.id -eq 'sit-002' })[0]).label             | Should -Be 'no dtype yet'
+        # foreign WIP on the untouched node survives byte-identical (the sit-477 shape)
+        $after | Should -BeLike '*"resolved_node_id": "sit-477"*'
+        $after | Should -BeLike '*"ratio": 3.0*'
+        # exactly two lines differ from the original — no whole-file churn
+        $origLines = @($script:fixture -split "`n")
+        $newLines  = @($after -split "`n")
+        $newLines.Count | Should -Be $origLines.Count
+        $diff = for ($i = 0; $i -lt $origLines.Count; $i++) { if ($origLines[$i] -ne $newLines[$i]) { $i } }
+        @($diff).Count | Should -Be 2
+    }
+
+    It 'surfaces not-found NodeIds in the result summary (no silent skip) and still lands the valid edits' {
+        $edits = @(
+            @{ NodeId = 'sit-001'; Field = 'disagreement_type'; Value = 'normative' }
+            @{ NodeId = 'sit-999'; Field = 'disagreement_type'; Value = 'x' }   # absent node
+        )
+        $result = Save-JsonNodeFieldEdits -Path $script:path -Edits $edits
+        $result.Applied  | Should -Be 1
+        $result.NotFound | Should -Contain 'sit-999'
+        (@((Get-Content -Raw -Path $script:path | ConvertFrom-Json).nodes | Where-Object { $_.id -eq 'sit-001' })[0]).disagreement_type | Should -Be 'normative'
+    }
+
+    It 'is a no-op write when no edit resolves (empty list leaves bytes untouched)' {
+        $before = Get-Content -Raw -Path $script:path
+        $result = Save-JsonNodeFieldEdits -Path $script:path -Edits @()
+        $result.Applied | Should -Be 0
+        (Get-Content -Raw -Path $script:path) | Should -Be $before
+    }
+
+    It 'aborts the whole batch and writes NOTHING when an edit hits the scalar-only limitation' {
+        # An object-valued field trips Update-JsonNodeField's re-parse-verify (duplicate key)
+        # -> throw. The batch is atomic on unexpected failure: nothing is written.
+        $objFixture = @'
+{
+  "nodes": [
+    { "id": "sit-001", "meta": { "a": 1 }, "note": "object-valued field" }
+  ]
+}
+'@ -replace "`r`n", "`n"
+        $p = Join-Path $TestDrive 'obj-fixture.json'
+        [System.IO.File]::WriteAllText($p, $objFixture, (New-Object System.Text.UTF8Encoding $false))
+        { Save-JsonNodeFieldEdits -Path $p -Edits @(@{ NodeId='sit-001'; Field='meta'; Value='scalar' }) } | Should -Throw
+        (Get-Content -Raw -Path $p) | Should -Be $objFixture   # unchanged
+    }
+
+    It 'throws New-ActionableError when the target file does not exist' {
+        { Save-JsonNodeFieldEdits -Path (Join-Path $TestDrive 'missing.json') -Edits @(@{ NodeId='x'; Field='y'; Value='z' }) } |
+            Should -Throw
+    }
+
+    It 'throws when an edit hashtable is missing a required key' {
+        { Save-JsonNodeFieldEdits -Path $script:path -Edits @(@{ NodeId='sit-001' }) } | Should -Throw
+    }
+}

--- a/tests/SurgicalWriteExemption.Tests.ps1
+++ b/tests/SurgicalWriteExemption.Tests.ps1
@@ -28,6 +28,25 @@
 
 BeforeAll {
     Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    # Shared detector (t/2916#10 hardening) — defined in BeforeAll so it is visible to It
+    # blocks at run time. Scans REPO-WIDE *.ps1 (InModuleScope reach — a writer can live
+    # outside scripts/), and matches ABBREVIATED params: `-Surg` binds -SurgicalWrite and
+    # evades a -SimpleMatch on the full name. The negative lookbehind `(?<![\w-])` requires
+    # a real parameter boundary before the dash, so the English word "field-surgical" in a
+    # comment (preceded by a word char) is NOT a false positive, while " -SurgicalWrite" /
+    # " -Surg" (preceded by whitespace) is. Vendored/checkout trees are excluded.
+    function Get-SurgicalExemptionViolations {
+        param([Parameter(Mandatory)][string]$Root, [Parameter(Mandatory)][string[]]$Allowed)
+        $rx = '(?<![\w-])-Surg\w*'
+        @(
+            Get-ChildItem -Path $Root -Recurse -Filter '*.ps1' -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -notmatch '[\\/](node_modules|\.git|\.worktrees|\.claude)[\\/]' } |
+                Where-Object { $_.Name -notin $Allowed } |
+                Where-Object { Select-String -Path $_.FullName -Pattern $rx -Quiet } |
+                ForEach-Object { $_.FullName }
+        )
+    }
 }
 
 Describe 'Surgical-write exemption — both-arms GV (t/2916 Fork 2)' -Tag 'summary' {
@@ -69,18 +88,38 @@ Describe 'Surgical-write exemption — both-arms GV (t/2916 Fork 2)' -Tag 'summa
 
 Describe 'Surgical-write exemption — reachable ONLY via the orchestrator (detection gate)' -Tag 'summary' {
 
-    It 'no data writer other than Save-JsonNodeFieldEdits claims -SurgicalWrite' {
-        # Enforces TL t/2916#8: the exemption is claimed ONLY inside the orchestrator, so a
-        # whole-file writer cannot regress to whole-file and silently keep the bypass.
-        # Allowed: the orchestrator (claims it), the sink (forwards it), the guard (declares it).
-        $scriptsRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' 'scripts')).Path
-        $allowed = @('Save-JsonNodeFieldEdits.ps1', 'Write-Utf8NoBom.ps1', 'Assert-DataWriteAllowed.ps1')
-        $violations = @(
-            Get-ChildItem -Path $scriptsRoot -Recurse -Filter '*.ps1' -File |
-                Where-Object { $_.Name -notin $allowed } |
-                Where-Object { Select-String -Path $_.FullName -Pattern '-SurgicalWrite' -SimpleMatch -Quiet } |
-                ForEach-Object { $_.FullName }
+    # Allowed to reference the exemption: the orchestrator (claims it), the sink (forwards
+    # it), the guard (declares it), and THIS both-arms test (exercises it directly).
+    BeforeAll {
+        $script:Allowed = @(
+            'Save-JsonNodeFieldEdits.ps1'
+            'Write-Utf8NoBom.ps1'
+            'Assert-DataWriteAllowed.ps1'
+            'SurgicalWriteExemption.Tests.ps1'
         )
-        $violations | Should -BeNullOrEmpty -Because 'only Save-JsonNodeFieldEdits may claim the surgical exemption; a whole-file writer must not bypass the BLOCK tier'
+    }
+
+    It 'CLEAN arm — repo-wide, only the allowlisted files reference the exemption' {
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+        Get-SurgicalExemptionViolations -Root $repoRoot -Allowed $script:Allowed |
+            Should -BeNullOrEmpty -Because 'only Save-JsonNodeFieldEdits may claim the surgical exemption; a whole-file writer must not bypass the BLOCK tier'
+    }
+
+    It 'FIRE arm — the detector FLAGS a non-allowlisted writer that claims the exemption (via an abbreviated -Surg)' {
+        # A detection gate never proven to fire is assumed, not verified (TL t/2916#10).
+        # The rogue writer uses the ABBREVIATED form to also prove the grep catches it.
+        $rogue = Join-Path $TestDrive 'Rogue-Writer.ps1'
+        Set-Content -LiteralPath $rogue -Value 'Write-Utf8NoBom -Path $p -Value $x -Surg' -Encoding utf8
+        $found = Get-SurgicalExemptionViolations -Root $TestDrive -Allowed $script:Allowed
+        @($found).Count | Should -BeGreaterThan 0
+        ($found -join ';')            | Should -Match 'Rogue-Writer'
+    }
+
+    It 'the "field-surgical" prose in a comment is NOT a false positive (lookbehind boundary)' {
+        $benign = Join-Path $TestDrive 'Benign-Comment.ps1'
+        Set-Content -LiteralPath $benign -Value '# performs a field-surgical, byte-surgical write; see byte-surgery notes' -Encoding utf8
+        Get-SurgicalExemptionViolations -Root $TestDrive -Allowed $script:Allowed |
+            Where-Object { $_ -match 'Benign-Comment' } |
+            Should -BeNullOrEmpty
     }
 }

--- a/tests/SurgicalWriteExemption.Tests.ps1
+++ b/tests/SurgicalWriteExemption.Tests.ps1
@@ -1,0 +1,86 @@
+# Tag: summary (t/2916) — GATE-TOUCHING: the -SurgicalWrite exemption on the BLOCK-tier
+#   dirty-tree guard. Routed to Main (TL) for both-arms Gate Verification.
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Both-arms GV for the surgical-write exemption (t/2916 Fork 2, TL ruling t/2916#8).
+
+    A field-surgical write is sweep-proof BY CONSTRUCTION (the re-parse-verify invariant +
+    byte-identical foreign-WIP preservation proven in Update-JsonNodeField tests 5/7), so
+    it MUST be exempt from the BLOCK-tier dirty-tree throw — otherwise the guard blocks the
+    one writer that is actually safe on a dirty tree, defeating the entire point of t/2916.
+
+    The exemption is a DISTINCT signal (-SurgicalWrite), NOT overloaded onto -AllowDirty
+    (TL: -AllowDirty = "tree is dirty, I choose to ignore it" [blanket override];
+    -SurgicalWrite = "this write is sweep-proof, the dirty check is N/A" [provably safe]).
+    Two different risk profiles must not share a flag.
+
+    Both arms:
+      ARM 1 — a surgical write to a dirty BLOCK-tier target PROCEEDS.
+      ARM 2 — the SAME write WITHOUT the surgical signal is BLOCKED.
+    Plus the reachability gate: only Save-JsonNodeFieldEdits may claim the exemption, so a
+    whole-file writer cannot regress to claiming the bypass.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Surgical-write exemption — both-arms GV (t/2916 Fork 2)' -Tag 'summary' {
+
+    It 'ARM 1 — a surgical write to a dirty BLOCK-tier target PROCEEDS (exemption honored)' {
+        InModuleScope AITriad {
+            Mock Get-DataWriteGuardMode { 'Block' }
+            Mock Test-IsUnderDataRoot   { $true }
+            Mock Assert-CleanDataTree   { throw 'dirty tree (simulated)' }   # would block a whole-file write
+            { Assert-DataWriteAllowed -Path 'X:\data\taxonomy\situations.json' -SurgicalWrite } | Should -Not -Throw
+            # the exemption returns BEFORE the dirty check — the tree is never even consulted
+            Should -Invoke Assert-CleanDataTree -Times 0
+        }
+    }
+
+    It 'ARM 2 — the SAME whole-file write WITHOUT the surgical signal is BLOCKED' {
+        InModuleScope AITriad {
+            Mock Get-DataWriteGuardMode { 'Block' }
+            Mock Test-IsUnderDataRoot   { $true }
+            Mock Assert-CleanDataTree   { throw 'dirty tree (simulated)' }
+            { Assert-DataWriteAllowed -Path 'X:\data\taxonomy\situations.json' } | Should -Throw
+        }
+    }
+
+    It 'the surgical signal is a DISTINCT parameter, not overloaded onto -AllowDirty' {
+        InModuleScope AITriad {
+            $p = (Get-Command Assert-DataWriteAllowed).Parameters.Keys
+            $p | Should -Contain 'SurgicalWrite'
+            $p | Should -Contain 'AllowDirty'
+        }
+    }
+
+    It 'Write-Utf8NoBom forwards the surgical signal to the guard' {
+        InModuleScope AITriad {
+            (Get-Command Write-Utf8NoBom).Parameters.Keys | Should -Contain 'SurgicalWrite'
+        }
+    }
+}
+
+Describe 'Surgical-write exemption — reachable ONLY via the orchestrator (detection gate)' -Tag 'summary' {
+
+    It 'no data writer other than Save-JsonNodeFieldEdits claims -SurgicalWrite' {
+        # Enforces TL t/2916#8: the exemption is claimed ONLY inside the orchestrator, so a
+        # whole-file writer cannot regress to whole-file and silently keep the bypass.
+        # Allowed: the orchestrator (claims it), the sink (forwards it), the guard (declares it).
+        $scriptsRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' 'scripts')).Path
+        $allowed = @('Save-JsonNodeFieldEdits.ps1', 'Write-Utf8NoBom.ps1', 'Assert-DataWriteAllowed.ps1')
+        $violations = @(
+            Get-ChildItem -Path $scriptsRoot -Recurse -Filter '*.ps1' -File |
+                Where-Object { $_.Name -notin $allowed } |
+                Where-Object { Select-String -Path $_.FullName -Pattern '-SurgicalWrite' -SimpleMatch -Quiet } |
+                ForEach-Object { $_.FullName }
+        )
+        $violations | Should -BeNullOrEmpty -Because 'only Save-JsonNodeFieldEdits may claim the surgical exemption; a whole-file writer must not bypass the BLOCK tier'
+    }
+}


### PR DESCRIPTION
## t/2916 writer-wiring — surgical-write orchestrator + BLOCK-tier exemption + first writer

**DRAFT — gate-touching (new guard parameter), routed to Main (TL) for both-arms GV** per ruling t/2916#8. Builds on the merged Phase-1 primitive `Update-JsonNodeField` (#1384).

### Fork 1 — `Save-JsonNodeFieldEdits` (new Public orchestrator)
Reads the target **fresh** → applies each edit via the Private `Update-JsonNodeField` (chaining `RawText`→next) → writes **once** through the guarded sink. Returns a **result summary** (`Applied` + `NotFound`) so a not-found node is surfaced, never silently dropped. Batch is **atomic** on unexpected splice failure (writes nothing). Whole-file round-trip in the writer is deleted.

### Fork 2 — BLOCK-tier exemption via a distinct `-SurgicalWrite` flag (NOT `-AllowDirty`)
`Assert-DataWriteAllowed` gains a semantically-honest early-return — *"this write is sweep-proof by construction, the dirty check is N/A"* — forwarded through `Write-Utf8NoBom`. Kept **separate** from the blanket `-AllowDirty` override so the audit trail stays honest. Claimed **only** inside the orchestrator; justification **co-located** at both the guard branch and the call site (Gate Co-Location, t/2909).

### Writer wired
`Invoke-DisagreementTypeBackfill` now collects an edit list and hands it to the orchestrator — byte-surgical, and it **proceeds on the perpetually-dirty BLOCK-tier `situations.json`** (the whole point of t/2916).

### Both-arms GV (the gate)
- **ARM 1** — a surgical write to a dirty BLOCK-tier target **PROCEEDS** (exemption honored; the tree is never consulted).
- **ARM 2** — the **same** write **WITHOUT** the surgical signal is **BLOCKED**.
- **Reachability gate** — a detection test fails if any source file other than `Save-JsonNodeFieldEdits` claims `-SurgicalWrite`, so a writer can't regress to whole-file and keep the bypass.

### Verification
- **38/38** targeted tests: new orchestrator suite + both-arms exemption + detection gate + all existing guard/sink/incident-fixture regressions.
- `Test-ModuleManifest` OK (`Save-JsonNodeFieldEdits` exported). All changed files parse-clean. Catalog updated.

### Deferred (own PRs)
`Invoke-CcToSitMigration`, the Python mirror for `reprocess_taxonomy_vocabulary`, Phase 2 `Repair-Pov*`/batch, and the per-call full-scan perf note for batch writers.

Paired with **explicit-path staging** at commit (the other half of sweep prevention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
