### PR TITLE
feat(eslint): warn-level degraded-catch-return gate, narrowed to data/IO paths (t/3200)

### DIFF
--- a/lib/eslint-rules/require-warn-on-degraded-catch-return.js
+++ b/lib/eslint-rules/require-warn-on-degraded-catch-return.js
@@ -1,0 +1,90 @@
+// Custom ESLint rule (t/3200, Fallback-Path Logging — follow-up to t/3169).
+//
+// A `catch` that returns a DEGRADED default (a `Literal` / `[]` / `{}`) FROM A DATA/COMPUTE/IO PATH
+// is a fallback by definition (the t/3165 genus: cache-miss→recompute, primary→secondary,
+// retry-exhausted→default, ADR-001 graceful-empty), so it must record at WARN or ERROR stating what
+// fell back and why. Info-level and the `/* silent by design */` escape-hatch do NOT satisfy it —
+// those were the two gaps the base `require-flight-recorder-in-catch` rule left open (t/3169#2).
+//
+// This is a SEPARATE rule from the base one on purpose: ESLint severity is per-rule-id, so keeping
+// the strict degraded-return check as its own rule lets it ship at `warn` (non-blocking visibility)
+// while the base catch-recording gate stays at `error`, unchanged. Promotion to `error` is a
+// separate, GV-gated step once the t/3169 cleanup lands the WARNs and the flagged count reaches zero
+// (TL t/3200#2). The predicate is deliberately NARROW — a benign UI/local default (a synchronous
+// `localStorage` miss → `[]` in a renderer hook) has no data/IO signal in its try block and is NOT
+// flagged, which keeps the gate low-noise.
+
+const FUNCTION_TYPES = new Set(['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression']);
+const DEGRADED_ARG_TYPES = new Set(['Literal', 'ArrayExpression', 'ObjectExpression']);
+
+// Data/compute/IO signal in the try block. localStorage/sessionStorage are deliberately EXCLUDED —
+// a UI-local default is not the t/3165 class. False negatives (a helper that hides its IO behind a
+// plain call) are the safe direction for a non-blocking gate; the error-flip tightens later.
+const DATA_IO_SIGNAL_RE = /\b(await|fs|fsp|readFile|readFileSync|writeFile|writeFileSync|readdir|createReadStream|fetch|https?|axios|got|request|backend|readDataFile|writeDataFile|getBackend|db|query|pool|exec|execSync|spawn|embed|computeEmbedding|onnx)\b/;
+
+/**
+ * Does this subtree contain a `return <Literal | [] | {}>` that belongs to THIS catch (not inside a
+ * nested function, whose returns are a different scope)? Descends control-flow blocks, stops at
+ * function boundaries.
+ */
+function containsDegradedReturn(node) {
+  if (!node || typeof node.type !== 'string') return false;
+  if (node.type === 'ReturnStatement') {
+    return !!node.argument && DEGRADED_ARG_TYPES.has(node.argument.type);
+  }
+  if (FUNCTION_TYPES.has(node.type)) return false;
+  for (const key of Object.keys(node)) {
+    if (key === 'parent') continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const c of child) {
+        if (c && typeof c.type === 'string' && containsDegradedReturn(c)) return true;
+      }
+    } else if (child && typeof child.type === 'string') {
+      if (containsDegradedReturn(child)) return true;
+    }
+  }
+  return false;
+}
+
+/** WARN-or-higher recording present (either transport: `log.*.warn|error`, or a warn/error record()). */
+function hasWarnOrErrorLogging(source) {
+  if (/\blog\.\w+\.(warn|error)\b/.test(source)) return true;
+  if (source.includes('getGlobalRecorder') && /\blevel\s*:\s*['"](warn|error)['"]/.test(source)) return true;
+  return false;
+}
+
+/** Does the catch's corresponding try block show a data/compute/IO operation? */
+function tryBlockHasDataIoSignal(catchNode, sourceCode) {
+  const tryStmt = catchNode.parent;
+  if (!tryStmt || tryStmt.type !== 'TryStatement' || !tryStmt.block) return false;
+  return DATA_IO_SIGNAL_RE.test(sourceCode.getText(tryStmt.block));
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'A degraded-default return from a data/compute/IO catch must record at WARN or ERROR (Fallback-Path Logging)',
+    },
+    messages: {
+      degradedReturnNeedsWarn:
+        'Catch on a data/IO path returns a degraded default (a literal / [] / {}) — that is a FALLBACK and must record at WARN or ERROR (getGlobalRecorder().record({ level: \'warn\' }) or log.*.warn/error()) stating what fell back and why. Info-level and the /* silent by design */ escape-hatch do NOT satisfy this (Fallback-Path Logging, t/3200/t/3169).',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CatchClause(node) {
+        if (
+          containsDegradedReturn(node.body) &&
+          tryBlockHasDataIoSignal(node, context.sourceCode) &&
+          !hasWarnOrErrorLogging(context.sourceCode.getText(node.body))
+        ) {
+          context.report({ node, messageId: 'degradedReturnNeedsWarn' });
+        }
+      },
+    };
+  },
+};

--- a/taxonomy-editor/eslint-rules/__tests__/require-warn-on-degraded-catch-return.test.ts
+++ b/taxonomy-editor/eslint-rules/__tests__/require-warn-on-degraded-catch-return.test.ts
@@ -1,0 +1,65 @@
+// Rule-level Gate Verification for local/require-warn-on-degraded-catch-return (t/3200).
+// The rule lives in lib/eslint-rules (Shared Lib scope) but is applied by taxonomy-editor's config,
+// so its test lives in the taxonomy-editor rule-test harness (same place as no-raw-data-root-read).
+// Both-arms proof: `invalid` = the FAIL arm (a degraded return FROM A DATA/IO PATH with no/
+// insufficient WARN recording fires), `valid` = the precision arm (adequate WARN recording — either
+// transport — plus NON-data-IO defaults like a localStorage miss and non-degraded catches, which the
+// narrowed predicate must NOT flag, so the gate isn't noisy — TL t/3200#2).
+// Snippets are wrapped in `async function h() {}` (top-level `return`/`await` are parse errors).
+import { describe, it, afterAll } from 'vitest';
+import { RuleTester } from 'eslint';
+import rule from '../../../lib/eslint-rules/require-warn-on-degraded-catch-return.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.afterAll = afterAll;
+
+const rt = new RuleTester({ languageOptions: { ecmaVersion: 2022, sourceType: 'module' } });
+
+const h = (body: string) => `async function h() { ${body} }`;
+
+rt.run('require-warn-on-degraded-catch-return', rule, {
+  valid: [
+    // ── Non-degraded / non-IO catches: this rule stays silent (base rule owns them) ──
+    h("try { f(); } catch (e) { getGlobalRecorder()?.record({ level: 'info' }); }"),
+    h("try { f(); } catch (e) { /* telemetry — silent by design */ }"),
+    h("try { f(); } catch (e) { doCleanup(); }"), // non-degraded, no recording → base rule's concern, not this one
+
+    // ── Degraded return FROM A DATA/IO PATH with adequate WARN/ERROR recording (both transports) ──
+    h("try { await load(); } catch (e) { log.server.warn('fell back to empty'); return []; }"),
+    h("try { const d = await fs.readFile(p); } catch (e) { log.ai.error('recompute failed'); return null; }"),
+    h("try { await fetch(u); } catch (e) { getGlobalRecorder()?.record({ level: 'warn', message: 'empty' }); return {}; }"),
+    h("try { const r = await backend.readFile(p); } catch (e) { log.server.warn('x'); return 0; }"),
+
+    // ── NARROWING: benign UI/local default (no data/IO signal) is NOT the strict class ──
+    h("try { return JSON.parse(localStorage.getItem('k')); } catch (e) { return []; }"),
+    h("try { const v = localStorage.getItem('k'); return v ? JSON.parse(v) : null; } catch (e) { log.renderer.info('no cache'); return []; }"),
+
+    // ── Nested-function return does NOT trigger the strict path (different scope) ──
+    h("try { await load(); } catch (e) { log.server.warn('x'); items.forEach(() => { return []; }); return []; }"),
+  ],
+  invalid: [
+    // Level gap: degraded return from an IO path but only info-level structured log.
+    {
+      code: h("try { await load(); } catch (e) { log.server.info('miss'); return []; }"),
+      errors: [{ messageId: 'degradedReturnNeedsWarn' }],
+    },
+    // Escape-hatch gap: degraded return from an fs read + silent-by-design comment but NO logging
+    // (audit Finding 1: aiBackends.ts:957 — comment present, emitted nothing).
+    {
+      code: h("try { const d = await fs.readFile(p); } catch (e) { /* telemetry — silent by design */ return []; }"),
+      errors: [{ messageId: 'degradedReturnNeedsWarn' }],
+    },
+    // Recorder present but wrong level (info) on a degraded return from a fetch path.
+    {
+      code: h("try { await fetch(u); } catch (e) { getGlobalRecorder()?.record({ level: 'info' }); return {}; }"),
+      errors: [{ messageId: 'degradedReturnNeedsWarn' }],
+    },
+    // Degraded return from an IO path with nothing at all.
+    {
+      code: h("try { await load(); } catch (e) { return null; }"),
+      errors: [{ messageId: 'degradedReturnNeedsWarn' }],
+    },
+  ],
+});

--- a/taxonomy-editor/eslint.config.mjs
+++ b/taxonomy-editor/eslint.config.mjs
@@ -18,6 +18,7 @@
 import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
 import requireFlightRecorderInCatch from '../lib/eslint-rules/require-flight-recorder-in-catch.js';
+import requireWarnOnDegradedCatchReturn from '../lib/eslint-rules/require-warn-on-degraded-catch-return.js';
 import noActionableErrorMessageNesting from '../lib/eslint-rules/no-actionable-error-message-nesting.js';
 import noUnmanagedModuleResources from './eslint-rules/no-unmanaged-module-resources.js';
 import noInlineStyle from './eslint-rules/no-inline-style.js';
@@ -26,6 +27,7 @@ import noRawDataRootRead from './eslint-rules/no-raw-data-root-read.js';
 const localPlugin = {
   rules: {
     'require-flight-recorder-in-catch': requireFlightRecorderInCatch,
+    'require-warn-on-degraded-catch-return': requireWarnOnDegradedCatchReturn,
     'no-unmanaged-module-resources': noUnmanagedModuleResources,
     'no-inline-style': noInlineStyle,
     'no-actionable-error-message-nesting': noActionableErrorMessageNesting,
@@ -79,6 +81,11 @@ export default tseslint.config(
       // ADR-003 enforcement (t/1323, repo-review B-401): every catch records to the
       // flight recorder. Flipped warn→error once the tree was clean (0 violations).
       'local/require-flight-recorder-in-catch': 'error',
+      // t/3200 (Fallback-Path Logging): a degraded-default return from a data/IO catch must record
+      // at WARN/ERROR. Shipped 'warn' (non-blocking visibility) — separate rule from the base one so
+      // this severity is independent. Promotion to 'error' is a separate GV-gated step once the
+      // t/3169 cleanup lands the WARNs and the flagged count reaches zero (TL t/3200#2).
+      'local/require-warn-on-degraded-catch-return': 'warn',
       'max-lines': MAX_LINES_SRC,
       // ActionableError nesting gate (t/2764 / t/2761): forbid err.message in problem:.
       // Custom rule (not no-restricted-syntax) so it restricts to error-named identifiers


### PR DESCRIPTION
Prevention follow-up to t/3169 (Fallback-Path Logging), per TL gate-design ruling (t/3200#2). A degraded-default return (`Literal`/`[]`/`{}`) from a **data/compute/IO** catch is a fallback (t/3165 genus) and must record at WARN/ERROR — info-level + the `/* silent by design */` escape-hatch don't satisfy it.

- **New rule** `lib/eslint-rules/require-warn-on-degraded-catch-return.js` — AST degraded-return detection (skips nested-fn returns) + a **data/IO signal** requirement in the try block (await/fs/fetch/backend/embedding/db; localStorage excluded) + warn/error via either transport.
- **Separate rule** (ESLint severity is per-rule-id) so it ships at **`warn` (non-blocking)** while the base `require-flight-recorder-in-catch` gate stays at **`error`, unchanged**.
- Both-arms RuleTester test (14 cases).

**Narrowing: 75 → 37 violations** (dropped renderer UI/localStorage false positives; kept server/main storage+IO+IPC data paths). **Non-blocking self-cert** per TL — only the future `error`-flip (after t/3169 cleanup → zero-noise) is a separate GV PR.

Verify: new-rule test 14/14, base rule **0 errors** (gate intact), `eslint --max-warnings=4256` **exit 0** (total warnings 658 << cap; +37 new). Advances t/3200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)