### PR TITLE
chore(gitignore): ignore .worktrees/ and .agents/ dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,11 +68,16 @@ research/**/fine_tuned_model/
 research/**/training_corpus*.json
 research/**/results/
 
+# Git worktrees — large checkouts, must not pollute git status
+.worktrees/
+
 # Orca — all runtime artifacts, configs, and generated files
 .orca.yaml
 **/.orca.yaml
 .orca/
 **/.orca/
+.agents/
+**/.agents/
 orca-support/
 roles/
 


### PR DESCRIPTION
Adds ignore rules for `.worktrees/` (git worktree checkouts) and `.agents/` + `**/.agents/` (agent runtime dirs) so linked worktrees and agent scratch dirs stop surfacing as untracked noise in `git status` on the shared checkout.

Lands a change that was stranded **uncommitted on the shared main tree** (DevOps drift alarm r/11#313) via proper PR flow, per owner direction. Content is byte-identical to the stranded diff (blob 666cb2d9..273e3c74). Root-scope file; landing authorized by repo owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)