### PR TITLE
test(licenses): both-arms unit test for generate-notices preflight guard (t/2973)

### DIFF
--- a/taxonomy-editor/scripts/__tests__/generate-notices-guard.test.ts
+++ b/taxonomy-editor/scripts/__tests__/generate-notices-guard.test.ts
@@ -1,0 +1,29 @@
+import { createRequire } from 'node:module';
+import { describe, it, expect } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { _guardShouldRefuse } = require('../generate-notices.cjs') as {
+  _guardShouldRefuse: (branch: string, isLinkedWorktree: boolean, isCI: boolean) => boolean;
+};
+
+// t/2973: direct both-arms test for the shared-main preflight guard.
+// PR CI runs on feature branches (branch≠main), so it can never exercise the
+// branch=main arms. These tests verify the guard predicate directly so the
+// CI=true exemption and worktree pass-through are proven before merge.
+describe('generate-notices preflight guard', () => {
+  it('refuses when branch=main, not a linked worktree, and CI is not set [FIRE]', () => {
+    expect(_guardShouldRefuse('main', false, false)).toBe(true);
+  });
+
+  it('passes when branch=main and CI=true [CLEAN — the case that broke in t/2971]', () => {
+    expect(_guardShouldRefuse('main', false, true)).toBe(false);
+  });
+
+  it('passes when branch=main and running inside a linked worktree [CLEAN]', () => {
+    expect(_guardShouldRefuse('main', true, false)).toBe(false);
+  });
+
+  it('passes on any non-main branch [CLEAN — normal PR CI]', () => {
+    expect(_guardShouldRefuse('devops/some-feature', false, false)).toBe(false);
+  });
+});

--- a/taxonomy-editor/scripts/generate-notices.cjs
+++ b/taxonomy-editor/scripts/generate-notices.cjs
@@ -113,6 +113,10 @@ function readLicenseText(pkgDir, spdx, pkgId) {
   return fallback;
 }
 
+function guardShouldRefuse(branch, isLinkedWorktree, isCI) {
+  return branch === 'main' && !isLinkedWorktree && !isCI;
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const pkgJsonPath = path.resolve('package.json');
@@ -147,7 +151,7 @@ function main() {
     const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'],
       { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
     const isLinkedWorktree = /[/\\]worktrees[/\\]/.test(gitDir);
-    if (branch === 'main' && !isLinkedWorktree && !process.env.CI) {
+    if (guardShouldRefuse(branch, isLinkedWorktree, Boolean(process.env.CI))) {
       console.error(
         'generate-notices: refusing to run on the shared main checkout — ' +
         'use a linked worktree instead: git worktree add -b <branch> .worktrees/<name>'
@@ -344,4 +348,7 @@ function main() {
   console.log(`generate-notices: wrote ${args.output} (${resolvedRows.length} packages, ${blocks.length} license blocks).`);
 }
 
-main();
+if (require.main === module) main();
+
+// Exported for unit testing only (t/2973).
+module.exports = { _guardShouldRefuse: guardShouldRefuse };

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -225,6 +225,7 @@ export default defineConfig({
       '**/*.test.{ts,tsx}',
       '../main/**/*.test.ts',
       '../server/__tests__/**/*.test.ts',
+      '../../../taxonomy-editor/scripts/__tests__/**/*.test.ts', // t/2973 — generate-notices guard unit tests
       '../../../lib/ai-client/**/*.test.ts',
       '../../../lib/chat/**/*.test.ts',
       '../../../lib/electron-shared/**/*.test.ts',


### PR DESCRIPTION
## Summary

Prevention for t/2971 — both-arms unit test for the `generate-notices.cjs` preflight guard.

Root cause of t/2971: the guard `branch=main && !isLinkedWorktree && !CI` cannot be exercised by PR-branch CI (PR branches are never `main`). It was proven FIRE on dev but never CLEAN in CI, so the `!process.env.CI` exemption went unverified until it hit production.

**Three changes:**
- `generate-notices.cjs`: extract `guardShouldRefuse(branch, isLinkedWorktree, isCI)` as a named function; export as `_guardShouldRefuse` for testing; guard `main()` with `require.main === module`.
- `scripts/__tests__/generate-notices-guard.test.ts`: 4 vitest cases — FIRE, CLEAN-CI, CLEAN-worktree, CLEAN-feature-branch.
- `vite.config.ts`: add `scripts/__tests__/**/*.test.ts` to vitest include.

## Test plan

- [x] 4/4 pass locally (`pnpm exec vitest run scripts/__tests__/generate-notices-guard.test.ts`)
- [ ] CI green on this branch
- [ ] TL Gate Verification (per t/2973 — gate-touching, new blocking test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
