### PR TITLE
obs(debate): FR warn on non-numeric divergence prop (t/2995)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/SituationListItem.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationListItem.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { useRef, useEffect } from 'react';
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
 
 const REL_LABELS: Record<string, string> = {
   is_a: 'is a',
@@ -27,6 +28,18 @@ export function SituationListItem({ id, label, isSelected, onSelect, indent, rel
       ref.current.scrollIntoView({ block: 'nearest' });
     }
   }, [isSelected]);
+
+  useEffect(() => {
+    if (divergence != null && typeof divergence !== 'number') {
+      getGlobalRecorder()?.record({
+        type: 'system.error',
+        component: 'SituationListItem',
+        level: 'warn',
+        message: `non-numeric divergence prop suppressed: ${JSON.stringify({ divergence_type: typeof divergence, divergence_value: String(divergence), node_id: id })}`,
+        error: { name: 'TypeError', message: `divergence is ${typeof divergence}, expected number`, stack: undefined },
+      });
+    }
+  }, [divergence, id]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Adds a `useEffect` in `SituationListItem` that fires a flight-recorder `system.error` warn event when a non-numeric `divergence` prop is silently suppressed by the typeof badge guard
- Log payload: `{ divergence_type, divergence_value, node_id }` for future prod diagnoses
- Complements the t/2994 crash fix (#1514, landed) and the t/2998 data-boundary fix (#1517, landed)

## Test plan
- [x] Existing 6 `SituationListItem` tests pass locally (including t/2996 string-divergence regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)