### PR TITLE
privacy(chat): remove submitter username from community Chat surfaces (t/3005)

### DIFF
--- a/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTab.tsx
@@ -234,9 +234,7 @@ function CommunityChatsList({
                 {MODE_LABELS[cc.mode as ChatMode] || cc.mode}
               </span>
             )}
-            {cc.community_metadata?.submitted_by_display && (
-              <span className="chat-community-submitter">{cc.community_metadata.submitted_by_display}</span>
-            )}
+
             <span className="chat-session-item-date">{formatDate(cc.updated_at)}</span>
           </div>
           <div className="chat-community-copy-row">
@@ -748,10 +746,7 @@ function CommunityChatMetaGrid({ metadataExpanded, full, chat }: { metadataExpan
       {chat.community_metadata && (
         <div className="debate-detail-section">
           <h3>Community Info</h3>
-          <div className="debate-detail-meta-row">
-            <span className="debate-detail-label">Shared by:</span>
-            <span>{chat.community_metadata.submitted_by_display}</span>
-          </div>
+
           <div className="debate-detail-meta-row">
             <span className="debate-detail-label">Submitted:</span>
             <span>{formatDate(chat.community_metadata.submitted_at)}</span>

--- a/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
+++ b/taxonomy-editor/src/renderer/components/chat/ChatTable.tsx
@@ -292,11 +292,7 @@ function ChatTableRowCommunity({
       </td>
       <td className="col-title">
         <div className="chat-table-title-text" title={cc.title}>{cc.title}</div>
-        {cc.community_metadata?.submitted_by_display && (
-          <div className="chat-table-title-secondary">
-            by {cc.community_metadata.submitted_by_display}
-          </div>
-        )}
+
       </td>
     </tr>
   );


### PR DESCRIPTION
## Summary
- Remove `submitted_by_display` from `ChatTable` community row title (table view)
- Remove `submitted_by_display` submitter span from `ChatTab` card-list (list view)
- Remove "Shared by:" row from `ChatTab` CommunityInfoSection detail panel

Fixes the community Chat privacy gap identified in t/2992. Admin moderation views are intentionally untouched — attribution is appropriate there.

## Self-cert
Self-certifying under /trivial-change.
Change: Remove submitted_by_display from 3 community Chat display surfaces
Files: ChatTab.tsx, ChatTable.tsx
Lines changed: 3 insertions, 12 deletions
Verify gate: worktree lacks node_modules; CI will verify. Deviations: none beyond missing local node_modules.

## Test plan
- [ ] Community Chat table: no "by <username>" under chat title
- [ ] Community Chat card list: no submitter span between mode badge and date
- [ ] Community Chat detail panel: "Shared by:" row absent from Community Info section
- [ ] My chats / private views: no regression (attribution not shown there either, unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)