### PR TITLE
feat(smoke): enable 2 surfaces + fix claim-attribution orphan + adjudicate medium-3 (t/3059)

### DIFF
--- a/taxonomy-editor/smoke/README.md
+++ b/taxonomy-editor/smoke/README.md
@@ -23,23 +23,40 @@ real server, so lazy CSS code-splitting behaves exactly as in prod.
 - **Warn-first**: DevOps wires the CI job non-blocking for ≥1 green real-env cycle before promoting
   to blocking (a flaky blocking smoke is the next incident). DevOps owns the CI flip.
 
-## Covered surfaces (reachability — validated live t/3026)
+## Covered surfaces (reachability — validated live t/3026 + t/3059)
 
 In the default web boot **only the 3 POV tabs render** in the tablist (`accelerationist` /
-`safetyist` / `skeptic`); `chat`, `debate`, etc. are gated (feature-flag/admin), so their
-`[data-tab]` buttons do not exist and their surfaces are unreachable here. The two POV-surface
-assertions are **active and proven both-arms**; the two gated surfaces are `test.fixme` until the
-CI job boots the app with those tabs flagged on.
+`safetyist` / `skeptic`); `chat`, `debate`, etc. are gated (feature-flag/admin). But a surface's
+CSS is reachable whenever its rule ships in a **chunk that loads at boot** — not only when its own
+tab is clicked. All five active surfaces below ride the **main entry chunk** (their components are
+statically imported via `App.tsx → PovTab`), so their rules are present at boot and probeable on
+any POV tab. **All five are active and proven both-arms** (t/3059).
 
 | surface | tab to load its chunk | probe class | assert (computed) | status |
 |---|---|---|---|---|
 | Attributes / GraphAttributesPanel | POV tab (`[data-tab="accelerationist"]`) | `.ga-grid-3col` | `grid-template-columns` ≥ 3 tracks | **active** ✓ |
 | HighlightedField (t/3025 fix) | POV tab (NodeDescriptionSection) | `.hl-backdrop` | `position: absolute` | **active** ✓ |
-| DataSourceCard (t/3025 fix) | `[data-tab="chat"]` (Prompt Inspector) | `.pi-node-count-preview` | `border-bottom-width` ≠ 0px | `fixme` — chat tab gated |
-| ApiKeyErrorMessage (t/3025 fix) | Analysis / settings error state | `.api-key-error-link` | `text-decoration` underline | `fixme` — surface/nav TBD |
+| DataSourceCard (t/3025 fix) | POV tab (main chunk via PromptInspector) | `.pi-node-count-preview` | `border-bottom-width` ≠ 0px | **active** ✓ (t/3059) |
+| ApiKeyErrorMessage (t/3025 fix) | POV tab (main chunk via AnalysisPanel) | `.api-key-error-link` | `text-decoration` underline | **active** ✓ (t/3059) |
+| claim-attribution (t/3025/t/3059 fix) | POV tab (NodeDetail) | `.claim-attribution-label` | `text-transform: uppercase` | **active** ✓ (t/3059) |
 
-**Medium candidates to adjudicate (t/3025#1)** — same probe technique decides each: `vocab-*`,
-`qbaf-delta`/`qbaf-badge`, `claim-attribution-*`. Pending the gated surfaces being reachable.
+> The DataSourceCard/ApiKeyErrorMessage `fixme`s were **over-conservative** — both ride the main
+> chunk, so no `chat`/settings tab flagging was needed (t/3059). Enabled + proven on a POV tab.
+
+**Medium-3 adjudication (t/3025#1) — DONE (t/3059). All three are CONFIRMED orphans** (single
+component-local definition each, no `styles.css` fallback; used cross-component on surfaces whose
+chunk does not load the defining sheet):
+
+| class | sole CSS home (chunk) | live usage off that chunk | verdict | action |
+|---|---|---|---|---|
+| `claim-attribution-*` | ArgumentGraph.css — imported only by `ArgumentGraph ← TimelineScrubber`, **never rendered → tree-shaken → ships in NO chunk** | NodeDetail (POV, main), ReflectionsPanel, 3 diagnostics surfaces | **CONFIRMED** — unstyled on the POV tab today | **FIXED here**: relocated to NodeDetail.css (main chunk) + active smoke assertion above |
+| `qbaf-delta` / `qbaf-badge` | QbafOverlay.css — loads only in diagnostics + harvest chunks | ConflictDetail (conflict chunk), StatementCard (debate chunk) | **CONFIRMED** — unstyled on conflict + debate surfaces | **Routed** → Conflict (ConflictDetail.css) + DebateWorkspace (StatementCard.css) |
+| `vocab-term` | VocabularyPanel.css — loads only in the debate chunk | OverviewTabRouter (diagnostics-window chunk) | **CONFIRMED** — unstyled on the diagnostics overview surface | **Routed** → DebateDiagnostics (OverviewTabRouter.css) |
+
+> qbaf/vocab consumers live on **gated** surfaces (conflict/debate/diagnostics) whose fix lands in
+> child-role scopes; those fixes are routed, not done here, and are **not** added as smoke
+> assertions — the gate stays POV-scoped and low-flake per TL (t/3026#10). claim-attribution is the
+> one confirmed orphan that renders on the POV surface, so it is both fixed and asserted here.
 
 ## Run
 
@@ -68,29 +85,37 @@ known-orphan surface would be a false-green):
   comment the rule → `build:web` (absent from all built CSS) → `"none"` (1 track) → **fails**.
 - **HighlightedField `.hl-backdrop`** — clean → `position: absolute` → **passes**; comment the rule →
   `build:web` → `position: static` → **fails** (`.ga-grid-3col` stayed 3 tracks — isolated).
+- **DataSourceCard `.pi-node-count-preview`** (t/3059) — clean → `border-bottom-width: 1px` →
+  **passes**; neuter the rule → `build:web` → `0px` → **fails**.
+- **ApiKeyErrorMessage `.api-key-error-link`** (t/3059) — clean → `text-decoration: underline` →
+  **passes**; neuter the rule → `build:web` → `none` → **fails**.
+- **claim-attribution `.claim-attribution-label`** (t/3059) — clean → `text-transform: uppercase` →
+  **passes**; neuter the rule → `build:web` → `none` → **fails** (`.ga`/`.hl` stayed styled — isolated).
 
-Both rules reverted after. Rebuilding (not DOM-hiding) is required — it exercises the Vite
-chunk-graph, which is the actual failure class.
+Both/all arms captured 2026-08-27 via the `@playwright/test` runner (v1.60.0, Node 24.15.0) against
+the prod web build: clean = **5 passed**; all-three-neutered = **3 failed / 2 passed**. Rules
+reverted after. Rebuilding (not DOM-hiding) is required — it exercises the Vite chunk-graph, which
+is the actual failure class.
 
-## STATUS — harness validated; CI wiring is the DevOps handoff
+## STATUS — harness validated; live CI gate wired (non-blocking)
 
 Validated against a live prod-build server: Chromium launches, the app boots to the POV tablist,
-probe-injection reads the lazy-chunk CSS, and both arms behave correctly.
+probe-injection reads the main-chunk CSS, and every arm behaves correctly.
 
-**Known local limitation:** the `@playwright/test` *runner* hangs on **Node 24** (this dev box);
-the raw Chromium API used to capture both-arms works fine. DevOps's CI runs **Node 22** (t/3026#4),
-where the runner is unaffected — so this does not block the gate.
+**Node-24 runner:** fixed. The `@playwright/test` runner previously hung on Node 24 (yauzl
+stream-destruction regression, Node ≥24.16); **v1.60.0 vendored the fix** and DevOps pinned it in
+the CI job (#1599). The runner now runs clean on Node 22 (CI) and Node 24.15.0 (this dev box).
 
-**DevOps handoff (CI wiring):** add the pinned `@playwright/test@1.48.2` devDep + lockfile sync
-(deferred here to avoid lockfile churn), `npx playwright install --with-deps chromium`, cache
-`~/.cache/ms-playwright`, wire the job **non-blocking** on **Node 22** for ≥1 green real-env cycle,
-then a separate draft PR flips warn→block held for TL sign-off (t/3026#4 promotion discipline).
-Pin Node 22 explicitly — the runner **hangs on Node 24**, so a future Node bump would silently wedge
-a blocking gate.
+**CI status:** DevOps wired the non-blocking render-smoke job on **Node 22**, pinned
+`@playwright/test@1.60.0`, `build:container` → `smoke:styled`, cached `~/.cache/ms-playwright`
+(#1599). It runs on every electron PR + main push. Promotion warn→block is a separate TL-signed
+draft PR gated on DevOps's real-env both-arms — unchanged, DevOps-owned (t/3026#10 cond 4).
 
-**Coverage (honest, per "no silent caps"):** this harness covers **2 of the 4** t/3026#1 surfaces
-active + both-arms-proven (Attributes `.ga-*`, HighlightedField `.hl-*`). DataSourceCard and
-ApiKeyErrorMessage are `test.fixme` (unreachable / TBD in the default web boot), and the 3-MEDIUM
-adjudication (`vocab-*`/`qbaf-*`/`claim-attribution-*`) is not done. A green check here is **not**
-full-class coverage. Those, plus enabling the 2 fixme surfaces and the Node-24 runner fix, are
-tracked in **t/3059**.
+**Coverage (honest, per "no silent caps"):** this harness now covers **5 active + both-arms-proven**
+POV-surface assertions (Attributes `.ga-*`, HighlightedField `.hl-*`, DataSourceCard `.pi-*`,
+ApiKeyErrorMessage `.api-key-error-*`, claim-attribution `.claim-attribution-*`). The medium-3
+adjudication is **done** (all CONFIRMED orphans): claim-attribution is fixed + asserted here;
+`qbaf-*` and `vocab-*` render only on **gated** surfaces (conflict/debate/diagnostics) — their fixes
+are **routed to the owning child roles** (Conflict, DebateWorkspace, DebateDiagnostics) and are
+deliberately **not** asserted here (the gate stays POV-scoped + low-flake). Those routed fixes are
+tracked in **t/3059**. A green check here covers the five POV surfaces above, not the gated ones.

--- a/taxonomy-editor/smoke/attributes-styled.smoke.mjs
+++ b/taxonomy-editor/smoke/attributes-styled.smoke.mjs
@@ -49,20 +49,35 @@ test('HighlightedField: .hl-backdrop overlay rule is loaded (t/3025)', async ({ 
   expect(await probe(page, 'hl-backdrop', 'position')).toBe('absolute');
 });
 
-// VALIDATE(live t/3026): in the default web boot only the 3 POV tabs render in the tablist —
-// `chat`/`debate`/etc. are gated (feature-flag/admin), so [data-tab="chat"] does not exist and
-// the DataSourceCard (Prompt Inspector) surface is unreachable here. Enable once the CI job
-// boots the app with those tabs flagged on, then point openTab() at the chat surface.
-test.fixme('DataSourceCard: .pi-node-count-preview rule is loaded (t/3025)', async ({ page }) => {
-  await openTab(page, 'chat'); // Prompt Inspector renders DataSourceCard
+// t/3059: DataSourceCard's CSS is NOT chat-gated — it rides the main entry chunk. The chain is
+// all static: DataSourceCard ← PromptInspector ← PromptsPanel ← ToolbarPaneRenderer ← PovTab
+// (App.tsx statically imports PovTab), so DataSourceCard.css is injected at boot and present on
+// every POV tab. The earlier `[data-tab="chat"]` assumption was over-conservative — probe on a
+// POV tab. `.pi-node-count-preview` sets `border-bottom: 1px` → styled = 1px, unstyled = 0px.
+test('DataSourceCard: .pi-node-count-preview rule is loaded (t/3025, enabled t/3059)', async ({ page }) => {
+  await openTab(page, 'accelerationist');
   const bw = await probe(page, 'pi-node-count-preview', 'border-bottom-width');
   expect(bw, `pi-node-count-preview border-bottom-width="${bw}"`).not.toBe('0px');
 });
 
-// VALIDATE(live): confirm which surface renders ApiKeyErrorMessage in the web build (its error
-// state), then point openTab() at it. Marked fixme until that nav is confirmed.
-test.fixme('ApiKeyErrorMessage: .api-key-error-link rule is loaded (t/3025)', async ({ page }) => {
-  await openTab(page, 'accelerationist'); // TODO: correct surface + trigger the error state
+// t/3059: ApiKeyErrorMessage.css also rides the main chunk — ApiKeyErrorMessage ← AnalysisPanel,
+// which PovTab statically imports (PovTab.tsx:23) and renders. So the rule is loaded at boot on
+// the POV tabs; probe-injection needs only the rule present, not the error state triggered.
+// `.api-key-error-link` sets `text-decoration: underline` → styled = 'underline', unstyled = 'none'.
+test('ApiKeyErrorMessage: .api-key-error-link rule is loaded (t/3025, enabled t/3059)', async ({ page }) => {
+  await openTab(page, 'accelerationist');
   const td = await probe(page, 'api-key-error-link', 'text-decoration-line');
   expect(td, `api-key-error-link text-decoration-line="${td}"`).toContain('underline');
+});
+
+// t/3059: `.claim-attribution-*` was a CONFIRMED orphan — used LIVE on the POV Attributes/Research
+// tab (NodeDetail.tsx renders `.claim-attribution-text`/`-label`) but its only CSS home was
+// ArgumentGraph.css, imported solely by ArgumentGraph ← TimelineScrubber, which is NEVER rendered
+// → tree-shaken → the rule shipped in NO chunk → unstyled on the POV tab. Fixed the #1561 way in
+// this PR by relocating the two rules into NodeDetail.css (main chunk → present on every consuming
+// surface). `.claim-attribution-label` sets `text-transform: uppercase` → styled, unstyled = 'none'.
+test('claim-attribution: .claim-attribution-label rule is loaded (t/3025/t/3059 orphan fix)', async ({ page }) => {
+  await openTab(page, 'accelerationist'); // NodeDetail renders claim-attribution on the POV surface
+  const tt = await probe(page, 'claim-attribution-label', 'text-transform');
+  expect(tt, `claim-attribution-label text-transform="${tt}"`).toBe('uppercase');
 });

--- a/taxonomy-editor/src/renderer/components/taxonomy/ArgumentGraph.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/ArgumentGraph.css
@@ -35,8 +35,10 @@
 .ag-detail-bdi { font-size: var(--text-2xs); padding: 1px 5px; border-radius: var(--radius-sm); background: var(--bg-hover); color: var(--text-muted); }
 .ag-detail-close { margin-left: auto; border: none; background: none; font-size: var(--text-lg); cursor: pointer; color: var(--text-muted); }
 .ag-detail-claim { line-height: 1.4; margin-bottom: 6px; }
-.claim-attribution-text { font-size: var(--text-xs); color: var(--text-muted); line-height: 1.35; margin-top: 2px; font-style: italic; }
-.claim-attribution-label { font-weight: 600; font-style: normal; margin-right: 4px; font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: 0.03em; opacity: 0.7; }
+/* .claim-attribution-text / .claim-attribution-label relocated to NodeDetail.css (t/3059):
+   they render on POV NodeDetail / ReflectionsPanel / diagnostics surfaces, but this sheet's
+   only importer (ArgumentGraph ← TimelineScrubber) is never rendered → tree-shaken → the rules
+   shipped in no chunk and rendered unstyled everywhere they were used (t/3025 confirmed orphan). */
 .ag-detail-meta { display: flex; flex-wrap: wrap; gap: 10px; font-size: var(--text-2xs); color: var(--text-muted); margin-bottom: 4px; }
 .ag-detail-refs { font-size: var(--text-2xs); color: var(--text-muted); margin-bottom: 4px; }
 .ag-detail-edges { font-size: var(--text-2xs); margin-top: 4px; }

--- a/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/NodeDetail.css
@@ -6,6 +6,13 @@
   vertical-align: -0.05em;
 }
 
+/* Claim attribution (relocated from ArgumentGraph.css, t/3059). NodeDetail renders these on the
+   POV Attributes/Research surface; ReflectionsPanel and the diagnostics windows render them too.
+   NodeDetail is in the always-loaded main chunk, so co-locating here makes the rules present on
+   every consuming surface — the ArgumentGraph.css home shipped in no chunk (dead importer). */
+.claim-attribution-text { font-size: var(--text-xs); color: var(--text-muted); line-height: 1.35; margin-top: 2px; font-style: italic; }
+.claim-attribution-label { font-weight: 600; font-style: normal; margin-right: 4px; font-size: var(--text-2xs); text-transform: uppercase; letter-spacing: 0.03em; opacity: 0.7; }
+
 /* ─── Node detail toolbar (pill buttons) ────────────────── */
 
 .node-detail-toolbar {


### PR DESCRIPTION
## t/3059 — render-smoke follow-ups (Parts 1 + 2)

Closes the harness-side scope of **t/3059** (follow-up to the t/3026 render-smoke gate). DevOps already shipped the CI job + Node-24 fix (#1599); this PR is the smoke-content increment.

### Part 1 — enable the 2 `test.fixme` surfaces (now active)
Both were **over-conservatively gated**. `DataSourceCard.css` and `ApiKeyErrorMessage.css` ride the **main entry chunk** (static import via `App.tsx → PovTab → {PromptInspector, AnalysisPanel}`), so their rules load at boot and are probeable on any POV tab — no `chat`/settings flagging needed. Pointed both probes at a POV tab and un-`fixme`'d.

### Part 2 — medium-3 adjudication: **all three CONFIRMED orphans**
Each flagged class has a single component-local definition (no `styles.css` fallback) and is used **cross-component** on a surface whose chunk does not load the defining sheet:

| class | verdict | action |
|---|---|---|
| `claim-attribution-*` | CONFIRMED — sole home ArgumentGraph.css is tree-shaken (dead `TimelineScrubber`), yet rendered on the **POV NodeDetail** surface → unstyled today | **Fixed here**: relocate 2 rules → `NodeDetail.css` (main chunk) + active POV smoke assertion |
| `qbaf-delta`/`qbaf-badge` | CONFIRMED — QbafOverlay.css loads only in diagnostics/harvest chunks; used in ConflictDetail + StatementCard | **Routed** → Conflict + DebateWorkspace |
| `vocab-term` | CONFIRMED — VocabularyPanel.css loads only in the debate chunk; used in OverviewTabRouter | **Routed** → DebateDiagnostics |

qbaf/vocab render only on **gated** surfaces (conflict/debate/diagnostics) whose fixes land in child-role scopes → routed, not asserted here (keeps the gate POV-scoped + low-flake per TL t/3026#10).

### Both-arms proof (TL t/3026#10 cond 1) — captured locally
`@playwright/test` **v1.60.0**, Node **24.15.0**, prod web build (`build:container` → `smoke:styled`):
- **Clean → 5 passed** (ga, hl, DataSourceCard, ApiKeyErrorMessage, claim-attribution).
- **All 3 new rules neutered → build:web → 3 failed / 2 passed**: `.pi-node-count-preview`→`0px`, `.api-key-error-link`→`none`, `.claim-attribution-label`→`none`; `.ga`/`.hl` stayed styled (isolated).

Every active assertion now has its own proven failure arm.

### Scope
4 files, all Rosetta-Stone-owned: `smoke/` (spec + README) + `taxonomy/{NodeDetail,ArgumentGraph}.css`. Promotion warn→block stays DevOps-owned (separate TL-signed draft PR).

Co-Authored-By: Rosetta Stone 2 (Rosetta Stone) (Orca) <rosetta-stone-2.taxonomy-editor@ai-triad-research.orca.local>
