### PR TITLE
ci(deploy): /readyz embeddings warm-gate — OBSERVE-ONLY (t/3114)

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -496,6 +496,24 @@ jobs:
             Add-Content -Path $env:GITHUB_OUTPUT -Value 'accepted=true'
           }
 
+      - name: Warm-gate observe (/readyz) — OBSERVE-ONLY, does not gate (t/3114, t/2683)
+        id: warm_gate
+        if: steps.health_check.outputs.healthy == 'true'
+        shell: pwsh
+        run: |
+          # t/3114 OBSERVE-ONLY (Gate Promotion t/2683, real-env-first): compute + LOG whether the
+          # new revision's embeddings.json vector-cache is warm (/readyz 200) BEFORE traffic shifts,
+          # but do NOT gate — this step is intentionally absent from every success/rollback
+          # if-condition. It validates real-env warm detection (FQDN resolves, real 503->200, no
+          # false timeout) on >=1 real deploy; a follow-up flip PR then wires it as the peer-blocking
+          # gate (require warm==true to shift; rollback on warm==false) — that wiring is already GV'd
+          # offline (t/3114#3). -ObserveOnly => a warm timeout logs ::warning:: and exits 0 (never
+          # blocks). The printed /readyz body lets us confirm the real 200 is {status:ready}, not the
+          # SPA index.html fallback (ServerAPI p/542#74); the flip couples a body-shape check.
+          $BaseUrl = "${{ steps.health_check.outputs.base_url }}"
+          & ./operations/devops/Invoke-ReadyzWarmGateCheck.ps1 -BaseUrl $BaseUrl -TimeoutSec 300 -PollIntervalSec 10 -ObserveOnly
+          Write-Host "warm-gate observe: /readyz probe complete (observe-only, non-gating)."
+
       - name: Shift traffic to new revision
         if: steps.health_check.outputs.healthy == 'true' && steps.acceptance.outputs.accepted == 'true' && steps.persona.outputs.accepted == 'true'
         shell: pwsh

--- a/operations/devops/Invoke-ReadyzWarmGateCheck.ps1
+++ b/operations/devops/Invoke-ReadyzWarmGateCheck.ps1
@@ -1,0 +1,95 @@
+#Requires -Version 7.0
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Pre-traffic-shift deploy gate (t/3114): block the ACA traffic-shift until the new revision's
+    embeddings.json cache is warm, by polling GET /readyz. Honors root constraint #1 (t/3090#11):
+    no traffic to an un-warmed revision (which would re-embed ~3600 taxonomy texts per debate).
+.DESCRIPTION
+    Polls {BaseUrl}/readyz against the 0%-traffic revision (its own FQDN) every -PollIntervalSec,
+    up to -TimeoutSec, and maps each poll's status via Get-ReadyzGateAction (pure predicate):
+      proceed (200)  -> cache warm; exit 0 (deploy shifts traffic).
+      skip    (404)  -> /readyz ABSENT (image predates the endpoint); warn + exit 0 so the deploy
+                        that first introduces /readyz cannot deadlock on its own not-yet-present
+                        route. ONLY 404/absent is skipped.
+      wait    (else) -> present-but-503 (still warming) or any transient/ambiguous code (incl. a
+                        connection error, treated as code 0): keep polling. A present-503 is NEVER
+                        skipped — it is waited on.
+    On sustained 'wait' past -TimeoutSec: in ENFORCING mode FAIL (exit 1) with an explicit ::error::
+    so a genuinely hung/corrupt warm fails the deploy legibly (existing auto-rollback fires) rather
+    than as a mystery timeout. In -ObserveOnly mode the timeout is a ::warning:: + exit 0 (see below).
+
+    -ObserveOnly (t/2683 Gate Promotion, real-env-first): compute + LOG the warm outcome but NEVER
+    fail — timeout downgrades ::error::->::warning:: and exits 0. Used to validate real-env warm
+    detection (FQDN resolves, real 503->200, no false timeout) on ≥1 real deploy BEFORE the gate is
+    promoted to blocking. In observe mode the caller also does NOT reference the warm output in its
+    success/rollback conditions, so the gate is provably non-blocking.
+
+    Exit codes: 0 = warm OR absent-skip (proceed) OR (-ObserveOnly) timeout;  1 = ENFORCING timeout.
+
+    -TimeoutSec default 300s sizes the observed pre-warm cost: 63MB embeddings.json read from the
+    AzureFiles mount + JSON.parse + cold ONNX warmup (t/3090#10). -PollIntervalSec default 10s.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $BaseUrl,
+    [int] $TimeoutSec      = 300,
+    [int] $PollIntervalSec = 10,
+    [switch] $ObserveOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Pure decision predicate (dot-sourceable; no I/O)
+. (Join-Path $PSScriptRoot 'ReadyzWarmGatePredicate.ps1')
+
+$uri      = "$($BaseUrl.TrimEnd('/'))/readyz"
+$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSec)
+$poll     = 0
+
+Write-Host "Warm-gate: polling $uri (timeout ${TimeoutSec}s, interval ${PollIntervalSec}s) until embeddings.json cache is ready..."
+
+while ($true) {
+    $poll++
+    $status = 0
+    $body   = ''
+    try {
+        $resp   = Invoke-WebRequest -Uri $uri -Method Get -SkipHttpErrorCheck -TimeoutSec 15
+        $status = [int]$resp.StatusCode
+        $body   = ($resp.Content | Out-String).Trim()
+    } catch {
+        # Connection-level failure (server not answering) — treat as 'wait' (transient); the
+        # health_check step already confirmed server-up, so this should be rare and self-clears.
+        $status = 0
+        Write-Host "  poll #${poll}: request error ($($_.Exception.Message)) — treating as warming"
+    }
+
+    $action = Get-ReadyzGateAction -StatusCode $status
+
+    switch ($action) {
+        'proceed' {
+            Write-Host "Warm-gate PASSED after $poll poll(s): /readyz 200 ready — $body"
+            exit 0
+        }
+        'skip' {
+            Write-Host "::warning::Warm-gate SKIPPED: /readyz returned 404 (absent) — this revision's image predates the /readyz endpoint (t/3112/t/3114). Proceeding WITHOUT the embeddings warm-gate for this deploy only."
+            exit 0
+        }
+        default {
+            # 'wait' — present-but-503 (warming) or transient/ambiguous code.
+            if ([DateTime]::UtcNow -ge $deadline) {
+                if ($ObserveOnly) {
+                    Write-Host "::warning::[OBSERVE-ONLY] embeddings pre-warm not ready (/readyz last status=$status) within ${TimeoutSec}s. In ENFORCING mode this would block the traffic-shift and roll back; observe-only logs and proceeds (exit 0) so real-env warm timing can be validated before the gate is promoted to blocking (t/2683). (t/3114)"
+                    exit 0
+                }
+                Write-Host "::error::embeddings pre-warm not ready (/readyz last status=$status) within ${TimeoutSec}s — NOT shifting traffic (root constraint #1). A revision stuck warming past the pre-warm budget (63MB AzureFiles load + JSON.parse + cold ONNX) is failed legibly; rollback restores the previous revision. (t/3114)"
+                exit 1
+            }
+            Write-Host "  poll #${poll}: /readyz status=$status (warming) — waiting ${PollIntervalSec}s..."
+            Start-Sleep -Seconds $PollIntervalSec
+        }
+    }
+}

--- a/operations/devops/ReadyzWarmGatePredicate.ps1
+++ b/operations/devops/ReadyzWarmGatePredicate.ps1
@@ -1,0 +1,43 @@
+#Requires -Version 7.0
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Pure decision predicate for the /readyz deploy warm-gate (t/3114). No I/O — dot-sourceable + unit-testable.
+.DESCRIPTION
+    Maps a single /readyz poll's HTTP status code to the deploy gate's per-poll action. The
+    caller (Invoke-ReadyzWarmGateCheck.ps1) loops on 'wait' until 200 or a bounded timeout.
+
+    Contract (taxonomy-editor/src/server/routes/meta.ts, t/3112):
+      200  {status:'ready',   nodeCount>0}  -> embeddings.json cache warm.
+      503  {status:'warming', ...}          -> cache still loading.
+      404  (route ABSENT)                   -> image predates /readyz (old revision).
+
+    Gate semantics (TL GV-preview p/542#65):
+      - 200            -> 'proceed'  (cache warm; shift traffic).
+      - 404            -> 'skip'     (endpoint ABSENT; the deploy that first introduces
+                                      /readyz must not deadlock on its own not-yet-present
+                                      route — proceed WITHOUT the gate, warn).
+      - anything else  -> 'wait'     (present-but-503, or any ambiguous/transient code; the
+        (incl. 503)                   loop keeps polling and, on sustained 'wait' past the
+                                      timeout, FAILS the deploy legibly). A present-503 is
+                                      NEVER skipped — only an explicit 404/absent is.
+
+    Deliberately conservative: ONLY 404 short-circuits to 'skip'. Every non-200/404 code
+    waits, so an un-warmed (503) or anomalous revision blocks the traffic-shift rather than
+    silently shipping a re-embed-storm revision (root constraint #1, t/3090#11).
+#>
+
+function Get-ReadyzGateAction {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)] [int] $StatusCode
+    )
+    switch ($StatusCode) {
+        200     { 'proceed'; break }
+        404     { 'skip';    break }
+        default { 'wait' }
+    }
+}

--- a/tests/ReadyzWarmGate.Tests.ps1
+++ b/tests/ReadyzWarmGate.Tests.ps1
@@ -1,0 +1,100 @@
+# Tests for the /readyz deploy warm-gate (t/3114).
+# Part 1 exercises the pure Get-ReadyzGateAction predicate (no I/O).
+# Part 2 exercises Invoke-ReadyzWarmGateCheck.ps1's polling loop with mocked HTTP —
+# the four gate arms TL GV requires: proceed(200), skip(404), wait-then-proceed(503->200),
+# timeout-fail(sustained 503).
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+BeforeAll {
+    $DevOpsDir  = Join-Path $PSScriptRoot '..' 'operations' 'devops'
+    . (Join-Path $DevOpsDir 'ReadyzWarmGatePredicate.ps1')
+    $script:ScriptPath = Join-Path $DevOpsDir 'Invoke-ReadyzWarmGateCheck.ps1'
+}
+
+Describe 'Get-ReadyzGateAction (pure predicate)' -Tag 'unit' {
+    It '200 -> proceed (cache warm)' {
+        Get-ReadyzGateAction -StatusCode 200 | Should -Be 'proceed'
+    }
+    It '404 -> skip (endpoint absent; only 404 short-circuits)' {
+        Get-ReadyzGateAction -StatusCode 404 | Should -Be 'skip'
+    }
+    It '503 -> wait (present-but-warming; NEVER skipped)' {
+        Get-ReadyzGateAction -StatusCode 503 | Should -Be 'wait'
+    }
+    It 'Ambiguous/transient codes -> wait (conservative: do not skip on anything but 404)' {
+        Get-ReadyzGateAction -StatusCode 500 | Should -Be 'wait'
+        Get-ReadyzGateAction -StatusCode 200 | Should -Not -Be 'wait'
+        Get-ReadyzGateAction -StatusCode 0   | Should -Be 'wait'   # connection error sentinel
+        Get-ReadyzGateAction -StatusCode 429 | Should -Be 'wait'
+    }
+}
+
+Describe 'Invoke-ReadyzWarmGateCheck.ps1 (polling arms)' -Tag 'unit' {
+
+    BeforeEach {
+        Mock Start-Sleep { }   # never actually sleep
+    }
+
+    It 'PROCEED: /readyz 200 on first poll -> exit 0' {
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200; Content = '{"status":"ready","nodeCount":4144}' } }
+        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 300 -PollIntervalSec 0 *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match 'Warm-gate PASSED'
+    }
+
+    It 'SKIP: /readyz 404 (absent) -> exit 0 + warning (no deadlock on introducing deploy)' {
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 404; Content = 'Not Found' } }
+        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 300 -PollIntervalSec 0 *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match '::warning::Warm-gate SKIPPED'
+        $out | Should -Match '404'
+    }
+
+    It 'WAIT-THEN-PROCEED: 503 then 200 -> waits, then exit 0 (present-503 is waited on, not skipped)' {
+        # $global: (not $script:) — the mock body runs inside the &-invoked script's scope, which
+        # has Set-StrictMode -Version Latest; an undefined $script:calls there would throw (read as
+        # a connection error by the script's catch) and loop to timeout. $global: initialized to 0
+        # is StrictMode-safe and visible across the invoked-script scope.
+        $global:readyzCalls = 0
+        Mock Invoke-WebRequest {
+            $global:readyzCalls++
+            if ($global:readyzCalls -lt 3) { [pscustomobject]@{ StatusCode = 503; Content = '{"status":"warming"}' } }
+            else                            { [pscustomobject]@{ StatusCode = 200; Content = '{"status":"ready","nodeCount":4144}' } }
+        }
+        try {
+            $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 30 -PollIntervalSec 0 *>&1 | Out-String
+            $LASTEXITCODE | Should -Be 0
+            $out | Should -Match 'Warm-gate PASSED after 3 poll'
+            $global:readyzCalls | Should -Be 3
+        } finally {
+            Remove-Variable -Name readyzCalls -Scope Global -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'TIMEOUT-FAIL: sustained 503 past timeout -> exit 1 + explicit error (blocks traffic shift)' {
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 503; Content = '{"status":"warming"}' } }
+        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 1
+        $out | Should -Match '::error::embeddings pre-warm not ready'
+        $out | Should -Match 'within 0s'
+    }
+
+    It 'TIMEOUT-FAIL: connection error treated as warming, still fails closed (never silently skips)' {
+        Mock Invoke-WebRequest { throw 'connection refused' }
+        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 1
+        $out | Should -Match '::error::embeddings pre-warm not ready'
+    }
+
+    It 'OBSERVE-ONLY: sustained 503 past timeout -> exit 0 + ::warning:: (logs, never blocks)' {
+        # t/2683 real-env-first: the observe-only ship must NOT fail the deploy on a warm timeout;
+        # it only logs, so real-env warm detection can be validated before the gate is promoted.
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 503; Content = '{"status":"warming"}' } }
+        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 -ObserveOnly *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -Match '::warning::\[OBSERVE-ONLY\] embeddings pre-warm not ready'
+    }
+}


### PR DESCRIPTION
## What (OBSERVE-ONLY)

Adds a **non-gating** `/readyz` warm-gate observation to the prod deploy. It polls the new revision's `GET /readyz` (t/3112, #1635) and **LOGS** whether the `embeddings.json` vector-cache is warm before the traffic-shift — but does **not** gate anything.

Per Gate Promotion (t/2683, real-env-first), a new blocking deploy gate can't go live on mocks alone. This ships observe-only to validate real-env warm detection (FQDN resolves, real 503→200, no false timeout) on **≥1 real deploy** (the t/3111 free-pool deploy). A follow-up **flip PR** then promotes it to blocking. Implements t/3114 (GV'd offline, t/3114#3).

## Diff in this PR

- **`operations/devops/ReadyzWarmGatePredicate.ps1`** — pure status→action predicate (`200→proceed`, `404→skip`, else→`wait`).
- **`operations/devops/Invoke-ReadyzWarmGateCheck.ps1`** — bounded poll (default 300s). `-ObserveOnly` ⇒ a warm timeout logs `::warning::` + exits 0 (never blocks); enforcing mode (`::error::`+exit 1) is retained for the flip.
- **`deploy-azure.yml`** — a **single new `warm_gate` step** (observe-only, `-ObserveOnly`), intentionally **absent from every success/rollback if-condition** so it is provably non-gating. **No condition changes** in this PR (verified: diff vs main is only the added step; YAML validated).
- **`tests/ReadyzWarmGate.Tests.ps1`** — **10 Pester tests, all green**: predicate + poll arms (proceed / 404-skip / 503→200 / sustained-503 enforce-fail / connection-error / observe-only-timeout).

## Merge

Safe to merge on green — it does not gate. Real-env evidence rides the next real deploy (t/3111).

## Promotion flip (separate PR → TL GV) — design locked (p/542 #73–#87)

- Predicate becomes **proceed iff `200` AND JSON-parsed body `.status -eq 'ready'`** (parse, never substring/regex — tolerant to field-order/whitespace/added-fields, per ServerAPI #86 / TL #87). **ELSE → wait→block** (404, 200-index SPA-fallback, sustained-503, conn-error all block). **Skip branch dropped** — the gate only ever polls forward images (all carry `/readyz`); revision-revert bypasses the gate.
- Re-adds `warm_gate.outputs.warm` as a **peer of acceptance/persona** across the 7 deploy conditions (the wiring GV'd offline here).
- **Shared fixture** links the gate's expected body to the handler's real 200 shape (`{"status":"ready","nodeCount":N}`) so a coordinated rename becomes a red test, not a block-every-deploy outage. ServerAPI supplies the fixture + a `/readyz` SPA-fallback exclusion (optional hygiene). Pester asserts against the real handler body.
- Carries the t/3111 real-env evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
