### PR TITLE
feat(smoke): embeddings-cache-presence probe via anon /readyz (t/3088 follow-up #1)

### DIFF
--- a/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
+++ b/scripts/AITriad/Public/Invoke-TaxEditorSmokeTest.ps1
@@ -509,6 +509,31 @@ function Invoke-TaxEditorSmokeTest {
     }
     Write-Host ''
 
+    # ── Phase 9: Embeddings cache presence (t/3088 follow-up #1) ────────────────
+    # t/3085/t/3086: the precomputed embeddings.json cache was silently dead for 3.5 months.
+    # /health exposes embeddings.cachePresent but ONLY to admins (meta.ts anon branch returns
+    # status+ai and early-returns), so an anon smoke can't read it. The anon /readyz (t/3112,
+    # PUBLIC_EXACT_PATHS) returns 200 IFF the precomputed-vector cache is loaded (present AND
+    # nodeCount>0) — the anon-accessible "cache present" signal this probe asserts, no creds.
+    # WARN-FIRST like Phase 8 (embedding latency): a fresh revision can be /healthz-ready but
+    # /readyz-503 during fire-and-forget prewarm, so a 503 surfaces as ::warning:: (a real but
+    # often transient signal), NOT a hard failure — EXCLUDED from $OverallPass so a cold-revision
+    # warmup can't false-red Health/Endpoints/Azure.
+    Write-Host '=== Embeddings Cache Presence ===' -ForegroundColor Cyan
+    $CacheCheck = Invoke-RemoteCheck -BaseUrl $BaseUrl -Path '/readyz' `
+        -Method 'GET' -TimeoutSec $TimeoutSec -AcceptableStatusCodes @(200, 503)
+    $EmbeddingCachePresent = ($CacheCheck.StatusCode -eq 200)
+    $EmbeddingCacheStatus  = if ($EmbeddingCachePresent) { 'present' }
+        elseif ($CacheCheck.StatusCode -eq 503) { 'warming' }
+        else { 'unreachable' }
+    $CCIcon  = if ($EmbeddingCachePresent) { '[PASS]' } else { '[DEGRADED]' }
+    $CCColor = if ($EmbeddingCachePresent) { 'Green' } else { 'Yellow' }
+    Write-Host "  $CCIcon GET /readyz — $($CacheCheck.StatusCode) $($CacheCheck.ResponseMs)ms — embeddings cache $EmbeddingCacheStatus" -ForegroundColor $CCColor
+    if (-not $EmbeddingCachePresent) {
+        Write-Host "::warning::Embeddings cache not present (/readyz=$($CacheCheck.StatusCode), $EmbeddingCacheStatus) — monitoring signal, does not block the gate. A sustained 'warming'/'unreachable' is the t/3085 dead-cache class."
+    }
+    Write-Host ''
+
     # ── Summary ──────────────────────────────────────────────────────────
     $AllResults = @($Endpoints) + @($AnonEndpoints) + @($Analytics) + @($DataPresence) + @($OpedFilesResult)
     $Passed = @($AllResults | Where-Object { $_.Pass }).Count
@@ -570,6 +595,8 @@ function Invoke-TaxEditorSmokeTest {
         EmbeddingStatus     = $EmbeddingStatus
         EmbeddingLatencyMs  = $EmbeddingMs
         EmbeddingCeilingSec = $EmbeddingCeilingSec
+        EmbeddingCachePresent = $EmbeddingCachePresent
+        EmbeddingCacheStatus  = $EmbeddingCacheStatus
         EndpointsPassed = $Passed
         EndpointsFailed = $Failed
         EndpointsTotal  = $Total

--- a/tests/Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.Analytics.Tests.ps1
@@ -47,6 +47,14 @@ Describe 'Invoke-TaxEditorSmokeTest analytics round-trip probe (t/2667)' -Tag 'h
             Mock Test-GitHubHealth -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
             Mock Start-Sleep -MockWith { }
 
+            # Fallback for any path not explicitly stubbed (e.g. Phase 9 /readyz cache probe,
+            # t/3088) — a benign reachable 200. Specific -ParameterFilter mocks below take
+            # precedence, so analytics call-count assertions are unaffected.
+            Mock Invoke-RemoteCheck -MockWith {
+                [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 5
+                    Body = $null; ContentType = 'application/json'; RawBody = ''; Error = $null }
+            }
+
             # Phase 5 now establishes an anon session (t/2684) before the round-trip —
             # stub it so the tests stay offline and fast. Default: a real session so
             # the -Session param is threaded through the three calls; individual tests

--- a/tests/Invoke-TaxEditorSmokeTest.CachePresence.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.CachePresence.Tests.ps1
@@ -1,0 +1,121 @@
+# Tag: health (t/3088 follow-up #1)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    t/3088 follow-up #1 — the embeddings-cache-presence probe (Phase 9) in
+    Invoke-TaxEditorSmokeTest, asserted via the ANON /readyz endpoint.
+.DESCRIPTION
+    /health.embeddings.cachePresent (t/3086) is admin-only (meta.ts anon branch early-returns
+    status+ai), so an anon smoke can't read it. /readyz (t/3112, PUBLIC_EXACT_PATHS) returns
+    200 IFF the precomputed-vector cache is loaded — the anon "cache present" signal. Like the
+    Phase 8 latency probe, this is WARN-FIRST: a 503 (cold-revision prewarm) or unreachable
+    surfaces as ::warning:: and is EXCLUDED from OverallPass so it can't false-red the gate.
+
+    Mocks the private Invoke-RemoteCheck HTTP seam (no spend/network) — the proven recipe.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Invoke-TaxEditorSmokeTest — embeddings cache presence (/readyz), warn-first (t/3088)' -Tag 'health' {
+
+    BeforeEach {
+        InModuleScope AITriad {
+            Mock Invoke-HealthProbe -MockWith {
+                $r = [TaxEditorHealthResult]::new()
+                $r.BaseUrl = 'https://stub'; $r.Healthy = $true
+                $r.Checks = @(); $r.AverageMs = 0; $r.FreeTierKeyPoolSize = 0
+                $r.Timestamp = (Get-Date).ToString('o'); $r
+            }
+            Mock Start-Sleep -MockWith { }
+            Mock New-AnonymousWebSession -MockWith { [Microsoft.PowerShell.Commands.WebRequestSession]::new() }
+            Mock Test-AzureHealth  -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
+            Mock Test-GitHubHealth -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
+
+            $script:AnQ = 0
+            Mock Invoke-RemoteCheck -MockWith {
+                switch -Wildcard ($Path) {
+                    '*/readyz' {
+                        return [PSCustomObject]@{ Success = ($script:ReadyzStatus -eq 200); StatusCode = $script:ReadyzStatus; ResponseMs = 8
+                            Body = $null; ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    '*/api/embeddings/compute' {
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 150
+                            Body = [PSCustomObject]@{ vectors = @(1, 2, 3, 4) }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    '*/api/analytics/query' {
+                        $script:AnQ++
+                        $total = if ($script:AnQ -eq 1) { 5 } else { 6 }
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 10
+                            Body = [PSCustomObject]@{ summary = [PSCustomObject]@{ totalEvents = $total }; eventTypes = [PSCustomObject]@{ 'view.dwell' = 1 } }
+                            ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    '*/api/analytics/event' {
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 10
+                            Body = [PSCustomObject]@{ ok = $true; count = 1 }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    '*/api/health/oped-files' {
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 10
+                            Body = [PSCustomObject]@{ ok = $true; assets = @('soul', 'oped') }; ContentType = 'application/json'; RawBody = ''; Error = $null }
+                    }
+                    default {
+                        return [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 42
+                            Body = [PSCustomObject]@{ nodes = @(); id = 'stub-item' }; ContentType = 'application/json'
+                            RawBody = '<!doctype html><html><body><div id="root"></div><script src="/assets/app.js"></script></body></html>'; Error = $null }
+                    }
+                }
+            }
+        }
+    }
+
+    It 'PRESENT: /readyz 200 → cache present, OverallPass true' {
+        InModuleScope AITriad {
+            $script:ReadyzStatus = 200
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' -HealthMaxAttempts 1 6>$null
+            $result.EmbeddingCachePresent | Should -BeTrue
+            $result.EmbeddingCacheStatus  | Should -Be 'present'
+            $result.OverallPass           | Should -BeTrue
+        }
+    }
+
+    It 'WARMING: /readyz 503 → not present but OverallPass STILL true (warn-first, excluded from gate)' {
+        InModuleScope AITriad {
+            $script:ReadyzStatus = 503
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' -HealthMaxAttempts 1 6>$null
+            $result.EmbeddingCachePresent | Should -BeFalse
+            $result.EmbeddingCacheStatus  | Should -Be 'warming'
+            $result.OverallPass           | Should -BeTrue -Because 'a cold-revision prewarm 503 is a monitoring signal, not a hard failure'
+        }
+    }
+
+    It 'UNREACHABLE: /readyz 0 → status unreachable, OverallPass still true' {
+        InModuleScope AITriad {
+            $script:ReadyzStatus = 0
+            $result = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' -HealthMaxAttempts 1 6>$null
+            $result.EmbeddingCachePresent | Should -BeFalse
+            $result.EmbeddingCacheStatus  | Should -Be 'unreachable'
+            $result.OverallPass           | Should -BeTrue
+        }
+    }
+
+    It 'surfaces a ::warning:: annotation when the cache is not present' {
+        InModuleScope AITriad {
+            $script:ReadyzStatus = 503
+            $out = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' -HealthMaxAttempts 1 6>&1 | Out-String
+            $out | Should -Match '::warning::Embeddings cache not present'
+        }
+    }
+
+    It 'emits NO cache warning when present' {
+        InModuleScope AITriad {
+            $script:ReadyzStatus = 200
+            $out = Invoke-TaxEditorSmokeTest -BaseUrl 'https://stub' -HealthMaxAttempts 1 6>&1 | Out-String
+            $out | Should -Not -Match '::warning::Embeddings cache not present'
+        }
+    }
+}

--- a/tests/Invoke-TaxEditorSmokeTest.ColdStart.Tests.ps1
+++ b/tests/Invoke-TaxEditorSmokeTest.ColdStart.Tests.ps1
@@ -43,6 +43,14 @@ Describe 'Invoke-TaxEditorSmokeTest Health-phase cold-start tolerance (t/1696)' 
             Mock Test-GitHubHealth -MockWith { [PSCustomObject]@{ Healthy = $true; Checks = @() } }
             Mock Start-Sleep -MockWith { }
 
+            # Fallback for any path not explicitly stubbed below (e.g. Phase 9 /readyz cache
+            # probe, t/3088) — a benign reachable 200 so an un-enumerated call can't sink the
+            # health phase under test. Specific -ParameterFilter mocks below take precedence.
+            Mock Invoke-RemoteCheck -MockWith {
+                [PSCustomObject]@{ Success = $true; StatusCode = 200; ResponseMs = 5
+                    Body = $null; ContentType = 'application/json'; RawBody = ''; Error = $null }
+            }
+
             # t/2667 — the Analytics phase (Phase 5) calls the Private Invoke-RemoteCheck
             # for a delta read-back. Stub it to a clean round-trip (totalEvents 0 → 1)
             # so the analytics phase passes and OverallPass hinges solely on the health


### PR DESCRIPTION
Implements **t/3088 follow-up #1** — the embeddings-cache-presence sub-check in `Invoke-TaxEditorSmokeTest` (Phase 9).

## What & why
The t/3085 class: the precomputed `embeddings.json` cache was silently dead for 3.5 months — every debate re-embedded ~3,600 static texts (25–48s vs a <200ms cache hit), invisible to error-rate gates because nothing *failed*. This probe asserts the cache is present.

## Signal choice (deviation from the literal ask — flagged)
The ticket said assert t/3086's "healthz cache field." That field (`/health.embeddings.cachePresent`) is **admin-only** — `meta.ts`'s anon branch early-returns `status`+`ai` — so an anonymous smoke can't read it. Instead this asserts the anon **`/readyz`** endpoint (t/3112, `PUBLIC_EXACT_PATHS`), which returns **200 iff** the precomputed-vector cache is loaded (present && nodeCount>0) — the anon-accessible equivalent, no creds.

## Warn-first (like Phase 8)
A fresh revision can be `/healthz`-ready but `/readyz`-503 during fire-and-forget prewarm, so a 503 (warming) / unreachable surfaces as `::warning::` and is **excluded from `OverallPass`** — a cold-revision warmup can't false-red the deploy gate. New return fields: `EmbeddingCachePresent`, `EmbeddingCacheStatus`. Promotion to a *blocking* gate is a separate TL Gate-Verification decision, not done here.

## Tests
5 new cases (`CachePresence.Tests.ps1`): present / warming / unreachable, `OverallPass` unaffected, warning emitted iff not present. The new `/readyz` call surfaced that `ColdStart` + `Analytics` tests mocked `Invoke-RemoteCheck` with per-path filters and no fallback — added a benign-200 default mock to each (specific filters still take precedence; call-count assertions unchanged). All smoke suites green (29/29).

## Design gate
`/trivial-change` self-cert — additive warn-first probe on an existing cmdlet, existing IO helper, no new public API/schema/data model, and **not** gate-touching (excluded from `OverallPass`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)