### PR TITLE
fix(bridge): chunk embeddings compute to bound the 50s server timeout (t/3072)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/embeddingsBatch.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/embeddingsBatch.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, vi } from 'vitest';
+import { computeEmbeddingsChunked, EMBEDDINGS_MAX_BATCH } from '../embeddingsBatch';
+
+// A fake `post` that returns one deterministic vector per input text ([index-within-request]),
+// and records the batch size + ids of every call so we can assert chunking + ordering.
+function makePost() {
+  const calls: { texts: string[]; ids?: string[] }[] = [];
+  const post = vi.fn(async (_path: string, body?: unknown) => {
+    const { texts, ids } = body as { texts: string[]; ids?: string[] };
+    calls.push({ texts, ids });
+    return { vectors: texts.map((_t, i) => [i]) };
+  });
+  return { post, calls };
+}
+
+describe('computeEmbeddingsChunked', () => {
+  it('sends a batch at the cap in a single POST (no behaviour change for small inputs)', async () => {
+    const { post, calls } = makePost();
+    const texts = Array.from({ length: EMBEDDINGS_MAX_BATCH }, (_v, i) => `t${i}`);
+    const res = await computeEmbeddingsChunked(post, texts);
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(calls[0].texts).toHaveLength(EMBEDDINGS_MAX_BATCH);
+    expect(res.vectors).toHaveLength(EMBEDDINGS_MAX_BATCH);
+    // idempotent flag preserved on the single-batch path
+    expect(post).toHaveBeenCalledWith('/api/embeddings/compute', { texts, ids: undefined }, { idempotent: true });
+  });
+
+  it('splits an oversized batch into ceil(n/cap) sequential POSTs, each within the cap', async () => {
+    const { post, calls } = makePost();
+    const n = 2587; // the incident batch size
+    const texts = Array.from({ length: n }, (_v, i) => `t${i}`);
+    await computeEmbeddingsChunked(post, texts);
+    const expectedChunks = Math.ceil(n / EMBEDDINGS_MAX_BATCH); // 6 at cap 512
+    expect(post).toHaveBeenCalledTimes(expectedChunks);
+    for (const c of calls) expect(c.texts.length).toBeLessThanOrEqual(EMBEDDINGS_MAX_BATCH);
+    // chunk sizes tile the input exactly (5×512 + 27)
+    expect(calls.reduce((sum, c) => sum + c.texts.length, 0)).toBe(n);
+    expect(calls[calls.length - 1].texts.length).toBe(n % EMBEDDINGS_MAX_BATCH);
+  });
+
+  it('concatenates vectors in input order and keeps ids aligned per chunk', async () => {
+    // vector value encodes the ORIGINAL global index so we can prove ordering across chunks
+    const post = vi.fn(async (_path: string, body?: unknown) => {
+      const { texts } = body as { texts: string[] };
+      return { vectors: texts.map((t) => [Number(t.slice(1))]) };
+    });
+    const n = EMBEDDINGS_MAX_BATCH + 5; // 2 chunks
+    const texts = Array.from({ length: n }, (_v, i) => `t${i}`);
+    const ids = Array.from({ length: n }, (_v, i) => `id${i}`);
+    const res = await computeEmbeddingsChunked(post, texts, ids);
+    expect(res.vectors).toEqual(Array.from({ length: n }, (_v, i) => [i]));
+    // ids sliced in lockstep with texts: 2nd chunk starts at the cap boundary
+    const secondCallIds = (post.mock.calls[1][1] as { ids: string[] }).ids;
+    expect(secondCallIds[0]).toBe(`id${EMBEDDINGS_MAX_BATCH}`);
+  });
+
+  it('is strictly sequential — chunk N+1 starts only after chunk N resolves', async () => {
+    const order: string[] = [];
+    let active = 0;
+    const post = vi.fn(async (_path: string, body?: unknown) => {
+      const { texts } = body as { texts: string[] };
+      active += 1;
+      expect(active).toBe(1); // never two in-flight at once
+      order.push(`start:${texts[0]}`);
+      await Promise.resolve();
+      order.push(`end:${texts[0]}`);
+      active -= 1;
+      return { vectors: texts.map(() => [0]) };
+    });
+    const texts = Array.from({ length: EMBEDDINGS_MAX_BATCH * 2 + 1 }, (_v, i) => `t${i}`); // 3 chunks
+    await computeEmbeddingsChunked(post, texts);
+    // each chunk fully ends before the next begins
+    expect(order).toEqual([
+      't0', 't0', `t${EMBEDDINGS_MAX_BATCH}`, `t${EMBEDDINGS_MAX_BATCH}`, `t${EMBEDDINGS_MAX_BATCH * 2}`, `t${EMBEDDINGS_MAX_BATCH * 2}`,
+    ].flatMap((label, i) => (i % 2 === 0 ? [`start:${label}`] : [`end:${label}`])));
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/embeddingsBatch.ts
+++ b/taxonomy-editor/src/renderer/bridge/embeddingsBatch.ts
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// Client-side batch chunking for POST /api/embeddings/compute (t/3072).
+//
+// The server processes the whole request inside a single 50s withEndpointTimeout('embeddings-compute')
+// window — it compute-chunks internally at EMBEDDING_COMPUTE_CHUNK=256 (t/2914), but all within that
+// one timeout. A single oversized batch blows the 50s ceiling → 504 → 500 → 'mutation' circuit-breaker
+// cascade (incident e8760507 sent 2587 items; prior calls of 643 and 792 succeeded). Bounding each POST
+// to a safe size turns one catastrophic timeout into sequential, recoverable chunks.
+
+const EMBEDDINGS_COMPUTE_PATH = '/api/embeddings/compute';
+
+/**
+ * Max texts per compute POST. Provisional (t/3072): 512 = 2× the server compute-chunk
+ * (EMBEDDING_COMPUTE_CHUNK=256, t/2914). Chosen SAFELY BELOW the known-good 792/643-item calls from
+ * incident e8760507 (2587 items was the failure) so a full chunk completes well under the 50s
+ * 'embeddings-compute' endpoint timeout even under load — a valid safe cap without production
+ * calibration. t/3071's batch_size observability is only needed to tune this UP later; recalibrate
+ * here (one line) once that data lands, and never raise it above the smallest observed failure
+ * without evidence.
+ */
+export const EMBEDDINGS_MAX_BATCH = 512;
+
+/** Minimal shape of web-bridge's generic `post` used here (path, JSON body, idempotent flag). */
+type EmbeddingsPost = <T = unknown>(
+  path: string,
+  body?: unknown,
+  opts?: { idempotent?: boolean },
+) => Promise<T>;
+
+/**
+ * Split texts/ids into ≤EMBEDDINGS_MAX_BATCH slices and POST them SEQUENTIALLY — never
+ * concurrently, which would re-burst the very server this guards (TL, t/3072). Vectors are
+ * concatenated in input order, so the return shape is identical to a single compute call. Each
+ * chunk keeps idempotent:true so a load-shed 503 (retryable + Retry-After) still gets its one
+ * retry, and embeddings are a pure function of inputs (t/2922).
+ */
+export async function computeEmbeddingsChunked(
+  post: EmbeddingsPost,
+  texts: string[],
+  ids?: string[],
+): Promise<{ vectors: number[][] }> {
+  if (texts.length <= EMBEDDINGS_MAX_BATCH) {
+    return post<{ vectors: number[][] }>(EMBEDDINGS_COMPUTE_PATH, { texts, ids }, { idempotent: true });
+  }
+  const vectors: number[][] = [];
+  for (let i = 0; i < texts.length; i += EMBEDDINGS_MAX_BATCH) {
+    const textChunk = texts.slice(i, i + EMBEDDINGS_MAX_BATCH);
+    const idChunk = ids ? ids.slice(i, i + EMBEDDINGS_MAX_BATCH) : undefined;
+    // Awaited in the loop → strictly sequential; the next chunk starts only after this one resolves.
+    const res = await post<{ vectors: number[][] }>(
+      EMBEDDINGS_COMPUTE_PATH,
+      { texts: textChunk, ids: idChunk },
+      { idempotent: true },
+    );
+    vectors.push(...res.vectors);
+  }
+  return { vectors };
+}

--- a/taxonomy-editor/src/renderer/bridge/web-bridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/web-bridge.ts
@@ -15,6 +15,7 @@ import type { OpEdSet, OpEdSetSummary } from '../../../../lib/oped/types';
 import { encryptKeysForSharing, decryptKeysFromSharing } from '../utils/keyShareCrypto';
 import { resilientFetch, categorizeEndpoint, registerConnectionPoolProvider, type EndpointCategory } from './resilience';
 import { nextStepsForStatus } from './httpErrorSteps';
+import { computeEmbeddingsChunked } from './embeddingsBatch';
 import { runChatStream, chatStreamBus } from './chatStream';
 import { runOpEdCreate, cancelActiveOpEdRun, opedProgressBus } from './opedStream';
 import { onQuotaMilestone } from '../hooks/useQuotaWarning';
@@ -991,10 +992,9 @@ const rawApi: AppAPI = {
   getProxyUsage: () => get('/api/proxy/usage'),
 
   // Embeddings & NLI
-  computeEmbeddings: (texts, ids) => post('/api/embeddings/compute', { texts, ids }, { idempotent: true }), // idempotent:true → 1 retry so a load-shed 503 (retryable:true+Retry-After) recovers; embeddings are a pure fn of inputs (t/2922)
-  // Web transport: the server embedding backend (Python/Gemini) has no DirectML GPU-OOM failure
-  // mode, so nothing goes stale on this path → always [] (t/2060 staleNodeIds contract). If the
-  // server route later reports partial failures, thread them through here.
+  computeEmbeddings: (texts, ids) => computeEmbeddingsChunked(post, texts, ids), // ≤EMBEDDINGS_MAX_BATCH sequential chunks so an oversized batch can't blow the 50s server timeout (t/3072)
+  // Web transport: server embedding backend (Python/Gemini) has no DirectML GPU-OOM mode, so nothing
+  // goes stale → always [] (t/2060 staleNodeIds contract; thread partial failures here if the route adds them).
   updateNodeEmbeddings: (nodes) => post('/api/embeddings/update-nodes', { nodes }).then(() => ({ staleNodeIds: [] as string[] })),
   computeQueryEmbedding: (text) => post('/api/embeddings/query', { text }),
   nliClassify: (pairs) => post('/api/nli/classify', { pairs }),


### PR DESCRIPTION
## Summary
Gap 1 (client) of t/3072 — TL-approved (t/3072#1, confirmed p/336#218). Incident e8760507: a single `POST /api/embeddings/compute` of **2587** items (prior 643/792 succeeded) blew the server's 50s `withEndpointTimeout('embeddings-compute')` window → 504 → 500 → `mutation` circuit-breaker cascade.

`computeEmbeddings` now delegates to a new sibling module **`embeddingsBatch.ts`** (web-bridge is at the hard 1500-line `max-lines` cap) that splits `texts`/`ids` into **≤EMBEDDINGS_MAX_BATCH (512)** slices and POSTs them **sequentially** — never concurrently, which would re-burst the server this guards — concatenating vectors in input order. Return shape and per-chunk `idempotent:true` (load-shed 503 recovery, t/2922) unchanged.

## N=512 rationale (TL nit incorporated)
`2× EMBEDDING_COMPUTE_CHUNK (256, t/2914)`, **safely below the known-good 792/643** and far below the failing 2587 → a full chunk finishes well under the **50s** endpoint timeout even under load — a valid safe cap without prod data. The const comment cites both the 50s timeout and the 792-good/2587-bad data point. t/3071's `batch_size` obs is only needed to tune N **up** later → one-line recalibration.

## Scope / decomposition (TL ownership split)
- **This PR:** client chunking only.
- **t/3074 (ServerAPI):** server-side batch cap + the preferred **Gap-2 503-when-shedding** route.
- **Gap-2 client 500-reclassify: deferred** — NOT flipping `classifyAiRetry` (500 stays terminal). Fallback bounded/circuit-aware client retry only if ServerAPI declines the 503-route.

## Verification
- New unit suite `embeddingsBatch.test.ts` — **4/4**: cap→single POST (behaviour preserved + idempotent flag); 2587→6 sequential POSTs, each ≤512, sizes tile exactly; cross-chunk vector-order + ids-alignment; **strictly-sequential** (asserts never two POSTs in flight).
- Full bridge suite **150/150**. eslint **0 errors** (6 pre-existing web-bridge warnings, none in new files). renderer-tsc: only the 3 known `lib/` worktree node_modules-layout artifacts (absent on shared main; CI `npm ci` resolves).
- web-bridge held at **exactly 1500 lines** (import offset by condensing an adjacent comment).

Closes t/3072. Routed to **Main (TL)** per p/336#218.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
Co-Authored-By: Diagnostics (Orca) <main.operations-diagnostics@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
