### PR TITLE
analysis(cl): WS-B Stage 1 — situation→POV-node evidence link proposals (t/3014)

### DIFF
--- a/research/comp-linguist/analyses/situation-evidence/proposal.json
+++ b/research/comp-linguist/analyses/situation-evidence/proposal.json
@@ -1,0 +1,27848 @@
+[
+  {
+    "situation_id": "sit-001",
+    "camp": "acc",
+    "node_id": "acc-beliefs-024",
+    "score": 0.658387,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-001",
+    "camp": "acc",
+    "node_id": "acc-beliefs-084",
+    "score": 0.609127,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-001",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.571801,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-001",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.65528,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-001",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.62648,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-001",
+    "camp": "saf",
+    "node_id": "saf-desires-001",
+    "score": 0.623861,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-001",
+    "camp": "skp",
+    "node_id": "skp-intentions-141",
+    "score": 0.668878,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-001",
+    "camp": "skp",
+    "node_id": "skp-beliefs-017",
+    "score": 0.593029,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-001",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.586254,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.673009,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.654303,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.647036,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.698555,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "saf",
+    "node_id": "saf-beliefs-101",
+    "score": 0.683903,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "saf",
+    "node_id": "saf-beliefs-098",
+    "score": 0.66328,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.760668,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.716233,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-002",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.713446,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.6854,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.67809,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.673363,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.735298,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.727673,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.727292,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.732587,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.721482,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-003",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.720239,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.703801,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.668424,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.607088,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.746248,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.73486,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.733441,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.729539,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.70195,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-004",
+    "camp": "skp",
+    "node_id": "skp-beliefs-043",
+    "score": 0.697348,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.671185,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.613905,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.607538,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.778936,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "saf",
+    "node_id": "saf-desires-016",
+    "score": 0.714847,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "saf",
+    "node_id": "saf-beliefs-094",
+    "score": 0.707617,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.70143,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "skp",
+    "node_id": "skp-intentions-143",
+    "score": 0.698852,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-005",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.655146,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.565016,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "acc",
+    "node_id": "acc-intentions-051",
+    "score": 0.564307,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.529213,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.595958,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.575559,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.570862,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.673441,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "skp",
+    "node_id": "skp-beliefs-094",
+    "score": 0.628266,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-006",
+    "camp": "skp",
+    "node_id": "skp-beliefs-061",
+    "score": 0.627054,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.629001,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.598161,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.588419,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.677091,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.659315,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.651716,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "skp",
+    "node_id": "skp-intentions-148",
+    "score": 0.656823,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.633482,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-007",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.630703,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.660243,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.629916,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.614473,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "saf",
+    "node_id": "saf-beliefs-033",
+    "score": 0.632801,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "saf",
+    "node_id": "saf-beliefs-091",
+    "score": 0.615528,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.600712,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "skp",
+    "node_id": "skp-beliefs-021",
+    "score": 0.719126,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "skp",
+    "node_id": "skp-beliefs-146",
+    "score": 0.670791,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-008",
+    "camp": "skp",
+    "node_id": "skp-beliefs-131",
+    "score": 0.641335,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.692721,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.657112,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.642741,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.743107,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.715502,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.685578,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.678629,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.667957,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-009",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.667334,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "acc",
+    "node_id": "acc-intentions-056",
+    "score": 0.662213,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.653852,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.648325,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.746691,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.734059,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.728252,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.692573,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.64325,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-010",
+    "camp": "skp",
+    "node_id": "skp-beliefs-129",
+    "score": 0.638578,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.654275,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.614652,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.580859,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "saf",
+    "node_id": "saf-beliefs-131",
+    "score": 0.699197,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.684897,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "saf",
+    "node_id": "saf-beliefs-017",
+    "score": 0.682213,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.665972,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.658229,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-011",
+    "camp": "skp",
+    "node_id": "skp-beliefs-183",
+    "score": 0.658098,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.67505,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.655108,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.654964,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.791665,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "saf",
+    "node_id": "saf-intentions-083",
+    "score": 0.778217,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.77725,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.743604,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.734274,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-012",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.730369,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.623538,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "acc",
+    "node_id": "acc-intentions-004",
+    "score": 0.605263,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.583499,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.572581,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.557234,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "saf",
+    "node_id": "saf-beliefs-057",
+    "score": 0.549707,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.648654,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.64288,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-013",
+    "camp": "skp",
+    "node_id": "skp-intentions-087",
+    "score": 0.614351,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "acc",
+    "node_id": "acc-intentions-036",
+    "score": 0.590415,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.564173,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.56211,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "saf",
+    "node_id": "saf-intentions-225",
+    "score": 0.614955,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "saf",
+    "node_id": "saf-beliefs-200",
+    "score": 0.608726,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "saf",
+    "node_id": "saf-intentions-031",
+    "score": 0.587144,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "skp",
+    "node_id": "skp-beliefs-074",
+    "score": 0.67139,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "skp",
+    "node_id": "skp-beliefs-064",
+    "score": 0.631202,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-014",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.621878,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.711078,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.67518,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "acc",
+    "node_id": "acc-intentions-119",
+    "score": 0.60322,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "saf",
+    "node_id": "saf-intentions-007",
+    "score": 0.75253,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "saf",
+    "node_id": "saf-beliefs-028",
+    "score": 0.730884,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.725626,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.733972,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.717705,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-015",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.692612,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.703914,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "acc",
+    "node_id": "acc-intentions-069",
+    "score": 0.697754,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "acc",
+    "node_id": "acc-intentions-005",
+    "score": 0.643636,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "saf",
+    "node_id": "saf-beliefs-033",
+    "score": 0.72819,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.706214,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.680057,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "skp",
+    "node_id": "skp-beliefs-139",
+    "score": 0.724417,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.688346,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-016",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.677792,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.688127,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "acc",
+    "node_id": "acc-desires-037",
+    "score": 0.630053,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.62968,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.749322,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "saf",
+    "node_id": "saf-desires-016",
+    "score": 0.74407,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.722351,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.666489,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.660257,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-017",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.659619,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.670825,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.62576,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "acc",
+    "node_id": "acc-intentions-009",
+    "score": 0.625454,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "saf",
+    "node_id": "saf-beliefs-131",
+    "score": 0.710302,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "saf",
+    "node_id": "saf-beliefs-017",
+    "score": 0.706543,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "saf",
+    "node_id": "saf-desires-004",
+    "score": 0.703398,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.719578,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.65322,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-018",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.652443,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "acc",
+    "node_id": "acc-intentions-056",
+    "score": 0.690202,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "acc",
+    "node_id": "acc-intentions-027",
+    "score": 0.667368,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.667048,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "saf",
+    "node_id": "saf-intentions-076",
+    "score": 0.720833,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "saf",
+    "node_id": "saf-beliefs-013",
+    "score": 0.716187,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.712534,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.659194,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.64349,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-019",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.637861,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.680687,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "acc",
+    "node_id": "acc-intentions-069",
+    "score": 0.665381,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.643021,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.718513,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.709441,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.709406,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.752913,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.708216,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-020",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.706055,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.565126,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.557151,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.5234,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.742423,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "saf",
+    "node_id": "saf-beliefs-057",
+    "score": 0.731392,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.715987,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "skp",
+    "node_id": "skp-beliefs-064",
+    "score": 0.666038,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "skp",
+    "node_id": "skp-beliefs-035",
+    "score": 0.664294,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-021",
+    "camp": "skp",
+    "node_id": "skp-beliefs-074",
+    "score": 0.597868,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.652819,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "acc",
+    "node_id": "acc-beliefs-084",
+    "score": 0.649764,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.638855,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "saf",
+    "node_id": "saf-intentions-086",
+    "score": 0.62484,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "saf",
+    "node_id": "saf-beliefs-033",
+    "score": 0.618578,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.617778,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.682918,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.678774,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-022",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.678242,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "acc",
+    "node_id": "acc-intentions-056",
+    "score": 0.668613,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "acc",
+    "node_id": "acc-beliefs-078",
+    "score": 0.636524,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.632611,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "saf",
+    "node_id": "saf-intentions-085",
+    "score": 0.742208,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.728156,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.724152,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.747622,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.664203,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-023",
+    "camp": "skp",
+    "node_id": "skp-beliefs-129",
+    "score": 0.663532,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.583096,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.568433,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "acc",
+    "node_id": "acc-beliefs-111",
+    "score": 0.550211,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.619504,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "saf",
+    "node_id": "saf-beliefs-030",
+    "score": 0.591317,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "saf",
+    "node_id": "saf-beliefs-104",
+    "score": 0.585976,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.617933,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.615793,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-024",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.583852,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.67464,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.658408,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "acc",
+    "node_id": "acc-intentions-071",
+    "score": 0.593788,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.710638,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "saf",
+    "node_id": "saf-beliefs-104",
+    "score": 0.708839,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "saf",
+    "node_id": "saf-intentions-143",
+    "score": 0.704005,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.79905,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "skp",
+    "node_id": "skp-desires-076",
+    "score": 0.660425,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-025",
+    "camp": "skp",
+    "node_id": "skp-intentions-014",
+    "score": 0.657136,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "acc",
+    "node_id": "acc-intentions-051",
+    "score": 0.598736,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.5865,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.575592,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "saf",
+    "node_id": "saf-beliefs-016",
+    "score": 0.678459,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "saf",
+    "node_id": "saf-beliefs-013",
+    "score": 0.67827,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.661951,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.635994,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "skp",
+    "node_id": "skp-beliefs-035",
+    "score": 0.6071,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-026",
+    "camp": "skp",
+    "node_id": "skp-desires-070",
+    "score": 0.604535,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.748352,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.690524,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.688939,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.658338,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "saf",
+    "node_id": "saf-intentions-159",
+    "score": 0.63738,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.636941,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "skp",
+    "node_id": "skp-beliefs-292",
+    "score": 0.737134,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.695374,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-027",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.684462,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.69486,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.653834,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "acc",
+    "node_id": "acc-intentions-056",
+    "score": 0.650386,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.723352,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.701012,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "saf",
+    "node_id": "saf-intentions-076",
+    "score": 0.695274,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.696896,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.672601,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-028",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.664563,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.715841,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.661753,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "acc",
+    "node_id": "acc-beliefs-072",
+    "score": 0.626088,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.713264,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.687296,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "saf",
+    "node_id": "saf-beliefs-210",
+    "score": 0.6429,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.742802,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.698811,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-029",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.677208,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.600061,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.584832,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.569884,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.576603,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.546726,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.536409,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.567817,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "skp",
+    "node_id": "skp-desires-083",
+    "score": 0.561422,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-030",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.560164,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.750389,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.690862,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.660406,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.681015,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.672967,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.664385,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "skp",
+    "node_id": "skp-beliefs-292",
+    "score": 0.759255,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.719661,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-031",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.715178,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.687067,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.666588,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.652342,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.793305,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.749661,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.725233,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.646003,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.638875,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-032",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.634202,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.662042,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.614754,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.568695,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.769213,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "saf",
+    "node_id": "saf-intentions-089",
+    "score": 0.743947,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "saf",
+    "node_id": "saf-beliefs-017",
+    "score": 0.688436,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.683029,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.665777,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-034",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.649898,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.659068,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "acc",
+    "node_id": "acc-beliefs-089",
+    "score": 0.607067,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "acc",
+    "node_id": "acc-intentions-069",
+    "score": 0.605987,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "saf",
+    "node_id": "saf-beliefs-064",
+    "score": 0.662479,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "saf",
+    "node_id": "saf-beliefs-137",
+    "score": 0.588161,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.559263,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.72338,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "skp",
+    "node_id": "skp-beliefs-139",
+    "score": 0.703421,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-036",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.698742,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "acc",
+    "node_id": "acc-intentions-076",
+    "score": 0.646612,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.625802,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.623699,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.732987,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.728616,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "saf",
+    "node_id": "saf-beliefs-033",
+    "score": 0.712483,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "skp",
+    "node_id": "skp-beliefs-017",
+    "score": 0.714038,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.70845,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-037",
+    "camp": "skp",
+    "node_id": "skp-beliefs-146",
+    "score": 0.681308,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.617115,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.614997,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.570501,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "saf",
+    "node_id": "saf-beliefs-064",
+    "score": 0.666677,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "saf",
+    "node_id": "saf-beliefs-137",
+    "score": 0.579083,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.575381,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.640831,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "skp",
+    "node_id": "skp-beliefs-022",
+    "score": 0.638486,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-038",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.618238,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "acc",
+    "node_id": "acc-beliefs-037",
+    "score": 0.514088,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "acc",
+    "node_id": "acc-beliefs-089",
+    "score": 0.50736,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.495004,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.590833,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.589612,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "saf",
+    "node_id": "saf-beliefs-064",
+    "score": 0.583898,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "skp",
+    "node_id": "skp-beliefs-135",
+    "score": 0.608112,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "skp",
+    "node_id": "skp-beliefs-022",
+    "score": 0.600773,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-039",
+    "camp": "skp",
+    "node_id": "skp-beliefs-166",
+    "score": 0.596621,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.551829,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.479441,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.474488,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.699855,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.64017,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "saf",
+    "node_id": "saf-beliefs-046",
+    "score": 0.59741,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "skp",
+    "node_id": "skp-beliefs-052",
+    "score": 0.598841,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "skp",
+    "node_id": "skp-beliefs-201",
+    "score": 0.576777,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-040",
+    "camp": "skp",
+    "node_id": "skp-beliefs-026",
+    "score": 0.566722,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.531784,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "acc",
+    "node_id": "acc-desires-037",
+    "score": 0.521115,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.514763,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.616725,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.610444,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "saf",
+    "node_id": "saf-beliefs-129",
+    "score": 0.605099,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "skp",
+    "node_id": "skp-beliefs-027",
+    "score": 0.600409,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "skp",
+    "node_id": "skp-beliefs-043",
+    "score": 0.587757,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-041",
+    "camp": "skp",
+    "node_id": "skp-beliefs-064",
+    "score": 0.582479,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.629364,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.605215,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.589377,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.675454,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "saf",
+    "node_id": "saf-beliefs-046",
+    "score": 0.673892,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.659929,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.654561,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "skp",
+    "node_id": "skp-intentions-035",
+    "score": 0.632936,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-042",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.620451,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.591613,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.584404,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.566449,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "saf",
+    "node_id": "saf-intentions-204",
+    "score": 0.702099,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.645102,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "saf",
+    "node_id": "saf-intentions-031",
+    "score": 0.588999,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.625483,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "skp",
+    "node_id": "skp-intentions-143",
+    "score": 0.614733,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-043",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.575599,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.600179,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.556938,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.529322,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.690003,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.683491,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "saf",
+    "node_id": "saf-intentions-074",
+    "score": 0.676866,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "skp",
+    "node_id": "skp-beliefs-095",
+    "score": 0.731811,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.726248,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-044",
+    "camp": "skp",
+    "node_id": "skp-beliefs-094",
+    "score": 0.698513,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.569383,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "acc",
+    "node_id": "acc-beliefs-079",
+    "score": 0.535163,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "acc",
+    "node_id": "acc-intentions-104",
+    "score": 0.522833,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "saf",
+    "node_id": "saf-beliefs-064",
+    "score": 0.798076,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "saf",
+    "node_id": "saf-beliefs-033",
+    "score": 0.698383,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.677739,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.782132,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "skp",
+    "node_id": "skp-beliefs-101",
+    "score": 0.728146,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-045",
+    "camp": "skp",
+    "node_id": "skp-beliefs-028",
+    "score": 0.686002,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.645794,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.60409,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.601069,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.739682,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "saf",
+    "node_id": "saf-intentions-202",
+    "score": 0.734346,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "saf",
+    "node_id": "saf-desires-004",
+    "score": 0.725193,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.670036,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.664926,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-046",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.640072,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.596106,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "acc",
+    "node_id": "acc-beliefs-015",
+    "score": 0.58749,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "acc",
+    "node_id": "acc-desires-011",
+    "score": 0.518378,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.707285,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "saf",
+    "node_id": "saf-beliefs-232",
+    "score": 0.698813,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "saf",
+    "node_id": "saf-beliefs-042",
+    "score": 0.629292,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "skp",
+    "node_id": "skp-beliefs-122",
+    "score": 0.54421,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "skp",
+    "node_id": "skp-beliefs-120",
+    "score": 0.542006,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-047",
+    "camp": "skp",
+    "node_id": "skp-beliefs-167",
+    "score": 0.541104,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.539895,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.535058,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.530991,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.709685,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.700294,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.688605,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.678609,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "skp",
+    "node_id": "skp-beliefs-052",
+    "score": 0.671301,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-048",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.657221,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.58037,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.57893,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.535359,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "saf",
+    "node_id": "saf-beliefs-099",
+    "score": 0.770069,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "saf",
+    "node_id": "saf-beliefs-016",
+    "score": 0.748741,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.740525,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "skp",
+    "node_id": "skp-beliefs-116",
+    "score": 0.691036,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.690803,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-049",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.646746,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.506163,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.492337,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "acc",
+    "node_id": "acc-intentions-060",
+    "score": 0.485948,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "saf",
+    "node_id": "saf-desires-008",
+    "score": 0.505739,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "saf",
+    "node_id": "saf-desires-024",
+    "score": 0.497774,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "saf",
+    "node_id": "saf-intentions-059",
+    "score": 0.489729,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.544065,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "skp",
+    "node_id": "skp-intentions-143",
+    "score": 0.53883,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-050",
+    "camp": "skp",
+    "node_id": "skp-intentions-029",
+    "score": 0.51558,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.629128,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.596112,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.591239,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.730359,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.704491,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.685348,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.679152,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.660938,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-051",
+    "camp": "skp",
+    "node_id": "skp-intentions-035",
+    "score": 0.638821,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.582728,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.579015,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "acc",
+    "node_id": "acc-intentions-035",
+    "score": 0.57602,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.706793,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.593434,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "saf",
+    "node_id": "saf-intentions-059",
+    "score": 0.582492,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "skp",
+    "node_id": "skp-beliefs-074",
+    "score": 0.614648,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.608488,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-052",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.597816,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "acc",
+    "node_id": "acc-intentions-004",
+    "score": 0.619583,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.580316,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.577164,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.586805,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.537536,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.513193,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "skp",
+    "node_id": "skp-beliefs-041",
+    "score": 0.612008,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.593255,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-053",
+    "camp": "skp",
+    "node_id": "skp-beliefs-044",
+    "score": 0.584766,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.684079,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.650437,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.628244,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.771657,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.751328,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.735416,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.711738,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.690711,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-054",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.682837,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "acc",
+    "node_id": "acc-intentions-086",
+    "score": 0.611573,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "acc",
+    "node_id": "acc-intentions-055",
+    "score": 0.575666,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "acc",
+    "node_id": "acc-beliefs-094",
+    "score": 0.573035,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.670953,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "saf",
+    "node_id": "saf-intentions-061",
+    "score": 0.655603,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.643164,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "skp",
+    "node_id": "skp-beliefs-008",
+    "score": 0.641757,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.62464,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-055",
+    "camp": "skp",
+    "node_id": "skp-beliefs-026",
+    "score": 0.615828,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "acc",
+    "node_id": "acc-intentions-045",
+    "score": 0.523671,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "acc",
+    "node_id": "acc-intentions-086",
+    "score": 0.522017,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.51509,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.723086,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "saf",
+    "node_id": "saf-intentions-061",
+    "score": 0.709844,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.664441,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.522356,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "skp",
+    "node_id": "skp-beliefs-021",
+    "score": 0.511922,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-056",
+    "camp": "skp",
+    "node_id": "skp-beliefs-008",
+    "score": 0.498514,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.589466,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "acc",
+    "node_id": "acc-intentions-075",
+    "score": 0.569597,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "acc",
+    "node_id": "acc-intentions-042",
+    "score": 0.553122,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "saf",
+    "node_id": "saf-intentions-058",
+    "score": 0.730418,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "saf",
+    "node_id": "saf-desires-024",
+    "score": 0.702173,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "saf",
+    "node_id": "saf-intentions-113",
+    "score": 0.694705,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.671317,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.656477,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-057",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.648387,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.621592,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.576742,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.544882,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "saf",
+    "node_id": "saf-desires-024",
+    "score": 0.714331,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "saf",
+    "node_id": "saf-intentions-127",
+    "score": 0.648092,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.638822,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "skp",
+    "node_id": "skp-intentions-044",
+    "score": 0.634148,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "skp",
+    "node_id": "skp-beliefs-257",
+    "score": 0.63246,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-058",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.629502,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "acc",
+    "node_id": "acc-beliefs-071",
+    "score": 0.638187,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "acc",
+    "node_id": "acc-intentions-104",
+    "score": 0.603515,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.602893,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.742889,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "saf",
+    "node_id": "saf-beliefs-217",
+    "score": 0.698659,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.687938,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.759357,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.680274,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-059",
+    "camp": "skp",
+    "node_id": "skp-intentions-143",
+    "score": 0.664497,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.570429,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.554629,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "acc",
+    "node_id": "acc-intentions-104",
+    "score": 0.549202,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.662237,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "saf",
+    "node_id": "saf-beliefs-228",
+    "score": 0.616945,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "saf",
+    "node_id": "saf-desires-002",
+    "score": 0.60903,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.579929,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.575782,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-060",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.569545,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.70704,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "acc",
+    "node_id": "acc-beliefs-072",
+    "score": 0.645447,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.641599,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.8203,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.762729,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "saf",
+    "node_id": "saf-intentions-043",
+    "score": 0.737503,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "skp",
+    "node_id": "skp-beliefs-144",
+    "score": 0.753952,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.708781,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-061",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.7054,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.600604,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.562141,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "acc",
+    "node_id": "acc-beliefs-072",
+    "score": 0.559686,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.824301,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.719765,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "saf",
+    "node_id": "saf-intentions-043",
+    "score": 0.711505,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "skp",
+    "node_id": "skp-beliefs-144",
+    "score": 0.737803,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "skp",
+    "node_id": "skp-beliefs-141",
+    "score": 0.709791,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-062",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.670106,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.696353,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.676564,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.65095,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.598156,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.580853,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.569556,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.697604,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.691088,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-063",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.680159,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.697752,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.686155,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.671906,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.720961,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "saf",
+    "node_id": "saf-intentions-074",
+    "score": 0.718276,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "saf",
+    "node_id": "saf-intentions-043",
+    "score": 0.707925,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.707042,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.695103,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-064",
+    "camp": "skp",
+    "node_id": "skp-intentions-029",
+    "score": 0.682439,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.777455,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.750846,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "acc",
+    "node_id": "acc-intentions-005",
+    "score": 0.742931,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.807695,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.780069,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "saf",
+    "node_id": "saf-intentions-069",
+    "score": 0.778873,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.767,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.755533,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-065",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.755197,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "acc",
+    "node_id": "acc-intentions-055",
+    "score": 0.605995,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "acc",
+    "node_id": "acc-intentions-018",
+    "score": 0.589363,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.580918,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.68159,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.677359,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "saf",
+    "node_id": "saf-intentions-061",
+    "score": 0.672702,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.643133,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "skp",
+    "node_id": "skp-beliefs-026",
+    "score": 0.634392,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-066",
+    "camp": "skp",
+    "node_id": "skp-beliefs-008",
+    "score": 0.627177,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.667857,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "acc",
+    "node_id": "acc-beliefs-024",
+    "score": 0.658957,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.636239,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "saf",
+    "node_id": "saf-beliefs-033",
+    "score": 0.771596,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.709238,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.68542,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.691075,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "skp",
+    "node_id": "skp-beliefs-139",
+    "score": 0.667941,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-067",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.660313,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.549097,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.534366,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "acc",
+    "node_id": "acc-beliefs-089",
+    "score": 0.53317,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "saf",
+    "node_id": "saf-intentions-063",
+    "score": 0.710317,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.681101,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "saf",
+    "node_id": "saf-beliefs-010",
+    "score": 0.63044,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "skp",
+    "node_id": "skp-beliefs-101",
+    "score": 0.713335,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.709831,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-068",
+    "camp": "skp",
+    "node_id": "skp-beliefs-017",
+    "score": 0.662251,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.599455,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.598853,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "acc",
+    "node_id": "acc-intentions-073",
+    "score": 0.572214,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.726142,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.699187,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.690527,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.619226,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.610087,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-069",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.596575,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.647398,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.631889,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.628629,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.833469,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "saf",
+    "node_id": "saf-beliefs-210",
+    "score": 0.766112,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.766052,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.655273,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.650505,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-070",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.627558,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.598434,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "acc",
+    "node_id": "acc-intentions-055",
+    "score": 0.597349,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "acc",
+    "node_id": "acc-intentions-018",
+    "score": 0.593108,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "saf",
+    "node_id": "saf-intentions-061",
+    "score": 0.6434,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.643294,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.642249,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.60659,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.59712,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-072",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.592763,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.548458,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.528496,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.523977,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "saf",
+    "node_id": "saf-beliefs-101",
+    "score": 0.660698,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.628439,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.612233,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "skp",
+    "node_id": "skp-beliefs-149",
+    "score": 0.607591,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.591077,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-073",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.567024,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.650071,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "acc",
+    "node_id": "acc-intentions-009",
+    "score": 0.634878,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "acc",
+    "node_id": "acc-intentions-051",
+    "score": 0.632009,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.67292,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "saf",
+    "node_id": "saf-intentions-048",
+    "score": 0.665024,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.619409,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.687158,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.681471,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-074",
+    "camp": "skp",
+    "node_id": "skp-beliefs-168",
+    "score": 0.676098,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "acc",
+    "node_id": "acc-intentions-051",
+    "score": 0.511041,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.508419,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.486455,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "saf",
+    "node_id": "saf-beliefs-063",
+    "score": 0.599738,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "saf",
+    "node_id": "saf-beliefs-005",
+    "score": 0.551548,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "saf",
+    "node_id": "saf-beliefs-104",
+    "score": 0.519372,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "skp",
+    "node_id": "skp-beliefs-145",
+    "score": 0.615873,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "skp",
+    "node_id": "skp-beliefs-029",
+    "score": 0.519457,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-075",
+    "camp": "skp",
+    "node_id": "skp-beliefs-098",
+    "score": 0.512387,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.681574,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.664221,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "acc",
+    "node_id": "acc-intentions-069",
+    "score": 0.655752,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.726574,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "saf",
+    "node_id": "saf-beliefs-033",
+    "score": 0.710413,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "saf",
+    "node_id": "saf-beliefs-064",
+    "score": 0.704852,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.699604,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "skp",
+    "node_id": "skp-beliefs-017",
+    "score": 0.691731,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-076",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.68795,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.616686,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "acc",
+    "node_id": "acc-intentions-006",
+    "score": 0.595562,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "acc",
+    "node_id": "acc-desires-025",
+    "score": 0.594707,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.78102,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "saf",
+    "node_id": "saf-beliefs-117",
+    "score": 0.763776,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "saf",
+    "node_id": "saf-intentions-085",
+    "score": 0.762877,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.686469,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "skp",
+    "node_id": "skp-beliefs-171",
+    "score": 0.670584,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-078",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.665697,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.458918,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "acc",
+    "node_id": "acc-intentions-035",
+    "score": 0.45361,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.452127,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "saf",
+    "node_id": "saf-intentions-059",
+    "score": 0.646514,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "saf",
+    "node_id": "saf-intentions-086",
+    "score": 0.627052,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.613967,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "skp",
+    "node_id": "skp-beliefs-074",
+    "score": 0.609319,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.512783,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-079",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.498971,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.516422,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.503089,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.489716,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.613622,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "saf",
+    "node_id": "saf-beliefs-046",
+    "score": 0.558708,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.554128,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "skp",
+    "node_id": "skp-beliefs-038",
+    "score": 0.855118,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "skp",
+    "node_id": "skp-beliefs-121",
+    "score": 0.775425,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-080",
+    "camp": "skp",
+    "node_id": "skp-beliefs-142",
+    "score": 0.759056,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.608543,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "acc",
+    "node_id": "acc-intentions-104",
+    "score": 0.608334,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "acc",
+    "node_id": "acc-intentions-052",
+    "score": 0.604635,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.648672,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "saf",
+    "node_id": "saf-intentions-086",
+    "score": 0.636326,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "saf",
+    "node_id": "saf-intentions-115",
+    "score": 0.631024,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "skp",
+    "node_id": "skp-desires-070",
+    "score": 0.721217,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.680076,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-081",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.646183,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "acc",
+    "node_id": "acc-beliefs-061",
+    "score": 0.583724,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.508123,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "acc",
+    "node_id": "acc-intentions-068",
+    "score": 0.497231,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "saf",
+    "node_id": "saf-intentions-077",
+    "score": 0.542143,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "saf",
+    "node_id": "saf-intentions-086",
+    "score": 0.520799,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.506722,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "skp",
+    "node_id": "skp-beliefs-121",
+    "score": 0.776722,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "skp",
+    "node_id": "skp-beliefs-038",
+    "score": 0.748468,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-082",
+    "camp": "skp",
+    "node_id": "skp-beliefs-142",
+    "score": 0.607579,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "acc",
+    "node_id": "acc-intentions-018",
+    "score": 0.608169,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "acc",
+    "node_id": "acc-desires-028",
+    "score": 0.607626,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.598544,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "saf",
+    "node_id": "saf-beliefs-057",
+    "score": 0.654899,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "saf",
+    "node_id": "saf-beliefs-096",
+    "score": 0.65223,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.648567,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "skp",
+    "node_id": "skp-beliefs-064",
+    "score": 0.692749,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "skp",
+    "node_id": "skp-beliefs-014",
+    "score": 0.667234,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-083",
+    "camp": "skp",
+    "node_id": "skp-beliefs-124",
+    "score": 0.655034,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.6919,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.651172,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.576108,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "saf",
+    "node_id": "saf-beliefs-030",
+    "score": 0.739379,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "saf",
+    "node_id": "saf-beliefs-028",
+    "score": 0.723349,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.701976,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.640462,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.60548,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-084",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.586842,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.730094,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.710442,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.53091,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.808832,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "saf",
+    "node_id": "saf-intentions-007",
+    "score": 0.768796,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "saf",
+    "node_id": "saf-beliefs-028",
+    "score": 0.746306,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.699568,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.669803,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-085",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.628133,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.611986,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.586573,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.547162,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.681746,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "saf",
+    "node_id": "saf-intentions-200",
+    "score": 0.666644,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.666014,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.567056,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.558664,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-086",
+    "camp": "skp",
+    "node_id": "skp-beliefs-276",
+    "score": 0.557375,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.661721,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.615143,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "acc",
+    "node_id": "acc-intentions-073",
+    "score": 0.527324,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "saf",
+    "node_id": "saf-intentions-200",
+    "score": 0.785361,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "saf",
+    "node_id": "saf-intentions-067",
+    "score": 0.728111,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.72767,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "skp",
+    "node_id": "skp-desires-070",
+    "score": 0.678622,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.650857,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-087",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.648924,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.597306,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.591239,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "acc",
+    "node_id": "acc-desires-033",
+    "score": 0.553609,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "saf",
+    "node_id": "saf-beliefs-132",
+    "score": 0.658142,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "saf",
+    "node_id": "saf-intentions-115",
+    "score": 0.649356,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "saf",
+    "node_id": "saf-intentions-052",
+    "score": 0.646774,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.721843,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.624541,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-088",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.621286,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "acc",
+    "node_id": "acc-beliefs-107",
+    "score": 0.561677,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "acc",
+    "node_id": "acc-intentions-104",
+    "score": 0.521586,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.499915,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "saf",
+    "node_id": "saf-beliefs-022",
+    "score": 0.773053,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "saf",
+    "node_id": "saf-beliefs-130",
+    "score": 0.742758,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "saf",
+    "node_id": "saf-beliefs-128",
+    "score": 0.714938,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "skp",
+    "node_id": "skp-beliefs-045",
+    "score": 0.635337,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "skp",
+    "node_id": "skp-beliefs-028",
+    "score": 0.625503,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-089",
+    "camp": "skp",
+    "node_id": "skp-beliefs-029",
+    "score": 0.617325,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "acc",
+    "node_id": "acc-intentions-120",
+    "score": 0.52997,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "acc",
+    "node_id": "acc-beliefs-076",
+    "score": 0.523176,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "acc",
+    "node_id": "acc-intentions-110",
+    "score": 0.503327,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "saf",
+    "node_id": "saf-beliefs-200",
+    "score": 0.574267,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "saf",
+    "node_id": "saf-beliefs-057",
+    "score": 0.567649,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "saf",
+    "node_id": "saf-beliefs-051",
+    "score": 0.565497,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "skp",
+    "node_id": "skp-beliefs-145",
+    "score": 0.735602,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "skp",
+    "node_id": "skp-beliefs-027",
+    "score": 0.588199,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-090",
+    "camp": "skp",
+    "node_id": "skp-beliefs-061",
+    "score": 0.585361,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "acc",
+    "node_id": "acc-intentions-009",
+    "score": 0.642851,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.622703,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.608552,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "saf",
+    "node_id": "saf-beliefs-094",
+    "score": 0.714284,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.708347,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "saf",
+    "node_id": "saf-beliefs-013",
+    "score": 0.702633,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "skp",
+    "node_id": "skp-beliefs-167",
+    "score": 0.648063,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.632738,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-091",
+    "camp": "skp",
+    "node_id": "skp-beliefs-043",
+    "score": 0.631855,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.685181,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.660665,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "acc",
+    "node_id": "acc-beliefs-084",
+    "score": 0.652383,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "saf",
+    "node_id": "saf-beliefs-094",
+    "score": 0.726298,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.711537,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.707925,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.668796,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "skp",
+    "node_id": "skp-beliefs-043",
+    "score": 0.654248,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-094",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.636757,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.604808,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.57663,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.521495,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "saf",
+    "node_id": "saf-beliefs-101",
+    "score": 0.686378,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "saf",
+    "node_id": "saf-beliefs-001",
+    "score": 0.603323,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "saf",
+    "node_id": "saf-intentions-127",
+    "score": 0.593229,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.756761,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "skp",
+    "node_id": "skp-beliefs-149",
+    "score": 0.703493,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-095",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.650349,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.657173,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.639864,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.639051,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.802613,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.712855,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.700692,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.696571,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.678199,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-096",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.674002,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.692155,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.661626,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.534014,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "saf",
+    "node_id": "saf-intentions-007",
+    "score": 0.711661,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "saf",
+    "node_id": "saf-intentions-015",
+    "score": 0.682347,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "saf",
+    "node_id": "saf-intentions-067",
+    "score": 0.682198,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "skp",
+    "node_id": "skp-beliefs-076",
+    "score": 0.611521,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.582204,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-097",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.579424,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.765275,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.674131,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.669288,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.807889,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.788214,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.786518,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.750064,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.727903,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-098",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.727867,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.660442,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.627702,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.607686,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.742727,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.718602,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.706697,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.693976,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.651026,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-099",
+    "camp": "skp",
+    "node_id": "skp-desires-070",
+    "score": 0.635841,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.692757,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "acc",
+    "node_id": "acc-intentions-013",
+    "score": 0.598143,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.595333,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "saf",
+    "node_id": "saf-beliefs-046",
+    "score": 0.620484,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.58201,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.573568,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "skp",
+    "node_id": "skp-beliefs-042",
+    "score": 0.744071,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "skp",
+    "node_id": "skp-beliefs-002",
+    "score": 0.709822,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-100",
+    "camp": "skp",
+    "node_id": "skp-beliefs-202",
+    "score": 0.694988,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.674101,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "acc",
+    "node_id": "acc-beliefs-089",
+    "score": 0.657939,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.648586,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "saf",
+    "node_id": "saf-beliefs-064",
+    "score": 0.647792,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.63598,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.621366,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.725265,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "skp",
+    "node_id": "skp-beliefs-018",
+    "score": 0.712075,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-101",
+    "camp": "skp",
+    "node_id": "skp-beliefs-042",
+    "score": 0.709721,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.567608,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.562417,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "acc",
+    "node_id": "acc-intentions-055",
+    "score": 0.549235,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.713337,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.708331,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "saf",
+    "node_id": "saf-intentions-058",
+    "score": 0.692093,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.687973,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.68212,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-102",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.675781,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "acc",
+    "node_id": "acc-intentions-086",
+    "score": 0.647744,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "acc",
+    "node_id": "acc-intentions-068",
+    "score": 0.604198,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "acc",
+    "node_id": "acc-intentions-069",
+    "score": 0.58737,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "saf",
+    "node_id": "saf-intentions-061",
+    "score": 0.662783,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.658227,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "saf",
+    "node_id": "saf-intentions-086",
+    "score": 0.656223,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.65581,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "skp",
+    "node_id": "skp-beliefs-021",
+    "score": 0.628011,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-103",
+    "camp": "skp",
+    "node_id": "skp-intentions-143",
+    "score": 0.622368,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.741047,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.696739,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.674499,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.699671,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.677626,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "saf",
+    "node_id": "saf-intentions-159",
+    "score": 0.677552,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.724824,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.723304,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-104",
+    "camp": "skp",
+    "node_id": "skp-beliefs-292",
+    "score": 0.678397,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.699382,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.690481,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.650849,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.811871,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.807914,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.799448,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.74819,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.712782,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-105",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.70742,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.670593,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.644382,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "acc",
+    "node_id": "acc-intentions-051",
+    "score": 0.627312,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "saf",
+    "node_id": "saf-intentions-080",
+    "score": 0.816352,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.793963,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "saf",
+    "node_id": "saf-intentions-144",
+    "score": 0.788636,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.728694,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "skp",
+    "node_id": "skp-intentions-087",
+    "score": 0.606175,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-106",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.596722,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.604963,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.593675,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.590416,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.720852,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "saf",
+    "node_id": "saf-beliefs-104",
+    "score": 0.686148,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "saf",
+    "node_id": "saf-beliefs-051",
+    "score": 0.67893,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "skp",
+    "node_id": "skp-beliefs-094",
+    "score": 0.731652,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "skp",
+    "node_id": "skp-beliefs-041",
+    "score": 0.722532,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-107",
+    "camp": "skp",
+    "node_id": "skp-beliefs-029",
+    "score": 0.71235,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.592747,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.577219,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.545701,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "saf",
+    "node_id": "saf-intentions-214",
+    "score": 0.712741,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "saf",
+    "node_id": "saf-intentions-047",
+    "score": 0.695792,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "saf",
+    "node_id": "saf-intentions-142",
+    "score": 0.688992,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.643452,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.584373,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-109",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.549735,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "acc",
+    "node_id": "acc-intentions-018",
+    "score": 0.62081,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.607005,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "acc",
+    "node_id": "acc-intentions-055",
+    "score": 0.594314,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.611487,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.609617,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.607707,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "skp",
+    "node_id": "skp-beliefs-116",
+    "score": 0.619541,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.615516,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-110",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.591588,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.601348,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.599097,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.585041,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "saf",
+    "node_id": "saf-intentions-214",
+    "score": 0.767526,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "saf",
+    "node_id": "saf-intentions-047",
+    "score": 0.761723,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.739654,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.639217,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.619045,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-111",
+    "camp": "skp",
+    "node_id": "skp-intentions-007",
+    "score": 0.602731,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.615148,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.594869,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.592388,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.692813,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.692531,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.671949,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.689152,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.680501,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-112",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.65638,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "acc",
+    "node_id": "acc-desires-028",
+    "score": 0.567842,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.564925,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "acc",
+    "node_id": "acc-beliefs-008",
+    "score": 0.547093,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.63532,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.584096,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.56994,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.46803,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "skp",
+    "node_id": "skp-beliefs-043",
+    "score": 0.431259,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-113",
+    "camp": "skp",
+    "node_id": "skp-desires-006",
+    "score": 0.411039,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "acc",
+    "node_id": "acc-beliefs-008",
+    "score": 0.501147,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "acc",
+    "node_id": "acc-beliefs-023",
+    "score": 0.438006,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "acc",
+    "node_id": "acc-desires-038",
+    "score": 0.422622,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "saf",
+    "node_id": "saf-intentions-168",
+    "score": 0.398897,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "saf",
+    "node_id": "saf-intentions-245",
+    "score": 0.365286,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "saf",
+    "node_id": "saf-beliefs-250",
+    "score": 0.364147,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "skp",
+    "node_id": "skp-beliefs-252",
+    "score": 0.602777,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "skp",
+    "node_id": "skp-beliefs-011",
+    "score": 0.433271,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-114",
+    "camp": "skp",
+    "node_id": "skp-beliefs-299",
+    "score": 0.407987,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.75199,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.701453,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.67328,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.675604,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.675035,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "saf",
+    "node_id": "saf-intentions-159",
+    "score": 0.671607,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "skp",
+    "node_id": "skp-beliefs-292",
+    "score": 0.72853,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.72471,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-115",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.693628,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.677367,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.671335,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.652049,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.713932,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "saf",
+    "node_id": "saf-intentions-047",
+    "score": 0.680602,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.660448,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.645299,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.644941,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-116",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.630794,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.621031,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.617601,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "acc",
+    "node_id": "acc-desires-035",
+    "score": 0.615553,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.692488,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.672797,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.672522,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "skp",
+    "node_id": "skp-beliefs-096",
+    "score": 0.509401,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.504534,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-117",
+    "camp": "skp",
+    "node_id": "skp-beliefs-057",
+    "score": 0.465885,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.675628,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.672873,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.644216,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.736982,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.725369,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.724775,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.691161,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.675402,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-118",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.669474,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.550036,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "acc",
+    "node_id": "acc-desires-026",
+    "score": 0.52772,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.521217,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.600931,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.591202,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.588423,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "skp",
+    "node_id": "skp-beliefs-043",
+    "score": 0.594391,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.592842,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-119",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.526285,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.677708,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.649841,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.632606,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "saf",
+    "node_id": "saf-intentions-159",
+    "score": 0.614237,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "saf",
+    "node_id": "saf-beliefs-247",
+    "score": 0.598987,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.576706,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "skp",
+    "node_id": "skp-desires-078",
+    "score": 0.659078,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "skp",
+    "node_id": "skp-intentions-034",
+    "score": 0.637044,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-120",
+    "camp": "skp",
+    "node_id": "skp-beliefs-292",
+    "score": 0.615254,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.662057,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.60614,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.600235,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "saf",
+    "node_id": "saf-intentions-214",
+    "score": 0.74277,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.725899,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "saf",
+    "node_id": "saf-intentions-202",
+    "score": 0.722558,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.614244,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.588518,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-121",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.561519,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.649471,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.630763,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.622191,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "saf",
+    "node_id": "saf-desires-003",
+    "score": 0.635136,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.633727,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "saf",
+    "node_id": "saf-intentions-052",
+    "score": 0.632316,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.696353,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "skp",
+    "node_id": "skp-beliefs-152",
+    "score": 0.622751,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-122",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.620544,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "acc",
+    "node_id": "acc-beliefs-008",
+    "score": 0.551554,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "acc",
+    "node_id": "acc-beliefs-023",
+    "score": 0.514437,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "acc",
+    "node_id": "acc-intentions-076",
+    "score": 0.482476,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "saf",
+    "node_id": "saf-intentions-168",
+    "score": 0.529151,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "saf",
+    "node_id": "saf-beliefs-250",
+    "score": 0.470771,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "saf",
+    "node_id": "saf-beliefs-251",
+    "score": 0.470771,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "skp",
+    "node_id": "skp-beliefs-252",
+    "score": 0.608422,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "skp",
+    "node_id": "skp-beliefs-254",
+    "score": 0.505044,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-123",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.471285,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.627147,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "acc",
+    "node_id": "acc-beliefs-078",
+    "score": 0.604033,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.603204,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.781548,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "saf",
+    "node_id": "saf-intentions-202",
+    "score": 0.776961,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "saf",
+    "node_id": "saf-intentions-025",
+    "score": 0.763964,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.68699,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.677906,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-124",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.664698,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.553546,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.529968,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "acc",
+    "node_id": "acc-desires-028",
+    "score": 0.495836,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.748113,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.631163,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.58437,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "skp",
+    "node_id": "skp-beliefs-052",
+    "score": 0.655466,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "skp",
+    "node_id": "skp-beliefs-201",
+    "score": 0.651916,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-125",
+    "camp": "skp",
+    "node_id": "skp-beliefs-026",
+    "score": 0.651102,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.626575,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "acc",
+    "node_id": "acc-intentions-071",
+    "score": 0.622019,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.594339,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.713026,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.7011,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.641383,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.714497,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "skp",
+    "node_id": "skp-intentions-044",
+    "score": 0.667776,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-126",
+    "camp": "skp",
+    "node_id": "skp-beliefs-256",
+    "score": 0.624088,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.531226,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.525365,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "acc",
+    "node_id": "acc-beliefs-092",
+    "score": 0.516288,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "saf",
+    "node_id": "saf-beliefs-050",
+    "score": 0.600533,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "saf",
+    "node_id": "saf-beliefs-101",
+    "score": 0.579526,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.56291,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "skp",
+    "node_id": "skp-beliefs-074",
+    "score": 0.585221,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "skp",
+    "node_id": "skp-beliefs-145",
+    "score": 0.563858,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-127",
+    "camp": "skp",
+    "node_id": "skp-intentions-087",
+    "score": 0.529081,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "acc",
+    "node_id": "acc-beliefs-093",
+    "score": 0.655238,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.626251,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.604837,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.727072,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.719858,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "saf",
+    "node_id": "saf-beliefs-030",
+    "score": 0.711103,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "skp",
+    "node_id": "skp-beliefs-178",
+    "score": 0.675387,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.661885,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-128",
+    "camp": "skp",
+    "node_id": "skp-beliefs-288",
+    "score": 0.657811,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.520395,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "acc",
+    "node_id": "acc-desires-040",
+    "score": 0.506022,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.492397,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "saf",
+    "node_id": "saf-beliefs-046",
+    "score": 0.582259,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.580076,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.557024,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "skp",
+    "node_id": "skp-beliefs-038",
+    "score": 0.789217,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "skp",
+    "node_id": "skp-beliefs-121",
+    "score": 0.780799,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-130",
+    "camp": "skp",
+    "node_id": "skp-beliefs-142",
+    "score": 0.728793,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.577074,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.574145,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.54665,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "saf",
+    "node_id": "saf-intentions-061",
+    "score": 0.685921,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.649012,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.636298,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.61828,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "skp",
+    "node_id": "skp-intentions-097",
+    "score": 0.615104,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-131",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.60402,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.638254,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "acc",
+    "node_id": "acc-beliefs-111",
+    "score": 0.612533,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "acc",
+    "node_id": "acc-beliefs-112",
+    "score": 0.612533,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "saf",
+    "node_id": "saf-intentions-114",
+    "score": 0.669611,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.590321,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "saf",
+    "node_id": "saf-desires-003",
+    "score": 0.570999,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "skp",
+    "node_id": "skp-beliefs-287",
+    "score": 0.673476,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.621769,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-132",
+    "camp": "skp",
+    "node_id": "skp-beliefs-278",
+    "score": 0.613248,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.653889,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.624925,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.572662,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.73723,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.698557,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "saf",
+    "node_id": "saf-intentions-067",
+    "score": 0.686547,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.682807,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.629472,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-133",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.623772,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.746154,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.724198,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.694394,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.775757,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.766356,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.757339,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.772811,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.74384,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-134",
+    "camp": "skp",
+    "node_id": "skp-intentions-108",
+    "score": 0.700446,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.506149,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "acc",
+    "node_id": "acc-intentions-092",
+    "score": 0.505989,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.499561,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "saf",
+    "node_id": "saf-beliefs-054",
+    "score": 0.710767,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "saf",
+    "node_id": "saf-beliefs-133",
+    "score": 0.59889,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "saf",
+    "node_id": "saf-intentions-143",
+    "score": 0.590522,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "skp",
+    "node_id": "skp-intentions-014",
+    "score": 0.669556,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "skp",
+    "node_id": "skp-beliefs-005",
+    "score": 0.619844,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-135",
+    "camp": "skp",
+    "node_id": "skp-intentions-008",
+    "score": 0.613457,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.607827,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "acc",
+    "node_id": "acc-intentions-013",
+    "score": 0.586112,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "acc",
+    "node_id": "acc-beliefs-024",
+    "score": 0.498186,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "saf",
+    "node_id": "saf-beliefs-046",
+    "score": 0.535169,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.503029,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.467756,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "skp",
+    "node_id": "skp-beliefs-166",
+    "score": 0.575152,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "skp",
+    "node_id": "skp-beliefs-214",
+    "score": 0.570844,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-136",
+    "camp": "skp",
+    "node_id": "skp-beliefs-002",
+    "score": 0.549492,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.549732,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "acc",
+    "node_id": "acc-beliefs-084",
+    "score": 0.542699,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "acc",
+    "node_id": "acc-intentions-076",
+    "score": 0.537333,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.611282,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "saf",
+    "node_id": "saf-intentions-076",
+    "score": 0.601732,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.591717,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.64645,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "skp",
+    "node_id": "skp-beliefs-008",
+    "score": 0.604687,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-137",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.604085,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "acc",
+    "node_id": "acc-intentions-029",
+    "score": 0.639276,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "acc",
+    "node_id": "acc-beliefs-076",
+    "score": 0.6229,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "acc",
+    "node_id": "acc-beliefs-107",
+    "score": 0.601235,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "saf",
+    "node_id": "saf-intentions-119",
+    "score": 0.649835,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "saf",
+    "node_id": "saf-beliefs-200",
+    "score": 0.633247,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.631627,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "skp",
+    "node_id": "skp-beliefs-029",
+    "score": 0.681185,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "skp",
+    "node_id": "skp-intentions-104",
+    "score": 0.671747,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-138",
+    "camp": "skp",
+    "node_id": "skp-intentions-087",
+    "score": 0.645475,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.673872,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.650166,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.645777,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.731574,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.710521,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.705091,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.656497,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.648415,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-139",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.641216,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "acc",
+    "node_id": "acc-desires-011",
+    "score": 0.584062,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.539176,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.531174,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "saf",
+    "node_id": "saf-intentions-039",
+    "score": 0.600991,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "saf",
+    "node_id": "saf-beliefs-146",
+    "score": 0.572076,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.555678,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "skp",
+    "node_id": "skp-intentions-044",
+    "score": 0.654416,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.638104,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-140",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.633081,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.647053,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "acc",
+    "node_id": "acc-intentions-006",
+    "score": 0.587865,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.578938,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "saf",
+    "node_id": "saf-beliefs-137",
+    "score": 0.678934,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "saf",
+    "node_id": "saf-beliefs-013",
+    "score": 0.64388,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.625896,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.72696,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.70038,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-141",
+    "camp": "skp",
+    "node_id": "skp-intentions-145",
+    "score": 0.639443,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.495578,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.494069,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.468469,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "saf",
+    "node_id": "saf-beliefs-063",
+    "score": 0.734502,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "saf",
+    "node_id": "saf-beliefs-104",
+    "score": 0.675405,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.617391,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.668237,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "skp",
+    "node_id": "skp-beliefs-004",
+    "score": 0.659559,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-142",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.612363,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.634713,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.620417,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.615405,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.620146,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.605927,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.556877,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.655942,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.64731,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-143",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.624414,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.603643,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.595099,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.59092,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.664934,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "saf",
+    "node_id": "saf-beliefs-017",
+    "score": 0.662711,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.654003,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.72638,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.66701,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-151",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.646853,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.676902,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.658988,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.655457,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.704739,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.66764,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.661794,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.652901,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.650225,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-152",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.647093,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.594124,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.582048,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "acc",
+    "node_id": "acc-intentions-086",
+    "score": 0.571832,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.641451,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "saf",
+    "node_id": "saf-intentions-127",
+    "score": 0.62997,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "saf",
+    "node_id": "saf-intentions-061",
+    "score": 0.625607,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.731708,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.687406,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-153",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.684074,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.702318,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.653861,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.597945,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.758633,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "saf",
+    "node_id": "saf-beliefs-040",
+    "score": 0.72146,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "saf",
+    "node_id": "saf-intentions-007",
+    "score": 0.719877,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.716,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.703809,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-155",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.694899,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.593365,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.557539,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.557155,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.664256,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.619342,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.596311,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "skp",
+    "node_id": "skp-beliefs-044",
+    "score": 0.683795,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "skp",
+    "node_id": "skp-beliefs-018",
+    "score": 0.671113,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-156",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.630369,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.601516,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.582265,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.574727,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "saf",
+    "node_id": "saf-beliefs-057",
+    "score": 0.620072,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "saf",
+    "node_id": "saf-desires-003",
+    "score": 0.616538,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "saf",
+    "node_id": "saf-beliefs-098",
+    "score": 0.603588,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.603091,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "skp",
+    "node_id": "skp-beliefs-064",
+    "score": 0.577058,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-157",
+    "camp": "skp",
+    "node_id": "skp-beliefs-044",
+    "score": 0.563129,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.67976,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "acc",
+    "node_id": "acc-desires-040",
+    "score": 0.59821,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "acc",
+    "node_id": "acc-intentions-013",
+    "score": 0.577662,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.606691,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.59745,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.594699,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "skp",
+    "node_id": "skp-beliefs-121",
+    "score": 0.711567,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.699104,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-158",
+    "camp": "skp",
+    "node_id": "skp-beliefs-038",
+    "score": 0.683131,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.531426,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.531209,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.53102,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "saf",
+    "node_id": "saf-intentions-047",
+    "score": 0.680463,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "saf",
+    "node_id": "saf-intentions-068",
+    "score": 0.643697,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "saf",
+    "node_id": "saf-intentions-214",
+    "score": 0.64028,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.641993,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "skp",
+    "node_id": "skp-intentions-104",
+    "score": 0.609321,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-159",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.600069,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.716959,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.667754,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.650036,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "saf",
+    "node_id": "saf-beliefs-090",
+    "score": 0.669467,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.607394,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.603503,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.700624,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.648588,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-160",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.637306,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.702858,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.694088,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "acc",
+    "node_id": "acc-beliefs-025",
+    "score": 0.683384,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.742171,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "saf",
+    "node_id": "saf-desires-006",
+    "score": 0.735456,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "saf",
+    "node_id": "saf-beliefs-017",
+    "score": 0.719295,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.79322,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.781353,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-161",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.77164,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.671212,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.663885,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.662927,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.644458,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.633209,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.607503,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.708811,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "skp",
+    "node_id": "skp-beliefs-167",
+    "score": 0.682173,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-162",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.661521,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.608996,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.598732,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.593132,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.669123,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "saf",
+    "node_id": "saf-beliefs-104",
+    "score": 0.647471,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "saf",
+    "node_id": "saf-intentions-126",
+    "score": 0.619346,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.723214,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "skp",
+    "node_id": "skp-beliefs-095",
+    "score": 0.718467,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-163",
+    "camp": "skp",
+    "node_id": "skp-intentions-014",
+    "score": 0.643492,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.628514,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "acc",
+    "node_id": "acc-beliefs-078",
+    "score": 0.625286,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.623575,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.716995,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.695213,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "saf",
+    "node_id": "saf-desires-004",
+    "score": 0.694224,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.709889,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.67328,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-164",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.66749,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.525612,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.497738,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.488823,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "saf",
+    "node_id": "saf-intentions-142",
+    "score": 0.668883,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "saf",
+    "node_id": "saf-beliefs-050",
+    "score": 0.668405,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "saf",
+    "node_id": "saf-beliefs-057",
+    "score": 0.615345,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.672966,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.631303,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-165",
+    "camp": "skp",
+    "node_id": "skp-intentions-087",
+    "score": 0.591856,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.67656,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.668959,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.65988,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "saf",
+    "node_id": "saf-beliefs-217",
+    "score": 0.789943,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.781489,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "saf",
+    "node_id": "saf-beliefs-210",
+    "score": 0.780349,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.771737,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.760853,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-166",
+    "camp": "skp",
+    "node_id": "skp-desires-087",
+    "score": 0.710184,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.602065,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.587341,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "acc",
+    "node_id": "acc-intentions-006",
+    "score": 0.568267,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "saf",
+    "node_id": "saf-beliefs-013",
+    "score": 0.662556,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.656569,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.633587,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.734009,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.702991,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-167",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.674245,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "acc",
+    "node_id": "acc-intentions-006",
+    "score": 0.699627,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.628362,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.626941,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "saf",
+    "node_id": "saf-intentions-085",
+    "score": 0.707924,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "saf",
+    "node_id": "saf-beliefs-117",
+    "score": 0.701629,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.694125,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.659244,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "skp",
+    "node_id": "skp-beliefs-167",
+    "score": 0.644647,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-168",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.641232,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.770986,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.70776,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.706835,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "saf",
+    "node_id": "saf-beliefs-210",
+    "score": 0.739228,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.718927,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.686997,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.797617,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.689903,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-169",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.67715,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.710078,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.705318,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.698865,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.737541,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.724393,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.71124,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.728844,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.699471,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-170",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.688207,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.653812,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.644143,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.621538,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.776375,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.673611,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.669614,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.655145,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.655058,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-171",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.646581,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.592674,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.545598,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.542956,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.659133,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "saf",
+    "node_id": "saf-beliefs-050",
+    "score": 0.648355,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.61154,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.604676,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "skp",
+    "node_id": "skp-beliefs-152",
+    "score": 0.583013,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-172",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.57542,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.736133,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.650576,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.643726,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.774379,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.726395,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.719247,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.761268,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.730863,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-173",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.716873,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.77771,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.731086,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.72848,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "saf",
+    "node_id": "saf-intentions-210",
+    "score": 0.754321,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.745799,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.743368,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.759877,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.703191,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-174",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.674056,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "acc",
+    "node_id": "acc-beliefs-101",
+    "score": 0.633376,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "acc",
+    "node_id": "acc-beliefs-091",
+    "score": 0.5185,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "acc",
+    "node_id": "acc-beliefs-077",
+    "score": 0.516209,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "saf",
+    "node_id": "saf-beliefs-265",
+    "score": 0.69851,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "saf",
+    "node_id": "saf-beliefs-263",
+    "score": 0.598806,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "saf",
+    "node_id": "saf-beliefs-239",
+    "score": 0.595772,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "skp",
+    "node_id": "skp-intentions-121",
+    "score": 0.579709,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "skp",
+    "node_id": "skp-beliefs-234",
+    "score": 0.555387,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-175",
+    "camp": "skp",
+    "node_id": "skp-beliefs-239",
+    "score": 0.531843,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "acc",
+    "node_id": "acc-beliefs-077",
+    "score": 0.632783,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.625423,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "acc",
+    "node_id": "acc-intentions-116",
+    "score": 0.616164,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "saf",
+    "node_id": "saf-beliefs-215",
+    "score": 0.646846,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "saf",
+    "node_id": "saf-desires-028",
+    "score": 0.627822,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "saf",
+    "node_id": "saf-beliefs-244",
+    "score": 0.611451,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "skp",
+    "node_id": "skp-beliefs-239",
+    "score": 0.648603,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.61142,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-176",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.572904,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "acc",
+    "node_id": "acc-beliefs-093",
+    "score": 0.745038,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.664934,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.617486,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "saf",
+    "node_id": "saf-beliefs-217",
+    "score": 0.818242,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.680648,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.667619,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.717824,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.696616,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-177",
+    "camp": "skp",
+    "node_id": "skp-beliefs-234",
+    "score": 0.67904,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.650034,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.630353,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.552724,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "saf",
+    "node_id": "saf-intentions-001",
+    "score": 0.581945,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "saf",
+    "node_id": "saf-intentions-234",
+    "score": 0.579514,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.561356,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "skp",
+    "node_id": "skp-intentions-008",
+    "score": 0.609384,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "skp",
+    "node_id": "skp-beliefs-111",
+    "score": 0.5454,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-178",
+    "camp": "skp",
+    "node_id": "skp-desires-003",
+    "score": 0.54474,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "acc",
+    "node_id": "acc-beliefs-101",
+    "score": 0.632056,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.542891,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "acc",
+    "node_id": "acc-beliefs-093",
+    "score": 0.527598,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "saf",
+    "node_id": "saf-beliefs-239",
+    "score": 0.560508,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "saf",
+    "node_id": "saf-beliefs-265",
+    "score": 0.556258,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "saf",
+    "node_id": "saf-intentions-246",
+    "score": 0.532947,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "skp",
+    "node_id": "skp-intentions-121",
+    "score": 0.568159,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "skp",
+    "node_id": "skp-intentions-008",
+    "score": 0.561227,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-179",
+    "camp": "skp",
+    "node_id": "skp-beliefs-272",
+    "score": 0.54919,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.801279,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.54081,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.534207,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "saf",
+    "node_id": "saf-beliefs-213",
+    "score": 0.652766,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.60357,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.581233,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.688553,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "skp",
+    "node_id": "skp-beliefs-260",
+    "score": 0.656999,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-180",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.594256,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "acc",
+    "node_id": "acc-beliefs-098",
+    "score": 0.621558,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.505113,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "acc",
+    "node_id": "acc-intentions-092",
+    "score": 0.504332,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "saf",
+    "node_id": "saf-intentions-222",
+    "score": 0.580908,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.52353,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "saf",
+    "node_id": "saf-beliefs-248",
+    "score": 0.519228,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "skp",
+    "node_id": "skp-beliefs-268",
+    "score": 0.644079,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "skp",
+    "node_id": "skp-desires-067",
+    "score": 0.619392,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-181",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.586208,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "acc",
+    "node_id": "acc-beliefs-008",
+    "score": 0.51473,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "acc",
+    "node_id": "acc-intentions-072",
+    "score": 0.479921,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "acc",
+    "node_id": "acc-intentions-068",
+    "score": 0.464705,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.551349,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.547279,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.541701,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "skp",
+    "node_id": "skp-desires-086",
+    "score": 0.559513,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "skp",
+    "node_id": "skp-beliefs-096",
+    "score": 0.535076,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-201",
+    "camp": "skp",
+    "node_id": "skp-beliefs-075",
+    "score": 0.474437,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.477324,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "acc",
+    "node_id": "acc-intentions-106",
+    "score": 0.449119,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.447046,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "saf",
+    "node_id": "saf-intentions-155",
+    "score": 0.625317,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.545796,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "saf",
+    "node_id": "saf-intentions-163",
+    "score": 0.525142,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "skp",
+    "node_id": "skp-beliefs-111",
+    "score": 0.614099,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "skp",
+    "node_id": "skp-intentions-131",
+    "score": 0.519914,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-202",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.495322,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "acc",
+    "node_id": "acc-desires-018",
+    "score": 0.604699,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.559178,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.52944,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "saf",
+    "node_id": "saf-intentions-145",
+    "score": 0.617329,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "saf",
+    "node_id": "saf-beliefs-091",
+    "score": 0.596751,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "saf",
+    "node_id": "saf-intentions-149",
+    "score": 0.595051,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.582315,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "skp",
+    "node_id": "skp-intentions-104",
+    "score": 0.565157,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-203",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.562516,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "acc",
+    "node_id": "acc-intentions-104",
+    "score": 0.595471,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.574235,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "acc",
+    "node_id": "acc-beliefs-071",
+    "score": 0.562299,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "saf",
+    "node_id": "saf-beliefs-051",
+    "score": 0.694247,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "saf",
+    "node_id": "saf-intentions-031",
+    "score": 0.606368,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.596601,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.763147,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "skp",
+    "node_id": "skp-beliefs-160",
+    "score": 0.684097,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-204",
+    "camp": "skp",
+    "node_id": "skp-beliefs-094",
+    "score": 0.646723,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.546079,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "acc",
+    "node_id": "acc-beliefs-015",
+    "score": 0.544444,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "acc",
+    "node_id": "acc-desires-025",
+    "score": 0.535039,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.577286,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.577076,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.571757,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.659368,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "skp",
+    "node_id": "skp-beliefs-122",
+    "score": 0.629369,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-205",
+    "camp": "skp",
+    "node_id": "skp-beliefs-095",
+    "score": 0.618211,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "acc",
+    "node_id": "acc-beliefs-015",
+    "score": 0.533586,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.499997,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "acc",
+    "node_id": "acc-beliefs-055",
+    "score": 0.490659,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "saf",
+    "node_id": "saf-beliefs-051",
+    "score": 0.657112,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "saf",
+    "node_id": "saf-beliefs-101",
+    "score": 0.574318,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "saf",
+    "node_id": "saf-desires-003",
+    "score": 0.554592,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.653204,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "skp",
+    "node_id": "skp-beliefs-160",
+    "score": 0.622859,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-206",
+    "camp": "skp",
+    "node_id": "skp-beliefs-173",
+    "score": 0.574079,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.604344,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.556517,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.524872,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.590126,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "saf",
+    "node_id": "saf-intentions-037",
+    "score": 0.563585,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "saf",
+    "node_id": "saf-intentions-089",
+    "score": 0.546832,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.637,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.631711,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-207",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.612191,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "acc",
+    "node_id": "acc-beliefs-024",
+    "score": 0.682103,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.582534,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.581886,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "saf",
+    "node_id": "saf-desires-001",
+    "score": 0.744074,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.69034,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.6882,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "skp",
+    "node_id": "skp-intentions-141",
+    "score": 0.660767,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.618119,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-208",
+    "camp": "skp",
+    "node_id": "skp-intentions-165",
+    "score": 0.602714,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.656164,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.635135,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.618192,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "saf",
+    "node_id": "saf-intentions-167",
+    "score": 0.739086,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "saf",
+    "node_id": "saf-desires-026",
+    "score": 0.734493,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "saf",
+    "node_id": "saf-intentions-210",
+    "score": 0.700077,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.660417,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "skp",
+    "node_id": "skp-intentions-165",
+    "score": 0.634888,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-209",
+    "camp": "skp",
+    "node_id": "skp-desires-088",
+    "score": 0.62971,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.69699,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "acc",
+    "node_id": "acc-intentions-056",
+    "score": 0.661164,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.648206,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.727862,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.71633,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "saf",
+    "node_id": "saf-intentions-085",
+    "score": 0.705682,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.696075,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.670034,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-210",
+    "camp": "skp",
+    "node_id": "skp-intentions-097",
+    "score": 0.655673,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.60326,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.579864,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.572439,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.653472,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "saf",
+    "node_id": "saf-intentions-047",
+    "score": 0.652489,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "saf",
+    "node_id": "saf-intentions-200",
+    "score": 0.651376,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.708865,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.704806,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-211",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.700263,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "acc",
+    "node_id": "acc-intentions-070",
+    "score": 0.387443,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "acc",
+    "node_id": "acc-intentions-076",
+    "score": 0.345981,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "acc",
+    "node_id": "acc-intentions-111",
+    "score": 0.34121,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "saf",
+    "node_id": "saf-intentions-212",
+    "score": 0.502618,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "saf",
+    "node_id": "saf-beliefs-247",
+    "score": 0.448387,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "saf",
+    "node_id": "saf-beliefs-044",
+    "score": 0.403304,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "skp",
+    "node_id": "skp-intentions-150",
+    "score": 0.58488,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "skp",
+    "node_id": "skp-beliefs-222",
+    "score": 0.562356,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-212",
+    "camp": "skp",
+    "node_id": "skp-beliefs-017",
+    "score": 0.518583,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "acc",
+    "node_id": "acc-intentions-076",
+    "score": 0.601903,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.600093,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "acc",
+    "node_id": "acc-desires-026",
+    "score": 0.55678,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "saf",
+    "node_id": "saf-beliefs-044",
+    "score": 0.660235,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "saf",
+    "node_id": "saf-beliefs-247",
+    "score": 0.536657,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "saf",
+    "node_id": "saf-beliefs-050",
+    "score": 0.526245,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "skp",
+    "node_id": "skp-beliefs-009",
+    "score": 0.69514,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "skp",
+    "node_id": "skp-beliefs-054",
+    "score": 0.693644,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-213",
+    "camp": "skp",
+    "node_id": "skp-intentions-044",
+    "score": 0.684496,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.563823,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.533644,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.528214,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "saf",
+    "node_id": "saf-intentions-015",
+    "score": 0.586072,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "saf",
+    "node_id": "saf-beliefs-040",
+    "score": 0.578685,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "saf",
+    "node_id": "saf-beliefs-038",
+    "score": 0.56211,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.533156,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.51509,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-214",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.514734,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.538899,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.533453,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "acc",
+    "node_id": "acc-beliefs-079",
+    "score": 0.533052,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.589272,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.587076,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "saf",
+    "node_id": "saf-desires-004",
+    "score": 0.569755,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "skp",
+    "node_id": "skp-beliefs-146",
+    "score": 0.519396,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "skp",
+    "node_id": "skp-beliefs-028",
+    "score": 0.51891,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-215",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.49756,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.698683,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.620566,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.592099,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.574852,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "saf",
+    "node_id": "saf-intentions-144",
+    "score": 0.568656,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.557356,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "skp",
+    "node_id": "skp-beliefs-146",
+    "score": 0.605181,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "skp",
+    "node_id": "skp-beliefs-131",
+    "score": 0.597711,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-216",
+    "camp": "skp",
+    "node_id": "skp-beliefs-133",
+    "score": 0.577437,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "acc",
+    "node_id": "acc-intentions-075",
+    "score": 0.611958,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.606073,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.60027,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.646249,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.616053,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.613019,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "skp",
+    "node_id": "skp-desires-088",
+    "score": 0.625451,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.606495,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-217",
+    "camp": "skp",
+    "node_id": "skp-intentions-069",
+    "score": 0.606076,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.525995,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.512703,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.50364,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "saf",
+    "node_id": "saf-desires-004",
+    "score": 0.582236,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "saf",
+    "node_id": "saf-desires-006",
+    "score": 0.570984,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "saf",
+    "node_id": "saf-intentions-139",
+    "score": 0.539141,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "skp",
+    "node_id": "skp-beliefs-070",
+    "score": 0.564306,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "skp",
+    "node_id": "skp-beliefs-146",
+    "score": 0.536606,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-218",
+    "camp": "skp",
+    "node_id": "skp-beliefs-131",
+    "score": 0.532076,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.594099,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.580727,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "acc",
+    "node_id": "acc-desires-028",
+    "score": 0.578229,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "saf",
+    "node_id": "saf-intentions-052",
+    "score": 0.657771,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.630542,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "saf",
+    "node_id": "saf-intentions-080",
+    "score": 0.617474,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "skp",
+    "node_id": "skp-intentions-139",
+    "score": 0.643048,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.642335,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-219",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.633766,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.452119,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "acc",
+    "node_id": "acc-intentions-109",
+    "score": 0.444959,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.431159,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "saf",
+    "node_id": "saf-intentions-043",
+    "score": 0.499108,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.482822,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "saf",
+    "node_id": "saf-desires-009",
+    "score": 0.477326,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.500224,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.484979,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-220",
+    "camp": "skp",
+    "node_id": "skp-beliefs-144",
+    "score": 0.473679,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.585305,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.552391,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "acc",
+    "node_id": "acc-intentions-099",
+    "score": 0.540266,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.59873,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.596538,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "saf",
+    "node_id": "saf-beliefs-228",
+    "score": 0.595101,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.544063,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.530275,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-221",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.523245,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "acc",
+    "node_id": "acc-beliefs-094",
+    "score": 0.523438,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.521459,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.516176,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.67233,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "saf",
+    "node_id": "saf-beliefs-132",
+    "score": 0.669558,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.657711,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.645026,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.628493,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-222",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.624104,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.609196,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.559876,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.547152,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "saf",
+    "node_id": "saf-intentions-149",
+    "score": 0.592451,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "saf",
+    "node_id": "saf-beliefs-205",
+    "score": 0.587976,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "saf",
+    "node_id": "saf-beliefs-106",
+    "score": 0.577949,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.654862,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "skp",
+    "node_id": "skp-beliefs-279",
+    "score": 0.639742,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-223",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.636874,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.60502,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.575123,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.571771,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "saf",
+    "node_id": "saf-desires-019",
+    "score": 0.62324,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.611064,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "saf",
+    "node_id": "saf-intentions-213",
+    "score": 0.604991,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.594045,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.588522,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-224",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.586319,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.50691,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "acc",
+    "node_id": "acc-intentions-027",
+    "score": 0.503508,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.483078,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.608028,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.607991,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "saf",
+    "node_id": "saf-intentions-003",
+    "score": 0.595572,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "skp",
+    "node_id": "skp-beliefs-133",
+    "score": 0.533878,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "skp",
+    "node_id": "skp-intentions-029",
+    "score": 0.513707,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-225",
+    "camp": "skp",
+    "node_id": "skp-beliefs-146",
+    "score": 0.513272,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.527062,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "acc",
+    "node_id": "acc-beliefs-025",
+    "score": 0.517343,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "acc",
+    "node_id": "acc-beliefs-110",
+    "score": 0.509439,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.657953,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.646293,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.645277,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "skp",
+    "node_id": "skp-beliefs-111",
+    "score": 0.658354,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.641691,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-226",
+    "camp": "skp",
+    "node_id": "skp-intentions-155",
+    "score": 0.641392,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.639808,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.629254,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.622042,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.701789,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "saf",
+    "node_id": "saf-intentions-058",
+    "score": 0.676252,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.675999,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "skp",
+    "node_id": "skp-intentions-143",
+    "score": 0.725596,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.723843,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-227",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.7215,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.729353,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.709591,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.592733,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "saf",
+    "node_id": "saf-intentions-015",
+    "score": 0.695669,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "saf",
+    "node_id": "saf-intentions-007",
+    "score": 0.657029,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "saf",
+    "node_id": "saf-desires-002",
+    "score": 0.633053,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.612106,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.609962,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-228",
+    "camp": "skp",
+    "node_id": "skp-intentions-165",
+    "score": 0.597965,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.538454,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.528656,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "acc",
+    "node_id": "acc-beliefs-092",
+    "score": 0.503371,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.641969,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.638928,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "saf",
+    "node_id": "saf-beliefs-057",
+    "score": 0.628157,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.651918,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.634569,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-229",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.626299,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "acc",
+    "node_id": "acc-intentions-073",
+    "score": 0.619722,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "acc",
+    "node_id": "acc-beliefs-078",
+    "score": 0.589605,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.58192,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.704892,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.686987,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.65906,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.679581,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "skp",
+    "node_id": "skp-intentions-143",
+    "score": 0.65246,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-230",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.651507,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.638965,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.608215,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.602893,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.622156,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.60784,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "saf",
+    "node_id": "saf-intentions-003",
+    "score": 0.605295,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.693778,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "skp",
+    "node_id": "skp-beliefs-044",
+    "score": 0.64332,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-231",
+    "camp": "skp",
+    "node_id": "skp-beliefs-133",
+    "score": 0.635273,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.507265,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.500608,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.496419,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.610652,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "saf",
+    "node_id": "saf-intentions-137",
+    "score": 0.588808,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "saf",
+    "node_id": "saf-beliefs-050",
+    "score": 0.580889,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.685438,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "skp",
+    "node_id": "skp-intentions-087",
+    "score": 0.620736,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-232",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.615887,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "acc",
+    "node_id": "acc-desires-040",
+    "score": 0.602262,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.467753,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "acc",
+    "node_id": "acc-intentions-089",
+    "score": 0.458528,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "saf",
+    "node_id": "saf-intentions-162",
+    "score": 0.531769,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "saf",
+    "node_id": "saf-intentions-025",
+    "score": 0.51014,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "saf",
+    "node_id": "saf-intentions-164",
+    "score": 0.507462,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.535221,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.524393,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-233",
+    "camp": "skp",
+    "node_id": "skp-beliefs-139",
+    "score": 0.515787,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.721293,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "acc",
+    "node_id": "acc-intentions-005",
+    "score": 0.662195,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.661651,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.710231,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.696569,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "saf",
+    "node_id": "saf-intentions-025",
+    "score": 0.689125,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "skp",
+    "node_id": "skp-beliefs-291",
+    "score": 0.691423,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.687523,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-234",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.686868,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "acc",
+    "node_id": "acc-desires-041",
+    "score": 0.638194,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "acc",
+    "node_id": "acc-desires-023",
+    "score": 0.545221,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "acc",
+    "node_id": "acc-intentions-006",
+    "score": 0.525785,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.559627,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "saf",
+    "node_id": "saf-intentions-162",
+    "score": 0.558269,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "saf",
+    "node_id": "saf-intentions-168",
+    "score": 0.555626,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "skp",
+    "node_id": "skp-beliefs-171",
+    "score": 0.524343,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.517027,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-235",
+    "camp": "skp",
+    "node_id": "skp-desires-011",
+    "score": 0.516229,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "acc",
+    "node_id": "acc-desires-040",
+    "score": 0.637786,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "acc",
+    "node_id": "acc-beliefs-026",
+    "score": 0.592809,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "acc",
+    "node_id": "acc-desires-038",
+    "score": 0.542711,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.460798,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.449086,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.414994,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.566875,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.528699,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-236",
+    "camp": "skp",
+    "node_id": "skp-intentions-145",
+    "score": 0.503063,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.641876,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.605508,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "acc",
+    "node_id": "acc-beliefs-024",
+    "score": 0.603849,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.617914,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.605927,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.595306,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "skp",
+    "node_id": "skp-intentions-141",
+    "score": 0.573393,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.572906,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-237",
+    "camp": "skp",
+    "node_id": "skp-beliefs-096",
+    "score": 0.565892,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.533277,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "acc",
+    "node_id": "acc-intentions-086",
+    "score": 0.531359,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.517502,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.67512,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.674342,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "saf",
+    "node_id": "saf-intentions-058",
+    "score": 0.645344,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "skp",
+    "node_id": "skp-beliefs-146",
+    "score": 0.592408,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.584941,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-238",
+    "camp": "skp",
+    "node_id": "skp-beliefs-133",
+    "score": 0.560863,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.647115,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.639396,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.605006,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.716324,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "saf",
+    "node_id": "saf-beliefs-017",
+    "score": 0.703561,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "saf",
+    "node_id": "saf-beliefs-040",
+    "score": 0.668694,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.681863,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.676693,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-239",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.67104,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.639088,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.586851,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.574652,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.711679,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "saf",
+    "node_id": "saf-intentions-058",
+    "score": 0.686794,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "saf",
+    "node_id": "saf-beliefs-017",
+    "score": 0.67257,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.724671,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.682852,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-240",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.668712,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.649348,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.525535,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.525535,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "saf",
+    "node_id": "saf-beliefs-049",
+    "score": 0.663078,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.661348,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.629727,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "skp",
+    "node_id": "skp-beliefs-299",
+    "score": 0.706205,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.559699,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-241",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.536267,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.525029,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.515327,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.495421,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.594912,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.577122,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "saf",
+    "node_id": "saf-beliefs-248",
+    "score": 0.541046,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.645712,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.633658,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-242",
+    "camp": "skp",
+    "node_id": "skp-intentions-104",
+    "score": 0.585295,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "acc",
+    "node_id": "acc-beliefs-083",
+    "score": 0.634367,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.567999,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.551189,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "saf",
+    "node_id": "saf-beliefs-263",
+    "score": 0.68129,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "saf",
+    "node_id": "saf-beliefs-265",
+    "score": 0.593526,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.573224,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "skp",
+    "node_id": "skp-beliefs-190",
+    "score": 0.633318,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.625178,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-243",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.599013,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.612288,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.61197,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.593475,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "saf",
+    "node_id": "saf-intentions-239",
+    "score": 0.646613,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "saf",
+    "node_id": "saf-beliefs-106",
+    "score": 0.608945,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "saf",
+    "node_id": "saf-intentions-125",
+    "score": 0.605476,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "skp",
+    "node_id": "skp-beliefs-225",
+    "score": 0.598694,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "skp",
+    "node_id": "skp-intentions-112",
+    "score": 0.586783,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-244",
+    "camp": "skp",
+    "node_id": "skp-beliefs-195",
+    "score": 0.574872,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.657047,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.633071,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.616682,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.728219,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.724978,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.715932,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.726132,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "skp",
+    "node_id": "skp-beliefs-148",
+    "score": 0.672538,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-245",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.666712,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.640934,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "acc",
+    "node_id": "acc-intentions-013",
+    "score": 0.626997,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "acc",
+    "node_id": "acc-beliefs-060",
+    "score": 0.557874,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "saf",
+    "node_id": "saf-beliefs-046",
+    "score": 0.637682,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.611972,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "saf",
+    "node_id": "saf-beliefs-100",
+    "score": 0.611148,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "skp",
+    "node_id": "skp-beliefs-002",
+    "score": 0.659155,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.654603,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-246",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.626156,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "acc",
+    "node_id": "acc-beliefs-024",
+    "score": 0.559588,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.559396,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "acc",
+    "node_id": "acc-intentions-005",
+    "score": 0.552928,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.648811,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.639865,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.638633,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.641393,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.599267,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-247",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.577046,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.568439,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.546976,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.534808,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "saf",
+    "node_id": "saf-intentions-025",
+    "score": 0.587881,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.586207,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "saf",
+    "node_id": "saf-intentions-058",
+    "score": 0.577083,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.675874,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.664821,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-248",
+    "camp": "skp",
+    "node_id": "skp-desires-083",
+    "score": 0.588242,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.63359,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.594047,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.594047,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.514867,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "saf",
+    "node_id": "saf-beliefs-049",
+    "score": 0.509902,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.509014,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "skp",
+    "node_id": "skp-beliefs-299",
+    "score": 0.647203,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.569959,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-249",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.557791,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.609289,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.583949,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.53772,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.533341,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.529189,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "saf",
+    "node_id": "saf-intentions-144",
+    "score": 0.517602,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.731014,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.6987,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-250",
+    "camp": "skp",
+    "node_id": "skp-intentions-034",
+    "score": 0.65672,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.70427,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "acc",
+    "node_id": "acc-intentions-056",
+    "score": 0.612578,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.560125,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "saf",
+    "node_id": "saf-beliefs-247",
+    "score": 0.649881,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "saf",
+    "node_id": "saf-beliefs-249",
+    "score": 0.609574,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "saf",
+    "node_id": "saf-beliefs-150",
+    "score": 0.603815,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "skp",
+    "node_id": "skp-beliefs-113",
+    "score": 0.637458,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.623657,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-251",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.571179,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.571657,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.548173,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.548173,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.623623,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.606006,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "saf",
+    "node_id": "saf-beliefs-049",
+    "score": 0.595154,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "skp",
+    "node_id": "skp-beliefs-094",
+    "score": 0.614854,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "skp",
+    "node_id": "skp-beliefs-299",
+    "score": 0.593546,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-252",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.570143,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.597246,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.586795,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "acc",
+    "node_id": "acc-desires-018",
+    "score": 0.586311,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "saf",
+    "node_id": "saf-intentions-025",
+    "score": 0.651553,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.640072,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.635718,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.684585,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.665662,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-253",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.63831,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.568584,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.567221,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.564904,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.682425,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.668987,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "saf",
+    "node_id": "saf-intentions-025",
+    "score": 0.662086,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.569006,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.558023,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-254",
+    "camp": "skp",
+    "node_id": "skp-intentions-145",
+    "score": 0.556648,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.592354,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.435537,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.435537,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.496054,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "saf",
+    "node_id": "saf-beliefs-049",
+    "score": 0.482216,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.47088,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "skp",
+    "node_id": "skp-beliefs-299",
+    "score": 0.598026,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.477444,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-255",
+    "camp": "skp",
+    "node_id": "skp-beliefs-125",
+    "score": 0.470199,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.561145,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.529931,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.529931,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.585481,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.553748,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "saf",
+    "node_id": "saf-beliefs-049",
+    "score": 0.55108,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.61681,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "skp",
+    "node_id": "skp-beliefs-299",
+    "score": 0.571185,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-256",
+    "camp": "skp",
+    "node_id": "skp-beliefs-125",
+    "score": 0.563707,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.557327,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.518768,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.515748,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.657026,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.647621,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "saf",
+    "node_id": "saf-intentions-089",
+    "score": 0.643066,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.649491,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "skp",
+    "node_id": "skp-desires-087",
+    "score": 0.635873,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-257",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.635305,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.452473,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.452473,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "acc",
+    "node_id": "acc-beliefs-055",
+    "score": 0.452138,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "saf",
+    "node_id": "saf-beliefs-117",
+    "score": 0.605787,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.587241,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "saf",
+    "node_id": "saf-intentions-027",
+    "score": 0.575809,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.665582,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "skp",
+    "node_id": "skp-beliefs-160",
+    "score": 0.659521,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-258",
+    "camp": "skp",
+    "node_id": "skp-beliefs-142",
+    "score": 0.645648,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "acc",
+    "node_id": "acc-intentions-112",
+    "score": 0.419454,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "acc",
+    "node_id": "acc-intentions-125",
+    "score": 0.374002,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "acc",
+    "node_id": "acc-intentions-118",
+    "score": 0.350372,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.497873,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "saf",
+    "node_id": "saf-beliefs-051",
+    "score": 0.45471,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "saf",
+    "node_id": "saf-desires-023",
+    "score": 0.449223,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "skp",
+    "node_id": "skp-beliefs-160",
+    "score": 0.581629,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.541138,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-259",
+    "camp": "skp",
+    "node_id": "skp-beliefs-061",
+    "score": 0.496514,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "acc",
+    "node_id": "acc-desires-025",
+    "score": 0.492818,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.466202,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.450798,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.567277,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "saf",
+    "node_id": "saf-beliefs-214",
+    "score": 0.534147,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "saf",
+    "node_id": "saf-intentions-027",
+    "score": 0.530724,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "skp",
+    "node_id": "skp-beliefs-113",
+    "score": 0.535349,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "skp",
+    "node_id": "skp-beliefs-249",
+    "score": 0.528251,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-260",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.511974,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.571013,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "acc",
+    "node_id": "acc-desires-028",
+    "score": 0.562532,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.559062,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "saf",
+    "node_id": "saf-beliefs-228",
+    "score": 0.6343,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "saf",
+    "node_id": "saf-beliefs-128",
+    "score": 0.62219,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "saf",
+    "node_id": "saf-beliefs-022",
+    "score": 0.561619,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.6443,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.599561,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-261",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.588297,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.693295,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "acc",
+    "node_id": "acc-beliefs-083",
+    "score": 0.628127,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.618455,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "saf",
+    "node_id": "saf-intentions-143",
+    "score": 0.64439,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.619951,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.609386,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "skp",
+    "node_id": "skp-beliefs-217",
+    "score": 0.676574,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.614315,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-262",
+    "camp": "skp",
+    "node_id": "skp-desires-014",
+    "score": 0.609276,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "acc",
+    "node_id": "acc-desires-041",
+    "score": 0.486771,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.474889,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.471452,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "saf",
+    "node_id": "saf-desires-027",
+    "score": 0.522478,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.519157,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "saf",
+    "node_id": "saf-beliefs-214",
+    "score": 0.511953,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "skp",
+    "node_id": "skp-desires-009",
+    "score": 0.612485,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "skp",
+    "node_id": "skp-desires-014",
+    "score": 0.551622,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-263",
+    "camp": "skp",
+    "node_id": "skp-desires-076",
+    "score": 0.543497,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "acc",
+    "node_id": "acc-beliefs-021",
+    "score": 0.368634,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "acc",
+    "node_id": "acc-intentions-117",
+    "score": 0.36823,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.355877,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "saf",
+    "node_id": "saf-intentions-137",
+    "score": 0.487471,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "saf",
+    "node_id": "saf-intentions-006",
+    "score": 0.446835,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.440412,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "skp",
+    "node_id": "skp-beliefs-064",
+    "score": 0.520182,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "skp",
+    "node_id": "skp-beliefs-201",
+    "score": 0.488685,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-264",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.487553,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.682682,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.65259,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "acc",
+    "node_id": "acc-intentions-027",
+    "score": 0.633415,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.749763,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "saf",
+    "node_id": "saf-beliefs-213",
+    "score": 0.740813,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.732116,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.728593,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.706835,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-265",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.700943,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.55551,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.515981,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.471075,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "saf",
+    "node_id": "saf-beliefs-051",
+    "score": 0.51723,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "saf",
+    "node_id": "saf-beliefs-248",
+    "score": 0.489104,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.482655,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.540596,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "skp",
+    "node_id": "skp-beliefs-001",
+    "score": 0.532629,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-266",
+    "camp": "skp",
+    "node_id": "skp-beliefs-176",
+    "score": 0.506976,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "acc",
+    "node_id": "acc-beliefs-114",
+    "score": 0.501902,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.479475,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.45798,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.596417,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "saf",
+    "node_id": "saf-beliefs-233",
+    "score": 0.59592,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "saf",
+    "node_id": "saf-intentions-005",
+    "score": 0.552971,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.581343,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "skp",
+    "node_id": "skp-beliefs-189",
+    "score": 0.55069,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-267",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.531023,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.786509,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.773047,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "acc",
+    "node_id": "acc-intentions-005",
+    "score": 0.703457,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "saf",
+    "node_id": "saf-intentions-210",
+    "score": 0.761238,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.744571,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.731449,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "skp",
+    "node_id": "skp-beliefs-113",
+    "score": 0.6724,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "skp",
+    "node_id": "skp-beliefs-102",
+    "score": 0.661166,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-268",
+    "camp": "skp",
+    "node_id": "skp-beliefs-148",
+    "score": 0.641646,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.585089,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "acc",
+    "node_id": "acc-intentions-091",
+    "score": 0.533327,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.527625,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.573965,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "saf",
+    "node_id": "saf-beliefs-117",
+    "score": 0.566101,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.540614,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "skp",
+    "node_id": "skp-intentions-155",
+    "score": 0.623855,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.623,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-269",
+    "camp": "skp",
+    "node_id": "skp-desires-009",
+    "score": 0.599732,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.697299,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.632328,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.624202,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "saf",
+    "node_id": "saf-beliefs-214",
+    "score": 0.778249,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.695566,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.672474,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.698772,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "skp",
+    "node_id": "skp-intentions-165",
+    "score": 0.675352,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-270",
+    "camp": "skp",
+    "node_id": "skp-intentions-157",
+    "score": 0.647093,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "acc",
+    "node_id": "acc-intentions-071",
+    "score": 0.453315,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.445529,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.437086,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.609555,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.589948,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "saf",
+    "node_id": "saf-beliefs-241",
+    "score": 0.533252,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.596308,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "skp",
+    "node_id": "skp-intentions-014",
+    "score": 0.5746,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-271",
+    "camp": "skp",
+    "node_id": "skp-intentions-168",
+    "score": 0.56974,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.432793,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "acc",
+    "node_id": "acc-intentions-002",
+    "score": 0.429429,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.424109,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "saf",
+    "node_id": "saf-beliefs-205",
+    "score": 0.608505,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.556431,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "saf",
+    "node_id": "saf-desires-026",
+    "score": 0.551723,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "skp",
+    "node_id": "skp-intentions-131",
+    "score": 0.636383,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "skp",
+    "node_id": "skp-beliefs-184",
+    "score": 0.626183,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-272",
+    "camp": "skp",
+    "node_id": "skp-beliefs-102",
+    "score": 0.596037,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.657718,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "acc",
+    "node_id": "acc-intentions-071",
+    "score": 0.599179,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.593266,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "saf",
+    "node_id": "saf-intentions-143",
+    "score": 0.637205,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.632331,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "saf",
+    "node_id": "saf-beliefs-222",
+    "score": 0.623449,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "skp",
+    "node_id": "skp-desires-076",
+    "score": 0.739819,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.702439,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-273",
+    "camp": "skp",
+    "node_id": "skp-beliefs-185",
+    "score": 0.667294,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.64035,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "acc",
+    "node_id": "acc-intentions-071",
+    "score": 0.579012,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.572063,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.678348,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.590809,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.573059,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "skp",
+    "node_id": "skp-desires-076",
+    "score": 0.704535,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "skp",
+    "node_id": "skp-desires-003",
+    "score": 0.676115,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-274",
+    "camp": "skp",
+    "node_id": "skp-intentions-014",
+    "score": 0.672211,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.493116,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.479716,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "acc",
+    "node_id": "acc-beliefs-024",
+    "score": 0.47914,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.501526,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.501262,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "saf",
+    "node_id": "saf-beliefs-227",
+    "score": 0.501014,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "skp",
+    "node_id": "skp-beliefs-051",
+    "score": 0.623829,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "skp",
+    "node_id": "skp-intentions-155",
+    "score": 0.592265,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-275",
+    "camp": "skp",
+    "node_id": "skp-desires-076",
+    "score": 0.58507,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.609202,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.596216,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "acc",
+    "node_id": "acc-beliefs-021",
+    "score": 0.586638,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.614057,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "saf",
+    "node_id": "saf-beliefs-214",
+    "score": 0.612146,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.60883,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "skp",
+    "node_id": "skp-desires-076",
+    "score": 0.669607,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "skp",
+    "node_id": "skp-beliefs-098",
+    "score": 0.65851,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-276",
+    "camp": "skp",
+    "node_id": "skp-beliefs-045",
+    "score": 0.617196,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.44428,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "acc",
+    "node_id": "acc-beliefs-104",
+    "score": 0.437834,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "acc",
+    "node_id": "acc-intentions-102",
+    "score": 0.425856,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "saf",
+    "node_id": "saf-intentions-163",
+    "score": 0.518499,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "saf",
+    "node_id": "saf-intentions-237",
+    "score": 0.494011,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "saf",
+    "node_id": "saf-beliefs-241",
+    "score": 0.493738,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "skp",
+    "node_id": "skp-beliefs-220",
+    "score": 0.587935,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "skp",
+    "node_id": "skp-desires-003",
+    "score": 0.571606,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-277",
+    "camp": "skp",
+    "node_id": "skp-intentions-008",
+    "score": 0.566789,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.718456,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.703576,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.687607,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.778176,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "saf",
+    "node_id": "saf-intentions-200",
+    "score": 0.749012,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "saf",
+    "node_id": "saf-beliefs-028",
+    "score": 0.748913,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "skp",
+    "node_id": "skp-beliefs-006",
+    "score": 0.702753,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "skp",
+    "node_id": "skp-beliefs-288",
+    "score": 0.69853,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-278",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.695367,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "acc",
+    "node_id": "acc-desires-028",
+    "score": 0.697904,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "acc",
+    "node_id": "acc-beliefs-041",
+    "score": 0.667533,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "acc",
+    "node_id": "acc-beliefs-021",
+    "score": 0.66724,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "saf",
+    "node_id": "saf-intentions-245",
+    "score": 0.632508,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "saf",
+    "node_id": "saf-intentions-031",
+    "score": 0.605469,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "saf",
+    "node_id": "saf-beliefs-102",
+    "score": 0.60193,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "skp",
+    "node_id": "skp-desires-076",
+    "score": 0.65676,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "skp",
+    "node_id": "skp-beliefs-029",
+    "score": 0.651972,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-279",
+    "camp": "skp",
+    "node_id": "skp-beliefs-168",
+    "score": 0.630847,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.444296,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "acc",
+    "node_id": "acc-beliefs-020",
+    "score": 0.406553,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "acc",
+    "node_id": "acc-intentions-113",
+    "score": 0.386703,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "saf",
+    "node_id": "saf-beliefs-229",
+    "score": 0.601095,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "saf",
+    "node_id": "saf-intentions-143",
+    "score": 0.591029,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "saf",
+    "node_id": "saf-beliefs-230",
+    "score": 0.57849,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "skp",
+    "node_id": "skp-intentions-127",
+    "score": 0.575561,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "skp",
+    "node_id": "skp-beliefs-005",
+    "score": 0.557089,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-280",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.515938,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "acc",
+    "node_id": "acc-beliefs-098",
+    "score": 0.451474,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.444648,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.432362,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "saf",
+    "node_id": "saf-intentions-155",
+    "score": 0.579759,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "saf",
+    "node_id": "saf-intentions-143",
+    "score": 0.576244,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "saf",
+    "node_id": "saf-intentions-150",
+    "score": 0.527188,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "skp",
+    "node_id": "skp-desires-067",
+    "score": 0.608608,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "skp",
+    "node_id": "skp-beliefs-224",
+    "score": 0.58272,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-281",
+    "camp": "skp",
+    "node_id": "skp-beliefs-217",
+    "score": 0.564184,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.556539,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.518741,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "acc",
+    "node_id": "acc-intentions-091",
+    "score": 0.452528,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "saf",
+    "node_id": "saf-intentions-143",
+    "score": 0.647129,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "saf",
+    "node_id": "saf-intentions-155",
+    "score": 0.625872,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "saf",
+    "node_id": "saf-beliefs-222",
+    "score": 0.569912,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "skp",
+    "node_id": "skp-intentions-127",
+    "score": 0.632929,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "skp",
+    "node_id": "skp-beliefs-224",
+    "score": 0.630888,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-282",
+    "camp": "skp",
+    "node_id": "skp-beliefs-228",
+    "score": 0.608051,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.540628,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "acc",
+    "node_id": "acc-beliefs-098",
+    "score": 0.501715,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "acc",
+    "node_id": "acc-beliefs-099",
+    "score": 0.498416,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "saf",
+    "node_id": "saf-intentions-155",
+    "score": 0.620242,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.614543,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "saf",
+    "node_id": "saf-intentions-143",
+    "score": 0.575088,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "skp",
+    "node_id": "skp-beliefs-228",
+    "score": 0.609952,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "skp",
+    "node_id": "skp-beliefs-268",
+    "score": 0.608643,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-283",
+    "camp": "skp",
+    "node_id": "skp-intentions-127",
+    "score": 0.574913,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "acc",
+    "node_id": "acc-beliefs-028",
+    "score": 0.515811,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.492823,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "acc",
+    "node_id": "acc-intentions-002",
+    "score": 0.466737,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "saf",
+    "node_id": "saf-intentions-003",
+    "score": 0.584262,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "saf",
+    "node_id": "saf-beliefs-108",
+    "score": 0.547809,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.544837,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.634539,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.571462,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-284",
+    "camp": "skp",
+    "node_id": "skp-beliefs-177",
+    "score": 0.539544,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.647832,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.623196,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.620732,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.65788,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.641358,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "saf",
+    "node_id": "saf-intentions-089",
+    "score": 0.63397,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.647514,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "skp",
+    "node_id": "skp-beliefs-006",
+    "score": 0.63226,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-285",
+    "camp": "skp",
+    "node_id": "skp-beliefs-190",
+    "score": 0.595314,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.572589,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.46995,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.440575,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "saf",
+    "node_id": "saf-beliefs-030",
+    "score": 0.596075,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "saf",
+    "node_id": "saf-intentions-067",
+    "score": 0.586176,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.585025,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "skp",
+    "node_id": "skp-intentions-167",
+    "score": 0.559135,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.55523,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-286",
+    "camp": "skp",
+    "node_id": "skp-beliefs-238",
+    "score": 0.539739,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.467733,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "acc",
+    "node_id": "acc-intentions-096",
+    "score": 0.46069,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "acc",
+    "node_id": "acc-intentions-105",
+    "score": 0.458463,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.557298,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "saf",
+    "node_id": "saf-intentions-231",
+    "score": 0.5538,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.549061,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "skp",
+    "node_id": "skp-intentions-008",
+    "score": 0.589518,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "skp",
+    "node_id": "skp-beliefs-267",
+    "score": 0.584347,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-287",
+    "camp": "skp",
+    "node_id": "skp-beliefs-269",
+    "score": 0.572985,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.470152,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.469451,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.448274,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.553355,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "saf",
+    "node_id": "saf-intentions-049",
+    "score": 0.550666,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.51332,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "skp",
+    "node_id": "skp-beliefs-260",
+    "score": 0.506633,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.505879,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-288",
+    "camp": "skp",
+    "node_id": "skp-intentions-105",
+    "score": 0.504511,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "acc",
+    "node_id": "acc-intentions-120",
+    "score": 0.508766,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "acc",
+    "node_id": "acc-intentions-112",
+    "score": 0.470016,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.447788,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "saf",
+    "node_id": "saf-intentions-240",
+    "score": 0.537792,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "saf",
+    "node_id": "saf-intentions-126",
+    "score": 0.535,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "saf",
+    "node_id": "saf-beliefs-060",
+    "score": 0.516892,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.582209,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "skp",
+    "node_id": "skp-beliefs-095",
+    "score": 0.558439,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-289",
+    "camp": "skp",
+    "node_id": "skp-intentions-044",
+    "score": 0.554619,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "acc",
+    "node_id": "acc-intentions-096",
+    "score": 0.663545,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "acc",
+    "node_id": "acc-beliefs-083",
+    "score": 0.537482,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.520971,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.611626,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "saf",
+    "node_id": "saf-intentions-231",
+    "score": 0.588978,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "saf",
+    "node_id": "saf-desires-004",
+    "score": 0.559674,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "skp",
+    "node_id": "skp-intentions-008",
+    "score": 0.576924,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.547755,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-290",
+    "camp": "skp",
+    "node_id": "skp-beliefs-263",
+    "score": 0.511356,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.643461,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.636323,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "acc",
+    "node_id": "acc-intentions-022",
+    "score": 0.59882,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.712767,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.689828,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "saf",
+    "node_id": "saf-intentions-210",
+    "score": 0.676964,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "skp",
+    "node_id": "skp-intentions-112",
+    "score": 0.581023,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "skp",
+    "node_id": "skp-beliefs-177",
+    "score": 0.579862,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-291",
+    "camp": "skp",
+    "node_id": "skp-beliefs-277",
+    "score": 0.572225,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "acc",
+    "node_id": "acc-intentions-119",
+    "score": 0.684372,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "acc",
+    "node_id": "acc-intentions-002",
+    "score": 0.580828,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.538126,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.693456,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "saf",
+    "node_id": "saf-intentions-219",
+    "score": 0.632902,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.631709,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "skp",
+    "node_id": "skp-intentions-105",
+    "score": 0.635083,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "skp",
+    "node_id": "skp-beliefs-076",
+    "score": 0.620892,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-292",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.617548,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.463909,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.454478,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.444554,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.619186,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.59286,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "saf",
+    "node_id": "saf-intentions-049",
+    "score": 0.56262,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.559294,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.557252,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-293",
+    "camp": "skp",
+    "node_id": "skp-intentions-105",
+    "score": 0.541323,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.477778,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "acc",
+    "node_id": "acc-beliefs-098",
+    "score": 0.443793,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "acc",
+    "node_id": "acc-intentions-118",
+    "score": 0.383854,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "saf",
+    "node_id": "saf-intentions-006",
+    "score": 0.566986,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "saf",
+    "node_id": "saf-intentions-008",
+    "score": 0.538419,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.535191,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "skp",
+    "node_id": "skp-beliefs-248",
+    "score": 0.563015,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "skp",
+    "node_id": "skp-intentions-095",
+    "score": 0.556633,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-294",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.549577,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "acc",
+    "node_id": "acc-intentions-111",
+    "score": 0.492013,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "acc",
+    "node_id": "acc-intentions-107",
+    "score": 0.490591,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.46354,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.654426,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "saf",
+    "node_id": "saf-intentions-154",
+    "score": 0.651718,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "saf",
+    "node_id": "saf-intentions-149",
+    "score": 0.642826,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.64466,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.637503,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-295",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.626077,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.478782,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.447668,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.428257,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "saf",
+    "node_id": "saf-intentions-005",
+    "score": 0.53731,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "saf",
+    "node_id": "saf-beliefs-213",
+    "score": 0.529714,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.528584,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.58653,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "skp",
+    "node_id": "skp-beliefs-177",
+    "score": 0.539024,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-296",
+    "camp": "skp",
+    "node_id": "skp-beliefs-061",
+    "score": 0.525981,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.638706,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.631612,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.629805,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "saf",
+    "node_id": "saf-beliefs-044",
+    "score": 0.707998,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "saf",
+    "node_id": "saf-beliefs-247",
+    "score": 0.647946,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "saf",
+    "node_id": "saf-intentions-139",
+    "score": 0.628473,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.630017,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.605512,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-297",
+    "camp": "skp",
+    "node_id": "skp-beliefs-034",
+    "score": 0.60227,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.644596,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "acc",
+    "node_id": "acc-intentions-027",
+    "score": 0.600436,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.575078,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "saf",
+    "node_id": "saf-beliefs-249",
+    "score": 0.595828,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.591863,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "saf",
+    "node_id": "saf-intentions-234",
+    "score": 0.573837,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "skp",
+    "node_id": "skp-beliefs-220",
+    "score": 0.627912,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "skp",
+    "node_id": "skp-intentions-112",
+    "score": 0.624013,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-298",
+    "camp": "skp",
+    "node_id": "skp-beliefs-165",
+    "score": 0.613581,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.557956,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.533199,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.512853,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "saf",
+    "node_id": "saf-desires-026",
+    "score": 0.649153,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.635206,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "saf",
+    "node_id": "saf-beliefs-222",
+    "score": 0.622458,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "skp",
+    "node_id": "skp-intentions-044",
+    "score": 0.654018,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.610151,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-299",
+    "camp": "skp",
+    "node_id": "skp-beliefs-044",
+    "score": 0.587711,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "acc",
+    "node_id": "acc-beliefs-024",
+    "score": 0.547086,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "acc",
+    "node_id": "acc-intentions-052",
+    "score": 0.514783,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.512398,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "saf",
+    "node_id": "saf-beliefs-094",
+    "score": 0.639888,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.632188,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "saf",
+    "node_id": "saf-intentions-162",
+    "score": 0.617636,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.623632,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.623266,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-300",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.615783,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.583339,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "acc",
+    "node_id": "acc-intentions-122",
+    "score": 0.53383,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.529902,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.641582,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.62816,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.627697,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "skp",
+    "node_id": "skp-beliefs-129",
+    "score": 0.529059,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "skp",
+    "node_id": "skp-beliefs-102",
+    "score": 0.508317,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-301",
+    "camp": "skp",
+    "node_id": "skp-intentions-169",
+    "score": 0.502085,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "acc",
+    "node_id": "acc-desires-007",
+    "score": 0.41302,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.403759,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.384235,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "saf",
+    "node_id": "saf-beliefs-063",
+    "score": 0.481992,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "saf",
+    "node_id": "saf-beliefs-005",
+    "score": 0.470082,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "saf",
+    "node_id": "saf-beliefs-236",
+    "score": 0.444236,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "skp",
+    "node_id": "skp-beliefs-260",
+    "score": 0.493062,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "skp",
+    "node_id": "skp-beliefs-276",
+    "score": 0.448292,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-302",
+    "camp": "skp",
+    "node_id": "skp-beliefs-064",
+    "score": 0.429663,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.643652,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.633103,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.624218,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.740879,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "saf",
+    "node_id": "saf-beliefs-040",
+    "score": 0.712642,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.704057,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "skp",
+    "node_id": "skp-beliefs-148",
+    "score": 0.683368,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.680762,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-303",
+    "camp": "skp",
+    "node_id": "skp-beliefs-213",
+    "score": 0.644226,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "acc",
+    "node_id": "acc-desires-023",
+    "score": 0.594926,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "acc",
+    "node_id": "acc-beliefs-008",
+    "score": 0.594296,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "acc",
+    "node_id": "acc-desires-040",
+    "score": 0.590635,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "saf",
+    "node_id": "saf-desires-001",
+    "score": 0.557427,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.537217,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.518272,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "skp",
+    "node_id": "skp-intentions-141",
+    "score": 0.488676,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.481958,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-304",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.481513,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "acc",
+    "node_id": "acc-intentions-009",
+    "score": 0.61152,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.610576,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "acc",
+    "node_id": "acc-beliefs-078",
+    "score": 0.598751,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.675174,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "saf",
+    "node_id": "saf-beliefs-013",
+    "score": 0.64449,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.640873,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "skp",
+    "node_id": "skp-beliefs-143",
+    "score": 0.569411,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "skp",
+    "node_id": "skp-beliefs-129",
+    "score": 0.562382,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-305",
+    "camp": "skp",
+    "node_id": "skp-beliefs-284",
+    "score": 0.561488,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.619541,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "acc",
+    "node_id": "acc-intentions-001",
+    "score": 0.605556,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.597986,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "saf",
+    "node_id": "saf-intentions-003",
+    "score": 0.515593,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "saf",
+    "node_id": "saf-beliefs-247",
+    "score": 0.514645,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.5014,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "skp",
+    "node_id": "skp-beliefs-190",
+    "score": 0.607723,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "skp",
+    "node_id": "skp-beliefs-096",
+    "score": 0.589931,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-306",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.588725,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.735533,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.699855,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.690793,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.671985,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.666855,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.635119,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "skp",
+    "node_id": "skp-intentions-104",
+    "score": 0.612683,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.608463,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-307",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.606039,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "acc",
+    "node_id": "acc-intentions-006",
+    "score": 0.565182,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "acc",
+    "node_id": "acc-beliefs-060",
+    "score": 0.556247,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "acc",
+    "node_id": "acc-beliefs-066",
+    "score": 0.551212,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.651023,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "saf",
+    "node_id": "saf-beliefs-099",
+    "score": 0.646576,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.635866,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "skp",
+    "node_id": "skp-beliefs-096",
+    "score": 0.59357,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "skp",
+    "node_id": "skp-beliefs-167",
+    "score": 0.583057,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-308",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.572537,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.563472,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.539521,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.529363,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "saf",
+    "node_id": "saf-intentions-081",
+    "score": 0.613086,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.609141,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "saf",
+    "node_id": "saf-intentions-084",
+    "score": 0.607704,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.556286,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.546088,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-309",
+    "camp": "skp",
+    "node_id": "skp-intentions-105",
+    "score": 0.531305,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.598095,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.583223,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.529766,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.641483,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.588813,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "saf",
+    "node_id": "saf-intentions-015",
+    "score": 0.575002,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "skp",
+    "node_id": "skp-beliefs-026",
+    "score": 0.651701,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.578072,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-310",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.560181,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "acc",
+    "node_id": "acc-intentions-036",
+    "score": 0.517378,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.495944,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.487908,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.547724,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.528101,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "saf",
+    "node_id": "saf-beliefs-248",
+    "score": 0.521601,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "skp",
+    "node_id": "skp-beliefs-248",
+    "score": 0.531223,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "skp",
+    "node_id": "skp-beliefs-176",
+    "score": 0.527796,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-311",
+    "camp": "skp",
+    "node_id": "skp-beliefs-103",
+    "score": 0.525985,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.44541,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.440912,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "acc",
+    "node_id": "acc-intentions-051",
+    "score": 0.419926,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.51304,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "saf",
+    "node_id": "saf-beliefs-116",
+    "score": 0.48548,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.480196,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.565767,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "skp",
+    "node_id": "skp-intentions-017",
+    "score": 0.505256,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-312",
+    "camp": "skp",
+    "node_id": "skp-beliefs-004",
+    "score": 0.479465,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "acc",
+    "node_id": "acc-beliefs-028",
+    "score": 0.584868,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.577504,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.566608,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "saf",
+    "node_id": "saf-intentions-226",
+    "score": 0.511328,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "saf",
+    "node_id": "saf-intentions-149",
+    "score": 0.503959,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "saf",
+    "node_id": "saf-beliefs-043",
+    "score": 0.500895,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.555693,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "skp",
+    "node_id": "skp-intentions-131",
+    "score": 0.551802,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-313",
+    "camp": "skp",
+    "node_id": "skp-beliefs-302",
+    "score": 0.536931,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.624061,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "acc",
+    "node_id": "acc-intentions-052",
+    "score": 0.623866,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.590144,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.617027,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.607575,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.604368,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "skp",
+    "node_id": "skp-beliefs-291",
+    "score": 0.612932,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "skp",
+    "node_id": "skp-beliefs-292",
+    "score": 0.583102,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-314",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.528505,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.633564,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.525547,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.521324,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "saf",
+    "node_id": "saf-intentions-047",
+    "score": 0.709622,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "saf",
+    "node_id": "saf-beliefs-099",
+    "score": 0.687619,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "saf",
+    "node_id": "saf-intentions-089",
+    "score": 0.680427,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.567405,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "skp",
+    "node_id": "skp-beliefs-143",
+    "score": 0.538444,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-315",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.536093,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.623336,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "acc",
+    "node_id": "acc-beliefs-116",
+    "score": 0.616856,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "acc",
+    "node_id": "acc-beliefs-117",
+    "score": 0.616856,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "saf",
+    "node_id": "saf-intentions-234",
+    "score": 0.544922,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.52776,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "saf",
+    "node_id": "saf-beliefs-249",
+    "score": 0.52665,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.562901,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "skp",
+    "node_id": "skp-beliefs-280",
+    "score": 0.524737,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-316",
+    "camp": "skp",
+    "node_id": "skp-beliefs-177",
+    "score": 0.516641,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.721953,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "acc",
+    "node_id": "acc-intentions-107",
+    "score": 0.646769,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.641183,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "saf",
+    "node_id": "saf-intentions-025",
+    "score": 0.738068,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.715795,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.671915,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "skp",
+    "node_id": "skp-beliefs-113",
+    "score": 0.612958,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.607349,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-317",
+    "camp": "skp",
+    "node_id": "skp-beliefs-277",
+    "score": 0.562361,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "acc",
+    "node_id": "acc-desires-037",
+    "score": 0.678271,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.655497,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.641608,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "saf",
+    "node_id": "saf-beliefs-120",
+    "score": 0.683516,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.668554,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "saf",
+    "node_id": "saf-beliefs-110",
+    "score": 0.645085,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.683697,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "skp",
+    "node_id": "skp-beliefs-231",
+    "score": 0.654608,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-318",
+    "camp": "skp",
+    "node_id": "skp-beliefs-281",
+    "score": 0.651646,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.703374,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.658172,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.644786,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "saf",
+    "node_id": "saf-beliefs-217",
+    "score": 0.737394,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "saf",
+    "node_id": "saf-beliefs-210",
+    "score": 0.647611,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "saf",
+    "node_id": "saf-desires-028",
+    "score": 0.637698,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.726913,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.71126,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-319",
+    "camp": "skp",
+    "node_id": "skp-desires-087",
+    "score": 0.688418,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.580237,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "acc",
+    "node_id": "acc-beliefs-028",
+    "score": 0.513248,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.502939,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.549732,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "saf",
+    "node_id": "saf-intentions-040",
+    "score": 0.548941,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "saf",
+    "node_id": "saf-desires-003",
+    "score": 0.531873,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "skp",
+    "node_id": "skp-beliefs-184",
+    "score": 0.626997,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "skp",
+    "node_id": "skp-intentions-044",
+    "score": 0.577962,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-320",
+    "camp": "skp",
+    "node_id": "skp-beliefs-238",
+    "score": 0.567151,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.497803,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.44767,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "acc",
+    "node_id": "acc-intentions-002",
+    "score": 0.427285,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.594435,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "saf",
+    "node_id": "saf-desires-024",
+    "score": 0.560309,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.552009,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.656413,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "skp",
+    "node_id": "skp-beliefs-279",
+    "score": 0.620895,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-321",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.615879,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.421105,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.421105,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "acc",
+    "node_id": "acc-intentions-091",
+    "score": 0.420124,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.635636,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "saf",
+    "node_id": "saf-intentions-146",
+    "score": 0.609149,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.600115,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "skp",
+    "node_id": "skp-desires-080",
+    "score": 0.636939,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "skp",
+    "node_id": "skp-beliefs-157",
+    "score": 0.575348,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-322",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.572501,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.596692,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.595479,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.584256,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.561971,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.55789,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.547949,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.57331,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.562599,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-323",
+    "camp": "skp",
+    "node_id": "skp-beliefs-006",
+    "score": 0.555776,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.546897,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.543536,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "acc",
+    "node_id": "acc-intentions-022",
+    "score": 0.509565,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.646852,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "saf",
+    "node_id": "saf-intentions-231",
+    "score": 0.616995,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "saf",
+    "node_id": "saf-intentions-001",
+    "score": 0.607562,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "skp",
+    "node_id": "skp-beliefs-190",
+    "score": 0.52749,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.527257,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-324",
+    "camp": "skp",
+    "node_id": "skp-beliefs-102",
+    "score": 0.523076,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.566221,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "acc",
+    "node_id": "acc-intentions-124",
+    "score": 0.506704,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.486335,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "saf",
+    "node_id": "saf-intentions-239",
+    "score": 0.614254,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "saf",
+    "node_id": "saf-beliefs-150",
+    "score": 0.614141,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "saf",
+    "node_id": "saf-beliefs-106",
+    "score": 0.605049,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "skp",
+    "node_id": "skp-beliefs-186",
+    "score": 0.688316,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "skp",
+    "node_id": "skp-beliefs-156",
+    "score": 0.584579,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-325",
+    "camp": "skp",
+    "node_id": "skp-beliefs-104",
+    "score": 0.571072,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.673114,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "acc",
+    "node_id": "acc-desires-033",
+    "score": 0.656891,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "acc",
+    "node_id": "acc-desires-029",
+    "score": 0.640624,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "saf",
+    "node_id": "saf-desires-002",
+    "score": 0.699623,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.699099,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "saf",
+    "node_id": "saf-intentions-160",
+    "score": 0.696727,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "skp",
+    "node_id": "skp-beliefs-096",
+    "score": 0.646698,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "skp",
+    "node_id": "skp-beliefs-158",
+    "score": 0.630664,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-326",
+    "camp": "skp",
+    "node_id": "skp-beliefs-199",
+    "score": 0.60661,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "acc",
+    "node_id": "acc-beliefs-051",
+    "score": 0.590318,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.584134,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "acc",
+    "node_id": "acc-intentions-060",
+    "score": 0.573679,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "saf",
+    "node_id": "saf-beliefs-139",
+    "score": 0.710596,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.671991,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "saf",
+    "node_id": "saf-desires-002",
+    "score": 0.664219,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.640217,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.615162,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-327",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.611079,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.639708,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.631431,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "acc",
+    "node_id": "acc-intentions-069",
+    "score": 0.59566,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.572213,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.559247,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.548453,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.614217,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.592835,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-328",
+    "camp": "skp",
+    "node_id": "skp-beliefs-139",
+    "score": 0.591192,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.485999,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "acc",
+    "node_id": "acc-intentions-001",
+    "score": 0.473175,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "acc",
+    "node_id": "acc-intentions-091",
+    "score": 0.468015,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.641027,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "saf",
+    "node_id": "saf-desires-027",
+    "score": 0.588183,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "saf",
+    "node_id": "saf-beliefs-155",
+    "score": 0.575138,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "skp",
+    "node_id": "skp-beliefs-233",
+    "score": 0.565934,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "skp",
+    "node_id": "skp-desires-080",
+    "score": 0.544513,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-329",
+    "camp": "skp",
+    "node_id": "skp-desires-078",
+    "score": 0.543425,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.616471,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "acc",
+    "node_id": "acc-intentions-074",
+    "score": 0.611753,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.607779,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "saf",
+    "node_id": "saf-intentions-211",
+    "score": 0.715572,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.703837,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.694327,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "skp",
+    "node_id": "skp-beliefs-213",
+    "score": 0.686175,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.657533,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-330",
+    "camp": "skp",
+    "node_id": "skp-intentions-023",
+    "score": 0.637451,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.520403,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "acc",
+    "node_id": "acc-beliefs-093",
+    "score": 0.486397,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.465116,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.632966,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.630417,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "saf",
+    "node_id": "saf-intentions-083",
+    "score": 0.578091,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "skp",
+    "node_id": "skp-desires-087",
+    "score": 0.607053,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.587176,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-331",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.586793,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.536868,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.534743,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.513632,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.641319,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "saf",
+    "node_id": "saf-intentions-214",
+    "score": 0.619853,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.591129,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "skp",
+    "node_id": "skp-beliefs-190",
+    "score": 0.632011,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.543976,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-332",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.535434,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.744995,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.663513,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.606616,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "saf",
+    "node_id": "saf-beliefs-217",
+    "score": 0.677076,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "saf",
+    "node_id": "saf-intentions-210",
+    "score": 0.631996,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.625079,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.690418,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "skp",
+    "node_id": "skp-intentions-029",
+    "score": 0.627269,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-333",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.625863,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.640205,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.58195,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "acc",
+    "node_id": "acc-intentions-027",
+    "score": 0.566106,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "saf",
+    "node_id": "saf-intentions-001",
+    "score": 0.676632,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "saf",
+    "node_id": "saf-intentions-234",
+    "score": 0.670985,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.66671,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.664703,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.653021,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-334",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.652927,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "acc",
+    "node_id": "acc-intentions-116",
+    "score": 0.588799,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.540968,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "acc",
+    "node_id": "acc-beliefs-093",
+    "score": 0.540381,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "saf",
+    "node_id": "saf-beliefs-217",
+    "score": 0.73257,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.700108,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.679901,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.618772,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "skp",
+    "node_id": "skp-beliefs-239",
+    "score": 0.617803,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-335",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.61071,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.539728,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "acc",
+    "node_id": "acc-intentions-080",
+    "score": 0.472035,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.467747,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "saf",
+    "node_id": "saf-intentions-149",
+    "score": 0.579429,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "saf",
+    "node_id": "saf-intentions-202",
+    "score": 0.558092,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "saf",
+    "node_id": "saf-intentions-242",
+    "score": 0.556352,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.569155,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.566172,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-336",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.542625,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.622228,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.618532,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "acc",
+    "node_id": "acc-intentions-056",
+    "score": 0.591992,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.695989,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "saf",
+    "node_id": "saf-intentions-005",
+    "score": 0.692568,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.676646,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.645804,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.645507,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-337",
+    "camp": "skp",
+    "node_id": "skp-beliefs-277",
+    "score": 0.63837,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.638375,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.63001,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.598416,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.626888,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "saf",
+    "node_id": "saf-intentions-202",
+    "score": 0.62043,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.613179,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "skp",
+    "node_id": "skp-beliefs-104",
+    "score": 0.717694,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "skp",
+    "node_id": "skp-beliefs-186",
+    "score": 0.604456,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-338",
+    "camp": "skp",
+    "node_id": "skp-intentions-108",
+    "score": 0.5724,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.512476,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.507971,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "acc",
+    "node_id": "acc-desires-010",
+    "score": 0.498316,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.463235,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.456986,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.438947,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "skp",
+    "node_id": "skp-beliefs-052",
+    "score": 0.556261,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "skp",
+    "node_id": "skp-beliefs-021",
+    "score": 0.555457,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-339",
+    "camp": "skp",
+    "node_id": "skp-beliefs-205",
+    "score": 0.532453,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "acc",
+    "node_id": "acc-beliefs-116",
+    "score": 0.601735,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "acc",
+    "node_id": "acc-beliefs-117",
+    "score": 0.601735,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.582746,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.652863,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "saf",
+    "node_id": "saf-beliefs-205",
+    "score": 0.634108,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "saf",
+    "node_id": "saf-intentions-234",
+    "score": 0.631075,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.624828,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "skp",
+    "node_id": "skp-beliefs-129",
+    "score": 0.607882,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-340",
+    "camp": "skp",
+    "node_id": "skp-beliefs-189",
+    "score": 0.587108,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.545596,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.51564,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.509083,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.652956,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "saf",
+    "node_id": "saf-intentions-151",
+    "score": 0.620316,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.60684,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.629481,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "skp",
+    "node_id": "skp-beliefs-076",
+    "score": 0.581892,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-341",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.574079,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.646874,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "acc",
+    "node_id": "acc-beliefs-116",
+    "score": 0.613765,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "acc",
+    "node_id": "acc-beliefs-117",
+    "score": 0.613765,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.62695,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "saf",
+    "node_id": "saf-intentions-094",
+    "score": 0.620989,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.617248,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "skp",
+    "node_id": "skp-beliefs-302",
+    "score": 0.643658,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "skp",
+    "node_id": "skp-beliefs-303",
+    "score": 0.643658,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-342",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.625455,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "acc",
+    "node_id": "acc-beliefs-082",
+    "score": 0.682007,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "acc",
+    "node_id": "acc-intentions-036",
+    "score": 0.410672,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "acc",
+    "node_id": "acc-beliefs-076",
+    "score": 0.399289,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "saf",
+    "node_id": "saf-beliefs-143",
+    "score": 0.619612,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "saf",
+    "node_id": "saf-beliefs-060",
+    "score": 0.557784,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "saf",
+    "node_id": "saf-beliefs-055",
+    "score": 0.518554,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "skp",
+    "node_id": "skp-beliefs-145",
+    "score": 0.517819,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "skp",
+    "node_id": "skp-beliefs-182",
+    "score": 0.503462,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-343",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.496555,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "acc",
+    "node_id": "acc-beliefs-082",
+    "score": 0.573398,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "acc",
+    "node_id": "acc-beliefs-094",
+    "score": 0.56186,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "acc",
+    "node_id": "acc-intentions-036",
+    "score": 0.508092,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.558494,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "saf",
+    "node_id": "saf-intentions-039",
+    "score": 0.516816,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.503672,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.52371,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "skp",
+    "node_id": "skp-beliefs-182",
+    "score": 0.510504,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-344",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.506283,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "acc",
+    "node_id": "acc-beliefs-028",
+    "score": 0.518589,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.497524,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.481878,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "saf",
+    "node_id": "saf-intentions-005",
+    "score": 0.625661,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "saf",
+    "node_id": "saf-intentions-001",
+    "score": 0.606242,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.582968,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "skp",
+    "node_id": "skp-beliefs-189",
+    "score": 0.67312,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "skp",
+    "node_id": "skp-beliefs-279",
+    "score": 0.621666,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-345",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.606124,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "acc",
+    "node_id": "acc-intentions-105",
+    "score": 0.514349,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.505468,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "acc",
+    "node_id": "acc-intentions-002",
+    "score": 0.483556,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.635926,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "saf",
+    "node_id": "saf-intentions-231",
+    "score": 0.592411,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.582007,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.618112,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.587248,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-346",
+    "camp": "skp",
+    "node_id": "skp-desires-088",
+    "score": 0.57965,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.520493,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "acc",
+    "node_id": "acc-intentions-002",
+    "score": 0.496564,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "acc",
+    "node_id": "acc-intentions-092",
+    "score": 0.496223,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "saf",
+    "node_id": "saf-beliefs-142",
+    "score": 0.689335,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "saf",
+    "node_id": "saf-intentions-228",
+    "score": 0.628922,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.621758,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "skp",
+    "node_id": "skp-beliefs-177",
+    "score": 0.627356,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "skp",
+    "node_id": "skp-beliefs-076",
+    "score": 0.612712,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-347",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.610269,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "acc",
+    "node_id": "acc-intentions-001",
+    "score": 0.478239,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "acc",
+    "node_id": "acc-intentions-002",
+    "score": 0.473999,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "acc",
+    "node_id": "acc-beliefs-093",
+    "score": 0.464538,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "saf",
+    "node_id": "saf-intentions-149",
+    "score": 0.559793,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.55061,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.548054,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "skp",
+    "node_id": "skp-intentions-107",
+    "score": 0.575575,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.573671,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-348",
+    "camp": "skp",
+    "node_id": "skp-beliefs-189",
+    "score": 0.512796,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.467697,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.424301,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.421926,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "saf",
+    "node_id": "saf-beliefs-133",
+    "score": 0.55113,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "saf",
+    "node_id": "saf-intentions-151",
+    "score": 0.549133,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.529998,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.554735,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "skp",
+    "node_id": "skp-intentions-105",
+    "score": 0.549368,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-349",
+    "camp": "skp",
+    "node_id": "skp-beliefs-268",
+    "score": 0.54013,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.505527,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.500351,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.481698,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "saf",
+    "node_id": "saf-beliefs-058",
+    "score": 0.573566,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "saf",
+    "node_id": "saf-beliefs-252",
+    "score": 0.562926,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.559571,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.644259,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.580826,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-350",
+    "camp": "skp",
+    "node_id": "skp-desires-076",
+    "score": 0.565488,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.509619,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "acc",
+    "node_id": "acc-intentions-036",
+    "score": 0.45278,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.437708,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.514494,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "saf",
+    "node_id": "saf-beliefs-242",
+    "score": 0.49995,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "saf",
+    "node_id": "saf-intentions-200",
+    "score": 0.476564,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "skp",
+    "node_id": "skp-beliefs-192",
+    "score": 0.536523,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "skp",
+    "node_id": "skp-beliefs-260",
+    "score": 0.511899,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-351",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.489095,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.535501,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.503713,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "acc",
+    "node_id": "acc-beliefs-092",
+    "score": 0.483259,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.510563,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "saf",
+    "node_id": "saf-beliefs-050",
+    "score": 0.504557,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.503022,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "skp",
+    "node_id": "skp-beliefs-193",
+    "score": 0.609544,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "skp",
+    "node_id": "skp-beliefs-182",
+    "score": 0.518686,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-352",
+    "camp": "skp",
+    "node_id": "skp-beliefs-152",
+    "score": 0.507273,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "acc",
+    "node_id": "acc-beliefs-092",
+    "score": 0.473589,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "acc",
+    "node_id": "acc-intentions-055",
+    "score": 0.472811,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "acc",
+    "node_id": "acc-intentions-034",
+    "score": 0.470467,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.585269,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "saf",
+    "node_id": "saf-intentions-086",
+    "score": 0.564414,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.552173,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "skp",
+    "node_id": "skp-beliefs-136",
+    "score": 0.622237,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "skp",
+    "node_id": "skp-beliefs-021",
+    "score": 0.602728,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-353",
+    "camp": "skp",
+    "node_id": "skp-beliefs-133",
+    "score": 0.601042,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.57429,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "acc",
+    "node_id": "acc-beliefs-044",
+    "score": 0.56743,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "acc",
+    "node_id": "acc-beliefs-079",
+    "score": 0.564835,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.681044,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.624451,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.60321,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "skp",
+    "node_id": "skp-beliefs-017",
+    "score": 0.639369,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.594153,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-354",
+    "camp": "skp",
+    "node_id": "skp-beliefs-182",
+    "score": 0.588451,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "acc",
+    "node_id": "acc-beliefs-092",
+    "score": 0.519551,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.51183,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "acc",
+    "node_id": "acc-intentions-110",
+    "score": 0.498172,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.523202,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.498619,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.484891,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "skp",
+    "node_id": "skp-beliefs-193",
+    "score": 0.607935,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "skp",
+    "node_id": "skp-beliefs-152",
+    "score": 0.499059,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-355",
+    "camp": "skp",
+    "node_id": "skp-beliefs-182",
+    "score": 0.484705,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.507008,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "acc",
+    "node_id": "acc-beliefs-094",
+    "score": 0.474676,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.453485,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.56929,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "saf",
+    "node_id": "saf-beliefs-050",
+    "score": 0.535833,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.533482,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "skp",
+    "node_id": "skp-beliefs-182",
+    "score": 0.610943,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "skp",
+    "node_id": "skp-beliefs-193",
+    "score": 0.600701,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-356",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.587811,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.50284,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.484197,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.478659,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.475369,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "saf",
+    "node_id": "saf-beliefs-058",
+    "score": 0.462959,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.451173,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "skp",
+    "node_id": "skp-beliefs-193",
+    "score": 0.608767,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.555805,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-357",
+    "camp": "skp",
+    "node_id": "skp-beliefs-182",
+    "score": 0.519548,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "acc",
+    "node_id": "acc-intentions-086",
+    "score": 0.522735,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "acc",
+    "node_id": "acc-intentions-082",
+    "score": 0.501809,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.462398,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "saf",
+    "node_id": "saf-intentions-068",
+    "score": 0.544078,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "saf",
+    "node_id": "saf-intentions-053",
+    "score": 0.469545,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "saf",
+    "node_id": "saf-intentions-137",
+    "score": 0.456328,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "skp",
+    "node_id": "skp-beliefs-136",
+    "score": 0.500974,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "skp",
+    "node_id": "skp-beliefs-133",
+    "score": 0.499892,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-358",
+    "camp": "skp",
+    "node_id": "skp-beliefs-021",
+    "score": 0.499871,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.468899,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.39858,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "acc",
+    "node_id": "acc-intentions-036",
+    "score": 0.394112,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "saf",
+    "node_id": "saf-beliefs-058",
+    "score": 0.52821,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.526124,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "saf",
+    "node_id": "saf-intentions-003",
+    "score": 0.520401,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "skp",
+    "node_id": "skp-beliefs-193",
+    "score": 0.587373,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.472151,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-359",
+    "camp": "skp",
+    "node_id": "skp-beliefs-191",
+    "score": 0.44596,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "acc",
+    "node_id": "acc-beliefs-092",
+    "score": 0.592134,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.522015,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.52069,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.591161,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.584462,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.56991,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "skp",
+    "node_id": "skp-beliefs-021",
+    "score": 0.605092,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "skp",
+    "node_id": "skp-beliefs-008",
+    "score": 0.602168,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-360",
+    "camp": "skp",
+    "node_id": "skp-beliefs-026",
+    "score": 0.596422,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.613432,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.606349,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.60396,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.666307,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.651809,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "saf",
+    "node_id": "saf-intentions-076",
+    "score": 0.646451,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "skp",
+    "node_id": "skp-intentions-104",
+    "score": 0.682369,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.679458,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-361",
+    "camp": "skp",
+    "node_id": "skp-intentions-055",
+    "score": 0.66736,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.555413,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "acc",
+    "node_id": "acc-intentions-027",
+    "score": 0.544869,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.540756,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "saf",
+    "node_id": "saf-intentions-085",
+    "score": 0.703453,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "saf",
+    "node_id": "saf-beliefs-098",
+    "score": 0.69756,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "saf",
+    "node_id": "saf-intentions-076",
+    "score": 0.689661,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "skp",
+    "node_id": "skp-desires-077",
+    "score": 0.560183,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.556885,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-362",
+    "camp": "skp",
+    "node_id": "skp-beliefs-129",
+    "score": 0.554688,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.479319,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "acc",
+    "node_id": "acc-intentions-106",
+    "score": 0.455391,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "acc",
+    "node_id": "acc-beliefs-003",
+    "score": 0.454782,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.5884,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.570416,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.566827,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.527281,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "skp",
+    "node_id": "skp-intentions-107",
+    "score": 0.504074,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-363",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.493259,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.618807,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.58156,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.569975,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "saf",
+    "node_id": "saf-intentions-137",
+    "score": 0.620778,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "saf",
+    "node_id": "saf-intentions-142",
+    "score": 0.611932,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "saf",
+    "node_id": "saf-intentions-054",
+    "score": 0.576833,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "skp",
+    "node_id": "skp-beliefs-076",
+    "score": 0.584381,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.576708,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-364",
+    "camp": "skp",
+    "node_id": "skp-beliefs-061",
+    "score": 0.573241,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.641973,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.56837,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "acc",
+    "node_id": "acc-intentions-099",
+    "score": 0.558832,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.649454,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.614299,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.606106,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.655305,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.638516,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-365",
+    "camp": "skp",
+    "node_id": "skp-beliefs-174",
+    "score": 0.612131,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "acc",
+    "node_id": "acc-desires-018",
+    "score": 0.476702,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.440338,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "acc",
+    "node_id": "acc-desires-021",
+    "score": 0.424361,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.593239,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.579718,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.545068,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "skp",
+    "node_id": "skp-beliefs-117",
+    "score": 0.609899,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "skp",
+    "node_id": "skp-beliefs-251",
+    "score": 0.548833,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-366",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.496722,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.528022,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.476793,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.468393,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.524887,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "saf",
+    "node_id": "saf-beliefs-112",
+    "score": 0.488857,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.479868,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.554204,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.52986,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-367",
+    "camp": "skp",
+    "node_id": "skp-intentions-102",
+    "score": 0.520019,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "acc",
+    "node_id": "acc-beliefs-099",
+    "score": 0.408695,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "acc",
+    "node_id": "acc-intentions-122",
+    "score": 0.393698,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "acc",
+    "node_id": "acc-beliefs-116",
+    "score": 0.391664,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "saf",
+    "node_id": "saf-beliefs-244",
+    "score": 0.539413,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.524617,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "saf",
+    "node_id": "saf-beliefs-253",
+    "score": 0.463689,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.508032,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "skp",
+    "node_id": "skp-intentions-121",
+    "score": 0.466196,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-368",
+    "camp": "skp",
+    "node_id": "skp-beliefs-239",
+    "score": 0.46325,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.459923,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.448829,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "acc",
+    "node_id": "acc-intentions-106",
+    "score": 0.421158,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.540773,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "saf",
+    "node_id": "saf-intentions-226",
+    "score": 0.528021,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.512843,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.574583,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.571216,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-369",
+    "camp": "skp",
+    "node_id": "skp-beliefs-177",
+    "score": 0.530003,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.551125,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.528438,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "acc",
+    "node_id": "acc-intentions-111",
+    "score": 0.523896,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "saf",
+    "node_id": "saf-intentions-210",
+    "score": 0.72154,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "saf",
+    "node_id": "saf-intentions-037",
+    "score": 0.71474,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.697753,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "skp",
+    "node_id": "skp-intentions-132",
+    "score": 0.630236,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "skp",
+    "node_id": "skp-beliefs-117",
+    "score": 0.577842,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-370",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.576169,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.515171,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.501969,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.500841,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.555279,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "saf",
+    "node_id": "saf-intentions-025",
+    "score": 0.553287,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.552935,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.629235,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.587611,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-371",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.525098,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.573936,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.504869,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.501574,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "saf",
+    "node_id": "saf-beliefs-096",
+    "score": 0.614873,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.591459,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "saf",
+    "node_id": "saf-beliefs-038",
+    "score": 0.584654,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.680204,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.649872,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-372",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.644437,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "acc",
+    "node_id": "acc-intentions-002",
+    "score": 0.465936,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.457208,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "acc",
+    "node_id": "acc-intentions-118",
+    "score": 0.440961,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "saf",
+    "node_id": "saf-intentions-226",
+    "score": 0.434644,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "saf",
+    "node_id": "saf-beliefs-223",
+    "score": 0.430029,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "saf",
+    "node_id": "saf-beliefs-224",
+    "score": 0.421435,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "skp",
+    "node_id": "skp-beliefs-268",
+    "score": 0.436749,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "skp",
+    "node_id": "skp-intentions-095",
+    "score": 0.416571,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-373",
+    "camp": "skp",
+    "node_id": "skp-beliefs-287",
+    "score": 0.411664,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.725505,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.657609,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.588832,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.615821,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.614955,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.614432,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.615815,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.60031,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-374",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.592195,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.570709,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "acc",
+    "node_id": "acc-beliefs-092",
+    "score": 0.516637,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "acc",
+    "node_id": "acc-beliefs-094",
+    "score": 0.508786,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "saf",
+    "node_id": "saf-intentions-112",
+    "score": 0.6127,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.59713,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.570961,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.676351,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.620741,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-375",
+    "camp": "skp",
+    "node_id": "skp-beliefs-021",
+    "score": 0.582793,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.484464,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.462765,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.457313,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "saf",
+    "node_id": "saf-intentions-126",
+    "score": 0.555376,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "saf",
+    "node_id": "saf-beliefs-154",
+    "score": 0.545636,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.504699,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "skp",
+    "node_id": "skp-intentions-131",
+    "score": 0.607774,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "skp",
+    "node_id": "skp-intentions-129",
+    "score": 0.588241,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-376",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.580127,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "acc",
+    "node_id": "acc-intentions-112",
+    "score": 0.588962,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "acc",
+    "node_id": "acc-intentions-120",
+    "score": 0.524143,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.494375,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "saf",
+    "node_id": "saf-beliefs-101",
+    "score": 0.610118,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "saf",
+    "node_id": "saf-beliefs-004",
+    "score": 0.545357,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.54429,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.505081,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.491716,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-377",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.485583,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.487602,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.431894,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.428379,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "saf",
+    "node_id": "saf-beliefs-060",
+    "score": 0.592828,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "saf",
+    "node_id": "saf-beliefs-261",
+    "score": 0.590849,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "saf",
+    "node_id": "saf-beliefs-102",
+    "score": 0.576992,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "skp",
+    "node_id": "skp-beliefs-173",
+    "score": 0.494808,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "skp",
+    "node_id": "skp-beliefs-301",
+    "score": 0.491405,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-378",
+    "camp": "skp",
+    "node_id": "skp-beliefs-177",
+    "score": 0.459323,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "acc",
+    "node_id": "acc-beliefs-051",
+    "score": 0.623219,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "acc",
+    "node_id": "acc-desires-033",
+    "score": 0.586843,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "acc",
+    "node_id": "acc-desires-040",
+    "score": 0.5752,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "saf",
+    "node_id": "saf-intentions-078",
+    "score": 0.702535,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "saf",
+    "node_id": "saf-intentions-086",
+    "score": 0.650822,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "saf",
+    "node_id": "saf-beliefs-227",
+    "score": 0.643985,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "skp",
+    "node_id": "skp-beliefs-099",
+    "score": 0.666259,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.666168,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-379",
+    "camp": "skp",
+    "node_id": "skp-beliefs-068",
+    "score": 0.645992,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "acc",
+    "node_id": "acc-beliefs-079",
+    "score": 0.525704,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "acc",
+    "node_id": "acc-beliefs-067",
+    "score": 0.524501,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "acc",
+    "node_id": "acc-beliefs-061",
+    "score": 0.524421,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "saf",
+    "node_id": "saf-beliefs-064",
+    "score": 0.708141,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "saf",
+    "node_id": "saf-beliefs-137",
+    "score": 0.531038,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.513738,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "skp",
+    "node_id": "skp-beliefs-257",
+    "score": 0.613999,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "skp",
+    "node_id": "skp-beliefs-028",
+    "score": 0.613601,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-380",
+    "camp": "skp",
+    "node_id": "skp-beliefs-101",
+    "score": 0.604818,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.472646,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "acc",
+    "node_id": "acc-desires-042",
+    "score": 0.471476,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.468801,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "saf",
+    "node_id": "saf-beliefs-102",
+    "score": 0.605642,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "saf",
+    "node_id": "saf-beliefs-128",
+    "score": 0.594039,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "saf",
+    "node_id": "saf-intentions-174",
+    "score": 0.584813,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.665168,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "skp",
+    "node_id": "skp-beliefs-061",
+    "score": 0.57589,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-381",
+    "camp": "skp",
+    "node_id": "skp-intentions-087",
+    "score": 0.550714,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "acc",
+    "node_id": "acc-intentions-111",
+    "score": 0.527086,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.499428,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "acc",
+    "node_id": "acc-beliefs-066",
+    "score": 0.490225,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "saf",
+    "node_id": "saf-beliefs-247",
+    "score": 0.504406,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.448598,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "saf",
+    "node_id": "saf-beliefs-044",
+    "score": 0.442081,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "skp",
+    "node_id": "skp-beliefs-104",
+    "score": 0.515411,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "skp",
+    "node_id": "skp-beliefs-186",
+    "score": 0.509489,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-382",
+    "camp": "skp",
+    "node_id": "skp-beliefs-156",
+    "score": 0.501586,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.535999,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.527532,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.52034,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.485604,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "saf",
+    "node_id": "saf-beliefs-022",
+    "score": 0.476167,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.465137,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.549052,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "skp",
+    "node_id": "skp-beliefs-076",
+    "score": 0.531114,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-383",
+    "camp": "skp",
+    "node_id": "skp-beliefs-069",
+    "score": 0.52975,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "acc",
+    "node_id": "acc-intentions-008",
+    "score": 0.518293,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "acc",
+    "node_id": "acc-intentions-106",
+    "score": 0.485675,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "acc",
+    "node_id": "acc-beliefs-046",
+    "score": 0.479155,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "saf",
+    "node_id": "saf-intentions-231",
+    "score": 0.554799,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "saf",
+    "node_id": "saf-intentions-170",
+    "score": 0.552815,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "saf",
+    "node_id": "saf-intentions-155",
+    "score": 0.544192,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "skp",
+    "node_id": "skp-beliefs-111",
+    "score": 0.687431,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "skp",
+    "node_id": "skp-beliefs-107",
+    "score": 0.547652,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-384",
+    "camp": "skp",
+    "node_id": "skp-beliefs-225",
+    "score": 0.531964,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.530585,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "acc",
+    "node_id": "acc-intentions-022",
+    "score": 0.512927,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.500772,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "saf",
+    "node_id": "saf-beliefs-241",
+    "score": 0.570649,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.544496,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.531489,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "skp",
+    "node_id": "skp-intentions-008",
+    "score": 0.61747,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "skp",
+    "node_id": "skp-intentions-014",
+    "score": 0.581257,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-385",
+    "camp": "skp",
+    "node_id": "skp-desires-003",
+    "score": 0.569356,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "acc",
+    "node_id": "acc-beliefs-028",
+    "score": 0.498604,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.457115,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.441426,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "saf",
+    "node_id": "saf-intentions-146",
+    "score": 0.606337,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "saf",
+    "node_id": "saf-intentions-145",
+    "score": 0.587633,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "saf",
+    "node_id": "saf-intentions-226",
+    "score": 0.584401,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "skp",
+    "node_id": "skp-beliefs-223",
+    "score": 0.691982,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "skp",
+    "node_id": "skp-beliefs-226",
+    "score": 0.670541,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-386",
+    "camp": "skp",
+    "node_id": "skp-beliefs-225",
+    "score": 0.669557,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "acc",
+    "node_id": "acc-intentions-071",
+    "score": 0.596104,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "acc",
+    "node_id": "acc-beliefs-068",
+    "score": 0.58125,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "acc",
+    "node_id": "acc-intentions-087",
+    "score": 0.578753,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "saf",
+    "node_id": "saf-intentions-146",
+    "score": 0.540126,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "saf",
+    "node_id": "saf-beliefs-017",
+    "score": 0.514813,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "saf",
+    "node_id": "saf-intentions-150",
+    "score": 0.499802,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "skp",
+    "node_id": "skp-desires-084",
+    "score": 0.671733,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "skp",
+    "node_id": "skp-beliefs-111",
+    "score": 0.579144,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-387",
+    "camp": "skp",
+    "node_id": "skp-beliefs-223",
+    "score": 0.567982,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.539688,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.532239,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "acc",
+    "node_id": "acc-beliefs-019",
+    "score": 0.525143,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "saf",
+    "node_id": "saf-intentions-245",
+    "score": 0.522497,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "saf",
+    "node_id": "saf-beliefs-212",
+    "score": 0.510821,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "saf",
+    "node_id": "saf-beliefs-146",
+    "score": 0.492491,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "skp",
+    "node_id": "skp-beliefs-168",
+    "score": 0.62475,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "skp",
+    "node_id": "skp-beliefs-124",
+    "score": 0.588486,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-388",
+    "camp": "skp",
+    "node_id": "skp-desires-006",
+    "score": 0.576041,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.542688,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "acc",
+    "node_id": "acc-intentions-071",
+    "score": 0.534462,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.52631,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "saf",
+    "node_id": "saf-intentions-245",
+    "score": 0.543232,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "saf",
+    "node_id": "saf-beliefs-212",
+    "score": 0.527968,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "saf",
+    "node_id": "saf-beliefs-137",
+    "score": 0.508902,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.640672,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.609112,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-389",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.605235,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "acc",
+    "node_id": "acc-intentions-027",
+    "score": 0.556836,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "acc",
+    "node_id": "acc-beliefs-116",
+    "score": 0.545159,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "acc",
+    "node_id": "acc-beliefs-117",
+    "score": 0.545159,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "saf",
+    "node_id": "saf-beliefs-106",
+    "score": 0.632749,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "saf",
+    "node_id": "saf-beliefs-152",
+    "score": 0.593699,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "saf",
+    "node_id": "saf-intentions-001",
+    "score": 0.580833,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.663976,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "skp",
+    "node_id": "skp-beliefs-195",
+    "score": 0.662409,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-390",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.660333,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.553229,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.552699,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "acc",
+    "node_id": "acc-intentions-045",
+    "score": 0.547543,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "saf",
+    "node_id": "saf-beliefs-137",
+    "score": 0.597643,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.592447,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "saf",
+    "node_id": "saf-beliefs-010",
+    "score": 0.573707,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "skp",
+    "node_id": "skp-beliefs-133",
+    "score": 0.692558,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.690829,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-391",
+    "camp": "skp",
+    "node_id": "skp-beliefs-152",
+    "score": 0.683074,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.509743,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "acc",
+    "node_id": "acc-beliefs-099",
+    "score": 0.48904,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "acc",
+    "node_id": "acc-beliefs-098",
+    "score": 0.481132,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "saf",
+    "node_id": "saf-intentions-163",
+    "score": 0.558334,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "saf",
+    "node_id": "saf-intentions-146",
+    "score": 0.511491,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "saf",
+    "node_id": "saf-beliefs-240",
+    "score": 0.504156,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "skp",
+    "node_id": "skp-beliefs-223",
+    "score": 0.806885,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "skp",
+    "node_id": "skp-beliefs-225",
+    "score": 0.772057,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-392",
+    "camp": "skp",
+    "node_id": "skp-beliefs-226",
+    "score": 0.722723,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.617515,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.597602,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "acc",
+    "node_id": "acc-beliefs-092",
+    "score": 0.585857,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.54155,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "saf",
+    "node_id": "saf-beliefs-050",
+    "score": 0.528125,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "saf",
+    "node_id": "saf-intentions-020",
+    "score": 0.513263,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "skp",
+    "node_id": "skp-beliefs-204",
+    "score": 0.609565,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "skp",
+    "node_id": "skp-beliefs-169",
+    "score": 0.587596,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-393",
+    "camp": "skp",
+    "node_id": "skp-beliefs-017",
+    "score": 0.536137,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.598502,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.588341,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.584495,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.599392,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.598607,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "saf",
+    "node_id": "saf-beliefs-248",
+    "score": 0.56319,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "skp",
+    "node_id": "skp-desires-088",
+    "score": 0.552974,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "skp",
+    "node_id": "skp-beliefs-257",
+    "score": 0.541736,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-394",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.525125,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "acc",
+    "node_id": "acc-beliefs-046",
+    "score": 0.396877,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "acc",
+    "node_id": "acc-intentions-106",
+    "score": 0.39302,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "acc",
+    "node_id": "acc-beliefs-114",
+    "score": 0.389553,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.544901,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.544735,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "saf",
+    "node_id": "saf-beliefs-013",
+    "score": 0.539823,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.518329,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "skp",
+    "node_id": "skp-beliefs-102",
+    "score": 0.502636,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-395",
+    "camp": "skp",
+    "node_id": "skp-intentions-141",
+    "score": 0.499874,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "acc",
+    "node_id": "acc-beliefs-003",
+    "score": 0.554375,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "acc",
+    "node_id": "acc-beliefs-083",
+    "score": 0.552937,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "acc",
+    "node_id": "acc-intentions-056",
+    "score": 0.535967,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "saf",
+    "node_id": "saf-beliefs-018",
+    "score": 0.598047,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "saf",
+    "node_id": "saf-desires-027",
+    "score": 0.596208,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "saf",
+    "node_id": "saf-desires-023",
+    "score": 0.570559,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "skp",
+    "node_id": "skp-beliefs-236",
+    "score": 0.600532,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "skp",
+    "node_id": "skp-beliefs-111",
+    "score": 0.573677,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-396",
+    "camp": "skp",
+    "node_id": "skp-beliefs-225",
+    "score": 0.570796,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "acc",
+    "node_id": "acc-beliefs-038",
+    "score": 0.50236,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.42227,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.402988,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "saf",
+    "node_id": "saf-beliefs-092",
+    "score": 0.712244,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "saf",
+    "node_id": "saf-intentions-047",
+    "score": 0.58411,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.571678,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "skp",
+    "node_id": "skp-beliefs-235",
+    "score": 0.660045,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.53032,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-397",
+    "camp": "skp",
+    "node_id": "skp-intentions-153",
+    "score": 0.501356,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.774225,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "acc",
+    "node_id": "acc-beliefs-072",
+    "score": 0.726045,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.699552,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.756079,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "saf",
+    "node_id": "saf-intentions-080",
+    "score": 0.748187,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.729883,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.745618,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.697384,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-398",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.689995,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "acc",
+    "node_id": "acc-intentions-080",
+    "score": 0.55256,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.531928,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "acc",
+    "node_id": "acc-beliefs-083",
+    "score": 0.518672,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.621302,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "saf",
+    "node_id": "saf-beliefs-106",
+    "score": 0.544058,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.541268,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "skp",
+    "node_id": "skp-beliefs-237",
+    "score": 0.686143,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "skp",
+    "node_id": "skp-beliefs-236",
+    "score": 0.594514,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-399",
+    "camp": "skp",
+    "node_id": "skp-beliefs-298",
+    "score": 0.552797,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "acc",
+    "node_id": "acc-intentions-027",
+    "score": 0.650609,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.636489,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.636219,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "saf",
+    "node_id": "saf-desires-012",
+    "score": 0.704089,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "saf",
+    "node_id": "saf-beliefs-217",
+    "score": 0.686014,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "saf",
+    "node_id": "saf-beliefs-127",
+    "score": 0.66398,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.695744,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.666913,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-400",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.639661,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.570096,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.558482,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.556841,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "saf",
+    "node_id": "saf-desires-004",
+    "score": 0.645613,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.639202,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.608025,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.697635,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.681084,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-401",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.659715,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.555646,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.52123,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.495378,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "saf",
+    "node_id": "saf-intentions-231",
+    "score": 0.64738,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "saf",
+    "node_id": "saf-intentions-170",
+    "score": 0.639512,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.637891,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "skp",
+    "node_id": "skp-beliefs-238",
+    "score": 0.612034,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "skp",
+    "node_id": "skp-intentions-008",
+    "score": 0.604385,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-402",
+    "camp": "skp",
+    "node_id": "skp-beliefs-234",
+    "score": 0.544679,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "acc",
+    "node_id": "acc-intentions-119",
+    "score": 0.582113,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "acc",
+    "node_id": "acc-beliefs-097",
+    "score": 0.554612,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "acc",
+    "node_id": "acc-beliefs-093",
+    "score": 0.459349,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "saf",
+    "node_id": "saf-beliefs-107",
+    "score": 0.577758,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "saf",
+    "node_id": "saf-beliefs-108",
+    "score": 0.563337,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "saf",
+    "node_id": "saf-beliefs-233",
+    "score": 0.545128,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "skp",
+    "node_id": "skp-beliefs-238",
+    "score": 0.720079,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.636258,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-403",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.578735,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "acc",
+    "node_id": "acc-beliefs-034",
+    "score": 0.558984,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.555818,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "acc",
+    "node_id": "acc-intentions-100",
+    "score": 0.536582,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "saf",
+    "node_id": "saf-intentions-158",
+    "score": 0.582199,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "saf",
+    "node_id": "saf-intentions-210",
+    "score": 0.573641,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "saf",
+    "node_id": "saf-intentions-040",
+    "score": 0.573422,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "skp",
+    "node_id": "skp-intentions-132",
+    "score": 0.543871,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "skp",
+    "node_id": "skp-beliefs-117",
+    "score": 0.537336,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-404",
+    "camp": "skp",
+    "node_id": "skp-intentions-105",
+    "score": 0.523702,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.576759,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.552913,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "acc",
+    "node_id": "acc-beliefs-028",
+    "score": 0.523898,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "saf",
+    "node_id": "saf-intentions-158",
+    "score": 0.659007,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "saf",
+    "node_id": "saf-intentions-242",
+    "score": 0.582581,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "saf",
+    "node_id": "saf-beliefs-110",
+    "score": 0.574319,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "skp",
+    "node_id": "skp-intentions-094",
+    "score": 0.528536,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "skp",
+    "node_id": "skp-intentions-162",
+    "score": 0.49899,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-405",
+    "camp": "skp",
+    "node_id": "skp-beliefs-102",
+    "score": 0.486598,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.638229,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "acc",
+    "node_id": "acc-intentions-103",
+    "score": 0.592085,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "acc",
+    "node_id": "acc-beliefs-113",
+    "score": 0.566722,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.795173,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.760994,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "saf",
+    "node_id": "saf-intentions-043",
+    "score": 0.747693,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "skp",
+    "node_id": "skp-beliefs-144",
+    "score": 0.700626,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.678515,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-406",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.668676,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "acc",
+    "node_id": "acc-beliefs-053",
+    "score": 0.570668,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "acc",
+    "node_id": "acc-beliefs-037",
+    "score": 0.49921,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "acc",
+    "node_id": "acc-beliefs-089",
+    "score": 0.4872,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "saf",
+    "node_id": "saf-beliefs-064",
+    "score": 0.61076,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "saf",
+    "node_id": "saf-intentions-063",
+    "score": 0.446195,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "saf",
+    "node_id": "saf-beliefs-137",
+    "score": 0.413697,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "skp",
+    "node_id": "skp-beliefs-030",
+    "score": 0.609673,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "skp",
+    "node_id": "skp-beliefs-028",
+    "score": 0.597591,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-407",
+    "camp": "skp",
+    "node_id": "skp-beliefs-101",
+    "score": 0.59347,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.611097,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.598674,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "acc",
+    "node_id": "acc-intentions-099",
+    "score": 0.561951,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.650679,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.628012,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "saf",
+    "node_id": "saf-intentions-231",
+    "score": 0.625285,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.64091,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "skp",
+    "node_id": "skp-desires-088",
+    "score": 0.640291,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-408",
+    "camp": "skp",
+    "node_id": "skp-beliefs-276",
+    "score": 0.617661,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "acc",
+    "node_id": "acc-beliefs-116",
+    "score": 0.598223,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "acc",
+    "node_id": "acc-beliefs-117",
+    "score": 0.598223,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "acc",
+    "node_id": "acc-beliefs-114",
+    "score": 0.569862,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.604484,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "saf",
+    "node_id": "saf-intentions-069",
+    "score": 0.596352,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "saf",
+    "node_id": "saf-beliefs-248",
+    "score": 0.589837,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "skp",
+    "node_id": "skp-intentions-097",
+    "score": 0.605556,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "skp",
+    "node_id": "skp-beliefs-279",
+    "score": 0.586505,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-409",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.554345,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.613619,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.601529,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "acc",
+    "node_id": "acc-beliefs-025",
+    "score": 0.600904,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.704531,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "saf",
+    "node_id": "saf-beliefs-218",
+    "score": 0.665352,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.639545,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "skp",
+    "node_id": "skp-intentions-034",
+    "score": 0.675224,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.612396,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-410",
+    "camp": "skp",
+    "node_id": "skp-beliefs-031",
+    "score": 0.611873,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.67,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.586569,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "acc",
+    "node_id": "acc-beliefs-106",
+    "score": 0.584663,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.665835,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "saf",
+    "node_id": "saf-intentions-226",
+    "score": 0.659702,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.637606,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "skp",
+    "node_id": "skp-beliefs-279",
+    "score": 0.648926,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "skp",
+    "node_id": "skp-beliefs-278",
+    "score": 0.621856,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-411",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.621209,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.615568,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "acc",
+    "node_id": "acc-beliefs-121",
+    "score": 0.612897,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.546545,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "saf",
+    "node_id": "saf-intentions-146",
+    "score": 0.633617,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.621469,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.619272,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "skp",
+    "node_id": "skp-beliefs-288",
+    "score": 0.658768,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "skp",
+    "node_id": "skp-beliefs-241",
+    "score": 0.657713,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-412",
+    "camp": "skp",
+    "node_id": "skp-intentions-069",
+    "score": 0.650606,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "acc",
+    "node_id": "acc-desires-042",
+    "score": 0.557675,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.55543,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "acc",
+    "node_id": "acc-beliefs-110",
+    "score": 0.516049,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "saf",
+    "node_id": "saf-intentions-094",
+    "score": 0.67783,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.637876,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "saf",
+    "node_id": "saf-intentions-234",
+    "score": 0.632837,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "skp",
+    "node_id": "skp-intentions-105",
+    "score": 0.594238,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "skp",
+    "node_id": "skp-beliefs-280",
+    "score": 0.587036,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-413",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.555557,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.610474,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.557562,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.555892,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "saf",
+    "node_id": "saf-beliefs-222",
+    "score": 0.626047,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.592335,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "saf",
+    "node_id": "saf-beliefs-104",
+    "score": 0.581074,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "skp",
+    "node_id": "skp-desires-080",
+    "score": 0.549608,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "skp",
+    "node_id": "skp-desires-003",
+    "score": 0.547949,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-414",
+    "camp": "skp",
+    "node_id": "skp-beliefs-177",
+    "score": 0.543407,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "acc",
+    "node_id": "acc-desires-025",
+    "score": 0.546151,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "acc",
+    "node_id": "acc-desires-026",
+    "score": 0.525688,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "acc",
+    "node_id": "acc-intentions-052",
+    "score": 0.522317,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "saf",
+    "node_id": "saf-intentions-102",
+    "score": 0.533605,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "saf",
+    "node_id": "saf-intentions-015",
+    "score": 0.526386,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.518409,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "skp",
+    "node_id": "skp-desires-085",
+    "score": 0.573199,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "skp",
+    "node_id": "skp-beliefs-254",
+    "score": 0.548472,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-415",
+    "camp": "skp",
+    "node_id": "skp-intentions-161",
+    "score": 0.48571,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.589359,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.589359,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "acc",
+    "node_id": "acc-intentions-091",
+    "score": 0.539699,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "saf",
+    "node_id": "saf-intentions-074",
+    "score": 0.565259,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "saf",
+    "node_id": "saf-intentions-076",
+    "score": 0.551493,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.549388,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.519625,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "skp",
+    "node_id": "skp-beliefs-233",
+    "score": 0.516224,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-416",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.505553,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "acc",
+    "node_id": "acc-intentions-117",
+    "score": 0.395259,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "acc",
+    "node_id": "acc-beliefs-082",
+    "score": 0.391867,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.391112,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "saf",
+    "node_id": "saf-beliefs-246",
+    "score": 0.614435,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "saf",
+    "node_id": "saf-desires-009",
+    "score": 0.581456,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "saf",
+    "node_id": "saf-intentions-166",
+    "score": 0.566635,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "skp",
+    "node_id": "skp-beliefs-145",
+    "score": 0.58881,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "skp",
+    "node_id": "skp-desires-088",
+    "score": 0.567863,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-417",
+    "camp": "skp",
+    "node_id": "skp-beliefs-052",
+    "score": 0.566029,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "acc",
+    "node_id": "acc-beliefs-080",
+    "score": 0.441101,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.428902,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "acc",
+    "node_id": "acc-intentions-110",
+    "score": 0.400255,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.57864,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.528712,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.513254,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.491438,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "skp",
+    "node_id": "skp-beliefs-301",
+    "score": 0.457654,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-418",
+    "camp": "skp",
+    "node_id": "skp-beliefs-159",
+    "score": 0.432129,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "acc",
+    "node_id": "acc-intentions-117",
+    "score": 0.489436,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "acc",
+    "node_id": "acc-beliefs-015",
+    "score": 0.458183,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "acc",
+    "node_id": "acc-beliefs-080",
+    "score": 0.419615,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "saf",
+    "node_id": "saf-intentions-174",
+    "score": 0.524427,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.51079,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "saf",
+    "node_id": "saf-intentions-037",
+    "score": 0.494973,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.476567,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "skp",
+    "node_id": "skp-beliefs-210",
+    "score": 0.463622,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-419",
+    "camp": "skp",
+    "node_id": "skp-beliefs-251",
+    "score": 0.455286,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "acc",
+    "node_id": "acc-beliefs-008",
+    "score": 0.653711,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "acc",
+    "node_id": "acc-beliefs-084",
+    "score": 0.647078,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.623436,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "saf",
+    "node_id": "saf-beliefs-204",
+    "score": 0.655989,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "saf",
+    "node_id": "saf-desires-002",
+    "score": 0.589931,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.583454,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "skp",
+    "node_id": "skp-desires-083",
+    "score": 0.669017,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "skp",
+    "node_id": "skp-desires-011",
+    "score": 0.654326,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-420",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.641444,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "acc",
+    "node_id": "acc-intentions-117",
+    "score": 0.537868,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "acc",
+    "node_id": "acc-intentions-093",
+    "score": 0.522544,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "acc",
+    "node_id": "acc-intentions-120",
+    "score": 0.510651,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.565648,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "saf",
+    "node_id": "saf-intentions-031",
+    "score": 0.544422,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "saf",
+    "node_id": "saf-intentions-174",
+    "score": 0.525847,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.543278,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.506267,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-421",
+    "camp": "skp",
+    "node_id": "skp-beliefs-215",
+    "score": 0.472706,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.50175,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.446179,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.43324,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "saf",
+    "node_id": "saf-beliefs-013",
+    "score": 0.529628,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "saf",
+    "node_id": "saf-desires-007",
+    "score": 0.498289,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "saf",
+    "node_id": "saf-beliefs-099",
+    "score": 0.496695,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "skp",
+    "node_id": "skp-beliefs-259",
+    "score": 0.510631,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "skp",
+    "node_id": "skp-beliefs-250",
+    "score": 0.411497,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-422",
+    "camp": "skp",
+    "node_id": "skp-beliefs-129",
+    "score": 0.409085,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "acc",
+    "node_id": "acc-intentions-091",
+    "score": 0.531472,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.501675,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.501675,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "saf",
+    "node_id": "saf-beliefs-007",
+    "score": 0.585236,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.584465,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.578039,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "skp",
+    "node_id": "skp-beliefs-254",
+    "score": 0.567316,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "skp",
+    "node_id": "skp-beliefs-233",
+    "score": 0.530044,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-423",
+    "camp": "skp",
+    "node_id": "skp-desires-003",
+    "score": 0.464281,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "acc",
+    "node_id": "acc-intentions-117",
+    "score": 0.418432,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "acc",
+    "node_id": "acc-intentions-110",
+    "score": 0.412561,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "acc",
+    "node_id": "acc-beliefs-080",
+    "score": 0.391226,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.484303,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "saf",
+    "node_id": "saf-intentions-223",
+    "score": 0.466132,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "saf",
+    "node_id": "saf-intentions-174",
+    "score": 0.458333,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.577996,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.572732,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-424",
+    "camp": "skp",
+    "node_id": "skp-beliefs-251",
+    "score": 0.537436,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.592358,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "acc",
+    "node_id": "acc-beliefs-111",
+    "score": 0.562879,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "acc",
+    "node_id": "acc-beliefs-112",
+    "score": 0.562879,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "saf",
+    "node_id": "saf-intentions-141",
+    "score": 0.660535,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "saf",
+    "node_id": "saf-intentions-203",
+    "score": 0.651592,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "saf",
+    "node_id": "saf-intentions-114",
+    "score": 0.633472,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "skp",
+    "node_id": "skp-intentions-105",
+    "score": 0.674468,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "skp",
+    "node_id": "skp-beliefs-278",
+    "score": 0.631269,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-425",
+    "camp": "skp",
+    "node_id": "skp-beliefs-287",
+    "score": 0.567626,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.540501,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.524206,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "acc",
+    "node_id": "acc-beliefs-076",
+    "score": 0.511219,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.613615,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "saf",
+    "node_id": "saf-intentions-039",
+    "score": 0.583333,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "saf",
+    "node_id": "saf-beliefs-116",
+    "score": 0.569823,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "skp",
+    "node_id": "skp-beliefs-074",
+    "score": 0.530119,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "skp",
+    "node_id": "skp-beliefs-064",
+    "score": 0.517896,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-426",
+    "camp": "skp",
+    "node_id": "skp-beliefs-286",
+    "score": 0.484552,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.624385,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.614075,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.602033,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "saf",
+    "node_id": "saf-beliefs-203",
+    "score": 0.56848,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "saf",
+    "node_id": "saf-intentions-213",
+    "score": 0.567833,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "saf",
+    "node_id": "saf-intentions-139",
+    "score": 0.567574,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.637901,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.608515,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-427",
+    "camp": "skp",
+    "node_id": "skp-beliefs-213",
+    "score": 0.605127,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.540046,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "acc",
+    "node_id": "acc-beliefs-110",
+    "score": 0.537031,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "acc",
+    "node_id": "acc-intentions-009",
+    "score": 0.524808,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "saf",
+    "node_id": "saf-beliefs-228",
+    "score": 0.670399,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "saf",
+    "node_id": "saf-beliefs-093",
+    "score": 0.62227,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "saf",
+    "node_id": "saf-beliefs-057",
+    "score": 0.599576,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.552995,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.537984,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-428",
+    "camp": "skp",
+    "node_id": "skp-beliefs-061",
+    "score": 0.535684,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.483623,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.483623,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.474721,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "saf",
+    "node_id": "saf-intentions-224",
+    "score": 0.580895,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.55905,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.546173,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "skp",
+    "node_id": "skp-beliefs-125",
+    "score": 0.511959,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.507737,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-429",
+    "camp": "skp",
+    "node_id": "skp-intentions-133",
+    "score": 0.502732,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "acc",
+    "node_id": "acc-desires-011",
+    "score": 0.52274,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.469834,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "acc",
+    "node_id": "acc-desires-025",
+    "score": 0.468336,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "saf",
+    "node_id": "saf-beliefs-095",
+    "score": 0.658205,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "saf",
+    "node_id": "saf-intentions-127",
+    "score": 0.655224,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.627743,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "skp",
+    "node_id": "skp-beliefs-167",
+    "score": 0.662818,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "skp",
+    "node_id": "skp-beliefs-147",
+    "score": 0.61857,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-430",
+    "camp": "skp",
+    "node_id": "skp-beliefs-008",
+    "score": 0.597875,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "acc",
+    "node_id": "acc-intentions-072",
+    "score": 0.493994,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "acc",
+    "node_id": "acc-intentions-017",
+    "score": 0.479214,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "acc",
+    "node_id": "acc-beliefs-048",
+    "score": 0.475247,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "saf",
+    "node_id": "saf-beliefs-227",
+    "score": 0.492139,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "saf",
+    "node_id": "saf-intentions-051",
+    "score": 0.455857,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "saf",
+    "node_id": "saf-beliefs-116",
+    "score": 0.431626,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "skp",
+    "node_id": "skp-beliefs-119",
+    "score": 0.601742,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.59888,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-431",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.573591,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "acc",
+    "node_id": "acc-desires-018",
+    "score": 0.588595,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "acc",
+    "node_id": "acc-desires-026",
+    "score": 0.585187,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "acc",
+    "node_id": "acc-desires-009",
+    "score": 0.583063,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "saf",
+    "node_id": "saf-beliefs-119",
+    "score": 0.605001,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.595043,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "saf",
+    "node_id": "saf-desires-002",
+    "score": 0.594075,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "skp",
+    "node_id": "skp-intentions-163",
+    "score": 0.584925,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "skp",
+    "node_id": "skp-intentions-111",
+    "score": 0.555168,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-432",
+    "camp": "skp",
+    "node_id": "skp-desires-075",
+    "score": 0.520487,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.638492,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "acc",
+    "node_id": "acc-desires-026",
+    "score": 0.6363,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "acc",
+    "node_id": "acc-desires-028",
+    "score": 0.628932,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "saf",
+    "node_id": "saf-beliefs-207",
+    "score": 0.730558,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "saf",
+    "node_id": "saf-beliefs-200",
+    "score": 0.602462,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "saf",
+    "node_id": "saf-intentions-086",
+    "score": 0.59908,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.644469,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "skp",
+    "node_id": "skp-beliefs-205",
+    "score": 0.615185,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-433",
+    "camp": "skp",
+    "node_id": "skp-desires-006",
+    "score": 0.610846,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "acc",
+    "node_id": "acc-beliefs-083",
+    "score": 0.588533,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.586555,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.549183,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "saf",
+    "node_id": "saf-desires-027",
+    "score": 0.574121,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "saf",
+    "node_id": "saf-beliefs-264",
+    "score": 0.568021,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "saf",
+    "node_id": "saf-intentions-216",
+    "score": 0.561444,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "skp",
+    "node_id": "skp-beliefs-252",
+    "score": 0.580832,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "skp",
+    "node_id": "skp-beliefs-236",
+    "score": 0.560746,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-434",
+    "camp": "skp",
+    "node_id": "skp-beliefs-190",
+    "score": 0.530338,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "acc",
+    "node_id": "acc-desires-011",
+    "score": 0.478812,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "acc",
+    "node_id": "acc-desires-025",
+    "score": 0.475431,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.471061,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "saf",
+    "node_id": "saf-intentions-059",
+    "score": 0.491731,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "saf",
+    "node_id": "saf-beliefs-007",
+    "score": 0.470032,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "saf",
+    "node_id": "saf-beliefs-232",
+    "score": 0.456032,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.591852,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "skp",
+    "node_id": "skp-intentions-147",
+    "score": 0.590274,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-435",
+    "camp": "skp",
+    "node_id": "skp-intentions-035",
+    "score": 0.578,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "acc",
+    "node_id": "acc-intentions-073",
+    "score": 0.488963,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.483288,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.475249,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "saf",
+    "node_id": "saf-intentions-102",
+    "score": 0.543279,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "saf",
+    "node_id": "saf-beliefs-206",
+    "score": 0.540599,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "saf",
+    "node_id": "saf-intentions-016",
+    "score": 0.523453,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "skp",
+    "node_id": "skp-beliefs-143",
+    "score": 0.644933,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "skp",
+    "node_id": "skp-desires-077",
+    "score": 0.585165,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-436",
+    "camp": "skp",
+    "node_id": "skp-beliefs-178",
+    "score": 0.52363,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "acc",
+    "node_id": "acc-beliefs-080",
+    "score": 0.375202,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.305946,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.291938,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.445621,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "saf",
+    "node_id": "saf-intentions-126",
+    "score": 0.438071,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.425141,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.48283,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "skp",
+    "node_id": "skp-beliefs-251",
+    "score": 0.428932,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-437",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.407633,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "acc",
+    "node_id": "acc-beliefs-015",
+    "score": 0.468264,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.457584,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "acc",
+    "node_id": "acc-desires-011",
+    "score": 0.453045,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "saf",
+    "node_id": "saf-beliefs-151",
+    "score": 0.558402,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "saf",
+    "node_id": "saf-intentions-006",
+    "score": 0.553719,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "saf",
+    "node_id": "saf-intentions-047",
+    "score": 0.542638,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "skp",
+    "node_id": "skp-intentions-161",
+    "score": 0.519195,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "skp",
+    "node_id": "skp-beliefs-254",
+    "score": 0.498694,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-438",
+    "camp": "skp",
+    "node_id": "skp-desires-085",
+    "score": 0.48813,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "acc",
+    "node_id": "acc-beliefs-070",
+    "score": 0.492663,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.472534,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.459967,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "saf",
+    "node_id": "saf-intentions-074",
+    "score": 0.576359,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "saf",
+    "node_id": "saf-beliefs-135",
+    "score": 0.542384,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "saf",
+    "node_id": "saf-intentions-050",
+    "score": 0.541794,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.606119,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "skp",
+    "node_id": "skp-intentions-097",
+    "score": 0.605482,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-439",
+    "camp": "skp",
+    "node_id": "skp-intentions-074",
+    "score": 0.605011,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.411324,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.394947,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "acc",
+    "node_id": "acc-beliefs-046",
+    "score": 0.344772,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "saf",
+    "node_id": "saf-beliefs-234",
+    "score": 0.76208,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "saf",
+    "node_id": "saf-beliefs-231",
+    "score": 0.597851,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "saf",
+    "node_id": "saf-intentions-008",
+    "score": 0.569151,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "skp",
+    "node_id": "skp-beliefs-268",
+    "score": 0.450651,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "skp",
+    "node_id": "skp-beliefs-276",
+    "score": 0.446936,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-440",
+    "camp": "skp",
+    "node_id": "skp-beliefs-076",
+    "score": 0.446267,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.365033,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "acc",
+    "node_id": "acc-beliefs-046",
+    "score": 0.355982,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "acc",
+    "node_id": "acc-beliefs-005",
+    "score": 0.346918,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "saf",
+    "node_id": "saf-beliefs-042",
+    "score": 0.514449,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "saf",
+    "node_id": "saf-intentions-137",
+    "score": 0.512579,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "saf",
+    "node_id": "saf-intentions-142",
+    "score": 0.502413,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "skp",
+    "node_id": "skp-beliefs-276",
+    "score": 0.41025,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "skp",
+    "node_id": "skp-beliefs-026",
+    "score": 0.382888,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-441",
+    "camp": "skp",
+    "node_id": "skp-beliefs-260",
+    "score": 0.381191,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.551673,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.543126,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "acc",
+    "node_id": "acc-desires-006",
+    "score": 0.48328,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "saf",
+    "node_id": "saf-beliefs-231",
+    "score": 0.620877,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "saf",
+    "node_id": "saf-beliefs-009",
+    "score": 0.581248,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "saf",
+    "node_id": "saf-beliefs-234",
+    "score": 0.574984,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "skp",
+    "node_id": "skp-intentions-104",
+    "score": 0.513065,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "skp",
+    "node_id": "skp-beliefs-286",
+    "score": 0.488221,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-442",
+    "camp": "skp",
+    "node_id": "skp-intentions-044",
+    "score": 0.484723,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "acc",
+    "node_id": "acc-intentions-054",
+    "score": 0.517918,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "acc",
+    "node_id": "acc-intentions-044",
+    "score": 0.506085,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "acc",
+    "node_id": "acc-desires-001",
+    "score": 0.500113,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "saf",
+    "node_id": "saf-beliefs-236",
+    "score": 0.637901,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "saf",
+    "node_id": "saf-desires-002",
+    "score": 0.626047,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "saf",
+    "node_id": "saf-intentions-149",
+    "score": 0.609314,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.618611,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "skp",
+    "node_id": "skp-intentions-104",
+    "score": 0.558602,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-443",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.547518,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.365981,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "acc",
+    "node_id": "acc-intentions-119",
+    "score": 0.347615,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "acc",
+    "node_id": "acc-beliefs-028",
+    "score": 0.341668,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.496732,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "saf",
+    "node_id": "saf-intentions-155",
+    "score": 0.492513,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "saf",
+    "node_id": "saf-intentions-150",
+    "score": 0.471872,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.456383,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "skp",
+    "node_id": "skp-beliefs-263",
+    "score": 0.453354,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-444",
+    "camp": "skp",
+    "node_id": "skp-beliefs-111",
+    "score": 0.451784,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "acc",
+    "node_id": "acc-beliefs-027",
+    "score": 0.506694,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.472632,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "acc",
+    "node_id": "acc-intentions-015",
+    "score": 0.461968,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "saf",
+    "node_id": "saf-beliefs-102",
+    "score": 0.541023,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "saf",
+    "node_id": "saf-beliefs-032",
+    "score": 0.535777,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "saf",
+    "node_id": "saf-beliefs-101",
+    "score": 0.52648,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.552721,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "skp",
+    "node_id": "skp-intentions-155",
+    "score": 0.540018,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-445",
+    "camp": "skp",
+    "node_id": "skp-beliefs-094",
+    "score": 0.539972,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "acc",
+    "node_id": "acc-intentions-115",
+    "score": 0.459084,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "acc",
+    "node_id": "acc-beliefs-088",
+    "score": 0.458932,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.42155,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "saf",
+    "node_id": "saf-beliefs-234",
+    "score": 0.665429,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "saf",
+    "node_id": "saf-intentions-008",
+    "score": 0.583614,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "saf",
+    "node_id": "saf-beliefs-231",
+    "score": 0.573876,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.524641,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.505736,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-446",
+    "camp": "skp",
+    "node_id": "skp-beliefs-006",
+    "score": 0.497888,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "acc",
+    "node_id": "acc-intentions-086",
+    "score": 0.583215,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "acc",
+    "node_id": "acc-intentions-061",
+    "score": 0.578691,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "acc",
+    "node_id": "acc-beliefs-039",
+    "score": 0.571285,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "saf",
+    "node_id": "saf-desires-008",
+    "score": 0.588602,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "saf",
+    "node_id": "saf-desires-025",
+    "score": 0.574985,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "saf",
+    "node_id": "saf-intentions-127",
+    "score": 0.572216,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "skp",
+    "node_id": "skp-beliefs-118",
+    "score": 0.583437,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "skp",
+    "node_id": "skp-beliefs-008",
+    "score": 0.581435,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-447",
+    "camp": "skp",
+    "node_id": "skp-intentions-013",
+    "score": 0.574426,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "acc",
+    "node_id": "acc-beliefs-110",
+    "score": 0.720964,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.589777,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "acc",
+    "node_id": "acc-beliefs-108",
+    "score": 0.562048,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "saf",
+    "node_id": "saf-beliefs-248",
+    "score": 0.769337,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "saf",
+    "node_id": "saf-desires-005",
+    "score": 0.653393,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.591094,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "skp",
+    "node_id": "skp-beliefs-286",
+    "score": 0.740525,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.578137,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-448",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.573814,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "acc",
+    "node_id": "acc-intentions-111",
+    "score": 0.566029,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.564166,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.526043,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.575753,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "saf",
+    "node_id": "saf-beliefs-205",
+    "score": 0.55456,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "saf",
+    "node_id": "saf-beliefs-237",
+    "score": 0.553871,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.597506,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.591224,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-449",
+    "camp": "skp",
+    "node_id": "skp-beliefs-302",
+    "score": 0.588711,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.601292,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.565228,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "acc",
+    "node_id": "acc-intentions-091",
+    "score": 0.553251,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "saf",
+    "node_id": "saf-intentions-237",
+    "score": 0.878606,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "saf",
+    "node_id": "saf-intentions-235",
+    "score": 0.86402,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "saf",
+    "node_id": "saf-beliefs-250",
+    "score": 0.84845,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "skp",
+    "node_id": "skp-beliefs-290",
+    "score": 0.834956,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "skp",
+    "node_id": "skp-beliefs-293",
+    "score": 0.616758,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-450",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.598383,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.556277,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.547457,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "acc",
+    "node_id": "acc-intentions-091",
+    "score": 0.545869,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "saf",
+    "node_id": "saf-intentions-237",
+    "score": 0.869633,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "saf",
+    "node_id": "saf-intentions-235",
+    "score": 0.860285,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "saf",
+    "node_id": "saf-beliefs-250",
+    "score": 0.790291,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "skp",
+    "node_id": "skp-beliefs-290",
+    "score": 0.783545,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "skp",
+    "node_id": "skp-beliefs-293",
+    "score": 0.662592,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-451",
+    "camp": "skp",
+    "node_id": "skp-desires-088",
+    "score": 0.566097,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.656163,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.650065,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "acc",
+    "node_id": "acc-intentions-005",
+    "score": 0.635691,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.675869,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "saf",
+    "node_id": "saf-desires-010",
+    "score": 0.65549,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.64727,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.66687,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.666252,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-452",
+    "camp": "skp",
+    "node_id": "skp-beliefs-279",
+    "score": 0.65775,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "acc",
+    "node_id": "acc-desires-020",
+    "score": 0.563853,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "acc",
+    "node_id": "acc-intentions-126",
+    "score": 0.548243,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "acc",
+    "node_id": "acc-intentions-036",
+    "score": 0.538322,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "saf",
+    "node_id": "saf-desires-023",
+    "score": 0.569524,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "saf",
+    "node_id": "saf-intentions-031",
+    "score": 0.568966,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "saf",
+    "node_id": "saf-beliefs-201",
+    "score": 0.557385,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "skp",
+    "node_id": "skp-intentions-124",
+    "score": 0.593691,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.568284,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-453",
+    "camp": "skp",
+    "node_id": "skp-beliefs-041",
+    "score": 0.567294,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.645192,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "acc",
+    "node_id": "acc-beliefs-115",
+    "score": 0.563896,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.537561,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.658572,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "saf",
+    "node_id": "saf-intentions-040",
+    "score": 0.618953,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "saf",
+    "node_id": "saf-intentions-145",
+    "score": 0.618264,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.677122,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "skp",
+    "node_id": "skp-beliefs-213",
+    "score": 0.666504,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-454",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.650886,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "acc",
+    "node_id": "acc-intentions-096",
+    "score": 0.537868,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.464902,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "acc",
+    "node_id": "acc-intentions-119",
+    "score": 0.426385,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.57952,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "saf",
+    "node_id": "saf-intentions-155",
+    "score": 0.533507,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "saf",
+    "node_id": "saf-desires-003",
+    "score": 0.505068,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "skp",
+    "node_id": "skp-intentions-167",
+    "score": 0.576672,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.571982,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-455",
+    "camp": "skp",
+    "node_id": "skp-beliefs-263",
+    "score": 0.545299,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "acc",
+    "node_id": "acc-intentions-075",
+    "score": 0.585989,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.553176,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "acc",
+    "node_id": "acc-beliefs-102",
+    "score": 0.54442,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "saf",
+    "node_id": "saf-intentions-231",
+    "score": 0.610867,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.566276,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "saf",
+    "node_id": "saf-intentions-127",
+    "score": 0.564805,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.61073,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "skp",
+    "node_id": "skp-beliefs-164",
+    "score": 0.587476,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-456",
+    "camp": "skp",
+    "node_id": "skp-intentions-069",
+    "score": 0.585104,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "acc",
+    "node_id": "acc-intentions-003",
+    "score": 0.532196,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "acc",
+    "node_id": "acc-beliefs-075",
+    "score": 0.504551,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "acc",
+    "node_id": "acc-beliefs-122",
+    "score": 0.481148,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "saf",
+    "node_id": "saf-beliefs-255",
+    "score": 0.614194,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.598563,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "saf",
+    "node_id": "saf-beliefs-258",
+    "score": 0.533035,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "skp",
+    "node_id": "skp-beliefs-140",
+    "score": 0.569427,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "skp",
+    "node_id": "skp-desires-082",
+    "score": 0.5518,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-457",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.541542,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.674593,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "acc",
+    "node_id": "acc-desires-037",
+    "score": 0.672738,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "acc",
+    "node_id": "acc-beliefs-086",
+    "score": 0.649923,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.701389,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "saf",
+    "node_id": "saf-desires-006",
+    "score": 0.650704,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.627911,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "skp",
+    "node_id": "skp-desires-081",
+    "score": 0.744167,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.729275,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-458",
+    "camp": "skp",
+    "node_id": "skp-beliefs-170",
+    "score": 0.727822,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.621848,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "acc",
+    "node_id": "acc-intentions-022",
+    "score": 0.59242,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.553797,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "saf",
+    "node_id": "saf-intentions-201",
+    "score": 0.649847,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "saf",
+    "node_id": "saf-intentions-239",
+    "score": 0.599763,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "saf",
+    "node_id": "saf-intentions-069",
+    "score": 0.589265,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "skp",
+    "node_id": "skp-beliefs-186",
+    "score": 0.525588,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "skp",
+    "node_id": "skp-beliefs-275",
+    "score": 0.523306,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-459",
+    "camp": "skp",
+    "node_id": "skp-beliefs-102",
+    "score": 0.517654,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "acc",
+    "node_id": "acc-beliefs-003",
+    "score": 0.507634,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "acc",
+    "node_id": "acc-intentions-108",
+    "score": 0.504061,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "acc",
+    "node_id": "acc-intentions-106",
+    "score": 0.50154,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "saf",
+    "node_id": "saf-intentions-226",
+    "score": 0.572099,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.555245,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "saf",
+    "node_id": "saf-intentions-169",
+    "score": 0.526689,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "skp",
+    "node_id": "skp-intentions-107",
+    "score": 0.553072,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.544703,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-460",
+    "camp": "skp",
+    "node_id": "skp-desires-088",
+    "score": 0.538058,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "acc",
+    "node_id": "acc-intentions-126",
+    "score": 0.615622,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "acc",
+    "node_id": "acc-desires-020",
+    "score": 0.613474,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "acc",
+    "node_id": "acc-beliefs-120",
+    "score": 0.608424,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "saf",
+    "node_id": "saf-beliefs-056",
+    "score": 0.62831,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "saf",
+    "node_id": "saf-intentions-013",
+    "score": 0.610378,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "saf",
+    "node_id": "saf-intentions-159",
+    "score": 0.598513,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "skp",
+    "node_id": "skp-intentions-124",
+    "score": 0.607204,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "skp",
+    "node_id": "skp-desires-059",
+    "score": 0.599482,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-461",
+    "camp": "skp",
+    "node_id": "skp-desires-006",
+    "score": 0.587226,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.604023,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.512078,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "acc",
+    "node_id": "acc-intentions-047",
+    "score": 0.503465,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.686222,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "saf",
+    "node_id": "saf-intentions-043",
+    "score": 0.609396,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "saf",
+    "node_id": "saf-intentions-127",
+    "score": 0.6017,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "skp",
+    "node_id": "skp-beliefs-144",
+    "score": 0.698023,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "skp",
+    "node_id": "skp-beliefs-141",
+    "score": 0.667714,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-462",
+    "camp": "skp",
+    "node_id": "skp-beliefs-275",
+    "score": 0.631578,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.571973,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.571973,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.529456,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "saf",
+    "node_id": "saf-intentions-148",
+    "score": 0.631356,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "saf",
+    "node_id": "saf-beliefs-062",
+    "score": 0.580311,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.561684,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "skp",
+    "node_id": "skp-intentions-142",
+    "score": 0.690959,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "skp",
+    "node_id": "skp-beliefs-095",
+    "score": 0.681988,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-463",
+    "camp": "skp",
+    "node_id": "skp-beliefs-098",
+    "score": 0.667606,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "acc",
+    "node_id": "acc-intentions-086",
+    "score": 0.590753,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.583387,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "acc",
+    "node_id": "acc-intentions-114",
+    "score": 0.581439,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "saf",
+    "node_id": "saf-beliefs-097",
+    "score": 0.728774,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "saf",
+    "node_id": "saf-beliefs-040",
+    "score": 0.699186,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "saf",
+    "node_id": "saf-intentions-002",
+    "score": 0.691429,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "skp",
+    "node_id": "skp-intentions-029",
+    "score": 0.692611,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "skp",
+    "node_id": "skp-intentions-108",
+    "score": 0.688772,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-464",
+    "camp": "skp",
+    "node_id": "skp-intentions-138",
+    "score": 0.661884,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "acc",
+    "node_id": "acc-intentions-112",
+    "score": 0.516084,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.424853,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.424853,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "saf",
+    "node_id": "saf-beliefs-262",
+    "score": 0.521507,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "saf",
+    "node_id": "saf-intentions-027",
+    "score": 0.508377,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "saf",
+    "node_id": "saf-beliefs-254",
+    "score": 0.488434,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "skp",
+    "node_id": "skp-beliefs-132",
+    "score": 0.577915,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "skp",
+    "node_id": "skp-intentions-144",
+    "score": 0.565667,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-465",
+    "camp": "skp",
+    "node_id": "skp-beliefs-145",
+    "score": 0.558364,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "acc",
+    "node_id": "acc-intentions-106",
+    "score": 0.420903,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.417683,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.417683,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "saf",
+    "node_id": "saf-intentions-235",
+    "score": 0.484931,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "saf",
+    "node_id": "saf-intentions-237",
+    "score": 0.467524,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "saf",
+    "node_id": "saf-beliefs-250",
+    "score": 0.458699,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "skp",
+    "node_id": "skp-beliefs-137",
+    "score": 0.423,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "skp",
+    "node_id": "skp-beliefs-299",
+    "score": 0.412445,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-466",
+    "camp": "skp",
+    "node_id": "skp-intentions-161",
+    "score": 0.397701,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.429707,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "acc",
+    "node_id": "acc-beliefs-119",
+    "score": 0.429707,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "acc",
+    "node_id": "acc-beliefs-035",
+    "score": 0.393371,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "saf",
+    "node_id": "saf-beliefs-250",
+    "score": 0.519578,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "saf",
+    "node_id": "saf-beliefs-251",
+    "score": 0.519578,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "saf",
+    "node_id": "saf-intentions-104",
+    "score": 0.468612,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "skp",
+    "node_id": "skp-beliefs-290",
+    "score": 0.52957,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "skp",
+    "node_id": "skp-intentions-154",
+    "score": 0.449407,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-467",
+    "camp": "skp",
+    "node_id": "skp-beliefs-146",
+    "score": 0.439536,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "acc",
+    "node_id": "acc-beliefs-046",
+    "score": 0.499337,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "acc",
+    "node_id": "acc-intentions-008",
+    "score": 0.432045,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "acc",
+    "node_id": "acc-intentions-106",
+    "score": 0.422945,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "saf",
+    "node_id": "saf-intentions-094",
+    "score": 0.455316,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "saf",
+    "node_id": "saf-desires-011",
+    "score": 0.417859,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "saf",
+    "node_id": "saf-beliefs-049",
+    "score": 0.41594,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "skp",
+    "node_id": "skp-desires-086",
+    "score": 0.498252,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "skp",
+    "node_id": "skp-intentions-107",
+    "score": 0.484918,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-468",
+    "camp": "skp",
+    "node_id": "skp-intentions-133",
+    "score": 0.464264,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "acc",
+    "node_id": "acc-intentions-127",
+    "score": 0.682281,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "acc",
+    "node_id": "acc-beliefs-074",
+    "score": 0.603218,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "acc",
+    "node_id": "acc-intentions-090",
+    "score": 0.583067,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "saf",
+    "node_id": "saf-beliefs-122",
+    "score": 0.658548,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "saf",
+    "node_id": "saf-beliefs-217",
+    "score": 0.651957,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "saf",
+    "node_id": "saf-intentions-215",
+    "score": 0.597465,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.711529,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "skp",
+    "node_id": "skp-beliefs-047",
+    "score": 0.700419,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-469",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.672789,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.619925,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.598121,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "acc",
+    "node_id": "acc-intentions-088",
+    "score": 0.578403,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.622961,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "saf",
+    "node_id": "saf-beliefs-126",
+    "score": 0.616391,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "saf",
+    "node_id": "saf-intentions-213",
+    "score": 0.596787,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "skp",
+    "node_id": "skp-beliefs-006",
+    "score": 0.589776,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "skp",
+    "node_id": "skp-intentions-029",
+    "score": 0.585965,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-470",
+    "camp": "skp",
+    "node_id": "skp-beliefs-040",
+    "score": 0.583574,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "acc",
+    "node_id": "acc-beliefs-120",
+    "score": 0.687512,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "acc",
+    "node_id": "acc-intentions-126",
+    "score": 0.516617,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "acc",
+    "node_id": "acc-desires-039",
+    "score": 0.498724,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "saf",
+    "node_id": "saf-intentions-040",
+    "score": 0.522088,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "saf",
+    "node_id": "saf-desires-030",
+    "score": 0.50242,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "saf",
+    "node_id": "saf-beliefs-211",
+    "score": 0.501224,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "skp",
+    "node_id": "skp-beliefs-189",
+    "score": 0.477941,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "skp",
+    "node_id": "skp-beliefs-165",
+    "score": 0.464668,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-471",
+    "camp": "skp",
+    "node_id": "skp-intentions-129",
+    "score": 0.457805,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "acc",
+    "node_id": "acc-intentions-018",
+    "score": 0.559929,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "acc",
+    "node_id": "acc-beliefs-020",
+    "score": 0.5434,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "acc",
+    "node_id": "acc-beliefs-118",
+    "score": 0.535777,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "saf",
+    "node_id": "saf-desires-002",
+    "score": 0.622397,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "saf",
+    "node_id": "saf-intentions-224",
+    "score": 0.584608,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "saf",
+    "node_id": "saf-beliefs-007",
+    "score": 0.582221,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "skp",
+    "node_id": "skp-beliefs-099",
+    "score": 0.611218,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "skp",
+    "node_id": "skp-beliefs-248",
+    "score": 0.589861,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-472",
+    "camp": "skp",
+    "node_id": "skp-beliefs-008",
+    "score": 0.587197,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "acc",
+    "node_id": "acc-beliefs-015",
+    "score": 0.596651,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "acc",
+    "node_id": "acc-intentions-117",
+    "score": 0.541211,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "acc",
+    "node_id": "acc-beliefs-021",
+    "score": 0.485227,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "saf",
+    "node_id": "saf-intentions-031",
+    "score": 0.595823,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "saf",
+    "node_id": "saf-intentions-174",
+    "score": 0.571362,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "saf",
+    "node_id": "saf-beliefs-132",
+    "score": 0.566927,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "skp",
+    "node_id": "skp-beliefs-273",
+    "score": 0.580913,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "skp",
+    "node_id": "skp-desires-067",
+    "score": 0.561272,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-473",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.548285,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "acc",
+    "node_id": "acc-intentions-073",
+    "score": 0.603837,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "acc",
+    "node_id": "acc-beliefs-099",
+    "score": 0.532667,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "acc",
+    "node_id": "acc-beliefs-077",
+    "score": 0.524805,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "saf",
+    "node_id": "saf-beliefs-244",
+    "score": 0.661125,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "saf",
+    "node_id": "saf-beliefs-205",
+    "score": 0.640369,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "saf",
+    "node_id": "saf-intentions-147",
+    "score": 0.638067,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "skp",
+    "node_id": "skp-intentions-040",
+    "score": 0.681318,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "skp",
+    "node_id": "skp-intentions-029",
+    "score": 0.663789,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-474",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.661931,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "acc",
+    "node_id": "acc-beliefs-083",
+    "score": 0.563605,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "acc",
+    "node_id": "acc-beliefs-116",
+    "score": 0.557165,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "acc",
+    "node_id": "acc-beliefs-117",
+    "score": 0.557165,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "saf",
+    "node_id": "saf-beliefs-267",
+    "score": 0.651915,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "saf",
+    "node_id": "saf-beliefs-266",
+    "score": 0.631493,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "saf",
+    "node_id": "saf-intentions-222",
+    "score": 0.583207,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "skp",
+    "node_id": "skp-beliefs-095",
+    "score": 0.590157,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "skp",
+    "node_id": "skp-beliefs-237",
+    "score": 0.588663,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-475",
+    "camp": "skp",
+    "node_id": "skp-beliefs-216",
+    "score": 0.569919,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "acc",
+    "node_id": "acc-intentions-078",
+    "score": 0.630301,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "acc",
+    "node_id": "acc-beliefs-028",
+    "score": 0.61226,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "acc",
+    "node_id": "acc-intentions-024",
+    "score": 0.607259,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "saf",
+    "node_id": "saf-desires-029",
+    "score": 0.687902,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "saf",
+    "node_id": "saf-intentions-213",
+    "score": 0.64871,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "saf",
+    "node_id": "saf-beliefs-150",
+    "score": 0.635099,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "skp",
+    "node_id": "skp-intentions-107",
+    "score": 0.658924,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "skp",
+    "node_id": "skp-intentions-146",
+    "score": 0.654828,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-476",
+    "camp": "skp",
+    "node_id": "skp-beliefs-156",
+    "score": 0.625912,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "acc",
+    "node_id": "acc-beliefs-085",
+    "score": 0.632143,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "acc",
+    "node_id": "acc-beliefs-043",
+    "score": 0.584917,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "acc",
+    "node_id": "acc-beliefs-066",
+    "score": 0.579306,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "saf",
+    "node_id": "saf-intentions-003",
+    "score": 0.660506,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "saf",
+    "node_id": "saf-beliefs-247",
+    "score": 0.654284,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "saf",
+    "node_id": "saf-beliefs-150",
+    "score": 0.652852,
+    "rank": 3
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "skp",
+    "node_id": "skp-beliefs-113",
+    "score": 0.653011,
+    "rank": 1
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "skp",
+    "node_id": "skp-beliefs-295",
+    "score": 0.651384,
+    "rank": 2
+  },
+  {
+    "situation_id": "sit-477",
+    "camp": "skp",
+    "node_id": "skp-desires-005",
+    "score": 0.644427,
+    "rank": 3
+  }
+]

--- a/research/comp-linguist/analyses/situation-evidence/propose_links.py
+++ b/research/comp-linguist/analyses/situation-evidence/propose_links.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+"""WS-B Stage 1 (t/3014): propose situation -> POV-node evidence links via embedding rank.
+
+Pure read. Emits a proposal JSON `[{situation_id, camp, node_id, score, rank}]` and
+writes NOTHING to the data repo (Stage 2 / PowerShell, t/3015, does the guarded write).
+
+Builds to the HLD (t/2979#12) and the CL semantics spec (t/2990 D1):
+  - per (situation, camp C in {acc,saf,skp}): query text = camp-C interpretation text
+    + label + description  (NOT the blended buildSituationText()).
+  - candidate pool = same-prefix nodes (acc-/saf-/skp-) from embeddings.json.
+  - rank by FULL cosine, top-3, no score threshold (PI Option 3); record cosine + rank.
+  - collision: skip any (situation, node) already authored in either direction
+    (situation.linked_nodes forward, node.situation_refs reverse) -- authored wins.
+  - scope: non-deprecated situations only ([DEPRECATED] description prefix exempt).
+
+Embedder reuse (coordinated with PowerShell, p/23): scripts/embed_taxonomy.py batch-encode
+(stdin [{id,text}] -> {id: vector}). PowerShell flagged that batch-encode returns
+L2-normalized vectors while embeddings.json node vectors are un-normalized, so we compute
+FULL cosine (normalize both sides) rather than a raw dot product.
+
+Deterministic: same inputs -> same proposal (sort by -score, then node_id).
+
+Usage:
+    python propose_links.py [--out proposal.json]
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+CAMPS = {"acc": "accelerationist", "saf": "safetyist", "skp": "skeptic"}
+TOP_N = 3
+
+
+def find_repo_root(start: Path) -> Path:
+    p = start.resolve()
+    while p != p.parent:
+        if (p / ".aitriad.json").exists():
+            return p
+        p = p.parent
+    raise SystemExit("repo root (.aitriad.json) not found")
+
+
+def resolve_taxonomy_dir(repo: Path) -> Path:
+    """Resolve taxonomy dir. Priority: AI_TRIAD_DATA_ROOT env > .aitriad.json > fallback.
+
+    The env override matters when running from a linked worktree: .aitriad.json's
+    relative data_root ("../ai-triad-data") resolves against the worktree location,
+    not the real sibling data repo, so the env var is the robust path here.
+    """
+    cfg = json.loads((repo / ".aitriad.json").read_text(encoding="utf-8"))
+    tax_dir = cfg.get("taxonomy_dir", "taxonomy/Origin")
+    env_root = os.environ.get("AI_TRIAD_DATA_ROOT")
+    if env_root:
+        base = Path(env_root)
+    else:
+        data_root = cfg.get("data_root", "../ai-triad-data")
+        base = Path(data_root) if Path(data_root).is_absolute() else (repo / data_root)
+    return (base / tax_dir).resolve()
+
+
+def camp_query_text(sit: dict, camp_full: str) -> str:
+    """Camp-C interpretation text + label + description (t/2990-D1).
+
+    Handles both the decomposed shape ({belief,desire,intention,...}) and the
+    legacy flat-string interpretation.
+    """
+    label = sit.get("label", "") or ""
+    desc = sit.get("description", "") or ""
+    interp = (sit.get("interpretations") or {}).get(camp_full)
+    if isinstance(interp, dict):
+        camp_text = " ".join(
+            v for v in (interp.get("belief"), interp.get("desire"), interp.get("intention")) if v
+        )
+    elif isinstance(interp, str):
+        camp_text = interp
+    else:
+        camp_text = ""
+    return f"{label}. {desc} {camp_text}".strip()
+
+
+def is_deprecated(sit: dict) -> bool:
+    return (sit.get("description", "") or "").lstrip().startswith("[DEPRECATED]")
+
+
+def batch_encode(repo: Path, items: list) -> dict:
+    """Call scripts/embed_taxonomy.py batch-encode; stdin [{id,text}] -> {id: vector}."""
+    script = repo / "scripts" / "embed_taxonomy.py"
+    proc = subprocess.run(
+        [sys.executable, str(script), "batch-encode"],
+        input=json.dumps(items),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+        raise SystemExit(f"batch-encode failed (rc={proc.returncode})")
+    return json.loads(proc.stdout)
+
+
+def l2_normalize(mat: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(mat, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    return mat / norms
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    here = Path(__file__).resolve().parent
+    ap.add_argument("--out", default=str(here / "proposal.json"))
+    args = ap.parse_args()
+
+    repo = find_repo_root(here)
+    tax = resolve_taxonomy_dir(repo)
+
+    situations = json.loads((tax / "situations.json").read_text(encoding="utf-8"))["nodes"]
+    emb = json.loads((tax / "embeddings.json").read_text(encoding="utf-8"))["nodes"]
+
+    # Candidate node matrices per camp prefix (un-normalized -> we cosine-normalize).
+    node_ids = {c: [] for c in CAMPS}
+    node_vecs = {c: [] for c in CAMPS}
+    for nid, rec in emb.items():
+        pref = nid.split("-", 1)[0]
+        if pref in CAMPS:
+            node_ids[pref].append(nid)
+            node_vecs[pref].append(rec["vector"])
+    node_mat = {c: l2_normalize(np.asarray(node_vecs[c], dtype=np.float64)) for c in CAMPS}
+    node_order = {c: node_ids[c] for c in CAMPS}
+
+    # Authored exclusion set (situation_id, node_id): forward linked_nodes + reverse situation_refs.
+    authored = set()
+    for s in situations:
+        sid = s.get("id")
+        for nid in (s.get("linked_nodes") or []):
+            authored.add((sid, nid))
+    for fname in ("accelerationist.json", "safetyist.json", "skeptic.json"):
+        for n in json.loads((tax / fname).read_text(encoding="utf-8"))["nodes"]:
+            nid = n.get("id")
+            for sref in (n.get("situation_refs") or []):
+                authored.add((sref, nid))
+
+    # Build query set (non-deprecated situations x 3 camps).
+    active = [s for s in situations if s.get("id") and not is_deprecated(s)]
+    query_items = []
+    for s in active:
+        for camp, camp_full in CAMPS.items():
+            query_items.append({"id": f"{s['id']}|{camp}", "text": camp_query_text(s, camp_full)})
+
+    sys.stderr.write(
+        f"[stage1] {len(active)} non-deprecated situations x {len(CAMPS)} camps "
+        f"= {len(query_items)} queries; {sum(len(node_order[c]) for c in CAMPS)} candidate nodes; "
+        f"{len(authored)} authored links excluded.\n"
+    )
+
+    qvecs = batch_encode(repo, query_items)  # {id: vector}
+
+    proposal = []
+    for s in active:
+        sid = s["id"]
+        for camp in CAMPS:
+            qv = np.asarray(qvecs[f"{sid}|{camp}"], dtype=np.float64)
+            n = np.linalg.norm(qv)
+            if n == 0:
+                continue
+            qv = qv / n
+            sims = node_mat[camp] @ qv  # full cosine (both sides L2-normalized)
+            order = sorted(range(len(sims)), key=lambda i: (-sims[i], node_order[camp][i]))
+            picked = 0
+            for i in order:
+                nid = node_order[camp][i]
+                if (sid, nid) in authored:
+                    continue
+                picked += 1
+                proposal.append(
+                    {
+                        "situation_id": sid,
+                        "camp": camp,
+                        "node_id": nid,
+                        "score": round(float(sims[i]), 6),
+                        "rank": picked,
+                    }
+                )
+                if picked >= TOP_N:
+                    break
+
+    proposal.sort(key=lambda r: (r["situation_id"], r["camp"], r["rank"]))
+    Path(args.out).write_text(json.dumps(proposal, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    scores = [r["score"] for r in proposal]
+    sys.stderr.write(
+        f"[stage1] wrote {len(proposal)} proposed links to {args.out} "
+        f"(score min {min(scores):.3f} / mean {sum(scores)/len(scores):.3f} / max {max(scores):.3f}).\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
WS-B Stage 1 of t/2979 (HLD t/2979#12, spec t/2990-D1). **Pure read; no data write** — emits the proposal JSON Stage 2 (t/3015, PowerShell) consumes.

**`propose_links.py`** (`research/comp-linguist/analyses/situation-evidence/`): per (situation, camp) embeds the camp-C interpretation text + label + description via `scripts/embed_taxonomy.py batch-encode` (read-only reuse, coordinated w/ PowerShell p/23), **full cosine** vs same-prefix nodes from `embeddings.json`, top-3, records `score`+`rank`, skips authored links (both directions). No score threshold (PI Option 3).

**Run:** 442 non-deprecated situations × 3 camps = 1,326 queries · 899 candidates · 55 authored excluded → **3,978 proposals** (score min 0.292 / mean 0.600 / max 0.879). `proposal.json` committed as the Stage-2 contract artifact + the set CL reproduces for precision@3 (t/2294).

**AC coverage:** top-3/camp on camp-C text ✓ · score+rank ✓ · authored excluded ✓ · well-formed contract ✓ · deterministic (sort -score,node_id) ✓ · reuses MiniLM (no new model) ✓.

**Note for Stage 2:** `proposal.json` is a snapshot of current live data (55 authored exclusions). If WS-A reciprocity adds authored links before the write, re-run (deterministic) or re-check collisions at write time. Design at t/3014#2.