### PR TITLE
feat(enrichment): Test-AIBackendQuota — proactively flag quota-exhausted AI backends (t/3029)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -127,6 +127,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Test-GitHubHealth` | GitHub platform + CI status |
 | `Test-AIApiKey` | Probe AI backend auth endpoints (no tokens consumed) — confirm a key is present and accepted before running jobs |
 | `Test-AIBackendHealth` | Full completion round-trip probe per backend — use before a debate run to surface degraded/unreachable models (t/2212) |
+| `Test-AIBackendQuota` | Per-backend quota probe — flags quota-exhausted backends (Status='quota') with a best-effort ResetAt; use at session start to catch quota exhaustion before a wall of judge failures (t/3029) |
 | `Test-DebateIndexIntegrity` | Validate debate-*.json field types for UI-crash regressions — catches the object-as-title bug (t/2335) |
 | `Get-DebateIndexHealth` | Scan the aggregated `.debate-index.json` for type-invalid entries (object-as-title etc.); `-Repair` deletes bad entries for re-extraction on next launch (t/2735) |
 | `Test-DebatePersistence` | Pre-flight atomic write+rename probe for the debates output dir — call before AI generation to surface LOCKED/NO_PERMISSION early (t/2545) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -189,6 +189,7 @@
         'Invoke-CcToSitMigration'
         'Test-AIApiKey'
         'Test-AIBackendHealth'
+        'Test-AIBackendQuota'
         'Test-AIModelsConfig'
         # t/1492 — GHCR cleanup
         'Remove-StaleContainerImages'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -937,6 +937,7 @@ Export-ModuleMember -Function @(
     'Invoke-CcToSitMigration'
     'Test-AIApiKey'
     'Test-AIBackendHealth'
+    'Test-AIBackendQuota'
     'Test-AIModelsConfig'
     # t/1492 — GHCR cleanup
     'Remove-StaleContainerImages'

--- a/scripts/AITriad/Private/Invoke-AIBackendProbe.ps1
+++ b/scripts/AITriad/Private/Invoke-AIBackendProbe.ps1
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Shared single-backend AI probe. Sends one minimal completion through Invoke-AIApi and
+    classifies the outcome. Private helper behind Test-AIBackendHealth and Test-AIBackendQuota.
+.DESCRIPTION
+    Invoke-AIApi swallows HTTP failures into a $null return plus one or more Write-Warning
+    lines that carry the status ("... API call failed (HTTP 429) ...") and, separately, the
+    (sensitive-scrubbed) response body. This helper captures those warnings via
+    -WarningVariable and classifies the result so both public cmdlets share exactly one probe
+    implementation and one classification table.
+
+    Status values:
+      ok       — a completion came back with text
+      quota    — HTTP 429, or HTTP 400 with a quota/rate-limit/exhausted signal in the body
+      timeout  — the probe hit its wall-clock budget or the warning names a cancellation
+      error    — any other null return (auth failure, transport error, unexpected shape)
+
+    ResetAt is best-effort: providers do not reliably surface a reset time, and Invoke-AIApi
+    scrubs the response body, so ResetAt is populated only when a Retry-After delay or an
+    explicit date survives in the captured warning text — otherwise $null.
+.PARAMETER Backend
+    Backend id (gemini, claude, groq, ...). Used only for labelling and messages.
+.PARAMETER ModelId
+    ai-models.json model id to probe. When empty the row is returned as 'no-model' without a call.
+.PARAMETER TimeoutSec
+    Per-probe wall-clock budget in seconds. Default 15.
+.OUTPUTS
+    [PSCustomObject] with Backend, Model, Status, LatencyMs, ResetAt, ErrorMessage, TestedAt.
+#>
+function Invoke-AIBackendProbe {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Backend,
+
+        [string]$ModelId,
+
+        [ValidateRange(1, 300)]
+        [int]$TimeoutSec = 15
+    )
+
+    Set-StrictMode -Version Latest
+
+    $Row = [ordered]@{
+        Backend      = $Backend
+        Model        = $ModelId
+        Status       = 'error'
+        LatencyMs    = $null
+        ResetAt      = $null
+        ErrorMessage = $null
+        TestedAt     = [datetime]::UtcNow
+    }
+
+    if ([string]::IsNullOrEmpty($ModelId)) {
+        $Row['Status']       = 'no-model'
+        $Row['ErrorMessage'] = "No default model configured for backend '$Backend' in ai-models.json."
+        return [PSCustomObject]$Row
+    }
+
+    $Sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $AIResult = Invoke-AIApi `
+        -Prompt          'ping' `
+        -Model           $ModelId `
+        -MaxTokens       5 `
+        -TimeoutSec      $TimeoutSec `
+        -MaxRetries      0 `
+        -Temperature     0.0 `
+        -SkipTokenCheck `
+        -WarningVariable WarnVar
+    $Sw.Stop()
+
+    $Row['LatencyMs'] = [int]$Sw.ElapsedMilliseconds
+
+    if ($null -ne $AIResult -and $AIResult.PSObject.Properties['Text']) {
+        $Row['Status'] = 'ok'
+        return [PSCustomObject]$Row
+    }
+
+    # ── Classify the failure from the captured warning(s) ──
+    # Invoke-AIApi emits the status line and the body as separate warnings; join so both are
+    # visible to a single set of patterns.
+    $WarnText = if (@($WarnVar).Count -gt 0) { (@($WarnVar) -join ' | ') } else { '' }
+
+    $IsQuota = ($WarnText -match 'HTTP\s*429') -or
+               (($WarnText -match 'HTTP\s*400') -and ($WarnText -match 'quota|rate.?limit|resource_exhausted|exhausted|insufficient|billing|credit')) -or
+               ($WarnText -match 'quota|resource_exhausted|rate.?limit')
+
+    $IsTimeout = ($Sw.ElapsedMilliseconds -ge ($TimeoutSec * 1000 - 500)) -or
+                 ($WarnText -match 'timeout|timed.out|TaskCanceled|OperationCanceled')
+
+    if ($IsQuota) {
+        $Row['Status']  = 'quota'
+        $Row['ResetAt'] = ConvertTo-QuotaResetAt -Text $WarnText
+    } elseif ($IsTimeout) {
+        $Row['Status'] = 'timeout'
+    } else {
+        $Row['Status'] = 'error'
+    }
+
+    $Row['ErrorMessage'] = if ($WarnText) { $WarnText }
+        elseif ($IsTimeout) { "Backend '$Backend' did not respond within ${TimeoutSec}s." }
+        else { "Invoke-AIApi returned null for backend '$Backend'." }
+
+    return [PSCustomObject]$Row
+}
+
+<#
+.SYNOPSIS
+    Best-effort extraction of a quota reset timestamp from captured warning text.
+.DESCRIPTION
+    Returns an ISO-8601 UTC string ('yyyy-MM-ddTHH:mm:ssZ') when a reset hint is recoverable,
+    else $null. Tries, in order: a Retry-After delay in seconds (relative to now), an explicit
+    ISO-8601 datetime, then a bare reset date. Any parse failure falls through to $null — this
+    is advisory, never fatal.
+#>
+function ConvertTo-QuotaResetAt {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([string]$Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) { return $null }
+
+    # 1) Retry-After: <seconds> (relative)
+    if ($Text -match 'Retry-?After["'':\s]+(\d{1,7})') {
+        try { return ([datetime]::UtcNow.AddSeconds([int]$Matches[1])).ToString('yyyy-MM-ddTHH:mm:ssZ') } catch { }
+    }
+
+    # 2) Explicit ISO-8601 datetime in the body (e.g. "resets 2026-09-01T00:00:00Z")
+    if ($Text -match '(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2})?(?:Z|[+-]\d{2}:?\d{2})?)') {
+        try { return ([datetimeoffset]::Parse($Matches[1])).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ') } catch { }
+    }
+
+    # 3) A bare reset date (e.g. "resets 2026-09-01")
+    if ($Text -match 'reset[s]?[^0-9]{0,12}(\d{4}-\d{2}-\d{2})') {
+        try { return ([datetimeoffset]::Parse($Matches[1])).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ') } catch { }
+    }
+
+    return $null
+}

--- a/scripts/AITriad/Public/Test-AIBackendHealth.ps1
+++ b/scripts/AITriad/Public/Test-AIBackendHealth.ps1
@@ -72,62 +72,29 @@ function Test-AIBackendHealth {
     $Config  = Get-Content -Raw $ConfigPath | ConvertFrom-Json
     $Defaults = $Config.defaults
 
-    # ── Inner probe ──────────────────────────────────────────────────────
-    function _Probe-Backend {
+    # ── Project the shared probe to this cmdlet's latency-focused columns ──
+    # The probe (Private/Invoke-AIBackendProbe) is the single source of the ping + classification,
+    # shared with Test-AIBackendQuota. Health reports latency and drops the quota-specific ResetAt.
+    function _HealthRow {
         param([string]$B, [string]$ModelId, [int]$Timeout)
-
-        $Row = [ordered]@{
-            Backend      = $B
-            Model        = $ModelId
-            Status       = 'error'
-            LatencyMs    = $null
-            ErrorMessage = $null
-            TestedAt     = [datetime]::UtcNow
+        $P = Invoke-AIBackendProbe -Backend $B -ModelId $ModelId -TimeoutSec $Timeout
+        [PSCustomObject]@{
+            Backend      = $P.Backend
+            Model        = $P.Model
+            Status       = $P.Status
+            LatencyMs    = $P.LatencyMs
+            ErrorMessage = $P.ErrorMessage
+            TestedAt     = $P.TestedAt
         }
-
-        if ([string]::IsNullOrEmpty($ModelId)) {
-            $Row['ErrorMessage'] = "No default model configured for backend '$B' in ai-models.json."
-            return [PSCustomObject]$Row
-        }
-
-        $Sw = [System.Diagnostics.Stopwatch]::StartNew()
-        $AIResult = Invoke-AIApi `
-            -Prompt         'ping' `
-            -Model          $ModelId `
-            -MaxTokens      5 `
-            -TimeoutSec     $Timeout `
-            -MaxRetries     0 `
-            -Temperature    0.0 `
-            -SkipTokenCheck `
-            -WarningVariable WarnVar
-        $Sw.Stop()
-
-        $Row['LatencyMs'] = [int]$Sw.ElapsedMilliseconds
-
-        if ($null -ne $AIResult -and $AIResult.PSObject.Properties['Text']) {
-            $Row['Status'] = 'ok'
-        } else {
-            $WarnText = if (@($WarnVar).Count -gt 0) { "$($WarnVar[0])" } else { $null }
-            $IsTimeout = ($Sw.ElapsedMilliseconds -ge ($Timeout * 1000 - 500)) -or
-                         ($WarnText -match 'timeout|timed.out|TaskCanceled|OperationCanceled')
-            $Row['Status']       = if ($IsTimeout) { 'timeout' } else { 'error' }
-            $Row['ErrorMessage'] = if ($WarnText) { $WarnText } else {
-                if ($IsTimeout) { "Backend '$B' did not respond within ${Timeout}s." }
-                else            { "Invoke-AIApi returned null for backend '$B'." }
-            }
-        }
-
-        return [PSCustomObject]$Row
     }
 
     # ── Dispatch ─────────────────────────────────────────────────────────
     if ($PSCmdlet.ParameterSetName -eq 'All') {
         foreach ($B in $Defaults.PSObject.Properties.Name) {
-            $MId = $Defaults.$B
-            _Probe-Backend -B $B -ModelId $MId -Timeout $TimeoutSec
+            _HealthRow -B $B -ModelId $Defaults.$B -Timeout $TimeoutSec
         }
     } else {
         $MId = if ($Defaults.PSObject.Properties[$Backend]) { $Defaults.$Backend } else { $null }
-        _Probe-Backend -B $Backend -ModelId $MId -Timeout $TimeoutSec
+        _HealthRow -B $Backend -ModelId $MId -Timeout $TimeoutSec
     }
 }

--- a/scripts/AITriad/Public/Test-AIBackendQuota.ps1
+++ b/scripts/AITriad/Public/Test-AIBackendQuota.ps1
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Probes each configured AI backend and flags quota-exhausted ones, with a best-effort reset time.
+.DESCRIPTION
+    Sends a minimal completion ('ping') to each backend's default model (from ai-models.json)
+    through the same Invoke-AIApi path production cmdlets use, and classifies the result. Its
+    purpose is proactive quota visibility: a backend whose quota is exhausted returns
+    Status='quota' here instead of surfacing only as a wall of judge failures mid-session.
+
+    Shares one probe implementation with Test-AIBackendHealth (Private/Invoke-AIBackendProbe);
+    the difference is projection — this cmdlet reports the quota reset time (ResetAt) rather than
+    latency, and is intended for the session-start health check.
+
+    Status values: ok | quota | timeout | error | no-model. Per-backend failure is a reported
+    row, never a thrown exception; only an unloadable ai-models.json throws.
+
+    ResetAt is best-effort. Providers do not reliably return a reset time and Invoke-AIApi scrubs
+    the response body, so ResetAt is populated only when a Retry-After delay or an explicit date
+    survives in the captured warning text — otherwise $null. Treat a $null ResetAt on a 'quota'
+    row as "reset time unknown", not "resets now".
+.PARAMETER Backend
+    Single backend to probe. One of: gemini, claude, groq, openai, deepseek, azure, zai,
+    moonshot, xai, ollama. Omit (or use -All) to probe every backend with a default model.
+.PARAMETER All
+    Probe every backend that has a default model in ai-models.json. This is the default when no
+    backend is named — a bare Test-AIBackendQuota probes all, for session-start use.
+.PARAMETER TimeoutSec
+    Per-probe timeout in seconds. Default 15.
+.EXAMPLE
+    Test-AIBackendQuota | Format-Table Backend, Model, Status, ResetAt
+    # Session-start sweep across every configured backend.
+.EXAMPLE
+    Test-AIBackendQuota | Where-Object Status -eq 'quota'
+    # Surface only quota-exhausted backends.
+.EXAMPLE
+    Test-AIBackendQuota -Backend claude
+    # Check a single backend (e.g. after a run of judge failures).
+.LINK
+    Test-AIBackendHealth
+.LINK
+    Test-AIApiKey
+.LINK
+    Show-AITriadHelp
+#>
+function Test-AIBackendQuota {
+    [CmdletBinding(DefaultParameterSetName = 'All')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'One', Position = 0)]
+        [ValidateSet('gemini', 'claude', 'groq', 'openai', 'deepseek', 'azure', 'zai', 'moonshot', 'xai', 'ollama')]
+        [string]$Backend,
+
+        [Parameter(ParameterSetName = 'All')]
+        [switch]$All,
+
+        [ValidateRange(1, 300)]
+        [int]$TimeoutSec = 15
+    )
+
+    Set-StrictMode -Version Latest
+
+    # ── Load ai-models.json defaults (backend id -> default model id) ──────
+    $ConfigPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..' '..' '..' 'ai-models.json'))
+    if (-not (Test-Path $ConfigPath)) {
+        throw (New-ActionableError `
+            -Goal      'Load AI backend defaults for quota probe' `
+            -Problem   "ai-models.json not found at: $ConfigPath" `
+            -Location  'Test-AIBackendQuota' `
+            -NextSteps 'Verify the repo root contains ai-models.json and that the module is loaded from its expected path.')
+    }
+    $Config   = Get-Content -Raw $ConfigPath | ConvertFrom-Json
+    $Defaults = $Config.defaults
+
+    # ── Project the shared probe to the quota-focused columns ─────────────
+    function _QuotaRow {
+        param([string]$B, [string]$ModelId, [int]$Timeout)
+        $P = Invoke-AIBackendProbe -Backend $B -ModelId $ModelId -TimeoutSec $Timeout
+        [PSCustomObject]@{
+            Backend      = $P.Backend
+            Model        = $P.Model
+            Status       = $P.Status
+            ResetAt      = $P.ResetAt
+            ErrorMessage = $P.ErrorMessage
+            TestedAt     = $P.TestedAt
+        }
+    }
+
+    # ── Dispatch (bare call / -All => every backend; -Backend => one) ─────
+    if ($PSCmdlet.ParameterSetName -eq 'One') {
+        $MId = if ($Defaults.PSObject.Properties[$Backend]) { $Defaults.$Backend } else { $null }
+        _QuotaRow -B $Backend -ModelId $MId -Timeout $TimeoutSec
+    } else {
+        foreach ($B in $Defaults.PSObject.Properties.Name) {
+            _QuotaRow -B $B -ModelId $Defaults.$B -Timeout $TimeoutSec
+        }
+    }
+}

--- a/tests/Test-AIBackendQuota.Tests.ps1
+++ b/tests/Test-AIBackendQuota.Tests.ps1
@@ -1,0 +1,107 @@
+# Tag: enrichment (t/3029)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Unit tests for Test-AIBackendQuota (t/3029).
+.DESCRIPTION
+    Mocks Invoke-AIApi (the shared probe's transport) to verify quota classification and
+    best-effort ResetAt extraction without hitting live backends. Exercises: ok, quota (429),
+    quota with a recoverable reset date (400 body), error, -All dispatch, and validation.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-AIBackendQuota' -Tag 'enrichment' {
+
+    It 'is exported from the module' {
+        Get-Command -Module AITriad -Name 'Test-AIBackendQuota' | Should -Not -BeNullOrEmpty
+    }
+
+    Context 'Single backend — ok' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad {
+                [PSCustomObject]@{ Text = 'pong'; Backend = 'gemini'; Model = 'm'; Truncated = $false; Usage = $null; RawResponse = $null }
+            }
+        }
+        It 'returns status ok with no ResetAt' {
+            $r = Test-AIBackendQuota -Backend gemini
+            $r.Status  | Should -Be 'ok'
+            $r.ResetAt | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Single backend — quota (HTTP 429)' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad {
+                Write-Warning 'gemini: API call failed (HTTP 429) — Rate limit exceeded — wait a moment and try again.'
+                $null
+            }
+        }
+        It 'classifies a 429 as quota' {
+            $r = Test-AIBackendQuota -Backend gemini
+            $r.Status | Should -Be 'quota'
+        }
+    }
+
+    Context 'Single backend — quota with recoverable reset date (HTTP 400 body)' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad {
+                Write-Warning 'claude: API call failed (HTTP 400) — invalid_request_error'
+                Write-Warning 'claude: Response body: {"error":{"message":"You have exhausted your quota. Quota resets 2026-09-01T00:00:00Z"}}'
+                $null
+            }
+        }
+        It 'classifies a 400 quota body as quota and extracts ResetAt' {
+            $r = Test-AIBackendQuota -Backend claude
+            $r.Status  | Should -Be 'quota'
+            $r.ResetAt | Should -Be '2026-09-01T00:00:00Z'
+        }
+    }
+
+    Context 'Single backend — error (null, no warning)' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad { $null }
+        }
+        It 'returns status error, not quota' {
+            $r = Test-AIBackendQuota -Backend gemini
+            $r.Status  | Should -Be 'error'
+            $r.ResetAt | Should -BeNullOrEmpty
+        }
+        It 'does not throw — failure is a reported row' {
+            { Test-AIBackendQuota -Backend claude } | Should -Not -Throw
+        }
+    }
+
+    Context '-All / bare dispatch' {
+        BeforeEach {
+            Mock Invoke-AIApi -ModuleName AITriad {
+                [PSCustomObject]@{ Text = 'ok'; Backend = 'x'; Model = 'x'; Truncated = $false; Usage = $null; RawResponse = $null }
+            }
+        }
+        It 'a bare call probes every backend in ai-models.json defaults' {
+            $results = @(Test-AIBackendQuota)
+            $results.Count | Should -BeGreaterThan 1
+        }
+        It 'all rows expose Backend, Model, Status, ResetAt' {
+            foreach ($row in @(Test-AIBackendQuota -All)) {
+                $row.PSObject.Properties.Name | Should -Contain 'Backend'
+                $row.PSObject.Properties.Name | Should -Contain 'Model'
+                $row.PSObject.Properties.Name | Should -Contain 'Status'
+                $row.PSObject.Properties.Name | Should -Contain 'ResetAt'
+            }
+        }
+    }
+
+    Context 'Parameter validation' {
+        It 'rejects an unknown backend name' {
+            { Test-AIBackendQuota -Backend 'nonexistent-backend' } | Should -Throw
+        }
+    }
+}


### PR DESCRIPTION
Adds `Test-AIBackendQuota`: probes each configured backend's default model with a minimal 'ping' and classifies the result, so quota exhaustion surfaces at **session start** (Status=`quota`) instead of only as a wall of mid-session judge failures. Emits the ticket's **Backend | Model | Status | ResetAt** table; a bare call sweeps all backends.

## Design
The probe + classification live in **one Private helper** (`Invoke-AIBackendProbe`), shared with `Test-AIBackendHealth` — which is refactored onto it. The refactor is **behavior-preserving**: same 6-column output, all its original tests still pass; `quota` is now a refinement of `error`. This avoids cloning a live-API probe.

Quota detection: `Invoke-AIApi` swallows HTTP failures into a `$null` return + `Write-Warning` lines carrying the status; the probe captures them via `-WarningVariable` and matches `HTTP 429` / `HTTP 400`+quota-signal. `ResetAt` is **best-effort** (a `Retry-After` delay or a date surviving in the scrubbed warning text) — `$null` when unknown; there is no reliable provider reset field.

## Deviations from /add-ps-cmdlet (self-cert, flagged for review)
1. Introduces a shared `Private/` probe + a behavior-preserving refactor of an existing cmdlet (vs. a standalone clone).
2. `ResetAt` is best-effort by necessity.
3. The **diag-session-start skill** wiring the ticket mentions is Diagnostics' scope — handed off to them, not edited here.

## Tests
9 new (ok / quota-429 / quota-400-with-reset+ResetAt / error / -All / validation), all green. Full PS suite green except a **pre-existing** xAI live round-trip that requires `XAI_API_KEY` (unset locally; unrelated to this change).

Closes t/3029.