### PR TITLE
fix(situations): guard divergence with typeof to prevent toFixed crash (t/2994, t/2996)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/SituationListItem.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationListItem.test.tsx
@@ -36,4 +36,21 @@ describe('SituationListItem', () => {
     expect(container.querySelector('.node-item-divergence.high')).toBeTruthy();
     expect(screen.getByText('0.55')).toBeTruthy();
   });
+
+  // t/2996 regression: string divergence from JSON must not crash (t/2994 failure class)
+  it('does not render divergence badge when divergence is a string (t/2996)', () => {
+    const { container } = render(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <SituationListItem id="sit-5" label="String div" isSelected={false} onSelect={() => {}} divergence={'0.5' as any} />,
+    );
+    expect(container.querySelector('.node-item-divergence')).toBeNull();
+  });
+
+  it('renders divergence badge with correct formatted value for numeric divergence', () => {
+    const { container } = render(
+      <SituationListItem id="sit-6" label="Num div" isSelected={false} onSelect={() => {}} divergence={0.3} />,
+    );
+    expect(container.querySelector('.node-item-divergence.medium')).toBeTruthy();
+    expect(screen.getByText('0.30')).toBeTruthy();
+  });
 });

--- a/taxonomy-editor/src/renderer/components/debate/SituationListItem.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationListItem.tsx
@@ -38,7 +38,7 @@ export function SituationListItem({ id, label, isSelected, onSelect, indent, rel
       <div className="node-item-id">
         {id}
         {relationship && <span className="node-item-rel">{REL_LABELS[relationship] || relationship}</span>}
-        {divergence != null && (
+        {typeof divergence === 'number' && (
           <span
             className={`node-item-divergence${divergence > 0.4 ? ' high' : divergence >= 0.2 ? ' medium' : ' low'}`}
             title={`Interpretation divergence: ${divergence.toFixed(3)}`}


### PR DESCRIPTION
## Summary

- **t/2994 (FATAL):** `SituationListItem.tsx:41` — change `divergence != null` guard to `typeof divergence === 'number'` so a string value from JSON (`"0.5"`) no longer reaches `.toFixed()` and crashes SituationsTab
- **t/2996 (regression test):** two new tests in `SituationListItem.test.tsx` — string divergence suppresses badge without throwing; numeric divergence renders badge with correct `.toFixed` output
- Same failure class as t/1243

## Test plan

- [x] `SituationListItem.test.tsx` — 6/6 pass locally (4 existing + 2 new)
- [x] Renderer tsc: 0/0 errors
- [x] Self-certified against `/trivial-change` (t/2994) and `/add-test` (t/2996) playbooks

## Fast-track review requested (FATAL prod crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)