### PR TITLE
obs(server): surface client error stack in flight recorder log (t/2982)

### DIFF
--- a/taxonomy-editor/src/server/routes/admin.ts
+++ b/taxonomy-editor/src/server/routes/admin.ts
@@ -558,7 +558,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
       // t/837: persist via the user-content backend so client error reports
       // survive container restarts (was raw fs to ephemeral /tmp).
       await fileIO.saveErrorReport(entry);
-      serverRecorder.record({ type: 'system.error', component: 'server', level: 'warn', message: `Client error reported: ${report.error.message ?? 'unknown'}`, data: { userId } });
+      serverRecorder.record({ type: 'system.error', component: 'server', level: 'warn', message: `Client error reported: ${report.error.message ?? 'unknown'}`, data: { userId, errorName: report.error.name, stack: report.error.stack } });
 
       json(res, { ok: true, id: entry.id });
     } catch (err) {


### PR DESCRIPTION
## Summary
- `POST /api/admin/errors` callers already pass `stack` (sliced to 2000 chars) in the payload but the server dropped it from the flight recorder `data` field
- Add `errorName` and `stack` to the recorded event so triage can read file:line directly instead of matching known error patterns

## Test plan
- [ ] Trigger a client JS error → confirm `system.error` event in flight recorder includes `errorName` and `stack` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)