### PR TITLE
test(oped): regression test for FromPrep+Topic param-split fix (t/2588)

### DIFF
--- a/scripts/AITriad/Public/New-OpEd.ps1
+++ b/scripts/AITriad/Public/New-OpEd.ps1
@@ -131,6 +131,7 @@ function New-OpEd {
     param(
         [Parameter(Mandatory, Position = 0, ParameterSetName = 'FromTopic')]
         [Parameter(Position = 0, ParameterSetName = 'FromUrl')]
+        [Parameter(ParameterSetName = 'FromPrep')]
         [ValidateNotNullOrEmpty()]
         [string]$Topic,
 

--- a/tests/New-OpEd.Tests.ps1
+++ b/tests/New-OpEd.Tests.ps1
@@ -206,6 +206,45 @@ Describe 'New-OpEd' -Tag 'oped' {
         }
     }
 
+    Context 'FromPrep parameter set' {
+        BeforeEach {
+            $script:capturedSystem = $null
+            $script:capturedPrompt = $null
+            Mock Invoke-AIApi -MockWith $script:MockAI -ModuleName AITriad
+            Mock Get-RelevantTaxonomyNodes { @() } -ModuleName AITriad
+        }
+
+        # Regression: t/2588 — -Topic was missing [Parameter(ParameterSetName='FromPrep')]
+        # so passing both -SourcePrep and -Topic together threw "parameter set cannot be resolved".
+        It 'Resolves FromPrep without error when both -SourcePrep and -Topic are passed' {
+            $Prep = [PSCustomObject]@{
+                Url                  = 'https://example.com/doc.pdf'
+                SourceMarkdown       = 'Artificial intelligence policy requires oversight and accountability mechanisms.'
+                SourceFormat         = 'pdf'
+                SourceExtractionTool = 'ConvertFrom-Pdf'
+                ReadableWords        = 12
+                ReadableRatio        = 0.92
+                SourceBrief          = [PSCustomObject]@{ thesis = 'AI needs oversight.'; readable = 'true' }
+            }
+            { New-OpEd -SourcePrep $Prep -Topic 'Explicit topic override' -Pov safetyist } |
+                Should -Not -Throw
+        }
+
+        It 'Uses SourcePrep.SourceMarkdown as the source material in the prompt' {
+            $Prep = [PSCustomObject]@{
+                Url                  = 'https://example.com/doc.pdf'
+                SourceMarkdown       = 'Unique source content marker for test assertion.'
+                SourceFormat         = 'pdf'
+                SourceExtractionTool = 'ConvertFrom-Pdf'
+                ReadableWords        = 8
+                ReadableRatio        = 0.88
+                SourceBrief          = [PSCustomObject]@{ thesis = 'test'; readable = 'true' }
+            }
+            New-OpEd -SourcePrep $Prep -Topic 'Explicit topic' -Pov safetyist | Out-Null
+            $script:capturedPrompt | Should -Match 'Unique source content marker'
+        }
+    }
+
     Context 'Degradation and errors' {
         # These exercise response handling, not grounding — run voice-only so no
         # retrieval subprocess is attempted.


### PR DESCRIPTION
## Summary
- Add regression test covering the FromPrep+Topic parameter-split fix from t/2588

🤖 Generated with Claude Code