### PR TITLE
feat(ps): Test-EmbeddingsCacheHealth — one-shot cache resolving/re-computing verdict (t/3168)

### DIFF
--- a/docs/cmdlet-reference.md
+++ b/docs/cmdlet-reference.md
@@ -137,6 +137,7 @@ Get-Help <CmdletName> -Full                     # full docs for any cmdlet
 | `Get-ContainerAppRevision` | Query ACA revisions by mode (Active/Stale/Fqdn) — replaces raw `az containerapp revision` calls (t/1498) |
 | `Get-ServerLog` | Retrieve + filter ACA server logs, correlate by Pino requestId — `-RequestId`/`-Recent`/`-StartTime`/`-Pattern` sets, `-Level`/`-Component`/`-Follow`/`-Raw` (t/2765) |
 | `Get-TaxEditorServerLogs` | Pull **deep** server-log history from Log Analytics (past the live-tail buffer) by `-From`/`-To`/`-RequestId`/`-Pattern`; parses Pino fields (Level/RequestId/Component/Method/Path/Status/DurationMs); `-System` for revision/restart events (t/3082) |
+| `Test-EmbeddingsCacheHealth` | One-shot `resolving`/`re-computing`/`no-traffic`/`unknown` verdict on whether the precomputed embeddings cache is serving on the live revision — compute p50/p95, load-shed 503s, cache-ready signal over `-From`/`-To` (default 30m); baseline-validation for the embedding-saturation class (t/3168) |
 | `Test-PreloadHealth` | Validate the built `preload.cjs` before launch — exists, calls `contextBridge.exposeInMainWorld`, self-contained (no relative `require('./…')`), optional `node --check` (t/2775, t/2777) |
 | `New-ContainerAppRevision` | Blue-green: deploy a new ACA revision at 0% traffic; returns real `RevisionName` for the promotion chain (t/1500 Phase 3) |
 | `Set-ContainerAppTraffic` | Shift traffic to a named revision with retry — call BEFORE `Disable-ContainerAppRevision` in rollback (t/1500 Phase 3) |

--- a/scripts/AITriad/AITriad.psd1
+++ b/scripts/AITriad/AITriad.psd1
@@ -245,6 +245,8 @@
         'Get-ServerLog'
         # t/3082 — Log Analytics server-log query (deep history) by window/requestId/pattern
         'Get-TaxEditorServerLogs'
+        # t/3168 — one-shot embeddings-cache resolving/re-computing verdict on the live revision
+        'Test-EmbeddingsCacheHealth'
     )
 
     # Aliases exported from this module

--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -997,6 +997,8 @@ Export-ModuleMember -Function @(
     'Get-ServerLog'
     # t/3082 — Log Analytics server-log query (deep history) by window/requestId/pattern
     'Get-TaxEditorServerLogs'
+    # t/3168 — one-shot embeddings-cache resolving/re-computing verdict on the live revision
+    'Test-EmbeddingsCacheHealth'
 ) -Alias @(
     'Import-Document'
     'TaxonomyEditor'

--- a/scripts/AITriad/Public/Test-EmbeddingsCacheHealth.ps1
+++ b/scripts/AITriad/Public/Test-EmbeddingsCacheHealth.ps1
@@ -1,0 +1,185 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    One-shot verdict on whether the precomputed embeddings cache is resolving on the live
+    prod revision, or silently re-computing — the recurring baseline-validation question for
+    the embedding-saturation incident class (t/2905, t/3072, t/3085, t/3165).
+.DESCRIPTION
+    Every embedding-saturation triage re-runs the same manual Log Analytics correlation to answer
+    one question: is the precomputed embeddings cache actually resolving on the serving revision,
+    or is the server silently re-embedding ~800 static texts per debate? This cmdlet assembles
+    that verdict in a single call.
+
+    It pulls all `embeddings`-tagged console lines over a window via Get-TaxEditorServerLogs
+    (reusing its Log Analytics workspace resolution and Pino parsing), then derives:
+      - Compute request durations on `/api/embeddings/compute` (cache-hit ≈ 1-183ms; re-compute ≈ 1.5-8.4s)
+      - Any `embeddings.compute: load-shed 503` back-pressure rows
+      - The boot-time `embeddings.json loaded` / `cache ready` signal, if it fell in the window
+      - The serving revision name (from the newest matching row)
+
+    Verdict logic (duration-based; robust today, sharper once t/3166's request-time cache-miss
+    log lands):
+      - p95 < 500ms and no load-shed 503  -> 'resolving'
+      - p95 > 1000ms or any load-shed 503  -> 're-computing'
+      - zero compute rows                  -> 'no-traffic'  (can't tell — reported, never false-passed)
+      - otherwise (p95 in the 500-1000ms grey band) -> 'unknown'
+
+    Requires the az CLI logged in with reader access to the Log Analytics workspace. No AI calls.
+.PARAMETER From
+    Lower bound of the window (UTC-compared). Default: 30 minutes before -To.
+.PARAMETER To
+    Upper bound. Default: now (UTC).
+.PARAMETER App
+    Container app to inspect. Default 'taxonomy-editor' (prod). Passed through to
+    Get-TaxEditorServerLogs. (Deviation from the ticket's -BaseUrl: the verdict is computed from
+    Log Analytics, not an HTTP probe, so -BaseUrl would be a dead parameter; -App is the real
+    log-source selector.)
+.PARAMETER ResourceGroup
+    Azure resource group. Default 'ai-triad'. Passed through to Get-TaxEditorServerLogs.
+.PARAMETER Max
+    Row cap for the underlying Log Analytics query. Default 2000.
+.OUTPUTS
+    [PSCustomObject] AITriad.EmbeddingsCacheHealth with fields: Revision, ComputeCount,
+    ComputeP50Ms, ComputeP95Ms, LoadShed503Count, CacheReadySignalSeen, Verdict, From, To.
+.EXAMPLE
+    Test-EmbeddingsCacheHealth
+    # Is the cache resolving on the live revision over the last 30 minutes?
+.EXAMPLE
+    Test-EmbeddingsCacheHealth -From (Get-Date).AddHours(-2)
+    # Widen the window to catch a boot 'cache ready' signal after a recent deploy.
+.LINK
+    Get-TaxEditorServerLogs
+.LINK
+    Show-AITriadHelp
+#>
+function Test-EmbeddingsCacheHealth {
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [datetime]$From,
+
+        [Parameter()]
+        [datetime]$To,
+
+        [Parameter()]
+        [ValidateSet('taxonomy-editor', 'taxonomy-editor-staging')]
+        [string]$App = 'taxonomy-editor',
+
+        [Parameter()]
+        [string]$ResourceGroup = 'ai-triad',
+
+        [Parameter()]
+        [ValidateRange(1, 50000)]
+        [int]$Max = 2000
+    )
+
+    process {
+        Set-StrictMode -Version Latest
+
+        # ── Window (default last 30 min) ──────────────────────────────────
+        $toUtc   = if ($PSBoundParameters.ContainsKey('To'))   { $To.ToUniversalTime() }   else { [datetime]::UtcNow }
+        $fromUtc = if ($PSBoundParameters.ContainsKey('From')) { $From.ToUniversalTime() } else { $toUtc.AddMinutes(-30) }
+        if ($fromUtc -gt $toUtc) {
+            throw (New-ActionableError `
+                -Goal     'Assess embeddings-cache health over a time window' `
+                -Problem  "-From ($fromUtc) is after -To ($toUtc)." `
+                -Location 'Test-EmbeddingsCacheHealth' `
+                -NextSteps @('Pass -From earlier than -To, or omit both for the last 30 minutes.'))
+        }
+
+        # ── Pull all embeddings-tagged console lines in one query ─────────
+        # -Pattern 'embeddings' captures compute request completions, load-shed 503s, and the
+        # boot 'embeddings.json loaded' / 'cache ready' signal (all contain the substring).
+        # Get-TaxEditorServerLogs owns workspace resolution + Pino parsing; New-ActionableError
+        # on an unreachable workspace propagates from there unchanged.
+        $rows = @(Get-TaxEditorServerLogs -From $fromUtc -To $toUtc -App $App `
+                -ResourceGroup $ResourceGroup -Pattern 'embeddings' -Max $Max)
+
+        # ── Classify rows (StrictMode-safe property reads) ────────────────
+        $field = {
+            param($obj, [string]$name)
+            if ($null -eq $obj) { return $null }
+            $p = $obj.PSObject.Properties[$name]
+            if ($p) { return $p.Value } else { return $null }
+        }
+
+        $computeDurations = [System.Collections.Generic.List[double]]::new()
+        $loadShed503      = 0
+        $cacheReadySeen   = $false
+        $revision         = $null
+
+        foreach ($row in $rows) {
+            $path    = & $field $row 'Path'
+            $msg     = & $field $row 'Message'
+            $status  = & $field $row 'Status'
+            $dur     = & $field $row 'DurationMs'
+            $rev     = & $field $row 'Revision'
+            $msgText = if ($null -ne $msg) { [string]$msg } else { '' }
+            $pathText = if ($null -ne $path) { [string]$path } else { '' }
+
+            # Newest row's revision wins (rows arrive chronologically ascending).
+            if (-not [string]::IsNullOrWhiteSpace([string]$rev)) { $revision = [string]$rev }
+
+            # Compute request completion with a measured duration.
+            if ($pathText -like '*/api/embeddings/compute*' -and $null -ne $dur) {
+                $d = 0.0
+                if ([double]::TryParse([string]$dur, [ref]$d)) { $computeDurations.Add($d) }
+            }
+
+            # Load-shed 503 back-pressure (message-tagged, or a 503 on the compute path).
+            if ($msgText -match '(?i)load-shed' -or
+                (($status -eq 503 -or [string]$status -eq '503') -and $pathText -like '*embeddings*')) {
+                $loadShed503++
+            }
+
+            # Boot-time cache-ready signal.
+            if ($msgText -match '(?i)embeddings\.json loaded' -or $msgText -match '(?i)cache ready') {
+                $cacheReadySeen = $true
+            }
+        }
+
+        # ── Percentiles (nearest-rank on the sorted duration set) ─────────
+        $percentile = {
+            param([System.Collections.Generic.List[double]]$values, [double]$p)
+            $n = $values.Count
+            if ($n -eq 0) { return $null }
+            $sorted = @($values | Sort-Object)
+            $rank = [int][math]::Ceiling(($p / 100.0) * $n)
+            if ($rank -lt 1) { $rank = 1 }
+            if ($rank -gt $n) { $rank = $n }
+            [math]::Round($sorted[$rank - 1], 1)
+        }
+
+        $computeCount = $computeDurations.Count
+        $p50 = & $percentile $computeDurations 50
+        $p95 = & $percentile $computeDurations 95
+
+        # ── Verdict ───────────────────────────────────────────────────────
+        $verdict =
+            if ($computeCount -eq 0) {
+                'no-traffic'
+            } elseif ($loadShed503 -gt 0 -or ($null -ne $p95 -and $p95 -gt 1000)) {
+                're-computing'
+            } elseif ($null -ne $p95 -and $p95 -lt 500) {
+                'resolving'
+            } else {
+                'unknown'
+            }
+
+        [PSCustomObject]@{
+            PSTypeName           = 'AITriad.EmbeddingsCacheHealth'
+            Revision             = $revision
+            ComputeCount         = $computeCount
+            ComputeP50Ms         = $p50
+            ComputeP95Ms         = $p95
+            LoadShed503Count     = $loadShed503
+            CacheReadySignalSeen = $cacheReadySeen
+            Verdict              = $verdict
+            From                 = $fromUtc
+            To                   = $toUtc
+        }
+    }
+}

--- a/tests/Test-EmbeddingsCacheHealth.Tests.ps1
+++ b/tests/Test-EmbeddingsCacheHealth.Tests.ps1
@@ -1,0 +1,127 @@
+# Tag: diagnostics (t/3168)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Unit tests for Test-EmbeddingsCacheHealth (t/3168). Mocks Get-TaxEditorServerLogs (the log seam,
+    via -ModuleName so module-internal calls are intercepted) so no live Azure call is made — asserts
+    the resolving/re-computing/no-traffic/unknown verdict logic, the compute-duration percentiles,
+    load-shed and cache-ready detection, and the guard rails.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+
+    # Build a parsed console row in the shape Get-TaxEditorServerLogs emits. Defined in test scope;
+    # the mock bodies below close over it (Mock -ModuleName routes interception to module-internal
+    # calls while the MockWith scriptblock still runs in this scope).
+    function New-Row {
+        param([string]$Path, [string]$Message, $Status, $DurationMs, [string]$Revision = 'rev-abc')
+        [PSCustomObject]@{
+            PSTypeName = 'AITriad.ServerLogEntry'
+            Time       = [datetime]::UtcNow
+            Level      = 'info'
+            RequestId  = $null
+            Component  = 'server'
+            Method     = 'POST'
+            Path       = $Path
+            Status     = $Status
+            DurationMs = $DurationMs
+            Message    = $Message
+            Revision   = $Revision
+            Raw        = $null
+        }
+    }
+}
+
+Describe 'Test-EmbeddingsCacheHealth' -Tag 'diagnostics' {
+
+    It 'is exported from the module' {
+        Get-Command -Module AITriad -Name 'Test-EmbeddingsCacheHealth' | Should -Not -BeNullOrEmpty
+    }
+
+    It 'verdict=resolving when compute p95 is fast and there is no load-shed' {
+        Mock Get-TaxEditorServerLogs -ModuleName AITriad -MockWith {
+            @(
+                New-Row -Path '/api/embeddings/compute' -DurationMs 5
+                New-Row -Path '/api/embeddings/compute' -DurationMs 10
+                New-Row -Path '/api/embeddings/compute' -DurationMs 50
+                New-Row -Path '/api/embeddings/compute' -DurationMs 100
+                New-Row -Path '/api/embeddings/compute' -DurationMs 150
+                New-Row -Path '/api/embeddings/compute' -DurationMs 183 -Revision 'rev-live'
+            )
+        }
+        $r = Test-EmbeddingsCacheHealth
+        $r.Verdict          | Should -Be 'resolving'
+        $r.ComputeCount     | Should -Be 6
+        $r.ComputeP50Ms     | Should -Be 50
+        $r.ComputeP95Ms     | Should -Be 183
+        $r.LoadShed503Count | Should -Be 0
+        $r.Revision         | Should -Be 'rev-live'   # newest row's revision wins
+    }
+
+    It 'verdict=re-computing when compute p95 exceeds ~1s' {
+        Mock Get-TaxEditorServerLogs -ModuleName AITriad -MockWith {
+            @(
+                New-Row -Path '/api/embeddings/compute' -DurationMs 1500
+                New-Row -Path '/api/embeddings/compute' -DurationMs 3000
+                New-Row -Path '/api/embeddings/compute' -DurationMs 8400
+            )
+        }
+        $r = Test-EmbeddingsCacheHealth
+        $r.Verdict      | Should -Be 're-computing'
+        $r.ComputeP95Ms | Should -BeGreaterThan 1000
+    }
+
+    It 'verdict=re-computing when a load-shed 503 is present even if durations look fast' {
+        Mock Get-TaxEditorServerLogs -ModuleName AITriad -MockWith {
+            @(
+                New-Row -Path '/api/embeddings/compute' -DurationMs 10
+                New-Row -Path '/api/embeddings/compute' -DurationMs 20
+                New-Row -Message 'embeddings.compute: load-shed 503' -Status 503
+            )
+        }
+        $r = Test-EmbeddingsCacheHealth
+        $r.LoadShed503Count | Should -Be 1
+        $r.Verdict          | Should -Be 're-computing'
+    }
+
+    It 'verdict=no-traffic (never false-passes) when there are zero compute rows' {
+        Mock Get-TaxEditorServerLogs -ModuleName AITriad -MockWith {
+            @( New-Row -Message 'embeddings.json loaded: 812 nodes' )   # boot signal, no compute traffic
+        }
+        $r = Test-EmbeddingsCacheHealth
+        $r.ComputeCount         | Should -Be 0
+        $r.Verdict              | Should -Be 'no-traffic'
+        $r.CacheReadySignalSeen | Should -BeTrue
+    }
+
+    It 'verdict=unknown in the 500-1000ms grey band' {
+        Mock Get-TaxEditorServerLogs -ModuleName AITriad -MockWith {
+            @(
+                New-Row -Path '/api/embeddings/compute' -DurationMs 600
+                New-Row -Path '/api/embeddings/compute' -DurationMs 700
+                New-Row -Path '/api/embeddings/compute' -DurationMs 800
+            )
+        }
+        $r = Test-EmbeddingsCacheHealth
+        $r.Verdict | Should -Be 'unknown'
+    }
+
+    It 'passes the default 30-minute window and embeddings pattern through to Get-TaxEditorServerLogs' {
+        Mock Get-TaxEditorServerLogs -ModuleName AITriad -MockWith { @() }
+        Test-EmbeddingsCacheHealth | Out-Null
+        Should -Invoke Get-TaxEditorServerLogs -ModuleName AITriad -Times 1 -Exactly -ParameterFilter {
+            $Pattern -eq 'embeddings' -and (($To - $From).TotalMinutes -ge 29 -and ($To - $From).TotalMinutes -le 31)
+        }
+    }
+
+    It 'throws an actionable error when -From is after -To' {
+        Mock Get-TaxEditorServerLogs -ModuleName AITriad -MockWith { @() }
+        { Test-EmbeddingsCacheHealth -From ([datetime]'2026-08-27T11:00:00Z') -To ([datetime]'2026-08-27T10:00:00Z') } |
+            Should -Throw
+    }
+}


### PR DESCRIPTION
## What

New `Test-EmbeddingsCacheHealth` cmdlet: a one-shot verdict on whether the precomputed embeddings cache is **resolving** on the live prod revision or silently **re-computing** — the recurring baseline-validation question for the embedding-saturation incident class (t/2905, t/3072, t/3085, t/3165).

Collapses what every prior triage assembled by hand (several `Get-TaxEditorServerLogs` pulls correlated manually) into one call.

## How

Pulls all `embeddings`-tagged console lines over a window via `Get-TaxEditorServerLogs` (reusing its Log Analytics workspace resolution + Pino parsing), then derives:
- `/api/embeddings/compute` durations → `ComputeCount`, `ComputeP50Ms`, `ComputeP95Ms`
- `embeddings.compute: load-shed 503` rows → `LoadShed503Count`
- boot `embeddings.json loaded` / `cache ready` signal → `CacheReadySignalSeen`
- serving `Revision` (newest matching row)

**Verdict:**
| condition | verdict |
|---|---|
| p95 < 500ms and no load-shed | `resolving` |
| p95 > 1000ms or any load-shed 503 | `re-computing` |
| zero compute rows | `no-traffic` (can't tell — never false-passes) |
| p95 in 500–1000ms grey band | `unknown` |

## Notes

- Follows `/add-ps-cmdlet`; registered in both `AITriad.psd1` `FunctionsToExport` and `AITriad.psm1` `Export-ModuleMember`; added to `docs/cmdlet-reference.md`.
- **Deviation from ticket:** exposes `-App` (the real log-source selector) instead of `-BaseUrl`. The verdict is computed from Log Analytics, not an HTTP probe, so `-BaseUrl` would be a dead parameter.
- Duration-based verdict works today; sharpens once t/3166's request-time cache-miss log lands.

## Tests

8 new Pester tests (`diagnostics` tag), all four verdicts + percentiles + load-shed/cache-ready detection + default-window passthrough + `-From > -To` guard. Full `diagnostics` suite green (43 passed, 0 failed). `Test-ModuleManifest` passes.

Closes t/3168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)