### PR TITLE
feat(entities): add description_provenance to the Entity contract (t/3132, prereq for t/3131)

### DIFF
--- a/lib/entities/types.ts
+++ b/lib/entities/types.ts
@@ -65,6 +65,17 @@ export type DolceCategory =
   | 'agentive-physical-object' | 'non-agentive-functional-artifact'
   | 'perdurant' | 'normative-description' | 'non-agentive-social-object';
 
+/**
+ * Provenance of an Entity's `description` (t/3131). Drives the person-approval gate in
+ * Import-Entity: a `person` is approvable only when this is `human-edited`/`human-authored`
+ * (or ABSENT with a non-empty description — grandfathered as human-authored, since the LLM
+ * never drafted person descriptions before t/3131). `ai-drafted` is proposable but NOT
+ * approvable until a human edits it. Any AI-drafting path for a person description MUST stamp
+ * `ai-drafted` at draft time — the grandfather rule (absent ⟺ legacy human-authored) rests
+ * entirely on no un-stamped AI draft ever existing (TL t/3131#2 safety condition).
+ */
+export type EntityDescriptionProvenance = 'ai-drafted' | 'human-edited' | 'human-authored';
+
 /** The new entity record (ent-*), stored in entities.json. */
 export interface Entity {
   id: string;                     // ent-NNN
@@ -72,8 +83,12 @@ export interface Entity {
   aliases: string[];
   entity_type: EntityType;
   dolce_category: DolceCategory;
-  /** Genus-differentia: "A [type] that [differentia]...". Human-authored for `person`. */
+  /** Genus-differentia: "A [type] that [differentia]...". For a `person`, AI may draft it but
+   *  approval requires a human edit — see `description_provenance` and the Import-Entity gate (t/3131). */
   description: string;
+  /** Provenance of `description` — gates person approval (t/3131). Absent = legacy/unset
+   *  (grandfathered as human-authored when the description is non-empty). See {@link EntityDescriptionProvenance}. */
+  description_provenance?: EntityDescriptionProvenance;
   external_refs?: { label: string; url: string }[];
   source_refs?: string[];         // doc_ids
   status: 'proposed' | 'approved' | 'deprecated';

--- a/tests/Entity.Tests.ps1
+++ b/tests/Entity.Tests.ps1
@@ -262,6 +262,9 @@ Describe 'Entity shape parity with lib/entities/types.ts (contract drift gate, T
         $script:RequiredFields | Should -Contain 'id'
         $script:RequiredFields | Should -Contain 'status'
         $script:OptionalFields | Should -Contain 'merged_into'
+        # t/3132: person-approval provenance marker — locks it as a known OPTIONAL contract field
+        # (absent = legacy/grandfathered) so a later removal from the TS Entity interface is caught here.
+        $script:OptionalFields | Should -Contain 'description_provenance'
     }
 
     It 'A record written by Import-Entity satisfies the contract (required present, no forked keys)' {


### PR DESCRIPTION
**t/3132** — the go-first schema prerequisite that unblocks **t/3131**'s person-approval flip. TL-approved design (t/3131#2); routed to you for the PR.

## Why go-first
The Entity drift-parity gate (`Entity.Tests.ps1:228-290`) reds if PowerShell's Import-Entity record writes a key absent from the TS Entity contract — so this field must land **before** the gate change (interface-first, TL t/3131#2 Decision 2).

## Change (19+/1-)
- **`lib/entities/types.ts`**: new named type `EntityDescriptionProvenance = 'ai-drafted' | 'human-edited' | 'human-authored'` + optional `description_provenance?` on `Entity`. Absent = legacy/unset (grandfathered as human-authored when description non-empty). JSDoc documents the TL t/3131#2 **safety invariant**: any AI-drafting path for a person description MUST stamp `ai-drafted` (grandfather rests on absent ⟺ legacy human-authored). Also corrects the outdated "Human-authored for person" comment.
- **`tests/Entity.Tests.ps1`**: parity spot-check locking `description_provenance` as a known optional field (the gate already auto-derives from the interface; this makes a later removal fail loudly).

## Verified
tsc + eslint clean; **parity Pester Describe 5/5 green** (incl. the drift gate accepting the new optional field + the PS record still passing).

## Scope note
**No Zod schema exists for Entity** (verified — interface-only, no zod anywhere; TL p/342#200 confirmed no validator to add). The interface IS the contract the parity gate parses.

Enum confirmed to PowerShell (p/44#60). On merge I ping PowerShell to land the gate+persist (step 2); CL holds the #1663 person import until then (t/3118#6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)