### PR TITLE
chore(smoke): calibrate embedding-probe ceiling against real post-t/3085 prod numbers (t/3088)

### DIFF
--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -91,8 +91,16 @@ function Invoke-TaxEditorSmokeTest {
         [switch]$AssertDataPresence,
 
         # t/3088 — wall-time ceiling (seconds) for the embedding-latency perf probe.
-        # The cache-hit path is well under 1s post-t/3085; a regressed cache re-embeds
-        # in-process at 25-48s/chunk. Over this ceiling the probe reports `degraded`.
+        # Calibrated against real prod post-t/3085 numbers (Diagnostics verify, deploy-64c7772):
+        #   cache-HIT embeddings.compute is <200ms server-side (1ms pure hit / 183ms warm max
+        #   incl. ~4 genuine dynamic-text misses); a regressed cache-MISS runs 24-56s (some
+        #   500-ing at the 50s ONNX-init timeout) — a ~130x gap.
+        # 2s = ~11x headroom over the warm max (safe for client-side network variance and the
+        # thin n=2 sample) and ~12x below the miss floor, so it catches the regression with
+        # margin without false-warning on normal jitter. Deliberately NOT set below ~1s: a
+        # request landing on a cold revision before prewarm completes transiently recomputes
+        # (the 24-56s spikes; t/3112 /readyz will gate this), so the category stays WARN-FIRST
+        # (excluded from OverallPass) — a breach is a monitoring signal, not a hard failure.
         [Parameter()]
         [ValidateRange(0.1, 60)]
         [double]$EmbeddingCeilingSec = 2


### PR DESCRIPTION
**t/3088 follow-up #2 — ceiling calibration** (the piece PS2's #1627 left as "tune when the real number lands").

Diagnostics' post-fix verify (deploy-64c7772, Log Analytics via `Get-TaxEditorServerLogs`) measured:
- cache-**HIT** `embeddings.compute`: **<200ms** server-side (1ms pure hit / 183ms warm max incl. ~4 genuine dynamic-text misses)
- regressed cache-**MISS**: **24–56s** (some 500-ing at the 50s ONNX-init timeout)

→ a **~130× gap**. Conclusion: the shipped **2s** default is correct, now **data-backed** rather than provisional. 2s = ~11× headroom over the warm max (safe for client-side network variance + the thin n=2 sample) and ~12× below the miss floor. Deliberately **not** tighter than ~1s: a request landing on a cold revision before prewarm completes transiently recomputes (t/3112 `/readyz` will gate that), so the category stays **warn-first**.

**Comment-only** — value and behavior unchanged; converts the inline rationale from the ticket's suggestion to the real prod numbers. EmbeddingLatency tests **10/10**, manifest clean.

**Gating-promotion** (warn-first → blocking) is intentionally **not** in this PR — it's a gate-touching change routed to TL Gate Verification; recommending warn-first stays (cold-revision transients must warn, not fail).

Self-cert /trivial-change (comment-only, no behavior/schema change). Refs t/3088; co-authored PS2 (probe) + Diagnostics (numbers).