### PR TITLE
feat(scripts): edge-rationale guard promotion — default→Block + observability (t/2947 flip)

### DIFF
--- a/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
+++ b/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
@@ -15,38 +15,34 @@
 # be written rationale-less (composite key source|type|target). Baseline is HEAD (committed),
 # NOT on-disk — an intra-run checkpoint write can poison an on-disk baseline (CL Main e/120#13).
 #
-# NEAR-KEY NOTE (CL e/120#30, restore pre-flight t/2946#4): source|type|target is a NEAR-key,
-# not a strict key — on the live 33,580-edge file 3 keys carry 2 genuinely distinct edges each
-# (differing discovered_at/model/confidence). Benign for THIS guard today (0 of the 3 have
-# mixed rationale presence), but it is set semantics: if two edges share a key and only one had
-# rationale, the guard reasons over the key, not the specific edge. The twin-aware identity
-# (disambiguate on discovered_at+model, else refuse-and-log) lives in the shared re-merge util
-# + restore (TL e/120#37, t/2946 AC) — this presence guard can't see cross-attribution.
+# NEAR-KEY NOTE (CL e/120#30, restore pre-flight t/2946#4): source|type|target is a NEAR-key;
+# on the live 33,580-edge file 3 keys carry 2 genuinely distinct edges each. Benign for THIS
+# guard today; twin-aware identity lives in the shared re-merge util + restore (t/2946 AC).
 #
-# Gate Promotion / warn-first (t/2683): Phase 1 = WARN (landed, PR #1430 / 491c7554). Phase 2
-# (this) = fail-open hardening + observability + baseline caching; Block (throw) flips default
-# only after the positive real-data cycle + TL GV (t/2947). Mode resolves from
-# $env:AI_TRIAD_EDGE_RATIONALE_GATE (Off|Warn|Block); default Warn.
+# GATE PROMOTION (t/2683): Phase 1 WARN landed (#1430 / 491c7554). Phase 2 hardening
+# (fail-open + observability + caching) landed (#1433 / 21a69608). THIS is the promotion:
+# default -> BLOCK, gated on CL's ba3128f5-as-HEAD positive real-data cycle + TL GV (t/2947).
+# Mode still resolves from $env:AI_TRIAD_EDGE_RATIONALE_GATE (Off|Warn|Block); the DEFAULT
+# (env unset) is now Block.
 #
-# FAIL-OPEN CONTRACT (CL e/120#30 Finding 1, TL #32): the guard must NEVER throw except on a
+# FAIL-OPEN CONTRACT (CL e/120#30 Finding 1, TL #32): the guard NEVER throws except on a
 # genuine Block-mode regression. Any inability to analyze the input (no HEAD baseline, an
-# edges-less/odd-shaped payload, a parse error) returns 0 without throwing — a guard that cannot
-# read its baseline must not block a legitimate write. Every fail-open branch emits a
-# DISTINGUISHABLE Write-Verbose (CL #30 Finding 2) so a permanently-dead gate is not
-# byte-identical to a clean pass; the promotion evidence asserts the baseline RESOLVED
-# (positive), not merely that nothing warned.
+# edges-less/odd-shaped payload, a parse error) returns 0 without throwing. Every fail-open
+# AND every resolved-positive path emits a DISTINGUISHABLE Write-Verbose (CL #30 Finding 2 +
+# e/120#43/#52 Finding 3): a healthy run positively reports "baseline resolved — N key(s)"
+# and "payload scanned — checked N", so a dead gate is never inferred from mere absence, and
+# a "no edges KEY" payload is never conflated with an "emptied edges array".
 
-# Per-run HEAD-baseline cache (TL e/120#27 (a) / #34): `git show HEAD:edges.json` + parse of a
-# ~19 MB file fires on EVERY Write-EdgesFile call, and Invoke-EdgeDiscovery has ~5 sink calls
-# per run. Resolve once per (repo-relative path @ HEAD sha) and reuse within the process. Keyed
-# by HEAD sha so a new commit mid-process invalidates; $null (fail-open) results are cached too
-# to avoid re-running a failing lookup every call.
+# Per-run HEAD-baseline cache (TL e/120#27(a)): `git show HEAD:edges.json` + parse of a ~19 MB
+# file fires on every Write-EdgesFile call (~5/run in Invoke-EdgeDiscovery). Resolve once per
+# (repo-relative path @ HEAD sha) and reuse in-process; keyed by HEAD sha so a new commit
+# invalidates; $null (dead-lookup) results cached too.
 $script:EdgeHeadBaselineCache = @{}
 
 function Get-EdgesFromHead {
     # Return the `edges` array from the committed (HEAD) version of $Path, or $null on any
-    # failure (fail-open, with a distinguishable Write-Verbose per cause). git is invoked via
-    # PowerShell (not the Bash tool) to avoid the MSYS colon-revspec path-mangling caveat.
+    # failure (fail-open, with a distinguishable Write-Verbose per cause). git via PowerShell
+    # (not the Bash tool) to avoid the MSYS colon-revspec path-mangling caveat.
     [OutputType([object[]])]
     param([string]$Path)
     if ([string]::IsNullOrWhiteSpace($Path)) { Write-Verbose 'edge-rationale baseline: no path supplied — fail-open.'; return $null }
@@ -59,13 +55,17 @@ function Get-EdgesFromHead {
         $top = ([string]$top).Trim()
         $rel = ([System.IO.Path]::GetRelativePath($top, $full)) -replace '\\', '/'
 
-        # Per-run cache keyed by path @ HEAD sha (TL e/120#27(a)).
+        # Per-run cache keyed by path @ HEAD sha (TL e/120#27a).
         $headSha = & git -C $top rev-parse HEAD 2>$null
         $headSha = if ($LASTEXITCODE -eq 0) { ([string]$headSha).Trim() } else { '' }
         $cacheKey = "$top|$rel@$headSha"
         if ($headSha -and $script:EdgeHeadBaselineCache.ContainsKey($cacheKey)) {
-            Write-Verbose "edge-rationale baseline: cache hit for '$rel@$($headSha.Substring(0,[Math]::Min(8,$headSha.Length)))'."
-            return $script:EdgeHeadBaselineCache[$cacheKey]
+            # S-1 (CL e/120#43, TL #45): branch the cache-hit message on $null so a DEAD-lookup
+            # (no committed baseline) is not reported identically to a RESOLVED one on calls 2..N.
+            $cached = $script:EdgeHeadBaselineCache[$cacheKey]
+            if ($null -eq $cached) { Write-Verbose "edge-rationale baseline: cache hit — NO committed baseline (dead-lookup) for '$rel'." }
+            else { Write-Verbose "edge-rationale baseline: cache hit — $(@($cached).Count) committed baseline edge(s) for '$rel'." }
+            return $cached
         }
 
         $result = $null
@@ -78,7 +78,7 @@ function Get-EdgesFromHead {
             if ($parsed.PSObject.Properties['edges']) { $result = @($parsed.edges) }
             else { Write-Verbose 'edge-rationale baseline: HEAD edges.json has no edges array — fail-open.' }
         }
-        if ($headSha) { $script:EdgeHeadBaselineCache[$cacheKey] = $result }   # cache incl. $null (dead-lookup) results
+        if ($headSha) { $script:EdgeHeadBaselineCache[$cacheKey] = $result }
         return $result
     } catch {
         Write-Verbose "edge-rationale baseline: could not read/parse HEAD edges.json ($($_.Exception.Message)) — fail-open."
@@ -87,25 +87,26 @@ function Get-EdgesFromHead {
 }
 
 function Get-EdgesArray {
-    # Robustly extract the edges array from an edges document that may be a PSCustomObject
-    # (the common ConvertFrom-Json shape) OR a hashtable, without throwing under StrictMode.
-    # Returns $null when there is no edges array (an edges-less doc is a legitimate write that
-    # Write-EdgesFile handles — it is generic over top-level keys).
+    # Extract the edges array from an edges document (PSCustomObject OR hashtable) without a
+    # StrictMode deref. Returns @{ HasKey; Edges } so the caller can distinguish a MISSING
+    # `edges` key from a present-but-EMPTY array (CL e/120#52/#53 — the two must not share a
+    # scannable message, else (c)'s payload-scanned positive is not independently attributable).
     param($EdgesData)
-    if ($null -eq $EdgesData) { return $null }
+    if ($null -eq $EdgesData) { return @{ HasKey = $false; Edges = @() } }
     if ($EdgesData -is [System.Collections.IDictionary]) {
-        if ($EdgesData.Contains('edges')) { return $EdgesData['edges'] }
-        return $null
+        if ($EdgesData.Contains('edges')) { return @{ HasKey = $true; Edges = @($EdgesData['edges']) } }
+        return @{ HasKey = $false; Edges = @() }
     }
-    if ($EdgesData.PSObject -and $EdgesData.PSObject.Properties['edges']) { return $EdgesData.edges }
-    return $null
+    if ($EdgesData.PSObject -and $EdgesData.PSObject.Properties['edges']) { return @{ HasKey = $true; Edges = @($EdgesData.edges) } }
+    return @{ HasKey = $false; Edges = @() }
 }
 
 function Test-EdgeRationaleRegression {
     <#
     .SYNOPSIS
-        Arm 1 guard (t/2945). Warn (or in Block mode, throw) when a write to edges.json would
-        drop `rationale` from an edge that carries one in HEAD. Composite-keyed (source|type|target).
+        Arm 1 guard (t/2945). In Block mode (now the default) throws when a write to edges.json
+        would drop `rationale` from an edge that carries one in HEAD; in Warn mode warns instead.
+        Composite-keyed (source|type|target).
     .OUTPUTS
         [int] the number of regressing edges (0 = clean). NEVER throws in Warn/Off mode, and in
         Block mode throws ONLY on a genuine rationale regression — any inability to analyze the
@@ -116,8 +117,6 @@ function Test-EdgeRationaleRegression {
     param(
         [Parameter(Mandatory)] $EdgesData,
         [string]$Path = '',
-        # Injectable baseline (array of edge objects) — for tests/callers with a known baseline.
-        # When $null, the baseline is resolved from HEAD:$Path.
         $BaselineEdges = $null,
         [ValidateSet('', 'Off', 'Warn', 'Block')]
         [string]$Mode = ''
@@ -128,11 +127,12 @@ function Test-EdgeRationaleRegression {
         $envMode = [Environment]::GetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE')
         $Mode = switch -Regex ("$envMode") {
             '^(?i)off$'   { 'Off' }
+            '^(?i)warn$'  { 'Warn' }
             '^(?i)block$' { 'Block' }
-            default       { 'Warn' }
+            default       { 'Block' }   # t/2947 Block flip: default is now Block (was Warn)
         }
     }
-    if ($Mode -eq 'Off') { return 0 }
+    if ($Mode -eq 'Off') { Write-Verbose 'edge-rationale guard: mode=Off — guard disabled, no check performed.'; return 0 }
 
     # ── Analyze (fail-OPEN): any error building the baseline map or scanning the write payload
     #    returns 0 without throwing. The intended Block-mode regression throw happens AFTER this
@@ -144,7 +144,6 @@ function Test-EdgeRationaleRegression {
             if ($null -eq $BaselineEdges) { return 0 }   # Get-EdgesFromHead already Write-Verbose'd the cause
         }
 
-        # Composite keys that carry a non-empty rationale in the baseline.
         $hadRationale = @{}
         foreach ($e in @($BaselineEdges)) {
             if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
@@ -154,22 +153,31 @@ function Test-EdgeRationaleRegression {
             }
         }
         if ($hadRationale.Count -eq 0) { Write-Verbose 'edge-rationale guard: HEAD baseline carries no rationaled edges — nothing to protect.'; return 0 }
+        # Finding 3 (CL e/120#43/#52): POSITIVE baseline-resolved signal — a healthy run must not
+        # rely on the ABSENCE of a fail-open line to prove the baseline resolved.
+        Write-Verbose "edge-rationale guard: HEAD baseline resolved — $($hadRationale.Count) rationaled key(s) protected."
 
-        # Robustly extract the write payload's edges (edges-less / odd-shaped doc -> fail-open).
-        $writeEdges = Get-EdgesArray -EdgesData $EdgesData
-        if ($null -eq $writeEdges) { Write-Verbose 'edge-rationale guard: write payload has no edges array — fail-open (nothing to check).'; return 0 }
+        # Distinguish a MISSING edges key (fail-open) from a present-but-empty array (scan finds
+        # nothing) — distinct, non-overlapping messages (CL e/120#52/#53 hard (c) precondition).
+        $extract = Get-EdgesArray -EdgesData $EdgesData
+        if (-not $extract.HasKey) { Write-Verbose 'edge-rationale guard: write payload has no edges KEY (missing) — fail-open (nothing to check).'; return 0 }
+        $writeEdges = @($extract.Edges)
 
-        foreach ($e in @($writeEdges)) {
-            if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
+        $checked = 0; $skipped = 0
+        foreach ($e in $writeEdges) {
+            if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { $skipped++; continue }
+            $checked++
             $key = "$($e.source)|$($e.type)|$($e.target)"
             if ($hadRationale.ContainsKey($key)) {
                 $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
                 if ([string]::IsNullOrWhiteSpace($r)) { [void]$lost.Add($key) }
             }
         }
+        # POSITIVE payload-scanned signal (CL e/120#44 Note 1 + #46 two-positive AC): reports the
+        # edges actually examined + those skipped for missing key fields, so "0 regressions" is
+        # never indistinguishable from "nothing was scanned".
+        Write-Verbose "edge-rationale guard: payload scanned — checked $checked edge(s), skipped $skipped (missing key fields)."
     } catch {
-        # Belt-and-suspenders (TL #32): a guard that cannot analyze the input MUST NOT block a
-        # legitimate write, in any mode. Distinguishable so a dead gate isn't silent.
         Write-Verbose "edge-rationale guard: unexpected error analyzing the write, fail-open (no throw): $($_.Exception.Message)"
         return 0
     }
@@ -189,7 +197,6 @@ function Test-EdgeRationaleRegression {
         throw (New-ActionableError -Goal "Preserve edge rationale on write to '$leaf'" `
             -Problem $problem -Location 'Write-EdgesFile / Test-EdgeRationaleRegression' -NextSteps $steps -PassThru)
     }
-    # Phase 1 — WARN (loud, does not throw).
-    Write-Warning ("EDGE-RATIONALE REGRESSION (would-block; t/2945 Arm 1, warn-first) — $problem Next steps: " + ($steps -join ' | '))
+    Write-Warning ("EDGE-RATIONALE REGRESSION (would-block; t/2945 Arm 1) — $problem Next steps: " + ($steps -join ' | '))
     return $lost.Count
 }

--- a/tests/EdgeRationaleRegression.Tests.ps1
+++ b/tests/EdgeRationaleRegression.Tests.ps1
@@ -6,15 +6,14 @@
 
 <#
 .SYNOPSIS
-    Both-arms GV for the Arm-1 edge-rationale-regression guard (t/2945; Phase-2 hardening t/2947).
+    GV suite for the Arm-1 edge-rationale-regression guard (t/2945; Block flip t/2947).
     FIRE  = a write dropping rationale from an edge rationaled in the baseline -> Block throws /
-            Warn emits a loud warning and reports the count.
-    CLEAN = a normal add-only, rationale-preserving write -> passes SILENTLY, zero noise.
-    Plus (Phase 2): fail-OPEN on odd-shaped input (CL e/120#30 Finding 1) and per-run HEAD
-    baseline caching (TL e/120#27(a)). Baseline is HEAD/committed (composite-keyed).
+            Warn warns and reports the count.
+    CLEAN = a rationale-preserving write -> passes SILENTLY, zero noise.
+    Plus: fail-OPEN on odd-shaped input, HEAD-baseline caching (incl. dead-lookup distinction),
+    default -> Block (the flip), and POSITIVE observability (baseline resolved + payload scanned;
+    emptied-array vs missing-key split). Baseline is HEAD/committed (composite-keyed).
     Edge objects are built in test scope and passed into InModuleScope (the guard is Private).
-    Coverage note (CL.Investigate1 e/120#22): this PS-sink guard covers PS writers + the pipeline
-    re-emit; the editor/server saves use the TS writeEdgesFile twin and are guarded separately.
 #>
 
 BeforeAll {
@@ -97,10 +96,6 @@ Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges
     }
 
     It 'FAIL-OPEN: an edges-less document returns 0 and does NOT throw — even with a rationaled baseline, even in Block mode' {
-        # CL e/120#30 Finding 1: the fail-closed deref is DOWNSTREAM of the hadRationale.Count==0
-        # early return, so it only manifests with a NON-empty baseline. Write-EdgesFile is generic
-        # over top-level keys — an edges-less doc is a legit write it handles; the guard must fail
-        # OPEN on it, not hard-throw.
         $noEdgesObj  = [PSCustomObject]@{ nodes = @() }
         $noEdgesHash = @{ nodes = @() }
         InModuleScope AITriad -Parameters @{ O = $noEdgesObj; H = $noEdgesHash; B = $script:Baseline } {
@@ -114,6 +109,72 @@ Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges
     }
 }
 
+Describe 'Test-EdgeRationaleRegression — Block flip + positive observability (t/2947)' -Tag 'edges' {
+
+    BeforeEach {
+        $script:Baseline = @(
+            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002' 'because X reinforces Y'),
+            (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W')
+        )
+    }
+
+    It 'DEFAULT mode is now Block (the flip): a regression throws with no -Mode and env unset' {
+        $write = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            $prev = [Environment]::GetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE')
+            [Environment]::SetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE', $null)
+            try {
+                { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B } | Should -Throw          # default = Block
+                # env override still wins: Warn downgrades to a warning
+                Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+            } finally {
+                [Environment]::SetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE', $prev)
+            }
+        }
+    }
+
+    It 'DEFAULT Block: a rationale-preserving write passes (0, no throw) with no -Mode' {
+        $write = New-EdgesData @(
+            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002' 'because X reinforces Y'),
+            (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W')
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            $prev = [Environment]::GetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE')
+            [Environment]::SetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE', $null)
+            try { { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B } | Should -Not -Throw }
+            finally { [Environment]::SetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE', $prev) }
+        }
+    }
+
+    It 'POSITIVE observability: emits "HEAD baseline resolved — N" and "payload scanned — checked N"' {
+        $write = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'because X reinforces Y') )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            $v = (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -Verbose 4>&1) | Out-String
+            $v | Should -Match 'HEAD baseline resolved — 2 rationaled key'
+            $v | Should -Match 'payload scanned — checked 1 edge'
+        }
+    }
+
+    It 'MESSAGE SPLIT: a missing edges KEY and an emptied edges array emit DISTINCT, non-overlapping text (CL (c) precondition)' {
+        $missingKey = [PSCustomObject]@{ nodes = @() }
+        $emptyArray = [PSCustomObject]@{ edges = @() }
+        InModuleScope AITriad -Parameters @{ MK = $missingKey; EA = $emptyArray; B = $script:Baseline } {
+            param($MK, $EA, $B)
+            $vMiss  = (Test-EdgeRationaleRegression -EdgesData $MK -BaselineEdges $B -Mode Warn -Verbose 4>&1) | Out-String
+            $vEmpty = (Test-EdgeRationaleRegression -EdgesData $EA -BaselineEdges $B -Mode Warn -Verbose 4>&1) | Out-String
+            # Missing key: reports "no edges KEY"; NOT a payload scan.
+            $vMiss  | Should -Match 'no edges KEY'
+            $vMiss  | Should -Not -Match 'payload scanned'
+            # Emptied array: reports a payload scan (checked 0); NOT "no edges KEY".
+            $vEmpty | Should -Match 'payload scanned — checked 0 edge'
+            $vEmpty | Should -Not -Match 'no edges KEY'
+        }
+    }
+}
+
 Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution + caching (git-backed, real repo)' -Tag 'edges' {
 
     It 'resolves the baseline from HEAD and fires on a same-file rationale strip; clean on add-only' {
@@ -121,48 +182,59 @@ Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution + caching (g
         $tax  = Join-Path $repo 'taxonomy/Origin'
         New-Item -ItemType Directory -Path $tax -Force | Out-Null
         $edgesPath = Join-Path $tax 'edges.json'
-
         $committed = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'committed rationale') )
         $strip     = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
         $ok        = New-EdgesData @(
             (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'committed rationale'),
             (New-Edge 'acc-007' 'WEAKENS'  'saf-008' 'new')
         )
-
         InModuleScope AITriad -Parameters @{ Committed = $committed; Strip = $strip; Ok = $ok; EdgesPath = $edgesPath; Repo = $repo } {
             param($Committed, $Strip, $Ok, $EdgesPath, $Repo)
             Write-EdgesFile -EdgesData $Committed -Path $EdgesPath
             Push-Location $Repo
-            try {
-                git init -q 2>$null
-                git config user.email 't@t' 2>$null; git config user.name 't' 2>$null
-                git add -A 2>$null; git commit -q -m 'baseline' 2>$null
-            } finally { Pop-Location }
-
+            try { git init -q 2>$null; git config user.email 't@t' 2>$null; git config user.name 't' 2>$null; git add -A 2>$null; git commit -q -m 'baseline' 2>$null } finally { Pop-Location }
             Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
             Test-EdgeRationaleRegression -EdgesData $Ok -Path $EdgesPath -Mode Warn | Should -Be 0
         }
     }
 
-    It 'caches the HEAD baseline per (path @ HEAD) — repeated calls in a run reuse it (TL e/120#27a)' {
+    It 'caches the HEAD baseline per (path @ HEAD); the second call reports its cache hit' {
         $repo = Join-Path $TestDrive 'cacherepo'
         $tax  = Join-Path $repo 'taxonomy/Origin'
         New-Item -ItemType Directory -Path $tax -Force | Out-Null
         $edgesPath = Join-Path $tax 'edges.json'
         $committed = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'committed rationale') )
         $strip     = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
-
         InModuleScope AITriad -Parameters @{ Committed = $committed; Strip = $strip; EdgesPath = $edgesPath; Repo = $repo } {
             param($Committed, $Strip, $EdgesPath, $Repo)
             Write-EdgesFile -EdgesData $Committed -Path $EdgesPath
             Push-Location $Repo
             try { git init -q 2>$null; git config user.email 't@t' 2>$null; git config user.name 't' 2>$null; git add -A 2>$null; git commit -q -m b 2>$null } finally { Pop-Location }
-
             $script:EdgeHeadBaselineCache = @{}
             Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
-            @($script:EdgeHeadBaselineCache.Keys).Count | Should -BeGreaterThan 0   # baseline cached after first call
-            # Second call resolves from cache and is still correct.
-            Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+            @($script:EdgeHeadBaselineCache.Keys).Count | Should -BeGreaterThan 0
+            $v = (Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -Verbose -WarningAction SilentlyContinue 4>&1) | Out-String
+            $v | Should -Match 'cache hit — 1 committed baseline edge'   # resolved baseline, not dead-lookup
+        }
+    }
+
+    It 'S-1: a DEAD-lookup (edges.json not committed) reports a DISTINCT cache-hit message on call 2' {
+        $repo = Join-Path $TestDrive 'deadrepo'
+        $tax  = Join-Path $repo 'taxonomy/Origin'
+        New-Item -ItemType Directory -Path $tax -Force | Out-Null
+        $edgesPath = Join-Path $tax 'edges.json'
+        $strip     = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
+        InModuleScope AITriad -Parameters @{ Strip = $strip; EdgesPath = $edgesPath; Repo = $repo; Tax = $tax } {
+            param($Strip, $EdgesPath, $Repo, $Tax)
+            # Commit SOMETHING so HEAD exists, but leave edges.json uncommitted -> HEAD:edges.json is absent.
+            Set-Content -Path (Join-Path $Repo 'readme.txt') -Value 'x' -Encoding utf8
+            Write-EdgesFile -EdgesData $Strip -Path $EdgesPath   # on-disk only, never committed
+            Push-Location $Repo
+            try { git init -q 2>$null; git config user.email 't@t' 2>$null; git config user.name 't' 2>$null; git add readme.txt 2>$null; git commit -q -m init 2>$null } finally { Pop-Location }
+            $script:EdgeHeadBaselineCache = @{}
+            Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn | Should -Be 0   # no baseline -> fail-open
+            $v = (Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -Verbose 4>&1) | Out-String
+            $v | Should -Match 'cache hit — NO committed baseline \(dead-lookup\)'
         }
     }
 }


### PR DESCRIPTION
## Edge-rationale guard PROMOTION — default→Block + S-1/observability/split (t/2947 flip)

**DRAFT — the Block-flip GV package's code half.** Per the locked sequencing (TL e/120#48): WARN (#1430) + hardening (#1433) landed; **this is the promotion** (`default→Block`), plus every observability item CL requires so `(c)`'s two-positive evidence is unambiguous — all in the one head the flip runs on (**evidence head == flip head**). Goes to Main (TL) for GV bundled with CL's `(c)` run against this head.

### Changes (CL delta-re-review scope, e/120#52/#53)
- **default→Block** (the flip): env-unset resolves Block; Off/Warn/Block env override unchanged. FIRE arm now **throws** `New-ActionableError` by default (Warn env → warning).
- **S-1** (CL #43): cache-hit verbose branches on `$null` — a dead-lookup on calls 2..N ≠ a resolved one.
- **Finding 3** (CL #43/#52): positive `HEAD baseline resolved — N rationaled key(s)` — resolution is proven positively, not from absence.
- **Payload-scanned + skipped-count** (CL #44/#46): `payload scanned — checked N, skipped M` — "0 regressions" ≠ "nothing scanned".
- **Emptied-array vs missing-key split** (CL #52/#53 hard `(c)` precondition): `Get-EdgesArray` → `@{HasKey;Edges}`; **distinct, non-overlapping** `no edges KEY` vs `payload scanned — checked 0`.
- **Off verbose**: no silent disable.

### Deferred (TL #55 / CL #54 — perf not a flip gate)
Memoizing `$hadRationale` under the same `path@sha` key (trivial warm-call cut) → follow-up, to keep this diff minimal for `(c)`.

### Verification
- Suite **13/13** (both-arms + fail-open + default-Block throws/clean + positive observability + message split + git-backed resolution + cache resolved/dead-lookup).
- Edge-writer regression **72/72** (Invoke-EdgeDiscovery / RationaleBackfill / Get-Edge / SinkGuard / Resolve-EdgeType / OrgEdge) — the flip does not break existing writers (they write non-HEAD temp paths → fail-open).

Coverage unchanged: PS-writer + pipeline-re-emit arm. This does not close t/2945 or make the restore durable (TS site fix/guard + Arm 2, on TL dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
