### PR TITLE
fix(ps): floor node-count in Invoke-VernacularBatch verbose (t/2926 follow-up)

### DIFF
--- a/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
+++ b/scripts/AITriad/Public/Invoke-VernacularBatch.ps1
@@ -254,7 +254,7 @@ Rules:
 
         $SurgResult = Save-JsonNodeFieldEdits -Path $FilePath -Edits $Edits.ToArray()
         $FileName = Split-Path $FilePath -Leaf
-        Write-Verbose "Updated $($SurgResult.Applied / 2) nodes in $FileName"
+        Write-Verbose "Updated $([Math]::Floor($SurgResult.Applied / 2)) nodes in $FileName"
         if (@($SurgResult.NotFound).Count -gt 0) {
             Write-Warning "Invoke-VernacularBatch: nodes not found in ${FileName}: $($SurgResult.NotFound -join ', ')"
             Write-Verbose "WARN: surgical write fallback — node IDs not found; REASON: NodeId/index mismatch from concurrent node removal"


### PR DESCRIPTION
## Summary

One-line correctness fix in `Invoke-VernacularBatch`: the surgical apply loop's verbose line reports node count as `$SurgResult.Applied / 2` (2 field-edits per node). Under a partial apply (a `NodeId` lands in `NotFound`), `Applied` can be odd, printing a fractional `Updated N.5 nodes`. Floored so the count is always whole.

## Context

Salvaged from closed PR #1775 (Invoke-VernacularBatch surgical conversion), which was **closed as superseded by #1777** — #1777 already landed the surgical conversion to main. This `[Math]::Floor` fix was #1775's one real improvement; brought over **without** the `-SurgicalWrite` comment token that tripped the detection gate. Credit: PowerShell 2 (`cb855c9b`).

## Verification

- `SurgicalWriteExemption` detection gate: **9/9 green** (no bare `-SurgicalWrite`/`-Surg` token in the file).
- Module imports; `Invoke-VernacularBatch` exported; parse clean.

## Self-certification

`/trivial-change` — one-line verbose-output fix, no behavioral/data-model/API change, no new error handling. TL-directed (p/360#261); allowlist entry moot (main avoids the token).
