### PR TITLE
docs(cl): correct the embedding-template producer in the marker spec (t/2944)

### DIFF
--- a/research/comp-linguist/designs/edge-rationale-source-marker.md
+++ b/research/comp-linguist/designs/edge-rationale-source-marker.md
@@ -23,11 +23,21 @@ Closed vocabulary (string enum). Absent/empty = **legacy/unknown** (the pre-mark
 | Value | Meaning | Written by |
 |---|---|---|
 | `discovery` | LLM classification at edge-discovery time (contemporaneous) | `Invoke-EdgeDiscovery` (per-node + batch LLM paths) |
-| `embedding-template` | Templated from similarity; no LLM justified it | `Invoke-EdgeDiscovery` embedding-first path (see plan 2a.3) |
+| `embedding-template` | Templated from similarity; no LLM justified it | **RESERVED — no producer exists today.** See the correction below. |
 | `reflection` | Emitted by a debate reflection proposal | `debateReflectionSlice` |
 | `restore` | Original discovery-time text git-restored after a data-loss event (e.g. from `ba3128f5`) | the restore script (t/2444 correction) |
 | `backfill` | Post-hoc LLM reconstruction from node content (last resort; t/2679, now void) | `Invoke-EdgeRationaleBackfill` |
 | `human` | Manually authored/edited by a curator | editor / `Set-Edge` when a human sets rationale |
+
+### Correction (t/2944, 2026-08-24): `embedding-template` had the wrong producer
+
+This table originally assigned `embedding-template` to "`Invoke-EdgeDiscovery` embedding-first path". **That was wrong**, and it was caught when PowerShell implemented the stamping and asked which value that path should write.
+
+Read in the code, not inferred: the embedding-first block calls `Invoke-AIByUsage -UsageId 'enrichment.edge-discovery.classify'` and takes `rationale` directly from the parsed LLM response. Its own warning attributes an empty rationale to "LLM omitted the schema-required field". Every rationale assignment in `Invoke-EdgeDiscovery` is LLM-sourced; there is no templating anywhere in it. **So the embedding-first path writes `discovery`.**
+
+**The conceptual error worth not repeating:** "embedding-first" names how *candidates are selected* — which node pairs get sent for classification — not how the *rationale is justified*. The embedding does retrieval; the LLM does the justification. **This field records who justified the edge, not who nominated it.** A retrieval strategy is never by itself a provenance class.
+
+`embedding-template` therefore has **no producer today** and is reserved for a genuine no-LLM templated path if one is ever built (it was written against "plan 2a.3", which was not). The nearest real instance of the shape it describes is `Invoke-OrgPublishedSeeding.ps1` (`rationale = "match_basis=..."`), which is org-edge seeding on a different surface and outside this vocabulary's current producer set — the obvious candidate if the value is ever activated.
 | *(absent)* | Legacy edge, pre-marker | — |
 
 **Invariant:** whenever a writer sets a non-empty `rationale`, it sets `rationale_source`
@@ -43,8 +53,9 @@ valid for legacy rows.
    tranche (plan 2a, separate).
 2. **PowerShell** — `Invoke-EdgeRationaleBackfill` sets `rationale_source = 'backfill'`
    on every edge it writes a rationale onto (one line at the write site, alongside the
-   existing `Add-Member`/assign). `Invoke-EdgeDiscovery` sets `discovery` /
-   `embedding-template` per path.
+   existing `Add-Member`/assign). `Invoke-EdgeDiscovery` sets **`discovery` on every path
+   it writes**, including embedding-first — all of its rationale comes from the Classify
+   LLM response, none of it is templated (see the correction above).
 3. **Consumer (optional, later)** — `EdgeDetailPanel` badges non-`discovery` sources
    ("backfilled", "templated") so the reader sees provenance at a glance.
 


### PR DESCRIPTION
My spec was wrong and PowerShell caught it. Surfaced while they implemented t/2944 stamping (PR #1471) and asked which value the embedding-first path should write.

## The error

The vocabulary table assigned:

| Value | Meaning | Written by |
|---|---|---|
| `embedding-template` | Templated from similarity; no LLM justified it | ~~`Invoke-EdgeDiscovery` embedding-first path~~ |

**That producer attribution is false.** Read in the code, not inferred:

- The embedding-first block calls `Invoke-AIByUsage -UsageId 'enrichment.edge-discovery.classify'`.
- It takes `rationale` straight from the parsed LLM response (`$E.rationale`).
- Its own warning attributes an empty rationale to *"LLM omitted the schema-required field"*.
- Every rationale assignment in `Invoke-EdgeDiscovery` is `$E.rationale` or `$Rationale` — all LLM-sourced. **No templating exists anywhere in it.**

So the embedding-first path writes **`discovery`**, which is what PS implemented.

## The conceptual error, which is the part worth keeping

**"Embedding-first" names how *candidates are selected*** — which node pairs get sent for classification — **not how the *rationale is justified*.** The embedding does retrieval; the LLM does the justification.

This field records **who justified the edge, not who nominated it**. A retrieval strategy is never by itself a provenance class. That is the mistake that put a selection mechanism into a justification vocabulary, and it's the thing most likely to recur if only the row were quietly patched.

## Changes

- `embedding-template` producer → **RESERVED — no producer exists today**, with the reasoning.
- Added a dated correction section explaining what was checked and why.
- Fixed the implementation-plan line carrying the same error (`Invoke-EdgeDiscovery` sets `discovery` on **every** path it writes).
- Noted the nearest real instance of the shape `embedding-template` describes — `Invoke-OrgPublishedSeeding.ps1` (`rationale = "match_basis=..."`) — as the candidate if the value is ever activated. Different surface, outside this vocabulary's current producer set.

## Scope

**No vocabulary value is added, removed or renamed** — the closed enum is unchanged. Only the producer attribution and its reasoning change. No consumer needs updating; no data is affected. The 33,399 `restore` tags landed by t/2946 (`1111d059`) are untouched.

Docs-only. PS is not blocked on this — I gave them the ✓ on `discovery` before opening it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017U4xd8fyYPJL6U6SmKiftY