### PR TITLE
feat(compliance): Test-SituationBdiCompliance data-boundary gate validator (t/3011)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -25,6 +25,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Repair-SituationReciprocity` | Reconcile situation `linked_nodes` ⇄ POV-node `situation_refs` so the two directions are mutual (t/2979); a dry-run-first RECOVERY tool, clean-tree-required, no commit/push. Use when the reciprocity check flags drift |
 | `Test-TaxonomyDir` | Pre-validate the taxonomy dir against the embed_taxonomy.py loader contract before `Update-TaxEmbeddings` — reports which files would be ingested vs skipped and flags any ingested file whose `nodes` lack `id` (the shape that crashes the embed run, t/2875) |
 | `Test-OntologyCompliance` | Check nodes against ontology rules |
+| `Test-SituationBdiCompliance` | Data-boundary gate validator: assert situations carry full per-POV BDI decomposition (belief+desire+intention across acc/saf/skp). `-ChangedOnly -BaseRef <ref>` scopes to new/modified situations vs a git baseline; `-FailOnViolation` throws (non-zero exit) for CI/hook gate use (t/3011) |
 | `Get-NodeTestingRecord` | Debate-Tested Phase 2 research surface — filter/sort POV nodes by tier, stale-hash, or importance×deficit (t/1579) |
 | `Update-NodeTestingRecord -RecomputeOnly` | Recompute tier + sort_key across all nodes after a constant change; historical record[] never touched; idempotent (t/1579) |
 

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -90,6 +90,7 @@
         'Show-DebateHarvest'
         'Get-AITSBOM'
         'Test-OntologyCompliance'
+        'Test-SituationBdiCompliance'
         'Get-RelevantTaxonomyNodes'
         'Invoke-QbafConflictAnalysis'
         'Test-ExtractionQuality'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -833,6 +833,8 @@ Export-ModuleMember -Function @(
     'Repair-DebateOutput'
     'Get-AITSBOM'
     'Test-OntologyCompliance'
+    # t/3011 — data-boundary gate validator for situation per-POV BDI decomposition
+    'Test-SituationBdiCompliance'
     'Get-RelevantTaxonomyNodes'
     'Invoke-QbafConflictAnalysis'
     'Test-ExtractionQuality'

--- a/scripts/AITriad/Private/Get-ChangedSituationId.ps1
+++ b/scripts/AITriad/Private/Get-ChangedSituationId.ps1
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-ChangedSituationId {
+    <#
+    .SYNOPSIS
+        Return the ids of situation nodes new-or-modified vs a git baseline ref (t/3011).
+    .DESCRIPTION
+        Support helper for Test-SituationBdiCompliance -ChangedOnly. Compares the
+        situations.json content at -BaseRef against the current on-disk file (passed
+        pre-parsed as -CurrentNodes) and returns the ids whose serialized content is
+        new or changed. Deleted ids are ignored — the validator only cares about
+        situations that are landing.
+
+        Returns $null (not an empty array) when the baseline cannot be resolved — not
+        a git work tree, git unavailable, or -BaseRef is not a real commit (shallow
+        checkout, all-zero first-push SHA). The caller treats $null as "fail safe:
+        validate the full corpus". An empty array means "baseline resolved, nothing
+        changed".
+
+        git is invoked with `-C <dir>` and cwd = the file's directory so the colon
+        revspec uses a repo-relative `./<leaf>` path — avoiding the MSYS path-conversion
+        quirk that mangles absolute Windows paths in git's pathspec/revspec parser
+        (see "Git Forensics" in root AGENTS.md). Runs from pwsh, so no MSYS arg
+        mangling applies at call time.
+    .PARAMETER SituationsPath
+        Path to the on-disk situations.json (its directory locates the git work tree).
+    .PARAMETER BaseRef
+        Baseline git ref to diff against.
+    .PARAMETER CurrentNodes
+        The already-parsed current situation node array (from the on-disk file).
+    .OUTPUTS
+        [string[]] of changed situation ids, or $null if the baseline is unresolvable.
+    #>
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$SituationsPath,
+
+        [Parameter(Mandatory)]
+        [string]$BaseRef,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]]$CurrentNodes
+    )
+
+    Set-StrictMode -Version Latest
+
+    $dir  = Split-Path -Parent $SituationsPath
+    $leaf = Split-Path -Leaf   $SituationsPath
+
+    # Baseline must be a real commit in a git work tree, else fail safe (-> $null).
+    $null = & git -C $dir rev-parse --verify --quiet "$BaseRef^{commit}" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Verbose "Get-ChangedSituationId: baseline '$BaseRef' does not resolve to a commit in '$dir' — returning null (fail-safe full scan)."
+        return $null
+    }
+
+    # File content at the baseline. A miss (file absent at BaseRef) means every
+    # current situation is new — return all current ids.
+    $baseText = & git -C $dir show "${BaseRef}:./$leaf" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Verbose "Get-ChangedSituationId: '$leaf' absent at '$BaseRef' — treating all current situations as new."
+        return @($CurrentNodes | Where-Object { $_.PSObject.Properties['id'] } | ForEach-Object { [string]$_.id })
+    }
+
+    try {
+        $baseJson = (@($baseText) -join "`n") | ConvertFrom-Json
+    }
+    catch {
+        # Baseline file present but unparseable — fail safe to full scan.
+        Write-Verbose "Get-ChangedSituationId: situations.json at '$BaseRef' did not parse — returning null (fail-safe full scan)."
+        return $null
+    }
+
+    $baseMap = @{}
+    if ($baseJson.PSObject.Properties['nodes']) {
+        foreach ($n in @($baseJson.nodes)) {
+            if ($n.PSObject.Properties['id']) {
+                $baseMap[[string]$n.id] = ($n | ConvertTo-Json -Depth 30 -Compress)
+            }
+        }
+    }
+
+    $changed = [System.Collections.Generic.List[string]]::new()
+    foreach ($n in @($CurrentNodes)) {
+        if (-not $n.PSObject.Properties['id']) { continue }
+        $id  = [string]$n.id
+        $cur = $n | ConvertTo-Json -Depth 30 -Compress
+        if (-not $baseMap.ContainsKey($id) -or $baseMap[$id] -ne $cur) {
+            $changed.Add($id)
+        }
+    }
+    return $changed.ToArray()
+}

--- a/scripts/AITriad/Public/Test-SituationBdiCompliance.ps1
+++ b/scripts/AITriad/Public/Test-SituationBdiCompliance.ps1
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Test-SituationBdiCompliance {
+    <#
+    .SYNOPSIS
+        Gate validator: assert situation nodes carry full per-POV BDI decomposition (t/3011).
+    .DESCRIPTION
+        Layer A of the INCIDENT-B prevention (t/3007 / t/3011). Situations can enter
+        `ai-triad-data` through paths that never call a PowerShell cmdlet — a bulk raw
+        `git commit` of "sync pipeline outputs" (78c943cf), the taxonomy-editor
+        workflow-app, or ad-hoc session generation — so the cmdlet-side write guard
+        (Set-SituationBdiInterpretation, t/2332) cannot catch them. The only choke
+        point every path crosses is the commit into the data repo; this cmdlet is the
+        validation core a data-boundary gate (Layer B, DevOps) invokes there.
+
+        Reuses the pure classifier `Test-SituationBdiDecomposition` (t/2332): every
+        non-deprecated situation must carry an interpretations block where
+        {accelerationist, safetyist, skeptic} each hold a nested object with a
+        non-empty belief + desire + intention. A situation whose description begins
+        '[DEPRECATED]' is exempt (CL, t/1312#2).
+
+        With -ChangedOnly the cmdlet validates only situation nodes that are new or
+        modified relative to -BaseRef (default HEAD), computed by diffing the parsed
+        situations.json at that ref against the on-disk file. This keeps the gate fast
+        and scoped to new regressions rather than pre-existing corpus state (TL
+        condition t/3011#2). If the baseline ref cannot be resolved (shallow checkout,
+        all-zero first-push SHA, not a git tree) the cmdlet FAILS SAFE and validates
+        the full corpus, emitting a warning.
+
+        Exit-code semantics: the cmdlet always returns a result object. With
+        -FailOnViolation it additionally throws a New-ActionableError on any violation
+        so a `pwsh -Command '... -FailOnViolation'` gate step exits non-zero. Omit the
+        switch for the warn-first (non-blocking) promotion phase.
+    .PARAMETER SituationsPath
+        Path to situations.json. Defaults to `<Get-TaxonomyDir>/situations.json`
+        (honors $env:AI_TRIAD_DATA_ROOT).
+    .PARAMETER ChangedOnly
+        Validate only situation nodes new-or-modified vs -BaseRef, instead of the
+        whole corpus.
+    .PARAMETER BaseRef
+        Baseline git ref for -ChangedOnly (default 'HEAD'). In push CI, pass the
+        previous tip (e.g. the push event's before-SHA, or HEAD~1).
+    .PARAMETER FailOnViolation
+        Throw a New-ActionableError (non-zero exit) if any validated situation fails.
+    .OUTPUTS
+        [pscustomobject] with Pass, Scope ('Changed'|'Full'), Checked, NonDeprecated,
+        Fail, NonDecomposedIds, EmptyIds, ViolationIds, Detail.
+    .EXAMPLE
+        Test-SituationBdiCompliance
+        # Full-corpus check against the resolved data root; returns a result object.
+    .EXAMPLE
+        Test-SituationBdiCompliance -ChangedOnly -BaseRef HEAD~1 -FailOnViolation
+        # Blocking data-boundary gate: throws if a newly-added situation is not decomposed.
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Test-OntologyCompliance
+    .LINK
+        Set-SituationBdiInterpretation
+    #>
+    [CmdletBinding()]
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter()]
+        [string]$SituationsPath,
+
+        [switch]$ChangedOnly,
+
+        [Parameter()]
+        [string]$BaseRef = 'HEAD',
+
+        [switch]$FailOnViolation
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    if (-not $SituationsPath) {
+        $SituationsPath = Join-Path (Get-TaxonomyDir) 'situations.json'
+    }
+    if (-not (Test-Path -LiteralPath $SituationsPath)) {
+        New-ActionableError `
+            -Goal 'Validate situation per-POV BDI decomposition' `
+            -Problem "situations.json not found: $SituationsPath" `
+            -Location 'Test-SituationBdiCompliance' `
+            -NextSteps @(
+                'Pass -SituationsPath explicitly, or set $env:AI_TRIAD_DATA_ROOT to the ai-triad-data checkout.',
+                'Confirm the data repo is checked out at the expected path.'
+            ) `
+            -Throw
+    }
+
+    $TaxData = Get-Content -Raw -LiteralPath $SituationsPath | ConvertFrom-Json
+    if (-not $TaxData.PSObject.Properties['nodes']) {
+        New-ActionableError `
+            -Goal 'Validate situation per-POV BDI decomposition' `
+            -Problem "situations.json has no 'nodes' array: $SituationsPath" `
+            -Location 'Test-SituationBdiCompliance' `
+            -NextSteps @('Confirm the file is a taxonomy situations file (expects a top-level `nodes` array).') `
+            -Throw
+    }
+    $AllNodes = @($TaxData.nodes)
+
+    $Scope        = 'Full'
+    $NodesToCheck = $AllNodes
+
+    if ($ChangedOnly) {
+        $ChangedIds = Get-ChangedSituationId -SituationsPath $SituationsPath -BaseRef $BaseRef -CurrentNodes $AllNodes
+        if ($null -eq $ChangedIds) {
+            Write-Warning "Test-SituationBdiCompliance: could not resolve baseline '$BaseRef' for $SituationsPath — validating the full corpus (fail-safe). Ensure the git history has depth >= 2 (e.g. actions/checkout fetch-depth: 2)."
+        }
+        else {
+            $Scope   = 'Changed'
+            $IdSet   = [System.Collections.Generic.HashSet[string]]::new([string[]]@($ChangedIds))
+            $NodesToCheck = @($AllNodes | Where-Object {
+                $_.PSObject.Properties['id'] -and $IdSet.Contains([string]$_.id)
+            })
+        }
+    }
+
+    $R = Test-SituationBdiDecomposition -Node $NodesToCheck
+
+    $ViolationIds = @(@($R.NonDecomposedIds) + @($R.EmptyIds))
+    $Pass = ($R.Fail -eq 0)
+
+    if ($Pass) {
+        $Detail = "$($R.Pass) / $($R.NonDeprecated) $Scope-scope non-deprecated situation(s) carry full per-POV BDI decomposition ($($R.Deprecated) exempt via [DEPRECATED] prefix)."
+    }
+    else {
+        $Detail = "$($R.Fail) $Scope-scope situation(s) fail per-POV BDI decomposition — $($R.NonDecomposed) non-decomposed, $($R.Empty) missing the interpretations block: $($ViolationIds -join ', '). Each of accelerationist/safetyist/skeptic must carry a non-empty belief + desire + intention."
+    }
+
+    $Result = [pscustomobject][ordered]@{
+        Pass             = $Pass
+        Scope            = $Scope
+        Checked          = @($NodesToCheck).Count
+        NonDeprecated    = $R.NonDeprecated
+        Fail             = $R.Fail
+        NonDecomposedIds = @($R.NonDecomposedIds)
+        EmptyIds         = @($R.EmptyIds)
+        ViolationIds     = $ViolationIds
+        Detail           = $Detail
+    }
+
+    if ($FailOnViolation -and -not $Pass) {
+        New-ActionableError `
+            -Goal 'Block a data-repo change that introduces a non-decomposed situation' `
+            -Problem $Detail `
+            -Location 'Test-SituationBdiCompliance' `
+            -NextSteps @(
+                "Decompose the flagged situation(s) into per-POV BDI before pushing: run enrichment.situation-bdi-decomposition via Invoke-AIByUsage, or Set-SituationBdiInterpretation, for each id.",
+                "Flagged ids: $($ViolationIds -join ', ')",
+                'Re-run Test-SituationBdiCompliance -ChangedOnly to confirm clean before committing.'
+            ) `
+            -Throw
+    }
+
+    return $Result
+}

--- a/tests/Test-SituationBdiCompliance.Tests.ps1
+++ b/tests/Test-SituationBdiCompliance.Tests.ps1
@@ -1,0 +1,183 @@
+# Tag: taxonomy (t/3011)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Gate tests for Test-SituationBdiCompliance — the Layer A validation core of the
+    INCIDENT-B data-boundary prevention (t/3007 / t/3011).
+.NOTES
+    Both-arms coverage (TL GV condition t/3011#2):
+      - a deliberately non-decomposed situation FIRES the gate (Pass=false; and
+        -FailOnViolation throws);
+      - a clean corpus passes SILENT (Pass=true; -FailOnViolation does not throw).
+    Plus -ChangedOnly scoping against a real temp git repo: only new/modified
+    situations are validated; a pre-existing non-decomposed node that is untouched is
+    NOT re-flagged; an unresolvable baseline fails safe to a full scan.
+
+    All tests pass -SituationsPath at a $TestDrive fixture so they never touch the
+    live ai-triad-data corpus.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+
+    # Production-shaped node fragments (parsed exactly like situations.json nodes).
+    $script:CleanNode1 = @'
+{ "id": "sit-clean-1", "description": "A clean, fully decomposed situation with a sufficiently long description.",
+  "interpretations": {
+    "accelerationist": { "belief": "acc belief", "desire": "acc desire", "intention": "acc intention" },
+    "safetyist":       { "belief": "saf belief", "desire": "saf desire", "intention": "saf intention" },
+    "skeptic":         { "belief": "skp belief", "desire": "skp desire", "intention": "skp intention" } } }
+'@
+    $script:CleanNode2 = @'
+{ "id": "sit-clean-2", "description": "A second clean, fully decomposed situation with a long-enough description.",
+  "interpretations": {
+    "accelerationist": { "belief": "b", "desire": "d", "intention": "i" },
+    "safetyist":       { "belief": "b", "desire": "d", "intention": "i" },
+    "skeptic":         { "belief": "b", "desire": "d", "intention": "i" } } }
+'@
+    # Legacy flat-string interpretations — the exact non-decomposed shape 78c943cf shipped.
+    $script:BadNode = @'
+{ "id": "sit-bad-1", "description": "A non-decomposed situation carrying legacy flat-string interpretations.",
+  "interpretations": {
+    "accelerationist": "accelerationists welcome this",
+    "safetyist":       "safetyists worry about this",
+    "skeptic":         "skeptics doubt this" } }
+'@
+    $script:DepNode = @'
+{ "id": "sit-dep-1", "description": "[DEPRECATED] superseded situation, exempt from the check.",
+  "interpretations": {} }
+'@
+
+    function script:Write-SitFixture {
+        param([Parameter(Mandatory)][string]$Path, [Parameter(Mandatory)][string[]]$NodeJson)
+        $body = '{ "nodes": [ ' + ($NodeJson -join ",`n") + ' ] }'
+        Set-Content -LiteralPath $Path -Value $body -Encoding utf8
+    }
+}
+
+Describe 'Test-SituationBdiCompliance — full-corpus validation (t/3011)' -Tag 'taxonomy' {
+
+    It 'CLEAN arm: a fully-decomposed corpus passes silent (Pass=true, Fail=0)' {
+        $f = Join-Path $TestDrive 'clean.json'
+        script:Write-SitFixture -Path $f -NodeJson @($script:CleanNode1, $script:CleanNode2, $script:DepNode)
+        $r = Test-SituationBdiCompliance -SituationsPath $f
+        $r.Pass | Should -BeTrue
+        $r.Fail | Should -Be 0
+        $r.Scope | Should -Be 'Full'
+        $r.NonDeprecated | Should -Be 2
+        $r.Detail | Should -Match 'carry full per-POV BDI decomposition'
+    }
+
+    It 'FIRES arm: a non-decomposed situation fails (Pass=false; flagged id surfaced)' {
+        $f = Join-Path $TestDrive 'dirty.json'
+        script:Write-SitFixture -Path $f -NodeJson @($script:CleanNode1, $script:BadNode)
+        $r = Test-SituationBdiCompliance -SituationsPath $f
+        $r.Pass | Should -BeFalse
+        $r.Fail | Should -Be 1
+        $r.ViolationIds | Should -Contain 'sit-bad-1'
+        $r.NonDecomposedIds | Should -Contain 'sit-bad-1'
+    }
+
+    It '-FailOnViolation THROWS on a dirty corpus (non-zero exit for the gate)' {
+        $f = Join-Path $TestDrive 'dirty2.json'
+        script:Write-SitFixture -Path $f -NodeJson @($script:CleanNode1, $script:BadNode)
+        { Test-SituationBdiCompliance -SituationsPath $f -FailOnViolation } | Should -Throw
+    }
+
+    It '-FailOnViolation does NOT throw on a clean corpus (silent pass)' {
+        $f = Join-Path $TestDrive 'clean2.json'
+        script:Write-SitFixture -Path $f -NodeJson @($script:CleanNode1, $script:CleanNode2)
+        { Test-SituationBdiCompliance -SituationsPath $f -FailOnViolation } | Should -Not -Throw
+        # Capture separately (assignment inside a Should scriptblock does not escape its scope).
+        $r = Test-SituationBdiCompliance -SituationsPath $f -FailOnViolation
+        $r.Pass | Should -BeTrue
+    }
+
+    It 'exempts a [DEPRECATED] situation from the non-deprecated set' {
+        $f = Join-Path $TestDrive 'dep.json'
+        script:Write-SitFixture -Path $f -NodeJson @($script:CleanNode1, $script:DepNode)
+        $r = Test-SituationBdiCompliance -SituationsPath $f
+        $r.Pass | Should -BeTrue
+        $r.NonDeprecated | Should -Be 1
+    }
+
+    It 'throws an ActionableError when situations.json is missing' {
+        $missing = Join-Path $TestDrive 'nope.json'
+        { Test-SituationBdiCompliance -SituationsPath $missing } |
+            Should -Throw -ExpectedMessage '*situations.json not found*'
+    }
+}
+
+Describe 'Test-SituationBdiCompliance — -ChangedOnly git-baseline scoping (t/3011)' -Tag 'taxonomy' {
+
+    # git is a hard repo/CI dependency, so these run unconditionally (no discovery-time
+    # skip — a -Skip computed in BeforeAll evaluates as $null at discovery and skips all).
+    BeforeAll {
+        function script:New-DataRepo {
+            param([Parameter(Mandatory)][string]$Name, [Parameter(Mandatory)][string[]]$BaselineNodes)
+            $repo = Join-Path $TestDrive $Name
+            New-Item -ItemType Directory -Path $repo -Force | Out-Null
+            & git -C $repo init -q
+            & git -C $repo config user.email 'test@example.com'
+            & git -C $repo config user.name  'Test'
+            $sit = Join-Path $repo 'situations.json'
+            script:Write-SitFixture -Path $sit -NodeJson $BaselineNodes
+            & git -C $repo add situations.json
+            & git -C $repo commit -qm 'baseline'
+            return $sit
+        }
+    }
+
+    It 'validates ONLY the newly-added situation, not untouched pre-existing nodes' {
+        # Baseline: two clean nodes committed. Then add a bad node (new).
+        $sit = script:New-DataRepo -Name 'repo-add' -BaselineNodes @($script:CleanNode1, $script:CleanNode2)
+        script:Write-SitFixture -Path $sit -NodeJson @($script:CleanNode1, $script:CleanNode2, $script:BadNode)
+        $r = Test-SituationBdiCompliance -SituationsPath $sit -ChangedOnly -BaseRef HEAD
+        $r.Scope   | Should -Be 'Changed'
+        $r.Checked | Should -Be 1
+        $r.Pass    | Should -BeFalse
+        $r.ViolationIds | Should -Contain 'sit-bad-1'
+    }
+
+    It 'does NOT re-flag a pre-existing non-decomposed node that is untouched' {
+        # Baseline already contains a bad node. Add a NEW clean node only.
+        $sit = script:New-DataRepo -Name 'repo-preexisting' -BaselineNodes @($script:CleanNode1, $script:BadNode)
+        script:Write-SitFixture -Path $sit -NodeJson @($script:CleanNode1, $script:BadNode, $script:CleanNode2)
+        $r = Test-SituationBdiCompliance -SituationsPath $sit -ChangedOnly -BaseRef HEAD
+        $r.Scope   | Should -Be 'Changed'
+        $r.Checked | Should -Be 1          # only sit-clean-2 (the added node)
+        $r.Pass    | Should -BeTrue        # the pre-existing bad node is out of scope
+    }
+
+    It 'flags a pre-existing node MODIFIED into a non-decomposed state' {
+        # Baseline: clean node. Then rewrite that same id to a flat-string shape.
+        $sit = script:New-DataRepo -Name 'repo-modify' -BaselineNodes @($script:CleanNode1, $script:CleanNode2)
+        $mutated = $script:CleanNode1 -replace '(?s)"interpretations".*', '"interpretations": { "accelerationist": "x", "safetyist": "y", "skeptic": "z" } }'
+        script:Write-SitFixture -Path $sit -NodeJson @($mutated, $script:CleanNode2)
+        $r = Test-SituationBdiCompliance -SituationsPath $sit -ChangedOnly -BaseRef HEAD
+        $r.Pass | Should -BeFalse
+        $r.ViolationIds | Should -Contain 'sit-clean-1'
+    }
+
+    It 'passes clean when only a compliant node is added' {
+        $sit = script:New-DataRepo -Name 'repo-cleanadd' -BaselineNodes @($script:CleanNode1)
+        script:Write-SitFixture -Path $sit -NodeJson @($script:CleanNode1, $script:CleanNode2)
+        $r = Test-SituationBdiCompliance -SituationsPath $sit -ChangedOnly -BaseRef HEAD
+        $r.Scope | Should -Be 'Changed'
+        $r.Pass  | Should -BeTrue
+    }
+
+    It 'fails safe to a FULL scan (with a warning) when the baseline ref is unresolvable' {
+        $sit = script:New-DataRepo -Name 'repo-badref' -BaselineNodes @($script:CleanNode1, $script:BadNode)
+        # Rewrite working copy (irrelevant here) and use a ref that does not exist.
+        $r = Test-SituationBdiCompliance -SituationsPath $sit -ChangedOnly -BaseRef 'no-such-ref' -WarningAction SilentlyContinue
+        $r.Scope | Should -Be 'Full'      # fell back to full corpus
+        $r.Pass  | Should -BeFalse        # full scan sees the pre-existing bad node
+        $r.ViolationIds | Should -Contain 'sit-bad-1'
+    }
+}


### PR DESCRIPTION
## Layer A — situation BDI data-boundary gate validator (t/3011)

INCIDENT-B prevention (t/3007). Design approved by TL at t/3011#2; **routed to Main (TL) for review** as the gate's validation core (producer↔gate alignment).

### Why
The cmdlet-side write guard (`Set-SituationBdiInterpretation`, t/2332) is fail-closed, but the three baseline regressions (sit-448–470, 471–475, 476/477) all entered `ai-triad-data` through paths that **never call a cmdlet** — the bulk raw-commit "sync pipeline outputs" (78c943cf), the workflow-app, ad-hoc session gen. The only choke point every path crosses is the commit into the data repo. This cmdlet is what DevOps wires into a data-boundary gate there (Layer B).

### What
- **`Test-SituationBdiCompliance`** (public) — reuses the pure classifier `Test-SituationBdiDecomposition` (t/2332).
  - `-ChangedOnly -BaseRef <ref>` — validate only situations new/modified vs a git baseline (new regressions, not pre-existing corpus — TL condition #4). **Fails safe** to a full scan (with a warning) when the baseline is unresolvable (shallow checkout / all-zero first-push SHA).
  - `-FailOnViolation` — throws `New-ActionableError` (non-zero exit) for the blocking arm; omit for warn-first. Same call, flip the switch.
- **`Get-ChangedSituationId`** (private) — content-diffs situations.json at `-BaseRef` vs on-disk; MSYS-safe git invocation.
- Registered in `AITriad.psm1` + `AITriad.psd1`; catalogued in `docs/cmdlet-reference.md`.

### Interface contract for Layer B
Full DevOps wiring contract at **t/3011#5** (params, warn→block sequence, ubuntu caveats incl. `fetch-depth: 2`). DevOps has wired against it (p/169).

### Tests (both-arms GV, TL condition #3)
`tests/Test-SituationBdiCompliance.Tests.ps1` — 11 cases, all green:
- **FIRES:** a non-decomposed situation fails; `-FailOnViolation` throws.
- **CLEAN:** a decomposed corpus passes silent; `-FailOnViolation` does not throw.
- `-ChangedOnly` scoping against a real temp git repo: only new/modified validated; a pre-existing bad-but-untouched node is **not** re-flagged; a node modified into a bad state **is** flagged; unresolvable ref → fail-safe full scan.

Local: new suite + existing `Test-OntologyCompliance.SituationBDI.Tests.ps1` green (23/0/0); `Test-ModuleManifest` passes. Followed `/add-ps-cmdlet` (deviation: TL pre-approved the read-only git-diff scoping).

Closes t/3011 Layer A. Layer B (DevOps) blocking promotion remains gated on t/3009 corpus-clean + TL both-arms GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
