### PR TITLE
fix(container): repoint taxonomy-editor base to ai-triad-base:2026-08-31 — clears openssl+tar HIGH CVEs (t/3137)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -137,8 +137,11 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store pnpm install --prod 
 # (deploy-staging.yml Test-TaxEditorHealth /healthz). :2026-07-30 was exonerated in t/2047 —
 # root cause was t/2061 (isDataAvailable path mismatch, app-side). Bumped to :2026-08-15 for
 # Debian 13 Trixie upgrade + .trivyignore cleanup (t/2681).
+# Bumped to :2026-08-31 for the cache-bust security rebuild (t/3137) — the base now
+# genuinely re-runs apt/npm upgrades: openssl 3.5.7-1~deb13u2 (CVE-2026-14456) and
+# npm's bundled tar 7.5.21 (CVE-2026-73566), both proven by the base build tripwires.
 # Gate base bumps on staging /healthz, not CI green.
-FROM ghcr.io/jpsnover/ai-triad-base:2026-08-24@sha256:5411f603a80b1f752d95e4430f03fe8c1607d5ed2cd2e9044fdbf33e0eebe358 AS runtime
+FROM ghcr.io/jpsnover/ai-triad-base:2026-08-31@sha256:8dc5517233bb06d1e6e863fa16b531b3508a5831941a49f3d59c9488ac6e6a09 AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/jpsnover/ai-triad-research"
 LABEL org.opencontainers.image.description="AI Triad Taxonomy Editor"


### PR DESCRIPTION
## Step 2 of t/3137 — repoint app image to the fixed base

Bumps `taxonomy-editor/Dockerfile` runtime `FROM` to the cache-bust security rebuild of `ai-triad-base` (**`:2026-08-31@sha256:8dc55172…`**, built by #1678's merge on main).

That base genuinely re-ran its apt/npm security upgrades (the cache-hit no-op is fixed), proven by the base build tripwires:
- `openssl / libssl3t64 / openssl-provider-legacy = 3.5.7-1~deb13u2` → **CVE-2026-14456**
- `npm bundled-tar after override = 7.5.21` → **CVE-2026-73566**

## Verify
`test-container` builds the app image on the new base here. After merge, `container.yml` rebuilds + Trivy rescans → both HIGH CVEs must be gone from code-scanning (the t/3137 acceptance criterion).

Pure 1-line digest bump (+ comment) — no app behavior change. Owner heads-up sent to Rosetta Stone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)