### PR TITLE
feat(toolbar): remove back (←) button per PI request (t/2932)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useEffect, useRef, Fragment } from 'react';
 import {
-  LayoutGrid, MessageSquare, MessageCircle, ArrowLeft,
+  LayoutGrid, MessageSquare, MessageCircle,
   Ellipsis, CircleHelp, MessageSquareText, Layers,
   RefreshCw, Settings, User, Users, Shield, LogOut, Newspaper,
 } from 'lucide-react';
@@ -193,7 +193,6 @@ export function Toolbar() {
     clearAttributeFilter,
     attributeInfo, showAttributeInfo,
     clearAttributeInfo,
-    previousView, navigateBack,
     loadAll, loading,
   } = useTaxonomyStore();
   const adminFlag = useFlag('permission-admin-features');
@@ -231,20 +230,6 @@ export function Toolbar() {
   const moreHasActive = secondaryGroups.flatMap(g => g.items).some(i => isNavItemActive(i));
   const viewMode = usePreferencesStore(state => state.viewMode);
   const setViewMode = usePreferencesStore(state => state.setViewMode);
-
-  // Escape key navigates back
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && previousView && !showHelp && !showSettings) {
-        const target = e.target as HTMLElement;
-        if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT') return;
-        e.preventDefault();
-        navigateBack();
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [previousView, navigateBack, showHelp, showSettings]);
 
   const clearCurrentPanel = () => {
     if (toolbarPanel === 'search') clearSimilarSearch();
@@ -287,19 +272,6 @@ export function Toolbar() {
   return (
     <nav className="toolbar" aria-label="Primary">
       <div className="toolbar-top">
-        {previousView && toolbarPanel !== null && activeTab !== 'debate' && (
-          <>
-            <button
-              className="toolbar-icon toolbar-back"
-              onClick={navigateBack}
-              aria-label="Back"
-              data-tooltip="Back"
-            >
-              <ArrowLeft size="1.25em" />
-            </button>
-            <div className="toolbar-separator" />
-          </>
-        )}
         {/* Primary nav — icon-over-label stacks */}
         {/* t/2813: Search removed from the nav rail; entry points now live in the
             Taxonomy panel header + POV detail header. toggle('search') still works. */}


### PR DESCRIPTION
## Summary
Removes the toolbar back-arrow button (PI pink-annotation request, `t5.png`, Toolbar.tsx:290-298), plus its **keyboard twin** — the Escape→`navigateBack` handler (235-247). The two are one back affordance; leaving a hidden Escape-back after removing the visible button is inconsistent, and the handler served no other feature.

## Dead-code hygiene (TL-required caller check)
Grepped `navigateBack` / `previousView` before deleting: both are **live store state used elsewhere** (searchSlice attribute-filter capture, NodeDetail search entry, taxonomyDataSlice `setToolbarPanel`, and store tests) → **kept in the store** (AC allows). Removed only the now-unused Toolbar-local refs: the `ArrowLeft` import + the `previousView, navigateBack` destructure.

## Verification
- `Toolbar.test.tsx` 9/9 (no back-button assertion), renderer `tsc` clean, ESLint clean (no orphaned refs). Layout: removed button + its separator; the flex row reflows (no empty slot).

## ⚠ Deviation flag
Ticket said "remove the button"; I **also removed the Escape-back handler** — deliberate, as the button's keyboard twin (TL raised it as a removal candidate in t/2932#1, "if no other feature uses it" — it doesn't). Store state untouched. Flagging since it's a small behavior change beyond the literal ask.

**Reviewer: Quality (TL)** — self-cert UI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)