### PR TITLE
obs(fr): structured retry_after_s on 429 ai.error events + ai.calls_total at debate end (t/3054)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
@@ -18,9 +18,15 @@ function apiRejectingWith(method: string, httpStatus?: number): AppAPI {
   return { [method]: () => Promise.reject(err) } as unknown as AppAPI;
 }
 
+/** Build a minimal AppAPI whose only method rejects with a 429 carrying a structured retryAfterS. */
+function apiRejecting429(method: string, retryAfterS?: number): AppAPI {
+  const err = Object.assign(new Error('Rate limit exceeded'), { httpStatus: 429, retryAfterS });
+  return { [method]: () => Promise.reject(err) } as unknown as AppAPI;
+}
+
 /** Return the failure-record the wrapped call emitted (the last recorded event). */
-function lastRecord(): { level: string; message: string; data?: { http_status?: number } } {
-  return mockRecord.mock.calls.at(-1)?.[0] as { level: string; message: string; data?: { http_status?: number } };
+function lastRecord(): { level: string; message: string; data?: { http_status?: number; retry_after_s?: number } } {
+  return mockRecord.mock.calls.at(-1)?.[0] as { level: string; message: string; data?: { http_status?: number; retry_after_s?: number } };
 }
 
 /** Find the ok-completion event for a bridge method (its enriched result meta). */
@@ -90,6 +96,38 @@ describe('instrumentBridge — loadOpEdSet grounding presence (t/2621)', () => {
     expect(ok?.data?.member_count).toBe(2);
     expect(ok?.data?.has_grounding).toBe(false);
     expect(ok?.data?.grounded_member_count).toBe(0);
+  });
+});
+
+describe('instrumentBridge — structured 429 retry_after_s (t/3054)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('records retry_after_s on a 429 failure when the error carries retryAfterS', async () => {
+    const api = instrumentBridge(apiRejecting429('generateText', 22));
+    await expect((api as unknown as { generateText: () => Promise<unknown> }).generateText()).rejects.toThrow();
+
+    const rec = lastRecord();
+    expect(rec.data?.http_status).toBe(429);
+    expect(rec.data?.retry_after_s).toBe(22);
+  });
+
+  it('omits retry_after_s when the 429 error has no structured cooldown', async () => {
+    const api = instrumentBridge(apiRejecting429('generateText'));
+    await expect((api as unknown as { generateText: () => Promise<unknown> }).generateText()).rejects.toThrow();
+
+    const rec = lastRecord();
+    expect(rec.data?.http_status).toBe(429);
+    expect(rec.data?.retry_after_s).toBeUndefined();
+  });
+
+  it('omits retry_after_s for a non-429 status even if retryAfterS is present', async () => {
+    const err = Object.assign(new Error('boom'), { httpStatus: 500, retryAfterS: 9 });
+    const api = instrumentBridge({ generateText: () => Promise.reject(err) } as unknown as AppAPI);
+    await expect((api as unknown as { generateText: () => Promise<unknown> }).generateText()).rejects.toThrow();
+
+    const rec = lastRecord();
+    expect(rec.data?.http_status).toBe(500);
+    expect(rec.data?.retry_after_s).toBeUndefined();
   });
 });
 

--- a/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
@@ -148,6 +148,17 @@ function isExpectedStatus(method: string, httpStatus: number | undefined): boole
   return httpStatus !== undefined && (EXPECTED_STATUS[method]?.has(httpStatus) ?? false);
 }
 
+/**
+ * Structured 429 cooldown for FR `ai.error` events (t/3054). web-bridge attaches
+ * `retryAfterS` to the thrown ActionableError; surface it as `retry_after_s` so a
+ * consumer can honor the cooldown without regex-parsing the message string.
+ */
+function retryAfterSFromError(err: unknown, httpStatus: number | undefined): number | undefined {
+  if (httpStatus !== 429) return undefined;
+  const v = (err as { retryAfterS?: unknown }).retryAfterS;
+  return typeof v === 'number' ? v : undefined;
+}
+
 /** Categorize bridge methods for the recorder. */
 function inferCategory(method: string): string {
   if (method.startsWith('generate') || method.startsWith('startChat') || method === 'nliClassify') return 'ai';
@@ -199,6 +210,7 @@ export function instrumentBridge(raw: AppAPI): AppAPI {
           ? (err as { httpStatus: number }).httpStatus
           : undefined;
         const expected = !isAI && isExpectedStatus(key, httpStatus);
+        const retryAfterS = retryAfterSFromError(err, httpStatus);
         getGlobalRecorder()?.record({
           type: isAI ? 'ai.error' : 'system.error',
           component: recorder?.intern('component', 'bridge') as string | number,
@@ -206,7 +218,7 @@ export function instrumentBridge(raw: AppAPI): AppAPI {
           message: expected ? `bridge.${key} expected ${httpStatus} (sync)` : `bridge.${key} failed (sync)`,
           duration_ms,
           error: normalizeError(err),
-          data: { method: key, category, ...(httpStatus !== undefined && { http_status: httpStatus }) },
+          data: { method: key, category, ...(httpStatus !== undefined && { http_status: httpStatus }), ...(retryAfterS !== undefined && { retry_after_s: retryAfterS }) },
         });
         throw err;
       }
@@ -244,6 +256,7 @@ export function instrumentBridge(raw: AppAPI): AppAPI {
             ? (err as { httpStatus: number }).httpStatus
             : undefined;
           const expected = !isAI && isExpectedStatus(key, httpStatus);
+          const retryAfterS = retryAfterSFromError(err, httpStatus);
           recorder?.record({
             type: isAI ? 'ai.error' : 'system.error',
             component: recorder.intern('component', 'bridge') as string | number,
@@ -251,7 +264,7 @@ export function instrumentBridge(raw: AppAPI): AppAPI {
             message: expected ? `bridge.${key} expected ${httpStatus}` : `bridge.${key} failed`,
             duration_ms,
             error: normalizeError(err),
-            data: { method: key, category, ...(httpStatus !== undefined && { http_status: httpStatus }) },
+            data: { method: key, category, ...(httpStatus !== undefined && { http_status: httpStatus }), ...(retryAfterS !== undefined && { retry_after_s: retryAfterS }) },
           });
           throw err;
         },

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -260,20 +260,16 @@ async function post<T = unknown>(path: string, body?: unknown, opts?: FetchOptio
     if (data.limitType === 'tokens_per_day' && !budgetWarning) {
       onQuotaMilestone(100, (data.resetsAt as string | undefined));
     }
-    const retryAfterS = Math.ceil((data.retryAfterMs as number || 60000) / 1000);
     const msg = data.limitType === 'tokens_per_day'
       ? 'Daily token limit exceeded. Try again tomorrow or use your own API key.'
-      : `Rate limit exceeded. Retry in ${retryAfterS}s.`;
+      : `Rate limit exceeded. Retry in ${Math.ceil((data.retryAfterMs as number || 60000) / 1000)}s.`;
     const err = new ActionableError({
       goal: 'Call AI backend',
       problem: msg,
       location: 'web-bridge.post',
       nextSteps: ['Wait for the rate limit to reset', 'Use your own API key to avoid shared limits'],
     });
-    (err as ActionableError & { limitType: string }).limitType = String(data.limitType ?? '');
-    // Structured cooldown (t/3054) — carry the retry-after seconds on the error so the
-    // FR `ai.error` event can record it as a field instead of forcing a message-string regex.
-    (err as ActionableError & { retryAfterS: number }).retryAfterS = retryAfterS;
+    Object.assign(err, { limitType: String(data.limitType ?? ''), retryAfterS: Math.ceil((data.retryAfterMs as number || 60000) / 1000) }); // + 429 retry_after_s for FR (t/3054)
     throwHttpError(429, err);
   }
   if (res.status === 400 && (path === '/api/ai/generate' || path === '/api/ai/search')) {

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -260,9 +260,10 @@ async function post<T = unknown>(path: string, body?: unknown, opts?: FetchOptio
     if (data.limitType === 'tokens_per_day' && !budgetWarning) {
       onQuotaMilestone(100, (data.resetsAt as string | undefined));
     }
+    const retryAfterS = Math.ceil((data.retryAfterMs as number || 60000) / 1000);
     const msg = data.limitType === 'tokens_per_day'
       ? 'Daily token limit exceeded. Try again tomorrow or use your own API key.'
-      : `Rate limit exceeded. Retry in ${Math.ceil((data.retryAfterMs as number || 60000) / 1000)}s.`;
+      : `Rate limit exceeded. Retry in ${retryAfterS}s.`;
     const err = new ActionableError({
       goal: 'Call AI backend',
       problem: msg,
@@ -270,6 +271,9 @@ async function post<T = unknown>(path: string, body?: unknown, opts?: FetchOptio
       nextSteps: ['Wait for the rate limit to reset', 'Use your own API key to avoid shared limits'],
     });
     (err as ActionableError & { limitType: string }).limitType = String(data.limitType ?? '');
+    // Structured cooldown (t/3054) — carry the retry-after seconds on the error so the
+    // FR `ai.error` event can record it as a field instead of forcing a message-string regex.
+    (err as ActionableError & { retryAfterS: number }).retryAfterS = retryAfterS;
     throwHttpError(429, err);
   }
   if (res.status === 400 && (path === '/api/ai/generate' || path === '/api/ai/search')) {

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/synthesisSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/synthesisSlice.ts
@@ -985,6 +985,20 @@ export const createSynthesisSlice: StateCreator<DebateStore, [], [], SynthesisSl
       api.trackEvent('debate_complete', 'debate', { debateId: activeDebate?.id, rounds: turnCount });
       trackDebateComplete(activeDebate?.id, turnCount, durationMs);
 
+      // Per-run AI-call counter, logged at debate end (t/3054) — surfaces burst patterns
+      // (e.g. 20+ calls during opening statements) without post-hoc log aggregation.
+      // Read from the freshest store state: post-synthesis passes above run more AI calls
+      // after `activeDebate` was captured at the top of the function.
+      const aiCallsTotal = get().activeDebate?.diagnostics?.overview.total_ai_calls ?? 0;
+      getGlobalRecorder()?.record({
+        type: 'debate.phase',
+        component: 'debate-store',
+        level: 'info',
+        debate_id: activeDebate?.id,
+        message: 'debate.end',
+        data: { phase: 'closed', ai_calls_total: aiCallsTotal, turn_count: turnCount, duration_ms: durationMs },
+      });
+
       runLineageDebateSummary(get, activeDebate);
     } catch (err) {
       // User cancel / model switch (t/2508) — bail quietly, no error toast (helper logged info).


### PR DESCRIPTION
## What
Two flight-recorder observability additions from the t/3054 diagnosis:

1. **`retry_after_s` on 429 `ai.error` events** — the retry cooldown was only embedded in the ActionableError message string (`"Retry in 22s."`), forcing consumers to regex-parse it and blocking cross-session aggregation. `web-bridge.post` now attaches `retryAfterS` to the thrown error; `instrumentBridge` records it as a structured `retry_after_s` FR field when `http_status === 429`.

2. **`ai_calls_total` at debate end** — a new `debate.end` FR event (`type: 'debate.phase'`, message `debate.end`) carries the per-run AI-call count (from the diagnostics overview) at debate close, surfacing burst patterns (e.g. 20+ calls during opening statements) without post-hoc log aggregation.

## Tests
- 3 new `instrumentBridge` cases: 429 with cooldown → records `retry_after_s`; 429 without → omits it; non-429 with stray `retryAfterS` → omits it.
- Full debate-store suite (267 tests) green — the `debate.end` emit path.

## Verify note
Local `npm run verify` is blocked by a pre-existing environment gap on the shared checkout: `lib/` deps (`pptxgenjs`, `decode-named-character-reference`, `micromark-util-decode-numeric-character-reference`) are not installed locally, producing 3 `TS2307` errors in `../lib/` files this diff never touches (identical on clean `main`). All `tsc` legs show *only* those 3 errors — none in changed files. CI's fresh install runs the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)