### PR TITLE
docs(cl): attack_weights → runtime [1.0, 1.05, 1.1] + derived reclass (t/3151 Decision A)

### DIFF
--- a/docs/debate-system-overview.md
+++ b/docs/debate-system-overview.md
@@ -1103,7 +1103,7 @@ Each debate logs a `CalibrationDataPoint` (~1KB) with metrics from existing inst
 |---|-----------|---------|-----------|-------------|
 | 1 | `exploration_exit` | 0.65 | Bucket-average quality | Neutral evaluator |
 | 2 | `relevance_threshold` | 0.45 | Directional (waste/miss rate) | Context injection manifest |
-| 3 | `attack_weights` | [1.0, 1.1, 1.2] | Concordance maximization | QBAF vs synthesis preferences |
+| 3 | `attack_weights` | [1.0, 1.05, 1.1] | Concordance maximization | QBAF vs synthesis preferences |
 | 4 | `draft_temperature` | 0.7 | Composite cost minimization | Turn validator errors |
 | 5 | `saturation_weights` | 6 weights | OLS regression | Convergence signals vs quality |
 | 6 | `recent_window` | 8 | Directional (forgotten rate) | Unanswered claims ledger |

--- a/research/comp-linguist/docs/metric-provenance-register.md
+++ b/research/comp-linguist/docs/metric-provenance-register.md
@@ -40,7 +40,7 @@ The honest summary: nearly every judgment-bearing number in the system is curren
 | `relevance_threshold` (0.48 base) | **derived** | Pairwise cosine-distribution analysis over 1,182 nodes (2026-05): 0.3 admitted 93.3% of pairs; 0.48 ≈ 65%. Self-tunes ±0.02–0.03 in [0.35, 0.60] from utilization telemetry (`calibrationOptimizer.ts`). | 2026-05 |
 | `argumentation_exit_threshold` | stipulated | Optimizer produces recommend-only adjustments from quality score; not auto-applied. | — |
 | `qbaf_damping_level` | **derived** | Raised in response to observed oscillation telemetry (`qbaf_oscillation_*`). | 2026-06 |
-| `attack_weights` [1.0, 1.1, 1.2] | stipulated | Rebut/undercut/undermine escalation asserted. Named validation path: gradient-learned edge weights from a labeled outcome set (Gradual AA-CBR, t/3023). | — |
+| `attack_weights` [1.0, 1.05, 1.1] | **derived** | Rebut/undercut/undermine escalation; values are a concordance-max fit against synthesis preferences (`provisional-weights.json`). Future validation path: gradient-learned edge weights from a labeled outcome set (Gradual AA-CBR, t/3023). | c135624d / t/244 |
 | `draft_temperature` (0.7) | stipulated | Informed by the temperature-per-task audit but no formal optimization. | — |
 | `argumentative_saturation_weights` | stipulated | Composite signal weights asserted. | — |
 | `semantic_recycling_threshold` | stipulated | | — |


### PR DESCRIPTION
**t/3151 Decision A** (CL self-landed doc edit; Shared Lib delegated p/3#172).

Runtime `DEFAULT_ATTACK_WEIGHTS` (`lib/debate/qbaf.ts:64-68`) = {rebut:1.0, undercut:1.05, undermine:1.1} = **[1.0, 1.05, 1.1]**. Two docs carried a stale **[1.0, 1.1, 1.2]**:
- `docs/debate-system-overview.md:1106`
- `research/comp-linguist/docs/metric-provenance-register.md:43`

Both corrected to match code. Register row reclassified **stipulated → derived** (concordance-max fit vs synthesis preferences, `provisional-weights.json`; evidence c135624d / t/244).

Doc-accuracy only — **no code change** (code was already correct; docs were stale). Verified no other stale refs across `*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)