### PR TITLE
fix(renderer): warn-log server-dump failures in flightRecorderInit (t/3069)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -178,9 +178,13 @@ async function persistDump(
           const serverResult = await resp.json() as { filename: string; filePath: string };
           serverFilename = serverResult.filename;
           console.log(`[flight-recorder] Server dump saved: ${serverResult.filePath}`);
+        } else {
+          // Best-effort still, but no longer silent: a non-ok status left the merged file
+          // sources:["client"] with no clue the server side was attempted (t/3069).
+          console.warn(`[flight-recorder] Server dump failed: HTTP ${resp.status} — merged dump will be client-only`);
         }
       // eslint-disable-next-line local/require-flight-recorder-in-catch -- flight recorder dump code cannot record to itself
-      } catch { /* server dump is best-effort */ }
+      } catch (err) { console.warn(`[flight-recorder] Server dump call errored: ${String(err)} — merged dump will be client-only`); }
 
       // Fire-and-forget: trigger admin-level server dump correlated by dumpId.
       // Non-admins/anon get 403 — that's expected and ignored.


### PR DESCRIPTION
## Summary
The best-effort `POST /api/flight-recorder/server-dump` call in `flightRecorderInit.ts` swallowed non-ok responses (404/500) and network errors **silently** — a merged dump that came back `sources:["client"]` gave no signal the server side was even attempted (t/3067 root symptom, t/3069 fix).

Now:
- **non-ok status** → `console.warn` with `HTTP ${status}` + "merged dump will be client-only" hint
- **catch (network error)** → `console.warn` with the error + same hint

**No behavioral change** — the server dump stays best-effort; `serverFilename` is still only set on `resp.ok`. The FR-can't-record-to-itself eslint-disable is retained (`console.warn` is the correct sink here).

## Verification
- `eslint src/renderer/lib/flightRecorderInit.ts` → **0 errors** (the two new lines use `console.warn`, which lint permits; added zero warnings — the 7 pre-existing warnings are untouched console.log/complexity in other functions).
- Clean shared `main` `tsc -p tsconfig.main.json` → **0 errors**.
- Local full `npm run verify` in the worktree hit 3 `TS2307` module-resolution errors in `lib/brief` + `lib/sanitize` (`pptxgenjs`, `decode-named-character-reference`, `micromark-util-decode-numeric-character-reference`) — a **worktree node_modules-layout artifact** (those packages live in `taxonomy-editor/node_modules`, not repo-root; the worktree's `../lib` files resolve from the package-less worktree root). Absent on shared main and unrelated to this 1-file/5-line logging edit. CI's fresh `npm ci` installs them correctly — **CI is the authoritative gate** for this PR.

Closes t/3069 (child of t/3067). Filed + TL-endorsed by Diagnostics.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Diagnostics (Orca) <main.operations-diagnostics@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
