### PR TITLE
fix(ci): fix Pester ExcludePath wildcard for data-compliance (t/3008)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
           $config.Run.Path = './tests/'
           # Live-data SituationBDI compliance decoupled to compliance-live.yml
           # (t/2331, t/2324#1): data-corpus state must not block code PRs.
-          $config.Run.ExcludePath = @('./tests/data-compliance/')
+          $config.Run.ExcludePath = @('*/data-compliance/*')
           $config.Output.Verbosity = 'Detailed'
           $config.Run.Exit = $true
           $config.CodeCoverage.Enabled = $true


### PR DESCRIPTION
## Summary
- `ExcludePath = @('./tests/data-compliance/')` is ineffective: Pester matches ExcludePath against full resolved paths, so the `./`-relative prefix never matches, letting live-data BDI tests run in the required `test-powershell` lane and red whenever the corpus grows past the hardcoded baseline.
- Fix: `'*/data-compliance/*'` matches anywhere in the resolved path, reliably excluding the directory from ci.yml while compliance-live.yml continues to own it.

## Test plan
- [ ] Both-arms GV by TL (t/3007): fail arm — data-compliance test fires the exclusion and does NOT run in test-powershell; pass arm — all other Pester tests still run and pass with zero noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)