### PR TITLE
fix(oped): reflection retry-on-empty insurance for claims (t/2919)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -283,41 +283,74 @@ async function runVoiceGeneration(
     })),
   ];
 
-  // Reflection pass — best-effort, maps grounding elements to where they appear
+  // Reflection pass — best-effort, maps grounding elements to where they appear.
   let reflClaims: { text: string; paragraph: number }[] | undefined;
   if (allGroundingRefs.length > 0 && body) {
-    try {
-      const groundingList = buildGroundingList(groundingNodes, sitNodes);
-      const sourceClaims = sourceBrief?.key_claims?.length
-        ? sourceBrief.key_claims.map((c, i) => `  ${i + 1}. ${c}`).join('\n')
-        : '(none)';
-      const reflPrompt = assembleReflectionPrompt(deps.promptsDir, body, groundingList, sourceClaims);
-      const reflMaxTokens = Math.max(4000, allGroundingRefs.length * 150 + 3000);
-      const reflRaw = await deps.adapter.generateText(reflPrompt, request.params.model, {
-        maxTokens: reflMaxTokens,
-        temperature: 0.2,
-        responseSchema: REFLECTION_SCHEMA as Record<string, unknown>,
-        signal: request.signal,
-      });
-      const reflParsed = JSON.parse(stripCodeFences(reflRaw)) as ReflectionResponse;
-      const usageMap = new Map(reflParsed.grounding_usage.map(u => [u.id, u]));
-      for (const ref of allGroundingRefs) {
-        const usage = usageMap.get(ref.node_id);
-        if (usage) {
-          ref.how_reflected = usage.reflection;
-          if (usage.document_claims?.length) ref.document_claims = usage.document_claims;
+    const groundingList = buildGroundingList(groundingNodes, sitNodes);
+    const keyClaimsCount = sourceBrief?.key_claims?.length ?? 0;
+    const sourceClaims = keyClaimsCount > 0
+      ? sourceBrief!.key_claims!.map((c, i) => `  ${i + 1}. ${c}`).join('\n')
+      : '(none)';
+    const reflPrompt = assembleReflectionPrompt(deps.promptsDir, body, groundingList, sourceClaims);
+    const reflMaxTokens = Math.max(4000, allGroundingRefs.length * 150 + 3000);
+
+    // One reflection attempt. Applies how_reflected + document_claims onto allGroundingRefs
+    // and sets reflClaims; returns true iff it produced any top-level claims. Fail-safe: a
+    // throw is recorded (t/2897 diagnosability) and treated as "no claims" — never rethrown,
+    // so a reflection failure can never block generation.
+    const runReflection = async (temperature: number): Promise<boolean> => {
+      try {
+        const reflRaw = await deps.adapter.generateText(reflPrompt, request.params.model, {
+          maxTokens: reflMaxTokens,
+          temperature,
+          responseSchema: REFLECTION_SCHEMA as Record<string, unknown>,
+          signal: request.signal,
+        });
+        const reflParsed = JSON.parse(stripCodeFences(reflRaw)) as ReflectionResponse;
+        const usageMap = new Map(reflParsed.grounding_usage.map(u => [u.id, u]));
+        for (const ref of allGroundingRefs) {
+          const usage = usageMap.get(ref.node_id);
+          if (usage) {
+            ref.how_reflected = usage.reflection;
+            if (usage.document_claims?.length) ref.document_claims = usage.document_claims;
+          }
         }
+        if (reflParsed.claims?.length) reflClaims = reflParsed.claims;
+        return !!reflParsed.claims?.length;
+      } catch (err) {
+        // Non-fatal — how_reflected stays '(not reported)', claims absent. Recorded so
+        // it's visible (the bare swallow made four failures undiagnosable, t/2897).
+        // 'system.error'+level:'warn' — the file's valid-EventType warn convention.
+        deps.recorder?.record({
+          type: 'system.error', component: 'opedGenerate', level: 'warn',
+          message: `Op-ed reflection pass failed for pov=${pov} set=${request.set_id}: ${String(err)} — grounding how_reflected + claims will be absent`,
+        });
+        return false;
       }
-      if (reflParsed.claims?.length) reflClaims = reflParsed.claims;
-    } catch (err) {
-      // Reflection failure is non-fatal — how_reflected stays '(not reported)' and
-      // claims are absent. The bare swallow here is why four claims-extraction
-      // failures were undiagnosable (t/2897); record it so it's visible. Uses
-      // 'system.error'+level:'warn' — the file's valid-EventType warn convention
-      // ('system.warning' is not in the union; TL confirmed the mapping, p/342#133).
+    };
+
+    const gotClaims = await runReflection(0.2);
+
+    // Retry-on-empty insurance (t/2919): the reflection came back with no claims even
+    // though a source brief WITH key_claims existed — a "should-have-but-didn't". The
+    // ~50% systematic defect was FALSIFIED (22/22 on measurement, t/2919#1); this guards
+    // only the one residual a clean measurement can't exclude — a rare transient LLM
+    // empty/malformed response — the last un-excludable cause of the t/2897 "no Claims
+    // section" after topic-mode (t/2899), stale-build, and the validation regression
+    // (t/2908) were fixed. NOT reached for a legitimately-empty topic-mode reflection
+    // (keyClaimsCount === 0). Single retry at temp 0, fail-safe, logged so any real prod
+    // transient-empty rate becomes visible. Mirrors the narrate empty-entries gate (t/2872).
+    if (!gotClaims && keyClaimsCount > 0) {
       deps.recorder?.record({
-        type: 'system.error', component: 'opedGenerate', level: 'warn',
-        message: `Op-ed reflection pass failed for pov=${pov} set=${request.set_id}: ${String(err)} — grounding how_reflected + claims will be absent`,
+        type: 'system.info', component: 'opedGenerate', level: 'info',
+        message: `Op-ed reflection returned no claims despite ${keyClaimsCount} source key_claims (pov=${pov} set=${request.set_id}) — retrying once (t/2919)`,
+        data: { reason: 'reflection-retry', pov, set_id: request.set_id, key_claims: keyClaimsCount },
+      });
+      const retried = await runReflection(0);
+      deps.recorder?.record({
+        type: 'system.info', component: 'opedGenerate', level: 'info',
+        message: `Op-ed reflection retry ${retried ? 'succeeded' : 'still empty'} (pov=${pov} set=${request.set_id}) (t/2919)`,
+        data: { reason: 'reflection-retry-outcome', pov, set_id: request.set_id, succeeded: retried },
       });
     }
   }

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -406,3 +406,71 @@ describe('generateOpEdSet — source provenance + reflection observability (t/28
     expect(round.source_mode).toBeUndefined();
   });
 });
+
+// ── Reflection retry-on-empty insurance (t/2919) ──────────────────────────────
+// The ~50% systematic emission defect was FALSIFIED by measurement (22/22, t/2919#1);
+// this single fail-safe retry guards only a rare transient LLM empty when a source brief
+// with key_claims existed but the reflection came back with no claims. Mirrors the narrate
+// empty-entries presence gate (t/2872). Fires ONLY on "should-have-but-didn't" (url mode);
+// never on a legitimate topic-mode empty.
+describe('generateOpEdSet — reflection retry-on-empty (t/2919)', () => {
+  const ESSAY = JSON.stringify({ headline: 'H', subtitle: '', body_markdown: 'Body text here.', word_count: 3 });
+  const BRIEF = JSON.stringify({ thesis: 't', author: 'a', actor_type: 'x', stance: 's', primary_recommendations: ['r'], key_claims: ['claim one', 'claim two'], readable: true });
+  const REFL_EMPTY = JSON.stringify({ grounding_usage: [{ id: 'acc-bel-001', reflection: 'used' }] }); // no top-level claims
+  const REFL_FULL = JSON.stringify({ grounding_usage: [{ id: 'acc-bel-001', reflection: 'used', document_claims: ['claim one'] }], claims: [{ text: 'claim one', paragraph: 1 }] });
+  const PROMPTS = join(REPO_ROOT, 'lib', 'oped', 'prompts');
+
+  it('retries once and recovers claims when a source brief has key_claims but the first reflection returned none', async () => {
+    let reflCall = 0;
+    const adapter = { generateText: async (p: string) => {
+      if (p === 'source-brief-prompt') return BRIEF;
+      if (p === 'refl') { reflCall++; return reflCall === 1 ? REFL_EMPTY : REFL_FULL; }
+      return ESSAY;
+    } };
+    const record = vi.fn();
+    let member: { claims?: { text: string; paragraph: number }[] } | undefined;
+    for await (const ev of generateOpEdSet(
+      { set_id: 's-retry', topic: 'AI', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' }, povs: ['accelerationist'], sourceMaterial: 'Doc', sourceUrl: 'https://example.org/x' } as never,
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT, recorder: { record } } as never,
+    ) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_complete') member = ev.member as typeof member;
+    }
+    expect(reflCall).toBe(2);                    // retry fired
+    expect(member?.claims?.length).toBe(1);      // retry recovered the claims
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ reason: 'reflection-retry' }) }));
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ reason: 'reflection-retry-outcome', succeeded: true }) }));
+  });
+
+  it('does NOT retry in topic mode (no source brief) even when the reflection has no claims', async () => {
+    let reflCall = 0;
+    const adapter = { generateText: async (p: string) => {
+      if (p === 'refl') { reflCall++; return REFL_EMPTY; }
+      return ESSAY;
+    } };
+    const record = vi.fn();
+    for await (const _ev of generateOpEdSet(
+      { set_id: 's-topic', topic: 'AI', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' }, povs: ['accelerationist'] } as never, // no sourceMaterial
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT, recorder: { record } } as never,
+    ) as AsyncGenerator<OpEdProgressEvent>) { /* drain */ }
+    expect(reflCall).toBe(1);                     // no retry — legitimately-empty topic-mode reflection
+    expect(record).not.toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ reason: 'reflection-retry' }) }));
+  });
+
+  it('does NOT retry when the first reflection already produced claims', async () => {
+    let reflCall = 0;
+    const adapter = { generateText: async (p: string) => {
+      if (p === 'source-brief-prompt') return BRIEF;
+      if (p === 'refl') { reflCall++; return REFL_FULL; }
+      return ESSAY;
+    } };
+    let member: { claims?: unknown[] } | undefined;
+    for await (const ev of generateOpEdSet(
+      { set_id: 's-ok', topic: 'AI', params: { model: 'm', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' }, povs: ['accelerationist'], sourceMaterial: 'Doc', sourceUrl: 'https://example.org/x' } as never,
+      { adapter, promptsDir: PROMPTS, repoRoot: REPO_ROOT } as never,
+    ) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_complete') member = ev.member as typeof member;
+    }
+    expect(reflCall).toBe(1);                     // no retry needed
+    expect(member?.claims?.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes t/2919 (last open axis of t/2897, with t/2917''s prevention test). Self-cert `/t2872` pattern (follows the narrate empty-entries presence gate); TL approved option B tightly scoped (t/2919#2).

## Finding first (measure-before-fix)
The ticket''s "~50% systematic reflection-emission defect" is **FALSIFIED**: 22/22 = 100% claims emission on current main under controlled measurement (isolated reflection 16/16 + full `generateOpEdSet` 6/6, `gemini-3.7-flash`). P(22/22 at a true 50% rate) ≈ 2×10⁻⁷. The original t/2917 misses were **test-harness confounds** — the legacy `gemini-2.5-flash` alias + a real vitest fork-pool worker crash — not a production defect. Full data: t/2919#1.

## Fix (TL option B, tightly scoped)
A single fail-safe retry as insurance against the one residual a clean measurement can''t exclude — a rare transient LLM empty/malformed reflection — the last un-excludable cause of the t/2897 "no Claims section" after topic-mode (t/2899), stale-build, and the validation regression (t/2908) were fixed.

`generate.ts`: extract the reflection attempt into `runReflection(temperature)` (fail-safe — a throw is recorded, never rethrown, can''t block generation). Run once at 0.2; if it returns **no claims AND a source brief with key_claims existed** (url-mode "should-have-but-didn''t", **not** a legit topic-mode empty), retry once at temp 0. Both the retry firing and its outcome are **logged** (`system.info`, `reason:'reflection-retry'` / `'reflection-retry-outcome'`) — so any real prod transient-empty rate becomes visible, closing the observability gap.

## Tests
`serialGeneration.test.ts`: (1) retry fires + recovers claims (url mode, first empty → second full); (2) **no** retry in topic mode (no source brief); (3) **no** retry when the first attempt already produced claims. Full `lib/oped` suite green (77), `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)