### PR TITLE
fix(embeddings): chunk-and-yield large computeEmbeddings batches (t/2914 item 2)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsChunkYield.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsChunkYield.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Coverage for the chunk-and-yield in computeEmbeddings (t/2914 item 2). A single large
+// in-process batch froze the event loop ~46.8s in prod (2389 texts → 500); the concurrency
+// cap can't catch a single request. resolveEmbeddingsChunked splits the batch and yields
+// (setImmediate) between chunks. These assert: chunking happens above the size, results are
+// order-preserving + identical to a single resolve, and the loop actually yields between chunks.
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => undefined }));
+
+const { resolveEmbeddingsChunked } = await import('../ai/aiBackends');
+
+// Fake chain: records the size of each chunk it was called with; returns a deterministic
+// 1-dim vector per text (= its length) so we can assert order/identity. local=null + no ids
+// routes every text to the chain (resolveEmbeddings treats all as missing).
+function makeChain(callSizes: number[]) {
+  return [{
+    name: 'fake',
+    compute: async (texts: string[]) => { callSizes.push(texts.length); return texts.map((t) => [t.length]); },
+  }];
+}
+
+describe('resolveEmbeddingsChunked (t/2914 item 2)', () => {
+  it('does NOT chunk when the batch is within the chunk size (single resolve)', async () => {
+    const sizes: number[] = [];
+    const texts = ['aa', 'bbb'];
+    const out = await resolveEmbeddingsChunked(texts, undefined, null, makeChain(sizes), 5);
+    expect(sizes).toEqual([2]);            // one chain call, whole batch
+    expect(out).toEqual([[2], [3]]);
+  });
+
+  it('splits a large batch into chunks and preserves order/identity', async () => {
+    const sizes: number[] = [];
+    const texts = ['a', 'bb', 'ccc', 'dddd', 'eeeee']; // lengths 1..5
+    const out = await resolveEmbeddingsChunked(texts, undefined, null, makeChain(sizes), 2);
+    expect(sizes).toEqual([2, 2, 1]);      // chunked 2+2+1
+    expect(out).toEqual([[1], [2], [3], [4], [5]]); // concatenated in original order
+  });
+
+  it('yields the event loop between chunks (setImmediate runs between compute calls)', async () => {
+    // A macrotask scheduled after the first chunk resolves must run BEFORE the final chunk if
+    // the loop is being yielded. We tick a flag via setImmediate and assert the chain saw a gap.
+    const order: string[] = [];
+    const chain = [{
+      name: 'fake',
+      compute: async (texts: string[]) => { order.push(`compute:${texts.length}`); return texts.map(() => [0]); },
+    }];
+    // schedule a marker on the macrotask queue; with yielding it interleaves between chunks.
+    const texts = ['x', 'y', 'z', 'w'];
+    const p = resolveEmbeddingsChunked(texts, undefined, null, chain, 2);
+    setImmediate(() => order.push('macrotask'));
+    await p;
+    // The macrotask must have run before the loop finished all chunks — i.e. it's not starved.
+    expect(order).toContain('macrotask');
+    expect(order.filter((o) => o.startsWith('compute')).length).toBe(2); // 2 chunks
+  });
+
+  it('returns exactly one vector per input across chunk boundaries', async () => {
+    const texts = Array.from({ length: 7 }, (_, i) => 'n'.repeat(i + 1));
+    const out = await resolveEmbeddingsChunked(texts, undefined, null, makeChain([]), 3);
+    expect(out).toHaveLength(7);
+    expect(out.map((v) => v[0])).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -594,6 +594,37 @@ function loadEmbeddingsFile(): EmbeddingsFile | null {
 
 const EMBEDDINGS_REQUEST_TIMEOUT_MS = 45_000;
 
+// Chunk-and-yield ceiling for a single computeEmbeddings call (t/2914 item 2). One large
+// in-process ONNX batch blocks the event loop for the whole compute — a real prod 2389-text
+// batch froze it ~46.8s → 500, past ACA's liveness deadline, and the t/2905 concurrency cap
+// can't catch a *single* request. Splitting the batch and yielding (setImmediate) between
+// chunks keeps the loop responsive to health checks + other work during a big compute.
+// TUNE from the first post-deploy large-compute trace (t/2904 loop-delay/heap observability);
+// 256 is the pre-calibration default.
+const EMBEDDING_COMPUTE_CHUNK = 256;
+
+// Resolve a (possibly large) batch in chunks, yielding the event loop between chunks. Safe
+// because resolveEmbeddings is order-preserving and per-text pure (local cache-hit or chain
+// compute), so concatenating per-chunk results is identical to resolving the whole batch at
+// once. Exported for unit test. `chunkSize` is injectable so a test can force chunking small.
+export async function resolveEmbeddingsChunked(
+  texts: string[],
+  ids: string[] | undefined,
+  local: EmbeddingsFile | null,
+  chain: EmbeddingFallback[],
+  chunkSize: number = EMBEDDING_COMPUTE_CHUNK,
+): Promise<number[][]> {
+  if (texts.length <= chunkSize) return resolveEmbeddings(texts, ids, local, chain);
+  const out: number[][] = [];
+  for (let i = 0; i < texts.length; i += chunkSize) {
+    const vecs = await resolveEmbeddings(texts.slice(i, i + chunkSize), ids?.slice(i, i + chunkSize), local, chain);
+    for (const v of vecs) out.push(v);
+    // Yield the loop between chunks so a big compute can't monopolize it past the liveness deadline.
+    if (i + chunkSize < texts.length) await new Promise<void>((r) => setImmediate(r));
+  }
+  return out;
+}
+
 // t/1641/t/1643: `_explicitApiKey` is retained for call-site arity (server.ts passes
 // the free-tier key) but is no longer consumed — embeddings are computed by the local
 // Python encoder or the in-process ONNX fallback, both 384-dim/all-MiniLM-L6-v2, no API.
@@ -627,7 +658,7 @@ export async function computeEmbeddings(texts: string[], ids?: string[], _explic
 
   try {
     const result = await withTimeout(
-      resolveEmbeddings(texts, ids, local, chain),
+      resolveEmbeddingsChunked(texts, ids, local, chain),
       EMBEDDINGS_REQUEST_TIMEOUT_MS,
       'embeddings-compute',
     );


### PR DESCRIPTION
## Summary — t/2914 item 2 (prod-evidenced, decoupled from item 1 per TL t/2914#4)
A single large in-process ONNX embedding batch blocks the Node event loop for the whole compute — a real prod **2389-text batch froze it ~46.8s → 500** (t/2905#9–12), past ACA's liveness deadline. The t/2905 concurrency cap can't catch this (it was ONE request, not N-concurrent), so the single-large-batch path stays unmitigated even post-deploy. **This is the direct fix.**

- `computeEmbeddings` now resolves via **`resolveEmbeddingsChunked`**: splits the batch into `EMBEDDING_COMPUTE_CHUNK` slices, resolves each, and `await setImmediate()` **yields the loop between chunks** so health checks + other requests stay responsive during a big compute.
- **Safe / no behavior change:** `resolveEmbeddings` (lib/embeddings — untouched, Shared Lib scope) is order-preserving + per-text pure (local cache-hit or chain compute), so concatenating per-chunk results == one resolve. Batches ≤ chunk size take the single-resolve path (zero overhead).
- **Server-side split, NO client change** — deliberately *not* a max-batch 503-shed, which would just make the t/2922 client retry the same oversized batch (re-shed loop) per your t/2914#4.

## Calibration (your call, post-deploy)
Chunk constant = **256** (pre-calibration default). Per t/2914#4, **tune from the first post-deploy large-compute trace** via t/2904 loop-delay/heap observability (the 2389 incident's server evidence was lost to scale-to-zero). Constant is a one-line change.

## Verification
- `embeddingsChunkYield.test.ts` **4/4** — chunk boundaries, order/identity preservation, no-chunk under size, and the loop yields (setImmediate interleaves) between chunks. Server `tsc` + ESLint clean.

Decoupled from item 1 (loop-delay signal → Quality); item 3 (worker-offload) stays last. Reviewer: **Main TL** (incident coordinator; calibration ties to your observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)