### PR TITLE
feat(server): auto-write paired server FR dump on client POST with dumpId (t/3049)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/autoServerDump.test.ts
+++ b/taxonomy-editor/src/server/__tests__/autoServerDump.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3049 — POST /api/flight-recorder/dump with a dumpId auto-writes the
+// paired server FR dump and returns serverDumpWritten in the response.
+// Verifies: (1) both writeDump calls fire (client + server), (2) server-dump
+// failure is non-fatal — client dump still returns 200 with serverDumpWritten: false.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+// ── Mocks ──
+
+let recordedEvents: unknown[] = [];
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: (ev: unknown) => { recordedEvents.push(ev); } }),
+}));
+
+const writeDump = vi.fn();
+const isValidDumpId = vi.fn(() => true);
+vi.mock('../flightRecorderDumps.js', () => ({
+  writeDump: (...a: unknown[]) => writeDump(...a),
+  isValidDumpId: (id: unknown) => isValidDumpId(id),
+  readMergedDump: vi.fn(),
+}));
+
+vi.mock('../config.js', () => ({
+  getDataRoot: () => '/fake/data',
+  getStateRoot: () => '/fake/state',
+  getProjectRoot: () => '/fake/project',
+  STORAGE_MODE: 'local',
+}));
+
+vi.mock('../community/community.js', () => ({ isAdmin: () => false }));
+vi.mock('../storage/fileIO.js', () => ({
+  loadDictionary: vi.fn(),
+  getTaxonomyDir: () => '/fake/taxonomy',
+  resolveDataPath: () => '/fake/taxonomy',
+  buildNodeSourceIndex: vi.fn(),
+  isSafeId: vi.fn(() => true),
+}));
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  getWarmupStatus: vi.fn(() => ({ ready: false })),
+  computeEmbedding: vi.fn(),
+}));
+vi.mock('../flightRecorderViewer.js', () => ({ escapeForInlineScript: (s: string) => s }));
+vi.mock('../security/accessControl.js', () => ({ clientSafeMessage: (s: string) => s }));
+vi.mock('../logger.js', () => ({
+  getRequestId: () => 'req-test',
+  log: { fr: { info: vi.fn() } },
+  writeFramedNdjson: vi.fn(),
+  LOG_MAX_LINE_BYTES: 65536,
+}));
+
+import { registerDiagnosticsRoutes } from '../routes/diagnostics.js';
+
+// ── Helpers ──
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body?: unknown) => Promise<void> | void;
+
+function makeRouter() {
+  const handlers: Record<string, Handler> = {};
+  const reg = (m: string) => (p: string, h: Handler) => { handlers[`${m} ${p}`] = h; };
+  return {
+    router: { get: reg('GET'), post: reg('POST'), put: reg('PUT'), patch: reg('PATCH'), del: reg('DELETE') },
+    handlers,
+  };
+}
+
+function fakeRes() {
+  const res: Record<string, unknown> = {
+    writableEnded: false,
+    headersSent: false,
+    _body: undefined as unknown,
+    writeHead: vi.fn(),
+    end: vi.fn((b?: string) => {
+      res._body = b !== undefined ? JSON.parse(b) : undefined;
+      res.writableEnded = true;
+      res.headersSent = true;
+    }),
+    setHeader: vi.fn(),
+  };
+  return res as unknown as ServerResponse & { _body: Record<string, unknown> };
+}
+
+const DUMP_ID = 'test-dump-id-123';
+const CLIENT_NDJSON = '{"seq":1}\n';
+const SERVER_NDJSON = '{"seq":2}\n';
+
+function makeCtx() {
+  return {
+    serverRecorder: { buildDump: vi.fn(() => ({ ndjson: SERVER_NDJSON })) },
+    appendServerLogs: vi.fn((s: string) => s),
+  } as unknown as Parameters<typeof registerDiagnosticsRoutes>[1];
+}
+
+// ── Tests ──
+
+describe('POST /api/flight-recorder/dump — auto-server-dump (t/3049)', () => {
+  let dumpHandler: Handler;
+  let ctx: ReturnType<typeof makeCtx>;
+
+  beforeEach(() => {
+    recordedEvents = [];
+    writeDump.mockResolvedValue('/fake/data/dumps/client-test-dump-id-123.jsonl');
+    isValidDumpId.mockReturnValue(true);
+    ctx = makeCtx();
+    const { router, handlers } = makeRouter();
+    registerDiagnosticsRoutes(router as never, ctx);
+    dumpHandler = handlers['POST /api/flight-recorder/dump'];
+  });
+
+  it('writes client + server dumps and returns serverDumpWritten: true', async () => {
+    const res = fakeRes();
+    await dumpHandler({} as IncomingMessage, res, { ndjson: CLIENT_NDJSON, dumpId: DUMP_ID });
+
+    expect(writeDump).toHaveBeenCalledTimes(2);
+    expect(writeDump).toHaveBeenCalledWith('/fake/data', 'client', DUMP_ID, CLIENT_NDJSON);
+    expect(writeDump).toHaveBeenCalledWith('/fake/data', 'server', DUMP_ID, SERVER_NDJSON);
+    expect(res._body).toMatchObject({ dumpId: DUMP_ID, serverDumpWritten: true });
+  });
+
+  it('returns serverDumpWritten: false and emits FR event when server dump write fails', async () => {
+    writeDump
+      .mockResolvedValueOnce('/fake/data/dumps/client-test-dump-id-123.jsonl') // client ok
+      .mockRejectedValueOnce(new Error('backend write failed'));                // server fails
+
+    const res = fakeRes();
+    await dumpHandler({} as IncomingMessage, res, { ndjson: CLIENT_NDJSON, dumpId: DUMP_ID });
+
+    expect(res._body).toMatchObject({ dumpId: DUMP_ID, serverDumpWritten: false });
+    expect(recordedEvents).toHaveLength(1);
+    expect(recordedEvents[0]).toMatchObject({ message: 'fr.auto_server_dump.failed', data: { dumpId: DUMP_ID } });
+  });
+});

--- a/taxonomy-editor/src/server/routes/diagnostics.ts
+++ b/taxonomy-editor/src/server/routes/diagnostics.ts
@@ -77,7 +77,25 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
       if (dumpId !== undefined) {
         if (!isValidDumpId(dumpId)) { error(res, 'dumpId must be a UUID-safe string', 400); return; }
         const filePath = await writeDump(getDataRoot(), 'client', dumpId, ndjson);
-        json(res, { filePath, filename: path.basename(filePath), dumpId });
+
+        // t/3049: auto-write paired server FR dump so the merged download includes
+        // both sources in one artifact. Best-effort — a server-dump write failure
+        // must never fail the client dump response.
+        let serverDumpWritten = false;
+        try {
+          const serverNdjson = appendServerLogs(serverRecorder.buildDump('manual').ndjson);
+          await writeDump(getDataRoot(), 'server', dumpId, serverNdjson);
+          serverDumpWritten = true;
+        } catch (serverErr) {
+          getGlobalRecorder()?.record({
+            type: 'system.error', component: 'flight-recorder-dump', level: 'warn',
+            message: 'fr.auto_server_dump.failed',
+            data: { dumpId },
+            error: { name: (serverErr as Error).name ?? 'Error', message: String(serverErr) },
+          });
+        }
+
+        json(res, { filePath, filename: path.basename(filePath), dumpId, serverDumpWritten });
         return;
       }
 


### PR DESCRIPTION
## Summary

- **t/3049**: `POST /api/flight-recorder/dump` now auto-writes a paired `server-{dumpId}.jsonl` alongside the client dump when a `dumpId` is provided. The existing `GET /api/flight-recorder/download-merged/:dumpId` already merges both sources — merged downloads now automatically include server-side events in one artifact, enabling evidence-based tracing instead of hypothesis-based reasoning.
- Server dump write is best-effort (non-fatal): failure returns `serverDumpWritten: false` and emits `fr.auto_server_dump.failed` FR event; client dump response is unaffected.
- No renderer changes needed — client already sends `dumpId`; the auto-server-dump is purely server-side.
- Read gate unchanged: `includeServer: admin || STORAGE_MODE !== 'github-api'` controls download access; write always happens server-side.

## Files changed

- `src/server/routes/diagnostics.ts` — extended dumpId branch to capture + write server FR buffer
- `src/server/__tests__/autoServerDump.test.ts` — NEW: 2 cases (success + server-write failure)

## Test plan

- [x] 2/2 tests pass locally
- [ ] CI green on pushed head
- [ ] Pre-self-merge verify: base=main, headRefOid matches push, CI on that OID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBHGCvj3awBhE3jYPYATPG