### PR TITLE
fix(tax): surface concept_refs/entity_refs through Get-Tax (t/3197)

### DIFF
--- a/scripts/AITriad/AITriad.psm1
+++ b/scripts/AITriad/AITriad.psm1
@@ -137,6 +137,15 @@ class TaxonomyNode {
     [string[]]$Children
     [string[]]$CrossCuttingRefs
     [string[]]$SituationRefs
+    # t/3197 — G1 grounding refs (t/3157), written onto POV nodes by the G7 reconciler
+    # (reconcile_grounding.py). Arrays of objects:
+    #   ConceptRefs[] : { ref: 'term:<canonical_form>', surface, method: surface|embedding, link_confidence, status: linked|proposed }
+    #   EntityRefs[]  : { ref: <entity_id>, surface, method: exact|alias, link_confidence, match_level, status: linked }
+    # Default to a NON-NULL empty array: under Set-StrictMode -Version Latest, `$null.Count`
+    # THROWS, so a $null default would break the AC filter `Where-Object { $_.ConceptRefs.Count }`
+    # on ungrounded nodes. ([PSObject[]]@() coerces to $null for a typed property; ::new(0) does not.)
+    [PSObject[]]$ConceptRefs = [PSObject[]]::new(0)
+    [PSObject[]]$EntityRefs  = [PSObject[]]::new(0)
     # t/1588 — structural signals mirrored from lib/debate/severeTestScheduler.ts's
     # computeNodeImportance() so PS + TS derive `degree` and `usage` from the
     # same source. ConflictIds may be absent on nodes with no conflict links;

--- a/scripts/AITriad/Private/ConvertTo-TaxonomyNode.ps1
+++ b/scripts/AITriad/Private/ConvertTo-TaxonomyNode.ps1
@@ -84,6 +84,14 @@ function ConvertTo-TaxonomyNode {
         if ($null -ne $Node.PSObject.Properties['debate_refs']) {
             $Obj.DebateRefs = @($Node.debate_refs)
         }
+
+        # t/3197 — G1 grounding refs (t/3157), written onto POV nodes by the G7 reconciler
+        # (reconcile_grounding.py). Overwrite ONLY when present; the class defaults both to a
+        # non-null empty array, so an ungrounded node keeps [] (not $null) and
+        # `Get-Tax | Where-Object { $_.ConceptRefs.Count }` / `... EntityRefs.Count` filter safely
+        # under StrictMode. (An `else { @() }` here would re-null the property — @() coerces to $null.)
+        if ($null -ne $Node.PSObject.Properties['concept_refs']) { $Obj.ConceptRefs = @($Node.concept_refs) }
+        if ($null -ne $Node.PSObject.Properties['entity_refs'])  { $Obj.EntityRefs  = @($Node.entity_refs) }
     }
 
     # Cross-cutting file has interpretations and linked_nodes

--- a/tests/ConvertTo-TaxonomyNode.GroundingRefs.Tests.ps1
+++ b/tests/ConvertTo-TaxonomyNode.GroundingRefs.Tests.ps1
@@ -1,0 +1,78 @@
+# Tag: unit (t/3197)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    t/3197: ConvertTo-TaxonomyNode must project the G1 grounding refs (concept_refs / entity_refs,
+    t/3157) onto the typed [TaxonomyNode] so `Get-Tax | Where-Object { $_.ConceptRefs.Count }` and
+    `... EntityRefs.Count` surface grounded nodes instead of silently returning zero rows.
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'ConvertTo-TaxonomyNode grounding refs (t/3197)' -Tag 'unit' {
+
+    It 'projects concept_refs and entity_refs from a POV node onto the typed object' {
+        InModuleScope AITriad {
+            $raw = [pscustomobject]@{
+                id            = 'acc-beliefs-001'
+                label         = 'Test node'
+                description   = 'desc'
+                category      = 'Beliefs'
+                parent_id     = $null
+                children      = @()
+                concept_refs  = @(
+                    [pscustomobject]@{ ref = 'term:oversight'; surface = 'oversight'; method = 'surface'; link_confidence = 1.0; status = 'linked' }
+                    [pscustomobject]@{ ref = 'term:alignment'; surface = 'alignment'; method = 'embedding'; link_confidence = 0.61; status = 'proposed' }
+                )
+                entity_refs   = @(
+                    [pscustomobject]@{ ref = 'ent-001'; surface = 'Apollo Project'; method = 'exact'; link_confidence = 1.0; match_level = 'exact'; status = 'linked' }
+                )
+            }
+
+            $node = ConvertTo-TaxonomyNode -PovKey 'accelerationist' -Node $raw
+
+            @($node.ConceptRefs).Count | Should -Be 2
+            @($node.EntityRefs).Count  | Should -Be 1
+            $node.ConceptRefs[0].ref   | Should -Be 'term:oversight'
+            $node.ConceptRefs[1].status | Should -Be 'proposed'
+            $node.EntityRefs[0].ref    | Should -Be 'ent-001'
+            $node.EntityRefs[0].match_level | Should -Be 'exact'
+        }
+    }
+
+    It 'defaults ConceptRefs/EntityRefs to empty arrays on an ungrounded POV node (so .Count filters correctly)' {
+        InModuleScope AITriad {
+            $raw = [pscustomobject]@{
+                id = 'acc-beliefs-002'; label = 'Ungrounded'; description = 'd'; category = 'Beliefs'; parent_id = $null; children = @()
+            }
+            $node = ConvertTo-TaxonomyNode -PovKey 'accelerationist' -Node $raw
+
+            # The AC's filter is `Where-Object { $_.ConceptRefs.Count }`; a [PSObject[]] class
+            # property left ungrounded reads as $null, and $null.Count is 0 — so the filter yields
+            # 0 and drops the node, exactly as intended (never a false positive).
+            $node.ConceptRefs.Count | Should -Be 0
+            $node.EntityRefs.Count  | Should -Be 0
+        }
+    }
+
+    It 'a Where-Object filter on .ConceptRefs.Count selects only grounded nodes (the AC)' {
+        InModuleScope AITriad {
+            $grounded = ConvertTo-TaxonomyNode -PovKey 'accelerationist' -Node ([pscustomobject]@{
+                    id = 'acc-1'; label = 'g'; description = 'd'; category = 'Beliefs'; parent_id = $null; children = @()
+                    concept_refs = @([pscustomobject]@{ ref = 'term:x'; status = 'linked' })
+                })
+            $bare = ConvertTo-TaxonomyNode -PovKey 'accelerationist' -Node ([pscustomobject]@{
+                    id = 'acc-2'; label = 'b'; description = 'd'; category = 'Beliefs'; parent_id = $null; children = @()
+                })
+            $selected = @($grounded, $bare) | Where-Object { $_.ConceptRefs.Count }
+            @($selected).Count | Should -Be 1
+            $selected.Id | Should -Be 'acc-1'
+        }
+    }
+}


### PR DESCRIPTION
## What

`Get-Tax | Where-Object { \$_.ConceptRefs.Count }` / `... EntityRefs.Count` returned **zero rows** even for grounded nodes — `ConvertTo-TaxonomyNode` projects a fixed `[TaxonomyNode]` property set that dropped the G1 grounding refs (`concept_refs`/`entity_refs`, t/3157) written by the G7 reconciler. Projection gap, not a data gap.

## Change

- Add `ConceptRefs` / `EntityRefs` (`[PSObject[]]`) to the `[TaxonomyNode]` class.
- Copy them in the POV-node block of `ConvertTo-TaxonomyNode` (alongside `ConflictIds`/`SituationRefs`).

## Deviation from the ticket's suggested `else { @() }` (flagging)

An empty `@()` assigned to a `[PSObject[]]` **class property coerces to `$null`**, and under `Set-StrictMode -Version Latest` **`$null.Count` throws** — which would break the AC's own `Where-Object { \$_.ConceptRefs.Count }` on ungrounded nodes. So instead the class **defaults both properties to a non-null empty array** (`[PSObject[]]::new(0)`), and the projection overwrites only when present. Ungrounded nodes keep `[]`, the filter is StrictMode-safe.

## Tests

`ConvertTo-TaxonomyNode.GroundingRefs.Tests.ps1` — 3 cases: grounded projection (incl. field shapes per CL's spec), ungrounded → empty `[]`, and the AC `Where`-filter selects only grounded nodes. Full unit suite **192/0**; manifest OK.

Self-cert: single-scope projection add following the existing `ConflictIds` pattern; no new public cmdlet, no schema change (reads existing JSON keys). **CL:** field shapes match your t/3197 spec — flag if you want any adjustment.

Refs t/3197, t/3157.

🤖 Generated with [Claude Code](https://claude.com/claude-code)