### PR TITLE
fix(qbaf): margin floor -> explicit undecided verdict (t/3151 Part 1)

### DIFF
--- a/scripts/enrich_conflicts_qbaf.py
+++ b/scripts/enrich_conflicts_qbaf.py
@@ -343,6 +343,14 @@ def enrich_conflict(conflict, node_meta):
     }
 
 
+# Resolution margin floor (t/3151, CL neutrality ruling t/3151#2). computed_strength is DF-QuAD
+# in [0, 1]; a top−runner-up gap below this means the two sides are not meaningfully separated, so
+# crowning the first-listed instance is noise (Python's stable sort silently made inst-0 win a
+# perfect tie with margin 0.0). Below the floor → explicit `undecided` (mirrors the crux layer);
+# at/above → `decided`. Stipulated day-one (registered; derivation path is t/3152).
+QBAF_MARGIN_FLOOR = 0.05
+
+
 def _finalize_qbaf(pre, bridge_result):
     """Finalize a QBAF object after bridge results are available."""
     qbaf_nodes_output = pre["qbaf_nodes_output"]
@@ -359,12 +367,24 @@ def _finalize_qbaf(pre, bridge_result):
         top = sorted_nodes[0]
         runner_up = sorted_nodes[1]
         margin = round(top["computed_strength"] - runner_up["computed_strength"], 4)
-        resolution = {
-            "prevailing_claim": top["id"],
-            "prevailing_strength": top["computed_strength"],
-            "margin": margin,
-            "criterion": "qbaf_computed_strength",
-        }
+        if margin < QBAF_MARGIN_FLOOR:
+            # Sides not meaningfully separated — explicit undecided, never a first-listed default.
+            resolution = {
+                "verdict": "undecided",
+                "prevailing_claim": None,
+                "prevailing_strength": None,
+                "margin": margin,
+                "criterion": "qbaf_computed_strength",
+                "reason": "margin below floor — sides not meaningfully separated",
+            }
+        else:
+            resolution = {
+                "verdict": "decided",
+                "prevailing_claim": top["id"],
+                "prevailing_strength": top["computed_strength"],
+                "margin": margin,
+                "criterion": "qbaf_computed_strength",
+            }
 
     qbaf = {
         "graph": {

--- a/scripts/test_enrich_conflicts_qbaf.py
+++ b/scripts/test_enrich_conflicts_qbaf.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+"""Neutrality tests for _finalize_qbaf's resolution margin floor (t/3151).
+
+CL neutrality ruling (t/3151#2): a top-runner-up computed_strength gap below
+QBAF_MARGIN_FLOOR (0.05) is not a meaningful separation, so the resolution is an
+explicit `undecided` with `prevailing_claim: null` -- never the first-listed
+default the stable sort used to crown on a perfect tie. Runs under pytest or
+standalone: `python test_enrich_conflicts_qbaf.py`.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import enrich_conflicts_qbaf as eq  # noqa: E402
+
+
+def _finalize(strengths):
+    """Run _finalize_qbaf over two instances with the given computed strengths."""
+    pre = {
+        "qbaf_nodes_output": [
+            {"id": "inst-0", "computed_strength": 0.0},
+            {"id": "inst-1", "computed_strength": 0.0},
+        ],
+        "edge_output": [],
+    }
+    bridge_result = {"strengths": strengths, "iterations": 1}
+    return eq._finalize_qbaf(pre, bridge_result)["resolution"]
+
+
+def test_margin_at_or_above_floor_is_decided():
+    r = _finalize({"inst-0": 0.90, "inst-1": 0.20})
+    assert r["verdict"] == "decided"
+    assert r["prevailing_claim"] == "inst-0"
+    assert r["prevailing_strength"] == 0.90
+    assert r["margin"] == 0.70
+
+
+def test_margin_below_floor_is_undecided_not_first_listed():
+    r = _finalize({"inst-0": 0.50, "inst-1": 0.48})  # margin 0.02 < 0.05
+    assert r["verdict"] == "undecided"
+    assert r["prevailing_claim"] is None
+    assert r["prevailing_strength"] is None
+    assert r["margin"] == 0.02
+    assert "floor" in r["reason"]
+
+
+def test_perfect_tie_is_undecided_not_inst_0():
+    # The original defect: Python's stable sort silently crowned the first-listed
+    # instance (inst-0) with margin 0.0. It must now be an explicit undecided.
+    r = _finalize({"inst-0": 0.50, "inst-1": 0.50})
+    assert r["verdict"] == "undecided"
+    assert r["prevailing_claim"] is None
+    assert r["margin"] == 0.0
+
+
+def test_floor_boundary_exactly_005_is_decided():
+    # margin == floor is decided (strict `<` gates undecided).
+    r = _finalize({"inst-0": 0.55, "inst-1": 0.50})  # margin exactly 0.05
+    assert r["margin"] == 0.05
+    assert r["verdict"] == "decided"
+    assert r["prevailing_claim"] == "inst-0"
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

t/3151 Part 1 (the sole remaining code change). Fixes the QBAF conflict-module neutrality defect from the t/3100 audit: `_finalize_qbaf` sorted instances by DF-QuAD `computed_strength` and unconditionally crowned `sorted_nodes[0]` as `prevailing_claim` — so Python's **stable sort silently declared the first-listed instance the winner on a perfect tie** (`margin: 0.0`), with no `undecided` outcome.

## Change (per CL neutrality ruling t/3151#2)

Add `QBAF_MARGIN_FLOOR = 0.05`. In `_finalize_qbaf`:
- `margin < 0.05` → explicit undecided: `{verdict: "undecided", prevailing_claim: null, prevailing_strength: null, margin, criterion, reason}` (mirrors the crux layer's `undecided`). **No first-listed default, ever.**
- `margin >= 0.05` → existing shape + `verdict: "decided"` for symmetry.

Rationale (CL): `computed_strength` is DF-QuAD in [0,1]; a top−runner-up gap < 0.05 means the sides are not meaningfully separated, so first-listed-wins is noise. Floor stipulated day-one (registered; derivation path is t/3152).

## Not in this PR

- **Part 2 (attack_weights register drift):** no code change — Decision A resolved to *code is authoritative* (`[1.0, 1.05, 1.1]` is the `c135624d`/t/244 calibration outcome). CL self-lands the register correction.
- **No `qbaf.ts` change.**

## Tests

`scripts/test_enrich_conflicts_qbaf.py` — 4 pytest cases: decided path, below-floor undecided, **perfect-tie undecided** (the original defect), exact-0.05 boundary (decided). 4/4 pass.

## Review

**CL reviews the neutrality semantics on this PR** (verdict shape + floor behavior).

Refs t/3151, t/3100#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)