### PR TITLE
fix(server): isolate free-tier cursor from BYOK/platform calls (t/3057)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/keyRotator.test.ts
+++ b/taxonomy-editor/src/server/__tests__/keyRotator.test.ts
@@ -9,14 +9,15 @@ import * as rpmLimiterMod from '../ai/rpmLimiter.js';
 const KEYS = ['key-pool-a', 'key-pool-b', 'key-pool-c'];
 const BACKEND = 'gemini';
 
-// Rotation/cooldown tests: leave FREE_TIER_GEMINI_KEY unset so these keys are NOT
-// in the pool and pacing is never acquired — avoids real setTimeout delays in CI.
+// Rotation/cooldown tests: put KEYS in the pool so allFree=true and rotation fires.
+// Pacing acquire() resolves immediately for calls within the burst (< RPM_PER_KEY per
+// key), which all tests below satisfy — no real setTimeout delays in CI.
 
 beforeEach(() => {
   resetRotator();
   resetLimiters();
   vi.restoreAllMocks();
-  delete process.env.FREE_TIER_GEMINI_KEY;
+  process.env.FREE_TIER_GEMINI_KEY = KEYS.join(',');
 });
 
 afterEach(() => {
@@ -125,6 +126,33 @@ describe('callWithKeyRotation — free-tier pool discriminator (t/3052)', () => 
 
     await callWithKeyRotation(BACKEND, ['byok-paid-key-xyz'], async (k) => k);
     expect(getLimiterSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('callWithKeyRotation — BYOK cursor isolation (t/3057)', () => {
+  it('BYOK call does not reset the free-tier pool cursor', async () => {
+    process.env.FREE_TIER_GEMINI_KEY = KEYS.join(',');
+    const poolUsed: string[] = [];
+    const byokUsed: string[] = [];
+    const fn = (store: string[]) => async (k: string) => { store.push(k); return k; };
+
+    // First free-tier call: cursor advances pool[0] → pool[1]
+    await callWithKeyRotation(BACKEND, KEYS, fn(poolUsed));
+    // Interleaved BYOK call (single non-pool key): must NOT reset the cursor
+    await callWithKeyRotation(BACKEND, ['byok-key-xyz'], fn(byokUsed));
+    // Second free-tier call: cursor should pick pool[1], not pool[0]
+    await callWithKeyRotation(BACKEND, KEYS, fn(poolUsed));
+
+    expect(poolUsed[0]).toBe(KEYS[0]);   // first free-tier call
+    expect(byokUsed[0]).toBe('byok-key-xyz'); // BYOK always gets its own key
+    expect(poolUsed[1]).toBe(KEYS[1]);   // cursor not reset — pool[0] would mean it was
+  });
+
+  it('BYOK call always returns keys[0] regardless of cursor position', async () => {
+    const used: string[] = [];
+    await callWithKeyRotation(BACKEND, ['byok-only'], async (k) => { used.push(k); return k; });
+    await callWithKeyRotation(BACKEND, ['byok-only'], async (k) => { used.push(k); return k; });
+    expect(used).toEqual(['byok-only', 'byok-only']);
   });
 });
 

--- a/taxonomy-editor/src/server/ai/keyRotator.ts
+++ b/taxonomy-editor/src/server/ai/keyRotator.ts
@@ -49,9 +49,14 @@ function freeTierKeySet(): Set<string> {
  * belongs to the free-tier pool (detected via parseFreeTierKeys — no flag to
  * thread or forget), call fn(key), and on 429 mark the key cooled until Retry-After.
  *
- * Pacing applies automatically to every caller that uses a free-tier key — paid /
- * BYOK paths carry their own keys and are never in the pool, so they bypass pacing
- * with no per-call configuration.
+ * Rotation and pacing share one discriminator: allFree = every key in `keys` is a
+ * free-tier pool member. BYOK/platform callers pass a single non-pool key → allFree
+ * is false → they bypass both rotation (cursor untouched) and pacing (no rate limit).
+ * This prevents BYOK keys[0] (len=1) from resetting the shared free-tier cursor to 0
+ * and skewing round-robin distribution (t/3057).
+ *
+ * v1 assumption: non-pool callers always pass a single key. If multi-key non-pool
+ * callers are ever added, they will always receive keys[0] without rotation — revisit.
  *
  * Per-caller audit (t/3052 #4 completeness): primary debate path (generateWithPaidFallback),
  * /api/ai/search, /api/ai/generate, chat-stream, sources evidence-eval (sources.ts),
@@ -65,8 +70,11 @@ export async function callWithKeyRotation<T>(
   keys: string[],
   fn: (key: string) => Promise<T>,
 ): Promise<T> {
-  const key = nextKey(backend, keys);
-  if (freeTierKeySet().has(key)) {
+  const pool = freeTierKeySet();
+  // keys.length > 0 guard: [].every() is vacuously true; empty keys should fail before here.
+  const allFree = keys.length > 0 && keys.every(k => pool.has(k));
+  const key = allFree ? nextKey(backend, keys) : keys[0];
+  if (allFree) {
     await getLimiter(key, FREE_TIER_RPM_PER_KEY).acquire();
   }
   try {


### PR DESCRIPTION
## Summary
- `callWithKeyRotation` now gates **both** rotation and pacing on `allFree = keys.length > 0 && keys.every(k => pool.has(k))`
- Non-pool (BYOK/platform) callers return `keys[0]` without advancing the shared cursor — eliminates pool[0]-bias under mixed traffic
- Empty-keys guard (`keys.length > 0`) prevents vacuous-true on `[].every()`

## Test plan
- [x] New regression test: BYOK call interleaved between two free-tier calls; free-tier cursor advances pool[0]→pool[1] (not reset)
- [x] New test: BYOK always returns `keys[0]` regardless of cursor position
- [x] All 11 existing tests pass (rotation, cooldown, discriminator, backend isolation)
- [x] tsc clean

Closes t/3057. Relates t/3052, t/3056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBHGCvj3awBhE3jYPYATPG