### PR TITLE
feat(diagnostics): Get-TaxEditorServerLogs — pull deep server logs from Log Analytics (t/3082)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -134,6 +134,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Test-DebatePersistence` | Pre-flight atomic write+rename probe for the debates output dir — call before AI generation to surface LOCKED/NO_PERMISSION early (t/2545) |
 | `Get-ContainerAppRevision` | Query ACA revisions by mode (Active/Stale/Fqdn) — replaces raw `az containerapp revision` calls (t/1498) |
 | `Get-ServerLog` | Retrieve + filter ACA server logs, correlate by Pino requestId — `-RequestId`/`-Recent`/`-StartTime`/`-Pattern` sets, `-Level`/`-Component`/`-Follow`/`-Raw` (t/2765) |
+| `Get-TaxEditorServerLogs` | Pull **deep** server-log history from Log Analytics (past the live-tail buffer) by `-From`/`-To`/`-RequestId`/`-Pattern`; parses Pino fields (Level/RequestId/Component/Method/Path/Status/DurationMs); `-System` for revision/restart events (t/3082) |
 | `Test-PreloadHealth` | Validate the built `preload.cjs` before launch — exists, calls `contextBridge.exposeInMainWorld`, self-contained (no relative `require('./…')`), optional `node --check` (t/2775, t/2777) |
 | `New-ContainerAppRevision` | Blue-green: deploy a new ACA revision at 0% traffic; returns real `RevisionName` for the promotion chain (t/1500 Phase 3) |
 | `Set-ContainerAppTraffic` | Shift traffic to a named revision with retry — call BEFORE `Disable-ContainerAppRevision` in rollback (t/1500 Phase 3) |

--- a/docs/diagnostics-cmdlets.md
+++ b/docs/diagnostics-cmdlets.md
@@ -16,3 +16,15 @@ PowerShell cmdlets for checking production health, shared by the Diagnostics / D
 All accept `-BaseUrl` to target staging or other instances. Default is the production URL.
 
 **Triage workflow:** when a flight recorder shows errors → `Test-TaxEditorHealth` (is it still live?) → `Test-TaxEditorEndpoints -Category <relevant>` (which endpoints are failing?) → `Test-AzureHealth` or `Test-GitHubHealth` (is it infra or platform?).
+
+## Evidence retrieval
+
+The cmdlets above probe liveness; the ones below pull the underlying evidence.
+
+| Cmdlet | Use When |
+|---|---|
+| `Get-ServerLog` | Trace a request through the **live-tail** ACA buffer by Pino requestId (shallow, seconds-to-minutes of history) |
+| `Get-TaxEditorServerLogs` | Query **Log Analytics** for history deeper than the live-tail buffer — `-From`/`-To`/`-RequestId`/`-Pattern`, parsed Pino fields, `-System` for revision/restart events. This is the cmdlet form of the hand-written `az monitor log-analytics query` KQL that debate-500 diagnoses used to require (t/3082) |
+| `Get-DebateRateLimitSummary` | Summarize 429/rate-limit buckets from a flight recorder dump (t/3065) |
+
+Both `Get-*ServerLog*` cmdlets require the az CLI logged in with reader access; `Get-TaxEditorServerLogs` resolves the Log Analytics workspace automatically (override with `$env:TAXEDITOR_LOG_WORKSPACE_ID`).

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -241,6 +241,8 @@
         'Test-DebatePersistence'
         # t/2765 — ACA server log retrieval with requestId correlation
         'Get-ServerLog'
+        # t/3082 — Log Analytics server-log query (deep history) by window/requestId/pattern
+        'Get-TaxEditorServerLogs'
     )
 
     # Aliases exported from this module

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -993,6 +993,8 @@ Export-ModuleMember -Function @(
     'Get-OpEdSource'
     # t/2765 — ACA server log retrieval with requestId correlation
     'Get-ServerLog'
+    # t/3082 — Log Analytics server-log query (deep history) by window/requestId/pattern
+    'Get-TaxEditorServerLogs'
 ) -Alias @(
     'Import-Document'
     'TaxonomyEditor'

--- a/scripts/AITriad/Private/Assert-AzCli.ps1
+++ b/scripts/AITriad/Private/Assert-AzCli.ps1
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Preflight: assert the Azure CLI is installed and logged in, else throw an actionable error.
+.DESCRIPTION
+    Two checks the az-using cmdlets need before their first real call:
+      1. `az` resolves on PATH (a bare `& az` otherwise throws a raw CommandNotFoundException,
+         not an actionable error).
+      2. `az account show` succeeds (confirms an authenticated context).
+    Routes the account probe through Invoke-Az so callers can mock a single seam in Pester.
+    This is the shared form of the login-preflight block that is otherwise copy-pasted across the
+    Azure cmdlets; new az cmdlets should call it instead of re-inlining.
+.PARAMETER CallerName
+    Location string stamped into the thrown ActionableError (usually the calling cmdlet's name).
+#>
+function Assert-AzCli {
+    [CmdletBinding()]
+    param(
+        [string]$CallerName = 'Assert-AzCli'
+    )
+
+    Set-StrictMode -Version Latest
+
+    if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+        throw (New-ActionableError `
+            -Goal     'Run an Azure CLI command' `
+            -Problem  'The Azure CLI (az) was not found on PATH.' `
+            -Location $CallerName `
+            -NextSteps @(
+                'Install the Azure CLI: https://aka.ms/azcli'
+                'Then authenticate: az login'
+            ))
+    }
+
+    # Invoke-Az throws an actionable error on non-zero exit (the not-logged-in case);
+    # a null return means az produced no account context.
+    $Account = Invoke-Az -Arguments @('account', 'show', '--output', 'json') -CallerName $CallerName
+    if (-not $Account) {
+        throw (New-ActionableError `
+            -Goal     'Run an Azure CLI command' `
+            -Problem  'Not logged into Azure (az account show returned no context).' `
+            -Location $CallerName `
+            -NextSteps @(
+                'Run: az login'
+                'Verify the active subscription: az account show'
+            ))
+    }
+}

--- a/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
+++ b/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
@@ -1,0 +1,271 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Pulls production taxonomy-editor server logs from Azure Log Analytics by time window /
+    requestId / pattern, parsing Pino JSON fields.
+.DESCRIPTION
+    Where Get-ServerLog wraps the shallow `az containerapp logs show` live-tail buffer, this
+    cmdlet queries Log Analytics directly (`az monitor log-analytics query`) for history deeper
+    than the buffer — the evidence source the t/3078 debate-500 diagnosis had to hand-write KQL for.
+
+    Queries ContainerAppConsoleLogs_CL (or ContainerAppSystemLogs_CL with -System), filters by
+    time window (default: last 15 min), requestId, and/or a substring pattern, then parses each
+    row's Log_s (the raw Pino JSON line) into structured fields: Level, RequestId, Component,
+    Method, Path, Status, DurationMs, Message. Non-JSON / boundary-sliced lines (t/2860) are still
+    surfaced as rows with Level='unparsed' so no evidence is lost, and counted.
+
+    Requires the az CLI logged in with reader access to the Log Analytics workspace. No AI calls.
+
+    Auth: the workspace customerId is resolved once (first workspace named 'log-aitriad*' in the
+    resource group) and cached for the session; override with $env:TAXEDITOR_LOG_WORKSPACE_ID.
+.PARAMETER From
+    Lower bound of the window (UTC-compared). Default: 15 minutes before -To.
+.PARAMETER To
+    Upper bound. Default: now (UTC).
+.PARAMETER RequestId
+    Correlate one request end-to-end. Console logs only (system logs are not per-request).
+.PARAMETER Pattern
+    Case-insensitive substring matched server-side against the raw log line (KQL `contains`).
+.PARAMETER App
+    Container app to query (ContainerAppName_s). Default 'taxonomy-editor'.
+.PARAMETER System
+    Query ContainerAppSystemLogs_CL (revision/replica/restart events) instead of console logs.
+    System rows are emitted raw (Type/Reason/Message), not Pino-parsed.
+.PARAMETER ResourceGroup
+    Azure resource group. Default 'ai-triad'.
+.PARAMETER Max
+    Row cap (KQL `take`). Default 1000.
+.PARAMETER Raw
+    Emit the raw Log_s string per row instead of a structured object (console mode only).
+.OUTPUTS
+    [PSCustomObject] AITriad.ServerLogEntry (console) or AITriad.ServerSystemLogEntry (-System),
+    or raw strings with -Raw.
+.EXAMPLE
+    Get-TaxEditorServerLogs -From (Get-Date).AddHours(-1) -Pattern '500'
+    # Every line containing '500' in the last hour.
+.EXAMPLE
+    Get-TaxEditorServerLogs -RequestId req-6f1c... -From (Get-Date).AddHours(-6)
+    # Trace one request across the deeper Log Analytics history.
+.EXAMPLE
+    Get-TaxEditorServerLogs -System -From (Get-Date).AddHours(-2)
+    # Revision/replica/restart events (e.g. correlate a 500 spike with a restart).
+.LINK
+    Get-ServerLog
+.LINK
+    Get-DebateRateLimitSummary
+.LINK
+    Show-AITriadHelp
+#>
+function Get-TaxEditorServerLogs {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [datetime]$From,
+
+        [Parameter()]
+        [datetime]$To,
+
+        [Parameter()]
+        [string]$RequestId,
+
+        [Parameter()]
+        [string]$Pattern,
+
+        [Parameter()]
+        [ValidateSet('taxonomy-editor', 'taxonomy-editor-staging')]
+        [string]$App = 'taxonomy-editor',
+
+        [Parameter()]
+        [switch]$System,
+
+        [Parameter()]
+        [string]$ResourceGroup = 'ai-triad',
+
+        [Parameter()]
+        [ValidateRange(1, 50000)]
+        [int]$Max = 1000,
+
+        [Parameter()]
+        [switch]$Raw
+    )
+
+    process {
+        Set-StrictMode -Version Latest
+
+        Assert-AzCli -CallerName 'Get-TaxEditorServerLogs'
+
+        # ── Window (default last 15 min) ──────────────────────────────────
+        $toUtc   = if ($PSBoundParameters.ContainsKey('To'))   { $To.ToUniversalTime() }   else { [datetime]::UtcNow }
+        $fromUtc = if ($PSBoundParameters.ContainsKey('From')) { $From.ToUniversalTime() } else { $toUtc.AddMinutes(-15) }
+        if ($fromUtc -gt $toUtc) {
+            throw (New-ActionableError `
+                -Goal     'Query server logs over a time window' `
+                -Problem  "-From ($fromUtc) is after -To ($toUtc)." `
+                -Location 'Get-TaxEditorServerLogs' `
+                -NextSteps @('Pass -From earlier than -To, or omit both for the last 15 minutes.'))
+        }
+
+        # ── Resolve + cache the Log Analytics workspace customerId ─────────
+        $workspaceId = if ($env:TAXEDITOR_LOG_WORKSPACE_ID) {
+            $env:TAXEDITOR_LOG_WORKSPACE_ID
+        } elseif ($script:TaxEditorLogWorkspaceId) {
+            $script:TaxEditorLogWorkspaceId
+        } else {
+            $wsRaw = Invoke-Az -CallerName 'Get-TaxEditorServerLogs' -Arguments @(
+                'monitor', 'log-analytics', 'workspace', 'list',
+                '--resource-group', $ResourceGroup,
+                '--query', "[?starts_with(name,'log-aitriad')].customerId | [0]",
+                '--output', 'tsv')
+            $wsId = if ($wsRaw) { ([string]$wsRaw).Trim() } else { $null }
+            if ([string]::IsNullOrWhiteSpace($wsId)) {
+                throw (New-ActionableError `
+                    -Goal     'Resolve the Log Analytics workspace for the container app' `
+                    -Problem  "No workspace named 'log-aitriad*' found in resource group '$ResourceGroup'." `
+                    -Location 'Get-TaxEditorServerLogs' `
+                    -NextSteps @(
+                        "List workspaces: az monitor log-analytics workspace list -g $ResourceGroup -o table"
+                        'Or set $env:TAXEDITOR_LOG_WORKSPACE_ID to the workspace customerId (GUID).'
+                    ))
+            }
+            $script:TaxEditorLogWorkspaceId = $wsId
+            $wsId
+        }
+
+        # ── Build the KQL (single-quote escape every interpolated value) ───
+        $esc = { param($s) if ($null -eq $s) { '' } else { ([string]$s).Replace('\', '\\').Replace("'", "\'") } }
+        $fromZ = $fromUtc.ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $toZ   = $toUtc.ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $table = if ($System) { 'ContainerAppSystemLogs_CL' } else { 'ContainerAppConsoleLogs_CL' }
+
+        $kql = [System.Collections.Generic.List[string]]::new()
+        $kql.Add($table)
+        $kql.Add("| where ContainerAppName_s == '$(& $esc $App)'")
+        $kql.Add("| where TimeGenerated between (datetime('$fromZ') .. datetime('$toZ'))")
+
+        if ($RequestId) {
+            if ($System) {
+                Write-Warning '-RequestId is ignored with -System (system logs are not per-request).'
+            } else {
+                if ($RequestId -notmatch '^[\w.:\-]+$') {
+                    throw (New-ActionableError `
+                        -Goal     'Filter server logs by requestId' `
+                        -Problem  "RequestId '$RequestId' contains characters outside the allowed set [A-Za-z0-9._:-]." `
+                        -Location 'Get-TaxEditorServerLogs' `
+                        -NextSteps @('Pass the requestId as emitted by the server (e.g. req-<uuid>).'))
+                }
+                $kql.Add("| where Log_s has '$(& $esc $RequestId)'")
+            }
+        }
+        if ($Pattern) { $kql.Add("| where Log_s contains '$(& $esc $Pattern)'") }
+
+        if ($System) { $kql.Add('| project TimeGenerated, Log_s, Type_s, Reason_s, RevisionName_s') }
+        else         { $kql.Add('| project TimeGenerated, Log_s, RevisionName_s') }
+        $kql.Add('| order by TimeGenerated asc')
+        $kql.Add("| take $Max")
+        $analyticsQuery = $kql -join "`n"
+        Write-Verbose "KQL:`n$analyticsQuery"
+
+        # ── Run the query ─────────────────────────────────────────────────
+        $json = Invoke-Az -CallerName 'Get-TaxEditorServerLogs' -Arguments @(
+            'monitor', 'log-analytics', 'query',
+            '--workspace', $workspaceId,
+            '--analytics-query', $analyticsQuery,
+            '--output', 'json')
+        $rows = if ($json) { @($json | ConvertFrom-Json) } else { @() }
+
+        # ── StrictMode-safe field read (absent property -> $null) ──────────
+        $getField = {
+            param($obj, [string]$name)
+            if ($null -eq $obj) { return $null }
+            $p = $obj.PSObject.Properties[$name]
+            if ($p) { return $p.Value } else { return $null }
+        }
+        $parseTime = {
+            param($iso)
+            if ([string]::IsNullOrWhiteSpace($iso)) { return $null }
+            try { return [datetimeoffset]::Parse([string]$iso).UtcDateTime } catch { return [string]$iso }
+        }
+
+        # ── System logs: emit raw rows, no Pino parse ──────────────────────
+        if ($System) {
+            foreach ($row in $rows) {
+                [PSCustomObject]@{
+                    PSTypeName = 'AITriad.ServerSystemLogEntry'
+                    Time       = & $parseTime (& $getField $row 'TimeGenerated')
+                    Type       = & $getField $row 'Type_s'
+                    Reason     = & $getField $row 'Reason_s'
+                    Revision   = & $getField $row 'RevisionName_s'
+                    Message    = & $getField $row 'Log_s'
+                }
+            }
+            return
+        }
+
+        # ── Console logs: parse Log_s as Pino JSON ─────────────────────────
+        $pinoLevelMap = @{ 10 = 'trace'; 20 = 'debug'; 30 = 'info'; 40 = 'warn'; 50 = 'error'; 60 = 'fatal' }
+        $unparsed = 0
+
+        foreach ($row in $rows) {
+            $logStr = & $getField $row 'Log_s'
+            $tg     = & $getField $row 'TimeGenerated'
+            $rev    = & $getField $row 'RevisionName_s'
+            if ([string]::IsNullOrWhiteSpace($logStr)) { continue }
+
+            if ($Raw) { Write-Output ([string]$logStr); continue }
+
+            $entry = $null
+            try { $entry = [string]$logStr | ConvertFrom-Json -ErrorAction Stop } catch { }
+
+            if ($null -eq $entry) {
+                # Boundary-sliced (t/2860) or non-JSON stdout — surface it, don't drop it.
+                $unparsed++
+                [PSCustomObject]@{
+                    PSTypeName = 'AITriad.ServerLogEntry'
+                    Time       = & $parseTime $tg
+                    Level      = 'unparsed'
+                    RequestId  = $null
+                    Component  = $null
+                    Method     = $null
+                    Path       = $null
+                    Status     = $null
+                    DurationMs = $null
+                    Message    = [string]$logStr
+                    Revision   = $rev
+                    Raw        = [string]$logStr
+                }
+                continue
+            }
+
+            $entryRequestId = & $getField $entry 'requestId'
+            # KQL `has` is token-coarse; confirm the exact requestId on the parsed field.
+            if ($RequestId -and $entryRequestId -ne $RequestId) { continue }
+
+            $entryLevel = & $getField $entry 'level'
+            $levelName  = if ($null -ne $entryLevel -and $pinoLevelMap.ContainsKey([int]$entryLevel)) {
+                $pinoLevelMap[[int]$entryLevel]
+            } else { "$entryLevel" }
+
+            [PSCustomObject]@{
+                PSTypeName = 'AITriad.ServerLogEntry'
+                Time       = & $parseTime $tg
+                Level      = $levelName
+                RequestId  = $entryRequestId
+                Component  = & $getField $entry 'component'
+                Method     = & $getField $entry 'method'
+                Path       = & $getField $entry 'path'
+                Status     = & $getField $entry 'status'
+                DurationMs = & $getField $entry 'duration_ms'
+                Message    = & $getField $entry 'msg'
+                Revision   = $rev
+                Raw        = $entry
+            }
+        }
+
+        if ($unparsed -gt 0) {
+            Write-Warning ("{0} log line(s) were unparseable (emitted with Level='unparsed') — likely Pino lines sliced at Azure's ~16KB Fluent Bit boundary (t/2860)." -f $unparsed)
+        }
+    }
+}

--- a/tests/Get-TaxEditorServerLogs.Tests.ps1
+++ b/tests/Get-TaxEditorServerLogs.Tests.ps1
@@ -1,0 +1,144 @@
+# Tag: diagnostics (t/3082)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Unit tests for Get-TaxEditorServerLogs (t/3082). Mocks Assert-AzCli (preflight) and Invoke-Az
+    (the az seam) so no live Azure call is made — asserts KQL construction, Pino parsing, the
+    -System path, and the guard rails.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Get-TaxEditorServerLogs' -Tag 'diagnostics' {
+
+    It 'is exported from the module' {
+        Get-Command -Module AITriad -Name 'Get-TaxEditorServerLogs' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'parses Pino console rows and surfaces unparseable lines as Level=unparsed' {
+        InModuleScope AITriad {
+            $script:TaxEditorLogWorkspaceId = $null
+            Mock Assert-AzCli { }
+            Mock Invoke-Az -ParameterFilter { $Arguments -contains 'list' } -MockWith { 'ws-guid-abc' }
+
+            $rows = @(
+                @{ TimeGenerated = '2026-08-27T10:00:01Z'; RevisionName_s = 'rev-1'
+                   Log_s = (@{ level = 30; time = 1756310401000; requestId = 'req-abc'; component = 'server'; method = 'GET'; path = '/api/health'; status = 200; duration_ms = 8; msg = 'Request completed' } | ConvertTo-Json -Compress) }
+                @{ TimeGenerated = '2026-08-27T10:00:02Z'; RevisionName_s = 'rev-1'
+                   Log_s = (@{ level = 50; time = 1756310402000; requestId = 'req-def'; component = 'server'; method = 'PUT'; path = '/api/debates'; status = 500; duration_ms = 133; msg = 'Request errored' } | ConvertTo-Json -Compress) }
+                @{ TimeGenerated = '2026-08-27T10:00:03Z'; RevisionName_s = 'rev-1'
+                   Log_s = '{"level":40,"requestId":"req-trunc","msg":"sliced' }   # boundary-sliced: invalid JSON
+            )
+            $queryJson = $rows | ConvertTo-Json -Depth 6
+            Mock Invoke-Az -ParameterFilter { $Arguments -contains 'query' } -MockWith { $queryJson }.GetNewClosure()
+
+            $r = @(Get-TaxEditorServerLogs -From ([datetime]'2026-08-27T09:00:00Z') -To ([datetime]'2026-08-27T11:00:00Z') -WarningAction SilentlyContinue)
+            $r.Count | Should -Be 3
+
+            $ok = $r | Where-Object RequestId -eq 'req-abc'
+            $ok.Level      | Should -Be 'info'
+            $ok.Status     | Should -Be 200
+            $ok.Method     | Should -Be 'GET'
+            $ok.DurationMs | Should -Be 8
+
+            $err = $r | Where-Object RequestId -eq 'req-def'
+            $err.Level  | Should -Be 'error'
+            $err.Status | Should -Be 500
+
+            $bad = $r | Where-Object Level -eq 'unparsed'
+            $bad.Message | Should -Match 'sliced'
+            $bad.Raw     | Should -Match 'sliced'
+        }
+    }
+
+    It 'builds console KQL with the app filter, requestId has-clause, and pattern contains-clause' {
+        InModuleScope AITriad {
+            $script:TaxEditorLogWorkspaceId = 'ws-guid-abc'   # pre-seed cache: skip workspace list
+            $script:capturedKql = $null
+            Mock Assert-AzCli { }
+            Mock Invoke-Az -ParameterFilter { $Arguments -contains 'query' } -MockWith {
+                $script:capturedKql = ($Arguments -join ' ')
+                '[]'
+            }
+
+            Get-TaxEditorServerLogs -RequestId 'req-abc' -Pattern 'GEMINI' -App 'taxonomy-editor' -WarningAction SilentlyContinue | Out-Null
+
+            $script:capturedKql | Should -Match 'ContainerAppConsoleLogs_CL'
+            $script:capturedKql | Should -Match "ContainerAppName_s == 'taxonomy-editor'"
+            $script:capturedKql | Should -Match "Log_s has 'req-abc'"
+            $script:capturedKql | Should -Match "Log_s contains 'GEMINI'"
+        }
+    }
+
+    It '-System queries the system table and emits raw Type/Reason rows' {
+        InModuleScope AITriad {
+            $script:TaxEditorLogWorkspaceId = 'ws-guid-abc'
+            Mock Assert-AzCli { }
+            $rows = @(@{ TimeGenerated = '2026-08-27T10:00:00Z'; Log_s = 'Replica restarted'; Type_s = 'Normal'; Reason_s = 'Killing'; RevisionName_s = 'rev-2' })
+            $queryJson = $rows | ConvertTo-Json -Depth 5
+            # .GetNewClosure() captures $queryJson for the return value; it also rebinds $script:,
+            # so assert the system table via Should -Invoke rather than a $script: capture var.
+            Mock Invoke-Az -ParameterFilter { $Arguments -contains 'query' } -MockWith { $queryJson }.GetNewClosure()
+
+            $r = @(Get-TaxEditorServerLogs -System)
+            Should -Invoke Invoke-Az -Times 1 -Exactly -ParameterFilter { ($Arguments -join ' ') -match 'ContainerAppSystemLogs_CL' }
+            $r.Count       | Should -Be 1
+            $r[0].Type     | Should -Be 'Normal'
+            $r[0].Reason   | Should -Be 'Killing'
+            $r[0].Message  | Should -Be 'Replica restarted'
+        }
+    }
+
+    It '-Raw emits the raw Log_s string rather than a structured object' {
+        InModuleScope AITriad {
+            $script:TaxEditorLogWorkspaceId = 'ws-guid-abc'
+            Mock Assert-AzCli { }
+            $rows = @(@{ TimeGenerated = '2026-08-27T10:00:01Z'; RevisionName_s = 'rev-1'
+                        Log_s = (@{ level = 30; requestId = 'req-abc'; msg = 'hi' } | ConvertTo-Json -Compress) })
+            $queryJson = $rows | ConvertTo-Json -Depth 6
+            Mock Invoke-Az -ParameterFilter { $Arguments -contains 'query' } -MockWith { $queryJson }.GetNewClosure()
+
+            $r = @(Get-TaxEditorServerLogs -Raw)
+            $r.Count | Should -Be 1
+            $r[0] | Should -BeOfType [string]
+            $r[0] | Should -Match 'req-abc'
+        }
+    }
+
+    It 'rejects a requestId with KQL-injection characters' {
+        InModuleScope AITriad {
+            $script:TaxEditorLogWorkspaceId = 'ws-guid-abc'
+            Mock Assert-AzCli { }
+            Mock Invoke-Az { '[]' }
+            { Get-TaxEditorServerLogs -RequestId "req-abc' | union *" } | Should -Throw
+        }
+    }
+
+    It 'throws when -From is after -To' {
+        InModuleScope AITriad {
+            Mock Assert-AzCli { }
+            { Get-TaxEditorServerLogs -From ([datetime]'2026-08-27T11:00:00Z') -To ([datetime]'2026-08-27T10:00:00Z') } | Should -Throw
+        }
+    }
+
+    It 'throws an actionable error when no Log Analytics workspace is found' {
+        InModuleScope AITriad {
+            $script:TaxEditorLogWorkspaceId = $null
+            $prevEnv = $env:TAXEDITOR_LOG_WORKSPACE_ID
+            $env:TAXEDITOR_LOG_WORKSPACE_ID = $null
+            try {
+                Mock Assert-AzCli { }
+                Mock Invoke-Az -ParameterFilter { $Arguments -contains 'list' } -MockWith { $null }
+                { Get-TaxEditorServerLogs } | Should -Throw
+            } finally {
+                $env:TAXEDITOR_LOG_WORKSPACE_ID = $prevEnv
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `Get-TaxEditorServerLogs`: queries **Log Analytics** (`az monitor log-analytics query`) for server-log history deeper than the `az containerapp logs show` live-tail buffer that `Get-ServerLog` wraps — the evidence source the t/3078 debate-500 diagnosis had to hand-write three KQL calls for.

## Behavior
- Filters: `-From`/`-To` (default last 15 min), `-RequestId`, `-Pattern`, `-App`, `-System`, `-Max`, `-Raw`.
- **Console mode** parses each row's `Log_s` (raw Pino JSON) → `Level | RequestId | Component | Method | Path | Status | DurationMs | Message`. Boundary-sliced lines (t/2860) are surfaced as `Level='unparsed'` rows (evidence not dropped) and counted.
- **`-System`** queries `ContainerAppSystemLogs_CL` (revision/replica/restart events), emitted raw.
- Resolves + caches the Log Analytics workspace customerId (first `log-aitriad*` in the RG); override via `$env:TAXEDITOR_LOG_WORKSPACE_ID`.

## Design
- All `az` calls route through the mockable `Invoke-Az`. New Private **`Assert-AzCli`** preflight throws an actionable error on missing az / not-logged-in (the shared form of the block copy-pasted across ~10 az cmdlets).
- **Injection-safe:** KQL string values are single-quote-escaped and `-RequestId` is charset-validated (`^[\w.:-]+$`).
- Modeled on `Get-ServerLog` (level map, StrictMode-safe field reads). **Purely additive** — no existing cmdlet modified.

## Self-cert & deviations (for @Diagnostics)
`/add-ps-cmdlet` (az is an established module dep; read-only query). Diagnostics-created ticket → no TL design gate.
- Verb `Get-` as the ticket titled it.
- **Staging caveat:** `-App taxonomy-editor-staging` filters `ContainerAppName_s=='taxonomy-editor-staging'`; if the staging ACA app name differs, that value needs confirming — the module has no staging app-name constant today (staging is a revision/URL concept elsewhere). Flagging in case you know the real name.

## Tests
8 (Pino parse + unparsed surfacing, KQL construction, `-System` table, `-Raw`, requestId injection reject, from>to guard, missing-workspace throw), all green. Manifest + parity OK.

Closes t/3082.