### PR TITLE
feat(grounding): G8a inline write-hook — debounced scoped reconcile after PUT /api/taxonomy/:pov (t/3171)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/groundingReconcileHook.test.ts
+++ b/taxonomy-editor/src/server/__tests__/groundingReconcileHook.test.ts
@@ -16,7 +16,13 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { recordSpy } = vi.hoisted(() => ({ recordSpy: vi.fn() }));
+const { recordSpy, mockExecFile } = vi.hoisted(() => ({
+  recordSpy: vi.fn(),
+  // node-style execFile(file, args, opts, cb) — cb(err, stdout, stderr). Default: success stats.
+  mockExecFile: vi.fn((_file: string, _args: string[], _opts: unknown, cb: (e: Error | null, o: string, s: string) => void) =>
+    cb(null, '{"changed":1,"skipped":0,"removed":0}\nAPPLIED (scoped): 1 POV file(s), 0 dict file(s)', '')),
+}));
+vi.mock('child_process', () => ({ execFile: mockExecFile }));
 vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: recordSpy }) }));
 vi.mock('../logger.js', () => ({
   log: { server: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }, api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
@@ -138,6 +144,21 @@ describe('groundingReconcileHook (t/3171 G8a)', () => {
     await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10);
     expect(runner).toHaveBeenCalledTimes(2);
     expect(runner.mock.calls[1][0]).toEqual(['b']);
+  });
+
+  it('defaultRunner spawns execFile with the scoped --nodes/--apply args (child_process mock)', async () => {
+    __setReconcilerRunnerForTest(null); // use the REAL defaultRunner (execFile) path
+    mockExecFile.mockClear();
+
+    enqueueGroundingReconcile(['acc-beliefs-003', 'pol-004']);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10);
+
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    const [file, args, opts] = mockExecFile.mock.calls[0];
+    expect(String(file)).toMatch(/python3?$/);                         // hardcoded PYTHON, not user-supplied
+    expect(args[0]).toMatch(/reconcile_grounding\.py$/);
+    expect(args.slice(1)).toEqual(['--nodes', 'acc-beliefs-003,pol-004', '--apply']);
+    expect(opts).toMatchObject({ timeout: expect.any(Number), maxBuffer: expect.any(Number) });
   });
 
   it('sanitizeNodeIds drops anything outside the node-id charset before the subprocess', () => {

--- a/taxonomy-editor/src/server/__tests__/groundingReconcileHook.test.ts
+++ b/taxonomy-editor/src/server/__tests__/groundingReconcileHook.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3171 (G8a) — the inline grounding write-hook's DEBOUNCE + single-child + error-isolation core.
+// Deterministic unit tests (fake timers + an injected runner), so no python/data-repo is spawned:
+//   1. FIRES:        one enqueue → after the quiet window, ONE scoped run for that id.
+//   2. UNCHANGED:    enqueue([]) (an unchanged PUT diffs to nothing) → no run, no timers armed.
+//   3. COALESCE:     a burst of enqueues → ONE run carrying the UNION dirty-set (not N runs).
+//   4. FRESHNESS:    a sustained stream that never goes quiet still flushes within MAX_WAIT.
+//   5. ISOLATION:    runner rejects → never throws, FR WARN emitted, state resets (the #1737 lesson).
+//   6. SINGLE-CHILD: an enqueue while a child runs does NOT spawn a 2nd; it flushes after completion.
+//
+// The reconciler's own re-resolution correctness (hash-gate no-op, refs refresh, purge) is covered by
+// reconcile_grounding.py's selftest (CL, GREEN) — these tests assert the HOOK's invocation contract.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { recordSpy } = vi.hoisted(() => ({ recordSpy: vi.fn() }));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: recordSpy }) }));
+vi.mock('../logger.js', () => ({
+  log: { server: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }, api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+import {
+  enqueueGroundingReconcile,
+  __setReconcilerRunnerForTest,
+  __resetGroundingHookForTest,
+  __stateForTest,
+  parseStats,
+  sanitizeNodeIds,
+  DEBOUNCE_QUIET_MS,
+  DEBOUNCE_MAX_WAIT_MS,
+  type ReconcilerStats,
+} from '../groundingReconcileHook.js';
+
+const okStats = (n = 1): ReconcilerStats => ({ changed: n, skipped: 0, removed: 0 });
+const warnRecords = () => recordSpy.mock.calls.map(c => c[0] as { level?: string; message?: string; data?: Record<string, unknown> })
+  .filter(r => r?.level === 'warn' && /grounding_reconcile_inline/.test(r.message ?? ''));
+
+describe('groundingReconcileHook (t/3171 G8a)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    recordSpy.mockReset();
+    __resetGroundingHookForTest();
+  });
+  afterEach(() => {
+    __setReconcilerRunnerForTest(null);
+    __resetGroundingHookForTest();
+    vi.useRealTimers();
+  });
+
+  it('FIRES: one enqueue flushes after the quiet window as a single scoped run', async () => {
+    const runner = vi.fn(async () => okStats());
+    __setReconcilerRunnerForTest(runner);
+
+    enqueueGroundingReconcile(['acc-beliefs-003']);
+    expect(runner).not.toHaveBeenCalled();              // debounced, not immediate
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10);
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(runner).toHaveBeenCalledWith(['acc-beliefs-003']);
+    const info = recordSpy.mock.calls.map(c => c[0] as { message?: string; data?: Record<string, unknown> })
+      .find(r => /grounding_reconcile_inline: reconciled/.test(r.message ?? ''));
+    expect(info?.data).toMatchObject({ node_ids: ['acc-beliefs-003'], changed: 1 });
+  });
+
+  it('UNCHANGED: an empty/blank dirty-set is a no-op — no run, no timers', async () => {
+    const runner = vi.fn(async () => okStats());
+    __setReconcilerRunnerForTest(runner);
+
+    enqueueGroundingReconcile([]);        // unchanged PUT → diffNodes returns nothing
+    enqueueGroundingReconcile(['', '']);  // blank ids ignored
+    expect(__stateForTest()).toMatchObject({ dirtySize: 0, quietArmed: false, maxArmed: false });
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_MAX_WAIT_MS + 10);
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it('COALESCE: a burst within the quiet window becomes ONE run carrying the union set', async () => {
+    const runner = vi.fn(async (ids: string[]) => okStats(ids.length));
+    __setReconcilerRunnerForTest(runner);
+
+    enqueueGroundingReconcile(['a']);
+    await vi.advanceTimersByTimeAsync(1000);          // < QUIET → resets the quiet timer
+    enqueueGroundingReconcile(['b', 'c']);
+    await vi.advanceTimersByTimeAsync(1000);
+    enqueueGroundingReconcile(['a']);                 // duplicate collapses in the Set
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10);
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(new Set(runner.mock.calls[0][0])).toEqual(new Set(['a', 'b', 'c']));
+  });
+
+  it('FRESHNESS: a stream that never goes quiet still flushes within MAX_WAIT', async () => {
+    const runner = vi.fn(async (ids: string[]) => okStats(ids.length));
+    __setReconcilerRunnerForTest(runner);
+
+    // enqueue every 2s (< QUIET=3s) so the quiet timer never elapses; MAX=15s must force the flush.
+    for (let t = 0; t <= 14_000; t += 2000) {
+      enqueueGroundingReconcile([`x${t}`]);
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+    expect(runner).toHaveBeenCalledTimes(1);          // forced by MAX_WAIT despite never going quiet
+    expect(runner.mock.calls[0][0].length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('ISOLATION: a runner failure never throws, emits a WARN, and resets state', async () => {
+    const runner = vi.fn(async () => { throw new Error('reconciler boom'); });
+    __setReconcilerRunnerForTest(runner);
+
+    expect(() => enqueueGroundingReconcile(['a'])).not.toThrow();
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10); // flush must swallow the rejection
+
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(warnRecords()).toHaveLength(1);
+    expect(warnRecords()[0].data).toMatchObject({ node_ids: ['a'] });
+    expect(__stateForTest().running).toBe(false);            // reset for the next window
+  });
+
+  it('SINGLE-CHILD: an enqueue while a child runs does not spawn a 2nd; pending ids flush after', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const runner = vi.fn(async (ids: string[]) => { await gate; return okStats(ids.length); });
+    __setReconcilerRunnerForTest(runner);
+
+    enqueueGroundingReconcile(['a']);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10); // first flush starts; child awaits the gate
+    expect(runner).toHaveBeenCalledTimes(1);
+    expect(__stateForTest().running).toBe(true);
+
+    enqueueGroundingReconcile(['b']);                          // arrives mid-run
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10); // quiet fires, but running → no 2nd child
+    expect(runner).toHaveBeenCalledTimes(1);
+
+    release();                                                 // child completes → finally re-schedules 'b'
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(DEBOUNCE_QUIET_MS + 10);
+    expect(runner).toHaveBeenCalledTimes(2);
+    expect(runner.mock.calls[1][0]).toEqual(['b']);
+  });
+
+  it('sanitizeNodeIds drops anything outside the node-id charset before the subprocess', () => {
+    const dirty = ['acc-beliefs-003', 'pol-004', 'term:acceleration', 'sei:x.y', 'x,y', 'a b', 'a;rm -rf', 'a\nb', '$(whoami)', ''];
+    expect(sanitizeNodeIds(dirty)).toEqual(['acc-beliefs-003', 'pol-004', 'term:acceleration', 'sei:x.y']);
+  });
+
+  it('parseStats extracts the reconciler leading JSON, nulls on a miss (never throws)', () => {
+    const stdout = '{\n  "changed": 3,\n  "skipped": 1,\n  "removed": 0\n}\nscoped nodes: 4  touched POVs: [\'accelerationist\']\nAPPLIED (scoped): 1 POV file(s), 2 dict file(s)';
+    expect(parseStats(stdout)).toEqual({ changed: 3, skipped: 1, removed: 0 });
+    expect(parseStats('no json here')).toEqual({ changed: null, skipped: null, removed: null });
+  });
+});

--- a/taxonomy-editor/src/server/__tests__/taxonomyGroundingWiring.test.ts
+++ b/taxonomy-editor/src/server/__tests__/taxonomyGroundingWiring.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3171 (G8a) — PUT /api/taxonomy/:pov → grounding-reconcile WIRING. Verifies the route computes the
+// changed-node set (real diffNodes) and enqueues it ONLY when the flag is on, and always after the
+// 200 (fire-and-forget). The hook's debounce/exec/error-isolation is covered separately
+// (groundingReconcileHook.test.ts); here the hook is mocked so we assert the route's contract:
+//   - flag ON  + changed node  → enqueue(changed ids); response still { ok: true }.
+//   - flag ON  + unchanged     → enqueue NOT called (an unchanged PUT reconciles nothing).
+//   - flag OFF                 → enqueue NOT called (the enable/sequencing gate).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+const { getFlagSpy, enqueueSpy } = vi.hoisted(() => ({ getFlagSpy: vi.fn(), enqueueSpy: vi.fn() }));
+
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+vi.mock('../featureFlags.js', () => ({ getFlag: (name: string) => getFlagSpy(name) }));
+vi.mock('../groundingReconcileHook.js', () => ({ enqueueGroundingReconcile: (ids: string[]) => enqueueSpy(ids) }));
+vi.mock('../security/userContext.js', () => ({
+  isAnonymousUser: () => false,
+  getCurrentUserId: () => 'tester',
+}));
+
+const oldNodesRef: { nodes: Array<{ id: string; text: string }> } = { nodes: [] };
+vi.mock('../storage/fileIO.js', () => ({
+  readTaxonomyFile: vi.fn(async () => oldNodesRef),
+  writeTaxonomyFile: vi.fn(async () => undefined),
+  loadSyntheticEmbeddings: vi.fn(),
+  loadSyntheticCorpus: vi.fn(),
+}));
+
+import { registerTaxonomyRoutes } from '../routes/taxonomy.js';
+import type { ServerCtx } from '../routes/context.js';
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body?: unknown) => Promise<void> | void;
+
+function makeRouter() {
+  const handlers: Record<string, Handler> = {};
+  const reg = (m: string) => (p: string, h: Handler) => { handlers[`${m} ${p}`] = h; };
+  return { router: { get: reg('GET'), put: reg('PUT'), post: reg('POST'), patch: reg('PATCH'), del: reg('DELETE') }, handlers };
+}
+function fakeRes() {
+  const res: Record<string, unknown> = {
+    writableEnded: false, headersSent: false, _statusCode: 200, _body: undefined,
+    writeHead: vi.fn((code: number) => { res._statusCode = code; res.headersSent = true; }),
+    end: vi.fn((b?: string) => { res._body = b !== undefined ? JSON.parse(b) : undefined; res.writableEnded = true; }),
+    setHeader: vi.fn(),
+  };
+  return res as unknown as ServerResponse & { _body: Record<string, unknown>; _statusCode: number };
+}
+const fakeReq = () => ({ url: '/api/taxonomy/accelerationist' } as unknown as IncomingMessage);
+
+describe('PUT /api/taxonomy/:pov → grounding reconcile wiring (t/3171)', () => {
+  let put: Handler;
+
+  beforeEach(() => {
+    getFlagSpy.mockReset();
+    enqueueSpy.mockReset();
+    oldNodesRef.nodes = [{ id: 'n1', text: 'original' }, { id: 'n2', text: 'stable' }];
+    const { router, handlers } = makeRouter();
+    registerTaxonomyRoutes(router as never, { ensureSessionBranch: vi.fn(async () => undefined) } as unknown as ServerCtx);
+    put = handlers['PUT /api/taxonomy/:pov'];
+  });
+
+  it('flag ON + a changed node → enqueues the changed id and still returns { ok: true }', async () => {
+    getFlagSpy.mockReturnValue(true);
+    const res = fakeRes();
+    await put(fakeReq(), res, { nodes: [{ id: 'n1', text: 'EDITED' }, { id: 'n2', text: 'stable' }] });
+    expect(res._body).toMatchObject({ ok: true });      // response not blocked by the reconcile
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy.mock.calls[0][0]).toEqual(['n1']); // only the modified node
+  });
+
+  it('flag ON + a new node → enqueues the added id', async () => {
+    getFlagSpy.mockReturnValue(true);
+    const res = fakeRes();
+    await put(fakeReq(), res, { nodes: [{ id: 'n1', text: 'original' }, { id: 'n2', text: 'stable' }, { id: 'n3', text: 'brand new' }] });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy.mock.calls[0][0]).toContain('n3');
+  });
+
+  it('flag ON + unchanged content → does NOT enqueue (nothing to reconcile)', async () => {
+    getFlagSpy.mockReturnValue(true);
+    const res = fakeRes();
+    await put(fakeReq(), res, { nodes: [{ id: 'n1', text: 'original' }, { id: 'n2', text: 'stable' }] });
+    expect(res._body).toMatchObject({ ok: true });
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  it('flag OFF → never enqueues even when nodes changed (the enable/sequencing gate)', async () => {
+    getFlagSpy.mockReturnValue(false);
+    const res = fakeRes();
+    await put(fakeReq(), res, { nodes: [{ id: 'n1', text: 'EDITED' }, { id: 'n2', text: 'stable' }] });
+    expect(res._body).toMatchObject({ ok: true });
+    expect(getFlagSpy).toHaveBeenCalledWith('grounding_reconcile_inline'); // gate was consulted → returned false
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+});

--- a/taxonomy-editor/src/server/config.ts
+++ b/taxonomy-editor/src/server/config.ts
@@ -396,6 +396,10 @@ export const PORT = parseInt(process.env.PORT || '7862', 10);
 export const EMBED_SCRIPT = path.join(PROJECT_ROOT, 'scripts', 'embed_taxonomy.py');
 export const SCRIPTS_DIR = path.join(PROJECT_ROOT, 'scripts');
 export const BROKER_SCRIPT = path.join(PROJECT_ROOT, 'src', 'main', 'pty-broker.py');
+// t/3171 (G8a): the CL-owned grounding reconciler (t/3160/#1736), invoked in scoped mode
+// (`--nodes <ids> --apply`) by the inline write-hook after a PUT /api/taxonomy/:pov. Resolved off
+// PROJECT_ROOT like EMBED_SCRIPT; the script is stdlib+numpy (present in the web container).
+export const RECONCILE_SCRIPT = path.join(PROJECT_ROOT, 'research', 'comp-linguist', 'scripts', 'reconcile_grounding.py');
 
 // t/3183 (t/2977 Item B): per-build capability switch that routes embedding miss-text compute
 // off the main thread to the lib/embeddings worker (t/3181). DEFAULT OFF, web-first — when off,

--- a/taxonomy-editor/src/server/groundingReconcileHook.ts
+++ b/taxonomy-editor/src/server/groundingReconcileHook.ts
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+/**
+ * G8a inline grounding write-hook (t/3171, design: t/3171#2).
+ *
+ * After a PUT /api/taxonomy/:pov write succeeds, the route enqueues the changed node ids here. This
+ * module DEBOUNCES rapid PUTs into a single scoped reconciler run and shells out to CL's reconciler
+ * (`reconcile_grounding.py --nodes <ids> --apply`, #1736) — the same `execFile(PYTHON, …)` pattern
+ * the server already uses for embeddings/NLI. It is FIRE-AND-FORGET: the route responds 200 before
+ * calling in, and a reconciler failure is caught + logged and NEVER propagated (a failed grounding
+ * refresh must not fail the taxonomy write — the #1737 masked-error lesson).
+ *
+ * CONCURRENCY (per the G8 ruling, t/3163#1):
+ *  - Debounce: coalesce a burst of PUTs into ONE run carrying the accumulated dirty-set, because the
+ *    reconciler pays a fixed dict+embeddings load per invocation regardless of dirty-set size.
+ *  - Cross-process serialization is owned by the reconciler's internal `grounding_lock` (t/3194) —
+ *    this hook does NOT need its own cross-process mutex. As belt-and-suspenders it runs at most ONE
+ *    child at a time in-process (the `running` guard) so overlapping PUT bursts don't spawn children
+ *    that all just block on the tool-lock (process churn).
+ *
+ * ENABLE SEQUENCING: the route gates the call on the `grounding_reconcile_inline` feature flag
+ * (default OFF). It must stay OFF until the reconciler tool-lock (t/3194, landed) AND the PS cmdlet
+ * lock-honoring (t/3203) are both confirmed — otherwise a concurrent unlocked writer can lost-update
+ * the shared file. This module is inert until the route calls it, so flag-OFF = zero behavior.
+ */
+
+import { execFile } from 'child_process';
+import { RECONCILE_SCRIPT } from './config.js';
+import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
+import { ActionableError } from '../../../lib/debate/errors.js';
+import { log } from './logger.js';
+
+// Mirrors aiBackends.ts:63 — the reconciler is a python3 script (win32 dev uses `python`).
+const PYTHON = process.platform === 'win32' ? 'python' : 'python3';
+
+// ── Tunable constants (co-located; TL spec t/3171#2) ──────────────────────────
+/** Quiet window: flush this long after the LAST enqueue, so a burst of PUTs coalesces into one run. */
+export const DEBOUNCE_QUIET_MS = 3000;
+/** Freshness cap: a sustained edit stream still flushes within this bound even if it never goes quiet. */
+export const DEBOUNCE_MAX_WAIT_MS = 15000;
+/** Child-process budget — a scoped reconcile is bounded; matches the embed batch ceiling. */
+const RECONCILE_TIMEOUT_MS = 120_000;
+const RECONCILE_MAX_BUFFER = 10 * 1024 * 1024;
+
+// ── Injectable runner (testability — tests drive flush/coalesce/failure without spawning python) ──
+export interface ReconcilerStats { changed: number | null; skipped: number | null; removed: number | null }
+export type ReconcilerRunner = (nodeIds: string[]) => Promise<ReconcilerStats>;
+
+// Node-id charset: `{pov}-{cat}-{NNN}`, `pol-*`, `term:*`, `sei:*`, `summary:*` — word chars, ':',
+// '.', '-'. The ids reach a subprocess and are the ONE user-controlled input on this path; execFile
+// (array args, no shell) already blocks shell injection, but this allowlist is defense-in-depth AND
+// prevents a comma/newline in an id from mis-splitting the reconciler's `--nodes` value.
+const SAFE_NODE_ID = /^[A-Za-z0-9:_.-]+$/;
+
+/** Keep only well-formed node ids before they reach the subprocess (exported for unit test). */
+export function sanitizeNodeIds(ids: string[]): string[] {
+  return ids.filter((id) => SAFE_NODE_ID.test(id));
+}
+
+function defaultRunner(nodeIds: string[]): Promise<ReconcilerStats> {
+  const safe = sanitizeNodeIds(nodeIds);
+  // No well-formed ids → nothing safe to reconcile; resolve as a no-op rather than spawn a child
+  // with an empty/degenerate --nodes value.
+  if (safe.length === 0) return Promise.resolve({ changed: 0, skipped: 0, removed: 0 });
+  return new Promise((resolve, reject) => {
+    // Presence of --nodes forces the reconciler's scoped mode; an empty/malformed list is a safe
+    // no-op there, never a full apply (CL contract, #1736). --apply persists; the script acquires
+    // its own grounding_lock around the read-merge-write.
+    execFile(
+      PYTHON,
+      [RECONCILE_SCRIPT, '--nodes', safe.join(','), '--apply'],
+      { timeout: RECONCILE_TIMEOUT_MS, maxBuffer: RECONCILE_MAX_BUFFER },
+      (err, stdout, stderr) => {
+        if (err) { reject(new Error(`reconcile_grounding.py exited non-zero/timeout: ${err.message}\n${stderr}`)); return; }
+        resolve(parseStats(stdout));
+      },
+    );
+  });
+}
+
+/** Extract the reconciler's leading `json.dumps(stats)` block ({changed,skipped,removed}, all ints,
+ *  indent=2). Observability only — a parse miss yields nulls, never a throw. */
+export function parseStats(stdout: string): ReconcilerStats {
+  try {
+    const m = stdout.match(/\{[\s\S]*?\n\}/); // first top-level object; integer values → no nested braces
+    if (m) {
+      const s = JSON.parse(m[0]) as Partial<ReconcilerStats>;
+      return { changed: s.changed ?? null, skipped: s.skipped ?? null, removed: s.removed ?? null };
+    }
+  } catch { /* observability only — never throw on a stdout parse */ }
+  return { changed: null, skipped: null, removed: null };
+}
+
+let _runner: ReconcilerRunner = defaultRunner;
+
+// ── State (module singleton — one debounce window, at most one child) ─────────
+const dirty = new Set<string>();
+let quietTimer: ReturnType<typeof setTimeout> | null = null;
+let maxTimer: ReturnType<typeof setTimeout> | null = null;
+let running = false;
+
+function clearTimers(): void {
+  if (quietTimer) { clearTimeout(quietTimer); quietTimer = null; }
+  if (maxTimer) { clearTimeout(maxTimer); maxTimer = null; }
+}
+
+function scheduleFlush(): void {
+  // Reset the quiet timer on every enqueue; arm the max timer once per debounce window.
+  if (quietTimer) clearTimeout(quietTimer);
+  quietTimer = setTimeout(() => { void flush(); }, DEBOUNCE_QUIET_MS);
+  quietTimer.unref?.(); // never keep the process alive for a pending grounding refresh
+  if (!maxTimer) {
+    maxTimer = setTimeout(() => { void flush(); }, DEBOUNCE_MAX_WAIT_MS);
+    maxTimer.unref?.();
+  }
+}
+
+async function flush(): Promise<void> {
+  clearTimers();
+  if (running) return;        // a child is mid-run; its completion re-checks the dirty-set below
+  if (dirty.size === 0) return;
+
+  const ids = Array.from(dirty);
+  dirty.clear();
+  running = true;
+  const startedMs = Date.now();
+
+  try {
+    const stats = await _runner(ids);
+    getGlobalRecorder()?.record({
+      type: 'system.info', component: 'grounding-reconcile', level: 'info',
+      message: `grounding_reconcile_inline: reconciled ${ids.length} node(s) — ${stats.changed ?? '?'} changed`,
+      data: { node_ids: ids, changed: stats.changed, skipped: stats.skipped, removed: stats.removed, duration_ms: Date.now() - startedMs },
+    });
+  } catch (err) {
+    // Fallback-Path Logging: a failed/skipped reconcile must be visible (silently-stale grounding is
+    // invisible degradation) — WARN it — but NEVER propagate: the taxonomy write already succeeded.
+    const ae = new ActionableError({
+      goal: 'Refresh grounding for the just-written taxonomy nodes',
+      problem: `Inline grounding reconcile failed for ${ids.length} node(s): ${(err as Error).message}`,
+      location: 'groundingReconcileHook.flush',
+      nextSteps: [
+        'The taxonomy write itself succeeded — this only affects derived grounding freshness',
+        'The scheduled G8b sweep is the backstop; check reconcile_grounding.py availability/deps in this env',
+      ],
+    });
+    getGlobalRecorder()?.record({
+      type: 'system.error', component: 'grounding-reconcile', level: 'warn',
+      message: `grounding_reconcile_inline: reconcile FAILED for ${ids.length} node(s) — grounding may be stale until the next sweep`,
+      data: { node_ids: ids, duration_ms: Date.now() - startedMs },
+      error: { name: (err as Error).name ?? 'Error', message: ae.message, stack: (err as Error).stack },
+    });
+    log.server.warn({ component: 'grounding-reconcile', node_ids: ids, err: (err as Error).message }, 'inline grounding reconcile failed (non-fatal)');
+  } finally {
+    running = false;
+    // ids enqueued while the child ran are still pending → start a fresh debounce window for them.
+    if (dirty.size > 0) scheduleFlush();
+  }
+}
+
+/**
+ * Enqueue changed node ids for a debounced, fire-and-forget grounding reconcile. Safe to call on
+ * every write; empty/blank ids are ignored (an unchanged PUT diffs to nothing → no run). Never
+ * throws. The caller (routes/taxonomy.ts) gates this on the `grounding_reconcile_inline` flag.
+ */
+export function enqueueGroundingReconcile(nodeIds: string[]): void {
+  let added = false;
+  for (const id of nodeIds) { if (id) { dirty.add(id); added = true; } }
+  if (!added) return; // nothing changed → no reconcile (the unchanged-PUT arm)
+  scheduleFlush();
+}
+
+// ── Test hooks (underscore-prefixed — not part of the caller contract) ─────────
+/** Inject a fake reconciler runner; pass null to restore the real execFile-based runner. */
+export function __setReconcilerRunnerForTest(r: ReconcilerRunner | null): void { _runner = r ?? defaultRunner; }
+/** Reset all debounce state between tests (timers, dirty-set, running flag). */
+export function __resetGroundingHookForTest(): void { clearTimers(); dirty.clear(); running = false; }
+/** Introspection for tests. */
+export function __stateForTest(): { dirtySize: number; running: boolean; quietArmed: boolean; maxArmed: boolean } {
+  return { dirtySize: dirty.size, running, quietArmed: quietTimer !== null, maxArmed: maxTimer !== null };
+}

--- a/taxonomy-editor/src/server/groundingReconcileHook.ts
+++ b/taxonomy-editor/src/server/groundingReconcileHook.ts
@@ -28,7 +28,7 @@
 import { execFile } from 'child_process';
 import { RECONCILE_SCRIPT } from './config.js';
 import { getGlobalRecorder } from '../../../lib/flight-recorder/index.js';
-import { ActionableError } from '../../../lib/debate/errors.js';
+import { errorMessage } from '../../../lib/debate/errors.js';
 import { log } from './logger.js';
 
 // Mirrors aiBackends.ts:63 — the reconciler is a python3 script (win32 dev uses `python`).
@@ -88,7 +88,7 @@ export function parseStats(stdout: string): ReconcilerStats {
       const s = JSON.parse(m[0]) as Partial<ReconcilerStats>;
       return { changed: s.changed ?? null, skipped: s.skipped ?? null, removed: s.removed ?? null };
     }
-  } catch { /* observability only — never throw on a stdout parse */ }
+  } catch { /* telemetry — silent by design: a stdout parse miss yields null stats, never throws (observability field only) */ }
   return { changed: null, skipped: null, removed: null };
 }
 
@@ -135,23 +135,16 @@ async function flush(): Promise<void> {
     });
   } catch (err) {
     // Fallback-Path Logging: a failed/skipped reconcile must be visible (silently-stale grounding is
-    // invisible degradation) — WARN it — but NEVER propagate: the taxonomy write already succeeded.
-    const ae = new ActionableError({
-      goal: 'Refresh grounding for the just-written taxonomy nodes',
-      problem: `Inline grounding reconcile failed for ${ids.length} node(s): ${(err as Error).message}`,
-      location: 'groundingReconcileHook.flush',
-      nextSteps: [
-        'The taxonomy write itself succeeded — this only affects derived grounding freshness',
-        'The scheduled G8b sweep is the backstop; check reconcile_grounding.py availability/deps in this env',
-      ],
-    });
+    // invisible degradation) — WARN it — but NEVER propagate: the taxonomy write already succeeded,
+    // and the scheduled G8b sweep is the backstop (the #1737 masked-error lesson). Not an
+    // ActionableError: this path is caught + logged, never thrown, so a plain WARN record is correct.
     getGlobalRecorder()?.record({
       type: 'system.error', component: 'grounding-reconcile', level: 'warn',
-      message: `grounding_reconcile_inline: reconcile FAILED for ${ids.length} node(s) — grounding may be stale until the next sweep`,
+      message: `grounding_reconcile_inline: reconcile FAILED for ${ids.length} node(s) — grounding may be stale until the next G8b sweep`,
       data: { node_ids: ids, duration_ms: Date.now() - startedMs },
-      error: { name: (err as Error).name ?? 'Error', message: ae.message, stack: (err as Error).stack },
+      error: { name: (err as Error).name ?? 'Error', message: errorMessage(err), stack: (err as Error).stack },
     });
-    log.server.warn({ component: 'grounding-reconcile', node_ids: ids, err: (err as Error).message }, 'inline grounding reconcile failed (non-fatal)');
+    log.server.warn({ component: 'grounding-reconcile', node_ids: ids, err: errorMessage(err) }, 'inline grounding reconcile failed (non-fatal)');
   } finally {
     running = false;
     // ids enqueued while the child ran are still pending → start a fresh debounce window for them.

--- a/taxonomy-editor/src/server/routes/taxonomy.ts
+++ b/taxonomy-editor/src/server/routes/taxonomy.ts
@@ -14,8 +14,10 @@ import type { ServerCtx } from './context.js';
 import { json, error, param } from '../httpKit.js';
 import { getGlobalRecorder } from '../../../../lib/flight-recorder/index.js';
 import * as fileIO from '../storage/fileIO.js';
-import { stampNodeAuthorship } from '../storage/editMeta.js';
+import { stampNodeAuthorship, diffNodes } from '../storage/editMeta.js';
 import { isAnonymousUser } from '../security/userContext.js';
+import { getFlag } from '../featureFlags.js';
+import { enqueueGroundingReconcile } from '../groundingReconcileHook.js';
 
 export function registerTaxonomyRoutes(r: Router, ctx: ServerCtx): void {
   const { get, put } = r;
@@ -63,12 +65,23 @@ export function registerTaxonomyRoutes(r: Router, ctx: ServerCtx): void {
       await ensureSessionBranch();
       const pov = param(req, 'pov', '/api/taxonomy/:pov');
       const incoming = body as { nodes?: unknown[] };
+      // t/3171 (G8a): changed-node ids for the inline grounding reconcile, captured before stamping
+      // (nodeContentHash excludes the stamp fields, so pre/post-stamp content diffs identically) and
+      // while oldNodes is in scope. Only computed when the flag is on → flag-OFF adds one getFlag().
+      let changedNodeIds: string[] = [];
       if (incoming.nodes && Array.isArray(incoming.nodes)) {
         let oldNodes: unknown[] = [];
         try {
           const existing = await fileIO.readTaxonomyFile(pov) as { nodes?: unknown[] };
           oldNodes = existing?.nodes ?? [];
         } catch { /* telemetry — silent by design: first write or missing file — treat as empty */ }
+        if (getFlag('grounding_reconcile_inline')) {
+          const { added, modified, deleted } = diffNodes(
+            oldNodes as Parameters<typeof diffNodes>[0],
+            incoming.nodes as Parameters<typeof diffNodes>[1],
+          );
+          changedNodeIds = [...added, ...modified, ...deleted]; // deleted → the reconciler purges their grounding
+        }
         incoming.nodes = stampNodeAuthorship(
           oldNodes as Parameters<typeof stampNodeAuthorship>[0],
           incoming.nodes as Parameters<typeof stampNodeAuthorship>[1],
@@ -76,6 +89,9 @@ export function registerTaxonomyRoutes(r: Router, ctx: ServerCtx): void {
       }
       await fileIO.writeTaxonomyFile(pov, body);
       json(res, { ok: true });
+      // Fire-and-forget AFTER the 200 (never blocks/fails the write): debounced scoped grounding
+      // reconcile for the changed nodes. Gated OFF above until the tool-lock + PS lock (t/3203) land.
+      if (changedNodeIds.length > 0) enqueueGroundingReconcile(changedNodeIds);
     } catch (err) { getGlobalRecorder()?.record({ type: 'system.error', component: 'server', level: 'error', message: 'Failed to write taxonomy file', error: { name: (err as Error).name ?? 'Error', message: String(err), stack: (err as Error).stack } }); error(res, String(err), 500, err); }
   });
 


### PR DESCRIPTION
## t/3171 (G8a) — inline grounding write-hook → Main (TL) GV

Built to TL's design spec (t/3171#2), on CL's scoped reconciler entry point (#1736). After a `PUT /api/taxonomy/:pov` write succeeds, the changed node ids are enqueued for a **debounced, fire-and-forget** scoped grounding reconcile — behind the **`grounding_reconcile_inline` feature flag (default OFF)**.

### ⚠️ Enable sequencing (hard, stated per TL spec)
Ships **flag-OFF**. Do NOT enable until BOTH land/confirmed: the reconciler tool-lock (**t/3194**, landed — `grounding_lock` is in `reconcile_grounding.py`) AND the PS cmdlet lock-honoring (**t/3203**, open). Enabling before then lets a concurrent unlocked writer lost-update the shared `entity_mentions.json`. Flag-OFF = zero behavior change (the route adds only a `getFlag()`).

### Changes
- **`groundingReconcileHook.ts`** (new): in-process dirty-set + debounce (`DEBOUNCE_QUIET_MS=3000` / `DEBOUNCE_MAX_WAIT_MS=15000`, co-located); single-child-at-a-time in-process guard (belt-and-suspenders over the reconciler's own cross-process lock); `execFile` the scoped `--nodes <ids> --apply` reusing the server's `PYTHON` pattern; parse the leading stats JSON for the FR `changed` field. **Error isolation:** non-zero/timeout/spawn → `ActionableError` + FR **WARN**, never propagated (a failed grounding refresh must not fail the taxonomy write — the #1737 lesson). Node ids are **allowlist-sanitized** before the subprocess (`sanitizeNodeIds`).
- **`routes/taxonomy.ts`**: flag-gated `diffNodes(old, incoming)` → `enqueueGroundingReconcile` **after** the 200.
- **`config.ts`**: `RECONCILE_SCRIPT` off `PROJECT_ROOT`.

### Tests (12; TL's both-arms plan)
Hook unit (fake timers + injected runner — no python/data-repo spawned): FIRES / UNCHANGED-no-op / COALESCE-burst-into-one / MAX_WAIT-freshness / ERROR-ISOLATION / SINGLE-CHILD-guard / sanitize / parseStats. Route-wiring: flag ON changed→enqueue, ON new→enqueue, ON unchanged→no-enqueue, OFF→no-enqueue. `routeTable` regression green; `tsc` clean (only pre-existing unrelated missing-dep errors).

**Deviation flag (asked→did→why):** TL's test plan reads integration-style ("reconciler ran, hash updated"). I assert the **hook's invocation contract** deterministically (fake timers + injected runner) and rely on `reconcile_grounding.py`'s own selftest (CL, GREEN) for the re-resolution/hash-gate/purge correctness — because shelling out to real python against the `ai-triad-data` repo is **not hermetic in CI**. Happy to add a gated integration smoke if you'd prefer.

→ **Main (TL) GV** (inline half of a gate-adjacent flow + new cross-process interaction). Un-draft + self-merge on approval; enable stays held on t/3203.