### PR TITLE
feat(entities): EntityVectorRecord contract + v1/v2 back-compat reader (t/3121 A+B)

### DIFF
--- a/lib/entities/entityVectors.ts
+++ b/lib/entities/entityVectors.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// entity_embeddings.json vector-store contract (t/3121, TL ruling t/3121#4). Interface-first:
+// the PowerShell writer (Import-Entity + Update-EntityEmbeddings) and the Shared Lib reader
+// (nameResolver) both target this shape. Kept separate from the entity RECORD contract (types.ts)
+// because it describes a distinct derived store.
+
+/**
+ * The per-entity value in entity_embeddings.json under schema v2. `name_vector` embeds the
+ * label + aliases and drives the resolution ladder's cosine tie-break; `description_vector`
+ * embeds the description and is written now for a FUTURE semantic rung (R6) — not yet wired.
+ * Both are all-MiniLM-L6-v2, 384-dim. Mirrors the multi-named-vector precedent `exclusion_vector`
+ * (lib/debate/exclusionGuard.ts): an object of named vectors where some are optional/skippable.
+ */
+export interface EntityVectorRecord {
+  name_vector: number[];
+  /** Optional — omitted when the entity has no description. Readers MUST tolerate its absence. */
+  description_vector?: number[];
+}
+
+/**
+ * The value stored at `vectors[<id>]` across the schema-version window. Back-compat is MANDATORY
+ * (TL t/3121#4): the multi-vector backfill is a human-run data-push, so code is v2 while prod data
+ * may still be v1 until the human runs it — no flag day.
+ *  - v1 (schema 1.0.0): a flat `number[]` — a single blended name+description vector.
+ *  - v2 (schema 2.0.0): an {@link EntityVectorRecord}.
+ * Structurally self-describing (array ⟺ v1, object ⟺ v2), so a reader can select the name vector
+ * without threading the envelope `_schema_version` per lookup.
+ */
+export type EntityVectorStored = number[] | EntityVectorRecord;
+
+/** entity_embeddings.json envelope `_schema_version` after the multi-vector upgrade (t/3121). */
+export const ENTITY_EMBEDDINGS_SCHEMA_VERSION = '2.0.0';
+
+/**
+ * Select the NAME vector from a stored value, handling both v1 (flat array → the vector as-is)
+ * and v2 (object → `name_vector`). The single home for the v1/v2 back-compat rule (TL t/3121#4)
+ * so every consumer reads it one way. Returns undefined for an absent entry.
+ */
+export function nameVectorOf(stored: EntityVectorStored | undefined): number[] | undefined {
+  if (stored === undefined) return undefined;
+  return Array.isArray(stored) ? stored : stored.name_vector;
+}

--- a/lib/entities/nameResolver.test.ts
+++ b/lib/entities/nameResolver.test.ts
@@ -9,6 +9,7 @@ import {
   ENTITY_RESOLUTION_MARGIN,
   type ApprovedEntityView,
 } from './nameResolver.js';
+import { nameVectorOf, type EntityVectorRecord } from './entityVectors.js';
 
 // Two entities sharing the exact alias "Chris" — the canonical alias-collision fixture.
 const CHRIS_OLAH: ApprovedEntityView = { id: 'ent-010', name: 'Chris Olah', aliases: ['Chris', 'Olah'] };
@@ -16,8 +17,12 @@ const CHRIS_MANNING: ApprovedEntityView = { id: 'ent-011', name: 'Chris Manning'
 const BENGIO: ApprovedEntityView = { id: 'ent-001', name: 'Yoshua Bengio', aliases: ['Bengio'] };
 const ANTHROPIC: ApprovedEntityView = { id: 'org-001', name: 'Anthropic', aliases: ['Anthropic PBC'] };
 
-// A trivial vector store keyed by entity id.
+// A trivial v1 vector store keyed by entity id (flat number[]).
 function vectorStore(map: Record<string, number[]>): (id: string) => number[] | undefined {
+  return (id) => map[id];
+}
+// A v2 vector store — per-entity { name_vector, description_vector? } record (t/3121 back-compat).
+function vectorStoreV2(map: Record<string, EntityVectorRecord>): (id: string) => EntityVectorRecord | undefined {
   return (id) => map[id];
 }
 const noVectors = (): number[] | undefined => undefined;
@@ -107,6 +112,22 @@ describe('resolveEntityName — embedding tie-break among alias collisions', () 
     expect(r.score).toBeCloseTo(1, 5);
   });
 
+  it('breaks a v2-record collision using name_vector, tolerating a missing description_vector (t/3121)', () => {
+    const r = resolveEntityName(
+      { name: 'Chris', contextVector: [1, 0, 0] },
+      collided,
+      vectorStoreV2({
+        // ent-010's DESCRIPTION vector points away ([0,0,1]); only name_vector must be scored.
+        'ent-010': { name_vector: [1, 0, 0], description_vector: [0, 0, 1] },
+        'ent-011': { name_vector: [0, 1, 0] }, // description_vector absent — must be tolerated
+      }),
+    );
+    expect(r.status).toBe('resolved');
+    expect(r.via).toBe('embedding');
+    expect(r.ref).toEqual({ kind: 'entity', id: 'ent-010' });
+    expect(r.score).toBeCloseTo(1, 5); // scored name_vector [1,0,0], NOT description_vector [0,0,1]
+  });
+
   it('refuses (ambiguous) when separation is below the margin', () => {
     const r = resolveEntityName(
       { name: 'Chris', contextVector: [1, 1, 0] },
@@ -161,5 +182,21 @@ describe('exported thresholds', () => {
   it('pins the documented defaults', () => {
     expect(ENTITY_RESOLUTION_MIN_COSINE).toBe(0.6);
     expect(ENTITY_RESOLUTION_MARGIN).toBe(0.05);
+  });
+});
+
+describe('nameVectorOf — v1/v2 back-compat name-vector selection (t/3121)', () => {
+  it('returns a v1 flat array as-is', () => {
+    expect(nameVectorOf([1, 0, 0])).toEqual([1, 0, 0]);
+  });
+  it('returns a v2 record\'s name_vector (not description_vector)', () => {
+    const rec: EntityVectorRecord = { name_vector: [1, 0], description_vector: [0, 1] };
+    expect(nameVectorOf(rec)).toEqual([1, 0]);
+  });
+  it('tolerates a v2 record with no description_vector', () => {
+    expect(nameVectorOf({ name_vector: [0, 1] })).toEqual([0, 1]);
+  });
+  it('returns undefined for an absent entry', () => {
+    expect(nameVectorOf(undefined)).toBeUndefined();
   });
 });

--- a/lib/entities/nameResolver.ts
+++ b/lib/entities/nameResolver.ts
@@ -16,6 +16,7 @@
 import type { EntityRef } from './types.js';
 import { parseEntityRef } from './types.js';
 import { cosineSimilarity } from '../embeddings/similarity.js';
+import { nameVectorOf, type EntityVectorStored } from './entityVectors.js';
 
 /**
  * Resolution-seam cosine floor. Reuses the §7 entity-linking cosine (0.60, stipulated,
@@ -107,13 +108,15 @@ function refsOf(entities: ApprovedEntityView[]): EntityRef[] {
 
 /**
  * Resolve a surface name to an {@link EntityRef}, or refuse. Pure. See file header for the
- * three-step contract. `getVector` maps an entity id to its approved name+description vector
- * (entity_embeddings.json), returning undefined when absent.
+ * three-step contract. `getVector` maps an entity id to its stored vector value in
+ * entity_embeddings.json — either v1 (a flat `number[]`) or v2 ({@link EntityVectorRecord}),
+ * returning undefined when absent. The cosine tie-break uses the NAME vector, selected across
+ * both schema versions via {@link nameVectorOf} (v1 array as-is, v2 `.name_vector`) — t/3121.
  */
 export function resolveEntityName(
   query: NameQuery,
   approved: ApprovedEntityView[],
-  getVector: (id: string) => number[] | undefined,
+  getVector: (id: string) => EntityVectorStored | undefined,
   opts?: { minCosine?: number; margin?: number },
 ): NameResolution {
   const minCosine = opts?.minCosine ?? ENTITY_RESOLUTION_MIN_COSINE;
@@ -156,7 +159,7 @@ export function resolveEntityName(
   const scored: { ref: EntityRef; score: number }[] = [];
   for (const e of matches) {
     const ref = parseEntityRef(e.id);
-    const vec = getVector(e.id);
+    const vec = nameVectorOf(getVector(e.id)); // v1 flat array or v2 name_vector (t/3121)
     if (!ref || !vec) continue;
     scored.push({ ref, score: cosineSimilarity(cv, vec) });
   }


### PR DESCRIPTION
**t/3121 items A+B** — the interface-first prerequisite for the multi-vector entity-embeddings upgrade (TL-approved design t/3121#4). Self-cert against the ruling; unblocks PowerShell's writer/backfill (C/D) + this reader in parallel.

## A — shared contract (`lib/entities/entityVectors.ts`, new)
`EntityVectorRecord = { name_vector: number[]; description_vector?: number[] }` (mirrors the `exclusion_vector` multi-named-vector precedent), `EntityVectorStored = number[] | EntityVectorRecord` for the schema window, `ENTITY_EMBEDDINGS_SCHEMA_VERSION = '2.0.0'`, and `nameVectorOf()` — the single home for the v1/v2 name-vector selection.

## B — reader widen (`nameResolver.ts`)
`getVector` widened to `(id) => EntityVectorStored | undefined`; the cosine tie-break selects the name vector via `nameVectorOf` (v1 flat array as-is, v2 `.name_vector`), tolerating a missing `description_vector`. **Back-compat mandatory** (TL): the backfill is a human-run data-push, so code is v2 while prod data may still be v1 — no flag day. `description_vector` is written for a future R6 semantic rung, not wired here.

## Verified
v2-record tie-break uses name_vector (not description_vector) + tolerates absent description_vector; direct `nameVectorOf` v1/v2/absent cases. **24/24 green**, tsc + eslint clean. No production caller today → tiny blast radius (TL). Routed to Quality; PowerShell's C/D unblock once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)