### PR TITLE
fix(server/ai): raise FREE_TIER_RPM_PER_KEY 6→24 — one key clears a debate burst (t/3104)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/freeTier.test.ts
+++ b/taxonomy-editor/src/server/__tests__/freeTier.test.ts
@@ -15,19 +15,26 @@ import { checkRate } from '../security/rateLimiter.js';
 describe('free-tier RPM scales with key-pool size (t/906)', () => {
   afterEach(() => { delete process.env.FREE_TIER_GEMINI_KEY; });
 
-  it('scaledFreeTierRpm = 6 per key, capped at 30 (AC#1, #3)', () => {
-    expect(scaledFreeTierRpm(1)).toBe(6);
-    expect(scaledFreeTierRpm(2)).toBe(12);
+  // t/3104: FREE_TIER_RPM_PER_KEY raised 6→24 so one key clears a debate's T≈20
+  // opening burst. The 30 hard cap is untouched, so 2+ keys now saturate at 30.
+  it('scaledFreeTierRpm = 24 per key, capped at 30 (AC#1, #3; t/3104)', () => {
+    expect(scaledFreeTierRpm(1)).toBe(24);
+    expect(scaledFreeTierRpm(2)).toBe(30); // 24×2=48 → capped at 30
     expect(scaledFreeTierRpm(5)).toBe(30);
     expect(scaledFreeTierRpm(6)).toBe(30); // capped
     expect(scaledFreeTierRpm(0)).toBe(0);
   });
 
+  it('one key clears a debate opening burst (T≈20 ≤ 24 = scaledFreeTierRpm(1)) (t/3104)', () => {
+    // The bug: at 6 RPM a single debate (~20 generate/min) self-throttled mid-openings.
+    expect(scaledFreeTierRpm(1)).toBeGreaterThanOrEqual(24);
+  });
+
   it('resolveTier applies the scaled RPM for keyless free-tier users', () => {
     process.env.FREE_TIER_GEMINI_KEY = 'k1,k2';
-    expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(12);
+    expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(30); // 24×2 → capped
     process.env.FREE_TIER_GEMINI_KEY = 'k1';
-    expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(6);
+    expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(24);
     process.env.FREE_TIER_GEMINI_KEY = 'k1,k2,k3,k4,k5,k6,k7';
     expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(30); // capped
   });
@@ -69,7 +76,7 @@ describe('free tier (t/793)', () => {
     expect(tier.pinnedModel).toBe('gemini-3.5-flash-lite'); // = DEFAULT_MODEL (t/2687)
     // t/812: no per-prompt char cap — cost is bounded by tokensPerDay + per-IP RPM.
     expect(tier.maxPromptChars).toBeUndefined();
-    expect(tier.limits).toEqual({ requestsPerMinute: 6, tokensPerDay: 500_000 });
+    expect(tier.limits).toEqual({ requestsPerMinute: 24, tokensPerDay: 500_000 }); // t/3104: 6→24 (single-key debate burst)
     expect(tier.allowedBackends).toEqual(['gemini']);
   });
 
@@ -143,7 +150,7 @@ describe('t/3061 — embed:<ip> bucket is independent of free:<ip> (fix arm)', (
     const ip = embedIp();
     const freeKey = `free:${ip}`;
     const embedKey = `embed:${ip}`;
-    const apiRpm = 6; // matches scaledFreeTierRpm(1) — the generate gate limit
+    const apiRpm = 6; // arbitrary small bucket limit — this test asserts bucket independence, not the RPM value (scaledFreeTierRpm(1) is 24 since t/3104)
 
     // Exhaust the generate API bucket (free:<ip>).
     for (let i = 0; i < apiRpm; i++) {

--- a/taxonomy-editor/src/server/ai/proxyTiers.ts
+++ b/taxonomy-editor/src/server/ai/proxyTiers.ts
@@ -184,8 +184,14 @@ export function byokGeminiFallbackKey(
   return freeKeys.length === 1 ? freeKeys[0] : freeKeys;
 }
 
-/** Per-Gemini-key free-tier RPM — single source of truth (also used by keyRotator.ts). */
-export const FREE_TIER_RPM_PER_KEY = 6;
+/** Per-Gemini-key free-tier RPM — single source of truth (also used by keyRotator.ts).
+ * t/3104: raised 6→24. A single debate's opening burst peaks at T≈20 generate/min
+ * (title + topic-critique + 3 openings + inline verify + search); at 6 RPM one debate
+ * self-throttled mid-openings with a front-door per_ip_rpm 429. 24 ≈ 1.2·T (demand
+ * margin) and sits far under the key project's upstream ceiling (Tier-2 = 10,000 RPM,
+ * so 0.8·P ≈ 8,000 — no upstream-429 risk). Per-IP daily cost stays bounded by the
+ * unchanged tokensPerDay budget; this only widens the per-minute burst, not daily spend. */
+export const FREE_TIER_RPM_PER_KEY = 24;
 
 /**
  * Per-IP RPM for LOCAL embedding + NLI ops (ONNX / Python encoder — zero Gemini quota).


### PR DESCRIPTION
## Summary

Raises `FREE_TIER_RPM_PER_KEY` 6→24 (`proxyTiers.ts:188`) so a single free-tier key serves one debate's opening burst without a front-door `per_ip_rpm` 429.

## Root cause (Diagnostics, dump merged-2f2975e7)

A single free-tier debate fires ~20 generate/min (title + topic-critique + 3 openings + inline verify + search). At 6 RPM the front-door per-IP limiter (`scaledFreeTierRpm`) 429'd mid-openings — self-inflicted throttle, **not** upstream exhaustion (fast-fail ~37ms; varying sub-minute retry_after).

## Decision (TL-confirmed, p/542)

Firm P (DevOps, AI Studio dashboard): the key's project is **Tier-2 billing-enabled**, upstream RPM = **10,000** for `gemini-3.5-flash-lite` → P ≫ 30 → **zero-provisioning row**:

- **V = 24, K = 1**, hard 30 cap untouched.
- `V = 24 ≈ 1.2·T` (demand margin over T≈20) and `24 ≤ 0.8·P (8,000)` → no upstream-429 risk.

## Cost flag (raised by DevOps, bounded)

V only widens the per-minute **burst**. The per-IP **daily** ceiling is the unchanged `tokensPerDay = 500K` budget — enforced *and* tracked on the free generate path (`enforceAiRateLimits` → `checkTokenLimit` / `recordTokenUsage`, ai.ts:91/205/354), independent of RPM. **Worst-case daily anon spend/IP is unchanged.**

## Behavior note

With V=24 the 30 hard cap now binds at **2 keys** (`scaledFreeTierRpm(2)=30`), not 5 — intentional; cap left in place per the row decision.

## Tests (`freeTier.test.ts`, 21/21 pass)

- `scaledFreeTierRpm(1)=24`, `(2)=30` (capped), `(5)=(6)=30`, `(0)=0`
- New: one key clears the burst (`scaledFreeTierRpm(1) ≥ 24`)
- `resolveTier` free-tier RPM: 1 key→24, 2 keys→30, 7 keys→30
- Free-tier `limits` = `{ requestsPerMinute: 24, tokensPerDay: 500_000 }`

## TL follow-ups (answered, non-blocking)

1. **daily_token gates the free GENERATE path?** Yes — `enforceAiRateLimits` (ai.ts:354) runs `checkTokenLimit(tokensPerDay)` (91) + `recordTokenUsage` (205).
2. **tokensPerDay sanity on a paid project?** Value = 500K/day/IP (unchanged). Real cost knob; whether 500K is right for a paid Tier-2 project is a separate budget decision — flagging, not changing here.

## Gate

Gate-touching (limits change) — **routing to Main (TL) for Gate Verification**, not self-merging. Closes t/3106 as not-needed (zero provisioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)