### PR TITLE
feat(deploy): 1→2 vCPU — worker-offload correctness floor (t/3182)

### DIFF
--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -623,7 +623,17 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'taxonomy-editor'
           image: containerImage
           resources: {
-            cpu: json('1.0')
+            // 2 vCPU is the CORRECTNESS FLOOR for the embedding worker-offload
+            // (t/3182 / t/2977 C1). The off-thread ONNX worker (EMBEDDING_WORKER_OFFLOAD)
+            // needs a REAL second core: on 1 vCPU the worker time-slices the same core
+            // as the event loop, so a big embed still starves liveness (defeats the
+            // offload). 2 vCPU keeps the loop responsive while the worker computes.
+            // Stays within the ACA Consumption plan (0.25-4 vCPU) - one-line resources
+            // edit, no workload-profile/topology migration. Cost ~$0 (free grant, t/2977#4).
+            // Memory unchanged: incident RSS peaked ~650MB/2048 + ~250MB worker model
+            // copy ~= 900MB, comfortably within 2Gi (embeddings.json is NOT copied to the
+            // worker - the cache resolve stays main-thread, only miss-texts marshal).
+            cpu: json('2.0')
             memory: '2Gi'
           }
           env: containerEnv

--- a/deploy/azure/main.bicep
+++ b/deploy/azure/main.bicep
@@ -643,6 +643,15 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               httpGet: { path: '/healthz', port: 7862 }
               periodSeconds: 30
               failureThreshold: 3
+              // timeoutSeconds made EXPLICIT (was defaulting to ACA's ~1s). This is
+              // the DETERMINISTIC liveness deadline the storm-replay canary gates on
+              // (t/3182/t/3199, Diagnostics p/168#13): /healthz can't answer while the
+              // event loop is ONNX-blocked, so a loop-block > this timeout fails
+              // liveness → 503/kill. The worker-offload must keep p99 loop-lag under
+              // this with margin. Explicit (not defaulted) so the pass line is a
+              // documented value, not a silent platform default. 1s preserves current
+              // prod behavior (the ACA default) — it does NOT loosen liveness.
+              timeoutSeconds: 1
             }
             {
               type: 'Readiness'


### PR DESCRIPTION
Un-held per TL (p/331#830). Bumps the taxonomy-editor container to **2 vCPU** (memory unchanged 2Gi) in `main.bicep`.

## Why (correctness floor, C1)
The off-thread ONNX embedding worker (`EMBEDDING_WORKER_OFFLOAD`, t/3183) needs a **real second core**: on 1 vCPU the worker time-slices the same core as the event loop, so a large embed still starves liveness → defeats the offload. 2 vCPU keeps the loop responsive while the worker computes.

## Scope / cost
- Within the ACA **Consumption** plan (0.25–4 vCPU) → one-line `resources` edit, **no workload-profile/topology migration**.
- **~$0** — free grant, MTD spend $0 (t/2977#4 sizing).
- Memory stays 2Gi: incident RSS peaked ~650MB/2048 + ~250MB worker model copy ≈ 900MB (embeddings.json is NOT copied to the worker; cache resolve stays main-thread).
- Gate Co-Location: rationale inline at the `resources` block.

## Verification
`az bicep build` clean; compiled ARM carries `"cpu": "[json('2.0')]"` on the main container (runner sidecar unchanged at 0.25).

**Ships WITH the storm-replay canary rev** (the close gate for t/3165). Draft — lands as part of the canary deployment sequence; routing to TL. No standalone prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)