### PR TITLE
test(data-compliance): bump situation BDI live baseline 440->442 (t/3009)

### DIFF
--- a/tests/data-compliance/Test-SituationBDI.LiveData.Tests.ps1
+++ b/tests/data-compliance/Test-SituationBDI.LiveData.Tests.ps1
@@ -26,6 +26,9 @@
       via enrichment.situation-bdi-decomposition, merged with CL sign-off.
     - 435->440 (t/2323): sit-471..475 added with flat-string interpretations; decomposed
       via enrichment.situation-bdi-decomposition.
+    - 440->442 (t/3009): sit-476/477 added by pipeline sync (78c943cf) with flat-string
+      interpretations; CL-authored per-POV BDI decomposition (t/3009#1). Recurring
+      pipeline gap tracked as t/3011 (decompose-on-emit).
     When this trip-wire fires, run the backfill on the flagged ids, then bump the count.
 #>
 
@@ -45,9 +48,9 @@ Describe 'Situation BDI-decomposition live-data baseline (t/1312, relocated t/23
         $script:BdiCheck | Should -Not -BeNullOrEmpty
     }
 
-    It 'Live-data baseline: 440 / 440 non-deprecated situations pass, 1 exempt (post-t/2323 backfill)' {
+    It 'Live-data baseline: 442 / 442 non-deprecated situations pass, 1 exempt (post-t/3009 backfill)' {
         $script:BdiCheck.Status | Should -Be 'pass'
-        $script:BdiCheck.Detail | Should -Match '440 / 440'
+        $script:BdiCheck.Detail | Should -Match '442 / 442'
         $script:BdiCheck.Detail | Should -Match '1 exempt via \[DEPRECATED\] prefix'
     }
 


### PR DESCRIPTION
INCIDENT-B (t/3009) content follow-up. sit-476/477 — added un-decomposed by pipeline sync `78c943cf` — now carry full per-POV BDI decomposition on `ai-triad-data` (data commit `83f13e1b`, CL-authored at t/3009#1, PowerShell-written).

Bumps the compliance-live trip-wire baseline `440 / 440` → `442 / 442` (1 exempt) to the empirically reproduced count.

**Verification:** `Invoke-Pester tests/data-compliance/Test-SituationBDI.LiveData.Tests.ps1` passes 3/3 against the live 442/442 corpus. `Test-OntologyCompliance` Detail reproduced: `"442 / 442 non-deprecated situations carry full per-POV BDI decomposition (1 exempt via [DEPRECATED] prefix)"`, status pass.

Recurring pipeline gap (situations emitted un-decomposed) tracked separately as **t/3011**. Baseline-bump is the documented maintenance action per the test file's NOTES; self-cert trivial. Co-authored with PowerShell (data write).