### PR TITLE
feat(taxonomy): situation<->POV reciprocity guard + reconciliation backfill (t/2979 Workstream A)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -21,7 +21,8 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-Policy` | Look up policy actions from the registry |
 | `Get-TaxonomyHealth` | Check node/edge counts, orphans, structural issues |
 | `Compare-Taxonomy` | Diff two taxonomy states |
-| `Test-TaxonomyIntegrity` | Validate referential integrity — dangling refs, edge source/target resolution, and self-loop edges (source == target); `-Repair` strips bad/self-loop edges (see `Test-OrganizationIntegrity` for the Organization slice) |
+| `Test-TaxonomyIntegrity` | Validate referential integrity — dangling refs, edge source/target resolution, self-loop edges, and situation⇄POV reciprocity (`SituationReciprocity`, warn-first); `-Repair` strips bad/self-loop edges (see `Test-OrganizationIntegrity` for the Organization slice) |
+| `Repair-SituationReciprocity` | Reconcile situation `linked_nodes` ⇄ POV-node `situation_refs` so the two directions are mutual (t/2979); a dry-run-first RECOVERY tool, clean-tree-required, no commit/push. Use when the reciprocity check flags drift |
 | `Test-TaxonomyDir` | Pre-validate the taxonomy dir against the embed_taxonomy.py loader contract before `Update-TaxEmbeddings` — reports which files would be ingested vs skipped and flags any ingested file whose `nodes` lack `id` (the shape that crashes the embed run, t/2875) |
 | `Test-OntologyCompliance` | Check nodes against ontology rules |
 | `Get-NodeTestingRecord` | Debate-Tested Phase 2 research surface — filter/sort POV nodes by tier, stale-hash, or importance×deficit (t/1579) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -37,6 +37,7 @@
         'Repair-PovDescriptions'
         'Repair-PovLineage'
         'Repair-PovAttributes'
+        'Repair-SituationReciprocity'
         'Export-AggregatedCruxes'
         'Export-TriadDebateBrief'
         'Test-BriefNarrationStage'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -777,6 +777,7 @@ Export-ModuleMember -Function @(
     'Repair-PovDescriptions'
     'Repair-PovLineage'
     'Repair-PovAttributes'
+    'Repair-SituationReciprocity'
     'Export-AggregatedCruxes'
     'Export-TriadDebateBrief'
     'Test-BriefNarrationStage'

--- a/scripts/AITriad/Public/Repair-SituationReciprocity.ps1
+++ b/scripts/AITriad/Public/Repair-SituationReciprocity.ps1
@@ -1,0 +1,211 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Repair-SituationReciprocity {
+    <#
+    .SYNOPSIS
+        Reconcile situation `linked_nodes` <-> POV-node `situation_refs` so the two directions are
+        MUTUAL (t/2979). A RECOVERY tool — run with -DryRun first.
+    .DESCRIPTION
+        `linked_nodes` (situation -> POV node) and `situation_refs` (POV node -> situation) are two
+        representations of the SAME hand-authored links, but nothing ever kept them in sync, so they
+        drifted — evidence authored on one side is invisible on the other (the t/2979 root cause; the
+        UI reads only `linked_nodes`). This cmdlet unions both directions: for each link present on
+        ONE side whose OTHER endpoint exists, it adds the missing back-ref on the other side. It
+        reconciles two views of the SAME authored links; it invents no evidence.
+
+        RECOVERY-OP CAVEAT (TL t/2979#7 — read before running): a union CANNOT distinguish a
+        drifted-but-authored link from a half-DELETED one. If a curator intentionally removed one
+        side of a link, this would resurrect it. So it is a deliberate, DRY-RUN-FIRST recovery tool,
+        NOT routine auto-repair. (The current ~7-situation drift is entirely additive — nothing was
+        deleted — so union is correct today; confirm the -DryRun report before writing.)
+
+        Only links whose BOTH endpoints exist are reconciled. A ref to a non-existent node/situation
+        is a DANGLING ref (fix it with `Test-TaxonomyIntegrity -Repair`, which prunes) — this cmdlet
+        never reconciles a dangling ref into existence.
+
+        Writes `situations.json` (BLOCK-tier) and any changed POV camp files. It requires a CLEAN
+        working tree (writes go through Write-Utf8NoBom -RequireCleanTree; there is no -AllowDirty).
+        A pre-flight aborts, writing nothing, if any target file is already dirty. It does NOT commit
+        or push — landing the reconciled data in ai-triad-data is a separate human step.
+
+        Pairs with the `Test-TaxonomyIntegrity` reciprocity check (Check 10, t/2979), which flags any
+        future drift so the two directions stay mutual.
+    .PARAMETER DryRun
+        Report what WOULD be reconciled (forward/reverse counts + samples) and make NO writes.
+    .PARAMETER RepoRoot
+        Repository root containing taxonomy/Origin. Defaults to the module-resolved data root.
+    .OUTPUTS
+        [PSCustomObject] summary: ForwardAdded, ReverseAdded, SituationsChanged, PovNodesChanged, FilesWritten, DryRun.
+    .EXAMPLE
+        Repair-SituationReciprocity -DryRun
+        # Preview the reconciliation (always do this first).
+    .EXAMPLE
+        Repair-SituationReciprocity
+        # Apply on a clean tree; then a human reviews the diff and pushes ai-triad-data.
+    .LINK
+        Test-TaxonomyIntegrity
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([PSCustomObject])]
+    param(
+        [switch]$DryRun,
+        [string]$RepoRoot
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    $TaxDir  = if ($RepoRoot) { Join-Path $RepoRoot 'taxonomy/Origin' } else { Get-TaxonomyDir }
+    $PovKeys = @('accelerationist', 'safetyist', 'skeptic')
+    $SitPath = Join-Path $TaxDir 'situations.json'
+
+    if (-not (Test-Path -LiteralPath $SitPath)) {
+        throw (New-ActionableError `
+            -Goal 'Reconcile situation <-> POV reciprocity' `
+            -Problem "situations.json not found at $SitPath" `
+            -Location 'Repair-SituationReciprocity' `
+            -NextSteps 'Verify the data root (Get-TaxonomyDir) or pass -RepoRoot to the repo containing taxonomy/Origin/situations.json.')
+    }
+
+    # ── Load ──
+    $SitData = Get-Content -Raw -LiteralPath $SitPath | ConvertFrom-Json
+    $PovFiles  = @{}                                 # povKey -> @{ Path; Data }
+    $NodeIndex = @{}                                 # POV node id -> node object
+    $NodePovKey = @{}                                # POV node id -> its povKey (which file to mark dirty)
+    foreach ($k in $PovKeys) {
+        $p = Join-Path $TaxDir "$k.json"
+        if (-not (Test-Path -LiteralPath $p)) { continue }
+        $d = Get-Content -Raw -LiteralPath $p | ConvertFrom-Json
+        $PovFiles[$k] = @{ Path = $p; Data = $d }
+        foreach ($n in @($d.nodes)) { $NodeIndex[$n.id] = $n; $NodePovKey[$n.id] = $k }
+    }
+
+    # Situation id -> node object, and the set of situation ids.
+    $SitIndex = @{}
+    foreach ($s in @($SitData.nodes)) { $SitIndex[$s.id] = $s }
+
+    $Helpers = {
+        param($Node, $Field)   # return the field's array (guarded), or @()
+        if ($Node.PSObject.Properties[$Field] -and $null -ne $Node.$Field) { return @($Node.$Field) }
+        return @()
+    }
+    $AddRef = {
+        param($Node, $Field, $Value)   # append $Value to $Node.$Field (array), creating the field if absent
+        $cur = & $Helpers $Node $Field
+        $new = @($cur) + $Value
+        if ($Node.PSObject.Properties[$Field]) { $Node.$Field = $new }
+        else { Add-Member -InputObject $Node -NotePropertyName $Field -NotePropertyValue $new -Force }
+    }
+
+    $ForwardAdded = [System.Collections.Generic.List[string]]::new()   # POV node gained situation_ref
+    $ReverseAdded = [System.Collections.Generic.List[string]]::new()   # situation gained linked_node
+    $DirtyPovKeys = [System.Collections.Generic.HashSet[string]]::new()
+    $SitDirty = $false
+
+    # ── Forward: situation.linked_nodes -> ensure POV node.situation_refs contains the situation ──
+    foreach ($sit in @($SitData.nodes)) {
+        foreach ($nid in (& $Helpers $sit 'linked_nodes')) {
+            if (-not $NodeIndex.ContainsKey($nid)) { continue }   # not a POV node / dangling -> Test-TaxonomyIntegrity -Repair
+            $node = $NodeIndex[$nid]
+            $refs = & $Helpers $node 'situation_refs'
+            if ($refs -notcontains $sit.id) {
+                & $AddRef $node 'situation_refs' $sit.id
+                $ForwardAdded.Add("$nid += situation_ref $($sit.id)")
+                if ($NodePovKey.ContainsKey($nid)) { [void]$DirtyPovKeys.Add($NodePovKey[$nid]) }
+            }
+        }
+    }
+
+    # ── Reverse: POV node.situation_refs -> ensure situation.linked_nodes contains the node ──
+    foreach ($k in $PovKeys) {
+        if (-not $PovFiles.ContainsKey($k)) { continue }
+        foreach ($node in @($PovFiles[$k].Data.nodes)) {
+            foreach ($sref in (& $Helpers $node 'situation_refs')) {
+                if (-not $SitIndex.ContainsKey($sref)) { continue }   # dangling situation_ref -> Test-TaxonomyIntegrity -Repair
+                $sit = $SitIndex[$sref]
+                $linked = & $Helpers $sit 'linked_nodes'
+                if ($linked -notcontains $node.id) {
+                    & $AddRef $sit 'linked_nodes' $node.id
+                    $ReverseAdded.Add("$sref += linked_node $($node.id)")
+                    $SitDirty = $true
+                }
+            }
+        }
+    }
+
+    $SituationsChanged = @($ReverseAdded | ForEach-Object { ($_ -split ' ')[0] } | Sort-Object -Unique).Count
+    $PovNodesChanged   = @($ForwardAdded | ForEach-Object { ($_ -split ' ')[0] } | Sort-Object -Unique).Count
+    $TotalAdds = $ForwardAdded.Count + $ReverseAdded.Count
+
+    # ── Report ──
+    Write-Host ''
+    Write-Host '=== Situation <-> POV reciprocity reconciliation ===' -ForegroundColor Cyan
+    Write-Host "  Forward (POV node += situation_ref): $($ForwardAdded.Count)" -ForegroundColor White
+    Write-Host "  Reverse (situation += linked_node):  $($ReverseAdded.Count)" -ForegroundColor White
+    Write-Host "  Situations changed:                  $SituationsChanged" -ForegroundColor White
+    Write-Host "  POV nodes changed:                   $PovNodesChanged" -ForegroundColor White
+    if ($TotalAdds -gt 0) {
+        Write-Host '  Sample:' -ForegroundColor DarkGray
+        foreach ($s in (@($ForwardAdded) + @($ReverseAdded) | Select-Object -First 10)) { Write-Host "    $s" -ForegroundColor DarkGray }
+    }
+
+    $FilesWritten = [System.Collections.Generic.List[string]]::new()
+
+    if ($TotalAdds -eq 0) {
+        Write-Host '  Already reciprocal — nothing to reconcile.' -ForegroundColor Green
+    }
+    elseif ($DryRun) {
+        Write-Host ''
+        Write-Host "  DRY RUN — no writes. Would reconcile $TotalAdds link(s) across $(($DirtyPovKeys.Count) + $(if ($SitDirty) { 1 } else { 0 })) file(s)." -ForegroundColor Yellow
+    }
+    else {
+        # Pre-flight: require a CLEAN tree for every target BEFORE writing any (BLOCK-tier situations.json;
+        # no -AllowDirty, TL t/2979#7). Abort atomically — write nothing — if any target is dirty.
+        $Targets = [System.Collections.Generic.List[string]]::new()
+        if ($SitDirty) { $Targets.Add($SitPath) }
+        foreach ($k in $DirtyPovKeys) { $Targets.Add($PovFiles[$k].Path) }
+
+        $DirtyTargets = @()
+        if (Get-Command Assert-CleanDataTree -ErrorAction SilentlyContinue) {
+            foreach ($t in $Targets) {
+                try { Assert-CleanDataTree -Path $t } catch { $DirtyTargets += (Split-Path -Leaf $t) }
+            }
+        }
+        if ($DirtyTargets.Count -gt 0) {
+            throw (New-ActionableError `
+                -Goal 'Reconcile situation <-> POV reciprocity' `
+                -Problem "target file(s) already have uncommitted changes: $($DirtyTargets -join ', '). A whole-file rewrite would sweep that concurrent state into your commit (situations.json is BLOCK-tier); nothing was written." `
+                -Location 'Repair-SituationReciprocity' `
+                -NextSteps 'Commit or stash the working-tree changes to these files first (clean-tree-required), then re-run. Use -DryRun to preview without writing.')
+        }
+
+        if ($SitDirty) {
+            if ($PSCmdlet.ShouldProcess($SitPath, "Reconcile $($ReverseAdded.Count) linked_node(s)")) {
+                ($SitData | ConvertTo-Json -Depth 40) | Write-Utf8NoBom -Path $SitPath -RequireCleanTree
+                $FilesWritten.Add($SitPath)
+                Write-Host "  Wrote $(Split-Path -Leaf $SitPath)" -ForegroundColor Green
+            }
+        }
+        foreach ($k in $DirtyPovKeys) {
+            $entry = $PovFiles[$k]
+            if ($PSCmdlet.ShouldProcess($entry.Path, 'Reconcile situation_ref(s)')) {
+                ($entry.Data | ConvertTo-Json -Depth 40) | Write-Utf8NoBom -Path $entry.Path -RequireCleanTree
+                $FilesWritten.Add($entry.Path)
+                Write-Host "  Wrote $(Split-Path -Leaf $entry.Path)" -ForegroundColor Green
+            }
+        }
+        Write-Host ''
+        Write-Host '  Reconciled. Review the diff and push ai-triad-data (this cmdlet does not commit/push).' -ForegroundColor Cyan
+    }
+    Write-Host ''
+
+    [PSCustomObject]@{
+        ForwardAdded      = $ForwardAdded.Count
+        ReverseAdded      = $ReverseAdded.Count
+        SituationsChanged = $SituationsChanged
+        PovNodesChanged   = $PovNodesChanged
+        FilesWritten      = @($FilesWritten)
+        DryRun            = [bool]$DryRun
+    }
+}

--- a/scripts/AITriad/Public/Test-TaxonomyIntegrity.ps1
+++ b/scripts/AITriad/Public/Test-TaxonomyIntegrity.ps1
@@ -324,6 +324,62 @@ function Test-TaxonomyIntegrity {
         $Issues.Add([PSCustomObject]@{ Check = 'DanglingLinked'; Severity = 'Warning'; Count = $DanglingLinked.Count; Detail = "linked_nodes ref non-existent nodes: $Detail" })
     } else { $Passed++ }
 
+    # ── Check 10: Situation <-> POV-node reciprocity (t/2979, WARN-first) ──
+    # linked_nodes (situation -> POV node) and situation_refs (POV node -> situation) must be
+    # MUTUAL: N in S.linked_nodes  <=>  S in N.situation_refs. The two directions were free to
+    # diverge — creation sites init both empty, and this cmdlet only PRUNES dangling refs (Checks
+    # 8/9), it never reciprocates — so evidence authored on one side is invisible on the other.
+    # That silent drift is the t/2979 root cause. WARN-first / observability only: ~7 reverse-only
+    # situations diverge today, so a hard Error would false-block; report BOTH asymmetry classes so
+    # the drift is visible and cannot grow. Only links whose BOTH endpoints exist are evaluated — a
+    # ref to a non-existent node/situation is a dangling-ref issue (Checks 8/9), not an asymmetry.
+    $Checks++
+    $SitLinked = @{}    # situation id -> HashSet of its linked node ids
+    if ($LoadedFiles.ContainsKey('situations')) {
+        foreach ($Node in $LoadedFiles['situations'].Data.nodes) {
+            $Set = [System.Collections.Generic.HashSet[string]]::new()
+            if ($Node.PSObject.Properties['linked_nodes'] -and $null -ne $Node.linked_nodes) {
+                foreach ($L in @($Node.linked_nodes)) { [void]$Set.Add($L) }
+            }
+            $SitLinked[$Node.id] = $Set
+        }
+    }
+    $NodeSitRefs = @{}  # POV node id -> HashSet of its situation refs
+    foreach ($PovKey in @('accelerationist', 'safetyist', 'skeptic')) {
+        if (-not $LoadedFiles.ContainsKey($PovKey)) { continue }
+        foreach ($Node in $LoadedFiles[$PovKey].Data.nodes) {
+            $Set = [System.Collections.Generic.HashSet[string]]::new()
+            if ($Node.PSObject.Properties['situation_refs'] -and $null -ne $Node.situation_refs) {
+                foreach ($R in @($Node.situation_refs)) { [void]$Set.Add($R) }
+            }
+            $NodeSitRefs[$Node.id] = $Set
+        }
+    }
+    # forward-only: N in S.linked_nodes (N a real POV node) but S NOT in N.situation_refs
+    $ForwardOnly = [System.Collections.Generic.List[string]]::new()
+    foreach ($SitId in $SitLinked.Keys) {
+        foreach ($N in $SitLinked[$SitId]) {
+            if (-not $PovNodeIds.Contains($N)) { continue }   # only POV nodes carry situation_refs
+            $Refs = if ($NodeSitRefs.ContainsKey($N)) { $NodeSitRefs[$N] } else { $null }
+            if ($null -eq $Refs -or -not $Refs.Contains($SitId)) { $ForwardOnly.Add("$SitId -> $N") }
+        }
+    }
+    # reverse-only: S in N.situation_refs (S a real situation) but N NOT in S.linked_nodes
+    $ReverseOnly = [System.Collections.Generic.List[string]]::new()
+    foreach ($N in $NodeSitRefs.Keys) {
+        foreach ($SitId in $NodeSitRefs[$N]) {
+            if (-not $SitIds.Contains($SitId)) { continue }   # dangling situation_ref -> Check 8
+            $Linked = if ($SitLinked.ContainsKey($SitId)) { $SitLinked[$SitId] } else { $null }
+            if ($null -eq $Linked -or -not $Linked.Contains($N)) { $ReverseOnly.Add("$N -> $SitId") }
+        }
+    }
+    $AsymCount = $ForwardOnly.Count + $ReverseOnly.Count
+    if ($AsymCount -gt 0) {
+        $FwdPart = if ($ForwardOnly.Count -gt 0) { " forward-only (in linked_nodes, missing situation_refs back-ref) [$($ForwardOnly.Count)]: $((@($ForwardOnly) | Select-Object -First 5) -join '; ')$(if ($ForwardOnly.Count -gt 5) { ' ...' })" } else { '' }
+        $RevPart = if ($ReverseOnly.Count -gt 0) { " reverse-only (in situation_refs, missing linked_nodes back-ref) [$($ReverseOnly.Count)]: $((@($ReverseOnly) | Select-Object -First 5) -join '; ')$(if ($ReverseOnly.Count -gt 5) { ' ...' })" } else { '' }
+        $Issues.Add([PSCustomObject]@{ Check = 'SituationReciprocity'; Severity = 'Warning'; Count = $AsymCount; Detail = "situation.linked_nodes and POV situation_refs are not mutual (t/2979) —$FwdPart$RevPart. WARN-first: a reciprocity backfill / UI-union recovers these; the two directions must not silently drift." })
+    } else { $Passed++ }
+
     # ── BDI weight range validation ──
     # Distinguishes "out-of-range" (Error — value present but violates the schema
     # range) from "unscored" (Warning — value null, node was never assigned).

--- a/tests/SituationReciprocity.Tests.ps1
+++ b/tests/SituationReciprocity.Tests.ps1
@@ -1,0 +1,156 @@
+# Tag: taxonomy (t/2979)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Situation <-> POV reciprocity (t/2979): the Test-TaxonomyIntegrity Check 10 WARN-first guard
+    (both asymmetry classes) + the Repair-SituationReciprocity reconciliation backfill (union both
+    directions, existing-endpoint only, idempotent, dry-run-first). No spend, no live-data writes —
+    every test builds a throwaway taxonomy dir.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    # Build a throwaway taxonomy/Origin with the given situation + POV nodes. $Sits/$Acc/$Saf/$Skp
+    # are arrays of [ordered] node hashtables. Returns the repo root (parent of taxonomy/Origin).
+    function New-ReciprocityFixture {
+        param($Sits = @(), $Acc = @(), $Saf = @(), $Skp = @())
+        $root = Join-Path ([System.IO.Path]::GetTempPath()) "recip-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        $tax  = Join-Path $root 'taxonomy/Origin'
+        New-Item -ItemType Directory -Path $tax -Force | Out-Null
+        @{ _schema_version = '1.0.0'; last_modified = '2026-01-01'; nodes = @($Sits) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $tax 'situations.json') -Encoding utf8
+        @{ _schema_version = '1.0.0'; pov = 'accelerationist'; last_modified = '2026-01-01'; nodes = @($Acc) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $tax 'accelerationist.json') -Encoding utf8
+        @{ _schema_version = '1.0.0'; pov = 'safetyist'; last_modified = '2026-01-01'; nodes = @($Saf) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $tax 'safetyist.json') -Encoding utf8
+        @{ _schema_version = '1.0.0'; pov = 'skeptic'; last_modified = '2026-01-01'; nodes = @($Skp) } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $tax 'skeptic.json') -Encoding utf8
+        # Minimal registry so Test-TaxonomyIntegrity's report ($Registry.policies.Count) has a value
+        # (it reads policy_actions.json; the real data dir always has one).
+        @{ policies = @() } | ConvertTo-Json -Depth 5 | Set-Content -Path (Join-Path $tax 'policy_actions.json') -Encoding utf8
+        return $root
+    }
+    function New-SitNode  { param($Id, $Linked = @()) [ordered]@{ id = $Id; label = $Id; linked_nodes = @($Linked) } }
+    function New-PovNode  { param($Id, $Refs = @())   [ordered]@{ id = $Id; category = 'Beliefs'; label = $Id; situation_refs = @($Refs) } }
+}
+
+Describe 'Test-TaxonomyIntegrity — situation reciprocity guard (t/2979, warn-first)' -Tag 'taxonomy' {
+
+    It 'FIRE: reports BOTH asymmetry classes (forward-only + reverse-only) as a Warning' {
+        $root = New-ReciprocityFixture `
+            -Sits @( (New-SitNode 'sit-001' @('acc-b-1')), (New-SitNode 'sit-002' @()) ) `
+            -Acc  @( (New-PovNode 'acc-b-1' @()) ) `
+            -Skp  @( (New-PovNode 'skp-b-1' @('sit-002')) )
+        try {
+            InModuleScope AITriad -Parameters @{ Root = $root } {
+                param($Root)
+                Mock Get-TaxonomyDir { Join-Path $Root 'taxonomy/Origin' }
+                $r = Test-TaxonomyIntegrity -PassThru 6>$null
+                $recip = @($r.Details | Where-Object { $_.Check -eq 'SituationReciprocity' })
+                @($recip).Count | Should -Be 1
+                $recip[0].Severity | Should -Be 'Warning'
+                $recip[0].Count    | Should -Be 2   # 1 forward-only + 1 reverse-only
+                $recip[0].Detail   | Should -Match 'forward-only'
+                $recip[0].Detail   | Should -Match 'reverse-only'
+            }
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'CLEAN: a fully-reciprocal pair produces NO SituationReciprocity issue' {
+        $root = New-ReciprocityFixture `
+            -Sits @( (New-SitNode 'sit-001' @('acc-b-1')) ) `
+            -Acc  @( (New-PovNode 'acc-b-1' @('sit-001')) )
+        try {
+            InModuleScope AITriad -Parameters @{ Root = $root } {
+                param($Root)
+                Mock Get-TaxonomyDir { Join-Path $Root 'taxonomy/Origin' }
+                $r = Test-TaxonomyIntegrity -PassThru 6>$null
+                @($r.Details | Where-Object { $_.Check -eq 'SituationReciprocity' }) | Should -BeNullOrEmpty
+            }
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'a dangling situation_ref is NOT a reciprocity asymmetry (that is Check 8)' {
+        $root = New-ReciprocityFixture `
+            -Skp @( (New-PovNode 'skp-b-1' @('sit-999')) )   # sit-999 does not exist
+        try {
+            InModuleScope AITriad -Parameters @{ Root = $root } {
+                param($Root)
+                Mock Get-TaxonomyDir { Join-Path $Root 'taxonomy/Origin' }
+                $r = Test-TaxonomyIntegrity -PassThru 6>$null
+                @($r.Details | Where-Object { $_.Check -eq 'SituationReciprocity' }) | Should -BeNullOrEmpty
+            }
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+Describe 'Repair-SituationReciprocity — reconciliation backfill (t/2979)' -Tag 'taxonomy' {
+
+    It 'is exported from the module' {
+        Get-Command -Module AITriad -Name 'Repair-SituationReciprocity' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'REVERSE-only: projects situation_refs -> linked_nodes (recovers the invisible situation)' {
+        $root = New-ReciprocityFixture `
+            -Sits @( (New-SitNode 'sit-002' @()) ) `
+            -Skp  @( (New-PovNode 'skp-b-1' @('sit-002')) )
+        try {
+            $sum = Repair-SituationReciprocity -RepoRoot $root 6>$null
+            $sum.ReverseAdded | Should -Be 1
+            $sum.ForwardAdded | Should -Be 0
+            $sit = (Get-Content -Raw -Path (Join-Path $root 'taxonomy/Origin/situations.json') | ConvertFrom-Json).nodes[0]
+            @($sit.linked_nodes) | Should -Contain 'skp-b-1'
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'FORWARD-only: projects linked_nodes -> situation_refs' {
+        $root = New-ReciprocityFixture `
+            -Sits @( (New-SitNode 'sit-001' @('acc-b-1')) ) `
+            -Acc  @( (New-PovNode 'acc-b-1' @()) )
+        try {
+            $sum = Repair-SituationReciprocity -RepoRoot $root 6>$null
+            $sum.ForwardAdded | Should -Be 1
+            $sum.ReverseAdded | Should -Be 0
+            $node = (Get-Content -Raw -Path (Join-Path $root 'taxonomy/Origin/accelerationist.json') | ConvertFrom-Json).nodes[0]
+            @($node.situation_refs) | Should -Contain 'sit-001'
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'is IDEMPOTENT: a second run reconciles nothing' {
+        $root = New-ReciprocityFixture `
+            -Sits @( (New-SitNode 'sit-002' @()) ) `
+            -Skp  @( (New-PovNode 'skp-b-1' @('sit-002')) )
+        try {
+            $null = Repair-SituationReciprocity -RepoRoot $root 6>$null
+            $again = Repair-SituationReciprocity -RepoRoot $root 6>$null
+            $again.ForwardAdded | Should -Be 0
+            $again.ReverseAdded | Should -Be 0
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'does NOT reconcile a dangling ref into existence (leaves it for Test-TaxonomyIntegrity -Repair)' {
+        $root = New-ReciprocityFixture `
+            -Sits @( (New-SitNode 'sit-001' @('acc-999')) ) `
+            -Skp  @( (New-PovNode 'skp-b-1' @('sit-999')) )
+        try {
+            $sum = Repair-SituationReciprocity -RepoRoot $root 6>$null
+            $sum.ForwardAdded | Should -Be 0
+            $sum.ReverseAdded | Should -Be 0
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'DRY RUN: reports the reconciliation but writes NOTHING' {
+        $root = New-ReciprocityFixture `
+            -Sits @( (New-SitNode 'sit-002' @()) ) `
+            -Skp  @( (New-PovNode 'skp-b-1' @('sit-002')) )
+        try {
+            $before = Get-Content -Raw -Path (Join-Path $root 'taxonomy/Origin/situations.json')
+            $sum = Repair-SituationReciprocity -RepoRoot $root -DryRun 6>$null
+            $sum.DryRun       | Should -BeTrue
+            $sum.ReverseAdded | Should -Be 1
+            @($sum.FilesWritten).Count | Should -Be 0
+            (Get-Content -Raw -Path (Join-Path $root 'taxonomy/Origin/situations.json')) | Should -Be $before
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+}


### PR DESCRIPTION
Workstream A of t/2979 (all-PS, your #5), design-approved at t/2979#7. Fixes the root cause of situations showing no supporting evidence: `linked_nodes` and `situation_refs` are two views of the same hand-authored links that silently drifted (~7 reverse-only situations invisible; the UI reads only `linked_nodes`).

**Test-TaxonomyIntegrity Check 10 `SituationReciprocity` (WARN-first guard):** flags BOTH asymmetry classes (forward-only / reverse-only) with counts + samples; only links whose both endpoints exist are evaluated (dangling stays Checks 8/9). Warning severity — **block-promotion is a follow-up AFTER the backfill reconciles current drift** (your sequence). Both-arms GV to you.

**`Repair-SituationReciprocity` (reconciliation backfill):** unions both directions, existing endpoints only (invents no evidence). Dedicated cmdlet (union != prune). **Clean-tree-required** via `Write-Utf8NoBom -RequireCleanTree` (situations.json is BLOCK-tier; NO `-AllowDirty`; atomic pre-flight writes nothing if any target is dirty). `-DryRun`/`-WhatIf`, idempotent, **does NOT commit/push** (human push). Recovery-op caveat in help (union can't tell drifted-authored from half-deleted → deliberate/dry-run-first).

Node-file whole-file rewrite verified **byte-stable** (PS 7.4 ConvertTo-Json matches the Python-authored format — 0 HTML-escapes, byte-identical except the changed arrays), so the reconciliation diff is minimal + reviewable.

**Tests 9/9** (guard both-arms incl. dangling-not-asymmetry; backfill reverse+forward projection, idempotency, dangling-skip, dry-run-no-write) + module export/parity gate 28/28.

Sequence: backfill run (human) → clean cycle → promote guard to block (follow-up). I'll post the live `-DryRun` reconciliation preview on t/2979 for your review. Refs t/2979.

Co-Authored-By: PowerShell (Orca)
Co-Authored-By: Tech Lead (Orca)
Co-Authored-By: Computational Linguist (Orca)