### PR TITLE
fix(entities): default Invoke-EntityExtraction to the usage's model (t/3123 follow-up)

### DIFF
--- a/scripts/AITriad/Public/Invoke-EntityExtraction.ps1
+++ b/scripts/AITriad/Public/Invoke-EntityExtraction.ps1
@@ -81,10 +81,12 @@ function Invoke-EntityExtraction {
     .PARAMETER Concurrency
         Parallel AI calls. Default 3 (same conservative default as Invoke-OrgStanceExtraction).
     .PARAMETER Model
-        AI model id used for every extraction call, overriding the model the
-        enrichment.entity-extraction UsageID resolves from ai-usages.json. Default
-        gemini-3.5-flash-lite. Tab-completes against registered ids; validated by
-        Test-AIModelId.
+        AI model id used for every extraction call, OVERRIDING the model the
+        enrichment.entity-extraction UsageID resolves from ai-usages.json. Default:
+        unset — the usage's configured model wins (currently claude-sonnet-4-6, whose
+        Claude-shaped structured-output schema a gemini-flash model rejects with HTTP
+        400, t/3123). Pass -Model only to deliberately override. Tab-completes against
+        registered ids; validated by Test-AIModelId.
     .PARAMETER Force
         Re-extract for node ids that already have a log entry.
     .PARAMETER ConfidenceThreshold
@@ -141,9 +143,9 @@ function Invoke-EntityExtraction {
         [int]$Concurrency = 3,
 
         [Parameter()]
-        [ValidateScript({ Test-AIModelId $_ })]
+        [ValidateScript({ [string]::IsNullOrEmpty($_) -or (Test-AIModelId $_) })]
         [ArgumentCompleter({ param($cmd, $param, $word) $script:ValidModelIds | Where-Object { $_ -like "$word*" } })]
-        [string]$Model = 'gemini-3.5-flash-lite',
+        [string]$Model = '',
 
         [Parameter()]
         [switch]$Force,
@@ -422,7 +424,11 @@ function Invoke-EntityExtraction {
         param($Item, $UsageId, $KnownTypes, $InvBag, $FailBag, $Model)
         $Node = [PSCustomObject]@{ NodeId = $Item.NodeId; DocIds = $Item.DocIds; Proposals = @(); OrgMentions = @(); Model = $null; ParseOk = $false }
         try {
-            $ai = Invoke-AIByUsage -UsageId $UsageId -Values @{ node_id = $Item.NodeId; facts = $Item.FactsText } -Override @{ model = $Model }
+            # t/3123: only override the usage's configured model when -Model was explicitly passed
+            # ($Model is '' by default). Otherwise the usage's model (claude-sonnet-4-6) wins — a
+            # gemini-flash default here sent the Claude-shaped schema to Gemini → HTTP 400.
+            $ModelOverride = if ($Model) { @{ model = $Model } } else { @{} }
+            $ai = Invoke-AIByUsage -UsageId $UsageId -Values @{ node_id = $Item.NodeId; facts = $Item.FactsText } -Override $ModelOverride
             if ($null -ne $ai -and $ai.Text) {
                 $body = [string]$ai.Text
                 $body = $body -replace '^\s*```(json)?\s*', ''
@@ -497,7 +503,9 @@ function Invoke-EntityExtraction {
 
             $Node = [PSCustomObject]@{ NodeId = $Item.NodeId; DocIds = $Item.DocIds; Proposals = @(); OrgMentions = @(); Model = $null; ParseOk = $false }
             try {
-                $ai = Invoke-AIByUsage -UsageId $UsageIdVal -Values @{ node_id = $Item.NodeId; facts = $Item.FactsText } -Override @{ model = $ModelVal }
+                # t/3123: override only when -Model was explicitly passed (see sequential path).
+                $ModelOverride = if ($ModelVal) { @{ model = $ModelVal } } else { @{} }
+                $ai = Invoke-AIByUsage -UsageId $UsageIdVal -Values @{ node_id = $Item.NodeId; facts = $Item.FactsText } -Override $ModelOverride
                 if ($null -ne $ai -and $ai.Text) {
                     $body = [string]$ai.Text
                     $body = $body -replace '^\s*```(json)?\s*', ''

--- a/tests/Invoke-EntityExtraction.Tests.ps1
+++ b/tests/Invoke-EntityExtraction.Tests.ps1
@@ -56,23 +56,27 @@ Describe 'Invoke-EntityExtraction (t/1806 Phase 1)' -Tag 'unit' {
             ($seiContent | ConvertTo-Json -Depth 8) | Set-Content -Path $script:seiPath -Encoding utf8NoBOM
         }
 
-        It 'Passes the default gemini-3.5-flash-lite to Invoke-AIByUsage when -Model is omitted' {
+        It 'Does NOT override the model when -Model is omitted — the usage''s configured model wins (t/3123)' {
             InModuleScope AITriad -Parameters @{ TaxDir = $script:emptyTaxDir; DataRoot = $script:emptyDataRoot; EntPath = $script:entPath; EmbPath = $script:embPath; SeiPath = $script:seiPath; LogPath = $script:logPath } {
                 param($TaxDir, $DataRoot, $EntPath, $EmbPath, $SeiPath, $LogPath)
 
                 Mock Get-UsageRegistry -MockWith { [PSCustomObject]@{ 'enrichment.entity-extraction' = @{} } }
                 Mock Get-TaxonomyDir -MockWith ({ $TaxDir }.GetNewClosure())
                 Mock Get-DataRoot -MockWith ({ $DataRoot }.GetNewClosure())
+                # t/3123: with -Model omitted, the cmdlet must pass an EMPTY override (no `model` key)
+                # so Invoke-AIByUsage falls back to the usage's configured model (claude-sonnet-4-6).
+                # Previously it force-injected gemini-3.5-flash-lite, which 400'd the Claude-shaped schema.
+                $script:capturedHasModel = 'MOCK-NOT-CALLED'
                 Mock Invoke-AIByUsage -MockWith {
                     param($UsageId, $Values, $Override, $ApiKey, $FallbackModels)
-                    $script:capturedModel = $Override.model
+                    $script:capturedHasModel = [bool]($Override -and $Override.ContainsKey('model'))
                     [PSCustomObject]@{ Text = '{"proposals":[],"org_mentions":[]}'; Model = 'stub' }
                 }
 
                 Invoke-EntityExtraction -NodeId 'node-a' -Concurrency 1 `
                     -EntitiesPath $EntPath -EmbeddingsPath $EmbPath -SourceEvidenceIndexPath $SeiPath -OutputPath $LogPath -Confirm:$false | Out-Null
 
-                $script:capturedModel | Should -Be 'gemini-3.5-flash-lite'
+                $script:capturedHasModel | Should -BeFalse
             }
         }
 


### PR DESCRIPTION
## What

Fix-forward for the model-default half of the t/3123 extraction unblock. #1737 merged at a **stale head** that carried only the `Protect-SensitiveText` relocation — the model-default fix (2 commits) was stranded on the branch. This cherry-picks them onto current `main`.

## Change

`Invoke-EntityExtraction -Model` defaulted to `gemini-3.5-flash-lite` and **force-overrode the usage's model on every call**. But `enrichment.entity-extraction` is configured for `claude-sonnet-4-6` (Claude-shaped structured schema), so the gemini-flash default sent a request Gemini rejects with **HTTP 400** — every node failed.

Fix: `-Model` now defaults to `''` and is applied as an override **only when explicitly passed**, so the usage's configured model wins by default. Human-approved (option A) after the smoke batch surfaced the 400. Verified live: default-model 1-node run mints end-to-end (was FAILED=1, now FAILED=0/MINTED=1).

## Tests

`Invoke-EntityExtraction.Tests.ps1` 14/0 (updated the model-override test to the new contract: no `model` key in the override when `-Model` is omitted).

Refs t/3123. Companion to #1737 (Protect-SensitiveText, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)