### PR TITLE
docs(cl): instrument-integrity checklist + register validation-path notes (t/3101)

### DIFF
--- a/research/comp-linguist/docs/instrument-integrity-checklist.md
+++ b/research/comp-linguist/docs/instrument-integrity-checklist.md
@@ -1,0 +1,34 @@
+# Instrument-Integrity Checklist
+
+**Owner:** Computational Linguist. **Applies to:** any new (or materially changed) metric, LLM judge, or verdict grammar before its output is cited as a disposition rather than an indicative sample.
+
+A scalar or verdict is an instrument. Before it counts as evidence, it must pass the six checks below. The first four are the protocol from the instrument-effects paper (arXiv 2607.14399 §5.3, four-check integrity protocol, retrieved verbatim); checks 5–6 are this project's standing additions. Each check names how we already enforce it, or flags the gap.
+
+## The checks
+
+**1. Taxonomy saturation.** *Can the outcome grammar express the weaker claim (a calibrated "incomplete"/"undecidable"/equivalent)? Add the missing verdict and measure what it absorbs.*
+- Enforcement: ad hoc today. The t/3097 audit found the model-facing crux grammar (`addressed | partially_addressed | unaddressed`) FAILS this: it lacks the `undecidable` option its structural twin (`CruxResolutionState.undecided`) has, so structurally-undecided cruxes are absorbed into `unaddressed`/`partially_addressed`, shaping `crux_addressed_rate`. Any new verdict grammar must include an explicit not-yet-decidable option and report what it absorbs. Follow-up A/B: t/3144.
+
+**2. Criterion disclosure.** *Run a disclosed-criterion arm. If "false" verdicts collapse when the judging criterion is made explicit, the hidden criterion was manufacturing them, and the instrument was measuring criterion opacity, not the construct.*
+- Enforcement: **NOT enforced. This is the gap.** We have no disclosed-criterion arm for any judge. New LLM judges must ship with a disclosed-criterion control run before their verdict rates are trusted. (Distinct from the provenance-laundering framing lever, t/3098: that is about how content is presented; this is about whether the *judge's* criterion is hidden.)
+
+**3. Censoring analysis.** *Condition verdict rates on reaching a decision point, and check whether resource budgets censor which verdicts can be observed at all.*
+- Enforcement: **enforced** via the censoring gate (t/1671): headline convergence metrics read un-pooled via `computeConvergenceWithCensoring` (decision-point-reached runs only); `CENSORED_REASONS = {max_iterations, situation_cap, api_ceiling}`; `n_unknown` excluded from the denominator. A metric shift is not actionable until its paired `censoring_rate` is stable across the compared windows.
+
+**4. Distribution replication.** *Re-run fixed configurations (n ≥ 10 per instance) and report verdict distributions, not single draws.*
+- Enforcement: **enforced for regression decisions** (replication gate, t/1668: n ≥ 10 clean-tree draws, read the metric as a distribution). Extending to *reporting* (t/3096): any headline cited as a disposition carries a distribution over n re-runs, not a point. Distinguish estimation-uncertainty (bootstrap of one draw) from run-instability (n re-runs); only the latter answers run-drift.
+
+**5. Provenance + reporting-treatment registration.** Every scalar carries a provenance class (`stipulated | derived | human-validated`) AND a reporting-treatment tag (`single-draw | n-draw distribution`) in `metric-provenance-register.md`. No evidence pointer = stipulated by definition. A grammar/threshold/weight change is a provenance event and requires a register update in the same PR.
+
+**6. Reproduce before assert (t/2294).** Before asserting a metric's ground truth, error class, or "correct" value, run the actual pipeline/retrieval that produced the observed behavior. Never infer from node/description text alone. Label constructed cases `constructed`, observed cases `observed`.
+
+## Truthfulness vs honesty (register caveat)
+
+Our behavioral honesty/consistency metrics (and the RepE-style probes, arXiv 2310.01405) measure whether a model **asserts claims consistently with its own reasoning**, not whether those claims correspond to external ground truth. Per the instrument-effects paper, the true-positive cell can be unpopulatable by construction, so such metrics measure false-positive behavior only. Any honesty/consistency metric in the register must state this truthfulness-vs-honesty limit so a consumer does not read it as a truth measure.
+
+## How to use
+
+- New/changed metric, judge, or verdict grammar → walk checks 1–6, record the outcome in the provenance register. Checks 1–4 that cannot be satisfied yet are declared open (with a follow-up ticket), not silently skipped.
+- **Gate-touching** application (wiring any check into CI as a blocking gate) routes to Main (TL) for both-arms Gate Verification. This checklist itself is advisory discipline, not a CI gate, until a specific check is proposed as one.
+
+*Sources: arXiv 2607.14399 §5.3 (four-check protocol, retrieved 2026-08-31); project gates t/1668, t/1671, t/2294; audit findings t/3096, t/3097, t/3098.*

--- a/research/comp-linguist/docs/metric-provenance-register.md
+++ b/research/comp-linguist/docs/metric-provenance-register.md
@@ -9,6 +9,8 @@
 
 Every scalar the system emits implies a measurement instrument. This register classifies each one so that false precision is a visible, countable property of the system rather than a critique waiting to be written.
 
+New or changed metrics, judges, and verdict grammars run the six-check **instrument-integrity checklist** (`instrument-integrity-checklist.md`) before their output is cited as a disposition. **Truthfulness-vs-honesty limit:** behavioral honesty and consistency metrics (and RepE-style probes) measure whether a model asserts claims consistently with its own reasoning, not whether those claims match external ground truth; read them as honesty measures, not truth measures (arXiv 2607.14399 §3.1; 2310.01405).
+
 **Classes:**
 
 | Class | Meaning | Evidence requirement |
@@ -38,7 +40,7 @@ The honest summary: nearly every judgment-bearing number in the system is curren
 | `relevance_threshold` (0.48 base) | **derived** | Pairwise cosine-distribution analysis over 1,182 nodes (2026-05): 0.3 admitted 93.3% of pairs; 0.48 ≈ 65%. Self-tunes ±0.02–0.03 in [0.35, 0.60] from utilization telemetry (`calibrationOptimizer.ts`). | 2026-05 |
 | `argumentation_exit_threshold` | stipulated | Optimizer produces recommend-only adjustments from quality score; not auto-applied. | — |
 | `qbaf_damping_level` | **derived** | Raised in response to observed oscillation telemetry (`qbaf_oscillation_*`). | 2026-06 |
-| `attack_weights` [1.0, 1.1, 1.2] | stipulated | Rebut/undercut/undermine escalation asserted. | — |
+| `attack_weights` [1.0, 1.1, 1.2] | stipulated | Rebut/undercut/undermine escalation asserted. Named validation path: gradient-learned edge weights from a labeled outcome set (Gradual AA-CBR, t/3023). | — |
 | `draft_temperature` (0.7) | stipulated | Informed by the temperature-per-task audit but no formal optimization. | — |
 | `argumentative_saturation_weights` | stipulated | Composite signal weights asserted. | — |
 | `semantic_recycling_threshold` | stipulated | | — |


### PR DESCRIPTION
New `research/comp-linguist/docs/instrument-integrity-checklist.md` — the six checks any new metric/judge/verdict-grammar must pass before its output is cited as a disposition:
1. **Taxonomy saturation** — grammar must express the weaker/undecidable verdict (the t/3097 crux-grammar gap)
2. **Criterion disclosure** — disclosed-criterion arm; **the unenforced gap we don't yet do**
3. **Censoring analysis** — condition on decision-point-reached (t/1671)
4. **Distribution replication** — n≥10, report distributions (t/1668 + t/3096)
5. Provenance + reporting-treatment registration
6. Reproduce-before-assert (t/2294)

Checks 1–4 are the arXiv 2607.14399 §5.3 four-check protocol, **retrieved verbatim** (not inferred). Register: `attack_weights` gains its named validation path (gradient-learned edge weights, Gradual AA-CBR t/3023); intro gains the truthfulness-vs-honesty limit on behavioral honesty metrics.

Docs-only, CL scope, 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)