### PR TITLE
fix(deploy): pin budget startDate to creation month; stop utcNow() rollover (t/3155)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -1013,8 +1013,8 @@ resource authConfigStaging 'Microsoft.App/containerApps/authConfigs@2024-10-02-p
 @description('Email address for budget alerts')
 param budgetAlertEmail string = ''
 
-@description('First day of the current month at deploy time — Azure Consumption budgets reject a monthly startDate prior to the current month')
-param budgetStartDate string = utcNow('yyyy-MM-01')
+@description('IMMUTABLE start date of budget-aitriad-monthly, pinned to its original creation month (2026-08-01). Azure Consumption Budgets FORBID updating startDate in place ("Start date of budgets cannot be updated"), so this MUST NOT be recomputed per-deploy with utcNow() — doing so rolls the date forward each month and fails every deploy in a later month (t/3155). For a brand-new environment with no existing budget, override this param to the first of the current month at create time.')
+param budgetStartDate string = '2026-08-01'
 
 var budgetAlertConfigured = !empty(budgetAlertEmail)
 


### PR DESCRIPTION
Fixes the production deploy failure (run 33476676056) at the Bicep/ARM stage:

```
400: Start date of budgets cannot be updated. Please delete and create a new budget.
```

**Root cause:** `deploy/azure/main.bicep` computed the budget `startDate` as `utcNow('yyyy-MM-01')` — first of the *current* month each deploy. The live `budget-aitriad-monthly` was created with `startDate=2026-08-01`; Azure Consumption Budgets forbid updating startDate in place, so every deploy in a later month fails the whole ARM deployment. Recurs monthly.

**Fix:** pin `budgetStartDate` to the verified live creation date `2026-08-01` so every deploy is a no-op on the budget. New-env creation overrides the param.

**Prod impact of the incident:** none — failure was pre-revision, prod stayed on the previous good revision.

Ref t/3155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)