### PR TITLE
fix(schema): conflict resolution — allow null prevailing_claim/strength + verdict/reason (t/3185, t/3151)

### DIFF
--- a/taxonomy/schemas/conflict.schema.json
+++ b/taxonomy/schemas/conflict.schema.json
@@ -284,16 +284,22 @@
         },
         "resolution": {
           "type": "object",
-          "description": "Optional: which claim prevails after QBAF computation.",
+          "description": "Optional: which claim prevails after QBAF computation. When the top−runner-up margin is below the margin floor (QBAF_MARGIN_FLOOR, t/3151), the sides are not meaningfully separated: verdict is 'undecided' and prevailing_claim/prevailing_strength are null.",
           "properties": {
-            "prevailing_claim": {
+            "verdict": {
               "type": "string",
-              "description": "ID of the claim with highest computed_strength."
+              "enum": ["decided", "undecided"],
+              "description": "Whether QBAF meaningfully separated the sides (t/3151). 'undecided' when the top−runner-up margin is below the margin floor; 'decided' otherwise."
+            },
+            "prevailing_claim": {
+              "type": ["string", "null"],
+              "description": "ID of the claim with highest computed_strength. null when verdict is 'undecided'."
             },
             "prevailing_strength": {
-              "type": "number",
+              "type": ["number", "null"],
               "minimum": 0.0,
-              "maximum": 1.0
+              "maximum": 1.0,
+              "description": "Computed strength of the prevailing claim. null when verdict is 'undecided'."
             },
             "margin": {
               "type": "number",
@@ -303,6 +309,10 @@
               "type": "string",
               "enum": ["qbaf_computed_strength"],
               "description": "Resolution method used."
+            },
+            "reason": {
+              "type": "string",
+              "description": "Human-readable explanation, present on the 'undecided' path (e.g. 'margin below floor — sides not meaningfully separated')."
             }
           }
         },


### PR DESCRIPTION
Fast-follow contract fix for **#1717** (already merged), which landed the QBAF margin-floor producer change **without** its schema — leaving `main` producer/contract-inconsistent (latent: fires whenever a conflict resolves with margin < QBAF_MARGIN_FLOOR=0.05).

## What #1717 now emits (undecided path)
```
{ verdict: "undecided", prevailing_claim: null, prevailing_strength: null, margin, criterion, reason }
```
…which `conflict.schema.json` rejected: `prevailing_claim` was `string`-only, `prevailing_strength` `number`-only, and `verdict`/`reason` undeclared.

## Change (taxonomy/schemas/conflict.schema.json — `resolution`)
- `prevailing_claim`: `"string"` → `["string","null"]`
- `prevailing_strength`: `"number"` → `["number","null"]` (min/max still bind on numbers; null exempt)
- add `verdict`: enum `["decided","undecided"]`
- add `reason`: string (undecided path)
- **decided path shape unchanged**

## Blast radius / why fix-forward, not revert
`validate-schemas.mjs` is report-only (no CI fail) and no undecided records exist until the next enrichment run, so `main` is not red — but the contract must be consistent before re-enrichment. Reverting #1717 would re-introduce the stable-sort tie-crowning neutrality defect for no urgent gain; the producer is correct, only the contract lagged.

Downstream (non-blocking): t/3186 (Rosetta TS types), t/3187 (Conflict UI).

**Cross-scope note:** `conflict.schema.json` is root-owned; authored by TL as a trivial data-contract fix-forward for a live inconsistency (contract-ownership remit). CL (filed t/3185, identified the gap) + neutrality sanity-check pending.

Closes t/3185.