### PR TITLE
feat(devops): share data presence+freshness assertion — catch silent seed-lag (t/3091)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -347,14 +347,17 @@ jobs:
           ./operations/devops/Invoke-BlobContainerGateCheck.ps1 `
             -StorageAccount '${{ steps.deploy.outputs.storageAccountName }}'
 
-      # Asserts seed-manifest.json exists on the share, seeded_at within 180 days,
-      # and key data files (embeddings.json) within 10% of their seeded size.
-      # Catches the silent lag pattern from t/3090 (share 3.5 months stale). (t/3091)
-      - name: Verify share data freshness
+      # Warn-only: compares share data against the data-repo canonical blob sha via
+      # GitHub Git Trees API. Catches seed-lag (t/3090 pattern — share stale relative
+      # to data repo). Flip to blocking is a separate Gate-Promotion PR after ≥1 green
+      # cycle on the real share. (t/3091)
+      - name: Verify share data freshness (warn-only — t/3091)
         shell: pwsh
+        continue-on-error: true
         run: |
           ./operations/devops/Invoke-ShareFreshnessGateCheck.ps1 `
-            -StorageAccount '${{ steps.deploy.outputs.storageAccountName }}'
+            -StorageAccount '${{ steps.deploy.outputs.storageAccountName }}' `
+            -GitHubToken    '${{ github.token }}'
 
       - name: Cleanup stale revisions
         shell: pwsh

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -347,6 +347,15 @@ jobs:
           ./operations/devops/Invoke-BlobContainerGateCheck.ps1 `
             -StorageAccount '${{ steps.deploy.outputs.storageAccountName }}'
 
+      # Asserts seed-manifest.json exists on the share, seeded_at within 180 days,
+      # and key data files (embeddings.json) within 10% of their seeded size.
+      # Catches the silent lag pattern from t/3090 (share 3.5 months stale). (t/3091)
+      - name: Verify share data freshness
+        shell: pwsh
+        run: |
+          ./operations/devops/Invoke-ShareFreshnessGateCheck.ps1 `
+            -StorageAccount '${{ steps.deploy.outputs.storageAccountName }}'
+
       - name: Cleanup stale revisions
         shell: pwsh
         run: |

--- a/deploy/azure/deploy.ps1
+++ b/deploy/azure/deploy.ps1
@@ -253,6 +253,38 @@ if ($SeedData) {
             --account-key $storageKey `
             --output none
 
+        # Write seed manifest to share for the freshness gate (t/3091).
+        # Records embedded file sizes + seed timestamp so Invoke-ShareFreshnessGateCheck.ps1
+        # can detect absence, truncation, and silent lag without re-downloading the data.
+        Write-OK 'Writing seed manifest...'
+        $manifestFiles  = [ordered]@{}
+        $assertedPaths  = @('taxonomy/Origin/embeddings.json')
+        foreach ($rel in $assertedPaths) {
+            $localPath = Join-Path $tempDir ($rel -replace '/', [IO.Path]::DirectorySeparatorChar)
+            if (Test-Path $localPath) {
+                $manifestFiles[$rel] = @{ size_bytes = (Get-Item $localPath).Length }
+            }
+        }
+        $manifestJson  = [ordered]@{ seeded_at = [DateTimeOffset]::UtcNow.ToString('o'); files = $manifestFiles } |
+                         ConvertTo-Json -Depth 3
+        $tmpManifest   = [IO.Path]::GetTempFileName()
+        try {
+            [IO.File]::WriteAllText($tmpManifest, $manifestJson, [Text.Encoding]::UTF8)
+            az storage file upload `
+                --share-name  $shareName `
+                --source      $tmpManifest `
+                --path        'seed-manifest.json' `
+                --account-name $storageAcct `
+                --account-key  $storageKey `
+                --output none
+            $embSize = if ($manifestFiles['taxonomy/Origin/embeddings.json']) {
+                [math]::Round($manifestFiles['taxonomy/Origin/embeddings.json'].size_bytes / 1MB, 1)
+            } else { '?' }
+            Write-OK "Seed manifest written (embeddings.json: $embSize MB)"
+        } finally {
+            Remove-Item $tmpManifest -Force -ErrorAction SilentlyContinue
+        }
+
         Write-OK 'Data seeded successfully'
     }
     finally {

--- a/deploy/azure/deploy.ps1
+++ b/deploy/azure/deploy.ps1
@@ -254,19 +254,30 @@ if ($SeedData) {
             --output none
 
         # Write seed manifest to share for the freshness gate (t/3091).
-        # Records embedded file sizes + seed timestamp so Invoke-ShareFreshnessGateCheck.ps1
-        # can detect absence, truncation, and silent lag without re-downloading the data.
+        # Records data-repo commit SHA + per-file blob_sha (canonical freshness signal) and
+        # size_bytes (upload truncation guard). The gate compares blob_sha against the data
+        # repo's current canonical tree — not self-referential. (Design: e/126#4)
         Write-OK 'Writing seed manifest...'
+        $dataRepoCommit = (git -C $tempDir rev-parse HEAD 2>$null).Trim()
         $manifestFiles  = [ordered]@{}
         $assertedPaths  = @('taxonomy/Origin/embeddings.json')
         foreach ($rel in $assertedPaths) {
             $localPath = Join-Path $tempDir ($rel -replace '/', [IO.Path]::DirectorySeparatorChar)
             if (Test-Path $localPath) {
-                $manifestFiles[$rel] = @{ size_bytes = (Get-Item $localPath).Length }
+                # git ls-tree output: "<mode> blob <sha>\t<path>"
+                $lsLine   = git -C $tempDir ls-tree HEAD -- $rel 2>$null
+                $blobSha  = if ($lsLine) { ($lsLine -split '\s+')[2] } else { '' }
+                $manifestFiles[$rel] = [ordered]@{
+                    size_bytes = (Get-Item $localPath).Length
+                    blob_sha   = $blobSha
+                }
             }
         }
-        $manifestJson  = [ordered]@{ seeded_at = [DateTimeOffset]::UtcNow.ToString('o'); files = $manifestFiles } |
-                         ConvertTo-Json -Depth 3
+        $manifestJson  = ([ordered]@{
+            seeded_at        = [DateTimeOffset]::UtcNow.ToString('o')
+            data_repo_commit = $dataRepoCommit
+            files            = $manifestFiles
+        }) | ConvertTo-Json -Depth 3
         $tmpManifest   = [IO.Path]::GetTempFileName()
         try {
             [IO.File]::WriteAllText($tmpManifest, $manifestJson, [Text.Encoding]::UTF8)

--- a/operations/devops/Invoke-ShareFreshnessGateCheck.ps1
+++ b/operations/devops/Invoke-ShareFreshnessGateCheck.ps1
@@ -4,31 +4,38 @@
 
 <#
 .SYNOPSIS
-    Post-deploy gate: verify the Azure Files share is seeded with fresh, full-size data.
+    Post-deploy gate (warn-only): verify the Azure Files share is seeded with data current
+    to the data-repo canonical. Catches silent seed-lag (t/3090 pattern).
 .DESCRIPTION
     Reads seed-manifest.json from the share root (written by deploy.ps1 -SeedData).
-    Fails if:
-      - manifest is missing (share never seeded or seeded before t/3091 fix)
-      - any asserted file is absent from the share
-      - any asserted file is undersized vs the manifest (>10% shrinkage — stale/truncated)
-      - seeded_at age exceeds -MaxAgeDays (silent lag detection; catches the t/3090 pattern)
+    Uses the GitHub Git Trees API to fetch the current canonical blob sha for each asserted
+    file — no 1 MB content limit, just metadata. Compares canonical sha vs seeded sha to
+    detect seed-lag (data repo advanced since seed). Also checks share file size vs seeded
+    size for upload truncation (independent failure class).
 
-    Requires the calling identity to have Storage File Data SMB Share Reader role on
-    the storage account, or pass -StorageKey for key-based auth.
+    seeded_at is kept as diagnostic metadata in the warning message; it is NOT a gate condition
+    (age is the wrong signal — sha divergence is). (t/3091 design: e/126#4)
 
-    GV FIRE arm:  delete seed-manifest.json OR upload a stale/undersized manifest → gate fires.
-    GV CLEAN arm: present, fresh, correctly-sized manifest → passes silently, zero noise.
+    WARN-ONLY phase: wired with continue-on-error: true in deploy-azure.yml until ≥1 green
+    cycle confirmed against the real share. Flip-to-blocking is a separate Gate-Promotion PR.
+
+    GV FIRE arm:  data repo advances past seed (sha mismatch) OR share file undersized → warns.
+    GV CLEAN arm: seed current, share full-size → passes silently, zero output.
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)] [string] $StorageAccount,
-    [string] $ShareName  = 'taxonomy-data',
-    [int]    $MaxAgeDays = 180,
-    [string] $StorageKey = ''
+    [Parameter(Mandatory)] [string] $GitHubToken,
+    [string] $ShareName    = 'taxonomy-data',
+    [string] $DataRepo     = 'jpsnover/ai-triad-data',
+    [string] $StorageKey   = ''
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+# Load pure predicate (dot-sourceable; no I/O)
+. (Join-Path $PSScriptRoot 'ShareFreshnessPredicate.ps1')
 
 $authArgs = if ($StorageKey) { @('--account-key', $StorageKey) }
             else             { @('--auth-mode', 'login') }
@@ -46,71 +53,66 @@ try {
     if ($LASTEXITCODE -ne 0) {
         $errText = ($dlOut | Out-String).Trim()
         if ($errText -match 'ResourceNotFound|does not exist|The specified resource does not exist') {
-            Write-Host ("::error::Share freshness gate FAIL: seed-manifest.json not found on " +
-                "share '$ShareName' (account=$StorageAccount). " +
-                "Run deploy.ps1 -SeedData to seed the share. (t/3091)")
+            Write-Host ("::warning::Share freshness: seed-manifest.json not found on share '$ShareName' " +
+                "(account=$StorageAccount). Run deploy.ps1 -SeedData to seed the share and write the manifest. (t/3091)")
         } else {
-            Write-Host "::error::Share freshness gate FAIL: could not read seed-manifest.json — $errText (t/3091)"
+            Write-Host "::warning::Share freshness: could not read seed-manifest.json — $errText (t/3091)"
         }
-        throw "Share freshness gate failed — manifest missing or inaccessible"
+        return  # warn-only: do not exit 1
     }
 
-    $manifest = Get-Content $tmp -Raw | ConvertFrom-Json
+    $manifest  = Get-Content $tmp -Raw | ConvertFrom-Json
+    $seededAt  = $manifest.seeded_at
 
-    # ── Check seeded_at age ──────────────────────────────────────────────────
-    $seededAt = [DateTimeOffset]::Parse($manifest.seeded_at)
-    $ageDays  = ([DateTimeOffset]::UtcNow - $seededAt).TotalDays
-    if ($ageDays -gt $MaxAgeDays) {
-        Write-Host ("::error::Share freshness gate FAIL: share data is {0:F0} days old " +
-            "(seeded_at={1}, threshold={2} days). Re-run deploy.ps1 -SeedData. (t/3091)") `
-            -f $ageDays, $manifest.seeded_at, $MaxAgeDays
-        throw "Share freshness gate failed — data stale ($([math]::Round($ageDays,0)) days > $MaxAgeDays)"
+    # ── Fetch canonical tree from GitHub Git Trees API ───────────────────────
+    $headers   = @{
+        Authorization        = "Bearer $GitHubToken"
+        'X-GitHub-Api-Version' = '2022-11-28'
+        Accept               = 'application/vnd.github+json'
     }
-    Write-Host "  [OK] seeded_at=$($manifest.seeded_at) ($([math]::Round($ageDays,1)) days ago)"
+    $treeUrl   = "https://api.github.com/repos/$DataRepo/git/trees/HEAD?recursive=1"
+    $treeResp  = Invoke-RestMethod -Uri $treeUrl -Headers $headers -ErrorAction Stop
+    $treeEntries = @($treeResp.tree)
 
-    # ── Check each asserted file against the manifest ────────────────────────
-    $failed = @()
-    foreach ($entry in $manifest.files.PSObject.Properties) {
-        $filePath      = $entry.Name
-        $expectedBytes = [long]$entry.Value.size_bytes
-        $minBytes      = [long][math]::Floor($expectedBytes * 0.9)  # 10% tolerance
-
-        $showRaw = az storage file show `
+    # ── Collect share file sizes ─────────────────────────────────────────────
+    $shareFileSizes = @{}
+    foreach ($prop in $manifest.files.PSObject.Properties) {
+        $filePath = $prop.Name
+        $showRaw  = az storage file show `
             --account-name $StorageAccount `
             --share-name   $ShareName `
             --path         $filePath `
             @authArgs `
             --output json 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host ("::error::  [$filePath] MISSING from share " +
-                "(expected ~$([math]::Round($expectedBytes/1MB,1)) MB). (t/3091)")
-            $failed += $filePath
-            continue
+        if ($LASTEXITCODE -eq 0) {
+            $info        = ($showRaw | Out-String) | ConvertFrom-Json
+            $props2      = $info.properties
+            $actualBytes = if ($null -ne $info.contentLength)         { [long]$info.contentLength }
+                           elseif ($null -ne $props2 -and
+                                   $null -ne $props2.contentLength)   { [long]$props2.contentLength }
+                           else                                       { 0L }
+            $shareFileSizes[$filePath] = $actualBytes
         }
-        $fileInfo    = ($showRaw | Out-String) | ConvertFrom-Json
-        # az storage file show places size at .contentLength or .properties.contentLength
-        $props       = $fileInfo.properties
-        $actualBytes = if ($null -ne $fileInfo.contentLength)             { [long]$fileInfo.contentLength }
-                       elseif ($null -ne $props -and
-                               $null -ne $props.contentLength)            { [long]$props.contentLength }
-                       else                                               { 0L }
-
-        if ($actualBytes -lt $minBytes) {
-            Write-Host ("::error::  [{0}] UNDERSIZED: {1:F1} MB on share, " +
-                "expected >= {2:F1} MB (manifest={3:F1} MB). Share may be stale or truncated. (t/3091)") `
-                -f $filePath, ($actualBytes/1MB), ($minBytes/1MB), ($expectedBytes/1MB)
-            $failed += $filePath
-        } else {
-            Write-Host "  [OK] $filePath — $([math]::Round($actualBytes/1MB,1)) MB"
-        }
+        # If show fails (file missing), leave it absent from hashtable — predicate handles it
     }
 
-    if ($failed.Count -gt 0) {
-        throw "Share freshness gate failed — $($failed.Count) file(s) missing or undersized: $($failed -join ', ')"
-    }
+    # ── Run pure predicate ───────────────────────────────────────────────────
+    $result = Test-ShareManifestPredicate `
+        -Manifest       $manifest `
+        -CanonicalTree  $treeEntries `
+        -ShareFileSizes $shareFileSizes
 
-    $fileCount = @($manifest.files.PSObject.Properties).Count
-    Write-Host "Share freshness gate passed: manifest valid, $fileCount file(s) verified. (t/3091)"
+    if (-not $result.Pass) {
+        foreach ($reason in $result.Reasons) {
+            Write-Host ("::warning::Share freshness [seeded=$seededAt, account=$StorageAccount]: $reason (t/3091)")
+        }
+        Write-Host ("::warning::Share data may be stale — re-run deploy.ps1 -SeedData if the above is unexpected. " +
+            "This gate is warn-only pending promotion GV. (t/3091)")
+    } else {
+        # CLEAN: silent pass — zero noise per GV requirement
+        $fileCount = @($manifest.files.PSObject.Properties).Count
+        Write-Host "Share freshness gate passed: $fileCount file(s) current to canonical. (t/3091)"
+    }
 
 } finally {
     Remove-Item $tmp -Force -ErrorAction SilentlyContinue

--- a/operations/devops/Invoke-ShareFreshnessGateCheck.ps1
+++ b/operations/devops/Invoke-ShareFreshnessGateCheck.ps1
@@ -1,0 +1,117 @@
+#Requires -Version 7.0
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Post-deploy gate: verify the Azure Files share is seeded with fresh, full-size data.
+.DESCRIPTION
+    Reads seed-manifest.json from the share root (written by deploy.ps1 -SeedData).
+    Fails if:
+      - manifest is missing (share never seeded or seeded before t/3091 fix)
+      - any asserted file is absent from the share
+      - any asserted file is undersized vs the manifest (>10% shrinkage — stale/truncated)
+      - seeded_at age exceeds -MaxAgeDays (silent lag detection; catches the t/3090 pattern)
+
+    Requires the calling identity to have Storage File Data SMB Share Reader role on
+    the storage account, or pass -StorageKey for key-based auth.
+
+    GV FIRE arm:  delete seed-manifest.json OR upload a stale/undersized manifest → gate fires.
+    GV CLEAN arm: present, fresh, correctly-sized manifest → passes silently, zero noise.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $StorageAccount,
+    [string] $ShareName  = 'taxonomy-data',
+    [int]    $MaxAgeDays = 180,
+    [string] $StorageKey = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$authArgs = if ($StorageKey) { @('--account-key', $StorageKey) }
+            else             { @('--auth-mode', 'login') }
+
+# ── Download seed-manifest.json ──────────────────────────────────────────────
+$tmp = [IO.Path]::GetTempFileName()
+try {
+    $dlOut = az storage file download `
+        --account-name $StorageAccount `
+        --share-name   $ShareName `
+        --path         'seed-manifest.json' `
+        --dest         $tmp `
+        @authArgs `
+        --output none 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $errText = ($dlOut | Out-String).Trim()
+        if ($errText -match 'ResourceNotFound|does not exist|The specified resource does not exist') {
+            Write-Host ("::error::Share freshness gate FAIL: seed-manifest.json not found on " +
+                "share '$ShareName' (account=$StorageAccount). " +
+                "Run deploy.ps1 -SeedData to seed the share. (t/3091)")
+        } else {
+            Write-Host "::error::Share freshness gate FAIL: could not read seed-manifest.json — $errText (t/3091)"
+        }
+        throw "Share freshness gate failed — manifest missing or inaccessible"
+    }
+
+    $manifest = Get-Content $tmp -Raw | ConvertFrom-Json
+
+    # ── Check seeded_at age ──────────────────────────────────────────────────
+    $seededAt = [DateTimeOffset]::Parse($manifest.seeded_at)
+    $ageDays  = ([DateTimeOffset]::UtcNow - $seededAt).TotalDays
+    if ($ageDays -gt $MaxAgeDays) {
+        Write-Host ("::error::Share freshness gate FAIL: share data is {0:F0} days old " +
+            "(seeded_at={1}, threshold={2} days). Re-run deploy.ps1 -SeedData. (t/3091)") `
+            -f $ageDays, $manifest.seeded_at, $MaxAgeDays
+        throw "Share freshness gate failed — data stale ($([math]::Round($ageDays,0)) days > $MaxAgeDays)"
+    }
+    Write-Host "  [OK] seeded_at=$($manifest.seeded_at) ($([math]::Round($ageDays,1)) days ago)"
+
+    # ── Check each asserted file against the manifest ────────────────────────
+    $failed = @()
+    foreach ($entry in $manifest.files.PSObject.Properties) {
+        $filePath      = $entry.Name
+        $expectedBytes = [long]$entry.Value.size_bytes
+        $minBytes      = [long][math]::Floor($expectedBytes * 0.9)  # 10% tolerance
+
+        $showRaw = az storage file show `
+            --account-name $StorageAccount `
+            --share-name   $ShareName `
+            --path         $filePath `
+            @authArgs `
+            --output json 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host ("::error::  [$filePath] MISSING from share " +
+                "(expected ~$([math]::Round($expectedBytes/1MB,1)) MB). (t/3091)")
+            $failed += $filePath
+            continue
+        }
+        $fileInfo    = ($showRaw | Out-String) | ConvertFrom-Json
+        # az storage file show places size at .contentLength or .properties.contentLength
+        $props       = $fileInfo.properties
+        $actualBytes = if ($null -ne $fileInfo.contentLength)             { [long]$fileInfo.contentLength }
+                       elseif ($null -ne $props -and
+                               $null -ne $props.contentLength)            { [long]$props.contentLength }
+                       else                                               { 0L }
+
+        if ($actualBytes -lt $minBytes) {
+            Write-Host ("::error::  [{0}] UNDERSIZED: {1:F1} MB on share, " +
+                "expected >= {2:F1} MB (manifest={3:F1} MB). Share may be stale or truncated. (t/3091)") `
+                -f $filePath, ($actualBytes/1MB), ($minBytes/1MB), ($expectedBytes/1MB)
+            $failed += $filePath
+        } else {
+            Write-Host "  [OK] $filePath — $([math]::Round($actualBytes/1MB,1)) MB"
+        }
+    }
+
+    if ($failed.Count -gt 0) {
+        throw "Share freshness gate failed — $($failed.Count) file(s) missing or undersized: $($failed -join ', ')"
+    }
+
+    $fileCount = @($manifest.files.PSObject.Properties).Count
+    Write-Host "Share freshness gate passed: manifest valid, $fileCount file(s) verified. (t/3091)"
+
+} finally {
+    Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+}

--- a/operations/devops/ShareFreshnessPredicate.ps1
+++ b/operations/devops/ShareFreshnessPredicate.ps1
@@ -1,0 +1,77 @@
+#Requires -Version 7.0
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# Pure predicate for the share-data freshness gate (t/3091).
+# Dot-sourceable by both Invoke-ShareFreshnessGateCheck.ps1 and Pester tests.
+# No I/O — accepts pre-fetched data, returns structured result.
+
+function Test-ShareManifestPredicate {
+    <#
+    .SYNOPSIS
+        Pure predicate for the share freshness gate (t/3091). No I/O.
+    .DESCRIPTION
+        Checks three independent failure classes:
+        1. Canonical mismatch: data repo blob_sha advanced since seed (seed-lag).
+        2. File missing from canonical tree (file removed from data repo — unusual but detectable).
+        3. Upload truncation: share file size < 90% of seeded size.
+        Returns @{ Pass=[bool]; Reasons=[string[]] }.
+    .PARAMETER Manifest
+        Parsed seed-manifest.json PSCustomObject: .files.<path>.blob_sha / .size_bytes
+    .PARAMETER CanonicalTree
+        Array of tree-entry PSCustomObjects from the GitHub Git Trees API:
+        each entry has .path (string) and .sha (string).
+    .PARAMETER ShareFileSizes
+        Hashtable of { "relative/path" = <long size_bytes> } for files on the share.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [pscustomobject] $Manifest,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [pscustomobject[]] $CanonicalTree,
+        [Parameter(Mandatory)] [hashtable] $ShareFileSizes
+    )
+
+    $reasons = [System.Collections.Generic.List[string]]::new()
+
+    # Index canonical tree by path for O(1) lookup
+    $treeIndex = @{}
+    foreach ($entry in $CanonicalTree) {
+        $treeIndex[$entry.path] = $entry
+    }
+
+    foreach ($prop in $manifest.files.PSObject.Properties) {
+        $filePath      = $prop.Name
+        $seedBlobSha   = $prop.Value.blob_sha
+        $seedSizeBytes = [long]$prop.Value.size_bytes
+        $minBytes      = [long][math]::Floor($seedSizeBytes * 0.9)
+
+        # ── Primary: canonical blob_sha comparison (detects seed-lag) ────────
+        if (-not $treeIndex.ContainsKey($filePath)) {
+            $reasons.Add("[$filePath] not found in data-repo canonical tree — file may have been moved or removed")
+            continue
+        }
+        $canonicalSha = $treeIndex[$filePath].sha
+        if ($canonicalSha -ne $seedBlobSha) {
+            $reasons.Add("[$filePath] data repo has advanced since seed (canonical sha=$canonicalSha, seeded sha=$seedBlobSha) — re-run deploy.ps1 -SeedData")
+            # Fall through to also check truncation against seeded size
+        }
+
+        # ── Secondary: share upload truncation guard (independent of sha) ────
+        if (-not $ShareFileSizes.ContainsKey($filePath)) {
+            $reasons.Add("[$filePath] not found on share — may not have been uploaded")
+            continue
+        }
+        $actualBytes = $ShareFileSizes[$filePath]
+        if ($actualBytes -lt $minBytes) {
+            $aMB = [math]::Round($actualBytes  / 1MB, 1)
+            $sMB = [math]::Round($seedSizeBytes / 1MB, 1)
+            $mMB = [math]::Round($minBytes      / 1MB, 1)
+            $reasons.Add("[$filePath] UNDERSIZED on share: $aMB MB vs seeded $sMB MB (min $mMB MB) — possible upload truncation")
+        }
+    }
+
+    return [pscustomobject]@{
+        Pass    = $reasons.Count -eq 0
+        Reasons = $reasons.ToArray()
+    }
+}

--- a/tests/ShareFreshnessGate.Tests.ps1
+++ b/tests/ShareFreshnessGate.Tests.ps1
@@ -1,0 +1,146 @@
+# Tests for the share-data freshness gate predicate (t/3091).
+# Exercises the pure Test-ShareManifestPredicate function — no Azure or GitHub I/O.
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' 'operations' 'devops' 'ShareFreshnessPredicate.ps1')
+
+    # Helper: build a minimal manifest PSCustomObject
+    function New-TestManifest {
+        param([hashtable] $Files)
+        $filesObj = [pscustomobject]::new()
+        foreach ($kv in $Files.GetEnumerator()) {
+            $filesObj | Add-Member -MemberType NoteProperty -Name $kv.Key -Value ([pscustomobject]$kv.Value)
+        }
+        [pscustomobject]@{
+            seeded_at        = '2026-08-01T00:00:00Z'
+            data_repo_commit = 'abc123'
+            files            = $filesObj
+        }
+    }
+
+    # Helper: build a tree entry
+    function New-TreeEntry { param([string]$Path, [string]$Sha) [pscustomobject]@{ path = $Path; sha = $Sha } }
+
+    $EmbPath   = 'taxonomy/Origin/embeddings.json'
+    $SeedSha   = 'aaa111bbb222ccc333ddd444eee555fff666777a'
+    $NewSha    = 'bbb222ccc333ddd444eee555fff666777aaa888b'
+    $SeedSize  = 63 * 1024 * 1024  # 63 MB
+}
+
+Describe 'Test-ShareManifestPredicate' -Tag 'unit' {
+
+    Context 'CLEAN arm — all conditions met' {
+        It 'Passes when sha matches and share size is at seeded size' {
+            $manifest = New-TestManifest @{ $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize } }
+            $tree     = @(New-TreeEntry $EmbPath $SeedSha)
+            $sizes    = @{ $EmbPath = [long]$SeedSize }
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Pass    | Should -BeTrue
+            $result.Reasons | Should -BeNullOrEmpty
+        }
+
+        It 'Passes when sha matches and share size is within 10% tolerance' {
+            $manifest = New-TestManifest @{ $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize } }
+            $tree     = @(New-TreeEntry $EmbPath $SeedSha)
+            $sizes    = @{ $EmbPath = [long]($SeedSize * 0.91) }  # 91% of seeded — just above floor
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Pass | Should -BeTrue
+        }
+    }
+
+    Context 'FIRE arm — sha mismatch (seed-lag, primary signal)' {
+        It 'Fires when canonical sha differs from seeded sha' {
+            $manifest = New-TestManifest @{ $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize } }
+            $tree     = @(New-TreeEntry $EmbPath $NewSha)   # data repo advanced
+            $sizes    = @{ $EmbPath = [long]$SeedSize }
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Pass                          | Should -BeFalse
+            $result.Reasons.Count                 | Should -BeGreaterOrEqual 1
+            $result.Reasons -join ' '             | Should -Match 'advanced since seed'
+        }
+
+        It 'Fire message includes both canonical and seeded sha for diagnosis' {
+            $manifest = New-TestManifest @{ $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize } }
+            $tree     = @(New-TreeEntry $EmbPath $NewSha)
+            $sizes    = @{ $EmbPath = [long]$SeedSize }
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Reasons -join ' ' | Should -Match $NewSha
+            $result.Reasons -join ' ' | Should -Match $SeedSha
+        }
+    }
+
+    Context 'FIRE arm — file missing from canonical tree' {
+        It 'Fires when file not found in canonical tree' {
+            $manifest = New-TestManifest @{ $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize } }
+            $tree     = @()   # empty tree — file removed from data repo
+            $sizes    = @{ $EmbPath = [long]$SeedSize }
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Pass          | Should -BeFalse
+            $result.Reasons -join ' ' | Should -Match 'not found in data-repo canonical tree'
+        }
+    }
+
+    Context 'FIRE arm — upload truncation (secondary, independent)' {
+        It 'Fires when share file is more than 10% smaller than seeded size' {
+            $manifest = New-TestManifest @{ $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize } }
+            $tree     = @(New-TreeEntry $EmbPath $SeedSha)   # sha still matches
+            $sizes    = @{ $EmbPath = [long]($SeedSize * 0.85) }  # 85% — below 90% floor
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Pass          | Should -BeFalse
+            $result.Reasons -join ' ' | Should -Match 'UNDERSIZED'
+        }
+
+        It 'Fires truncation even when sha matches (independent check)' {
+            $manifest = New-TestManifest @{ $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize } }
+            $tree     = @(New-TreeEntry $EmbPath $SeedSha)
+            $sizes    = @{ $EmbPath = [long]1024 }  # 1 KB — clearly truncated
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Pass | Should -BeFalse
+        }
+
+        It 'Fires when file missing from share entirely' {
+            $manifest = New-TestManifest @{ $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize } }
+            $tree     = @(New-TreeEntry $EmbPath $SeedSha)
+            $sizes    = @{}   # file not on share
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Pass          | Should -BeFalse
+            $result.Reasons -join ' ' | Should -Match 'not found on share'
+        }
+    }
+
+    Context 'Multiple files in manifest' {
+        It 'Reports all failing files, not just the first' {
+            $path2    = 'taxonomy/Origin/taxonomy.json'
+            $sha2     = 'ccc333ddd444eee555fff666777aaa888bbb999c'
+            $manifest = New-TestManifest @{
+                $EmbPath = @{ blob_sha = $SeedSha; size_bytes = $SeedSize }
+                $path2   = @{ blob_sha = $sha2;    size_bytes = 10MB }
+            }
+            $tree     = @(
+                New-TreeEntry $EmbPath $NewSha    # mismatch
+                New-TreeEntry $path2   $sha2      # matches
+            )
+            $sizes    = @{
+                $EmbPath = [long]$SeedSize
+                $path2   = [long]10MB
+            }
+
+            $result = Test-ShareManifestPredicate -Manifest $manifest -CanonicalTree $tree -ShareFileSizes $sizes
+            $result.Pass          | Should -BeFalse
+            $result.Reasons.Count | Should -Be 1   # only embeddings.json fires
+            $result.Reasons[0]    | Should -Match $EmbPath
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `Invoke-ShareFreshnessGateCheck.ps1`: post-deploy gate that reads `seed-manifest.json` from the Azure Files share, checks `seeded_at` age (≤180 days), and asserts `taxonomy/Origin/embeddings.json` size is within 10% of its seeded value
- `deploy.ps1 -SeedData`: writes `seed-manifest.json` to the share after upload, recording file sizes and timestamp
- `deploy-azure.yml`: new blocking "Verify share data freshness" step after the blob container gate

## Root cause (t/3090)

Azure Files share silently lagged the data repo for ~3.5 months — embeddings.json was 36 MB (stale, 2026-05-04) vs 63 MB canonical. A mere presence check would have passed. This gate catches absence, truncation, and silent lag.

## Gate Verification required (TL sign-off)

Per t/3091 and DevOps AGENTS.md — gate-touching, both arms required:
- **FIRE**: delete or corrupt `seed-manifest.json`, or supply stale seeded_at → gate fires
- **CLEAN**: present, fresh, correctly-sized manifest → passes silently

Holding as draft until TL GV sign-off.

## Test plan

- [ ] FIRE arm: delete `seed-manifest.json` from share → gate fires with clear error
- [ ] FIRE arm: seed with stale `seeded_at` (>180 days) → gate fires age check
- [ ] FIRE arm: undersized manifest entry (>10% shrinkage) → gate fires size check
- [ ] CLEAN arm: fresh seed → gate passes, zero noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
