### PR TITLE
feat(devops): paid-fallback overflow cost alert (t/3110)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -1310,9 +1310,15 @@ resource fallbackActive 'Microsoft.Insights/scheduledQueryRules@2023-03-15-previ
 // single paid key as overflow-only fallback (t/3111); the default path is free,
 // so paid-fallback usage should be ~0. Any sustained nonzero is a real operational
 // signal that the free pool is under-provisioned or throttling — NOT steady-state
-// cost. Keys on the `Paid fallback succeeded` log emitted at routes/ai.ts:187 when
-// generateWithPaidFallback completes a billed call. 60-min window distinguishes
-// sustained overflow from a lone transient.
+// cost. 60-min window distinguishes sustained overflow from a lone transient.
+//
+// MATCH-TOKEN IS A CONTRACT: the substring "Paid fallback succeeded" below is a
+// shared marker that EVERY paid-fallback success emitter must include verbatim, or
+// its overflow goes unmonitored. Emitters today: routes/ai.ts:187 (generate) ✓ and
+// routes/ai.ts:232 (generate+search) — the search path must carry the same marker
+// (t/3110 GV coverage-gap fix, ServerAPI). A mirror of this comment lives at each
+// emitter. Change the token in one place → change it in all, or this alert silently
+// misses the overflow it exists to catch (the t/3165 debate-search second front).
 resource paidFallbackOverflow 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
   name: 'alert-paid-fallback-overflow'
   location: location

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -1306,6 +1306,46 @@ resource fallbackActive 'Microsoft.Insights/scheduledQueryRules@2023-03-15-previ
   }
 }
 
+// Paid Gemini fallback overflow (t/3110). The anon key pool is free-primary +
+// single paid key as overflow-only fallback (t/3111); the default path is free,
+// so paid-fallback usage should be ~0. Any sustained nonzero is a real operational
+// signal that the free pool is under-provisioned or throttling — NOT steady-state
+// cost. Keys on the `Paid fallback succeeded` log emitted at routes/ai.ts:187 when
+// generateWithPaidFallback completes a billed call. 60-min window distinguishes
+// sustained overflow from a lone transient.
+resource paidFallbackOverflow 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
+  name: 'alert-paid-fallback-overflow'
+  location: location
+  tags: tags
+  properties: {
+    displayName: 'Paid Gemini Fallback Overflow'
+    description: 'The paid Gemini fallback key served a request (expected ~0 on the free-primary path). Sustained hits mean the free key pool is under-provisioned or throttling into billable overflow — consider adding a free key.'
+    severity: 2
+    enabled: true
+    scopes: [ logAnalytics.id ]
+    evaluationFrequency: 'PT15M'
+    windowSize: 'PT1H'
+    criteria: {
+      allOf: [
+        {
+          query: '''
+            ContainerAppConsoleLogs_CL
+            | where Log_s contains "Paid fallback succeeded"
+            | summarize PaidFallbacks = count()
+            | where PaidFallbacks > 0
+          '''
+          timeAggregation: 'Count'
+          operator: 'GreaterThan'
+          threshold: 0
+        }
+      ]
+    }
+    actions: {
+      actionGroups: budgetAlertConfigured ? [ restartAlertActionGroup.id ] : []
+    }
+  }
+}
+
 resource branchDivergence 'Microsoft.Insights/scheduledQueryRules@2023-03-15-preview' = {
   name: 'alert-branch-divergence'
   location: location

--- a/deploy/azure/runbooks/production-release.md
+++ b/deploy/azure/runbooks/production-release.md
@@ -146,6 +146,7 @@ All alerts route to the `ag-aitriad-restart-alert` action group, which emails `A
 | `alert-github-api-error-spike` | 1 (Error) | 5+ GitHub API errors | 5min / 5min |
 | `alert-cache-degraded` | 2 (Warning) | 50+ cache misses | 5min / 5min |
 | `alert-fallback-active` | 1 (Error) | App serving from fallback data | 5min / 5min |
+| `alert-paid-fallback-overflow` | 2 (Warning) | Paid Gemini fallback key served a request (free pool exhausted → billable overflow; expect ~0) | 15min / 60min |
 | `alert-branch-divergence` | 3 (Info) | Session branch 10+ commits behind | 15min / 15min |
 
 ### External Availability Probe (GitHub Actions)


### PR DESCRIPTION
Lands t/3110 — cost-alert on the PAID Gemini fallback key. Unblocked by t/3143 (GEMINI_PAID_KEY now live in prod).

## What
New Azure Monitor scheduled-query alert **`alert-paid-fallback-overflow`** in `deploy/azure/main.bicep`:
- **Signal:** `ContainerAppConsoleLogs_CL` where `Log_s contains "Paid fallback succeeded"` — the log emitted at `routes/ai.ts:187` when `generateWithPaidFallback` completes a **billed** call.
- **Threshold:** >0 occurrences in a rolling **60 min** (`windowSize PT1H`, `evaluationFrequency PT15M`) — distinguishes sustained overflow from a lone transient.
- **Severity 2 (Warning)**, routed to the existing `ag-aitriad-restart-alert` action group (emails `ALERT_EMAIL`), same pattern as the other 7 Bicep alerts.
- Runbook alert table updated (`production-release.md`).

## Why
Per the free-primary/paid-overflow design (t/3111), the default anon path is free (4-key pool, 30 RPM front-door), so paid-fallback usage should be **~0**. Any sustained nonzero = the free pool is under-provisioned or throttling into billable overflow — a real operational signal, not steady-state cost. Gives us the data to decide if a 3rd/4th free key is ever needed (per TL p/331#800).

## Verification
- `az bicep build` compiles clean (exit 0); `alert-paid-fallback-overflow` present in the compiled ARM JSON.
- No GCP dependency — the signal is entirely Azure-side (supersedes the original "GCP budget alert" framing in the ticket).

## Gate Verification (draft-held for TL, per t/3111 cost/limits surface)
Both arms, provable now that the paid key is live:
- **FIRE:** with `GEMINI_PAID_KEY` set, force free-pool exhaustion → `Paid fallback succeeded` logs → alert fires.
- **CLEAN:** default free path → no such log → silent.

Held as **draft** pending TL GV sign-off (cost-governance per t/3111). Un-draft on approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)