### PR TITLE
fix(server/ai): EMBEDDING_COMPUTE_CHUNK 256→128 — interim liveness relief (t/3180)

### DIFF
--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -615,9 +615,12 @@ const EMBEDDINGS_REQUEST_TIMEOUT_MS = 45_000;
 // batch froze it ~46.8s → 500, past ACA's liveness deadline, and the t/2905 concurrency cap
 // can't catch a *single* request. Splitting the batch and yielding (setImmediate) between
 // chunks keeps the loop responsive to health checks + other work during a big compute.
-// TUNE from the first post-deploy large-compute trace (t/2904 loop-delay/heap observability);
-// 256 is the pre-calibration default.
-const EMBEDDING_COMPUTE_CHUNK = 256;
+// TUNE from the first post-deploy large-compute trace (t/2904 loop-delay/heap observability).
+// t/3180 (t/2977 Item A, interim relief): 256→128 — the t/3165 incident's novel-text batches
+// (~200/792) still blocked the loop enough to trip ACA liveness 503s at chunk=256; halving the
+// chunk yields the loop 2× as often between ONNX passes → fewer liveness 503s. Interim only
+// (reduces, doesn't eliminate — the durable fix is worker-offload, t/2977 Item B / t/3183).
+const EMBEDDING_COMPUTE_CHUNK = 128;
 
 // Resolve a (possibly large) batch in chunks, yielding the event loop between chunks. Safe
 // because resolveEmbeddings is order-preserving and per-text pure (local cache-hit or chain


### PR DESCRIPTION
**FAST-TRACK stopgap — users failing now** (TL p/522#113). t/2977 Item A.

One-line const: the t/3165 novel-text compute batches (~200/792) blocked the event loop long enough at chunk=256 to trip ACA liveness 503s. Halving to 128 yields the loop 2× as often between in-process ONNX passes → fewer liveness 503s. The t/2905 concurrency cap stays active for the concurrent-request case; this addresses the single-large-request case.

Interim only — reduces, doesn't eliminate. Durable fix = worker-offload (t/3183).

**Self-cert /trivial-change**: one-line const, single file, no API/schema/behavior-contract change. (Note: `embeddingsChunkYield.test.ts` fails to *collect* in an isolated worktree due to a `lib/` transitive dep — `decode-named-character-reference` — that resolves fine in CI's full install; unrelated to this const. `embeddingsBatchCapAnd503` passes 5/5 locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)