### PR TITLE
feat(quota): actionable "Add API key" deep-link on daily-limit surfaces (t/3190)

### DIFF
--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.css
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.css
@@ -65,6 +65,19 @@
 .debate-daily-limit-text {
   flex: 1;
 }
+.debate-daily-limit-action {
+  font-size: var(--text-xs);
+  padding: 2px 10px;
+  border: 1px solid var(--warning, #e6a700);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--warning, #e6a700);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.debate-daily-limit-action:hover {
+  background: color-mix(in srgb, var(--warning, #e6a700) 15%, transparent);
+}
 .debate-daily-limit-dismiss {
   font-size: var(--text-lg);
   line-height: 1;

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.test.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.test.tsx
@@ -3,8 +3,9 @@
 
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { useRef } from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { ProgressIndicator, PhaseProgressBar, DebaterToggles, TokenBudgetIndicator, DebateActions } from './DebateActionBar';
+import { useSettingsDialog } from '../../hooks/useSettingsDialog';
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -451,5 +452,19 @@ describe('DebateActions — exhaustion error banner', () => {
     mockStore.debateError = null;
     render(<DebateActions {...actionsProps} />);
     expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+  });
+
+  // t/3190: daily-cap banner offers an "Add API key" deep-link to Settings (the
+  // "continue now" path), and no Retry (the cap is not retryable).
+  it('daily-limit banner shows "Add API key" (not Retry) and opens Settings on click', () => {
+    useSettingsDialog.setState({ isOpen: false });
+    mockStore.debateError = 'Daily AI usage limit reached (resets at midnight UTC).';
+    mockStore.dailyLimitPaused = true;
+    render(<DebateActions {...actionsProps} />);
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    const addKey = screen.getByRole('button', { name: 'Add API key' });
+    fireEvent.click(addKey);
+    expect(useSettingsDialog.getState().isOpen).toBe(true);
+    useSettingsDialog.setState({ isOpen: false });
   });
 });

--- a/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
+++ b/taxonomy-editor/src/renderer/components/debate-workspace/DebateActionBar.tsx
@@ -18,6 +18,7 @@ import { isElectronMode } from '@bridge';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { triggerManualDump } from '../../lib/flightRecorderInit';
 import { bandColor, BUDGET_BANDS } from '../../lib/bandColor';
+import { useSettingsDialog } from '../../hooks/useSettingsDialog';
 import './DebateActionBar.css';
 
 export function ProgressIndicator() {
@@ -384,10 +385,14 @@ function DebateErrorBanner({
   onRetry: () => void;
   onDismiss: () => void;
 }) {
+  const openSettings = useSettingsDialog(s => s.open);
   return (
     <div className={dailyLimitPaused ? 'debate-daily-limit' : 'debate-error'}>
       <span className={dailyLimitPaused ? 'debate-daily-limit-text' : 'debate-error-text'}>{debateError}</span>
-      {!dailyLimitPaused && (
+      {dailyLimitPaused ? (
+        // "Continue now" path for the daily cap is registering a BYOK key (t/3190).
+        <button className="debate-daily-limit-action" onClick={openSettings}>Add API key</button>
+      ) : (
         <button className="debate-error-retry" onClick={onRetry} disabled={disableAnalysis}>Retry</button>
       )}
       <button className={dailyLimitPaused ? 'debate-daily-limit-dismiss' : 'debate-error-dismiss'} onClick={onDismiss} title="Dismiss" aria-label="Dismiss">&times;</button>

--- a/taxonomy-editor/src/renderer/components/shared/QuotaBanner.css
+++ b/taxonomy-editor/src/renderer/components/shared/QuotaBanner.css
@@ -56,6 +56,22 @@
   line-height: 1.4;
 }
 
+.quota-banner-action {
+  flex-shrink: 0;
+  font-size: var(--text-sm);
+  padding: 2px 10px;
+  border: 1px solid var(--danger, #ef4444);
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: var(--danger, #ef4444);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.quota-banner-action:hover {
+  background: color-mix(in srgb, var(--danger, #ef4444) 15%, transparent);
+}
+
 .quota-banner-dismiss {
   flex-shrink: 0;
   background: none;

--- a/taxonomy-editor/src/renderer/components/shared/QuotaBanner.test.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/QuotaBanner.test.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QuotaBanner } from './QuotaBanner';
+import { useQuotaWarning } from '../../hooks/useQuotaWarning';
+import { useSettingsDialog } from '../../hooks/useSettingsDialog';
+
+function setWarning(level: 'info' | 'warning' | 'error', message = 'msg') {
+  useQuotaWarning.setState({
+    warning: { milestone: level === 'error' ? 100 : 80, level, message, dismissedAt: null },
+  });
+}
+
+describe('QuotaBanner — daily-limit deep-link (t/3190)', () => {
+  beforeEach(() => {
+    useQuotaWarning.setState({ warning: null });
+    useSettingsDialog.setState({ isOpen: false });
+  });
+
+  it('renders "Add API key" on the error (daily-cap) banner and opens Settings on click', () => {
+    setWarning('error', 'Daily AI quota reached. Resets at midnight UTC.');
+    render(<QuotaBanner />);
+    const addKey = screen.getByRole('button', { name: 'Add API key' });
+    fireEvent.click(addKey);
+    expect(useSettingsDialog.getState().isOpen).toBe(true);
+  });
+
+  it('does not render "Add API key" on non-error banners', () => {
+    setWarning('warning');
+    render(<QuotaBanner />);
+    expect(screen.queryByRole('button', { name: 'Add API key' })).toBeNull();
+    // warning-level keeps its dismiss control
+    expect(screen.getByRole('button', { name: 'Dismiss quota warning' })).toBeInTheDocument();
+  });
+});

--- a/taxonomy-editor/src/renderer/components/shared/QuotaBanner.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/QuotaBanner.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE file in the project root.
 
 import { useQuotaWarning, type QuotaLevel } from '../../hooks/useQuotaWarning';
+import { useSettingsDialog } from '../../hooks/useSettingsDialog';
 import './QuotaBanner.css';
 
 function QuotaIcon({ level }: { level: QuotaLevel }) {
@@ -35,6 +36,7 @@ function QuotaIcon({ level }: { level: QuotaLevel }) {
 export function QuotaBanner() {
   const warning = useQuotaWarning(s => s.warning);
   const dismiss = useQuotaWarning(s => s.dismiss);
+  const openSettings = useSettingsDialog(s => s.open);
 
   if (!warning || warning.dismissedAt) return null;
 
@@ -46,6 +48,16 @@ export function QuotaBanner() {
     >
       <QuotaIcon level={warning.level} />
       <span className="quota-banner-text">{warning.message}</span>
+      {/* Daily-cap (error) surface: the "continue now" path is registering a BYOK
+          key, so give the user an actionable route to Settings → API Keys (t/3190). */}
+      {warning.level === 'error' && (
+        <button
+          className="quota-banner-action"
+          onClick={openSettings}
+        >
+          Add API key
+        </button>
+      )}
       {warning.level !== 'error' && (
         <button
           className="quota-banner-dismiss"

--- a/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
+++ b/taxonomy-editor/src/renderer/components/shared/Toolbar.tsx
@@ -15,6 +15,7 @@ import { SettingsDialog } from '../settings/SettingsDialog';
 import { useAuthStatus, useUserProfile } from '../../hooks/useAuthStatus';
 import { useFlag } from '../../hooks/useFeatureFlags';
 import { useNavVisibilityContext } from '../../hooks/useNavVisibilityContext';
+import { useSettingsDialog } from '../../hooks/useSettingsDialog';
 import { useTierInfo } from '../../hooks/useTierInfo';
 import { FeedbackPopover } from './FeedbackPopover';
 import { NAV_ITEMS, getVisibleNavItems, getSecondaryByGroup, type NavItem, type NavAction } from '../../data/navConfig';
@@ -198,6 +199,10 @@ export function Toolbar() {
   const adminFlag = useFlag('permission-admin-features');
   const [showHelp, setShowHelp] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  // Global open-signal so surfaces outside the toolbar (e.g. the daily-quota
+  // banners) can route the user to Settings → API Keys (t/3190).
+  const settingsRequested = useSettingsDialog(s => s.isOpen);
+  const closeSettingsSignal = useSettingsDialog(s => s.close);
   const [showMore, setShowMore] = useState(false);
   const [showFeedback, setShowFeedback] = useState(false);
   const moreRef = useRef<HTMLDivElement>(null);
@@ -396,7 +401,9 @@ export function Toolbar() {
           <Settings size="1.25em" />
         </button>
       </div>
-      {showSettings && <SettingsDialog onClose={() => setShowSettings(false)} />}
+      {(showSettings || settingsRequested) && (
+        <SettingsDialog onClose={() => { setShowSettings(false); closeSettingsSignal(); }} />
+      )}
       {showHelp && <HelpDialog onClose={() => setShowHelp(false)} />}
     </nav>
   );

--- a/taxonomy-editor/src/renderer/hooks/useSettingsDialog.ts
+++ b/taxonomy-editor/src/renderer/hooks/useSettingsDialog.ts
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+import { create } from 'zustand';
+
+/**
+ * Global signal for opening the Settings dialog from surfaces outside the
+ * Toolbar (t/3190). The dialog itself is rendered/owned by the Toolbar, which
+ * subscribes to `isOpen`; any component (e.g. the daily-quota banners) can call
+ * `useSettingsDialog.getState().open()` to route the user to Settings → API Keys
+ * without threading callbacks through the tree.
+ */
+interface SettingsDialogStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useSettingsDialog = create<SettingsDialogStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
Closes t/3190.

## Problem
When the free-tier **daily token cap** fires, the message says "add your own API key in Settings to continue now" but gives the user no way to get there — the error-level `QuotaBanner` renders plain text with no action, and the inline debate `dailyLimitPaused` notice likewise.

## Change (renderer-only)
- **`hooks/useSettingsDialog.ts`** (new): tiny zustand store (`isOpen/open/close`) so surfaces outside the Toolbar can open the Settings dialog (previously toolbar-local `useState`).
- **`QuotaBanner.tsx`**: error-level (100% daily-cap) banner now renders an **"Add API key"** button → opens Settings → API Keys. Styles in co-located `QuotaBanner.css` (styles.css is frozen).
- **`DebateActionBar.tsx`** `DebateErrorBanner`: `dailyLimitPaused` branch renders the same **"Add API key"** button in place of Retry (the daily cap is not retryable). New class in co-located `DebateActionBar.css`.
- **`Toolbar.tsx`**: renders `SettingsDialog` when the global open-signal fires as well as its local button; close clears both.

No quota-policy or server change — the cap firing is correct free-tier behavior; this only makes the "continue now" (BYOK) path reachable.

## Cross-scope note
`DebateActionBar.*` is owned by the **DebateWorkspace** child role. The ~6-line addition is bundled here for a consistent, atomic UX change across both daily-limit surfaces; DebateWorkspace pinged to review.

## Tests
- New `QuotaBanner.test.tsx`: asserts "Add API key" appears only on the error banner and opens Settings on click.
- `DebateActionBar.test.tsx`: asserts the daily-limit banner shows "Add API key" (not Retry) and opens Settings on click.
- Both targeted suites green (28 tests). Full local `npm run verify` tsc/eslint/depcruise/build pass; remaining local vitest failures are environmental only (undici Node-version skew — CI uses Node 22; Azurite emulator; a filesystem-scan lint tripping on local worktree node_modules junctions) and unrelated to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)