### PR TITLE
fix(server/embeddings): async cache hydration + ENOENT→warn (t/3085)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsCache.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsCache.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3085 — async embeddings cache hydration.
+// Verifies: async load, promise coalescing (hydrate-once), ENOENT→warn (not info),
+// and "embeddings.json loaded: N nodes" success signal.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Hoisted fns (must precede vi.mock calls — factories run at hoist time) ───
+
+const { mockReadFile, frRecords, mockRecorder } = vi.hoisted(() => {
+  const frRecords: Array<Record<string, unknown>> = [];
+  const mockRecorder = { record: vi.fn((r: Record<string, unknown>) => { frRecords.push(r); }) };
+  const mockReadFile = vi.fn<[string, string], Promise<string>>();
+  return { mockReadFile, frRecords, mockRecorder };
+});
+
+// ── Fake data ─────────────────────────────────────────────────────────────────
+
+const FAKE_EMBEDDINGS = JSON.stringify({
+  model: 'all-MiniLM-L6-v2',
+  dimension: 384,
+  node_count: 3,
+  nodes: { 'acc-bel-001': {}, 'saf-bel-001': {}, 'skp-bel-001': {} },
+});
+
+// ── FR record capture ─────────────────────────────────────────────────────────
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => mockRecorder,
+  setGlobalRecorder: vi.fn(),
+}));
+
+// ── fs mock: default ENOENT, overridable per test ─────────────────────────────
+
+vi.mock('fs', async (importActual) => {
+  const actual = await importActual<typeof import('fs')>();
+  return { ...actual, default: { ...actual, promises: { ...actual.promises, readFile: mockReadFile } } };
+});
+
+// ── config mock ───────────────────────────────────────────────────────────────
+
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return {
+    ...actual,
+    resolveDataPath: vi.fn(() => '/fake/data/taxonomy/Origin'),
+    getProjectRoot: vi.fn(() => '/fake-root'),
+    getApiKey: vi.fn(async () => 'fake-key'),
+    getApiKeys: vi.fn(async () => ['fake-key']),
+  };
+});
+
+// ── Remaining heavy mocks (prevent ONNX / Python init at import time) ─────────
+
+vi.mock('../ai/fsCache.js', () => ({ readFileWithMtime: vi.fn(() => ({ content: '{}', mtimeMs: 1 })) }));
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  warmup: vi.fn(async () => false),
+  tryWarmup: vi.fn(async () => false),
+  computeEmbedding: vi.fn(async () => []),
+  computeEmbeddings: vi.fn(async () => []),
+}));
+vi.mock('../../../../lib/embeddings/embeddingResolver.js', () => ({
+  resolveEmbeddings: vi.fn(async () => []),
+}));
+vi.mock('../../../../lib/search/tavily.js', () => ({
+  tavilySearch: vi.fn(),
+  buildSearchAugmentedPrompt: vi.fn(),
+}));
+vi.mock('../../../../lib/ai-client/index.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../../../lib/ai-client/index.js')>();
+  return { ...actual, callProvider: vi.fn(), withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()) };
+});
+
+// ── Imports after mocks ───────────────────────────────────────────────────────
+
+import { prewarmEmbeddingsCache, _resetEmbeddingsCacheForTest } from '../ai/aiBackends.js';
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('embeddingsCache async hydration (t/3085)', () => {
+  beforeEach(() => {
+    _resetEmbeddingsCacheForTest();
+    frRecords.length = 0;
+    mockRecorder.record.mockClear();
+    mockReadFile.mockReset();
+  });
+
+  it('ENOENT → resolves void without throwing', async () => {
+    const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    mockReadFile.mockRejectedValue(err);
+    await expect(prewarmEmbeddingsCache()).resolves.toBeUndefined();
+  });
+
+  it('t/3085: ENOENT is recorded at warn level (not info)', async () => {
+    const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    mockReadFile.mockRejectedValue(err);
+    await prewarmEmbeddingsCache();
+    const enoentRec = frRecords.find(r => typeof r.message === 'string' && r.message.includes('not found'));
+    expect(enoentRec).toBeDefined();
+    expect(enoentRec!.level).toBe('warn');
+  });
+
+  it('success → "embeddings.json loaded: N nodes" signal', async () => {
+    mockReadFile.mockResolvedValue(FAKE_EMBEDDINGS);
+    await prewarmEmbeddingsCache();
+    const loaded = frRecords.find(r => typeof r.message === 'string' && r.message.includes('embeddings.json loaded'));
+    expect(loaded).toBeDefined();
+    expect(loaded!.message).toContain('3 nodes');
+  });
+
+  it('t/3085 hydrate-once: concurrent calls share one in-flight readFile', async () => {
+    mockReadFile.mockResolvedValue(FAKE_EMBEDDINGS);
+    await Promise.all([prewarmEmbeddingsCache(), prewarmEmbeddingsCache(), prewarmEmbeddingsCache()]);
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('second sequential call is a cache hit (no second readFile)', async () => {
+    mockReadFile.mockResolvedValue(FAKE_EMBEDDINGS);
+    await prewarmEmbeddingsCache();
+    mockReadFile.mockClear();
+    await prewarmEmbeddingsCache();
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  it('_resetEmbeddingsCacheForTest clears the cache (next call re-reads)', async () => {
+    mockReadFile.mockResolvedValue(FAKE_EMBEDDINGS);
+    await prewarmEmbeddingsCache();
+    _resetEmbeddingsCacheForTest();
+    mockReadFile.mockClear();
+    await prewarmEmbeddingsCache();
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -532,32 +532,64 @@ export async function generateTextWithSearchByUsage(
 // ── Embeddings ──
 
 let embeddingsCache: EmbeddingsFile | null = null;
+// Hydrate-once dedup: coalesce concurrent callers onto one fs.readFile (t/3085).
+let embeddingsLoadInFlight: Promise<EmbeddingsFile | null> | null = null;
 
 function getEmbeddingsPath(): string {
   return path.join(resolveDataPath('taxonomy/Origin'), 'embeddings.json');
 }
 
-function loadEmbeddingsFile(): EmbeddingsFile | null {
-  try {
-    const p = getEmbeddingsPath();
-    if (embeddingsCache) return embeddingsCache;
-    embeddingsCache = JSON.parse(fs.readFileSync(p, 'utf-8'));
-    return embeddingsCache;
-  } catch (err) {
-    // ENOENT is expected (no precomputed cache) → fall through to fresh
-    // embedding. Anything else (corrupt JSON, permissions) silently re-embeds
-    // against the API quota, so surface it at warn.
-    const code = (err as NodeJS.ErrnoException).code;
-    getGlobalRecorder()?.record({
-      type: 'system.error', component: 'ai-backends',
-      level: code === 'ENOENT' ? 'info' : 'warn',
-      message: code === 'ENOENT'
-        ? 'No embeddings cache file — computing fresh'
-        : 'Embeddings cache unreadable — falling back to full re-embed (API quota)',
-      error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
-    });
-    return null;
-  }
+/**
+ * Load the precomputed embeddings.json once, asynchronously, with promise coalescing so
+ * concurrent callers all await the same read rather than each issuing a separate disk I/O.
+ * t/3085: replaces sync fs.readFileSync; ENOENT promoted to warn because in prod ACA
+ * (github-api mode) the file never reaches /tmp — every absence fires this path.
+ */
+async function loadEmbeddingsFileAsync(): Promise<EmbeddingsFile | null> {
+  if (embeddingsCache) return embeddingsCache;
+  if (embeddingsLoadInFlight) return embeddingsLoadInFlight;
+  embeddingsLoadInFlight = (async () => {
+    try {
+      const p = getEmbeddingsPath();
+      const raw = await fs.promises.readFile(p, 'utf-8');
+      const parsed = JSON.parse(raw) as EmbeddingsFile;
+      embeddingsCache = parsed;
+      const nodeCount = Object.keys(parsed.nodes ?? {}).length;
+      getGlobalRecorder()?.record({
+        type: 'system.info', component: 'ai-backends', level: 'info',
+        message: `embeddings.json loaded: ${nodeCount} nodes`,
+        data: { embeddings_node_count: nodeCount, embeddings_model: parsed.model },
+      });
+      return embeddingsCache;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      // t/3085: ENOENT promoted to warn — in prod ACA (github-api mode) the file never
+      // reaches /tmp, so every request hits this path. It is not a normal miss; it is the
+      // root-cause symptom that triggers ~3,600 ONNX re-embeds per debate.
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'ai-backends', level: 'warn',
+        message: code === 'ENOENT'
+          ? 'embeddings.json not found — re-embedding all taxonomy texts (quota impact in prod)'
+          : 'embeddings.json unreadable — falling back to full re-embed (API quota)',
+        error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack },
+      });
+      return null;
+    } finally {
+      embeddingsLoadInFlight = null;
+    }
+  })();
+  return embeddingsLoadInFlight;
+}
+
+/** Pre-warm the embeddings cache at server startup (t/3085). Fire-and-forget; errors are FR-recorded. */
+export async function prewarmEmbeddingsCache(): Promise<void> {
+  await loadEmbeddingsFileAsync();
+}
+
+/** Reset the embeddings cache — test isolation only. */
+export function _resetEmbeddingsCacheForTest(): void {
+  embeddingsCache = null;
+  embeddingsLoadInFlight = null;
 }
 
 const EMBEDDINGS_REQUEST_TIMEOUT_MS = 45_000;
@@ -615,7 +647,7 @@ export async function resolveEmbeddingsChunked(
 // Python encoder or the in-process ONNX fallback, both 384-dim/all-MiniLM-L6-v2, no API.
 export async function computeEmbeddings(texts: string[], ids?: string[], _explicitApiKey?: string): Promise<number[][]> {
   const startMs = Date.now();
-  const local = loadEmbeddingsFile();
+  const local = await loadEmbeddingsFileAsync();
   const chain: EmbeddingFallback[] = [];
 
   // Local Python encoder stays primary when present (TL ruling t/1641#10).
@@ -912,6 +944,7 @@ export async function updateNodeEmbeddings(nodes: { id: string; text: string; po
   data.node_count = Object.keys(data.nodes).length;
   fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf-8');
   embeddingsCache = null;
+  embeddingsLoadInFlight = null; // bust any in-flight read that would return the stale file
 }
 
 // ── NLI classification ──

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -20,6 +20,7 @@ import { createRequire } from 'module';
 import { spawn, execFile, ChildProcess } from 'child_process';
 import { getGlobalRecorder, setGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 import { warmup as warmupEmbeddings } from '../../../lib/embeddings/onnxEmbedding.js';
+import { prewarmEmbeddingsCache } from './ai/aiBackends.js';
 
 const require = createRequire(import.meta.url);
 
@@ -1347,6 +1348,11 @@ server.listen(PORT, BIND_HOST, () => {
   void warmupEmbeddings().catch((err: unknown) => {
     log.server.error({ err: String(err) }, 'ONNX embedding warmup failed at boot');
     getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'ONNX embedding warmup failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });
+  });
+  // t/3085: pre-warm the embeddings.json cache at startup so the first debate request
+  // gets the precomputed vectors. Emits an FR signal "embeddings.json loaded: N nodes".
+  void prewarmEmbeddingsCache().catch((err: unknown) => {
+    getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'warn', message: 'embeddings.json pre-warm failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });
   });
 
   // t/924: surface the free-tier key pool + effective RPM so rate-limit


### PR DESCRIPTION
## Summary

- `loadEmbeddingsFile()` (sync `fs.readFileSync`) → `loadEmbeddingsFileAsync()` (async `fs.promises.readFile`)
- Promise coalescing: concurrent callers share one in-flight read (hydrate-once dedup)
- ENOENT promoted from `info`→`warn`: in prod ACA (github-api mode) the file never reaches `/tmp` — every absence is the root-cause symptom (~3,600 re-embeds per debate), not a normal miss
- FR signal: `"embeddings.json loaded: N nodes"` on success (diagnostic requirement from TL)
- `prewarmEmbeddingsCache()`: startup pre-warm called from `server.listen` callback alongside `warmupEmbeddings()`
- `updateNodeEmbeddings` cache bust also clears `embeddingsLoadInFlight`
- 6 new tests: ENOENT→warn, success signal, hydrate-once coalescing, cache-hit, reset isolation

## TL design review
- Approved: p/522#68 (all 4 questions answered at t/3085#3)
- Simplified per TL: dropped storage-backend branch (local dev reads data-repo path directly today; prod reads same path once DevOps bakes embeddings.json into Docker image)

## Test plan
- [x] New tests 6/6 pass
- [x] Existing aiBackends tests 23/23 pass (no regressions)
- [x] tsc: no errors in changed files
- [ ] **NON-NEGOTIABLE: Verify in deployed web container** (ENOENT warn absent + ~4 misses not ~3,600 per debate) — unit-green ≠ done per TL
- [ ] DevOps precondition: `/tmp/taxonomy-cache/embeddings.json` baked into Docker image must land **before** or **together** with this PR

## Files changed
- `taxonomy-editor/src/server/ai/aiBackends.ts` — async hydration, coalescing, warn, FR signal, prewarm export
- `taxonomy-editor/src/server/server.ts` — startup prewarm call
- `taxonomy-editor/src/server/__tests__/embeddingsCache.test.ts` — 6 new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBHGCvj3awBhE3jYPYATPG