### PR TITLE
fix(taxonomy): wrap node-detail header title instead of clamping to 2 lines (t/2937)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.css
@@ -7,11 +7,18 @@
   gap: var(--sp-3);
 }
 
+/* t/2937: wrap the title to N lines instead of clamping to 2 with an ellipsis.
+   flex:1 + min-width:0 lets the title column take remaining width and shrink so the
+   label wraps within it (min-width:0 defeats the flex-item min-content floor that
+   would otherwise force overflow); overflow-wrap keeps a very long single token from
+   spilling past the actions. Sidebar list already wraps — this matches it. */
+.nd-header-title {
+  flex: 1;
+  min-width: 0;
+}
+
 .nd-header-title > span.nd-header-label {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
+  overflow-wrap: anywhere;
 }
 
 .nd-header-meta {


### PR DESCRIPTION
Reopened t/2937 (t/2937#2): PR #1408 fixed the wrong element (`.detail-pane-title`); the reported truncation is the taxonomy NodeDetail header `.nd-header-label`, which clamped via `-webkit-line-clamp:2; overflow:hidden`.

**Fix:** constrain the title flex column (`flex:1; min-width:0`) so the label wraps to N lines within the available width (matching the sidebar); drop the clamp. Single file, CSS only.

**Verification:** the original mis-fix passed compile-only. This will NOT be signed Done until the wrap is confirmed in the rendered taxonomy node detail. CI verifies build; visual confirm gates the ticket.