### PR TITLE
fix(debate): crossRespond 429 backoff + idempotent turn-failure marker (t/3053)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/crossRespondModeratorBackoff.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/crossRespondModeratorBackoff.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression for t/3053 (facet A): a transient 429 on moderator selection propagated straight
+// to debate.ended(reason:'error') with no backoff, so the UI re-entered immediately → 3× in
+// 130ms. runModeratorStep now backs off (MAX 2 / 2-min budget) and only ends on non-retryable
+// or budget/cap exhaustion. These are the store-level arms TL required at merge (t/3053#3);
+// t/3055 remains the separate FaultHarness gate.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+import { runModeratorSelection, executeTurnWithRetry } from '@lib/debate/orchestration';
+import { releaseDebateDriver } from '../shared/guards';
+
+const mockRecords: Array<Record<string, unknown>> = [];
+const mockRecord = vi.fn((event: Record<string, unknown>) => { mockRecords.push(event); });
+vi.mock('@lib/flight-recorder/index', () => ({ getGlobalRecorder: () => ({ record: mockRecord }) }));
+
+const makeModResult = (speaker: string) => ({
+  responder: speaker, focusPoint: 'f', addressing: 'all', agreementDetected: false,
+  selectionResult: {}, intervention: null, interventionBriefInjection: '',
+  modState: { budget_remaining: 10, budget_total: 10, health_history: [], consecutive_decline: 0, round: 1, phase: 'debate', required_gap: 2, rounds_since_last_intervention: 5, burden_per_debater: {} },
+  healthScore: { value: 0.8, trend: 0, components: {} }, earlyReturn: false,
+  diagnostics: { selectionPrompt: '', selectionResponse: '' },
+});
+const makeTurnResult = (speaker: string) => ({
+  statement: `${speaker} response`, taxonomyRefs: [], meta: { move_types: ['CHALLENGE'], policy_refs: [] },
+  validation: { outcome: 'accept', score: 0.9, repairHints: [], clarifies_taxonomy: [] },
+  attempts: [{ statement: `${speaker} response`, score: 0.9 }],
+  pipelineResult: { draft: {}, total_time_ms: 100, stage_diagnostics: [{ stage: 'draft', prompt: 'p', raw_response: 'r' }], topicAlignmentResult: null },
+  aborted: false,
+});
+const rateLimit = (message: string, httpStatus = 429) => Object.assign(new Error(message), { httpStatus });
+const endedErrors = () => mockRecords.filter(r => r.message === 'debate.ended' && (r.data as Record<string, unknown> | undefined)?.reason === 'error');
+
+function seedDebate() {
+  releaseDebateDriver();
+  useDebateStore.setState({
+    debateGenerating: null, debateError: null, debateProgress: null,
+    activeDebate: makeSession({
+      phase: 'debate', active_povers: ['accelerationist', 'safetyist', 'skeptic'],
+      transcript: [
+        { id: 'o1', timestamp: 't', type: 'opening', speaker: 'accelerationist', content: 'Opening A', taxonomy_refs: [] },
+        { id: 'o2', timestamp: 't', type: 'opening', speaker: 'safetyist', content: 'Opening S', taxonomy_refs: [] },
+        { id: 'o3', timestamp: 't', type: 'opening', speaker: 'skeptic', content: 'Opening K', taxonomy_refs: [] },
+      ],
+    } as never),
+  } as never);
+  mockRecords.length = 0;
+}
+
+describe('crossRespond moderator-selection 429 backoff (t/3053 facet A)', () => {
+  afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+  it('429 then recover: backs off, retries after the cooldown, no debate.ended', async () => {
+    vi.useFakeTimers();
+    vi.mocked(runModeratorSelection)
+      .mockRejectedValueOnce(rateLimit('Rate limited. Retry in 3s'))
+      .mockResolvedValueOnce(makeModResult('accelerationist') as never);
+    vi.mocked(executeTurnWithRetry).mockResolvedValue(makeTurnResult('accelerationist') as never);
+    seedDebate();
+
+    const pending = useDebateStore.getState().crossRespond();
+    await vi.advanceTimersByTimeAsync(3200); // elapse the 3s cooldown → retry fires
+    await pending;
+
+    expect(vi.mocked(runModeratorSelection)).toHaveBeenCalledTimes(2); // failed once, retried once
+    expect(endedErrors(), 'no debate.ended(reason:error) on a recovered 429').toHaveLength(0);
+    expect(useDebateStore.getState().debateError, 'no failure banner after recovery').toBeNull();
+  });
+
+  it('cooldown beyond the 30s cap: terminal banner, never freezes (no sleep scheduled)', async () => {
+    vi.useFakeTimers();
+    vi.mocked(runModeratorSelection).mockRejectedValue(rateLimit('Retry in 60s')); // 60s > 30s cap
+    seedDebate();
+
+    // No timer advance: if a 60s sleep were scheduled this await would hang under fake timers.
+    // Completing here IS the proof it fell through instead of freezing.
+    await useDebateStore.getState().crossRespond();
+
+    expect(vi.mocked(runModeratorSelection)).toHaveBeenCalledTimes(1); // no retry
+    expect(useDebateStore.getState().debateError).toMatch(/Cross-respond selection failed/);
+    expect(endedErrors()).toHaveLength(1);
+  });
+
+  it('non-retryable error: ends terminally exactly once, no retry', async () => {
+    vi.useFakeTimers();
+    vi.mocked(runModeratorSelection).mockRejectedValue(rateLimit('Bad request', 400));
+    seedDebate();
+
+    await useDebateStore.getState().crossRespond();
+
+    expect(vi.mocked(runModeratorSelection)).toHaveBeenCalledTimes(1);
+    expect(endedErrors()).toHaveLength(1);
+    expect(useDebateStore.getState().debateError).toMatch(/Cross-respond selection failed/);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/crossRespondTurnFailure.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/crossRespondTurnFailure.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Regression for t/3053 (facet B): the crossRespond pipeline-failure path appended a NEW
+// system "…failed to cross-respond…" entry on every retry — the S6→S7 duplicate markers
+// jsnover saw. It now keeps ONE idempotent marker per round (metadata.turn_failure + round),
+// matched ANYWHERE in the transcript (not trailing-only) and updated in place on re-failure.
+import { describe, it, expect, vi } from 'vitest';
+import { makeSession } from './storeTestHarness';
+import { useDebateStore } from '../../useDebateStore';
+import { runModeratorSelection, executeTurnWithRetry } from '@lib/debate/orchestration';
+import { releaseDebateDriver } from '../shared/guards';
+
+const makeModResult = (speaker: string) => ({
+  responder: speaker,
+  focusPoint: 'test focus',
+  addressing: 'all',
+  agreementDetected: false,
+  selectionResult: {},
+  intervention: null,
+  interventionBriefInjection: '',
+  modState: {
+    budget_remaining: 10, budget_total: 10, health_history: [],
+    consecutive_decline: 0, round: 1, phase: 'debate', required_gap: 2,
+    rounds_since_last_intervention: 5, burden_per_debater: {},
+  },
+  healthScore: { value: 0.8, trend: 0, components: {} },
+  earlyReturn: false,
+  diagnostics: { selectionPrompt: '', selectionResponse: '' },
+});
+
+function turnFailureEntries() {
+  return (useDebateStore.getState().activeDebate?.transcript ?? []).filter(
+    e => e.type === 'system'
+      && (e.metadata as Record<string, unknown> | undefined)?.turn_failure === true
+      && (e.metadata as Record<string, unknown> | undefined)?.round === 1,
+  );
+}
+
+describe('crossRespond turn-failure marker is idempotent per round (t/3053 facet B)', () => {
+  it('updates the existing round-1 marker in place instead of appending a second', async () => {
+    releaseDebateDriver();
+    vi.mocked(runModeratorSelection).mockResolvedValue(makeModResult('accelerationist') as never);
+    // Force the turn pipeline to fail → crossRespond hits the pipeline catch (the facet-B path).
+    vi.mocked(executeTurnWithRetry).mockRejectedValue(new Error('pipeline boom'));
+
+    useDebateStore.setState({
+      debateGenerating: null, debateError: null,
+      activeDebate: makeSession({
+        phase: 'debate',
+        active_povers: ['accelerationist', 'safetyist', 'skeptic'],
+        transcript: [
+          { id: 'o1', timestamp: 't', type: 'opening', speaker: 'accelerationist', content: 'Opening A', taxonomy_refs: [] },
+          { id: 'o2', timestamp: 't', type: 'opening', speaker: 'safetyist', content: 'Opening S', taxonomy_refs: [] },
+          { id: 'o3', timestamp: 't', type: 'opening', speaker: 'skeptic', content: 'Opening K', taxonomy_refs: [] },
+          // A pre-existing round-1 failure marker from an earlier retry…
+          { id: 'tf1', timestamp: 't', type: 'system', speaker: 'system', content: 'OLD failure text', taxonomy_refs: [], metadata: { turn_failure: true, round: 1 } },
+          // …followed by an unrelated system entry, so the marker is NOT the trailing entry
+          // (proves the dedupe matches anywhere, not just the last entry).
+          { id: 'note', timestamp: 't', type: 'system', speaker: 'system', content: 'some later note', taxonomy_refs: [] },
+        ],
+      } as never),
+    } as never);
+
+    await useDebateStore.getState().crossRespond();
+
+    const markers = turnFailureEntries();
+    expect(markers, 'exactly one round-1 turn-failure marker (updated, not duplicated)').toHaveLength(1);
+    expect(markers[0].id, 'the existing marker was reused').toBe('tf1');
+    expect(markers[0].content, 'the marker content was refreshed').not.toBe('OLD failure text');
+    expect(markers[0].content).toMatch(/failed to cross-respond/i);
+    // The unrelated trailing system entry is untouched.
+    const note = useDebateStore.getState().activeDebate?.transcript.find(e => e.id === 'note');
+    expect(note?.content).toBe('some later note');
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/debatePhaseSlice.ts
@@ -84,6 +84,7 @@ import { computeOperationality } from '@lib/debate/intentionOperationality';
 import { useTaxonomyStore } from '../../useTaxonomyStore';
 import { usePromptConfigStore } from '../../usePromptConfigStore';
 import { mapErrorToUserMessage } from '../../../utils/errorMessages';
+import { classifyAiRetry, parseRetryAfterMs } from '../../../utils/retryClassifier';
 import { cosineSimilarity, scoreNodesLexical } from '../../../utils/taxonomyRelevance';
 import { getConfiguredModel, getSpeakerModel } from '../shared/modelConfig';
 import { generateTextWithProgress, phaseGuardedSet, summarizeTranscriptEntry, makeStageGenerate, routeTurnValidatorHintsIntoSuggestions, getSourceEvidenceIndex, getDocTitles } from '../shared/generation';
@@ -414,12 +415,21 @@ export const createDebatePhaseSlice: StateCreator<DebateStore, [], [], DebatePha
         getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'debate.paused', data: { reason: 'daily_token_limit', round: crossRespondRound, speaker: responderPover } });
         return;
       }
-      addTranscriptEntry({
-        type: 'system',
-        speaker: 'system',
-        content: `${info.label} failed to cross-respond: ${mapErrorToUserMessage(err)}`,
-        taxonomy_refs: [],
-      });
+      // t/3053: idempotent per-round turn-failure marker (mirror t/2907 slot-lifecycle). Each retry
+      // for a failed turn adds no statement, so the round is stable — refresh ONE marker for this
+      // round instead of appending a fresh one every pass (the S6→S7 dupes). Matched anywhere in the
+      // transcript (not trailing-only), keyed on the round.
+      const turnFailureContent = `${info.label} failed to cross-respond: ${mapErrorToUserMessage(err)}`;
+      const existingFailure = get().activeDebate?.transcript.find(
+        e => e.type === 'system'
+          && (e.metadata as Record<string, unknown> | undefined)?.turn_failure === true
+          && (e.metadata as Record<string, unknown> | undefined)?.round === crossRespondRound,
+      );
+      if (existingFailure) {
+        get().updateTranscriptEntry(existingFailure.id, { content: turnFailureContent, metadata: { turn_failure: true, round: crossRespondRound } });
+      } else {
+        addTranscriptEntry({ type: 'system', speaker: 'system', content: turnFailureContent, taxonomy_refs: [], metadata: { turn_failure: true, round: crossRespondRound } });
+      }
       getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'error', debate_id: activeDebate.id, message: 'debate.turn_failed', data: { reason: 'pipeline_error', round: crossRespondRound, speaker: responderPover, error: String(err) } });
     }
 
@@ -1413,33 +1423,59 @@ function buildModeratorTrace(activeDebate: DebateSession, aiPovers: _AiPover[], 
 }
 
 async function runModeratorStep(selectionInput: ModeratorSelectionInput, selectionCallbacks: ModeratorSelectionCallbacks, activeDebate: DebateSession, crossRespondRound: number, phase: DebatePhase, isStillValid: () => boolean, get: _Get, set: _Set, saveDebate: _SaveDebate): Promise<_ModResult | null> {
-    let modResult: Awaited<ReturnType<typeof runModeratorSelection>>;
-    try {
-      modResult = await runModeratorSelection(selectionInput, selectionCallbacks);
-      if (!isStillValid()) {
-        getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'crossRespond aborted post-moderator — debate no longer valid' });
-        releaseDebateDriver(); return null;
+    // t/3053: bounded backoff loop around moderator selection. A transient 429 previously propagated
+    // straight to debate.ended with no wait, so the UI re-entered immediately → 3× loop in 130ms.
+    // Now, on a retryable rate-limit, await the server's cooldown (driving debateProgress so the
+    // DebateActionBar countdown lights up) and retry — up to MAX_MOD_RETRIES within a budget. Never
+    // sleep past the remaining budget or the 30s resilientFetch cap (TL t/3053#3): fall through to
+    // the manual debateError banner instead of freezing.
+    const MAX_MOD_RETRIES = 2;
+    const MOD_RETRY_BUDGET_MS = 2 * 60 * 1000;
+    const MOD_RETRY_CAP_MS = 30_000;
+    const modStartedAt = Date.now();
+    let modResult!: Awaited<ReturnType<typeof runModeratorSelection>>;
+    for (let modPass = 0; ; modPass++) {
+      try {
+        modResult = await runModeratorSelection(selectionInput, selectionCallbacks);
+        if (!isStillValid()) {
+          getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'crossRespond aborted post-moderator — debate no longer valid' });
+          releaseDebateDriver(); set({ debateProgress: null }); return null;
+        }
+        set({ debateProgress: null }); // clear the retry countdown on success
+        break;
+      } catch (err) {
+        // User cancel / model switch (t/2508) — bail quietly, no error toast (helper logged info).
+        if (isCancellationError(err)) { releaseDebateDriver(); set({ debateGenerating: null, debateActivity: null, debateProgress: null }); return null; }
+        const { retryable } = classifyAiRetry(err);
+        const cooldownMs = parseRetryAfterMs(err) ?? 5000;
+        const remainingMs = MOD_RETRY_BUDGET_MS - (Date.now() - modStartedAt);
+        if (retryable && !isDailyLimitError(err) && modPass < MAX_MOD_RETRIES && cooldownMs <= remainingMs && cooldownMs <= MOD_RETRY_CAP_MS) {
+          getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'warn', debate_id: activeDebate.id, message: 'Cross-respond moderator selection rate-limited — backing off', data: { round: crossRespondRound, attempt: modPass + 1, retry_in_ms: cooldownMs } });
+          set({ debateProgress: { attempt: modPass + 1, maxRetries: MAX_MOD_RETRIES, backoffSeconds: Math.ceil(cooldownMs / 1000), phase: 'retry' } });
+          await new Promise(resolve => setTimeout(resolve, cooldownMs));
+          if (!isStillValid()) { releaseDebateDriver(); set({ debateGenerating: null, debateProgress: null }); return null; }
+          continue; // retry the moderator selection after the cooldown
+        }
+        // Terminal: non-retryable, or budget/cap/pass exhausted, or daily-limit.
+        getGlobalRecorder()?.record({
+          type: 'system.error',
+          debate_id: activeDebate?.id,
+          component: 'debate-store',
+          level: 'error',
+          message: 'Cross-respond moderator selection failed',
+          error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+        });
+        releaseDebateDriver();
+        set({ debateProgress: null });
+        if (isDailyLimitError(err)) {
+          set({ debateError: DAILY_LIMIT_MESSAGE, dailyLimitPaused: true, debateGenerating: null });
+          getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'debate.paused', data: { reason: 'daily_token_limit' } });
+        } else {
+          set({ debateError: `Cross-respond selection failed: ${mapErrorToUserMessage(err)}`, debateRetryAction: 'crossRespond', debateGenerating: null });
+          getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'debate.ended', data: { reason: 'error', error: String(err) } });
+        }
+        return null;
       }
-    } catch (err) {
-      // User cancel / model switch (t/2508) — bail quietly, no error toast (helper logged info).
-      if (isCancellationError(err)) { releaseDebateDriver(); set({ debateGenerating: null, debateActivity: null }); return null; }
-      getGlobalRecorder()?.record({
-        type: 'system.error',
-        debate_id: activeDebate?.id,
-        component: 'debate-store',
-        level: 'error',
-        message: 'Cross-respond moderator selection failed',
-        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-      });
-      releaseDebateDriver();
-      if (isDailyLimitError(err)) {
-        set({ debateError: DAILY_LIMIT_MESSAGE, dailyLimitPaused: true, debateGenerating: null });
-        getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'debate.paused', data: { reason: 'daily_token_limit' } });
-      } else {
-        set({ debateError: `Cross-respond selection failed: ${mapErrorToUserMessage(err)}`, debateRetryAction: 'crossRespond', debateGenerating: null });
-        getGlobalRecorder()?.record({ type: 'debate.lifecycle', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'debate.ended', data: { reason: 'error', error: String(err) } });
-      }
-      return null;
     }
 
     if (modResult.earlyReturn && modResult.agreementDetected) {


### PR DESCRIPTION
## Summary
Two tightly-coupled facets in the `crossRespond` catch (TL design t/3053#2, refinements #3).

### Facet A — moderator-selection 429 backoff (`runModeratorStep`)
A transient 429 propagated straight to `debate.ended(reason:'error')` with no wait → the UI re-entered immediately → **`debate.ended` 3× in 130ms**. Now wraps `runModeratorSelection` in a bounded backoff loop (mirrors the opening-statement loop; reuses t/3048's `classifyAiRetry` + `parseRetryAfterMs`):
- On a **retryable** rate-limit: drive `debateProgress {attempt,maxRetries,backoffSeconds,phase:'retry'}` (DebateActionBar countdown lights up for free — TL option **(a)**), `await` the server cooldown, retry — up to **MAX 2** within a **2-min budget**.
- **Never sleep past the remaining budget or the 30s resilientFetch cap** (TL #3): fall through to the manual `debateError` banner instead of freezing.
- `debate.ended` only on non-retryable / budget-or-cap exhausted. Daily-limit + cancel paths unchanged.

### Facet B — idempotent per-round turn-failure marker (pipeline catch, :417)
Each retry appended a **new** system "failed to cross-respond" entry (the S6→S7 dupes). Now tags `metadata:{turn_failure:true, round}` and, if a marker for that round already exists **anywhere** in the transcript (not trailing-only, per TL), **updates it in place** instead of appending. One marker per round. Mirrors the t/2907 opening slot-lifecycle.

## Tests
- **Facet B:** a pre-existing round-1 marker + a non-matching trailing system entry → one failing `crossRespond` **updates** the marker (one entry, content refreshed) and leaves the trailing entry untouched (proves match-anywhere).
- **Facet A** fault-injection test is **t/3055** (TL owns both-arms verification at PR, per t/3053#3).

renderer-tsc **0/0** · eslint **0 errors** · vitest `useDebateStore` **268/268**.

Closes t/3053 · routed to **Main-TL** (state-machine error handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
