### PR TITLE
fix(server/ai): grounded-search key rotation + retry + paid-overflow parity (t/3175)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/searchKeyRotation.test.ts
+++ b/taxonomy-editor/src/server/__tests__/searchKeyRotation.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3175 — generateTextWithSearch must route the Gemini grounded-search provider call
+// through callWithKeyRotation + withRetry (parity with generateText), NOT hammer key[0].
+// Before the fix, a debate round's search bursts exhausted ONE free-tier key → 429 while
+// the rest of the pool sat idle. Both arms: 429-on-first-key rotates+recovers; a fully
+// exhausted pool surfaces the 429 (for outer withRetry backoff); healthy search unchanged.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockGroundedSearch } = vi.hoisted(() => ({ mockGroundedSearch: vi.fn() }));
+
+// Real callWithKeyRotation (from keyRotator.js) — that's the mechanism under test. Mock only
+// the provider call it invokes (geminiGroundedSearch) + keep withRetry a passthrough so a
+// fully-429'd pool surfaces synchronously instead of sleeping through real backoff.
+vi.mock('../../../../lib/ai-client/index.js', async (importActual) => {
+  const actual = await importActual<typeof import('../../../../lib/ai-client/index.js')>();
+  return {
+    ...actual,
+    geminiGroundedSearch: mockGroundedSearch,
+    withRetry: vi.fn(async (fn: () => Promise<unknown>) => fn()), // one pass — no real backoff sleeps
+  };
+});
+
+// Heavy-dep silencers (prevent ONNX / Python / data init at import time).
+vi.mock('../storage/readDataFile.js', () => ({ readDataFile: vi.fn(async () => Buffer.from('{}')) }));
+vi.mock('../ai/fsCache.js', () => ({ readFileWithMtime: vi.fn(() => ({ content: '{}', mtimeMs: 1 })) }));
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  warmup: vi.fn(async () => false), tryWarmup: vi.fn(async () => false),
+  computeEmbedding: vi.fn(async () => []), computeEmbeddings: vi.fn(async () => []),
+}));
+vi.mock('../../../../lib/embeddings/embeddingResolver.js', () => ({ resolveEmbeddings: vi.fn(async () => []) }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }), setGlobalRecorder: vi.fn() }));
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return { ...actual, getApiKey: vi.fn(async () => 'k1'), getProjectRoot: vi.fn(() => '/fake') };
+});
+
+import { generateTextWithSearch } from '../ai/aiBackends.js';
+import { resetRotator } from '../ai/keyRotator.js';
+
+const mk429 = () => Object.assign(new Error('429 Too Many Requests'), { status: 429 });
+const POOL = ['k1', 'k2', 'k3'];
+
+describe('generateTextWithSearch key rotation (t/3175)', () => {
+  beforeEach(() => {
+    resetRotator();
+    mockGroundedSearch.mockReset();
+    process.env.FREE_TIER_GEMINI_KEY = POOL.join(','); // makes the pool "all free" → rotation engages
+  });
+  afterEach(() => { delete process.env.FREE_TIER_GEMINI_KEY; });
+
+  it('429 on the first key → ROTATES to the next and recovers (no surfaced failure)', async () => {
+    const seen: string[] = [];
+    mockGroundedSearch.mockImplementation(async (_fetch: unknown, _p: string, _m: string, key: string) => {
+      seen.push(key);
+      if (seen.length === 1) throw mk429();          // first key exhausted
+      return { text: 'grounded answer', citations: [] };
+    });
+    const res = await generateTextWithSearch('verify this claim', 'gemini-3.5-flash-lite', POOL);
+    expect(res.text).toBe('grounded answer');
+    expect(seen.length).toBe(2);                     // rotated to a second key
+    expect(seen[0]).not.toBe(seen[1]);               // a DIFFERENT key, not a retry on the same one
+  });
+
+  it('every key 429s → surfaces the 429 (so outer withRetry can back off), tried each key once', async () => {
+    mockGroundedSearch.mockRejectedValue(mk429());
+    await expect(generateTextWithSearch('claim', 'gemini-3.5-flash-lite', POOL)).rejects.toMatchObject({ status: 429 });
+    expect(mockGroundedSearch).toHaveBeenCalledTimes(POOL.length); // rotated through the whole pool
+  });
+
+  it('healthy search returns text + citations unchanged (regression)', async () => {
+    mockGroundedSearch.mockResolvedValue({ text: 'ok', citations: [{ uri: 'u', title: 't', segments: [] }] });
+    const res = await generateTextWithSearch('claim', 'gemini-3.5-flash-lite', POOL);
+    expect(res.text).toBe('ok');
+    expect(res.citations).toEqual([{ uri: 'u', title: 't', segments: [] }]);
+    expect(mockGroundedSearch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/searchPaidOverflow.test.ts
+++ b/taxonomy-editor/src/server/__tests__/searchPaidOverflow.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3175 — generateWithSearch paid-overflow arm (route level). Mirrors generateWithPaidFallback
+// (t/3111): the free pool (explicitKey) is tried first via generateTextWithSearchByUsage; the
+// paid key is reached ONLY on a free-tier 429 with the pool exhausted, exactly once, on the
+// 'server.search:paid-fallback' usage — never in the primary call. No-op unless a paid key
+// exists (GEMINI_PAID_KEY / t/3143). Uses fake timers for the deliberate 3s throttle.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockSearchByUsage, mockIs429, mockGetPaidKey, frRecords, mockRecorder } = vi.hoisted(() => {
+  const frRecords: Array<Record<string, unknown>> = [];
+  return {
+    mockSearchByUsage: vi.fn(),
+    mockIs429: vi.fn(),
+    mockGetPaidKey: vi.fn(),
+    frRecords,
+    mockRecorder: { record: vi.fn((r: Record<string, unknown>) => { frRecords.push(r); }) },
+  };
+});
+
+vi.mock('../ai/aiBackends.js', () => ({
+  generateTextWithSearchByUsage: mockSearchByUsage,
+  is429Error: mockIs429,
+  generateText: vi.fn(),
+  generateTextByUsage: vi.fn(),
+}));
+
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return { ...actual, getPaidGeminiFallbackKey: mockGetPaidKey };
+});
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => mockRecorder,
+  setGlobalRecorder: vi.fn(),
+}));
+
+import { generateWithSearch } from '../routes/ai.js';
+
+const CTX = { isFree: true, backend: 'gemini' as const, requestModel: 'gemini-3.5-flash-lite', t0: 0 };
+
+describe('generateWithSearch — paid-overflow arm (t/3175)', () => {
+  beforeEach(() => {
+    frRecords.length = 0;
+    mockSearchByUsage.mockReset();
+    mockIs429.mockReset();
+    mockGetPaidKey.mockReset();
+    mockRecorder.record.mockClear();
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('free pool succeeds → returns result, paid key never consulted (no fallback)', async () => {
+    mockSearchByUsage.mockResolvedValueOnce({ text: 'ok', citations: [] });
+    const out = await generateWithSearch('claim', undefined, ['free1', 'free2'], CTX);
+    expect(out.text).toBe('ok');
+    expect(mockGetPaidKey).not.toHaveBeenCalled();
+    expect(mockSearchByUsage).toHaveBeenCalledTimes(1);
+    // primary call used the FREE pool key, on the base usage
+    expect(mockSearchByUsage.mock.calls[0][0]).toBe('server.search');
+    expect(mockSearchByUsage.mock.calls[0][3]).toEqual(['free1', 'free2']);
+    expect(frRecords.some(r => r.type === 'ai.fallback')).toBe(false);
+  });
+
+  it('non-429 error → rethrows, paid NOT consulted (overflow only on 429)', async () => {
+    mockSearchByUsage.mockRejectedValueOnce(new Error('boom'));
+    mockIs429.mockReturnValue(false);
+    await expect(generateWithSearch('claim', undefined, ['free1'], CTX)).rejects.toThrow('boom');
+    expect(mockGetPaidKey).not.toHaveBeenCalled();
+    expect(mockSearchByUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it('free-tier 429 but no paid key configured → rethrows the original 429 (no-op until t/3143)', async () => {
+    const err = Object.assign(new Error('429'), { status: 429 });
+    mockSearchByUsage.mockRejectedValueOnce(err);
+    mockIs429.mockReturnValue(true);
+    mockGetPaidKey.mockResolvedValue(null);
+    await expect(generateWithSearch('claim', undefined, ['free1'], CTX)).rejects.toThrow('429');
+    expect(mockSearchByUsage).toHaveBeenCalledTimes(1); // no paid retry
+  });
+
+  it('non-free tier + 429 → does NOT reach the paid key (paid is a free-tier overflow only)', async () => {
+    const err = Object.assign(new Error('429'), { status: 429 });
+    mockSearchByUsage.mockRejectedValueOnce(err);
+    mockIs429.mockReturnValue(true);
+    await expect(generateWithSearch('claim', undefined, ['byok'], { ...CTX, isFree: false })).rejects.toThrow('429');
+    expect(mockGetPaidKey).not.toHaveBeenCalled();
+  });
+
+  it('free-tier 429 + paid key → paid fallback fires ONCE with the paid key on the paid-fallback usage + records the signal', async () => {
+    vi.useFakeTimers();
+    const err = Object.assign(new Error('429'), { status: 429 });
+    mockSearchByUsage
+      .mockRejectedValueOnce(err)                           // free pool exhausted
+      .mockResolvedValueOnce({ text: 'paid-ok', citations: [] }); // paid retry succeeds
+    mockIs429.mockReturnValue(true);
+    mockGetPaidKey.mockResolvedValue('paid-key');
+
+    const p = generateWithSearch('claim', undefined, ['free1', 'free2'], CTX);
+    await vi.advanceTimersByTimeAsync(3000); // the deliberate 3s throttle
+    const out = await p;
+
+    expect(out.text).toBe('paid-ok');
+    expect(mockSearchByUsage).toHaveBeenCalledTimes(2);
+    // call 1 = FREE pool on base usage; call 2 = PAID key on the paid-fallback usage
+    expect(mockSearchByUsage.mock.calls[0][0]).toBe('server.search');
+    expect(mockSearchByUsage.mock.calls[0][3]).toEqual(['free1', 'free2']);
+    expect(mockSearchByUsage.mock.calls[1][0]).toBe('server.search:paid-fallback');
+    expect(mockSearchByUsage.mock.calls[1][3]).toBe('paid-key'); // paid key never in the free pool array
+    const fired = frRecords.find(r => r.type === 'ai.fallback');
+    expect(fired).toBeDefined();
+    expect((fired!.data as Record<string, unknown>).fallback).toBe('paid');
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -454,9 +454,20 @@ export async function generateTextWithSearch(
     return { text: result.text };
   }
 
-  const apiKey = (typeof explicitApiKey === 'string' ? explicitApiKey : explicitApiKey?.[0])
-    ?? await getApiKey('gemini');
-  if (!apiKey) {
+  // t/3175: parity with generateText's resilience stack. Previously this used only
+  // explicitApiKey[0] and called geminiGroundedSearch directly — so a debate round's
+  // search-verify bursts hammered ONE free-tier key (the other pool keys idle) → 429
+  // api_key_exhausted with no retry. Route the grounded-search provider call through
+  // callWithKeyRotation (round-robin + 429 cooldown across the whole pool) wrapped in
+  // withRetry (backoff), exactly like generateText (aiBackends.ts:383). Paid-overflow
+  // is layered at the route caller (routes/ai.ts), mirroring generateWithPaidFallback.
+  const fallbackKey = (Array.isArray(explicitApiKey) || explicitApiKey) ? undefined : await getApiKey('gemini');
+  const keys: string[] = Array.isArray(explicitApiKey)
+    ? explicitApiKey.filter(Boolean)
+    : explicitApiKey
+      ? [explicitApiKey]
+      : (fallbackKey ? [fallbackKey] : []);
+  if (keys.length === 0) {
     throw new ActionableError({
       goal: 'Perform grounded search via Gemini',
       problem: 'No Gemini API key configured',
@@ -466,7 +477,12 @@ export async function generateTextWithSearch(
   }
 
   const apiModel = getApiModelId(resolved);
-  return geminiGroundedSearch(fetch, prompt, apiModel, apiKey);
+  return withRetry(
+    () => callWithKeyRotation('gemini', keys,
+      (apiKey) => geminiGroundedSearch(fetch, prompt, apiModel, apiKey)),
+    SERVER_RETRY_CONFIG,
+    `gemini-search/${apiModel}`,
+  );
 }
 
 // ── UsageID wrappers (t/1262) ──

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -211,22 +211,55 @@ function applyTokenBudgetHeaders(res: http.ServerResponse, result: Awaited<Retur
   }
 }
 
-/** Search-grounded generation (server.search usage) + success record. */
+/** Search-grounded generation (server.search usage) + success record.
+ *  t/3175: full parity with generateWithPaidFallback — the in-backend fix routes the
+ *  grounded-search provider call through key rotation + retry; this adds the same
+ *  route-level paid-overflow safety net: on a free-tier 429 with the whole free pool
+ *  exhausted, retry ONCE with the admin paid key after a 3s throttle (the paid key never
+ *  enters the free rotation). No-op until GEMINI_PAID_KEY is set (t/3143). */
 async function generateWithSearch(
   prompt: string,
   effectiveModel: string | undefined,
   explicitKey: string | string[] | undefined,
-  ctx: { backend: AIBackend; requestModel: string; t0: number },
+  ctx: { isFree: boolean; backend: AIBackend; requestModel: string; t0: number },
 ): Promise<Awaited<ReturnType<typeof ai.generateTextWithSearchByUsage>>> {
-  const { backend, requestModel, t0 } = ctx;
-  const result = await ai.generateTextWithSearchByUsage('server.search', { prompt }, effectiveModel ? { model: effectiveModel } : undefined, explicitKey);
-  getGlobalRecorder()?.record({
-    type: 'ai.response', component: 'ai-generate', level: 'info',
-    duration_ms: Date.now() - t0,
-    message: `generate+search success ${backend}/${requestModel}`,
-    data: { model: requestModel, backend, responseLength: result.text?.length ?? 0, search: true },
-  });
-  return result;
+  const { isFree, backend, requestModel, t0 } = ctx;
+  const overrides = effectiveModel ? { model: effectiveModel } : undefined;
+  const recordSuccess = (result: Awaited<ReturnType<typeof ai.generateTextWithSearchByUsage>>, fallback?: 'paid') => {
+    getGlobalRecorder()?.record({
+      type: 'ai.response', component: 'ai-generate', level: 'info',
+      duration_ms: Date.now() - t0,
+      message: `generate+search success ${backend}/${requestModel}${fallback ? ' (paid fallback)' : ''}`,
+      data: { model: requestModel, backend, responseLength: result.text?.length ?? 0, search: true, ...(fallback ? { fallback } : {}) },
+    });
+  };
+  try {
+    const result = await ai.generateTextWithSearchByUsage('server.search', { prompt }, overrides, explicitKey);
+    recordSuccess(result);
+    return result;
+  } catch (searchErr) {
+    const paidKey = (ai.is429Error(searchErr) && isFree) ? await getPaidGeminiFallbackKey() : null;
+    if (!paidKey) throw searchErr; // non-free, non-429, or no paid key → outer catch maps to 429
+    getGlobalRecorder()?.record({
+      type: 'ai.fallback', component: 'ai-generate', level: 'info',
+      message: 'Free-tier search keys exhausted — waiting 3s before paid fallback',
+      data: { model: requestModel, backend, fallback: 'paid', delayMs: 3000, search: true, freeKeyCount: proxyTiers.parseFreeTierKeys(process.env.FREE_TIER_GEMINI_KEY).length },
+    });
+    await new Promise(r => setTimeout(r, 3000));
+    try {
+      const result = await ai.generateTextWithSearchByUsage('server.search:paid-fallback', { prompt }, overrides, paidKey);
+      recordSuccess(result, 'paid');
+      return result;
+    } catch (fallbackErr) {
+      getGlobalRecorder()?.record({
+        type: 'ai.error', component: 'ai-generate', level: 'warn',
+        message: 'Paid search fallback also failed',
+        data: { model: requestModel, backend, fallback: 'paid', search: true },
+        error: { name: (fallbackErr as Error).name ?? 'Error', message: String(fallbackErr), stack: (fallbackErr as Error).stack },
+      });
+      throw searchErr; // both exhausted → outer catch maps to a client 429
+    }
+  }
 }
 
 /** t/997: Gemini surfaces a too-long context window as RESOURCE_EXHAUSTED — a 400-class
@@ -382,7 +415,7 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
       };
 
       if (search) {
-        json(res, await generateWithSearch(prompt, effectiveModel, explicitKey, { backend, requestModel, t0 }));
+        json(res, await generateWithSearch(prompt, effectiveModel, explicitKey, { isFree, backend, requestModel, t0 }));
       } else {
         const result = await generateWithPaidFallback(prompt, usageOverrides, explicitKey, {
           isFree, backend, requestModel, t0,

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -217,7 +217,7 @@ function applyTokenBudgetHeaders(res: http.ServerResponse, result: Awaited<Retur
  *  route-level paid-overflow safety net: on a free-tier 429 with the whole free pool
  *  exhausted, retry ONCE with the admin paid key after a 3s throttle (the paid key never
  *  enters the free rotation). No-op until GEMINI_PAID_KEY is set (t/3143). */
-async function generateWithSearch(
+export async function generateWithSearch(
   prompt: string,
   effectiveModel: string | undefined,
   explicitKey: string | string[] | undefined,
@@ -240,9 +240,12 @@ async function generateWithSearch(
   } catch (searchErr) {
     const paidKey = (ai.is429Error(searchErr) && isFree) ? await getPaidGeminiFallbackKey() : null;
     if (!paidKey) throw searchErr; // non-free, non-429, or no paid key → outer catch maps to 429
+    // t/3175 (TL GV): WARN, not info — free-pool exhaustion is the second-front signal we
+    // want visible (Fallback-Path Logging rule, docs/error-handling.md); at info it's below
+    // the detectable threshold. Records THAT the paid fallback fired and WHY (free 429).
     getGlobalRecorder()?.record({
-      type: 'ai.fallback', component: 'ai-generate', level: 'info',
-      message: 'Free-tier search keys exhausted — waiting 3s before paid fallback',
+      type: 'ai.fallback', component: 'ai-generate', level: 'warn',
+      message: 'Free-tier search keys exhausted (429) — falling back to paid key after 3s throttle',
       data: { model: requestModel, backend, fallback: 'paid', delayMs: 3000, search: true, freeKeyCount: proxyTiers.parseFreeTierKeys(process.env.FREE_TIER_GEMINI_KEY).length },
     });
     await new Promise(r => setTimeout(r, 3000));


### PR DESCRIPTION
Fixes the debate search 429 (t/3165 sub-issue). Both TL decisions approved (p/522#117/#118); design in t/3175#2. → **Main (TL) GV** (AI-resilience surface).

## Root cause
`generateTextWithSearch`'s Gemini path used only `explicitApiKey[0]` and called `geminiGroundedSearch` **directly** — no rotation, no retry, no paid-fallback. A debate round's search-verify bursts hammered **one** free-tier key while the other 3 sat idle → `429 api_key_exhausted`, no recovery. `generateText` has the full stack; search never did (the keyRotator audit claim was stale).

## Fix (full parity with generateText)
1. **LOAD-BEARING** (`aiBackends.ts`): wrap the grounded-search call in `withRetry(callWithKeyRotation('gemini', keys, apiKey => geminiGroundedSearch(...)))`. Distributes across the whole pool + backs off. Fixes it **with the existing keys** (pool was under-utilized, not exhausted).
2. **PARITY add-on** (`routes/ai.ts`): `generateWithSearch` gains `generateWithPaidFallback`-style paid overflow — free-tier 429 + pool exhausted → 3s throttle → retry once with the paid key (never in the free rotation). **No-op until `GEMINI_PAID_KEY` is set (t/3143)**; ships independently of it.

## Tests
`searchKeyRotation.test.ts` (3/3): 429-on-first-key **rotates to a different key + recovers**; whole-pool-429 **surfaces the 429** for outer backoff (tried each key once); healthy search returns text+citations unchanged. tsc clean.

The paid-overflow wrapper structurally mirrors the already-tested `generateWithPaidFallback` (`paidFallbackOrdering.test.ts`) — flag if you want a dedicated route-level test at GV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)