### PR TITLE
obs(debate): prefix enriched-meta guidance block with machine-origin signal (t/3146)

### DIFF
--- a/lib/debate/taxonomyContext.ts
+++ b/lib/debate/taxonomyContext.ts
@@ -280,6 +280,10 @@ export function formatTaxonomyContext(ctx: TaxonomyContext, pov: string, maxNode
       sorted = sorted.slice(0, maxDesires);
     }
 
+    // t/3146: machine-origin signal — emitted once per category section, before any node guidance
+    if (sorted.length > 0) {
+      lines.push('  [heuristic] The following tactical annotations are machine-estimated heuristics, not established facts — use them as suggestions.');
+    }
     for (let i = 0; i < sorted.length; i++) {
       const n = sorted[i];
       const isPrimary = !hasScores || i < PRIMARY_COUNT;


### PR DESCRIPTION
## Summary

- Adds a single framing line once per BDI category section in `taxonomyContext.ts`, before the ARGUE/ATTACK VIA/PREMISES/VULNERABLE/DO NOT CONCEDE guidance emitted by `generateNodeGuidance`
- Placement: block-assembly site (~line 283), NOT inside the generator — so it appears exactly once per category, not once per node
- Text (CL-authored, CL-approved p/49#339): `[heuristic] The following tactical annotations are machine-estimated heuristics, not established facts — use them as suggestions.`
- `[heuristic]` label retained per CL: consistent with codebase convention (OPPONENT INTELLIGENCE, STRONG FOUNDATIONS) and aids visual scanning
- Framing-only per t/3098 provenance-laundering audit; no metric, schema, or interface changes

## Test plan

- [ ] ESLint: clean (exit 0)
- [ ] Vitest 2845/2847 pass; 2 failures (ENOSPC/EACCES persistence fault tests) and 16 AI-integration test files are pre-existing environment failures (Gemini 429/503 rate limits) — unrelated to this string-only change
- [ ] CL mandatory text review: approved (p/49#339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)