### PR TITLE
feat(server/embeddings): promote load-shed default warn→block, concurrency cap 2→4 (t/3078)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsLoad.test.ts
@@ -69,14 +69,20 @@ describe('embeddingsLoad load-shed (t/2905)', () => {
     while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
   });
 
-  it('mode defaults to warn (warn-first Gate Promotion)', () => {
+  it('t/3078 Gate Promotion: mode defaults to block (kill switch: set to warn)', () => {
+    expect(embeddingLoadShedMode()).toBe('block');
+  });
+
+  it('t/3078 kill switch: EMBEDDINGS_LOAD_SHED_MODE=warn reverts default block→warn instantly', () => {
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'warn';
     expect(embeddingLoadShedMode()).toBe('warn');
   });
 
-  it('mode reads EMBEDDINGS_LOAD_SHED_MODE (block|off, case-insensitive), else warn', () => {
+  it('mode reads EMBEDDINGS_LOAD_SHED_MODE (warn|off|block, case-insensitive), else block', () => {
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'warn';     expect(embeddingLoadShedMode()).toBe('warn');
     process.env.EMBEDDINGS_LOAD_SHED_MODE = 'block';    expect(embeddingLoadShedMode()).toBe('block');
     process.env.EMBEDDINGS_LOAD_SHED_MODE = 'OFF';      expect(embeddingLoadShedMode()).toBe('off');
-    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'nonsense'; expect(embeddingLoadShedMode()).toBe('warn');
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'nonsense'; expect(embeddingLoadShedMode()).toBe('block');
   });
 
   it('BLOCK arm: at the concurrency cap → shed, mode=block, reason=concurrency', () => {
@@ -92,8 +98,20 @@ describe('embeddingsLoad load-shed (t/2905)', () => {
     expect(d.retryAfterMs).toBeGreaterThan(0);
   });
 
-  it('WARN arm: at the cap → shed=true but mode=warn (route warns + proceeds)', () => {
-    process.env.EMBEDDINGS_MAX_CONCURRENT = '2'; // mode defaults warn
+  it('t/3078 both-arms A — default (no env var): shed → mode=block (gate promoted)', () => {
+    // mode defaults to block; in-flight at cap → 503 path
+    process.env.EMBEDDINGS_MAX_CONCURRENT = '2';
+    while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
+    beginEmbeddingCompute();
+    beginEmbeddingCompute();
+    const d = evaluateEmbeddingLoadShed();
+    expect(d.shed).toBe(true);
+    expect(d.mode).toBe('block');
+  });
+
+  it('t/3078 both-arms B — kill switch (LOAD_SHED_MODE=warn): shed → mode=warn, proceeds', () => {
+    process.env.EMBEDDINGS_LOAD_SHED_MODE = 'warn';
+    process.env.EMBEDDINGS_MAX_CONCURRENT = '2';
     while (inFlightEmbeddingComputes() > 0) endEmbeddingCompute();
     beginEmbeddingCompute();
     beginEmbeddingCompute();

--- a/taxonomy-editor/src/server/embeddingsLoad.ts
+++ b/taxonomy-editor/src/server/embeddingsLoad.ts
@@ -134,12 +134,17 @@ function intFromEnv(name: string, fallback: number): number {
   return Number.isFinite(n) && n > 0 ? n : fallback;
 }
 
-/** Resolve the load-shed mode: EMBEDDINGS_LOAD_SHED_MODE = warn|block|off (default warn). */
+/**
+ * Resolve the load-shed mode: EMBEDDINGS_LOAD_SHED_MODE = warn|block|off (default block).
+ * t/3078 Gate Promotion (TL GV p/522#64): real-env evidence showed loop-delay fires at
+ * 3001–4290 ms (13–17× threshold) with zero false-positives; default promoted to block.
+ * Kill switch: set EMBEDDINGS_LOAD_SHED_MODE=warn to revert to observe-only instantly.
+ */
 export function embeddingLoadShedMode(): LoadShedMode {
   const raw = (process.env.EMBEDDINGS_LOAD_SHED_MODE ?? '').trim().toLowerCase();
-  if (raw === 'block') return 'block';
+  if (raw === 'warn') return 'warn'; // kill switch — revert to observe-only instantly
   if (raw === 'off') return 'off';
-  return 'warn'; // warn-first default (Gate Promotion)
+  return 'block'; // default: block (t/3078 Gate Promotion, TL GV p/522#64)
 }
 
 export interface LoadShedDecision {
@@ -198,20 +203,21 @@ export function decideLoadShed(input: LoadShedInput): LoadShedDecision {
 /**
  * Decide whether to shed a NEW embedding compute. Call at route entry BEFORE
  * accepting the compute (so `inFlight` is the count of OTHER computes running).
- * Reads the live signals and delegates to `decideLoadShed`. Env-tunable (warn-first):
- *   EMBEDDINGS_MAX_CONCURRENT  (default 2)   — shed when in-flight >= this.
+ * Reads the live signals and delegates to `decideLoadShed`. Env-tunable:
+ *   EMBEDDINGS_MAX_CONCURRENT  (default 4)   — shed when in-flight >= this.
+ *     Raised 2→4 (t/3078): prod evidence showed in_flight 0–1 under real load, so
+ *     cap=2 had untested FP risk for concurrent multi-user sessions.
  *   EMBEDDINGS_LOOP_SHED_MS    (default 250) — shed when recent-window MAX loop delay > this.
  *   EMBEDDINGS_RETRY_AFTER_MS  (default 2000)
- *   EMBEDDINGS_LOAD_SHED_MODE  (default warn)
- * Defaults are conservative starting points; tune from the t/2904 curve before
- * promoting to block. Reading the shed signal RESETS its recent window.
+ *   EMBEDDINGS_LOAD_SHED_MODE  (default block) — kill switch: set to 'warn' to revert.
+ * Reading the shed signal RESETS its recent window.
  */
 export function evaluateEmbeddingLoadShed(): LoadShedDecision {
   return decideLoadShed({
     mode: embeddingLoadShedMode(),
     inFlight,
     loopMaxMs: readRecentLoopDelayMaxMs(),
-    cap: intFromEnv('EMBEDDINGS_MAX_CONCURRENT', 2),
+    cap: intFromEnv('EMBEDDINGS_MAX_CONCURRENT', 4), // t/3078: raised from 2 (FP risk; evidence showed in_flight 0–1)
     loopShedMs: intFromEnv('EMBEDDINGS_LOOP_SHED_MS', 250),
     retryAfterMs: intFromEnv('EMBEDDINGS_RETRY_AFTER_MS', 2000),
   });


### PR DESCRIPTION
## Summary

- `embeddingLoadShedMode()`: default `warn` → `block`. `warn` is now the explicit **kill switch** — set `EMBEDDINGS_LOAD_SHED_MODE=warn` to revert to observe-only instantly.
- `EMBEDDINGS_MAX_CONCURRENT` default **2 → 4**: prod evidence (t/3078#2) showed `in_flight` 0–1 under real load, so cap=2 had untested FP risk for concurrent multi-user sessions. TL condition per p/522#64.
- Tests: update 3 expectations broken by default flip; add **both-arms tests** (A: no env var → `block`; B: `LOAD_SHED_MODE=warn` → `warn` kill switch confirmed).

## TL conditions met (p/522#64)

- [x] Kill switch: `EMBEDDINGS_LOAD_SHED_MODE=warn` reverts instantly
- [x] Concurrency cap raised 2→4 (FP de-risk, untested at cap=2 in prod)
- [x] Both-arms test: default=block arm + kill-switch=warn arm
- [ ] Post-flip block-rate monitoring < 1% in healthy windows (operational, post-merge)

## Test plan

- [x] `npx vitest run src/server/__tests__/embeddingsLoad.test.ts` — 23/23 pass
- [ ] CI green on `5a38cc82` before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBHGCvj3awBhE3jYPYATPG