### PR TITLE
test(ai-client): lock Claude quota-error mapping against the real nested 400 envelope (t/3028)

### DIFF
--- a/lib/ai-client/providers/claude.test.ts
+++ b/lib/ai-client/providers/claude.test.ts
@@ -27,6 +27,16 @@ const QUOTA_BODY = JSON.stringify({
   message: 'You have reached your specified API usage limits. You will regain access on 2026-09-01 at 00:00 UTC.',
 });
 
+// The REAL Anthropic 400 wire format nests the code under `error` (t/3028): the detection is
+// substring-based, so it must fire on the nested envelope too — this locks that against a refactor.
+const QUOTA_BODY_NESTED = JSON.stringify({
+  type: 'error',
+  error: {
+    type: 'invalid_request_error',
+    message: 'You have reached your specified API usage limits. You will regain access on 2026-09-01 at 00:00 UTC.',
+  },
+});
+
 async function callFor(bodyText: string, status: number): Promise<ActionableError> {
   return generateViaClaude(makeFetch(bodyText, status), 'p', 'claude-x', 'key', { timeoutMs: 5000 })
     .then(() => { throw new Error('expected generateViaClaude to throw'); })
@@ -44,6 +54,17 @@ describe('generateViaClaude — quota-exhaustion error mapping (t/3020)', () => 
     expect(steps).toContain('console.anthropic.com');         // upgrade path
     expect(steps.toLowerCase()).toContain('gemini');          // switch backend
     expect(steps).not.toContain('Check your API key');        // NOT the misleading generic step
+  });
+
+  it('maps the REAL nested Anthropic 400 envelope (error.type=invalid_request_error) to the same quota steps (t/3028)', async () => {
+    const err = await callFor(QUOTA_BODY_NESTED, 400);
+    expect(err).toBeInstanceOf(ActionableError);
+    expect(err.problem).toContain('Monthly API usage limit reached');
+    expect(err.problem).toContain('2026-09-01 at 00:00 UTC'); // reset date extracted from the nested message
+    const steps = err.nextSteps.join(' ');
+    expect(steps).toContain('2026-09-01 at 00:00 UTC');
+    expect(steps).not.toContain('Check your API key');        // detection fires on the nested wire format too
+    expect(steps).not.toContain('Verify the model ID');
   });
 
   it('keeps the generic Resolve steps for a non-quota 400 (branch is narrow)', async () => {


### PR DESCRIPTION
Prevention regression for the t/3020 quota-Resolve fix (PR #1556). **Self-cert /add-test** — one `it()` added to the existing `lib/ai-client/providers/claude.test.ts`, no production change.

## Why this, not a from-scratch test
The regression test **already shipped with the fix in #1556** — claude.test.ts already asserts both arms against the flat incident body (quota-400 → reset-date Resolve steps, NOT "Check your API key"; non-quota 400 → generic steps; + a date fallback). Verified on origin/main. So t/3028's core intent is already covered.

The one genuine gap: the ticket specifies the **real Anthropic 400 wire format**, which nests the code under `error` (`{"type":"error","error":{"type":"invalid_request_error",…}}`). The landed tests only exercise the flatter incident body. This adds a case proving detection fires on the **nested envelope** too (it's substring-based) — so a refactor can't silently break the mapping on the format Anthropic actually sends. That closes the FR-dump concern (a stale build showed 20 judge errors with the wrong pre-fix steps).

## Verify
4/4 claude suite green; tsc + eslint clean. Minor /add-test deviation: ai-client tests are co-located `.test.ts` (matches gemini.test.ts et al.), not `__tests__/`.

Routed to Main (TL)/Quality per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)