### PR TITLE
rescue: orphaned shared-tree WIP — surgical-write-exemption set (t/2452)

### DIFF
--- a/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
+++ b/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
@@ -210,6 +210,7 @@ Rules:
                 $FileDict = $ResultsDict.GetOrAdd($Item.FilePath,
                     [System.Collections.Concurrent.ConcurrentDictionary[int, PSCustomObject]]::new())
                 [void]$FileDict.TryAdd($Item.NodeIndex, [PSCustomObject]@{
+                    NodeId           = $Item.NodeId
                     PlainDescription = $PlainText
                     Version          = $VersionTag
                 })
@@ -234,33 +235,30 @@ Rules:
 
     Write-Progress -Id $ProgressId -Activity 'Generating plain descriptions' -Completed
 
+    # ── Apply via field-surgical writer (t/2926) ─────────────────────────────
+    # Replaces the whole-file ConvertTo-Json round-trip: each edit is an explicit
+    # scalar-field splice via Save-JsonNodeFieldEdits → Update-JsonNodeField, which
+    # re-reads the file FRESH before writing and preserves every untouched byte.
+    # plain_description and plain_description_version are both depth-1 scalars;
+    # absent-key INSERT is supported by Update-JsonNodeField (t/2916).
     foreach ($FilePath in $Results.Keys) {
         $FileResults = $Results[$FilePath]
         if ($FileResults.Count -eq 0) { continue }
 
-        $TaxData = Get-Content $FilePath -Raw | ConvertFrom-Json
-        $NodesArray = @($TaxData.nodes)
+        $Edits = [System.Collections.Generic.List[hashtable]]::new()
         foreach ($Idx in $FileResults.Keys) {
             $Entry = $FileResults[$Idx]
-            $Node  = $NodesArray[$Idx]
-
-            if ($Node.PSObject.Properties['plain_description']) {
-                $Node.plain_description = $Entry.PlainDescription
-            } else {
-                $Node | Add-Member -NotePropertyName 'plain_description' -NotePropertyValue $Entry.PlainDescription
-            }
-
-            if ($Node.PSObject.Properties['plain_description_version']) {
-                $Node.plain_description_version = $Entry.Version
-            } else {
-                $Node | Add-Member -NotePropertyName 'plain_description_version' -NotePropertyValue $Entry.Version
-            }
+            $Edits.Add(@{ NodeId = $Entry.NodeId; Field = 'plain_description';         Value = $Entry.PlainDescription })
+            $Edits.Add(@{ NodeId = $Entry.NodeId; Field = 'plain_description_version'; Value = $Entry.Version })
         }
 
-        Assert-DataWriteAllowed -Path $FilePath  # t/2902
-        $TaxData | ConvertTo-Json -Depth 20 | Set-Content -Path $FilePath -Encoding UTF8
+        $SurgResult = Save-JsonNodeFieldEdits -Path $FilePath -Edits $Edits.ToArray()
         $FileName = Split-Path $FilePath -Leaf
-        Write-Verbose "Updated $($FileResults.Count) nodes in $FileName" # Changed to verbose
+        Write-Verbose "Updated $($SurgResult.Applied / 2) nodes in $FileName"
+        if (@($SurgResult.NotFound).Count -gt 0) {
+            Write-Warning "Invoke-VernacularBatch: nodes not found in ${FileName}: $($SurgResult.NotFound -join ', ')"
+            Write-Verbose "WARN: surgical write fallback — node IDs not found; REASON: NodeId/index mismatch from concurrent node removal"
+        }
     }
 
     $GenCount  = @($Generated).Count

--- a/scripts/data_tree_guard.py
+++ b/scripts/data_tree_guard.py
@@ -89,7 +89,9 @@ def _data_write_guard_mode(path=None) -> str:
     return "warn"
 
 
-def assert_clean_data_tree(path, force: bool = False) -> None:
+def assert_clean_data_tree(
+    path, force: bool = False, surgical_write: bool = False
+) -> None:
     """Guard a whole-file data-repo rewrite against a dirty-tree sweep (t/2902).
 
     Warn-first by default; the mode comes from ``$AI_TRIAD_DATA_WRITE_GUARD``
@@ -101,7 +103,19 @@ def assert_clean_data_tree(path, force: bool = False) -> None:
 
     ``force=True`` opts out entirely (mirrors PowerShell ``-AllowDirty``) — for a
     writer that legitimately rewrites a target left dirty by a prior pass.
+
+    ``surgical_write=True`` is a DISTINCT, semantically-honest exemption for a
+    field-surgical writer (t/2926, mirrors PowerShell ``-SurgicalWrite``). Its claim
+    is NOT "ignore the dirty tree" but "this write is sweep-proof by construction, so
+    the dirty-tree check is N/A." Kept separate from ``force`` on purpose: the two
+    carry different risk profiles, and a grep for ``surgical_write=True`` must not
+    conflate "provably safe surgical" with "blanket override — scrutinise." Reachable
+    only via an allowlisted writer (enforced by the detection gate in
+    SurgicalWriteExemption.Tests.ps1), so a whole-file writer cannot claim it and
+    bypass the BLOCK tier.
     """
+    if surgical_write:
+        return
     if force:
         return
     mode = _data_write_guard_mode(path)   # per-target tier (t/2909)

--- a/scripts/test_data_tree_guard.py
+++ b/scripts/test_data_tree_guard.py
@@ -181,6 +181,58 @@ def test_env_override_wins_over_tier():
         assert raised, "env=Block must override the WARN tier"
 
 
+def test_surgical_write_arm1_true_proceeds_on_dirty_block_tier():
+    # ARM 1 — surgical_write=True on a dirty BLOCK-tier target must PROCEED (exemption
+    # honored). A field-surgical write is sweep-proof by construction, so the dirty-tree
+    # check is N/A (t/2926, mirrors PS -SurgicalWrite). Guard must return before the tier
+    # or the git check are even consulted.
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "sw_arm1", name="situations.json")
+        f.write_text("mutated\n", encoding="utf-8")
+        with _guard_mode(None):  # no env override — tier decides (Block for situations.json)
+            assert_clean_data_tree(f, surgical_write=True)  # must not raise
+
+
+def test_surgical_write_arm2_false_fires_on_dirty_block_tier():
+    # ARM 2 / fire arm — surgical_write=False (default) on the same dirty BLOCK-tier target
+    # MUST raise DirtyTreeError, proving the gate fires. A detection gate never proven to
+    # fire is assumed, not verified (mirrors TL ruling t/2916#10 applied to t/2926).
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "sw_arm2", name="situations.json")
+        f.write_text("mutated\n", encoding="utf-8")
+        raised = False
+        with _guard_mode(None):  # no env -> tier = Block for situations.json
+            try:
+                assert_clean_data_tree(f)  # surgical_write defaults to False -> must raise
+            except DirtyTreeError:
+                raised = True
+        assert raised, (
+            "Without surgical_write=True, a dirty BLOCK-tier target must raise DirtyTreeError; "
+            "the gate is assumed working, not verified, if this arm never executes."
+        )
+
+
+def test_surgical_write_distinct_from_force():
+    # surgical_write and force are SEPARATE parameters with different risk profiles:
+    # surgical_write = "sweep-proof by construction" (safe); force = "blanket override" (scrutinize).
+    # Verify the signature accepts both independently and that surgical_write short-circuits
+    # before force is evaluated (implementation detail of the guard contract).
+    import inspect
+    sig = inspect.signature(assert_clean_data_tree)
+    assert "surgical_write" in sig.parameters, "assert_clean_data_tree must have surgical_write param"
+    assert "force" in sig.parameters, "assert_clean_data_tree must retain force param"
+    # Both False (default) -> guard runs normally (no raise on a clean file)
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "sw_distinct")
+        assert_clean_data_tree(f, force=False, surgical_write=False)  # clean -> no raise
+    # surgical_write alone bypasses even block mode
+    with tempfile.TemporaryDirectory() as tmp:
+        f = _make_repo(Path(tmp) / "sw_distinct2", name="situations.json")
+        f.write_text("mutated\n", encoding="utf-8")
+        with _guard_mode("Block"):
+            assert_clean_data_tree(f, force=False, surgical_write=True)  # must not raise
+
+
 if __name__ == "__main__":
     _tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0

--- a/tests/SurgicalWriteExemption.Tests.ps1
+++ b/tests/SurgicalWriteExemption.Tests.ps1
@@ -37,13 +37,31 @@ BeforeAll {
     # comment (preceded by a word char) is NOT a false positive, while " -SurgicalWrite" /
     # " -Surg" (preceded by whitespace) is. Vendored/checkout trees are excluded.
     function Get-SurgicalExemptionViolations {
-        param([Parameter(Mandatory)][string]$Root, [Parameter(Mandatory)][string[]]$Allowed)
-        $rx = '(?<![\w-])-Surg\w*'
+        # Scans REPO-WIDE for unauthorized claims of the surgical-write exemption.
+        # PS files: matches -SurgicalWrite and any abbreviation (e.g. -Surg).
+        # Python files (t/2926): matches assert_clean_data_tree calls with surgical_write=True.
+        # Both allowlists are checked independently so a PS allowlist entry does not
+        # accidentally exclude a Python file with the same basename.
+        param(
+            [Parameter(Mandatory)][string]$Root,
+            [Parameter(Mandatory)][string[]]$Allowed,
+            [string[]]$PyAllowed = @()
+        )
+        $rxPs  = '(?<![\w-])-Surg\w*'
+        $rxPy  = 'surgical_write\s*=\s*True'
+        $excl  = '[\\/](node_modules|\.git|\.worktrees|\.claude)[\\/]'
         @(
+            # PowerShell: -SurgicalWrite / abbreviated -Surg forms
             Get-ChildItem -Path $Root -Recurse -Filter '*.ps1' -File -ErrorAction SilentlyContinue |
-                Where-Object { $_.FullName -notmatch '[\\/](node_modules|\.git|\.worktrees|\.claude)[\\/]' } |
+                Where-Object { $_.FullName -notmatch $excl } |
                 Where-Object { $_.Name -notin $Allowed } |
-                Where-Object { Select-String -Path $_.FullName -Pattern $rx -Quiet } |
+                Where-Object { Select-String -Path $_.FullName -Pattern $rxPs -Quiet } |
+                ForEach-Object { $_.FullName }
+            # Python: assert_clean_data_tree(..., surgical_write=True) (t/2926)
+            Get-ChildItem -Path $Root -Recurse -Filter '*.py' -File -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -notmatch $excl } |
+                Where-Object { $_.Name -notin $PyAllowed } |
+                Where-Object { Select-String -Path $_.FullName -Pattern $rxPy -Quiet } |
                 ForEach-Object { $_.FullName }
         )
     }
@@ -90,6 +108,8 @@ Describe 'Surgical-write exemption — reachable ONLY via the orchestrator (dete
 
     # Allowed to reference the exemption: the orchestrator (claims it), the sink (forwards
     # it), the guard (declares it), and THIS both-arms test (exercises it directly).
+    # Python allowlist (t/2926): test_data_tree_guard.py exercises the Python surgical_write
+    # parameter directly in both-arms tests; no other Python consumer is currently authorized.
     BeforeAll {
         $script:Allowed = @(
             'Save-JsonNodeFieldEdits.ps1'
@@ -97,29 +117,52 @@ Describe 'Surgical-write exemption — reachable ONLY via the orchestrator (dete
             'Assert-DataWriteAllowed.ps1'
             'SurgicalWriteExemption.Tests.ps1'
         )
+        $script:PyAllowed = @(
+            'data_tree_guard.py'        # declares the surgical_write parameter (analogous to Assert-DataWriteAllowed.ps1)
+            'test_data_tree_guard.py'   # both-arms GV for the Python surgical_write exemption (t/2926)
+        )
     }
 
-    It 'CLEAN arm — repo-wide, only the allowlisted files reference the exemption' {
+    It 'CLEAN arm — repo-wide, only the allowlisted files reference the exemption (PS and Python)' {
         $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
-        Get-SurgicalExemptionViolations -Root $repoRoot -Allowed $script:Allowed |
-            Should -BeNullOrEmpty -Because 'only Save-JsonNodeFieldEdits may claim the surgical exemption; a whole-file writer must not bypass the BLOCK tier'
+        Get-SurgicalExemptionViolations -Root $repoRoot -Allowed $script:Allowed -PyAllowed $script:PyAllowed |
+            Should -BeNullOrEmpty -Because 'only Save-JsonNodeFieldEdits (PS) and test_data_tree_guard.py (Python GV) may claim the surgical exemption; a whole-file writer must not bypass the BLOCK tier'
     }
 
-    It 'FIRE arm — the detector FLAGS a non-allowlisted writer that claims the exemption (via an abbreviated -Surg)' {
+    It 'FIRE arm — the detector FLAGS a non-allowlisted PS writer that claims the exemption (via an abbreviated -Surg)' {
         # A detection gate never proven to fire is assumed, not verified (TL t/2916#10).
         # The rogue writer uses the ABBREVIATED form to also prove the grep catches it.
         $rogue = Join-Path $TestDrive 'Rogue-Writer.ps1'
         Set-Content -LiteralPath $rogue -Value 'Write-Utf8NoBom -Path $p -Value $x -Surg' -Encoding utf8
-        $found = Get-SurgicalExemptionViolations -Root $TestDrive -Allowed $script:Allowed
+        $found = Get-SurgicalExemptionViolations -Root $TestDrive -Allowed $script:Allowed -PyAllowed $script:PyAllowed
         @($found).Count | Should -BeGreaterThan 0
         ($found -join ';')            | Should -Match 'Rogue-Writer'
+    }
+
+    It 'FIRE arm (Python) — the detector FLAGS a non-allowlisted Python writer that claims surgical_write=True (t/2926)' {
+        # Proves the Python scanner fires; mirrors the PS FIRE arm (TL t/2916#10 bar).
+        $rogue = Join-Path $TestDrive 'rogue_writer.py'
+        Set-Content -LiteralPath $rogue -Value 'assert_clean_data_tree(path, surgical_write=True)' -Encoding utf8
+        $found = Get-SurgicalExemptionViolations -Root $TestDrive -Allowed $script:Allowed -PyAllowed $script:PyAllowed
+        @($found).Count | Should -BeGreaterThan 0
+        ($found -join ';') | Should -Match 'rogue_writer'
     }
 
     It 'the "field-surgical" prose in a comment is NOT a false positive (lookbehind boundary)' {
         $benign = Join-Path $TestDrive 'Benign-Comment.ps1'
         Set-Content -LiteralPath $benign -Value '# performs a field-surgical, byte-surgical write; see byte-surgery notes' -Encoding utf8
-        Get-SurgicalExemptionViolations -Root $TestDrive -Allowed $script:Allowed |
+        Get-SurgicalExemptionViolations -Root $TestDrive -Allowed $script:Allowed -PyAllowed $script:PyAllowed |
             Where-Object { $_ -match 'Benign-Comment' } |
+            Should -BeNullOrEmpty
+    }
+
+    It 'surgical_write=False in a Python comment/declaration is NOT a false positive' {
+        # The parameter declaration "surgical_write: bool = False" in data_tree_guard.py
+        # must not trigger the scanner — only "surgical_write=True" (the call site) is flagged.
+        $benign = Join-Path $TestDrive 'benign_decl.py'
+        Set-Content -LiteralPath $benign -Value 'def assert_clean_data_tree(path, force=False, surgical_write=False): pass' -Encoding utf8
+        Get-SurgicalExemptionViolations -Root $TestDrive -Allowed $script:Allowed -PyAllowed $script:PyAllowed |
+            Where-Object { $_ -match 'benign_decl' } |
             Should -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
Preserving uncommitted WIP found on the shared main checkout (TL p/564, t/2452 shared-tree cleanup) so it is not lost when DevOps ff-syncs the checkout. Authorship uncertain — PowerShell-scope WIP, not Main's; captured here verbatim for whoever owns it to pick up from a worktree/PR.

Files (136 insertions, 29 deletions):
- scripts/data_tree_guard.py
- scripts/test_data_tree_guard.py
- tests/SurgicalWriteExemption.Tests.ps1
- scripts/AITriad/Public/Invoke-VernacularBatch.ps1

Not reviewed/verified — a rescue snapshot only.