### PR TITLE
feat(ps): Update-EntityMentionIndex honors entity_mentions.lock (t/3203)

### DIFF
--- a/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
+++ b/scripts/AITriad/Public/Update-EntityMentionIndex.ps1
@@ -109,7 +109,11 @@ function Update-EntityMentionIndex {
         [string[]]$Status = @('approved'),
 
         [Parameter()]
-        [switch]$Force
+        [switch]$Force,
+
+        # Advisory lockfile timeout in seconds (default 60). Override in tests for fast timeout.
+        [Parameter()]
+        [int]$LockTimeoutSeconds = 60
     )
 
     Set-StrictMode -Version Latest
@@ -195,23 +199,7 @@ function Update-EntityMentionIndex {
         }
     }
 
-    # --- Existing index (for human-mention preservation + idempotency) ---------------------
-    $ExistingById = @{}
-    $ExistingLastModified = $null
-    if (Test-Path -LiteralPath $OutPath) {
-        try {
-            $prior = Get-Content -Raw -LiteralPath $OutPath -Encoding utf8 | ConvertFrom-Json
-            if ($prior.PSObject.Properties['last_modified']) { $ExistingLastModified = [string]$prior.last_modified }
-            if ($prior.PSObject.Properties['containers'] -and $prior.containers) {
-                foreach ($p in $prior.containers.PSObject.Properties) { $ExistingById[$p.Name] = $p.Value }
-            }
-        }
-        catch {
-            Write-Verbose "Existing $OutPath unreadable ($($_.Exception.Message)); rebuilding from scratch."
-        }
-    }
-
-    # --- Collect containers: id -> exact analyzed text ------------------------------------
+    # --- Collect containers: id -> exact analyzed text (outside lock — heavy load) -----------
     $Containers = [ordered]@{}   # insertion order irrelevant; sorted before write
 
     if (Test-Path -LiteralPath $SeiPath) {
@@ -278,6 +266,67 @@ function Update-EntityMentionIndex {
                 $text = Get-MentionContainerText -Kind 'fc' -Fields @($claimVal)
                 if ($text -ne '') { $Containers["summary:$docId#fc-$i"] = $text }
             }
+        }
+    }
+
+    # --- Advisory lockfile (entity_mentions.lock) — shared with reconcile_grounding.py (t/3203) --
+    # Alias table and container collection (heavy loads) complete above, outside the lock.
+    # Lock wraps only the read-merge-write of entity_mentions.json.
+    # Contract: exclusive create (O_CREAT|O_EXCL equivalent); stale lock (>120 s mtime) is
+    # broken with Write-Warning (fallback-path logging rule); bounded wait 0.5 s poll / 60 s timeout.
+    $LockPath = "$OutPath.lock"
+    $LockStream = $null
+    $LockStaleSec = 120
+    $LockWaitStart = [System.Diagnostics.Stopwatch]::StartNew()
+
+    while ($true) {
+        try {
+            $LockStream = [System.IO.File]::Open(
+                $LockPath,
+                [System.IO.FileMode]::CreateNew,
+                [System.IO.FileAccess]::Write,
+                [System.IO.FileShare]::None)
+            break   # exclusive lock acquired
+        }
+        catch [System.IO.IOException] {
+            # Lock file exists — inspect staleness before deciding to wait
+            $lockItem = Get-Item -LiteralPath $LockPath -ErrorAction SilentlyContinue
+            if ($lockItem) {
+                $lockAgeSec = ((Get-Date) - $lockItem.LastWriteTime).TotalSeconds
+                if ($lockAgeSec -gt $LockStaleSec) {
+                    Write-Warning ("Update-EntityMentionIndex: breaking stale entity_mentions.lock " +
+                        "(age $([int]$lockAgeSec)s > ${LockStaleSec}s); prior writer may have crashed. Re-acquiring.")
+                    Remove-Item -LiteralPath $LockPath -Force -ErrorAction SilentlyContinue
+                    continue   # retry immediately after stale-break
+                }
+            }
+            if ($LockWaitStart.Elapsed.TotalSeconds -ge $LockTimeoutSeconds) {
+                throw (New-ActionableError -PassThru `
+                        -Goal      'Update the entity mention index (entity_mentions.json)' `
+                        -Problem   "Timed out after ${LockTimeoutSeconds}s waiting for advisory lockfile '$LockPath'. Another Update-EntityMentionIndex or reconcile_grounding.py may be running." `
+                        -Location  'Update-EntityMentionIndex' `
+                        -NextSteps @(
+                            'Check whether another Update-EntityMentionIndex or reconcile_grounding.py process is running',
+                            "Delete '$LockPath' manually if the previous writer crashed and the lock is stale (> ${LockStaleSec}s old)"))
+            }
+            Start-Sleep -Milliseconds 500
+        }
+    }
+    try {
+
+    # --- Existing index (for human-mention preservation + idempotency) ---------------------
+    $ExistingById = @{}
+    $ExistingLastModified = $null
+    if (Test-Path -LiteralPath $OutPath) {
+        try {
+            $prior = Get-Content -Raw -LiteralPath $OutPath -Encoding utf8 | ConvertFrom-Json
+            if ($prior.PSObject.Properties['last_modified']) { $ExistingLastModified = [string]$prior.last_modified }
+            if ($prior.PSObject.Properties['containers'] -and $prior.containers) {
+                foreach ($p in $prior.containers.PSObject.Properties) { $ExistingById[$p.Name] = $p.Value }
+            }
+        }
+        catch {
+            Write-Verbose "Existing $OutPath unreadable ($($_.Exception.Message)); rebuilding from scratch."
         }
     }
 
@@ -470,4 +519,14 @@ function Update-EntityMentionIndex {
     }
 
     return $result
+
+    } # end try (lockfile scope)
+    finally {
+        # Release advisory lock: close and delete lockfile regardless of success or error.
+        if ($null -ne $LockStream) {
+            try { $LockStream.Dispose() } catch { }
+            $LockStream = $null
+        }
+        Remove-Item -LiteralPath $LockPath -Force -ErrorAction SilentlyContinue
+    }
 }

--- a/tests/Update-EntityMentionIndex.Tests.ps1
+++ b/tests/Update-EntityMentionIndex.Tests.ps1
@@ -448,6 +448,91 @@ Describe 'Update-EntityMentionIndex (t/1894 Phase 2-B)' -Tag 'unit' {
         }
     }
 
+    # Lockfile tests (t/3203): advisory entity_mentions.lock shared with reconcile_grounding.py.
+    Context 'Lockfile (t/3203)' {
+
+        It 'Lock is acquired and released — lockfile absent before and after a normal run' {
+            # Verify the lockfile does not linger after a successful run.
+            New-Sei -Path $script:seiPath -Map @{ 'n1' = @{ facts = @(@{ claim = 'Apollo Project.'; doc_id = 'd1' }) } }
+            $lockPath = "$($script:outPath).lock"
+
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -SummariesPath @() -OutputPath $script:outPath
+            $r.Written | Should -BeTrue
+            # Lock must be cleaned up after a successful run.
+            Test-Path -LiteralPath $lockPath | Should -BeFalse
+        }
+
+        It 'Lockfile is released even when the write fails (finally cleanup)' {
+            # Simulate a write error by making OutputPath a directory — the move will fail, but
+            # the lockfile must still be removed.
+            New-Sei -Path $script:seiPath -Map @{ 'n1' = @{ facts = @(@{ claim = 'Apollo Project.'; doc_id = 'd1' }) } }
+            $lockPath = "$($script:outPath).lock"
+            # Make OutputPath a directory so the write throws.
+            New-Item -ItemType Directory -Path $script:outPath -Force | Out-Null
+            try {
+                Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath -SummariesPath @() -OutputPath $script:outPath -ErrorAction Stop
+            }
+            catch { }
+            # Lock must be cleaned up even after write failure.
+            Test-Path -LiteralPath $lockPath | Should -BeFalse
+            # Cleanup: remove the directory we created.
+            Remove-Item -LiteralPath $script:outPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        It 'Pre-existing non-stale lock causes timeout with New-ActionableError (simulates concurrent writer)' {
+            # Pre-seed a fresh (non-stale) lock file. The cmdlet must time out and raise ActionableError.
+            New-Sei -Path $script:seiPath -Map @{ 'n1' = @{ facts = @(@{ claim = 'Apollo Project.'; doc_id = 'd1' }) } }
+            $lockPath = "$($script:outPath).lock"
+            # Hold the lock with an open FileStream (exclusive) to block the cmdlet.
+            $blocker = [System.IO.File]::Open($lockPath, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+            try {
+                # Use LockTimeoutSeconds=1 so the test runs in ~1 s instead of 60 s.
+                # New-ActionableError -PassThru returns a string; throw wraps it as RuntimeException.
+                # Assert on the message content (rendered label 'Error:') rather than the ErrorId.
+                { Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath `
+                        -SummariesPath @() -OutputPath $script:outPath -LockTimeoutSeconds 1 -ErrorAction Stop } |
+                    Should -Throw -ExpectedMessage '*Timed out*waiting for advisory lockfile*'
+            }
+            finally {
+                $blocker.Dispose()
+                Remove-Item -LiteralPath $lockPath -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Stale lock (>120 s mtime) is broken with Write-Warning and cmdlet succeeds' {
+            New-Sei -Path $script:seiPath -Map @{ 'n1' = @{ facts = @(@{ claim = 'Apollo Project.'; doc_id = 'd1' }) } }
+            $lockPath = "$($script:outPath).lock"
+            # Create a lock file and backdate its LastWriteTime to 200 s ago (> 120 s staleness threshold).
+            [System.IO.File]::WriteAllText($lockPath, '')
+            $staleTime = (Get-Date).AddSeconds(-200)
+            (Get-Item -LiteralPath $lockPath).LastWriteTime = $staleTime
+
+            $warnings = @()
+            $r = Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath `
+                -SummariesPath @() -OutputPath $script:outPath -WarningVariable warnings
+            # Cmdlet must succeed and write the index.
+            $r.Written | Should -BeTrue
+            # A warning about the stale lock must have been emitted.
+            [string]($warnings -join ' ') | Should -Match 'stale'
+            # Lock must be cleaned up after completion.
+            Test-Path -LiteralPath $lockPath | Should -BeFalse
+        }
+
+        It 'Atomic write uses tmp+rename — tmp file is absent after a successful write' {
+            # Confirm the existing atomic-write pattern: entity_mentions.json.tmp must not linger.
+            New-Sei -Path $script:seiPath -Map @{ 'n1' = @{ facts = @(@{ claim = 'Apollo Project.'; doc_id = 'd1' }) } }
+            $tmpPath = "$($script:outPath).tmp"
+
+            Update-EntityMentionIndex -EntitiesPath $script:entPath -SourceEvidenceIndexPath $script:seiPath `
+                -SummariesPath @() -OutputPath $script:outPath | Out-Null
+            # The .tmp file must be renamed away; it must not be present after success.
+            Test-Path -LiteralPath $tmpPath | Should -BeFalse
+            # The output file must exist and be valid JSON.
+            Test-Path -LiteralPath $script:outPath | Should -BeTrue
+            { Get-Content -Raw -LiteralPath $script:outPath -Encoding utf8 | ConvertFrom-Json } | Should -Not -Throw
+        }
+    }
+
     # Cross-runtime recipe drift guard (t/1904). Reconstructs each shared golden fixture through
     # the SAME production helper the indexer uses (Get-MentionContainerText) and asserts the
     # NFC code points + sha256 match lib/entities/mentionTextFixtures.json — the identical file


### PR DESCRIPTION
## Summary

- `Update-EntityMentionIndex` now acquires `entity_mentions.lock` (beside `entity_mentions.json`) before its read-merge-write, using `[System.IO.File]::Open(..., CreateNew)` for O_CREAT|O_EXCL exclusive create — the same advisory lockfile `reconcile_grounding.py` uses.
- Stale locks (mtime > 120 s) are detected, broken with `Write-Warning` (fallback-path logging rule), and retried immediately.
- Bounded wait: polls every 500 ms up to 60 s; timeout raises `New-ActionableError -PassThru`.
- Lock acquired **after** alias table build and container collection (heavy loads stay outside the lock); only the read-merge-write of `entity_mentions.json` is inside the lock scope.
- Lock released in a `finally` block regardless of success or failure.
- Atomic write (`.tmp` + `File.Move`) confirmed present and inside the lock.
- Added `-LockTimeoutSeconds` parameter (default 60) for test-controllable timeout.

## Test plan

- [ ] All 37 existing + new `Update-EntityMentionIndex.Tests.ps1` tests pass (`Tests Passed: 37, Failed: 0`)
- [ ] New `Context 'Lockfile (t/3203)'` covers: release after success, release after write failure (finally), timeout with ActionableError (using `-LockTimeoutSeconds 1`), stale-lock break with Write-Warning, and atomic-write confirmation
- [ ] Run: `pwsh -Command "Import-Module ./scripts/AITriad/AITriad.psm1; Invoke-Pester ./tests/Update-EntityMentionIndex.Tests.ps1 -Output Normal"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PFdqAGqgBXZV8tMz38grr