### PR TITLE
chore(eslint): promote local/no-raw-data-root-read warn→error + exit-2 note (t/3113)

### DIFF
--- a/taxonomy-editor/eslint.config.mjs
+++ b/taxonomy-editor/eslint.config.mjs
@@ -109,9 +109,13 @@ export default tseslint.config(
   },
   // ── Block A-dataroot: data-root read gate (t/3093 / t/3087) ──
   // Flags a raw fs read whose path traces to a data-root resolver (the t/3085 migration-remnant
-  // class). Ships as `warn` first; TL promotes to `error` after >=1 green CI cycle.
+  // class). Promoted warn→error after >=1 green CI cycle + the exit-2 precondition was cleared
+  // (t/3109 / t/3113, TL GV p/336#231).
   // tripwire: green != verified — a new hit is a true positive; silence it only with an inline
   // eslint-disable + TL-approved rationale at the call site, never by baselining here.
+  // Lint by DIRECTORY (`eslint src/`, as CI does): an eslint exit-2 carrying "No files matching the
+  // pattern" is a target-resolution error on an explicit file path (typo / mid-rename), NOT a rule
+  // or projectService failure — a directory target never yields it (t/3109).
   {
     files: ['src/server/**/*.ts'],
     ignores: [
@@ -120,7 +124,7 @@ export default tseslint.config(
       'src/server/config.ts',    // defines the resolver functions themselves
     ],
     rules: {
-      'local/no-raw-data-root-read': 'warn',
+      'local/no-raw-data-root-read': 'error',
     },
   },
   // ── Block B: LOC budget for test source (syntactic parse; tests are outside the


### PR DESCRIPTION
## Promote `local/no-raw-data-root-read` warn → error (t/3113)

TL-approved gate promotion (p/392#21/#22; GV **p/336#231**). Closes the t/3093 warn-phase by making the data-root read gate blocking.

### Both preconditions met
- **≥1 green CI cycle** on main since #1633 (rule shipped as `warn`).
- **exit-2 precondition cleared (t/3109):** the intermittent `npx eslint` exit-2 is ESLint's *unmatched-pattern* path (`No files matching the pattern`) on explicit **file** targets against the mid-migration shared tree — **not** a projectService/type-aware crash (27/27 directory-target runs deterministic under memory pressure) and **not** heap OOM (that's exit 134, loud). CI runs `eslint src/` (directory, clean checkout) → **structurally immune**.

### Diff (final state)
Just the severity flip + a co-located note in Block A-dataroot (lint by directory; an exit-2 "No files matching" is a target-resolution error, not a rule failure — t/3109).

### Both arms (validated locally; FIRE arm also shown in CI on this PR)
- **CLEAN:** rule=`error`, no fixture → `eslint src/` **exit 0**, 0 rule hits.
- **FIRE:** a temporary `src/server/__dataroot_fire_fixture__.ts` (raw `fs.readFileSync(getDataRoot())`) → `eslint src/` **exit 1** with exactly `local/no-raw-data-root-read`. I will push that fixture as a follow-up commit to red the lint job **in CI**, then revert it so the final PR diff is flip+note only. The red→green run history is the CI evidence for the GV.

**Gated on TL GV — kept as draft.** Do not merge until the promotion GV is signed off. @Main (Technical Lead).