### PR TITLE
feat(nodedetail): Simple-view last-edited line (t/3022, Option 3)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.css
@@ -877,3 +877,14 @@
 .nd-split-height {
   height: var(--nd-split-height, auto);
 }
+
+/* Simple-view last-edited line (t/3022) */
+.nd-last-edited {
+  margin-top: 6px;
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+.nd-last-edited-user {
+  color: var(--text-secondary);
+  font-weight: 500;
+}

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.test.tsx
@@ -285,3 +285,47 @@ describe('NodeDetail — History tab viewMode gating (t/3021)', () => {
     expect(screen.getByRole('button', { name: /content/i }).className).toContain('node-detail-tab-active');
   });
 });
+
+// ── Simple-view last-edited line (t/3022, Option 3) ───────────────────────────
+// The full History tab stays Advanced-only; Simple view surfaces just the
+// who/when last-edited datum inline. Sourced from _edit_meta, falling back to the
+// most-recent _edit_history entry.
+
+describe('NodeDetail — Simple-view last-edited line (t/3022)', () => {
+  const nodeWithMeta: PovNode = {
+    ...mockNode,
+    _edit_meta: { last_edited_by: 'editor@test.com', last_edited_at: '2026-02-03T10:00:00Z' },
+  };
+  const nodeWithHistoryOnly: PovNode = {
+    ...mockNode,
+    _edit_history: [{ user: 'histuser@test.com', timestamp: '2026-02-04T10:00:00Z', fields_changed: ['label'] }],
+  };
+
+  beforeEach(() => {
+    mockPrefsState.viewMode = 'simple';
+    vi.clearAllMocks();
+  });
+
+  it('shows the last-edited line in Simple view from _edit_meta (username, domain stripped)', () => {
+    render(<NodeDetail pov="acc" node={nodeWithMeta} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />);
+    expect(screen.getByText(/last edited by/i)).toBeInTheDocument();
+    expect(screen.getByText('editor')).toBeInTheDocument();
+  });
+
+  it('falls back to the most-recent _edit_history entry when _edit_meta is absent', () => {
+    render(<NodeDetail pov="acc" node={nodeWithHistoryOnly} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />);
+    expect(screen.getByText(/last edited by/i)).toBeInTheDocument();
+    expect(screen.getByText('histuser')).toBeInTheDocument();
+  });
+
+  it('omits the last-edited line in Advanced view (the History tab covers it)', () => {
+    mockPrefsState.viewMode = 'advanced';
+    render(<NodeDetail pov="acc" node={nodeWithMeta} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />);
+    expect(screen.queryByText(/last edited by/i)).not.toBeInTheDocument();
+  });
+
+  it('omits the last-edited line when the node has no edit metadata', () => {
+    render(<NodeDetail pov="acc" node={mockNode} readOnly={false} onPin={vi.fn()} onSimilarSearch={vi.fn()} onRelated={vi.fn()} />);
+    expect(screen.queryByText(/last edited by/i)).not.toBeInTheDocument();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.tsx
@@ -112,6 +112,29 @@ function getEditHistoryLength(node: PovNode): number | undefined {
   return node._edit_history?.length;
 }
 
+// ── Simple-view last-edited line (t/3022, TL Option-3 ruling) ─────────────────
+// Surfaces the who/when accountability datum in Simple view, where the full
+// History tab is Advanced-only (t/3021 locks that gating). Prefers the canonical
+// _edit_meta last-edited fields, falling back to the most-recent _edit_history
+// entry. Formatting mirrors NodeEditHistory but is kept local here to avoid a new
+// cross-module export (trivial-change scope).
+function NodeLastEditedLine({ node, viewMode }: { node: PovNode; viewMode: 'simple' | 'advanced' }) {
+  if (viewMode !== 'simple') return null; // Advanced view has the full History tab.
+  const latest = node._edit_history?.[node._edit_history.length - 1];
+  const user = node._edit_meta?.last_edited_by ?? latest?.user;
+  const when = node._edit_meta?.last_edited_at ?? latest?.timestamp;
+  if (!user || !when) return null;
+  const name = user === '_local' ? 'Local (Electron)' : user.includes('@') ? user.slice(0, user.indexOf('@')) : user;
+  const parsed = new Date(when);
+  const date = Number.isNaN(parsed.getTime()) ? when : parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  return (
+    <div className="nd-last-edited">
+      Last edited by <span className="nd-last-edited-user">{name}</span>
+      <span className="nd-last-edited-time"> · {date}</span>
+    </div>
+  );
+}
+
 export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRelated, onOpenSoulDoc, chipDepth = 0, conflict, resolveUrl }: NodeDetailProps) {
   const { updatePovNode, deletePovNode, movePovNodeCategory, movePovNode, validationErrors, getAllNodeIds, getAllConflictIds, runAttributeFilter, showAttributeInfo, navigateToLineage, setToolbarPanel, selectedEdge, relatedNodeId, loadEdges, edgesFile, setSelectedNodeId, getLabelForId, aggregatedCruxes, showCruxDetail, conflicts } = useTaxonomyStore();
   const viewMode = usePreferencesStore(state => state.viewMode);
@@ -395,6 +418,7 @@ export function NodeDetail({ pov, node, readOnly, onPin, onSimilarSearch, onRela
           aphorismDraft={aphorismDraft}
           setAphorismDraft={setAphorismDraft}
         />
+        <NodeLastEditedLine node={node} viewMode={viewMode} />
       </div>
 
       {hasErrors && (


### PR DESCRIPTION
## Summary
Implements TL Option-3 ruling (t/3022#1): keep the full History tab Advanced-only, and surface the who/when accountability datum inline in **Simple view**, where the History tab is hidden. Fixes the UAT report that edit history "disappeared" for Simple-view users.

## Change
- New **module-local** `NodeLastEditedLine` in `NodeDetail.tsx`, rendered in the header (below the aphorism section), gated to `viewMode === 'simple'`.
- Datum source: canonical `node._edit_meta` (`last_edited_by`/`last_edited_at`), falling back to the most-recent `node._edit_history` entry. Username domain stripped; date localized (mirrors `NodeEditHistory`).
- `.nd-last-edited` styles co-located in `NodeDetail.css` (styles.css frozen).

## Review routing
TL created this ticket and asked to route the PR here. Diff is **79 lines** (over `/trivial-change`'s ≤50 ceiling), so **not self-certified** — routing to you for review. Single-scope UI change, no new public API / interface / schema / auth surface.

## Deviations from the literal ruling (please sanity-check)
1. **Primary source `_edit_meta`** rather than "the most-recent edit-history entry" — `_edit_meta` is the canonical last-edited datum (exactly what `NodeEditHistory`'s summary row shows); the latest `_edit_history` entry is the fallback.
2. **Inlined formatting** (mirrors `NodeEditHistory`) rather than reusing its helpers, to avoid a new cross-module export for a one-line surface. Minor duplication — happy to extract to a shared util if you'd prefer DRY.

## Verify
renderer-tsc **0/0** · eslint **0 errors** (pre-existing NodeDetail complexity-24 warning unchanged) · vitest **14/14** (4 new + 10 existing)

Closes t/3022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
