### PR TITLE
feat(diagnostics): Get-DebateRateLimitSummary — summarize 429 pattern from a flight recorder dump (t/3065)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -130,6 +130,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Test-AIBackendQuota` | Per-backend quota probe — flags quota-exhausted backends (Status='quota') with a best-effort ResetAt; use at session start to catch quota exhaustion before a wall of judge failures (t/3029) |
 | `Test-DebateIndexIntegrity` | Validate debate-*.json field types for UI-crash regressions — catches the object-as-title bug (t/2335) |
 | `Get-DebateIndexHealth` | Scan the aggregated `.debate-index.json` for type-invalid entries (object-as-title etc.); `-Repair` deletes bad entries for re-extraction on next launch (t/2735) |
+| `Get-DebateRateLimitSummary` | Summarize 429/rate-limit patterns from a flight recorder dump — per-bucket (`embed:<ip>`/`free:<ip>`) count, first/last, retry-after min/max/mean/distinct; reuses `Get-FlightRecorderReport` (t/3065) |
 | `Test-DebatePersistence` | Pre-flight atomic write+rename probe for the debates output dir — call before AI generation to surface LOCKED/NO_PERMISSION early (t/2545) |
 | `Get-ContainerAppRevision` | Query ACA revisions by mode (Active/Stale/Fqdn) — replaces raw `az containerapp revision` calls (t/1498) |
 | `Get-ServerLog` | Retrieve + filter ACA server logs, correlate by Pino requestId — `-RequestId`/`-Recent`/`-StartTime`/`-Pattern` sets, `-Level`/`-Component`/`-Follow`/`-Raw` (t/2765) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -233,6 +233,8 @@
         'Test-DebateIndexIntegrity'
         # t/2735 — Debate index (.debate-index.json) type-invalid entry scan + repair
         'Get-DebateIndexHealth'
+        # t/3065 — 429/rate-limit pattern summary from a flight recorder dump
+        'Get-DebateRateLimitSummary'
         # t/2367 — Debate blob existence check in Azure storage
         'Test-DebateSession'
         # t/2545 — Pre-flight atomic write+rename probe for debate output dir

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -981,6 +981,8 @@ Export-ModuleMember -Function @(
     'Test-DebateIndexIntegrity'
     # t/2735 — Debate index (.debate-index.json) type-invalid entry scan + repair
     'Get-DebateIndexHealth'
+    # t/3065 — 429/rate-limit pattern summary from a flight recorder dump
+    'Get-DebateRateLimitSummary'
     # t/2367 — Debate blob existence check in Azure storage
     'Test-DebateSession'
     # t/2545 — Pre-flight atomic write+rename probe for debate output dir

--- a/scripts/AITriad/Public/Get-DebateRateLimitSummary.ps1
+++ b/scripts/AITriad/Public/Get-DebateRateLimitSummary.ps1
@@ -1,0 +1,183 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Summarizes HTTP 429 / rate-limit patterns from a flight recorder JSONL dump, grouped by bucket.
+.DESCRIPTION
+    Reads a (merged) flight recorder dump and reports, per rate-limit bucket: how many 429s fired,
+    the first/last time, and the retry-after distribution (min/max/mean + distinct-value count).
+    Distinct retry-after values across one bucket hint at multiple keys / sub-buckets behind it.
+
+    Parsing reuses Get-FlightRecorderReport (-Detailed -AsObject) — this cmdlet is a classifier over
+    its .Events, not a second JSONL parser.
+
+    Rate-limit events are identified by schema (see lib/flight-recorder/types.ts and
+    taxonomy-editor/src/server/routes/ai.ts):
+      - server rate-limiter : type == 'ai.error' with data.limitKey (or data.type in
+                              requests_per_minute / tokens_per_day). Bucket = data.limitKey
+                              (e.g. 'embed:<ip>' — per-IP local-ONNX bucket, t/3061; 'free:<ip>' —
+                              shared free-tier generate bucket). retry-after = ceil(data.retryAfterMs/1000).
+      - client 429          : data.http_status == 429 (instrumented web bridge). Bucket = data.method
+                              (or data.category). retry-after = data.retry_after_s (when present).
+      - github rate limit   : type == 'github.api.rate_limit'.
+
+    SCHEMA REALITY (differs from the ticket's proposal, by design):
+      - There is no 'rate_limit_source' field in the dump. Bucket identity is data.limitKey; the
+        Source column is its prefix (embed / free / client / github), with LimitType/Backend/Tier
+        carrying the rest.
+      - retry_after is normalized to seconds from two source fields with different units
+        (server data.retryAfterMs [ms], client data.retry_after_s [s]).
+      - Per-KEY identity (key_hash / key_slot) is NOT in the flight recorder dump — it is only in the
+        Pino server log stream (keyRotator). So "were retries on the same key?" cannot be answered
+        from a dump; RetryAfterDistinct is the closest bucket-level signal. For key-level attribution,
+        cross-reference the server Pino logs.
+.PARAMETER Path
+    Path to the flight recorder JSONL dump (merged client+server dump preferred). Accepts pipeline
+    input by property name (alias FullName) from Get-FlightRecorderDump / Merge-FlightRecorderDumps.
+.PARAMETER PerEvent
+    Emit one flat record per rate-limit event (Bucket, Source, LimitType, Backend, Tier,
+    RetryAfterSec, WallMs) instead of the grouped per-bucket summary. Useful for drilling in.
+.OUTPUTS
+    [PSCustomObject] (AITriad.RateLimitSummary) grouped rows, or flat per-event records with -PerEvent.
+.EXAMPLE
+    Get-DebateRateLimitSummary -Path ./merged-dump.jsonl
+    # Per-bucket 429 summary: Bucket, Source, Count, FirstAt/LastAt, retry-after min/max/mean/distinct.
+.EXAMPLE
+    Get-LatestFlightRecorderDump | Merge-FlightRecorderDumps | Get-DebateRateLimitSummary
+.EXAMPLE
+    Get-DebateRateLimitSummary -Path ./merged-dump.jsonl -PerEvent | Sort-Object WallMs
+    # Every 429 event in time order.
+.LINK
+    Get-FlightRecorderReport
+.LINK
+    Merge-FlightRecorderDumps
+.LINK
+    Show-AITriadHelp
+#>
+function Get-DebateRateLimitSummary {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, Position = 0)]
+        [Alias('FullName')]
+        [string]$Path,
+
+        [switch]$PerEvent
+    )
+
+    process {
+        Set-StrictMode -Version Latest
+
+        # Reuse the canonical JSONL parser (throws New-ActionableError on a missing file).
+        $report = Get-FlightRecorderReport -Path $Path -Detailed -AsObject
+        $events = if ($report.PSObject.Properties['Events']) { @($report.Events) } else { @() }
+
+        $records = [System.Collections.Generic.List[PSObject]]::new()
+
+        foreach ($e in $events) {
+            $type = if ($e.PSObject.Properties['type']) { [string]$e.type } else { '' }
+            $data = if ($e.PSObject.Properties['data']) { $e.data } else { $null }
+            $wall = if ($e.PSObject.Properties['_wall']) { [long]$e._wall } else { $null }
+
+            $isRL      = $false
+            $bucket    = $null
+            $source    = $null
+            $limitType = $null
+            $backend   = $null
+            $tier      = $null
+            $retrySec  = $null
+
+            if ($null -ne $data) {
+                $hasLimitKey = [bool]$data.PSObject.Properties['limitKey']
+                $dtype       = if ($data.PSObject.Properties['type']) { [string]$data.type } else { '' }
+                $httpStatus  = if ($data.PSObject.Properties['http_status']) { $data.http_status } else { $null }
+
+                if ($type -eq 'ai.error' -and ($hasLimitKey -or $dtype -in 'requests_per_minute', 'tokens_per_day')) {
+                    # ── Server-side rate-limiter event ──
+                    $isRL      = $true
+                    $bucket    = if ($hasLimitKey) { [string]$data.limitKey } else { $dtype }
+                    $source    = if ($bucket -match '^([^:]+):') { $Matches[1] } else { 'server' }
+                    $limitType = $dtype
+                    if ($data.PSObject.Properties['backend']) { $backend = [string]$data.backend }
+                    if ($data.PSObject.Properties['tier'])    { $tier    = "$($data.tier)" }
+                    if ($data.PSObject.Properties['retryAfterMs'] -and $null -ne $data.retryAfterMs) {
+                        $retrySec = [int][math]::Ceiling([double]$data.retryAfterMs / 1000)
+                    }
+                }
+                elseif ($null -ne $httpStatus -and [int]$httpStatus -eq 429) {
+                    # ── Client-side 429 from the instrumented web bridge ──
+                    $isRL   = $true
+                    $bucket = if ($data.PSObject.Properties['method'])   { [string]$data.method }
+                              elseif ($data.PSObject.Properties['category']) { [string]$data.category }
+                              else { 'client' }
+                    $source = 'client'
+                    if ($data.PSObject.Properties['retry_after_s'] -and $null -ne $data.retry_after_s) {
+                        $retrySec = [int][math]::Ceiling([double]$data.retry_after_s)
+                    }
+                }
+            }
+
+            if (-not $isRL -and $type -eq 'github.api.rate_limit') {
+                # ── GitHub API rate limit ──
+                $isRL   = $true
+                $bucket = 'github'
+                $source = 'github'
+                if ($null -ne $data -and $data.PSObject.Properties['retry_after_s'] -and $null -ne $data.retry_after_s) {
+                    $retrySec = [int][math]::Ceiling([double]$data.retry_after_s)
+                }
+            }
+
+            if ($isRL) {
+                $records.Add([PSCustomObject]@{
+                    Bucket        = $bucket
+                    Source        = $source
+                    LimitType     = $limitType
+                    Backend       = $backend
+                    Tier          = $tier
+                    RetryAfterSec = $retrySec
+                    WallMs        = $wall
+                })
+            }
+        }
+
+        if ($records.Count -eq 0) {
+            Write-Warning "No rate-limit / HTTP 429 events found in $Path."
+            return
+        }
+
+        if ($PerEvent) {
+            $records | Sort-Object WallMs
+            return
+        }
+
+        # ── Group by bucket → per-bucket summary ──
+        $records | Group-Object Bucket | ForEach-Object {
+            $g       = @($_.Group)
+            $retries = @($g | Where-Object { $null -ne $_.RetryAfterSec } | ForEach-Object { [int]$_.RetryAfterSec })
+            $walls   = @($g | Where-Object { $null -ne $_.WallMs } | ForEach-Object { [long]$_.WallMs })
+
+            $first = if ($walls.Count) { [DateTimeOffset]::FromUnixTimeMilliseconds(($walls | Measure-Object -Minimum).Minimum).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ') } else { $null }
+            $last  = if ($walls.Count) { [DateTimeOffset]::FromUnixTimeMilliseconds(($walls | Measure-Object -Maximum).Maximum).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ') } else { $null }
+            $rmin  = if ($retries.Count) { ($retries | Measure-Object -Minimum).Minimum } else { $null }
+            $rmax  = if ($retries.Count) { ($retries | Measure-Object -Maximum).Maximum } else { $null }
+            $rmean = if ($retries.Count) { [math]::Round(($retries | Measure-Object -Average).Average, 1) } else { $null }
+
+            [PSCustomObject]@{
+                PSTypeName         = 'AITriad.RateLimitSummary'
+                Bucket             = $_.Name
+                Source             = $g[0].Source
+                Count              = $g.Count
+                FirstAt            = $first
+                LastAt             = $last
+                RetryAfterMinSec   = $rmin
+                RetryAfterMaxSec   = $rmax
+                RetryAfterMeanSec  = $rmean
+                RetryAfterDistinct = @($retries | Sort-Object -Unique).Count
+                LimitType          = (@($g | Where-Object { $_.LimitType } | ForEach-Object { $_.LimitType }) | Select-Object -Unique) -join ','
+                Backend            = (@($g | Where-Object { $_.Backend } | ForEach-Object { $_.Backend }) | Select-Object -Unique) -join ','
+                Tier               = (@($g | Where-Object { $_.Tier } | ForEach-Object { $_.Tier }) | Select-Object -Unique) -join ','
+            }
+        } | Sort-Object Bucket
+    }
+}

--- a/tests/Get-DebateRateLimitSummary.Tests.ps1
+++ b/tests/Get-DebateRateLimitSummary.Tests.ps1
@@ -1,0 +1,113 @@
+# Tag: diagnostics (t/3065)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Tests for Get-DebateRateLimitSummary (t/3065) — 429/rate-limit summary from a flight recorder dump.
+.DESCRIPTION
+    Builds a throwaway JSONL dump with server rate-limiter events (embed:/free: buckets, retryAfterMs)
+    and a client 429 (http_status/retry_after_s), plus non-rate-limit noise, then asserts the grouped
+    summary. _wall is epoch-ms (matching lib/flight-recorder/types.ts), NOT the ISO strings used in the
+    TS test mocks.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    function New-RlDumpFixture {
+        param([switch]$NoRateLimit)
+
+        $path = Join-Path ([System.IO.Path]::GetTempPath()) "rl-$([guid]::NewGuid().ToString('N').Substring(0,8)).jsonl"
+        $lines = [System.Collections.Generic.List[string]]::new()
+        $lines.Add((@{ _type = 'header'; schema_version = '1.0.0'; ring_buffer_capacity = 500 } | ConvertTo-Json -Compress -Depth 5))
+
+        function _Evt($h) { $h['_type'] = 'event'; ($h | ConvertTo-Json -Compress -Depth 6) }
+
+        if (-not $NoRateLimit) {
+            $base = 1756310000000  # arbitrary epoch-ms
+            # embed:<ip> per-IP local-ONNX bucket — 3× 429 with distinct retryAfterMs (44s / 3s / 45s)
+            $lines.Add((_Evt @{ type = 'ai.error'; component = 'rate-limiter'; level = 'warn'; _wall = $base + 1000; message = 'RPM limit reached (60/60)'; data = @{ type = 'requests_per_minute'; limitKey = 'embed:203.0.113.7'; limit = 60; current = 60; retryAfterMs = 44000; backend = 'local-onnx'; tier = 'free' } }))
+            $lines.Add((_Evt @{ type = 'ai.error'; component = 'rate-limiter'; level = 'warn'; _wall = $base + 2000; message = 'RPM limit reached (60/60)'; data = @{ type = 'requests_per_minute'; limitKey = 'embed:203.0.113.7'; limit = 60; current = 60; retryAfterMs = 3000;  backend = 'local-onnx'; tier = 'free' } }))
+            $lines.Add((_Evt @{ type = 'ai.error'; component = 'rate-limiter'; level = 'warn'; _wall = $base + 3000; message = 'RPM limit reached (60/60)'; data = @{ type = 'requests_per_minute'; limitKey = 'embed:203.0.113.7'; limit = 60; current = 60; retryAfterMs = 45000; backend = 'local-onnx'; tier = 'free' } }))
+            # free:<ip> shared generate bucket — 2× 429
+            $lines.Add((_Evt @{ type = 'ai.error'; component = 'rate-limiter'; level = 'warn'; _wall = $base + 1500; message = 'RPM limit reached (30/30)'; data = @{ type = 'requests_per_minute'; limitKey = 'free:203.0.113.7'; limit = 30; current = 30; retryAfterMs = 46000; backend = 'gemini'; tier = 'free' } }))
+            $lines.Add((_Evt @{ type = 'ai.error'; component = 'rate-limiter'; level = 'warn'; _wall = $base + 4000; message = 'RPM limit reached (30/30)'; data = @{ type = 'requests_per_minute'; limitKey = 'free:203.0.113.7'; limit = 30; current = 30; retryAfterMs = 4000;  backend = 'gemini'; tier = 'free' } }))
+            # client-side 429 from the instrumented web bridge
+            $lines.Add((_Evt @{ type = 'ai.error'; component = 'web-bridge'; level = 'warn'; _wall = $base + 5000; message = 'HTTP 429'; data = @{ method = 'PUT /api/debates'; category = 'debate'; http_status = 429; retry_after_s = 46 } }))
+        }
+        # non-rate-limit noise (must be ignored)
+        $lines.Add((_Evt @{ type = 'ai.response'; component = 'ai-generate'; level = 'info'; _wall = 1756310009000; message = 'ok'; data = @{ duration_ms = 12 } }))
+        $lines.Add((_Evt @{ type = 'debate.phase'; component = 'orchestrator'; level = 'info'; _wall = 1756310010000; data = @{ phase = 'opening' } }))
+
+        Set-Content -LiteralPath $path -Value $lines -Encoding utf8
+        return $path
+    }
+}
+
+Describe 'Get-DebateRateLimitSummary' -Tag 'diagnostics' {
+
+    It 'is exported from the module' {
+        Get-Command -Module AITriad -Name 'Get-DebateRateLimitSummary' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'groups by bucket and ignores non-rate-limit events' {
+        $p = New-RlDumpFixture
+        try {
+            $r = @(Get-DebateRateLimitSummary -Path $p)
+            $r.Count | Should -Be 3   # embed:, free:, client method — noise excluded
+            ($r.Bucket | Sort-Object) | Should -Contain 'embed:203.0.113.7'
+            ($r.Bucket | Sort-Object) | Should -Contain 'free:203.0.113.7'
+            ($r.Bucket | Sort-Object) | Should -Contain 'PUT /api/debates'
+        } finally { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'computes the embed bucket count + retry-after stats (ms→s) correctly' {
+        $p = New-RlDumpFixture
+        try {
+            $embed = Get-DebateRateLimitSummary -Path $p | Where-Object Bucket -eq 'embed:203.0.113.7'
+            $embed.Count              | Should -Be 3
+            $embed.Source             | Should -Be 'embed'
+            $embed.LimitType          | Should -Be 'requests_per_minute'
+            $embed.Backend            | Should -Be 'local-onnx'
+            $embed.RetryAfterMinSec   | Should -Be 3
+            $embed.RetryAfterMaxSec   | Should -Be 45
+            $embed.RetryAfterMeanSec  | Should -Be 30.7   # (44+3+45)/3
+            $embed.RetryAfterDistinct | Should -Be 3
+            $embed.PSObject.TypeNames | Should -Contain 'AITriad.RateLimitSummary'
+        } finally { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'classifies the client 429 (http_status/retry_after_s) with Source=client' {
+        $p = New-RlDumpFixture
+        try {
+            $client = Get-DebateRateLimitSummary -Path $p | Where-Object Bucket -eq 'PUT /api/debates'
+            $client.Source           | Should -Be 'client'
+            $client.Count            | Should -Be 1
+            $client.RetryAfterMaxSec | Should -Be 46
+        } finally { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
+    }
+
+    It '-PerEvent emits one flat record per 429 event, in time order' {
+        $p = New-RlDumpFixture
+        try {
+            $ev = @(Get-DebateRateLimitSummary -Path $p -PerEvent)
+            $ev.Count | Should -Be 6   # 3 embed + 2 free + 1 client
+            $ev[0].WallMs | Should -BeLessOrEqual $ev[-1].WallMs
+        } finally { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'warns and returns nothing when the dump has no rate-limit events' {
+        $p = New-RlDumpFixture -NoRateLimit
+        try {
+            $r = Get-DebateRateLimitSummary -Path $p -WarningAction SilentlyContinue
+            $r | Should -BeNullOrEmpty
+        } finally { Remove-Item -LiteralPath $p -Force -ErrorAction SilentlyContinue }
+    }
+
+    It 'throws an actionable error when the dump file is missing' {
+        { Get-DebateRateLimitSummary -Path (Join-Path ([System.IO.Path]::GetTempPath()) 'no-such-dump.jsonl') } | Should -Throw
+    }
+}


### PR DESCRIPTION
Adds `Get-DebateRateLimitSummary`: reads a (merged) flight recorder JSONL dump and reports, **per rate-limit bucket**, the 429 count, first/last time, and retry-after distribution (min/max/mean/distinct) — the structured view the t/3061 diagnosis had to assemble by hand.

## Design
Reuses `Get-FlightRecorderReport -Detailed -AsObject` as the JSONL parser; this cmdlet is a **classifier over its `.Events`, not a second parser**. Rate-limit events key off the real schema (verified against `lib/flight-recorder/types.ts` + `taxonomy-editor/src/server/routes/ai.ts`):
- server rate-limiter: `type=='ai.error'` + `data.limitKey` / `data.type∈{requests_per_minute,tokens_per_day}`, retry from `data.retryAfterMs`
- client 429: `data.http_status==429`, `data.retry_after_s`
- `github.api.rate_limit`

All key on top-level `type` + `data`, so **no dictionary-handle resolution needed**.

## Schema-grounded deviations from the ticket (flagged for @Diagnostics)
1. Verb **`Get-`** (read cmdlet), not the title's `Add-`.
2. **No `rate_limit_source` field exists** in the dump — bucket identity is `data.limitKey`, exposed as `Source` (prefix embed/free/client/github) + `LimitType`/`Backend`/`Tier`.
3. **retry-after normalized to seconds** from two fields/units (server `retryAfterMs` ms, client `retry_after_s` s).
4. **Per-KEY identity (`key_hash`/`key_slot`) is NOT in the FR dump** (only Pino server logs), so "same key?" is answered at *bucket* level via `RetryAfterDistinct`; documented as a gap with a pointer to server logs.

Faithful to the ticket's intent ("embeddings: 4× 429, retry_after 44/3/45 (per-IP bucket)"); the substitutions are because the proposed fields don't exist in the actual schema. Happy to adjust if you want a different shape.

## Self-cert
`/add-ps-cmdlet` (new public read cmdlet; reuses an existing parser, no new module deps, no schema/data-model change). Diagnostics-created ticket, so no TL design gate.

## Tests
7 (bucket grouping + noise exclusion, embed count/stats ms→s, client 429, `-PerEvent`, no-RL warning, missing-file throw), all green. Manifest + export parity OK. Purely additive — no existing cmdlet modified.

Closes t/3065.