### PR TITLE
fix(server): dictionary 30s hang + embeddings cold-start observability (t/3046, t/3047)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/dictionaryTimeout.test.ts
+++ b/taxonomy-editor/src/server/__tests__/dictionaryTimeout.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3047 — GET /api/dictionary route-level timeout + graceful fallback.
+// Verifies: (1) a hanging loadDictionary call is bounded by the 10 s server-side
+// timeout and returns empty data (not a 30 s client hang), (2) any loadDictionary
+// error (including non-timeout failures) degrades gracefully to the same empty
+// fallback and emits a 'dictionary.github.timeout' FR event whose error.message
+// distinguishes the cause.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+// ── Mocks (hoisted before imports) ──
+
+let recordedEvents: { message?: string; data?: Record<string, unknown>; error?: { message?: string } }[] = [];
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: (ev: unknown) => { recordedEvents.push(ev as never); } }),
+}));
+
+const loadDictionary = vi.fn();
+vi.mock('../storage/fileIO.js', () => ({
+  loadDictionary: () => loadDictionary(),
+  getTaxonomyDir: () => '/tmp/test-dict',
+  resolveDataPath: () => '/tmp/test-dict',
+  buildNodeSourceIndex: vi.fn(),
+  isSafeId: vi.fn(() => true),
+}));
+
+import { registerSourcesRoutes } from '../routes/sources.js';
+
+// ── Helpers ──
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body?: unknown) => Promise<void> | void;
+
+function makeRouter() {
+  const handlers: Record<string, Handler> = {};
+  const reg = (m: string) => (p: string, h: Handler) => { handlers[`${m} ${p}`] = h; };
+  return {
+    router: { get: reg('GET'), post: reg('POST'), put: reg('PUT'), patch: reg('PATCH'), del: reg('DELETE') },
+    handlers,
+  };
+}
+
+function fakeRes() {
+  const res: Record<string, unknown> = {
+    writableEnded: false,
+    headersSent: false,
+    _body: undefined as unknown,
+    writeHead: vi.fn(),
+    end: vi.fn((b?: string) => {
+      res._body = b !== undefined ? JSON.parse(b) : undefined;
+      res.writableEnded = true;
+      res.headersSent = true;
+    }),
+    setHeader: vi.fn(),
+  };
+  return res as unknown as ServerResponse & { _body: unknown };
+}
+
+const stubCtx = {} as never;
+const EMPTY_DICT = { standardized: [], colloquial: [], lintViolations: [] };
+
+// ── Tests ──
+
+describe('GET /api/dictionary — timeout + fallback (t/3047)', () => {
+  let dictionaryHandler: Handler;
+
+  beforeEach(() => {
+    recordedEvents = [];
+    const { router, handlers } = makeRouter();
+    registerSourcesRoutes(router as never, stubCtx);
+    dictionaryHandler = handlers['GET /api/dictionary'];
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('returns empty fallback and emits FR event when loadDictionary hangs (timeout)', async () => {
+    loadDictionary.mockReturnValue(new Promise(() => { /* never resolves */ }));
+    const res = fakeRes();
+    const pending = dictionaryHandler({} as IncomingMessage, res);
+    // Advance past the 10 s server-side timeout
+    await vi.advanceTimersByTimeAsync(10_001);
+    await pending;
+    expect(res._body).toEqual(EMPTY_DICT);
+    expect(recordedEvents).toHaveLength(1);
+    expect(recordedEvents[0]).toMatchObject({ message: 'dictionary.github.timeout' });
+    expect((recordedEvents[0].data as { duration_ms: number }).duration_ms).toBeGreaterThanOrEqual(10_000);
+  });
+
+  it('returns empty fallback and FR event on non-timeout error (error.message reflects actual cause)', async () => {
+    loadDictionary.mockRejectedValue(new Error('GitHub rate limit exceeded'));
+    const res = fakeRes();
+    await dictionaryHandler({} as IncomingMessage, res);
+    expect(res._body).toEqual(EMPTY_DICT);
+    expect(recordedEvents).toHaveLength(1);
+    expect(recordedEvents[0]).toMatchObject({ message: 'dictionary.github.timeout' });
+    // error.message must contain the actual cause so triage can distinguish timeout vs API error
+    expect(recordedEvents[0].error?.message).toMatch(/rate limit/);
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
@@ -6,7 +6,7 @@
 // and the load snapshot. The counter is the same one the t/2905 concurrency cap
 // will read, so its increment/decrement/floor invariants are load-bearing.
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import {
   beginEmbeddingCompute,
   endEmbeddingCompute,
@@ -16,6 +16,9 @@ import {
   evaluateEmbeddingLoadShed,
   decideLoadShed,
   readRecentLoopDelayMaxMs,
+  isEmbeddingModelWarm,
+  markEmbeddingModelWarm,
+  resetEmbeddingModelWarm,
 } from '../embeddingsLoad.js';
 
 describe('embeddingsLoad (t/2904)', () => {
@@ -172,5 +175,28 @@ describe('readRecentLoopDelayMaxMs — recent-window signal (t/2914 item 1)', ()
     const v = readRecentLoopDelayMaxMs();
     expect(Number.isFinite(v)).toBe(true);
     expect(v).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// t/3046 — model-warm flag drives the async-vs-keep-warm architecture decision.
+// If the flag is silently wrong, the wrong architecture gets chosen.
+describe('embeddingModelWarm flag (t/3046)', () => {
+  beforeEach(() => { resetEmbeddingModelWarm(); });
+
+  it('starts cold before any compute', () => {
+    // model_cold_start = !isEmbeddingModelWarm() = true for the first request
+    expect(isEmbeddingModelWarm()).toBe(false);
+  });
+
+  it('first mark → warm; second compute sees model_cold_start: false', () => {
+    expect(isEmbeddingModelWarm()).toBe(false); // first compute: model_cold_start = true
+    markEmbeddingModelWarm();
+    expect(isEmbeddingModelWarm()).toBe(true);  // subsequent: model_cold_start = false
+  });
+
+  it('reset restores cold state (test isolation)', () => {
+    markEmbeddingModelWarm();
+    resetEmbeddingModelWarm();
+    expect(isEmbeddingModelWarm()).toBe(false);
   });
 });

--- a/taxonomy-editor/src/server/embeddingsLoad.ts
+++ b/taxonomy-editor/src/server/embeddingsLoad.ts
@@ -68,6 +68,15 @@ export function endEmbeddingCompute(): void { inFlight = Math.max(0, inFlight - 
 /** Current number of in-flight embedding computes on this replica. */
 export function inFlightEmbeddingComputes(): number { return inFlight; }
 
+// t/3046: tracks whether the embedding model has been warmed (first successful
+// computeEmbeddings call per container). Used to split cold-start vs compute
+// latency in the FR event — drives the async-vs-keep-warm architecture decision.
+let embeddingModelWarm = false;
+export function isEmbeddingModelWarm(): boolean { return embeddingModelWarm; }
+export function markEmbeddingModelWarm(): void { embeddingModelWarm = true; }
+/** Reset the warm flag — test isolation only. */
+export function resetEmbeddingModelWarm(): void { embeddingModelWarm = false; }
+
 export interface EmbeddingLoadSnapshot {
   heap_used_mb: number;
   heap_total_mb: number;

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -29,7 +29,7 @@ import * as rateLimiter from '../security/rateLimiter.js';
 import * as ai from '../ai/aiBackends.js';
 import { resolveGenerationContext, enforceBackendAllowed } from './generationContext.js';
 import * as fileIO from '../storage/fileIO.js';
-import { beginEmbeddingCompute, endEmbeddingCompute, embeddingLoadSnapshot, evaluateEmbeddingLoadShed } from '../embeddingsLoad.js';
+import { beginEmbeddingCompute, endEmbeddingCompute, embeddingLoadSnapshot, evaluateEmbeddingLoadShed, isEmbeddingModelWarm, markEmbeddingModelWarm } from '../embeddingsLoad.js';
 
 // Pure mirror of the server.ts parseCookies helper (used by the logout /
 // fresh-login handlers). Depends only on the request headers; holds no state.
@@ -558,9 +558,18 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
         }
         log.api.warn({ ...embeddingLoadSnapshot(), reason: shedDecision.reason }, 'embeddings.compute: WOULD load-shed (warn-first; not blocking)');
       }
+      const modelWarm = isEmbeddingModelWarm();
+      const t0 = Date.now();
+      const inFlightAtEntry = embeddingLoadSnapshot().in_flight_embedding_computes;
       beginEmbeddingCompute();
       try {
         const vectors = await ai.computeEmbeddings(texts, ids, gate.key);
+        markEmbeddingModelWarm();
+        getGlobalRecorder()?.record({
+          type: 'system.info', component: 'embeddings-compute', level: 'info',
+          message: 'embedding.compute',
+          data: { duration_ms: Date.now() - t0, model_cold_start: !modelWarm, in_flight_at_entry: inFlightAtEntry },
+        });
         json(res, { vectors });
       } finally {
         endEmbeddingCompute();

--- a/taxonomy-editor/src/server/routes/sources.ts
+++ b/taxonomy-editor/src/server/routes/sources.ts
@@ -28,7 +28,7 @@ import type { Router } from '../httpKit.js';
 import type { ServerCtx } from './context.js';
 import { json, error, param } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
-import { DEFAULT_MODEL } from '../../../../lib/ai-client/index.js';
+import { DEFAULT_MODEL, withTimeout } from '../../../../lib/ai-client/index.js';
 import { log } from '../logger.js';
 import * as ai from '../ai/aiBackends.js';
 import { resolveGenerationContext, enforceBackendAllowed } from './generationContext.js';
@@ -209,8 +209,21 @@ export function registerSourcesRoutes(r: Router, _ctx: ServerCtx): void {
 
   // ── Dictionary ──
 
+  const DICTIONARY_TIMEOUT_MS = 10_000;
+
   get('/api/dictionary', async (_req, res) => {
-    json(res, await fileIO.loadDictionary());
+    const t0 = Date.now();
+    try {
+      json(res, await withTimeout(fileIO.loadDictionary(), DICTIONARY_TIMEOUT_MS, 'dictionary-github'));
+    } catch (err) {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'dictionary', level: 'warn',
+        message: 'dictionary.github.timeout',
+        data: { duration_ms: Date.now() - t0 },
+        error: { name: (err as Error).name ?? 'Error', message: String(err) },
+      });
+      json(res, { standardized: [], colloquial: [], lintViolations: [] });
+    }
   });
 
   // ── Source evidence ──


### PR DESCRIPTION
## Summary

- **t/3047**: `GET /api/dictionary` no longer hangs 30 s in github-api mode. The handler races `loadDictionary()` against a 10 s `withTimeout` fence and returns an empty fallback on timeout or any error, emitting a `dictionary.github.timeout` FR event with `duration_ms` and `error.message` so triage can distinguish timeout vs API errors (e.g. rate limit). Prevents the 30 s hang from cascading into a circuit-breaker failure.
- **t/3046**: `POST /api/embeddings/compute` now wraps every compute with an `embedding.compute` FR event carrying `duration_ms`, `model_cold_start` (true on first successful compute per container, false thereafter), and `in_flight_at_entry`. The binary warm flag is the proxy for the cold-start latency split that drives the async-vs-keep-warm architecture decision. No architecture change — observability only per TL hold.

## Files changed

- `src/server/routes/sources.ts` — dictionary handler with `withTimeout` + FR event fallback
- `src/server/routes/ai.ts` — embeddings compute FR event with warm-flag capture
- `src/server/embeddingsLoad.ts` — `isEmbeddingModelWarm` / `markEmbeddingModelWarm` / `resetEmbeddingModelWarm`
- `src/server/__tests__/dictionaryTimeout.test.ts` — NEW: 2 cases (hang → timeout fallback, non-timeout error fallback)
- `src/server/__tests__/embeddingsLoad.test.ts` — +3 warm-flag cases; `beforeEach` import added

## Test plan

- [x] 23/23 tests pass locally (`dictionaryTimeout.test.ts` + `embeddingsLoad.test.ts`)
- [ ] CI green on pushed head
- [ ] Pre-self-merge verify: base=main, headRefOid matches push, CI on that OID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBHGCvj3awBhE3jYPYATPG