### PR TITLE
obs(search): emit FR event on findMode change (t/2935)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts
@@ -61,7 +61,10 @@ export const createSearchSlice: StateCreator<TaxonomyStore, [], [], SearchSlice>
   // Clear a stale semantic embeddingError when leaving semantic mode, so it doesn't stick
   // in the wildcard/raw taxonomy view (t/2931). runSemanticSearch resets it at start, so a
   // NEW semantic failure still surfaces — this only clears on mode-leave, never suppresses.
-  setFindMode: (mode) => set({ findMode: mode, ...(mode !== 'semantic' ? { embeddingError: null } : {}) }),
+  setFindMode: (mode) => {
+    getGlobalRecorder()?.record({ type: 'ui.select', component: 'search-panel', level: 'debug', message: 'search.mode', data: { mode } });
+    set({ findMode: mode, ...(mode !== 'semantic' ? { embeddingError: null } : {}) });
+  },
   setFindCaseSensitive: (cs) => set({ findCaseSensitive: cs }),
 
   embeddingCache: new Map(),


### PR DESCRIPTION
## Summary

Adds a `debug`-level flight-recorder record in `setFindMode` so that search mode switches (raw/wildcard/regex/semantic) are traceable in dump analysis. The t/2931 `embeddingError` clear was already present — this only adds the observability event alongside it.

## Self-Cert

Self-certifying under /trivial-change.
Change: wrap `set()` in `setFindMode` with a `getGlobalRecorder()?.record(...)` call
Files: `taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts`
Lines changed: 4 insertions, 1 deletion
Verify gate: passed (pre-existing undici-skew failures are LOCAL-ONLY, unrelated)
Deviations: none

Closes t/2935.