### PR TITLE
fix(debate): gate situation_debate.* FR events to situation debates only (t/3032 follow-up)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -239,15 +239,19 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
     const { activeDebate, addTranscriptEntry, saveDebate, debateGenerating } = get();
     if (!activeDebate) return;
 
+    // t/3032 (DebateTool follow-up): the situation_debate.* observability events are
+    // situations-specific — gate them so they don't fire for document/url/topic clarification.
+    const isSituation = activeDebate.source_type === 'situations';
+
     // Guard: don't run if already generating or if clarification already exists.
     // t/3032: emit a skipped marker at each guard so a dump distinguishes
     // "trigger fired but declined to generate (with reason)" from "never fired".
     if (debateGenerating) {
-      getGlobalRecorder()?.record({ type: 'situation_debate.generation_skipped', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_skipped', data: { reason: 'already_generating' } });
+      if (isSituation) getGlobalRecorder()?.record({ type: 'situation_debate.generation_skipped', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_skipped', data: { reason: 'already_generating' } });
       return;
     }
     if (activeDebate.transcript.some(e => e.type === 'clarification')) {
-      getGlobalRecorder()?.record({ type: 'situation_debate.generation_skipped', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_skipped', data: { reason: 'clarification_exists' } });
+      if (isSituation) getGlobalRecorder()?.record({ type: 'situation_debate.generation_skipped', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_skipped', data: { reason: 'clarification_exists' } });
       return;
     }
 
@@ -266,7 +270,7 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
     try {
       // t/3032: the clarification trigger point — emitted immediately before the first AI call
       // dispatches, so a dump shows the trigger fired (vs. never firing → absent ai.request).
-      getGlobalRecorder()?.record({ type: 'situation_debate.generation_trigger', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_trigger', data: { model, phase: 'clarification' } });
+      if (isSituation) getGlobalRecorder()?.record({ type: 'situation_debate.generation_trigger', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'situation_debate.generation_trigger', data: { model, phase: 'clarification' } });
       const { text } = await generateTextWithProgress(prompt, model, `Generating clarifying questions (${model})`, set);
       if (!isStillValid()) { getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'warn', debate_id: activeDebate?.id, message: 'runClarification aborted: guard failed after question generation' }); return; }
       let questions: string[];
@@ -301,7 +305,7 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
       // t/3032: dedicated observability marker (greppable by type) so a dump distinguishes
       // trigger-fired-and-failed from trigger-never-fired. The ADR-003 system.error above
       // carries the stack; this marker carries the spec's { debate_id, error.name, error.message }.
-      getGlobalRecorder()?.record({ type: 'situation_debate.generation_error', component: 'debate-store', level: 'error', debate_id: activeDebate?.id, message: 'situation_debate.generation_error', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
+      if (isSituation) getGlobalRecorder()?.record({ type: 'situation_debate.generation_error', component: 'debate-store', level: 'error', debate_id: activeDebate?.id, message: 'situation_debate.generation_error', error: { name: (err as Error).name ?? 'Error', message: String(err) } });
       addTranscriptEntry({
         type: 'system',
         speaker: 'system',


### PR DESCRIPTION
DebateTool follow-up (p/61#76): gate the 3 `situation_debate.*` FR events in `runClarification` behind `activeDebate.source_type === 'situations'` (via a single `isSituation` flag), so they no longer fire for document/url/topic clarification. ADR-003 `system.error` in the catch stays unconditional.

**Self-cert /trivial-change**: 1 file, ~6 lines, no new API/interface/schema/auth/data-model. renderer-tsc 0/0 · eslint 0 · vitest useDebateStore 267/267.

Follow-up to t/3032 (merged 1e18002e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)