### PR TITLE
feat(integrity): promote Check 10 SituationReciprocity Warning→Error (t/2979)

### DIFF
--- a/scripts/AITriad/Public/Test-TaxonomyIntegrity.ps1
+++ b/scripts/AITriad/Public/Test-TaxonomyIntegrity.ps1
@@ -324,15 +324,17 @@ function Test-TaxonomyIntegrity {
         $Issues.Add([PSCustomObject]@{ Check = 'DanglingLinked'; Severity = 'Warning'; Count = $DanglingLinked.Count; Detail = "linked_nodes ref non-existent nodes: $Detail" })
     } else { $Passed++ }
 
-    # ── Check 10: Situation <-> POV-node reciprocity (t/2979, WARN-first) ──
+    # ── Check 10: Situation <-> POV-node reciprocity (t/2979) ──
     # linked_nodes (situation -> POV node) and situation_refs (POV node -> situation) must be
     # MUTUAL: N in S.linked_nodes  <=>  S in N.situation_refs. The two directions were free to
     # diverge — creation sites init both empty, and this cmdlet only PRUNES dangling refs (Checks
     # 8/9), it never reciprocates — so evidence authored on one side is invisible on the other.
-    # That silent drift is the t/2979 root cause. WARN-first / observability only: ~7 reverse-only
-    # situations diverge today, so a hard Error would false-block; report BOTH asymmetry classes so
-    # the drift is visible and cannot grow. Only links whose BOTH endpoints exist are evaluated — a
-    # ref to a non-existent node/situation is a dangling-ref issue (Checks 8/9), not an asymmetry.
+    # That silent drift is the t/2979 root cause. PROMOTED Warning -> Error (t/2979): the WS-A
+    # reciprocity backfill is pushed and the live corpus is confirmed fully mutual
+    # (Repair-SituationReciprocity -DryRun = 0/0), so the false-block risk that kept this warn-first
+    # is gone; any NEW drift is now a hard failure. Report BOTH asymmetry classes. Only links whose
+    # BOTH endpoints exist are evaluated — a ref to a non-existent node/situation is a dangling-ref
+    # issue (Checks 8/9), not an asymmetry.
     $Checks++
     $SitLinked = @{}    # situation id -> HashSet of its linked node ids
     if ($LoadedFiles.ContainsKey('situations')) {
@@ -377,7 +379,7 @@ function Test-TaxonomyIntegrity {
     if ($AsymCount -gt 0) {
         $FwdPart = if ($ForwardOnly.Count -gt 0) { " forward-only (in linked_nodes, missing situation_refs back-ref) [$($ForwardOnly.Count)]: $((@($ForwardOnly) | Select-Object -First 5) -join '; ')$(if ($ForwardOnly.Count -gt 5) { ' ...' })" } else { '' }
         $RevPart = if ($ReverseOnly.Count -gt 0) { " reverse-only (in situation_refs, missing linked_nodes back-ref) [$($ReverseOnly.Count)]: $((@($ReverseOnly) | Select-Object -First 5) -join '; ')$(if ($ReverseOnly.Count -gt 5) { ' ...' })" } else { '' }
-        $Issues.Add([PSCustomObject]@{ Check = 'SituationReciprocity'; Severity = 'Warning'; Count = $AsymCount; Detail = "situation.linked_nodes and POV situation_refs are not mutual (t/2979) —$FwdPart$RevPart. WARN-first: a reciprocity backfill / UI-union recovers these; the two directions must not silently drift." })
+        $Issues.Add([PSCustomObject]@{ Check = 'SituationReciprocity'; Severity = 'Error'; Count = $AsymCount; Detail = "situation.linked_nodes and POV situation_refs are not mutual (t/2979) —$FwdPart$RevPart. Fix: run Repair-SituationReciprocity -DryRun to preview, then Repair-SituationReciprocity to reconcile both directions. The two directions must stay mutual." })
     } else { $Passed++ }
 
     # ── BDI weight range validation ──

--- a/tests/SituationReciprocity.Tests.ps1
+++ b/tests/SituationReciprocity.Tests.ps1
@@ -35,9 +35,9 @@ BeforeAll {
     function New-PovNode  { param($Id, $Refs = @())   [ordered]@{ id = $Id; category = 'Beliefs'; label = $Id; situation_refs = @($Refs) } }
 }
 
-Describe 'Test-TaxonomyIntegrity — situation reciprocity guard (t/2979, warn-first)' -Tag 'taxonomy' {
+Describe 'Test-TaxonomyIntegrity — situation reciprocity guard (t/2979, Error-tier)' -Tag 'taxonomy' {
 
-    It 'FIRE: reports BOTH asymmetry classes (forward-only + reverse-only) as a Warning' {
+    It 'FIRE: reports BOTH asymmetry classes (forward-only + reverse-only) as an Error' {
         $root = New-ReciprocityFixture `
             -Sits @( (New-SitNode 'sit-001' @('acc-b-1')), (New-SitNode 'sit-002' @()) ) `
             -Acc  @( (New-PovNode 'acc-b-1' @()) ) `
@@ -49,7 +49,7 @@ Describe 'Test-TaxonomyIntegrity — situation reciprocity guard (t/2979, warn-f
                 $r = Test-TaxonomyIntegrity -PassThru 6>$null
                 $recip = @($r.Details | Where-Object { $_.Check -eq 'SituationReciprocity' })
                 @($recip).Count | Should -Be 1
-                $recip[0].Severity | Should -Be 'Warning'
+                $recip[0].Severity | Should -Be 'Error'
                 $recip[0].Count    | Should -Be 2   # 1 forward-only + 1 reverse-only
                 $recip[0].Detail   | Should -Match 'forward-only'
                 $recip[0].Detail   | Should -Match 'reverse-only'


### PR DESCRIPTION
## Promote Check 10 `SituationReciprocity` Warning → Error (t/2979)

Authorized at p/498#2 (WS-A push confirmed clean). **Draft, gated on your both-arms GV** — un-draft + self-merge only on your approval.

### Change
- `Test-TaxonomyIntegrity` Check 10: `Severity` **Warning → Error**; Detail reworded to point at `Repair-SituationReciprocity` (dropped the warn-first framing). Comment header records *why* it's now safe to block: the WS-A reciprocity backfill is pushed and the live corpus is confirmed fully mutual (`Repair-SituationReciprocity -DryRun` = 0 forward / 0 reverse), so the false-block risk that kept it warn-first is gone.

### Both-arms (tests/SituationReciprocity.Tests.ps1 — 9/9 green locally)
- **FIRE:** a drifted fixture (1 forward-only + 1 reverse-only) now surfaces the `SituationReciprocity` issue at **`Severity = Error`**.
- **CLEAN:** a fully-reciprocal fixture produces **no** `SituationReciprocity` issue (zero noise).
- A dangling ref remains Check 8, not an asymmetry (unchanged).

### Scope note
`Test-TaxonomyIntegrity` is an **on-demand cmdlet, not wired into any CI job** (grep of `.github/` = no reference). So this is a **severity-tier promotion** (the `Error` reporting tier consumers treat as must-fix), **not a new merge gate**. Live corpus verified 0/0 so the promotion doesn't retro-fire on current `main`.

Followed the pattern-playbook conventions; single-scope PS change. Routed to you for the both-arms eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
