### PR TITLE
fix(server): invert withRetry/callWithKeyRotation — rotate on 429 before 120s backoff (t/3062)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/keyRotator.test.ts
+++ b/taxonomy-editor/src/server/__tests__/keyRotator.test.ts
@@ -50,47 +50,69 @@ describe('callWithKeyRotation — round-robin distribution (t/3056)', () => {
   });
 });
 
-describe('callWithKeyRotation — 429 cooldown skipping (t/3056)', () => {
-  it('skips a key that returned 429 until its cooldown expires', async () => {
+describe('callWithKeyRotation — within-call 429 rotation (t/3062)', () => {
+  it('immediately tries next key on 429 within the same call', async () => {
     const used: string[] = [];
-    const fn = async (k: string) => { used.push(k); return k; };
-
-    // First call: key[0] is selected and throws 429.
     const err429 = new Error('429 Too Many Requests, retry-after: 60s');
-    let firstCall = true;
-    const failThenSucceed = async (k: string) => {
+
+    // key[0] always 429s; key[1] succeeds.
+    const fn = async (k: string) => {
       used.push(k);
-      if (firstCall) { firstCall = false; throw err429; }
+      if (k === KEYS[0]) throw err429;
       return k;
     };
 
-    await expect(callWithKeyRotation(BACKEND, KEYS, failThenSucceed)).rejects.toThrow('429');
-    // key[0] is now cooled; next two calls should use key[1] and key[2].
-    await callWithKeyRotation(BACKEND, KEYS, fn);
-    await callWithKeyRotation(BACKEND, KEYS, fn);
-
-    expect(used[0]).toBe(KEYS[0]); // original 429 attempt
-    expect(used[1]).toBe(KEYS[1]); // skipped key[0]
-    expect(used[2]).toBe(KEYS[2]); // skipped key[0]
+    const result = await callWithKeyRotation(BACKEND, KEYS, fn);
+    expect(result).toBe(KEYS[1]);
+    expect(used).toEqual([KEYS[0], KEYS[1]]); // tried key[0], rotated to key[1]
   });
 
-  it('falls through to the cooled key when all keys are cooled', async () => {
+  it('cools 429 key and subsequent calls skip it', async () => {
+    const used: string[] = [];
+    const err429 = new Error('429 Too Many Requests, retry-after: 60s');
+
+    // First call: key[0] 429s, key[1] succeeds internally.
+    await callWithKeyRotation(BACKEND, KEYS, async (k) => {
+      used.push(k);
+      if (k === KEYS[0]) throw err429;
+      return k;
+    });
+
+    // Next call: cursor is at key[2]; key[0] is cooled but key[2] is available.
+    await callWithKeyRotation(BACKEND, KEYS, async (k) => { used.push(k); return k; });
+
+    expect(used[0]).toBe(KEYS[0]); // first attempt, cooled
+    expect(used[1]).toBe(KEYS[1]); // rotation within first call
+    expect(used[2]).toBe(KEYS[2]); // second top-level call advances cursor
+  });
+
+  it('rethrows after exhausting all keys on 429 (all-cooled arm)', async () => {
     const err429 = new Error('429 Too Many Requests');
 
-    // Cool all 3 keys by throwing 429 on each.
-    for (const _ of KEYS) {
-      await expect(
-        callWithKeyRotation(BACKEND, KEYS, async (_k) => { throw err429; })
-      ).rejects.toThrow('429');
-    }
+    // Single call exhausts all 3 keys (each 429s), then rethrows.
+    await expect(
+      callWithKeyRotation(BACKEND, KEYS, async () => { throw err429; })
+    ).rejects.toThrow('429');
 
-    // All keys cooled — next call must still pick a key (no infinite loop / undefined).
+    // All keys are now cooled; next call still picks a key (no infinite loop).
     const used: string[] = [];
     await expect(
       callWithKeyRotation(BACKEND, KEYS, async (k) => { used.push(k); throw new Error('still failing'); })
     ).rejects.toThrow('still failing');
     expect(used).toHaveLength(1);
     expect(KEYS).toContain(used[0]);
+  });
+
+  it('AbortError short-circuits rotation immediately without trying other keys', async () => {
+    const used: string[] = [];
+    const abortErr = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+
+    await expect(
+      callWithKeyRotation(BACKEND, KEYS, async (k) => { used.push(k); throw abortErr; })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    // Must not have rotated to key[1] or key[2].
+    expect(used).toHaveLength(1);
+    expect(used[0]).toBe(KEYS[0]);
   });
 });
 

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -371,20 +371,22 @@ export async function generateText(
     const apiModel = getApiModelId(currentModel);
     const opts = buildGenerateOptions(options, timeoutMs, currentModel, entryMap);
 
-    const runWithRetry = (apiKey: string) => withRetry(
-      () => callProvider(fetch, backend, prompt, apiModel, apiKey, opts),
-      SERVER_RETRY_CONFIG,
-      `${backend}/${apiModel}`,
-      (msg: string) => reportProviderRetry(msg, backend, apiModel, onRetry),
-      // t/2510: signal-aware backoff + pre-attempt abort check; an AbortError is
-      // rethrown non-retryable so a deliberate cancel never enters the retry ladder.
-      options?.signal,
-    );
-
     try {
       // t/3052+t/3056: rotate across the key pool (round-robin + 429 cooldown);
       // callWithKeyRotation paces free-tier keys automatically via pool membership.
-      const result = await callWithKeyRotation(backend, keys, runWithRetry);
+      // t/3062: withRetry wraps callWithKeyRotation (not inside it) so a 429 bubbles
+      // out to the rotation loop immediately; the inner loop exhausts the key pool
+      // before outer withRetry ever sees the error and backs off for 120s.
+      // t/2510: signal-aware backoff + pre-attempt abort check; an AbortError is
+      // rethrown non-retryable so a deliberate cancel never enters the retry ladder.
+      const result = await withRetry(
+        () => callWithKeyRotation(backend, keys,
+          (apiKey) => callProvider(fetch, backend, prompt, apiModel, apiKey, opts)),
+        SERVER_RETRY_CONFIG,
+        `${backend}/${apiModel}`,
+        (msg: string) => reportProviderRetry(msg, backend, apiModel, onRetry),
+        options?.signal,
+      );
 
       if (mi > 0) {
         getGlobalRecorder()?.record({

--- a/taxonomy-editor/src/server/ai/keyRotator.ts
+++ b/taxonomy-editor/src/server/ai/keyRotator.ts
@@ -20,8 +20,6 @@ function keyHash(key: string): string {
 }
 
 // Round-robin across keys, skipping any in their 429 cooldown window.
-// No within-call rotation — a single callWithKeyRotation picks one key and uses
-// it for the duration of that call; rotation applies across successive calls (v1).
 function nextKey(backend: string, keys: string[]): { key: string; slot: number } {
   const base = _cursors.get(backend) ?? 0;
   const N = keys.length;
@@ -66,12 +64,22 @@ function freeTierKeySet(): Set<string> {
  * v1 assumption: non-pool callers always pass a single key. If multi-key non-pool
  * callers are ever added, they will always receive keys[0] without rotation — revisit.
  *
- * Per-caller audit (t/3052 #4 completeness): primary debate path (generateWithPaidFallback),
- * /api/ai/search, /api/ai/generate, chat-stream, sources evidence-eval (sources.ts),
- * news-report (debates.ts), web op-ed (opedAdapter.ts), and generateWithSearch all
- * route through callWithKeyRotation. Those that pass the FREE_TIER_GEMINI_KEY pool
- * explicitly are paced. Those that pass getApiKeys() keys (BYOK/platform GEMINI_API_KEY)
- * are not in the pool and correctly bypass pacing — no flag to thread or forget.
+ * On 429, the cooled key is marked and the loop immediately tries the next available
+ * key (up to keys.length attempts for free-tier). This prevents outer withRetry from
+ * burning its 120s minimum backoff against the same exhausted key (t/3062). When all
+ * keys are 429'd the last error is rethrown so outer withRetry backs off normally.
+ * AbortError bypasses rotation and propagates immediately.
+ *
+ * Per-caller audit (t/3052 #4, updated t/3061+t/3062): all server paths using the
+ * FREE_TIER_GEMINI_KEY pool were audited:
+ * - Generate: generateWithPaidFallback, /api/ai/search, /api/ai/generate, chat-stream,
+ *   sources.ts, debates.ts, opedAdapter.ts, generateWithSearch → all route here ✓
+ * - Embeddings: /api/embeddings/compute + /api/embeddings/query → local ONNX, key=undefined,
+ *   bypass pacing (zero Gemini quota); separate embed:<ip> bucket guards CPU-abuse (t/3061) ✓
+ * - NLI: /api/nli/classify → passes key pool directly to classifyNli (t/3061 t/1650 restore) ✓
+ * - resolveExplicitAiKey (routes/ai.ts + chat.ts): returns full array for callWithKeyRotation ✓
+ * - server.ts + meta.ts: pool size diagnostic only, no AI calls ✓
+ * BYOK/platform pass a single non-pool key → allFree=false → bypass pacing (no flag to thread).
  */
 export async function callWithKeyRotation<T>(
   backend: string,
@@ -81,22 +89,35 @@ export async function callWithKeyRotation<T>(
   const pool = freeTierKeySet();
   // keys.length > 0 guard: [].every() is vacuously true; empty keys should fail before here.
   const allFree = keys.length > 0 && keys.every(k => pool.has(k));
-  const { key, slot } = allFree ? nextKey(backend, keys) : { key: keys[0], slot: undefined };
-  const kh = keyHash(key);
-  log.api.debug({ key_hash: kh, key_slot: slot, backend }, 'keyRotator: selected');
-  if (allFree) {
-    await getLimiter(key, FREE_TIER_RPM_PER_KEY).acquire();
-  }
-  try {
-    return await fn(key);
-  } catch (err) {
-    if (is429Error(err)) {
-      const delay = retryAfterMs(err);
-      markKeyCooled(key, delay);
-      log.api.warn({ key_hash: kh, key_slot: slot, delay_ms: delay }, 'keyRotator: 429 on key, cooling');
+  // Free-tier: try each key at most once before letting outer withRetry back off.
+  // BYOK: single attempt — no rotation.
+  const maxAttempts = allFree ? keys.length : 1;
+  let lastErr: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const { key, slot } = allFree ? nextKey(backend, keys) : { key: keys[0], slot: undefined };
+    const kh = keyHash(key);
+    log.api.debug({ key_hash: kh, key_slot: slot, backend, attempt }, 'keyRotator: selected');
+    if (allFree) {
+      await getLimiter(key, FREE_TIER_RPM_PER_KEY).acquire();
     }
-    throw err;
+    try {
+      return await fn(key);
+    } catch (err) {
+      // Abort must never rotate — propagate immediately.
+      if ((err as { name?: unknown } | null)?.name === 'AbortError') throw err;
+      if (is429Error(err)) {
+        const delay = retryAfterMs(err);
+        markKeyCooled(key, delay);
+        log.api.warn({ key_hash: kh, key_slot: slot, delay_ms: delay, attempt }, 'keyRotator: 429 on key, cooling — trying next');
+        lastErr = err;
+        continue; // immediately try next key; no sleep
+      }
+      throw err;
+    }
   }
+  // All keys 429'd — rethrow so outer withRetry sees the 429 and backs off.
+  throw lastErr;
 }
 
 /** Reset all rotator state — for test isolation only. */


### PR DESCRIPTION
## Summary
- **Root cause (t/3062):** `withRetry` was nested *inside* `callWithKeyRotation`'s `fn`. A 429 was caught by the inner retry loop and backed off 120 s against the **same exhausted key** before the rotation cursor ever advanced.
- **Fix — `keyRotator.ts`:** Bounded rotation loop (up to `keys.length` attempts for free-tier). On 429: mark key cooled, immediately try next key — no sleep. When all keys are 429'd, rethrow so outer `withRetry` backs off.
- **Fix — `aiBackends.ts`:** `withRetry` now wraps `callWithKeyRotation` (inverted nesting). 429 bubbles out to rotation loop first.
- **Also:** `keyHash` hashes only 75% of the key prefix + `codeql[js/insufficient-password-hash]` suppression.
- **Tests updated:** within-call rotation arm, all-cooled rethrow arm, AbortError short-circuit arm.

Stacked on #1592 (t/3061). Will rebase on main after #1591 and #1592 land; retarget PR base to main then.

## Test plan
- [ ] CI passes (keyRotator.test.ts covers all three new behavior arms)
- [ ] Pre-self-merge verify: base=main, head matches push, CI green on that OID, no holds
- [ ] Rebase on main after #1591 + #1592 land and retarget PR

Generated with Claude Code