### PR TITLE
fix(analytics): stamp events with the derived storage id so Your Activity isn't empty (t/2978)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/__tests__/analyticsEmitter.test.ts
+++ b/taxonomy-editor/src/renderer/lib/__tests__/analyticsEmitter.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * t/2978 — write/read identity contract for analytics `user`.
+ *
+ * The bug: the emitter stamped events with the RAW principal from /api/auth/me
+ * (e.g. `a@b.com`), while "Your Activity" + the engagement self-filter query by the
+ * DERIVED storage id from /api/user/profile (deriveStorageUserId → `a-at-b-com`). For
+ * any principal the derivation rewrites, written events never matched the query →
+ * empty panel. resolveAnalyticsUser MUST return the derived id for authenticated users
+ * (so writes match reads), and the per-session anon key for anonymous users.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { resolveAnalyticsUser } from '../analyticsEmitter';
+
+/** fetch stub: match by URL substring → ok:true with the mapped JSON; miss → ok:false. */
+function stubFetch(map: Record<string, unknown>): void {
+  vi.stubGlobal('fetch', vi.fn((url: string) => {
+    const key = Object.keys(map).find(k => url.includes(k));
+    return key
+      ? Promise.resolve({ ok: true, json: () => Promise.resolve(map[key]) })
+      : Promise.resolve({ ok: false });
+  }));
+}
+
+describe('resolveAnalyticsUser — write/read identity contract (t/2978)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('authenticated: returns the DERIVED storage id from /api/user/profile, NOT the raw principal', async () => {
+    stubFetch({
+      '/api/user/profile': { userId: 'jsnover13-at-gmail-com', isAnonymous: false },
+      '/api/auth/me': { user: 'jsnover13@gmail.com' }, // raw principal — must NOT be used
+    });
+    expect(await resolveAnalyticsUser()).toBe('jsnover13-at-gmail-com');
+  });
+
+  it('anonymous: keeps the per-session anon key from /api/auth/me (never the collapsed profile.userId)', async () => {
+    stubFetch({
+      '/api/user/profile': { userId: '_local_local', isAnonymous: true },
+      '/api/auth/me': { user: 'anon-abc123' },
+    });
+    expect(await resolveAnalyticsUser()).toBe('anon-abc123');
+  });
+
+  it('falls back to the anon key when profile is unavailable but auth/me responds', async () => {
+    stubFetch({ '/api/auth/me': { user: 'anon-xyz' } }); // profile → ok:false
+    expect(await resolveAnalyticsUser()).toBe('anon-xyz');
+  });
+
+  it('falls back to _anonymous when both endpoints fail', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false })));
+    expect(await resolveAnalyticsUser()).toBe('_anonymous');
+  });
+
+  it('falls back to _anonymous when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('network'))));
+    expect(await resolveAnalyticsUser()).toBe('_anonymous');
+  });
+});

--- a/taxonomy-editor/src/renderer/lib/analyticsEmitter.ts
+++ b/taxonomy-editor/src/renderer/lib/analyticsEmitter.ts
@@ -70,19 +70,36 @@ async function flush(): Promise<void> {
   }
 }
 
+/**
+ * Resolve the analytics event `user` id (t/2978). It MUST equal the id the reads
+ * query by, or per-user analytics silently mismatch: authenticated users key on the
+ * DERIVED storage id (`/api/user/profile`.userId = deriveStorageUserId) — the same id
+ * "Your Activity" and the engagement self-filter (analytics.ts) use — NOT the raw
+ * principal from `/api/auth/me` (which rewrites e.g. `a@b.com` → `a-at-b-com`, so a
+ * raw-written event never matches a derived-id query). Anonymous users keep the
+ * per-session/cookie anon key (auth/me.user): profile.userId for anon would collapse
+ * every anonymous user into the single id deriveStorageUserId('_local','_local').
+ */
+export async function resolveAnalyticsUser(): Promise<string> {
+  try {
+    const [profRes, meRes] = await Promise.all([
+      fetch('/api/user/profile'),
+      fetch('/api/auth/me'),
+    ]);
+    const prof = profRes.ok ? (await profRes.json()) as { userId?: string; isAnonymous?: boolean } : null;
+    if (prof && prof.isAnonymous === false && prof.userId) return prof.userId;
+    const me = meRes.ok ? (await meRes.json()) as { user?: string } : null;
+    return me?.user || '_anonymous';
+  } catch { /* telemetry — silent by design */ return '_anonymous'; }
+}
+
 /** Initialize analytics. Call once after app loads. No-op in Electron. */
 export async function initAnalytics(): Promise<void> {
   if (!isWeb || initialized) return;
   initialized = true;
 
-  // Resolve user identity
-  try {
-    const res = await fetch('/api/auth/me');
-    if (res.ok) {
-      const data = await res.json() as { user: string };
-      user = data.user || '_anonymous';
-    }
-  } catch { /* telemetry — silent by design */ }
+  // Resolve user identity — MUST match the read-side id (t/2978).
+  user = await resolveAnalyticsUser();
 
   // Session start event
   emit('session.start', 'navigation', { userAgent: navigator.userAgent });


### PR DESCRIPTION
## t/2978 — "Your Activity" panel empty despite active use

**Root cause (full writeup: t/2978#1):** a write/read identity mismatch. The web analytics emitter stamped the event `user` from `/api/auth/me` — the **raw** principal (e.g. `a@b.com`) — but "Your Activity" and the engagement self-filter query by `/api/user/profile`.userId = `deriveStorageUserId` (e.g. `a-at-b-com`). The engagement query filters `evt.user === opts.user` (analytics.ts), so for any principal the derivation rewrites (all emails / special-char logins) written events never matched → empty panel. A plain login like `jpsnover` survives derivation unchanged, masking it.

**Fix:** extract `resolveAnalyticsUser()` and stamp the **derived storage id** (`profile.userId`) for authenticated users so writes match reads; keep the per-session anon key (`auth/me.user`) for anonymous — `profile.userId` for anon would collapse every anon user into `deriveStorageUserId('_local','_local')`. `/api/auth/me` is left untouched (avoids its broader consumer surface).

**Scope:** web build only (analytics is a no-op in Electron).

**Tests:** +5 locking the write==read identity contract — authenticated → derived id (NOT the raw principal), anonymous → session key, profile-miss fallback, both-fail → `_anonymous`, throw → `_anonymous`. 5/5 green; `tsc -p tsconfig.json` clean.

**Known limitation:** events already written under the raw principal won't retroactively match; the panel populates going forward as new `view.dwell` events accrue (a one-time re-key migration is possible but out of scope for this tool).

Reviewer: **Quality (Tech Lead)** — I implemented; routing for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
