### PR TITLE
style(css): co-locate PhrasesPanel + data-update clusters — Phase 3 (t/2901)

### DIFF
--- a/quality-gates.json
+++ b/quality-gates.json
@@ -1,7 +1,7 @@
 {
   "$comment": "Non-LOC quality gates only (ADR-007 Gate Co-Location). ESLint `max-lines`, co-located in the eslint configs (lib/eslint.config.mjs, taxonomy-editor/eslint.config.mjs), is the SINGLE source of truth for .ts/.tsx LOC — do NOT re-add .ts ceilings here. styles.css stays: CSS is not covered by the TS eslint configs. See docs/design/adr/007-file-size-budget.md.",
   "loc_ceilings": {
-    "taxonomy-editor/src/renderer/styles.css": 16513
+    "taxonomy-editor/src/renderer/styles.css": 16348
   },
   "max_file_bytes": 5242880,
   "tsc_error_ceilings": {

--- a/taxonomy-editor/src/renderer/App.css
+++ b/taxonomy-editor/src/renderer/App.css
@@ -47,3 +47,126 @@
 .pov-badge-acc { color: var(--color-acc); border: 1px solid var(--color-acc); }
 .pov-badge-saf { color: var(--color-saf); border: 1px solid var(--color-saf); }
 .pov-badge-skp { color: var(--color-skp); border: 1px solid var(--color-skp); }
+
+/* ─── Data update banner (App.tsx) ──────────────────────── */
+
+.data-update-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  background: rgba(37, 99, 235, 0.12);
+  border-bottom: 1px solid rgba(37, 99, 235, 0.25);
+  font-size: var(--text-sm);
+  flex-shrink: 0;
+}
+
+.data-update-text {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.data-update-btn {
+  background: var(--focus-ring, #2563eb) !important;
+  color: #fff !important;
+  border: none !important;
+}
+
+.data-update-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-lg);
+  padding: 0 4px;
+  line-height: 1;
+  margin-left: auto;
+}
+
+.data-update-dismiss:hover {
+  color: var(--text-primary);
+}
+
+.data-update-result {
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+.data-update-result.success {
+  color: #22c55e;
+}
+.data-update-result.error {
+  color: #ef4444;
+}
+
+.data-update-files {
+  padding: 6px 16px 8px;
+  background: rgba(37, 99, 235, 0.06);
+  border-bottom: 1px solid rgba(37, 99, 235, 0.15);
+  font-size: var(--text-sm);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.data-update-file-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+}
+
+.data-update-file-status {
+  display: inline-block;
+  min-width: 36px;
+  text-align: center;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+}
+
+.data-update-file-status-M {
+  background: rgba(234, 179, 8, 0.18);
+  color: #b45309;
+}
+
+.data-update-file-status-A {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+}
+
+.data-update-file-status-D {
+  background: rgba(239, 68, 68, 0.18);
+  color: #dc2626;
+}
+
+.data-update-file-path {
+  flex: 1;
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.data-update-file-diff-btn {
+  background: none;
+  border: 1px solid var(--border-color, #ddd);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+
+.data-update-file-diff-btn:hover,
+.data-update-file-diff-btn.active {
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--focus-ring, #2563eb);
+  border-color: var(--focus-ring, #2563eb);
+}
+
+.data-update-diff-content .diff-add { color: #22863a; background: #f0fff4; }
+.data-update-diff-content .diff-del { color: #cb2431; background: #ffeef0; }
+.data-update-diff-content .diff-hunk { color: #6f42c1; }

--- a/taxonomy-editor/src/renderer/components/policy/PhrasesPanel.css
+++ b/taxonomy-editor/src/renderer/components/policy/PhrasesPanel.css
@@ -1,0 +1,48 @@
+/* Copyright (c) 2026 Jeffrey Snover. All rights reserved. */
+/* Licensed under the MIT License. See LICENSE file in the project root. */
+
+/* ─── Audience badges (phrases panel) ───────────────────── */
+
+.phrases-audience-badge {
+  font-size: var(--text-2xs);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.phrases-audience-industry_leader {
+  background: rgba(37, 99, 235, 0.1);
+  color: #2563eb;
+}
+
+.phrases-audience-policymaker {
+  background: rgba(147, 51, 234, 0.1);
+  color: #7c3aed;
+}
+
+.phrases-audience-technical_researcher {
+  background: rgba(13, 148, 136, 0.1);
+  color: #0d9488;
+}
+
+/* ─── Vocabulary confidence underlines ───────────────────── */
+
+.vocab-confidence-high {
+  text-decoration-color: rgba(34, 197, 94, 0.4);
+}
+.vocab-confidence-high:hover {
+  text-decoration-color: rgba(34, 197, 94, 0.8);
+  background: rgba(34, 197, 94, 0.08);
+}
+
+.vocab-confidence-low {
+  text-decoration-color: rgba(239, 68, 68, 0.4);
+}
+.vocab-confidence-low:hover {
+  text-decoration-color: rgba(239, 68, 68, 0.8);
+  background: rgba(239, 68, 68, 0.08);
+}

--- a/taxonomy-editor/src/renderer/components/policy/PhrasesPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/policy/PhrasesPanel.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
+import './PhrasesPanel.css';
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { api } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';

--- a/taxonomy-editor/src/renderer/styles.css
+++ b/taxonomy-editor/src/renderer/styles.css
@@ -677,129 +677,6 @@ body {
   color: var(--text-secondary, #999);
 }
 
-/* ─── Data update banner ─────────────────────────────── */
-
-.data-update-banner {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 16px;
-  background: rgba(37, 99, 235, 0.12);
-  border-bottom: 1px solid rgba(37, 99, 235, 0.25);
-  font-size: var(--text-sm);
-  flex-shrink: 0;
-}
-
-.data-update-text {
-  color: var(--text-primary);
-  font-weight: 600;
-}
-
-.data-update-btn {
-  background: var(--focus-ring, #2563eb) !important;
-  color: #fff !important;
-  border: none !important;
-}
-
-.data-update-dismiss {
-  background: none;
-  border: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: var(--text-lg);
-  padding: 0 4px;
-  line-height: 1;
-  margin-left: auto;
-}
-
-.data-update-dismiss:hover {
-  color: var(--text-primary);
-}
-
-.data-update-result {
-  font-size: var(--text-sm);
-  font-weight: 600;
-}
-.data-update-result.success {
-  color: #22c55e;
-}
-.data-update-result.error {
-  color: #ef4444;
-}
-
-.data-update-files {
-  padding: 6px 16px 8px;
-  background: rgba(37, 99, 235, 0.06);
-  border-bottom: 1px solid rgba(37, 99, 235, 0.15);
-  font-size: var(--text-sm);
-  max-height: 200px;
-  overflow-y: auto;
-}
-
-.data-update-file-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 3px 0;
-}
-
-.data-update-file-status {
-  display: inline-block;
-  min-width: 36px;
-  text-align: center;
-  font-size: var(--text-xs);
-  font-weight: 700;
-  padding: 1px 5px;
-  border-radius: var(--radius-sm);
-  text-transform: uppercase;
-}
-
-.data-update-file-status-M {
-  background: rgba(234, 179, 8, 0.18);
-  color: #b45309;
-}
-
-.data-update-file-status-A {
-  background: rgba(34, 197, 94, 0.18);
-  color: #15803d;
-}
-
-.data-update-file-status-D {
-  background: rgba(239, 68, 68, 0.18);
-  color: #dc2626;
-}
-
-.data-update-file-path {
-  flex: 1;
-  color: var(--text-primary);
-  font-family: var(--font-mono, monospace);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.data-update-file-diff-btn {
-  background: none;
-  border: 1px solid var(--border-color, #ddd);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: var(--text-xs);
-  padding: 1px 8px;
-  border-radius: var(--radius-sm);
-  white-space: nowrap;
-}
-
-.data-update-file-diff-btn:hover,
-.data-update-file-diff-btn.active {
-  background: rgba(37, 99, 235, 0.1);
-  color: var(--focus-ring, #2563eb);
-  border-color: var(--focus-ring, #2563eb);
-}
-
-.data-update-diff-content .diff-add { color: #22863a; background: #f0fff4; }
-.data-update-diff-content .diff-del { color: #cb2431; background: #ffeef0; }
-.data-update-diff-content .diff-hunk { color: #6f42c1; }
-
 /* ─── Git Progress Banner ─────────────────────────────── */
 
 .git-progress-banner {
@@ -4361,32 +4238,6 @@ body {
 .phrases-item-text {
   color: var(--text-primary);
   flex: 1;
-}
-
-.phrases-audience-badge {
-  font-size: var(--text-2xs);
-  padding: 1px 5px;
-  border-radius: var(--radius-sm);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  flex-shrink: 0;
-  margin-top: 2px;
-}
-
-.phrases-audience-industry_leader {
-  background: rgba(37, 99, 235, 0.1);
-  color: #2563eb;
-}
-
-.phrases-audience-policymaker {
-  background: rgba(147, 51, 234, 0.1);
-  color: #7c3aed;
-}
-
-.phrases-audience-technical_researcher {
-  background: rgba(13, 148, 136, 0.1);
-  color: #0d9488;
 }
 
 /* ── Feedback Popover (toolbar-anchored) ──────────────────────────────── */
@@ -8582,22 +8433,6 @@ a.vocab-term,
 .vocab-term:hover {
   text-decoration-color: rgba(168, 85, 247, 0.8);
   background: rgba(168, 85, 247, 0.08);
-}
-
-.vocab-confidence-high {
-  text-decoration-color: rgba(34, 197, 94, 0.4);
-}
-.vocab-confidence-high:hover {
-  text-decoration-color: rgba(34, 197, 94, 0.8);
-  background: rgba(34, 197, 94, 0.08);
-}
-
-.vocab-confidence-low {
-  text-decoration-color: rgba(239, 68, 68, 0.4);
-}
-.vocab-confidence-low:hover {
-  text-decoration-color: rgba(239, 68, 68, 0.8);
-  background: rgba(239, 68, 68, 0.08);
 }
 
 /* ─── Detail Tier Pills (DT-3) ────────────────────────── */


### PR DESCRIPTION
## Summary

Phase 3 feature-cluster PR (t/2901, self-cert against approved pattern t/2925#2). Two smallest clean clusters extracted from `styles.css`:

- **`PhrasesPanel.css`** (new) — `phrases-audience-*` (4 selectors: badge + 3 audience variants) and `vocab-confidence-*` (4 selectors: high/low + :hover). Single component owner (`PhrasesPanel.tsx`), 0 dynamic classes. Import added to `PhrasesPanel.tsx`.
- **`App.css`** (existing) — `data-update-*` (21 selectors: banner, text, btn, dismiss, result, files, file-row, file-status, file-status-M/A/D, file-path, file-diff-btn + variants, diff-content). Single component owner (`App.tsx`), 0 dynamic classes.
- **`styles.css`** — 165 LOC removed (16,513 → 16,348).
- **`quality-gates.json`** — ceiling ratcheted 16,513 → 16,348.

## Self-cert (t/2925#2 pattern)

- Plain co-located CSS (not Modules) — zero dynamic-class breakage by construction ✓
- Pre-move equal-specificity grep: all 3 clusters appear only in extracted blocks — no cascade conflicts ✓
- `App.css` already imported globally by `App.tsx` — no new import needed for data-update ✓
- Line-ceiling ratchet (automated gate) ✓
- Four-theme visual diff: manual — PhrasesPanel audience badges and vocab underlines visible in PhrasesPanel / vocabulary view.

## Test plan

- [ ] Quality-gates ceiling passes (16,348 ≤ 16,348) ✓ verified locally
- [ ] Phrases panel renders audience badges (industry_leader / policymaker / technical_researcher) with correct colors
- [ ] Vocabulary panel shows confidence underlines (high = green, low = red)
- [ ] Data-update banner renders when a data update is available
- [ ] Four-theme visual check (light / dark / BKC / Harvard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)