### PR TITLE
feat(chat): add chat_model field to ChatSessionSummary (t/2779)

### DIFF
--- a/taxonomy-editor/src/main/chatIO.ts
+++ b/taxonomy-editor/src/main/chatIO.ts
@@ -16,6 +16,7 @@ export interface ChatSessionSummary {
   updated_at: string;
   mode: string;
   pover: string;
+  chat_model?: string;
 }
 
 function ensureChatsDir(): void {
@@ -44,6 +45,7 @@ export function listChatSessions(): ChatSessionSummary[] {
         updated_at: data.updated_at,
         mode: data.mode,
         pover: data.pover,
+        ...(typeof data.chat_model === 'string' ? { chat_model: data.chat_model } : {}),
       });
     } catch {
       /* telemetry — silent by design */

--- a/taxonomy-editor/src/renderer/hooks/useCommunityStore.ts
+++ b/taxonomy-editor/src/renderer/hooks/useCommunityStore.ts
@@ -24,6 +24,7 @@ export interface CommunityItem {
 
 export interface CommunityChat extends CommunityItem {
   mode?: string;
+  model?: string;
 }
 
 export interface CommunityDebate extends CommunityItem {

--- a/taxonomy-editor/src/renderer/types/chat.ts
+++ b/taxonomy-editor/src/renderer/types/chat.ts
@@ -36,6 +36,7 @@ export interface ChatSessionSummary {
   updated_at: string;
   mode: ChatMode;
   pover: Exclude<SpeakerId, 'user'>;
+  chat_model?: string;
 }
 
 export const CHAT_MODE_INFO: Record<ChatMode, {

--- a/taxonomy-editor/src/server/community/community.ts
+++ b/taxonomy-editor/src/server/community/community.ts
@@ -52,7 +52,7 @@ export function isAdmin(userId?: string): boolean {
 const COMMUNITY_INDEX_FILE = '_index.json';
 
 // Bump when toEntry shape changes so stale caches are replaced on next list.
-const CHAT_INDEX_VERSION = 'chat-v1';
+const CHAT_INDEX_VERSION = 'chat-v2'; // v2: added model (t/2779)
 const DEBATE_INDEX_VERSION = 'debate-v2'; // v2: added model + turn_count (t/2362/t/2384)
 const OPED_INDEX_VERSION = 'oped-v1';
 
@@ -148,7 +148,7 @@ async function listViaIndex<T>(spec: ListingIndexSpec<T>): Promise<T[]> {
 
 interface CommunityChatEntry {
   id: unknown; title: string; created_at: string; updated_at: string;
-  mode: string; community_metadata: unknown;
+  mode: string; community_metadata: unknown; chat_model?: string;
 }
 
 interface CommunityDebateEntry {
@@ -177,6 +177,7 @@ export async function listCommunityChats(): Promise<unknown[]> {
       updated_at: parsed.updated_at || parsed.created_at || '',
       mode: parsed.mode || '',
       community_metadata: stripOriginalId(parsed.community_metadata || null), // t/856
+      ...(typeof parsed.chat_model === 'string' ? { model: parsed.chat_model } : {}),
     }),
   });
   return [...items].sort((a, b) => (b.updated_at || '').localeCompare(a.updated_at || ''));


### PR DESCRIPTION
## Summary
- Add chat_model field to ChatSessionSummary to surface the model used per session

🤖 Generated with Claude Code