### PR TITLE
obs(server/embeddings): boot probe + cache_hits/cache_misses FR counters (t/3086)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsBatchCapAnd503.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsBatchCapAnd503.test.ts
@@ -166,7 +166,7 @@ describe('POST /api/embeddings/compute — batch cap + typed-timeout 503 (t/3074
 
   beforeEach(() => {
     evaluateEmbeddingLoadShed.mockReturnValue({ shed: false });
-    computeEmbeddings.mockResolvedValue([[0.1, 0.2]]);
+    computeEmbeddings.mockResolvedValue({ vectors: [[0.1, 0.2]], cacheHits: 1, cacheMisses: 0 });
 
     const { router, handlers } = makeRouter();
     registerAiRoutes(router as never, makeCtx());
@@ -184,7 +184,7 @@ describe('POST /api/embeddings/compute — batch cap + typed-timeout 503 (t/3074
   it('arm 2 — 200 when texts.length === MAX_EMBED_BATCH (boundary pass)', async () => {
     const texts = Array.from({ length: MAX_EMBED_BATCH }, (_, i) => `text-${i}`);
     const vectors = texts.map(() => [0.1]);
-    computeEmbeddings.mockResolvedValueOnce(vectors);
+    computeEmbeddings.mockResolvedValueOnce({ vectors, cacheHits: 0, cacheMisses: vectors.length });
     const res = fakeRes();
     await computeHandler({} as IncomingMessage, res, { texts });
     expect(res._statusCode).not.toBe(413);

--- a/taxonomy-editor/src/server/__tests__/embeddingsProbe.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsProbe.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3086 — embeddings.json boot probe + cache hit/miss counters.
+// Covers: getEmbeddingsCacheStatus (absent/present), computeEmbeddings
+// returns { vectors, cacheHits, cacheMisses } with correct counts.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Hoisted fns ───────────────────────────────────────────────────────────────
+
+const { mockReadFile, mockRecorder } = vi.hoisted(() => {
+  const mockRecorder = { record: vi.fn() };
+  const mockReadFile = vi.fn<[string, string], Promise<string>>();
+  return { mockReadFile, mockRecorder };
+});
+
+// ── Fake data ─────────────────────────────────────────────────────────────────
+
+const FAKE_EMBEDDINGS = JSON.stringify({
+  model: 'all-MiniLM-L6-v2',
+  dimension: 384,
+  node_count: 3,
+  nodes: {
+    'acc-bel-001': { vector: Array(384).fill(0.1) },
+    'saf-bel-001': { vector: Array(384).fill(0.2) },
+    'skp-bel-001': { vector: Array(384).fill(0.3) },
+  },
+});
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => mockRecorder,
+  setGlobalRecorder: vi.fn(),
+}));
+
+vi.mock('fs', async (importActual) => {
+  const actual = await importActual<typeof import('fs')>();
+  return { ...actual, default: { ...actual, promises: { ...actual.promises, readFile: mockReadFile } } };
+});
+
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return {
+    ...actual,
+    resolveDataPath: vi.fn(() => '/fake/data/taxonomy/Origin'),
+    getProjectRoot: vi.fn(() => '/fake-root'),
+    getApiKey: vi.fn(async () => 'fake-key'),
+    getApiKeys: vi.fn(async () => ['fake-key']),
+  };
+});
+
+vi.mock('../ai/fsCache.js', () => ({ readFileWithMtime: vi.fn(() => ({ content: '{}', mtimeMs: 1 })) }));
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  warmup: vi.fn(async () => false),
+  tryWarmup: vi.fn(async () => false),
+  computeEmbedding: vi.fn(async () => []),
+  computeEmbeddings: vi.fn(async () => []),
+}));
+vi.mock('../../../../lib/embeddings/embeddingResolver.js', () => ({
+  resolveEmbeddings: vi.fn(async (texts: string[]) => texts.map(() => Array(384).fill(0))),
+}));
+vi.mock('../../../../lib/search/tavily.js', () => ({
+  tavilySearch: vi.fn(),
+  buildSearchAugmentedPrompt: vi.fn(),
+}));
+vi.mock('../../../../lib/ai-client/index.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../../../lib/ai-client/index.js')>();
+  return { ...actual, callProvider: vi.fn(), withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()) };
+});
+
+// ── Imports after mocks ───────────────────────────────────────────────────────
+
+import {
+  prewarmEmbeddingsCache,
+  _resetEmbeddingsCacheForTest,
+  _setPythonAvailableForTest,
+  getEmbeddingsCacheStatus,
+  computeEmbeddings,
+} from '../ai/aiBackends.js';
+
+// ── getEmbeddingsCacheStatus ──────────────────────────────────────────────────
+
+describe('getEmbeddingsCacheStatus (t/3086)', () => {
+  beforeEach(() => {
+    _resetEmbeddingsCacheForTest();
+    _setPythonAvailableForTest(false);
+    mockRecorder.record.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it('returns absent before any prewarm', () => {
+    expect(getEmbeddingsCacheStatus()).toEqual({ present: false, nodeCount: null });
+  });
+
+  it('returns absent when file is missing (ENOENT)', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await prewarmEmbeddingsCache();
+    expect(getEmbeddingsCacheStatus()).toEqual({ present: false, nodeCount: null });
+  });
+
+  it('returns present with nodeCount after successful load', async () => {
+    mockReadFile.mockResolvedValue(FAKE_EMBEDDINGS);
+    await prewarmEmbeddingsCache();
+    expect(getEmbeddingsCacheStatus()).toEqual({ present: true, nodeCount: 3 });
+  });
+});
+
+// ── computeEmbeddings hit/miss counters ───────────────────────────────────────
+
+describe('computeEmbeddings cache_hits / cache_misses (t/3086)', () => {
+  beforeEach(() => {
+    _resetEmbeddingsCacheForTest();
+    _setPythonAvailableForTest(false);
+    mockRecorder.record.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it('all misses when file absent (cacheHits=0)', async () => {
+    mockReadFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
+    await prewarmEmbeddingsCache();
+    const result = await computeEmbeddings(['text1', 'text2'], ['acc-bel-001', 'saf-bel-001']);
+    expect(result.cacheHits).toBe(0);
+    expect(result.cacheMisses).toBe(2);
+    expect(result.vectors).toHaveLength(2);
+  });
+
+  it('all hits when every id is in the file', async () => {
+    mockReadFile.mockResolvedValue(FAKE_EMBEDDINGS);
+    await prewarmEmbeddingsCache();
+    const result = await computeEmbeddings(
+      ['text1', 'text2'],
+      ['acc-bel-001', 'saf-bel-001'],
+    );
+    expect(result.cacheHits).toBe(2);
+    expect(result.cacheMisses).toBe(0);
+    expect(result.vectors).toHaveLength(2);
+  });
+
+  it('partial hit/miss when only some ids match', async () => {
+    mockReadFile.mockResolvedValue(FAKE_EMBEDDINGS);
+    await prewarmEmbeddingsCache();
+    const result = await computeEmbeddings(
+      ['text1', 'text2', 'text3'],
+      ['acc-bel-001', 'unknown-id', 'saf-bel-001'],
+    );
+    expect(result.cacheHits).toBe(2);
+    expect(result.cacheMisses).toBe(1);
+  });
+
+  it('all misses when no ids provided (text-only batch)', async () => {
+    mockReadFile.mockResolvedValue(FAKE_EMBEDDINGS);
+    await prewarmEmbeddingsCache();
+    const result = await computeEmbeddings(['text1', 'text2']);
+    expect(result.cacheHits).toBe(0);
+    expect(result.cacheMisses).toBe(2);
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -586,10 +586,21 @@ export async function prewarmEmbeddingsCache(): Promise<void> {
   await loadEmbeddingsFileAsync();
 }
 
+/** t/3086: probe result after prewarmEmbeddingsCache() resolves. */
+export function getEmbeddingsCacheStatus(): { present: boolean; nodeCount: number | null } {
+  if (!embeddingsCache) return { present: false, nodeCount: null };
+  return { present: true, nodeCount: Object.keys(embeddingsCache.nodes ?? {}).length };
+}
+
 /** Reset the embeddings cache — test isolation only. */
 export function _resetEmbeddingsCacheForTest(): void {
   embeddingsCache = null;
   embeddingsLoadInFlight = null;
+}
+
+/** Pre-set Python availability without spawning the probe — test isolation only. */
+export function _setPythonAvailableForTest(v: boolean): void {
+  _pythonAvailable = v;
 }
 
 const EMBEDDINGS_REQUEST_TIMEOUT_MS = 45_000;
@@ -645,9 +656,16 @@ export async function resolveEmbeddingsChunked(
 // t/1641/t/1643: `_explicitApiKey` is retained for call-site arity (server.ts passes
 // the free-tier key) but is no longer consumed — embeddings are computed by the local
 // Python encoder or the in-process ONNX fallback, both 384-dim/all-MiniLM-L6-v2, no API.
-export async function computeEmbeddings(texts: string[], ids?: string[], _explicitApiKey?: string): Promise<number[][]> {
+export async function computeEmbeddings(
+  texts: string[], ids?: string[], _explicitApiKey?: string,
+): Promise<{ vectors: number[][]; cacheHits: number; cacheMisses: number }> {
   const startMs = Date.now();
   const local = await loadEmbeddingsFileAsync();
+  // t/3086: pre-pass hit count (cheap dict lookup, same data resolveEmbeddings uses).
+  const cacheHits = (ids && local)
+    ? ids.filter(id => id != null && local.nodes[id] != null).length
+    : 0;
+  const cacheMisses = texts.length - cacheHits;
   const chain: EmbeddingFallback[] = [];
 
   // Local Python encoder stays primary when present (TL ruling t/1641#10).
@@ -680,9 +698,9 @@ export async function computeEmbeddings(texts: string[], ids?: string[], _explic
     getGlobalRecorder()?.record({
       type: 'ai.response', component: 'ai-backends', level: 'info',
       message: `computeEmbeddings completed: ${texts.length} inputs in ${elapsedMs}ms`,
-      data: { inputCount: texts.length, dimensions: result[0]?.length ?? 0, elapsedMs, chainMembers: chain.map(c => c.name) },
+      data: { inputCount: texts.length, dimensions: result[0]?.length ?? 0, elapsedMs, chainMembers: chain.map(c => c.name), cacheHits, cacheMisses },
     });
-    return result;
+    return { vectors: result, cacheHits, cacheMisses };
   } catch (err) {
     const elapsedMs = Date.now() - startMs;
     getGlobalRecorder()?.record({

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -534,6 +534,9 @@ export async function generateTextWithSearchByUsage(
 let embeddingsCache: EmbeddingsFile | null = null;
 // Hydrate-once dedup: coalesce concurrent callers onto one fs.readFile (t/3085).
 let embeddingsLoadInFlight: Promise<EmbeddingsFile | null> | null = null;
+// t/3086: Python availability probe result. Declared here so _setPythonAvailableForTest (below)
+// satisfies no-use-before-define. Populated lazily by isPythonEmbeddingAvailable().
+let _pythonAvailable: boolean | null = null;
 
 function getEmbeddingsPath(): string {
   return path.join(resolveDataPath('taxonomy/Origin'), 'embeddings.json');
@@ -762,8 +765,6 @@ function computeBatchViaLocalPython(texts: string[], ids: string[]): Promise<num
 }
 
 // ── Python embedding availability probe ──
-
-let _pythonAvailable: boolean | null = null;
 
 function isPythonEmbeddingAvailable(): Promise<boolean> {
   if (_pythonAvailable !== null) return Promise.resolve(_pythonAvailable);

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -577,14 +577,13 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
       beginEmbeddingCompute();
       try {
         // t/3061: local ONNX — no Gemini call, no key needed.
-        const vectors = await ai.computeEmbeddings(texts, ids, undefined);
+        const { vectors, cacheHits, cacheMisses } = await ai.computeEmbeddings(texts, ids, undefined);
         markEmbeddingModelWarm();
-        // t/3079: item_count added so a merged FR dump captures row count alongside
-        // duration — completes the server-side counterpart to t/3071's client batch_size.
+        // t/3079: item_count; t/3086: cache_hits/cache_misses (sustained 0% hit = t/3085 condition).
         getGlobalRecorder()?.record({
           type: 'system.info', component: 'embeddings-compute', level: 'info',
           message: 'embedding.compute',
-          data: { duration_ms: Date.now() - t0, item_count: texts.length, model_cold_start: !modelWarm, in_flight_at_entry: inFlightAtEntry },
+          data: { duration_ms: Date.now() - t0, item_count: texts.length, model_cold_start: !modelWarm, in_flight_at_entry: inFlightAtEntry, cache_hits: cacheHits, cache_misses: cacheMisses },
         });
         json(res, { vectors });
       } finally {

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -19,6 +19,7 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { getProjectRoot, getDataRoot, hasApiKey, STORAGE_MODE } from '../config.js';
 import { getConfig } from '../runtimeConfig.js';
 import * as proxyTiers from '../ai/proxyTiers.js';
+import { getEmbeddingsCacheStatus } from '../ai/aiBackends.js';
 import * as community from '../community/community.js';
 import * as fileIO from '../storage/fileIO.js';
 import { log } from '../logger.js';
@@ -113,6 +114,10 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
       freeTierKeyPoolSize: freeKeyPoolSize,
       freeTierLimits: freeKeyPoolSize > 0 ? { requestsPerMinute: proxyTiers.scaledFreeTierRpm(freeKeyPoolSize), tokensPerDay: getConfig().tiers.free.tokensPerDay } : null,
     };
+
+    // t/3086: embeddings cache probe result — surfaces t/3085 condition in /health without FR access.
+    const embeddingsStatus = getEmbeddingsCacheStatus();
+    base.embeddings = { cachePresent: embeddingsStatus.present, nodeCount: embeddingsStatus.nodeCount };
 
     const githubBackend = ctx.getGithubBackend();
     if (githubBackend) {

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -20,7 +20,7 @@ import { createRequire } from 'module';
 import { spawn, execFile, ChildProcess } from 'child_process';
 import { getGlobalRecorder, setGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 import { warmup as warmupEmbeddings } from '../../../lib/embeddings/onnxEmbedding.js';
-import { prewarmEmbeddingsCache } from './ai/aiBackends.js';
+import { prewarmEmbeddingsCache, getEmbeddingsCacheStatus } from './ai/aiBackends.js';
 
 const require = createRequire(import.meta.url);
 
@@ -1351,7 +1351,20 @@ server.listen(PORT, BIND_HOST, () => {
   });
   // t/3085: pre-warm the embeddings.json cache at startup so the first debate request
   // gets the precomputed vectors. Emits an FR signal "embeddings.json loaded: N nodes".
-  void prewarmEmbeddingsCache().catch((err: unknown) => {
+  // t/3086: after prewarm resolves, emit a Pino startup probe (both arms) so the cache
+  // state is visible in server logs and in /health without reading the FR dump.
+  void prewarmEmbeddingsCache().then(() => {
+    const { present, nodeCount } = getEmbeddingsCacheStatus();
+    if (present) {
+      log.server.info({ embeddings_node_count: nodeCount }, 'startup probe: embeddings.json cache ready');
+    } else {
+      log.server.warn({}, 'startup probe: embeddings.json ABSENT — debates will re-embed ~3600 texts per session (check t/3085 DevOps half)');
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'server', level: 'warn',
+        message: 'startup probe: embeddings.json cache absent',
+      });
+    }
+  }).catch((err: unknown) => {
     getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'warn', message: 'embeddings.json pre-warm failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });
   });
 


### PR DESCRIPTION
## Summary

- `getEmbeddingsCacheStatus()` — post-prewarm probe; exposed on `/health` (admin) so the embeddings.json absence (t/3085 condition) is visible without FR access
- `computeEmbeddings` return shape extended to `{ vectors, cacheHits, cacheMisses }` — pre-pass dict lookup against the loaded file, zero overhead when file absent
- `ai.ts` FR exit event (`embeddings.compute`) gains `cache_hits` + `cache_misses` fields (alongside the t/3079 `item_count`)
- `server.ts` startup: `.then()` on prewarm logs + FR-records when embeddings absent (warn-level, surfaces to ops dashboards)
- `_setPythonAvailableForTest()` — test hook bypassing the 10s Python probe that caused vitest timeouts
- `embeddingsProbe.test.ts` — 7 new tests: probe absent/missing/present + all-miss/all-hit/partial/no-ids hit-miss

## Test plan

- [x] `embeddingsProbe.test.ts` 7/7 pass
- [x] `embeddingsBatchCapAnd503.test.ts` 5/5 pass (updated mock shape)
- [x] `embeddingsCache.test.ts` pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)