### PR TITLE
fix(edges): route remaining edge writers through coercion-free reader + adoption guard (t/2974 PR-2)

### DIFF
--- a/scripts/AITriad/Public/Approve-Edge.ps1
+++ b/scripts/AITriad/Public/Approve-Edge.ps1
@@ -77,7 +77,7 @@ function Approve-Edge {
         return
     }
 
-    $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+    $EdgesData = Read-EdgesFile -Path $EdgesPath   # t/2974: coercion-free read (preserve discovered_at strings)
 
     if ($Interactive) {
         $Proposed = @()

--- a/scripts/AITriad/Public/Invoke-EdgeWeightEvaluation.ps1
+++ b/scripts/AITriad/Public/Invoke-EdgeWeightEvaluation.ps1
@@ -78,7 +78,7 @@ function Invoke-EdgeWeightEvaluation {
     }
 
     # ── Load data ──
-    $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+    $EdgesData = Read-EdgesFile -Path $EdgesPath   # t/2974: coercion-free read (preserve discovered_at strings)
     $AllEdges  = $EdgesData.edges
 
     # ── Build label + description lookup ──

--- a/scripts/AITriad/Public/Set-Edge.ps1
+++ b/scripts/AITriad/Public/Set-Edge.ps1
@@ -108,7 +108,7 @@ function Set-Edge {
             return
         }
 
-        $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+        $EdgesData = Read-EdgesFile -Path $EdgesPath   # t/2974: coercion-free read (preserve discovered_at strings)
         $MaxIndex  = $EdgesData.edges.Count - 1
 
         # Track whether any modifications were made

--- a/scripts/AITriad/Public/Test-EdgeDirection.ps1
+++ b/scripts/AITriad/Public/Test-EdgeDirection.ps1
@@ -68,7 +68,7 @@ function Test-EdgeDirection {
     }
 
     # ── Load data ──
-    $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+    $EdgesData = Read-EdgesFile -Path $EdgesPath   # t/2974: coercion-free read (preserve discovered_at strings)
     $AllEdges  = $EdgesData.edges
 
     # ── Build label lookup ──

--- a/scripts/AITriad/Public/Test-TaxonomyIntegrity.ps1
+++ b/scripts/AITriad/Public/Test-TaxonomyIntegrity.ps1
@@ -160,7 +160,7 @@ function Test-TaxonomyIntegrity {
     $BadEdges = 0
     $SelfLoopEdges = 0
     if (Test-Path $EdgesPath) {
-        $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+        $EdgesData = Read-EdgesFile -Path $EdgesPath   # t/2974: coercion-free read (preserve discovered_at strings)
         $ValidIds = [System.Collections.Generic.HashSet[string]]::new($AllNodeIds)
         if ($Registry) { foreach ($Pol in $Registry.policies) { [void]$ValidIds.Add($Pol.id) } }
 
@@ -419,7 +419,7 @@ function Test-TaxonomyIntegrity {
         # Fix dangling edges
         $EdgesPath = Join-Path $TaxDir 'edges.json'
         if ($BadEdges -gt 0 -and (Test-Path $EdgesPath)) {
-            $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+            $EdgesData = Read-EdgesFile -Path $EdgesPath   # t/2974: coercion-free read (preserve discovered_at strings)
             $ValidIds = [System.Collections.Generic.HashSet[string]]::new($AllNodeIds)
             if ($Registry) { foreach ($Pol in $Registry.policies) { [void]$ValidIds.Add($Pol.id) } }
             $OrigCount = $EdgesData.edges.Count
@@ -435,7 +435,7 @@ function Test-TaxonomyIntegrity {
         # Fix self-loop edges (source == target). Re-read from disk so this composes
         # correctly after the dangling-edge fix above may have rewritten the file.
         if ($SelfLoopEdges -gt 0 -and (Test-Path $EdgesPath)) {
-            $EdgesData = Get-Content -Raw -Path $EdgesPath | ConvertFrom-Json
+            $EdgesData = Read-EdgesFile -Path $EdgesPath   # t/2974: coercion-free read (preserve discovered_at strings)
             $OrigCount = @($EdgesData.edges).Count
             $EdgesData.edges = @($EdgesData.edges | Where-Object { $_.source -ne $_.target })
             $Removed = $OrigCount - @($EdgesData.edges).Count

--- a/tests/EdgesReadAdoption.Tests.ps1
+++ b/tests/EdgesReadAdoption.Tests.ps1
@@ -1,0 +1,46 @@
+# Tag: taxonomy (t/2974)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Adoption guard (t/2974 PR-2, TL ruling t/2974#2): every cmdlet that WRITES edges.json (calls
+    Write-EdgesFile) must read it through the coercion-free Read-EdgesFile primitive — never via a
+    direct `ConvertFrom-Json`, which coerces discovered_at to [datetime] and truncates trailing-zero
+    milliseconds on the whole-file write-back. This stops a future edge writer from silently
+    re-introducing the t/2974 round-trip bug.
+#>
+
+BeforeAll {
+    $script:PublicDir = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'Public'
+}
+
+Describe 'edges.json read adoption — writers use the coercion-free reader (t/2974)' -Tag 'taxonomy' {
+
+    It 'no edges.json WRITER does a direct coercing ConvertFrom-Json read of edges.json' {
+        $writers = @(
+            Get-ChildItem -Path $script:PublicDir -Filter '*.ps1' -File |
+                Where-Object { Select-String -Path $_.FullName -Pattern 'Write-EdgesFile' -Quiet }
+        )
+        @($writers).Count | Should -BeGreaterThan 0 -Because 'sanity: there must be edge-writing cmdlets to check'
+
+        # A violation = a line that calls ConvertFrom-Json AND references the edges path/file — i.e. a
+        # direct coercing read of edges.json instead of Read-EdgesFile.
+        $violations = foreach ($f in $writers) {
+            Select-String -Path $f.FullName -Pattern 'ConvertFrom-Json' |
+                Where-Object { $_.Line -match '\$EdgesPath' -or $_.Line -match 'edges\.json' } |
+                ForEach-Object { "$($f.Name):$($_.LineNumber): $($_.Line.Trim())" }
+        }
+        @($violations) | Should -BeNullOrEmpty -Because 'an edges.json writer must read via Read-EdgesFile (t/2974), not a direct ConvertFrom-Json that coerces discovered_at'
+    }
+
+    It 'the routed writers actually reference Read-EdgesFile' {
+        foreach ($name in @('Invoke-EdgeRationaleBackfill', 'Invoke-EdgeDiscovery', 'Set-Edge', 'Approve-Edge', 'Invoke-EdgeWeightEvaluation', 'Test-TaxonomyIntegrity', 'Test-EdgeDirection')) {
+            $path = Join-Path $script:PublicDir "$name.ps1"
+            Select-String -Path $path -Pattern 'Read-EdgesFile' -Quiet |
+                Should -BeTrue -Because "$name reads-then-writes edges.json and must use Read-EdgesFile (t/2974)"
+        }
+    }
+}


### PR DESCRIPTION
**PR-2 fast-follow** to #1494 (per your split, t/2974#2). Completes the t/2974 rollout.

Routes the other 5 read-then-write edges.json cmdlets through `Read-EdgesFile` so `discovered_at` round-trips byte-identically on their whole-file writes: **Set-Edge, Approve-Edge, Invoke-EdgeWeightEvaluation, Test-TaxonomyIntegrity** (all 3 edges reads incl. the read-only integrity scan), **Test-EdgeDirection**. Verified none does date-math on `discovered_at` → string-preserving parse is safe.

**Scope answer (your Q):** Test-TaxonomyIntegrity + Test-EdgeDirection DO write edges.json (via `-Repair` modes) — confirmed writers, correctly in scope.

**Adoption guard** (`tests/EdgesReadAdoption.Tests.ps1`): asserts NO edges.json writer (any Public cmdlet calling `Write-EdgesFile`) does a direct `ConvertFrom-Json` read of edges.json — so a future writer can't silently re-introduce the truncation. Plus a check that all 7 routed writers reference `Read-EdgesFile`.

**Tests 14/14:** adoption guard (2) + primitive (6) + Test-TaxonomyIntegrity repair/self-loop/strict-mode (6) — the repair suites exercise a routed read through a real `-Repair` write. No new public API (Read-EdgesFile/ConvertFrom-EdgesJson are Private) → no manifest change.

Closes the t/2974 rollout. Refs t/2974.

Co-Authored-By: PowerShell (Orca)
Co-Authored-By: Tech Lead (Orca)