### PR TITLE
fix(ai-client): log Ollama→cloud silent fallback (Fallback-Path Logging) (t/3178)

### DIFF
--- a/lib/ai-client/modelRouter.test.ts
+++ b/lib/ai-client/modelRouter.test.ts
@@ -1,9 +1,21 @@
 ﻿// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { describe, it, expect } from 'vitest';
-import { resolveMultiProviderModels } from './modelRouter.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolveMultiProviderModels, resolveModelForPurpose, probeOllama, TaskTier } from './modelRouter.js';
 import type { ModelRegistry } from './registry.js';
+import type { FetchFn } from './types.js';
+
+// ── Mocks for the Ollama-fallback logging tests (t/3178) ────────────────────
+const mockIsOllamaAvailable = vi.fn();
+const mockRecord = vi.fn();
+
+vi.mock('./providers/ollama.js', () => ({
+  isOllamaAvailable: (...args: unknown[]) => mockIsOllamaAvailable(...args),
+}));
+vi.mock('../flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: mockRecord }),
+}));
 
 const TEST_REGISTRY: ModelRegistry = {
   backends: [],
@@ -105,5 +117,57 @@ describe('resolveMultiProviderModels', () => {
     for (const m of models) {
       expect(m).not.toBe('claude-haiku-4-5');
     }
+  });
+});
+
+describe('resolveModelForPurpose — Ollama→cloud fallback logging (t/3178)', () => {
+  const fakeFetch = (() => Promise.resolve(undefined)) as unknown as FetchFn;
+
+  beforeEach(async () => {
+    // Baseline every test as "Ollama available" so state + the warn-once gate start clean.
+    mockRecord.mockClear();
+    mockIsOllamaAvailable.mockReset().mockResolvedValue(true);
+    await probeOllama(fakeFetch);
+    mockRecord.mockClear();
+  });
+
+  it('emits an ai.fallback WARN with purpose + substituted model when Ollama is unavailable', async () => {
+    mockIsOllamaAvailable.mockResolvedValue(false);
+    await probeOllama(fakeFetch);
+
+    const routed = await resolveModelForPurpose('summarization');
+    expect(routed).toMatchObject({ model: 'gemini-3.5-flash-lite', isLocal: false, tier: TaskTier.LOCAL, purpose: 'summarization' });
+
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+    const ev = mockRecord.mock.calls[0][0];
+    expect(ev.type).toBe('ai.fallback');
+    expect(ev.level).toBe('warn');
+    expect(ev.data).toMatchObject({ purpose: 'summarization', substitutedModel: 'gemini-3.5-flash-lite', reason: 'ollama_unavailable' });
+  });
+
+  it('warns once per unavailable episode, not on every routed call', async () => {
+    mockIsOllamaAvailable.mockResolvedValue(false);
+    await probeOllama(fakeFetch);
+    await resolveModelForPurpose('summarization');
+    await resolveModelForPurpose('fallacy_analysis');
+    expect(mockRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn when Ollama is available (local route taken)', async () => {
+    const routed = await resolveModelForPurpose('summarization');
+    expect(routed).toMatchObject({ model: 'ollama-gemma4-e4b', isLocal: true });
+    expect(mockRecord).not.toHaveBeenCalled();
+  });
+
+  it('re-arms the warning after a fresh probe (new outage episode)', async () => {
+    mockIsOllamaAvailable.mockResolvedValue(false);
+    await probeOllama(fakeFetch);
+    await resolveModelForPurpose('summarization'); // episode 1 → warn
+    mockIsOllamaAvailable.mockResolvedValue(true);
+    await probeOllama(fakeFetch);                  // recovery re-arms the gate
+    mockIsOllamaAvailable.mockResolvedValue(false);
+    await probeOllama(fakeFetch);                  // episode 2
+    await resolveModelForPurpose('summarization'); // → warn again
+    expect(mockRecord).toHaveBeenCalledTimes(2);
   });
 });

--- a/lib/ai-client/modelRouter.ts
+++ b/lib/ai-client/modelRouter.ts
@@ -11,6 +11,7 @@ import type { FetchFn } from './types.js';
 import type { ModelRegistry } from './registry.js';
 import { isOllamaAvailable } from './providers/ollama.js';
 import { ActionableError } from '../debate/errors.js';
+import { getGlobalRecorder } from '../flight-recorder/index.js';
 
 // ── Task tiers ───────────────────────────────────────────
 
@@ -108,6 +109,10 @@ const DEFAULT_ROUTER_CONFIG: RouterConfig = {
 
 let _ollamaAvailable: boolean | null = null;
 let _config: RouterConfig = { ...DEFAULT_ROUTER_CONFIG };
+// Warn-once gate for the Ollama→cloud fallback (Fallback-Path Logging, t/3178): warn on the
+// first routed call of each unavailable episode, not on every call. A fresh probe restarts the
+// episode, so a later outage warns again.
+let _ollamaFallbackWarned = false;
 
 /**
  * Probe Ollama availability and cache the result.
@@ -115,7 +120,25 @@ let _config: RouterConfig = { ...DEFAULT_ROUTER_CONFIG };
  */
 export async function probeOllama(fetchFn: FetchFn): Promise<boolean> {
   _ollamaAvailable = await isOllamaAvailable(fetchFn);
+  _ollamaFallbackWarned = false; // fresh probe → new episode; re-arm the fallback WARN
   return _ollamaAvailable;
+}
+
+/**
+ * Record the Ollama→cloud-fast fallback once per unavailable episode (Fallback-Path Logging,
+ * docs/error-handling.md). A caller expecting local inference (no quota cost, data stays local)
+ * silently gets cloud otherwise — the t/3165 class of invisible degradation.
+ */
+function warnOllamaFallbackOnce(purpose: TaskPurpose, substitutedModel: string): void {
+  if (_ollamaFallbackWarned) return;
+  _ollamaFallbackWarned = true;
+  getGlobalRecorder()?.record({
+    type: 'ai.fallback',
+    component: 'model-router',
+    level: 'warn',
+    message: 'Ollama unavailable — routing LOCAL-tier task to cloud fast',
+    data: { purpose, fromModel: _config.localModel, substitutedModel, reason: 'ollama_unavailable' },
+  });
 }
 
 /** Update router configuration. Merges with current config. */
@@ -172,7 +195,8 @@ export async function resolveModelForPurpose(
     if (_ollamaAvailable) {
       return { model: _config.localModel, tier, isLocal: true, purpose };
     }
-    // Fall through to cloud fast when Ollama unavailable
+    // Ollama unavailable — fall through to cloud fast, logging the degraded path (t/3178).
+    warnOllamaFallbackOnce(purpose, _config.cloudFastModel);
   }
 
   // Cloud routing by tier


### PR DESCRIPTION
## t/3178 — Fallback-Path Logging: modelRouter Ollama→cloud silent fallback

Back-fills the missing fallback log flagged in the t/3169#1 audit (finding 5). `resolveModelForPurpose` silently substituted the cloud-fast model for the local Ollama model when Ollama was unavailable — a caller expecting local inference (no quota cost, data stays local) got cloud with no observable signal.

### Change (`lib/ai-client/modelRouter.ts`)
- New private `warnOllamaFallbackOnce(purpose, substitutedModel)` emits an `ai.fallback` **WARN** via the flight recorder with `{ purpose, fromModel, substitutedModel, reason: 'ollama_unavailable' }`.
- Called at the local→cloud fall-through in the `TaskTier.LOCAL && preferLocal` branch.
- Warn-once per unavailable **episode**: a module gate suppresses repeats; `probeOllama` re-arms it on a fresh probe, so a later outage warns again.

### Tests (`lib/ai-client/modelRouter.test.ts`, +4)
warn fires with purpose + substituted model · warns once per episode · silent when Ollama is up (local route) · re-arms after recovery. All 14 in-file tests pass locally.

### Deviation from ticket text (flagged for review)
The ticket suggested a literal `console.warn(...)`. I used the **flight-recorder `ai.fallback` WARN** instead, because (a) docs/error-handling.md explicitly allows "a flight-recorder event," (b) the whole rationale is FR-greppability (a `console.warn` isn't greppable in FR dumps), and (c) it matches the established `ai-client` pattern (`embeddingResolver` uses `type: 'ai.fallback'`; `usageRegistry` uses `getGlobalRecorder`). Behaviorally equivalent WARN; asks-X-did-Y flagged per the Deviation rule.

**Gating:** draft pending **Quality (TL)** review — 94-line diff exceeds the /trivial-change self-cert cap and no exact pattern playbook fits (production + test). Framing/observability only; no public API, interface, schema, auth, or data-model change.

Closes t/3178.