### PR TITLE
feat(server): /readyz RESOLUTION gate + large-recompute WARN (t/3165)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingsCache.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingsCache.test.ts
@@ -78,7 +78,7 @@ vi.mock('../../../../lib/ai-client/index.js', async (importActual) => {
 
 // ── Imports after mocks ───────────────────────────────────────────────────────
 
-import { prewarmEmbeddingsCache, _resetEmbeddingsCacheForTest } from '../ai/aiBackends.js';
+import { prewarmEmbeddingsCache, _resetEmbeddingsCacheForTest, getEmbeddingsResolution, EMBEDDINGS_RESOLUTION_CANARY } from '../ai/aiBackends.js';
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
@@ -133,5 +133,50 @@ describe('embeddingsCache async hydration (t/3085)', () => {
     readDataFileMock.mockClear();
     await prewarmEmbeddingsCache();
     expect(readDataFileMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// t/3165 — getEmbeddingsResolution: presence != resolution. Asserts the canary keyed lookup
+// hits a REAL EMBEDDING_DIM vector; a present-but-non-resolving cache (canary absent, or its
+// vector empty/wrong-dim) → resolves:false. This is the /readyz + deploy-gate resolution core.
+const withCanary = (vector: number[]) => JSON.stringify({
+  model: 'all-MiniLM-L6-v2', dimension: 384, node_count: 2,
+  nodes: { [EMBEDDINGS_RESOLUTION_CANARY]: { vector }, 'saf-beliefs-001': { vector } },
+});
+const VALID_384 = Array.from({ length: 384 }, (_v, i) => (i % 7) * 0.01 + 0.001); // non-zero, 384-dim
+
+describe('getEmbeddingsResolution (t/3165)', () => {
+  beforeEach(() => { _resetEmbeddingsCacheForTest(); readDataFileMock.mockReset(); });
+
+  it('resolves:true when the canary node has a real 384-dim non-zero vector', async () => {
+    readDataFileMock.mockResolvedValue(Buffer.from(withCanary(VALID_384)));
+    await prewarmEmbeddingsCache();
+    const r = getEmbeddingsResolution();
+    expect(r.present).toBe(true);
+    expect(r.resolves).toBe(true);
+    expect(r.canaryId).toBe(EMBEDDINGS_RESOLUTION_CANARY);
+  });
+
+  it('resolves:false when the canary is ABSENT though the cache is loaded (stale/wrong corpus)', async () => {
+    readDataFileMock.mockResolvedValue(Buffer.from(JSON.stringify({
+      model: 'x', dimension: 384, node_count: 1, nodes: { 'some-other-001': { vector: VALID_384 } },
+    })));
+    await prewarmEmbeddingsCache();
+    const r = getEmbeddingsResolution();
+    expect(r.present).toBe(true);       // cache loaded (nodeCount>0)
+    expect(r.nodeCount).toBe(1);
+    expect(r.resolves).toBe(false);     // but the expected canary doesn't resolve
+  });
+
+  it('resolves:false when the canary vector is the wrong dimension', async () => {
+    readDataFileMock.mockResolvedValue(Buffer.from(withCanary([0.1, 0.2, 0.3])));
+    await prewarmEmbeddingsCache();
+    expect(getEmbeddingsResolution().resolves).toBe(false);
+  });
+
+  it('resolves:false + present:false when the cache never loaded', () => {
+    const r = getEmbeddingsResolution();
+    expect(r.present).toBe(false);
+    expect(r.resolves).toBe(false);
   });
 });

--- a/taxonomy-editor/src/server/__tests__/fixtures/readyz-ready-body.json
+++ b/taxonomy-editor/src/server/__tests__/fixtures/readyz-ready-body.json
@@ -1,1 +1,1 @@
-{"status":"ready","nodeCount":4144}
+{"status":"ready","nodeCount":4144,"resolves":true}

--- a/taxonomy-editor/src/server/__tests__/readyz.test.ts
+++ b/taxonomy-editor/src/server/__tests__/readyz.test.ts
@@ -33,44 +33,52 @@ describe('publicPaths — /readyz', () => {
 });
 
 // ── handler response shape (inline simulation) ───────────────────────────────
-// The route handler is a thin conditional over getEmbeddingsCacheStatus(). We test the
+// The route handler is a thin conditional over getEmbeddingsResolution(). We test the
 // output the conditional produces rather than importing meta.ts (which pulls heavy deps).
 // Keep this in lockstep with the handler in routes/meta.ts.
+// t/3165: 200 now requires RESOLUTION (a canary keyed lookup hits a real vector), not mere
+// presence — a present-but-non-resolving cache (stale/wrong corpus) → 503.
 
-type CacheStatus = { present: boolean; nodeCount: number | null };
+const CANARY = 'acc-beliefs-003';
+type Resolution = { present: boolean; nodeCount: number | null; resolves: boolean };
 type HandlerResult = { statusCode: number; body: Record<string, unknown> };
 
-function simulateReadyz(status: CacheStatus): HandlerResult {
-  const { present, nodeCount } = status;
-  if (present && (nodeCount ?? 0) > 0) {
-    return { statusCode: 200, body: { status: 'ready', nodeCount } };
+function simulateReadyz(r: Resolution): HandlerResult {
+  const { present, nodeCount, resolves } = r;
+  if (present && (nodeCount ?? 0) > 0 && resolves) {
+    return { statusCode: 200, body: { status: 'ready', nodeCount, resolves: true } };
   }
-  return { statusCode: 503, body: { status: 'warming', present, nodeCount } };
+  const reason = !present ? 'cache-absent' : !resolves ? 'canary-not-resolving' : 'empty';
+  return { statusCode: 503, body: { status: 'warming', present, nodeCount, resolves: false, reason, canary: CANARY } };
 }
 
-describe('GET /readyz — response shape (t/3112)', () => {
-  it('200 { status: ready, nodeCount } when cache present with nodeCount>0', () => {
-    const { statusCode, body } = simulateReadyz({ present: true, nodeCount: 4144 });
+describe('GET /readyz — response shape (t/3112, t/3165 resolution)', () => {
+  it('200 { status: ready, nodeCount, resolves } when present, nodeCount>0 AND canary resolves', () => {
+    const { statusCode, body } = simulateReadyz({ present: true, nodeCount: 4144, resolves: true });
     expect(statusCode).toBe(200);
-    expect(body).toEqual({ status: 'ready', nodeCount: 4144 });
+    expect(body).toEqual({ status: 'ready', nodeCount: 4144, resolves: true });
+  });
+
+  it('t/3165: 503 when cache present + nodeCount>0 but the canary does NOT resolve (stale/wrong corpus)', () => {
+    const { statusCode, body } = simulateReadyz({ present: true, nodeCount: 4144, resolves: false });
+    expect(statusCode).toBe(503);
+    expect(body.status).toBe('warming');
+    expect(body.resolves).toBe(false);
+    expect(body.reason).toBe('canary-not-resolving');
   });
 
   it('503 while warming when cache absent', () => {
-    const { statusCode, body } = simulateReadyz({ present: false, nodeCount: null });
+    const { statusCode, body } = simulateReadyz({ present: false, nodeCount: null, resolves: false });
     expect(statusCode).toBe(503);
     expect(body.status).toBe('warming');
     expect(body.present).toBe(false);
+    expect(body.reason).toBe('cache-absent');
   });
 
   it('503 when present but nodeCount is 0 (empty/partial cache is not ready)', () => {
-    const { statusCode, body } = simulateReadyz({ present: true, nodeCount: 0 });
+    const { statusCode, body } = simulateReadyz({ present: true, nodeCount: 0, resolves: false });
     expect(statusCode).toBe(503);
     expect(body.status).toBe('warming');
-  });
-
-  it('503 when present but nodeCount is null (guards the ?? 0 branch)', () => {
-    const { statusCode } = simulateReadyz({ present: true, nodeCount: null });
-    expect(statusCode).toBe(503);
   });
 });
 
@@ -85,12 +93,13 @@ describe('GET /readyz — response shape (t/3112)', () => {
 // or in the Pester (gate parses the old key, gets a non-'ready' body → wait).
 describe('/readyz shared body-contract fixture (t/3114)', () => {
   it('fixture equals the handler\'s real 200 ready body (producer-side pin)', () => {
-    const real = simulateReadyz({ present: true, nodeCount: readyBody.nodeCount }).body;
+    const real = simulateReadyz({ present: true, nodeCount: readyBody.nodeCount, resolves: true }).body;
     expect(real).toEqual(readyBody);
   });
 
-  it('fixture carries the contract invariant the gate keys on: status==="ready", nodeCount>0', () => {
+  it('fixture carries the contract invariants the gate keys on: status==="ready", nodeCount>0, resolves===true', () => {
     expect(readyBody.status).toBe('ready');
     expect(readyBody.nodeCount).toBeGreaterThan(0);
+    expect(readyBody.resolves).toBe(true); // t/3165: resolution is now part of the 200 contract
   });
 });

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -597,6 +597,31 @@ export function getEmbeddingsCacheStatus(): { present: boolean; nodeCount: numbe
   return { present: true, nodeCount: Object.keys(embeddingsCache.nodes ?? {}).length };
 }
 
+/** t/3165: a stable core POV belief node used as the /readyz + deploy-gate RESOLUTION canary.
+ *  If the taxonomy ever legitimately drops it, update this one constant (the resolution check
+ *  will otherwise false-fail; corpusNodeCount>0 distinguishes that config case from a dead cache). */
+export const EMBEDDINGS_RESOLUTION_CANARY = 'acc-beliefs-003';
+const EMBEDDING_DIM = 384; // all-MiniLM-L6-v2
+
+/**
+ * t/3165: RESOLUTION probe (presence != resolution). The t/3165 class is a cache that is
+ * present (nodeCount>0) but doesn't actually resolve a keyed lookup at runtime (stale/wrong
+ * corpus, or empty/corrupt vectors). Asserts the canary id resolves to a real EMBEDDING_DIM
+ * vector — the SAME `nodes[id].vector` lookup the compute path uses (embeddingResolver.ts),
+ * so /readyz gates on the real resolve path, not mere file presence. `/readyz` and DevOps2's
+ * deploy gate (t/3091) share this single predicate.
+ */
+export function getEmbeddingsResolution(): {
+  present: boolean; nodeCount: number | null; resolves: boolean; canaryId: string;
+} {
+  const cache = embeddingsCache;
+  const present = !!(cache && cache.nodes && Object.keys(cache.nodes).length > 0);
+  const nodeCount = cache ? Object.keys(cache.nodes ?? {}).length : null;
+  const vec = cache?.nodes?.[EMBEDDINGS_RESOLUTION_CANARY]?.vector;
+  const resolves = present && Array.isArray(vec) && vec.length === EMBEDDING_DIM && vec.some((v) => v !== 0);
+  return { present, nodeCount, resolves, canaryId: EMBEDDINGS_RESOLUTION_CANARY };
+}
+
 /** Reset the embeddings cache — test isolation only. */
 export function _resetEmbeddingsCacheForTest(): void {
   embeddingsCache = null;

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -536,6 +536,10 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
   // Invariant: MAX_EMBED_BATCH must be ≥ the client's chunk size (currently 512 per t/3072).
   // A server cap below the client chunk size would 413 every legitimate request.
   const MAX_EMBED_BATCH = 512;
+  // t/3165: a fully-recomputed batch at/above this size is flagged as a volume event (novel
+  // no-ids text). ≥64 catches the ~200/792 debate grounding batches; below it, small ad-hoc
+  // computes stay silent (TL p/522#111 threshold guidance).
+  const LARGE_RECOMPUTE_WARN_ITEMS = 64;
 
   post('/api/embeddings/compute', (req, res, body) => withEndpointTimeout(res, 50_000, 'embeddings-compute', async () => {
     const { texts, ids } = body as { texts: string[]; ids?: string[] };
@@ -600,6 +604,21 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
             data: { cache_hits: cacheHits, cache_misses: cacheMisses, item_count: texts.length, request_id: getRequestId() },
           });
           log.api.warn({ component: 'embeddings-compute', cache_hits: cacheHits, cache_misses: cacheMisses, item_count: texts.length, request_id: getRequestId() }, missMsg);
+        }
+        // t/3165 (TL p/522#111): the keyed-miss WARN above is ids-gated, so it MISSES the actual
+        // t/3165 mechanism — a large batch of NOVEL, no-ids text (frames/paras/claims) that
+        // legitimately re-computes (correct-miss → VOLUME, ties t/2977). Flag that volume case:
+        // a big batch (≥ LARGE_RECOMPUTE_WARN_ITEMS) that fully re-computes (cacheHits==0),
+        // regardless of ids. Threshold ≥64 catches the ~200/792 debate batches but stays silent
+        // on small legit ad-hoc computes (both arms — TL GV condition).
+        if (texts.length >= LARGE_RECOMPUTE_WARN_ITEMS && cacheHits === 0) {
+          const volMsg = `embeddings.compute: large no-cache recompute — ${texts.length} texts, 0 cache hits (${ids ? 'keyed but unresolved' : 'novel no-ids text — volume, not a cache miss'})`;
+          getGlobalRecorder()?.record({
+            type: 'system.error', component: 'embeddings-compute', level: 'warn',
+            message: volMsg,
+            data: { item_count: texts.length, cache_hits: 0, has_ids: !!ids, request_id: getRequestId() },
+          });
+          log.api.warn({ component: 'embeddings-compute', item_count: texts.length, cache_hits: 0, has_ids: !!ids, request_id: getRequestId() }, volMsg);
         }
         // t/3165: expose cacheHits/cacheMisses + corpusNodeCount so the t/3091 resolution gate
         // (DevOps 2) can (1) assert a canary keyed lookup actually HITS the cache — presence≠resolution —

--- a/taxonomy-editor/src/server/routes/meta.ts
+++ b/taxonomy-editor/src/server/routes/meta.ts
@@ -19,7 +19,7 @@ import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import { getProjectRoot, getDataRoot, hasApiKey, STORAGE_MODE } from '../config.js';
 import { getConfig } from '../runtimeConfig.js';
 import * as proxyTiers from '../ai/proxyTiers.js';
-import { getEmbeddingsCacheStatus } from '../ai/aiBackends.js';
+import { getEmbeddingsCacheStatus, getEmbeddingsResolution } from '../ai/aiBackends.js';
 import * as community from '../community/community.js';
 import * as fileIO from '../storage/fileIO.js';
 import { log } from '../logger.js';
@@ -81,20 +81,23 @@ export function registerMetaRoutes(r: Router, ctx: ServerCtx): void {
     json(res, { status: 'unhealthy', state: readiness.state, reason: readiness.reason, dataRoot }, 503);
   });
 
-  // t/3112: deploy warm-gate. Constraint #1 (t/3090#11): no traffic to an un-warmed
-  // revision. /healthz gates on DATA load only; the embeddings.json cache is pre-warmed
-  // fire-and-forget (server.ts), so a revision can be /healthz-ready while debates would
-  // still re-embed ~3600 texts. /readyz reports 200 ONLY when the precomputed-vector cache
-  // is loaded (present AND nodeCount>0); the ACA deploy gate polls it and blocks the
-  // traffic-shift until 200. Distinct from /api/health/embeddings (that reflects the ONNX
-  // model warmup, not this cache). Anon (PUBLIC_EXACT_PATHS) so the pre-auth probe reaches it.
+  // t/3112/t/3165: deploy warm-gate + RESOLUTION gate. Constraint #1 (t/3090#11): no traffic
+  // to an un-warmed revision. /healthz gates on DATA load only; the embeddings.json cache is
+  // pre-warmed fire-and-forget (server.ts). t/3165 hardened this from PRESENCE to RESOLUTION:
+  // a cache can be present (nodeCount>0) yet not resolve a keyed lookup at runtime (stale/wrong
+  // corpus, empty/corrupt vectors) — the t/3165 class that mere-presence let through the gate.
+  // /readyz now returns 200 ONLY when a canary keyed lookup RESOLVES to a real vector via the
+  // same nodes[id].vector path the compute path uses. Single shared predicate: the ACA warm-gate
+  // AND DevOps2's resolution deploy-gate (t/3091) both poll GET /readyz — status code 503 = block,
+  // no auth (PUBLIC_EXACT_PATHS, anon). Distinct from /api/health/embeddings (ONNX model warmup).
   get('/readyz', (_req, res) => {
-    const { present, nodeCount } = getEmbeddingsCacheStatus();
-    if (present && (nodeCount ?? 0) > 0) {
-      json(res, { status: 'ready', nodeCount });
+    const { present, nodeCount, resolves, canaryId } = getEmbeddingsResolution();
+    if (present && (nodeCount ?? 0) > 0 && resolves) {
+      json(res, { status: 'ready', nodeCount, resolves: true });
       return;
     }
-    json(res, { status: 'warming', present, nodeCount }, 503);
+    const reason = !present ? 'cache-absent' : !resolves ? 'canary-not-resolving' : 'empty';
+    json(res, { status: 'warming', present, nodeCount, resolves: false, reason, canary: canaryId }, 503);
   });
 
   get('/health', async (_req, res) => {


### PR DESCRIPTION
Hardens `/readyz` from PRESENCE to RESOLUTION (the t/3165 class: cache present but not resolving at runtime) + adds the volume WARN. TL-approved in-thread (p/522); shape confirmed with DevOps2 (p/555).

## Changes
- **`getEmbeddingsResolution()`** (aiBackends.ts) — asserts a canary node-id (`acc-beliefs-003`) resolves to a real 384-dim non-zero vector via the same `nodes[id].vector` path the compute path uses. The single shared resolution predicate.
- **`/readyz`** (meta.ts) — 200 `{status:"ready",nodeCount,resolves:true}` only when the canary resolves; else 503 `{status:"warming",resolves:false,reason}`. Both the ACA warm-gate AND DevOps2's resolution deploy-gate (t/3091) poll `GET /readyz` (status 503=block, no auth — public path). **Resolves DevOps2's Easy-Auth wall** (their gate was probing the auth-walled compute POST). Shared fixture updated to include `resolves:true`.
- **large-recompute WARN** (ai.ts) — fires when `item_count ≥ 64 AND cacheHits==0` (any ids), so the NOVEL no-ids volume case (the real t/3165 mechanism, ties t/2977) is greppable — the ids-gated keyed-miss WARN alone missed it (TL p/522#111).

## Tests (19/19)
`readyz.test.ts` (resolution both arms + 503 canary-not-resolving); `embeddingsCache` `getEmbeddingsResolution` (canary hits real vector → true; absent / wrong-dim / unloaded → false).

## Gate
Gate-touching (deploy/warm-gate predicate) → **Main (TL) GV**. Consumers: DevOps2 points t/3091 at `/readyz`; warm-gate flip predicate (#1689, `status=='ready'`) unaffected (extra field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)