### PR TITLE
perf(debate): memoize grounding corpus embed once per debate, not per speaker (t/3165)

### DIFF
--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/taxonomyContextCorpusDedup.test.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/__tests__/taxonomyContextCorpusDedup.test.ts
@@ -1,0 +1,66 @@
+// t/3165 — regression test for the per-debate corpus-embed dedup (defense-in-depth blast-radius
+// mitigation for the embedding-saturation incident; the ROOT fix is prod embeddings.json coverage,
+// DevOps-owned). Proves the shared static corpus (situations) is embedded ONCE per debate, not
+// once per speaker, and that per-speaker pov tagging + per-debate scoping are preserved.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  computeEmbeddings: vi.fn(),
+  activeDebateId: 'd0' as string | null,
+}));
+
+vi.mock('@bridge', () => ({
+  api: {
+    computeEmbeddings: h.computeEmbeddings,
+    loadSyntheticEmbeddings: async () => null, // no synthetic merge in the test
+  },
+}));
+vi.mock('../store', () => ({
+  useDebateStore: { getState: () => ({ activeDebate: h.activeDebateId ? { id: h.activeDebateId } : null }) },
+}));
+vi.mock('../../useTaxonomyStore', () => ({ useTaxonomyStore: { getState: () => ({}) } }));
+
+import { buildNodeEmbeddingMap } from '../shared/taxonomyContext';
+
+const node = (id: string) => ({ id, label: id, description: 'd' }) as never;
+
+beforeEach(() => {
+  h.computeEmbeddings.mockReset();
+  h.computeEmbeddings.mockImplementation(async (texts: string[]) => ({ vectors: texts.map(() => [1, 2, 3]) }));
+});
+
+describe('buildNodeEmbeddingMap — per-debate corpus dedup (t/3165)', () => {
+  it('embeds the shared situation corpus ONCE across speakers, not per-speaker', async () => {
+    h.activeDebateId = 'd-shared';
+    const situations = [node('sit-1'), node('sit-2'), node('sit-3')];
+    // Speaker 1 (acc): its POV nodes + all situations
+    await buildNodeEmbeddingMap('accelerationist', [node('acc-1'), node('acc-2')], situations);
+    // Speaker 2 (saf): its POV nodes + the SAME situations
+    await buildNodeEmbeddingMap('safetyist', [node('saf-1')], situations);
+
+    expect(h.computeEmbeddings).toHaveBeenCalledTimes(2);
+    // 1st call embeds acc-1/acc-2 + the 3 situations; 2nd embeds ONLY saf-1 (situations memoized)
+    expect(h.computeEmbeddings.mock.calls[0][1]).toEqual(['acc-1', 'acc-2', 'sit-1', 'sit-2', 'sit-3']);
+    expect(h.computeEmbeddings.mock.calls[1][1]).toEqual(['saf-1']);
+  });
+
+  it('resolves memoized nodes with the CURRENT speaker pov tag (behaviour-equivalent)', async () => {
+    h.activeDebateId = 'd-tag';
+    const situations = [node('sit-9')];
+    await buildNodeEmbeddingMap('accelerationist', [node('acc-9')], situations);
+    const { nodeEmbeddings } = await buildNodeEmbeddingMap('safetyist', [node('saf-9')], situations);
+    // sit-9 came from the memo but is tagged with the second speaker's pov, exactly as before
+    expect(nodeEmbeddings['sit-9']).toEqual({ pov: 'safetyist', vector: [1, 2, 3] });
+    expect(nodeEmbeddings['saf-9']).toEqual({ pov: 'safetyist', vector: [1, 2, 3] });
+  });
+
+  it('re-embeds when the debate changes (memo is scoped per debate, not global)', async () => {
+    const situations = [node('sit-x')];
+    h.activeDebateId = 'd-A';
+    await buildNodeEmbeddingMap('accelerationist', [], situations);
+    h.activeDebateId = 'd-B'; // new debate → memo cleared, so sit-x re-embeds
+    await buildNodeEmbeddingMap('accelerationist', [], situations);
+    expect(h.computeEmbeddings).toHaveBeenCalledTimes(2);
+    expect(h.computeEmbeddings.mock.calls[1][1]).toEqual(['sit-x']);
+  });
+});

--- a/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
+++ b/taxonomy-editor/src/renderer/hooks/useDebateStore/shared/taxonomyContext.ts
@@ -172,8 +172,23 @@ export function serializeNodeSourceMap(
 // phase is independently testable.
 type NodeEmbeddingMap = Record<string, { pov: string; vector: number[]; vectors?: number[][] }>;
 
-/** Embed all POV+CC nodes into a combined map, merging synthetic multi-vectors when available. */
-async function buildNodeEmbeddingMap(pov: string, allPovNodes: PovNode[], allCCNodes: SituationNode[]): Promise<{ nodeEmbeddings: NodeEmbeddingMap; allNodeIds: string[] }> {
+// Per-debate base-embedding memo (t/3165 blast-radius mitigation — DEFENSE-IN-DEPTH, not the root
+// fix). getRelevantTaxonomyContext runs once per speaker (acc/saf/skp); each call re-embeds
+// current-POV nodes + ALL situations, and the ~443 situations are identical across all 3 speakers,
+// so they recompute 3×. Each ~800-text recompute is what starves the event loop when prod's
+// embeddings.json is stale vs the taxonomy data (the real driver — DevOps-owned coverage/reseed).
+// Memoizing base vectors by node-id within a debate embeds the shared corpus ONCE, not per speaker.
+// Behaviour-equivalent: embeddings are a deterministic fn of text; the memo keys on node-id and is
+// scoped to the active debate (cleared when the debate id changes), so a node whose text changed
+// between debates is re-embedded.
+const corpusEmbedMemo = new Map<string, number[]>();
+let corpusEmbedMemoDebateId: string | null = null;
+
+/**
+ * Embed all POV+CC nodes into a combined map, merging synthetic multi-vectors when available.
+ * Exported for the t/3165 corpus-dedup regression test.
+ */
+export async function buildNodeEmbeddingMap(pov: string, allPovNodes: PovNode[], allCCNodes: SituationNode[]): Promise<{ nodeEmbeddings: NodeEmbeddingMap; allNodeIds: string[] }> {
   const allNodeTexts = [
     ...allPovNodes.map(n => `${n.label}: ${n.description}`),
     ...allCCNodes.map(n => `${n.label}: ${n.description}`),
@@ -182,10 +197,28 @@ async function buildNodeEmbeddingMap(pov: string, allPovNodes: PovNode[], allCCN
     ...allPovNodes.map(n => n.id),
     ...allCCNodes.map(n => n.id),
   ];
-  const { vectors: allVectors } = await api.computeEmbeddings(allNodeTexts, allNodeIds);
-  const baseNodeEmbeddings: Record<string, { pov: string; vector: number[] }> = {};
+
+  // Reset the memo when the active debate changes, then embed ONLY the ids not yet seen this
+  // debate (the shared situations are embedded on the first speaker, resolved for the rest).
+  const debateId = useDebateStore.getState().activeDebate?.id ?? null;
+  if (debateId !== corpusEmbedMemoDebateId) {
+    corpusEmbedMemo.clear();
+    corpusEmbedMemoDebateId = debateId;
+  }
+  const missIdx: number[] = [];
   for (let i = 0; i < allNodeIds.length; i++) {
-    baseNodeEmbeddings[allNodeIds[i]] = { pov, vector: allVectors[i] };
+    if (!corpusEmbedMemo.has(allNodeIds[i])) missIdx.push(i);
+  }
+  if (missIdx.length > 0) {
+    const missTexts = missIdx.map(i => allNodeTexts[i]);
+    const missIds = missIdx.map(i => allNodeIds[i]);
+    const { vectors } = await api.computeEmbeddings(missTexts, missIds);
+    for (let k = 0; k < missIds.length; k++) corpusEmbedMemo.set(missIds[k], vectors[k]);
+  }
+
+  const baseNodeEmbeddings: Record<string, { pov: string; vector: number[] }> = {};
+  for (const id of allNodeIds) {
+    baseNodeEmbeddings[id] = { pov, vector: corpusEmbedMemo.get(id) as number[] };
   }
 
   // Merge synthetic multi-vector embeddings when available


### PR DESCRIPTION
## Summary — DEFENSE-IN-DEPTH for incident t/3165 (NOT the root fix)
The root cause is **prod-side**: `embeddings.json` stale-vs-taxonomy-data / cold-replica load-race (DevOps-owned regen/reseed + the resolution gate). My census (t/3165#15) proved this is **not a renderer id-bug** — 99.5% of the debate corpus ids resolve from the 4144 cache. TL confirmed the target (t/3165#16/#17) and approved this as blast-radius mitigation, correct under either root condition.

**The waste:** `getRelevantTaxonomyContext` runs **once per speaker** (acc/saf/skp); `buildNodeEmbeddingMap` re-embedded current-POV nodes + **all situations** each time — the ~443 situations (identical across all 3 speakers) recomputed **3×**. Each ~800-text recompute is what starves the single-threaded event loop when the server cache doesn't resolve → load-shed 503 + ACA-fabricated 500 ("Safetyist FAILED").

**The fix:** memoize base vectors by node-id within a debate (keyed on `activeDebate.id`, cleared when it changes) → the shared corpus embeds **once**, later speakers resolve from the memo. **Behaviour-equivalent:** embeddings are deterministic in text; per-speaker pov tagging, synthetic-vector merge, and doctrinal anchoring downstream are unchanged.

## Verification
- New `taxonomyContextCorpusDedup.test.ts` — **3/3** (TL's GV spec): shared situation corpus embedded **once** across speakers (not per-speaker); memoized nodes carry the **current speaker's pov tag** (behaviour-equivalent); memo **re-embeds on a new debate** (per-debate scoping).
- Full `useDebateStore` suite **158/158** (no regression). eslint **0 errors**; renderer-tsc clean for the changed files (only the 3 known `lib/` worktree node_modules artifacts, absent in CI).

## Scope / self-cert
Pure call-dedup, no behaviour change → self-cert `/trivial-change` per your t/3165#16. Touches `useDebateStore/shared/` (DebateWorkspace territory) — done under your explicit incident routing to Rosetta Stone (t/3165#10). Root fix stays with **DevOps**. Routed to **Main (TL)** for GV.

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Tech Lead (Orca) <main.engineering-tech-lead@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)