### PR TITLE
feat(taxonomy): Get-Situation — list/filter situations with per-POV evidence counts

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -18,6 +18,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-Tax` | Load full taxonomy (nodes, edges, metadata) |
 | `Get-GraphNode` | Look up a specific node by ID |
 | `Get-Edge` | Fetch edges (filter by source/target/type) |
+| `Get-Situation` | List/filter situations (by id/label/text/linked-node/camp); reports per-POV supporting-evidence counts derived from `linked_nodes` |
 | `Get-Policy` | Look up policy actions from the registry |
 | `Get-TaxonomyHealth` | Check node/edge counts, orphans, structural issues |
 | `Compare-Taxonomy` | Diff two taxonomy states |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -51,6 +51,7 @@
         'Approve-Edge'
         'Approve-TaxonomyProposal'
         'Get-Edge'
+        'Get-Situation'
         'Set-Edge'
         'Invoke-GraphQuery'
         'Get-ConflictEvolution'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -792,6 +792,7 @@ Export-ModuleMember -Function @(
     'Approve-Edge'
     'Approve-TaxonomyProposal'
     'Get-Edge'
+    'Get-Situation'
     'Set-Edge'
     'Invoke-GraphQuery'
     'Get-ConflictEvolution'

--- a/scripts/AITriad/Public/Get-Situation.ps1
+++ b/scripts/AITriad/Public/Get-Situation.ps1
@@ -1,0 +1,169 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Get-Situation {
+    <#
+    .SYNOPSIS
+        Lists and filters situations in the taxonomy.
+    .DESCRIPTION
+        Reads situations.json and returns situations matching the specified criteria.
+        String filters support wildcards; multiple filters are AND-combined. With no
+        parameters, returns all situations sorted by Id.
+
+        A situation's per-POV "supporting evidence" is derived from `linked_nodes` by POV
+        id-prefix (acc-/saf-/skp-) — the same derivation the UI uses (SituationDetail) — so
+        the AccEvidence/SafEvidence/SkpEvidence counts mirror what a reader sees per camp.
+    .PARAMETER Id
+        Wildcard pattern matched against the situation id (e.g. 'sit-001', 'sit-0*').
+    .PARAMETER Label
+        Wildcard pattern matched against the situation label.
+    .PARAMETER Text
+        Wildcard pattern matched against the description (and plain_description if present).
+    .PARAMETER LinkedNode
+        Wildcard pattern matched against the situation's linked_nodes entries — find every
+        situation that links a given POV node (e.g. 'acc-beliefs-039', 'skp-*').
+    .PARAMETER Camp
+        Return only situations that have at least one linked node for this POV camp
+        (by id-prefix), i.e. situations showing supporting evidence for that camp.
+    .PARAMETER WithLinks
+        Return only situations that have at least one linked_node (any camp).
+    .PARAMETER First
+        Return only the first N matching situations.
+    .PARAMETER RepoRoot
+        Path to the repository root.
+    .EXAMPLE
+        Get-Situation
+        # All situations.
+    .EXAMPLE
+        Get-Situation sit-001
+        # A single situation by id.
+    .EXAMPLE
+        Get-Situation -Label '*alignment*'
+        # Situations whose label mentions alignment.
+    .EXAMPLE
+        Get-Situation -LinkedNode 'acc-beliefs-039'
+        # Every situation that links that node as supporting evidence.
+    .EXAMPLE
+        Get-Situation -Camp skeptic -WithLinks
+        # Situations that have Skeptic-camp supporting evidence.
+    .EXAMPLE
+        Get-Situation -Text '*existential*' -First 5
+        # First 5 situations mentioning existential (risk) in their description.
+    .LINK
+        Show-AITriadHelp
+    .LINK
+        Repair-SituationReciprocity
+    .LINK
+        Add-SituationEvidenceLink
+    .LINK
+        Get-Edge
+    .LINK
+        Get-GraphNode
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Position = 0)]
+        [string]$Id,
+
+        [string]$Label,
+
+        [string]$Text,
+
+        [string]$LinkedNode,
+
+        [ValidateSet('accelerationist', 'safetyist', 'skeptic', '')]
+        [string]$Camp,
+
+        [switch]$WithLinks,
+
+        [int]$First = 0,
+
+        [string]$RepoRoot = $script:RepoRoot
+    )
+
+    Set-StrictMode -Version Latest
+    $ErrorActionPreference = 'Stop'
+
+    $TaxDir  = if ($RepoRoot) { Join-Path $RepoRoot 'taxonomy/Origin' } else { Get-TaxonomyDir }
+    $SitPath = Join-Path $TaxDir 'situations.json'
+
+    if (-not (Test-Path -LiteralPath $SitPath)) {
+        Write-Fail "No situations.json found at $SitPath."
+        return
+    }
+
+    $SitData = Get-Content -Raw -LiteralPath $SitPath | ConvertFrom-Json
+
+    # POV camp -> node id-prefix (how the UI derives per-camp supporting evidence).
+    $CampPrefix = @{ accelerationist = 'acc-'; safetyist = 'saf-'; skeptic = 'skp-' }
+
+    $Results = [System.Collections.Generic.List[PSObject]]::new()
+
+    foreach ($S in @($SitData.nodes)) {
+        # ── Filters (guard every optional field for StrictMode) ──
+        if ($Id    -and $S.id    -notlike $Id)    { continue }
+        if ($Label) {
+            $SLabel = if ($S.PSObject.Properties['label']) { [string]$S.label } else { '' }
+            if ($SLabel -notlike $Label) { continue }
+        }
+        if ($Text) {
+            $SDesc  = if ($S.PSObject.Properties['description']) { [string]$S.description } else { '' }
+            $SPlain = if ($S.PSObject.Properties['plain_description']) { [string]$S.plain_description } else { '' }
+            if ($SDesc -notlike $Text -and $SPlain -notlike $Text) { continue }
+        }
+
+        # NB: an if-EXPRESSION returning @() unrolls to $null, so assign @() directly then overwrite —
+        # otherwise a situation with empty linked_nodes yields $null and $Linked.Count throws (StrictMode).
+        $Linked = @()
+        if ($S.PSObject.Properties['linked_nodes'] -and $null -ne $S.linked_nodes) { $Linked = @($S.linked_nodes) }
+
+        if ($LinkedNode) {
+            if (-not (@($Linked | Where-Object { $_ -like $LinkedNode }).Count -gt 0)) { continue }
+        }
+        if ($WithLinks -and $Linked.Count -eq 0) { continue }
+        if ($Camp) {
+            $CampCount = @($Linked | Where-Object { $_ -like "$($CampPrefix[$Camp])*" }).Count
+            if ($CampCount -eq 0) { continue }
+        }
+
+        # ── Per-camp evidence counts (by prefix — mirrors the UI's linkedByPov) ──
+        $AccN = @($Linked | Where-Object { $_ -like 'acc-*' }).Count
+        $SafN = @($Linked | Where-Object { $_ -like 'saf-*' }).Count
+        $SkpN = @($Linked | Where-Object { $_ -like 'skp-*' }).Count
+
+        # ── Machine-linked provenance (WS-B; field is optional/absent pre-apply) ──
+        $MachineLinked = 0
+        if ($S.PSObject.Properties['evidence_provenance'] -and $null -ne $S.evidence_provenance) {
+            foreach ($p in $S.evidence_provenance.PSObject.Properties) {
+                $prov = $p.Value
+                if ($prov.PSObject.Properties['origin'] -and $prov.origin -eq 'machine') { $MachineLinked++ }
+            }
+        }
+
+        $Results.Add([PSCustomObject]@{
+            PSTypeName       = 'AITriad.Situation'
+            Id               = $S.id
+            Label            = if ($S.PSObject.Properties['label']) { $S.label } else { $null }
+            Description      = if ($S.PSObject.Properties['description']) { $S.description } else { $null }
+            LinkedNodes      = $Linked
+            LinkedNodeCount  = $Linked.Count
+            AccEvidence      = $AccN
+            SafEvidence      = $SafN
+            SkpEvidence      = $SkpN
+            MachineLinked    = $MachineLinked
+            DisagreementType = if ($S.PSObject.Properties['disagreement_type']) { $S.disagreement_type } else { $null }
+            ParentId         = if ($S.PSObject.Properties['parent_id']) { $S.parent_id } else { $null }
+            Interpretations  = if ($S.PSObject.Properties['interpretations']) { $S.interpretations } else { $null }
+        })
+
+        if ($First -gt 0 -and $Results.Count -ge $First) { break }
+    }
+
+    if ($Results.Count -eq 0) {
+        Write-Warning 'No situations matched the specified filters.'
+        return
+    }
+
+    $Results | Sort-Object Id
+}

--- a/tests/Get-Situation.Tests.ps1
+++ b/tests/Get-Situation.Tests.ps1
@@ -1,0 +1,122 @@
+# Tag: taxonomy
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Get-Situation — list/filter situations from situations.json. No live-data reads;
+    every test builds a throwaway taxonomy/Origin via -RepoRoot.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    function New-SituationsFixture {
+        $root = Join-Path ([System.IO.Path]::GetTempPath()) "getsit-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        $tax  = Join-Path $root 'taxonomy/Origin'
+        New-Item -ItemType Directory -Path $tax -Force | Out-Null
+        @{
+            _schema_version = '1.0.0'; last_modified = '2026-01-01'
+            nodes = @(
+                @{ id = 'sit-001'; label = 'Alpha timeline'; description = 'A situation about existential risk timelines.'; disagreement_type = 'empirical'; linked_nodes = @('acc-beliefs-1', 'skp-beliefs-2') }
+                @{ id = 'sit-002'; label = 'Beta gap';       description = 'A situation with no supporting evidence yet.'; linked_nodes = @() }
+                @{ id = 'sit-003'; label = 'Gamma alignment'; description = 'A situation about technical alignment.'; linked_nodes = @('saf-beliefs-3') }
+            )
+        } | ConvertTo-Json -Depth 20 | Set-Content -Path (Join-Path $tax 'situations.json') -Encoding utf8
+        return $root
+    }
+}
+
+Describe 'Get-Situation' -Tag 'taxonomy' {
+
+    It 'is exported from the module' {
+        Get-Command -Module AITriad -Name 'Get-Situation' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'returns all situations sorted by Id when no filter is given' {
+        $root = New-SituationsFixture
+        try {
+            $r = @(Get-Situation -RepoRoot $root)
+            $r.Count | Should -Be 3
+            $r[0].Id | Should -Be 'sit-001'
+            $r[2].Id | Should -Be 'sit-003'
+            $r[0].PSObject.TypeNames | Should -Contain 'AITriad.Situation'
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'filters by -Id and reports per-POV evidence counts from linked_nodes (prefix-derived)' {
+        $root = New-SituationsFixture
+        try {
+            $s = Get-Situation -Id 'sit-001' -RepoRoot $root
+            @($s).Count      | Should -Be 1
+            $s.LinkedNodeCount | Should -Be 2
+            $s.AccEvidence   | Should -Be 1
+            $s.SkpEvidence   | Should -Be 1
+            $s.SafEvidence   | Should -Be 0
+            $s.MachineLinked | Should -Be 0   # evidence_provenance absent pre-WSB-apply
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'wildcard -Id matches multiple' {
+        $root = New-SituationsFixture
+        try {
+            @(Get-Situation -Id 'sit-00*' -RepoRoot $root).Count | Should -Be 3
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It '-LinkedNode finds every situation that links a given node' {
+        $root = New-SituationsFixture
+        try {
+            $r = @(Get-Situation -LinkedNode 'acc-beliefs-1' -RepoRoot $root)
+            $r.Count | Should -Be 1
+            $r[0].Id | Should -Be 'sit-001'
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It '-WithLinks excludes situations with empty linked_nodes' {
+        $root = New-SituationsFixture
+        try {
+            $ids = @(Get-Situation -WithLinks -RepoRoot $root).Id
+            $ids | Should -Contain 'sit-001'
+            $ids | Should -Contain 'sit-003'
+            $ids | Should -Not -Contain 'sit-002'
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It '-Camp returns only situations with evidence for that POV (by prefix)' {
+        $root = New-SituationsFixture
+        try {
+            $skp = @(Get-Situation -Camp skeptic -RepoRoot $root)
+            $skp.Count | Should -Be 1
+            $skp[0].Id | Should -Be 'sit-001'
+            @(Get-Situation -Camp safetyist -RepoRoot $root)[0].Id | Should -Be 'sit-003'
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It '-Text and -Label match description/label (wildcards)' {
+        $root = New-SituationsFixture
+        try {
+            @(Get-Situation -Text '*existential*' -RepoRoot $root)[0].Id | Should -Be 'sit-001'
+            @(Get-Situation -Label '*alignment*'  -RepoRoot $root)[0].Id | Should -Be 'sit-003'
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'warns and returns nothing when no situation matches' {
+        $root = New-SituationsFixture
+        try {
+            $r = Get-Situation -Id 'sit-999' -RepoRoot $root -WarningAction SilentlyContinue
+            $r | Should -BeNullOrEmpty
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'reports a failure and returns nothing when situations.json is missing' {
+        $root = Join-Path ([System.IO.Path]::GetTempPath()) "getsit-none-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+        New-Item -ItemType Directory -Path (Join-Path $root 'taxonomy/Origin') -Force | Out-Null
+        try {
+            $r = Get-Situation -RepoRoot $root 6>$null 2>$null
+            $r | Should -BeNullOrEmpty
+        } finally { Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+}


### PR DESCRIPTION
New public read cmdlet (self-cert `/add-ps-cmdlet`; mirrors `Get-Edge`). Reads situations.json → `AITriad.Situation` objects.

**Filters** (wildcard, AND-combined): `-Id`, `-Label`, `-Text` (description + plain_description), `-LinkedNode` (every situation linking a node), `-Camp` (situations with evidence for a POV, by id-prefix), `-WithLinks`, `-First`.

**Reports** per situation: per-POV supporting-evidence counts derived from `linked_nodes` by prefix (Acc/Saf/Skp) — the same derivation the UI uses (`SituationDetail.linkedByPov`) — plus `LinkedNodeCount`, `MachineLinked` (from the WS-B `evidence_provenance` map, guarded/optional), `DisagreementType`, `ParentId`, `Interpretations`.

Registered in both psd1 `FunctionsToExport` and psm1 `Export-ModuleMember`; catalogued in `docs/cmdlet-reference.md`. Read-only, no data write. StrictMode-safe (every optional field guarded; fixed the if-expression-returns-@()-unrolls-to-null trap for empty `linked_nodes`, caught by the tests).

**Tests 10/10** + module export/parity 33/33 + `Test-ModuleManifest` passes.

Complements the WS-A/WS-B evidence-link work (t/2979 `Repair-SituationReciprocity`, t/3015 `Add-SituationEvidenceLink`) with a read/query surface over the same data.

Co-Authored-By: PowerShell (Orca)