### PR TITLE
chore(sync): typeof guard on cache_hit_rate before .toFixed() (t/2999)

### DIFF
--- a/taxonomy-editor/src/renderer/components/sync/SyncDiagnosticsDialog.test.tsx
+++ b/taxonomy-editor/src/renderer/components/sync/SyncDiagnosticsDialog.test.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { SyncDiagnostics, SyncStatus } from '../../utils/syncApi';
+
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => null }));
+vi.mock('./GitProgressBanner', () => ({ GitProgressBanner: () => null }));
+
+const getSyncDiagnostics = vi.fn();
+const getSyncStatus = vi.fn();
+vi.mock('../../utils/syncApi', () => ({
+  getSyncDiagnostics: (...args: unknown[]) => getSyncDiagnostics(...args),
+  getSyncStatus: (...args: unknown[]) => getSyncStatus(...args),
+  createPullRequestTracked: vi.fn(),
+  fetchOriginTracked: vi.fn(),
+  resetMainTracked: vi.fn(),
+  setGithubCredentials: vi.fn(),
+  clearGithubCredentials: vi.fn(),
+}));
+
+function makeStatus(overrides: Partial<SyncStatus> = {}): SyncStatus {
+  return {
+    enabled: true, unsynced_count: 0, session_branch: null, pr_number: null,
+    pr_url: null, push_pending: false, github_configured: true,
+    main_updated_available: false, rebase_in_progress: false,
+    ...overrides,
+  };
+}
+
+function makeDiag(overrides: Partial<SyncDiagnostics> = {}): SyncDiagnostics {
+  return {
+    mode: 'github-api', git_ok: true, files: [], unsynced_count: 0,
+    session_branch: null, pr_number: null, pr_url: null,
+    cache_hit_rate: null, cache_file_count: null,
+    circuit_state: 'closed', rate_limit_remaining: null,
+    recent_commits: [], head_sha: null, main_sha: null,
+    ...overrides,
+  } as unknown as SyncDiagnostics;
+}
+
+const { SyncDiagnosticsDialog } = await import('./SyncDiagnosticsDialog');
+
+describe('SyncDiagnosticsDialog — cache_hit_rate typeof guard', () => {
+  it('shows "--" when cache_hit_rate arrives as a string (t/2999)', async () => {
+    getSyncDiagnostics.mockResolvedValue(makeDiag({ cache_hit_rate: '0.85' as unknown as number }));
+    getSyncStatus.mockResolvedValue(makeStatus());
+
+    render(<SyncDiagnosticsDialog open={true} onClose={vi.fn()} />);
+
+    const label = await screen.findByText('Cache Hit Rate');
+    const row = label.closest('.sync-diag-kv');
+    const value = row?.querySelector('.sync-diag-kv-value');
+    expect(value?.textContent).toBe('--');
+  });
+
+  it('renders percentage when cache_hit_rate is a valid number', async () => {
+    getSyncDiagnostics.mockResolvedValue(makeDiag({ cache_hit_rate: 0.85 }));
+    getSyncStatus.mockResolvedValue(makeStatus());
+
+    render(<SyncDiagnosticsDialog open={true} onClose={vi.fn()} />);
+
+    const label = await screen.findByText('Cache Hit Rate');
+    const row = label.closest('.sync-diag-kv');
+    const value = row?.querySelector('.sync-diag-kv-value');
+    expect(value?.textContent).toBe('85.0%');
+  });
+});

--- a/taxonomy-editor/src/renderer/components/sync/SyncDiagnosticsDialog.tsx
+++ b/taxonomy-editor/src/renderer/components/sync/SyncDiagnosticsDialog.tsx
@@ -274,7 +274,7 @@ function ConnectionStatusSection({
       </KV>
       {diag.mode === 'github-api' && (
         <>
-          <KV label="Cache Hit Rate">{diag.cache_hit_rate != null ? `${(diag.cache_hit_rate * 100).toFixed(1)}%` : '--'}</KV>
+          <KV label="Cache Hit Rate">{typeof diag.cache_hit_rate === 'number' ? `${(diag.cache_hit_rate * 100).toFixed(1)}%` : '--'}</KV>
           <KV label="Cached Files">{diag.cache_file_count ?? '--'}</KV>
           <KV label="Circuit Breaker">
             <StatusDot ok={diag.circuit_state === 'closed'} />{' '}


### PR DESCRIPTION
## Summary
- `SyncDiagnosticsDialog.tsx:277`: replaced `diag.cache_hit_rate != null` with `typeof diag.cache_hit_rate === 'number'` — prevents `.toFixed()` crash when server delivers a string
- Adds `SyncDiagnosticsDialog.test.tsx` with 2 cases: string value → `--`, numeric value → `85.0%`

Part of the renderer-wide `typeof === 'number'` guard sweep (t/2999 / t/1243 class).

## Test plan
- [x] `npx vitest run src/renderer/components/sync/SyncDiagnosticsDialog.test.tsx` — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)