### PR TITLE
feat(edges): stamp rationale_source=reflection at debate reflection edge write site (t/2975)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/debateSlices.test.ts
@@ -1055,7 +1055,29 @@ describe('Synthesis slice: propose_new apply (t/1773, ruling B)', () => {
     const persisted = edgeCall!.edgesFile!.edges as Array<Record<string, unknown>>;
     expect(persisted).toHaveLength(1);
     expect(persisted[0]).toMatchObject({ source: 'new-node-id', target: 'acc-B-001', type: 'SUPPORTS', status: 'proposed' });
+    // t/2975: the reflection edge writer stamps rationale_source alongside its non-empty
+    // rationale (write-together invariant, marker spec).
+    expect(persisted[0]).toMatchObject({ rationale: 'why the edge', rationale_source: 'reflection' });
     expect(useDebateStore.getState().newItemProposalStatus['accelerationist#0']).toBe('approved');
+  });
+
+  it('leaves rationale_source ABSENT when the proposed edge carries no rationale (t/2975 absent≠null)', async () => {
+    mockTaxonomyState.saveError = null;
+    mockTaxonomyState.accelerationist.nodes = [{ id: 'acc-B-001' }];
+    // Proposal whose edge has an empty rationale: the writer must NOT invent provenance.
+    const reflections = makeProposalReflections();
+    reflections[0].new_item_proposals[0].proposed_edges[0].rationale = '';
+    useDebateStore.setState({ reflections: reflections as any, newItemProposalStatus: {}, activeDebateId: 'debate-1' });
+
+    const result = await useDebateStore.getState().applyReflectionProposal('accelerationist', 0);
+
+    expect(result).toMatchObject({ ok: true, createdNodeId: 'new-node-id' });
+    const edgeCall = vi.mocked(useTaxonomyStore.setState).mock.calls
+      .map(c => c[0] as { edgesFile?: { edges: unknown[] } })
+      .find(arg => arg && arg.edgesFile);
+    const persisted = edgeCall!.edgesFile!.edges as Array<Record<string, unknown>>;
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).not.toHaveProperty('rationale_source');
   });
 
   it('refuses to create an orphan when no edge target resolves to a live node (AC2 anti-orphan)', async () => {

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debateReflectionSlice.ts
@@ -894,6 +894,11 @@ export const createDebateReflectionSlice: StateCreator<DebateStore, [], [], Deba
         confidence,
         weight: confidence,
         rationale: pe.rationale,
+        // Write-together invariant (t/2975, marker spec): this is the debate-reflection edge
+        // writer, so stamp `rationale_source = 'reflection'` in the SAME write that sets a
+        // non-empty `rationale`. An absent/empty rationale leaves the field absent — never
+        // coerced to null/empty (absent≠null contract, t/2943).
+        ...(pe.rationale ? { rationale_source: 'reflection' as const } : {}),
         status: 'proposed',
         discovered_at: nowISO(),
         model: 'debate-reflection',


### PR DESCRIPTION
## What

Stamps `rationale_source = "reflection"` at the **sole TS edge writer for debate reflection** — `applyReflectionProposal` in `debateReflectionSlice.ts`. This is the residual TS half of t/2944 (the two PS writers were stamped in #1471); the reflection path is TS in Shared Lib scope and was explicitly not stamped there.

## How

In the same write that sets a non-empty `rationale` on each new edge, stamp the provenance (write-together invariant, per `research/comp-linguist/designs/edge-rationale-source-marker.md`):

- **Absent/empty rationale ⇒ `rationale_source` stays absent** (never coerced to null/empty — absent≠null contract, t/2943), via a conditional spread.
- **Does not touch edges it does not author** — existing `discovery`/`backfill`/`restore` values are carried forward untouched through the edges-file spread.

## Tests

- Existing atomic-persist test now also asserts `rationale_source: 'reflection'` on the reflection-authored edge.
- New test: a proposal edge with an empty rationale leaves `rationale_source` **absent**.
- Full `debateSlices.test.ts` suite green (70 tests); renderer `tsc` clean.

## Deferred (AC item)

The 2 existing untagged debate-reflection edges live in the **data repo** (`taxonomy/Origin/edges.json`) — a fixed, enumerable cohort. Deferred to a one-time data pass (the AC explicitly permits deferral with a note). No metric/threshold/lexicon introduced.

Closes t/2975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)