### PR TITLE
fix(conflict): co-locate qbaf badge/delta CSS into ConflictDetail.css (t/3075)

### DIFF
--- a/taxonomy-editor/src/renderer/components/conflict/ConflictDetail.css
+++ b/taxonomy-editor/src/renderer/components/conflict/ConflictDetail.css
@@ -1196,3 +1196,13 @@
   font-size: var(--text-2xs);
   color: var(--text-muted);
 }
+
+/* ── QBAF badge / delta (co-located from QbafOverlay.css; t/3075) ── */
+.qbaf-badge { display: inline-flex; align-items: center; gap: 3px; font-size: var(--text-2xs); padding: 1px 5px; border-radius: var(--radius-sm); font-weight: 600; white-space: nowrap; }
+.qbaf-strong { background: rgba(22,163,74,0.15); color: #16a34a; }
+.qbaf-moderate { background: rgba(37,99,235,0.15); color: #2563eb; }
+.qbaf-weak { background: rgba(217,119,6,0.15); color: #d97706; }
+.qbaf-very-weak { background: rgba(220,38,38,0.15); color: #dc2626; }
+.qbaf-delta { font-size: var(--text-2xs); font-weight: 400; }
+.qbaf-delta-up { color: #16a34a; }
+.qbaf-delta-down { color: #dc2626; }


### PR DESCRIPTION
## Summary
- CSS orphan: `.qbaf-badge`, `.qbaf-strong/moderate/weak/very-weak`, `.qbaf-delta/up/down` rules lived only in `QbafOverlay.css` (imported only on diagnostics/harvest chunks), leaving them unstyled on the conflict surface
- Co-located a copy into `ConflictDetail.css` following the DataSourceCard / ApiKeyErrorMessage orphan-fix pattern (#1561)
- `QbafOverlay.css` retains its own copy for the diagnostics surface (accepted small-duplication tradeoff)

## Test plan
- [ ] Visual check: open a conflict node with QBAF badges — verify `.qbaf-badge` / `.qbaf-strong` / `.qbaf-delta-up` render styled (color + background)
- [ ] No regression on diagnostics surface (QbafOverlay.css unchanged)

Closes t/3075

🤖 Generated with [Claude Code](https://claude.com/claude-code)