### PR TITLE
feat(server): session-scoped server FR dump filter (t/3067)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/autoServerDump.test.ts
+++ b/taxonomy-editor/src/server/__tests__/autoServerDump.test.ts
@@ -46,6 +46,8 @@ vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
 }));
 vi.mock('../flightRecorderViewer.js', () => ({ escapeForInlineScript: (s: string) => s }));
 vi.mock('../security/accessControl.js', () => ({ clientSafeMessage: (s: string) => s }));
+vi.mock('../security/userContext.js', () => ({ getSessionBranchName: () => 'test-branch' }));
+vi.mock('../routes/sessionScopedDump.js', () => ({ filterSessionEvents: (ndjson: string) => ndjson }));
 vi.mock('../logger.js', () => ({
   getRequestId: () => 'req-test',
   log: { fr: { info: vi.fn() } },

--- a/taxonomy-editor/src/server/__tests__/sessionScopedFrDump.test.ts
+++ b/taxonomy-editor/src/server/__tests__/sessionScopedFrDump.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+
+/**
+ * t/3067 — session-scoped server FR dump filter.
+ * Load-bearing test (TL condition #3): two sessionBranches A+B plus global
+ * events in the buffer → A's dump has ONLY A's events, zero B, zero
+ * always-exclude types (_type:context, null _sessionBranch).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { filterSessionEvents } from '../routes/sessionScopedDump.js';
+
+const SESSION_A = 'users/alice/session';
+const SESSION_B = 'users/bob/session';
+
+function makeNdjson(lines: Record<string, unknown>[]): string {
+  return lines.map(l => JSON.stringify(l)).join('\n') + '\n';
+}
+
+describe('filterSessionEvents (t/3067)', () => {
+  it('keeps only structural lines and session-A events from a mixed buffer', () => {
+    const header = { _type: 'header', _version: 1, schema_version: '1.0.0' };
+    const dict   = { _type: 'dictionary', entries: [] };
+    const ctx    = { _type: 'context', active_branches: 5, github: { rate_limit_remaining: 100 } };
+    const evtA1  = { type: 'lifecycle', component: 'server', _sessionBranch: SESSION_A, path: '/api/a' };
+    const evtA2  = { type: 'ai.retry', component: 'server', _sessionBranch: SESSION_A, attempt: 1 };
+    const evtB   = { type: 'lifecycle', component: 'server', _sessionBranch: SESSION_B, path: '/api/b' };
+    const evtGlb = { type: 'system.error', component: 'server', _sessionBranch: null, message: 'startup-err' };
+    const trigger = { _type: 'trigger', timestamp: '2026-01-01T00:00:00Z', trigger_type: 'manual' };
+
+    const ndjson = makeNdjson([header, dict, ctx, evtA1, evtB, evtA2, evtGlb, trigger]);
+    const result = filterSessionEvents(ndjson, SESSION_A);
+    const lines  = result.trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+
+    // Structural lines retained
+    expect(lines.find(l => l._type === 'header')).toBeDefined();
+    expect(lines.find(l => l._type === 'dictionary')).toBeDefined();
+    expect(lines.find(l => l._type === 'trigger')).toBeDefined();
+
+    // Session-A events retained
+    expect(lines.filter(l => l._sessionBranch === SESSION_A)).toHaveLength(2);
+
+    // Context line excluded (always global)
+    expect(lines.find(l => l._type === 'context')).toBeUndefined();
+
+    // Session-B events excluded
+    expect(lines.find(l => l._sessionBranch === SESSION_B)).toBeUndefined();
+
+    // Global/null-session events excluded
+    expect(lines.find(l => l._sessionBranch === null)).toBeUndefined();
+  });
+
+  it('returns only structural lines when no events match the session', () => {
+    const ndjson = makeNdjson([
+      { _type: 'header', _version: 1, schema_version: '1.0.0' },
+      { _type: 'dictionary', entries: [] },
+      { type: 'lifecycle', _sessionBranch: SESSION_B },
+      { _type: 'trigger', trigger_type: 'manual' },
+    ]);
+    const lines = filterSessionEvents(ndjson, SESSION_A)
+      .trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+
+    expect(lines).toHaveLength(3); // header, dict, trigger
+    expect(lines.filter(l => !l._type)).toHaveLength(0); // no event lines
+  });
+
+  it('fail-CLOSED: empty ndjson returns only a trailing newline', () => {
+    const result = filterSessionEvents('', SESSION_A);
+    expect(result.trim()).toBe('');
+  });
+
+  it('excludes context lines regardless of session match', () => {
+    const ndjson = makeNdjson([
+      { _type: 'header', _version: 1, schema_version: '1.0.0' },
+      { _type: 'context', _sessionBranch: SESSION_A, active_branches: 3 },
+      { _type: 'trigger', trigger_type: 'manual' },
+    ]);
+    const lines = filterSessionEvents(ndjson, SESSION_A)
+      .trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+
+    expect(lines.find(l => l._type === 'context')).toBeUndefined();
+    expect(lines).toHaveLength(2); // header + trigger only
+  });
+
+  it('excludes events with no _sessionBranch field (startup/global, exclude-by-default)', () => {
+    const ndjson = makeNdjson([
+      { _type: 'header', _version: 1, schema_version: '1.0.0' },
+      { type: 'storage.mode', accountUrl: 'https://account.blob.core.windows.net' }, // no _sessionBranch
+      { _type: 'trigger', trigger_type: 'manual' },
+    ]);
+    const lines = filterSessionEvents(ndjson, SESSION_A)
+      .trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+
+    expect(lines.find(l => l.type === 'storage.mode')).toBeUndefined();
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/sessionScopedFrDump.test.ts
+++ b/taxonomy-editor/src/server/__tests__/sessionScopedFrDump.test.ts
@@ -93,4 +93,31 @@ describe('filterSessionEvents (t/3067)', () => {
 
     expect(lines.find(l => l.type === 'storage.mode')).toBeUndefined();
   });
+
+  it('fail-CLOSED: falsy sessionBranch arg returns only a trailing newline', () => {
+    const ndjson = makeNdjson([
+      { _type: 'header', _version: 1, schema_version: '1.0.0' },
+      { type: 'lifecycle', _sessionBranch: SESSION_A },
+    ]);
+    expect(filterSessionEvents(ndjson, '')).toBe('\n');
+  });
+
+  // TL 6th vector (p/522#53): dictionary is the process-GLOBAL intern table.
+  // A B-only intern entry must NOT appear in A's dump — the dict is always emitted
+  // with empty entries so the format is structurally valid without leaking.
+  it('dictionary line is emptied: B-only intern entries are absent from A\'s dump', () => {
+    const ndjson = makeNdjson([
+      { _type: 'header', _version: 1, schema_version: '1.0.0' },
+      { _type: 'dictionary', entries: ['users/bob/session', 'users/alice/session', 'some/path'] },
+      { type: 'lifecycle', _sessionBranch: SESSION_A },
+      { _type: 'trigger', trigger_type: 'manual' },
+    ]);
+    const lines = filterSessionEvents(ndjson, SESSION_A)
+      .trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+
+    const dict = lines.find(l => l._type === 'dictionary');
+    expect(dict).toBeDefined();
+    // Intern table must be empty — no cross-session entries leak
+    expect(dict.entries).toEqual([]);
+  });
 });

--- a/taxonomy-editor/src/server/routes/diagnostics.ts
+++ b/taxonomy-editor/src/server/routes/diagnostics.ts
@@ -24,6 +24,8 @@ import { getDataRoot, getStateRoot, getProjectRoot, STORAGE_MODE } from '../conf
 import { writeDump, isValidDumpId, readMergedDump } from '../flightRecorderDumps.js';
 import { escapeForInlineScript } from '../flightRecorderViewer.js';
 import { clientSafeMessage } from '../security/accessControl.js';
+import { getSessionBranchName } from '../security/userContext.js';
+import { filterSessionEvents } from './sessionScopedDump.js';
 import { getRequestId } from '../logger.js';
 import { log } from '../logger.js';
 import * as community from '../community/community.js';
@@ -78,14 +80,20 @@ export function registerDiagnosticsRoutes(r: Router, ctx: ServerCtx): void {
         if (!isValidDumpId(dumpId)) { error(res, 'dumpId must be a UUID-safe string', 400); return; }
         const filePath = await writeDump(getDataRoot(), 'client', dumpId, ndjson);
 
-        // t/3049: auto-write paired server FR dump so the merged download includes
-        // both sources in one artifact. Best-effort — a server-dump write failure
-        // must never fail the client dump response.
+        // t/3049: auto-write paired server FR dump.
+        // t/3067: filter ring buffer to requesting session (fail-CLOSED: anon/no-session
+        // → no server dump). Pino tee lines (appendServerLogs) are global and excluded
+        // from the session-scoped path to prevent cross-user log-line exposure.
         let serverDumpWritten = false;
         try {
-          const serverNdjson = appendServerLogs(serverRecorder.buildDump('manual').ndjson);
-          await writeDump(getDataRoot(), 'server', dumpId, serverNdjson);
-          serverDumpWritten = true;
+          const sessionBranch = getSessionBranchName();
+          if (sessionBranch !== undefined) {
+            const rawNdjson = serverRecorder.buildDump('manual').ndjson;
+            const filteredNdjson = filterSessionEvents(rawNdjson, sessionBranch);
+            await writeDump(getDataRoot(), 'server', dumpId, filteredNdjson);
+            serverDumpWritten = true;
+          }
+          // sessionBranch undefined → fail-CLOSED: anon session gets client-only dump
         } catch (serverErr) {
           getGlobalRecorder()?.record({
             type: 'system.error', component: 'flight-recorder-dump', level: 'warn',

--- a/taxonomy-editor/src/server/routes/sessionScopedDump.ts
+++ b/taxonomy-editor/src/server/routes/sessionScopedDump.ts
@@ -19,6 +19,9 @@
  * request handler without side effects.
  */
 export function filterSessionEvents(ndjson: string, sessionBranch: string): string {
+  // Fail-CLOSED: empty/null caller → return nothing rather than leaking everything.
+  if (!sessionBranch) return '\n';
+
   const kept: string[] = [];
   for (const line of ndjson.split('\n')) {
     const trimmed = line.trim();
@@ -26,8 +29,14 @@ export function filterSessionEvents(ndjson: string, sessionBranch: string): stri
     let parsed: Record<string, unknown>;
     try { parsed = JSON.parse(trimmed); } catch { continue; }
     const lineType = parsed._type as string | undefined;
-    if (lineType === 'header' || lineType === 'dictionary' || lineType === 'trigger') {
+    if (lineType === 'header' || lineType === 'trigger') {
       kept.push(trimmed);
+    } else if (lineType === 'dictionary') {
+      // The intern table is process-GLOBAL — it crosses session boundaries (latent
+      // leak once paths/userIds are interned). The serializer already expands handles
+      // into each event, so the table is redundant in a session-scoped dump. Emit an
+      // empty placeholder so the NDJSON format remains structurally valid.
+      kept.push(JSON.stringify({ _type: 'dictionary', entries: [] }));
     } else if (lineType === 'context') {
       // Always global — exclude from session-scoped dump
     } else if (parsed._sessionBranch === sessionBranch) {

--- a/taxonomy-editor/src/server/routes/sessionScopedDump.ts
+++ b/taxonomy-editor/src/server/routes/sessionScopedDump.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * t/3067: Filter a server FR dump NDJSON to only events from `sessionBranch`.
+ *
+ * Filtering rules:
+ * - _type: header / dictionary / trigger — structural; always kept.
+ * - _type: context — always excluded; contains process-global state
+ *   (active_branches, shared GitHub quota, aggregate cache rates).
+ * - All other lines (events): kept only when _sessionBranch === sessionBranch.
+ *   Exclude-by-default: null or absent _sessionBranch means startup/background
+ *   (no request context) → excluded from any user-scoped dump.
+ * - Pino tee lines (type: log.line, no _sessionBranch) are excluded by the
+ *   same rule, keeping key_hash/key_slot and other log-level fields out of
+ *   non-admin dumps.
+ *
+ * This is a pure function with no I/O — safe to unit-test and call from any
+ * request handler without side effects.
+ */
+export function filterSessionEvents(ndjson: string, sessionBranch: string): string {
+  const kept: string[] = [];
+  for (const line of ndjson.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: Record<string, unknown>;
+    try { parsed = JSON.parse(trimmed); } catch { continue; }
+    const lineType = parsed._type as string | undefined;
+    if (lineType === 'header' || lineType === 'dictionary' || lineType === 'trigger') {
+      kept.push(trimmed);
+    } else if (lineType === 'context') {
+      // Always global — exclude from session-scoped dump
+    } else if (parsed._sessionBranch === sessionBranch) {
+      kept.push(trimmed);
+    }
+  }
+  return kept.length > 0 ? kept.join('\n') + '\n' : '\n';
+}

--- a/taxonomy-editor/src/server/routes/sessionScopedDump.ts
+++ b/taxonomy-editor/src/server/routes/sessionScopedDump.ts
@@ -27,7 +27,7 @@ export function filterSessionEvents(ndjson: string, sessionBranch: string): stri
     const trimmed = line.trim();
     if (!trimmed) continue;
     let parsed: Record<string, unknown>;
-    try { parsed = JSON.parse(trimmed); } catch { continue; }
+    try { parsed = JSON.parse(trimmed); } catch { /* telemetry — silent by design */ continue; }
     const lineType = parsed._type as string | undefined;
     if (lineType === 'header' || lineType === 'trigger') {
       kept.push(trimmed);

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -35,7 +35,7 @@ import {
 } from './config.js';
 import { GitHubAPIBackend } from './storage/githubAPIBackend.js';
 import { SessionBranchManager } from './storage/sessionBranchManager.js';
-import { runWithUser, getCurrentUserId, setSessionBranchName, deriveStorageUserId, type UserContext } from './security/userContext.js';
+import { runWithUser, getCurrentUserId, getSessionBranchName, setSessionBranchName, deriveStorageUserId, type UserContext } from './security/userContext.js';
 import { isAuthDisabledAllowed, isPathWithinDir, isTerminalAccessAllowed, isAnonAllowedRoute, invalidRouteParam, missingApiKeyError, resolveTestPersonaOverride } from './security/accessControl.js';
 import { sanitizeUserText } from './security/contentSanitizer.js';
 import { isFreeTierAiPath } from './anonAiRoutes.js';
@@ -92,7 +92,9 @@ const serverRecorder = new FlightRecorder({ capacity: 2000, dumpOnError: false }
 // correlate to the originating HTTP request. An explicit request_id passed to
 // record() still wins; outside a request the field is omitted.
 const _baseServerRecord = serverRecorder.record.bind(serverRecorder);
-serverRecorder.record = (input) => _baseServerRecord({ request_id: getRequestId(), ...input });
+// t/3067: stamp _sessionBranch on every event so session-scoped dump filtering
+// can isolate this user's events from the global ring buffer at write time.
+serverRecorder.record = (input) => _baseServerRecord({ request_id: getRequestId(), _sessionBranch: getSessionBranchName() ?? null, ...input });
 serverRecorder.intern('component', 'server');
 serverRecorder.intern('component', 'git');
 serverRecorder.intern('component', 'data-pull');

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -94,7 +94,11 @@ const serverRecorder = new FlightRecorder({ capacity: 2000, dumpOnError: false }
 const _baseServerRecord = serverRecorder.record.bind(serverRecorder);
 // t/3067: stamp _sessionBranch on every event so session-scoped dump filtering
 // can isolate this user's events from the global ring buffer at write time.
-serverRecorder.record = (input) => _baseServerRecord({ request_id: getRequestId(), _sessionBranch: getSessionBranchName() ?? null, ...input });
+// Object.assign avoids the object-literal excess-property check (RecordInput
+// doesn't declare _sessionBranch; Shared Lib owns that type).
+serverRecorder.record = (input) => _baseServerRecord(
+  Object.assign({}, input, { request_id: getRequestId(), _sessionBranch: getSessionBranchName() ?? null }),
+);
 serverRecorder.intern('component', 'server');
 serverRecorder.intern('component', 'git');
 serverRecorder.intern('component', 'data-pull');


### PR DESCRIPTION
## Summary

- Stamps `_sessionBranch` on every server FR event (via `getSessionBranchName()` in the recorder wrapper in `server.ts`)
- `routes/sessionScopedDump.ts`: pure `filterSessionEvents()` — keeps structural lines (header/dictionary/trigger), always excludes `_type:context` (global), excludes events where `_sessionBranch !== sessionBranch` (exclude-by-default: null = startup/background)
- `routes/diagnostics.ts`: `POST /api/flight-recorder/dump` now writes session-scoped `server-{dumpId}.jsonl`; anon fails-CLOSED to client-only; `appendServerLogs` omitted from session path
- `__tests__/sessionScopedFrDump.test.ts`: load-bearing test (TL condition 3) — A+B+global events → A dump has ONLY A events, zero B, zero always-exclude types
- isAdmin() gate in download-merged unchanged; gate-widening is separate TL step

## Test plan

- [ ] CI green on head a1f6f642
- [ ] sessionScopedFrDump tests pass
- [ ] test-server-prod-config passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)