### PR TITLE
feat(entities,debate): BDI node concept_refs[] + entity_refs[] forward-grounding fields (t/3157)

### DIFF
--- a/lib/debate/taxonomyTypes.ts
+++ b/lib/debate/taxonomyTypes.ts
@@ -5,6 +5,10 @@
 // TE's types/taxonomy.ts re-exports these; TE-only types stay there.
 
 import type { PovKey } from './types.js';
+// Type-only import (erased at runtime) — entities/types.ts already type-imports PovNode from here,
+// so keeping this `import type` prevents a runtime cycle (t/3157). Link-ref shapes are homed in
+// lib/entities (the entity contract) and reused by both BDI nodes and claim containers (t/3124).
+import type { EntityLinkRef, ConceptLinkRef } from '../entities/types.js';
 export type Pov = PovKey;
 export type Category = 'Desires' | 'Beliefs' | 'Intentions';
 
@@ -180,6 +184,14 @@ export interface PovNode {
   plain_description?: string | null;
   /** Model+prompt version string (e.g., "flash-lite:v1") for staleness detection. */
   plain_description_version?: string | null;
+  /** Forward grounding links to register entities (t/3157, epic t/3156 §13). Optional; absent = no
+   *  links. Each is an {@link EntityLinkRef} carrying method/status so a confirmed link is never
+   *  confused with a speculative embedding proposal. Written by the resolution pass (G2/G3); the
+   *  reverse map is entities' used_by_nodes. */
+  entity_refs?: EntityLinkRef[];
+  /** Forward grounding links to dictionary concepts (term:*) (t/3157). Optional; {@link ConceptLinkRef}
+   *  (no match_level — a concept ref already names a kind). */
+  concept_refs?: ConceptLinkRef[];
   _edit_meta?: NodeEditMeta;
   _edit_history?: EditHistoryEntry[];
 }

--- a/lib/entities/types.ts
+++ b/lib/entities/types.ts
@@ -87,6 +87,48 @@ export type EntityDescriptionProvenance = 'ai-drafted' | 'human-edited' | 'human
  */
 export type EntityMatchLevel = 'exact' | 'instance_of' | 'subclass' | 'superclass' | 'related';
 
+/**
+ * Confirmation state of a link (t/3157, CL p/3#153). LOAD-BEARING — it's what lets a precise link
+ * coexist with a speculative one without contaminating it: `linked` = confirmed (a surface/exact/
+ * alias match, or a human/threshold-confirmed embedding hit); `proposed` = an unconfirmed embedding
+ * candidate that must NOT count until confirmed (the "Andreessen cos-matches 45 nodes it doesn't
+ * mention" problem). Required on every link ref — an unstatused ref is indistinguishable from a
+ * confirmed one, which is the failure this field exists to prevent.
+ */
+export type EntityLinkStatus = 'linked' | 'proposed';
+
+/**
+ * A resolved link from a container (a BDI node's `entity_refs[]` — t/3157 — or a claim's
+ * `entity_refs[]` — t/3124) to a register entity. ONE shape serves both containers (CL p/3#154).
+ * `ref` is the raw `ent-*` token (parsed on read via {@link parseEntityRef}); `method` records how
+ * it was found; `match_level` how it matched relative to the register ({@link EntityMatchLevel});
+ * `link_confidence` the method-dependent score (exact/alias = 1.0; embedding = cosine); `status`
+ * gates whether it counts. Assignment semantics (which label/method/status) are owned by the
+ * resolution pass (t/3124) — this is the persisted shape only.
+ */
+export interface EntityLinkRef {
+  ref: string;                                   // ent-* raw token
+  surface: string;                               // matched surface form
+  method: 'exact' | 'alias' | 'embedding';
+  link_confidence: number;                       // [0,1] — method-dependent: 1.0 for exact/alias, cosine for embedding
+  match_level: EntityMatchLevel;
+  status: EntityLinkStatus;
+}
+
+/**
+ * A resolved link from a BDI node's `concept_refs[]` to a dictionary concept (`term:*`) — t/3157.
+ * Parallel to {@link EntityLinkRef} but simpler: NO `match_level`, because a concept ref already
+ * names a kind/class, so there is no subsumption hop to record (CL p/3#154). `method` is narrower
+ * (a concept is matched by surface or embedding, never an alias table).
+ */
+export interface ConceptLinkRef {
+  ref: string;                                   // term:<slug> raw token
+  surface: string;
+  method: 'surface' | 'embedding';
+  link_confidence: number;                       // [0,1] — method-dependent: 1.0 for exact/alias, cosine for embedding
+  status: EntityLinkStatus;
+}
+
 /** The new entity record (ent-*), stored in entities.json. */
 export interface Entity {
   id: string;                     // ent-NNN

--- a/taxonomy-editor/src/renderer/utils/validation.test.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.test.ts
@@ -47,6 +47,33 @@ describe('povTaxonomyFileSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('accepts + RETAINS t/3157 entity_refs/concept_refs (survive the node write, not stripped)', () => {
+    const result = povTaxonomyFileSchema.safeParse(validFile({
+      entity_refs: [{ ref: 'ent-001', surface: 'Anthropic', method: 'alias', link_confidence: 1.0, match_level: 'exact', status: 'linked' }],
+      concept_refs: [{ ref: 'term:alignment', surface: 'alignment', method: 'surface', link_confidence: 0.8, status: 'proposed' }],
+    }));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const node = result.data.nodes[0] as Record<string, unknown>;
+      expect(node.entity_refs).toHaveLength(1);  // retained — this is the whole point of G1
+      expect(node.concept_refs).toHaveLength(1);
+      expect((node.entity_refs as { status: string }[])[0].status).toBe('linked');
+      expect((node.concept_refs as { status: string }[])[0].status).toBe('proposed');
+    }
+  });
+
+  it('rejects an entity_ref with an invalid status (schema validates the link shape, not just passthrough)', () => {
+    const result = povTaxonomyFileSchema.safeParse(validFile({
+      entity_refs: [{ ref: 'ent-001', surface: 'x', method: 'alias', link_confidence: 1, match_level: 'exact', status: 'guessed' }],
+    }));
+    expect(result.success).toBe(false);
+  });
+
+  it('omits entity_refs/concept_refs entirely on a legacy node (optional, absence is legal)', () => {
+    const result = povTaxonomyFileSchema.safeParse(validFile());
+    expect(result.success).toBe(true);
+  });
+
   it('accepts all three POV prefixes', () => {
     for (const [pov, prefix] of [['accelerationist', 'acc'], ['safetyist', 'saf'], ['skeptic', 'skp']] as const) {
       const result = povTaxonomyFileSchema.safeParse({

--- a/taxonomy-editor/src/renderer/utils/validation.ts
+++ b/taxonomy-editor/src/renderer/utils/validation.ts
@@ -6,6 +6,25 @@ import { POV_KEYS } from '@lib/debate/types';
 
 const categoryEnum = z.enum(['Desires', 'Beliefs', 'Intentions']);
 
+// t/3157 forward-grounding link refs — Zod mirror of lib/entities EntityLinkRef/ConceptLinkRef so a
+// reflection/node write validates + KEEPS them. The node schema already .passthrough()es unknowns,
+// but making these explicit is what G1 gates the forward write on. Inner .passthrough() = fwd-compat.
+const entityLinkRefSchema = z.object({
+  ref: z.string(),
+  surface: z.string(),
+  method: z.enum(['exact', 'alias', 'embedding']),
+  link_confidence: z.number(),
+  match_level: z.enum(['exact', 'instance_of', 'subclass', 'superclass', 'related']),
+  status: z.enum(['linked', 'proposed']),
+}).passthrough();
+const conceptLinkRefSchema = z.object({
+  ref: z.string(),
+  surface: z.string(),
+  method: z.enum(['surface', 'embedding']),
+  link_confidence: z.number(),
+  status: z.enum(['linked', 'proposed']),
+}).passthrough();
+
 const povNodeSchema = z.object({
   id: z.string().regex(/^(acc|saf|skp)-(desires|beliefs|intentions)-\d{3}$/, 'ID must match {pov}-{category}-{NNN}'),
   category: categoryEnum,
@@ -19,6 +38,8 @@ const povNodeSchema = z.object({
   confidence: z.number().min(0).max(1).nullish(),
   priority: z.number().int().min(1).max(5).nullish(),
   operationality: z.number().int().min(1).max(5).nullish(),
+  entity_refs: z.array(entityLinkRefSchema).optional(),   // t/3157 forward grounding
+  concept_refs: z.array(conceptLinkRefSchema).optional(), // t/3157 forward grounding
 }).passthrough();
 
 export const povTaxonomyFileSchema = z.object({


### PR DESCRIPTION
**G1** for the BDI↔{entity,concept} epic (t/3156 §13) — the schema blocker for G2/G3 forward writes. CL DOLCE-approved shape (p/3#156); DebateTool signed off on the PovNode change (p/64#51/#53). **Holding merge for DebateTool's PovNode-diff review + CL's final DOLCE check.**

## Types (`lib/entities/types.ts`)
- `EntityLinkStatus = 'linked' | 'proposed'` — **required**, load-bearing (keeps a confirmed link from being confused with a speculative embedding proposal).
- `EntityLinkRef` {ref, surface, method, link_confidence, match_level, status} — ONE shape for node **and** claim `entity_refs[]` (t/3124); reuses `EntityMatchLevel` (#1700).
- `ConceptLinkRef` — no match_level (a concept ref already names a kind).

## PovNode (`lib/debate/taxonomyTypes.ts`, DebateTool's — edited with sign-off)
Optional `entity_refs?: EntityLinkRef[]` + `concept_refs?: ConceptLinkRef[]`. **Type-only** import from lib/entities keeps the pre-existing entities↔debate cycle runtime-free.

## Survival (CL/DebateTool requirement)
- Confirmed **no `Pick/Omit<PovNode>`** in lib/debate strips them.
- `validation.ts` povNodeSchema gains a Zod mirror so a reflection/node write **validates + keeps** them (the schema already `.passthrough()`es, but explicit is what G1 gates on).

## Tests
Node with entity_refs/concept_refs validates + retains them; bad status rejected; legacy absence legal. tsc + eslint clean; validation suite **24/24**.

Scope: lib/entities (mine) + lib/debate (DebateTool sign-off) + taxonomy-editor validation (ownerless). Once merged, CL runs G2/G3 forward writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)