### PR TITLE
feat(eslint): data-root read gate — flag raw fs reads of resolver paths (t/3093)

### DIFF
--- a/taxonomy-editor/eslint-rules/__tests__/no-raw-data-root-read.test.ts
+++ b/taxonomy-editor/eslint-rules/__tests__/no-raw-data-root-read.test.ts
@@ -1,0 +1,39 @@
+// Rule-level Gate Verification for local/no-raw-data-root-read (t/3093).
+// RuleTester uses the default espree parser (no TS projectService), so this is the
+// deterministic both-arms proof: `invalid` = the FAIL arm (every realistic remnant shape
+// fires), `valid` = the precision arm (non-data-root reads + sanctioned patterns stay silent).
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from '../no-raw-data-root-read.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.afterAll = afterAll;
+
+const rt = new RuleTester({ languageOptions: { ecmaVersion: 2022, sourceType: 'module' } });
+
+rt.run('no-raw-data-root-read', rule, {
+  valid: [
+    // non-data-root base paths — not one of the 4 resolvers
+    "import fs from 'fs'; import path from 'path'; fs.readFileSync(path.join(getProjectRoot(), 'x'));",
+    "import fs from 'fs'; import path from 'path'; fs.readFileSync(path.join(__dirname, 'package.json'));",
+    "import fs from 'fs'; fs.readFileSync('literal/path.json');",
+    // cross-function wrapper — the documented KNOWN LIMITATION (closed by t/3094 convention, not this rule)
+    "import fs from 'fs'; const p = makePath(); fs.readFileSync(p);",
+    // backend.readFile is the sanctioned data-root path — must NOT be treated as a raw fs read
+    "const p = resolveDataPath('x'); backend.readFile(p);",
+  ],
+  invalid: [
+    // direct resolver call
+    { code: "import fs from 'fs'; fs.readFileSync(getEmbeddingsPath());", errors: [{ messageId: 'rawDataRootRead' }] },
+    // one-hop const (aiBackends.ts:557 shape)
+    { code: "import fs from 'fs'; const p = getEmbeddingsPath(); fs.promises.readFile(p);", errors: [{ messageId: 'rawDataRootRead' }] },
+    // member-form resolver + 2-hop path.join const chain (sources.ts:52 shape)
+    { code: "import fs from 'fs'; import path from 'path'; const d = fileIO.getTaxonomyDir(); const f = path.join(d, 'x'); fs.readFileSync(f);", errors: [{ messageId: 'rawDataRootRead' }] },
+    // inline path.join(getDataRoot(), …)
+    { code: "import fs from 'fs'; import path from 'path'; fs.readFileSync(path.join(getDataRoot(), 'x'));", errors: [{ messageId: 'rawDataRootRead' }] },
+    // for-of over a same-scope const array of resolver paths (server.ts:443 authorized-users shape)
+    { code: "import fs from 'fs'; import path from 'path'; const candidates = [path.join(getDataRoot(), 'a')]; for (const p of candidates) { fs.readFileSync(p); }", errors: [{ messageId: 'rawDataRootRead' }] },
+  ],
+});

--- a/taxonomy-editor/eslint-rules/no-raw-data-root-read.js
+++ b/taxonomy-editor/eslint-rules/no-raw-data-root-read.js
@@ -1,0 +1,126 @@
+// Custom ESLint rule: no raw fs read of a data-root path (t/3087 / t/3093).
+//
+// The May 14 GitHub API-First migration (dc8651b0) moved every data-root consumer behind
+// StorageBackend except a raw fs read in loadEmbeddingsFile, which then silently read an empty
+// cache for 3.5 months (t/3085). This rule turns "remember to migrate every caller" into a
+// lint signal: flag a raw fs read (fs.readFile / fs.readFileSync / fs.promises.readFile) whose
+// PATH ARGUMENT traces to a data-root resolver — resolveDataPath / getTaxonomyDir /
+// getEmbeddingsPath / getDataRoot, including member forms like fileIO.getTaxonomyDir()
+// (resolveDataPath(sub) === path.join(getDataRoot(), sub), config.ts, so getDataRoot is the base).
+// Data-root reads must go through src/server/storage/readDataFile(), which carries the
+// empty/missing-read guard.
+//
+// KNOWN LIMITATION (tripwire, not proof — green ≠ verified): catches inline reads and
+// SAME-SCOPE const indirection, including transitive const → path.join(const, …) → const hops
+// (the sources.ts:52 style). It does NOT follow CROSS-FUNCTION / cross-module wrapper
+// indirection (e.g. `fs.readFile(makePath())` where makePath() is defined elsewhere) — that
+// hole is closed by the t/3094 data-root-reader-location convention + review, not this rule.
+// A new hit is a true positive requiring TL review before it is silenced.
+
+const RESOLVERS = new Set(['resolveDataPath', 'getTaxonomyDir', 'getEmbeddingsPath', 'getDataRoot']);
+const FS_OBJECTS = new Set(['fs', 'fsp', 'fsPromises']);
+const PATH_JOINERS = new Set(['join', 'resolve', 'normalize']);
+const MAX_HOPS = 6; // same-scope, bounded — not full data-flow
+
+/** A data-root resolver call — bare `foo()` or member `obj.foo()` (e.g. fileIO.getTaxonomyDir()). */
+function isResolverCall(node) {
+  if (!node || node.type !== 'CallExpression') return false;
+  const c = node.callee;
+  if (c.type === 'Identifier') return RESOLVERS.has(c.name);
+  if (c.type === 'MemberExpression' && c.property.type === 'Identifier' && !c.computed) {
+    return RESOLVERS.has(c.property.name);
+  }
+  return false;
+}
+
+/** A raw fs read: fs.readFile(Sync) / fsp.readFile(Sync) / fs.promises.readFile — NOT backend.readFile. */
+function isFsReadCall(node) {
+  const c = node.callee;
+  if (c.type !== 'MemberExpression' || c.computed || c.property.type !== 'Identifier') return false;
+  if (c.property.name !== 'readFile' && c.property.name !== 'readFileSync') return false;
+  const obj = c.object;
+  if (obj.type === 'Identifier') return FS_OBJECTS.has(obj.name);
+  // fs.promises.readFile
+  return obj.type === 'MemberExpression'
+    && obj.object.type === 'Identifier' && obj.object.name === 'fs'
+    && obj.property.type === 'Identifier' && obj.property.name === 'promises';
+}
+
+/** Find a variable binding by walking up the scope chain (same-scope + enclosing scopes). */
+function findVariable(scope, name) {
+  for (let s = scope; s; s = s.upper) {
+    const v = s.set.get(name);
+    if (v) return v;
+  }
+  return null;
+}
+
+/** Does `node` (a path expression) trace to a data-root resolver within bounded same-scope hops? */
+function tracesToResolver(node, scope, depth) {
+  if (!node || depth > MAX_HOPS) return false;
+  if (isResolverCall(node)) return true;
+  // path.join(a, b, …) / path.resolve(…) — traces if ANY argument does
+  if (node.type === 'CallExpression'
+      && node.callee.type === 'MemberExpression'
+      && node.callee.object.type === 'Identifier' && node.callee.object.name === 'path'
+      && node.callee.property.type === 'Identifier' && PATH_JOINERS.has(node.callee.property.name)) {
+    return node.arguments.some((a) => tracesToResolver(a, scope, depth + 1));
+  }
+  // Array literal → any element tracing counts (a `candidates`-style path list).
+  if (node.type === 'ArrayExpression') {
+    return node.elements.some((el) => el && tracesToResolver(el, scope, depth + 1));
+  }
+  // Identifier → resolve to a same-scope `const` and follow its initializer, OR a
+  // `for (const x of <array>)` loop variable → follow the iterated array (the server.ts:443
+  // authorized-users pattern: `const candidates = [path.join(getDataRoot(), …)]; for (const p
+  // of candidates) fs.readFileSync(p)`). Both are same-scope + bounded — still "light".
+  if (node.type === 'Identifier') {
+    const variable = findVariable(scope, node.name);
+    if (!variable) return false;
+    for (const def of variable.defs) {
+      if (def.type !== 'Variable' || def.node.type !== 'VariableDeclarator') continue;
+      const decl = def.parent; // the enclosing VariableDeclaration
+      if (!decl || decl.kind !== 'const') continue;
+      if (decl.parent && decl.parent.type === 'ForOfStatement' && decl.parent.left === decl) {
+        if (tracesToResolver(decl.parent.right, scope, depth + 1)) return true;
+      } else if (def.node.init && tracesToResolver(def.node.init, scope, depth + 1)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Flag a raw fs read whose path traces to a data-root resolver — route it through storage/readDataFile() (migration-remnant class, t/3085/t/3087)',
+    },
+    messages: {
+      rawDataRootRead:
+        'Raw fs read of a data-root path (its argument traces to a data-root resolver). Route it '
+        + 'through src/server/storage/readDataFile() — the migration-remnant class that silently '
+        + 'read an empty cache for 3.5 months (t/3085/t/3087). If this is a sanctioned exception, add '
+        + '// eslint-disable-next-line local/no-raw-data-root-read -- <TL-approved rationale> at the '
+        + 'call site. tripwire: green ≠ verified — a new hit needs TL review before silencing.',
+    },
+    schema: [],
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+    return {
+      CallExpression(node) {
+        if (!isFsReadCall(node)) return;
+        const pathArg = node.arguments[0];
+        if (!pathArg) return;
+        const scope = sourceCode.getScope(node);
+        if (tracesToResolver(pathArg, scope, 0)) {
+          context.report({ node, messageId: 'rawDataRootRead' });
+        }
+      },
+    };
+  },
+};

--- a/taxonomy-editor/eslint.config.mjs
+++ b/taxonomy-editor/eslint.config.mjs
@@ -21,6 +21,7 @@ import requireFlightRecorderInCatch from '../lib/eslint-rules/require-flight-rec
 import noActionableErrorMessageNesting from '../lib/eslint-rules/no-actionable-error-message-nesting.js';
 import noUnmanagedModuleResources from './eslint-rules/no-unmanaged-module-resources.js';
 import noInlineStyle from './eslint-rules/no-inline-style.js';
+import noRawDataRootRead from './eslint-rules/no-raw-data-root-read.js';
 
 const localPlugin = {
   rules: {
@@ -28,6 +29,7 @@ const localPlugin = {
     'no-unmanaged-module-resources': noUnmanagedModuleResources,
     'no-inline-style': noInlineStyle,
     'no-actionable-error-message-nesting': noActionableErrorMessageNesting,
+    'no-raw-data-root-read': noRawDataRootRead,
   },
 };
 
@@ -103,6 +105,22 @@ export default tseslint.config(
         message:
           'Module-level call expressions are banned in server/storage — they fire at import time and can crash Vitest collection or the container on startup. Move invariant checks into a constructor or explicit init function. See undiciInvariant.ts + GitHubRestClient constructor as the canonical pattern. (t/2113, t/2114)',
       }],
+    },
+  },
+  // ── Block A-dataroot: data-root read gate (t/3093 / t/3087) ──
+  // Flags a raw fs read whose path traces to a data-root resolver (the t/3085 migration-remnant
+  // class). Ships as `warn` first; TL promotes to `error` after >=1 green CI cycle.
+  // tripwire: green != verified — a new hit is a true positive; silence it only with an inline
+  // eslint-disable + TL-approved rationale at the call site, never by baselining here.
+  {
+    files: ['src/server/**/*.ts'],
+    ignores: [
+      ...TEST_GLOBS,             // tests hit resolver + fs.read constantly — not migration remnants
+      'src/server/storage/**',   // sanctioned home for data-root reads (readDataFile lives here)
+      'src/server/config.ts',    // defines the resolver functions themselves
+    ],
+    rules: {
+      'local/no-raw-data-root-read': 'warn',
     },
   },
   // ── Block B: LOC budget for test source (syntactic parse; tests are outside the

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -440,6 +440,7 @@ function loadAuthorizedUsers(): AuthorizedUsersFile | null {
   for (const p of candidates) {
     try {
       if (fs.existsSync(p)) {
+        // eslint-disable-next-line local/no-raw-data-root-read -- auth allowlist is mount-sourced (/data volume) with an existsSync fallback loop BY DESIGN; routing through readDataFile would flip the trust source from the mount to the data-repo-via-API (auth surface — t/3093#3, ServerAPI route-b)
         const data = JSON.parse(fs.readFileSync(p, 'utf-8')) as AuthorizedUsersFile;
         log.auth.info({ count: data.users.length, path: p }, 'Loaded authorized users');
         return data;

--- a/taxonomy-editor/vite.config.ts
+++ b/taxonomy-editor/vite.config.ts
@@ -226,6 +226,7 @@ export default defineConfig({
       '../main/**/*.test.ts',
       '../server/__tests__/**/*.test.ts',
       '../../../taxonomy-editor/scripts/__tests__/**/*.test.ts', // t/2973 — generate-notices guard unit tests
+      '../../../taxonomy-editor/eslint-rules/__tests__/**/*.test.ts', // t/3093 — custom ESLint rule RuleTester specs
       '../../../lib/ai-client/**/*.test.ts',
       '../../../lib/chat/**/*.test.ts',
       '../../../lib/electron-shared/**/*.test.ts',


### PR DESCRIPTION
## Summary
The t/3087 prevention gate (design t/3093#2/#3). Custom ESLint rule `local/no-raw-data-root-read` flags a raw fs read (`fs.readFile`/`readFileSync`/`fs.promises.readFile`) whose path argument traces to a data-root resolver — `resolveDataPath` / `getTaxonomyDir` / `getEmbeddingsPath` / `getDataRoot` (+ member forms) — so data-root reads must go through `storage/readDataFile()`. Turns the t/3085 migration-remnant class (a raw read that silently served an empty cache for 3.5 months) into a lint signal.

- **Argument/data-flow, not file-level.** Light same-scope const-tracking: `resolver() → const → path.join(const,…) → const → fs.readFile(const)`, incl. member-form resolvers (`fileIO.getTaxonomyDir()`) and a for-of loop var over a same-scope const/inline array (the `server.ts:443` shape). Bounded (`MAX_HOPS=6`), same-scope only.
- **Ships as `warn`** (TL promotes to `error` after ≥1 green cycle). Structural exemptions only — `storage/`, `config.ts`, `__tests__/` — each with a rationale. Co-located tripwire + known-limitation comment.
- **Empty baseline:** #1627 (landed) migrated the 3 genuine readers (aiBackends, sources, preferences); `server.ts:443` (mount-sourced auth allowlist) carries a **line-level route-(b) disable** with rationale (TL t/3093#3, ServerAPI p/528#12) — landed atomically here so the clean arm is empty with zero file exemptions.

## Deviation (asked X, did Y, because Z)
t/3093#3 specified tracking as `const → path.join → const`. I **also** trace a for-of loop var over a same-scope const/inline array, because your ruling lists `server.ts:443` (a for-of-over-candidates read) as a true positive the gate must catch — reconcilable only if the rule follows the loop-array form. Stays same-scope + bounded ⇒ still "light".

## Known limitation (in rule header + gate comment)
Catches inline + same-scope const indirection; **cross-function/module wrapper** indirection is not caught — closed by the t/3094 convention + review. Tripwire, not proof.

## Verification
- **RuleTester spec** (`eslint-rules/__tests__`, wired to vitest via `vite.config.ts`) — **10/10**: 5 invalid (direct / one-hop / 2-hop-member / inline-join / for-of) + 5 valid (getProjectRoot / __dirname / literal / wrapper-fn / `backend.readFile`).
- **Clean arm (local):** `eslint src/server` → **0** `no-raw-data-root-read` hits, no unused-disable directive.
  - ⚠️ Local `eslint` on the type-aware `src/server` tree intermittently exits 2 with **no error message** (a `projectService` flake that hit every local eslint run this session; the flat config loads fine). The **rule-hit count is 0** and RuleTester is green — but the authoritative whole-tree clean arm is **CI + your GV**, where `eslint src/` runs in the proper pipeline (it's linted all my recent PRs cleanly).

## Gate Verification (yours, TL)
Requesting both arms on this PR: FAIL arm (re-introduce a raw resolver read → flagged) and CLEAN arm (green, zero new warnings). Not self-merging — this is gate-touching.

Closes t/3093 (parent t/3087).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>
Co-Authored-By: ServerAPI (Orca) <main.taxonomy-editor-src-server@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)