### PR TITLE
feat(ps): Invoke-VernacularBatch — surgical field writes (t/2926)

### DIFF
--- a/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
+++ b/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
@@ -244,8 +244,8 @@ Rules:
     # plain_description and plain_description_version are both depth-1 scalars;
     # absent-key INSERT at the node level is supported by Update-JsonNodeField (t/2916).
     # The surgical exemption to the dirty-tree guard is claimed inside
-    # Save-JsonNodeFieldEdits (Write-Utf8NoBom -SurgicalWrite), so Assert-DataWriteAllowed
-    # is not called explicitly here.
+    # Save-JsonNodeFieldEdits (which propagates the surgical signal to Write-Utf8NoBom),
+    # so Assert-DataWriteAllowed is not called explicitly here.
     foreach ($FilePath in $Results.Keys) {
         $FileResults = $Results[$FilePath]
         if ($FileResults.Count -eq 0) { continue }

--- a/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
+++ b/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+# Copyright (c) 2026 Jeffrey Snover. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root.
 
 <#
@@ -209,7 +209,10 @@ Rules:
 
                 $FileDict = $ResultsDict.GetOrAdd($Item.FilePath,
                     [System.Collections.Concurrent.ConcurrentDictionary[int, PSCustomObject]]::new())
+                # t/2926: store NodeId so the surgical apply phase can key on node id
+                # (Save-JsonNodeFieldEdits requires node id, not array index).
                 [void]$FileDict.TryAdd($Item.NodeIndex, [PSCustomObject]@{
+                    NodeId           = $Item.NodeId
                     PlainDescription = $PlainText
                     Version          = $VersionTag
                 })
@@ -234,33 +237,33 @@ Rules:
 
     Write-Progress -Id $ProgressId -Activity 'Generating plain descriptions' -Completed
 
+    # ── Apply via field-surgical writer (t/2926) ─────────────────────────────
+    # Replaces the whole-file ConvertTo-Json round-trip: each edit is an explicit
+    # scalar-field splice via Save-JsonNodeFieldEdits → Update-JsonNodeField, which
+    # re-reads the file FRESH before writing and preserves every untouched byte.
+    # plain_description and plain_description_version are both depth-1 scalars;
+    # absent-key INSERT at the node level is supported by Update-JsonNodeField (t/2916).
+    # The surgical exemption to the dirty-tree guard is claimed inside
+    # Save-JsonNodeFieldEdits (Write-Utf8NoBom -SurgicalWrite), so Assert-DataWriteAllowed
+    # is not called explicitly here.
     foreach ($FilePath in $Results.Keys) {
         $FileResults = $Results[$FilePath]
         if ($FileResults.Count -eq 0) { continue }
 
-        $TaxData = Get-Content $FilePath -Raw | ConvertFrom-Json
-        $NodesArray = @($TaxData.nodes)
+        $Edits = [System.Collections.Generic.List[hashtable]]::new()
         foreach ($Idx in $FileResults.Keys) {
             $Entry = $FileResults[$Idx]
-            $Node  = $NodesArray[$Idx]
-
-            if ($Node.PSObject.Properties['plain_description']) {
-                $Node.plain_description = $Entry.PlainDescription
-            } else {
-                $Node | Add-Member -NotePropertyName 'plain_description' -NotePropertyValue $Entry.PlainDescription
-            }
-
-            if ($Node.PSObject.Properties['plain_description_version']) {
-                $Node.plain_description_version = $Entry.Version
-            } else {
-                $Node | Add-Member -NotePropertyName 'plain_description_version' -NotePropertyValue $Entry.Version
-            }
+            $Edits.Add(@{ NodeId = $Entry.NodeId; Field = 'plain_description';         Value = $Entry.PlainDescription })
+            $Edits.Add(@{ NodeId = $Entry.NodeId; Field = 'plain_description_version'; Value = $Entry.Version })
         }
 
-        Assert-DataWriteAllowed -Path $FilePath  # t/2902
-        $TaxData | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
+        $SurgResult = Save-JsonNodeFieldEdits -Path $FilePath -Edits $Edits.ToArray()
         $FileName = Split-Path $FilePath -Leaf
-        Write-Verbose "Updated $($FileResults.Count) nodes in $FileName" # Changed to verbose
+        Write-Verbose "Updated $([Math]::Floor($SurgResult.Applied / 2)) nodes in $FileName"
+        if (@($SurgResult.NotFound).Count -gt 0) {
+            Write-Warning "Invoke-VernacularBatch: nodes not found in ${FileName}: $($SurgResult.NotFound -join ', ')"
+            Write-Verbose "WARN fallback: NodeId not found in file — REASON: concurrent node removal between AI pass and write"
+        }
     }
 
     $GenCount  = @($Generated).Count


### PR DESCRIPTION
## Summary

- Converts `Invoke-VernacularBatch` from a whole-file `ConvertTo-Json` round-trip to `Save-JsonNodeFieldEdits` (t/2926 Phase 2b, Group B).
- `plain_description` and `plain_description_version` are both depth-1 scalars on the node object; `Update-JsonNodeField` supports absent-key INSERT at depth-1, so new nodes and updates are both covered.
- The surgical write re-reads the file fresh before writing, preserving every untouched byte — eliminates the sit-477 sweep risk on the always-dirty POV files.
- `NodeId` is now stored in the parallel-loop result object so the apply phase can key on node id (required by `Save-JsonNodeFieldEdits`).
- Removes explicit `Assert-DataWriteAllowed` call — the surgical exemption is claimed inside `Save-JsonNodeFieldEdits` → `Write-Utf8NoBom -SurgicalWrite`.

## Test plan

- [x] 14/14 Pester tests in `tests/VernacularBatch.Tests.ps1` pass
- [x] WhatIf now correctly gates via `ShouldProcess` propagation through `Save-JsonNodeFieldEdits` (previously the test relied on AI failure; now it works by design)
- [x] `tests/JsonNodeField*.Tests.ps1` and `tests/SurgicalWriteExemption.Tests.ps1` green (underlying surgical primitives unchanged)

## Assessment notes (t/2926)

Group A (Repair-Pov*) and remaining Group B/C writers are NOT suitable for surgical conversion — see t/2926 comment for full assessment table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PFdqAGqgBXZV8tMz38grr