### PR TITLE
feat(settings): show Already promoted/approved toast on 409 double-submit (t/3038)

### DIFF
--- a/taxonomy-editor/src/renderer/components/settings/AdminPanel.test.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/AdminPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 vi.mock('@bridge', () => ({ api: {} }));
@@ -10,10 +10,11 @@ vi.mock('@lib/flight-recorder/index', () => ({
 const mockFetchSubmissions = vi.fn().mockResolvedValue(undefined);
 const mockApproveSubmission = vi.fn().mockResolvedValue(undefined);
 const mockRejectSubmission = vi.fn().mockResolvedValue(undefined);
+let mockSubmissions: Array<{ id: string; type: string; originalId: string; submittedBy: string; submittedAt: string; status: string }> = [];
 
 vi.mock('../../hooks/useCommunityStore', () => ({
   useCommunityStore: () => ({
-    submissions: [],
+    submissions: mockSubmissions,
     fetchSubmissions: mockFetchSubmissions,
     approveSubmission: mockApproveSubmission,
     rejectSubmission: mockRejectSubmission,
@@ -45,10 +46,23 @@ vi.mock('zustand/react/shallow', () => ({
 
 import { AdminPanel } from './AdminPanel';
 
+const SAMPLE_SUBMISSION = {
+  id: 'sub-1',
+  type: 'debate',
+  originalId: 'orig-abc123',
+  submittedBy: 'user@test.com',
+  submittedAt: '2026-01-01T00:00:00Z',
+  status: 'pending',
+};
+
 describe('AdminPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProfile = { isAdmin: true };
+    mockSubmissions = [];
+    mockFetchSubmissions.mockResolvedValue(undefined);
+    mockApproveSubmission.mockResolvedValue(undefined);
+    mockRejectSubmission.mockResolvedValue(undefined);
   });
 
   it('renders the admin header and tab bar', () => {
@@ -98,5 +112,26 @@ describe('AdminPanel', () => {
     await user.click(screen.getByText('Enrichment'));
     expect(screen.getByText('Enrichment Repair')).toBeInTheDocument();
     expect(screen.getByText('All nodes are fully enriched.')).toBeInTheDocument();
+  });
+
+  it('shows "Already approved" toast when approve returns 409', async () => {
+    const user = userEvent.setup();
+    mockSubmissions = [SAMPLE_SUBMISSION];
+    const err409 = Object.assign(new Error('conflict'), { httpStatus: 409 });
+    mockApproveSubmission.mockRejectedValueOnce(err409);
+    render(<AdminPanel />);
+    await user.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => expect(screen.getByText(/Already approved/)).toBeInTheDocument());
+    expect(screen.queryByText(/^Error:/)).not.toBeInTheDocument();
+  });
+
+  it('shows generic error toast when approve returns a non-409 error', async () => {
+    const user = userEvent.setup();
+    mockSubmissions = [SAMPLE_SUBMISSION];
+    mockApproveSubmission.mockRejectedValueOnce(new Error('Server error'));
+    render(<AdminPanel />);
+    await user.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => expect(screen.getByText(/Error: Server error/)).toBeInTheDocument());
+    expect(screen.queryByText(/Already approved/)).not.toBeInTheDocument();
   });
 });

--- a/taxonomy-editor/src/renderer/components/settings/AdminPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/AdminPanel.tsx
@@ -186,8 +186,9 @@ export function AdminPanel() {
       setMsg('Submission approved');
       void fetchSubmissions(filter || undefined);
     } catch (err) {
-      getGlobalRecorder()?.record({ type: 'system.error', component: 'AdminPanel', level: 'error', message: 'Failed to approve submission', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
-      setMsg(`Error: ${err instanceof Error ? err.message : String(err)}`);
+      const is409 = (err as { httpStatus?: number }).httpStatus === 409;
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'AdminPanel', level: is409 ? 'info' : 'error', message: is409 ? 'Approve 409 — already approved (benign)' : 'Failed to approve submission', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+      setMsg(is409 ? 'Already approved — no action needed.' : `Error: ${err instanceof Error ? err.message : String(err)}`);
     }
     setTimeout(() => setMsg(null), TOAST_DURATION_INFO);
   };

--- a/taxonomy-editor/src/renderer/components/settings/CommunityReviewViewer.test.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/CommunityReviewViewer.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@bridge', () => ({
+  api: {
+    adminReviewDetail: vi.fn(),
+    adminReviewAction: vi.fn(),
+    trackEvent: vi.fn(),
+  },
+}));
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: vi.fn() }),
+}));
+vi.mock('@lib/electron-shared/povMeta', () => ({
+  POV_META: {
+    accelerationist: { color: '#ef4444', label: 'Accelerationist' },
+    safetyist: { color: '#3b82f6', label: 'Safetyist' },
+    skeptic: { color: '#22c55e', label: 'Skeptic' },
+  },
+}));
+
+import { api } from '@bridge';
+import { CommunityReviewViewer } from './CommunityReviewViewer';
+
+const MOCK_DETAIL = {
+  submissionId: 'sub-abc',
+  type: 'debate',
+  submitter: 'user@test.com',
+  submittedAt: '2026-01-01T00:00:00Z',
+  preview: 'Test debate preview',
+  metadata: {},
+  sanitization: { willStrip: [], willAdd: [] },
+};
+
+describe('CommunityReviewViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.adminReviewDetail).mockResolvedValue(MOCK_DETAIL);
+    vi.mocked(api.adminReviewAction).mockResolvedValue(undefined);
+  });
+
+  it('shows "Already promoted" toast when promote returns 409', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.adminReviewAction).mockRejectedValueOnce(new Error('POST action failed: HTTP 409'));
+    render(<CommunityReviewViewer groupId="group-1" />);
+    await screen.findByRole('button', { name: 'Promote' });
+    await user.click(screen.getByRole('button', { name: 'Promote' }));
+    await waitFor(() => expect(screen.getByText(/Already promoted/)).toBeInTheDocument());
+    expect(screen.queryByText(/^Error:/)).not.toBeInTheDocument();
+  });
+
+  it('shows generic error toast when promote returns a non-409 HTTP error', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.adminReviewAction).mockRejectedValueOnce(new Error('POST action failed: HTTP 500'));
+    render(<CommunityReviewViewer groupId="group-1" />);
+    await screen.findByRole('button', { name: 'Promote' });
+    await user.click(screen.getByRole('button', { name: 'Promote' }));
+    await waitFor(() => expect(screen.getByText(/Error:/)).toBeInTheDocument());
+    expect(screen.queryByText(/Already promoted/)).not.toBeInTheDocument();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/settings/CommunityReviewViewer.tsx
+++ b/taxonomy-editor/src/renderer/components/settings/CommunityReviewViewer.tsx
@@ -336,14 +336,18 @@ export function CommunityReviewViewer({ groupId, onActionComplete }: CommunityRe
       setToast('Submission promoted');
       onActionComplete?.();
     } catch (err) {
+      // adminReviewAction throws "POST action failed: HTTP {N}" — extract via regex to
+      // avoid substring false-positives. Degrades gracefully to generic toast on format drift.
+      const httpStatus = /HTTP (\d+)/.exec((err as Error).message ?? '')?.[1];
+      const is409 = httpStatus === '409';
       getGlobalRecorder()?.record({
         type: 'system.error',
         component: 'CommunityReviewViewer',
-        level: 'error',
-        message: 'Failed to promote community submission',
+        level: is409 ? 'info' : 'error',
+        message: is409 ? 'Promote 409 — already promoted (benign)' : 'Failed to promote community submission',
         error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
       });
-      setToast(`Error: ${(err as Error).message}`);
+      setToast(is409 ? 'Already promoted — no action needed.' : `Error: ${(err as Error).message}`);
     } finally {
       setBusy(null);
       setTimeout(() => setToast(null), 4000);


### PR DESCRIPTION
## Summary
- `CommunityReviewViewer.handlePromote`: detects HTTP 409 via `/HTTP (\d+)/` regex, records `system.error` at `level:info`, shows "Already promoted — no action needed." toast
- `AdminPanel.handleApprove`: detects 409 via `.httpStatus` property (same as bridgePost), same benign treatment
- 4 new test cases (2 per component): 409 benign path + generic error path

## Notes
- 409 branch is **inert until t/3034** (ServerAPI) lands — safe to ship now
- `level:info` on 409 also satisfies t/3035 (FR level discipline)
- Design approved at t/3038#2

## Test plan
- [x] `AdminPanel.test.tsx` — 9 tests pass (2 new: 409 benign, non-409 generic)
- [x] `CommunityReviewViewer.test.tsx` — 2 tests pass (new file)
- [x] renderer TSC: 0/0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
