### PR TITLE
fix(debate-workspace): co-locate qbaf-net-delta CSS into StatementCard.css (t/3076)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/StatementCard.css
@@ -728,3 +728,11 @@ a.lineage-link,
   animation: spin 0.8s linear infinite;
   flex-shrink: 0;
 }
+
+/* ── QBAF net-delta chip (t/3076) ── co-located from QbafOverlay.css so the
+   debate chunk (which never imports QbafOverlay) renders the strength delta. */
+.qbaf-delta-up { color: #16a34a; }
+.qbaf-delta-down { color: #dc2626; }
+.qbaf-net-delta { margin-left: auto; font-size: var(--text-2xs); font-weight: 600; white-space: nowrap; padding: 1px 5px; border-radius: var(--radius-sm); }
+.qbaf-net-delta.qbaf-delta-up { background: rgba(22,163,74,0.1); }
+.qbaf-net-delta.qbaf-delta-down { background: rgba(220,38,38,0.1); }


### PR DESCRIPTION
## Summary

- `.qbaf-net-delta`, `.qbaf-delta-up`, `.qbaf-delta-down` were defined only in `QbafOverlay.css`, which is never imported by the debate chunk — causing the inline strength-delta chip on `StatementCard` to render unstyled
- Paste the 5 rules into `StatementCard.css` (consumer-owned co-location, same pattern as #1561)
- `QbafOverlay.css` retains its copy for the diagnostics/harvest surfaces

## Test plan

- [ ] Visual: debate transcript strength-delta chip renders with green/red color and pill background
- [ ] No regression on QbafOverlay diagnostics surface (it retains its own copy)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)