### PR TITLE
fix(ps): POV-scope summary kp container id — summary:<doc>#<pov>-kp-<n> (t/3122 follow-up)

### DIFF
--- a/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
+++ b/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
@@ -26,11 +26,13 @@ function Update-EntityMentionIndex {
           - POV / situation nodes: container id `node:<node_id>`, text = `label`, then
             `description`, then `plain_description` (present fields only), newline-separated.
           - Summary key points (t/3122, claims-entity-fol-recommendations.md §4/R2.2 T2):
-            container id `summary:<doc_id>#kp-<n>`, text = the key point's `point` field.
-            `<n>` is a 0-based index over the concatenation of `pov_summaries.accelerationist
-            .key_points`, then `.safetyist.key_points`, then `.skeptic.key_points`, in that
-            fixed order (matching the POV order used elsewhere for summary claims, e.g.
-            Remove-DuplicateClaims) — one running counter per document, not per POV.
+            container id `summary:<doc_id>#<pov>-kp-<n>` where <pov> ∈ acc/saf/skp, text = the
+            key point's `point` field. `<n>` is a 0-based index reset PER POV array
+            (`pov_summaries.<pov>.key_points`). POV-scoping (CL ruling p/23#220-221) confines
+            renumber-churn to a single POV array instead of cascading a running counter across
+            all three; key_points carry no stable per-claim id (taxonomy_node_id is a non-unique
+            node reference), so positional is the pragmatic key and inserts within a POV still
+            churn that array's tail (the reconciler must tolerate it).
           - Summary factual claims (t/3122, same doc §4/R2.2 T2): container id
             `summary:<doc_id>#fc-<n>`, text = the `factual_claims[n].claim` field, `<n>` the
             0-based index into that array.
@@ -268,19 +270,25 @@ function Update-EntityMentionIndex {
         if (-not $summary.PSObject.Properties['doc_id'] -or -not $summary.doc_id) { continue }
         $docId = [string]$summary.doc_id
 
-        # key_points: ONE running 0-based index over the concatenation of the three POV
-        # arrays in fixed order — not per-POV — so `summary:<doc_id>#kp-<n>` is unique per
-        # document (the container-id shape carries no POV segment).
+        # key_points: POV-SCOPED 0-based index — `summary:<doc_id>#<pov>-kp-<n>` (<pov> ∈
+        # acc/saf/skp), `<n>` reset per POV array. CL ruling (p/23#220-221): a single running
+        # counter across the three arrays is positionally fragile — inserting/removing a
+        # key_point in one POV renumbers every later container id, churning unrelated refs and
+        # spuriously staling their text_sha256. No stable per-claim id exists on a key_point
+        # (taxonomy_node_id is a non-unique node reference), so POV-scoped positional is the
+        # pragmatic key; inserts WITHIN a POV array still churn that array's tail.
         if ($summary.PSObject.Properties['pov_summaries'] -and $summary.pov_summaries) {
-            $kpIndex = 0
+            $povCode = @{ accelerationist = 'acc'; safetyist = 'saf'; skeptic = 'skp' }
             foreach ($povName in @('accelerationist', 'safetyist', 'skeptic')) {
                 if (-not $summary.pov_summaries.PSObject.Properties[$povName]) { continue }
                 $povData = $summary.pov_summaries.$povName
                 if (-not $povData -or -not $povData.PSObject.Properties['key_points'] -or -not $povData.key_points) { continue }
+                $code = $povCode[$povName]
+                $kpIndex = 0
                 foreach ($kp in @($povData.key_points)) {
                     $pointVal = if ($kp.PSObject.Properties['point']) { $kp.point } else { $null }
                     $text = Get-MentionContainerText -Kind 'kp' -Fields @($pointVal)
-                    if ($text -ne '') { $Containers["summary:$docId#kp-$kpIndex"] = $text }
+                    if ($text -ne '') { $Containers["summary:$docId#$code-kp-$kpIndex"] = $text }
                     $kpIndex++
                 }
             }

--- a/tests/Update-EntityMentionIndex.Tests.ps1
+++ b/tests/Update-EntityMentionIndex.Tests.ps1
@@ -213,13 +213,19 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
 
     Context 'Summary containers (t/3122, §4/R2.2 T2)' {
 
-        It 'Indexes key_points as summary:<doc_id>#kp-<n> with a running index across POVs in fixed order' {
+        It 'Indexes key_points as summary:<doc_id>#<pov>-kp-<n> with <n> reset PER POV (CL ruling p/23#220-221)' {
             $summPath = Join-Path $script:root 'doc1.json'
+            # safetyist has TWO key_points so its index runs 0,1; skeptic then RESETS to 0.
+            # Under the old running-counter scheme skeptic's point would have been kp-3 — this
+            # asserts the per-POV reset, i.e. an insert/remove in one POV can't renumber another.
             New-Summary -Path $summPath -Doc @{
                 doc_id        = 'doc1'
                 pov_summaries = [ordered]@{
                     accelerationist = @{ key_points = @(@{ point = 'No entity here.' }) }
-                    safetyist       = @{ key_points = @(@{ point = 'The Apollo Project reshaped ambition.' }) }
+                    safetyist       = @{ key_points = @(
+                            @{ point = 'The Apollo Project reshaped ambition.' },
+                            @{ point = 'Apollo again, a second safetyist point.' }
+                        ) }
                     skeptic         = @{ key_points = @(@{ point = 'Also mentions Apollo alone.' }) }
                 }
             }
@@ -227,16 +233,22 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
             Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath (Join-Path $script:root 'no-sei.json') -PovPath @() -SummariesPath @($summPath) -OutputPath $script:outPath | Out-Null
 
             $file = Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json
-            # index 0 = accelerationist point (no mentions, so omitted entirely — absence == "no links yet")
-            $file.containers.PSObject.Properties['summary:doc1#kp-0'] | Should -BeNullOrEmpty
-            # index 1 = safetyist point (Apollo Project)
-            $kp1 = $file.containers.'summary:doc1#kp-1'
-            $kp1 | Should -Not -BeNullOrEmpty
-            @($kp1.mentions).entity_ref | Should -Contain 'ent-001'
-            # index 2 = skeptic point (Apollo)
-            $kp2 = $file.containers.'summary:doc1#kp-2'
-            $kp2 | Should -Not -BeNullOrEmpty
-            @($kp2.mentions).entity_ref | Should -Contain 'ent-002'
+            # accelerationist #acc-kp-0 has no entity → omitted (absence == "no links yet")
+            $file.containers.PSObject.Properties['summary:doc1#acc-kp-0'] | Should -BeNullOrEmpty
+            # safetyist indexes reset to 0 within its own array: saf-kp-0 (Apollo Project) + saf-kp-1 (Apollo)
+            $sk0 = $file.containers.'summary:doc1#saf-kp-0'
+            $sk0 | Should -Not -BeNullOrEmpty
+            @($sk0.mentions).entity_ref | Should -Contain 'ent-001'
+            $sk1 = $file.containers.'summary:doc1#saf-kp-1'
+            $sk1 | Should -Not -BeNullOrEmpty
+            @($sk1.mentions).entity_ref | Should -Contain 'ent-002'
+            # skeptic RESETS to 0 (skp-kp-0), proving it is not a document-wide running counter
+            $sp0 = $file.containers.'summary:doc1#skp-kp-0'
+            $sp0 | Should -Not -BeNullOrEmpty
+            @($sp0.mentions).entity_ref | Should -Contain 'ent-002'
+            # the retired running-counter ids must NOT exist
+            $file.containers.PSObject.Properties['summary:doc1#kp-1'] | Should -BeNullOrEmpty
+            $file.containers.PSObject.Properties['summary:doc1#kp-2'] | Should -BeNullOrEmpty
         }
 
         It 'Indexes factual_claims as summary:<doc_id>#fc-<n> by array position' {


### PR DESCRIPTION
## What

Follow-up to #1707 (t/3122). Changes the summary key-point container id from the document-wide running counter `summary:<doc>#kp-<n>` (which #1707 shipped) to **POV-scoped** `summary:<doc>#<pov>-kp-<n>` (`<pov>` ∈ acc/saf/skp), with `<n>` reset per POV array.

## Why

CL ruling (p/23#220–221): a single running counter across the three per-POV `key_points` arrays is positionally fragile — inserting/removing a key_point in one POV renumbers every later container id, spuriously staling unrelated `text_sha256` and breaking stored refs. POV-scoping confines renumber-churn to a single array.

`key_points` carry no stable per-claim id (verified against live data: fields are `stance/taxonomy_node_id/category/point/…`; `taxonomy_node_id` is a non-unique node reference), so POV-scoped positional is the pragmatic key. Inserts *within* a POV array still churn that array's tail (the reconciler must tolerate it). `fc` containers (single `factual_claims[]` array) are unchanged.

## Context — why a follow-up and not part of #1707

#1707 auto-merged on its original head before this rework landed (the fix was pushed to the branch post-merge and stranded). This PR cherry-picks that stranded commit onto current `main`. No consumer of summary containers exists yet (t/3124 is blocked), so no migration is needed — the index is regenerable.

## Tests

Test reworked to prove per-POV reset: safetyist gets two key_points (`saf-kp-0`/`saf-kp-1`); skeptic resets to `skp-kp-0` (was `kp-3` under the running counter); asserts the retired running-counter ids no longer exist. **33/33 pass**; `Test-ModuleManifest` OK.

Refs t/3122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)