### PR TITLE
wip(smoke): scaffold the t/3026 render-smoke harness (Playwright-Chro…

### DIFF
--- a/taxonomy-editor/package.json
+++ b/taxonomy-editor/package.json
@@ -39,6 +39,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:changed": "vitest run --changed",
+    "smoke:styled": "node smoke/run-smoke.mjs",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "depgraph": "node scripts/depgraph.mjs --stats",

--- a/taxonomy-editor/smoke/README.md
+++ b/taxonomy-editor/smoke/README.md
@@ -1,0 +1,63 @@
+# Render smoke — "surface renders styled" (t/3026)
+
+Durable gate for the failure class **single-context validation + silent degradation → invisible
+failure**: a component's CSS lives in a lazy tab-chunk that is *not* loaded on the surface that
+uses the classes, so the surface renders **unstyled with no error** (the t/3024 `.ga-*` incident;
+plus the three t/3025 orphans this smoke regression-tests).
+
+jsdom/vitest **cannot** compute stylesheet cascade → a unit test here is a false-green. This smoke
+runs in a **real browser** (Playwright-Chromium) against a **production web build** served by the
+real server, so lazy CSS code-splitting behaves exactly as in prod.
+
+## Why this shape (locked with TL p/336#198/#199 + DevOps t/3026#4)
+
+- **Playwright-Chromium vs `start:server`** (the real prod web artifact), NOT `vite preview` and NOT
+  Electron+xvfb. The bug is a Vite-bundling concern → the web profile covers the class at lowest
+  flake. Must be a **prod build** — the dev server serves unbundled (no lazy split → false green).
+- **Assertion = probe-injection.** For each surface we navigate to the tab that owns it (which loads
+  that surface's lazy chunk → injects its CSS into `<head>`), then inject a throwaway element with a
+  target class and read `getComputedStyle`. This asserts the *rule is loaded on that surface* without
+  needing real data to mount a real element — it catches the whole failure class, not one instance.
+- **Both-arms** (required, Gate Verification): a correct build **passes**; deliberately re-misfiling
+  the `.ga-*` block into `GroundingPanel.css` (a lazy diagnostics chunk) makes it **fail**. See below.
+- **Warn-first**: DevOps wires the CI job non-blocking for ≥1 green real-env cycle before promoting
+  to blocking (a flaky blocking smoke is the next incident). DevOps owns the CI flip.
+
+## Covered surfaces (reachability)
+
+| surface | tab to load its chunk | probe class | assert (computed) |
+|---|---|---|---|
+| Attributes / GraphAttributesPanel | a POV tab (`[data-tab="accelerationist"]`) | `.ga-grid-3col` | `grid-template-columns` resolves to 3 tracks |
+| HighlightedField (t/3025 fix) | POV tab (NodeDescriptionSection) | `.hl-backdrop` | `position: absolute` |
+| ApiKeyErrorMessage (t/3025 fix) | Analysis / settings surface | `.api-key-error-link` | `text-decoration` underline |
+| DataSourceCard (t/3025 fix) | `[data-tab="chat"]` (Prompt Inspector) | `.pi-node-count-preview` | `border-bottom-width` ≠ 0px |
+
+**Medium candidates to adjudicate (t/3025#1)** — same probe technique decides each: `vocab-*`,
+`qbaf-delta`/`qbaf-badge`, `claim-attribution-*`. Confirmed unstyled → fix #1561 way; styled → leave.
+
+## Run
+
+```
+# 1. Build the prod web artifact + server (once)
+npm run build:container
+# 2. Run the smoke (starts the server, waits for :7862, drives Chromium, tears down)
+npm run smoke:styled
+```
+
+`run-smoke.mjs` spawns `start:server`, `wait-on http://localhost:7862`, runs the Playwright spec,
+then kills the server. Exits non-zero on any failed assertion.
+
+## Both-arms proof (Gate Verification)
+
+- **Clean arm (pass):** `npm run build:container && npm run smoke:styled` → all surfaces styled.
+- **Deliberate-misfile arm (fail):** move the `.ga-*` block from `GraphAttributesPanel.css` back into
+  `analysis/GroundingPanel.css`, `npm run build:container && npm run smoke:styled` → the Attributes
+  probe FAILS (the diagnostics chunk that now owns `.ga-*` never loads on the POV tab). Revert after.
+
+## STATUS — scaffold; NOT yet validated against a live run
+
+Authored from the locked design + boot investigation (server `PORT=7862`; web boot may show
+`FirstRunDialog` → the spec skips it; tabs are `[data-tab="<id>"]` under `role="tablist"`). The
+selectors + probe classes are **best-effort and must be tuned against a running app**, and the
+**both-arms proof must be captured**, before this is offered to DevOps for CI wiring. That live-run
++ both-arms is the next step (route the proof to TL per t/3026#1).

--- a/taxonomy-editor/smoke/attributes-styled.smoke.mjs
+++ b/taxonomy-editor/smoke/attributes-styled.smoke.mjs
@@ -1,0 +1,68 @@
+// Render smoke (t/3026): assert key surfaces render STYLED in a real prod web build.
+// Technique = probe-injection: navigate to the tab that owns a surface (loads its lazy
+// chunk → injects that chunk's CSS into <head>), then inject a throwaway element with a
+// target class and read getComputedStyle. This asserts the RULE is loaded on that surface
+// without needing real data to mount a real element — catching the whole failure class
+// (a surface's CSS living in a chunk it doesn't load → silent unstyling; t/3024 + t/3025).
+//
+// STATUS: scaffold — selectors/probe classes are best-effort from static analysis and MUST
+// be tuned against a running app, and both-arms must be captured, before CI wiring (see README).
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.SMOKE_BASE_URL || 'http://localhost:7862';
+
+/** Inject `<div class=className>`, read one computed property, remove it. */
+async function probe(page, className, prop) {
+  return page.evaluate(({ className, prop }) => {
+    const el = document.createElement('div');
+    el.className = className;
+    document.body.appendChild(el);
+    const v = getComputedStyle(el).getPropertyValue(prop);
+    el.remove();
+    return v;
+  }, { className, prop });
+}
+
+/** Dismiss the FirstRunDialog (web boot may gate on it) so the main tabs are reachable. */
+async function dismissFirstRun(page) {
+  const skip = page.getByRole('button', { name: /skip/i });
+  if (await skip.count().catch(() => 0)) await skip.first().click().catch(() => {});
+}
+
+/** Navigate to a main tab (loads its lazy chunk → injects that chunk's CSS). */
+async function openTab(page, tabId) {
+  await page.locator(`[data-tab="${tabId}"]`).first().click();
+  await page.waitForLoadState('networkidle').catch(() => {});
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+  await dismissFirstRun(page);
+  await page.waitForSelector('[role="tablist"], .tab-bar', { timeout: 30_000 });
+});
+
+test('Attributes / GraphAttributesPanel: .ga-* grid rule is loaded (t/3024 regression)', async ({ page }) => {
+  await openTab(page, 'accelerationist'); // POV chunk statically imports NodeDetail → GraphAttributesPanel
+  const cols = await probe(page, 'ga-grid-3col', 'grid-template-columns');
+  // styled → 3 tracks; unstyled → 'none' / single track
+  expect(cols.split(/\s+/).filter(Boolean).length, `ga-grid-3col grid-template-columns="${cols}"`).toBeGreaterThanOrEqual(3);
+});
+
+test('HighlightedField: .hl-backdrop overlay rule is loaded (t/3025)', async ({ page }) => {
+  await openTab(page, 'accelerationist'); // NodeDescriptionSection renders HighlightedField
+  expect(await probe(page, 'hl-backdrop', 'position')).toBe('absolute');
+});
+
+test('DataSourceCard: .pi-node-count-preview rule is loaded (t/3025)', async ({ page }) => {
+  await openTab(page, 'chat'); // Prompt Inspector renders DataSourceCard
+  const bw = await probe(page, 'pi-node-count-preview', 'border-bottom-width');
+  expect(bw, `pi-node-count-preview border-bottom-width="${bw}"`).not.toBe('0px');
+});
+
+// VALIDATE(live): confirm which tab/panel loads settings/ApiKeyErrorMessage in the web build,
+// then point openTab() at it. Marked fixme until the nav is confirmed so it can't false-fail.
+test.fixme('ApiKeyErrorMessage: .api-key-error-link rule is loaded (t/3025)', async ({ page }) => {
+  await openTab(page, 'accelerationist'); // TODO: correct surface
+  const td = await probe(page, 'api-key-error-link', 'text-decoration-line');
+  expect(td, `api-key-error-link text-decoration-line="${td}"`).toContain('underline');
+});

--- a/taxonomy-editor/smoke/playwright.config.mjs
+++ b/taxonomy-editor/smoke/playwright.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Scoped to smoke/ so Playwright never scans the app's vitest suites.
+export default defineConfig({
+  testDir: '.',
+  testMatch: '**/*.smoke.mjs',
+  timeout: 60_000,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: [['list']],
+  use: {
+    ...devices['Desktop Chrome'],
+    headless: true,
+    baseURL: process.env.SMOKE_BASE_URL || 'http://localhost:7862',
+  },
+});

--- a/taxonomy-editor/smoke/run-smoke.mjs
+++ b/taxonomy-editor/smoke/run-smoke.mjs
@@ -1,0 +1,34 @@
+// Render-smoke orchestrator (t/3026): start:server → wait for :7862 → run the Playwright
+// spec → tear down. Assumes `npm run build:container` has produced dist/ (prod web artifact +
+// server). Exits non-zero on any failed assertion. DevOps owns the CI job wiring (t/3026#4).
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SMOKE_DIR = dirname(fileURLToPath(import.meta.url));
+const APP_DIR = resolve(SMOKE_DIR, '..');
+const PORT = process.env.PORT || '7862';
+const BASE = `http://localhost:${PORT}`;
+const useShell = process.platform === 'win32';
+
+function launch(cmd, args, opts = {}) {
+  return spawn(cmd, args, { stdio: 'inherit', shell: useShell, cwd: APP_DIR, ...opts });
+}
+const waitExit = (child) => new Promise((res) => child.on('exit', (c) => res(c ?? 1)));
+
+const server = launch('node', ['dist/server/taxonomy-editor/src/server/server.js']);
+let code = 1;
+try {
+  const waited = await waitExit(launch('npx', ['wait-on', '-t', '120000', BASE]));
+  if (waited !== 0) throw new Error(`wait-on failed for ${BASE} (exit ${waited}) — is build:container built?`);
+  code = await waitExit(
+    launch('npx', ['playwright', 'test', '-c', 'smoke/playwright.config.mjs'], {
+      env: { ...process.env, SMOKE_BASE_URL: BASE },
+    }),
+  );
+} catch (err) {
+  console.error(`[run-smoke] ${err instanceof Error ? err.message : String(err)}`);
+} finally {
+  server.kill();
+}
+process.exit(code);


### PR DESCRIPTION
…mium vs start:server)

Authors the render-smoke harness per the locked design (TL p/336#198/#199, DevOps t/3026#4): Playwright-Chromium against a PROD web build served by start:server, asserting key surfaces render STYLED via probe-injection (navigate to a surface's tab → its lazy chunk injects its CSS → inject a class'd probe element → assert getComputedStyle). Catches the whole silent-unstyling failure class (t/3024 + the t/3025 orphans) that jsdom can't.

Files (taxonomy-editor/smoke/):
- attributes-styled.smoke.mjs — spec: .ga-grid-3col (3 tracks), .hl-backdrop (absolute), .pi-node-count-preview (border), + ApiKeyErrorMessage (test.fixme until its nav is tuned).
- playwright.config.mjs — chromium, headless, testMatch scoped to smoke/.
- run-smoke.mjs — start:server → wait-on :7862 → playwright test → teardown.
- README.md — design, boot sequence (PORT 7862, FirstRun skip, [data-tab] nav), both-arms proof.
+ package.json: `smoke:styled` script.

WIP / NOT for merge: selectors + probe classes are best-effort from static analysis and must be tuned against a live run, the @playwright/test devDep + lockfile land with that install, and the both-arms proof must be captured — then route to TL (t/3026#1) before DevOps wires the CI job.