### PR TITLE
fix(web-bridge): guard put/del helpers against res.json() on 204 (t/2980)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -384,10 +384,7 @@ async function put<T = unknown>(path: string, body?: unknown, opts?: FetchOption
       nextSteps: ['Sign in or navigate to /.auth/anonymous to start an anonymous session'],
     });
   }
-  // 204 No Content has an empty body — res.json() would throw SyntaxError (t/2980).
-  // e.g. PUT /api/preferences returns 204; the caller discards the value with .then(() => {}).
-  if (res.status === 204) return undefined as T;
-  return res.json();
+  return res.status === 204 ? (undefined as T) : res.json(); // 204 No Content has no body — res.json() would throw (t/2980)
 }
 
 async function del<T = unknown>(path: string, opts?: FetchOptions): Promise<T> {
@@ -432,10 +429,7 @@ async function del<T = unknown>(path: string, opts?: FetchOptions): Promise<T> {
       nextSteps: ['Sign in or navigate to /.auth/anonymous to start an anonymous session'],
     });
   }
-  // 204 No Content has an empty body — res.json() would throw SyntaxError (t/2980).
-  // DELETE endpoints returning 204 on success are standard REST; guard defensively.
-  if (res.status === 204) return undefined as T;
-  return res.json();
+  return res.status === 204 ? (undefined as T) : res.json(); // 204 No Content has no body (standard for DELETE) — res.json() would throw (t/2980)
 }
 
 /**

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -384,6 +384,9 @@ async function put<T = unknown>(path: string, body?: unknown, opts?: FetchOption
       nextSteps: ['Sign in or navigate to /.auth/anonymous to start an anonymous session'],
     });
   }
+  // 204 No Content has an empty body — res.json() would throw SyntaxError (t/2980).
+  // e.g. PUT /api/preferences returns 204; the caller discards the value with .then(() => {}).
+  if (res.status === 204) return undefined as T;
   return res.json();
 }
 
@@ -429,6 +432,9 @@ async function del<T = unknown>(path: string, opts?: FetchOptions): Promise<T> {
       nextSteps: ['Sign in or navigate to /.auth/anonymous to start an anonymous session'],
     });
   }
+  // 204 No Content has an empty body — res.json() would throw SyntaxError (t/2980).
+  // DELETE endpoints returning 204 on success are standard REST; guard defensively.
+  if (res.status === 204) return undefined as T;
   return res.json();
 }
 

--- a/taxonomy-editor/src/renderer/bridge/webBridge204NoContent.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/webBridge204NoContent.test.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression for t/2980: the web-bridge put()/del() helpers called res.json()
+// unconditionally, so a 204 No Content response (empty body) threw
+// "SyntaxError: Failed to execute 'json' on 'Response': Unexpected end of JSON input".
+// PUT /api/preferences returns 204 on success, so setPreferences silently failed to
+// persist. The guard `if (res.status === 204) return undefined` fixes both helpers.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => undefined }));
+
+import { api } from './web-bridge';
+
+describe('web-bridge 204 No Content handling (t/2980)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('setPreferences resolves (no SyntaxError) when PUT returns 204', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Before the fix, put() → res.json() on the empty 204 body rejected with SyntaxError.
+    await expect(api.setPreferences({} as never)).resolves.toBeUndefined();
+
+    const putCall = fetchMock.mock.calls.find((c) => String(c[0]).includes('/api/preferences'));
+    expect(putCall, 'expected a fetch to PUT /api/preferences').toBeTruthy();
+    expect((putCall![1] as RequestInit | undefined)?.method).toBe('PUT');
+  });
+
+  it('a 200 JSON response still parses normally (guard is 204-specific)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ theme: 'dark' }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // getPreferences uses get(); a real JSON body must still be read (no regression).
+    await expect(api.getPreferences()).resolves.toMatchObject({ theme: 'dark' });
+  });
+});


### PR DESCRIPTION
## Summary
The web-bridge `put()` and `del()` helpers called `res.json()` unconditionally. A **204 No Content** response has an empty body, so `res.json()` threw `SyntaxError: Unexpected end of JSON input`. `PUT /api/preferences` returns 204 on success → `setPreferences` silently failed to persist (the caller discards the value with `.then(() => {})`, so it only surfaced in the bridge error recorder — flight recorder `merged-8a601ac3…`, build `57f855c`).

**Fix:** `if (res.status === 204) return undefined as T;` before `res.json()` in both helpers.

## 204-route audit (AC)
- **PUT `/api/preferences`** → 204 — fixed via `put()`.
- **OPTIONS preflight** (`server.ts:580`) — browser-handled, not a bridge route.
- **POST `/api/diagnostics/sw-state`** (`session.ts:194`) → 204 — delivered via `navigator.sendBeacon`, which never reads the response body, so it does **not** go through `post()`/`res.json()`. No bug.
- **GitHub-API 204** (`githubAPIBackend.ts`) — server-side outbound, already `status === 204`-checked.

No `post()`/`patch()` bridge caller hits a 204 → no other guard needed. The delete helper is guarded defensively anyway (DELETE-204 is standard REST).

## Test plan
- [x] New `webBridge204NoContent.test.ts`: `setPreferences` resolves `undefined` on a mocked 204 (would reject pre-fix); a 200 JSON response still parses (guard is 204-specific)
- [x] renderer-tsc 0/0 · bridge vitest 159/159
- [ ] CI green

Closes t/2980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
