### PR TITLE
feat(bridge): typed retryable backpressure for load-shed 503 (t/2922)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/resilience.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/resilience.test.ts
@@ -251,6 +251,71 @@ describe('resilience', () => {
     });
   });
 
+  // GV arms for t/2922: a load-shed 503 carrying { retryable: true } + Retry-After is typed
+  // backpressure (server healthy, shedding) — retry it and DON'T trip the breaker; a genuine-down
+  // 503 (no retryable:true, or a non-JSON body) still fails fast + trips exactly as before.
+  describe('resilientFetch — typed backpressure retryable 503 (t/2922)', () => {
+    const shed503 = (retryAfter = '1') =>
+      mockFetchResponse(503, { error: 'shedding', retryable: true, reason: 'concurrency', retryAfterMs: 1000 }, { 'Retry-After': retryAfter });
+
+    // A 503 whose body is not JSON (e.g. an HTML error page from a genuinely-down server):
+    // clone().json() rejects → not backpressure.
+    function mockNonJson503(): Response {
+      const res = mockFetchResponse(503, {});
+      (res as unknown as { json: () => Promise<unknown> }).json = () => Promise.reject(new SyntaxError('Unexpected token < in JSON'));
+      (res as unknown as { clone: () => Response }).clone = () => mockNonJson503();
+      return res;
+    }
+
+    it('retries a retryable:true 503 after Retry-After, recovers, and does NOT trip the breaker', async () => {
+      fetchSpy
+        .mockResolvedValueOnce(shed503('1'))
+        .mockResolvedValueOnce(mockFetchResponse(200, { ok: true }));
+      const promise = resilientFetch('/api/embeddings/compute', { method: 'POST' }, defaultOpts({ category: 'mutation', maxRetries: 1 }));
+      await vi.advanceTimersByTimeAsync(5000);
+      const res = await promise;
+      expect(res.ok).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      const c = getResilienceState().circuits.mutation;
+      expect(c.state).toBe('CLOSED');
+      expect(c.consecutiveFailures).toBe(0);
+    });
+
+    it('fails fast and trips the breaker on a genuine-down 503 (no retryable:true), unchanged', async () => {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse(503, { error: 'down' }));
+      const res = await resilientFetch('/api/embeddings/compute', { method: 'POST' }, defaultOpts({ category: 'mutation' }));
+      expect(res.status).toBe(503);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(getResilienceState().circuits.mutation.consecutiveFailures).toBe(1);
+    });
+
+    it('treats a non-JSON 503 body as a genuine failure (not backpressure)', async () => {
+      fetchSpy.mockResolvedValueOnce(mockNonJson503());
+      await resilientFetch('/api/embeddings/compute', { method: 'POST' }, defaultOpts({ category: 'mutation' }));
+      expect(getResilienceState().circuits.mutation.consecutiveFailures).toBe(1);
+    });
+
+    it('surfaces the 503 after retries on a persistent shed — no hang, no breaker trip', async () => {
+      fetchSpy
+        .mockResolvedValueOnce(shed503('1'))
+        .mockResolvedValueOnce(shed503('1'));
+      const promise = resilientFetch('/api/embeddings/compute', { method: 'POST' }, defaultOpts({ category: 'mutation', maxRetries: 1 }));
+      await vi.advanceTimersByTimeAsync(5000);
+      const res = await promise;
+      expect(res.status).toBe(503);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(getResilienceState().circuits.mutation.consecutiveFailures).toBe(0);
+    });
+
+    it('skips retry when a retryable 503 Retry-After exceeds the cap, still no breaker trip', async () => {
+      fetchSpy.mockResolvedValueOnce(shed503('120'));
+      const res = await resilientFetch('/api/embeddings/compute', { method: 'POST' }, defaultOpts({ category: 'mutation', maxRetries: 3 }));
+      expect(res.status).toBe(503);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(getResilienceState().circuits.mutation.consecutiveFailures).toBe(0);
+    });
+  });
+
   describe('circuit breaker', () => {
     it('opens after 5 consecutive failures', async () => {
       for (let i = 0; i < 5; i++) {

--- a/taxonomy-editor/src/renderer/bridge/resilience.ts
+++ b/taxonomy-editor/src/renderer/bridge/resilience.ts
@@ -284,6 +284,30 @@ function parseRetryAfter(res: Response): number | null {
   return null;
 }
 
+/** A typed backpressure signal — the server is healthy but shedding load / rate-limiting and
+ *  wants the client to honor Retry-After and re-offer the request (t/2922). Two shapes converge
+ *  on one concept:
+ *    - HTTP 429 (rate limit — backpressure by status), and
+ *    - any retryable status whose JSON body carries `retryable: true` — the load-shed 503
+ *      (t/2905, `routes/ai.ts`) and the upstream-429 mapping both set this.
+ *  Backpressure resets the breaker (`onCircuitSuccess`) rather than tripping it. A genuine-down
+ *  503 (no `retryable: true`, or a non-JSON/empty body) is NOT backpressure — it fails fast and
+ *  trips the breaker, unchanged. The 429 disjunct is retained so a non-retryable `tokens_per_day`
+ *  429 stays on the healthy path (a pure `retryable`-key would regress it into a breaker trip).
+ *  Peeks a clone so the original body stays intact for the retry-path cancel or the caller's
+ *  final read. */
+async function isBackpressure(res: Response): Promise<boolean> {
+  if (res.status === 429) return true;
+  try {
+    const data = await res.clone().json() as { retryable?: unknown } | null;
+    return data?.retryable === true;
+  } catch {
+    // silent by design: a non-JSON / empty body means this is not a typed-backpressure
+    // response (e.g. a genuinely-down 503) — treat as a real failure, not backpressure.
+    return false;
+  }
+}
+
 // ── Main entry point ──
 
 export async function resilientFetch(
@@ -314,15 +338,19 @@ export async function resilientFetch(
         return res;
       }
 
-      // Retryable HTTP status — 429 is rate-limiting (server healthy), not a failure
-      if (res.status === 429) {
+      // Retryable HTTP status. Typed backpressure (429, or a retryable:true body — the
+      // load-shed 503) means the server is healthy but shedding: honor Retry-After and
+      // re-offer, and treat it as a success for the breaker. Anything else is a real
+      // failure that trips the breaker (t/2922).
+      const backpressure = await isBackpressure(res);
+      if (backpressure) {
         onCircuitSuccess(category);
       } else {
         onCircuitFailure(category, `HTTP ${res.status}`, path, init.method);
       }
 
       if (attempt < maxRetries) {
-        const retryAfterMs = res.status === 429 ? parseRetryAfter(res) : null;
+        const retryAfterMs = backpressure ? parseRetryAfter(res) : null;
         if (retryAfterMs !== null && retryAfterMs > cfg().maxRetryAfterMs) {
           return res;
         }

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -991,7 +991,7 @@ const rawApi: AppAPI = {
   getProxyUsage: () => get('/api/proxy/usage'),
 
   // Embeddings & NLI
-  computeEmbeddings: (texts, ids) => post('/api/embeddings/compute', { texts, ids }),
+  computeEmbeddings: (texts, ids) => post('/api/embeddings/compute', { texts, ids }, { idempotent: true }), // idempotent:true → 1 retry so a load-shed 503 (retryable:true+Retry-After) recovers; embeddings are a pure fn of inputs (t/2922)
   // Web transport: the server embedding backend (Python/Gemini) has no DirectML GPU-OOM failure
   // mode, so nothing goes stale on this path → always [] (t/2060 staleNodeIds contract). If the
   // server route later reports partial failures, thread them through here.


### PR DESCRIPTION
## Summary
Prerequisite for the t/2905 load-shed promotion. The web-bridge did not retry the embeddings load-shed 503, ignored its Retry-After, and tripped the circuit breaker on it — so promoting the shed to block would fail debate turns and OPEN the breaker. Design approved by TL (t/2922#1 → t/2922#2).

- **resilience.ts** — unify "healthy but shedding" into one typed-backpressure concept: `isBackpressure(res)` = HTTP 429 **or** body `{ retryable: true }`. Backpressure honors Retry-After and calls `onCircuitSuccess` (no trip). A genuine-down 503 (no `retryable:true`, or a non-JSON body) still fails fast + trips, unchanged. Body peeked via `res.clone()` so the original stays intact for retry-cancel / caller final read.
- **web-bridge.ts** — `computeEmbeddings` posts `{ idempotent: true }` → one retry budget (embeddings are a pure function of inputs; safe re-offer; sanctioned t/878 exception).
- **resilience.test.ts** — 5 GV arms (below).

## GV arms (all green locally)
1. retryable:true 503 + Retry-After → retries, recovers on attempt 2, breaker stays CLOSED.
2. genuine-down 503 (no `retryable`) → fails fast + trips (`consecutiveFailures` 1).
3. non-JSON 503 body → treated as genuine failure.
4. persistent shed → surfaces the 503 after retries, no hang, no trip.
5. Retry-After over the cap → skips retry, no trip.

## Verification
- `resilience.test.ts` 46/46 pass; renderer `tsc -p tsconfig.json` clean (exit 0).
- Full `npm run verify` is authoritative on CI Node 22 (local Node 7.x hits the unrelated undici-skew only).

## ⚠ Deviation flag for GV
TL guidance was "key the discriminator on `retryable===true`." I implemented `status===429 || body.retryable===true` — the `429` disjunct is retained deliberately so a **non-retryable `tokens_per_day` 429** (web-bridge post L260) keeps its existing healthy-path behavior. A pure `retryable`-key would have regressed it into `onCircuitFailure` → breaker trips on quota exhaustion. If you'd rather I drop the disjunct, say so.

**Draft — holding for your GV before merge.** Fixes t/2922. Blocks: t/2905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)