### PR TITLE
docs(cl): anchor is a visibility point, not a lock (t/2961 AC6)

### DIFF
--- a/research/comp-linguist/docs/incident-claim-discipline.md
+++ b/research/comp-linguist/docs/incident-claim-discipline.md
@@ -29,9 +29,19 @@ That changes how you speak and how you check.
 
 The pre-existing root rule ("Live incident: claim follow-ups before filing") covers only the second class. The write class is the addition. This incident's most expensive failure was a write nobody could attribute, not a filing.
 
-### 3. The anchor is the single serialization point
+### 3. The anchor gives visibility, not a lock
 
-Both claim classes land as comments on the incident anchor ticket, so any actor can read the complete set of in-flight claims in one place. Claims scattered across email threads, pings, and per-role tickets do not serialize. They only look like they do.
+Both claim classes land as comments on the incident anchor ticket, so any actor can read the complete set of in-flight claims in one place. Claims scattered across email threads, pings, and per-role tickets do not give you that one place to look. They only look like they do.
+
+What the anchor does **not** do is order anything. A ticket comment is not a mutex. Two background jobs can each post a claim and each proceed, because neither posting blocks the other. Treating the anchor as a lock is the failure mode one step removed from having no claim at all. You believe you hold exclusive access, so you skip the check that would have told you otherwise.
+
+Where actual serialization matters, use the stronger form:
+
+> **Claim, then re-read the anchor before acting.**
+
+The re-read is what converts visibility into exclusion. It is cheap, it happens after any competing claim would have landed, and it is the only step that catches a peer who claimed while you were preparing your write.
+
+*Wording aligned with the root `AGENTS.md` **Incident Response** rule (t/2961, PI-approved).* An earlier revision of this section called the anchor "the single serialization point," which overstated it. Corrected here so the CL-scope statement cannot drift from the root rule it elaborates.
 
 ## Evidence base
 


### PR DESCRIPTION
Closes **t/2961 AC6**, the last open acceptance criterion, now that the PI-approved root rule landed in **#1462** (`f4439734`).

## Why this isn't just a pointer

The plan was "add a CL-scope pointer to the root section." Reading the landed root text against my own doc surfaced a contradiction on the load-bearing half.

**Landed root rule (PI-approved):**
> The anchor is a **visibility** point, not a lock: it makes concurrent actors see each other, it does not serialize them. Where actual serialization is required, use the stronger form — claim, then re-read the anchor before acting.

**This doc, §3, before:**
> ### 3. The anchor is the single serialization point

**The root text is right and mine overstated.** A ticket comment is not a mutex. Two background jobs can each post a claim and each proceed, because neither posting blocks the other. What produces exclusion is the protocol — claim, then re-read before acting — and the re-read is the only step that catches a peer who claimed while you were preparing your write.

Left uncorrected, a CL-scope doc would assert the anchor **is** the serialization point while the root rule it elaborates says explicitly that it is not. That is precisely the drift the pointer exists to prevent, so it had to be fixed in the same change.

## What changed

`research/comp-linguist/docs/incident-claim-discipline.md` §3 only:

- Heading: "The anchor is the single serialization point" → "The anchor gives visibility, not a lock".
- **Kept** the part that was true: claims scattered across threads, pings, and per-role tickets don't give you one place to look.
- **Added** the failure mode: believing you hold a lock is worse than having no claim, because the belief is what makes you skip the check.
- **Added** the stronger form (claim → re-read before acting) and why the re-read is the step that does the work.
- Notes the correction inline so the revision history is legible rather than silently rewritten.

No other section touched. No metric, threshold, or lexicon introduced — provenance class `derived` is unchanged, no register entry needed.

## Verification

`/review-prose` on the rewritten section:

| tell | §3 before | §3 after | whole doc after |
|---|---|---|---|
| colon-hinge | 8.3% (1/12) | **0%** | 3.6% (2/56), under the <5% threshold |
| em-dashes | 0 | 0 | 0 |
| all other tells | 0 | 0 | 0 |

The one hinge was split into two sentences rather than repunctuated, per the skill's "rewrite, don't swap" rule.

## Not in this PR

The one-line pointer in `research/comp-linguist/AGENTS.md` is **not** here — that file is **overlay-tracked** (`ogit`), and `.orca-git` lives at the main checkout root, so it is absent from any linked worktree (verified: neither the file nor `.orca-git` exists in this worktree). It needs a separate `ogit` commit from the shared checkout. Tracked on t/2961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017U4xd8fyYPJL6U6SmKiftY