### PR TITLE
fix(diagnostics): Get-TaxEditorServerLogs -Max keeps NEWEST rows, not oldest + cap-hit warn (t/3150)

### DIFF
--- a/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
+++ b/scripts/AITriad/Public/Get-TaxEditorServerLogs.ps1
@@ -167,7 +167,11 @@ function Get-TaxEditorServerLogs {
 
         if ($System) { $kql.Add('| project TimeGenerated, Log_s, Type_s, Reason_s, RevisionName_s') }
         else         { $kql.Add('| project TimeGenerated, Log_s, RevisionName_s') }
-        $kql.Add('| order by TimeGenerated asc')
+        # t/3150: order DESC then take, so the cap keeps the NEWEST $Max rows. (asc+take silently
+        # returned the OLDEST $Max and dropped the most recent events — a triage footgun; the
+        # silent-wrong-subset class, same as t/3117.) The set is re-sorted ascending below for
+        # chronological display; the emitted row shape is unchanged.
+        $kql.Add('| order by TimeGenerated desc')
         $kql.Add("| take $Max")
         # t/3117: MUST be a SINGLE LINE (join with space, not newline). The query is passed inline
         # as one `--analytics-query` arg to `& az`; an embedded newline truncates the arg at the
@@ -185,6 +189,14 @@ function Get-TaxEditorServerLogs {
             '--analytics-query', $analyticsQuery,
             '--output', 'json')
         $rows = if ($json) { @($json | ConvertFrom-Json) } else { @() }
+
+        # t/3150: the query returns the NEWEST $Max (desc+take); re-sort ascending for chronological
+        # display (TimeGenerated is ISO-8601 → a lexical sort is chronological). Warn on a cap hit —
+        # older events in the window were dropped; never silently return a wrong subset.
+        $rows = @($rows | Sort-Object { [string]$_.TimeGenerated })
+        if ($rows.Count -ge $Max) {
+            Write-Warning "Hit the -Max cap ($Max): the window has at least $Max matching lines — showing the NEWEST $Max; older events were dropped. Narrow -From/-To or raise -Max to see them."
+        }
 
         # ── StrictMode-safe field read (absent property -> $null) ──────────
         $getField = {

--- a/tests/Get-TaxEditorServerLogs.Tests.ps1
+++ b/tests/Get-TaxEditorServerLogs.Tests.ps1
@@ -124,6 +124,32 @@ Describe 'Get-TaxEditorServerLogs' -Tag 'diagnostics' {
             $script:capturedQueryArg | Should -Match 'take '                          # take survives (the tell)
             $script:capturedQueryArg | Should -Match "todatetime\('"                  # window bound uses todatetime (valid KQL)
             $script:capturedQueryArg | Should -Not -Match "between \(datetime\('"     # not the quoted-datetime() literal
+            $script:capturedQueryArg | Should -Match 'order by TimeGenerated desc'    # t/3150: cap keeps NEWEST N, not oldest
+        }
+    }
+
+    It 'keeps the newest rows at the cap, re-sorts ascending for display, and warns on cap-hit (t/3150)' {
+        InModuleScope AITriad {
+            $script:TaxEditorLogWorkspaceId = 'ws-guid-abc'
+            Mock Assert-AzCli { }
+            # Query returns rows newest-first (as desc+take yields); scrambled here to prove the cmdlet
+            # re-sorts ascending regardless of input order.
+            $rows = @(
+                @{ TimeGenerated = '2026-08-31T10:00:03Z'; RevisionName_s = 'r'; Log_s = (@{ level = 30; requestId = 'c'; msg = 'newest' } | ConvertTo-Json -Compress) }
+                @{ TimeGenerated = '2026-08-31T10:00:01Z'; RevisionName_s = 'r'; Log_s = (@{ level = 30; requestId = 'a'; msg = 'oldest' } | ConvertTo-Json -Compress) }
+                @{ TimeGenerated = '2026-08-31T10:00:02Z'; RevisionName_s = 'r'; Log_s = (@{ level = 30; requestId = 'b'; msg = 'mid' } | ConvertTo-Json -Compress) }
+            )
+            $queryJson = $rows | ConvertTo-Json -Depth 6
+            Mock Invoke-Az -ParameterFilter { $Arguments -contains 'query' } -MockWith { $queryJson }.GetNewClosure()
+
+            $warn = @()
+            $r = @(Get-TaxEditorServerLogs -Max 3 -WarningVariable warn)   # returned count == -Max → cap-hit
+            $r.Count | Should -Be 3
+            # re-sorted ascending (oldest → newest) regardless of the query's return order
+            $r[0].RequestId | Should -Be 'a'
+            $r[1].RequestId | Should -Be 'b'
+            $r[2].RequestId | Should -Be 'c'
+            ($warn -join ' ') | Should -Match 'Hit the -Max cap'
         }
     }
 


### PR DESCRIPTION
**Medium** (Diagnostics, found in the t/3111 acceptance run; bit them twice). The KQL was `order by TimeGenerated asc | take $Max`, so on a window with >$Max lines the cap returned the **OLDEST** $Max and silently dropped the most recent events — triage queries hid the very lines under investigation. Silent-wrong-subset class, same as t/3117.

**Fix:** `order by TimeGenerated desc | take $Max` (cap keeps the **newest** $Max), then re-sort the returned set ascending for chronological display (TimeGenerated is ISO-8601 → lexical sort is chronological). Emitted **row shape unchanged** — no log-shape-contract change, so self-cert /trivial-change per TL (p/360#219). Added a cap-hit `Write-Warning` (rows.Count ≥ -Max) so a truncated window is never silently a wrong subset.

**Prevention:** tests assert the KQL uses `order by TimeGenerated desc`, that output is re-sorted ascending regardless of the query's return order, and that the cap-hit warning fires at -Max. **10/10**, manifest clean.

Closes t/3150.