### PR TITLE
fix(conflict): render explicit Undecided state when verdict===undecided (t/3187)

### DIFF
--- a/taxonomy-editor/src/renderer/components/conflict/ConflictDetail.tsx
+++ b/taxonomy-editor/src/renderer/components/conflict/ConflictDetail.tsx
@@ -802,8 +802,14 @@ function QbafConflictPanel({ qbaf }: { qbaf: ConflictQbaf }) {
         <div className="conflict-qbaf-resolution">
           <div className="conflict-qbaf-resolution-header">Resolution Analysis</div>
           <div className="conflict-qbaf-resolution-body">
-            <span>Prevailing: <strong>{graph.nodes.find(n => n.id === resolution.prevailing_claim)?.text.slice(0, 60) ?? resolution.prevailing_claim}</strong></span>
-            <span>Strength: {(resolution.prevailing_strength ?? 0).toFixed(2)} (margin: {(resolution.margin ?? 0).toFixed(2)})</span>
+            {resolution.verdict === 'undecided' ? (
+              <span><em>Undecided — sides not meaningfully separated (margin &lt; 0.05)</em></span>
+            ) : (
+              <>
+                <span>Prevailing: <strong>{graph.nodes.find(n => n.id === resolution.prevailing_claim)?.text.slice(0, 60) ?? resolution.prevailing_claim}</strong></span>
+                <span>Strength: {(resolution.prevailing_strength ?? 0).toFixed(2)} (margin: {(resolution.margin ?? 0).toFixed(2)})</span>
+              </>
+            )}
             <span>Criterion: {resolution.criterion.replace(/_/g, ' ')}</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- When `resolution.verdict === "undecided"` (margin < 0.05, introduced in t/3151 / PR #1717), the resolution card was rendering "Prevailing: **null**" and "Strength: 0.00" — falsely implying inst-0 prevailed
- Branch on `verdict` in the resolution card: undecided path shows "*Undecided — sides not meaningfully separated (margin < 0.05)*"; decided path shows prevailing claim + strength as before
- Criterion line renders in both branches
- `isPrevailing` check (L762) was already safe; `?? 0` crash guard was already in place — display neutrality fix only

## Test plan
- [ ] Visual: open a conflict with QBAF verdict=undecided — confirm italicised undecided message appears, no "null" or "0.00" visible
- [ ] Visual: open a conflict with a decided verdict — confirm prevailing claim + strength still render normally
- [ ] No regression on criterion line in either branch

Closes t/3187

🤖 Generated with [Claude Code](https://claude.com/claude-code)