### PR TITLE
fix(resilience): dedicated 'save' circuit breaker + queued breaker-blocked saves (t/3073)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/resilience.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/resilience.test.ts
@@ -6,6 +6,7 @@ import {
   resetResilience,
   subscribeResilience,
   setThrottleFromProbe,
+  isCircuitOpenError,
   type EndpointCategory,
   type ResilientFetchOptions,
 } from '../resilience';
@@ -92,6 +93,23 @@ describe('resilience', () => {
       expect(categorizeEndpoint('/api/taxonomy/acc', 'PUT')).toBe('mutation');
       expect(categorizeEndpoint('/api/debates', 'POST')).toBe('mutation');
       expect(categorizeEndpoint('/api/debates/abc', 'DELETE')).toBe('mutation');
+    });
+
+    it('routes embedding-compute to the ai breaker, NOT the save/mutation breaker (t/3073)', () => {
+      // A read-like compute must never share a breaker with data-saving writes.
+      expect(categorizeEndpoint('/api/embeddings/compute', 'POST')).toBe('ai');
+      expect(categorizeEndpoint('/api/embeddings/compute', 'PUT')).toBe('ai');
+    });
+
+    it('gives debate-session writes a dedicated save breaker (t/3073)', () => {
+      expect(categorizeEndpoint('/api/debates', 'PUT')).toBe('save');            // full save
+      expect(categorizeEndpoint('/api/debates/abc-123', 'PATCH')).toBe('save');  // delta save
+      // Deeper debate paths and non-save methods stay on the general 'mutation' breaker.
+      expect(categorizeEndpoint('/api/debates/abc/comments', 'PUT')).toBe('mutation');
+      expect(categorizeEndpoint('/api/debates/abc/exports', 'POST')).toBe('mutation');
+      expect(categorizeEndpoint('/api/debates/abc', 'DELETE')).toBe('mutation');
+      expect(categorizeEndpoint('/api/debates', 'GET')).toBe('read');
+      expect(categorizeEndpoint('/api/debates/list', 'GET')).toBe('read');
     });
   });
 
@@ -325,6 +343,31 @@ describe('resilience', () => {
       const state = getResilienceState();
       expect(state.circuits.read.state).toBe('OPEN');
       expect(state.circuits.read.consecutiveFailures).toBe(5);
+    });
+
+    it('isolation: embedding-compute failures open the ai breaker but leave save CLOSED (t/3073)', async () => {
+      // 5 consecutive 500s on the ai (embeddings-compute) breaker.
+      for (let i = 0; i < 5; i++) {
+        fetchSpy.mockResolvedValueOnce(mockFetchResponse(500));
+        await resilientFetch('/api/embeddings/compute', { method: 'POST' }, defaultOpts({ category: 'ai' }));
+      }
+      expect(getResilienceState().circuits.ai.state).toBe('OPEN');
+      // The save breaker is untouched, so a concurrent debate save is NOT blocked — the
+      // coupling that caused the incident is gone.
+      expect(getResilienceState().circuits.save.state).toBe('CLOSED');
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse(200, { ok: true }));
+      const res = await resilientFetch('/api/debates', { method: 'PUT' }, defaultOpts({ category: 'save' }));
+      expect(res.ok).toBe(true);
+    });
+
+    it('circuit-open error carries the typed circuitOpen discriminator (t/3073)', async () => {
+      for (let i = 0; i < 5; i++) {
+        fetchSpy.mockResolvedValueOnce(mockFetchResponse(500));
+        await resilientFetch('/api/debates', { method: 'PUT' }, defaultOpts({ category: 'save' }));
+      }
+      const err = await resilientFetch('/api/debates', { method: 'PUT' }, defaultOpts({ category: 'save' })).catch((e: unknown) => e);
+      expect(isCircuitOpenError(err)).toBe(true);
+      expect((err as { circuitCategory?: string }).circuitCategory).toBe('save');
     });
 
     it('rejects immediately when circuit is OPEN', async () => {

--- a/taxonomy-editor/src/renderer/bridge/resilience.ts
+++ b/taxonomy-editor/src/renderer/bridge/resilience.ts
@@ -7,13 +7,23 @@ import { getClientConfig } from '../lib/clientConfig';
 
 // ── Public types ──
 
-export type EndpointCategory = 'read' | 'mutation' | 'ai' | 'admin' | 'telemetry';
+export type EndpointCategory = 'read' | 'mutation' | 'save' | 'ai' | 'admin' | 'telemetry';
 export type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
 export type ThrottleState = 'NORMAL' | 'THROTTLED';
 
 export interface ResilienceStatus {
   circuits: Record<EndpointCategory, { state: CircuitState; consecutiveFailures: number; recentFailures: string[] }>;
   throttles: Record<EndpointCategory, { state: ThrottleState; p95Ms: number; baselineMs: number }>;
+}
+
+/** Typed discriminator for a request rejected because its circuit breaker is OPEN (t/3073).
+ *  A save that fails with this is NOT an ordinary error — it must be flagged degraded and
+ *  queued for retry, never silently dropped. Keyed off a structured field so downstream
+ *  logic never string-matches the message (fragile-prose class, t/2952). */
+export interface CircuitOpenError { circuitOpen: true; circuitCategory: EndpointCategory }
+
+export function isCircuitOpenError(err: unknown): err is CircuitOpenError {
+  return typeof err === 'object' && err !== null && (err as { circuitOpen?: unknown }).circuitOpen === true;
 }
 
 export interface ResilientFetchOptions {
@@ -47,15 +57,31 @@ function anySignal(caller: AbortSignal | undefined, timeout: AbortSignal): Abort
 
 function cfg() { return getClientConfig().resilience; }
 
-const ALL_CATEGORIES: EndpointCategory[] = ['read', 'mutation', 'ai', 'admin', 'telemetry'];
+const ALL_CATEGORIES: EndpointCategory[] = ['read', 'mutation', 'save', 'ai', 'admin', 'telemetry'];
+
+/** Cooldown before an OPEN circuit admits a HALF_OPEN probe. Exposed so the debate
+ *  save-durability path can schedule its post-breaker retry off the same source of
+ *  truth as the breaker itself (t/3073). */
+export function getCircuitCooldownMs(): number { return cfg().circuitCooldownMs; }
 
 // ── Endpoint categorization ──
 
 export function categorizeEndpoint(path: string, method: string): EndpointCategory {
   if (path === '/api/admin/telemetry' || path === '/api/admin/errors') return 'telemetry';
   if (path.startsWith('/api/ai/')) return 'ai';
+  // Embedding compute is a read-like AI compute (returns vectors, mutates no user data).
+  // It must NOT share a breaker with data-saving writes — a compute outage tripping the
+  // save breaker escalates a recoverable failure into user data loss (t/3073). The 'ai'
+  // breaker is its natural home.
+  if (path.startsWith('/api/embeddings/')) return 'ai';
   if (path.startsWith('/api/admin/')) return 'admin';
   if (method === 'GET') return 'read';
+  // Debate-session writes get a DEDICATED breaker so no unrelated mutation's failures can
+  // open the save path — saves are the highest-integrity op (t/3073). Full save =
+  // PUT /api/debates; delta save = PATCH /api/debates/:id. Deeper debate paths
+  // (comments/exports/news-report) and POST/DELETE stay on the general 'mutation' breaker.
+  if (method === 'PUT' && path === '/api/debates') return 'save';
+  if (method === 'PATCH' && /^\/api\/debates\/[^/]+$/.test(path)) return 'save';
   return 'mutation';
 }
 
@@ -132,12 +158,16 @@ function checkCircuit(cat: EndpointCategory, path: string): void {
     const remaining = Math.ceil((cfg().circuitCooldownMs - elapsed) / 1000);
     const failureSummary = summarizeFailures(c.recentFailures.map(f => f.reason));
     const detail = failureSummary ? `\nLast failures: ${failureSummary}` : '';
-    throw new ActionableError({
+    const circuitErr = new ActionableError({
       goal: `Make request to ${path}`,
       problem: `Circuit breaker OPEN for '${cat}' after ${c.consecutiveFailures} consecutive failures. ${remaining}s cooldown remaining.${detail}`,
       location: 'web-bridge/resilience',
       nextSteps: ['Wait for the cooldown period to expire', 'Check whether the server is healthy'],
     });
+    // Typed discriminator (t/3073, TL refinement): downstream save-durability logic keys off
+    // this structured field, never a message substring — the fragile-prose class (t/2952).
+    Object.assign(circuitErr, { circuitOpen: true, circuitCategory: cat } satisfies CircuitOpenError);
+    throw circuitErr;
   }
   // HALF_OPEN — allow one probe request through
 }

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/saveDebateCoalescing.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/saveDebateCoalescing.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+﻿import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import { create } from 'zustand';
 import type { DebateStore } from '../types';
 import { createSessionSlice } from '../slices/sessionSlice';
@@ -286,5 +286,86 @@ describe('saveDebate degraded-save surfacing (t/1639)', () => {
     const errorEvents = mockRecords.filter(r => r.type === 'state.error');
     expect(errorEvents.length).toBe(1);
     expect(errorEvents[0].data).toMatchObject({ save_degraded: true, at_risk_turns: 3 });
+  });
+});
+
+// t/3073 — a save rejected because the 'save' circuit breaker is OPEN must never be
+// silently dropped. The incident recorded save_degraded:false on a breaker-blocked save
+// and queued nothing. It must now: flag save_degraded:true (observable), surface a paused
+// message, queue a cooldown retry that flushes on recovery, and — after the retry cap —
+// escalate to a LOUD, actionable terminal state rather than a silent give-up.
+describe('saveDebate breaker-blocked durability (t/3073)', () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  // Mirrors the typed circuit-open ActionableError from web-bridge/resilience — the
+  // discriminator is the structured `circuitOpen` field, never a message substring (t/2952).
+  const breakerError = () => Object.assign(new Error('save circuit breaker OPEN'), { circuitOpen: true, circuitCategory: 'save' });
+
+  function debateWithTurns() {
+    return {
+      ...makeMinimalDebate(),
+      transcript: [{ type: 'opening' }, { type: 'statement' }, { type: 'statement' }],
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecords.length = 0;
+    vi.useFakeTimers();
+    store = createTestStore();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('arm2a: flags save_degraded=true (not false) + surfaces a paused message + queues a retry — never silent', async () => {
+    mockSaveDebateSession.mockRejectedValueOnce(breakerError());
+    store.setState({ activeDebate: debateWithTurns() as unknown as DebateStore['activeDebate'] });
+
+    await store.getState().saveDebate('breaker-block');
+
+    const err = store.getState().debateError ?? '';
+    expect(err.toLowerCase()).toContain('saving is paused');
+    expect(err).toContain('3 turns');
+    const errorEvents = mockRecords.filter(r => r.type === 'state.error');
+    expect(errorEvents.length).toBe(1);
+    // The incident's exact defect: a breaker-blocked save recorded save_degraded:false.
+    expect(errorEvents[0].data).toMatchObject({ save_degraded: true, at_risk_turns: 3 });
+    // A cooldown retry is queued (not dropped).
+    expect(store.getState()._breakerRetryScheduled).toBe(true);
+    expect(store.getState()._breakerRetryCount).toBe(1);
+  });
+
+  it('arm2b: flushes the queued save on cooldown and clears the degraded state on success', async () => {
+    mockSaveDebateSession
+      .mockRejectedValueOnce(breakerError())   // first attempt — breaker OPEN
+      .mockResolvedValueOnce(undefined);        // cooldown retry — server recovered
+    store.setState({ activeDebate: debateWithTurns() as unknown as DebateStore['activeDebate'] });
+
+    await store.getState().saveDebate('breaker-block');
+    expect(store.getState().debateError).toBeTruthy();
+
+    // Advance past the breaker cooldown so the scheduled retry fires.
+    await vi.advanceTimersByTimeAsync(61_000);
+
+    expect(mockSaveDebateSession).toHaveBeenCalledTimes(2);
+    expect(store.getState().debateError).toBeNull();       // cleared on the recovered save
+    expect(store.getState()._breakerRetryCount).toBe(0);   // counter reset
+  });
+
+  it('arm3: escalates to a LOUD, actionable terminal state after the retry cap — never a silent give-up', async () => {
+    mockSaveDebateSession.mockRejectedValue(breakerError());   // every attempt blocked
+    // Preset the counter at the cap so this attempt is the terminal one.
+    store.setState({ activeDebate: debateWithTurns() as unknown as DebateStore['activeDebate'], _breakerRetryCount: 5 });
+
+    await store.getState().saveDebate('breaker-block-final');
+
+    const err = store.getState().debateError ?? '';
+    // Loud + actionable: exact unsaved-turn count + local-export escape hatch.
+    expect(err).toContain('3 turns');
+    expect(err.toLowerCase()).toContain('export');
+    const exhausted = mockRecords.filter(r => r.type === 'state.error' && (r.data as Record<string, unknown> | undefined)?.breaker_retry_exhausted === true);
+    expect(exhausted.length).toBe(1);
+    expect((exhausted[0].data as Record<string, unknown>).save_degraded).toBe(true);
+    // Terminal: auto-retry stops (no new timer scheduled).
+    expect(store.getState()._breakerRetryScheduled).toBe(false);
   });
 });

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/slices/sessionSlice.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../../types/debate';
 import { POVER_INFO, AI_POVERS, POV_KEYS, normalizeActivePovers, migrateSpeakerId } from '../../../types/debate';
 import { api, setActiveDebateId, isElectronMode } from '@bridge';
+import { isCircuitOpenError, getCircuitCooldownMs } from '../../../bridge/resilience';
 import { buildDebateDelta } from './buildDebateDelta';
 import { getDocTitles } from '../shared/docTitles';
 import type { DocMetaMap } from '@lib/debate/evidenceFromSummaries';
@@ -86,6 +87,13 @@ export interface SessionSlice {
   // these (the store routes Electron saves through the full path).
   _lastSyncedVersion: number | null;
   _lastSyncedSnapshot: DebateSession | null;
+  // Save-durability under an OPEN 'save' circuit breaker (t/3073). When a save is rejected
+  // because the breaker is open, it is NOT dropped: it is flagged degraded and re-attempted
+  // after the breaker cooldown. `_breakerRetryCount` counts consecutive breaker-blocked
+  // attempts (reset to 0 on any successful save); `_breakerRetryScheduled` guards against
+  // scheduling more than one cooldown retry when several callers race the open breaker.
+  _breakerRetryCount: number;
+  _breakerRetryScheduled: boolean;
   toggleStepMode: () => Promise<void>;
   setDebatePhase: (phase: 'confrontation' | 'argumentation' | 'concluding') => Promise<void>;
 }
@@ -302,13 +310,18 @@ async function persistDebateToServer(activeDebate: DebateSession, saveDiag: Save
  *      with stable markers.
  * The at-risk count is recomputed locally from the transcript (not string-scraped).
  */
-function computeSaveErrorState(err: unknown, activeDebate: DebateSession): { isDurableSaveLoss: boolean; atRiskTurns: number; debateError: string } {
+function computeSaveErrorState(err: unknown, activeDebate: DebateSession): { isDurableSaveLoss: boolean; isBreakerBlocked: boolean; atRiskTurns: number; debateError: string } {
   const rawMessage = String((err as Error)?.message ?? '');
   const httpStatus = (err as { httpStatus?: number }).httpStatus;
   const isAuthQuotaFailure = httpStatus === 401 || httpStatus === 402 || httpStatus === 403;
   const isDiskLoss =
     rawMessage.includes('taxonomy-editor/src/main/debateIO.ts saveDebateSession') &&
     (rawMessage.includes('only durable copy') || rawMessage.includes('at risk of being lost'));
+  // Breaker-blocked (t/3073): the 'save' circuit is OPEN, so this save never reached the
+  // server. Detected via the TYPED discriminator, never a message substring (t/2952). This
+  // is a recoverable degraded state — flagged (never silent), then queued for cooldown retry
+  // by the caller — so it counts as save_degraded but is NOT a durable (terminal) loss.
+  const isBreakerBlocked = isCircuitOpenError(err);
   const isDurableSaveLoss = isAuthQuotaFailure || isDiskLoss;
   const atRiskTurns = activeDebate.transcript.filter(
     (t) => t.type === 'statement' || t.type === 'opening',
@@ -318,10 +331,55 @@ function computeSaveErrorState(err: unknown, activeDebate: DebateSession): { isD
     debateError = `Save failed: the server rejected this save (HTTP ${httpStatus}). ${atRiskTurns} ${atRiskTurns === 1 ? 'turn is' : 'turns are'} at risk of being lost. Check your API key and account status in Settings.`;
   } else if (isDiskLoss) {
     debateError = `Save failed: this debate couldn't be written to disk — a file lock (often antivirus or a file indexer) is holding the file. ${atRiskTurns} ${atRiskTurns === 1 ? 'turn is' : 'turns are'} at risk. A recovery copy was preserved on disk; retry the save once the lock clears, and don't close the app before it succeeds.`;
+  } else if (isBreakerBlocked) {
+    debateError = `Saving is paused while the server recovers. ${atRiskTurns} ${atRiskTurns === 1 ? 'turn is' : 'turns are'} not yet saved — this will retry automatically. Keep the app open.`;
   } else {
     debateError = mapErrorToUserMessage(err);
   }
-  return { isDurableSaveLoss, atRiskTurns, debateError };
+  return { isDurableSaveLoss, isBreakerBlocked, atRiskTurns, debateError };
+}
+
+/** Max consecutive breaker-blocked save attempts before auto-retry stops and the state
+ *  escalates to the LOUD terminal message (t/3073). */
+const BREAKER_RETRY_CAP = 5;
+
+/**
+ * A save rejected by an OPEN 'save' circuit breaker (t/3073). Never dropped:
+ *   - Under the cap: surface the degraded state and schedule ONE retry after the breaker
+ *     cooldown (a `_breakerRetryScheduled` guard keeps racing callers from stacking timers).
+ *     The retry rides the normal saveDebate path, whose HALF_OPEN probe either closes the
+ *     breaker (save succeeds, counters reset in saveDebate's try) or re-queues.
+ *   - At the cap: auto-retry stops and we emit a LOUD, actionable terminal state (TL
+ *     refinement) — exact unsaved-turn count + "export a local copy now" — never a silent
+ *     give-up. Saves still self-heal on the next natural save (each new turn calls
+ *     saveDebate); a success there resets the counters.
+ */
+function handleBreakerBlockedSave(
+  activeDebate: DebateSession,
+  caller: string,
+  atRiskTurns: number,
+  degradedError: string,
+  get: SessionGet,
+  set: SessionSet,
+): void {
+  const attempts = get()._breakerRetryCount;
+  if (attempts >= BREAKER_RETRY_CAP) {
+    const loudError = `Save failed: the server stayed unreachable through ${attempts} automatic retries. ${atRiskTurns} ${atRiskTurns === 1 ? 'turn is' : 'turns are'} unsaved. Export this debate now (Export ▸ Download) to keep a local copy — saving retries on your next turn once the server recovers.`;
+    set({ debateError: loudError, _breakerRetryScheduled: false });
+    getGlobalRecorder()?.record({ type: 'state.error', component: 'debate-store', level: 'error', debate_id: activeDebate.id, message: 'Debate save abandoned after breaker-retry cap — turns unsaved, local export advised', error: { name: 'SaveBreakerExhaustedError', message: `save circuit OPEN through ${attempts} retries` }, data: { caller, turn_count: activeDebate.transcript.length, save_degraded: true, breaker_retry_exhausted: true, at_risk_turns: atRiskTurns } });
+    return;
+  }
+  // Degraded but recoverable: surface it (observable — never save_degraded:false), then
+  // schedule one cooldown retry unless a peer caller already did.
+  set({ debateError: degradedError });
+  getGlobalRecorder()?.record({ type: 'state.error', component: 'debate-store', level: 'warn', debate_id: activeDebate.id, message: 'Debate save paused — save circuit OPEN, retrying after cooldown', error: { name: 'SaveBreakerBlockedError', message: 'save circuit breaker OPEN' }, data: { caller, turn_count: activeDebate.transcript.length, save_degraded: true, breaker_retry: attempts + 1, at_risk_turns: atRiskTurns } });
+  if (get()._breakerRetryScheduled) return;
+  set({ _breakerRetryScheduled: true, _breakerRetryCount: attempts + 1 });
+  const delay = getCircuitCooldownMs() + Math.random() * 500;
+  setTimeout(() => {
+    set({ _breakerRetryScheduled: false });
+    void get().saveDebate('breaker-cooldown-retry');
+  }, delay);
 }
 
 /**
@@ -365,6 +423,8 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
   _loadInFlight: {},
   _lastSyncedVersion: null,
   _lastSyncedSnapshot: null,
+  _breakerRetryCount: 0,
+  _breakerRetryScheduled: false,
 
   loadSessions: async () => {
     set({ sessionsLoading: true });
@@ -1070,18 +1130,30 @@ export const createSessionSlice: StateCreator<DebateStore, [], [], SessionSlice>
       const saveDiag = buildSaveDiag(activeDebate, caller);
       // Save-path selection + post-save bookkeeping (t/1637) — see persistDebateToServer.
       await persistDebateToServer(activeDebate, saveDiag, get, set);
+      // Save reached the server: clear any breaker-retry degradation left by prior
+      // blocked attempts (t/3073). Only touch debateError when we were actually retrying,
+      // so a successful save never clobbers an unrelated error.
+      if (get()._breakerRetryCount > 0) {
+        set({ _breakerRetryCount: 0, debateError: null });
+      }
     } catch (err) {
       const errorCode = (err as Error & { errorCode?: string }).errorCode;
       if (errorCode === 'save_in_progress') {
         set({ _saveDirty: true });
         getGlobalRecorder()?.record({ type: 'state.save-coalesced', component: 'debate-store', level: 'info', debate_id: activeDebate.id, message: 'Server 409 save_in_progress — will retry via coalesced follow-up' });
       } else {
-        // Distinguish a durable-save loss from an ordinary save error (t/1639) so the
-        // user is told their debate is at risk — see computeSaveErrorState. record()
-        // stays inline here per ADR-003.
-        const { isDurableSaveLoss, atRiskTurns, debateError } = computeSaveErrorState(err, activeDebate);
-        getGlobalRecorder()?.record({ type: 'state.error', component: 'debate-store', level: 'error', debate_id: activeDebate.id, message: isDurableSaveLoss ? 'Durable debate save failed — recovery copy preserved' : 'Failed to save debate', error: { name: isDurableSaveLoss ? 'DurableSaveError' : 'SaveError', message: String(err), stack: (err as Error).stack }, data: { caller, payload_bytes: JSON.stringify(activeDebate).length, turn_count: activeDebate.transcript.length, save_degraded: isDurableSaveLoss, at_risk_turns: atRiskTurns } });
-        set({ debateError });
+        // Distinguish durable-save loss, breaker-blocked (recoverable), and ordinary errors
+        // (t/1639, t/3073) so the user is told their debate is at risk — see
+        // computeSaveErrorState. record() stays inline here per ADR-003.
+        const { isDurableSaveLoss, isBreakerBlocked, atRiskTurns, debateError } = computeSaveErrorState(err, activeDebate);
+        if (isBreakerBlocked) {
+          // Save never reached the server (save circuit OPEN). Flag degraded + queue a
+          // cooldown retry — never a silent drop (t/3073).
+          handleBreakerBlockedSave(activeDebate, caller, atRiskTurns, debateError, get, set);
+        } else {
+          getGlobalRecorder()?.record({ type: 'state.error', component: 'debate-store', level: 'error', debate_id: activeDebate.id, message: isDurableSaveLoss ? 'Durable debate save failed — recovery copy preserved' : 'Failed to save debate', error: { name: isDurableSaveLoss ? 'DurableSaveError' : 'SaveError', message: String(err), stack: (err as Error).stack }, data: { caller, payload_bytes: JSON.stringify(activeDebate).length, turn_count: activeDebate.transcript.length, save_degraded: isDurableSaveLoss, at_risk_turns: atRiskTurns } });
+          set({ debateError });
+        }
       }
     } finally {
       const wasDirty = get()._saveDirty;

--- a/taxonomy-editor/src/renderer/hooks/useResilienceStatus.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useResilienceStatus.test.ts
@@ -3,7 +3,7 @@ import { useResilienceStatus } from './useResilienceStatus';
 import type { ResilienceStatus, EndpointCategory, CircuitState, ThrottleState } from '../bridge/resilience';
 
 vi.mock('../bridge/resilience', () => {
-  const ALL: EndpointCategory[] = ['read', 'mutation', 'ai', 'admin', 'telemetry'];
+  const ALL: EndpointCategory[] = ['read', 'mutation', 'save', 'ai', 'admin', 'telemetry'];
   const mkState = (
     overrides?: Partial<Record<EndpointCategory, { state: CircuitState; consecutiveFailures: number }>>,
     throttleOverrides?: Partial<Record<EndpointCategory, { state: ThrottleState; p95Ms: number; baselineMs: number }>>,
@@ -40,8 +40,8 @@ describe('useResilienceStatus', () => {
     useResilienceStatus.setState({
       alerts: [],
       toasts: [],
-      _prevCircuits: { read: 'CLOSED', mutation: 'CLOSED', ai: 'CLOSED', admin: 'CLOSED', telemetry: 'CLOSED' },
-      _prevThrottles: { read: 'NORMAL', mutation: 'NORMAL', ai: 'NORMAL', admin: 'NORMAL', telemetry: 'NORMAL' },
+      _prevCircuits: { read: 'CLOSED', mutation: 'CLOSED', save: 'CLOSED', ai: 'CLOSED', admin: 'CLOSED', telemetry: 'CLOSED' },
+      _prevThrottles: { read: 'NORMAL', mutation: 'NORMAL', save: 'NORMAL', ai: 'NORMAL', admin: 'NORMAL', telemetry: 'NORMAL' },
     });
   });
 
@@ -156,7 +156,14 @@ describe('useResilienceStatus', () => {
 
   describe('category labels', () => {
     it('uses correct label for mutation category', () => {
+      // Saves moved to their own breaker (t/3073); the generic mutation breaker is now "Edits".
       simulate(mkState({ mutation: { state: 'OPEN', consecutiveFailures: 5 } }));
+      const { alerts } = useResilienceStatus.getState();
+      expect(alerts[0].message).toContain('Edits unavailable');
+    });
+
+    it('uses correct label for the dedicated save category (t/3073)', () => {
+      simulate(mkState({ save: { state: 'OPEN', consecutiveFailures: 5 } }));
       const { alerts } = useResilienceStatus.getState();
       expect(alerts[0].message).toContain('Save unavailable');
     });

--- a/taxonomy-editor/src/renderer/hooks/useResilienceStatus.ts
+++ b/taxonomy-editor/src/renderer/hooks/useResilienceStatus.ts
@@ -27,7 +27,8 @@ export interface RecoveryToast {
 
 const CATEGORY_LABELS: Record<EndpointCategory, string> = {
   read: 'Data',
-  mutation: 'Save',
+  mutation: 'Edits',
+  save: 'Save',           // dedicated debate-save breaker (t/3073)
   ai: 'AI service',
   admin: 'Admin',
   telemetry: 'Telemetry',


### PR DESCRIPTION
## Summary
Fixes the highest-severity finding from the 2026-08-27 debate-stall incident: embedding-compute failures tripped the shared `'mutation'` circuit breaker, which then blocked debate saves — a recoverable compute outage escalating into silent user data loss. Design approved by TL at t/3073#1/#2 (1+2+3+4A + two refinements).

### Part 1 — breaker granularity (`resilience.ts`)
- New dedicated `'save'` `EndpointCategory`: `PUT /api/debates` (full save) + `PATCH /api/debates/:id` (delta) get their own breaker — no unrelated mutation's failures can open the save path.
- `/api/embeddings/*` reclassified to the `'ai'` breaker (read-like compute, mutates no user data).
- Circuit-open error carries a **typed** `circuitOpen`/`circuitCategory` field + `isCircuitOpenError` guard — downstream keys off the field, never a message substring (t/2952). *(TL refinement #1)*

### Part 2 — save durability (`sessionSlice.ts`)
- Breaker-blocked save → `save_degraded:true` (incident logged `false`) + user-surfaced — never silent.
- Queued + retried after breaker cooldown (guarded against racing callers); recovered save clears the degraded state + resets counters.
- Cap-exhausted → **LOUD, actionable terminal** state (exact unsaved-turn count + local-export escape hatch), never a silent give-up. *(TL refinement #2)*

UI: `'save'` breaker gets its own "Save" label; generic mutation breaker relabeled "Edits".

### Tests (three arms, TL-required)
1. **Isolation** — 5×500 on `/api/embeddings/compute` opens `'ai'`, leaves `'save'` CLOSED, a concurrent `PUT /api/debates` succeeds.
2. **Durability** — breaker-blocked save recorded `save_degraded:true` + queued + flushed on cooldown + cleared on success.
3. **Terminal** — cap-exhausted emits `breaker_retry_exhausted:true` + loud export-now message.

### Verification (worktree)
- `vitest` resilience + saveDebateCoalescing + useResilienceStatus: **78 passed**
- `tsc` main + `check-renderer-tsc.sh`: **0 errors**
- `eslint` changed files: **0 errors** (5 pre-existing complexity warnings, under gate ceiling)

Routing to **Main (TL)** for review (resilience surface). Draft until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)