### PR TITLE
fix(oped): base64 shim transport + surface parse failure for FromUrl source (t/2928)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/opedShimTransport.test.ts
+++ b/taxonomy-editor/src/main/__tests__/opedShimTransport.test.ts
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression coverage for the FromUrl op-ed shim→handler transport (t/2928). The real incident
+// was a PS ConvertTo-Json defect (invalid JSON for real article HTML) that the handler then
+// silently swallowed → opaque "No result received." These test the two pure defenses directly:
+// base64 round-trip of arbitrary content, and surfacing (not swallowing) a broken result line.
+
+import { describe, it, expect } from 'vitest';
+import { ActionableError } from '../../../../lib/debate/errors.js';
+import { parseShimLine, decodeB64Fields } from '../ipc/opedShimTransport.js';
+
+// The exact shape that broke it: prose with an embedded `*"..."*` quote + a base64 data-URI.
+const NASTY = '# Title\n\n*"Who is talking to your child?"*\n\nBody with a data URI ![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ) and a trailing "quote".';
+
+function b64(s: string): string {
+  return Buffer.from(s, 'utf-8').toString('base64');
+}
+
+describe('opedShimTransport — decodeB64Fields (t/2928)', () => {
+  it('round-trips a base64 SourceMarkdown byte-faithfully', () => {
+    const data = { SourceMarkdown: b64(NASTY), Excerpt: b64('short "excerpt"'), _b64Fields: ['SourceMarkdown', 'Excerpt'] };
+    const decoded = decodeB64Fields({ ...data });
+    expect(decoded.SourceMarkdown).toBe(NASTY);
+    expect(decoded.Excerpt).toBe('short "excerpt"');
+  });
+
+  it('strips the _b64Fields marker so downstream never sees it', () => {
+    const decoded = decodeB64Fields({ SourceMarkdown: b64('x'), _b64Fields: ['SourceMarkdown'] });
+    expect('_b64Fields' in decoded).toBe(false);
+  });
+
+  it('is a no-op when _b64Fields is absent (backward-safe)', () => {
+    const decoded = decodeB64Fields({ SourceMarkdown: 'already-plain', ReadableWords: 42 });
+    expect(decoded.SourceMarkdown).toBe('already-plain');
+    expect(decoded.ReadableWords).toBe(42);
+  });
+
+  it('leaves a non-string field named in _b64Fields untouched', () => {
+    const decoded = decodeB64Fields({ SourceMarkdown: null as unknown as string, _b64Fields: ['SourceMarkdown'] });
+    expect(decoded.SourceMarkdown).toBeNull();
+  });
+});
+
+describe('opedShimTransport — parseShimLine (t/2928)', () => {
+  it('parses a valid result line and returns its data', () => {
+    const line = JSON.stringify({ type: 'result', data: { SourceMarkdown: b64(NASTY), _b64Fields: ['SourceMarkdown'] } });
+    const msg = parseShimLine(line);
+    expect(msg?.type).toBe('result');
+  });
+
+  it('THROWS an ActionableError on a result-looking line that fails to parse (never swallows)', () => {
+    // Contains "type":"result" but a bare unescaped " prematurely ends the string — the exact defect.
+    const broken = '{"type":"result","data":{"SourceMarkdown":"a bare " quote ends the string"}}';
+    expect(() => parseShimLine(broken)).toThrow(ActionableError);
+    try {
+      parseShimLine(broken);
+    } catch (e) {
+      expect((e as ActionableError).problem).toMatch(/unparseable result line/i);
+      expect((e as ActionableError).nextSteps.some((s) => /base64/i.test(s))).toBe(true);
+    }
+  });
+
+  it('returns null (skips) a non-result line that does not parse', () => {
+    expect(parseShimLine('not json at all')).toBeNull();
+    expect(parseShimLine('{"type":"stage", broken')).toBeNull();
+  });
+
+  it('parses a valid stage line', () => {
+    expect(parseShimLine(JSON.stringify({ type: 'stage', stage: 'fetching' }))?.type).toBe('stage');
+  });
+});

--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -23,6 +23,7 @@ import { generateOpEdSet } from '../../../../lib/oped/generate.js';
 import type { GenerateOpEdRequest, OpEdGeneratorDeps } from '../../../../lib/oped/generate.js';
 import { makeElectronAIAdapter } from '../electronAIAdapter.js';
 import { validateCreateOpEdPayload } from './opedValidation.js';
+import { parseShimLine, decodeB64Fields } from './opedShimTransport.js';
 
 // Shared prompts dir: op-ed-*.prompt artifacts (relocated to lib/oped/prompts by t/2609).
 const PROMPTS_DIR = path.join(PROJECT_ROOT, 'lib', 'oped', 'prompts');
@@ -58,11 +59,7 @@ interface OpEdProgressEvent {
   error?: string;
 }
 
-// ── Shim stdout line shapes (Stage-A only) ────────────────────────────────────
-
-interface ShimStageLine { type: 'stage'; stage: string }
-interface ShimResultLine { type: 'result'; data: Record<string, unknown> }
-type ShimLine = ShimStageLine | ShimResultLine;
+// Shim stdout line shapes + parse/decode transport live in ./opedShimTransport (pure, unit-tested).
 
 // ── Stage-A: source prep runner ───────────────────────────────────────────────
 
@@ -105,10 +102,22 @@ function runGetOpEdSource(url: string, signal: AbortSignal): Promise<Record<stri
       for (const line of lines) {
         const trimmed = line.trim();
         if (!trimmed) continue;
-        let msg: ShimLine;
-        try { msg = JSON.parse(trimmed) as ShimLine; } catch { /* telemetry — silent by design */ continue; }
-        if (msg.type === 'result') {
-          settle(() => resolve((msg as ShimResultLine).data ?? {}));
+        let msg;
+        try {
+          msg = parseShimLine(trimmed);
+        } catch (err) {
+          // A result-looking line that fails to parse is a hard serialization failure — record it
+          // and surface it, never swallow into the opaque close-handler "No result received" (t/2928).
+          getGlobalRecorder()?.record({
+            type: 'system.error', component: 'opedHandlers', level: 'error',
+            message: 'Get-OpEdSource emitted an unparseable result line',
+            error: { name: (err as Error).name ?? 'Error', message: String((err as Error).message ?? err), stack: (err as Error).stack },
+          });
+          settle(() => reject(err));
+          return;
+        }
+        if (msg && msg.type === 'result') {
+          settle(() => resolve(decodeB64Fields(msg.data ?? {})));
         }
       }
     });

--- a/taxonomy-editor/src/main/ipc/opedShimTransport.ts
+++ b/taxonomy-editor/src/main/ipc/opedShimTransport.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Transport contract between the Get-OpEdSource PS shim and opedHandlers (t/2928).
+//
+// PowerShell `ConvertTo-Json` emits INVALID JSON for some real fetched web content (it left a
+// bare unescaped `"` inside a string value), which made FromUrl op-ed generation fail end-to-end
+// while the handler reported an opaque "No result received." Two defenses live here, extracted
+// as pure functions (no electron import) so the real shim→handler boundary is unit-testable:
+//
+//  1. Arbitrary-web-content fields travel base64-encoded and are listed in `_b64Fields`; the shim
+//     encodes them BEFORE ConvertTo-Json (so it only ever sees ASCII for them), and decodeB64Fields
+//     restores them here. Bulletproof by construction, PS-version-independent.
+//  2. parseShimLine SURFACES a result-line parse failure as an ActionableError instead of the old
+//     `catch { continue }` that silently dropped it — the loud backstop if a future content field
+//     is ever missed from the shim's encode list.
+
+import { ActionableError, errorMessage } from '../../../../lib/debate/errors.js';
+
+export interface ShimStageLine { type: 'stage'; stage: string }
+export interface ShimResultLine { type: 'result'; data: Record<string, unknown> }
+export type ShimLine = ShimStageLine | ShimResultLine;
+
+/** Bounded head+tail excerpt so a 13k-char malformed line doesn't flood the recorder while still
+ *  showing where the parse broke (recovery-vs-silent-loss convention). */
+function boundedSnippet(s: string, edge = 160): string {
+  if (s.length <= edge * 2) return s;
+  return `${s.slice(0, edge)} …[${s.length - edge * 2} chars]… ${s.slice(-edge)}`;
+}
+
+/**
+ * Parse one stdout line from the Get-OpEdSource shim.
+ * - Valid JSON → the parsed {@link ShimLine}.
+ * - A non-result line that fails to parse (stage telemetry) → `null` (safe to skip).
+ * - A line that LOOKS like the result (`"type":"result"`) but fails `JSON.parse` → THROWS an
+ *   {@link ActionableError}. This is the hard serialization failure that must never be swallowed
+ *   (t/2928); silently skipping it is what surfaced as the opaque "No result received."
+ */
+export function parseShimLine(trimmed: string): ShimLine | null {
+  try {
+    return JSON.parse(trimmed) as ShimLine;
+  } catch (err) {
+    // Not recorded here (ADR-003): a result-looking line re-throws below — the handler's catch
+    // records that; a non-result line is intentionally skipped. (telemetry — silent by design)
+    if (trimmed.includes('"type":"result"')) {
+      throw new ActionableError({
+        goal: 'Read the prepared source from Get-OpEdSource',
+        problem: `The source shim emitted an unparseable result line (${errorMessage(err)}). Near: ${boundedSnippet(trimmed)}`,
+        location: 'opedShimTransport.parseShimLine',
+        nextSteps: [
+          'This is a serialization defect in the Stage-A shim, not a problem with the web page',
+          'Ensure every fetched-content field is base64-encoded in invoke-get-oped-source.ps1 (_b64Fields)',
+        ],
+        innerError: err,
+      });
+    }
+    return null; // non-result line (e.g. a stage event) that didn't parse — skip, unchanged
+  }
+}
+
+/**
+ * Decode the base64 transport fields the shim flagged in `_b64Fields` back to UTF-8, in place,
+ * and strip the marker so downstream consumers never see it. No-op when the marker is absent
+ * (backward-safe against an un-upgraded shim). Byte-faithful: `UTF8.GetBytes` ↔ base64 ↔ utf-8.
+ */
+export function decodeB64Fields<T extends Record<string, unknown>>(data: T): T {
+  const fields = data['_b64Fields'];
+  if (Array.isArray(fields)) {
+    for (const f of fields) {
+      if (typeof f === 'string' && typeof data[f] === 'string') {
+        (data as Record<string, unknown>)[f] = Buffer.from(data[f] as string, 'base64').toString('utf-8');
+      }
+    }
+  }
+  delete (data as Record<string, unknown>)['_b64Fields'];
+  return data;
+}

--- a/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
+++ b/taxonomy-editor/src/main/ps/invoke-get-oped-source.ps1
@@ -18,6 +18,26 @@ Import-Module $modulePath -Force -ErrorAction Stop
 
 $prep = Get-OpEdSource -Url ([string]$p.Url)
 
+# Base64-encode the fetched arbitrary-web-content fields BEFORE ConvertTo-Json, so it only ever
+# serializes safe ASCII for them. PS ConvertTo-Json emits INVALID JSON for some real article HTML
+# (a bare unescaped `"` inside the value), which the handler then can't parse (t/2928). The handler
+# base64-decodes anything listed in `_b64Fields`.
+#
+# ANY future $prep field carrying fetched / arbitrary web content MUST be added to this list.
+# (Today only SourceMarkdown + Excerpt are content; SourceBrief is $null here — the New-OpEd
+# comprehension pass fills it downstream, not this shim.) Backstop if one is ever missed:
+# opedHandlers surfaces a LOUD ActionableError (parseShimLine), never a silent drop — so the worst
+# case is a diagnosable failure, not a recurrence of this once-invisible bug.
+$b64Fields = @()
+foreach ($f in @('SourceMarkdown', 'Excerpt')) {
+    $val = $prep.$f
+    if ($val -is [string] -and $val.Length -gt 0) {
+        $prep.$f = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($val))
+        $b64Fields += $f
+    }
+}
+$prep | Add-Member -NotePropertyName '_b64Fields' -NotePropertyValue $b64Fields -Force
+
 $resultLine = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
 [Console]::Out.WriteLine($resultLine)
 [Console]::Out.Flush()

--- a/tests/OpEdShimTransport.Tests.ps1
+++ b/tests/OpEdShimTransport.Tests.ps1
@@ -1,0 +1,66 @@
+#Requires -Version 7
+# Regression test for the FromUrl op-ed shim↔handler transport (t/2928).
+#
+# The incident: invoke-get-oped-source.ps1 did `$prep | ConvertTo-Json` on real article HTML and
+# PowerShell emitted INVALID JSON (a bare unescaped " inside SourceMarkdown), which the Node
+# handler could not JSON.parse → opaque "No result received." Fix: base64-encode the arbitrary
+# fetched-content fields before ConvertTo-Json so it only ever serializes ASCII for them.
+#
+# This test replicates the shim's serialization step on the EXACT failing content shape (no
+# network, no Get-OpEdSource call) and asserts the output is byte-faithful and, crucially, that
+# the raw article text never reaches the JSON (so no quote in it can break Node's parser).
+#
+# NB: PowerShell ConvertFrom-Json is more lenient than Node JSON.parse, so a PS-side round-trip is
+# NOT a full proxy for the Node handler — the byte-faithful + raw-text-absent assertions are what
+# make this meaningful; the Node side is covered by opedShimTransport.test.ts + the live-app smoke.
+
+Describe 'invoke-get-oped-source shim — base64 content transport (t/2928)' {
+    BeforeAll {
+        # The exact shape that broke it: prose with an embedded *"..."* quote + a base64 data-URI.
+        $script:Nasty = "# Title`n`n*""Who is talking to your child?""*`n`nBody with a data URI ![](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ) and a trailing ""quote""."
+
+        # Mirror of Get-OpEdSource's PSCustomObject output (only the fields the shim touches).
+        $prep = [PSCustomObject]@{
+            Url            = 'https://example.test/article'
+            SourceMarkdown = $script:Nasty
+            Excerpt        = 'lead-in with a ""quoted"" phrase'
+            ReadableWords  = 640
+            SourceBrief    = $null
+        }
+
+        # Replicate the shim's encode step verbatim (invoke-get-oped-source.ps1).
+        $b64Fields = @()
+        foreach ($f in @('SourceMarkdown', 'Excerpt')) {
+            $val = $prep.$f
+            if ($val -is [string] -and $val.Length -gt 0) {
+                $prep.$f = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($val))
+                $b64Fields += $f
+            }
+        }
+        $prep | Add-Member -NotePropertyName '_b64Fields' -NotePropertyValue $b64Fields -Force
+
+        $script:Json = [ordered]@{ type = 'result'; data = $prep } | ConvertTo-Json -Depth 10 -Compress
+    }
+
+    It 'flags both content fields in _b64Fields' {
+        $parsed = $script:Json | ConvertFrom-Json
+        $parsed.data._b64Fields | Should -Contain 'SourceMarkdown'
+        $parsed.data._b64Fields | Should -Contain 'Excerpt'
+    }
+
+    It 'never emits the raw article text into the JSON (so no quote in it can break the parser)' {
+        $script:Json | Should -Not -Match 'Who is talking'
+        $script:Json | Should -Not -Match 'quoted'
+    }
+
+    It 'round-trips SourceMarkdown byte-faithfully through base64 decode (handler-side)' {
+        $parsed = $script:Json | ConvertFrom-Json
+        $decoded = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($parsed.data.SourceMarkdown))
+        $decoded | Should -BeExactly $script:Nasty
+    }
+
+    It 'leaves non-content numeric fields untouched' {
+        $parsed = $script:Json | ConvertFrom-Json
+        $parsed.data.ReadableWords | Should -Be 640
+    }
+}


### PR DESCRIPTION
## Summary
FromUrl op-ed generation was broken end-to-end: the Stage-A shim `ConvertTo-Json`d real article HTML → **invalid JSON** (a bare unescaped `"` inside SourceMarkdown), and the handler stdout loop **swallowed** the parse failure (`catch{continue}`) → opaque "No result received." Blocks t/2897. Design approved (t/2928#2).

- **`invoke-get-oped-source.ps1`** — base64-encode the arbitrary-web-content fields (SourceMarkdown, Excerpt) BEFORE `ConvertTo-Json`, flagged in `_b64Fields`; only ASCII reaches the serializer. Co-located footgun comment: any future fetched-content field MUST be added here.
- **`opedShimTransport.ts`** (new, pure/no-electron) — `parseShimLine` **surfaces** a result-looking-but-unparseable line as an ActionableError with a bounded snippet (the loud backstop), never swallows; `decodeB64Fields` restores UTF-8 + strips the marker.
- **`opedHandlers.ts`** — stdout loop delegates to both; decode-before-resolve keeps the consumer unchanged.

## Verification
- `opedShimTransport.test.ts` **8/8** (byte-faithful round-trip + throw-not-swallow); `OpEdShimTransport.Tests.ps1` **4/4** (shim serialize round-trip on the exact failing content; raw text never reaches the JSON). Main-process `tsc` clean.
- **HARD-GATE live smoke (the real shim→handler boundary the unit tests bypass):** spawned the **real shim** on the exact repro URL `techpolicy.press/ai-is-not-social-media...` → real fetch (1,909 words) → base64 → **`JSON.parse` cleanly through Node** (the op that failed pre-fix) → decoded SourceMarkdown byte-faithful, contains the repro quote *"Who is talking to your child"*. exit 0. This is the real-path proof the incident was missing.

## For your review
Draft, held for your review (design gate). One note: the live smoke exercises the full shim→handler boundary on the real repro content through Node's parser (the entire defect surface). The downstream Electron-UI generate + AI-voice persistence is orthogonal to this Stage-A fix — say the word if you also want a full in-app generate run and I'll do it. Fixes t/2928. Blocks: t/2897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)