### PR TITLE
docs(cl): t/2947 (c) Block-flip real-data evidence harness + transcripts

### DIFF
--- a/research/comp-linguist/evidence/t2947/README.md
+++ b/research/comp-linguist/evidence/t2947/README.md
@@ -1,0 +1,62 @@
+# t/2947 (c) — Block-flip real-data evidence
+
+The (c) half of the edge-rationale Block-flip Gate Verification package: the `ba3128f5`-as-HEAD
+positive clean cycle run against the flip head. Kept here so the GV evidence is re-runnable
+rather than existing only as numbers quoted in a ticket comment.
+
+## Heads under evidence
+
+| What | Commit |
+| --- | --- |
+| Guard code (PR #1435, `default → Block`) | `775537b30c1fafe0c58039fb6df5a3df69305825` |
+| `ai-triad-data` baseline (HEAD for the run) | `ba3128f51de23cbbed47703ab899c0cef6120bf7` |
+| Guard file blob | `40870ae92b8ce3bd70de9c22e3b3e916e6e5f612` |
+
+Head discipline (TL e/120#48): the evidence head **is** the flip head. The guard is dot-sourced
+from a worktree pinned at that OID — not from `main`, and not from a predecessor.
+
+## Files
+
+- `run-c-evidence.ps1` — the (c) harness. Four arms: clean (uncached), clean (cache hit),
+  deliberate-strip (expects the Block throw), and the emptied-array/missing-key message split.
+  18 assertions.
+- `probe-delta.ps1` — two delta-re-review probes. **P1** reconciles rationaled *edges* against
+  distinct rationaled *keys*. **P2** tests whether a committed-but-empty `edges` array fails open
+  silently (it does — filed as t/2953).
+- `c-evidence-transcript.txt`, `probe-transcript.txt` — captured output of the runs quoted in
+  t/2947.
+
+## Re-running
+
+Both scripts take `-CodeWt` and `-DataWt` (paths to worktrees pinned at the two commits above);
+the defaults point at the throwaway worktrees used for the original run, so pass your own:
+
+```powershell
+git -C <ai-triad-research> worktree add -b <branch> <code-wt> 775537b3
+git -C <ai-triad-data>     worktree add -b <branch> <data-wt> ba3128f5
+
+pwsh -NoProfile -File run-c-evidence.ps1 -CodeWt <code-wt> -DataWt <data-wt>
+```
+
+Exit code is the number of failed assertions (0 = PASS). The harness unsets
+`AI_TRIAD_EDGE_RATIONALE_GATE` so it exercises the *default* mode, which is the thing under test —
+setting the mode explicitly would prove nothing about the flip.
+
+Neither script writes to `ai-triad-data`: the strip arm mutates an in-memory copy of the payload,
+and P2 builds its own throwaway git sandbox under `TEMP` and deletes it.
+
+## Results (2026-08-23, three replications, all PASS)
+
+Clean arm: baseline resolved to **33,445** rationaled keys; payload scanned **33,454** checked /
+**0** skipped; returns 0, zero warnings, no throw. Strip arm: throws `New-ActionableError` with all
+four fields. Split: `payload scanned` and `no edges KEY` are non-overlapping.
+
+Wall clock: ~6–10s uncached (the `git show HEAD:` + parse of an 18.6 MB file), ~2–3s on the cache
+hit — the per-run HEAD-baseline cache is doing its job.
+
+**On the 33,448 vs 33,445 gap** (P1, empirical): the baseline carries 33,448 edges with a rationale
+but only **33,445 distinct** `source|type|target` keys — 3 keys carry 2 edges each
+(`acc-beliefs-051|SUPPORTS|acc-desires-001`, `acc-beliefs-069|SUPPORTS|acc-intentions-054`,
+`acc-intentions-100|SUPPORTS|acc-beliefs-039`). The guard counts *keys*, so 33,445 is correct and
+the 3-edge difference is the known near-key collision (CL e/120#30) showing up in the count, not a
+lookup failure.

--- a/research/comp-linguist/evidence/t2947/c-evidence-transcript.txt
+++ b/research/comp-linguist/evidence/t2947/c-evidence-transcript.txt
@@ -1,0 +1,75 @@
+=== HEAD DISCIPLINE ===
+code worktree HEAD : 775537b30c1fafe0c58039fb6df5a3df69305825
+data worktree HEAD : ba3128f51de23cbbed47703ab899c0cef6120bf7
+guard file sha     : 40870ae92b8ce3bd70de9c22e3b3e916e6e5f612
+env gate           : '' (unset => default)
+payload edges      : 33454 (load+parse 2.0s)
+
+=== ARM 1: CLEAN (uncached baseline resolve) ===
+  V: edge-rationale guard: HEAD baseline resolved — 33445 rationaled key(s) protected.
+  V: edge-rationale guard: payload scanned — checked 33454 edge(s), skipped 0 (missing key fields).
+  return   : 0
+  warnings : 0
+  threw    : False
+  wall     : 10.02s
+
+=== ARM 1b: CLEAN repeat (cache hit) ===
+  V: edge-rationale baseline: cache hit — 33454 committed baseline edge(s) for 'taxonomy/Origin/edges.json'.
+  V: edge-rationale guard: HEAD baseline resolved — 33445 rationaled key(s) protected.
+  V: edge-rationale guard: payload scanned — checked 33454 edge(s), skipped 0 (missing key fields).
+  return   : 0   wall: 2.96s
+
+=== ARM 2: FIRE (deliberate rationale strip, in-memory copy) ===
+  stripped 5 edge(s); keys: acc-desires-001|SUPPORTS|acc-desires-037 ; acc-desires-001|ASSUMES|acc-desires-039 ; acc-desires-001|SUPPORTS|acc-intentions-100 ; acc-desires-001|SUPPORTS|acc-beliefs-039 ; acc-desires-001|SUPPORTS|acc-beliefs-086
+  return   : 
+  warnings : 0
+  THREW    : yes
+  --- error text ---
+
+  Goal:     Preserve edge rationale on write to 'edges.json'
+  Error:    5 edge(s) carrying a rationale in HEAD would be written WITHOUT one (composite key source|type|target). Sample: acc-desires-001|SUPPORTS|acc-desires-037, acc-desires-001|ASSUMES|acc-desires-039, acc-desires-001|SUPPORTS|acc-intentions-100. This is the edge-rationale wipe class (t/2945).
+  Location: Write-EdgesFile / Test-EdgeRationaleRegression
+  Resolve:
+   1. A whole-file edges save MUST re-merge rationale from HEAD/on-disk by composite key before writing — never persist a rationale-stripped list payload (the taxonomy-editor load-list->save round-trip, t/2945).
+   2. If this removal is intentional, set $env:AI_TRIAD_EDGE_RATIONALE_GATE=Off for the run.
+  --- end ---
+  wall     : 2.65s
+
+=== ARM 3: emptied-array vs missing-key message split ===
+  emptied-array verbose:
+    V: edge-rationale baseline: cache hit — 33454 committed baseline edge(s) for 'taxonomy/Origin/edges.json'.
+    V: edge-rationale guard: HEAD baseline resolved — 33445 rationaled key(s) protected.
+    V: edge-rationale guard: payload scanned — checked 0 edge(s), skipped 0 (missing key fields).
+  missing-key   verbose:
+    V: edge-rationale baseline: cache hit — 33454 committed baseline edge(s) for 'taxonomy/Origin/edges.json'.
+    V: edge-rationale guard: HEAD baseline resolved — 33445 rationaled key(s) protected.
+    V: edge-rationale guard: write payload has no edges KEY (missing) — fail-open (nothing to check).
+  'payload scanned' -> emptied:1 missing:0
+  'no edges KEY'    -> emptied:0 missing:1
+
+=== (c) ASSERTIONS ===
+  PASS  positive #1 baseline-resolved emitted, count > 0 (count=33445)
+  PASS  positive #2 payload-scanned emitted, checked > 0 (checked=33454)
+  PASS  positive #2 skipped == 0 (skipped=0)
+  PASS  payload-scanned checked == payload edge count (33454 vs 33454)
+  PASS  clean arm returns 0 
+  PASS  clean arm emits ZERO warnings (n=0)
+  PASS  clean arm does not throw 
+  PASS  FIRE arm THROWS on default (Block flip) 
+  PASS  throw carries Goal 
+  PASS  throw carries Problem 
+  PASS  throw carries Location 
+  PASS  throw carries NextSteps 
+  PASS  throw names the strip count 
+  PASS  FIRE arm emits no Write-Warning (throw, not warn) (n=0)
+  PASS  split: emptied array reports payload scanned 
+  PASS  split: emptied array does NOT report no-edges-KEY 
+  PASS  split: missing key reports no-edges-KEY 
+  PASS  split: missing key does NOT report payload scanned 
+
+=== WALL CLOCK ===
+  clean (uncached baseline resolve) : 10.02s
+  clean (cache hit)                 : 2.96s
+  fire  (cache hit)                 : 2.65s
+
+=== RESULT: PASS (0 failed assertion(s)) ===

--- a/research/comp-linguist/evidence/t2947/probe-delta.ps1
+++ b/research/comp-linguist/evidence/t2947/probe-delta.ps1
@@ -1,0 +1,79 @@
+# Delta re-review side probes (t/2947, CL Main) — empirical, not inferred.
+# P1: reconcile PS's predicted baseline count (33,448) with the guard's key count.
+# P2: does a committed-but-EMPTY `edges` array fail open SILENTLY (no Write-Verbose)?
+
+param(
+    [string]$CodeWt = 'C:/Users/jsnov/repos/ai-triad-research/.worktrees/cl-t2947-c',
+    [string]$DataWt = 'C:/Users/jsnov/.claude/jobs/8a1caf99/tmp/data-ba3128f5'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$EdgesPath = Join-Path $DataWt 'taxonomy/Origin/edges.json'
+
+[Environment]::SetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE', $null)
+. (Join-Path $CodeWt 'scripts/AITriad/Private/New-ActionableError.ps1')
+. (Join-Path $CodeWt 'scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1')
+
+Write-Host "=== P1: rationaled EDGES vs distinct rationaled KEYS at ba3128f5 ==="
+$doc = Get-Content -LiteralPath $EdgesPath -Raw | ConvertFrom-Json
+$all = @($doc.edges)
+$rationaledEdges = 0
+$keys = @{}
+$dupKeys = @{}
+foreach ($e in $all) {
+    if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
+    $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
+    if (-not [string]::IsNullOrWhiteSpace($r)) {
+        $rationaledEdges++
+        $k = "$($e.source)|$($e.type)|$($e.target)"
+        if ($keys.ContainsKey($k)) { $dupKeys[$k] = ($keys[$k] + 1); $keys[$k] = $keys[$k] + 1 } else { $keys[$k] = 1 }
+    }
+}
+Write-Host ("  total edges                 : {0}" -f $all.Count)
+Write-Host ("  edges carrying a rationale  : {0}" -f $rationaledEdges)
+Write-Host ("  DISTINCT rationaled keys    : {0}" -f $keys.Count)
+Write-Host ("  collisions (key seen >1x)   : {0}" -f $dupKeys.Count)
+foreach ($k in $dupKeys.Keys) { Write-Host ("    dup x{0}: {1}" -f $dupKeys[$k], $k) }
+Write-Host ("  => edges - keys = {0}" -f ($rationaledEdges - $keys.Count))
+
+Write-Host "`n=== P2: committed edges.json with an EMPTY edges array ==="
+$sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("cl-t2947-p2-" + [System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $sandbox -Force | Out-Null
+Push-Location $sandbox
+try {
+    & git init -q . 2>&1 | Out-Null
+    & git config user.email 'cl@local' ; & git config user.name 'cl'
+    '{ "edges": [] }' | Set-Content -LiteralPath (Join-Path $sandbox 'edges.json') -Encoding utf8
+    & git add edges.json 2>&1 | Out-Null
+    & git commit -q -m 'empty edges baseline' --no-verify 2>&1 | Out-Null
+    Write-Host ("  sandbox HEAD: " + (& git rev-parse --short HEAD))
+
+    $payload = [pscustomobject]@{ edges = @([pscustomobject]@{ source = 'a'; type = 'SUPPORTS'; target = 'b' }) }
+    $v = @()
+    $rv = Test-EdgeRationaleRegression -EdgesData $payload -Path (Join-Path $sandbox 'edges.json') -Verbose 4>&1 |
+          ForEach-Object {
+              if ($_ -is [System.Management.Automation.VerboseRecord]) { $script:v += [string]$_.Message; $null }
+              else { $_ }
+          }
+    Write-Host ("  return       : {0}" -f $rv)
+    Write-Host ("  verbose lines: {0}" -f @($v).Count)
+    foreach ($m in @($v)) { Write-Host "    V: $m" }
+    if (@($v).Count -eq 0) { Write-Host "  => SILENT fail-open (no verbose emitted) — Finding-2 contract gap" }
+    else { Write-Host "  => fail-open IS annotated" }
+
+    Write-Host "`n  -- P2b: same sandbox, second call (cache-hit path) --"
+    $v2 = @()
+    $rv2 = Test-EdgeRationaleRegression -EdgesData $payload -Path (Join-Path $sandbox 'edges.json') -Verbose 4>&1 |
+           ForEach-Object {
+               if ($_ -is [System.Management.Automation.VerboseRecord]) { $script:v2 += [string]$_.Message; $null }
+               else { $_ }
+           }
+    Write-Host ("  return       : {0}" -f $rv2)
+    foreach ($m in @($v2)) { Write-Host "    V: $m" }
+}
+finally {
+    Pop-Location
+    Remove-Item -LiteralPath $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/research/comp-linguist/evidence/t2947/probe-transcript.txt
+++ b/research/comp-linguist/evidence/t2947/probe-transcript.txt
@@ -1,0 +1,19 @@
+=== P1: rationaled EDGES vs distinct rationaled KEYS at ba3128f5 ===
+  total edges                 : 33454
+  edges carrying a rationale  : 33448
+  DISTINCT rationaled keys    : 33445
+  collisions (key seen >1x)   : 3
+    dup x2: acc-beliefs-051|SUPPORTS|acc-desires-001
+    dup x2: acc-beliefs-069|SUPPORTS|acc-intentions-054
+    dup x2: acc-intentions-100|SUPPORTS|acc-beliefs-039
+  => edges - keys = 3
+
+=== P2: committed edges.json with an EMPTY edges array ===
+  sandbox HEAD: db96b1f
+  return       : 0
+  verbose lines: 0
+  => SILENT fail-open (no verbose emitted) — Finding-2 contract gap
+
+  -- P2b: same sandbox, second call (cache-hit path) --
+  return       : 
+    V: edge-rationale baseline: cache hit — 0 committed baseline edge(s) for 'edges.json'.

--- a/research/comp-linguist/evidence/t2947/run-c-evidence.ps1
+++ b/research/comp-linguist/evidence/t2947/run-c-evidence.ps1
@@ -1,0 +1,182 @@
+# (c) real-data evidence run — t/2947, CL Main.
+# Head discipline: guard code is dot-sourced from the code worktree pinned at the FLIP head
+# 775537b3; baseline HEAD is the ai-triad-data worktree pinned at ba3128f5.
+# Read-only: no PS file is edited; the strip arm mutates an in-memory payload only.
+
+param(
+    # Code worktree pinned at the commit under evidence (the flip head 775537b3 for this run).
+    [string]$CodeWt = 'C:/Users/jsnov/repos/ai-triad-research/.worktrees/cl-t2947-c',
+    # ai-triad-data worktree pinned at the baseline commit (ba3128f5 for this run).
+    [string]$DataWt = 'C:/Users/jsnov/.claude/jobs/8a1caf99/tmp/data-ba3128f5'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$EdgesPath = Join-Path $DataWt 'taxonomy/Origin/edges.json'
+
+# Environment must be UNSET so we exercise the new DEFAULT (Block), not an explicit mode.
+[Environment]::SetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE', $null)
+
+. (Join-Path $CodeWt 'scripts/AITriad/Private/New-ActionableError.ps1')
+. (Join-Path $CodeWt 'scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1')
+
+Write-Host "=== HEAD DISCIPLINE ==="
+Write-Host ("code worktree HEAD : " + (& git -C $CodeWt rev-parse HEAD))
+Write-Host ("data worktree HEAD : " + (& git -C $DataWt rev-parse HEAD))
+Write-Host ("guard file sha     : " + (& git -C $CodeWt rev-parse 'HEAD:scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1'))
+Write-Host ("env gate           : '" + [Environment]::GetEnvironmentVariable('AI_TRIAD_EDGE_RATIONALE_GATE') + "' (unset => default)")
+
+$swLoad = [System.Diagnostics.Stopwatch]::StartNew()
+$doc = Get-Content -LiteralPath $EdgesPath -Raw | ConvertFrom-Json
+$swLoad.Stop()
+$totalEdges = @($doc.edges).Count
+Write-Host ("payload edges      : {0} (load+parse {1:N1}s)" -f $totalEdges, $swLoad.Elapsed.TotalSeconds)
+
+function Invoke-Arm {
+    param([string]$Name, $Payload)
+    $verbose = $null; $warn = $null; $rv = $null; $threw = $null
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $rv = Test-EdgeRationaleRegression -EdgesData $Payload -Path $EdgesPath `
+                -Verbose -WarningVariable warn 4>&1 |
+              ForEach-Object { $_ }   # merge verbose into the pipeline for capture
+    } catch {
+        $threw = $_
+    }
+    $sw.Stop()
+    [pscustomobject]@{
+        Name = $Name; Raw = $rv; Warnings = @($warn); Threw = $threw; Seconds = $sw.Elapsed.TotalSeconds
+    }
+}
+
+function Split-Stream {
+    param($Raw)
+    $v = @(); $r = $null
+    foreach ($item in @($Raw)) {
+        if ($item -is [System.Management.Automation.VerboseRecord]) { $v += [string]$item.Message }
+        elseif ($item -is [int]) { $r = $item }
+        elseif ($null -ne $item) { $v += "[other:$($item.GetType().Name)] $item" }
+    }
+    [pscustomobject]@{ Verbose = $v; Return = $r }
+}
+
+# ── ARM 1: CLEAN (real full tree, unmodified payload) ─────────────────────────
+Write-Host "`n=== ARM 1: CLEAN (uncached baseline resolve) ==="
+$a1 = Invoke-Arm -Name 'clean' -Payload $doc
+$s1 = Split-Stream $a1.Raw
+$s1.Verbose | ForEach-Object { Write-Host "  V: $_" }
+Write-Host ("  return   : {0}" -f $s1.Return)
+Write-Host ("  warnings : {0}" -f $a1.Warnings.Count)
+Write-Host ("  threw    : {0}" -f ($null -ne $a1.Threw))
+Write-Host ("  wall     : {0:N2}s" -f $a1.Seconds)
+
+# ── ARM 1b: CLEAN again (cache-hit path, wall-clock delta) ────────────────────
+Write-Host "`n=== ARM 1b: CLEAN repeat (cache hit) ==="
+$a1b = Invoke-Arm -Name 'clean-cached' -Payload $doc
+$s1b = Split-Stream $a1b.Raw
+$s1b.Verbose | ForEach-Object { Write-Host "  V: $_" }
+Write-Host ("  return   : {0}   wall: {1:N2}s" -f $s1b.Return, $a1b.Seconds)
+
+# ── ARM 2: FIRE (deliberate strip on the same real baseline) ──────────────────
+Write-Host "`n=== ARM 2: FIRE (deliberate rationale strip, in-memory copy) ==="
+$stripN = 5
+$stripped = [pscustomobject]@{ edges = @() }
+$newEdges = New-Object System.Collections.Generic.List[object]
+$done = 0
+$strippedKeys = @()
+foreach ($e in @($doc.edges)) {
+    $hasR = ($e.PSObject.Properties['rationale']) -and -not [string]::IsNullOrWhiteSpace([string]$e.rationale)
+    if ($hasR -and $done -lt $stripN) {
+        $copy = [pscustomobject]@{}
+        foreach ($p in $e.PSObject.Properties) {
+            if ($p.Name -ne 'rationale') { $copy | Add-Member -NotePropertyName $p.Name -NotePropertyValue $p.Value }
+        }
+        $newEdges.Add($copy)
+        $strippedKeys += "$($e.source)|$($e.type)|$($e.target)"
+        $done++
+    } else {
+        $newEdges.Add($e)
+    }
+}
+$stripped.edges = $newEdges.ToArray()
+Write-Host ("  stripped {0} edge(s); keys: {1}" -f $done, ($strippedKeys -join ' ; '))
+
+$a2 = Invoke-Arm -Name 'fire' -Payload $stripped
+$s2 = Split-Stream $a2.Raw
+$s2.Verbose | ForEach-Object { Write-Host "  V: $_" }
+Write-Host ("  return   : {0}" -f $s2.Return)
+Write-Host ("  warnings : {0}" -f $a2.Warnings.Count)
+if ($a2.Threw) {
+    Write-Host "  THREW    : yes"
+    Write-Host ("  --- error text ---`n{0}`n  --- end ---" -f $a2.Threw.Exception.Message)
+} else {
+    Write-Host "  THREW    : NO  <-- FAIL: Block default did not throw"
+}
+Write-Host ("  wall     : {0:N2}s" -f $a2.Seconds)
+
+# ── ARM 3: message-split classification (missing KEY vs emptied array) ────────
+Write-Host "`n=== ARM 3: emptied-array vs missing-key message split ==="
+$emptied = [pscustomobject]@{ edges = @() }
+$missing = [pscustomobject]@{ nodes = @() }
+$a3a = Split-Stream (Invoke-Arm -Name 'emptied' -Payload $emptied).Raw
+$a3b = Split-Stream (Invoke-Arm -Name 'missing' -Payload $missing).Raw
+Write-Host "  emptied-array verbose:"; $a3a.Verbose | ForEach-Object { Write-Host "    V: $_" }
+Write-Host "  missing-key   verbose:"; $a3b.Verbose | ForEach-Object { Write-Host "    V: $_" }
+
+$emptiedMsgs = @($a3a.Verbose)
+$missingMsgs = @($a3b.Verbose)
+$scanTokenHitsEmptied = @($emptiedMsgs | Where-Object { $_ -match 'payload scanned' }).Count
+$scanTokenHitsMissing = @($missingMsgs | Where-Object { $_ -match 'payload scanned' }).Count
+$keyTokenHitsEmptied  = @($emptiedMsgs | Where-Object { $_ -match 'no edges KEY' }).Count
+$keyTokenHitsMissing  = @($missingMsgs | Where-Object { $_ -match 'no edges KEY' }).Count
+Write-Host ("  'payload scanned' -> emptied:{0} missing:{1}" -f $scanTokenHitsEmptied, $scanTokenHitsMissing)
+Write-Host ("  'no edges KEY'    -> emptied:{0} missing:{1}" -f $keyTokenHitsEmptied, $keyTokenHitsMissing)
+
+# ── ASSERTIONS ────────────────────────────────────────────────────────────────
+Write-Host "`n=== (c) ASSERTIONS ==="
+$fail = 0
+function Assert-True { param([string]$Label, [bool]$Cond, [string]$Detail = '')
+    if ($Cond) { Write-Host "  PASS  $Label $Detail" } else { Write-Host "  FAIL  $Label $Detail"; $script:fail++ }
+}
+
+$baseLine = @($s1.Verbose | Where-Object { $_ -match 'HEAD baseline resolved' }) | Select-Object -First 1
+$baseCount = if ($baseLine -match 'resolved — ([\d,]+) rationaled key') { [int](($Matches[1]) -replace ',', '') } else { -1 }
+Assert-True 'positive #1 baseline-resolved emitted, count > 0' ($baseCount -gt 0) "(count=$baseCount)"
+
+$scanLine = @($s1.Verbose | Where-Object { $_ -match 'payload scanned' }) | Select-Object -First 1
+$checked = -1; $skipped = -1
+if ($scanLine -match 'checked ([\d,]+) edge\(s\), skipped ([\d,]+)') {
+    $checked = [int](($Matches[1]) -replace ',', ''); $skipped = [int](($Matches[2]) -replace ',', '')
+}
+Assert-True 'positive #2 payload-scanned emitted, checked > 0' ($checked -gt 0) "(checked=$checked)"
+Assert-True 'positive #2 skipped == 0'                        ($skipped -eq 0) "(skipped=$skipped)"
+Assert-True 'payload-scanned checked == payload edge count'   ($checked -eq $totalEdges) "($checked vs $totalEdges)"
+Assert-True 'clean arm returns 0'                             ($s1.Return -eq 0)
+Assert-True 'clean arm emits ZERO warnings'                   ($a1.Warnings.Count -eq 0) "(n=$($a1.Warnings.Count))"
+Assert-True 'clean arm does not throw'                        ($null -eq $a1.Threw)
+
+Assert-True 'FIRE arm THROWS on default (Block flip)'         ($null -ne $a2.Threw)
+if ($a2.Threw) {
+    $t = [string]$a2.Threw.Exception.Message
+    # New-ActionableError renders the four fields as Goal:/Error:/Location:/Resolve:
+    Assert-True 'throw carries Goal'      ($t -match '(?im)^\s*Goal:')
+    Assert-True 'throw carries Problem'   ($t -match '(?im)^\s*Error:')
+    Assert-True 'throw carries Location'  ($t -match '(?im)^\s*Location:')
+    Assert-True 'throw carries NextSteps' ($t -match '(?im)^\s*Resolve:')
+    Assert-True 'throw names the strip count' ($t -match [regex]::Escape("$done edge(s) carrying a rationale"))
+}
+Assert-True 'FIRE arm emits no Write-Warning (throw, not warn)' ($a2.Warnings.Count -eq 0) "(n=$($a2.Warnings.Count))"
+
+Assert-True 'split: emptied array reports payload scanned'      ($scanTokenHitsEmptied -eq 1)
+Assert-True 'split: emptied array does NOT report no-edges-KEY' ($keyTokenHitsEmptied -eq 0)
+Assert-True 'split: missing key reports no-edges-KEY'           ($keyTokenHitsMissing -eq 1)
+Assert-True 'split: missing key does NOT report payload scanned' ($scanTokenHitsMissing -eq 0)
+
+Write-Host ("`n=== WALL CLOCK ===")
+Write-Host ("  clean (uncached baseline resolve) : {0:N2}s" -f $a1.Seconds)
+Write-Host ("  clean (cache hit)                 : {0:N2}s" -f $a1b.Seconds)
+Write-Host ("  fire  (cache hit)                 : {0:N2}s" -f $a2.Seconds)
+
+Write-Host ("`n=== RESULT: {0} ({1} failed assertion(s)) ===" -f $(if ($fail -eq 0) { 'PASS' } else { 'FAIL' }), $fail)
+exit $fail


### PR DESCRIPTION
Persists the (c) evidence harness and captured transcripts for the edge-rationale Block-flip Gate Verification (t/2947), so the GV evidence is re-runnable rather than existing only as numbers quoted in a ticket comment.

**Docs/evidence only — no production code, no test-suite change, no gate change.** Nothing here runs in CI.

### What's in it

- `run-c-evidence.ps1` — the (c) harness: 4 arms / 18 assertions, run with the guard dot-sourced from a worktree pinned at the flip head `775537b3` (PR #1435) and `ai-triad-data` pinned at `ba3128f5`.
- `probe-delta.ps1` — the two delta-re-review probes: **P1** reconciles 33,448 rationaled edges against 33,445 distinct composite keys (3 known near-key collisions); **P2** reproduces the silent fail-open on a committed-but-empty `edges` array, filed as t/2953.
- `c-evidence-transcript.txt`, `probe-transcript.txt` — captured output of the runs quoted in t/2947.
- `README.md` — heads under evidence, re-run instructions, results.

### Results recorded

Clean arm: baseline resolved to 33,445 rationaled keys, payload scanned 33,454 checked / 0 skipped, returns 0, zero warnings, no throw. Strip arm: throws `New-ActionableError` with all four fields. Split arm: `payload scanned` and `no edges KEY` are non-overlapping. Three replications, all PASS.

### Safety

Read-only evidence. No PowerShell source file is edited under any arm (t/2947 forbids it); the strip arm mutates an in-memory copy of the payload, and P2 builds its own throwaway git sandbox under `TEMP` and removes it. Nothing is written to `ai-triad-data`.

### Relationship to PR #1435

Independent of it. This PR carries **no** guard code — #1435 is the flip and carries its own review and GV. Merging this one neither gates nor unblocks the flip.

Tickets: t/2947 (evidence half), t/2953 (follow-up filed from P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgWFhDqtH1pub4jgxHwume
