### PR TITLE
fix(scripts): warn-first edge-rationale-regression guard at Write-EdgesFile (Arm 1, t/2945)

### DIFF
--- a/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
+++ b/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# ── Arm 1: edge-rationale-regression guard (t/2945, TL design e/120#19) ────────
+# Incident: a whole-file edges.json save dropped `rationale` from ~33k edges that had it
+# (a rationale-only field projection; every other field byte-identical) — the taxonomy-editor
+# load-list-then-save round-trip (CL.Investigate1 e/120#20). This guard funnels at the PS
+# serialization sink (Write-EdgesFile), so it fires on the pipeline RE-EMIT (Invoke-EdgeDiscovery
+# append-preserves the already-stripped set and re-writes it here) and on every in-repo PS
+# edge writer. NOTE (coverage, CL.Investigate1 e/120#22/#23): the editor/server saves write
+# through the TS `writeEdgesFile` twin + server PUT, NOT this PS sink — those need the TS-side
+# guard / Arm 2 (CI diff vs HEAD). This is the PS-writer arm only.
+#
+# Rule: an edge that carries a non-empty `rationale` in the HEAD/committed edges.json must not
+# be written rationale-less (composite key source|type|target). Baseline is HEAD (committed),
+# NOT on-disk — an intra-run checkpoint write can poison an on-disk baseline (CL Main e/120#13).
+#
+# Gate Promotion / warn-first (t/2683): Phase 1 = WARN (loud, does not throw). Phase 2 =
+# Block (throw New-ActionableError) after a real-data clean cycle + TL GV. Mode resolves from
+# $env:AI_TRIAD_EDGE_RATIONALE_GATE (Off|Warn|Block); default Warn. Fail-OPEN on any
+# baseline-resolution failure (not a git repo / path not in HEAD / parse error) — the guard
+# must never block a legitimate write because it couldn't read the baseline.
+
+function Get-EdgesFromHead {
+    # Return the `edges` array from the committed (HEAD) version of $Path, or $null on any
+    # failure (fail-open). git is invoked via PowerShell (not the Bash tool) to avoid the
+    # MSYS colon-revspec path-mangling caveat (root AGENTS.md, Git Forensics).
+    [OutputType([object[]])]
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+    try {
+        $full = [System.IO.Path]::GetFullPath($Path)
+        $dir  = Split-Path -Parent $full
+        if (-not (Test-Path -LiteralPath $dir)) { return $null }
+        $top = & git -C $dir rev-parse --show-toplevel 2>$null
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($top)) { return $null }
+        $top = ([string]$top).Trim()
+        $rel = ([System.IO.Path]::GetRelativePath($top, $full)) -replace '\\', '/'
+        $json = & git -C $top show "HEAD:$rel" 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $json) { return $null }
+        $parsed = ($json -join "`n") | ConvertFrom-Json
+        if ($parsed.PSObject.Properties['edges']) { return @($parsed.edges) }
+        return $null
+    } catch { return $null }
+}
+
+function Test-EdgeRationaleRegression {
+    <#
+    .SYNOPSIS
+        Arm 1 guard (t/2945). Warn (or in Block mode, throw) when a write to edges.json would
+        drop `rationale` from an edge that carries one in HEAD. Composite-keyed (source|type|target).
+    .OUTPUTS
+        [int] the number of regressing edges (0 = clean). Never throws in Warn/Off mode.
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param(
+        [Parameter(Mandatory)] $EdgesData,
+        [string]$Path = '',
+        # Injectable baseline (array of edge objects) — for tests/callers with a known baseline.
+        # When $null, the baseline is resolved from HEAD:$Path.
+        $BaselineEdges = $null,
+        [ValidateSet('', 'Off', 'Warn', 'Block')]
+        [string]$Mode = ''
+    )
+    Set-StrictMode -Version Latest
+
+    if (-not $Mode) {
+        $envMode = [Environment]::GetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE')
+        $Mode = switch -Regex ("$envMode") {
+            '^(?i)off$'   { 'Off' }
+            '^(?i)block$' { 'Block' }
+            default       { 'Warn' }
+        }
+    }
+    if ($Mode -eq 'Off') { return 0 }
+
+    if ($null -eq $BaselineEdges) {
+        $BaselineEdges = Get-EdgesFromHead -Path $Path
+        if ($null -eq $BaselineEdges) { return 0 }   # no HEAD baseline -> fail-open
+    }
+
+    # Composite keys that carry a non-empty rationale in the baseline.
+    $hadRationale = @{}
+    foreach ($e in @($BaselineEdges)) {
+        if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
+        $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
+        if (-not [string]::IsNullOrWhiteSpace($r)) {
+            $hadRationale["$($e.source)|$($e.type)|$($e.target)"] = $true
+        }
+    }
+    if ($hadRationale.Count -eq 0) { return 0 }
+
+    # Edges in this write that had rationale in HEAD but would be written without one.
+    $lost = [System.Collections.Generic.List[string]]::new()
+    foreach ($e in @($EdgesData.edges)) {
+        if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
+        $key = "$($e.source)|$($e.type)|$($e.target)"
+        if ($hadRationale.ContainsKey($key)) {
+            $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
+            if ([string]::IsNullOrWhiteSpace($r)) { [void]$lost.Add($key) }
+        }
+    }
+    if ($lost.Count -eq 0) { return 0 }
+
+    $sample  = (@($lost) | Select-Object -First 3) -join ', '
+    $leaf    = if ($Path) { [System.IO.Path]::GetFileName($Path) } else { 'edges.json' }
+    $problem = "$($lost.Count) edge(s) carrying a rationale in HEAD would be written WITHOUT one " +
+               "(composite key source|type|target). Sample: $sample. This is the edge-rationale wipe class (t/2945)."
+    $steps   = @(
+        'A whole-file edges save MUST re-merge rationale from HEAD/on-disk by composite key before writing — never persist a rationale-stripped list payload (the taxonomy-editor load-list->save round-trip, t/2945).',
+        'If this removal is intentional, set $env:AI_TRIAD_EDGE_RATIONALE_GATE=Off for the run.'
+    )
+
+    if ($Mode -eq 'Block') {
+        throw (New-ActionableError -Goal "Preserve edge rationale on write to '$leaf'" `
+            -Problem $problem -Location 'Write-EdgesFile / Test-EdgeRationaleRegression' -NextSteps $steps -PassThru)
+    }
+    # Phase 1 — WARN (loud, does not throw).
+    Write-Warning ("EDGE-RATIONALE REGRESSION (would-block; t/2945 Arm 1, warn-first) — $problem Next steps: " + ($steps -join ' | '))
+    return $lost.Count
+}

--- a/scripts/AITriad/Private/Write-EdgesFile.ps1
+++ b/scripts/AITriad/Private/Write-EdgesFile.ps1
@@ -36,6 +36,16 @@ function Write-EdgesFile {
         [string]$Path
     )
 
+    # t/2945 Arm 1 (warn-first) — edge-rationale-regression guard. Every PS edge write funnels
+    # through this sink, so guarding here covers all in-repo PS writers + the pipeline re-emit
+    # (Invoke-EdgeDiscovery append-preserves an upstream-stripped set and re-writes it here).
+    # Best-effort: skip cleanly if the guard isn't loaded (Build-Module standalone dot-sources
+    # this file without the guard chain, like the t/2902 sink). Fail-open on any baseline miss.
+    # Phase 1 = WARN (does not throw); $env:AI_TRIAD_EDGE_RATIONALE_GATE=Block promotes it.
+    if (Get-Command Test-EdgeRationaleRegression -ErrorAction SilentlyContinue) {
+        $null = Test-EdgeRationaleRegression -EdgesData $EdgesData -Path $Path
+    }
+
     $sb = [System.Text.StringBuilder]::new()
     [void]$sb.Append("{`n")
 

--- a/tests/EdgeRationaleRegression.Tests.ps1
+++ b/tests/EdgeRationaleRegression.Tests.ps1
@@ -1,0 +1,131 @@
+# Tag: edges (t/2945)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Both-arms GV for the Arm-1 edge-rationale-regression guard (t/2945, TL design e/120#19/#24).
+    FIRE  = a write dropping rationale from an edge rationaled in the baseline -> Block throws /
+            Warn emits a loud warning and reports the count.
+    CLEAN = a normal add-only, rationale-preserving write -> passes SILENTLY, zero noise.
+    Baseline is HEAD/committed (composite-keyed source|type|target). The injected-baseline arms
+    are deterministic (no git); the git-backed context proves the HEAD-resolution path end-to-end.
+    Edge objects are built in test scope and passed into InModuleScope (the guard is Private).
+    Coverage note (CL.Investigate1 e/120#22): this PS-sink guard covers PS writers + the pipeline
+    re-emit; the editor/server saves use the TS writeEdgesFile twin and are guarded separately.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    function New-Edge {
+        param([string]$Source, [string]$Type, [string]$Target, [string]$Rationale = $null)
+        $o = [ordered]@{ source = $Source; type = $Type; target = $Target; confidence = 0.95; status = 'approved' }
+        if ($null -ne $Rationale) { $o['rationale'] = $Rationale }
+        [PSCustomObject]$o
+    }
+    function New-EdgesData {
+        param([object[]]$Edges)
+        [PSCustomObject]@{ _schema_version = '1.0.0'; edges = @($Edges) }
+    }
+}
+
+Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges' {
+
+    BeforeEach {
+        $script:Baseline = @(
+            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002' 'because X reinforces Y'),
+            (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W')
+        )
+    }
+
+    It 'FIRE (Warn): a write dropping rationale from a HEAD-rationaled edge warns and counts it' {
+        $write = New-EdgesData @(
+            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002'),                          # rationale dropped
+            (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W')
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            $n = Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningVariable w -WarningAction SilentlyContinue
+            $n | Should -Be 1
+            ($w -join ' ') | Should -Match 'EDGE-RATIONALE REGRESSION'
+        }
+    }
+
+    It 'FIRE (Block): the same write THROWS New-ActionableError and writes nothing' {
+        $write = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )       # rationale dropped
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Throw
+        }
+    }
+
+    It 'CLEAN: a rationale-preserving add-only write passes SILENTLY with ZERO noise' {
+        $write = New-EdgesData @(
+            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002' 'because X reinforces Y'),
+            (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W'),
+            (New-Edge 'acc-005' 'WEAKENS'     'saf-006' 'a freshly discovered edge')   # new, rationaled
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            $n = Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningVariable w -WarningAction SilentlyContinue
+            $n | Should -Be 0
+            @($w).Count | Should -Be 0   # zero noise on a legit write (gate signal integrity)
+        }
+    }
+
+    It 'CLEAN: a NEW edge with an empty rationale is not a regression (never had one in HEAD)' {
+        $write = New-EdgesData @(
+            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002' 'because X reinforces Y'),
+            (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W'),
+            (New-Edge 'acc-009' 'ASSUMES'     'saf-010' '')   # new edge, blank rationale — allowed
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn | Should -Be 0
+        }
+    }
+
+    It 'Off mode is a no-op even on a real regression' {
+        $write = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Off | Should -Be 0
+        }
+    }
+}
+
+Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution (git-backed, real repo)' -Tag 'edges' {
+
+    It 'resolves the baseline from HEAD and fires on a same-file rationale strip; clean on add-only' {
+        $repo = Join-Path $TestDrive 'datarepo'
+        $tax  = Join-Path $repo 'taxonomy/Origin'
+        New-Item -ItemType Directory -Path $tax -Force | Out-Null
+        $edgesPath = Join-Path $tax 'edges.json'
+
+        $committed = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'committed rationale') )
+        $strip     = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
+        $ok        = New-EdgesData @(
+            (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'committed rationale'),
+            (New-Edge 'acc-007' 'WEAKENS'  'saf-008' 'new')
+        )
+
+        InModuleScope AITriad -Parameters @{ Committed = $committed; Strip = $strip; Ok = $ok; EdgesPath = $edgesPath; Repo = $repo } {
+            param($Committed, $Strip, $Ok, $EdgesPath, $Repo)
+            Write-EdgesFile -EdgesData $Committed -Path $EdgesPath   # no HEAD yet -> guard fail-open no-op
+            Push-Location $Repo
+            try {
+                git init -q 2>$null
+                git config user.email 't@t' 2>$null; git config user.name 't' 2>$null
+                git add -A 2>$null; git commit -q -m 'baseline' 2>$null
+            } finally { Pop-Location }
+
+            # Baseline resolved from HEAD: a same-file strip regresses.
+            Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+            # Add-only preserving write is clean against the same HEAD.
+            Test-EdgeRationaleRegression -EdgesData $Ok -Path $EdgesPath -Mode Warn | Should -Be 0
+        }
+    }
+}


### PR DESCRIPTION
## Arm 1 (warn-first): edge-rationale-regression guard at `Write-EdgesFile` — t/2945

**DRAFT — gate-touching, routed to Main (TL) for both-arms GV.** The PS-side arm of the three-arm coverage map (TL e/120#24). Warn-first per Gate Promotion (t/2683) — **Phase 1 = WARN, does not throw.**

### Coverage (precise)
- **Covers:** all in-repo PS edge writers **+ the pipeline re-emit** — `Invoke-EdgeDiscovery` append-preserves an upstream-stripped set and re-writes it through this PS sink.
- **Does NOT cover** the actual incident site (taxonomy-editor `save-edges` IPC + server PUT), which writes through the **TS** `writeEdgesFile` twin — that needs the TS write-guard + Arm 2 (CI diff), owned elsewhere (CL.Investigate1 e/120#22, TL #24).

### Mechanism
Per-edge, composite key `source|type|target`: an edge carrying a non-empty `rationale` in **HEAD/committed** must not be written rationale-less. HEAD baseline (not on-disk — an intra-run checkpoint write can poison an on-disk baseline). Funnels at the sink (best-effort `Get-Command`, like the t/2902 dirty-tree guard) → covers current + future PS writers. **Fail-OPEN** on any baseline miss (not a repo / path not in HEAD / parse error). git invoked via PowerShell (not Bash) to dodge the MSYS colon-revspec caveat. `$env:AI_TRIAD_EDGE_RATIONALE_GATE=Off|Warn|Block` (default Warn); `Block` = Phase 2.

### Both-arms GV evidence (offline, deterministic + git-backed real-repo) — 6/6
- **FIRE (Warn):** drop rationale from a HEAD-rationaled edge → returns count 1 + loud `EDGE-RATIONALE REGRESSION` warning.
- **FIRE (Block):** same → throws `New-ActionableError`.
- **CLEAN:** rationale-preserving add-only → passes **silently, zero warnings**.
- New edge with blank rationale (never had one) → not a regression.
- **Off** mode → no-op even on a real regression.
- **git-backed:** commit a rationaled edges.json as HEAD → a same-file strip fires (count 1); an add-only preserving write is clean — proves the HEAD-resolution path end-to-end on a real repo.

Edge-writer regression (Invoke-EdgeDiscovery / RationaleBackfill / Get-Edge / DataWriteSinkGuard) **25/25**; parse-clean.

### Promotion to Phase 2 (Block)
After this lands as WARN + a real-data clean cycle against `ba3128f5`'s edges.json (I'll run the `ba3128f5`-as-HEAD add-only harness and attach zero-noise evidence), flip default → Block under your GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
