### PR TITLE
fix(community): accept type 'oped' in community-submit IPC validator (t/2986)

### DIFF
--- a/taxonomy-editor/src/main/ipc/communityHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/communityHandlers.ts
@@ -18,6 +18,7 @@ import {
 } from '../communityReviewIO.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
+import { communitySubmitPayloadSchema } from './communitySubmitSchema.js';
 
 export function registerCommunityHandlers(): void {
   // Submit a debate/chat to the remote Community Library.
@@ -34,9 +35,10 @@ export function registerCommunityHandlers(): void {
       if (!/^https?:\/\//i.test(base)) {
         throw new Error('Community server URL must be an http(s) URL. Set it in Settings to share debates.');
       }
-      const submitPayload = z
-        .object({ type: z.enum(['chat', 'debate']), data: z.unknown(), note: z.string().optional() })
-        .parse(payload);
+      // t/2986: 'oped' MUST be in the enum — the op-ed share sends type:'oped', which
+      // the client bridge type + server already accept. Schema single-sourced +
+      // tested in communitySubmitSchema.ts to prevent this drift recurring.
+      const submitPayload = communitySubmitPayloadSchema.parse(payload);
       const url = `${base}/api/community/submit`;
       try {
         const res = await net.fetch(url, {

--- a/taxonomy-editor/src/main/ipc/communitySubmitSchema.test.ts
+++ b/taxonomy-editor/src/main/ipc/communitySubmitSchema.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2986 — the community-submit IPC validator rejected type:'oped' (enum was only
+// ['chat','debate']) while the client bridge type + server already accepted 'oped',
+// so every op-ed → community share failed at the IPC boundary. This locks the
+// runtime enum to the full contract so the drift can't recur.
+
+import { describe, it, expect } from 'vitest';
+import { communitySubmitPayloadSchema, COMMUNITY_SUBMISSION_TYPES } from './communitySubmitSchema';
+
+describe('community-submit payload schema (t/2986)', () => {
+  it.each(['chat', 'debate', 'oped'] as const)('accepts type=%s', (type) => {
+    expect(communitySubmitPayloadSchema.safeParse({ type, data: {}, note: 'x' }).success).toBe(true);
+  });
+
+  it("accepts 'oped' — the type the op-ed share sends (regression for t/2986)", () => {
+    expect(communitySubmitPayloadSchema.safeParse({ type: 'oped', data: { foo: 1 } }).success).toBe(true);
+  });
+
+  it('rejects an unknown type', () => {
+    const r = communitySubmitPayloadSchema.safeParse({ type: 'bogus', data: {} });
+    expect(r.success).toBe(false);
+  });
+
+  it('note is optional; data is required', () => {
+    expect(communitySubmitPayloadSchema.safeParse({ type: 'chat', data: {} }).success).toBe(true);
+    expect(communitySubmitPayloadSchema.safeParse({ type: 'chat' }).success).toBe(false);
+  });
+
+  it('the enum is exactly the client bridge contract (chat|debate|oped)', () => {
+    expect([...COMMUNITY_SUBMISSION_TYPES]).toEqual(['chat', 'debate', 'oped']);
+  });
+});

--- a/taxonomy-editor/src/main/ipc/communitySubmitSchema.ts
+++ b/taxonomy-editor/src/main/ipc/communitySubmitSchema.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { z } from 'zod';
+
+/**
+ * Runtime validation for the community-submit IPC payload (t/2986).
+ *
+ * Extracted from communityHandlers so the type-enum contract is testable WITHOUT
+ * importing electron. This enum is the RUNTIME gate — it MUST stay in sync with the
+ * client bridge type (renderer/bridge/types.ts `communitySubmit`) and the server
+ * accept set (server/community/community.ts `submitToCommunity`). The drift that
+ * broke op-ed sharing (t/2986) was this enum missing 'oped' while the TS types
+ * already listed it, so a `type: 'oped'` share was rejected at the IPC boundary.
+ */
+export const COMMUNITY_SUBMISSION_TYPES = ['chat', 'debate', 'oped'] as const;
+
+export const communitySubmitPayloadSchema = z.object({
+  type: z.enum(COMMUNITY_SUBMISSION_TYPES),
+  data: z.unknown(),
+  note: z.string().optional(),
+});


### PR DESCRIPTION
## t/2986 — op-ed → community share fails ("Invalid option: expected one of chat|debate")

**Root cause (full triage: t/2986#1):** validator/type drift. The `community-submit` IPC handler's Zod enum was `['chat','debate']`, but the client bridge type (`renderer/bridge/types.ts`) and the server accept set (`community.ts` `submitToCommunity` + the `oped-` dir/prefix branch at `community.ts:419-424`) already include `'oped'`. So a `type:'oped'` share was rejected at the IPC boundary. Web path unaffected (its route casts rather than re-validates).

**Fix:** extract the payload schema to `communitySubmitSchema.ts` (electron-free, so the enum contract is unit-testable) with the full `['chat','debate','oped']` set; `communityHandlers` imports it. Electron IPC scope; downstream already handles `oped`.

**Tests:** +7 locking the runtime enum to the client contract — accepts all three (incl. `oped`, the regression), rejects unknown, `data` required, `note` optional, and asserts the enum == the client contract. 7/7 green; `tsc -p tsconfig.main.json` clean.

**Prevention note:** the durable fix for this drift class is single-sourcing the submission-type enum across the client bridge type + IPC validator + server route. This PR single-sources it within main/ipc + adds the test; unifying across the main/server build boundary is a larger follow-up worth filing if we see the drift again.

Reviewer: **Quality (Tech Lead)** — I implemented; routing for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
