### PR TITLE
privacy: remove username display from community debate views (t/2992)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTab.tsx
@@ -1388,10 +1388,6 @@ function CommunityInfoSection({ debate }: { debate: CommunityDebate }) {
     <div className="debate-detail-section">
       <h3>Community Info</h3>
       <div className="debate-detail-meta-row">
-        <span className="debate-detail-label">Shared by:</span>
-        <span>{debate.community_metadata.submitted_by_display}</span>
-      </div>
-      <div className="debate-detail-meta-row">
         <span className="debate-detail-label">Submitted:</span>
         <span>{formatDateLong(debate.community_metadata.submitted_at)}</span>
       </div>

--- a/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/DebateTable.tsx
@@ -491,8 +491,6 @@ export function CommunityTableRow({
     }
   }, [isPhone, cd, onPhoneSelect, onOpen]);
 
-  const submitter = cd.community_metadata?.submitted_by_display;
-
   return (
     <tr
       className={isSelected ? 'selected' : ''}
@@ -554,11 +552,6 @@ export function CommunityTableRow({
         <div className="debate-table-title-text" title={cd.title}>
           {cd.title}
         </div>
-        {submitter && (
-          <div className="debate-table-title-secondary">
-            by {submitter}
-          </div>
-        )}
       </td>
     </tr>
   );

--- a/taxonomy-editor/src/renderer/components/debate/communityFilter.test.ts
+++ b/taxonomy-editor/src/renderer/components/debate/communityFilter.test.ts
@@ -21,10 +21,6 @@ describe('filterCommunityDebates', () => {
     expect(filterCommunityDebates(debates, 'SAFETY').map(d => d.id)).toEqual(['1']);
   });
 
-  it('matches on the submitter display name (participant)', () => {
-    expect(filterCommunityDebates(debates, 'lovelace').map(d => d.id)).toEqual(['2']);
-  });
-
   it('returns an empty list when nothing matches', () => {
     expect(filterCommunityDebates(debates, 'zzz-no-match')).toHaveLength(0);
   });

--- a/taxonomy-editor/src/renderer/components/debate/communityFilter.ts
+++ b/taxonomy-editor/src/renderer/components/debate/communityFilter.ts
@@ -12,7 +12,6 @@ export function filterCommunityDebates(debates: CommunityDebate[], query: string
   const q = query.trim().toLowerCase();
   if (!q) return debates;
   return debates.filter(cd =>
-    (cd.title ?? '').toLowerCase().includes(q) ||
-    (cd.community_metadata?.submitted_by_display?.toLowerCase().includes(q) ?? false)
+    (cd.title ?? '').toLowerCase().includes(q)
   );
 }


### PR DESCRIPTION
## Summary
- **DebateTable.tsx** — remove `const submitter` + `{submitter && ...}` "by {submitter}" secondary title line
- **DebateTab.tsx** — remove "Shared by:" row from `CommunityInfoSection` (Submitted/Approved dates retained)
- **communityFilter.ts** — remove `submitted_by_display` from search predicate; title-only search remains
- **communityFilter.test.ts** — remove now-defunct submitter-name search test (capability intentionally removed)

## Test plan
- [x] 95/95 debate component tests pass locally (18 test files)
- [x] No regression to private views (submitter field only appeared in community_metadata context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)