### PR TITLE
docs(cl): edge-rationale restore tool + regression-gate spec (t/2444)

### DIFF
--- a/research/comp-linguist/analyses/t2444-rationale-restore/apply_restore.py
+++ b/research/comp-linguist/analyses/t2444-rationale-restore/apply_restore.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Edge-rationale restore (t/2444). Restores discovery-time `rationale` fields that the
+# workflow-app data pipeline wiped from edges.json on 2026-08-08 and again on 2026-08-20.
+#
+# Source of truth for the original rationales: git commit ba3128f5 (2026-07-24) in the
+# ai-triad-data repo, the last state before wipe #1 — 33,448/33,454 edges carried a rationale.
+#
+# Design & evidence: research/comp-linguist/designs/edge-rationale-restore-and-gate-spec.md
+#
+# SAFETY MODEL (why this is a minimal, reversible data edit):
+#   * Edges have NO `id` field. Identity is the composite (source, target, type).
+#   * For each CURRENT edge that lacks a non-empty rationale but whose composite key matches a
+#     rationale-bearing edge at ba3128f5, we insert `rationale` immediately AFTER `confidence`,
+#     preserving every other key in its exact current order (the current file has 17 distinct
+#     per-edge key orderings — we never reorder).
+#   * Edges already carrying a rationale in the current file are left byte-for-byte untouched.
+#   * STRIP-BACK PROOF (run every invocation): removing only the rationales we added and
+#     re-serializing must reproduce the current file byte-for-byte. If it does not, we abort
+#     and write nothing. This guarantees the restore changes *only* rationale.
+#   * Output uses the compact hybrid contract of lib/edges/serializeEdges.ts (one compact
+#     edge per line at 4-space indent, `,`/`:` separators, LF, single trailing newline),
+#     verified to round-trip the current file byte-for-byte.
+#
+# This script does NOT commit. It writes <current>.restored next to the target and prints a
+# report. The data-repo owner applies it (out of CL scope), AFTER the pipeline destroyer is
+# fixed — restoring without fixing the pipeline just resets the clock (both prior wipes proved
+# the field is destroyed on the next full-tree pipeline run).
+#
+# Usage:
+#   1. Extract the source snapshot from the data repo:
+#        git -C <ai-triad-data> show ba3128f5:taxonomy/Origin/edges.json > /tmp/edges_ba3128f5.json
+#   2. python apply_restore.py --current <ai-triad-data>/taxonomy/Origin/edges.json \
+#                              --source /tmp/edges_ba3128f5.json
+#      (optional: --out <path>  default: <current>.restored ; --write-in-place to overwrite)
+
+import argparse, json, sys, os
+
+
+def load(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def has_rat(e):
+    r = e.get("rationale")
+    return isinstance(r, str) and r.strip() != ""
+
+
+def ckey(e):
+    return (e.get("source"), e.get("target"), e.get("type"))
+
+
+def serialize(doc):
+    """Byte-compatible with lib/edges/serializeEdges.ts (verified round-trip on the live file)."""
+    parts = []
+    for k in doc:
+        v = doc[k]
+        if k == "edges" and isinstance(v, list):
+            if not v:
+                parts.append('  "edges": []')
+                continue
+            lines = ",\n".join(
+                "    " + json.dumps(e, ensure_ascii=False, separators=(",", ":")) for e in v
+            )
+            parts.append('  "edges": [\n' + lines + "\n  ]")
+        else:
+            pretty = json.dumps(v, ensure_ascii=False, indent=2).replace("\n", "\n  ")
+            parts.append("  " + json.dumps(k) + ": " + pretty)
+    return "{\n" + ",\n".join(parts) + "\n}\n"
+
+
+def insert_after_confidence(e, rat):
+    out = {}
+    for k, v in e.items():
+        out[k] = v
+        if k == "confidence":
+            out["rationale"] = rat
+    if "rationale" not in out:  # no `confidence` key: append at end
+        out["rationale"] = rat
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--current", required=True, help="path to live edges.json to restore into")
+    ap.add_argument("--source", required=True, help="edges.json extracted from ba3128f5")
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--write-in-place", action="store_true")
+    args = ap.parse_args()
+
+    cur_doc = load(args.current)
+    cur_blob = open(args.current, encoding="utf-8", newline="").read()
+    src = load(args.source)["edges"]
+
+    # Self-check: our serializer must reproduce the current file byte-for-byte before we trust it.
+    if serialize(cur_doc) != cur_blob:
+        sys.exit("ABORT: serializer does not round-trip the current file byte-for-byte; "
+                 "the file's byte format has changed — update serialize() before restoring.")
+
+    old_by = {ckey(e): e["rationale"] for e in src if has_rat(e)}
+    had = {ckey(e) for e in cur_doc["edges"] if has_rat(e)}
+
+    restored = kept = gap = 0
+    new_edges = []
+    for e in cur_doc["edges"]:
+        if has_rat(e):
+            kept += 1
+            new_edges.append(e)
+            continue
+        k = ckey(e)
+        if k in old_by:
+            new_edges.append(insert_after_confidence(e, old_by[k]))
+            restored += 1
+        else:
+            new_edges.append(e)
+            gap += 1
+    cur_doc["edges"] = new_edges
+    out_blob = serialize(cur_doc)
+
+    # STRIP-BACK PROOF: strip only the rationales we added; must equal the original current file.
+    check = json.loads(out_blob)
+    for e in check["edges"]:
+        if ckey(e) not in had:
+            e.pop("rationale", None)
+    if serialize(check) != cur_blob:
+        sys.exit("ABORT: strip-back proof failed — the restore changed more than rationale. "
+                 "Nothing written.")
+
+    out_path = args.current if args.write_in_place else (args.out or args.current + ".restored")
+    with open(out_path, "w", encoding="utf-8", newline="") as f:
+        f.write(out_blob)
+
+    final = sum(1 for e in new_edges if has_rat(e))
+    print(f"restored={restored}  kept_existing={kept}  generation_gap(new edges)={gap}")
+    print(f"final edges with rationale = {final} / {len(new_edges)}")
+    print("strip-back proof: PASS (only rationale changed)")
+    print(f"wrote: {out_path}")
+    if gap:
+        print(f"\n{gap} edges have no source in ba3128f5 (created after the wipe) and still need "
+              f"generation — see gap breakdown in the spec doc.")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/comp-linguist/analyses/t2444-rationale-restore/gap-backfill-prompt.md
+++ b/research/comp-linguist/analyses/t2444-rationale-restore/gap-backfill-prompt.md
@@ -1,0 +1,84 @@
+# Gap-Backfill Prompt — 179 post-wipe edges (t/2946 Phase 2)
+
+**Ticket:** t/2946 Phase 2 · **Author:** CL.Investigate1 · **Parent:** t/2444
+**Scope:** the **179** edges that have no source in `ba3128f5` (created *after* wipe #1, so the
+git-restore in t/2946 Phase 1 cannot cover them). This is the *only* cohort that needs
+generation — 0.5% of edges, not 33k.
+
+## Why this is rationale-*only*, not re-discovery
+
+These 179 rows already exist as edges: their `source`, `target`, `type`, `confidence`, and
+`weight`/`strength` were decided at discovery time. Only `rationale` is missing. So — unlike
+`Invoke-EdgeDiscovery`'s classify prompt (which *chooses* type + direction) — this prompt is
+handed the fixed relationship and asked to **explain the already-committed edge**. Do not let the
+model re-classify, flip direction, or second-guess the type; it justifies, it does not decide.
+
+## Provenance (load-bearing)
+
+A backfilled rationale is a **post-hoc reconstruction** from node content, not the contemporaneous
+discovery reasoning. Provenance class: **derived** (not human-validated, not the original
+stipulation). Every edge this prompt fills MUST be tagged **`rationale_source: "backfill"`** so it
+is never mistaken for a discovery-time or restored (`rationale_source: "restore"`) rationale — per
+CL Main's `rationale_source` marker spec (Shared-Lib t/2943 / PowerShell t/2944). Update
+`docs/metric-provenance-register.md` in the landing PR.
+
+## Input assembly (per edge)
+
+From the POV node files (`taxonomy/Origin/{accelerationist,safetyist,skeptic,cc}.json`), nodes
+carry `id`, `label`, `description`, `category`. From `edges.json`, the edge carries the fixed
+`type`, plus `confidence` / `weight` as strength hints. Assemble:
+
+```
+SOURCE  [<source.id>] <source.label> (<source.category>): <source.description>
+TARGET  [<target.id>] <target.label> (<target.category>): <target.description>
+EDGE    type=<type> — <edge_type.definition>   (confidence <confidence>, weight <weight>)
+```
+
+## Prompt template
+
+```
+You are documenting WHY an already-established relationship exists between two taxonomy nodes.
+The relationship type and direction are FIXED and correct — do not question, re-classify, or
+reverse them. Write only the missing rationale.
+
+SOURCE  [{source_id}] {source_label} ({source_category}): {source_description}
+TARGET  [{target_id}] {target_label} ({target_category}): {target_description}
+RELATIONSHIP (fixed): {source_id} --{type}--> {target_id}
+  {type}: {type_definition}
+
+Write one sentence (max ~40 words) stating why the SOURCE stands in this {type} relationship to
+the TARGET, grounded in the two descriptions above. Quote or paraphrase the specific content that
+licenses the relationship. Do not restate the node labels verbatim; do not hedge ("may", "could
+be seen as") unless the descriptions themselves are tentative. If the descriptions genuinely do
+not support the {type} relationship, return exactly: INSUFFICIENT_BASIS
+
+Return JSON only, no markdown fences: {"rationale": "..."}
+```
+
+## Output handling
+
+- Parse `{"rationale": "..."}`; write it into the edge and set `rationale_source: "backfill"`.
+- **`INSUFFICIENT_BASIS`** → leave `rationale` empty, do **not** fabricate. Flag the edge for CL
+  review (a real signal: an edge whose own node content doesn't justify it may be a bad edge, not
+  just a missing rationale). Count and report these, per the `Invoke-EdgeDiscovery` silent-blank
+  convention (t/2674) — a run that quietly produces blanks must surface the count.
+- Never emit a rationale that merely echoes the labels; the harness screens for this.
+
+## Verification (gate before landing)
+
+Every backfilled rationale runs through CL Main's rationale-quality harness (PR #1426, repurposed
+as restore/backfill verifier) — same screen as the restored set. Only harness-passing rationales
+land. `INSUFFICIENT_BASIS` and harness-rejected rows route to CL review, not to auto-fill.
+
+## Model / cost
+
+Free-tier `gemini-flash-lite` (the discovery-era model for this cohort: 119 gemini-3.5-flash-lite,
+50 gemini-2.5-flash, 10 debate-reflection). 179 edges × ~700 in / ~60 out tokens ≈ trivial;
+effectively $0. Batch by `type` to maximize prompt-cache hits. No paid model is warranted at this
+volume.
+
+## Sequencing
+
+Runs **after** t/2946 Phase 1 (git-restore) and **after** t/2945 lands the pipeline fix — same
+reason: a full-tree pipeline run before the fix would wipe these too (killed t/2679).
+```

--- a/research/comp-linguist/designs/edge-rationale-restore-and-gate-spec.md
+++ b/research/comp-linguist/designs/edge-rationale-restore-and-gate-spec.md
@@ -1,0 +1,150 @@
+# Edge-Rationale Restore + Regression-Gate Spec
+
+**Last updated:** 2026-08-23
+**Ticket:** t/2444 · **Author:** CL.Investigate1 · **Requested by:** Main (CL) (e/119)
+**Status:** artifacts ready + verified; restore is a data-repo write (out of CL scope) and gate
+is a CI/pipeline gate (routes to Main (TL)) — both handed off, neither self-applied.
+
+## Why this supersedes the "prompt never asked" root cause
+
+`designs/edge-rationale-remediation-plan.md` diagnosed the missing rationales as an *origin gap*
+("created before the rationale-required prompt landed"). Git history in `../ai-triad-data`
+(`taxonomy/Origin/edges.json`) refutes that: the rationales existed and were **destroyed by the
+`workflow-app` data pipeline**, twice.
+
+| date | commit | edges w/ rationale | event |
+|------|--------|--------------------|-------|
+| 2026-07-24 | `ba3128f5` | **33,448 / 33,454** (incl. 25,759 approved) | last good state |
+| 2026-08-08 | `904feb92` | 165 | **WIPE #1** — pipeline full-tree add drops the field |
+| 2026-08-15 | `b5a76c8e` | 2,440 | t/2679 backfilled 2,275 approved rationales |
+| 2026-08-20 | `9d019c9e` | 2 | **WIPE #2** — same pipeline destroys the backfill |
+
+The 2026-08-11 remediation plan scanned the **post-wipe-#1** state (165) and mistook the symptom
+for the origin. The serializer (`lib/edges/serializeEdges.ts` / `Write-EdgesFile.ps1`) is not at
+fault — it preserves every field per edge. The drop is upstream, in the edge *rebuild*.
+
+**Bug site (traced by TL, e/120#5):** the `workflow-app` "edges" step is a thin shell-out —
+`pipeline.ts:289` → **`scripts/AITriad/Public/Invoke-EdgeDiscovery.ps1`** (PowerShell-owned,
+in-repo; the app is just the trigger). On a full-tree run it re-proposes edges and writes them
+**without carrying forward the existing `rationale`** for edges that already had one, then
+persists via `Write-EdgesFile` (L723/746). So the destroyer *does* route through the shared
+serializer — which is what makes the write-boundary regression assertion the primary catch (Part
+B). This writer was never in the remediation plan's inventory (§1a).
+
+**Consequence:** the fix is not LLM backfill of 33k edges. It is (A) **git-restore** of the
+original discovery-time text + (B) a **regression gate** that catches the drop + a pipeline fix
+(pipeline is DevOps-owned; see §Handoff).
+
+## Part A — Restore procedure
+
+### Edge identity: composite, not `id`
+Edges carry **no `id` field**. Identity is the composite **`(source, target, type)`**. The
+"id-keyed restore" requested in e/119 is therefore **composite-keyed**. (Empirically verified:
+0/33,580 current and 0/33,454 old edges have an `id`.)
+
+### Coverage (measured against the live file, 2026-08-20 state)
+
+| bucket | count |
+|--------|-------|
+| current edges | 33,580 |
+| already carry rationale (untouched) | 2 (both `debate-reflection`) |
+| **restorable from `ba3128f5` by composite key** | **33,399** (approved 25,710; conf ≥0.75 → 27,608) |
+| no source in `ba3128f5` — genuine generation gap | 179 |
+| **result after restore** | **33,401 / 33,580 (99.5%)** carry rationale |
+
+The 179 gap edges were created *after* the Jul-24 snapshot: 173 discovered 2026-08, 6 in 2026-03
+(re-keyed since). By model: `gemini-3.5-flash-lite` 119, `gemini-2.5-flash` 50, `debate-reflection`
+10. These — and *only* these — are the true "needs generation" cohort (LLM backfill or the
+embedding-first templated rationale). The gap list is emitted as `gap_new_edges.json` by the
+analysis run.
+
+### Byte-safety (proven, not asserted)
+The restore is a **minimal, reversible** edit:
+- `rationale` is inserted **immediately after `confidence`**, matching its original placement.
+- Every other key keeps its exact current position — the current file has **17 distinct per-edge
+  key orderings** (weight / modulated_weight / strength / discovered_by vary); we never reorder.
+- **Strip-back proof:** removing only the rationales we add and re-serializing reproduces the
+  current file **byte-for-byte** (`STRIP-ADDED-ONLY == current blob: True`). The apply script
+  runs this proof every invocation and **aborts, writing nothing,** if it fails.
+- Output matches the compact hybrid contract of `serializeEdges.ts` (verified to round-trip the
+  live file byte-for-byte: separators `,`/`:`, LF, single trailing newline).
+
+### Tooling
+`analyses/t2444-rationale-restore/apply_restore.py` — self-contained, self-verifying. Does **not**
+commit; writes `<current>.restored` and prints the report above. Run:
+```
+git -C ../ai-triad-data show ba3128f5:taxonomy/Origin/edges.json > /tmp/edges_ba3128f5.json
+python apply_restore.py --current ../ai-triad-data/taxonomy/Origin/edges.json --source /tmp/edges_ba3128f5.json
+```
+
+### Sequencing (load-bearing)
+**Do not restore until the pipeline destroyer is fixed.** Both prior wipes prove the field is
+destroyed on the next full-tree pipeline run; t/2679's backfill died in 5 days. Restore *after*
+the upstream edge-build fix lands, then let the regression gate (Part B) hold the line.
+
+## Part B — Regression / count-floor gate spec
+
+**Requirement (e/119 ask #1):** the gate must fire when a write **drops `rationale` from edges
+that previously had it** — a *regression*, not merely "a new edge lacks rationale." The
+remediation plan's §2a gate ("new edge lacks rationale") would have caught **neither** wipe,
+because the pipeline rewrites *all* edges and both wipes removed the field from pre-existing ones.
+
+### Signal
+Per-edge, keyed by composite `(source, target, type)`, comparing the **incoming** `edges.json`
+against the **base** (committed) version:
+```
+regressed = { e : base[e].rationale is non-empty  AND  incoming[e].rationale is empty/absent }
+```
+Gate **fails** if `|regressed| > THRESHOLD`. Recommended `THRESHOLD = 0` (any rationale-bearing
+edge losing its rationale is a defect). A count-floor variant — fail if
+`count(rationale) < floor(base_count * (1 - tolerance))` — is a weaker backstop; prefer the
+per-edge regression check as primary because it localizes *which* edges regressed for the failure
+message.
+
+### Placement (two non-redundant arms — coverage confirmed by TL's trace, e/120#5)
+Both arms are wanted; they cover different writer populations. The bug-site trace (above) settles
+which arm catches *this* incident vs. the *class*:
+
+1. **Write-EdgesFile serializer assertion — PRIMARY (catches this incident).** A per-edge
+   regression check at the shared sink (`Write-EdgesFile.ps1` / `serializeEdgesJson`): throw if a
+   write drops `rationale` from an edge that had it on disk (composite-keyed vs the current
+   `edges.json`). Because `Invoke-EdgeDiscovery` — the actual destroyer — writes **through**
+   `Write-EdgesFile` (L723/746), this arm catches the exact wipe, and every other in-repo edge
+   writer at the sink (same centralize-at-the-sink pattern as the t/2902 dirty-tree guard).
+   **PowerShell owns**; wire with TL two-arm GV. (§2a's serializer assertion, but *regression*-
+   scoped, not *new-edge*-scoped.)
+2. **CI diff-gate — DEFENSE-IN-DEPTH (catches the future class, not this incident).** Committed
+   `edges.json` base→HEAD (wired like `npm run verify:config`): fail on any per-edge rationale
+   regression. Covers any path that ever **bypasses** `Write-EdgesFile` — a future direct writer,
+   a manual edit, a raw file replacement. TL designs/routes this arm.
+
+**Coverage story (corrected — inverts the e/120#4 framing):** serializer arm = *this* incident
+(primary), CI-gate = *future bypass* (defense-in-depth). Stated explicitly so the serializer arm
+is not undersold: it is the load-bearing catch here precisely because the pipeline is **not**
+external to the serializer.
+
+### Two-arm verification (required before it can block prod)
+Per the prevention-per-incident / gate-signal-integrity rules, prove **both arms**:
+- **Failing arm:** a deliberately-regressed edge (strip rationale from one previously-bearing
+  edge) makes the gate exit non-zero, naming the regressed edge(s).
+- **Clean arm:** the current→restored diff (which only *adds* rationale) passes with zero noise;
+  an unrelated edge edit that touches no rationale passes silently.
+- **Reliability:** deterministic, no network, fast enough to block — a flaky blocking gate is the
+  next incident.
+- Config co-located at point of use.
+
+### Ownership / routing
+- The **gate** touches CI/pipeline routes → **Main (TL)** for Gate Verification.
+- The **serializer assertion** in `lib/edges/` / `scripts/AITriad/` is Shared-Lib / PowerShell
+  scope — CL specifies, they implement.
+- The **`workflow-app` pipeline edge-build fix** (the actual destroyer) is **outside CL scope** —
+  DevOps / pipeline owner (resolve via `resolve_owner`). CL provides the evidence; restoring data
+  without this fix resets the clock.
+
+## Handoff checklist
+- [ ] Pipeline owner: audit + fix `workflow-app` edge-build so it preserves `rationale`.
+- [ ] TL: Gate Verification (two-arm) for the CI regression gate.
+- [ ] Shared-Lib / PS: regression assertion in the shared serializers.
+- [ ] Data owner: run `apply_restore.py`, land the restored `edges.json` (**after** the pipeline fix).
+- [ ] CL (Main): correct `edge-rationale-remediation-plan.md`; decide LLM/templated backfill for
+      the 179 gap edges; reframe PR #1426 (harness now screens *restored* rationales).


### PR DESCRIPTION
## Summary

Deliverables for the edge-rationale data-loss incident (parent **t/2444**), split out from CL Main's PR #1426 so each PR stays coherent.

**Root-cause correction:** the missing edge rationales were **not** a "prompt never asked" origin gap. Git history in `../ai-triad-data` shows the `workflow-app` pipeline wiped `rationale` from ~33k edges on 2026-08-08 and again on 2026-08-20 (destroying the t/2679 backfill 5 days after it landed).

## Files (all in `research/comp-linguist`)

- **`analyses/t2444-rationale-restore/apply_restore.py`** — self-verifying restore tool (feeds **t/2946**). Composite-keyed `(source,target,type)` — edges carry no `id`. Byte-safe: inserts `rationale` after `confidence`, preserves every other byte, and a **strip-back proof** reproduces the current file byte-for-byte or it aborts and writes nothing. Restores **33,399/33,580 → 99.5%**. Does not commit.
- **`designs/edge-rationale-restore-and-gate-spec.md`** — restore evidence + the **regression-gate spec** (Part B, for TL Gate Verification under **t/2945**): per-edge regression check, two non-redundant arms — serializer assertion guards in-repo writers, CI diff-gate is the **only** arm covering the external pipeline.
- **`analyses/t2444-rationale-restore/gap-backfill-prompt.md`** — rationale-only reconstruction prompt for the **179** genuinely-new post-wipe edges (**t/2946 Phase 2**), tagged `rationale_source=backfill`.

## Safety

Docs + one standalone analysis script; touches no build package. The restore tool **must not be run until t/2945 lands** the pipeline fix — a full-tree pipeline run before the fix would wipe the restore (exactly what killed t/2679). The tool's no-commit guard enforces this at the artifact level.

Refs t/2444, t/2945 (gate spec), t/2946 (restore tool + gap prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
