### PR TITLE
obs(debate): add judge.skipped FR event when judge call is abandoned (t/3027)

### DIFF
--- a/lib/debate/turnValidator.test.ts
+++ b/lib/debate/turnValidator.test.ts
@@ -1,7 +1,12 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRecord = vi.hoisted(() => vi.fn());
+vi.mock('../flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: mockRecord }),
+}));
 import { resolveTurnValidationConfig, validateTurn, validatePlanStage, validateCiteStage, validateDraftStage, checkDirectiveContentCompliance, isFillerRelevance, parseDraftQualityResult, checkBoundaryConcession } from './turnValidator.js';
 import type { ValidateTurnParams } from './turnValidator.js';
 import type {
@@ -997,6 +1002,37 @@ describe('judge parse failures', () => {
     // With no judge and no Stage-A errors, advancement.pass depends on judgeAttempted
     // judgeAttempted=true but judge=null, so advancement.pass = stageA.pass && !judgeAttempted = false
     expect(r.dimensions.advancement.pass).toBe(false);
+  });
+
+  describe('judge.skipped FR event', () => {
+    beforeEach(() => { mockRecord.mockClear(); });
+
+    it('emits judge.skipped with reason=quota_exhausted when primary fails with quota error and no fallback', async () => {
+      const cfg = resolveTurnValidationConfig({ enabled: true, deterministicOnly: false });
+      const p = makeParams({
+        config: cfg,
+        callJudge: async () => { throw new Error('429 quota exhausted'); },
+      });
+      await validateTurn(p);
+      const skipped = mockRecord.mock.calls.find(([e]) => e.type === 'judge.skipped');
+      expect(skipped).toBeDefined();
+      expect(skipped![0].data.reason).toBe('quota_exhausted');
+      expect(skipped![0].data.model).toBe(cfg.judgeModel);
+    });
+
+    it('emits judge.skipped when both primary and fallback fail', async () => {
+      const p = makeParams({
+        config: resolveTurnValidationConfig({ enabled: true, deterministicOnly: false }),
+        callJudge: async () => { throw new Error('primary down'); },
+        callJudgeFallback: async () => { throw new Error('fallback down'); },
+      });
+      await validateTurn(p);
+      const skipped = mockRecord.mock.calls.find(([e]) => e.type === 'judge.skipped');
+      expect(skipped).toBeDefined();
+      expect(skipped![0].level).toBe('warn');
+      expect(skipped![0].data.speaker).toBeDefined();
+      expect(skipped![0].data.round).toBeDefined();
+    });
   });
 });
 

--- a/lib/debate/turnValidator/core.ts
+++ b/lib/debate/turnValidator/core.ts
@@ -433,6 +433,16 @@ function parseJudgeVerdict(raw: string): JudgeVerdict {
   }
 }
 
+// ── Judge failure classifier ────────────────────────────
+
+function classifyJudgeFailureReason(err: unknown): string {
+  const msg = String(err);
+  if (/quota|rate.?limit|429/i.test(msg)) return 'quota_exhausted';
+  if (/unavailable|overload|503/i.test(msg)) return 'model_unavailable';
+  if (/network|ECONNRESET|ETIMEDOUT|fetch failed/i.test(msg)) return 'network_error';
+  return 'unknown';
+}
+
 // ── Orchestrator ─────────────────────────────────────────
 
 export async function validateTurn(p: ValidateTurnParams): Promise<TurnValidation> {
@@ -480,7 +490,7 @@ export async function validateTurn(p: ValidateTurnParams): Promise<TurnValidatio
       judge = parseJudgeVerdict(raw);
       judgeUsed = true;
       judgeModel = p.config.judgeModel;
-    } catch {
+    } catch (primaryErr) {
       // Primary judge failed (e.g. missing Anthropic key) — try fallback model.
       if (p.callJudgeFallback) {
         try {
@@ -488,9 +498,12 @@ export async function validateTurn(p: ValidateTurnParams): Promise<TurnValidatio
           judge = parseJudgeVerdict(raw);
           judgeUsed = true;
           judgeModel = 'fallback';
-        } catch {
+        } catch (fallbackErr) {
+          getGlobalRecorder()?.record({ type: 'judge.skipped', component: 'turn-validator', level: 'warn', message: 'Judge abandoned — primary and fallback both failed', data: { reason: classifyJudgeFailureReason(fallbackErr), model: p.config.judgeModel, speaker: p.speaker, round: p.round, phase: p.phase } });
           judge = null;
         }
+      } else {
+        getGlobalRecorder()?.record({ type: 'judge.skipped', component: 'turn-validator', level: 'warn', message: 'Judge abandoned — primary failed, no fallback', data: { reason: classifyJudgeFailureReason(primaryErr), model: p.config.judgeModel, speaker: p.speaker, round: p.round, phase: p.phase } });
       }
     }
   }

--- a/lib/flight-recorder/types.ts
+++ b/lib/flight-recorder/types.ts
@@ -154,6 +154,8 @@ export type EventType =
   | 'sw.update_found'
   // Embed / external content
   | 'embed.load-failure'
+  // Judge (turn validator)
+  | 'judge.skipped'
   // System
   | 'system.error'
   | 'system.info'


### PR DESCRIPTION
## Summary

- Emits `judge.skipped` (warn) in `turnValidator/core.ts` whenever the judge is abandoned — primary fails with no fallback, or both primary and fallback fail
- Classifies failure reason: `quota_exhausted`, `model_unavailable`, `network_error`, `unknown`
- Adds `judge.skipped` to the `EventType` union in `lib/flight-recorder/types.ts` (1-line trivial cross-scope addition)
- 2 focused tests via `vi.mock` + `vi.hoisted`: verifies event fires with correct reason and fields

## Test plan

- [x] 164/164 existing + new tests pass (`npx vitest run turnValidator.test.ts`)
- [x] Self-certifying under /trivial-change for the flight-recorder types.ts edit (1 line, additive-only, no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)