### PR TITLE
fix(sync): harden SaveBar with flex-shrink:0 (t/3017)

### DIFF
--- a/taxonomy-editor/src/renderer/components/sync/SaveBar.css
+++ b/taxonomy-editor/src/renderer/components/sync/SaveBar.css
@@ -11,6 +11,10 @@
   border-top: 1px solid var(--border-color);
   min-height: 44px;
   position: relative;
+  /* Fixed bottom bar: never shrink/scroll away. SaveBar is a flex child of `.app`
+     below the `overflow:hidden` `.app-body` scroll region, so it stays pinned; this
+     guards against compression on very short viewports (e.g. landscape phone). t/3017 */
+  flex-shrink: 0;
 }
 
 .save-bar-status {


### PR DESCRIPTION
## Summary
Adds `flex-shrink: 0` to `.save-bar` so the bottom save/status bar can never be compressed or scroll away.

## Context (t/3017)
Ticket reported the save bar "scrolls with content instead of staying fixed." Investigation shows the bar is **already** architecturally outside the scroll region — it renders as a flex child of `.app`, below the `overflow:hidden` `.app-body` scroll container.

Verified at runtime via CDP (electron :9223): injected a `.save-bar` at its exact real DOM position and scrolled each tab's tallest scroller to the end. The bar stayed pinned at the viewport bottom (moved 0px) with no page-level scroll — on Taxonomy, Settings, Op-Ed Studies, Debate, Chat, and at mobile 390×700. **The reported behavior does not reproduce.**

This change closes the one real gap found: on a very short viewport (e.g. landscape phone with the data-update banner open), the bar could otherwise be compressed below its `min-height`.

## Scope
CSS-only, single file (`SaveBar.css`, Sync scope). No logic/behavior change.