### PR TITLE
feat(taxonomy-editor): common bookmark (DocLink) control on 5 concept view headers

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate/CruxesTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/CruxesTab.tsx
@@ -13,6 +13,7 @@ import './CruxesTab.css';
 import { useKeyboardNav } from '../../hooks/useKeyboardNav';
 import { useResizablePanel } from '../../hooks/useResizablePanel';
 import { SearchWithHistory } from '../shared/SearchWithHistory';
+import { DocLink } from '../shared/TheoryLink';
 import { SearchPreview } from '../edge-browser/SearchPreview';
 import { FallacyDetailPanel } from '../analysis/FallacyPanel';
 import { PromptDetailPanel } from '../chat/PromptsPanel';
@@ -233,6 +234,7 @@ function CruxListPane({
     >
       <div className="list-panel-header">
         <h2>Cruxes</h2>
+        <DocLink docPath="research/comp-linguist/docs/theory-of-success/theory-of-success-cruxes.md" label="Theory of success: Cruxes" tooltip="Open the Cruxes theory-of-success doc in GitHub" />
         <div className="list-panel-header-actions">
           <span className="crux-count-label">{filteredCruxes.length} of {cruxes.length}</span>
           <button className="pane-collapse-btn" onClick={() => setListCollapsed(true)} title="Collapse" aria-label="Collapse panel">&lsaquo;</button>

--- a/taxonomy-editor/src/renderer/components/debate/SituationsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/debate/SituationsTab.tsx
@@ -11,6 +11,7 @@ import { useResizablePanel, useResizableRightPanel } from '../../hooks/useResiza
 import { SituationDetail } from './SituationDetail';
 import { FallacyDetailPanel } from '../analysis/FallacyPanel';
 import { PinnedPanel } from '../shared/PinnedPanel';
+import { DocLink } from '../shared/TheoryLink';
 import { ExternalEmbed } from '../shared/ExternalEmbed';
 import { SearchPreview } from '../edge-browser/SearchPreview';
 import { EdgeDetailPanel } from '../edge-browser/EdgeDetailPanel';
@@ -110,6 +111,7 @@ function SituationsListPane({
       >
         <div className="list-panel-header">
           <h2>Situations</h2>
+          <DocLink docPath="research/comp-linguist/docs/theory-of-success/theory-of-success-situations.md" label="Theory of success: Situations" tooltip="Open the Situations theory-of-success doc in GitHub" />
           <div className="list-panel-header-actions">
             <select
               className="sort-select"

--- a/taxonomy-editor/src/renderer/components/organizations/OrganizationsTab.tsx
+++ b/taxonomy-editor/src/renderer/components/organizations/OrganizationsTab.tsx
@@ -6,6 +6,7 @@ import './OrganizationsTab.css';
 import { useOrganizationStore } from '../../hooks/useOrganizationStore';
 import { useResizablePanel } from '../../hooks/useResizablePanel';
 import { OrganizationDetail, OrgLogo } from './OrganizationDetail';
+import { DocLink } from '../shared/TheoryLink';
 import type { Organization, PovStance, PovAlignmentTier } from '../../bridge/types';
 
 const POV_COLORS: Record<string, string> = {
@@ -90,6 +91,7 @@ export function OrganizationsTab() {
       >
         <div className="list-panel-header">
           <h2>Organizations</h2>
+          <DocLink docPath="research/comp-linguist/docs/theory-of-success/theory-of-success-organizations.md" label="Theory of success: Organizations" tooltip="Open the Organizations theory-of-success doc in GitHub" />
           <span className="orgs-tab-muted-075">
             {filtered.length}{filtered.length !== organizations.length ? ` / ${organizations.length}` : ''}
           </span>

--- a/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/EntityBrowserPanel.tsx
@@ -16,6 +16,7 @@ import { TypeBadge } from './DetailPrimitives';
 import { coerceStringArray } from '@lib/entities/entityResolve';
 import { DetailPane } from './DetailPane';
 import { EmptyState } from './EmptyState';
+import { DocLink } from './TheoryLink';
 import './EntityBrowserPanel.css';
 
 type SortKey = 'name' | 'type' | 'status' | 'confidence' | 'modified';
@@ -194,6 +195,7 @@ export function EntityBrowserPanel() {
       <div className="ebp-list-col">
         <div className="ebp-header">
           <h3 className="ebp-title">Entities</h3>
+          <DocLink docPath="research/comp-linguist/docs/theory-of-success/theory-of-success-entities.md" label="Theory of success: Entities" tooltip="Open the Entities theory-of-success doc in GitHub" />
         </div>
 
         <div className="ebp-controls">

--- a/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/VocabularyPanel.tsx
@@ -4,6 +4,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { getGlobalRecorder } from '@lib/flight-recorder/index';
 import { bridgeGet } from '../../bridge/web-bridge';
+import { DocLink } from './TheoryLink';
 import type { StandardizedTerm, ColloquialTerm, LintViolation, CampOrigin, CoinageStatus } from '@lib/dictionary';
 
 const POV_COLORS: Record<string, string> = {
@@ -113,6 +114,7 @@ export function VocabularyPanel() {
     <div className="vocabulary-panel">
       <div className="vocab-header">
         <h3>Vocabulary</h3>
+        <DocLink docPath="research/comp-linguist/docs/theory-of-success/theory-of-success-vocabulary.md" label="Theory of success: Vocabulary" tooltip="Open the Vocabulary theory-of-success doc in GitHub" />
         <span className="vocab-stats">
           {standardized.length} terms / {colloquial.length} colloquial
           {lintResults.length > 0 && (


### PR DESCRIPTION
Adds the shared **DocLink**/`TheoryLink` "common bookmark control" (the open-book doc-link glyph, t/2343/t/2410) to the **right of the title** on five concept views that lacked it — **Situations, Cruxes, Entities, Vocabulary, Organizations** — each pointing at that concept's theory-of-success document under `research/comp-linguist/docs/theory-of-success/` (landed via #1577).

- **Advanced-view-only**, matching the existing DocLink gate (t/2867) — consistent with the controls on POV/Situations detail headers.
- 5 files, each: import `DocLink` + one `<DocLink docPath=… />` next to the `<h2>/<h3>` title. No new components, no store/PinnedPanel changes.

**Scope note:** these are taxonomy-editor renderer files (not CL scope). The repo owner explicitly authorized the direct edit.

**Verification** (against the shared checkout's working deps — the fresh worktree had no lockfile to `npm ci`): `check-renderer-tsc.sh` clean (0 new errors); `VocabularyPanel` + `EntityBrowserPanel` tests 12/12 pass. CI runs the full gate.