### PR TITLE
style(css): co-locate shared tab-bar / pov-badge cluster — Phase 3 shared sheet (t/2901)

### DIFF
--- a/quality-gates.json
+++ b/quality-gates.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Non-LOC quality gates only (ADR-007 Gate Co-Location). ESLint `max-lines`, co-located in the eslint configs (lib/eslint.config.mjs, taxonomy-editor/eslint.config.mjs), is the SINGLE source of truth for .ts/.tsx LOC — do NOT re-add .ts ceilings here. styles.css stays: CSS is not covered by the TS eslint configs. See docs/design/adr/007-file-size-budget.md.",
   "loc_ceilings": {
-    "taxonomy-editor/src/renderer/styles.css": 16626
+    "taxonomy-editor/src/renderer/styles.css": 16513
   },
   "max_file_bytes": 5242880,
   "tsc_error_ceilings": {

--- a/taxonomy-editor/src/renderer/App.css
+++ b/taxonomy-editor/src/renderer/App.css
@@ -26,3 +26,24 @@
   min-height: 0;
   display: flex;
 }
+
+/* ─── Tab Content ──────────────────────────────────────── */
+
+.tab-content {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+}
+
+/* ─── POV Badge (shared across analysis, conflict, debate, lineage, validation) ── */
+
+.pov-badge {
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  padding: 1px 4px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+.pov-badge-acc { color: var(--color-acc); border: 1px solid var(--color-acc); }
+.pov-badge-saf { color: var(--color-saf); border: 1px solid var(--color-saf); }
+.pov-badge-skp { color: var(--color-skp); border: 1px solid var(--color-skp); }

--- a/taxonomy-editor/src/renderer/components/shared/TabBar.css
+++ b/taxonomy-editor/src/renderer/components/shared/TabBar.css
@@ -1,0 +1,102 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/* ─── Tab Bar ──────────────────────────────────────────── */
+
+.tab-bar {
+  display: flex;
+  background: var(--bg-secondary);
+  border-bottom: none;
+  padding: 0 8px;
+  -webkit-app-region: drag;
+  position: relative;
+  z-index: 10;
+}
+
+.tab-bar button {
+  -webkit-app-region: no-drag;
+  padding: var(--sp-2) var(--sp-4);
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border-bottom: 2px solid transparent;
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+}
+
+.tab-bar button:hover {
+  color: var(--text-primary);
+}
+
+.tab-bar button.active {
+  font-weight: 600;
+}
+
+.tab-bar button[data-tab="accelerationist"].active { border-bottom-color: var(--color-acc); color: var(--color-acc); background: var(--tint-acc); }
+.tab-bar button[data-tab="safetyist"].active       { border-bottom-color: var(--color-saf); color: var(--color-saf); background: var(--tint-saf); }
+.tab-bar button[data-tab="skeptic"].active          { border-bottom-color: var(--color-skp); color: var(--color-skp); background: var(--tint-skp); }
+.tab-bar button[data-tab="situations"].active    { border-bottom-color: var(--color-sit);  color: var(--color-sit); background: var(--tint-sit); }
+.tab-bar button[data-tab="conflicts"].active        { border-bottom-color: var(--color-conflicts); color: var(--color-conflicts); }
+.tab-bar button[data-tab="debate"].active           { border-bottom-color: var(--text-primary); color: var(--text-primary); }
+
+/* ─── Tab bar header actions (theme switcher, menu) ─────── */
+
+.tab-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+  -webkit-app-region: no-drag;
+}
+
+.tab-bar-menu-btn {
+  padding: 3px 8px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.tab-bar-menu-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+/* ─── Responsive ─────────────────────────────────────────── */
+
+@media (orientation: landscape) and (max-height: 500px) {
+  .tab-bar { display: none; }
+}
+
+@media (max-width: 767px) {
+  .tab-bar {
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    white-space: nowrap;
+  }
+  .tab-bar::-webkit-scrollbar { display: none; }
+
+  .tab-bar button {
+    padding: 8px 16px;
+    min-height: 44px;
+    flex-shrink: 0;
+  }
+}
+
+@media (pointer: coarse) {
+  .tab-bar button {
+    padding: 8px 16px;
+    min-height: 44px;
+  }
+}

--- a/taxonomy-editor/src/renderer/components/shared/TabBar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/TabBar.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
+import './TabBar.css';
 import { POV_META } from '@lib/electron-shared/povMeta';
 import { useTaxonomyStore } from '../../hooks/useTaxonomyStore';
 import type { TabId } from '../../types/taxonomy';

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -447,50 +447,6 @@ body {
   color: var(--text-secondary);
 }
 
-/* ─── Tab Bar ──────────────────────────────────────────── */
-
-.tab-bar {
-  display: flex;
-  background: var(--bg-secondary);
-  border-bottom: none;
-  padding: 0 8px;
-  -webkit-app-region: drag;
-  position: relative;
-  z-index: 10;
-}
-
-.tab-bar button {
-  -webkit-app-region: no-drag;
-  padding: var(--sp-2) var(--sp-4);
-  border: none;
-  background: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  border-bottom: 2px solid transparent;
-  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-  transition: color 0.2s, border-color 0.2s, background 0.2s;
-  display: flex;
-  align-items: center;
-  gap: var(--sp-1);
-}
-
-.tab-bar button:hover {
-  color: var(--text-primary);
-}
-
-.tab-bar button.active {
-  font-weight: 600;
-}
-
-.tab-bar button[data-tab="accelerationist"].active { border-bottom-color: var(--color-acc); color: var(--color-acc); background: var(--tint-acc); }
-.tab-bar button[data-tab="safetyist"].active       { border-bottom-color: var(--color-saf); color: var(--color-saf); background: var(--tint-saf); }
-.tab-bar button[data-tab="skeptic"].active          { border-bottom-color: var(--color-skp); color: var(--color-skp); background: var(--tint-skp); }
-.tab-bar button[data-tab="situations"].active    { border-bottom-color: var(--color-sit);  color: var(--color-sit); background: var(--tint-sit); }
-.tab-bar button[data-tab="conflicts"].active        { border-bottom-color: var(--color-conflicts); color: var(--color-conflicts); }
-.tab-bar button[data-tab="debate"].active           { border-bottom-color: var(--text-primary); color: var(--text-primary); }
-
 /* ─── App body (toolbar + tab content) ─────────────────── */
 
 /* ─── Data update banner ─────────────────────────────── */
@@ -1240,14 +1196,6 @@ body {
 .toolbar-back:hover {
   color: #fff;
   background: var(--focus-ring);
-}
-
-/* ─── Tab Content ──────────────────────────────────────── */
-
-.tab-content {
-  flex: 1;
-  overflow: hidden;
-  display: flex;
 }
 
 /* ─── Two-column layout ────────────────────────────────── */
@@ -4104,32 +4052,6 @@ body {
   background: var(--scrollbar-thumb-hover, var(--text-muted));
 }
 
-/* ─── Theme selector ──────────────────────────────────────── */
-
-.tab-bar-actions {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  margin-left: auto;
-  -webkit-app-region: no-drag;
-}
-
-.tab-bar-menu-btn {
-  padding: 3px 8px;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--text-muted);
-  font-size: var(--text-xs);
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-.tab-bar-menu-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
 /* ─── Taxonomy directory switcher ─────────────────────── */
 
 /* ─── Settings dialog ─────────────────────────────────── */
@@ -6290,17 +6212,6 @@ body {
   white-space: nowrap;
   max-width: 200px;
 }
-.pov-badge {
-  font-size: var(--text-2xs);
-  font-weight: 700;
-  padding: 1px 4px;
-  border-radius: var(--radius-sm);
-  flex-shrink: 0;
-}
-.pov-badge-acc { color: var(--color-acc); border: 1px solid var(--color-acc); }
-.pov-badge-saf { color: var(--color-saf); border: 1px solid var(--color-saf); }
-.pov-badge-skp { color: var(--color-skp); border: 1px solid var(--color-skp); }
-
 .lineage-detail-secondary {
   margin-top: 16px;
   padding: 12px 14px;
@@ -14972,10 +14883,6 @@ th[data-tooltip]::after {
 /* ─── Auto-rotation: phone landscape (t/364) ──────────── */
 
 @media (orientation: landscape) and (max-height: 500px) {
-  .tab-bar {
-    display: none;
-  }
-
   .bottom-nav {
     display: none !important;
   }
@@ -15057,21 +14964,6 @@ th[data-tooltip]::after {
 /* ─── Responsive: phone enhancements (t/360) ──────────── */
 
 @media (max-width: 767px) {
-  .tab-bar {
-    overflow-x: auto;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    white-space: nowrap;
-  }
-  .tab-bar::-webkit-scrollbar { display: none; }
-
-  .tab-bar button {
-    padding: 8px 16px;
-    min-height: 44px;
-    flex-shrink: 0;
-  }
-
   .list-panel-header {
     flex-wrap: wrap;
     gap: 4px;
@@ -15160,11 +15052,6 @@ th[data-tooltip]::after {
   .toolbar-icon {
     width: 44px;
     height: 44px;
-  }
-
-  .tab-bar button {
-    padding: 8px 16px;
-    min-height: 44px;
   }
 
   .node-item {


### PR DESCRIPTION
## Summary

Phase 3 shared-sheet PR (t/2901 epic, approved design t/2925). Extracts the cross-feature shared CSS cluster from the 16.6 kLOC `styles.css` monolith into co-located files:

- **`TabBar.css`** (new) — all `.tab-bar*`, `.tab-bar-actions`, `.tab-bar-menu-btn` rules, including `@media (orientation:landscape)`, `(max-width:767px)`, and `(pointer:coarse)` overrides. Import added to `TabBar.tsx`.
- **`App.css`** — `.tab-content` (App.tsx only) and `.pov-badge*` (used across 6 features; no PovBadge component exists, so global import at App root is the correct target).
- **`styles.css`** — 113 LOC removed (16,626 → 16,513).
- **`quality-gates.json`** — ceiling ratcheted 16,626 → 16,513 (monotonic decrease, gate enforced).

## Design conformance (t/2925#2)

- Mechanism: plain co-located CSS (not CSS Modules) — zero dynamic-class breakage by construction.
- Pre-move equal-specificity grep: `.tab-bar` / `.tab-content` / `.pov-badge` each appear only in the extracted blocks — no cascade conflicts.
- Source-order safety: moved selectors have no equal-specificity duplicates elsewhere; `@media` override blocks surgically trimmed (non-tab-bar selectors remain in `styles.css`).
- Shared-sheet PR routes to **Main (TL)** for review per design (not self-cert).

## Regression guard

- Quality-gates line-ceiling ratchet (automated) ✓
- Four-theme visual diff (light / dark / BKC / Harvard): manual screenshots required before merge — tab bar and pov badges render on every tab, providing broad coverage.

## Test plan

- [ ] Four-theme visual diff: load app in each theme, confirm tab bar and pov badges render identically to pre-PR screenshots
- [ ] Quality-gates ceiling check passes (16,513 ≤ 16,513) ✓ (verified locally)
- [ ] Tab switching works (all data-tab active variants)
- [ ] Responsive: phone (max-width 767px) tab bar scrolls; landscape hides; coarse-pointer touch targets apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)