### PR TITLE
test(nodedetail): lock History-tab viewMode gating (t/3021)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
@@ -217,3 +217,71 @@ describe('NodeDetail — Zustand scalar selector regression (t/2142)', () => {
     expect(screen.getByRole('menuitem', { name: /pin for comparison/i })).toBeInTheDocument();
   });
 });
+
+// ── History tab viewMode gating (t/3021) ──────────────────────────────────────
+// Locks the current policy: History is an Advanced-only tab (NodeDetail.tsx:670,
+// advanced: true → filtered out of the tab bar in Simple view) and the activeTab
+// reset effect forces 'content' whenever the view drops to Simple off a hidden
+// tab. The t/3022 Option-3 ruling keeps this gating (it adds a *separate* Simple
+// last-edited line, not the tab), so these assertions stay valid.
+
+describe('NodeDetail — History tab viewMode gating (t/3021)', () => {
+  const nodeWithHistory: PovNode = {
+    ...mockNode,
+    _edit_history: [
+      { user: 'first@test.com', timestamp: '2026-01-01T00:00:00Z', fields_changed: ['label'] },
+      { user: 'second@test.com', timestamp: '2026-01-02T00:00:00Z', fields_changed: ['description'] },
+    ],
+  };
+
+  beforeEach(() => {
+    mockPrefsState.viewMode = 'simple';
+    vi.clearAllMocks();
+  });
+
+  it('shows the History tab in advanced mode when edit history exists', () => {
+    mockPrefsState.viewMode = 'advanced';
+    render(
+      <NodeDetail pov="acc" node={nodeWithHistory} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /history/i })).toBeInTheDocument();
+  });
+
+  it('hides the History tab in simple mode even when edit history exists', () => {
+    mockPrefsState.viewMode = 'simple';
+    render(
+      <NodeDetail pov="acc" node={nodeWithHistory} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />,
+    );
+    expect(screen.queryByRole('button', { name: /history/i })).not.toBeInTheDocument();
+  });
+
+  it('hides the History tab in simple mode when there is no edit history', () => {
+    mockPrefsState.viewMode = 'simple';
+    render(
+      <NodeDetail pov="acc" node={mockNode} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />,
+    );
+    expect(screen.queryByRole('button', { name: /history/i })).not.toBeInTheDocument();
+  });
+
+  it('resets the active tab to Content when switching advanced→simple while on History', () => {
+    mockPrefsState.viewMode = 'advanced';
+    const { rerender } = render(
+      <NodeDetail pov="acc" node={nodeWithHistory} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />,
+    );
+
+    // Open the History tab — it becomes the active tab.
+    const historyTab = screen.getByRole('button', { name: /history/i });
+    fireEvent.click(historyTab);
+    expect(historyTab.className).toContain('node-detail-tab-active');
+
+    // Drop to Simple view. The reset effect keys on viewMode → forces activeTab back to 'content'.
+    mockPrefsState.viewMode = 'simple';
+    rerender(
+      <NodeDetail pov="acc" node={nodeWithHistory} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />,
+    );
+
+    // History tab is gone, and Content is now the active tab (not a stale hidden 'history').
+    expect(screen.queryByRole('button', { name: /history/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /content/i }).className).toContain('node-detail-tab-active');
+  });
+});


### PR DESCRIPTION
## Summary
Locks the History-tab viewMode gating in `NodeDetail` with regression tests (UAT gap Q1/Q2). The History tab is Advanced-only (`NodeDetail.tsx:670`, `advanced: true`) → filtered out of the tab bar in Simple view (`NodeDetailTabBar`, line 675). A user read this as history "disappearing"; no test asserted the behavior, so it could regress silently.

## Tests added (`NodeDetail.test.tsx`, new describe block)
- History tab **shows** in Advanced when `editHistoryLength > 0`
- History tab **absent** in Simple with edit history present
- History tab **absent** in Simple with no edit history
- switching **Advanced→Simple while on History** resets `activeTab` to `content` (asserted via the `node-detail-tab-active` class on the Content tab)

Mirrors the existing viewMode-gating tests in the file (`mockPrefsState.viewMode` + role-button queries); `_edit_history` fixture uses the `EditHistoryEntry` shape.

## Pattern / review
**Self-cert `/add-test`** — pure test addition, no production code or API changes. Compatible with the t/3022 Option-3 ruling (keeps this gating; adds a *separate* Simple last-edited line, not the tab), so these assertions stay valid. Routed to TL per t/3021#1.

## Verify
renderer-tsc **0/0** · eslint **0** · vitest **10/10** (4 new + 6 existing)

Closes t/3021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
