### PR TITLE
ci(dependabot): consolidate lockfile-less pnpm-workspace members under root entry (t/3116)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,33 +31,25 @@ updates:
       - dependency-name: undici
         update-types: [version-update:semver-major]
 
-  - package-ecosystem: npm
-    directory: /workflow-app
-    schedule:
-      interval: weekly
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
-    open-pull-requests-limit: 2
-
-  - package-ecosystem: npm
-    directory: /poviewer
-    schedule:
-      interval: weekly
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
-    open-pull-requests-limit: 2
-
-  - package-ecosystem: npm
-    directory: /summary-viewer
-    schedule:
-      interval: weekly
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
-    open-pull-requests-limit: 2
-
+  # ── npm workspace ROOT — owns the pnpm workspace's lockfile-less members ──
+  # poviewer / summary-viewer / workflow-app / lib are pnpm-WORKSPACE members
+  # (pnpm-workspace.yaml) with NO in-dir lockfile — they share the ONE root
+  # pnpm-lock.yaml. A per-app `directory:` entry bumps only that member's
+  # package.json and can't reach the root lockfile, so `pnpm install
+  # --frozen-lockfile` reds with ERR_PNPM_OUTDATED_LOCKFILE before build/test
+  # ever runs (t/3116; surfaced by electron 43→44 #1645/#1648/#1649). A single
+  # workspace ROOT entry updates member manifests + the shared root lockfile in
+  # the SAME PR, so frozen-install stays green. Do NOT re-add per-app entries
+  # for these four members.
+  #
+  # taxonomy-editor + lib/debate are ALSO workspace members but keep their own
+  # entries (above/below): each carries an in-dir STANDALONE lockfile (Docker /
+  # isolated build, synced via scripts/sync-standalone-lockfile.mjs +
+  # lockfile-overrides-check, t/2188) that Dependabot updates correctly per
+  # directory. WATCH-ITEM (t/3116): confirm the first post-merge Dependabot
+  # cycle does not ALSO emit workspace-root PRs for those two (double-manage);
+  # if it does, add per-dependency ignores here. Fallback if root-lockfile
+  # regen proves unreliable: a lockfile-heal step on member PRs (t/3116 opt B).
   - package-ecosystem: npm
     directory: /
     schedule:
@@ -65,16 +57,7 @@ updates:
     groups:
       minor-and-patch:
         update-types: [minor, patch]
-    open-pull-requests-limit: 2
-
-  - package-ecosystem: npm
-    directory: /lib
-    schedule:
-      interval: weekly
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 4
 
   - package-ecosystem: npm
     directory: /lib/debate


### PR DESCRIPTION
## Problem (t/3116)

`poviewer`, `summary-viewer`, `workflow-app`, and `lib` are **pnpm-workspace members** (`pnpm-workspace.yaml`) with **no in-dir lockfile** — they share the ONE root `pnpm-lock.yaml`. Each had its own Dependabot `directory:` entry that bumps only the member `package.json` and cannot reach the root lockfile, so `pnpm install --frozen-lockfile` reds with `ERR_PNPM_OUTDATED_LOCKFILE` **before build/test runs**. Surfaced by the electron 43→44 majors (#1645/#1648/#1649); recurs on every member bump.

## Fix (A-scoped, TL-approved t/3116#2)

- Remove the 4 lockfile-less per-app npm entries (`/lib`, `/poviewer`, `/summary-viewer`, `/workflow-app`).
- The workspace **root `/`** npm entry now owns them — Dependabot updates member manifests + the shared root lockfile in the **same PR**, so frozen-install stays green.
- **Keep** `/taxonomy-editor` and `/lib/debate` entries: each has an in-dir **standalone** lockfile Dependabot updates correctly per-directory (dual-lockfile, t/2188).
- Root open-PR limit 2→4 to absorb the now-consolidated members' majors.

Net: npm entries `[/taxonomy-editor, /, /lib/debate, /deploy/azure/runner/function]`. YAML validated (parses, 8 update entries).

## Gate Verification (both arms)

- **Stale = RED (today):** member bump → stale root lockfile → `ERR_PNPM_OUTDATED_LOCKFILE`. Demonstrated by the 9 failing jobs on #1645/#1648/#1649.
- **Regen = GREEN (clean arm):** regenerated the root lockfile for the real workflow-app E44 bump (`pnpm install --lockfile-only`, minimal 15+/2- diff, `lockfileVersion` unchanged) and pushed to #1645 → CI runs the real E44 build/smoke. Independent corroboration: SummaryViewer regenerated the root lockfile on #1648 → E44 build clean, 28/28 tests green, UI rendered, zero console errors (2e7e4af5).

## Inherent limitation + mitigation

Dependabot's live PR-generation for the workspace can only be confirmed **post-merge** (can't force a live run offline). Per TL: merge on offline both-arms, then **watch the first post-merge Dependabot cycle** as live confirmation, with **option B (lockfile-heal step)** armed as fallback. WATCH-ITEM documented inline in the config: confirm the root entry does not *also* emit workspace-root PRs for the two standalone-lockfile members (double-management).

**Held as draft pending TL Gate Verification.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iv1toUh9SurtepKUd8hpG