### PR TITLE
feat(bridge): coerce interpretation_divergence at situations load boundary (t/3002)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/coerceSituationDivergence.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/coerceSituationDivergence.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const records: Array<Record<string, unknown>> = [];
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: (e: Record<string, unknown>) => records.push(e) }),
+}));
+
+import { coerceSituationDivergence } from './coerceSituationDivergence';
+
+beforeEach(() => { records.length = 0; });
+
+describe('coerceSituationDivergence (t/3002)', () => {
+  it('coerces a numeric string to a number and records a warning', () => {
+    const f = { nodes: [{ id: 'sit-1', interpretation_divergence: '0.52' }] };
+    coerceSituationDivergence(f);
+    expect(f.nodes[0].interpretation_divergence).toBe(0.52);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ type: 'system.error', level: 'warn', component: 'situations-load' });
+    expect(records[0].data).toMatchObject({ nodeId: 'sit-1', value: '0.52', action: 'coerced' });
+  });
+
+  it('strips a non-numeric string to undefined and records a warning naming the node + value', () => {
+    const f = { nodes: [{ id: 'sit-2', interpretation_divergence: 'moderate' }] };
+    coerceSituationDivergence(f);
+    expect(f.nodes[0].interpretation_divergence).toBeUndefined();
+    expect(records[0].data).toMatchObject({ nodeId: 'sit-2', value: 'moderate', action: 'stripped' });
+  });
+
+  it('treats an empty string as non-numeric (stripped, not coerced to 0)', () => {
+    const f = { nodes: [{ id: 'sit-6', interpretation_divergence: '' }] };
+    coerceSituationDivergence(f);
+    expect(f.nodes[0].interpretation_divergence).toBeUndefined();
+    expect(records[0].data).toMatchObject({ action: 'stripped' });
+  });
+
+  it('leaves a real number and absent/undefined values untouched, recording nothing', () => {
+    const f = { nodes: [{ id: 'a', interpretation_divergence: 0.8 }, { id: 'b' }, { id: 'c', interpretation_divergence: undefined }] };
+    coerceSituationDivergence(f);
+    expect(f.nodes[0].interpretation_divergence).toBe(0.8);
+    expect(records).toHaveLength(0);
+  });
+
+  it('passes non-situation input (null / no nodes array) through without throwing', () => {
+    expect(() => coerceSituationDivergence(null)).not.toThrow();
+    expect(coerceSituationDivergence({ foo: 1 })).toEqual({ foo: 1 });
+    expect(records).toHaveLength(0);
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/coerceSituationDivergence.ts
+++ b/taxonomy-editor/src/renderer/bridge/coerceSituationDivergence.ts
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+
+/**
+ * Defense-in-depth at the situations load boundary (t/3002).
+ *
+ * `interpretation_divergence` MUST be a number for the UI — SituationDetail (and others)
+ * call `.toFixed()` on it. A producer mismatch once shipped it as a string, which crashed
+ * the Situations tab silently (t/2994; the 5 bad nodes are corrected by the sibling data
+ * fix, but the load boundary had no validation, so a future mismatch would crash again).
+ *
+ * This coerces at ingest: a numeric string ("0.52") becomes a number; a non-numeric string
+ * ("moderate") is stripped to `undefined`; and any string arrival is recorded so the
+ * mismatch is observable in the flight recorder instead of fatal.
+ *
+ * Mutates the freshly-loaded nodes in place and returns the same reference. Non-situation
+ * inputs (no `nodes` array) pass through untouched, so it is safe to wrap any load result.
+ *
+ * NOTE: the flight-recorder EventType union has no `system.warning` (see
+ * lib/oped/generate.ts and taxonomyDataSlice.ts) — the ticket's "system.warning" is emitted
+ * as the canonical `system.error` + `level: 'warn'`.
+ */
+export function coerceSituationDivergence<T>(file: T): T {
+  const nodes = (file as { nodes?: unknown } | null | undefined)?.nodes;
+  if (!Array.isArray(nodes)) return file;
+
+  for (const node of nodes as Array<Record<string, unknown>>) {
+    if (!node || typeof node !== 'object') continue;
+    const value = node.interpretation_divergence;
+    if (typeof value !== 'string') continue; // already a number, undefined, etc. — leave as-is
+
+    const parsed = Number(value);
+    const coerced = value.trim() !== '' && Number.isFinite(parsed);
+    node.interpretation_divergence = coerced ? parsed : undefined;
+
+    getGlobalRecorder()?.record({
+      type: 'system.error',
+      component: 'situations-load',
+      level: 'warn',
+      message: coerced
+        ? `interpretation_divergence arrived as a numeric string on ${String(node.id ?? '?')}; coerced "${value}" → ${parsed} (t/3002)`
+        : `interpretation_divergence arrived as a non-numeric string on ${String(node.id ?? '?')}; stripped "${value}" (t/3002)`,
+      data: { nodeId: node.id, value, action: coerced ? 'coerced' : 'stripped' },
+    });
+  }
+  return file;
+}

--- a/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useTaxonomyStore/slices/taxonomyDataSlice.ts
@@ -20,6 +20,7 @@ import type {
   TextEditSource,
 } from '../../../types/taxonomy';
 import { interpretationText } from '../../../types/taxonomy';
+import { coerceSituationDivergence } from '../../../bridge/coerceSituationDivergence';
 import {
   povTaxonomyFileSchema,
   crossCuttingFileSchema as situationsFileSchema,
@@ -310,7 +311,7 @@ export const createTaxonomyDataSlice: StateCreator<TaxonomyStore, [], [], Taxono
       set({
         safetyist: saf as PovTaxonomyFile,
         skeptic: skp as PovTaxonomyFile,
-        situations: cc as SituationsFile,
+        situations: coerceSituationDivergence(cc) as SituationsFile, // t/3002: guard interpretation_divergence type at load
         policyRegistry: regData?.policies ?? null,
         backgroundLoading: false,
         embeddingDirty: true,


### PR DESCRIPTION
## Summary
Defense-in-depth follow-up to the t/2994 crash: `interpretation_divergence` arrived as a string and the UI calls `.toFixed()` on it. The sibling data fix corrects the 5 bad nodes, but the load boundary had no validation — a future producer mismatch would crash again silently.

New **`src/renderer/bridge/coerceSituationDivergence.ts`** helper, invoked once at the situations ingest point (`taxonomyDataSlice.ts`, where `loadTaxonomyFile('situations')` becomes the store's situations file):
1. numeric string (`"0.52"`) → number `0.52`
2. non-numeric string (`"moderate"`, `""`) → `undefined`
3. any string arrival is recorded to the flight recorder (node id + bad value + action) so mismatches are observable, not fatal

## Placement & deviation notes
- The ticket named `src/renderer/bridge/` — the helper lives there, but it's invoked at the **single ingest chokepoint in the store slice** rather than branching `loadTaxonomyFile` on `pov==='situations'` in **both** bridge impls (web-bridge.ts is at its 1500-line eslint ceiling). One call site, my scope end-to-end.
- The flight-recorder `EventType` union has **no `system.warning`** (documented in `lib/oped/generate.ts`); the ticket's "system.warning" is emitted as the canonical **`system.error` + `level: 'warn'`** (matching `taxonomyDataSlice.ts:298`).

## Test plan
- [x] `coerceSituationDivergence.test.ts` — 5 cases (coerce / strip / empty-string / number+undefined passthrough / non-situation input)
- [x] renderer-tsc 0/0 · eslint 0 errors · vitest 5/5
- [ ] CI green

Closes t/3002

🤖 Generated with [Claude Code](https://claude.com/claude-code)
