### PR TITLE
test(smoke): computed-style invariance leg for render harness (t/2940)

### DIFF
--- a/taxonomy-editor/package.json
+++ b/taxonomy-editor/package.json
@@ -40,6 +40,7 @@
     "test:watch": "vitest",
     "test:changed": "vitest run --changed",
     "smoke:styled": "node smoke/run-smoke.mjs",
+    "smoke:invariance:capture": "cross-env SMOKE_CAPTURE=1 node smoke/run-smoke.mjs",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "depgraph": "node scripts/depgraph.mjs --stats",

--- a/taxonomy-editor/smoke/README.md
+++ b/taxonomy-editor/smoke/README.md
@@ -119,3 +119,32 @@ adjudication is **done** (all CONFIRMED orphans): claim-attribution is fixed + a
 are **routed to the owning child roles** (Conflict, DebateWorkspace, DebateDiagnostics) and are
 deliberately **not** asserted here (the gate stays POV-scoped + low-flake). Those routed fixes are
 tracked in **t/3059**. A green check here covers the five POV surfaces above, not the gated ones.
+
+## Computed-style invariance leg (t/2940 — second assertion class)
+
+The reachability leg above answers *"is the class's sheet loaded on its surface?"* This leg answers
+*"did a CSS source-split change any computed value?"* — TL's Option C (t/2940#5/#6). A source-split is
+a pure move (delete from `styles.css` → co-locate, **no value change**), so its invariant is
+identical `getComputedStyle` per theme. Files: `computed-style-invariance.smoke.mjs` (+ `.manifest.mjs`).
+
+**Covered clusters** (split in the t/2989 push *without* the automated leg — t/2940#3):
+`sumt-*` (SummariesTab.css), `lineage-*` (LineagePanel.css + LineageDetailView.css), debate-popout
+(DebatePopoutWindow.css). Representative selectors × the 4 themes (`light`/`dark`/`bkc`/`harvard`,
+set via `data-theme`) × TL's prop set (grid/border/color/background/padding/font) → committed fixture
+`fixtures/computed-style-invariance.json`.
+
+**Modes:** default = ASSERT (current computed style `== fixture`; **skips** when the fixture is
+absent, so the gate is inert until a baseline is committed). `SMOKE_CAPTURE=1` = capture → write the
+fixture (`npm run smoke:invariance:capture`).
+
+**Baseline capture + both-arms run in CI (Node 22), not local Node 24** — the `@playwright/test`
+runner hangs on Node 24 (the t/3026 finding), and a committed style baseline must come from the
+deterministic CI browser. DevOps owns the CI wiring (the spec is already picked up by
+`testMatch: **/*.smoke.mjs`, so it rides the existing `render-smoke` job). **Both-arms GV (TL):**
+alter one moved value in a cluster CSS → computed style diverges from the fixture → gate FIRES;
+revert / pure move → PASSES.
+
+**Reachability caveat (CI-validated):** `openTab` per cluster is best-effort (SummariesTab/LineagePanel
+ride ToolbarPaneRenderer ← PovTab, so a POV tab). The capture run confirms each cluster's CSS actually
+loads there; `debatePopout` is a separate window (`reachabilityUnconfirmed`) — the capture confirms
+whether it's reachable in the web smoke or needs the popout route opened.

--- a/taxonomy-editor/smoke/computed-style-invariance.manifest.mjs
+++ b/taxonomy-editor/smoke/computed-style-invariance.manifest.mjs
@@ -1,0 +1,74 @@
+// Computed-style invariance manifest (t/2940 — TL Option C, t/2940#5/#6).
+//
+// A CSS *source-split* is a pure move (delete rule from styles.css → co-locate in a component
+// sheet, NO value change), so its invariant is byte-identical getComputedStyle per theme. This
+// manifest enumerates, per smoke-covered cluster that was split in the t/2989 push WITHOUT the
+// automated visual leg (t/2940#3), the probe-injectable single-class selectors whose computed
+// style must not drift. The invariance spec captures PROPS × THEMES for each into a committed
+// fixture (baseline), then asserts equality on every run — a real value change (non-pure split)
+// fires the gate; a pure move passes.
+
+/** The 4 explicit themes (data-theme on <html>). `system` resolves to light/dark, not a distinct value. */
+export const THEMES = ['light', 'dark', 'bkc', 'harvard'];
+
+/**
+ * Fixed computed-style property set — TL's t/2940#5 visual-meaning categories (grid / border /
+ * color / background / padding / margin / font). Captured for every selector × theme.
+ */
+export const PROPS = [
+  'display', 'position', 'grid-template-columns', 'flex-direction',
+  'border-top-width', 'border-bottom-width', 'border-radius',
+  'color', 'background-color',
+  'padding-top', 'padding-left', 'margin-top',
+  'font-size', 'font-weight', 'text-transform', 'text-decoration-line',
+];
+
+/**
+ * Covered clusters → { openTab, selectors }. `openTab` is the tab whose lazy chunk loads the
+ * cluster's co-located CSS (probe needs the rule loaded). SummariesTab/LineagePanel/LineageDetail
+ * render via ToolbarPaneRenderer ← PovTab, so they load on a POV tab (same chunk reachability the
+ * existing harness proved for DataSourceCard/ApiKeyErrorMessage). Representative selectors only
+ * (container/badge/header/button rules that carry visual styling), not all 97, per t/2940#6.
+ *
+ * NOTE (CI-validated): exact reachability + the captured values are determined by the CI capture
+ * run (Node-22 real browser) — the @playwright/test runner hangs on local Node-24 (t/3026). If a
+ * cluster's CSS is NOT reachable on `openTab` (values come back at CSS defaults / identical across
+ * themes), the capture surfaces it and the openTab/surface is corrected. debate-popout is a
+ * separate BrowserWindow — flagged as likely NOT reachable in the web smoke; its leg may need the
+ * popout route opened, to be confirmed by the capture run.
+ */
+export const CLUSTERS = {
+  summaries: {
+    css: 'analysis/SummariesTab.css',
+    openTab: 'accelerationist',
+    selectors: [
+      'sumt-card', 'sumt-detail-panel', 'sumt-pov-badge', 'sumt-tag',
+      'sumt-stance', 'sumt-tab-bar', 'sumt-node-item', 'sumt-viewmode-btn',
+    ],
+  },
+  lineagePanel: {
+    css: 'analysis/LineagePanel.css',
+    openTab: 'accelerationist',
+    selectors: [
+      'lineage-panel', 'lineage-panel-header', 'lineage-category-badge',
+      'lineage-panel-item', 'lineage-l2-header', 'lineage-detail-section',
+    ],
+  },
+  lineageDetail: {
+    css: 'shared/LineageDetailView.css',
+    openTab: 'accelerationist',
+    selectors: [
+      'lineage-detail-pov-badge-sm', 'lineage-detail-filter-btn',
+      'lineage-detail-ctx-menu', 'lineage-detail-ref-id',
+    ],
+  },
+  debatePopout: {
+    css: 'debate/DebatePopoutWindow.css',
+    openTab: 'accelerationist',
+    reachabilityUnconfirmed: true, // separate window — CI capture confirms whether the CSS loads in web
+    selectors: [
+      'debate-popout-shell', 'debate-popout-error-box',
+      'debate-popout-error-title', 'debate-popout-hint',
+    ],
+  },
+};

--- a/taxonomy-editor/smoke/computed-style-invariance.smoke.mjs
+++ b/taxonomy-editor/smoke/computed-style-invariance.smoke.mjs
@@ -1,0 +1,75 @@
+// Computed-style invariance leg (t/2940 — TL Option C, t/2940#5/#6). Second assertion class in
+// the t/3026 Playwright harness. A CSS source-split is a pure move → getComputedStyle unchanged
+// per theme; this asserts the moved selectors' computed style still equals a committed fixture,
+// across the 4 themes. A value change (non-pure split) fires the gate; a pure move passes.
+//
+// TWO MODES:
+//   • CAPTURE (SMOKE_CAPTURE=1) — snapshot current computed style → write the fixture (commit it).
+//   • ASSERT (default) — compare current vs the committed fixture. Skips (does not fail) when the
+//     fixture is absent, so the gate is inert until a baseline is captured + committed.
+// Fixture capture + both-arms belong in the Node-22 CI browser — the @playwright/test runner
+// hangs on local Node-24 (t/3026/#1589), and a committed style baseline must come from the
+// deterministic CI env. DevOps owns the CI wiring (t/2940#5); TL owns the both-arms GV.
+import { test, expect } from '@playwright/test';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { THEMES, PROPS, CLUSTERS } from './computed-style-invariance.manifest.mjs';
+
+const BASE = process.env.SMOKE_BASE_URL || 'http://127.0.0.1:7862';
+const CAPTURE = process.env.SMOKE_CAPTURE === '1';
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(HERE, 'fixtures', 'computed-style-invariance.json');
+
+/** For one theme, inject each selector's class, read PROPS via getComputedStyle, remove it. */
+async function probeCluster(page, theme, selectors) {
+  return page.evaluate(({ theme, selectors, props }) => {
+    document.documentElement.dataset.theme = theme;
+    const out = {};
+    for (const sel of selectors) {
+      const el = document.createElement('div');
+      el.className = sel;
+      document.body.appendChild(el);
+      const cs = getComputedStyle(el);
+      const rec = {};
+      for (const p of props) rec[p] = cs.getPropertyValue(p);
+      el.remove();
+      out[sel] = rec;
+    }
+    return out;
+  }, { theme, selectors, props: PROPS });
+}
+
+test.beforeEach(async ({ page }) => {
+  // Suppress the aria-modal OnboardingTour (intercepts every click) — same as attributes spec (t/3026).
+  await page.addInitScript(() => {
+    try { localStorage.setItem('taxonomy-editor-onboarding-dismissed', 'true'); } catch { /* private mode */ }
+  });
+  await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('[data-tab]', { timeout: 30_000 });
+});
+
+test('computed-style invariance across the 4 themes (t/2940)', async ({ page }) => {
+  const captured = {};
+  for (const [name, cluster] of Object.entries(CLUSTERS)) {
+    // Navigate to the surface whose lazy chunk loads this cluster's co-located CSS.
+    await page.locator(`[data-tab="${cluster.openTab}"]`).first().click();
+    await page.waitForLoadState('networkidle').catch(() => {});
+    captured[name] = {};
+    for (const theme of THEMES) {
+      captured[name][theme] = await probeCluster(page, theme, cluster.selectors);
+    }
+  }
+
+  if (CAPTURE) {
+    mkdirSync(dirname(FIXTURE), { recursive: true });
+    writeFileSync(FIXTURE, JSON.stringify(captured, null, 2) + '\n');
+    test.info().annotations.push({ type: 'capture', description: `wrote invariance fixture → ${FIXTURE}` });
+    return; // capture run — nothing to assert against
+  }
+
+  test.skip(!existsSync(FIXTURE), 'invariance fixture not yet captured — run `SMOKE_CAPTURE=1` and commit fixtures/computed-style-invariance.json (t/2940)');
+  const expected = JSON.parse(readFileSync(FIXTURE, 'utf-8'));
+  // Whole-object equality: any drifted selector/theme/prop surfaces in the diff.
+  expect(captured).toEqual(expected);
+});


### PR DESCRIPTION
Establishes the automated visual-regression leg for the t/3026 smoke harness — TL's Option C (t/2940#5/#6).

## What
A CSS **source-split** is a pure move (delete rule from `styles.css` → co-locate, no value change), so its invariant is identical `getComputedStyle` per theme. This adds a second assertion class alongside the existing reachability leg:

- `smoke/computed-style-invariance.manifest.mjs` — 4 themes (light/dark/bkc/harvard) × 16 computed props (grid/border/color/background/padding/font) × 4 clusters (summaries, lineagePanel, lineageDetail, debatePopout) = 22 representative selectors.
- `smoke/computed-style-invariance.smoke.mjs` — CAPTURE mode (`SMOKE_CAPTURE=1`) writes the fixture; ASSERT mode (default) compares vs committed baseline and **skips when the fixture is absent** (gate inert until a baseline is committed).
- `package.json` — `smoke:invariance:capture` script.
- `smoke/README.md` — invariance-leg section.

Auto-picked up by `testMatch: '**/*.smoke.mjs'` — rides the existing `render-smoke` job, no config change.

## Scope of this PR (Option A per user + t/2940#5)
This lands the **spec + capture helper + selector manifest** only. The two CI-owned steps are **routed, not done here**:
1. **Baseline fixture capture** (Node-22 CI) — the `@playwright/test` runner hangs on local Node-24 (t/3026), and a committed style baseline must come from the deterministic CI browser. → **DevOps**.
2. **Both-arms Gate Verification** — alter one moved value → gate FIRES; pure move → PASSES. → **TL**.

Also to confirm in the capture run: `debatePopout` reachability (`reachabilityUnconfirmed` — separate BrowserWindow, may need the popout route opened).

## Local verification
- `node --check` both `.mjs` — clean.
- Manifest loads + exports (4 themes / 16 props / 4 clusters / 22 selectors).
- ASSERT arm is inert (skips) until the CI capture commits the fixture — safe to land without the baseline.

**Gated: draft until TL both-arms GV + DevOps CI capture land.** Do not self-merge (adds a gate-assertion class).

Co-Authored-By: Rosetta Stone (Orca) <main.taxonomy-editor@ai-triad-research.orca.local>