### PR TITLE
fix(oped): reframe source-brief header from fact-assertion to attribution (t/3146)

### DIFF
--- a/lib/oped/prompts/op-ed-generation-user.prompt
+++ b/lib/oped/prompts/op-ed-generation-user.prompt
@@ -20,7 +20,7 @@ AUTHOR (for the authority line / bio):
 SOURCE MATERIAL (use as factual grounding; quote or paraphrase from it where it strengthens a pillar — do not invent statistics it does not support):
 {{SOURCE_MATERIAL}}
 
-WHAT THE SOURCE ACTUALLY ARGUES. This is a neutral brief prepared from the source above. Treat each line as an established fact about the document that you must represent accurately:
+WHAT THE SOURCE ACTUALLY ARGUES. This is a neutral brief prepared from the source above. Treat each line as this brief's representation of the source. It is a machine-prepared summary — represent it faithfully, but do not assert any line as established fact beyond what the source text supports:
 - Published by: {{SOURCE_AUTHOR}} ({{SOURCE_ACTOR_TYPE}})
 - Its thesis: {{SOURCE_THESIS}}
 - Its stance: {{SOURCE_STANCE}}


### PR DESCRIPTION
Reframes the op-ed source-brief header (t/3098 provenance-laundering audit) so a machine-prepared summary is attributed as the brief's own representation, not elevated to established fact. Framing-only, no schema/metric change.

- `lib/oped/prompts/op-ed-generation-user.prompt:23` — CL-authored reframe, verbatim (p/3#166); terminal `.`→`:` to preserve the bulleted-brief introduction.

CL mandatory prompt-quality review: approved (p/3#166). Edit #2 (lib/debate enriched-meta prefix) is DebateTool's own PR. Closes the Shared Lib half of t/3146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)