### PR TITLE
fix(bridge): match resolve-steps to empty-body 5xx (infra outage, not auth) (t/3083)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/httpErrorSteps.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/httpErrorSteps.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect } from 'vitest';
+import { nextStepsForStatus } from '../httpErrorSteps';
+
+describe('nextStepsForStatus — empty-body 5xx (t/3083)', () => {
+  it('returns overload/restart steps for a 500 with an empty body (infra-generated)', () => {
+    const steps = nextStepsForStatus(500, '');
+    expect(steps[0]).toMatch(/overloaded or restarting/i);
+    expect(steps.join(' ')).toMatch(/production health/i);
+    // the misleading auth line must NOT appear for an infra outage
+    expect(steps.join(' ')).not.toMatch(/authentication/i);
+  });
+
+  it('treats a whitespace-only body as empty (Connection reset → blank payload)', () => {
+    expect(nextStepsForStatus(503, '   \n ')[0]).toMatch(/overloaded or restarting/i);
+  });
+
+  it('applies to any 5xx, not just 500', () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(nextStepsForStatus(status, '')[0]).toMatch(/overloaded or restarting/i);
+    }
+  });
+
+  it('does NOT trigger for a 5xx that carries a body — a JSON error body is an app error, use generic', () => {
+    const steps = nextStepsForStatus(500, '{"error":"boom"}');
+    expect(steps).toEqual(['Check the server is running', 'Verify your authentication']);
+  });
+
+  it('does NOT treat a non-5xx empty body as an overload (e.g. a bare 400)', () => {
+    expect(nextStepsForStatus(400, '')).toEqual(['Check the server is running', 'Verify your authentication']);
+  });
+});
+
+describe('nextStepsForStatus — existing branches still hold', () => {
+  it('403 → auth-oriented steps', () => {
+    expect(nextStepsForStatus(403, '')).toEqual(['Verify your authentication', 'Check your API key tier supports this backend']);
+  });
+
+  it('404 with a "not found" body → resource-gone steps, not the generic server/auth copy', () => {
+    const steps = nextStepsForStatus(404, '{"error":"Debate not found"}');
+    expect(steps[0]).toMatch(/was not found/i);
+    expect(steps.join(' ')).not.toMatch(/Check the server is running/);
+  });
+});

--- a/taxonomy-editor/src/renderer/bridge/httpErrorSteps.ts
+++ b/taxonomy-editor/src/renderer/bridge/httpErrorSteps.ts
@@ -44,5 +44,16 @@ export function nextStepsForStatus(status: number, responseText: string): string
       ];
     }
   }
+  if (status >= 500 && responseText.trim() === '') {
+    // Empty-body 5xx = middleware/infra-generated, not an application error: our Express
+    // handlers ALWAYS emit a JSON error body, so no body ⇒ the response came from the ACA
+    // EasyAuth middleware / platform (Node unresponsive → "Connection reset by peer"). The
+    // generic "Verify your authentication" actively misled during the 2026-08-27 saturation
+    // incident — auth was fine, the server was overloaded/restarting (t/3083). Match the shape.
+    return [
+      'The server appears overloaded or restarting — wait ~30s and retry',
+      'If it persists, check production health',
+    ];
+  }
   return ['Check the server is running', 'Verify your authentication'];
 }


### PR DESCRIPTION
## Summary
Post-diagnosis reflection from the 2026-08-27 debate-500 recurrence (t/3078#2, FR `merged-5d622686`). When the ACA EasyAuth middleware fabricates an **empty-body 500** (Node unresponsive → "Connection reset by peer"), `web-bridge` rendered the generic `Check the server is running / Verify your authentication` — the auth line **actively misled** (auth was fine; the server was saturated).

Our Express handlers **always** emit a JSON error body, so an **empty (or whitespace-only) 5xx body** is a reliable discriminator for a middleware/infra-generated failure. `nextStepsForStatus` now returns *"The server appears overloaded or restarting — wait ~30s and retry / If it persists, check production health"* for `status >= 500 && body.trim() === ''`. A 5xx **with** a body falls through to the generic steps.

Single leaf-function change (`httpErrorSteps.ts`) → covers all five verbs (get/post/put/del/patchDebateDelta), which all route through `nextStepsForStatus`. **Message-only — no retry-policy change** (that's t/3074/t/3078).

## Verification
- New `httpErrorSteps.test.ts` — **7/7**: empty-body 500 → overload steps (and asserts the `authentication` line is gone); whitespace-only body; all of 500/502/503/504; 5xx **with** body → generic; non-5xx empty body → generic; plus 403/404 regression guards.
- eslint **0 errors**; renderer-tsc only the 3 known `lib/` worktree node_modules-layout artifacts (absent on shared main; CI `npm ci` resolves).

Chore / self-cert (`/add-test` leaf-function pattern; message-only). Closes t/3083.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Diagnostics (Orca) <main.operations-diagnostics@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)