### PR TITLE
fix(debate): default judgeModel → gemini-3.5-flash-lite (t/3033)

### DIFF
--- a/lib/debate/turnValidator.test.ts
+++ b/lib/debate/turnValidator.test.ts
@@ -94,7 +94,7 @@ describe('resolveTurnValidationConfig', () => {
     expect(c.enabled).toBe(true);
     expect(c.maxRetries).toBe(0);
     expect(c.deterministicOnly).toBe(false);
-    expect(c.judgeModel).toBe('claude-haiku-4-5-20251001');
+    expect(c.judgeModel).toBe('gemini-3.5-flash-lite');
     expect(c.sampleRate['confrontation']).toBe(1);
     expect(c.sampleRate.argumentation).toBe(1);
     expect(c.sampleRate.concluding).toBe(1);

--- a/lib/debate/turnValidator/config.ts
+++ b/lib/debate/turnValidator/config.ts
@@ -18,7 +18,7 @@ export function resolveTurnValidationConfig(
     enabled: src.enabled ?? true,
     maxRetries: clamped as 0 | 1 | 2 | 3 | 4,
     deterministicOnly: src.deterministicOnly ?? false,
-    judgeModel: src.judgeModel ?? 'claude-haiku-4-5-20251001',
+    judgeModel: src.judgeModel ?? 'gemini-3.5-flash-lite',
     sampleRate: {
       'confrontation': src.sampleRate?.['confrontation'] ?? 1,
       argumentation: src.sampleRate?.argumentation ?? 1,


### PR DESCRIPTION
## Summary

- Change default `judgeModel` in `resolveTurnValidationConfig` from `claude-haiku-4-5-20251001` to `gemini-3.5-flash-lite`
- Update the corresponding test assertion

## Motivation

Claude quota exhaustion silently stalled the judge on every turn across a full session (FR dump 2026-08-26). The judge was the only debate component calling Claude without explicit user config — a cross-provider dependency the user didn't set up and can't easily debug when it fails.

## Scope

2 lines changed, `lib/debate/` only. No interface changes, no new exports.

Self-certifying under /trivial-change. All 162 `turnValidator.test.ts` tests pass.

Note: `judgeAudit.ts:171` has `haiku: 'claude-haiku-4-5'` in `MODEL_ALIASES` — this is a user-facing shortcut alias, not a routing default. Left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)