### PR TITLE
fix(embeddings): identity-guard worker handlers (t/3181 — recover stranded GV fix)

### DIFF
--- a/lib/embeddings/offThreadEmbedding.test.ts
+++ b/lib/embeddings/offThreadEmbedding.test.ts
@@ -126,6 +126,39 @@ describe('offThreadEmbedding — arm (b): crash → reject + respawn with backof
   });
 });
 
+describe('offThreadEmbedding — respawn survives a stale event from the superseded worker (identity-guard)', () => {
+  it('ignores a late exit/message from the old terminated worker; the fresh worker keeps serving', async () => {
+    vi.useFakeTimers();
+    const workers: FakeWorker[] = [];
+    __setEmbeddingWorkerFactory(() => { const w = new FakeWorker(); workers.push(w); return w; });
+
+    // Task 1 dispatched on worker1, then worker1 crashes → reject + respawn-backoff.
+    const p1 = computeEmbeddingsOffThread(['x'], { requester: 'first' });
+    const p1Rejected = expect(p1).rejects.toThrow(/worker crash/i);
+    workers[0].emit('error', new Error('boom'));
+    await p1Rejected;
+    const staleId = workers[0].lastId();
+
+    // Clear the backoff gap and dispatch task 2 on a fresh worker2.
+    await vi.advanceTimersByTimeAsync(300);
+    const p2 = computeEmbeddingsOffThread(['y'], { requester: 'second' });
+    expect(workers).toHaveLength(2);
+    const liveId = workers[1].lastId();
+    const warnsBefore = warns().length;
+
+    // The OLD (terminated) worker fires late events — the identity-guard must DROP them so the
+    // healthy new worker is neither torn down nor its in-flight task disturbed.
+    workers[0].emit('exit', 137);
+    workers[0].emit('message', resultFor(staleId, [[9, 9, 9, 9]]));
+    expect(workers[1].terminated).toBe(false);   // new worker untouched
+    expect(warns().length).toBe(warnsBefore);    // no crash/wedge WARN from the stale events
+
+    // worker2 completes task 2 normally → resolves cleanly (respawn survived).
+    workers[1].emit('message', resultFor(liveId, [[1, 0, 0, 0]]));
+    await expect(p2).resolves.toHaveLength(1);
+  });
+});
+
 describe('offThreadEmbedding — arm (c): wedge (heartbeat stall) → terminate + respawn + WARN', () => {
   it('terminates + respawns + WARNs when no heartbeat arrives within the watchdog window', async () => {
     vi.useFakeTimers();

--- a/lib/embeddings/offThreadEmbedding.ts
+++ b/lib/embeddings/offThreadEmbedding.ts
@@ -174,9 +174,18 @@ function pump(): void {
 
 function spawnWorker(): EmbeddingWorkerLike {
   const w = _workerFactory();
-  w.on('message', onWorkerMessage as (arg: never) => void);
-  w.on('error', ((err: Error) => onWorkerDown('crash', err instanceof Error ? err.message : String(err))) as (arg: never) => void);
-  w.on('exit', ((code: number) => { if (code !== 0) onWorkerDown('exit', `worker exited with code ${code}`); }) as (arg: never) => void);
+  // IDENTITY-GUARD every handler on the specific worker instance `w`: after a respawn the OLD
+  // (terminated) worker can still emit a late 'exit'/'error'/'message'. Without this guard that
+  // stale event would act on the CURRENT module state — e.g. an old worker's late 'exit' would
+  // call onWorkerDown and tear down the HEALTHY new worker (reject its task, terminate, re-respawn).
+  // `w !== _worker` means the event came from a superseded worker → drop it. (TL GV required fix.)
+  w.on('message', ((msg: WorkerMessage) => { if (w === _worker) onWorkerMessage(msg); }) as (arg: never) => void);
+  w.on('error', ((err: Error) => {
+    if (w === _worker) onWorkerDown('crash', err instanceof Error ? err.message : String(err));
+  }) as (arg: never) => void);
+  w.on('exit', ((code: number) => {
+    if (w === _worker && code !== 0) onWorkerDown('exit', `worker exited with code ${code}`);
+  }) as (arg: never) => void);
   return w;
 }
 


### PR DESCRIPTION
Lands the t/3181 identity-guard fix that was **stranded**: #1748 merged at the pre-fix head a77ed078 (merge 594a503a), so main got the buggy version and the fix commit 7530f055 never landed. This is that exact 2-file diff cherry-picked onto current main.

**The fix (TL GV-cleared, p/342#234):** capture the worker ref in `spawnWorker` and identity-guard all three handlers (`w === _worker`) so a superseded/terminated worker's late error/exit/message can't tear down the healthy respawned worker. Plus the respawn-survives test (old worker's late exit(137)+stale message after respawn → new worker untouched, no spurious WARN, task completes; genuinely discriminates vs pre-fix).

Identical content already verified: vitest 7 pass/1 skip, eslint 0, CI 25/25 on 7530f055. Cherry-pick applied clean onto main (main already had a77ed078's base files via #1748). Self-merge on green — GV already granted.

Unblocks B (t/3183) + C (t/3184) once on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)