### PR TITLE
ci: extend onnxruntime install retry to renderer-tsc, test-powershell, test-server-prod-config (t/2976)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,18 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - name: Install Node dependencies (tsx for parity tests)
-        run: pnpm install --frozen-lockfile --filter taxonomy-editor
+      - name: Install Node dependencies (tsx for parity tests) (retry on transient nuget/network failures — t/2975)
+        run: |
+          for i in 1 2 3; do
+            pnpm install --frozen-lockfile --filter taxonomy-editor && break
+            if [ "$i" -lt 3 ]; then
+              echo "pnpm install attempt $i failed; retry in $((i * 15))s"
+              sleep $((i * 15))
+            else
+              echo "::error::pnpm install failed after $i attempts"
+              exit 1
+            fi
+          done
 
       - name: Install Pester
         shell: pwsh
@@ -377,8 +387,18 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient nuget/network failures — t/2975)
+        run: |
+          for i in 1 2 3; do
+            pnpm install --frozen-lockfile && break
+            if [ "$i" -lt 3 ]; then
+              echo "pnpm install attempt $i failed; retry in $((i * 15))s"
+              sleep $((i * 15))
+            else
+              echo "::error::pnpm install failed after $i attempts"
+              exit 1
+            fi
+          done
 
       - name: Renderer type-check
         run: bash taxonomy-editor/scripts/check-renderer-tsc.sh
@@ -1064,8 +1084,18 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient nuget/network failures — t/2975)
+        run: |
+          for i in 1 2 3; do
+            pnpm install --frozen-lockfile && break
+            if [ "$i" -lt 3 ]; then
+              echo "pnpm install attempt $i failed; retry in $((i * 15))s"
+              sleep $((i * 15))
+            else
+              echo "::error::pnpm install failed after $i attempts"
+              exit 1
+            fi
+          done
 
       - name: Build server
         working-directory: taxonomy-editor


### PR DESCRIPTION
## Summary

Extends the onnxruntime install retry added in t/2968 to all remaining exposed CI jobs.

t/2968 added a 3-attempt retry loop (15s/30s backoff) to `test-electron` only. Three other jobs run `pnpm install --frozen-lockfile` without `--ignore-scripts` and were equally exposed to transient onnxruntime nuget/network ETIMEDOUT failures:

- **`test-powershell`** — `pnpm install --frozen-lockfile --filter taxonomy-editor` triggers onnxruntime postinstall
- **`renderer-tsc`** — bare `pnpm install --frozen-lockfile`
- **`test-server-prod-config`** — confirmed flaking on PR #1496 with the same ETIMEDOUT pattern

Jobs using `--ignore-scripts` (dependency-audit, doc-accuracy, debate-eval, schema-validation) are safe — they skip postinstall entirely. No change needed there.

**Change**: apply the identical 3-attempt retry shell loop to all three exposed install steps.

Closes t/2976. Flagged by TL via p/331#594.

## Test plan

- [ ] CI green on this branch (all three newly-retried jobs pass)
- [ ] No regressions in previously-green jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
