### PR TITLE
fix(licenses): exempt CI from shared-main preflight guard (hotfix)

### DIFF
--- a/taxonomy-editor/scripts/generate-notices.cjs
+++ b/taxonomy-editor/scripts/generate-notices.cjs
@@ -147,7 +147,7 @@ function main() {
     const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'],
       { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
     const isLinkedWorktree = /[/\\]worktrees[/\\]/.test(gitDir);
-    if (branch === 'main' && !isLinkedWorktree) {
+    if (branch === 'main' && !isLinkedWorktree && !process.env.CI) {
       console.error(
         'generate-notices: refusing to run on the shared main checkout — ' +
         'use a linked worktree instead: git worktree add -b <branch> .worktrees/<name>'


### PR DESCRIPTION
## Summary

One-line hotfix: exempt CI from the shared-main preflight guard added in t/2969.

The guard (`branch === 'main' && !isLinkedWorktree`) fires in GitHub Actions because CI checks out main directly — no worktrees path in the git-dir. Adding `&& !process.env.CI` (GitHub Actions always sets `CI=true`) allows CI to pass while preserving the dev-machine protection.

## Test plan

- [ ] CI green on this branch (license-notices gate now unblocked in CI)
- [ ] Confirm dev shared-main run still refuses (branch=main, CI unset → guard fires)
- [ ] CI + linked-worktree runs pass clean

Fixes main CI RED introduced by t/2969 preflight guard (run 32713508531).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
