### PR TITLE
feat(scripts): nested-path surgical JSON editor + shared-internals extraction (t/2921 Phase 2)

### DIFF
--- a/scripts/AITriad/Private/JsonSurgeryCore.ps1
+++ b/scripts/AITriad/Private/JsonSurgeryCore.ps1
@@ -1,0 +1,173 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# ── Shared internals for the field-surgical JSON writers (t/2916 / t/2921) ────
+# Both surgical entry points share these (TL ruling t/2921#2 Q3 — factor shared
+# internals; keep the two callers separate):
+#   * Update-JsonNodeField  (t/2916)  — depth-1 scalar field, incl. absent-key INSERT.
+#   * Update-JsonNodePath   (t/2921)  — in-place scalar replacement at a NESTED path.
+# The load-bearing safety net is the re-parse-VERIFY invariant (Test-JsonSemanticEqual
+# over ConvertTo-CanonicalForm): after any splice we re-parse and assert the result equals
+# the original with EXACTLY the intended change, else the caller throws and writes nothing.
+# That is what makes byte-surgery safe regardless of splice edge cases.
+
+function ConvertTo-CanonicalForm {
+    # Recursively normalize a ConvertFrom-Json value into order-insensitive canonical
+    # form (sorted hashtable keys) so the verify compares DATA, not key order/formatting.
+    param([Parameter(Mandatory)][AllowNull()]$Value)
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [System.Management.Automation.PSCustomObject]) {
+        $out = [ordered]@{}
+        foreach ($p in ($Value.PSObject.Properties | Sort-Object Name)) {
+            $out[$p.Name] = ConvertTo-CanonicalForm -Value $p.Value
+        }
+        return $out
+    }
+    if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+        return @($Value | ForEach-Object { ConvertTo-CanonicalForm -Value $_ })
+    }
+    return $Value
+}
+
+function Test-JsonSemanticEqual {
+    param([Parameter(Mandatory)][AllowNull()]$A, [Parameter(Mandatory)][AllowNull()]$B)
+    $ca = ConvertTo-CanonicalForm -Value $A | ConvertTo-Json -Depth 100 -Compress
+    $cb = ConvertTo-CanonicalForm -Value $B | ConvertTo-Json -Depth 100 -Compress
+    return $ca -eq $cb
+}
+
+function Find-JsonObjectSpan {
+    # Single-pass, string/escape-aware forward scan: given a char index KNOWN to be
+    # inside a { } object, return @{ Start; End } for the INNERMOST enclosing object
+    # (indices of its '{' and matching '}'). A brace stack tracks nesting; at the inner
+    # index we capture the innermost open '{', then return when its matching '}' pops.
+    param([Parameter(Mandatory)][string]$Text, [Parameter(Mandatory)][int]$InnerIndex)
+
+    $stack = New-Object System.Collections.Generic.Stack[int]
+    $inStr = $false; $esc = $false; $targetOpen = -1
+    for ($i = 0; $i -lt $Text.Length; $i++) {
+        $c = $Text[$i]
+        if ($inStr) {
+            if ($esc) { $esc = $false }
+            elseif ($c -eq '\') { $esc = $true }
+            elseif ($c -eq '"') { $inStr = $false }
+        }
+        else {
+            if ($c -eq '"') { $inStr = $true }
+            elseif ($c -eq '{') { $stack.Push($i) }
+            elseif ($c -eq '}') {
+                if ($stack.Count -eq 0) { return $null }
+                $popped = $stack.Pop()
+                if ($targetOpen -ge 0 -and $popped -eq $targetOpen) { return @{ Start = $targetOpen; End = $i } }
+            }
+        }
+        # Once we reach the inner index, the innermost currently-open '{' is our object.
+        if ($i -eq $InnerIndex -and $targetOpen -lt 0) {
+            if ($stack.Count -eq 0) { return $null }
+            $targetOpen = $stack.Peek()
+        }
+    }
+    return $null
+}
+
+function Get-JsonValueSpan {
+    # Given an index at the first char of a JSON value (string / number / bool / null /
+    # object / array), return @{ Start; End } spanning the COMPLETE value (string-aware for
+    # objects/arrays so nested quotes/braces don't confuse the scan). Leading whitespace is
+    # skipped defensively. Returns $null on malformed input (the re-parse-verify still
+    # backstops any locate error). This is the value-skipper that keeps member/element
+    # iteration at exactly depth-1.
+    param([Parameter(Mandatory)][string]$Text, [Parameter(Mandatory)][int]$Start)
+    $n = $Text.Length
+    $i = $Start
+    while ($i -lt $n -and [char]::IsWhiteSpace($Text[$i])) { $i++ }
+    if ($i -ge $n) { return $null }
+    $c = $Text[$i]
+    if ($c -eq '"') {
+        $j = $i + 1; $esc = $false
+        while ($j -lt $n) {
+            $cj = $Text[$j]
+            if ($esc) { $esc = $false }
+            elseif ($cj -eq '\') { $esc = $true }
+            elseif ($cj -eq '"') { return @{ Start = $i; End = $j } }
+            $j++
+        }
+        return $null
+    }
+    if ($c -eq '{' -or $c -eq '[') {
+        $depth = 0; $inStr = $false; $esc = $false; $j = $i
+        while ($j -lt $n) {
+            $cj = $Text[$j]
+            if ($inStr) {
+                if ($esc) { $esc = $false }
+                elseif ($cj -eq '\') { $esc = $true }
+                elseif ($cj -eq '"') { $inStr = $false }
+            }
+            else {
+                if ($cj -eq '"') { $inStr = $true }
+                elseif ($cj -eq '{' -or $cj -eq '[') { $depth++ }
+                elseif ($cj -eq '}' -or $cj -eq ']') { $depth--; if ($depth -eq 0) { return @{ Start = $i; End = $j } } }
+            }
+            $j++
+        }
+        return $null
+    }
+    # scalar: number / true / false / null — read until a structural delimiter or whitespace
+    $j = $i
+    while ($j -lt $n) {
+        $cj = $Text[$j]
+        if ($cj -eq ',' -or $cj -eq '}' -or $cj -eq ']' -or [char]::IsWhiteSpace($cj)) { break }
+        $j++
+    }
+    if ($j -eq $i) { return $null }
+    return @{ Start = $i; End = $j - 1 }
+}
+
+function Find-JsonMemberValueStart {
+    # Within the object at [ObjStart='{' .. ObjEnd='}'], find the depth-1 member whose key
+    # equals $Key and return the start index of ITS VALUE (or -1 if absent). Keys are
+    # JSON-decoded (handles escapes) so a substring collision can't false-match. Nested
+    # values are skipped via Get-JsonValueSpan so iteration stays at depth 1.
+    param([Parameter(Mandatory)][string]$Text, [Parameter(Mandatory)][int]$ObjStart,
+          [Parameter(Mandatory)][int]$ObjEnd, [Parameter(Mandatory)][string]$Key)
+    $i = $ObjStart + 1
+    while ($i -lt $ObjEnd) {
+        while ($i -lt $ObjEnd -and ([char]::IsWhiteSpace($Text[$i]) -or $Text[$i] -eq ',')) { $i++ }
+        if ($i -ge $ObjEnd) { break }
+        if ($Text[$i] -ne '"') { return -1 }   # expected a key string
+        $keySpan = Get-JsonValueSpan -Text $Text -Start $i
+        if ($null -eq $keySpan) { return -1 }
+        $keyToken = $Text.Substring($keySpan.Start, $keySpan.End - $keySpan.Start + 1)
+        try { $decodedKey = $keyToken | ConvertFrom-Json } catch { return -1 }
+        $i = $keySpan.End + 1
+        while ($i -lt $ObjEnd -and [char]::IsWhiteSpace($Text[$i])) { $i++ }
+        if ($i -ge $ObjEnd -or $Text[$i] -ne ':') { return -1 }
+        $i++
+        while ($i -lt $ObjEnd -and [char]::IsWhiteSpace($Text[$i])) { $i++ }
+        $valSpan = Get-JsonValueSpan -Text $Text -Start $i
+        if ($null -eq $valSpan) { return -1 }
+        if ([string]$decodedKey -eq $Key) { return $valSpan.Start }
+        $i = $valSpan.End + 1
+    }
+    return -1
+}
+
+function Find-JsonArrayElementStart {
+    # Within the array at [ArrStart='[' .. ArrEnd=']'], return the start index of the
+    # element at $Index (depth-1), or -1 if out of range. Elements are skipped via
+    # Get-JsonValueSpan so nested commas/structures don't miscount.
+    param([Parameter(Mandatory)][string]$Text, [Parameter(Mandatory)][int]$ArrStart,
+          [Parameter(Mandatory)][int]$ArrEnd, [Parameter(Mandatory)][int]$Index)
+    $i = $ArrStart + 1
+    $idx = 0
+    while ($i -lt $ArrEnd) {
+        while ($i -lt $ArrEnd -and ([char]::IsWhiteSpace($Text[$i]) -or $Text[$i] -eq ',')) { $i++ }
+        if ($i -ge $ArrEnd) { break }
+        $elSpan = Get-JsonValueSpan -Text $Text -Start $i
+        if ($null -eq $elSpan) { return -1 }
+        if ($idx -eq $Index) { return $elSpan.Start }
+        $idx++
+        $i = $elSpan.End + 1
+    }
+    return -1
+}

--- a/scripts/AITriad/Private/Update-JsonNodeField.ps1
+++ b/scripts/AITriad/Private/Update-JsonNodeField.ps1
@@ -20,65 +20,13 @@
 # ConvertFrom-Json throws on duplicate keys) so the helper throws New-ActionableError and
 # writes nothing. Callers needing to rewrite object/array-valued fields must use a
 # different mechanism; this helper is for the scalar node-field backfills (t/2916 scope).
-
-function ConvertTo-CanonicalForm {
-    # Recursively normalize a ConvertFrom-Json value into order-insensitive canonical
-    # form (sorted hashtable keys) so the verify compares DATA, not key order/formatting.
-    param([Parameter(Mandatory)][AllowNull()]$Value)
-    if ($null -eq $Value) { return $null }
-    if ($Value -is [System.Management.Automation.PSCustomObject]) {
-        $out = [ordered]@{}
-        foreach ($p in ($Value.PSObject.Properties | Sort-Object Name)) {
-            $out[$p.Name] = ConvertTo-CanonicalForm -Value $p.Value
-        }
-        return $out
-    }
-    if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
-        return @($Value | ForEach-Object { ConvertTo-CanonicalForm -Value $_ })
-    }
-    return $Value
-}
-
-function Test-JsonSemanticEqual {
-    param([Parameter(Mandatory)][AllowNull()]$A, [Parameter(Mandatory)][AllowNull()]$B)
-    $ca = ConvertTo-CanonicalForm -Value $A | ConvertTo-Json -Depth 100 -Compress
-    $cb = ConvertTo-CanonicalForm -Value $B | ConvertTo-Json -Depth 100 -Compress
-    return $ca -eq $cb
-}
-
-function Find-JsonObjectSpan {
-    # Single-pass, string/escape-aware forward scan: given a char index KNOWN to be
-    # inside a { } object, return @{ Start; End } for the INNERMOST enclosing object
-    # (indices of its '{' and matching '}'). A brace stack tracks nesting; at the inner
-    # index we capture the innermost open '{', then return when its matching '}' pops.
-    param([Parameter(Mandatory)][string]$Text, [Parameter(Mandatory)][int]$InnerIndex)
-
-    $stack = New-Object System.Collections.Generic.Stack[int]
-    $inStr = $false; $esc = $false; $targetOpen = -1
-    for ($i = 0; $i -lt $Text.Length; $i++) {
-        $c = $Text[$i]
-        if ($inStr) {
-            if ($esc) { $esc = $false }
-            elseif ($c -eq '\') { $esc = $true }
-            elseif ($c -eq '"') { $inStr = $false }
-        }
-        else {
-            if ($c -eq '"') { $inStr = $true }
-            elseif ($c -eq '{') { $stack.Push($i) }
-            elseif ($c -eq '}') {
-                if ($stack.Count -eq 0) { return $null }
-                $popped = $stack.Pop()
-                if ($targetOpen -ge 0 -and $popped -eq $targetOpen) { return @{ Start = $targetOpen; End = $i } }
-            }
-        }
-        # Once we reach the inner index, the innermost currently-open '{' is our object.
-        if ($i -eq $InnerIndex -and $targetOpen -lt 0) {
-            if ($stack.Count -eq 0) { return $null }
-            $targetOpen = $stack.Peek()
-        }
-    }
-    return $null
-}
+#
+# SHARED INTERNALS (t/2921#2 Q3): ConvertTo-CanonicalForm, Test-JsonSemanticEqual, and
+# Find-JsonObjectSpan were extracted to Private/JsonSurgeryCore.ps1 so this depth-1 writer
+# and the nested-path writer (Update-JsonNodePath) share one re-parse-verify + span scanner.
+# The depth-1 logic below is UNCHANGED (TL t/2921#2: don't touch the proven,
+# situations.json-critical path); it just calls the extracted helpers, which the module
+# dot-sources alongside it.
 
 function Update-JsonNodeField {
     <#

--- a/scripts/AITriad/Private/Update-JsonNodePath.ps1
+++ b/scripts/AITriad/Private/Update-JsonNodePath.ps1
@@ -1,0 +1,144 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# ── Nested-path surgical JSON writer (t/2921, TL ruling t/2921#2) ──────────────
+# Sibling to Update-JsonNodeField (t/2916). Where that writer edits a depth-1 scalar
+# field (and can INSERT an absent key), this one does IN-PLACE SCALAR REPLACEMENT at a
+# NESTED path addressed as a segment array: object keys (string) and array indices (int),
+# anchored on the stable node id. Same guarantees: parse-LOCATE (recursive, span-scoped) +
+# minimal-SPLICE + re-parse-VERIFY invariant. Every untouched byte is preserved, so a write
+# cannot sweep concurrent WIP elsewhere (the sit-477 class), regardless of tree state.
+#
+# SCOPE (t/2921#2 Q2, in-place-only): replaces an EXISTING scalar value at the path.
+# NOT supported (safe-throw, writes nothing): path-not-found (no insert-at-depth), an
+# object/array-valued target, or structural add/remove. The re-parse-verify backstops any
+# locate error — a bad splice degrades to a safe abort, never a corrupt write.
+#
+# Addressing is a SEGMENT ARRAY, never a dotted string (t/2921#2 Q1): a dotted parser breaks
+# on keys containing '.'/'['/']'. Segment type distinguishes key (string) vs index (int)
+# with zero ambiguity and is trivially lockstep with the Python mirror. A dotted/bracket
+# form is rendered for ERROR/LOG display only — never parsed.
+#
+# Shared internals (Find-JsonObjectSpan, Get-JsonValueSpan, Find-JsonMemberValueStart,
+# Find-JsonArrayElementStart, Test-JsonSemanticEqual) live in Private/JsonSurgeryCore.ps1.
+
+function ConvertTo-JsonPathDisplay {
+    # Human-readable rendering of a segment-array path for error/log messages ONLY.
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Path)
+    $s = ''
+    foreach ($seg in $Path) {
+        if ($seg -is [int]) { $s += "[$seg]" }
+        else { if ($s.Length -gt 0) { $s += '.' }; $s += [string]$seg }
+    }
+    return $s
+}
+
+function Set-JsonValueAtPath {
+    # Navigate a ConvertFrom-Json clone by the segment path and set the final scalar — used
+    # ONLY to build the re-parse-verify EXPECTED baseline (never touches the file). Assumes
+    # the path was already located in the raw text, so every segment resolves.
+    param(
+        [Parameter(Mandatory)]$Root,
+        [Parameter(Mandatory)][object[]]$Path,
+        [Parameter(Mandatory)][AllowNull()]$Value,
+        [Parameter(Mandatory)][scriptblock]$Fail
+    )
+    $cur = $Root
+    for ($k = 0; $k -lt $Path.Count - 1; $k++) {
+        $seg = $Path[$k]
+        if ($seg -is [int]) { $cur = $cur[$seg] }
+        else { $cur = $cur.$seg }
+        if ($null -eq $cur) { & $Fail "verify baseline could not descend segment '$seg'" @('internal: path/parse mismatch') }
+    }
+    $last = $Path[$Path.Count - 1]
+    if ($last -is [int]) { $cur[$last] = $Value }
+    elseif ($cur.PSObject.Properties[$last]) { $cur.$last = $Value }
+    else { & $Fail "verify baseline expected key '$last' present" @('internal: path/parse mismatch') }
+}
+
+function Update-JsonNodePath {
+    <#
+    .SYNOPSIS
+        In-place surgical replacement of ONE scalar value at a NESTED path on ONE nodes[]
+        entry (t/2921). Byte-preserving everywhere except the target value; re-parse-verified.
+    .PARAMETER Path
+        Segment array addressing the value relative to the node: object keys (string) and
+        array indices (int), e.g. @('graph_attributes','policy_actions',2,'framing').
+    .OUTPUTS
+        [string] the patched raw JSON. Throws New-ActionableError (writes nothing) on:
+        invalid JSON, node/path not found, an object/array-valued target (scalar-only), or a
+        re-parse-verify mismatch (any change beyond the intended value).
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string]$RawText,
+        [Parameter(Mandatory)][string]$NodeId,
+        [Parameter(Mandatory)][object[]]$Path,
+        [Parameter(Mandatory)][AllowNull()]$Value
+    )
+    Set-StrictMode -Version Latest
+
+    $pathDisplay = ConvertTo-JsonPathDisplay -Path $Path
+    $fail = {
+        param($problem, $steps)
+        throw (New-ActionableError -Goal "Nested surgical update of '$pathDisplay' on node '$NodeId'" `
+            -Problem $problem -Location 'Update-JsonNodePath' -NextSteps $steps -PassThru)
+    }
+
+    if (@($Path).Count -eq 0) { & $fail 'Path is empty' @('Provide at least one path segment') }
+
+    # --- Parse (locate + verification baseline) ---
+    try { $original = $RawText | ConvertFrom-Json } catch { & $fail "Input is not valid JSON: $($_.Exception.Message)" @('Pass well-formed JSON text') }
+    if (-not $original.PSObject.Properties['nodes']) { & $fail 'No nodes[] array in the JSON' @('Expected a top-level nodes[] array') }
+    $match = @($original.nodes | Where-Object { $_.PSObject.Properties['id'] -and $_.id -eq $NodeId })
+    if ($match.Count -eq 0) { & $fail "Node id '$NodeId' not found in nodes[]" @('Verify the node id exists in the file') }
+
+    # --- Locate the node object span, then descend the path to the target value span ---
+    $idToken = [regex]::Match($RawText, '"id"\s*:\s*"' + [regex]::Escape($NodeId) + '"')
+    if (-not $idToken.Success) { & $fail "id token for '$NodeId' not found in raw text" @('File text may not match the parsed structure') }
+    $nodeSpan = Find-JsonObjectSpan -Text $RawText -InnerIndex $idToken.Index
+    if ($null -eq $nodeSpan) { & $fail "could not locate the enclosing object span for '$NodeId'" @('Check the JSON is well-formed') }
+
+    $curStart = $nodeSpan.Start   # index of the current container's opening '{' or '['
+    $curEnd   = $nodeSpan.End
+    for ($k = 0; $k -lt $Path.Count; $k++) {
+        $seg = $Path[$k]
+        $curChar = $RawText[$curStart]
+        if ($seg -is [int]) {
+            if ($curChar -ne '[') { & $fail "segment [$seg] expects an array but the container at that level is not an array" @('Check the path matches the document shape') }
+            $vStart = Find-JsonArrayElementStart -Text $RawText -ArrStart $curStart -ArrEnd $curEnd -Index $seg
+            if ($vStart -lt 0) { & $fail "array index [$seg] is out of range (path-not-found)" @('Verify the index exists; no insert-at-depth in this phase (t/2921 Q2)') }
+        }
+        else {
+            if ($curChar -ne '{') { & $fail "segment '$seg' expects an object but the container at that level is not an object" @('Check the path matches the document shape') }
+            $vStart = Find-JsonMemberValueStart -Text $RawText -ObjStart $curStart -ObjEnd $curEnd -Key ([string]$seg)
+            if ($vStart -lt 0) { & $fail "key '$seg' not found at this level (path-not-found)" @('Verify the key exists; no insert-at-depth in this phase (t/2921 Q2)') }
+        }
+        $vSpan = Get-JsonValueSpan -Text $RawText -Start $vStart
+        if ($null -eq $vSpan) { & $fail "could not span-scan the value at segment '$seg'" @('Report with the input file + path') }
+        $curStart = $vSpan.Start; $curEnd = $vSpan.End
+    }
+
+    # --- Target must be a SCALAR (in-place scalar replacement only, t/2921 Q2) ---
+    $targetChar = $RawText[$curStart]
+    if ($targetChar -eq '{' -or $targetChar -eq '[') {
+        & $fail "target at '$pathDisplay' is an object/array; only in-place scalar replacement is supported" `
+            @('Object/array-valued replacement is out of scope (t/2921 Q2)')
+    }
+
+    # --- Splice the target value span ---
+    $encoded = $Value | ConvertTo-Json -Depth 100 -Compress
+    $patched = $RawText.Substring(0, $curStart) + $encoded + $RawText.Substring($curEnd + 1)
+
+    # --- Re-parse-VERIFY invariant (the safety net) ---
+    try { $actual = $patched | ConvertFrom-Json } catch { & $fail "patched text is not valid JSON — writing nothing: $($_.Exception.Message)" @('Splice produced invalid JSON; this is a bug in Update-JsonNodePath') }
+    $expected = $RawText | ConvertFrom-Json
+    $expNode = @($expected.nodes | Where-Object { $_.PSObject.Properties['id'] -and $_.id -eq $NodeId })[0]
+    Set-JsonValueAtPath -Root $expNode -Path $Path -Value $Value -Fail $fail
+    if (-not (Test-JsonSemanticEqual -A $expected -B $actual)) {
+        & $fail "re-parse-verify FAILED: the splice changed more than the intended value at '$pathDisplay' on '$NodeId' — writing nothing" `
+            @('This is a splice bug; the guard refused a corrupting write', 'Report with the input file + node id + path')
+    }
+    return $patched
+}

--- a/tests/Update-JsonNodePath.Tests.ps1
+++ b/tests/Update-JsonNodePath.Tests.ps1
@@ -1,0 +1,134 @@
+# Tag: summary (t/2921)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Adversarial suite for the nested-path surgical writer Update-JsonNodePath (t/2921, TL
+    ruling t/2921#2). Written FIRST (TDD). Segment-array addressing (key=string, index=int),
+    in-place scalar replacement only, re-parse-verify backstop. The written text must be
+    byte-preserving everywhere except the target value, so concurrent WIP elsewhere cannot
+    ride into the write (the sit-477 sweep).
+
+    Each node is on its OWN line so a nested edit changes exactly that node's line — the
+    byte-preservation / line-diff assertions depend on that layout.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    $script:Fixture = @'
+{
+  "nodes": [
+    { "id": "acc-001", "graph_attributes": { "assumes": ["a0", "a1"], "policy_actions": [ { "action": "act0", "framing": "frame0" }, { "action": "act1", "framing": "frame1" } ], "type": "belief", "disagreement_type": "empirical" }, "interpretations": { "accelerationist": { "summary": "sumA" } } },
+    { "id": "acc-002", "note": "keep", "resolved_node_id": "sit-477", "ratio": 3.0 },
+    { "id": "acc-003", "interpretations": { "skeptic": { "summary": "sumS" } } }
+  ]
+}
+'@ -replace "`r`n", "`n"
+}
+
+Describe 'Update-JsonNodePath — nested surgical replacement (t/2921)' -Tag 'summary' {
+
+    It '1. nested object field replace (interpretations.accelerationist.summary)' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('interpretations','accelerationist','summary') -Value 'NEWSUM'
+            $o = @($out | ConvertFrom-Json | Select-Object -ExpandProperty nodes | Where-Object { $_.id -eq 'acc-001' })[0]
+            $o.interpretations.accelerationist.summary | Should -Be 'NEWSUM'
+        }
+    }
+
+    It '2. string-array element replace (graph_attributes.assumes[1])' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('graph_attributes','assumes',1) -Value 'A1X'
+            $ga = (@($out | ConvertFrom-Json | Select-Object -ExpandProperty nodes | Where-Object { $_.id -eq 'acc-001' })[0]).graph_attributes
+            $ga.assumes[1] | Should -Be 'A1X'
+            $ga.assumes[0] | Should -Be 'a0'   # sibling element untouched
+        }
+    }
+
+    It '3. array-element object field replace (graph_attributes.policy_actions[1].framing)' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('graph_attributes','policy_actions',1,'framing') -Value 'FRAME1X'
+            $pa = (@($out | ConvertFrom-Json | Select-Object -ExpandProperty nodes | Where-Object { $_.id -eq 'acc-001' })[0]).graph_attributes.policy_actions
+            $pa[1].framing | Should -Be 'FRAME1X'
+            $pa[1].action  | Should -Be 'act1'   # sibling field untouched
+            $pa[0].framing | Should -Be 'frame0'  # sibling element untouched
+        }
+    }
+
+    It '4. nested field-name collision: replacing ga.type does not touch ga.disagreement_type' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('graph_attributes','type') -Value 'desire'
+            $ga = (@($out | ConvertFrom-Json | Select-Object -ExpandProperty nodes | Where-Object { $_.id -eq 'acc-001' })[0]).graph_attributes
+            $ga.type              | Should -Be 'desire'
+            $ga.disagreement_type | Should -Be 'empirical'   # substring-collider untouched
+        }
+    }
+
+    It '5. escaping: quotes / backslash / newline round-trip exactly at a nested path' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $tricky = 'He said "hi"' + "`n" + 'C:\path\to'
+            $out = Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('interpretations','accelerationist','summary') -Value $tricky
+            (@($out | ConvertFrom-Json | Select-Object -ExpandProperty nodes | Where-Object { $_.id -eq 'acc-001' })[0]).interpretations.accelerationist.summary | Should -Be $tricky
+        }
+    }
+
+    It '6. anti-sweep: a nested edit leaves foreign WIP on another node byte-identical' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out = Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('interpretations','accelerationist','summary') -Value 'NEWSUM'
+            $out | Should -BeLike '*"resolved_node_id": "sit-477"*'
+            $out | Should -BeLike '*"ratio": 3.0*'   # NOT churned to 3
+            $origLines = @($Raw -split "`n")
+            $newLines  = @($out -split "`n")
+            $newLines.Count | Should -Be $origLines.Count
+            $diff = for ($i = 0; $i -lt $origLines.Count; $i++) { if ($origLines[$i] -ne $newLines[$i]) { $i } }
+            @($diff).Count | Should -Be 1   # only the acc-001 line changed
+        }
+    }
+
+    It '7. multi-node sequential composition: chained nested edits land AND foreign WIP survives' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            $out1 = Update-JsonNodePath -RawText $Raw  -NodeId 'acc-001' -Path @('interpretations','accelerationist','summary') -Value 'S1'
+            $out2 = Update-JsonNodePath -RawText $out1 -NodeId 'acc-003' -Path @('interpretations','skeptic','summary')       -Value 'S3'
+            $nodes = @($out2 | ConvertFrom-Json | Select-Object -ExpandProperty nodes)
+            (@($nodes | Where-Object { $_.id -eq 'acc-001' })[0]).interpretations.accelerationist.summary | Should -Be 'S1'
+            (@($nodes | Where-Object { $_.id -eq 'acc-003' })[0]).interpretations.skeptic.summary          | Should -Be 'S3'
+            $out2 | Should -BeLike '*"resolved_node_id": "sit-477"*'
+            $out2 | Should -BeLike '*"ratio": 3.0*'
+            $origLines = @($Raw  -split "`n"); $newLines = @($out2 -split "`n")
+            $diff = for ($i = 0; $i -lt $origLines.Count; $i++) { if ($origLines[$i] -ne $newLines[$i]) { $i } }
+            @($diff).Count | Should -Be 2   # exactly the two edited node lines
+        }
+    }
+
+    It '8. path-not-found (bad key and out-of-range index) throws and writes nothing' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            { Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('graph_attributes','nonexistent') -Value 'x' } | Should -Throw
+            { Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('graph_attributes','assumes',9) -Value 'x' }   | Should -Throw
+            { Update-JsonNodePath -RawText $Raw -NodeId 'acc-999' -Path @('graph_attributes','type') -Value 'x' }        | Should -Throw
+        }
+    }
+
+    It '9. wrong-type-at-path: object/array target and mid-path type mismatch safe-throw' {
+        InModuleScope AITriad -Parameters @{ Raw = $script:Fixture } {
+            param($Raw)
+            # target is an object (graph_attributes) — scalar-only replacement refuses
+            { Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('graph_attributes') -Value 'scalar' } | Should -Throw
+            # mid-path descends into a scalar with a further key segment
+            { Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('graph_attributes','type','x') -Value 'y' } | Should -Throw
+            # index segment against an object container
+            { Update-JsonNodePath -RawText $Raw -NodeId 'acc-001' -Path @('graph_attributes',0) -Value 'y' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
## t/2921 Phase 2 — nested-path surgical editor `Update-JsonNodePath` + shared-internals extraction

**DRAFT — routed to Main (TL) for GV** per ruling t/2921#2. Builds on the merged Phase-1 primitive. Both entry points are Private; **no export/guard change (NOT gate-touching)**. Consumers held until GV (LOW priority).

### Mechanism (per your 4 rulings)
- **Q1 — segment-array addressing:** NodeId-anchored + ordered segments (key=string, index=int), e.g. `@('graph_attributes','policy_actions',2,'framing')`. Not a dotted string, not JSON Pointer. Dotted/bracket form rendered for error/log **display only**.
- Recursive **span-scoped parse-LOCATE** (node object span → descend member/element spans via a string/escape-aware value-skipper) → **minimal SPLICE** → **re-parse-VERIFY** invariant (expected = clone + intended change at path; canonical order-insensitive compare; any other delta → `New-ActionableError`, writes nothing).
- **Q2 — in-place scalar only:** path-not-found, object/array-valued target, and mid-path type mismatch all **safe-throw**. No insert-at-depth, no structural add/remove.
- **Q3 — alongside, not supersede:** extracted the shared internals both writers call into `Private/JsonSurgeryCore.ps1` (`ConvertTo-CanonicalForm`, `Test-JsonSemanticEqual`, `Find-JsonObjectSpan` + new `Get-JsonValueSpan`/`Find-JsonMemberValueStart`/`Find-JsonArrayElementStart`). The proven depth-1 `Update-JsonNodeField` logic is **unchanged** (helpers relocated only).

### Verification
- **Adversarial suite (TDD, written first) 9/9** incl. your required additions: nested field; string-array element; array-element object field; nested field-name collision; escaping; **byte-identical foreign-WIP survival on a nested edit**; multi-node sequential composition; path-not-found safe-throw; **wrong-type-at-path safe-throw**.
- **Phase-1 regression 8/8** (proves the extraction didn't disturb the situations.json-critical depth-1 path).
- All changed files parse-clean.

### Next (separate PRs, held until this GV's)
Python mirror of the editor + the **gate-touching** `-SurgicalWrite`/`surgical_write` Python exemption on `data_tree_guard.py` (both-arms GV + fire-arm + `.py` detection-grep coverage); then incremental consumer conversions (`reprocess`, `Repair-Pov*`, batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
