### PR TITLE
fix(community): hide submitter usernames on community library cards (t/2992, partial)

### DIFF
--- a/taxonomy-editor/src/renderer/components/community/CommunityLibrary.tsx
+++ b/taxonomy-editor/src/renderer/components/community/CommunityLibrary.tsx
@@ -24,10 +24,6 @@ function cardTitle(item: CommunityItem): string {
   return 'title' in item ? item.title : (item.topic || 'Untitled study');
 }
 
-function cardSubmitter(item: CommunityItem): string | undefined {
-  return (item.community_metadata as { submitted_by_display?: string } | null | undefined)?.submitted_by_display;
-}
-
 function formatDate(iso: string): string {
   if (!iso) return '';
   try {
@@ -71,9 +67,6 @@ function RemoveConfirmPopover({ item, onConfirm, onCancel }: {
       <div className="community-remove-popover-title">Remove from Community Library?</div>
       <div className="community-remove-popover-detail">
         <strong>{cardTitle(item)}</strong>
-        {cardSubmitter(item) && (
-          <span> by {cardSubmitter(item)}</span>
-        )}
       </div>
       <textarea
         className="community-remove-reason"
@@ -123,9 +116,6 @@ function CommunityCard({ item, isAdmin, onCopy, onRemove }: {
         )}
       </div>
       <div className="community-card-meta">
-        {cardSubmitter(item) && (
-          <span>by {cardSubmitter(item)}</span>
-        )}
         <span>{formatDate(item.updated_at || item.created_at)}</span>
         {'phase' in item && item.phase && <span className="community-card-badge">{item.phase}</span>}
         {'mode' in item && item.mode && <span className="community-card-badge">{item.mode}</span>}


### PR DESCRIPTION
## Summary
Privacy (t/2992): community-shared artifacts must not display usernames. Removes both `cardSubmitter()` render sites in `CommunityLibrary.tsx` (the remove-confirm popover and the card meta line) and deletes the now-unused helper. Community library cards no longer render `submitted_by_display`.

## Scope + a finding (this is PARTIAL for t/2992)
`submitted_by_display` is also rendered on **other** community surfaces outside this file/scope, which still leak the username:
- `components/chat/ChatTab.tsx` (L237/L753), `components/chat/ChatTable.tsx` (L295) — **Chat** scope
- `components/debate/DebateTab.tsx` (L1392), `components/debate/DebateTable.tsx` (L494/L557) — **DebateUI** scope

t/2992's AC ("not displayed on community debates, op-eds, or chats") is **not** fully met until those land — flagged to the coordinator/TL for sibling fixes. Admin/moderation views (`AdminReviewPanel`, `CommunityReviewViewer`) intentionally keep attribution (appropriate per the AC).

## Test plan
- [x] `cardSubmitter` fully removed (0 refs) · renderer-tsc 0/0 · eslint 0 errors
- [ ] CI green

Part of t/2992 (do not auto-close — sibling surfaces pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)