### PR TITLE
fix(taxonomy): Get-Situation reads the data repo, not the empty code-repo taxonomy dir

### DIFF
--- a/scripts/AITriad/Public/Get-Situation.ps1
+++ b/scripts/AITriad/Public/Get-Situation.ps1
@@ -30,7 +30,9 @@ function Get-Situation {
     .PARAMETER First
         Return only the first N matching situations.
     .PARAMETER RepoRoot
-        Path to the repository root.
+        Test/override hook only. When set, situations.json is read from
+        <RepoRoot>/taxonomy/Origin. Left empty in production so the path resolves via
+        Get-TaxonomyDir (→ .aitriad.json → the data repo, where situations.json lives).
     .EXAMPLE
         Get-Situation
         # All situations.
@@ -79,7 +81,11 @@ function Get-Situation {
 
         [int]$First = 0,
 
-        [string]$RepoRoot = $script:RepoRoot
+        # Test/override hook only — left empty in production so the taxonomy dir resolves via
+        # Get-TaxonomyDir (→ .aitriad.json → data repo). Defaulting to the code-repo root sent
+        # the reader to <code-repo>\taxonomy\Origin, which does not exist — situations.json
+        # lives in the DATA repo — so Get-Situation always reported "No situations.json found".
+        [string]$RepoRoot = ''
     )
 
     Set-StrictMode -Version Latest


### PR DESCRIPTION
`Get-Situation` always reported "No situations.json found" because `-RepoRoot` defaulted to `$script:RepoRoot` (the **code**-repo root, always truthy), so the resolver never fell through to `Get-TaxonomyDir`. It built `<code-repo>\taxonomy\Origin\situations.json` — a path that doesn't exist; situations.json lives in the **data** repo (`../ai-triad-data`, per `.aitriad.json`).

**Fix:** default `-RepoRoot` to `''` so production resolves via `Get-TaxonomyDir`; `-RepoRoot` stays a test/override hook.

**Verified:** `Get-Situation` now returns all **443** live situations with populated per-POV evidence counts. Pester 10/10.

Self-cert /add-ps-cmdlet (bugfix to existing read cmdlet; no new API/schema).