### PR TITLE
fix(cl): restore edge rationale to its original slot, not hardcoded after-confidence (t/2949)

### DIFF
--- a/research/comp-linguist/analyses/t2444-rationale-restore/apply_restore.py
+++ b/research/comp-linguist/analyses/t2444-rationale-restore/apply_restore.py
@@ -10,13 +10,23 @@
 # SAFETY MODEL (why this is a minimal, reversible data edit):
 #   * Edges have NO `id` field. Identity is the composite (source, target, type).
 #   * For each CURRENT edge that lacks a non-empty rationale but whose composite key matches a
-#     rationale-bearing edge at ba3128f5, we insert `rationale` immediately AFTER `confidence`,
-#     preserving every other key in its exact current order (the current file has 17 distinct
-#     per-edge key orderings — we never reorder).
+#     rationale-bearing edge at ba3128f5, we insert `rationale` at ITS ORIGINAL PER-EDGE POSITION
+#     — immediately after the key that preceded `rationale` in the ba3128f5 source edge — and
+#     preserve every other key in its exact current order (the file has many per-edge key
+#     orderings; we never reorder the other keys).
+#     NOTE (t/2949, wrong-slot fix): rationale was NOT always after `confidence`. Empirically,
+#     of 33,399 restorable edges, 3,761 had it after `weight` and 528 after `model`; a hardcoded
+#     "after confidence" mis-slots 4,289 edges, producing spurious diff churn on the restore that
+#     defeats the very diff-vs-HEAD signal Arm 2 relies on. Placing it after the SOURCE
+#     predecessor restores the exact original position on 33,399/33,399.
 #   * Edges already carrying a rationale in the current file are left byte-for-byte untouched.
-#   * STRIP-BACK PROOF (run every invocation): removing only the rationales we added and
-#     re-serializing must reproduce the current file byte-for-byte. If it does not, we abort
-#     and write nothing. This guarantees the restore changes *only* rationale.
+#   * TWO PROOFS (run every invocation, abort + write nothing on failure):
+#     - STRIP-BACK: removing only the rationales we added and re-serializing must reproduce the
+#       current file byte-for-byte (guarantees the restore changes *only* rationale).
+#     - POSITION: for every restored edge, `rationale`'s predecessor key must equal the source
+#       edge's predecessor (whenever that predecessor exists in the current edge). Strip-back is
+#       structurally BLIND to slot (it strips exactly what it inserted), so this second proof is
+#       required to catch a wrong-slot insertion (t/2949).
 #   * Output uses the compact hybrid contract of lib/edges/serializeEdges.ts (one compact
 #     edge per line at 4-space indent, `,`/`:` separators, LF, single trailing newline),
 #     verified to round-trip the current file byte-for-byte.
@@ -33,7 +43,7 @@
 #                              --source /tmp/edges_ba3128f5.json
 #      (optional: --out <path>  default: <current>.restored ; --write-in-place to overwrite)
 
-import argparse, json, sys, os
+import argparse, json, sys
 
 
 def load(path):
@@ -69,15 +79,47 @@ def serialize(doc):
     return "{\n" + ",\n".join(parts) + "\n}\n"
 
 
-def insert_after_confidence(e, rat):
-    out = {}
-    for k, v in e.items():
-        out[k] = v
-        if k == "confidence":
-            out["rationale"] = rat
-    if "rationale" not in out:  # no `confidence` key: append at end
-        out["rationale"] = rat
-    return out
+def source_predecessor(src_edge):
+    """The key immediately before `rationale` in the ba3128f5 source edge (None if first)."""
+    sk = list(src_edge.keys())
+    ri = sk.index("rationale")
+    return sk[ri - 1] if ri > 0 else None
+
+
+def restore_rationale(cur_edge, src_edge):
+    """Insert the source rationale into cur_edge AT ITS ORIGINAL SLOT — immediately after the key
+    that preceded `rationale` in the source. Preserve cur_edge's key order for everything else.
+    Fall back to after `confidence`, then append, only when the source predecessor is not present
+    in the current edge (differing field sets). Returns (new_edge, predecessor_used)."""
+    rat = src_edge["rationale"]
+    pred = source_predecessor(src_edge)
+    if pred is not None and pred in cur_edge:
+        out = {}
+        for k, v in cur_edge.items():
+            out[k] = v
+            if k == pred:
+                out["rationale"] = rat
+        return out, pred
+    # Fallbacks (predecessor absent from the current edge or rationale was first in source):
+    if "confidence" in cur_edge:
+        out = {}
+        for k, v in cur_edge.items():
+            out[k] = v
+            if k == "confidence":
+                out["rationale"] = rat
+        return out, "confidence"
+    out = dict(cur_edge)
+    out["rationale"] = rat
+    return out, None
+
+
+def predecessor_of(edge):
+    """The key immediately before `rationale` in `edge` (None if absent/first)."""
+    ks = list(edge.keys())
+    if "rationale" not in ks:
+        return None
+    ri = ks.index("rationale")
+    return ks[ri - 1] if ri > 0 else None
 
 
 def main():
@@ -97,25 +139,46 @@ def main():
         sys.exit("ABORT: serializer does not round-trip the current file byte-for-byte; "
                  "the file's byte format has changed — update serialize() before restoring.")
 
-    old_by = {ckey(e): e["rationale"] for e in src if has_rat(e)}
+    # Keep the whole source edge (not just its rationale text) so we can restore the original slot.
+    src_by = {ckey(e): e for e in src if has_rat(e)}
     had = {ckey(e) for e in cur_doc["edges"] if has_rat(e)}
 
     restored = kept = gap = 0
+    slot_mismatches = []   # (key, expected_pred, actual_pred) — must be empty
     new_edges = []
+    from collections import Counter
+    placement = Counter()
     for e in cur_doc["edges"]:
         if has_rat(e):
             kept += 1
             new_edges.append(e)
             continue
         k = ckey(e)
-        if k in old_by:
-            new_edges.append(insert_after_confidence(e, old_by[k]))
+        if k in src_by:
+            src_e = src_by[k]
+            new_e, used_pred = restore_rationale(e, src_e)
+            new_edges.append(new_e)
             restored += 1
+            placement[f"after:{used_pred}"] += 1
+            # POSITION PROOF (per edge): rationale must sit after the source predecessor whenever
+            # that predecessor is present in the current edge.
+            exp = source_predecessor(src_e)
+            if exp is not None and exp in e:
+                act = predecessor_of(new_e)
+                if act != exp:
+                    slot_mismatches.append((k, exp, act))
         else:
             new_edges.append(e)
             gap += 1
     cur_doc["edges"] = new_edges
     out_blob = serialize(cur_doc)
+
+    # POSITION PROOF: no restored edge may sit in the wrong slot.
+    if slot_mismatches:
+        sample = "; ".join(f"{'|'.join(map(str, k))}: expected after {exp}, got after {act}"
+                           for k, exp, act in slot_mismatches[:3])
+        sys.exit(f"ABORT: position proof failed — {len(slot_mismatches)} restored edge(s) placed "
+                 f"rationale in the wrong slot vs the ba3128f5 source. Nothing written. e.g. {sample}")
 
     # STRIP-BACK PROOF: strip only the rationales we added; must equal the original current file.
     check = json.loads(out_blob)
@@ -133,6 +196,8 @@ def main():
     final = sum(1 for e in new_edges if has_rat(e))
     print(f"restored={restored}  kept_existing={kept}  generation_gap(new edges)={gap}")
     print(f"final edges with rationale = {final} / {len(new_edges)}")
+    print(f"rationale placement (at source-original slot): {dict(placement)}")
+    print("position proof: PASS (every restored edge in its ba3128f5 slot)")
     print("strip-back proof: PASS (only rationale changed)")
     print(f"wrote: {out_path}")
     if gap:


### PR DESCRIPTION
CL Main (p/250#62) caught a latent **wrong-slot bug** in `apply_restore.py` (landed #1428). `insert_after_confidence()` placed `rationale` after `confidence` unconditionally.

**Empirically wrong for 4,289 of 33,399 restorable edges** (verified vs `ba3128f5`): 3,761 originally had `rationale` after `weight`, 528 after `model`. On the eventual t/2946 33k restore that would emit 4,289 mis-ordered lines — spurious diff churn that defeats the diff-vs-HEAD signal **Arm 2** depends on. The strip-back proof was structurally blind to it (strips exactly what it inserts, so any slot round-trips clean).

**Fix:**
- `restore_rationale()` inserts `rationale` after the key that preceded it in the **source** edge (per-edge), preserving current key order otherwise; falls back to after-`confidence` then append only when the source predecessor is absent from the current edge.
- New **POSITION PROOF** asserts every restored edge's `rationale`-predecessor equals the source's — aborts and writes nothing on any mismatch (catches the class strip-back can't see; same blind-spot family as the near-key twin catch).

**Verified on real data:** 33,399/33,399 placed at the source-original slot (after confidence 29,110 / weight 3,761 / model 528); both proofs PASS. Same one-function fix applies to the #1438 re-merge tool.

Refs t/2949, t/2946, t/2945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)