### PR TITLE
feat(server/embeddings): batch cap 413 + typed timeout 503 (t/3074)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsBatchCapAnd503.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsBatchCapAnd503.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3074 — POST /api/embeddings/compute batch cap (413) + typed-timeout 503.
+// TL-approved test arms (p/522#59):
+//   1. texts.length > MAX_EMBED_BATCH → 413 (non-retryable)
+//   2. texts.length === MAX_EMBED_BATCH → proceeds normally (boundary pass)
+//   3. evaluateEmbeddingLoadShed → {shed:true, mode:'block'} → 503 retryable
+//   4. computeEmbeddings throws error with .timeout=true → 503 retryable (NOT 500)
+//   5. computeEmbeddings throws error WITHOUT .timeout → 500 (deterministic, non-retryable)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+// ── Hoisted mocks (vi.fn() refs shared between factory and test body) ─────────
+
+const computeEmbeddings = vi.fn();
+const evaluateEmbeddingLoadShed = vi.fn();
+
+// ── Module mocks (hoisted before import) ─────────────────────────────────────
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: vi.fn() }),
+}));
+
+vi.mock('../security/accessControl.js', () => ({
+  callerTierIdentity: () => ({ principalName: 'testuser', idp: 'aad' }),
+  missingApiKeyError: vi.fn(() => null),
+  expiredAuthCookies: vi.fn(() => []),
+  clientSafeMessage: (msg: string) => msg,
+}));
+
+vi.mock('../security/userContext.js', () => ({
+  getCurrentUser: vi.fn(() => ({ principalName: 'testuser', idp: 'aad' })),
+  getCurrentUserId: vi.fn(() => 'testuser'),
+}));
+
+vi.mock('../logger.js', () => ({
+  log: {
+    api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    server: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    fr: { info: vi.fn(), warn: vi.fn() },
+  },
+  getRequestContext: vi.fn(() => ({})),
+  getRequestId: vi.fn(() => 'req-test'),
+  LOG_MAX_LINE_BYTES: 65536,
+}));
+
+vi.mock('../../../../lib/ai-client/index.js', () => ({
+  DEFAULT_MODEL: 'test-model',
+}));
+
+vi.mock('../config.js', () => ({
+  hasApiKey: vi.fn(() => false),
+  getPaidGeminiFallbackKey: vi.fn(() => null),
+  getDataRoot: () => '/fake/data',
+  getStateRoot: () => '/fake/state',
+  getProjectRoot: () => '/fake/project',
+  STORAGE_MODE: 'local',
+}));
+
+vi.mock('../ai/proxyTiers.js', () => ({
+  resolveTier: vi.fn(() => ({ level: 'platform', limits: { requestsPerMinute: 100, tokensPerDay: 1_000_000 } })),
+  LOCAL_EMBED_RPM_PER_IP: 120,
+  getTierKey: vi.fn(() => 'platform'),
+}));
+
+vi.mock('../security/rateLimiter.js', () => ({
+  checkRate: vi.fn(() => ({ allowed: true })),
+  checkRequestRate: vi.fn(() => ({ allowed: true })),
+  checkTokenBudget: vi.fn(() => ({ allowed: true })),
+  resetRateLimiters: vi.fn(),
+}));
+
+vi.mock('../ai/aiBackends.js', () => ({
+  computeEmbeddings: (...a: unknown[]) => computeEmbeddings(...a),
+  computeQueryEmbedding: vi.fn(),
+  generateText: vi.fn(),
+  generateTextByUsage: vi.fn(),
+  classifyNli: vi.fn(),
+  updateNodeEmbeddings: vi.fn(),
+  setDebateTemperature: vi.fn(),
+  resolveEmbeddingsChunked: vi.fn(),
+}));
+
+vi.mock('./generationContext.js', () => ({
+  resolveGenerationContext: vi.fn(() => ({ model: 'test-model', backend: 'gemini' })),
+  enforceBackendAllowed: vi.fn(() => false),
+}));
+
+vi.mock('../embeddingsLoad.js', () => ({
+  evaluateEmbeddingLoadShed: (...a: unknown[]) => evaluateEmbeddingLoadShed(...a),
+  embeddingLoadSnapshot: vi.fn(() => ({
+    in_flight_embedding_computes: 0,
+    heap_limit_mb: 512,
+    heap_used_mb: 100,
+    rss_mb: 200,
+    event_loop_delay_max_ms: 0,
+  })),
+  beginEmbeddingCompute: vi.fn(),
+  endEmbeddingCompute: vi.fn(),
+  isEmbeddingModelWarm: vi.fn(() => false),
+  markEmbeddingModelWarm: vi.fn(),
+  decideLoadShed: vi.fn(),
+  inFlightEmbeddingComputes: vi.fn(() => 0),
+  embeddingLoadShedMode: vi.fn(() => 'warn'),
+  readRecentLoopDelayMaxMs: vi.fn(() => 0),
+  resetEmbeddingModelWarm: vi.fn(),
+}));
+
+vi.mock('../storage/fileIO.js', () => ({
+  loadDictionary: vi.fn(),
+  getTaxonomyDir: () => '/fake/taxonomy',
+  resolveDataPath: () => '/fake/taxonomy',
+  buildNodeSourceIndex: vi.fn(),
+  isSafeId: vi.fn(() => true),
+}));
+
+import { registerAiRoutes } from '../routes/ai.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body?: unknown) => Promise<void> | void;
+
+function makeRouter() {
+  const handlers: Record<string, Handler> = {};
+  const reg = (m: string) => (p: string, h: Handler) => { handlers[`${m} ${p}`] = h; };
+  return {
+    router: { get: reg('GET'), post: reg('POST'), put: reg('PUT'), patch: reg('PATCH'), del: reg('DELETE') },
+    handlers,
+  };
+}
+
+function fakeRes() {
+  const res: Record<string, unknown> = {
+    writableEnded: false,
+    headersSent: false,
+    _statusCode: 200,
+    _headers: {} as Record<string, string>,
+    _body: undefined as unknown,
+    writeHead: vi.fn((code: number, headers?: Record<string, string>) => {
+      res._statusCode = code;
+      if (headers) Object.assign(res._headers as object, headers);
+      res.headersSent = true;
+    }),
+    end: vi.fn((b?: string) => {
+      res._body = b !== undefined ? JSON.parse(b) : undefined;
+      res.writableEnded = true;
+    }),
+    setHeader: vi.fn(),
+  };
+  return res as unknown as ServerResponse & { _body: Record<string, unknown>; _statusCode: number; _headers: Record<string, string> };
+}
+
+const MAX_EMBED_BATCH = 512;
+
+function makeCtx() {
+  return {} as Parameters<typeof registerAiRoutes>[1];
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /api/embeddings/compute — batch cap + typed-timeout 503 (t/3074)', () => {
+  let computeHandler: Handler;
+
+  beforeEach(() => {
+    evaluateEmbeddingLoadShed.mockReturnValue({ shed: false });
+    computeEmbeddings.mockResolvedValue([[0.1, 0.2]]);
+
+    const { router, handlers } = makeRouter();
+    registerAiRoutes(router as never, makeCtx());
+    computeHandler = handlers['POST /api/embeddings/compute'];
+  });
+
+  it('arm 1 — 413 when texts.length exceeds MAX_EMBED_BATCH (Gap 1 server-side cap)', async () => {
+    const res = fakeRes();
+    const texts = Array.from({ length: MAX_EMBED_BATCH + 1 }, (_, i) => `text-${i}`);
+    await computeHandler({} as IncomingMessage, res, { texts });
+    expect(res._statusCode).toBe(413);
+    expect(res._body).toMatchObject({ error: expect.stringContaining(`${MAX_EMBED_BATCH + 1}`) });
+  });
+
+  it('arm 2 — 200 when texts.length === MAX_EMBED_BATCH (boundary pass)', async () => {
+    const texts = Array.from({ length: MAX_EMBED_BATCH }, (_, i) => `text-${i}`);
+    const vectors = texts.map(() => [0.1]);
+    computeEmbeddings.mockResolvedValueOnce(vectors);
+    const res = fakeRes();
+    await computeHandler({} as IncomingMessage, res, { texts });
+    expect(res._statusCode).not.toBe(413);
+    expect(res._body).toMatchObject({ vectors });
+  });
+
+  it('arm 3 — 503 retryable when load-shed mode is block', async () => {
+    evaluateEmbeddingLoadShed.mockReturnValue({ shed: true, mode: 'block', reason: 'concurrency', retryAfterMs: 3000 });
+    const res = fakeRes();
+    await computeHandler({} as IncomingMessage, res, { texts: ['hello'] });
+    expect(res._statusCode).toBe(503);
+    expect(res._body).toMatchObject({ retryable: true });
+  });
+
+  it('arm 4 — 503 retryable when computeEmbeddings throws with .timeout=true (NOT 500)', async () => {
+    const timeoutErr = Object.assign(new Error('embeddings-chunk timed out after 45s'), { timeout: true });
+    computeEmbeddings.mockRejectedValueOnce(timeoutErr);
+    const res = fakeRes();
+    await computeHandler({} as IncomingMessage, res, { texts: ['hello'] });
+    expect(res._statusCode).toBe(503);
+    expect(res._body).toMatchObject({ retryable: true, retryAfterMs: 5000 });
+  });
+
+  it('arm 5 — 500 when computeEmbeddings throws without .timeout (deterministic errors stay non-retryable)', async () => {
+    computeEmbeddings.mockRejectedValueOnce(new Error('model initialization failed'));
+    const res = fakeRes();
+    await computeHandler({} as IncomingMessage, res, { texts: ['hello'] });
+    expect(res._statusCode).toBe(500);
+    expect(res._body).not.toMatchObject({ retryable: true });
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/embeddingsPerChunkTimeout.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsPerChunkTimeout.test.ts
@@ -43,4 +43,16 @@ describe('resolveEmbeddingsChunked per-chunk timeout (t/2985)', () => {
       resolveEmbeddingsChunked(texts, undefined, null, chain, 10, 50),
     ).rejects.toThrow('timed out');
   });
+
+  it('t/3074 TL-GV: stuck chunk carries .timeout=true — stamped at throw site, not via message-match', async () => {
+    // Verifies the full chain: stuck chunk → resolveChunk timeout fires → .timeout=true stamped.
+    // A wording drift in the timeout message would NOT revert to 500 because the marker
+    // is set structurally (not via message.includes) — this test would still catch any regression.
+    const chain = [{
+      name: 'stuck',
+      compute: async (_: string[]) => new Promise<number[][]>(() => { /* never resolves */ }),
+    }];
+    const err = await resolveEmbeddingsChunked(['a'], undefined, null, chain, 10, 50).catch(e => e);
+    expect((err as { timeout?: boolean }).timeout).toBe(true);
+  });
 });

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -586,16 +586,18 @@ export async function resolveEmbeddingsChunked(
 ): Promise<number[][]> {
   // t/2985: timeout is per-chunk, not aggregate — large healthy batches complete while a
   // stuck chunk still gets bounded. The outer withTimeout (aggregate) was removed.
-  // Add a typed .timeout marker so the route-level catch can branch without fragile-prose
-  // string matching (t/2952). String check is internal to this call site (the only one that
-  // calls withTimeout for embeddings) — callers use (err as any).timeout === true.
+  // t/3074 TL-GV: stamp .timeout at the rejection throw site (not via message-matching —
+  // that was fragile-prose per t/2952; a wording drift in withTimeout would silently revert
+  // timeouts to 500). Promise.race owns the rejection object so the marker is structural.
   const resolveChunk = async (t: string[], i: string[] | undefined): Promise<number[][]> => {
-    try {
-      return await withTimeout(resolveEmbeddings(t, i, local, chain), chunkTimeoutMs, 'embeddings-chunk');
-    } catch (err) {
-      if (err instanceof Error && err.message.includes('timed out after')) Object.assign(err, { timeout: true });
-      throw err;
-    }
+    const timeoutErr = Object.assign(
+      new Error(`embeddings-chunk timed out after ${chunkTimeoutMs / 1000}s`),
+      { timeout: true },
+    );
+    const timeoutRace = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(timeoutErr), chunkTimeoutMs),
+    );
+    return Promise.race([resolveEmbeddings(t, i, local, chain), timeoutRace]);
   };
   if (texts.length <= chunkSize) return resolveChunk(texts, ids);
   const out: number[][] = [];

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -586,8 +586,17 @@ export async function resolveEmbeddingsChunked(
 ): Promise<number[][]> {
   // t/2985: timeout is per-chunk, not aggregate — large healthy batches complete while a
   // stuck chunk still gets bounded. The outer withTimeout (aggregate) was removed.
-  const resolveChunk = (t: string[], i: string[] | undefined) =>
-    withTimeout(resolveEmbeddings(t, i, local, chain), chunkTimeoutMs, 'embeddings-chunk');
+  // Add a typed .timeout marker so the route-level catch can branch without fragile-prose
+  // string matching (t/2952). String check is internal to this call site (the only one that
+  // calls withTimeout for embeddings) — callers use (err as any).timeout === true.
+  const resolveChunk = async (t: string[], i: string[] | undefined): Promise<number[][]> => {
+    try {
+      return await withTimeout(resolveEmbeddings(t, i, local, chain), chunkTimeoutMs, 'embeddings-chunk');
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('timed out after')) Object.assign(err, { timeout: true });
+      throw err;
+    }
+  };
   if (texts.length <= chunkSize) return resolveChunk(texts, ids);
   const out: number[][] = [];
   for (let i = 0; i < texts.length; i += chunkSize) {

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -531,8 +531,19 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
     return { blocked: false };
   }
 
+  // Invariant: MAX_EMBED_BATCH must be ≥ the client's chunk size (currently 512 per t/3072).
+  // A server cap below the client chunk size would 413 every legitimate request.
+  const MAX_EMBED_BATCH = 512;
+
   post('/api/embeddings/compute', (req, res, body) => withEndpointTimeout(res, 50_000, 'embeddings-compute', async () => {
     const { texts, ids } = body as { texts: string[]; ids?: string[] };
+    // t/3074 Gap 1: reject oversized batches before they enter the compute path.
+    // Client (t/3072) chunks to ≤MAX_EMBED_BATCH; this is the server-side backstop.
+    if (!Array.isArray(texts) || texts.length > MAX_EMBED_BATCH) {
+      const count = Array.isArray(texts) ? texts.length : 'non-array';
+      error(res, `Batch too large (${count}) — max ${MAX_EMBED_BATCH} texts per request`, 413);
+      return;
+    }
     try {
       const gate = freeTierEmbeddingGate(req, res);
       if (gate.blocked) return;
@@ -575,7 +586,19 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
       } finally {
         endEmbeddingCompute();
       }
-    } catch (err) { getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to compute embeddings', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); error(res, String(err), 500, err); }
+    } catch (err) {
+      getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to compute embeddings', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } });
+      // t/3074 Sub-change B: per-chunk timeout is transient (server under load) → retryable 503
+      // so the client backs off instead of receiving an opaque 500. Branch on the typed
+      // .timeout marker set by resolveEmbeddingsChunked (not fragile-prose — t/2952).
+      // Deterministic errors (bad input, init failure) have no .timeout → remain 500.
+      if ((err as { timeout?: boolean }).timeout === true) {
+        res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': '5' });
+        res.end(JSON.stringify({ error: 'Embedding compute timed out — retry after backoff', retryable: true, retryAfterMs: 5000 }));
+        return;
+      }
+      error(res, String(err), 500, err);
+    }
   }));
 
   // t/1171: same free-tier exemption + rate limiting + key as /compute, so anonymous


### PR DESCRIPTION
## Summary

- **Gap 1**: Reject batches > 512 texts with 413 before compute (server-side backstop matching client chunk size per t/3072; invariant documented in code)
- **Sub-change B**: `resolveEmbeddingsChunked` adds typed `.timeout = true` marker on chunk timeout; `/api/embeddings/compute` routes on it (not fragile-prose per t/2952) to return retryable 503+Retry-After:5 instead of opaque 500
- **5 TL-approved test arms** (p/522#59): 413 cap, boundary pass at 512, shed 503, typed-timeout 503, deterministic 500

Note: Sub-change A (warn→block default) is split to t/3078 pending prod warn-accuracy evidence (t/2683 shape).

## Test plan

- [ ] `npx vitest run taxonomy-editor/src/server/__tests__/embeddingsBatchCapAnd503.test.ts` — 5/5 pass
- [ ] `npx vitest run taxonomy-editor/src/server/__tests__/embeddingsPerChunkTimeout.test.ts` — existing timeout unit tests still pass
- [ ] CI green on this head before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBHGCvj3awBhE3jYPYATPG