### PR TITLE
ci(dependabot): auto-heal standalone lockfile + license notices (t/3116)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,15 +11,32 @@ version: 2
 #   - Expected steady state with weekly triage: ~5-8 open dependabot PRs.
 # Change the limits here (not by manually closing PRs) if the pile reappears.
 updates:
-  # ── npm — grouped minor/patch, majors individual ──
+  # ── npm workspace ROOT — a single entry owns the ENTIRE pnpm workspace ──
+  # All workspace members (pnpm-workspace.yaml: taxonomy-editor, lib, poviewer,
+  # summary-viewer, workflow-app) share the ONE root pnpm-lock.yaml. A per-app
+  # `directory:` entry bumps only that member's package.json and can't reach the
+  # root lockfile → ERR_PNPM_OUTDATED_LOCKFILE on frozen install (t/3116;
+  # electron 43→44 #1645/#1648/#1649). This single ROOT entry updates member
+  # manifests + the shared root lockfile in the SAME PR. Do NOT re-add per-app
+  # entries for workspace members.
+  #
+  # taxonomy-editor additionally carries an in-dir STANDALONE lockfile (Docker
+  # prod-deps) + generated license notices; a root-entry bump leaves those stale
+  # (test-container / test-electron(taxonomy-editor) red). The companion
+  # dependabot-lockfile-heal.yml workflow re-syncs both in-PR (t/3116; SO e/127).
+  #
+  # lib/debate keeps its OWN entry (below): its root-workspace importer is empty
+  # — the root entry never bumps it — so its standalone lockfile is managed only
+  # per-directory, no heal needed. (If a future lib/debate bump ever drifts its
+  # standalone lockfile, extend sync-standalone-lockfile.mjs to cover it.)
   - package-ecosystem: npm
-    directory: /taxonomy-editor  # largest app (most deps) — a little more headroom
+    directory: /
     schedule:
       interval: weekly
     groups:
       minor-and-patch:
         update-types: [minor, patch]
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 6  # covers taxonomy-editor majors (was on its own entry) too
     ignore:
       # undici MAJOR is HELD (t/2053/t/2113/t/2281; #1091). The GitHub REST client passes an
       # undici.Agent as `dispatcher:` to Node's built-in fetch; per assertUndiciMajorInvariant,
@@ -30,34 +47,6 @@ updates:
       # REVISIT when the pinned Node runtime bundles a newer undici major, then bump both together.
       - dependency-name: undici
         update-types: [version-update:semver-major]
-
-  # ── npm workspace ROOT — owns the pnpm workspace's lockfile-less members ──
-  # poviewer / summary-viewer / workflow-app / lib are pnpm-WORKSPACE members
-  # (pnpm-workspace.yaml) with NO in-dir lockfile — they share the ONE root
-  # pnpm-lock.yaml. A per-app `directory:` entry bumps only that member's
-  # package.json and can't reach the root lockfile, so `pnpm install
-  # --frozen-lockfile` reds with ERR_PNPM_OUTDATED_LOCKFILE before build/test
-  # ever runs (t/3116; surfaced by electron 43→44 #1645/#1648/#1649). A single
-  # workspace ROOT entry updates member manifests + the shared root lockfile in
-  # the SAME PR, so frozen-install stays green. Do NOT re-add per-app entries
-  # for these four members.
-  #
-  # taxonomy-editor + lib/debate are ALSO workspace members but keep their own
-  # entries (above/below): each carries an in-dir STANDALONE lockfile (Docker /
-  # isolated build, synced via scripts/sync-standalone-lockfile.mjs +
-  # lockfile-overrides-check, t/2188) that Dependabot updates correctly per
-  # directory. WATCH-ITEM (t/3116): confirm the first post-merge Dependabot
-  # cycle does not ALSO emit workspace-root PRs for those two (double-manage);
-  # if it does, add per-dependency ignores here. Fallback if root-lockfile
-  # regen proves unreliable: a lockfile-heal step on member PRs (t/3116 opt B).
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
-    open-pull-requests-limit: 4
 
   - package-ecosystem: npm
     directory: /lib/debate

--- a/.github/workflows/dependabot-lockfile-heal.yml
+++ b/.github/workflows/dependabot-lockfile-heal.yml
@@ -1,0 +1,139 @@
+# ─── Dependabot Standalone-Lockfile + License-Notices Heal (t/3116) ───
+# What:  On a Dependabot PR that bumps a workspace dependency, the single root
+#        `/` Dependabot entry updates member manifests + the shared root
+#        pnpm-lock.yaml — but it CANNOT update taxonomy-editor's in-dir STANDALONE
+#        lockfile (Docker prod-deps) or its generated license notices. Those go
+#        stale → test-container / test-electron(taxonomy-editor) red. This
+#        workflow re-syncs them and commits the result back onto the PR branch,
+#        so the Dependabot PR carries all three artifacts and goes green.
+#
+# Design: Second Opinion e/127#2 (Option B), TL-approved (t/3116#7). A plain
+#        `pull_request` trigger (never pull_request_target — Dependabot runs
+#        already receive Dependabot secrets, so no elevated base-repo context is
+#        needed, and the RCE-class footprint is avoided entirely). Write access
+#        comes from a runtime-minted GitHub App installation token, NOT the
+#        read-only default GITHUB_TOKEN.
+#
+# SECURITY (do not refactor without re-reading e/127#2):
+#   * The App token is minted AFTER every dependency-touching step and is
+#     referenced ONLY by the push step (step-level env). Step ordering IS the
+#     security boundary — moving the mint earlier exposes a write credential to
+#     dependency/script execution. See the marked step below.
+#   * `pnpm install --lockfile-only` (inside sync-standalone-lockfile.mjs) and the
+#     license install both run with scripts disabled (`--ignore-scripts` + an
+#     `.npmrc` belt) so no registry postinstall hook executes during a resolve.
+#   * Job guard requires BOTH actor == dependabot[bot] AND a same-repo head, so a
+#     fork PR can never reach the write path.
+#   * The App/PAT push (unlike a GITHUB_TOKEN push) DOES retrigger CI — that is
+#     load-bearing: the heal commit must get fresh checks. Do not "simplify" to
+#     the default token.
+#
+# CREDENTIAL PREREQUISITE (owner/admin, one-time): a GitHub App with
+#   `contents: write` on this repo, installed, with its App ID + private key
+#   stored as DEPENDABOT secrets (NOT Actions secrets — Dependabot-triggered runs
+#   read the Dependabot secret store):
+#     - DEPENDABOT_HEAL_APP_ID
+#     - DEPENDABOT_HEAL_APP_PRIVATE_KEY
+#   Fine-grained single-repo PAT (contents:write, 90-day) is the accepted fallback
+#   (swap the mint step for a `token:` referencing a DEPENDABOT_HEAL_PAT secret).
+#
+# NOTE (t/3116): lib/debate is NOT healed here — its root-workspace importer is
+#   empty (the root Dependabot entry never bumps it), so its standalone lockfile
+#   is managed only by the /lib/debate Dependabot entry. If that ever changes,
+#   extend scripts/sync-standalone-lockfile.mjs to cover lib/debate and add it here.
+
+name: Dependabot Lockfile Heal
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# Read-only by default; the write credential is the minted App token, not this.
+permissions:
+  contents: read
+
+# One heal at a time per PR — a Dependabot rebase/force-push mid-heal must not
+# interleave two pushes (e/127#2).
+concurrency:
+  group: dependabot-heal-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  heal:
+    # actor AND same-repo head — a fork PR can never reach the write path.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+        with:
+          ref: ${{ github.head_ref }}
+          # Do not persist the default (read-only) token; we push with the App token.
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3  # TODO(gv): confirm/repin SHA
+        with:
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b  # v4  # TODO(gv): confirm/repin SHA
+        with:
+          node-version: 22
+
+      # Belt: forbid lifecycle scripts for every install in this job.
+      - name: Disable install scripts (defense-in-depth)
+        run: echo "ignore-scripts=true" >> ./.npmrc
+
+      # 1) Re-sync taxonomy-editor's standalone lockfile (runs pnpm install
+      #    --lockfile-only internally; no packages built, no scripts).
+      - name: Sync standalone lockfile
+        run: node scripts/sync-standalone-lockfile.mjs
+
+      # 2) Regenerate taxonomy-editor license notices. generate-notices.cjs scans
+      #    node_modules, so a real (scripts-disabled) install is required first.
+      - name: Regenerate license notices
+        working-directory: taxonomy-editor
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          npm run licenses
+
+      # 3) Nothing changed → no commit, no CI noise (idempotency).
+      - name: Detect drift
+        id: drift
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Heal produced changes:"; git status --short
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Already in sync — nothing to heal."
+          fi
+
+      # ── SECURITY BOUNDARY ─────────────────────────────────────────────────
+      # Mint the write credential ONLY here, AFTER every dependency/script step
+      # above. Do NOT move this earlier and do NOT expose `token` to any step but
+      # the push below. (e/127#2)
+      - name: Mint GitHub App token
+        id: app-token
+        if: steps.drift.outputs.changed == 'true'
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b  # v2  # TODO(gv): confirm/repin SHA
+        with:
+          app-id: ${{ secrets.DEPENDABOT_HEAL_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_HEAL_APP_PRIVATE_KEY }}
+
+      - name: Commit and push heal
+        if: steps.drift.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config user.name "dependabot-heal[bot]"
+          git config user.email "dependabot-heal[bot]@users.noreply.github.com"
+          git add taxonomy-editor/pnpm-lock.yaml \
+                  taxonomy-editor/THIRD-PARTY-NOTICES.txt \
+                  taxonomy-editor/src/renderer/data/oss-licenses.json
+          git commit -m "ci(deps): heal standalone lockfile + license notices [dependabot-heal]"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          git push origin "HEAD:${{ github.head_ref }}"

--- a/.github/workflows/dependabot-lockfile-heal.yml
+++ b/.github/workflows/dependabot-lockfile-heal.yml
@@ -74,12 +74,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3  # TODO(gv): confirm/repin SHA
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10 (repo-standard pin)
         with:
           run_install: false
 
       - name: Set up Node
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b  # v4  # TODO(gv): confirm/repin SHA
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6 (repo-standard pin)
         with:
           node-version: 22
 
@@ -119,7 +119,7 @@ jobs:
       - name: Mint GitHub App token
         id: app-token
         if: steps.drift.outputs.changed == 'true'
-        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b  # v2  # TODO(gv): confirm/repin SHA
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349  # v2.2.2
         with:
           app-id: ${{ secrets.DEPENDABOT_HEAL_APP_ID }}
           private-key: ${{ secrets.DEPENDABOT_HEAL_APP_PRIVATE_KEY }}


### PR DESCRIPTION
**DRAFT — pre-staged per PM (p/33#74) to cut latency. Cannot merge/GV until the owner provisions the write credential.**

## What

Completes the t/3116 permanent fix. Two parts:

1. **Config: full workspace consolidation** — folds the `/taxonomy-editor` Dependabot entry into the single root `/` entry (undici major-ignore preserved on root; open-PR limit 4→6). `/lib/debate` keeps its own entry (empty root importer — root never bumps it). npm entries now `[/, /lib/debate, /deploy/azure/runner/function]`.

2. **New workflow `dependabot-lockfile-heal.yml`** — on a Dependabot PR, re-syncs taxonomy-editor's **standalone lockfile** (`sync-standalone-lockfile.mjs`) + **license notices** (`npm run licenses`) and commits them back in-PR, so the PR carries all three generated artifacts and goes green. Automates the interim manual heal proven on #1652/#1653.

## Design provenance

Second Opinion **e/127#2** (Option B), TL-approved **t/3116#7**. Hardening implemented verbatim:
- Plain `pull_request` (`opened`, `synchronize`) — **never** `pull_request_target`.
- Job guard: `actor == dependabot[bot]` **and** same-repo head (forks can't reach the write path).
- Write via a **runtime-minted GitHub App token**, minted **after** all dependency-touching steps, referenced **only** by the push step (step ordering = the security boundary; commented inline).
- `--ignore-scripts` + `.npmrc` belt so no registry lifecycle script runs during a resolve.
- Per-PR `concurrency` (cancel-in-progress) for Dependabot rebase races; porcelain-diff idempotency; `[dependabot-heal]` commit marker.
- App/PAT push (not `GITHUB_TOKEN`) **does** retrigger CI — load-bearing, so the heal commit gets fresh checks.

## Owner prerequisite (blocks un-draft)

A GitHub App (`contents: write`, this repo) with App ID + private key stored as **Dependabot** secrets (not Actions secrets): `DEPENDABOT_HEAL_APP_ID`, `DEPENDABOT_HEAL_APP_PRIVATE_KEY`. Fine-grained single-repo PAT (contents:write, 90-day) is the accepted fallback. Decision pending with owner.

## GV plan (both-arms, for TL once the credential lands)

- **Arm 1 (heal):** a Dependabot PR with a stale standalone lockfile/notices gets healed **and the heal commit triggers a fresh CI run that goes green**.
- **Arm 2 (clean):** a Dependabot PR already in sync produces **zero commits, zero noise**.
- **Third check:** the dependency-resolve step's env contains **no token**.

## Open items before un-draft

- [ ] Owner provisions the credential (App or PAT).
- [ ] Repin `TODO(gv)` action SHAs (pnpm/action-setup, setup-node, create-github-app-token) — checkout is already at the repo-standard SHA.
- [ ] lib/debate coverage intentionally deferred (empty root importer); extend `sync-standalone-lockfile.mjs` only if a future lib/debate bump drifts its standalone lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iv1toUh9SurtepKUd8hpG