### PR TITLE
security(devops): t/3135 CVE sweep — image-size@2.0.2, perl/libtiff6 dismissals, base rebuild trigger

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,8 +4,8 @@
 # POLICY (t/2006): no silent suppression. Every entry MUST carry: the CVE, the
 # affected package, WHY it is ignored, and a concrete REVISIT trigger. Anything
 # with an available upstream fix must be patched (base rebuild), not ignored.
-# Last reviewed: 2026-08-15 (Docker). Trixie migration complete (t/2681) — re-scan
-# will confirm which entries below are cleared by Trixie's newer package versions.
+# Last reviewed: 2026-09-01 (t/3135). Added perl CRITICALs + libtiff6 CVE-2026-52490
+# (no-fix dismissals). image-size bumped to 2.0.2 via override (no longer suppressed here).
 
 # ── util-linux (Debian bookworm) — NO UPSTREAM FIX AVAILABLE ────────────────────
 # CVE-2026-13595  util-linux mount privilege-escalation via crafted fstab (warning)
@@ -696,5 +696,33 @@ CVE-2026-23949
 #            at runtime.
 # REVISIT:   drop when Debian trixie ships a fixed python3.13 (deb13u5+). Re-scan.
 CVE-2026-4360
+
+# ── perl (Trixie) — CRITICAL — NO UPSTREAM FIX AVAILABLE ─────────────────────
+# CVE-2026-13221  perl: CRITICAL — no Trixie fix as of 2026-09-01 (t/3135)
+# CVE-2026-8376   perl: CRITICAL — no Trixie fix as of 2026-09-01 (t/3135)
+#
+# Package:   perl (trixie, transitive dep of dpkg maintenance scripts)
+# Fix state: Debian trixie has published NO fixed version for either CVE.
+# Exposure:  perl is pulled in transitively by dpkg/dpkg-dev post-install hooks;
+#            it cannot be stripped from the runtime image without breaking package
+#            management. No exec surface: the container CMD is a direct `node`
+#            invocation; the web console spawns pwsh (not perl); perl is not
+#            callable from any external-facing interface.
+# REVISIT:   drop when Debian trixie ships a fixed perl. Re-scan.
+CVE-2026-13221
+CVE-2026-8376
+
+# ── libtiff6 (Trixie) — HIGH — NO UPSTREAM FIX AVAILABLE ────────────────────
+# CVE-2026-52490  libtiff6: HIGH — no Trixie fix as of 2026-09-01 (t/3135)
+#
+# Package:   libtiff6 (trixie, transitive dep of poppler-utils)
+# Fix state: Debian trixie has published NO fixed version as of 2026-09-01.
+# Exposure:  libtiff6 is a transitive dep of poppler-utils (PDF text extraction).
+#            The application processes academic PDFs via pandoc/poppler for text
+#            only; the vulnerable TIFFReadDirectory path is not invoked by our
+#            PDF pipeline (we extract text, not TIFF images embedded in PDFs).
+#            Practical exploitability is negligible.
+# REVISIT:   drop when Debian trixie ships a fixed libtiff6. Re-scan.
+CVE-2026-52490
 
 

--- a/deploy/azure/Dockerfile.base
+++ b/deploy/azure/Dockerfile.base
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7
 
 # AI Triad Base Image — heavy system dependencies, rebuilt monthly.
-# Last rebuild forced: 2026-08-31 (CACHE_BUST added so security upgrades stop cache-hitting, t/3137)
+# Last rebuild forced: 2026-09-01 (t/3135 CVE sweep — image-size, perl, libtiff6 triage; .trivyignore added)
 #
 # Contains: Node 22, system packages, a build-time-baked flat ONNX embedding
 # model (all-MiniLM-L6-v2, read in-process via onnxruntime-node), and the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   uuid: '>=11.1.1'
   '@opentelemetry/core': '>=2.8.0'
   js-yaml: '>=4.3.1'
+  image-size: '>=1.2.2'
 
 importers:
 
@@ -3921,8 +3922,8 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
-  image-size@1.2.1:
-    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+  image-size@2.0.2:
+    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
     hasBin: true
 
@@ -5128,9 +5129,6 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
-
-  queue@6.0.2:
-    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -10422,9 +10420,7 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  image-size@1.2.1:
-    dependencies:
-      queue: 6.0.2
+  image-size@2.0.2: {}
 
   immediate@3.0.6: {}
 
@@ -11707,7 +11703,7 @@ snapshots:
     dependencies:
       '@types/node': 22.20.1
       https: 1.0.0
-      image-size: 1.2.1
+      image-size: 2.0.2
       jszip: 3.10.1
 
   prelude-ls@1.2.1: {}
@@ -11794,10 +11790,6 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
-
-  queue@6.0.2:
-    dependencies:
-      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,7 @@ overrides:
   uuid: ">=11.1.1"
   "@opentelemetry/core": ">=2.8.0"
   js-yaml: ">=4.3.1"
+  image-size: ">=1.2.2"
 
 allowBuilds:
   '@google/genai': true

--- a/taxonomy-editor/THIRD-PARTY-NOTICES.txt
+++ b/taxonomy-editor/THIRD-PARTY-NOTICES.txt
@@ -2725,7 +2725,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - image-size@1.2.1
+ - image-size@2.0.2
 
 This package contains the following license:
 
@@ -4369,23 +4369,6 @@ This package contains the following license:
 The MIT License (MIT)
 
 Copyright (c) 2012 Ryan Day
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
------------
-
-The following npm package may be included in this product:
-
- - queue@6.0.2
-
-This package contains the following license:
-
-The MIT License (MIT)
-Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/taxonomy-editor/pnpm-lock.yaml
+++ b/taxonomy-editor/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   uuid: '>=11.1.1'
   '@opentelemetry/core': '>=2.8.0'
   js-yaml: '>=4.3.1'
+  image-size: '>=1.2.2'
 
 importers:
 
@@ -3375,8 +3376,8 @@ packages:
     resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
     engines: {node: '>= 4'}
 
-  image-size@1.2.1:
-    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+  image-size@2.0.2:
+    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
     hasBin: true
 
@@ -4543,9 +4544,6 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
-
-  queue@6.0.2:
-    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -9556,9 +9554,7 @@ snapshots:
 
   ignore@7.0.6: {}
 
-  image-size@1.2.1:
-    dependencies:
-      queue: 6.0.2
+  image-size@2.0.2: {}
 
   immediate@3.0.6: {}
 
@@ -10808,7 +10804,7 @@ snapshots:
     dependencies:
       '@types/node': 22.20.1
       https: 1.0.0
-      image-size: 1.2.1
+      image-size: 2.0.2
       jszip: 3.10.1
 
   prelude-ls@1.2.1: {}
@@ -10894,10 +10890,6 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
-
-  queue@6.0.2:
-    dependencies:
-      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 

--- a/taxonomy-editor/src/renderer/data/oss-licenses.json
+++ b/taxonomy-editor/src/renderer/data/oss-licenses.json
@@ -732,7 +732,7 @@
     },
     {
       "name": "image-size",
-      "version": "1.2.1",
+      "version": "2.0.2",
       "license": "MIT"
     },
     {
@@ -1278,11 +1278,6 @@
     {
       "name": "qrcode",
       "version": "1.5.4",
-      "license": "MIT"
-    },
-    {
-      "name": "queue",
-      "version": "6.0.2",
       "license": "MIT"
     },
     {
@@ -2943,7 +2938,7 @@
       "packages": [
         {
           "name": "image-size",
-          "version": "1.2.1"
+          "version": "2.0.2"
         }
       ],
       "licenseType": "MIT",
@@ -3312,16 +3307,6 @@
       ],
       "licenseType": "MIT",
       "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2012 Ryan Day\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
-    },
-    {
-      "packages": [
-        {
-          "name": "queue",
-          "version": "6.0.2"
-        }
-      ],
-      "licenseType": "MIT",
-      "licenseText": "The MIT License (MIT)\nCopyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
     },
     {
       "packages": [


### PR DESCRIPTION
## Summary

- **image-size** bumped `1.2.1→2.0.2` via `pnpm-workspace.yaml` override (clears CVE-2025-71329 and CVE-2025-71330 HIGH from `pptxgenjs` transitive dep); both lockfiles regenerated
- **`.trivyignore`** header updated; perl CRITICALs (CVE-2026-13221, CVE-2026-8376) and libtiff6 HIGH (CVE-2026-52490) added as dismiss-with-justification — all three have no Debian trixie fix available, with exposure analysis per t/2006 policy
- **`Dockerfile.base`** comment updated → triggers `base-image.yml` rebuild on merge via path-based push trigger; cache-bust mechanism (t/3137, #1678) ensures the rebuild genuinely runs `apt-get upgrade`, clearing residual Debian OS mediums

## Context (t/3135)

Prior steps already landed: cache-bust fix (#1678), strip-npm (#1683), openssl/tar base rebuild (t/3137). This PR completes the npm-dep and no-fix-CVE arms.

After merge the base-image workflow fires automatically. Once the new base digest is available, a follow-up PR will bump `taxonomy-editor/Dockerfile`'s `FROM ghcr.io/jpsnover/ai-triad-base:` tag + digest and trigger a container rescan to confirm the open-alert count drops to only documented dismissals.

## Test plan

- [ ] CI green (pnpm lockfile consistency, TypeScript build, test-container)
- [ ] `base-image.yml` fires automatically on merge (Dockerfile.base path trigger)
- [ ] After base rebuild: container rescan shows `image-size` alerts gone; perl/libtiff6 suppressed by `.trivyignore`; residual Debian OS mediums reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiB6s5mCbCXbkWrQ8AjHXT