### PR TITLE
fix(edges): PR-B — re-merge edge rationale on whole-file save + absence-vs-failure baseline split (t/2957)

### DIFF
--- a/taxonomy-editor/src/main/__tests__/saveEdges.test.ts
+++ b/taxonomy-editor/src/main/__tests__/saveEdges.test.ts
@@ -21,6 +21,10 @@ const h = vi.hoisted(() => ({
   handlers: new Map<string, (...a: unknown[]) => unknown>(),
   writeEdgesArg: undefined as unknown,
   writeThrows: null as Error | null,
+  // The on-disk baseline the rationale re-merge reads (t/2957). null = genuine absence (ABSENT_BASELINE
+  // → write as-is); readThrows models a corrupt/unreadable edges.json (parseJsonFile/readFileSync throw).
+  readEdgesReturn: null as unknown,
+  readThrows: null as Error | null,
 }));
 
 vi.mock('electron', () => ({
@@ -33,7 +37,8 @@ vi.mock('../fileIO.js', () => {
   return {
     readTaxonomyFile: stub, writeTaxonomyFile: stub, readAllConflictFiles: stub,
     readConflictClusters: stub, writeConflictFile: stub, createConflictFile: stub,
-    deleteConflictFile: stub, readEdgesFile: stub,
+    deleteConflictFile: stub,
+    readEdgesFile: (): unknown => { if (h.readThrows) throw h.readThrows; return h.readEdgesReturn; },
     writeEdgesFile: (data: unknown): void => { if (h.writeThrows) throw h.writeThrows; h.writeEdgesArg = data; },
     getTaxonomyDirs: stub, getActiveTaxonomyDirName: stub, setActiveTaxonomyDir: stub,
     buildNodeSourceIndex: stub, buildPolicySourceIndex: stub, readPolicyRegistry: stub,
@@ -59,6 +64,8 @@ beforeEach(() => {
   h.handlers.clear();
   h.writeEdgesArg = undefined;
   h.writeThrows = null;
+  h.readEdgesReturn = null; // default: genuine absence → write payload as-is
+  h.readThrows = null;
   registerTaxonomyHandlers();
 });
 
@@ -88,5 +95,38 @@ describe('save-edges IPC handler (t/1822)', () => {
   it('surfaces a write failure as an ActionableError (not a raw fs error)', () => {
     h.writeThrows = new Error('EACCES: permission denied');
     expect(() => saveEdges({ edges: [] })).toThrow(ActionableError);
+  });
+});
+
+describe('save-edges IPC — rationale re-merge on save (t/2957)', () => {
+  const key = { source: 'a', type: 'SUPPORTS', target: 'b' };
+
+  it('REPRO: a stripped whole-file save restores rationale from the on-disk baseline before writing', () => {
+    h.readEdgesReturn = { edges: [{ ...key, confidence: 0.9, rationale: 'ON-DISK rationale', model: 'm', discovered_at: 't1' }] };
+    saveEdges({ edges: [{ ...key, confidence: 0.9, model: 'm', discovered_at: 't1' }] }); // stripped payload
+    const written = h.writeEdgesArg as { edges: Record<string, unknown>[] };
+    expect(written.edges[0].rationale).toBe('ON-DISK rationale'); // NOT wiped
+  });
+
+  it('BLOCKER arm 1 — genuine absence (readEdgesFile null): first write persists the payload as-is', () => {
+    h.readEdgesReturn = null; // no edges.json yet → ABSENT_BASELINE
+    const body = { edges: [{ ...key, rationale: 'fresh', model: 'm', discovered_at: 't1' }] };
+    saveEdges(body);
+    expect(h.writeEdgesArg).toEqual(body);
+  });
+
+  it('BLOCKER arm 2 — a read/parse FAILURE refuses the save (ActionableError) and writes NOTHING', () => {
+    h.readThrows = new Error('EACCES: permission denied'); // transient read error, NOT absence
+    expect(() => saveEdges({ edges: [{ ...key, model: 'm', discovered_at: 't1' }] })).toThrow(ActionableError);
+    expect(h.writeEdgesArg).toBeUndefined(); // no stripped write
+  });
+
+  it('refuses indistinguishable twins (same key AND discovered_at AND model) — ActionableError, no write', () => {
+    h.readEdgesReturn = { edges: [
+      { ...key, rationale: 'twin-A', model: 'm', discovered_at: 't' },
+      { ...key, rationale: 'twin-B', model: 'm', discovered_at: 't' },
+    ] };
+    expect(() => saveEdges({ edges: [{ ...key, model: 'm', discovered_at: 't' }] })).toThrow(/Ambiguous rationale attribution/);
+    expect(h.writeEdgesArg).toBeUndefined();
   });
 });

--- a/taxonomy-editor/src/main/ipc/taxonomyHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/taxonomyHandlers.ts
@@ -35,11 +35,21 @@ import {
   loadDataConfig,
 } from '../fileIO.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
+import { mergeEdgesPreservingRationale, ABSENT_BASELINE, type EdgesData, type EdgeMergeWarn } from '../../../../lib/edges/mergeEdgesPreservingRationale.js';
 import { renameSyncWithRetry } from '../../../../lib/debate/persistence.js';
 import { recordLockHolder } from '../../../../lib/debate/lockHolder.js';
 import { stampNodeAuthorship } from '../../server/storage/editMeta.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { VALID_POV } from '../ipcSchemas.js';
+
+// Recorder-backed sink for the rationale re-merge's "baseline twin matched no incoming edge"
+// case: a real rationale isn't written, logged so a systematic tie-break mismatch is
+// discoverable (CL Issue 4). Payload is IDs/counts only — no rationale content is recorded.
+const onEdgeMergeWarn: EdgeMergeWarn = (e) =>
+  getGlobalRecorder()?.record({
+    type: 'system.error', component: 'ipc-save-edges', level: 'warn',
+    message: `${e.message} ${JSON.stringify(e.data)}`,
+  });
 
 /**
  * Stamp _edit_meta / _edit_history authorship onto a save's nodes (mirroring the server's
@@ -391,15 +401,28 @@ export function registerTaxonomyHandlers(): void {
       });
     }
     try {
-      writeEdgesFile(data);
+      // t/2957: the editor loads the edge list rationale-stripped, then saves the WHOLE file —
+      // persisting the stripped set would wipe on-disk rationale. Re-merge it from the on-disk
+      // baseline first. `readEdgesFile` returns null ONLY for a genuinely absent edges.json
+      // (existsSync guard) and THROWS (via parseJsonFile / readFileSync) on a corrupt or
+      // unreadable file — so `== null` is a true first-write (write as-is), never a masked
+      // read failure. A read/parse throw or an indistinguishable-twin refusal propagates below.
+      const raw = readEdgesFile();
+      const baseline = raw == null ? ABSENT_BASELINE : (raw as EdgesData);
+      const merged = mergeEdgesPreservingRationale(data as EdgesData, baseline, onEdgeMergeWarn);
+      writeEdgesFile(merged);
     } catch (err) {
       getGlobalRecorder()?.record({
         type: 'system.error',
         component: 'ipc-save-edges',
         level: 'error',
-        message: 'Failed to persist edges.json',
+        message: 'Failed to persist edges.json (rationale-preserving save)',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
+      // A merge refusal (unreadable baseline / indistinguishable twins) is already an
+      // ActionableError with the precise Goal/Problem/Location/NextSteps — surface it verbatim
+      // rather than masking it behind the generic write-failure message. Only wrap a raw fs error.
+      if (err instanceof ActionableError) throw err;
       throw new ActionableError({
         goal: 'Persist the taxonomy edges to disk',
         problem: 'Could not write edges.json to the active taxonomy directory',

--- a/taxonomy-editor/src/server/__tests__/edgesSave.test.ts
+++ b/taxonomy-editor/src/server/__tests__/edgesSave.test.ts
@@ -9,15 +9,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'http';
 
-const { writeEdgesFileMock, readEdgesFileMock } = vi.hoisted(() => ({
+const { writeEdgesFileMock, readBaselineMock } = vi.hoisted(() => ({
   writeEdgesFileMock: vi.fn(async () => {}),
-  readEdgesFileMock: vi.fn(async () => ({ edges: [] })),
+  // The write-baseline read (t/2957): default to a genuinely-empty baseline (nothing to restore).
+  // 'absent' is ABSENT_BASELINE; a rejecting impl models a read/parse failure (must refuse, no write).
+  readBaselineMock: vi.fn(async (): Promise<unknown> => ({ edges: [] })),
 }));
 
 // Partial mock: override the two edge fileIO calls, keep everything else real.
 vi.mock('../storage/fileIO.js', async (importActual) => {
   const actual = await importActual<typeof import('../storage/fileIO.js')>();
-  return { ...actual, writeEdgesFile: writeEdgesFileMock, readEdgesFile: readEdgesFileMock };
+  return { ...actual, writeEdgesFile: writeEdgesFileMock, readEdgesForSaveBaseline: readBaselineMock };
 });
 
 import type { ServerCtx } from '../routes/context.js';
@@ -46,7 +48,11 @@ async function putEdges(body: unknown): Promise<InvokeResult> {
 }
 
 describe('PUT /api/edges — whole-file edge save (t/1821)', () => {
-  beforeEach(() => { writeEdgesFileMock.mockClear(); readEdgesFileMock.mockClear(); });
+  beforeEach(() => {
+    writeEdgesFileMock.mockClear();
+    readBaselineMock.mockReset();
+    readBaselineMock.mockResolvedValue({ edges: [] }); // default: empty baseline, nothing to restore
+  });
 
   it('persists a valid EdgesFile body via the atomic writeEdgesFile', async () => {
     const file = { edges: [{ source: 'a', target: 'b', type: 'supports', status: 'proposed' }] };
@@ -77,6 +83,48 @@ describe('PUT /api/edges — whole-file edge save (t/1821)', () => {
   it('rejects a body whose edges is not an array with 400 and does NOT write', async () => {
     const res = await putEdges({ edges: 'nope' });
     expect(res.status).toBe(400);
+    expect(writeEdgesFileMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('PUT /api/edges — rationale re-merge on save (t/2957)', () => {
+  const key = { source: 'a', type: 'SUPPORTS', target: 'b' };
+  beforeEach(() => {
+    writeEdgesFileMock.mockClear();
+    readBaselineMock.mockReset();
+  });
+
+  it('REPRO: a stripped whole-file save restores rationale from the on-disk baseline before writing', async () => {
+    // The editor loaded the list rationale-stripped; the save payload has no rationale.
+    readBaselineMock.mockResolvedValue({ edges: [{ ...key, confidence: 0.9, rationale: 'ON-DISK rationale', model: 'm', discovered_at: 't1' }] });
+    const strippedBody = { edges: [{ ...key, confidence: 0.9, model: 'm', discovered_at: 't1' }] };
+    const res = await putEdges(strippedBody);
+    expect(res.status).toBe(200);
+    expect(writeEdgesFileMock).toHaveBeenCalledTimes(1);
+    const written = writeEdgesFileMock.mock.calls[0][0] as { edges: Record<string, unknown>[] };
+    expect(written.edges[0].rationale).toBe('ON-DISK rationale'); // NOT wiped
+  });
+
+  it('BLOCKER arm 1 — genuine absence (ABSENT_BASELINE): first write persists the payload as-is', async () => {
+    readBaselineMock.mockResolvedValue('absent'); // ABSENT_BASELINE — no edges.json yet
+    const body = { edges: [{ ...key, rationale: 'fresh', model: 'm', discovered_at: 't1' }] };
+    const res = await putEdges(body);
+    expect(res.status).toBe(200);
+    expect(writeEdgesFileMock).toHaveBeenCalledTimes(1);
+    expect(writeEdgesFileMock).toHaveBeenCalledWith(body);
+  });
+
+  it('BLOCKER arm 2 — a read/parse FAILURE refuses the save with 500 and writes NOTHING (never a stripped write)', async () => {
+    readBaselineMock.mockRejectedValue(new Error('EACCES: permission denied')); // transient read error, NOT absence
+    const res = await putEdges({ edges: [{ ...key, model: 'm', discovered_at: 't1' }] });
+    expect(res.status).toBe(500);
+    expect(writeEdgesFileMock).not.toHaveBeenCalled();
+  });
+
+  it('BLOCKER arm 2b — a malformed baseline object refuses with 500 and writes NOTHING', async () => {
+    readBaselineMock.mockResolvedValue({ edges: 'not-an-array' }); // corrupt parse result reaching the util
+    const res = await putEdges({ edges: [{ ...key, model: 'm', discovered_at: 't1' }] });
+    expect(res.status).toBe(500);
     expect(writeEdgesFileMock).not.toHaveBeenCalled();
   });
 });

--- a/taxonomy-editor/src/server/routes/edges.ts
+++ b/taxonomy-editor/src/server/routes/edges.ts
@@ -15,7 +15,17 @@ import { json, error, param, query } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import * as fileIO from '../storage/fileIO.js';
 import { stripEdgeRationale, type EdgesData } from '../community/edgesApi.js';
+import { mergeEdgesPreservingRationale, type EdgeMergeWarn } from '../../../../lib/edges/mergeEdgesPreservingRationale.js';
 import { getAllFlags } from '../featureFlags.js';
+
+// Recorder-backed sink for the merge's "baseline twin matched no incoming edge" case: a real
+// rationale isn't written, logged so a systematic tie-break mismatch is discoverable (CL Issue 4).
+// The payload is IDs/counts only — no rationale content ever enters the recorder.
+const onEdgeMergeWarn: EdgeMergeWarn = (e) =>
+  getGlobalRecorder()?.record({
+    type: 'system.error', component: 'edges-route', level: 'warn',
+    message: `${e.message} ${JSON.stringify(e.data)}`,
+  });
 
 export function registerEdgesRoutes(r: Router, _ctx: ServerCtx): void {
   const { get, put } = r;
@@ -63,9 +73,25 @@ export function registerEdgesRoutes(r: Router, _ctx: ServerCtx): void {
       error(res, 'edges file must be an object with an edges array', 400);
       return;
     }
-    await fileIO.writeEdgesFile(data);
-    edgesCache = data;
-    json(res, stripEdgeRationale(edgesCache));
+    // t/2957: the editor loads the edge list rationale-stripped, then saves the WHOLE file —
+    // persisting the stripped set would wipe on-disk rationale. Re-merge it from the on-disk
+    // baseline BEFORE the write. The baseline read discriminates genuine absence (first write →
+    // write as-is) from a read/parse failure (throws → refuse, never a stripped write); an
+    // indistinguishable-twin baseline also throws (refuse-and-log, never guesses).
+    try {
+      const baseline = await fileIO.readEdgesForSaveBaseline();
+      const merged = mergeEdgesPreservingRationale(data, baseline, onEdgeMergeWarn);
+      await fileIO.writeEdgesFile(merged);
+      edgesCache = merged;
+      json(res, stripEdgeRationale(edgesCache));
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'edges-route', level: 'error',
+        message: 'PUT /api/edges rationale-preserving save refused/failed',
+        error: { name: (err as Error).name ?? 'Error', message: String((err as Error).message), stack: (err as Error).stack },
+      });
+      error(res, (err as Error).message, 500);
+    }
   });
 
   put('/api/edges/status', async (_req, res, body) => {

--- a/taxonomy-editor/src/server/storage/fileIO.ts
+++ b/taxonomy-editor/src/server/storage/fileIO.ts
@@ -25,6 +25,7 @@ import type { OrganizationEdge } from '../../../../lib/organizations/types.js';
 import type { Entity } from '../../../../lib/entities/types.js';
 import type { EntityMentionsFile, ContainerMentions } from '../../../../lib/entities/mentionTypes.js';
 import { serializeEdgesJson } from '../../../../lib/edges/serializeEdges.js';
+import { ABSENT_BASELINE, type EdgesData } from '../../../../lib/edges/mergeEdgesPreservingRationale.js';
 
 // ── Extracted sub-modules (ADR-007, t/1688) — cohesion splits behind a stable
 // barrel: importers keep importing these symbols from './fileIO.js'. Each module
@@ -698,6 +699,27 @@ export async function readEdgesFile(): Promise<unknown | null> {
     /* telemetry — silent by design */
     return null;
   }
+}
+
+/**
+ * Read the on-disk edges.json as a WRITE baseline for the rationale re-merge (t/2957),
+ * strictly discriminating genuine absence from a read/parse failure — unlike `readEdgesFile`
+ * above, which deliberately collapses both to `null` for its degrade-to-empty DISPLAY callers
+ * (GET, updateEdgeStatus). The whole-file save re-merges rationale from this baseline; treating
+ * a transient read error as "absent" would make the save write the stripped payload and wipe
+ * on-disk rationale (the t/2945 incident), so a read or parse failure MUST propagate (refuse the
+ * save) and never resolve to ABSENT_BASELINE. This is where the t/2957 #6.1 BLOCKER truly closes.
+ *
+ * `backend.readFile` returns `null` ONLY for genuine not-found (ENOENT / blob-not-found) and
+ * THROWS on any other read error — verified in filesystemBackend.ts:53-54 (`code==='ENOENT'`
+ * → null; else `throw err`) and azureBlobBackend.ts:149-155 (`isNotFound` → null; else throw).
+ * So `raw === null` here is a TRUE absence, and `JSON.parse` throws on a corrupt file. Both
+ * failure modes propagate to the caller; only a real ENOENT yields ABSENT_BASELINE.
+ */
+export async function readEdgesForSaveBaseline(): Promise<EdgesData | typeof ABSENT_BASELINE> {
+  const raw = await backend.readFile(getEdgesPath());
+  if (raw === null) return ABSENT_BASELINE;
+  return JSON.parse(raw) as EdgesData;
 }
 
 export async function writeEdgesFile(data: unknown): Promise<void> {


### PR DESCRIPTION
## PR-B — re-merge edge rationale on whole-file save (t/2957)

Wires the PR-A `lib/edges/mergeEdgesPreservingRationale` util into **both** whole-file save paths so a rationale-stripped save can no longer wipe on-disk rationale (t/2945 data-loss incident). Blocks the t/2946 restore.

### What changed
- **`server routes/edges.ts` — `PUT /api/edges`**: reads the discriminated baseline, re-merges, then writes. A merge refusal (indistinguishable twins / unreadable baseline) → **500**, no write.
- **`main ipc/taxonomyHandlers.ts` — `save-edges` IPC**: same re-merge before `writeEdgesFile`; a merge refusal surfaces as its own `ActionableError` verbatim (not masked behind the generic write-failure message); only a raw fs error is wrapped.
- **`server storage/fileIO.ts` — new `readEdgesForSaveBaseline()`** (BLOCKER close, t/2957 #6.1): non-swallowing baseline read that discriminates genuine absence (`backend.readFile` null → `ABSENT_BASELINE`) from a read/parse failure (throws → refuse). Leaves `readEdgesFile`'s degrade-to-empty contract untouched for its display callers (GET, updateEdgeStatus).

### Why the BLOCKER truly closes here
`backend.readFile` returns `null` **only** for genuine not-found and **throws** on any other read error — verified in `filesystemBackend.ts:53-54` (`code==='ENOENT'` → null; else `throw err`) and `azureBlobBackend.ts:149-155` (`isNotFound` → null; else throw). So a transient read error can never reach the util as `ABSENT_BASELINE`. Desktop `readEdgesFile` already discriminates (`existsSync` → null; `parseJsonFile`/`readFileSync` throw), so `== null` is a true first write.

### Tests (repro-first + both blocker arms, server + desktop)
- **REPRO**: a stripped whole-file save restores on-disk rationale before writing.
- **Blocker arm 1** (genuine absence): first write persists the payload as-is.
- **Blocker arm 2** (read/parse failure): refuses (500 / ActionableError) with **no** stripped write; plus a malformed-baseline variant.
- Indistinguishable twins → refuse.

tsc + eslint clean; the two affected suites 18/18 green.

### Follow-up
t/2949 (collapse the duplicated `stripEdgeRationale` to the lib home + `?include=rationale` at both load sites) follows as **PR-B2** — deliberately split out so this durability fix (which gates t/2946) stays tightly scoped and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
