### PR TITLE
tools(cl): twin-aware edge-rationale re-merge from HEAD + both-arms proof (t/2946)

### DIFF
--- a/research/comp-linguist/analyses/t2444-rationale-restore/remerge_from_head.py
+++ b/research/comp-linguist/analyses/t2444-rationale-restore/remerge_from_head.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+# Scoped twin-aware edge-rationale re-merge from committed HEAD (t/2946, t/2444).
+#
+# WHAT THIS IS FOR
+#   The confirmed recurrence vector (t/2946#5) is the taxonomy-editor load-list /
+#   save-whole-file round-trip: it loads edges with `rationale` stripped by the load-side
+#   projection, then writes the whole file back through the TS serializer -- silently
+#   dropping the field for every edge it round-tripped, while legitimately appending the
+#   edges the user actually added.
+#
+#   The repair is a RE-MERGE, not a `git checkout`. A checkout would restore the stripped
+#   rationales but also discard the newly appended edges, which are real user work. This
+#   re-merges `rationale` from committed HEAD into the working-tree file, edge by edge,
+#   and leaves everything else -- including the appended edges -- untouched.
+#
+#   This is the offline twin of the Option-1 site fix the AC prescribes (`save-edges` IPC +
+#   `PUT /api/edges` re-merging rationale from HEAD before writing). It uses the SAME
+#   twin-aware identity the restore uses, per TL e/120#37: one identity model across
+#   guard + restore + re-merge.
+#
+# IDENTITY MODEL (TL-prescribed, e/120#37 -- shared with apply_restore.py)
+#   Edges have no `id`. Primary key is the composite `(source, type, target)`.
+#   That is a NEAR-key, not a key: on the live file 3 keys carry 2 genuinely distinct
+#   edges each (t/2946#4). Where the key is non-unique in EITHER file, the twin is
+#   disambiguated on `discovered_at` + `model`. If it is still ambiguous after that
+#   tie-break, the edge is REFUSED and logged -- never guessed. A mis-attributed
+#   rationale is invisible to the byte proofs below, so it has to be refused up front.
+#
+# SAFETY MODEL
+#   * Round-trip self-check: the serializer must reproduce the current working-tree file
+#     byte-for-byte before anything is trusted. Otherwise: abort, write nothing.
+#   * `rationale` is inserted immediately after `confidence`, preserving every other key
+#     in its exact current order (the live file has many distinct per-edge key orderings;
+#     we never reorder).
+#   * Edges that already carry a rationale are left byte-for-byte untouched.
+#   * STRIP-BACK PROOF: removing only the rationales we added and re-serializing must
+#     reproduce the pre-merge file byte-for-byte. If not: abort, write nothing.
+#   * Scope is intrinsically bounded by what HEAD carries -- this re-merges only fields
+#     that are already committed. It is NOT the ba3128f5 restore (t/2946 Phase 1), which
+#     stays gated on the durability AC.
+#
+# Usage:
+#   python remerge_from_head.py --data-repo <path-to-ai-triad-data>
+#                               [--file taxonomy/Origin/edges.json]
+#                               [--head-ref HEAD] [--out PATH | --write-in-place]
+
+import argparse, collections, json, os, subprocess, sys
+
+
+def has_rat(e):
+    r = e.get("rationale")
+    return isinstance(r, str) and r.strip() != ""
+
+
+def ckey(e):
+    return (e.get("source"), e.get("type"), e.get("target"))
+
+
+def twin_id(e):
+    return (e.get("source"), e.get("type"), e.get("target"),
+            e.get("discovered_at"), e.get("model"))
+
+
+def serialize(doc):
+    """Byte-compatible with lib/edges/serializeEdges.ts (round-trip verified per run)."""
+    parts = []
+    for k in doc:
+        v = doc[k]
+        if k == "edges" and isinstance(v, list):
+            if not v:
+                parts.append('  "edges": []')
+                continue
+            lines = ",\n".join(
+                "    " + json.dumps(e, ensure_ascii=False, separators=(",", ":")) for e in v
+            )
+            parts.append('  "edges": [\n' + lines + "\n  ]")
+        else:
+            pretty = json.dumps(v, ensure_ascii=False, indent=2).replace("\n", "\n  ")
+            parts.append("  " + json.dumps(k) + ": " + pretty)
+    return "{\n" + ",\n".join(parts) + "\n}\n"
+
+
+def insert_after_confidence(e, rat):
+    out = {}
+    for k, v in e.items():
+        out[k] = v
+        if k == "confidence":
+            out["rationale"] = rat
+    if "rationale" not in out:  # no `confidence` key: append at end
+        out["rationale"] = rat
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-repo", required=True)
+    ap.add_argument("--file", default="taxonomy/Origin/edges.json")
+    ap.add_argument("--head-ref", default="HEAD")
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--write-in-place", action="store_true")
+    args = ap.parse_args()
+
+    cur_path = os.path.join(args.data_repo, args.file)
+    cur_blob = open(cur_path, encoding="utf-8", newline="").read()
+    cur_doc = json.loads(cur_blob)
+
+    env = dict(os.environ, MSYS_NO_PATHCONV="1")
+    head_blob = subprocess.run(
+        ["git", "-C", args.data_repo, "show", f"{args.head_ref}:{args.file}"],
+        capture_output=True, check=True, env=env,
+    ).stdout.decode("utf-8")
+    head_edges = json.loads(head_blob)["edges"]
+
+    # Serializer must reproduce the CURRENT file byte-for-byte before we trust it.
+    if serialize(cur_doc) != cur_blob:
+        sys.exit("ABORT: serializer does not round-trip the working-tree file byte-for-byte; "
+                 "the file's byte format has changed -- update serialize() before re-merging.")
+
+    head_by_ck = collections.defaultdict(list)
+    for e in head_edges:
+        head_by_ck[ckey(e)].append(e)
+    cur_by_ck = collections.defaultdict(list)
+    for e in cur_doc["edges"]:
+        cur_by_ck[ckey(e)].append(e)
+
+    had = {twin_id(e) for e in cur_doc["edges"] if has_rat(e)}
+
+    remerged = kept = absent = 0
+    refused = []
+    changed = []
+    new_edges = []
+
+    for e in cur_doc["edges"]:
+        if has_rat(e):
+            kept += 1
+            new_edges.append(e)
+            continue
+        k = ckey(e)
+        cands = head_by_ck.get(k, [])
+        if not cands:
+            absent += 1                       # appended in the working tree; nothing to merge
+            new_edges.append(e)
+            continue
+        # Twin-aware disambiguation: only trust a bare composite-key match when that key
+        # is unique on BOTH sides. Otherwise tie-break on discovered_at + model.
+        if len(cands) == 1 and len(cur_by_ck[k]) == 1:
+            match = cands[0]
+        else:
+            tw = [c for c in cands if twin_id(c) == twin_id(e)]
+            if len(tw) == 1:
+                match = tw[0]
+            else:
+                refused.append({"key": k, "discovered_at": e.get("discovered_at"),
+                                "model": e.get("model"), "head_candidates": len(cands),
+                                "twin_matches": len(tw)})
+                new_edges.append(e)
+                continue
+        if has_rat(match):
+            new_edges.append(insert_after_confidence(e, match["rationale"]))
+            remerged += 1
+            changed.append({"key": k, "discovered_at": e.get("discovered_at"),
+                            "model": e.get("model")})
+        else:
+            absent += 1
+            new_edges.append(e)
+
+    cur_doc["edges"] = new_edges
+    out_blob = serialize(cur_doc)
+
+    # STRIP-BACK PROOF: strip only the rationales we added; must equal the pre-merge file.
+    check = json.loads(out_blob)
+    for e in check["edges"]:
+        if twin_id(e) not in had:
+            e.pop("rationale", None)
+    if serialize(check) != cur_blob:
+        sys.exit("ABORT: strip-back proof failed -- the re-merge changed more than rationale. "
+                 "Nothing written.")
+
+    print(f"re-merged={remerged}  kept_existing={kept}  "
+          f"no_head_rationale_or_appended={absent}  refused_ambiguous={len(refused)}")
+    for c in changed:
+        print(f"  + {c['key'][0]} {c['key'][1]} {c['key'][2]}  "
+              f"({c['discovered_at']}, {c['model']})")
+    if refused:
+        print("\nREFUSED (ambiguous twin -- rationale NOT attributed, needs manual "
+              "disambiguation):")
+        for r in refused:
+            print(f"  ! {r['key']}  discovered_at={r['discovered_at']} model={r['model']} "
+                  f"head_candidates={r['head_candidates']} twin_matches={r['twin_matches']}")
+
+    final = sum(1 for e in new_edges if has_rat(e))
+    print(f"\nedges with rationale: {len(had)} -> {final} / {len(new_edges)}")
+    print("strip-back proof: PASS (only rationale changed)")
+
+    if refused:
+        sys.exit("\nABORT: refused-and-log is non-empty -- nothing written. Disambiguate the "
+                 "twins above, then re-run.")
+
+    out_path = cur_path if args.write_in_place else (args.out or cur_path + ".remerged")
+    with open(out_path, "w", encoding="utf-8", newline="") as f:
+        f.write(out_blob)
+    print(f"wrote: {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/research/comp-linguist/analyses/t2444-rationale-restore/test_remerge_from_head.py
+++ b/research/comp-linguist/analyses/t2444-rationale-restore/test_remerge_from_head.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Both-arms proof for remerge_from_head.py.
+
+A deliberate failure must fire the refusal; the clean case must pass with zero noise.
+Builds throwaway git repos so the real code path (including `git show`) is exercised.
+"""
+import json, os, shutil, subprocess, sys, tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from remerge_from_head import serialize  # noqa: E402
+
+TOOL = os.path.join(os.path.dirname(os.path.abspath(__file__)), "remerge_from_head.py")
+ENV = dict(os.environ, MSYS_NO_PATHCONV="1")
+
+
+def edge(src, typ, tgt, conf, disc, model, rat=None):
+    e = {"source": src, "target": tgt, "type": typ, "bidirectional": False,
+         "confidence": conf, "weight": conf, "discovered_at": disc, "model": model}
+    if rat is not None:
+        # match the live layout: rationale sits immediately after confidence
+        out = {}
+        for k, v in e.items():
+            out[k] = v
+            if k == "confidence":
+                out["rationale"] = rat
+        return out
+    return e
+
+
+def doc(edges):
+    return {"_schema_version": "1.0.0", "last_modified": "2026-08-20T00:00:00.000Z",
+            "edges": edges}
+
+
+def make_repo(tmp, head_edges, wt_edges):
+    repo = tempfile.mkdtemp(dir=tmp)
+    os.makedirs(os.path.join(repo, "taxonomy", "Origin"))
+    path = os.path.join(repo, "taxonomy", "Origin", "edges.json")
+
+    def write(edges):
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(serialize(doc(edges)))
+
+    q = dict(capture_output=True, cwd=repo, env=ENV)
+    subprocess.run(["git", "init", "-q"], **q)
+    subprocess.run(["git", "config", "user.email", "t@t"], **q)
+    subprocess.run(["git", "config", "user.name", "t"], **q)
+    subprocess.run(["git", "config", "core.autocrlf", "false"], **q)
+    write(head_edges)
+    subprocess.run(["git", "add", "-A"], **q)
+    subprocess.run(["git", "commit", "-qm", "head"], **q)
+    write(wt_edges)
+    return repo, path
+
+
+def run(repo):
+    return subprocess.run([sys.executable, TOOL, "--data-repo", repo, "--write-in-place"],
+                          capture_output=True, text=True, env=ENV)
+
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}" + (f" -- {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+tmp = tempfile.mkdtemp()
+try:
+    # ---- ARM 1 (positive): stripped rationales re-merge; appended edge preserved -------
+    print("\nARM 1 -- positive: strip 2, append 1")
+    head = [edge("a", "SUPPORTS", "b", 0.9, "2026-01-01", "m1", "rat-AB"),
+            edge("c", "SUPPORTS", "d", 0.8, "2026-01-02", "m1", "rat-CD"),
+            edge("e", "SUPPORTS", "f", 0.7, "2026-01-03", "m1")]
+    wt = [edge("a", "SUPPORTS", "b", 0.9, "2026-01-01", "m1"),          # stripped
+          edge("c", "SUPPORTS", "d", 0.8, "2026-01-02", "m1"),          # stripped
+          edge("e", "SUPPORTS", "f", 0.7, "2026-01-03", "m1"),          # never had one
+          edge("g", "SUPPORTS", "h", 0.6, "2026-02-01", "m2", "rat-GH")]  # appended by user
+    repo, path = make_repo(tmp, head, wt)
+    r = run(repo)
+    print("   " + r.stdout.strip().replace("\n", "\n   "))
+    check("exit 0", r.returncode == 0, r.stderr)
+    check("re-merged=2", "re-merged=2" in r.stdout)
+    check("strip-back proof PASS", "strip-back proof: PASS" in r.stdout)
+    got = json.load(open(path, encoding="utf-8"))["edges"]
+    check("AB rationale restored", got[0].get("rationale") == "rat-AB")
+    check("CD rationale restored", got[1].get("rationale") == "rat-CD")
+    check("EF still has none", "rationale" not in got[2])
+    check("appended GH preserved with its rationale",
+          len(got) == 4 and got[3]["source"] == "g" and got[3]["rationale"] == "rat-GH")
+    check("rationale inserted after confidence",
+          list(got[0].keys()).index("rationale") == list(got[0].keys()).index("confidence") + 1)
+
+    # ---- ARM 2 (negative): ambiguous twin must refuse and write NOTHING ---------------
+    print("\nARM 2 -- negative: ambiguous twin (same key, same discovered_at+model)")
+    head = [edge("a", "SUPPORTS", "b", 0.9, "2026-01-01", "m1", "rat-TWIN-1"),
+            edge("a", "SUPPORTS", "b", 0.5, "2026-01-01", "m1", "rat-TWIN-2")]
+    wt = [edge("a", "SUPPORTS", "b", 0.9, "2026-01-01", "m1"),
+          edge("a", "SUPPORTS", "b", 0.5, "2026-01-01", "m1")]
+    repo, path = make_repo(tmp, head, wt)
+    before = open(path, encoding="utf-8", newline="").read()
+    r = run(repo)
+    print("   " + (r.stdout + r.stderr).strip().replace("\n", "\n   "))
+    check("exit non-zero", r.returncode != 0)
+    check("refused_ambiguous=2", "refused_ambiguous=2" in r.stdout)
+    check("REFUSED logged", "REFUSED" in r.stdout)
+    check("re-merged=0", "re-merged=0" in r.stdout)
+    check("file left byte-identical (nothing written)",
+          open(path, encoding="utf-8", newline="").read() == before)
+
+    # ---- ARM 3 (twin, resolvable): distinct discovered_at/model -> correct attribution -
+    print("\nARM 3 -- twin resolvable on discovered_at+model")
+    head = [edge("a", "SUPPORTS", "b", 0.9, "2026-03-01", "gemini-2.5-flash", "rat-MARCH"),
+            edge("a", "SUPPORTS", "b", 0.5, "2026-06-11", "llm_proposed", "rat-JUNE")]
+    wt = [edge("a", "SUPPORTS", "b", 0.9, "2026-03-01", "gemini-2.5-flash"),
+          edge("a", "SUPPORTS", "b", 0.5, "2026-06-11", "llm_proposed")]
+    repo, path = make_repo(tmp, head, wt)
+    r = run(repo)
+    print("   " + r.stdout.strip().replace("\n", "\n   "))
+    check("exit 0", r.returncode == 0, r.stderr)
+    check("re-merged=2", "re-merged=2" in r.stdout)
+    got = json.load(open(path, encoding="utf-8"))["edges"]
+    check("March twin got the March rationale", got[0].get("rationale") == "rat-MARCH")
+    check("June twin got the June rationale", got[1].get("rationale") == "rat-JUNE")
+
+    # ---- ARM 4 (clean no-op): nothing to do, zero noise -------------------------------
+    print("\nARM 4 -- clean: working tree already matches HEAD")
+    head = [edge("a", "SUPPORTS", "b", 0.9, "2026-01-01", "m1", "rat-AB")]
+    repo, path = make_repo(tmp, head, head)
+    before = open(path, encoding="utf-8", newline="").read()
+    r = run(repo)
+    print("   " + r.stdout.strip().replace("\n", "\n   "))
+    check("exit 0", r.returncode == 0, r.stderr)
+    check("re-merged=0", "re-merged=0" in r.stdout)
+    check("no refusals", "REFUSED" not in r.stdout)
+    check("file unchanged", open(path, encoding="utf-8", newline="").read() == before)
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+print("\n" + ("ALL ARMS PASS" if not failures else f"FAILURES: {failures}"))
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
Offline counterpart of the **Option-1 site fix** the t/2946 durability AC prescribes (`save-edges` IPC + `PUT /api/edges` re-merge `rationale` from HEAD before writing). Adds the tool + its both-arms proof; **no data is committed by this PR**.

## Why a re-merge and not a checkout

The confirmed recurrence vector (t/2946#5) is the taxonomy-editor load-list/save-whole-file round-trip: it loads edges with `rationale` stripped by the load-side projection, then writes the whole file back through the TS serializer — dropping the field for every edge it round-tripped, while legitimately appending the edges the user actually added. `git checkout` would restore the stripped rationales *and discard the appended edges*, which are real user work.

## Identity model

The one TL prescribed in e/120#37, shared with `apply_restore.py` — one model across guard + restore + re-merge:

- primary key `source|type|target`
- where that key is non-unique in **either** file, disambiguate the twin on `discovered_at` + `model`
- if still ambiguous: **refuse and log**, never guess

That last case is the point. A mis-attributed rationale satisfies *both* byte proofs — "only rationale changed" and exact strip-back — so it is invisible downstream (t/2946#4). It has to be refused up front.

## Safety

- serializer must round-trip the target file byte-for-byte before anything is trusted
- `rationale` inserted after `confidence`; all other keys keep their exact current order
- strip-back of only the added rationales must reproduce the pre-merge file byte-for-byte, else **abort, nothing written**

## Both-arms proof

`test_remerge_from_head.py` builds throwaway git repos so the real `git show` path is exercised:

| Arm | Case | Expect |
|---|---|---|
| 1 | positive: 2 stripped, 1 appended | re-merged=2, appended preserved with its rationale, insert position correct |
| 2 | **negative**: ambiguous twin | refuses, exits non-zero, file left byte-identical |
| 3 | twin resolvable on `discovered_at`+`model` | each twin gets its own rationale, no crossover |
| 4 | clean | no-op, zero noise |

**All arms pass**, locally and from the landed path.

## Live-tree status

Verified against the live tree at 11:21 EDT — reproduced CL.Investigate1's #60 finding exactly: 6 regressed, 2 appended, 0 dropped, 0 other diffs, none of the 6 a twin. At 11:22:17 `edges.json` was repaired by a writer outside my process; the tool now reports `re-merged=0 / kept_existing=8`, strip-back PASS — i.e. the live tree is already in the end state this tool would produce. Attribution of that write is open with CL.Investigate1 (p/250#46).

## Scope

Re-merges only what committed HEAD already carries. **Not** the ba3128f5 33.4k restore (t/2946 Phase 1), which stays gated on the durability AC.

Draft until the attribution question resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNNKmUpy2fEE7mRCsh666D