### PR TITLE
[FIRE-ARM · DO NOT MERGE] prove render-smoke fires on .ga-* misfile (t/3026)

### DIFF
--- a/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.css
+++ b/taxonomy-editor/src/renderer/components/taxonomy/GraphAttributesPanel.css
@@ -123,7 +123,7 @@
   transform: rotate(90deg);
 }
 
-.ga-grid-3col {
+.ga-grid-3col-FIREARM-DO-NOT-MERGE-t3026 {
   padding: 10px 14px;
   display: grid;
   grid-template-columns: 2fr 1fr 1fr;


### PR DESCRIPTION
Throwaway both-arms FIRE demonstration for the t/3026 render-smoke promotion GV (#1692). Renames .ga-grid-3col so the rule is absent → render-smoke should go RED in the CI runner. **DO NOT MERGE** — closed + branch deleted once the red render-smoke run is captured.