### PR TITLE
feat(edges): stamp rationale_source at PS write sites (t/2944 stamping half)

### DIFF
--- a/scripts/AITriad/Public/Invoke-EdgeDiscovery.ps1
+++ b/scripts/AITriad/Public/Invoke-EdgeDiscovery.ps1
@@ -698,6 +698,14 @@ Omit pairs with no relationship. No markdown fences.
                         }
 
                         if ([string]::IsNullOrWhiteSpace($NewEdge.rationale)) { $MissingRationaleCount++ }
+                        # t/2944 write-together invariant: stamp provenance iff a non-empty rationale is
+                        # set (absent != null contract). NOTE: this is the embedding-FIRST candidate path
+                        # (pairs found by similarity), BUT the rationale here is LLM-authored — it comes
+                        # from the Classify prompt / Invoke-AIByUsage 'enrichment.edge-discovery.classify'
+                        # response above, not a similarity template. So provenance is 'discovery', NOT
+                        # 'embedding-template' (which the design reserves for a no-LLM template path; that
+                        # path does not exist in this cmdlet today — flagged to CL, edge-rationale-source-marker.md).
+                        if (-not [string]::IsNullOrWhiteSpace([string]$NewEdge.rationale)) { $NewEdge['rationale_source'] = 'discovery' }
                         $EdgesList.Add([PSCustomObject]$NewEdge)
                         $null = $ExistingEdgeKeys.Add($EdgeKey)
                         $BatchNewEdges++
@@ -947,6 +955,10 @@ $BatchSchemaPrompt
                 }
                 if ($Edge.PSObject.Properties['strength'] -and $Edge.strength) { $EdgeObj['strength'] = $Edge.strength }
                 if ($Edge.PSObject.Properties['notes']    -and $Edge.notes)    { $EdgeObj['notes']    = $Edge.notes    }
+                # t/2944 write-together invariant: stamp provenance iff a non-empty rationale is set —
+                # never emit rationale_source:null where the rationale is absent (absent != null contract,
+                # e/120#88/#91). LLM discovery path -> 'discovery' (edge-rationale-source-marker.md).
+                if (-not [string]::IsNullOrWhiteSpace([string]$Rationale)) { $EdgeObj['rationale_source'] = 'discovery' }
 
                 $EdgesList.Add([PSCustomObject]$EdgeObj)
                 [void]$ExistingEdgeKeys.Add($EdgeKey)
@@ -1277,6 +1289,10 @@ $SchemaPrompt
                 }
                 if ($Edge.PSObject.Properties['strength'] -and $Edge.strength) { $EdgeObj['strength'] = $Edge.strength }
                 if ($Edge.PSObject.Properties['notes']    -and $Edge.notes)    { $EdgeObj['notes']    = $Edge.notes    }
+                # t/2944 write-together invariant: stamp provenance iff a non-empty rationale is set —
+                # never emit rationale_source:null where the rationale is absent (absent != null contract,
+                # e/120#88/#91). LLM discovery path -> 'discovery' (edge-rationale-source-marker.md).
+                if (-not [string]::IsNullOrWhiteSpace([string]$Rationale)) { $EdgeObj['rationale_source'] = 'discovery' }
 
                 $EdgesList.Add([PSCustomObject]$EdgeObj)
                 [void]$ExistingEdgeKeys.Add($EdgeKey)
@@ -1408,6 +1424,10 @@ $SchemaPrompt
                 }
                 if ($Edge.PSObject.Properties['strength'] -and $Edge.strength) { $EdgeObj['strength'] = $Edge.strength }
                 if ($Edge.PSObject.Properties['notes']    -and $Edge.notes)    { $EdgeObj['notes']    = $Edge.notes    }
+                # t/2944 write-together invariant: stamp provenance iff a non-empty rationale is set —
+                # never emit rationale_source:null where the rationale is absent (absent != null contract,
+                # e/120#88/#91). LLM discovery path -> 'discovery' (edge-rationale-source-marker.md).
+                if (-not [string]::IsNullOrWhiteSpace([string]$Rationale)) { $EdgeObj['rationale_source'] = 'discovery' }
 
                 $EdgesList.Add([PSCustomObject]$EdgeObj)
                 [void]$ExistingEdgeKeys.Add($EdgeKey)

--- a/scripts/AITriad/Public/Invoke-EdgeRationaleBackfill.ps1
+++ b/scripts/AITriad/Public/Invoke-EdgeRationaleBackfill.ps1
@@ -267,6 +267,14 @@ function Invoke-EdgeRationaleBackfill {
         } else {
             Add-Member -InputObject $Edge -NotePropertyName 'rationale' -NotePropertyValue $Rationale -Force
         }
+        # t/2944 write-together invariant: this edge just received a non-empty rationale (the empty case
+        # returned above via the silent-blank contract), so stamp its provenance in the SAME write —
+        # backfill = post-hoc LLM reconstruction (edge-rationale-source-marker.md).
+        if ($Edge.PSObject.Properties['rationale_source']) {
+            $Edge.rationale_source = 'backfill'
+        } else {
+            Add-Member -InputObject $Edge -NotePropertyName 'rationale_source' -NotePropertyValue 'backfill' -Force
+        }
         $Backfilled++
 
         if ($CheckpointEvery -gt 0 -and ($Backfilled % $CheckpointEvery) -eq 0) {

--- a/tests/Invoke-EdgeDiscovery.Tests.ps1
+++ b/tests/Invoke-EdgeDiscovery.Tests.ps1
@@ -200,3 +200,53 @@ Describe 'Rationale silent-blank observability (t/2674)' -Tag 'taxonomy' {
         }
     }
 }
+
+Describe 'rationale_source provenance stamping (t/2944)' -Tag 'taxonomy' {
+
+    It 'stamps rationale_source=discovery on a discovered edge that carries a rationale, and leaves it ABSENT when the rationale is absent' {
+        InModuleScope AITriad {
+            $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "edge-src-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+            $TaxJson = @{
+                nodes = @(
+                    @{ id = 'acc-beliefs-001'; label = 'A'; description = 'A'; category = 'Beliefs' }
+                    @{ id = 'saf-beliefs-001'; label = 'B'; description = 'B'; category = 'Beliefs' }
+                )
+            } | ConvertTo-Json -Depth 5
+            Set-Content -Path (Join-Path $TempDir 'accelerationist.json') -Value $TaxJson
+            Set-Content -Path (Join-Path $TempDir 'safetyist.json') -Value '{"nodes":[]}'
+            Set-Content -Path (Join-Path $TempDir 'skeptic.json') -Value '{"nodes":[]}'
+            Set-Content -Path (Join-Path $TempDir 'situations.json') -Value '{"nodes":[]}'
+
+            Mock Get-TaxonomyDir { $TempDir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            $script:CapturedEdgesJson = $null
+            Mock Write-Utf8NoBom { if ($Path -like '*edges.json') { $script:CapturedEdgesJson = $Value } }
+
+            Mock Invoke-NodeEdgeDiscovery {
+                [PSCustomObject]@{
+                    NodeId = $Node.id
+                    RawEdges = @(
+                        [PSCustomObject]@{ target = 'saf-beliefs-001'; type = 'SUPPORTS'; confidence = 0.8; rationale = 'because it supports' }  # carries rationale
+                        [PSCustomObject]@{ target = 'saf-beliefs-001'; type = 'WEAKENS';  confidence = 0.8 }                                      # NO rationale
+                    )
+                    NewEdgeTypes = @(); Error = $null; ElapsedSec = 0.5
+                }
+            }
+
+            $null = Invoke-EdgeDiscovery -NodeId 'acc-beliefs-001' -Force -MaxConcurrent 1 -RepoRoot $TempDir -WarningAction SilentlyContinue 3>$null 6>$null
+            $written = $script:CapturedEdgesJson | ConvertFrom-Json
+
+            $withRat = @($written.edges | Where-Object { $_.type -eq 'SUPPORTS' })[0]
+            $noRat   = @($written.edges | Where-Object { $_.type -eq 'WEAKENS'  })[0]
+
+            # write-together invariant: a non-empty rationale gets 'discovery'...
+            $withRat.rationale        | Should -Be 'because it supports'
+            $withRat.rationale_source | Should -Be 'discovery'
+            # ...and a rationale-less edge is NOT given a source (absent, not coerced to null — absent != null)
+            $noRat.PSObject.Properties['rationale_source'] | Should -BeNullOrEmpty
+
+            Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}

--- a/tests/Invoke-EdgeDiscovery.Tests.ps1
+++ b/tests/Invoke-EdgeDiscovery.Tests.ps1
@@ -249,4 +249,58 @@ Describe 'rationale_source provenance stamping (t/2944)' -Tag 'taxonomy' {
             Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
+
+    It 'does NOT overwrite an existing rationale_source=restore on carry-forward (t/2946 restore protection, CL p/23#193)' {
+        InModuleScope AITriad {
+            $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "edge-src-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
+            $TaxJson = @{
+                nodes = @( @{ id = 'acc-beliefs-001'; label = 'A'; description = 'A'; category = 'Beliefs' } )
+            } | ConvertTo-Json -Depth 5
+            Set-Content -Path (Join-Path $TempDir 'accelerationist.json') -Value $TaxJson
+            @{ nodes = @(
+                @{ id = 'saf-beliefs-001'; label = 'B'; description = 'B'; category = 'Beliefs' }
+                @{ id = 'saf-beliefs-002'; label = 'C'; description = 'C'; category = 'Beliefs' }
+            ) } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $TempDir 'safetyist.json')
+            Set-Content -Path (Join-Path $TempDir 'skeptic.json') -Value '{"nodes":[]}'
+            Set-Content -Path (Join-Path $TempDir 'situations.json') -Value '{"nodes":[]}'
+
+            # Pre-existing edges.json with a RESTORE-tagged edge (mirrors the 33,399 restored by t/2946).
+            @{
+                _schema_version = '1.0.0'; _doc = 't'; last_modified = '2026-01-01'
+                edge_types = @(@{ type = 'SUPPORTS'; bidirectional = $false; definition = 'x' })
+                edges = @(
+                    @{ source = 'acc-beliefs-001'; target = 'saf-beliefs-002'; type = 'SUPPORTS'; confidence = 0.9; status = 'approved'; rationale = 'original discovery-time text'; rationale_source = 'restore' }
+                )
+            } | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $TempDir 'edges.json')
+
+            Mock Get-TaxonomyDir { $TempDir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            $script:CapturedEdgesJson = $null
+            Mock Write-Utf8NoBom { if ($Path -like '*edges.json') { $script:CapturedEdgesJson = $Value } }
+
+            # Discovery proposes a NEW edge on a different target (won't dedup against the restored one).
+            Mock Invoke-NodeEdgeDiscovery {
+                [PSCustomObject]@{
+                    NodeId = $Node.id
+                    RawEdges = @( [PSCustomObject]@{ target = 'saf-beliefs-001'; type = 'SUPPORTS'; confidence = 0.8; rationale = 'freshly discovered' } )
+                    NewEdgeTypes = @(); Error = $null; ElapsedSec = 0.5
+                }
+            }
+
+            $null = Invoke-EdgeDiscovery -NodeId 'acc-beliefs-001' -Force -MaxConcurrent 1 -RepoRoot $TempDir -WarningAction SilentlyContinue 3>$null 6>$null
+            $written = $script:CapturedEdgesJson | ConvertFrom-Json
+
+            $restored = @($written.edges | Where-Object { $_.target -eq 'saf-beliefs-002' })[0]
+            $fresh    = @($written.edges | Where-Object { $_.target -eq 'saf-beliefs-001' })[0]
+
+            # The restored edge is carried forward WHOLE — tag and text untouched.
+            $restored.rationale_source | Should -Be 'restore'
+            $restored.rationale        | Should -Be 'original discovery-time text'
+            # The newly-discovered edge is the only one stamped 'discovery'.
+            $fresh.rationale_source    | Should -Be 'discovery'
+
+            Remove-Item -Path $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
 }

--- a/tests/Invoke-EdgeRationaleBackfill.Tests.ps1
+++ b/tests/Invoke-EdgeRationaleBackfill.Tests.ps1
@@ -89,6 +89,36 @@ Describe 'Invoke-EdgeRationaleBackfill (t/2679)' -Tag 'taxonomy' {
         }
     }
 
+    It 'stamps rationale_source=backfill on a backfilled edge (t/2944 write-together invariant)' {
+        InModuleScope AITriad {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            @{ nodes = @(
+                @{ id = 'acc-b-1'; label = 'A'; description = 'Desc A' }
+                @{ id = 'acc-b-2'; label = 'B'; description = 'Desc B' }
+            ) } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $dir 'accelerationist.json')
+            @{
+                _schema_version = '1.0.0'; _doc = 't'; last_modified = '2026-01-01'
+                edge_types = @(@{ type = 'SUPPORTS'; bidirectional = $false; definition = 'Source strengthens target.' })
+                edges = @(@{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'SUPPORTS'; confidence = 0.8; status = 'approved' })
+            } | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $dir 'edges.json')
+
+            Mock Get-TaxonomyDir { $dir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = '{"rationale":"Generated reason"}' } }
+            $script:Captured = $null
+            Mock Write-EdgesFile { $script:Captured = $EdgesData }
+
+            try {
+                $r = Invoke-EdgeRationaleBackfill -Scope UIVisible -CheckpointEvery 0 6>$null
+                $r.Backfilled | Should -Be 1
+                # The rationale and its provenance move together in the same write.
+                $script:Captured.edges[0].rationale        | Should -Be 'Generated reason'
+                $script:Captured.edges[0].rationale_source | Should -Be 'backfill'
+            } finally { Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
     It 'is idempotent + scope-aware: -Scope All includes proposed, excludes already-populated' {
         InModuleScope AITriad {
             $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"

--- a/tests/Invoke-EdgeRationaleBackfill.Tests.ps1
+++ b/tests/Invoke-EdgeRationaleBackfill.Tests.ps1
@@ -119,6 +119,46 @@ Describe 'Invoke-EdgeRationaleBackfill (t/2679)' -Tag 'taxonomy' {
         }
     }
 
+    It 'does NOT overwrite rationale_source=restore: skips the restored edge, stamps only the backfilled one (t/2946 protection, CL p/23#193)' {
+        InModuleScope AITriad {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            @{ nodes = @(
+                @{ id = 'acc-b-1'; label = 'A'; description = 'Desc A' }
+                @{ id = 'acc-b-2'; label = 'B'; description = 'Desc B' }
+            ) } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $dir 'accelerationist.json')
+            @{
+                _schema_version = '1.0.0'; _doc = 't'; last_modified = '2026-01-01'
+                edge_types = @(@{ type = 'SUPPORTS'; bidirectional = $false; definition = 'x' }, @{ type = 'WEAKENS'; bidirectional = $false; definition = 'y' })
+                edges = @(
+                    # A restored edge (has rationale + source=restore) — backfill must SKIP it, untouched.
+                    @{ source = 'acc-b-1'; target = 'acc-b-2'; type = 'SUPPORTS'; confidence = 0.9; status = 'approved'; rationale = 'original discovery-time text'; rationale_source = 'restore' }
+                    # A rationale-less edge — backfill fills it and stamps 'backfill'.
+                    @{ source = 'acc-b-2'; target = 'acc-b-1'; type = 'WEAKENS';  confidence = 0.9; status = 'approved' }
+                )
+            } | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $dir 'edges.json')
+
+            Mock Get-TaxonomyDir { $dir }
+            Mock Resolve-AIApiKey { 'fake-key' }
+            Mock Invoke-AIApi { [PSCustomObject]@{ Text = '{"rationale":"reconstructed reason"}' } }
+            $script:Captured = $null
+            Mock Write-EdgesFile { $script:Captured = $EdgesData }
+
+            try {
+                $r = Invoke-EdgeRationaleBackfill -Scope UIVisible -CheckpointEvery 0 6>$null
+                $r.Backfilled | Should -Be 1 -Because 'only the rationale-less edge is a target; the restored one is already populated'
+                $restored   = @($script:Captured.edges | Where-Object { $_.type -eq 'SUPPORTS' })[0]
+                $backfilled = @($script:Captured.edges | Where-Object { $_.type -eq 'WEAKENS'  })[0]
+                # The restore tag + text survive untouched...
+                $restored.rationale_source | Should -Be 'restore'
+                $restored.rationale        | Should -Be 'original discovery-time text'
+                # ...and only the freshly-backfilled edge is tagged 'backfill'.
+                $backfilled.rationale        | Should -Be 'reconstructed reason'
+                $backfilled.rationale_source | Should -Be 'backfill'
+            } finally { Remove-Item -Path $dir -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
     It 'is idempotent + scope-aware: -Scope All includes proposed, excludes already-populated' {
         InModuleScope AITriad {
             $dir = Join-Path ([System.IO.Path]::GetTempPath()) "erb-$([guid]::NewGuid().ToString('N').Substring(0,8))"


### PR DESCRIPTION
The stamping half of t/2944, now unblocked by the live t/2946 restore (33,399 edges tagged `rationale_source=restore` on origin/main `1111d059`). Implements the write-together invariant (edge-rationale-source-marker.md): whenever a PS writer sets a non-empty rationale, it sets `rationale_source` in the same write.

- **`Invoke-EdgeRationaleBackfill` → `backfill`** (post-hoc LLM reconstruction). Stamped at the write site; the empty case already returns via the t/2674 silent-blank contract.
- **`Invoke-EdgeDiscovery` LLM paths (per-node + batch classify) → `discovery`**, stamped **only when the rationale is non-empty** so a rationale-less proposed edge stays source-**absent** (never coerced to `null` — the absent≠null contract, e/120#88/#91).
- **`reflection` not here** — `debateReflectionSlice.ts` is TypeScript (Shared Lib scope).

**Restore protection (CL p/23#193 — the field is no longer null-everywhere):** stamping must never overwrite the 33,399 `restore` tags. This holds by construction — discovery only stamps *newly-built* edges (existing edges are skipped via `$ExistingEdgeKeys` and carried forward whole); backfill skips already-populated edges. **Locked with two regression tests** (discovery carry-forward preserves `restore`; backfill skips a restored edge and stamps only the backfilled one).

**⚠️ One value for CL to confirm at review:** the embedding-**first** candidate block (`discovered_by='embedding-first'`) is stamped **`discovery`, not `embedding-template`** — its rationale is LLM-authored (`Invoke-AIByUsage 'enrichment.edge-discovery.classify'`), and no no-LLM template path exists in this cmdlet. Flagged in-code; one-word change if you want `embedding-template`.

**Tests:** +4 (backfill/discovery stamping incl. absent-stays-absent + both restore-protection tests). Local: 16/16 both writer suites; 52/52 incl. guard + round-trip earlier. Full suite runs in CI.

Holding merge for CL review (they own the vocabulary + the flag). Refs t/2944.

Co-Authored-By: PowerShell (Orca)
Co-Authored-By: Computational Linguist (Orca)