### PR TITLE
fix(server): propagate err.statusCode + structured FR level across route catch blocks (t/3034–3037)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/adminReview.test.ts
+++ b/taxonomy-editor/src/server/__tests__/adminReview.test.ts
@@ -202,6 +202,23 @@ describe('admin review registry', () => {
     await expect(getReviewDetail('ghost:u1')).rejects.toThrow(/ghost/);
   });
 
+  // t/3034 regression: err.statusCode must survive executeReviewAction so the
+  // route handler propagates 409 → HTTP 409 (not 500 from the two-arg error())
+  it('preserves err.statusCode through executeReviewAction (double-submit → 409 not 500)', async () => {
+    const alreadyApproved = Object.assign(new Error('Submission already approved'), { statusCode: 409 });
+    registerReviewHandler({
+      domain: 'calibration',
+      async getPendingItems() { return []; },
+      async getDetailForViewer() { return {}; },
+      async executeAction() { throw alreadyApproved; },
+    });
+    const caught = await executeReviewAction({
+      domain: 'calibration', groupId: 'calibration:u1', action: 'promote', itemIds: ['x'],
+    }).catch(e => e);
+    expect(caught).toBe(alreadyApproved);
+    expect((caught as { statusCode?: number }).statusCode).toBe(409);
+  });
+
   // AC#3 — admin middleware
   it('rejects non-admin callers with 403', () => {
     const m = mockRes();

--- a/taxonomy-editor/src/server/community/admin/reviewRegistry.ts
+++ b/taxonomy-editor/src/server/community/admin/reviewRegistry.ts
@@ -213,7 +213,7 @@ export async function executeReviewAction(action: ReviewAction): Promise<void> {
     getGlobalRecorder()?.record({
       type: 'system.error',
       component: 'admin-review',
-      level: 'error',
+      level: ((err as { statusCode?: number }).statusCode ?? 500) < 500 ? 'warn' : 'error',
       message: `Review handler "${handler.domain}" failed during executeAction:${action.action}`,
       error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
     });

--- a/taxonomy-editor/src/server/httpKit.ts
+++ b/taxonomy-editor/src/server/httpKit.ts
@@ -48,6 +48,7 @@ function recordServerError(route: string, status: number, message: string, cause
     level: 'error',
     message: `${route}: server error (detail withheld from client)`,
     error: { name: (cause as Error)?.name ?? 'Error', message, stack: (cause as Error)?.stack },
+    data: { response_status: status },
   });
 }
 

--- a/taxonomy-editor/src/server/routes/admin.ts
+++ b/taxonomy-editor/src/server/routes/admin.ts
@@ -176,7 +176,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Failed to list community submissions',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -229,7 +229,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err }, 'calibration pending failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -257,7 +257,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err }, 'calibration promote failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -280,7 +280,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err }, 'calibration reject failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -407,7 +407,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err }, 'admin review queue failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -424,7 +424,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err }, 'admin review stats failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -442,7 +442,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err }, 'admin review detail failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -459,12 +459,12 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
       getGlobalRecorder()?.record({
         type: 'system.error',
         component: 'server',
-        level: 'error',
+        level: ((err as { statusCode?: number }).statusCode ?? 500) < 500 ? 'warn' : 'error',
         message: 'Operation failed',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err }, 'admin review action failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -501,7 +501,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
       json(res, { ok: true, id: entry.id });
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to store feedback', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -537,7 +537,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err }, 'admin feedback list failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -563,7 +563,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
       json(res, { ok: true, id: entry.id });
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to store error report', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -595,7 +595,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Failed to build admin status report',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -753,7 +753,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
       json(res, { ok: true });
     } catch (err) {
       getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to write telemetry event', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -813,7 +813,7 @@ export function registerAdminRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Failed to build telemetry summaries',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 

--- a/taxonomy-editor/src/server/routes/community.ts
+++ b/taxonomy-editor/src/server/routes/community.ts
@@ -67,7 +67,7 @@ export function registerCommunityRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Failed to list community chats',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -102,7 +102,7 @@ export function registerCommunityRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Failed to list community debates',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 
@@ -140,7 +140,7 @@ export function registerCommunityRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Failed to list community opeds',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 

--- a/taxonomy-editor/src/server/routes/diagnostics.ts
+++ b/taxonomy-editor/src/server/routes/diagnostics.ts
@@ -218,7 +218,7 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Failed to list flight-recorder dumps',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 

--- a/taxonomy-editor/src/server/routes/session.ts
+++ b/taxonomy-editor/src/server/routes/session.ts
@@ -288,7 +288,7 @@ export function registerSessionRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Operation failed',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 }

--- a/taxonomy-editor/src/server/routes/sources.ts
+++ b/taxonomy-editor/src/server/routes/sources.ts
@@ -203,7 +203,7 @@ export function registerSourcesRoutes(r: Router, _ctx: ServerCtx): void {
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
       log.api.warn({ err, docId }, 'source-document file serve failed');
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 

--- a/taxonomy-editor/src/server/routes/taxonomy.ts
+++ b/taxonomy-editor/src/server/routes/taxonomy.ts
@@ -35,7 +35,7 @@ export function registerTaxonomyRoutes(r: Router, ctx: ServerCtx): void {
         message: 'Failed to load synthetic embeddings',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      error(res, String(err));
+      error(res, String(err), (err as { statusCode?: number }).statusCode ?? 500);
     }
   });
 


### PR DESCRIPTION
## Summary

- **t/3034**: `admin.ts` `POST /api/admin/review/action` now passes `err.statusCode` to `error()` — a 409 double-submit reaches the client as HTTP 409, not 500
- **t/3035**: FR event `level` in `reviewRegistry.ts` and `admin.ts` catch blocks derives from statusCode (4xx → `'warn'`, 5xx → `'error'`) instead of always `'error'`
- **t/3036**: All 21 bare `error(res, String(err))` calls across 6 route files upgraded to propagate `err.statusCode ?? 500` — client-controlled status codes no longer silently downgraded
- **t/3037**: `httpKit.ts` `recordServerError` gains `data: { response_status: status }` so the FR event carries the actual HTTP status emitted to the client

Regression test added to `adminReview.test.ts`: verifies `statusCode: 409` survives `executeReviewAction` (16 tests total, all passing).

Reject route at `admin.ts:200–215` already uses correct `json(res, { error: String(err) }, status)` pattern — no change needed there (TL condition satisfied).

## Hold — GHA outage

CI will be 0-check-class until the GitHub Actions outage (e/124) clears. **Do not merge** until DevOps signals recovery and CI is green on this head. Will push `--allow-empty` retrigger once the outage resolves.

## Test plan

- [ ] `npx vitest run src/server/__tests__/adminReview.test.ts` from `taxonomy-editor/` → 16/16 pass
- [ ] POST `/api/admin/review/action` with a double-submit that throws `{ statusCode: 409 }` → HTTP 409 response, FR event `level: 'warn'`
- [ ] POST any route catch that throws `{ statusCode: 422 }` → HTTP 422 forwarded to client (not 500)
- [ ] `httpKit.ts` `recordServerError` FR event includes `data.response_status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBHGCvj3awBhE3jYPYATPG