### PR TITLE
feat(ci): warn-first license-notices staleness gate (t/2918)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,6 +15,7 @@
 .githooks/pre-commit text eol=lf
 # Web / config: LF
 *.md   text eol=lf
+*.txt  text eol=lf
 *.json text eol=lf
 *.yml  text eol=lf
 *.yaml text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,24 @@ jobs:
         working-directory: ${{ matrix.app }}
         run: pnpm run build
 
+      # ── License-notices staleness warn (t/2918 — warn-first phase) ──
+      # The build step above already ran `npm run licenses`, regenerating
+      # THIRD-PARTY-NOTICES.txt + src/renderer/data/oss-licenses.json from the
+      # current pnpm lockfile. If the committed versions differ from what the
+      # generator produced, the files are stale (dep bump without re-committing).
+      # Warn-first: emits ::warning:: but does NOT fail CI yet. After ≥1 green
+      # warn cycle with zero false-fires and determinism confirmed (CRLF + sort
+      # stability), promote to exit 1 — separate PR, TL sign-off required (t/2918).
+      - name: Check license notices are up to date (warn-only — t/2918)
+        if: matrix.app == 'taxonomy-editor'
+        working-directory: ${{ matrix.app }}
+        continue-on-error: true
+        run: |
+          if ! git diff --exit-code THIRD-PARTY-NOTICES.txt src/renderer/data/oss-licenses.json; then
+            echo "::warning::License notices are stale — run 'npm run licenses' in taxonomy-editor/ and commit the updated THIRD-PARTY-NOTICES.txt + src/renderer/data/oss-licenses.json before merging (t/2918)"
+            exit 1
+          fi
+
       - name: Preload self-contained gate (t/2776)
         if: matrix.app == 'taxonomy-editor'
         shell: pwsh


### PR DESCRIPTION
## Summary

- Adds a `git diff --exit-code` check after the `Build` step in `test-electron (taxonomy-editor)` — zero extra cost since `pnpm run build` already regenerates `THIRD-PARTY-NOTICES.txt` + `oss-licenses.json` via `npm run licenses`
- **Warn-first** (`continue-on-error: true` + `::warning::`) per TL gate-promotion protocol — will flip to `exit 1` in a separate PR after ≥1 green warn cycle + determinism confirmed
- Adds `*.txt text eol=lf` to `.gitattributes` to make line endings explicit for `.txt` files (eliminates CRLF false-fire risk on the CI diff)

## Gate Verification

TL-approved (e/118#2). Both-arms GV:
- **Fire:** dep bump + lockfile change WITHOUT committed notices → `git diff` non-empty → `::warning::` emitted (non-blocking during warn phase)
- **Clean:** dep bump WITH regenerated+committed notices → `git diff` empty → passes

## Related

Fixes recurring t/2452 shared-tree drift (generated license churn leaving main checkout dirty). Follow-up ticket for warn→block promotion to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)