### PR TITLE
fix(devops): add --enable-file-backup-request-intent to freshness gate OAuth (t/3091)

### DIFF
--- a/operations/devops/Invoke-ShareFreshnessGateCheck.ps1
+++ b/operations/devops/Invoke-ShareFreshnessGateCheck.ps1
@@ -38,7 +38,7 @@ $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'ShareFreshnessPredicate.ps1')
 
 $authArgs = if ($StorageKey) { @('--account-key', $StorageKey) }
-            else             { @('--auth-mode', 'login') }
+            else             { @('--auth-mode', 'login', '--enable-file-backup-request-intent') }
 
 # ── Download seed-manifest.json ──────────────────────────────────────────────
 $tmp = [IO.Path]::GetTempFileName()


### PR DESCRIPTION
## Summary
- Azure File Share requires `--enable-file-backup-request-intent` when using `--auth-mode login` for `az storage file` commands
- Without it, the gate exits before running the predicate (first real-env cycle exposed this — deploy run 33136196457)
- Warn-only, so deploy completed unaffected

## Change
One-line fix in `Invoke-ShareFreshnessGateCheck.ps1`: add the flag to `$authArgs` for the login auth path.

## Test plan
- [ ] CI green
- [ ] Next deploy shows "Share freshness gate passed" instead of the OAuth error warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01MiB6s5mCbCXbkWrQ8AjHXT