### PR TITLE
obs(bridge): record client embeddings-compute cache stats to the FR (t/3173)

### DIFF
--- a/taxonomy-editor/src/renderer/bridge/__tests__/embeddingsBatch.test.ts
+++ b/taxonomy-editor/src/renderer/bridge/__tests__/embeddingsBatch.test.ts
@@ -1,19 +1,32 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { computeEmbeddingsChunked, EMBEDDINGS_MAX_BATCH } from '../embeddingsBatch';
+
+const mockRecord = vi.fn();
+vi.mock('@lib/flight-recorder/index', () => ({
+  getGlobalRecorder: () => ({ record: mockRecord, intern: (_ns: string, v: string) => v }),
+}));
 
 // A fake `post` that returns one deterministic vector per input text ([index-within-request]),
 // and records the batch size + ids of every call so we can assert chunking + ordering.
-function makePost() {
+// `stats` optionally attaches per-chunk cacheHits/cacheMisses/corpusNodeCount to the response.
+function makePost(stats?: { cacheHits: number; cacheMisses: number; corpusNodeCount?: number }) {
   const calls: { texts: string[]; ids?: string[] }[] = [];
   const post = vi.fn(async (_path: string, body?: unknown) => {
     const { texts, ids } = body as { texts: string[]; ids?: string[] };
     calls.push({ texts, ids });
-    return { vectors: texts.map((_t, i) => [i]) };
+    return { vectors: texts.map((_t, i) => [i]), ...(stats ?? {}) };
   });
   return { post, calls };
+}
+
+/** The client cache-stats FR record (t/3173), or undefined if none was emitted. */
+function cacheStatRecord(): { data?: Record<string, unknown> } | undefined {
+  return mockRecord.mock.calls
+    .map((c) => c[0] as { component?: string; data?: Record<string, unknown> })
+    .find((e) => e.component === 'embeddings-compute-client');
 }
 
 describe('computeEmbeddingsChunked', () => {
@@ -76,5 +89,44 @@ describe('computeEmbeddingsChunked', () => {
     expect(order).toEqual([
       't0', 't0', `t${EMBEDDINGS_MAX_BATCH}`, `t${EMBEDDINGS_MAX_BATCH}`, `t${EMBEDDINGS_MAX_BATCH * 2}`, `t${EMBEDDINGS_MAX_BATCH * 2}`,
     ].flatMap((label, i) => (i % 2 === 0 ? [`start:${label}`] : [`end:${label}`])));
+  });
+});
+
+describe('computeEmbeddingsChunked — client cache-stats FR record (t/3173)', () => {
+  beforeEach(() => { mockRecord.mockClear(); });
+
+  it('records item_count + summed cache_hits/cache_misses + has_ids for a single compute', async () => {
+    const { post } = makePost({ cacheHits: 40, cacheMisses: 10, corpusNodeCount: 4144 });
+    const texts = Array.from({ length: 50 }, (_v, i) => `t${i}`);
+    const ids = texts.map((_t, i) => `n${i}`);
+    await computeEmbeddingsChunked(post, texts, ids);
+
+    const rec = cacheStatRecord();
+    expect(rec).toBeDefined();
+    expect(rec?.data).toMatchObject({ item_count: 50, has_ids: true, cache_hits: 40, cache_misses: 10, corpus_node_count: 4144 });
+  });
+
+  it('SUMS cache stats across chunks (one logical compute = one record)', async () => {
+    const { post } = makePost({ cacheHits: 100, cacheMisses: 12 }); // per-chunk
+    const texts = Array.from({ length: EMBEDDINGS_MAX_BATCH * 2 + 1 }, (_v, i) => `t${i}`); // 3 chunks
+    await computeEmbeddingsChunked(post, texts);
+
+    const recs = mockRecord.mock.calls.filter((c) => (c[0] as { component?: string }).component === 'embeddings-compute-client');
+    expect(recs).toHaveLength(1); // exactly one record, not one per chunk
+    expect(recs[0][0].data).toMatchObject({ item_count: EMBEDDINGS_MAX_BATCH * 2 + 1, cache_hits: 300, cache_misses: 36, has_ids: false });
+  });
+
+  it('emits NO record when the server response omits cache stats (older server)', async () => {
+    const { post } = makePost(); // vectors only, no cacheHits/cacheMisses
+    await computeEmbeddingsChunked(post, ['a', 'b'], ['n0', 'n1']);
+    expect(cacheStatRecord()).toBeUndefined();
+  });
+
+  it('emits no record and makes no POST for an empty batch', async () => {
+    const { post } = makePost({ cacheHits: 0, cacheMisses: 0 });
+    const res = await computeEmbeddingsChunked(post, []);
+    expect(post).not.toHaveBeenCalled();
+    expect(res.vectors).toEqual([]);
+    expect(cacheStatRecord()).toBeUndefined();
   });
 });

--- a/taxonomy-editor/src/renderer/bridge/embeddingsBatch.ts
+++ b/taxonomy-editor/src/renderer/bridge/embeddingsBatch.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 // Licensed under the MIT License. See LICENSE file in the project root.
 
+import { getGlobalRecorder } from '@lib/flight-recorder/index';
+
 // Client-side batch chunking for POST /api/embeddings/compute (t/3072).
 //
 // The server processes the whole request inside a single 50s withEndpointTimeout('embeddings-compute')
@@ -30,6 +32,48 @@ type EmbeddingsPost = <T = unknown>(
 ) => Promise<T>;
 
 /**
+ * Compute response. `cacheHits`/`cacheMisses`/`corpusNodeCount` were added server-side in #1704
+ * (t/3165); optional here so an older/other server that returns only `vectors` still type-checks.
+ */
+interface ComputeResponse {
+  vectors: number[][];
+  cacheHits?: number;
+  cacheMisses?: number;
+  corpusNodeCount?: number;
+}
+
+/**
+ * Record the compute cache-resolution stats into the RENDERER flight recorder (t/3173, t/3165 Q3a).
+ * The server's own `embedding.compute` record is excluded from an anonymous debate's merged dump
+ * (anon has no session branch → the whole server dump is dropped), so the client half is what makes
+ * "novel-text volume vs keyed cache-miss" visible in the anon dump: high item_count + cacheHits=0 +
+ * no ids = volume (t/2977); cacheHits=0 WITH ids = a keyed miss (the t/3165 shape). Summed across
+ * chunks so one logical compute = one record. Best-effort: skipped if the server omitted the stats.
+ */
+function recordComputeCacheStats(
+  itemCount: number,
+  hasIds: boolean,
+  hits: number | undefined,
+  misses: number | undefined,
+  corpusNodeCount: number | undefined,
+): void {
+  if (hits === undefined && misses === undefined) return; // server didn't report stats — nothing to record
+  getGlobalRecorder()?.record({
+    type: 'system.info',
+    component: 'embeddings-compute-client',
+    level: 'info',
+    message: 'embedding.compute (client)',
+    data: {
+      item_count: itemCount,
+      has_ids: hasIds,
+      cache_hits: hits ?? 0,
+      cache_misses: misses ?? 0,
+      ...(corpusNodeCount !== undefined && { corpus_node_count: corpusNodeCount }),
+    },
+  });
+}
+
+/**
  * Split texts/ids into ≤EMBEDDINGS_MAX_BATCH slices and POST them SEQUENTIALLY — never
  * concurrently, which would re-burst the very server this guards (TL, t/3072). Vectors are
  * concatenated in input order, so the return shape is identical to a single compute call. Each
@@ -41,20 +85,28 @@ export async function computeEmbeddingsChunked(
   texts: string[],
   ids?: string[],
 ): Promise<{ vectors: number[][] }> {
-  if (texts.length <= EMBEDDINGS_MAX_BATCH) {
-    return post<{ vectors: number[][] }>(EMBEDDINGS_COMPUTE_PATH, { texts, ids }, { idempotent: true });
-  }
   const vectors: number[][] = [];
+  let hits = 0;
+  let misses = 0;
+  let sawStats = false;
+  let corpusNodeCount: number | undefined;
   for (let i = 0; i < texts.length; i += EMBEDDINGS_MAX_BATCH) {
     const textChunk = texts.slice(i, i + EMBEDDINGS_MAX_BATCH);
     const idChunk = ids ? ids.slice(i, i + EMBEDDINGS_MAX_BATCH) : undefined;
     // Awaited in the loop → strictly sequential; the next chunk starts only after this one resolves.
-    const res = await post<{ vectors: number[][] }>(
+    const res = await post<ComputeResponse>(
       EMBEDDINGS_COMPUTE_PATH,
       { texts: textChunk, ids: idChunk },
       { idempotent: true },
     );
     vectors.push(...res.vectors);
+    if (res.cacheHits !== undefined || res.cacheMisses !== undefined) {
+      sawStats = true;
+      hits += res.cacheHits ?? 0;
+      misses += res.cacheMisses ?? 0;
+      if (res.corpusNodeCount !== undefined) corpusNodeCount = res.corpusNodeCount;
+    }
   }
+  recordComputeCacheStats(texts.length, !!ids, sawStats ? hits : undefined, sawStats ? misses : undefined, corpusNodeCount);
   return { vectors };
 }


### PR DESCRIPTION
## Summary
Client half of the t/3165 Q3a observability gap. The server's `embedding.compute` FR record is **excluded from an anonymous debate's merged dump** — anon has no session branch, so the whole server dump is dropped (`includeServer=false`). That made "novel-text volume vs keyed cache-miss" unconfirmable from the anon dump.

ServerAPI (#1704) added `{cacheHits, cacheMisses, corpusNodeCount}` to the `/api/embeddings/compute` **response**. `computeEmbeddingsChunked` now sums those across chunks (one logical compute = one record) and emits a `system.info` **`embeddings-compute-client`** FR event with `item_count / has_ids / cache_hits / cache_misses / corpus_node_count` — which **does** land in the anon merged dump (client events are present for anon).

So a client-only dump now distinguishes **high item_count + cacheHits=0 + no ids** (novel-text VOLUME, t/2977) from **cacheHits=0 WITH ids** (a keyed cache miss — the t/3165 shape).

Best-effort: skipped when the server omits the stats (typed optional → still compiles against an older server).

## Deviation (minor, intentional — asked X, did Y, because Z)
Unified the single-batch fast path into the chunk loop so the FR record covers small computes too. Side effect: an **empty** `texts` array now makes **0 POSTs** instead of 1 (old fast path POSTed empty). Safe — callers already guard empty (`searchSlice`/`analysisSlice` `if (texts.length===0) return`), an empty embed is pure waste, no test asserted the empty→POST behaviour, and vectors output is identical.

## Verification
- `embeddingsBatch.test.ts` **8/8** (+4): records summed stats + item_count + has_ids; **sums across 3 chunks into ONE record**; omits the record when stats absent; empty batch → no POST + no record. (Original 4 chunking/ordering tests unchanged.)
- renderer-tsc clean (only the 3 known `lib/` worktree node_modules artifacts, absent in CI); eslint 0 errors.

Self-cert `/add-test` + `/trivial-change` (additive observability, no API change). Closes t/3173 (t/3165 Q3a; relates t/2977).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>
Co-Authored-By: ServerAPI (Orca) <main.taxonomy-editor-src-server@ai-triad-research.orca.local>

🤖 Generated with [Claude Code](https://claude.com/claude-code)