### PR TITLE
feat(arm2): pipeline courier activates data-repo rationale-drop hook (t/2958 Option B)

### DIFF
--- a/workflow-app/src/main/pipeline.ts
+++ b/workflow-app/src/main/pipeline.ts
@@ -231,7 +231,10 @@ export function buildGitCommitCommand(dataRoot: string, config: Record<string, u
       `See data-repo CONTRIBUTING.md section 5.'; git add -A`;
   }
 
-  return `Set-Location '${dataRoot}'; ${stage}; git commit -m '${message}'`;
+  // Activate the data-repo rationale-drop hook (t/2958 Arm 2 Option B).
+  // Idempotent; no-op if already set. Hook is warn-first until TL GV promotes it.
+  const activateHook = `git config core.hooksPath .githooks`;
+  return `Set-Location '${dataRoot}'; ${activateHook}; ${stage}; git commit -m '${message}'`;
 }
 
 function buildPsCommand(stepId: string, config: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary
- Prepends `git config core.hooksPath .githooks` in `buildGitCommitCommand` before stage+commit
- Ensures the warn-first rationale-drop pre-commit hook (Option C, 59861754) fires on every pipeline commit including `git add -A` fallback path
- Idempotent: sets a local git config value each run

## Hold
**Draft — gated on TL both-arms Gate Verification** alongside Option C hook promotion (t/2958 ACs). Do not merge until TL signs off.

## Test plan
- [ ] TL GV: pipeline commit with rationale-drop fires warning
- [ ] TL GV: pipeline commit preserving rationale passes clean

Co-Authored-By: DevOps (Orca) <main.operations-devops@ai-triad-research.orca.local>