### PR TITLE
fix(security): redact newer-format Gemini AQ. API keys in the TS redactors (t/3139)

### DIFF
--- a/lib/ai-client/providers/gemini.ts
+++ b/lib/ai-client/providers/gemini.ts
@@ -295,7 +295,7 @@ export function mapGeminiError(status: number, bodyText: string): ActionableErro
         problem: `Gemini 401 UNAUTHENTICATED: credential is an OAuth access token, not an API key. ${bodyText.slice(0, 300)}`,
         location: 'ai-client.generateViaGemini',
         nextSteps: [
-          'Your Gemini credential looks like an OAuth access token, not an API key. Gemini API keys start with AIza.',
+          'Your Gemini credential looks like an OAuth access token, not an API key. Gemini API keys start with AIza or AQ. (t/3139).',
           'Re-register a valid key (Settings → API Keys, or Register-AIBackend)',
         ],
       });

--- a/lib/flight-recorder/flightRecorder.test.ts
+++ b/lib/flight-recorder/flightRecorder.test.ts
@@ -795,6 +795,11 @@ describe('redactString', () => {
     expect(redactString(input)).toBe('key=[REDACTED]');
   });
 
+  it('redacts newer-format Gemini keys (AQ. prefix) — t/3139', () => {
+    const input = 'key=AQ.FakeKeyForTesting1234567890123456';
+    expect(redactString(input)).toBe('key=[REDACTED]');
+  });
+
   it('redacts OpenAI/Anthropic keys (sk- prefix)', () => {
     const input = 'Authorization: sk-abcdefghijklmnopqrstuvwxyz';
     expect(redactString(input)).toBe('Authorization: [REDACTED]');
@@ -939,6 +944,19 @@ describe('serializer redaction integration', () => {
 
     expect(eventLine.message).toContain('[REDACTED]');
     expect(eventLine.message).not.toContain('AIzaSy');
+  });
+
+  it('redacts AQ.-format Gemini keys in an event message within dumps (t/3139)', () => {
+    recorder.record(makeInput({
+      message: 'API call failed with key AQ.FakeKeyForTesting1234567890123456',
+    }));
+
+    const { ndjson } = recorder.buildDump('explicit');
+    const lines = ndjson.trim().split('\n');
+    const eventLine = JSON.parse(lines[2]);
+
+    expect(eventLine.message).toContain('[REDACTED]');
+    expect(eventLine.message).not.toContain('AQ.FakeKeyForTesting');
   });
 
   it('redacts trigger error.message and context', () => {

--- a/lib/flight-recorder/redact.ts
+++ b/lib/flight-recorder/redact.ts
@@ -5,6 +5,7 @@ const REDACTED = '[REDACTED]';
 
 const API_KEY_PATTERNS: RegExp[] = [
   /AIzaSy[A-Za-z0-9_-]{33}/g,
+  /AQ\.[A-Za-z0-9_\-.]{20,}/g, // t/3139: newer Gemini key format (AQ.<...>) — bypassed the AIzaSy-only screen
   /\bsk-[A-Za-z0-9]{20,}/g,
   /\bgsk_[A-Za-z0-9]{20,}/g,
   /\bkey-[A-Za-z0-9]{20,}/g,

--- a/lib/sanitize/stripSensitiveKeys.test.ts
+++ b/lib/sanitize/stripSensitiveKeys.test.ts
@@ -23,6 +23,11 @@ describe('stripSensitiveKeys', () => {
     expect(out).toEqual({ c: 'S(normal)' }); // a + b dropped by SECRET_PREFIX_RE
   });
 
+  it('object branch: drops newer-format Gemini AQ. key values (t/3139)', () => {
+    const out = stripSensitiveKeys({ k: 'AQ.FakeKeyForTesting1234567890123456', c: 'normal' }, tag);
+    expect(out).toEqual({ c: 'S(normal)' }); // AQ. value dropped by SECRET_PREFIX_RE
+  });
+
   it('array branch: redacts secret-prefixed elements to "" and sanitizes the rest in place', () => {
     const out = stripSensitiveKeys(['sk-abc', 'hello', 'Bearer tok'], tag);
     expect(out).toEqual(['', 'S(hello)', '']); // shape preserved; secrets blanked, not dropped
@@ -58,6 +63,7 @@ describe('stripSensitiveKeys', () => {
     expect(SENSITIVE_KEYS.size).toBe(19); // drift guard — a dropped/added key trips this
     expect(SECRET_PREFIX_RE.test('sk-abc')).toBe(true);
     expect(SECRET_PREFIX_RE.test('AIzaXYZ')).toBe(true);
+    expect(SECRET_PREFIX_RE.test('AQ.FakeKey123')).toBe(true); // t/3139 newer Gemini key format
     expect(SECRET_PREFIX_RE.test('Bearer tok')).toBe(true);
     expect(SECRET_PREFIX_RE.test('normal-text')).toBe(false);
   });

--- a/lib/sanitize/stripSensitiveKeys.ts
+++ b/lib/sanitize/stripSensitiveKeys.ts
@@ -30,7 +30,7 @@ export const SENSITIVE_KEYS: ReadonlySet<string> = new Set<string>([
  * two-branches-one-updated drift the t/2032 fix closed). Kept byte-identical to the
  * original community.ts copy.
  */
-export const SECRET_PREFIX_RE = /^(sk-|AIza|gsk_|key-|xai-|Bearer\s)/;
+export const SECRET_PREFIX_RE = /^(sk-|AIza|AQ\.|gsk_|key-|xai-|Bearer\s)/; // AQ\. — t/3139 newer Gemini key format
 
 /**
  * Recursively strip sensitive keys + secret-prefixed strings and sanitize the rest,


### PR DESCRIPTION
**Security fix (t/3139, child of t/3138).** Google's newer Gemini key format `AQ.<...>` bypassed both TS redactors (matched only `AIzaSy…`); the live free-tier pool holds 4 such keys, so an AQ. key could leak in cleartext into logs / a flight-recorder dump / a public community blob.

## Fix (27+/2-)
- `flight-recorder/redact.ts`: add `/AQ\.[A-Za-z0-9_\-.]{20,}/g` to `API_KEY_PATTERNS` (substring redaction, like AIzaSy).
- `sanitize/stripSensitiveKeys.ts`: add `AQ\.` to `SECRET_PREFIX_RE` (public-blob prefix screen, like AIza/sk-/key-).
- `ai-client/providers/gemini.ts:298`: stale 401 message now says keys start with "AIza or AQ.".

## Regression tests (synthetic values only — never a real key)
redactString + a flight-recorder **event message** redact the AQ. key; stripSensitiveKeys drops an AQ. object value; `SECRET_PREFIX_RE` matches AQ. — mirrors the existing AIzaSy coverage. **97/97 green**, tsc + eslint clean.

Follows the existing redaction pattern (no new API/schema) — self-cert per /trivial-change, but **routed to TL for the security-diff review** per the ticket. Same-diff review requested before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)