### PR TITLE
fix(container): strip npm from taxonomy-editor runtime image — kills npm-bundled CVE class (t/3135)

### DIFF
--- a/taxonomy-editor/Dockerfile
+++ b/taxonomy-editor/Dockerfile
@@ -222,6 +222,19 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get update \
     && apt-get install -y --no-install-recommends powershell
 
+# 8. Strip global npm from the runtime image (t/3135). npm is NOT reachable at
+# runtime — CMD is a direct `node`; npm/pnpm are used only in the discarded
+# builder/prod-deps stages; the web console spawns pwsh (not npm); there is no
+# start-time npm script. Removing it deletes the entire npm-bundled-dep CVE class
+# (e.g. tar CVE-2026-73566 under .../node_modules/npm/node_modules/tar) from the
+# deployed image in one shot. The `command -v npm` guard fails the build loudly if
+# a future base layout leaves npm behind, so the strip can't silently regress.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm \
+           /usr/local/bin/npx \
+    && if command -v npm >/dev/null 2>&1; then echo "[t/3135] ERROR: npm still on PATH after strip" && exit 1; fi \
+    && echo "[t/3135] npm/npx stripped from runtime image"
+
 USER aitriad
 
 EXPOSE 7862


### PR DESCRIPTION
## t/3135 sweep — strip npm from the deployed runtime image

Removes the global npm package + `npm`/`npx` bin symlinks in `taxonomy-editor/Dockerfile` stage 3 (runtime), as root before `USER aitriad`.

**Why:** npm is **not reachable at container runtime** (verified in t/3137 — CMD is a direct `node`; npm/pnpm only in the discarded builder/prod-deps stages; the web console spawns pwsh, not npm; no start-time npm script). Deleting it removes the **entire npm-bundled-dep CVE class** from the deployed image at once — e.g. `tar` CVE-2026-73566 under `usr/local/lib/node_modules/npm/node_modules/tar` — instead of patching each bundled dep forever.

**Guard:** a `command -v npm` check **fails the build loudly** if a future base layout leaves npm behind, so the strip can't silently regress.

## Verify
- `test-container` here builds the image without npm and runs the readiness smoke → proves the server still starts.
- After merge: `container.yml` rebuild → Trivy rescan → npm-bundled alerts drop out of code-scanning.

TL-approved approach (p/331#730/#731). Owner-directed action of t/3135. Heads-up sent to Rosetta Stone (file owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)