### PR TITLE
feat(edges): add rationale_source provenance field to Edge type (t/2943)

### DIFF
--- a/lib/debate/taxonomyTypes.ts
+++ b/lib/debate/taxonomyTypes.ts
@@ -289,6 +289,25 @@ export type CanonicalEdgeType =
 /** Accept both canonical and legacy edge types — backward-compat handler (kept permanently). */
 export type EdgeType = CanonicalEdgeType | (string & {});
 
+/**
+ * Provenance of an edge's `rationale` (t/2943, CL design edge-rationale-source-marker.md).
+ * Closed vocabulary; absent = legacy/unknown (the pre-marker era):
+ *   - `discovery`          — LLM classification at edge-discovery time (contemporaneous)
+ *   - `embedding-template` — templated from similarity; no LLM justified it
+ *   - `reflection`         — emitted by a debate reflection proposal
+ *   - `restore`            — original discovery-time text git-restored after a data-loss event
+ *   - `backfill`           — post-hoc LLM reconstruction from node content (last resort; t/2679, now void)
+ *   - `human`              — manually authored/edited by a curator
+ * No validation gate here — that's the separate prospective-gate tranche (t/2444 plan 2a).
+ */
+export type EdgeRationaleSource =
+  | 'discovery'
+  | 'embedding-template'
+  | 'reflection'
+  | 'restore'
+  | 'backfill'
+  | 'human';
+
 export interface Edge {
   source: string;
   target: string;
@@ -299,6 +318,13 @@ export interface Edge {
   /** Weight modulated by endpoint confidence/priority. Computed by modulateEdgeWeights.ts. */
   modulated_weight?: number;
   rationale?: string;
+  /**
+   * Provenance of `rationale` (t/2943). One of {@link EdgeRationaleSource}; absent = legacy/unknown.
+   * `(string & {})` keeps the closed vocabulary as documentation/autocomplete while tolerating any
+   * value (no validation gate yet — prospective-gate tranche). Invariant (writers): set alongside a
+   * non-empty `rationale` in the same write; a rationale without a source is valid only for legacy rows.
+   */
+  rationale_source?: EdgeRationaleSource | (string & {});
   status: EdgeStatus;
   discovered_at: string;
   model: string;

--- a/lib/edges/serializeEdges.test.ts
+++ b/lib/edges/serializeEdges.test.ts
@@ -73,4 +73,23 @@ describe('serializeEdgesJson', () => {
   it('throws an ActionableError (not a bare TypeError) on a top-level undefined value', () => {
     expect(() => serializeEdgesJson({ a: 1, bad: undefined, edges: [] })).toThrow(/undefined value/);
   });
+
+  // t/2943: the serializer emits each edge via JSON.stringify(edge), so it preserves every
+  // field including the new rationale_source marker — confirm round-trip survival explicitly.
+  it('preserves an edge rationale_source through serialize→parse (t/2943)', () => {
+    const edge = {
+      source: 'acc-beliefs-001', target: 'saf-beliefs-042', type: 'SUPPORTS',
+      rationale: 'saf-042 grants the premise acc-001 asserts', rationale_source: 'backfill',
+    };
+    const output = serializeEdgesJson({ _schema_version: '1.0.0', edges: [edge] });
+    const round = JSON.parse(output);
+    expect(round.edges[0].rationale_source).toBe('backfill');
+    expect(round.edges[0]).toEqual(edge); // whole edge unchanged, field order intact
+  });
+
+  it('leaves an edge without rationale_source unchanged — absent stays absent (t/2943)', () => {
+    const edge = { source: 'acc-beliefs-001', target: 'saf-beliefs-042', type: 'SUPPORTS' };
+    const round = JSON.parse(serializeEdgesJson({ edges: [edge] }));
+    expect('rationale_source' in round.edges[0]).toBe(false);
+  });
 });


### PR DESCRIPTION
Implements t/2943 (Shared Lib tranche of CL design `edge-rationale-source-marker.md`, t/2444). Self-cert `/trivial-change` (additive optional field + test, no behavior change, no validation gate).

## Change
- **`lib/debate/taxonomyTypes.ts`** — new `EdgeRationaleSource` closed-vocabulary type (`discovery | embedding-template | reflection | restore | backfill | human`) + `rationale_source?: EdgeRationaleSource | (string & {})` on `Edge`. Mirrors the file''s existing `EdgeType` pattern — documented enum + autocomplete while tolerating legacy/unknown values (no validation gate; that''s the separate prospective-gate tranche). Absent = legacy/unknown. Additive/optional — legacy edges unaffected.
- **`lib/edges/serializeEdges.test.ts`** — round-trip tests: an edge with `rationale_source` survives serialize→parse unchanged (the serializer already preserves all fields via `JSON.stringify(edge)`), and an edge without it stays absent.

## Acceptance
- ✔ `rationale_source` typed on the edge schema (optional, documented enum).
- ✔ Round-trip test: edge with `rationale_source` survives serialize→parse unchanged.
- ✔ No behavior change — absent stays absent.

## Two notes for CL
1. **`restore` vocab value:** I implemented the design doc''s **6**-value vocabulary (incl. `restore`); the ticket''s enum list had only 5 (omitted `restore`). Design doc is authoritative + `restore` is load-bearing (git-restored original vs backfill). Flagging the ticket/doc mismatch.
2. **`Write-EdgesFile` (PowerShell):** the design routes its preservation to PowerShell (scripts scope), not this lib PR. This PR covers the TS serializer (`serializeEdgesJson`) + type. A PS Pester round-trip for `Write-EdgesFile` belongs to the scripts owner — flagging so that half isn''t assumed done here.

## Verify
`lib/edges` suite green (11), `tsc` + `eslint` clean.

Also touches `lib/debate/taxonomyTypes.ts` (DebateTool child scope) — a trivial additive field on a shared taxonomy type, no debate-logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)