### PR TITLE
fix(diagnostics): Get-TaxEditorServerLogs window — pass single-line KQL to az (t/3117, real fix)

### DIFF
--- a/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
+++ b/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
@@ -169,8 +169,14 @@ function Get-TaxEditorServerLogs {
         else         { $kql.Add('| project TimeGenerated, Log_s, RevisionName_s') }
         $kql.Add('| order by TimeGenerated asc')
         $kql.Add("| take $Max")
-        $analyticsQuery = $kql -join "`n"
-        Write-Verbose "KQL:`n$analyticsQuery"
+        # t/3117: MUST be a SINGLE LINE (join with space, not newline). The query is passed inline
+        # as one `--analytics-query` arg to `& az`; an embedded newline truncates the arg at the
+        # PowerShell→az native-command boundary, so az receives only the first line
+        # (`ContainerAppConsoleLogs_CL`) and dumps the whole table — every where/project/order/take
+        # clause is silently lost (Diagnostics proof: multi-line → 116k full dump; single-line → 3
+        # in-window rows). KQL is whitespace-insensitive between `|` stages, so space-join is valid.
+        $analyticsQuery = $kql -join ' '
+        Write-Verbose "KQL (single-line arg to az): $analyticsQuery"
 
         # ── Run the query ─────────────────────────────────────────────────
         $json = Invoke-Az -CallerName 'Get-TaxEditorServerLogs' -Arguments @(

--- a/tests/Get-TaxEditorServerLogs.Tests.ps1
+++ b/tests/Get-TaxEditorServerLogs.Tests.ps1
@@ -61,9 +61,13 @@ Describe 'Get-TaxEditorServerLogs' -Tag 'diagnostics' {
         InModuleScope AITriad {
             $script:TaxEditorLogWorkspaceId = 'ws-guid-abc'   # pre-seed cache: skip workspace list
             $script:capturedKql = $null
+            $script:capturedQueryArg = $null
             Mock Assert-AzCli { }
             Mock Invoke-Az -ParameterFilter { $Arguments -contains 'query' } -MockWith {
                 $script:capturedKql = ($Arguments -join ' ')
+                # capture the exact --analytics-query value (the single arg az receives)
+                $qi = [array]::IndexOf($Arguments, '--analytics-query')
+                $script:capturedQueryArg = if ($qi -ge 0 -and ($qi + 1) -lt $Arguments.Count) { $Arguments[$qi + 1] } else { $null }
                 '[]'
             }
 
@@ -73,11 +77,18 @@ Describe 'Get-TaxEditorServerLogs' -Tag 'diagnostics' {
             $script:capturedKql | Should -Match "ContainerAppName_s == 'taxonomy-editor'"
             $script:capturedKql | Should -Match "Log_s has 'req-abc'"
             $script:capturedKql | Should -Match "Log_s contains 'GEMINI'"
-            # t/3117 regression guard: the window bound MUST use todatetime('<iso>'); the KQL
-            # datetime() literal wrapped around a quoted string silently no-ops the filter
-            # (returns full retention + out-of-window rows).
-            $script:capturedKql | Should -Match "TimeGenerated between \(todatetime\('"
-            $script:capturedKql | Should -Not -Match "between \(datetime\('"
+            # t/3117 REAL root cause: the query is passed inline as ONE --analytics-query arg to
+            # `& az`; an embedded NEWLINE truncates the arg at the PS→az boundary, so az sees only
+            # the first line and dumps the whole table (where/project/order/take all lost — `take`
+            # returning full retention was the tell). Guard the single-line-transport invariant on
+            # the ACTUAL arg, and confirm the full pipeline survives inside that one arg. A
+            # content-only assertion on the query string can't catch this — the bug is in transport.
+            $script:capturedQueryArg | Should -Not -BeNullOrEmpty
+            $script:capturedQueryArg | Should -Not -Match "`n"                        # single line: no embedded newline
+            $script:capturedQueryArg | Should -Match 'where TimeGenerated between'    # window clause reaches az
+            $script:capturedQueryArg | Should -Match 'take '                          # take survives (the tell)
+            $script:capturedQueryArg | Should -Match "todatetime\('"                  # window bound uses todatetime (valid KQL)
+            $script:capturedQueryArg | Should -Not -Match "between \(datetime\('"     # not the quoted-datetime() literal
         }
     }
 


### PR DESCRIPTION
**HIGH — t/3117 reopened.** The prior fix (#1658, `datetime→todatetime`) was **inert**: the where-clause never reached az.

**Real root cause** (Diagnostics): the KQL was built multi-line (`-join "\n"`) and passed inline as one `--analytics-query` arg to `& az`. The embedded newline **truncates the arg at the PowerShell→az boundary** — az receives only `ContainerAppConsoleLogs_CL` and dumps the whole table; **every** `where`/`project`/`order by`/`take` clause is silently lost.

**Proof** (Diagnostics, direct az, same workspace):
| join form | rows | oldest |
|---|---|---|
| `-join "\n"` (was) | 116,560 (full dump) | out-of-window |
| `-join ' '` (this PR) | 3 | in-window ✓ |

`take 3` returning 116k was the tell — the whole pipeline was gone.

**Fix:** `$analyticsQuery = $kql -join ' '` (KQL is whitespace-insensitive between `|` stages). Kept `todatetime()` (correct now that the clause reaches az). `-Verbose` prints the single-line arg.

**Prevention:** the earlier content-only guard couldn't catch a *transport* bug. New guard captures the actual `--analytics-query` arg and asserts the **single-line invariant** (no embedded newline) + that the full pipeline (`where TimeGenerated` / `take` / `todatetime`) survives in that one arg. Failure class: *silent-filter-noop via arg-transport corruption*.

Tests **8/8**, manifest clean. **NOTE:** unit tests mock the az seam and cannot reproduce the real PS→az truncation — I'm gating **Done on Diagnostics' live re-verify** (narrow `-From` → in-window rows only) after merge, given the prior misdiagnosis. Refs t/3117 (reopened).