### PR TITLE
feat(sync): hide SaveBar for non-admin users (t/2984)

### DIFF
--- a/taxonomy-editor/src/renderer/components/sync/SaveBar.test.tsx
+++ b/taxonomy-editor/src/renderer/components/sync/SaveBar.test.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }));
+
+// Stub heavy child components to isolate SaveBar logic.
+vi.mock('./UnsyncedChangesDrawer', () => ({ UnsyncedChangesDrawer: () => null }));
+vi.mock('./SyncDiagnosticsDialog', () => ({ SyncDiagnosticsDialog: () => null }));
+vi.mock('./TaxonomyDiffPanel', () => ({ TaxonomyDiffPanel: () => null }));
+vi.mock('./TaxonomyUpdateToast', () => ({ TaxonomyUpdateToast: () => null }));
+vi.mock('../shared', () => ({ TheoryLink: () => null }));
+
+// Stub hooks with controllable return values.
+const mockUseFlag = vi.fn();
+vi.mock('../../hooks/useFeatureFlags', () => ({ useFlag: (flag: string) => mockUseFlag(flag) }));
+
+vi.mock('../../hooks/useTaxonomyStore', () => ({
+  useTaxonomyStore: () => ({
+    dirty: new Set(),
+    save: vi.fn(),
+    saveError: null,
+    dismissSaveError: vi.fn(),
+    validationErrors: {},
+    integrityIssues: [],
+    fixIntegrityErrors: vi.fn(),
+  }),
+}));
+
+vi.mock('../../hooks/useSyncStatus', () => ({
+  useSyncStatus: () => ({
+    status: {
+      enabled: false,
+      unsynced_count: 0,
+      session_branch: null,
+      pr_number: null,
+      pr_url: null,
+      push_pending: false,
+      github_configured: false,
+      main_updated_available: false,
+      rebase_in_progress: false,
+      has_conflicts: false,
+    },
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../hooks/useOnlineStatus', () => ({ useOnlineStatus: () => true }));
+
+const { SaveBar } = await import('./SaveBar');
+
+describe('SaveBar admin gate', () => {
+  it('renders nothing for non-admin users', () => {
+    mockUseFlag.mockReturnValue(false);
+    const { container } = render(<SaveBar />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the bar for admin users', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { container } = render(<SaveBar />);
+    expect(container.querySelector('.save-bar')).not.toBeNull();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/sync/SaveBar.tsx
+++ b/taxonomy-editor/src/renderer/components/sync/SaveBar.tsx
@@ -75,6 +75,8 @@ export function SaveBar() {
     return groups;
   }, [validationErrors]);
 
+  if (!adminFlag) return null;
+
   return (
     <div className="save-bar">
       {!isOnline && <span className="save-bar-offline">Offline</span>}


### PR DESCRIPTION
## Summary
- Adds `if (!adminFlag) return null;` early return in `SaveBar` before the render, hiding the entire bar (including child dialogs/drawers) for non-admin users
- `adminFlag` was already read via `useFlag('permission-admin-features')` — no new imports or hooks
- Adds `SaveBar.test.tsx` with two-case regression coverage: non-admin renders null, admin renders `.save-bar`

## Test plan
- [x] `npx vitest run src/renderer/components/sync/SaveBar.test.tsx` — 2/2 pass
- [x] Targeted test: non-admin → `container.firstChild` is null; admin → `.save-bar` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)