### PR TITLE
feat(observability): stamp retry_in_ms on the opening-statement 429 FR event (t/3048)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/clarificationSlice.ts
@@ -20,7 +20,7 @@ import { api, emitBriefTimeout, emitBriefRetriesExhausted } from '@bridge';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { generateId, nowISO, parseAIJson, parsePoverResponse, formatRecentTranscript } from '@lib/debate/helpers';
 import { formatTaxonomyContext } from '../../../utils/taxonomyContext';
-import { classifyAiRetry, retryReasonLabel } from '../../../utils/retryClassifier';
+import { classifyAiRetry, retryReasonLabel, parseRetryAfterMs } from '../../../utils/retryClassifier';
 import { formatCommitments, formatEstablishedPoints } from '../../../prompts/argumentNetwork';
 import { formatVocabularyContext } from '@lib/debate/vocabularyContext';
 import {
@@ -1161,8 +1161,10 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
         const httpStatus = (err as { httpStatus?: number }).httpStatus;
         // Broadened classification (t/2492): transient timeout/5xx/network now auto-retry, not just 429.
         const { retryable: isRetryable, reason: retryReason } = classifyAiRetry(err);
+        // t/3048: surface the server's advertised retry window structured in FR data (not just the message string).
+        const retryInMs = retryReason === 'rate_limit' ? parseRetryAfterMs(err) : undefined;
         console.error(`[debate] ${info.label} opening statement failed (status=${httpStatus ?? 'unknown'}, retry=${retryReason}):`, err);
-        getGlobalRecorder()?.record({ type: 'system.error', debate_id: activeDebate?.id, component: 'debate-engine', level: 'error', message: `Opening statement failed: ${info.label} (status=${httpStatus ?? 'unknown'})`, data: { retry_reason: retryReason, retryable: isRetryable, retry_pass: openingRetryPass }, error: { name: (err as Error).name ?? 'Error', message: (err as Error).message ?? String(err), stack: (err as Error).stack?.slice(0, 500) } });
+        getGlobalRecorder()?.record({ type: 'system.error', debate_id: activeDebate?.id, component: 'debate-engine', level: 'error', message: `Opening statement failed: ${info.label} (status=${httpStatus ?? 'unknown'})`, data: { retry_reason: retryReason, retryable: isRetryable, retry_pass: openingRetryPass, ...(retryInMs !== undefined && { retry_in_ms: retryInMs }) }, error: { name: (err as Error).name ?? 'Error', message: (err as Error).message ?? String(err), stack: (err as Error).stack?.slice(0, 500) } });
         if (isDailyLimitError(err)) {
           // Terminal for the whole run: settle this speaker's slot to 'error' so its
           // spinner doesn't stick (t/2907), and keep the run-level system notice + banner.
@@ -1190,9 +1192,8 @@ export const createClarificationSlice: StateCreator<DebateStore, [], [], Clarifi
           hasRetryableFailure = true;
           lastRetryReason = retryReasonLabel(retryReason);
           if (retryReason === 'rate_limit') {
-            // Honor the server's advertised Retry-After when present.
-            const msgMatch = String(err).match(/Retry in (\d+)s/);
-            retryBackoffMs = msgMatch ? parseInt(msgMatch[1], 10) * 1000 : 5000;
+            // Honor the server's advertised Retry-After when present (parsed once above, t/3048).
+            retryBackoffMs = retryInMs ?? 5000;
           } else {
             // Exponential backoff for transient timeout/5xx/network (5s, 10s, …), capped at 30s.
             retryBackoffMs = Math.min(5000 * 2 ** openingRetryPass, 30_000);

--- a/taxonomy-editor/src/renderer/utils/retryClassifier.test.ts
+++ b/taxonomy-editor/src/renderer/utils/retryClassifier.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { describe, it, expect } from 'vitest';
-import { classifyAiRetry, retryReasonLabel } from './retryClassifier';
+import { classifyAiRetry, retryReasonLabel, parseRetryAfterMs } from './retryClassifier';
 
 // Helper: build an error carrying an httpStatus (as the bridge attaches it).
 function httpErr(status: number, message = 'boom'): Error & { httpStatus: number } {
@@ -69,5 +69,22 @@ describe('retryReasonLabel (t/2492)', () => {
     expect(retryReasonLabel('timeout')).toMatch(/timed out/i);
     expect(retryReasonLabel('network')).toMatch(/network/i);
     expect(retryReasonLabel('non_retryable')).toMatch(/failed/i);
+  });
+});
+
+describe('parseRetryAfterMs (t/3048) — structured retry window for FR data + backoff', () => {
+  it.each([
+    ['Rate limited. Retry in 8s', 8000],
+    ['429 Too Many Requests — Retry in 11s before the next attempt', 11000],
+    ['Retry in 120s', 120000],
+  ])('parses %j → %ims', (message, expected) => {
+    expect(parseRetryAfterMs(new Error(message))).toBe(expected);
+    expect(parseRetryAfterMs(message)).toBe(expected); // also works on a bare string
+  });
+
+  it('returns undefined when no retry window is advertised', () => {
+    expect(parseRetryAfterMs(new Error('Rate limited, please slow down'))).toBeUndefined();
+    expect(parseRetryAfterMs(new Error('boom'))).toBeUndefined();
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
   });
 });

--- a/taxonomy-editor/src/renderer/utils/retryClassifier.ts
+++ b/taxonomy-editor/src/renderer/utils/retryClassifier.ts
@@ -71,3 +71,14 @@ export function retryReasonLabel(reason: RetryReason): string {
     default: return 'failed';
   }
 }
+
+/**
+ * The server's advertised retry window for a rate-limit failure, in ms, if present.
+ * The renderer only receives it embedded in the error message ("Retry in Ns") today; this
+ * surfaces it structured so it can be stamped onto FR data and reused for backoff (t/3048).
+ * Returns undefined when no window is advertised (caller falls back to a default backoff).
+ */
+export function parseRetryAfterMs(err: unknown): number | undefined {
+  const m = String(err).match(/Retry in (\d+)s/);
+  return m ? parseInt(m[1], 10) * 1000 : undefined;
+}


### PR DESCRIPTION
## Summary
Observability-only slice of t/3048 (TL re-scope, t/3048#3): stamp **`retry_in_ms`** onto the opening-statement rate-limit FR event. The server's advertised retry window previously lived only in the error message string (`"Retry in Ns"`) — invisible to structured dump triage; now it's a first-class `data.retry_in_ms`.

## Change
- New `parseRetryAfterMs(err)` helper in `utils/retryClassifier.ts` (beside the sibling retry helpers).
- `clarificationSlice.ts` opening-statement catch: compute `retryInMs` once, add `retry_in_ms` to the FR `data` (conditional spread — omitted when no window advertised), and the later backoff reuses the same value instead of re-parsing (**dedup, identical behavior**).

## Why observability-only (premise correction — t/3048#2)
I traced the path before coding: there is **no concurrency** — speakers `await` one-by-one (`clarificationSlice.ts:935/1044`) and pipeline stages `await` one-by-one (`opening.ts`, 4 sequential `generate()` calls). So the ticket's "concurrent AI requests" premise and fix #1 ("cap concurrency") were a no-op. The 429s are sequential **volume** vs the free-tier **per-minute** RPM. TL agreed and re-scoped the burst fix to a shared AI-layer limiter (**t/3052 → ServerAPI**); this ticket keeps the observability item.

## Test
`parseRetryAfterMs` unit cases (parses `"Retry in Ns"` → ms across formats; `undefined` when none). renderer-tsc **0/0** · eslint **0 errors** · vitest **293/293** (incl. all debate-store tests — the backoff dedup preserves retry behavior).

Closes t/3048 · routed to Quality (TL) for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
