### PR TITLE
fix(oped): guard reader Share to the user's own op-eds, not community (t/2987)

### DIFF
--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.shareGuard.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.shareGuard.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2987 — the reader's Share control was shown for ANY open op-ed, so sharing a
+// community-loaded op-ed hit /api/oped-sets/:id/share → 404 (the id isn't in the user's
+// own oped-sets store). Design: Share (My) / Copy (Community). This locks the guard:
+// Share renders only when the open op-ed is the user's own (canShare).
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { OpEdSet } from '../../../../../lib/oped/types';
+
+// Web mode (share is web-only, t/2728); api is only touched on click, not on render.
+vi.mock('@bridge', () => ({
+  api: { shareOpEdSet: vi.fn(), unshareOpEdSet: vi.fn() },
+  isElectronMode: () => false,
+}));
+
+import { OpEdReaderView } from './OpEdTab';
+
+const SHARE_LABEL = 'Create a public share link';
+const set = { set_id: 'set-1' } as unknown as OpEdSet;
+
+// readerLoading keeps OpEdReader unrendered so we isolate the reader bar (where Share lives).
+function renderReader(canShare: boolean) {
+  return render(
+    <OpEdReaderView
+      readerSet={set}
+      readerLoading
+      readerError={null}
+      status={null}
+      onBack={() => {}}
+      canShare={canShare}
+    />,
+  );
+}
+
+describe('OpEdReaderView Share guard (t/2987)', () => {
+  it('does NOT render Share for a community op-ed (canShare=false)', () => {
+    renderReader(false);
+    expect(screen.queryByLabelText(SHARE_LABEL)).toBeNull();
+  });
+
+  it("renders Share for the user's own op-ed (canShare=true)", () => {
+    renderReader(true);
+    expect(screen.queryByLabelText(SHARE_LABEL)).not.toBeNull();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTab.tsx
@@ -240,14 +240,16 @@ function ShareOpEdControl({ setId }: { setId: string }) {
 
 // ── Reader view (back bar + article/loading/error) ────────────────────────────
 
-function OpEdReaderView({
-  readerSet, readerLoading, readerError, status, onBack,
+export function OpEdReaderView({
+  readerSet, readerLoading, readerError, status, onBack, canShare,
 }: {
   readerSet: OpEdSet | null;
   readerLoading: boolean;
   readerError: string | null;
   status: string | null;
   onBack: () => void;
+  /** t/2987: only the user's OWN op-eds are shareable — community ones 404 the share endpoint. */
+  canShare: boolean;
 }) {
   return (
     <div className="two-column oped-tab-table-mode">
@@ -255,8 +257,10 @@ function OpEdReaderView({
         <div className="oped-reader-bar">
           <button type="button" className="oped-reader-back" onClick={onBack}>‹ Op-Ed Studies</button>
           {status && <span className="oped-status">{status}</span>}
-          {/* Share is web-only: electron-bridge rejects shareOpEdSet (t/2728). */}
-          {readerSet && !isElectronMode() && <ShareOpEdControl setId={readerSet.set_id} />}
+          {/* Share is web-only (electron-bridge rejects shareOpEdSet, t/2728) AND only for the
+              user's OWN op-eds — a community op-ed isn't in the user's oped-sets store, so its
+              share endpoint 404s (t/2987). Design: Share (My) / Copy (Community). */}
+          {readerSet && canShare && !isElectronMode() && <ShareOpEdControl setId={readerSet.set_id} />}
         </div>
         {readerLoading && <p className="oped-reader-loading">Loading op-ed…</p>}
         {readerError && <p className="oped-reader-error">{readerError}</p>}
@@ -297,6 +301,10 @@ export function OpEdTab() {
   // The set currently open in the reader — may come from the personal store (My)
   // or a community load (Community). null = table view.
   const [readerSet, setReaderSet] = useState<OpEdSet | null>(null);
+  // t/2987: which store the open op-ed came from. 'my' sets are shareable (they live in the
+  // user's oped-sets store); 'community' ones are NOT — the share endpoint reads the user's own
+  // store, so sharing a community-loaded op-ed 404s. Design: Share (My) / Copy (Community).
+  const [readerSource, setReaderSource] = useState<'my' | 'community' | null>(null);
   const [readerLoading, setReaderLoading] = useState(false);
   const [readerError, setReaderError] = useState<string | null>(null);
 
@@ -363,6 +371,7 @@ export function OpEdTab() {
   const openMy = useCallback((id: string) => {
     // The My list holds index summaries (no body) — load the full doc for the reader.
     selectSet(id);
+    setReaderSource('my'); // t/2987: My sets are shareable.
     setReaderError(null);
     setReaderSet(null);
     setReaderLoading(true);
@@ -376,7 +385,9 @@ export function OpEdTab() {
 
   const openCommunity = useCallback((id: string) => {
     selectSet(id);
+    setReaderSource('community'); // t/2987: community op-eds are NOT shareable (Copy, not Share).
     setReaderError(null);
+    setReaderSet(null);
     setReaderLoading(true);
     api.loadCommunityOpEd(id).then(set => {
       setReaderSet(set);
@@ -389,6 +400,7 @@ export function OpEdTab() {
   const closeReader = useCallback(() => {
     selectSet(null);
     setReaderSet(null);
+    setReaderSource(null);
     setReaderError(null);
   }, [selectSet]);
 
@@ -398,6 +410,7 @@ export function OpEdTab() {
     await loadSets();
     // loadSets returns index summaries (no body) — load the full doc for the reader.
     selectSet(setId);
+    setReaderSource('my'); // t/2987: a freshly-created set is the user's own → shareable.
     setReaderError(null);
     setReaderSet(null);
     setReaderLoading(true);
@@ -480,6 +493,7 @@ export function OpEdTab() {
         readerError={readerError}
         status={status}
         onBack={closeReader}
+        canShare={readerSource === 'my'}
       />
     );
   }


### PR DESCRIPTION
## t/2987 — op-ed share 404 "Op-ed set not found"

**Root cause (full triage: t/2987#1):** the reader's `ShareOpEdControl` (OpEdTab.tsx:259) rendered for **any** open op-ed in web mode, guarding only on web-vs-electron — not on my-vs-community. So opening a **community** op-ed and clicking Share hit `POST /api/oped-sets/:id/share`, which reads the user's **own** `oped-sets/` store where a community op-ed's id doesn't exist → 404 (confirmed server-side: `readFile failed: users/{id}/oped-sets/oped-set-{id}.json — blob does not exist`). The design is explicit — **Share (My) / Copy (Community)** — but the reader bar lacked the my-vs-community guard the per-row buttons have.

**Fix:** track the open op-ed's source (`readerSource: 'my' | 'community'`) set by the open handlers (`openMy`/`handleCreated` → my; `openCommunity` → community), thread `canShare` into `OpEdReaderView`, and render Share only when the open set is the user's own. Community op-eds keep Copy (per-row, unchanged).

**Tests:** +2 — render `OpEdReaderView` with `canShare=false` → no Share button (by aria-label); `canShare=true` → Share present. 2/2 green; `tsc -p tsconfig.json` clean.

**Scope:** web-only (share is web-only, t/2728). Different endpoint from t/2986's community-submit enum, but same op-ed-share surface.

Reviewer: **Quality (Tech Lead)** — I implemented; routing for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
