### PR TITLE
fix(entities): preserve datetimes + single-element arrays in claim entity_refs writer (t/3124)

### DIFF
--- a/scripts/AITriad/Private/ConvertFrom-JsonPreserveShape.ps1
+++ b/scripts/AITriad/Private/ConvertFrom-JsonPreserveShape.ps1
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+# Shape-preserving JSON reader for whole-file read-modify-write (t/3124 follow-up). PowerShell
+# 7.4's `ConvertFrom-Json` mutates document SHAPE in two ways that a subsequent whole-file
+# `ConvertTo-Json` then bakes into the file — silently changing fields the write never targeted:
+#
+#   1. ISO-8601 datetime STRINGS are coerced to [datetime], losing the original timezone offset +
+#      trailing fractional digits ("2026-05-02T20:38:45.7336380-04:00" -> re-emitted "...+01:00").
+#      Same defect class as ConvertFrom-EdgesJson / t/2974. `-DateKind String` is PS 7.5+ only.
+#   2. SINGLE-ELEMENT arrays are unwrapped to scalars (`"vocabulary_terms": ["x"]` -> `"x"`, and
+#      `[{...}]` -> a bare object), the "Force-array" pitfall this module already fights.
+#
+# Both are corrected at READ time by walking the ConvertFrom-Json result and a parallel
+# System.Text.Json JsonDocument in tandem (objects matched by property NAME, arrays by INDEX —
+# both parsers preserve source order). SCHEMA-AGNOSTIC: a general walk, not a field allowlist.
+#
+# POWERSHELL ARRAY HAZARD (why the walk is structured the way it is): returning a container through
+# the pipeline is lossy — an EMPTY array collapses to $null and a SINGLE-element array unwraps to a
+# scalar, and each function boundary re-triggers it. So the walker reassigns a slot ONLY for the two
+# corrections that genuinely need a new value — a coerced datetime (-> its string) and a COLLAPSED
+# single-element array (rebuilt via the `,([object[]]...)` idiom in ONE function hop, assigned
+# directly so it is not unwrapped). Objects, empty arrays, and genuine (>=2 element) arrays are
+# fixed IN PLACE and their slot is left untouched. Fails OPEN but NOT silent (mirrors
+# ConvertFrom-EdgesJson, TL t/2974#3). Dot-sourced — do NOT export.
+
+function Restore-CollapsedJsonArray {
+    # ConvertFrom-Json collapsed a single-element source array to the scalar/object $Collapsed.
+    # Rebuild it as an [object[]], recursing into the sole element if it is itself a container or a
+    # coerced datetime. Returns via `,([object[]]...)` in ONE hop so a direct slot assignment at the
+    # caller keeps it an array (no pipeline unwrap).
+    [CmdletBinding()]
+    param(
+        $Collapsed,
+        [System.Text.Json.JsonElement]$Element
+    )
+    Set-StrictMode -Version Latest
+    $list = [System.Collections.Generic.List[object]]::new()
+    foreach ($childEl in $Element.EnumerateArray()) {
+        $item = $Collapsed
+        switch ($childEl.ValueKind) {
+            ([System.Text.Json.JsonValueKind]::Object) {
+                if ($item -is [System.Management.Automation.PSCustomObject]) { Restore-JsonShapeInPlace -Container $item -Element $childEl }
+            }
+            ([System.Text.Json.JsonValueKind]::Array) {
+                if ($item -is [System.Collections.IList] -and $item -isnot [string]) { Restore-JsonShapeInPlace -Container $item -Element $childEl }
+                else { $item = Restore-CollapsedJsonArray -Collapsed $item -Element $childEl }
+            }
+            ([System.Text.Json.JsonValueKind]::String) {
+                if ($item -is [datetime] -or $item -is [datetimeoffset]) { $item = $childEl.GetString() }
+            }
+        }
+        $list.Add($item)
+    }
+    $arr = [object[]]$list.ToArray()
+    return , $arr
+}
+
+function Restore-JsonShapeInPlace {
+    # Reconcile $Container (a PSCustomObject when $Element is Object, or an IList when $Element is
+    # Array) against $Element, fixing children in place. Returns nothing.
+    [CmdletBinding()]
+    param(
+        $Container,
+        [System.Text.Json.JsonElement]$Element
+    )
+    Set-StrictMode -Version Latest
+
+    if ($Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Object) {
+        if ($Container -isnot [System.Management.Automation.PSCustomObject]) { return }
+        foreach ($prop in $Container.PSObject.Properties) {
+            $child = [System.Text.Json.JsonElement]::new()
+            if (-not $Element.TryGetProperty($prop.Name, [ref]$child)) { continue }
+            switch ($child.ValueKind) {
+                ([System.Text.Json.JsonValueKind]::Object) {
+                    if ($prop.Value -is [System.Management.Automation.PSCustomObject]) { Restore-JsonShapeInPlace -Container $prop.Value -Element $child }
+                }
+                ([System.Text.Json.JsonValueKind]::Array) {
+                    if ($prop.Value -is [System.Collections.IList] -and $prop.Value -isnot [string]) {
+                        Restore-JsonShapeInPlace -Container $prop.Value -Element $child   # empty + multi: in place
+                    }
+                    else {
+                        $prop.Value = Restore-CollapsedJsonArray -Collapsed $prop.Value -Element $child
+                    }
+                }
+                ([System.Text.Json.JsonValueKind]::String) {
+                    if ($prop.Value -is [datetime] -or $prop.Value -is [datetimeoffset]) { $prop.Value = $child.GetString() }
+                }
+            }
+        }
+        return
+    }
+
+    if ($Element.ValueKind -eq [System.Text.Json.JsonValueKind]::Array) {
+        if ($Container -isnot [System.Collections.IList]) { return }
+        $idx = 0
+        foreach ($childEl in $Element.EnumerateArray()) {
+            if ($idx -ge $Container.Count) { break }
+            switch ($childEl.ValueKind) {
+                ([System.Text.Json.JsonValueKind]::Object) {
+                    if ($Container[$idx] -is [System.Management.Automation.PSCustomObject]) { Restore-JsonShapeInPlace -Container $Container[$idx] -Element $childEl }
+                }
+                ([System.Text.Json.JsonValueKind]::Array) {
+                    if ($Container[$idx] -is [System.Collections.IList] -and $Container[$idx] -isnot [string]) {
+                        Restore-JsonShapeInPlace -Container $Container[$idx] -Element $childEl
+                    }
+                    else {
+                        $Container[$idx] = Restore-CollapsedJsonArray -Collapsed $Container[$idx] -Element $childEl
+                    }
+                }
+                ([System.Text.Json.JsonValueKind]::String) {
+                    if ($Container[$idx] -is [datetime] -or $Container[$idx] -is [datetimeoffset]) { $Container[$idx] = $childEl.GetString() }
+                }
+            }
+            $idx++
+        }
+        return
+    }
+}
+
+function ConvertFrom-JsonPreserveShape {
+    <#
+    .SYNOPSIS
+        Parse JSON preserving ISO-datetime strings AND single-element array shape (t/3124; PS 7.4).
+    .DESCRIPTION
+        ConvertFrom-Json for the fast structure, then a System.Text.Json.JsonDocument pass restores
+        (1) every coerced datetime leaf to its exact original string and (2) any single-element
+        array the fast parser unwrapped to a scalar/object. Use wherever a cmdlet reads a JSON
+        document and later rewrites the WHOLE file, so unrelated fields round-trip byte-identically.
+        Fails OPEN but NOT silent: if System.Text.Json cannot parse, returns the plain
+        ConvertFrom-Json result with a Write-Verbose note (mirrors ConvertFrom-EdgesJson, t/2974#3).
+    .PARAMETER Json
+        The raw JSON text.
+    .OUTPUTS
+        The parsed document with datetime fields + single-element arrays preserved verbatim.
+    #>
+    [CmdletBinding()]
+    [OutputType([object])]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Json
+    )
+    Set-StrictMode -Version Latest
+
+    $obj = $Json | ConvertFrom-Json
+    if ($null -eq $obj) { return $obj }
+
+    $doc = $null
+    try { $doc = [System.Text.Json.JsonDocument]::Parse($Json) }
+    catch {
+        Write-Verbose "ConvertFrom-JsonPreserveShape: System.Text.Json could not parse for shape restoration ($($_.Exception.Message)); falling back to ConvertFrom-Json — datetimes/single-element arrays may be mutated (t/3124)."
+        return $obj
+    }
+
+    try {
+        $root = $doc.RootElement
+        if ($root.ValueKind -eq [System.Text.Json.JsonValueKind]::Object -or
+            $root.ValueKind -eq [System.Text.Json.JsonValueKind]::Array) {
+            Restore-JsonShapeInPlace -Container $obj -Element $root
+        }
+        return $obj
+    }
+    finally {
+        $doc.Dispose()
+    }
+}

--- a/scripts/AITriad/Public/Update-ClaimEntityRef.ps1
+++ b/scripts/AITriad/Public/Update-ClaimEntityRef.ps1
@@ -120,7 +120,12 @@ function Update-ClaimEntityRef {
         }
 
         try {
-            $summary = Get-Content -Raw -LiteralPath $file -Encoding utf8 | ConvertFrom-Json
+            # ConvertFrom-JsonPreserveShape (NOT ConvertFrom-Json): PS 7.4 mutates document shape on
+            # a whole-file round-trip — it coerces ISO datetimes to [datetime] (re-emitting
+            # measured_at/generated_at in a different offset) AND unwraps single-element arrays to
+            # scalars (vocabulary_terms: ["x"] -> "x"). The re-serialize below would bake both into
+            # fields this pass never targeted (t/3124 follow-up; class of ConvertFrom-EdgesJson/t/2974).
+            $summary = ConvertFrom-JsonPreserveShape -Json (Get-Content -Raw -LiteralPath $file -Encoding utf8)
         }
         catch {
             # Fallback-path logging: an unreadable/invalid summary is skipped rather than

--- a/tests/Update-ClaimEntityRef.Tests.ps1
+++ b/tests/Update-ClaimEntityRef.Tests.ps1
@@ -186,4 +186,55 @@ Describe 'Update-ClaimEntityRef (t/3124)' -Tag 'unit', 'entity' {
             $r.FilesWritten | Should -Be 1
         }
     }
+
+    Context 'Document shape is preserved on write (t/3124 follow-up)' {
+
+        It 'Does NOT mutate measured_at / generated_at when appending entity_refs' {
+            # These fields have timezone offsets + fractional seconds that PS 7.4 ConvertFrom-Json
+            # would coerce to [datetime] and re-emit in a different offset. The write must touch
+            # ONLY entity_refs. New-Summary via ConvertTo-Json emits these as strings, matching how
+            # Invoke-DocumentSummary writes real summaries.
+            New-Summary -Path $script:sumPath -Doc @{
+                doc_id        = 'd1'
+                generated_at  = '2026-05-02T20:38:45.7336380-04:00'
+                context_rot   = @{ measured_at = '2026-05-02T20:38:45.7336380-04:00' }
+                pov_summaries = @{ accelerationist = @{ key_points = @(@{ point = 'The Apollo Project endures.' }) } }
+                factual_claims = @()
+            }
+
+            $r = Update-ClaimEntityRef -EntitiesPath $script:entPath -SummariesPath $script:sumPath
+            $r.RefsWritten | Should -Be 1   # proves the write actually happened
+
+            # Re-read the RAW string values (not the coerced form) and assert byte-identity.
+            $after = Get-Content -Raw -LiteralPath $script:sumPath -Encoding utf8
+            $after | Should -BeLike '*"generated_at": "2026-05-02T20:38:45.7336380-04:00"*'
+            $after | Should -BeLike '*"measured_at": "2026-05-02T20:38:45.7336380-04:00"*'
+            # And the entity_ref was in fact added.
+            $after | Should -BeLike '*"entity_refs"*ent-001*'
+        }
+
+        It 'Does NOT collapse a single-element array (vocabulary_terms) to a scalar' {
+            # ConvertFrom-Json unwraps ["x"] -> "x"; a whole-file re-serialize would then persist
+            # the scalar, silently changing the schema of an untargeted field. -Depth 12 keeps the
+            # 1-element array intact in the fixture.
+            $doc = @{
+                doc_id        = 'd1'
+                pov_summaries = @{ accelerationist = @{ key_points = @(
+                            @{ point = 'The Apollo Project endures.'; vocabulary_terms = @('capabilities_scaling') }
+                        ) } }
+                factual_claims = @()
+            }
+            ($doc | ConvertTo-Json -Depth 12) | Set-Content -LiteralPath $script:sumPath -Encoding utf8NoBOM
+
+            Update-ClaimEntityRef -EntitiesPath $script:entPath -SummariesPath $script:sumPath | Out-Null
+
+            # Must still be an array in the raw text (the [ ] survive) — the real shape proof.
+            # ('[' is a -BeLike metachar, so assert via .Contains, not -BeLike.)
+            $raw = Get-Content -Raw -LiteralPath $script:sumPath -Encoding utf8
+            $raw.Contains('"vocabulary_terms": [') | Should -BeTrue
+            $parsed = $raw | ConvertFrom-Json
+            $vt = $parsed.pov_summaries.accelerationist.key_points[0].vocabulary_terms
+            $vt[0] | Should -Be 'capabilities_scaling'
+        }
+    }
 }


### PR DESCRIPTION
Follow-up bugfix to #1741 (t/3124).

## Problem
`Update-ClaimEntityRef` reads each summary with `ConvertFrom-Json` and rewrites the whole file with `ConvertTo-Json`. On PowerShell 7.4 that round-trip silently mutates two shapes of fields the pass never targeted:

1. **ISO datetimes** are coerced to `[datetime]` and re-emitted in a different timezone offset — `"measured_at": "...T20:38:45.7336380-04:00"` → `"...T01:38:45.733638+01:00"`.
2. **Single-element arrays** unwrap to scalars — `"vocabulary_terms": ["x"]` → `"x"` (and `[{...}]` → a bare object).

`-DateKind String` (the clean fix) is PS 7.5+; this repo is on 7.4.

## Fix
New `ConvertFrom-JsonPreserveShape` — `ConvertFrom-Json` for speed, then a `System.Text.Json.JsonDocument` tandem walk restores every coerced datetime leaf to its exact original string and re-wraps any collapsed single-element array. Schema-agnostic (these occur at several depths); mirrors the established `ConvertFrom-EdgesJson`/t/2974 technique. Fails open but not silent.

## Verification
- Real summaries: the write diff is now **`entity_refs` additions + necessary comma-flips only — zero genuine value mutations** (comma-normalized diff check across 5 files).
- 11 Pester tests pass, incl. 2 new shape-preservation regressions (datetime offset + single-element array).
- Module loads, `Test-ModuleManifest` passes.

No corpus data was committed with the bug — the earlier backfill working-tree writes were reverted; a clean backfill follows this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)