### PR TITLE
fix(scripts): edge-rationale guard Phase-2 hardening — fail-open + observability + HEAD caching (t/2947 code half)

### DIFF
--- a/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
+++ b/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
@@ -15,33 +15,90 @@
 # be written rationale-less (composite key source|type|target). Baseline is HEAD (committed),
 # NOT on-disk — an intra-run checkpoint write can poison an on-disk baseline (CL Main e/120#13).
 #
-# Gate Promotion / warn-first (t/2683): Phase 1 = WARN (loud, does not throw). Phase 2 =
-# Block (throw New-ActionableError) after a real-data clean cycle + TL GV. Mode resolves from
-# $env:AI_TRIAD_EDGE_RATIONALE_GATE (Off|Warn|Block); default Warn. Fail-OPEN on any
-# baseline-resolution failure (not a git repo / path not in HEAD / parse error) — the guard
-# must never block a legitimate write because it couldn't read the baseline.
+# NEAR-KEY NOTE (CL e/120#30, restore pre-flight t/2946#4): source|type|target is a NEAR-key,
+# not a strict key — on the live 33,580-edge file 3 keys carry 2 genuinely distinct edges each
+# (differing discovered_at/model/confidence). Benign for THIS guard today (0 of the 3 have
+# mixed rationale presence), but it is set semantics: if two edges share a key and only one had
+# rationale, the guard reasons over the key, not the specific edge. The twin-aware identity
+# (disambiguate on discovered_at+model, else refuse-and-log) lives in the shared re-merge util
+# + restore (TL e/120#37, t/2946 AC) — this presence guard can't see cross-attribution.
+#
+# Gate Promotion / warn-first (t/2683): Phase 1 = WARN (landed, PR #1430 / 491c7554). Phase 2
+# (this) = fail-open hardening + observability + baseline caching; Block (throw) flips default
+# only after the positive real-data cycle + TL GV (t/2947). Mode resolves from
+# $env:AI_TRIAD_EDGE_RATIONALE_GATE (Off|Warn|Block); default Warn.
+#
+# FAIL-OPEN CONTRACT (CL e/120#30 Finding 1, TL #32): the guard must NEVER throw except on a
+# genuine Block-mode regression. Any inability to analyze the input (no HEAD baseline, an
+# edges-less/odd-shaped payload, a parse error) returns 0 without throwing — a guard that cannot
+# read its baseline must not block a legitimate write. Every fail-open branch emits a
+# DISTINGUISHABLE Write-Verbose (CL #30 Finding 2) so a permanently-dead gate is not
+# byte-identical to a clean pass; the promotion evidence asserts the baseline RESOLVED
+# (positive), not merely that nothing warned.
+
+# Per-run HEAD-baseline cache (TL e/120#27 (a) / #34): `git show HEAD:edges.json` + parse of a
+# ~19 MB file fires on EVERY Write-EdgesFile call, and Invoke-EdgeDiscovery has ~5 sink calls
+# per run. Resolve once per (repo-relative path @ HEAD sha) and reuse within the process. Keyed
+# by HEAD sha so a new commit mid-process invalidates; $null (fail-open) results are cached too
+# to avoid re-running a failing lookup every call.
+$script:EdgeHeadBaselineCache = @{}
 
 function Get-EdgesFromHead {
     # Return the `edges` array from the committed (HEAD) version of $Path, or $null on any
-    # failure (fail-open). git is invoked via PowerShell (not the Bash tool) to avoid the
-    # MSYS colon-revspec path-mangling caveat (root AGENTS.md, Git Forensics).
+    # failure (fail-open, with a distinguishable Write-Verbose per cause). git is invoked via
+    # PowerShell (not the Bash tool) to avoid the MSYS colon-revspec path-mangling caveat.
     [OutputType([object[]])]
     param([string]$Path)
-    if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+    if ([string]::IsNullOrWhiteSpace($Path)) { Write-Verbose 'edge-rationale baseline: no path supplied — fail-open.'; return $null }
     try {
         $full = [System.IO.Path]::GetFullPath($Path)
         $dir  = Split-Path -Parent $full
-        if (-not (Test-Path -LiteralPath $dir)) { return $null }
+        if (-not (Test-Path -LiteralPath $dir)) { Write-Verbose "edge-rationale baseline: directory '$dir' does not exist — fail-open."; return $null }
         $top = & git -C $dir rev-parse --show-toplevel 2>$null
-        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($top)) { return $null }
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($top)) { Write-Verbose "edge-rationale baseline: '$dir' is not inside a git work tree — fail-open."; return $null }
         $top = ([string]$top).Trim()
         $rel = ([System.IO.Path]::GetRelativePath($top, $full)) -replace '\\', '/'
+
+        # Per-run cache keyed by path @ HEAD sha (TL e/120#27(a)).
+        $headSha = & git -C $top rev-parse HEAD 2>$null
+        $headSha = if ($LASTEXITCODE -eq 0) { ([string]$headSha).Trim() } else { '' }
+        $cacheKey = "$top|$rel@$headSha"
+        if ($headSha -and $script:EdgeHeadBaselineCache.ContainsKey($cacheKey)) {
+            Write-Verbose "edge-rationale baseline: cache hit for '$rel@$($headSha.Substring(0,[Math]::Min(8,$headSha.Length)))'."
+            return $script:EdgeHeadBaselineCache[$cacheKey]
+        }
+
+        $result = $null
         $json = & git -C $top show "HEAD:$rel" 2>$null
-        if ($LASTEXITCODE -ne 0 -or -not $json) { return $null }
-        $parsed = ($json -join "`n") | ConvertFrom-Json
-        if ($parsed.PSObject.Properties['edges']) { return @($parsed.edges) }
+        if ($LASTEXITCODE -ne 0 -or -not $json) {
+            Write-Verbose "edge-rationale baseline: 'HEAD:$rel' not found in the repo (new file / not committed) — fail-open."
+        }
+        else {
+            $parsed = ($json -join "`n") | ConvertFrom-Json
+            if ($parsed.PSObject.Properties['edges']) { $result = @($parsed.edges) }
+            else { Write-Verbose 'edge-rationale baseline: HEAD edges.json has no edges array — fail-open.' }
+        }
+        if ($headSha) { $script:EdgeHeadBaselineCache[$cacheKey] = $result }   # cache incl. $null (dead-lookup) results
+        return $result
+    } catch {
+        Write-Verbose "edge-rationale baseline: could not read/parse HEAD edges.json ($($_.Exception.Message)) — fail-open."
         return $null
-    } catch { return $null }
+    }
+}
+
+function Get-EdgesArray {
+    # Robustly extract the edges array from an edges document that may be a PSCustomObject
+    # (the common ConvertFrom-Json shape) OR a hashtable, without throwing under StrictMode.
+    # Returns $null when there is no edges array (an edges-less doc is a legitimate write that
+    # Write-EdgesFile handles — it is generic over top-level keys).
+    param($EdgesData)
+    if ($null -eq $EdgesData) { return $null }
+    if ($EdgesData -is [System.Collections.IDictionary]) {
+        if ($EdgesData.Contains('edges')) { return $EdgesData['edges'] }
+        return $null
+    }
+    if ($EdgesData.PSObject -and $EdgesData.PSObject.Properties['edges']) { return $EdgesData.edges }
+    return $null
 }
 
 function Test-EdgeRationaleRegression {
@@ -50,7 +107,9 @@ function Test-EdgeRationaleRegression {
         Arm 1 guard (t/2945). Warn (or in Block mode, throw) when a write to edges.json would
         drop `rationale` from an edge that carries one in HEAD. Composite-keyed (source|type|target).
     .OUTPUTS
-        [int] the number of regressing edges (0 = clean). Never throws in Warn/Off mode.
+        [int] the number of regressing edges (0 = clean). NEVER throws in Warn/Off mode, and in
+        Block mode throws ONLY on a genuine rationale regression — any inability to analyze the
+        input fails open (returns 0, with a Write-Verbose) and never blocks a legitimate write.
     #>
     [CmdletBinding()]
     [OutputType([int])]
@@ -75,32 +134,46 @@ function Test-EdgeRationaleRegression {
     }
     if ($Mode -eq 'Off') { return 0 }
 
-    if ($null -eq $BaselineEdges) {
-        $BaselineEdges = Get-EdgesFromHead -Path $Path
-        if ($null -eq $BaselineEdges) { return 0 }   # no HEAD baseline -> fail-open
-    }
-
-    # Composite keys that carry a non-empty rationale in the baseline.
-    $hadRationale = @{}
-    foreach ($e in @($BaselineEdges)) {
-        if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
-        $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
-        if (-not [string]::IsNullOrWhiteSpace($r)) {
-            $hadRationale["$($e.source)|$($e.type)|$($e.target)"] = $true
-        }
-    }
-    if ($hadRationale.Count -eq 0) { return 0 }
-
-    # Edges in this write that had rationale in HEAD but would be written without one.
+    # ── Analyze (fail-OPEN): any error building the baseline map or scanning the write payload
+    #    returns 0 without throwing. The intended Block-mode regression throw happens AFTER this
+    #    block, so a genuine regression still blocks while an un-analyzable input never does.
     $lost = [System.Collections.Generic.List[string]]::new()
-    foreach ($e in @($EdgesData.edges)) {
-        if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
-        $key = "$($e.source)|$($e.type)|$($e.target)"
-        if ($hadRationale.ContainsKey($key)) {
-            $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
-            if ([string]::IsNullOrWhiteSpace($r)) { [void]$lost.Add($key) }
+    try {
+        if ($null -eq $BaselineEdges) {
+            $BaselineEdges = Get-EdgesFromHead -Path $Path
+            if ($null -eq $BaselineEdges) { return 0 }   # Get-EdgesFromHead already Write-Verbose'd the cause
         }
+
+        # Composite keys that carry a non-empty rationale in the baseline.
+        $hadRationale = @{}
+        foreach ($e in @($BaselineEdges)) {
+            if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
+            $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
+            if (-not [string]::IsNullOrWhiteSpace($r)) {
+                $hadRationale["$($e.source)|$($e.type)|$($e.target)"] = $true
+            }
+        }
+        if ($hadRationale.Count -eq 0) { Write-Verbose 'edge-rationale guard: HEAD baseline carries no rationaled edges — nothing to protect.'; return 0 }
+
+        # Robustly extract the write payload's edges (edges-less / odd-shaped doc -> fail-open).
+        $writeEdges = Get-EdgesArray -EdgesData $EdgesData
+        if ($null -eq $writeEdges) { Write-Verbose 'edge-rationale guard: write payload has no edges array — fail-open (nothing to check).'; return 0 }
+
+        foreach ($e in @($writeEdges)) {
+            if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
+            $key = "$($e.source)|$($e.type)|$($e.target)"
+            if ($hadRationale.ContainsKey($key)) {
+                $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
+                if ([string]::IsNullOrWhiteSpace($r)) { [void]$lost.Add($key) }
+            }
+        }
+    } catch {
+        # Belt-and-suspenders (TL #32): a guard that cannot analyze the input MUST NOT block a
+        # legitimate write, in any mode. Distinguishable so a dead gate isn't silent.
+        Write-Verbose "edge-rationale guard: unexpected error analyzing the write, fail-open (no throw): $($_.Exception.Message)"
+        return 0
     }
+
     if ($lost.Count -eq 0) { return 0 }
 
     $sample  = (@($lost) | Select-Object -First 3) -join ', '

--- a/tests/EdgeRationaleRegression.Tests.ps1
+++ b/tests/EdgeRationaleRegression.Tests.ps1
@@ -6,12 +6,12 @@
 
 <#
 .SYNOPSIS
-    Both-arms GV for the Arm-1 edge-rationale-regression guard (t/2945, TL design e/120#19/#24).
+    Both-arms GV for the Arm-1 edge-rationale-regression guard (t/2945; Phase-2 hardening t/2947).
     FIRE  = a write dropping rationale from an edge rationaled in the baseline -> Block throws /
             Warn emits a loud warning and reports the count.
     CLEAN = a normal add-only, rationale-preserving write -> passes SILENTLY, zero noise.
-    Baseline is HEAD/committed (composite-keyed source|type|target). The injected-baseline arms
-    are deterministic (no git); the git-backed context proves the HEAD-resolution path end-to-end.
+    Plus (Phase 2): fail-OPEN on odd-shaped input (CL e/120#30 Finding 1) and per-run HEAD
+    baseline caching (TL e/120#27(a)). Baseline is HEAD/committed (composite-keyed).
     Edge objects are built in test scope and passed into InModuleScope (the guard is Private).
     Coverage note (CL.Investigate1 e/120#22): this PS-sink guard covers PS writers + the pipeline
     re-emit; the editor/server saves use the TS writeEdgesFile twin and are guarded separately.
@@ -43,7 +43,7 @@ Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges
 
     It 'FIRE (Warn): a write dropping rationale from a HEAD-rationaled edge warns and counts it' {
         $write = New-EdgesData @(
-            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002'),                          # rationale dropped
+            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002'),
             (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W')
         )
         InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
@@ -55,7 +55,7 @@ Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges
     }
 
     It 'FIRE (Block): the same write THROWS New-ActionableError and writes nothing' {
-        $write = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )       # rationale dropped
+        $write = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
         InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
             param($W, $B)
             { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Throw
@@ -66,13 +66,13 @@ Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges
         $write = New-EdgesData @(
             (New-Edge 'acc-001' 'SUPPORTS'    'saf-002' 'because X reinforces Y'),
             (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W'),
-            (New-Edge 'acc-005' 'WEAKENS'     'saf-006' 'a freshly discovered edge')   # new, rationaled
+            (New-Edge 'acc-005' 'WEAKENS'     'saf-006' 'a freshly discovered edge')
         )
         InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
             param($W, $B)
             $n = Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningVariable w -WarningAction SilentlyContinue
             $n | Should -Be 0
-            @($w).Count | Should -Be 0   # zero noise on a legit write (gate signal integrity)
+            @($w).Count | Should -Be 0
         }
     }
 
@@ -80,7 +80,7 @@ Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges
         $write = New-EdgesData @(
             (New-Edge 'acc-001' 'SUPPORTS'    'saf-002' 'because X reinforces Y'),
             (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W'),
-            (New-Edge 'acc-009' 'ASSUMES'     'saf-010' '')   # new edge, blank rationale — allowed
+            (New-Edge 'acc-009' 'ASSUMES'     'saf-010' '')
         )
         InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
             param($W, $B)
@@ -95,9 +95,26 @@ Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges
             Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Off | Should -Be 0
         }
     }
+
+    It 'FAIL-OPEN: an edges-less document returns 0 and does NOT throw — even with a rationaled baseline, even in Block mode' {
+        # CL e/120#30 Finding 1: the fail-closed deref is DOWNSTREAM of the hadRationale.Count==0
+        # early return, so it only manifests with a NON-empty baseline. Write-EdgesFile is generic
+        # over top-level keys — an edges-less doc is a legit write it handles; the guard must fail
+        # OPEN on it, not hard-throw.
+        $noEdgesObj  = [PSCustomObject]@{ nodes = @() }
+        $noEdgesHash = @{ nodes = @() }
+        InModuleScope AITriad -Parameters @{ O = $noEdgesObj; H = $noEdgesHash; B = $script:Baseline } {
+            param($O, $H, $B)
+            { Test-EdgeRationaleRegression -EdgesData $O -BaselineEdges $B -Mode Warn }  | Should -Not -Throw
+            { Test-EdgeRationaleRegression -EdgesData $H -BaselineEdges $B -Mode Warn }  | Should -Not -Throw
+            { Test-EdgeRationaleRegression -EdgesData $O -BaselineEdges $B -Mode Block } | Should -Not -Throw
+            Test-EdgeRationaleRegression -EdgesData $O -BaselineEdges $B -Mode Warn | Should -Be 0
+            Test-EdgeRationaleRegression -EdgesData $H -BaselineEdges $B -Mode Warn | Should -Be 0
+        }
+    }
 }
 
-Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution (git-backed, real repo)' -Tag 'edges' {
+Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution + caching (git-backed, real repo)' -Tag 'edges' {
 
     It 'resolves the baseline from HEAD and fires on a same-file rationale strip; clean on add-only' {
         $repo = Join-Path $TestDrive 'datarepo'
@@ -114,7 +131,7 @@ Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution (git-backed,
 
         InModuleScope AITriad -Parameters @{ Committed = $committed; Strip = $strip; Ok = $ok; EdgesPath = $edgesPath; Repo = $repo } {
             param($Committed, $Strip, $Ok, $EdgesPath, $Repo)
-            Write-EdgesFile -EdgesData $Committed -Path $EdgesPath   # no HEAD yet -> guard fail-open no-op
+            Write-EdgesFile -EdgesData $Committed -Path $EdgesPath
             Push-Location $Repo
             try {
                 git init -q 2>$null
@@ -122,10 +139,30 @@ Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution (git-backed,
                 git add -A 2>$null; git commit -q -m 'baseline' 2>$null
             } finally { Pop-Location }
 
-            # Baseline resolved from HEAD: a same-file strip regresses.
             Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
-            # Add-only preserving write is clean against the same HEAD.
             Test-EdgeRationaleRegression -EdgesData $Ok -Path $EdgesPath -Mode Warn | Should -Be 0
+        }
+    }
+
+    It 'caches the HEAD baseline per (path @ HEAD) — repeated calls in a run reuse it (TL e/120#27a)' {
+        $repo = Join-Path $TestDrive 'cacherepo'
+        $tax  = Join-Path $repo 'taxonomy/Origin'
+        New-Item -ItemType Directory -Path $tax -Force | Out-Null
+        $edgesPath = Join-Path $tax 'edges.json'
+        $committed = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'committed rationale') )
+        $strip     = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
+
+        InModuleScope AITriad -Parameters @{ Committed = $committed; Strip = $strip; EdgesPath = $edgesPath; Repo = $repo } {
+            param($Committed, $Strip, $EdgesPath, $Repo)
+            Write-EdgesFile -EdgesData $Committed -Path $EdgesPath
+            Push-Location $Repo
+            try { git init -q 2>$null; git config user.email 't@t' 2>$null; git config user.name 't' 2>$null; git add -A 2>$null; git commit -q -m b 2>$null } finally { Pop-Location }
+
+            $script:EdgeHeadBaselineCache = @{}
+            Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+            @($script:EdgeHeadBaselineCache.Keys).Count | Should -BeGreaterThan 0   # baseline cached after first call
+            # Second call resolves from cache and is still correct.
+            Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
         }
     }
 }


### PR DESCRIPTION
## Edge-rationale guard Phase-2 hardening — fail-open + observability + HEAD caching (t/2947 code half)

The WARN guard landed (`491c7554` / PR #1430). Per the deconfliction (TL e/120#34, CL #39/#40): **PowerShell owns the guard CODE; t/2947 (CL) owns the real-data evidence.** This is the code half — the `(a)+(b)` Block-flip prerequisites — **still WARN default** (the Block flip is a later step, gated on CL's `ba3128f5`-as-HEAD positive cycle + TL GV).

### (b) FAIL-OPEN — CL e/120#30 Finding 1 (TL #32)
The guard promised "never throws in Warn/Off," but under `Set-StrictMode` an edges-less `$EdgesData` hard-threw — a legit write `Write-EdgesFile` handles (it's generic over top-level keys). Fix: the analysis body is wrapped in `try/catch → return 0` in **all** modes; the intended Block-mode regression `throw` is **outside** the try, so a real regression still blocks while an un-analyzable input never does. New `Get-EdgesArray` extracts the edges array from PSCustomObject **or** hashtable **or** edges-less doc without dereferencing under strict.

### Finding 2 — observability
Distinguishable `Write-Verbose` on **every** fail-open branch, so a permanently-dead gate is not byte-identical to a clean pass (the promotion evidence asserts the baseline *resolved*, positive).

### (a) HEAD-baseline caching — TL e/120#27(a)
`git show HEAD:edges.json` + parse of a ~19 MB file fired on every `Write-EdgesFile` call (~5/run in `Invoke-EdgeDiscovery`). Now resolved **once per `(path @ HEAD sha)`** and reused in-process; keyed by HEAD sha so a new commit invalidates; `$null` (dead-lookup) results cached too.

### near-key header note (CL scope-b)
`source|type|target` is a near-key (3 keys carry 2 edges on the live file); the twin-aware identity lives in the shared re-merge util + restore (t/2946 AC) — this presence guard can't see cross-attribution.

### Verification — 8/8
Both-arms (FIRE warn+block, CLEAN silent zero-noise, new-blank-rationale, Off) + **fail-open** (edges-less obj+hash, Warn+Block → 0, no throw) + git-backed HEAD resolution + **caching** (baseline cached after first call, second call correct).

**Flow (CL #40):** PS lands `(a)+(b)` → CL re-reviews this head (7th/fail-open case + distinguishable verbose branches) → CL runs `(c)` `ba3128f5`-as-HEAD positive cycle → single Block-flip GV package to TL. Coverage unchanged: PS-writer + pipeline-re-emit arm only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
