### PR TITLE
ux: double-click debate/op-ed table rows to open (t/2991)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -291,6 +291,11 @@ export function DebateTableRow({
     }
   }, [editMode, isPhone, s, onPhoneSelect, onOpen]);
 
+  const handleRowDoubleClick = useCallback(() => {
+    if (editMode) return;
+    if (isPhone) { onPhoneSelect(s); } else { onOpen(s.id); }
+  }, [editMode, isPhone, s, onPhoneSelect, onOpen]);
+
   const handleDoubleClick = useCallback((e: React.MouseEvent) => {
     // Double-click title cell to rename (only when not in edit-mode bulk flow)
     e.stopPropagation();
@@ -315,6 +320,7 @@ export function DebateTableRow({
       tabIndex={0}
       onClick={handleRowClick}
       onKeyDown={handleKeyDown}
+      onDoubleClick={handleRowDoubleClick}
     >
       {editMode && (
         <td className="col-cb" onClick={e => e.stopPropagation()}>

--- a/taxonomy-editor/src/renderer/components/debate/__tests__/DebateTable.dblclick.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/__tests__/DebateTable.dblclick.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2991 — double-click a row in the debate My table should open that debate.
+// Prior: double-click had no row handler (only the title-cell rename handler).
+// Fix: handleRowDoubleClick mirrors the Enter handler — desktop non-edit → onOpen,
+// phone non-edit → onPhoneSelect, editMode → no-op.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { SessionRowData } from '../DebateTable';
+
+vi.mock('@bridge', () => ({ api: {}, isElectronMode: () => false }));
+
+import { DebateTableRow } from '../DebateTable';
+
+const noop = vi.fn();
+const s = { id: 'd1', title: 'Test Debate', created_at: '' } as unknown as SessionRowData;
+
+function renderRow(opts: { editMode?: boolean; isPhone?: boolean; onOpen?: ReturnType<typeof vi.fn>; onPhoneSelect?: ReturnType<typeof vi.fn> } = {}) {
+  const { editMode = false, isPhone = false, onOpen = noop, onPhoneSelect = noop } = opts;
+  return render(
+    <table><tbody>
+      <DebateTableRow
+        s={s} idx={0} totalRows={1} isActive={false}
+        editMode={editMode} isSelected={false}
+        onToggleSelect={noop} renamingId={null} setRenamingId={noop}
+        renameValue="" setRenameValue={noop}
+        onRename={async () => {}} onMoveSession={noop}
+        onOpen={onOpen} onExport={noop} onShare={noop}
+        onPhoneSelect={onPhoneSelect} isPhone={isPhone}
+      />
+    </tbody></table>,
+  );
+}
+
+describe('DebateTableRow double-click (t/2991)', () => {
+  it('double-clicking a row on desktop non-edit calls onOpen', () => {
+    const onOpen = vi.fn();
+    renderRow({ onOpen });
+    fireEvent.dblClick(screen.getByRole('row'));
+    expect(onOpen).toHaveBeenCalledWith('d1');
+  });
+
+  it('double-clicking a row on phone calls onPhoneSelect, not onOpen', () => {
+    const onOpen = vi.fn();
+    const onPhoneSelect = vi.fn();
+    renderRow({ isPhone: true, onOpen, onPhoneSelect });
+    fireEvent.dblClick(screen.getByRole('row'));
+    expect(onPhoneSelect).toHaveBeenCalledWith(s);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('double-click in editMode does NOT call onOpen', () => {
+    const onOpen = vi.fn();
+    renderRow({ editMode: true, onOpen });
+    fireEvent.dblClick(screen.getByRole('row'));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/OpEdTable.tsx
@@ -305,6 +305,10 @@ export function OpEdMyRow({
     }
   }, [editMode, onOpen, set.set_id]);
 
+  const handleRowDoubleClick = useCallback(() => {
+    if (!editMode) onOpen(set.set_id);
+  }, [editMode, onOpen, set.set_id]);
+
   const commitRename = useCallback(() => {
     const v = renameValue.trim();
     if (v && v !== headline) onRename(set.set_id, v);
@@ -318,6 +322,7 @@ export function OpEdMyRow({
       tabIndex={0}
       onClick={handleRowClick}
       onKeyDown={handleKeyDown}
+      onDoubleClick={handleRowDoubleClick}
     >
       {editMode && (
         <td className="col-cb" onClick={e => e.stopPropagation()}>

--- a/taxonomy-editor/src/renderer/components/opeds/__tests__/OpEdTable.dblclick.test.tsx
+++ b/taxonomy-editor/src/renderer/components/opeds/__tests__/OpEdTable.dblclick.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/2991 — double-click a row in the op-ed My table should open that op-ed.
+// Prior: double-click had no handler, so no effect. Fix: handleRowDoubleClick
+// mirrors the Enter handler (open in non-edit mode, no-op in edit mode).
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { OpEdSetSummary } from '../../../../../../lib/oped/types';
+
+vi.mock('@bridge', () => ({ api: {}, isElectronMode: () => false }));
+
+import { OpEdMyRow } from '../OpEdTable';
+
+const noop = vi.fn();
+const set = { set_id: 's1', topic: 'Test Op-Ed', voice_count: 1, camps: [], created_at: '' } as unknown as OpEdSetSummary;
+
+function renderRow(editMode: boolean, onOpen = noop) {
+  return render(
+    <table><tbody>
+      <OpEdMyRow
+        set={set} idx={0} totalRows={1} isActive={false}
+        editMode={editMode} isSelected={false}
+        onToggleSelect={noop} renamingId={null} setRenamingId={noop}
+        renameValue="" setRenameValue={noop}
+        onRename={noop} onMoveSet={noop}
+        onOpen={onOpen} onExport={noop} onShare={noop}
+      />
+    </tbody></table>,
+  );
+}
+
+describe('OpEdMyRow double-click (t/2991)', () => {
+  it('double-clicking a row in non-edit mode calls onOpen', () => {
+    const onOpen = vi.fn();
+    renderRow(false, onOpen);
+    fireEvent.dblClick(screen.getByRole('row'));
+    expect(onOpen).toHaveBeenCalledWith('s1');
+  });
+
+  it('single-click does NOT call onOpen', () => {
+    const onOpen = vi.fn();
+    renderRow(false, onOpen);
+    fireEvent.click(screen.getByRole('row'));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('double-click in editMode does NOT call onOpen', () => {
+    const onOpen = vi.fn();
+    renderRow(true, onOpen);
+    fireEvent.dblClick(screen.getByRole('row'));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## t/2991 — double-click table rows to open debate / op-ed

**Problem.** Double-clicking a row in the Debate or Op-Ed My table had no effect. Open was only via the explicit Open button or the Enter key.

**Fix.** Add `onDoubleClick={handleRowDoubleClick}` to `DebateTableRow` and `OpEdMyRow`, mirroring each table's existing `handleKeyDown` Enter-open handler:
- `OpEdMyRow`: `if (!editMode) onOpen(set.set_id)`
- `DebateTableRow`: `if (editMode) return; isPhone ? onPhoneSelect(s) : onOpen(s.id)`

Title-cell rename preserved — the existing `onDoubleClick` on the title cell calls `e.stopPropagation()`, so double-clicking the title still renames and the row handler doesn't fire there. Single-click unchanged.

**Tests.** +6 across both row components: desktop double-click → onOpen; phone double-click → onPhoneSelect; editMode double-click → no-op; OpEdMyRow single-click → no-op.

Self-cert: /trivial-change (additive, mirrors Enter handler, no existing interaction changed).

Reviewer: **Main (Tech Lead)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)