### PR TITLE
types(conflict): nullable prevailing_claim/strength + verdict/reason on QBAF resolution (t/3186)

### DIFF
--- a/taxonomy-editor/src/renderer/types/taxonomy.ts
+++ b/taxonomy-editor/src/renderer/types/taxonomy.ts
@@ -97,10 +97,14 @@ export interface ConflictQbaf {
     edges: ConflictQbafEdge[];
   };
   resolution?: {
-    prevailing_claim: string;
-    prevailing_strength: number;
+    // Nullable on the undecided path (t/3151 Part 1, #1717): a QBAF with no clear winner
+    // produces null for both + verdict/reason. Consumers null-guard (ConflictDetail.tsx).
+    prevailing_claim: string | null;
+    prevailing_strength: number | null;
     margin: number;
     criterion: string;
+    verdict?: 'decided' | 'undecided';
+    reason?: string;
   };
   computed_at: string;
   algorithm: string;


### PR DESCRIPTION
## Summary
t/3151 Part 1 (#1717) added an undecided QBAF path yielding `null` for `prevailing_claim` + `prevailing_strength` plus new `verdict`/`reason` fields, but `taxonomy.ts:100-101` typed both as non-nullable — mistyping the undecided resolution in the renderer.

Widen to `string | null` / `number | null` and add optional `verdict?: 'decided' | 'undecided'` and `reason?: string`.

**Type-only, no behaviour change.** The JSON data is already neutral (CL review of #1717), and the sole consumer `ConflictDetail.tsx` already null-guards: `resolution?.prevailing_claim === node.id` (:762), `?? resolution.prevailing_claim` (:805), `(resolution.prevailing_strength ?? 0)` (:806).

## Verification
- renderer-tsc clean (only the 3 known `lib/` worktree node_modules artifacts, absent in CI) — whole renderer typechecks with the widened type.
- eslint 0 errors.

Self-cert `/trivial-change` (type-only). Closes t/3186 (downstream of t/3151).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: Computational Linguist (Orca) <main.research-comp-linguist@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)