### PR TITLE
docs(cl): paired-contrast design guideline (check 7) — instrument-integrity checklist (t/3153)

### DIFF
--- a/research/comp-linguist/docs/instrument-integrity-checklist.md
+++ b/research/comp-linguist/docs/instrument-integrity-checklist.md
@@ -2,7 +2,7 @@
 
 **Owner:** Computational Linguist. **Applies to:** any new (or materially changed) metric, LLM judge, or verdict grammar before its output is cited as a disposition rather than an indicative sample.
 
-A scalar or verdict is an instrument. Before it counts as evidence, it must pass the six checks below. The first four are the protocol from the instrument-effects paper (arXiv 2607.14399 §5.3, four-check integrity protocol, retrieved verbatim); checks 5–6 are this project's standing additions. Each check names how we already enforce it, or flags the gap.
+A scalar or verdict is an instrument. Before it counts as evidence, it must pass the seven checks below. The first four are the protocol from the instrument-effects paper (arXiv 2607.14399 §5.3, four-check integrity protocol, retrieved verbatim); checks 5–7 are this project's standing additions. Each check names how we already enforce it, or flags the gap.
 
 ## The checks
 
@@ -22,13 +22,16 @@ A scalar or verdict is an instrument. Before it counts as evidence, it must pass
 
 **6. Reproduce before assert (t/2294).** Before asserting a metric's ground truth, error class, or "correct" value, run the actual pipeline/retrieval that produced the observed behavior. Never infer from node/description text alone. Label constructed cases `constructed`, observed cases `observed`.
 
+**7. Paired-contrast framing for probes with a natural reference (RepE, arXiv 2310.01405).** *Design guideline.* Any NEW concept probe or judge that has a natural reference or opposite MUST read the concept from paired-contrast stimuli (experimental vs reference stimulus) rather than a single one-sided prompt — separability improves when the two stimuli differ only in the target concept. An absolute quality judge with no natural matched-reference counterpart is exempt and must state so explicitly.
+- Enforcement: design-review discipline, applies at judge/probe authoring time. Existing relational judges already comply and need no retrofit: the NLI polarity gate (position-framed entailment/contradiction, `nli_classify.py`), synthesis `prevails` (explicit C1-vs-C2 comparison, `synthesis.ts:194`), and entailment-repair (claim-vs-source contrast, `topic-crux.ts:151`). The absolute one-sided judges — neutral-evaluator claim assessment (`well_supported…refuted`), crux status, `FactVerdict` — have no natural reference pair and are appropriately exempt; retrofitting them is not warranted (marginal expected separability gain). Lexicon/map-based scores (`affect_intensity`, `source_authority`, etc.) are lookups, not model probes, so paired-contrast is N/A. Source: t/3099 audit (t/3099#1).
+
 ## Truthfulness vs honesty (register caveat)
 
 Our behavioral honesty/consistency metrics (and the RepE-style probes, arXiv 2310.01405) measure whether a model **asserts claims consistently with its own reasoning**, not whether those claims correspond to external ground truth. Per the instrument-effects paper, the true-positive cell can be unpopulatable by construction, so such metrics measure false-positive behavior only. Any honesty/consistency metric in the register must state this truthfulness-vs-honesty limit so a consumer does not read it as a truth measure.
 
 ## How to use
 
-- New/changed metric, judge, or verdict grammar → walk checks 1–6, record the outcome in the provenance register. Checks 1–4 that cannot be satisfied yet are declared open (with a follow-up ticket), not silently skipped.
+- New/changed metric, judge, or verdict grammar → walk checks 1–7, record the outcome in the provenance register. Checks 1–4 that cannot be satisfied yet are declared open (with a follow-up ticket), not silently skipped. Check 7 is a design guideline applied at authoring time (or an explicit exemption).
 - **Gate-touching** application (wiring any check into CI as a blocking gate) routes to Main (TL) for both-arms Gate Verification. This checklist itself is advisory discipline, not a CI gate, until a specific check is proposed as one.
 
 *Sources: arXiv 2607.14399 §5.3 (four-check protocol, retrieved 2026-08-31); project gates t/1668, t/1671, t/2294; audit findings t/3096, t/3097, t/3098.*


### PR DESCRIPTION
Adds check 7 (paired-contrast framing design guideline, RepE arXiv 2310.01405) to `research/comp-linguist/docs/instrument-integrity-checklist.md`, per the t/3099 audit (t/3099#1). New concept probes/judges with a natural reference use paired-contrast; absolute judges without a natural reference are exempt and must say so. Updated intro count (six→seven) and the How-to-use walk (1–6→1–7). Docs-only, CL scope; no code touched.

Closes t/3153.