### PR TITLE
chore(renderer): merged dump = sole download; drop stale admin + server-dump calls (t/3068)

### DIFF
--- a/taxonomy-editor/src/renderer/lib/dumpToast.ts
+++ b/taxonomy-editor/src/renderer/lib/dumpToast.ts
@@ -54,7 +54,6 @@ export function showDumpToast(opts: {
   isWeb: boolean;
   onCopy?: () => void;
   onOpen?: () => void;
-  serverFilename?: string;
   dumpId?: string;
 }): void {
   const container = getOrCreateContainer();
@@ -87,10 +86,14 @@ export function showDumpToast(opts: {
   toast.appendChild(title);
 
   if (opts.isWeb) {
-    // Merged dump link (primary — interleaves client + server events by timestamp)
     if (opts.dumpId) {
+      // Merged dump is THE download — one prominent button, no separate Client:/Server:
+      // links (users grabbed the client-only file → 6/8 prod dumps were client-only,
+      // t/3067/t/3068). The endpoint interleaves client + server events by timestamp;
+      // its isAdmin() gate means non-admins silently get a client-only merged file
+      // (diagnostics.ts:163), which is the same content the old Client: link served.
       const mergedLink = document.createElement('a');
-      mergedLink.textContent = 'Download merged dump';
+      mergedLink.textContent = 'Download dump';
       Object.assign(mergedLink.style, {
         display: 'block',
         color: 'var(--focus-ring, #89b4fa)',
@@ -110,7 +113,7 @@ export function showDumpToast(opts: {
             if (diag && (diag.goal || diag.problem)) {
               showDiagnosticPanel(diag);
             } else {
-              mergedLink.textContent = `Merged download failed (${resp.status})`;
+              mergedLink.textContent = `Download failed (${resp.status})`;
             }
             return;
           }
@@ -121,67 +124,35 @@ export function showDumpToast(opts: {
           a.download = `merged-${opts.dumpId}.jsonl`;
           a.click();
           URL.revokeObjectURL(url);
-        } catch (err) { mergedLink.textContent = `Merged download failed: ${err}`; /* flight recorder UI — silent by design (error shown in toast) */ }
+        } catch (err) { mergedLink.textContent = `Download failed: ${err}`; /* flight recorder UI — silent by design (error shown in toast) */ }
       };
       toast.appendChild(mergedLink);
-    }
-
-    // Individual client dump link
-    const link = document.createElement('a');
-    link.textContent = opts.dumpId ? `Client: ${opts.filename}` : opts.filename;
-    Object.assign(link.style, {
-      display: 'block',
-      color: 'var(--focus-ring, #89b4fa)',
-      textDecoration: 'underline',
-      cursor: 'pointer',
-      wordBreak: 'break-all',
-      fontSize: opts.dumpId ? '0.8em' : '1em',
-      marginTop: opts.dumpId ? '4px' : '0',
-    });
-    link.onclick = async (e) => {
-      e.preventDefault();
-      try {
-        const resp = await fetch(`/api/flight-recorder/download/${encodeURIComponent(opts.filename)}`);
-        if (!resp.ok) { link.textContent = `Download failed (${resp.status})`; return; }
-        const blob = await resp.blob();
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = opts.filename;
-        a.click();
-        URL.revokeObjectURL(url);
-      } catch (err) { link.textContent = `Download failed: ${err}`; /* flight recorder UI — silent by design (error shown in toast) */ }
-    };
-    toast.appendChild(link);
-
-    // Server dump link (if available)
-    if (opts.serverFilename) {
-      const serverLink = document.createElement('a');
-      serverLink.textContent = `Server: ${opts.serverFilename}`;
-      Object.assign(serverLink.style, {
+    } else {
+      // No server correlation (dumpId absent) — the client dump is the only download.
+      const link = document.createElement('a');
+      link.textContent = opts.filename;
+      Object.assign(link.style, {
         display: 'block',
         color: 'var(--focus-ring, #89b4fa)',
         textDecoration: 'underline',
         cursor: 'pointer',
         wordBreak: 'break-all',
-        fontSize: '0.8em',
-        marginTop: '4px',
       });
-      serverLink.onclick = async (e) => {
+      link.onclick = async (e) => {
         e.preventDefault();
         try {
-          const resp = await fetch(`/api/flight-recorder/download/${encodeURIComponent(opts.serverFilename!)}`);
-          if (!resp.ok) { serverLink.textContent = `Server download failed (${resp.status})`; return; }
+          const resp = await fetch(`/api/flight-recorder/download/${encodeURIComponent(opts.filename)}`);
+          if (!resp.ok) { link.textContent = `Download failed (${resp.status})`; return; }
           const blob = await resp.blob();
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');
           a.href = url;
-          a.download = opts.serverFilename!;
+          a.download = opts.filename;
           a.click();
           URL.revokeObjectURL(url);
-        } catch (err) { serverLink.textContent = `Server download failed: ${err}`; /* flight recorder UI — silent by design (error shown in toast) */ }
+        } catch (err) { link.textContent = `Download failed: ${err}`; /* flight recorder UI — silent by design (error shown in toast) */ }
       };
-      toast.appendChild(serverLink);
+      toast.appendChild(link);
     }
   } else {
     // Electron mode: file path + Copy + Open buttons

--- a/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
+++ b/taxonomy-editor/src/renderer/lib/flightRecorderInit.ts
@@ -168,32 +168,13 @@ async function persistDump(
     const result = await api.dumpFlightRecorder(ndjson, dumpId);
     console.log(`[flight-recorder] Dump saved: ${result.filePath} (dumpId=${dumpId})`);
 
-    // In web/container mode, also dump the server-side flight recorder
-    // so server events (git ops, GitHub API, cache) are captured alongside client events.
-    let serverFilename: string | undefined;
-    if (isWeb) {
-      try {
-        const resp = await fetch('/api/flight-recorder/server-dump', { method: 'POST' });
-        if (resp.ok) {
-          const serverResult = await resp.json() as { filename: string; filePath: string };
-          serverFilename = serverResult.filename;
-          console.log(`[flight-recorder] Server dump saved: ${serverResult.filePath}`);
-        } else {
-          // Best-effort still, but no longer silent: a non-ok status left the merged file
-          // sources:["client"] with no clue the server side was attempted (t/3069).
-          console.warn(`[flight-recorder] Server dump failed: HTTP ${resp.status} — merged dump will be client-only`);
-        }
-      // eslint-disable-next-line local/require-flight-recorder-in-catch -- flight recorder dump code cannot record to itself
-      } catch (err) { console.warn(`[flight-recorder] Server dump call errored: ${String(err)} — merged dump will be client-only`); }
-
-      // Fire-and-forget: trigger admin-level server dump correlated by dumpId.
-      // Non-admins/anon get 403 — that's expected and ignored.
-      void fetch('/api/admin/flight-recorder/dump', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ dumpId }),
-      }).catch(() => { /* admin dump is best-effort */ });
-    }
+    // In web mode the server writes its own dump correlated by dumpId inside the dump POST
+    // (t/3049); the merged download (t/3068) serves both client + server by dumpId. No
+    // separate server-dump call or admin trigger is needed here:
+    //   - the fire-and-forget POST /api/admin/flight-recorder/dump was redundant since t/3049
+    //     and only produced 403 noise for non-admins;
+    //   - the uncorrelated POST /api/flight-recorder/server-dump call only fed the removed
+    //     Server: link (its output was never part of the merged file).
 
     showDumpToast({
       filename: result.filename,
@@ -201,7 +182,6 @@ async function persistDump(
       isWeb,
       onCopy: () => { void api.clipboardWriteText(result.filePath); },
       onOpen: () => { void api.openFlightRecorderViewer(result.filePath); },
-      serverFilename,
       dumpId: isWeb ? dumpId : undefined,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
Client half of t/3067 (6/8 prod web dumps were `sources:["client"]` only — users clicked the demoted client-only file instead of the merged download). Approved-safe scope per ServerAPI **t/3068#2** (p/522#49).

**`dumpToast.ts`** — merged download is now the **sole** web download: one prominent `Download dump` button hitting `GET /api/flight-recorder/download-merged/{dumpId}`. Removed the confusing `Client:` / `Server:` links and the `serverFilename` opt. The endpoint's `isAdmin()` gate means non-admins silently get a **client-only** merged file — the same content the old `Client:` link served — so **no non-admin download regression**. (No-`dumpId` path keeps the plain client link as before.)

**`flightRecorderInit.ts`** — dropped two now-dead web-mode calls:
- `POST /api/admin/flight-recorder/dump` (fire-and-forget) — redundant since t/3049's server auto-write; only produced 403 noise for non-admins.
- `POST /api/flight-recorder/server-dump` (uncorrelated) — only fed the removed `Server:` link; its output was never part of the merged file (merged's server data comes from the dumpId-correlated auto-write inside the dump POST, t/3049).

## Interaction with t/3069
This removes the exact `server-dump` call that **t/3069** (landed `381e48ac`) had just added warn-logging to. Removing the redundant call entirely is the better end-state than instrumenting it — the observability need disappears with the code. Diagnostics notified.

## Not touched (still blocked)
`isAdmin()` gate at `diagnostics.ts:163` — session-scoped non-admin server events remain pending TL sign-off on t/3067 (t/3068#2).

## Verification
- eslint on both files → **0 errors** (6 pre-existing warnings in unrelated functions; my edit removed a console line, 7→6).
- renderer-tsc → only the 3 known `lib/` `TS2307` worktree node_modules-layout artifacts (`pptxgenjs`, `decode-named-character-reference`, `micromark-util-decode-numeric-character-reference`) — **no new errors in the changed files**; absent on shared main; CI's fresh `npm ci` resolves them (proven on #1596/t3069).
- vitest flight-recorder renderer tests → **9/9 pass**.

Chore (no design gate). Closes t/3068 (child of t/3067). Routed to **ServerAPI** (co-owner of the endpoints).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: ServerAPI (Orca) <main.taxonomy-editor-src-server@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
