### PR TITLE
feat(entities): Entity relations[] + EntityRelation DOLCE types (t/3119)

### DIFF
--- a/lib/entities/types.ts
+++ b/lib/entities/types.ts
@@ -129,6 +129,34 @@ export interface ConceptLinkRef {
   status: EntityLinkStatus;
 }
 
+/**
+ * A DOLCE-typed relation between two register entities (or an entity and a `term:*` type) — R4.1.
+ * The three types are kept explicitly DISTINCT (CL DOLCE review, t/3119#2):
+ * - `instance_of` — a particular → its type. This is the bridge that crosses `ent-*` → `term:*`
+ *   (a particular entity is an instance of a vocabulary kind). NOT interchangeable with subclass.
+ * - `subclass_of` — a type → its supertype (type-level subsumption, e.g. one term narrows another).
+ * - `part_of` — generic mereology (a particular part_of a particular, a sub-event part_of a
+ *   perdurant). Constitution is deliberately excluded (CL §7.2); `part_of` must NEVER be used to
+ *   encode an instance/subclass hop.
+ */
+export type EntityRelationType = 'instance_of' | 'subclass_of' | 'part_of';
+
+/**
+ * One relation edge on an {@link Entity}. `target` is a RAW `ent-*` | `term:<slug>` token (parsed on
+ * read via {@link parseEntityRef}, like `Mention.entity_ref` — never persist a pre-parsed form).
+ *
+ * INVARIANT (R4.3, enforced WRITE-SIDE — not by this type): the relation graph is a shallow DAG —
+ * acyclic, depth ≤ 3, `target` well-formed. A TypeScript interface cannot prevent a cycle or an
+ * over-depth graph, so enforcement lives at the relation-authoring path (Import-Entity when a
+ * relation is added) + the entity audit-cycle sweep, NOT here (TL t/3119, p/342#204). The DAG/
+ * depth/target validator is a separate ticket (t/3170) that hard-BLOCKS any relations-populating
+ * work — no path may persist an unvalidated `relations[]` (fast-follow enforced, not intended).
+ */
+export interface EntityRelation {
+  type: EntityRelationType;
+  target: string;                 // ent-* | term:<slug> raw token (parsed via parseEntityRef)
+}
+
 /** The new entity record (ent-*), stored in entities.json. */
 export interface Entity {
   id: string;                     // ent-NNN
@@ -144,6 +172,11 @@ export interface Entity {
   description_provenance?: EntityDescriptionProvenance;
   external_refs?: { label: string; url: string }[];
   source_refs?: string[];         // doc_ids
+  /** DOLCE-typed relation edges (instance_of/subclass_of/part_of) to other entities/terms (R4.1).
+   *  Optional; shallow-DAG + depth≤3 + acyclic invariant is enforced write-side, NOT by this type —
+   *  see {@link EntityRelation}. Currently ACCEPTED-BUT-DROPPED by Import-Entity (allowlisted, not
+   *  persisted) until the relation-authoring path + DAG validator land (t/3119 fast-follow). */
+  relations?: EntityRelation[];
   status: 'proposed' | 'approved' | 'deprecated';
   /** Set ⇒ this record is a merge tombstone; resolve to the canonical id (Section 7). */
   merged_into?: string;

--- a/scripts/AITriad/Private/Get-EntityProposalFieldName.ps1
+++ b/scripts/AITriad/Private/Get-EntityProposalFieldName.ps1
@@ -32,6 +32,7 @@ function Get-EntityProposalFieldName {
         'description_provenance'
         'external_refs'
         'source_refs'
+        'relations'
         'merged_into'
         'discovered_by'
         'confidence'

--- a/tests/Entity.Tests.ps1
+++ b/tests/Entity.Tests.ps1
@@ -112,6 +112,21 @@ Describe 'Import-Entity — curation write (t/1804 §4)' -Tag 'unit' {
         { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Not -Throw
     }
 
+    It 'ACCEPTS but DROPS relations — allowlisted, not yet persisted (t/3119 fast-follow safety)' {
+        # relations is on the contract + allowlist (so it is NOT loud-rejected), but Import-Entity
+        # applies only NAMED fields — there is no copy-all step — so relations is NOT written to the
+        # record. This is the inert accepted-but-dropped window that lets the type land before the
+        # DAG/acyclic/depth≤3 validator (TL p/342#218). The drop-assertion is load-bearing: if a
+        # future writer starts PERSISTING relations without validation, this test reds and stops it.
+        $tmp = Join-Path $TestDrive 'entities-relations-dropped.json'
+        $p = New-Prop @{ relations = @(@{ type = 'instance_of'; target = 'term:language-model' }) }
+        # (1) allowlisted → no loud reject.
+        { Import-Entity -Proposal @($p) -Path $tmp -SkipEmbedding } | Should -Not -Throw
+        # (2) the persisted record carries NO relations property (dropped, not persisted).
+        $stored = (Get-Content -Raw -Path $tmp | ConvertFrom-Json).entities[0]
+        $stored.PSObject.Properties['relations'] | Should -BeNullOrEmpty
+    }
+
     It 'Rejects approving a PERSON record with no human description (§4/§9.3)' {
         $tmp = Join-Path $TestDrive 'entities-person.json'
         $p = @{ name = 'Jane Doe'; entity_type = 'person'; dolce_category = 'agentive-physical-object'; status = 'approved' }


### PR DESCRIPTION
## t/3119 — Entity `relations[]` + `EntityRelation` DOLCE types (atomic types + allowlist)

Adds the DOLCE-typed entity-relation vocabulary to the `Entity` contract (go-first, interface-first) plus the atomic Import-Entity allowlist sync it couples to. **Self-cert** per TL clearance (p/342#216/#218) — CL DOLCE review (t/3119#2) + TL data-model + enforcement-timing (p/342#204/#218) already done.

### Changes
- **`lib/entities/types.ts`** — `EntityRelationType` (`instance_of` | `subclass_of` | `part_of`, kept explicitly distinct per CL DOLCE review), `EntityRelation {type, target}` (raw `ent-*`|`term:*` token, parsed on read), `Entity.relations?: EntityRelation[]`. JSDoc pins the shallow-DAG + depth≤3 + acyclic invariant as **write-side** (a type can't enforce it) and names the validator **t/3170**.
- **`scripts/AITriad/Private/Get-EntityProposalFieldName.ps1`** — `'relations'` added so the t/3133 allowlist-sync exact-match gate stays green. Must land in the **same PR** as the interface field (PowerShell sign-off, p/44#66).
- **`tests/Entity.Tests.ps1`** — drop-assertion test: Import-Entity **accepts but drops** `relations` (allowlisted, applied via named fields only, never persisted). Reds if a future writer starts persisting relations without validation (TL condition 3, p/342#218; PS sign-off p/44#70).

### Safety posture (fast-follow, enforced not intended)
- **Accepted-but-dropped** confirmed in code: Import-Entity applies only named fields (new-record literal + fixed apply-loop + desc_prov/merged_into) — no copy-all — so `relations` is never persisted.
- **t/3170** (DAG/acyclic/depth≤3 + target well-formedness validator, PS-owned → TL gate-verify) hard-blocks any future relations-populating ticket. Nothing persists an unvalidated `relations[]` until validation lands. No population ticket exists yet.

### Verification
- renderer tsc: **0 errors** · eslint (types.ts): **0** · Pester `Entity.Tests.ps1`: **44/44** (incl. drift-parity + t/3133 allowlist-sync gates).

Closes t/3119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
