### PR TITLE
chore(devops): promote key-pool health check to paging (t/3142)

### DIFF
--- a/.github/workflows/key-pool-health.yml
+++ b/.github/workflows/key-pool-health.yml
@@ -39,7 +39,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   FLOOR: '2'
-  PAGE_ENABLED: 'false'   # observe-only until TL promotes (see header)
+  PAGE_ENABLED: 'true'    # PROMOTED to paging (TL auth p/331#829) after 1 green real-env observe cycle (run 33536887620: usable=4, alert=False, NetworkErr quiet). See header for the observe→paging rule.
   OWNER_HANDLE: 'jpsnover'
 
 jobs:


### PR DESCRIPTION
Flip `PAGE_ENABLED: false→true` in `key-pool-health.yml`. Self-cert one-liner per **TL promotion authorization (p/331#829)** — the gate was both-arms GV'd at merge (#1757), and TL authorized promotion on the evidence:

**1 green real-env observe cycle** (run 33536887620): `unique=4 valid=4 dead=0 throttled=0 netErr=0 usable=4 → alert=False`, SILENT, NetworkErr quiet. Also confirms the K=4 pool is live with all 4 keys valid (closes t/3191).

Gate now live-paging (issue + owner @-mention on Dead>0 or usable<2; 429 never pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)