### PR TITLE
perf(embeddings): off-thread ONNX compute behind EMBEDDING_WORKER_OFFLOAD (t/3183)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/embeddingWorkerOffload.test.ts
+++ b/taxonomy-editor/src/server/__tests__/embeddingWorkerOffload.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3183 (t/2977 Item B) — computeEmbeddings delegates the ONNX miss-text pass to the shared
+// off-thread worker (t/3181) behind the per-build capability switch EMBEDDING_WORKER_OFFLOAD.
+//
+// The headline proof is the BOTH-ARMS LIVENESS test the t/3165 incident lacked: under a ≥1347-text
+// compute, the main-thread event-loop max-gap stays under the ACA liveness deadline with the flag
+// ON (work is off-thread) and BLOWS the deadline with it OFF (a 128-text ONNX chunk blocks the loop
+// synchronously). The other four tests lock the contract: flag-OFF byte-identical, flag-ON routes to
+// the worker + widens Float32Array→number[], the requester label reaches the worker, and the C6
+// demand-baseline WARN fires above the by-design novel-text ceiling / stays silent at it.
+//
+// The REAL resolveEmbeddings + resolveEmbeddingsChunked run (chunk-and-yield is the mechanism under
+// test); only the two leaf computes (onnx in-thread / off-thread worker) and the data-file read are
+// mocked. isPythonEmbeddingAvailable is forced false so the chain is onnx-only (the ACA shape).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { performance } from 'node:perf_hooks';
+
+const { onnxCompute, offthread, records } = vi.hoisted(() => ({
+  onnxCompute: vi.fn(),
+  offthread: vi.fn(),
+  records: [] as Array<{ level?: string; message?: string; data?: Record<string, unknown> }>,
+}));
+
+// onnx-only chain (Python venv absent = the ACA shape). tryWarmup true → the onnx member is pushed.
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  tryWarmup: vi.fn(async () => true),
+  warmup: vi.fn(async () => true),
+  computeEmbedding: vi.fn(async () => []),
+  computeEmbeddings: onnxCompute,
+}));
+// The worker contract (t/3181) — mocked so this test never spawns a real thread.
+vi.mock('../../../../lib/embeddings/offThreadEmbedding.js', () => ({ computeEmbeddingsOffThread: offthread }));
+// Capture FR records so the demand-baseline WARN is assertable.
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({
+  getGlobalRecorder: () => ({ record: (r: unknown) => { records.push(r as { message?: string }); } }),
+  setGlobalRecorder: vi.fn(),
+}));
+// Empty cache → every text is a miss → the whole batch flows to the chain compute.
+vi.mock('../storage/readDataFile.js', () => ({ readDataFile: vi.fn(async () => Buffer.from('{"nodes":{}}')) }));
+vi.mock('../ai/fsCache.js', () => ({ readFileWithMtime: vi.fn(() => ({ content: '{}', mtimeMs: 1 })) }));
+
+import { computeEmbeddings, _resetEmbeddingsCacheForTest, _setPythonAvailableForTest } from '../ai/aiBackends.js';
+
+const DIM = 8; // tiny vectors — dimensionality is irrelevant to liveness/conversion, keep the test cheap.
+
+/** Busy-spin the main thread for `ms` (simulates a synchronous ONNX batch blocking the event loop). */
+function blockFor(ms: number): void {
+  const end = performance.now() + ms;
+  while (performance.now() < end) { /* deliberate synchronous block */ }
+}
+
+/** Measure the worst main-thread stall while `run` executes, via a recursive-setImmediate heartbeat. */
+async function maxEventLoopGapDuring(run: () => Promise<unknown>): Promise<number> {
+  let last = performance.now();
+  let maxGap = 0;
+  let running = true;
+  const tick = (): void => {
+    const now = performance.now();
+    maxGap = Math.max(maxGap, now - last);
+    last = now;
+    if (running) setImmediate(tick);
+  };
+  setImmediate(tick);
+  await run();
+  running = false;
+  return maxGap;
+}
+
+const vecs = (n: number, dim = DIM): number[][] => Array.from({ length: n }, () => new Array(dim).fill(0.1));
+const f32vecs = (n: number, dim = DIM): Float32Array[] => Array.from({ length: n }, () => Float32Array.from(new Array(dim).fill(0.1)));
+
+describe('computeEmbeddings worker offload (t/3183)', () => {
+  beforeEach(() => {
+    _resetEmbeddingsCacheForTest();
+    _setPythonAvailableForTest(false); // chain = onnx only
+    onnxCompute.mockReset();
+    offthread.mockReset();
+    records.length = 0;
+    onnxCompute.mockImplementation(async (t: string[]) => vecs(t.length));
+    offthread.mockImplementation(async (t: string[]) => f32vecs(t.length));
+    delete process.env.EMBEDDING_WORKER_OFFLOAD;
+  });
+  afterEach(() => { delete process.env.EMBEDDING_WORKER_OFFLOAD; });
+
+  // ── The both-arms liveness proof (the assertion the t/3165 incident lacked) ──
+  it('LIVENESS: flag OFF starves the event loop on a ≥1347-text compute; flag ON keeps it live', async () => {
+    const N = 1347;
+    const texts = Array.from({ length: N }, (_, i) => `novel-${i}`);
+    const BLOCK_MS = 50;   // a single 128-text ONNX chunk's synchronous cost, simulated
+    const DEADLINE_MS = 30; // the assertion threshold (well under ACA's liveness budget), injectable here
+
+    // Arm OFF: in-thread onnx blocks synchronously per chunk → the loop stalls past the deadline.
+    delete process.env.EMBEDDING_WORKER_OFFLOAD;
+    onnxCompute.mockImplementation(async (t: string[]) => { blockFor(BLOCK_MS); return vecs(t.length); });
+    const gapOff = await maxEventLoopGapDuring(() => computeEmbeddings(texts));
+    expect(gapOff).toBeGreaterThanOrEqual(DEADLINE_MS); // starves — this is the incident, reproduced
+    expect(offthread).not.toHaveBeenCalled();
+
+    // Arm ON: the worker does the same work off the caller's thread → the main loop stays responsive.
+    // Model that honestly: the mock resolves via setImmediate and NEVER blocks the caller's stack (a
+    // real worker's compute runs on its own thread; only the transferred result crosses back).
+    _resetEmbeddingsCacheForTest();
+    records.length = 0;
+    onnxCompute.mockClear(); // drop the OFF-arm call history so the ON-arm "never touched" check is honest
+    process.env.EMBEDDING_WORKER_OFFLOAD = '1';
+    offthread.mockImplementation((t: string[]) => new Promise<Float32Array[]>((resolve) => {
+      setImmediate(() => resolve(f32vecs(t.length))); // resolves without blocking the caller's loop
+    }));
+    const gapOn = await maxEventLoopGapDuring(() => computeEmbeddings(texts));
+    expect(gapOn).toBeLessThan(DEADLINE_MS); // live — the loop yields between chunks, nothing blocks it
+    expect(offthread).toHaveBeenCalled();
+    expect(onnxCompute).not.toHaveBeenCalled(); // flag ON never touches the in-thread path
+  });
+
+  it('flag OFF is byte-identical: runs the in-thread onnx path, never the worker', async () => {
+    delete process.env.EMBEDDING_WORKER_OFFLOAD;
+    const { vectors, cacheMisses } = await computeEmbeddings(['a', 'b', 'c']);
+    expect(cacheMisses).toBe(3);
+    expect(vectors).toHaveLength(3);
+    expect(onnxCompute).toHaveBeenCalledTimes(1);
+    expect(offthread).not.toHaveBeenCalled();
+  });
+
+  it('flag ON routes to the worker and widens Float32Array[] → number[][]', async () => {
+    process.env.EMBEDDING_WORKER_OFFLOAD = '1';
+    offthread.mockImplementation(async (t: string[]) =>
+      t.map((_, i) => Float32Array.from([i, i + 0.5, i + 0.25, 0, 0, 0, 0, 0])));
+    const { vectors } = await computeEmbeddings(['x', 'y']);
+    expect(offthread).toHaveBeenCalledTimes(1);
+    expect(onnxCompute).not.toHaveBeenCalled();
+    expect(Array.isArray(vectors[0])).toBe(true);          // number[], not a Float32Array view
+    expect(vectors[0][0]).toBeCloseTo(0);
+    expect(vectors[1][1]).toBeCloseTo(1.5);                // second text, second component
+  });
+
+  it('threads the requester label into the worker (so a shed WARN names who was dropped)', async () => {
+    process.env.EMBEDDING_WORKER_OFFLOAD = '1';
+    await computeEmbeddings(['q'], undefined, undefined, { requester: 'my-caller' });
+    expect(offthread).toHaveBeenCalledWith(expect.any(Array), { requester: 'my-caller' });
+  });
+
+  it('C6 demand cap-and-WARN: fires above the by-design baseline, silent at/below it', async () => {
+    const over = Array.from({ length: 300 }, (_, i) => `t${i}`); // 300 misses > 256 baseline
+    await computeEmbeddings(over);
+    const warn = records.find(r => r.level === 'warn' && /exceeds by-design baseline/.test(r.message ?? ''));
+    expect(warn).toBeDefined();
+    expect(warn!.data).toMatchObject({ requester: 'unknown', cacheMisses: 300, baseline: 256 });
+
+    records.length = 0;
+    _resetEmbeddingsCacheForTest();
+    await computeEmbeddings(Array.from({ length: 100 }, (_, i) => `s${i}`)); // 100 ≤ 256 → silent
+    expect(records.find(r => r.level === 'warn' && /exceeds by-design baseline/.test(r.message ?? ''))).toBeUndefined();
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -16,7 +16,7 @@ import { createRequire } from 'module';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 
 const require = createRequire(import.meta.url);
-import { getApiKey, getApiKeys, getProjectRoot, EMBED_SCRIPT, resolveDataPath, type AIBackend } from '../config.js';
+import { getApiKey, getApiKeys, getProjectRoot, EMBED_SCRIPT, resolveDataPath, isEmbeddingWorkerOffloadEnabled, type AIBackend } from '../config.js';
 import { ActionableError } from '../../../../lib/debate/errors.js';
 import { parseJsonRobust } from '../../../../lib/debate/helpers.js';
 import { extractProviderReason, deriveKeyErrorMessage } from './providerErrors.js';
@@ -33,6 +33,9 @@ import {
   computeEmbeddings as onnxComputeEmbeddings,
   tryWarmup as onnxTryWarmup,
 } from '../../../../lib/embeddings/onnxEmbedding.js';
+// t/3183 (t/2977 Item B): off-main-thread ONNX compute via the shared worker (t/3181). Consumed
+// only when EMBEDDING_WORKER_OFFLOAD is on; flag-off never touches this path (byte-identical).
+import { computeEmbeddingsOffThread } from '../../../../lib/embeddings/offThreadEmbedding.js';
 import {
   resolveBackend,
   callProvider,
@@ -663,6 +666,26 @@ const EMBEDDINGS_REQUEST_TIMEOUT_MS = 45_000;
 // (reduces, doesn't eliminate — the durable fix is worker-offload, t/2977 Item B / t/3183).
 const EMBEDDING_COMPUTE_CHUNK = 128;
 
+// t/3183 C6 (t/2977#6) — PROVISIONAL demand baseline for the novel-text class's 3rd recurrence.
+// The worker (Item B) raises the compute CEILING (a big batch no longer blocks the loop) but does
+// NOT bound DEMAND. When a single request's NOVEL (cacheHits=0) count exceeds this, we emit ONE
+// WARN naming the requester — never a hard reject — so an unbounded-demand caller is visible BEFORE
+// it saturates the worker queue (offload on) or the loop (offload off).
+//
+// TIERING vs LARGE_RECOMPUTE_WARN_ITEMS=64 (routes/ai.ts, #1720) — intentionally NOT redundant
+// (TL p/522#134):
+//   • 64  = "notable volume" — a large recompute happened (INFO/WARN, expected under cold cache).
+//   • 256 = "demand baseline exceeded — the DEMAND itself may be the bug" (the class's failure mode).
+//
+// 256 is PROVISIONAL and MUST be calibrated from real data before the flag flips on (TL p/522#133;
+// t/3085 baseline-validation — do NOT confirm a baseline by fiat). It has to sit ABOVE the legit
+// residual-novel-per-turn max or it fires every normal debate (noise = dead gate). The t/3165
+// 792/1347 batches were largely STATIC corpus (now cached), so they do NOT reveal the residual
+// novel count of a normal turn — the storm-replay canary replays the real debate shape and yields
+// that cacheHits=0 distribution; set baseline = observed-legit-max + margin at the canary. 256 is a
+// deliberately-generous placeholder (2× the 128 chunk) chosen to under-fire until calibrated.
+const NOVEL_TEXT_DEMAND_BASELINE = 256;
+
 // Resolve a (possibly large) batch in chunks, yielding the event loop between chunks. Safe
 // because resolveEmbeddings is order-preserving and per-text pure (local cache-hit or chain
 // compute), so concatenating per-chunk results is identical to resolving the whole batch at
@@ -707,14 +730,30 @@ export async function resolveEmbeddingsChunked(
 // Python encoder or the in-process ONNX fallback, both 384-dim/all-MiniLM-L6-v2, no API.
 export async function computeEmbeddings(
   texts: string[], ids?: string[], _explicitApiKey?: string,
+  opts?: { requester?: string },
 ): Promise<{ vectors: number[][]; cacheHits: number; cacheMisses: number }> {
   const startMs = Date.now();
+  // t/3183: label the caller so a worker-queue shed WARN (offload on) and the demand-baseline WARN
+  // both name WHO. Defaults to 'unknown' — callers pass the route/usage (see routes/ai.ts).
+  const requester = opts?.requester ?? 'unknown';
   const local = await loadEmbeddingsFileAsync();
   // t/3086: pre-pass hit count (cheap dict lookup, same data resolveEmbeddings uses).
   const cacheHits = (ids && local)
     ? ids.filter(id => id != null && local.nodes[id] != null).length
     : 0;
   const cacheMisses = texts.length - cacheHits;
+
+  // t/3183 C6: the worker raises the compute ceiling but does not bound demand (class's 3rd
+  // recurrence). One WARN per over-baseline request makes an unbounded-demand caller visible
+  // BEFORE it saturates the worker queue / starves the loop — offload on or off.
+  if (cacheMisses > NOVEL_TEXT_DEMAND_BASELINE) {
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'ai-backends', level: 'warn',
+      message: `Novel-text demand ${cacheMisses} exceeds by-design baseline ${NOVEL_TEXT_DEMAND_BASELINE} (provisional — calibrated at the storm-replay canary) — the worker raises the compute ceiling but does not bound demand; check for an unbounded-demand caller`,
+      data: { requester, cacheMisses, cacheHits, baseline: NOVEL_TEXT_DEMAND_BASELINE, provisional: true, inputCount: texts.length },
+    });
+  }
+
   const chain: EmbeddingFallback[] = [];
 
   // Local Python encoder stays primary when present (TL ruling t/1641#10).
@@ -735,8 +774,17 @@ export async function computeEmbeddings(
   // 384-dim vector space as the stored corpus; no API key, no network.
   if (await onnxTryWarmup()) {
     chain.push({
-      name: 'onnx-batch',
-      compute: (t) => onnxComputeEmbeddings(t),
+      // t/3183 (t/2977 Item B): flag ON → run the ONNX pass in the shared worker thread so a large
+      // miss-text batch can't block the event loop past ACA's liveness deadline (t/3165). The worker
+      // returns Float32Array views over a transferred buffer → widen to number[][] for the resolver.
+      // A shed/crash rejects (load-shed 503) and is NOT caught here — an in-thread recompute would
+      // reintroduce the exact starvation the offload removes (the worker already WARNs the shed with
+      // the requester, per Fallback-Path Logging). Flag OFF → today's exact in-thread call → the
+      // 'onnx-batch' name and behaviour are byte-identical.
+      name: isEmbeddingWorkerOffloadEnabled() ? 'onnx-batch-worker' : 'onnx-batch',
+      compute: (t) => isEmbeddingWorkerOffloadEnabled()
+        ? computeEmbeddingsOffThread(t, { requester }).then(vecs => vecs.map(v => Array.from(v)))
+        : onnxComputeEmbeddings(t),
     });
   }
 

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -396,3 +396,15 @@ export const PORT = parseInt(process.env.PORT || '7862', 10);
 export const EMBED_SCRIPT = path.join(PROJECT_ROOT, 'scripts', 'embed_taxonomy.py');
 export const SCRIPTS_DIR = path.join(PROJECT_ROOT, 'scripts');
 export const BROKER_SCRIPT = path.join(PROJECT_ROOT, 'src', 'main', 'pty-broker.py');
+
+// t/3183 (t/2977 Item B): per-build capability switch that routes embedding miss-text compute
+// off the main thread to the lib/embeddings worker (t/3181). DEFAULT OFF, web-first — when off,
+// computeEmbeddings runs the ONNX fallback in-thread exactly as before (byte-identical). Read
+// per-call (not a module-load const) so the both-arms liveness test can toggle it around a single
+// compute. `EMBEDDING_WORKER_OFFLOAD=1` (or `true`) enables. This is a build/deploy capability, not
+// the admin runtime feature-flag surface (feature-flags.json) — the worker's availability is a
+// property of the build, and the canary flip is an ops action, not a per-user admin toggle.
+export function isEmbeddingWorkerOffloadEnabled(): boolean {
+  const v = process.env.EMBEDDING_WORKER_OFFLOAD?.trim().toLowerCase();
+  return v === '1' || v === 'true';
+}

--- a/taxonomy-editor/src/server/routes/ai.ts
+++ b/taxonomy-editor/src/server/routes/ai.ts
@@ -581,6 +581,10 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
   // t/3165: a fully-recomputed batch at/above this size is flagged as a volume event (novel
   // no-ids text). ≥64 catches the ~200/792 debate grounding batches; below it, small ad-hoc
   // computes stay silent (TL p/522#111 threshold guidance).
+  // TIERED with aiBackends' NOVEL_TEXT_DEMAND_BASELINE=256 (t/3183, TL p/522#134) — NOT redundant:
+  // 64 here = "notable volume, a large recompute happened" (expected under cold cache); 256 there =
+  // "demand baseline exceeded — the demand ITSELF may be the bug" (the novel-text class's failure
+  // mode). Two rungs of the same ladder, different meanings.
   const LARGE_RECOMPUTE_WARN_ITEMS = 64;
 
   post('/api/embeddings/compute', (req, res, body) => withEndpointTimeout(res, 50_000, 'embeddings-compute', async () => {
@@ -625,7 +629,9 @@ export function registerAiRoutes(r: Router, ctx: ServerCtx): void {
       beginEmbeddingCompute();
       try {
         // t/3061: local ONNX — no Gemini call, no key needed.
-        const { vectors, cacheHits, cacheMisses } = await ai.computeEmbeddings(texts, ids, undefined);
+        // t/3183: name the caller so a worker-queue shed WARN (offload on) / demand-baseline WARN
+        // attributes the drop to this route rather than 'unknown'.
+        const { vectors, cacheHits, cacheMisses } = await ai.computeEmbeddings(texts, ids, undefined, { requester: 'embeddings-compute' });
         markEmbeddingModelWarm();
         // t/3079: item_count; t/3086: cache_hits/cache_misses (sustained 0% hit = t/3085 condition).
         getGlobalRecorder()?.record({


### PR DESCRIPTION
## t/3183 — Item B of t/2977 (the t/3165 durable fix, web arm)

Consumes the shared off-thread embedding worker (**t/3181 / #1748, now on main**). `computeEmbeddings` routes its ONNX miss-text pass to `computeEmbeddingsOffThread` behind the per-build env switch **`EMBEDDING_WORKER_OFFLOAD`** (default **OFF**, web-first). Flag OFF is **byte-identical** to today's in-thread path; flag ON keeps the event loop responsive under a large novel-text batch (the t/3165 starvation). Cache resolve + chunk-and-yield stay on the main thread unchanged.

**Ships flag-OFF → zero prod behavior change** until the deliberate post-GV canary flip.

### Changes
- **`config.ts`** — `isEmbeddingWorkerOffloadEnabled()`: env, per-call, default-OFF on unset/blank/non-true (case-insensitive `1`/`true`), documented at point-of-use.
- **`ai/aiBackends.ts`** — the `onnx-batch` chain member routes to the worker when enabled (`Float32Array[]`→`number[][]`); `requester` threaded through so a worker shed WARN names the caller; **no in-thread fallback** on shed (fail-loud → 503, matching the worker's contract). C6 demand cap-and-WARN `NOVEL_TEXT_DEMAND_BASELINE=256`.
- **`routes/ai.ts`** — `/api/embeddings/compute` passes `requester='embeddings-compute'`; tiering comment vs `LARGE_RECOMPUTE_WARN_ITEMS=64`.
- **`__tests__/embeddingWorkerOffload.test.ts`** — 5 tests.

### TL GV context (Q1/Q2 absorbed — t/3183#3)
- **Q1:** capability switch = **env var** (per-revision deploy toggle; flag-off = instant rollback; consistent with sibling `EMBEDDING_COMPUTE_CHUNK`). Not `feature-flags.json`.
- **Q2:** `256` is **PROVISIONAL + WARN-only** (never a hard reject), **tiered** vs `LARGE_RECOMPUTE_WARN_ITEMS=64` (64 = "notable volume"; 256 = "demand itself may be the bug"). Calibrated from the storm-replay canary's real novel-per-turn (cacheHits=0) distribution **before flag-on** — tracked as **t/3199** (blocks the flip). Not confirmed by fiat (t/3085).

### Verification
- **Both-arms liveness proof** (the assertion the incident lacked): a 1347-text compute keeps the main-thread max event-loop gap **under** the deadline with the flag ON, and **starves past** it with the flag OFF.
- 4 contract tests: flag-OFF byte-identical, flag-ON worker routing + `Float32Array→number[]` widen, `requester` threaded, cap-and-WARN above/at baseline.
- `embeddingWorkerOffload.test.ts` **5/5**; 28/28 regression across embeddings/search suites; `tsc -p tsconfig.server.json` clean on touched files.

→ **Main (TL) GV.** Un-draft + self-merge on approval (pre-self-merge verification). Then line up the storm-replay canary (t/3199).