### PR TITLE
fix(licenses): resolve pnpm path-hash mismatch on Windows (t/2969)

### DIFF
--- a/taxonomy-editor/scripts/generate-notices.cjs
+++ b/taxonomy-editor/scripts/generate-notices.cjs
@@ -35,15 +35,55 @@ function parseArgs(argv) {
 
 const LICENSE_FILE_RE = /^(LICEN[CS]E|COPYING|COPYRIGHT|NOTICE)(\.|$)/i;
 
+/**
+ * Resolve the actual on-disk pnpm virtual-store directory for a package.
+ *
+ * `pnpm licenses list --json` on Windows returns a hashed peer-dep suffix
+ * (e.g. `react-markdown@10.1.0_@type_e84814f...`) that does NOT match the
+ * real on-disk directory name (`react-markdown@10.1.0_@types+react@19.2.18_...`).
+ * This function scans `.pnpm/` for the matching entry so `readLicenseText`
+ * can always find the license file (t/2969 — Windows parity fix).
+ */
+function resolveActualPkgDir(dir) {
+  // Fast path: directory already exists (Linux/CI, and Windows when hash matches).
+  try { if (fs.statSync(dir).isDirectory()) return dir; } catch { /* fall through */ }
+  // Slow path: scan .pnpm/ for the real directory entry.
+  // dir: .../node_modules/.pnpm/<hashedEntry>/node_modules/<pkgName>[/...]
+  const m = /^(.+[/\\]node_modules[/\\]\.pnpm[/\\])([^/\\]+)((?:[/\\]node_modules[/\\].+)?)$/.exec(dir);
+  if (!m) return dir;
+  const [, pnpmRoot, hashedEntry, tail] = m;
+  // Extract name@version prefix: everything up to the first peer-dep separator
+  // ('_' that appears after the version's '@'). For scoped packages the name
+  // starts with '@'; skip that '@' when finding the version separator.
+  const vAt = hashedEntry.indexOf('@', hashedEntry.startsWith('@') ? 1 : 0);
+  if (vAt === -1) return dir;
+  const uIdx = hashedEntry.indexOf('_', vAt);
+  const prefix = uIdx === -1 ? hashedEntry : hashedEntry.slice(0, uIdx);
+  // prefix e.g. "react-markdown@10.1.0" or "@types+react@19.2.18"
+  let entries;
+  try { entries = fs.readdirSync(pnpmRoot); } catch { return dir; }
+  const candidates = entries.filter(e => e === prefix || e.startsWith(prefix + '_'));
+  if (candidates.length === 1) {
+    // Normalize tail separator and join to form the resolved path.
+    const resolvedTail = tail ? tail.replace(/^[/\\]/, '') : '';
+    return path.join(pnpmRoot, candidates[0], resolvedTail);
+  }
+  // Multiple candidates (different peer-dep combos) — can't resolve unambiguously.
+  return dir;
+}
+
 /** Read the best-effort license text for a package from its installed directory. */
-function readLicenseText(pkgDir, spdx) {
+function readLicenseText(pkgDir, spdx, pkgId) {
+  const resolvedDir = resolveActualPkgDir(pkgDir);
+  let dirAccessible = false;
   try {
-    const files = fs.readdirSync(pkgDir);
+    const files = fs.readdirSync(resolvedDir);
+    dirAccessible = true;
     // Prefer a plain LICENSE file; fall back to any LICENSE-* variant.
     const exact = files.filter(f => LICENSE_FILE_RE.test(f))
       .sort((a, b) => a.length - b.length || a.localeCompare(b));
     for (const f of exact) {
-      const full = path.join(pkgDir, f);
+      const full = path.join(resolvedDir, f);
       // Single fd (open → fstat → read → close) so the is-file check and the
       // read act on the same handle — no TOCTOU race (js/file-system-race).
       let fd;
@@ -57,10 +97,20 @@ function readLicenseText(pkgDir, spdx) {
         if (fd !== undefined) { try { fs.closeSync(fd); } catch { /* already closed */ } }
       }
     }
-  } catch { /* dir gone — fall through */ }
-  // No license file shipped: fall back to the SPDX identifier so the package is
-  // still disclosed (with its declared license) rather than dropped.
-  return spdx && spdx !== 'Unknown' ? spdx : 'License text not provided by the package author.';
+  } catch { /* dir gone or unreadable */ }
+  const fallback = spdx && spdx !== 'Unknown' ? spdx : 'License text not provided by the package author.';
+  // Emit an observable warning when the package directory couldn't be found even
+  // after path resolution — silent SPDX substitution is the silent-degradation
+  // anti-pattern (t/2969). Packages that exist on disk but ship without a license
+  // file (dirAccessible=true, no LICENSE) are intentional and do not warn.
+  if (!dirAccessible) {
+    const label = pkgId || path.basename(resolvedDir);
+    process.stderr.write(
+      `::warning::generate-notices: package dir not found for ${label}` +
+      ` — falling back to SPDX "${fallback}". Resolved path: ${resolvedDir}\n`
+    );
+  }
+  return fallback;
 }
 
 function main() {
@@ -76,6 +126,35 @@ function main() {
     console.error(`generate-notices: package.json "name" missing or not a valid npm name: ${pkgName}`);
     process.exit(1);
   }
+
+  // Preflight: node_modules must be present to produce a complete license list.
+  // Running without them yields a partial/empty set and silently commits incorrect
+  // output — an early exit with a clear message is preferable (t/2969).
+  if (!fs.existsSync(path.resolve('node_modules'))) {
+    console.error(
+      'generate-notices: node_modules not found in the current directory' +
+      ' — run "pnpm install" first'
+    );
+    process.exit(1);
+  }
+
+  // Preflight: refuse to run on the shared main checkout to prevent accidental
+  // dirty-tree incidents (t/2969). Linked worktrees have a git-dir path that
+  // contains "/worktrees/" or "\worktrees\"; the primary checkout does not.
+  try {
+    const gitDir = execFileSync('git', ['rev-parse', '--git-dir'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    const isLinkedWorktree = /[/\\]worktrees[/\\]/.test(gitDir);
+    if (branch === 'main' && !isLinkedWorktree) {
+      console.error(
+        'generate-notices: refusing to run on the shared main checkout — ' +
+        'use a linked worktree instead: git worktree add -b <branch> .worktrees/<name>'
+      );
+      process.exit(1);
+    }
+  } catch { /* git unavailable or not a repo — skip guard */ }
 
   // Ask pnpm for this importer's production dependency closure with store paths.
   // On Windows `pnpm` is a .cmd shim which execFile can't spawn directly (EINVAL);
@@ -134,7 +213,7 @@ function main() {
   const spdxTextCache = new Map();
   for (const r of unique) {
     if (!spdxTextCache.has(r.spdx)) {
-      const t = readLicenseText(r.dir, r.spdx);
+      const t = readLicenseText(r.dir, r.spdx, r.id);
       if (t !== r.spdx) spdxTextCache.set(r.spdx, t);
     }
   }
@@ -147,25 +226,46 @@ function main() {
     // @img/sharp-* normalizer — prevents a silent false-fire on the blocking gate.
     // Triggered? Extend the normalization block in this script to cover the new family.
     // Scans packages: section only (not snapshots/importers); resets on every entry
-    // (scoped or not) to prevent cpu/os from non-scoped packages bleeding across boundaries.
+    // (scoped or non-scoped) to prevent cpu/os from one package bleeding across
+    // boundaries into the next (t/2969 — broadened from scoped-only).
+    //
+    // A package is "platform-conditional" only when its cpu/os is RESTRICTIVE —
+    // i.e. it excludes at least one common platform (win32/darwin/linux) or is
+    // limited to a single CPU arch. A package with os:[win32,darwin,linux] is
+    // cross-platform and must NOT be flagged (t/2969 — onnxruntime-node false-positive fix).
     { const gLines = lockContent.split('\n');
+      const COMMON_OS = ['win32', 'darwin', 'linux'];
       const platformIds = new Set();
-      let inPkgs = false; let curPkg = null; let hasCpuOs = false;
+      let inPkgs = false; let curPkg = null; let isRestricted = false;
       for (const ln of gLines) {
         if (ln === 'packages:') { inPkgs = true; continue; }
         if (inPkgs && /^\S/.test(ln)) { // new top-level section — end of packages:
-          if (curPkg && hasCpuOs) platformIds.add(curPkg);
-          inPkgs = false; curPkg = null; hasCpuOs = false; continue;
+          if (curPkg && isRestricted) platformIds.add(curPkg);
+          inPkgs = false; curPkg = null; isRestricted = false; continue;
         }
         if (!inPkgs) continue;
         if (/^  \S/.test(ln)) { // any package entry at 2-space indent
-          if (curPkg && hasCpuOs) platformIds.add(curPkg);
-          const gm = /^  '?(@[^'@]+)@([^':\s]+)'?:/.exec(ln);
+          if (curPkg && isRestricted) platformIds.add(curPkg);
+          // Match both scoped (@scope/name) and non-scoped (name) packages.
+          const gm = /^  '?(@[^'@]+|[^'@\s][^'@]*)@([^':\s]+)'?:/.exec(ln);
           curPkg = gm ? `${gm[1].replace(/\\/g, '/')}@${gm[2]}` : null;
-          hasCpuOs = false;
-        } else if (curPkg && /^\s+(cpu:|os:)/.test(ln)) { hasCpuOs = true; }
+          isRestricted = false;
+        } else if (curPkg) {
+          // os: [win32] is restrictive; os: [win32,darwin,linux] is not.
+          const osM = /^\s+os:\s*\[([^\]]*)\]/.exec(ln);
+          if (osM) {
+            const osList = osM[1].split(',').map(s => s.trim().replace(/'/g, ''));
+            if (COMMON_OS.some(o => !osList.includes(o))) isRestricted = true;
+          }
+          // cpu: [x64] is restrictive (single-arch); broader lists are not.
+          const cpuM = /^\s+cpu:\s*\[([^\]]*)\]/.exec(ln);
+          if (cpuM) {
+            const cpuList = cpuM[1].split(',').map(s => s.trim().replace(/'/g, ''));
+            if (cpuList.length <= 1) isRestricted = true;
+          }
+        }
       }
-      if (inPkgs && curPkg && hasCpuOs) platformIds.add(curPkg);
+      if (inPkgs && curPkg && isRestricted) platformIds.add(curPkg);
       const unexpected = unique.filter(r => {
         const name = r.id.lastIndexOf('@') > 0 ? r.id.slice(0, r.id.lastIndexOf('@')) : r.id;
         return platformIds.has(r.id) && !SHARP_RE.test(name);
@@ -200,7 +300,7 @@ function main() {
     // For lockfile-sourced entries (no local install, dir=''), use spdxTextCache
     // populated from the installed peer; fall back to the SPDX identifier.
     const text = r.dir
-      ? readLicenseText(r.dir, r.spdx)
+      ? readLicenseText(r.dir, r.spdx, r.id)
       : (spdxTextCache.get(r.spdx) ?? r.spdx);
     if (!groups.has(text)) groups.set(text, new Set());
     groups.get(text).add(r.id);


### PR DESCRIPTION
## Summary

- **`resolveActualPkgDir`**: scans `.pnpm/` for the real directory when pnpm reports a hashed virtual path that doesn't exist on disk (Windows-specific). Restores react-markdown's Espen Hovlandsdal copyright block that was silently dropped → bare SPDX fallback → wrong block count (128 vs 129).
- **Observable fallback**: `readLicenseText` emits `::warning::` when dir is inaccessible after resolution — no more silent SPDX-only degradation.
- **Platform-conditional guard**: broadened lockfile regex catches non-scoped packages; value-aware parsing skips `os:[win32,darwin,linux]` (cross-platform) and only marks single-cpu or partial-os packages as conditional.
- **Preflight guards**: refuse if `node_modules` absent; refuse if running on shared main checkout.

## Windows parity proof

Fixed generator on Windows → 129 license blocks (matches Linux CI). `git diff` on `THIRD-PARTY-NOTICES.txt` and `oss-licenses.json` is clean — no platform divergence.

## Test plan

- [x] Write mode: `node scripts/generate-notices.cjs --output THIRD-PARTY-NOTICES.txt` → 325 packages, 129 license blocks (Windows)
- [x] Check mode: `node scripts/generate-notices.cjs --check` → "up to date (325 packages)" (Windows)
- [x] `parse-licenses.cjs` → 325 packages, 129 groups (Windows)
- [x] `git diff THIRD-PARTY-NOTICES.txt oss-licenses.json` → clean (no platform divergence)
- [ ] CI green on this branch (license-notices gate warn-only — watching)

Closes t/2969. Gate flip (PR #1451) stays DRAFT pending ≥1 green warn cycle on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
