### PR TITLE
docs(server): note twin count-guards at PUBLIC_EXACT_PATHS (t/3112 follow-up)

### DIFF
--- a/taxonomy-editor/src/server/publicPaths.ts
+++ b/taxonomy-editor/src/server/publicPaths.ts
@@ -14,7 +14,11 @@
  * Watch the flip pair: `/sw.js` is EXACT, `/workbox-` is a PREFIX.
  */
 
-/** Exact-match public paths (were `urlPath === X`). */
+/** Exact-match public paths (were `urlPath === X`).
+ *  ⚠️ Adding/removing an entry trips TWO count-guards — update BOTH or CI goes red
+ *  (t/3112): `publicPaths.test.ts` (PUBLIC_EXACT_PATHS.size + samples.length) AND, if the
+ *  path is also a new route, `routeTable.test.ts` (route count + snapshot). Missing the
+ *  twin is an easy slip — the /readyz add caught the routeTable count but missed this one. */
 export const PUBLIC_EXACT_PATHS: ReadonlySet<string> = new Set<string>([
   '/health',
   '/healthz',


### PR DESCRIPTION
One-line preventive comment at the `PUBLIC_EXACT_PATHS` definition — the edit site — so a future allowlist add doesn't miss the twin count-guard (the recurrence TL flagged, p/542#69).

Adding to the public allowlist trips **both** `publicPaths.test.ts` (size + samples) **and**, for a new route, `routeTable.test.ts` (count + snapshot). The /readyz add caught the routeTable count but missed the publicPaths twin → one red CI cycle. This comment points the next editor at both.

**Self-cert /trivial-change:** comment-only, single file, no behavior change, no new API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)