### PR TITLE
fix(hooks): normalize root AND ftop via cd+pwd — MSYS hook-context mangle (t/2112 salvage)

### DIFF
--- a/.githooks/agent-file-owner.sh
+++ b/.githooks/agent-file-owner.sh
@@ -49,7 +49,12 @@ set -u
 MAIN_OWNED='AGENTS.md
 operations/devops/azure/AGENTS.md'
 
-root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+# Normalise via cd+pwd: raw --show-toplevel returns C:/... when invoked from a
+# git hook on Windows, but /c/... when run directly. ogit's -C flag then sees a
+# different working set than a direct run, producing spurious double-tracked /
+# neither-tracked failures that block every commit on the shared checkout.
+# Same idiom pre-commit already applies to git-dir / git-common-dir (t/2112).
+root=$(cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null && pwd) || {
   echo "agent-file-owner: not inside a git work tree" >&2; exit 2; }
 
 overlay_dir="$root/.orca-git"
@@ -102,7 +107,10 @@ mode_path() {
   # cloned inside the tree) is that repo's to track, not this project's.
   if [ -e "$root/$rel" ]; then
     case "$rel" in */*) fdir="$root/${rel%/*}" ;; *) fdir="$root" ;; esac
-    ftop=$(git -C "$fdir" rev-parse --show-toplevel 2>/dev/null) || ftop=$root
+    # Normalise the same way as $root — a raw --show-toplevel returns C:/...
+    # while $root is /c/..., so an un-normalised compare never matches and
+    # classifies EVERY file as external, silently emptying the audit.
+    ftop=$(cd "$(git -C "$fdir" rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null && pwd) || ftop=$root
     if [ "$ftop" != "$root" ]; then
       echo "external (nested git repo at ${ftop#"$root"/} — tracked there, not by this project)"
       return 0
@@ -153,7 +161,8 @@ mode_audit() {
       # data repo clone); that repo, not this one, is their backing store. A
       # genuine orphan's directory resolves to THIS root and still fires.
       case "$f" in */*) fdir="$root/${f%/*}" ;; *) fdir="$root" ;; esac
-      ftop=$(git -C "$fdir" rev-parse --show-toplevel 2>/dev/null) || ftop=$root
+      # Normalise to match $root's form (see the paired site above).
+      ftop=$(cd "$(git -C "$fdir" rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null && pwd) || ftop=$root
       [ "$ftop" != "$root" ] && continue
       echo "$f"
     done)


### PR DESCRIPTION
> **Draft — gate change, needs TL Gate Verification.** Touches `.githooks/agent-file-owner.sh`, which the pre-commit hook runs on every commit. Held as draft per the gated-PR rule until signed off.

## What this is

Salvages the one real fix stranded on `chore/junk-file-guard-t2112` — commit `821a9a0c`, pushed **after** PR #393 merged, never landed. Reapplied to main's current file rather than merged.

## Why not just merge that branch

**1. It would regress `main`.** The branch predates three things main has since gained:
- the t/2548 nested-git-repo exclusion
- the `.worktrees` prune in the find
- the `GIT_INDEX_FILE` fix in `ogit()`

Merging reverts all three.

**2. Worse — its one-line form silently disables the gate.**

It normalizes `$root` to `/c/...` but leaves the two t/2548 `ftop` compares on raw `--show-toplevel` (`C:/...`). The two never match, so **every** file is classified "external nested repo" and skipped. The audit reports clean with a real orphan sitting there.

| With a deliberate orphan present | Result |
|---|---|
| `main` today | ✅ fires, names the file |
| branch's one-line fix | ❌ reports "clean" |

That is a false-negative on the guard that exists to stop `AGENTS.md` files being stranded with no backing repo.

## The fix

Normalizes all three sites (`root` + both `ftop` compares) so the comparisons stay consistent. Same `cd "$(...)" && pwd` idiom `pre-commit:114-115` already uses for `git-dir` / `git-common-dir`.

## Gate verification — both arms, overlay present

| Arm | `main` | this PR |
|---|---|---|
| Clean case | clean, no noise | clean, no noise |
| Deliberate orphan | FIRES + names it | FIRES + names it |
| `--path` probe (root, lib) | `main` / `overlay` | `main` / `overlay` |
| Nested repo (`.local-data/ai-triad-data`) | `external` | `external` |

## Known limitation — please read before merging

**The original bug does not reproduce on this machine.** Both root forms produce an identical 83-file `ogit ls-files` set, so I could not demonstrate the fix resolving the reported symptom (audit passes standalone / `git commit` blocks).

AGENTS.md documents this mangle as environment-dependent — "confirmed on ≥2 agents, not reproduced on others." So this change is **behaviorally neutral here** and its benefit needs confirming on an affected machine.

Two defensible calls, TL's choice:
1. **Merge** — neutral where the bug is absent, fixes it where present, and removes a stranded-fix trap.
2. **Hold** — don't touch a blocking gate on an unreproducible bug; close `chore/junk-file-guard-t2112` as dangerous instead.

Either way, **that branch should not be merged as-is**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
