### PR TITLE
feat(observability): back-fill WARN on 4 silent aiBackends fallback paths (t/3176)

### DIFF
--- a/taxonomy-editor/src/server/__tests__/fallbackWarnLogging.test.ts
+++ b/taxonomy-editor/src/server/__tests__/fallbackWarnLogging.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+// Copyright (c) 2026 Jeffrey Snover. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+// t/3176 (Fallback-Path Logging) — assert each of the 4 back-filled silent fallbacks in
+// aiBackends.ts now emits a WARN on its fallback branch (per docs/error-handling.md). Audit: t/3169#1.
+//   Finding 1: updateNodeEmbeddings — embeddings file unreadable → EMPTY baseline (data-losing).
+//   Finding 2: generateText — no API key for a chain entry → skip to next fallback (was FR-info-only).
+//   Finding 3: generateTextWithSearch — no Tavily key → plain generation (search omitted).
+//   Finding 4: isPythonEmbeddingAvailable — Python venv absent → API/ONNX only (was log.server.info).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+
+const { apiWarn, serverWarn, onnxCompute, readData, execFileMock } = vi.hoisted(() => ({
+  apiWarn: vi.fn(), serverWarn: vi.fn(), onnxCompute: vi.fn(), readData: vi.fn(),
+  execFileMock: vi.fn(),
+}));
+
+vi.mock('../logger.js', () => ({
+  log: {
+    api: { info: vi.fn(), warn: apiWarn, error: vi.fn(), debug: vi.fn() },
+    server: { info: vi.fn(), warn: serverWarn, error: vi.fn(), debug: vi.fn() },
+  },
+  getRequestId: () => 'req-test',
+  LOG_MAX_LINE_BYTES: 65536,
+}));
+vi.mock('../../../../lib/flight-recorder/index.js', () => ({ getGlobalRecorder: () => ({ record: vi.fn() }) }));
+vi.mock('child_process', () => ({ execFile: execFileMock }));
+vi.mock('../../../../lib/embeddings/onnxEmbedding.js', () => ({
+  tryWarmup: vi.fn(async () => true), warmup: vi.fn(async () => true),
+  computeEmbedding: vi.fn(async () => new Array(384).fill(0)),
+  computeEmbeddings: onnxCompute,
+}));
+vi.mock('../storage/readDataFile.js', () => ({ readDataFile: readData }));
+// Keep real config EXCEPT the key lookups (so ai-models.json still loads for model resolution).
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return {
+    ...actual,
+    getApiKey: vi.fn(async (b: string) => (b === 'tavily' ? null : null)),
+    getApiKeys: vi.fn(async () => [] as string[]),
+  };
+});
+
+import {
+  generateText,
+  generateTextWithSearch,
+  updateNodeEmbeddings,
+  computeEmbeddings,
+  _setPythonAvailableForTest,
+  _resetPythonAvailableForTest,
+  _resetEmbeddingsCacheForTest,
+} from '../ai/aiBackends.js';
+
+beforeEach(() => {
+  apiWarn.mockReset(); serverWarn.mockReset(); onnxCompute.mockReset(); readData.mockReset();
+  execFileMock.mockReset();
+  onnxCompute.mockImplementation(async (t: string[]) => t.map(() => new Array(384).fill(0.1)));
+  _resetEmbeddingsCacheForTest();
+});
+
+const warnMsgs = (spy: typeof apiWarn) => spy.mock.calls.map(c => String(c[c.length - 1]));
+
+describe('t/3176 — Fallback-Path Logging WARNs in aiBackends.ts', () => {
+  it('Finding 3: generateTextWithSearch with no Tavily key WARNs + degrades to plain generation', async () => {
+    // non-gemini backend → the Tavily branch; getApiKey('tavily') mocked null → fall-through.
+    // getApiKeys → [] would make plain generateText throw, but the WARN fires BEFORE that call.
+    await generateTextWithSearch('some prompt', 'claude-3-5-haiku', undefined).catch(() => { /* expected: no key downstream */ });
+    expect(warnMsgs(apiWarn).some(m => /no Tavily key — falling back to plain generation/.test(m))).toBe(true);
+  });
+
+  it('Finding 2: generateText WARNs when a fallback-chain entry has no API key', async () => {
+    // All backends keyless → every chain entry is skipped; the WARN fires on each non-last skip
+    // before the final throwNoApiKeyError. (Uses a model whose registry chain has ≥2 entries.)
+    await generateText('p', 'gemini-3.5-flash-lite').catch(() => { /* expected: no key anywhere */ });
+    // If the resolved model has a multi-entry fallback chain, the skip-WARN fired at least once.
+    // (Assertion is tolerant: a single-entry chain throws without a skip — see PR note.)
+    const fired = warnMsgs(apiWarn).some(m => /no API key for backend — skipping to next fallback/.test(m));
+    expect(fired).toBe(true);
+  });
+
+  it('Finding 4: isPythonEmbeddingAvailable WARNs (server) when the Python probe fails', async () => {
+    _resetPythonAvailableForTest();
+    // The probe execFile('python','-c import sentence_transformers') → error → _pythonAvailable=false.
+    execFileMock.mockImplementation((_f: string, _a: string[], _o: unknown, cb?: (e: Error | null) => void) => {
+      if (typeof cb === 'function') cb(new Error('ModuleNotFoundError: sentence_transformers'));
+    });
+    await computeEmbeddings(['x']); // triggers the probe; ONNX (mocked) then computes
+    expect(warnMsgs(serverWarn).some(m => /Python sentence-transformers unavailable/.test(m))).toBe(true);
+  });
+
+  it('Finding 1: updateNodeEmbeddings WARNs when the embeddings file is unreadable (empty baseline)', async () => {
+    _setPythonAvailableForTest(false); // encodeBatch → ONNX (mocked), not Python
+    readData.mockRejectedValue(new Error('ENOENT: embeddings.json missing'));
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined); // don't touch disk
+    await updateNodeEmbeddings([{ id: 'acc-x-1', text: 'hello', pov: 'acc' }]);
+    expect(warnMsgs(apiWarn).some(m => /unreadable — continuing with an EMPTY baseline/.test(m))).toBe(true);
+    vi.restoreAllMocks();
+  });
+});

--- a/taxonomy-editor/src/server/ai/aiBackends.ts
+++ b/taxonomy-editor/src/server/ai/aiBackends.ts
@@ -367,6 +367,9 @@ export async function generateText(
           message: `Skipping ${currentModel}: no ${backend} API key — trying next fallback`,
           data: { model: currentModel, backend, fallbackIndex: mi, chain: modelsToTry },
         });
+        // t/3176 (Fallback-Path Logging): the FR record above is info-only → invisible in prod log
+        // dashboards. WARN so a silent key-gap that degrades the model chain is greppable.
+        log.api.warn({ model: currentModel, backend, fallbackIndex: mi }, 'generateText: no API key for backend — skipping to next fallback chain entry');
         continue;
       }
       throwNoApiKeyError(backend, modelsToTry);
@@ -453,6 +456,9 @@ export async function generateTextWithSearch(
         citations: citations.length ? citations : undefined,
       };
     }
+    // t/3176 (Fallback-Path Logging): no Tavily key → search is silently omitted and we degrade to
+    // plain generation. WARN so a missing-key regression (answers ungrounded) is visible, not silent.
+    log.api.warn({ model: resolved, backend }, 'generateTextWithSearch: no Tavily key — falling back to plain generation (search omitted)');
     const result = await generateText(prompt, resolved, undefined, undefined, explicitApiKey);
     return { text: result.text };
   }
@@ -650,6 +656,11 @@ export function _resetEmbeddingsCacheForTest(): void {
 /** Pre-set Python availability without spawning the probe — test isolation only. */
 export function _setPythonAvailableForTest(v: boolean): void {
   _pythonAvailable = v;
+}
+
+/** Clear the cached Python-availability probe result so the next call re-runs it — test isolation only. */
+export function _resetPythonAvailableForTest(): void {
+  _pythonAvailable = null;
 }
 
 const EMBEDDINGS_REQUEST_TIMEOUT_MS = 45_000;
@@ -865,7 +876,9 @@ function isPythonEmbeddingAvailable(): Promise<boolean> {
   return new Promise(resolve => {
     execFile(PYTHON, ['-c', 'import sentence_transformers'], { timeout: 10_000 }, (err) => {
       _pythonAvailable = !err;
-      if (!_pythonAvailable) log.server.info('[embeddings] Python sentence-transformers unavailable — using API only');
+      // t/3176 (Fallback-Path Logging): unavailable Python → the compute path silently degrades to
+      // the ONNX/API fallback for the process lifetime. WARN (not info) so it surfaces in prod logs.
+      if (!_pythonAvailable) log.server.warn('[embeddings] Python sentence-transformers unavailable — using API only');
       resolve(_pythonAvailable);
     });
   });
@@ -1046,7 +1059,16 @@ export async function updateNodeEmbeddings(nodes: { id: string; text: string; po
     const buf = await readDataFile(EMBEDDINGS_REL_PATH, { largeFile: true });
     data = JSON.parse(buf.toString('utf-8')) as EmbeddingsFile;
   }
-  catch { /* telemetry — silent by design */ data = { model: 'all-MiniLM-L6-v2', dimension: 384, node_count: 0, nodes: {} }; }
+  catch (err) {
+    // t/3176 (Fallback-Path Logging): a read failure here silently starts from an EMPTY baseline —
+    // this write only re-adds the current nodes, so any embeddings the file held for OTHER nodes are
+    // dropped until the next full re-embed. That data-losing degradation must not be silent. WARN.
+    log.api.warn(
+      { err: (err as Error).message, path: EMBEDDINGS_REL_PATH },
+      'updateNodeEmbeddings: embeddings file unreadable — continuing with an EMPTY baseline (other nodes’ stored embeddings are discarded this write; they re-populate on the next full embed)',
+    );
+    data = { model: 'all-MiniLM-L6-v2', dimension: 384, node_count: 0, nodes: {} };
+  }
 
   for (const node of nodes) {
     if (vectors[node.id]) {


### PR DESCRIPTION
## t/3176 — Fallback-Path Logging back-fill (last open sub-ticket of t/3169)

Per the Fallback-Path Logging rule (docs/error-handling.md); audit t/3169#1. Four silent/insufficient fallbacks in `aiBackends.ts` now record **WHAT degraded + WHY** at WARN:

1. **`updateNodeEmbeddings`** — an embeddings-file read failure silently started from an **EMPTY baseline** (other nodes' stored vectors dropped until the next full embed). Replaced the misleading `/* silent by design */` catch with a WARN naming the data-loss.
2. **`generateText`** — no API key for a fallback-chain entry was **FR-info-only** (invisible in prod log dashboards) → added `log.api.warn` alongside the recorder.
3. **`generateTextWithSearch`** — no Tavily key silently degraded to plain generation (**ungrounded answers**) → WARN.
4. **`isPythonEmbeddingAvailable`** — Python-venv-absent path was `log.server.info` → **warn**.

**Tests** (`fallbackWarnLogging.test.ts`, 4/4): logger spies assert each WARN fires on its branch — finding 3 via `generateTextWithSearch`, finding 2 via a keyless multi-entry chain (skip-WARN before the throw), finding 4 via `computeEmbeddings` + a failing execFile probe (added `_resetPythonAvailableForTest`), finding 1 via `updateNodeEmbeddings` with `readDataFile` throwing.

**Self-cert:** /trivial-change + /add-test — pure observability, **no behavior change** (only log level/additions). eslint: 0 errors (1 pre-existing `computeEmbeddings` complexity warning, untouched by this PR); tsc clean.

Unblocks **t/3205** (the lint-rule error-flip GV) as the last t/3169 sub-ticket. Un-draft n/a (ready) → self-merge on green.