### PR TITLE
fix(ai): WARN on AIEnrich silent fallback paths (t/3179)

### DIFF
--- a/scripts/AIEnrich.psm1
+++ b/scripts/AIEnrich.psm1
@@ -120,6 +120,12 @@ if (Test-Path $_aiModelsPath) {
         Write-Warning "AIEnrich: failed to load ai-models.json — $($_.Exception.Message). Using hardcoded fallback."
     }
 }
+else {
+    # Fallback-Path Logging (docs/error-handling.md; t/3179 Finding 7): the file-not-found path is
+    # as anomalous as a parse failure (which warns above) — warn rather than silently dropping to
+    # the hardcoded registry, which may be stale relative to ai-models.json.
+    Write-Warning "AIEnrich: ai-models.json not found at any candidate path (last tried: $_aiModelsPath) — using hardcoded fallback model list (may be stale)."
+}
 
 # Fallback if ai-models.json missing or empty
 if ($script:ModelRegistry.Count -eq 0) {
@@ -281,7 +287,10 @@ function Measure-PromptTokens {
                 Accurate   = $true
             }
         } catch {
-            Write-Verbose "Measure-PromptTokens: Gemini countTokens failed — $($_.Exception.Message). Using heuristic."
+            # Fallback-Path Logging (docs/error-handling.md; t/3179 Finding 6): WARN, not Verbose.
+            # The pre-flight token-overflow check downstream depends on this count, so a silent
+            # heuristic undercount can suppress that warning — surface the degraded accuracy.
+            Write-Warning "Measure-PromptTokens: Gemini countTokens failed ($($_.Exception.Message)) — falling back to character heuristic (Accurate=`$false)"
         }
     }
 

--- a/tests/AIEnrich.FallbackLogging.Tests.ps1
+++ b/tests/AIEnrich.FallbackLogging.Tests.ps1
@@ -1,0 +1,62 @@
+# Tag: unit (t/3179)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    Fallback-Path Logging tests for AIEnrich.psm1 (t/3179) — both silent-fallback paths must
+    emit Write-Warning with the triggering condition (docs/error-handling.md).
+      Finding 6: Measure-PromptTokens — Gemini countTokens API failure -> character heuristic.
+      Finding 7: module load — ai-models.json absent at all candidate paths -> hardcoded registry.
+#>
+
+BeforeAll {
+    $script:ModulePath = (Resolve-Path (Join-Path $PSScriptRoot '..' 'scripts' 'AIEnrich.psm1')).Path
+    Import-Module $script:ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'AIEnrich fallback-path logging (t/3179)' -Tag 'unit' {
+
+    Context 'Finding 6 — Measure-PromptTokens countTokens failure -> heuristic' {
+        It 'emits Write-Warning (not just Verbose) and falls back to the heuristic when countTokens fails' {
+            Mock -ModuleName AIEnrich Resolve-AIApiKey { 'fake-gemini-key' }
+            Mock -ModuleName AIEnrich Invoke-RestMethod { throw 'HTTP 503 countTokens unavailable' }
+
+            $warn = @()
+            $r = Measure-PromptTokens -Text 'some prompt text to measure' -WarningVariable warn -WarningAction SilentlyContinue
+
+            # Fell back to the heuristic...
+            $r.Accurate | Should -BeFalse
+            $r.Method | Should -Match 'heuristic'
+            # ...and surfaced the degraded path as a WARNING naming the trigger.
+            ($warn -join ' ') | Should -Match 'countTokens failed'
+        }
+    }
+
+    Context 'Finding 7 — ai-models.json absent at all candidate paths -> hardcoded registry' {
+        It 'emits Write-Warning at module load when ai-models.json is not found' {
+            # Isolate a copy of the module in a deeply-nested temp dir so NONE of its three
+            # candidate paths (PSScriptRoot, its parent, its grandparent) contain ai-models.json,
+            # forcing the file-not-found branch to fire on import.
+            $iso = Join-Path $TestDrive ([guid]::NewGuid().ToString('N')) 'a' 'b'
+            New-Item -ItemType Directory -Path $iso -Force | Out-Null
+            $isoModule = Join-Path $iso 'AIEnrich.psm1'
+            Copy-Item -LiteralPath $script:ModulePath -Destination $isoModule
+
+            try {
+                # 3>&1 captures the warning stream emitted during module load (no success output
+                # without -PassThru, so only WarningRecords are collected).
+                $warns = @(Import-Module $isoModule -Force 3>&1)
+                $msg = ($warns | ForEach-Object { $_.ToString() }) -join ' '
+                $msg | Should -Match 'ai-models\.json not found'
+            }
+            finally {
+                Remove-Module AIEnrich -Force -ErrorAction SilentlyContinue
+                # Restore the real module for any later tests in the run.
+                Import-Module $script:ModulePath -Force -WarningAction SilentlyContinue
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

t/3179 — back-fill WARN logging on two silent/insufficient fallback paths in `scripts/AIEnrich.psm1` per the Fallback-Path Logging rule (docs/error-handling.md). Audit source: t/3169#1.

- **Finding 6 — `Measure-PromptTokens`:** Gemini `countTokens` API failure fell back to the character heuristic at `Write-Verbose` (invisible). The downstream pre-flight token-overflow check depends on this count, so a silent undercount can suppress that warning. → `Write-Warning` naming the trigger (`Accurate=$false`).
- **Finding 7 — module load:** when `ai-models.json` is absent from **all** candidate paths, the module silently used the hardcoded registry (the parse-failure path already warned; file-not-found did not). → symmetric `Write-Warning` on the `Test-Path` else branch. Adapted to the module's actual `ModelRegistry.Count`-based load state (no `_aiModelsLoaded` flag exists).

## Tests

`tests/AIEnrich.FallbackLogging.Tests.ps1` (2/2):
- Finding 6: mocked `Resolve-AIApiKey` + throwing `Invoke-RestMethod` → asserts the warning fires and the heuristic result (`Accurate=$false`) is returned.
- Finding 7: imports an **isolated copy** of the module from a temp dir with no `ai-models.json` in any candidate path → asserts the load-time warning.

Both branches emit `Write-Warning` with the triggering condition (the AC). Self-cert: trivial logging change following the documented Fallback-Path Logging pattern; no API/signature/schema change.

Refs t/3179, t/3169#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)