### PR TITLE
feat(enrichment): Test-GeminiKeyPool — definitive free-key count + masked per-key validity (t/3141)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -126,6 +126,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-AnalyticsEventTypes` | Read-side analytics check — per-event-type counts from `GET /api/analytics/query` (surfaces instrumentation gaps like `view.dwell: 0`); `-Days`/`-Env prod\|staging` |
 | `Test-GitHubHealth` | GitHub platform + CI status |
 | `Test-AIApiKey` | Probe AI backend auth endpoints (no tokens consumed) — confirm a key is present and accepted before running jobs |
+| `Test-GeminiKeyPool` | Definitive count + per-key validity of the Gemini free-key pool from a key file (AIza + AQ. formats) via the auth-only probe; masked fingerprints only, never raw keys (t/3141) |
 | `Test-AIBackendHealth` | Full completion round-trip probe per backend — use before a debate run to surface degraded/unreachable models (t/2212) |
 | `Test-AIBackendQuota` | Per-backend quota probe — flags quota-exhausted backends (Status='quota') with a best-effort ResetAt; use at session start to catch quota exhaustion before a wall of judge failures (t/3029) |
 | `Test-DebateIndexIntegrity` | Validate debate-*.json field types for UI-crash regressions — catches the object-as-title bug (t/2335) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -188,6 +188,7 @@
         # t/1308 — cc→sit migration
         'Invoke-CcToSitMigration'
         'Test-AIApiKey'
+        'Test-GeminiKeyPool'
         'Test-AIBackendHealth'
         'Test-AIBackendQuota'
         'Test-AIModelsConfig'

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -936,6 +936,7 @@ Export-ModuleMember -Function @(
     # t/1308 — cc→sit migration
     'Invoke-CcToSitMigration'
     'Test-AIApiKey'
+    'Test-GeminiKeyPool'
     'Test-AIBackendHealth'
     'Test-AIBackendQuota'
     'Test-AIModelsConfig'

--- a/scripts/AITriad/Public/Test-GeminiKeyPool.ps1
+++ b/scripts/AITriad/Public/Test-GeminiKeyPool.ps1
@@ -1,0 +1,123 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Definitive count + per-key validity of the Gemini free-key pool, from a key file — masked only.
+.DESCRIPTION
+    Reads a key file, extracts every Gemini key (both the classic `AIza…` and the newer `AQ.<...>`
+    formats), dedups, and validates each via the canonical auth-only probe (`Test-AIApiKey -Backend
+    gemini` → `GET /v1beta/models?key=` — no tokens consumed). Reports a definitive unique count and
+    a per-key status, each key shown only as a MASKED fingerprint (first 6 … last 4).
+
+    SECURITY: raw keys are NEVER printed or written to disk — only masked fingerprints. The key file
+    is read locally and never echoed. (t/3141)
+
+    Status classification (from Test-AIApiKey's StatusCode/Functional):
+      VALID       — 200
+      DEAD        — 401 / 403 (present but rejected)
+      THROTTLED   — 429 (rate-limited; validity indeterminate right now)
+      NETWORK-ERR — no StatusCode (timeout / transport)
+      ERROR(<n>)  — any other status
+.PARAMETER Path
+    Key file to read. Defaults to $env:GEMINI_FREE_KEYS_FILE. One key per line, or any file the two
+    key-format regexes can extract from (blank lines and `#` comments are ignored in line-fallback).
+.PARAMETER TimeoutSec
+    Per-key probe timeout (seconds). Default 12.
+.OUTPUTS
+    [PSCustomObject] (AITriad.GeminiKeyPool): UniqueCount, Valid, Dead, Throttled, NetworkErr, Error,
+    and Keys (array of masked per-key rows: Fingerprint, Status, StatusCode, LatencyMs).
+.EXAMPLE
+    Test-GeminiKeyPool -Path ./free-keys.txt
+    # Definitive pool report; each key masked.
+.EXAMPLE
+    (Test-GeminiKeyPool -Path ./free-keys.txt).Keys | Where-Object Status -ne 'VALID'
+    # Surface only the non-valid keys (masked).
+.LINK
+    Test-AIApiKey
+.LINK
+    Show-AITriadHelp
+#>
+function Test-GeminiKeyPool {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Position = 0)]
+        [string]$Path,
+
+        [ValidateRange(1, 120)]
+        [int]$TimeoutSec = 12
+    )
+
+    Set-StrictMode -Version Latest
+
+    $keyFile = if ($Path) { $Path } elseif ($env:GEMINI_FREE_KEYS_FILE) { $env:GEMINI_FREE_KEYS_FILE } else { $null }
+    if (-not $keyFile) {
+        throw (New-ActionableError `
+            -Goal     'Report the Gemini free-key pool' `
+            -Problem  'No key-file path given.' `
+            -Location 'Test-GeminiKeyPool' `
+            -NextSteps @('Pass -Path <file>', 'or set $env:GEMINI_FREE_KEYS_FILE to the key file'))
+    }
+    if (-not (Test-Path -LiteralPath $keyFile)) {
+        throw (New-ActionableError `
+            -Goal     'Report the Gemini free-key pool' `
+            -Problem  "Key file not found: $keyFile" `
+            -Location 'Test-GeminiKeyPool' `
+            -NextSteps @('Verify the path', 'Pass -Path to the correct key file'))
+    }
+
+    # ── Parse: match both key formats; fall back to one-per-line; dedup (t/3141, TL ref) ──
+    $raw = Get-Content -Raw -LiteralPath $keyFile
+    $rxMatches = [regex]::Matches($raw, '(AIza[0-9A-Za-z_\-]{35}|AQ\.[A-Za-z0-9_\-\.]{20,80})')
+    $all = @($rxMatches | ForEach-Object { $_.Value })
+    if ($all.Count -eq 0) {
+        $all = @(Get-Content -LiteralPath $keyFile |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ -and -not $_.StartsWith('#') })
+    }
+    $unique = @($all | Select-Object -Unique)
+
+    # Masked fingerprint — never the raw key.
+    $mask = {
+        param([string]$k)
+        if ([string]::IsNullOrEmpty($k)) { return '' }
+        if ($k.Length -le 10) { return ('*' * $k.Length) }
+        "$($k.Substring(0, 6))…$($k.Substring($k.Length - 4))"
+    }
+
+    $rows = [System.Collections.Generic.List[PSObject]]::new()
+    foreach ($k in $unique) {
+        $probe = Test-AIApiKey -Backend gemini -ApiKey $k
+        $sc = if ($probe -and $probe.PSObject.Properties['StatusCode']) { $probe.StatusCode } else { $null }
+        $fn = if ($probe -and $probe.PSObject.Properties['Functional']) { [bool]$probe.Functional } else { $false }
+        $lat = if ($probe -and $probe.PSObject.Properties['LatencyMs']) { $probe.LatencyMs } else { $null }
+
+        $status =
+            if ($fn -and $sc -eq 200) { 'VALID' }
+            elseif ($sc -in 401, 403) { 'DEAD' }
+            elseif ($sc -eq 429)      { 'THROTTLED' }
+            elseif ($null -eq $sc)    { 'NETWORK-ERR' }
+            else                      { "ERROR($sc)" }
+
+        $rows.Add([PSCustomObject]@{
+            Fingerprint = & $mask $k
+            Status      = $status
+            StatusCode  = $sc
+            LatencyMs   = $lat
+        })
+    }
+
+    $count = { param($s) @($rows | Where-Object { $_.Status -eq $s }).Count }
+
+    [PSCustomObject]@{
+        PSTypeName  = 'AITriad.GeminiKeyPool'
+        UniqueCount = $unique.Count
+        Valid       = (& $count 'VALID')
+        Dead        = (& $count 'DEAD')
+        Throttled   = (& $count 'THROTTLED')
+        NetworkErr  = (& $count 'NETWORK-ERR')
+        Error       = @($rows | Where-Object { $_.Status -like 'ERROR(*' }).Count
+        Keys        = @($rows)
+    }
+}

--- a/tests/Test-GeminiKeyPool.Tests.ps1
+++ b/tests/Test-GeminiKeyPool.Tests.ps1
@@ -1,0 +1,82 @@
+# Tag: enrichment (t/3141)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Unit tests for Test-GeminiKeyPool (t/3141). Mocks the Test-AIApiKey auth probe; uses SYNTHETIC
+    keys built at runtime (split literals) so no source literal matches a key pattern, and asserts
+    output is MASKED (never a raw key).
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Test-GeminiKeyPool' -Tag 'enrichment' {
+
+    It 'is exported from the module' {
+        Get-Command -Module AITriad -Name 'Test-GeminiKeyPool' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'parses both key formats, dedups, ignores blank/# lines; classifies via the probe; masks output' {
+        InModuleScope AITriad {
+            # SYNTHETIC keys — built via concatenation so the source never contains a full key literal.
+            $k1 = 'AIza' + 'SYNTHETIC_key_' + ('0' * 21)    # valid (200); exactly 35 chars after AIza
+            $k2 = 'AQ.'  + 'SYNTHETICdeadkey' + ('0' * 14)  # dead (403)
+            $k3 = 'AIza' + 'SYNTHETIC_thr_' + ('1' * 21)    # throttled (429)
+
+            $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "keys-$([guid]::NewGuid().ToString('N').Substring(0,8)).txt"
+            Set-Content -LiteralPath $tmp -Value @('# free-tier keys', '', $k1, $k2, $k3, $k1) -Encoding utf8  # k1 duplicated
+
+            Mock Test-AIApiKey -MockWith {
+                if ($ApiKey -like '*deadkey*') { [PSCustomObject]@{ Functional = $false; StatusCode = 403; LatencyMs = 5 } }
+                elseif ($ApiKey -like '*_thr_*') { [PSCustomObject]@{ Functional = $false; StatusCode = 429; LatencyMs = 5 } }
+                else { [PSCustomObject]@{ Functional = $true; StatusCode = 200; LatencyMs = 5 } }
+            }
+
+            try {
+                $r = Test-GeminiKeyPool -Path $tmp
+                $r.UniqueCount | Should -Be 3        # k1 deduped
+                $r.Valid       | Should -Be 1
+                $r.Dead        | Should -Be 1
+                $r.Throttled   | Should -Be 1
+                $r.NetworkErr  | Should -Be 0
+                @($r.Keys).Count | Should -Be 3
+
+                # MASKED: no raw key material in the output (distinctive middle chunk absent).
+                $joined = (@($r.Keys) | ForEach-Object { "$($_.Fingerprint)" }) -join ' '
+                $joined | Should -Not -Match 'SYNTHETIC'          # middle of every synthetic key
+                $joined | Should -Match '…'                        # masked fingerprint format
+            } finally { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'classifies a NETWORK-ERR (null StatusCode) key' {
+        InModuleScope AITriad {
+            $k = 'AIza' + 'SYNTHETIC_net_' + ('2' * 21)
+            $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "keys-$([guid]::NewGuid().ToString('N').Substring(0,8)).txt"
+            Set-Content -LiteralPath $tmp -Value @($k) -Encoding utf8
+            Mock Test-AIApiKey -MockWith { [PSCustomObject]@{ Functional = $false; StatusCode = $null; LatencyMs = $null } }
+            try {
+                $r = Test-GeminiKeyPool -Path $tmp
+                $r.NetworkErr | Should -Be 1
+                $r.Keys[0].Status | Should -Be 'NETWORK-ERR'
+            } finally { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue }
+        }
+    }
+
+    It 'throws when no -Path and no $env:GEMINI_FREE_KEYS_FILE' {
+        InModuleScope AITriad {
+            $prev = $env:GEMINI_FREE_KEYS_FILE
+            $env:GEMINI_FREE_KEYS_FILE = $null
+            try { { Test-GeminiKeyPool } | Should -Throw } finally { $env:GEMINI_FREE_KEYS_FILE = $prev }
+        }
+    }
+
+    It 'throws an actionable error when the key file is missing' {
+        { Test-GeminiKeyPool -Path (Join-Path ([System.IO.Path]::GetTempPath()) 'no-such-keys-file.txt') } | Should -Throw
+    }
+}


### PR DESCRIPTION
Adds `Test-GeminiKeyPool`: reads a key file, extracts **both** Gemini formats (`AIza…` + newer `AQ.<...>`), dedups, and validates each via the canonical auth-only probe (`Test-AIApiKey -Backend gemini` — no tokens consumed). Emits a definitive unique count + `VALID / DEAD(401·403) / THROTTLED(429) / NETWORK-ERR` classification and a per-key **MASKED** fingerprint (first6…last4). **Raw keys are never printed or persisted.**

- `-Path` (default `$env:GEMINI_FREE_KEYS_FILE`); `New-ActionableError` when neither is set or the file is missing. Tolerant parse: two-format regex → one-per-line fallback (skips blank/`#`) → dedup.
- **Reuses `Test-AIApiKey`** (single canonical probe path, per TL) rather than inlining REST.
- Folds in TL's validated reference (t/3141#1: parse + mask); masked output only.

Self-cert **/add-ps-cmdlet**. Tests **5/5** (both formats + dedup + comment/blank + classification incl. NETWORK-ERR + **masked-never-raw** + missing-path/file), manifest + export parity OK. Scope: reporter only (2b, TL decision). Closes t/3141.