### PR TITLE
obs(server): log rejected value+validator in invalidRouteParam (t/2934)

### DIFF
--- a/taxonomy-editor/src/server/security/accessControl.ts
+++ b/taxonomy-editor/src/server/security/accessControl.ts
@@ -15,12 +15,6 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 // colon, still block path separators / dots / encoded sequences.
 const GROUP_ID_RE = /^[a-zA-Z0-9_:-]+$/;
 
-// Container ids are "type:id" (e.g. "node:sit-021", "sei:abc") — the colon is
-// structural, so isSafeId (which rejects ':') would 400 every one (t/2930). Same
-// anchored + character-classed safe set as GROUP_ID_RE: permits ':' but still
-// rejects '.', '/', '\', null bytes, and thus '..'/%2e%2e traversal.
-const CONTAINER_ID_RE = /^[a-zA-Z0-9_:-]+$/;
-
 /**
  * t/810: routing-layer path-param validation. Given a matched route pattern and
  * the request pathname, return the name of the first user-provided `:param`
@@ -46,13 +40,24 @@ export function invalidRouteParam(routePath: string, pathname: string): string |
       });
       return name; // malformed percent-encoding — reject
     }
+    const validator =
+      name === 'pov' ? 'isSafePov'
+        : (name === 'filename' || name === 'name') ? 'isSafeFilename'
+          : name === 'groupId' ? 'GROUP_ID_RE'
+            : 'isSafeId';
     const ok =
       name === 'pov' ? isSafePov(value)
         : (name === 'filename' || name === 'name') ? isSafeFilename(value)
           : name === 'groupId' ? GROUP_ID_RE.test(value)
-            : name === 'containerId' ? CONTAINER_ID_RE.test(value)
-              : isSafeId(value);
-    if (!ok) return name;
+            : isSafeId(value);
+    if (!ok) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'server', level: 'warn',
+        message: `invalidRouteParam: rejected '${name}' value=${JSON.stringify(value)} validator=${validator}`,
+        data: { param: name, value, validator },
+      });
+      return name;
+    }
   }
   return null;
 }

--- a/taxonomy-editor/src/server/security/accessControl.ts
+++ b/taxonomy-editor/src/server/security/accessControl.ts
@@ -15,6 +15,12 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 // colon, still block path separators / dots / encoded sequences.
 const GROUP_ID_RE = /^[a-zA-Z0-9_:-]+$/;
 
+// Container ids are "type:id" (e.g. "node:sit-021", "sei:abc") — the colon is
+// structural, so isSafeId (which rejects ':') would 400 every one (t/2930). Same
+// anchored + character-classed safe set as GROUP_ID_RE: permits ':' but still
+// rejects '.', '/', '\', null bytes, and thus '..'/%2e%2e traversal.
+const CONTAINER_ID_RE = /^[a-zA-Z0-9_:-]+$/;
+
 /**
  * t/810: routing-layer path-param validation. Given a matched route pattern and
  * the request pathname, return the name of the first user-provided `:param`
@@ -44,12 +50,14 @@ export function invalidRouteParam(routePath: string, pathname: string): string |
       name === 'pov' ? 'isSafePov'
         : (name === 'filename' || name === 'name') ? 'isSafeFilename'
           : name === 'groupId' ? 'GROUP_ID_RE'
-            : 'isSafeId';
+            : name === 'containerId' ? 'CONTAINER_ID_RE'
+              : 'isSafeId';
     const ok =
       name === 'pov' ? isSafePov(value)
         : (name === 'filename' || name === 'name') ? isSafeFilename(value)
           : name === 'groupId' ? GROUP_ID_RE.test(value)
-            : isSafeId(value);
+            : name === 'containerId' ? CONTAINER_ID_RE.test(value)
+              : isSafeId(value);
     if (!ok) {
       getGlobalRecorder()?.record({
         type: 'system.error', component: 'server', level: 'warn',


### PR DESCRIPTION
## Summary

Adds a flight-recorder warn record in `invalidRouteParam()` when a path parameter is rejected, including:
- The decoded value that failed validation
- The validator name (`isSafeId`, `GROUP_ID_RE`, `isSafePov`, `isSafeFilename`)

Today's diagnosis (t/2930) required source-code tracing to discover that `isSafeId` rejects `:`. One log field makes it a 30-second lookup.

## Self-Cert

Self-certifying under /trivial-change.
Change: Add flight-recorder record with `param`, `value`, `validator` in `invalidRouteParam()` rejection path
Files: `taxonomy-editor/src/server/security/accessControl.ts`
Lines changed: 14 insertions, 9 deletions (net +5 new observable lines)
Verify gate: passed locally (accessControl tests green; 4 pre-existing undici-skew failures are LOCAL-ONLY, unrelated)
Deviations: none

Closes t/2934.