### PR TITLE
fix(oped): fail a voice whose AI response is non-JSON instead of garbage-complete (t/3013 sibling)

### DIFF
--- a/lib/oped/generate.ts
+++ b/lib/oped/generate.ts
@@ -273,8 +273,15 @@ async function runVoiceGeneration(
   let parsed: EssayResponse;
   try {
     parsed = JSON.parse(stripCodeFences(rawText)) as EssayResponse;
-  } catch {
-    parsed = { headline: '', body_markdown: rawText, word_count: undefined };
+  } catch (err) {
+    // t/3013 sibling: a NON-empty but non-JSON essay response (the empty case is guarded above).
+    // Most often a truncated response (token-budget exhaustion) leaving unterminated JSON, or the
+    // model emitting prose / ```json fences that survive stripCodeFences. The old silent fallback
+    // stored that raw text as body_markdown, which <Markdown> renders as a monospace code block
+    // with an always-empty headline — a garbage-looking tab, not a clean failure. Throw instead so
+    // runVoice's catch marks the voice status:'failed' + emits voice_failed → the existing
+    // OpEdArticle failed-state notice renders cleanly.
+    throw new Error(`Voice generation returned invalid JSON (pov=${pov}): ${String(err)}`);
   }
 
   const body = parsed.body_markdown ?? '';

--- a/lib/oped/serialGeneration.test.ts
+++ b/lib/oped/serialGeneration.test.ts
@@ -575,3 +575,49 @@ describe('generateOpEdSet — empty voice response finalizes as failed, not blan
     expect(members.find(m => m.pov === 'skeptic')?.status).toBe('complete');
   });
 });
+
+// ── Non-JSON / truncated voice response → failed, not garbage-complete (t/3013 sibling) ───────
+// A NON-empty but non-JSON essay response (a truncated response leaving unterminated JSON, or
+// prose / ```json fences surviving stripCodeFences) previously fell into the JSON.parse raw-text
+// fallback, which stored the raw text as body_markdown → rendered as a monospace code block with
+// an always-empty headline. runVoiceGeneration now throws on a JSON.parse failure, so runVoice
+// marks the voice failed + emits voice_failed → the existing OpEdArticle notice renders cleanly.
+describe('generateOpEdSet — non-JSON voice response finalizes as failed, not garbage-complete (t/3013 sibling)', () => {
+  it('a voice whose essay is non-empty but invalid JSON yields voice_failed + status:failed; others unaffected', async () => {
+    let essayCall = 0;
+    const adapter = {
+      generateText: async (prompt: string) => {
+        if (prompt === 'refl') return JSON.stringify({ grounding_usage: [] });
+        essayCall++;
+        // Truncated JSON (token-budget exhaustion): non-empty, no code fences, JSON.parse throws on the unterminated string.
+        if (essayCall === 2) return '{"headline":"H","body_markdown":"Lorem ipsum dolor sit';
+        return JSON.stringify({ headline: 'H', subtitle: '', body_markdown: 'Body.', word_count: 1 });
+      },
+    };
+    const req = {
+      set_id: 's-badjson', topic: 'AI policy',
+      params: { model: 'gemini-flash', wordCount: 800, outlet: 'nyt', newsHook: '', thesis: '' } as never,
+      povs: ['accelerationist', 'safetyist', 'skeptic'] as PovKey[],
+    };
+    const deps = { adapter: adapter as never, promptsDir: join(REPO_ROOT, 'lib', 'oped', 'prompts'), repoRoot: REPO_ROOT };
+
+    const failed: PovKey[] = [];
+    const completed: PovKey[] = [];
+    let set: OpEdSet | undefined;
+    for await (const ev of generateOpEdSet(req, deps) as AsyncGenerator<OpEdProgressEvent>) {
+      if (ev.type === 'voice_failed') failed.push(ev.pov);
+      if (ev.type === 'voice_complete') completed.push(ev.pov);
+      if (ev.type === 'complete') set = ev.set;
+    }
+
+    // The invalid-JSON voice fails (previously a silent garbage-complete → code-block tab with empty headline).
+    expect(failed).toEqual(['safetyist']);
+    expect(completed.sort()).toEqual(['accelerationist', 'skeptic']);
+
+    const members = set!.opeds as unknown as { pov: string; status: string; body: string }[];
+    expect(members.find(m => m.pov === 'safetyist')?.status).toBe('failed');
+    expect(members.find(m => m.pov === 'safetyist')?.body).toBe(''); // the raw garbage is NOT stored as the body
+    expect(members.find(m => m.pov === 'accelerationist')?.status).toBe('complete');
+    expect(members.find(m => m.pov === 'skeptic')?.status).toBe('complete');
+  });
+});


### PR DESCRIPTION
Sibling to t/3013 — the remaining gap I flagged at **t/3013#4** (partial/truncated non-JSON → degraded-complete). Recovered from stranded uncommitted WIP on the shared main checkout (TL p/342#189); re-derived cleanly on origin/main.

## Root cause
t/3013 fixed the **empty**-response case. This fixes the **non-empty-but-non-JSON** case: `runVoiceGeneration` parsed the essay with `JSON.parse(stripCodeFences(rawText))`; on failure it silently fell back to `{ headline:'', body_markdown: rawText }` — storing raw non-JSON (a truncated/unterminated response from token-budget exhaustion, or prose/```json fences surviving stripCodeFences) as the body. `<Markdown>` renders that as a monospace **code block with an empty headline** — a garbage-looking tab, not a clean failure.

## Fix (generate.ts, +8/-1)
Throw in the JSON.parse catch (naming pov + parse error) so `runVoice`'s catch marks the voice `status:'failed'` + emits `voice_failed` → the existing `OpEdArticle` notice renders. The empty case is still guarded above (t/3013), so this catch only fires for non-empty non-JSON. **Kept the accurate landed t/3013 empty-guard comment** (the stranded WIP's comment tweak muddled it — dropped that hunk).

## Test (serialGeneration.test.ts, +46)
A voice whose essay is truncated JSON → `voice_failed` + finalizes `status:'failed'` with an empty body; other voices complete. Fails on unfixed code (garbage-complete), so it guards the fix.

Routed to **Main (TL)** for review (you asked to claim + PR to you). tsc + eslint clean; 23/23 oped suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)