### PR TITLE
chore(devops): map research/ scopes in junk attribution (t/3058)

### DIFF
--- a/operations/devops/check-shared-drift.ps1
+++ b/operations/devops/check-shared-drift.ps1
@@ -60,6 +60,8 @@ $scopeRoleMap = [ordered]@{
     'operations/devops'                              = 'DevOps'
     'operations/sage'                                = 'Sage'
     'operations/diagnostics'                         = 'Diagnostics'
+    'research/comp-linguist'                         = 'Computational Linguist'
+    'research/collaborator'                          = 'Collaborator'
     'scripts'                                        = 'PowerShell'
 }
 function Get-OwningScope {


### PR DESCRIPTION
Adds `research/comp-linguist` → **Computational Linguist** and `research/collaborator` → **Collaborator** to check-shared-drift.ps1's scope→role map, so junk in the research subtree attributes by role name instead of `unmapped:research` (surfaced live in the r/11#381 drift cycle).

Verified in isolation via `Get-OwningScope`: both research paths resolve to their roles; existing longest-prefix precedence unchanged (`taxonomy-editor/src/server` → ServerAPI, `operations/sage` → Sage). 2-line map addition.