### PR TITLE
ci: extend onnxruntime install retry to more CI steps (t/2976)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,18 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - name: Install Node dependencies (tsx for parity tests)
-        run: pnpm install --frozen-lockfile --filter taxonomy-editor
+      - name: Install Node dependencies (tsx for parity tests) (retry on transient nuget/network failures — t/2975)
+        run: |
+          for i in 1 2 3; do
+            pnpm install --frozen-lockfile --filter taxonomy-editor && break
+            if [ "$i" -lt 3 ]; then
+              echo "pnpm install attempt $i failed; retry in $((i * 15))s"
+              sleep $((i * 15))
+            else
+              echo "::error::pnpm install failed after $i attempts"
+              exit 1
+            fi
+          done
 
       - name: Install Pester
         shell: pwsh
@@ -377,8 +387,18 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient nuget/network failures — t/2975)
+        run: |
+          for i in 1 2 3; do
+            pnpm install --frozen-lockfile && break
+            if [ "$i" -lt 3 ]; then
+              echo "pnpm install attempt $i failed; retry in $((i * 15))s"
+              sleep $((i * 15))
+            else
+              echo "::error::pnpm install failed after $i attempts"
+              exit 1
+            fi
+          done
 
       - name: Renderer type-check
         run: bash taxonomy-editor/scripts/check-renderer-tsc.sh
@@ -1064,8 +1084,18 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install dependencies (retry on transient nuget/network failures — t/2975)
+        run: |
+          for i in 1 2 3; do
+            pnpm install --frozen-lockfile && break
+            if [ "$i" -lt 3 ]; then
+              echo "pnpm install attempt $i failed; retry in $((i * 15))s"
+              sleep $((i * 15))
+            else
+              echo "::error::pnpm install failed after $i attempts"
+              exit 1
+            fi
+          done
 
       - name: Build server
         working-directory: taxonomy-editor


### PR DESCRIPTION
## Summary
- Extends onnxruntime install retry logic to renderer-tsc, test-powershell, and test-server-prod-config CI steps

## Test plan
- [ ] CI passes on this PR
- [ ] Retry logic covers all affected steps

Generated with Claude Code