### PR TITLE
feat(search): telemetry — record search.mode changes in setFindMode (observability)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/searchSlice.ts
@@ -61,7 +61,10 @@ export const createSearchSlice: StateCreator<TaxonomyStore, [], [], SearchSlice>
   // Clear a stale semantic embeddingError when leaving semantic mode, so it doesn't stick
   // in the wildcard/raw taxonomy view (t/2931). runSemanticSearch resets it at start, so a
   // NEW semantic failure still surfaces — this only clears on mode-leave, never suppresses.
-  setFindMode: (mode) => set({ findMode: mode, ...(mode !== 'semantic' ? { embeddingError: null } : {}) }),
+  setFindMode: (mode) => {
+    getGlobalRecorder()?.record({ type: 'ui.select', component: 'search-panel', level: 'debug', message: 'search.mode', data: { mode } });
+    set({ findMode: mode, ...(mode !== 'semantic' ? { embeddingError: null } : {}) });
+  },
   setFindCaseSensitive: (cs) => set({ findCaseSensitive: cs }),
 
   embeddingCache: new Map(),


### PR DESCRIPTION
## Summary
Small observability add: `setFindMode` now emits a flight-recorder `ui.select` event naming the new search mode before applying state, so search mode-switches are observable in the flight recorder. No behavioral change to the state update (the t/2931 embeddingError-clear logic is untouched).

**Provenance:** rescued from unstaged WIP stranded on the shared main tree (built on the landed t/2931 fix). Preserved to this worktree branch (`c05c7d54`), then rebased clean onto origin/main (no conflict).

## Verification
- `searchSlice.test.ts` **3/3** — the t/2931 setFindMode tests still pass with the telemetry wrap (state update unchanged).
- Renderer `tsc` clean (`ui.select` is a valid EventType), ESLint 0 errors.

Self-cert **/trivial-change** (single-file, no new API/schema, additive telemetry). Reviewer: **Quality (TL)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)