### PR TITLE
style(css): dedup .ndd-style-desc / .ndd-hint-error to co-located file (t/2939)

### DIFF
--- a/quality-gates.json
+++ b/quality-gates.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Non-LOC quality gates only (ADR-007 Gate Co-Location). ESLint `max-lines`, co-located in the eslint configs (lib/eslint.config.mjs, taxonomy-editor/eslint.config.mjs), is the SINGLE source of truth for .ts/.tsx LOC — do NOT re-add .ts ceilings here. styles.css stays: CSS is not covered by the TS eslint configs. See docs/design/adr/007-file-size-budget.md.",
   "loc_ceilings": {
-    "taxonomy-editor/src/renderer/styles.css": 16635
+    "taxonomy-editor/src/renderer/styles.css": 16626
   },
   "max_file_bytes": 5242880,
   "tsc_error_ceilings": {

--- a/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.css
+++ b/taxonomy-editor/src/renderer/components/debate/NewDebateDialog.css
@@ -942,6 +942,8 @@
 .ndd-style-desc {
   color: var(--text-secondary);
   font-size: var(--text-xs);
+  margin-top: 2px;
+  line-height: 1.3;
 }
 
 /* Rounds per phase grid */

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -9720,12 +9720,7 @@ a.vocab-term,
 /* ── Pacing ── */
 
 /* ── Dialectical Style ── */
-.ndd-style-desc {
-  font-size: var(--text-2xs);
-  color: var(--text-muted);
-  margin-top: 2px;
-  line-height: 1.3;
-}
+/* .ndd-style-desc moved to components/debate/NewDebateDialog.css (t/2939 dedup) */
 
 /* ── Adaptive staging toggle ── */
 
@@ -9736,11 +9731,7 @@ a.vocab-term,
 /* ── Audience ── */
 
 /* ── Debaters ── */
-.ndd-hint-error {
-  font-size: var(--text-xs);
-  color: var(--danger);
-  margin-top: 8px;
-}
+/* .ndd-hint-error moved to components/debate/NewDebateDialog.css (t/2939 dedup) */
 
 /* ── Footer ── */
 


### PR DESCRIPTION
Closes t/2939. Follow-up from the t/2925 Phase-3 pattern-setter, which deliberately left two duplicate `ndd-*` selectors in `styles.css` (moving them then would have flipped the cascade).

## What
Both `.ndd-style-desc` and `.ndd-hint-error` were defined **twice with different declarations** — in the `styles.css` monolith and in the co-located `NewDebateDialog.css`. This dedups to the co-located file.

## Which definition currently renders — verified, not assumed
`styles.css` is imported at the renderer entry (`index.tsx:13`); `NewDebateDialog.css` is imported deep in the component tree (`NewDebateDialog.tsx:14`). Vite emits CSS in import-graph order, so the co-located rule lands **after** the monolith in the bundle and **wins every overlapping property**. (Ground-truthed from the import graph rather than a dev-mode `getComputedStyle` probe, which is subject to lazy per-module CSS injection.)

## Render-preserving by construction
- **`.ndd-hint-error`** — every property (`font-size`/`color`/`margin-top`) is also set co-located → the styles.css copy was fully inert → **deleted**, zero effect.
- **`.ndd-style-desc`** — `font-size`/`color` are overridden by the co-located copy, but **`margin-top:2px` and `line-height:1.3` exist ONLY in styles.css** (additive, never overridden). These are **migrated verbatim** into the co-located rule before deleting the styles.css copy, so the computed style is byte-identical across all four themes (referenced theme vars unchanged; the two migrated props are literal constants).

## Gate
- styles.css **16635 → 16626** (−9); `quality-gates.json` ceiling ratcheted to match (monotonic-down, per `css-source-split-playbook`). Passes at zero margin.
- `contrast-check` reads styles.css live — only color declarations were *removed*, so findings can only drop; stays ≤ ceiling.
- Both classes still referenced in `NewDebateDialog.tsx` (`:621`, `:693`).

## Visual check
Provably identical by the construction above. A manual 4-theme confirmation is available on request but is confirmatory only — no rendered declaration changed.