### PR TITLE
feat(search): inline clear (✕) button + fix sticky embeddingError (t/2929, t/2931)

### DIFF
--- a/taxonomy-editor/src/renderer/components/edge-browser/SearchPanel.clearButton.test.tsx
+++ b/taxonomy-editor/src/renderer/components/edge-browser/SearchPanel.clearButton.test.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Coverage for the Search-panel inline clear (✕) button (t/2929). Tests the presentational
+// TaxonomyInputArea directly — the clear must route through setFindQuery (the same setter that
+// drives wildcard + POV/BDI + results), so clearing == deleting the text (the no-regression AC).
+
+import { describe, it, expect, vi } from 'vitest';
+import { createRef } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TaxonomyInputArea } from './SearchPanel';
+
+// styles.css is not loaded in jsdom; the co-located SearchPanel.css import is a no-op here.
+type Props = Parameters<typeof TaxonomyInputArea>[0];
+
+function makeProps(overrides: Partial<Props> = {}): Props {
+  return {
+    inputRef: createRef<HTMLInputElement>(),
+    findQuery: '',
+    setFindQuery: vi.fn(),
+    isSemantic: false,
+    runSemanticSearch: vi.fn().mockResolvedValue(undefined),
+    findMode: 'wildcard',
+    setFindMode: vi.fn(),
+    isOnline: true,
+    povFilter: 'all',
+    setPovFilter: vi.fn(),
+    bdiFilter: 'all',
+    setBdiFilter: vi.fn(),
+    mode: 'taxonomy',
+    ...overrides,
+  } as Props;
+}
+
+describe('SearchPanel clear button (t/2929)', () => {
+  it('hides the ✕ when the field is empty', () => {
+    render(<TaxonomyInputArea {...makeProps({ findQuery: '' })} />);
+    expect(screen.queryByLabelText('Clear search')).toBeNull();
+  });
+
+  it('shows the ✕ when the field has one or more characters', () => {
+    render(<TaxonomyInputArea {...makeProps({ findQuery: 'excludes*harmf' })} />);
+    expect(screen.getByLabelText('Clear search')).toBeDefined();
+  });
+
+  it('clicking ✕ clears via setFindQuery (the same setter that drives results)', () => {
+    const setFindQuery = vi.fn();
+    render(<TaxonomyInputArea {...makeProps({ findQuery: 'governance', setFindQuery })} />);
+    fireEvent.click(screen.getByLabelText('Clear search'));
+    expect(setFindQuery).toHaveBeenCalledWith('');
+  });
+
+  it('keeps focus on the input after clearing (caret/keyboard stay active)', () => {
+    const inputRef = createRef<HTMLInputElement>();
+    render(<TaxonomyInputArea {...makeProps({ findQuery: 'governance', inputRef })} />);
+    fireEvent.click(screen.getByLabelText('Clear search'));
+    expect(document.activeElement).toBe(inputRef.current);
+  });
+
+  it('preventDefault on mousedown so the click does not blur the input first', () => {
+    render(<TaxonomyInputArea {...makeProps({ findQuery: 'x' })} />);
+    const btn = screen.getByLabelText('Clear search');
+    const ev = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    btn.dispatchEvent(ev);
+    expect(ev.defaultPrevented).toBe(true);
+  });
+});

--- a/taxonomy-editor/src/renderer/components/edge-browser/SearchPanel.css
+++ b/taxonomy-editor/src/renderer/components/edge-browser/SearchPanel.css
@@ -1,0 +1,55 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/* Inline clear (✕) affordance for the taxonomy Search-panel input (t/2929).
+   styles.css is frozen, so this co-located sheet holds the new selectors. The wrapper
+   takes over the input's former `flex: 1` role inside .search-panel-input-row so layout
+   is unchanged; the ✕ is absolutely positioned inside the input's right edge. Colors are
+   design tokens only → legible + theme-aware across light / dark / BKC / Harvard. */
+
+.search-panel-input-clearable {
+  position: relative;
+  flex: 1;            /* the input was the flex:1 child; the wrapper now fills that role */
+  display: flex;
+  min-width: 0;       /* allow the input to shrink within the row instead of overflowing */
+}
+
+.search-panel-input-clearable .search-panel-text-input {
+  flex: 1;
+  width: 100%;
+}
+
+/* Only reserve right-padding when the ✕ is shown, so placeholder/empty state is unchanged. */
+.search-panel-input-clearable.has-value .search-panel-text-input {
+  padding-right: 26px;
+}
+
+.search-panel-clear-btn {
+  position: absolute;
+  right: 3px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.search-panel-clear-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.search-panel-clear-btn:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}

--- a/taxonomy-editor/src/renderer/components/edge-browser/SearchPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/edge-browser/SearchPanel.tsx
@@ -10,6 +10,7 @@ import { interpretationText } from '../../types/taxonomy';
 import { buildSearchRegex } from '../../utils/searchRegex';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { useOnlineStatus } from '../../hooks/useOnlineStatus';
+import './SearchPanel.css';
 
 type SearchPanelMode =
   | 'taxonomy'
@@ -295,7 +296,8 @@ interface TaxonomyInputAreaProps {
   mode: SearchPanelMode;
 }
 
-function TaxonomyInputArea({
+// Exported for unit test (t/2929 clear-button AC); presentational, no hooks.
+export function TaxonomyInputArea({
   inputRef, findQuery, setFindQuery, isSemantic, runSemanticSearch,
   findMode, setFindMode, isOnline,
   povFilter, setPovFilter, bdiFilter, setBdiFilter, mode,
@@ -303,20 +305,38 @@ function TaxonomyInputArea({
   return (
     <div className="search-panel-taxonomy">
       <div className="search-panel-input-row">
-        <input
-          ref={inputRef}
-          className="search-panel-text-input"
-          type="text"
-          value={findQuery}
-          onChange={(e) => setFindQuery(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && isSemantic) {
-              void runSemanticSearch(findQuery, new Set(), new Set());
-            }
-            // Let arrow keys bubble up to panel handler
-          }}
-          placeholder={isSemantic ? 'Describe what you\'re looking for...' : 'Search taxonomy...'}
-        />
+        <div className={`search-panel-input-clearable${findQuery.length > 0 ? ' has-value' : ''}`}>
+          <input
+            ref={inputRef}
+            className="search-panel-text-input"
+            type="text"
+            value={findQuery}
+            onChange={(e) => setFindQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && isSemantic) {
+                void runSemanticSearch(findQuery, new Set(), new Set());
+              }
+              // Let arrow keys bubble up to panel handler
+            }}
+            placeholder={isSemantic ? 'Describe what you\'re looking for...' : 'Search taxonomy...'}
+          />
+          {findQuery.length > 0 && (
+            // Clear via the same setFindQuery that drives wildcard + POV/BDI + results, so
+            // clearing resets results identically to deleting the text (t/2929, no-regression).
+            // onMouseDown preventDefault keeps the input from blurring before onClick, so the
+            // refocus keeps the caret/mobile keyboard active for immediate re-typing.
+            <button
+              type="button"
+              className="search-panel-clear-btn"
+              aria-label="Clear search"
+              title="Clear search"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => { setFindQuery(''); inputRef.current?.focus(); }}
+            >
+              &#x2715;
+            </button>
+          )}
+        </div>
         <select
           className="search-panel-search-mode"
           value={findMode}

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Coverage for setFindMode clearing the sticky semantic embeddingError (t/2931). The bug:
+// embeddingError was only reset at the START of runSemanticSearch, so it stuck in the
+// wildcard/raw view until reload. Fix clears it when leaving semantic — but NOT when staying
+// in semantic (a new semantic failure must still surface).
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@bridge', () => ({ api: {} }));
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+
+const { createSearchSlice } = await import('./searchSlice');
+
+// Minimal harness: capture the partial passed to set(); get() is unused by setFindMode.
+function makeSlice() {
+  const setCalls: Array<Record<string, unknown>> = [];
+  const set = (partial: unknown) => { setCalls.push(partial as Record<string, unknown>); };
+  const get = () => ({}) as never;
+  // StateCreator signature is (set, get, api) — api unused here.
+  const slice = createSearchSlice(set as never, get, {} as never);
+  return { slice, setCalls };
+}
+
+describe('searchSlice.setFindMode — embeddingError stickiness (t/2931)', () => {
+  it('clears embeddingError when switching to wildcard', () => {
+    const { slice, setCalls } = makeSlice();
+    slice.setFindMode('wildcard');
+    expect(setCalls[0]).toEqual({ findMode: 'wildcard', embeddingError: null });
+  });
+
+  it('clears embeddingError when switching to raw', () => {
+    const { slice, setCalls } = makeSlice();
+    slice.setFindMode('raw');
+    expect(setCalls[0]).toMatchObject({ findMode: 'raw', embeddingError: null });
+  });
+
+  it('does NOT clear embeddingError when staying in semantic (new failures must still show)', () => {
+    const { slice, setCalls } = makeSlice();
+    slice.setFindMode('semantic');
+    expect(setCalls[0]).toEqual({ findMode: 'semantic' });
+    expect('embeddingError' in setCalls[0]).toBe(false);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts
@@ -58,7 +58,10 @@ export const createSearchSlice: StateCreator<TaxonomyStore, [], [], SearchSlice>
   findMode: 'wildcard' as SearchMode,
   findCaseSensitive: false,
   setFindQuery: (query) => set({ findQuery: query }),
-  setFindMode: (mode) => set({ findMode: mode }),
+  // Clear a stale semantic embeddingError when leaving semantic mode, so it doesn't stick
+  // in the wildcard/raw taxonomy view (t/2931). runSemanticSearch resets it at start, so a
+  // NEW semantic failure still surfaces — this only clears on mode-leave, never suppresses.
+  setFindMode: (mode) => set({ findMode: mode, ...(mode !== 'semantic' ? { embeddingError: null } : {}) }),
   setFindCaseSensitive: (cs) => set({ findCaseSensitive: cs }),
 
   embeddingCache: new Map(),


### PR DESCRIPTION
## Summary — two batched search-panel fixes (TL-endorsed batching, t/2931#1)

### t/2929 — inline clear (✕) button in the taxonomy Search-panel input
Conditional ✕ inside the right edge of the Search panel's taxonomy query input (the wildcard `excludes*harmf` field). **Matched the exact input**: the live panel is `SearchPanel.tsx` (via `ToolbarPaneRenderer` for `toolbarPanel==='search'`) — the obvious `SearchBar.tsx`/edge-browser `FindBar.tsx` are NOT mounted. Scoped to the taxonomy input only.
- Visible only when `findQuery.length > 0`; clears via `setFindQuery('')` (same setter driving wildcard + POV/BDI + results → no-regression by construction); `onMouseDown` preventDefault + refocus keeps caret/keyboard.
- Co-located `SearchPanel.css` (styles.css frozen); tokens-only, four-theme legible; layout unchanged.

### t/2931 — clear sticky semantic `embeddingError` on mode-leave
`embeddingError` only reset at `runSemanticSearch` start → red banner stuck in wildcard view until reload. `setFindMode` now clears it when leaving semantic; a NEW semantic failure still reappears (AC arm 3 preserved).

## Verification
- Tests: `SearchPanel.clearButton.test.tsx` (5) + `searchSlice.test.ts` (3) — all pass. Renderer `tsc` clean, ESLint clean, `vite build` green.

**Reviewer: Quality (TL)** — both self-cert UI-only (no new API/data model/cross-role interface). Diffs are logically separable per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)