### PR TITLE
obs(persistence): surface lock_holder in ActionableError on EPERM exhaustion (t/3019)

### DIFF
--- a/lib/debate/__tests__/persistenceRetryBudget.test.ts
+++ b/lib/debate/__tests__/persistenceRetryBudget.test.ts
@@ -13,6 +13,7 @@ import { setGlobalRecorder, clearGlobalRecorder, type FlightRecorder } from '../
 import type { RecordInput } from '../../flight-recorder/types.js';
 
 import { atomicWriteSync, renameSyncWithRetry } from '../persistence.js';
+import { ActionableError } from '../errors.js';
 
 // ── Hermetic isolation ────────────────────────────────────
 beforeAll(() => {
@@ -213,5 +214,72 @@ describe('renameSyncWithRetry — onLockExhausted callback (t/2544)', () => {
     // Callback fired at least once (primary rename + .tmp2 fallback may both exhaust)
     expect(onLockExhausted).toHaveBeenCalled();
     cleanup(target);
+  });
+
+  // t/3019: lock-holder interpolation in ActionableError message
+  describe('atomicWriteSync ActionableError interpolates lock_holder (t/3019)', () => {
+    function setupEpermRenames() {
+      vi.spyOn(Atomics, 'wait').mockReturnValue('ok');
+      vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+        throw makeStorageError('EPERM', 'operation not permitted');
+      });
+    }
+
+    afterEach(() => { vi.restoreAllMocks(); });
+
+    it('names the lock holder process in problem when callback returns a description', () => {
+      setupEpermRenames();
+      const target = tmpPath('lock-holder-named.json');
+      const onLockExhausted = vi.fn().mockReturnValue('MsMpEng.exe (pid 1234)');
+
+      let ae: unknown;
+      try { atomicWriteSync(target, '{"x":1}', onLockExhausted); } catch (e) { ae = e; }
+
+      expect(ae).toBeInstanceOf(ActionableError);
+      expect((ae as ActionableError).problem).toContain('MsMpEng.exe (pid 1234)');
+      expect((ae as ActionableError).nextSteps.join(' ')).toContain('antivirus');
+      cleanup(target);
+    });
+
+    it('emits self-lock guidance when lock holder is electron.exe', () => {
+      setupEpermRenames();
+      const target = tmpPath('self-lock.json');
+      const onLockExhausted = vi.fn().mockReturnValue('electron.exe (pid 52308)');
+
+      let ae: unknown;
+      try { atomicWriteSync(target, '{"x":1}', onLockExhausted); } catch (e) { ae = e; }
+
+      expect(ae).toBeInstanceOf(ActionableError);
+      expect((ae as ActionableError).problem).toContain('electron.exe (pid 52308)');
+      const steps = (ae as ActionableError).nextSteps.join(' ');
+      expect(steps).toContain('Electron process itself');
+      expect(steps).not.toContain('antivirus');
+      cleanup(target);
+    });
+
+    it('falls back to "unidentified process" when callback returns undefined', () => {
+      setupEpermRenames();
+      const target = tmpPath('lock-holder-unavailable.json');
+      const onLockExhausted = vi.fn().mockReturnValue(undefined);
+
+      let ae: unknown;
+      try { atomicWriteSync(target, '{"x":1}', onLockExhausted); } catch (e) { ae = e; }
+
+      expect(ae).toBeInstanceOf(ActionableError);
+      expect((ae as ActionableError).problem).toContain('unidentified process');
+      cleanup(target);
+    });
+
+    it('falls back to "unidentified process" when no callback is provided', () => {
+      setupEpermRenames();
+      const target = tmpPath('lock-holder-no-callback.json');
+
+      let ae: unknown;
+      try { atomicWriteSync(target, '{"x":1}'); } catch (e) { ae = e; }
+
+      expect(ae).toBeInstanceOf(ActionableError);
+      expect((ae as ActionableError).problem).toContain('unidentified process');
+      cleanup(target);
+    });
   });
 });

--- a/lib/debate/lockHolder.ts
+++ b/lib/debate/lockHolder.ts
@@ -31,16 +31,20 @@ function queryLockHolder(filePath: string): LockHolderInfo {
 }
 
 /**
- * Query the lock holder for filePath and emit an io.lock-holder FR event.
+ * Query the lock holder for filePath, emit an io.lock-holder FR event, and
+ * return a human-readable description (e.g. "electron.exe (pid 52308)") or
+ * undefined when detection is unavailable. The return value is consumed by
+ * atomicWriteSync to build a lock-holder-specific ActionableError message.
  * Pass as the onLockExhausted callback to atomicWriteSync / renameSyncWithRetry.
  */
-export function recordLockHolder(filePath: string): void {
-  const lockHolder = queryLockHolder(filePath);
+export function recordLockHolder(filePath: string): string | undefined {
+  const info = queryLockHolder(filePath);
   getGlobalRecorder()?.record({
     type: 'io.lock-holder', component: 'persistence', level: 'warn',
-    message: lockHolder.unavailable
-      ? `io.lock-holder: unavailable (${lockHolder.reason})`
-      : `io.lock-holder: ${lockHolder.processName} pid ${lockHolder.pid}`,
-    data: { filePath, ...lockHolder },
+    message: info.unavailable
+      ? `io.lock-holder: unavailable (${info.reason})`
+      : `io.lock-holder: ${info.processName} pid ${info.pid}`,
+    data: { filePath, ...info },
   });
+  return info.unavailable ? undefined : `${info.processName} (pid ${info.pid})`;
 }

--- a/lib/debate/persistence.ts
+++ b/lib/debate/persistence.ts
@@ -129,7 +129,7 @@ export async function renameWithRetry(oldPath: string, newPath: string, maxRetri
 export function atomicWriteSync(
   filePath: string,
   content: string,
-  onLockExhausted?: (filePath: string) => void,
+  onLockExhausted?: (filePath: string) => string | undefined,
 ): void {
   // codeql[js/insecure-temporary-file] FP: same-directory atomic write via rename, not an os.tmpdir() temp file
   const tmpPath = `${filePath}.tmp`;
@@ -137,8 +137,15 @@ export function atomicWriteSync(
   // t/2546: scale retry budget with payload size — AV scan time grows with file size.
   const bytes = Buffer.byteLength(content, 'utf-8');
   const wallClockCapMs = bytes > 200 * 1024 ? 30_000 : undefined;
+  // Capture the lock-holder description returned by the callback (t/3019).
+  // ??= keeps the first capture — both rename attempts target the same file,
+  // so the second call would return the same process anyway.
+  let lockHolderDesc: string | undefined;
+  const wrappedOnLockExhausted: ((p: string) => void) | undefined = onLockExhausted
+    ? (p: string) => { lockHolderDesc ??= onLockExhausted(p); }
+    : undefined;
   try {
-    renameSyncWithRetry(tmpPath, filePath, 7, wallClockCapMs, onLockExhausted);
+    renameSyncWithRetry(tmpPath, filePath, 7, wallClockCapMs, wrappedOnLockExhausted);
     return;
   } catch (renameErr) {
     const renameCode = (renameErr as NodeJS.ErrnoException).code;
@@ -165,7 +172,7 @@ export function atomicWriteSync(
     try {
       fs.writeFileSync(tmp2Path, content, 'utf-8');
       // writeFileSync closes the handle on return, flushing OS write buffers.
-      renameSyncWithRetry(tmp2Path, filePath, 7, wallClockCapMs, onLockExhausted);
+      renameSyncWithRetry(tmp2Path, filePath, 7, wallClockCapMs, wrappedOnLockExhausted);
       // .tmp2 rename succeeded — clean up the original .tmp (best-effort)
       try { fs.unlinkSync(tmpPath); } catch { /* best-effort */ }
       getGlobalRecorder()?.record({
@@ -197,14 +204,18 @@ export function atomicWriteSync(
           stack: (tmp2Err as Error).stack,
         },
       });
+      const lockerText = lockHolderDesc ?? 'an unidentified process (lock holder detection unavailable)';
+      const isSelfLock = /^electron/i.test(lockHolderDesc ?? '');
       throw new ActionableError({
         goal: `Persist ${bytes} bytes to ${filePath}`,
-        problem: `Atomic rename and .tmp2 rename fallback were both denied (rename ${firstRenameCode}, fallback ${tmp2Code}) — the target is held by another process (Windows antivirus/indexer) longer than the retry budget allows.`,
+        problem: `Atomic rename and .tmp2 rename fallback were both denied (rename ${firstRenameCode}, fallback ${tmp2Code}) — the target is held by ${lockerText} longer than the retry budget allows.`,
         location: 'lib/debate/persistence.ts atomicWriteSync',
         nextSteps: [
           `The new content is preserved at ${tmpPath} and was NOT deleted — it is the only durable copy of this write. Do not remove it.`,
           `Retry the save once the lock clears: a subsequent successful atomicWriteSync replaces ${filePath}, after which ${tmpPath} may be removed.`,
-          `If saves keep failing, exclude the debates directory from antivirus/search-indexer scanning.`,
+          ...(isSelfLock
+            ? [`The locker is the Electron process itself (${lockerText}) — check for overlapping write operations or an unclosed read handle in the same process.`]
+            : [`If saves keep failing, exclude the debates directory from antivirus/search-indexer scanning.`]),
         ],
         innerError: tmp2Err,
       });


### PR DESCRIPTION
## Summary

- `lockHolder.ts`: `recordLockHolder` now returns `string | undefined` — the human-readable process description (e.g. `"electron.exe (pid 52308)"`) — while still recording the `io.lock-holder` FR event unchanged.
- `persistence.ts`: `atomicWriteSync` wraps `onLockExhausted` in a closure that captures the returned description. The `ActionableError` built on budget exhaustion now interpolates the actual locker into `problem` and selects context-appropriate `nextSteps`: self-lock guidance when the process is `electron.exe`, AV exclusion otherwise, "unidentified process" fallback when detection is unavailable.
- `persistenceRetryBudget.test.ts`: 4 new tests cover all three branches (named external process, electron self-lock, unavailable, no callback).

## Test plan

- [ ] `npx vitest run __tests__/persistenceRetryBudget.test.ts` — 15/15 pass (11 existing + 4 new)
- [ ] `npx vitest run` — 3046/3057 pass, 0 fail
- [ ] `npx tsc -p tsconfig.json --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0131WQtXY2tWQE4HmSVxpwk6