### PR TITLE
obs(oped): log voice_failed + voice_complete to flight recorder (t/3012)

### DIFF
--- a/taxonomy-editor/src/main/ipc/opedHandlers.ts
+++ b/taxonomy-editor/src/main/ipc/opedHandlers.ts
@@ -291,11 +291,19 @@ export function registerOpEdHandlers(): void {
               saveOpEdSetTemp({ schema_version: 1, set_id: setId, topic, params, created_at: createdAt, opeds: [...completedMembers], ...provenanceFields() });
             } catch { /* telemetry — silent by design; temp save is best-effort */ }
             send({ set_id: setId, voice: evt.pov, stage: 'complete' });
+            getGlobalRecorder()?.record({
+              type: 'system.info', component: 'opedHandlers', level: 'info',
+              message: `Op-ed voice complete for set ${setId} pov=${evt.pov}: wordCount=${evt.member.wordCount} grounding=${evt.member.grounding.length}`,
+            });
             break;
           }
           case 'voice_failed': {
             const failed: OpEdMember = { pov: evt.pov, status: 'failed', headline: '', subtitle: '', body: '', wordCount: 0, grounding: [], byline: '', disclosure: '', rhetorical_meta: '' };
             completedMembers.push(failed);
+            getGlobalRecorder()?.record({
+              type: 'system.error', component: 'opedHandlers', level: 'error',
+              message: `Op-ed voice failed for set ${setId} pov=${evt.pov}: ${evt.error}`,
+            });
             send({ set_id: setId, voice: evt.pov, stage: 'failed', error: evt.error });
             break;
           }


### PR DESCRIPTION
## Summary
- `voice_failed` now records to the flight recorder with `level:error` so dump analysis surfaces the exact error string per failed voice
- `voice_complete` records `wordCount` and `grounding.length` so per-voice outcomes are visible in every dump, not just failures
- Mirrors the existing `grounding_failed` pattern already in the same switch block

## Test plan
- [ ] tsc --noEmit clean (verified locally)
- [ ] No new tests needed — this is pure observability (recorder calls are optional-chained, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127E2pUYzbrHFYyNYjgVAgR