### PR TITLE
fix(security): allow colon in containerId route param, preserve traversal block (t/2930)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/accessControl.test.ts
+++ b/taxonomy-editor/src/server/__tests__/accessControl.test.ts
@@ -409,6 +409,18 @@ describe('invalidRouteParam (t/810)', () => {
     expect(invalidRouteParam('/api/admin/review/detail/:groupId', '/api/admin/review/detail/%2e%2e%2fx')).toBe('groupId');
   });
 
+  // t/2930: containerId is "type:id" (node:sit-021, sei:abc); the colon is structural so
+  // isSafeId 400'd every one. Both arms — colon passes; traversal still rejected (the proof).
+  it('allows colon in container ids but blocks traversal', () => {
+    expect(invalidRouteParam('/api/container-mentions/:containerId', '/api/container-mentions/node%3Asit-021')).toBeNull();
+    expect(invalidRouteParam('/api/container-mentions/:containerId', '/api/container-mentions/sei%3Aabc')).toBeNull();
+    // negative arm (security): encoded/decoded traversal + separators + null byte must still 400
+    expect(invalidRouteParam('/api/container-mentions/:containerId', '/api/container-mentions/node%3A%2e%2e%2fsecret')).toBe('containerId'); // node:../secret
+    expect(invalidRouteParam('/api/container-mentions/:containerId', '/api/container-mentions/%2e%2e')).toBe('containerId');                 // ..
+    expect(invalidRouteParam('/api/container-mentions/:containerId', '/api/container-mentions/node%3A..%2Fx')).toBe('containerId');          // node:../x
+    expect(invalidRouteParam('/api/container-mentions/:containerId', '/api/container-mentions/node%3Ax%00')).toBe('containerId');            // null byte
+  });
+
   it('rejects invalid pov names', () => {
     expect(invalidRouteParam('/api/taxonomy/:pov', '/api/taxonomy/%2e%2e')).toBe('pov');
     expect(invalidRouteParam('/api/taxonomy/:pov', '/api/taxonomy/ACC')).toBe('pov'); // uppercase not allowed

--- a/taxonomy-editor/src/server/security/accessControl.ts
+++ b/taxonomy-editor/src/server/security/accessControl.ts
@@ -15,6 +15,12 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 // colon, still block path separators / dots / encoded sequences.
 const GROUP_ID_RE = /^[a-zA-Z0-9_:-]+$/;
 
+// Container ids are "type:id" (e.g. "node:sit-021", "sei:abc") — the colon is
+// structural, so isSafeId (which rejects ':') would 400 every one (t/2930). Same
+// anchored + character-classed safe set as GROUP_ID_RE: permits ':' but still
+// rejects '.', '/', '\', null bytes, and thus '..'/%2e%2e traversal.
+const CONTAINER_ID_RE = /^[a-zA-Z0-9_:-]+$/;
+
 /**
  * t/810: routing-layer path-param validation. Given a matched route pattern and
  * the request pathname, return the name of the first user-provided `:param`
@@ -44,7 +50,8 @@ export function invalidRouteParam(routePath: string, pathname: string): string |
       name === 'pov' ? isSafePov(value)
         : (name === 'filename' || name === 'name') ? isSafeFilename(value)
           : name === 'groupId' ? GROUP_ID_RE.test(value)
-            : isSafeId(value);
+            : name === 'containerId' ? CONTAINER_ID_RE.test(value)
+              : isSafeId(value);
     if (!ok) return name;
   }
   return null;


### PR DESCRIPTION
## Summary — SECURITY SURFACE (review → Main TL)
`GET /api/container-mentions/node%3Asit-021` returned **400** for every `node:*`/`sei:*` container id: `invalidRouteParam` fell through to `isSafeId` (`SAFE_ID_RE` rejects the colon that is structurally part of container ids). Breaks container-mentions on every `sit-*` node.

**Fix** — add a `containerId` branch using `CONTAINER_ID_RE = /^[a-zA-Z0-9_:-]+$/` — the **same anchored, character-classed safe set** as the existing `GROUP_ID_RE`: permits `:` but still rejects `.`, `/`, `\`, null bytes, and thus `..`/`%2e%2e` traversal. One added ternary branch, co-located, mirroring the `groupId` shape. **Not a broad allow.**

## Both-arms regression test (the security proof — AC-mandated)
`accessControl.test.ts` — new `containerId` case:
- **Positive:** `node%3Asit-021`, `sei%3Aabc` → `null` (pass).
- **Negative (security):** `node%3A%2e%2e%2fsecret` (node:../secret), `%2e%2e`, `node%3A..%2Fx`, `node%3Ax%00` (null byte) → all return `'containerId'` (400).

## Verification
- `accessControl.test.ts` 60/60 pass (incl. the 6 new assertions). Server `tsc` clean, ESLint clean.

**Draft — held for your security review** (per docs/review-routing.md, accessControl.ts path-param validation is a Main-TL gate, not self-cert). Fixes t/2930.

🤖 Generated with [Claude Code](https://claude.com/claude-code)