### PR TITLE
fix(diagnostics): Get-TaxEditorServerLogs Time — parse tz-naive TimeGenerated as UTC (t/3129)

### DIFF
--- a/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
+++ b/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
@@ -196,7 +196,11 @@ function Get-TaxEditorServerLogs {
         $parseTime = {
             param($iso)
             if ([string]::IsNullOrWhiteSpace($iso)) { return $null }
-            try { return [datetimeoffset]::Parse([string]$iso).UtcDateTime } catch { return [string]$iso }
+            # t/3129: Log Analytics TimeGenerated is UTC, but `az --output json | ConvertFrom-Json`
+            # yields a timezone-NAIVE value. A bare Parse() assumes LOCAL time, so on a DST-observing
+            # machine it applies the summer offset then .UtcDateTime subtracts it → Time shifted by the
+            # offset (e.g. 06:42Z shown as 05:42 on BST). AssumeUniversal parses the naive value as UTC.
+            try { return [datetimeoffset]::Parse([string]$iso, $null, [System.Globalization.DateTimeStyles]::AssumeUniversal).UtcDateTime } catch { return [string]$iso }
         }
 
         # ── System logs: emit raw rows, no Pino parse ──────────────────────

--- a/tests/Get-TaxEditorServerLogs.Tests.ps1
+++ b/tests/Get-TaxEditorServerLogs.Tests.ps1
@@ -57,6 +57,41 @@ Describe 'Get-TaxEditorServerLogs' -Tag 'diagnostics' {
         }
     }
 
+    It 'parses tz-naive TimeGenerated as UTC — no DST offset shift (t/3129)' {
+        InModuleScope AITriad {
+            # Force a DST-observing zone so a naive-as-local parse would shift by +1h (BST on 2026-08-31).
+            # $env:TZ + ClearCachedData drives TimeZoneInfo.Local on Linux CI; on a machine that ignores
+            # $env:TZ the assertion still holds for the fixed (AssumeUniversal) code and only the old
+            # local-assume code fails — so this never false-fails, and catches the bug on any DST host.
+            $origTZ = $env:TZ
+            try {
+                $env:TZ = 'Europe/London'
+                [System.TimeZoneInfo]::ClearCachedData()
+
+                $script:TaxEditorLogWorkspaceId = 'ws-guid-abc'
+                Mock Assert-AzCli { }
+                # tz-NAIVE TimeGenerated (no 'Z'/offset), exactly as `az --output json | ConvertFrom-Json` yields.
+                $rows = @(
+                    @{ TimeGenerated = '2026-08-31T06:42:47'; RevisionName_s = 'rev-1'
+                       Log_s = (@{ level = 30; requestId = 'req-tz'; msg = 'hi' } | ConvertTo-Json -Compress) }
+                )
+                $queryJson = $rows | ConvertTo-Json -Depth 6
+                Mock Invoke-Az -ParameterFilter { $Arguments -contains 'query' } -MockWith { $queryJson }.GetNewClosure()
+
+                $r = @(Get-TaxEditorServerLogs -WarningAction SilentlyContinue)
+                $r.Count | Should -Be 1
+                # UTC wall-clock preserved (06:42), NOT shifted to 05:42 by the local +1 DST offset.
+                # $parseTime is shared by the console and -System paths, so this covers both call sites.
+                $r[0].Time.Hour   | Should -Be 6
+                $r[0].Time.Minute | Should -Be 42
+                $r[0].Time.Kind   | Should -Be 'Utc'
+            } finally {
+                $env:TZ = $origTZ
+                [System.TimeZoneInfo]::ClearCachedData()
+            }
+        }
+    }
+
     It 'builds console KQL with the app filter, requestId has-clause, and pattern contains-clause' {
         InModuleScope AITriad {
             $script:TaxEditorLogWorkspaceId = 'ws-guid-abc'   # pre-seed cache: skip workspace list


### PR DESCRIPTION
**Medium bug** (found by Diagnostics while re-verifying t/3117). Display-only — server-side filtering, requestId traces, and duration_ms were unaffected.

Log Analytics `TimeGenerated` is UTC, but `az --output json | ConvertFrom-Json` yields a **timezone-naive** value. `$parseTime` used a bare `[datetimeoffset]::Parse(iso).UtcDateTime`, which **assumes local time** — so on a DST-observing machine it applied the summer offset then subtracted it, shifting the displayed `Time` by the offset (e.g. `06:42Z` shown as `05:42` on BST).

**Fix:** parse with `[System.Globalization.DateTimeStyles]::AssumeUniversal` so the naive value is read as UTC. Single shared `$parseTime` helper → covers both the console and `-System` call sites.

**Prevention** (failure class: *implicit-local-timezone assumption on tz-naive input*): Pester test forces a DST zone (`$env:TZ='Europe/London'` + `ClearCachedData`), feeds a naive `TimeGenerated`, asserts the emitted `Time` is the UTC wall-clock (06:42, not 05:42). Never false-fails the fixed code; catches the bug on any DST host incl. Linux CI.

Tests **9/9**, manifest clean. Self-cert bugfix (single-behavior fix + regression test; no new API/schema). Closes t/3129.