### PR TITLE
fix(devops): switch embeddings resolution gate to GET /readyz — no auth needed (t/3091)

### DIFF
--- a/operations/devops/Invoke-EmbeddingsResolutionGateCheck.ps1
+++ b/operations/devops/Invoke-EmbeddingsResolutionGateCheck.ps1
@@ -4,32 +4,29 @@
 
 <#
 .SYNOPSIS
-    Post-deploy gate (warn-only): verify the embeddings cache resolves a confirmed-real
-    taxonomy node id via the same keyed lookup path that computeEmbeddings uses. Catches
-    cache-present-but-non-resolving failures (t/3165 pattern, t/3091).
+    Post-deploy gate (warn-only): confirm the embeddings cache resolved the canary key by
+    reading the resolves field on GET /readyz (anon-exempt, no auth needed). t/3091.
 .DESCRIPTION
-    Calls POST /api/embeddings/compute with canary id acc-beliefs-003 (a confirmed-real
-    stored key in the production embeddings corpus). The response includes cacheHits,
-    cacheMisses, and corpusNodeCount (added by ServerAPI in t/3165 PR #1704).
+    Calls GET /readyz and reads the `resolves` bool added by ServerAPI's /readyz upgrade
+    (p/555#21-23). The warm-gate (#1689) already blocks on /readyz 503, so by the time this
+    gate runs (if: warm_gate.outputs.warm == 'true'), /readyz is 200 with resolves:true.
+    This step provides explicit log evidence of resolution state and degrades gracefully if
+    the `resolves` field is absent (pre-upgrade revision).
 
-    cacheHits >= 1  -> PASS (canary resolved through cache hit path)
-    cacheHits == 0  -> WARN (corpus is warm per warm-gate, but canary not resolving;
-                             implies a genuine resolution failure on this keying path)
+    /readyz contract (ServerAPI p/555#23):
+      200 { status:"ready",  nodeCount, resolves:true  }  — corpus loaded + canary resolves
+      503 { status:"warming", present, nodeCount, resolves:false, reason } — not ready
 
-    Canary: acc-beliefs-003
-      - Full-word stored key form (NOT the abbreviated docs form acc-bel-001)
-      - Confirmed present in live production corpus by ServerAPI (p/555#4, p/555#5)
-      - canaryPresent === cacheHits: both check nodes[id] != null (p/555#12) — no
-        separate canaryPresent field needed
-      - Warm-gate already proved nodeCount > 0, so cacheHits:0 here is a resolution
-        failure, not a dead-cache (warm-gate owns that detection)
+    NOTE: The warm-gate's 200-gating already enforces resolution (non-resolving → 503 →
+    warm-gate blocks, this step is skipped). This gate is a logging confirmation, not an
+    independent guard. Kept separate for per-step observability in CI.
 
-    WARN-ONLY phase: wired with continue-on-error: true in deploy-azure.yml until both GV
-    arms proven on real environments. Flip-to-blocking is a separate Gate-Promotion PR per
-    Gate Promotion Discipline (operations/devops/AGENTS.md).
+    WARN-ONLY: continue-on-error:true until both GV arms proven on the upgraded /readyz.
+    Flip-to-blocking is a separate Gate-Promotion PR per Gate Promotion Discipline.
 
-    GV FIRE arm:  cacheHits:0 on a mis-keyed or dead-cache revision -> emits ::warning::
-    GV CLEAN arm: cacheHits:1 on a healthy resolving revision -> passes silently
+    GV FIRE arm:  resolves:false on a non-resolving revision → warm-gate blocks; this step
+                  is skipped (if: warm == 'true'). FIRE arm is warm-gate's responsibility.
+    GV CLEAN arm: resolves:true after warm-gate passes → logs PASS.
 #>
 [CmdletBinding()]
 param(
@@ -39,52 +36,45 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$Canary   = 'acc-beliefs-003'
-$Endpoint = "$($BaseUrl.TrimEnd('/'))/api/embeddings/compute"
+$Endpoint = "$($BaseUrl.TrimEnd('/'))/readyz"
 
-Write-Host "Embeddings resolution gate: probing $Endpoint with canary '$Canary'..."
+Write-Host "Embeddings resolution gate: reading resolution state from $Endpoint ..."
 
 try {
-    $body = @{
-        texts = @($Canary)
-        ids   = @($Canary)
-    } | ConvertTo-Json -Compress
-
     $resp = Invoke-RestMethod `
-        -Uri         $Endpoint `
-        -Method      Post `
-        -Body        $body `
-        -ContentType 'application/json' `
-        -TimeoutSec  30 `
+        -Uri        $Endpoint `
+        -Method     Get `
+        -TimeoutSec 15 `
         -ErrorAction Stop
 
-    $cacheHitsField       = $resp.PSObject.Properties['cacheHits']
-    $cacheMissesField     = $resp.PSObject.Properties['cacheMisses']
-    $corpusNodeCountField = $resp.PSObject.Properties['corpusNodeCount']
+    $resolvesField   = $resp.PSObject.Properties['resolves']
+    $nodeCountField  = $resp.PSObject.Properties['nodeCount']
+    $reasonField     = $resp.PSObject.Properties['reason']
 
-    if ($null -eq $cacheHitsField) {
-        # cacheHits absent — ServerAPI t/3165 PR #1704 not yet merged on this revision
+    if ($null -eq $resolvesField) {
+        # resolves field absent — /readyz upgrade (p/555#21) not yet on this revision
         $keys = $resp.PSObject.Properties.Name -join ', '
-        Write-Host ("::warning::Embeddings resolution gate: response missing 'cacheHits' field — " +
-            "confirm ServerAPI t/3165 PR #1704 is merged on this revision. Response keys: $keys. (t/3091)")
+        Write-Host ("::warning::Embeddings resolution gate: /readyz missing 'resolves' field — " +
+            "ServerAPI /readyz upgrade (p/555#21) not yet on this revision. " +
+            "Response keys: $keys. Resolution unconfirmed; warm-gate already proved nodeCount>0. (t/3091)")
         return
     }
 
-    $cacheHits       = [int]$cacheHitsField.Value
-    $cacheMisses     = [int]($null -ne $cacheMissesField     ? $cacheMissesField.Value     : -1)
-    $corpusNodeCount = [int]($null -ne $corpusNodeCountField ? $corpusNodeCountField.Value : -1)
+    $resolves   = [bool]$resolvesField.Value
+    $nodeCount  = [int]($null -ne $nodeCountField ? $nodeCountField.Value : -1)
+    $reason     = if ($null -ne $reasonField) { $reasonField.Value } else { '' }
 
-    if ($cacheHits -ge 1) {
-        Write-Host ("Embeddings resolution gate PASSED: canary '$Canary' resolved from cache " +
-            "(cacheHits=$cacheHits, corpusNodeCount=$corpusNodeCount). (t/3091)")
+    if ($resolves) {
+        Write-Host ("Embeddings resolution gate PASSED: /readyz reports resolves=true " +
+            "(nodeCount=$nodeCount). Canary keyed lookup confirmed on this revision. (t/3091)")
     } else {
-        Write-Host ("::warning::Embeddings resolution gate FAILED: canary '$Canary' not resolved " +
-            "(cacheHits=$cacheHits, cacheMisses=$cacheMisses, corpusNodeCount=$corpusNodeCount). " +
-            "Warm-gate already confirmed corpus is loaded (nodeCount > 0), so this is a genuine " +
-            "key-resolution failure on the compute path. This gate is warn-only pending GV. (t/3091)")
+        # Shouldn't reach here (warm-gate blocks on 503 before this runs), but guard anyway.
+        Write-Host ("::warning::Embeddings resolution gate UNEXPECTED: /readyz returned 200 " +
+            "but resolves=false (nodeCount=$nodeCount, reason=$reason). " +
+            "Warm-gate should have blocked — investigate gate sequencing. (t/3091)")
     }
 
 } catch {
-    Write-Host ("::warning::Embeddings resolution gate: POST $Endpoint failed — " +
+    Write-Host ("::warning::Embeddings resolution gate: GET $Endpoint failed — " +
         "$($_.Exception.Message). Skipping resolution check. (t/3091)")
 }


### PR DESCRIPTION
## Summary

- Replaces `POST /api/embeddings/compute` (blocked by Easy Auth → SPA HTML fallback) with `GET /readyz` (anon-exempt, `PUBLIC_EXACT_PATHS`)
- Reads the `resolves` bool added by the ServerAPI `/readyz` upgrade (p/555#21-23)
- The warm-gate already enforces resolution (non-resolving → 503 → warm-gate blocks before this step runs); this step provides explicit log confirmation
- Degrades gracefully if `resolves` absent (pre-upgrade revision: warns, does not fail)

## Root cause of false-warn

`#1706` false-warned on every prod deploy: anonymous `POST /api/embeddings/compute` gets SPA HTML fallback (Easy Auth intercept). `Invoke-RestMethod` returned a string; `PSObject.Properties['cacheHits']` saw only `Length`. Fix: move probe to `/readyz` which is already anon-exempt — no AAD token, no probe-header needed. Shared approach with ServerAPI's `/readyz` resolution-canary (TL requirement, p/494#20, p/331#780).

## Dependency

ServerAPI `/readyz` upgrade must be deployed for the `resolves` field to appear. Gate degrades gracefully until then (warns "resolves field absent"). Draft until ServerAPI upgrade is live + TL GV.

## Gate-touching — DRAFT pending TL GV

Both arms needed (gate now reads `/readyz`, not `compute`):
- **CLEAN:** `resolves:true` after warm-gate passes → logs PASS
- **FIRE:** absorbed by warm-gate (non-resolving → 503 → warm-gate blocks before this step runs)

## Test plan
- [ ] ServerAPI `/readyz` upgrade shipped with `resolves` field
- [ ] Deploy confirms: gate logs `resolves=true, nodeCount=N` (no false-warn)
- [ ] TL GV both arms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiB6s5mCbCXbkWrQ8AjHXT