### PR TITLE
fix(detail): wrap detail panel title instead of truncating (t/2937)

### DIFF
--- a/taxonomy-editor/src/renderer/components/shared/DetailPane.css
+++ b/taxonomy-editor/src/renderer/components/shared/DetailPane.css
@@ -15,7 +15,7 @@
 
 .detail-pane-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   padding: 10px 12px;
   border-bottom: 1px solid var(--border-color);
@@ -27,9 +27,6 @@
   font-weight: 600;
   font-size: 0.9rem;
   color: var(--text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .detail-pane-close {


### PR DESCRIPTION
## Summary

- Remove `white-space: nowrap` + `text-overflow: ellipsis` + `overflow: hidden` from `.detail-pane-title` so long taxonomy node labels wrap to multiple lines instead of clipping with "…"
- Switch `.detail-pane-header` to `align-items: flex-start` so the close (✕) button aligns to the top when the title wraps

## Why

`titleFor()` returns `d.record.label` for taxonomy nodes — so the pane header was showing the full node label in a single-line ellipsis container. Long titles like "Human and Planetary Flourishing as the Governing Metric…" were clipped. Sidebar already wraps; now the detail header matches.

## Self-cert

/trivial-change — 1 file, 1+4 CSS lines, no API/interface/data model changes. `npm run verify` ✓, `tsc --noEmit` ✓.

Closes t/2937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)