### PR TITLE
feat(entities): person approval → AI-drafted + human-edited, gated by description_provenance (t/3131)

### DIFF
--- a/scripts/AITriad/Public/Import-Entity.ps1
+++ b/scripts/AITriad/Public/Import-Entity.ps1
@@ -12,9 +12,12 @@ function Import-Entity {
         ever added, updated, tombstoned (`merged_into`), or `deprecated` — NEVER hard-deleted.
         That is the invariant the monotonic id allocator depends on (design §3, TL t/1804#2 Q3).
 
-        Person exception (owner decision, design §4/§9.3): a `person` record cannot be
-        `approved` without a human-authored `description` — approving one with an empty
-        description throws an ActionableError (no LLM ever drafts a person description).
+        Person policy (owner decision 2026-08-31, design §4/§9.3, t/3131): a `person` description
+        may be AI-DRAFTED, but approval requires a human editor. A `person` is `approved` only when
+        `description` is non-empty AND `description_provenance` is `human-edited` / `human-authored`
+        (or unset — grandfathered legacy, safe while no AI path drafts a person description without
+        stamping `ai-drafted`). Approving a `person` whose provenance is still `ai-drafted`, or whose
+        description is empty, throws an ActionableError directing the human to edit + set provenance.
 
         Approved records get one all-MiniLM-L6-v2 embedding (name + genus-differentia line)
         written to a SEPARATE entity_embeddings.json via the existing Get-TextEmbedding path
@@ -26,7 +29,8 @@ function Import-Entity {
         1-20 proposal records (hashtable or PSCustomObject). New records require `name`,
         `entity_type`, `dolce_category`; optional `description`, `aliases`, `source_refs`,
         `external_refs`, `discovered_by`, `confidence`, `status` (default 'proposed'), `id`
-        (to update an existing record), `merged_into` (to tombstone/merge into a canonical id).
+        (to update an existing record), `merged_into` (to tombstone/merge into a canonical id),
+        `description_provenance` (`ai-drafted` | `human-edited` | `human-authored`; gates person approval).
     .PARAMETER Path
         Override entities.json path (fixtures/tests). Defaults to Get-EntitiesFilePath.
     .PARAMETER EmbeddingsPath
@@ -94,6 +98,7 @@ function Import-Entity {
         $description = [string](& $prop $p 'description' '')
         $status      = [string](& $prop $p 'status' 'proposed')
         $mergedInto  = [string](& $prop $p 'merged_into' '')
+        $descProv    = [string](& $prop $p 'description_provenance' '')   # t/3131: '' = unset/legacy
 
         $idx = if ($propId) { & $findIndex $propId } else { -1 }
         $isUpdate = ($idx -ge 0)
@@ -106,18 +111,48 @@ function Import-Entity {
         if ($isUpdate -and -not $description -and $existing[$idx].PSObject.Properties['description']) {
             $description = [string]$existing[$idx].description
         }
+        # t/3131: resolve effective provenance from the existing record on updates, so an approval
+        # can't dodge the person gate by omitting description_provenance on the update. An explicit
+        # value on the proposal (e.g. flipping ai-drafted -> human-edited) still wins.
+        if ($isUpdate -and -not $descProv -and $existing[$idx].PSObject.Properties['description_provenance']) {
+            $descProv = [string]$existing[$idx].description_provenance
+        }
 
-        # Person-approval gate (design §4/§9.3): no approval without a human description.
-        if ($entityType -eq 'person' -and $status -eq 'approved' -and [string]::IsNullOrWhiteSpace($description)) {
-            throw (New-ActionableError -PassThru `
-                -Goal 'Approve a person entity' `
-                -Problem "Person entity '$(if ($propId) { $propId } else { $name })' cannot be approved without a human-authored description" `
-                -Location 'Import-Entity' `
-                -NextSteps @(
-                    'Author a genus-differentia description ("A person who ...") for the record',
-                    'The LLM never drafts person descriptions — a human writes every one (design §4)',
-                    'Re-run Import-Entity with the description populated'
-                ))
+        # Person-approval gate (design §4/§9.3, revised t/3131): AI may DRAFT a person description,
+        # but approval still requires a human. A person is approvable iff `description` is non-empty
+        # AND provenance is human (human-edited / human-authored) OR unset. It is NOT approvable when
+        # provenance is 'ai-drafted' (an unedited AI draft) or the description is empty.
+        #
+        # GRANDFATHER SAFETY INVARIANT (t/3131, TL-required): unset provenance is treated as
+        # human-authored ONLY because no code path AI-drafts a person description without stamping
+        # 'ai-drafted' — verified: Invoke-EntityExtraction mints person proposals with NO description
+        # (:40-43/:766). Any FUTURE person AI-drafter MUST stamp description_provenance='ai-drafted',
+        # or an unedited draft would land as unset+non-empty and be silently auto-approved here.
+        # ORDERING (t/3131): this cmdlet must READ+PERSIST description_provenance before any
+        # ai-drafted person is imported (else the marker drops -> grandfather misfires).
+        if ($entityType -eq 'person' -and $status -eq 'approved') {
+            $idLabel = if ($propId) { $propId } else { $name }
+            if ([string]::IsNullOrWhiteSpace($description)) {
+                throw (New-ActionableError -PassThru `
+                    -Goal 'Approve a person entity' `
+                    -Problem "Person entity '$idLabel' cannot be approved without a description" `
+                    -Location 'Import-Entity' `
+                    -NextSteps @(
+                        'Provide a genus-differentia description ("A person who ...")',
+                        "Set description_provenance to 'human-edited' (an AI draft a human edited) or 'human-authored'",
+                        'Re-run Import-Entity'
+                    ))
+            }
+            if ($descProv -eq 'ai-drafted') {
+                throw (New-ActionableError -PassThru `
+                    -Goal 'Approve a person entity' `
+                    -Problem "Person entity '$idLabel' has an AI draft that no human has edited" `
+                    -Location 'Import-Entity' `
+                    -NextSteps @(
+                        "Edit the drafted description and set description_provenance to 'human-edited', then re-run"
+                    ))
+            }
+            # else: description non-empty AND provenance in {human-edited, human-authored, unset} -> approvable.
         }
 
         if ($isUpdate) {
@@ -156,6 +191,15 @@ function Import-Entity {
         $rec.description   = $description
         $rec.status        = $status
         $rec.last_modified = $now
+
+        # t/3131 (TL-required): READ + PERSIST description_provenance so an imported 'ai-drafted'
+        # marker survives on the stored record (that's what keeps the grandfather rule safe — an
+        # unedited AI draft stays blockable instead of degrading to unset+non-empty). Optional enum:
+        # only written when set; never write '' (not a valid contract value).
+        if ($descProv) {
+            if ($rec.PSObject.Properties['description_provenance']) { $rec.description_provenance = $descProv }
+            else { Add-Member -InputObject $rec -MemberType NoteProperty -Name 'description_provenance' -Value $descProv }
+        }
 
         foreach ($fld in @(
             @{ k = 'aliases';       d = @() },

--- a/tests/Entity.Tests.ps1
+++ b/tests/Entity.Tests.ps1
@@ -106,11 +106,52 @@ Describe 'Import-Entity — curation write (t/1804 §4)' -Tag 'unit' {
         { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Throw -ExpectedMessage '*description*'
     }
 
-    It 'Allows approving a PERSON record WITH a human description' {
+    It 'Allows approving a PERSON record WITH a human description (unset provenance = grandfathered, t/3131)' {
         $tmp = Join-Path $TestDrive 'entities-person-ok.json'
         $p = @{ name = 'Jane Doe'; entity_type = 'person'; dolce_category = 'agentive-physical-object'; status = 'approved'; description = 'A person who researches AI policy.' }
         { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Not -Throw
         (Get-Content -Raw -Path $tmp | ConvertFrom-Json).entities[0].status | Should -Be 'approved'
+    }
+
+    It 'Blocks approving a PERSON with an ai-drafted (unedited) description — deliberate-fail arm (t/3131)' {
+        $tmp = Join-Path $TestDrive 'entities-person-aidraft.json'
+        $p = @{ name = 'Jane Doe'; entity_type = 'person'; dolce_category = 'agentive-physical-object'; status = 'approved'; description = 'A person who researches AI policy.'; description_provenance = 'ai-drafted' }
+        { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Throw -ExpectedMessage '*AI draft*'
+    }
+
+    It 'Allows approving a PERSON once provenance is human-edited — clean arm (t/3131)' {
+        $tmp = Join-Path $TestDrive 'entities-person-edited.json'
+        $p = @{ name = 'Jane Doe'; entity_type = 'person'; dolce_category = 'agentive-physical-object'; status = 'approved'; description = 'A person who researches AI policy.'; description_provenance = 'human-edited' }
+        { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Not -Throw
+        $stored = (Get-Content -Raw -Path $tmp | ConvertFrom-Json).entities[0]
+        $stored.status                 | Should -Be 'approved'
+        $stored.description_provenance  | Should -Be 'human-edited'
+    }
+
+    It 'Allows PROPOSING (not approving) a PERSON with an ai-drafted description (t/3131)' {
+        $tmp = Join-Path $TestDrive 'entities-person-propose.json'
+        $p = @{ name = 'Jane Doe'; entity_type = 'person'; dolce_category = 'agentive-physical-object'; status = 'proposed'; description = 'A person who researches AI policy.'; description_provenance = 'ai-drafted' }
+        { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Not -Throw
+        $stored = (Get-Content -Raw -Path $tmp | ConvertFrom-Json).entities[0]
+        $stored.status                 | Should -Be 'proposed'
+        $stored.description_provenance  | Should -Be 'ai-drafted'
+    }
+
+    It 'PERSISTS ai-drafted on import; the stored marker blocks a later approval that omits provenance (persist + anti-dodge, t/3131)' {
+        $tmp = Join-Path $TestDrive 'entities-person-persist.json'
+        # 1) propose an ai-drafted person → provenance must PERSIST on the stored record
+        $prop = @{ name = 'Jane Doe'; entity_type = 'person'; dolce_category = 'agentive-physical-object'; status = 'proposed'; description = 'A person who researches AI policy.'; description_provenance = 'ai-drafted' }
+        $r1 = Import-Entity -Proposal @($prop) -Path $tmp -SkipEmbedding
+        $id = $r1[0].Id
+        (Get-Content -Raw -Path $tmp | ConvertFrom-Json).entities[0].description_provenance | Should -Be 'ai-drafted'
+        # 2) approve WITHOUT re-supplying provenance → anti-dodge resolves the persisted 'ai-drafted'
+        #    → still blocked (proves the marker survived import; grandfather cannot misfire)
+        { Import-Entity -Proposal @(@{ id = $id; status = 'approved' }) -Path $tmp -SkipEmbedding } | Should -Throw -ExpectedMessage '*AI draft*'
+        # 3) human edits + flips to human-edited → approval succeeds
+        { Import-Entity -Proposal @(@{ id = $id; status = 'approved'; description_provenance = 'human-edited' }) -Path $tmp -SkipEmbedding } | Should -Not -Throw
+        $final = (Get-Content -Raw -Path $tmp | ConvertFrom-Json).entities[0]
+        $final.status                 | Should -Be 'approved'
+        $final.description_provenance  | Should -Be 'human-edited'
     }
 
     It 'NEVER hard-deletes: deprecate + merge leave the record count monotonic (§3, TL Q3)' {


### PR DESCRIPTION
**TL-approved** (t/3131#2/#4). Replaces the person human-authored-only hard-block with a provenance gate: AI may now DRAFT a person description (proposable), but approval requires a human edit.

## Gate (truth table)
| provenance | description | approval |
|---|---|---|
| unset | empty | **block** |
| `ai-drafted` | any | **block** |
| unset | non-empty | **allow** (grandfathered human-authored) |
| `human-edited` / `human-authored` | non-empty | **allow** |

## Key pieces
- **READ + PERSIST** `description_provenance` on the record (TL-required hard condition) — so an imported `ai-drafted` marker survives; that's what keeps grandfathering safe.
- **Anti-dodge:** effective provenance is resolved from the existing record on updates → an approval can't bypass the ai-drafted block by omitting provenance.
- **Grandfather safety invariant documented at the gate:** unset=human-authored is safe *only* while no AI path drafts a person description without stamping `ai-drafted` (verified: extraction mints persons with no description). Any future person AI-drafter MUST stamp `ai-drafted`.
- Docstring updated to the new policy; **ordering note** baked in (persist must precede any ai-drafted import).

## Cross-role sequencing (enforced)
Shared Lib's `description_provenance` landed first (**t/3132**, `89e14ce2`); the drift-parity gate parses that interface, so this PS write is contract-clean. No Zod (interface-only).

## Decisions / deviations
Grandfather (unset+non-empty=human-authored) approved by **CL** (p/547#4) + **TL** (p/360#206). **No deviations** from the approved design.

## Tests
34/34 — 5 new (grandfather / ai-drafted-block / human-edited-allow / proposed-ai-drafted / **persist+anti-dodge proof**) + drift-parity gate green + manifest clean.

## Downstream
CL is holding the #1663 person import (t/3118#6) until this lands; I'll ping them to green-light on merge. Closes t/3131.