### PR TITLE
feat(smoke): timed embedding-latency probe + non-gating Performance category (t/3088)

### DIFF
--- a/scripts/AITriad/Private/Measure-EmbeddingLatency.ps1
+++ b/scripts/AITriad/Private/Measure-EmbeddingLatency.ps1
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+function Measure-EmbeddingLatency {
+    <#
+    .SYNOPSIS
+        Timed probe of the embeddings compute path — catches a "correct but 100x slow"
+        perf regression that error-rate gates can't see (t/3088).
+    .DESCRIPTION
+        POSTs a small fixed batch of KNOWN taxonomy node ids (present in embeddings.json)
+        to /api/embeddings/compute and measures the request wall-time. Those ids resolve
+        against the precomputed embeddings.json cache (t/3085): a healthy cache returns in
+        milliseconds; a regressed cache (embeddings.json unreachable in prod, as in the
+        3.5-month t/3085 incident) falls through to in-process ONNX at 25-48s per chunk.
+        Nothing *fails* in that state — every request still returns 200 — so only a
+        wall-time ceiling catches it.
+
+        Returns a status object; does NOT gate anything itself (the caller decides). A
+        breach of -CeilingSec, or a completed non-200 (503 load-shed / 500 / typed
+        timeout), is reported as `degraded`. A connection-level failure (the server never
+        answered) raises New-ActionableError — that is "server unreachable", a different
+        condition from "answered slowly".
+    .PARAMETER BaseUrl
+        Base URL of the deployed Taxonomy Editor.
+    .PARAMETER NodeId
+        Known node ids to probe (must exist in embeddings.json so they cache-hit). Default
+        is a small cross-POV batch of stable ids (skp/sit/acc/saf) — the classes t/3085
+        confirmed are ~fully covered by the precomputed cache.
+    .PARAMETER CeilingSec
+        Wall-time ceiling. Over this the result is `degraded`. Default 2s (the cache-hit
+        path is well under 1s post-t/3085; tune from real post-fix timings).
+    .PARAMETER TimeoutSec
+        Per-request HTTP timeout. Default 15.
+    .PARAMETER Session
+        Optional anonymous WebRequestSession (the endpoint is anon-allowed but AUTH_OPTIONAL
+        serves a Sign-In interstitial to a cookie-less request — pass a session to avoid it).
+    .OUTPUTS
+        [PSCustomObject] { DurationMs; Status ('ok'|'degraded'); Count; HttpStatus; CeilingSec; NodeIds; Error }
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$BaseUrl,
+
+        [Parameter()]
+        [string[]]$NodeId = @('skp-beliefs-001', 'sit-001', 'acc-desires-001', 'saf-desires-001'),
+
+        [Parameter()]
+        [ValidateRange(0.1, 60)]
+        [double]$CeilingSec = 2,
+
+        [Parameter()]
+        [ValidateRange(1, 120)]
+        [int]$TimeoutSec = 15,
+
+        [Parameter()]
+        [Microsoft.PowerShell.Commands.WebRequestSession]$Session
+    )
+
+    Set-StrictMode -Version Latest
+
+    $ids = @($NodeId)
+    if ($ids.Count -eq 0) {
+        New-ActionableError `
+            -Goal 'Measure embedding latency' `
+            -Problem 'no node ids supplied for the probe batch' `
+            -Location 'Measure-EmbeddingLatency' `
+            -NextSteps 'Pass -NodeId with >=1 known taxonomy node id present in embeddings.json.' `
+            -Throw
+    }
+
+    # A cache-hit id never re-embeds its text, so placeholder text is fine; the server
+    # requires `texts` to be an array (413 otherwise), so force arrays past ConvertTo-Json's
+    # single-element unwrap.
+    $texts = @($ids | ForEach-Object { "smoke-probe:$_" })
+    $bodyJson = '{"texts":' + (ConvertTo-Json @($texts) -Compress -AsArray) +
+                ',"ids":' + (ConvertTo-Json @($ids) -Compress -AsArray) + '}'
+
+    $params = @{
+        BaseUrl               = $BaseUrl
+        Path                  = '/api/embeddings/compute'
+        Method                = 'POST'
+        Body                  = $bodyJson
+        TimeoutSec            = $TimeoutSec
+        AcceptableStatusCodes = @(200)
+    }
+    if ($Session) { $params.Session = $Session }
+
+    $check = Invoke-RemoteCheck @params
+    $ms = [int]$check.ResponseMs
+
+    # StatusCode 0 = the request never reached a responding server (DNS/connection/timeout
+    # before any HTTP status). That is "unreachable" — actionable, distinct from "slow".
+    if ($check.StatusCode -eq 0) {
+        New-ActionableError `
+            -Goal 'Measure embedding latency' `
+            -Problem "embeddings endpoint unreachable at $BaseUrl/api/embeddings/compute after ${ms}ms: $($check.Error)" `
+            -Location 'Measure-EmbeddingLatency' `
+            -NextSteps 'Confirm the server is up (Test-TaxEditorHealth -BaseUrl <url>) and the BaseUrl is correct.' `
+            -Throw
+    }
+
+    $count = 0
+    if ($check.Success -and $check.Body -and
+        $check.Body.PSObject.Properties['vectors'] -and $null -ne $check.Body.vectors) {
+        $count = @($check.Body.vectors).Count
+    }
+
+    # degraded = answered but over the ceiling, OR answered non-200 (a completed 503/500/
+    # typed-timeout is a real degradation signal, not unreachable). ok = 200 within ceiling.
+    $status = if (-not $check.Success) { 'degraded' }
+    elseif ($ms -gt ($CeilingSec * 1000)) { 'degraded' }
+    else { 'ok' }
+
+    [PSCustomObject]@{
+        DurationMs = $ms
+        Status     = $status
+        Count      = $count
+        HttpStatus = $check.StatusCode
+        CeilingSec = $CeilingSec
+        NodeIds    = $ids
+        Error      = $check.Error
+    }
+}

--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -88,7 +88,14 @@ function Invoke-TaxEditorSmokeTest {
         [switch]$Detailed,
 
         [Parameter()]
-        [switch]$AssertDataPresence
+        [switch]$AssertDataPresence,
+
+        # t/3088 — wall-time ceiling (seconds) for the embedding-latency perf probe.
+        # The cache-hit path is well under 1s post-t/3085; a regressed cache re-embeds
+        # in-process at 25-48s/chunk. Over this ceiling the probe reports `degraded`.
+        [Parameter()]
+        [ValidateRange(0.1, 60)]
+        [double]$EmbeddingCeilingSec = 2
     )
 
     Set-StrictMode -Version Latest
@@ -465,6 +472,35 @@ function Invoke-TaxEditorSmokeTest {
         $OpedFilesResult.Error = $OpedFilesDetail
     }
 
+    # ── Phase 8: Embedding latency (t/3088) — perf-regression probe, its OWN category ──
+    # embeddings.json was unreachable in prod for 3.5 months (t/3085): every debate
+    # re-embedded ~3,600 static texts in-process at 25-48s/chunk where a cache hit is
+    # milliseconds — invisible to error-rate gates because nothing FAILED. This probe
+    # POSTs a small batch of known cached node ids and times the round-trip. Like the
+    # GitHub check (t/2673), a breach is a monitoring signal surfaced as a ::warning::,
+    # NOT a hard failure: it is EXCLUDED from $OverallPass (below) so a slow embed can't
+    # false-red Health/Endpoints/Azure. Warn-first — promote to gating only after the
+    # ceiling is calibrated against real post-t/3085 prod timings.
+    Write-Host '=== Embedding Latency ===' -ForegroundColor Cyan
+    $EmbeddingStatus = 'ok'
+    $EmbeddingMs     = 0
+    try {
+        $Perf = Measure-EmbeddingLatency -BaseUrl $BaseUrl -CeilingSec $EmbeddingCeilingSec -TimeoutSec $TimeoutSec
+        $EmbeddingStatus = $Perf.Status
+        $EmbeddingMs     = $Perf.DurationMs
+        $PerfIcon  = if ($Perf.Status -eq 'ok') { '[PASS]' } else { '[DEGRADED]' }
+        $PerfColor = if ($Perf.Status -eq 'ok') { 'Green' } else { 'Yellow' }
+        Write-Host "  $PerfIcon embeddings.compute — $($Perf.DurationMs)ms (ceiling $($EmbeddingCeilingSec)s, $($Perf.Count) vectors, http $($Perf.HttpStatus))" -ForegroundColor $PerfColor
+    } catch {
+        # New-ActionableError from an unreachable server — report degraded, do NOT crash the smoke.
+        $EmbeddingStatus = 'unreachable'
+        Write-Host "  [DEGRADED] embeddings.compute — unreachable: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+    if ($EmbeddingStatus -ne 'ok') {
+        Write-Host "::warning::Embedding latency $EmbeddingStatus — ${EmbeddingMs}ms vs ${EmbeddingCeilingSec}s ceiling (perf-regression probe t/3088; monitoring signal, does not block the gate). A sustained breach is the t/3085 cache-miss class."
+    }
+    Write-Host ''
+
     # ── Summary ──────────────────────────────────────────────────────────
     $AllResults = @($Endpoints) + @($AnonEndpoints) + @($Analytics) + @($DataPresence) + @($OpedFilesResult)
     $Passed = @($AllResults | Where-Object { $_.Pass }).Count
@@ -523,6 +559,9 @@ function Invoke-TaxEditorSmokeTest {
         AzureOk         = $Azure.Healthy
         GitHubOk        = $GitHub.Healthy
         OpedFilesOk     = $OpedFilesPass
+        EmbeddingStatus     = $EmbeddingStatus
+        EmbeddingLatencyMs  = $EmbeddingMs
+        EmbeddingCeilingSec = $EmbeddingCeilingSec
         EndpointsPassed = $Passed
         EndpointsFailed = $Failed
         EndpointsTotal  = $Total

--- a/tests/Invoke-TaxEditorSmokeTest.EmbeddingLatency.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.EmbeddingLatency.Tests.ps1
@@ -1,0 +1,192 @@
+# Tag: health (t/3088)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    t/3088 — timed embedding-latency probe (Measure-EmbeddingLatency) + its non-gating
+    Performance category in Invoke-TaxEditorSmokeTest.
+.DESCRIPTION
+    Prevention for the t/3085 class: embeddings.json was unreachable in prod for 3.5
+    months, so every debate re-embedded ~3,600 static texts in-process (25-48s) where a
+    cache hit is milliseconds. Nothing FAILED — error-rate gates were blind — so only a
+    wall-time ceiling catches it.
+
+    All tests mock the private Invoke-RemoteCheck HTTP seam (no spend, no network) — the
+    proven-on-CI recipe (mock the innermost primitive, not the public phase fn; t/2673).
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Measure-EmbeddingLatency — timed probe arms (t/3088)' -Tag 'health' {
+
+    It 'OK: a fast 200 under the ceiling → Status ok, vector count, http 200' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 120
+                    Body = [PSCustomObject]@{ vectors = @(1, 2, 3, 4) }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+            }
+            $r = Measure-EmbeddingLatency -BaseUrl 'https://stub' -CeilingSec 2
+            $r.Status     | Should -Be 'ok'
+            $r.DurationMs | Should -Be 120
+            $r.Count      | Should -Be 4
+            $r.HttpStatus | Should -Be 200
+        }
+    }
+
+    It 'DEGRADED (slow): a 200 OVER the ceiling → Status degraded (the correct-but-100x-slow catch)' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 5000
+                    Body = [PSCustomObject]@{ vectors = @(1, 2, 3, 4) }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+            }
+            $r = Measure-EmbeddingLatency -BaseUrl 'https://stub' -CeilingSec 2
+            $r.Status     | Should -Be 'degraded'
+            $r.DurationMs | Should -Be 5000
+        }
+    }
+
+    It 'CEILING param is load-bearing: same 1500ms is ok at 2s but degraded at 1s' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 1500
+                    Body = [PSCustomObject]@{ vectors = @(1) }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+            }
+            (Measure-EmbeddingLatency -BaseUrl 'https://stub' -CeilingSec 2).Status | Should -Be 'ok'
+            (Measure-EmbeddingLatency -BaseUrl 'https://stub' -CeilingSec 1).Status | Should -Be 'degraded'
+        }
+    }
+
+    It 'DEGRADED (non-200): a completed 503 load-shed → Status degraded, http 503 (answered, not unreachable)' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                [PSCustomObject]@{ Success = $false; StatusCode = 503; ResponseMs = 200
+                    Body = $null; ContentType = 'application/json'; RawBody = ''; Error = 'HTTP 503' }
+            }
+            $r = Measure-EmbeddingLatency -BaseUrl 'https://stub' -CeilingSec 2
+            $r.Status     | Should -Be 'degraded'
+            $r.HttpStatus | Should -Be 503
+            $r.Count      | Should -Be 0
+        }
+    }
+
+    It 'UNREACHABLE (StatusCode 0): server never answered → New-ActionableError (distinct from slow)' {
+        InModuleScope AITriad {
+            Mock Invoke-RemoteCheck -MockWith {
+                [PSCustomObject]@{ Success = $false; StatusCode = 0; ResponseMs = 15000
+                    Body = $null; ContentType = ''; RawBody = ''; Error = 'No connection could be made' }
+            }
+            { Measure-EmbeddingLatency -BaseUrl 'https://stub' -CeilingSec 2 } |
+                Should -Throw -ExpectedMessage '*unreachable*'
+        }
+    }
+
+    It 'empty -NodeId → actionable error (no silent zero-length probe)' {
+        InModuleScope AITriad {
+            { Measure-EmbeddingLatency -BaseUrl 'https://stub' -NodeId @() } |
+                Should -Throw -ExpectedMessage '*node id*'
+        }
+    }
+
+    It 'sends texts AND ids as JSON ARRAYS even for a single id (server requires an array — 413 otherwise)' {
+        InModuleScope AITriad {
+            $script:CapturedBody = $null
+            Mock Invoke-RemoteCheck -MockWith {
+                $script:CapturedBody = $Body
+                [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 50
+                    Body = [PSCustomObject]@{ vectors = @(1) }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+            }
+            $null = Measure-EmbeddingLatency -BaseUrl 'https://stub' -NodeId @('skp-beliefs-001')
+            $script:CapturedBody | Should -Match '"texts":\['
+            $script:CapturedBody | Should -Match '"ids":\['
+            $script:CapturedBody | Should -Match 'skp-beliefs-001'
+        }
+    }
+}
+
+Describe 'Invoke-TaxEditorSmokeTest — embedding probe is its OWN category, NON-gating (t/3088)' -Tag 'health' {
+
+    # Full offline pipeline: mock every private primitive healthy; the embeddings-compute
+    # path returns slow so the probe is `degraded`. Asserts a slow embed does NOT sink
+    # OverallPass (mirrors the GitHub-check exclusion, t/2673) — perf ceiling is its own
+    # signal, not a hard failure of unrelated checks.
+    BeforeEach {
+        InModuleScope AITriad {
+            Mock Invoke-HealthProbe -MockWith {
+                $r = [TaxEditorHealthResult]::new()
+                $r.BaseUrl = 'https://stub'; $r.Healthy = $true
+                $r.Checks = @(); $r.AverageMs = 0; $r.FreeTierKeyPoolSize = 0
+                $r.Timestamp = (Get-Date).ToString('o'); $r
+            }
+            Mock Start-Sleep -MockWith { }
+            Mock New-AnonymousWebSession -MockWith { [Microsoft.PowerShell.Commands.WebRequestSession]::new() }
+            Mock Test-AzureHealth  -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
+            Mock Test-GitHubHealth -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
+
+            $script:AnQ = 0
+            Mock Invoke-RemoteCheck -MockWith {
+                switch -Wildcard ($Path) {
+                    '*/api/embeddings/compute' {
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = $script:EmbMs
+                            Body = [PSCustomObject]@{ vectors = @(1, 2, 3, 4) }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    '*/api/analytics/query' {
+                        $script:AnQ++
+                        $total = if ($script:AnQ -eq 1) { 5 } else { 6 }
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 10
+                            Body = [PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total }; eventTypes = [PSCustomObject]@{ 'view.dwell' = 1 } }
+                            ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    '*/api/analytics/event' {
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 10
+                            Body = [PSCustomObject]@{ ok = $true; count = 1 }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    '*/api/health/oped-files' {
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 10
+                            Body = [PSCustomObject]@{ ok = $true; assets = @('soul', 'oped') }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    default {
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 42
+                            Body = [PSCustomObject]@{ nodes = @(); id = 'stub-item' }; ContentType = 'application/json'
+                            RawBody = '<!doctype html><html><body><div id="root"></div><script src="/assets/app.js"></script></body></html>'; Error = $null }
+                    }
+                }
+            }
+        }
+    }
+
+    It 'a DEGRADED embedding probe does NOT sink OverallPass (own category, warning-only)' {
+        InModuleScope AITriad {
+            $script:EmbMs = 5000   # over the 2s ceiling → degraded
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' -HealthMaxAttempts 1 6>$null
+
+            $result.EmbeddingStatus | Should -Be 'degraded'
+            $result.EmbeddingLatencyMs | Should -Be 5000
+            $result.OverallPass | Should -BeTrue -Because 'a slow embed is a monitoring signal, not a hard failure — it must not false-red the deploy gate'
+            $result.HealthOk | Should -BeTrue
+            $result.AzureOk  | Should -BeTrue
+        }
+    }
+
+    It 'surfaces a ::warning:: annotation when the embedding probe is degraded' {
+        InModuleScope AITriad {
+            $script:EmbMs = 5000
+            $out = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' -HealthMaxAttempts 1 6>&1 | Out-String
+            $out | Should -Match '::warning::Embedding latency degraded'
+        }
+    }
+
+    It 'a fast embedding probe reports ok and the field is populated' {
+        InModuleScope AITriad {
+            $script:EmbMs = 150   # under the 2s ceiling → ok
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' -HealthMaxAttempts 1 6>$null
+            $result.EmbeddingStatus    | Should -Be 'ok'
+            $result.EmbeddingLatencyMs | Should -Be 150
+            $result.OverallPass        | Should -BeTrue
+        }
+    }
+}


### PR DESCRIPTION
Prevention for the t/3085 class — embeddings.json unreachable in prod for 3.5 months meant every debate re-embedded ~3,600 static texts in-process (25–48s vs milliseconds for a cache hit), invisible to error-rate gates because nothing *failed*. A wall-time ceiling is the only thing that catches 'correct but 100× slow'. Unblocked now: t/3085 (cache fix) + t/3086 (healthz cache field) both landed.

**What shipped**
- Private `Measure-EmbeddingLatency` — POSTs a small fixed batch of KNOWN cached node ids (skp/sit/acc/saf, verified present in embeddings.json) to `/api/embeddings/compute`, times the round-trip → `{DurationMs; Status ok|degraded; Count; HttpStatus; CeilingSec}`. `New-ActionableError` when the server is unreachable (StatusCode 0) — distinct from 'answered slowly'. Forces `texts`/`ids` JSON arrays (server 413s on a non-array).
- `Invoke-TaxEditorSmokeTest` — new `-EmbeddingCeilingSec` (default 2s; cache-hit <1s post-t/3085, tunable from real prod timings) + a Phase 8 `Embedding Latency` category that, like the GitHub check (t/2673), surfaces a breach as a `::warning::` and populates `EmbeddingStatus`/`EmbeddingLatencyMs` **but is EXCLUDED from OverallPass** — a slow embed can't false-red Health/Endpoints/Azure. **Warn-first**; promote to gating after real-prod calibration.

**Executes Main's shovel-ready plan (t/3088#1).** Scoped OUT: the t/3086 healthz cache-present sub-check (needs the exact health-payload field contract) — follow-up.

**Verified:** new tests **10/10** (probe arms: ok/slow/ceiling/non-200/unreachable/empty/array-forcing + smoke integration proving non-gating + the warning); full `-Tag health` **333/0**; `Test-ModuleManifest` clean. `/add-ps-cmdlet`-adjacent self-cert.