### PR TITLE
fix(diagnostics): Get-TaxEditorServerLogs -From/-To window silently ignored — use todatetime() (t/3117)

### DIFF
--- a/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
+++ b/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
@@ -143,7 +143,11 @@ function Get-TaxEditorServerLogs {
         $kql = [System.Collections.Generic.List[string]]::new()
         $kql.Add($table)
         $kql.Add("| where ContainerAppName_s == '$(& $esc $App)'")
-        $kql.Add("| where TimeGenerated between (datetime('$fromZ') .. datetime('$toZ'))")
+        # t/3117: MUST be todatetime('<iso>'), NOT datetime('<iso>'). KQL's datetime() literal is
+        # unquoted (datetime(2026-08-28T…)); wrapping a QUOTED string in datetime() silently fails to
+        # constrain the `between`, so the query returns full Log Analytics retention (116K rows, timeout)
+        # AND leaks out-of-window rows into results. todatetime() is the string→datetime conversion fn.
+        $kql.Add("| where TimeGenerated between (todatetime('$fromZ') .. todatetime('$toZ'))")
 
         if ($RequestId) {
             if ($System) {

--- a/tests/Get-TaxEditorServerLogs.Tests.ps1
+++ b/tests/Get-TaxEditorServerLogs.Tests.ps1
@@ -73,6 +73,11 @@ Describe 'Get-TaxEditorServerLogs' -Tag 'diagnostics' {
             $script:capturedKql | Should -Match "ContainerAppName_s == 'taxonomy-editor'"
             $script:capturedKql | Should -Match "Log_s has 'req-abc'"
             $script:capturedKql | Should -Match "Log_s contains 'GEMINI'"
+            # t/3117 regression guard: the window bound MUST use todatetime('<iso>'); the KQL
+            # datetime() literal wrapped around a quoted string silently no-ops the filter
+            # (returns full retention + out-of-window rows).
+            $script:capturedKql | Should -Match "TimeGenerated between \(todatetime\('"
+            $script:capturedKql | Should -Not -Match "between \(datetime\('"
         }
     }
 


### PR DESCRIPTION
**HIGH bug** (reported by Diagnostics, found during the t/3088 calibration pull).

`Get-TaxEditorServerLogs`'s time-window filter emitted `datetime('<iso>')` — a **quoted string inside KQL's `datetime()` literal** (which is unquoted, e.g. `datetime(2026-08-28T…)`). The malformed bound doesn't constrain the `between`, so **every windowed call returned full Log Analytics retention** (repro: an 8/28 `-From` returned rows from 8/19 — 116,930 rows, 2-min timeout) **and leaked out-of-window rows into results**.

**Impact:** silent wrong data. It corrupted the t/3088 calibration pull — pre-fix 24–56s cache-miss samples from old revisions bled into what should have been a post-fix window; a naive p95 came out 56503ms vs the real ≤183ms, caught only by manual per-revision separation.

**Fix:** `todatetime('<iso>')` (the string→datetime conversion fn). `-RequestId`/`-Pattern` are separate `where` clauses and were unaffected.

**Prevention** (failure class: *silent-filter-noop* — query returns a superset, not an error): the KQL-construction test now asserts the window bound uses `todatetime('` and **not** `between (datetime('`.

Tests 8/8, manifest clean. Self-cert bugfix (single-behavior correction + regression test; no new API/schema). Closes t/3117.