### PR TITLE
fix(cl): twin-aware identity + attribution proof in apply_restore (t/2946)

### DIFF
--- a/research/comp-linguist/analyses/t2444-rationale-restore/apply_restore.py
+++ b/research/comp-linguist/analyses/t2444-rationale-restore/apply_restore.py
@@ -122,6 +122,41 @@ def predecessor_of(edge):
     return ks[ri - 1] if ri > 0 else None
 
 
+def twin_id(e):
+    """The discriminator used to tell apart two edges sharing one composite key."""
+    return (e.get("discovered_at"), e.get("model"))
+
+
+def resolve_source(cur_edge, candidates):
+    """Twin-aware identity (t/2946 AC; TL-prescribed e/120#37).
+
+    The composite (source, target, type) is a NEAR-key, not a key: on the live file 3 keys carry
+    2 genuinely distinct edges each, and ba3128f5 carries a DIFFERENT rationale on each twin of
+    all three. Indexing the source by composite key alone is last-one-wins, which hands both
+    current twins the same text and mis-attributes half of them.
+
+    Same model as `lib/edges/mergeEdgesPreservingRationale` (t/2957) and the PS Arm-1 guard
+    (t/2956), validated against the shared `twin-fixture.json`:
+      primary key source|type|target -> tie-break on (discovered_at, model) -> refuse, never guess.
+
+    Returns (source_edge_or_None, disposition):
+      'unique'         - the key resolves to exactly one rationale-bearing source edge
+      'twin-resolved'  - non-unique key, the discriminator picked exactly one
+      'twin-unmatched' - non-unique key, no candidate matches this edge's discriminator
+      'twin-ambiguous' - non-unique key, the discriminator does not separate the candidates
+    The last two restore NOTHING. Guessing is the failure mode; a wrong rationale is invisible to
+    both the strip-back and position proofs.
+    """
+    if len(candidates) == 1:
+        return candidates[0], "unique"
+    matches = [c for c in candidates if twin_id(c) == twin_id(cur_edge)]
+    if len(matches) == 1:
+        return matches[0], "twin-resolved"
+    if not matches:
+        return None, "twin-unmatched"
+    return None, "twin-ambiguous"
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--current", required=True, help="path to live edges.json to restore into")
@@ -131,7 +166,8 @@ def main():
     args = ap.parse_args()
 
     cur_doc = load(args.current)
-    cur_blob = open(args.current, encoding="utf-8", newline="").read()
+    with open(args.current, encoding="utf-8", newline="") as f:   # context-managed: no leaked fd
+        cur_blob = f.read()
     src = load(args.source)["edges"]
 
     # Self-check: our serializer must reproduce the current file byte-for-byte before we trust it.
@@ -139,39 +175,73 @@ def main():
         sys.exit("ABORT: serializer does not round-trip the current file byte-for-byte; "
                  "the file's byte format has changed — update serialize() before restoring.")
 
-    # Keep the whole source edge (not just its rationale text) so we can restore the original slot.
-    src_by = {ckey(e): e for e in src if has_rat(e)}
-    had = {ckey(e) for e in cur_doc["edges"] if has_rat(e)}
+    # Keep whole source edges (not just rationale text) so we can restore the original slot.
+    # GROUPED, not a dict comp (t/2946#16): a dict keyed on the composite is last-one-wins on a
+    # duplicated key, which silently hands both current twins the same rationale.
+    from collections import Counter, defaultdict
+    src_groups = defaultdict(list)
+    for e in src:
+        if has_rat(e):
+            src_groups[ckey(e)].append(e)
 
     restored = kept = gap = 0
-    slot_mismatches = []   # (key, expected_pred, actual_pred) — must be empty
+    slot_mismatches = []      # (key, expected_pred, actual_pred) — must be empty
+    attribution_bad = []      # (key, cur_twin_id, src_twin_id) — must be empty
+    refusals = []             # (key, disposition, cur_twin_id) — restored nothing, logged
+    restored_idx = set()      # positions we added rationale to (strip-back is index-exact)
     new_edges = []
-    from collections import Counter
     placement = Counter()
-    for e in cur_doc["edges"]:
+    disposition = Counter()
+    for i, e in enumerate(cur_doc["edges"]):
         if has_rat(e):
             kept += 1
             new_edges.append(e)
             continue
         k = ckey(e)
-        if k in src_by:
-            src_e = src_by[k]
-            new_e, used_pred = restore_rationale(e, src_e)
-            new_edges.append(new_e)
-            restored += 1
-            placement[f"after:{used_pred}"] += 1
-            # POSITION PROOF (per edge): rationale must sit after the source predecessor whenever
-            # that predecessor is present in the current edge.
-            exp = source_predecessor(src_e)
-            if exp is not None and exp in e:
-                act = predecessor_of(new_e)
-                if act != exp:
-                    slot_mismatches.append((k, exp, act))
-        else:
+        cands = src_groups.get(k)
+        if not cands:
             new_edges.append(e)
             gap += 1
+            continue
+
+        src_e, disp = resolve_source(e, cands)
+        disposition[disp] += 1
+        if src_e is None:
+            # twin-unmatched / twin-ambiguous → refuse-and-log, restore nothing for this edge.
+            refusals.append((k, disp, twin_id(e)))
+            new_edges.append(e)
+            continue
+
+        new_e, used_pred = restore_rationale(e, src_e)
+        new_edges.append(new_e)
+        restored_idx.add(i)
+        restored += 1
+        placement[f"after:{used_pred}"] += 1
+
+        # POSITION PROOF (per edge): rationale must sit after the source predecessor whenever
+        # that predecessor is present in the current edge.
+        exp = source_predecessor(src_e)
+        if exp is not None and exp in e:
+            act = predecessor_of(new_e)
+            if act != exp:
+                slot_mismatches.append((k, exp, act))
+
+        # ATTRIBUTION PROOF (per edge, t/2946#16): on a NON-UNIQUE key the rationale must come
+        # from the twin whose (discovered_at, model) matches this edge. Strip-back is blind to
+        # this (it removes exactly what it inserted) and so is the position proof (it checks the
+        # slot, not whose text landed there) — so mis-attribution needs its own assertion.
+        if len(cands) > 1 and twin_id(src_e) != twin_id(e):
+            attribution_bad.append((k, twin_id(e), twin_id(src_e)))
     cur_doc["edges"] = new_edges
     out_blob = serialize(cur_doc)
+
+    # ATTRIBUTION PROOF: no restored rationale may come from the wrong twin.
+    if attribution_bad:
+        sample = "; ".join(f"{'|'.join(map(str, k))}: edge{ct} got source{st}"
+                           for k, ct, st in attribution_bad[:3])
+        sys.exit(f"ABORT: attribution proof failed — {len(attribution_bad)} restored edge(s) took "
+                 f"rationale from a twin with a different (discovered_at, model). Nothing written. "
+                 f"e.g. {sample}")
 
     # POSITION PROOF: no restored edge may sit in the wrong slot.
     if slot_mismatches:
@@ -181,9 +251,12 @@ def main():
                  f"rationale in the wrong slot vs the ba3128f5 source. Nothing written. e.g. {sample}")
 
     # STRIP-BACK PROOF: strip only the rationales we added; must equal the original current file.
+    # Index-exact (t/2946#16): the previous version stripped by composite key, which on a twin key
+    # would strip BOTH twins even when only one was restored — the same near-key blindness that
+    # produced the mis-attribution. Edge order is preserved, so positions align.
     check = json.loads(out_blob)
-    for e in check["edges"]:
-        if ckey(e) not in had:
+    for i, e in enumerate(check["edges"]):
+        if i in restored_idx:
             e.pop("rationale", None)
     if serialize(check) != cur_blob:
         sys.exit("ABORT: strip-back proof failed — the restore changed more than rationale. "
@@ -197,8 +270,20 @@ def main():
     print(f"restored={restored}  kept_existing={kept}  generation_gap(new edges)={gap}")
     print(f"final edges with rationale = {final} / {len(new_edges)}")
     print(f"rationale placement (at source-original slot): {dict(placement)}")
-    print("position proof: PASS (every restored edge in its ba3128f5 slot)")
-    print("strip-back proof: PASS (only rationale changed)")
+    print(f"key disposition: {dict(disposition)}")
+    print("position proof:    PASS (every restored edge in its ba3128f5 slot)")
+    print("strip-back proof:  PASS (only rationale changed)")
+    print("attribution proof: PASS (no rationale taken from a mismatched twin)")
+    if refusals:
+        print(f"\nREFUSED (twin could not be resolved — restored nothing, never guessed): "
+              f"{len(refusals)}")
+        for k, disp, ct in refusals[:10]:
+            print(f"  {'|'.join(map(str, k))}  [{disp}]  edge discovered_at/model={ct}")
+        if len(refusals) > 10:
+            print(f"  ... and {len(refusals) - 10} more")
+        print("  These edges keep no rationale. Route them to the Phase-2 residual cohort.")
+    else:
+        print("refusals: 0 (every non-unique key resolved by the discovered_at+model tie-break)")
     print(f"wrote: {out_path}")
     if gap:
         print(f"\n{gap} edges have no source in ba3128f5 (created after the wipe) and still need "

--- a/research/comp-linguist/analyses/t2444-rationale-restore/test_apply_restore_twin.py
+++ b/research/comp-linguist/analyses/t2444-rationale-restore/test_apply_restore_twin.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Twin-aware identity conformance for apply_restore.py (t/2946).
+
+The restore is the THIRD consumer of the identity model TL prescribed in e/120#37 — alongside
+`lib/edges/mergeEdgesPreservingRationale` (TS, t/2957) and the PS Arm-1 guard (t/2956). Literal
+code reuse is impossible across Python/TS/PowerShell, so drift is prevented the same way it is
+for the PS guard: all three conform to ONE shared fixture, loaded BY PATH, never transcribed.
+A copied fixture makes divergence undetectable, which is the whole failure this guards.
+
+Run: python test_apply_restore_twin.py
+"""
+import json, os, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+FIXTURE = os.path.join(HERE, "twin-fixture.json")   # shared with the TS + PS suites
+
+sys.path.insert(0, HERE)
+from apply_restore import resolve_source, twin_id, ckey, has_rat   # noqa: E402
+
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+    if not cond:
+        failures.append(f"{name} — {detail}")
+    return cond
+
+
+def main():
+    with open(FIXTURE, encoding="utf-8") as f:
+        fx = json.load(f)
+
+    print(f"fixture: {FIXTURE}")
+    print(f"identity_rule: {fx['identity_rule'][:88]}...\n")
+
+    # ---- case_a (observed): distinguishable twins → each twin gets ITS OWN rationale ----
+    a = fx["case_a_distinguishable"]
+    print("case_a_distinguishable (observed — real ba3128f5 pair):")
+    on_disk = a["on_disk"]["edges"]
+    payload = a["save_payload"]["edges"]
+    cands = [e for e in on_disk if has_rat(e)]
+    check("both on-disk twins carry a rationale", len(cands) == 2, f"got {len(cands)}")
+
+    resolved = []
+    for p in payload:
+        src, disp = resolve_source(p, cands)
+        resolved.append((p, src, disp))
+        check(f"twin {twin_id(p)} resolves via tie-break",
+              src is not None and disp == "twin-resolved", f"disp={disp}")
+
+    # The load-bearing assertion: NO CROSSOVER. Each payload twin must get the rationale of the
+    # on-disk edge sharing its (discovered_at, model) — not the other twin's.
+    for p, src, _ in resolved:
+        if src is None:
+            continue
+        expected = next(c["rationale"] for c in cands if twin_id(c) == twin_id(p))
+        check(f"twin {twin_id(p)} got its OWN rationale (no crossover)",
+              src["rationale"] == expected,
+              f"got {src['rationale'][:48]!r}, expected {expected[:48]!r}")
+
+    texts = {src["rationale"] for _, src, _ in resolved if src}
+    check("the two twins received DIFFERENT rationales", len(texts) == 2,
+          "both twins got the same text — this is the last-wins bug t/2946#16 found")
+
+    # ---- case_b (constructed): indistinguishable twins → refuse, never guess ----
+    b = fx["case_b_indistinguishable"]
+    print("\ncase_b_indistinguishable (constructed — no such pair exists live):")
+    on_disk_b = b["on_disk"]["edges"]
+    payload_b = b["save_payload"]["edges"]
+    cands_b = [e for e in on_disk_b if has_rat(e)]
+    check("both on-disk twins carry a rationale", len(cands_b) == 2, f"got {len(cands_b)}")
+    check("the twins are genuinely indistinguishable",
+          twin_id(cands_b[0]) == twin_id(cands_b[1]), "fixture twins differ — case_b is vacuous")
+
+    for p in payload_b:
+        src, disp = resolve_source(p, cands_b)
+        check("indistinguishable twin REFUSES (returns nothing)", src is None, f"got {src}")
+        check("disposition is twin-ambiguous", disp == "twin-ambiguous", f"disp={disp}")
+
+    # ---- unique key still resolves (no regression on the 33,393 non-twin edges) ----
+    print("\nunique-key control:")
+    solo = [dict(on_disk[0])]
+    src, disp = resolve_source(payload[0], solo)
+    check("single candidate resolves as 'unique'", src is not None and disp == "unique",
+          f"disp={disp}")
+
+    print()
+    if failures:
+        print(f"FAILED ({len(failures)}):")
+        for f_ in failures:
+            print(f"  - {f_}")
+        return 1
+    print("ALL TWIN-CONFORMANCE CHECKS PASS — apply_restore.py matches the shared identity model.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The near-key pre-flight that t/2946's AC mandates **caught a live defect** that would have silently corrupted the 33k restore. Full analysis: **t/2946#16**.

## The defect

`apply_restore.py` indexed the source with a dict comprehension on the composite key:

```python
src_by = {ckey(e): e for e in src if has_rat(e)}
```

`(source, target, type)` is a **near-key, not a key**. On a duplicated key that is **last-one-wins, silently** — the second source twin overwrites the first, and both current twins then receive the same rationale. A grep for `discovered_at|twin|ambiguous|refuse` across the file returned nothing: there was no twin handling at all.

**The hazard is live, not theoretical.** All 3 duplicated keys on the current file carry **two** rationale-bearing edges in `ba3128f5`, with genuinely different text:

| key | source twins | texts differ |
|---|---|---|
| `acc-beliefs-051 SUPPORTS acc-desires-001` | 04-06/gemini · 06-11/None | yes |
| `acc-beliefs-069 SUPPORTS acc-intentions-054` | 04-06/gemini · 06-11/None | yes |
| `acc-intentions-100 SUPPORTS acc-beliefs-039` | 03-07/gemini · 06-11/None | yes |

A run would have handed every March/April `gemini-2.5-flash` twin the June `llm_proposed` rationale — **6 edges written, 3 definitively wrong** — and **both existing proofs would have passed**. Strip-back removes exactly what it inserted; the position proof checks the *slot*, not whose text landed in it.

## Changes

**1. Twin-aware identity.** Source grouped per key instead of collapsed. Primary key `source|type|target` → tie-break on `(discovered_at, model)` → **refuse-and-log, never guess**. Dispositions counted and reported: `unique` / `twin-resolved` / `twin-unmatched` / `twin-ambiguous`. The last two restore nothing and are logged for the Phase-2 residual cohort.

**2. ATTRIBUTION PROOF (third proof).** On a non-unique key, the restored rationale must come from the twin whose `(discovered_at, model)` matches. Aborts and writes nothing otherwise. Both other proofs are structurally blind to this.

**3. Strip-back is now index-exact.** It previously stripped by composite key, so on a twin key it would strip **both** twins when only one was restored — the same near-key blindness, inside the proof itself.

## Why here and not a shared util

This is the **third** consumer of the identity model TL prescribed in e/120#37. The TS re-merge (t/2957) and PS Arm-1 guard (t/2956) already have it; the restore — the tool that *populates* the twin cohort and makes the hazard live for the other two — never did.

Literal reuse is impossible across Python/TS/PowerShell, so conformance is proven the way it is for the PS guard: against the **shared `twin-fixture.json`, loaded by path, never transcribed**. A copied fixture makes drift undetectable, which is the whole point.

## Verification

```
conformance   13/13 vs twin-fixture.json — incl. no-crossover on the real case_a
              pair and refuse-and-log on case_b
dry run       restored=33,399  kept=8  gap=173
              disposition: unique=33,393, twin-resolved=6, refusals=0
              placement: after confidence 29,110 / weight 3,761 / model 528
              position PASS · strip-back PASS · attribution PASS
negative arm  re-introducing last-wins aborts with the attribution message and
              writes nothing — the proof is not decorative
live data     ../ai-triad-data untouched (verified clean); output to a scratchpad
```

All 6 twins resolve cleanly by the tie-break, so **0 refusals** on the real data — but refuse-and-log exists for the case that doesn't resolve.

`/review-py`: fixed an unclosed read handle in `main()` now that the function was substantially rewritten.

## Not in this PR

The restore itself has **not** been run against the live file. This PR makes it safe to run; the run and its commit remain gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017U4xd8fyYPJL6U6SmKiftY