### PR TITLE
feat(devops): flag nested .worktrees dirs outside repo root in drift check (t/3145) [DRAFT]

### DIFF
--- a/operations/devops/check-shared-drift.ps1
+++ b/operations/devops/check-shared-drift.ps1
@@ -146,31 +146,43 @@ try {
 
     # 5c. NESTED .worktrees directories outside repo root (t/3145; t/2222 cwd-reset class).
     #     A `git worktree add` run with the shell cwd reset into a subdir drops .worktrees UNDER a
-    #     role subtree instead of the repo root (Rosetta found two such inert dirs, p/519). Legit
-    #     worktrees live ONLY at <root>/.worktrees/; a .worktrees segment anywhere else is cruft.
-    #     Warn-only (advisory). Detected two ways so both variants are caught:
-    #       (a) registered-but-misplaced — `git worktree list` path not directly under <root>/.worktrees/
-    #       (b) inert leftover (no .git linkage) — an untracked path with a non-root .worktrees segment
-    $rootFull    = ((Resolve-Path $RepoRoot -ErrorAction SilentlyContinue).Path -replace '\\', '/').TrimEnd('/')
-    $legitPrefix = "$rootFull/.worktrees/"
-    $nestedWorktrees = @()
-    # (a) registered worktrees
+    #     role subtree instead of the repo root. Legit worktrees live ONLY at <root>/.worktrees/.
+    #     Warn-only (advisory). Per TL disposition (t/3145#2):
+    #       - ONLY INERT (unregistered) nested dirs are drift; an ACTIVE registered worktree nested
+    #         under a subtree is EXEMPT (someone's using it — it has a .git safety net).
+    #       - Route each flag to the OWNING role (path-derived) so the owner cleans it, not DevOps.
+    #     Root <root>/.worktrees/ is never flagged. Each entry is "<relpath> (Owner)".
+    $rootFull = ((Resolve-Path $RepoRoot -ErrorAction SilentlyContinue).Path -replace '\\', '/').TrimEnd('/')
+    # Registered worktree paths (absolute, normalized, lowercased) — the EXEMPT set.
+    $registered = @{}
     foreach ($line in @(Invoke-Git @('-C', $RepoRoot, 'worktree', 'list', '--porcelain') | Where-Object { $_ -like 'worktree *' })) {
-        $wtPath = (($line -replace '^worktree\s+', '') -replace '\\', '/').TrimEnd('/')
-        if ($wtPath -eq $rootFull) { continue }                 # the main checkout — fine
-        if ($wtPath.StartsWith($legitPrefix)) { continue }      # <root>/.worktrees/<name> — fine
-        if (-not $wtPath.StartsWith("$rootFull/")) { continue } # worktree OUTSIDE the repo (e.g. ../wt-x) — legit/out-of-scope, NOT nested cruft
-        $nestedWorktrees += $wtPath.Substring($rootFull.Length + 1)
+        $wp = ((($line -replace '^worktree\s+', '') -replace '\\', '/').TrimEnd('/')).ToLowerInvariant()
+        $registered[$wp] = $true
     }
-    # (b) inert leftover (no .git linkage). NOTE: the root .worktrees/ is .gitignore'd, so the
-    #     $untracked list above (--exclude-standard) never surfaces a nested .worktrees either.
-    #     Use `git ls-files --others --directory` WITHOUT --exclude-standard so ignored dirs are
-    #     surfaced, and --directory collapses each untracked dir to one entry (cheap — no descent
-    #     into node_modules/dist contents). Filter to non-root .worktrees segments.
+    # Find every nested .worktrees dir (not root). `git ls-files --others --directory` WITHOUT
+    # --exclude-standard surfaces the .gitignore'd .worktrees; --directory collapses dirs (cheap —
+    # no descent into node_modules/dist contents). Then flag each INERT child (exempt registered).
+    $nestedWorktrees = @()
+    $seenNested = @{}
     foreach ($d in @(Invoke-Git @('-C', $RepoRoot, 'ls-files', '--others', '--directory') | Where-Object { $_ })) {
         $nd = ($d -replace '\\', '/').TrimEnd('/')
         if ($nd -notmatch '^\.worktrees(/|$)' -and $nd -match '^(.+?/\.worktrees)(/|$)') {
-            $nestedWorktrees += $matches[1]
+            $wtDir = $matches[1]
+            if ($seenNested[$wtDir]) { continue }
+            $seenNested[$wtDir] = $true
+            $abs = "$rootFull/$wtDir"
+            $children = @(Get-ChildItem -LiteralPath $abs -Directory -Force -ErrorAction SilentlyContinue)
+            if ($children.Count -eq 0) {
+                $owner = Get-OwningScope -Path $wtDir
+                $nestedWorktrees += "$wtDir ($($owner.Role))"     # empty nested .worktrees dir — inert leftover
+            } else {
+                foreach ($c in $children) {
+                    if ($registered[(($c.FullName -replace '\\', '/').TrimEnd('/')).ToLowerInvariant()]) { continue } # active registered — EXEMPT
+                    $childRel = "$wtDir/$($c.Name)"
+                    $owner = Get-OwningScope -Path $childRel
+                    $nestedWorktrees += "$childRel ($($owner.Role))"
+                }
+            }
         }
     }
     $nestedWorktrees = @($nestedWorktrees | Select-Object -Unique)
@@ -216,7 +228,7 @@ try {
 
     # t/3058: also attribute non-removed spray (guard-blocked junk + suspicious files) so the
     # tally covers every fragment, not just the auto-cleaned ones. mtime best-effort (may be gone).
-    foreach ($f in @($remainingJunk + $suspiciousPaths + $nestedWorktrees)) {
+    foreach ($f in @($remainingJunk + $suspiciousPaths)) {   # nestedWorktrees carry their own (Owner) annotation + hint; not re-attributed here
         $mtime = $null
         try { $mtime = (Get-Item (Join-Path $RepoRoot $f) -ErrorAction Stop).LastWriteTime.ToString('o') } catch { }
         $owner = Get-OwningScope -Path $f
@@ -262,8 +274,8 @@ try {
             $hints += "suspicious extension-less file(s) in source dir [$listed]: verify untracked, then Remove-Item <paths>"
         }
         if ($nestedWorktrees.Count -gt 0) {
-            $listed = $nestedWorktrees -join ', '
-            $hints += "NESTED .worktrees dir(s) outside repo root (t/3145; t/2222 cwd-reset class) [$listed]: a worktree add landed in a role subtree instead of <root>/.worktrees/ — verify no unpushed work, then 'git worktree remove <path>' (if registered) or 'Remove-Item -Recurse -Force <path>' (if inert cruft)"
+            $listed = $nestedWorktrees -join '; '
+            $hints += "INERT nested .worktrees dir(s) outside <root>/.worktrees/ (t/3145; t/2222 cwd-reset drift) — routed to owning role [$listed]: orphaned copies (no .git safety net). OWNER: confirm inert (no .git, no unpushed/unique content) then 'Remove-Item -Recurse -Force <path>'. Active registered worktrees are EXEMPT (never listed)."
         }
         if ($dirtyFiles.Count -gt 0) {
             if (-not $hasRealDiff) {

--- a/operations/devops/check-shared-drift.ps1
+++ b/operations/devops/check-shared-drift.ps1
@@ -84,6 +84,7 @@ $result = [PSCustomObject]@{
     HasRealDiff      = $false
     JunkPaths        = @()
     SuspiciousPaths  = @()
+    NestedWorktrees  = @()
     AutoRemoved      = @()
     Attribution      = @{}
     RemediationHint  = ''
@@ -143,6 +144,38 @@ try {
     }
     $result.SuspiciousPaths = $suspiciousPaths
 
+    # 5c. NESTED .worktrees directories outside repo root (t/3145; t/2222 cwd-reset class).
+    #     A `git worktree add` run with the shell cwd reset into a subdir drops .worktrees UNDER a
+    #     role subtree instead of the repo root (Rosetta found two such inert dirs, p/519). Legit
+    #     worktrees live ONLY at <root>/.worktrees/; a .worktrees segment anywhere else is cruft.
+    #     Warn-only (advisory). Detected two ways so both variants are caught:
+    #       (a) registered-but-misplaced — `git worktree list` path not directly under <root>/.worktrees/
+    #       (b) inert leftover (no .git linkage) — an untracked path with a non-root .worktrees segment
+    $rootFull    = ((Resolve-Path $RepoRoot -ErrorAction SilentlyContinue).Path -replace '\\', '/').TrimEnd('/')
+    $legitPrefix = "$rootFull/.worktrees/"
+    $nestedWorktrees = @()
+    # (a) registered worktrees
+    foreach ($line in @(Invoke-Git @('-C', $RepoRoot, 'worktree', 'list', '--porcelain') | Where-Object { $_ -like 'worktree *' })) {
+        $wtPath = (($line -replace '^worktree\s+', '') -replace '\\', '/').TrimEnd('/')
+        if ($wtPath -eq $rootFull) { continue }                 # the main checkout — fine
+        if ($wtPath.StartsWith($legitPrefix)) { continue }      # <root>/.worktrees/<name> — fine
+        if (-not $wtPath.StartsWith("$rootFull/")) { continue } # worktree OUTSIDE the repo (e.g. ../wt-x) — legit/out-of-scope, NOT nested cruft
+        $nestedWorktrees += $wtPath.Substring($rootFull.Length + 1)
+    }
+    # (b) inert leftover (no .git linkage). NOTE: the root .worktrees/ is .gitignore'd, so the
+    #     $untracked list above (--exclude-standard) never surfaces a nested .worktrees either.
+    #     Use `git ls-files --others --directory` WITHOUT --exclude-standard so ignored dirs are
+    #     surfaced, and --directory collapses each untracked dir to one entry (cheap — no descent
+    #     into node_modules/dist contents). Filter to non-root .worktrees segments.
+    foreach ($d in @(Invoke-Git @('-C', $RepoRoot, 'ls-files', '--others', '--directory') | Where-Object { $_ })) {
+        $nd = ($d -replace '\\', '/').TrimEnd('/')
+        if ($nd -notmatch '^\.worktrees(/|$)' -and $nd -match '^(.+?/\.worktrees)(/|$)') {
+            $nestedWorktrees += $matches[1]
+        }
+    }
+    $nestedWorktrees = @($nestedWorktrees | Select-Object -Unique)
+    $result.NestedWorktrees = $nestedWorktrees
+
     # 5b. Auto-remediate 0-byte junk — triple guard per t/2476#1:
     #     (a) path is in $junkPaths (already classified as 0-byte untracked)
     #     (b1) not tracked in main repo (git ls-files returns empty at delete time)
@@ -183,7 +216,7 @@ try {
 
     # t/3058: also attribute non-removed spray (guard-blocked junk + suspicious files) so the
     # tally covers every fragment, not just the auto-cleaned ones. mtime best-effort (may be gone).
-    foreach ($f in @($remainingJunk + $suspiciousPaths)) {
+    foreach ($f in @($remainingJunk + $suspiciousPaths + $nestedWorktrees)) {
         $mtime = $null
         try { $mtime = (Get-Item (Join-Path $RepoRoot $f) -ErrorAction Stop).LastWriteTime.ToString('o') } catch { }
         $owner = Get-OwningScope -Path $f
@@ -208,7 +241,7 @@ try {
     }
 
     # 6. Determine alarm + remediation hint
-    $alarm = $behind -gt 0 -or $dirtyFiles.Count -gt 0 -or $remainingJunk.Count -gt 0 -or $suspiciousPaths.Count -gt 0
+    $alarm = $behind -gt 0 -or $dirtyFiles.Count -gt 0 -or $remainingJunk.Count -gt 0 -or $suspiciousPaths.Count -gt 0 -or $nestedWorktrees.Count -gt 0
     $result.Alarm = $alarm
 
     if ($alarm) {
@@ -227,6 +260,10 @@ try {
         if ($suspiciousPaths.Count -gt 0) {
             $listed = $suspiciousPaths -join ', '
             $hints += "suspicious extension-less file(s) in source dir [$listed]: verify untracked, then Remove-Item <paths>"
+        }
+        if ($nestedWorktrees.Count -gt 0) {
+            $listed = $nestedWorktrees -join ', '
+            $hints += "NESTED .worktrees dir(s) outside repo root (t/3145; t/2222 cwd-reset class) [$listed]: a worktree add landed in a role subtree instead of <root>/.worktrees/ — verify no unpushed work, then 'git worktree remove <path>' (if registered) or 'Remove-Item -Recurse -Force <path>' (if inert cruft)"
         }
         if ($dirtyFiles.Count -gt 0) {
             if (-not $hasRealDiff) {


### PR DESCRIPTION
## t/3145 — nested-.worktrees drift guard (advisory)

Extends `check-shared-drift.ps1` to flag `.worktrees` dirs NOT at repo root (the t/2222 cwd-reset class Rosetta found, p/519). New `NestedWorktrees` field + hint; warn-only (never auto-deletes — nested worktrees may hold unpushed work).

**Detection:** (a) `git worktree list` for registered-but-nested worktrees inside the repo (external `../wt-x` excluded); (b) `git ls-files --others --directory` (no `--exclude-standard`, since `.worktrees` is gitignored) for inert leftovers. Root `<root>/.worktrees/` never flagged.

**Both arms proven** against a disposable clone: clean (incl. a legit root `.worktrees`) → silent; planted nested → flags only the nested dir.

## ⚠️ Held DRAFT — a real fleet-wide finding needs disposition before this alarms hourly
A live run flags **8** existing nested `.worktrees` across scopes — mostly **inert cruft**:
- `lib/.worktrees` — **18 inert** dirs + 1 registered (`wt-t3119`, active)
- `taxonomy-editor/.worktrees` (t2310, t3059), `taxonomy-editor/src/main/.worktrees` (t3012)
- `engineering/tech-lead/.worktrees` (fix-1597), `management/project-manager/.worktrees` (dep-fix)
- `operations/sage/.worktrees` (empty). (`operations/devops/.worktrees` was mine — already removed.)

Shipping this makes the hourly drift check ping DevOps about all 8 until the **owning roles** clean them (cross-scope; can't auto-delete — possible unpushed work). **Question for TL/PM:** are these cwd-reset cruft to clean fleet-wide (then merge this to prevent recurrence), or is nested `.worktrees` a deliberate per-role convention (then the guard's premise needs narrowing)? Merge gated on that call.