### PR TITLE
feat(edges): twin-aware identity in the Arm-1 edge-rationale guard (t/2956)

### DIFF
--- a/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
+++ b/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
@@ -29,6 +29,10 @@
 #   ActionableError; the guard must FAIL-OPEN (distinguishable Write-Verbose, no throw) — the Arm-1
 #   fail-open contract (CL e/120#30 F1 / TL #32) outranks mirroring the TS disposition. Same identity
 #   model, different disposition on ambiguity. (CL ruling t/2956#4.)
+#   AC#7 (CL PR review t/2956#8): a write that MUTATES a twin's discriminator (discovered_at/model)
+#   while dropping its rationale yields an identity that matches no baseline twin — unattributable, so
+#   not blocked, but COUNTED and surfaced in the payload-scanned line (the tie-break-0 case) so it is
+#   never silent. Innocent twins (own discriminator, never rationaled) stay unflagged via TwinIdentities.
 #
 # EDGE SHAPE (t/2955): edge field reads go through Test-EdgeHasField / Get-EdgeField so a raw
 # [hashtable]/[IDictionary] edge is CHECKED, not skipped — a hashtable's PSObject.Properties are
@@ -203,9 +207,11 @@ function New-EdgeBaselineModel {
         [void]$byNearKey[$nk].Add($entry)
     }
 
-    $hadRationale  = @{}
-    $twinKeys      = [System.Collections.Generic.HashSet[string]]::new()
-    $ambiguousKeys = [System.Collections.Generic.HashSet[string]]::new()
+    $hadRationale       = @{}
+    $twinKeys           = [System.Collections.Generic.HashSet[string]]::new()
+    $ambiguousKeys      = [System.Collections.Generic.HashSet[string]]::new()
+    $twinIdentities     = [System.Collections.Generic.HashSet[string]]::new()   # every baseline twin's full identity (t/2956 AC#7)
+    $rationaledTwinKeys = [System.Collections.Generic.HashSet[string]]::new()   # twin near-keys with >=1 rationaled twin
     foreach ($nk in $byNearKey.Keys) {
         $group = $byNearKey[$nk]
         if ($group.Count -eq 1) {
@@ -225,10 +231,18 @@ function New-EdgeBaselineModel {
         }
         [void]$twinKeys.Add($nk)
         foreach ($g in $group) {
-            if ($g.HasRat) { $hadRationale["$nk|$($g.Da)|$($g.Model)"] = $true }
+            $id = "$nk|$($g.Da)|$($g.Model)"
+            [void]$twinIdentities.Add($id)                                    # every baseline twin identity (rationaled or not)
+            if ($g.HasRat) { $hadRationale[$id] = $true; [void]$rationaledTwinKeys.Add($nk) }
         }
     }
-    return @{ HadRationale = $hadRationale; TwinKeys = $twinKeys; AmbiguousKeys = $ambiguousKeys }
+    return @{
+        HadRationale       = $hadRationale
+        TwinKeys           = $twinKeys
+        AmbiguousKeys      = $ambiguousKeys
+        TwinIdentities     = $twinIdentities
+        RationaledTwinKeys = $rationaledTwinKeys
+    }
 }
 
 function Test-EdgeRationaleRegression {
@@ -290,9 +304,11 @@ function Test-EdgeRationaleRegression {
             $model = New-EdgeBaselineModel -BaselineEdges $BaselineEdges   # twin-aware (t/2956)
             if ($mapKey) { $script:EdgeHadRationaleCache[$mapKey] = $model }
         }
-        $hadRationale  = $model.HadRationale
-        $twinKeys      = $model.TwinKeys
-        $ambiguousKeys = $model.AmbiguousKeys
+        $hadRationale       = $model.HadRationale
+        $twinKeys           = $model.TwinKeys
+        $ambiguousKeys      = $model.AmbiguousKeys
+        $twinIdentities     = $model.TwinIdentities
+        $rationaledTwinKeys = $model.RationaledTwinKeys
         if ($hadRationale.Count -eq 0) { Write-Verbose 'edge-rationale guard: HEAD baseline carries no rationaled edges — nothing to protect.'; return 0 }
         # Finding 3 (CL e/120#43/#52): POSITIVE baseline-resolved signal — a healthy run must not
         # rely on the ABSENCE of a fail-open line to prove the baseline resolved.
@@ -304,7 +320,7 @@ function Test-EdgeRationaleRegression {
         if (-not $extract.HasKey) { Write-Verbose 'edge-rationale guard: write payload has no edges KEY (missing) — fail-open (nothing to check).'; return 0 }
         $writeEdges = @($extract.Edges)
 
-        $checked = 0; $skipped = 0; $skippedNull = 0; $skippedFault = 0; $skippedAmbiguous = 0
+        $checked = 0; $skipped = 0; $skippedNull = 0; $skippedFault = 0; $skippedAmbiguous = 0; $unmatchedTwin = 0
         foreach ($e in $writeEdges) {
             # t/2951: per-element resilience. Before, a $null element (or any element whose field
             # read threw) tripped the whole-body try/catch below into a SILENT whole-file fail-open
@@ -329,10 +345,20 @@ function Test-EdgeRationaleRegression {
                 $identity = if ($twinKeys.Contains($nearKey)) {
                     "$nearKey|$([string](Get-EdgeField $e 'discovered_at'))|$([string](Get-EdgeField $e 'model'))"
                 } else { $nearKey }
+                $rv = Get-EdgeField $e 'rationale'
+                $isEmpty = [string]::IsNullOrWhiteSpace([string]$rv)   # non-empty predicate — matches TS hasRationale (CL t/2956#4)
                 if ($hadRationale.ContainsKey($identity)) {
-                    $rv = Get-EdgeField $e 'rationale'
-                    $r  = if ($null -ne $rv) { [string]$rv } else { '' }
-                    if ([string]::IsNullOrWhiteSpace($r)) { [void]$lost.Add($identity) }
+                    if ($isEmpty) { [void]$lost.Add($identity) }
+                }
+                elseif ($isEmpty -and $twinKeys.Contains($nearKey) -and $rationaledTwinKeys.Contains($nearKey) -and (-not $twinIdentities.Contains($identity))) {
+                    # t/2956 AC#7 (CL PR review, tie-break-0 case): this edge is on a twin key that HAS a
+                    # rationaled twin, is empty, but its discovered_at+model matches NO baseline twin — the
+                    # discriminator may have been mutated on a write that also dropped the rationale, so a
+                    # baseline rationale could be going unwritten UNATTRIBUTABLY. We cannot safely attribute
+                    # it to a specific twin (it may be a legitimately new edge), so do NOT block — but COUNT
+                    # and surface it so the case is never SILENT (byte-identical to a clean pass). The
+                    # onWarn-analog of the TS util's tie-break-0 log.
+                    $unmatchedTwin++
                 }
             } catch {
                 $skippedFault++
@@ -349,6 +375,9 @@ function Test-EdgeRationaleRegression {
         }
         if ($skippedAmbiguous -gt 0) {
             $scanMsg += " Skipped $skippedAmbiguous edge(s) on indistinguishable twin key(s) — refuse-and-log, fail-open (t/2956)."
+        }
+        if ($unmatchedTwin -gt 0) {
+            $scanMsg += " Surfaced $unmatchedTwin empty edge(s) on a rationaled twin key whose discovered_at+model matches NO baseline twin — discriminator may have been mutated; potential unattributable drop, surfaced not blocked (t/2956 AC#7)."
         }
         Write-Verbose $scanMsg
     } catch {

--- a/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
+++ b/scripts/AITriad/Private/Test-EdgeRationaleRegression.ps1
@@ -15,9 +15,20 @@
 # be written rationale-less (composite key source|type|target). Baseline is HEAD (committed),
 # NOT on-disk — an intra-run checkpoint write can poison an on-disk baseline (CL Main e/120#13).
 #
-# NEAR-KEY NOTE (CL e/120#30, restore pre-flight t/2946#4): source|type|target is a NEAR-key;
-# on the live 33,580-edge file 3 keys carry 2 genuinely distinct edges each. Benign for THIS
-# guard today; twin-aware identity lives in the shared re-merge util + restore (t/2946 AC).
+# TWIN-AWARE IDENTITY (t/2956; was the near-key NOTE, CL e/120#30 / t/2946#4). source|type|target
+# is a NEAR-key, not a strict key — on the live 33,580-edge file 3 keys carry 2 genuinely distinct
+# edges each (differing discovered_at/model). The guard now identifies edges the SAME way as the
+# shared TS `mergeEdgesPreservingRationale` util (t/2957) and the t/2946 restore — ONE model across
+# guard + re-merge + restore so the three cannot drift: primary key source|type|target; where that
+# key is non-unique in the baseline, disambiguate the twin on discovered_at+model; if a twin group
+# is INDISTINGUISHABLE (same key AND discovered_at AND model), refuse-and-log — never guess. PS cannot
+# import the TS util, so conformance is proven against the shared research/comp-linguist/analyses/
+# t2444-rationale-restore/twin-fixture.json (the exact bytes the TS suite reads), not by code sharing
+# — the sanctioned parallel-writer pattern (cf. lib/edges/edgesWriterGuard.test.ts, t/2945#10).
+#   ONE DELIBERATE DIVERGENCE from the TS util: on an indistinguishable twin the TS util THROWS
+#   ActionableError; the guard must FAIL-OPEN (distinguishable Write-Verbose, no throw) — the Arm-1
+#   fail-open contract (CL e/120#30 F1 / TL #32) outranks mirroring the TS disposition. Same identity
+#   model, different disposition on ambiguity. (CL ruling t/2956#4.)
 #
 # EDGE SHAPE (t/2955): edge field reads go through Test-EdgeHasField / Get-EdgeField so a raw
 # [hashtable]/[IDictionary] edge is CHECKED, not skipped — a hashtable's PSObject.Properties are
@@ -162,6 +173,64 @@ function Get-EdgeField {
     return $null
 }
 
+function New-EdgeBaselineModel {
+    # t/2956: build the TWIN-AWARE baseline identity model from a baseline edge array. Returns
+    # @{ HadRationale; TwinKeys; AmbiguousKeys }:
+    #   HadRationale  - identity -> $true for every baseline edge carrying a NON-EMPTY rationale
+    #                   (predicate matches the TS util's hasRationale: null/''/whitespace = absent).
+    #                   Identity = the near-key `source|type|target` for a UNIQUE near-key, or
+    #                   `source|type|target|discovered_at|model` for a DISTINGUISHABLE twin group.
+    #   TwinKeys      - HashSet of near-keys that are distinguishable twin groups (the payload scan
+    #                   must key those on the FULL identity, not the bare near-key).
+    #   AmbiguousKeys - HashSet of near-keys whose twins are INDISTINGUISHABLE on discovered_at+model
+    #                   — refuse-and-log: never guarded, never guessed (fail-open, logged here).
+    # Same identity model as the shared TS mergeEdgesPreservingRationale util (t/2957) + t/2946
+    # restore — proven by the shared twin-fixture.json, not by code sharing (PS can't import TS).
+    param($BaselineEdges)
+
+    $byNearKey = @{}
+    foreach ($e in @($BaselineEdges)) {
+        if ($null -eq $e) { continue }
+        if (-not ((Test-EdgeHasField $e 'source') -and (Test-EdgeHasField $e 'type') -and (Test-EdgeHasField $e 'target'))) { continue }
+        $nk = "$(Get-EdgeField $e 'source')|$(Get-EdgeField $e 'type')|$(Get-EdgeField $e 'target')"
+        $rv = Get-EdgeField $e 'rationale'
+        $entry = @{
+            HasRat = -not [string]::IsNullOrWhiteSpace([string]$rv)
+            Da     = [string](Get-EdgeField $e 'discovered_at')
+            Model  = [string](Get-EdgeField $e 'model')
+        }
+        if (-not $byNearKey.ContainsKey($nk)) { $byNearKey[$nk] = [System.Collections.Generic.List[object]]::new() }
+        [void]$byNearKey[$nk].Add($entry)
+    }
+
+    $hadRationale  = @{}
+    $twinKeys      = [System.Collections.Generic.HashSet[string]]::new()
+    $ambiguousKeys = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($nk in $byNearKey.Keys) {
+        $group = $byNearKey[$nk]
+        if ($group.Count -eq 1) {
+            if ($group[0].HasRat) { $hadRationale[$nk] = $true }   # unique near-key -> identity IS the near-key
+            continue
+        }
+        # Twin group: distinguishable iff every (discovered_at, model) discriminator is unique.
+        $discSeen  = [System.Collections.Generic.HashSet[string]]::new()
+        $ambiguous = $false
+        foreach ($g in $group) {
+            if (-not $discSeen.Add("$($g.Da)|$($g.Model)")) { $ambiguous = $true; break }
+        }
+        if ($ambiguous) {
+            [void]$ambiguousKeys.Add($nk)
+            Write-Verbose "edge-rationale guard: twin near-key '$nk' has $($group.Count) edges INDISTINGUISHABLE on discovered_at+model — refuse-and-log (t/2956): fail-open for this key, not guarded, not guessed."
+            continue
+        }
+        [void]$twinKeys.Add($nk)
+        foreach ($g in $group) {
+            if ($g.HasRat) { $hadRationale["$nk|$($g.Da)|$($g.Model)"] = $true }
+        }
+    }
+    return @{ HadRationale = $hadRationale; TwinKeys = $twinKeys; AmbiguousKeys = $ambiguousKeys }
+}
+
 function Test-EdgeRationaleRegression {
     <#
     .SYNOPSIS
@@ -207,28 +276,23 @@ function Test-EdgeRationaleRegression {
             $baselineFromHead = $true
         }
 
-        # t/2951: memoize the derived hadRationale map under the same path@HEAD-sha key as the
-        # baseline array — but ONLY when the baseline came from HEAD (an injected baseline has no
-        # stable cache identity; those callers/tests rebuild every call, unchanged). The key was
-        # published by Get-EdgesFromHead into $script:LastEdgeBaselineKey, so no extra git call.
+        # t/2951: memoize the derived baseline MODEL (twin-aware, t/2956) under the same path@HEAD-sha
+        # key as the baseline array — but ONLY when the baseline came from HEAD (an injected baseline
+        # has no stable cache identity; those callers/tests rebuild every call, unchanged). The key
+        # was published by Get-EdgesFromHead into $script:LastEdgeBaselineKey, so no extra git call.
+        # The model is a pure function of the baseline, so it shares the array cache's invalidation.
         $mapKey = if ($baselineFromHead) { $script:LastEdgeBaselineKey } else { $null }
         if ($mapKey -and $script:EdgeHadRationaleCache.ContainsKey($mapKey)) {
-            $hadRationale = $script:EdgeHadRationaleCache[$mapKey]
-            Write-Verbose "edge-rationale guard: hadRationale map cache hit — $($hadRationale.Count) rationaled key(s) reused (memoized, t/2951)."
+            $model = $script:EdgeHadRationaleCache[$mapKey]
+            Write-Verbose "edge-rationale guard: hadRationale map cache hit — $($model.HadRationale.Count) rationaled key(s) reused (memoized, t/2951)."
         }
         else {
-            $hadRationale = @{}
-            foreach ($e in @($BaselineEdges)) {
-                if ($null -eq $e) { continue }
-                if (-not ((Test-EdgeHasField $e 'source') -and (Test-EdgeHasField $e 'type') -and (Test-EdgeHasField $e 'target'))) { continue }
-                $rv = Get-EdgeField $e 'rationale'
-                $r  = if ($null -ne $rv) { [string]$rv } else { '' }
-                if (-not [string]::IsNullOrWhiteSpace($r)) {
-                    $hadRationale["$(Get-EdgeField $e 'source')|$(Get-EdgeField $e 'type')|$(Get-EdgeField $e 'target')"] = $true
-                }
-            }
-            if ($mapKey) { $script:EdgeHadRationaleCache[$mapKey] = $hadRationale }
+            $model = New-EdgeBaselineModel -BaselineEdges $BaselineEdges   # twin-aware (t/2956)
+            if ($mapKey) { $script:EdgeHadRationaleCache[$mapKey] = $model }
         }
+        $hadRationale  = $model.HadRationale
+        $twinKeys      = $model.TwinKeys
+        $ambiguousKeys = $model.AmbiguousKeys
         if ($hadRationale.Count -eq 0) { Write-Verbose 'edge-rationale guard: HEAD baseline carries no rationaled edges — nothing to protect.'; return 0 }
         # Finding 3 (CL e/120#43/#52): POSITIVE baseline-resolved signal — a healthy run must not
         # rely on the ABSENCE of a fail-open line to prove the baseline resolved.
@@ -240,7 +304,7 @@ function Test-EdgeRationaleRegression {
         if (-not $extract.HasKey) { Write-Verbose 'edge-rationale guard: write payload has no edges KEY (missing) — fail-open (nothing to check).'; return 0 }
         $writeEdges = @($extract.Edges)
 
-        $checked = 0; $skipped = 0; $skippedNull = 0; $skippedFault = 0
+        $checked = 0; $skipped = 0; $skippedNull = 0; $skippedFault = 0; $skippedAmbiguous = 0
         foreach ($e in $writeEdges) {
             # t/2951: per-element resilience. Before, a $null element (or any element whose field
             # read threw) tripped the whole-body try/catch below into a SILENT whole-file fail-open
@@ -252,12 +316,23 @@ function Test-EdgeRationaleRegression {
             try {
                 if ($null -eq $e) { $skippedNull++; continue }
                 if (-not ((Test-EdgeHasField $e 'source') -and (Test-EdgeHasField $e 'type') -and (Test-EdgeHasField $e 'target'))) { $skipped++; continue }
+                $nearKey = "$(Get-EdgeField $e 'source')|$(Get-EdgeField $e 'type')|$(Get-EdgeField $e 'target')"
+                # t/2956: an INDISTINGUISHABLE twin near-key was refuse-and-logged at baseline build —
+                # fail-open for it here too (cannot attribute a per-twin drop without guessing), and
+                # surface the count so a memo-hit run (which skips the build-time verbose) still reports it.
+                if ($ambiguousKeys.Contains($nearKey)) { $skippedAmbiguous++; continue }
                 $checked++
-                $key = "$(Get-EdgeField $e 'source')|$(Get-EdgeField $e 'type')|$(Get-EdgeField $e 'target')"
-                if ($hadRationale.ContainsKey($key)) {
+                # t/2956: identify the SPECIFIC edge, not just the near-key. For a distinguishable twin
+                # group, the identity is near-key|discovered_at|model — so a drop on the twin that carried
+                # a rationale is attributed to THAT twin, and an innocent twin (never had one) written
+                # empty is NOT false-flagged as a drop. For a unique near-key the identity IS the near-key.
+                $identity = if ($twinKeys.Contains($nearKey)) {
+                    "$nearKey|$([string](Get-EdgeField $e 'discovered_at'))|$([string](Get-EdgeField $e 'model'))"
+                } else { $nearKey }
+                if ($hadRationale.ContainsKey($identity)) {
                     $rv = Get-EdgeField $e 'rationale'
                     $r  = if ($null -ne $rv) { [string]$rv } else { '' }
-                    if ([string]::IsNullOrWhiteSpace($r)) { [void]$lost.Add($key) }
+                    if ([string]::IsNullOrWhiteSpace($r)) { [void]$lost.Add($identity) }
                 }
             } catch {
                 $skippedFault++
@@ -267,9 +342,13 @@ function Test-EdgeRationaleRegression {
         # edges actually examined + those skipped for missing key fields, so "0 regressions" is
         # never indistinguishable from "nothing was scanned". t/2951: null/faulted elements are
         # counted separately and only surfaced when non-zero — zero new noise on the all-valid path.
+        # t/2956: edges on an indistinguishable-twin key are counted + surfaced likewise.
         $scanMsg = "edge-rationale guard: payload scanned — checked $checked edge(s), skipped $skipped (missing key fields)."
         if (($skippedNull + $skippedFault) -gt 0) {
             $scanMsg += " Skipped individually, scan continued (t/2951): $skippedNull null element(s), $skippedFault faulted element(s)."
+        }
+        if ($skippedAmbiguous -gt 0) {
+            $scanMsg += " Skipped $skippedAmbiguous edge(s) on indistinguishable twin key(s) — refuse-and-log, fail-open (t/2956)."
         }
         Write-Verbose $scanMsg
     } catch {
@@ -282,7 +361,8 @@ function Test-EdgeRationaleRegression {
     $sample  = (@($lost) | Select-Object -First 3) -join ', '
     $leaf    = if ($Path) { [System.IO.Path]::GetFileName($Path) } else { 'edges.json' }
     $problem = "$($lost.Count) edge(s) carrying a rationale in HEAD would be written WITHOUT one " +
-               "(composite key source|type|target). Sample: $sample. This is the edge-rationale wipe class (t/2945)."
+               "(twin-aware identity source|type|target, disambiguated on discovered_at+model for twin keys). " +
+               "Sample: $sample. This is the edge-rationale wipe class (t/2945)."
     $steps   = @(
         'A whole-file edges save MUST re-merge rationale from HEAD/on-disk by composite key before writing — never persist a rationale-stripped list payload (the taxonomy-editor load-list->save round-trip, t/2945).',
         'If this removal is intentional, set $env:AI_TRIAD_EDGE_RATIONALE_GATE=Off for the run.'

--- a/tests/EdgeRationaleRegression.Tests.ps1
+++ b/tests/EdgeRationaleRegression.Tests.ps1
@@ -437,3 +437,147 @@ Describe 'Test-EdgeRationaleRegression — per-element null/fault resilience in 
         }
     }
 }
+
+Describe 'Test-EdgeRationaleRegression — twin-aware edge identity (t/2956)' -Tag 'edges' {
+
+    BeforeAll {
+        # An edge with discovered_at + optional model, for building twin (shared-near-key) cases.
+        function New-TwinEdge {
+            param([string]$Source, [string]$Type, [string]$Target, [string]$DiscoveredAt, [string]$Model, [string]$Rationale)
+            $o = [ordered]@{ source = $Source; type = $Type; target = $Target; confidence = 0.85; status = 'approved'; discovered_at = $DiscoveredAt }
+            if ($PSBoundParameters.ContainsKey('Model'))     { $o['model'] = $Model }
+            if ($PSBoundParameters.ContainsKey('Rationale')) { $o['rationale'] = $Rationale }
+            [pscustomobject]$o
+        }
+        # CL directive (t/2956#4): load the SHARED fixture by PATH — do not transcribe it. Reading the
+        # exact bytes the TS suite reads is what makes drift detectable; a copied fixture defeats it.
+        $script:TwinFixturePath = Join-Path $PSScriptRoot '..' 'research' 'comp-linguist' 'analyses' 't2444-rationale-restore' 'twin-fixture.json'
+    }
+
+    # --- Real near-key defect: the current bare-near-key guard FALSE-POSITIVES on an innocent twin
+    #     (never had rationale) written empty on a key another twin rationaled → a spurious Block.
+    #     Twin-aware identity attributes per specific edge, so the innocent twin is not flagged. ---
+    It 'does NOT false-flag an innocent twin (never had rationale) written empty on a rationaled twin key' {
+        $baseline = @(
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-04-06' 'gemini-2.5-flash' 'twin A carried this'),
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-06-11' 'llm_proposed')   # twin B: never had one
+        )
+        $write = New-EdgesData @(
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-04-06' 'gemini-2.5-flash' 'twin A carried this'),  # kept
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-06-11' 'llm_proposed')                             # empty, legitimately
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $baseline } {
+            param($W, $B)
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 0
+            { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Not -Throw
+        }
+    }
+
+    It 'detects a drop on the rationaled twin PRECISELY (count 1, not 2) while its innocent twin is written empty' {
+        $baseline = @(
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-04-06' 'gemini-2.5-flash' 'twin A carried this'),
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-06-11' 'llm_proposed')   # never had one
+        )
+        $write = New-EdgesData @(
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-04-06' 'gemini-2.5-flash'),  # DROP (twin A stripped)
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-06-11' 'llm_proposed')       # empty, never had one
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $baseline } {
+            param($W, $B)
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+            { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Throw
+        }
+    }
+
+    It 'AC#3: INDISTINGUISHABLE twins (same key AND discovered_at AND model) -> refuse-and-log, fail-open, NO throw, distinguishable verbose' {
+        $baseline = @(
+            (New-TwinEdge 'acc-beliefs-069' 'SUPPORTS' 'acc-intentions-054' '2026-04-06' 'gemini-2.5-flash' 'twin A rationale'),
+            (New-TwinEdge 'acc-beliefs-069' 'SUPPORTS' 'acc-intentions-054' '2026-04-06' 'gemini-2.5-flash' 'twin B rationale')  # same discriminator
+        )
+        $write = New-EdgesData @(
+            (New-TwinEdge 'acc-beliefs-069' 'SUPPORTS' 'acc-intentions-054' '2026-04-06' 'gemini-2.5-flash'),   # both stripped
+            (New-TwinEdge 'acc-beliefs-069' 'SUPPORTS' 'acc-intentions-054' '2026-04-06' 'gemini-2.5-flash')
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $baseline } {
+            param($W, $B)
+            $v = (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -Verbose -WarningAction SilentlyContinue 4>&1) | Out-String
+            (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block) | Should -Be 0   # fail-OPEN, never throws
+            $v | Should -Match 'INDISTINGUISHABLE'
+            $v | Should -Match 'refuse-and-log'
+        }
+    }
+
+    It 'mixed: an indistinguishable twin key is skipped + surfaced in the payload scan while other keys are still guarded' {
+        $baseline = @(
+            (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'guarded singleton'),
+            (New-TwinEdge 'x-1' 'SUPPORTS' 'y-1' '2026-01-01' 'm' 'twin A'),
+            (New-TwinEdge 'x-1' 'SUPPORTS' 'y-1' '2026-01-01' 'm' 'twin B')   # indistinguishable
+        )
+        $write = New-EdgesData @(
+            (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'guarded singleton'),    # kept
+            (New-TwinEdge 'x-1' 'SUPPORTS' 'y-1' '2026-01-01' 'm'),           # stripped
+            (New-TwinEdge 'x-1' 'SUPPORTS' 'y-1' '2026-01-01' 'm')            # stripped
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $baseline } {
+            param($W, $B)
+            $v = (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -Verbose -WarningAction SilentlyContinue 4>&1) | Out-String
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 0
+            $v | Should -Match 'Skipped 2 edge\(s\) on indistinguishable twin key'
+        }
+    }
+
+    # --- Non-empty predicate conformance with the TS hasRationale (CL t/2956#4; twin-independent) ---
+    It 'CONFORMANCE: rationale of "" or whitespace counts as ABSENT (a drop), matching the TS hasRationale' {
+        $baseline = @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'because X reinforces Y') )
+        $emptyStr = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' '') )
+        $wsOnly   = New-EdgesData @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' '   ') )
+        InModuleScope AITriad -Parameters @{ E = $emptyStr; Wsp = $wsOnly; B = $baseline } {
+            param($E, $Wsp, $B)
+            Test-EdgeRationaleRegression -EdgesData $E   -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+            Test-EdgeRationaleRegression -EdgesData $Wsp -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 1
+            { Test-EdgeRationaleRegression -EdgesData $E -BaselineEdges $B -Mode Block } | Should -Throw
+        }
+    }
+
+    It 'CLEAN (AC#5): distinguishable twins that each KEEP their own rationale pass silently, zero noise' {
+        $baseline = @(
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-04-06' 'gemini-2.5-flash' 'twin A rationale'),
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-06-11' 'llm_proposed'      'twin B rationale')
+        )
+        $write = New-EdgesData @(
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-04-06' 'gemini-2.5-flash' 'twin A rationale'),
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-06-11' 'llm_proposed'      'twin B rationale')
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $baseline } {
+            param($W, $B)
+            $n = Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningVariable w -WarningAction SilentlyContinue
+            $n | Should -Be 0
+            @($w).Count | Should -Be 0
+        }
+    }
+
+    # --- Conformance against the SHARED fixture (loaded by path), so the PS model provably matches
+    #     the TS mergeEdgesPreservingRationale model rather than drifting. ---
+    It 'FIXTURE case_a (observed): distinguishable twins, both stripped on save -> both drops detected' {
+        $fx = Get-Content -Raw -LiteralPath $script:TwinFixturePath | ConvertFrom-Json
+        $baseline = @($fx.case_a_distinguishable.on_disk.edges)
+        $write    = [pscustomobject]@{ _schema_version = '1.0.0'; edges = @($fx.case_a_distinguishable.save_payload.edges) }
+        InModuleScope AITriad -Parameters @{ W = $write; B = $baseline } {
+            param($W, $B)
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 2
+            { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Throw
+        }
+    }
+
+    It 'FIXTURE case_b (constructed): indistinguishable twins -> refuse-and-log, fail-open, NO throw' {
+        $fx = Get-Content -Raw -LiteralPath $script:TwinFixturePath | ConvertFrom-Json
+        $baseline = @($fx.case_b_indistinguishable.on_disk.edges)
+        $write    = [pscustomobject]@{ _schema_version = '1.0.0'; edges = @($fx.case_b_indistinguishable.save_payload.edges) }
+        InModuleScope AITriad -Parameters @{ W = $write; B = $baseline } {
+            param($W, $B)
+            $v = (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -Verbose -WarningAction SilentlyContinue 4>&1) | Out-String
+            (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block) | Should -Be 0   # fail-open, never throws
+            $v | Should -Match 'INDISTINGUISHABLE'
+        }
+    }
+}

--- a/tests/EdgeRationaleRegression.Tests.ps1
+++ b/tests/EdgeRationaleRegression.Tests.ps1
@@ -526,6 +526,29 @@ Describe 'Test-EdgeRationaleRegression — twin-aware edge identity (t/2956)' -T
         }
     }
 
+    It 'AC#7 (CL PR review): a twin whose discriminator is MUTATED while its rationale is dropped is SURFACED, not silent' {
+        # Baseline: a distinguishable twin key; twin A carries a rationale under model gemini-2.5-flash.
+        $baseline = @(
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-04-06' 'gemini-2.5-flash' 'twin A carried this'),
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-06-11' 'llm_proposed')   # innocent twin, distinct discriminator
+        )
+        # Payload rewrites twin A's MODEL (gemini-2.5-flash -> mutated) AND drops its rationale. Its new
+        # identity matches no baseline twin, so it can't be attributed — but it must not be silent.
+        $write = New-EdgesData @(
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-04-06' 'MUTATED-MODEL'),
+            (New-TwinEdge 'acc-beliefs-051' 'SUPPORTS' 'acc-desires-001' '2026-06-11' 'llm_proposed')   # innocent twin, unchanged: NOT surfaced
+        )
+        InModuleScope AITriad -Parameters @{ W = $write; B = $baseline } {
+            param($W, $B)
+            $v = (Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -Verbose -WarningAction SilentlyContinue 4>&1) | Out-String
+            # Non-blocking (can't attribute), but NOT silent — surfaced in the scan line, exactly once.
+            Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Warn -WarningAction SilentlyContinue | Should -Be 0
+            { Test-EdgeRationaleRegression -EdgesData $W -BaselineEdges $B -Mode Block } | Should -Not -Throw
+            $v | Should -Match 'Surfaced 1 empty edge\(s\) on a rationaled twin key'
+            $v | Should -Match 'discriminator may have been mutated'
+        }
+    }
+
     # --- Non-empty predicate conformance with the TS hasRationale (CL t/2956#4; twin-independent) ---
     It 'CONFORMANCE: rationale of "" or whitespace counts as ABSENT (a drop), matching the TS hasRationale' {
         $baseline = @( (New-Edge 'acc-001' 'SUPPORTS' 'saf-002' 'because X reinforces Y') )


### PR DESCRIPTION
Brings `Test-EdgeRationaleRegression` onto the SAME identity model as the shared TS `mergeEdgesPreservingRationale` (t/2957) + t/2946 restore — one model across guard + re-merge + restore. PS can't import the TS util, so conformance is proven against the shared `twin-fixture.json` **loaded by path (not transcribed)** — the sanctioned parallel-writer pattern (cf. `edgesWriterGuard.test.ts`). CL-cleared (t/2956#4); **holding merge for CL review** (they asked to be pinged).

**Identity:** key `source|type|target`; non-unique → tie-break `discovered_at`+`model`; still ambiguous → refuse-and-log.

**One deliberate divergence from the TS util:** on an indistinguishable twin the TS util **throws**; the guard **fails open** (distinguishable `Write-Verbose`, no throw) — the Arm-1 fail-open contract outranks mirroring the TS disposition. Documented in the file header.

**Folded in (CL t/2956#4):** non-empty-predicate conformance — the guard already treats `''`/whitespace/`null` as absent on both sides (matching TS `hasRationale`); now locked with a test so a `rationale:""` drop can't read as "still has one".

### ⚠️ Finding for review — AC#2 reframing
On close analysis, the **current** bare-near-key guard does **not** mask a drop: its payload scan is **per-empty-edge** (not set-vs-set), so it already detects AC#2's literal drop. Its real defect is the **inverse — a false-POSITIVE**: an innocent twin (never had rationale) written empty on a key another twin rationaled is flagged as a drop → a spurious **Block** (the flaky-blocking-gate hazard). The twin-aware fix eliminates that **and** makes detection precise (exact count, no over-count). Tests demonstrate the real behavior; I've reframed AC#2 accordingly rather than fabricate a "current=MISS" test. Flagging for your confirmation.

**Tests:** +8, guard suite **34/34** green locally (false-positive elimination; precise per-twin drop; indistinguishable refuse-and-log fail-open + verbose; mixed skipped-ambiguous surfaced; non-empty conformance; clean distinguishable-twin zero-noise; fixture case_a `observed` / case_b `constructed` by path). Full suite runs in CI; the only known-failing tests are unrelated live-dependency ones (xAI live, Situation BDI live).

Refs t/2956.

Co-Authored-By: PowerShell (Orca)
Co-Authored-By: Computational Linguist (Orca)