### PR TITLE
fix(debate): WARN when TAVILY_API_KEY unset in generateTextWithSearch (t/3177)

### DIFF
--- a/lib/debate/aiAdapter.test.ts
+++ b/lib/debate/aiAdapter.test.ts
@@ -81,6 +81,14 @@ function zaiOkBody(text = 'Hello from Z.AI') {
   };
 }
 
+// ── Mock flight recorder ─────────────────────────────────
+
+const { mockRecord } = vi.hoisted(() => ({ mockRecord: vi.fn() }));
+
+vi.mock('../flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: mockRecord }),
+}));
+
 // ── Mock fs to control registry loading ─────────────────
 
 const mockExistsSync = vi.fn();
@@ -132,6 +140,7 @@ beforeEach(() => {
   mockFetch.mockReset();
   mockExistsSync.mockReset();
   mockReadFileSync.mockReset();
+  mockRecord.mockReset();
 
   mockExistsSync.mockReturnValue(true);
   mockReadFileSync.mockReturnValue(JSON.stringify(makeRegistry()));
@@ -1021,6 +1030,35 @@ describe('aiAdapter', () => {
       const mod = await getModule();
       const adapter = mod.createCLIAdapter('/fake/root');
       expect(adapter.generateTextWithSearch).toBeTypeOf('function');
+    });
+  });
+
+  // ── generateTextWithSearch fallback logging ───────────
+
+  describe('generateTextWithSearch — no-Tavily WARN', () => {
+    async function getModule() {
+      vi.resetModules();
+      return import('./aiAdapter.js');
+    }
+
+    it('emits ai.fallback WARN when TAVILY_API_KEY is unset and backend is non-gemini', async () => {
+      process.env.GROQ_API_KEY = 'test-key';
+      delete process.env.TAVILY_API_KEY;
+      mockFetch.mockImplementation(async () => freshResponse(groqOkBody('result'), 200));
+
+      const mod = await getModule();
+      const adapter = mod.createCLIAdapter('/fake/root');
+      const result = await adapter.generateTextWithSearch('test prompt', 'groq-llama-3.3-70b-versatile');
+
+      expect(result.text).toBe('result');
+      const warnCall = mockRecord.mock.calls.find(
+        (c: unknown[]) => (c[0] as { level?: string })?.level === 'warn' &&
+          (c[0] as { message?: string })?.message?.includes('TAVILY_API_KEY not set'),
+      );
+      expect(warnCall).toBeDefined();
+      expect((warnCall![0] as { type: string }).type).toBe('ai.fallback');
+      expect((warnCall![0] as { message: string }).message).toContain('model=groq-llama-3.3-70b-versatile');
+      expect((warnCall![0] as { message: string }).message).toContain('backend=groq');
     });
   });
 

--- a/lib/debate/aiAdapter.ts
+++ b/lib/debate/aiAdapter.ts
@@ -476,6 +476,8 @@ export function createCLIAdapter(repoRoot: string, explicitApiKey?: string): Ext
         return { text, searchQueries: searchQueries.length ? searchQueries : undefined, citations: citations.length ? citations : undefined };
       }
 
+      // t/3177: Fallback-Path Logging — TAVILY_API_KEY absent, no search available
+      getGlobalRecorder()?.record({ type: 'ai.fallback', component: 'ai-adapter', level: 'warn', message: `generateTextWithSearch: TAVILY_API_KEY not set — returning plain generation (no search). model=${resolved} backend=${backend}` });
       const text = await doGenerateText(prompt, resolved);
       return { text };
     },


### PR DESCRIPTION
## Summary

- Adds `ai.fallback` WARN via flight recorder in `generateTextWithSearch` when `TAVILY_API_KEY` is absent and backend is non-Gemini — previously silent
- Records `model` and `backend` in the warn message per the Fallback-Path Logging rule (`docs/error-handling.md`)
- Test asserts the warn fires with correct `type`, `level`, `model`, and `backend` when key is unset

Self-cert: /trivial-change — ≤50 lines, single scope, no new exports or interface changes (t/3177#1).

## Test plan

- [x] `npx vitest run aiAdapter.test.ts` — 66/66 passed at af336792
- [x] New test: `generateTextWithSearch — no-Tavily WARN` asserts warn fires when `TAVILY_API_KEY` unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxTgvajJ6AtoqBLufJbQSr