### PR TITLE
feat(security): observability — name the rejecting validator in invalidRouteParam

### DIFF
--- a/taxonomy-editor/src/server/security/accessControl.ts
+++ b/taxonomy-editor/src/server/security/accessControl.ts
@@ -46,13 +46,26 @@ export function invalidRouteParam(routePath: string, pathname: string): string |
       });
       return name; // malformed percent-encoding — reject
     }
+    const validator =
+      name === 'pov' ? 'isSafePov'
+        : (name === 'filename' || name === 'name') ? 'isSafeFilename'
+          : name === 'groupId' ? 'GROUP_ID_RE'
+            : name === 'containerId' ? 'CONTAINER_ID_RE'
+              : 'isSafeId';
     const ok =
       name === 'pov' ? isSafePov(value)
         : (name === 'filename' || name === 'name') ? isSafeFilename(value)
           : name === 'groupId' ? GROUP_ID_RE.test(value)
             : name === 'containerId' ? CONTAINER_ID_RE.test(value)
               : isSafeId(value);
-    if (!ok) return name;
+    if (!ok) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'server', level: 'warn',
+        message: `invalidRouteParam: rejected '${name}' value=${JSON.stringify(value)} validator=${validator}`,
+        data: { param: name, value, validator },
+      });
+      return name;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary — SECURITY SURFACE (review → Main TL)
Observability enhancement to `invalidRouteParam` (accessControl.ts): on a rejected path param, record a `system.warning` naming **which** validator rejected (`isSafePov` / `isSafeFilename` / `GROUP_ID_RE` / `CONTAINER_ID_RE` / `isSafeId`) + the param/value — so a 400 on a path param is diagnosable instead of opaque.

**Provenance:** this was staged WIP stranded on the shared main tree (base predated t/2930). Preserved to this worktree branch (commit 4387668e) to unblock the DevOps ff-pull, then **rebased onto post-t/2930 main and reconciled** the `invalidRouteParam` collision with the landed `CONTAINER_ID_RE`.

**Reconciliation (per TL guidance):** folded `containerId` into **both**
- the `ok` dispatch — `name === 'containerId' ? CONTAINER_ID_RE.test(value)` (from t/2930), and
- the new validator-**name** map — `name === 'containerId' ? 'CONTAINER_ID_RE'` — so the observability log names the right validator.

No change to the reject/pass logic — purely adds the warn on the existing reject path.

## Verification
- `accessControl.test.ts` **60/60** — including t/2930's containerId **both-arms** (colon passes; `node:../secret`, `%2e%2e`, `node:../x`, null-byte still 400). The traversal negative arm holds under the refactor.
- Server `tsc` clean, ESLint clean.

**Draft — held for your security review.** The traversal negative arm is the invariant to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)