### PR TITLE
docs: document PS New-ActionableError rendered labels (Goal/Error/Location/Resolve) (t/2952)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,8 @@ On some Windows agents, MSYS path conversion mangles the `<path>` half of a git 
 
 All unrecoverable errors must use `New-ActionableError` (PowerShell) or `ActionableError` (TypeScript) with four fields: **Goal**, **Problem**, **Location**, **Next Steps**. Never use bare `throw "message"`. Prefer recovery (retry, fallback, partial results) over failure. See `docs/error-handling.md`.
 
+**Rendered surface labels differ from the field names (PowerShell) — assert against the rendered labels.** The four fields above are the *parameter* names (`-Goal` / `-Problem` / `-Location` / `-NextSteps`), but `New-ActionableError` renders the emitted message with labels **`Goal:` / `Error:` / `Location:` / `Resolve:`** — i.e. `-Problem` prints as `Error:` and `-NextSteps` prints as `Resolve:`. Any test, log scraper, or reviewer assertion written against the *emitted text* must match the rendered labels (`Error:` / `Resolve:`), not the convention/parameter vocabulary — an assertion written honestly from the field names above will spuriously fail against a correctly-formed error (t/2952).
+
 ## Token Efficiency
 
 - Batch ToolSearch: always fetch all needed schemas in one call (select:t1,t2,t3)

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -20,6 +20,10 @@ Every unrecoverable error must include these four fields:
 | **Location** | Function/file where it occurred | "Import-AITriadDocument (Public/Import-AITriadDocument.ps1:42)" |
 | **Next Steps** | Specific actions to resolve | "1. Verify the file path exists 2. Check file permissions" |
 
+> **Rendered labels ≠ field names (PowerShell).** The names above are the *field / parameter* names. The PowerShell `New-ActionableError` renderer emits the message surface with **different labels**: `Goal:` / **`Error:`** / `Location:` / **`Resolve:`** — i.e. the `-Problem` field prints under `Error:` and `-NextSteps` prints under `Resolve:`. This is the authoritative emitted vocabulary. When you write a test, log parser, or review assertion against the *emitted text* of a PowerShell actionable error, match `Error:` and `Resolve:` — matching the field names `Problem` / `Next Steps` will spuriously fail against a correctly-formed error (t/2952). (The TypeScript `ActionableError` is a separate surface and is not covered by this note.)
+
+A worked example of the exact rendered shape is in the PowerShell section below.
+
 ---
 
 ## PowerShell
@@ -50,6 +54,29 @@ catch {
         -Location '...' -NextSteps @('...') -InnerError $_
 }
 ```
+
+**Rendered output shape.** `New-ActionableError` renders the message with the surface labels `Goal:` / `Error:` / `Location:` / `Resolve:` — note `-Problem` prints as **`Error:`** and `-NextSteps` prints as **`Resolve:`**. Given:
+
+```powershell
+New-ActionableError -Goal 'Loading taxonomy' `
+    -Problem 'File not found: accelerationist.json' `
+    -Location 'Get-Tax (Public/Get-Tax.ps1)' `
+    -NextSteps @('Run Install-AITriadData to clone the data repository',
+                 'Verify $env:AI_TRIAD_DATA_ROOT points to the correct directory') -PassThru
+```
+
+the emitted text is:
+
+```text
+  Goal:     Loading taxonomy
+  Error:    File not found: accelerationist.json
+  Location: Get-Tax (Public/Get-Tax.ps1)
+  Resolve:
+   1. Run Install-AITriadData to clone the data repository
+   2. Verify $env:AI_TRIAD_DATA_ROOT points to the correct directory
+```
+
+Assert against `Error:` / `Resolve:` (the rendered labels), not `Problem` / `Next Steps` (the field names). With `-InnerError`, an extra `Inner error: <message>` line is appended under `Error:`.
 
 #### `Invoke-WithRecovery` — Retry + fallback + actionable error
 


### PR DESCRIPTION
## Summary

Docs-only. Closes the vocabulary drift in t/2952: the Error Handling Convention documents the four fields as **Goal / Problem / Location / Next Steps** (the parameter names), but the PowerShell `New-ActionableError` renderer emits the message with surface labels **`Goal:` / `Error:` / `Location:` / `Resolve:`** — `-Problem` prints as `Error:` and `-NextSteps` prints as `Resolve:`. An assertion written honestly from the documented vocabulary spuriously fails against a correctly-formed actionable error (this cost a diagnosis cycle on the t/2947 evidence run).

Direction per TL disposition (t/2952#1): **docs→renderer (option 2)** — make the rendered labels authoritative and documented; **no renderer change** (so nothing already matching `Error:`/`Resolve:` breaks; AC#3's `Select-String` sweep is moot under this direction).

## Changes
- **`AGENTS.md`** (Error Handling Convention): note that the rendered surface labels differ from the field/parameter names and that emitted-text assertions must match `Error:` / `Resolve:`.
- **`docs/error-handling.md`**: a callout after the Structured Error Format table, plus a worked **rendered-output example** under `New-ActionableError` — so a reader can write a correct assertion without consulting the renderer source (AC#2). TypeScript `ActionableError` explicitly scoped out (separate surface, t/2763).

## Acceptance criteria
- **AC#1** — single authoritative vocabulary: the rendered `Goal/Error/Location/Resolve` labels are now documented alongside the `-Problem`/`-NextSteps` parameter names. ✓
- **AC#2** — a reader of the convention can write a correct assertion without reading the renderer source (worked example added). ✓
- **AC#3** — moot under option 2 (no renderer label change, so no `Error:`/`Resolve:` consumer sweep needed). ✓
- **AC#4** — no behavioural change to any guard or cmdlet; labels/docs only. ✓

## Notes
The two edited files are owned by the root project role (not `scripts/`); this PR was made at the repo owner's explicit direction. Verified against the renderer source (`scripts/AITriad/Private/New-ActionableError.ps1`) — the example matches the emitted format byte-for-byte (incl. the `   N.` step indent and the `-InnerError` appended line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVRjToQq8uw26V9xwfg5QK
