### PR TITLE
docs(cl): theory-of-success set — Situations/Cruxes/Entities/Vocabulary/Organizations (t/3041–t/3045)

### DIFF
--- a/research/comp-linguist/docs/theory-of-success/theory-of-success-cruxes.md
+++ b/research/comp-linguist/docs/theory-of-success/theory-of-success-cruxes.md
@@ -1,0 +1,57 @@
+# Theory of Success: Cruxes
+
+**Author:** Computational Linguist (AI Triad Research). **Ticket:** t/3042. **Date:** 2026-08-26.
+
+## What a Crux is
+
+A Crux (`crux-NNN`) is the load-bearing point of disagreement in a debate: the specific question whose answer would actually move a camp's position. "Does mechanistic interpretability provide a reliable, high-fidelity signal of model intent that can prevent deceptive alignment?" is a crux. A debate is only as good as its ability to find and engage the real crux rather than argue past it.
+
+Structure (as seen in the Cruxes view and the crux registry):
+- **Category:** Empirical, Values, or Definitional. The category names how the crux could resolve: by evidence, by a value tradeoff, or by pinning a definition. The corpus is roughly 399 Empirical, 127 Values, 60 Definitional.
+- **Resolution status:** Active, Resolved, or Irreducible. Irreducible marks a genuine values-level disagreement that will not resolve, which is a legitimate outcome, not a failure.
+- **Source debates** (the `×N` recurrence count): a crux is extracted from debates and often recurs across several.
+- **Linked nodes:** the taxonomy positions that diverge at this crux.
+- **External evidence:** an evidence URL and note, used mainly for Empirical cruxes.
+- **`question_form`:** a neutral, presentational restatement of the crux as a question.
+
+## The theory of success
+
+Finding the true crux is the point of a debate. Two camps can exchange arguments for hours and never touch the question that actually separates them; a crux makes that question explicit, trackable, and, where it is empirical, resolvable by evidence. Cruxes are how disagreement is made precise instead of rhetorical.
+
+**A Crux succeeds when it names the actual disagreement rather than a strawman, is categorized correctly so the right resolution mechanism applies, is engaged by the debaters, and carries a resolution status that honestly reflects reality without false convergence.** The corpus succeeds when cruxes are deduplicated across debates, neutrally phrased, and grounded in linked nodes and (for empirical ones) evidence.
+
+Success criteria, each measurable:
+1. **Engagement.** `crux_addressed_rate` / `crux_addressed_ratio` are high: debaters engage the actual crux, not adjacent ground.
+2. **Correct categorization.** Empirical cruxes route to evidence, Values cruxes to an explicit tradeoff, Definitional cruxes to a definition; genuinely irreducible cruxes are flagged as such rather than argued forever.
+3. **Honest resolution.** Convergence and resolution are read un-pooled over decision-point-reached runs (via `computeConvergenceWithCensoring`), so an undecided or censored crux is never laundered as resolved. `crux_resolution_divergence_rate` is low, meaning camps agree on whether the crux resolved.
+4. **Neutral phrasing.** `question_form` does not smuggle a camp's framing.
+5. **Grounding and dedup.** Linked nodes are present, and a recurring crux is merged into one entry with a recurrence count, not duplicated.
+
+Failure modes, each an active concern:
+- **Talking past the crux** (low `crux_addressed_rate`): the debate never touches the real disagreement.
+- **Miscategorization**: treating a Values crux as Empirical invites endless "evidence" that can never resolve it.
+- **False convergence**: declaring a crux resolved when the run was censored or the verdict was undecided. This is the reason the censoring gate (t/1671) reads convergence un-pooled and keys `censored` off the run-level termination reason, not the per-crux undecided verdict; when `n_unknown` dominates a window, the headline is reported as untrustworthy rather than interpreted.
+- **Biased phrasing**: a `question_form` that presupposes one camp's answer.
+- **Duplication**: the same crux scattered across many un-merged entries, hiding its true recurrence.
+
+## How Cruxes are generated
+
+- **Extraction from debates.** Cruxes are identified as the load-bearing disagreements during and after a debate, from claim extraction and the argument network. A crux that appears in multiple debates accumulates a source-debate count (`×N`).
+- **Neutral question-form enrichment (t/1507).** An LLM rewrites each crux into a neutral question; neutrality is prompt-enforced and sample-reviewed. The `question_form` is presentational and carries no scoring weight, so a phrasing slip cannot bias a metric.
+- **Categorization.** Each crux is typed Empirical / Values / Definitional, and its resolution status is tracked Active / Resolved / Irreducible.
+- **Registry.** `cruxRegistry.ts` holds cruxes with their linked nodes and source debates.
+
+## How Cruxes are used
+
+- **Debate steering.** Cruxes focus a debate on the real disagreement (the CRUX_FOCUS prompt family), and `crux_addressed_rate` measures whether the debaters actually engaged them.
+- **Convergence measurement.** Crux resolution across a debate feeds `convergence_score_at_termination` and `crux_resolution_divergence_rate`, read un-pooled with the censoring gate so termination-driven censoring does not masquerade as agreement.
+- **Situation alignment.** `situation_crux_alignment` asks whether injected situations shape the cruxes the debate engages.
+- **Taxonomy feedback.** `cruxTaxonomyFeedback.ts` uses cruxes to surface gaps and tensions in the taxonomy, so recurring disagreements drive taxonomy refinement.
+- **Evidence attachment.** Empirical cruxes can carry external evidence URLs, moving them toward resolution by evidence rather than rhetoric.
+- **Browsing and analysis.** The Cruxes view filters by category and by resolution status, and each crux shows its source debates and linked nodes.
+
+## Success metrics and current gaps
+
+- **Primary engagement metric:** `crux_addressed_rate` / `crux_addressed_ratio`.
+- **Resolution honesty:** convergence read un-pooled with the censoring gate (t/1671); the standing caveat is that a window dominated by `n_unknown` is untrustworthy and must be reported as such.
+- **Open items:** `question_form` neutrality is sample-reviewed, not human-validated; category assignment and irreducibility flags are stipulated rather than validated against an adjudicated set.

--- a/research/comp-linguist/docs/theory-of-success/theory-of-success-entities.md
+++ b/research/comp-linguist/docs/theory-of-success/theory-of-success-entities.md
@@ -1,0 +1,51 @@
+# Theory of Success: Entities
+
+**Author:** Computational Linguist (AI Triad Research). **Ticket:** t/3043. **Date:** 2026-08-26.
+
+## What an Entity is
+
+An Entity is a named real-world referent that the literature actually talks about: a person, an institution, an event, a piece of legislation, or an artifact. "AI Action Plan" (legislation, also known as "Trump AI Action Plan"), "AI Impact Summit" (event), "Apollo Project" (event, also "Apollo Program"). Where Situations are scenarios and Cruxes are disagreements, Entities are the concrete actors, laws, events, and objects those scenarios and disagreements are about.
+
+Structure (as seen in the Entities view):
+- **Type:** person, artifact, event, legislation, or institution. Current counts are roughly person 9, artifact 43, event 12, legislation 5, institution 9, for 78 total.
+- **Canonical name** plus **aliases** (the "also:" variants), so "Trump AI Action Plan" resolves to the one canonical "AI Action Plan."
+- **Status lifecycle:** proposed, approved, deprecated. At present all 78 are proposed and none are approved, which is the single most important fact about the current state.
+
+## The theory of success
+
+Entities ground abstract claims in reality. A debate about "a government Manhattan Project for AI" is anchored when it can point to the actual AI Action Plan, the actual AI Impact Summit, the actual institutions involved. Entities are what let the system connect a claim or situation to the real actors and instruments being discussed, resolve the same referent across many documents, and build an intellectual lineage.
+
+**An Entity succeeds when it unambiguously identifies one real referent, with the correct type, a canonical name, and aliases that fold in the variant spellings; when it is deduplicated against the rest of the set; and when it has passed curation from proposed to approved so only vetted entities are treated as canonical.** The corpus succeeds when it covers the referents the literature discusses, resolves coreference across documents, and does not proliferate near-duplicates or unvetted noise.
+
+Success criteria, each checkable:
+1. **Correct typing.** The person / artifact / event / legislation / institution tag matches the referent.
+2. **Canonicalization and alias resolution.** One entity per real referent, with variant names captured as aliases rather than spawning duplicate entities.
+3. **Curation lifecycle.** Proposed entities are reviewed and promoted to approved; the approved gate keeps unvetted extractions out of the canonical set.
+4. **Grounding and linkage.** Entities connect claims, situations, debates, and source documents, and feed the Intellectual Lineage.
+5. **Coverage.** The entities the corpus actually discusses are represented.
+
+Failure modes, each an active concern:
+- **Duplicate or unresolved aliases**: the same referent living as two entities because a variant name was not folded in.
+- **Mistyping**: an event tagged as an artifact, which breaks type-filtered retrieval.
+- **The approval gap**: 78 proposed and 0 approved means the entire set is currently unvetted. Nothing has passed the curation gate, so downstream consumers cannot yet trust "approved" as a signal. Clearing this backlog is the first success milestone.
+- **Extraction noise**: spurious entities pulled from documents by the extractor.
+- **Cross-document coreference failure**: the same person or law not recognized as the same entity across sources.
+
+## How Entities are generated
+
+- **Extraction from documents.** Entities are pulled from the source corpus by the entity-extraction pipeline (the first live batch landed under t/1826), which identifies candidate persons, institutions, events, legislation, and artifacts, along with their alias variants.
+- **Schema.** The entity types and fields follow the entity-ontology proposal (`research/comp-linguist/designs/entity-ontology-proposal.md`).
+- **Proposed on extraction.** New entities enter as proposed; human curation promotes them to approved or marks them deprecated. This is the same propose-then-confirm discipline used elsewhere in the project, and it is the reason "0 approved" is a backlog signal rather than a bug.
+
+## How Entities are used
+
+- **Grounding.** Entities anchor claims, situations, and debates to concrete real-world referents, so an argument is about the actual law or actor rather than an abstraction.
+- **Cross-document linkage.** The same entity recognized across multiple sources ties otherwise separate documents together.
+- **Intellectual Lineage.** Entities feed the lineage view that traces which actors, works, and events shaped a position.
+- **Search and filter.** The Entities view supports search by name, alias, and type, and filtering by the proposed / approved / deprecated status.
+
+## Success metrics and current gaps
+
+- **Curation coverage:** the fraction of entities promoted from proposed to approved, currently 0 of 78. This is the headline gap.
+- **Alias / dedup quality:** the rate of unresolved duplicate referents (candidate for a dedup audit, analogous to the situation and crux dedup concerns).
+- **Typing accuracy and extraction precision:** currently stipulated by the extractor, not validated against an adjudicated set.

--- a/research/comp-linguist/docs/theory-of-success/theory-of-success-organizations.md
+++ b/research/comp-linguist/docs/theory-of-success/theory-of-success-organizations.md
@@ -1,0 +1,50 @@
+# Theory of Success: Organizations
+
+**Author:** Computational Linguist (AI Triad Research). **Ticket:** t/3045. **Date:** 2026-08-26.
+
+## What an Organization is
+
+An Organization is a real-world institutional actor in the AI policy ecosystem, carrying a per-camp stance profile derived from its public positions: Anthropic (corporate, San Francisco), AI Now Institute (research lab, New York), Andreessen Horowitz (corporate, Menlo Park), Center for AI Safety (advocacy, San Francisco), Electronic Frontier Foundation (civil society), European AI Office (regulatory, Brussels), Future of Life Institute (advocacy). Where Entities are named referents in general, Organizations are the subset that hold and express positions, so the system can map the abstract four-camp model onto who actually argues each side in the world.
+
+Structure (as seen in the Organizations view, about 25 organizations):
+- **Type:** corporate, research lab, advocacy, civil society, or regulatory.
+- **Identity:** name, short name or acronym (a16z, CAIS, EFF), and location (city, country).
+- **Stance profile:** a per-camp alignment across the three camps (accelerationist, safetyist, skeptic), shown as the ACC / SAF / SKE indicators, ideally derived from the organization's public claims rather than asserted.
+
+## The theory of success
+
+The four-camp taxonomy is a model of positions; Organizations are how that model is grounded in reality. Knowing that a claim is "accelerationist" is abstract; knowing that Andreessen Horowitz and the AI Now Institute sit on opposite sides of a specific claim makes the model concrete and checkable against the public record. Organizations turn the taxonomy from a theory of positions into a map of who holds them.
+
+**An Organization succeeds when it is correctly identified and typed, and when its per-camp stance profile is derived from actual matched evidence rather than asserted.** The corpus succeeds when it covers the influential organizations across the ecosystem and each stance is traceable to the public claims that justify it, through a matching process with known precision.
+
+Success criteria, each checkable:
+1. **Correct identity.** Name, type, and location match the real organization, with acronyms and aliases resolved.
+2. **Evidence-grounded stance.** The per-camp alignment is derived from organization-to-claim matching (public statements matched to taxonomy claims), not stipulated by an annotator.
+3. **Matching quality.** The org-claim match gate performs at acceptable precision, and matches are reviewed rather than accepted blind.
+4. **Coverage across sectors.** Corporate labs, research institutes, advocacy groups, civil society, and regulators are all represented, so the stance map is not skewed to one sector.
+5. **Neutrality.** Stance profiles reflect the evidence, not the annotator's priors, which matters especially because organizations are named and reputationally sensitive.
+
+Failure modes, each a real concern:
+- **Ungrounded stance**: labeling an organization accelerationist or safetyist without matched claims behind it, which is both wrong and reputationally risky.
+- **Matching false positives**: a single organization absorbing a disproportionate share of claims (org-014 accounted for about 45% of claims in the first batch), which the cross-document family-key rule exists to correct.
+- **Coverage gaps or duplicates**: influential organizations missing, or one organization split across two records.
+- **Stale stances**: an organization's position shifts and the profile is not refreshed.
+
+## How Organizations are generated
+
+- **Curated and extracted.** The organization list is assembled from the corpus and curated, with type and location attached.
+- **Stance via org-claim matching.** `Invoke-OrgClaimMatching` matches an organization's public statements to taxonomy claims by cosine similarity. The current gates are a single-claim threshold of 0.60 cosine and a cross-document-family minimum of 2 claims, where the family key is the source id stripped of its trailing year suffix so a trio of related documents collapses to one unit. This family rule proved load-bearing on the first batch, where org-014 would otherwise have dominated. Proposals are reviewed, and rejections are kept as telemetry by design so the accept rate per cosine band can eventually take the threshold off "stipulated."
+- **Profile assembly.** Matched claims aggregate into the per-camp stance indicators.
+
+## How Organizations are used
+
+- **Grounding camp positions.** Organizations show which real institutions hold a given camp position, turning an abstract stance into a concrete example.
+- **Stance mapping.** The per-camp alignment lets analysis see where an organization sits and how organizations cluster or oppose.
+- **Evidence for debates.** Organizational stances serve as real-world instantiations of camp positions, so a debate can cite who actually argues a side.
+- **Browsing and analysis.** The Organizations view supports search and filtering by type and by camp alignment.
+
+## Success metrics and current gaps
+
+- **Stance grounding rate:** the fraction of stance assignments backed by matched claims rather than asserted.
+- **Matching precision:** accept rate per cosine band from reviewer decisions, which is the planned path to take the 0.60 threshold off "stipulated" (recorded in the metric provenance register).
+- **Open items:** the 0.60 single-claim threshold and the 2-claim family minimum are stipulated pending that review-derived calibration; coverage and dedup are not yet audited against a reference list.

--- a/research/comp-linguist/docs/theory-of-success/theory-of-success-situations.md
+++ b/research/comp-linguist/docs/theory-of-success/theory-of-success-situations.md
@@ -1,0 +1,56 @@
+# Theory of Success: Situations
+
+**Author:** Computational Linguist (AI Triad Research). **Ticket:** t/3041. **Date:** 2026-08-26.
+
+## What a Situation is
+
+A Situation is a DOLCE-typed concept node (`sit-NNN`) representing a concrete real-world scenario or state of affairs relevant to AI policy: "A Government 'Manhattan Project' for AI," "Internal Deployment Scope Expansion," "Democratic Failure to Curb Digital Corporate Power." It occupies the middle layer between the abstract four-camp taxonomy and a live debate. A camp holds beliefs in the abstract; a Situation is the specific circumstance those beliefs get tested against.
+
+Schema (in `ai-triad-data/taxonomy/Origin/situations.json`):
+- `label`, `description` with genus-differentia `Encompasses:` / `Excludes:` boundaries.
+- `interpretations`: per-POV (accelerationist / safetyist / skeptic), each a decomposed `{belief, desire, intention, summary}` that states how that camp reads the situation.
+- `linked_nodes`: the per-POV taxonomy nodes that serve as supporting evidence.
+- `situation_refs`: reverse links to debates that substantively engaged the situation.
+- `conflict_ids`, `source_refs`, `parent_id` / `parent_relationship` (an `is_a` hierarchy), plus a per-situation embedding (`sit-` prefix, all-MiniLM-L6-v2).
+
+## The theory of success
+
+A Situation exists to turn an abstract, camp-level disagreement into a concrete scenario the debate engine can reason about. Argument over "should we regulate internal AI deployments" is sharper when anchored to a specific situation than argued in the abstract, because a situation forces each camp to take a concrete stance and supplies real-world texture the debate can grip.
+
+**A Situation succeeds when, injected into a debate, it measurably shapes the substance of the argument rather than decorating it; each camp's interpretation is genuine and distinct; and it carries real per-POV supporting evidence tying it to the taxonomy.** The corpus succeeds when it is curated, ontologically grounded, non-degenerate, non-redundant, and broad enough to cover the policy space.
+
+Success criteria, each measurable:
+1. **Substance-shaping.** `situation_crux_alignment` is high: injected situations shift what the debate actually argues about, verified by sampling transcripts (do injected situations shape substance or just decorate?).
+2. **Interpretive integrity.** Every non-deprecated situation carries non-degenerate per-POV belief, desire, and intention, enforced by the BDI-decomposition compliance gate.
+3. **Grounded evidence.** Each situation links to genuine per-POV supporting nodes rather than an empty evidence panel.
+4. **Provenance clarity.** Machine-generated content is marked and not read back as authoritative fact.
+5. **Coverage without redundancy.** The corpus spans the policy space without near-duplicate situations.
+
+Failure modes, each an active concern:
+- **Decoration, not shaping** (low crux alignment): the central situation-injection quality risk.
+- **Degenerate interpretations** (literal `"null"` or empty belief/desire/intention): found and fixed under t/3018, with the compliance check hardened to reject null-sentinels.
+- **Empty supporting evidence**: 97% of situations showed no per-POV evidence, which motivated the WS-B evidence-link work (t/2990).
+- **Pipeline-emitted, un-decomposed**: the generation pipeline emits flat-string interpretations that red the compliance baseline until backfilled (recurring; tracked as t/3011).
+- **Lost-in-the-Middle**: a genuinely relevant situation buried by injection order.
+- **Provenance laundering**: machine-proposed evidence read back into a prompt as established fact (the risk named in the tool-result-authority review, arXiv 2608.14992).
+
+## How Situations are generated
+
+- **Sources.** Automated pipeline sync ("sync pipeline outputs" commits, e.g. sit-476/477), earlier workflow-app batches (sit-448–470), and hand-authored curation.
+- **BDI decomposition.** New situations often arrive with flat-string or empty per-POV interpretations. The `enrichment.situation-bdi-decomposition` step (CL authors or signs off) turns each POV into a distinct `{belief, desire, intention}`, where belief is what the camp holds true, desire is the state it wants, and intention is how it will act or argue.
+- **Compliance gate.** `Test-SituationBdiDecomposition` requires each non-deprecated situation to carry non-empty per-POV belief, desire, and intention, hardened under t/3018 to reject null-sentinels (`null` / `none` / `n/a` / `tbd` / `-`). A `[DEPRECATED]` description prefix exempts a situation from the count.
+- **Embedding.** Each situation is embedded (all-MiniLM-L6-v2, description-based) for retrieval and injection scoring.
+
+## How Situations are used
+
+- **Debate injection.** `situationScoring.ts` ranks situations before a debate (a wisdom-potential score over relevance, diversity, freshness, BDI entropy, and conflict openness) and re-scores them mid-debate for context injection as cruxes emerge, weighting relevance more heavily mid-debate. A cap (`situation_max_nodes`) bounds how many are injected, and injection order is managed against Lost-in-the-Middle.
+- **Framing.** Each camp's interpretation (belief, desire, intention) frames how that camp argues the situation, so the injected context is not neutral background but a per-camp reading.
+- **Supporting-evidence surface.** The per-POV `linked_nodes` render in the Situations detail view as each camp's supporting evidence. WS-B (t/2990) auto-proposes embedding-ranked situation-to-node links, provenance-stamped, at precision@3 ≈ 0.63, with a read-time score filter as the quality lever.
+- **Post-debate feedback.** `situationRefs.ts` (t/193) extracts which situations a completed debate substantively engaged and writes them back as `situation_refs`, closing the loop between debate and taxonomy.
+- **Conflict analysis.** `conflict_ids` tie situations into the QBAF conflict graph.
+
+## Success metrics and current gaps
+
+- **Primary effectiveness metric:** `situation_crux_alignment` (do injected situations shape debate substance).
+- **Interpretive integrity:** the BDI-decomposition compliance baseline (currently 442/442 non-deprecated, hardened against null-sentinels).
+- **Open gaps:** empty supporting evidence pending the WS-B batch apply (not yet live on data); the recurring pipeline-un-decomposed emit (t/3011); and the standing provenance-laundering caution for any machine content fed back into generation.

--- a/research/comp-linguist/docs/theory-of-success/theory-of-success-vocabulary.md
+++ b/research/comp-linguist/docs/theory-of-success/theory-of-success-vocabulary.md
@@ -1,0 +1,52 @@
+# Theory of Success: Vocabulary
+
+**Author:** Computational Linguist (AI Triad Research). **Ticket:** t/3044. **Date:** 2026-08-26.
+
+## What the Vocabulary is
+
+The Vocabulary is the controlled dictionary of canonical concept terms that keeps the whole system speaking one language. Each entry is a canonical `snake_case` key with a human-readable gloss and a camp association: `accountability_algorithmic` ("accountability (algorithmic)"), `accountability_institutional`, `accountability_market`, `autonomy_human` / `autonomy_individual` / `autonomy_machine`, `bias_systemic` / `bias_technical`, `capabilities_scaling`, `capability_frontier`. It is the concrete expression of the project's guiding principle: meaning is carried by a controlled term list in prompts and JSON, not by OWL/RDF triples. Vocabulary over formalism.
+
+The Vocabulary view has three parts:
+- **Dictionary** (about 45 terms): the canonical terms.
+- **Colloquial** (about 24): informal phrasings mapped to their canonical term.
+- **Lint**: a check that flags content using off-vocabulary language.
+
+## The theory of success
+
+Without a controlled vocabulary, "accountability" means whatever each node, claim, and debate turn happens to call it, and the system loses the ability to retrieve, aggregate, or cross-reference reliably. The Vocabulary fixes the referent: it pins which accountability (algorithmic versus institutional versus market), so that everything downstream can group and compare on a stable key.
+
+**The Vocabulary succeeds when every concept the system reasons about has exactly one canonical term, informal variants resolve to it, and content across the corpus uses the canonical terms consistently, with the granularity to distinguish genuine senses without proliferating redundant near-synonyms.** It is the load-bearing normalization layer under Situations, Cruxes, Entities, and the taxonomy nodes.
+
+Success criteria, each checkable:
+1. **Canonicalization.** One term per concept-sense, with genuine senses disambiguated by the qualifier pattern (`accountability_algorithmic` versus `_institutional` versus `_market`).
+2. **Colloquial coverage.** Informal phrasings in real content resolve to a canonical term rather than drifting off-vocabulary.
+3. **Lint compliance.** Content uses canonical vocabulary, and the Lint check surfaces violations for cleanup.
+4. **Camp awareness.** Terms carry camp association where a concept is camp-inflected, while the dictionary itself stays shared across camps.
+5. **Right granularity.** The dictionary distinguishes real senses without minting redundant duplicates.
+
+Failure modes:
+- **Drift**: one concept referred to by several un-normalized strings, which quietly defeats retrieval and aggregation.
+- **Wrong granularity**: too many near-synonyms, or a single term conflating two distinct senses.
+- **Colloquial gaps**: informal text that never maps to a canonical term.
+- **Lint debt**: off-vocabulary content that accumulates un-flagged.
+- **Formalism creep**: expanding the vocabulary into a heavyweight ontology, against the vocabulary-over-formalism guard.
+
+## How the Vocabulary is generated
+
+- **Curated dictionary.** Canonical terms (key, gloss, camp) are curated and grown as new concepts appear in the taxonomy and debates.
+- **Colloquial mapping.** Informal phrasings observed in content are collected and mapped to their canonical term, so the system can normalize natural language onto the controlled set.
+- **Lint.** An automated check compares content against the dictionary and flags off-vocabulary usage, turning vocabulary compliance into a reviewable signal rather than an aspiration.
+
+## How the Vocabulary is used
+
+- **Normalization.** Nodes, claims, situations, and cruxes reference canonical terms, so the same concept reads the same way everywhere.
+- **Retrieval and aggregation.** Shared canonical keys let the system group and compare content that would otherwise be split across synonyms.
+- **Prompts and JSON.** The controlled vocabulary is used directly in prompt templates and data files, which is how the project encodes ontological meaning without formal logic.
+- **Lint enforcement.** The Lint pass keeps new content aligned to the vocabulary.
+- **Camp filtering.** Terms can be filtered by camp for camp-specific analysis.
+
+## Success metrics and current gaps
+
+- **Coverage:** the fraction of corpus concepts that have a canonical term, and of informal phrasings that resolve via the Colloquial map.
+- **Compliance:** the Lint violation rate across content, trending down.
+- **Open items:** granularity decisions (sense splits versus merges) are curator judgment and are not yet validated against a labeled disambiguation set; the guard against formalism creep is a standing editorial discipline rather than a metric.


### PR DESCRIPTION
Owner-requested set of "Theory of Success" strategy docs, **all five in one PR** as requested, one per core taxonomy concept. Each covers what success looks like, the failure modes, how the concept is **generated**, and how it is **used** — grounded in the running app views (owner screenshots) and this session's codebase knowledge.

New files under `research/comp-linguist/docs/theory-of-success/` (CL scope):
- `theory-of-success-situations.md` — t/3041
- `theory-of-success-cruxes.md` — t/3042
- `theory-of-success-entities.md` — t/3043
- `theory-of-success-vocabulary.md` — t/3044
- `theory-of-success-organizations.md` — t/3045

Docs-only. Self-checked against the doc-prose voice-tell taxonomy (em-dashes 0 across all five).

Note: the "bookmark via the app's common bookmark control" step from each request is being confirmed with the owner separately (mechanism ambiguous); this PR lands the documents.