### PR TITLE
chore(licenses): sync notices to Linux CI output — sharp linux-x64 + libvips-linux-x64 (t/2920)

### DIFF
--- a/taxonomy-editor/THIRD-PARTY-NOTICES.txt
+++ b/taxonomy-editor/THIRD-PARTY-NOTICES.txt
@@ -809,9 +809,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 -----------
 
+The following npm package may be included in this product:
+
+ - @img/sharp-libvips-linux-x64@1.3.2
+
+This package contains the following license:
+
+LGPL-3.0-or-later
+
+-----------
+
 The following npm packages may be included in this product:
 
- - @img/sharp-win32-x64@0.35.3
+ - @img/sharp-linux-x64@0.35.3
  - sharp@0.35.3
 
 These packages each contain the following license:

--- a/taxonomy-editor/src/renderer/data/oss-licenses.json
+++ b/taxonomy-editor/src/renderer/data/oss-licenses.json
@@ -136,7 +136,12 @@
       "license": "MIT"
     },
     {
-      "name": "@img/sharp-win32-x64",
+      "name": "@img/sharp-libvips-linux-x64",
+      "version": "1.3.2",
+      "license": "LGPL-3.0-or-later"
+    },
+    {
+      "name": "@img/sharp-linux-x64",
       "version": "0.35.3",
       "license": "Apache-2.0"
     },
@@ -1686,7 +1691,17 @@
     {
       "packages": [
         {
-          "name": "@img/sharp-win32-x64",
+          "name": "@img/sharp-libvips-linux-x64",
+          "version": "1.3.2"
+        }
+      ],
+      "licenseType": "LGPL-3.0-or-later",
+      "licenseText": "LGPL-3.0-or-later"
+    },
+    {
+      "packages": [
+        {
+          "name": "@img/sharp-linux-x64",
           "version": "0.35.3"
         },
         {


### PR DESCRIPTION
## Summary

- Applies diff from CI run 32572104990: `@img/sharp-win32-x64` → `@img/sharp-linux-x64` + new `@img/sharp-libvips-linux-x64@1.3.2` (LGPL-3.0-or-later) entry
- Eliminates the license-notices staleness warning (t/2918) that fires on every taxonomy-editor PR
- Files: `taxonomy-editor/THIRD-PARTY-NOTICES.txt`, `taxonomy-editor/src/renderer/data/oss-licenses.json`

## Platform-drift note (t/2920 blocker 2)

`sharp` installs platform-specific optional deps: `win32-x64` on Windows, `linux-x64` + `libvips-linux-x64` on Linux. CI runs on Linux — **CI output is authoritative** for what ships in the container. Local regen on Windows will always differ; that is expected. Notices track the Linux (CI/container) platform.

## Test plan

- [ ] CI `test-electron (taxonomy-editor)` passes with no `::warning::` on license notices step
- [ ] Observe ≥1 clean green cycle, then ping TL (p/490) for gate-promotion sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)