### PR TITLE
fix(scripts): edge-rationale guard shape+observability hardening + rationale_source pin (t/2955, t/2953, t/2950)

### DIFF
--- a/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
+++ b/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
@@ -19,6 +19,13 @@
 # on the live 33,580-edge file 3 keys carry 2 genuinely distinct edges each. Benign for THIS
 # guard today; twin-aware identity lives in the shared re-merge util + restore (t/2946 AC).
 #
+# EDGE SHAPE (t/2955): edge field reads go through Test-EdgeHasField / Get-EdgeField so a raw
+# [hashtable]/[IDictionary] edge is CHECKED, not skipped — a hashtable's PSObject.Properties are
+# Count/Keys/Values, not its entries, so a naive `$e.PSObject.Properties['source']` silently
+# skipped hashtable edges and a rationale wipe delivered that way passed the gate. Symmetric with
+# Get-EdgesArray's document-level IDictionary branch; Write-EdgesFile serializes both shapes (AC#4).
+# t/2953: a committed-but-EMPTY `edges` baseline now emits its own distinguishable fail-open line.
+#
 # GATE PROMOTION (t/2683): Phase 1 WARN landed (#1430 / 491c7554). Phase 2 hardening
 # (fail-open + observability + caching) landed (#1433 / 21a69608). THIS is the promotion:
 # default -> BLOCK, gated on CL's ba3128f5-as-HEAD positive real-data cycle + TL GV (t/2947).
@@ -75,7 +82,16 @@ function Get-EdgesFromHead {
         }
         else {
             $parsed = ($json -join "`n") | ConvertFrom-Json
-            if ($parsed.PSObject.Properties['edges']) { $result = @($parsed.edges) }
+            if ($parsed.PSObject.Properties['edges']) {
+                $result = @($parsed.edges)
+                # t/2953: a committed-but-EMPTY `edges` array is a real read, not a lookup failure,
+                # but @() unrolls to $null on return so the caller short-circuits at the `$null -eq
+                # $BaselineEdges` check — previously with NO verbose (the only silent fail-open path
+                # on the first/uncached resolution; the cache-hit path already annotates it). Emit a
+                # DISTINGUISHABLE line naming the shape so a payload scan can classify it into exactly
+                # one class, non-overlapping with 'has no edges array' (missing key) and 'not found'.
+                if ($result.Count -eq 0) { Write-Verbose "edge-rationale baseline: HEAD '$rel' has an EMPTY edges array — no committed baseline to protect — fail-open." }
+            }
             else { Write-Verbose 'edge-rationale baseline: HEAD edges.json has no edges array — fail-open.' }
         }
         if ($headSha) { $script:EdgeHeadBaselineCache[$cacheKey] = $result }
@@ -99,6 +115,31 @@ function Get-EdgesArray {
     }
     if ($EdgesData.PSObject -and $EdgesData.PSObject.Properties['edges']) { return @{ HasKey = $true; Edges = @($EdgesData.edges) } }
     return @{ HasKey = $false; Edges = @() }
+}
+
+function Test-EdgeHasField {
+    # Is a named field present on an edge ELEMENT that may be a PSCustomObject (the common
+    # ConvertFrom-Json shape) OR a raw [IDictionary]/[hashtable]? Element-level symmetry with
+    # Get-EdgesArray's document-level IDictionary branch (t/2955): a hashtable's PSObject.Properties
+    # are Count/Keys/Values — NOT its entries — so `$e.PSObject.Properties['source']` finds nothing
+    # for a hashtable edge and the edge is wrongly bucketed as "missing key fields" and skipped.
+    param($Edge, [string]$Name)
+    if ($null -eq $Edge) { return $false }
+    if ($Edge -is [System.Collections.IDictionary]) { return $Edge.Contains($Name) }
+    return [bool]($Edge.PSObject -and $Edge.PSObject.Properties[$Name])
+}
+
+function Get-EdgeField {
+    # Read a named field's value from an edge element (PSCustomObject OR [IDictionary]); $null when
+    # absent. Paired with Test-EdgeHasField so field reads work uniformly across both shapes (t/2955).
+    param($Edge, [string]$Name)
+    if ($null -eq $Edge) { return $null }
+    if ($Edge -is [System.Collections.IDictionary]) {
+        if ($Edge.Contains($Name)) { return $Edge[$Name] }
+        return $null
+    }
+    if ($Edge.PSObject -and $Edge.PSObject.Properties[$Name]) { return $Edge.PSObject.Properties[$Name].Value }
+    return $null
 }
 
 function Test-EdgeRationaleRegression {
@@ -146,10 +187,11 @@ function Test-EdgeRationaleRegression {
 
         $hadRationale = @{}
         foreach ($e in @($BaselineEdges)) {
-            if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { continue }
-            $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
+            if (-not ((Test-EdgeHasField $e 'source') -and (Test-EdgeHasField $e 'type') -and (Test-EdgeHasField $e 'target'))) { continue }
+            $rv = Get-EdgeField $e 'rationale'
+            $r  = if ($null -ne $rv) { [string]$rv } else { '' }
             if (-not [string]::IsNullOrWhiteSpace($r)) {
-                $hadRationale["$($e.source)|$($e.type)|$($e.target)"] = $true
+                $hadRationale["$(Get-EdgeField $e 'source')|$(Get-EdgeField $e 'type')|$(Get-EdgeField $e 'target')"] = $true
             }
         }
         if ($hadRationale.Count -eq 0) { Write-Verbose 'edge-rationale guard: HEAD baseline carries no rationaled edges — nothing to protect.'; return 0 }
@@ -165,11 +207,12 @@ function Test-EdgeRationaleRegression {
 
         $checked = 0; $skipped = 0
         foreach ($e in $writeEdges) {
-            if (-not ($e.PSObject.Properties['source'] -and $e.PSObject.Properties['type'] -and $e.PSObject.Properties['target'])) { $skipped++; continue }
+            if (-not ((Test-EdgeHasField $e 'source') -and (Test-EdgeHasField $e 'type') -and (Test-EdgeHasField $e 'target'))) { $skipped++; continue }
             $checked++
-            $key = "$($e.source)|$($e.type)|$($e.target)"
+            $key = "$(Get-EdgeField $e 'source')|$(Get-EdgeField $e 'type')|$(Get-EdgeField $e 'target')"
             if ($hadRationale.ContainsKey($key)) {
-                $r = if ($e.PSObject.Properties['rationale']) { [string]$e.rationale } else { '' }
+                $rv = Get-EdgeField $e 'rationale'
+                $r  = if ($null -ne $rv) { [string]$rv } else { '' }
                 if ([string]::IsNullOrWhiteSpace($r)) { [void]$lost.Add($key) }
             }
         }

--- a/scripts/AITriad/Private/Write-EdgesFile.ps1
+++ b/scripts/AITriad/Private/Write-EdgesFile.ps1
@@ -49,7 +49,19 @@ function Write-EdgesFile {
     $sb = [System.Text.StringBuilder]::new()
     [void]$sb.Append("{`n")
 
-    $props = @($EdgesData.PSObject.Properties)
+    # Top-level shape normalization (t/2955 AC#4): iterate a uniform [{Name;Value}] list whether
+    # the document is the usual PSCustomObject (ConvertFrom-Json) OR a raw [IDictionary]/[hashtable].
+    # Without this branch a hashtable document's `.PSObject.Properties` yields Count/Keys/Values
+    # (NOT its entries), so the whole document would mis-serialize — the "half-support" the
+    # edge-rationale guard's document-level IDictionary branch would otherwise protect but this
+    # sink could not honor. Use [ordered]@{} upstream for deterministic key order (a bare hashtable
+    # has no defined order). Per-edge shape is already handled below via ConvertTo-Json.
+    $props =
+        if ($EdgesData -is [System.Collections.IDictionary]) {
+            @($EdgesData.Keys | ForEach-Object { [PSCustomObject]@{ Name = $_; Value = $EdgesData[$_] } })
+        } else {
+            @($EdgesData.PSObject.Properties)
+        }
     for ($i = 0; $i -lt $props.Count; $i++) {
         $prop     = $props[$i]
         $keyJson  = $prop.Name | ConvertTo-Json -Compress

--- a/tests/EdgeRationaleRegression.Tests.ps1
+++ b/tests/EdgeRationaleRegression.Tests.ps1
@@ -29,6 +29,15 @@ BeforeAll {
         param([object[]]$Edges)
         [PSCustomObject]@{ _schema_version = '1.0.0'; edges = @($Edges) }
     }
+    # t/2955: a RAW [hashtable] edge (NOT cast to PSCustomObject). A hashtable's PSObject.Properties
+    # are Count/Keys/Values, so a naive `$e.PSObject.Properties['source']` finds nothing and the edge
+    # was silently skipped by the guard. -Rationale omitted => the field is absent (a genuine wipe).
+    function New-HashEdge {
+        param([string]$Source, [string]$Type, [string]$Target, [string]$Rationale)
+        $h = @{ source = $Source; type = $Type; target = $Target; confidence = 0.95; status = 'approved' }
+        if ($PSBoundParameters.ContainsKey('Rationale')) { $h['rationale'] = $Rationale }
+        $h
+    }
 }
 
 Describe 'Test-EdgeRationaleRegression — Arm 1 both-arms (t/2945)' -Tag 'edges' {
@@ -175,6 +184,79 @@ Describe 'Test-EdgeRationaleRegression — Block flip + positive observability (
     }
 }
 
+Describe 'Test-EdgeRationaleRegression — edge SHAPE coverage: hashtable edges are checked, not skipped (t/2955)' -Tag 'edges' {
+
+    BeforeEach {
+        $script:Baseline = @(
+            (New-Edge 'acc-001' 'SUPPORTS'    'saf-002' 'because X reinforces Y'),
+            (New-Edge 'acc-003' 'CONTRADICTS' 'skp-004' 'because Z conflicts with W')
+        )
+    }
+
+    It 'FIRE: a rationale wipe delivered as a hashtable edge in a PSCustomObject doc THROWS in Block (was silently skipped)' {
+        $write = New-EdgesData @( (New-HashEdge 'acc-001' 'SUPPORTS' 'saf-002') )   # hashtable edge, rationale absent
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Throw
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+        }
+    }
+
+    It 'FIRE: a rationale wipe delivered as a hashtable edge in a HASHTABLE doc THROWS in Block' {
+        $write = @{ _schema_version = '1.0.0'; edges = @( (New-HashEdge 'acc-001' 'SUPPORTS' 'saf-002') ) }  # doc AND edge are hashtables
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Throw
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+        }
+    }
+
+    It 'CONTROL: the same wipe as a PSCustomObject edge also throws (parity across shapes)' {
+        $write = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Throw
+        }
+    }
+
+    It 'CLEAN: a rationale-PRESERVING hashtable edge passes SILENTLY with zero noise (both-arms clean case)' {
+        $write = New-EdgesData @( (New-HashEdge 'acc-001' 'SUPPORTS' 'saf-002' 'because X reinforces Y') )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            $n = Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningVariable w -WarningAction SilentlyContinue
+            $n | Should -Be 0
+            @($w).Count | Should -Be 0
+        }
+    }
+
+    It 'SKIPPED counter is accurate: a well-formed hashtable edge is CHECKED (checked 1, skipped 0), not skipped for its container type' {
+        $write = New-EdgesData @( (New-HashEdge 'acc-001' 'SUPPORTS' 'saf-002' 'because X reinforces Y') )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            $v = (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -Verbose 4>&1) | Out-String
+            $v | Should -Match 'payload scanned — checked 1 edge\(s\), skipped 0'
+        }
+    }
+
+    It 'SKIPPED counter still counts a genuinely malformed edge (missing key fields), regardless of container type' {
+        $write = New-EdgesData @( (New-HashEdge 'acc-001' 'SUPPORTS' 'saf-002' 'keep me'), @{ confidence = 0.5 } )  # 2nd edge lacks source/type/target
+        InModuleScope AITriad -Parameters @{ W = $write; B = $script:Baseline } {
+            param($W, $B)
+            $v = (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -Verbose 4>&1) | Out-String
+            $v | Should -Match 'payload scanned — checked 1 edge\(s\), skipped 1'
+        }
+    }
+
+    It 'BASELINE shape: a hashtable baseline edge is honored too (its rationale protects the key)' {
+        $hashBaseline = @( (New-HashEdge 'acc-001' 'SUPPORTS' 'saf-002' 'committed rationale') )
+        $write        = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002') )   # drops it
+        InModuleScope AITriad -Parameters @{ W = $write; B = $hashBaseline } {
+            param($W, $B)
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+        }
+    }
+}
+
 Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution + caching (git-backed, real repo)' -Tag 'edges' {
 
     It 'resolves the baseline from HEAD and fires on a same-file rationale strip; clean on add-only' {
@@ -215,6 +297,30 @@ Describe 'Test-EdgeRationaleRegression — HEAD baseline resolution + caching (g
             @($script:EdgeHeadBaselineCache.Keys).Count | Should -BeGreaterThan 0
             $v = (Test-EdgeRationaleRegression -EdgesData $Strip -Path $EdgesPath -Mode Warn -Verbose -WarningAction SilentlyContinue 4>&1) | Out-String
             $v | Should -Match 'cache hit — 1 committed baseline edge'   # resolved baseline, not dead-lookup
+        }
+    }
+
+    It 't/2953: a committed-but-EMPTY edges array baseline fails open with its OWN distinguishable verbose on the FIRST (uncached) resolution' {
+        $repo = Join-Path $TestDrive 'emptybaselinerepo'
+        $tax  = Join-Path $repo 'taxonomy/Origin'
+        New-Item -ItemType Directory -Path $tax -Force | Out-Null
+        $edgesPath = Join-Path $tax 'edges.json'
+        $committed = New-EdgesData @()                                        # committed { "edges": [] }
+        $write     = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'new edge') )
+        InModuleScope AITriad -Parameters @{ Committed = $committed; Write = $write; EdgesPath = $edgesPath; Repo = $repo } {
+            param($Committed, $Write, $EdgesPath, $Repo)
+            Write-EdgesFile -EdgesData $Committed -Path $EdgesPath
+            Push-Location $Repo
+            try { git init -q 2>$null; git config user.email 't@t' 2>$null; git config user.name 't' 2>$null; git add -A 2>$null; git commit -q -m empty 2>$null } finally { Pop-Location }
+            $script:EdgeHeadBaselineCache = @{}
+            # FIRST (uncached) resolution: returns 0 (fail-open) AND emits ≥1 verbose naming the empty shape.
+            $v = (Test-EdgeRationaleRegression -EdgesData $Write -Path $EdgesPath -Mode Warn -Verbose 4>&1) | Out-String
+            (Test-EdgeRationaleRegression -EdgesData $Write -Path $EdgesPath -Mode Block) | Should -Be 0   # fails OPEN, no throw
+            $v | Should -Match 'EMPTY edges array'
+            # Distinct from the other fail-open strings (not conflatable by a payload-scan classifier).
+            $v | Should -Not -Match 'has no edges array'
+            $v | Should -Not -Match 'not found in the repo'
+            $v | Should -Not -Match 'payload scanned'
         }
     }
 

--- a/tests/Write-EdgesFile.Tests.ps1
+++ b/tests/Write-EdgesFile.Tests.ps1
@@ -97,3 +97,84 @@ Describe 'Write-EdgesFile (t/1943: edges.json byte contract)' -Tag 'taxonomy' {
         }
     }
 }
+
+Describe 'Write-EdgesFile — rationale_source provenance survives round-trip (t/2950)' -Tag 'taxonomy' {
+    # CL design edge-rationale-source-marker.md: edges carry an optional rationale_source with a
+    # closed vocabulary (discovery|embedding-template|reflection|restore|backfill|human); absent =
+    # legacy/unknown. Write-EdgesFile is structurally field-agnostic (ConvertTo-Json over the whole
+    # edge PSObject), so it SHOULD preserve the field untouched — this pins that a future refactor to
+    # explicit property projection can't silently drop a provenance marker (invisible in the data:
+    # a dropped marker looks exactly like a legacy edge). Test-only; no production change expected.
+
+    It 'preserves rationale_source value AND its key position, and keeps a legacy edge field-absent' {
+        $OutPath = Join-Path ([System.IO.Path]::GetTempPath()) "write-edges-ratsrc-$(Get-Random).json"
+        try {
+            # Edge 1 carries rationale_source=restore (positioned right after rationale). Edge 2 is a
+            # legacy edge with the field ABSENT — it must stay absent, never materialized as null.
+            $withSource = [PSCustomObject][ordered]@{
+                source = 'acc-001'; type = 'SUPPORTS'; target = 'saf-002'
+                confidence = 0.95; rationale = 'because X'; rationale_source = 'restore'
+            }
+            $legacy = [PSCustomObject][ordered]@{
+                source = 'acc-003'; type = 'CONTRADICTS'; target = 'skp-004'
+                confidence = 0.9; rationale = 'because Z'
+            }
+            $Data = [PSCustomObject][ordered]@{ _schema_version = '1.0.0'; edges = @($withSource, $legacy) }
+
+            InModuleScope AITriad -Parameters @{ Data = $Data; OutPath = $OutPath } {
+                param($Data, $OutPath)
+                Write-EdgesFile -EdgesData $Data -Path $OutPath
+            }
+
+            $Text     = [System.IO.File]::ReadAllText($OutPath)
+            $Reparsed = $Text | ConvertFrom-Json
+
+            # Value preserved on re-read.
+            $e1 = $Reparsed.edges[0]
+            $e1.rationale_source | Should -Be 'restore' -Because 'the provenance marker must survive serialization'
+
+            # Key POSITION preserved: rationale_source serialized immediately after rationale (compact contract).
+            $Text | Should -Match '"rationale":"because X","rationale_source":"restore"' -Because 'key order is preserved exactly'
+
+            # Legacy edge stays field-absent — not materialized as null/empty. Exactly ONE edge carries the marker.
+            $e2 = $Reparsed.edges[1]
+            $e2.PSObject.Properties['rationale_source'] | Should -BeNullOrEmpty -Because 'an absent marker must not be materialized'
+            ([regex]::Matches($Text, 'rationale_source')).Count | Should -Be 1 -Because 'only the one edge that had the field keeps it'
+        }
+        finally {
+            if (Test-Path -LiteralPath $OutPath) { Remove-Item -LiteralPath $OutPath -Force }
+        }
+    }
+}
+
+Describe 'Write-EdgesFile — top-level hashtable document serializes correctly (t/2955 AC#4)' -Tag 'taxonomy' {
+    # AC#4: the edge-rationale guard's document-level IDictionary branch protects a shape the sink
+    # must actually be able to write. A raw [IDictionary] document's .PSObject.Properties are
+    # Count/Keys/Values, so without the normalization branch the whole document mis-serializes.
+
+    It 'round-trips an [ordered] hashtable document (top-level keys + edges) to valid, correct JSON' {
+        $OutPath = Join-Path ([System.IO.Path]::GetTempPath()) "write-edges-hashdoc-$(Get-Random).json"
+        try {
+            # Document is a hashtable; edge is a hashtable too. [ordered] for deterministic key order.
+            $Data = [ordered]@{
+                _schema_version = '1.0.0'
+                edges = @( [ordered]@{ source = 'acc-001'; type = 'SUPPORTS'; target = 'saf-002'; confidence = 0.95; rationale = 'r1' } )
+            }
+            InModuleScope AITriad -Parameters @{ Data = $Data; OutPath = $OutPath } {
+                param($Data, $OutPath)
+                Write-EdgesFile -EdgesData $Data -Path $OutPath
+            }
+            $Text     = [System.IO.File]::ReadAllText($OutPath)
+            $Reparsed = $Text | ConvertFrom-Json
+            $Reparsed._schema_version | Should -Be '1.0.0' -Because 'top-level hashtable keys must serialize, not Count/Keys/Values'
+            @($Reparsed.edges).Count  | Should -Be 1
+            $Reparsed.edges[0].source | Should -Be 'acc-001'
+            $Reparsed.edges[0].rationale | Should -Be 'r1'
+            # No hashtable-internals leaked into the document.
+            $Text | Should -Not -Match '"(Count|Keys|Values|IsReadOnly|IsFixedSize)"' -Because 'hashtable internals must never serialize as document keys'
+        }
+        finally {
+            if (Test-Path -LiteralPath $OutPath) { Remove-Item -LiteralPath $OutPath -Force }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Batched edge-rationale guard / edge-writer hardening on the current Block-flip head — three cohesive tickets, all in `scripts/` scope, no public API or manifest change.

### t/2955 (med bug) — hashtable-shaped edge elements were silently skipped
A hashtable's `PSObject.Properties` are `Count`/`Keys`/`Values` (not its entries), so the guard's `$e.PSObject.Properties['source']` found nothing and the edge landed in the `skipped` bucket — a genuine rationale wipe delivered as hashtable edges **passed the gate**.
- **Fix:** element-level `Test-EdgeHasField` / `Get-EdgeField` helpers (symmetric with `Get-EdgesArray`'s document-level `IDictionary` branch), used at every field-read site in both the baseline loop and the payload scan → hashtable edges are now **checked, not skipped**.
- **AC#4:** `Write-EdgesFile` now normalizes a top-level `IDictionary` document into a uniform `{Name;Value}` list, so the shape the guard protects is one the sink can actually write (previously mis-serialized via `.PSObject.Properties`).

### t/2953 (low bug) — committed-but-EMPTY `edges` array failed open SILENTLY
The only unannotated fail-open path on the first (uncached) resolution. `Get-EdgesFromHead` now emits a distinguishable `"EMPTY edges array"` verbose, non-overlapping with the missing-key / not-found / payload-scanned strings — making the caller's `# already Write-Verbose'd the cause` comment true for every path.

### t/2950 (med task) — `rationale_source` round-trip pin
Pester test: `Write-EdgesFile` preserves an edge's `rationale_source` (value + key position) and keeps a legacy field-absent edge absent (no null materialized). Test-only — `Write-EdgesFile` is field-agnostic and already preserved it; this pins it against a future explicit-projection refactor silently dropping a provenance marker.

## Tests
- `EdgeRationaleRegression.Tests.ps1` **+8**: 3-shape fire/clean (hashtable edge in PSCustomObject doc, hashtable edge in hashtable doc, PSCustomObject control), skipped-counter accuracy (both arms), hashtable baseline honored, empty-baseline distinguishable verbose.
- `Write-EdgesFile.Tests.ps1` **+2**: `rationale_source` round-trip, top-level hashtable-doc serialization.
- Local: **111 green** across guard / edge-writer / module suites (0 failures); `Test-ModuleManifest` clean.

## Not in this PR
- **t/2956** (twin-aware edge identity) — deferred: blocked on **t/2946** (backlog), which builds the shared `lib/edges` twin-aware identity util. That ticket forbids inventing a third keying, so this can't proceed until the shared model lands.
- **t/2952** (ActionableError label docs) — cross-scope: touches root `AGENTS.md` + `docs/error-handling.md` (owned by the root project role), routed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVRjToQq8uw26V9xwfg5QK
