### PR TITLE
feat(edges): PR-A — mergeEdgesPreservingRationale + shared strip (t/2957, t/2949)

### DIFF
--- a/lib/edges/mergeEdgesPreservingRationale.test.ts
+++ b/lib/edges/mergeEdgesPreservingRationale.test.ts
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2957 — write-side rationale re-merge. Both-arms test evidence required by TL #6 Q1:
+// FIRE = indistinguishable twins throw ActionableError; CLEAN = ordinary save is byte-identical.
+// Twin coverage is driven by CL's canonical twin-fixture.json (the authoritative specimen — case_a
+// is the REAL observed twin pair, case_b constructed-indistinguishable); the inline constructed
+// cases below additionally isolate the per-branch tie-break / onWarn paths.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, it, expect, vi } from 'vitest';
+import { mergeEdgesPreservingRationale, ABSENT_BASELINE, type EdgesData } from './mergeEdgesPreservingRationale.js';
+import { serializeEdgesJson } from './serializeEdges.js';
+import { ActionableError } from '../debate/errors.js';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(dirname, '../..');
+
+const edge = (o: Record<string, unknown>) => o;
+
+describe('mergeEdgesPreservingRationale — restore + slot (t/2957)', () => {
+  it('restores a stripped edge\'s rationale from the on-disk baseline by composite key', () => {
+    const onDisk: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', confidence: 0.9, rationale: 'R1 established the support', status: 'approved', model: 'm', discovered_at: 't1' })] };
+    const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', confidence: 0.9, status: 'approved', model: 'm', discovered_at: 't1' })] };
+    const merged = mergeEdgesPreservingRationale(incoming, onDisk);
+    expect(merged.edges[0].rationale).toBe('R1 established the support');
+    // t/2949 slot fix: rationale restored to its ORIGINAL position (after confidence), not appended.
+    expect(Object.keys(merged.edges[0])).toEqual(['source', 'type', 'target', 'confidence', 'rationale', 'status', 'model', 'discovered_at']);
+  });
+
+  it('keeps a genuinely new edge (no baseline key) as-is; honours an editor edit to a non-rationale field', () => {
+    const onDisk: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'R1', status: 'approved', model: 'm', discovered_at: 't1' })] };
+    const incoming: EdgesData = {
+      edges: [
+        edge({ source: 'a', type: 'SUPPORTS', target: 'b', status: 'rejected', model: 'm', discovered_at: 't1' }), // status edited
+        edge({ source: 'c', type: 'SUPPORTS', target: 'd', rationale: 'brand new', status: 'proposed', model: 'm', discovered_at: 't2' }), // new
+      ],
+    };
+    const merged = mergeEdgesPreservingRationale(incoming, onDisk);
+    expect(merged.edges[0].rationale).toBe('R1');        // restored
+    expect(merged.edges[0].status).toBe('rejected');     // editor edit preserved
+    expect(merged.edges[1].rationale).toBe('brand new'); // new edge untouched
+  });
+
+  it('never clobbers an incoming edge that already carries a non-empty rationale', () => {
+    const onDisk: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'OLD', model: 'm', discovered_at: 't1' })] };
+    const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'NEW edit', model: 'm', discovered_at: 't1' })] };
+    expect(mergeEdgesPreservingRationale(incoming, onDisk).edges[0].rationale).toBe('NEW edit');
+  });
+});
+
+describe('mergeEdgesPreservingRationale — absence predicate is non-empty (t/2957 #6.3 / CL Issue 3)', () => {
+  const onDisk: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'HEAD text', model: 'm', discovered_at: 't1' })] };
+  for (const empty of ['', '   ', '\n\t'] as const) {
+    it(`treats rationale=${JSON.stringify(empty)} as absent → restores`, () => {
+      const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: empty, model: 'm', discovered_at: 't1' })] };
+      expect(mergeEdgesPreservingRationale(incoming, onDisk).edges[0].rationale).toBe('HEAD text');
+    });
+  }
+  it('treats a missing rationale key as absent → restores', () => {
+    const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', model: 'm', discovered_at: 't1' })] };
+    expect(mergeEdgesPreservingRationale(incoming, onDisk).edges[0].rationale).toBe('HEAD text');
+  });
+});
+
+describe('mergeEdgesPreservingRationale — rationale_source co-restore, verbatim + absent-stays-absent (t/2943 / CL Q2)', () => {
+  it('carries rationale_source verbatim from the baseline', () => {
+    const onDisk: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'R', rationale_source: 'backfill', model: 'm', discovered_at: 't1' })] };
+    const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', model: 'm', discovered_at: 't1' })] };
+    expect(mergeEdgesPreservingRationale(incoming, onDisk).edges[0].rationale_source).toBe('backfill');
+  });
+  it('leaves rationale_source ABSENT when the baseline had none — never coerces to null', () => {
+    const onDisk: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'R', model: 'm', discovered_at: 't1' })] };
+    const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', model: 'm', discovered_at: 't1' })] };
+    const out = mergeEdgesPreservingRationale(incoming, onDisk).edges[0];
+    expect(out.rationale).toBe('R');
+    expect('rationale_source' in out).toBe(false);
+  });
+});
+
+describe('mergeEdgesPreservingRationale — twin-aware identity (constructed)', () => {
+  // Two genuinely distinct edges sharing source|type|target, distinguishable by discovered_at+model.
+  const distinguishableOnDisk: EdgesData = {
+    edges: [
+      edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'twin-1 rationale', model: 'm1', discovered_at: 't1' }),
+      edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'twin-2 rationale', model: 'm2', discovered_at: 't2' }),
+    ],
+  };
+
+  it('re-merges EACH distinguishable twin its OWN rationale via discovered_at+model tie-break', () => {
+    const incoming: EdgesData = {
+      edges: [
+        edge({ source: 'a', type: 'SUPPORTS', target: 'b', model: 'm2', discovered_at: 't2' }),
+        edge({ source: 'a', type: 'SUPPORTS', target: 'b', model: 'm1', discovered_at: 't1' }),
+      ],
+    };
+    const merged = mergeEdgesPreservingRationale(incoming, distinguishableOnDisk);
+    expect(merged.edges[0].rationale).toBe('twin-2 rationale'); // m2/t2
+    expect(merged.edges[1].rationale).toBe('twin-1 rationale'); // m1/t1
+  });
+
+  it('FIRE: indistinguishable twins (same key AND discovered_at AND model) throw ActionableError — never guesses', () => {
+    const indistinguishableOnDisk: EdgesData = {
+      edges: [
+        edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'twin-A', model: 'm', discovered_at: 't' }),
+        edge({ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'twin-B', model: 'm', discovered_at: 't' }),
+      ],
+    };
+    const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', model: 'm', discovered_at: 't' })] };
+    expect(() => mergeEdgesPreservingRationale(incoming, indistinguishableOnDisk)).toThrow(ActionableError);
+    expect(() => mergeEdgesPreservingRationale(incoming, indistinguishableOnDisk)).toThrow(/Ambiguous rationale attribution/);
+  });
+
+  it('no twin matched (baseline twins, incoming discovered_at/model matches neither) → onWarn, no guess, no throw', () => {
+    const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', model: 'm3', discovered_at: 't3' })] };
+    const onWarn = vi.fn();
+    const merged = mergeEdgesPreservingRationale(incoming, distinguishableOnDisk, onWarn);
+    expect('rationale' in merged.edges[0]).toBe(false);   // not guessed
+    expect(onWarn).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ candidateCount: 2 }) }));
+  });
+});
+
+// Canonical twin fixture — CL's authoritative specimen (twin-fixture.json, PR #1443). Single source
+// of truth shared across restore (t/2946), this re-merge util (t/2957), and the TS write-guard, so the
+// three cannot drift. case_a = the REAL acc-beliefs-051|SUPPORTS|acc-desires-001 twin pair from
+// ba3128f5 (distinguishable on discovered_at+model → per-twin restore); case_b = constructed
+// indistinguishable twins → refuse-and-log. Loading from the file (not re-inlining) is what keeps the
+// util's behaviour locked to CL's identity model verbatim.
+describe('mergeEdgesPreservingRationale — canonical twin fixture (CL twin-fixture.json, t/2957)', () => {
+  const fixture = JSON.parse(
+    readFileSync(path.join(repoRoot, 'research/comp-linguist/analyses/t2444-rationale-restore/twin-fixture.json'), 'utf8'),
+  ) as {
+    case_a_distinguishable: { on_disk: EdgesData; save_payload: EdgesData; expected_merged: EdgesData };
+    case_b_indistinguishable: { on_disk: EdgesData; save_payload: EdgesData };
+  };
+
+  it('case_a distinguishable twins → each twin restored ITS OWN rationale at the original slot (deep-equals expected_merged)', () => {
+    const { on_disk, save_payload, expected_merged } = fixture.case_a_distinguishable;
+    const merged = mergeEdgesPreservingRationale(save_payload, on_disk);
+    expect(merged.edges).toEqual(expected_merged.edges);
+    // Explicit no-cross-attribution assertion (the failure mode this case guards): each twin keeps its own.
+    expect(merged.edges[0].discovered_at).toBe('2026-04-06');
+    expect(merged.edges[0].rationale).toBe(expected_merged.edges[0].rationale);
+    expect(merged.edges[1].discovered_at).toBe('2026-06-11');
+    expect(merged.edges[1].rationale).toBe(expected_merged.edges[1].rationale);
+  });
+
+  it('case_b indistinguishable twins (same key AND discovered_at AND model) → refuse-and-log ActionableError, never guesses', () => {
+    const { on_disk, save_payload } = fixture.case_b_indistinguishable;
+    expect(() => mergeEdgesPreservingRationale(save_payload, on_disk)).toThrow(ActionableError);
+    expect(() => mergeEdgesPreservingRationale(save_payload, on_disk)).toThrow(/Ambiguous rationale attribution/);
+  });
+});
+
+describe('mergeEdgesPreservingRationale — baseline discrimination (t/2957 #6.1 BLOCKER / CL Issue 1)', () => {
+  const incoming: EdgesData = { edges: [edge({ source: 'a', type: 'SUPPORTS', target: 'b', model: 'm', discovered_at: 't1' })] };
+
+  it('ABSENT_BASELINE (genuine first write) → writes incoming as-is, no error', () => {
+    expect(mergeEdgesPreservingRationale(incoming, ABSENT_BASELINE)).toEqual(incoming);
+  });
+
+  it('a malformed/unreadable baseline (read failure) THROWS — refuses to write a stripped payload', () => {
+    // read-failure shapes the two fileIO twins can produce vs a genuine absence.
+    for (const bad of [null, undefined, {}, { edges: 'not-an-array' }, 'garbage'] as unknown[]) {
+      expect(() => mergeEdgesPreservingRationale(incoming, bad as never)).toThrow(/could not be read as a valid/);
+    }
+  });
+});
+
+describe('mergeEdgesPreservingRationale — CLEAN case is byte-identical (t/2957 #6 Q1)', () => {
+  it('an ordinary save with no rationale-bearing baseline delta serializes byte-identically', () => {
+    // Neither incoming nor baseline carries rationale for these keys → nothing to restore.
+    const incoming: EdgesData = {
+      _schema_version: '1.0.0',
+      edges: [
+        edge({ source: 'a', type: 'SUPPORTS', target: 'b', confidence: 0.9, status: 'approved', model: 'm', discovered_at: 't1' }),
+        edge({ source: 'c', type: 'TENSION_WITH', target: 'd', confidence: 0.8, status: 'proposed', model: 'm', discovered_at: 't2' }),
+      ],
+    };
+    const onDisk: EdgesData = { _schema_version: '1.0.0', edges: incoming.edges.map(e => ({ ...e })) };
+    const merged = mergeEdgesPreservingRationale(incoming, onDisk);
+    expect(serializeEdgesJson(merged)).toBe(serializeEdgesJson(incoming)); // byte-identical
+  });
+});

--- a/lib/edges/mergeEdgesPreservingRationale.ts
+++ b/lib/edges/mergeEdgesPreservingRationale.ts
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Write-side rationale re-merge for the edges.json whole-file save path (t/2957, part of the
+// t/2945 edge-rationale data-loss incident). The taxonomy editor loads the edge list through a
+// path that strips `rationale` (payload trim, ~37% smaller), then saves the WHOLE file back —
+// persisting the stripped set and wiping the on-disk rationale. This util re-merges `rationale`
+// (and `rationale_source`, which move together per t/2943) from the on-disk baseline by composite
+// key BEFORE the save, so a payload that originated from the stripped list endpoint never
+// persists the strip. Pure: no fs, no I/O — the two save call-sites read the baseline and pass it
+// in. TL-approved design t/2957#5, with the #6 required changes folded in.
+//
+// BASELINE = ON-DISK, deliberately NOT committed git-HEAD (TL t/2957#6 change 2; CL Issue 2).
+// The fix's job is "never wipe what's on disk." Recovering rationale that was ALREADY lost from
+// the working tree (a poisoned/degraded on-disk file) is the RESTORE's job (t/2946, in flight
+// against ba3128f5), not this util's — so there is intentionally no git-HEAD fallback here (it
+// would be transitional dead-code once the restore lands and blur the fix/restore split).
+// Consequence recorded on t/2957: this util cannot recover rationale already missing from the
+// on-disk file; an on-disk baseline only guarantees no NEW loss.
+//
+// READ-FAILURE IS NOT ABSENCE (TL #6 change 1 [BLOCKER]; CL Issue 1). `readEdgesFile()` returns
+// `null` for both a missing file and a read/parse failure. Treating a read *failure* as "no
+// baseline, write as-is" would make this fix fail-open into the exact wipe it prevents. So the
+// baseline is a DISCRIMINATED input: pass the literal `'absent'` ONLY for a genuine first write
+// (file truly absent); on a read/parse failure the CALLER must throw and never call this — and a
+// malformed baseline object handed here throws rather than silently writing a stripped payload.
+//
+// Twin-aware identity (correctness, not a nicety — TL e/120#37; CL spec): the live file has 3
+// composite keys carrying 2 genuinely distinct edges each. Primary key source|type|target; on a
+// non-unique key, tie-break on discovered_at + model; still ambiguous → refuse-and-log, never guess.
+
+import { ActionableError } from '../debate/errors.js';
+
+/** The edges.json shape: an `edges` array of arbitrary-field edge objects, plus top-level keys. */
+export type EdgesData = { edges: Record<string, unknown>[];[k: string]: unknown };
+
+/** Sentinel for a genuine first write (edges.json truly absent) — distinct from a read failure. */
+export const ABSENT_BASELINE = 'absent' as const;
+
+/** Structured warning sink (optional). Lets the pure util surface the silent-loss case (CL Issue 4)
+ *  without depending on a flight recorder — the call-site passes a recorder-backed callback. */
+export type EdgeMergeWarn = (event: { message: string; data: Record<string, unknown> }) => void;
+
+type Edge = Record<string, unknown>;
+
+const keyOf = (e: Edge): string => `${String(e.source)}|${String(e.type)}|${String(e.target)}`;
+
+/** Non-empty rationale predicate (TL #6 change 3; CL Issue 3). Must match Arm 1 (PS) + the Arm-2
+ *  constraint (t/2958#2): `undefined | null | '' | whitespace-only` all count as ABSENT (eligible
+ *  for re-merge), so a cleared/empty payload can't read as "already has one" and silently wipe. */
+const hasRationale = (e: Edge): boolean => typeof e.rationale === 'string' && e.rationale.trim().length > 0;
+
+/**
+ * Restore `rationale` (+ `rationale_source`) from a baseline edge onto an incoming edge that lost
+ * it on the strip-on-load round-trip, KEEPING the field in its original baseline slot (t/2949 slot
+ * fix — never append) and preserving absent-ness (TL #6: if the baseline has no `rationale_source`,
+ * leave it absent — never coerce to null; CL Q2: copy verbatim, never synthesize). Non-rationale
+ * field VALUES come from `incoming` (an intentional editor edit to e.g. `status` is honoured); their
+ * ORDER follows the baseline so a preserved edge is byte-stable vs the baseline.
+ */
+function restoreFrom(incoming: Edge, base: Edge): Edge {
+  const out: Edge = {};
+  for (const [k, baseVal] of Object.entries(base)) {
+    if (k === 'rationale' || k === 'rationale_source') out[k] = baseVal; // sourced only from baseline, verbatim
+    else if (k in incoming) out[k] = incoming[k];                        // editor-owned value wins
+    // A baseline-only non-rationale key absent from incoming = an editor deletion → respect it (drop).
+  }
+  for (const [k, v] of Object.entries(incoming)) {
+    if (k === 'rationale' || k === 'rationale_source') continue; // never reintroduced from a stale payload
+    if (!(k in out)) out[k] = v;                                 // preserve editor-added keys
+  }
+  return out;
+}
+
+/**
+ * Merge `incoming` (the save payload) against the on-disk `baseline`, restoring rationale that the
+ * strip-on-load round-trip dropped. Incoming edges that already carry a non-empty rationale are left
+ * untouched (an intentional edit is never clobbered). New edges (no baseline key) and deleted edges
+ * (absent from incoming) are natural no-ops. Returns a new EdgesData; edge order and every
+ * non-rationale field are otherwise unchanged (serializer contract intact).
+ *
+ * @param baseline the parsed on-disk edges.json, or `ABSENT_BASELINE` for a genuine first write.
+ *   A read/parse FAILURE must NOT be passed as `ABSENT_BASELINE` — throw at the call site instead.
+ * @param onWarn optional sink for the "baseline has rationale for this key but no twin matched the
+ *   incoming edge" case — a real rationale is not written; logged so a systematic tie-break
+ *   mismatch is discoverable without a forensic reconstruction (CL Issue 4). Does not throw.
+ * @throws ActionableError when the baseline is a malformed object (read failure — refuses rather
+ *   than writing a stripped payload against an unreadable baseline), or when a non-unique key stays
+ *   ambiguous after the discovered_at+model tie-break — never guesses.
+ */
+export function mergeEdgesPreservingRationale(
+  incoming: EdgesData,
+  baseline: EdgesData | typeof ABSENT_BASELINE,
+  onWarn?: EdgeMergeWarn,
+): EdgesData {
+  if (!incoming || !Array.isArray(incoming.edges)) return incoming; // caller validated the payload shape
+  if (baseline === ABSENT_BASELINE) return incoming;               // genuine first write — nothing to restore
+
+  // BLOCKER guard: a baseline that is not a readable EdgesData is a read/parse failure, not absence.
+  // Refuse — writing the stripped payload against an unreadable baseline is the incident itself.
+  if (!baseline || typeof baseline !== 'object' || !Array.isArray((baseline as EdgesData).edges)) {
+    throw new ActionableError({
+      goal: 'Preserve edge rationale across a whole-file edges.json save',
+      problem: 'The on-disk edges.json baseline could not be read as a valid { edges: [...] } object (read or parse failure). Refusing to save — writing the payload against an unreadable baseline would wipe rationale.',
+      location: 'lib/edges/mergeEdgesPreservingRationale.ts mergeEdgesPreservingRationale',
+      nextSteps: [
+        'Confirm the edges.json on disk is present and valid JSON before saving.',
+        'For a genuine first write (no edges.json yet), pass ABSENT_BASELINE, not a null/failed read.',
+      ],
+    });
+  }
+
+  // Index baseline edges that CARRY a (non-empty) rationale, by composite key — restoration sources.
+  const baseByKey = new Map<string, Edge[]>();
+  for (const e of baseline.edges) {
+    if (!hasRationale(e)) continue;
+    const k = keyOf(e);
+    const bucket = baseByKey.get(k);
+    if (bucket) bucket.push(e); else baseByKey.set(k, [e]);
+  }
+
+  const edges = incoming.edges.map((edge) => {
+    if (hasRationale(edge)) return edge;               // intentional edit / new rationale — keep
+    const candidates = baseByKey.get(keyOf(edge));
+    if (!candidates || candidates.length === 0) return edge; // nothing on the baseline to restore
+
+    if (candidates.length === 1) return restoreFrom(edge, candidates[0]);
+
+    // Non-unique key (twins): disambiguate on discovered_at + model.
+    const matches = candidates.filter(c => c.discovered_at === edge.discovered_at && c.model === edge.model);
+    if (matches.length === 1) return restoreFrom(edge, matches[0]);
+    if (matches.length === 0) {
+      // No twin matched: a rationale that exists is about to not be written. Not a guess, but not
+      // silent either (CL Issue 4) — surface it so a systematic tie-break mismatch is discoverable.
+      onWarn?.({
+        message: `Edge rationale not restored: key "${keyOf(edge)}" is a baseline twin (${candidates.length} rationaled edges) but none matched the incoming edge's discovered_at/model`,
+        data: { key: keyOf(edge), candidateCount: candidates.length, incoming_discovered_at: edge.discovered_at ?? null, incoming_model: edge.model ?? null },
+      });
+      return edge;
+    }
+
+    // Still ambiguous after the tie-break — indistinguishable twins. Refuse, never guess.
+    throw new ActionableError({
+      goal: 'Preserve edge rationale across a whole-file edges.json save',
+      problem: `Ambiguous rationale attribution for edge "${keyOf(edge)}": ${matches.length} on-disk edges share the same source|type|target AND discovered_at (${String(edge.discovered_at)}) AND model (${String(edge.model)}) — which rationale to restore cannot be determined.`,
+      location: 'lib/edges/mergeEdgesPreservingRationale.ts mergeEdgesPreservingRationale',
+      nextSteps: [
+        'Disambiguate the duplicate edges in edges.json (give them distinct discovered_at or model), or remove the true duplicate.',
+        'Do not save until the ambiguity is resolved — saving now would guess which rationale belongs to which edge.',
+      ],
+    });
+  });
+
+  return { ...incoming, edges };
+}

--- a/lib/edges/stripEdgeRationale.test.ts
+++ b/lib/edges/stripEdgeRationale.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2949 — the ONE shared strip projection now lives in lib/edges. These lock the projection
+// contract both TS writers (server edgesApi.ts + main taxonomyHandlers.ts) will call into.
+
+import { describe, it, expect } from 'vitest';
+import { stripEdgeRationale } from './stripEdgeRationale.js';
+
+describe('stripEdgeRationale (shared lib/edges home, t/2949)', () => {
+  it('removes ONLY rationale — preserves rationale_source, discovered_at, model, and all other fields', () => {
+    const input = { _schema_version: '1.0.0', edges: [{ source: 'a', type: 'SUPPORTS', target: 'b', rationale: 'R', rationale_source: 'backfill', discovered_at: 't1', model: 'm', confidence: 0.9 }] };
+    const out = stripEdgeRationale(input) as { edges: Record<string, unknown>[] };
+    expect('rationale' in out.edges[0]).toBe(false);
+    expect(out.edges[0]).toEqual({ source: 'a', type: 'SUPPORTS', target: 'b', rationale_source: 'backfill', discovered_at: 't1', model: 'm', confidence: 0.9 });
+  });
+
+  it('returns non-object / missing-edges input unchanged (defensive)', () => {
+    expect(stripEdgeRationale(null)).toBeNull();
+    expect(stripEdgeRationale({ foo: 1 })).toEqual({ foo: 1 });
+  });
+
+  it('preserves top-level keys and does not mutate the input', () => {
+    const input = { _schema_version: '1.0.0', last_modified: 'x', edges: [{ source: 'a', type: 'T', target: 'b', rationale: 'R' }] };
+    const out = stripEdgeRationale(input) as { _schema_version: string; last_modified: string; edges: Record<string, unknown>[] };
+    expect(out._schema_version).toBe('1.0.0');
+    expect(out.last_modified).toBe('x');
+    expect(input.edges[0].rationale).toBe('R'); // input not mutated
+  });
+});

--- a/lib/edges/stripEdgeRationale.ts
+++ b/lib/edges/stripEdgeRationale.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// The ONE shared edge-rationale strip projection (t/2949). The edges.json file carries large
+// per-edge `rationale` strings (~7 MB); list and mutation responses strip them so clients get a
+// ~37% smaller payload — the on-disk file and in-memory cache keep full data, and full rationale
+// is served per-edge via GET /api/edges/:index.
+//
+// This lives in lib/edges as the single home so BOTH TS writers import it — the Electron main
+// process (which cannot import server code) and the server route helper. The t/2949 defect was
+// exactly a DUPLICATED strip: the server `edgesApi.ts` helper plus an inline COPY in the main
+// process (taxonomyHandlers.ts:260-266). Two implementations drift; collapsing to one call is the
+// fix. (Byte-identical to the prior edgesApi.ts implementation — a pure projection.)
+
+import type { EdgesData } from './mergeEdgesPreservingRationale.js';
+
+export type { EdgesData };
+
+/**
+ * Return a shallow copy of the edges file with `rationale` removed from every edge. Non-object /
+ * missing-edges input is returned unchanged (defensive — the caller may pass a null cache or an
+ * unexpected shape). Removes ONLY `rationale`; all other fields (incl. `rationale_source`,
+ * `discovered_at`, `model`) are preserved so the write-side re-merge can tie-break twins.
+ */
+export function stripEdgeRationale(data: unknown): unknown {
+  const d = data as EdgesData | null;
+  if (!d || !Array.isArray(d.edges)) return data;
+  return { ...d, edges: d.edges.map(({ rationale: _rationale, ...rest }) => rest) };
+}


### PR DESCRIPTION
**PR-A of the coupled t/2957 (write-side re-merge) + t/2949 (load-side collapse) grant.** Shared-lib core only; call-site wiring is PR-B (will reference this landed util). **Routing to Main (TL) for code review** (cross-role data-integrity — not self-cert), per t/2957#6. cc CL for re-review (algorithm signed off spec-conformant at t/2957#3).

## What
`lib/edges/mergeEdgesPreservingRationale(incoming, baseline, onWarn?)` — re-merge `rationale` (+ `rationale_source`, verbatim, absent-stays-absent) from the on-disk baseline onto a stripped save payload by `source|type|target`; non-unique key → tie-break `discovered_at`+`model`; still ambiguous → refuse-and-log `ActionableError`, never guess. Restores rationale to its **original slot** (t/2949 slot fix). Plus `lib/edges/stripEdgeRationale` — the ONE shared home both TS writers will import (t/2949; the duplication is the defect).

## TL #6 required changes (all folded in)
1. **[BLOCKER] discriminated baseline** `EdgesData | ABSENT_BASELINE`: genuine first-write → write as-is; read/parse **failure** (malformed baseline) → **throws**, never fail-open into writing a stripped payload against an unreadable baseline.
2. **baseline = on-disk** (param `baseline`, not `head`), deliberately NOT git-HEAD — recovering already-lost rationale is the restore''s job (t/2946); no HEAD-fallback. **Consequence recorded:** this util cannot recover rationale already missing on disk — on-disk baseline only guarantees no NEW loss.
3. **absence predicate = non-empty** (`undefined|null|''|whitespace`), matching Arm 1 / Arm 2 (t/2958#2).
Plus CL Issue 4: baseline-twin-but-no-match logs via `onWarn` (no silent loss), without guessing.

## Both-arms test evidence (TL #6 Q1)
- **FIRE:** indistinguishable twins throw `ActionableError`.
- **CLEAN:** ordinary save → zero errors, **byte-identical** serializer output.
- Plus: distinguishable-twin per-twin restore, non-empty predicate (incl. whitespace + `""`), `rationale_source` verbatim + absent-stays-absent, baseline discrimination (absent vs read-fail), original-slot preservation.

18 tests green; `tsc` + `eslint` clean.

## Not in this PR
Call-site wiring, `?include=rationale`, inline-copy deletion, repro-first real-save-path + live-specimen round-trip → **PR-B**. Throwing Arm 1-TS → **PR-C** (fast-follow, warn-first + GV). Does not unblock t/2946 alone (Arm 2 stays on that path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)