### PR TITLE
fix(embeddings): recent-window max loop-delay shed signal + deterministic test (t/2914 item 1)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
@@ -14,6 +14,8 @@ import {
   embeddingLoadSnapshot,
   embeddingLoadShedMode,
   evaluateEmbeddingLoadShed,
+  decideLoadShed,
+  readRecentLoopDelayMaxMs,
 } from '../embeddingsLoad.js';
 
 describe('embeddingsLoad (t/2904)', () => {
@@ -115,5 +117,60 @@ describe('embeddingsLoad load-shed (t/2905)', () => {
     beginEmbeddingCompute();
     beginEmbeddingCompute(); // in-flight = 2 > cap 1
     expect(evaluateEmbeddingLoadShed().shed).toBe(false);
+  });
+});
+
+// t/2914 item 1 — the `event_loop_delay` shed branch is unreachable through
+// evaluateEmbeddingLoadShed() in a test env (real loop delay ≈ 0). decideLoadShed
+// takes the already-read signals, so that branch is exercised deterministically.
+describe('decideLoadShed — deterministic shed logic (t/2914 item 1)', () => {
+  const base = { cap: 2, loopShedMs: 250, retryAfterMs: 2000 };
+
+  it('event_loop_delay branch: recent-window max over threshold → shed, reason=event_loop_delay', () => {
+    const d = decideLoadShed({ ...base, mode: 'block', inFlight: 0, loopMaxMs: 300 });
+    expect(d.shed).toBe(true);
+    expect(d.reason).toBe('event_loop_delay');
+    expect(d.event_loop_delay_max_ms).toBe(300);
+  });
+
+  it('event_loop_delay branch fires in warn mode too (shed=true, mode=warn)', () => {
+    const d = decideLoadShed({ ...base, mode: 'warn', inFlight: 0, loopMaxMs: 251 });
+    expect(d.shed).toBe(true);
+    expect(d.mode).toBe('warn');
+    expect(d.reason).toBe('event_loop_delay');
+  });
+
+  it('concurrency takes precedence over loop delay when both trip', () => {
+    const d = decideLoadShed({ ...base, mode: 'block', inFlight: 5, loopMaxMs: 9999 });
+    expect(d.shed).toBe(true);
+    expect(d.reason).toBe('concurrency');
+  });
+
+  it('exactly at the loop-delay threshold does NOT shed (strict >)', () => {
+    const d = decideLoadShed({ ...base, mode: 'block', inFlight: 0, loopMaxMs: 250 });
+    expect(d.shed).toBe(false);
+    expect(d.reason).toBeUndefined();
+  });
+
+  it('under both thresholds → no shed', () => {
+    expect(decideLoadShed({ ...base, mode: 'block', inFlight: 1, loopMaxMs: 10 }).shed).toBe(false);
+  });
+
+  it('off mode never sheds even with a huge loop delay', () => {
+    const d = decideLoadShed({ ...base, mode: 'off', inFlight: 99, loopMaxMs: 9999 });
+    expect(d.shed).toBe(false);
+    expect(d.reason).toBeUndefined();
+  });
+
+  it('rounds the reported max to 0.1 ms', () => {
+    expect(decideLoadShed({ ...base, mode: 'warn', inFlight: 0, loopMaxMs: 12.345 }).event_loop_delay_max_ms).toBe(12.3);
+  });
+});
+
+describe('readRecentLoopDelayMaxMs — recent-window signal (t/2914 item 1)', () => {
+  it('returns a finite, non-negative number', () => {
+    const v = readRecentLoopDelayMaxMs();
+    expect(Number.isFinite(v)).toBe(true);
+    expect(v).toBeGreaterThanOrEqual(0);
   });
 });

--- a/taxonomy-editor/src/server/embeddingsLoad.ts
+++ b/taxonomy-editor/src/server/embeddingsLoad.ts
@@ -31,6 +31,34 @@ function getLoopDelay(): IntervalHistogram {
   return loopDelay;
 }
 
+// Separate RECENT-WINDOW histogram for the load-shed decision (t/2914 item 1).
+// `loopDelay` above is lifetime — good for the t/2904 trend log, but a weak freeze
+// *trigger*: a current freeze barely moves a mean taken since process start. The
+// shed decision reads THIS histogram's max and resets it on every read, so each
+// decision sees only the delay accrued since the previous embedding request, and
+// gates on the max (a freeze spikes the max, not the average). Kept separate so
+// resetting it never perturbs the obs snapshot.
+let shedLoopDelay: IntervalHistogram | undefined;
+function getShedLoopDelay(): IntervalHistogram {
+  if (!shedLoopDelay) {
+    shedLoopDelay = monitorEventLoopDelay({ resolution: 20 });
+    shedLoopDelay.enable();
+  }
+  return shedLoopDelay;
+}
+
+/**
+ * Max event-loop delay (ms) since the previous call, then reset the window.
+ * Recent-window signal for the shed decision (t/2914 item 1) — distinct from the
+ * lifetime obs value in `embeddingLoadSnapshot()`. NaN before the first sample → 0.
+ */
+export function readRecentLoopDelayMaxMs(): number {
+  const d = getShedLoopDelay();
+  const maxMs = Number.isFinite(d.max) ? d.max / NS_PER_MS : 0;
+  d.reset();
+  return maxMs;
+}
+
 let inFlight = 0;
 
 /** Increment the in-flight embedding-compute counter (call before the compute). */
@@ -78,8 +106,10 @@ export function embeddingLoadSnapshot(): EmbeddingLoadSnapshot {
 // Two signals, either trips the shed:
 //   - in-flight embedding-compute count >= a concurrency cap (the trigger was 3
 //     parallel 702-item computes), OR
-//   - mean event-loop delay > a threshold (the DIRECT pre-liveness-miss signal,
-//     robust regardless of count — the mechanism this incident actually hit).
+//   - recent-window MAX event-loop delay > a threshold (the DIRECT pre-liveness-
+//     miss signal, robust regardless of count — the mechanism this incident hit).
+//     Windowed max, reset each read, NOT the lifetime mean — a current freeze
+//     barely moves a since-process-start mean, so it would rarely trip (t/2914 item 1).
 //
 // Gate promotion (warn-first): ships in WARN mode — the route LOGS "would shed"
 // but proceeds, so the real concurrency + loop-delay distribution can be observed
@@ -114,42 +144,66 @@ export interface LoadShedDecision {
   retryAfterMs: number;
   /** Signals at decision time (for the log). */
   in_flight: number;
-  event_loop_delay_mean_ms: number;
+  /** Recent-window MAX event-loop delay (ms) the decision gated on (t/2914 item 1). */
+  event_loop_delay_max_ms: number;
+}
+
+/** Already-read signals for a shed decision. */
+export interface LoadShedInput {
+  mode: LoadShedMode;
+  /** In-flight OTHER embedding computes at decision time. */
+  inFlight: number;
+  /** Recent-window MAX event-loop delay (ms) since the last decision. */
+  loopMaxMs: number;
+  /** Shed when inFlight >= this. */
+  cap: number;
+  /** Shed when loopMaxMs > this. */
+  loopShedMs: number;
+  retryAfterMs: number;
 }
 
 /**
- * Decide whether to shed a NEW embedding compute. Call at route entry BEFORE
- * accepting the compute (so `in_flight` is the count of OTHER computes running).
- * Env-tunable (warn-first):
- *   EMBEDDINGS_MAX_CONCURRENT  (default 2)   — shed when in-flight >= this.
- *   EMBEDDINGS_LOOP_SHED_MS    (default 250) — shed when mean loop delay > this.
- *   EMBEDDINGS_RETRY_AFTER_MS  (default 2000)
- *   EMBEDDINGS_LOAD_SHED_MODE  (default warn)
- * Defaults are conservative starting points; tune from the t/2904 curve before
- * promoting to block.
+ * Pure shed decision from already-read signals (t/2914 item 1). Split out from the
+ * signal reads so the `event_loop_delay` branch is deterministically testable — a
+ * real test-env loop sits at ~0 delay and can't exercise it. Concurrency takes
+ * precedence over loop delay (it's the cheaper, more direct trigger).
  */
-export function evaluateEmbeddingLoadShed(): LoadShedDecision {
-  const mode = embeddingLoadShedMode();
-  const cap = intFromEnv('EMBEDDINGS_MAX_CONCURRENT', 2);
-  const loopShedMs = intFromEnv('EMBEDDINGS_LOOP_SHED_MS', 250);
-  const retryAfterMs = intFromEnv('EMBEDDINGS_RETRY_AFTER_MS', 2000);
-
-  const d = getLoopDelay();
-  const loopMeanMs = Number.isFinite(d.mean) ? d.mean / NS_PER_MS : 0;
-
+export function decideLoadShed(input: LoadShedInput): LoadShedDecision {
+  const { mode, inFlight, loopMaxMs, cap, loopShedMs, retryAfterMs } = input;
   let shed = false;
   let reason: LoadShedDecision['reason'];
   if (mode !== 'off') {
     if (inFlight >= cap) { shed = true; reason = 'concurrency'; }
-    else if (loopMeanMs > loopShedMs) { shed = true; reason = 'event_loop_delay'; }
+    else if (loopMaxMs > loopShedMs) { shed = true; reason = 'event_loop_delay'; }
   }
-
   return {
     shed,
     mode,
     reason,
     retryAfterMs,
     in_flight: inFlight,
-    event_loop_delay_mean_ms: Math.round(loopMeanMs * 10) / 10,
+    event_loop_delay_max_ms: Math.round(loopMaxMs * 10) / 10,
   };
+}
+
+/**
+ * Decide whether to shed a NEW embedding compute. Call at route entry BEFORE
+ * accepting the compute (so `inFlight` is the count of OTHER computes running).
+ * Reads the live signals and delegates to `decideLoadShed`. Env-tunable (warn-first):
+ *   EMBEDDINGS_MAX_CONCURRENT  (default 2)   — shed when in-flight >= this.
+ *   EMBEDDINGS_LOOP_SHED_MS    (default 250) — shed when recent-window MAX loop delay > this.
+ *   EMBEDDINGS_RETRY_AFTER_MS  (default 2000)
+ *   EMBEDDINGS_LOAD_SHED_MODE  (default warn)
+ * Defaults are conservative starting points; tune from the t/2904 curve before
+ * promoting to block. Reading the shed signal RESETS its recent window.
+ */
+export function evaluateEmbeddingLoadShed(): LoadShedDecision {
+  return decideLoadShed({
+    mode: embeddingLoadShedMode(),
+    inFlight,
+    loopMaxMs: readRecentLoopDelayMaxMs(),
+    cap: intFromEnv('EMBEDDINGS_MAX_CONCURRENT', 2),
+    loopShedMs: intFromEnv('EMBEDDINGS_LOOP_SHED_MS', 250),
+    retryAfterMs: intFromEnv('EMBEDDINGS_RETRY_AFTER_MS', 2000),
+  });
 }


### PR DESCRIPTION
## t/2914 item 1 — recent-window loop-delay shed signal + deterministic test

**Problem.** The embedding load-shed's `event_loop_delay` trigger read the histogram's LIFETIME mean (since process start). A current freeze barely moves a since-boot average, so once promoted to block the arm would rarely fire (t/2905#6). And the branch had no direct test — a real test-env loop sits at ~0 delay (t/2905#5).

**Change (warn-only; no promotion).**
- Separate recent-window histogram for the shed decision, reset on each read, gated on windowed **max** (a freeze spikes max, not the mean). Kept distinct from the t/2904 obs snapshot so resetting it never perturbs the lifetime trend log.
- Extract a pure `decideLoadShed(signals)` so the `event_loop_delay` branch is deterministically testable. `evaluateEmbeddingLoadShed()` is now a thin signal-reader over it.
- `LoadShedDecision.event_loop_delay_mean_ms` → `event_loop_delay_max_ms` (no consumer read it — `routes/ai.ts` logs the obs snapshot + `reason` only).

**Tests.** +8 (event_loop_delay fire arm, concurrency precedence, strict-threshold boundary, off-mode, rounding, recent-window smoke). 18/18 green locally; `tsc -p tsconfig.server.json` clean.

**Scope.** Still **warn-only**. TL Gate Verification is still required before the loop-delay signal is ever promoted to block (separate step, unchanged). Item 2 (chunk-yield) already landed; item 3 (worker-offload) deferred evidence-gated per t/2914#7.

Reviewer: **Quality (Tech Lead)** — I implemented this, routing for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
