### PR TITLE
feat(entities): Import-Entity v2 multi-vector records + _src_hash staleness (t/3121 C)

### DIFF
--- a/scripts/AITriad/Private/EntitiesStore.ps1
+++ b/scripts/AITriad/Private/EntitiesStore.ps1
@@ -64,13 +64,19 @@ function New-EmptyEntityEmbeddingsStore {
     #>
     [CmdletBinding()]
     param()
+    # _schema_version '2.0.0' (t/3121): vectors[<id>] is an EntityVectorRecord
+    # { name_vector, description_vector? } — see lib/entities/entityVectors.ts. `_src_hashes`
+    # is a PS-owned envelope map { <id>: sha256(name+aliases\ndescription) } used by the
+    # writer + Update-EntityEmbeddings to skip unchanged records (staleness guard, t/3085
+    # class). It is deliberately NOT part of the EntityVectorRecord type — readers ignore it.
     return [PSCustomObject]@{
-        _schema_version = '1.0.0'
+        _schema_version = '2.0.0'
         _doc            = 'Entity vectors for linking and dedup ONLY. Never an input to debate relevance.'
         model           = 'all-MiniLM-L6-v2'
         dim             = 384
         last_modified   = (Get-Date).ToString('yyyy-MM-dd')
         vectors         = [PSCustomObject]@{}
+        _src_hashes     = [PSCustomObject]@{}
     }
 }
 

--- a/scripts/AITriad/Public/Import-Entity.ps1
+++ b/scripts/AITriad/Public/Import-Entity.ps1
@@ -258,16 +258,54 @@ function Import-Entity {
             if ($null -eq $embStore) {
                 $embStore = if (Test-Path $embPath) { Get-Content -Raw -Path $embPath -Encoding utf8 | ConvertFrom-Json } else { New-EmptyEntityEmbeddingsStore }
             }
-            $text = if ($description) { "$name`n$description" } else { $name }
-            $vecMap = Get-TextEmbedding -Texts @($text) -Ids @($newId)
-            if ($vecMap -and $vecMap.ContainsKey($newId)) {
-                if (-not $embStore.PSObject.Properties['vectors']) {
-                    Add-Member -InputObject $embStore -MemberType NoteProperty -Name 'vectors' -Value ([PSCustomObject]@{})
-                }
-                if ($embStore.vectors.PSObject.Properties[$newId]) { $embStore.vectors.$newId = @($vecMap[$newId]) }
-                else { Add-Member -InputObject $embStore.vectors -MemberType NoteProperty -Name $newId -Value (@($vecMap[$newId])) }
-                $embDirty = $true
+            # t/3121 v2 multi-vector: name_vector embeds label + aliases (drives the resolution
+            # ladder's cosine tie-break); description_vector embeds the description (future R6
+            # rung), OMITTED when description is empty (Shared Lib readers tolerate absence,
+            # entityVectors.ts nameVectorOf). One sub-id batch → one embed subprocess.
+            # `_src_hash` (envelope-side `_src_hashes` map, PS-owned — deliberately NOT in the
+            # EntityVectorRecord type) fingerprints the EXACT embedded source so a re-import and
+            # Update-EntityEmbeddings (t/3121 D) can skip unchanged records idempotently
+            # (staleness guard, t/3085 class). Hash over the same text the writer embeds.
+            $aliasText = @($rec.aliases) -join ' '
+            $nameText  = if ($aliasText) { "$($rec.name) $aliasText" } else { [string]$rec.name }
+            $descText  = [string]$rec.description
+            $srcHash   = Get-TextSha256 -Text "$nameText`n$descText"
+
+            $priorHash = if ($embStore.PSObject.Properties['_src_hashes'] -and $embStore._src_hashes.PSObject.Properties[$newId]) { [string]$embStore._src_hashes.$newId } else { '' }
+            $hasV2Rec  = $embStore.PSObject.Properties['vectors'] -and $embStore.vectors.PSObject.Properties[$newId] -and ($embStore.vectors.$newId -isnot [array])
+            if ($hasV2Rec -and $priorHash -eq $srcHash) {
+                # Already current (v2 record + matching fingerprint): carries a vector, no re-embed.
                 $embedded = $true
+            }
+            else {
+                $subIds   = @("$newId#name")
+                $subTexts = @($nameText)
+                if ($descText) { $subIds += "$newId#desc"; $subTexts += $descText }
+                $vecMap = Get-TextEmbedding -Texts $subTexts -Ids $subIds
+                if ($vecMap -and $vecMap.ContainsKey("$newId#name")) {
+                    $vrec = [PSCustomObject]@{ name_vector = @($vecMap["$newId#name"]) }
+                    if ($descText -and $vecMap.ContainsKey("$newId#desc")) {
+                        Add-Member -InputObject $vrec -MemberType NoteProperty -Name 'description_vector' -Value (@($vecMap["$newId#desc"]))
+                    }
+                    if (-not $embStore.PSObject.Properties['vectors']) {
+                        Add-Member -InputObject $embStore -MemberType NoteProperty -Name 'vectors' -Value ([PSCustomObject]@{})
+                    }
+                    if ($embStore.vectors.PSObject.Properties[$newId]) { $embStore.vectors.$newId = $vrec }
+                    else { Add-Member -InputObject $embStore.vectors -MemberType NoteProperty -Name $newId -Value $vrec }
+
+                    if (-not $embStore.PSObject.Properties['_src_hashes']) {
+                        Add-Member -InputObject $embStore -MemberType NoteProperty -Name '_src_hashes' -Value ([PSCustomObject]@{})
+                    }
+                    if ($embStore._src_hashes.PSObject.Properties[$newId]) { $embStore._src_hashes.$newId = $srcHash }
+                    else { Add-Member -InputObject $embStore._src_hashes -MemberType NoteProperty -Name $newId -Value $srcHash }
+
+                    # This store now holds a v2 record — declare the schema (bumps a loaded v1 envelope).
+                    if ($embStore.PSObject.Properties['_schema_version']) { $embStore._schema_version = '2.0.0' }
+                    else { Add-Member -InputObject $embStore -MemberType NoteProperty -Name '_schema_version' -Value '2.0.0' }
+
+                    $embDirty = $true
+                    $embedded = $true
+                }
             }
         }
 

--- a/tests/Entity.Tests.ps1
+++ b/tests/Entity.Tests.ps1
@@ -362,3 +362,91 @@ Describe 'Entity cmdlets - manifest' -Tag 'unit' {
         $manifest.ExportedFunctions.Keys | Should -Contain 'Import-Entity'
     }
 }
+
+Describe 'Import-Entity — v2 multi-vector embed (t/3121 C)' -Tag 'unit' {
+
+    BeforeEach {
+        # Deterministic embed: name (or any non-#desc id) → 0.1×384; description (#desc) → 0.2×384.
+        Mock -ModuleName AITriad Get-TextEmbedding {
+            $m = @{}
+            foreach ($id in $Ids) {
+                $fill = if ($id -like '*#desc') { 0.2 } else { 0.1 }
+                $m[$id] = @(1..384 | ForEach-Object { $fill })
+            }
+            return $m
+        }
+    }
+
+    It 'Writes a v2 EntityVectorRecord {name_vector, description_vector} + _src_hash for an approved entity with a description' {
+        $ent = Join-Path $TestDrive 'v2-ent.json'
+        $emb = Join-Path $TestDrive 'v2-emb.json'
+        $r = Import-Entity -Proposal @((New-Prop @{ status = 'approved'; aliases = @('GPT4', 'GPT-four') })) -Path $ent -EmbeddingsPath $emb
+        $r[0].Embedded | Should -BeTrue
+        Should -Invoke -ModuleName AITriad Get-TextEmbedding -Times 1 -Exactly
+
+        $store = Get-Content -Raw -Path $emb | ConvertFrom-Json
+        $store._schema_version | Should -Be '2.0.0'
+        $rec = $store.vectors.'ent-001'
+        @($rec.name_vector).Count        | Should -Be 384
+        @($rec.description_vector).Count | Should -Be 384
+        $rec.name_vector[0]        | Should -Be 0.1
+        $rec.description_vector[0] | Should -Be 0.2
+        $store._src_hashes.'ent-001' | Should -Match '^[0-9a-f]{64}$'
+    }
+
+    It 'OMITS description_vector when the entity has no description (readers tolerate absence)' {
+        $ent = Join-Path $TestDrive 'v2-nodesc-ent.json'
+        $emb = Join-Path $TestDrive 'v2-nodesc-emb.json'
+        Import-Entity -Proposal @((New-Prop @{ status = 'approved'; description = '' })) -Path $ent -EmbeddingsPath $emb | Out-Null
+        $rec = (Get-Content -Raw -Path $emb | ConvertFrom-Json).vectors.'ent-001'
+        @($rec.name_vector).Count | Should -Be 384
+        $rec.PSObject.Properties['description_vector'] | Should -BeNullOrEmpty
+    }
+
+    It 'Batches name + description in ONE Get-TextEmbedding call (sub-id #name/#desc)' {
+        $ent = Join-Path $TestDrive 'v2-batch-ent.json'
+        $emb = Join-Path $TestDrive 'v2-batch-emb.json'
+        Import-Entity -Proposal @((New-Prop @{ status = 'approved' })) -Path $ent -EmbeddingsPath $emb | Out-Null
+        Should -Invoke -ModuleName AITriad Get-TextEmbedding -Times 1 -Exactly -ParameterFilter {
+            ($Ids -contains 'ent-001#name') -and ($Ids -contains 'ent-001#desc')
+        }
+    }
+
+    It 'Is idempotent — a re-approve with unchanged source does NOT re-embed (_src_hash staleness guard)' {
+        $ent = Join-Path $TestDrive 'v2-idem-ent.json'
+        $emb = Join-Path $TestDrive 'v2-idem-emb.json'
+        Import-Entity -Proposal @((New-Prop @{ status = 'approved' })) -Path $ent -EmbeddingsPath $emb | Out-Null
+        $r2 = Import-Entity -Proposal @((New-Prop @{ id = 'ent-001'; status = 'approved' })) -Path $ent -EmbeddingsPath $emb
+        $r2[0].Embedded | Should -BeTrue   # still carries a vector
+        Should -Invoke -ModuleName AITriad Get-TextEmbedding -Times 1 -Exactly   # not re-embedded
+    }
+
+    It 'Re-embeds when the source changed (hash mismatch → fresh vectors)' {
+        $ent = Join-Path $TestDrive 'v2-change-ent.json'
+        $emb = Join-Path $TestDrive 'v2-change-emb.json'
+        Import-Entity -Proposal @((New-Prop @{ status = 'approved' })) -Path $ent -EmbeddingsPath $emb | Out-Null
+        Import-Entity -Proposal @((New-Prop @{ id = 'ent-001'; status = 'approved'; description = 'A different description entirely.' })) -Path $ent -EmbeddingsPath $emb | Out-Null
+        Should -Invoke -ModuleName AITriad Get-TextEmbedding -Times 2 -Exactly
+    }
+
+    It 'Upgrades a v1 flat-array record to a v2 record on the next approval (back-compat)' {
+        $ent = Join-Path $TestDrive 'v1up-ent.json'
+        $emb = Join-Path $TestDrive 'v1up-emb.json'
+        # Seed a v1 store: vectors[id] is a flat number[] (single blended vector), schema 1.0.0.
+        @{
+            _schema_version = '1.0.0'
+            model           = 'all-MiniLM-L6-v2'
+            dim             = 384
+            vectors         = @{ 'ent-001' = @(1..384 | ForEach-Object { 0.5 }) }
+        } | ConvertTo-Json -Depth 6 | Set-Content -Path $emb -Encoding utf8
+        Import-Entity -Proposal @((New-Prop)) -Path $ent -SkipEmbedding | Out-Null   # ent-001, proposed, no embed
+        Import-Entity -Proposal @((New-Prop @{ id = 'ent-001'; status = 'approved' })) -Path $ent -EmbeddingsPath $emb | Out-Null
+
+        $store = Get-Content -Raw -Path $emb | ConvertFrom-Json
+        $store._schema_version | Should -Be '2.0.0'
+        $rec = $store.vectors.'ent-001'
+        $rec -is [array]          | Should -BeFalse   # no longer a flat array
+        @($rec.name_vector).Count | Should -Be 384    # now a v2 record
+        Should -Invoke -ModuleName AITriad Get-TextEmbedding -Times 1 -Exactly   # v1 array ≠ v2 → re-embedded
+    }
+}


### PR DESCRIPTION
Implements **t/3121 C** — the PowerShell writer half of the multi-vector entity-embeddings upgrade, against the Shared Lib contract `lib/entities/entityVectors.ts` (TL ruling t/3121#4).

## What changed
- **`Import-Entity.ps1`** now writes the schema-`2.0.0` `entity_embeddings.json` shape:
  - `vectors[<id>]` is an `EntityVectorRecord { name_vector, description_vector? }` (was a flat `number[]`). `name_vector` embeds **label + aliases**; `description_vector` embeds the description and is **omitted when empty** (readers tolerate absence, `nameVectorOf`).
  - Both vectors come from **one** `Get-TextEmbedding` batch via sub-ids `<id>#name` / `<id>#desc` (one embed subprocess per approval).
  - `_src_hash` lives in a **PS-owned envelope map `_src_hashes` `{ <id>: sha256 }`** — deliberately **not** in the `EntityVectorRecord` type (readers ignore it). It fingerprints the exact embedded source so a re-import and `Update-EntityEmbeddings` (t/3121 D) skip unchanged records idempotently (staleness guard, closes the t/3085 class for entities).
  - **Back-compat (mandatory, t/3121#4):** a loaded v1 flat-array record is not a v2 record, so the next approval re-embeds and upgrades it in place, bumping the envelope `_schema_version` to `2.0.0`. No flag day.
- **`EntitiesStore.ps1`** — `New-EmptyEntityEmbeddingsStore` mints a `2.0.0` envelope with an empty `_src_hashes`.

## Tests
6 new cases in `Entity.Tests.ps1`: record shape + `_src_hash`, description-vector omission, single-batch sub-id call, idempotent skip, re-embed on source change, v1→v2 upgrade. Entity suite green (43/43); full local Pester green except 4 pre-existing env-dependent failures outside this diff (xai-grok backend key; unbuilt TS side of the PS↔TS prompt-parity tests) — none touch the 3 changed files.

## Design gate
Covered by **TL ruling t/3121#4** (data-model change; not self-cert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)