### PR TITLE
feat(taxonomy): surface Attributes tab in Simple view (t/3003)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
@@ -165,7 +165,7 @@ describe('NodeDetail — Zustand scalar selector regression (t/2142)', () => {
     ).not.toThrow();
   });
 
-  it('shows only Content and Related tabs in simple mode', () => {
+  it('surfaces Content, Related, and Attributes in simple mode; other advanced tabs stay hidden (t/3003)', () => {
     render(
       <NodeDetail
         pov="acc"
@@ -178,7 +178,7 @@ describe('NodeDetail — Zustand scalar selector regression (t/2142)', () => {
     );
     expect(screen.getByRole('button', { name: /content/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /related/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /attributes/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /attributes/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /research/i })).not.toBeInTheDocument();
   });
 

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -128,7 +128,7 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
 
   // Reset to a visible tab when switching to Simple (which hides most tabs).
   useEffect(() => {
-    if (viewMode === 'simple' && activeTab !== 'content' && activeTab !== 'related') {
+    if (viewMode === 'simple' && activeTab !== 'content' && activeTab !== 'related' && activeTab !== 'attributes') {
       setActiveTab('content');
     }
   }, [viewMode]);
@@ -727,11 +727,11 @@ interface NodeDetailTabBarProps {
 }
 
 function NodeDetailTabBar({ activeTab, setActiveTab, conflictCount, cruxCount, factCount, editHistoryLength, viewMode }: NodeDetailTabBarProps) {
-  // Content + Related always show; the rest are Advanced-only (t/2120).
+  // Content + Related + Attributes always show; the rest are Advanced-only (t/2120, t/3003).
   const tabs: { id: NodeDetailTabId; label: string; advanced?: boolean }[] = [
     { id: 'content', label: 'Content' },
     { id: 'related', label: 'Related' },
-    { id: 'attributes', label: 'Attributes', advanced: true },
+    { id: 'attributes', label: 'Attributes' },
     { id: 'conflicts', label: `Conflicts${conflictCount > 0 ? ` (${conflictCount})` : ''}`, advanced: true },
     { id: 'cruxes', label: `Cruxes${cruxCount > 0 ? ` (${cruxCount})` : ''}`, advanced: true },
     { id: 'phrases', label: 'Phrases', advanced: true },


### PR DESCRIPTION
## Summary
The POV taxonomy Attributes tab was Advanced-only. Two changes in `NodeDetail.tsx`:
1. Remove `advanced: true` from the Attributes tab entry so it renders in Simple view.
2. Exempt `attributes` from the Simple-view tab-reset effect so selecting it does not bounce the user back to Content.

Conflicts / Cruxes / Phrases / Research remain Advanced-only — no regression to Advanced-view access (AC).

## Test plan
- [x] Updated `NodeDetail.test.tsx` simple-mode assertion (Attributes now present; Research still hidden) — NodeDetail + GraphAttributesPanel 8/8
- [x] renderer-tsc 0/0 · eslint 0 errors
- [ ] CI green

Closes t/3003

🤖 Generated with [Claude Code](https://claude.com/claude-code)