### PR TITLE
fix(cl): correct edge-rationale root cause + quality harness + rationale_source spec (t/2444)

### DIFF
--- a/research/comp-linguist/analyses/edge-rationale-quality/README.md
+++ b/research/comp-linguist/analyses/edge-rationale-quality/README.md
@@ -2,10 +2,17 @@
 
 **Tranche:** follow-up to t/2444 (edge-rationale coverage plan) · **Author:** Computational Linguist
 
-An **automated, no-hand-grading** quality screen for the AI-generated `rationale`
-field that `Invoke-EdgeRationaleBackfill` writes onto taxonomy edges. It answers one
-question before a 25–33k-edge backfill spend commits: *is the output good enough, or
-is it spraying label-restatements?*
+An **automated, no-hand-grading** quality screen for the `rationale` field on taxonomy
+edges. It answers one question about a batch of rationale text: *is it good, or is it
+empty / off-type / label-restatement junk?*
+
+> **Context (t/2444 correction, 2026-08-23):** the ~33k missing rationales were **not**
+> "never generated" — the workflow-app pipeline **wiped** original discovery-time
+> rationales twice; they are git-restorable intact from `ba3128f5`. The remediation is a
+> **git-restore + pipeline fix + regression gate**, not an LLM backfill. This harness is
+> therefore primarily a **restore-verifier** (confirm the restored text is the good
+> original, not corrupted/empty) and a general screen for any future rationale — it is
+> *not* gating a 33k-edge backfill spend (that path is superseded).
 
 ## Two layers
 
@@ -49,10 +56,13 @@ The judge verdict is a **junk screen** (catches empty / off-type / label-restate
 do not promote these thresholds to `derived` without an evidence pointer (a labeled
 sample the thresholds were tuned against).
 
-## Intended use in the tranche sequence
+## Intended use
 
-This is the automated bar the **E′ pilot** measures against: run
-`Invoke-EdgeRationaleBackfill -Limit 150` on one edge type, point this harness at the
-result, and read the flag/verdict distribution. A low flag rate is the evidence PI
-needs to approve (or a high rate the reason to fix the prompt first) — before the full
-backfill spend.
+**Restore-verifier (primary).** After the git-restore lands rationales from `ba3128f5`,
+point this harness at the restored `edges.json`. A low flag rate confirms the restore
+recovered the good original text; a spike in `empty`/`too_short` flags would mean the
+restore missed edges or pulled corrupted rows. This is the cheap automated check that the
+restore did what it claims — before trusting 25k reviewer-facing rationales.
+
+**General screen (secondary).** Run it over any batch of rationale text — new discovery-time
+output, or a residual LLM backfill of the ~6 edges that never had one — to catch obvious junk.

--- a/research/comp-linguist/analyses/edge-rationale-quality/README.md
+++ b/research/comp-linguist/analyses/edge-rationale-quality/README.md
@@ -1,0 +1,58 @@
+# Edge-Rationale Quality Harness (A′)
+
+**Tranche:** follow-up to t/2444 (edge-rationale coverage plan) · **Author:** Computational Linguist
+
+An **automated, no-hand-grading** quality screen for the AI-generated `rationale`
+field that `Invoke-EdgeRationaleBackfill` writes onto taxonomy edges. It answers one
+question before a 25–33k-edge backfill spend commits: *is the output good enough, or
+is it spraying label-restatements?*
+
+## Two layers
+
+1. **Mechanical** (`check_rationale_quality.py`, always run, deterministic, **free**)
+   flags each rationale as: `empty`, `too_short`, `too_long`, `restatement`,
+   `low_novelty`, `both_labels_verbatim`. Pure token heuristics — no model, no cost.
+2. **LLM-judge** (`judge-prompt.txt`, **opt-in**, costs tokens). The script does *not*
+   call a model. `--emit-judge-prompts` renders one scoring prompt per edge to JSONL;
+   score them with any backend; `--judge-results` merges the verdicts back into the
+   report. This keeps *building* the harness free and *running* the judge a separate,
+   explicit decision.
+
+## Usage
+
+```bash
+# mechanical-only report (free)
+python check_rationale_quality.py \
+  --edges  <data>/taxonomy/Origin/edges.json \
+  --taxdir <data>/taxonomy/Origin \
+  --out report.json
+
+# also render judge prompts for a later scoring run
+python check_rationale_quality.py --edges ... --taxdir ... \
+  --emit-judge-prompts judge_prompts.jsonl
+
+# merge scored verdicts back
+python check_rationale_quality.py --edges ... --taxdir ... \
+  --judge-results judge_results.jsonl --out report.json
+```
+
+`test_check_rationale_quality.py` is the two-arm proof: a genuinely good rationale
+draws zero flags, and each defect fires exactly its flag. Run
+`python test_check_rationale_quality.py` (exit 0 = pass; no pytest needed).
+
+## Provenance (load-bearing)
+
+**Every threshold here is `stipulated`** — asserted by design, not derived from a
+labeled study. Registered in `research/comp-linguist/docs/metric-provenance-register.md`.
+The judge verdict is a **junk screen** (catches empty / off-type / label-restatement),
+**not a proof of rationale quality**. Do not read a judge `pass` as ground truth, and
+do not promote these thresholds to `derived` without an evidence pointer (a labeled
+sample the thresholds were tuned against).
+
+## Intended use in the tranche sequence
+
+This is the automated bar the **E′ pilot** measures against: run
+`Invoke-EdgeRationaleBackfill -Limit 150` on one edge type, point this harness at the
+result, and read the flag/verdict distribution. A low flag rate is the evidence PI
+needs to approve (or a high rate the reason to fix the prompt first) — before the full
+backfill spend.

--- a/research/comp-linguist/analyses/edge-rationale-quality/check_rationale_quality.py
+++ b/research/comp-linguist/analyses/edge-rationale-quality/check_rationale_quality.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Edge-rationale quality harness (A' tranche, follows t/2444 remediation plan).
+
+Screens AI-generated edge `rationale` text WITHOUT any hand-grading. Two layers:
+
+  1. MECHANICAL (always run, deterministic, free): flags empty / too-short /
+     too-long / label-restatement / low-novelty rationales. Pure heuristics.
+  2. LLM-JUDGE (opt-in, costs tokens): this script does NOT call a model. With
+     --emit-judge-prompts it renders one scoring prompt per edge to a JSONL that
+     any backend can score; --judge-results merges the scored verdicts back so the
+     report carries both mechanical flags and judge verdicts.
+
+Provenance: every threshold here is STIPULATED (see the metric-provenance-register).
+The judge verdict is a stipulated screen for obvious junk (empty, off-type,
+label-restatement) — NOT a proof of rationale quality. Do not read a judge "pass"
+as ground truth.
+
+Usage:
+  # mechanical-only report (free)
+  python check_rationale_quality.py --edges <taxonomy/Origin/edges.json> \
+      --taxdir <taxonomy/Origin> --out report.json
+
+  # also render judge prompts for a later scoring run
+  python check_rationale_quality.py --edges ... --taxdir ... \
+      --emit-judge-prompts judge_prompts.jsonl
+
+  # merge judge verdicts back into a combined report
+  python check_rationale_quality.py --edges ... --taxdir ... \
+      --judge-results judge_results.jsonl --out report.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+# ── Stipulated thresholds (provisional; see metric-provenance-register) ──────
+MIN_CHARS = 40           # below this, a rationale is too thin to justify anything
+MAX_CHARS = 400          # prompt asks for ~300; 400 is the hard ceiling
+MIN_NOVEL_WORDS = 4      # content words not drawn from the two labels / edge type
+RESTATEMENT_OVERLAP = 0.60  # share of rationale content words taken from the labels
+RESTATEMENT_NOVEL_MAX = 6   # ...combined with few novel words = restatement
+
+_STOP = {
+    "the", "and", "for", "with", "that", "this", "from", "are", "was", "its",
+    "have", "has", "not", "but", "which", "their", "them", "they", "into",
+    "than", "then", "also", "such", "more", "most", "can", "may", "will",
+    "these", "those", "because", "while", "between", "both", "when", "who",
+    "whom", "how", "why", "what", "where", "a", "an", "of", "to", "in", "on",
+    "as", "is", "by", "or", "it", "be", "at", "so",
+}
+
+
+def content_tokens(text: str) -> list[str]:
+    toks = re.findall(r"[a-z0-9]+", (text or "").lower())
+    return [t for t in toks if len(t) >= 3 and t not in _STOP]
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def build_node_text(taxdir: Path) -> dict[str, dict[str, str]]:
+    """id -> {label, desc}, mirroring Invoke-EdgeRationaleBackfill node resolution."""
+    skip = {"edges.json", "embeddings.json", "policy_actions.json"}
+    out: dict[str, dict[str, str]] = {}
+    for f in sorted(taxdir.glob("*.json")):
+        if f.name in skip:
+            continue
+        try:
+            doc = load_json(f)
+        except Exception:
+            continue
+        if not isinstance(doc, dict) or "nodes" not in doc:
+            continue
+        for n in doc.get("nodes") or []:
+            if isinstance(n, dict) and "id" in n:
+                out[n["id"]] = {
+                    "label": str(n.get("label", "")),
+                    "desc": str(n.get("description", "")),
+                }
+    return out
+
+
+def edge_list(edges_doc) -> list[dict]:
+    if isinstance(edges_doc, list):
+        return edges_doc
+    if isinstance(edges_doc, dict):
+        for k in ("edges", "data"):
+            v = edges_doc.get(k)
+            if isinstance(v, list):
+                return v
+            if isinstance(v, dict) and isinstance(v.get("edges"), list):
+                return v["edges"]
+    return []
+
+
+def type_defs(edges_doc) -> dict[str, str]:
+    out: dict[str, str] = {}
+    if isinstance(edges_doc, dict):
+        for t in edges_doc.get("edge_types") or []:
+            if isinstance(t, dict) and "type" in t:
+                out[t["type"]] = str(t.get("definition", ""))
+    return out
+
+
+def mechanical_flags(rationale: str, src_label: str, tgt_label: str,
+                     edge_type: str) -> list[str]:
+    flags: list[str] = []
+    r = (rationale or "").strip()
+    if not r:
+        return ["empty"]
+    if len(r) < MIN_CHARS:
+        flags.append("too_short")
+    if len(r) > MAX_CHARS:
+        flags.append("too_long")
+
+    label_toks = set(content_tokens(src_label)) | set(content_tokens(tgt_label)) \
+        | set(content_tokens(edge_type))
+    r_toks = content_tokens(r)
+    if r_toks:
+        overlap = sum(1 for t in r_toks if t in label_toks) / len(r_toks)
+        novel = [t for t in set(r_toks) if t not in label_toks]
+        if len(novel) < MIN_NOVEL_WORDS:
+            flags.append("low_novelty")
+        if overlap >= RESTATEMENT_OVERLAP and len(novel) <= RESTATEMENT_NOVEL_MAX:
+            flags.append("restatement")
+
+    rl = r.lower()
+    if src_label and src_label.lower() in rl and tgt_label and tgt_label.lower() in rl:
+        flags.append("both_labels_verbatim")
+    return flags
+
+
+def render_judge_prompt(template: str, edge: dict, nodes: dict, tdefs: dict) -> str | None:
+    src = nodes.get(edge.get("source"))
+    tgt = nodes.get(edge.get("target"))
+    if not src or not tgt:
+        return None
+    repl = {
+        "EDGE_TYPE": str(edge.get("type", "")),
+        "EDGE_TYPE_DEF": tdefs.get(edge.get("type", ""), "(see taxonomy edge-type vocabulary)"),
+        "SOURCE_ID": str(edge.get("source", "")),
+        "SOURCE_LABEL": src["label"],
+        "SOURCE_DESC": src["desc"][:400],
+        "TARGET_ID": str(edge.get("target", "")),
+        "TARGET_LABEL": tgt["label"],
+        "TARGET_DESC": tgt["desc"][:400],
+        "RATIONALE": str(edge.get("rationale", "")),
+    }
+    out = template
+    for k, v in repl.items():
+        out = out.replace("{{" + k + "}}", v)
+    return out
+
+
+def edge_key(edge: dict) -> str:
+    return f"{edge.get('source')}->{edge.get('target')} ({edge.get('type')})"
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--edges", required=True, type=Path)
+    ap.add_argument("--taxdir", required=True, type=Path,
+                    help="taxonomy/Origin dir holding node JSON files")
+    ap.add_argument("--out", type=Path, help="write JSON report here")
+    ap.add_argument("--emit-judge-prompts", type=Path,
+                    help="write one rendered judge prompt per rationaled edge (JSONL)")
+    ap.add_argument("--judge-template", type=Path,
+                    default=Path(__file__).with_name("judge-prompt.txt"))
+    ap.add_argument("--judge-results", type=Path,
+                    help="JSONL of {key, grounded, specific_to_type, not_restatement, "
+                         "verdict} to merge into the report")
+    ap.add_argument("--sample", type=int, default=15,
+                    help="how many flagged examples to include in the report")
+    args = ap.parse_args(argv)
+
+    edges_doc = load_json(args.edges)
+    edges = edge_list(edges_doc)
+    nodes = build_node_text(args.taxdir)
+    tdefs = type_defs(edges_doc)
+
+    rationaled = [e for e in edges if isinstance(e, dict)
+                  and str(e.get("rationale", "")).strip()]
+
+    judge_map: dict[str, dict] = {}
+    if args.judge_results and args.judge_results.exists():
+        for line in args.judge_results.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+                if "key" in rec:
+                    judge_map[rec["key"]] = rec
+            except json.JSONDecodeError:
+                continue
+
+    flag_counts: Counter = Counter()
+    examples: list[dict] = []
+    unresolved = 0
+    per_edge: list[dict] = []
+    for e in rationaled:
+        src = nodes.get(e.get("source"), {})
+        tgt = nodes.get(e.get("target"), {})
+        if not src or not tgt:
+            unresolved += 1
+        flags = mechanical_flags(str(e.get("rationale", "")), src.get("label", ""),
+                                 tgt.get("label", ""), str(e.get("type", "")))
+        for f in flags:
+            flag_counts[f] += 1
+        rec = {"key": edge_key(e), "flags": flags,
+               "rationale": str(e.get("rationale", ""))}
+        jv = judge_map.get(edge_key(e))
+        if jv:
+            rec["judge"] = {k: jv.get(k) for k in
+                            ("grounded", "specific_to_type", "not_restatement",
+                             "verdict", "note")}
+        per_edge.append(rec)
+        if flags and len(examples) < args.sample:
+            examples.append(rec)
+
+    clean = sum(1 for r in per_edge if not r["flags"])
+    judged = [r for r in per_edge if "judge" in r]
+    judge_verdicts = Counter(r["judge"].get("verdict") for r in judged)
+
+    report = {
+        "edges_total": len(edges),
+        "edges_with_rationale": len(rationaled),
+        "node_text_unresolved": unresolved,
+        "mechanical": {
+            "clean": clean,
+            "flagged": len(rationaled) - clean,
+            "flag_counts": dict(flag_counts.most_common()),
+            "thresholds": {
+                "MIN_CHARS": MIN_CHARS, "MAX_CHARS": MAX_CHARS,
+                "MIN_NOVEL_WORDS": MIN_NOVEL_WORDS,
+                "RESTATEMENT_OVERLAP": RESTATEMENT_OVERLAP,
+                "RESTATEMENT_NOVEL_MAX": RESTATEMENT_NOVEL_MAX,
+            },
+        },
+        "judge": {
+            "scored": len(judged),
+            "verdicts": dict(judge_verdicts.most_common()),
+        } if judged else None,
+        "examples_flagged": examples,
+        "provenance_note": "All thresholds STIPULATED (provisional). Judge verdict is "
+                           "a junk screen, not a quality proof.",
+    }
+
+    if args.emit_judge_prompts:
+        template = args.judge_template.read_text(encoding="utf-8")
+        n = 0
+        with args.emit_judge_prompts.open("w", encoding="utf-8") as fh:
+            for e in rationaled:
+                prompt = render_judge_prompt(template, e, nodes, tdefs)
+                if prompt is None:
+                    continue
+                fh.write(json.dumps({"key": edge_key(e), "prompt": prompt},
+                                    ensure_ascii=False) + "\n")
+                n += 1
+        report["judge_prompts_emitted"] = n
+
+    text = json.dumps(report, indent=2, ensure_ascii=False)
+    if args.out:
+        args.out.write_text(text, encoding="utf-8")
+    # Console summary (report always to stdout tail for quick read)
+    m = report["mechanical"]
+    print(f"rationaled edges: {report['edges_with_rationale']}/{report['edges_total']}")
+    print(f"  mechanical clean: {m['clean']}  flagged: {m['flagged']}")
+    print(f"  flag_counts: {m['flag_counts']}")
+    if report["judge"]:
+        print(f"  judge verdicts: {report['judge']['verdicts']}")
+    if args.emit_judge_prompts:
+        print(f"  judge prompts emitted: {report['judge_prompts_emitted']}")
+    if args.out:
+        print(f"report -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/research/comp-linguist/analyses/edge-rationale-quality/judge-prompt.txt
+++ b/research/comp-linguist/analyses/edge-rationale-quality/judge-prompt.txt
@@ -1,0 +1,42 @@
+You are a quality screen for AI-generated edge rationales in the AI Triad taxonomy
+(an AI policy/safety ontology). An "edge rationale" is a 1-2 sentence justification of
+WHY a SOURCE node stands in a typed relationship (the EDGE_TYPE) to a TARGET node.
+
+You are NOT judging whether the edge itself is correct. You judge only whether the
+RATIONALE TEXT is a good justification: grounded in the substance of the two nodes,
+specific to the asserted relationship, and not a hollow restatement of the labels.
+
+Score three independent dimensions. Be strict — this is a junk screen, not a grade
+curve. When unsure, score DOWN.
+
+1. grounded (0-2): Does the rationale draw on the actual CONTENT of the source and
+   target (their descriptions), rather than generic filler that would fit any pair?
+     0 = generic/boilerplate, could be pasted onto unrelated nodes
+     1 = references one node's substance but not the conceptual link
+     2 = grounds the link in the substance of BOTH nodes
+
+2. specific_to_type (0-2): Does the rationale actually explain the "{{EDGE_TYPE}}"
+   relationship specifically, versus asserting some vague association?
+     0 = no engagement with what {{EDGE_TYPE}} means
+     1 = directionally consistent with {{EDGE_TYPE}} but could fit several edge types
+     2 = the justification is specific to {{EDGE_TYPE}} and would not fit its opposite
+
+3. not_restatement (0-1): Is the rationale MORE than the two labels glued together?
+     0 = essentially restates SOURCE_LABEL and TARGET_LABEL with connective tissue
+     1 = adds genuine explanatory content beyond the labels
+
+EDGE_TYPE "{{EDGE_TYPE}}" means: {{EDGE_TYPE_DEF}}
+
+SOURCE ({{SOURCE_ID}}) label: {{SOURCE_LABEL}}
+  description: {{SOURCE_DESC}}
+TARGET ({{TARGET_ID}}) label: {{TARGET_LABEL}}
+  description: {{TARGET_DESC}}
+
+RATIONALE UNDER REVIEW:
+{{RATIONALE}}
+
+Return ONLY JSON, no markdown fences, no commentary:
+{"grounded": 0-2, "specific_to_type": 0-2, "not_restatement": 0-1, "verdict": "pass"|"weak"|"fail", "note": "<=120 chars"}
+
+verdict rubric: fail if grounded==0 OR not_restatement==0; pass if grounded==2 AND
+specific_to_type>=1 AND not_restatement==1; otherwise weak.

--- a/research/comp-linguist/analyses/edge-rationale-quality/test_check_rationale_quality.py
+++ b/research/comp-linguist/analyses/edge-rationale-quality/test_check_rationale_quality.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Two-arm adversarial checks for the mechanical rationale screen.
+
+Arm 1 (clean case passes): a grounded, type-specific rationale draws ZERO flags.
+Arm 2 (each defect fires exactly its flag): empty, too-short, too-long,
+restatement, low-novelty, both-labels-verbatim.
+
+Run: python test_check_rationale_quality.py   (exit 0 = pass; no pytest needed)
+"""
+import check_rationale_quality as m
+
+SRC = "Open-source model release"
+TGT = "Proliferation of dual-use capability"
+ETYPE = "enables"
+
+FAILURES: list[str] = []
+
+
+def expect(name: str, cond: bool, detail: str = "") -> None:
+    if not cond:
+        FAILURES.append(f"{name}: {detail}")
+
+
+# ── Arm 1: a genuinely good rationale is clean ───────────────────────────────
+good = ("Publishing model weights removes the access controls that would "
+        "otherwise limit who can fine-tune the system, so bad actors gain the "
+        "same frontier capability as vetted labs — directly enabling misuse.")
+flags = m.mechanical_flags(good, SRC, TGT, ETYPE)
+expect("clean_passes", flags == [], f"expected no flags, got {flags}")
+
+# ── Arm 2a: empty ────────────────────────────────────────────────────────────
+expect("empty", m.mechanical_flags("   ", SRC, TGT, ETYPE) == ["empty"],
+       str(m.mechanical_flags("   ", SRC, TGT, ETYPE)))
+
+# ── Arm 2b: too short ────────────────────────────────────────────────────────
+short = "It enables it."
+expect("too_short", "too_short" in m.mechanical_flags(short, SRC, TGT, ETYPE),
+       str(m.mechanical_flags(short, SRC, TGT, ETYPE)))
+
+# ── Arm 2c: too long ─────────────────────────────────────────────────────────
+longr = ("Publishing the weights removes access controls and this matters a great "
+         "deal for many reasons that we will now enumerate at considerable and "
+         "frankly excessive length well beyond what any reader could possibly "
+         "want to absorb in a single sitting about proliferation dynamics and "
+         "governance and capability diffusion and monitoring and enforcement and "
+         "verification regimes and international coordination and much more still.")
+expect("too_long", "too_long" in m.mechanical_flags(longr, SRC, TGT, ETYPE),
+       str(len(longr)))
+
+# ── Arm 2d: restatement — rationale is basically the two labels glued ─────────
+restate = ("The open-source model release enables the proliferation of dual-use "
+           "capability.")
+rflags = m.mechanical_flags(restate, SRC, TGT, ETYPE)
+expect("restatement", "restatement" in rflags or "low_novelty" in rflags,
+       str(rflags))
+
+# ── Arm 2e: low novelty — few content words beyond the labels ────────────────
+lown = "This model release enables that dual-use capability proliferation indeed."
+expect("low_novelty", "low_novelty" in m.mechanical_flags(lown, SRC, TGT, ETYPE),
+       str(m.mechanical_flags(lown, SRC, TGT, ETYPE)))
+
+# ── Arm 2f: both labels verbatim ─────────────────────────────────────────────
+verbatim = (f"The {SRC} clearly enables the {TGT} through a diffusion mechanism "
+            "that lowers the marginal cost of acquiring frontier tooling.")
+expect("both_labels_verbatim",
+       "both_labels_verbatim" in m.mechanical_flags(verbatim, SRC, TGT, ETYPE),
+       str(m.mechanical_flags(verbatim, SRC, TGT, ETYPE)))
+
+if FAILURES:
+    print("FAIL:")
+    for f in FAILURES:
+        print("  -", f)
+    raise SystemExit(1)
+print("OK — all two-arm checks passed")

--- a/research/comp-linguist/designs/edge-rationale-remediation-plan.md
+++ b/research/comp-linguist/designs/edge-rationale-remediation-plan.md
@@ -1,7 +1,41 @@
 # Edge Rationale Coverage: Exploration and Remediation Plan
 
-**Last updated:** 2026-08-11
-**Ticket:** t/2444 (PI-requested) · **Status:** exploration + plan only, routed to Main (TL) for review; PI approves any backfill spend.
+**Last updated:** 2026-08-23
+**Ticket:** t/2444 (PI-requested) · **Status:** ⚠️ **root cause CORRECTED 2026-08-23 — see banner below; the backfill plan is superseded by a git-restore.**
+
+> ## ⚠️ CORRECTION (2026-08-23): root cause was misdiagnosed — this is recoverable data loss, not an origin gap
+>
+> The Summary and Deliverable 1 below (written 2026-08-11) concluded the ~33k edges "never had"
+> a rationale — "created before the rationale-required prompt landed." **The git history of
+> `../ai-triad-data` refutes this** (traced by CL.Investigate1, e/119; empirically reproduced by Main):
+>
+> | commit | date | edges w/ non-empty rationale |
+> |---|---|---|
+> | `ba3128f5` | 2026-07-24 | **33,448 / 33,454** (incl. **25,759 / 25,765 approved**) |
+> | `904feb92` | 2026-08-08 | 165 ← **WIPE #1** (workflow-app v1.0.0 "automated data pipeline update", full-tree rebuild drops the field) |
+> | `b5a76c8e` | 2026-08-15 | 2,440 ← t/2679 LLM backfill adds ~2,275 approved |
+> | `9d019c9e` | 2026-08-20 | **2** ← **WIPE #2** (same pipeline destroys the backfill) |
+>
+> Every one of the ~33k edges **carried a discovery-time rationale from May through 07-24**; two
+> destructive writes by the workflow-app data pipeline wiped them. The 08-11 scan below read the
+> post-wipe-#1 state (165) and mistook a symptom for an origin gap. The writer inventory (1a) is
+> not wrong about the inventoried writers — but it **omitted the actual destroyer** (the workflow-app
+> full-tree pipeline, which rebuilds edge objects from a source that omits `rationale`, upstream of
+> the serializer, which is not at fault). **t/2679's backfill is void** (wiped 5 days later).
+>
+> **Revised fix (supersedes Deliverable 2):**
+> 1. **Restore, don't backfill.** git-restore the original discovery-time rationales from
+>    `ba3128f5:taxonomy/Origin/edges.json` by edge id — original quality, near-zero cost. Beats an
+>    LLM reconstruction of 33k edges on both axes.
+> 2. **Fix the destroyer.** Audit/fix the workflow-app pipeline's edge-build step so it preserves
+>    `rationale` (and every other non-rebuilt field). *Outside CL scope — routed to the pipeline owner.*
+> 3. **Regression/count-floor gate**, not the new-edge assertion in 2a. The 2a gate would NOT have
+>    caught either wipe (the pipeline rewrites ALL edges and is not an inventoried writer). The gate
+>    that catches this fails a write that **drops rationale from edges that previously had it**.
+> 4. **Sequencing:** restore is pointless before the pipeline fix — the next pipeline run wipes it
+>    again (that is literally what happened to t/2679). Restore is **blocked on** the pipeline fix.
+>
+> Everything below 2026-08-11 is retained as the (superseded) exploration record.
 
 ## Summary
 

--- a/research/comp-linguist/designs/edge-rationale-remediation-plan.md
+++ b/research/comp-linguist/designs/edge-rationale-remediation-plan.md
@@ -18,28 +18,41 @@
 >
 > Every one of the ~33k edges **carried a discovery-time rationale from May through 07-24**; two
 > destructive writes by the workflow-app data pipeline wiped them. The 08-11 scan below read the
-> post-wipe-#1 state (165) and mistook a symptom for an origin gap. **The destroyer is an *inventoried*
-> writer** (TL trace, e/120#5/#7; CL-confirmed): `workflow-app/src/main/pipeline.ts:289` shells out to
-> `Invoke-EdgeDiscovery -Verbose`, which on a full-tree run loads the existing edges and composite-keys
-> them but **fails to carry forward the existing `rationale`** when it re-proposes an edge — then writes
-> through `Write-EdgesFile` (L723/746). The serializer is not at fault: it faithfully persists edge
-> objects whose `rationale` was already dropped upstream in `Invoke-EdgeDiscovery`. The 1a inventory's
-> error was reading discovery's rationale handling as "generates + persists" without noticing the
-> re-propose drop. **t/2679's backfill is void** (wiped 5 days later).
+> post-wipe-#1 state (165) and mistook a symptom for an origin gap. **t/2679's backfill is void**
+> (wiped 5 days later).
+>
+> **Verified mechanism (git forensics, ../ai-triad-data):** the wipe is a **field-strip of preserved
+> edges, not a set-regenerate.** At wipe #1 (`904feb92`, one commit after `ba3128f5`): **100% of the
+> 33,451 pre-wipe edge keys survive** (removed 0, added 167), and **all 33,445 rationaled edges kept
+> their composite key but lost the `rationale` field**. Both wipes carry `Tool: workflow-app v1.0.0`,
+> whose `edges` step is `pipeline.ts:289` → `Invoke-EdgeDiscovery -Verbose`, and every in-repo
+> edges.json write goes through `Write-EdgesFile` (the serializer is not at fault — it persists whole
+> edge objects). Edge-by-edge diff (CL.Investigate1): **every non-`rationale` field is byte-identical
+> pre→post** (confidence, status, discovered_at, model, weight, strength) — so the existing edges are
+> *carried through* with `rationale` specifically projected out; a fresh LLM re-propose would have
+> changed confidence/model/timestamp. This **rules out re-proposal** and, at both code states, the
+> `Invoke-EdgeDiscovery` seed (which adds whole objects, no field allowlist).
+>
+> **NOT yet pinned (empirical reproduce in flight, t/2945):** *which* pipeline step applies the
+> rationale-specific projection — a step that round-trips edges.json through a rationale-omitting
+> representation (validate / embeddings / other) is favored. Discriminating test (PS): run the exact
+> bare `Invoke-EdgeDiscovery -Verbose` against a fixture of rationaled edges — do pre-existing rationales
+> survive? If yes, hunt the earlier step. Do not assert the site until that run names it (t/2294).
 >
 > **Revised fix (supersedes Deliverable 2):**
 > 1. **Restore, don't backfill.** git-restore the original discovery-time rationales from
 >    `ba3128f5:taxonomy/Origin/edges.json` by **composite key `(source,target,type)`** (edges carry no
 >    id) — original quality, near-zero cost. 33,399/33,580 restorable (99.5%); byte-safety proven by
 >    `analyses/t2444-rationale-restore/apply_restore.py`. Beats an LLM reconstruction on both axes. (t/2946)
-> 2. **Fix the destroyer.** `Invoke-EdgeDiscovery` (PowerShell-owned, in-repo) must carry forward the
->    existing `rationale` by composite key on a full-tree re-propose instead of dropping it. Routed to
->    PowerShell under t/2945.
+> 2. **Fix the destroyer.** Preserve the existing `rationale` (composite-keyed) across a full-tree
+>    pipeline run. Owner = PowerShell (t/2945), in-repo; the exact fix site awaits the reproduce above.
 > 3. **Two-arm regression gate**, not the §2a new-edge assertion (which would have caught neither wipe).
->    **Arm 1 (primary):** a per-edge regression assertion in `Write-EdgesFile` — throw if a write drops
->    `rationale` from an edge that had it. Because the pipeline writes *through* this sink, Arm 1 throws
->    *before* the wipe. **Arm 2 (defense-in-depth):** a CI diff-gate (committed `edges.json` vs HEAD) for
->    any future path that bypasses the serializer. TL owns Gate Verification under t/2945.
+>    **Arm 1:** a per-edge regression assertion at `Write-EdgesFile` — throw if a write drops `rationale`
+>    from an edge that had it, **baselined on the committed/HEAD `edges.json`** (not the on-disk file — a
+>    same-run whole-array rewrite would poison an on-disk baseline). **Arm 2:** a CI diff-gate (committed
+>    `edges.json` vs HEAD) catching any net rationale regression regardless of step or mode — likely
+>    co-primary, not merely defense-in-depth. TL owns Gate Verification under t/2945; final placement is
+>    re-derived once the reproduce names the drop site.
 > 4. **Sequencing:** restore is pointless before the pipeline fix — the next pipeline run wipes it
 >    again (that is literally what happened to t/2679). Restore is **blocked on** the pipeline fix.
 >

--- a/research/comp-linguist/designs/edge-rationale-remediation-plan.md
+++ b/research/comp-linguist/designs/edge-rationale-remediation-plan.md
@@ -24,37 +24,51 @@
 > **Verified mechanism (git forensics, ../ai-triad-data):** the wipe is a **field-strip of preserved
 > edges, not a set-regenerate.** At wipe #1 (`904feb92`, one commit after `ba3128f5`): **100% of the
 > 33,451 pre-wipe edge keys survive** (removed 0, added 167), and **all 33,445 rationaled edges kept
-> their composite key but lost the `rationale` field**. Both wipes carry `Tool: workflow-app v1.0.0`,
-> whose `edges` step is `pipeline.ts:289` → `Invoke-EdgeDiscovery -Verbose`, and every in-repo
-> edges.json write goes through `Write-EdgesFile` (the serializer is not at fault — it persists whole
-> edge objects). Edge-by-edge diff (CL.Investigate1): **every non-`rationale` field is byte-identical
-> pre→post** (confidence, status, discovered_at, model, weight, strength) — so the existing edges are
-> *carried through* with `rationale` specifically projected out; a fresh LLM re-propose would have
-> changed confidence/model/timestamp. This **rules out re-proposal** and, at both code states, the
-> `Invoke-EdgeDiscovery` seed (which adds whole objects, no field allowlist).
+> their composite key but lost the `rationale` field** — and edge-by-edge, **every non-`rationale`
+> field is byte-identical pre→post** (confidence, status, discovered_at, model, weight, strength). That
+> fingerprint (drop exactly one field, carry the rest byte-for-byte) is a `({ rationale, ...rest })`
+> object spread, not a rewrite.
 >
-> **NOT yet pinned (empirical reproduce in flight, t/2945):** *which* pipeline step applies the
-> rationale-specific projection — a step that round-trips edges.json through a rationale-omitting
-> representation (validate / embeddings / other) is favored. Discriminating test (PS): run the exact
-> bare `Invoke-EdgeDiscovery -Verbose` against a fixture of rationaled edges — do pre-existing rationales
-> survive? If yes, hunt the earlier step. Do not assert the site until that run names it (t/2294).
+> **CONFIRMED site (CL.Investigate1 #20; PS #21 cleared the alternatives) — it is NOT the pipeline.**
+> The `Invoke-EdgeDiscovery` cmdlet is append-preserve in all four modes, `embed_taxonomy.py` skips
+> edges.json, and no PS pipeline step projects the field. The strip is the **taxonomy-editor
+> load-list/save-whole-file round-trip**:
+> - **Desktop** — `taxonomy-editor/src/main/ipc/taxonomyHandlers.ts`: `load-edges` returns
+>   `edges.map(({ rationale, ...rest }) => rest)` (strips rationale for the list payload — an intentional
+>   lazy-load optimization, see §1c below), and `save-edges` writes the **entire** caller-supplied array
+>   via `writeEdgesFile`, guarding body shape only, not field completeness. Load list → append one edge →
+>   save whole file = rationale wiped from every existing edge, other fields intact, +new edges appended.
+>   Exactly the observed shape (+167 new, 33k stripped).
+> - **Server twin** — `src/server/community/edgesApi.ts` (same strip) + `PUT /api/edges` (whole-file save).
+> The `Tool: workflow-app v1.0.0` attribution was a full-tree `git add` **capturing** an editor/server
+> save, not the pipeline writing it.
 >
 > **Revised fix (supersedes Deliverable 2):**
 > 1. **Restore, don't backfill.** git-restore the original discovery-time rationales from
 >    `ba3128f5:taxonomy/Origin/edges.json` by **composite key `(source,target,type)`** (edges carry no
 >    id) — original quality, near-zero cost. 33,399/33,580 restorable (99.5%); byte-safety proven by
 >    `analyses/t2444-rationale-restore/apply_restore.py`. Beats an LLM reconstruction on both axes. (t/2946)
-> 2. **Fix the destroyer.** Preserve the existing `rationale` (composite-keyed) across a full-tree
->    pipeline run. Owner = PowerShell (t/2945), in-repo; the exact fix site awaits the reproduce above.
-> 3. **Two-arm regression gate**, not the §2a new-edge assertion (which would have caught neither wipe).
->    **Arm 1:** a per-edge regression assertion at `Write-EdgesFile` — throw if a write drops `rationale`
->    from an edge that had it, **baselined on the committed/HEAD `edges.json`** (not the on-disk file — a
->    same-run whole-array rewrite would poison an on-disk baseline). **Arm 2:** a CI diff-gate (committed
->    `edges.json` vs HEAD) catching any net rationale regression regardless of step or mode — likely
->    co-primary, not merely defense-in-depth. TL owns Gate Verification under t/2945; final placement is
->    re-derived once the reproduce names the drop site.
-> 4. **Sequencing:** restore is pointless before the pipeline fix — the next pipeline run wipes it
->    again (that is literally what happened to t/2679). Restore is **blocked on** the pipeline fix.
+> 2. **Fix the destroyer.** The whole-file save paths (`save-edges` IPC + `PUT /api/edges`) must
+>    **re-merge `rationale` (and any list-trimmed field) from the on-disk edges.json by composite key
+>    before writing** — never persist a payload that came from the rationale-stripped list endpoint.
+>    Keep the read-side strip (it's an intentional payload-size optimization; §1c). Add a save-preserves-
+>    on-disk-rationale test (both arms). Site = `taxonomy-editor` (desktop + server), which resolves to
+>    **root/ownerless** — TL dispatches, PI assigns an owner (t/2945).
+> 3. **Regression gate — two serializers, so coverage must span both** (per-edge rule everywhere: fail a
+>    write that drops `rationale` from an edge rationaled in HEAD; baseline = **committed HEAD**, not
+>    on-disk). Coverage map (CL.Investigate1's spec owns the detail; TL GVs under t/2945):
+>    - **PS writers** (`Write-EdgesFile.ps1`: Invoke-EdgeDiscovery + other PS edge cmdlets) → **Arm 1**
+>      (warn-first, then throw — Gate Promotion, t/2683). Catches a *pipeline re-emit*, **not** the editor
+>      save — the editor/server write through the **TS** serializer (`lib/edges/serializeEdges.ts`), which
+>      never routes through PS `Write-EdgesFile`.
+>    - **Editor + server saves** (the actual site) → the **site fix** itself (re-merge), and/or a
+>      **TS-side write-boundary guard** mirroring Arm 1, and/or **Arm 2** (CI diff vs committed HEAD on
+>      ai-triad-data). Arm 2 is genuinely co-primary — the only currently-planned arm that catches a direct
+>      editor/server save.
+> 4. **Sequencing (durability — the t/2679 lesson).** The restore (t/2946) must sequence **behind the
+>    site fix (or a TS-side write guard), with Arm 2 as the commit-time backstop** — **not** behind PS
+>    Arm 1 alone, which does not execute on an editor add-edge save (the exact original trigger). Marker
+>    (t/2943/t/2944) follows. Nothing restored until an editor save can no longer silently re-wipe it.
 >
 > Everything below 2026-08-11 is retained as the (superseded) exploration record.
 

--- a/research/comp-linguist/designs/edge-rationale-remediation-plan.md
+++ b/research/comp-linguist/designs/edge-rationale-remediation-plan.md
@@ -18,20 +18,28 @@
 >
 > Every one of the ~33k edges **carried a discovery-time rationale from May through 07-24**; two
 > destructive writes by the workflow-app data pipeline wiped them. The 08-11 scan below read the
-> post-wipe-#1 state (165) and mistook a symptom for an origin gap. The writer inventory (1a) is
-> not wrong about the inventoried writers — but it **omitted the actual destroyer** (the workflow-app
-> full-tree pipeline, which rebuilds edge objects from a source that omits `rationale`, upstream of
-> the serializer, which is not at fault). **t/2679's backfill is void** (wiped 5 days later).
+> post-wipe-#1 state (165) and mistook a symptom for an origin gap. **The destroyer is an *inventoried*
+> writer** (TL trace, e/120#5/#7; CL-confirmed): `workflow-app/src/main/pipeline.ts:289` shells out to
+> `Invoke-EdgeDiscovery -Verbose`, which on a full-tree run loads the existing edges and composite-keys
+> them but **fails to carry forward the existing `rationale`** when it re-proposes an edge — then writes
+> through `Write-EdgesFile` (L723/746). The serializer is not at fault: it faithfully persists edge
+> objects whose `rationale` was already dropped upstream in `Invoke-EdgeDiscovery`. The 1a inventory's
+> error was reading discovery's rationale handling as "generates + persists" without noticing the
+> re-propose drop. **t/2679's backfill is void** (wiped 5 days later).
 >
 > **Revised fix (supersedes Deliverable 2):**
 > 1. **Restore, don't backfill.** git-restore the original discovery-time rationales from
->    `ba3128f5:taxonomy/Origin/edges.json` by edge id — original quality, near-zero cost. Beats an
->    LLM reconstruction of 33k edges on both axes.
-> 2. **Fix the destroyer.** Audit/fix the workflow-app pipeline's edge-build step so it preserves
->    `rationale` (and every other non-rebuilt field). *Outside CL scope — routed to the pipeline owner.*
-> 3. **Regression/count-floor gate**, not the new-edge assertion in 2a. The 2a gate would NOT have
->    caught either wipe (the pipeline rewrites ALL edges and is not an inventoried writer). The gate
->    that catches this fails a write that **drops rationale from edges that previously had it**.
+>    `ba3128f5:taxonomy/Origin/edges.json` by **composite key `(source,target,type)`** (edges carry no
+>    id) — original quality, near-zero cost. 33,399/33,580 restorable (99.5%); byte-safety proven by
+>    `analyses/t2444-rationale-restore/apply_restore.py`. Beats an LLM reconstruction on both axes. (t/2946)
+> 2. **Fix the destroyer.** `Invoke-EdgeDiscovery` (PowerShell-owned, in-repo) must carry forward the
+>    existing `rationale` by composite key on a full-tree re-propose instead of dropping it. Routed to
+>    PowerShell under t/2945.
+> 3. **Two-arm regression gate**, not the §2a new-edge assertion (which would have caught neither wipe).
+>    **Arm 1 (primary):** a per-edge regression assertion in `Write-EdgesFile` — throw if a write drops
+>    `rationale` from an edge that had it. Because the pipeline writes *through* this sink, Arm 1 throws
+>    *before* the wipe. **Arm 2 (defense-in-depth):** a CI diff-gate (committed `edges.json` vs HEAD) for
+>    any future path that bypasses the serializer. TL owns Gate Verification under t/2945.
 > 4. **Sequencing:** restore is pointless before the pipeline fix — the next pipeline run wipes it
 >    again (that is literally what happened to t/2679). Restore is **blocked on** the pipeline fix.
 >

--- a/research/comp-linguist/designs/edge-rationale-source-marker.md
+++ b/research/comp-linguist/designs/edge-rationale-source-marker.md
@@ -1,0 +1,55 @@
+# Edge `rationale_source` Marker — Design / Decision
+
+**Tranche:** follow-up to t/2444 (edge-rationale coverage plan, open-decision #2)
+**Author:** Computational Linguist · **Status:** spec for implementation, routed to owners
+**Scope:** cross-role — schema/type (Shared Lib), write sites (PowerShell + Shared Lib)
+
+## Problem
+
+A backfilled rationale is a **post-hoc reconstruction** from node content, not the
+contemporaneous discovery reasoning. Today nothing distinguishes the two: a reviewer
+reading an edge's rationale cannot tell whether it justified the edge *when it was
+created* or was generated months later from labels + descriptions. Before any backfill
+run writes ~25–33k rationales, the field must carry its own provenance so a reconstruction
+is never mistaken for original justification.
+
+## Decision: add a `rationale_source` field on edges
+
+Closed vocabulary (string enum). Absent/empty = **legacy/unknown** (the pre-marker era).
+
+| Value | Meaning | Written by |
+|---|---|---|
+| `discovery` | LLM classification at edge-discovery time (contemporaneous) | `Invoke-EdgeDiscovery` (per-node + batch LLM paths) |
+| `embedding-template` | Templated from similarity; no LLM justified it | `Invoke-EdgeDiscovery` embedding-first path (see plan 2a.3) |
+| `reflection` | Emitted by a debate reflection proposal | `debateReflectionSlice` |
+| `backfill` | Post-hoc reconstruction from node content | `Invoke-EdgeRationaleBackfill` |
+| `human` | Manually authored/edited by a curator | editor / `Set-Edge` when a human sets rationale |
+| *(absent)* | Legacy edge, pre-marker | — |
+
+**Invariant:** whenever a writer sets a non-empty `rationale`, it sets `rationale_source`
+in the same write. The two fields move together; a rationale without a source is only
+valid for legacy rows.
+
+## Implementation (routed)
+
+1. **Shared Lib** — add `rationale_source?: string` to the edge type/schema
+   (`lib/edges/*`), and ensure the shared serializers (`serializeEdgesJson`,
+   `Write-EdgesFile`) **preserve** it on round-trip (they must already preserve unknown
+   fields; confirm with a test). No validation gate here yet — that's the prospective-gate
+   tranche (plan 2a, separate).
+2. **PowerShell** — `Invoke-EdgeRationaleBackfill` sets `rationale_source = 'backfill'`
+   on every edge it writes a rationale onto (one line at the write site, alongside the
+   existing `Add-Member`/assign). `Invoke-EdgeDiscovery` sets `discovery` /
+   `embedding-template` per path.
+3. **Consumer (optional, later)** — `EdgeDetailPanel` badges non-`discovery` sources
+   ("backfilled", "templated") so the reader sees provenance at a glance.
+
+## Why a decision doc and not a PR here
+
+The write sites and schema live in PowerShell + Shared Lib scope. CL owns the *decision*
+(the vocabulary and the invariant); the owning roles implement. Tickets filed:
+- Shared Lib: schema field + serializer-preserve test.
+- PowerShell: set `rationale_source` at the three write sites.
+
+Sequencing note: land this marker **before** any full backfill run, else the backfill's
+25–33k rows land unlabeled and need a second pass to tag.

--- a/research/comp-linguist/designs/edge-rationale-source-marker.md
+++ b/research/comp-linguist/designs/edge-rationale-source-marker.md
@@ -6,12 +6,15 @@
 
 ## Problem
 
-A backfilled rationale is a **post-hoc reconstruction** from node content, not the
-contemporaneous discovery reasoning. Today nothing distinguishes the two: a reviewer
-reading an edge's rationale cannot tell whether it justified the edge *when it was
-created* or was generated months later from labels + descriptions. Before any backfill
-run writes ~25–33k rationales, the field must carry its own provenance so a reconstruction
-is never mistaken for original justification.
+Rationale text can reach an edge three different ways, and a reviewer cannot currently
+tell them apart: (a) the **contemporaneous discovery reasoning** written when the edge was
+created; (b) a **git-restore** of that original text after a data-loss event (the actual
+situation — the workflow-app pipeline wiped ~33k discovery-time rationales twice, recoverable
+from `ba3128f5`; see the t/2444 correction banner); or (c) a **post-hoc LLM reconstruction**
+from node content (the t/2679 backfill, now void). These have very different trust levels —
+(a) and (b) are the original justification; (c) is a reconstruction. The field must carry its
+own provenance so a reconstruction is never mistaken for the original, and so a restore is
+recognisable as such.
 
 ## Decision: add a `rationale_source` field on edges
 
@@ -22,7 +25,8 @@ Closed vocabulary (string enum). Absent/empty = **legacy/unknown** (the pre-mark
 | `discovery` | LLM classification at edge-discovery time (contemporaneous) | `Invoke-EdgeDiscovery` (per-node + batch LLM paths) |
 | `embedding-template` | Templated from similarity; no LLM justified it | `Invoke-EdgeDiscovery` embedding-first path (see plan 2a.3) |
 | `reflection` | Emitted by a debate reflection proposal | `debateReflectionSlice` |
-| `backfill` | Post-hoc reconstruction from node content | `Invoke-EdgeRationaleBackfill` |
+| `restore` | Original discovery-time text git-restored after a data-loss event (e.g. from `ba3128f5`) | the restore script (t/2444 correction) |
+| `backfill` | Post-hoc LLM reconstruction from node content (last resort; t/2679, now void) | `Invoke-EdgeRationaleBackfill` |
 | `human` | Manually authored/edited by a curator | editor / `Set-Edge` when a human sets rationale |
 | *(absent)* | Legacy edge, pre-marker | — |
 

--- a/research/comp-linguist/docs/metric-provenance-register.md
+++ b/research/comp-linguist/docs/metric-provenance-register.md
@@ -203,6 +203,19 @@ Parameters declared in approved-pending designs; rows move to §1/§5 when the i
 Rows for the Debate-Tested tier instrument moved to §1 on 2026-07-15 (Phase 0 implemented, t/1545 `7f4b85f8`; renamed per t/1533). Testing-deficit ladder and importance weights moved to §1 on 2026-07-15 (Phase 3 implemented, t/1587 `c968fbc7`); WELL_TESTED_EXCLUSION constants added to §1 same date.
 | External evidence pointer (`external_evidence[]`: `{url, note, added_by, added_at}` on cruxes; same shape planned on Debate-Tested `revisions[]` entries) | t/1535 (external review suggestion, t/1523) | `metadata` | Human-entered record of real-world evidence a reviewer found when investigating a crux or high-impact revision. Not computed, not an instrument — carries no evidence pointer because it doesn't measure anything, it records outside-the-loop input. **Hard rule:** MUST NOT be read by any scoring, sort-key, or tier-computation code path. A PR that adds such a read reopens the exact self-corroboration risk t/1523's rename closed and should be blocked outright, not merely flagged. |
 
+## 9. Edge-rationale quality screen (t/2444 A′ tranche)
+
+Automated, no-hand-grading screen over the AI-generated edge `rationale` field
+(`Invoke-EdgeRationaleBackfill` output). Tool: `analyses/edge-rationale-quality/`
+(`check_rationale_quality.py` mechanical layer + `judge-prompt.txt` LLM-judge layer).
+Both layers are **stipulated screens for obvious junk — NOT proofs of rationale
+quality**; a judge `pass` is not ground truth.
+
+| Instrument / threshold | Provenance | Evidence / notes |
+|---|---|---|
+| Mechanical thresholds — `MIN_CHARS=40`, `MAX_CHARS=400`, `MIN_NOVEL_WORDS=4`, `RESTATEMENT_OVERLAP=0.60`, `RESTATEMENT_NOVEL_MAX=6` | **stipulated** | Token-heuristic flags (`empty` / `too_short` / `too_long` / `low_novelty` / `restatement` / `both_labels_verbatim`). Values asserted by design; `MAX_CHARS` tracks the backfill prompt's ~300-char target with slack. Two-arm proven in `test_check_rationale_quality.py` (good rationale → 0 flags; each defect → its flag) but never tuned against a labeled sample. **Path off stipulated:** score flags against a hand-labeled rationale sample; promote to `derived` only with that evidence pointer. |
+| LLM-judge verdict (`grounded` 0–2, `specific_to_type` 0–2, `not_restatement` 0–1; verdict `pass`/`weak`/`fail`) | **stipulated** | `judge-prompt.txt` rubric asserted by design. A junk screen (catches empty / off-type / label-restatement), not a calibrated quality metric — the model's own scores do not transport across backends. **Path off stipulated:** agreement study vs a human-labeled rationale sample; until then never read a `pass` as validated quality. |
+
 ## Maintenance
 
 - Every PR adding or modifying a metric, threshold, weight, or lexicon must state its provenance class and update this register in the same PR (CL review checklist item).

--- a/research/comp-linguist/docs/owned-files.md
+++ b/research/comp-linguist/docs/owned-files.md
@@ -61,6 +61,8 @@ Files the Computational Linguist holds **mandatory review authority** over. Chan
 | `scripts/AITriad/Private/Get-EmbeddingClusters.ps1` | Embeddings | Mandatory |
 | `validation-report.json` | Validation outputs | Mandatory (sign-off) |
 | `research/comp-linguist/docs/frame-survival-metric-spec.md` | Frame-survival metric family — definitions, thresholds, validation gates (t/2042) | Mandatory |
+| `research/comp-linguist/analyses/edge-rationale-quality/check_rationale_quality.py` | Edge-rationale mechanical quality screen — stipulated flag thresholds (t/2444 A′) | Mandatory |
+| `research/comp-linguist/analyses/edge-rationale-quality/judge-prompt.txt` | Edge-rationale LLM-judge scoring prompt (t/2444 A′) | Mandatory |
 
 ## Maintenance rule
 

--- a/scripts/AITriad/Prompts/edge-rationale-backfill.prompt
+++ b/scripts/AITriad/Prompts/edge-rationale-backfill.prompt
@@ -1,6 +1,16 @@
 You are a research analyst for the AI Triad project (AI policy/safety taxonomy).
 
-Write ONE concise rationale (1-2 sentences, at most ~300 characters) explaining WHY the SOURCE node stands in a "{{EDGE_TYPE}}" relationship to the TARGET node. Ground the rationale in the substance of the two nodes; do not merely restate their labels. Be specific about the conceptual link the edge type asserts.
+Write ONE concise rationale (1-2 sentences, at most ~300 characters) explaining WHY the SOURCE node stands in a "{{EDGE_TYPE}}" relationship to the TARGET node. Ground the rationale in the SUBSTANCE of the two nodes (their descriptions), and be specific about the conceptual link the "{{EDGE_TYPE}}" edge type asserts.
+
+Hard constraints:
+- Do NOT restate or paraphrase the two labels glued together — a reader who has the labels must still learn something new from your rationale.
+- Explain the mechanism specific to "{{EDGE_TYPE}}": the justification should NOT read equally well for a different or opposite edge type.
+- No generic filler ("is related to", "is important for") that would fit any pair of nodes.
+
+Example (edge type "enables"):
+  SOURCE label: Open-weight model release   TARGET label: Dual-use capability diffusion
+  BAD  (restates labels): "Open-weight model release enables dual-use capability diffusion."
+  GOOD (grounds the mechanism): "Publishing weights removes the access controls that gate who can fine-tune the system, so the same frontier capability reaches unvetted actors — the diffusion the target describes."
 
 Edge type "{{EDGE_TYPE}}" means: {{EDGE_TYPE_DEF}}
 


### PR DESCRIPTION
Started as the next edge-rationale tranche; **mid-flight a peer (CL.Investigate1, e/119) refuted the root cause** and I verified the correction against `../ai-triad-data` git history. This PR now carries the corrected diagnosis plus the CL-owned artifacts that survive it.

## Root-cause correction (the important part)
The ~33k missing rationales were **not** "never generated." They existed and were **wiped twice** by the workflow-app data pipeline:

| commit | date | edges w/ rationale |
|---|---|---|
| `ba3128f5` | Jul 24 | **33,448 / 33,454** (25,759 approved) |
| `904feb92` | Aug 08 | 165 ← wipe #1 |
| `b5a76c8e` | Aug 15 | 2,440 ← t/2679 backfill |
| `9d019c9e` | Aug 20 | **2** ← wipe #2 (destroys the backfill) |

Fix pivots from LLM-backfill to **git-restore from `ba3128f5` + pipeline fix + regression/count-floor gate**. t/2679's backfill is void. Details in the corrected `designs/edge-rationale-remediation-plan.md` banner. Pipeline fix + gate routed to TL (data-loss incident, cross-scope).

## What lands here (CL-owned, correctly reframed)
- **Quality harness** (`analyses/edge-rationale-quality/`) — mechanical screen (free, deterministic) + opt-in LLM-judge prompt, two-arm proven. Repurposed as a **restore-verifier** (confirm the restored text is the good original) + general rationale screen.
- **`rationale_source` marker spec** (`designs/edge-rationale-source-marker.md`) — closed vocabulary incl. a `restore` value; cross-scope impl routed to Shared Lib (t/2943) + PowerShell (t/2944).
- **Hardened backfill prompt** — no-restatement + type-specificity constraints (marginal now; helps the residual ~6 never-had-one edges + future discovery).
- **Provenance register + owned-files** updated; harness thresholds registered **stipulated**.

All thresholds/judge verdicts are stipulated screens, not quality proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)