### PR TITLE
fix(ai-client): map Claude 400 quota-exhaustion to correct Resolve steps (t/3020)

### DIFF
--- a/lib/ai-client/providers/claude.test.ts
+++ b/lib/ai-client/providers/claude.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3020 — a Claude monthly-quota-exhaustion error arrives as HTTP 400 `invalid_request_error`
+// (not an auth/model fault). Before the fix it fell into the generic error whose "Check your API
+// key / Verify the model ID" Resolve steps misattributed the cause (t/2985 pattern class). These
+// lock the quota-specific mapping: the reset date is surfaced and the steps say wait / upgrade /
+// switch backend — and the branch stays narrow (a non-quota 400 keeps the generic steps).
+
+import { describe, it, expect } from 'vitest';
+import { generateViaClaude } from './claude.js';
+import { ActionableError } from '../../debate/errors.js';
+import type { FetchFn } from '../types.js';
+
+function makeFetch(bodyText: string, status: number): FetchFn {
+  return async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => bodyText,
+    body: null,
+  } as unknown as Response);
+}
+
+// The exact body Diagnostics captured on debate 3a02e301 (t/3020 incident).
+const QUOTA_BODY = JSON.stringify({
+  type: 'invalid_request_error',
+  message: 'You have reached your specified API usage limits. You will regain access on 2026-09-01 at 00:00 UTC.',
+});
+
+async function callFor(bodyText: string, status: number): Promise<ActionableError> {
+  return generateViaClaude(makeFetch(bodyText, status), 'p', 'claude-x', 'key', { timeoutMs: 5000 })
+    .then(() => { throw new Error('expected generateViaClaude to throw'); })
+    .catch((e: unknown) => e as ActionableError);
+}
+
+describe('generateViaClaude — quota-exhaustion error mapping (t/3020)', () => {
+  it('maps a 400 invalid_request_error usage-limit body to quota-specific Resolve steps, naming the reset date', async () => {
+    const err = await callFor(QUOTA_BODY, 400);
+    expect(err).toBeInstanceOf(ActionableError);
+    expect(err.problem).toContain('Monthly API usage limit reached');
+    expect(err.problem).toContain('2026-09-01 at 00:00 UTC'); // reset date extracted from the message
+    const steps = err.nextSteps.join(' ');
+    expect(steps).toContain('2026-09-01 at 00:00 UTC');       // "wait until <date>" names the date
+    expect(steps).toContain('console.anthropic.com');         // upgrade path
+    expect(steps.toLowerCase()).toContain('gemini');          // switch backend
+    expect(steps).not.toContain('Check your API key');        // NOT the misleading generic step
+  });
+
+  it('keeps the generic Resolve steps for a non-quota 400 (branch is narrow)', async () => {
+    const err = await callFor(JSON.stringify({ type: 'invalid_request_error', message: 'unknown model xyz' }), 400);
+    expect(err).toBeInstanceOf(ActionableError);
+    expect(err.nextSteps).toContain('Check your API key');
+    expect(err.problem).not.toContain('Monthly API usage limit');
+  });
+
+  it('falls back to a generic date phrase when the usage-limit body has no parseable reset date', async () => {
+    const err = await callFor(JSON.stringify({ type: 'invalid_request_error', message: 'You have reached your specified API usage limits.' }), 400);
+    expect(err.problem).toContain('Monthly API usage limit reached');
+    expect(err.problem).toContain('the date shown in the error message');
+  });
+});

--- a/lib/ai-client/providers/claude.ts
+++ b/lib/ai-client/providers/claude.ts
@@ -81,6 +81,25 @@ export async function generateViaClaude(
     }
     return parseClaudeResponse(retryBodyText);
   }
+  // t/3020: Claude returns HTTP 400 `invalid_request_error` for MONTHLY QUOTA EXHAUSTION (not an
+  // auth/model problem) — e.g. "You have reached your specified API usage limits. You will regain
+  // access on 2026-09-01 at 00:00 UTC." Without this branch it falls into the generic error below,
+  // whose "Check your API key / Verify the model ID" steps misattribute the cause (t/2985 pattern
+  // class). Derive the Resolve steps from the actual condition: wait for reset / upgrade / switch.
+  if (response.status === 400 && bodyText.includes('invalid_request_error') && /usage limits|regain access/i.test(bodyText)) {
+    const resetMatch = bodyText.match(/regain access on ([^"]+)/i);
+    const resetDate = resetMatch ? resetMatch[1].trim().replace(/\.$/, '') : 'the date shown in the error message';
+    throw new ActionableError({
+      goal: 'Generate text via Claude',
+      problem: `Monthly API usage limit reached — access resets on ${resetDate}`,
+      location: 'ai-client.generateViaClaude',
+      nextSteps: [
+        `Wait until ${resetDate} for the quota to reset automatically`,
+        'Upgrade the plan at console.anthropic.com',
+        'Switch to a different backend (Gemini or Groq) in Settings → AI Model',
+      ],
+    });
+  }
   if (!response.ok) {
     throw new ActionableError({
       goal: 'Generate text via Claude',


### PR DESCRIPTION
Fixes t/3020 — Claude monthly-quota-exhaustion (HTTP 400 `invalid_request_error`) showed misleading "Check your API key" Resolve steps. Instance 3 of the ActionableError-misattributes-cause pattern (t/2985 class; Diagnostics t/3020#1).

## Fix (claude.ts, +19)
Before the generic `!response.ok` branch, detect a 400 whose body is `invalid_request_error` and contains "usage limits"/"regain access", extract the reset date from the message, and emit a quota-specific ActionableError:
- **Problem:** `Monthly API usage limit reached — access resets on <date>`
- **Resolve:** wait until \<date\> / upgrade at console.anthropic.com / switch to Gemini or Groq in Settings.

Narrow by design — a non-quota 400 keeps the generic steps.

## Test (new claude.test.ts, 3 cases)
Incident body → quota steps naming the reset date, **not** "Check your API key"; non-quota 400 → generic steps unchanged; usage-limit body with no parseable date → generic date-phrase fallback.

## Review note
Routed to **Main (TL)** for a quick code-review sign-off — 80-line diff (fix is 19; rest is the regression test), just over /trivial-change's ≤50 bar. Fix framing was prescribed by Diagnostics (t/3020#1) + DebateTool (t/3020#2). tsc + eslint clean; 3/3 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)