### PR TITLE
docs(ci): inline post-merge watch-item in heal workflow (t/3134 GV condition)

### DIFF
--- a/.github/workflows/dependabot-lockfile-heal.yml
+++ b/.github/workflows/dependabot-lockfile-heal.yml
@@ -39,6 +39,15 @@
 #   root entry never bumps it); its standalone lockfile is managed by the
 #   /lib/debate Dependabot entry. Extend sync-standalone-lockfile.mjs + this scope
 #   guard if that ever changes.
+#
+# POST-MERGE WATCH-ITEM (GV condition, t/3134): the App-token push retriggering CI
+#   is only observable once this workflow is on main (a pull_request workflow runs
+#   from the BASE branch). VERIFY on the FIRST taxonomy-editor-touching Dependabot
+#   npm PR after merge: the heal commits → the App-token push retriggers CI → the
+#   PR goes GREEN including this heal job. If instead it loops/reds (e.g. the push
+#   fails to retrigger, or an empty commit), REVERT immediately per #1674 and
+#   re-open t/3134. Offline both-arms were proven at GV (#1676 evidence); this is
+#   the one arm only main can exercise.
 
 name: Dependabot Lockfile Heal
 


### PR DESCRIPTION
Follow-up to #1676. The heal workflow merged (7b74c050) at head 23d80555 — before the inline post-merge watch-item comment I was adding as TL''s Gate Co-Location merge condition (p/331#712) reached the branch. This lands that comment (comment-only, 9 lines).

The inlined note records the one arm only main can exercise: on the FIRST taxonomy-editor-touching Dependabot npm PR, the heal must commit → the App-token push retriggers CI → the PR goes green incl. the heal job; else revert per #1674.

Self-certifying under /trivial-change: comment-only, single file, no behavioral change; verify gate = ci-gate + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iv1toUh9SurtepKUd8hpG