### PR TITLE
feat(tax): Update-EntityMentionIndex honors the shared grounding lockfile (t/3203)

### DIFF
--- a/scripts/AITriad/Private/GroundingLock.ps1
+++ b/scripts/AITriad/Private/GroundingLock.ps1
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+<#
+.SYNOPSIS
+    Advisory cross-tool grounding write-lock for entity_mentions.json (t/3203).
+.DESCRIPTION
+    entity_mentions.json is a SHARED read-merge-write: CL's reconcile_grounding.py owns node:*
+    and Update-EntityMentionIndex owns {sei:*, summary:*}. Once G8's inline hook / scheduled sweep
+    can run them concurrently, an unguarded overlap lost-updates the other writer. Both tools honor
+    the SAME advisory lockfile with matching semantics (TL contract t/3163#1; Python side landed
+    t/3194, reconcile_grounding.py grounding_lock()):
+
+      - Lockfile: `entity_mentions.lock` beside entity_mentions.json (same dir).
+      - Acquire: atomic exclusive create — [IO.File]::Open(..., CreateNew, ...) is the .NET
+        equivalent of the Python side's os.open(O_CREAT|O_EXCL); it throws when the file exists.
+      - Staleness: a holder whose mtime age exceeds LOCK_STALE_SEC (120s, matching Python) is
+        presumed dead and broken (unlink + re-acquire) with a WARN (Fallback-Path Logging rule).
+      - Bounded wait: poll every LOCK_POLL_SEC (0.5s) up to LOCK_WAIT_SEC (60s); on timeout throw
+        New-ActionableError. Constants mirror reconcile_grounding.py exactly.
+      - Release: close the handle + unlink, in the caller's finally.
+
+    NOTE: like the Python side, the lock is advisory and mtime-staleness assumes an operation
+    completes within 120s; it does not heartbeat the mtime. This is intentional parity.
+#>
+
+Set-Variable -Name 'GroundingLockWaitSec'  -Value 60  -Scope Script -Option ReadOnly -Force
+Set-Variable -Name 'GroundingLockStaleSec' -Value 120 -Scope Script -Option ReadOnly -Force
+Set-Variable -Name 'GroundingLockPollSec'  -Value 0.5 -Scope Script -Option ReadOnly -Force
+
+function Enter-GroundingLock {
+    [CmdletBinding()]
+    [OutputType([System.IO.FileStream])]
+    param(
+        [Parameter(Mandatory)][string]$LockPath,
+        [int]$WaitSec = $script:GroundingLockWaitSec,
+        [int]$StaleSec = $script:GroundingLockStaleSec,
+        [double]$PollSec = $script:GroundingLockPollSec
+    )
+    Set-StrictMode -Version Latest
+
+    $lockDir = Split-Path -Parent $LockPath
+    if ($lockDir -and -not (Test-Path -LiteralPath $lockDir)) {
+        throw (New-ActionableError -PassThru `
+                -Goal     'Acquire the entity_mentions grounding lock' `
+                -Problem  "Lock directory does not exist: $lockDir" `
+                -Location 'Enter-GroundingLock' `
+                -NextSteps @('Ensure the entity_mentions.json output directory exists before writing.'))
+    }
+
+    $start = Get-Date
+    while ($true) {
+        try {
+            # CreateNew == O_CREAT|O_EXCL: succeeds only if the file does not already exist.
+            return [System.IO.File]::Open($LockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+        }
+        catch [System.IO.IOException] {
+            if (Test-Path -LiteralPath $LockPath) {
+                # Held by another writer — check mtime staleness.
+                $age = ((Get-Date) - (Get-Item -LiteralPath $LockPath -Force).LastWriteTime).TotalSeconds
+                if ($age -gt $StaleSec) {
+                    Write-Warning "Enter-GroundingLock: breaking stale lock '$LockPath' (mtime age $([int]$age)s > ${StaleSec}s — holder presumed dead). Fallback-path per docs/error-handling.md."
+                    Remove-Item -LiteralPath $LockPath -Force -ErrorAction SilentlyContinue
+                    continue   # re-acquire immediately
+                }
+                if (((Get-Date) - $start).TotalSeconds -ge $WaitSec) {
+                    throw (New-ActionableError -PassThru `
+                            -Goal     'Serialize the entity_mentions.json read-merge-write across grounding writers' `
+                            -Problem  "Lock '$LockPath' held by another writer for >${WaitSec}s and not stale (mtime age $([int]$age)s)." `
+                            -Location 'Enter-GroundingLock' `
+                            -NextSteps @(
+                                'Wait for the other grounding writer (reconcile_grounding.py or another Update-EntityMentionIndex) to finish.',
+                                "If no writer is actually running, the lock is stale — remove it: $LockPath"
+                            ))
+                }
+                Start-Sleep -Seconds $PollSec
+            }
+            else {
+                # The lock was released between the failed create and this check (the race we are
+                # waiting to win) — retry promptly, still bounded by the overall timeout.
+                if (((Get-Date) - $start).TotalSeconds -ge $WaitSec) { throw }
+                Start-Sleep -Milliseconds 50
+            }
+        }
+    }
+}
+
+function Exit-GroundingLock {
+    [CmdletBinding()]
+    param(
+        [System.IO.FileStream]$Handle,
+        [Parameter(Mandatory)][string]$LockPath
+    )
+    Set-StrictMode -Version Latest
+    if ($Handle) { try { $Handle.Close(); $Handle.Dispose() } catch { } }
+    Remove-Item -LiteralPath $LockPath -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
+++ b/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
@@ -195,6 +195,17 @@ function Update-EntityMentionIndex {
         }
     }
 
+    # --- Grounding write-lock (t/3203) ----------------------------------------------------
+    # entity_mentions.json is a SHARED read-merge-write with CL's reconcile_grounding.py (which
+    # owns node:*). Serialize the read→merge→write below against it via the same advisory lockfile
+    # + mtime-staleness rule the Python side honors (TL contract t/3163#1 / t/3194). The heavy
+    # entities.json alias-table load above is intentionally OUTSIDE the lock; the source-file
+    # container collection stays inside because the existing-index read (the lost-update surface)
+    # must be under the lock and precedes it here.
+    $LockPath = Join-Path (Split-Path -Parent $OutPath) 'entity_mentions.lock'
+    $LockHandle = Enter-GroundingLock -LockPath $LockPath
+    try {
+
     # --- Existing index (for human-mention preservation + idempotency) ---------------------
     $ExistingById = @{}
     $ExistingLastModified = $null
@@ -470,4 +481,10 @@ function Update-EntityMentionIndex {
     }
 
     return $result
+
+    }
+    finally {
+        # t/3203: always release the grounding lock (even on an early return or a write error).
+        Exit-GroundingLock -Handle $LockHandle -LockPath $LockPath
+    }
 }

--- a/tests/GroundingLock.Tests.ps1
+++ b/tests/GroundingLock.Tests.ps1
@@ -1,0 +1,91 @@
+# Tag: unit (t/3203)
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Licensed under the MIT License. See LICENSE file in the project root.
+
+#Requires -Module Pester
+
+<#
+.SYNOPSIS
+    t/3203: the entity_mentions grounding write-lock (Enter/Exit-GroundingLock) — advisory,
+    exclusive-create acquire, mtime-staleness break (>120s), bounded wait → ActionableError,
+    and Update-EntityMentionIndex acquires/releases it around its read-merge-write. Mirrors the
+    Python reconcile_grounding.py contract (t/3194).
+#>
+
+BeforeAll {
+    Import-Module (Join-Path $PSScriptRoot '..' 'scripts' 'AITriad' 'AITriad.psm1') -Force -WarningAction SilentlyContinue
+}
+
+Describe 'Enter/Exit-GroundingLock (t/3203)' -Tag 'unit' {
+
+    It 'acquires an unheld lock (creates the file, returns a handle) and releases it' {
+        InModuleScope AITriad {
+            $lock = Join-Path $TestDrive ([guid]::NewGuid().ToString('N')) 'entity_mentions.lock'
+            New-Item -ItemType Directory -Path (Split-Path $lock) -Force | Out-Null
+
+            $h = Enter-GroundingLock -LockPath $lock
+            try {
+                Test-Path -LiteralPath $lock | Should -BeTrue
+                $h | Should -BeOfType [System.IO.FileStream]
+            }
+            finally {
+                Exit-GroundingLock -Handle $h -LockPath $lock
+            }
+            # released — file gone
+            Test-Path -LiteralPath $lock | Should -BeFalse
+        }
+    }
+
+    It 'times out with an ActionableError when the lock is held (fresh) and not stale' {
+        InModuleScope AITriad {
+            $lock = Join-Path $TestDrive ([guid]::NewGuid().ToString('N')) 'entity_mentions.lock'
+            New-Item -ItemType Directory -Path (Split-Path $lock) -Force | Out-Null
+            New-Item -ItemType File -Path $lock -Force | Out-Null   # held (mtime = now)
+
+            # WaitSec 1, StaleSec 120 → not stale, so it waits ~1s then throws.
+            { Enter-GroundingLock -LockPath $lock -WaitSec 1 -StaleSec 120 -PollSec 0.2 } |
+                Should -Throw '*held by another writer*'
+        }
+    }
+
+    It 'breaks a stale lock (mtime age > StaleSec), WARNs, and acquires' {
+        InModuleScope AITriad {
+            $lock = Join-Path $TestDrive ([guid]::NewGuid().ToString('N')) 'entity_mentions.lock'
+            New-Item -ItemType Directory -Path (Split-Path $lock) -Force | Out-Null
+            New-Item -ItemType File -Path $lock -Force | Out-Null
+            # Age the holder past the staleness threshold.
+            (Get-Item -LiteralPath $lock).LastWriteTime = (Get-Date).AddSeconds(-200)
+
+            $warn = @()
+            $h = Enter-GroundingLock -LockPath $lock -WaitSec 5 -StaleSec 120 -PollSec 0.2 -WarningVariable warn -WarningAction SilentlyContinue
+            try {
+                $h | Should -BeOfType [System.IO.FileStream]     # acquired after breaking the stale lock
+                ($warn -join ' ') | Should -Match 'stale lock'
+            }
+            finally {
+                Exit-GroundingLock -Handle $h -LockPath $lock
+            }
+        }
+    }
+}
+
+Describe 'Update-EntityMentionIndex honors the grounding lock (t/3203)' -Tag 'unit' {
+
+    It 'acquires + releases the lock around the write (no leftover entity_mentions.lock)' {
+        $root = Join-Path $TestDrive ([guid]::NewGuid().ToString('N'))
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+        $entPath = Join-Path $root 'entities.json'
+        $outPath = Join-Path $root 'entity_mentions.json'
+        ([ordered]@{ _schema_version = '1.0.0'; _doc = 't'; entity_count = 1; last_modified = '2026-09-01'
+                entities = @([ordered]@{ id = 'ent-001'; name = 'Apollo Project'; aliases = @(); entity_type = 'event'; status = 'approved' }) } |
+            ConvertTo-Json -Depth 8) | Set-Content -LiteralPath $entPath -Encoding utf8NoBOM
+        ([ordered]@{ 'acc-desires-001' = @{ facts = @(@{ claim = 'The Apollo Project reshaped ambition.' }) } } |
+            ConvertTo-Json -Depth 8) | Set-Content -LiteralPath (Join-Path $root 'sei.json') -Encoding utf8NoBOM
+
+        $r = Update-EntityMentionIndex -EntitiesPath $entPath `
+            -SourceEvidenceIndexPath (Join-Path $root 'sei.json') -SummariesPath @() -OutputPath $outPath
+        $r.Written | Should -BeTrue
+        # The write happened AND the lock was released (no leftover lockfile beside the output).
+        Test-Path -LiteralPath (Join-Path $root 'entity_mentions.lock') | Should -BeFalse
+    }
+}


### PR DESCRIPTION
## What
The **PS half** of the cross-tool grounding write-lock (TL contract t/3163#1). `entity_mentions.json` is a shared read-merge-write — CL's `reconcile_grounding.py` owns `node:*`, this cmdlet owns `{sei:*, summary:*}`. Once G8a/G8b run them concurrently, an unguarded overlap lost-updates the other writer. The Python side already acquires the lock (t/3194); this makes `Update-EntityMentionIndex` honor **the same lockfile with the same semantics**. Prerequisite for **G8a (t/3171)**.

## Contract parity (mirrors reconcile_grounding.py exactly)
- Lockfile `entity_mentions.lock` beside `entity_mentions.json` (same dir/name).
- Acquire = `[IO.File]::Open(CreateNew)` — the .NET `O_CREAT|O_EXCL`; throws when held.
- Staleness: holder mtime age > **120s** → broken (unlink + re-acquire) with `Write-Warning`.
- Bounded wait: poll **0.5s** up to **60s** → `New-ActionableError`. Constants match Python's `LOCK_WAIT_SEC`/`LOCK_STALE_SEC`/`LOCK_POLL_SEC`.
- Released (close + unlink) in the cmdlet's `finally`, even on early return / write error.
- Atomic write (tmp + `File.Move`, #1718) unchanged/confirmed present.

## Scope decision (flagging — non-blocking)
Lock wraps existing-index read → merge → write. The heavy `entities.json` alias-table load is **outside**; the source-file **container collection is inside** (the existing-index read — the lost-update surface — must be under the lock and precedes collection). Tightening is a clean follow-up if preferred.

## Tests
`GroundingLock.Tests.ps1` 4/0 (acquire→hold→release; held+fresh → ActionableError timeout; stale >120s → WARN+broken+acquired; cmdlet leaves no leftover lockfile). `Update-EntityMentionIndex` suite 32/0; manifest OK.

**Routed to Main (TL)** to confirm cross-tool lock parity + the scope decision before it gates G8a. Refs t/3203, t/3163, t/3194. Blocks t/3171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)