### PR TITLE
fix(server/ai): revert FREE_TIER_RPM_PER_KEY 24→12 — free-pool-safe per-key (t/3111)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/freeTier.test.ts
+++ b/taxonomy-editor/src/server/__tests__/freeTier.test.ts
@@ -15,26 +15,31 @@ import { checkRate } from '../security/rateLimiter.js';
 describe('free-tier RPM scales with key-pool size (t/906)', () => {
   afterEach(() => { delete process.env.FREE_TIER_GEMINI_KEY; });
 
-  // t/3104: FREE_TIER_RPM_PER_KEY raised 6→24 so one key clears a debate's T≈20
-  // opening burst. The 30 hard cap is untouched, so 2+ keys now saturate at 30.
-  it('scaledFreeTierRpm = 24 per key, capped at 30 (AC#1, #3; t/3104)', () => {
-    expect(scaledFreeTierRpm(1)).toBe(24);
-    expect(scaledFreeTierRpm(2)).toBe(30); // 24×2=48 → capped at 30
+  // t/3111: FREE_TIER_RPM_PER_KEY reverted 24→12 (the t/3104 24 was sized against a paid
+  // Tier-2 key; on a real free key P_free≈15, so 12=0.8·P is the safe per-key value). The
+  // ~20/min debate burst is cleared by POOL SIZE (K=2 → min(12×2,30)=24), not one hot key.
+  // 30 hard cap untouched → 3+ keys saturate at 30.
+  it('scaledFreeTierRpm = 12 per key, capped at 30 (AC#1, #3; t/3111)', () => {
+    expect(scaledFreeTierRpm(1)).toBe(12);
+    expect(scaledFreeTierRpm(2)).toBe(24); // 12×2=24, under the 30 cap
+    expect(scaledFreeTierRpm(3)).toBe(30); // 12×3=36 → capped at 30
     expect(scaledFreeTierRpm(5)).toBe(30);
     expect(scaledFreeTierRpm(6)).toBe(30); // capped
     expect(scaledFreeTierRpm(0)).toBe(0);
   });
 
-  it('one key clears a debate opening burst (T≈20 ≤ 24 = scaledFreeTierRpm(1)) (t/3104)', () => {
-    // The bug: at 6 RPM a single debate (~20 generate/min) self-throttled mid-openings.
-    expect(scaledFreeTierRpm(1)).toBeGreaterThanOrEqual(24);
+  it('the locked K=2 free pool clears a debate opening burst (T≈20 ≤ 24 = scaledFreeTierRpm(2)) (t/3111)', () => {
+    // One key (12) intentionally does NOT clear ~20/min — pool size is the lever; the
+    // paid fallback (generateWithPaidFallback) catches rare bursts above 24.
+    expect(scaledFreeTierRpm(2)).toBeGreaterThanOrEqual(24);
+    expect(scaledFreeTierRpm(1)).toBeLessThan(20);
   });
 
   it('resolveTier applies the scaled RPM for keyless free-tier users', () => {
     process.env.FREE_TIER_GEMINI_KEY = 'k1,k2';
-    expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(30); // 24×2 → capped
+    expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(24); // 12×2, under the cap
     process.env.FREE_TIER_GEMINI_KEY = 'k1';
-    expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(24);
+    expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(12);
     process.env.FREE_TIER_GEMINI_KEY = 'k1,k2,k3,k4,k5,k6,k7';
     expect(resolveTier('', 'github').limits.requestsPerMinute).toBe(30); // capped
   });
@@ -76,7 +81,7 @@ describe('free tier (t/793)', () => {
     expect(tier.pinnedModel).toBe('gemini-3.5-flash-lite'); // = DEFAULT_MODEL (t/2687)
     // t/812: no per-prompt char cap — cost is bounded by tokensPerDay + per-IP RPM.
     expect(tier.maxPromptChars).toBeUndefined();
-    expect(tier.limits).toEqual({ requestsPerMinute: 24, tokensPerDay: 500_000 }); // t/3104: 6→24 (single-key debate burst)
+    expect(tier.limits).toEqual({ requestsPerMinute: 12, tokensPerDay: 500_000 }); // t/3111: 24→12 (free-tier-safe per-key; pool size K=2 clears the burst)
     expect(tier.allowedBackends).toEqual(['gemini']);
   });
 

--- a/taxonomy-editor/src/server/__tests__/paidFallbackOrdering.test.ts
+++ b/taxonomy-editor/src/server/__tests__/paidFallbackOrdering.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3111 — generateWithPaidFallback ordering + paid-fired signal.
+// Verifies the free-pool-primary / paid-overflow shape (t/948): the free pool (explicitKey)
+// is ALWAYS tried first; the paid key is reached ONLY on a free-tier 429, and never enters
+// the primary call. Also asserts the `ai.fallback` "paid fired" signal.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockGenerateTextByUsage, mockIs429, mockGetPaidKey, frRecords, mockRecorder } = vi.hoisted(() => {
+  const frRecords: Array<Record<string, unknown>> = [];
+  return {
+    mockGenerateTextByUsage: vi.fn(),
+    mockIs429: vi.fn(),
+    mockGetPaidKey: vi.fn(),
+    frRecords,
+    mockRecorder: { record: vi.fn((r: Record<string, unknown>) => { frRecords.push(r); }) },
+  };
+});
+
+vi.mock('../ai/aiBackends.js', () => ({
+  generateTextByUsage: mockGenerateTextByUsage,
+  is429Error: mockIs429,
+  generateText: vi.fn(),
+}));
+
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return { ...actual, getPaidGeminiFallbackKey: mockGetPaidKey };
+});
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => mockRecorder,
+  setGlobalRecorder: vi.fn(),
+}));
+
+import { generateWithPaidFallback } from '../routes/ai.js';
+
+const CTX = { isFree: true, backend: 'gemini' as const, requestModel: 'gemini-3.5-flash-lite', t0: 0 };
+
+describe('generateWithPaidFallback — free-primary / paid-overflow ordering (t/3111)', () => {
+  beforeEach(() => {
+    frRecords.length = 0;
+    mockGenerateTextByUsage.mockReset();
+    mockIs429.mockReset();
+    mockGetPaidKey.mockReset();
+    mockRecorder.record.mockClear();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('free pool succeeds → returns result, paid key never consulted (no fallback)', async () => {
+    mockGenerateTextByUsage.mockResolvedValueOnce({ text: 'ok' });
+    const out = await generateWithPaidFallback('p', {}, ['free1', 'free2'], CTX);
+    expect(out).toEqual({ text: 'ok' });
+    expect(mockGetPaidKey).not.toHaveBeenCalled();          // paid never reached on success
+    expect(mockGenerateTextByUsage).toHaveBeenCalledTimes(1);
+    // First (only) call used the FREE pool key, not a paid key.
+    expect(mockGenerateTextByUsage.mock.calls[0][4]).toEqual(['free1', 'free2']);
+    expect(frRecords.some(r => r.type === 'ai.fallback')).toBe(false);
+  });
+
+  it('non-429 error → rethrows, paid fallback NOT triggered (ordering: paid only on 429)', async () => {
+    const err = new Error('boom');
+    mockGenerateTextByUsage.mockRejectedValueOnce(err);
+    mockIs429.mockReturnValue(false);
+    await expect(generateWithPaidFallback('p', {}, ['free1'], CTX)).rejects.toThrow('boom');
+    expect(mockGetPaidKey).not.toHaveBeenCalled();
+    expect(mockGenerateTextByUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it('free-tier 429 but no paid key configured → rethrows original 429 (no fallback)', async () => {
+    const err = Object.assign(new Error('429'), { status: 429 });
+    mockGenerateTextByUsage.mockRejectedValueOnce(err);
+    mockIs429.mockReturnValue(true);
+    mockGetPaidKey.mockResolvedValue(null);
+    await expect(generateWithPaidFallback('p', {}, ['free1'], CTX)).rejects.toThrow('429');
+    expect(mockGenerateTextByUsage).toHaveBeenCalledTimes(1); // no paid retry
+  });
+
+  it('free-tier 429 + paid key → paid fallback fires ONCE with the paid key + records the signal', async () => {
+    vi.useFakeTimers();
+    const err = Object.assign(new Error('429'), { status: 429 });
+    mockGenerateTextByUsage
+      .mockRejectedValueOnce(err)                 // free pool exhausts
+      .mockResolvedValueOnce({ text: 'paid-ok' }); // paid retry succeeds
+    mockIs429.mockReturnValue(true);
+    mockGetPaidKey.mockResolvedValue('paid-key');
+
+    const p = generateWithPaidFallback('p', {}, ['free1', 'free2'], CTX);
+    await vi.advanceTimersByTimeAsync(3000); // the deliberate 3s throttle
+    const out = await p;
+
+    expect(out).toEqual({ text: 'paid-ok' });
+    expect(mockGenerateTextByUsage).toHaveBeenCalledTimes(2);
+    // Ordering: call 1 = FREE pool; call 2 = PAID key (paid never in the primary/rotation).
+    expect(mockGenerateTextByUsage.mock.calls[0][4]).toEqual(['free1', 'free2']);
+    expect(mockGenerateTextByUsage.mock.calls[0][0]).toBe('server.chat-response');
+    expect(mockGenerateTextByUsage.mock.calls[1][4]).toBe('paid-key');
+    expect(mockGenerateTextByUsage.mock.calls[1][0]).toBe('server.chat-response:paid-fallback');
+    // Paid-fired signal recorded.
+    const fired = frRecords.find(r => r.type === 'ai.fallback');
+    expect(fired).toBeDefined();
+    expect((fired!.data as Record<string, unknown>).fallback).toBe('paid');
+  });
+});

--- a/taxonomy-editor/src/server/ai/proxyTiers.ts
+++ b/taxonomy-editor/src/server/ai/proxyTiers.ts
@@ -185,13 +185,16 @@ export function byokGeminiFallbackKey(
 }
 
 /** Per-Gemini-key free-tier RPM — single source of truth (also used by keyRotator.ts).
- * t/3104: raised 6→24. A single debate's opening burst peaks at T≈20 generate/min
- * (title + topic-critique + 3 openings + inline verify + search); at 6 RPM one debate
- * self-throttled mid-openings with a front-door per_ip_rpm 429. 24 ≈ 1.2·T (demand
- * margin) and sits far under the key project's upstream ceiling (Tier-2 = 10,000 RPM,
- * so 0.8·P ≈ 8,000 — no upstream-429 risk). Per-IP daily cost stays bounded by the
- * unchanged tokensPerDay budget; this only widens the per-minute burst, not daily spend. */
-export const FREE_TIER_RPM_PER_KEY = 24;
+ * t/3111: reverted 24→12. The t/3104 raise to 24 was sized against a *paid* Tier-2 key
+ * (10k RPM ceiling), which was the wrong shape — the anon pool should be FREE keys as
+ * primary with a single paid key as overflow-only fallback (generateWithPaidFallback,
+ * t/948). On a real free key the upstream ceiling is P_free≈15 RPM (firm, AI Studio),
+ * so 24 (> 0.8·P=12) would trip an UPSTREAM Gemini 429. 12 = 0.8·15 stays safe, and the
+ * debate's ~20/min burst is cleared by POOL SIZE: with K=2 free keys, front-door =
+ * min(12×2, 30) = 24 ≥ 1.2·T. The paid fallback catches rare >24 bursts. (TL-locked
+ * V=12/K=2, p/542.) Scale to a 3rd free key only if the paid-overflow alert (t/3110)
+ * shows frequent paid hits — data-driven, not now. */
+export const FREE_TIER_RPM_PER_KEY = 12;
 
 /**
  * Per-IP RPM for LOCAL embedding + NLI ops (ONNX / Python encoder — zero Gemini quota).

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -158,7 +158,9 @@ export function shouldAbortOnClientClose(finished: boolean, responseEnded: boole
  *  free pool exhausted, retry ONCE with the admin-registered paid Gemini key after a
  *  deliberate 3s throttle (t/948). Re-throws the original error when there's no paid
  *  path or the paid retry also fails. The paid key never enters the round-robin pool. */
-async function generateWithPaidFallback(
+// Exported for the t/3111 fallback-ordering test (free pool tried first; paid reached
+// ONLY on a free-tier 429; paid never in the rotation). Otherwise an internal helper.
+export async function generateWithPaidFallback(
   prompt: string,
   usageOverrides: Record<string, unknown>,
   explicitKey: string | string[] | undefined,


### PR DESCRIPTION
## Summary

Reverts `FREE_TIER_RPM_PER_KEY` 24→12 (`proxyTiers.ts:188`), correcting the t/3104 shape per the owner-directed redesign (t/3111, TL-approved p/542).

## Why

The 6→24 raise was sized against a **paid** Tier-2 key (10k RPM). The anon pool should be **free keys primary + a single paid key as overflow-only fallback** — which already exists via `generateWithPaidFallback` (t/948). On a real free key the upstream ceiling is **P_free≈15 RPM** (firm, AI Studio), so V=24 (> 0.8·P=12) would trip an **upstream** Gemini 429. **V=12 = 0.8·15** is safe; the ~20/min debate burst is cleared by **pool size**: K=2 free keys → `min(12×2, 30) = 24 ≥ 1.2·T`. Paid fallback catches rare >24 bursts.

## ⚠️ Deploy ordering (DevOps holds this)

Merging to main is safe, but **do NOT deploy main until the free-key pool is provisioned + the config swap lands**. With V=12 on the *current* single **paid** key, `min(12×1,30)=12 < 20` → anon debates would 429 again. The deploy folds V=12 + the config swap (`FREE_TIER_GEMINI_KEY` → 2 distinct free-project keys; paid key → `GEMINI_PAID_KEY`, already read by `getPaidGeminiFallbackKey` — no code change) + the /readyz gate (#1635). DevOps is holding the deploy for exactly this.

## Tests

`freeTier.test.ts` (21/21) — V=12: `scaledFreeTierRpm(1)=12, (2)=24, (3)=30`; `resolveTier` 1→12/2→24/7→30; free limits `rpm=12`; **K=2 clears the burst, K=1 does not** (pool-size lever).

## Follow-up (this branch)

`generateWithPaidFallback` ordering + paid-fired-signal test per TL — needs exporting the internal fn + `aiBackends` module mocks; adding as a companion commit. The resolver itself is already covered (`paidGeminiFallback.test.ts`); the ordering is pre-existing t/948 behavior unchanged by this PR.

## Gate

Gate-touching (limits/cost) → **Main (TL) for Gate Verification**. Not self-merging. Closes the ServerAPI half of t/3111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)