### PR TITLE
obs(server): event-loop lag + request-time cache-miss + cacheHits/corpusNodeCount response (t/3166, t/3165)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsBatchCapAnd503.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsBatchCapAnd503.test.ts
@@ -75,6 +75,7 @@ vi.mock('../security/rateLimiter.js', () => ({
 
 vi.mock('../ai/aiBackends.js', () => ({
   computeEmbeddings: (...a: unknown[]) => computeEmbeddings(...a),
+  getEmbeddingsCacheStatus: () => ({ present: true, nodeCount: 4144 }), // t/3165: response now reads corpusNodeCount
   computeQueryEmbedding: vi.fn(),
   generateText: vi.fn(),
   generateTextByUsage: vi.fn(),

--- a/taxonomy-editor/src/server/__tests__/eventLoopMonitor.test.ts
+++ b/taxonomy-editor/src/server/__tests__/eventLoopMonitor.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3166 — event-loop lag classification. The timer/histogram glue is boot code; the
+// classification (which sample is a starvation WARN vs a routine gauge) is the pure,
+// testable core. Both arms + the threshold boundary.
+
+import { describe, it, expect } from 'vitest';
+import { classifyEventLoopSample, EVENT_LOOP_LAG_WARN_MS, type EventLoopSample } from '../eventLoopMonitor.js';
+
+const sample = (maxMs: number, overrides: Partial<EventLoopSample> = {}): EventLoopSample => ({
+  maxMs, meanMs: 5, p99Ms: 20, utilization: 0.3, ...overrides,
+});
+
+describe('classifyEventLoopSample (t/3166)', () => {
+  it('a multi-second block → warn, message reproduces the greppable "event loop blocked Nms"', () => {
+    const { level, message } = classifyEventLoopSample(sample(8123));
+    expect(level).toBe('warn');
+    expect(message).toContain('event loop blocked 8123ms');
+  });
+
+  it('a routine sample (< threshold) → info gauge, NOT a warn (keeps the FR ring clean)', () => {
+    const { level, message } = classifyEventLoopSample(sample(42));
+    expect(level).toBe('info');
+    expect(message).not.toContain('blocked');
+    expect(message).toContain('event-loop max 42ms');
+  });
+
+  it('threshold is inclusive: max exactly EVENT_LOOP_LAG_WARN_MS → warn; one below → info', () => {
+    expect(classifyEventLoopSample(sample(EVENT_LOOP_LAG_WARN_MS)).level).toBe('warn');
+    expect(classifyEventLoopSample(sample(EVENT_LOOP_LAG_WARN_MS - 1)).level).toBe('info');
+  });
+
+  it('respects an injected threshold (both arms)', () => {
+    expect(classifyEventLoopSample(sample(600), 500).level).toBe('warn');
+    expect(classifyEventLoopSample(sample(400), 500).level).toBe('info');
+  });
+
+  it('gauge message carries mean/p99/ELU for trending', () => {
+    const { message } = classifyEventLoopSample(sample(50, { meanMs: 3.2, p99Ms: 12, utilization: 0.55 }));
+    expect(message).toContain('mean 3.2ms');
+    expect(message).toContain('p99 12ms');
+    expect(message).toContain('ELU 55%');
+  });
+});

--- a/taxonomy-editor/src/server/eventLoopMonitor.ts
+++ b/taxonomy-editor/src/server/eventLoopMonitor.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3166 — periodic event-loop lag observability. The t/3165 incident (an infra-fabricated
+// empty-body 500 while the Node loop was starved by 7–8s of in-process ONNX embedding) was
+// diagnosable ONLY by inference — the starvation was recorded nowhere. This turns
+// "I inferred N-second starvation from ONNX durations" into a directly greppable
+// "event loop blocked Nms at HH:MM:SS".
+//
+// Deliberately SEPARATE from embeddingsLoad.ts's monitorEventLoopDelay histograms
+// (getLoopDelay / getShedLoopDelay, t/3078): those are read + reset per-request to drive
+// the load-shed decision. Coupling this 5s observability sampler's reset() to their
+// per-request cycle would corrupt both readings. Same cheap libuv primitive, distinct
+// lifecycle → distinct histogram.
+
+import { monitorEventLoopDelay, performance, type IntervalHistogram, type EventLoopUtilization } from 'perf_hooks';
+import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
+import { log } from './logger.js';
+
+const NS_PER_MS = 1e6;
+
+/** Max single-tick lag (ms) at/above which a sample is treated as a starvation event
+ *  (FR warn), not a routine gauge. 1s is well above normal GC/JIT pauses but far below
+ *  the multi-second block that fabricates ingress 5xx (t/3165). */
+export const EVENT_LOOP_LAG_WARN_MS = 1000;
+
+const SAMPLE_INTERVAL_MS = 5000;
+
+export interface EventLoopSample {
+  /** Worst single-tick delay over the interval (ms). */
+  maxMs: number;
+  /** Mean tick delay over the interval (ms). */
+  meanMs: number;
+  /** 99th-percentile tick delay over the interval (ms). */
+  p99Ms: number;
+  /** Event-loop utilization over the interval (0..1 — fraction of wall-clock the loop was busy). */
+  utilization: number;
+}
+
+/**
+ * Pure decision for one sample. A sample whose WORST tick crossed the warn threshold is a
+ * starvation event → `warn` (recorded to the FR ring, which is capacity-bounded and curated).
+ * Otherwise it's a routine gauge → `info` (Pino-only; emitting a 2000-capacity FR event every
+ * 5s would evict real events). Extracted from the timer glue so both arms are unit-testable.
+ */
+export function classifyEventLoopSample(
+  s: EventLoopSample,
+  warnMs: number = EVENT_LOOP_LAG_WARN_MS,
+): { level: 'warn' | 'info'; message: string } {
+  const gauge = `event-loop max ${s.maxMs.toFixed(0)}ms mean ${s.meanMs.toFixed(1)}ms `
+    + `p99 ${s.p99Ms.toFixed(0)}ms ELU ${(s.utilization * 100).toFixed(0)}%`;
+  if (s.maxMs >= warnMs) {
+    return { level: 'warn', message: `event loop blocked ${s.maxMs.toFixed(0)}ms — ${gauge}` };
+  }
+  return { level: 'info', message: gauge };
+}
+
+let timer: NodeJS.Timeout | null = null;
+let hist: IntervalHistogram | null = null;
+
+/**
+ * Start the periodic event-loop monitor. Idempotent (a second call is a no-op while running).
+ * The interval is `unref()`d so it never keeps the process alive. Returns the stop fn.
+ */
+export function startEventLoopMonitor(intervalMs: number = SAMPLE_INTERVAL_MS): () => void {
+  if (timer) return stopEventLoopMonitor;
+  hist = monitorEventLoopDelay({ resolution: 20 });
+  hist.enable();
+  let prevElu: EventLoopUtilization = performance.eventLoopUtilization();
+
+  timer = setInterval(() => {
+    if (!hist) return;
+    // One-arg form: delta utilization since prevElu; then re-baseline for the next tick.
+    const delta = performance.eventLoopUtilization(prevElu);
+    prevElu = performance.eventLoopUtilization();
+    const sample: EventLoopSample = {
+      maxMs: hist.max / NS_PER_MS,
+      meanMs: (Number.isFinite(hist.mean) ? hist.mean : 0) / NS_PER_MS,
+      p99Ms: hist.percentile(99) / NS_PER_MS,
+      utilization: delta.utilization,
+    };
+    hist.reset();
+
+    const { level, message } = classifyEventLoopSample(sample);
+    if (level === 'warn') {
+      getGlobalRecorder()?.record({
+        type: 'system.error', component: 'event-loop', level: 'warn',
+        message, data: { ...sample },
+      });
+      log.server.warn({ component: 'event-loop', ...sample }, message);
+    } else {
+      // Routine gauge — Pino only; never the capacity-bounded FR ring.
+      log.server.info({ component: 'event-loop', ...sample }, message);
+    }
+  }, intervalMs);
+  timer.unref();
+  return stopEventLoopMonitor;
+}
+
+/** Stop the monitor and release the histogram (idempotent). */
+export function stopEventLoopMonitor(): void {
+  if (timer) { clearInterval(timer); timer = null; }
+  if (hist) { hist.disable(); hist = null; }
+}

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -587,7 +587,26 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
           message: 'embedding.compute',
           data: { duration_ms: Date.now() - t0, item_count: texts.length, model_cold_start: !modelWarm, in_flight_at_entry: inFlightAtEntry, cache_hits: cacheHits, cache_misses: cacheMisses },
         });
-        json(res, { vectors });
+        // t/3166 item 2 / t/3165: a boot-only "loaded N nodes" signal (t/3081) can't see a
+        // MID-LIFE cache miss — the exact shape of t/3165 (present-but-non-resolving cache
+        // re-embedding keyed corpus texts). Emit a WARN when KEYED texts (ids provided) fail to
+        // resolve, so a re-embed is directly greppable instead of inferred from latency. Gated on
+        // `ids` because ad-hoc query embeds pass none (cacheHits=0 by construction) and would spam.
+        if (ids && cacheMisses > 0) {
+          const missMsg = `embeddings.compute: cache miss — re-computing ${cacheMisses} of ${texts.length} keyed texts (resolved ${cacheHits} from cache)`;
+          getGlobalRecorder()?.record({
+            type: 'system.error', component: 'embeddings-compute', level: 'warn',
+            message: missMsg,
+            data: { cache_hits: cacheHits, cache_misses: cacheMisses, item_count: texts.length, request_id: getRequestId() },
+          });
+          log.api.warn({ component: 'embeddings-compute', cache_hits: cacheHits, cache_misses: cacheMisses, item_count: texts.length, request_id: getRequestId() }, missMsg);
+        }
+        // t/3165: expose cacheHits/cacheMisses + corpusNodeCount so the t/3091 resolution gate
+        // (DevOps 2) can (1) assert a canary keyed lookup actually HITS the cache — presence≠resolution —
+        // and (2) disambiguate a DEAD cache from a bad canary id: cacheHits==0 && corpusNodeCount==0 →
+        // cache dead (rollback); cacheHits==0 && corpusNodeCount>0 → id not in corpus (config error, no rollback).
+        const corpusNodeCount = ai.getEmbeddingsCacheStatus?.()?.nodeCount ?? 0;
+        json(res, { vectors, cacheHits, cacheMisses, corpusNodeCount });
       } finally {
         endEmbeddingCompute();
       }

--- a/taxonomy-editor/src/server/server.ts
+++ b/taxonomy-editor/src/server/server.ts
@@ -21,6 +21,7 @@ import { spawn, execFile, ChildProcess } from 'child_process';
 import { getGlobalRecorder, setGlobalRecorder } from '../../../lib/flight-recorder/index.js';
 import { warmup as warmupEmbeddings } from '../../../lib/embeddings/onnxEmbedding.js';
 import { prewarmEmbeddingsCache, getEmbeddingsCacheStatus } from './ai/aiBackends.js';
+import { startEventLoopMonitor } from './eventLoopMonitor.js';
 
 const require = createRequire(import.meta.url);
 
@@ -1299,6 +1300,10 @@ server.listen(PORT, BIND_HOST, () => {
   serverRecorder.record({ type: 'lifecycle', component: 'server', level: 'info', message: 'Server started', data: { port: PORT, host: BIND_HOST, version: SERVER_VERSION, dataRoot: getDataRoot(), platform: process.platform, arch: process.arch, storageMode: STORAGE_MODE } });
   log.server.info({ port: PORT, host: BIND_HOST }, 'Taxonomy Editor running');
   log.server.info({ dataRoot: getDataRoot() }, 'Data root');
+  // t/3166: periodic event-loop lag gauge (Pino) + threshold-crossing FR warn at >1s block,
+  // so a starvation event (t/3165: 7–8s in-process ONNX froze the loop → ingress-fabricated
+  // 500) is directly greppable instead of inferred. Unref'd interval — never holds the process.
+  startEventLoopMonitor();
   void warmupEmbeddings().catch((err: unknown) => {
     log.server.error({ err: String(err) }, 'ONNX embedding warmup failed at boot');
     getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'ONNX embedding warmup failed at boot', error: { name: (err as Error)?.name ?? 'Error', message: String(err), stack: (err as Error)?.stack } });


### PR DESCRIPTION
Observability half of the t/3165 prevention pair (t/3166) + the resolution-gate response fields DevOps2's t/3091 needs. All TL-directed (incident coordination + DevOps2 gate).

## Changes
- **`eventLoopMonitor.ts` (t/3166 item 1)** — periodic `monitorEventLoopDelay` + `eventLoopUtilization` gauge (unref'd 5s, boot-started). >1s block → FR WARN (`event loop blocked Nms`); routine gauge → Pino only (keeps the 2000-cap FR ring clean). Pure `classifyEventLoopSample` unit-tested both arms. Separate from `embeddingsLoad.ts` load-shed histograms (distinct lifecycle).
- **`routes/ai.ts` (t/3166 item 2 + t/3165)** — request-time cache-miss **WARN** when keyed texts (ids provided) fail to resolve (greppable mid-life miss); `{cacheHits, cacheMisses, corpusNodeCount}` added to the compute response for the resolution gate.
- Split: item 3 (ACA ingress 5xx) → **t/3167** (DevOps).

## Tests
`eventLoopMonitor.test.ts` 5/5; `embeddingsBatchCapAnd503` mock updated, 5/5.

## Incident note (t/3165)
My coverage diagnostic (t/3165#14) shows the corpus is **99.5% cached (7/1347 miss)** and resolves by id — so the "dead cache / re-embeds 798" keying theory does not hold (the "cacheHits:0" was an abbreviated-canary artifact). Holding the `/readyz` resolution-canary upgrade as a separate follow-up pending TL's root-cause redirect; these observability + gate pieces are correct regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)