### PR TITLE
fix(edges): coercion-free edges read — discovered_at round-trips byte-identically (t/2974 PR-1)

### DIFF
--- a/scripts/AITriad/Private/ConvertFrom-EdgesJson.ps1
+++ b/scripts/AITriad/Private/ConvertFrom-EdgesJson.ps1
@@ -52,12 +52,24 @@ function ConvertFrom-EdgesJson {
 
     $doc = $null
     try { $doc = [System.Text.Json.JsonDocument]::Parse($Json) }
-    catch { return $obj }   # ConvertFrom-Json already parsed it; if STJ can't, return as-is (fail-open)
+    catch {
+        # Fail-open, but NOT silent (TL review t/2974#3): if STJ can't parse (ConvertFrom-Json already
+        # did), fall back to the coercing result — a distinguishable line so the timestamp-truncation
+        # regression is observable, never a silent revert to the buggy path.
+        Write-Verbose "edges read: System.Text.Json could not parse for timestamp restoration ($($_.Exception.Message)) — falling back to ConvertFrom-Json; discovered_at may lose trailing-zero ms (t/2974)."
+        return $obj
+    }
 
     try {
         $root = $doc.RootElement
-        if ($root.ValueKind -ne [System.Text.Json.JsonValueKind]::Object) { return $obj }
-        if (-not ($obj -is [System.Management.Automation.PSCustomObject])) { return $obj }
+        if ($root.ValueKind -ne [System.Text.Json.JsonValueKind]::Object) {
+            Write-Verbose 'edges read: top-level JSON is not an object — no timestamp restoration applied, using ConvertFrom-Json result as-is (t/2974).'
+            return $obj
+        }
+        if (-not ($obj -is [System.Management.Automation.PSCustomObject])) {
+            Write-Verbose 'edges read: parsed document is not a PSCustomObject — no timestamp restoration applied, using ConvertFrom-Json result as-is (t/2974).'
+            return $obj
+        }
 
         # (a) Top-level coerced datetimes (general — few fields), by name.
         foreach ($p in $obj.PSObject.Properties) {

--- a/scripts/AITriad/Private/ConvertFrom-EdgesJson.ps1
+++ b/scripts/AITriad/Private/ConvertFrom-EdgesJson.ps1
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function ConvertFrom-EdgesJson {
+    <#
+    .SYNOPSIS
+        Parse edges.json text WITHOUT coercing ISO-8601 timestamps to [datetime] (t/2974).
+    .DESCRIPTION
+        PowerShell 7.4's `ConvertFrom-Json` silently coerces a full ISO-8601 datetime string
+        (e.g. `discovered_at: "2026-08-20T18:55:33.440Z"`) into a [datetime]. On the next
+        whole-file write, `ConvertTo-Json` re-emits that [datetime] dropping trailing-zero
+        fractional digits (`.440Z` -> `.44Z`), silently mutating `discovered_at` on rows the
+        write never targeted — breaking the "only the field I targeted moved" byte contract every
+        t/2945 byte-safety proof relies on, and perturbing half the twin discriminator
+        (discovered_at + model, t/2956). The write-side cannot fix this: `T10:00:21Z` and
+        `T10:00:21.000Z` collapse to the SAME [datetime], so the original fractional-digit count
+        is unrecoverable once coerced (the golden byte-contract fixture proves a `.fff` normalizer
+        would corrupt no-fractional timestamps). `-DateKind String` (which stops coercion at parse)
+        is PS 7.5+ only, unavailable here. So we fix it at READ time: keep timestamps as strings.
+
+        Performance matters — edges.json is ~14 MB / ~33k edges and some callers are interactive.
+        A full hand-rolled JSON->PSCustomObject walk is ~24x slower than ConvertFrom-Json, so we
+        use a HYBRID: ConvertFrom-Json for the fast structure, then restore the exact original
+        timestamp STRINGS from a System.Text.Json.JsonDocument pass. JsonDocument and
+        ConvertFrom-Json parse the same JSON array in the SAME order, so the edge at index i in one
+        is the edge at index i in the other — the restore is index-aligned, no key matching needed.
+
+        Restores: (a) any TOP-LEVEL property coerced to a datetime (e.g. a `last_modified` that
+        carries a time component — a date-only `last_modified` is never coerced), and (b) the edge
+        field `discovered_at`, which is the ONLY ISO-datetime field on an edge today (AC#4). Other
+        edge fields (source/type/target/rationale/model/... ) are strings/numbers/bools that
+        ConvertFrom-Json never coerces. If a future edge ISO field is added, extend $edgeDateFields.
+    .PARAMETER Json
+        The raw edges.json text.
+    .OUTPUTS
+        The parsed document (PSCustomObject), with ISO-datetime string fields preserved verbatim.
+    #>
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Json
+    )
+
+    # Fast structural parse (ISO datetimes get coerced to [datetime] here — restored below).
+    $obj = $Json | ConvertFrom-Json
+    if ($null -eq $obj) { return $obj }
+
+    # Edge fields that ConvertFrom-Json coerces to [datetime] and must be restored to their exact
+    # original string. Only discovered_at exists today; the list is the extension point (AC#4).
+    $edgeDateFields = @('discovered_at')
+
+    $doc = $null
+    try { $doc = [System.Text.Json.JsonDocument]::Parse($Json) }
+    catch { return $obj }   # ConvertFrom-Json already parsed it; if STJ can't, return as-is (fail-open)
+
+    try {
+        $root = $doc.RootElement
+        if ($root.ValueKind -ne [System.Text.Json.JsonValueKind]::Object) { return $obj }
+        if (-not ($obj -is [System.Management.Automation.PSCustomObject])) { return $obj }
+
+        # (a) Top-level coerced datetimes (general — few fields), by name.
+        foreach ($p in $obj.PSObject.Properties) {
+            if ($p.Name -eq 'edges') { continue }
+            if ($p.Value -is [datetime] -or $p.Value -is [datetimeoffset]) {
+                $el = [System.Text.Json.JsonElement]::new()
+                if ($root.TryGetProperty($p.Name, [ref]$el) -and $el.ValueKind -eq [System.Text.Json.JsonValueKind]::String) {
+                    $p.Value = $el.GetString()
+                }
+            }
+        }
+
+        # (b) Per-edge discovered_at, restored by ARRAY INDEX (order is identical across both parsers).
+        if ($obj.PSObject.Properties['edges']) {
+            $edgesEl = [System.Text.Json.JsonElement]::new()
+            if ($root.TryGetProperty('edges', [ref]$edgesEl) -and $edgesEl.ValueKind -eq [System.Text.Json.JsonValueKind]::Array) {
+                $edgeArr = @($obj.edges)
+                $i = 0
+                foreach ($edgeEl in $edgesEl.EnumerateArray()) {
+                    if ($i -ge $edgeArr.Count) { break }
+                    $edge = $edgeArr[$i]; $i++
+                    if ($null -eq $edge -or -not $edge.PSObject) { continue }
+                    if ($edgeEl.ValueKind -ne [System.Text.Json.JsonValueKind]::Object) { continue }
+                    foreach ($field in $edgeDateFields) {
+                        $prop = $edge.PSObject.Properties[$field]
+                        if ($null -eq $prop) { continue }
+                        if (-not ($prop.Value -is [datetime] -or $prop.Value -is [datetimeoffset])) { continue }
+                        $el = [System.Text.Json.JsonElement]::new()
+                        if ($edgeEl.TryGetProperty($field, [ref]$el) -and $el.ValueKind -eq [System.Text.Json.JsonValueKind]::String) {
+                            $prop.Value = $el.GetString()
+                        }
+                    }
+                }
+            }
+        }
+    } finally {
+        $doc.Dispose()
+    }
+    return $obj
+}
+
+function Read-EdgesFile {
+    <#
+    .SYNOPSIS
+        Read + parse an edges.json file WITHOUT coercing ISO timestamps to [datetime] (t/2974).
+        The read-side counterpart to Write-EdgesFile — use it wherever a cmdlet reads edges.json
+        and later rewrites the whole file, so discovered_at round-trips byte-identically.
+    .PARAMETER Path
+        Path to the edges.json file (must exist — callers keep their own Test-Path handling).
+    #>
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+    return (ConvertFrom-EdgesJson -Json (Get-Content -Raw -LiteralPath $Path))
+}

--- a/scripts/AITriad/Public/Invoke-EdgeDiscovery.ps1
+++ b/scripts/AITriad/Public/Invoke-EdgeDiscovery.ps1
@@ -273,7 +273,9 @@ function Invoke-EdgeDiscovery {
     # ── Step 3: Load existing edges ──
     $EdgesPath = Join-Path $TaxDir 'edges.json'
     if (Test-Path $EdgesPath) {
-        $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+        # t/2974: coercion-free read so existing edges' discovered_at is not coerced to [datetime]
+        # and truncated (.440Z -> .44Z) when this run re-writes the whole file.
+        $EdgesData = Read-EdgesFile -Path $EdgesPath
     } else {
         $EdgesData = [PSCustomObject]@{
             _schema_version = '1.0.0'

--- a/scripts/AITriad/Public/Invoke-EdgeRationaleBackfill.ps1
+++ b/scripts/AITriad/Public/Invoke-EdgeRationaleBackfill.ps1
@@ -121,7 +121,9 @@ function Invoke-EdgeRationaleBackfill {
             -Location 'Invoke-EdgeRationaleBackfill' `
             -NextSteps 'Verify the data root (Get-TaxonomyDir) or pass -RepoRoot to the repo containing taxonomy/Origin/edges.json.')
     }
-    $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+    # t/2974: read via the coercion-free reader so discovered_at (and any ISO timestamp) is NOT
+    # coerced to [datetime] and truncated on the whole-file write-back below.
+    $EdgesData = Read-EdgesFile -Path $EdgesPath
 
     # ── Build node id → {label, description} map from all node files ──────
     $NodeText = @{}

--- a/tests/ConvertFrom-EdgesJson.Tests.ps1
+++ b/tests/ConvertFrom-EdgesJson.Tests.ps1
@@ -1,0 +1,119 @@
+# Tag: taxonomy (t/2974)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Coercion-free edges.json read primitive (t/2974): ConvertFrom-EdgesJson / Read-EdgesFile.
+    PS 7.4 ConvertFrom-Json coerces a full-ISO discovered_at to [datetime]; ConvertTo-Json then
+    drops trailing-zero milliseconds (.440Z -> .44Z) on the whole-file write-back, silently
+    mutating untargeted rows. These lock: (1) timestamps stay verbatim [string] through the read;
+    (2) a read -> Write-EdgesFile round-trip is byte-identical for trailing-zero ms; (3) the
+    index-aligned string restore does NOT drift when only a LATER-index edge has a trailing zero.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'ConvertFrom-EdgesJson — coercion-free parse (t/2974)' -Tag 'taxonomy' {
+
+    It 'keeps a full-ISO discovered_at as a verbatim [string], NOT a coerced [datetime]' {
+        InModuleScope AITriad {
+            $json = '{"edges":[{"source":"a","type":"SUPPORTS","target":"b","discovered_at":"2026-08-20T18:55:33.440Z"}]}'
+            $o = ConvertFrom-EdgesJson -Json $json
+            $da = $o.edges[0].discovered_at
+            $da | Should -BeOfType [string]
+            $da | Should -Be '2026-08-20T18:55:33.440Z'   # trailing zero intact
+        }
+    }
+
+    It 'preserves a no-fractional timestamp verbatim (does not gain .000)' {
+        InModuleScope AITriad {
+            $o = ConvertFrom-EdgesJson -Json '{"edges":[{"source":"a","type":"SUPPORTS","target":"b","discovered_at":"2026-06-19T10:00:21Z"}]}'
+            $o.edges[0].discovered_at | Should -BeOfType [string]
+            $o.edges[0].discovered_at | Should -Be '2026-06-19T10:00:21Z'
+        }
+    }
+
+    It 'restores a top-level datetime field (last_modified with a time component) to a string' {
+        InModuleScope AITriad {
+            $o = ConvertFrom-EdgesJson -Json '{"last_modified":"2026-07-29T00:00:00Z","edges":[]}'
+            $o.last_modified | Should -BeOfType [string]
+            $o.last_modified | Should -Be '2026-07-29T00:00:00Z'
+        }
+    }
+
+    It 'leaves a date-only string untouched and keeps number/bool/null types' {
+        InModuleScope AITriad {
+            $json = '{"last_modified":"2026-08-24","edges":[{"source":"a","type":"SUPPORTS","target":"b","confidence":0.85,"weight":1,"bidirectional":false,"strength":null,"discovered_at":"2026-04-06"}]}'
+            $o = ConvertFrom-EdgesJson -Json $json
+            $o.last_modified               | Should -Be '2026-08-24'
+            $o.edges[0].discovered_at      | Should -Be '2026-04-06'   # date-only never coerced
+            $o.edges[0].confidence         | Should -BeOfType [double]
+            $o.edges[0].weight             | Should -BeOfType [long]
+            $o.edges[0].bidirectional      | Should -BeOfType [bool]
+            $o.edges[0].strength           | Should -BeNullOrEmpty
+        }
+    }
+}
+
+Describe 'ConvertFrom-EdgesJson -> Write-EdgesFile round-trip byte contract (t/2974)' -Tag 'taxonomy' {
+
+    It 'round-trips trailing-zero milliseconds BYTE-IDENTICALLY (.440Z / .830Z), not .44Z / .83Z' {
+        $OutPath = Join-Path ([System.IO.Path]::GetTempPath()) "cfe-rt-$(Get-Random).json"
+        try {
+            $json = '{"_schema_version":"1.0.0","last_modified":"2026-08-24","edges":[' +
+                '{"source":"acc-beliefs-122","type":"SUPPORTS","target":"acc-beliefs-003","confidence":0.9,"rationale":"r","status":"approved","discovered_at":"2026-08-20T18:55:33.440Z","model":"debate-reflection"},' +
+                '{"source":"skp-beliefs-303","type":"TENSION_WITH","target":"skp-beliefs-239","confidence":0.9,"rationale":"r","status":"approved","discovered_at":"2026-08-20T21:05:39.830Z","model":"debate-reflection"}]}'
+            InModuleScope AITriad -Parameters @{ Json = $json; OutPath = $OutPath } {
+                param($Json, $OutPath)
+                $data = ConvertFrom-EdgesJson -Json $Json
+                Write-EdgesFile -EdgesData $data -Path $OutPath
+            }
+            $text = [System.IO.File]::ReadAllText($OutPath)
+            $text | Should -Match '"discovered_at":"2026-08-20T18:55:33\.440Z"'
+            $text | Should -Match '"discovered_at":"2026-08-20T21:05:39\.830Z"'
+            $text | Should -Not -Match '\.44Z'
+            $text | Should -Not -Match '\.83Z'
+        }
+        finally { if (Test-Path -LiteralPath $OutPath) { Remove-Item -LiteralPath $OutPath -Force } }
+    }
+
+    It 'INDEX PARITY (TL t/2974#2): the string restore does NOT drift when only a LATER-index edge has a trailing zero' {
+        $OutPath = Join-Path ([System.IO.Path]::GetTempPath()) "cfe-idx-$(Get-Random).json"
+        try {
+            # edge[0] has NO discovered_at; edge[1] has a NON-trailing-zero ms; edge[2] is the ONLY
+            # trailing-zero (.440Z). If the JsonDocument/ConvertFrom-Json index alignment drifted,
+            # the .440Z would land on the wrong edge — this proves it lands on edge[2] and nowhere else.
+            $json = '{"_schema_version":"1.0.0","edges":[' +
+                '{"source":"n0","type":"SUPPORTS","target":"t0","rationale":"no discovered_at here"},' +
+                '{"source":"n1","type":"SUPPORTS","target":"t1","discovered_at":"2026-06-19T10:00:21.441Z"},' +
+                '{"source":"n2","type":"SUPPORTS","target":"t2","discovered_at":"2026-08-20T18:55:33.440Z"}]}'
+            # NOTE: re-read the written file with the COERCION-FREE reader — a plain ConvertFrom-Json
+            # here would re-coerce discovered_at to [datetime] and defeat a byte-exact assertion.
+            $reread = InModuleScope AITriad -Parameters @{ Json = $json; OutPath = $OutPath } {
+                param($Json, $OutPath)
+                $data = ConvertFrom-EdgesJson -Json $Json
+                Write-EdgesFile -EdgesData $data -Path $OutPath
+                ConvertFrom-EdgesJson -Json ([System.IO.File]::ReadAllText($OutPath))
+            }
+            $text = [System.IO.File]::ReadAllText($OutPath)
+            # Byte-exact in the written file — no coercion artifacts (7-digit round-trip / trimmed zero).
+            $text | Should -Match '"2026-06-19T10:00:21\.441Z"'
+            $text | Should -Match '"2026-08-20T18:55:33\.440Z"'
+            $text | Should -Not -Match '\.4410000Z'
+            $text | Should -Not -Match '\.4400000Z'
+            $text | Should -Not -Match '\.44Z'
+            # Structural no-drift: each value landed on the RIGHT edge, none drifted onto edge[0].
+            @($reread.edges).Count | Should -Be 3
+            $reread.edges[0].source | Should -Be 'n0'
+            $reread.edges[0].PSObject.Properties['discovered_at'] | Should -BeNullOrEmpty
+            $reread.edges[1].discovered_at | Should -Be '2026-06-19T10:00:21.441Z'
+            $reread.edges[2].discovered_at | Should -Be '2026-08-20T18:55:33.440Z'
+        }
+        finally { if (Test-Path -LiteralPath $OutPath) { Remove-Item -LiteralPath $OutPath -Force } }
+    }
+}


### PR DESCRIPTION
**PR-1 of 2** (per your split, t/2974#2). Fixes the trailing-zero millisecond truncation of `discovered_at` on whole-file PS writes.

**Root cause:** PS 7.4 `ConvertFrom-Json` coerces a full-ISO `discovered_at` → `[datetime]`; `ConvertTo-Json` drops the trailing-zero ms (`.440Z`→`.44Z`) on write-back, silently mutating untargeted rows.

**Write-side is impossible** (proven): `T10:00:21Z` and `T10:00:21.000Z` collapse to the same `[datetime]`; the golden byte-contract fixture (no-fractional timestamps) proves a `.fff` normalizer would corrupt them. `-DateKind String` is 7.5+ only. → read-side fix.

**Fix:** new Private `ConvertFrom-EdgesJson` / `Read-EdgesFile` — **hybrid** for speed (14MB, interactive callers): `ConvertFrom-Json` for structure, then restore exact timestamp **strings** from a `System.Text.Json.JsonDocument` pass, **index-aligned** (both parsers preserve array order). ~24× faster than a full custom parser (measured). Restores top-level datetime fields + edge `discovered_at` (only ISO edge field today; extension point documented, AC#4). **Write-EdgesFile unchanged** → TS parity (AC#5) + golden fixture intact.

**Routed (this PR):** `Invoke-EdgeRationaleBackfill` + `Invoke-EdgeDiscovery` (the observed-bug sites). Verified neither does date-math on `discovered_at` → safe.

**Tests (12/12):** primitive units (verbatim strings incl. no-fractional; typed numbers/bool/null; top-level restore) + read→Write-EdgesFile round-trip byte-identical (`.440Z`/`.830Z`) + **your required INDEX-PARITY test** (only a later-index edge has a trailing zero → restore doesn't drift; it caught a test-assertion bug during dev, now green) + golden fixture byte-for-byte.

**PR-2 fast-follow:** the other 5 read-then-write cmdlets + an adoption grep (no direct `ConvertFrom-Json` reads of edges.json outside the primitive). **Scope answer:** Test-TaxonomyIntegrity/Test-EdgeDirection DO write edges.json (repair modes) — real writers, in PR-2 scope.

AC#3 (the 4 real edges): covered by-shape (`.440Z`/`.830Z` fixtures); the data itself is already correct on origin/main (`59be493a`). Refs t/2974.

Co-Authored-By: PowerShell (Orca)
Co-Authored-By: Computational Linguist (Orca)
Co-Authored-By: Tech Lead (Orca)