### PR TITLE
feat(entities): add EntityMatchLevel type (split from t/3119 to land early)

### DIFF
--- a/lib/entities/types.ts
+++ b/lib/entities/types.ts
@@ -76,6 +76,17 @@ export type DolceCategory =
  */
 export type EntityDescriptionProvenance = 'ai-drafted' | 'human-edited' | 'human-authored';
 
+/**
+ * How a link (an `entity_refs[]` entry on a claim or BDI node) matched its target relative to the
+ * register (R4.2) — lets downstream consumers (conflict detection, FOL export) tell an exact match
+ * from a subsumption hop. `exact` = the surface names the target; the others = matched via ≤1–2
+ * relation hops. Shared match-level VOCABULARY only; the link-record shape and the direction
+ * semantics of each label are ASSIGNED by the resolution pass (t/3124) — see there for what each
+ * label means at assignment time. Split out of t/3119 to land early (pure enum, no relations/
+ * allowlist coupling — CL p/3#156), unblocking the t/3157 node link-refs + t/3124.
+ */
+export type EntityMatchLevel = 'exact' | 'instance_of' | 'subclass' | 'superclass' | 'related';
+
 /** The new entity record (ent-*), stored in entities.json. */
 export interface Entity {
   id: string;                     // ent-NNN


### PR DESCRIPTION
Pure match-level enum split out of t/3119 to land early per CL (p/3#156, DOLCE-approved). Self-cert (type-only, additive).

## Why split
`EntityMatchLevel = 'exact' | 'instance_of' | 'subclass' | 'superclass' | 'related'` (R4.2) is a standalone enum with **no** relations[]/allowlist coupling, so it's independent of t/3119's blocked t/3133 allowlist-sync sequencing. Landing it now unblocks:
- **t/3157** — the BDI node `EntityLinkRef.match_level`,
- **t/3124** — the claim `entity_refs[]` link record.

t/3119's `relations[]` + `EntityRelation` stay held on the allowlist-sync ruling (separate).

## Scope
Type-only; label-direction assignment semantics are owned by the resolution pass (t/3124). tsc + eslint clean; no test needed (no runtime). CL DOLCE-reviewed the vocabulary in t/3119#2 + p/3#156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)