### PR TITLE
feat(entities): Import-Entity rejects unknown proposal fields loudly (t/3133)

### DIFF
--- a/scripts/AITriad/Private/Get-EntityProposalFieldName.ps1
+++ b/scripts/AITriad/Private/Get-EntityProposalFieldName.ps1
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Allowlist of proposal fields Import-Entity accepts — the Entity contract field set (t/3133).
+.DESCRIPTION
+    Any `-Proposal` key outside this set is an UNKNOWN field and is rejected loudly by Import-Entity,
+    instead of being silently dropped. Silent drop is the t/3118 near-miss: a stale (pre-t/3131)
+    module didn't read `description_provenance`, dropped it, and the grandfather rule would have
+    auto-approved unedited AI drafts. Loud rejection turns any stale-code / typo'd-field case into an
+    immediate failure rather than silent data-correctness drift.
+
+    This list MUST match the Entity contract (lib/entities/types.ts). The Entity drift-parity test
+    asserts the two stay in sync, so a newly-added contract field can't be silently rejected here.
+    `created_at` / `last_modified` are contract fields the cmdlet manages (ignored if echoed on a
+    proposal) — included so a full-record round-trip is tolerated, not rejected.
+#>
+function Get-EntityProposalFieldName {
+    [OutputType([string[]])]
+    param()
+    @(
+        'id'
+        'name'
+        'aliases'
+        'entity_type'
+        'dolce_category'
+        'description'
+        'status'
+        'created_at'
+        'last_modified'
+        'description_provenance'
+        'external_refs'
+        'source_refs'
+        'merged_into'
+        'discovered_by'
+        'confidence'
+    )
+}

--- a/scripts/AITriad/Public/Import-Entity.ps1
+++ b/scripts/AITriad/Public/Import-Entity.ps1
@@ -100,6 +100,28 @@ function Import-Entity {
         $mergedInto  = [string](& $prop $p 'merged_into' '')
         $descProv    = [string](& $prop $p 'description_provenance' '')   # t/3131: '' = unset/legacy
 
+        # t/3133: reject UNKNOWN proposal fields loudly instead of silently dropping them. The t/3118
+        # near-miss: a stale (pre-t/3131) module didn't read description_provenance, dropped it, and
+        # the grandfather rule would have auto-approved unedited AI drafts. Erroring turns any
+        # stale-code / typo'd-field case into an immediate failure, not silent data-correctness drift.
+        # Top-level keys only (nested shapes like discovered_by.{usage_id,model} are not recursed);
+        # allowlist = the Entity contract (Get-EntityProposalFieldName, kept in sync by the parity test).
+        $knownFields   = Get-EntityProposalFieldName
+        $provKeys      = if ($p -is [hashtable]) { @($p.Keys) } else { @($p.PSObject.Properties.Name) }
+        $unknownFields = @($provKeys | Where-Object { $_ -notin $knownFields })
+        if ($unknownFields.Count -gt 0) {
+            $idLabel = if ($propId) { $propId } elseif ($name) { $name } else { '(unnamed)' }
+            throw (New-ActionableError -PassThru `
+                -Goal 'Import an entity proposal' `
+                -Problem "Proposal '$idLabel' carries unrecognized field(s): $($unknownFields -join ', ')" `
+                -Location 'Import-Entity' `
+                -NextSteps @(
+                    'Remove the unrecognized field(s) from the proposal, OR'
+                    'If a field is a new Entity contract field, add it to lib/entities/types.ts AND Get-EntityProposalFieldName (the drift-parity test guards the pairing)'
+                    'Older module versions silently DROP unknown fields — this refusal prevents a stale-module field-drop (t/3133)'
+                ))
+        }
+
         $idx = if ($propId) { & $findIndex $propId } else { -1 }
         $isUpdate = ($idx -ge 0)
 

--- a/tests/Entity.Tests.ps1
+++ b/tests/Entity.Tests.ps1
@@ -100,6 +100,18 @@ Describe 'Import-Entity — curation write (t/1804 §4)' -Tag 'unit' {
         (Get-Content -Raw -Path $tmp | ConvertFrom-Json).entity_count | Should -Be 20
     }
 
+    It 'Rejects a proposal carrying an UNRECOGNIZED field — loud, not silent drop (t/3133)' {
+        $tmp = Join-Path $TestDrive 'entities-unknownfield.json'
+        $p = New-Prop @{ bogus_field = 'oops' }
+        { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Throw -ExpectedMessage '*bogus_field*'
+    }
+
+    It 'Accepts a proposal whose fields are all recognized — guard does not false-reject (t/3133)' {
+        $tmp = Join-Path $TestDrive 'entities-knownfields.json'
+        $p = New-Prop @{ status = 'proposed'; aliases = @('GPT4'); description_provenance = 'ai-drafted'; confidence = 0.9 }
+        { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Not -Throw
+    }
+
     It 'Rejects approving a PERSON record with no human description (§4/§9.3)' {
         $tmp = Join-Path $TestDrive 'entities-person.json'
         $p = @{ name = 'Jane Doe'; entity_type = 'person'; dolce_category = 'agentive-physical-object'; status = 'approved' }
@@ -330,6 +342,15 @@ Describe 'Entity shape parity with lib/entities/types.ts (contract drift gate, T
     It 'GATE-VERIFY: a MISSING required key makes parity FAIL' {
         $keysMissingId = @($script:RequiredFields | Where-Object { $_ -ne 'id' }) + @('external_refs', 'source_refs')
         (Test-EntityKeyParity -RecordKeys $keysMissingId -Required $script:RequiredFields -Optional $script:OptionalFields) | Should -BeFalse
+    }
+
+    It 'Import-Entity unknown-field allowlist stays in sync with the Entity contract (t/3133)' {
+        # The t/3133 guard rejects any proposal field not in Get-EntityProposalFieldName. That
+        # allowlist MUST equal the contract field set, else a newly-added contract field would be
+        # silently rejected (or a removed one silently accepted). Private fn → read via InModuleScope.
+        $allow    = @(InModuleScope AITriad { Get-EntityProposalFieldName }) | Sort-Object
+        $contract = (@($script:RequiredFields) + @($script:OptionalFields)) | Sort-Object
+        ($allow -join ',') | Should -Be ($contract -join ',')
     }
 }
 


### PR DESCRIPTION
Prevention for the **t/3118 near-miss**: Import-Entity was run from a stale (pre-t/3131) checkout that didn't read `description_provenance`, so it **silently dropped** the field from 9 person proposals — the grandfather rule would then have auto-approved unedited AI drafts. Failure class: *silent field-drop from a lagging checkout*.

**Fix (CL's recommended option 2):** any `-Proposal` key outside the Entity contract field set now throws an actionable error naming the field(s), instead of being silently ignored — turning any stale-code / typo'd-field case into an immediate failure. Top-level keys only (nested `discovered_by.{usage_id,model}` not recursed).

- New Private `Get-EntityProposalFieldName` = the allowlist (= Entity contract, 15 fields incl. cmdlet-managed `created_at`/`last_modified` so a full-record round-trip is tolerated).
- Guard at the top of the per-proposal loop.

**Caller-safety verified** (subagent analysis of every call site): Invoke-EntityExtraction mint, the #1663/t/3118 curation batch, and all tests pass **only** recognized fields → the guard false-rejects nothing. Extraction's `quote` is evidence, never forwarded.

**Prevention-of-prevention:** a parity test asserts the allowlist == the contract field set (parsed from `lib/entities/types.ts`), so a future contract field can't be silently rejected nor a removed one silently accepted.

**Self-cert:** bounded cmdlet input-validation guard — NOT gate-touching (no CI/deploy gate, no schema change); CL routed to PowerShell as cmdlet owner. Tests **37/37** (3 new), manifest clean.

Note for @CL: `research/comp-linguist/curation/entity-curation-batch.json` `_doc` still says provenance is dropped 'until t/3131' — now stale (your scope). Closes t/3133.