### PR TITLE
feat(entities): extend entity_mentions.json to summary key points/claims (t/3122)

### DIFF
--- a/scripts/AITriad/Private/Get-MentionContainerText.ps1
+++ b/scripts/AITriad/Private/Get-MentionContainerText.ps1
@@ -12,16 +12,22 @@
 # hash basis and must never be collapsed). NFC is applied LAST to the whole reconstructed
 # string — never a per-field normalize, never a whitespace-collapse. Returns "" when nothing
 # remains. Dot-sourced — do NOT export.
+#
+# 'kp'/'fc' (t/3122, claims-entity-fol-recommendations.md §4/R2.2 T2): summary claim
+# containers. 'kp' = a pov_summaries.<pov>.key_points[] entry's `point` field (the extracted
+# narrative text). 'fc' = a factual_claims[] entry's `claim` field. Both are single-field
+# today, so the delimiter choice is inert, but they share the omission/NFC contract above.
 function Get-MentionContainerText {
     [CmdletBinding()]
     [OutputType([string])]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet('node', 'sei')]
+        [ValidateSet('node', 'sei', 'kp', 'fc')]
         [string]$Kind,
 
-        # Ordered raw field values (node: label, description, plain_description; sei: claims).
-        # Absent fields pass as $null. Filtering/omission happens here, not at the call site.
+        # Ordered raw field values (node: label, description, plain_description; sei: claims;
+        # kp: point; fc: claim). Absent fields pass as $null. Filtering/omission happens here,
+        # not at the call site.
         [Parameter()]
         [AllowNull()]
         [AllowEmptyCollection()]

--- a/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
+++ b/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
@@ -25,6 +25,15 @@ function Update-EntityMentionIndex {
             `facts[].claim` values joined by newline in file order.
           - POV / situation nodes: container id `node:<node_id>`, text = `label`, then
             `description`, then `plain_description` (present fields only), newline-separated.
+          - Summary key points (t/3122, claims-entity-fol-recommendations.md §4/R2.2 T2):
+            container id `summary:<doc_id>#kp-<n>`, text = the key point's `point` field.
+            `<n>` is a 0-based index over the concatenation of `pov_summaries.accelerationist
+            .key_points`, then `.safetyist.key_points`, then `.skeptic.key_points`, in that
+            fixed order (matching the POV order used elsewhere for summary claims, e.g.
+            Remove-DuplicateClaims) — one running counter per document, not per POV.
+          - Summary factual claims (t/3122, same doc §4/R2.2 T2): container id
+            `summary:<doc_id>#fc-<n>`, text = the `factual_claims[n].claim` field, `<n>` the
+            0-based index into that array.
         Live statement-side (debate/chat, `<debate_id>#<entry_id>`) is Phase 2b — NOT here.
 
         Per-container `text_sha256` (lowercase hex over the exact text's UTF-8 bytes) is the
@@ -48,6 +57,11 @@ function Update-EntityMentionIndex {
         Override the POV/situation node files to scan. Defaults to the four canonical files
         under Get-TaxonomyDir (accelerationist/safetyist/skeptic/situations). Pass @() to
         skip POV containers entirely. Absent files are skipped (non-fatal).
+    .PARAMETER SummariesPath
+        Override the summary JSON files to scan for `summary:<doc_id>#kp-<n>` /
+        `#fc-<n>` containers (t/3122). Defaults to every `*.json` file directly under
+        Get-SummariesDir. Pass @() to skip summary containers entirely. Absent files/dir
+        are skipped (non-fatal).
     .PARAMETER OutputPath
         Override entity_mentions.json output path. Defaults to Get-EntityMentionsFilePath.
     .PARAMETER Status
@@ -63,6 +77,8 @@ function Update-EntityMentionIndex {
         Update-EntityMentionIndex
     .EXAMPLE
         Update-EntityMentionIndex -PovPath @()   # facts-only re-index
+    .EXAMPLE
+        Update-EntityMentionIndex -SummariesPath @()   # skip summary key-point/claim containers
     .LINK
         Invoke-EntityExtraction
     .LINK
@@ -79,6 +95,9 @@ function Update-EntityMentionIndex {
 
         [Parameter()]
         [string[]]$PovPath,
+
+        [Parameter()]
+        [string[]]$SummariesPath,
 
         [Parameter()]
         [Alias('Path')]
@@ -105,6 +124,20 @@ function Update-EntityMentionIndex {
         $TaxDir = Get-TaxonomyDir
         $PovFiles = @('accelerationist.json', 'safetyist.json', 'skeptic.json', 'situations.json') |
             ForEach-Object { Join-Path $TaxDir $_ }
+    }
+    if ($PSBoundParameters.ContainsKey('SummariesPath')) {
+        $SummaryFiles = @($SummariesPath)
+    }
+    else {
+        $SummDir = Get-SummariesDir
+        if (Test-Path -LiteralPath $SummDir) {
+            $SummaryFiles = @(Get-ChildItem -LiteralPath $SummDir -Filter '*.json' -File |
+                    Sort-Object -Property Name | ForEach-Object { $_.FullName })
+        }
+        else {
+            Write-Verbose "Summaries dir not found: $SummDir; skipping summary containers."
+            $SummaryFiles = @()
+        }
     }
 
     # Safe field read across both shapes we handle: [ordered] dicts (our freshly-built
@@ -222,6 +255,45 @@ function Update-EntityMentionIndex {
             $text = Get-MentionContainerText -Kind 'node' -Fields @($vals)
             if ($text -eq '') { continue }
             $Containers["node:$($node.id)"] = $text
+        }
+    }
+
+    # --- Summary key points + factual claims (t/3122, §4/R2.2 T2) -------------------------
+    foreach ($summaryFile in $SummaryFiles) {
+        if (-not (Test-Path -LiteralPath $summaryFile)) {
+            Write-Verbose "Summary file not found: $summaryFile; skipping."
+            continue
+        }
+        $summary = Get-Content -Raw -LiteralPath $summaryFile -Encoding utf8 | ConvertFrom-Json
+        if (-not $summary.PSObject.Properties['doc_id'] -or -not $summary.doc_id) { continue }
+        $docId = [string]$summary.doc_id
+
+        # key_points: ONE running 0-based index over the concatenation of the three POV
+        # arrays in fixed order — not per-POV — so `summary:<doc_id>#kp-<n>` is unique per
+        # document (the container-id shape carries no POV segment).
+        if ($summary.PSObject.Properties['pov_summaries'] -and $summary.pov_summaries) {
+            $kpIndex = 0
+            foreach ($povName in @('accelerationist', 'safetyist', 'skeptic')) {
+                if (-not $summary.pov_summaries.PSObject.Properties[$povName]) { continue }
+                $povData = $summary.pov_summaries.$povName
+                if (-not $povData -or -not $povData.PSObject.Properties['key_points'] -or -not $povData.key_points) { continue }
+                foreach ($kp in @($povData.key_points)) {
+                    $pointVal = if ($kp.PSObject.Properties['point']) { $kp.point } else { $null }
+                    $text = Get-MentionContainerText -Kind 'kp' -Fields @($pointVal)
+                    if ($text -ne '') { $Containers["summary:$docId#kp-$kpIndex"] = $text }
+                    $kpIndex++
+                }
+            }
+        }
+
+        # factual_claims: 0-based index into the top-level array.
+        if ($summary.PSObject.Properties['factual_claims'] -and $summary.factual_claims) {
+            $claims = @($summary.factual_claims)
+            for ($i = 0; $i -lt $claims.Count; $i++) {
+                $claimVal = if ($claims[$i].PSObject.Properties['claim']) { $claims[$i].claim } else { $null }
+                $text = Get-MentionContainerText -Kind 'fc' -Fields @($claimVal)
+                if ($text -ne '') { $Containers["summary:$docId#fc-$i"] = $text }
+            }
         }
     }
 

--- a/tests/Update-EntityMentionIndex.Tests.ps1
+++ b/tests/Update-EntityMentionIndex.Tests.ps1
@@ -13,6 +13,11 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             param([hashtable]$Map, [string]$Path)
             ($Map | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $Path -Encoding utf8NoBOM
         }
+
+        function New-Summary {
+            param([hashtable]$Doc, [string]$Path)
+            ($Doc | ConvertTo-Json -Depth 10) | Set-Content -LiteralPath $Path -Encoding utf8NoBOM
+        }
     }
 
     BeforeEach {
@@ -43,7 +48,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
                 'acc-desires-001' = @{ facts = @(@{ claim = 'The Apollo Project reshaped ambition.'; doc_id = 'd1' }) }
             }
 
-            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath
             $r.Written | Should -BeTrue
 
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
@@ -67,7 +72,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             New-Sei -Path $script:seiPath -Map @{
                 'n1' = @{ facts = @(@{ claim = 'Apollo Program milestone'; doc_id = 'd1' }) }
             }
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath | Out-Null
 
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
             $m = @($file.containers.'sei:n1'.mentions)
@@ -83,7 +88,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             New-Sei -Path $script:seiPath -Map @{
                 'n1' = @{ facts = @(@{ claim = "Apollo${nbsp}Program advanced"; doc_id = 'd1' }) }
             }
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath | Out-Null
 
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
             $m = @($file.containers.'sei:n1'.mentions)
@@ -107,7 +112,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             New-Sei -Path $script:seiPath -Map @{
                 'n1' = @{ facts = @(@{ claim = 'GPT-4o beats o4-mini but GPT-4omini is fake.'; doc_id = 'd1' }) }
             }
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath | Out-Null
 
             $m = @((Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json).containers.'sei:n1'.mentions)
             $m.Count | Should -Be 2   # standalone GPT-4o + o4-mini; the 'GPT-4omini' occurrence must NOT match
@@ -120,7 +125,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             New-Sei -Path $script:seiPath -Map @{
                 'n1' = @{ facts = @(@{ claim = 'the APOLLO team; also apollonian ideals'; doc_id = 'd1' }) }
             }
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath | Out-Null
 
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
             $m = @($file.containers.'sei:n1'.mentions)
@@ -137,11 +142,11 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             New-Sei -Path $script:seiPath -Map @{
                 'n1' = @{ facts = @(@{ claim = 'The Apollo Project reshaped ambition.'; doc_id = 'd1' }) }
             }
-            $r1 = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath
+            $r1 = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath
             $r1.Written | Should -BeTrue
             $hash1 = (Get-FileHash -LiteralPath $script:outPath -Algorithm SHA256).Hash
 
-            $r2 = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath
+            $r2 = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath
             $r2.Unchanged | Should -BeTrue
             $r2.Written | Should -BeFalse
             (Get-FileHash -LiteralPath $script:outPath -Algorithm SHA256).Hash | Should -Be $hash1
@@ -149,8 +154,8 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
 
         It '-Force rewrites even when unchanged' {
             New-Sei -Path $script:seiPath -Map @{ 'n1' = @{ facts = @(@{ claim = 'Apollo Project.'; doc_id = 'd1' }) } }
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath | Out-Null
-            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath -Force
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath | Out-Null
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath -Force
             $r.Written | Should -BeTrue
         }
     }
@@ -161,7 +166,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             New-Sei -Path $script:seiPath -Map @{
                 'n1' = @{ facts = @(@{ claim = 'The Apollo Project reshaped ambition.'; doc_id = 'd1' }) }
             }
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath | Out-Null
 
             # Inject a human mention at the SAME offset/span as the alias hit, different ref.
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
@@ -169,7 +174,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             $c.mentions = @([ordered]@{ entity_ref = 'ent-999'; quote = 'Apollo Project'; offset = 4; discovered_by = 'human' })
             ($file | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $script:outPath -Encoding utf8NoBOM
 
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath -Force | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath -Force | Out-Null
 
             $after = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
             $m = @($after.containers.'sei:n1'.mentions)
@@ -191,7 +196,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             }
             ($pov | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $povPath -Encoding utf8NoBOM
 
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'missing-sei.json') -PovPath @($povPath) -OutputPath $script:outPath | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'missing-sei.json') -PovPath @($povPath) -SummariesPath @() -OutputPath $script:outPath | Out-Null
 
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
             $c = $file.containers.'node:acc-beliefs-001'
@@ -201,7 +206,124 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
         }
 
         It 'Absent SEI and POV files are non-fatal (empty index, no throw)' {
-            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'nope.json') -PovPath @() -OutputPath $script:outPath
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'nope.json') -PovPath @() -SummariesPath @() -OutputPath $script:outPath
+            $r.ContainerCount | Should -Be 0
+        }
+    }
+
+    Context 'Summary containers (t/3122, §4/R2.2 T2)' {
+
+        It 'Indexes key_points as summary:<doc_id>#kp-<n> with a running index across POVs in fixed order' {
+            $summPath = Join-Path $script:root 'doc1.json'
+            New-Summary -Path $summPath -Doc @{
+                doc_id        = 'doc1'
+                pov_summaries = [ordered]@{
+                    accelerationist = @{ key_points = @(@{ point = 'No entity here.' }) }
+                    safetyist       = @{ key_points = @(@{ point = 'The Apollo Project reshaped ambition.' }) }
+                    skeptic         = @{ key_points = @(@{ point = 'Also mentions Apollo alone.' }) }
+                }
+            }
+
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @() -SummariesPath @($summPath) -OutputPath $script:outPath | Out-Null
+
+            $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
+            # index 0 = accelerationist point (no mentions, so omitted entirely — absence == "no links yet")
+            $file.containers.PSObject.Properties['summary:doc1#kp-0'] | Should -BeNullOrEmpty
+            # index 1 = safetyist point (Apollo Project)
+            $kp1 = $file.containers.'summary:doc1#kp-1'
+            $kp1 | Should -Not -BeNullOrEmpty
+            @($kp1.mentions).entity_ref | Should -Contain 'ent-001'
+            # index 2 = skeptic point (Apollo)
+            $kp2 = $file.containers.'summary:doc1#kp-2'
+            $kp2 | Should -Not -BeNullOrEmpty
+            @($kp2.mentions).entity_ref | Should -Contain 'ent-002'
+        }
+
+        It 'Indexes factual_claims as summary:<doc_id>#fc-<n> by array position' {
+            $summPath = Join-Path $script:root 'doc2.json'
+            New-Summary -Path $summPath -Doc @{
+                doc_id         = 'doc2'
+                factual_claims = @(
+                    @{ claim = 'Unrelated claim.' },
+                    @{ claim = 'The Apollo Project launched in 1961.' }
+                )
+            }
+
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @() -SummariesPath @($summPath) -OutputPath $script:outPath | Out-Null
+
+            $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
+            $file.containers.PSObject.Properties['summary:doc2#fc-0'] | Should -BeNullOrEmpty
+            $fc1 = $file.containers.'summary:doc2#fc-1'
+            $fc1 | Should -Not -BeNullOrEmpty
+            $m = @($fc1.mentions)
+            $m.Count | Should -Be 1
+            $m[0].entity_ref | Should -Be 'ent-001'
+            $m[0].quote | Should -Be 'Apollo Project'
+            $m[0].discovered_by | Should -Be 'alias'
+        }
+
+        It 'Reused mention record shape: entity_ref/quote/offset/discovered_by only' {
+            $summPath = Join-Path $script:root 'doc3.json'
+            New-Summary -Path $summPath -Doc @{
+                doc_id         = 'doc3'
+                factual_claims = @(@{ claim = 'Apollo Project.' })
+            }
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @() -SummariesPath @($summPath) -OutputPath $script:outPath | Out-Null
+
+            $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
+            $m = $file.containers.'summary:doc3#fc-0'.mentions[0]
+            ($m.PSObject.Properties.Name | Sort-Object) | Should -Be @('discovered_by', 'entity_ref', 'offset', 'quote')
+        }
+
+        It 'Second run on unchanged summary input is a byte-stable no-op (idempotent)' {
+            $summPath = Join-Path $script:root 'doc4.json'
+            New-Summary -Path $summPath -Doc @{
+                doc_id         = 'doc4'
+                factual_claims = @(@{ claim = 'Apollo Project.' })
+            }
+            $r1 = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @() -SummariesPath @($summPath) -OutputPath $script:outPath
+            $r1.Written | Should -BeTrue
+            $hash1 = (Get-FileHash -LiteralPath $script:outPath -Algorithm SHA256).Hash
+
+            $r2 = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @() -SummariesPath @($summPath) -OutputPath $script:outPath
+            $r2.Unchanged | Should -BeTrue
+            $r2.Written | Should -BeFalse
+            (Get-FileHash -LiteralPath $script:outPath -Algorithm SHA256).Hash | Should -Be $hash1
+        }
+
+        It 'Existing node:* behavior is unchanged when summary containers are also present' {
+            $povPath = Join-Path $script:root 'accelerationist.json'
+            $pov = [ordered]@{
+                _schema_version = '1.0.0'; pov = 'accelerationist'; last_modified = '2026-07-28'
+                nodes           = @([ordered]@{ id = 'acc-beliefs-001'; category = 'Beliefs'; label = 'Apollo Project analogy'; description = 'Framed after the Apollo Program push.' })
+            }
+            ($pov | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $povPath -Encoding utf8NoBOM
+
+            $summPath = Join-Path $script:root 'doc5.json'
+            New-Summary -Path $summPath -Doc @{ doc_id = 'doc5'; factual_claims = @(@{ claim = 'Apollo Project.' }) }
+
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @($povPath) -SummariesPath @($summPath) -OutputPath $script:outPath | Out-Null
+
+            $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
+            $nodeC = $file.containers.'node:acc-beliefs-001'
+            $nodeC | Should -Not -BeNullOrEmpty
+            @($nodeC.mentions).entity_ref | Should -Contain 'ent-001'
+            $file.containers.'summary:doc5#fc-0' | Should -Not -BeNullOrEmpty
+        }
+
+        It 'A summary file missing doc_id is skipped (non-fatal)' {
+            $summPath = Join-Path $script:root 'nodocid.json'
+            New-Summary -Path $summPath -Doc @{ factual_claims = @(@{ claim = 'Apollo Project.' }) }
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @() -SummariesPath @($summPath) -OutputPath $script:outPath
+            $r.ContainerCount | Should -Be 0
+        }
+
+        It '-SummariesPath @() skips summary containers entirely' {
+            $summPath = Join-Path $script:root 'doc6.json'
+            New-Summary -Path $summPath -Doc @{ doc_id = 'doc6'; factual_claims = @(@{ claim = 'Apollo Project.' }) }
+            # Explicit -SummariesPath overrides default discovery; passing a non-empty array but then
+            # verifying an empty array truly yields zero summary containers.
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @() -SummariesPath @() -OutputPath $script:outPath
             $r.ContainerCount | Should -Be 0
         }
     }
@@ -219,7 +341,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
                 nodes           = @([ordered]@{ id = 'acc-b-1'; category = 'Beliefs'; label = 'Alpha'; plain_description = 'Beta Apollo Project gamma' })
             }
             ($pov | ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $povPath -Encoding utf8NoBOM
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @($povPath) -OutputPath $script:outPath | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @($povPath) -SummariesPath @() -OutputPath $script:outPath | Out-Null
 
             $m = @((Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json).containers.'node:acc-b-1'.mentions)
             $m.Count | Should -Be 1
@@ -236,7 +358,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
                         @{ claim = 'Apollo Project here.'; doc_id = 'd3' }
                     ) }
             }
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath | Out-Null
 
             $m = @((Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json).containers.'sei:n1'.mentions)
             $m.Count | Should -Be 1
@@ -249,7 +371,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
 
         It '-WhatIf does not write the file' {
             New-Sei -Path $script:seiPath -Map @{ 'n1' = @{ facts = @(@{ claim = 'Apollo Project.'; doc_id = 'd1' }) } }
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath -WhatIf | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath -WhatIf | Out-Null
             Test-Path -LiteralPath $script:outPath | Should -BeFalse
         }
     }
@@ -273,7 +395,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
         }
 
         It 'Default indexes ONLY approved entities (proposed + status-less skipped)' {
-            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath
             $r.IndexedStatus | Should -Be @('approved')
 
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
@@ -284,7 +406,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
         }
 
         It '-Status proposed indexes ONLY the proposed entity' {
-            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath -Status proposed | Out-Null
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath -Status proposed | Out-Null
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
             $file.indexed_status | Should -Be @('proposed')
             $m = @($file.containers.'sei:n1'.mentions)
@@ -293,7 +415,7 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
         }
 
         It '-Status approved,proposed (the explicit preview) indexes both, and records both in the envelope' {
-            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -OutputPath $script:outPath -Status approved, proposed
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -PovPath @() -SummariesPath @() -OutputPath $script:outPath -Status approved, proposed
             ($r.IndexedStatus | Sort-Object) | Should -Be @('approved', 'proposed')
 
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json


### PR DESCRIPTION
## Summary

- Extends `Update-EntityMentionIndex.ps1` with two new mention-index container kinds, reusing the existing `{entity_ref, quote, offset, discovered_by}` record shape and rebuild/idempotency/human-mention-preservation semantics unchanged:
  - `summary:<doc_id>#kp-<n>` — key points (`pov_summaries.<pov>.key_points[]`), `<n>` a single running 0-based index over accelerationist → safetyist → skeptic in that fixed order (container id carries no POV segment).
  - `summary:<doc_id>#fc-<n>` — factual claims (`factual_claims[]`), `<n>` the 0-based array position.
- New `-SummariesPath` override parameter (default: every `*.json` under `Get-SummariesDir`), mirroring the existing `-PovPath` contract, including `-SummariesPath @()` to opt out.
- `Get-MentionContainerText` gains `'kp'`/`'fc'` kinds (single-field reconstruction: `point` / `claim` respectively) alongside existing `'node'`/`'sei'`.

## Design-review gate self-certification

Per t/3122's spec, this is a bounded EXTENSION: new container-key kinds only, same record shape, same rebuild flow, no new file/layout, no cross-module API change. Authoritative design: `research/comp-linguist/docs/claims-entity-fol-recommendations.md` §4 (R2.2) item T2 — implemented exactly what it specifies (container-id shapes + record-shape reuse); no schema invented beyond it. Self-certified as a `/trivial-change`-style extension per the ticket's own routing rule; not routed to Tech Lead design review.

## Test plan

- [x] `Invoke-Pester ./tests/Update-EntityMentionIndex.Tests.ps1` — 33/33 passed (existing 26 unaffected + 7 new: kp running-index across POVs, fc array-position indexing, reused record shape, idempotent rebuild, node:* behavior unchanged alongside summary containers, missing-doc_id non-fatal skip, `-SummariesPath @()` opt-out).
- [x] `Test-ModuleManifest -Path ./scripts/AITriad/AITriad.psd1` — OK.
- [x] `Get-Command Update-EntityMentionIndex` resolves from the module after `Import-Module -Force`.
- [x] Rebased onto latest `origin/main`, no conflicts, re-ran tests + manifest check post-rebase (still 33/33, still OK).

Refs t/3122.

Co-Authored-By: PowerShell (Orca) <main.scripts@ai-triad-research.orca.local>
Co-Authored-By: Computational Linguist (Orca) <main.research-comp-linguist@ai-triad-research.orca.local>