### PR TITLE
fix(ai): capture HttpClient error body on AI failures (t/3196)

### DIFF
--- a/scripts/AIEnrich.psm1
+++ b/scripts/AIEnrich.psm1
@@ -1065,12 +1065,24 @@ function Invoke-AIApi {
         $SafeMsg = Protect-SensitiveText -Text $LastError.Exception.Message -Secret $ResolvedKey
         Write-Warning "$($Backend): API call failed (HTTP $StatusCode) — $SafeMsg"
         if ($Hint) { Write-Warning "$($Backend): $Hint" }
+        # Capture the HTTP error BODY — it carries the real reason (e.g. a 400's message). t/3196:
+        # Invoke-RestMethod (HttpClient) surfaces the response body on $_.ErrorDetails.Message, NOT
+        # on Exception.Response.GetResponseStream() (the old WebRequest shape) — so the previous
+        # read silently caught nothing on every HttpClient failure, and the body was invisible
+        # (this masked the t/3123 400 during diagnosis). Prefer ErrorDetails.Message; fall back to
+        # the WebRequest stream for any caller still on that path.
         try {
-            if ($LastError.Exception.Response) {
+            $ErrBody = $null
+            if ($LastError.PSObject.Properties['ErrorDetails'] -and $LastError.ErrorDetails -and $LastError.ErrorDetails.Message) {
+                $ErrBody = [string]$LastError.ErrorDetails.Message
+            }
+            elseif ($LastError.Exception.Response -and ($LastError.Exception.Response | Get-Member -Name GetResponseStream -MemberType Method -ErrorAction SilentlyContinue)) {
                 $ErrStream = $LastError.Exception.Response.GetResponseStream()
                 $ErrReader = [System.IO.StreamReader]::new($ErrStream)
                 $ErrBody   = $ErrReader.ReadToEnd()
                 $ErrReader.Close()
+            }
+            if (-not [string]::IsNullOrWhiteSpace($ErrBody)) {
                 $SafeBody = Protect-SensitiveText -Text $ErrBody -Secret $ResolvedKey
                 Write-Warning "$($Backend): Response body: $SafeBody"
             }

--- a/tests/AIEnrich.ErrorBody.Tests.ps1
+++ b/tests/AIEnrich.ErrorBody.Tests.ps1
@@ -1,0 +1,51 @@
+# Tag: enrichment (t/3196)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    t/3196: Invoke-AIApi's all-retries-exhausted error path must log the HTTP response BODY.
+    Invoke-RestMethod (HttpClient) surfaces the body on $_.ErrorDetails.Message — the previous
+    read only looked at Exception.Response.GetResponseStream() (WebRequest shape) and silently
+    caught nothing, so a 4xx's real reason was invisible (this masked the t/3123 400). The body
+    must be logged AND scrubbed via Protect-SensitiveText.
+#>
+
+BeforeAll {
+    $ModulePath = Join-Path $PSScriptRoot '..' 'scripts' 'AIEnrich.psm1'
+    Import-Module $ModulePath -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Invoke-AIApi error-body capture (t/3196)' -Tag 'enrichment' {
+
+    It 'logs the HttpClient ErrorDetails.Message body (redacted) on a failed call' {
+        Mock Start-Sleep { } -ModuleName AIEnrich   # no retry backoff delay
+        Mock Invoke-RestMethod -ModuleName AIEnrich -MockWith {
+            $ex = [System.Exception]::new('Response status code does not indicate success: 400 (Bad Request).')
+            $er = [System.Management.Automation.ErrorRecord]::new(
+                $ex, 'HttpError400', [System.Management.Automation.ErrorCategory]::InvalidResult, $null)
+            # Invoke-RestMethod puts the response body here for HttpClient errors. Includes a
+            # synthetic leaked key to prove redaction. Split so the source literal can't trip
+            # secret scanning.
+            $er.ErrorDetails = [System.Management.Automation.ErrorDetails]::new(
+                '{"error":{"message":"model not found or not supported","status":"INVALID_ARGUMENT"},"leaked":"' + ('AIza' + 'SyLEAKEDkeyNOTREAL0123456789abcd') + '"}')
+            throw $er
+        }
+
+        $warn = @()
+        Invoke-AIApi -Prompt 'test' -Model 'claude-sonnet-4-5' -ApiKey 'sk-secret-explicit-key-xyz' `
+            -WarningVariable warn -WarningAction SilentlyContinue 3>$null 2>$null | Out-Null
+
+        $msg = ($warn | ForEach-Object { $_.ToString() }) -join ' '
+        # The body reached a log line...
+        $msg | Should -Match 'Response body'
+        # ...carrying the real reason...
+        $msg | Should -Match 'model not found'
+        # ...with the embedded key redacted...
+        $msg | Should -Not -Match 'AIzaSyLEAKED'
+        # ...and the explicit -ApiKey redacted too.
+        $msg | Should -Not -Match 'sk-secret-explicit-key-xyz'
+    }
+}


### PR DESCRIPTION
## What

`Invoke-AIApi`'s all-retries-exhausted error path read the HTTP error **body** only via `Exception.Response.GetResponseStream()` — the legacy WebRequest shape. The calls use `Invoke-RestMethod` (HttpClient), which surfaces the response body on **`$_.ErrorDetails.Message`** instead — so the read silently caught nothing on every HttpClient failure and the body (the real 4xx reason) was invisible. This directly masked the t/3123 400 during diagnosis.

## Fix

Prefer `$LastError.ErrorDetails.Message`; fall back to the WebRequest stream for any caller still on that path; still redacted via `Protect-SensitiveText`.

## Test

`AIEnrich.ErrorBody.Tests.ps1` — mocks `Invoke-RestMethod` to throw an ErrorRecord with `ErrorDetails.Message`; asserts the body reaches a log line with the real reason **and** that both an embedded key and the explicit `-ApiKey` are redacted. 1/0.

## Scope note (ticket correction)

t/3196's **part 1 (persist `possible_duplicates`) was already implemented by t/1881** — they ride the per-node `entity_extraction_log.json` sidecar (verified: 25 nodes carry them in the committed log). My run-time observation that they weren't persisted was mistaken (I'd checked only node[0], which had none). So this PR lands the **error-body fix only**.

Pre-existing note: the live `xai-grok-4-6` token-count test flakes locally (real-API drift, gated on `XAI_API_KEY`, self-skips on CI) — unrelated to this error-path change.

Closes t/3196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)