### PR TITLE
fix(taxonomy-editor): wrap node/situation detail title via auto-growing textarea (t/2937)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationDetail.tsx
@@ -14,6 +14,7 @@ import { TypeaheadSelect } from '../shared/TypeaheadSelect';
 import { EmptyState } from '../shared/EmptyState';
 import { FieldHelp } from '../shared/FieldHelp';
 import { LinkedChip } from '../shared/LinkedChip';
+import { InlineEditTitle } from '../shared/InlineEditTitle';
 import { useMentionRenderer } from '../shared/MentionField';
 import { reconstructNodeContainer } from '../shared/mentionText';
 import { GraphAttributesPanel } from '../taxonomy/GraphAttributesPanel';
@@ -133,13 +134,12 @@ function SitHeader({ node, readOnly, onDebate, onPin, err, hasErrors, update, la
           {readOnly ? (
             <span className="nd-header-label" title={node.label}>{labelContent ?? node.label}</span>
           ) : (
-            <input
-              className={`nd-header-label nd-header-label-editable ${err('label') ? 'has-error' : ''}`}
+            <InlineEditTitle
               value={node.label}
-              onChange={(e) => update({ label: e.target.value })}
+              onChange={(v) => update({ label: v })}
+              hasError={!!err('label')}
               placeholder="Label"
-              aria-label="Label"
-              title={node.label}
+              ariaLabel="Label"
             />
           )}
           <span className="nd-header-id">{node.id}</span>

--- a/taxonomy-editor/src/renderer/components/shared/InlineEditTitle.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/InlineEditTitle.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InlineEditTitle } from './InlineEditTitle';
+
+describe('InlineEditTitle (t/2937)', () => {
+  it('renders a <textarea> (not an <input>) so long titles can wrap', () => {
+    render(<InlineEditTitle value="A very long title" onChange={vi.fn()} ariaLabel="Label" />);
+    const el = screen.getByLabelText('Label');
+    expect(el.tagName).toBe('TEXTAREA'); // an <input> is single-line by spec and cannot wrap
+    expect((el as HTMLTextAreaElement).value).toBe('A very long title');
+  });
+
+  it('fires onChange with the new value on edit', () => {
+    const onChange = vi.fn();
+    render(<InlineEditTitle value="old" onChange={onChange} ariaLabel="Label" />);
+    fireEvent.change(screen.getByLabelText('Label'), { target: { value: 'new title' } });
+    expect(onChange).toHaveBeenCalledWith('new title');
+  });
+
+  it('Enter commits (blur) and never inserts a newline', () => {
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    render(<InlineEditTitle value="title" onChange={onChange} onBlur={onBlur} ariaLabel="Label" />);
+    const el = screen.getByLabelText('Label') as HTMLTextAreaElement;
+    el.focus();
+    const prevented = !fireEvent.keyDown(el, { key: 'Enter' }); // returns false when preventDefault was called
+    expect(prevented).toBe(true);   // Enter is intercepted
+    expect(onBlur).toHaveBeenCalled(); // committed via blur
+    expect(onChange).not.toHaveBeenCalled(); // no newline written
+  });
+
+  it('applies the has-error class only when hasError is set', () => {
+    const { rerender } = render(<InlineEditTitle value="t" onChange={vi.fn()} ariaLabel="Label" />);
+    expect(screen.getByLabelText('Label').className).not.toContain('has-error');
+    rerender(<InlineEditTitle value="t" onChange={vi.fn()} hasError ariaLabel="Label" />);
+    expect(screen.getByLabelText('Label').className).toContain('has-error');
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/InlineEditTitle.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/InlineEditTitle.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import type { KeyboardEvent } from 'react';
+
+export interface InlineEditTitleProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Optional blur handler (e.g. NodeDetail's aphorism regen). */
+  onBlur?: () => void;
+  /** Applies the `has-error` class (validation banner mirror). */
+  hasError?: boolean;
+  placeholder?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * Auto-growing inline-edit title for the node/situation detail headers (t/2937).
+ *
+ * Renders a `<textarea>`, NOT an `<input>`: a long title must WRAP to multiple lines instead of
+ * truncating with an ellipsis, and an `<input>` is single-line by HTML spec — no CSS can wrap it
+ * (which is why the two prior CSS-only fixes did nothing; t/2937#3). Height auto-grows to the
+ * wrapped content via CSS `field-sizing: content` on `.nd-header-label-editable` (Chromium 123+/
+ * Electron 35). Enter COMMITS (blur) rather than inserting a literal newline — titles are single-
+ * value, and the store is already updated live via onChange, so blur is the natural commit point.
+ */
+export function InlineEditTitle({ value, onChange, onBlur, hasError, placeholder, ariaLabel }: InlineEditTitleProps) {
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Any Enter commits (never a newline) — a title carries no line breaks; wrapping is visual only.
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.currentTarget.blur();
+    }
+  };
+
+  return (
+    <textarea
+      className={`nd-header-label nd-header-label-editable ${hasError ? 'has-error' : ''}`}
+      value={value}
+      rows={1}
+      onChange={(e) => onChange(e.target.value)}
+      onBlur={onBlur}
+      onKeyDown={handleKeyDown}
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+      title={value}
+    />
+  );
+}

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -38,6 +38,7 @@ import { usePreferencesStore } from '../../store/preferencesStore';
 import { EmptyState } from '../shared/EmptyState';
 import { OverflowMenu, type OverflowMenuEntry } from '../shared/OverflowMenu';
 import { CopyLinkButton } from '../shared/CopyLinkButton';
+import { InlineEditTitle } from '../shared/InlineEditTitle';
 import { publicPovSharePath } from '../../utils/shareLinks';
 import { DebateTestedChip } from './DebateTestedChip';
 import { DebateTestedDrilldown } from './DebateTestedDrilldown';
@@ -585,14 +586,13 @@ function NodeDetailHeaderTop({ pov, node, readOnly, err, update, maybeRegenAphor
         {readOnly ? (
           <span className="nd-header-label" title={node.label}>{labelContent ?? node.label}</span>
         ) : (
-          <input
-            className={`nd-header-label nd-header-label-editable ${err('label') ? 'has-error' : ''}`}
+          <InlineEditTitle
             value={node.label}
-            onChange={(e) => update({ label: e.target.value })}
+            onChange={(v) => update({ label: v })}
             onBlur={maybeRegenAphorism}
+            hasError={!!err('label')}
             placeholder="Label"
-            aria-label="Label"
-            title={node.label}
+            ariaLabel="Label"
           />
         )}
       </div>

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -3213,8 +3213,7 @@ body {
   margin: -2px -6px;
   width: 100%;
   min-width: 0;
-  text-overflow: ellipsis;
-  overflow: hidden;
+  overflow: hidden; resize: none; field-sizing: content; /* t/2937: <textarea> title wraps + auto-grows, no ellipsis (dropped text-overflow) */
   transition: border-color var(--transition-fast), background-color var(--transition-fast);
 }
 


### PR DESCRIPTION
Design + full approach: t/2937#4 (TL-approved p/342#178).

Swaps the editable detail-panel title `<input>` (can't wrap, single-line by spec) for a shared `InlineEditTitle` `<textarea>` with `field-sizing:content` auto-grow + Enter→commit, and drops `text-overflow:ellipsis` on `.nd-header-label-editable`. One shared component, both call sites (NodeDetail + SituationDetail).

**Draft** until I attach the rendered-DOM verification (TL's non-negotiable bar: element is a textarea + long title wraps on a POV node AND a Situation, before/after). Unit test green (textarea-not-input, Enter commits without newline, onChange, has-error); tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)