### PR TITLE
fix(compliance): reject null-sentinel B/D/I in situation decomposition (t/3018)

### DIFF
--- a/scripts/AITriad/Private/Test-SituationBdiDecomposition.ps1
+++ b/scripts/AITriad/Private/Test-SituationBdiDecomposition.ps1
@@ -44,6 +44,15 @@ function Test-SituationBdiDecomposition {
         $pass = 0; $empty = 0; $nonDecomposed = 0; $nonDep = 0; $deprecated = 0
         $nonDecomposedIds = [System.Collections.Generic.List[string]]::new()
         $emptyIds         = [System.Collections.Generic.List[string]]::new()
+
+        # Null-sentinel placeholders (t/3018, CL-owned predicate): a B/D/I field
+        # whose whole value is one of these is non-empty but carries no real
+        # interpretation, so it must fail decomposition like a blank field.
+        # Case-insensitive, whole-value match only (a sentence containing 'none'
+        # is not a sentinel).
+        $nullSentinels = [System.Collections.Generic.HashSet[string]]::new(
+            [string[]]@('null', 'none', 'n/a', 'tbd', '-'),
+            [System.StringComparer]::OrdinalIgnoreCase)
     }
 
     process {
@@ -86,10 +95,14 @@ function Test-SituationBdiDecomposition {
                 if (-not $p -or -not $p.PSObject.Properties['belief'] -or -not $p.PSObject.Properties['desire'] -or -not $p.PSObject.Properties['intention']) {
                     $allOk = $false; break
                 }
-                $b = if ($p.belief)    { [string]$p.belief    } else { '' }
-                $d = if ($p.desire)    { [string]$p.desire    } else { '' }
-                $i = if ($p.intention) { [string]$p.intention } else { '' }
-                if (-not $b.Trim() -or -not $d.Trim() -or -not $i.Trim()) { $allOk = $false; break }
+                $b = if ($p.belief)    { ([string]$p.belief).Trim()    } else { '' }
+                $d = if ($p.desire)    { ([string]$p.desire).Trim()    } else { '' }
+                $i = if ($p.intention) { ([string]$p.intention).Trim() } else { '' }
+                # Fail on empty-after-Trim OR a null-sentinel whole-value (t/3018).
+                if (-not $b -or -not $d -or -not $i -or
+                    $nullSentinels.Contains($b) -or $nullSentinels.Contains($d) -or $nullSentinels.Contains($i)) {
+                    $allOk = $false; break
+                }
             }
             if ($allOk) {
                 $pass++

--- a/tests/Test-OntologyCompliance.SituationBDI.Tests.ps1
+++ b/tests/Test-OntologyCompliance.SituationBDI.Tests.ps1
@@ -157,6 +157,87 @@ Describe 'Situation BDI-decomposition classification logic (fixture-based, t/233
     }
 }
 
+Describe 'Situation BDI-decomposition null-sentinel rejection (t/3018)' -Tag 'taxonomy' {
+    # Hardening arm (t/3018): a B/D/I field whose whole value is a null-sentinel
+    # ("null"/"none"/"n/a"/"tbd"/"-", case-insensitive) is non-empty but carries no
+    # interpretation, so it must fail decomposition like a blank field. Isolated
+    # fixture so the count assertions above stay stable. Both arms + a substring
+    # false-positive guard.
+
+    BeforeAll {
+        $script:SentinelJson = @'
+{
+  "nodes": [
+    {
+      "id": "sit-sentinel-clean",
+      "description": "A situation fully decomposed with real interpretations.",
+      "interpretations": {
+        "accelerationist": { "belief": "real belief", "desire": "real desire", "intention": "real intention" },
+        "safetyist":       { "belief": "real belief", "desire": "real desire", "intention": "real intention" },
+        "skeptic":         { "belief": "real belief", "desire": "real desire", "intention": "real intention" }
+      }
+    },
+    {
+      "id": "sit-sentinel-allnull",
+      "description": "A situation whose fields are the literal null-sentinel strings.",
+      "interpretations": {
+        "accelerationist": { "belief": "null", "desire": "null", "intention": "null" },
+        "safetyist":       { "belief": "None", "desire": "N/A", "intention": "tbd" },
+        "skeptic":         { "belief": "-",    "desire": "null", "intention": "none" }
+      }
+    },
+    {
+      "id": "sit-sentinel-onefield",
+      "description": "A situation with one sentinel field in an otherwise real block.",
+      "interpretations": {
+        "accelerationist": { "belief": "real belief", "desire": "TBD", "intention": "real intention" },
+        "safetyist":       { "belief": "real belief", "desire": "real desire", "intention": "real intention" },
+        "skeptic":         { "belief": "real belief", "desire": "real desire", "intention": "real intention" }
+      }
+    },
+    {
+      "id": "sit-sentinel-substring",
+      "description": "A situation whose real prose merely contains sentinel words as substrings.",
+      "interpretations": {
+        "accelerationist": { "belief": "None of the current models are safe.", "desire": "Leave no ambiguity in policy.", "intention": "Treat n/a-status vendors with caution." },
+        "safetyist":       { "belief": "real belief", "desire": "real desire", "intention": "real intention" },
+        "skeptic":         { "belief": "real belief", "desire": "real desire", "intention": "real intention" }
+      }
+    }
+  ]
+}
+'@
+        $script:SentinelFixture = $script:SentinelJson | ConvertFrom-Json
+        $script:SentinelResult = InModuleScope AITriad -Parameters @{ Nodes = $script:SentinelFixture.nodes } {
+            param($Nodes)
+            Test-SituationBdiDecomposition -Node $Nodes
+        }
+    }
+
+    It 'Passes the clean situation (clean arm)' {
+        $script:SentinelResult.NonDecomposedIds | Should -Not -Contain 'sit-sentinel-clean'
+    }
+
+    It 'Flags an all-sentinel situation as non-decomposed (failure arm)' {
+        $script:SentinelResult.NonDecomposedIds | Should -Contain 'sit-sentinel-allnull'
+    }
+
+    It 'Flags a situation with a single sentinel field as non-decomposed' {
+        $script:SentinelResult.NonDecomposedIds | Should -Contain 'sit-sentinel-onefield'
+    }
+
+    It 'Does NOT flag prose that merely contains sentinel words as substrings (whole-value match only)' {
+        $script:SentinelResult.NonDecomposedIds | Should -Not -Contain 'sit-sentinel-substring'
+    }
+
+    It 'Counts exactly the two sentinel-bearing situations as non-decomposed' {
+        # 4 nodes: clean + substring pass; allnull + onefield fail. None are empty/deprecated.
+        $script:SentinelResult.NonDecomposed | Should -Be 2
+        $script:SentinelResult.Pass | Should -Be 2
+        $script:SentinelResult.Empty | Should -Be 0
+    }
+}
+
 Describe 'Ingestion no-op confirmation (t/1312 Part 2)' -Tag 'taxonomy' {
 
     It 'No PowerShell public cmdlet writes new situation nodes (grep sanity)' {


### PR DESCRIPTION
## What

Hardens `Test-SituationBdiDecomposition` (the Private predicate behind the `Test-OntologyCompliance` situation-BDI gate and the live compliance baseline) to reject **null-sentinel** belief/desire/intention values.

A field whose whole value is `null` / `none` / `n/a` / `tbd` / `-` (case-insensitive, after `Trim`) is non-empty but carries no interpretation — it now fails decomposition like a blank field. Previously the literal string `"null"` passed the non-empty check, so degenerate interpretations scored as decomposed.

## Why

WS-B precision audit (t/2990#5) surfaced sit-050 as `"null null null"`. A full scan found 6 situations with this shape; 5 were baseline-relevant (sit-030/050/080/081 all camps, sit-082 skeptic). t/3018.

## Sequencing (content-first, no baseline regression)

1. ✅ CL authored 13 replacement interpretations (t/3018#1).
2. ✅ Content landed on `ai-triad-data` main — commit `0804b5f9`.
3. ✅ **This PR** hardens the predicate.
4. ✅ CL re-verified (t/3018#2): origin post-write passes **442/442 under both the current and hardened predicates** — the hardened check flips nothing, no baseline regression. Predicate definition approved.

## Tests

New isolated `Describe` in `Test-OntologyCompliance.SituationBDI.Tests.ps1`:
- **Failure arm** — all-sentinel + single-sentinel-field situations flagged non-decomposed.
- **Clean arm** — real interpretations still pass.
- **Substring guard** — prose containing "none"/"n/a" as substrings (whole-value match only) is not flagged.

Local: 17/17 in the SituationBDI suite green.

## Gate

Draft until CL's final code sign-off (confirm predicate implementation at lines 89–92 + the actual check outputs 442/442) and CI green.

t/3018

Co-authored-by CL (Computational Linguist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
