### PR TITLE
fix(server/ai): search paid-success emits shared 'Paid fallback succeeded' marker (t/3110)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/searchPaidOverflow.test.ts
+++ b/taxonomy-editor/src/server/__tests__/searchPaidOverflow.test.ts
@@ -112,5 +112,13 @@ describe('generateWithSearch — paid-overflow arm (t/3175)', () => {
     const fired = frRecords.find(r => r.type === 'ai.fallback');
     expect(fired).toBeDefined();
     expect((fired!.data as Record<string, unknown>).fallback).toBe('paid');
+    // t/3110: the paid-SUCCESS record must carry the shared "Paid fallback succeeded" marker
+    // DevOps's overflow-cost alert (#1733) keys on — same token as generateWithPaidFallback.
+    const paidSuccess = frRecords.find(r => r.type === 'ai.response' && String(r.message).includes('Paid fallback succeeded'));
+    expect(paidSuccess).toBeDefined();
+    expect((paidSuccess!.data as Record<string, unknown>).fallback).toBe('paid');
+    // The marker must NOT appear on the attempt log (only billed successes count).
+    const attempt = frRecords.find(r => r.type === 'ai.fallback');
+    expect(String(attempt!.message)).not.toContain('Paid fallback succeeded');
   });
 });

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -229,7 +229,13 @@ export async function generateWithSearch(
     getGlobalRecorder()?.record({
       type: 'ai.response', component: 'ai-generate', level: 'info',
       duration_ms: Date.now() - t0,
-      message: `generate+search success ${backend}/${requestModel}${fallback ? ' (paid fallback)' : ''}`,
+      // t/3110: paid-success carries the shared "Paid fallback succeeded" marker DevOps's
+      // overflow-cost alert (#1733) keys on — the same token the non-search
+      // generateWithPaidFallback path emits — so the alert also counts debate-search overflow.
+      // Marker is on the SUCCESS record only (billed overflow), never the attempt/failure logs.
+      message: fallback === 'paid'
+        ? `Paid fallback succeeded (search) ${backend}/${requestModel}`
+        : `generate+search success ${backend}/${requestModel}`,
       data: { model: requestModel, backend, responseLength: result.text?.length ?? 0, search: true, ...(fallback ? { fallback } : {}) },
     });
   };


### PR DESCRIPTION
Follow-up to #1731 (TL, p/522#125). DevOps's paid-overflow cost alert (#1733, t/3110) counts free→paid overflow by matching the log token **"Paid fallback succeeded"**. The non-search `generateWithPaidFallback` emits it; #1731's search paid-success logged `generate+search success …(paid fallback)` — a different string, so the alert would **miss debate-search overflow** (the t/3165 second front).

**Fix:** the search paid-**success** record now carries the shared marker. The attempt log and failure log keep their own wording, so only billed successes are counted (no double-count / false positives).

**Test:** `searchPaidOverflow.test.ts` asserts the paid-success record carries the marker AND the attempt record does not. 5/5.

**Self-cert /trivial-change** — one message string + a test assertion, single scope, no behavior/API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)