### PR TITLE
obs(bridge): named batch_size on embedding ai.request FR events (t/3071)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/instrumentBridge.test.ts
@@ -175,3 +175,38 @@ describe('instrumentBridge — expected-status downgrade (t/2395)', () => {
     expect(failure).toBeDefined();
   });
 });
+
+describe('instrumentBridge — embedding batch_size (t/3071)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  /** Find the request/start event for a bridge method (message `bridge.<method>`, no suffix). */
+  function startRecord(method: string): { data?: Record<string, unknown> } | undefined {
+    return mockRecord.mock.calls
+      .map((c) => c[0] as { message: string; data?: Record<string, unknown> })
+      .find((e) => e.message === `bridge.${method}`);
+  }
+
+  it('records batch_size = texts.length on the computeEmbeddings request event (the 2587 incident)', async () => {
+    const texts = Array.from({ length: 2587 }, (_v, i) => `t${i}`);
+    const api = instrumentBridge({ computeEmbeddings: () => Promise.resolve({ vectors: [] }) } as unknown as AppAPI);
+    await (api as unknown as { computeEmbeddings: (t: string[]) => Promise<unknown> }).computeEmbeddings(texts);
+
+    expect(startRecord('computeEmbeddings')?.data?.batch_size).toBe(2587);
+  });
+
+  it('records batch_size = 1 for a single-text computeQueryEmbedding', async () => {
+    const api = instrumentBridge({ computeQueryEmbedding: () => Promise.resolve({ vector: [] }) } as unknown as AppAPI);
+    await (api as unknown as { computeQueryEmbedding: (t: string) => Promise<unknown> }).computeQueryEmbedding('hello');
+
+    expect(startRecord('computeQueryEmbedding')?.data?.batch_size).toBe(1);
+  });
+
+  it('omits batch_size for a non-embedding AI method (field is embedding-scoped)', async () => {
+    const api = instrumentBridge({ generateText: () => Promise.resolve('ok') } as unknown as AppAPI);
+    await (api as unknown as { generateText: () => Promise<unknown> }).generateText();
+
+    const start = startRecord('generateText');
+    expect(start).toBeDefined();
+    expect(start?.data?.batch_size).toBeUndefined();
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
+++ b/taxonomy-editor/src/renderer/bridge/instrumentBridge.ts
@@ -48,6 +48,20 @@ function summarizeArgs(args: unknown[], method?: string): unknown[] {
   );
 }
 
+/**
+ * Named `batch_size` fragment for embedding requests (t/3071). The e8760507 incident's failing
+ * call was [Array(2587)] vs prior good 643/792 — as a first-class field (not just a truncated arg
+ * preview) the outlier jumps out in the dump. This is the *bridge-level* size, i.e. the full
+ * requested batch before web-bridge's chunker splits it into ≤EMBEDDINGS_MAX_BATCH sequential
+ * POSTs (t/3072). `computeQueryEmbedding` takes a single text, so its batch is always 1. Returns a
+ * spreadable object (`{}` when N/A) so the call site can splat it without adding a branch there.
+ */
+function embeddingBatchData(method: string, args: unknown[]): { batch_size?: number } {
+  if (method === 'computeEmbeddings') return Array.isArray(args[0]) ? { batch_size: args[0].length } : {};
+  if (method === 'computeQueryEmbedding') return typeof args[0] === 'string' ? { batch_size: 1 } : {};
+  return {};
+}
+
 /** Extract result metadata for data-loading methods to enrich completion events. */
 function extractResultMeta(method: string, args: unknown[], value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object') return undefined;
@@ -197,7 +211,7 @@ export function instrumentBridge(raw: AppAPI): AppAPI {
         component: recorder.intern('component', 'bridge') as string | number,
         level: 'debug',
         message: `bridge.${key}`,
-        data: { method: key, category, arg_count: args.length, args: summarizeArgs(args, key) },
+        data: { method: key, category, arg_count: args.length, args: summarizeArgs(args, key), ...embeddingBatchData(key, args) },
       });
 
       let result: unknown;


### PR DESCRIPTION
## Summary
Client half (Part 1) of t/3071 — observability from incident e8760507. The failing `POST /api/embeddings/compute` sent `[Array(2587)]` vs prior good 643/792, but the client FR only carried a **truncated arg preview**, so the outlier batch size wasn't a queryable field and diagnosis was slow.

`instrumentBridge` now attaches a **named `batch_size`** to the `ai.request` event for:
- **computeEmbeddings** → `texts.length`. Because instrumentBridge wraps the *outer* bridge call, this is the full requested size (e.g. 2587) **before** t/3072's chunker splits it into ≤512 sequential POSTs — exactly the signal the incident wanted.
- **computeQueryEmbedding** → always `1` (single text).

The branch lives in a helper (`embeddingBatchData`) that returns a spreadable fragment (`{}` when N/A), spread unconditionally at the call site — so the wrapped arrow's cyclomatic complexity is **unchanged** (no new eslint warning).

## Scope / decomposition
- **This PR:** client `batch_size` field only.
- **t/3079 (ServerAPI):** Part 2 (Pino requestId correlation on success+error) + Part 3 (server FR event for embedding compute start/end + row count/duration). Routed, related. (t/3068 already made the merged dump the default download, so server events now reach the dump — t/3079 makes the embedding event exist to capture.)

## Verification
- `instrumentBridge.test.ts` — **15/15** (3 new: computeEmbeddings→batch_size=2587, computeQueryEmbedding→1, non-embedding AI method omits it).
- eslint **0 errors**, and the added code introduces **no new warning** (verified the wrapped arrow's complexity warning I briefly caused with an inline `&&` is gone after moving the branch into the helper; only the 2 pre-existing `extractResultMeta`/`inferCategory` warnings remain).
- renderer-tsc: only the 3 known `lib/` worktree node_modules-layout artifacts (absent on shared main; CI `npm ci` resolves).

Chore / additive observability (no behaviour change). Closes t/3071 (Part 1).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Diagnostics (Orca) <main.operations-diagnostics@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
