### PR TITLE
fix(oped): fail a voice whose AI response is empty instead of blank-complete (t/3013)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -260,6 +260,16 @@ async function runVoiceGeneration(
     signal: request.signal,
   });
 
+  // t/3013: an empty AI response comes back as '' WITHOUT throwing — e.g. Gemini returns a
+  // candidate with empty/absent text parts on a safety block or certain truncations, and
+  // generateViaGemini joins those to ''. Left unguarded, JSON.parse('') below fails into the
+  // raw-text fallback, so the voice returns status:'complete' with an empty body — the blank
+  // op-ed tab with no error state. Throw here so runVoice's catch marks the voice failed and
+  // emits voice_failed (which the OpEdArticle failed-state notice then renders).
+  if (!rawText.trim()) {
+    throw new Error(`Voice generation returned empty response (pov=${pov})`);
+  }
+
   let parsed: EssayResponse;
   try {
     parsed = JSON.parse(stripCodeFences(rawText)) as EssayResponse;

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -525,3 +525,53 @@ describe('generateOpEdSet — reflection retry-on-empty (t/2919)', () => {
     expect(member?.claims?.length).toBe(1);
   });
 });
+
+// ── Empty voice response → failed, not blank-complete (t/3013) ────────────────
+// An empty AI response ('' — Gemini can return a candidate with empty/absent text parts on a
+// safety block or certain truncations, which generateViaGemini joins to '') previously fell
+// through JSON.parse('') into the raw-text fallback, so the voice finalized status:'complete'
+// with an empty body — a blank op-ed tab with no error state. runVoiceGeneration's empty-text
+// guard now throws, so runVoice marks the voice failed and emits voice_failed.
+describe('generateOpEdSet — empty voice response finalizes as failed, not blank-complete (t/3013)', () => {
+  it('a voice whose essay comes back empty yields voice_failed + status:failed; other voices unaffected', async () => {
+    let essayCall = 0;
+    const adapter = {
+      // Reflection calls use the 'refl' prompt (mocked) and don't increment the essay counter,
+      // so essayCall maps 1:1 to voices in request.povs order → the 2nd voice (safetyist) gets ''.
+      generateText: async (prompt: string) => {
+        if (prompt === 'refl') return JSON.stringify({ grounding_usage: [] });
+        essayCall++;
+        if (essayCall === 2) return ''; // safetyist essay comes back empty (empty Gemini candidate)
+        return JSON.stringify({ headline: 'H', subtitle: '', body_markdown: 'Body.', word_count: 1 });
+      },
+    };
+    const req = {
+      set_id: 's-empty', topic: 'AI policy',
+      params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' } as never,
+      povs: ['accelerationist', 'safetyist', 'skeptic'] as PovKey[],
+    };
+    const deps = { adapter: adapter as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT };
+
+    const failed: PovKey[] = [];
+    const completed: PovKey[] = [];
+    let set: OpEdSet | undefined;
+    for await (const ev of generateOpEdSet(req, deps) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_failed') failed.push(ev.pov);
+      if (ev.type === 'voice_complete') completed.push(ev.pov);
+      if (ev.type === 'complete') set = ev.set;
+    }
+
+    // The empty voice now surfaces as a failure (previously a silent empty-complete → blank tab).
+    expect(failed).toEqual(['safetyist']);
+    expect(completed.sort()).toEqual(['accelerationist', 'skeptic']);
+
+    // …and it finalizes in the set as status:'failed' with an empty body — the render layer's
+    // OpEdArticle failed-state notice keys on status !== 'complete', so the tab is no longer blank.
+    const members = set!.opeds as unknown as { pov: string; status: string; body: string }[];
+    expect(members.find(m => m.pov === 'safetyist')?.status).toBe('failed');
+    expect(members.find(m => m.pov === 'safetyist')?.body).toBe('');
+    // Unaffected voices still complete normally.
+    expect(members.find(m => m.pov === 'accelerationist')?.status).toBe('complete');
+    expect(members.find(m => m.pov === 'skeptic')?.status).toBe('complete');
+  });
+});


### PR DESCRIPTION
Fixes t/3013 — op-ed tabs rendering **blank** for failed voices.

## Root cause (confirmed TL t/3013#1, ElectronMain t/3013#2)
An empty AI response (`''`) returns from the adapter **without throwing** (e.g. Gemini returns a candidate with empty/absent text parts on a safety block/truncation; `generateViaGemini` joins to `''`). In `runVoiceGeneration`, unguarded `JSON.parse('')` fell into the raw-text fallback → the voice finalized `status:'complete'` with an empty body. `OpEdArticle`'s failed-state notice keys on `status !== 'complete'`, so a complete-but-empty member rendered as a **blank tab, no error**.

## Fix (lib/oped/generate.ts, +10)
Throw when the response is empty (after trim), so `runVoice`'s existing catch marks the voice `status:'failed'` and emits `voice_failed` — which the existing render notice surfaces. Backend-agnostic (one join point, all providers). No renderer/handler/adapter change needed.

## Regression test (serialGeneration.test.ts, +50, no live AI)
Mock adapter returns `''` for one voice's essay → asserts that voice yields `voice_failed` and finalizes `status:'failed'` with an empty body; the other voices complete normally. Fails on unfixed code (empty voice would emit `voice_complete`), so it genuinely guards the fix.

## Review note
Routed to **Main (TL)** for code review (not design — design/direction was approved at t/3013#1, exact fix specified by ElectronMain t/3013#2). Slightly exceeds /trivial-change's ≤50-line bar only due to the regression test (fix itself is 9 lines). tsc + eslint clean; 22/22 oped suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)