### PR TITLE
fix(embeddings): per-chunk timeout so large batches complete, accurate timeout error (t/2985)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsPerChunkTimeout.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsPerChunkTimeout.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * t/2985 — regression tests for per-chunk timeout in resolveEmbeddingsChunked.
+ *
+ * Root cause: the 45s EMBEDDINGS_REQUEST_TIMEOUT_MS wrapped the ENTIRE
+ * resolveEmbeddingsChunked call (aggregate), so a 2,579-input batch whose total compute
+ * exceeds 45s timed out even though each chunk was healthy. Fix: timeout is now per-chunk
+ * inside resolveEmbeddingsChunked — large batches complete; a stuck chunk still times out.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => undefined }));
+
+const { resolveEmbeddingsChunked } = await import('../ai/aiBackends');
+
+describe('resolveEmbeddingsChunked per-chunk timeout (t/2985)', () => {
+  it('multi-chunk batch succeeds when each chunk fits the per-chunk budget', async () => {
+    // 3 chunks × ~15ms each = ~45ms aggregate. With an aggregate timeout of 30ms this
+    // would have failed under the old code; with a 30ms per-chunk budget each chunk passes.
+    const chain = [{
+      name: 'slow',
+      compute: async (texts: string[]) => {
+        await new Promise(r => setTimeout(r, 15));
+        return texts.map(() => [1]);
+      },
+    }];
+    const texts = Array.from({ length: 6 }, (_, i) => `t${i}`);
+    const result = await resolveEmbeddingsChunked(texts, undefined, null, chain, 2, 30);
+    expect(result).toHaveLength(6);
+    expect(result.every(v => Array.isArray(v) && v[0] === 1)).toBe(true);
+  });
+
+  it('a stuck chunk times out with an error message containing "timed out"', async () => {
+    const chain = [{
+      name: 'stuck',
+      compute: async (_: string[]) => new Promise<number[][]>(() => { /* never resolves */ }),
+    }];
+    const texts = ['a', 'b'];
+    await expect(
+      resolveEmbeddingsChunked(texts, undefined, null, chain, 10, 50),
+    ).rejects.toThrow('timed out');
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -606,18 +606,24 @@ const EMBEDDING_COMPUTE_CHUNK = 256;
 // Resolve a (possibly large) batch in chunks, yielding the event loop between chunks. Safe
 // because resolveEmbeddings is order-preserving and per-text pure (local cache-hit or chain
 // compute), so concatenating per-chunk results is identical to resolving the whole batch at
-// once. Exported for unit test. `chunkSize` is injectable so a test can force chunking small.
+// once. Exported for unit test. `chunkSize` and `chunkTimeoutMs` are injectable so tests can
+// force chunking small and verify per-chunk timeout behaviour (t/2985).
 export async function resolveEmbeddingsChunked(
   texts: string[],
   ids: string[] | undefined,
   local: EmbeddingsFile | null,
   chain: EmbeddingFallback[],
   chunkSize: number = EMBEDDING_COMPUTE_CHUNK,
+  chunkTimeoutMs: number = EMBEDDINGS_REQUEST_TIMEOUT_MS,
 ): Promise<number[][]> {
-  if (texts.length <= chunkSize) return resolveEmbeddings(texts, ids, local, chain);
+  // t/2985: timeout is per-chunk, not aggregate — large healthy batches complete while a
+  // stuck chunk still gets bounded. The outer withTimeout (aggregate) was removed.
+  const resolveChunk = (t: string[], i: string[] | undefined) =>
+    withTimeout(resolveEmbeddings(t, i, local, chain), chunkTimeoutMs, 'embeddings-chunk');
+  if (texts.length <= chunkSize) return resolveChunk(texts, ids);
   const out: number[][] = [];
   for (let i = 0; i < texts.length; i += chunkSize) {
-    const vecs = await resolveEmbeddings(texts.slice(i, i + chunkSize), ids?.slice(i, i + chunkSize), local, chain);
+    const vecs = await resolveChunk(texts.slice(i, i + chunkSize), ids?.slice(i, i + chunkSize));
     for (const v of vecs) out.push(v);
     // Yield the loop between chunks so a big compute can't monopolize it past the liveness deadline.
     if (i + chunkSize < texts.length) await new Promise<void>((r) => setImmediate(r));
@@ -657,11 +663,8 @@ export async function computeEmbeddings(texts: string[], ids?: string[], _explic
   }
 
   try {
-    const result = await withTimeout(
-      resolveEmbeddingsChunked(texts, ids, local, chain),
-      EMBEDDINGS_REQUEST_TIMEOUT_MS,
-      'embeddings-compute',
-    );
+    // t/2985: timeout is now per-chunk inside resolveEmbeddingsChunked — no aggregate ceiling.
+    const result = await resolveEmbeddingsChunked(texts, ids, local, chain);
     const elapsedMs = Date.now() - startMs;
     getGlobalRecorder()?.record({
       type: 'ai.response', component: 'ai-backends', level: 'info',
@@ -677,6 +680,20 @@ export async function computeEmbeddings(texts: string[], ids?: string[], _explic
       error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       data: { inputCount: texts.length, elapsedMs, chainMembers: chain.map(c => c.name) },
     });
+    // t/2985: distinguish a per-chunk timeout from an empty-chain init failure so triage
+    // isn't misdirected to a packaging cause when the encoder worked but timed out.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('timed out')) {
+      throw new ActionableError({
+        goal: 'Compute embeddings',
+        problem: `Embedding chunk timed out after ${elapsedMs}ms (${texts.length} inputs) — a ${EMBEDDING_COMPUTE_CHUNK}-text chunk exceeded the ${EMBEDDINGS_REQUEST_TIMEOUT_MS / 1000}s per-chunk budget`,
+        location: 'aiBackends.computeEmbeddings',
+        nextSteps: [
+          `Increase EMBEDDINGS_REQUEST_TIMEOUT_MS (currently ${EMBEDDINGS_REQUEST_TIMEOUT_MS}ms) if ONNX compute on this host is slower than expected`,
+          'Or reduce the batch size sent to /api/embeddings/compute',
+        ],
+      });
+    }
     throw new ActionableError({
       goal: 'Compute embeddings',
       problem: `No local embedding encoder available after ${elapsedMs}ms — the Python sentence-transformers venv is absent and the in-process ONNX all-MiniLM-L6-v2 fallback failed to initialize`,


### PR DESCRIPTION
## t/2985 — per-chunk timeout removes aggregate ceiling; accurate timeout error message

**Root cause (t/2985#1).** The 45s \`EMBEDDINGS_REQUEST_TIMEOUT_MS\` wrapped the entire \`resolveEmbeddingsChunked\` call (aggregate). A 2,579-input batch whose total compute exceeds 45s timed out even though each 256-chunk was individually healthy. t/2914 item 2 (chunk-yield) kept the loop alive but didn't fix the aggregate timeout.

**Secondary bug.** The catch unconditionally reported any failure — including this timeout — as "No local embedding encoder available … ONNX fallback failed to initialize." False when the encoder worked; only the actual \`timed out after 45s\` line in a nested recorder entry revealed the truth.

**Changes.**
- \`resolveEmbeddingsChunked\`: add \`chunkTimeoutMs\` param (default \`EMBEDDINGS_REQUEST_TIMEOUT_MS\`); wrap each \`resolveEmbeddings\` call with \`withTimeout\` per-chunk. Both the single-chunk short-circuit and the loop body are covered.
- \`computeEmbeddings\`: remove outer \`withTimeout\` — no more aggregate ceiling.
- Catch: check \`err.message.includes('timed out')\` → emit accurate timeout \`ActionableError\`; fall through to the existing "no encoder available" message for init/chain failures (\`chain.length===0\`).

**Regression tests (2).**
- Multi-chunk batch where aggregate > a low timeout but each chunk < that timeout → succeeds.
- Stuck chunk (never resolves) → times out with message containing "timed out".

\`chunkTimeoutMs\` injectable so tests don't need real ONNX or 45s waits.

Reviewer: **Main (Tech Lead)** — I implemented, routing for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)