### PR TITLE
fix(security): redact newer AQ.-format Gemini keys (Protect-SensitiveText + PII sweep) (t/3140)

### DIFF
--- a/scripts/AITriad/Private/Protect-SensitiveText.ps1
+++ b/scripts/AITriad/Private/Protect-SensitiveText.ps1
@@ -49,7 +49,8 @@ function Protect-SensitiveText {
         #    "Bearer" eaten as the value, leaving the token behind.
         $patterns = @(
             '(?i)\bBearer\s+[A-Za-z0-9._\-]+'
-            'AIza[0-9A-Za-z\-_]{20,}'        # Google API key
+            'AIza[0-9A-Za-z\-_]{20,}'        # Google API key (AIza… classic)
+            'AQ\.[0-9A-Za-z\-_\.]{20,}'      # Google API key (AQ.… newer format, t/3140)
             'sk-[A-Za-z0-9\-_]{16,}'         # OpenAI / Anthropic style
             'gsk_[A-Za-z0-9]{16,}'           # Groq
             '(?i)\bkey=[^&\s"'']+'           # ?key= query parameter

--- a/scripts/Project-Template/Public/Test-FlightRecorderPII.ps1
+++ b/scripts/Project-Template/Public/Test-FlightRecorderPII.ps1
@@ -36,6 +36,7 @@ function Test-FlightRecorderPII {
 
         $patterns = @(
             @{ Name = 'API Key (Google)';    Regex = 'AIzaSy[A-Za-z0-9_-]{33}' }
+            @{ Name = 'API Key (Google AQ.)'; Regex = 'AQ\.[0-9A-Za-z\-_.]{20,}' }   # newer Gemini key format (t/3140)
             @{ Name = 'API Key (OpenAI)';    Regex = 'sk-[A-Za-z0-9]{20,}' }
             @{ Name = 'API Key (Groq)';      Regex = 'gsk_[A-Za-z0-9]{20,}' }
             @{ Name = 'API Key (xAI)';       Regex = 'xai-[A-Za-z0-9]{20,}' }

--- a/tests/Protect-SensitiveText.Tests.ps1
+++ b/tests/Protect-SensitiveText.Tests.ps1
@@ -32,12 +32,15 @@ Describe 'Protect-SensitiveText (t/2530 L14)' -Tag 'unit' {
         }
     }
 
-    It 'redacts a Google AIza key, a Bearer token, sk-, and gsk_ tokens' {
+    It 'redacts Google AIza + AQ. keys, a Bearer token, sk-, and gsk_ tokens' {
         InModuleScope AITriad {
             # Synthetic, never-valid fixture. Split so the source literal cannot match a
             # Google-key pattern — the inline form tripped GitHub secret scanning as a
             # false positive (alert #12). Runtime value is unchanged.
             (Protect-SensitiveText -Text ('AIza' + 'SyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456')) | Should -Not -Match 'AIzaSyABCDEF'
+            # t/3140: the newer Gemini AQ.<...> format must redact too (classic AIza… pattern missed it).
+            (Protect-SensitiveText -Text ('AQ.' + 'SYNTHETICtestkeyNOTreal000000000000')) | Should -Not -Match 'AQ\.SYNTHETIC'
+            (Protect-SensitiveText -Text ('AQ.' + 'SYNTHETICtestkeyNOTreal000000000000')) | Should -Match '\[REDACTED\]'
             (Protect-SensitiveText -Text 'Authorization: Bearer abc.def.ghijklmnop') | Should -Not -Match 'abc\.def\.ghijklmnop'
             (Protect-SensitiveText -Text 'sk-ant-api03-AAAAAAAAAAAAAAAA') | Should -Not -Match 'sk-ant-api03-A'
             (Protect-SensitiveText -Text 'gsk_ABCDEFGHIJKLMNOPQRST') | Should -Not -Match 'gsk_ABCDEFGH'


### PR DESCRIPTION
**HIGH / security** (child of t/3138). The newer Gemini `AQ.<...>` key format bypassed the PowerShell secret redactor (matched only `AIza…`). The live free-tier pool holds **4 AQ. keys** → a real leak surface in flight-recorder dumps and scrubbed logs.

- `Protect-SensitiveText.ps1`: added `AQ\.[0-9A-Za-z\-_\.]{20,}` alongside the AIza pattern.
- `Test-FlightRecorderPII.ps1`: added an `AQ.` key regex to the PII sweep.
- Regression: `Protect-SensitiveText.Tests.ps1` asserts a **synthetic** AQ. key is redacted (never a real key; split-literal fixture to avoid source-scanner false positives) — both a negative (`AQ.` gone) and positive (`[REDACTED]` present) assertion.

Self-cert **/trivial-change** (single-scope redaction pattern + test, no public API change). Tests 6/6, manifest clean. @TL — flagged for your diff review per p/360#211.