### PR TITLE
feat(debate): FR events for clarification generation trigger/skip/error (t/3032)

### DIFF
--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -131,6 +131,10 @@ export type EventType =
   | 'lookahead.regen'
   // Situation
   | 'situation.divergence-summary'
+  // Situation-debate clarification startup observability (t/3032)
+  | 'situation_debate.generation_trigger'
+  | 'situation_debate.generation_skipped'
+  | 'situation_debate.generation_error'
   // Topic scope
   | 'topic.critique'
   | 'topic_scope_extracted'

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -239,9 +239,17 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
     const { activeDebate, addTranscriptEntry, saveDebate, debateGenerating } = get();
     if (!activeDebate) return;
 
-    // Guard: don't run if already generating or if clarification already exists
-    if (debateGenerating) return;
-    if (activeDebate.transcript.some(e => e.type === 'clarification')) return;
+    // Guard: don't run if already generating or if clarification already exists.
+    // t/3032: emit a skipped marker at each guard so a dump distinguishes
+    // "trigger fired but declined to generate (with reason)" from "never fired".
+    if (debateGenerating) {
+      getGlobalRecorder()?.record({ type: 'situation_debate.generation_skipped', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_skipped', data: { reason: 'already_generating' } });
+      return;
+    }
+    if (activeDebate.transcript.some(e => e.type === 'clarification')) {
+      getGlobalRecorder()?.record({ type: 'situation_debate.generation_skipped', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_skipped', data: { reason: 'clarification_exists' } });
+      return;
+    }
 
     const isStillValid = createDebateGuard(get);
     set({ debateError: null, debateWarnings: [] });
@@ -256,6 +264,9 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         ? documentClarificationPrompt(topic, activeDebate.source_content, activeDebate.audience, lineageCtx)
         : buildClarificationPrompt(topic, activeDebate.source_content || undefined, activeDebate.audience, lineageCtx);
     try {
+      // t/3032: the clarification trigger point — emitted immediately before the first AI call
+      // dispatches, so a dump shows the trigger fired (vs. never firing → absent ai.request).
+      getGlobalRecorder()?.record({ type: 'situation_debate.generation_trigger', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_trigger', data: { model, phase: 'clarification' } });
       const { text } = await generateTextWithProgress(prompt, model, `Generating clarifying questions (${model})`, set);
       if (!isStillValid()) { getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'warn', debate_id: activeDebate?.id, message: 'runClarification aborted: guard failed after question generation' }); return; }
       let questions: string[];
@@ -287,6 +298,10 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         message: 'Failed to generate clarifying questions',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
+      // t/3032: dedicated observability marker (greppable by type) so a dump distinguishes
+      // trigger-fired-and-failed from trigger-never-fired. The ADR-003 system.error above
+      // carries the stack; this marker carries the spec's { debate_id, error.name, error.message }.
+      getGlobalRecorder()?.record({ type: 'situation_debate.generation_error', component: 'debate-store', level: 'error', debate_id: activeDebate?.id, message: 'situation_debate.generation_error', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
       addTranscriptEntry({
         type: 'system',
         speaker: 'system',


### PR DESCRIPTION
## Summary
Adds the 3 flight-recorder events DebateTool specced (e/123) to `clarificationSlice.ts:runClarification`, so a dump distinguishes **trigger-fired-and-succeeded / skipped (with reason) / failed (with error)** from **trigger-never-fired** (previously only the absence of `ai.request`, invisible in a 5000-event ring).

| event | where | fields |
|---|---|---|
| `situation_debate.generation_trigger` | immediately before `generateTextWithProgress` | `debate_id`, `data:{ model, phase:'clarification' }` |
| `situation_debate.generation_skipped` | each early-return guard | `debate_id`, `data:{ reason }` (`already_generating` \| `clarification_exists`) |
| `situation_debate.generation_error` | catch block | `debate_id`, `error:{ name, message }` |

Registers the 3 new `EventType`s in `lib/flight-recorder/types.ts`.

## Notes / deviations (please sanity-check)
1. **`lib/flight-recorder/types.ts` is Shared Lib scope.** The 3 additions are trivial, additive union members (the union is a shared registry many roles contribute to) — self-managed under the <5-line cross-scope rule. **@Shared Lib** flagging for awareness.
2. **`runClarification` is the shared clarification trigger** (situations/document/url/topic). The spec placed the events at its `generateTextWithProgress` call, so `situation_debate.*` fire for **all** clarification, not situations-only. Kept the spec's placement + names — if you want situations-only (`source_type==='situations'` gate) or a neutral prefix (`clarification.generation_*`), it's a one-liner. **@DebateTool** your call.
3. **`generation_error` is added alongside** the existing ADR-003 `system.error` in the catch (not a retype) — the `system.error` keeps the stack; the marker is the greppable trigger-failed signal.

## Verify
renderer-tsc **0/0** · eslint **0 errors** · vitest `useDebateStore` **267/267**.

## CI note
GitHub Actions is in a major outage — this PR may show an empty check rollup (same as #1563/#1566/#1567). Holding merge until CI is available (not close/reopen-spamming per TL p/336#196).

Closes t/3032

🤖 Generated with [Claude Code](https://claude.com/claude-code)
