### PR TITLE
ci(deploy): promote /readyz warm-gate to blocking (t/3148) [DRAFT — held for TL GV]

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -496,26 +496,28 @@ jobs:
             Add-Content -Path $env:GITHUB_OUTPUT -Value 'accepted=true'
           }
 
-      - name: Warm-gate observe (/readyz) — OBSERVE-ONLY, does not gate (t/3114, t/2683)
+      - name: Warm-gate (/readyz) — PEER-BLOCKING (t/3148, promoted from observe-only)
         id: warm_gate
         if: steps.health_check.outputs.healthy == 'true'
         shell: pwsh
         run: |
-          # t/3114 OBSERVE-ONLY (Gate Promotion t/2683, real-env-first): compute + LOG whether the
-          # new revision's embeddings.json vector-cache is warm (/readyz 200) BEFORE traffic shifts,
-          # but do NOT gate — this step is intentionally absent from every success/rollback
-          # if-condition. It validates real-env warm detection (FQDN resolves, real 503->200, no
-          # false timeout) on >=1 real deploy; a follow-up flip PR then wires it as the peer-blocking
-          # gate (require warm==true to shift; rollback on warm==false) — that wiring is already GV'd
-          # offline (t/3114#3). -ObserveOnly => a warm timeout logs ::warning:: and exits 0 (never
-          # blocks). The printed /readyz body lets us confirm the real 200 is {status:ready}, not the
-          # SPA index.html fallback (ServerAPI p/542#74); the flip couples a body-shape check.
+          # t/3148 BLOCKING flip (mechanism B, TL-decided p/542#108; real-env evidence run
+          # 33434586564: "Warm-gate PASSED after 1 poll … {status:ready,nodeCount:4144}"). Poll the
+          # new revision's /readyz until the embeddings.json cache is warm, then emit warm=true/false.
+          # This step is a PEER of the acceptance/persona gates: 'Shift traffic' requires
+          # warm=='true'; warm=='false' takes the SAME full rollback path as an acceptance failure.
+          # The runner is FAIL-CLOSED (warm defaults false; only a proven-warm 200 with body
+          # {status:ready,nodeCount>0} sets true) and always exits 0 — the gate is OUTPUT-driven,
+          # not exit-code-driven. A non-JSON SPA index.html 200 is NOT warm (body-shape check,
+          # ServerAPI p/542#74). warm is UNSET only when this step is SKIPPED (health!='true'),
+          # which every rollback condition already covers via its health!='true' clause (no limbo).
           $BaseUrl = "${{ steps.health_check.outputs.base_url }}"
-          & ./operations/devops/Invoke-ReadyzWarmGateCheck.ps1 -BaseUrl $BaseUrl -TimeoutSec 300 -PollIntervalSec 10 -ObserveOnly
-          Write-Host "warm-gate observe: /readyz probe complete (observe-only, non-gating)."
+          & ./operations/devops/Invoke-ReadyzWarmGateCheck.ps1 -BaseUrl $BaseUrl -TimeoutSec 300 -PollIntervalSec 10
 
       - name: Shift traffic to new revision
-        if: steps.health_check.outputs.healthy == 'true' && steps.acceptance.outputs.accepted == 'true' && steps.persona.outputs.accepted == 'true'
+        # t/3148: warm_gate is now a peer gate — traffic shifts only when the /readyz warm-gate
+        # reports warm=='true' (embeddings.json cache proven warm), alongside acceptance/persona.
+        if: steps.health_check.outputs.healthy == 'true' && steps.acceptance.outputs.accepted == 'true' && steps.persona.outputs.accepted == 'true' && steps.warm_gate.outputs.warm == 'true'
         shell: pwsh
         run: |
           Import-Module ./scripts/AITriad/AITriad.psm1 -Force
@@ -578,7 +580,9 @@ jobs:
           Write-Host "Config verification passed ($($ConfigChecks.Count) checks)"
 
       - name: Collect failure diagnostics
-        if: steps.health_check.outputs.healthy != 'true' || steps.acceptance.outputs.accepted == 'false' || steps.persona.outputs.accepted == 'false'
+        # t/3148: warm_gate is a peer failure trigger — a warm-timeout (warm=='false') collects
+        # diagnostics on the same footing as an acceptance/persona failure.
+        if: steps.health_check.outputs.healthy != 'true' || steps.acceptance.outputs.accepted == 'false' || steps.persona.outputs.accepted == 'false' || steps.warm_gate.outputs.warm == 'false'
         continue-on-error: true
         shell: pwsh
         run: |
@@ -599,7 +603,7 @@ jobs:
           else { Write-Host '(no system logs available)' }
 
       - name: Re-authenticate before rollback
-        if: always() && (steps.health_check.outputs.healthy != 'true' || steps.acceptance.outputs.accepted == 'false' || steps.persona.outputs.accepted == 'false') && steps.current_revision.outputs.revision != ''
+        if: always() && (steps.health_check.outputs.healthy != 'true' || steps.acceptance.outputs.accepted == 'false' || steps.persona.outputs.accepted == 'false' || steps.warm_gate.outputs.warm == 'false') && steps.current_revision.outputs.revision != ''
         uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c  # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -607,7 +611,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Rollback on failure
-        if: always() && (steps.health_check.outputs.healthy != 'true' || steps.acceptance.outputs.accepted == 'false' || steps.persona.outputs.accepted == 'false') && steps.current_revision.outputs.revision != ''
+        if: always() && (steps.health_check.outputs.healthy != 'true' || steps.acceptance.outputs.accepted == 'false' || steps.persona.outputs.accepted == 'false' || steps.warm_gate.outputs.warm == 'false') && steps.current_revision.outputs.revision != ''
         shell: pwsh
         run: |
           Import-Module ./scripts/AITriad/AITriad.psm1 -Force
@@ -632,7 +636,7 @@ jobs:
           exit 1
 
       - name: Fail if unhealthy (no previous revision to rollback to)
-        if: (steps.health_check.outputs.healthy != 'true' || steps.acceptance.outputs.accepted == 'false' || steps.persona.outputs.accepted == 'false') && steps.current_revision.outputs.revision == ''
+        if: (steps.health_check.outputs.healthy != 'true' || steps.acceptance.outputs.accepted == 'false' || steps.persona.outputs.accepted == 'false' || steps.warm_gate.outputs.warm == 'false') && steps.current_revision.outputs.revision == ''
         run: |
           echo "::error::Health check failed and no previous revision exists for rollback"
           exit 1

--- a/operations/devops/Invoke-ReadyzWarmGateCheck.ps1
+++ b/operations/devops/Invoke-ReadyzWarmGateCheck.ps1
@@ -4,30 +4,25 @@
 
 <#
 .SYNOPSIS
-    Pre-traffic-shift deploy gate (t/3114): block the ACA traffic-shift until the new revision's
-    embeddings.json cache is warm, by polling GET /readyz. Honors root constraint #1 (t/3090#11):
-    no traffic to an un-warmed revision (which would re-embed ~3600 taxonomy texts per debate).
+    Pre-traffic-shift deploy warm-gate (t/3114, blocking flip t/3148): decide whether the new
+    revision's embeddings.json cache is warm by polling GET /readyz, then emit warm=true/false for
+    the deploy workflow's peer-blocking wiring. Honors root constraint #1 (t/3090#11): no traffic
+    to an un-warmed revision (which would re-embed ~3600 taxonomy texts per debate).
 .DESCRIPTION
     Polls {BaseUrl}/readyz against the 0%-traffic revision (its own FQDN) every -PollIntervalSec,
-    up to -TimeoutSec, and maps each poll's status via Get-ReadyzGateAction (pure predicate):
-      proceed (200)  -> cache warm; exit 0 (deploy shifts traffic).
-      skip    (404)  -> /readyz ABSENT (image predates the endpoint); warn + exit 0 so the deploy
-                        that first introduces /readyz cannot deadlock on its own not-yet-present
-                        route. ONLY 404/absent is skipped.
-      wait    (else) -> present-but-503 (still warming) or any transient/ambiguous code (incl. a
-                        connection error, treated as code 0): keep polling. A present-503 is NEVER
-                        skipped — it is waited on.
-    On sustained 'wait' past -TimeoutSec: in ENFORCING mode FAIL (exit 1) with an explicit ::error::
-    so a genuinely hung/corrupt warm fails the deploy legibly (existing auto-rollback fires) rather
-    than as a mystery timeout. In -ObserveOnly mode the timeout is a ::warning:: + exit 0 (see below).
+    up to -TimeoutSec, mapping each poll (status + body) via Get-ReadyzGateAction (pure predicate):
+      proceed -> 200 with a JSON body {status:'ready', nodeCount>0} (cache warm).
+      wait    -> everything else (503 warming, 404 absent, a non-'ready'/SPA-HTML 200, or a
+                 connection error treated as code 0): keep polling to the deadline.
 
-    -ObserveOnly (t/2683 Gate Promotion, real-env-first): compute + LOG the warm outcome but NEVER
-    fail — timeout downgrades ::error::->::warning:: and exits 0. Used to validate real-env warm
-    detection (FQDN resolves, real 503->200, no false timeout) on ≥1 real deploy BEFORE the gate is
-    promoted to blocking. In observe mode the caller also does NOT reference the warm output in its
-    success/rollback conditions, so the gate is provably non-blocking.
+    Mechanism B (t/3148, TL-decided p/542#108) — the gate is OUTPUT-driven, not exit-code-driven:
+    this script writes `warm=true` (proceed) or `warm=false` (timeout / any non-warm outcome) to
+    $env:GITHUB_OUTPUT and ALWAYS exits 0. The deploy workflow shifts traffic iff warm=='true' and
+    runs the full rollback path iff warm=='false' (peer of the acceptance/persona gates).
 
-    Exit codes: 0 = warm OR absent-skip (proceed) OR (-ObserveOnly) timeout;  1 = ENFORCING timeout.
+    FAIL-CLOSED: warm defaults to false and is only set true on a proven-warm 200, so a hung probe,
+    an unexpected error, or a sustained-503 timeout all emit warm=false → the deploy blocks the
+    traffic-shift and rolls back rather than silently shipping an un-warmed revision.
 
     -TimeoutSec default 300s sizes the observed pre-warm cost: 63MB embeddings.json read from the
     AzureFiles mount + JSON.parse + cold ONNX warmup (t/3090#10). -PollIntervalSec default 10s.
@@ -36,8 +31,7 @@
 param(
     [Parameter(Mandatory)] [string] $BaseUrl,
     [int] $TimeoutSec      = 300,
-    [int] $PollIntervalSec = 10,
-    [switch] $ObserveOnly
+    [int] $PollIntervalSec = 10
 )
 
 Set-StrictMode -Version Latest
@@ -46,50 +40,61 @@ $ErrorActionPreference = 'Stop'
 # Pure decision predicate (dot-sourceable; no I/O)
 . (Join-Path $PSScriptRoot 'ReadyzWarmGatePredicate.ps1')
 
+# Emit the peer-gate output the deploy workflow keys on (mechanism B, t/3148/t/3114#3).
+function Write-WarmOutput {
+    param([bool] $Warm)
+    if ($env:GITHUB_OUTPUT) {
+        "warm=$($Warm.ToString().ToLowerInvariant())" | Add-Content -Path $env:GITHUB_OUTPUT
+    }
+}
+
 $uri      = "$($BaseUrl.TrimEnd('/'))/readyz"
 $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSec)
 $poll     = 0
+$warm     = $false   # fail-closed default
 
 Write-Host "Warm-gate: polling $uri (timeout ${TimeoutSec}s, interval ${PollIntervalSec}s) until embeddings.json cache is ready..."
 
-while ($true) {
-    $poll++
-    $status = 0
-    $body   = ''
-    try {
-        $resp   = Invoke-WebRequest -Uri $uri -Method Get -SkipHttpErrorCheck -TimeoutSec 15
-        $status = [int]$resp.StatusCode
-        $body   = ($resp.Content | Out-String).Trim()
-    } catch {
-        # Connection-level failure (server not answering) — treat as 'wait' (transient); the
-        # health_check step already confirmed server-up, so this should be rare and self-clears.
+try {
+    while ($true) {
+        $poll++
         $status = 0
-        Write-Host "  poll #${poll}: request error ($($_.Exception.Message)) — treating as warming"
-    }
+        $body   = ''
+        try {
+            $resp   = Invoke-WebRequest -Uri $uri -Method Get -SkipHttpErrorCheck -TimeoutSec 15
+            $status = [int]$resp.StatusCode
+            $body   = ($resp.Content | Out-String).Trim()
+        } catch {
+            # Connection-level failure (server not answering) — treat as 'wait' (transient); the
+            # health_check step already confirmed server-up, so this should be rare and self-clears.
+            $status = 0
+            Write-Host "  poll #${poll}: request error ($($_.Exception.Message)) — treating as warming"
+        }
 
-    $action = Get-ReadyzGateAction -StatusCode $status
+        $action = Get-ReadyzGateAction -StatusCode $status -Body $body
 
-    switch ($action) {
-        'proceed' {
+        if ($action -eq 'proceed') {
             Write-Host "Warm-gate PASSED after $poll poll(s): /readyz 200 ready — $body"
-            exit 0
+            $warm = $true
+            break
         }
-        'skip' {
-            Write-Host "::warning::Warm-gate SKIPPED: /readyz returned 404 (absent) — this revision's image predates the /readyz endpoint (t/3112/t/3114). Proceeding WITHOUT the embeddings warm-gate for this deploy only."
-            exit 0
+
+        # 'wait' — 503 warming, 404 absent, a non-'ready'/SPA-HTML 200, or a transient/connection error.
+        if ([DateTime]::UtcNow -ge $deadline) {
+            Write-Host "::error::embeddings pre-warm not ready (/readyz last status=$status, body=$body) within ${TimeoutSec}s — warm=false: NOT shifting traffic (root constraint #1). The deploy rolls back to the previous revision. (t/3148)"
+            $warm = $false
+            break
         }
-        default {
-            # 'wait' — present-but-503 (warming) or transient/ambiguous code.
-            if ([DateTime]::UtcNow -ge $deadline) {
-                if ($ObserveOnly) {
-                    Write-Host "::warning::[OBSERVE-ONLY] embeddings pre-warm not ready (/readyz last status=$status) within ${TimeoutSec}s. In ENFORCING mode this would block the traffic-shift and roll back; observe-only logs and proceeds (exit 0) so real-env warm timing can be validated before the gate is promoted to blocking (t/2683). (t/3114)"
-                    exit 0
-                }
-                Write-Host "::error::embeddings pre-warm not ready (/readyz last status=$status) within ${TimeoutSec}s — NOT shifting traffic (root constraint #1). A revision stuck warming past the pre-warm budget (63MB AzureFiles load + JSON.parse + cold ONNX) is failed legibly; rollback restores the previous revision. (t/3114)"
-                exit 1
-            }
-            Write-Host "  poll #${poll}: /readyz status=$status (warming) — waiting ${PollIntervalSec}s..."
-            Start-Sleep -Seconds $PollIntervalSec
-        }
+        Write-Host "  poll #${poll}: /readyz status=$status (warming) — waiting ${PollIntervalSec}s..."
+        Start-Sleep -Seconds $PollIntervalSec
     }
+} catch {
+    # Any unexpected error → fail-closed (warm=false), so the gate blocks rather than shipping unverified.
+    Write-Host "::error::warm-gate probe errored ($($_.Exception.Message)) — warm=false (fail-closed). (t/3148)"
+    $warm = $false
+} finally {
+    Write-WarmOutput -Warm $warm
 }
+
+# Mechanism B: always exit 0 — the deploy workflow gates on the warm output, not this exit code.
+exit 0

--- a/operations/devops/ReadyzWarmGatePredicate.ps1
+++ b/operations/devops/ReadyzWarmGatePredicate.ps1
@@ -4,40 +4,53 @@
 
 <#
 .SYNOPSIS
-    Pure decision predicate for the /readyz deploy warm-gate (t/3114). No I/O — dot-sourceable + unit-testable.
+    Pure decision predicate for the /readyz deploy warm-gate (t/3114, blocking flip t/3148).
+    No I/O — dot-sourceable + unit-testable.
 .DESCRIPTION
-    Maps a single /readyz poll's HTTP status code to the deploy gate's per-poll action. The
-    caller (Invoke-ReadyzWarmGateCheck.ps1) loops on 'wait' until 200 or a bounded timeout.
+    Maps a single /readyz poll (HTTP status code + response body) to the deploy gate's per-poll
+    action. The caller (Invoke-ReadyzWarmGateCheck.ps1) loops on 'wait' until 'proceed' or a
+    bounded timeout, then emits warm=true/false for the deploy workflow's peer-blocking wiring.
 
     Contract (taxonomy-editor/src/server/routes/meta.ts, t/3112):
       200  {status:'ready',   nodeCount>0}  -> embeddings.json cache warm.
       503  {status:'warming', ...}          -> cache still loading.
       404  (route ABSENT)                   -> image predates /readyz (old revision).
 
-    Gate semantics (TL GV-preview p/542#65):
-      - 200            -> 'proceed'  (cache warm; shift traffic).
-      - 404            -> 'skip'     (endpoint ABSENT; the deploy that first introduces
-                                      /readyz must not deadlock on its own not-yet-present
-                                      route — proceed WITHOUT the gate, warn).
-      - anything else  -> 'wait'     (present-but-503, or any ambiguous/transient code; the
-        (incl. 503)                   loop keeps polling and, on sustained 'wait' past the
-                                      timeout, FAILS the deploy legibly). A present-503 is
-                                      NEVER skipped — only an explicit 404/absent is.
+    Gate semantics (blocking flip, TL-decided mechanism B, p/542#108):
+      - 'proceed'  iff  StatusCode == 200  AND  the body parses as JSON with
+                        .status == 'ready' AND nodeCount > 0 (a real warm signal).
+      - 'wait'     for EVERYTHING else, and the loop blocks on sustained 'wait':
+          * non-200 (503 warming, 5xx, connection-error sentinel 0) -> wait.
+          * 404 (route absent) -> wait. /readyz is live in prod now, so a dropped route must
+            BLOCK, not skip (t/3148 dropped the old 404->'skip' short-circuit; the first-deploy
+            deadlock rationale is gone — the introducing image already carries the route).
+          * 200 with a non-'ready' status, OR an SPA-fallback HTML page (an unregistered /readyz
+            served index.html — NON-JSON) -> wait. A bare 200 is NOT a warm signal; the body
+            shape is load-bearing (ServerAPI p/542#74, confirmed real on run 33434586564).
 
-    Deliberately conservative: ONLY 404 short-circuits to 'skip'. Every non-200/404 code
-    waits, so an un-warmed (503) or anomalous revision blocks the traffic-shift rather than
-    silently shipping a re-embed-storm revision (root constraint #1, t/3090#11).
+    Parse the body as JSON and check .status — NEVER substring/regex the raw string (brittle to
+    whitespace, field order, added fields). Deliberately conservative: only a proven-warm 200
+    proceeds, so an un-warmed/anomalous/SPA revision blocks the traffic-shift rather than shipping
+    a re-embed-storm revision (root constraint #1, t/3090#11).
 #>
 
 function Get-ReadyzGateAction {
     [CmdletBinding()]
     [OutputType([string])]
     param(
-        [Parameter(Mandatory)] [int] $StatusCode
+        [Parameter(Mandatory)] [int] $StatusCode,
+        [Parameter()] [AllowNull()] [AllowEmptyString()] [string] $Body
     )
-    switch ($StatusCode) {
-        200     { 'proceed'; break }
-        404     { 'skip';    break }
-        default { 'wait' }
+    if ($StatusCode -ne 200) { return 'wait' }
+    try {
+        $parsed = $Body | ConvertFrom-Json -ErrorAction Stop
+        # Property access is INSIDE the try so that under the caller's Set-StrictMode -Version
+        # Latest a body missing the contract fields (e.g. {}, a JSON scalar/array, or the SPA
+        # index.html fallback that isn't even JSON) raises a missing-property error that is
+        # caught → 'wait'. Never a false 'proceed' on a malformed/SPA 200.
+        if ($parsed.status -eq 'ready' -and [int]$parsed.nodeCount -gt 0) { return 'proceed' }
+    } catch {
+        return 'wait'
     }
+    return 'wait'
 }

--- a/taxonomy-editor/src/server/__tests__/fixtures/readyz-ready-body.json
+++ b/taxonomy-editor/src/server/__tests__/fixtures/readyz-ready-body.json
@@ -1,0 +1,1 @@
+{"status":"ready","nodeCount":4144}

--- a/taxonomy-editor/src/server/__tests__/headStaticServe.test.ts
+++ b/taxonomy-editor/src/server/__tests__/headStaticServe.test.ts
@@ -88,3 +88,27 @@ describe('serveStatic HEAD support (t/3084)', () => {
     expect(head.headers['Content-Length']).toBe(get.headers['Content-Length']);
   });
 });
+
+// t/3114 — /readyz is excluded from the SPA fallback, so an UNREGISTERED /readyz returns a
+// clean 404 (serveStatic returns false → caller writes 404) instead of a 200 index.html page.
+describe('serveStatic /readyz SPA-fallback exclusion (t/3114)', () => {
+  const staticDir = path.resolve('/fake/static');
+
+  it('unregistered /readyz (file absent) → returns false (404 path), NOT index.html', () => {
+    mockExistsSync.mockReturnValue(false); // no /readyz file on disk
+    const res = makeRes();
+    const handled = serveStatic(makeReq('GET', '/readyz'), res as unknown as http.ServerResponse, staticDir);
+    expect(handled).toBe(false);          // falls through → server.ts 404s
+    expect(res.statusCode).toBe(0);       // serveStatic wrote nothing (no index.html 200)
+    expect(res.body.length).toBe(0);
+  });
+
+  it('contrast: a normal absent SPA route DOES fall back to index.html (200)', () => {
+    mockExistsSync.mockReturnValue(false);
+    mockReadFileSync.mockReturnValue(Buffer.from('<!doctype html>'));
+    const res = makeRes();
+    const handled = serveStatic(makeReq('GET', '/some/spa/route'), res as unknown as http.ServerResponse, staticDir);
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);     // index.html served — proves the exclusion is /readyz-specific
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/readyz.test.ts
+++ b/taxonomy-editor/src/server/__tests__/readyz.test.ts
@@ -9,6 +9,13 @@
 import { describe, it, expect } from 'vitest';
 import { PUBLIC_EXACT_PATHS, computeIsPublicPath } from '../publicPaths.js';
 
+// t/3114 shared body-contract fixture. This SAME file is read by the deploy warm-gate's
+// Pester (tests/ReadyzWarmGate.Tests.ps1) as the "real 200 body" it feeds to the predicate.
+// The coupling: the assertion below forces this fixture to track the handler's actual output,
+// and the Pester forces the gate to parse whatever key the fixture uses — so a coordinated
+// status-field rename can't silently pass both (it goes red on one side or the other).
+import readyBody from './fixtures/readyz-ready-body.json';
+
 // ── publicPaths ──────────────────────────────────────────────────────────────
 
 describe('publicPaths — /readyz', () => {
@@ -64,5 +71,26 @@ describe('GET /readyz — response shape (t/3112)', () => {
   it('503 when present but nodeCount is null (guards the ?? 0 branch)', () => {
     const { statusCode } = simulateReadyz({ present: true, nodeCount: null });
     expect(statusCode).toBe(503);
+  });
+});
+
+// ── shared body-contract fixture ↔ handler coupling (t/3114) ──────────────────
+// This is the guard TL required for promoting the deploy warm-gate to BLOCKING: a
+// blocking gate whose expected body drifts from the handler = block-every-deploy.
+// readyz-ready-body.json is the single literal BOTH sides reference — here (producer
+// side) and the gate's Pester (consumer side, feeds it to the predicate). The first
+// assertion forces the fixture to track the handler's real 200 output; the Pester
+// forces the gate to parse whatever key the fixture uses. A coordinated rename of
+// `status` can't pass both — it goes red here (fixture no longer matches the handler)
+// or in the Pester (gate parses the old key, gets a non-'ready' body → wait).
+describe('/readyz shared body-contract fixture (t/3114)', () => {
+  it('fixture equals the handler\'s real 200 ready body (producer-side pin)', () => {
+    const real = simulateReadyz({ present: true, nodeCount: readyBody.nodeCount }).body;
+    expect(real).toEqual(readyBody);
+  });
+
+  it('fixture carries the contract invariant the gate keys on: status==="ready", nodeCount>0', () => {
+    expect(readyBody.status).toBe('ready');
+    expect(readyBody.nodeCount).toBeGreaterThan(0);
   });
 });

--- a/taxonomy-editor/src/server/staticServe.ts
+++ b/taxonomy-editor/src/server/staticServe.ts
@@ -45,8 +45,13 @@ export function serveStatic(
   }
 
   if (!fs.existsSync(filePath)) {
-    // SPA fallback: serve index.html for non-API routes
-    if (!url.pathname.startsWith('/api/') && !url.pathname.startsWith('/ws/') && !url.pathname.startsWith('/health')) {
+    // SPA fallback: serve index.html for non-API routes.
+    // t/3114: /readyz is excluded so an UNREGISTERED /readyz (a routing regression, or an
+    // image predating the route) returns a clean 404 instead of a 200 index.html page — the
+    // deploy warm-gate treats a non-{status:ready} 200 as not-warm anyway (block), but a real
+    // 404 is unambiguous and keeps the gate's health signal honest.
+    if (!url.pathname.startsWith('/api/') && !url.pathname.startsWith('/ws/')
+        && !url.pathname.startsWith('/health') && !url.pathname.startsWith('/readyz')) {
       filePath = path.join(staticDir, 'index.html');
     } else {
       return false;

--- a/tests/ReadyzWarmGate.Tests.ps1
+++ b/tests/ReadyzWarmGate.Tests.ps1
@@ -1,8 +1,11 @@
-# Tests for the /readyz deploy warm-gate (t/3114).
-# Part 1 exercises the pure Get-ReadyzGateAction predicate (no I/O).
-# Part 2 exercises Invoke-ReadyzWarmGateCheck.ps1's polling loop with mocked HTTP —
-# the four gate arms TL GV requires: proceed(200), skip(404), wait-then-proceed(503->200),
-# timeout-fail(sustained 503).
+# Tests for the /readyz deploy warm-gate (t/3114; blocking flip t/3148).
+# Part 1 exercises the pure Get-ReadyzGateAction predicate (status + body → action).
+# Part 2 exercises Invoke-ReadyzWarmGateCheck.ps1's polling loop with mocked HTTP, asserting
+# the emitted warm=true/false peer-gate output (mechanism B) and exit 0.
+#
+# The 'ready' body comes from the SHARED fixture that the server's readyz.test.ts also pins to the
+# handler's real 200 — so a coordinated status-contract rename fails BOTH sides (gate↔handler
+# coupling, t/3148). Fixture: taxonomy-editor/src/server/__tests__/fixtures/readyz-ready-body.json.
 # Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root.
 
@@ -12,61 +15,96 @@ BeforeAll {
     $DevOpsDir  = Join-Path $PSScriptRoot '..' 'operations' 'devops'
     . (Join-Path $DevOpsDir 'ReadyzWarmGatePredicate.ps1')
     $script:ScriptPath = Join-Path $DevOpsDir 'Invoke-ReadyzWarmGateCheck.ps1'
+
+    # Consumer-side pin: read the SAME shared fixture literal the handler test pins (producer side).
+    $script:ReadyFixturePath = Join-Path $PSScriptRoot '..' 'taxonomy-editor' 'src' 'server' '__tests__' 'fixtures' 'readyz-ready-body.json'
+    $script:ReadyBody = (Get-Content -Raw -LiteralPath $script:ReadyFixturePath).Trim()
+
+    # SPA index.html fallback that an unregistered /readyz would 200 with — NOT a warm signal.
+    $script:SpaBody = '<!doctype html><html><head><title>App</title></head><body><div id="root"></div></body></html>'
+
+    # Read the warm=... value the gate appended to $env:GITHUB_OUTPUT. Defined in BeforeAll so it
+    # is in scope during the Pester run phase for the It blocks (a function in the Describe body is
+    # only present during discovery).
+    function Get-EmittedWarm {
+        $line = Get-Content -LiteralPath $env:GITHUB_OUTPUT -ErrorAction SilentlyContinue |
+            Where-Object { $_ -like 'warm=*' } | Select-Object -Last 1
+        if ($line) { return ($line -replace '^warm=', '') }
+        return $null
+    }
 }
 
-Describe 'Get-ReadyzGateAction (pure predicate)' -Tag 'unit' {
-    It '200 -> proceed (cache warm)' {
-        Get-ReadyzGateAction -StatusCode 200 | Should -Be 'proceed'
+Describe 'Get-ReadyzGateAction (pure predicate: status + body)' -Tag 'unit' {
+    It 'PROCEED: 200 + shared ready fixture {status:ready,nodeCount>0}' {
+        Get-ReadyzGateAction -StatusCode 200 -Body $script:ReadyBody | Should -Be 'proceed'
     }
-    It '404 -> skip (endpoint absent; only 404 short-circuits)' {
-        Get-ReadyzGateAction -StatusCode 404 | Should -Be 'skip'
+    It 'WAIT: 200 + {status:warming} (present-but-warming, never proceeds)' {
+        Get-ReadyzGateAction -StatusCode 200 -Body '{"status":"warming"}' | Should -Be 'wait'
     }
-    It '503 -> wait (present-but-warming; NEVER skipped)' {
-        Get-ReadyzGateAction -StatusCode 503 | Should -Be 'wait'
+    It 'WAIT: 200 + SPA index.html fallback (non-JSON body → not warm; bare 200 is not a signal)' {
+        Get-ReadyzGateAction -StatusCode 200 -Body $script:SpaBody | Should -Be 'wait'
     }
-    It 'Ambiguous/transient codes -> wait (conservative: do not skip on anything but 404)' {
-        Get-ReadyzGateAction -StatusCode 500 | Should -Be 'wait'
-        Get-ReadyzGateAction -StatusCode 200 | Should -Not -Be 'wait'
-        Get-ReadyzGateAction -StatusCode 0   | Should -Be 'wait'   # connection error sentinel
-        Get-ReadyzGateAction -StatusCode 429 | Should -Be 'wait'
+    It 'WAIT: 200 + {status:ready} but nodeCount:0 (empty cache is not warm)' {
+        Get-ReadyzGateAction -StatusCode 200 -Body '{"status":"ready","nodeCount":0}' | Should -Be 'wait'
+    }
+    It 'WAIT: 200 + {status:ready} with nodeCount MISSING (contract violation → not warm)' {
+        Get-ReadyzGateAction -StatusCode 200 -Body '{"status":"ready"}' | Should -Be 'wait'
+    }
+    It 'WAIT: 200 + empty body' {
+        Get-ReadyzGateAction -StatusCode 200 -Body '' | Should -Be 'wait'
+    }
+    It 'WAIT: 404 (route absent) → wait, NOT skip (t/3148 dropped the 404 short-circuit)' {
+        Get-ReadyzGateAction -StatusCode 404 -Body 'Not Found' | Should -Be 'wait'
+    }
+    It 'WAIT: 503 present-but-warming' {
+        Get-ReadyzGateAction -StatusCode 503 -Body '{"status":"warming"}' | Should -Be 'wait'
+    }
+    It 'WAIT: transient/ambiguous codes (500, connection-error sentinel 0, 429) never proceed' {
+        Get-ReadyzGateAction -StatusCode 500 -Body ''  | Should -Be 'wait'
+        Get-ReadyzGateAction -StatusCode 0   -Body ''  | Should -Be 'wait'
+        Get-ReadyzGateAction -StatusCode 429 -Body ''  | Should -Be 'wait'
+    }
+    It 'The only PROCEED path is 200 + a valid ready body — nothing else' {
+        Get-ReadyzGateAction -StatusCode 200 -Body $script:ReadyBody | Should -Be 'proceed'
+        Get-ReadyzGateAction -StatusCode 200 -Body $script:SpaBody   | Should -Not -Be 'proceed'
+        Get-ReadyzGateAction -StatusCode 404 -Body $script:ReadyBody | Should -Not -Be 'proceed'
     }
 }
 
-Describe 'Invoke-ReadyzWarmGateCheck.ps1 (polling arms)' -Tag 'unit' {
+Describe 'Invoke-ReadyzWarmGateCheck.ps1 (warm=true/false output, mechanism B)' -Tag 'unit' {
 
     BeforeEach {
         Mock Start-Sleep { }   # never actually sleep
+        # Capture the emitted GITHUB_OUTPUT to a temp file the gate appends warm=... to.
+        $script:OutFile = New-TemporaryFile
+        $env:GITHUB_OUTPUT = $script:OutFile.FullName
+    }
+    AfterEach {
+        Remove-Item -LiteralPath $script:OutFile.FullName -ErrorAction SilentlyContinue
+        Remove-Item Env:\GITHUB_OUTPUT -ErrorAction SilentlyContinue
     }
 
-    It 'PROCEED: /readyz 200 on first poll -> exit 0' {
-        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200; Content = '{"status":"ready","nodeCount":4144}' } }
+    It 'PROCEED: 200 + ready body on first poll → warm=true, exit 0' {
+        $readyBody = $script:ReadyBody   # capture into the mock closure ($script: doesn't resolve inside a deferred mock body)
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200; Content = $readyBody } }.GetNewClosure()
         $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 300 -PollIntervalSec 0 *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
+        Get-EmittedWarm | Should -Be 'true'
         $out | Should -Match 'Warm-gate PASSED'
     }
 
-    It 'SKIP: /readyz 404 (absent) -> exit 0 + warning (no deadlock on introducing deploy)' {
-        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 404; Content = 'Not Found' } }
-        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 300 -PollIntervalSec 0 *>&1 | Out-String
-        $LASTEXITCODE | Should -Be 0
-        $out | Should -Match '::warning::Warm-gate SKIPPED'
-        $out | Should -Match '404'
-    }
-
-    It 'WAIT-THEN-PROCEED: 503 then 200 -> waits, then exit 0 (present-503 is waited on, not skipped)' {
-        # $global: (not $script:) — the mock body runs inside the &-invoked script's scope, which
-        # has Set-StrictMode -Version Latest; an undefined $script:calls there would throw (read as
-        # a connection error by the script's catch) and loop to timeout. $global: initialized to 0
-        # is StrictMode-safe and visible across the invoked-script scope.
+    It 'WAIT-THEN-PROCEED: 503 then 200 → waits, then warm=true (present-503 is waited on)' {
+        $readyBody = $script:ReadyBody   # capture into the mock closure
         $global:readyzCalls = 0
         Mock Invoke-WebRequest {
             $global:readyzCalls++
             if ($global:readyzCalls -lt 3) { [pscustomobject]@{ StatusCode = 503; Content = '{"status":"warming"}' } }
-            else                            { [pscustomobject]@{ StatusCode = 200; Content = '{"status":"ready","nodeCount":4144}' } }
-        }
+            else                            { [pscustomobject]@{ StatusCode = 200; Content = $readyBody } }
+        }.GetNewClosure()
         try {
             $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 30 -PollIntervalSec 0 *>&1 | Out-String
             $LASTEXITCODE | Should -Be 0
+            Get-EmittedWarm | Should -Be 'true'
             $out | Should -Match 'Warm-gate PASSED after 3 poll'
             $global:readyzCalls | Should -Be 3
         } finally {
@@ -74,27 +112,33 @@ Describe 'Invoke-ReadyzWarmGateCheck.ps1 (polling arms)' -Tag 'unit' {
         }
     }
 
-    It 'TIMEOUT-FAIL: sustained 503 past timeout -> exit 1 + explicit error (blocks traffic shift)' {
+    It 'TIMEOUT → warm=false + exit 0 + ::error:: (blocks traffic shift; deploy rolls back)' {
         Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 503; Content = '{"status":"warming"}' } }
         $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 *>&1 | Out-String
-        $LASTEXITCODE | Should -Be 1
+        $LASTEXITCODE | Should -Be 0
+        Get-EmittedWarm | Should -Be 'false'
         $out | Should -Match '::error::embeddings pre-warm not ready'
-        $out | Should -Match 'within 0s'
     }
 
-    It 'TIMEOUT-FAIL: connection error treated as warming, still fails closed (never silently skips)' {
+    It '404 (route absent) sustained → warm=false (NOT skip; a dropped route blocks, t/3148)' {
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 404; Content = 'Not Found' } }
+        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        Get-EmittedWarm | Should -Be 'false'
+    }
+
+    It 'SPA-HTML 200 sustained → warm=false (body-shape check: a bare 200 is not warm)' {
+        $spaBody = $script:SpaBody   # capture into the mock closure
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200; Content = $spaBody } }.GetNewClosure()
+        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 *>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        Get-EmittedWarm | Should -Be 'false'
+    }
+
+    It 'CONNECTION-ERROR → fail-closed warm=false + exit 0 (never silently proceeds)' {
         Mock Invoke-WebRequest { throw 'connection refused' }
         $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 *>&1 | Out-String
-        $LASTEXITCODE | Should -Be 1
-        $out | Should -Match '::error::embeddings pre-warm not ready'
-    }
-
-    It 'OBSERVE-ONLY: sustained 503 past timeout -> exit 0 + ::warning:: (logs, never blocks)' {
-        # t/2683 real-env-first: the observe-only ship must NOT fail the deploy on a warm timeout;
-        # it only logs, so real-env warm detection can be validated before the gate is promoted.
-        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 503; Content = '{"status":"warming"}' } }
-        $out = & $script:ScriptPath -BaseUrl 'http://rev.local' -TimeoutSec 0 -PollIntervalSec 0 -ObserveOnly *>&1 | Out-String
         $LASTEXITCODE | Should -Be 0
-        $out | Should -Match '::warning::\[OBSERVE-ONLY\] embeddings pre-warm not ready'
+        Get-EmittedWarm | Should -Be 'false'
     }
 }


### PR DESCRIPTION
## t/3148 — /readyz warm-gate: observe-only → PEER-BLOCKING (mechanism B)

**DRAFT, held for TL promotion GV** per gate-promotion discipline (a blocking-gate flip is a separate deliberate step). Do not un-draft until TL signs off the both-arms + real-env evidence.

### Real-env evidence (TL-verified, p/542#104)
Run **33434586564** warm_gate observe step: `Warm-gate PASSED after 1 poll: /readyz 200 ready — {"status":"ready","nodeCount":4144}` — FQDN resolves, true 200 with correct body shape (distinguishes real 200 from SPA index.html), no false timeout. (Warm on poll 1, so the 503→wait progression rides the offline predicate unit tests per t/2971.)

### What changed
- **`ReadyzWarmGatePredicate.ps1`** — `-Body` added. `proceed` iff `200` AND JSON `.status=='ready'` AND `nodeCount>0`; else `wait`. Dropped `404→skip` (route is live in prod → a dropped route must block). SPA index.html (non-JSON) 200 → `wait`. Property access inside `try` so a malformed body under StrictMode → `wait`, never a false proceed.
- **`Invoke-ReadyzWarmGateCheck.ps1`** — emits `warm=true/false` to `GITHUB_OUTPUT`, **always exits 0** (output-driven). **Fail-closed**: `warm` defaults false; only a proven-warm 200 sets true. `-ObserveOnly` removed.
- **`deploy-azure.yml`** — `warm_gate` is now a **peer of acceptance/persona**: `Shift traffic` requires `warm=='true'`; `warm=='false'` takes the **same full rollback path** (diagnostics + re-auth + rollback + fail-no-prev).
- **`ReadyzWarmGate.Tests.ps1`** — both-arms against the **shared fixture** `readyz-ready-body.json` (cherry-picked from ServerAPI `feat-readyz-flip-fixture`): proceed→warm=true, timeout→warm=false, 404→wait, SPA-200→wait, conn-error fail-closed. **16/16 green locally.**

### GV focus — the warm-UNSET edge (TL point 3)
`warm_gate` is `if: health_check.healthy == 'true'`-gated, so `outputs.warm` is empty **only** when the step is **skipped** (health failed). Every rollback condition already includes `health_check.healthy != 'true'`, so unset-warm rolls back via that clause — **no no-shift/no-rollback limbo**. When the step runs, the fail-closed runner always emits `true`/`false`.

### Coupling
The shared `readyz-ready-body.json` is consumed by BOTH the gate Pester (consumer) and `readyz.test.ts` (producer, pins the handler's real 200) → a coordinated `.status` rename fails both sides.

Bundle = predicate + runner + workflow + Pester + cherry-picked fixture/SPA-exclusion + this evidence → **TL GV**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)